### PR TITLE
docs: per-project model enablement, backend.mdx error table + wording

### DIFF
--- a/apps/web/content/docs/backend.mdx
+++ b/apps/web/content/docs/backend.mdx
@@ -154,7 +154,8 @@ await kortix.project(projectId).sessions.list({ end_user_ref: 'your-app-user-123
 ```
 
 Every status is included, so completed sessions come back too. The deprecated
-`origin_ref` spelling also works; sending both with different values is a `400`.
+`origin_ref` spelling also works; sending both with different values is refused
+— see `END_USER_REF_CONFLICT` in the error table below.
 
 ## 3. Bring each user's own connector
 
@@ -277,6 +278,7 @@ starting a second one. Replaying a key with a **different** body — different
 | --- | --- | --- |
 | `400` | `INVALID_SESSION_MODEL` | `opencode_model` isn't servable for this account. |
 | `400` | `INVALID_SESSION_CONNECTOR_BINDINGS` / `INVALID_SESSION_SECRETS` | Malformed overrides, or a secret/binding cap exceeded. |
+| `404` | `SECRET_IDENTIFIER_NOT_FOUND` | A backend session referenced a secret name that doesn't exist in the project. |
 | `404` | `CONNECTOR_PROFILE_NOT_FOUND` | The bound `profile_id` doesn't exist for this project (or isn't yours). |
 | `409` | `CONNECTOR_PROFILE_INACTIVE` | The bound profile is revoked or the connector is disabled. |
 | `409` | `IDEMPOTENCY_*_CONFLICT` | An `Idempotency-Key` was replayed with a different body. Keep the body identical across retries. |

--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -58,6 +58,21 @@ If you see credit charges on a BYOK-only project, check these two causes
 before reporting a billing bug.
 </Callout>
 
+## Per-project model enablement
+
+The gateway enforces which models a project may use. By default, the newest
+model of each family is offered automatically. Model families you connect
+through a provider key or that Kortix manages are offered by default — a guard
+never prunes a managed model or one your project's routing policy references.
+
+You can override the default for individual models on the **Manage models**
+page (Customize → Models). An exception is stored per project and takes effect
+immediately. The model picker, chat, Slack, triggers, and the raw API all
+respect the same enabled set.
+
+A model that is not enabled is refused everywhere and hidden from the picker.
+The gateway never falls back to a disabled model.
+
 ## Shared, not private, keys
 
 A connected provider key applies to the whole project. There is no private,


### PR DESCRIPTION
## docs: per-project model enablement, backend.mdx error table + wording

Docs-only accuracy sweep from the autonomous `docs-maintainer` run (2026-07-29). Three drifts found by four parallel `docs-maintainer-worker` shards and independently re-verified by the orchestrator against current source before editing.

### Audit window
- `kortix-ai/suna`: `1bff03283` (2026-07-28 checkpoint) → `11ffee3b5` (origin/main). 185 reachable commits. Full-SHA coverage manifest passes `check-commit-coverage.mjs` (12 `docs-change`, 17 `already-current`, 156 `no-doc-impact`). Window includes: ACP multi-harness runtime (docs updated by feature authors), per-project model enablement, Secret Delivery Strategy stage 1, KaaB depth-plan corrections (end_user_ref session filter, per-end-user spend cap, agent-switch grant re-mint), starter slim-down, reaper refactor, onboarding improvement.

### Fixes
**1. Per-project model enablement (HIGH) — `project/models.mdx`**
The docs described managed vs BYOK models and auto-pick resolution but never mentioned that the gateway enforces per-project model enablement. By default the newest model of each family is offered; a managed model or one the project's routing policy references is never pruned. Projects override individual models on the Manage models page. Source proof: `apps/api/src/llm-gateway/model-enablement.ts:7-13` ("Per-project model enablement. The newest model of each family is offered by default; a project stores only the EXCEPTIONS…"); `:48-71` (`defaultEnabledFromCatalog` always includes `isKnownManagedModelId` and `alwaysOn` models); `apps/api/src/projects/routes/r4.ts:2729-2748` (model-picker stamps `enabled` flag per model); `r4.ts:2753-2822` (PUT `/model-enablement` route).

**2. Missing error code `SECRET_IDENTIFIER_NOT_FOUND` (MEDIUM) — `backend.mdx` error table**
The errors table in the KaaB guide was missing the `404 SECRET_IDENTIFIER_NOT_FOUND` error that occurs when a backend session references a nonexistent secret name. Source proof: `apps/api/src/projects/lib/sessions.ts:832` returns `code: 'SECRET_IDENTIFIER_NOT_FOUND'` at 404; `apps/api/src/__tests__/e2e-project-session-contract.test.ts:1302` confirms.

**3. Ambiguous status code wording (LOW) — `backend.mdx:156`**
The `end_user_ref`/`origin_ref` conflict text said "sending both with different values is a `400`" but the error table correctly notes it's `409` on create and `400` on list filter. Changed to "is refused — see `END_USER_REF_CONFLICT` in the error table below."

### Verification
- `check-fumadocs.mjs` PASS (28 pages, 6 nav, 28 routes).
- `git diff --check` PASS; `test-docs-maintainer-gates.mjs` PASS.
- Grep gates PASS (positive markers: `Per-project model enablement`, `never prunes a managed model`, `Manage models`, `SECRET_IDENTIFIER_NOT_FOUND`, `is refused — see`).
- This PR is docs-only — 2 files under `apps/web/content/docs/**`.

