### PR TITLE
docs(runtime): record live dev Pi latency proof

### DIFF
--- a/docs/specs/2026-07-29-session-start-latency-and-acp-architecture.md
+++ b/docs/specs/2026-07-29-session-start-latency-and-acp-architecture.md
@@ -402,3 +402,74 @@ Keep the harness initialized before a user requests a session.
 Use commit artifacts and writable overlays instead of repository clone.
 
 Build Pi in-process behind the same ACP contract.
+
+## 15. Post-deploy dev proof
+
+Dev API commit `7935cd9360afbd8f182ba6ac1dd12d0b3fdb6d3e` contains the
+selected-harness change.
+
+The live API returned:
+
+```text
+status=ok
+version=0.11.1-dev.7935cd93
+environment=dev
+```
+
+The first Daytona Pi session missed the snapshot cache.
+
+| phase | elapsed |
+|---|---:|
+| Row and tokens | 499 ms |
+| Snapshot cache resolution | 341.853 s |
+| Daytona create | 1.237 s |
+| Host provision total | 343.589 s |
+| Guest repository materialization | 5.418 s |
+| Pi ACP initialization after repository | 132 ms |
+| Guest ACP ready | 5.575 s |
+
+The first chat request used `kortix/glm-5.2`.
+
+It returned `503` after the API's 25-second processing deadline.
+
+The second Daytona Pi session hit the snapshot cache.
+
+| phase | elapsed |
+|---|---:|
+| Row and tokens | 658 ms |
+| Snapshot cache resolution | 94 ms |
+| Daytona create | 1.569 s |
+| Host provision total | 2.320 s |
+| Guest repository materialization | 15 ms |
+| Pi ACP initialization after repository | 136 ms |
+| Guest ACP ready | 183 ms |
+
+The second chat lifecycle used `kortix/deepseek-v4-flash`.
+
+It passed the initial response, follow-up, transcript reload, restart, and
+post-restart response.
+
+The live daemon reported:
+
+```text
+runtimeReady=true
+runtime_harness=pi
+opencode=down
+opencode_pid=null
+runtime-acp-initialized=183ms
+```
+
+The guest repository returned the same SHA for `HEAD` and remote `main`:
+
+```text
+8de781b942a3154dfd23ed7918ada8ae97f7c4a9
+```
+
+The raw record is
+`tests/performance/session-start/results/2026-07-29/dev-pi-post-deploy.json`.
+
+The result isolates three separate costs:
+
+1. ACP is a protocol. It does not remove provider or repository latency.
+2. Selected Pi removes the OpenCode process from the readiness path.
+3. Exact artifact cache hits remove snapshot build and repository clone costs.

