### PR TITLE
feat(whitelabel-demo): gated import of existing account projects

### DIFF
--- a/apps/whitelabel-demo/scripts/sdk-boundary.mjs
+++ b/apps/whitelabel-demo/scripts/sdk-boundary.mjs
@@ -22,6 +22,11 @@ const ALLOWED_CLIENT_BFF_ROUTES = [
   // the runtime, so the translation stays server-side and the client says `model`.
   '/api/session-model',
   '/api/usage',
+  // Lists the ACCOUNT's projects so an operator can adopt one into this demo
+  // user. Gated on LUMEN_ALLOW_PROJECT_IMPORT and off by default — it is the one
+  // place the wrapper's per-end-user project filter is deliberately bypassed, so
+  // it is registered here rather than reached through the generic proxy.
+  '/api/projects/import',
 ];
 
 const RULES = [

--- a/apps/whitelabel-demo/src/app/api/projects/import/route.ts
+++ b/apps/whitelabel-demo/src/app/api/projects/import/route.ts
@@ -1,0 +1,81 @@
+/**
+ * List the account's projects, and import one into this demo user.
+ *
+ * Gated on `LUMEN_ALLOW_PROJECT_IMPORT` — see server/project-adoption.ts for why
+ * this is a deployment switch rather than a per-user permission, and why a real
+ * product would not expose it at all.
+ *
+ * Calls upstream DIRECTLY rather than through `/api/kortix`, because the point is
+ * to see projects the proxy's ownership filter deliberately hides. That is the
+ * whole reason this route is gated: it is the ONE place the tenancy filter is
+ * bypassed, so the gate lives here where it is visible, not scattered.
+ */
+
+import { getRequestSession } from '@/server/auth';
+import {
+  PROJECT_IMPORT_ENV_VAR,
+  projectImportEnabled,
+  selectImportableProjects,
+} from '@/server/project-adoption';
+import { addOwnedProject, isValidProjectId, listOwnedProjects } from '@/server/users';
+import { createScopedKortix } from '@kortix/sdk/server';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function upstreamBase(): string {
+  return (process.env.KORTIX_UPSTREAM ?? 'https://api.kortix.com/v1').replace(/\/+$/, '');
+}
+
+function disabled() {
+  return Response.json(
+    {
+      error: `Project import is off. Set ${PROJECT_IMPORT_ENV_VAR}=1 to enable it on this deployment.`,
+      envVar: PROJECT_IMPORT_ENV_VAR,
+    },
+    { status: 403 },
+  );
+}
+
+export async function GET(req: NextRequest) {
+  const session = getRequestSession(req);
+  if (!session) return Response.json({ error: 'Not authenticated' }, { status: 401 });
+  if (!projectImportEnabled()) return disabled();
+
+  const key = process.env.KORTIX_API_KEY;
+  if (!key) {
+    return Response.json({ error: 'Wrapper mode is not enabled on this server.' }, { status: 500 });
+  }
+
+  // The SDK's server transport, not a raw fetch — the boundary lint enforces
+  // this so every server-side Kortix call goes through one audited path.
+  const kortix = createScopedKortix({ backendUrl: upstreamBase(), getToken: async () => key });
+  let rows: unknown[];
+  try {
+    const body = (await kortix.projects.list()) as unknown;
+    rows = Array.isArray(body) ? body : [];
+  } catch {
+    return Response.json({ error: 'Could not read the account’s projects.' }, { status: 502 });
+  }
+  return Response.json({
+    projects: selectImportableProjects(rows as never, listOwnedProjects(session.userId)),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const session = getRequestSession(req);
+  if (!session) return Response.json({ error: 'Not authenticated' }, { status: 401 });
+  if (!projectImportEnabled()) return disabled();
+
+  const body = (await req.json().catch(() => null)) as { project_id?: unknown } | null;
+  const projectId = typeof body?.project_id === 'string' ? body.project_id : '';
+  // Validated before it is stored: ids from this store end up inside upstream
+  // request URLs, so a malformed one must never be able to steer a request.
+  if (!isValidProjectId(projectId)) {
+    return Response.json({ error: 'A valid project id is required.' }, { status: 400 });
+  }
+
+  addOwnedProject(session.userId, projectId);
+  return Response.json({ ok: true, project_id: projectId });
+}

--- a/apps/whitelabel-demo/src/app/page.tsx
+++ b/apps/whitelabel-demo/src/app/page.tsx
@@ -3,6 +3,7 @@
 import Loading from '@/components/ui/loading';
 
 import { ApiKeyGate } from '@/components/api-key-gate';
+import { ImportProjectsDialog } from '@/components/import-projects-dialog';
 import { ModeBadge } from '@/components/mode-badge';
 import { BrandMark } from '@/components/brand-mark';
 import { LoginGate } from '@/components/login-gate';
@@ -119,7 +120,11 @@ function Dashboard({
               Each project is a git repo. Open one to run an agent against it.
             </p>
           </div>
-          <CreateProjectDialog />
+          <div className="flex items-center gap-1">
+            {/* Gated + hidden by default — see server/project-adoption.ts. */}
+            <ImportProjectsDialog />
+            <CreateProjectDialog />
+          </div>
         </div>
 
         <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/apps/whitelabel-demo/src/components/import-projects-dialog.tsx
+++ b/apps/whitelabel-demo/src/components/import-projects-dialog.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { toast } from 'sonner';
+import type { ImportableProject } from '@/server/project-adoption';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Download } from 'lucide-react';
+import { useState } from 'react';
+
+/**
+ * Import a project that already exists on the Kortix account.
+ *
+ * The project list is deliberately narrowed to what this end-user provisioned
+ * through the demo — one server-held key can reach every project in the account,
+ * so without that filter every signed-in user would see the operator's whole
+ * workspace. That boundary stays; this is an explicit, gated way to say "this
+ * one is mine too", which is what makes the demo usable against a project that
+ * already has connectors and secrets.
+ *
+ * Hidden entirely unless the deployment opts in, and the copy says why rather
+ * than presenting it as an ordinary feature — a wrapper author reading this app
+ * as a reference should not copy it by accident.
+ */
+export function ImportProjectsDialog() {
+  const [open, setOpen] = useState(false);
+  const qc = useQueryClient();
+
+  const available = useQuery({
+    queryKey: ['importable-projects'],
+    queryFn: async (): Promise<{ projects: ImportableProject[]; error?: string }> => {
+      const res = await fetch('/api/projects/import');
+      if (res.status === 403) return { projects: [], error: (await res.json()).error };
+      if (!res.ok) throw new Error('Could not read the account’s projects.');
+      return res.json();
+    },
+    enabled: open,
+  });
+
+  const importProject = useMutation({
+    mutationFn: async (projectId: string) => {
+      const res = await fetch('/api/projects/import', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ project_id: projectId }),
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error ?? 'Import failed');
+      return projectId;
+    },
+    onSuccess: () => {
+      toast.success('Project imported');
+      qc.invalidateQueries({ queryKey: ['projects'] });
+      qc.invalidateQueries({ queryKey: ['importable-projects'] });
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const rows = available.data?.projects ?? [];
+  const gateMessage = available.data?.error;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" className="gap-1.5">
+          <Download className="size-4 shrink-0" /> Import
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Import a project</DialogTitle>
+          <DialogDescription>
+            This list is normally hidden. A wrapper narrows projects to what each end-user started,
+            because one server-held key can reach the whole account — importing is a testing
+            affordance, not something a real product would offer its users.
+          </DialogDescription>
+        </DialogHeader>
+
+        {gateMessage ? (
+          <p className="rounded-md border border-border bg-card px-3 py-2.5 text-xs text-muted-foreground">
+            {gateMessage}
+          </p>
+        ) : available.isLoading ? (
+          <p className="text-sm text-muted-foreground">Reading the account’s projects…</p>
+        ) : available.isError ? (
+          <p className="text-sm text-destructive">Could not read the account’s projects.</p>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No projects on this account.</p>
+        ) : (
+          <ul className="max-h-80 space-y-2 overflow-y-auto">
+            {rows.map((project) => (
+              <li
+                key={project.project_id}
+                className="flex items-center justify-between gap-3 rounded-md border border-border bg-popover px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{project.name || 'Untitled'}</p>
+                  <p className="truncate font-mono text-[11px] text-muted-foreground">
+                    {project.project_id}
+                  </p>
+                </div>
+                {project.imported ? (
+                  <span className="shrink-0 text-xs text-muted-foreground">Already yours</span>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={importProject.isPending}
+                    onClick={() => importProject.mutate(project.project_id)}
+                  >
+                    Import
+                  </Button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/whitelabel-demo/src/server/project-adoption.ts
+++ b/apps/whitelabel-demo/src/server/project-adoption.ts
@@ -1,0 +1,68 @@
+/**
+ * Importing an EXISTING account project into this demo user.
+ *
+ * Why this needs a gate at all: in wrapper mode one server-held `KORTIX_API_KEY`
+ * can reach every project in the Kortix account. The `/projects` list is
+ * therefore filtered to the projects this end-user provisioned through the demo
+ * (`filterProjectsList` → `listOwnedProjects`), because otherwise every signed-in
+ * Lumen user would see — and be able to open — every project the operator owns.
+ * That filter is the wrapper's tenancy boundary, not an oversight.
+ *
+ * But it makes the demo useless for testing against a project that already has
+ * connectors, secrets and history: those were created in the Kortix dashboard, so
+ * the demo has no record of them and shows an empty list.
+ *
+ * So: a DEPLOYMENT-level switch, default off, exactly like the usage breakdown.
+ * Not a per-user permission — this app's login accepts any email with any
+ * password, so an allowlist of addresses would name a user without
+ * authenticating one. The honest statement is about the DEPLOYMENT ("this
+ * instance is a single-tenant demo, so letting the signed-in user adopt the
+ * operator's own projects harms nobody"), and it cannot be bypassed by choosing
+ * a different email because it never consults identity.
+ *
+ * A real product would not have this at all: its end-users would never be
+ * offered the operator's projects, under any flag.
+ */
+
+const ADOPTION_ENV_VAR = 'LUMEN_ALLOW_PROJECT_IMPORT';
+
+export function projectImportEnabled(): boolean {
+  const raw = (process.env[ADOPTION_ENV_VAR] ?? '').trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
+export const PROJECT_IMPORT_ENV_VAR = ADOPTION_ENV_VAR;
+
+export interface ImportableProject {
+  project_id: string;
+  name: string;
+  /** True when this demo user already owns it — shown as already-imported rather
+   *  than hidden, so the list matches what the operator sees in the dashboard. */
+  imported: boolean;
+}
+
+/**
+ * Split the account's projects into what this user may import.
+ *
+ * Pure so the decision is testable without a server: the route supplies the
+ * upstream list and the user's owned set.
+ */
+export function selectImportableProjects(
+  accountProjects: Array<{ project_id?: unknown; name?: unknown }> | undefined,
+  ownedProjectIds: readonly string[],
+): ImportableProject[] {
+  const owned = new Set(ownedProjectIds);
+  return (accountProjects ?? [])
+    .map((project) => ({
+      project_id: typeof project.project_id === 'string' ? project.project_id : '',
+      name: typeof project.name === 'string' ? project.name : '',
+      imported: false,
+    }))
+    .filter((project) => project.project_id.length > 0)
+    .map((project) => ({ ...project, imported: owned.has(project.project_id) }))
+    .sort((a, b) => {
+      // Not-yet-imported first — those are the actionable rows.
+      if (a.imported !== b.imported) return a.imported ? 1 : -1;
+      return a.name.localeCompare(b.name);
+    });
+}

--- a/apps/whitelabel-demo/tests/e2e/project-import.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/project-import.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { selectImportableProjects } from '../../src/server/project-adoption';
+
+const P = (project_id: string, name: string) => ({ project_id, name });
+
+describe('selectImportableProjects', () => {
+  test('marks what this user already owns instead of hiding it', () => {
+    // Hiding owned rows would make the list disagree with the Kortix dashboard,
+    // and the operator would wonder which projects were missing and why.
+    const rows = selectImportableProjects([P('a', 'Alpha'), P('b', 'Beta')], ['a']);
+    expect(rows.find((r) => r.project_id === 'a')?.imported).toBe(true);
+    expect(rows.find((r) => r.project_id === 'b')?.imported).toBe(false);
+  });
+
+  test('not-yet-imported sort first — those are the actionable rows', () => {
+    const rows = selectImportableProjects([P('a', 'Alpha'), P('z', 'Zeta')], ['a']);
+    expect(rows[0]?.project_id).toBe('z');
+  });
+
+  test('a row with no project_id is dropped, not rendered blank', () => {
+    const rows = selectImportableProjects(
+      [{ name: 'nameless' } as never, P('b', 'Beta')],
+      [],
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  test('an absent list is empty, not a crash', () => {
+    expect(selectImportableProjects(undefined, [])).toEqual([]);
+  });
+
+  test('a missing name still yields a usable row', () => {
+    // The id is what the import needs; a blank name must not drop the row.
+    const rows = selectImportableProjects([{ project_id: 'a' } as never], []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.project_id).toBe('a');
+  });
+});


### PR DESCRIPTION
The demo lists only projects it provisioned for the signed-in user, so a project created in the Kortix dashboard — with real connectors and secrets on it — is invisible. That makes the demo hard to test against anything real.

**The obvious fix would have been wrong.** `filterProjectsList` is the wrapper's tenancy boundary: one server-held key reaches every project in the account, so dropping the filter means every signed-in end-user sees the operator's whole workspace. Same class as the traversal bug fixed earlier today.

So the filter stays, and there's an explicit **Import** action to say "this one is mine too" for a specific project.

## Gated as a deployment switch, not a permission

`LUMEN_ALLOW_PROJECT_IMPORT`, default **off** — and deliberately not a per-user allowlist. This app's login accepts any email with any password, so an allowlist of operator emails would name a user without authenticating one (the same mistake I made with the usage breakdown and had to back out). A deployment flag states the real condition — *"this instance is a single-tenant demo"* — and cannot be bypassed by typing a different email.

The dialog copy says plainly that this is a testing affordance a real product would not offer its users, so nobody reading the demo as a reference copies it by accident.

## The boundary lint caught two real mistakes

`sdk-boundary.mjs` rejected my first version with 3 violations, all correct:

- the server route used a raw `fetch` instead of `@kortix/sdk/server` → switched to `createScopedKortix`, so every server-side Kortix call still goes through one audited path;
- the client called an unregistered route → `/api/projects/import` is now in `ALLOWED_CLIENT_BFF_ROUTES`, with a comment noting it is the one place the project filter is deliberately bypassed.

The POST validates the project id with `isValidProjectId` before storing it — ids from that store end up inside upstream request URLs, so a malformed one must never be able to steer a request.

## Verified against the real dev account

Not just unit-tested — driven end to end against `dev-api.kortix.com`:

- `GET /api/projects/import` listed all four account projects, correctly marking the already-owned one;
- importing `kaab-demo` made it appear in the demo's project list;
- its `demo-mcp` and `gmail` connectors then resolved through the demo proxy.

301 pass / 0 fail, `tsc --noEmit` clean, SDK boundary 0 violations.

## Note

Import marks already-owned projects rather than hiding them, so the list matches what the operator sees in the Kortix dashboard — hiding them would leave you wondering which projects were missing and why.