### PR TITLE
fix(whitelabel-demo): actually let the scope bar re-scope this session

### DIFF
--- a/apps/whitelabel-demo/scripts/sdk-boundary.mjs
+++ b/apps/whitelabel-demo/scripts/sdk-boundary.mjs
@@ -21,6 +21,10 @@ const ALLOWED_CLIENT_BFF_ROUTES = [
   // Provider-neutral session model control: the upstream field is named after
   // the runtime, so the translation stays server-side and the client says `model`.
   '/api/session-model',
+  // Re-scope a RUNNING session's secrets / connector bindings. A BFF route so
+  // ownership is checked before any id reaches an upstream path and the
+  // wrapper's key never nears the browser.
+  '/api/session-scope',
   '/api/usage',
   // Lists the ACCOUNT's projects so an operator can adopt one into this demo
   // user. Gated on LUMEN_ALLOW_PROJECT_IMPORT and off by default — it is the one

--- a/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
@@ -180,6 +180,43 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
     />
   );
 
+  // Apply the draft to THIS session. The bar said "Changeable" before this
+  // existed — a badge without the control, which is worse than saying frozen.
+  const applyScope = useMutation({
+    mutationFn: async (secretsList: string[] | null) => {
+      const res = await fetch(
+        `/api/session-scope?projectId=${encodeURIComponent(projectId)}&sessionId=${encodeURIComponent(sessionId)}`,
+        {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ secrets: secretsList }),
+        },
+      );
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        detail?: string;
+        retroactive?: boolean;
+        dropped_secrets?: string[];
+      };
+      if (!res.ok) throw new Error(body.error ?? 'Could not re-scope this session');
+      return body;
+    },
+    onSuccess: (body) => {
+      // Report what actually happened, not a flat "saved". A dropped secret stops
+      // being DELIVERED from the next prompt — the agent may still hold the value
+      // it already read, and saying "revoked" here would be false assurance.
+      const dropped = body.dropped_secrets ?? [];
+      if (dropped.length > 0 && body.retroactive === false) {
+        toast.warning(body.detail ?? 'Applies from the next prompt.', { duration: 8000 });
+      } else {
+        toast.success(body.detail ?? 'Scope updated — applies from the next prompt.');
+      }
+      qc.invalidateQueries({ queryKey: ['session', projectId, sessionId] });
+      setDraftSecrets(null);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
   const toggleSecret = (identifier: string, on: boolean) => {
     const base = nextSecrets ?? [];
     setDraftSecrets(
@@ -361,6 +398,26 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
             </div>
           )}
         </NextSession>
+        {/* Apply to THIS session. Shown above "start a new session" because it is
+            now the ordinary path — starting fresh is the fallback for the one
+            thing a re-scope cannot do, not the default. */}
+        {draftSecrets !== null && (
+          <div className="mt-2 space-y-1.5 border-t border-border pt-2">
+            <Button
+              size="sm"
+              className="w-full"
+              disabled={applyScope.isPending || issues.length > 0}
+              onClick={() => applyScope.mutate(nextSecrets)}
+            >
+              {applyScope.isPending ? 'Applying…' : 'Apply to this session'}
+            </Button>
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              Takes effect on the next prompt. Removing one stops it being handed
+              out — it cannot un-read a value the agent already has, so rotate it
+              if you need it truly revoked.
+            </p>
+          </div>
+        )}
         {startAction}
         {/* The call behind the control, next to the control — the demo's job is
             to teach what to send, and re-scoping is the least obvious of these. */}

--- a/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
@@ -183,13 +183,16 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
   // Apply the draft to THIS session. The bar said "Changeable" before this
   // existed — a badge without the control, which is worse than saying frozen.
   const applyScope = useMutation({
-    mutationFn: async (secretsList: string[] | null) => {
+    mutationFn: async (patch: { secrets?: string[] | null; bindings?: Record<string, string> }) => {
       const res = await fetch(
         `/api/session-scope?projectId=${encodeURIComponent(projectId)}&sessionId=${encodeURIComponent(sessionId)}`,
         {
           method: 'PUT',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ secrets: secretsList }),
+          // Only the axis being changed is sent. Omitting a key leaves it
+          // untouched upstream; sending `secrets: null` would be the very
+          // different instruction "stop narrowing".
+          body: JSON.stringify(patch),
         },
       );
       const body = (await res.json().catch(() => ({}))) as {
@@ -197,6 +200,7 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
         detail?: string;
         retroactive?: boolean;
         dropped_secrets?: string[];
+        dropped_bindings?: string[];
       };
       if (!res.ok) throw new Error(body.error ?? 'Could not re-scope this session');
       return body;
@@ -205,6 +209,9 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
       // Report what actually happened, not a flat "saved". A dropped secret stops
       // being DELIVERED from the next prompt — the agent may still hold the value
       // it already read, and saying "revoked" here would be false assurance.
+      // Only a dropped SECRET carries the "cannot un-read" caveat. A dropped
+      // BINDING is fully retroactive, so warning about it would teach a limit
+      // that does not exist there.
       const dropped = body.dropped_secrets ?? [];
       if (dropped.length > 0 && body.retroactive === false) {
         toast.warning(body.detail ?? 'Applies from the next prompt.', { duration: 8000 });
@@ -213,6 +220,7 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
       }
       qc.invalidateQueries({ queryKey: ['session', projectId, sessionId] });
       setDraftSecrets(null);
+      setDraftBindings(undefined);
     },
     onError: (err: Error) => toast.error(err.message),
   });
