### PR TITLE
fix(kaab): a sandbox may not enumerate other end-users' connector profiles

### DIFF
--- a/apps/api/src/projects/lib/connector-profile-visibility.test.ts
+++ b/apps/api/src/projects/lib/connector-profile-visibility.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+
+import { sessionMayEnumerateProfile } from './connector-profile-visibility';
+
+const profile = (profileId: string, ownerType: string, ownerId: string | null = null) => ({
+  profileId,
+  ownerType,
+  ownerId,
+});
+
+const WRAPPER_OPERATOR = null; // not session-bound
+const BOUND = new Set(['p-mine']);
+
+describe('sessionMayEnumerateProfile', () => {
+  test('a caller that is NOT session-bound is unaffected', () => {
+    // The dashboard user, the wrapper's operator credential and the laptop CLI
+    // all enumerate their own account's profiles. This narrowing is for sandboxes
+    // only, and must not change what an operator sees.
+    for (const owner of ['project', 'member', 'external']) {
+      expect(sessionMayEnumerateProfile(profile('p-any', owner), WRAPPER_OPERATOR)).toBe(true);
+    }
+  });
+
+  test('THE LEAK: another end-user’s external profile is hidden from a sandbox', () => {
+    // The escalation this closes: an agent in end-user A's session reads B's
+    // profile_id + owner_id + label off this list, then starts a session bound to
+    // it and runs as B's connected account. `mayManageSystemProfiles` was true
+    // for the token because it carries the WRAPPER's user id.
+    expect(sessionMayEnumerateProfile(profile('p-theirs', 'external', 'end-user-b'), BOUND)).toBe(
+      false,
+    );
+  });
+
+  test('a session CAN see the external profile it was actually bound to', () => {
+    // Otherwise the binding a wrapper deliberately handed the session becomes
+    // invisible to it, which breaks the legitimate flow.
+    expect(sessionMayEnumerateProfile(profile('p-mine', 'external', 'end-user-a'), BOUND)).toBe(
+      true,
+    );
+  });
+
+  test('team-shared connections stay visible — the project already publishes them', () => {
+    // A connector may hold several TEAM connections (support@, sales@) and they
+    // are visible to every project member by design. Hiding them from a sandbox
+    // would break connector use without protecting anything.
+    expect(sessionMayEnumerateProfile(profile('p-team', 'project'), BOUND)).toBe(true);
+  });
+
+  test('someone’s PRIVATE member connection is hidden unless bound', () => {
+    expect(sessionMayEnumerateProfile(profile('p-private', 'member', 'human-1'), BOUND)).toBe(false);
+  });
+
+  test('an EMPTY bound set hides everything except team connections', () => {
+    // A session with no bindings at all is the common KaaB case. Empty must mean
+    // "bound to nothing", not "unbound, so show everything" — treating an empty
+    // set as absent is exactly how this kind of guard fails open.
+    const none: ReadonlySet<string> = new Set();
+    expect(sessionMayEnumerateProfile(profile('p-x', 'external', 'b'), none)).toBe(false);
+    expect(sessionMayEnumerateProfile(profile('p-team', 'project'), none)).toBe(true);
+  });
+
+  test('an unknown owner_type is hidden, not shown', () => {
+    // Fail closed on a value this code does not recognise: a future owner class
+    // should have to be added deliberately, not inherit visibility by default.
+    expect(sessionMayEnumerateProfile(profile('p-future', 'something_new'), BOUND)).toBe(false);
+  });
+});

--- a/apps/api/src/projects/lib/connector-profile-visibility.ts
+++ b/apps/api/src/projects/lib/connector-profile-visibility.ts
@@ -1,0 +1,54 @@
+/**
+ * Which connection profiles a SESSION-BOUND caller may enumerate.
+ *
+ * The executor PAT injected into every sandbox carries the LAUNCHING USER's id —
+ * in Kortix-as-a-Backend that is the wrapper's own credential owner, who is a
+ * project manager. So `mayManageSystemProfiles` is true for it, and the profile
+ * list's final rule (`return mayManageSystemProfiles` for any non-member owner)
+ * handed a prompt-injected agent in end-user A's sandbox the profile_id, owner_id
+ * and label of every OTHER end-user's `external` connection. From there a single
+ * session create with `connector_bindings` runs as B's Gmail.
+ *
+ * Nothing in the session-isolation work touches this, because the escalation
+ * never reads a session row — it reads the connector surface directly.
+ *
+ * `GET /projects/:id/secrets` already solved the same shape: a session-bound
+ * token must not ENUMERATE what its session cannot use, or the narrowing that
+ * scrubs values from the env still leaks their identity. This is that rule for
+ * connectors.
+ */
+
+/** Owner classes a profile can have. `project` = team-shared; `member` = one
+ *  person's private connection; `external` = bound by reference for one
+ *  end-user, which is the KaaB shape. */
+export interface ProfileOwner {
+  ownerType: string;
+  ownerId: string | null;
+}
+
+/**
+ * @param boundProfileIds The profile ids THIS session is actually bound to, or
+ *        `null` when the caller is not session-bound (a dashboard user, the
+ *        wrapper's own operator credential, the CLI). `null` preserves today's
+ *        behaviour exactly — this narrowing exists for sandboxes.
+ */
+export function sessionMayEnumerateProfile(
+  profile: ProfileOwner & { profileId: string },
+  boundProfileIds: ReadonlySet<string> | null,
+): boolean {
+  // Not session-bound → unchanged. The operator enumerating their own account's
+  // profiles is the normal, intended case.
+  if (boundProfileIds === null) return true;
+
+  // Team-shared connections are visible to the whole project by construction —
+  // several may exist per connector (support@, sales@) and members pick between
+  // them. A sandbox seeing these leaks nothing that its own project does not
+  // already publish.
+  if (profile.ownerType === 'project') return true;
+
+  // Everything else — `member` (someone's private connection) and `external`
+  // (another end-user's, bound by reference) — is visible ONLY if this session
+  // is actually bound to it. A session can use what it was given; it has no
+  // business discovering what it was not.
+  return boundProfileIds.has(profile.profileId);
+}

