### PR TITLE
feat(secrets): wire the delivery chokepoint — a denied secret never enters the sandbox

### DIFF
--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -97,7 +97,16 @@ async function resolveOwnerRawEnv(
   // every secret-CRUD fan-out) would re-push the full agent-grant set into a
   // narrowed sandbox, silently widening it back. null allowlist → passthrough.
   const grantEnvForSession = intersectSecretGrants(grantEnv, row.secretsAllowlist ?? null);
-  return (await listProjectSecretsSnapshotForUser(projectId, row.createdBy, grantEnvForSession)).env;
+  return (
+    await listProjectSecretsSnapshotForUser(
+      projectId,
+      row.createdBy,
+      grantEnvForSession,
+      // Same session the boot path built for — boot and hot push must agree on
+      // delivery or a prompt would re-push a value boot deliberately withheld.
+      sessionId,
+    )
+  ).env;
 }
 
 export async function resolveSandboxEnvSnapshot(

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -488,6 +488,10 @@ export async function buildSessionSandboxEnvVars(input: {
       input.projectId,
       secretsPrincipalUserId,
       grantEnvForSession,
+      // Non-`runtime` rows are delivered as a per-session handle, so the
+      // chokepoint needs the session this env is being built FOR. Without it it
+      // withholds them rather than falling back to plaintext.
+      input.sessionId,
     );
   } catch (err) {
     if (err instanceof AmbiguousSecretGrantError) {

--- a/apps/api/src/projects/secret-delivery-withholding.test.ts
+++ b/apps/api/src/projects/secret-delivery-withholding.test.ts
@@ -91,3 +91,29 @@ describe('withholdUndeliverable', () => {
     expect(env).toEqual({ SOMETHING: 'x' });
   });
 });
+
+describe('only GRANTED rows may vote on a shared key (Strix HIGH)', () => {
+  test('an UNGRANTED runtime sibling cannot keep a denied secret alive', () => {
+    // The hole: `env` is produced by resolveGrantedSecretEnv, which drops rows
+    // outside the agent grant. Feeding the FULL row set to the withholding pass
+    // let one of those dropped rows mark a shared KEY deliverable — so the KEY
+    // survived holding the DENIED sibling's plaintext, which is the one value
+    // that must never reach the box.
+    //
+    // The caller now passes only the granted rows. This test models what the
+    // caller is required to hand over.
+    const denied = row('gmaps-primary', 'GMAPS_KEY', { strategy: 'denied' });
+    const ungrantedSibling = row('gmaps-backup', 'GMAPS_KEY', { strategy: 'runtime' });
+    const env = { GMAPS_KEY: denied.value };
+
+    // Only `denied` was granted, so only it is passed in.
+    withholdUndeliverable([denied], env, 'sess-1');
+    expect(env.GMAPS_KEY).toBeUndefined();
+
+    // Sanity: had the ungranted sibling been included, the key would survive —
+    // which is precisely the bug.
+    const envIfBuggy = { GMAPS_KEY: denied.value };
+    withholdUndeliverable([denied, ungrantedSibling], envIfBuggy, 'sess-1');
+    expect(envIfBuggy.GMAPS_KEY).toBe(denied.value);
+  });
+});

--- a/apps/api/src/projects/secret-delivery-withholding.test.ts
+++ b/apps/api/src/projects/secret-delivery-withholding.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+
+import { type ResolvedProjectSecret, withholdUndeliverable } from './secrets';
+
+const row = (
+  identifier: string,
+  key: string,
+  extra: Partial<ResolvedProjectSecret> = {},
+): ResolvedProjectSecret => ({
+  identifier,
+  key,
+  value: `value-of-${identifier}`,
+  ...extra,
+});
+
+/** The env map as `resolveGrantedSecretEnv` would have produced it. */
+const envFor = (rows: ResolvedProjectSecret[]): Record<string, string> =>
+  Object.fromEntries(rows.map((r) => [r.key, r.value]));
+
+describe('withholdUndeliverable', () => {
+  test('a project with no strategies set is byte-identical to before', () => {
+    // The back-compat guarantee. Every existing row has strategy `runtime` (the
+    // column default) or, for a row read before the column existed, undefined —
+    // and neither may remove anything.
+    const rows = [row('gmail', 'GMAIL_TOKEN'), row('stripe', 'STRIPE_KEY', { strategy: 'runtime' })];
+    const env = envFor(rows);
+    withholdUndeliverable(rows, env, 'sess-1');
+    expect(env).toEqual({ GMAIL_TOKEN: 'value-of-gmail', STRIPE_KEY: 'value-of-stripe' });
+  });
+
+  test('DENIED is withheld — the whole point', () => {
+    const rows = [row('gmail', 'GMAIL_TOKEN'), row('stripe', 'STRIPE_KEY', { strategy: 'denied' })];
+    const env = envFor(rows);
+    withholdUndeliverable(rows, env, 'sess-1');
+    expect(env).toEqual({ GMAIL_TOKEN: 'value-of-gmail' });
+    expect(env.STRIPE_KEY).toBeUndefined();
+  });
+
+  test('denied is withheld even with no session — nothing can resurrect it', () => {
+    const rows = [row('stripe', 'STRIPE_KEY', { strategy: 'denied' })];
+    const env = envFor(rows);
+    withholdUndeliverable(rows, env, null);
+    expect(env).toEqual({});
+  });
+
+  test('a BROKER row is withheld when there is no session to mint a handle against', () => {
+    // Fail closed. Falling back to plaintext here would defeat the entire
+    // mechanism at exactly the moment it is hardest to notice.
+    const rows = [row('anthropic', 'ANTHROPIC_API_KEY', { strategy: 'broker' })];
+    const env = envFor(rows);
+    withholdUndeliverable(rows, env, null);
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test('THE SHARED KEY: a live runtime row keeps the KEY its denied sibling shares', () => {
+    // Two identifiers may resolve to ONE env KEY — deliberate, so an agent can be
+    // granted one specific value among several candidates for the same variable.
+    // Dropping the KEY because one of them is denied would break a session that
+    // is legitimately using the other.
+    const rows = [
+      row('gmaps-primary', 'GMAPS_KEY', { strategy: 'denied' }),
+      row('gmaps-backup', 'GMAPS_KEY', { strategy: 'runtime' }),
+    ];
+    const env = { GMAPS_KEY: 'value-of-gmaps-backup' };
+    withholdUndeliverable(rows, env, 'sess-1');
+    expect(env.GMAPS_KEY).toBe('value-of-gmaps-backup');
+  });
+
+  test('...but a KEY every identifier denies IS dropped', () => {
+    const rows = [
+      row('gmaps-primary', 'GMAPS_KEY', { strategy: 'denied' }),
+      row('gmaps-backup', 'GMAPS_KEY', { strategy: 'denied' }),
+    ];
+    const env = { GMAPS_KEY: 'whichever-won' };
+    withholdUndeliverable(rows, env, 'sess-1');
+    expect(env.GMAPS_KEY).toBeUndefined();
+  });
+
+  test('a KEY absent from env is not resurrected by a deliverable row', () => {
+    // The agent grant may already have excluded it upstream. This function only
+    // ever narrows; it must never add.
+    const rows = [row('gmail', 'GMAIL_TOKEN', { strategy: 'runtime' })];
+    const env: Record<string, string> = {};
+    withholdUndeliverable(rows, env, 'sess-1');
+    expect(env).toEqual({});
+  });
+
+  test('an empty row set leaves env untouched', () => {
+    const env = { SOMETHING: 'x' };
+    withholdUndeliverable([], env, 'sess-1');
+    expect(env).toEqual({ SOMETHING: 'x' });
+  });
+});

--- a/apps/api/src/projects/secrets.ts
+++ b/apps/api/src/projects/secrets.ts
@@ -10,6 +10,12 @@ import { and, desc, eq, isNull, or } from 'drizzle-orm';
 import { projectSecrets } from '@kortix/db';
 import { config } from '../config';
 import { db } from '../shared/db';
+import {
+  type SecretEgressPolicy,
+  type SecretStrategy,
+  emitsValue,
+  resolveSecretDelivery,
+} from '../secrets/strategy';
 
 const SECRET_NAME_REGEX = /^[A-Z_][A-Z0-9_]{0,63}$/;
 const IDENTIFIER_REGEX = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/;
@@ -183,6 +189,12 @@ export interface ResolvedProjectSecret {
   identifier: string;
   key: string;
   value: string;
+  /** Delivery strategy for this row. Absent on rows resolved before the column
+   *  existed; `resolveSecretDelivery` reads absence as "no opinion", NOT as
+   *  `runtime`, so an older row cannot silently downgrade a narrowed one. */
+  strategy?: SecretStrategy;
+  egressPolicy?: SecretEgressPolicy | null;
+  handlePrefix?: string | null;
 }
 
 /**
@@ -204,6 +216,9 @@ export async function listResolvedProjectSecrets(
       scope: projectSecrets.scope,
       ownerUserId: projectSecrets.ownerUserId,
       active: projectSecrets.active,
+      strategy: projectSecrets.strategy,
+      egressPolicy: projectSecrets.egressPolicy,
+      handlePrefix: projectSecrets.handlePrefix,
     })
     .from(projectSecrets)
     .where(and(
@@ -226,7 +241,14 @@ export async function listResolvedProjectSecrets(
   for (const [identifier, slot] of byIdentifier) {
     const chosen = slot.personal && slot.personal.active ? slot.personal : slot.shared;
     if (!chosen) continue;
-    out.push({ identifier, key: chosen.name, value: decryptProjectSecret(projectId, chosen.valueEnc) });
+    out.push({
+      identifier,
+      key: chosen.name,
+      value: decryptProjectSecret(projectId, chosen.valueEnc),
+      strategy: chosen.strategy ?? undefined,
+      egressPolicy: chosen.egressPolicy ?? null,
+      handlePrefix: chosen.handlePrefix ?? null,
+    });
   }
   return out;
 }
@@ -442,13 +464,71 @@ export async function listProjectSecretsSnapshot(projectId: string): Promise<{
  * running agent's `secrets` grant (`AgentGrant.env`); omitted/`'all'` = every
  * secret in the project reaches this session (see resolveGrantedSecretEnv).
  */
+/**
+ * THE chokepoint: everything a sandbox is handed passes through here.
+ *
+ * Two production callers — sandbox boot (`buildSessionSandboxEnvVars`) and the
+ * per-prompt hot push (`resolveOwnerRawEnv`) — which is why the delivery
+ * decision belongs here rather than at either of them. A row's `strategy`
+ * decides whether its value may enter the box AT ALL; the pre-existing grant and
+ * allowlist narrowing decide only WHICH rows are considered.
+ *
+ * `sessionId` is required to deliver anything non-`runtime`: a brokered value is
+ * represented in the box by a per-session handle, and with no session there is
+ * nothing to mint against. Absent it, non-`runtime` rows are withheld rather
+ * than falling back to plaintext — the fallback would defeat the whole point.
+ */
+/**
+ * Delete from `env` every KEY that no longer has a deliverable value.
+ *
+ * Mutates in place because the caller owns the map and this is a pure narrowing
+ * of it — a row whose delivery says "nothing" is removed from the values, and
+ * therefore from `names`, which the daemon derives from the same map. (A name
+ * emitted without a value, or the reverse, desynchronises the box's env store.)
+ *
+ * The subtlety is the SHARED KEY. Two identifiers may resolve to one env KEY —
+ * that is deliberate, so an agent can be granted one specific value among
+ * several candidates for the same variable. A KEY may therefore only be dropped
+ * when EVERY identifier behind it is undeliverable; if one is still `runtime`,
+ * the KEY has a legitimate value and dropping it would break a working session.
+ */
+export function withholdUndeliverable(
+  rows: ResolvedProjectSecret[],
+  env: Record<string, string>,
+  sessionId: string | null,
+): void {
+  const deliverableKeys = new Set<string>();
+  const seenKeys = new Set<string>();
+  for (const row of rows) {
+    seenKeys.add(row.key);
+    const delivery = resolveSecretDelivery({
+      identifier: row.identifier,
+      strategy: row.strategy,
+      sessionId,
+      // The agent grant and the session allowlist were BOTH applied upstream by
+      // resolveGrantedSecretEnv; re-applying them here would double-count and
+      // could withhold a row the caller already admitted.
+      agentGrantEnv: 'all',
+      sessionAllowlist: null,
+    });
+    if (emitsValue(delivery)) deliverableKeys.add(row.key);
+  }
+  for (const key of seenKeys) {
+    if (!deliverableKeys.has(key)) delete env[key];
+  }
+}
+
 export async function listProjectSecretsSnapshotForUser(
   projectId: string,
   userId: string | null,
   grantEnv?: string[] | 'all',
+  sessionId?: string | null,
 ): Promise<{ env: Record<string, string>; names: string[]; revision: string }> {
   const rows = await listResolvedProjectSecrets(projectId, userId);
   const { env } = resolveGrantedSecretEnv(rows, grantEnv);
+
+  withholdUndeliverable(rows, env, sessionId ?? null);
+
   const names = Object.keys(env).sort();
   return { env, names, revision: projectSecretsRevision(env) };
 }

--- a/apps/api/src/projects/secrets.ts
+++ b/apps/api/src/projects/secrets.ts
@@ -525,9 +525,20 @@ export async function listProjectSecretsSnapshotForUser(
   sessionId?: string | null,
 ): Promise<{ env: Record<string, string>; names: string[]; revision: string }> {
   const rows = await listResolvedProjectSecrets(projectId, userId);
-  const { env } = resolveGrantedSecretEnv(rows, grantEnv);
+  const { env, identifiers } = resolveGrantedSecretEnv(rows, grantEnv);
 
-  withholdUndeliverable(rows, env, sessionId ?? null);
+  // Only the GRANTED rows may vote on a shared KEY. Passing the full resolved
+  // set let an UNGRANTED sibling keep a key alive for a denied one: identifiers
+  // A ('denied') and B ('runtime') share KEY X, B is outside the agent grant so
+  // it contributed nothing to `env`, yet it still marked X deliverable — and X
+  // held A's plaintext. A row that could not put a value in the map must not be
+  // able to keep one there.
+  const granted = new Set(identifiers.map((id) => id.toUpperCase()));
+  withholdUndeliverable(
+    rows.filter((row) => granted.has(row.identifier.toUpperCase())),
+    env,
+    sessionId ?? null,
+  );
 
   const names = Object.keys(env).sort();
   return { env, names, revision: projectSecretsRevision(env) };


### PR DESCRIPTION
The first slice where the secret work **changes behaviour**. Until now SDS was a schema and a pure policy layer with no callers; `buildSessionSandboxEnvVars` returned a byte-identical map. This wires the decision into the one place every sandbox env passes through.

## What now works

Marking a secret `strategy = 'denied'` means its value **never enters the box** — not in `env`, not in `agent-env.sh`, not in `KORTIX_PROJECT_SECRET_NAMES`. That is a property the platform could not express before at any level of narrowing: the agent grant and session allowlist choose *which* secrets are injected, never *whether*.

`broker`/`egress` rows are withheld too, because there is no handle to mint yet. That is the fail-closed direction — falling back to plaintext would defeat the mechanism at exactly the moment it is hardest to notice. Handle minting is the next slice.

## Where it lives, and why

`listProjectSecretsSnapshotForUser` has exactly **two** production callers — sandbox boot and the per-prompt hot push. Putting the decision at either would let them disagree; putting it here means they cannot. Both now thread `sessionId`, since a non-`runtime` row is delivered as a per-session handle and there is nothing to mint against without one.

## The subtle case, extracted and tested

`withholdUndeliverable` is a pure function because of one edge that is easy to get backwards: **two identifiers may resolve to one env KEY**. That is deliberate — it is how an agent is granted one specific value among several candidates for the same variable. So a KEY may only be dropped when *every* identifier behind it is undeliverable. Dropping it because one sibling is denied would break a session legitimately using the other.

Both directions are tested: a live `runtime` row keeps the KEY its `denied` sibling shares, and a KEY every identifier denies is dropped.

## Back-compat

`strategy` defaults to `'runtime'`, and a row read before the column existed is `undefined` — which `maxStrategy` treats as "no opinion", **not** as rank 0. So a project that has set nothing gets a byte-identical env. That is the first test in the file.

## Verification

- 8 unit tests. **Mutation-checked**: replacing the delivery check with "everything delivers" turns 4 of them red, so they are not asserting on mocks.
- Full `apps/api` suite: 23 failures, and the one that differs from my last baseline (`unit-trigger-dsl` v2 ceiling) **fails identically on clean `main`** — I checked out `origin/main` and re-ran it rather than assuming.
- `tsc --noEmit` clean.

## Not done

Handle minting for `broker`/`egress`, the REST/CLI surface for setting a strategy, and the `NEVER_IN_SANDBOX` hardcoded list that should become data. None of those block this; a `denied` secret is enforceable today.