### PR TITLE
fix(acp): exempt harness turns from request deadline

### DIFF
--- a/apps/api/src/__tests__/unit-request-deadline.test.ts
+++ b/apps/api/src/__tests__/unit-request-deadline.test.ts
@@ -34,6 +34,9 @@ function makeApp() {
   app.get('/v1/llm/chat/completions', slow);          // exempt prefix (LLM streaming)
   app.post('/v1/billing/webhooks/stripe', slow);      // exempt prefix (webhook)
   app.post('/v1/projects/x/sessions/y/start', slow);  // exempt fragment (long sync op)
+  app.post('/v1/projects/x/sessions/y/acp', slow);    // exact ACP JSON-RPC turn
+  app.get('/v1/projects/x/sessions/y/acp', slow);     // bounded — only POST is exempt
+  app.post('/v1/projects/x/acp', slow);               // bounded — wrong route shape
   app.post('/v1/projects/x/oauth/openai/start', slow); // exempt fragment (OAuth device flow — start can be slow on a cold replica)
   app.post('/v1/projects', slow);                      // exempt method+path (provision)
   app.get('/v1/projects', slow);                       // bounded — only POST is exempt
@@ -88,6 +91,18 @@ describe('requestDeadline', () => {
   it('exempts long sync sandbox ops (start) via fragment', async () => {
     const res = await makeApp().request('/v1/projects/x/sessions/y/start', { method: 'POST' });
     expect(res.status).toBe(200);
+  });
+
+  it('exempts only the ACP JSON-RPC POST route', async () => {
+    const app = makeApp();
+    const post = await app.request('/v1/projects/x/sessions/y/acp', { method: 'POST' });
+    expect(post.status).toBe(200);
+
+    const get = await app.request('/v1/projects/x/sessions/y/acp');
+    expect(get.status).toBe(503);
+
+    const wrongShape = await app.request('/v1/projects/x/acp', { method: 'POST' });
+    expect(wrongShape.status).toBe(503);
   });
 
   it('exempts the provider OAuth device flow start (can be slow on a cold replica)', async () => {

--- a/apps/api/src/middleware/request-deadline.test.ts
+++ b/apps/api/src/middleware/request-deadline.test.ts
@@ -29,6 +29,26 @@ describe('requestDeadline exemptions', () => {
     expect(isExempt(ctx(path))).toBe(false);
   });
 
+  test('exempts only POST requests to the exact ACP JSON-RPC route shape', () => {
+    const path =
+      '/v1/projects/00000000-0000-4000-a000-000000000001/sessions/00000000-0000-4000-a000-000000000002/acp';
+    expect(isExempt(ctx(path, 'POST'))).toBe(true);
+    expect(isExempt(ctx(path, 'GET'))).toBe(false);
+    expect(
+      isExempt(
+        ctx('/v1/projects/00000000-0000-4000-a000-000000000001/acp', 'POST'),
+      ),
+    ).toBe(false);
+    expect(
+      isExempt(
+        ctx(
+          '/v1/projects/00000000-0000-4000-a000-000000000001/sessions/00000000-0000-4000-a000-000000000002/acp/extra',
+          'POST',
+        ),
+      ),
+    ).toBe(false);
+  });
+
   test.each([
     '/v1/projects/00000000-0000-4000-a000-000000000001/commit-push',
     '/v1/projects/00000000-0000-4000-a000-000000000001/provision',

--- a/apps/api/src/middleware/request-deadline.ts
+++ b/apps/api/src/middleware/request-deadline.ts
@@ -101,6 +101,13 @@ const EXEMPT_METHOD_PATHS: Array<{ method: string; path: string }> = [
   { method: 'POST', path: '/v1/projects' },          // create + seed + provision
 ];
 
+const EXEMPT_METHOD_PATH_PATTERNS: Array<{ method: string; path: RegExp }> = [
+  {
+    method: 'POST',
+    path: /^\/v1\/projects\/[^/]+\/sessions\/[^/]+\/acp$/,
+  }, // ACP JSON-RPC waits for the harness turn; cold harnesses can exceed 25s
+];
+
 export function isExempt(c: Context): boolean {
   // WebSocket upgrade (defensive — these are handled before app.fetch).
   if (c.req.header('upgrade')?.toLowerCase() === 'websocket') return true;
@@ -117,6 +124,9 @@ export function isExempt(c: Context): boolean {
   }
   for (const mp of EXEMPT_METHOD_PATHS) {
     if (c.req.method === mp.method && path === mp.path) return true;
+  }
+  for (const mp of EXEMPT_METHOD_PATH_PATTERNS) {
+    if (c.req.method === mp.method && mp.path.test(path)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

- Exempt only `POST /v1/projects/:projectId/sessions/:sessionId/acp` from the 25-second request deadline.
- Keep `GET`, unrelated `/acp`, and nested ACP paths bounded.
- Add route-shape and middleware behavior regression tests.

## Evidence

The Dev four-harness smoke reached OpenCode. Claude Code then returned:

```text
HTTP 503: Request exceeded the 25s server processing deadline
```

The smoke cleanup removed the project, sessions, account, and user.

## Verification

```text
bun test apps/api/src/middleware/request-deadline.test.ts
10 pass, 0 fail

bun test apps/api/src/__tests__/unit-request-deadline.test.ts
16 pass, 0 fail

pnpm --filter kortix-api typecheck
exit 0
```

The full API suite reports unrelated current-main failures in hosted-deployment cleanup tests and stale export imports. The focused deadline tests pass inside that suite.