--- a/tests/performance/session-start/results/2026-07-29/dev-pi-post-deploy.json
+++ b/tests/performance/session-start/results/2026-07-29/dev-pi-post-deploy.json
@@ -1,0 +1,188 @@
+{
+  "schema_version": 1,
+  "recorded_at": "2026-07-29T01:46:26.553Z",
+  "environment": "dev",
+  "api_base": "https://dev-api.kortix.com/v1",
+  "provider": "daytona",
+  "harness": "pi",
+  "deployed_api": {
+    "status": "ok",
+    "version": "0.11.1-dev.7935cd93",
+    "commit": "7935cd9360afbd8f182ba6ac1dd12d0b3fdb6d3e",
+    "environment": "dev",
+    "deploy_run": 30413472528,
+    "deploy_run_conclusion": "cancelled",
+    "deploy_note": "A newer main push canceled the workflow after the API rollout. The live health route reports this run's exact commit."
+  },
+  "cold_snapshot_cache_miss": {
+    "runtime_model": "kortix/glm-5.2",
+    "host_provision_timeline_ms": [
+      {
+        "label": "row+tokens",
+        "at_ms": 499,
+        "delta_ms": 499
+      },
+      {
+        "label": "image-cached",
+        "at_ms": 342352,
+        "delta_ms": 341853
+      },
+      {
+        "label": "provider-create:1x",
+        "at_ms": 343589,
+        "delta_ms": 1237
+      }
+    ],
+    "host_provision_total_ms": 343589,
+    "guest_boot_timeline_ms": [
+      {
+        "label": "static-web",
+        "at_ms": 4
+      },
+      {
+        "label": "git-identity",
+        "at_ms": 19
+      },
+      {
+        "label": "proxy-up",
+        "at_ms": 25
+      },
+      {
+        "label": "repo-materialized",
+        "at_ms": 5443
+      },
+      {
+        "label": "selected-harness-config-ready",
+        "at_ms": 5444
+      },
+      {
+        "label": "opencode-skipped",
+        "at_ms": 5449
+      },
+      {
+        "label": "runtime-process-spawned",
+        "at_ms": 5452
+      },
+      {
+        "label": "runtime-acp-first-output",
+        "at_ms": 5575
+      },
+      {
+        "label": "runtime-acp-initialized",
+        "at_ms": 5575
+      },
+      {
+        "label": "acp-runtime-ready",
+        "at_ms": 5575
+      }
+    ],
+    "health": {
+      "runtimeReady": true,
+      "runtime_harness": "pi",
+      "opencode": "down",
+      "opencode_pid": null
+    },
+    "chat_smoke": {
+      "result": "failed",
+      "status": 503,
+      "error": "Request exceeded the 25s server processing deadline"
+    }
+  },
+  "warm_snapshot_cache_hit": {
+    "runtime_model": "kortix/deepseek-v4-flash",
+    "host_provision_timeline_ms": [
+      {
+        "label": "row+tokens",
+        "at_ms": 658,
+        "delta_ms": 658
+      },
+      {
+        "label": "image-cached",
+        "at_ms": 752,
+        "delta_ms": 94
+      },
+      {
+        "label": "provider-create:1x",
+        "at_ms": 2320,
+        "delta_ms": 1569
+      }
+    ],
+    "host_provision_total_ms": 2320,
+    "guest_boot_timeline_ms": [
+      {
+        "label": "static-web",
+        "at_ms": 10
+      },
+      {
+        "label": "git-identity",
+        "at_ms": 27
+      },
+      {
+        "label": "proxy-up",
+        "at_ms": 32
+      },
+      {
+        "label": "repo-materialized",
+        "at_ms": 47
+      },
+      {
+        "label": "selected-harness-config-ready",
+        "at_ms": 48
+      },
+      {
+        "label": "opencode-skipped",
+        "at_ms": 53
+      },
+      {
+        "label": "runtime-process-spawned",
+        "at_ms": 56
+      },
+      {
+        "label": "runtime-acp-first-output",
+        "at_ms": 182
+      },
+      {
+        "label": "runtime-acp-initialized",
+        "at_ms": 183
+      },
+      {
+        "label": "acp-runtime-ready",
+        "at_ms": 183
+      }
+    ],
+    "health": {
+      "runtimeReady": true,
+      "runtime_harness": "pi",
+      "opencode": "down",
+      "opencode_pid": null
+    },
+    "chat_smoke": {
+      "result": "pass",
+      "harnesses_passed": 1,
+      "harnesses_total": 1,
+      "checks": [
+        "initial response",
+        "follow-up response",
+        "transcript reload",
+        "immutable agent identity",
+        "runtime restart",
+        "post-restart response",
+        "persisted runtime identity"
+      ]
+    },
+    "repository": {
+      "head": "8de781b942a3154dfd23ed7918ada8ae97f7c4a9",
+      "remote_main": "8de781b942a3154dfd23ed7918ada8ae97f7c4a9",
+      "match": true
+    }
+  },
+  "derived": {
+    "cold_image_cache_ms": 341853,
+    "warm_image_cache_ms": 94,
+    "image_cache_speedup": 3636.734,
+    "cold_repository_ms": 5418,
+    "warm_repository_ms": 15,
+    "repository_speedup": 361.2,
+    "warm_pi_acp_initialize_after_repository_ms": 136
+  }
+}


### PR DESCRIPTION
## Summary

- record the live dev Daytona Pi cold-cache and warm-cache timelines
- record Pi health, ACP lifecycle, and repository SHA proof
- record the 25-second model deadline failure and the passing fast-model retry

## Verification

- `jq empty tests/performance/session-start/results/2026-07-29/dev-pi-post-deploy.json`
- `git diff --check`
- live dev Pi smoke: `PASS 1/1 harnesses`
- guest `git rev-parse HEAD` equals `git ls-remote origin refs/heads/main`
- both disposable Daytona sandboxes return `404 DaytonaNotFoundError` after cleanup