### PR TITLE
fix(auth): never return sign-in to projects list

### DIFF
--- a/apps/web/src/lib/auth/return-url.test.mts
+++ b/apps/web/src/lib/auth/return-url.test.mts
@@ -3,7 +3,11 @@ import test from 'node:test'
 
 import { DEFAULT_AUTH_RETURN_URL, sanitizeAuthReturnUrl } from './return-url.ts'
 
-test('keeps safe relative auth return paths', () => {
+test('does not return from auth to the projects list', () => {
+  assert.equal(sanitizeAuthReturnUrl('/projects'), DEFAULT_AUTH_RETURN_URL)
+})
+
+test('keeps explicit projects-list actions', () => {
   assert.equal(sanitizeAuthReturnUrl('/projects?tab=recent'), '/projects?tab=recent')
 })
 

--- a/apps/web/src/lib/auth/return-url.test.ts
+++ b/apps/web/src/lib/auth/return-url.test.ts
@@ -21,9 +21,10 @@ describe('sanitizeAuthReturnUrl', () => {
     expect(sanitizeAuthReturnUrl('//evil.example.com')).toBe(PROJECT_LANDING_PATH);
   });
 
-  test('still honours an explicit deep link to the projects list', () => {
-    // The list stays reachable — it just stops being the default.
-    expect(sanitizeAuthReturnUrl('/projects')).toBe('/projects');
+  test('does not return from auth to the projects list', () => {
+    // Middleware sends an unauthenticated /projects request through /auth.
+    // Returning to the list exposes it while first-project provisioning runs.
+    expect(sanitizeAuthReturnUrl('/projects')).toBe(PROJECT_LANDING_PATH);
   });
 });
 

--- a/apps/web/src/lib/auth/return-url.ts
+++ b/apps/web/src/lib/auth/return-url.ts
@@ -43,6 +43,12 @@ export function sanitizeAuthReturnUrl(
     return fallback;
   }
 
+  // Middleware preserves an unauthenticated request as the post-auth return
+  // path. A request for the bare list must still enter through the landing
+  // door. Otherwise a new account renders /projects while its first project is
+  // being provisioned.
+  if (trimmedValue === '/projects') return PROJECT_LANDING_PATH;
+
   if (LEGACY_AUTH_RETURN_PREFIXES.some((prefix) => {
     return trimmedValue === prefix || trimmedValue.startsWith(`${prefix}/`) || trimmedValue.startsWith(`${prefix}?`);
   })) {


### PR DESCRIPTION
## Summary
- Normalize the bare /projects post-auth return path to /projects/start.
- Keep explicit projects-list query actions unchanged.
- Add regression coverage for the unauthenticated /projects sign-in path.

## Verification
- bun test: 2337 pass, 0 fail.
- Focused auth and landing tests: 22 pass, 0 fail.
- ESLint: return-url.ts and return-url.test.ts pass.
- Real local signup: POST /auth/v1/signup returned 200 in 108 ms.
- Real first-project provision: POST /v1/projects/provision returned 201 in 2731 ms.
- Read-back returned My First Project with a managed repo URL.
- Browser DOM verification is pending because the browser connector reported zero available backends.