@@ -407,7 +415,7 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
               size="sm"
               className="w-full"
               disabled={applyScope.isPending || issues.length > 0}
-              onClick={() => applyScope.mutate(nextSecrets)}
+              onClick={() => applyScope.mutate({ secrets: nextSecrets })}
             >
               {applyScope.isPending ? 'Applying…' : 'Apply to this session'}
             </Button>
@@ -479,7 +487,28 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
             onChange={setDraftBindings}
           />
         </NextSession>
+        {/* Same control as secrets, different guarantee: a binding is resolved
+            server-side on every tool call, so this one IS fully effective — the
+            copy must not borrow the secrets caveat. */}
+        {draftBindings !== undefined && (
+          <div className="mt-2 space-y-1.5 border-t border-border pt-2">
+            <Button
+              size="sm"
+              className="w-full"
+              disabled={applyScope.isPending}
+              onClick={() => applyScope.mutate({ bindings: nextBindings })}
+            >
+              {applyScope.isPending ? 'Applying…' : 'Apply to this session'}
+            </Button>
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              Takes effect on the next tool call — connections resolve
+              server-side, so unlike secrets this change is complete. An alias
+              you unbind falls back to the project default.
+            </p>
+          </div>
+        )}
         {startAction}
+        <CallSnippet id="session.rescope" context={{ projectId, sessionId }} />
       </ScopeChip>
 
       <ScopeChip

--- a/apps/whitelabel-demo/src/lib/session-scope.ts
+++ b/apps/whitelabel-demo/src/lib/session-scope.ts
@@ -102,18 +102,18 @@ export function sessionScopeRows(input: SessionScopeInput): SessionScopeRow[] {
     {
       key: 'secrets',
       label: 'Secrets',
-      badge: 'Fixed at start',
+      badge: 'Changeable now',
       value: describeSecretsAllowlist(input.secretsAllowlist, agent),
       detail:
         input.secretsAllowlist === null || input.secretsAllowlist === undefined
-          ? 'This session was started without a narrower allowlist, so it gets the agent’s full secret grant. An allowlist can only be set when a session starts — narrowing one mid-flight could leave the session unable to boot.'
-          : 'This allowlist was set when the session started and cannot be widened or narrowed now. Start a new session to change it.',
+          ? 'No narrower allowlist was set, so this session gets the agent’s full secret grant. Set one from the scope bar under the composer — what you send REPLACES the list, from the next prompt.'
+          : 'Change it from the scope bar under the composer. What you send REPLACES this list, from the next prompt. Removing one stops it being handed out, but cannot un-read a value the agent already has — rotate the secret if you need it truly revoked.',
       control: null,
     },
     {
       key: 'connections',
       label: 'Connections',
-      badge: 'Fixed at start',
+      badge: 'Changeable now',
       value:
         bound.length === 0
           ? 'The project default for every connector'
@@ -121,7 +121,7 @@ export function sessionScopeRows(input: SessionScopeInput): SessionScopeRow[] {
       detail:
         bound.length === 0
           ? 'Every connector this agent uses resolves to the project’s default connection. Bind a specific team connection when starting a session to run as that account instead.'
-          : 'Bound when the session started. Connectors not listed here still use the project default. Sessions started from here can only run as a TEAM connection — never a teammate’s private one.',
+          : 'Change these from the scope bar under the composer. Unlike secrets a binding change is fully retroactive — connections resolve server-side on each tool call, so the next call already uses the new one. Only TEAM connections can be bound, never a teammate’s private one.',
       control: null,
     },
   ];

--- a/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
@@ -358,3 +358,33 @@ describe('the draft carried into the next session', () => {
     expect(body).not.toHaveProperty('connector_bindings');
   });
 });
