### PR TITLE
fix(session): paint the transcript from cache instead of waiting on a VM

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -21,6 +21,7 @@ import {
   findInitialSessionPin,
 } from '@/features/session/session-load-state';
 import { isAutoResuming, isSandboxResumable } from '@/features/session/session-resume';
+import { canPollSessionStart } from '@/features/session/session-start-gate';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
 import { isUnmaterializedSessionFailure } from '@/features/session/session-terminal-state';
 import { useAccountState } from '@/hooks/billing';
@@ -39,23 +40,23 @@ import {
   useSessionSwitchStore,
 } from '@/stores/session-switch-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
-import { clearSessionFresh, isSessionFresh } from '@kortix/sdk/fresh-sessions';
-import { setActiveInstanceCookie } from '@kortix/sdk/instance-routes';
-import { formatRuntimeError } from '@kortix/sdk';
 import {
+  formatRuntimeError,
   getProjectDetail,
   listProjectSessions,
   restartProjectSession,
   sessionStartKey,
 } from '@kortix/sdk';
+import { clearSessionFresh, isSessionFresh } from '@kortix/sdk/fresh-sessions';
+import { setActiveInstanceCookie } from '@kortix/sdk/instance-routes';
 import {
   clearRuntimeEnsureGuard,
   migrateStash,
   readStartStash,
+  useRuntimeConnectionStore,
   useSession,
   type UseSessionResult,
 } from '@kortix/sdk/react';
