### PR TITLE
fix(sandbox): bound the execution lease and stop it forging lastTurnAt

### DIFF
--- a/apps/api/src/projects/execution-lease-write.test.ts
+++ b/apps/api/src/projects/execution-lease-write.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let sandboxRow: {
+  provider: string;
+  externalId: string;
+  metadata: Record<string, unknown> | null;
+} | null = null;
+let updateCalls = 0;
+const setPayloads: unknown[] = [];
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (sandboxRow ? [sandboxRow] : []),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (payload: unknown) => {
+        updateCalls += 1;
+        setPayloads.push(payload);
+        return {
+          where: () => ({
+            returning: async () =>
+              sandboxRow
+                ? [{ provider: sandboxRow.provider, externalId: sandboxRow.externalId }]
+                : [],
+          }),
+        };
+      },
+    }),
+  },
+}));
+
+mock.module('../platform/providers', () => ({
+  getProvider: () => ({
+    resolveEndpoint: async () => ({ url: 'https://sandbox.example.test', headers: {} }),
+  }),
+}));
+
+const { acquireExecutionLease, renewExecutionLease } = await import('./execution-lease');
+
+const target = {
+  sandboxId: 'sandbox-1',
+  sessionId: 'session-1',
+  projectId: 'project-1',
+  accountId: 'account-1',
+};
+
+function containsString(value: unknown, needle: string, depth = 0): boolean {
+  if (depth > 12 || value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.includes(needle);
+  if (typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some((item) => containsString(item, needle, depth + 1));
+  return Object.values(value as Record<string, unknown>).some((item) =>
+    containsString(item, needle, depth + 1),
+  );
+}
+
+const NOW = new Date('2026-07-29T20:00:00.000Z');
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 3_600_000).toISOString();
+
+const ENV_KEYS = [
+  'KORTIX_EXECUTION_LEASE_MAX_HELD_MINUTES',
+  'KORTIX_EXECUTION_LEASE_CEILING_ENABLED',
+] as const;
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+beforeEach(() => {
+  updateCalls = 0;
+  setPayloads.length = 0;
+  sandboxRow = { provider: 'daytona', externalId: 'sandbox-ext-1', metadata: null };
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('writeExecutionLease no longer forges lastTurnAt', () => {
+  test('a renew writes the lease but never touches the activity clock', async () => {
+    sandboxRow = {
+      provider: 'daytona',
+      externalId: 'sandbox-ext-1',
+      metadata: { executionLeaseStartedAt: hoursAgo(1), lastTurnAt: hoursAgo(9) },
+    };
+
+    const result = await renewExecutionLease(target, 180, NOW);
+
+    expect(result.ok).toBe(true);
+    expect(updateCalls).toBe(1);
+    expect(containsString(setPayloads[0], 'executionLeaseUntil')).toBe(true);
+    expect(containsString(setPayloads[0], 'lastTurnAt')).toBe(false);
+  });
+
+  test('an acquire writes the lease but never touches the activity clock', async () => {
+    const result = await acquireExecutionLease(target, 180, NOW);
+
+    expect(result.ok).toBe(true);
+    expect(updateCalls).toBe(1);
+    expect(containsString(setPayloads[0], 'lastTurnAt')).toBe(false);
+  });
+});
+
+describe('writeExecutionLease enforces the cumulative ceiling', () => {
+  test('renews normally while the lease is inside the ceiling', async () => {
+    sandboxRow = {
+      provider: 'daytona',
+      externalId: 'sandbox-ext-1',
+      metadata: { executionLeaseStartedAt: hoursAgo(5) },
+    };
+
+    const result = await renewExecutionLease(target, 180, NOW);
+
+    expect(result.ok).toBe(true);
+    expect(result.leaseUntil).toBe('2026-07-29T20:03:00.000Z');
+    expect(updateCalls).toBe(1);
+  });
+
+  test('refuses to renew past the ceiling and issues no write at all', async () => {
+    sandboxRow = {
+      provider: 'daytona',
+      externalId: 'sandbox-ext-1',
+      metadata: { executionLeaseStartedAt: hoursAgo(7) },
+    };
+
+    const result = await renewExecutionLease(target, 180, NOW);
+
+    expect(result.ok).toBe(false);
+    expect(result.leaseUntil).toBeNull();
+    expect(updateCalls).toBe(0);
+  });
+
+  test('refuses an acquire past the ceiling too, so release-and-reacquire cannot reset it', async () => {
+    sandboxRow = {
+      provider: 'daytona',
+      externalId: 'sandbox-ext-1',
+      metadata: { executionLeaseStartedAt: hoursAgo(264), executionLeaseUntil: null },
+    };
+
+    const result = await acquireExecutionLease(target, 180, NOW);
+
+    expect(result.ok).toBe(false);
+    expect(updateCalls).toBe(0);
+  });
+
+  test('the kill switch restores the old unbounded behaviour', async () => {
+    process.env.KORTIX_EXECUTION_LEASE_CEILING_ENABLED = 'false';
+    sandboxRow = {
+      provider: 'daytona',
+      externalId: 'sandbox-ext-1',
+      metadata: { executionLeaseStartedAt: hoursAgo(264) },
+    };
+
+    const result = await renewExecutionLease(target, 180, NOW);
+
+    expect(result.ok).toBe(true);
+    expect(updateCalls).toBe(1);
+  });
+
+  test('a missing sandbox row is refused without a write', async () => {
+    sandboxRow = null;
+
+    const result = await renewExecutionLease(target, 180, NOW);
+
+    expect(result.ok).toBe(false);
+    expect(updateCalls).toBe(0);
+  });
+});

--- a/apps/api/src/projects/execution-lease.test.ts
+++ b/apps/api/src/projects/execution-lease.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, test } from 'bun:test';
-import { executionLeaseUntilOf, hasActiveExecutionLease } from './execution-lease';
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  EXECUTION_LEASE_METADATA_KEYS,
+  decideExecutionLeaseWrite,
+  executionLeaseStartedAtOf,
+  executionLeaseUntilOf,
+  hasActiveExecutionLease,
+  leaseCeilingEnforced,
+  maxLeaseHeldMs,
+} from './execution-lease';
 
 describe('execution lease policy', () => {
   const now = new Date('2026-07-11T20:00:00.000Z');
@@ -14,5 +22,178 @@ describe('execution lease policy', () => {
   test('fails closed on malformed or missing timestamps', () => {
     expect(executionLeaseUntilOf({ executionLeaseUntil: 'bad' })).toBeNull();
     expect(hasActiveExecutionLease(null, now)).toBe(false);
+  });
+});
+
+describe('cumulative execution lease ceiling', () => {
+  const now = new Date('2026-07-29T20:00:00.000Z');
+  const ceilingMs = 6 * 60 * 60_000;
+  const at = (msAgo: number) => new Date(now.getTime() - msAgo).toISOString();
+
+  test('anchors the first lease write at now and allows it', () => {
+    const decision = decideExecutionLeaseWrite({ metadata: null, now, ceilingMs });
+    expect(decision.allowed).toBe(true);
+    if (!decision.allowed) throw new Error('unreachable');
+    expect(decision.heldMs).toBe(0);
+    expect(decision.patch.executionLeaseStartedAt).toBe(now.toISOString());
+  });
+
+  test('carries the original anchor forward instead of advancing it', () => {
+    const anchor = at(3 * 60 * 60_000);
+    const decision = decideExecutionLeaseWrite({
+      metadata: { executionLeaseStartedAt: anchor, executionLeaseUntil: at(30_000) },
+      now,
+      ceilingMs,
+    });
+    expect(decision.allowed).toBe(true);
+    if (!decision.allowed) throw new Error('unreachable');
+    expect(decision.patch.executionLeaseStartedAt).toBe(anchor);
+    expect(decision.heldMs).toBe(3 * 60 * 60_000);
+  });
+
+  test('refuses a renew once the lease has been held past the ceiling', () => {
+    const decision = decideExecutionLeaseWrite({
+      metadata: { executionLeaseStartedAt: at(ceilingMs) },
+      now,
+      ceilingMs,
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.heldMs).toBe(ceilingMs);
+  });
+
+  test('refuses the 264-hour immortal box measured in production', () => {
+    const decision = decideExecutionLeaseWrite({
+      metadata: { executionLeaseStartedAt: at(264 * 60 * 60_000) },
+      now,
+      ceilingMs,
+    });
+    expect(decision.allowed).toBe(false);
+  });
+
+  test('still allows a renew one millisecond before the ceiling', () => {
+    const decision = decideExecutionLeaseWrite({
+      metadata: { executionLeaseStartedAt: at(ceilingMs - 1) },
+      now,
+      ceilingMs,
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  test('a future-dated anchor cannot buy immortality', () => {
+    const decision = decideExecutionLeaseWrite({
+      metadata: { executionLeaseStartedAt: new Date(now.getTime() + 86_400_000).toISOString() },
+      now,
+      ceilingMs,
+    });
+    expect(decision.allowed).toBe(true);
+    if (!decision.allowed) throw new Error('unreachable');
+    expect(decision.patch.executionLeaseStartedAt).toBe(now.toISOString());
+    expect(decision.heldMs).toBe(0);
+  });
+
+  test('a malformed anchor is treated as a fresh anchor, never as unbounded', () => {
+    expect(executionLeaseStartedAtOf({ executionLeaseStartedAt: 'not-a-date' })).toBeNull();
+    const decision = decideExecutionLeaseWrite({
+      metadata: { executionLeaseStartedAt: 'not-a-date' },
+      now,
+      ceilingMs,
+    });
+    expect(decision.allowed).toBe(true);
+    if (!decision.allowed) throw new Error('unreachable');
+    expect(decision.patch.executionLeaseStartedAt).toBe(now.toISOString());
+  });
+
+  test('the kill switch restores unbounded renewal', () => {
+    const decision = decideExecutionLeaseWrite({
+      metadata: { executionLeaseStartedAt: at(264 * 60 * 60_000) },
+      now,
+      ceilingMs,
+      enforced: false,
+    });
+    expect(decision.allowed).toBe(true);
+  });
+});
+
+describe('only a control-plane wake restores lease eligibility', () => {
+  const now = new Date('2026-07-29T20:00:00.000Z');
+  const ceilingMs = 6 * 60 * 60_000;
+  const exhausted = {
+    executionLeaseStartedAt: new Date(now.getTime() - 40 * 3_600_000).toISOString(),
+    executionLeaseUntil: new Date(now.getTime() - 30_000).toISOString(),
+    source: 'trigger:cron',
+  };
+
+  test('the wake key list covers every key the lease writes', () => {
+    const decision = decideExecutionLeaseWrite({ metadata: null, now, ceilingMs });
+    if (!decision.allowed) throw new Error('unreachable');
+    const leaseOwned = Object.keys(decision.patch).filter((key) =>
+      key.startsWith('executionLease'),
+    );
+    const wakeKeys: string[] = [...EXECUTION_LEASE_METADATA_KEYS];
+    expect(leaseOwned.length).toBeGreaterThan(0);
+    for (const key of leaseOwned) expect(wakeKeys).toContain(key);
+  });
+
+  test('deleting the wake keys makes an exhausted box leasable again', () => {
+    expect(decideExecutionLeaseWrite({ metadata: exhausted, now, ceilingMs }).allowed).toBe(false);
+
+    const woken: Record<string, unknown> = { ...exhausted };
+    for (const key of EXECUTION_LEASE_METADATA_KEYS) delete woken[key];
+
+    const afterWake = decideExecutionLeaseWrite({ metadata: woken, now, ceilingMs });
+    expect(afterWake.allowed).toBe(true);
+    expect(woken.source).toBe('trigger:cron');
+  });
+});
+
+describe('the lease write must not forge the activity clock', () => {
+  const now = new Date('2026-07-29T20:00:00.000Z');
+  const ceilingMs = 6 * 60 * 60_000;
+
+  test('an acquire never stamps lastTurnAt', () => {
+    const decision = decideExecutionLeaseWrite({ metadata: null, now, ceilingMs });
+    if (!decision.allowed) throw new Error('unreachable');
+    expect(Object.keys(decision.patch)).not.toContain('lastTurnAt');
+  });
+
+  test('a renew never stamps lastTurnAt and leaves an existing one untouched', () => {
+    const stale = '2026-07-20T04:00:00.000Z';
+    const decision = decideExecutionLeaseWrite({
+      metadata: {
+        executionLeaseStartedAt: '2026-07-29T19:00:00.000Z',
+        lastTurnAt: stale,
+      },
+      now,
+      ceilingMs,
+    });
+    if (!decision.allowed) throw new Error('unreachable');
+    expect(Object.keys(decision.patch)).not.toContain('lastTurnAt');
+    expect(decision.patch.executionLeaseUntil).toBe('2026-07-29T20:02:00.000Z');
+  });
+});
+
+describe('execution lease ceiling configuration', () => {
+  const originalMinutes = process.env.KORTIX_EXECUTION_LEASE_MAX_HELD_MINUTES;
+  const originalEnabled = process.env.KORTIX_EXECUTION_LEASE_CEILING_ENABLED;
+
+  afterEach(() => {
+    if (originalMinutes === undefined) delete process.env.KORTIX_EXECUTION_LEASE_MAX_HELD_MINUTES;
+    else process.env.KORTIX_EXECUTION_LEASE_MAX_HELD_MINUTES = originalMinutes;
+    if (originalEnabled === undefined) delete process.env.KORTIX_EXECUTION_LEASE_CEILING_ENABLED;
+    else process.env.KORTIX_EXECUTION_LEASE_CEILING_ENABLED = originalEnabled;
+  });
+
+  test('defaults to a 6 hour ceiling, enforced', () => {
+    delete process.env.KORTIX_EXECUTION_LEASE_MAX_HELD_MINUTES;
+    delete process.env.KORTIX_EXECUTION_LEASE_CEILING_ENABLED;
+    expect(maxLeaseHeldMs()).toBe(6 * 60 * 60_000);
+    expect(leaseCeilingEnforced()).toBe(true);
+  });
+
+  test('is overridable and disengageable by env', () => {
+    process.env.KORTIX_EXECUTION_LEASE_MAX_HELD_MINUTES = '90';
+    process.env.KORTIX_EXECUTION_LEASE_CEILING_ENABLED = 'false';
+    expect(maxLeaseHeldMs()).toBe(90 * 60_000);
+    expect(leaseCeilingEnforced()).toBe(false);
   });
 });

--- a/apps/api/src/projects/execution-lease.ts
+++ b/apps/api/src/projects/execution-lease.ts
@@ -3,10 +3,63 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 import { setContextField } from '../lib/request-context';
 import { type ProviderName, getProvider } from '../platform/providers';
 import { db } from '../shared/db';
+import { positiveEnvInt } from './reaper-constants';
 
 export const DEFAULT_EXECUTION_LEASE_SECONDS = 120;
 export const MIN_EXECUTION_LEASE_SECONDS = 30;
 export const MAX_EXECUTION_LEASE_SECONDS = 300;
+
+/**
+ * THE LEASE CEILING — the bound on how long a sandbox may keep granting itself
+ * a reprieve.
+ *
+ * The execution lease is written by the IN-SANDBOX reporter
+ * (kortix-sandbox-agent-server/src/execution-lease.ts), which renews every ~60s
+ * for as long as its local opencode believes ANY session is 'busy' or 'retry'.
+ * `hasActiveExecutionLease` short-circuits the reaper BEFORE it probes, so an
+ * unbounded renew is an unbounded veto: a retry loop, a dropped opencode event
+ * subscription, or any daemon wedge buys the box immortality. Measured live
+ * 2026-07-29: 187 leased boxes genuinely running, 175 of them older than 12h,
+ * the oldest 264 hours, and 156 of them had never emitted a single LLM call.
+ *
+ * So the renew is now cumulative-bounded per sandbox row: the FIRST lease write
+ * anchors `metadata.executionLeaseStartedAt`, the anchor is never advanced by a
+ * later sandbox-authored write, and past the ceiling every further acquire/renew
+ * is refused. Refusing does NOT kill the box — it only drops the short-circuit
+ * so the reaper evaluates it normally (busy probe → idle arm → stop, plus the
+ * absolute ceiling in reaping/policy.ts). A genuinely mid-turn box still wins
+ * its veto from the control-plane-initiated busy probe, which is why this cannot
+ * recreate the 2026-06-24 "idle sandboxes stopping too quickly mid-session"
+ * regression.
+ *
+ * Only a control-plane-observed event resets the anchor: waking a stopped box
+ * (projects/routes/shared.ts) clears it, because a stopped box burns nothing.
+ */
+const DEFAULT_MAX_LEASE_HELD_MINUTES = 360;
+
+export function maxLeaseHeldMs(): number {
+  return (
+    positiveEnvInt('KORTIX_EXECUTION_LEASE_MAX_HELD_MINUTES', DEFAULT_MAX_LEASE_HELD_MINUTES) *
+    60_000
+  );
+}
+
+/** Kill switch for the lease ceiling. Default ON — enforcement is the default. */
+export function leaseCeilingEnforced(): boolean {
+  return process.env.KORTIX_EXECUTION_LEASE_CEILING_ENABLED !== 'false';
+}
+
+/**
+ * Every metadata key the lease owns. A control-plane-OBSERVED wake of a stopped
+ * box (projects/routes/shared.ts) deletes exactly these, which is what restores
+ * lease eligibility to a box that had exhausted the ceiling before it was
+ * stopped. Nothing the sandbox itself can call may clear them — that is the
+ * difference between shortening a life and extending one.
+ */
+export const EXECUTION_LEASE_METADATA_KEYS = [
+  'executionLeaseUntil',
+  'executionLeaseStartedAt',
+] as const;
 
 export interface ExecutionLeaseTarget {
   sandboxId: string;
@@ -53,9 +106,68 @@ export function hasActiveExecutionLease(
   return until !== null && until.getTime() > now.getTime();
 }
 
+/** When this sandbox row FIRST took an execution lease. Written once by the
+ *  API, never advanced by the sandbox — the anchor the ceiling measures from. */
+export function executionLeaseStartedAtOf(metadata: Record<string, unknown> | null): Date | null {
+  const raw = metadata?.executionLeaseStartedAt;
+  if (typeof raw !== 'string') return null;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export type ExecutionLeaseWriteDecision =
+  | { allowed: false; heldMs: number }
+  | { allowed: true; heldMs: number; leaseUntil: string; patch: Record<string, unknown> };
+
+/**
+ * The whole lease-write decision, pure so the money semantics are exhaustively
+ * unit-tested without a DB.
+ *
+ * Note what the patch does NOT contain: `lastTurnAt`. Until 2026-07-29 every
+ * lease write stamped `lastTurnAt = now`, which is the exact signal
+ * `reaping/policy.ts lastMeaningfulAt` uses to judge the box — so the sandbox
+ * forged its own alibi and erased the fallback activity clock in the same
+ * statement. A sandbox-reported signal may only SHORTEN a sandbox's life; the
+ * activity clock is now advanced only by control-plane-observed events (the
+ * reaper's own busy probe, an explicit wake, an in-place restart).
+ */
+export function decideExecutionLeaseWrite(input: {
+  metadata: Record<string, unknown> | null;
+  requestedTtlSeconds?: number;
+  now: Date;
+  ceilingMs: number;
+  enforced?: boolean;
+}): ExecutionLeaseWriteDecision {
+  const { metadata, requestedTtlSeconds, now, ceilingMs } = input;
+  const stored = executionLeaseStartedAtOf(metadata);
+  // A stored anchor in the future can only come from a clock skew or a hand-edit;
+  // trusting it would make heldMs negative and restore the immortality this
+  // exists to remove, so it is clamped back to now.
+  const anchor = stored && stored.getTime() <= now.getTime() ? stored : now;
+  const heldMs = now.getTime() - anchor.getTime();
+  if (input.enforced !== false && heldMs >= ceilingMs) return { allowed: false, heldMs };
+  const leaseUntil = new Date(
+    now.getTime() + clampLeaseSeconds(requestedTtlSeconds) * 1_000,
+  ).toISOString();
+  return {
+    allowed: true,
+    heldMs,
+    leaseUntil,
+    patch: {
+      executionLeaseUntil: leaseUntil,
+      executionLeaseStartedAt: anchor.toISOString(),
+      idleObservedAt: null,
+    },
+  };
+}
+
 async function loadLeaseSandbox(target: ExecutionLeaseTarget) {
   const [row] = await db
-    .select({ provider: sessionSandboxes.provider, externalId: sessionSandboxes.externalId })
+    .select({
+      provider: sessionSandboxes.provider,
+      externalId: sessionSandboxes.externalId,
+      metadata: sessionSandboxes.metadata,
+    })
     .from(sessionSandboxes)
     .where(
       and(
@@ -134,14 +246,25 @@ async function writeExecutionLease(
   provider: string;
   externalId: string | null;
 } | null> {
-  const leaseUntil = new Date(
-    now.getTime() + clampLeaseSeconds(requestedTtlSeconds) * 1_000,
-  ).toISOString();
-  const patch = JSON.stringify({
-    executionLeaseUntil: leaseUntil,
-    lastTurnAt: now.toISOString(),
-    idleObservedAt: null,
+  const current = await loadLeaseSandbox(target);
+  if (!current) return null;
+  const decision = decideExecutionLeaseWrite({
+    metadata: (current.metadata ?? null) as Record<string, unknown> | null,
+    requestedTtlSeconds,
+    now,
+    ceilingMs: maxLeaseHeldMs(),
+    enforced: leaseCeilingEnforced(),
   });
+  if (!decision.allowed) {
+    console.warn('[execution-lease] renew refused — cumulative lease ceiling reached', {
+      sandbox_id: target.sandboxId,
+      held_ms: decision.heldMs,
+      ceiling_ms: maxLeaseHeldMs(),
+    });
+    return null;
+  }
+  const { leaseUntil } = decision;
+  const patch = JSON.stringify(decision.patch);
   const [row] = await db
     .update(sessionSandboxes)
     .set({

--- a/apps/api/src/projects/reaping/box-reaper.ts
+++ b/apps/api/src/projects/reaping/box-reaper.ts
@@ -98,10 +98,10 @@ export const EMPTY_REAP_RESULT: ReapResult = {
  * Bounded concurrency so a batch of provider round-trips doesn't serialize.
  *
  * ORPHAN-ACCOUNT BYPASS: a box whose owning account has been deleted keeps
- * heartbeating forever otherwise — the execution-lease renewal and the
- * busy-veto path both stamp `lastTurnAt`/clear `idleObservedAt` (see the
- * module header), so the idle clock can never accumulate and the box is
- * never even probed. There is no customer behind a deleted account whose
+ * heartbeating forever otherwise — the execution-lease renewal clears
+ * `idleObservedAt` and short-circuits the pass before the probe (see the module
+ * header), so the idle clock can never accumulate and the box is never even
+ * probed. There is no customer behind a deleted account whose
  * in-flight tool call this would interrupt, so for orphaned rows ONLY this
  * pass skips the lease short-circuit and tells `reapRunningBox` to skip the
  * busy probe too, going straight to `provider.stop()`. Every non-orphan row
@@ -184,9 +184,11 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
           const isOrphanAccount = !!row.accountId && orphanAccountIds !== null && orphanAccountIds.has(row.accountId);
           if (isOrphanAccount) orphanCandidates += 1;
 
-          // The execution lease is written by the box's OWN heartbeat and is
-          // renewed forever by a wedged/retrying daemon — it may defer a stop,
-          // never prevent one past the ceiling.
+          // The execution lease is written by the box's OWN heartbeat, so it may
+          // defer a stop, never prevent one past the ceiling. Doubly bounded
+          // since 2026-07-29: the API also refuses to renew a lease held longer
+          // than execution-lease.ts `maxLeaseHeldMs`, so a wedged/retrying daemon
+          // stops being able to write this veto at all.
           if (!isOrphanAccount && !hardStop && hasActiveExecutionLease(row.metadata, now)) {
             result.busyVetoed += 1;
             continue;

--- a/apps/api/src/projects/reaping/policy.ts
+++ b/apps/api/src/projects/reaping/policy.ts
@@ -28,16 +28,18 @@ export function autoStopTtlMs(): number {
  * THE BACKSTOP — the answer to "a box must NEVER run 24/7 when it is not in use".
  *
  * Every other liveness signal the reaper trusts is written by the box itself:
- * `metadata.lastTurnAt` and `metadata.executionLeaseUntil` are stamped by the
- * in-sandbox agent's heartbeat (execution-lease.ts `writeExecutionLease`, renewed
- * every 60s while it believes ANY opencode session is 'busy' OR 'retry'), and the
- * busy probe asks that same wedged daemon. A retry loop, a dropped opencode event
- * subscription, or any daemon wedge therefore renews its own reprieve forever —
- * measured live 2026-07-29: 188 of 279 active prod boxes held a live execution
- * lease, 182 of them older than 12h, and `metadata.idleObservedAt` was a JSON
- * null on EVERY row platform-wide because the lease veto returns before the arm
- * write and every lease renew force-nulls it. The idle-TTL stop path had never
- * fired in production, not once.
+ * `metadata.executionLeaseUntil` is stamped by the in-sandbox agent's heartbeat
+ * (execution-lease.ts `writeExecutionLease`, renewed every 60s while it believes
+ * ANY opencode session is 'busy' OR 'retry'), and the busy probe asks that same
+ * wedged daemon. A retry loop, a dropped opencode event subscription, or any
+ * daemon wedge therefore renews its own reprieve forever — measured live
+ * 2026-07-29: 188 of 279 active prod boxes held a live execution lease, 182 of
+ * them older than 12h, and `metadata.idleObservedAt` was a JSON null on EVERY
+ * row platform-wide because the lease veto returns before the arm write and
+ * every lease renew force-nulls it. The idle-TTL stop path had never fired in
+ * production, not once. (That renew also stamped `lastTurnAt`, letting the box
+ * forge the very clock below; removed 2026-07-29 together with the cumulative
+ * lease ceiling in execution-lease.ts, which bounds the veto itself.)
  *
  * So the ceiling below deliberately consults ONLY evidence the box cannot forge:
  * the sandbox row's creation time and real `usage_events` rows (see
@@ -128,10 +130,16 @@ export function decideReconcile(providerStatus: SandboxStatus): ReconcileAction 
 
 /**
  * Last MEANINGFUL activity for a sandbox row. Driven by `metadata.lastTurnAt`
- * (stamped at every turn boundary — the only thing that should keep a box alive)
  * with a fallback to row creation so a never-used box still ages out after the
  * grace TTL. Deliberately does NOT consider `last_used_at` (proxy traffic) or
  * any passive signal.
+ *
+ * Since 2026-07-29 `lastTurnAt` is written ONLY by control-plane-observed
+ * events — the reaper's own busy probe (reaping/running-box.ts), an explicit
+ * wake (routes/shared.ts), an in-place restart (session-lifecycle/
+ * readiness-clocks.ts). The in-sandbox lease renew used to stamp it too, which
+ * meant a wedged daemon kept this clock permanently fresh and could never age
+ * out; the whole point of the clock is that the box cannot wind it forward.
  */
 export function lastMeaningfulAt(row: {
   metadata: Record<string, unknown> | null;
@@ -149,10 +157,11 @@ export function lastMeaningfulAt(row: {
 /**
  * The UNFORGEABLE activity clock, and the only input to the absolute ceiling.
  *
- * `lastMeaningfulAt` above reads `metadata.lastTurnAt`, which the in-sandbox
- * agent rewrites to `now` on every 60s execution-lease renew — so a wedged box
- * keeps its own activity clock permanently fresh and can never age out. This
- * function reads only signals the box cannot write to:
+ * `lastMeaningfulAt` above reads `metadata.lastTurnAt`, which until 2026-07-29
+ * the in-sandbox agent rewrote to `now` on every 60s execution-lease renew — so
+ * a wedged box kept its own activity clock permanently fresh and could never age
+ * out. That stamp is gone, but this function stays the load-bearing one: it
+ * reads only signals the box cannot write to at all:
  *
  *   - `createdAt` — when WE provisioned the row, and
  *   - the newest `usage_events` row for the session — a real LLM call, written

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -10,6 +10,7 @@ import { resolveBranchTip } from '../git';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, eq, sql } from 'drizzle-orm';
+import { EXECUTION_LEASE_METADATA_KEYS } from '../execution-lease';
 import { withProjectGitAuth } from '../lib/git';
 import { ProjectRow, serializeSessionSandboxConfig } from '../lib/serializers';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
@@ -102,6 +103,11 @@ export async function resumeStoppedSandbox(row: {
     'runtimeWakeFailedAt',
     'opencodeReadyWaitStartedAt',
     'opencodeReadyWaitReason',
+    // The cumulative execution-lease anchor. The ceiling bounds how long a
+    // RUNNING box may keep renewing its own reprieve; a box that was stopped
+    // burned nothing, and a wake is a control-plane-OBSERVED event, so it is
+    // the one thing allowed to reset the anchor.
+    ...EXECUTION_LEASE_METADATA_KEYS,
   ])
     delete wakeMetadata[key];
   Object.assign(wakeMetadata, {


### PR DESCRIPTION
Immediate bleeding-stop for the immortal-sandbox class. Two surgical changes to
the lease write path; the deadline_at redesign is deliberately NOT in here.

Measured live 2026-07-29: 198 sandbox rows held a live executionLeaseUntil, 187
of them genuinely RUNNING on the provider (~4,488 box-hours/day). 175 were older
than 12h, the oldest 264 hours. 156 had never emitted a single LLM usage_event.
metadata.idleObservedAt was a JSON null or absent on all 284 active rows: the
arm/stop machine had never fired in production, not once.

Root cause: writeExecutionLease (shared by acquire AND renew) is driven by the
IN-SANDBOX ExecutionLeaseReporter, which renews every ~60s while its local
opencode believes any session is 'busy' or 'retry'. hasActiveExecutionLease
short-circuits the reaper BEFORE it probes, so an unbounded renew is an
unbounded veto. The same statement also stamped lastTurnAt = now, so the box
forged the very activity clock used to judge it and erased the reaper's
fallback in one write.

1. BOUND THE LEASE. The first lease write anchors metadata.executionLeaseStartedAt
   and no later sandbox-authored write advances it. Past a cumulative ceiling,
   every further acquire and renew is refused (no DB write at all). Acquire is
   guarded too, so release-then-reacquire cannot buy a fresh budget.

   Ceiling: 6h (KORTIX_EXECUTION_LEASE_MAX_HELD_MINUTES=360, kill switch
   KORTIX_EXECUTION_LEASE_CEILING_ENABLED=false). Chosen because it is:
   - 72x the maximum single lease TTL (300s), so no plausible turn is affected;
   - above the 120m provider auto-stop TTL raised on 2026-06-24 and above the
     reaper's 240m absolute ceiling, which therefore stays the primary killer
     and this stays a strictly secondary belt;
   - 44x below the observed 264h worst case, and below the 12h mark that 175 of
     187 running boxes had already passed.

   Refusing a renew does NOT kill a box. It only drops the short-circuit so the
   reaper evaluates the box normally: control-plane-initiated busy probe -> idle
   arm -> stop, plus the absolute ceiling. A genuinely mid-turn box still wins
   its veto from the busy probe, which is why this cannot recreate the
   2026-06-24 "idle sandboxes stopping too quickly mid-session" regression that
   PR #4228 already had to reimburse for once.

   A wake of a stopped box (routes/shared.ts) clears the anchor. A stopped box
   burns nothing and a wake is control-plane OBSERVED, so it is the only thing
   allowed to extend the budget. The sandbox has no path to clear it.

2. STOP THE LEASE WRITE STAMPING lastTurnAt. Removed from the patch entirely.
   lastTurnAt is now written only by control-plane-observed events: the reaper's
   own busy probe (reaping/running-box.ts), an explicit wake (routes/shared.ts),
   an in-place restart (session-lifecycle/readiness-clocks.ts).

   Checked for mass false-kills and found none, so it ships ungated. The only
   consumer of a fresh lastTurnAt is lastMeaningfulAt in reaping/policy.ts, and
   it feeds exactly one branch: fallbackLastMeaningful, used ONLY when the busy
   probe returns 'unknown' (box unreachable). That branch already takes the max
   of lastMeaningfulAt and the session's newest usage_event, so an actually
   working box is covered by real LLM calls. And reaching that branch at all
   requires no live lease, i.e. the box has not phoned home in <=300s while
   claiming to be busy. A box that is unreachable, silent on the gateway for the
   TTL, and not holding a lease is not running a turn; stopping it is the whole
   point of the fallback.

Invariant both changes enforce, the same one the compute-liveness billing clamp
already applies to BILLING and that was never applied to the KILL decision:
a sandbox-reported signal may only SHORTEN a sandbox's life; only a
control-plane-OBSERVED event may extend it, and only to a bounded ceiling.

Note for the rollout: existing prod rows carry no executionLeaseStartedAt, so
their anchor is set on their next renew and the 6h clock starts from deploy. The
240m absolute ceiling in reaping/policy.ts is what clears the current backlog.

Tests (bun:test, run individually):
- projects/execution-lease.test.ts: anchor never advances, refusal at and past
  the ceiling incl. the 264h prod case, boundary at ceiling-1ms, future-dated
  and malformed anchors cannot buy immortality, kill switch, env override,
  wake-clears-anchor restores eligibility, and the patch never contains
  lastTurnAt.
- projects/execution-lease-write.test.ts (new): drives acquire/renew through a
  mocked db and asserts the real write payload - no lastTurnAt on either path, a
  refused renew issues zero UPDATEs, kill switch restores the old behaviour.
Both fail against the pre-change module (5 of 7 in the new file, on real
assertions).