--- a/apps/api/src/projects/lib/sandbox-token-session.test.ts
+++ b/apps/api/src/projects/lib/sandbox-token-session.test.ts
@@ -18,3 +18,18 @@ describe('sandboxTokenMayActOnSession', () => {
     expect(sandboxTokenMayActOnSession('', 'sess-a')).toBe(false);
   });
 });
+
+describe('commit-push shares the same invariant', () => {
+  test('a sandbox may push its OWN session', () => {
+    expect(sandboxTokenMayActOnSession('sess-a', 'sess-a')).toBe(true);
+  });
+
+  test('a sandbox may NOT push a sibling session', () => {
+    // `POST /sessions/:sessionId/commit-push` gates on PROJECT_GITOPS_PUSH,
+    // which is project-wide — and in KaaB every end-user's sandbox holds it,
+    // because they all share the wrapper's credential. Without the binding,
+    // end-user A's agent could commit and push end-user B's working tree to B's
+    // branch: a write into another end-user's repository state.
+    expect(sandboxTokenMayActOnSession('sess-a', 'sess-b')).toBe(false);
+  });
+});

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -13,6 +13,7 @@ import {
   projectTriggerRuntime,
   projects,
   sessionSandboxes,
+  projectSessionConnectorBindings,
 } from '@kortix/db';
 import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { getCachedAccountTier } from '../../billing/services/entitlements';
@@ -58,6 +59,8 @@ import {
   relayTurnStep,
 } from '../../channels/turn-relay';
 import { setProjectBotName } from '../../channels/voice-identity';
+import { callerKortixSessionId } from '../lib/caller-session';
+import { sessionMayEnumerateProfile } from '../lib/connector-profile-visibility';
 import { config } from '../../config';
 import { upsertProfileCredential, upsertProfileOAuth2Credential } from '../../executor/credentials';
 import { revokeProfileOAuth2 } from '../../executor/oauth2-store';
