### PR TITLE
ci: cover the ECS environments in drift detection

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -149,6 +149,14 @@ jobs:
         root:
           - infra/terraform/environments/prod-eks/cluster
           - infra/terraform/environments/dev-eks/cluster
+          # The ECS envs became plannable from a clean checkout once their
+          # non-secret config moved out of gitignored tfvars into variable
+          # defaults (#5771, #5778). Before that a plan here proposed replacing
+          # the production certificate and live DNS, so covering them would
+          # have reported catastrophic false drift every night.
+          - infra/terraform/environments/prod
+          - infra/terraform/environments/staging
+          - infra/terraform/environments/dev
           # Not under environments/ — the stack lives at the terraform root.
           - infra/terraform/security-baseline
     steps:


### PR DESCRIPTION
Last piece of the source-of-truth work. `prod`, `staging` and `dev` now join the drift matrix.

They were excluded because they could not be planned from a clean checkout — their non-secret config lived only in gitignored, laptop-local tfvars, so a CI plan proposed replacing the production certificate and recreating live DNS. Covering them then would have reported catastrophic false drift every night.

That is fixed: #5771 and #5778 moved the config into variable defaults, #5763 gave the job a Cloudflare token, and both envs now plan identically with and without a local tfvars. Whatever drift they report from here is real.