### PR TITLE
fix(web): stop the project sidebar flickering on cold load

### DIFF
--- a/apps/web/src/features/workspace/project-layout/project-shell.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-shell.tsx
@@ -8,13 +8,12 @@ import { PersonalOnboardingWelcome } from '@/components/projects/personal-onboar
 import { ProjectOnboardingWizard } from '@/components/projects/project-onboarding-wizard';
 import { Button } from '@/components/ui/button';
 import Hint from '@/components/ui/hint';
-import { SidebarEdgePeek, SidebarTrigger, useSidebar } from '@/components/ui/sidebar';
+import { SidebarEdgePeek, useSidebar } from '@/components/ui/sidebar';
 import { AppProviders } from '@/features/layout/app-providers';
 import { useAuth } from '@/features/providers/auth-provider';
 import { CustomizPanel } from '@/features/workspace/customize/customize-panel';
 import { parseSidebarStateCookie } from '@/features/workspace/project-layout/sidebar-cookie';
 import { ProjectSidebar } from '@/features/workspace/project-sidebar/project-sidebar';
-import { useGatewayCatalogSync } from '@kortix/sdk/react';
 import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { useProjectShellShortcuts } from '@/hooks/projects/use-project-shell-shortcuts';
 import { parseCustomizeSection } from '@/lib/customize-sections';
@@ -30,6 +29,7 @@ import { BillingAccountProvider } from '@/stores/billing-account-context';
 import { useCustomizeStore } from '@/stores/customize-store';
 import { useProjectSessionTabsStore } from '@/stores/project-session-tabs-store';
 import { getProjectDetail } from '@kortix/sdk';
