### PR TITLE
fix(models): lock the default row, refresh without a reload, set the default inline

### DIFF
--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -2713,6 +2713,11 @@ projectsApp.openapi(
       getAccountModelDefaults(accountId, projectId),
       getProjectRoutingPolicy(projectId),
     ]);
+    // What `auto` resolves to for this project. Served below so the client can
+    // LOCK its switch instead of offering a toggle that always 409s.
+    const effectiveDefault = toWireModel(
+      defaults.projects[projectId] ?? defaults.account ?? config.LLM_GATEWAY_DEFAULT_MODEL ?? '',
+    );
     const requiredModels = [
       defaults.projects[projectId],
       defaults.account,
@@ -2742,6 +2747,11 @@ projectsApp.openapi(
       // merged map back without having to reconstruct it by diffing the
       // resolved flags against a default it would have to recompute.
       modelOverrides: routing?.modelOverrides ?? {},
+      // The model `auto` resolves to. It cannot be turned off (that would break
+      // every default request — the PUT refuses it with 409), so the client
+      // renders its switch as locked rather than letting the user click into an
+      // error.
+      defaultModel: effectiveDefault || undefined,
       // True while the project has made no exceptions at all — the only thing
       // "reset to defaults" has left to act on, and not derivable from the
       // `enabled` flags alone (they look identical either way).

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
@@ -6,7 +6,13 @@ import { Switch } from '@/components/ui/switch';
 import { Tag } from '@/components/ui/tag';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { cn } from '@/lib/utils';
-import { useModelEnablement, useProjectModels } from '@kortix/sdk/react';
+import {
+  useModelDefaults,
+  useModelEnablement,
+  useProjectModels,
+  wireToModelKey,
+} from '@kortix/sdk/react';
+import { Star } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 
@@ -24,6 +30,10 @@ export function ModelsTab({ projectId, search }: { projectId: string; search: st
   // is the one and only thing deciding whether it appears there.
   const models = useProjectModels(projectId);
   const enablement = useModelEnablement(projectId);
+  // Setting the project default from here is what makes the locked row
+  // actionable: the only way to turn the default off is to make something else
+  // the default, so the control for that belongs on the same screen.
+  const defaults = useModelDefaults(projectId);
 
   const groups = useMemo(() => buildModelGroups(models, search), [models, search]);
   const enabledCount = useMemo(() => models.filter((m) => m.enabled).length, [models]);
@@ -86,6 +96,11 @@ export function ModelsTab({ projectId, search }: { projectId: string; search: st
             <div className="bg-popover overflow-hidden rounded-md border">
               {group.rows.map(({ model, wireId, isRollingAlias }, i) => {
                 const enabled = !!model.enabled;
+                // `auto` resolves to this one, so turning it off would break
+                // every default request — the server refuses it with a 409.
+                // Lock the switch and say why instead of letting the click
+                // become a failed action.
+                const isProjectDefault = wireId === enablement.defaultModel;
                 const ctx = formatTokenCount(model.contextWindow);
                 const priceIn = model.cost ? formatPricePerMillion(model.cost.input) : '';
                 const priceOut = model.cost ? formatPricePerMillion(model.cost.output) : '';
@@ -93,7 +108,8 @@ export function ModelsTab({ projectId, search }: { projectId: string; search: st
                   <label
                     key={wireId}
                     className={cn(
-                      'hover:bg-muted/40 flex cursor-pointer items-start gap-3 px-3 py-2.5 transition-colors',
+                      'hover:bg-muted/40 flex items-start gap-3 px-3 py-2.5 transition-colors',
+                      isProjectDefault ? 'cursor-default' : 'cursor-pointer',
                       i > 0 && 'border-border border-t',
                       !enabled && 'opacity-60',
                     )}
@@ -109,6 +125,7 @@ export function ModelsTab({ projectId, search }: { projectId: string; search: st
                         {/* Same display name as its pinned snapshots — say which
                             row is the one that rolls forward. */}
                         {isRollingAlias && <Tag>latest</Tag>}
+                        {isProjectDefault && <Tag>project default</Tag>}
                       </div>
                       <div className="flex min-w-0 items-center gap-0.5">
                         <code className="text-muted-foreground/50 min-w-0 truncate font-mono text-xs">
@@ -127,9 +144,36 @@ export function ModelsTab({ projectId, search }: { projectId: string; search: st
                         </InlineMeta>
                       )}
                     </div>
+                    {!isProjectDefault && enabled && (
+                      <button
+                        type="button"
+                        disabled={defaults.isUpdating}
+                        title={`Make ${model.modelName} this project's default model`}
+                        onClick={(e) => {
+                          // The row is a <label> wrapping the switch — without
+                          // this the click would toggle enablement instead.
+                          e.preventDefault();
+                          e.stopPropagation();
+                          void defaults.setProjectDefault(wireToModelKey(wireId));
+                        }}
+                        className="text-muted-foreground/50 hover:text-foreground hover:bg-muted mt-0.5 flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <Star className="size-3.5" />
+                      </button>
+                    )}
                     <Switch
                       checked={enabled}
-                      disabled={enablement.isUpdating}
+                      disabled={enablement.isUpdating || isProjectDefault}
+                      aria-label={
+                        isProjectDefault
+                          ? `${model.modelName} is this project's default model and cannot be turned off`
+                          : `Offer ${model.modelName}`
+                      }
+                      title={
+                        isProjectDefault
+                          ? "This project's default model — set a different default to turn it off."
+                          : undefined
+                      }
                       onCheckedChange={(next) => void enablement.setEnabled(wireId, next)}
                       className="mt-0.5 shrink-0"
                     />

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
@@ -105,11 +105,15 @@ export function ModelsTab({ projectId, search }: { projectId: string; search: st
                 const priceIn = model.cost ? formatPricePerMillion(model.cost.input) : '';
                 const priceOut = model.cost ? formatPricePerMillion(model.cost.output) : '';
                 return (
-                  <label
+                  // A plain row, NOT a <label>: it holds three controls (copy
+                  // id, set-as-default, the switch) and a label binds to the
+                  // FIRST labelable one — the copy button — so "click the row
+                  // to toggle" never did what it looked like. Each control
+                  // carries its own accessible name instead.
+                  <div
                     key={wireId}
                     className={cn(
                       'hover:bg-muted/40 flex items-start gap-3 px-3 py-2.5 transition-colors',
-                      isProjectDefault ? 'cursor-default' : 'cursor-pointer',
                       i > 0 && 'border-border border-t',
                       !enabled && 'opacity-60',
                     )}
@@ -149,13 +153,7 @@ export function ModelsTab({ projectId, search }: { projectId: string; search: st
                         type="button"
                         disabled={defaults.isUpdating}
                         title={`Make ${model.modelName} this project's default model`}
-                        onClick={(e) => {
-                          // The row is a <label> wrapping the switch — without
-                          // this the click would toggle enablement instead.
-                          e.preventDefault();
-                          e.stopPropagation();
-                          void defaults.setProjectDefault(wireToModelKey(wireId));
-                        }}
+                        onClick={() => void defaults.setProjectDefault(wireToModelKey(wireId))}
                         className="text-muted-foreground/50 hover:text-foreground hover:bg-muted mt-0.5 flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         <Star className="size-3.5" />
@@ -177,7 +175,7 @@ export function ModelsTab({ projectId, search }: { projectId: string; search: st
                       onCheckedChange={(next) => void enablement.setEnabled(wireId, next)}
                       className="mt-0.5 shrink-0"
                     />
-                  </label>
+                  </div>
                 );
               })}
             </div>

--- a/packages/sdk/src/core/rest/projects-client/projects.ts
+++ b/packages/sdk/src/core/rest/projects-client/projects.ts
@@ -173,6 +173,12 @@ export interface ProjectLlmCatalogResponse {
    * `enabled` flags alone.
    */
   usingDefaults?: boolean;
+  /**
+   * The wire model `auto` resolves to for this project. It can never be turned
+   * off (the PUT refuses it with 409 — disabling it would break every default
+   * request), so surfaces with a per-model switch must render this one locked.
+   */
+  defaultModel?: string;
 }
 
 export interface ProjectInput {

--- a/packages/sdk/src/react/use-model-enablement.ts
+++ b/packages/sdk/src/react/use-model-enablement.ts
@@ -3,12 +3,20 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
+import type { ProjectLlmCatalogResponse } from '../core/rest/projects-client';
 import { getProjectModelPicker } from '../core/rest/projects-client';
 import { setProjectModelEnablement } from '../core/rest/projects-client/model-enablement';
+
+type ProjectModelPicker = ProjectLlmCatalogResponse;
 
 export interface UseModelEnablement {
   /** True while the project has made no exceptions to the catalog default. */
   usingDefaults: boolean;
+  /**
+   * The model `auto` resolves to. It cannot be turned off, so render its switch
+   * locked rather than letting the user click into a 409.
+   */
+  defaultModel: string | undefined;
   /** Pin a wire model on/off, as an exception to the default. */
   setEnabled: (wireModel: string, enabled: boolean) => Promise<void>;
   /** Drop every exception so the catalog default applies again. */
@@ -40,7 +48,37 @@ export function useModelEnablement(projectId: string | null | undefined): UseMod
   const mutation = useMutation({
     mutationFn: (next: Record<string, boolean>) =>
       setProjectModelEnablement(projectId as string, next),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey }),
+    // Apply the new flags to the cached picker payload up front. Every surface
+    // reads `enabled` off THIS query — the switch and the session picker both —
+    // so without it the UI sits on the pre-toggle answer until the round trip
+    // lands (and any picker that is currently unmounted keeps serving the stale
+    // list when it remounts, which reads as "I had to hard refresh").
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ProjectModelPicker>(queryKey);
+      if (previous) {
+        queryClient.setQueryData<ProjectModelPicker>(queryKey, {
+          ...previous,
+          models: Object.fromEntries(
+            Object.entries(previous.models ?? {}).map(([id, model]) => [
+              id,
+              next[id] === undefined ? model : { ...model, enabled: next[id] },
+            ]),
+          ),
+          modelOverrides: next,
+          usingDefaults: Object.keys(next).length === 0,
+        });
+      }
+      return { previous };
+    },
+    // A rejected write (e.g. 409 on the project default) must not leave the UI
+    // showing a state the server refused.
+    onError: (_err, _next, context) => {
+      if (context?.previous) queryClient.setQueryData(queryKey, context.previous);
+    },
+    // `refetchType: 'all'` so an unmounted picker's cache is refreshed too, not
+    // just marked stale.
+    onSettled: () => queryClient.invalidateQueries({ queryKey, refetchType: 'all' }),
   });
 
   // The stored exceptions, served alongside the resolved flags so a toggle is
@@ -49,6 +87,7 @@ export function useModelEnablement(projectId: string | null | undefined): UseMod
 
   return {
     usingDefaults: data?.usingDefaults ?? true,
+    defaultModel: data?.defaultModel,
     setEnabled: useCallback(
       async (wireModel: string, enabled: boolean) => {
         await mutation.mutateAsync({ ...overrides, [wireModel]: enabled });


### PR DESCRIPTION
Three issues reported from actually using the Manage models tab.

### 1. `Cannot disable the project default model` shown as a failed action

The default model's switch rendered as freely toggleable, and clicking it produced a raw 409 toast.

The guard itself is correct — turning off the model `auto` resolves to would break every default request — but the UI had no way to know which row it applied to, because `/model-picker` never said which model was the default.

It now serves `defaultModel`, and that row renders with a **`project default`** tag, a **locked switch**, and a title explaining why.

### 2. "I have to hard refresh the page in order to see the models"

Toggling only invalidated the picker query, so the UI sat on the pre-toggle answer until the round trip landed — and a picker that was *unmounted* at the time (its popover is closed while you're in the modal) kept serving the stale list when it remounted.

The mutation now applies the new flags to the cached payload **optimistically** and settles with `refetchType: 'all'`, with a rollback so a refused write never leaves the UI ahead of the server.

### 3. Show + set the project default from the provider modal

Each enabled row gets a star action wiring straight into `useModelDefaults.setProjectDefault`, which already invalidates the picker query.

This is also what makes the locked row **actionable**: the only way to turn the default off is to make something else the default, so that control now lives on the same screen.

## Verified live

Against a real project and the real HTTP routes:

| step | result |
|---|---|
| `/model-picker` serves the default | `defaultModel: "glm-5.2"` |
| PUT that model off | `409 cannot_disable_default` |
| set default → `claude-opus-4.8` | lock **moves** to that row |
| now PUT `glm-5.2` off | `200`, toggles off cleanly |
| clear the project default | reverts to `glm-5.2` |

Tests: sdk 567, api 11, web 45. Typecheck + Biome clean.