### PR TITLE
fix(models): never prune a managed or configured model from the default set

### DIFF
--- a/apps/api/src/__tests__/unit-model-enablement.test.ts
+++ b/apps/api/src/__tests__/unit-model-enablement.test.ts
@@ -26,6 +26,12 @@ const CATALOG = {
   },
 };
 
+// glm-5.2 is the PLATFORM DEFAULT and, like every managed model, publishes no
+// release date or family — see the regression test below.
+mock.module('../llm-gateway/models/managed-models', () => ({
+  isKnownManagedModelId: (id: string) => id === 'glm-5.2' || id === 'claude-opus-4.8',
+}));
+
 const { defaultEnabledFromCatalog, resolveEnablement, isModelEnabledForProject } = await import(
   '../llm-gateway/model-enablement'
 );
@@ -67,6 +73,25 @@ describe('model-enablement', () => {
     };
     const enabled = resolveEnablement(withNewModel, { 'anthropic/claude-opus-4-1': true });
     expect(enabled.get('anthropic/claude-opus-6')).toBe(true);
+  });
+
+  it('never prunes a managed model, however thin its catalog metadata', () => {
+    // REGRESSION: managed models are hand-curated and publish no `released` or
+    // `family`, so the recency rule dropped every one of them — including
+    // glm-5.2, the PLATFORM DEFAULT. The gateway then refused every `auto`
+    // request with "This model is turned off for this project."
+    const withManaged = { ...CATALOG, 'glm-5.2': {}, 'claude-opus-4.8': {} };
+    const set = defaultEnabledFromCatalog(withManaged);
+    expect(set.has('glm-5.2')).toBe(true);
+    expect(set.has('claude-opus-4.8')).toBe(true);
+  });
+
+  it('never prunes a model the project is configured to route to', () => {
+    // A stale BYOK model set as the project default (or a routing-rule target)
+    // must stay offered — refusing it would break a request the project's own
+    // settings just produced.
+    const set = defaultEnabledFromCatalog(CATALOG, ['anthropic/claude-opus-4-1']);
+    expect(set.has('anthropic/claude-opus-4-1')).toBe(true);
   });
 
   it('offers a newly connected provider without any manual clicking', () => {

--- a/apps/api/src/llm-gateway/model-enablement.ts
+++ b/apps/api/src/llm-gateway/model-enablement.ts
@@ -2,6 +2,7 @@ import { defaultEnabledModelIds } from '@kortix/llm-catalog';
 
 import { config } from '../config';
 import { getProjectRoutingPolicy } from '../repositories/project-routing-policies';
+import { isKnownManagedModelId } from './models/managed-models';
 
 // Per-project model enablement. The newest model of each family is offered by
 // default; a project stores only the EXCEPTIONS it made to that. Anything not
@@ -33,13 +34,22 @@ type ServedModel = {
 export type ModelOverrides = Record<string, boolean>;
 
 /**
- * The models a catalog offers by default: reduced to the newest per family.
+ * The models a catalog offers by default: the newest per family, PLUS two sets
+ * the recency rule must never prune.
+ *
  * Takes the catalog rather than fetching one so each caller defaults over
  * exactly the models it is answering about — the picker route narrows by
  * connected providers and plan, the gateway judges against everything routable.
+ *
+ * `alwaysOn` is the models this project is CONFIGURED to use (its effective
+ * default, vision model, fallbacks, routing-rule targets). Pruning one of those
+ * would refuse a request the project's own settings just produced.
  */
-export function defaultEnabledFromCatalog(catalog: Record<string, ServedModel>): Set<string> {
-  return defaultEnabledModelIds(
+export function defaultEnabledFromCatalog(
+  catalog: Record<string, ServedModel>,
+  alwaysOn: Iterable<string> = [],
+): Set<string> {
+  const enabled = defaultEnabledModelIds(
     Object.entries(catalog).map(([id, model]) => ({
       id,
       released: model.released ?? model.release_date,
@@ -47,6 +57,18 @@ export function defaultEnabledFromCatalog(catalog: Record<string, ServedModel>):
       provider: model.provider,
     })),
   );
+  for (const id of Object.keys(catalog)) {
+    // Kortix-managed models are a small hand-curated set, not the models.dev
+    // firehose the recency rule exists to tame — every one of them is in the
+    // catalog precisely because we want it offered. Several (glm-5.2, the
+    // PLATFORM DEFAULT) publish no release date or family at all, so the rule
+    // would prune them and the gateway would refuse every `auto` request.
+    if (isKnownManagedModelId(id)) enabled.add(id);
+  }
+  for (const id of alwaysOn) {
+    if (catalog[id]) enabled.add(id);
+  }
+  return enabled;
 }
 
 /**
@@ -56,6 +78,7 @@ export function defaultEnabledFromCatalog(catalog: Record<string, ServedModel>):
 export function resolveEnablement(
   catalog: Record<string, ServedModel>,
   overrides: ModelOverrides,
+  alwaysOn: Iterable<string> = [],
 ): Map<string, boolean> {
   // Feature off is a kill switch, not a mode: everything is offered, and the
   // gateway's check below agrees. Both halves read the flag so the picker can
@@ -63,7 +86,7 @@ export function resolveEnablement(
   if (!config.MODEL_ENABLEMENT_ENABLED) {
     return new Map(Object.keys(catalog).map((id) => [id, true]));
   }
-  const byDefault = defaultEnabledFromCatalog(catalog);
+  const byDefault = defaultEnabledFromCatalog(catalog, alwaysOn);
   return new Map(Object.keys(catalog).map((id) => [id, overrides[id] ?? byDefault.has(id)]));
 }
 
@@ -81,5 +104,25 @@ export async function isModelEnabledForProject(
   const policy = await getProjectRoutingPolicy(projectId);
   const override = policy?.modelOverrides?.[wireModel];
   if (override !== undefined) return override;
-  return defaultEnabledFromCatalog(catalog).has(wireModel);
+  return defaultEnabledFromCatalog(catalog, routingReferencedModels(policy)).has(wireModel);
+}
+
+/**
+ * Models a routing policy points at, which the project is therefore configured
+ * to route to. Refusing one of these would break a request the project's own
+ * routing rules produced.
+ */
+export function routingReferencedModels(
+  policy: {
+    visionModel?: string | null;
+    defaultFallback?: { models: string[] } | null;
+    rules?: Array<{ model: string; fallbackModels: string[] }>;
+  } | null,
+): string[] {
+  if (!policy) return [];
+  return [
+    policy.visionModel,
+    ...(policy.defaultFallback?.models ?? []),
+    ...(policy.rules?.flatMap((rule) => [rule.model, ...rule.fallbackModels]) ?? []),
+  ].filter((model): model is string => !!model);
 }

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -2730,7 +2730,7 @@ projectsApp.openapi(
     // model so every client renders the same answer the gateway enforces. The
     // session picker shows the enabled ones; "Manage models" shows them all and
     // switches on this flag. Neither re-derives it.
-    const enabled = resolveEnablement(models, routing?.modelOverrides ?? {});
+    const enabled = resolveEnablement(models, routing?.modelOverrides ?? {}, requiredModels);
     return c.json({
       models: Object.fromEntries(
         Object.entries(models).map(([id, model]) => [


### PR DESCRIPTION
Follow-up to #5780, caught by verifying it live against a real project instead of trusting the unit tests.

## The bug

`glm-5.2` — the **platform default model** — resolved as **not enabled**, so the gateway refused it:

> This model is turned off for this project.

Every `auto` request on a default-configured project would have failed.

**Why:** managed models publish no `released` and no `family` (they're a hand-curated Kortix set, not models.dev entries), so the newest-per-family recency rule pruned all of them. The old client-side store had an explicit carve-out for exactly this — *"a small, hand-picked catalog we control, so every model in it is shown by default"* — and moving the rule server-side in #5780 dropped it.

## The fix

Two sets are exempt from the recency rule:

- **Managed models** (`isKnownManagedModelId`). The rule exists to tame models.dev's ~5k-model firehose; applying it to a curated set of four is meaningless, and their thin metadata makes it actively wrong.
- **Models the project is configured to route to** — effective default, vision model, fallbacks, routing-rule targets. Refusing one of those would break a request the project's own settings just produced. The picker route already computed this list (`requiredModels`); the gateway path derives it from the routing policy it has already fetched, at no extra query.

## Verified live

Against a real project on local Postgres, through the real HTTP routes:

| check | before | after |
|---|---|---|
| `glm-5.2` in default set | ❌ false | ✅ true |
| gateway accepts `glm-5.2` | ❌ false | ✅ true |

Plus the full round-trip on the real endpoints: default state → toggle off (picker hides **and** gateway refuses) → toggle back on → `409 cannot_disable_default` on the project default → reset to defaults. BYOK narrowing still correct (anthropic: 14 in catalog → 3 enabled by default), and a newly released model is still auto-enabled for a project that already has overrides.

Tests: model-enablement 11 (2 new regression cases), resolve-candidates 25.