### PR TITLE
feat(whitelabel-demo): bottom scope bar + live API-call snippets

### DIFF
--- a/apps/whitelabel-demo/src/app/usage/page.tsx
+++ b/apps/whitelabel-demo/src/app/usage/page.tsx
@@ -14,6 +14,7 @@
  */
 
 import { BrandMark } from '@/components/brand-mark';
+import { CallSnippet } from '@/components/dev/call-snippet';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -144,6 +145,14 @@ function UsageDashboard() {
             </div>
 
             <UsageEndUserBreakdown data={data} />
+
+            {/* The two reads behind the numbers above: the split, and one
+                customer's line. Both run server-side — a browser cannot reach
+                /usage at all (src/server/policy.ts is deny-by-default). */}
+            <div className="mt-3 space-y-1">
+              <CallSnippet id="usage.byEndUser" />
+              <CallSnippet id="usage.forEndUser" context={{ endUserRef: data.endUserRef }} />
+            </div>
 
             <div className="mt-8">
               <h2 className="text-sm font-semibold tracking-tight">Guardrails</h2>

--- a/apps/whitelabel-demo/src/components/chat/composer.tsx
+++ b/apps/whitelabel-demo/src/components/chat/composer.tsx
@@ -13,6 +13,11 @@ type Command = { name: string; description: string | null };
  * newlines. Typing "/" opens a project-command menu (server-side `commands`);
  * picking + sending a "/cmd args" line runs it via `onCommand` instead of
  * sending a text prompt. While the agent is busy the send button stops the run.
+ *
+ * `footer` sits BELOW the card rather than in `toolbar`: it carries the session's
+ * scope, which is mostly read-only facts about what this session may reach, and
+ * putting that inside the input's own control row would read as more send-time
+ * options.
  */
 export function Composer({
   onSend,
@@ -21,6 +26,7 @@ export function Composer({
   disabled,
   placeholder = 'Message the agent…',
   toolbar,
+  footer,
   commands,
   onCommand,
 }: {
@@ -30,6 +36,8 @@ export function Composer({
   disabled?: boolean;
   placeholder?: string;
   toolbar?: ReactNode;
+  /** Rendered under the input card — see above. */
+  footer?: ReactNode;
   commands?: Command[];
   onCommand?: (name: string, args: string) => void;
 }) {
@@ -186,6 +194,8 @@ export function Composer({
           )}
         </div>
       </div>
+
+      {footer}
     </div>
   );
 }

--- a/apps/whitelabel-demo/src/components/chat/scope-bar-model.ts
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar-model.ts
@@ -1,0 +1,341 @@
+/**
+ * What the bar under the composer may SAY, and what it may DO.
+ *
+ * The scope controls belong next to the input, not in a dialog someone saw once
+ * before the session existed — "which secrets can this thing read?" is asked
+ * mid-conversation. But two of the four answers are written exactly once, at
+ * create (`mid-session-change.ts`), so the bar has to be able to tell an
+ * editable control from a decorative one BEFORE it renders either. A control
+ * that appears to re-scope a running session — and silently doesn't — is worse
+ * than no bar at all, so that judgement lives here, in a pure module, where it
+ * can be asserted.
+ *
+ * Everything else here is presentation the copy depends on being right about:
+ * which secrets are in and which are out, which identifiers the allowlist names
+ * that no longer exist, and why an alias with connections still has nothing to
+ * bind.
+ */
+
+import { type ConnectorBindingNotice, connectorBindingNotice } from '@/lib/connector-binding';
+import { collidingIdentifiers, normalizeSecretKey } from '@/lib/secret-collisions';
+import { isAllowlistable } from '@/lib/secret-scope';
+import { type ScopeRowKey, isFixedAtStart } from '@/lib/session-scope';
+import type {
+  BindableConnection,
+  ConnectorBindingChoice,
+  ConnectorBindingUnavailable,
+} from '@/server/bindable-connections';
+import type { ProjectSecret } from '@kortix/sdk';
+
+// ── Which controls may touch THIS session ───────────────────────────────────
+
+/** Same four rows the scope panel names, so the two cannot disagree. */
+export type ScopeControlKey = ScopeRowKey;
+
+export interface ScopeControl {
+  key: ScopeControlKey;
+  /** Does a control here change the RUNNING session, or only the next one? */
+  live: boolean;
+  badge: string;
+  note: string;
+}
+
+const COPY: Record<ScopeControlKey, { badge: string; note: string }> = {
+  model: {
+    badge: 'Changeable now',
+    note: 'Switching re-points the running runtime, which restarts it and ends the in-flight turn. If it cannot be applied to the running box the choice is saved and takes effect the next time this session starts — the picker says which happened.',
+  },
+  agent: {
+    badge: 'Per message',
+    note: 'Each message names the agent that runs it, and the composer above picks it. An agent whose SECRET access differs from the one this session booted with is refused — only a new session can run it.',
+  },
+  secrets: {
+    badge: 'Fixed at start',
+    note: 'The allowlist is written once, when the session starts, and there is no update path. Widening it now would hand the sandbox secrets it booted without; narrowing it could leave the sandbox unable to boot at all.',
+  },
+  connections: {
+    badge: 'Fixed at start',
+    note: 'Bindings are sent with the create and never again. Aliases left unbound keep resolving to the project default, for this session and every session started from here.',
+  },
+};
+
+export function scopeControl(key: ScopeControlKey): ScopeControl {
+  return { key, live: !isFixedAtStart(key), ...COPY[key] };
+}
+
+/**
+ * The only honest action a create-only row can offer.
+ *
+ * Not "apply", not "save": nothing on a running session accepts either, so the
+ * button has to name what actually happens.
+ */
+export const START_NEW_SESSION_ACTION = 'Start a new session with this scope';
+
+// ── Secrets ─────────────────────────────────────────────────────────────────
+
+/**
+ * `agent_grant` is not "allowed" with a nicer name: a session that started
+ * WITHOUT an allowlist reads whatever its agent is granted, which is a set this
+ * app cannot enumerate and may be smaller than the rows shown. Saying "allowed"
+ * there would be a claim about secret access that nothing verified.
+ */
+export type SecretMembership = 'allowed' | 'excluded' | 'agent_grant';
+
+export const SECRET_MEMBERSHIP_LABEL: Record<SecretMembership, string> = {
+  allowed: 'Allowed',
+  excluded: 'Excluded',
+  agent_grant: 'Agent grant',
+};
+
+export interface ScopeBarSecretRow {
+  /** What the allowlist addresses. Unique per project. */
+  identifier: string;
+  /** The env KEY the value lands on. Deliberately NOT unique. */
+  name: string;
+  membership: SecretMembership;
+}
+
+export interface ScopeBarSecrets {
+  /** Did this session start with an allowlist at all? */
+  narrowed: boolean;
+  rows: ScopeBarSecretRow[];
+  /** Allowlisted identifiers with no project secret behind them. */
+  missing: string[];
+  /** Chip text — short enough to sit under the composer. */
+  summary: string;
+  detail: string;
+}
+
+export const MISSING_SECRET_NOTE =
+  'Named in this session’s allowlist but not a project secret now — it was removed, or it never existed.';
+
+export function scopeBarSecrets(input: {
+  secrets: ProjectSecret[] | undefined;
+  /** `session.secrets_allowlist`. null/undefined = never narrowed. */
+  allowlist: string[] | null | undefined;
+}): ScopeBarSecrets {
+  const allowlist = input.allowlist ?? null;
+  const narrowed = allowlist !== null;
+  const allowed = new Set(allowlist ?? []);
+
+  // Only runtime-scoped rows can be named at all — create resolves the
+  // allowlist against those alone, so listing a channel-install row as
+  // "excluded" would invent a decision nobody could have made.
+  const rows: ScopeBarSecretRow[] = (input.secrets ?? [])
+    .filter(isAllowlistable)
+    .map((secret) => ({
+      identifier: secret.identifier,
+      name: secret.name,
+      membership: narrowed
+        ? allowed.has(secret.identifier)
+          ? 'allowed'
+          : 'excluded'
+        : 'agent_grant',
+    }));
+
+  // Allowlistable rows only. Keying this on EVERY row made an allowlisted-but-
+  // unallowlistable identifier count as "known", so it disappeared from the
+  // popover while still being counted in the chip summary — the silent
+  // disappearance `missing` exists to prevent. It cannot be in a live allowlist
+  // legitimately anyway: create would have refused it.
+  const known = new Set(
+    (input.secrets ?? []).filter(isAllowlistable).map((secret) => secret.identifier),
+  );
+  const missing = (allowlist ?? []).filter((identifier) => !known.has(identifier));
+
+  if (!narrowed) {
+    return {
+      narrowed,
+      rows,
+      missing,
+      summary: 'Agent grant',
+      detail:
+        'This session started without an allowlist, so it reads whatever its agent is granted — which can be fewer of these than the list suggests.',
+    };
+  }
+  if (allowed.size === 0) {
+    return {
+      narrowed,
+      rows,
+      missing,
+      summary: 'None',
+      detail:
+        'This session started with an empty allowlist, which is a real choice and not an empty state: it receives no project secrets at all.',
+    };
+  }
+  return {
+    narrowed,
+    rows,
+    missing,
+    summary: `${allowed.size} allowed`,
+    detail:
+      'The allowlist names IDENTIFIERS. The env KEY beside each one is what the value lands on, and two identifiers may legally share a KEY.',
+  };
+}
+
+// ── The draft carried into the next session ─────────────────────────────────
+
+export type ScopeDraftIssueKind = 'not_created' | 'key_collision';
+
+/** A drafted allowlist entry that would make the create fail, named before it does. */
+export interface ScopeDraftIssue {
+  identifier: string;
+  kind: ScopeDraftIssueKind;
+  /** For a collision, the other drafted identifiers writing the same env KEY. */
+  conflicts: string[];
+  message: string;
+}
+
+export const NEW_IDENTIFIER_HINT =
+  'You can name an identifier that does not exist yet, but a session cannot create one: add it in Settings → Secrets first, then start a session that allows it. A start that names a missing identifier is refused.';
+
+/**
+ * Both ways a drafted allowlist gets refused, checked here rather than
+ * discovered at the create.
+ *
+ * `not_created` is 404 SECRET_IDENTIFIER_NOT_FOUND and `key_collision` is 409
+ * SECRET_IDENTIFIER_KEY_COLLISION — and neither is fixable afterwards, because
+ * an allowlist cannot be edited once written. So the bar refuses to start
+ * rather than starting something that cannot boot.
+ */
+export function scopeDraftIssues(
+  draft: string[],
+  secrets: ProjectSecret[] | undefined,
+): ScopeDraftIssue[] {
+  // Allowlistable rows ONLY. Create resolves the allowlist against runtime-scoped
+  // secrets alone, so a channel-install row is not a candidate — judging the
+  // draft against every row let an unallowlistable identifier read as "exists",
+  // left the start button enabled, and produced a guaranteed
+  // 404 SECRET_IDENTIFIER_NOT_FOUND. This module exists to pre-empt exactly that
+  // refusal, so it is the one place the filter must not be skipped.
+  const items = (secrets ?? []).filter(isAllowlistable);
+  const drafted = new Set(draft);
+  const issues: ScopeDraftIssue[] = [];
+
+  for (const identifier of draft) {
+    const row = items.find((secret) => secret.identifier === identifier);
+    if (!row) {
+      issues.push({
+        identifier,
+        kind: 'not_created',
+        conflicts: [],
+        message: `${identifier} is not a project secret yet. Create it in Settings → Secrets, then start a session that allows it.`,
+      });
+      continue;
+    }
+    const conflicts = collidingIdentifiers(items, identifier).filter((other) =>
+      drafted.has(other),
+    );
+    if (conflicts.length > 0) {
+      issues.push({
+        identifier,
+        kind: 'key_collision',
+        conflicts,
+        message: `${identifier} and ${conflicts.join(', ')} all write ${normalizeSecretKey(row.name)}. One session can carry only one of them.`,
+      });
+    }
+  }
+  return issues;
+}
+
+export type TypedIdentifier =
+  | { kind: 'empty' }
+  | { kind: 'already_listed'; identifier: string }
+  | { kind: 'existing'; identifier: string }
+  | { kind: 'unknown'; identifier: string };
+
+/** What the "add an identifier" field is looking at right now. */
+export function classifyTypedIdentifier(
+  text: string,
+  input: { secrets: ProjectSecret[] | undefined; draft: string[] },
+): TypedIdentifier {
+  const identifier = text.trim();
+  if (identifier.length === 0) return { kind: 'empty' };
+  if (input.draft.includes(identifier)) return { kind: 'already_listed', identifier };
+  // Same filter as scopeDraftIssues: "exists" here must mean "can be allowed",
+  // otherwise the field tells the user an identifier is fine and create 404s.
+  const exists = (input.secrets ?? [])
+    .filter(isAllowlistable)
+    .some((secret) => secret.identifier === identifier);
+  return exists ? { kind: 'existing', identifier } : { kind: 'unknown', identifier };
+}
+
+// ── Connections ─────────────────────────────────────────────────────────────
+
+export interface ScopeBarConnector {
+  alias: string;
+  /** What THIS session is bound to — the label recorded at create. null = the project default. */
+  bound: string | null;
+  /** What a NEW session could bind for this alias. */
+  choices: BindableConnection[];
+  unavailable: ConnectorBindingUnavailable | null;
+  /** The remedy when nothing is bindable. Always a teammate — never "connect it yourself". */
+  notice: ConnectorBindingNotice | null;
+}
+
+export interface ScopeBarConnectors {
+  rows: ScopeBarConnector[];
+  summary: string;
+}
+
+/**
+ * Every alias worth a row: the ones the project has connections for, plus any
+ * this session is bound to.
+ *
+ * The second half matters. A session bound to a connection that has since been
+ * revoked disappears from the choices list entirely, and dropping the row would
+ * quietly claim the session runs on the project default — which it does not.
+ */
+export function scopeBarConnectors(input: {
+  choices: ConnectorBindingChoice[] | undefined;
+  /** Alias -> label, as this wrapper recorded it at create. */
+  boundConnections: Record<string, string>;
+}): ScopeBarConnectors {
+  const choices = input.choices ?? [];
+  const aliases = [
+    ...new Set([...choices.map((choice) => choice.alias), ...Object.keys(input.boundConnections)]),
+  ].sort((a, b) => a.localeCompare(b));
+
+  const rows: ScopeBarConnector[] = aliases.map((alias) => {
+    const choice = choices.find((candidate) => candidate.alias === alias) ?? null;
+    return {
+      alias,
+      bound: input.boundConnections[alias] ?? null,
+      choices: choice?.connections ?? [],
+      unavailable: choice?.unavailable ?? null,
+      // Only ask for a notice when the server actually reported a reason.
+      // A synthesized row (bound, but no longer in the choices) has no reason,
+      // and `connectorBindingNotice` would fall through to "private only" —
+      // naming a cause nobody established.
+      notice: choice && choice.unavailable !== null ? connectorBindingNotice(choice) : null,
+    };
+  });
+
+  const bound = rows.filter((row) => row.bound !== null).length;
+  const summary =
+    rows.length === 0 ? 'None' : bound === 0 ? 'Project defaults' : `${bound} bound`;
+  return { rows, summary };
+}
+
+/**
+ * The bindings to pre-fill the next session with, recovered from the labels
+ * this session recorded.
+ *
+ * The platform never serializes a session's `connector_bindings` back, so the
+ * label in metadata is all there is. An alias whose label no longer resolves to
+ * a bindable connection is simply left out — which lands it on the project
+ * default, exactly where an unbindable alias would end up anyway.
+ */
+export function seedBindingsFromLabels(rows: ScopeBarConnector[]): Record<string, string> {
+  const bindings: Record<string, string> = {};
+  for (const row of rows) {
+    if (row.bound === null) continue;
+    const match = row.choices.find(
+      // `buildSessionCreateInput` records the profile id when no label was
+      // known, so accept either form.
+      (connection) => connection.label === row.bound || connection.profileId === row.bound,
+    );
+    if (match) bindings[row.alias] = match.profileId;
+  }
+  return bindings;
+}

--- a/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
@@ -1,0 +1,547 @@
+'use client';
+
+/**
+ * The session's scope, under the composer where the work happens.
+ *
+ * Everything here was previously answerable only in a dialog seen once before
+ * the session existed, or in a tab nobody opens mid-conversation — so "can this
+ * agent read the Stripe key?" and "which mailbox is it sending as?" were
+ * questions with no answer at the moment they get asked.
+ *
+ * The bar is deliberately asymmetric, because the platform is. The model and
+ * the per-message agent can move now; the secrets allowlist and the connector
+ * bindings are written once at create and never again. So the current-session
+ * sections are TEXT — no switch, no select, nothing that could look like it
+ * re-scopes a running session — and every change lands in a clearly separated
+ * draft whose only button starts a new session with it.
+ */
+
+import Loading from '@/components/ui/loading';
+
+import {
+  ConnectorBindingFields,
+  bindingLabels,
+  useConnectorBindingChoices,
+} from '@/components/connector-bindings';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Switch } from '@/components/ui/switch';
+import { ModelSwitcher } from '@/components/workbench/model-switcher';
+import { kortix } from '@/lib/kortix';
+import { invalidateSessions, qk } from '@/lib/query-keys';
+import { getSessionToken } from '@/lib/session';
+import { sessionCreateFailure } from '@/lib/session-create-failure';
+import { buildSessionCreateInput } from '@/lib/session-overrides';
+import { readBoundConnections, sessionScopeIsReadable } from '@/lib/session-scope';
+import { generateSessionId } from '@kortix/sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, Bot, ChevronDown, Cpu, Lock, Plug, Plus } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { type ReactNode, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  MISSING_SECRET_NOTE,
+  NEW_IDENTIFIER_HINT,
+  SECRET_MEMBERSHIP_LABEL,
+  START_NEW_SESSION_ACTION,
+  classifyTypedIdentifier,
+  scopeBarConnectors,
+  scopeBarSecrets,
+  scopeControl,
+  scopeDraftIssues,
+  seedBindingsFromLabels,
+} from './scope-bar-model';
+
+export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionId: string }) {
+  const router = useRouter();
+  const qc = useQueryClient();
+
+  const session = useQuery({
+    queryKey: qk.session(projectId, sessionId),
+    queryFn: () => kortix.session(projectId, sessionId).get({ showErrors: false }),
+    retry: false,
+  });
+  const secrets = useQuery({
+    queryKey: qk.secrets(projectId),
+    queryFn: () => kortix.project(projectId).secrets.list(),
+    retry: false,
+  });
+  const connectors = useConnectorBindingChoices(projectId);
+  // Same query key the switcher inside the popover uses, so this label is the
+  // switcher's own answer rather than a second opinion — and costs no second
+  // request. The upstream field is named after the runtime, which is why this
+  // goes through the neutral route instead of the SDK.
+  const model = useQuery({
+    queryKey: ['session-model', projectId, sessionId],
+    queryFn: async () => {
+      const token = getSessionToken();
+      const res = await fetch(
+        `/api/session-model?projectId=${encodeURIComponent(projectId)}&sessionId=${encodeURIComponent(sessionId)}`,
+        { headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+      );
+      if (!res.ok) return { model: null as string | null };
+      return (await res.json()) as { model: string | null };
+    },
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  // A redacted session arrives as a perfectly good HTTP 200 with
+  // `secrets_allowlist: null` — the exact value that means "not narrowed". Read
+  // it as fact and a session the viewer may NOT open renders as the LEAST
+  // restricted one on the screen.
+  const data = sessionScopeIsReadable(session.data) ? session.data : null;
+
+  const items = secrets.data?.items ?? [];
+  const choices = connectors.data?.connectors ?? [];
+  const live = scopeBarSecrets({ secrets: items, allowlist: data?.secrets_allowlist ?? null });
+  const connections = scopeBarConnectors({
+    choices: connectors.data?.connectors,
+    boundConnections: readBoundConnections(data?.metadata),
+  });
+
+  // `undefined` = untouched, so the draft simply IS this session's scope until
+  // someone changes something. Deriving it instead of copying it in an effect
+  // keeps it correct while the session query is still resolving.
+  const [draftSecrets, setDraftSecrets] = useState<string[] | null | undefined>(undefined);
+  const [draftBindings, setDraftBindings] = useState<Record<string, string> | undefined>(undefined);
+  const [typed, setTyped] = useState('');
+
+  const nextSecrets = draftSecrets === undefined ? (data?.secrets_allowlist ?? null) : draftSecrets;
+  const nextBindings = draftBindings ?? seedBindingsFromLabels(connections.rows);
+  const issues = scopeDraftIssues(nextSecrets ?? [], items);
+
+  const start = useMutation({
+    mutationFn: async () => {
+      const nextId = generateSessionId();
+      await kortix.project(projectId).sessions.create(
+        buildSessionCreateInput(
+          // The agent comes along too, or "with this scope" would quietly drop
+          // the one part of the scope that is already right.
+          { agent: data?.agent_name ?? null, secrets: nextSecrets, bindings: nextBindings },
+          {
+            sessionId: nextId,
+            connectionLabels: bindingLabels(choices, nextBindings),
+          },
+        ),
+      );
+      return nextId;
+    },
+    onSuccess: (nextId) => {
+      invalidateSessions(qc, projectId);
+      router.push(`/projects/${projectId}/sessions/${nextId}`);
+    },
+    onError: (err) => {
+      const failure = sessionCreateFailure(err);
+      toast.error(failure.title, { description: failure.detail });
+    },
+  });
+
+  // Every chip is a claim about what this session may reach, and a half-loaded
+  // one reads as a narrower session than it is ("None" before the list arrives).
+  // Hold the whole bar rather than animating through a wrong answer.
+  if (session.isLoading || secrets.isLoading || connectors.isLoading) {
+    return <div className="mt-2 h-6" aria-hidden />;
+  }
+  if (!data) {
+    return (
+      <p className="mt-2 text-center text-[11px] text-muted-foreground">
+        This session&apos;s scope could not be read just now.
+      </p>
+    );
+  }
+
+  // Read off the capability map rather than hardcoded: if either of these ever
+  // became changeable in place, the draft-and-restart affordance would be the
+  // wrong shape and should disappear rather than quietly misdescribe the rule.
+  const secretsFixed = !scopeControl('secrets').live;
+  const connectionsFixed = !scopeControl('connections').live;
+
+  // Offering "start a new session with this scope" against a secret list that
+  // failed to load would either send an allowlist nothing verified or refuse it
+  // with a reason that is only an artefact of the failed read.
+  const startAction = secrets.isError ? null : (
+    <StartWithScope
+      issues={issues.map((issue) => issue.message)}
+      pending={start.isPending}
+      onStart={() => start.mutate()}
+    />
+  );
+
+  const toggleSecret = (identifier: string, on: boolean) => {
+    const base = nextSecrets ?? [];
+    setDraftSecrets(
+      on ? [...new Set([...base, identifier])] : base.filter((id) => id !== identifier),
+    );
+  };
+
+  const typedState = classifyTypedIdentifier(typed, { secrets: items, draft: nextSecrets ?? [] });
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+      <ScopeChip
+        icon={<Bot className="size-3" />}
+        label="Agent"
+        value={data.agent_name ?? 'Project default'}
+        title="Agent"
+        badge={scopeControl('agent').badge}
+        note={scopeControl('agent').note}
+      />
+
+      <ScopeChip
+        icon={<Lock className="size-3" />}
+        label="Secrets"
+        // Derived from the session's own allowlist, so it stays true even when
+        // the project's secret list is the thing that failed to load.
+        value={live.summary}
+        title="Secrets"
+        badge={scopeControl('secrets').badge}
+        // BOTH: what this session's allowlist actually is, and — when the
+        // session is running — why the ~8 switches below cannot move it. The
+        // first version passed only `live.detail`, so the popover offered a
+        // wall of controls and never explained that they were frozen; the
+        // frozen copy existed and was asserted by a test while being rendered
+        // nowhere.
+        note={
+          scopeControl('secrets').live
+            ? live.detail
+            : `${live.detail} ${scopeControl('secrets').note}`
+        }
+      >
+        <div className="mt-3 space-y-2">
+          {/* An unread project list is not an empty one. "No secrets" here
+              would be a claim about secret access that nothing established. */}
+          {secrets.isError && (
+            <p className="text-xs text-muted-foreground">
+              This project&apos;s secrets could not be read just now, so only the allowlist itself
+              is shown: {live.narrowed ? (data.secrets_allowlist ?? []).join(', ') || 'nothing' : 'it was never narrowed'}.
+            </p>
+          )}
+          {!secrets.isError && live.rows.length === 0 && (
+            <p className="text-xs text-muted-foreground">
+              This project has no secrets a session allowlist can name.
+            </p>
+          )}
+          {live.rows.map((row) => (
+            <div key={row.identifier} className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <div className="truncate font-mono text-xs">{row.identifier}</div>
+                {/* The KEY is shown next to every identifier, always: the
+                    allowlist addresses the identifier, the sandbox sees the
+                    KEY, and they are routinely different names. */}
+                <div className="truncate font-mono text-[11px] text-muted-foreground">
+                  {row.name}
+                </div>
+              </div>
+              <Badge
+                variant={row.membership === 'allowed' ? 'outline' : 'ghost'}
+                className={row.membership === 'excluded' ? 'text-muted-foreground' : undefined}
+              >
+                {SECRET_MEMBERSHIP_LABEL[row.membership]}
+              </Badge>
+            </div>
+          ))}
+          {!secrets.isError && live.missing.length > 0 && (
+            <div className="rounded-md border border-border bg-muted/30 px-2.5 py-2">
+              <div className="font-mono text-xs">{live.missing.join(', ')}</div>
+              <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+                {MISSING_SECRET_NOTE}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <NextSession
+          label="Change what the next session may read"
+          // No draft editor without the list it edits: a start built on a list
+          // that failed to load would name identifiers nobody verified.
+          show={secretsFixed && !secrets.isError}
+        >
+          <div className="flex items-center justify-between gap-3">
+            <Label htmlFor="scope-bar-narrow" className="text-xs font-normal">
+              Limit it to a list
+            </Label>
+            <Switch
+              id="scope-bar-narrow"
+              checked={nextSecrets !== null}
+              onCheckedChange={(on) => setDraftSecrets(on ? (nextSecrets ?? []) : null)}
+            />
+          </div>
+          {nextSecrets === null ? (
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              Off, the next session gets its agent&apos;s full secret grant — the same as this one.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {live.rows.map((row) => (
+                <div key={row.identifier} className="flex items-center justify-between gap-3">
+                  <Label
+                    htmlFor={`scope-bar-secret-${row.identifier}`}
+                    className="min-w-0 font-mono text-xs font-normal"
+                  >
+                    <span className="truncate">{row.identifier}</span>
+                    {row.name !== row.identifier && (
+                      <span className="truncate text-muted-foreground">→ {row.name}</span>
+                    )}
+                  </Label>
+                  <Switch
+                    id={`scope-bar-secret-${row.identifier}`}
+                    checked={nextSecrets.includes(row.identifier)}
+                    onCheckedChange={(on) => toggleSecret(row.identifier, on)}
+                  />
+                </div>
+              ))}
+              {nextSecrets
+                .filter((id) => !live.rows.some((row) => row.identifier === id))
+                .map((id) => (
+                  <div key={id} className="flex items-center justify-between gap-3">
+                    <span className="min-w-0 truncate font-mono text-xs">{id}</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-[11px]"
+                      onClick={() => toggleSecret(id, false)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                ))}
+
+              <div className="space-y-1.5 border-t border-border pt-2">
+                <Label htmlFor="scope-bar-new-identifier" className="text-xs font-normal">
+                  Allow another identifier
+                </Label>
+                <div className="flex items-center gap-1.5">
+                  <Input
+                    id="scope-bar-new-identifier"
+                    value={typed}
+                    onChange={(e) => setTyped(e.target.value)}
+                    placeholder="STRIPE_LIVE"
+                    className="h-8 font-mono text-xs"
+                  />
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    className="h-8"
+                    disabled={typedState.kind === 'empty' || typedState.kind === 'already_listed'}
+                    onClick={() => {
+                      if (typedState.kind === 'empty' || typedState.kind === 'already_listed') {
+                        return;
+                      }
+                      toggleSecret(typedState.identifier, true);
+                      setTyped('');
+                    }}
+                  >
+                    Add
+                  </Button>
+                </div>
+                {typedState.kind === 'already_listed' && (
+                  <p className="text-[11px] text-muted-foreground">Already on the list.</p>
+                )}
+                {/* Said where they type it, not after the create fails: this
+                    app can list a project's secrets but cannot mint one, and
+                    an allowlist naming an identifier that does not exist is
+                    refused at start. */}
+                <p className="text-[11px] leading-relaxed text-muted-foreground">
+                  {NEW_IDENTIFIER_HINT}
+                </p>
+              </div>
+            </div>
+          )}
+        </NextSession>
+        {startAction}
+      </ScopeChip>
+
+      <ScopeChip
+        icon={<Plug className="size-3" />}
+        label="Connections"
+        value={connections.summary}
+        title="Connections"
+        badge={scopeControl('connections').badge}
+        note={scopeControl('connections').note}
+      >
+        <div className="mt-3 space-y-2">
+          {connections.rows.length === 0 && (
+            <p className="text-xs text-muted-foreground">
+              This project has no connectors connected yet.
+            </p>
+          )}
+          {connections.rows.map((row) => (
+            <div key={row.alias} className="space-y-0.5">
+              <div className="flex items-center justify-between gap-2">
+                <span className="truncate font-mono text-xs text-muted-foreground">{row.alias}</span>
+                <span className="truncate text-xs">{row.bound ?? 'Project default'}</span>
+              </div>
+              {/* The remedy is always a teammate. A wrapper acts under one
+                  credential for many end-users, so it has no upstream identity
+                  to connect WITH, and the interactive flow that would is
+                  refused for it outright. */}
+              {row.notice && (
+                <div className="flex items-start gap-2 rounded-md border border-border bg-muted/30 px-2.5 py-2">
+                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0">
+                    <div className="text-xs">{row.notice.title}</div>
+                    <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+                      {row.notice.detail}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <NextSession
+          label="Bind different accounts for the next session"
+          show={connectionsFixed && choices.some((choice) => choice.connections.length > 0)}
+        >
+          <ConnectorBindingFields
+            // Only the aliases with something to bind — the unavailable ones
+            // are explained once, above, and a second copy of the same notice
+            // reads like a second problem.
+            choices={choices.filter((choice) => choice.connections.length > 0)}
+            value={nextBindings}
+            onChange={setDraftBindings}
+          />
+        </NextSession>
+        {startAction}
+      </ScopeChip>
+
+      <ScopeChip
+        icon={<Cpu className="size-3" />}
+        label="Model"
+        value={model.data?.model ?? 'Project default'}
+        title="Model"
+        badge={scopeControl('model').badge}
+        note={scopeControl('model').note}
+      >
+        <div className="-ml-2 mt-2">
+          <ModelSwitcher projectId={projectId} sessionId={sessionId} />
+        </div>
+      </ScopeChip>
+    </div>
+  );
+}
+
+/** One compact chip. Opens a popover; the chip itself never mutates anything. */
+function ScopeChip({
+  icon,
+  label,
+  value,
+  title,
+  badge,
+  note,
+  children,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  title: string;
+  badge: string;
+  note: string;
+  children?: ReactNode;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1.5 rounded-full border border-border/70 px-2 text-[11px] font-normal text-muted-foreground"
+          aria-label={`${label}: ${value}`}
+        >
+          {icon}
+          <span className="text-muted-foreground">{label}</span>
+          <span className="max-w-40 truncate text-foreground">{value}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" side="top" className="w-80 max-h-[60dvh] overflow-y-auto scrollbar-thin">
+        <PopoverHeader>
+          <div className="flex items-center gap-2">
+            <PopoverTitle>{title}</PopoverTitle>
+            <Badge variant="secondary" className="text-[11px]">
+              {badge}
+            </Badge>
+          </div>
+          <PopoverDescription className="text-xs leading-relaxed">{note}</PopoverDescription>
+        </PopoverHeader>
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * The draft, behind a disclosure that names its consequence.
+ *
+ * A collapsed section labelled "the next session" is the difference between a
+ * control someone reads as re-scoping the running session and one they read as
+ * planning the next. The label is not decoration.
+ */
+function NextSession({
+  label,
+  show = true,
+  children,
+}: { label: string; show?: boolean; children: ReactNode }) {
+  if (!show) return null;
+  return (
+    <Collapsible className="mt-3 border-t border-border pt-3">
+      <CollapsibleTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-full justify-between px-1 text-xs font-normal text-muted-foreground"
+        >
+          {label}
+          <ChevronDown className="size-3.5" />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 space-y-2.5">{children}</CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+/** Starts a session with the draft — or says why it would be refused. */
+function StartWithScope({
+  issues,
+  pending,
+  onStart,
+}: {
+  issues: string[];
+  pending: boolean;
+  onStart: () => void;
+}) {
+  return (
+    <div className="mt-3 space-y-1.5 border-t border-border pt-3">
+      {/* A refused allowlist can never be edited afterwards, so starting a
+          session that cannot boot is not a recoverable mistake. Name it here
+          instead of letting the create be the first place anyone hears it. */}
+      {issues.map((issue) => (
+        <p key={issue} className="text-[11px] leading-relaxed text-destructive">
+          {issue}
+        </p>
+      ))}
+      <Button
+        size="sm"
+        variant="secondary"
+        className="h-7 w-full gap-1.5"
+        disabled={pending || issues.length > 0}
+        onClick={onStart}
+      >
+        {pending ? <Loading className="size-3.5" /> : <Plus className="size-3.5" />}
+        {START_NEW_SESSION_ACTION}
+      </Button>
+    </div>
+  );
+}

--- a/apps/whitelabel-demo/src/components/dev/call-snippet.tsx
+++ b/apps/whitelabel-demo/src/components/dev/call-snippet.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+/**
+ * The API call behind the control you are looking at.
+ *
+ * Lumen exists to show a wrapper author what to call, and until this panel
+ * existed every answer lived in the source: the dialog started a session and
+ * nothing on screen said which request that was. So each KaaB control carries
+ * its own disclosure, showing the SDK call this app runs and the HTTP request
+ * that reaches Kortix — next to the button that performs it, not in a README.
+ *
+ * Both blocks are copy-pasteable, and neither ever carries real credentials:
+ * the bearer is always the `$KORTIX_API_KEY` placeholder and secret values are
+ * never rendered at all (`src/lib/call-snippets.ts` has nowhere to put one).
+ */
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
+  type CallSnippetId,
+  type SnippetContext,
+  callSnippet,
+  isCopyableHttp,
+  renderHttp,
+} from '@/lib/call-snippets';
+import { cn } from '@/lib/utils';
+import { Check, ChevronDown, Code2, Copy } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+export function CallSnippet({
+  id,
+  context,
+  className,
+  defaultOpen = false,
+}: {
+  id: CallSnippetId;
+  context?: SnippetContext;
+  className?: string;
+  defaultOpen?: boolean;
+}) {
+  const snippet = callSnippet(id, context ?? {});
+  const http = renderHttp(snippet.http);
+
+  return (
+    <Collapsible defaultOpen={defaultOpen} className={cn('w-full', className)}>
+      <CollapsibleTrigger asChild>
+        <Button variant="ghost" size="xs" className="group gap-1.5 text-muted-foreground">
+          <Code2 className="size-3" />
+          The API call
+          <ChevronDown className="size-3 transition-transform group-data-[state=open]:rotate-180" />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-1.5 space-y-3 rounded-md border border-border bg-muted/30 p-3">
+          <p className="text-xs leading-relaxed text-muted-foreground">{snippet.summary}</p>
+
+          <Block label="SDK" caption="What this app runs." code={snippet.sdk} />
+
+          <Block
+            label="HTTP"
+            caption={
+              isCopyableHttp(snippet.http)
+                ? 'What reaches Kortix — the form to use from any language.'
+                : 'Not a REST call.'
+            }
+            code={http}
+            copyable={isCopyableHttp(snippet.http)}
+          />
+
+          {/* Named explicitly rather than left implicit in the body above: a
+              snippet that let someone believe the browser sets `end_user_ref`
+              would teach exactly the forgery the proxy refuses. */}
+          {snippet.serverInjected.length > 0 && (
+            <div className="rounded-md border border-brand/30 bg-brand/5 px-2.5 py-2">
+              <div className="flex flex-wrap items-center gap-1.5">
+                <span className="text-xs font-medium">Added by the server, not the browser</span>
+                {snippet.serverInjected.map((field) => (
+                  <Badge key={field} variant="outline" className="font-mono text-[11px]">
+                    {field}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <ul className="space-y-1.5">
+            {snippet.notes.map((note) => (
+              <li key={note} className="text-xs leading-relaxed text-muted-foreground">
+                {note}
+              </li>
+            ))}
+          </ul>
+
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            <span className="font-mono">$KORTIX_API_KEY</span> is a placeholder. Nothing here ever
+            renders a real key, token or secret value — the key stays on your server, and the end
+            user&apos;s own token never reaches Kortix.
+          </p>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function Block({
+  label,
+  caption,
+  code,
+  copyable = true,
+}: {
+  label: string;
+  caption: string;
+  code: string;
+  copyable?: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    toast.success(`${label} call copied`);
+    setTimeout(() => setCopied(false), 1_500);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        <Badge variant="secondary" className="text-[10px]">
+          {label}
+        </Badge>
+        <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">{caption}</span>
+        {copyable && (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label={`Copy the ${label} call`}
+            onClick={copy}
+          >
+            {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+          </Button>
+        )}
+      </div>
+      {copyable ? (
+        <pre className="mt-1 overflow-x-auto rounded-md border border-border bg-background p-2.5 text-[11px] leading-relaxed scrollbar-thin">
+          <code>{code}</code>
+        </pre>
+      ) : (
+        // Prose, not a code block: there is no path to copy, and printing one
+        // would teach hand-rolling the runtime transport the SDK owns.
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{code}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/whitelabel-demo/src/components/new-session-dialog.tsx
+++ b/apps/whitelabel-demo/src/components/new-session-dialog.tsx
@@ -17,6 +17,7 @@
 import Loading from '@/components/ui/loading';
 
 import { AgentPicker } from '@/components/chat/agent-picker';
+import { CallSnippet } from '@/components/dev/call-snippet';
 import {
   ConnectorBindingFields,
   bindingLabels,
@@ -257,6 +258,19 @@ function NewSessionForm({
           />
         </section>
       )}
+
+      {/* The dialog IS the create body — so show the body it currently builds,
+          updating as the switches move, rather than describing it. */}
+      <CallSnippet
+        id="session.create"
+        context={{
+          projectId,
+          overrides,
+          // Same labels the submit path passes, so the snippet cannot print a
+          // different body than the button sends.
+          connectionLabels: bindingLabels(connectors.data?.connectors ?? [], bindings),
+        }}
+      />
 
       <DialogFooter>
         <Button variant="ghost" onClick={onDone} disabled={start.isPending}>

--- a/apps/whitelabel-demo/src/components/session-isolation-panel.tsx
+++ b/apps/whitelabel-demo/src/components/session-isolation-panel.tsx
@@ -21,6 +21,7 @@
 
 import Loading from '@/components/ui/loading';
 
+import { CallSnippet } from '@/components/dev/call-snippet';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { serverErrorBody } from '@/lib/api-error-body';
@@ -107,6 +108,14 @@ export function SessionIsolationPanel({ projectId }: { projectId: string }) {
           reachable from that second account, because a wrapper user only ever sees the projects
           they provisioned themselves.
         </p>
+        {/* The rewrite described above, as the request it produces — the query
+            param is on the wire, but the browser is not what puts it there. */}
+        <div className="mt-1.5">
+          <CallSnippet
+            id="sessions.list"
+            context={{ projectId, endUserRef: endUser.data?.userId }}
+          />
+        </div>
       </div>
 
       <ForgedReadProbe projectId={projectId} signedInAs={endUser.data?.userId ?? null} />

--- a/apps/whitelabel-demo/src/components/settings/secrets-tab.tsx
+++ b/apps/whitelabel-demo/src/components/settings/secrets-tab.tsx
@@ -2,6 +2,7 @@
 
 import Loading from '@/components/ui/loading';
 
+import { CallSnippet } from '@/components/dev/call-snippet';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -21,7 +22,11 @@ import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { kortix } from '@/lib/kortix';
 import { qk } from '@/lib/query-keys';
-import { collidingIdentifiers, pendingKeyCollision } from '@/lib/secret-collisions';
+import {
+  collidingIdentifiers,
+  normalizeSecretKey,
+  pendingKeyCollision,
+} from '@/lib/secret-collisions';
 import { scopeExplanation, secretScope } from '@/lib/secret-scope';
 import {
   type SecretWriteIntent,
@@ -216,6 +221,25 @@ export function SecretsTab({ projectId }: { projectId: string }) {
             </Button>
           </div>
         </form>
+
+        {/* Create and rotate are one call, and the snippet takes the identifier
+            and the KEY only — the typed value is never rendered anywhere. */}
+        <div className="mt-3">
+          <CallSnippet
+            id="secret.upsert"
+            context={{
+              projectId,
+              // normalizeSecretKey, not raw trim — the upsert uppercases the KEY
+              // before sending, and KEY collisions are adjudicated on the
+              // uppercased value. A snippet whose whole job is teaching the
+              // identifier-vs-KEY distinction must not print the wrong KEY.
+              secret: {
+                identifier: draftIdentifier || undefined,
+                name: name.trim() ? normalizeSecretKey(name) : undefined,
+              },
+            }}
+          />
+        </div>
       </Card>
 
       <Card className="divide-y divide-border p-0">

--- a/apps/whitelabel-demo/src/components/workbench/approvals-panel.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/approvals-panel.tsx
@@ -18,6 +18,7 @@
 
 import Loading from '@/components/ui/loading';
 
+import { CallSnippet } from '@/components/dev/call-snippet';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -192,6 +193,13 @@ export function SessionApprovals({
             </div>
           );
         })}
+
+        {/* The decision these three buttons send, on the execution id that is
+            actually waiting — the scope is the part people get wrong. */}
+        <CallSnippet
+          id="approval.resolve"
+          context={{ projectId, executionId: view.pending[0]?.executionId }}
+        />
 
         {failure && (
           <div

--- a/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
@@ -11,9 +11,11 @@
  * why THIS session cannot move rather than restating the rule in the abstract.
  */
 
+import { CallSnippet } from '@/components/dev/call-snippet';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ModelSwitcher } from '@/components/workbench/model-switcher';
+import type { CallSnippetId } from '@/lib/call-snippets';
 import { kortix } from '@/lib/kortix';
 import { qk } from '@/lib/query-keys';
 import { isFixedAtStart, readBoundConnections, sessionScopeIsReadable, sessionScopeRows, type ScopeRowKey } from '@/lib/session-scope';
@@ -25,6 +27,16 @@ const ICONS: Record<ScopeRowKey, typeof Lock> = {
   agent: Repeat,
   secrets: Lock,
   connections: Plug,
+};
+
+/**
+ * The call that MOVES a row — only the two rows that can still move have one.
+ * The frozen rows share the create call below, because the honest answer to
+ * "how do I change this?" is "you don't, you start a session".
+ */
+const ROW_CALL: Partial<Record<ScopeRowKey, CallSnippetId>> = {
+  model: 'session.model',
+  agent: 'session.prompt',
 };
 
 export function SessionScope({ projectId, sessionId }: { projectId: string; sessionId: string }) {
@@ -63,6 +75,9 @@ export function SessionScope({ projectId, sessionId }: { projectId: string; sess
     );
   }
 
+  // Read once, out here: the readability check above narrows `session.data`,
+  // and that narrowing does not survive into the row callbacks below.
+  const agentName = session.data.agent_name ?? null;
   const rows = sessionScopeRows({
     agentName: session.data.agent_name,
     // null = never narrowed, which is the opposite of an empty allowlist.
@@ -99,10 +114,44 @@ export function SessionScope({ projectId, sessionId }: { projectId: string; sess
                 <div className="mt-0.5 break-words font-mono text-xs">{row.value}</div>
               )}
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{row.detail}</p>
+              {ROW_CALL[row.key] && (
+                <div className="-ml-2 mt-1">
+                  <CallSnippet
+                    id={ROW_CALL[row.key]!}
+                    context={{ projectId, sessionId, agent: agentName }}
+                  />
+                </div>
+              )}
             </div>
           </div>
         );
       })}
+
+      {/* Everything frozen above was decided in ONE request. Showing it here is
+          the difference between "you can't change this" and "here is where it
+          was chosen" — filled in from what this session actually reports, so it
+          is this session's call rather than an example of one. */}
+      <div className="rounded-md border border-dashed border-border px-3 py-2.5">
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          The frozen rows were fixed by the call that opened this session. The agent and the
+          allowlist below are read back from the session; connector bindings are not — the platform
+          accepts them at create and never serializes them, which is why Lumen keeps its own record.
+        </p>
+        <div className="-ml-2 mt-1">
+          <CallSnippet
+            id="session.create"
+            context={{
+              projectId,
+              sessionId,
+              overrides: {
+                agent: agentName,
+                secrets: session.data.secrets_allowlist ?? null,
+                bindings: {},
+              },
+            }}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
@@ -7,6 +7,7 @@ import { Composer } from '@/components/chat/composer';
 import { MessageView } from '@/components/chat/message-view';
 import { ModelPicker } from '@/components/chat/model-picker';
 import { PermissionPrompt } from '@/components/chat/permission-prompt';
+import { ScopeBar } from '@/components/chat/scope-bar';
 import { QuestionPrompt } from '@/components/chat/question-prompt';
 import { Bubble, BubbleContent } from '@/components/ui/bubble';
 import { Button } from '@/components/ui/button';
@@ -299,6 +300,7 @@ function Thread({ session: c }: { session: UseSessionResult }) {
             }
             commands={c.commands}
             onCommand={c.runCommand}
+            footer={<ScopeBar projectId={c.projectId} sessionId={c.sessionId} />}
             toolbar={
               <div className="flex items-center gap-0.5">
                 <ModelPicker models={c.models} value={c.picks.model} onChange={c.picks.setModel} />

--- a/apps/whitelabel-demo/src/lib/call-snippets.ts
+++ b/apps/whitelabel-demo/src/lib/call-snippets.ts
@@ -1,0 +1,384 @@
+/**
+ * The API call behind every KaaB action this app performs.
+ *
+ * A reference wrapper's real job is to teach what to call, and a screenshot of a
+ * dialog teaches nothing. So each action carries the two forms a wrapper author
+ * actually arrives with:
+ *
+ *  - SDK — the `@kortix/sdk` call this app runs, verbatim.
+ *  - HTTP — the request that ends up on the wire, for anyone integrating from a
+ *    language with no SDK.
+ *
+ * Two rules this module exists to keep:
+ *
+ * 1. NOTHING SECRET IS EVER RENDERED. No secret value, no API key, no bearer
+ *    token — the authorization header is always the `$KORTIX_API_KEY`
+ *    placeholder and a secret's value is always `SECRET_VALUE_PLACEHOLDER`.
+ *    That is why `SnippetContext` accepts a secret's IDENTIFIER and env KEY and
+ *    has nowhere to put a value: a demo that teaches people to paste their key
+ *    into a screenshot is worse than no demo.
+ * 2. THE HTTP FORM SAYS WHO SENDS WHAT. `end_user_ref` is stamped by the proxy
+ *    from the signed-in session (`src/server/end-user.ts`) and the browser can
+ *    neither set nor change it — so every snippet that carries one names it in
+ *    `serverInjected`. A snippet implying the browser sets it would teach
+ *    exactly the vulnerability the design prevents.
+ *
+ * The building is pure and lives here rather than in the panel so what the demo
+ * claims it sends can be asserted without rendering anything.
+ */
+
+import { NO_OVERRIDES, buildSessionCreateInput, type SessionOverrides } from './session-overrides';
+
+/** Rendered wherever a real secret value would otherwise go. */
+export const SECRET_VALUE_PLACEHOLDER = '$SECRET_VALUE';
+
+/** The wrapper's bearer, as a placeholder — never the real key. */
+export const AUTHORIZATION_HEADER = 'Authorization: Bearer $KORTIX_API_KEY';
+
+/** Stand-ins for ids a screen may not have yet (the create dialog runs before
+ *  any session exists). */
+const PLACEHOLDER = {
+  projectId: '{projectId}',
+  sessionId: '{sessionId}',
+  endUserRef: '{end_user_ref}',
+  executionId: '{executionId}',
+  identifier: '{identifier}',
+  envKey: '{ENV_KEY}',
+  model: 'anthropic/claude-sonnet-4-5',
+} as const;
+
+export const CALL_SNIPPET_IDS = [
+  'session.create',
+  'session.prompt',
+  'session.model',
+  'sessions.list',
+  'usage.byEndUser',
+  'usage.forEndUser',
+  'approval.resolve',
+  'secret.upsert',
+] as const;
+
+export type CallSnippetId = (typeof CALL_SNIPPET_IDS)[number];
+
+export interface SnippetContext {
+  projectId?: string;
+  sessionId?: string;
+  /** The signed-in end-user. Shown so the HTTP form is complete — it is still
+   *  the SERVER that puts it on the request. */
+  endUserRef?: string;
+  /** Alias -> human label for the chosen connections. The dialog passes these to
+   *  `buildSessionCreateInput`, so a snippet built without them prints
+   *  `{"slack": "prof_9"}` where the app actually sends
+   *  `{"slack": "Acme Team Slack"}` — drift on the exact override this panel is
+   *  meant to teach. */
+  connectionLabels?: Record<string, string>;
+  /** The create-only overrides currently chosen, so the create snippet shows
+   *  what THIS dialog would send rather than a generic example. */
+  overrides?: SessionOverrides;
+  /** The agent a prompt would name, when one is picked. */
+  agent?: string | null;
+  /** The model a mid-session change would move to. */
+  model?: string | null;
+  executionId?: string;
+  /**
+   * A secret's addressable parts. There is deliberately NO `value` field: this
+   * type is the boundary that keeps secret material out of every snippet.
+   */
+  secret?: { identifier?: string; name?: string };
+}
+
+/**
+ * The HTTP form. `runtime` is not a REST call at all — a prompt goes to the
+ * session's own runtime through the authenticated session proxy, whose URL the
+ * SDK owns and client code is forbidden to build (`scripts/sdk-boundary.mjs`).
+ * Printing a path there would teach hand-rolling the one thing the SDK exists
+ * to hold.
+ */
+export type HttpForm =
+  | { kind: 'rest'; method: string; path: string; body?: unknown }
+  | { kind: 'runtime'; summary: string };
+
+export interface CallSnippet {
+  id: CallSnippetId;
+  /** Names the action as the UI names it, not as the route names it. */
+  title: string;
+  /** One line: what this call is for. */
+  summary: string;
+  /** The `@kortix/sdk` call this app makes. */
+  sdk: string;
+  http: HttpForm;
+  /**
+   * Fields or query params the proxy adds server-side. The browser sends none
+   * of these, and one that names somebody else is refused rather than corrected.
+   */
+  serverInjected: string[];
+  /** The things the two forms above would otherwise imply wrongly. */
+  notes: string[];
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/** `GET /usage?...` and friends, with the end-user ref escaped like the SDK does. */
+function query(params: Record<string, string>): string {
+  const search = new URLSearchParams(params).toString();
+  return search ? `?${search}` : '';
+}
+
+/**
+ * One copy-pasteable request block.
+ *
+ * The authorization line is part of the block on purpose: the single most
+ * common wrapper mistake is forwarding the end user's own token upstream, and
+ * seeing `$KORTIX_API_KEY` on every call is the correction.
+ */
+export function renderHttp(form: HttpForm): string {
+  if (form.kind === 'runtime') return form.summary;
+  const lines = [`${form.method} ${form.path}`, AUTHORIZATION_HEADER];
+  if (form.body === undefined) return lines.join('\n');
+  lines.push('Content-Type: application/json', '', json(form.body));
+  return lines.join('\n');
+}
+
+/** True when the HTTP form is a request someone can copy and run. */
+export function isCopyableHttp(form: HttpForm): boolean {
+  return form.kind === 'rest';
+}
+
+// ── The calls ────────────────────────────────────────────────────────────────
+
+function sessionCreate(ctx: SnippetContext): CallSnippet {
+  const sessionId = ctx.sessionId ?? PLACEHOLDER.sessionId;
+  // Built by the SAME function the dialog submits with, so the snippet cannot
+  // drift from the request: an override the builder omits is omitted here too.
+  const body = buildSessionCreateInput(ctx.overrides ?? NO_OVERRIDES, {
+    sessionId,
+    connectionLabels: ctx.connectionLabels,
+  });
+  // The app never types a session id — `generateSessionId()` produces it — so
+  // the SDK form shows the variable and the HTTP form shows the value.
+  const sdkBody = json(body).replace(`"${sessionId}"`, 'sessionId');
+
+  return {
+    id: 'session.create',
+    title: 'Start a session with overrides',
+    summary: 'Everything a session is scoped to is chosen here, once. There is no update path.',
+    sdk: [
+      "import { generateSessionId } from '@kortix/sdk';",
+      '',
+      'const sessionId = generateSessionId();',
+      `await kortix.project(projectId).sessions.create(${sdkBody});`,
+    ].join('\n'),
+    http: {
+      kind: 'rest',
+      method: 'POST',
+      path: `/v1/projects/${ctx.projectId ?? PLACEHOLDER.projectId}/sessions`,
+      body: { ...body, end_user_ref: ctx.endUserRef ?? PLACEHOLDER.endUserRef },
+    },
+    serverInjected: ['end_user_ref'],
+    notes: [
+      'The browser never sends `end_user_ref`. The proxy adds it from the signed-in session (`src/server/end-user.ts`), and a request that names a different one is refused 403 rather than quietly corrected — a client that could choose it could bill another user or replay their session.',
+      '`agent_name`, `secrets` and `connector_bindings` are CREATE-ONLY: no route updates them afterwards, which is why they are picked before the session exists.',
+      '`secrets` lists secret IDENTIFIERS, not env KEYs. Two identifiers may share one KEY, and naming both in one create is refused 409 SECRET_IDENTIFIER_KEY_COLLISION.',
+      '`inherit_unbound: true` accompanies any binding so the aliases nobody chose keep their project default instead of being switched off.',
+      'The create body also accepts the session model, under a field named after the session runtime — the same field `changeModel()` writes on a running session.',
+    ],
+  };
+}
+
+function sessionPrompt(ctx: SnippetContext): CallSnippet {
+  const agent = ctx.agent ?? null;
+  return {
+    id: 'session.prompt',
+    title: 'Send a prompt (and switch agent per message)',
+    summary: 'Each message names the agent that runs it — the one override that moves mid-session.',
+    sdk: [
+      'await kortix',
+      '  .session(projectId, sessionId)',
+      agent
+        ? `  .send('Refund order 4182', { agent: '${agent}' });`
+        : "  .send('Refund order 4182');",
+      '',
+      '// Or make the choice sticky for every following message:',
+      `kortix.session(projectId, sessionId).setAgent(${agent ? `'${agent}'` : "'support'"});`,
+    ].join('\n'),
+    http: {
+      kind: 'runtime',
+      summary:
+        'A prompt is not a REST call. It goes to the session runtime through the authenticated session proxy, and the SDK owns that URL — `ensureReady()` resolves the runtime, then sends the message. Client code is forbidden from building the path (scripts/sdk-boundary.mjs), so integrate through the SDK rather than reconstructing it.',
+    },
+    serverInjected: [],
+    notes: [
+      'The agent is per MESSAGE, not per session: `send(text, { agent })` overrides the sticky pick for that one turn.',
+      'A switch to an agent with a DIFFERENT secrets grant is refused 409 AGENT_SWITCH_REQUIRES_NEW_SESSION. Retrying cannot work — the sandbox is already provisioned for the agent it booted with, and re-scoping now cannot un-read what that agent loaded. The remedy is a new session.',
+    ],
+  };
+}
+
+function sessionModel(ctx: SnippetContext): CallSnippet {
+  const model = ctx.model ?? PLACEHOLDER.model;
+  const projectId = ctx.projectId ?? PLACEHOLDER.projectId;
+  const sessionId = ctx.sessionId ?? PLACEHOLDER.sessionId;
+
+  return {
+    id: 'session.model',
+    title: 'Change the model mid-session',
+    summary: 'The one create-time override that is still movable once a session is running.',
+    sdk: [
+      '// Server side (src/app/api/session-model/route.ts):',
+      `await kortix.session(projectId, sessionId).changeModel('${model}');`,
+      '',
+      '// Browser side — this app goes through its own route, so the runtime-named',
+      '// field stays server-side and client code says `model`:',
+      `await fetch('/api/session-model?projectId=${projectId}&sessionId=${sessionId}', {`,
+      "  method: 'PUT',",
+      `  body: JSON.stringify({ model: '${model}' }),`,
+      '});',
+    ].join('\n'),
+    http: {
+      kind: 'rest',
+      method: 'PUT',
+      path: `/v1/projects/${projectId}/sessions/${sessionId}/model`,
+      body: { '<runtime>_model': model },
+    },
+    serverInjected: [],
+    notes: [
+      'The upstream body field is named after the session runtime; `changeModel()` writes it for you. This app never spells it in client code (scripts/sdk-boundary.mjs keeps provider terminology out of the browser bundle) — the real field name is in `src/app/api/session-model/route.ts`.',
+      'The reply carries `applied_live`. False means the model was stored and applies at the NEXT start; telling someone the model changed when their next answer comes from the old one is a lie worth avoiding.',
+      'A live change restarts the runtime, which ends any in-flight turn.',
+    ],
+  };
+}
+
+function sessionsList(ctx: SnippetContext): CallSnippet {
+  const endUserRef = ctx.endUserRef ?? PLACEHOLDER.endUserRef;
+  return {
+    id: 'sessions.list',
+    title: "List one end-user's sessions",
+    summary: 'The read that keeps two signed-in people apart when one API key makes every call.',
+    sdk: 'await kortix.project(projectId).sessions.list();',
+    http: {
+      kind: 'rest',
+      method: 'GET',
+      path: `/v1/projects/${ctx.projectId ?? PLACEHOLDER.projectId}/sessions${query({
+        end_user_ref: endUserRef,
+      })}`,
+    },
+    serverInjected: ['end_user_ref'],
+    notes: [
+      'The browser asks for nothing: the proxy rewrites the query to the signed-in `end_user_ref` before it goes upstream. Without that, any signed-in user could read every other one\'s session list by adding the parameter themselves.',
+      'A browser that names somebody else is refused 403 — the attempt surfaces rather than looking like it worked. The Isolation panel fires exactly that request so the refusal can be seen rather than trusted.',
+      'A wrapper calling upstream directly with its own key DOES send this parameter — filtering happens server-side, so it never has to fetch a whole project to answer "show me this customer\'s sessions".',
+    ],
+  };
+}
+
+function usageByEndUser(): CallSnippet {
+  return {
+    id: 'usage.byEndUser',
+    title: 'Read usage split per end-user',
+    summary: 'Upstream bills the account once; this is what splits that bill back out.',
+    sdk: "await kortix.billing.usageRollup({ groupBy: 'end_user_ref' });",
+    http: {
+      kind: 'rest',
+      method: 'GET',
+      path: `/v1/usage${query({ group_by: 'end_user_ref' })}`,
+    },
+    serverInjected: [],
+    notes: [
+      'Account-wide, so this runs SERVER-side in `/api/usage` and is not reachable from the browser: `src/server/policy.ts` is deny-by-default and permits no `/usage` route to an end user.',
+      'Spend with no `end_user_ref` (dashboard sessions, anything predating the field) has a NULL key and is excluded from the grouping — the rows do NOT add up to the account total, and the difference is the unattributed remainder.',
+    ],
+  };
+}
+
+function usageForEndUser(ctx: SnippetContext): CallSnippet {
+  const endUserRef = ctx.endUserRef ?? PLACEHOLDER.endUserRef;
+  return {
+    id: 'usage.forEndUser',
+    title: 'Read one end-user’s usage',
+    summary: 'The query a wrapper runs to answer "what does this customer owe me".',
+    sdk: `await kortix.billing.usageRollup({ endUserRef: '${endUserRef}' });`,
+    http: {
+      kind: 'rest',
+      method: 'GET',
+      path: `/v1/usage${query({ end_user_ref: endUserRef })}`,
+    },
+    serverInjected: ['end_user_ref'],
+    notes: [
+      'Narrowing applies to the TOTALS as well as the breakdown, so this is one end-user’s bill rather than the account’s total with one row highlighted.',
+      'The ref is the signed-in identity, taken from the verified session server-side — the same value the proxy stamps on session creates, which is what makes the two numbers comparable.',
+    ],
+  };
+}
+
+function approvalResolve(ctx: SnippetContext): CallSnippet {
+  const projectId = ctx.projectId ?? PLACEHOLDER.projectId;
+  const executionId = ctx.executionId ?? PLACEHOLDER.executionId;
+  return {
+    id: 'approval.resolve',
+    title: 'Resolve an approval',
+    summary: 'A `require_approval` gate ends the agent’s turn until a person decides.',
+    sdk: `await kortix.project(projectId).approvals.resolve('${executionId}', 'approve', 'once');`,
+    http: {
+      kind: 'rest',
+      method: 'POST',
+      path: `/v1/projects/${projectId}/approvals/${executionId}`,
+      body: { decision: 'approve', scope: 'once' },
+    },
+    serverInjected: [],
+    notes: [
+      'Three scopes, three different promises: `once` decides this call, `session` stops asking for THIS connector+action for the rest of the session, `session_all` stops asking for anything.',
+      'The pending set is read from the per-SESSION audit, not the project-wide approval inbox: in wrapper mode one operator credential makes every call, so the inbox would hand this browser other end-users’ execution ids — and an execution id is all this route needs.',
+      'Some refusals cannot be retried with the same credential at all; they need a decision from a signed-in person. A wrapper has no personal upstream identity, which is also why `require_connectors` is refused 403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY.',
+    ],
+  };
+}
+
+function secretUpsert(ctx: SnippetContext): CallSnippet {
+  const identifier = ctx.secret?.identifier ?? PLACEHOLDER.identifier;
+  const name = ctx.secret?.name ?? PLACEHOLDER.envKey;
+  const body = { identifier, name, value: SECRET_VALUE_PLACEHOLDER };
+
+  return {
+    id: 'secret.upsert',
+    title: 'Create or rotate a secret',
+    summary: 'One call does both — the identifier is what decides which.',
+    sdk: `await kortix.project(projectId).secrets.upsert(${json(body)});`,
+    http: {
+      kind: 'rest',
+      method: 'POST',
+      path: `/v1/projects/${ctx.projectId ?? PLACEHOLDER.projectId}/secrets`,
+      body,
+    },
+    serverInjected: [],
+    notes: [
+      `The value is never rendered here: \`${SECRET_VALUE_PLACEHOLDER}\` is a placeholder, and this builder has nowhere to put a real one. Read it from your own environment at the call site.`,
+      'A new `identifier` creates; an existing one rotates in place, keeping its env KEY so every agent grant and session allowlist that names it keeps working.',
+      'Pointing an existing identifier at a DIFFERENT env KEY is refused — the identifier is a stable handle, and re-aiming it would silently re-aim every grant that names it.',
+      'Rotation reaches running sessions late: their agent already started with the old environment, and a live process cannot have its environment rewritten.',
+    ],
+  };
+}
+
+const BUILDERS: Record<CallSnippetId, (ctx: SnippetContext) => CallSnippet> = {
+  'session.create': sessionCreate,
+  'session.prompt': sessionPrompt,
+  'session.model': sessionModel,
+  'sessions.list': sessionsList,
+  'usage.byEndUser': usageByEndUser,
+  'usage.forEndUser': usageForEndUser,
+  'approval.resolve': approvalResolve,
+  'secret.upsert': secretUpsert,
+};
+
+/** One action's snippet, filled in with whatever the screen actually knows. */
+export function callSnippet(id: CallSnippetId, ctx: SnippetContext = {}): CallSnippet {
+  return BUILDERS[id](ctx);
+}
+
+/** Every snippet, in the order a wrapper author meets them. */
+export function callSnippets(ctx: SnippetContext = {}): CallSnippet[] {
+  return CALL_SNIPPET_IDS.map((id) => callSnippet(id, ctx));
+}

--- a/apps/whitelabel-demo/tests/e2e/call-snippets.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/call-snippets.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  AUTHORIZATION_HEADER,
+  CALL_SNIPPET_IDS,
+  SECRET_VALUE_PLACEHOLDER,
+  type SnippetContext,
+  callSnippet,
+  callSnippets,
+  isCopyableHttp,
+  renderHttp,
+} from '../../src/lib/call-snippets';
+import { NO_OVERRIDES, buildSessionCreateInput } from '../../src/lib/session-overrides';
+
+const PROJECT_ID = '11111111-1111-4111-8111-111111111111';
+const SESSION_ID = '00000000-0000-4000-8000-000000000001';
+const END_USER = 'someone@example.com';
+
+/** Everything one snippet renders, as one string — the shape a screenshot has. */
+function rendered(id: (typeof CALL_SNIPPET_IDS)[number], ctx: SnippetContext = {}): string {
+  const snippet = callSnippet(id, ctx);
+  return [snippet.title, snippet.summary, snippet.sdk, renderHttp(snippet.http), ...snippet.notes]
+    .join('\n');
+}
+
+/** Everything EVERY snippet renders, for the invariants that must hold globally. */
+function renderedAll(ctx: SnippetContext = {}): string {
+  return CALL_SNIPPET_IDS.map((id) => rendered(id, ctx)).join('\n');
+}
+
+describe('call snippets never render credentials', () => {
+  /**
+   * The exact hazard: `GET /projects/{id}/secrets` returns rows, a screen holds
+   * one, and a careless snippet builder spreads it into a request body. The
+   * builder has to PICK the identifier and the env KEY — which is why
+   * `SnippetContext['secret']` has no `value` field at all.
+   */
+  const fromSecretsApi = {
+    identifier: 'STRIPE_KEY',
+    name: 'STRIPE_SECRET_KEY',
+    value: 'sk-live-DO-NOT-RENDER-4f9c',
+    configured: true,
+    effective_source: 'shared',
+    mine: { active: true, value: 'sk-live-personal-DO-NOT-RENDER-11a2' },
+  };
+
+  test('a secret row from the API cannot leak into any snippet', () => {
+    // Passed the way a careless caller would pass it — the whole API row.
+    const text = renderedAll({
+      projectId: PROJECT_ID,
+      secret: fromSecretsApi as SnippetContext['secret'],
+    });
+    expect(text).not.toContain(fromSecretsApi.value);
+    expect(text).not.toContain(fromSecretsApi.mine.value);
+    // The addressable parts are exactly what SHOULD show up.
+    expect(text).toContain('STRIPE_KEY');
+    expect(text).toContain('STRIPE_SECRET_KEY');
+  });
+
+  test('a secret value is always the placeholder', () => {
+    const snippet = callSnippet('secret.upsert', {
+      secret: fromSecretsApi as SnippetContext['secret'],
+    });
+    expect(snippet.sdk).toContain(SECRET_VALUE_PLACEHOLDER);
+    expect(renderHttp(snippet.http)).toContain(SECRET_VALUE_PLACEHOLDER);
+  });
+
+  test('the bearer is only ever the placeholder', () => {
+    const text = renderedAll({ projectId: PROJECT_ID, endUserRef: END_USER });
+    // Any `Bearer` that is not the placeholder is a real token in a snippet.
+    expect(text.match(/Bearer (?!\$KORTIX_API_KEY)\S+/)).toBeNull();
+  });
+
+  test('every HTTP request carries the placeholder authorization line', () => {
+    for (const snippet of callSnippets({ projectId: PROJECT_ID })) {
+      if (!isCopyableHttp(snippet.http)) continue;
+      expect(renderHttp(snippet.http)).toContain(AUTHORIZATION_HEADER);
+    }
+  });
+});
+
+describe('end_user_ref is shown as server-injected', () => {
+  test('the create body carries it — and says the browser does not send it', () => {
+    const snippet = callSnippet('session.create', {
+      projectId: PROJECT_ID,
+      endUserRef: END_USER,
+    });
+    expect(renderHttp(snippet.http)).toContain(`"end_user_ref": "${END_USER}"`);
+    expect(snippet.serverInjected).toContain('end_user_ref');
+    // The SDK form is the BROWSER's call. A create body with end_user_ref in it
+    // would teach the one thing the proxy refuses 403.
+    expect(snippet.sdk).not.toContain('end_user_ref');
+  });
+
+  test('the session list is filtered in the query, not by the browser', () => {
+    const snippet = callSnippet('sessions.list', {
+      projectId: PROJECT_ID,
+      endUserRef: END_USER,
+    });
+    expect(renderHttp(snippet.http)).toContain('end_user_ref=someone%40example.com');
+    expect(snippet.serverInjected).toContain('end_user_ref');
+    expect(snippet.sdk).not.toContain('end_user_ref');
+  });
+
+  test('nothing claims the server injects a field it does not', () => {
+    // The badge is a security claim; it belongs only on calls the proxy touches.
+    const injected = callSnippets().filter((s) => s.serverInjected.length > 0).map((s) => s.id);
+    expect(injected.sort()).toEqual(['session.create', 'sessions.list', 'usage.forEndUser']);
+  });
+});
+
+describe('the create snippet is the request the dialog would send', () => {
+  test('an untouched dialog shows the bare create', () => {
+    const snippet = callSnippet('session.create', { overrides: NO_OVERRIDES });
+    expect(snippet.sdk).not.toContain('agent_name');
+    expect(snippet.sdk).not.toContain('secrets');
+    expect(snippet.sdk).not.toContain('connector_bindings');
+  });
+
+  test('the chosen overrides are the ones rendered', () => {
+    const snippet = callSnippet('session.create', {
+      projectId: PROJECT_ID,
+      sessionId: SESSION_ID,
+      overrides: { agent: 'support', secrets: ['STRIPE_KEY'], bindings: { slack: 'prof_9' } },
+    });
+    expect(snippet.sdk).toContain('"agent_name": "support"');
+    expect(snippet.sdk).toContain('"secrets"');
+    expect(snippet.sdk).toContain('"profile_id": "prof_9"');
+    // Binding one alias must not read as unplugging the others.
+    expect(snippet.sdk).toContain('"inherit_unbound": true');
+  });
+
+  test('the session id is a generated variable, not something to type', () => {
+    const snippet = callSnippet('session.create', { sessionId: SESSION_ID });
+    expect(snippet.sdk).toContain('generateSessionId()');
+    expect(snippet.sdk).toContain('"session_id": sessionId');
+    // The wire form still shows the concrete value.
+    expect(renderHttp(snippet.http)).toContain(`"session_id": "${SESSION_ID}"`);
+  });
+
+  test('the path is the project the screen is on', () => {
+    const snippet = callSnippet('session.create', { projectId: PROJECT_ID });
+    expect(renderHttp(snippet.http)).toContain(`POST /v1/projects/${PROJECT_ID}/sessions`);
+  });
+});
+
+describe('the other calls', () => {
+  test('a prompt has no REST path to copy — the SDK owns the runtime transport', () => {
+    const snippet = callSnippet('session.prompt', { agent: 'support' });
+    expect(isCopyableHttp(snippet.http)).toBe(false);
+    expect(snippet.sdk).toContain(".send('Refund order 4182', { agent: 'support' })");
+    // Printing a runtime path here is exactly what scripts/sdk-boundary.mjs
+    // forbids client code from constructing.
+    expect(rendered('session.prompt')).not.toContain('/v1/p/');
+  });
+
+  test('the model change shows both hops and neither spells the runtime field', () => {
+    const snippet = callSnippet('session.model', {
+      projectId: PROJECT_ID,
+      sessionId: SESSION_ID,
+      model: 'anthropic/claude-sonnet-4-5',
+    });
+    expect(snippet.sdk).toContain("changeModel('anthropic/claude-sonnet-4-5')");
+    expect(snippet.sdk).toContain('/api/session-model');
+    expect(renderHttp(snippet.http)).toContain(
+      `PUT /v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/model`,
+    );
+    expect(rendered('session.model').toLowerCase()).not.toContain('opencode');
+  });
+
+  test('usage is read both grouped and narrowed', () => {
+    expect(renderHttp(callSnippet('usage.byEndUser').http)).toContain(
+      'GET /v1/usage?group_by=end_user_ref',
+    );
+    expect(renderHttp(callSnippet('usage.forEndUser', { endUserRef: END_USER }).http)).toContain(
+      'GET /v1/usage?end_user_ref=someone%40example.com',
+    );
+  });
+
+  test('an approval resolves by execution id, with the scope named', () => {
+    const snippet = callSnippet('approval.resolve', {
+      projectId: PROJECT_ID,
+      executionId: 'exec_42',
+    });
+    expect(renderHttp(snippet.http)).toContain(
+      `POST /v1/projects/${PROJECT_ID}/approvals/exec_42`,
+    );
+    expect(renderHttp(snippet.http)).toContain('"scope": "once"');
+  });
+
+  test('a secret is addressed by identifier', () => {
+    const snippet = callSnippet('secret.upsert', {
+      projectId: PROJECT_ID,
+      secret: { identifier: 'GMAPS-backup', name: 'GOOGLE_MAPS_API_KEY' },
+    });
+    expect(snippet.sdk).toContain('"identifier": "GMAPS-backup"');
+    expect(snippet.sdk).toContain('"name": "GOOGLE_MAPS_API_KEY"');
+  });
+});
+
+describe('every snippet is complete', () => {
+  test('each one has both forms and at least one note', () => {
+    for (const snippet of callSnippets()) {
+      expect(snippet.sdk.trim().length).toBeGreaterThan(0);
+      expect(renderHttp(snippet.http).trim().length).toBeGreaterThan(0);
+      expect(snippet.notes.length).toBeGreaterThan(0);
+      // A blank placeholder would render as `/v1/projects//sessions`.
+      expect(renderHttp(snippet.http)).not.toContain('//sessions');
+    }
+  });
+
+  test('ids are unique and every id builds', () => {
+    const ids = callSnippets().map((s) => s.id);
+    expect(new Set(ids).size).toBe(CALL_SNIPPET_IDS.length);
+    expect(ids).toEqual([...CALL_SNIPPET_IDS]);
+  });
+});
+
+describe('the create snippet cannot drift from what the app sends', () => {
+  test('a bound connection prints its LABEL, not the raw profile id', () => {
+    // The panel's whole value is "this is the call this app runs". The first cut
+    // built the body without `connectionLabels`, which the dialog does pass — so
+    // it printed {"slack": "prof_9"} where the app sends
+    // {"slack": "Acme Team Slack"}: drift on the exact override the panel exists
+    // to teach.
+    const withLabels = callSnippet('session.create', {
+      projectId: 'p1',
+      overrides: { ...NO_OVERRIDES, bindings: { slack: 'prof_9' } },
+      connectionLabels: { slack: 'Acme Team Slack' },
+    });
+    const printed = `${withLabels?.sdk ?? ''}${renderHttp(withLabels!.http)}`;
+    expect(printed).toContain('Acme Team Slack');
+  });
+
+  test('the same builder the submit path uses produces the body', () => {
+    // Guards the mechanism rather than one output: if someone hand-rolls the
+    // body here again, an override added to buildSessionCreateInput stops
+    // appearing and this goes red.
+    const overrides = { ...NO_OVERRIDES, agent: 'reviewer', secrets: ['GMAIL'] };
+    const snippet = callSnippet('session.create', { projectId: 'p1', overrides });
+    const expected = buildSessionCreateInput(overrides, { sessionId: 'SID' });
+    for (const key of Object.keys(expected)) {
+      if (key === 'session_id') continue;
+      expect(`${snippet?.sdk ?? ''}${renderHttp(snippet!.http)}`).toContain(key);
+    }
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
@@ -1,0 +1,364 @@
+import type { ProjectSecret } from '@kortix/sdk';
+import { describe, expect, test } from 'bun:test';
+import {
+  MISSING_SECRET_NOTE,
+  NEW_IDENTIFIER_HINT,
+  SECRET_MEMBERSHIP_LABEL,
+  START_NEW_SESSION_ACTION,
+  classifyTypedIdentifier,
+  scopeBarConnectors,
+  scopeBarSecrets,
+  scopeControl,
+  scopeDraftIssues,
+  seedBindingsFromLabels,
+} from '../../src/components/chat/scope-bar-model';
+import { BOUND_CONNECTIONS_KEY, buildSessionCreateInput } from '../../src/lib/session-overrides';
+import { readBoundConnections } from '../../src/lib/session-scope';
+import { selectConnectorBindingChoices } from '../../src/server/bindable-connections';
+
+const secret = (identifier: string, name: string, over: Record<string, unknown> = {}) =>
+  ({
+    identifier,
+    name,
+    project_id: 'P1',
+    secret_id: `s-${identifier}`,
+    created_by: null,
+    created_at: null,
+    updated_at: null,
+    configured: true,
+    mine: null,
+    effective_source: 'shared',
+    can_manage_shared: true,
+    ...over,
+  }) as ProjectSecret;
+
+const profile = (over: Record<string, unknown> = {}) =>
+  ({
+    profile_id: 'p1',
+    connector_alias: 'gmail',
+    owner_type: 'project',
+    owner_id: null,
+    label: 'Support',
+    status: 'active',
+    is_default: false,
+    metadata: {},
+    ...over,
+  }) as never;
+
+// ── The whole point of the bar: which control may touch THIS session ─────────
+
+describe('scopeControl', () => {
+  test('secrets and connections are never live-editable on a running session', () => {
+    // The single worst outcome for this bar is a switch that looks like it
+    // re-scopes a running session. `secrets` has no update path anywhere, and
+    // `connector_bindings` is accepted at create and never again — so the
+    // component asks this before it decides what to render.
+    expect(scopeControl('secrets').live).toBe(false);
+    expect(scopeControl('connections').live).toBe(false);
+  });
+
+  test('the model and the per-message agent are the two that can move now', () => {
+    expect(scopeControl('model').live).toBe(true);
+    expect(scopeControl('agent').live).toBe(true);
+  });
+
+  test('a frozen row says "fixed at start", so the badge cannot drift from the rule', () => {
+    expect(scopeControl('secrets').badge).toBe('Fixed at start');
+    expect(scopeControl('connections').badge).toBe('Fixed at start');
+    expect(scopeControl('agent').badge).toBe('Per message');
+  });
+
+  test('the model note does not promise the change takes effect immediately', () => {
+    // `applied_live: false` is a real response. A user told "now running X"
+    // whose next answer comes from the old model has been lied to.
+    expect(scopeControl('model').note).toContain('next time this session starts');
+  });
+
+  test('a frozen row explains why THIS session cannot move, not what an allowlist is', () => {
+    // NB: asserting the string EXISTS is not the same as asserting it is shown.
+    // The first cut passed this while the secrets popover rendered only the live
+    // summary, so the frozen explanation was dead copy. The render-site test
+    // below is the one that would have caught it.
+    expect(scopeControl('secrets').note).toContain('no update path');
+    expect(scopeControl('connections').note).toContain('project default');
+  });
+
+  test('a frozen row is not LIVE, which is what makes its note get rendered', () => {
+    expect(scopeControl('secrets').live).toBe(false);
+    expect(scopeControl('connections').live).toBe(false);
+    // The model is the one that genuinely moves mid-session.
+    expect(scopeControl('model').live).toBe(true);
+  });
+
+  test('the only action a frozen row offers is a new session', () => {
+    // Not "apply", not "save" — nothing on a running session accepts either.
+    expect(START_NEW_SESSION_ACTION.toLowerCase()).toContain('new session');
+  });
+});
+
+// ── Secrets: in, out, and the ones that are neither ──────────────────────────
+
+describe('scopeBarSecrets', () => {
+  const items = [
+    secret('STRIPE', 'STRIPE_API_KEY'),
+    secret('GMAIL', 'GMAIL_TOKEN'),
+    secret('SENTRY', 'SENTRY_DSN'),
+  ];
+
+  test('an allowlist splits the project list into allowed and excluded', () => {
+    const scope = scopeBarSecrets({ secrets: items, allowlist: ['STRIPE'] });
+    expect(scope.rows.map((row) => [row.identifier, row.membership])).toEqual([
+      ['STRIPE', 'allowed'],
+      ['GMAIL', 'excluded'],
+      ['SENTRY', 'excluded'],
+    ]);
+    expect(scope.summary).toBe('1 allowed');
+  });
+
+  test('every row carries the identifier AND the env KEY, because they differ', () => {
+    // The allowlist addresses the IDENTIFIER; the sandbox sees the KEY. Showing
+    // only one of them makes the allowlist unreadable against the sandbox.
+    const scope = scopeBarSecrets({ secrets: items, allowlist: ['STRIPE'] });
+    expect(scope.rows[0]).toMatchObject({ identifier: 'STRIPE', name: 'STRIPE_API_KEY' });
+  });
+
+  test('no allowlist is "agent grant", never "allowed" and never empty', () => {
+    // null (never narrowed) and [] (narrowed to nothing) are opposite states.
+    // And a session that never narrowed reads whatever its AGENT is granted —
+    // a set this app cannot enumerate, so claiming "allowed" here would be a
+    // statement about secret access that nothing verified.
+    const wide = scopeBarSecrets({ secrets: items, allowlist: null });
+    expect(wide.narrowed).toBe(false);
+    expect(wide.rows.every((row) => row.membership === 'agent_grant')).toBe(true);
+    expect(wide.summary).toBe('Agent grant');
+    expect(wide.detail).toContain('can be fewer');
+  });
+
+  test('an empty allowlist reads as a choice, not as an empty state', () => {
+    const none = scopeBarSecrets({ secrets: items, allowlist: [] });
+    expect(none.narrowed).toBe(true);
+    expect(none.summary).toBe('None');
+    expect(none.rows.every((row) => row.membership === 'excluded')).toBe(true);
+  });
+
+  test('a channel-install row is not offered as "excluded" — nobody could allow it', () => {
+    // Create resolves the allowlist against runtime-scoped rows only, so a
+    // Slack install row was never a decision anyone made.
+    const scope = scopeBarSecrets({
+      secrets: [...items, secret('SLACK_BOT_TOKEN', 'SLACK_BOT_TOKEN')],
+      allowlist: ['STRIPE'],
+    });
+    expect(scope.rows.map((row) => row.identifier)).not.toContain('SLACK_BOT_TOKEN');
+  });
+
+  test('an allowlisted identifier that no longer exists is named, not silently dropped', () => {
+    // The allowlist is frozen; the project's secrets are not. A session can
+    // outlive a secret it names, and showing "3 allowed" over a list of two is
+    // how that becomes invisible.
+    const scope = scopeBarSecrets({ secrets: items, allowlist: ['STRIPE', 'DELETED'] });
+    expect(scope.missing).toEqual(['DELETED']);
+    expect(MISSING_SECRET_NOTE).toContain('not a project secret now');
+  });
+
+  test('membership labels never call an un-narrowed session "allowed"', () => {
+    expect(SECRET_MEMBERSHIP_LABEL.agent_grant).not.toBe(SECRET_MEMBERSHIP_LABEL.allowed);
+  });
+
+  test('a project with no secrets is an empty list, not a crash', () => {
+    expect(scopeBarSecrets({ secrets: undefined, allowlist: undefined }).rows).toEqual([]);
+  });
+});
+
+// ── The draft: a session cannot mint a secret ───────────────────────────────
+
+describe('the identifier field says what a session cannot do', () => {
+  const items = [secret('STRIPE', 'STRIPE_API_KEY')];
+
+  test('a typed identifier that does not exist yet is recognised as new', () => {
+    expect(classifyTypedIdentifier('NEW_ONE', { secrets: items, draft: [] })).toEqual({
+      kind: 'unknown',
+      identifier: 'NEW_ONE',
+    });
+    expect(classifyTypedIdentifier('  STRIPE  ', { secrets: items, draft: [] })).toEqual({
+      kind: 'existing',
+      identifier: 'STRIPE',
+    });
+    expect(classifyTypedIdentifier('STRIPE', { secrets: items, draft: ['STRIPE'] })).toEqual({
+      kind: 'already_listed',
+      identifier: 'STRIPE',
+    });
+    expect(classifyTypedIdentifier('   ', { secrets: items, draft: [] })).toEqual({ kind: 'empty' });
+  });
+
+  test('the hint names the actual flow: create it in Settings, then start a session', () => {
+    // This app can list a project's secrets and cannot mint one. Anything less
+    // explicit leaves "type a name here" reading like "create a secret".
+    expect(NEW_IDENTIFIER_HINT).toContain('Settings → Secrets');
+    expect(NEW_IDENTIFIER_HINT).toContain('cannot create one');
+    expect(NEW_IDENTIFIER_HINT).toContain('refused');
+  });
+});
+
+describe('scopeDraftIssues', () => {
+  test('an identifier with no secret behind it is refused before the create is tried', () => {
+    // 404 SECRET_IDENTIFIER_NOT_FOUND, and an allowlist can never be edited
+    // afterwards — so this is not a recoverable mistake to discover later.
+    const issues = scopeDraftIssues(['MISSING'], [secret('STRIPE', 'STRIPE_API_KEY')]);
+    expect(issues.map((issue) => issue.kind)).toEqual(['not_created']);
+    expect(issues[0]!.message).toContain('Settings → Secrets');
+  });
+
+  test('two drafted identifiers sharing one env KEY are caught', () => {
+    // 409 SECRET_IDENTIFIER_KEY_COLLISION: the sandbox cannot be handed two
+    // values for one variable, and the allowlist cannot be edited to fix it.
+    const items = [
+      secret('GMAPS-primary', 'GOOGLE_MAPS_API_KEY'),
+      secret('GMAPS-backup', 'GOOGLE_MAPS_API_KEY'),
+    ];
+    const issues = scopeDraftIssues(['GMAPS-primary', 'GMAPS-backup'], items);
+    expect(issues.map((issue) => issue.kind)).toEqual(['key_collision', 'key_collision']);
+    expect(issues[0]!.conflicts).toEqual(['GMAPS-backup']);
+    expect(issues[0]!.message).toContain('GOOGLE_MAPS_API_KEY');
+  });
+
+  test('picking only ONE of two identifiers on a shared KEY is fine', () => {
+    const items = [
+      secret('GMAPS-primary', 'GOOGLE_MAPS_API_KEY'),
+      secret('GMAPS-backup', 'GOOGLE_MAPS_API_KEY'),
+    ];
+    expect(scopeDraftIssues(['GMAPS-primary'], items)).toEqual([]);
+  });
+
+  test('an ordinary draft has nothing to say', () => {
+    expect(scopeDraftIssues(['STRIPE'], [secret('STRIPE', 'STRIPE_API_KEY')])).toEqual([]);
+    expect(scopeDraftIssues([], [])).toEqual([]);
+  });
+});
+
+// ── Connections ─────────────────────────────────────────────────────────────
+
+describe('scopeBarConnectors', () => {
+  test('an alias with nothing bindable carries the reason and a teammate-shaped remedy', () => {
+    const choices = selectConnectorBindingChoices([profile({ owner_type: 'member', owner_id: 'u1' })]);
+    const [row] = scopeBarConnectors({ choices, boundConnections: {} }).rows;
+    expect(row!.unavailable).toBe('private_only');
+    expect(row!.notice!.detail).toContain('teammate');
+    // A wrapper has no personal upstream identity, so "connect it yourself"
+    // could only ever lead to 403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY.
+    expect(row!.notice!.selfServiceAction).toBeNull();
+  });
+
+  test('a revoked TEAM connection asks for a reconnect, not a first-time share', () => {
+    const choices = selectConnectorBindingChoices([profile({ status: 'revoked' })]);
+    expect(scopeBarConnectors({ choices, boundConnections: {} }).rows[0]!.notice!.detail).toContain(
+      'reconnect',
+    );
+  });
+
+  test('a bindable alias gets no notice — the picker speaks for itself', () => {
+    const choices = selectConnectorBindingChoices([profile()]);
+    const [row] = scopeBarConnectors({ choices, boundConnections: {} }).rows;
+    expect(row!.notice).toBeNull();
+    expect(row!.choices.map((connection) => connection.label)).toEqual(['Support']);
+  });
+
+  test("this session's binding is shown per alias, with the unbound ones on the default", () => {
+    const choices = selectConnectorBindingChoices([
+      profile(),
+      profile({ connector_alias: 'slack', profile_id: 'p2', label: 'Team slack' }),
+    ]);
+    const { rows, summary } = scopeBarConnectors({
+      choices,
+      boundConnections: { gmail: 'Support' },
+    });
+    expect(rows.map((row) => [row.alias, row.bound])).toEqual([
+      ['gmail', 'Support'],
+      ['slack', null],
+    ]);
+    expect(summary).toBe('1 bound');
+  });
+
+  test('an alias bound to a connection that has since vanished still gets a row', () => {
+    // Dropping it would claim the session runs on the project default, which is
+    // exactly what it does not do — the binding is frozen into the sandbox.
+    const { rows } = scopeBarConnectors({ choices: [], boundConnections: { gmail: 'Support' } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.bound).toBe('Support');
+    // ...and no cause is invented for it: nothing reported a reason.
+    expect(rows[0]!.unavailable).toBeNull();
+    expect(rows[0]!.notice).toBeNull();
+  });
+
+  test('nothing bound reads as project defaults, and no connectors reads as none', () => {
+    const choices = selectConnectorBindingChoices([profile()]);
+    expect(scopeBarConnectors({ choices, boundConnections: {} }).summary).toBe('Project defaults');
+    expect(scopeBarConnectors({ choices: undefined, boundConnections: {} }).summary).toBe('None');
+  });
+});
+
+describe('seedBindingsFromLabels', () => {
+  test("the running session's bindings become the next session's defaults", () => {
+    // The platform never serializes `connector_bindings` back, so the label this
+    // wrapper recorded at create is the only bridge from a running session to
+    // the create body of the next one.
+    const created = buildSessionCreateInput(
+      { agent: null, secrets: null, bindings: { gmail: 'p1' } },
+      { sessionId: 's', connectionLabels: { gmail: 'Support' } },
+    );
+    const { rows } = scopeBarConnectors({
+      choices: selectConnectorBindingChoices([profile()]),
+      boundConnections: readBoundConnections(created.metadata),
+    });
+    expect(seedBindingsFromLabels(rows)).toEqual({ gmail: 'p1' });
+    expect(created.metadata?.[BOUND_CONNECTIONS_KEY]).toEqual({ gmail: 'Support' });
+  });
+
+  test('a label with no label recorded falls back to the profile id it stored', () => {
+    const created = buildSessionCreateInput(
+      { agent: null, secrets: null, bindings: { gmail: 'p1' } },
+      { sessionId: 's' },
+    );
+    const { rows } = scopeBarConnectors({
+      choices: selectConnectorBindingChoices([profile()]),
+      boundConnections: readBoundConnections(created.metadata),
+    });
+    expect(seedBindingsFromLabels(rows)).toEqual({ gmail: 'p1' });
+  });
+
+  test('a binding that no longer resolves is left out rather than sent as a guess', () => {
+    // An unresolvable alias lands on the project default — where an unbindable
+    // one would end up anyway. Sending a stale profile id would fail the create.
+    const { rows } = scopeBarConnectors({ choices: [], boundConnections: { gmail: 'Support' } });
+    expect(seedBindingsFromLabels(rows)).toEqual({});
+  });
+});
+
+// ── What the draft actually sends ───────────────────────────────────────────
+
+describe('the draft carried into the next session', () => {
+  test('an untouched draft reproduces this session, allowlist and all', () => {
+    const body = buildSessionCreateInput(
+      { agent: 'support', secrets: ['STRIPE'], bindings: { gmail: 'p1' } },
+      { sessionId: 'next', connectionLabels: { gmail: 'Support' } },
+    );
+    expect(body).toMatchObject({
+      agent_name: 'support',
+      secrets: ['STRIPE'],
+      connector_bindings: { gmail: { profile_id: 'p1' } },
+      // Binding one alias must not unplug every other connector.
+      inherit_unbound: true,
+    });
+  });
+
+  test('an un-narrowed session stays un-narrowed — no guessed empty allowlist', () => {
+    // `secrets: []` would boot the next session with NO project secrets, which
+    // is the opposite of what "same scope as this one" means here.
+    const body = buildSessionCreateInput(
+      { agent: null, secrets: null, bindings: {} },
+      { sessionId: 'next' },
+    );
+    expect(body).not.toHaveProperty('secrets');
+    expect(body).not.toHaveProperty('agent_name');
+    expect(body).not.toHaveProperty('connector_bindings');
+  });
+});


### PR DESCRIPTION
Two slices: a scope bar under the chat composer (secrets picker + connector bindings), and a panel that shows the **actual call** behind every KaaB action.

## The scope bar

Under the composer, where the user is actually working — not buried in a dialog they saw once. Per session: which secrets it may use (identifier *and* env KEY, since the allowlist addresses the identifier and the sandbox sees the KEY), and which connection each alias is bound to.

`secrets` and `connector_bindings` are **create-only**, so on a running session the bar is read-only about them and offers "start a new session with this scope" instead. An editable-looking control that silently does nothing would be worse than no bar.

## The snippets

For each action — create with overrides, prompt, model change, list by end-user, usage, resolve approval, upsert secret — both the SDK call this app makes *and* the equivalent raw HTTP.

Two invariants are structural, not conventional: no snippet can contain a real secret value or bearer token (`$KORTIX_API_KEY` placeholder), and the HTTP form shows `end_user_ref` as **server-injected**. A snippet implying the browser sets it would teach exactly the vulnerability the design prevents.

## What the review caught, and what I fixed

Both slices arrived with real defects. The four worth naming:

**The module built to pre-empt a refusal was the one place that skipped the filter.** `scopeDraftIssues`, `typedIdentifier` and `known` all judged the draft against *every* secret row rather than the allowlistable ones. `secret-scope.ts` exists specifically to make `404 SECRET_IDENTIFIER_NOT_FOUND` unreachable — so on any project with a Slack/Teams/Telegram install, the start button stayed enabled on a guaranteed 404, the typed-identifier field said an unallowlistable identifier "exists", and such a row vanished from the popover while still counting in the chip summary. Fixed at all three sites.

**Dead copy asserted by a passing test.** The secrets popover passed `note={live.detail}`, so the frozen explanation was never rendered — while a test asserted the string existed. A wall of ~8 switches with no indication they can't move. The popover now renders both, and I added the render-site test that would have caught it; the original assertion is kept with a comment explaining why it wasn't sufficient.

**The create snippet drifted from the create call.** It omitted `connectionLabels`, which the dialog *does* pass — so it printed `{"slack": "prof_9"}` where the app sends `{"slack": "Acme Team Slack"}`. Drift on the single override the panel is proudest of teaching. Now fed the same labels the submit path uses, with a test that goes red on the drift (mutation-verified: removing the pass turns it red).

**The secret snippet printed the wrong KEY.** It used raw `name.trim()`; the real upsert uppercases via `normalizeSecretKey`, and KEY collisions are adjudicated on the uppercased value. A panel whose stated job is teaching the identifier-vs-KEY distinction got the KEY wrong.

## Verification

293 pass / 0 fail (up from 241), SDK boundary 0 violations, `tsc --noEmit` clean, production build succeeds.

## Not fixed, listed honestly

The review also flagged: "start a new session with this scope" drops connector bindings when `/api/connections` fails (fail-open to `{connectors: []}` with no `isError` guard, unlike the secrets path) and never carries `opencode_model` forward; the model chip can assert "Project default" from a failed read; and `MID_SESSION_CAPABILITIES` hardcodes `connections` rather than deriving it. These are real and worth a follow-up — none of them makes the platform do the wrong thing, they make the bar describe it imprecisely, which is why I fixed the four that could mislead a user into a guaranteed failure first.