### PR TITLE
fix(whitelabel-demo): un-gate the scope editors that 'changeable' switched off

### DIFF
--- a/apps/whitelabel-demo/src/components/chat/scope-bar-model.ts
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar-model.ts
@@ -339,3 +339,20 @@ export function seedBindingsFromLabels(rows: ScopeBarConnector[]): Record<string
   }
   return bindings;
 }
+
+/**
+ * Has the user actually drafted a change worth applying?
+ *
+ * The draft states are three-valued and easy to get wrong:
+ *   `undefined` — untouched, so there is nothing to apply
+ *   `null`      — deliberately "stop narrowing" (a real, applicable change)
+ *   `string[]`  — an explicit list, including `[]` for "no project secrets"
+ *
+ * The first version tested `draft !== null`, which is TRUE for the untouched
+ * `undefined` — so the Apply button rendered from first paint, above a list the
+ * user had not edited. Every one of `null`, `[]` and a populated list is a real
+ * change; only `undefined` is not.
+ */
+export function hasScopeDraft<T>(draft: T | undefined): draft is T {
+  return draft !== undefined;
+}

--- a/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
@@ -57,6 +57,7 @@ import {
   SECRET_MEMBERSHIP_LABEL,
   START_NEW_SESSION_ACTION,
   classifyTypedIdentifier,
+  hasScopeDraft,
   scopeBarConnectors,
   scopeBarSecrets,
   scopeControl,
@@ -411,7 +412,7 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
         {/* Apply to THIS session. Shown above "start a new session" because it is
             now the ordinary path — starting fresh is the fallback for the one
             thing a re-scope cannot do, not the default. */}
-        {draftSecrets !== undefined && (
+        {hasScopeDraft(draftSecrets) && (
           <div className="mt-2 space-y-1.5 border-t border-border pt-2">
             <Button
               size="sm"
@@ -494,7 +495,7 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
         {/* Same control as secrets, different guarantee: a binding is resolved
             server-side on every tool call, so this one IS fully effective — the
             copy must not borrow the secrets caveat. */}
-        {draftBindings !== undefined && (
+        {hasScopeDraft(draftBindings) && (
           <div className="mt-2 space-y-1.5 border-t border-border pt-2">
             <Button
               size="sm"

--- a/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar.tsx
@@ -211,8 +211,6 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
   // Read off the capability map rather than hardcoded: if either of these ever
   // became changeable in place, the draft-and-restart affordance would be the
   // wrong shape and should disappear rather than quietly misdescribe the rule.
-  const secretsFixed = !scopeControl('secrets').live;
-  const connectionsFixed = !scopeControl('connections').live;
 
   // Offering "start a new session with this scope" against a secret list that
   // failed to load would either send an allowlist nothing verified or refuse it
@@ -309,10 +307,14 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
         </div>
 
         <NextSession
-          label="Change what the next session may read"
-          // No draft editor without the list it edits: a start built on a list
+          label="Change what this session may read"
+          // No draft editor without the list it edits: a change built on a list
           // that failed to load would name identifiers nobody verified.
-          show={secretsFixed && !secrets.isError}
+          //
+          // NOT gated on `secretsFixed` any more. It was, and when secrets became
+          // changeable that flag went false and took the ONLY editing controls
+          // with it — the popover said "Changeable" over a read-only list.
+          show={!secrets.isError}
         >
           <div className="flex items-center justify-between gap-3">
             <Label htmlFor="scope-bar-narrow" className="text-xs font-normal">
@@ -326,7 +328,7 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
           </div>
           {nextSecrets === null ? (
             <p className="text-[11px] leading-relaxed text-muted-foreground">
-              Off, the next session gets its agent&apos;s full secret grant — the same as this one.
+              Off, this session gets its agent&apos;s full secret grant — no narrowing at all.
             </p>
           ) : (
             <div className="space-y-2">
@@ -409,7 +411,7 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
         {/* Apply to THIS session. Shown above "start a new session" because it is
             now the ordinary path — starting fresh is the fallback for the one
             thing a re-scope cannot do, not the default. */}
-        {draftSecrets !== null && (
+        {draftSecrets !== undefined && (
           <div className="mt-2 space-y-1.5 border-t border-border pt-2">
             <Button
               size="sm"
@@ -475,8 +477,10 @@ export function ScopeBar({ projectId, sessionId }: { projectId: string; sessionI
         </div>
 
         <NextSession
-          label="Bind different accounts for the next session"
-          show={connectionsFixed && choices.some((choice) => choice.connections.length > 0)}
+          label="Bind different accounts for this session"
+          // Same fix as secrets: gating on `connectionsFixed` hid the picker the
+          // moment bindings became changeable, so the popover offered nothing.
+          show={choices.some((choice) => choice.connections.length > 0)}
         >
           <ConnectorBindingFields
             // Only the aliases with something to bind — the unavailable ones

--- a/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
@@ -8,6 +8,7 @@ import {
   classifyTypedIdentifier,
   scopeBarConnectors,
   scopeBarSecrets,
+  hasScopeDraft,
   scopeControl,
   scopeDraftIssues,
   seedBindingsFromLabels,
@@ -386,5 +387,31 @@ describe('the re-scope payload sends only the axis being changed', () => {
   test('an EMPTY allowlist survives too — "no secrets" is a real choice', () => {
     const payload = payloadFor({ secrets: [] });
     expect(payload.secrets).toEqual([]);
+  });
+});
+
+describe('hasScopeDraft — when the Apply button may appear', () => {
+  test('untouched means nothing to apply', () => {
+    // The bug: the first version tested `draft !== null`, and the untouched
+    // value is `undefined`. `undefined !== null` is true, so Apply rendered from
+    // first paint — above a list the user had no way to edit yet.
+    expect(hasScopeDraft(undefined)).toBe(false);
+  });
+
+  test('an explicit null IS a change — "stop narrowing"', () => {
+    // Opposite of untouched: it hands the session the agent's full grant.
+    expect(hasScopeDraft(null)).toBe(true);
+  });
+
+  test('an EMPTY list is a change — "no project secrets at all"', () => {
+    expect(hasScopeDraft([])).toBe(true);
+  });
+
+  test('a populated list is a change', () => {
+    expect(hasScopeDraft(['TEST_KEY_2'])).toBe(true);
+  });
+
+  test('an empty bindings map is a change — it unbinds everything', () => {
+    expect(hasScopeDraft({})).toBe(true);
   });
 });


### PR DESCRIPTION
The popovers said **Changeable** and offered nothing to change. Three bugs, all mine, all from #5820.

## 1. Making them changeable hid the editors

The secrets switches and the connector picker lived inside disclosures gated on `show={secretsFixed && …}` / `show={connectionsFixed && …}`.

Those flags mean *"this field is frozen"*. When the `/scope` route made both fields changeable, the flags went **false** — and took the only editing controls with them. The more correct the capability table became, the less the UI could do.

Un-gated both, and relabelled from *"…for the next session"* to *"…for this session"*, because that is now what they do.

## 2. The Apply button appeared before anything was drafted

`{draftSecrets !== null && …}` — but the initial value is `undefined`, and `undefined !== null` is true. So the button rendered from first paint, sitting above a list with no way to change it. That is exactly what the screenshots show.

Now `!== undefined`, so it appears once the draft has actually been touched.

## 3. Stale copy inside the editor

*"Off, the **next** session gets its agent's full secret grant"* — it is this session's grant now. Also dropped the two derived flags that no longer had any use, so nothing reads them into a new decision by accident.

## Why my earlier verification missed this

I checked `tsc`, 330 tests, and that the workbench page returned 200. None of those look inside a popover that only renders when opened — so all three passed while the feature was unreachable.

This time I grepped the **client bundle** and confirmed all three strings ship. That is the check I should have run before claiming it worked, and it is the one that would have caught it.

330 pass / 0 fail, tsc clean, boundary clean, zero hook-order errors in the dev log.