### PR TITLE
fix(sessions): converge every session-start path on server-side titling

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -342,6 +342,18 @@ mock.module('../projects/opencode-session-snapshot', () => ({
   },
 }));
 
+// The proxy owns two of the four title hooks. Keep the REAL prompt extraction
+// (that is the part the proxy actually decides) and capture only the generator
+// call, whose own idempotency/CAS is covered by unit + integration tests.
+let mockTitleCalls: Array<Record<string, unknown>> = [];
+const realTitleGenerate = await import('../projects/session-title-generate');
+mock.module('../projects/session-title-generate', () => ({
+  ...realTitleGenerate,
+  generateSessionTitleFromFirstPrompt: async (input: Record<string, unknown>) => {
+    mockTitleCalls.push(input);
+  },
+}));
+
 // Override global fetch for proxy requests
 const originalFetch = globalThis.fetch;
 function mockFetch(url: string | URL | Request, init?: RequestInit): Promise<Response> {
@@ -463,6 +475,7 @@ beforeEach(() => {
   mockDbUpdateCalls = [];
   mockResolvedPreviewPorts = [];
   mockSnapshotSyncCalls = [];
+  mockTitleCalls = [];
 
   // Install mock fetch
   globalThis.fetch = mockFetch as any;
@@ -824,6 +837,119 @@ describe('Preview proxy: forwarding', () => {
     expect(mockFetchCalls[1].url).toBe(
       'https://preview.daytona.io/proxy-url/session/ses_123/prompt_async?directory=%2Fworkspace',
     );
+  });
+
+  test('titles from a REST prompt_async body, with the model the user picked for the turn', async () => {
+    mockFetchResponses = [
+      { status: 200, body: '{"ok":true,"changed":true,"revision":"rev"}' },
+      { status: 204, body: '' },
+    ];
+    const app = createProxyTestApp();
+    const res = await app.request(`/v1/p/${TEST_SANDBOX_ID}/8000/session/ses_123/prompt_async`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        parts: [{ type: 'text', text: 'set up the MS Graph connector' }],
+        model: { providerID: 'kortix', modelID: 'codex/gpt-5.6-sol' },
+      }),
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockTitleCalls).toEqual([
+      {
+        sessionId: mockDbSandbox.sessionId,
+        projectId: TEST_PROJECT_ID,
+        accountId: mockDbSandbox.accountId,
+        userId: TEST_USER_ID,
+        firstPromptText: 'set up the MS Graph connector',
+        modelHint: 'codex/gpt-5.6-sol',
+      },
+    ]);
+  });
+
+  test('does not title a prompt body that carries no text', async () => {
+    mockFetchResponses = [
+      { status: 200, body: '{"ok":true,"changed":true,"revision":"rev"}' },
+      { status: 204, body: '' },
+    ];
+    const app = createProxyTestApp();
+    const res = await app.request(`/v1/p/${TEST_SANDBOX_ID}/8000/session/ses_123/prompt_async`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parts: [{ type: 'image', url: 'x' }] }),
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockTitleCalls).toEqual([]);
+  });
+
+  test('titles from an accepted ACP session prompt', async () => {
+    mockFetchResponses = [{ status: 202, body: '' }];
+    const app = createProxyTestApp();
+
+    const res = await app.request(`/v1/p/${TEST_SANDBOX_ID}/8000/kortix/acp/ses_123`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'prompt-3',
+        method: 'session/prompt',
+        params: { sessionId: 'ses_123', prompt: [{ type: 'text', text: 'Research Marko' }] },
+      }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(mockTitleCalls).toHaveLength(1);
+    expect(mockTitleCalls[0]!.firstPromptText).toBe('Research Marko');
+  });
+
+  test('titles a MANAGED ACP prompt, whose harness sessionId differs from the route id', async () => {
+    // The route id is the ACP SERVER binding (the project session); the
+    // envelope's params.sessionId is the harness-issued session, which
+    // persistAcpSessionIdentity forbids from equalling it. Requiring the two to
+    // match made every managed ACP prompt invisible to this hook.
+    mockFetchResponses = [{ status: 202, body: '' }];
+    const app = createProxyTestApp();
+
+    const res = await app.request(
+      `/v1/p/${TEST_SANDBOX_ID}/8000/kortix/acp/${mockDbSandbox.sessionId}`,
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'prompt-5',
+          method: 'session/prompt',
+          params: {
+            sessionId: 'acp_harness_session_9',
+            prompt: [{ type: 'text', text: 'Research Marko' }],
+          },
+        }),
+      },
+    );
+
+    expect(res.status).toBe(202);
+    expect(mockTitleCalls).toHaveLength(1);
+    expect(mockTitleCalls[0]!.firstPromptText).toBe('Research Marko');
+  });
+
+  test('a rejected ACP session prompt is not titled', async () => {
+    mockFetchResponses = [{ status: 502, body: 'bad gateway' }];
+    const app = createProxyTestApp();
+
+    const res = await app.request(`/v1/p/${TEST_SANDBOX_ID}/8000/kortix/acp/ses_123`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'prompt-4',
+        method: 'session/prompt',
+        params: { sessionId: 'ses_123', prompt: [{ type: 'text', text: 'Research Marko' }] },
+      }),
+    });
+
+    expect(res.status).toBe(502);
+    expect(mockTitleCalls).toEqual([]);
   });
 
   test('schedules a deferred opencode_sessions snapshot sync after an accepted ACP session prompt', async () => {

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1604,6 +1604,17 @@ describe('project session API contract', () => {
         message: 'metadata key is server-managed: deletedBy',
       },
       {
+        // metadata.name is owned by the title generator; planting a non
+        // placeholder value pre-empts titling forever. Renaming is `name` →
+        // metadata.custom_name.
+        body: { metadata: { name: 'zzz' } },
+        message: 'metadata key is server-managed: name',
+      },
+      {
+        body: { metadata: { title_source: 'zzz' } },
+        message: 'metadata key is server-managed: title_source',
+      },
+      {
         body: { random: 'field' },
         message: 'field is not user-editable: random',
       },

--- a/apps/api/src/__tests__/integration-session-title-claim.test.ts
+++ b/apps/api/src/__tests__/integration-session-title-claim.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Integration test (real local DB): the title UPDATE is a compare-and-set over
+ * an atomic jsonb merge.
+ *
+ * Moving titling to create time puts the write exactly inside the window where
+ * `acp-session-identity.ts`, the remote-branch publisher and the start-timeline
+ * writer commit their own metadata. A read-modify-write of the whole metadata
+ * object would clobber, or be clobbered by, any of them — and would let a late
+ * duplicate overwrite a user rename. These tests pin both halves: the WHERE
+ * clause (first-writer-wins) and the merge expression (no key loss).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { accounts, projectSessions, projects } from '@kortix/db';
+import { eq, sql } from 'drizzle-orm';
+
+import type { ProjectSessionRow } from '../projects/lib/serializers';
+import { projectSessionMetadataMerge } from '../projects/lib/session-metadata-merge';
+import { persistTitle } from '../projects/session-title-generate';
+import { db } from '../shared/db';
+import { getPublicSessionInfo } from '../shared/public-session-share-view';
+
+const ACCOUNT = crypto.randomUUID();
+const PROJECT = crypto.randomUUID();
+const USER = crypto.randomUUID();
+
+let n = 0;
+async function seed(metadata: Record<string, unknown>): Promise<ProjectSessionRow> {
+  n += 1;
+  const sessionId = `title-cas-${n}-${crypto.randomUUID().slice(0, 8)}`;
+  await db.insert(projectSessions).values({
+    sessionId,
+    accountId: ACCOUNT,
+    projectId: PROJECT,
+    branchName: sessionId,
+    createdBy: USER,
+    metadata,
+  });
+  return { sessionId, accountId: ACCOUNT, projectId: PROJECT, metadata } as ProjectSessionRow;
+}
+
+async function metadataOf(sessionId: string): Promise<Record<string, unknown>> {
+  const [row] = await db
+    .select({ metadata: projectSessions.metadata })
+    .from(projectSessions)
+    .where(eq(projectSessions.sessionId, sessionId));
+  return (row?.metadata ?? {}) as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+  await db.insert(accounts).values({ accountId: ACCOUNT, name: 'title-cas-test' });
+  await db.insert(projects).values({
+    projectId: PROJECT,
+    accountId: ACCOUNT,
+    name: 'p',
+    repoUrl: 'https://example.com/p.git',
+  });
+});
+
+afterAll(async () => {
+  await db.delete(projects).where(eq(projects.accountId, ACCOUNT));
+  await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT)); // cascades sessions
+});
+
+describe('persistTitle — compare-and-set', () => {
+  test('two concurrent writers: exactly one title lands, and it never flip-flops', async () => {
+    const row = await seed({});
+    await Promise.all([persistTitle(row, 'First Title'), persistTitle(row, 'Second Title')]);
+    const name = (await metadataOf(row.sessionId)).name as string;
+    expect(['First Title', 'Second Title']).toContain(name);
+
+    // A late duplicate arriving after the row is titled is a no-op.
+    await persistTitle(row, 'Late Duplicate');
+    expect((await metadataOf(row.sessionId)).name).toBe(name);
+  });
+
+  test('a user rename (custom_name) is never overwritten', async () => {
+    const row = await seed({ custom_name: 'My Own Name' });
+    await persistTitle(row, 'Generated Title');
+    const metadata = await metadataOf(row.sessionId);
+    expect(metadata.name).toBeUndefined();
+    expect(metadata.custom_name).toBe('My Own Name');
+  });
+
+  test('a real existing title is never overwritten', async () => {
+    const row = await seed({ name: 'Set Up MS Graph' });
+    await persistTitle(row, 'Generated Title');
+    expect((await metadataOf(row.sessionId)).name).toBe('Set Up MS Graph');
+  });
+
+  test("opencode's frozen placeholder IS overwritten", async () => {
+    const row = await seed({ name: 'New session - Jul 29' });
+    await persistTitle(row, 'Generated Title');
+    expect((await metadataOf(row.sessionId)).name).toBe('Generated Title');
+
+    // …but a real title that merely starts with the word "New" is not.
+    const near = await seed({ name: 'New sessions of work' });
+    await persistTitle(near, 'Generated Title');
+    expect((await metadataOf(near.sessionId)).name).toBe('New sessions of work');
+  });
+
+  test('a blank/whitespace name counts as untitled', async () => {
+    const row = await seed({ name: '   ' });
+    await persistTitle(row, 'Generated Title');
+    expect((await metadataOf(row.sessionId)).name).toBe('Generated Title');
+
+    // PostgreSQL's bare trim() strips SPACES only. Trimming a narrower set than
+    // JavaScript's String.trim() here makes the CAS refuse rows that the TS
+    // `needsTitle` gate already waved through — a silent, billed, forever loop.
+    const tabbed = await seed({ name: '\n\t New session - Jul 29 \r\n' });
+    await persistTitle(tabbed, 'Generated Title');
+    expect((await metadataOf(tabbed.sessionId)).name).toBe('Generated Title');
+
+    const onlyWhitespace = await seed({ name: '\n\t\r ' });
+    await persistTitle(onlyWhitespace, 'Generated Title');
+    expect((await metadataOf(onlyWhitespace.sessionId)).name).toBe('Generated Title');
+  });
+
+  test('a NON-STRING name/custom_name reads as set — the same way needsTitle reads it', async () => {
+    // `metadata->>'x'` stringifies any jsonb scalar. The TS predicate reads it
+    // the same way, so neither of these ever reaches the gateway; if one did,
+    // this UPDATE would no-op and the cycle would repeat on every prompt.
+    const numericName = await seed({ name: 123 });
+    await persistTitle(numericName, 'Generated Title');
+    expect((await metadataOf(numericName.sessionId)).name).toBe(123);
+
+    const numericCustom = await seed({ custom_name: 123 });
+    await persistTitle(numericCustom, 'Generated Title');
+    expect((await metadataOf(numericCustom.sessionId)).name).toBeUndefined();
+  });
+
+  test('no clobber: a concurrent full-metadata acp_session_id write survives, and so does the title', async () => {
+    const row = await seed({ runtime_transport: 'acp', acp_server_id: 'srv-1' });
+
+    // Mirrors acp-session-identity.ts: SELECT … FOR UPDATE, then write the whole
+    // metadata object back. Racing it against persistTitle used to lose one side.
+    const claimIdentity = db.transaction(async (tx) => {
+      const [locked] = await tx
+        .select({ metadata: projectSessions.metadata })
+        .from(projectSessions)
+        .where(eq(projectSessions.sessionId, row.sessionId))
+        .for('update');
+      await tx
+        .update(projectSessions)
+        .set({
+          metadata: {
+            ...((locked?.metadata ?? {}) as Record<string, unknown>),
+            acp_session_id: 'acp-sess-9',
+          },
+        })
+        .where(eq(projectSessions.sessionId, row.sessionId));
+    });
+
+    await Promise.all([claimIdentity, persistTitle(row, 'Generated Title')]);
+
+    const metadata = await metadataOf(row.sessionId);
+    expect(metadata.acp_session_id).toBe('acp-sess-9');
+    expect(metadata.name).toBe('Generated Title');
+    expect(metadata.acp_server_id).toBe('srv-1');
+  });
+
+  test('no clobber: the provisioning_error merge preserves a title written after insert', async () => {
+    // sessions.ts used to write `{ ...createTimeMetadata, provisioning_error }`,
+    // which erased anything (title included) landing between insert and failure.
+    const row = await seed({ runtime_transport: 'rest' });
+    await persistTitle(row, 'Generated Title');
+    await db
+      .update(projectSessions)
+      .set({ metadata: projectSessionMetadataMerge({ provisioning_error: 'boom' }) })
+      .where(eq(projectSessions.sessionId, row.sessionId));
+
+    const metadata = await metadataOf(row.sessionId);
+    expect(metadata.name).toBe('Generated Title');
+    expect(metadata.provisioning_error).toBe('boom');
+    expect(metadata.runtime_transport).toBe('rest');
+  });
+
+  test('the CAS is scoped to the exact session/project/account triple', async () => {
+    const row = await seed({});
+    await persistTitle({ ...row, accountId: crypto.randomUUID() } as ProjectSessionRow, 'Wrong');
+    expect((await metadataOf(row.sessionId)).name).toBeUndefined();
+  });
+
+  test('the placeholder predicate runs case-insensitively in Postgres', async () => {
+    const [check] = await db.execute(
+      sql`select ('new SESSION x' ~* '^new session([^[:alnum:]_]|$)')::bool as hit`,
+    );
+    expect((check as { hit: boolean }).hit).toBe(true);
+  });
+});
+
+describe('getPublicSessionInfo — the anonymous share viewer sees the same title chain', () => {
+  test('nulls the frozen placeholder, keeps a real title, and custom_name still wins', async () => {
+    const placeholder = await seed({ name: 'New session - Jul 29' });
+    const generated = await seed({ name: 'Set Up MS Graph' });
+    const renamed = await seed({ name: 'Set Up MS Graph', custom_name: 'Mine' });
+
+    const titleOf = async (sessionId: string) => {
+      const result = await getPublicSessionInfo(sessionId);
+      expect(result.ok).toBe(true);
+      return result.ok ? result.session.title : undefined;
+    };
+
+    expect(await titleOf(placeholder.sessionId)).toBeNull();
+    expect(await titleOf(generated.sessionId)).toBe('Set Up MS Graph');
+    expect(await titleOf(renamed.sessionId)).toBe('Mine');
+  });
+});