+
+describe('the re-scope payload sends only the axis being changed', () => {
+  // The bar builds `{ secrets }` or `{ bindings }`, never both, and never a key
+  // the user did not touch. The distinction is load-bearing upstream: an ABSENT
+  // `secrets` key means "leave secrets alone", while `secrets: null` means the
+  // very different "stop narrowing — fall back to the agent's full grant".
+  // Collapsing them would silently widen a session at the moment someone only
+  // meant to rebind a connector.
+  const payloadFor = (patch: { secrets?: string[] | null; bindings?: Record<string, string> }) =>
+    JSON.parse(JSON.stringify(patch)) as Record<string, unknown>;
+
+  test('changing secrets does not mention bindings', () => {
+    expect('bindings' in payloadFor({ secrets: ['A'] })).toBe(false);
+  });
+
+  test('changing bindings does not mention secrets', () => {
+    expect('secrets' in payloadFor({ bindings: { gmail: 'p1' } })).toBe(false);
+  });
+
+  test('an explicit null survives serialisation — it is not the same as absent', () => {
+    const payload = payloadFor({ secrets: null });
+    expect('secrets' in payload).toBe(true);
+    expect(payload.secrets).toBeNull();
+  });
+
+  test('an EMPTY allowlist survives too — "no secrets" is a real choice', () => {
+    const payload = payloadFor({ secrets: [] });
+    expect(payload.secrets).toEqual([]);
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
@@ -30,8 +30,11 @@ describe('sessionScopeRows', () => {
   });
 
   test('the allowlist reason is specific to whether THIS session has one', () => {
-    expect(row('secrets', { secretsAllowlist: null }).detail).toContain('without a narrower');
-    expect(row('secrets', { secretsAllowlist: ['A'] }).detail).toContain('cannot be widened');
+    // Both cases must say where to change it, and the narrowed one must state
+    // the limit that survives: removing a secret stops DELIVERY, it cannot
+    // un-read what the agent already holds.
+    expect(row('secrets', { secretsAllowlist: null }).detail).toContain('full secret grant');
+    expect(row('secrets', { secretsAllowlist: ['A'] }).detail).toContain('cannot un-read');
   });
 
   test("the agent row names this session's agent, in both directions", () => {
@@ -65,7 +68,7 @@ describe('sessionScopeRows', () => {
 
   test('a bound session is told unbound connectors still fall back to the default', () => {
     expect(row('connections', { boundConnections: { slack: 'Support' } }).detail).toContain(
-      'still use the project default',
+      'retroactive',
     );
   });
 


### PR DESCRIPTION
I shipped the **label** without the **feature**.

#5810 changed the badge to "Changeable" and updated the capability table, but the scope bar never called `/api/session-scope`. Its only actions stayed *"Change what the next session may read"* and *"Start a new session with this scope"*. So the UI claimed a capability and offered no way to use it — worse than honestly saying frozen, because the user hunts for a control that isn't there.

Worse, the **Scope tab** was a second surface still hardcoding the old copy: *"Fixed at start — this allowlist was set when the session started and cannot be widened or narrowed now."* Two panels in the same app, contradicting each other, one of them wrong.

Found because the founder opened both and asked why he couldn't change it.

## What's fixed

- **Apply to this session** in the secrets popover, calling `PUT /api/session-scope` → the platform's `/scope` route. Placed above "start a new session", because re-scoping is now the ordinary path and starting fresh is the fallback for the one thing it can't do.
- The result is reported honestly: a dropped secret raises a **warning** toast carrying the server's `detail`, not a flat success, because `retroactive: false` means delivery stopped but the agent may still hold the value it already read.
- The Scope tab now says "Changeable now" and points at the control, with the retroactive caveat for secrets and the *"bindings resolve at call time so this one IS complete"* distinction for connections.

## The boundary lint caught me again, correctly

`/api/session-scope` wasn't in `ALLOWED_CLIENT_BFF_ROUTES`, so the client fetch was rejected. Registered with a comment on why it's a BFF route (ownership checked before any id reaches an upstream path; the wrapper's key never nears the browser).

## Verification

326 pass / 0 fail, `tsc --noEmit` clean, SDK boundary 0 violations. Ran it against dev: the route is live and an unowned project correctly gets `404 Not found`, so the ownership gate is intact.

Two tests asserted the old copy verbatim (`'cannot be widened'`) — updated to assert the properties that must hold instead: that the narrowed case states `cannot un-read`, and that connections say `retroactive`.