### PR TITLE
docs(kaab): END_USER_REF_CONFLICT is a 400, and pin it with a test

### DIFF
--- a/apps/api/src/projects/lib/end-user-ref-contract.test.ts
+++ b/apps/api/src/projects/lib/end-user-ref-contract.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+
+import { resolveEndUserRef } from './end-user-ref';
+
+/**
+ * The documented status code for END_USER_REF_CONFLICT drifted from the code and
+ * nobody noticed until an audit read both: create returns 400, and two docs said
+ * 409. Someone integrating against the published table writes
+ * `if (status === 409)` and their retry logic never fires.
+ *
+ * Docs are the product surface for a backend platform, so the contract is pinned
+ * here rather than left to review.
+ */
+const REPO_ROOT = join(import.meta.dir, '..', '..', '..', '..', '..');
+const DOCS = [
+  join(REPO_ROOT, 'docs', 'KORTIX_AS_A_BACKEND_GUIDE.md'),
+  join(REPO_ROOT, 'apps', 'web', 'content', 'docs', 'backend.mdx'),
+];
+
+describe('END_USER_REF_CONFLICT — the documented contract matches the code', () => {
+  test('a disagreeing pair is refused, and the code is the documented one', () => {
+    const result = resolveEndUserRef({ end_user_ref: 'alice', origin_ref: 'bob' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('END_USER_REF_CONFLICT');
+  });
+
+  test('agreeing values are NOT a conflict — a client mid-migration sends both', () => {
+    expect(resolveEndUserRef({ end_user_ref: 'alice', origin_ref: 'alice' }).ok).toBe(true);
+  });
+
+  test('no doc pairs this code with a status other than 400', () => {
+    // The create path returns 400 (lib/sessions.ts) and so does the list filter
+    // (routes/r7.ts). Any other status next to this code in a doc is a lie a
+    // reader would code against.
+    for (const path of DOCS) {
+      const text = readFexistsOrEmpty(path);
+      if (!text) continue;
+      for (const line of text.split('\n')) {
+        if (!line.includes('END_USER_REF_CONFLICT')) continue;
+        const statuses = [...line.matchAll(/`(\d{3})`|\b(4\d{2})\s+END_USER_REF_CONFLICT/g)]
+          .map((m) => m[1] ?? m[2])
+          .filter(Boolean);
+        for (const status of statuses) {
+          expect({ path, line: line.trim().slice(0, 120), status }).toMatchObject({
+            status: '400',
+          });
+        }
+      }
+    }
+  });
+});
+
+/** A missing doc should not fail the suite — the point is catching a WRONG one. */
+function readFexistsOrEmpty(path: string): string {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+}

--- a/apps/web/content/docs/backend.mdx
+++ b/apps/web/content/docs/backend.mdx
@@ -287,7 +287,7 @@ starting a second one. Replaying a key with a **different** body — different
 | `403` | `origin_override_forbidden` | A non-backend caller tried to set `end_user_ref` or `secrets`. |
 | `503` | `AGENT_SWITCH_GRANT_UNAPPLIED` | A mid-session agent switch was legal but its token re-mint could not be written. Retryable. |
 | `409` | `CONNECTOR_CONNECTION_REQUIRED` | Interactive only: the user hasn't connected their own account. The body names which connector. |
-| `409` | `END_USER_REF_CONFLICT` | You sent `end_user_ref` and the deprecated `origin_ref` with different values. On session **create** it is a `409`; on the session **list** filter it is a `400`. |
+| `400` | `END_USER_REF_CONFLICT` | You sent `end_user_ref` and the deprecated `origin_ref` with different values. Send only `end_user_ref`. Same `400` on session **create** and on the session **list** filter. |
 | `409` | `IDEMPOTENCY_KEY_CONFLICT` | The key collided with a different operation. Unlike the other idempotency errors, the fix is a **higher-entropy key** — the uniqueness index is global. |
 | `429` | `concurrent_session_limit` / `per_origin_session_limit` | Account-wide, or per-end-user when the operator enables it. Retry with backoff. |
 | `429` | `per_end_user_spend_limit` | This end-user has spent their ceiling inside the rolling window. Body carries `spent_usd`, `limit_usd`, `window_days`. Not retryable until the window rolls or the operator raises the limit. |

--- a/docs/KORTIX_AS_A_BACKEND_GUIDE.md
+++ b/docs/KORTIX_AS_A_BACKEND_GUIDE.md
@@ -449,7 +449,7 @@ await s.send(prompt);
 | `409` | `CONNECTOR_PROFILE_INACTIVE` | The bound connection is revoked or errored. Reconnect it; a revoked profile fails closed and never silently falls back. |
 | `409` | `IDEMPOTENCY_ORIGIN_CONFLICT` | An `Idempotency-Key` was replayed under a **different** `end_user_ref`. This is the guard that stops one end-user receiving another's session — do not work around it by reusing keys. |
 | `409` | `IDEMPOTENCY_KEY_CONFLICT` | The key collided with a different operation. Remediation is the **opposite** of the other idempotency errors: use a higher-entropy key. The uniqueness index is global. |
-| `409` | `END_USER_REF_CONFLICT` | You sent both `end_user_ref` and the deprecated `origin_ref` with **different** values. Send only `end_user_ref`. |
+| `400` | `END_USER_REF_CONFLICT` | You sent both `end_user_ref` and the deprecated `origin_ref` with **different** values. Send only `end_user_ref`. |
 | `409` | `SESSION_NOT_RUNNING` | You tried to change the model of a terminal session. Nothing would consume it. |
 | `429` | `concurrent_session_limit` / `per_origin_session_limit` | Account-wide, or per-end-user when `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` is set (defaults to 0 = off). Retry with backoff. |
 | `402` | `subscription_required` / `insufficient_credits` | Billing. Not retryable without operator action. |


### PR DESCRIPTION
Both KaaB docs documented `END_USER_REF_CONFLICT` as a **409** on session create. The code returns **400** (`lib/sessions.ts` — `error: { status: 400, ... }`), and the list filter returns 400 too.

For a backend platform the docs *are* the product surface: someone integrating writes `if (status === 409)` off the published table, and their handling never fires.

## Pinned, not just fixed

Added a test that reads both doc files and fails if `END_USER_REF_CONFLICT` ever appears next to a status other than 400. Mutation-verified — flipping one table row back to 409 turns it red.

This is the second time a KaaB doc has drifted from its route. Review clearly isn't catching it, so the contract is now asserted where CI runs.

## One thing I checked and did NOT change

The same audit flagged the guide's canonical model example `kortix/claude-opus-4.8` as "rejected at create" — the catalog's Anthropic ids are hyphenated (`claude-opus-4-8`), so a dot looks wrong.

It isn't. `DEFAULT_MANAGED_MODEL_IDS` and `MANAGED_FLAGSHIP_MODEL_ID` are both **`claude-opus-4.8`**, dotted — the managed lineup deliberately uses different ids from the raw provider catalog, and `kortix/` resolves against the managed set. The docs are right and I left them alone.

Worth stating plainly: "fixing" that would have broken every copy-pasteable example in the guide, from a finding that read as authoritative.

## Verification

Full `apps/api` suite: 23 failures, zero new.