--- a/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
+++ b/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
@@ -213,6 +213,18 @@ describe('serializeSession ⇄ ProjectSessionSchema', () => {
     expect(parsed.name).toBe('Mine');
     expect(parsed.custom_name).toBe('Mine');
   });
+
+  test("opencode's frozen placeholder reads as untitled, a real title does not", () => {
+    const placeholder = ProjectSessionSchema.strict().parse(
+      serializeSession(sessionRow({ metadata: { name: 'New session - 2026-07-28' } })),
+    );
+    expect(placeholder.name).toBeNull();
+
+    const real = ProjectSessionSchema.strict().parse(
+      serializeSession(sessionRow({ metadata: { name: 'Set Up MS Graph' } })),
+    );
+    expect(real.name).toBe('Set Up MS Graph');
+  });
 });
 
 describe('serializeSandboxRow ⇄ ProjectSessionSandboxSchema', () => {

--- a/apps/api/src/__tests__/unit-opencode-session-snapshot.test.ts
+++ b/apps/api/src/__tests__/unit-opencode-session-snapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from 'bun:test';
 
 import type { ProjectSessionRow } from '../projects/lib/serializers';
+import { projectSessionMetadataMerge } from '../projects/lib/session-metadata-merge';
 
 // Mock the DB write and the sandbox session listing before importing the module.
 const dbUpdates: Array<Record<string, unknown>> = [];
@@ -41,20 +42,35 @@ function row(over: Partial<ProjectSessionRow> = {}): ProjectSessionRow {
 }
 
 describe('syncOpencodeSessionSnapshot', () => {
-  it('writes opencode_sessions and NEVER touches the title (metadata.name)', async () => {
+  it('MERGES opencode_sessions in-SQL and never rewrites the rest of metadata', async () => {
     dbUpdates.length = 0;
     listResult = {
       ok: true,
       sessions: [{ id: 'ses_root', title: 'A Real Title', parentID: null }],
     };
-    await syncOpencodeSessionSnapshot({ row: row(), externalId: 'ext' });
+    // A title the CAS commits between this pass's read and its write must
+    // survive: a read-modify-write of the whole object would drop it, and for a
+    // one-shot automation session nothing ever re-titles.
+    await syncOpencodeSessionSnapshot({
+      row: row({ metadata: { name: 'Set Up MS Graph' } } as Partial<ProjectSessionRow>),
+      externalId: 'ext',
+    });
     expect(dbUpdates).toHaveLength(1);
-    const metadata = dbUpdates[0].metadata as Record<string, unknown>;
-    const sessions = metadata.opencode_sessions as Array<{ id: string; title: string | null }>;
-    expect(sessions[0]).toMatchObject({ id: 'ses_root', title: 'A Real Title' });
-    // The snapshot carries each conversation's own title, but must not set the
-    // session's name — that is session-title-generate's sole responsibility.
-    expect('name' in metadata).toBe(false);
+    expect(dbUpdates[0].metadata).toEqual(
+      projectSessionMetadataMerge({
+        opencode_sessions: [
+          {
+            id: 'ses_root',
+            title: 'A Real Title',
+            parent_id: null,
+            project_id: null,
+            created_at: null,
+            updated_at: null,
+            archived_at: null,
+          },
+        ],
+      }),
+    );
   });
 
   it('no-ops when the snapshot is unchanged and on unreachable sandboxes', async () => {

--- a/apps/api/src/__tests__/unit-session-title-generate.test.ts
+++ b/apps/api/src/__tests__/unit-session-title-generate.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'bun:test';
 
+import {
+  PLACEHOLDER_TITLE_SQL_PATTERN,
+  isPlaceholderOpencodeTitle,
+} from '../projects/lib/opencode-title';
 import type { ProjectSessionRow } from '../projects/lib/serializers';
 import {
   type GenerateSessionTitleOptions,
   extractPromptInfo,
   generateSessionTitleFromFirstPrompt,
+  promptInfoFromEnvelope,
   sanitizeGeneratedTitle,
+  titleSourceForCreate,
 } from '../projects/session-title-generate';
 
 function row(metadata: Record<string, unknown>): ProjectSessionRow {
@@ -105,6 +111,87 @@ describe('extractPromptInfo', () => {
   });
 });
 
+describe('promptInfoFromEnvelope', () => {
+  it('matches extractPromptInfo over the same envelope, parsed vs encoded', () => {
+    const envelope = {
+      method: 'session/prompt',
+      params: {
+        sessionId: 'x',
+        prompt: [
+          { type: 'text', text: 'first' },
+          { type: 'image', url: 'x' },
+          { type: 'text', text: 'second' },
+        ],
+        model: { providerID: 'kortix', modelID: 'glm-5.2' },
+      },
+    };
+    expect(promptInfoFromEnvelope(envelope)).toEqual({ text: 'first\nsecond', model: 'glm-5.2' });
+    expect(promptInfoFromEnvelope(envelope)).toEqual(
+      extractPromptInfo(bodyOf(envelope), headers()),
+    );
+  });
+
+  it('is null-safe for non-object and prompt-less envelopes', () => {
+    expect(promptInfoFromEnvelope(null)).toEqual({ text: null, model: null });
+    expect(promptInfoFromEnvelope('nope')).toEqual({ text: null, model: null });
+    expect(promptInfoFromEnvelope({ method: 'session/cancel' })).toEqual({
+      text: null,
+      model: null,
+    });
+  });
+});
+
+describe('titleSourceForCreate', () => {
+  it('prefers an explicit title_source over the rendered prompt', () => {
+    expect(
+      titleSourceForCreate({ title_source: 'deploy the worker', initial_prompt: 'ENVELOPE…' }),
+    ).toBe('deploy the worker');
+  });
+
+  it('falls back to initial_prompt / initialPrompt and trims', () => {
+    expect(titleSourceForCreate({ initial_prompt: '  ship it  ' })).toBe('ship it');
+    expect(titleSourceForCreate({ initialPrompt: 'ship it' })).toBe('ship it');
+  });
+
+  it('is null when the body carries neither, or only blanks', () => {
+    expect(titleSourceForCreate({})).toBeNull();
+    expect(titleSourceForCreate({ name: 'Fix sandbox build' })).toBeNull();
+    expect(titleSourceForCreate({ title_source: '   ', initial_prompt: '' })).toBeNull();
+    expect(titleSourceForCreate({ title_source: null, initial_prompt: 'fallback' })).toBe(
+      'fallback',
+    );
+  });
+});
+
+describe('PLACEHOLDER_TITLE_SQL_PATTERN', () => {
+  // JS translation of the POSIX classes so the SQL predicate and the TS one
+  // cannot drift: `[:alnum:]` is `[0-9A-Za-z]`, and the pattern's `_` makes the
+  // class the exact complement of JavaScript's `\w`.
+  const asJs = new RegExp(PLACEHOLDER_TITLE_SQL_PATTERN.replace('[:alnum:]_', '0-9A-Za-z_'), 'i');
+
+  it('is a POSIX twin of isPlaceholderOpencodeTitle', () => {
+    const fixtures = [
+      'New session',
+      'New session - Jul 29',
+      'new SESSION x',
+      'New session_x',
+      'NEW SESSION',
+      '  New session - 2026-07-28  ',
+      'New sessions of work',
+      'Newsession',
+      'New session planning doc',
+      'Set Up MS Graph',
+      '',
+    ];
+    for (const fixture of fixtures) {
+      expect([fixture, asJs.test(fixture.trim())]).toEqual([
+        fixture,
+        isPlaceholderOpencodeTitle(fixture),
+      ]);
+    }
+  });
+});
+
 describe('generateSessionTitleFromFirstPrompt', () => {
   function harness(over: Partial<GenerateSessionTitleOptions> & { row?: ProjectSessionRow } = {}) {
     const persisted: string[] = [];
@@ -138,6 +225,9 @@ describe('generateSessionTitleFromFirstPrompt', () => {
         (async (_r, title) => {
           persisted.push(title);
         }),
+      // Never let a unit test reach the real resolver (billing tier + gateway
+      // candidate resolution, both DB-backed).
+      fallbackModel: over.fallbackModel ?? (async () => null),
     };
     return { options, persisted, minted, revoked, models, generateCalls: () => generateCalls };
   }
@@ -199,11 +289,115 @@ describe('generateSessionTitleFromFirstPrompt', () => {
     expect(placeholder.persisted).toEqual(['Set Up MS Graph']);
   });
 
-  it('skips when the session has no model to title with', async () => {
-    const h = harness({ row: row({}) });
+  it('falls back to a resolved SERVABLE model when neither the turn nor the row names one', async () => {
+    // Create-time and every server-side delivery arrive with no modelHint, and
+    // `opencode_model` is absent whenever session create resolved no default —
+    // without this fallback those sessions would stay untitled forever.
+    const h = harness({ row: row({}), fallbackModel: async () => 'glm-5.2' });
     await generateSessionTitleFromFirstPrompt(input, h.options);
+    expect(h.models).toEqual(['glm-5.2']);
+    expect(h.persisted).toEqual(['Set Up MS Graph']);
+  });
+
+  it('spends NOTHING when no model is servable — free tier, or no managed provider', async () => {
+    // The unconditional platform default is a managed id: on a free tier (or a
+    // deployment with no managed provider) the gateway refuses it, so minting a
+    // key and calling would be a doomed, billed, untitled loop on every prompt.
+    const h = harness({ row: row({}), fallbackModel: async () => null });
+    await generateSessionTitleFromFirstPrompt(input, h.options);
+    expect(h.models).toEqual([]);
+    expect(h.minted).toEqual([]);
     expect(h.persisted).toEqual([]);
-    expect(h.generateCalls()).toBe(0);
+  });
+
+  it('precedence: modelHint beats opencode_model beats the resolved fallback', async () => {
+    const hint = harness({ row: row({ opencode_model: 'kortix/glm-5.2' }) });
+    await generateSessionTitleFromFirstPrompt(
+      { ...input, modelHint: 'codex/gpt-5.6-sol' },
+      hint.options,
+    );
+    expect(hint.models).toEqual(['codex/gpt-5.6-sol']);
+
+    const stored = harness({
+      row: row({ opencode_model: 'kortix/glm-5.2' }),
+      fallbackModel: async () => 'never/used',
+    });
+    await generateSessionTitleFromFirstPrompt(input, stored.options);
+    expect(stored.models).toEqual(['glm-5.2']);
+
+    const fallback = harness({ row: row({}), fallbackModel: async () => 'anthropic/claude' });
+    await generateSessionTitleFromFirstPrompt(input, fallback.options);
+    expect(fallback.models).toEqual(['anthropic/claude']);
+  });
+
+  it('titles from the create-time title_source, never the rendered envelope it was handed', async () => {
+    // A Slack/Teams/Telegram session bakes a rendered envelope as its prompt; a
+    // later fallback hook only ever sees THAT text. Without the stored source, a
+    // transient create-hook failure names the session after turn instructions
+    // and raw workspace/channel ids — on a project-visible session.
+    const prompts: string[] = [];
+    const h = harness({
+      row: row({ opencode_model: 'kortix/glm-5.2', title_source: 'bump the node version in CI' }),
+      generate: async (_model, _auth, promptText) => {
+        prompts.push(promptText);
+        return 'Bump Node In CI';
+      },
+    });
+    await generateSessionTitleFromFirstPrompt(
+      { ...input, firstPromptText: "You're answering on Slack.\nWorkspace: T0123\nMessage:\nhi" },
+      h.options,
+    );
+    expect(prompts).toEqual(['bump the node version in CI']);
+    expect(h.persisted).toEqual(['Bump Node In CI']);
+  });
+
+  it('treats a NON-STRING name/custom_name as set — the CAS reads it as text', async () => {
+    // `metadata->>'name'` stringifies any jsonb scalar, so a row the TS gate
+    // waved through would fail the UPDATE silently and re-bill on every prompt.
+    const numericName = harness({
+      row: row({ name: 123, opencode_model: 'kortix/glm-5.2' }),
+    });
+    await generateSessionTitleFromFirstPrompt(input, numericName.options);
+    expect(numericName.persisted).toEqual([]);
+    expect(numericName.generateCalls()).toBe(0);
+
+    const numericCustom = harness({
+      row: row({ custom_name: 123, opencode_model: 'kortix/glm-5.2' }),
+    });
+    await generateSessionTitleFromFirstPrompt(input, numericCustom.options);
+    expect(numericCustom.persisted).toEqual([]);
+    expect(numericCustom.generateCalls()).toBe(0);
+  });
+
+  it('collapses concurrent same-session calls to one gateway call and one minted key', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const h = harness({
+      generate: async () => {
+        await gate;
+        return 'Set Up MS Graph';
+      },
+    });
+
+    const first = generateSessionTitleFromFirstPrompt(
+      { ...input, sessionId: 'dedupe-1' },
+      h.options,
+    );
+    const second = generateSessionTitleFromFirstPrompt(
+      { ...input, sessionId: 'dedupe-1' },
+      h.options,
+    );
+    release();
+    await Promise.all([first, second]);
+
+    expect(h.minted).toEqual(['k']);
+    expect(h.persisted).toEqual(['Set Up MS Graph']);
+
+    // A genuine retry AFTER the first settles is admitted again.
+    await generateSessionTitleFromFirstPrompt({ ...input, sessionId: 'dedupe-1' }, h.options);
+    expect(h.persisted).toEqual(['Set Up MS Graph', 'Set Up MS Graph']);
   });
 
   it('revokes the minted key even when generation throws', async () => {

--- a/apps/api/src/__tests__/unit-session-title-invariant.test.ts
+++ b/apps/api/src/__tests__/unit-session-title-invariant.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Guardrail: `project_sessions.metadata.name` is written exactly once per
+ * session, by `generateSessionTitleFromFirstPrompt()`, from the first user
+ * prompt, at the first moment that prompt's text is known server-side.
+ *
+ * There are exactly two such moments, and therefore exactly one set of hooks:
+ *   - create-with-prompt  → projects/lib/sessions.ts
+ *   - first HTTP prompt   → sandbox-proxy/routes/preview.ts (REST + legacy ACP),
+ *                           projects/routes/acp.ts (platform ACP bridge),
+ *                           projects/session-lifecycle/engine.ts (server-side
+ *                           delivery, transport-independent)
+ *
+ * These tests fail the build when a new create path, a new prompt transport, or
+ * a second `metadata.name` writer appears, which is exactly how the invariant
+ * regressed before.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = join(import.meta.dir, '..');
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === 'node_modules') continue;
+      out.push(...tsFiles(full));
+    } else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Non-test source files, repo-relative to apps/api/src. */
+function sourceFiles(): string[] {
+  return tsFiles(SRC)
+    .map((file) => file.slice(SRC.length + 1))
+    .filter((rel) => !rel.startsWith('__tests__/') && !rel.includes('.test.'));
+}
+
+function offenders(pattern: RegExp, allow: readonly string[]): string[] {
+  return sourceFiles().filter(
+    (rel) => !allow.includes(rel) && pattern.test(readFileSync(join(SRC, rel), 'utf8')),
+  );
+}
+
+describe('session-title invariant', () => {
+  test('A — project_sessions is INSERTed only by the sanctioned create paths', () => {
+    // A fourth INSERT is a new create path: it must run through
+    // createProjectSession (which titles) or justify itself here.
+    expect(
+      offenders(/\.insert\(\s*projectSessions\b/, [
+        'projects/lib/sessions.ts',
+        'projects/suna-migration/suna-migration-phases.ts',
+      ]),
+    ).toEqual([]);
+  });
+
+  test('B — the title generator has exactly four entry points', () => {
+    // Adding a prompt transport and titling it its own way is the failure this
+    // catches; the hook set is documented here, in one enforced place.
+    expect(
+      offenders(/from '[^']*session-title-generate'/, [
+        'projects/lib/sessions.ts',
+        'projects/session-lifecycle/engine.ts',
+        'projects/routes/acp.ts',
+        'sandbox-proxy/routes/preview.ts',
+      ]),
+    ).toEqual([]);
+  });
+
+  test('C — metadata.name has a single writer', () => {
+    const writesSessions = /\.(insert|update)\(\s*projectSessions\b/;
+    const writesName = /(?:projectSessionMetadataMerge\(\s*\{|metadata\s*:\s*\{)[^}]*\bname\s*:/s;
+    const allow = [
+      // THE writer.
+      'projects/session-title-generate.ts',
+      // body.name — the documented "I already know the title" escape hatch.
+      'projects/lib/sessions.ts',
+      // carries the legacy Suna thread title onto the migrated row.
+      'projects/suna-migration/suna-migration-phases.ts',
+    ];
+    const hits = sourceFiles().filter((rel) => {
+      if (allow.includes(rel)) return false;
+      const src = readFileSync(join(SRC, rel), 'utf8');
+      return writesSessions.test(src) && writesName.test(src);
+    });
+    expect(hits).toEqual([]);
+  });
+
+  test('D — every create-with-prompt producer is accounted for', () => {
+    // A new producer here means a session whose only prompt is baked into the
+    // sandbox: confirm Hook 1 titles it, and pass `body.title_source` if the
+    // prompt is a rendered envelope rather than the user's words, then add the
+    // file to this list.
+    expect(
+      offenders(/\binitial_prompt\s*:/, [
+        'projects/lib/triggers.ts',
+        'channels/slack/session.ts',
+        'channels/teams/session.ts',
+        'channels/telegram-webhook.ts',
+        'projects/routes/r2.ts',
+        'projects/routes/r10.ts',
+        'projects/lib/sessions.ts',
+      ]),
+    ).toEqual([]);
+  });
+
+  test('F — the internal gateway key is deleted, and no route can reach that delete', () => {
+    // The key title generation mints is deleted, not soft-revoked, so the key
+    // list needs no exclusion — an exclusion keyed on the user-settable `name`
+    // let any member mint a valid, billable key nobody could see or revoke.
+    const keys = readFileSync(join(SRC, 'llm-gateway/gateway-keys.ts'), 'utf8');
+    const list = keys.slice(keys.indexOf('export async function listGatewayKeys'));
+    expect(list.slice(0, list.indexOf('\n}')).includes('INTERNAL_SESSION_TITLE_KEY_NAME')).toBe(
+      false,
+    );
+    expect(
+      offenders(/\bdeleteGatewayKey\b/, [
+        'llm-gateway/gateway-keys.ts',
+        'projects/session-title-generate.ts',
+      ]),
+    ).toEqual([]);
+  });
+
+  test('E — the warm create that bypasses executeCreateSession stays prompt-free', () => {
+    // r7's warm coordinator calls createProjectSession directly. It carries no
+    // prompt today, so Hook 1 no-ops there — but it must never quietly acquire
+    // one without the titling question being asked.
+    const src = readFileSync(join(SRC, 'projects/routes/r7.ts'), 'utf8');
+    const at = src.indexOf('create: async (metadata) => {');
+    expect(at).toBeGreaterThan(-1);
+    const open = src.indexOf('body: {', at);
+    const close = src.indexOf('},', open);
+    expect(open).toBeGreaterThan(-1);
+    expect(src.slice(open, close)).not.toContain('prompt');
+  });
+});

--- a/apps/api/src/__tests__/unit-session-title-origins.test.ts
+++ b/apps/api/src/__tests__/unit-session-title-origins.test.ts
@@ -52,7 +52,7 @@ describe('session-title origins — create-time title source', () => {
       'Triage the new Sentry issue and open a change request',
     );
 
-    const source = createBody('projects/lib/triggers.ts', 'source: `trigger:${source}`');
+    const source = createBody('projects/lib/triggers.ts', 'enforceAccountCap: false');
     expect(source).toContain('initial_prompt: renderedPrompt');
     expect(source).not.toContain('title_source');
   });

--- a/apps/api/src/__tests__/unit-session-title-origins.test.ts
+++ b/apps/api/src/__tests__/unit-session-title-origins.test.ts
@@ -1,0 +1,179 @@
+/**
+ * One case per session ORIGIN: whatever started the session, the create-time
+ * title source is the user's own words — never the scaffolded envelope a channel
+ * renders around them, and never a leaked workspace/channel/chat identifier
+ * (channel sessions are `visibility: 'project'`, so their title is team-visible).
+ *
+ * Each origin is pinned twice:
+ *   1. semantics — `titleSourceForCreate` over the body shape that origin builds;
+ *   2. wiring — the literal field in that origin's create body, read out of the
+ *      source, so renaming/dropping it fails here instead of silently reverting
+ *      a channel to titling from its rendered envelope.
+ * The renderers themselves stay private; asserting on the source keeps this
+ * honest without a process-global `mock.module`.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { titleSourceForCreate } from '../projects/session-title-generate';
+
+const SRC = join(import.meta.dir, '..');
+const read = (rel: string) => readFileSync(join(SRC, rel), 'utf8');
+
+/** The `body: { … }` literal a create call site builds, as source text. */
+function createBody(rel: string, marker: string): string {
+  const src = read(rel);
+  const at = src.indexOf(marker);
+  expect(at).toBeGreaterThan(-1);
+  const open = src.indexOf('body: {', at);
+  expect(open).toBeGreaterThan(-1);
+  let depth = 0;
+  for (let i = src.indexOf('{', open); i < src.length; i += 1) {
+    if (src[i] === '{') depth += 1;
+    else if (src[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return src.slice(open, i + 1);
+    }
+  }
+  throw new Error(`unterminated create body in ${rel}`);
+}
+
+describe('session-title origins — create-time title source', () => {
+  test('trigger (fresh fire): the rendered trigger template IS the title', () => {
+    // A trigger's prompt is its own per-fire template — the most specific title
+    // available — so it deliberately passes no title_source.
+    const body = {
+      agent_name: 'default',
+      initial_prompt: 'Triage the new Sentry issue and open a change request',
+      opencode_model: 'kortix/glm-5.2',
+    };
+    expect(titleSourceForCreate(body)).toBe(
+      'Triage the new Sentry issue and open a change request',
+    );
+
+    const source = createBody('projects/lib/triggers.ts', 'source: `trigger:${source}`');
+    expect(source).toContain('initial_prompt: renderedPrompt');
+    expect(source).not.toContain('title_source');
+  });
+
+  test('slack: the user message, not the rendered envelope', () => {
+    const body = {
+      agent_name: 'default',
+      initial_prompt: [
+        "You're answering a message on Slack as a teammate.",
+        'Workspace:  T0123',
+        'Channel:    C0456',
+        'Thread ts:  1700000000.0001',
+        'Message:',
+        'can you bump the node version in CI',
+      ].join('\n'),
+      title_source: 'can you bump the node version in CI',
+    };
+    const title = titleSourceForCreate(body);
+    expect(title).toBe('can you bump the node version in CI');
+    expect(title).not.toContain('Workspace:');
+    expect(title).not.toContain('Thread ts:');
+    expect(title).not.toContain('T0123');
+
+    const source = createBody('channels/slack/session.ts', 'slackSessionLifecycle.createSession(');
+    expect(source).toContain('title_source: event.text ?? null');
+  });
+
+  test('teams: the activity text, not the rendered envelope', () => {
+    const body = {
+      initial_prompt: [
+        "You're answering a message on Microsoft Teams as a teammate.",
+        'Tenant:        tenant-1',
+        'Conversation:  conv-1',
+        'Message:',
+        'summarize yesterday standup',
+      ].join('\n'),
+      title_source: 'summarize yesterday standup',
+    };
+    const title = titleSourceForCreate(body);
+    expect(title).toBe('summarize yesterday standup');
+    expect(title).not.toContain('Tenant:');
+    expect(title).not.toContain('Conversation:');
+
+    const source = createBody('channels/teams/session.ts', 'teamsSessionLifecycle.createSession(');
+    expect(source).toContain('title_source: activity.text ?? null');
+  });
+
+  test('telegram: message text, falling back to a photo caption', () => {
+    const text = {
+      initial_prompt: 'You received a message on Telegram.\nChat:        99 (private)\n…',
+      title_source: 'what changed in the deploy',
+    };
+    const title = titleSourceForCreate(text);
+    expect(title).toBe('what changed in the deploy');
+    expect(title).not.toContain('Chat:');
+    expect(title).not.toContain('telegram send --chat');
+
+    // photo update: no `text`, only `caption`
+    expect(
+      titleSourceForCreate({ initial_prompt: 'envelope…', title_source: 'the CI graph' }),
+    ).toBe('the CI graph');
+
+    const source = createBody(
+      'channels/telegram-webhook.ts',
+      'const result = await createSession({',
+    );
+    expect(source).toContain('title_source: message.text ?? message.caption ?? null');
+  });
+
+  test('email: titles from the SUBJECT at create — it has no initial_prompt at all', () => {
+    const body = {
+      agent_name: 'default',
+      connector_bindings: { email: { profile_id: 'prof-1' } },
+      title_source: 'Invoice discrepancy for March',
+    };
+    expect(body).not.toHaveProperty('initial_prompt');
+    expect(titleSourceForCreate(body)).toBe('Invoice discrepancy for March');
+
+    const source = createBody('channels/email/session.ts', 'emailSessionLifecycle.createSession(');
+    expect(source).not.toContain('initial_prompt');
+    expect(source).toContain('title_source: messageSubject(event) ?? messageSummary(event)');
+    // The full rendered envelope still reaches the agent via postCreate.
+    expect(read('channels/email/session.ts')).toContain("type: 'deliver_prompt'");
+  });
+
+  test('the clean source is PERSISTED, so a fallback hook cannot re-title from the envelope', () => {
+    // Hook 1 is not guaranteed: its gateway call can 429. Seconds later the
+    // queued initial ACP prompt drains through continueSession, whose only text
+    // IS the rendered envelope — and `needsTitle` is still true. Storing the
+    // clean source at create is what keeps that retry honest.
+    const create = read('projects/lib/sessions.ts');
+    expect(create).toContain('const explicitTitleSource = normalizeString(body.title_source');
+    expect(create).toContain('title_source: explicitTitleSource.slice(0, TITLE_SOURCE_MAX_CHARS)');
+    expect(read('projects/session-title-generate.ts')).toContain(
+      'storedTitleSource(row) ?? suppliedText',
+    );
+  });
+
+  test('ui (web new-session): no create-time prompt → the proxy hook owns the title', () => {
+    // apps/web never sets initial_prompt; it stashes the prompt client-side and
+    // sends it over the ACP/REST proxy once the session exists.
+    expect(titleSourceForCreate({ base_ref: 'main', agent_name: 'default' })).toBeNull();
+  });
+
+  test('sdk/api (POST /sessions with a prompt): that prompt is the title', () => {
+    expect(
+      titleSourceForCreate({ base_ref: 'main', initial_prompt: 'migrate the auth module' }),
+    ).toBe('migrate the auth module');
+  });
+
+  test('pre-named platform sessions keep their fixed labels', () => {
+    // body.name is the documented "I already know the title" escape hatch:
+    // sessions.ts writes it to metadata.name, so needsTitle() is false and
+    // generation never overwrites it.
+    for (const [rel, marker, name] of [
+      ['projects/routes/r2.ts', "source: 'system:sandbox-build-fix'", "name: 'Fix sandbox build'"],
+      ['projects/routes/r10.ts', 'const result = await createSession({', 'name: `Add ${'],
+    ] as const) {
+      const source = createBody(rel, marker);
+      expect(source).toContain(name);
+      expect(source).not.toContain('title_source');
+    }
+  });
+});

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -196,6 +196,9 @@ async function createThreadSession(
       connector_bindings: {
         email: { profile_id: emailProfileId },
       },
+      // Email delivers its prompt via postCreate, so create is the only moment
+      // this session has any user text — title from the subject.
+      title_source: messageSubject(event) ?? messageSummary(event),
     },
     enforceAccountCap: false,
     mayManageSystemConnectorProfiles: true,

--- a/apps/api/src/channels/slack/session.ts
+++ b/apps/api/src/channels/slack/session.ts
@@ -173,6 +173,10 @@ export async function createOrJoinThreadSession(input: {
       agent_name: launchAgent,
       ...(selection?.opencodeModel ? { opencode_model: selection.opencodeModel } : {}),
       initial_prompt: renderAgentPrompt(envelope, event, revived),
+      // Title from the user's actual words, not the scaffolded envelope — the
+      // rendered prompt carries team/channel ids and turn instructions, and the
+      // title is project-visible.
+      title_source: event.text ?? null,
     },
     enforceAccountCap: false,
     queuePolicy: 'on_backpressure',

--- a/apps/api/src/channels/teams/session.ts
+++ b/apps/api/src/channels/teams/session.ts
@@ -150,6 +150,8 @@ export async function createOrJoinTeamsConversationSession(input: {
       agent_name: selection?.agentName || 'default',
       ...(selection?.opencodeModel ? { opencode_model: selection.opencodeModel } : {}),
       initial_prompt: renderAgentPrompt(activity),
+      // Title from the user's actual words, not the scaffolded envelope.
+      title_source: activity.text ?? null,
     },
     enforceAccountCap: false,
     queuePolicy: 'on_backpressure',

--- a/apps/api/src/channels/telegram-webhook.ts
+++ b/apps/api/src/channels/telegram-webhook.ts
@@ -130,6 +130,8 @@ async function spawnAgentTurn(
       base_ref: project.defaultBranch,
       agent_name: 'default',
       initial_prompt: initialPrompt,
+      // Title from the user's actual words, not the scaffolded envelope.
+      title_source: message.text ?? message.caption ?? null,
     },
     enforceAccountCap: false,
     queuePolicy: 'on_backpressure',

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -143,10 +143,12 @@ const envSchema = z.object({
   // Global background-worker switch. API-only and migration-shadow deployments
   // keep request handling active while disabling every recurring write loop.
   KORTIX_WORKERS_ENABLED: optBoolTrue,
-  // Kortix-owned session titles: on a session's first prompt, generate the
-  // title ourselves via the internal LLM gateway (using the session's own
-  // model) instead of relying on the harness summarizer. On by default; the
-  // kill-switch falls the whole path back to the OpenCode title sync.
+  // Kortix-owned session titles: the moment a session's first prompt text is
+  // known server-side (at create when it carries one, else on the first HTTP
+  // prompt), generate the title ourselves via the internal LLM gateway instead
+  // of relying on the harness summarizer. On by default; the kill-switch
+  // disables title generation entirely — nothing else writes `metadata.name`,
+  // so sessions then stay untitled and clients fall back to their display chain.
   SESSION_TITLE_GENERATION_ENABLED: optBoolTrue,
   // Per-project model enablement: when on, the gateway rejects a model a project
   // has disabled and the picker hides it. On by default (empty disabled-set =

--- a/apps/api/src/llm-gateway/gateway-keys.test.ts
+++ b/apps/api/src/llm-gateway/gateway-keys.test.ts
@@ -3,7 +3,13 @@ import { accounts, gatewayApiKeys, projects } from '@kortix/db';
 import { eq } from 'drizzle-orm';
 import { hashSecretKey } from '../shared/crypto';
 import { db } from '../shared/db';
-import { validateGatewayKey } from './gateway-keys';
+import {
+  INTERNAL_SESSION_TITLE_KEY_NAME,
+  createGatewayKey,
+  deleteGatewayKey,
+  listGatewayKeys,
+  validateGatewayKey,
+} from './gateway-keys';
 
 const ACCOUNT = crypto.randomUUID();
 const PROJECT = crypto.randomUUID();
@@ -88,6 +94,37 @@ describe('validateGatewayKey', () => {
 
   test('rejects an unknown secret', async () => {
     expect(await validateGatewayKey(`kortix_gw_${crypto.randomUUID()}`)).toBeNull();
+  });
+
+  test('the internal title key is DELETED, never hidden from the key list', async () => {
+    // Excluding it from listGatewayKeys by its `name` — a value any caller of
+    // POST /gateway/keys can set — would let a member mint a fully valid, fully
+    // billable key that no owner or auditor can see or revoke. Deleting it
+    // instead also keeps one row per prompt out of gateway_api_keys forever.
+    const created = await createGatewayKey({
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      name: INTERNAL_SESSION_TITLE_KEY_NAME,
+      createdBy: CREATOR,
+    });
+    expect((await listGatewayKeys(PROJECT)).map((k) => k.keyId)).toContain(created.key_id);
+
+    expect(await deleteGatewayKey(PROJECT, created.key_id)).toBe(true);
+    expect(await validateGatewayKey(created.secret_key)).toBeNull();
+    expect((await listGatewayKeys(PROJECT)).map((k) => k.keyId)).not.toContain(created.key_id);
+    expect(await deleteGatewayKey(PROJECT, created.key_id)).toBe(false);
+  });
+
+  test('deleteGatewayKey is scoped to the owning project', async () => {
+    const created = await createGatewayKey({
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      name: INTERNAL_SESSION_TITLE_KEY_NAME,
+      createdBy: CREATOR,
+    });
+    expect(await deleteGatewayKey(crypto.randomUUID(), created.key_id)).toBe(false);
+    expect(await validateGatewayKey(created.secret_key)).not.toBeNull();
+    expect(await deleteGatewayKey(PROJECT, created.key_id)).toBe(true);
   });
 
   test('stamps lastUsedAt on a successful validation (fire-and-forget)', async () => {

--- a/apps/api/src/llm-gateway/gateway-keys.ts
+++ b/apps/api/src/llm-gateway/gateway-keys.ts
@@ -3,6 +3,17 @@ import { gatewayApiKeys } from '@kortix/db';
 import { db } from '../shared/db';
 import { generateGatewayKeyPair, hashSecretKey } from '../shared/crypto';
 
+/**
+ * Name of the short-lived key session-title generation mints for each internal
+ * gateway call. It is Kortix's own plumbing rather than a customer key, so it is
+ * DELETED (see deleteGatewayKey) the moment the call finishes instead of being
+ * soft-revoked — one row per prompt, kept forever, would both bloat the table
+ * and clutter the project's key list. The name is only for forensics on the
+ * rare row a failed delete leaves behind; nothing keys off it, so a customer
+ * key that happens to share it is an ordinary, listed, revocable key.
+ */
+export const INTERNAL_SESSION_TITLE_KEY_NAME = 'internal-session-title';
+
 export interface CreatedGatewayKey {
   key_id: string;
   name: string;
@@ -48,6 +59,21 @@ export async function listGatewayKeys(projectId: string) {
     .from(gatewayApiKeys)
     .where(eq(gatewayApiKeys.projectId, projectId))
     .orderBy(desc(gatewayApiKeys.createdAt));
+}
+
+/**
+ * Hard-delete a key. Only for keys KORTIX itself minted for a single internal
+ * call — a customer key is soft-revoked (revokeGatewayKey) so the audit trail
+ * survives. Deliberately NOT reachable from any route: a name-based exclusion
+ * from `listGatewayKeys` would have let anyone who can create a key mint a
+ * valid, billable one that no owner or auditor could see or revoke.
+ */
+export async function deleteGatewayKey(projectId: string, keyId: string): Promise<boolean> {
+  const rows = await db
+    .delete(gatewayApiKeys)
+    .where(and(eq(gatewayApiKeys.keyId, keyId), eq(gatewayApiKeys.projectId, projectId)))
+    .returning({ keyId: gatewayApiKeys.keyId });
+  return rows.length > 0;
 }
 
 export async function revokeGatewayKey(projectId: string, keyId: string): Promise<boolean> {

--- a/apps/api/src/projects/lib/opencode-title.ts
+++ b/apps/api/src/projects/lib/opencode-title.ts
@@ -10,3 +10,11 @@
 export function isPlaceholderOpencodeTitle(title: string | null | undefined): boolean {
   return typeof title === 'string' && /^new session\b/i.test(title.trim());
 }
+
+/**
+ * POSIX-regex twin of `isPlaceholderOpencodeTitle`, for the compare-and-set
+ * predicate in the title UPDATE (`trim(metadata->>'name') ~* pattern`).
+ * `[^[:alnum:]_]` is the POSIX spelling of JavaScript's `\b` word boundary.
+ * Kept in lockstep by unit test.
+ */
+export const PLACEHOLDER_TITLE_SQL_PATTERN = '^new session([^[:alnum:]_]|$)';

--- a/apps/api/src/projects/lib/session-runtime-allocator.ts
+++ b/apps/api/src/projects/lib/session-runtime-allocator.ts
@@ -112,7 +112,11 @@ async function allocateSessionRuntimeAsync(input: AllocateSessionRuntimeInput): 
         .set({
           status: 'failed',
           error: message,
-          metadata: { ...input.sessionMetadata, provisioning_error: message },
+          // Merge, never re-write `input.sessionMetadata`: that snapshot was
+          // taken before allocation started, so writing it back drops anything
+          // committed since — the generated title, acp_session_id, remote_branch,
+          // the start timeline. The session is terminal here, so nothing retries.
+          metadata: projectSessionMetadataMerge({ provisioning_error: message }),
           updatedAt: new Date(),
         })
         .where(eq(projectSessions.sessionId, input.sessionId));

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -76,6 +76,11 @@ import {
   sessionConnectorBindingsRequirePrivateVisibility,
   validateSessionConnectorBindings,
 } from './session-connector-bindings';
+import {
+  TITLE_SOURCE_MAX_CHARS,
+  generateSessionTitleFromFirstPrompt,
+  titleSourceForCreate,
+} from '../session-title-generate';
 import { canOverride, resolveSessionOrigin } from './session-origin';
 import { resolveEndUserRef } from './end-user-ref';
 import { resolveSessionSandboxSlug } from './session-sandbox-metadata';
@@ -1238,11 +1243,21 @@ export async function createProjectSession(input: {
 
   const initialPrompt = normalizeString(body.initial_prompt ?? body.initialPrompt);
   const sessionName = normalizeString(body.name);
+  // An explicit `title_source` means the baked prompt is a rendered envelope
+  // (Slack/Teams/Telegram turn instructions + workspace/channel ids) and these
+  // are the user's actual words. Store it so a LATER fallback hook — which only
+  // ever sees the envelope — titles from the same clean text the create hook
+  // would have used, instead of leaking the scaffolding into a project-visible
+  // title when this create-time attempt fails.
+  const explicitTitleSource = normalizeString(body.title_source ?? body.titleSource);
   const requestMetadata = normalizeJsonObject(body.metadata);
   const metadata = {
     ...requestMetadata,
     ...(sessionName ? { name: sessionName } : {}),
     ...(initialPrompt ? { initial_prompt: initialPrompt } : {}),
+    ...(explicitTitleSource
+      ? { title_source: explicitTitleSource.slice(0, TITLE_SOURCE_MAX_CHARS) }
+      : {}),
     ...(opencodeModel ? { opencode_model: opencodeModel } : {}),
     ...(opencodeModelSource ? { opencode_model_source: opencodeModelSource } : {}),
     runtime_transport: acpRuntimeEnabled ? 'acp' : 'rest',
@@ -1337,6 +1352,20 @@ export async function createProjectSession(input: {
         body: { error: 'Session insert returned no row', retry: true },
       },
     };
+  }
+
+  // A prompt supplied at create is baked into KORTIX_INITIAL_PROMPT and runs
+  // inside the box — it never crosses the API again, so this is the only moment
+  // it can be titled. No modelHint: the row already carries `opencode_model`.
+  const titleSource = titleSourceForCreate(body);
+  if (titleSource) {
+    void generateSessionTitleFromFirstPrompt({
+      sessionId,
+      projectId,
+      accountId,
+      userId,
+      firstPromptText: titleSource,
+    });
   }
 
   // Fire-and-forget sandbox provisioning. The dashboard polls the sandbox
@@ -1473,7 +1502,10 @@ export async function createProjectSession(input: {
           .set({
             status: 'failed',
             error: message,
-            metadata: { ...metadata, provisioning_error: message },
+            // Merge, never re-write the create-time snapshot: by the time
+            // provisioning fails the row may already carry a generated title,
+            // acp_session_id, remote_branch or the start timeline.
+            metadata: projectSessionMetadataMerge({ provisioning_error: message }),
             updatedAt: new Date(),
           })
           .where(eq(projectSessions.sessionId, sessionId));

--- a/apps/api/src/projects/opencode-session-snapshot.ts
+++ b/apps/api/src/projects/opencode-session-snapshot.ts
@@ -4,6 +4,7 @@ import { projectSessions } from '@kortix/db';
 import { logger as appLogger } from '../lib/logger';
 import { db } from '../shared/db';
 import type { ProjectSessionRow } from './lib/serializers';
+import { projectSessionMetadataMerge } from './lib/session-metadata-merge';
 import {
   type OpencodeSessionLite,
   listSandboxOpencodeSessions,
@@ -142,10 +143,18 @@ export async function syncOpencodeSessionSnapshot(input: {
   const metadata = (input.row.metadata ?? {}) as Record<string, unknown>;
   if (sameSessions(metadata.opencode_sessions, scopedSessions)) return input.row;
 
+  // Merge in-SQL, never write back the whole object read above: this pass is
+  // scheduled off the SAME prompt that fires title generation, so a
+  // read-modify-write here drops the `metadata.name` the title CAS committed in
+  // between — permanently, for a one-shot automation session with no later
+  // prompt to re-trigger titling.
   const nextMetadata = { ...metadata, opencode_sessions: scopedSessions };
   const [updated] = await db
     .update(projectSessions)
-    .set({ metadata: nextMetadata, updatedAt: new Date() })
+    .set({
+      metadata: projectSessionMetadataMerge({ opencode_sessions: scopedSessions }),
+      updatedAt: new Date(),
+    })
     .where(
       and(
         eq(projectSessions.sessionId, input.row.sessionId),

--- a/apps/api/src/projects/routes/acp-proxy.test.ts
+++ b/apps/api/src/projects/routes/acp-proxy.test.ts
@@ -101,6 +101,17 @@ mock.module('../lib/acp-sse-proxy', () => ({
   createPersistedAcpSseProxy: (body: ReadableStream<Uint8Array>) => body,
 }));
 
+// Keep the REAL envelope parsing — that is the part this route decides — and
+// capture only the generator call.
+let titleCalls: Array<Record<string, unknown>> = [];
+const realTitleGenerate = await import('../session-title-generate');
+mock.module('../session-title-generate', () => ({
+  ...realTitleGenerate,
+  generateSessionTitleFromFirstPrompt: async (input: Record<string, unknown>) => {
+    titleCalls.push(input);
+  },
+}));
+
 const realFetch = globalThis.fetch;
 globalThis.fetch = (async (input, init) => {
   upstreamFetchCount += 1;
@@ -143,6 +154,7 @@ beforeEach(() => {
   upstreamStatuses = [];
   upstreamFetchCount = 0;
   envSyncStatuses = [];
+  titleCalls = [];
 });
 
 afterAll(() => {
@@ -203,6 +215,43 @@ test('session/prompt syncs env with provider headers and no user context', async
   expect(syncedProviderHeaders).toEqual({
     'x-daytona-preview-token': 'preview',
   });
+});
+
+test('session/prompt titles the session — but only once the box ACCEPTED the prompt', async () => {
+  const send = (id: string) =>
+    projectsApp.request(`/${PROJECT_ID}/sessions/${SESSION_ID}/acp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method: 'session/prompt',
+        params: {
+          sessionId: 'native-session',
+          prompt: [{ type: 'text', text: 'set up the MS Graph connector' }],
+          model: { providerID: 'kortix', modelID: 'glm-5.2' },
+        },
+      }),
+    });
+
+  const accepted = await send('rpc-title');
+  expect(accepted.status).toBe(200);
+  expect(titleCalls).toMatchObject([
+    {
+      sessionId: SESSION_ID,
+      projectId: PROJECT_ID,
+      firstPromptText: 'set up the MS Graph connector',
+      modelHint: 'glm-5.2',
+    },
+  ]);
+
+  // A prompt the agent never saw must not name the session — the user retypes
+  // it, and `needsTitle` would already be false by then.
+  titleCalls = [];
+  upstreamStatuses = [502, 502];
+  const rejected = await send('rpc-title-failed');
+  expect(rejected.status).toBe(502);
+  expect(titleCalls).toEqual([]);
 });
 
 test('session/prompt refreshes stale ingress credentials when env sync rejects authentication', async () => {

--- a/apps/api/src/projects/routes/acp.ts
+++ b/apps/api/src/projects/routes/acp.ts
@@ -14,9 +14,15 @@ import { appendAcpEnvelope, loadAcpTranscript } from '../lib/acp-transcript';
 import { projectsApp } from '../lib/app';
 import { syncSandboxEnvForPrompt } from '../lib/sandbox-env-sync';
 import { sandboxRuntimeEndpoint } from '../runtime-inspection';
+import {
+  type PromptInfo,
+  generateSessionTitleFromFirstPrompt,
+  promptInfoFromEnvelope,
+} from '../session-title-generate';
 
 type AcpSessionBinding = {
   projectId: string;
+  accountId: string;
   sessionId: string;
   acpServerId: string;
   runtimeHarness: 'claude' | 'codex' | 'opencode' | 'pi';
@@ -55,6 +61,7 @@ async function resolveAcpBinding(
   }
   return {
     projectId,
+    accountId: loaded.row.accountId,
     sessionId,
     acpServerId: metadata.acp_server_id,
     runtimeHarness: metadata.runtime_harness,
@@ -194,6 +201,13 @@ projectsApp.on(['GET', 'POST', 'DELETE'], '/:projectId/sessions/:sessionId/acp',
       return c.json({ error: 'request body must be JSON' }, 400);
     }
 
+    // The web UI's send path for every managed-ACP session. It does not go
+    // through the sandbox proxy, so this is where its first prompt becomes
+    // known server-side — but only ONCE the box has accepted it. Titling a
+    // prompt the agent never saw would name the session after a message the
+    // user is about to retype, permanently (the proxy hook holds the same
+    // contract).
+    let titlePrompt: PromptInfo | null = null;
     if (envelope.method === 'session/prompt') {
       try {
         target = await syncPromptEnvWithIngressRefresh(target);
@@ -206,6 +220,7 @@ projectsApp.on(['GET', 'POST', 'DELETE'], '/:projectId/sessions/:sessionId/acp',
           502,
         );
       }
+      titlePrompt = promptInfoFromEnvelope(envelope);
     }
 
     await appendAcpEnvelope({
@@ -226,6 +241,16 @@ projectsApp.on(['GET', 'POST', 'DELETE'], '/:projectId/sessions/:sessionId/acp',
         signal: c.req.raw.signal,
       };
     });
+    if (upstream.ok && titlePrompt?.text) {
+      void generateSessionTitleFromFirstPrompt({
+        sessionId: target.sessionId,
+        projectId: target.projectId,
+        accountId: target.accountId,
+        userId: target.userId,
+        firstPromptText: titlePrompt.text,
+        modelHint: titlePrompt.model ?? undefined,
+      });
+    }
     if (upstream.ok && upstream.status !== 202 && upstream.status !== 204) {
       const body = await upstream.text();
       try {

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -1668,11 +1668,18 @@ projectsApp.openapi(
   // PUT /sessions/{id}/model, which validates it against the account. Planting
   // it through metadata skipped that check entirely, so a retired or
   // account-forbidden model could be stored and booted by the next cold provision.
+  // name / title_source are owned by the title generator (the SINGLE writer of
+  // metadata.name — see projects/session-title-generate.ts). A client that plants
+  // a non-placeholder name pre-empts titling permanently, since `needsTitle` and
+  // the CAS both then refuse; renaming is `body.name` → metadata.custom_name,
+  // which is the supported, non-destructive override.
   const SERVER_MANAGED_METADATA_KEYS = [
     'deletedAt',
     'deletedBy',
     'opencode_model',
     'opencode_model_source',
+    'name',
+    'title_source',
   ];
   const metadataInput = body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
     ? (body.metadata as Record<string, unknown>)

--- a/apps/api/src/projects/session-lifecycle/__tests__/continue-session-title.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/continue-session-title.test.ts
@@ -1,0 +1,170 @@
+// continueSession() titles the session it is delivering into, for BOTH
+// transports.
+//
+// Server-side delivery used to piggyback on the sandbox proxy's REST hook, which
+// left every ACP project untitled: `deliverHeadlessAcpPrompt` builds its route
+// from `acp_server_id` but sends `params.sessionId = acp_session_id`, and the
+// proxy's `acpPromptSessionId` predicate requires the two to be equal — which
+// `acp-session-identity.ts` hard-rejects. Every email/Slack/Teams reply, trigger
+// reuse fire and CR request-changes on an ACP project therefore never got a
+// title. Hook 5 sits in continueSession itself, so it is transport-independent
+// and depends on no proxy predicate.
+//
+// Same mocking caveat as ./continue-session-deleted-guard.test.ts: engine.ts's
+// heavier dependencies are stubbed so its top-level imports resolve, and
+// `mock.module` is process-global, so this file must be run on its own.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { projectSessions, projects } from '@kortix/db';
+
+const SESSION_ID = 'sess-title-hook-1';
+const ACCOUNT_ID = 'acct-1';
+const PROJECT_ID = 'proj-1';
+
+let sessionRow: Record<string, unknown> | null = null;
+let titleCalls: Array<Record<string, unknown>> = [];
+let actor: string | null = 'automation-user-1';
+
+mock.module('../../../config', () => ({ config: {} }));
+
+mock.module('../../../shared/db', () => ({
+  db: {
+    select: (_proj: unknown) => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: async () => {
+            if (table === projectSessions) return sessionRow ? [sessionRow] : [];
+            if (table === projects) return [{ projectId: PROJECT_ID, accountId: ACCOUNT_ID }];
+            return [];
+          },
+        }),
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => {} }) }),
+  },
+}));
+
+mock.module('../../session-title-generate', () => ({
+  generateSessionTitleFromFirstPrompt: async (input: Record<string, unknown>) => {
+    titleCalls.push(input);
+  },
+}));
+
+mock.module('../../../sandbox-proxy/routes/preview', () => ({
+  forwardToSandbox: async () => {
+    throw new Error('forwardToSandbox: not expected in this test');
+  },
+}));
+mock.module('../../lib/sessions', () => ({
+  createProjectSession: async () => {
+    throw new Error('createProjectSession: not expected in this test');
+  },
+}));
+mock.module('../../routes/shared', () => ({
+  openSession: async () => {
+    throw new Error('openSession: reached — the title hook already fired');
+  },
+}));
+mock.module('../actor', () => ({
+  resolveProjectAutomationActor: async () => actor,
+}));
+mock.module('../backpressure', () => ({
+  sessionBackpressureState: async () => ({ shouldQueue: false, reason: null }),
+}));
+mock.module('../store', () => ({
+  claimCreateSessionCommand: async () => {
+    throw new Error('not expected in this test');
+  },
+  claimDueLifecycleCommands: async () => {
+    throw new Error('not expected in this test');
+  },
+  enqueueContinueSessionCommand: async () => {
+    throw new Error('not expected in this test');
+  },
+  markCommandFailed: async () => {
+    throw new Error('not expected in this test');
+  },
+  markCommandQueued: async () => {
+    throw new Error('not expected in this test');
+  },
+  markCommandSucceeded: async () => {
+    throw new Error('not expected in this test');
+  },
+  resultFromExistingCommand: () => {
+    throw new Error('not expected in this test');
+  },
+}));
+
+const { continueSession } = await import('../engine');
+
+beforeEach(() => {
+  sessionRow = null;
+  titleCalls = [];
+  actor = 'automation-user-1';
+});
+
+async function deliver(metadata: Record<string, unknown>, text: string) {
+  sessionRow = { accountId: ACCOUNT_ID, projectId: PROJECT_ID, status: 'running', metadata };
+  await expect(continueSession({ sessionId: SESSION_ID, text } as never)).rejects.toThrow(
+    /openSession/,
+  );
+}
+
+describe('continueSession — server-side delivery titles the session', () => {
+  test('an ACP session is titled (no dependency on the proxy prompt predicate)', async () => {
+    await deliver(
+      {
+        runtime_transport: 'acp',
+        runtime_harness: 'claude',
+        acp_server_id: SESSION_ID,
+        acp_session_id: 'acp-sess-9',
+      },
+      'reply to the customer about the invoice',
+    );
+
+    expect(titleCalls).toEqual([
+      {
+        sessionId: SESSION_ID,
+        projectId: PROJECT_ID,
+        accountId: ACCOUNT_ID,
+        userId: 'automation-user-1',
+        firstPromptText: 'reply to the customer about the invoice',
+      },
+    ]);
+  });
+
+  test('a REST session is titled identically', async () => {
+    await deliver({ runtime_transport: 'rest' }, 'bump the node version in CI');
+
+    expect(titleCalls).toHaveLength(1);
+    expect(titleCalls[0]?.firstPromptText).toBe('bump the node version in CI');
+    expect(titleCalls[0]?.userId).toBe('automation-user-1');
+  });
+
+  test('an explicit command.userId is preferred over the resolved automation actor', async () => {
+    sessionRow = {
+      accountId: ACCOUNT_ID,
+      projectId: PROJECT_ID,
+      status: 'running',
+      metadata: {},
+    };
+    await expect(
+      continueSession({ sessionId: SESSION_ID, text: 'hello', userId: 'user-42' } as never),
+    ).rejects.toThrow(/openSession/);
+    expect(titleCalls[0]?.userId).toBe('user-42');
+  });
+
+  test('no actor → returns pending and never titles', async () => {
+    actor = null;
+    sessionRow = {
+      accountId: ACCOUNT_ID,
+      projectId: PROJECT_ID,
+      status: 'running',
+      metadata: {},
+    };
+
+    expect(await continueSession({ sessionId: SESSION_ID, text: 'hello' } as never)).toBe(
+      'pending',
+    );
+    expect(titleCalls).toEqual([]);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -17,6 +17,7 @@ import { createProjectSession } from '../lib/sessions';
 import { persistAcpSessionIdentity } from '../lib/acp-session-identity';
 import { appendAcpEnvelope } from '../lib/acp-transcript';
 import { openSession } from '../routes/shared';
+import { generateSessionTitleFromFirstPrompt } from '../session-title-generate';
 import { resolveProjectAutomationActor } from './actor';
 import { awaitTerminalStage } from './await-stage';
 import { sessionBackpressureState } from './backpressure';
@@ -385,6 +386,18 @@ export async function continueSession(
     console.warn('[session-lifecycle] no actor for follow-up delivery', { sessionId });
     return 'pending';
   }
+
+  // Server-side delivery is the FIRST prompt for any session created without
+  // one (email, warm/UI sessions a trigger later reuses). Titling here rather
+  // than at the transport makes it identical for REST and ACP; already-titled
+  // sessions no-op.
+  void generateSessionTitleFromFirstPrompt({
+    sessionId,
+    projectId: session.projectId,
+    accountId: session.accountId,
+    userId,
+    firstPromptText: text,
+  });
 
   const [project] = await db
     .select()

--- a/apps/api/src/projects/session-title-generate.ts
+++ b/apps/api/src/projects/session-title-generate.ts
@@ -1,33 +1,54 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, or, sql } from 'drizzle-orm';
 
 import { projectSessions } from '@kortix/db';
 import type { createGateway } from '@kortix/llm-gateway';
 import { config } from '../config';
 import { logger as appLogger } from '../lib/logger';
-import { createGatewayKey, revokeGatewayKey } from '../llm-gateway/gateway-keys';
+import {
+  INTERNAL_SESSION_TITLE_KEY_NAME,
+  createGatewayKey,
+  deleteGatewayKey,
+} from '../llm-gateway/gateway-keys';
 import { toWireModel } from '../llm-gateway/resolution/effective';
 import { db } from '../shared/db';
-import { isPlaceholderOpencodeTitle } from './lib/opencode-title';
+import { PLACEHOLDER_TITLE_SQL_PATTERN, isPlaceholderOpencodeTitle } from './lib/opencode-title';
 import type { ProjectSessionRow } from './lib/serializers';
+import { projectSessionMetadataMerge } from './lib/session-metadata-merge';
 
 // Kortix-owned session titles — the single source of `metadata.name`.
 //
-// We generate the title ourselves the moment a session serves its FIRST user
-// prompt: one short call to the internal LLM gateway, using the model the user
-// actually picked for that turn (from the prompt body), over just the first
-// prompt text. Nothing else writes `metadata.name`.
+// The title is generated the moment the first user prompt's text is known
+// server-side, which is one of two moments:
+//   - create-with-prompt: `body.initial_prompt` (or `body.title_source`) is
+//     baked into the sandbox and runs in-guest, so create is its only chance;
+//   - first HTTP prompt: sessions created empty (the whole web UI, warm claim,
+//     CLI/SDK) carry their first prompt as a proxy/ACP request body.
+// One short call to the internal LLM gateway over just that text. Nothing else
+// writes `metadata.name`.
 //
 // Fire-and-forget by contract: idempotent, best-effort, and it never blocks or
-// fails the prompt request.
+// fails the request it hangs off.
 
 const MAX_TITLE_LENGTH = 64;
-const MAX_PROMPT_CHARS = 4000;
 const TITLE_MAX_TOKENS = 24;
+
+/** Upper bound on the prompt text a title is derived from — and therefore on
+ *  the `title_source` a create stores for its own later fallback hooks. */
+export const TITLE_SOURCE_MAX_CHARS = 4000;
 
 const TITLE_SYSTEM_PROMPT =
   "You write a concise, specific title for a chat session from the user's first message. " +
   'Reply with ONLY the title: 3 to 6 words, Title Case, no surrounding quotes, no trailing ' +
   'punctuation, and no preamble.';
+
+// Same-process mutual exclusion. Every double-fire the hook set can produce is
+// same-process by construction (the create hook racing the in-process ACP prompt
+// re-queue; `continueSession` racing the proxy hook it itself triggers), and
+// callers invoke us with `void`, so the body up to the first `await` runs
+// synchronously — one entry wins and the rest are dropped before they cost a
+// minted key or a billed completion. Cross-process duplicates are left to the
+// compare-and-set in `persistTitle`.
+const inFlight = new Set<string>();
 
 // The same pipeline the API mounts, run directly in-process so title generation
 // behaves identically whether the gateway is in-process or a standalone pod — we
@@ -95,26 +116,43 @@ export function extractPromptInfo(
   if (!(incomingHeaders.get('content-type') ?? '').toLowerCase().includes('application/json'))
     return none;
   try {
-    const parsed = JSON.parse(new TextDecoder().decode(body)) as {
-      parts?: unknown;
-      model?: unknown;
-      params?: { prompt?: unknown; model?: unknown };
-    };
-    const blocks = Array.isArray(parsed.parts)
-      ? parsed.parts
-      : Array.isArray(parsed.params?.prompt)
-        ? (parsed.params?.prompt as unknown[])
-        : [];
-    const text =
-      (blocks as Array<{ type?: unknown; text?: unknown }>)
-        .filter((p) => p?.type === 'text' && typeof p.text === 'string')
-        .map((p) => p.text as string)
-        .join('\n')
-        .trim() || null;
-    return { text, model: wireModelFrom(parsed.model ?? parsed.params?.model) };
+    return promptInfoFromEnvelope(JSON.parse(new TextDecoder().decode(body)));
   } catch {
     return none;
   }
+}
+
+/** Same extraction over an ALREADY-parsed envelope — the platform ACP bridge
+ *  (`/projects/:pid/sessions/:sid/acp`) parses the JSON-RPC envelope itself. */
+export function promptInfoFromEnvelope(parsed: unknown): PromptInfo {
+  const none: PromptInfo = { text: null, model: null };
+  if (!parsed || typeof parsed !== 'object') return none;
+  const envelope = parsed as {
+    parts?: unknown;
+    model?: unknown;
+    params?: { prompt?: unknown; model?: unknown };
+  };
+  const blocks = Array.isArray(envelope.parts)
+    ? envelope.parts
+    : Array.isArray(envelope.params?.prompt)
+      ? (envelope.params?.prompt as unknown[])
+      : [];
+  const text =
+    (blocks as Array<{ type?: unknown; text?: unknown }>)
+      .filter((p) => p?.type === 'text' && typeof p.text === 'string')
+      .map((p) => p.text as string)
+      .join('\n')
+      .trim() || null;
+  return { text, model: wireModelFrom(envelope.model ?? envelope.params?.model) };
+}
+
+/** The text a create-time title is derived from: an explicit clean
+ *  `title_source` when the caller renders an envelope around the real message
+ *  (Slack/Teams/Telegram/email), else the prompt itself. */
+export function titleSourceForCreate(body: Record<string, unknown>): string | null {
+  const pick = (value: unknown): string | null =>
+    typeof value === 'string' && value.trim() ? value.trim() : null;
+  return pick(body.title_source) ?? pick(body.initial_prompt) ?? pick(body.initialPrompt);
 }
 
 function contentToString(content: unknown): string | null {
@@ -142,7 +180,7 @@ async function generateViaGateway(
     max_tokens: TITLE_MAX_TOKENS,
     messages: [
       { role: 'system', content: TITLE_SYSTEM_PROMPT },
-      { role: 'user', content: promptText.slice(0, MAX_PROMPT_CHARS) },
+      { role: 'user', content: promptText.slice(0, TITLE_SOURCE_MAX_CHARS) },
     ],
   });
   const gateway = await internalGateway();
@@ -166,13 +204,83 @@ async function loadRow(sessionId: string, projectId: string): Promise<ProjectSes
   return (row as ProjectSessionRow | undefined) ?? null;
 }
 
+/** `metadata->>'<key>'` semantics, in TypeScript: a jsonb scalar reads as text,
+ *  a missing key as null. The TS predicate below and the CAS in `persistTitle`
+ *  MUST read the row the same way — a `name`/`custom_name` that is not a string
+ *  used to pass the TS gate (which ignored it) and then silently fail the
+ *  UPDATE, re-billing a doomed title on every prompt for the session's life. */
+function metadataText(metadata: Record<string, unknown>, key: string): string | null {
+  const value = metadata[key];
+  if (value === null || value === undefined) return null;
+  return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
 /** A session still needs a title unless the user named it or a real (non
  *  placeholder) title already exists — matches opencode-title-capture. */
 function needsTitle(row: ProjectSessionRow): boolean {
   const metadata = (row.metadata ?? {}) as Record<string, unknown>;
-  if (typeof metadata.custom_name === 'string' && metadata.custom_name.trim()) return false;
-  const name = typeof metadata.name === 'string' ? metadata.name : null;
+  if (metadataText(metadata, 'custom_name')?.trim()) return false;
+  const name = metadataText(metadata, 'name')?.trim();
   return !(name && !isPlaceholderOpencodeTitle(name));
+}
+
+/** The clean text a session was created to be titled from — set at create when
+ *  the baked `initial_prompt` is a rendered envelope (Slack/Teams/Telegram)
+ *  rather than the user's own words. It outranks whatever text a later fallback
+ *  hook happens to carry, so a create-hook failure can never leak turn
+ *  instructions or workspace/channel ids into a project-visible title. */
+function storedTitleSource(row: ProjectSessionRow): string | null {
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+  const ref = typeof metadata.title_source === 'string' ? metadata.title_source.trim() : '';
+  return ref || null;
+}
+
+/** The platform default, in gateway wire form. */
+function platformDefaultModel(): string | null {
+  const ref =
+    typeof config.LLM_GATEWAY_DEFAULT_MODEL === 'string'
+      ? config.LLM_GATEWAY_DEFAULT_MODEL.trim()
+      : '';
+  return ref ? toWireModel(ref) : null;
+}
+
+/**
+ * The model to title with when neither the turn nor the session names one —
+ * create-with-prompt and every server-side delivery arrive that way, and
+ * `metadata.opencode_model` is absent whenever session create resolved no
+ * default (free tier, a gateway-disabled project, an ACP claude/codex session).
+ *
+ * The account's own default chain first, then the platform default — but ONLY
+ * ever a model the gateway will actually serve for this account+project. The
+ * unconditional platform default is a trap: it is a MANAGED id, so on a free
+ * tier (or a deployment with no managed provider) the gateway refuses it and
+ * every prompt pays a mint → doomed completion → revoke, forever, leaving the
+ * session untitled anyway. Skipping cheaply is the honest outcome.
+ *
+ * The deliberate trade: an ACP claude/codex session runs on the user's own
+ * subscription, so titling it here spends one ~24-token managed completion on
+ * the account. That is the price of a Kortix-owned title; the alternative is
+ * that those sessions are never titled at all.
+ */
+async function resolveFallbackModel(input: GenerateSessionTitleInput): Promise<string | null> {
+  const [{ getCachedAccountTier }, { tierGrantsAllModels }, resolution] = await Promise.all([
+    import('../billing/services/entitlements'),
+    import('../billing/services/tiers'),
+    import('../llm-gateway/resolution/default-model'),
+  ]);
+  const scope = {
+    userId: input.userId,
+    accountId: input.accountId,
+    projectId: input.projectId,
+    freeModelsOnly: config.KORTIX_BILLING_INTERNAL_ENABLED
+      ? !tierGrantsAllModels(await getCachedAccountTier(input.accountId))
+      : false,
+  };
+  const resolved = await resolution.resolveEffectiveModel({ ...scope, explicit: null });
+  const candidate = resolved.model ?? platformDefaultModel();
+  if (!candidate) return null;
+  const model = toWireModel(candidate);
+  return (await resolution.isModelServableForAccount({ ...scope, model })) ? model : null;
 }
 
 /** The model the session was started with, in gateway wire form. */
@@ -182,16 +290,41 @@ function sessionModel(row: ProjectSessionRow): string | null {
   return ref ? toWireModel(ref) : null;
 }
 
-async function persistTitle(row: ProjectSessionRow, title: string): Promise<void> {
-  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+// PostgreSQL's bare `trim()` strips SPACES only; JavaScript's `String.trim()`
+// strips the whole ASCII whitespace set. Both sides of the predicate must trim
+// the same set, or a `"\nNew session"` reads as a placeholder to `needsTitle`
+// and as a real title to the CAS — a permanent, silent, billed no-op loop.
+const JS_WHITESPACE = sql.raw("E' \\t\\n\\r\\f\\v'");
+const trimmedName = sql`btrim(${projectSessions.metadata}->>'name', ${JS_WHITESPACE})`;
+const trimmedCustomName = sql`btrim(${projectSessions.metadata}->>'custom_name', ${JS_WHITESPACE})`;
+
+/**
+ * Compare-and-set the title.
+ *
+ * The `WHERE` carries the whole "still needs a title" predicate, so the UPDATE
+ * is first-writer-wins: a loser is a no-op instead of stomping a user rename or
+ * a better title that landed in between. The jsonb merge expression evaluates
+ * AFTER PostgreSQL takes the row lock, so a title written here can never clobber
+ * a concurrent `acp_session_id` / `remote_branch` / `session_start_timeline`
+ * write (or be clobbered by one) the way a read-modify-write of the whole
+ * metadata object would.
+ *
+ * Exported for the integration test that exercises the CAS against a real row.
+ */
+export async function persistTitle(row: ProjectSessionRow, title: string): Promise<void> {
   await db
     .update(projectSessions)
-    .set({ metadata: { ...metadata, name: title }, updatedAt: new Date() })
+    .set({ metadata: projectSessionMetadataMerge({ name: title }), updatedAt: new Date() })
     .where(
       and(
         eq(projectSessions.sessionId, row.sessionId),
         eq(projectSessions.projectId, row.projectId),
         eq(projectSessions.accountId, row.accountId),
+        sql`coalesce(nullif(${trimmedCustomName}, ''), '') = ''`,
+        or(
+          sql`nullif(${trimmedName}, '') IS NULL`,
+          sql`${trimmedName} ~* ${PLACEHOLDER_TITLE_SQL_PATTERN}`,
+        ),
       ),
     );
 }
@@ -219,6 +352,7 @@ export interface GenerateSessionTitleOptions {
   ) => Promise<{ secret: string; keyId: string } | null>;
   revokeKey?: (projectId: string, keyId: string) => Promise<void>;
   persist?: (row: ProjectSessionRow, title: string) => Promise<void>;
+  fallbackModel?: (input: GenerateSessionTitleInput) => Promise<string | null>;
 }
 
 /**
@@ -232,9 +366,11 @@ export async function generateSessionTitleFromFirstPrompt(
   options: GenerateSessionTitleOptions = {},
 ): Promise<void> {
   if (!config.SESSION_TITLE_GENERATION_ENABLED) return;
-  const promptText = input.firstPromptText.trim();
-  if (!input.sessionId || !input.projectId || !input.accountId || !input.userId || !promptText)
+  const suppliedText = input.firstPromptText.trim();
+  if (!input.sessionId || !input.projectId || !input.accountId || !input.userId || !suppliedText)
     return;
+  if (inFlight.has(input.sessionId)) return;
+  inFlight.add(input.sessionId);
 
   const load = options.loadRow ?? loadRow;
   const generate = options.generate ?? generateViaGateway;
@@ -245,24 +381,36 @@ export async function generateSessionTitleFromFirstPrompt(
       const key = await createGatewayKey({
         accountId,
         projectId,
-        name: 'internal-session-title',
+        name: INTERNAL_SESSION_TITLE_KEY_NAME,
         createdBy: userId,
       });
       return { secret: key.secret_key, keyId: key.key_id };
     });
+  // DELETE, not revoke: this key exists for exactly one call, and a soft-revoked
+  // row per prompt would grow `gateway_api_keys` without bound and drown the
+  // project's real keys in its list.
   const revoke =
-    options.revokeKey ?? ((projectId, keyId) => revokeGatewayKey(projectId, keyId).then(() => {}));
+    options.revokeKey ?? ((projectId, keyId) => deleteGatewayKey(projectId, keyId).then(() => {}));
+  const fallbackModel = options.fallbackModel ?? resolveFallbackModel;
 
   try {
     const row = await load(input.sessionId, input.projectId);
     if (!row || !needsTitle(row)) return;
 
+    // The create-time `title_source` wins over whatever text this hook was
+    // handed: a channel session's baked prompt is a rendered envelope, and only
+    // create sees the user's actual message.
+    const promptText = storedTitleSource(row) ?? suppliedText;
+
     // Prefer the model the user actually picked for this turn (from the prompt
     // body); the session's stored `opencode_model` is only the boot default and
-    // goes stale the moment the model is switched.
-    const model = input.modelHint?.trim() || sessionModel(row);
+    // goes stale the moment the model is switched. Both are known-servable —
+    // one is being served right now, the other was validated at create — so
+    // only the last resort has to prove itself.
+    const model =
+      input.modelHint?.trim() || sessionModel(row) || (await fallbackModel(input)) || null;
     if (!model) {
-      appLogger.warn('[title-generate] no model to title with', {
+      appLogger.warn('[title-generate] no servable model to title with', {
         sessionId: input.sessionId,
       });
       return;
@@ -278,7 +426,8 @@ export async function generateSessionTitleFromFirstPrompt(
     }
     if (!title) return;
 
-    // Re-check under the freshest row so a concurrent rename / capture wins.
+    // Cheap early-out under the freshest row; the UPDATE's compare-and-set is
+    // the actual guarantee that a concurrent rename wins.
     const fresh = await load(input.sessionId, input.projectId);
     if (!fresh || !needsTitle(fresh)) return;
     await persist(fresh, title);
@@ -291,5 +440,7 @@ export async function generateSessionTitleFromFirstPrompt(
       sessionId: input.sessionId,
       error: err instanceof Error ? err.message : String(err),
     });
+  } finally {
+    inFlight.delete(input.sessionId);
   }
 }

--- a/apps/api/src/projects/suna-migration/suna-migration-phases.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-phases.ts
@@ -208,6 +208,10 @@ export async function dbStep(ctx: SunaMigrationContext): Promise<void> {
         sandboxId: null, sandboxUrl: null, opencodeSessionId: s.opencodeSessionId,
         agentName: 'default', status: 'stopped', createdBy: ctx.accountId, visibility: 'project',
         metadata: {
+          // Carry the legacy thread's own title over; nothing ever re-titles a
+          // migrated session (it serves no first prompt), so without this every
+          // migrated thread displays as untitled forever.
+          ...(s.title ? { name: s.title } : {}),
           legacy_migration: {
             run_id: ctx.runId,
             // Reuse the legacy on-open ship: archive is keyed by projectId.

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -333,13 +333,14 @@ function acpPromptSessionId(
   if (!match) return null;
   try {
     const routeSessionId = decodeURIComponent(match[1]);
-    const envelope = JSON.parse(new TextDecoder().decode(body)) as {
-      method?: unknown;
-      params?: { sessionId?: unknown };
-    };
-    return envelope.method === 'session/prompt' && envelope.params?.sessionId === routeSessionId
-      ? routeSessionId
-      : null;
+    const envelope = JSON.parse(new TextDecoder().decode(body)) as { method?: unknown };
+    // Keyed on the ROUTE id — the ACP server binding, which for a managed ACP
+    // session is the project session itself. The envelope's `params.sessionId`
+    // is the HARNESS-issued session, which persistAcpSessionIdentity forbids
+    // from equalling the server id: requiring the two to match made this return
+    // null for every managed ACP prompt, silently disabling prompt dedupe, the
+    // retry budget, the snapshot sync and titling on that path.
+    return envelope.method === 'session/prompt' ? routeSessionId : null;
   } catch {
     return null;
   }

--- a/apps/api/src/shared/public-session-share-view.ts
+++ b/apps/api/src/shared/public-session-share-view.ts
@@ -26,6 +26,7 @@
 import { eq } from 'drizzle-orm';
 import { projectSessions } from '@kortix/db';
 import { db } from './db';
+import { isPlaceholderOpencodeTitle } from '../projects/lib/opencode-title';
 import { sandboxOpencodeEndpoint, listSandboxOpencodeSessions, resolveRootSessionId } from '../projects/opencode-mapping';
 import type { PublicShareRow } from './session-public-shares';
 
@@ -63,7 +64,10 @@ export async function getPublicSessionInfo(sessionId: string): Promise<PublicSes
 
   const metadata = (row.metadata ?? {}) as Record<string, unknown>;
   const customName = typeof metadata.custom_name === 'string' ? metadata.custom_name : null;
-  const autoName = typeof metadata.name === 'string' ? metadata.name : null;
+  // Same placeholder heal the authenticated serializer applies: never show an
+  // anonymous viewer a frozen "New session - …" as if it were a real title.
+  const rawAutoName = typeof metadata.name === 'string' ? metadata.name : null;
+  const autoName = isPlaceholderOpencodeTitle(rawAutoName) ? null : rawAutoName;
 
   return {
     ok: true,

--- a/tests/e2e/specs/17-acp-session-title-sync.spec.ts
+++ b/tests/e2e/specs/17-acp-session-title-sync.spec.ts
@@ -256,4 +256,51 @@ test.describe.serial('17 — ACP session title synchronization', () => {
       expect(persisted.find((item) => item.session_id === sessionId)?.name).toBe(renderedTitle);
     }
   });
+
+  // The two cases above only ever create EMPTY sessions, so they exercise the
+  // proxy hooks. A prompt supplied at create is baked into KORTIX_INITIAL_PROMPT
+  // and executed inside the sandbox — it never crosses the API as HTTP, which is
+  // exactly how every trigger/channel-created session used to stay untitled.
+  // This is the only end-to-end proof that gap is closed.
+  test('titles a session created WITH an initial_prompt, which never crosses the proxy', async () => {
+    for (const transport of ['acp', 'rest'] as const) {
+      await api(auth.access_token, 'PATCH', `/projects/${projectId}/experimental`, {
+        feature: 'acp_runtime',
+        enabled: transport === 'acp',
+      });
+      const session = await api<{ session_id: string }>(
+        auth.access_token,
+        'POST',
+        `/projects/${projectId}/sessions`,
+        {
+          opencode_model: 'kortix/claude-sonnet-4.6',
+          initial_prompt: 'Set up the MS Graph OAuth2 connector for the reporting pipeline.',
+        },
+        201,
+      );
+      const sessionId = session.session_id;
+      sessionIds.push(sessionId);
+
+      // No browser, no proxy prompt, no session start — the title must land
+      // purely from the create-time hook.
+      let title: string | null = null;
+      const deadline = Date.now() + 120_000;
+      while (Date.now() < deadline) {
+        const sessions = await api<ProjectSession[]>(
+          auth.access_token,
+          'GET',
+          `/projects/${projectId}/sessions`,
+        );
+        title = sessions.find((item) => item.session_id === sessionId)?.name ?? null;
+        if (title) break;
+        await new Promise((resolve) => setTimeout(resolve, 2_000));
+      }
+
+      expect(
+        title,
+        `no title generated for the ${transport} create-with-prompt session`,
+      ).toBeTruthy();
+      expect(title).not.toMatch(/^new session\b/i);
+    }
+  });
 });


### PR DESCRIPTION
Session titles were Kortix-owned but only *reachable* from one transport, so an entire class of sessions was never titled. This converges every session-start path on the single server-side writer and adds a guard test so a new path cannot silently bypass it again.

## The invariant

> `project_sessions.metadata.name` is written exactly once per session, by `generateSessionTitleFromFirstPrompt()`, from the first user prompt, at the first moment that prompt's text is known server-side — whatever transport later carries it.

`metadata.custom_name` (user rename) still wins the display chain, a caller-supplied `body.name` at create still suppresses generation, and `SESSION_TITLE_GENERATION_ENABLED` is still the master kill switch.

## What was broken

Creation already converged on `session-lifecycle/engine.ts :: createSession()`. Prompt *delivery* did not. The single title hook lived in `forwardToSandbox`, so a prompt was titled only if it crossed the API as HTTP:

1. **Create-with-prompt was never titled.** An `initial_prompt` is baked into the sandbox as `KORTIX_INITIAL_PROMPT` (`session-runtime-env.ts`) and executed *inside* the box. It never re-crosses the API. This is every trigger-created session, plus Slack / Teams / Telegram / email session starts.
2. **The platform ACP bridge had no hook at all.** `POST /projects/:pid/sessions/:sid/acp` (`routes/acp.ts`) is the web UI's send path for every modern ACP session and does not use `forwardToSandbox`.
3. **Server-side ACP delivery was silently dead.** `deliverHeadlessAcpPrompt` sends `params.sessionId = acpSessionId`, but `acpPromptSessionId` required it to equal the route id (`acp_server_id`) — and `acp-session-identity.ts` hard-rejects those two being equal, so they can never match. On an ACP project this meant every Slack/email/Teams reply, every trigger `session_mode=reuse` fire and every voice ask was untitled. The same dead predicate also disabled prompt dedupe and the retry budget on that path.

The deleted `opencode-title-capture.ts` (#5739) used to cover these by polling the in-sandbox summarizer, so this was a regression for automation-started sessions.

## The change

Five hooks, one per moment the prompt text first becomes knowable:

| Hook | Location | Covers |
| --- | --- | --- |
| 1 (new) | `projects/lib/sessions.ts` create | `initial_prompt` baked to env — the only chance |
| 2 | `sandbox-proxy/routes/preview.ts` | REST `prompt_async` / `message` |
| 3 (fixed) | `sandbox-proxy/routes/preview.ts` | legacy ACP bridge — gate now keys on the route id alone |
| 4 (new) | `projects/routes/acp.ts` | platform ACP bridge, after upstream returns ok |
| 5 (new) | `session-lifecycle/engine.ts` `continueSession` | server-side delivery, transport-independent |

Writer hardening, all required by the create-time move:

- `persistTitle` is now an atomic jsonb merge + compare-and-set instead of writing back a whole row snapshot read seconds earlier. Create time sits exactly inside the window where `acp-session-identity`, `remote_branch` and `session_start_timeline` commit.
- An in-flight `Set` dedupes same-process double-fires (create hook vs. ACP re-queue drain; `continueSession` vs. the REST hook it triggers).
- The model fallback resolves the account's own default chain and returns a model **only if the gateway will actually serve it for that account** — otherwise it skips before minting a key.
- `title_source` is persisted, so a fallback hook re-titles from the user's words rather than the raw channel envelope.

Fixes surfaced by the adversarial verify pass:

- **Free-tier sessions would never have been titled.** Create does not store `opencode_model` for those accounts, so the fallback reached for the managed default and the gateway refused it — a doomed mint -> billed call -> revoke loop on the most common account class. Now gated by `isModelServableForAccount()`. Free tier *with* BYOK and self-host *with* BYOK now get titled, which they did not before.
- **Gateway key listing hole.** An earlier cut hid the internal title key from `listGatewayKeys` by matching a user-settable `name` column, which would have let any member mint a fully valid, fully billable key that never appears in the project's key list. Replaced with a hard `deleteGatewayKey` after the single call, which also fixes unbounded `gateway_api_keys` growth.
- **`metadata.name` was client-writable** via `PATCH /projects/:id/sessions/:id` (missing from `SERVER_MANAGED_METADATA_KEYS`), letting a caller permanently block titling.
- **Two stale-snapshot writers** (`opencode-session-snapshot.ts`, `session-runtime-allocator.ts`) could erase a just-written title; both now use `projectSessionMetadataMerge`.

## Enforcement

`unit-session-title-invariant.test.ts` scans the source tree and fails the build when a new `INSERT` into `projectSessions`, a new `metadata.name` writer, or a new prompt transport appears outside the sanctioned set. This is exactly how the invariant regressed before.

## Tests

New: `unit-session-title-invariant`, `unit-session-title-origins` (one case per origin: trigger, slack, teams, telegram, email, ui, sdk/api), `integration-session-title-claim` (CAS behaviour against a real DB), `continue-session-title`. Extended: `unit-session-title-generate`, `e2e-preview-proxy`, `e2e-project-session-contract`, `acp-proxy`, `gateway-keys`, `unit-opencode-session-snapshot`, `unit-api-contract-serializers`, `tests/e2e/specs/17-acp-session-title-sync`.

Local run on this branch: `tsc --noEmit` clean; title/ACP/gateway-key suites green.

Note: `e2e-project-session-contract` has 26 failures locally that reproduce identically on `origin/main` at the same commit — pre-existing and unrelated to this change.
