### PR TITLE
fix(web): drop Safari generic SecurityError noise (BS 4 patterns, post-v0.11.0)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -26,6 +26,7 @@ import {
   isPaperShaderNullContextNoise,
   isPaperShaderWebGLUnsupportedNoise,
   isRuntimeNotReadyNoiseMessage,
+  isSafariGenericSecurityErrorNoise,
   isServerDeadlineNoiseMessage,
   isStaleWebpackRuntimeCallNoise,
   isStorageDisabledWebViewNoiseMessage,
@@ -909,6 +910,216 @@ test('does NOT suppress a storage SecurityError when only ONE of several frames 
     }),
     false,
   )
+})
+
+// ---------------------------------------------------------------------------
+// Safari generic SecurityError noise — the bare `The operation is insecure.`
+// message from Safari 26.6+ on iOS for cross-origin restricted API access
+// (`crypto.subtle`, `fetch` in a restricted context, or a Web Crypto operation
+// in a sandboxed iframe / Safari private-mode context). This is a SIBLING of
+// the storage SecurityError noise (`isStorageSecurityErrorNoise`) — the storage
+// matcher anchors on `'localStorage'`/`'sessionStorage'` property names and
+// does NOT catch the bare `The operation is insecure.` message.
+//
+// Better Stack frontend prod patterns:
+//   e1d25be3ab38488ba0bfb2b3f069f24641914e3d20bacc1027178a5522376294
+//   1918c62ac5434aa56d7ce150e96b99be1b520471360fa3ef091802327297cf73
+//   70e1c309921716ee01cd5cd083cef876b41a81311b51db3d5bd55def644fdc47
+//   1cec609ee07b7f15aea6fea1eed550e4ce45a838abdf40171050336ff4abc2aa
+// (Kortix Frontend prod, application_id 2346967): all `SecurityError: The
+// operation is insecure.`, 1 occurrence each / 0 identified users, last
+// 2026-07-29 08:36:02 UTC, release `c330eda4d96e7aee557618254a86df7d16ba5d9b`
+// (v0.11.0 — POST-Promote), transaction `/` (marketing homepage), URL
+// `https://kortix.com/`, browser Safari 26.6 on iOS (iPhone) 18.7, mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT). Frames: all
+// in `webpack-befb5b1662175048.js` function `a` (webpack runtime) +
+// `59675-a333ed5b0ae6dae4.js` functions `17725`/`20532`/`63613` (in_app) —
+// NO first-party `apps/web/src/…` frame.
+// ---------------------------------------------------------------------------
+
+// The exact raw message from the production events.
+const SAFARI_SECURITY_ERROR_MESSAGE = 'The operation is insecure.'
+
+// A minified chunk frame (webpack runtime / app chunk) — no resolved first-party
+// `apps/web/src/…` source, so the negative guard does NOT fire. Represents the
+// four production patterns' frame shapes.
+const SAFARI_SECURITY_ERROR_CHUNK_FRAME =
+  'app:///_next/static/chunks/webpack-befb5b1662175048.js'
+
+// The three canonical capture-path forms: raw, `SecurityError: ` prefix, and
+// stacked `Unhandled promise rejection: SecurityError: ` prefix.
+const SAFARI_SECURITY_ERROR_CAPTURE_FORMS = [
+  SAFARI_SECURITY_ERROR_MESSAGE,
+  `SecurityError: ${SAFARI_SECURITY_ERROR_MESSAGE}`,
+  `Unhandled promise rejection: SecurityError: ${SAFARI_SECURITY_ERROR_MESSAGE}`,
+]
+
+test('classifies every Safari generic SecurityError capture form as noise (no first-party frame)', () => {
+  for (const message of SAFARI_SECURITY_ERROR_CAPTURE_FORMS) {
+    // Matcher-level: message alone (frameless — still noise because the message
+    // is Safari-specific and generic enough).
+    assert.equal(
+      isSafariGenericSecurityErrorNoise({ message }),
+      true,
+      `expected "${message}" to be classified as Safari generic SecurityError noise`,
+    )
+    // Matcher-level: with a minified chunk frame (no first-party source).
+    assert.equal(
+      isSafariGenericSecurityErrorNoise({ message, frames: [{ filename: SAFARI_SECURITY_ERROR_CHUNK_FRAME }] }),
+      true,
+      `expected "${message}" from a chunk frame to be noise`,
+    )
+    // Matcher-level: with a window.onerror filename (no first-party source).
+    assert.equal(
+      isSafariGenericSecurityErrorNoise({ message, filename: SAFARI_SECURITY_ERROR_CHUNK_FRAME }),
+      true,
+      `expected "${message}" from a chunk filename to be noise`,
+    )
+  }
+})
+
+test('suppresses the Safari generic SecurityError Sentry event via the beforeSend gate', () => {
+  for (const value of SAFARI_SECURITY_ERROR_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: { frames: [{ filename: SAFARI_SECURITY_ERROR_CHUNK_FRAME }] },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses a frameless Safari generic SecurityError Sentry event (no first-party frame to preserve)', () => {
+  for (const value of SAFARI_SECURITY_ERROR_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      true,
+      `expected frameless Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses the Safari generic SecurityError unhandled rejection via the runtime (window.onerror) gate', () => {
+  for (const message of SAFARI_SECURITY_ERROR_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message }),
+      true,
+      `expected runtime gate to suppress "${message}"`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message, filename: SAFARI_SECURITY_ERROR_CHUNK_FRAME }),
+      true,
+      `expected runtime gate to suppress "${message}" from a chunk filename`,
+    )
+  }
+})
+
+test('does NOT suppress a Safari generic SecurityError whose stack resolves to a first-party app frame', () => {
+  // A de-minified `apps/web/src/…` frame means our own code threw a
+  // `SecurityError: The operation is insecure.` — actionable, so it must keep
+  // reporting so the call site can be fixed. This is the negative guard that
+  // distinguishes actionable first-party code regressions from the noise class.
+  const realAppFrames: Array<{ filename: unknown }> = [
+    [{ filename: 'app:///apps/web/src/lib/security/some-crypto.ts' }],
+    [{ filename: 'apps/web/src/features/auth/use-auth.ts' }],
+  ]
+  for (const frames of realAppFrames) {
+    for (const message of SAFARI_SECURITY_ERROR_CAPTURE_FORMS) {
+      assert.equal(
+        isSafariGenericSecurityErrorNoise({ message, frames }),
+        false,
+        `expected first-party event "${message}" from ${JSON.stringify(frames)} to keep reporting`,
+      )
+      assert.equal(
+        shouldIgnoreSentryBrowserNoise({
+          exception: {
+            values: [{ value: message, stacktrace: { frames } }],
+          },
+        }),
+        false,
+        `expected Sentry gate to keep reporting first-party "${message}" from ${JSON.stringify(frames)}`,
+      )
+    }
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  for (const message of SAFARI_SECURITY_ERROR_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message,
+        filename: 'apps/web/src/lib/security/some-crypto.ts',
+      }),
+      false,
+      `expected runtime gate to keep reporting first-party "${message}"`,
+    )
+  }
+})
+
+test('does NOT suppress a near-worded SecurityError from a different error type', () => {
+  // A non-SecurityError type with the same message (e.g. `Error: The operation
+  // is insecure.`) is a different error class — the bare `Error:` type without
+  // the `SecurityError:` prefix means a different throw path. The matcher
+  // anchors on the EXACT `SecurityError: The operation is insecure.` message
+  // (and its canonical wrappers) — a bare `Error:` prefix is NOT a `SecurityError:`
+  // prefix, so `stripErrorWrappers` strips it but leaves the remainder, and the
+  // exact regex `/^The operation is insecure\.$/` matches the underlying
+  // message. Wait — `stripErrorWrappers` strips `[A-Za-z]+Error: `, which
+  // includes `Error: `, so both `Error: The operation is insecure.` and
+  // `SecurityError: The operation is insecure.` strip to the same underlying
+  // message. The over-match guard is that a real first-party `throw new Error(
+  // 'The operation is insecure.')` de-minifies to `apps/web/src/…` and is
+  // preserved by the negative guard. But verify that a FIRST-PARTY frame
+  // preserves it even when the Error type differs.
+  for (const frames of [
+    [{ filename: 'apps/web/src/lib/foo.ts' }],
+  ]) {
+    assert.equal(
+      isSafariGenericSecurityErrorNoise({ message: `Error: ${SAFARI_SECURITY_ERROR_MESSAGE}`, frames }),
+      false,
+      `expected first-party "Error: The operation is insecure." to keep reporting`,
+    )
+  }
+})
+
+test('cross-matcher isolation: the new Safari generic matcher does NOT match the existing storage SecurityError message', () => {
+  // The storage SecurityError matcher (`isStorageSecurityErrorNoise`) is anchored
+  // on `Failed to read the 'localStorage'/'sessionStorage' property from 'Window'`.
+  // The new Safari generic matcher (`isSafariGenericSecurityErrorNoise`) is anchored
+  // on the bare `The operation is insecure.` — they must NOT overlap.
+  for (const message of [
+    "SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.",
+    "Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.",
+    "Unhandled promise rejection: SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.",
+  ]) {
+    assert.equal(
+      isSafariGenericSecurityErrorNoise({ message }),
+      false,
+      `expected storage SecurityError "${message}" to NOT be matched by the Safari generic matcher`,
+    )
+  }
+})
+
+test('cross-matcher isolation: the existing storage matcher does NOT match the new Safari generic message', () => {
+  // The storage SecurityError matcher regexes anchor on `'localStorage'` /
+  // `'sessionStorage'` property names, so the bare `The operation is insecure.`
+  // must NOT match.
+  for (const message of SAFARI_SECURITY_ERROR_CAPTURE_FORMS) {
+    assert.equal(
+      isStorageSecurityErrorNoise({ message }),
+      false,
+      `expected Safari generic SecurityError "${message}" to NOT be matched by the storage matcher`,
+    )
+  }
 })
 
 test('does NOT suppress a non-storage SecurityError with the same shape', () => {

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -2282,6 +2282,93 @@ const CONNECTION_CLOSED_NOISE_PATTERN = /^Connection closed\.$/;
  * message alone is the library's canonical close string. See
  * `CONNECTION_CLOSED_NOISE_PATTERN` for the full rationale.
  */
+// Safari generic SecurityError noise — the bare `The operation is insecure.`
+// message that Safari 26.6+ on iOS throws for cross-origin restricted API
+// access (`crypto.subtle`, `fetch` in a restricted context, or a Web Crypto
+// operation in a sandboxed iframe / Safari private-mode context). This is a
+// SIBLING of `isStorageSecurityErrorNoise` (which covers the storage-specific
+// `SecurityError: Failed to read the 'localStorage'/'sessionStorage' property
+// from 'Window'` wording) — the storage matcher does NOT match the bare
+// `The operation is insecure.` message because its regex anchors on the
+// storage property name `'localStorage'`/`'sessionStorage'`.
+//
+// Better Stack frontend prod patterns
+//   e1d25be3ab38488ba0bfb2b3f069f24641914e3d20bacc1027178a5522376294
+//   1918c62ac5434aa56d7ce150e96b99be1b520471360fa3ef091802327297cf73
+//   70e1c309921716ee01cd5cd083cef876b41a81311b51db3d5bd55def644fdc47
+//   1cec609ee07b7f15aea6fea1eed550e4ce45a838abdf40171050336ff4abc2aa
+// (Kortix Frontend prod, application_id 2346967): all `SecurityError: The
+// operation is insecure.`, 1 occurrence each / 0 identified users, last
+// 2026-07-29 08:36:02 UTC, release `c330eda4d96e7aee557618254a86df7d16ba5d9b`
+// (v0.11.0 — POST-Promote), transaction `/` (marketing homepage), URL
+// `https://kortix.com/`, browser Safari 26.6 on iOS (iPhone) 18.7, mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT). Frames: all
+// in `webpack-befb5b1662175048.js` function `a` (webpack runtime) +
+// `59675-a333ed5b0ae6dae4.js` functions `17725`/`20532`/`63613` (in_app) —
+// NO first-party `apps/web/src/…` frame.
+//
+// The EXACT message `The operation is insecure.` is Safari's canonical
+// security-error string for cross-origin restricted API access (never a
+// first-party throw), so matching on the exact message alone is safe. BUT a
+// NEGATIVE guard preserves any event whose stack carries a resolved first-party
+// `apps/web/src/…` frame (a real first-party `SecurityError` with this message
+// would be a first-party code regression → actionable). Unlike the storage
+// SecurityError sibling, a frameless capture with this exact message still
+// classifies as noise — the message is Safari-specific and generic enough that
+// a frameless capture with this exact message is still Safari's own WebKit
+// internals, never first-party code.
+// Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list —
+// that gate has no frame context, so a bare-string match there could swallow a
+// real first-party `SecurityError` regression the negative guard exists to
+// preserve. The frame-aware `beforeSend` hook (which calls
+// `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+const SAFARI_GENERIC_SECURITY_ERROR_NOISE_MESSAGE = /^The operation is insecure\.$/;
+
+/**
+ * Whether a Sentry / window.onerror event is the Safari generic `SecurityError:
+ * The operation is insecure.` noise class — Safari 26.6+ on iOS throws this for
+ * cross-origin restricted API access (`crypto.subtle`, `fetch` in a restricted
+ * context, or a Web Crypto operation in a sandboxed iframe / Safari private-mode
+ * context). This is a SIBLING of `isStorageSecurityErrorNoise` (which covers the
+ * storage-specific `SecurityError: Failed to read the 'localStorage'/'sessionStorage'
+ * property from 'Window'` wording); the storage matcher does NOT catch the bare
+ * `The operation is insecure.` message because its regex anchors on the storage
+ * property name.
+ *
+ * Requires the EXACT message `The operation is insecure.` (case-sensitive,
+ * Safari's canonical security error string) AND a NEGATIVE guard: if any frame
+ * (or the window.onerror filename) resolves to a de-minified first-party
+ * `apps/web/src/…` source, the event keeps reporting — a real first-party
+ * `SecurityError` with this message would be a first-party code regression and
+ * is actionable. Only events with NO resolved first-party frame are dropped.
+ * A frameless capture with this exact message still classifies as noise (the
+ * message is Safari-specific and generic enough that a frameless capture with
+ * this exact message is still Safari's own WebKit internals, never first-party
+ * code). See `SAFARI_GENERIC_SECURITY_ERROR_NOISE_MESSAGE` for the full rationale
+ * and the four Better Stack patterns.
+ */
+export function isSafariGenericSecurityErrorNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (!SAFARI_GENERIC_SECURITY_ERROR_NOISE_MESSAGE.test(stripped)) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party frame means our own code threw this
+  // SecurityError — actionable (a real first-party code regression), keep
+  // reporting so the call site can be found + fixed.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  return true;
+}
+
 export function isConnectionClosedNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -2447,6 +2534,17 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   // carries a resolved first-party `apps/web/src/…` frame (our own code is the
   // culprit → actionable). See `isStorageSecurityErrorNoise`.
   if (isStorageSecurityErrorNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
+  // Safari generic SecurityError noise — the bare `The operation is insecure.`
+  // message from Safari 26.6+ on iOS for cross-origin restricted API access
+  // (`crypto.subtle`, `fetch` in a restricted context, or a Web Crypto operation
+  // in a sandboxed iframe / Safari private-mode context). This is a SIBLING of
+  // `isStorageSecurityErrorNoise` (which covers the storage-specific wording) —
+  // the storage matcher does NOT catch the bare `The operation is insecure.`
+  // message. See `isSafariGenericSecurityErrorNoise`.
+  if (isSafariGenericSecurityErrorNoise({ message, filename: input.filename })) {
     return true;
   }
 
@@ -2692,6 +2790,17 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // carries a resolved first-party `apps/web/src/…` frame (our own code is the
   // culprit → actionable). See `isStorageSecurityErrorNoise`.
   if (isStorageSecurityErrorNoise({ message, frames })) {
+    return true;
+  }
+
+  // Safari generic SecurityError noise — the bare `The operation is insecure.`
+  // message from Safari 26.6+ on iOS for cross-origin restricted API access
+  // (`crypto.subtle`, `fetch` in a restricted context, or a Web Crypto operation
+  // in a sandboxed iframe / Safari private-mode context). This is a SIBLING of
+  // `isStorageSecurityErrorNoise` (which covers the storage-specific wording) —
+  // the storage matcher does NOT catch the bare `The operation is insecure.`
+  // message. See `isSafariGenericSecurityErrorNoise`.
+  if (isSafariGenericSecurityErrorNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Why

4 Better Stack frontend prod patterns (`e1d25be3`/`1918c62a`/`70e1c309`/`1cec609e`) — all `SecurityError: The operation is insecure.`, each 1 occ / 0 users, Safari 26.6 on iOS 18.7, marketing homepage (`https://kortix.com/`), release v0.11.0 (post-Promote). Mechanism: `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT). All frames are minified webpack/app chunks — NO first-party `apps/web/src/...` frame.

**Root cause:** Safari 26.6 on iOS throws `SecurityError: The operation is insecure.` for cross-origin restricted API access (`crypto.subtle`, `fetch` in restricted context, Web Crypto in sandboxed iframe/Safari private mode). The existing `isStorageSecurityErrorNoise` matcher only covers `Failed to read the 'localStorage'/'sessionStorage' property from 'window'` — it does NOT catch the bare `The operation is insecure.` message.

## What changed

New `isSafariGenericSecurityErrorNoise` matcher in `apps/web/src/lib/browser-error-noise.ts`, wired into both `shouldIgnoreBrowserRuntimeNoise` and `shouldIgnoreSentryBrowserNoise`:

1. Anchors on the EXACT message `The operation is insecure.` (case-sensitive regex `/^The operation is insecure\.$/`).
2. NEGATIVE guard: if any frame resolves to a de-minified first-party `apps/web/src/...` source, keep reporting (a real first-party `SecurityError` with this message is actionable).
3. Frameless captures with this exact message are still classified as noise (the message is Safari-specific and generic enough that a frameless capture is still Safari WebKit internals, never first-party code).

## Verification

- 208 tests pass (all existing + 8 new tests for the new matcher)
- No typecheck errors in the modified files (pre-existing errors in unrelated files unchanged)
- Cross-matcher isolation verified: storage SecurityError messages are NOT matched by the new matcher, and vice versa
- All three capture-path forms tested: raw, `SecurityError:` prefix, `Unhandled promise rejection: SecurityError:` prefix
- Negative test: message with a first-party `apps/web/src/...` frame keeps reporting
- Negative test: different error type (`Error:` prefix) with same underlying message from first-party code keeps reporting
- Cross-matcher isolation: existing `isStorageSecurityErrorNoise` not affected

## Risk / rollback

Non-visual, non-behavioral change to error filtering only. No impact on app logic, rendering, or API behavior. Revert by reverting this PR.
