### PR TITLE
fix(kaab): prove the WebSocket isolation, add the mode badge and runtime_context

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -179,8 +179,19 @@ mock.module('../shared/db', () => {
 });
 
 mock.module('../shared/preview-ownership', () => ({
-  canAccessSandboxSession: async ({ userId }: { userId?: string }) =>
-    Boolean(userId && mockDbSandbox && mockDbMembership),
+  // Mirrors the REAL narrowing (executor/share.ts): a session-bound caller — a
+  // sandbox token — may reach only its OWN session. Without this the mock
+  // ignored callerSessionId entirely, so a test could pass one and prove
+  // nothing; the WebSocket leg's isolation had no coverage at all.
+  canAccessSandboxSession: async ({
+    userId,
+    sessionId,
+    callerSessionId,
+  }: { userId?: string; sessionId?: string; callerSessionId?: string | null }) => {
+    if (!(userId && mockDbSandbox && mockDbMembership)) return false;
+    if (callerSessionId != null && callerSessionId !== sessionId) return false;
+    return true;
+  },
   canAccessPreviewSandbox: async ({ userId }: { userId?: string }) =>
     Boolean(userId && mockDbSandbox && mockDbMembership),
   resolvePreviewUserContext: async (sandboxId: string, userId?: string) =>
@@ -477,6 +488,38 @@ describe('Preview proxy: websocket upstream resolution', () => {
     if (upstream.ok) {
       expect(upstream.url).toBe('wss://preview.daytona.io/proxy-url/pty/pty_test/connect');
     }
+  });
+
+  test('a sandbox token may open the PTY of its OWN session', async () => {
+    const upstream = await resolvePreviewWsUpstream({
+      sandboxId: TEST_SANDBOX_ID,
+      upstreamPort: 4096,
+      userId: TEST_USER_ID,
+      remainingPath: '/pty/pty_test/connect',
+      queryString: '',
+      // The sandbox's own session id — the legitimate case, which must keep
+      // working or the narrowing has broken the product.
+      callerSessionId: mockDbSandbox?.sessionId ?? null,
+    });
+    expect(upstream.ok).toBe(true);
+  });
+
+  test('a sandbox token may NOT open ANOTHER end-user’s PTY', async () => {
+    // The KaaB isolation property, on the WebSocket leg. Every session a wrapper
+    // creates shares one `created_by`, so ownership alone cannot separate
+    // end-users — the per-session gate is what does, and until now all three
+    // tests here passed `callerSessionId: null`, exercising only the unbound
+    // path. The leg was wired and unproven.
+    const upstream = await resolvePreviewWsUpstream({
+      sandboxId: TEST_SANDBOX_ID,
+      upstreamPort: 4096,
+      userId: TEST_USER_ID,
+      remainingPath: '/pty/pty_test/connect',
+      queryString: '',
+      callerSessionId: '99999999-9999-4999-8999-999999999999',
+    });
+    expect(upstream.ok).toBe(false);
+    if (!upstream.ok) expect(upstream.status).toBe(403);
   });
 
   test('routes Platinum PTY websocket upstreams through the signed agent bridge on 8000', async () => {

--- a/apps/whitelabel-demo/src/app/page.tsx
+++ b/apps/whitelabel-demo/src/app/page.tsx
@@ -3,6 +3,7 @@
 import Loading from '@/components/ui/loading';
 
 import { ApiKeyGate } from '@/components/api-key-gate';
+import { ModeBadge } from '@/components/mode-badge';
 import { BrandMark } from '@/components/brand-mark';
 import { LoginGate } from '@/components/login-gate';
 import { Button } from '@/components/ui/button';
@@ -82,7 +83,13 @@ function Dashboard({
     <div className="min-h-dvh bg-background">
       <header className="sticky top-0 z-10 border-b border-border bg-background/80 backdrop-blur">
         <div className="mx-auto flex max-w-4xl items-center justify-between px-5 py-3">
-          <BrandMark />
+          <div className="flex items-center gap-2">
+            <BrandMark />
+            {/* The two integration shapes behave differently and the difference
+                is otherwise invisible — which makes every other observation on
+                this page ambiguous. */}
+            <ModeBadge wrapperMode={wrapperMode} />
+          </div>
           <div className="flex items-center gap-1">
             {wrapperMode ? (
               <Link href="/usage">

--- a/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
@@ -129,7 +129,7 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
         buildSessionCreateInput(
           // The agent comes along too, or "with this scope" would quietly drop
           // the one part of the scope that is already right.
-          { agent: data?.agent_name ?? null, secrets: nextSecrets, bindings: nextBindings },
+          { agent: data?.agent_name ?? null, secrets: nextSecrets, bindings: nextBindings, runtimeContext: null },
           {
             sessionId: nextId,
             connectionLabels: bindingLabels(choices, nextBindings),

--- a/apps/whitelabel-demo/src/components/mode-badge.tsx
+++ b/apps/whitelabel-demo/src/components/mode-badge.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { KeyRound, ServerCog } from 'lucide-react';
+
+/**
+ * Which of the TWO integration shapes this instance is running.
+ *
+ * They behave very differently and the difference is invisible otherwise, which
+ * makes every other observation ambiguous — "is `end_user_ref` being stamped?"
+ * has no answer until you know this:
+ *
+ *   - BACKEND (wrapper / KaaB): the server holds ONE Kortix key, every upstream
+ *     call goes through this app's proxy, and `end_user_ref` is injected
+ *     server-side from the signed-in user. Per-end-user metering, isolation and
+ *     caps are all in play.
+ *   - DIRECT (SDK-only): the browser talks to Kortix with a key the user pasted.
+ *     There is no wrapper, no server-side stamping, and none of the KaaB
+ *     properties apply.
+ *
+ * A missing `KORTIX_API_KEY` silently falls back to DIRECT, so the badge is also
+ * the fastest way to see that the server env did not load.
+ */
+export function ModeBadge({ wrapperMode }: { wrapperMode: boolean }) {
+  const label = wrapperMode ? 'Backend mode' : 'Direct mode';
+  const detail = wrapperMode
+    ? 'This server holds the Kortix key and stamps end_user_ref on every session. Per-end-user usage, isolation and caps apply.'
+    : 'The browser talks to Kortix with a key you pasted. No wrapper, no end_user_ref stamping — Kortix-as-a-Backend features do not apply.';
+
+  return (
+    <span
+      title={detail}
+      className="inline-flex items-center gap-1.5 rounded-full border border-border bg-popover px-2.5 py-1 text-xs text-muted-foreground"
+      data-mode={wrapperMode ? 'backend' : 'direct'}
+    >
+      {wrapperMode ? (
+        <ServerCog className="size-3.5 shrink-0" />
+      ) : (
+        <KeyRound className="size-3.5 shrink-0" />
+      )}
+      {label}
+    </span>
+  );
+}

--- a/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
@@ -146,8 +146,7 @@ export function SessionScope({ projectId, sessionId }: { projectId: string; sess
               overrides: {
                 agent: agentName,
                 secrets: session.data.secrets_allowlist ?? null,
-                bindings: {},
-              },
+                bindings: {}, runtimeContext: null },
             }}
           />
         </div>

--- a/apps/whitelabel-demo/src/lib/session-overrides.ts
+++ b/apps/whitelabel-demo/src/lib/session-overrides.ts
@@ -24,9 +24,23 @@ export interface SessionOverrides {
   secrets: SecretsAllowlist;
   /** Connector alias -> connection profile id. Empty = bind nothing. */
   bindings: Record<string, string>;
+  /**
+   * Arbitrary non-secret key/values handed to the run as context — the one
+   * documented create override the demo could not exercise, so a wrapper author
+   * had no way to see what the agent actually receives.
+   *
+   * NOT a place for credentials: it is stored on the session and echoed back by
+   * the API, so anything here is readable by anyone who can read the session.
+   */
+  runtimeContext: Record<string, string> | null;
 }
 
-export const NO_OVERRIDES: SessionOverrides = { agent: null, secrets: null, bindings: {} };
+export const NO_OVERRIDES: SessionOverrides = {
+  agent: null,
+  secrets: null,
+  bindings: {},
+  runtimeContext: null,
+};
 
 /** Labels for the connections that were bound, keyed by alias — see
  *  `BOUND_CONNECTIONS_KEY`. */
@@ -67,6 +81,11 @@ export function buildSessionCreateInput(
     // An empty allowlist is a real choice (inject zero project secrets), so the
     // "don't narrow" signal has to be null rather than an empty array.
     ...(overrides.secrets ? { secrets: overrides.secrets } : {}),
+    // Omitted entirely when unset, so a session that declines to pass context is
+    // byte-identical to one from before this existed.
+    ...(overrides.runtimeContext && Object.keys(overrides.runtimeContext).length > 0
+      ? { runtime_context: overrides.runtimeContext }
+      : {}),
     ...(aliases.length > 0
       ? {
           connector_bindings: Object.fromEntries(

--- a/apps/whitelabel-demo/tests/e2e/call-snippets.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/call-snippets.test.ts
@@ -120,7 +120,7 @@ describe('the create snippet is the request the dialog would send', () => {
     const snippet = callSnippet('session.create', {
       projectId: PROJECT_ID,
       sessionId: SESSION_ID,
-      overrides: { agent: 'support', secrets: ['STRIPE_KEY'], bindings: { slack: 'prof_9' } },
+      overrides: { agent: 'support', secrets: ['STRIPE_KEY'], bindings: { slack: 'prof_9' }, runtimeContext: null },
     });
     expect(snippet.sdk).toContain('"agent_name": "support"');
     expect(snippet.sdk).toContain('"secrets"');
@@ -224,7 +224,7 @@ describe('the create snippet cannot drift from what the app sends', () => {
     // to teach.
     const withLabels = callSnippet('session.create', {
       projectId: 'p1',
-      overrides: { ...NO_OVERRIDES, bindings: { slack: 'prof_9' } },
+      overrides: { ...NO_OVERRIDES, bindings: { slack: 'prof_9' }, runtimeContext: null },
       connectionLabels: { slack: 'Acme Team Slack' },
     });
     const printed = `${withLabels?.sdk ?? ''}${renderHttp(withLabels!.http)}`;

--- a/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
@@ -302,7 +302,7 @@ describe('seedBindingsFromLabels', () => {
     // wrapper recorded at create is the only bridge from a running session to
     // the create body of the next one.
     const created = buildSessionCreateInput(
-      { agent: null, secrets: null, bindings: { gmail: 'p1' } },
+      { agent: null, secrets: null, bindings: { gmail: 'p1' }, runtimeContext: null },
       { sessionId: 's', connectionLabels: { gmail: 'Support' } },
     );
     const { rows } = scopeBarConnectors({
@@ -315,7 +315,7 @@ describe('seedBindingsFromLabels', () => {
 
   test('a label with no label recorded falls back to the profile id it stored', () => {
     const created = buildSessionCreateInput(
-      { agent: null, secrets: null, bindings: { gmail: 'p1' } },
+      { agent: null, secrets: null, bindings: { gmail: 'p1' }, runtimeContext: null },
       { sessionId: 's' },
     );
     const { rows } = scopeBarConnectors({
@@ -338,7 +338,7 @@ describe('seedBindingsFromLabels', () => {
 describe('the draft carried into the next session', () => {
   test('an untouched draft reproduces this session, allowlist and all', () => {
     const body = buildSessionCreateInput(
-      { agent: 'support', secrets: ['STRIPE'], bindings: { gmail: 'p1' } },
+      { agent: 'support', secrets: ['STRIPE'], bindings: { gmail: 'p1' }, runtimeContext: null },
       { sessionId: 'next', connectionLabels: { gmail: 'Support' } },
     );
     expect(body).toMatchObject({
@@ -354,7 +354,7 @@ describe('the draft carried into the next session', () => {
     // `secrets: []` would boot the next session with NO project secrets, which
     // is the opposite of what "same scope as this one" means here.
     const body = buildSessionCreateInput(
-      { agent: null, secrets: null, bindings: {} },
+      { agent: null, secrets: null, bindings: {}, runtimeContext: null },
       { sessionId: 'next' },
     );
     expect(body).not.toHaveProperty('secrets');

--- a/apps/whitelabel-demo/tests/e2e/session-overrides.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-overrides.test.ts
@@ -115,7 +115,7 @@ describe('buildSessionCreateInput', () => {
 
   test('everything at once composes into one body', () => {
     const input = buildSessionCreateInput(
-      { agent: 'support', secrets: ['STRIPE_KEY'], bindings: { slack: 'prof_9' } },
+      { agent: 'support', secrets: ['STRIPE_KEY'], bindings: { slack: 'prof_9' }, runtimeContext: null },
       { sessionId: SESSION_ID, name: 'Refund a customer', sandboxSlug: 'python' },
     );
     expect(input).toEqual({
@@ -128,5 +128,28 @@ describe('buildSessionCreateInput', () => {
       inherit_unbound: true,
       metadata: { [BOUND_CONNECTIONS_KEY]: { slack: 'prof_9' } },
     });
+  });
+});
+
+describe('runtime_context', () => {
+  test('is sent when set — the one documented override the demo could not exercise', () => {
+    const body = buildSessionCreateInput(
+      { ...NO_OVERRIDES, runtimeContext: { plan: 'pro', locale: 'en-GB' } },
+      { sessionId: 's1' },
+    );
+    expect(body.runtime_context).toEqual({ plan: 'pro', locale: 'en-GB' });
+  });
+
+  test('is OMITTED when unset, so an untouched session is byte-identical to before', () => {
+    const body = buildSessionCreateInput(NO_OVERRIDES, { sessionId: 's1' });
+    expect('runtime_context' in body).toBe(false);
+  });
+
+  test('an EMPTY map is omitted too — sending {} would claim context that is not there', () => {
+    const body = buildSessionCreateInput(
+      { ...NO_OVERRIDES, runtimeContext: {} },
+      { sessionId: 's1' },
+    );
+    expect('runtime_context' in body).toBe(false);
   });
 });

--- a/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
@@ -85,7 +85,7 @@ describe('readBoundConnections', () => {
     // body and the scope panel have to agree on one metadata key or the
     // Connections row silently reads empty forever.
     const created = buildSessionCreateInput(
-      { agent: null, secrets: null, bindings: { slack: 'prof_9' } },
+      { agent: null, secrets: null, bindings: { slack: 'prof_9' }, runtimeContext: null },
       { sessionId: 's', connectionLabels: { slack: 'Support' } },
     );
     expect(readBoundConnections(created.metadata)).toEqual({ slack: 'Support' });


### PR DESCRIPTION
Three gaps from a completeness audit against every stated requirement. Each verified against current `main` before acting — **four other findings were stale**, reported against a `main` from before the last merges, and I did not act on those.

## 1. The WebSocket isolation leg was wired and unproven

I said this leg was "finished" earlier. It was wired — but all three `resolvePreviewWsUpstream` tests passed `callerSessionId: null`, exercising only the *unbound* path. Worse, the mock `canAccessSandboxSession` ignored `callerSessionId` entirely, so a test passing one would have proved nothing either.

The mock now mirrors the real rule (a session-bound caller may reach only its own session), and there are two tests: a sandbox opening its **own** PTY succeeds, and a sandbox reaching **another end-user's** PTY gets 403. That is the KaaB property on the WS leg, now actually asserted.

This is the second time today a claim of mine rested on a test that couldn't fail.

## 2. Mode badge

You asked for an indicator showing whether the demo is in KaaB or SDK-only mode. The mode was resolved and available (`/api/mode` → `useWrapperMode`) but rendered nowhere.

Now in the header. It matters more than cosmetics: the two shapes behave differently, and until you know which one you're in, every other observation is ambiguous — *"is `end_user_ref` being stamped?"* has no answer without it. A missing `KORTIX_API_KEY` silently falls back to direct mode, so it is also the fastest way to see the server env didn't load.

## 3. `runtime_context`

A documented create override with **zero** occurrences in the demo — no field, no way to see what the agent actually receives. Added to `SessionOverrides` and emitted.

Made it a **required** field on the type rather than optional, so the compiler named all 7 construction sites instead of letting them default silently. Omitted from the request when unset *and* when empty — sending `{}` would claim context that isn't there, and an untouched session stays byte-identical.

## One finding I am deliberately NOT fixing

The audit flagged that the end-user usage card returns `null` when the rollup has zero rows, so a founder who hasn't driven KaaB traffic gets no affordance that the view exists.

Real, but the existing behaviour has a better reason than the fix: only KaaB accounts have `origin_ref` rows at all, and a permanently blank card on every non-KaaB account reads as broken. Showing an empty state to everyone trades a small discoverability gap for a permanent wrong-looking card. Distinguishing them properly needs a "does this account use KaaB" signal the usage response doesn't carry — worth doing when that exists, not worth faking now.

## Verification

`apps/api`: 23 failures, zero new. Demo: 296 pass / 0 fail, `tsc --noEmit` clean, SDK boundary clean.