### PR TITLE
fix(web): order reused sessions by last activity

### DIFF
--- a/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.ts
+++ b/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.ts
@@ -1,7 +1,10 @@
 import type { ProjectSession } from '@kortix/sdk';
 
 import { sessionSource } from '@/components/projects/session-label';
-import { getSessionDisplayTitle } from '@/features/workspace/project-sidebar/project-session-list-helpers';
+import {
+  getSessionDisplayTitle,
+  sortSessionsByLastActivity,
+} from '@/features/workspace/project-sidebar/project-session-list-helpers';
 
 export type ProjectSessionsFilter =
   | 'all'
@@ -101,16 +104,13 @@ export function filterProjectSessions(
   query: string,
 ): ProjectSession[] {
   const normalizedQuery = query.trim().toLocaleLowerCase();
-  return sessions
-    .filter((session) => matchesProjectSessionsFilter(session, filter))
-    .filter((session) => !normalizedQuery || sessionSearchText(session).includes(normalizedQuery))
-    .sort((a, b) => {
-      const parsedA = new Date(a.updated_at || a.created_at).getTime();
-      const parsedB = new Date(b.updated_at || b.created_at).getTime();
-      const aTime = Number.isFinite(parsedA) ? parsedA : 0;
-      const bTime = Number.isFinite(parsedB) ? parsedB : 0;
-      return bTime - aTime;
-    });
+  return sortSessionsByLastActivity(
+    sessions
+      .filter((session) => matchesProjectSessionsFilter(session, filter))
+      .filter(
+        (session) => !normalizedQuery || sessionSearchText(session).includes(normalizedQuery),
+      ),
+  );
 }
 
 export function projectSessionsFilterCounts(

--- a/apps/web/src/features/workspace/project-sessions/project-sessions-view.tsx
+++ b/apps/web/src/features/workspace/project-sessions/project-sessions-view.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/features/workspace/project-sidebar/modal/share-session-modal';
 import {
   getSessionDisplayTitle,
+  sessionLastActivityAt,
   shouldPollProjectSessions,
 } from '@/features/workspace/project-sidebar/project-session-list-helpers';
 import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
@@ -133,7 +134,7 @@ function DetailItem({ label, value, mono }: { label: string; value: string; mono
       <dt className="text-muted-foreground text-xs">{label}</dt>
       <dd
         className={cn(
-          'text-foreground break-words text-sm',
+          'text-foreground text-sm break-words',
           mono && 'font-mono text-xs tabular-nums',
         )}
       >
@@ -185,7 +186,7 @@ function SessionRow({
           ? 'Unknown principal'
           : 'Unattributed';
   const created = formatTimestamp(session.created_at);
-  const updated = formatTimestamp(session.updated_at || session.created_at);
+  const updated = formatTimestamp(sessionLastActivityAt(session));
   const conversationCount = (session.opencode_sessions ?? []).length;
   const archivedConversationCount = (session.opencode_sessions ?? []).filter(
     (item) => item.archived_at,
@@ -260,9 +261,12 @@ function SessionRow({
           </div>
 
           <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
-            <DetailItem label="Created" value={created.exact} />
             <DetailItem label="Last activity" value={updated.exact} />
             <DetailItem label="Status" value={status.label} />
+            <DetailItem
+              label="Source"
+              value={source.triggerSlug ? `${source.label} · ${source.triggerSlug}` : source.label}
+            />
             <DetailItem label="Session / resource owner" value={ownerLabel} />
             <DetailItem label="Owner identity" value={ownerTypeLabel} />
             <DetailItem
@@ -272,10 +276,7 @@ function SessionRow({
             />
             <DetailItem label="Your access" value={access.label} />
             <DetailItem label="Visibility" value={visibility.label} />
-            <DetailItem
-              label="Source"
-              value={source.triggerSlug ? `${source.label} · ${source.triggerSlug}` : source.label}
-            />
+            <DetailItem label="Created" value={created.exact} />
             <DetailItem label="Agent" value={session.agent_name || 'Project default'} />
             <DetailItem label="Runtime" value={session.sandbox_provider || 'Not provisioned'} />
             <DetailItem
@@ -488,7 +489,7 @@ export function ProjectSessionsView({ projectId }: { projectId: string }) {
           {search ? <InputGroupSearchClear onClick={() => setSearch('')} /> : null}
         </InputGroupSearch>
 
-        <div className="overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="[scrollbar-width:none] overflow-x-auto pb-1 [&::-webkit-scrollbar]:hidden">
           <FilterBar className="h-8 rounded-md">
             {PROJECT_SESSIONS_FILTERS.map((option) => (
               <FilterBarItem

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 
+import type { ProjectSession } from '@kortix/sdk';
 import {
   getSessionDisplayTitle,
   resolveSessionListViewState,
+  sessionLastActivityAt,
   shortRelative,
   shouldPollProjectSessions,
-  sortSessionsByCreatedAt,
+  sortSessionsByLastActivity,
 } from './project-session-list-helpers';
-import type { ProjectSession } from '@kortix/sdk';
 
 function makeSession(overrides: Partial<ProjectSession> = {}): ProjectSession {
   return {
@@ -51,13 +52,43 @@ describe('shouldPollProjectSessions', () => {
   });
 });
 
-describe('sortSessionsByCreatedAt', () => {
-  test('orders sessions newest-first', () => {
-    const oldest = makeSession({ session_id: 'a', created_at: '2026-01-01T00:00:00.000Z' });
-    const middle = makeSession({ session_id: 'b', created_at: '2026-01-02T00:00:00.000Z' });
-    const newest = makeSession({ session_id: 'c', created_at: '2026-01-03T00:00:00.000Z' });
+describe('session last activity', () => {
+  test('uses updated_at for a reused session', () => {
+    const session = makeSession({
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-08T08:00:00.000Z',
+    });
 
-    const result = sortSessionsByCreatedAt([oldest, newest, middle]);
+    expect(sessionLastActivityAt(session)).toBe('2026-01-08T08:00:00.000Z');
+  });
+
+  test('falls back to created_at when updated_at is absent', () => {
+    const session = makeSession({
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: undefined,
+    });
+
+    expect(sessionLastActivityAt(session)).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  test('orders reused sessions by latest activity', () => {
+    const oldest = makeSession({
+      session_id: 'a',
+      created_at: '2026-01-03T00:00:00.000Z',
+      updated_at: '2026-01-03T00:00:00.000Z',
+    });
+    const middle = makeSession({
+      session_id: 'b',
+      created_at: '2026-01-02T00:00:00.000Z',
+      updated_at: '2026-01-05T00:00:00.000Z',
+    });
+    const newest = makeSession({
+      session_id: 'c',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-06T00:00:00.000Z',
+    });
+
+    const result = sortSessionsByLastActivity([oldest, newest, middle]);
 
     expect(result.map((s) => s.session_id)).toEqual(['c', 'b', 'a']);
   });
@@ -69,13 +100,13 @@ describe('sortSessionsByCreatedAt', () => {
     ];
     const inputCopy = [...input];
 
-    sortSessionsByCreatedAt(input);
+    sortSessionsByLastActivity(input);
 
     expect(input).toEqual(inputCopy);
   });
 
   test('an empty list sorts to an empty list', () => {
-    expect(sortSessionsByCreatedAt([])).toEqual([]);
+    expect(sortSessionsByLastActivity([])).toEqual([]);
   });
 });
 

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.ts
@@ -19,12 +19,22 @@ export function shouldPollProjectSessions(sessions: ProjectSession[] | undefined
   return (sessions ?? []).some((session) => LIVE_SESSION_STATUSES.includes(session.status));
 }
 
-/** Newest-first sort by `created_at`. Extracted so the ordering rule (and its
- *  stability for equal timestamps) is independently testable. */
-export function sortSessionsByCreatedAt(sessions: ProjectSession[]): ProjectSession[] {
-  return sessions
-    .slice()
-    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+/** The latest user-visible activity for a session. Reused scheduled sessions
+ *  keep their original `created_at`, while `updated_at` advances on each run. */
+export function sessionLastActivityAt(session: ProjectSession): string {
+  return session.updated_at || session.created_at;
+}
+
+/** Newest-first sort by last activity. This keeps reused scheduled sessions
+ *  visible when a new trigger run updates an older session. */
+export function sortSessionsByLastActivity(sessions: ProjectSession[]): ProjectSession[] {
+  return sessions.slice().sort((a, b) => {
+    const parsedA = new Date(sessionLastActivityAt(a)).getTime();
+    const parsedB = new Date(sessionLastActivityAt(b)).getTime();
+    const aTime = Number.isFinite(parsedA) ? parsedA : 0;
+    const bTime = Number.isFinite(parsedB) ? parsedB : 0;
+    return bTime - aTime;
+  });
 }
 
 /**

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -29,9 +29,10 @@ import { ShareSessionModal } from '@/features/workspace/project-sidebar/modal/sh
 import {
   getSessionDisplayTitle,
   resolveSessionListViewState,
+  sessionLastActivityAt,
   shortRelative,
   shouldPollProjectSessions,
-  sortSessionsByCreatedAt,
+  sortSessionsByLastActivity,
 } from '@/features/workspace/project-sidebar/project-session-list-helpers';
 import { useReviewCenterEnabled } from '@/hooks/projects/use-review-center-enabled';
 import { cn } from '@/lib/utils';
@@ -45,7 +46,7 @@ import {
 } from '@kortix/sdk';
 import { Icon as IconMynauiType, Pencil, Share, TrashSolid } from '@mynaui/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { formatDistanceToNowStrict } from 'date-fns';
+import { format, formatDistanceToNowStrict } from 'date-fns';
 import {
   CalendarClock,
   Mail,
@@ -156,7 +157,7 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
     },
   });
 
-  const sessions = sortSessionsByCreatedAt(data ?? []);
+  const sessions = sortSessionsByLastActivity(data ?? []);
   // Filtering itself lives in the SESSIONS header dropdown (project-sidebar);
   // this list only applies the chosen filter.
   const visibleSessions = sessions.filter((session) => matchesSessionFilter(session, filter));
@@ -344,11 +345,15 @@ function ProjectSessionRow({
     requestAnimationFrame(() => fn());
   };
 
-  const relative = (() => {
+  const activity = (() => {
     try {
-      return formatDistanceToNowStrict(new Date(session.created_at), { addSuffix: false });
+      const date = new Date(sessionLastActivityAt(session));
+      return {
+        relative: formatDistanceToNowStrict(date, { addSuffix: false }),
+        exact: format(date, 'MMM d, yyyy, h:mm a'),
+      };
     } catch {
-      return '';
+      return null;
     }
   })();
 
@@ -405,15 +410,17 @@ function ProjectSessionRow({
           </span>
 
           <div className="relative w-10 min-w-10 shrink-0">
-            {relative && (
+            {activity && (
               <span
                 className={cn(
                   SESSION_RELATIVE_TIME_CLASS,
                   'pr-1.5 transition-opacity duration-150',
                   'opacity-100 group-hover/session-list:opacity-0 group-has-data-[state=open]/session-list:opacity-0',
                 )}
+                title={`Last activity: ${activity.exact}`}
+                aria-label={`Last activity: ${activity.relative}`}
               >
-                {shortRelative(relative)}
+                {shortRelative(activity.relative)}
               </span>
             )}
 
@@ -428,7 +435,7 @@ function ProjectSessionRow({
                   )}
                   className={cn(
                     'absolute top-1/2 right-0 -translate-y-1/2 transition-opacity duration-150 focus:ring-0 focus-visible:ring-0',
-                    relative
+                    activity
                       ? cn(
                           'pointer-events-none opacity-0',
                           'group-hover/session-list:pointer-events-auto group-hover/session-list:opacity-100',


### PR DESCRIPTION
## What

- Sort the project sidebar session list by `updated_at`.
- Fall back to `created_at` when `updated_at` is absent.
- Render the sidebar relative timestamp from last activity.
- Add an exact last-activity tooltip and accessible label.
- Promote Last activity above Created in the session inventory details.

## Why

Scheduled triggers can reuse one session. The session keeps its original `created_at`, so a fresh run appears old in the sidebar. The session API advances `updated_at` on each trigger run.

## Verification

- `bun test ./src/features/workspace/project-sidebar/project-session-list-helpers.test.ts ./src/features/workspace/project-sessions/project-sessions-helpers.test.ts` — 33 pass, 0 fail.
- `pnpm exec eslint <6 scoped files>` — exit 0.
- `pnpm exec prettier --check <6 scoped files>` — all matched files use Prettier.
- `git diff --check origin/main...HEAD` — exit 0.
- Live session probe: `a5244eba-cb3a-464c-92ab-0dd90d4d1c56` renders `updated_at=2026-07-29T13:21:06.921Z`, not `created_at=2026-07-22T13:39:43.029Z`.
- Local API `GET http://localhost:20508/v1/health` — `status=ok`.

## Known verification limits

- Authenticated browser control is unavailable in this Codex session. Local DOM verification remains blocked.
- Full `apps/web` typecheck reports two unrelated errors in `src/app/(system)/api/og/template/template-url.test.ts`; no errors reference the changed files.