### PR TITLE
fix(web): make the sidebar Review pill actually open the Review inbox

### DIFF
--- a/apps/web/src/features/workspace/customize/customize-checkpoints.test.ts
+++ b/apps/web/src/features/workspace/customize/customize-checkpoints.test.ts
@@ -2,16 +2,21 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { menuRegistry } from '@/lib/menu-registry';
+import { railGroups } from './rail';
 
-const customizePanelSource = readFileSync(join(import.meta.dir, 'customize-panel.tsx'), 'utf8');
+// The rail lives in rail.ts and the panel that renders it in customize-panel.tsx;
+// read both so a checkpoint holds wherever a section is declared.
+const customizeSource = ['rail.ts', 'customize-panel.tsx']
+  .map((f) => readFileSync(join(import.meta.dir, f), 'utf8'))
+  .join('\n');
 
 describe('Customize information architecture', () => {
   test('Git and Sandbox templates live in Manage without a Workspace group', () => {
-    expect(customizePanelSource).not.toContain("label: 'Workspace'");
-    expect(customizePanelSource).toContain("section: 'git', label: 'Git'");
-    expect(customizePanelSource).toContain("section: 'sandbox', label: 'Sandbox templates'");
-    expect(customizePanelSource).not.toContain("section: 'changes'");
-    expect(customizePanelSource).not.toContain("section: 'dev'");
+    expect(customizeSource).not.toContain("label: 'Workspace'");
+    expect(customizeSource).toContain("section: 'git', label: 'Git'");
+    expect(customizeSource).toContain("section: 'sandbox', label: 'Sandbox templates'");
+    expect(customizeSource).not.toContain("section: 'changes'");
+    expect(customizeSource).not.toContain("section: 'dev'");
 
     const git = menuRegistry.find((item) => item.id === 'proj-git');
     expect(git?.label).toBe('Customize · Git');
@@ -22,13 +27,20 @@ describe('Customize information architecture', () => {
   });
 
   test('Files is not a customize rail section — it lives on the standalone files page', () => {
-    expect(customizePanelSource).not.toContain("section: 'files'");
+    expect(customizeSource).not.toContain("section: 'files'");
     const entry = menuRegistry.find((item) => item.id === 'proj-files');
     expect(entry?.label).toBe('Files');
     expect(entry?.href).toBe('/projects/{projectId}/files');
   });
 
   test('LLM management remains reachable from the Connect rail group', () => {
-    expect(customizePanelSource).toContain('if (llmGatewayAvailable) items.push(LLM_ITEM)');
+    const connect = railGroups({
+      tunnelEnabled: false,
+      marketplaceEnabled: false,
+      llmGatewayAvailable: true,
+      voiceEnabled: false,
+      reviewEnabled: false,
+    }).find((g) => g.label === 'Connect');
+    expect(connect?.items.some((i) => i.section === 'llm-management')).toBe(true);
   });
 });

--- a/apps/web/src/features/workspace/customize/customize-panel.tsx
+++ b/apps/web/src/features/workspace/customize/customize-panel.tsx
@@ -13,12 +13,12 @@ import { AgentsView } from '@/features/workspace/customize/sections/view/agents-
 import { ChannelsView } from '@/features/workspace/customize/sections/view/channels-view';
 import { ComputersView } from '@/features/workspace/customize/sections/view/computers-view';
 import { GitView } from '@/features/workspace/customize/sections/view/git-view';
-import { VoiceView } from '@/features/workspace/customize/sections/view/voice-view';
 import { MembersView } from '@/features/workspace/customize/sections/view/members-view';
 import { SandboxView } from '@/features/workspace/customize/sections/view/sandbox-view';
 import { SecretsView } from '@/features/workspace/customize/sections/view/secrets-view';
 import { SettingsView } from '@/features/workspace/customize/sections/view/settings-view';
 import { SkillsView } from '@/features/workspace/customize/sections/view/skills-view';
+import { VoiceView } from '@/features/workspace/customize/sections/view/voice-view';
 import { useIsMobile } from '@/hooks/utils';
 import { type CustomizeSection, DEFAULT_CUSTOMIZE_SECTION } from '@/lib/customize-sections';
 import { isLlmGatewayAvailable, isLlmGatewayEnabled } from '@/lib/llm-gateway';
@@ -28,113 +28,16 @@ import { cn } from '@/lib/utils';
 import { hasOpenFloatingLayer, hasOpenNestedDialog } from '@/lib/z-stack';
 import { useCustomizeStore } from '@/stores/customize-store';
 import { getProjectDetail } from '@kortix/sdk';
-import { ArrowLeft, ChatMessages, Sparkles } from '@mynaui/icons-react';
+import { ArrowLeft } from '@mynaui/icons-react';
 import { useQuery } from '@tanstack/react-query';
-import {
-  AlarmClock,
-  ArrowUpCircle,
-  AudioLines,
-  Bot,
-  Boxes,
-  Command,
-  Container,
-  GitFork,
-  Inbox,
-  KeyRound,
-  LucideSettings,
-  LucideUsersRound,
-  Monitor,
-  Plug,
-  Store,
-  Webhook,
-} from 'lucide-react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { detectManifestVersion } from './migrate-to-v2/manifest-version';
 import { UpgradesView } from './migrate-to-v2/upgrade-view';
-import { isRailItemActive } from './rail';
+import { UPGRADE_ITEM, isRailItemActive, railGroups } from './rail';
 import { RelatedProjectsSwitcher } from './related-projects-switcher';
 import { LlmManagementView } from './sections/gateway-view';
 import { ReviewView } from './sections/view/review-view';
-import type { RailGroup, RailItem } from './type';
-
-const COMPUTERS_ITEM: RailItem = { section: 'computers', label: 'Computers', icon: Monitor };
-
-const MARKETPLACE_ITEM: RailItem = { section: 'marketplace', label: 'Marketplace', icon: Store };
-
-const VOICE_ITEM: RailItem = { section: 'voice', label: 'Voice', icon: AudioLines };
-
-const REVIEW_ITEM: RailItem = { section: 'review', label: 'Review', icon: Inbox };
-
-// The Upgrades section is always reachable (it hosts the one-off prompt runner)
-// and lives pinned at the very bottom of the rail — out of the scrolling nav (see
-// the desktop footer / mobile tail below). When a registry upgrade is actually
-// applicable (e.g. the project is still on a v1 manifest) it carries a small
-// attention dot instead of claiming a more prominent slot.
-const UPGRADE_ITEM: RailItem = { section: 'upgrade', label: 'Upgrades', icon: ArrowUpCircle };
-
-const GROUPS: readonly RailGroup[] = [
-  {
-    label: 'Build',
-    items: [
-      { section: 'agents', label: 'Agents', icon: Bot },
-      { section: 'skills', label: 'Skills', icon: Sparkles },
-      { section: 'commands', label: 'Commands', icon: Command },
-    ],
-  },
-  {
-    label: 'Connect',
-    items: [
-      { section: 'connectors', label: 'Connectors', icon: Plug },
-      { section: 'secrets', label: 'Environment variables', icon: KeyRound },
-      { section: 'channels', label: 'Channels', icon: ChatMessages },
-    ],
-  },
-  {
-    label: 'Automate',
-    items: [
-      { section: 'schedules', label: 'Schedules', icon: AlarmClock },
-      { section: 'webhooks', label: 'Webhooks', icon: Webhook },
-    ],
-  },
-  {
-    label: 'Manage',
-    items: [
-      { section: 'git', label: 'Git', icon: GitFork },
-      { section: 'sandbox', label: 'Sandbox templates', icon: Container },
-      { section: 'members', label: 'Members', icon: LucideUsersRound },
-      { section: 'settings', label: 'Settings', icon: LucideSettings },
-    ],
-  },
-];
-
-const LLM_ITEM: RailItem = { section: 'llm-management', label: 'LLM', icon: Boxes };
-
-function railGroups(
-  tunnelEnabled: boolean,
-  marketplaceEnabled: boolean,
-  llmGatewayAvailable: boolean,
-  voiceEnabled: boolean,
-  reviewEnabled: boolean,
-): readonly RailGroup[] {
-  return GROUPS.map((g) => {
-    if (g.label === 'Build' && marketplaceEnabled) {
-      return { ...g, items: [...g.items, MARKETPLACE_ITEM] };
-    }
-    if (g.label === 'Connect') {
-      const items = [...g.items];
-      if (voiceEnabled) items.push(VOICE_ITEM);
-      if (tunnelEnabled) items.push(COMPUTERS_ITEM);
-      if (llmGatewayAvailable) items.push(LLM_ITEM);
-      return { ...g, items };
-    }
-    if (g.label === 'Build' && reviewEnabled) {
-      const items = [...g.items];
-      items.push(REVIEW_ITEM);
-      return { ...g, items };
-    }
-    return g;
-  });
-}
+import type { RailItem } from './type';
 
 export function CustomizPanel({ projectId }: { projectId: string }) {
   const open = useCustomizeStore((s) => s.open);
@@ -210,7 +113,13 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
     // BOTH its flag check (baked into railGroups) AND its read-leaf probe. Empty
     // groups drop out so no orphan header renders.
     () =>
-      railGroups(tunnelEnabled, marketplaceEnabled, llmGatewayAvailable, voiceEnabled, reviewEnabled)
+      railGroups({
+        tunnelEnabled,
+        marketplaceEnabled,
+        llmGatewayAvailable,
+        voiceEnabled,
+        reviewEnabled,
+      })
         .map((g) => ({ ...g, items: g.items.filter((item) => isSectionAllowed(item.section)) }))
         .filter((g) => g.items.length > 0),
     [

--- a/apps/web/src/features/workspace/customize/rail.test.ts
+++ b/apps/web/src/features/workspace/customize/rail.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, test } from 'bun:test';
-import { isRailItemActive } from './rail';
+import type { CustomizeSection } from '@/lib/customize-sections';
+import { type RailFlags, isRailItemActive, railGroups } from './rail';
 import type { RailItem } from './type';
 
 const item = (section: RailItem['section']): RailItem => ({ section, label: section });
+
+const flags = (overrides: Partial<RailFlags> = {}): RailFlags => ({
+  tunnelEnabled: false,
+  marketplaceEnabled: false,
+  llmGatewayAvailable: false,
+  voiceEnabled: false,
+  reviewEnabled: false,
+  ...overrides,
+});
+
+const sectionsOf = (f: RailFlags): CustomizeSection[] =>
+  railGroups(f).flatMap((g) => g.items.map((i) => i.section));
 
 describe('isRailItemActive', () => {
   test('matches an item against its own section', () => {
@@ -35,5 +48,66 @@ describe('isRailItemActive', () => {
   test('a plain item does not match a different section', () => {
     expect(isRailItemActive(item('secrets'), 'connectors')).toBe(false);
     expect(isRailItemActive(item('git'), 'sandbox')).toBe(false);
+  });
+});
+
+describe('railGroups', () => {
+  test('the base rail carries no flag-gated item', () => {
+    const sections = sectionsOf(flags());
+    for (const gated of [
+      'marketplace',
+      'review',
+      'voice',
+      'computers',
+      'llm-management',
+    ] as const) {
+      expect(sections).not.toContain(gated);
+    }
+  });
+
+  test('Review is in the rail whenever the flag is on — even with Marketplace on', () => {
+    // Marketplace defaults ON for every project, so this is the ONLY combination
+    // that matters in practice: an early return on the first matching Build flag
+    // used to drop Review, which made the sidebar "Review" pill open Customize on
+    // the default section instead of the inbox.
+    expect(sectionsOf(flags({ reviewEnabled: true }))).toContain('review');
+    expect(sectionsOf(flags({ reviewEnabled: true, marketplaceEnabled: true }))).toContain(
+      'review',
+    );
+  });
+
+  test('Marketplace survives Review being on', () => {
+    expect(sectionsOf(flags({ reviewEnabled: true, marketplaceEnabled: true }))).toContain(
+      'marketplace',
+    );
+  });
+
+  test('every Connect flag adds its own item independently', () => {
+    const sections = sectionsOf(
+      flags({ voiceEnabled: true, tunnelEnabled: true, llmGatewayAvailable: true }),
+    );
+    expect(sections).toContain('voice');
+    expect(sections).toContain('computers');
+    expect(sections).toContain('llm-management');
+  });
+
+  test('turning every flag on keeps the rail free of duplicates', () => {
+    const sections = sectionsOf(
+      flags({
+        reviewEnabled: true,
+        marketplaceEnabled: true,
+        voiceEnabled: true,
+        tunnelEnabled: true,
+        llmGatewayAvailable: true,
+      }),
+    );
+    expect(new Set(sections).size).toBe(sections.length);
+  });
+
+  test('a section reachable in the rail is the one the panel can activate', () => {
+    // The panel bounces to the default section when no rail item matches, so a
+    // gated section MUST resolve through isRailItemActive to be reachable.
+    const items = railGroups(flags({ reviewEnabled: true })).flatMap((g) => g.items);
+    expect(items.some((i) => isRailItemActive(i, 'review'))).toBe(true);
   });
 });

--- a/apps/web/src/features/workspace/customize/rail.ts
+++ b/apps/web/src/features/workspace/customize/rail.ts
@@ -1,5 +1,24 @@
 import type { CustomizeSection } from '@/lib/customize-sections';
-import type { RailItem } from './type';
+import { ChatMessages, Sparkles } from '@mynaui/icons-react';
+import {
+  AlarmClock,
+  ArrowUpCircle,
+  AudioLines,
+  Bot,
+  Boxes,
+  Command,
+  Container,
+  GitFork,
+  Inbox,
+  KeyRound,
+  LucideSettings,
+  LucideUsersRound,
+  Monitor,
+  Plug,
+  Store,
+  Webhook,
+} from 'lucide-react';
+import type { RailGroup, RailItem } from './type';
 
 /**
  * Whether a rail item is the active one for the current section.
@@ -12,4 +31,102 @@ import type { RailItem } from './type';
 export function isRailItemActive(item: RailItem, section: CustomizeSection): boolean {
   if (item.section === 'llm-management') return section.startsWith('llm-');
   return item.section === section;
+}
+
+export const COMPUTERS_ITEM: RailItem = { section: 'computers', label: 'Computers', icon: Monitor };
+
+export const MARKETPLACE_ITEM: RailItem = {
+  section: 'marketplace',
+  label: 'Marketplace',
+  icon: Store,
+};
+
+export const VOICE_ITEM: RailItem = { section: 'voice', label: 'Voice', icon: AudioLines };
+
+export const REVIEW_ITEM: RailItem = { section: 'review', label: 'Review', icon: Inbox };
+
+/**
+ * The Upgrades section is always reachable (it hosts the one-off prompt runner)
+ * and lives pinned at the very bottom of the rail — out of the scrolling nav (see
+ * the desktop footer / mobile tail in customize-panel). When a registry upgrade is
+ * actually applicable (e.g. the project is still on a v1 manifest) it carries a
+ * small attention dot instead of claiming a more prominent slot.
+ */
+export const UPGRADE_ITEM: RailItem = {
+  section: 'upgrade',
+  label: 'Upgrades',
+  icon: ArrowUpCircle,
+};
+
+export const LLM_ITEM: RailItem = { section: 'llm-management', label: 'LLM', icon: Boxes };
+
+const GROUPS: readonly RailGroup[] = [
+  {
+    label: 'Build',
+    items: [
+      { section: 'agents', label: 'Agents', icon: Bot },
+      { section: 'skills', label: 'Skills', icon: Sparkles },
+      { section: 'commands', label: 'Commands', icon: Command },
+    ],
+  },
+  {
+    label: 'Connect',
+    items: [
+      { section: 'connectors', label: 'Connectors', icon: Plug },
+      { section: 'secrets', label: 'Environment variables', icon: KeyRound },
+      { section: 'channels', label: 'Channels', icon: ChatMessages },
+    ],
+  },
+  {
+    label: 'Automate',
+    items: [
+      { section: 'schedules', label: 'Schedules', icon: AlarmClock },
+      { section: 'webhooks', label: 'Webhooks', icon: Webhook },
+    ],
+  },
+  {
+    label: 'Manage',
+    items: [
+      { section: 'git', label: 'Git', icon: GitFork },
+      { section: 'sandbox', label: 'Sandbox templates', icon: Container },
+      { section: 'members', label: 'Members', icon: LucideUsersRound },
+      { section: 'settings', label: 'Settings', icon: LucideSettings },
+    ],
+  },
+];
+
+export interface RailFlags {
+  tunnelEnabled: boolean;
+  marketplaceEnabled: boolean;
+  llmGatewayAvailable: boolean;
+  voiceEnabled: boolean;
+  reviewEnabled: boolean;
+}
+
+/**
+ * The rail, composed from the static groups plus every flag-gated item.
+ *
+ * Each group accumulates ALL of its optional items in one pass — a group is
+ * never returned early on the first flag that matches, or a second flag-gated
+ * item in the same group would be silently dropped (Marketplace defaults ON for
+ * every project, so an early return there made Review unreachable and bounced
+ * the panel back to the default section).
+ */
+export function railGroups(flags: RailFlags): readonly RailGroup[] {
+  return GROUPS.map((g) => {
+    if (g.label === 'Build') {
+      const items = [...g.items];
+      if (flags.marketplaceEnabled) items.push(MARKETPLACE_ITEM);
+      if (flags.reviewEnabled) items.push(REVIEW_ITEM);
+      return { ...g, items };
+    }
+    if (g.label === 'Connect') {
+      const items = [...g.items];
+      if (flags.voiceEnabled) items.push(VOICE_ITEM);
+      if (flags.tunnelEnabled) items.push(COMPUTERS_ITEM);
+      if (flags.llmGatewayAvailable) items.push(LLM_ITEM);
+      return { ...g, items };
+    }
+    return g;
+  });
 }


### PR DESCRIPTION
## The bug

Clicking **Review** in the project sidebar opened Customize on **Agents** instead of the Review inbox — the surface the pill exists to reach was unreachable. Turning the `review_center` flag *off* "fixed" it, because that routes the pill down a completely different branch (the legacy `ChangeRequestDetailDialog`), bypassing the broken path entirely.

## Root cause

`railGroups()` built the **Build** group with two independent early returns:

```js
if (g.label === 'Build' && marketplaceEnabled) return { ...g, items: [...g.items, MARKETPLACE_ITEM] }
// ...
if (g.label === 'Build' && reviewEnabled)      return { ...g, items: [...g.items, REVIEW_ITEM] }
```

Marketplace's `platformDefault` is `() => true` — on for **every** project — so the first branch always won and `REVIEW_ITEM` was never added to the rail.

With no rail item matching, the panel's `sectionVisible` check failed and its effect bounced the section straight back to `DEFAULT_CUSTOMIZE_SECTION`:

```js
if (open && !sectionVisible) setSection(DEFAULT_CUSTOMIZE_SECTION)  // → 'agents'
```

So `openCustomize('review')` landed on Agents, with no Review entry in the rail to click through to.

Not involved: IAM (`project.review.read` is in the floor `member` baseline, so every role has it) and the `ReviewView` render case, which was wired correctly all along.

## The fix

Each group now accumulates **all** of its flag-gated items in one pass — the shape the Connect group already used — so a second gated item in the same group can't be silently dropped.

The rail definition (groups + gated items + `railGroups`) moves into `rail.ts` so the composition is unit-testable without pulling in every section view.

## Tests

New `railGroups` coverage: Review survives Marketplace, Marketplace survives Review, every Connect flag adds its item independently, and no flag combination duplicates an entry. **The Marketplace+Review case fails against the old logic** (verified by reverting).

`customize-checkpoints` source assertions retargeted at the rail's new home, and the LLM-in-Connect checkpoint made behavioral rather than a source-text match.

235 tests pass across the customize suite; `tsc --noEmit` and biome clean on the touched files.

## Manual verification

Booted the branch locally with `review_center` on and one seeded `needs_you` item, then clicked the sidebar pill:

- Customize opens directly on **Review** (not Agents)
- The rail shows **both** Marketplace and Review — the exact combination that was broken
- The inbox renders the pending item, and its detail modal offers Approve / Deny
