### PR TITLE
fix(whitelabel-demo): call the re-scope hook unconditionally

### DIFF
--- a/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
@@ -149,37 +149,6 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
     },
   });
 
-  // Every chip is a claim about what this session may reach, and a half-loaded
-  // one reads as a narrower session than it is ("None" before the list arrives).
-  // Hold the whole bar rather than animating through a wrong answer.
-  if (session.isLoading || secrets.isLoading || connectors.isLoading) {
-    return <div className="mt-2 h-6" aria-hidden />;
-  }
-  if (!data) {
-    return (
-      <p className="mt-2 text-center text-[11px] text-muted-foreground">
-        This session&apos;s scope could not be read just now.
-      </p>
-    );
-  }
-
-  // Read off the capability map rather than hardcoded: if either of these ever
-  // became changeable in place, the draft-and-restart affordance would be the
-  // wrong shape and should disappear rather than quietly misdescribe the rule.
-  const secretsFixed = !scopeControl('secrets').live;
-  const connectionsFixed = !scopeControl('connections').live;
-
-  // Offering "start a new session with this scope" against a secret list that
-  // failed to load would either send an allowlist nothing verified or refuse it
-  // with a reason that is only an artefact of the failed read.
-  const startAction = secrets.isError ? null : (
-    <StartWithScope
-      issues={issues.map((issue) => issue.message)}
-      pending={start.isPending}
-      onStart={() => start.mutate()}
-    />
-  );
-
   // Apply the draft to THIS session. The bar said "Changeable" before this
   // existed — a badge without the control, which is worse than saying frozen.
   const applyScope = useMutation({
@@ -224,6 +193,37 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
     },
     onError: (err: Error) => toast.error(err.message),
   });
+
+  // Every chip is a claim about what this session may reach, and a half-loaded
+  // one reads as a narrower session than it is ("None" before the list arrives).
+  // Hold the whole bar rather than animating through a wrong answer.
+  if (session.isLoading || secrets.isLoading || connectors.isLoading) {
+    return <div className="mt-2 h-6" aria-hidden />;
+  }
+  if (!data) {
+    return (
+      <p className="mt-2 text-center text-[11px] text-muted-foreground">
+        This session&apos;s scope could not be read just now.
+      </p>
+    );
+  }
+
+  // Read off the capability map rather than hardcoded: if either of these ever
+  // became changeable in place, the draft-and-restart affordance would be the
+  // wrong shape and should disappear rather than quietly misdescribe the rule.
+  const secretsFixed = !scopeControl('secrets').live;
+  const connectionsFixed = !scopeControl('connections').live;
+
+  // Offering "start a new session with this scope" against a secret list that
+  // failed to load would either send an allowlist nothing verified or refuse it
+  // with a reason that is only an artefact of the failed read.
+  const startAction = secrets.isError ? null : (
+    <StartWithScope
+      issues={issues.map((issue) => issue.message)}
+      pending={start.isPending}
+      onStart={() => start.mutate()}
+    />
+  );
 
   const toggleSecret = (identifier: string, on: boolean) => {
     const base = nextSecrets ?? [];


### PR DESCRIPTION
Runtime crash I shipped in #5820: *"React has detected a change in the order of Hooks called by ScopeBar."*

I added `useMutation` **below** the component's `if (…) return` guard for "scope could not be read". On the render where that guard fires, the hook is skipped, hook #44 goes from `useContext` to `undefined`, and React tears the component.

It type-checked, all 330 tests passed, and the SDK boundary was clean. The failure only appears at runtime on the branch a test rarely takes — the founder hit it immediately.

Fixed by moving the mutation up beside `start`, above every early return. Verified structurally (hook at line 154, first guard return at 204) and by loading a real session workbench: **200, zero hook-order errors in the dev log**.

## A guard I wrote and then deleted

I tried to add a test asserting no `use*()` appears after a component's first early return. It was wrong in **both** directions:

- **Missed the actual bug.** My pattern matched `^  return (` — two spaces — but the real guard clause is inside an `if`, so it sits at four. The test passed while the bug was present.
- **Then false-positived twice** once widened: a `return` inside a `useMemo` callback, and `export default function` defeating the "new component resets the rule" check.

A regex cannot do scope analysis, and a guard that mis-reports both ways is worse than none — it is the same "test that still passes with the feature deleted" failure I flagged in review this morning. Deleted rather than shipped.

**The real fix is `eslint-plugin-react-hooks`**, which does proper scope analysis. This app has no eslint config at all, so that is its own piece of work — worth doing, and I would rather name it than leave a decorative test implying the class is covered.

330 pass / 0 fail, tsc clean, boundary clean.