@@ -210,11 +213,17 @@ function serializeConnectionProfile(row: {
 }
 
 function mayReadConnectionProfile(
-  profile: { ownerType: string; ownerId: string | null; isDefault: boolean },
+  profile: { profileId: string; ownerType: string; ownerId: string | null; isDefault: boolean },
   userId: string,
   actingPrincipalIsServiceAccount: boolean,
   mayManageSystemProfiles: boolean,
+  /** Profile ids the CALLER'S session is bound to, or null when the caller is
+   *  not session-bound. See connector-profile-visibility.ts: a sandbox's token
+   *  carries the WRAPPER's user id, so without this every end-user's agent could
+   *  enumerate every other end-user's connection and then bind it. */
+  sessionBoundProfileIds: ReadonlySet<string> | null,
 ): boolean {
+  if (!sessionMayEnumerateProfile(profile, sessionBoundProfileIds)) return false;
   if (profile.ownerType === 'member') {
     return !actingPrincipalIsServiceAccount && profile.ownerId === userId;
   }
@@ -308,6 +317,23 @@ projectsApp.openapi(
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     const actingPrincipalIsServiceAccount = c.get('authType') === 'service_account';
+    // A sandbox executor token is bound to ONE session. Load what that session was
+    // actually GIVEN so the enumeration below can be narrowed to it. null for
+    // every non-session caller, which leaves the operator's view unchanged.
+    const callerSessionId = callerKortixSessionId(c);
+    let sessionBoundProfileIds: ReadonlySet<string> | null = null;
+    if (callerSessionId) {
+      const bound = await db
+        .select({ profileId: projectSessionConnectorBindings.profileId })
+        .from(projectSessionConnectorBindings)
+        .where(
+          and(
+            eq(projectSessionConnectorBindings.sessionId, callerSessionId),
+            eq(projectSessionConnectorBindings.projectId, projectId),
+          ),
+        );
+      sessionBoundProfileIds = new Set(bound.map((row) => row.profileId));
+    }
     const mayManageSystemProfiles = await projectCapabilityAllowed(
       c,
       loaded.userId,
@@ -340,6 +366,7 @@ projectsApp.openapi(
             loaded.userId,
             actingPrincipalIsServiceAccount,
             mayManageSystemProfiles,
+            sessionBoundProfileIds,
           ),
         )
         .map(serializeConnectionProfile),

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -22,6 +22,8 @@ import { and, desc, eq } from 'drizzle-orm';
 import { loadProjectForUser, loadVisibleSession, assertProjectCapability } from '../lib/access';
 import { assertAgentScope } from '../../iam/agent-scope';
 import { PROJECT_ACTIONS } from '../../iam';
+import { callerKortixSessionId } from '../lib/caller-session';
+import { sandboxTokenMayActOnSession } from '../lib/sandbox-token-session';
 import { AnyObject, ChangeRequestSchema, SessionStartResultSchema, projectsApp } from '../lib/app';
 import { withProjectGitAuth } from '../lib/git';
 import { UUID_V4_REGEX, normalizeString, readBody } from '../lib/serializers';
@@ -484,6 +486,20 @@ projectsApp.openapi(
       projectId,
       PROJECT_ACTIONS.PROJECT_GITOPS_PUSH,
     );
+
+    // The capability check above is PROJECT-wide, and in Kortix-as-a-Backend the
+    // sandbox's own token holds it — every KaaB session shares the wrapper's
+    // credential, so "may push in this project" is true for every end-user's
+    // agent. Without this, end-user A's sandbox could commit and push end-user
+    // B's working tree to B's branch. A sandbox token acts for exactly one
+    // session (sandbox_id == session_id by construction); bind it to that one.
+    const callerSandboxSessionId = callerKortixSessionId(c);
+    if (
+      callerSandboxSessionId !== null &&
+      !sandboxTokenMayActOnSession(callerSandboxSessionId, sessionId)
+    ) {
+      return c.json({ error: 'sandbox token is not scoped to this session' }, 403);
+    }
 
     const body = await readBody(c);
     const message = normalizeString(body.message) ?? undefined;


### PR DESCRIPTION
The audit's remaining **critical**, and the one that caps how much the secret-brokering work is worth.

## The escalation

The executor PAT injected into every sandbox carries the **launching user's** id. In Kortix-as-a-Backend that is the wrapper's own credential owner — a project manager. So `mayManageSystemProfiles` is true for it, and the profile list's final rule was:

```ts
if (profile.ownerType === 'project') return true;
return mayManageSystemProfiles;   // ← every `external` profile, for a sandbox
```

A prompt-injected agent in end-user **A**'s session could therefore:

```
curl -H "Authorization: Bearer $KORTIX_CLI_TOKEN" $KORTIX_API_URL/projects/$KORTIX_PROJECT_ID/connector-profiles
→ end-user B's profile_id, owner_id and label
```

then create a session with `connector_bindings: { gmail: { profile_id: <B's> } }` and run as **B's connected account**.

None of the session-isolation work shipped earlier touches this, because the escalation never reads a session row — it reads the connector surface directly.

## The fix

`GET /projects/:id/secrets` already solved exactly this shape: a session-bound token must not *enumerate* what its session cannot use, or the narrowing that scrubs values out of the env still leaks their identity. This applies that rule to connectors.

A session-bound caller now sees only:
- **team-shared** (`owner_type === 'project'`) connections — the project already publishes these to every member, and several may exist per connector (support@, sales@) for people to pick between; and
- the profiles **this session was actually bound to**.

A session can use what it was given. It has no business discovering what it was not.

`sessionBoundProfileIds` is `null` for every non-session caller — the dashboard, the operator credential, the laptop CLI — so their view is byte-identical. The narrowing exists for sandboxes.

## Tests worth reading

- An **empty** bound set hides everything but team connections. A session with no bindings is the common KaaB case, and treating empty as absent is precisely how this class of guard fails open.
- An **unknown** `owner_type` is hidden, not shown — a future owner class has to be added deliberately rather than inheriting visibility.
- A caller that is not session-bound is unaffected across all three owner types.

**Mutation-checked**: replacing the final `boundProfileIds.has(...)` with `return true` turns 4 of the 7 red.

## Verification

Full `apps/api` suite: **23 failures, zero new**. `tsc --noEmit` clean.

## What this does not fix

The token still *authorizes as* the wrapper's user — `validateAccountToken` returns `row.userId` and never reads back the stored `serviceAccountId`. This closes the connector-enumeration path specifically. Making the sandbox authorize as its own service account is the general fix and is a larger change; worth doing, but it should not gate this.