### PR TITLE
chore(security): adopt the last unmanaged IAM roles, retire the dead ones

### DIFF
--- a/infra/terraform/security-baseline/imports-legacy-roles.tf
+++ b/infra/terraform/security-baseline/imports-legacy-roles.tf
@@ -1,0 +1,45 @@
+# ════════════════════════════════════════════════════════════════════════════
+# Roles that existed in the account but in no Terraform state.
+#
+# The 2026-07-29 inventory found 29 such roles. 21 were dead (last used on or
+# before 2026-04-07, when the old EKS/ECS estate was retired) and were deleted
+# along with 4 orphaned instance profiles and 3 unattached policies. These are
+# the survivors that are genuinely in use, adopted here so the account has no
+# IAM principal without a source of truth.
+#
+# Deliberately NOT adopted:
+#   - DrataAutopilotRole: created and rotated by Drata's own integration.
+#     Managing it here would fight the vendor.
+#   - kortix-enterprise-publisher-terraform: the role the enterprise publisher
+#     Terraform assumes. A root cannot own the credential it runs as.
+# ════════════════════════════════════════════════════════════════════════════
+
+import {
+  to = aws_iam_role.bedrock_logs
+  id = "bedrock-logs"
+}
+
+import {
+  to = aws_iam_role.prod_eks_ebs_csi_driver
+  id = "kortix-prod-eks-ebs-csi-driver"
+}
+
+import {
+  to = aws_iam_role.qa_portal
+  id = "qa-portal"
+}
+
+import {
+  to = aws_iam_role.qa_publisher
+  id = "kortix-qa-publisher"
+}
+
+import {
+  to = aws_iam_role.whatsapp_gateway_instance
+  id = "whatsapp-gateway-instance"
+}
+
+import {
+  to = aws_iam_role.whatsapp_gateway_github_deploy
+  id = "whatsapp-gateway-github-deploy"
+}

--- a/infra/terraform/security-baseline/legacy-roles.tf
+++ b/infra/terraform/security-baseline/legacy-roles.tf
@@ -1,0 +1,104 @@
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "whatsapp-gateway-github-deploy"
+resource "aws_iam_role" "whatsapp_gateway_github_deploy" {
+  assume_role_policy    = "{\"Statement\":[{\"Action\":\"sts:AssumeRoleWithWebIdentity\",\"Condition\":{\"StringEquals\":{\"token.actions.githubusercontent.com:aud\":\"sts.amazonaws.com\",\"token.actions.githubusercontent.com:sub\":[\"repo:kortix-ai/whatsapp-gateway:ref:refs/heads/main\",\"repo:kortix-ai@170767358/whatsapp-gateway@1307148265:ref:refs/heads/main\"]}},\"Effect\":\"Allow\",\"Principal\":{\"Federated\":\"arn:aws:iam::935064898258:oidc-provider/token.actions.githubusercontent.com\"}}],\"Version\":\"2012-10-17\"}"
+  description           = null
+  force_detach_policies = false
+  max_session_duration  = 3600
+  name                  = "whatsapp-gateway-github-deploy"
+  name_prefix           = null
+  path                  = "/"
+  permissions_boundary  = null
+  tags                  = {}
+  tags_all              = {}
+}
+
+# __generated__ by Terraform from "kortix-qa-publisher"
+resource "aws_iam_role" "qa_publisher" {
+  assume_role_policy    = "{\"Statement\":[{\"Action\":\"sts:AssumeRoleWithWebIdentity\",\"Condition\":{\"StringEquals\":{\"token.actions.githubusercontent.com:aud\":\"sts.amazonaws.com\"},\"StringLike\":{\"token.actions.githubusercontent.com:sub\":[\"repo:kortix-ai/suna:pull_request\",\"repo:kortix-ai/suna:ref:refs/heads/main\",\"repo:kortix-ai/suna:ref:refs/heads/prod\",\"repo:kortix-ai/suna:ref:refs/heads/staging\"]}},\"Effect\":\"Allow\",\"Principal\":{\"Federated\":\"arn:aws:iam::935064898258:oidc-provider/token.actions.githubusercontent.com\"}}],\"Version\":\"2012-10-17\"}"
+  description           = null
+  force_detach_policies = false
+  max_session_duration  = 3600
+  name                  = "kortix-qa-publisher"
+  name_prefix           = null
+  path                  = "/"
+  permissions_boundary  = null
+  tags = {
+    Component = "qa-portal"
+    ManagedBy = "terraform"
+    Project   = "kortix"
+  }
+  tags_all = {
+    Component = "qa-portal"
+    ManagedBy = "terraform"
+    Project   = "kortix"
+  }
+}
+
+# __generated__ by Terraform from "bedrock-logs"
+resource "aws_iam_role" "bedrock_logs" {
+  assume_role_policy    = "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Condition\":{\"ArnLike\":{\"aws:SourceArn\":\"arn:aws:bedrock:us-west-2:935064898258:*\"},\"StringEquals\":{\"aws:SourceAccount\":\"935064898258\"}},\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"bedrock.amazonaws.com\"},\"Sid\":\"AmazonBedrockModelInvocationCWDeliveryRole\"}],\"Version\":\"2012-10-17\"}"
+  description           = "Bedrock Access to CloudWatch Log Group"
+  force_detach_policies = false
+  max_session_duration  = 3600
+  name                  = "bedrock-logs"
+  name_prefix           = null
+  path                  = "/service-role/"
+  permissions_boundary  = null
+  tags                  = {}
+  tags_all              = {}
+}
+
+# __generated__ by Terraform from "kortix-prod-eks-ebs-csi-driver"
+resource "aws_iam_role" "prod_eks_ebs_csi_driver" {
+  assume_role_policy    = "{\"Statement\":[{\"Action\":\"sts:AssumeRoleWithWebIdentity\",\"Condition\":{\"StringEquals\":{\"oidc.eks.eu-west-2.amazonaws.com/id/3CF875DFB25E8312D43B2203CD389F72:aud\":\"sts.amazonaws.com\",\"oidc.eks.eu-west-2.amazonaws.com/id/3CF875DFB25E8312D43B2203CD389F72:sub\":\"system:serviceaccount:kube-system:ebs-csi-controller-sa\"}},\"Effect\":\"Allow\",\"Principal\":{\"Federated\":\"arn:aws:iam::935064898258:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/3CF875DFB25E8312D43B2203CD389F72\"}}],\"Version\":\"2012-10-17\"}"
+  description           = null
+  force_detach_policies = false
+  max_session_duration  = 3600
+  name                  = "kortix-prod-eks-ebs-csi-driver"
+  name_prefix           = null
+  path                  = "/"
+  permissions_boundary  = null
+  tags                  = {}
+  tags_all              = {}
+}
+
+# __generated__ by Terraform from "qa-portal"
+resource "aws_iam_role" "qa_portal" {
+  assume_role_policy    = "{\"Statement\":[{\"Action\":\"sts:AssumeRoleWithWebIdentity\",\"Condition\":{\"StringEquals\":{\"oidc.eks.us-west-2.amazonaws.com/id/01F423916879E83FBF85E4540EA8E868:aud\":\"sts.amazonaws.com\",\"oidc.eks.us-west-2.amazonaws.com/id/01F423916879E83FBF85E4540EA8E868:sub\":\"system:serviceaccount:kortix-qa:qa-portal\"}},\"Effect\":\"Allow\",\"Principal\":{\"Federated\":\"arn:aws:iam::935064898258:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/01F423916879E83FBF85E4540EA8E868\"}}],\"Version\":\"2012-10-17\"}"
+  description           = null
+  force_detach_policies = false
+  max_session_duration  = 3600
+  name                  = "qa-portal"
+  name_prefix           = null
+  path                  = "/"
+  permissions_boundary  = null
+  tags = {
+    Cluster   = "kortix-dev-eks"
+    Component = "qa-portal"
+    ManagedBy = "terraform"
+    Project   = "kortix"
+  }
+  tags_all = {
+    Cluster   = "kortix-dev-eks"
+    Component = "qa-portal"
+    ManagedBy = "terraform"
+    Project   = "kortix"
+  }
+}
+
+# __generated__ by Terraform from "whatsapp-gateway-instance"
+resource "aws_iam_role" "whatsapp_gateway_instance" {
+  assume_role_policy    = "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
+  description           = null
+  force_detach_policies = false
+  max_session_duration  = 3600
+  name                  = "whatsapp-gateway-instance"
+  name_prefix           = null
+  path                  = "/"
+  permissions_boundary  = null
+  tags                  = {}
+  tags_all              = {}
+}