+import { useGatewayCatalogSync } from '@kortix/sdk/react';
 import { PanelLeft } from 'lucide-react';
 
 const CommandPalette = lazy(() =>
@@ -165,7 +165,14 @@ export function ProjectShell({ projectId, initialSidebarOpen, children }: Projec
   }
 
   return (
-    <BillingAccountProvider accountId={projectDetail?.project?.account_id ?? null}>
+    // `resolved` is what keeps the sidebar's billing items from flickering:
+    // until project-detail lands we don't know this project's account, and a
+    // provisional fetch against the primary account would paint them once,
+    // then unpaint them when the real account id swaps the cache slot.
+    <BillingAccountProvider
+      accountId={projectDetail?.project?.account_id ?? null}
+      resolved={!!projectDetail}
+    >
       <AppProviders
         showSidebar
         showRightSidebar={false}
@@ -219,7 +226,7 @@ const ProjectSheelLayout = ({ children }: { children: React.ReactNode }) => {
           headers come and go (sessions render theirs only once booted) — so
           the opener lives here, always mounted, on every project view. The
           session header indents its leading buttons past it below md. */}
-       
+
       {desktopShell && !isExpanded && (
         <Hint label={peek ? 'Pin sidebar' : 'Open sidebar'} side="bottom">
           <Button

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar-footer-order.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar-footer-order.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * The sidebar's footer group is bottom-anchored (`mt-auto`), so it grows
+ * upward: every item that mounts late shoves everything ABOVE it up the page.
+ * Billing items mount late by nature — they wait on account state — so they
+ * have to sit above the permanent nav, otherwise Files / Customize / Connect
+ * visibly jump the moment the wallet resolves.
+ *
+ * Asserted against the source because the alternative is mounting the whole
+ * sidebar (sidebar + auth + query + i18n providers) to observe pure ordering.
+ */
+const source = readFileSync(join(import.meta.dir, 'project-sidebar.tsx'), 'utf8');
+
+function orderOf(component: string): number {
+  const at = source.indexOf(`<${component}`);
+  expect(at).toBeGreaterThan(-1);
+  return at;
+}
+
+describe('project sidebar footer ordering', () => {
+  test('late-arriving billing items render above the permanent nav', () => {
+    expect(orderOf('SidebarUpgradeButton')).toBeLessThan(orderOf('ProjectFilesNavItem'));
+    expect(orderOf('SidebarBalanceWarning')).toBeLessThan(orderOf('ProjectFilesNavItem'));
+  });
+
+  test('the permanent nav keeps its own order', () => {
+    expect(orderOf('ProjectFilesNavItem')).toBeLessThan(orderOf('ProjectCustomizeNavItem'));
+    expect(orderOf('ProjectCustomizeNavItem')).toBeLessThan(
+      orderOf('ProjectChatGptConnectNavItem'),
+    );
+  });
+});

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -267,14 +267,20 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
                   is impossible to miss — one click starts the migration session
                   end-to-end. Self-hides once the project is on v2. */}
               <ProjectManifestUpgradeAlert projectId={projectId} />
+              {/* Billing sits ABOVE the permanent nav on purpose. This group is
+                  bottom-anchored (mt-auto), so it grows upward as items appear:
+                  anything below a late-arriving item gets shoved up the moment
+                  billing state lands. Keeping the async items on top means
+                  Files/Customize/Connect never move — only the session list
+                  above them gives up the space. */}
+              <SidebarBalanceWarning accountId={accountId} />
+              <SidebarUpgradeButton accountId={accountId} />
               {/* Files used to live on the collapsed icon rail; with the rail
                   gone (offcanvas + hover flyout) it needs a docked entry. Above
                   Customize — files aren't gated behind customize access. */}
               <ProjectFilesNavItem />
               <ProjectCustomizeNavItem />
               <ProjectChatGptConnectNavItem projectId={projectId} />
-              <SidebarBalanceWarning accountId={accountId} />
-              <SidebarUpgradeButton accountId={accountId} />
             </SidebarMenu>
           </SidebarGroup>
         </div>

--- a/apps/web/src/features/workspace/project-sidebar/project-switcher-label.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-switcher-label.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveSwitcherLabel } from './project-switcher-label';
+
+describe('resolveSwitcherLabel', () => {
+  test('names the project once the name is known', () => {
+    expect(
+      resolveSwitcherLabel({ activeProjectId: 'p1', activeProjectName: 'My First Project' }),
+    ).toEqual({ label: 'My First Project', pending: false });
+  });
+
+  test('never says "Projects" while a project route is still resolving', () => {
+    const state = resolveSwitcherLabel({ activeProjectId: 'p1', activeProjectName: null });
+    expect(state.pending).toBe(true);
+    expect(state.label).toBeNull();
+  });
+
+  test('off a project route it is genuinely the projects entry', () => {
+    expect(resolveSwitcherLabel({ activeProjectId: undefined })).toEqual({
+      label: 'Projects',
+      pending: false,
+    });
+  });
+
+  test('a blank name counts as unresolved, not as a name', () => {
+    expect(resolveSwitcherLabel({ activeProjectId: 'p1', activeProjectName: '   ' })).toEqual({
+      label: null,
+      pending: true,
+    });
+  });
+
+  test('cold load goes placeholder → name, never placeholder → wrong name → name', () => {
+    const boot = resolveSwitcherLabel({ activeProjectId: 'p1', activeProjectName: null });
+    const settled = resolveSwitcherLabel({ activeProjectId: 'p1', activeProjectName: 'Acme' });
+    expect(boot.label).toBeNull();
+    expect(settled.label).toBe('Acme');
+  });
+});

--- a/apps/web/src/features/workspace/project-sidebar/project-switcher-label.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-switcher-label.ts
@@ -1,0 +1,27 @@
+/**
+ * What the project switcher's trigger should say.
+ *
+ * The switcher used to fall back to the generic "Projects" label whenever it
+ * couldn't name the active project. On a project route that fallback is just
+ * wrong: the project list resolves a beat after the shell paints, so every
+ * cold load of /projects/<id> showed "Projects" before settling on the real
+ * name. A route that names a project is never the projects list — it's a
+ * project we can't name *yet*, which calls for a placeholder, not a label.
+ */
+export interface SwitcherLabel {
+  /** Trigger text, or null while the project's name is still unknown. */
+  label: string | null;
+  /** Render a placeholder — we are on a project we cannot name yet. */
+  pending: boolean;
+}
+
+export function resolveSwitcherLabel(input: {
+  activeProjectId?: string | null;
+  activeProjectName?: string | null;
+}): SwitcherLabel {
+  const name = input.activeProjectName?.trim() || null;
+  if (name) return { label: name, pending: false };
+  // No project in the route — the switcher really is the "all projects" entry.
+  if (!input.activeProjectId) return { label: 'Projects', pending: false };
+  return { label: null, pending: true };
+}

--- a/apps/web/src/features/workspace/project-sidebar/project-switcher.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-switcher.tsx
@@ -33,10 +33,16 @@ import { Input } from '@/components/ui/input';
 import Loading from '@/components/ui/loading';
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { Skeleton } from '@/components/ui/skeleton';
-import { listAccounts, listProjectsForAccount, type KortixProject } from '@kortix/sdk';
+import { resolveSwitcherLabel } from '@/features/workspace/project-sidebar/project-switcher-label';
 import { cn } from '@/lib/utils';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
 import { useIsSwitchingProject, useProjectSwitchStore } from '@/stores/project-switch-store';
+import {
+  getProjectDetail,
+  listAccounts,
+  listProjectsForAccount,
+  type KortixProject,
+} from '@kortix/sdk';
 import { formatRelative } from '@kortix/shared';
 import { CheckCircleSolid, ChevronsUpDownSolid } from '@mynaui/icons-react';
 
@@ -93,6 +99,20 @@ export function ProjectSwitcher({
     [projectsQuery.data, activeProjectId],
   );
 
+  // The project list is the slow way to learn the open project's name — it
+  // waits on `accounts` first. This is the SAME cache entry the project shell
+  // already fetches on mount, so subscribing costs no extra request and names
+  // the project as early as anything on the page can.
+  const projectDetailQuery = useQuery({
+    queryKey: ['project-detail', activeProjectId],
+    queryFn: () => getProjectDetail(activeProjectId as string),
+    enabled: !!activeProjectId,
+  });
+  const { label: switcherLabel, pending: labelPending } = resolveSwitcherLabel({
+    activeProjectId,
+    activeProjectName: activeProject?.name ?? projectDetailQuery.data?.project?.name ?? null,
+  });
+
   useEffect(() => {
     if (!activeProjectId) return;
     const target = useProjectSwitchStore.getState().targetProjectId;
@@ -124,18 +144,26 @@ export function ProjectSwitcher({
     router.push(`/projects/${project.project_id}`);
   };
 
-  const label = activeProject?.name ?? 'Projects';
-  const tile = activeProject ? (
-    <EntityAvatar label={activeProject.name} size={variant === 'header' ? 'xs' : 'sm'} />
+  const avatarSize = variant === 'header' ? 'xs' : 'sm';
+  const tile = labelPending ? (
+    // Placeholder, not a guess: the initial tile is derived from the name, so
+    // showing one before we have the name would swap letters mid-load.
+    <Skeleton className={cn('shrink-0 rounded-sm', variant === 'header' ? 'size-5' : 'size-6')} />
+  ) : activeProjectId && switcherLabel ? (
+    <EntityAvatar label={switcherLabel} size={avatarSize} />
   ) : (
-    <EntityAvatar icon={FolderGit2} size={variant === 'header' ? 'xs' : 'sm'} />
+    <EntityAvatar icon={FolderGit2} size={avatarSize} />
   );
 
   const trigger =
     variant === 'header' ? (
       <Button type="button" className={cn(className)}>
         {tile}
-        <span className="max-w-40 truncate text-sm font-medium">{label}</span>
+        {labelPending ? (
+          <Skeleton className="h-3.5 w-24 rounded-sm" />
+        ) : (
+          <span className="max-w-40 truncate text-sm font-medium">{switcherLabel}</span>
+        )}
         <ChevronsUpDownSolid className="text-muted-foreground size-3" />
       </Button>
     ) : (
@@ -146,9 +174,13 @@ export function ProjectSwitcher({
         )}
       >
         {tile}
-        <span className="text-foreground min-w-0 flex-1 truncate text-left text-sm font-semibold tracking-tight group-data-[collapsible=icon]:hidden">
-          {label}
-        </span>
+        {labelPending ? (
+          <Skeleton className="h-3.5 w-28 rounded-sm group-data-[collapsible=icon]:hidden" />
+        ) : (
+          <span className="text-foreground min-w-0 flex-1 truncate text-left text-sm font-semibold tracking-tight group-data-[collapsible=icon]:hidden">
+            {switcherLabel}
+          </span>
+        )}
         <ChevronsUpDown className="text-muted-foreground/40 ml-auto size-4 shrink-0 group-data-[collapsible=icon]:hidden" />
       </SidebarMenuButton>
     );

--- a/apps/web/src/hooks/billing/account-state-gating.test.ts
+++ b/apps/web/src/hooks/billing/account-state-gating.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+
+import { shouldQueryAccountState } from './account-state-gating';
+
+describe('shouldQueryAccountState', () => {
+  test('runs immediately outside any provider (global surfaces = primary account)', () => {
+    expect(
+      shouldQueryAccountState({
+        enabled: true,
+        hasExplicitAccountId: false,
+        contextResolved: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('waits while the surface has not resolved which account it bills', () => {
+    expect(
+      shouldQueryAccountState({
+        enabled: true,
+        hasExplicitAccountId: false,
+        contextResolved: false,
+      }),
+    ).toBe(false);
+  });
+
+  test('an explicit accountId is answerable regardless of the provider', () => {
+    expect(
+      shouldQueryAccountState({
+        enabled: true,
+        hasExplicitAccountId: true,
+        contextResolved: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("the caller's own enabled:false still wins", () => {
+    expect(
+      shouldQueryAccountState({
+        enabled: false,
+        hasExplicitAccountId: true,
+        contextResolved: true,
+      }),
+    ).toBe(false);
+  });
+
+  test('the project-shell boot sequence never fetches twice', () => {
+    // Cold load: the shell mounts with no project-detail, so the sidebar's
+    // billing items must stay quiet rather than resolve against the primary
+    // account and then re-resolve against the project's — the two paints that
+    // made Upgrade Plan flicker in and out.
+    const beforeDetail = shouldQueryAccountState({
+      enabled: true,
+      hasExplicitAccountId: false,
+      contextResolved: false,
+    });
+    const afterDetail = shouldQueryAccountState({
+      enabled: true,
+      hasExplicitAccountId: false,
+      contextResolved: true,
+    });
+    expect([beforeDetail, afterDetail]).toEqual([false, true]);
+  });
+});

--- a/apps/web/src/hooks/billing/account-state-gating.ts
+++ b/apps/web/src/hooks/billing/account-state-gating.ts
@@ -1,0 +1,26 @@
+/**
+ * When may an account-state query run?
+ *
+ * Account state is cached per accountId, so a surface that learns its account
+ * late (the project shell, which reads it off `project-detail`) walks two
+ * different cache slots: first the provisional "primary account" slot, then
+ * the real one. Each slot starts empty, so every consumer that renders on
+ * presence of data — the sidebar's Upgrade Plan button, the balance warning —
+ * paints, unpaints, and paints again on a single cold load.
+ *
+ * The fix is to not ask until we know who we're asking about. An explicitly
+ * passed accountId is always answerable; a context-derived one waits for the
+ * provider to resolve.
+ */
+export function shouldQueryAccountState(input: {
+  /** The caller's own `enabled` option. */
+  enabled: boolean;
+  /** True when the call site passed a concrete accountId of its own. */
+  hasExplicitAccountId: boolean;
+  /** {@link useBillingAccountResolved} — true outside any provider. */
+  contextResolved: boolean;
+}): boolean {
+  if (!input.enabled) return false;
+  if (input.hasExplicitAccountId) return true;
+  return input.contextResolved;
+}

--- a/apps/web/src/hooks/billing/use-account-state.ts
+++ b/apps/web/src/hooks/billing/use-account-state.ts
@@ -13,7 +13,8 @@
  */
 
 import { errorToast, infoToast, successToast } from '@/components/ui/toast';
-import { useBillingAccountId } from '@/stores/billing-account-context';
+import { shouldQueryAccountState } from '@/hooks/billing/account-state-gating';
+import { useBillingAccountId, useBillingAccountResolved } from '@/stores/billing-account-context';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
@@ -184,12 +185,20 @@ interface UseAccountStateOptions {
  * - Agent run completes (credits deducted)
  */
 export function useAccountState(options?: UseAccountStateOptions) {
-  const enabled = options?.enabled ?? true;
   // Explicit option wins; fall back to the nearest BillingAccountProvider so
   // any consumer inside /accounts/[id] is automatically scoped without
   // every call site having to pass the id by hand.
   const contextAccountId = useBillingAccountId();
+  const contextResolved = useBillingAccountResolved();
   const accountId = options?.accountId ?? contextAccountId;
+  // Hold the query until the surface knows whose account it is; fetching the
+  // primary account as a stand-in only to swap cache slots is what made every
+  // presence-driven billing UI paint, unpaint, and paint again on cold load.
+  const enabled = shouldQueryAccountState({
+    enabled: options?.enabled ?? true,
+    hasExplicitAccountId: options?.accountId !== undefined,
+    contextResolved,
+  });
 
   return useQuery<AccountState>({
     queryKey: accountStateKeys.state(accountId),
@@ -227,9 +236,16 @@ export function useAccountStateWithStreaming(isStreaming: boolean = false) {
   // Inherit the BillingAccountProvider if one is wrapping us — keeps the
   // streaming variant aligned with the static one on /accounts/[id].
   const accountId = useBillingAccountId();
+  const contextResolved = useBillingAccountResolved();
   return useQuery<AccountState>({
     queryKey: accountStateKeys.state(accountId),
     queryFn: () => getAccountState({ accountId }),
+    // Same wait as useAccountState — never fetch under a provisional account.
+    enabled: shouldQueryAccountState({
+      enabled: true,
+      hasExplicitAccountId: false,
+      contextResolved,
+    }),
     staleTime: 1000 * 60 * 5, // 5 minutes during streaming
     gcTime: 1000 * 60 * 15,
     refetchOnWindowFocus: false,

--- a/apps/web/src/stores/billing-account-context.tsx
+++ b/apps/web/src/stores/billing-account-context.tsx
@@ -12,27 +12,46 @@ import * as React from 'react';
  * `accountId === null` means "fall back to the user's primary account" —
  * used by global surfaces (user menu, upgrade dialog) that intentionally
  * stay account-agnostic.
+ *
+ * `resolved === false` is a *third* state, and it is not the same as `null`:
+ * it means "this surface owns an account, we just don't know its id yet"
+ * (the project shell before `project-detail` lands). Billing queries wait it
+ * out rather than fetch the primary account as a stand-in — see
+ * `shouldQueryAccountState`.
  */
 
-const BillingAccountContext = React.createContext<string | null>(null);
+interface BillingAccountContextValue {
+  accountId: string | null;
+  resolved: boolean;
+}
+
+const BillingAccountContext = React.createContext<BillingAccountContextValue | null>(null);
 
 export function BillingAccountProvider({
   accountId,
+  resolved = true,
   children,
 }: {
   // `null` = fall back to the user's primary account (global surfaces).
   accountId: string | null;
+  /** Pass `false` while the owning account is still being fetched. */
+  resolved?: boolean;
   children: React.ReactNode;
 }) {
-  return (
-    <BillingAccountContext.Provider value={accountId}>
-      {children}
-    </BillingAccountContext.Provider>
-  );
+  const value = React.useMemo(() => ({ accountId, resolved }), [accountId, resolved]);
+  return <BillingAccountContext.Provider value={value}>{children}</BillingAccountContext.Provider>;
 }
 
 /** Returns the explicit accountId from context, or undefined if not wrapped. */
 export function useBillingAccountId(): string | undefined {
-  const value = React.useContext(BillingAccountContext);
-  return value ?? undefined;
+  return React.useContext(BillingAccountContext)?.accountId ?? undefined;
+}
+
+/**
+ * True once the account this surface bills against is known. Outside any
+ * provider this is always true: a global surface means "the primary account",
+ * and that never needs resolving.
+ */
+export function useBillingAccountResolved(): boolean {
+  return React.useContext(BillingAccountContext)?.resolved ?? true;
 }


### PR DESCRIPTION
A fresh load of `/projects/<id>` settles through three visible artifacts before it looks right.

### 1. The switcher says "Projects" for a beat, then the project's name

It named the open project off the projects *list* (`listProjectsForAccount`), which is gated behind `accounts` — two round-trips deep. Until then it fell back to the generic `'Projects'` label. But a route that names a project is never the projects list; it's a project we can't name *yet*, which calls for a placeholder rather than the wrong label.

It now also reads the `['project-detail', id]` entry the shell already fetches on mount — the same cache key, so no extra request — and shows a skeleton until either query answers. The avatar tile is skeletoned too: its initial is derived from the name, so drawing one early would just swap letters mid-load.

### 2. Upgrade Plan appears, vanishes, appears again

The real one. Account state is cached **per accountId**, and the project shell learns its account late (off `project-detail`):

```
mount        → accountId undefined → key state({accountId: null}) → empty → hidden
primary lands→ data                                                       → SHOWN
detail lands → accountId "abc"     → key state({accountId: "abc"}) → empty → hidden
account lands→ data                                                       → SHOWN
```

Two cache slots, both starting empty, so every billing UI that renders on presence of data painted twice. `BillingAccountProvider` now distinguishes *"this surface means the primary account"* (`accountId: null`) from *"this surface owns an account whose id we don't have yet"* (`resolved: false`), and account-state queries hold until it resolves. One fetch, one appearance.

`useProjectCanRun` already hand-rolled exactly this guard; this generalises it to every consumer of the context.

### 3. The whole nav jumps upward when billing lands

The footer group is bottom-anchored (`mt-auto`), so it grows *upward*: anything below a late-arriving item gets shoved up the instant it mounts. Moving the async billing items above Files/Customize/Connect means the permanent nav never moves — only the session list above gives up the space. (This is what @marko-kraemer suggested — "put the upgrade plan over the files".)

## Tests

- `account-state-gating.test.ts` — the gate, including the project-shell boot sequence never fetching twice
- `project-switcher-label.test.ts` — never `"Projects"` on a project route; still `"Projects"` off one
- `project-sidebar-footer-order.test.ts` — guard on the ordering, with the `mt-auto` reasoning in the file so it isn't "fixed" back

440 web unit tests pass in the touched areas; `tsc --noEmit` clean (the two pre-existing `template-url.test.ts` errors are untouched).

## Not changed

`useDownloadRestriction` fails open while account state is unknown (no state → not free tier → download allowed). That was already true during cold load; this shifts the window by one round-trip rather than introducing it. Flagging it as pre-existing rather than folding an unrelated paywall change into this PR.
