### PR TITLE
fix(kaab): enforce the per-end-user session cap on resume, not just create

### DIFF
--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -4,6 +4,7 @@ import type { ProjectSessionSandbox, SessionStartResult } from '@kortix/api-cont
 import { auth, json } from '../../openapi';
 import { getProvider, type SandboxStatus } from '../../platform/providers';
 import { db } from '../../shared/db';
+import { enforcePerOriginSessionCap } from '../lib/sessions';
 import { resolveBranchTip } from '../git';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
@@ -58,6 +59,30 @@ export async function resumeStoppedSandbox(row: {
 }): Promise<boolean> {
   if (!row.externalId) return false;
   if (!(config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(row.provider)) return false;
+
+  // The per-end-user concurrency cap was enforced only at session CREATE, so it
+  // was bypassable by simply resuming: stop N sessions, resume them all, and one
+  // end-user holds more live sandboxes than the operator allowed. A cap that any
+  // caller can step around by pausing is not a cap.
+  //
+  // Safe to count here: the session being resumed is still `stopped`, which is
+  // NOT in ACTIVE_SESSION_STATUSES, so it cannot count itself.
+  const [sessionRow] = await db
+    .select({ originRef: projectSessions.originRef })
+    .from(projectSessions)
+    .where(eq(projectSessions.sessionId, row.sessionId))
+    .limit(1);
+  const capRefusal = await enforcePerOriginSessionCap(row.accountId, sessionRow?.originRef ?? null);
+  if (capRefusal) {
+    // Returning false degrades to the caller's existing "could not resume" path.
+    // Logged at warn because the surfaced error is a generic unreachable page,
+    // and an operator debugging "why won't this session wake" needs the real
+    // reason to be findable.
+    console.warn(
+      `[projects] resume refused by per-end-user session cap for ${row.sessionId} (end_user_ref=${sessionRow?.originRef ?? 'none'})`,
+    );
+    return false;
+  }
 
   const externalId = row.externalId;
   const now = new Date();

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -4,6 +4,7 @@ import type { ProjectSessionSandbox, SessionStartResult } from '@kortix/api-cont
 import { auth, json } from '../../openapi';
 import { getProvider, type SandboxStatus } from '../../platform/providers';
 import { db } from '../../shared/db';
+import { logSafe } from '../../shared/log-safe';
 import { enforcePerOriginSessionCap } from '../lib/sessions';
 import { resolveBranchTip } from '../git';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
@@ -79,7 +80,7 @@ export async function resumeStoppedSandbox(row: {
     // and an operator debugging "why won't this session wake" needs the real
     // reason to be findable.
     console.warn(
-      `[projects] resume refused by per-end-user session cap for ${row.sessionId} (end_user_ref=${sessionRow?.originRef ?? 'none'})`,
+      `[projects] resume refused by per-end-user session cap for ${row.sessionId} (end_user_ref=${logSafe(sessionRow?.originRef)})`,
     );
     return false;
   }

--- a/apps/api/src/shared/log-safe.test.ts
+++ b/apps/api/src/shared/log-safe.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import { logSafe } from './log-safe';
+
+const LF = String.fromCharCode(10);
+const CR = String.fromCharCode(13);
+const TAB = String.fromCharCode(9);
+
+describe('logSafe', () => {
+  test('an ordinary value passes through unchanged', () => {
+    expect(logSafe('acme-corp')).toBe('acme-corp');
+  });
+
+  test('THE ATTACK: a newline cannot end the line and forge a new event', () => {
+    // `end_user_ref` is chosen by the wrapper's backend and only trimmed and
+    // length-bounded on create. Interpolated raw, a crafted value emits what
+    // looks like a separate log entry, which line-oriented ingestion indexes as
+    // a real one.
+    const forged = logSafe(`bob${LF}[projects] SECURITY: all checks disabled`);
+    expect(forged).not.toContain(LF);
+    expect(forged).toContain('\\x0a');
+  });
+
+  test('carriage returns and tabs are escaped too', () => {
+    expect(logSafe(`a${CR}b`)).toBe('a\\x0db');
+    expect(logSafe(`a${TAB}b`)).toBe('a\\x09b');
+  });
+
+  test('a backslash is escaped FIRST, so an escape cannot be spoofed', () => {
+    // Otherwise the literal text `\x0a` would be indistinguishable from a real
+    // escaped newline, letting a value fake having been sanitised.
+    expect(logSafe('a\\x0ab')).toBe('a\\\\x0ab');
+  });
+
+  test('null and undefined read as "none"', () => {
+    expect(logSafe(null)).toBe('none');
+    expect(logSafe(undefined)).toBe('none');
+  });
+
+  test('a very long value is truncated so one row cannot flood the log', () => {
+    const out = logSafe('x'.repeat(500));
+    expect(out.length).toBeLessThanOrEqual(121);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  test('an empty string stays empty rather than becoming "none"', () => {
+    // Empty and absent are different facts; collapsing them loses information.
+    expect(logSafe('')).toBe('');
+  });
+});

--- a/apps/api/src/shared/log-safe.ts
+++ b/apps/api/src/shared/log-safe.ts
@@ -1,0 +1,24 @@
+/**
+ * Make an untrusted string safe to put in a log line.
+ *
+ * `end_user_ref` is chosen by the wrapper's own backend and reaches us as opaque
+ * text. The create path trims it and bounds its length, but does not reject
+ * control characters — so a crafted value containing CR/LF can forge whole log
+ * lines, and line-oriented ingestion (Betterstack, CloudWatch, journald) will
+ * happily index the forgery as its own event.
+ *
+ * Anything that could end or restructure a line becomes a visible escape rather
+ * than being dropped: an operator reading the log should be able to tell the
+ * value contained something odd, which is itself the signal.
+ */
+export function logSafe(value: string | null | undefined, maxLength = 120): string {
+  if (value == null) return 'none';
+  const escaped = value
+    // Backslash FIRST, so a literal `\x0a` in the input cannot be mistaken for an
+    // escape this function produced — otherwise a value could fake having been
+    // sanitised.
+    .replace(/\\/g, '\\\\')
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: escaping them is the point
+    .replace(/[\u0000-\u001f\u007f]/g, (ch) => `\\x${ch.charCodeAt(0).toString(16).padStart(2, '0')}`);
+  return escaped.length > maxLength ? `${escaped.slice(0, maxLength)}…` : escaped;
+}


### PR DESCRIPTION
`enforcePerOriginSessionCap` ran only at session **create**. `resumeStoppedSandboxByExternalId` flipped a session straight back to `running` with no check — so an end-user at their limit could stop N sessions and resume them all, holding more live sandboxes than the operator allowed.

A cap any caller can step around by pausing is not a cap.

## Why counting here is safe

The session being resumed is still `stopped`, and `stopped` is not in `ACTIVE_SESSION_STATUSES` — so it cannot count itself and push the caller over their own limit. Same predicate the create path uses, served by the same `idx_project_sessions_account_origin_active` index.

## What a refusal looks like — stated honestly

Returning `false` degrades into the caller's existing "could not resume" path, which surfaces as the generic **503 unreachable page**, not a `429 per_origin_session_limit`. That is not ideal, and I chose it deliberately over threading a new error shape through the sandbox proxy for a guardrail that is **off by default**.

The mitigation is a `console.warn` naming the session and its `end_user_ref`, because an operator debugging *"why won't this session wake"* needs the real reason to be findable. If the cap gets real use, the follow-up is to surface a proper 429 at the proxy — I would rather say that plainly than pretend the error message is fine.

## Verification

Full `apps/api` suite: **23 failures, zero new**. `tsc --noEmit` clean. Checked that `lib/sessions` does not import `routes/shared`, so the new import direction introduces no cycle.