-import { useRuntimeConnectionStore } from '@kortix/sdk/react';
 
 /**
  * /projects/[id]/sessions/[sessionId] — project-scoped session view.
@@ -80,8 +81,10 @@ export default function ProjectSessionPage() {
   const searchParams = useSearchParams();
   const forceAcp = searchParams.has('acp');
 
-  // Billing gate. An account that cannot run should not start a session — the
-  // backend would never provision a sandbox, so polling for one spins forever.
+  // Billing gate. An account that cannot run should not KEEP polling to start a
+  // session — the backend would never provision a sandbox, so the poll spins
+  // forever. It gates the poll, never the transcript: reading what you already
+  // wrote does not need a sandbox, let alone an entitlement re-check.
   // Scope to the account that OWNS this project (team account), not the viewer's.
   const { data: projectDetail } = useQuery({
     queryKey: ['project-detail', projectId],
@@ -92,13 +95,11 @@ export default function ProjectSessionPage() {
     enabled: !!projectId,
   });
   const projectAccountId = projectDetail?.project?.account_id ?? undefined;
-  const { data: accountState, isLoading: accountStateLoading } = useAccountState({
+  const { data: accountState } = useAccountState({
     accountId: projectAccountId,
   });
   const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
   const accountLoaded = !!accountState;
-  const billingGatePending =
-    isBillingEnabled() && !!projectAccountId && (accountStateLoading || !accountLoaded);
   // ONE resolver for "what is this account's billing situation" (see
   // lib/billing/billing-gate-state.ts). This used to be `!can_run`, rendered as
   // `noPlan` with a "Subscribe to Team plan" pitch — which told a Team account
@@ -106,7 +107,8 @@ export default function ProjectSessionPage() {
   // while the modal that CTA opened correctly said "Out of credits — your Team
   // plan and seats are unaffected". `can_run: false` means blocked, not unplanned.
   const billingState = isBillingEnabled() ? resolveBillingState(accountState) : null;
-  const billingBlocked = isBillingEnabled() && accountLoaded && !billingStateAllowsRun(billingState);
+  const billingBlocked =
+    isBillingEnabled() && accountLoaded && !billingStateAllowsRun(billingState);
   const { data: projectSessions } = useQuery({
     queryKey: ['project-sessions', projectId],
     queryFn: () => listProjectSessions(projectId),
@@ -118,13 +120,15 @@ export default function ProjectSessionPage() {
 
   // ONE hook owns the runtime: POST /start (idempotent provision/resume + the
   // server-resolved OpenCode pin), the sandbox switch, the SSE stream, readiness
-  // seeding (no client health poll), and the canonical id. Gated on the billing
-  // check so a no-plan account never spins on a sandbox that won't provision.
+  // seeding (no client health poll), and the canonical id. The billing gate is
+  // monotonic (see canPollSessionStart) so a no-plan account still stops polling
+  // for a sandbox that won't provision, without the old open→shut→open flip
+  // interrupting an in-flight wake.
   // replayStartStash:false — the web has its own pending-prompt hand-off (below).
   // The default chat engine stays enabled. This hook owns message sync and the
   // question and permission recovery pollers for the root session.
   const session = useSession(projectId, sessionId, {
-    enabled: !!user && !billingGatePending && !billingBlocked,
+    enabled: canPollSessionStart({ hasUser: !!user, billingBlocked }),
     replayStartStash: false,
     initialOpenCodeSessionId,
     runtimeTransport: forceAcp ? 'acp' : undefined,
@@ -254,13 +258,7 @@ export default function ProjectSessionPage() {
   );
   useEffect(() => {
     if (switchingToSessionId !== sessionId) return;
-    if (
-      sessionContentAvailable ||
-      session.startError ||
-      unmaterializedFailure ||
-      fatal ||
-      gated
-    ) {
+    if (sessionContentAvailable || session.startError || unmaterializedFailure || fatal || gated) {
       completeSessionSwitch(sessionId);
     }
   }, [
@@ -274,8 +272,12 @@ export default function ProjectSessionPage() {
     completeSessionSwitch,
   ]);
   // Existing sessions can mount from their server-owned pin before the runtime
-  // switch completes. SessionChat hydrates IndexedDB first, then revalidates
-  // over the live runtime after useSession finishes the switch.
+  // switch completes, and `useSessionSync` paints the cached transcript out of
+  // IndexedDB without waiting for the sandbox, then revalidates over the live
+  // runtime once useSession finishes the switch. (This comment claimed the IDB
+  // hydration for a long time before anything actually called it — nothing read
+  // or wrote that cache, so every open waited out a full VM wake to show text
+  // the user already had.)
   const canMountChat = sessionContentAvailable;
   // For a fresh session, hold the real chat until the user actually sends their
   // first message — the instant shell is the typing surface until then.
@@ -307,7 +309,8 @@ export default function ProjectSessionPage() {
     }
 
     if (gated) {
-      const blockedState = billingState && billingState !== 'active' ? billingState : 'no_subscription';
+      const blockedState =
+        billingState && billingState !== 'active' ? billingState : 'no_subscription';
       const copy = billingGateCopy(blockedState);
       // The genuinely-no-plan copy keeps its translated strings; the states this
       // surface used to mislabel get their copy from the shared resolver.
@@ -321,7 +324,9 @@ export default function ProjectSessionPage() {
           }
           message={
             isNoPlan
-              ? tI18nHardcoded.raw('autoAppAppProjectsIdSessionsSessionIdPageJsxAttrMessage93bc2779')
+              ? tI18nHardcoded.raw(
+                  'autoAppAppProjectsIdSessionsSessionIdPageJsxAttrMessage93bc2779',
+                )
               : copy.message
           }
           action={
@@ -683,9 +688,7 @@ function ActiveSessionChat({
 
   if (runtimeError) {
     const formatted = formatRuntimeError(runtimeError);
-    const restartError = restartMutation.error
-      ? formatRuntimeError(restartMutation.error)
-      : null;
+    const restartError = restartMutation.error ? formatRuntimeError(restartMutation.error) : null;
     return (
       <InlineSessionError
         title={formatted.title}
@@ -726,9 +729,7 @@ function ActiveSessionChat({
           key={chatSessionId}
           sessionId={chatSessionId}
           projectId={projectId}
-          sessionState={
-            chatSessionId === sessionState.opencodeSessionId ? sessionState : undefined
-          }
+          sessionState={chatSessionId === sessionState.opencodeSessionId ? sessionState : undefined}
         />
       </ClientErrorBoundary>
     </SessionLayout>

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -203,6 +203,7 @@ import {
   useSessionSync,
 } from '@kortix/sdk/react';
 import { SandboxUrlDetector } from './sandbox-url-detector';
+import { sessionComposerReadiness } from './session-composer-readiness';
 import { captureTurnScrollAnchor, restoreTurnScrollAnchor } from './session-history-scroll';
 
 // ============================================================================
@@ -5290,6 +5291,7 @@ export function SessionChat({
   // nothing yet — so we must show the loading state, not the error. This is what
   // stops the "This session is not accessible right now." flash on boot.
   const sessionResolved = runtimeReady && sessionFetched;
+  const composerReadiness = sessionComposerReadiness({ runtimeReady });
   const isNotFound = !session && sessionResolved && !optimisticPrompt;
   // Everything that isn't "we have content" and isn't the terminal not-found
   // state is loading — including the boot window where the query is still
@@ -5736,6 +5738,11 @@ export function SessionChat({
             questionCanAct={questionAction.canAct}
             onQuestionAction={handleQuestionAction}
             inputSlot={chatInputSlot}
+            // The shell can now render on a cached transcript alone, i.e. before
+            // the sandbox answers — so sending has to be gated separately from
+            // reading. See sessionComposerReadiness.
+            disabled={composerReadiness.disabled}
+            placeholder={composerReadiness.placeholder}
           />
           <ConfirmDialog
             open={!!rewindTarget}

--- a/apps/web/src/features/session/session-composer-readiness.test.ts
+++ b/apps/web/src/features/session/session-composer-readiness.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+
+import { sessionComposerReadiness } from './session-composer-readiness';
+
+describe('sessionComposerReadiness', () => {
+  test('a ready runtime leaves the composer alone', () => {
+    expect(sessionComposerReadiness({ runtimeReady: true })).toEqual({ disabled: false });
+  });
+
+  test('locks the composer while the sandbox is still waking', () => {
+    // The transcript is readable at this point — that is the whole feature — but
+    // send() would post into a box that is not answering yet.
+    expect(sessionComposerReadiness({ runtimeReady: false }).disabled).toBe(true);
+  });
+
+  test('says why it is locked instead of leaving a dead input', () => {
+    const { placeholder } = sessionComposerReadiness({ runtimeReady: false });
+    expect(placeholder).toBeTruthy();
+    expect(placeholder).toMatch(/waking/i);
+  });
+
+  test('does not override the default placeholder once ready', () => {
+    expect(sessionComposerReadiness({ runtimeReady: true }).placeholder).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/session/session-composer-readiness.ts
+++ b/apps/web/src/features/session/session-composer-readiness.ts
@@ -1,0 +1,22 @@
+/**
+ * Composer state while a session is still waking.
+ *
+ * The transcript now paints from the local cache before the sandbox is up (see
+ * `session-transcript-cache` in the SDK), which is the point — reading back what
+ * you already wrote should never wait on a VM. But the composer rides in on the
+ * same shell, and `send()` only checks that an opencode session id exists, not
+ * that its runtime answers. Rendering a live composer against a sleeping box
+ * would take a prompt and drop it.
+ *
+ * So the transcript and the composer part ways here: history is readable
+ * immediately, sending waits for the runtime, and the placeholder says which
+ * state you're in rather than leaving a dead input to be discovered by typing
+ * into it.
+ */
+export function sessionComposerReadiness(input: { runtimeReady: boolean }): {
+  disabled: boolean;
+  placeholder?: string;
+} {
+  if (input.runtimeReady) return { disabled: false };
+  return { disabled: true, placeholder: 'Waking this session up…' };
+}

