### PR TITLE
fix(models): one answer for "which models does this project offer"

### DIFF
--- a/apps/api/src/__tests__/unit-model-enablement.test.ts
+++ b/apps/api/src/__tests__/unit-model-enablement.test.ts
@@ -3,37 +3,112 @@ import { describe, expect, it, mock } from 'bun:test';
 const config: Record<string, unknown> = {};
 mock.module('../config', () => ({ config }));
 
-let policy: { disabledModels: string[] } | null = null;
+let policy: { modelOverrides: Record<string, boolean> } | null = null;
 mock.module('../repositories/project-routing-policies', () => ({
   getProjectRoutingPolicy: async () => policy,
 }));
 
-const { getProjectDisabledModels, isModelDisabledForProject } = await import(
+const TODAY = new Date().toISOString().slice(0, 10);
+
+// Two Anthropic families: one current, one stale. Enough to observe "newest of
+// each family, within the window".
+const CATALOG = {
+  'anthropic/claude-sonnet-5': { family: 'claude-5', provider: 'anthropic', released: TODAY },
+  'anthropic/claude-sonnet-4-6': {
+    family: 'claude-5',
+    provider: 'anthropic',
+    released: '2026-01-01',
+  },
+  'anthropic/claude-opus-4-1': {
+    family: 'claude-4',
+    provider: 'anthropic',
+    released: '2025-01-01',
+  },
+};
+
+const { defaultEnabledFromCatalog, resolveEnablement, isModelEnabledForProject } = await import(
   '../llm-gateway/model-enablement'
 );
 
 describe('model-enablement', () => {
-  it('returns nothing disabled when the feature flag is off', async () => {
-    config.MODEL_ENABLEMENT_ENABLED = false;
-    policy = { disabledModels: ['glm-5.2'] };
-    expect((await getProjectDisabledModels('p')).size).toBe(0);
-    expect(await isModelDisabledForProject('p', 'glm-5.2')).toBe(false);
+  it('offers the newest model of each in-window family by default', () => {
+    const set = defaultEnabledFromCatalog(CATALOG);
+    expect(set.has('anthropic/claude-sonnet-5')).toBe(true);
+    // Superseded within its family, and a family whose newest is stale.
+    expect(set.has('anthropic/claude-sonnet-4-6')).toBe(false);
+    expect(set.has('anthropic/claude-opus-4-1')).toBe(false);
   });
 
-  it('returns the project disabled set when on', async () => {
+  it('resolves a whole catalog with no overrides straight from the default', () => {
     config.MODEL_ENABLEMENT_ENABLED = true;
-    policy = { disabledModels: ['glm-5.2', 'codex/gpt-5.4'] };
-    const set = await getProjectDisabledModels('p');
-    expect(set.has('glm-5.2')).toBe(true);
-    expect(await isModelDisabledForProject('p', 'codex/gpt-5.4')).toBe(true);
-    expect(await isModelDisabledForProject('p', 'anthropic/claude-sonnet-5')).toBe(false);
+    const enabled = resolveEnablement(CATALOG, {});
+    expect(enabled.get('anthropic/claude-sonnet-5')).toBe(true);
+    expect(enabled.get('anthropic/claude-opus-4-1')).toBe(false);
   });
 
-  it('short-circuits with no project or no policy', async () => {
+  it('lets an override turn a non-default model on and a default model off', () => {
+    config.MODEL_ENABLEMENT_ENABLED = true;
+    const enabled = resolveEnablement(CATALOG, {
+      'anthropic/claude-opus-4-1': true,
+      'anthropic/claude-sonnet-5': false,
+    });
+    expect(enabled.get('anthropic/claude-opus-4-1')).toBe(true);
+    expect(enabled.get('anthropic/claude-sonnet-5')).toBe(false);
+  });
+
+  it('keeps offering newly-released models after a project has made overrides', () => {
+    // THE reason overrides are stored instead of the resolved set: a project
+    // that once toggled something must not have to hand-enable every future
+    // model. A brand-new family the project has never seen is on by default.
+    config.MODEL_ENABLEMENT_ENABLED = true;
+    const withNewModel = {
+      ...CATALOG,
+      'anthropic/claude-opus-6': { family: 'claude-6', provider: 'anthropic', released: TODAY },
+    };
+    const enabled = resolveEnablement(withNewModel, { 'anthropic/claude-opus-4-1': true });
+    expect(enabled.get('anthropic/claude-opus-6')).toBe(true);
+  });
+
+  it('offers a newly connected provider without any manual clicking', () => {
+    config.MODEL_ENABLEMENT_ENABLED = true;
+    const withOpenai = {
+      ...CATALOG,
+      'openai/gpt-5.5': { family: 'gpt-5', provider: 'openai', released: TODAY },
+    };
+    const enabled = resolveEnablement(withOpenai, { 'anthropic/claude-sonnet-5': false });
+    expect(enabled.get('openai/gpt-5.5')).toBe(true);
+  });
+
+  it('offers everything when the feature flag is off, on both halves', async () => {
+    config.MODEL_ENABLEMENT_ENABLED = false;
+    policy = { modelOverrides: { 'anthropic/claude-opus-4-1': false } };
+    // The picker projection and the gateway check must agree, or the picker
+    // shows a model the gateway refuses.
+    expect(resolveEnablement(CATALOG, policy.modelOverrides).get('anthropic/claude-opus-4-1')).toBe(
+      true,
+    );
+    expect(await isModelEnabledForProject('p', 'anthropic/claude-opus-4-1', CATALOG)).toBe(true);
+  });
+
+  it('enforces the project overrides at the gateway', async () => {
+    config.MODEL_ENABLEMENT_ENABLED = true;
+    policy = { modelOverrides: { 'anthropic/claude-sonnet-5': false } };
+    expect(await isModelEnabledForProject('p', 'anthropic/claude-sonnet-5', CATALOG)).toBe(false);
+    // No override → the default decides.
+    expect(await isModelEnabledForProject('p', 'anthropic/claude-opus-4-1', CATALOG)).toBe(false);
+  });
+
+  it('applies the default when the project has no policy row at all', async () => {
     config.MODEL_ENABLEMENT_ENABLED = true;
     policy = null;
-    expect(await isModelDisabledForProject(null, 'glm-5.2')).toBe(false);
-    expect(await isModelDisabledForProject(undefined, 'glm-5.2')).toBe(false);
-    expect((await getProjectDisabledModels('p')).size).toBe(0);
+    expect(await isModelEnabledForProject('p', 'anthropic/claude-sonnet-5', CATALOG)).toBe(true);
+    expect(await isModelEnabledForProject('p', 'anthropic/claude-opus-4-1', CATALOG)).toBe(false);
+  });
+
+  it('offers everything when there is no project to scope the overrides to', async () => {
+    config.MODEL_ENABLEMENT_ENABLED = true;
+    policy = { modelOverrides: { 'glm-5.2': false } };
+    expect(await isModelEnabledForProject(null, 'glm-5.2', CATALOG)).toBe(true);
+    expect(await isModelEnabledForProject(undefined, 'glm-5.2', CATALOG)).toBe(true);
   });
 });

--- a/apps/api/src/llm-gateway/model-enablement.ts
+++ b/apps/api/src/llm-gateway/model-enablement.ts
@@ -1,28 +1,85 @@
+import { defaultEnabledModelIds } from '@kortix/llm-catalog';
+
 import { config } from '../config';
 import { getProjectRoutingPolicy } from '../repositories/project-routing-policies';
 
-// Per-project model enablement (opt-out). A project may turn specific wire
-// models OFF; the gateway then refuses them everywhere (chat, Slack, triggers,
-// raw API) and the picker hides them. Absent from the disabled set = usable.
+// Per-project model enablement. The newest model of each family is offered by
+// default; a project stores only the EXCEPTIONS it made to that. Anything not
+// effectively enabled is refused everywhere (chat, Slack, triggers, raw API)
+// and hidden from the session picker.
 //
-// NOTE: distinct from ../llm-gateway/enablement.ts, which resolves the
-// `llm_gateway` experimental FEATURE flag — not model on/off.
+//     enabled(id) = overrides[id] ?? defaultEnabledModelIds(catalog).has(id)
+//
+// Keeping the default in the formula (rather than resolving it into a stored
+// set) is what makes "the latest models are on" stay true as the catalog moves
+// — connect a new provider, or ship a new Claude, and it is offered without
+// anyone clicking anything.
+//
+// This module is the ONLY place that resolves overrides + default into an
+// answer, so the gateway and both UI surfaces can never disagree.
+//
+// NOTE: distinct from ./enablement.ts, which resolves the `llm_gateway`
+// experimental FEATURE flag — not model on/off.
 
-/** The wire-model ids this project has turned off. Empty when the feature is off
- *  or nothing is disabled. */
-export async function getProjectDisabledModels(
-  projectId: string | null | undefined,
-): Promise<Set<string>> {
-  if (!config.MODEL_ENABLEMENT_ENABLED || !projectId) return new Set();
-  const policy = await getProjectRoutingPolicy(projectId);
-  return new Set(policy?.disabledModels ?? []);
+/** Catalog metadata the default rule reads, as the models routes serve it. */
+type ServedModel = {
+  released?: string | null;
+  release_date?: string | null;
+  family?: string;
+  provider?: string;
+};
+
+/** Per-project exceptions to the default: `wireModelId -> enabled`. */
+export type ModelOverrides = Record<string, boolean>;
+
+/**
+ * The models a catalog offers by default: reduced to the newest per family.
+ * Takes the catalog rather than fetching one so each caller defaults over
+ * exactly the models it is answering about — the picker route narrows by
+ * connected providers and plan, the gateway judges against everything routable.
+ */
+export function defaultEnabledFromCatalog(catalog: Record<string, ServedModel>): Set<string> {
+  return defaultEnabledModelIds(
+    Object.entries(catalog).map(([id, model]) => ({
+      id,
+      released: model.released ?? model.release_date,
+      family: model.family,
+      provider: model.provider,
+    })),
+  );
 }
 
-/** True when `wireModel` is disabled for `projectId`. */
-export async function isModelDisabledForProject(
+/**
+ * Resolve enablement for a whole catalog at once: `wireModelId -> enabled`.
+ * The picker route serves this verbatim so clients never recompute it.
+ */
+export function resolveEnablement(
+  catalog: Record<string, ServedModel>,
+  overrides: ModelOverrides,
+): Map<string, boolean> {
+  // Feature off is a kill switch, not a mode: everything is offered, and the
+  // gateway's check below agrees. Both halves read the flag so the picker can
+  // never show a model the gateway would refuse, or vice versa.
+  if (!config.MODEL_ENABLEMENT_ENABLED) {
+    return new Map(Object.keys(catalog).map((id) => [id, true]));
+  }
+  const byDefault = defaultEnabledFromCatalog(catalog);
+  return new Map(Object.keys(catalog).map((id) => [id, overrides[id] ?? byDefault.has(id)]));
+}
+
+/**
+ * True when `projectId` offers `wireModel`. Always true when there's no project
+ * to scope the overrides to — enablement simply doesn't apply, which must never
+ * read as "refuse everything".
+ */
+export async function isModelEnabledForProject(
   projectId: string | null | undefined,
   wireModel: string,
+  catalog: Record<string, ServedModel>,
 ): Promise<boolean> {
-  if (!config.MODEL_ENABLEMENT_ENABLED || !projectId) return false;
-  return (await getProjectDisabledModels(projectId)).has(wireModel);
+  if (!config.MODEL_ENABLEMENT_ENABLED || !projectId) return true;
+  const policy = await getProjectRoutingPolicy(projectId);
+  const override = policy?.modelOverrides?.[wireModel];
+  if (override !== undefined) return override;
+  return defaultEnabledFromCatalog(catalog).has(wireModel);
 }

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -120,12 +120,14 @@ mock.module('../models/managed-models', () => ({
 let capabilities = { reasoning: false, temperature: true };
 mock.module('../models/catalog-models', () => ({
   capabilitiesForModel: () => capabilities,
+  gatewayModelCatalog: () => ({}),
 }));
 
 let disabledModelId: string | null = null;
 mock.module('../model-enablement', () => ({
-  isModelDisabledForProject: async (_projectId: string | null | undefined, model: string) =>
-    model === disabledModelId,
+  isModelEnabledForProject: async (_projectId: string | null | undefined, model: string) =>
+    model !== disabledModelId,
+  defaultEnabledFromCatalog: () => new Set<string>(),
 }));
 
 const { resolveCandidates, resolveCachedAccountTier } = await import('./resolve-candidates');

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -8,8 +8,8 @@ import { accountIsFreeTierForModels } from '../../billing/services/tiers';
 import { config } from '../../config';
 import { getProjectSecretValue } from '../../projects/secrets';
 import { CodexRefreshError, resolveCodexCredential } from '../credentials/codex';
-import { isModelDisabledForProject } from '../model-enablement';
-import { capabilitiesForModel } from '../models/catalog-models';
+import { isModelEnabledForProject } from '../model-enablement';
+import { capabilitiesForModel, gatewayModelCatalog } from '../models/catalog-models';
 import { getRuntimeManagedModel, isKnownManagedModelId } from '../models/managed-models';
 import { resolveCatalogUpstream } from '../models/provider-registry';
 import {
@@ -80,9 +80,17 @@ export async function resolveCandidates(
   const effectiveModel = model;
   const provider = effectiveModel.includes('/') ? effectiveModel.split('/')[0] : '';
 
-  // Per-project enablement: a model the project turned OFF is refused before any
-  // provider-specific resolution, so it's uniformly unusable everywhere.
-  if (await isModelDisabledForProject(principal.projectId, effectiveModel)) {
+  // Per-project enablement: a model the project doesn't offer is refused before
+  // any provider-specific resolution, so it's uniformly unusable everywhere.
+  // Judged against everything the project could route — not the picker's
+  // narrowed projection — so a raw-API caller is held to the same set.
+  if (
+    !(await isModelEnabledForProject(
+      principal.projectId,
+      effectiveModel,
+      gatewayModelCatalog(principal.projectId),
+    ))
+  ) {
     throw new GatewayResolutionError(
       'model_disabled',
       'This model is turned off for this project.',

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -72,6 +72,7 @@ import { resolveExperimentalFeature } from '../../experimental/features';
 import { PROJECT_ACTIONS } from '../../iam';
 import { setContextField } from '../../lib/request-context';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
+import { resolveEnablement } from '../../llm-gateway/model-enablement';
 import { gatewayModelCatalog } from '../../llm-gateway/models/catalog-models';
 import { projectPickerCatalog } from '../../llm-gateway/models/picker-catalog';
 import { runtimeModelCatalog } from '../../llm-gateway/models/runtime-catalog';
@@ -89,7 +90,7 @@ import {
 } from '../../repositories/model-preferences';
 import {
   getProjectRoutingPolicy,
-  setProjectDisabledModels,
+  setProjectModelOverrides,
 } from '../../repositories/project-routing-policies';
 import { db } from '../../shared/db';
 import {
@@ -2725,16 +2726,40 @@ projectsApp.openapi(
       new Set(secrets.names.map((name) => name.toUpperCase())),
       requiredModels,
     );
-    // Server-owned per-project enablement: the client renders these as OFF and
-    // hides them from the session picker; the gateway also refuses them.
-    return c.json({ models, disabledModels: routing?.disabledModels ?? [] });
+    // Server-owned per-project enablement, resolved HERE and stamped onto each
+    // model so every client renders the same answer the gateway enforces. The
+    // session picker shows the enabled ones; "Manage models" shows them all and
+    // switches on this flag. Neither re-derives it.
+    const enabled = resolveEnablement(models, routing?.modelOverrides ?? {});
+    return c.json({
+      models: Object.fromEntries(
+        Object.entries(models).map(([id, model]) => [
+          id,
+          { ...model, enabled: enabled.get(id) ?? true },
+        ]),
+      ),
+      // The stored EXCEPTIONS, so a client toggling one model can PUT the
+      // merged map back without having to reconstruct it by diffing the
+      // resolved flags against a default it would have to recompute.
+      modelOverrides: routing?.modelOverrides ?? {},
+      // True while the project has made no exceptions at all — the only thing
+      // "reset to defaults" has left to act on, and not derivable from the
+      // `enabled` flags alone (they look identical either way).
+      usingDefaults: Object.keys(routing?.modelOverrides ?? {}).length === 0,
+    });
   },
 );
 
-// PUT /v1/projects/:projectId/model-enablement  { disabledModels: string[] }
-// Replace the project's disabled-model set (opt-out). Authoritative: the gateway
-// refuses any model in this set for every surface. Refuses to disable the
-// project's own default model (that would break every `auto` request).
+// PUT /v1/projects/:projectId/model-enablement  { modelOverrides: {id: boolean} }
+// Replace the project's EXCEPTIONS to the default model set (the newest model
+// per family). Authoritative: the gateway refuses anything not effectively
+// enabled on every surface. An empty object restores the pure default. Refuses
+// to turn off the project's own default model (that would break every `auto`
+// request).
+const modelEnablementBody = z.object({
+  modelOverrides: z.record(z.string().min(1).max(128), z.boolean()),
+});
+
 projectsApp.openapi(
   createRoute({
     method: 'put',
@@ -2744,13 +2769,7 @@ projectsApp.openapi(
     ...auth,
     request: {
       params: z.object({ projectId: z.string() }),
-      body: {
-        content: {
-          'application/json': {
-            schema: z.object({ disabledModels: z.array(z.string().min(1).max(128)).max(500) }),
-          },
-        },
-      },
+      body: { content: { 'application/json': { schema: modelEnablementBody } } },
     },
     responses: {
       200: { description: 'OK', content: { 'application/json': { schema: z.any() } } },
@@ -2771,21 +2790,23 @@ projectsApp.openapi(
     const accountId = loaded.row.accountId as string;
     const userId = c.get('userId') as string;
 
-    const parsed = z
-      .object({ disabledModels: z.array(z.string().min(1).max(128)).max(500) })
-      .safeParse(await c.req.json().catch(() => null));
+    const parsed = modelEnablementBody.safeParse(await c.req.json().catch(() => null));
     if (!parsed.success) {
       return c.json({ error: 'Invalid body', code: 'invalid_body' }, 400);
     }
-    const disabledModels = Array.from(
-      new Set(parsed.data.disabledModels.map((m) => toWireModel(m.trim())).filter(Boolean)),
-    );
+    const modelOverrides: Record<string, boolean> = {};
+    for (const [model, enabled] of Object.entries(parsed.data.modelOverrides)) {
+      const wire = toWireModel(model.trim());
+      if (wire) modelOverrides[wire] = enabled;
+    }
 
-    // A project must never disable the model its own `auto` resolves to.
+    // A project must never turn off the model its own `auto` resolves to. Only
+    // an explicit `false` can do that — omitting it leaves the default in
+    // charge, which always offers the current one.
     const defaults = await getAccountModelDefaults(accountId, projectId);
     const effectiveDefault =
       defaults.projects[projectId] ?? defaults.account ?? config.LLM_GATEWAY_DEFAULT_MODEL;
-    if (effectiveDefault && disabledModels.includes(toWireModel(effectiveDefault))) {
+    if (effectiveDefault && modelOverrides[toWireModel(effectiveDefault)] === false) {
       return c.json(
         {
           error: 'Cannot disable the project default model — change the default first.',
@@ -2795,8 +2816,8 @@ projectsApp.openapi(
       );
     }
 
-    await setProjectDisabledModels({ projectId, updatedBy: userId, disabledModels });
-    return c.json({ ok: true, disabledModels });
+    await setProjectModelOverrides({ projectId, updatedBy: userId, modelOverrides });
+    return c.json({ ok: true, modelOverrides });
   },
 );
 

--- a/apps/api/src/repositories/project-routing-policies.test.ts
+++ b/apps/api/src/repositories/project-routing-policies.test.ts
@@ -37,7 +37,7 @@ test('reads current routing policy from the shared DB on every request', async (
       defaultFallbackModels: ['glm-5.2'],
       defaultFallbackOn: 'any-error',
       rules: [],
-      disabledModels: ['codex/gpt-5.4'],
+      modelOverrides: { 'codex/gpt-5.4': false },
     },
   ];
   expect(await getProjectRoutingPolicy('multi-replica-project')).toEqual({
@@ -45,7 +45,7 @@ test('reads current routing policy from the shared DB on every request', async (
     defaultFallback: { models: ['glm-5.2'], fallbackOn: 'any-error' },
     rules: [],
     modelGenerationConfig: {},
-    disabledModels: ['codex/gpt-5.4'],
+    modelOverrides: { 'codex/gpt-5.4': false },
   });
   expect(selectCalls).toBe(2);
 });

--- a/apps/api/src/repositories/project-routing-policies.ts
+++ b/apps/api/src/repositories/project-routing-policies.ts
@@ -13,8 +13,12 @@ export interface StoredProjectRoutingPolicy {
   defaultFallback: ProjectRoutingFallback | null;
   rules: ProjectRoutingRule[];
   modelGenerationConfig: ProjectModelGenerationConfig;
-  /** Wire-model ids explicitly disabled for this project (opt-out). */
-  disabledModels: string[];
+  /**
+   * Exceptions to the default model set: `wireModelId -> enabled`. Resolve it
+   * through `llm-gateway/model-enablement.ts` (which layers it over the catalog
+   * default); never read this field as if it were the answer on its own.
+   */
+  modelOverrides: Record<string, boolean>;
 }
 
 function fromRow(row: typeof projectLlmRoutingPolicies.$inferSelect): StoredProjectRoutingPolicy {
@@ -29,32 +33,32 @@ function fromRow(row: typeof projectLlmRoutingPolicies.$inferSelect): StoredProj
           },
     rules: row.rules,
     modelGenerationConfig: (row.modelGenerationConfig ?? {}) as ProjectModelGenerationConfig,
-    disabledModels: Array.isArray(row.disabledModels) ? row.disabledModels : [],
+    modelOverrides: (row.modelOverrides ?? {}) as Record<string, boolean>,
   };
 }
 
 /**
- * Persist ONLY the project's disabled-model set, preserving any routing policy.
+ * Persist ONLY the project's model overrides, preserving any routing policy.
  * Upserts the policy row (other fields keep their column defaults on insert and
  * are untouched on conflict), so model enablement is independent of the routing
- * editor.
+ * editor. An empty object clears every exception, restoring the catalog default.
  */
-export async function setProjectDisabledModels(params: {
+export async function setProjectModelOverrides(params: {
   projectId: string;
   updatedBy: string;
-  disabledModels: string[];
+  modelOverrides: Record<string, boolean>;
 }): Promise<void> {
   await db
     .insert(projectLlmRoutingPolicies)
     .values({
       projectId: params.projectId,
-      disabledModels: params.disabledModels,
+      modelOverrides: params.modelOverrides,
       updatedBy: params.updatedBy,
     })
     .onConflictDoUpdate({
       target: projectLlmRoutingPolicies.projectId,
       set: {
-        disabledModels: params.disabledModels,
+        modelOverrides: params.modelOverrides,
         updatedBy: params.updatedBy,
         updatedAt: new Date(),
       },

--- a/apps/web/src/features/session/model-flatten.ts
+++ b/apps/web/src/features/session/model-flatten.ts
@@ -1,7 +1,7 @@
-import { normalizeProviderList } from '@kortix/sdk/react';
-import type { ProviderListResponse } from '@kortix/sdk/react';
 import { LLM_PROVIDER_BY_ID } from '@/lib/llm-providers';
 import type { GatewayCatalogModel } from '@kortix/sdk';
+import { normalizeProviderList } from '@kortix/sdk/react';
+import type { ProviderListResponse } from '@kortix/sdk/react';
 
 // ============================================================================
 // Flat model list helper
@@ -57,6 +57,14 @@ export interface FlatModel {
   openWeights?: boolean;
   /** When models.dev last refreshed this model's own entry. */
   lastUpdated?: string;
+  /**
+   * Whether the project OFFERS this model. Server-owned per-project
+   * enablement, resolved by the API and enforced by the gateway — the session
+   * picker renders the enabled ones and "Manage models" switches on this flag.
+   * Neither re-derives it. Undefined on catalogs that don't carry enablement
+   * (anything but `/model-picker`), which callers read as "not applicable".
+   */
+  enabled?: boolean;
 }
 
 /**
@@ -165,6 +173,7 @@ export function flattenModels(providers: ProviderListResponse | undefined): Flat
         description: model.description,
         openWeights: model.open_weights,
         lastUpdated: model.last_updated,
+        enabled: model.enabled,
       });
     }
   }

--- a/apps/web/src/features/session/model-grouping.test.ts
+++ b/apps/web/src/features/session/model-grouping.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { pickerGroupId, pickerGroupLabel } from './model-selector';
+import { pickerGroupId, pickerGroupLabel } from './model-grouping';
 import type { FlatModel } from './session-chat-input';
 
 // Regression coverage for the "every provider shows as Kortix" picker bug.

--- a/apps/web/src/features/session/model-grouping.ts
+++ b/apps/web/src/features/session/model-grouping.ts
@@ -1,0 +1,47 @@
+import { DEFAULT_MANAGED_MODEL_IDS, PROVIDER_LABELS } from '@kortix/llm-catalog';
+
+import type { FlatModel } from './session-chat-input';
+
+const MANAGED_MODEL_IDS = new Set<string>(DEFAULT_MANAGED_MODEL_IDS);
+
+// The gateway exposes its whole catalog through a single `kortix` provider, with
+// model ids namespaced as `<provider>/<model>`. For the picker we recover the
+// REAL provider: platform-managed defaults stay under the "Kortix" group, while
+// every BYOK model surfaces under its real provider ("Anthropic", "OpenAI", …) —
+// so a connected provider reads as its own section, not buried in Kortix.
+//
+// *** BUG THIS FIXES (every model showing under "Kortix", even BYOK Anthropic) ***
+// `pickerGroupId` always correctly computed the grouping KEY (it split
+// `modelID` on "/" and returned e.g. "anthropic"). The bug was never in the
+// key — it was that the group's DISPLAY NAME, built in `grouped` below, was
+// taken verbatim from `model.providerName` (opencode's raw provider name,
+// which is ALWAYS "Kortix" — every gateway model is registered under the one
+// synthetic `kortix` opencode provider). So the group's icon rendered
+// correctly (`ProviderLogo` is keyed off the correct `providerID`), but the
+// text label next to it always read "Kortix" regardless of which provider
+// actually served the model.
+//
+// The robust fix (per the live /v1/models trace): the gateway now serves an
+// EXPLICIT `provider` field per model (`GatewayModel.provider`, threaded onto
+// `FlatModel.provider` by flattenModels) — grouping/labeling should prefer
+// that over parsing the wire id at all. String-splitting `modelID` remains
+// ONLY as a fallback for a stale/older baked catalog that predates the field.
+export function pickerGroupId(model: FlatModel): string {
+  if (model.providerID !== 'kortix') {
+    return model.providerID;
+  }
+  if (MANAGED_MODEL_IDS.has(model.modelID)) return model.provider ?? model.providerID;
+  if (model.provider) return model.provider;
+  const slash = model.modelID.indexOf('/');
+  return slash === -1 ? model.providerID : model.modelID.slice(0, slash);
+}
+
+// The group's display name/label — NEVER the raw `FlatModel.providerName`
+// (always "Kortix" under the gateway, see the bug note above). Prefer the
+// canonical label for the resolved real-provider id; only fall back to the
+// model's own providerName for a truly unknown id (e.g. `pickerGroupId`
+// degrading to the raw `providerID` because neither `provider` nor a `/` was
+// present — at that point `groupID === model.providerID` anyway).
+export function pickerGroupLabel(groupID: string, model: FlatModel): string {
+  return PROVIDER_LABELS[groupID] ?? model.providerName;
+}

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -30,18 +30,14 @@ import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { MODEL_SELECTOR_PROVIDER_IDS, ProviderLogo } from '@/features/providers/provider-branding';
-import { useLlmProviderCatalogRevision } from '@/features/workspace/customize/sections/llm-provider/use-live-catalog';
-import { accountStateSelectors, useAccountState } from '@/hooks/billing';
 import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
 import type { ProviderModalTab } from '@/stores/provider-modal-store';
 import { useProviderModalStore } from '@/stores/provider-modal-store';
-import { DEFAULT_MANAGED_MODEL_IDS, PROVIDER_LABELS } from '@kortix/llm-catalog';
-import { getProjectDetail, listProjectSecrets } from '@kortix/sdk';
-import { connectedGatewayProviderIdsFromSecretNames } from '@kortix/sdk/react';
-import { modelKeyToWire, useModelEnablement, useModelStore } from '@kortix/sdk/react';
+import { getProjectDetail } from '@kortix/sdk';
 import type { ProviderListResponse } from '@kortix/sdk/react';
 import { useQuery } from '@tanstack/react-query';
 import { resolveAvailableSelectedModel } from './model-availability';
+import { pickerGroupId, pickerGroupLabel } from './model-grouping';
 import { shouldShowFreeTag } from './model-tags';
 import type { FlatModel } from './session-chat-input';
 import { useModelConnectionGate } from './use-model-connection-gate';
@@ -78,50 +74,6 @@ export function ConnectProviderDialog({
 
 // Import from canonical UI component and re-export for consumers
 import { Tag } from '@/components/ui/tag';
-
-const MANAGED_MODEL_IDS = new Set<string>(DEFAULT_MANAGED_MODEL_IDS);
-
-// The gateway exposes its whole catalog through a single `kortix` provider, with
-// model ids namespaced as `<provider>/<model>`. For the picker we recover the
-// REAL provider: platform-managed defaults stay under the "Kortix" group, while
-// every BYOK model surfaces under its real provider ("Anthropic", "OpenAI", …) —
-// so a connected provider reads as its own section, not buried in Kortix.
-//
-// *** BUG THIS FIXES (every model showing under "Kortix", even BYOK Anthropic) ***
-// `pickerGroupId` always correctly computed the grouping KEY (it split
-// `modelID` on "/" and returned e.g. "anthropic"). The bug was never in the
-// key — it was that the group's DISPLAY NAME, built in `grouped` below, was
-// taken verbatim from `model.providerName` (opencode's raw provider name,
-// which is ALWAYS "Kortix" — every gateway model is registered under the one
-// synthetic `kortix` opencode provider). So the group's icon rendered
-// correctly (`ProviderLogo` is keyed off the correct `providerID`), but the
-// text label next to it always read "Kortix" regardless of which provider
-// actually served the model.
-//
-// The robust fix (per the live /v1/models trace): the gateway now serves an
-// EXPLICIT `provider` field per model (`GatewayModel.provider`, threaded onto
-// `FlatModel.provider` by flattenModels) — grouping/labeling should prefer
-// that over parsing the wire id at all. String-splitting `modelID` remains
-// ONLY as a fallback for a stale/older baked catalog that predates the field.
-export function pickerGroupId(model: FlatModel): string {
-  if (model.providerID !== 'kortix') {
-    return model.providerID;
-  }
-  if (MANAGED_MODEL_IDS.has(model.modelID)) return model.provider ?? model.providerID;
-  if (model.provider) return model.provider;
-  const slash = model.modelID.indexOf('/');
-  return slash === -1 ? model.providerID : model.modelID.slice(0, slash);
-}
-
-// The group's display name/label — NEVER the raw `FlatModel.providerName`
-// (always "Kortix" under the gateway, see the bug note above). Prefer the
-// canonical label for the resolved real-provider id; only fall back to the
-// model's own providerName for a truly unknown id (e.g. `pickerGroupId`
-// degrading to the raw `providerID` because neither `provider` nor a `/` was
-// present — at that point `groupID === model.providerID` anyway).
-export function pickerGroupLabel(groupID: string, model: FlatModel): string {
-  return PROVIDER_LABELS[groupID] ?? model.providerName;
-}
 
 // ─── ModelSelector ───────────────────────────────────────────────────────────
 
@@ -199,49 +151,12 @@ export function ModelSelector({
     return llmGatewayEnabled ? models : models.filter((m) => m.providerID !== 'kortix');
   }, [models, llmGatewayEnabled]);
 
-  // Track project secrets whenever we're in a project (not only while the picker
-  // is open) so connecting/disconnecting a provider flips model visibility live —
-  // the connect mutation invalidates this exact key, and an always-subscribed
-  // query refetches immediately instead of waiting for the next picker open.
-  const secretsQuery = useQuery({
-    queryKey: ['project-secrets', projectId],
-    queryFn: () => listProjectSecrets(projectId as string),
-    enabled: !!projectId && llmGatewayEnabled,
-    staleTime: 10_000,
-  });
-  const secretNames = useMemo(() => {
-    const data = secretsQuery.data;
-    const items = Array.isArray(data) ? data : (data?.items ?? []);
-    return new Set(items.map((secret: { name: string }) => secret.name));
-  }, [secretsQuery.data]);
-  // Providers whose key(s) are present — drives which of the gateway's full
-  // baked catalog is shown by default in the picker (connected providers light
-  // up the instant their secret lands; everything else stays search-only).
-  // Re-renders when LlmCatalogBootstrap's live-catalog fetch lands — see
-  // use-connected-providers.ts for the same pattern.
-  const catalogRevision = useLlmProviderCatalogRevision();
-  const connectedProviderIds = useMemo(() => {
-    if (!llmGatewayEnabled) return new Set<string>();
-    return connectedGatewayProviderIdsFromSecretNames(secretNames);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- catalogRevision drives a re-read of the module-level LLM_PROVIDERS binding, not a value used directly here
-  }, [llmGatewayEnabled, secretNames, catalogRevision]);
-
-  // Free tier (free/no plan AND no active subscription) hides Kortix-managed
-  // models. Connected BYOK providers remain.
-  const { data: accountState } = useAccountState();
-  const freeTier = useMemo(() => {
-    const tierKey = accountStateSelectors.tierKey(accountState).toLowerCase();
-    const hasActiveSubscription = !!accountState?.subscription?.subscription_id;
-    return (tierKey === 'free' || tierKey === 'none') && !hasActiveSubscription;
-  }, [accountState]);
-
-  const modelStore = useModelStore(baseModels, {
-    connectedProviderIds,
-    freeTier: llmGatewayEnabled && freeTier,
-  });
-  // Server-owned enablement: a model the project turned OFF is unusable (the
-  // gateway refuses it), so it never appears in the picker — not even via search.
-  const { disabledModels } = useModelEnablement(projectId);
+  // NOTE: the picker deliberately derives NO availability of its own. Which
+  // models a project can call (connected BYOK providers, plan entitlement) and
+  // which of those it offers are both resolved server-side by `/model-picker`
+  // — the route this list already comes from. Re-deriving either here from
+  // project secrets + account tier is what let this view disagree with both
+  // the "Manage models" tab and the gateway.
 
   const availableSelectedModel = entitlementsPending
     ? selectedModel
@@ -262,36 +177,24 @@ export function ModelSelector({
 
   // ── Filtered + grouped models ──
 
+  // The list is exactly what the project OFFERS. `enabled` is resolved by the
+  // server (and enforced by the gateway), so the picker applies no visibility
+  // rule of its own — a second, client-only filter here is precisely what made
+  // "Manage models" report 15 of 15 shown while this rendered 3. Turn a model
+  // on in "Manage models" and it appears here; there is nothing else to check.
   const visibleModels = useMemo(() => {
     const q = search.toLowerCase();
     return baseModels
-      .filter((m) => {
-        if (!isSelectableModel({ providerID: m.providerID, modelID: m.modelID })) {
-          return false;
-        }
-        // A project-disabled model is unusable — hide it unconditionally.
-        if (disabledModels.has(modelKeyToWire({ providerID: m.providerID, modelID: m.modelID })))
-          return false;
-        // Search reveals usable models that the user hid from the default list.
-        // It never reveals models that the account cannot call.
-        if (
-          !q &&
-          !modelStore.isVisible({
-            providerID: m.providerID,
-            modelID: m.modelID,
-            provider: m.provider,
-          })
-        )
-          return false;
-        return (
-          !q ||
-          (m.modelName || '').toLowerCase().includes(q) ||
-          (m.modelID || '').toLowerCase().includes(q) ||
-          (m.providerName || '').toLowerCase().includes(q)
-        );
-      })
+      .filter(
+        (m) =>
+          m.enabled !== false &&
+          (!q ||
+            (m.modelName || '').toLowerCase().includes(q) ||
+            (m.modelID || '').toLowerCase().includes(q) ||
+            (m.providerName || '').toLowerCase().includes(q)),
+      )
       .sort((a, b) => a.modelName.localeCompare(b.modelName));
-  }, [baseModels, search, modelStore, isSelectableModel, disabledModels]);
+  }, [baseModels, search]);
 
   const grouped = useMemo(() => {
     const groups = new Map<
@@ -471,20 +374,6 @@ export function ModelSelector({
                           availableSelectedModel?.modelID === model.modelID;
 
                         const isFree = shouldShowFreeTag(model);
-                        // `.provider` (the real upstream, when the gateway
-                        // serves it) makes isVisible's connection-gating
-                        // check the correct sub-provider instead of falling
-                        // back to string-splitting modelID — see
-                        // use-model-store.ts's subProviderOf.
-                        const modelKey = {
-                          providerID: model.providerID,
-                          modelID: model.modelID,
-                          provider: model.provider,
-                        };
-                        // "Latest" models are always shown; older ones get an
-                        // activation switch so they can be pinned into the picker.
-                        const isLatestModel = modelStore.isLatest(modelKey);
-                        const isModelVisible = modelStore.isVisible(modelKey);
                         // Under a BYOK provider group the `<provider>/` prefix is
                         // redundant — show just the bare model id.
                         const displayModelID =
@@ -496,11 +385,7 @@ export function ModelSelector({
                           <CommandItem
                             key={`${model.providerID}:${model.modelID}`}
                             value={`model-${model.providerID}-${model.modelID}`}
-                            className={cn(
-                              '!pl-3',
-                              isSelected && 'bg-foreground/[0.06]',
-                              !isLatestModel && !isModelVisible && 'opacity-60',
-                            )}
+                            className={cn('!pl-3', isSelected && 'bg-foreground/[0.06]')}
                             onSelect={() => handleSelect(model)}
                           >
                             <div className="min-w-0 flex-1 py-0.5">

--- a/apps/web/src/features/session/model-tags.test.ts
+++ b/apps/web/src/features/session/model-tags.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { modelVisibilityKeyForProviderModel, shouldShowFreeTag } from './model-tags';
+import { shouldShowFreeTag } from './model-tags';
 
 describe('shouldShowFreeTag', () => {
   test('uses an explicit free marker when a provider sends one', () => {
@@ -32,22 +32,3 @@ describe('shouldShowFreeTag', () => {
   });
 });
 
-describe('modelVisibilityKeyForProviderModel', () => {
-  test('keeps native provider keys unchanged', () => {
-    expect(
-      modelVisibilityKeyForProviderModel('anthropic', 'claude-sonnet-4-6', false),
-    ).toEqual({ providerID: 'anthropic', modelID: 'claude-sonnet-4-6' });
-  });
-
-  test('maps gateway BYOK provider models onto the kortix provider namespace', () => {
-    expect(
-      modelVisibilityKeyForProviderModel('anthropic', 'claude-sonnet-4-6', true),
-    ).toEqual({ providerID: 'kortix', modelID: 'anthropic/claude-sonnet-4-6' });
-  });
-
-  test('keeps managed kortix model ids bare in gateway mode', () => {
-    expect(
-      modelVisibilityKeyForProviderModel('kortix', 'claude-opus-4.8', true),
-    ).toEqual({ providerID: 'kortix', modelID: 'claude-opus-4.8' });
-  });
-});

--- a/apps/web/src/features/session/model-tags.ts
+++ b/apps/web/src/features/session/model-tags.ts
@@ -2,19 +2,9 @@ import type { FlatModel } from './session-chat-input';
 
 const FREE_TOKEN = /(^|[\s/_-])free($|[\s/_-])/i;
 
-export function shouldShowFreeTag(model: Pick<FlatModel, 'free' | 'modelID' | 'modelName'>): boolean {
+export function shouldShowFreeTag(
+  model: Pick<FlatModel, 'free' | 'modelID' | 'modelName'>,
+): boolean {
   if (model.free === true) return true;
   return FREE_TOKEN.test(model.modelName) || FREE_TOKEN.test(model.modelID);
-}
-
-export function modelVisibilityKeyForProviderModel(
-  providerID: string,
-  modelID: string,
-  llmGatewayEnabled: boolean,
-): { providerID: string; modelID: string } {
-  if (!llmGatewayEnabled) return { providerID, modelID };
-  return {
-    providerID: 'kortix',
-    modelID: providerID === 'kortix' ? modelID : `${providerID}/${modelID}`,
-  };
 }

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
@@ -279,7 +279,11 @@ function ProviderDetail({
                       <span className="text-foreground truncate text-sm font-medium">
                         {model.name}
                       </span>
-                      <ModelCapabilityIcons model={model} />
+                      <ModelCapabilityIcons
+                        reasoning={model.reasoning}
+                        toolCall={model.tool_call}
+                        vision={model.attachment}
+                      />
                     </div>
                     <div className="flex min-w-0 items-center gap-0.5">
                       <code className="text-muted-foreground/50 min-w-0 truncate font-mono text-xs">

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -227,11 +227,7 @@ export function ProjectProviderModal({
             </TabsContent>
 
             <TabsContent value="models" className="mt-0">
-              <ModelsTab
-                projectId={projectId}
-                connectedProviders={connectedProviders}
-                search={search}
-              />
+              <ModelsTab projectId={projectId} search={search} />
             </TabsContent>
           </>
         )}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/model-capability-icons.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/model-capability-icons.tsx
@@ -1,32 +1,39 @@
 'use client';
 
 import Hint from '@/components/ui/hint';
-import type { LlmProviderModel } from '@/lib/llm-providers';
 import { Brain, Eye, Wrench } from 'lucide-react';
 
 const ICON_CLASS = 'text-muted-foreground/50 size-3.5 shrink-0';
 
 /**
  * Compact capability chips — reasoning / tool-calling / vision — mirrored
- * verbatim from models.dev (`LlmProviderModel.reasoning` / `tool_call` /
- * `attachment`). Icon-only with a `Hint` tooltip so a dense model row stays
- * scannable; renders nothing when a model declares no capabilities.
+ * verbatim from models.dev. Takes the three flags rather than a model object
+ * so it serves every catalog shape that carries them; renders nothing when a
+ * model declares no capabilities.
  */
-export function ModelCapabilityIcons({ model }: { model: LlmProviderModel }) {
-  if (!model.reasoning && !model.tool_call && !model.attachment) return null;
+export function ModelCapabilityIcons({
+  reasoning,
+  toolCall,
+  vision,
+}: {
+  reasoning?: boolean;
+  toolCall?: boolean;
+  vision?: boolean;
+}) {
+  if (!reasoning && !toolCall && !vision) return null;
   return (
     <div className="flex shrink-0 items-center gap-1">
-      {model.reasoning && (
+      {reasoning && (
         <Hint label="Reasoning">
           <Brain className={ICON_CLASS} />
         </Hint>
       )}
-      {model.tool_call && (
+      {toolCall && (
         <Hint label="Tool calling">
           <Wrench className={ICON_CLASS} />
         </Hint>
       )}
-      {model.attachment && (
+      {vision && (
         <Hint label="Vision / file input">
           <Eye className={ICON_CLASS} />
         </Hint>

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/model-rows.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/model-rows.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { FlatModel } from '@/features/session/session-chat-input';
+import { buildModelGroups } from './model-rows';
+
+function model(modelID: string, over: Partial<FlatModel> = {}): FlatModel {
+  return {
+    providerID: 'kortix',
+    providerName: 'Kortix',
+    modelID,
+    modelName: modelID,
+    ...over,
+  } as FlatModel;
+}
+
+describe('buildModelGroups', () => {
+  test('groups by the real upstream provider, not the synthetic kortix id', () => {
+    const groups = buildModelGroups([
+      model('anthropic/claude-sonnet-5', { provider: 'anthropic' }),
+      model('openai/gpt-5.5', { provider: 'openai' }),
+    ]);
+    expect(groups.map((g) => g.providerName)).toEqual(['Anthropic', 'OpenAI']);
+  });
+
+  test('orders each group newest release first', () => {
+    const [group] = buildModelGroups([
+      model('anthropic/old', { provider: 'anthropic', releaseDate: '2025-01-01' }),
+      model('anthropic/new', { provider: 'anthropic', releaseDate: '2026-06-01' }),
+      model('anthropic/mid', { provider: 'anthropic', releaseDate: '2026-01-01' }),
+    ]);
+    expect(group.rows.map((r) => r.model.modelID)).toEqual([
+      'anthropic/new',
+      'anthropic/mid',
+      'anthropic/old',
+    ]);
+  });
+
+  test('flags the undated pointer when pinned snapshots exist', () => {
+    // Both render as "Claude Sonnet 4.5"; without the flag they are two
+    // indistinguishable rows with two independent switches.
+    const [group] = buildModelGroups([
+      model('anthropic/claude-sonnet-4-5', { provider: 'anthropic' }),
+      model('anthropic/claude-sonnet-4-5-20250929', { provider: 'anthropic' }),
+    ]);
+    const byId = new Map(group.rows.map((r) => [r.model.modelID, r]));
+    expect(byId.get('anthropic/claude-sonnet-4-5')?.isRollingAlias).toBe(true);
+    expect(byId.get('anthropic/claude-sonnet-4-5-20250929')?.isRollingAlias).toBe(false);
+  });
+
+  test('does not flag an undated model with no pinned sibling', () => {
+    const [group] = buildModelGroups([model('anthropic/claude-opus-5', { provider: 'anthropic' })]);
+    expect(group.rows[0].isRollingAlias).toBe(false);
+  });
+
+  test('carries the wire id the server stores enablement against', () => {
+    const [group] = buildModelGroups([
+      model('anthropic/claude-sonnet-5', { provider: 'anthropic' }),
+    ]);
+    expect(group.rows[0].wireId).toBe('anthropic/claude-sonnet-5');
+  });
+
+  test('filters by name and by id, keeping groups that still have rows', () => {
+    const models = [
+      model('anthropic/claude-sonnet-5', { provider: 'anthropic', modelName: 'Claude Sonnet 5' }),
+      model('openai/gpt-5.5', { provider: 'openai', modelName: 'GPT-5.5' }),
+    ];
+    expect(buildModelGroups(models, 'sonnet').map((g) => g.providerID)).toEqual(['anthropic']);
+    expect(buildModelGroups(models, 'openai/').map((g) => g.providerID)).toEqual(['openai']);
+    expect(buildModelGroups(models, 'nothing-matches')).toEqual([]);
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/model-rows.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/model-rows.ts
@@ -1,0 +1,99 @@
+import { MODEL_SELECTOR_PROVIDER_IDS } from '@/features/providers/provider-branding';
+import { pickerGroupId, pickerGroupLabel } from '@/features/session/model-grouping';
+import type { FlatModel } from '@/features/session/session-chat-input';
+import { modelKeyToWire } from '@kortix/sdk/react';
+
+/**
+ * Row/group shaping for the "Manage models" tab. Pure so it can be tested
+ * without rendering, and deliberately built from the SAME `FlatModel[]` and the
+ * SAME grouping helpers the session picker uses — the two views listing
+ * different catalogs (models.dev per-provider vs the gateway's served set) is
+ * what let them disagree about which models exist at all.
+ */
+
+/** Trailing models.dev snapshot date, e.g. `claude-sonnet-4-5-20250929`. */
+const DATED_SUFFIX = /-\d{8}$/;
+
+export interface ModelRow {
+  model: FlatModel;
+  /** The id the server stores enablement against. */
+  wireId: string;
+  /**
+   * True when this is the undated pointer for a family that also publishes
+   * pinned snapshots — `claude-sonnet-4-5` alongside
+   * `claude-sonnet-4-5-20250929`. Both are separately selectable models with
+   * identical display names, so the list has to say which is which.
+   */
+  isRollingAlias: boolean;
+}
+
+export interface ModelGroup {
+  providerID: string;
+  providerName: string;
+  rows: ModelRow[];
+}
+
+function releasedAt(model: FlatModel): number {
+  const ms = model.releaseDate ? new Date(model.releaseDate).getTime() : Number.NaN;
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+function matchesSearch(model: FlatModel, query: string): boolean {
+  if (!query) return true;
+  return (
+    model.modelName.toLowerCase().includes(query) || model.modelID.toLowerCase().includes(query)
+  );
+}
+
+/**
+ * Group by real upstream provider, newest model first, with rolling aliases
+ * flagged. Provider order matches the session picker's.
+ */
+export function buildModelGroups(models: FlatModel[], search = ''): ModelGroup[] {
+  const query = search.trim().toLowerCase();
+  const groups = new Map<string, ModelGroup>();
+
+  for (const model of models) {
+    if (!matchesSearch(model, query)) continue;
+    const providerID = pickerGroupId(model);
+    const group = groups.get(providerID);
+    const row: ModelRow = {
+      model,
+      wireId: modelKeyToWire({ providerID: model.providerID, modelID: model.modelID }),
+      isRollingAlias: false,
+    };
+    if (group) group.rows.push(row);
+    else {
+      groups.set(providerID, {
+        providerID,
+        providerName: pickerGroupLabel(providerID, model),
+        rows: [row],
+      });
+    }
+  }
+
+  for (const group of groups.values()) {
+    const dated = new Set(
+      group.rows
+        .filter((row) => DATED_SUFFIX.test(row.model.modelID))
+        .map((row) => row.model.modelID.replace(DATED_SUFFIX, '')),
+    );
+    for (const row of group.rows) {
+      row.isRollingAlias = !DATED_SUFFIX.test(row.model.modelID) && dated.has(row.model.modelID);
+    }
+    group.rows.sort(
+      (a, b) =>
+        releasedAt(b.model) - releasedAt(a.model) ||
+        a.model.modelName.localeCompare(b.model.modelName),
+    );
+  }
+
+  return [...groups.values()].sort((a, b) => {
+    const ai = MODEL_SELECTOR_PROVIDER_IDS.indexOf(a.providerID);
+    const bi = MODEL_SELECTOR_PROVIDER_IDS.indexOf(b.providerID);
+    if (ai >= 0 && bi < 0) return -1;
+    if (ai < 0 && bi >= 0) return 1;
+    if (ai >= 0 && bi >= 0) return ai - bi;
+    return a.providerName.localeCompare(b.providerName);
+  });
+}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
@@ -3,72 +3,32 @@
 import { Button } from '@/components/ui/button';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { Switch } from '@/components/ui/switch';
+import { Tag } from '@/components/ui/tag';
 import { ProviderLogo } from '@/features/providers/provider-branding';
-import type { LlmProviderEntry } from '@/lib/llm-providers';
-import { useModelPricingLookup } from '@/lib/model-pricing';
 import { cn } from '@/lib/utils';
-import { useModelEnablement } from '@kortix/sdk/react';
-import { ExternalLink } from 'lucide-react';
+import { useModelEnablement, useProjectModels } from '@kortix/sdk/react';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 
 import { ModelCapabilityIcons } from './model-capability-icons';
 import { ModelIdCopyButton } from './model-id-copy-button';
-import {
-  formatPricePerMillion,
-  formatTokenCount,
-  gatewayModelId,
-  helpHostnameFromUrl,
-} from './utils';
+import { buildModelGroups } from './model-rows';
+import { formatPricePerMillion, formatTokenCount } from './utils';
 
-export function ModelsTab({
-  projectId,
-  connectedProviders,
-  search,
-}: {
-  projectId: string;
-  connectedProviders: LlmProviderEntry[];
-  search: string;
-}) {
+export function ModelsTab({ projectId, search }: { projectId: string; search: string }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
-  const pricingLookup = useModelPricingLookup(undefined);
 
-  // Enablement is SERVER-owned (the gateway enforces it): each switch persists
-  // to `PUT /projects/:id/model-enablement`, not localStorage. `gatewayModelId`
-  // gives each row its wire id — the key the server stores.
+  // The SAME server list the session picker renders (`GET /model-picker`), so
+  // the two views can never show different models — and each model's `enabled`
+  // flag is resolved server-side and enforced by the gateway, so a switch here
+  // is the one and only thing deciding whether it appears there.
+  const models = useProjectModels(projectId);
   const enablement = useModelEnablement(projectId);
 
-  const rows = useMemo(
-    () => connectedProviders.flatMap((p) => p.models.map((m) => ({ provider: p, model: m }))),
-    [connectedProviders],
-  );
+  const groups = useMemo(() => buildModelGroups(models, search), [models, search]);
+  const enabledCount = useMemo(() => models.filter((m) => m.enabled).length, [models]);
 
-  const enabledCount = useMemo(
-    () =>
-      rows.filter((row) => enablement.isEnabled(gatewayModelId(row.provider, row.model.id))).length,
-    [rows, enablement],
-  );
-  const hasOverrides = enablement.disabledModels.size > 0;
-
-  const grouped = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    const byProvider = new Map<string, { provider: LlmProviderEntry; rows: typeof rows }>();
-    for (const row of rows) {
-      if (
-        q &&
-        !row.model.name.toLowerCase().includes(q) &&
-        !row.model.id.toLowerCase().includes(q)
-      ) {
-        continue;
-      }
-      const existing = byProvider.get(row.provider.id);
-      if (existing) existing.rows.push(row);
-      else byProvider.set(row.provider.id, { provider: row.provider, rows: [row] });
-    }
-    return Array.from(byProvider.values());
-  }, [rows, search]);
-
-  if (connectedProviders.length === 0) {
+  if (models.length === 0) {
     return (
       <div className="flex min-h-[200px] items-center justify-center px-6 text-center">
         <p className="text-muted-foreground/60 text-xs">
@@ -80,7 +40,7 @@ export function ModelsTab({
     );
   }
 
-  if (grouped.length === 0) {
+  if (groups.length === 0) {
     return (
       <div className="flex min-h-[200px] items-center justify-center px-6 text-center">
         <p className="text-muted-foreground/60 text-xs">
@@ -95,17 +55,18 @@ export function ModelsTab({
       {!search && (
         <div className="flex items-center justify-between gap-3 px-1 pb-2.5">
           <p className="text-muted-foreground/60 text-xs">
-            {enabledCount} of {rows.length}{' '}
+            {enabledCount} of {models.length}{' '}
             {tHardcodedUi.raw(
               'autoComponentsProjectsProjectProviderModalJsxTextShownInTheb8c08575',
             )}
           </p>
-          {hasOverrides && (
+          {!enablement.usingDefaults && (
             <Button
               variant="ghost"
               size="sm"
+              disabled={enablement.isUpdating}
               className="text-muted-foreground hover:text-foreground h-7 shrink-0 px-2 text-xs"
-              onClick={() => void enablement.enableAll()}
+              onClick={() => void enablement.resetToDefaults()}
             >
               {tHardcodedUi.raw(
                 'autoComponentsProjectsProjectProviderModalJsxTextResetToDefaults75549180',
@@ -115,83 +76,69 @@ export function ModelsTab({
         </div>
       )}
       <div className="space-y-3">
-        {grouped.map(({ provider, rows: providerRows }) => {
-          const helpHostname = helpHostnameFromUrl(provider.helpUrl);
-          return (
-            <div key={provider.id}>
-              <div className="flex items-center gap-2 px-1 pb-1">
-                <ProviderLogo providerID={provider.id} name={provider.label} size="small" />
-                <span className="text-foreground/70 text-xs font-medium">{provider.label}</span>
-                {helpHostname && provider.helpUrl && (
-                  <a
-                    href={provider.helpUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-muted-foreground/50 hover:text-foreground inline-flex items-center gap-0.5 text-[11px] transition-colors"
-                  >
-                    <ExternalLink className="size-2.5 shrink-0" />
-                    {helpHostname}
-                  </a>
-                )}
-                <span className="text-muted-foreground/40 ml-auto text-xs">
-                  {providerRows.length}
-                </span>
-              </div>
-              <div className="bg-popover overflow-hidden rounded-md border">
-                {providerRows.map(({ model }, i) => {
-                  const wireId = gatewayModelId(provider, model.id);
-                  const visible = enablement.isEnabled(wireId);
-                  const rates = pricingLookup(provider.id, model.id);
-                  const ctx = formatTokenCount(model.limit?.context);
-                  const out = formatTokenCount(model.limit?.output);
-                  const priceIn = rates ? formatPricePerMillion(rates.inputPer1M) : '';
-                  const priceOut = rates ? formatPricePerMillion(rates.outputPer1M) : '';
-                  const hasMeta = !!ctx || !!out || (!!priceIn && !!priceOut);
-                  return (
-                    <label
-                      key={model.id}
-                      className={cn(
-                        'hover:bg-muted/40 flex cursor-pointer items-start gap-3 px-3 py-2.5 transition-colors',
-                        i > 0 && 'border-border border-t',
-                        !visible && 'opacity-60',
-                      )}
-                    >
-                      <div className="min-w-0 flex-1 space-y-1">
-                        <div className="flex flex-wrap items-center gap-1.5">
-                          <span className="text-foreground truncate text-sm">{model.name}</span>
-                          <ModelCapabilityIcons model={model} />
-                        </div>
-                        <div className="flex min-w-0 items-center gap-0.5">
-                          <code className="text-muted-foreground/50 min-w-0 truncate font-mono text-xs">
-                            {wireId}
-                          </code>
-                          <ModelIdCopyButton value={wireId} />
-                        </div>
-                        {hasMeta && (
-                          <InlineMeta>
-                            {ctx && <span className="tabular-nums">{ctx} ctx</span>}
-                            {out && <span className="tabular-nums">{out} max out</span>}
-                            {priceIn && priceOut && (
-                              <span className="tabular-nums">
-                                {priceIn} / {priceOut} per 1M
-                              </span>
-                            )}
-                          </InlineMeta>
-                        )}
-                      </div>
-                      <Switch
-                        checked={visible}
-                        disabled={enablement.isUpdating}
-                        onCheckedChange={(c) => void enablement.setEnabled(wireId, c)}
-                        className="mt-0.5 shrink-0"
-                      />
-                    </label>
-                  );
-                })}
-              </div>
+        {groups.map((group) => (
+          <div key={group.providerID}>
+            <div className="flex items-center gap-2 px-1 pb-1">
+              <ProviderLogo providerID={group.providerID} name={group.providerName} size="small" />
+              <span className="text-foreground/70 text-xs font-medium">{group.providerName}</span>
+              <span className="text-muted-foreground/40 ml-auto text-xs">{group.rows.length}</span>
             </div>
-          );
-        })}
+            <div className="bg-popover overflow-hidden rounded-md border">
+              {group.rows.map(({ model, wireId, isRollingAlias }, i) => {
+                const enabled = !!model.enabled;
+                const ctx = formatTokenCount(model.contextWindow);
+                const priceIn = model.cost ? formatPricePerMillion(model.cost.input) : '';
+                const priceOut = model.cost ? formatPricePerMillion(model.cost.output) : '';
+                return (
+                  <label
+                    key={wireId}
+                    className={cn(
+                      'hover:bg-muted/40 flex cursor-pointer items-start gap-3 px-3 py-2.5 transition-colors',
+                      i > 0 && 'border-border border-t',
+                      !enabled && 'opacity-60',
+                    )}
+                  >
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="text-foreground truncate text-sm">{model.modelName}</span>
+                        <ModelCapabilityIcons
+                          reasoning={model.capabilities?.reasoning}
+                          toolCall={model.capabilities?.toolcall}
+                          vision={model.capabilities?.vision}
+                        />
+                        {/* Same display name as its pinned snapshots — say which
+                            row is the one that rolls forward. */}
+                        {isRollingAlias && <Tag>latest</Tag>}
+                      </div>
+                      <div className="flex min-w-0 items-center gap-0.5">
+                        <code className="text-muted-foreground/50 min-w-0 truncate font-mono text-xs">
+                          {wireId}
+                        </code>
+                        <ModelIdCopyButton value={wireId} />
+                      </div>
+                      {(ctx || (priceIn && priceOut)) && (
+                        <InlineMeta>
+                          {ctx && <span className="tabular-nums">{ctx} ctx</span>}
+                          {priceIn && priceOut && (
+                            <span className="tabular-nums">
+                              {priceIn} / {priceOut} per 1M
+                            </span>
+                          )}
+                        </InlineMeta>
+                      )}
+                    </div>
+                    <Switch
+                      checked={enabled}
+                      disabled={enablement.isUpdating}
+                      onCheckedChange={(next) => void enablement.setEnabled(wireId, next)}
+                      className="mt-0.5 shrink-0"
+                    />
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/utils.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/utils.ts
@@ -150,12 +150,10 @@ export function envVarPlaceholder(provider: LlmProviderEntry, envVar: string): s
 export const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 /**
- * The literal model id you'd pass as `model` in a gateway request body
- * (`POST /v1/chat/completions`, `/v1/messages`, …) — `provider/model` for
- * BYOK providers (e.g. `anthropic/claude-sonnet-4.6`), the bare id for
- * Kortix-managed models (single-segment by design — see `@kortix/llm-catalog`'s
- * `MANAGED_MODELS` doc comment), and `codex/<id>` for the ChatGPT-subscription
- * provider.
+ * The gateway wire id for a model listed under a PROVIDER entry (the "Add
+ * provider" catalog, which browses providers rather than the project's served
+ * models). Surfaces that work from the served catalog have the wire id already
+ * and use `modelKeyToWire` instead — see model-rows.ts.
  */
 export function gatewayModelId(
   provider: Pick<LlmProviderEntry, 'id' | 'managed'>,

--- a/packages/db/drizzle/meta/20260729013229_snapshot.json
+++ b/packages/db/drizzle/meta/20260729013229_snapshot.json
@@ -1,0 +1,16729 @@
+{
+  "id": "ebd50b84-3904-4862-959f-2a8f56b0814c",
+  "prevId": "04e77f19-0118-4c3c-a754-7c38b3fd397b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "kortix.access_allowlist": {
+      "name": "access_allowlist",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_allowlist_type_value": {
+          "name": "idx_access_allowlist_type_value",
+          "columns": [
+            {
+              "expression": "entry_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.access_requests": {
+      "name": "access_requests",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_case": {
+          "name": "use_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "access_request_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_requests_email": {
+          "name": "idx_access_requests_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_requests_status": {
+          "name": "idx_access_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_deletion_requests": {
+      "name": "account_deletion_requests",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_github_installation_states": {
+      "name": "account_github_installation_states",
+      "schema": "kortix",
+      "columns": {
+        "state_nonce": {
+          "name": "state_nonce",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_github_installation_states_account": {
+          "name": "idx_account_github_installation_states_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_github_installation_states_expires_at": {
+          "name": "idx_account_github_installation_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_github_installation_states_account_id_accounts_account_id_fk": {
+          "name": "account_github_installation_states_account_id_accounts_account_id_fk",
+          "tableFrom": "account_github_installation_states",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_github_installations": {
+      "name": "account_github_installations",
+      "schema": "kortix",
+      "columns": {
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Organization'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_github_installations_account": {
+          "name": "idx_account_github_installations_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_github_installations_account_installation": {
+          "name": "idx_account_github_installations_account_installation",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_github_installations_owner": {
+          "name": "idx_account_github_installations_owner",
+          "columns": [
+            {
+              "expression": "owner_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_github_installations_account_id_accounts_account_id_fk": {
+          "name": "account_github_installations_account_id_accounts_account_id_fk",
+          "tableFrom": "account_github_installations",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_group_members": {
+      "name": "account_group_members",
+      "schema": "kortix",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_group_members_user": {
+          "name": "idx_account_group_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_group_members_group_id_account_groups_group_id_fk": {
+          "name": "account_group_members_group_id_account_groups_group_id_fk",
+          "tableFrom": "account_group_members",
+          "tableTo": "account_groups",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "group_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_group_members_group_id_user_id_pk": {
+          "name": "account_group_members_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_groups": {
+      "name": "account_groups",
+      "schema": "kortix",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "account_group_source",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_groups_account": {
+          "name": "idx_account_groups_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_groups_account_name": {
+          "name": "idx_account_groups_account_name",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_groups_account_id_accounts_account_id_fk": {
+          "name": "account_groups_account_id_accounts_account_id_fk",
+          "tableFrom": "account_groups",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_invitations": {
+      "name": "account_invitations",
+      "schema": "kortix",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_role": {
+          "name": "initial_role",
+          "type": "account_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "bootstrap_grants": {
+          "name": "bootstrap_grants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '14 days'"
+        }
+      },
+      "indexes": {
+        "idx_account_invitations_email": {
+          "name": "idx_account_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_invitations_account": {
+          "name": "idx_account_invitations_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_invitations_expires_at": {
+          "name": "idx_account_invitations_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_invitations_pending": {
+          "name": "idx_account_invitations_pending",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_account_id_accounts_account_id_fk": {
+          "name": "account_invitations_account_id_accounts_account_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_members": {
+      "name": "account_members",
+      "schema": "kortix",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_role": {
+          "name": "account_role",
+          "type": "account_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scim_external_id": {
+          "name": "scim_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_members_user_id": {
+          "name": "idx_account_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_members_account_id": {
+          "name": "idx_account_members_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_members_user_account": {
+          "name": "idx_account_members_user_account",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_members_account_id_accounts_account_id_fk": {
+          "name": "account_members_account_id_accounts_account_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_members_user_id_account_id_pk": {
+          "name": "account_members_user_id_account_id_pk",
+          "columns": [
+            "user_id",
+            "account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_model_preferences": {
+      "name": "account_model_preferences",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_model_preferences_account": {
+          "name": "idx_account_model_preferences_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_model_preferences_scope_global": {
+          "name": "idx_account_model_preferences_scope_global",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"account_model_preferences\".\"project_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_model_preferences_scope_project": {
+          "name": "idx_account_model_preferences_scope_project",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"account_model_preferences\".\"project_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_model_preferences_account_id_accounts_account_id_fk": {
+          "name": "account_model_preferences_account_id_accounts_account_id_fk",
+          "tableFrom": "account_model_preferences",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_model_preferences_project_id_projects_project_id_fk": {
+          "name": "account_model_preferences_project_id_projects_project_id_fk",
+          "tableFrom": "account_model_preferences",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_session_activity": {
+      "name": "account_session_activity",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_account_session_activity_account": {
+          "name": "idx_account_session_activity_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_session_activity_user": {
+          "name": "idx_account_session_activity_user",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_session_activity_account_id_accounts_account_id_fk": {
+          "name": "account_session_activity_account_id_accounts_account_id_fk",
+          "tableFrom": "account_session_activity",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_session_activity_account_id_user_id_session_id_pk": {
+          "name": "account_session_activity_account_id_user_id_session_id_pk",
+          "columns": [
+            "account_id",
+            "user_id",
+            "session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_sso_group_mappings": {
+      "name": "account_sso_group_mappings",
+      "schema": "kortix",
+      "columns": {
+        "mapping_id": {
+          "name": "mapping_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_value": {
+          "name": "claim_value",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_sso_mappings_claim": {
+          "name": "idx_account_sso_mappings_claim",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claim_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_sso_mappings_provider": {
+          "name": "idx_account_sso_mappings_provider",
+          "columns": [
+            {
+              "expression": "sso_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_sso_mappings_group": {
+          "name": "idx_account_sso_mappings_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_sso_group_mappings_account_id_accounts_account_id_fk": {
+          "name": "account_sso_group_mappings_account_id_accounts_account_id_fk",
+          "tableFrom": "account_sso_group_mappings",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_sso_group_mappings_sso_provider_id_account_sso_providers_sso_provider_id_fk": {
+          "name": "account_sso_group_mappings_sso_provider_id_account_sso_providers_sso_provider_id_fk",
+          "tableFrom": "account_sso_group_mappings",
+          "tableTo": "account_sso_providers",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sso_provider_id"
+          ],
+          "columnsTo": [
+            "sso_provider_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_sso_group_mappings_group_id_account_groups_group_id_fk": {
+          "name": "account_sso_group_mappings_group_id_account_groups_group_id_fk",
+          "tableFrom": "account_sso_group_mappings",
+          "tableTo": "account_groups",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "group_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_sso_providers": {
+      "name": "account_sso_providers",
+      "schema": "kortix",
+      "columns": {
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_sso_provider_id": {
+          "name": "supabase_sso_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_domain": {
+          "name": "primary_domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_claim_name": {
+          "name": "group_claim_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'groups'"
+        },
+        "auto_create_members": {
+          "name": "auto_create_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_provision_groups": {
+          "name": "auto_provision_groups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enforce_sso": {
+          "name": "enforce_sso",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_sso_providers_account": {
+          "name": "idx_account_sso_providers_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_sso_providers_supabase": {
+          "name": "idx_account_sso_providers_supabase",
+          "columns": [
+            {
+              "expression": "supabase_sso_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_sso_providers_domain": {
+          "name": "idx_account_sso_providers_domain",
+          "columns": [
+            {
+              "expression": "primary_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_sso_providers_account_id_accounts_account_id_fk": {
+          "name": "account_sso_providers_account_id_accounts_account_id_fk",
+          "tableFrom": "account_sso_providers",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_tokens": {
+      "name": "account_tokens",
+      "schema": "kortix",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_key_hash": {
+          "name": "secret_key_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "api_key_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_grant": {
+          "name": "agent_grant",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_account_id": {
+          "name": "service_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_account_tokens_public_key": {
+          "name": "idx_account_tokens_public_key",
+          "columns": [
+            {
+              "expression": "public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_secret_hash": {
+          "name": "idx_account_tokens_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_account": {
+          "name": "idx_account_tokens_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_user": {
+          "name": "idx_account_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_project": {
+          "name": "idx_account_tokens_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_tokens_account_id_accounts_account_id_fk": {
+          "name": "account_tokens_account_id_accounts_account_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_tokens_project_id_projects_project_id_fk": {
+          "name": "account_tokens_project_id_projects_project_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_tokens_service_account_id_service_accounts_service_account_id_fk": {
+          "name": "account_tokens_service_account_id_service_accounts_service_account_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "service_accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "service_account_id"
+          ],
+          "columnsTo": [
+            "service_account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.accounts": {
+      "name": "accounts",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_complete_at": {
+          "name": "setup_complete_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_wizard_step": {
+          "name": "setup_wizard_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mfa_required": {
+          "name": "mfa_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "session_max_lifetime_minutes": {
+          "name": "session_max_lifetime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_idle_timeout_minutes": {
+          "name": "session_idle_timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pat_max_lifetime_days": {
+          "name": "pat_max_lifetime_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pat_require_expiry": {
+          "name": "pat_require_expiry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pat_idle_revoke_days": {
+          "name": "pat_idle_revoke_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.acp_session_envelopes": {
+      "name": "acp_session_envelopes",
+      "schema": "kortix",
+      "columns": {
+        "ordinal": {
+          "name": "ordinal",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "acp_session_envelopes_ordinal_seq",
+            "schema": "kortix",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_instance_id": {
+          "name": "runtime_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_event_id": {
+          "name": "upstream_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_acp_session_envelopes_event_id": {
+          "name": "idx_acp_session_envelopes_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_acp_session_envelopes_upstream_event": {
+          "name": "idx_acp_session_envelopes_upstream_event",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "upstream_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"acp_session_envelopes\".\"upstream_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_acp_session_envelopes_session_ordinal": {
+          "name": "idx_acp_session_envelopes_session_ordinal",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acp_session_envelopes_session_id_project_sessions_session_id_fk": {
+          "name": "acp_session_envelopes_session_id_project_sessions_session_id_fk",
+          "tableFrom": "acp_session_envelopes",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acp_session_envelopes_project_id_projects_project_id_fk": {
+          "name": "acp_session_envelopes_project_id_projects_project_id_fk",
+          "tableFrom": "acp_session_envelopes",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acp_session_envelopes_direction_check": {
+          "name": "acp_session_envelopes_direction_check",
+          "value": "\"kortix\".\"acp_session_envelopes\".\"direction\" IN ('client_to_agent', 'agent_to_client')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kortix.audit_events": {
+      "name": "audit_events",
+      "schema": "kortix",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_events_account_time": {
+          "name": "idx_audit_events_account_time",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_events_actor_time": {
+          "name": "idx_audit_events_actor_time",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_events_resource": {
+          "name": "idx_audit_events_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_events_occurred_at": {
+          "name": "idx_audit_events_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_account_id_accounts_account_id_fk": {
+          "name": "audit_events_account_id_accounts_account_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.audit_webhooks": {
+      "name": "audit_webhooks",
+      "schema": "kortix",
+      "columns": {
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "action_prefix": {
+          "name": "action_prefix",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivered_at": {
+          "name": "last_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_webhooks_account": {
+          "name": "idx_audit_webhooks_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_webhooks_enabled": {
+          "name": "idx_audit_webhooks_enabled",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_webhooks_account_id_accounts_account_id_fk": {
+          "name": "audit_webhooks_account_id_accounts_account_id_fk",
+          "tableFrom": "audit_webhooks",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.billing_customers": {
+      "name": "billing_customers",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_kortix_billing_customers_account_id": {
+          "name": "idx_kortix_billing_customers_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.change_requests": {
+      "name": "change_requests",
+      "schema": "kortix",
+      "columns": {
+        "cr_id": {
+          "name": "cr_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "change_request_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "head_commit_sha": {
+          "name": "head_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_commit_sha": {
+          "name": "base_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_session_id": {
+          "name": "origin_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by": {
+          "name": "merged_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_commit_sha": {
+          "name": "merge_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by": {
+          "name": "closed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_change_requests_account": {
+          "name": "idx_change_requests_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_change_requests_project": {
+          "name": "idx_change_requests_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_change_requests_project_status": {
+          "name": "idx_change_requests_project_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_change_requests_project_number": {
+          "name": "idx_change_requests_project_number",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_requests_account_id_accounts_account_id_fk": {
+          "name": "change_requests_account_id_accounts_account_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_requests_project_id_projects_project_id_fk": {
+          "name": "change_requests_project_id_projects_project_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_requests_origin_session_id_project_sessions_session_id_fk": {
+          "name": "change_requests_origin_session_id_project_sessions_session_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "origin_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_channel_bindings": {
+      "name": "chat_channel_bindings",
+      "schema": "kortix",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picker_ts": {
+          "name": "picker_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opencode_model": {
+          "name": "opencode_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_policy": {
+          "name": "conversation_policy",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project_open'"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_channel_bindings_channel": {
+          "name": "idx_chat_channel_bindings_channel",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_channel_bindings_project": {
+          "name": "idx_chat_channel_bindings_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_channel_bindings_project_id_projects_project_id_fk": {
+          "name": "chat_channel_bindings_project_id_projects_project_id_fk",
+          "tableFrom": "chat_channel_bindings",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_event_dedup": {
+      "name": "chat_event_dedup",
+      "schema": "kortix",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_event_dedup_expiry": {
+          "name": "idx_chat_event_dedup_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_installs": {
+      "name": "chat_installs",
+      "schema": "kortix",
+      "columns": {
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_installs_workspace_project": {
+          "name": "idx_chat_installs_workspace_project",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_installs_workspace": {
+          "name": "idx_chat_installs_workspace",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_installs_project": {
+          "name": "idx_chat_installs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_installs_project_id_projects_project_id_fk": {
+          "name": "chat_installs_project_id_projects_project_id_fk",
+          "tableFrom": "chat_installs",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_pending_auth_messages": {
+      "name": "chat_pending_auth_messages",
+      "schema": "kortix",
+      "columns": {
+        "pending_id": {
+          "name": "pending_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'slack'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_response_url": {
+          "name": "slack_response_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_pending_auth_messages_lookup": {
+          "name": "idx_chat_pending_auth_messages_lookup",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_pending_auth_messages_expiry": {
+          "name": "idx_chat_pending_auth_messages_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_pending_auth_messages_project_id_projects_project_id_fk": {
+          "name": "chat_pending_auth_messages_project_id_projects_project_id_fk",
+          "tableFrom": "chat_pending_auth_messages",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_thread_participants": {
+      "name": "chat_thread_participants",
+      "schema": "kortix",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_participants_thread_user": {
+          "name": "idx_chat_thread_participants_thread_user",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_participants_session": {
+          "name": "idx_chat_thread_participants_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_participants_user": {
+          "name": "idx_chat_thread_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_thread_participants_session_id_project_sessions_session_id_fk": {
+          "name": "chat_thread_participants_session_id_project_sessions_session_id_fk",
+          "tableFrom": "chat_thread_participants",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_threads": {
+      "name": "chat_threads",
+      "schema": "kortix",
+      "columns": {
+        "thread_row_id": {
+          "name": "thread_row_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_thread": {
+          "name": "idx_chat_threads_thread",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_project": {
+          "name": "idx_chat_threads_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_session": {
+          "name": "idx_chat_threads_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_project_id_projects_project_id_fk": {
+          "name": "chat_threads_project_id_projects_project_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_threads_session_id_project_sessions_session_id_fk": {
+          "name": "chat_threads_session_id_project_sessions_session_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_turn_streams": {
+      "name": "chat_turn_streams",
+      "schema": "kortix",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_ts": {
+          "name": "trigger_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming": {
+          "name": "streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "placeholder_active": {
+          "name": "placeholder_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "finalized": {
+          "name": "finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "originating_event": {
+          "name": "originating_event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_ref": {
+          "name": "channel_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_turn_streams_expiry": {
+          "name": "idx_chat_turn_streams_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_user_identities": {
+      "name": "chat_user_identities",
+      "schema": "kortix",
+      "columns": {
+        "identity_id": {
+          "name": "identity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_user_identities_platform_user": {
+          "name": "idx_chat_user_identities_platform_user",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_user_identities_user": {
+          "name": "idx_chat_user_identities_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.credit_accounts": {
+      "name": "credit_accounts",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_precise": {
+          "name": "balance_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetime_granted": {
+          "name": "lifetime_granted",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetime_granted_precise": {
+          "name": "lifetime_granted_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetime_purchased": {
+          "name": "lifetime_purchased",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetime_purchased_precise": {
+          "name": "lifetime_purchased_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetime_used": {
+          "name": "lifetime_used",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetime_used_precise": {
+          "name": "lifetime_used_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_grant_date": {
+          "name": "last_grant_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'free'"
+        },
+        "billing_cycle_anchor": {
+          "name": "billing_cycle_anchor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_credit_grant": {
+          "name": "next_credit_grant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiring_credits": {
+          "name": "expiring_credits",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "expiring_credits_precise": {
+          "name": "expiring_credits_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "non_expiring_credits": {
+          "name": "non_expiring_credits",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "non_expiring_credits_precise": {
+          "name": "non_expiring_credits_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "daily_credits_balance": {
+          "name": "daily_credits_balance",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "daily_credits_balance_precise": {
+          "name": "daily_credits_balance_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "trial_status": {
+          "name": "trial_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "trial_started_at": {
+          "name": "trial_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_grandfathered_free": {
+          "name": "is_grandfathered_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_type": {
+          "name": "commitment_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_start_date": {
+          "name": "commitment_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_end_date": {
+          "name": "commitment_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_price_id": {
+          "name": "commitment_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_cancel_after": {
+          "name": "can_cancel_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_renewal_period_start": {
+          "name": "last_renewal_period_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "last_payment_failure": {
+          "name": "last_payment_failure",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_tier_change": {
+          "name": "scheduled_tier_change",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_tier_change_date": {
+          "name": "scheduled_tier_change_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_price_id": {
+          "name": "scheduled_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'stripe'"
+        },
+        "revenuecat_customer_id": {
+          "name": "revenuecat_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_subscription_id": {
+          "name": "revenuecat_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_cancelled_at": {
+          "name": "revenuecat_cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_cancel_at_period_end": {
+          "name": "revenuecat_cancel_at_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_pending_change_product": {
+          "name": "revenuecat_pending_change_product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_pending_change_date": {
+          "name": "revenuecat_pending_change_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_pending_change_type": {
+          "name": "revenuecat_pending_change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_product_id": {
+          "name": "revenuecat_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'monthly'"
+        },
+        "stripe_subscription_status": {
+          "name": "stripe_subscription_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_daily_refresh": {
+          "name": "last_daily_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_enabled": {
+          "name": "auto_topup_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_topup_threshold": {
+          "name": "auto_topup_threshold",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'5'"
+        },
+        "auto_topup_amount": {
+          "name": "auto_topup_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20'"
+        },
+        "auto_topup_last_charged": {
+          "name": "auto_topup_last_charged",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_model": {
+          "name": "billing_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "seat_count": {
+          "name": "seat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "seat_subscription_item_id": {
+          "name": "seat_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_customized": {
+          "name": "auto_topup_customized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_topup_consecutive_failures": {
+          "name": "auto_topup_consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_topup_disabled_reason": {
+          "name": "auto_topup_disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_enterprise": {
+          "name": "demo_enterprise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kortix_credit_accounts_account_id_idx": {
+          "name": "kortix_credit_accounts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_accounts_billing_model": {
+          "name": "idx_credit_accounts_billing_model",
+          "columns": [
+            {
+              "expression": "billing_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_precise": {
+          "name": "amount_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance_after_precise": {
+          "name": "balance_after_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_expiring": {
+          "name": "is_expiring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_source": {
+          "name": "processing_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_kortix_credit_ledger_idempotency": {
+          "name": "idx_kortix_credit_ledger_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"credit_ledger\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kortix_unique_stripe_event": {
+          "name": "kortix_unique_stripe_event",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.credit_purchases": {
+      "name": "credit_purchases",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_dollars": {
+          "name": "amount_dollars",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'stripe'"
+        },
+        "revenuecat_transaction_id": {
+          "name": "revenuecat_transaction_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_product_id": {
+          "name": "revenuecat_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.credit_usage": {
+      "name": "credit_usage",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_dollars": {
+          "name": "amount_dollars",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'token_overage'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connection_policies": {
+      "name": "executor_connection_policies",
+      "schema": "kortix",
+      "columns": {
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match": {
+          "name": "match",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "executor_policy_action",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connection_policies_profile": {
+          "name": "idx_executor_connection_policies_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connection_policies_profile_id_fk": {
+          "name": "executor_connection_policies_profile_id_fk",
+          "tableFrom": "executor_connection_policies",
+          "tableTo": "executor_connection_profiles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connection_profiles": {
+      "name": "executor_connection_profiles",
+      "schema": "kortix",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "executor_connection_profile_owner_type",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "executor_connection_profile_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connection_profiles_tenant_identity": {
+          "name": "idx_executor_connection_profiles_tenant_identity",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_connector_identity": {
+          "name": "idx_executor_connection_profiles_connector_identity",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_default_project": {
+          "name": "idx_executor_connection_profiles_default_project",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_connection_profiles\".\"is_default\" = true and \"kortix\".\"executor_connection_profiles\".\"owner_type\" = 'project'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_default_owner": {
+          "name": "idx_executor_connection_profiles_default_owner",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_connection_profiles\".\"is_default\" = true and \"kortix\".\"executor_connection_profiles\".\"owner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_owner_label": {
+          "name": "idx_executor_connection_profiles_owner_label",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_connection_profiles\".\"owner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_project_label": {
+          "name": "idx_executor_connection_profiles_project_label",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_connection_profiles\".\"owner_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_project": {
+          "name": "idx_executor_connection_profiles_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_connector": {
+          "name": "idx_executor_connection_profiles_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connection_profiles_connector_tenant_fk": {
+          "name": "executor_connection_profiles_connector_tenant_fk",
+          "tableFrom": "executor_connection_profiles",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id",
+            "project_id",
+            "connector_id"
+          ],
+          "columnsTo": [
+            "account_id",
+            "project_id",
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "executor_connection_profiles_owner_check": {
+          "name": "executor_connection_profiles_owner_check",
+          "value": "(\"kortix\".\"executor_connection_profiles\".\"owner_type\" = 'project' AND \"kortix\".\"executor_connection_profiles\".\"owner_id\" IS NULL) OR (\"kortix\".\"executor_connection_profiles\".\"owner_type\" <> 'project' AND \"kortix\".\"executor_connection_profiles\".\"owner_id\" IS NOT NULL AND btrim(\"kortix\".\"executor_connection_profiles\".\"owner_id\") <> '')"
+        },
+        "executor_connection_profiles_metadata_check": {
+          "name": "executor_connection_profiles_metadata_check",
+          "value": "jsonb_typeof(\"kortix\".\"executor_connection_profiles\".\"metadata\") = 'object' AND octet_length(\"kortix\".\"executor_connection_profiles\".\"metadata\"::text) <= 16384"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connector_actions": {
+      "name": "executor_connector_actions",
+      "schema": "kortix",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "executor_risk",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "binding": {
+          "name": "binding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connector_actions_connector": {
+          "name": "idx_executor_connector_actions_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connector_actions_path": {
+          "name": "idx_executor_connector_actions_path",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connector_actions_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_connector_actions_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_connector_actions",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connector_grants": {
+      "name": "executor_connector_grants",
+      "schema": "kortix",
+      "columns": {
+        "grant_id": {
+          "name": "grant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "secret_grant_principal",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connector_grants_connector": {
+          "name": "idx_executor_connector_grants_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connector_grants_unique": {
+          "name": "idx_executor_connector_grants_unique",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connector_grants_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_connector_grants_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_connector_grants",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connector_policies": {
+      "name": "executor_connector_policies",
+      "schema": "kortix",
+      "columns": {
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match": {
+          "name": "match",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "executor_policy_action",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connector_policies_connector": {
+          "name": "idx_executor_connector_policies_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connector_policies_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_connector_policies_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_connector_policies",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connectors": {
+      "name": "executor_connectors",
+      "schema": "kortix",
+      "columns": {
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "executor_connector_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "auth_secret": {
+          "name": "auth_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_scope": {
+          "name": "share_scope",
+          "type": "secret_share_scope",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "agent_scope": {
+          "name": "agent_scope",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_mode": {
+          "name": "credential_mode",
+          "type": "executor_credential_mode",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "executor_connector_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connectors_project": {
+          "name": "idx_executor_connectors_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connectors_account": {
+          "name": "idx_executor_connectors_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connectors_project_slug": {
+          "name": "idx_executor_connectors_project_slug",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connectors_tenant_identity": {
+          "name": "idx_executor_connectors_tenant_identity",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connectors_tenant_alias": {
+          "name": "idx_executor_connectors_tenant_alias",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connectors_account_id_accounts_account_id_fk": {
+          "name": "executor_connectors_account_id_accounts_account_id_fk",
+          "tableFrom": "executor_connectors",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "executor_connectors_project_id_projects_project_id_fk": {
+          "name": "executor_connectors_project_id_projects_project_id_fk",
+          "tableFrom": "executor_connectors",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_credentials": {
+      "name": "executor_credentials",
+      "schema": "kortix",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secret'"
+        },
+        "value_enc": {
+          "name": "value_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_credentials_connector": {
+          "name": "idx_executor_credentials_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_credentials_profile": {
+          "name": "idx_executor_credentials_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_credentials_profile_unique": {
+          "name": "idx_executor_credentials_profile_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_credentials\".\"profile_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_credentials_legacy_connector_unique": {
+          "name": "idx_executor_credentials_legacy_connector_unique",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_credentials\".\"profile_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_credentials_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_credentials_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_credentials",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "executor_credentials_connector_profile_fk": {
+          "name": "executor_credentials_connector_profile_fk",
+          "tableFrom": "executor_credentials",
+          "tableTo": "executor_connection_profiles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id",
+            "profile_id"
+          ],
+          "columnsTo": [
+            "connector_id",
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_executions": {
+      "name": "executor_executions",
+      "schema": "kortix",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_path": {
+          "name": "action_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acting_user_id": {
+          "name": "acting_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "executor_execution_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk": {
+          "name": "risk",
+          "type": "executor_risk",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_digest": {
+          "name": "request_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_executor_executions_project": {
+          "name": "idx_executor_executions_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_executions_project_session_created": {
+          "name": "idx_executor_executions_project_session_created",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_executions_connector": {
+          "name": "idx_executor_executions_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_executions_profile": {
+          "name": "idx_executor_executions_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_executions_status": {
+          "name": "idx_executor_executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_executions_account_id_accounts_account_id_fk": {
+          "name": "executor_executions_account_id_accounts_account_id_fk",
+          "tableFrom": "executor_executions",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "executor_executions_project_id_projects_project_id_fk": {
+          "name": "executor_executions_project_id_projects_project_id_fk",
+          "tableFrom": "executor_executions",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "executor_executions_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_executions_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_executions",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "executor_executions_profile_id_executor_connection_profiles_profile_id_fk": {
+          "name": "executor_executions_profile_id_executor_connection_profiles_profile_id_fk",
+          "tableFrom": "executor_executions",
+          "tableTo": "executor_connection_profiles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_oauth_applications": {
+      "name": "executor_oauth_applications",
+      "schema": "kortix",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_enc": {
+          "name": "config_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_oauth_applications_profile": {
+          "name": "idx_executor_oauth_applications_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_oauth_applications_project": {
+          "name": "idx_executor_oauth_applications_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_oauth_applications_profile_tenant_fk": {
+          "name": "executor_oauth_applications_profile_tenant_fk",
+          "tableFrom": "executor_oauth_applications",
+          "tableTo": "executor_connection_profiles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "profile_id"
+          ],
+          "columnsTo": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_oauth_sessions": {
+      "name": "executor_oauth_sessions",
+      "schema": "kortix",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow": {
+          "name": "flow",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "state_hash": {
+          "name": "state_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pkce_verifier_enc": {
+          "name": "pkce_verifier_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_code_enc": {
+          "name": "device_code_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success_redirect_uri": {
+          "name": "success_redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_redirect_uri": {
+          "name": "error_redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_oauth_sessions_state_hash": {
+          "name": "idx_executor_oauth_sessions_state_hash",
+          "columns": [
+            {
+              "expression": "state_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_oauth_sessions\".\"state_hash\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_oauth_sessions_profile": {
+          "name": "idx_executor_oauth_sessions_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_oauth_sessions_expires": {
+          "name": "idx_executor_oauth_sessions_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_oauth_sessions_application_fk": {
+          "name": "executor_oauth_sessions_application_fk",
+          "tableFrom": "executor_oauth_sessions",
+          "tableTo": "executor_oauth_applications",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "application_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "executor_oauth_sessions_flow_check": {
+          "name": "executor_oauth_sessions_flow_check",
+          "value": "\"kortix\".\"executor_oauth_sessions\".\"flow\" IN ('authorization_code', 'device_authorization')"
+        },
+        "executor_oauth_sessions_status_check": {
+          "name": "executor_oauth_sessions_status_check",
+          "value": "\"kortix\".\"executor_oauth_sessions\".\"status\" IN ('pending', 'active', 'consumed', 'error', 'expired')"
+        },
+        "executor_oauth_sessions_material_check": {
+          "name": "executor_oauth_sessions_material_check",
+          "value": "(\"kortix\".\"executor_oauth_sessions\".\"flow\" = 'authorization_code' AND \"kortix\".\"executor_oauth_sessions\".\"state_hash\" IS NOT NULL AND \"kortix\".\"executor_oauth_sessions\".\"pkce_verifier_enc\" IS NOT NULL AND \"kortix\".\"executor_oauth_sessions\".\"device_code_enc\" IS NULL) OR (\"kortix\".\"executor_oauth_sessions\".\"flow\" = 'device_authorization' AND \"kortix\".\"executor_oauth_sessions\".\"state_hash\" IS NULL AND \"kortix\".\"executor_oauth_sessions\".\"pkce_verifier_enc\" IS NULL AND \"kortix\".\"executor_oauth_sessions\".\"device_code_enc\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kortix.executor_project_policies": {
+      "name": "executor_project_policies",
+      "schema": "kortix",
+      "columns": {
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match": {
+          "name": "match",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "executor_policy_action",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_project_policies_project": {
+          "name": "idx_executor_project_policies_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_project_policies_project_id_projects_project_id_fk": {
+          "name": "executor_project_policies_project_id_projects_project_id_fk",
+          "tableFrom": "executor_project_policies",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_project_settings": {
+      "name": "executor_project_settings",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "default_mode": {
+          "name": "default_mode",
+          "type": "executor_default_mode",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allow_all'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "executor_project_settings_project_id_projects_project_id_fk": {
+          "name": "executor_project_settings_project_id_projects_project_id_fk",
+          "tableFrom": "executor_project_settings",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.gateway_api_keys": {
+      "name": "gateway_api_keys",
+      "schema": "kortix",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_key_hash": {
+          "name": "secret_key_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "api_key_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gateway_keys_secret_hash": {
+          "name": "idx_gateway_keys_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_keys_project": {
+          "name": "idx_gateway_keys_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_keys_account": {
+          "name": "idx_gateway_keys_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gateway_api_keys_account_id_accounts_account_id_fk": {
+          "name": "gateway_api_keys_account_id_accounts_account_id_fk",
+          "tableFrom": "gateway_api_keys",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gateway_api_keys_project_id_projects_project_id_fk": {
+          "name": "gateway_api_keys_project_id_projects_project_id_fk",
+          "tableFrom": "gateway_api_keys",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.gateway_budgets": {
+      "name": "gateway_budgets",
+      "schema": "kortix",
+      "columns": {
+        "budget_id": {
+          "name": "budget_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "gateway_budget_scope",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_usd": {
+          "name": "limit_usd",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "gateway_budget_period",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'month'"
+        },
+        "action": {
+          "name": "action",
+          "type": "gateway_budget_action",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gateway_budgets_project": {
+          "name": "idx_gateway_budgets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_budgets_lookup": {
+          "name": "idx_gateway_budgets_lookup",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gateway_budgets_project_id_projects_project_id_fk": {
+          "name": "gateway_budgets_project_id_projects_project_id_fk",
+          "tableFrom": "gateway_budgets",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.gateway_request_logs": {
+      "name": "gateway_request_logs",
+      "schema": "kortix",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_model": {
+          "name": "resolved_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "candidates_tried": {
+          "name": "candidates_tried",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_tokens": {
+          "name": "cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "upstream_cost": {
+          "name": "upstream_cost",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "upstream_cost_precise": {
+          "name": "upstream_cost_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "final_cost": {
+          "name": "final_cost",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "final_cost_precise": {
+          "name": "final_cost_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "streaming": {
+          "name": "streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "billing_mode": {
+          "name": "billing_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gateway_logs_request_id": {
+          "name": "idx_gateway_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_account_time": {
+          "name": "idx_gateway_logs_account_time",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_project_time": {
+          "name": "idx_gateway_logs_project_time",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_model": {
+          "name": "idx_gateway_logs_model",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_account_ok": {
+          "name": "idx_gateway_logs_account_ok",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ok",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_session": {
+          "name": "idx_gateway_logs_session",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gateway_request_logs_account_id_accounts_account_id_fk": {
+          "name": "gateway_request_logs_account_id_accounts_account_id_fk",
+          "tableFrom": "gateway_request_logs",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gateway_request_logs_project_id_projects_project_id_fk": {
+          "name": "gateway_request_logs_project_id_projects_project_id_fk",
+          "tableFrom": "gateway_request_logs",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.iam_policies": {
+      "name": "iam_policies",
+      "schema": "kortix",
+      "columns": {
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_policies_account_principal": {
+          "name": "idx_iam_policies_account_principal",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_policies_scope": {
+          "name": "idx_iam_policies_scope",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_policies_role": {
+          "name": "idx_iam_policies_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iam_policies_account_id_accounts_account_id_fk": {
+          "name": "iam_policies_account_id_accounts_account_id_fk",
+          "tableFrom": "iam_policies",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "iam_policies_role_id_iam_roles_role_id_fk": {
+          "name": "iam_policies_role_id_iam_roles_role_id_fk",
+          "tableFrom": "iam_policies",
+          "tableTo": "iam_roles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "role_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.iam_resource_grants": {
+      "name": "iam_resource_grants",
+      "schema": "kortix",
+      "columns": {
+        "grant_id": {
+          "name": "grant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allow'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_iam_resource_grants": {
+          "name": "uq_iam_resource_grants",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_resource_grants_project_type": {
+          "name": "idx_iam_resource_grants_project_type",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_resource_grants_resource": {
+          "name": "idx_iam_resource_grants_resource",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_resource_grants_principal": {
+          "name": "idx_iam_resource_grants_principal",
+          "columns": [
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_resource_grants_account": {
+          "name": "idx_iam_resource_grants_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iam_resource_grants_account_id_accounts_account_id_fk": {
+          "name": "iam_resource_grants_account_id_accounts_account_id_fk",
+          "tableFrom": "iam_resource_grants",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "iam_resource_grants_project_id_projects_project_id_fk": {
+          "name": "iam_resource_grants_project_id_projects_project_id_fk",
+          "tableFrom": "iam_resource_grants",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.iam_role_actions": {
+      "name": "iam_role_actions",
+      "schema": "kortix",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "iam_role_actions_role_id_iam_roles_role_id_fk": {
+          "name": "iam_role_actions_role_id_iam_roles_role_id_fk",
+          "tableFrom": "iam_role_actions",
+          "tableTo": "iam_roles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "role_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "iam_role_actions_role_id_action_pk": {
+          "name": "iam_role_actions_role_id_action_pk",
+          "columns": [
+            "role_id",
+            "action"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.iam_roles": {
+      "name": "iam_roles",
+      "schema": "kortix",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_roles_account": {
+          "name": "idx_iam_roles_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_roles_account_key": {
+          "name": "idx_iam_roles_account_key",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iam_roles_account_id_accounts_account_id_fk": {
+          "name": "iam_roles_account_id_accounts_account_id_fk",
+          "tableFrom": "iam_roles",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.api_keys": {
+      "name": "api_keys",
+      "schema": "kortix",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_key_hash": {
+          "name": "secret_key_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "api_key_type",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "status": {
+          "name": "status",
+          "type": "api_key_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kortix_api_keys_public_key": {
+          "name": "idx_kortix_api_keys_public_key",
+          "columns": [
+            {
+              "expression": "public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kortix_api_keys_secret_hash": {
+          "name": "idx_kortix_api_keys_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kortix_api_keys_sandbox": {
+          "name": "idx_kortix_api_keys_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kortix_api_keys_account": {
+          "name": "idx_kortix_api_keys_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.legacy_sandbox_migrations": {
+      "name": "legacy_sandbox_migrations",
+      "schema": "kortix",
+      "columns": {
+        "migration_id": {
+          "name": "migration_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dry_run'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rollback": {
+          "name": "rollback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "opencode_archive": {
+          "name": "opencode_archive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_legacy_sandbox_migrations_run": {
+          "name": "idx_legacy_sandbox_migrations_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_legacy_sandbox_migrations_sandbox": {
+          "name": "idx_legacy_sandbox_migrations_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_legacy_sandbox_migrations_status": {
+          "name": "idx_legacy_sandbox_migrations_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_legacy_sandbox_migrations_account": {
+          "name": "idx_legacy_sandbox_migrations_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_legacy_sandbox_migrations_heartbeat": {
+          "name": "idx_legacy_sandbox_migrations_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_access_token_hash": {
+          "name": "idx_oauth_access_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_access_tokens_client": {
+          "name": "idx_oauth_access_tokens_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_access_tokens_user": {
+          "name": "idx_oauth_access_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_codes_code": {
+          "name": "idx_oauth_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_codes_client": {
+          "name": "idx_oauth_codes_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_codes_expires": {
+          "name": "idx_oauth_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "kortix",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_id": {
+          "name": "access_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_refresh_token_hash": {
+          "name": "idx_oauth_refresh_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_refresh_tokens_client": {
+          "name": "idx_oauth_refresh_tokens_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_access_token_id_oauth_access_tokens_id_fk": {
+          "name": "oauth_refresh_tokens_access_token_id_oauth_access_tokens_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_access_tokens",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "access_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.platform_settings": {
+      "name": "platform_settings",
+      "schema": "kortix",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.platform_user_roles": {
+      "name": "platform_user_roles",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "platform_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_user_roles_account_id": {
+          "name": "idx_platform_user_roles_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_platform_user_roles_role": {
+          "name": "idx_platform_user_roles_role",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_access_requests": {
+      "name": "project_access_requests",
+      "schema": "kortix",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_user_id": {
+          "name": "requester_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_email": {
+          "name": "requester_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_access_request_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_access_requests_project": {
+          "name": "idx_project_access_requests_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_access_requests_account": {
+          "name": "idx_project_access_requests_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_access_requests_requester": {
+          "name": "idx_project_access_requests_requester",
+          "columns": [
+            {
+              "expression": "requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_access_requests_status": {
+          "name": "idx_project_access_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_access_requests_pending_unique": {
+          "name": "idx_project_access_requests_pending_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"project_access_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_access_requests_account_id_accounts_account_id_fk": {
+          "name": "project_access_requests_account_id_accounts_account_id_fk",
+          "tableFrom": "project_access_requests",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_access_requests_project_id_projects_project_id_fk": {
+          "name": "project_access_requests_project_id_projects_project_id_fk",
+          "tableFrom": "project_access_requests",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_git_connections": {
+      "name": "project_git_connections",
+      "schema": "kortix",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_repo_id": {
+          "name": "external_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_ref": {
+          "name": "credential_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_git_connections_account": {
+          "name": "idx_project_git_connections_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_git_connections_project": {
+          "name": "idx_project_git_connections_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_git_connections_provider_repo": {
+          "name": "idx_project_git_connections_provider_repo",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_git_connections_status": {
+          "name": "idx_project_git_connections_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_git_connections_account_id_accounts_account_id_fk": {
+          "name": "project_git_connections_account_id_accounts_account_id_fk",
+          "tableFrom": "project_git_connections",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_git_connections_project_id_projects_project_id_fk": {
+          "name": "project_git_connections_project_id_projects_project_id_fk",
+          "tableFrom": "project_git_connections",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_git_credentials": {
+      "name": "project_git_credentials",
+      "schema": "kortix",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'token'"
+        },
+        "value_enc": {
+          "name": "value_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_git_credentials_account": {
+          "name": "idx_project_git_credentials_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_git_credentials_project_provider": {
+          "name": "idx_project_git_credentials_project_provider",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_git_credentials_account_id_accounts_account_id_fk": {
+          "name": "project_git_credentials_account_id_accounts_account_id_fk",
+          "tableFrom": "project_git_credentials",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_git_credentials_project_id_projects_project_id_fk": {
+          "name": "project_git_credentials_project_id_projects_project_id_fk",
+          "tableFrom": "project_git_credentials",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_group_grants": {
+      "name": "project_group_grants",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "project_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_group_grants_project": {
+          "name": "idx_project_group_grants_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_group_grants_group": {
+          "name": "idx_project_group_grants_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_group_grants_account": {
+          "name": "idx_project_group_grants_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_grants_project_id_projects_project_id_fk": {
+          "name": "project_group_grants_project_id_projects_project_id_fk",
+          "tableFrom": "project_group_grants",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_grants_group_id_account_groups_group_id_fk": {
+          "name": "project_group_grants_group_id_account_groups_group_id_fk",
+          "tableFrom": "project_group_grants",
+          "tableTo": "account_groups",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "group_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_grants_account_id_accounts_account_id_fk": {
+          "name": "project_group_grants_account_id_accounts_account_id_fk",
+          "tableFrom": "project_group_grants",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_group_grants_project_id_group_id_pk": {
+          "name": "project_group_grants_project_id_group_id_pk",
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_llm_routing_policies": {
+      "name": "project_llm_routing_policies",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vision_model": {
+          "name": "vision_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_fallback_models": {
+          "name": "default_fallback_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_fallback_on": {
+          "name": "default_fallback_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model_generation_config": {
+          "name": "model_generation_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_overrides": {
+          "name": "model_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "disabled_models": {
+          "name": "disabled_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_llm_routing_policies_project_id_projects_project_id_fk": {
+          "name": "project_llm_routing_policies_project_id_projects_project_id_fk",
+          "tableFrom": "project_llm_routing_policies",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_llm_routing_policies_fallback_pair_check": {
+          "name": "project_llm_routing_policies_fallback_pair_check",
+          "value": "(\"kortix\".\"project_llm_routing_policies\".\"default_fallback_models\" IS NULL AND \"kortix\".\"project_llm_routing_policies\".\"default_fallback_on\" IS NULL) OR (\"kortix\".\"project_llm_routing_policies\".\"default_fallback_models\" IS NOT NULL AND \"kortix\".\"project_llm_routing_policies\".\"default_fallback_on\" IN ('transient', 'any-error'))"
+        },
+        "project_llm_routing_policies_rules_array_check": {
+          "name": "project_llm_routing_policies_rules_array_check",
+          "value": "jsonb_typeof(\"kortix\".\"project_llm_routing_policies\".\"rules\") = 'array'"
+        },
+        "project_llm_routing_policies_gen_config_object_check": {
+          "name": "project_llm_routing_policies_gen_config_object_check",
+          "value": "jsonb_typeof(\"kortix\".\"project_llm_routing_policies\".\"model_generation_config\") = 'object'"
+        },
+        "project_llm_routing_policies_disabled_models_array_check": {
+          "name": "project_llm_routing_policies_disabled_models_array_check",
+          "value": "jsonb_typeof(\"kortix\".\"project_llm_routing_policies\".\"disabled_models\") = 'array'"
+        },
+        "project_llm_routing_policies_model_overrides_object_check": {
+          "name": "project_llm_routing_policies_model_overrides_object_check",
+          "value": "jsonb_typeof(\"kortix\".\"project_llm_routing_policies\".\"model_overrides\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kortix.project_members": {
+      "name": "project_members",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_role": {
+          "name": "project_role",
+          "type": "project_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_members_account_user": {
+          "name": "idx_project_members_account_user",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_members_project": {
+          "name": "idx_project_members_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_members_project_user": {
+          "name": "idx_project_members_project_user",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_account_id_accounts_account_id_fk": {
+          "name": "project_members_account_id_accounts_account_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_project_id_projects_project_id_fk": {
+          "name": "project_members_project_id_projects_project_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_secrets": {
+      "name": "project_secrets",
+      "schema": "kortix",
+      "columns": {
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_enc": {
+          "name": "value_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "project_secret_scope",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runtime'"
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "project_secret_strategy",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runtime'"
+        },
+        "egress_policy": {
+          "name": "egress_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle_prefix": {
+          "name": "handle_prefix",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategy_locked": {
+          "name": "strategy_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_secrets_project": {
+          "name": "idx_project_secrets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_secrets_project_name": {
+          "name": "idx_project_secrets_project_name",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_secrets_project_identifier_shared": {
+          "name": "idx_project_secrets_project_identifier_shared",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"project_secrets\".\"owner_user_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_secrets_project_name_owner": {
+          "name": "idx_project_secrets_project_name_owner",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"project_secrets\".\"owner_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_project_id_fk": {
+          "name": "project_secrets_project_id_projects_project_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_session_connector_bindings": {
+      "name": "project_session_connector_bindings",
+      "schema": "kortix",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_alias": {
+          "name": "connector_alias",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "project_session_connector_binding_source",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'request'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_session_connector_bindings_profile": {
+          "name": "idx_project_session_connector_bindings_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_session_connector_bindings_project": {
+          "name": "idx_project_session_connector_bindings_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_session_connector_bindings_session_tenant_fk": {
+          "name": "project_session_connector_bindings_session_tenant_fk",
+          "tableFrom": "project_session_connector_bindings",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id",
+            "project_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "account_id",
+            "project_id",
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_session_connector_bindings_alias_tenant_fk": {
+          "name": "project_session_connector_bindings_alias_tenant_fk",
+          "tableFrom": "project_session_connector_bindings",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "connector_alias"
+          ],
+          "columnsTo": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_session_connector_bindings_profile_tenant_fk": {
+          "name": "project_session_connector_bindings_profile_tenant_fk",
+          "tableFrom": "project_session_connector_bindings",
+          "tableTo": "executor_connection_profiles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "profile_id"
+          ],
+          "columnsTo": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "profile_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_session_connector_bindings_session_id_connector_alias_pk": {
+          "name": "project_session_connector_bindings_session_id_connector_alias_pk",
+          "columns": [
+            "session_id",
+            "connector_alias"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_session_grants": {
+      "name": "project_session_grants",
+      "schema": "kortix",
+      "columns": {
+        "grant_id": {
+          "name": "grant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "secret_grant_principal",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_session_grants_session": {
+          "name": "idx_project_session_grants_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_session_grants_unique": {
+          "name": "idx_project_session_grants_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_session_grants_session_id_project_sessions_session_id_fk": {
+          "name": "project_session_grants_session_id_project_sessions_session_id_fk",
+          "tableFrom": "project_session_grants",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_session_public_shares": {
+      "name": "project_session_public_shares",
+      "schema": "kortix",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preview'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'App preview'"
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'view'"
+        },
+        "allow_websocket": {
+          "name": "allow_websocket",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_session_public_shares_token_hash": {
+          "name": "idx_project_session_public_shares_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_session_public_shares_session": {
+          "name": "idx_project_session_public_shares_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_session_public_shares_project": {
+          "name": "idx_project_session_public_shares_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_session_public_shares_session_id_project_sessions_session_id_fk": {
+          "name": "project_session_public_shares_session_id_project_sessions_session_id_fk",
+          "tableFrom": "project_session_public_shares",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_session_public_shares_project_id_projects_project_id_fk": {
+          "name": "project_session_public_shares_project_id_projects_project_id_fk",
+          "tableFrom": "project_session_public_shares",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_session_public_shares_account_id_accounts_account_id_fk": {
+          "name": "project_session_public_shares_account_id_accounts_account_id_fk",
+          "tableFrom": "project_session_public_shares",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_session_runtime_contexts": {
+      "name": "project_session_runtime_contexts",
+      "schema": "kortix",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_session_runtime_contexts_updated": {
+          "name": "idx_project_session_runtime_contexts_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_session_runtime_contexts_session_id_project_sessions_session_id_fk": {
+          "name": "project_session_runtime_contexts_session_id_project_sessions_session_id_fk",
+          "tableFrom": "project_session_runtime_contexts",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_session_runtime_contexts_byte_size_check": {
+          "name": "project_session_runtime_contexts_byte_size_check",
+          "value": "\"kortix\".\"project_session_runtime_contexts\".\"byte_size\" >= 2 AND \"kortix\".\"project_session_runtime_contexts\".\"byte_size\" <= 16384"
+        },
+        "project_session_runtime_contexts_object_check": {
+          "name": "project_session_runtime_contexts_object_check",
+          "value": "jsonb_typeof(\"kortix\".\"project_session_runtime_contexts\".\"context\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kortix.project_session_secret_handles": {
+      "name": "project_session_secret_handles",
+      "schema": "kortix",
+      "columns": {
+        "handle_id": {
+          "name": "handle_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env_name": {
+          "name": "env_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lookup_id": {
+          "name": "lookup_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle_hash": {
+          "name": "handle_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "policy_snapshot": {
+          "name": "policy_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "project_secret_handle_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_session_secret_handles_project_id_projects_project_id_fk": {
+          "name": "project_session_secret_handles_project_id_projects_project_id_fk",
+          "tableFrom": "project_session_secret_handles",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_session_secret_handles_session_id_project_sessions_session_id_fk": {
+          "name": "project_session_secret_handles_session_id_project_sessions_session_id_fk",
+          "tableFrom": "project_session_secret_handles",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_session_secret_handles_secret_id_project_secrets_secret_id_fk": {
+          "name": "project_session_secret_handles_secret_id_project_secrets_secret_id_fk",
+          "tableFrom": "project_session_secret_handles",
+          "tableTo": "project_secrets",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "secret_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_sessions": {
+      "name": "project_sessions",
+      "schema": "kortix",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "sandbox_provider": {
+          "name": "sandbox_provider",
+          "type": "sandbox_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_url": {
+          "name": "sandbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opencode_session_id": {
+          "name": "opencode_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "status": {
+          "name": "status",
+          "type": "project_session_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "project_session_visibility",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "project_session_origin",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "origin_ref": {
+          "name": "origin_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secrets_allowlist": {
+          "name": "secrets_allowlist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connector_bindings_inherit_unbound": {
+          "name": "connector_bindings_inherit_unbound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_sessions_account": {
+          "name": "idx_project_sessions_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_project": {
+          "name": "idx_project_sessions_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_status": {
+          "name": "idx_project_sessions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_created_by": {
+          "name": "idx_project_sessions_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_project_origin": {
+          "name": "idx_project_sessions_project_origin",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"project_sessions\".\"origin_ref\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_account_origin_active": {
+          "name": "idx_project_sessions_account_origin_active",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"project_sessions\".\"origin_ref\" is not null and \"kortix\".\"project_sessions\".\"status\" in ('queued','branching','provisioning','running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_project_branch": {
+          "name": "idx_project_sessions_project_branch",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_tenant_identity": {
+          "name": "idx_project_sessions_tenant_identity",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_one_available_warm": {
+          "name": "idx_project_sessions_one_available_warm",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"project_sessions\".\"created_by\" is not null\n          and \"kortix\".\"project_sessions\".\"metadata\"->'warm_session'->>'state' = 'available'\n          and coalesce(\"kortix\".\"project_sessions\".\"metadata\"->>'deletedAt', '') = ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_sessions_account_id_accounts_account_id_fk": {
+          "name": "project_sessions_account_id_accounts_account_id_fk",
+          "tableFrom": "project_sessions",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_sessions_project_id_projects_project_id_fk": {
+          "name": "project_sessions_project_id_projects_project_id_fk",
+          "tableFrom": "project_sessions",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_snapshot_builds": {
+      "name": "project_snapshot_builds",
+      "schema": "kortix",
+      "columns": {
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "snapshot_name": {
+          "name": "snapshot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_category": {
+          "name": "error_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_project_snapshot_builds_project_recent": {
+          "name": "idx_project_snapshot_builds_project_recent",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_snapshot_builds_status": {
+          "name": "idx_project_snapshot_builds_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_snapshot_builds_account_id_accounts_account_id_fk": {
+          "name": "project_snapshot_builds_account_id_accounts_account_id_fk",
+          "tableFrom": "project_snapshot_builds",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_snapshot_builds_project_id_projects_project_id_fk": {
+          "name": "project_snapshot_builds_project_id_projects_project_id_fk",
+          "tableFrom": "project_snapshot_builds",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_trigger_executions": {
+      "name": "project_trigger_executions",
+      "schema": "kortix",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_revision": {
+          "name": "schedule_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_trigger_executions_slot": {
+          "name": "idx_project_trigger_executions_slot",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schedule_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_trigger_executions_due": {
+          "name": "idx_project_trigger_executions_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_trigger_executions_project": {
+          "name": "idx_project_trigger_executions_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_trigger_exec_project_fk": {
+          "name": "project_trigger_exec_project_fk",
+          "tableFrom": "project_trigger_executions",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_trigger_exec_session_fk": {
+          "name": "project_trigger_exec_session_fk",
+          "tableFrom": "project_trigger_executions",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_trigger_runtime": {
+      "name": "project_trigger_runtime",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_run_at": {
+          "name": "schedule_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_timezone": {
+          "name": "schedule_timezone",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_revision": {
+          "name": "schedule_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_spec": {
+          "name": "schedule_spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_fire_at": {
+          "name": "next_fire_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_scheduled_for": {
+          "name": "last_scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_trigger_runtime_owner_user": {
+          "name": "idx_project_trigger_runtime_owner_user",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_trigger_runtime_due": {
+          "name": "idx_project_trigger_runtime_due",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_fire_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_trigger_runtime_project_id_projects_project_id_fk": {
+          "name": "project_trigger_runtime_project_id_projects_project_id_fk",
+          "tableFrom": "project_trigger_runtime",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_trigger_runtime_session_id_project_sessions_session_id_fk": {
+          "name": "project_trigger_runtime_session_id_project_sessions_session_id_fk",
+          "tableFrom": "project_trigger_runtime",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_trigger_runtime_project_id_slug_pk": {
+          "name": "project_trigger_runtime_project_id_slug_pk",
+          "columns": [
+            "project_id",
+            "slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.projects": {
+      "name": "projects",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "manifest_path": {
+          "name": "manifest_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'kortix.yaml'"
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "secret_default_strategy": {
+          "name": "secret_default_strategy",
+          "type": "project_secret_strategy",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runtime'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "sandbox_provider_generation": {
+          "name": "sandbox_provider_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_account": {
+          "name": "idx_projects_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_status": {
+          "name": "idx_projects_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_updated": {
+          "name": "idx_projects_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_account_repo": {
+          "name": "idx_projects_account_repo",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_account_id_accounts_account_id_fk": {
+          "name": "projects_account_id_accounts_account_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.provider_events": {
+      "name": "provider_events",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_ms": {
+          "name": "total_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marks": {
+          "name": "marks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_events_provider": {
+          "name": "idx_provider_events_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_events_kind": {
+          "name": "idx_provider_events_kind",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_events_outcome": {
+          "name": "idx_provider_events_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_events_created": {
+          "name": "idx_provider_events_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.provider_transitions": {
+      "name": "provider_transitions",
+      "schema": "kortix",
+      "columns": {
+        "transition_id": {
+          "name": "transition_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_provider": {
+          "name": "source_provider",
+          "type": "sandbox_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_provider": {
+          "name": "target_provider",
+          "type": "sandbox_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'switch'"
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_transition_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_runtime_identity": {
+          "name": "base_runtime_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_name": {
+          "name": "snapshot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_template_id": {
+          "name": "external_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_transitions_project_recent": {
+          "name": "idx_provider_transitions_project_recent",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_transitions_status": {
+          "name": "idx_provider_transitions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_transitions_resume": {
+          "name": "idx_provider_transitions_resume",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_provider_transitions_live_identity": {
+          "name": "uq_provider_transitions_live_identity",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_runtime_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('pending','building','ready','activating')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_transitions_account_id_accounts_account_id_fk": {
+          "name": "provider_transitions_account_id_accounts_account_id_fk",
+          "tableFrom": "provider_transitions",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_transitions_project_id_projects_project_id_fk": {
+          "name": "provider_transitions_project_id_projects_project_id_fk",
+          "tableFrom": "provider_transitions",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_provider_transitions_project_generation": {
+          "name": "uq_provider_transitions_project_generation",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "generation"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.review_items": {
+      "name": "review_items",
+      "schema": "kortix",
+      "columns": {
+        "review_item_id": {
+          "name": "review_item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_session_id": {
+          "name": "origin_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "review_item_kind",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "review_item_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'needs_you'"
+        },
+        "risk": {
+          "name": "risk",
+          "type": "review_item_risk",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "source": {
+          "name": "source",
+          "type": "review_item_source",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agent'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acted_by": {
+          "name": "acted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acted_at": {
+          "name": "acted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_review_items_project": {
+          "name": "idx_review_items_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_review_items_project_status": {
+          "name": "idx_review_items_project_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_review_items_project_kind": {
+          "name": "idx_review_items_project_kind",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_review_items_created": {
+          "name": "idx_review_items_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_items_account_id_accounts_account_id_fk": {
+          "name": "review_items_account_id_accounts_account_id_fk",
+          "tableFrom": "review_items",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_items_project_id_projects_project_id_fk": {
+          "name": "review_items_project_id_projects_project_id_fk",
+          "tableFrom": "review_items",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_items_origin_session_id_project_sessions_session_id_fk": {
+          "name": "review_items_origin_session_id_project_sessions_session_id_fk",
+          "tableFrom": "review_items",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "origin_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_compute_sessions": {
+      "name": "sandbox_compute_sessions",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "cpu_cores": {
+          "name": "cpu_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_gb": {
+          "name": "memory_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disk_gb": {
+          "name": "disk_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_billed_at": {
+          "name": "last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "ledger_id": {
+          "name": "ledger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_compute_sessions_account_time": {
+          "name": "idx_sandbox_compute_sessions_account_time",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_compute_sessions_provider_time": {
+          "name": "idx_sandbox_compute_sessions_provider_time",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_compute_sessions_open": {
+          "name": "idx_sandbox_compute_sessions_open",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"sandbox_compute_sessions\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_sandbox_compute_sessions_one_open": {
+          "name": "uniq_sandbox_compute_sessions_one_open",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"sandbox_compute_sessions\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_compute_sessions_last_billed": {
+          "name": "idx_sandbox_compute_sessions_last_billed",
+          "columns": [
+            {
+              "expression": "last_billed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"sandbox_compute_sessions\".\"state\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_invites": {
+      "name": "sandbox_invites",
+      "schema": "kortix",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_role": {
+          "name": "initial_role",
+          "type": "account_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '14 days'"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_invites_email": {
+          "name": "idx_sandbox_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_invites_sandbox": {
+          "name": "idx_sandbox_invites_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_invites_expires_at": {
+          "name": "idx_sandbox_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_invites_sandbox_id_sandboxes_sandbox_id_fk": {
+          "name": "sandbox_invites_sandbox_id_sandboxes_sandbox_id_fk",
+          "tableFrom": "sandbox_invites",
+          "tableTo": "sandboxes",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sandbox_id"
+          ],
+          "columnsTo": [
+            "sandbox_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_member_scopes": {
+      "name": "sandbox_member_scopes",
+      "schema": "kortix",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "scope_effect",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_member_scopes_unique": {
+          "name": "idx_sandbox_member_scopes_unique",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_member_scopes_lookup": {
+          "name": "idx_sandbox_member_scopes_lookup",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_member_scopes_sandbox_id_sandboxes_sandbox_id_fk": {
+          "name": "sandbox_member_scopes_sandbox_id_sandboxes_sandbox_id_fk",
+          "tableFrom": "sandbox_member_scopes",
+          "tableTo": "sandboxes",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sandbox_id"
+          ],
+          "columnsTo": [
+            "sandbox_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_members": {
+      "name": "sandbox_members",
+      "schema": "kortix",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_spend_cap_cents": {
+          "name": "monthly_spend_cap_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_cents": {
+          "name": "current_period_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sandbox_members_unique": {
+          "name": "idx_sandbox_members_unique",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_members_user": {
+          "name": "idx_sandbox_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_members_sandbox": {
+          "name": "idx_sandbox_members_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_members_sandbox_id_sandboxes_sandbox_id_fk": {
+          "name": "sandbox_members_sandbox_id_sandboxes_sandbox_id_fk",
+          "tableFrom": "sandbox_members",
+          "tableTo": "sandboxes",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sandbox_id"
+          ],
+          "columnsTo": [
+            "sandbox_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_templates": {
+      "name": "sandbox_templates",
+      "schema": "kortix",
+      "columns": {
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'toml'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dockerfile_path": {
+          "name": "dockerfile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrypoint": {
+          "name": "entrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_gb": {
+          "name": "memory_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_gb": {
+          "name": "disk_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_from_commit": {
+          "name": "built_from_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swap_key": {
+          "name": "swap_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_snapshot_name": {
+          "name": "provider_snapshot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'missing'"
+        },
+        "last_built_at": {
+          "name": "last_built_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_templates_project": {
+          "name": "idx_sandbox_templates_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_templates_shared": {
+          "name": "idx_sandbox_templates_shared",
+          "columns": [
+            {
+              "expression": "is_shared",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_templates_project_slug": {
+          "name": "idx_sandbox_templates_project_slug",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_templates_project_id_projects_project_id_fk": {
+          "name": "sandbox_templates_project_id_projects_project_id_fk",
+          "tableFrom": "sandbox_templates",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sandbox_templates_account_id_accounts_account_id_fk": {
+          "name": "sandbox_templates_account_id_accounts_account_id_fk",
+          "tableFrom": "sandbox_templates",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandboxes": {
+      "name": "sandboxes",
+      "schema": "kortix",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sandbox_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_included": {
+          "name": "is_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sandboxes_account": {
+          "name": "idx_sandboxes_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_external_id": {
+          "name": "idx_sandboxes_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_status": {
+          "name": "idx_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.scim_tokens": {
+      "name": "scim_tokens",
+      "schema": "kortix",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_prefix": {
+          "name": "public_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_scim_tokens_account": {
+          "name": "idx_scim_tokens_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scim_tokens_secret_hash": {
+          "name": "idx_scim_tokens_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scim_tokens_account_id_accounts_account_id_fk": {
+          "name": "scim_tokens_account_id_accounts_account_id_fk",
+          "tableFrom": "scim_tokens",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.service_accounts": {
+      "name": "service_accounts",
+      "schema": "kortix",
+      "columns": {
+        "service_account_id": {
+          "name": "service_account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_prefix": {
+          "name": "public_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_service_accounts_account": {
+          "name": "idx_service_accounts_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_service_accounts_secret_hash": {
+          "name": "idx_service_accounts_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_service_accounts_account_name": {
+          "name": "idx_service_accounts_account_name",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_name IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_service_accounts_agent": {
+          "name": "idx_service_accounts_agent",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_name IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_accounts_account_id_accounts_account_id_fk": {
+          "name": "service_accounts_account_id_accounts_account_id_fk",
+          "tableFrom": "service_accounts",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_accounts_project_id_projects_project_id_fk": {
+          "name": "service_accounts_project_id_projects_project_id_fk",
+          "tableFrom": "service_accounts",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.session_lifecycle_commands": {
+      "name": "session_lifecycle_commands",
+      "schema": "kortix",
+      "columns": {
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_lifecycle_command_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_session_lifecycle_commands_idempotency": {
+          "name": "idx_session_lifecycle_commands_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_lifecycle_commands_due": {
+          "name": "idx_session_lifecycle_commands_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_lifecycle_commands_project": {
+          "name": "idx_session_lifecycle_commands_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_lifecycle_commands_session": {
+          "name": "idx_session_lifecycle_commands_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_lifecycle_commands_locked": {
+          "name": "idx_session_lifecycle_commands_locked",
+          "columns": [
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_lifecycle_commands_project_id_projects_project_id_fk": {
+          "name": "session_lifecycle_commands_project_id_projects_project_id_fk",
+          "tableFrom": "session_lifecycle_commands",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_lifecycle_commands_session_id_project_sessions_session_id_fk": {
+          "name": "session_lifecycle_commands_session_id_project_sessions_session_id_fk",
+          "tableFrom": "session_lifecycle_commands",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_lifecycle_commands_account_id_accounts_account_id_fk": {
+          "name": "session_lifecycle_commands_account_id_accounts_account_id_fk",
+          "tableFrom": "session_lifecycle_commands",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.session_sandboxes": {
+      "name": "session_sandboxes",
+      "schema": "kortix",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "session_sandbox_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_session_sandboxes_session": {
+          "name": "idx_session_sandboxes_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_sandboxes_project": {
+          "name": "idx_session_sandboxes_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_sandboxes_account": {
+          "name": "idx_session_sandboxes_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_sandboxes_status": {
+          "name": "idx_session_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_sandboxes_external_id": {
+          "name": "idx_session_sandboxes_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_sandboxes_session_id_unique": {
+          "name": "session_sandboxes_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.session_tool_approvals": {
+      "name": "session_tool_approvals",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_path": {
+          "name": "action_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_tool_approvals_unique": {
+          "name": "session_tool_approvals_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_tool_approvals_session_idx": {
+          "name": "session_tool_approvals_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_tool_approvals_project_id_projects_project_id_fk": {
+          "name": "session_tool_approvals_project_id_projects_project_id_fk",
+          "tableFrom": "session_tool_approvals",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_tool_approvals_connector_id_executor_connectors_connector_id_fk": {
+          "name": "session_tool_approvals_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "session_tool_approvals",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.stripe_webhook_events_processed": {
+      "name": "stripe_webhook_events_processed",
+      "schema": "kortix",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_webhook_events_processed_at": {
+          "name": "idx_stripe_webhook_events_processed_at",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.suna_account_migrations": {
+      "name": "suna_account_migrations",
+      "schema": "kortix",
+      "columns": {
+        "migration_id": {
+          "name": "migration_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dry_run'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_suna_account_migrations_status": {
+          "name": "idx_suna_account_migrations_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_suna_account_migrations_account": {
+          "name": "idx_suna_account_migrations_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_suna_account_migrations_heartbeat": {
+          "name": "idx_suna_account_migrations_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.teams_pending_uploads": {
+      "name": "teams_pending_uploads",
+      "schema": "kortix",
+      "columns": {
+        "upload_id": {
+          "name": "upload_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_url": {
+          "name": "service_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_teams_pending_uploads_expiry": {
+          "name": "idx_teams_pending_uploads_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_audit_logs": {
+      "name": "tunnel_audit_logs",
+      "schema": "kortix",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "tunnel_capability",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_summary": {
+          "name": "request_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes_transferred": {
+          "name": "bytes_transferred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_audit_tunnel": {
+          "name": "idx_tunnel_audit_tunnel",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_audit_account": {
+          "name": "idx_tunnel_audit_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_audit_capability": {
+          "name": "idx_tunnel_audit_capability",
+          "columns": [
+            {
+              "expression": "capability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_audit_created": {
+          "name": "idx_tunnel_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_audit_logs_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_audit_logs_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_audit_logs",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_connections": {
+      "name": "tunnel_connections",
+      "schema": "kortix",
+      "columns": {
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tunnel_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "machine_info": {
+          "name": "machine_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "relay_owner_id": {
+          "name": "relay_owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relay_owner_instance": {
+          "name": "relay_owner_instance",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relay_owner_started_at": {
+          "name": "relay_owner_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relay_owner_heartbeat_at": {
+          "name": "relay_owner_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_token_hash": {
+          "name": "setup_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_connections_account": {
+          "name": "idx_tunnel_connections_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_connections_sandbox": {
+          "name": "idx_tunnel_connections_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_connections_status": {
+          "name": "idx_tunnel_connections_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_connections_relay_owner": {
+          "name": "idx_tunnel_connections_relay_owner",
+          "columns": [
+            {
+              "expression": "relay_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_connections_sandbox_id_sandboxes_sandbox_id_fk": {
+          "name": "tunnel_connections_sandbox_id_sandboxes_sandbox_id_fk",
+          "tableFrom": "tunnel_connections",
+          "tableTo": "sandboxes",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sandbox_id"
+          ],
+          "columnsTo": [
+            "sandbox_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_device_auth_requests": {
+      "name": "tunnel_device_auth_requests",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_secret_hash": {
+          "name": "device_secret_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tunnel_device_auth_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "machine_hostname": {
+          "name": "machine_hostname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_token": {
+          "name": "setup_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_device_auth_code": {
+          "name": "idx_tunnel_device_auth_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_device_auth_status": {
+          "name": "idx_tunnel_device_auth_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_device_auth_expires": {
+          "name": "idx_tunnel_device_auth_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_device_auth_requests_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_device_auth_requests_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_device_auth_requests",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_permission_requests": {
+      "name": "tunnel_permission_requests",
+      "schema": "kortix",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "tunnel_capability",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_scope": {
+          "name": "requested_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tunnel_permission_request_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_perm_requests_tunnel": {
+          "name": "idx_tunnel_perm_requests_tunnel",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_perm_requests_account": {
+          "name": "idx_tunnel_perm_requests_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_perm_requests_status": {
+          "name": "idx_tunnel_perm_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_permission_requests_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_permission_requests_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_permission_requests",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_permissions": {
+      "name": "tunnel_permissions",
+      "schema": "kortix",
+      "columns": {
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "tunnel_capability",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "tunnel_permission_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_permissions_tunnel": {
+          "name": "idx_tunnel_permissions_tunnel",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_permissions_account": {
+          "name": "idx_tunnel_permissions_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_permissions_capability": {
+          "name": "idx_tunnel_permissions_capability",
+          "columns": [
+            {
+              "expression": "capability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_permissions_status": {
+          "name": "idx_tunnel_permissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_permissions_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_permissions_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_permissions",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_rpc_forwards": {
+      "name": "tunnel_rpc_forwards",
+      "schema": "kortix",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_relay_owner_id": {
+          "name": "requester_relay_owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_relay_owner_id": {
+          "name": "target_relay_owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tunnel_rpc_forwards_target_status": {
+          "name": "idx_tunnel_rpc_forwards_target_status",
+          "columns": [
+            {
+              "expression": "target_relay_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_rpc_forwards_expiry": {
+          "name": "idx_tunnel_rpc_forwards_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_rpc_forwards_tunnel": {
+          "name": "idx_tunnel_rpc_forwards_tunnel",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_rpc_forwards_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_rpc_forwards_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_rpc_forwards",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.usage_events": {
+      "name": "usage_events",
+      "schema": "kortix",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_ref": {
+          "name": "origin_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_tokens": {
+          "name": "cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_usd_precise": {
+          "name": "cost_usd_precise",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "streaming": {
+          "name": "streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "upstream_status": {
+          "name": "upstream_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_usage_events_account_time": {
+          "name": "idx_usage_events_account_time",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_project_time": {
+          "name": "idx_usage_events_project_time",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_session": {
+          "name": "idx_usage_events_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_model": {
+          "name": "idx_usage_events_model",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_account_origin_time": {
+          "name": "idx_usage_events_account_origin_time",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"usage_events\".\"origin_ref\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_events_account_id_accounts_account_id_fk": {
+          "name": "usage_events_account_id_accounts_account_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_events_project_id_projects_project_id_fk": {
+          "name": "usage_events_project_id_projects_project_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.voice_call_read_cursors": {
+      "name": "voice_call_read_cursors",
+      "schema": "kortix",
+      "columns": {
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.voice_call_turns": {
+      "name": "voice_call_turns",
+      "schema": "kortix",
+      "columns": {
+        "cursor": {
+          "name": "cursor",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "voice_call_turns_cursor_seq",
+            "schema": "kortix",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker": {
+          "name": "speaker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_voice_call_turns_call_cursor": {
+          "name": "idx_voice_call_turns_call_cursor",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cursor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_voice_call_turns_session": {
+          "name": "idx_voice_call_turns_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cursor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.voice_join_links": {
+      "name": "voice_join_links",
+      "schema": "kortix",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_voice_join_links_call": {
+          "name": "idx_voice_join_links_call",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.worker_leader_lease": {
+      "name": "worker_leader_lease",
+      "schema": "kortix",
+      "columns": {
+        "lock_key": {
+          "name": "lock_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.yolo_member_tokens": {
+      "name": "yolo_member_tokens",
+      "schema": "kortix",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_yolo_member_tokens_prefix": {
+          "name": "idx_yolo_member_tokens_prefix",
+          "columns": [
+            {
+              "expression": "token_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"yolo_member_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_yolo_member_tokens_account": {
+          "name": "idx_yolo_member_tokens_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "yolo_member_tokens_user_id_account_id_pk": {
+          "name": "yolo_member_tokens_user_id_account_id_pk",
+          "columns": [
+            "user_id",
+            "account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "kortix.access_request_status": {
+      "name": "access_request_status",
+      "schema": "kortix",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "kortix.account_group_source": {
+      "name": "account_group_source",
+      "schema": "kortix",
+      "values": [
+        "manual",
+        "scim",
+        "sso"
+      ]
+    },
+    "kortix.account_role": {
+      "name": "account_role",
+      "schema": "kortix",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "kortix.api_key_status": {
+      "name": "api_key_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "revoked",
+        "expired"
+      ]
+    },
+    "kortix.api_key_type": {
+      "name": "api_key_type",
+      "schema": "kortix",
+      "values": [
+        "user",
+        "sandbox"
+      ]
+    },
+    "kortix.change_request_status": {
+      "name": "change_request_status",
+      "schema": "kortix",
+      "values": [
+        "open",
+        "merged",
+        "closed"
+      ]
+    },
+    "kortix.executor_connection_profile_owner_type": {
+      "name": "executor_connection_profile_owner_type",
+      "schema": "kortix",
+      "values": [
+        "project",
+        "agent",
+        "member",
+        "subject",
+        "external"
+      ]
+    },
+    "kortix.executor_connection_profile_status": {
+      "name": "executor_connection_profile_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "revoked",
+        "error"
+      ]
+    },
+    "kortix.executor_connector_provider": {
+      "name": "executor_connector_provider",
+      "schema": "kortix",
+      "values": [
+        "pipedream",
+        "mcp",
+        "openapi",
+        "postman",
+        "graphql",
+        "http",
+        "channel",
+        "computer"
+      ]
+    },
+    "kortix.executor_connector_status": {
+      "name": "executor_connector_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "disabled",
+        "needs_auth",
+        "error"
+      ]
+    },
+    "kortix.executor_credential_mode": {
+      "name": "executor_credential_mode",
+      "schema": "kortix",
+      "values": [
+        "shared",
+        "per_user"
+      ]
+    },
+    "kortix.executor_default_mode": {
+      "name": "executor_default_mode",
+      "schema": "kortix",
+      "values": [
+        "risk",
+        "allow_all"
+      ]
+    },
+    "kortix.executor_execution_status": {
+      "name": "executor_execution_status",
+      "schema": "kortix",
+      "values": [
+        "ok",
+        "error",
+        "denied",
+        "pending_approval"
+      ]
+    },
+    "kortix.executor_policy_action": {
+      "name": "executor_policy_action",
+      "schema": "kortix",
+      "values": [
+        "always_run",
+        "require_approval",
+        "block"
+      ]
+    },
+    "kortix.executor_risk": {
+      "name": "executor_risk",
+      "schema": "kortix",
+      "values": [
+        "read",
+        "write",
+        "destructive"
+      ]
+    },
+    "kortix.gateway_budget_action": {
+      "name": "gateway_budget_action",
+      "schema": "kortix",
+      "values": [
+        "block",
+        "warn"
+      ]
+    },
+    "kortix.gateway_budget_period": {
+      "name": "gateway_budget_period",
+      "schema": "kortix",
+      "values": [
+        "day",
+        "week",
+        "month"
+      ]
+    },
+    "kortix.gateway_budget_scope": {
+      "name": "gateway_budget_scope",
+      "schema": "kortix",
+      "values": [
+        "project",
+        "member"
+      ]
+    },
+    "kortix.platform_role": {
+      "name": "platform_role",
+      "schema": "kortix",
+      "values": [
+        "user",
+        "admin",
+        "super_admin"
+      ]
+    },
+    "kortix.project_access_request_status": {
+      "name": "project_access_request_status",
+      "schema": "kortix",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "kortix.project_role": {
+      "name": "project_role",
+      "schema": "kortix",
+      "values": [
+        "manager",
+        "editor",
+        "member",
+        "viewer"
+      ]
+    },
+    "kortix.project_secret_handle_status": {
+      "name": "project_secret_handle_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "superseded",
+        "revoked"
+      ]
+    },
+    "kortix.project_secret_scope": {
+      "name": "project_secret_scope",
+      "schema": "kortix",
+      "values": [
+        "runtime",
+        "connector"
+      ]
+    },
+    "kortix.project_secret_strategy": {
+      "name": "project_secret_strategy",
+      "schema": "kortix",
+      "values": [
+        "runtime",
+        "egress",
+        "broker",
+        "denied"
+      ]
+    },
+    "kortix.project_session_connector_binding_source": {
+      "name": "project_session_connector_binding_source",
+      "schema": "kortix",
+      "values": [
+        "request",
+        "default"
+      ]
+    },
+    "kortix.project_session_origin": {
+      "name": "project_session_origin",
+      "schema": "kortix",
+      "values": [
+        "user",
+        "trigger",
+        "schedule",
+        "backend",
+        "system"
+      ]
+    },
+    "kortix.project_session_status": {
+      "name": "project_session_status",
+      "schema": "kortix",
+      "values": [
+        "queued",
+        "branching",
+        "provisioning",
+        "running",
+        "stopped",
+        "failed",
+        "completed"
+      ]
+    },
+    "kortix.project_session_visibility": {
+      "name": "project_session_visibility",
+      "schema": "kortix",
+      "values": [
+        "private",
+        "project",
+        "restricted"
+      ]
+    },
+    "kortix.project_status": {
+      "name": "project_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "kortix.provider_transition_status": {
+      "name": "provider_transition_status",
+      "schema": "kortix",
+      "values": [
+        "pending",
+        "building",
+        "ready",
+        "activating",
+        "activated",
+        "failed",
+        "superseded",
+        "cancelled"
+      ]
+    },
+    "kortix.review_item_kind": {
+      "name": "review_item_kind",
+      "schema": "kortix",
+      "values": [
+        "change",
+        "approval",
+        "output",
+        "decision",
+        "batch"
+      ]
+    },
+    "kortix.review_item_risk": {
+      "name": "review_item_risk",
+      "schema": "kortix",
+      "values": [
+        "none",
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "kortix.review_item_source": {
+      "name": "review_item_source",
+      "schema": "kortix",
+      "values": [
+        "web",
+        "slack",
+        "agent"
+      ]
+    },
+    "kortix.review_item_status": {
+      "name": "review_item_status",
+      "schema": "kortix",
+      "values": [
+        "needs_you",
+        "waiting",
+        "approved",
+        "changes_requested",
+        "rejected",
+        "done",
+        "dismissed"
+      ]
+    },
+    "kortix.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "kortix",
+      "values": [
+        "daytona",
+        "platinum",
+        "e2b",
+        "local-docker"
+      ]
+    },
+    "kortix.sandbox_status": {
+      "name": "sandbox_status",
+      "schema": "kortix",
+      "values": [
+        "provisioning",
+        "active",
+        "stopped",
+        "archived",
+        "error"
+      ]
+    },
+    "kortix.scope_effect": {
+      "name": "scope_effect",
+      "schema": "kortix",
+      "values": [
+        "grant",
+        "revoke"
+      ]
+    },
+    "kortix.secret_grant_principal": {
+      "name": "secret_grant_principal",
+      "schema": "kortix",
+      "values": [
+        "member",
+        "group"
+      ]
+    },
+    "kortix.secret_share_scope": {
+      "name": "secret_share_scope",
+      "schema": "kortix",
+      "values": [
+        "project",
+        "restricted"
+      ]
+    },
+    "kortix.session_lifecycle_command_status": {
+      "name": "session_lifecycle_command_status",
+      "schema": "kortix",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "dead_lettered"
+      ]
+    },
+    "kortix.session_sandbox_status": {
+      "name": "session_sandbox_status",
+      "schema": "kortix",
+      "values": [
+        "provisioning",
+        "active",
+        "stopped",
+        "error",
+        "archived"
+      ]
+    },
+    "kortix.tunnel_capability": {
+      "name": "tunnel_capability",
+      "schema": "kortix",
+      "values": [
+        "filesystem",
+        "shell",
+        "network",
+        "apps",
+        "hardware",
+        "desktop",
+        "gpu"
+      ]
+    },
+    "kortix.tunnel_device_auth_status": {
+      "name": "tunnel_device_auth_status",
+      "schema": "kortix",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "expired"
+      ]
+    },
+    "kortix.tunnel_permission_request_status": {
+      "name": "tunnel_permission_request_status",
+      "schema": "kortix",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "expired"
+      ]
+    },
+    "kortix.tunnel_permission_status": {
+      "name": "tunnel_permission_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "revoked",
+        "expired"
+      ]
+    },
+    "kortix.tunnel_status": {
+      "name": "tunnel_status",
+      "schema": "kortix",
+      "values": [
+        "online",
+        "offline",
+        "connecting"
+      ]
+    }
+  },
+  "schemas": {
+    "kortix": "kortix"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1785272948205,
       "tag": "20260728210908_acp_session_envelopes",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1785288749251,
+      "tag": "20260729013229_add_project_model_overrides",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/20260729013229262_add_project_model_overrides.sql
+++ b/packages/db/migrations/20260729013229262_add_project_model_overrides.sql
@@ -1,0 +1,43 @@
+-- Migration: add_project_model_overrides
+--
+-- SAFETY HEADER (house rules -- see packages/db/MIGRATIONS.md#zero-downtime-rules).
+set lock_timeout = '2s';
+set statement_timeout = '30s';
+
+-- Per-project model enablement, stored as EXCEPTIONS to the catalog default:
+-- `{"anthropic/claude-opus-4-1": true, "glm-5.2": false}`.
+--
+-- Effective enablement is
+--   overrides[id] ?? defaultEnabledModelIds(catalog).has(id)
+-- where the default is "the newest model of each family" (see
+-- packages/llm-catalog/src/enablement.ts). The latest models are therefore on
+-- out of the box, and this column records only what an admin deliberately
+-- changed.
+--
+-- Why exceptions and not the resolved set: a stored set freezes at write time,
+-- so every later catalog addition (a newly connected provider, next month's
+-- Claude release) would land OFF and need a manual click. Overrides let the
+-- default keep tracking "the latest" forever.
+--
+-- This supersedes `disabled_models`, whose opt-out shape spelled BOTH "use the
+-- default" and "the user turned everything on" as `[]` and so could not express
+-- the default at all. `disabled_models` is deliberately left in place and
+-- un-read for one release: old API pods still SELECT it on the gateway's hot
+-- path, so dropping it here would 500 them mid-rollout. The contract step (DROP
+-- COLUMN) is a follow-up migration once every pod is on this version.
+--
+-- No backfill: `disabled_models` is empty for every project (the feature is one
+-- day old and gated behind MODEL_ENABLEMENT_ENABLED), and a faithful conversion
+-- would need the live model catalog, which SQL has no access to. Any project
+-- that HAD turned models off reverts to the default set.
+--
+-- Expand step 1/2 -- a constant DEFAULT '{}' is PG11+ metadata-only (no table
+-- rewrite), and the CHECK is NOT VALID so it takes no validating scan /
+-- write-blocking lock here. A later migration validates it (every existing row
+-- gets the '{}' default, which the constraint admits).
+ALTER TABLE "kortix"."project_llm_routing_policies"
+  ADD COLUMN "model_overrides" jsonb DEFAULT '{}'::jsonb NOT NULL;
+
+ALTER TABLE "kortix"."project_llm_routing_policies"
+  ADD CONSTRAINT "project_llm_routing_policies_model_overrides_object_check"
+  CHECK (jsonb_typeof("model_overrides") = 'object') NOT VALID;

--- a/packages/db/migrations/20260729013230000_validate_project_model_overrides_check.sql
+++ b/packages/db/migrations/20260729013230000_validate_project_model_overrides_check.sql
@@ -1,0 +1,15 @@
+-- Migration: validate_project_model_overrides_check
+--
+-- SAFETY HEADER (house rules -- see packages/db/MIGRATIONS.md#zero-downtime-rules).
+set lock_timeout = '2s';
+set statement_timeout = '30s';
+
+-- Expand step 2/2: validate the NOT VALID CHECK constraint added in the previous
+-- migration (20260729013229262_add_project_model_overrides.sql). VALIDATE
+-- CONSTRAINT takes only a SHARE UPDATE EXCLUSIVE lock (does not block reads/
+-- writes) and every existing row already satisfies it trivially (the column's
+-- own DEFAULT is '{}', a valid jsonb object), so this completes near-instantly
+-- regardless of table size.
+
+ALTER TABLE "kortix"."project_llm_routing_policies"
+  VALIDATE CONSTRAINT "project_llm_routing_policies_model_overrides_object_check";

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -947,9 +947,28 @@ export const projectLlmRoutingPolicies = kortixSchema.table(
       .default({})
       .$type<ProjectModelGenerationConfig>()
       .notNull(),
-    // Wire-model ids the project has explicitly DISABLED. Opt-out: absent from
-    // this list = usable. The gateway rejects a disabled model everywhere (chat,
-    // Slack, triggers, API) and the picker hides it. Default [] = all enabled.
+    /**
+     * EXCEPTIONS to the catalog default, as `wireModelId -> enabled`. Effective
+     * enablement is `overrides[id] ?? defaultEnabledModelIds(catalog).has(id)`
+     * — the newest model per family is on, and this records only what an admin
+     * deliberately changed. The gateway refuses anything not effectively
+     * enabled everywhere (chat, Slack, triggers, API); the picker and "Manage
+     * models" render from the same answer.
+     *
+     * Storing EXCEPTIONS rather than the resolved set is load-bearing: a stored
+     * set freezes the moment it's written, so every later catalog addition (a
+     * newly connected provider, next month's Claude) lands OFF and needs a
+     * manual click. Overrides let the default keep tracking "the latest"
+     * forever while still honouring explicit choices. It also removes the
+     * `[]`-means-two-things ambiguity that made the previous `disabled_models`
+     * opt-out list unable to express the default at all.
+     */
+    modelOverrides: jsonb('model_overrides').default({}).$type<Record<string, boolean>>().notNull(),
+    /**
+     * @deprecated Superseded by `modelOverrides`. Retained un-read for one
+     * release so a mixed-version rollout can't hit a missing column on the
+     * gateway's hot path; the contract migration drops it.
+     */
     disabledModels: jsonb('disabled_models').default([]).$type<string[]>().notNull(),
     updatedBy: uuid('updated_by'),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
@@ -971,6 +990,10 @@ export const projectLlmRoutingPolicies = kortixSchema.table(
     check(
       'project_llm_routing_policies_disabled_models_array_check',
       sql`jsonb_typeof(${table.disabledModels}) = 'array'`,
+    ),
+    check(
+      'project_llm_routing_policies_model_overrides_object_check',
+      sql`jsonb_typeof(${table.modelOverrides}) = 'object'`,
     ),
   ],
 );

--- a/packages/llm-catalog/src/enablement.test.ts
+++ b/packages/llm-catalog/src/enablement.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+
+import { type EnablementCandidate, defaultEnabledModelIds } from './enablement';
+
+const NOW = new Date('2026-07-29T00:00:00Z');
+
+function ids(models: EnablementCandidate[]): string[] {
+  return [...defaultEnabledModelIds(models, { now: NOW })].sort();
+}
+
+describe('defaultEnabledModelIds', () => {
+  test('keeps only the newest model of each family', () => {
+    expect(
+      ids([
+        { id: 'anthropic/claude-sonnet-5', family: 'claude-5', released: '2026-06-01' },
+        { id: 'anthropic/claude-sonnet-4-6', family: 'claude-5', released: '2026-05-01' },
+        { id: 'anthropic/claude-opus-5', family: 'opus-5', released: '2026-06-10' },
+      ]),
+    ).toEqual(['anthropic/claude-opus-5', 'anthropic/claude-sonnet-5']);
+  });
+
+  test('drops families whose newest release is outside the window', () => {
+    expect(
+      ids([
+        { id: 'anthropic/claude-sonnet-5', family: 'claude-5', released: '2026-06-01' },
+        { id: 'anthropic/claude-opus-4-1', family: 'claude-4', released: '2025-08-01' },
+      ]),
+    ).toEqual(['anthropic/claude-sonnet-5']);
+  });
+
+  test('groups by real upstream provider, not the synthetic kortix id', () => {
+    // Both are served under `kortix`; a shared family name must not let one
+    // provider's model suppress the other's.
+    expect(
+      ids([
+        { id: 'anthropic/a-1', provider: 'anthropic', family: 'shared', released: '2026-06-01' },
+        { id: 'openai/o-1', provider: 'openai', family: 'shared', released: '2026-05-01' },
+      ]),
+    ).toEqual(['anthropic/a-1', 'openai/o-1']);
+  });
+
+  test('treats a bare wire id as managed', () => {
+    expect(ids([{ id: 'glm-5.2', family: 'glm', released: '2026-06-01' }])).toEqual(['glm-5.2']);
+  });
+
+  test('keeps a provider whose models are all stale or undated', () => {
+    // Otherwise a connected provider silently contributes nothing at all.
+    expect(
+      ids([
+        { id: 'mistral/old', family: 'm', released: '2020-01-01' },
+        { id: 'mistral/older', family: 'm', released: '2019-01-01' },
+      ]),
+    ).toEqual(['mistral/old']);
+    expect(ids([{ id: 'mistral/undated' }])).toEqual(['mistral/undated']);
+  });
+
+  test('falls back to the model id when no family is published', () => {
+    expect(
+      ids([
+        { id: 'openai/gpt-a', released: '2026-06-01' },
+        { id: 'openai/gpt-b', released: '2026-06-02' },
+      ]),
+    ).toEqual(['openai/gpt-a', 'openai/gpt-b']);
+  });
+
+  test('is empty for an empty catalog', () => {
+    expect(ids([])).toEqual([]);
+  });
+});

--- a/packages/llm-catalog/src/enablement.ts
+++ b/packages/llm-catalog/src/enablement.ts
@@ -1,0 +1,98 @@
+/**
+ * Which models a project shows by DEFAULT — the single source of truth for
+ * "the latest ones", shared by the gateway (which enforces enablement) and the
+ * web picker / "Manage models" tab (which render it).
+ *
+ * This rule used to live client-side inside `useModelStore` (packages/sdk), so
+ * the server had no idea which models the picker would actually show: an admin
+ * saw "15 of 15 shown in the model picker" while the picker rendered 3. It's a
+ * pure function over catalog metadata, so it belongs here next to
+ * `providerFlagship` — the other "which model should we pick for you" rule.
+ */
+
+/** The catalog metadata the default-set rule needs. `id` is the gateway WIRE id. */
+export interface EnablementCandidate {
+  /** Wire id — bare (`glm-5.2`) for managed, `provider/model` for BYOK. */
+  id: string;
+  /** models.dev release date (`YYYY-MM-DD`). */
+  released?: string | null;
+  /** models.dev family/lineage grouping (e.g. `claude-4`, `gpt-sol`). */
+  family?: string | null;
+  /** Real upstream provider. Falls back to the wire id's `provider/` prefix. */
+  provider?: string | null;
+}
+
+/** A model released within this window counts as current. */
+export const DEFAULT_ENABLEMENT_WINDOW_MONTHS = 6;
+
+const MS_PER_MONTH = 1000 * 60 * 60 * 24 * 30.44;
+
+/** Epoch ms for a models.dev date, or null when absent/unparseable. */
+function releasedAt(model: EnablementCandidate): number | null {
+  if (!model.released) return null;
+  const ms = new Date(model.released).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * The provider a model belongs to. Every gateway model is registered under the
+ * one synthetic `kortix` provider, so grouping by the SERVED provider id would
+ * collapse every upstream into a single bucket — prefer the explicit field and
+ * fall back to the wire id's prefix (bare ids are managed, i.e. `kortix`).
+ */
+function providerOf(model: EnablementCandidate): string {
+  if (model.provider) return model.provider;
+  const slash = model.id.indexOf('/');
+  return slash === -1 ? 'kortix' : model.id.slice(0, slash);
+}
+
+function groupBy<T>(items: T[], key: (item: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const item of items) {
+    const k = key(item);
+    const existing = groups.get(k);
+    if (existing) existing.push(item);
+    else groups.set(k, [item]);
+  }
+  return groups;
+}
+
+/** The newest member of a group; ties and undated models resolve by catalog order. */
+function newest(models: EnablementCandidate[]): EnablementCandidate {
+  return models.reduce((best, model) =>
+    (releasedAt(model) ?? 0) > (releasedAt(best) ?? 0) ? model : best,
+  );
+}
+
+/**
+ * The wire ids enabled by default: the newest model of each family, limited to
+ * families with a release inside the window.
+ *
+ * A provider whose catalog carries no usable dates at all would otherwise
+ * contribute NOTHING and vanish from the picker, so every provider always keeps
+ * at least its newest model. That guarantee is why this returns a set per
+ * provider rather than filtering the flat list by date.
+ */
+export function defaultEnabledModelIds(
+  models: EnablementCandidate[],
+  opts?: { now?: Date; windowMonths?: number },
+): Set<string> {
+  const now = (opts?.now ?? new Date()).getTime();
+  const windowMs = (opts?.windowMonths ?? DEFAULT_ENABLEMENT_WINDOW_MONTHS) * MS_PER_MONTH;
+  const enabled = new Set<string>();
+
+  for (const [, providerModels] of groupBy(models, providerOf)) {
+    const families = [...groupBy(providerModels, (m) => m.family || m.id).values()];
+    const picks = families.map(newest);
+    const current = picks.filter((m) => {
+      const at = releasedAt(m);
+      return at !== null && Math.abs(now - at) < windowMs;
+    });
+    // Never let a connected provider fall out of the picker entirely.
+    for (const model of current.length > 0 ? current : [newest(picks)]) {
+      enabled.add(model.id);
+    }
+  }
+
+  return enabled;
+}

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -1,5 +1,11 @@
 import catalogJson from './catalog.generated.json' with { type: 'json' };
 
+export {
+  DEFAULT_ENABLEMENT_WINDOW_MONTHS,
+  defaultEnabledModelIds,
+  type EnablementCandidate,
+} from './enablement';
+
 // ─── Kortix-owned provider auth requirements ────────────────────────────────
 //
 // *** THE PROBLEM THIS FIXES ***

--- a/packages/sdk/src/core/rest/projects-client/model-enablement.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/model-enablement.test.ts
@@ -7,7 +7,7 @@ let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
 
 beforeEach(() => {
   calls = [];
-  nextResponse = { status: 200, body: { ok: true, disabledModels: [] } };
+  nextResponse = { status: 200, body: { ok: true, modelOverrides: {} } };
   globalThis.fetch = mock(async (url: unknown, opts: { method?: string; body?: string } = {}) => {
     calls.push({
       url: String(url),
@@ -24,16 +24,16 @@ beforeEach(() => {
 configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
 const last = () => calls[calls.length - 1];
 
-test('PUTs the disabled set to the project model-enablement endpoint', async () => {
-  nextResponse = { status: 200, body: { ok: true, disabledModels: ['glm-5.2'] } };
-  const res = await setProjectModelEnablement('proj-1', ['glm-5.2']);
+test('PUTs the override map to the project model-enablement endpoint', async () => {
+  nextResponse = { status: 200, body: { ok: true, modelOverrides: { 'glm-5.2': false } } };
+  const res = await setProjectModelEnablement('proj-1', { 'glm-5.2': false });
   expect(last().method).toBe('PUT');
   expect(last().url).toContain('/projects/proj-1/model-enablement');
-  expect(last().body).toEqual({ disabledModels: ['glm-5.2'] });
-  expect(res).toEqual({ ok: true, disabledModels: ['glm-5.2'] });
+  expect(last().body).toEqual({ modelOverrides: { 'glm-5.2': false } });
+  expect(res).toEqual({ ok: true, modelOverrides: { 'glm-5.2': false } });
 });
 
-test('sends an empty set to re-enable everything', async () => {
-  await setProjectModelEnablement('proj-1', []);
-  expect(last().body).toEqual({ disabledModels: [] });
+test('sends an empty map to drop every exception and restore the default', async () => {
+  await setProjectModelEnablement('proj-1', {});
+  expect(last().body).toEqual({ modelOverrides: {} });
 });

--- a/packages/sdk/src/core/rest/projects-client/model-enablement.ts
+++ b/packages/sdk/src/core/rest/projects-client/model-enablement.ts
@@ -1,17 +1,24 @@
 import { backendApi } from '../../http/api-client';
 import { unwrap } from './shared';
 
-// ── Per-project model enablement (opt-out, gateway-enforced) ───────────────
-// The disabled set is server-owned: the gateway refuses these wire models
-// everywhere and the picker hides them. `GET /projects/:id/model-picker`
-// returns the current `disabledModels`; this replaces it wholesale.
+// ── Per-project model enablement (gateway-enforced) ───────────────────────
+// The newest model of each family is offered by default; a project stores only
+// the EXCEPTIONS it made to that. `GET /projects/:id/model-picker` resolves the
+// two and stamps `enabled` onto every model it serves, so clients never
+// recompute enablement — they read the flag and PUT exceptions.
 
-/** Replace the project's disabled-model set. Empty array = every model enabled. */
-export async function setProjectModelEnablement(projectId: string, disabledModels: string[]) {
+/**
+ * Replace the project's model overrides (`wireModelId -> enabled`). An empty
+ * object clears every exception, restoring the pure catalog default.
+ */
+export async function setProjectModelEnablement(
+  projectId: string,
+  modelOverrides: Record<string, boolean>,
+) {
   return unwrap(
-    await backendApi.put<{ ok: boolean; disabledModels: string[] }>(
+    await backendApi.put<{ ok: boolean; modelOverrides: Record<string, boolean> }>(
       `/projects/${projectId}/model-enablement`,
-      { disabledModels },
+      { modelOverrides },
     ),
   );
 }

--- a/packages/sdk/src/core/rest/projects-client/projects.ts
+++ b/packages/sdk/src/core/rest/projects-client/projects.ts
@@ -149,13 +149,30 @@ export interface GatewayCatalogModel {
   description?: string;
   open_weights?: boolean;
   last_updated?: string;
+  /**
+   * Whether the project OFFERS this model — server-owned per-project
+   * enablement, resolved by the API and enforced by the gateway. Served by
+   * `/model-picker`; absent on the raw `/llm-catalog` (sandbox config) path,
+   * where enablement doesn't apply.
+   */
+  enabled?: boolean;
 }
 
 export interface ProjectLlmCatalogResponse {
   models: Record<string, GatewayCatalogModel>;
-  /** Wire-model ids the project has turned OFF (server-owned enablement). Only
-   *  populated by the `/model-picker` endpoint. Absent → treat as none. */
-  disabledModels?: string[];
+  /**
+   * The project's stored EXCEPTIONS to the default model set
+   * (`wireModelId -> enabled`). Served by `/model-picker` so a client toggling
+   * one model can PUT the merged map back. Read `GatewayCatalogModel.enabled`
+   * for the RESOLVED answer — this is only the delta.
+   */
+  modelOverrides?: Record<string, boolean>;
+  /**
+   * True while the project has made no exceptions and is running on the pure
+   * catalog default. What "reset to defaults" acts on; not derivable from the
+   * `enabled` flags alone.
+   */
+  usingDefaults?: boolean;
 }
 
 export interface ProjectInput {

--- a/packages/sdk/src/react/model-flatten.ts
+++ b/packages/sdk/src/react/model-flatten.ts
@@ -30,6 +30,7 @@ type LooseModel =
       description?: string;
       open_weights?: boolean;
       last_updated?: string;
+      enabled?: boolean;
     };
 
 function hasCapabilities(model: LooseModel): model is Model {
@@ -84,6 +85,14 @@ export interface FlatModel {
   openWeights?: boolean;
   /** When models.dev last refreshed this model's own entry. */
   lastUpdated?: string;
+  /**
+   * Whether the project OFFERS this model. Server-owned per-project
+   * enablement, resolved by the API and enforced by the gateway — the picker
+   * renders the enabled ones and "Manage models" switches on this flag.
+   * Neither re-derives it. Undefined on catalogs that don't carry enablement
+   * (anything but `/model-picker`), which callers read as "not applicable".
+   */
+  enabled?: boolean;
 }
 
 // The gateway-specific fields (`provider`, `reasoning_options`,
@@ -97,6 +106,7 @@ type WithGatewayFields = {
   description?: string;
   open_weights?: boolean;
   last_updated?: string;
+  enabled?: boolean;
 };
 
 export function flattenModels(providers: ProviderListResponse | undefined): FlatModel[] {
@@ -152,6 +162,7 @@ export function flattenModels(providers: ProviderListResponse | undefined): Flat
         description: (model as WithGatewayFields).description,
         openWeights: (model as WithGatewayFields).open_weights,
         lastUpdated: (model as WithGatewayFields).last_updated,
+        enabled: (model as WithGatewayFields).enabled,
       });
     }
   }

--- a/packages/sdk/src/react/use-model-enablement.ts
+++ b/packages/sdk/src/react/use-model-enablement.ts
@@ -7,22 +7,23 @@ import { getProjectModelPicker } from '../core/rest/projects-client';
 import { setProjectModelEnablement } from '../core/rest/projects-client/model-enablement';
 
 export interface UseModelEnablement {
-  /** Wire-model ids the project has turned OFF. */
-  disabledModels: Set<string>;
-  /** True unless the wire model is in the disabled set. */
-  isEnabled: (wireModel: string) => boolean;
-  /** Turn a wire model on/off and persist the new set to the server. */
+  /** True while the project has made no exceptions to the catalog default. */
+  usingDefaults: boolean;
+  /** Pin a wire model on/off, as an exception to the default. */
   setEnabled: (wireModel: string, enabled: boolean) => Promise<void>;
-  /** Re-enable every model (clear the disabled set). */
-  enableAll: () => Promise<void>;
+  /** Drop every exception so the catalog default applies again. */
+  resetToDefaults: () => Promise<void>;
   isUpdating: boolean;
 }
 
 /**
- * Server-owned per-project model enablement (opt-out). Reads the disabled set
- * from the same `/model-picker` query `useProjectModels` uses, and persists
- * toggles via `PUT /projects/:id/model-enablement`. The gateway enforces the
- * set; this hook drives the "Manage models" switches and the picker's hiding.
+ * Server-owned per-project model enablement. Every model served by
+ * `/model-picker` already carries its own resolved `enabled` flag — read THAT
+ * to render a switch or filter a list. This hook only handles the writes.
+ *
+ * Writes are EXCEPTIONS, never the resolved set: a project that pins its whole
+ * list would stop tracking "the latest", and every future model would arrive
+ * switched off.
  */
 export function useModelEnablement(projectId: string | null | undefined): UseModelEnablement {
   const queryClient = useQueryClient();
@@ -36,35 +37,27 @@ export function useModelEnablement(projectId: string | null | undefined): UseMod
     retry: false,
   });
 
-  const disabledModels = useMemo(
-    () => new Set<string>((data?.disabledModels ?? []) as string[]),
-    [data],
-  );
-
   const mutation = useMutation({
-    mutationFn: (next: string[]) => setProjectModelEnablement(projectId as string, next),
+    mutationFn: (next: Record<string, boolean>) =>
+      setProjectModelEnablement(projectId as string, next),
     onSuccess: () => queryClient.invalidateQueries({ queryKey }),
   });
 
-  const setEnabled = useCallback(
-    async (wireModel: string, enabled: boolean) => {
-      const next = new Set(disabledModels);
-      if (enabled) next.delete(wireModel);
-      else next.add(wireModel);
-      await mutation.mutateAsync([...next]);
-    },
-    [disabledModels, mutation],
-  );
-
-  const enableAll = useCallback(async () => {
-    await mutation.mutateAsync([]);
-  }, [mutation]);
+  // The stored exceptions, served alongside the resolved flags so a toggle is
+  // a merge into what's already there rather than a fresh full set.
+  const overrides = useMemo(() => data?.modelOverrides ?? {}, [data]);
 
   return {
-    disabledModels,
-    isEnabled: useCallback((wireModel: string) => !disabledModels.has(wireModel), [disabledModels]),
-    setEnabled,
-    enableAll,
+    usingDefaults: data?.usingDefaults ?? true,
+    setEnabled: useCallback(
+      async (wireModel: string, enabled: boolean) => {
+        await mutation.mutateAsync({ ...overrides, [wireModel]: enabled });
+      },
+      [overrides, mutation],
+    ),
+    resetToDefaults: useCallback(async () => {
+      await mutation.mutateAsync({});
+    }, [mutation]),
     isUpdating: mutation.isPending,
   };
 }

--- a/packages/sdk/src/react/use-model-store.ts
+++ b/packages/sdk/src/react/use-model-store.ts
@@ -13,13 +13,14 @@
  * zustand-like pattern via useState + useCallback.
  */
 
-import type { FlatModel } from './model-flatten';
-import { safeSetItem } from '../platform/storage/managed-storage';
 import {
   DEFAULT_MANAGED_MODEL_IDS,
   MANAGED_FLAGSHIP_MODEL_ID,
+  defaultEnabledModelIds,
 } from '@kortix/llm-catalog';
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { safeSetItem } from '../platform/storage/managed-storage';
+import type { FlatModel } from './model-flatten';
 import { createModelLookup } from './model-lookup';
 import { shouldSetSessionAgentName } from './session-agent-name-guard';
 
@@ -262,62 +263,27 @@ export function isDefaultVisible(model: ModelKey): boolean {
   return DEFAULT_VISIBLE_MODEL_IDS.has(model.modelID);
 }
 
-function isWithinMonths(dateStr: string | undefined, months: number): boolean {
-  if (!dateStr) return false;
-  try {
-    const date = new Date(dateStr);
-    if (Number.isNaN(date.getTime())) return false;
-    const now = new Date();
-    const diffMs = Math.abs(now.getTime() - date.getTime());
-    const diffMonths = diffMs / (1000 * 60 * 60 * 24 * 30.44);
-    return diffMonths < months;
-  } catch {
-    return false;
-  }
-}
-
 /**
- * Compute "latest" models: models released within 6 months,
- * grouped by provider then family, newest per family wins.
+ * "Latest" models, keyed `providerID:modelID` for the store's lookup maps.
+ *
+ * The RULE itself lives in `@kortix/llm-catalog` — the gateway enforces the
+ * same default set server-side, and two copies of "newest per family within
+ * the window" is exactly how the picker and "Manage models" drifted apart.
+ * This is only the key-shape adapter.
  */
 export function computeLatestSet(models: FlatModel[]): Set<string> {
-  // Filter to recent models (within 6 months)
-  const recent = models.filter((m) => isWithinMonths(m.releaseDate, 6));
-
-  // Group by provider
-  const byProvider = new Map<string, FlatModel[]>();
-  for (const m of recent) {
-    const list = byProvider.get(m.providerID) || [];
-    list.push(m);
-    byProvider.set(m.providerID, list);
-  }
-
-  const latestKeys = new Set<string>();
-
-  for (const [, providerModels] of byProvider) {
-    // Group by family
-    const byFamily = new Map<string, FlatModel[]>();
-    for (const m of providerModels) {
-      const family = m.family || m.modelID;
-      const list = byFamily.get(family) || [];
-      list.push(m);
-      byFamily.set(family, list);
-    }
-
-    // Pick newest per family
-    for (const [, familyModels] of byFamily) {
-      familyModels.sort((a, b) => {
-        const da = a.releaseDate ? new Date(a.releaseDate).getTime() : 0;
-        const db = b.releaseDate ? new Date(b.releaseDate).getTime() : 0;
-        return db - da; // newest first
-      });
-      if (familyModels[0]) {
-        latestKeys.add(`${familyModels[0].providerID}:${familyModels[0].modelID}`);
-      }
-    }
-  }
-
-  return latestKeys;
+  return defaultEnabledModelIds(
+    models.map((m) => ({
+      // Feed the store's own composite key through as the candidate id so the
+      // result needs no lossy id → model lookup on the way back out.
+      id: `${m.providerID}:${m.modelID}`,
+      released: m.releaseDate,
+      family: m.family,
+      // `provider` is the real upstream under the gateway (every model is
+      // served as `kortix`); for a native provider it IS the providerID.
+      provider: m.provider ?? m.providerID,
+    })),
+  );
 }
 
 // ============================================================================


### PR DESCRIPTION
## The bug

"Manage models" reported **"15 of 15 shown in the model picker"** while the picker rendered **3**.

#5746 moved enablement to the server but left the **old client-side filter** running in the picker. Two independent gates decided the list: the tab drove the server's disabled-set, while what you actually saw was `useModelStore.isVisible` — localStorage plus a newest-per-family heuristic — that the tab knew nothing about.

Underneath that, *"is this model available"* was answered in **three** places (the server's `projectPickerCatalog` + `freeManagedOnly`, `useModelConnectionGate`'s `hasUsableModel`, and the picker's own `useModelStore`), and the two views walked **different catalogs** — the tab enumerated models.dev per-provider via `LLM_PROVIDERS`, the picker used the gateway's served set — with different wire-id helpers that agreed only by coincidence.

## The fix

`GET /model-picker` already exists to answer "what can this project pick". It now resolves enablement and stamps **one field — `enabled`** — onto each model it serves. Both surfaces read that field. Neither derives anything.

Enablement stores **exceptions**, not the resolved set:

```
enabled(id) = overrides[id] ?? defaultEnabledModelIds(catalog).has(id)
```

This is the load-bearing part. Storing the resolved *set* freezes it at write time — the first toggle pins the project forever, and every later model (a newly connected provider, next month's Claude) lands **off** needing a manual click. Keeping the default in the formula means *"the latest models are on"* stays true as the catalog moves, while explicit choices are still honoured.

## Changes

- **`packages/llm-catalog/enablement.ts`** (new) — the newest-per-family rule, one implementation shared by gateway and web. Replaces the copy that lived inside `useModelStore` (~45 lines of duplicated date/family logic).
- **db** — `model_overrides jsonb NOT NULL DEFAULT '{}'` supersedes `disabled_models`, whose opt-out shape spelled *both* "use the default" and "everything on" as `[]` and so could not express the default at all. The old column is left in place and **un-read for one release** (old pods still `SELECT` it on the gateway hot path); a follow-up migration drops it.
- **picker** — deleted `useModelStore` plus the secrets / `connectedProviderIds` / `freeTier` / `catalogRevision` plumbing that existed only to feed it. The server already applies exactly that gating.
- **Manage models** — same `/model-picker` query as the picker, same wire ids, shared grouping (extracted to `model-grouping.ts`), sorted newest-first, and rolling aliases (`claude-sonnet-4-5` vs `-20250929`, previously two identical-looking rows) tagged `latest`.
- **`MODEL_ENABLEMENT_ENABLED`** now gates the picker projection too, not just the gateway — the two disagreeing is the exact bug class this removes.

Net **−159 lines** of production code across the five core files.

## Verification

| | |
|---|---|
| Typecheck | clean in all 5 packages (web has 2 pre-existing unrelated errors) |
| Biome | clean (2 pre-existing a11y + 4 pre-existing `any` warnings unchanged) |
| llm-catalog | 71 pass |
| sdk (react + rest + surface snapshots) | 567 pass |
| web (model surfaces) | 48 pass |
| api (enablement 9, resolve-candidates 25, routing-policies 2, catalog-models 21) | 57 pass |
| migration lint + squawk | clean |
| migration applied to scratch DB | default `{}`, constraint validated, non-objects rejected |

Tests cover the case that drove the design: **a project that has made overrides still gets newly-released models and newly-connected providers enabled automatically.**

## Notes for review

- **No backfill.** `disabled_models` is empty for every project (the feature is one day old and flag-gated), and a faithful conversion would need the live catalog, which SQL can't reach. Any project that *had* turned models off reverts to the default set.
- **`disabled_models` drop is a follow-up** — dropping it here would 500 old API pods mid-rollout.
- **Not verified in a running browser.** Every layer is unit-tested and the migration is verified against a real DB, but I did not boot the web stack to click through it.