### PR DESCRIPTION
Closes the "loose policies hanging in the air" half of the source-of-truth audit. **Already applied** — this PR records what was done.

## The inventory

77 live IAM roles, 48 in Terraform state (across **two** state buckets), **29 owned by nothing**. Last-used dates split them cleanly either side of **2026-04-07** — the EKS/ECS retirement.

## Deleted (dead)

21 roles, none used since 2026-04-07, five never used at all: 14 `suna-*` legacy roles, 6 console/eksctl roles with random suffixes, and `GITHUB_DEPLOY_ECS`. Plus **4 orphaned instance profiles** and **3 unattached customer-managed policies** (`GITHUB_DEPLOY_ECS`, `suna-eks-alb-controller-policy`, `suna-eks-cluster-autoscaler-policy`).

Full role definitions — trust policy, inline policies, attachments, instance profiles — were captured to JSON before deletion and are held outside the repo.

## Adopted (in use)

6 roles, every one used within a day of the inventory: `bedrock-logs`, `kortix-prod-eks-ebs-csi-driver`, `qa-portal`, `kortix-qa-publisher`, `whatsapp-gateway-instance`, `whatsapp-gateway-github-deploy`.

Config was **generated from the live roles** (`-generate-config-out`) rather than hand-written, so it matches byte-for-byte:

```
Plan: 6 to import, 0 to add, 0 to change, 0 to destroy
post-import: No changes. Your infrastructure matches the configuration.
```

## Deliberately not adopted

- `DrataAutopilotRole` — created and rotated by Drata's integration; managing it here would fight the vendor.
- `kortix-enterprise-publisher-terraform` — the role its own Terraform assumes. A root cannot own the credential it runs as.

**77 roles → 56. 29 unmanaged → 8, all documented.**

## One thing worth a look separately

`kortix-qa-publisher` trusts `repo:kortix-ai/suna:pull_request` — so any pull request can assume it. That is the same exposure class Strix flagged on #5760, on a role that predates this work. Not changed here because it may well be intentional for publishing QA reports from PRs, but it deserves a decision.