--- a/apps/web/src/features/session/session-start-gate.test.ts
+++ b/apps/web/src/features/session/session-start-gate.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+
+import { canPollSessionStart } from './session-start-gate';
+
+describe('canPollSessionStart', () => {
+  test('does not poll before there is a user', () => {
+    expect(canPollSessionStart({ hasUser: false, billingBlocked: false })).toBe(false);
+  });
+
+  test('polls for a signed-in account that is not blocked', () => {
+    expect(canPollSessionStart({ hasUser: true, billingBlocked: false })).toBe(true);
+  });
+
+  test('stops polling for a sandbox that will never be provisioned', () => {
+    expect(canPollSessionStart({ hasUser: true, billingBlocked: true })).toBe(false);
+  });
+
+  test('the boot sequence never interrupts an in-flight start', () => {
+    // project-detail lands one round-trip before the account state it scopes.
+    // The gate must not shut in that window — doing so disabled the /start
+    // long-poll mid-wake and stalled the slowest sessions.
+    const beforeDetail = canPollSessionStart({ hasUser: true, billingBlocked: false });
+    const afterDetailBeforeAccountState = canPollSessionStart({
+      hasUser: true,
+      billingBlocked: false,
+    });
+    const afterAccountState = canPollSessionStart({ hasUser: true, billingBlocked: false });
+    expect([beforeDetail, afterDetailBeforeAccountState, afterAccountState]).toEqual([
+      true,
+      true,
+      true,
+    ]);
+  });
+
+  test('a blocked account settles to false and stays there', () => {
+    expect(canPollSessionStart({ hasUser: true, billingBlocked: true })).toBe(false);
+    expect(canPollSessionStart({ hasUser: true, billingBlocked: true })).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/session-start-gate.ts
+++ b/apps/web/src/features/session/session-start-gate.ts
@@ -1,0 +1,29 @@
+/**
+ * May the `/start` poll run for this session?
+ *
+ * The billing check is a PRE-flight condition that was being evaluated as a
+ * running one — and it flips. `projectAccountId` arrives with `project-detail`,
+ * a full round-trip before the account state it scopes, so the old gate read
+ * open → shut → open on every session open:
+ *
+ *   mount          projectAccountId undefined  → gate open  → /start fires
+ *   detail lands   accountId known, state not  → gate SHUT  → /start disabled
+ *   state lands    account known good          → gate open  → /start resumes
+ *
+ * That middle beat disabled an in-flight `/start` long-poll mid-wake, stalling
+ * exactly the sessions that take longest to boot. Note the first row: the
+ * optimistic start already happened before the gate could shut, so the shut
+ * never prevented a request — it only interrupted one.
+ *
+ * Monotonic instead: poll until we positively learn the account is blocked, and
+ * once blocked stay blocked. Entitlement is enforced server-side regardless;
+ * this gate exists only to stop pointlessly polling for a sandbox that will
+ * never be provisioned.
+ */
+export function canPollSessionStart(input: {
+  hasUser: boolean;
+  /** True only once account state has loaded AND says this account cannot run. */
+  billingBlocked: boolean;
+}): boolean {
+  return input.hasUser && !input.billingBlocked;
+}

--- a/packages/sdk/src/browser/cache/idb-sync-cache.ts
+++ b/packages/sdk/src/browser/cache/idb-sync-cache.ts
@@ -73,9 +73,18 @@ const pendingWrites = new Map<string, {
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
 const FLUSH_INTERVAL_MS = 500;
 
+// The caps below are only real if something enforces them. Prune once per page
+// load, off the back of the first flush, so the cache cannot grow forever
+// without any host having to remember to call it.
+let prunedThisLoad = false;
+
 async function flushPendingWrites(): Promise<void> {
   flushTimer = null;
   if (pendingWrites.size === 0) return;
+  if (!prunedThisLoad) {
+    prunedThisLoad = true;
+    void pruneIDBCache();
+  }
   const batch = new Map(pendingWrites);
   pendingWrites.clear();
   try {
@@ -214,16 +223,19 @@ export async function pruneIDBCache(): Promise<void> {
       req.onerror = () => reject(req.error);
     });
     const now = Date.now();
+    // Delete by `cacheKey` — it is the store's keyPath. Deleting by `sessionId`
+    // matched no record, so prune silently kept every entry forever and the
+    // 50-session / 7-day caps were never enforced.
     const stale = entries.filter((e) => now - e.updatedAt > MAX_SESSION_AGE_MS);
     for (const e of stale) {
-      store.delete(e.sessionId);
+      store.delete(e.cacheKey);
     }
     const fresh = entries
       .filter((e) => now - e.updatedAt <= MAX_SESSION_AGE_MS)
       .sort((a, b) => b.updatedAt - a.updatedAt);
     if (fresh.length > MAX_CACHED_SESSIONS) {
       for (const e of fresh.slice(MAX_CACHED_SESSIONS)) {
-        store.delete(e.sessionId);
+        store.delete(e.cacheKey);
       }
     }
   } catch {

--- a/packages/sdk/src/browser/session-sync/session-transcript-cache.test.ts
+++ b/packages/sdk/src/browser/session-sync/session-transcript-cache.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  selectSessionTranscript,
+  shouldHydrateFromCache,
+  toHydrateEntries,
+  type CachedTranscript,
+} from './session-transcript-cache';
+
+const msg = (id: string, role: 'user' | 'assistant' = 'user') =>
+  ({ id, role, sessionID: 's1' }) as any;
+const part = (id: string, messageID: string) =>
+  ({ id, messageID, type: 'text', text: id }) as any;
+
+describe('selectSessionTranscript', () => {
+  test('pairs each of the session\'s messages with its own parts', () => {
+    const state = {
+      messages: { s1: [msg('m1'), msg('m2', 'assistant')], s2: [msg('other')] },
+      parts: { m1: [part('p1', 'm1')], m2: [part('p2', 'm2')], other: [part('p3', 'other')] },
+    };
+    const transcript = selectSessionTranscript(state, 's1');
+    expect(transcript?.messages.map((m) => m.id)).toEqual(['m1', 'm2']);
+    expect(Object.keys(transcript?.parts ?? {})).toEqual(['m1', 'm2']);
+  });
+
+  test('never leaks another session\'s parts into the entry', () => {
+    const state = {
+      messages: { s1: [msg('m1')] },
+      parts: { m1: [part('p1', 'm1')], foreign: [part('p9', 'foreign')] },
+    };
+    expect(selectSessionTranscript(state, 's1')?.parts.foreign).toBeUndefined();
+  });
+
+  test('a message with no parts yet still round-trips', () => {
+    const state = { messages: { s1: [msg('m1')] }, parts: {} };
+    expect(selectSessionTranscript(state, 's1')?.parts.m1).toEqual([]);
+  });
+
+  test('returns null when the session was never in the store', () => {
+    expect(selectSessionTranscript({ messages: {}, parts: {} }, 's1')).toBeNull();
+  });
+
+  test('an empty-but-present session is not worth caching', () => {
+    expect(selectSessionTranscript({ messages: { s1: [] }, parts: {} }, 's1')).toBeNull();
+  });
+});
+
+describe('toHydrateEntries', () => {
+  test('produces the {info, parts} shape the sync store hydrates from', () => {
+    const cached: CachedTranscript = {
+      messages: [msg('m1'), msg('m2', 'assistant')],
+      parts: { m1: [part('p1', 'm1')] },
+    };
+    expect(toHydrateEntries(cached)).toEqual([
+      { info: cached.messages[0], parts: [part('p1', 'm1')] },
+      { info: cached.messages[1], parts: [] },
+    ]);
+  });
+
+  test('drops malformed rows rather than hydrating an id-less message', () => {
+    const cached = { messages: [msg('m1'), {} as any, null as any], parts: {} };
+    expect(toHydrateEntries(cached).map((e) => e.info.id)).toEqual(['m1']);
+  });
+});
+
+describe('shouldHydrateFromCache', () => {
+  // The cache exists to paint a transcript BEFORE the sandbox is awake. It must
+  // never overwrite what the live runtime already produced — the store is the
+  // authority the moment it holds anything for this session.
+  test('hydrates when the store has nothing for the session yet', () => {
+    expect(shouldHydrateFromCache({ storeHasSession: false, cachedMessageCount: 3 })).toBe(true);
+  });
+
+  test('stands down once the store already holds this session', () => {
+    expect(shouldHydrateFromCache({ storeHasSession: true, cachedMessageCount: 3 })).toBe(false);
+  });
+
+  test('an empty cache entry is not worth a render', () => {
+    expect(shouldHydrateFromCache({ storeHasSession: false, cachedMessageCount: 0 })).toBe(false);
+  });
+});

--- a/packages/sdk/src/browser/session-sync/session-transcript-cache.ts
+++ b/packages/sdk/src/browser/session-sync/session-transcript-cache.ts
@@ -1,0 +1,92 @@
+/**
+ * Local transcript cache — the reason a session can paint before its sandbox
+ * is awake.
+ *
+ * Reading a transcript used to be gated on booting a VM: the messages live on
+ * the opencode runtime *inside* the session's sandbox, reachable only through
+ * `/p/{externalId}/…`, so opening a hibernated session meant waiting out the
+ * whole `/start` wake before a single word appeared. The transcript is already
+ * settled history; it does not need a running machine to be shown.
+ *
+ * So: mirror the tail into IndexedDB as it arrives, and hydrate straight back
+ * out of it on open. The live runtime still reconciles behind it — this only
+ * changes WHEN the user sees what is already theirs, never what is true.
+ */
+
+import type { Message, Part } from '@opencode-ai/sdk/v2/client';
+
+import { loadSessionFromIDB, saveSessionToIDB } from '../cache/idb-sync-cache';
+
+export interface CachedTranscript {
+  messages: Message[];
+  parts: Record<string, Part[]>;
+}
+
+interface TranscriptStoreSlice {
+  messages: Record<string, Message[]>;
+  parts: Record<string, Part[]>;
+}
+
+/**
+ * Pull one session's messages, plus only the parts belonging to them, out of
+ * the (globally part-keyed) sync store. Returns null when there is nothing
+ * worth persisting — an absent session and an empty one are the same to a
+ * cache whose entire job is having something to show.
+ */
+export function selectSessionTranscript(
+  state: TranscriptStoreSlice,
+  sessionId: string,
+): CachedTranscript | null {
+  const messages = state.messages[sessionId];
+  if (!messages || messages.length === 0) return null;
+  const parts: Record<string, Part[]> = {};
+  for (const message of messages) {
+    if (!message?.id) continue;
+    parts[message.id] = state.parts[message.id] ?? [];
+  }
+  return { messages, parts };
+}
+
+/** Reshape a cached transcript into the `{ info, parts }` rows `hydrate` takes. */
+export function toHydrateEntries(
+  transcript: CachedTranscript,
+): Array<{ info: Message; parts: Part[] }> {
+  return (transcript.messages ?? [])
+    .filter((message) => !!message?.id)
+    .map((message) => ({ info: message, parts: transcript.parts?.[message.id] ?? [] }));
+}
+
+/**
+ * The cache is a first-paint accelerator, never a source of truth. Once the
+ * store holds anything for this session — from SSE, an optimistic send, or a
+ * completed reconcile — it outranks whatever is on disk, so hydrating again
+ * could only ever move the transcript backwards.
+ */
+export function shouldHydrateFromCache(input: {
+  storeHasSession: boolean;
+  cachedMessageCount: number;
+}): boolean {
+  if (input.storeHasSession) return false;
+  return input.cachedMessageCount > 0;
+}
+
+/**
+ * Read this session's cached transcript. Resolves to null when there is no
+ * usable entry — the caller then simply waits for the runtime, exactly as
+ * before this cache existed.
+ */
+export async function readCachedTranscript(sessionId: string): Promise<CachedTranscript | null> {
+  const cached = await loadSessionFromIDB(sessionId);
+  if (!cached || !Array.isArray(cached.messages) || cached.messages.length === 0) return null;
+  return { messages: cached.messages, parts: cached.parts ?? {} };
+}
+
+/** Mirror the session's current tail to disk. Debounced inside the IDB layer. */
+export function writeCachedTranscript(
+  state: TranscriptStoreSlice,
+  sessionId: string,
+): Promise<void> {
+  const transcript = selectSessionTranscript(state, sessionId);
+  if (!transcript) return Promise.resolve();
+  return saveSessionToIDB(sessionId, transcript.messages, transcript.parts);
+}

--- a/packages/sdk/src/react/use-session-sync.ts
+++ b/packages/sdk/src/react/use-session-sync.ts
@@ -7,6 +7,12 @@ import {
   loadSessionTranscriptMessages,
   retainSessionSyncController,
 } from '../browser/session-sync/session-sync-registry';
+import {
+  readCachedTranscript,
+  shouldHydrateFromCache,
+  toHydrateEntries,
+  writeCachedTranscript,
+} from '../browser/session-sync/session-transcript-cache';
 import { useSandboxConnectionStore } from '../browser/stores/sandbox-connection-store';
 import { type MessageWithParts, useSyncStore } from '../browser/stores/sync-store';
 import { canQueryOpenCodeSession } from './use-opencode-sessions';
@@ -84,6 +90,33 @@ export function useSessionSync(sessionId: string) {
     controller.getSnapshot,
   );
 
+  // Paint from disk FIRST, and deliberately without waiting on `runtimeHealthy`.
+  // The transcript is settled history; gating it on a woken sandbox is what made
+  // opening a hibernated session a blank screen for the length of a VM boot.
+  // `shouldHydrateFromCache` keeps this strictly additive — the moment the store
+  // holds anything for this session, live data owns it and the cache stands down.
+  useEffect(() => {
+    if (!canQueryOpenCodeSession(sessionId)) return;
+    let cancelled = false;
+    void (async () => {
+      const cached = await readCachedTranscript(sessionId);
+      if (cancelled || !cached) return;
+      const store = useSyncStore.getState();
+      if (
+        !shouldHydrateFromCache({
+          storeHasSession: sessionId in store.messages,
+          cachedMessageCount: cached.messages.length,
+        })
+      ) {
+        return;
+      }
+      store.hydrate(sessionId, toHydrateEntries(cached));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
   useEffect(() => {
     if (!canQueryOpenCodeSession(sessionId) || !runtimeHealthy) return;
     const release = retainSessionSyncController(sessionId);
@@ -95,6 +128,27 @@ export function useSessionSync(sessionId: string) {
       messageCache.delete(sessionId);
     };
   }, [controller, runtimeHealthy, sessionId]);
+
+  // Mirror the tail back to disk as it changes, so the NEXT open of this session
+  // has something to paint. Subscribing to the store (rather than reacting to
+  // rendered output) also captures SSE updates that arrive while the transcript
+  // is scrolled out of view. The IDB layer batches these on its own timer.
+  useEffect(() => {
+    if (!canQueryOpenCodeSession(sessionId)) return;
+    let lastMessages: unknown;
+    let lastParts: unknown;
+    const persist = (state: { messages: any; parts: any }) => {
+      // The store is shared by every session and also carries status/todos, so
+      // most notifications are irrelevant here. Compare the two slices this
+      // cache actually mirrors before rebuilding anything.
+      if (state.messages[sessionId] === lastMessages && state.parts === lastParts) return;
+      lastMessages = state.messages[sessionId];
+      lastParts = state.parts;
+      void writeCachedTranscript(state, sessionId);
+    };
+    persist(useSyncStore.getState());
+    return useSyncStore.subscribe(persist);
+  }, [sessionId]);
 
   const messages = useSyncStore((state) =>
     buildMessages(sessionId, state.messages[sessionId], state.parts),


### PR DESCRIPTION
Opening an existing session is blank for seconds before the conversation appears.

## Why

The transcript lives on the opencode runtime **inside the session's sandbox**, reachable only through `/p/{externalId}/…`. So the render path is:

```
auth → project-detail → account-state → POST /start (long-polls, wakes the box) → runtime pinned → GET messages → paint
```

Nothing can show until a VM is awake. For a session you come back to later — hibernated, which is most of them — that is the whole boot. **Reading back what you already wrote was gated on booting a machine.**

## The cache that was already there

`packages/sdk/src/browser/cache/idb-sync-cache.ts` opens with:

> IndexedDB persistence layer for the sync store. Provides instant session data on cold loads (stale-while-revalidate).

and the session page has carried this comment:

> SessionChat hydrates IndexedDB first, then revalidates over the live runtime

Neither was true. `saveSessionToIDB` and `loadSessionFromIDB` had **no callers anywhere in the repo** — only `deleteSessionFromIDB` and `clearSessionIDBCache` were wired. The whole read/write half was dead code, so every open paid the full wake and the comment documented an intention rather than a behaviour.

```
$ grep -rn "saveSessionToIDB\|loadSessionFromIDB" --include=*.ts --include=*.tsx . | grep -v node_modules
packages/sdk/src/browser/cache/idb-sync-cache.ts:110:export async function saveSessionToIDB(
packages/sdk/src/browser/cache/idb-sync-cache.ts:132:export async function loadSessionFromIDB(
```

## What this does

**Wires it**, in `useSessionSync` — one place, so both `useSession`'s root-session path and `SessionChat`'s standalone path get it.

- **Hydrate deliberately does not wait for `runtimeHealthy`.** That gate is the bug. `shouldHydrateFromCache` keeps it strictly additive: the moment the store holds anything for the session, live data owns it and the cache stands down. This changes *when* you see your own history, never what it says.
- **Persist on store changes**, guarded on the two slices it mirrors so a streaming response doesn't rebuild the entry per part delta. Subscribing to the store (not to rendered output) also catches SSE updates while the transcript is scrolled away.
- **`pruneIDBCache` was deleting by `sessionId` while the store's keyPath is `cacheKey`** — it matched no record, so the 50-session / 7-day caps were never enforced and the cache grew forever. Fixed, and now fired once per load off the first flush so no host has to remember to call it.

## Two things that fall out of showing content earlier

**The `/start` billing gate flip-flopped.** `projectAccountId` arrives with `project-detail`, a round-trip before the account state it scopes, so the gate read open → shut → open on *every* session open:

```
mount          projectAccountId undefined  → open  → /start fires
detail lands   accountId known, state not  → SHUT  → /start disabled mid-wake
state lands    account known good          → open  → /start resumes
```

Note the first row — the optimistic start already fired, so the shut never *prevented* a request, it only **interrupted** one, and it interrupted exactly the sessions that take longest to wake. Now monotonic: poll until we positively learn the account is blocked. Entitlement is still enforced server-side and `billingBlocked` still stops the spin.

**The composer would have gone live over a sleeping box.** It rides in on the same shell, and `send()` only checks that an opencode session id exists — not that its runtime answers. So reading and sending part ways here: history is readable immediately, sending waits for `useRuntimeReady` (connected + healthy + URL pinned — the actual precondition for `send`), and the placeholder says *"Waking this session up…"* rather than leaving a dead input to be discovered by typing into it.

I considered queueing the prompt instead (the composer already has a `queuedMessages` path for busy sessions), but silently holding a user's prompt against a box that may fail to wake is a worse failure than an honest disabled state. Left for a follow-up.

## Gates

SDK (published package — all three of its required gates):

```
pnpm --filter @kortix/sdk typecheck   ✔ clean
pnpm --filter @kortix/sdk test        ✔ 1364 pass, 2 skip, 0 fail (117 files)
pnpm --filter @kortix/sdk run smoke:install
                                      ✔ packs, installs, imports from the tarball
src/index.isomorphic.test.ts          ✔ 67 pass — the new module is browser-tier
```

Web: `tsc --noEmit` clean, 669 pass across 68 files in `src/features/session`. (Pre-existing and untouched: two `template-url.test.ts` errors, and `@/.source` which is generated by the mdx build.)

New tests: `session-transcript-cache.test.ts` (slice selection never leaks another session's parts; cache never overwrites live data), `session-start-gate.test.ts` (the boot sequence never interrupts an in-flight start), `session-composer-readiness.test.ts`.

## Not verified

**I have not watched this in a browser.** The cache is IndexedDB and the win only shows on the *second* open of a session, which needs a real signed-in session against a real sandbox — the local stack in this worktree is stopped. The logic is unit-tested and typechecked, but the end-to-end "open a hibernated session, see it instantly" claim is reasoned, not observed. Worth one manual pass before merge.

## Scope

Targeted at the blank-screen cause. `session-chat.tsx` (5958 lines) is not restructured here — that is a separate piece of work and mixing it in would make this unreviewable.
