### PR TITLE
fix(auth): never send a signup to a project it cannot open

### DIFF
--- a/apps/web/src/app/(auth)/auth/actions.ts
+++ b/apps/web/src/app/(auth)/auth/actions.ts
@@ -2,7 +2,11 @@
 
 import { accountHasAppAccess } from '@/lib/auth/account-access';
 import { buildMobileSessionHandoffUrl } from '@/lib/auth/mobile-handoff';
-import { isInviteReturnUrl, sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
+import {
+  isInviteReturnUrl,
+  resolveNewAccountReturnUrl,
+  sanitizeAuthReturnUrl,
+} from '@/lib/auth/return-url';
 import {
   type EmailFlowMode,
   SIGNUPS_CLOSED_MESSAGE,
@@ -138,7 +142,7 @@ export async function resolveAuthMode(email: string): Promise<{ mode: EmailFlowM
  */
 export async function sendEmailCode(prevState: any, formData: FormData) {
   const email = formData.get('email') as string;
-  const returnUrl = sanitizeAuthReturnUrl(formData.get('returnUrl') as string | undefined);
+  const requestedReturnUrl = sanitizeAuthReturnUrl(formData.get('returnUrl') as string | undefined);
   const origin = formData.get('origin') as string;
   const acceptedTerms = formData.get('acceptedTerms') === 'true';
   const referralCode = formData.get('referralCode') as string | undefined;
@@ -157,6 +161,15 @@ export async function sendEmailCode(prevState: any, formData: FormData) {
   if (flowMode === 'sso') {
     return { code: 'sso_required', message: SSO_REQUIRED_MESSAGE };
   }
+
+  // `flowMode === 'signup'` means the API just confirmed this address has no
+  // account, so resolve the return URL against the signup rule HERE — before it
+  // is baked into the email link. That link can be opened minutes or days
+  // later, long after the "created in the last 60s?" heuristic the callback
+  // uses stops being true, and a stale link is precisely how a fresh account
+  // ends up staring at a stranger's "Request access" page.
+  const returnUrl =
+    flowMode === 'signup' ? resolveNewAccountReturnUrl(requestedReturnUrl) : requestedReturnUrl;
 
   const supabase = await createClient();
   const emailRedirectTo = emailRedirectUrl({
@@ -318,8 +331,11 @@ export async function signInWithPassword(prevState: any, formData: FormData) {
   const isNewUser = data.user && Date.now() - new Date(data.user.created_at).getTime() < 60000;
   const authEvent = isNewUser ? 'signup' : 'login';
 
-  // Return success — let the client redirect after auth state hydrates.
-  const finalReturnUrl = returnUrl;
+  // Return success — let the client redirect after auth state hydrates. An
+  // account this young signed up moments ago (the sign-up form ends in a
+  // password sign-in), so it gets the signup destination rule, not a return URL
+  // pointing at a resource that predates it.
+  const finalReturnUrl = isNewUser ? resolveNewAccountReturnUrl(returnUrl) : returnUrl;
   const redirectUrl = new URL(finalReturnUrl, 'http://localhost');
   redirectUrl.searchParams.set('auth_event', authEvent);
   redirectUrl.searchParams.set('auth_method', 'email');
@@ -354,7 +370,11 @@ export async function signUpWithPassword(prevState: any, formData: FormData) {
   const email = (formData.get('email') as string | null)?.trim().toLowerCase();
   const password = formData.get('password') as string;
   const confirmPassword = formData.get('confirmPassword') as string;
-  const returnUrl = sanitizeAuthReturnUrl(formData.get('returnUrl') as string | undefined);
+  const requestedReturnUrl = sanitizeAuthReturnUrl(formData.get('returnUrl') as string | undefined);
+  // This is the sign-up form: unless the account turns out to already exist
+  // (`alreadyExists` below), the identity about to be created cannot own
+  // anything the visitor was looking at before they got here.
+  const newAccountReturnUrl = resolveNewAccountReturnUrl(requestedReturnUrl);
   const origin = formData.get('origin') as string;
   const mobileState = mobileCallbackState(formData);
 
@@ -383,7 +403,9 @@ export async function signUpWithPassword(prevState: any, formData: FormData) {
   const supabase = await createClient();
   const emailRedirectTo = emailRedirectUrl({
     origin,
-    returnUrl,
+    // The confirmation link outlives the "new user" heuristic downstream, so
+    // the signup rule has to be applied before it is minted, not after.
+    returnUrl: newAccountReturnUrl,
     email,
     mobileState,
   });
@@ -433,11 +455,14 @@ export async function signUpWithPassword(prevState: any, formData: FormData) {
     return { message: signInError.message || 'Account created but could not sign in' };
   }
 
-  // `returnUrl` already defaults to PROJECT_LANDING_PATH, which paints
-  // instantly and provisions the first project behind the UI. This action used
-  // to await a managed git repo create + a full starter push here (up to 90s)
-  // before it could return a redirect, which blocked the sign-up form itself.
-  const redirectTo = returnUrl;
+  // A signup enters through the landing door, which paints instantly and
+  // provisions the first project behind the UI. This action used to await a
+  // managed git repo create + a full starter push here (up to 90s) before it
+  // could return a redirect, which blocked the sign-up form itself.
+  //
+  // `alreadyExists` means the address had an account and the password was
+  // right — that is a sign-IN, so the visitor's own return URL still stands.
+  const redirectTo = alreadyExists ? requestedReturnUrl : newAccountReturnUrl;
 
   return {
     success: true,
@@ -527,7 +552,11 @@ export async function verifyOtp(prevState: any, formData: FormData) {
   // repo-first app surface starts from /projects; the old plan route is not v1.
   const runtimeEnv = getServerPublicEnv();
   const billingEnabled = runtimeEnv.BILLING_ENABLED;
-  let finalDestination = returnUrl;
+  // `sendEmailCode` already applied this rule when the API could tell us the
+  // address was new. Re-applying it here covers the case where it could not
+  // (a fail-open 'unknown' flow mode), so a fresh account never rides a
+  // pre-signup return URL into a project it cannot open.
+  let finalDestination = isNewUser ? resolveNewAccountReturnUrl(returnUrl) : returnUrl;
 
   // Invited users (returnUrl → /invites/:id) must land on the accept/decline
   // dialog verbatim — skip the billing-aware landing (account page or a freshly

--- a/apps/web/src/app/(auth)/auth/callback/route.ts
+++ b/apps/web/src/app/(auth)/auth/callback/route.ts
@@ -1,6 +1,11 @@
 import { accountHasAppAccess } from '@/lib/auth/account-access';
 import { buildDesktopBounceHtml, buildMobileBounceHtml } from '@/lib/auth/desktop-bounce';
-import { isInviteReturnUrl, resolveAuthRedirectBaseUrl, sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
+import {
+  isInviteReturnUrl,
+  resolveAuthRedirectBaseUrl,
+  resolveNewAccountReturnUrl,
+  sanitizeAuthReturnUrl,
+} from '@/lib/auth/return-url';
 import {
   LAST_PROJECT_COOKIE,
   PROJECT_LANDING_PATH,
@@ -169,6 +174,12 @@ export async function GET(request: NextRequest) {
         const isNewUser = now - createdAt < 60000; // Created within last 60 seconds
         authEvent = isNewUser ? 'signup' : 'login';
         authMethod = data.user.app_metadata?.provider || 'email';
+
+        // OAuth/SSO signups reach this handler seconds after the account is
+        // created, so this is where a provider signup gets the rule the
+        // email flows already applied when they minted their link: a return
+        // URL the new account cannot own does not survive the signup.
+        if (isNewUser) finalDestination = resolveNewAccountReturnUrl(next);
 
         const pendingReferralCode = request.cookies.get('pending-referral-code')?.value;
         if (pendingReferralCode) {

--- a/apps/web/src/app/(auth)/auth/callback/signup-destination.test.ts
+++ b/apps/web/src/app/(auth)/auth/callback/signup-destination.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+/**
+ * A signup must not land on somebody else's project.
+ *
+ * Live report: opening a private project link while logged out sends the path
+ * through `/auth` as `?redirect=`. Creating an account from there replayed that
+ * path verbatim, so the first screen a brand-new user saw was "Request access
+ * to this project" — a stranger's locked door, on an account that could not
+ * possibly own it.
+ *
+ * This drives the real route handler, because the rule is only as good as its
+ * wiring: `return-url.test.ts` proves the decision, this proves the callback
+ * actually makes it.
+ */
+
+const FOREIGN_PROJECT = '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c';
+const NEW_USER_ID = '44444444-4444-4444-4444-444444444444';
+
+let userCreatedAt = new Date().toISOString();
+let exchangeError: { message: string; status?: number } | null = null;
+
+mock.module('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      exchangeCodeForSession: async () => ({
+        data: {
+          user: {
+            id: NEW_USER_ID,
+            created_at: userCreatedAt,
+            app_metadata: { provider: 'google' },
+            user_metadata: {},
+          },
+        },
+        error: exchangeError,
+      }),
+      getSession: async () => ({ data: { session: { access_token: 'tok' } } }),
+      updateUser: async () => ({ data: {}, error: null }),
+    },
+  }),
+}));
+
+mock.module('@/lib/public-env-server', () => ({
+  getServerPublicEnv: () => ({
+    APP_URL: 'https://dev.kortix.com',
+    BACKEND_URL: '',
+    BILLING_ENABLED: false,
+  }),
+}));
+
+const { GET } = await import('./route');
+const { PROJECT_LANDING_PATH } = await import('@/lib/onboarding/landing-destination');
+
+/** The three things the handler actually reads off a NextRequest. */
+function callbackRequest(returnUrl: string) {
+  const url = new URL('https://dev.kortix.com/auth/callback');
+  url.searchParams.set('code', 'auth-code');
+  url.searchParams.set('returnUrl', returnUrl);
+  return {
+    url: url.toString(),
+    nextUrl: url,
+    cookies: { get: () => undefined },
+  } as never;
+}
+
+async function destinationFor(returnUrl: string): Promise<string> {
+  const response = await GET(callbackRequest(returnUrl));
+  const location = new URL(response.headers.get('location') as string);
+  return `${location.pathname}${location.search}`;
+}
+
+describe('auth callback destination for a brand-new account', () => {
+  beforeEach(() => {
+    userCreatedAt = new Date().toISOString(); // created just now → this is a signup
+    exchangeError = null;
+  });
+
+  test('does not send a signup to a project it cannot open', async () => {
+    const destination = await destinationFor(FOREIGN_PROJECT);
+
+    expect(destination.startsWith(PROJECT_LANDING_PATH)).toBe(true);
+    expect(destination).not.toContain('319395c1-9c3f-41b4-ac6c-9539a12dbb7c');
+  });
+
+  test('still marks it as a signup for analytics', async () => {
+    expect(await destinationFor(FOREIGN_PROJECT)).toContain('auth_event=signup');
+  });
+
+  test('an invite still survives — the signup happened for it', async () => {
+    // Bouncing an invited user to their own first project skips the
+    // accept/decline dialog and leaves the invite unaccepted.
+    expect(await destinationFor('/invites/abc-123')).toStartWith('/invites/abc-123');
+  });
+
+  test('an existing user keeps the deep link — request-access is a real surface', async () => {
+    // Only signups are redirected away. Someone who was legitimately sent a
+    // project link must still reach the page where they can ask for access.
+    userCreatedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+    const destination = await destinationFor(FOREIGN_PROJECT);
+
+    expect(destination).toStartWith(FOREIGN_PROJECT);
+    expect(destination).toContain('auth_event=login');
+  });
+});

--- a/apps/web/src/lib/auth/return-url.test.ts
+++ b/apps/web/src/lib/auth/return-url.test.ts
@@ -32,6 +32,15 @@ describe('sanitizeAuthReturnUrl', () => {
     // Returning to the list exposes it while first-project provisioning runs.
     expect(sanitizeAuthReturnUrl('/projects')).toBe(PROJECT_LANDING_PATH);
   });
+
+  test('returns the canonical path, so later rules see what the browser opens', () => {
+    expect(sanitizeAuthReturnUrl('/marketplace/../invites/abc')).toBe('/invites/abc');
+    // A dot segment must not sneak a legacy path past its own prefix check.
+    expect(sanitizeAuthReturnUrl('/invites/../dashboard')).toBe(PROJECT_LANDING_PATH);
+    // Normalization must not disturb an ordinary path, its query, or its hash.
+    expect(sanitizeAuthReturnUrl('/projects?tab=recent')).toBe('/projects?tab=recent');
+    expect(sanitizeAuthReturnUrl('/invites/abc-123?x=1#note')).toBe('/invites/abc-123?x=1#note');
+  });
 });
 
 describe('isInviteReturnUrl', () => {
@@ -140,6 +149,24 @@ describe('resolveNewAccountReturnUrl', () => {
     expect(isSignupSafeReturnUrl(null)).toBe(false);
     expect(isSignupSafeReturnUrl(undefined)).toBe(false);
     expect(isSignupSafeReturnUrl('')).toBe(false);
+  });
+
+  test('a dot segment cannot smuggle a foreign project past the allowlist', () => {
+    // Every consumer rebuilds this path through `new URL()`, which collapses
+    // dot segments — so testing the raw string tests a path the browser never
+    // visits. `/marketplace/../projects/<id>` would pass a `/marketplace`
+    // check and then open `/projects/<id>`: the exact bug, through the fix.
+    for (const crafted of [
+      '/marketplace/../projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c',
+      '/marketplace/%2e%2e/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c',
+      '/invites/../projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c',
+      '/use-cases/a/../../projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c',
+    ]) {
+      const resolved = resolveNewAccountReturnUrl(crafted);
+      // What the browser will actually open, not what the string looks like.
+      expect(new URL(`https://kortix.local${resolved}`).pathname).not.toContain('319395c1');
+      expect(resolved).toBe(PROJECT_LANDING_PATH);
+    }
   });
 });
 

--- a/apps/web/src/lib/auth/return-url.test.ts
+++ b/apps/web/src/lib/auth/return-url.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 
 import { PROJECT_LANDING_PATH } from '@/lib/onboarding/landing-destination';
-import { isInviteReturnUrl, resolveAuthRedirectBaseUrl, sanitizeAuthReturnUrl } from './return-url';
+import {
+  isInviteReturnUrl,
+  isSignupSafeReturnUrl,
+  resolveAuthRedirectBaseUrl,
+  resolveNewAccountReturnUrl,
+  sanitizeAuthReturnUrl,
+} from './return-url';
 
 describe('sanitizeAuthReturnUrl', () => {
   test('preserves an invite URL verbatim (must survive to reach the dialog)', () => {
@@ -49,6 +55,91 @@ describe('isInviteReturnUrl', () => {
 
   test('the sanitized invite URL is recognized end-to-end', () => {
     expect(isInviteReturnUrl(sanitizeAuthReturnUrl('/invites/xyz'))).toBe(true);
+  });
+});
+
+describe('resolveNewAccountReturnUrl', () => {
+  test('drops a foreign project deep link — the reported bug', () => {
+    // Live repro: opening a private project link while logged out sends the
+    // path through /auth as ?redirect=. Creating an account there landed the
+    // brand-new user on "Request access to this project" for a stranger's
+    // project — an account seconds old cannot own something older than itself.
+    expect(resolveNewAccountReturnUrl('/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c')).toBe(
+      PROJECT_LANDING_PATH,
+    );
+  });
+
+  test('drops every account-scoped destination', () => {
+    for (const path of [
+      '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c/sessions/abc',
+      '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c/files',
+      '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c/customize',
+      '/accounts/319395c1-9c3f-41b4-ac6c-9539a12dbb7c',
+      '/accounts',
+      '/connectors',
+      '/review',
+      '/checkout',
+      '/setup',
+    ]) {
+      expect(resolveNewAccountReturnUrl(path)).toBe(PROJECT_LANDING_PATH);
+    }
+  });
+
+  test('keeps join/authorize flows — the signup happened FOR these', () => {
+    // Dropping any of these strands the flow that sent the user to sign up.
+    expect(resolveNewAccountReturnUrl('/invites/abc-123')).toBe('/invites/abc-123');
+    expect(resolveNewAccountReturnUrl('/oauth/authorize?client_id=x')).toBe(
+      '/oauth/authorize?client_id=x',
+    );
+    expect(resolveNewAccountReturnUrl('/cli/authorize?code=x')).toBe('/cli/authorize?code=x');
+    expect(resolveNewAccountReturnUrl('/tunnel/authorize/abc')).toBe('/tunnel/authorize/abc');
+    expect(resolveNewAccountReturnUrl('/slack/login/tok')).toBe('/slack/login/tok');
+    expect(resolveNewAccountReturnUrl('/teams/login/tok')).toBe('/teams/login/tok');
+    expect(resolveNewAccountReturnUrl('/github/setup?installation_id=1')).toBe(
+      '/github/setup?installation_id=1',
+    );
+  });
+
+  test('keeps public pages — the CTA that started the signup', () => {
+    expect(resolveNewAccountReturnUrl('/use-cases/research-agent')).toBe('/use-cases/research-agent');
+    expect(resolveNewAccountReturnUrl('/marketplace/acme/tool')).toBe('/marketplace/acme/tool');
+  });
+
+  test('keeps the landing door itself', () => {
+    expect(resolveNewAccountReturnUrl(PROJECT_LANDING_PATH)).toBe(PROJECT_LANDING_PATH);
+    expect(resolveNewAccountReturnUrl(undefined)).toBe(PROJECT_LANDING_PATH);
+    expect(resolveNewAccountReturnUrl(null)).toBe(PROJECT_LANDING_PATH);
+    // The bare list is rewritten to the door by the sanitizer, and stays safe.
+    expect(resolveNewAccountReturnUrl('/projects')).toBe(PROJECT_LANDING_PATH);
+  });
+
+  test('still rejects everything sanitizeAuthReturnUrl rejects', () => {
+    expect(resolveNewAccountReturnUrl('https://evil.example.com')).toBe(PROJECT_LANDING_PATH);
+    expect(resolveNewAccountReturnUrl('//evil.example.com')).toBe(PROJECT_LANDING_PATH);
+    expect(resolveNewAccountReturnUrl('javascript:alert(1)')).toBe(PROJECT_LANDING_PATH);
+  });
+
+  test('matches on segment boundaries, not raw string prefixes', () => {
+    // A lookalike path must not inherit an allowlisted prefix's exemption.
+    expect(isSignupSafeReturnUrl('/marketplace-evil')).toBe(false);
+    expect(isSignupSafeReturnUrl('/invitesomething')).toBe(false);
+    expect(isSignupSafeReturnUrl('/projects/startle')).toBe(false);
+    expect(isSignupSafeReturnUrl('/marketplace')).toBe(true);
+    expect(isSignupSafeReturnUrl('/marketplace/acme')).toBe(true);
+    expect(isSignupSafeReturnUrl('/marketplace?q=1')).toBe(true);
+  });
+
+  test('is default-deny: an unknown route is not signup-safe', () => {
+    // A route added later must fail into the user's own project, never into
+    // whatever the visitor had open before they had an account.
+    expect(isSignupSafeReturnUrl('/some-future-route/123')).toBe(false);
+    expect(resolveNewAccountReturnUrl('/some-future-route/123')).toBe(PROJECT_LANDING_PATH);
+  });
+
+  test('is nullish-safe', () => {
+    expect(isSignupSafeReturnUrl(null)).toBe(false);
+    expect(isSignupSafeReturnUrl(undefined)).toBe(false);
+    expect(isSignupSafeReturnUrl('')).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/auth/return-url.ts
+++ b/apps/web/src/lib/auth/return-url.ts
@@ -11,6 +11,37 @@ const LEGACY_AUTH_RETURN_PREFIXES = [
   '/subscription',
 ] as const;
 
+/**
+ * Return paths that still mean something to an account created seconds ago.
+ *
+ * Two kinds qualify:
+ *  - *join / authorize* flows — the signup happened FOR this destination (an
+ *    invite, a CLI pairing code, an OAuth consent screen). Dropping these
+ *    strands the very flow that sent the user to sign up.
+ *  - *public* pages — nothing behind them is account-scoped, so a brand-new
+ *    identity renders them exactly like an old one. These are the marketplace
+ *    and use-case CTAs that started the signup in the first place.
+ *
+ * Everything else is account-scoped, and a brand-new account cannot own a
+ * resource that existed before it did. See `resolveNewAccountReturnUrl`.
+ */
+const SIGNUP_SAFE_RETURN_PREFIXES = [
+  '/invites',
+  '/oauth/authorize',
+  '/cli/authorize',
+  '/tunnel/authorize',
+  '/slack/login',
+  '/teams/login',
+  '/github/setup',
+  '/marketplace',
+  '/use-cases',
+] as const;
+
+/** Prefix match on path segment boundaries, so `/marketplace` never matches `/marketplace-evil`. */
+function matchesReturnPrefix(value: string, prefix: string): boolean {
+  return value === prefix || value.startsWith(`${prefix}/`) || value.startsWith(`${prefix}?`);
+}
+
 export function sanitizeAuthReturnUrl(
   value?: string | null,
   fallback = DEFAULT_AUTH_RETURN_URL,
@@ -49,13 +80,47 @@ export function sanitizeAuthReturnUrl(
   // being provisioned.
   if (trimmedValue === '/projects') return PROJECT_LANDING_PATH;
 
-  if (LEGACY_AUTH_RETURN_PREFIXES.some((prefix) => {
-    return trimmedValue === prefix || trimmedValue.startsWith(`${prefix}/`) || trimmedValue.startsWith(`${prefix}?`);
-  })) {
+  if (LEGACY_AUTH_RETURN_PREFIXES.some((prefix) => matchesReturnPrefix(trimmedValue, prefix))) {
     return fallback;
   }
 
   return trimmedValue;
+}
+
+/**
+ * True when an (already-sanitized) return URL is one a brand-new account can
+ * actually act on.
+ */
+export function isSignupSafeReturnUrl(returnUrl: string | null | undefined): boolean {
+  if (typeof returnUrl !== 'string' || returnUrl.length === 0) return false;
+  if (matchesReturnPrefix(returnUrl, PROJECT_LANDING_PATH)) return true;
+  return SIGNUP_SAFE_RETURN_PREFIXES.some((prefix) => matchesReturnPrefix(returnUrl, prefix));
+}
+
+/**
+ * The post-auth destination for an account that has just been created.
+ *
+ * Middleware turns any unauthenticated request into `?redirect=<path>`, so the
+ * return URL is whatever the visitor happened to have open — very often a link
+ * to somebody else's project. Replaying that after a SIGNUP drops a
+ * seconds-old account on "Request access to this project": the one page it can
+ * never act on, because the account did not exist when that project was
+ * created and no amount of waiting changes that. The first thing a new user
+ * sees is a locked door belonging to a stranger.
+ *
+ * So a signup keeps its return URL only when the URL is signup-safe, and
+ * otherwise enters through the landing door into its own first project.
+ *
+ * This is an allowlist on purpose. An account-scoped route added later fails
+ * safe — the new user lands in their own project — instead of silently reviving
+ * this bug, which is exactly what a denylist would do.
+ */
+export function resolveNewAccountReturnUrl(
+  returnUrl: string | null | undefined,
+  fallback = DEFAULT_AUTH_RETURN_URL,
+): string {
+  const sanitized = sanitizeAuthReturnUrl(returnUrl, fallback);
+  return isSignupSafeReturnUrl(sanitized) ? sanitized : fallback;
 }
 
 /**

--- a/apps/web/src/lib/auth/return-url.ts
+++ b/apps/web/src/lib/auth/return-url.ts
@@ -67,9 +67,22 @@ export function sanitizeAuthReturnUrl(
     return fallback;
   }
 
+  // Canonicalize BEFORE any prefix check, and return the canonical form.
+  //
+  // Every consumer eventually rebuilds this path through `new URL()` — the
+  // password flow to attach auth_event, the callback to prepend the origin —
+  // and that collapses dot segments. So a prefix test against the raw string
+  // is testing a path the browser will never visit:
+  // `/marketplace/../projects/<id>` passes a `/marketplace` check and then
+  // lands on `/projects/<id>`, which is exactly the foreign-project bug the
+  // signup rule below exists to prevent (and would equally slip a
+  // `/x/../dashboard` past LEGACY_AUTH_RETURN_PREFIXES). Normalizing here
+  // means every downstream rule sees the path that will actually be opened.
+  let normalizedValue: string;
   try {
     const resolved = new URL(trimmedValue, 'https://kortix.local');
     if (resolved.origin !== 'https://kortix.local') return fallback;
+    normalizedValue = `${resolved.pathname}${resolved.search}${resolved.hash}`;
   } catch {
     return fallback;
   }
@@ -78,13 +91,13 @@ export function sanitizeAuthReturnUrl(
   // path. A request for the bare list must still enter through the landing
   // door. Otherwise a new account renders /projects while its first project is
   // being provisioned.
-  if (trimmedValue === '/projects') return PROJECT_LANDING_PATH;
+  if (normalizedValue === '/projects') return PROJECT_LANDING_PATH;
 
-  if (LEGACY_AUTH_RETURN_PREFIXES.some((prefix) => matchesReturnPrefix(trimmedValue, prefix))) {
+  if (LEGACY_AUTH_RETURN_PREFIXES.some((prefix) => matchesReturnPrefix(normalizedValue, prefix))) {
     return fallback;
   }
 
-  return trimmedValue;
+  return normalizedValue;
 }
 
 /**

--- a/apps/web/src/lib/auth/signup-return-url-wiring.test.ts
+++ b/apps/web/src/lib/auth/signup-return-url-wiring.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * A signup must never inherit the visitor's pre-signup return URL.
+ *
+ * `resolveNewAccountReturnUrl` holds the rule (see return-url.ts). This test is
+ * the enforcement: the rule is only worth anything if EVERY path that turns an
+ * authentication into a destination actually calls it. A path that quietly
+ * stops calling it puts a brand-new account back on a stranger's "Request
+ * access to this project" page, which is how this bug shipped in the first
+ * place — the destination logic lives in four separate places and only the
+ * invite case had ever been special-cased.
+ *
+ * Each entry names WHERE in that file the rule has to apply, so a rewrite that
+ * moves the code still has to make a deliberate choice.
+ */
+
+const SRC = join(import.meta.dir, '..', '..');
+
+const DESTINATION_PATHS = new Map<string, string>([
+  [
+    'app/(auth)/auth/actions.ts',
+    'sendEmailCode (before the email link is minted), signUpWithPassword, signInWithPassword and verifyOtp all resolve a post-auth destination.',
+  ],
+  [
+    'app/(auth)/auth/callback/route.ts',
+    'OAuth/SSO/magic-link code exchange — the only signup path with no server action in front of it.',
+  ],
+]);
+
+describe('the signup destination rule is wired into every auth path', () => {
+  test('each destination-resolving file applies resolveNewAccountReturnUrl', () => {
+    const missing: string[] = [];
+
+    for (const [rel, why] of DESTINATION_PATHS) {
+      const source = readFileSync(join(SRC, rel), 'utf8');
+      if (!source.includes('resolveNewAccountReturnUrl(')) missing.push(`${rel} — ${why}`);
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  test('the email-code flow applies the rule before minting the link, not after', () => {
+    // A confirmation link can be opened days later, long after the "created in
+    // the last 60s?" heuristic downstream stops being true. Resolving only on
+    // the way out leaves the slow-email path broken — which is the exact shape
+    // of the live report.
+    const source = readFileSync(join(SRC, 'app/(auth)/auth/actions.ts'), 'utf8');
+    const ruleAt = source.indexOf('resolveNewAccountReturnUrl(requestedReturnUrl)');
+    const linkAt = source.indexOf('const emailRedirectTo = emailRedirectUrl(');
+
+    expect(ruleAt).toBeGreaterThan(-1);
+    expect(linkAt).toBeGreaterThan(-1);
+    expect(ruleAt).toBeLessThan(linkAt);
+  });
+});


### PR DESCRIPTION
Opening a private project link while logged out sends the path through `/auth` as `?redirect=`. Creating an account from there replayed that path **verbatim**, so the first screen a brand-new user saw was **"Request access to this project"** for a stranger's project — the one page that account can never act on, since it did not exist when the project was created.

Reported live on dev against `/projects/319395c1-…`.

This is **not** the `kortix_last_project` cookie bug from #5767 — that pointer is properly user-bound. This is a separate carrier: the middleware's `?redirect=` param. Only the invite case had ever been special-cased, and the destination logic was duplicated across four call sites, so nothing else was.

## The rule, in one place

`resolveNewAccountReturnUrl` (`lib/auth/return-url.ts`): a signup keeps its return URL only when the URL is *signup-safe*, and otherwise enters through the landing door into its own first project.

Signup-safe is an **allowlist**, deliberately:

- **join / authorize flows** — the signup happened *for* this destination (invites, OAuth consent, CLI/tunnel pairing, Slack/Teams login, GitHub App setup). Dropping these strands the flow that sent the user to sign up.
- **public pages** — nothing behind them is account-scoped (marketplace, use-cases). These are the CTAs that started the signup.

Everything else resolves to the landing door. A denylist would let an account-scoped route added later silently revive this bug; an allowlist makes it fail into the user's own project instead.

Existing users are untouched. Request-access is a legitimate surface for someone who was genuinely sent a link — only signups are redirected away from it.

## Why the rule is applied on the way *in*

Applying it only on the way out would have left the reported repro broken. Every `isNewUser` check is `created_at < 60s`, but a confirmation email can sit for minutes — by the time it is clicked the user no longer looks new, and the stale link wins.

So the email flows resolve the rule **before the link is minted**: `sendEmailCode` when the API confirms the address has no account, and `signUpWithPassword` unconditionally (it is the sign-up form). The `isNewUser` checks remain as a second layer for OAuth/SSO, which complete in seconds, and to cover a fail-open `unknown` flow mode.

## Tests

- `return-url.test.ts` — the decision itself: the reported project id, every account-scoped destination, each signup-safe flow, segment-boundary matching (`/marketplace-evil` is not `/marketplace`), default-deny for unknown routes.
- `callback/signup-destination.test.ts` — drives the **real** route handler. Verified red without the fix, green with it.
- `signup-return-url-wiring.test.ts` — guard: fails if any destination-resolving auth path stops applying the rule, or if the email flow starts applying it after minting the link instead of before.

Full web suite: **2358 pass, 0 fail**.
