### PR TITLE
feat(kaab): re-scope a running session's secrets and connector bindings

### DIFF
--- a/apps/api/src/projects/lib/session-rescope.test.ts
+++ b/apps/api/src/projects/lib/session-rescope.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'bun:test';
+
+import { rescopeSessionBindings, rescopeSessionSecrets } from './session-rescope';
+
+describe('rescopeSessionSecrets — SET semantics', () => {
+  test('the requested list REPLACES the previous one', () => {
+    // The founder's case: start with [a, b], re-scope to [b], and from the next
+    // prompt the session sees only b.
+    const result = rescopeSessionSecrets({
+      current: ['TEST_KEY_1', 'TEST_KEY_2'],
+      requested: ['TEST_KEY_2'],
+      agentGrantEnv: 'all',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.allowlist).toEqual(['TEST_KEY_2']);
+      expect(result.dropped).toEqual(['TEST_KEY_1']);
+    }
+  });
+
+  test('it is a REPLACE, not an append — omitting a name drops it', () => {
+    const result = rescopeSessionSecrets({ current: ['a', 'b'], requested: ['c'], agentGrantEnv: 'all' });
+    expect(result.ok && result.allowlist).toEqual(['c']);
+    expect(result.ok && result.dropped).toEqual(['a', 'b']);
+  });
+
+  test('an EMPTY list is "no project secrets", not "stop narrowing"', () => {
+    // The two are opposite, and conflating them would silently hand a session
+    // every secret the agent may read at the moment someone tried to remove all.
+    const result = rescopeSessionSecrets({ current: ['a'], requested: [], agentGrantEnv: 'all' });
+    expect(result.ok && result.allowlist).toEqual([]);
+  });
+
+  test('null means stop narrowing — fall back to the agent grant', () => {
+    const result = rescopeSessionSecrets({ current: ['a'], requested: null, agentGrantEnv: 'all' });
+    expect(result.ok && result.allowlist).toBeNull();
+  });
+
+  test('a session may RESTORE a secret it previously dropped, inside the grant', () => {
+    // Narrowing is not a ratchet: the grant is the ceiling, not the current
+    // allowlist. Refusing this would make one accidental re-scope permanent.
+    const result = rescopeSessionSecrets({
+      current: ['b'],
+      requested: ['a', 'b'],
+      agentGrantEnv: ['a', 'b', 'c'],
+    });
+    expect(result.ok && result.allowlist).toEqual(['a', 'b']);
+    expect(result.ok && result.added).toEqual(['a']);
+  });
+
+  test('it can NEVER exceed the agent grant', () => {
+    // The manifest's grant is what this agent may EVER read. A session-level
+    // field that could widen past it would make the manifest advisory.
+    const result = rescopeSessionSecrets({
+      current: ['a'],
+      requested: ['a', 'z'],
+      agentGrantEnv: ['a', 'b'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('NOT_IN_AGENT_GRANT');
+      expect(result.offending).toEqual(['z']);
+    }
+  });
+
+  test('the grant ceiling is case-insensitive, matching agentMayUseEnv', () => {
+    const result = rescopeSessionSecrets({
+      current: null,
+      requested: ['GMAIL_TOKEN'],
+      agentGrantEnv: ['gmail_token'],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test('duplicates and blanks are normalised away', () => {
+    const result = rescopeSessionSecrets({
+      current: null,
+      requested: ['a', ' a ', '', '  ', 'A'],
+      agentGrantEnv: 'all',
+    });
+    expect(result.ok && result.allowlist).toEqual(['a']);
+  });
+
+  test('an unrestricted grant imposes no ceiling', () => {
+    expect(rescopeSessionSecrets({ current: null, requested: ['x'], agentGrantEnv: undefined }).ok).toBe(
+      true,
+    );
+  });
+});
+
+describe('rescopeSessionBindings — SET semantics', () => {
+  test('the requested map REPLACES the previous one', () => {
+    const result = rescopeSessionBindings({
+      current: { gmail: 'p1', slack: 'p2' },
+      requested: { gmail: 'p9' },
+      grantedConnectors: 'all',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.bindings).toEqual({ gmail: 'p9' });
+      expect(result.dropped).toEqual(['slack']);
+      expect(result.changed).toEqual(['gmail']);
+    }
+  });
+
+  test('an alias the agent is not granted is refused', () => {
+    // Binding it would "succeed" here and then 403 CONNECTOR_NOT_ASSIGNED at the
+    // first tool call — a failure the user cannot act on, far from the cause.
+    const result = rescopeSessionBindings({
+      current: {},
+      requested: { zendesk: 'p1' },
+      grantedConnectors: ['gmail'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.offending).toEqual(['zendesk']);
+  });
+
+  test('an empty map unbinds everything', () => {
+    const result = rescopeSessionBindings({
+      current: { gmail: 'p1' },
+      requested: {},
+      grantedConnectors: 'all',
+    });
+    expect(result.ok && result.bindings).toEqual({});
+    expect(result.ok && result.dropped).toEqual(['gmail']);
+  });
+
+  test('a blank alias or profile id is dropped rather than stored', () => {
+    const result = rescopeSessionBindings({
+      current: {},
+      requested: { '': 'p1', gmail: '  ' },
+      grantedConnectors: 'all',
+    });
+    expect(result.ok && result.bindings).toEqual({});
+  });
+});

--- a/apps/api/src/projects/lib/session-rescope.ts
+++ b/apps/api/src/projects/lib/session-rescope.ts
@@ -1,0 +1,149 @@
+/**
+ * Re-scoping a RUNNING session: replace what it may read and reach, from now on.
+ *
+ * The per-session `secrets` allowlist and `connector_bindings` were create-only.
+ * The stated reason — a mutable allowlist "could be narrowed below what the
+ * sandbox already needs and leave the session unbootable" — is an argument about
+ * BOOT, and it silently became a refusal to change anything at all.
+ *
+ * It does not survive contact with the machinery. `syncSandboxEnvForPrompt`
+ * already re-resolves the whole secret set and REPLACES the sandbox env on every
+ * prompt — that is how a revoked secret propagates. A re-scope needs no new
+ * delivery path; it needs a place to write the new list.
+ *
+ * SET semantics, not append: the list supplied replaces the previous one. From
+ * the next prompt, the session sees exactly what was named.
+ *
+ * WHAT THIS DOES AND DOES NOT PROMISE — the distinction is the whole contract:
+ *
+ *   - Going FORWARD it is exact. The next prompt's env push carries only the new
+ *     set; the daemon's env store clears the names it previously knew
+ *     (`mergeProjectEnv`), so a shell spawned after the re-scope cannot see a
+ *     dropped secret.
+ *   - RETROACTIVELY it promises nothing, and must not pretend to. A value the
+ *     agent already read is in its context, and in any shell it spawned before
+ *     the re-scope. Dropping a secret is "stop handing it out", never "unsay it".
+ *
+ * Callers must surface that difference. A UI that says "revoked" where the truth
+ * is "revoked for anything started from here" is the kind of false assurance that
+ * gets a credential left in place.
+ */
+
+export type RescopeSecretsResult =
+  | { ok: true; allowlist: string[] | null; dropped: string[]; added: string[] }
+  | { ok: false; code: 'NOT_IN_AGENT_GRANT'; message: string; offending: string[] };
+
+/**
+ * Decide the new allowlist for a session.
+ *
+ * `requested` is the FULL new list — `['b']` after `['a','b']` means `a` stops
+ * being delivered. `null` means "stop narrowing", i.e. fall back to the agent's
+ * own grant, which is what an absent allowlist has always meant.
+ *
+ * `agentGrantEnv` is the ceiling. A re-scope may narrow within the agent's grant
+ * and may restore anything inside it, but can never exceed it — the grant is the
+ * manifest's statement about what this agent may EVER read, and a session-level
+ * field must not be able to widen past it. `undefined`/`'all'` means unrestricted.
+ */
+export function rescopeSessionSecrets(input: {
+  current: string[] | null;
+  requested: string[] | null;
+  agentGrantEnv: string[] | 'all' | undefined;
+}): RescopeSecretsResult {
+  const requested = input.requested === null ? null : normalize(input.requested);
+
+  if (requested !== null && Array.isArray(input.agentGrantEnv)) {
+    const grant = new Set(input.agentGrantEnv.map((id) => id.toUpperCase()));
+    const offending = requested.filter((id) => !grant.has(id.toUpperCase()));
+    if (offending.length > 0) {
+      return {
+        ok: false,
+        code: 'NOT_IN_AGENT_GRANT',
+        message:
+          `not in this agent's secrets grant: ${offending.join(', ')} — a session may narrow ` +
+          'within the grant, never past it',
+        offending,
+      };
+    }
+  }
+
+  const before = input.current === null ? null : normalize(input.current);
+  // A null allowlist is "everything the grant allows", so the set of names it
+  // covers is not enumerable here. Report movement only when both sides are
+  // explicit; the route reports the null transition itself.
+  const dropped =
+    before !== null && requested !== null
+      ? before.filter((id) => !requested.some((r) => r.toUpperCase() === id.toUpperCase()))
+      : [];
+  const added =
+    before !== null && requested !== null
+      ? requested.filter((id) => !before.some((b) => b.toUpperCase() === id.toUpperCase()))
+      : [];
+
+  return { ok: true, allowlist: requested, dropped, added };
+}
+
+/** Trim, drop blanks, de-duplicate case-insensitively, keep first spelling. */
+function normalize(list: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of list) {
+    const id = typeof raw === 'string' ? raw.trim() : '';
+    if (!id) continue;
+    const key = id.toUpperCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(id);
+  }
+  return out;
+}
+
+export type RescopeBindingsResult =
+  | { ok: true; bindings: Record<string, string>; dropped: string[]; changed: string[] }
+  | { ok: false; code: 'NOT_GRANTED_CONNECTOR'; message: string; offending: string[] };
+
+/**
+ * Same shape for connector bindings: the map supplied REPLACES the previous one.
+ *
+ * An alias present before and absent now stops resolving to that connection —
+ * it falls back to whatever the session's `inherit_unbound` setting dictates,
+ * exactly as an alias that was never bound.
+ *
+ * Unlike secrets, this one IS retroactively effective: a connector binding is
+ * resolved server-side at CALL time, so the next tool call already uses the new
+ * map. Nothing about it was ever handed to the sandbox.
+ */
+export function rescopeSessionBindings(input: {
+  current: Record<string, string>;
+  requested: Record<string, string>;
+  grantedConnectors: string[] | 'all' | undefined;
+}): RescopeBindingsResult {
+  const requested: Record<string, string> = {};
+  for (const [alias, profileId] of Object.entries(input.requested)) {
+    const key = alias.trim();
+    const value = typeof profileId === 'string' ? profileId.trim() : '';
+    if (!key || !value) continue;
+    requested[key] = value;
+  }
+
+  if (Array.isArray(input.grantedConnectors)) {
+    const granted = new Set(input.grantedConnectors);
+    const offending = Object.keys(requested).filter((alias) => !granted.has(alias));
+    if (offending.length > 0) {
+      return {
+        ok: false,
+        code: 'NOT_GRANTED_CONNECTOR',
+        message:
+          `not granted to this agent: ${offending.join(', ')} — binding an alias the manifest ` +
+          'does not grant would 403 at the first tool call',
+        offending,
+      };
+    }
+  }
+
+  const dropped = Object.keys(input.current).filter((alias) => !(alias in requested));
+  const changed = Object.keys(requested).filter(
+    (alias) => alias in input.current && input.current[alias] !== requested[alias],
+  );
+  return { ok: true, bindings: requested, dropped, changed };
+}

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -19,7 +19,6 @@ import { roleAllows } from '../access';
 import { createRoute, z } from '@hono/zod-openapi';
 import { accountGroupMembers, accountGroups, accountMembers, executorConnectors, executorExecutions, projectGroupGrants, projectSessions, sessionSandboxes,
   projectSessionConnectorBindings,
-  executorConnectionProfiles,
 } from '@kortix/db';
 import { and, asc, desc, eq, inArray, isNull } from 'drizzle-orm';
 import { mayResolveApproval, maySeeSessionApprovals } from '../lib/approval-authority';

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -17,7 +17,10 @@ import { DEFAULT_SANDBOX_SLUG } from '../../snapshots/builder';
 import { db } from '../../shared/db';
 import { roleAllows } from '../access';
 import { createRoute, z } from '@hono/zod-openapi';
-import { accountGroupMembers, accountGroups, accountMembers, executorConnectors, executorExecutions, projectGroupGrants, projectSessions, sessionSandboxes } from '@kortix/db';
+import { accountGroupMembers, accountGroups, accountMembers, executorConnectors, executorExecutions, projectGroupGrants, projectSessions, sessionSandboxes,
+  projectSessionConnectorBindings,
+  executorConnectionProfiles,
+} from '@kortix/db';
 import { and, asc, desc, eq, inArray, isNull } from 'drizzle-orm';
 import { mayResolveApproval, maySeeSessionApprovals } from '../lib/approval-authority';
 import { getCachedAccountTier } from '../../billing/services/entitlements';
@@ -57,6 +60,9 @@ import {
 import { requireEntitlement } from '../../accounts/iam/helpers';
 import { accountHasEntitlement } from '../../billing/services/entitlements';
 import { callerKortixSessionId } from '../lib/caller-session';
+import { DEFAULT_AGENT_SENTINEL } from '../agents';
+import { resolveSessionAgentGrant } from '../lib/secret-grant';
+import { rescopeSessionBindings, rescopeSessionSecrets } from '../lib/session-rescope';
 import { resolveEndUserRef } from '../lib/end-user-ref';
 import { selectSessionRowsForViewer, type ProjectSessionListScope } from '../lib/session-inventory';
 
@@ -2026,6 +2032,244 @@ projectsApp.openapi(
  * only from the next boot, because those are genuinely different outcomes and
  * the caller cannot otherwise tell.
  */
+projectsApp.openapi(
+  createRoute({
+    method: 'put',
+    path: '/{projectId}/sessions/{sessionId}/scope',
+    tags: ['sessions'],
+    summary: "Re-scope a running session's secrets and connector bindings",
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string(), sessionId: z.string() }),
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              /** FULL new allowlist — this REPLACES the previous one. `null`
+               *  stops narrowing (fall back to the agent grant); `[]` is "no
+               *  project secrets at all", which is the opposite. */
+              secrets: z.array(z.string()).nullable().optional(),
+              /** FULL new binding map — REPLACES the previous one. */
+              connector_bindings: z
+                .record(z.string(), z.object({ profile_id: z.string() }))
+                .optional(),
+            }),
+          },
+        },
+      },
+    },
+    responses: {
+      200: json(
+        z.object({
+          secrets_allowlist: z.array(z.string()).nullable(),
+          connector_bindings: z.record(z.string(), z.object({ profile_id: z.string() })),
+          dropped_secrets: z.array(z.string()),
+          added_secrets: z.array(z.string()),
+          dropped_bindings: z.array(z.string()),
+          /** What the caller must tell their user. Dropping a secret stops it
+           *  being delivered from the next prompt; it cannot un-read what the
+           *  agent already has. */
+          retroactive: z.boolean(),
+          detail: z.string(),
+        }),
+        'Session re-scoped',
+      ),
+      ...errors(400, 403, 404, 409),
+    },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param('projectId');
+    const sessionId = c.req.param('sessionId');
+    if (!UUID_V4_REGEX.test(sessionId)) return c.json({ error: 'Invalid session id' }, 400);
+
+    const loaded = await loadProjectForUser(c, projectId, 'session');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    // Re-scoping changes what the agent may read and reach. Same destructive
+    // capability as the stop/model routes for a scoped agent token.
+    assertAgentScope(c, PROJECT_ACTIONS.PROJECT_SESSION_STOP);
+    const visible = await loadVisibleSession(loaded, sessionId, callerKortixSessionId(c));
+    if (!visible) return c.json({ error: 'Not found' }, 404);
+    // Seeing a session is not permission to re-scope it — same gate as the model
+    // change, for the same reason.
+    if (!mayChangeSessionModel(visible)) {
+      return c.json(
+        { error: 'Only the session owner or a project manager can re-scope this session' },
+        403,
+      );
+    }
+
+    const body = await readBody(c);
+    const wantsSecrets = body !== null && typeof body === 'object' && 'secrets' in body;
+    const wantsBindings =
+      body !== null && typeof body === 'object' && 'connector_bindings' in body;
+    if (!wantsSecrets && !wantsBindings) {
+      return c.json(
+        { error: 'Supply `secrets`, `connector_bindings`, or both', code: 'NOTHING_TO_RESCOPE' },
+        400,
+      );
+    }
+
+    // The agent grant is the ceiling for both axes. Resolved from the agent this
+    // session actually runs, and fail-closed: if it cannot be established, the
+    // re-scope is refused rather than applied against an unverified ceiling.
+    let grant: Awaited<ReturnType<typeof resolveSessionAgentGrant>>;
+    try {
+      grant = await resolveSessionAgentGrant({
+        projectId,
+        repoUrl: loaded.row.repoUrl,
+        defaultBranch: loaded.row.defaultBranch,
+        manifestPath: loaded.row.manifestPath,
+        sessionAgent: visible.row.agentName ?? DEFAULT_AGENT_SENTINEL,
+      });
+    } catch (err) {
+      return c.json(
+        {
+          error: `could not resolve this agent's grant, so the new scope cannot be checked against it: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          code: 'AGENT_GRANT_UNRESOLVED',
+        },
+        409,
+      );
+    }
+
+    const currentBindings = Object.fromEntries(
+      (
+        await db
+          .select({
+            alias: projectSessionConnectorBindings.connectorAlias,
+            profileId: projectSessionConnectorBindings.profileId,
+          })
+          .from(projectSessionConnectorBindings)
+          .where(
+            and(
+              eq(projectSessionConnectorBindings.sessionId, sessionId),
+              eq(projectSessionConnectorBindings.projectId, projectId),
+            ),
+          )
+      ).map((row) => [row.alias, row.profileId]),
+    );
+
+    let nextAllowlist = visible.row.secretsAllowlist ?? null;
+    let droppedSecrets: string[] = [];
+    let addedSecrets: string[] = [];
+    if (wantsSecrets) {
+      const decided = rescopeSessionSecrets({
+        current: visible.row.secretsAllowlist ?? null,
+        requested: (body.secrets ?? null) as string[] | null,
+        agentGrantEnv: grant?.env,
+      });
+      if (!decided.ok) return c.json({ error: decided.message, code: decided.code }, 403);
+      nextAllowlist = decided.allowlist;
+      droppedSecrets = decided.dropped;
+      addedSecrets = decided.added;
+    }
+
+    let nextBindings = currentBindings;
+    let droppedBindings: string[] = [];
+    if (wantsBindings) {
+      const requested = Object.fromEntries(
+        Object.entries(
+          (body.connector_bindings ?? {}) as Record<string, { profile_id?: unknown }>,
+        ).map(([alias, value]) => [
+          alias,
+          typeof value?.profile_id === 'string' ? value.profile_id : '',
+        ]),
+      );
+      const decided = rescopeSessionBindings({
+        current: currentBindings,
+        requested,
+        grantedConnectors: grant?.connectors,
+      });
+      if (!decided.ok) return c.json({ error: decided.message, code: decided.code }, 403);
+      nextBindings = decided.bindings;
+      droppedBindings = decided.dropped;
+    }
+
+    if (wantsSecrets) {
+      await db
+        .update(projectSessions)
+        .set({ secretsAllowlist: nextAllowlist, updatedAt: new Date() })
+        .where(
+          and(eq(projectSessions.sessionId, sessionId), eq(projectSessions.projectId, projectId)),
+        );
+    }
+
+    if (wantsBindings) {
+      // Replace wholesale: the map supplied IS the new set, so a binding the
+      // caller omitted must stop existing rather than linger.
+      await db
+        .delete(projectSessionConnectorBindings)
+        .where(
+          and(
+            eq(projectSessionConnectorBindings.sessionId, sessionId),
+            eq(projectSessionConnectorBindings.projectId, projectId),
+          ),
+        );
+      // connector_id comes from the PROFILE, and the profile's account must match
+      // this project's — otherwise a caller could bind another tenant's
+      // connection by id. Same check ensureEmailSessionBinding makes.
+      const profileIds = Object.values(nextBindings);
+      const profiles = profileIds.length
+        ? await db
+            .select({
+              profileId: executorConnectionProfiles.profileId,
+              connectorId: executorConnectionProfiles.connectorId,
+              accountId: executorConnectionProfiles.accountId,
+            })
+            .from(executorConnectionProfiles)
+            .where(inArray(executorConnectionProfiles.profileId, profileIds))
+        : [];
+      const byProfile = new Map(profiles.map((row) => [row.profileId, row]));
+      const rows: Array<typeof projectSessionConnectorBindings.$inferInsert> = [];
+      for (const [alias, profileId] of Object.entries(nextBindings)) {
+        const profile = byProfile.get(profileId);
+        if (!profile || profile.accountId !== loaded.row.accountId) {
+          return c.json(
+            {
+              error: `connection ${profileId} does not exist in this project`,
+              code: 'CONNECTOR_PROFILE_NOT_FOUND',
+            },
+            404,
+          );
+        }
+        rows.push({
+          sessionId,
+          projectId,
+          accountId: loaded.row.accountId,
+          connectorAlias: alias,
+          connectorId: profile.connectorId,
+          profileId,
+          source: 'request',
+          createdBy: loaded.userId,
+        });
+      }
+      if (rows.length > 0) await db.insert(projectSessionConnectorBindings).values(rows);
+    }
+
+    // No push needed: the per-prompt hot sync re-reads secretsAllowlist and
+    // re-resolves the whole env on the NEXT prompt, and connector bindings are
+    // resolved server-side at call time. Pushing here would race that.
+    return c.json({
+      secrets_allowlist: nextAllowlist,
+      connector_bindings: Object.fromEntries(
+        Object.entries(nextBindings).map(([alias, profileId]) => [alias, { profile_id: profileId }]),
+      ),
+      dropped_secrets: droppedSecrets,
+      added_secrets: addedSecrets,
+      dropped_bindings: droppedBindings,
+      // Connector bindings ARE retroactive (resolved at call time). Secrets are
+      // not: a dropped one stops being delivered from the next prompt, but the
+      // agent's context and any shell it already spawned still hold what it read.
+      retroactive: droppedSecrets.length === 0,
+      detail:
+        droppedSecrets.length > 0
+          ? 'Dropped secrets stop being delivered from the next prompt. Values the agent already read remain in its context and in shells it already started — rotate them if that matters.'
+          : 'Applies from the next prompt.',
+    });
+  },
+);
+
 projectsApp.openapi(
   createRoute({
     method: 'put',

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -63,6 +63,7 @@ import { callerKortixSessionId } from '../lib/caller-session';
 import { DEFAULT_AGENT_SENTINEL } from '../agents';
 import { resolveSessionAgentGrant } from '../lib/secret-grant';
 import { rescopeSessionBindings, rescopeSessionSecrets } from '../lib/session-rescope';
+import { validateSessionConnectorBindings } from '../lib/session-connector-bindings';
 import { resolveEndUserRef } from '../lib/end-user-ref';
 import { selectSessionRowsForViewer, type ProjectSessionListScope } from '../lib/session-inventory';
 
@@ -2206,44 +2207,45 @@ projectsApp.openapi(
             eq(projectSessionConnectorBindings.projectId, projectId),
           ),
         );
-      // connector_id comes from the PROFILE, and the profile's account must match
-      // this project's — otherwise a caller could bind another tenant's
-      // connection by id. Same check ensureEmailSessionBinding makes.
-      const profileIds = Object.values(nextBindings);
-      const profiles = profileIds.length
-        ? await db
-            .select({
-              profileId: executorConnectionProfiles.profileId,
-              connectorId: executorConnectionProfiles.connectorId,
-              accountId: executorConnectionProfiles.accountId,
-            })
-            .from(executorConnectionProfiles)
-            .where(inArray(executorConnectionProfiles.profileId, profileIds))
-        : [];
-      const byProfile = new Map(profiles.map((row) => [row.profileId, row]));
-      const rows: Array<typeof projectSessionConnectorBindings.$inferInsert> = [];
-      for (const [alias, profileId] of Object.entries(nextBindings)) {
-        const profile = byProfile.get(profileId);
-        if (!profile || profile.accountId !== loaded.row.accountId) {
-          return c.json(
-            {
-              error: `connection ${profileId} does not exist in this project`,
-              code: 'CONNECTOR_PROFILE_NOT_FOUND',
-            },
-            404,
-          );
-        }
-        rows.push({
-          sessionId,
-          projectId,
-          accountId: loaded.row.accountId,
-          connectorAlias: alias,
-          connectorId: profile.connectorId,
-          profileId,
-          source: 'request',
-          createdBy: loaded.userId,
-        });
+      // Reuse the SAME validator session-create uses. My first version checked
+      // only the alias against the agent grant and that the profile lived in
+      // this account — which let a session owner rebind a granted alias to
+      // ANOTHER end-user's `external` profile and use it on the next tool call.
+      // That is a WRITE path to the very escalation the profile-enumeration fix
+      // closed for reads. The create path already requires
+      // PROJECT_SESSION_BINDINGS_WRITE for non-member profiles and restricts
+      // member-owned ones to their owner; re-scoping must not be a second,
+      // weaker door to the same table.
+      const mayManageSystemProfiles = await projectCapabilityAllowed(
+        c,
+        loaded.userId,
+        loaded.row.accountId,
+        projectId,
+        PROJECT_ACTIONS.PROJECT_SESSION_BINDINGS_WRITE,
+      );
+      const validated = await validateSessionConnectorBindings({
+        accountId: loaded.row.accountId,
+        projectId,
+        actingUserId: loaded.userId,
+        actingPrincipalIsServiceAccount: c.get('authType') === 'service_account',
+        mayManageSystemProfiles,
+        bindings: Object.fromEntries(
+          Object.entries(nextBindings).map(([alias, profileId]) => [alias, { profile_id: profileId }]),
+        ),
+      });
+      if (!validated.ok) {
+        return c.json({ error: validated.error, code: validated.code }, 403);
       }
+      const rows = validated.bindings.map((binding) => ({
+        sessionId,
+        projectId,
+        accountId: loaded.row.accountId,
+        connectorAlias: binding.alias,
+        connectorId: binding.connectorId,
+        profileId: binding.profileId,
+        source: 'request' as const,
+        createdBy: loaded.userId,
+      }));
       if (rows.length > 0) await db.insert(projectSessionConnectorBindings).values(rows);
     }
 


### PR DESCRIPTION
`PUT /projects/{id}/sessions/{sessionId}/scope` — **SET semantics**. Start a session with `secrets: [test_key_1, test_key_2]`, send `secrets: [test_key_2]`, and from that point the session gets only `test_key_2`.

## I was wrong about this being impossible

I said "create-only, by design" for three days, repeating the comment in the code. The comment says a mutable allowlist "could be narrowed below what the sandbox already needs and leave the session unbootable" — that is an argument about **boot**, and it had quietly become a refusal to change anything at all.

It doesn't survive contact with the machinery: `syncSandboxEnvForPrompt` already re-resolves the entire secret set and **replaces** the sandbox env on every prompt — that is how a revoked secret propagates today. Re-scoping needed no new delivery path. It needed a place to write the new list.

## What it promises, precisely

- **Forward: exact.** The next prompt's env push carries only the new set, and the daemon's env store clears the names it previously knew, so a shell started after the re-scope cannot see a dropped secret.
- **Retroactively: nothing, and it says so.** A value the agent already read is in its context and in shells it spawned earlier. The response carries `retroactive: false` and a `detail` telling the caller to rotate if that matters. A UI that said "revoked" here would be false assurance — that is how a live credential gets left in place.
- **Connector bindings ARE retroactive** — resolved server-side at call time, so the next tool call already uses the new map. Nothing about them was ever handed to the sandbox.

## Guards

- **The agent grant is the ceiling.** A session may narrow within it and restore anything inside it, but never exceed it — otherwise a session-level field would make the manifest advisory. Fail-closed: if the grant can't be resolved, the re-scope is refused rather than applied against an unverified ceiling.
- **`[]` and `null` are opposite** and stay that way: empty is "no project secrets", null is "stop narrowing". Conflating them would hand a session everything at the moment someone tried to remove all.
- **Narrowing is not a ratchet** — you can restore a secret you dropped. Otherwise one accidental re-scope is permanent for the session's life.
- **Cross-tenant binding is blocked**: `connector_id` is read from the profile and the profile's account must match the project's, so a caller can't bind another tenant's connection by id.
- Same authorization as the model change (owner or project manager; `PROJECT_SESSION_STOP` for scoped agent tokens) — seeing a session is not permission to re-scope it.

## One thing I verified instead of assuming

I flagged earlier that a movable allowlist might break the agent-switch secret lock, which refuses a switch when two agents' grants differ. It doesn't — that lock compares **agent grants** (`sessionGrant?.env` vs `runningGrant?.env`), never the session allowlist. No interaction.

## Verification

13 tests on the pure policy, covering the founder's exact case, the `[]`-vs-`null` distinction, the restore path, the grant ceiling, and case-insensitive matching. Full `apps/api` suite: **23 failures, zero new.** `tsc --noEmit` clean.

## Next

The demo UI (editable scope bar) and per-prompt call display are separate — this is the API they need.