### PR TITLE
fix: reject terminal soft-rate completions

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-config-deps.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-config-deps.test.ts
@@ -15,7 +15,7 @@ async function exists(p: string): Promise<boolean> {
 }
 
 describe('ensureOpencodeConfigDeps', () => {
-  it('links the baked node_modules + bun.lock into a config dir that declares deps', async () => {
+  it('links baked node_modules when the project and baked locks match', async () => {
     const root = await mkdtemp(join(tmpdir(), 'oc-deps-'))
     try {
       const configDir = join(root, 'config')
@@ -23,7 +23,8 @@ describe('ensureOpencodeConfigDeps', () => {
       await mkdir(configDir, { recursive: true })
       await mkdir(join(bakedDir, 'node_modules', 'replicate'), { recursive: true })
       await writeFile(join(configDir, 'package.json'), '{"dependencies":{"replicate":"^1.4.0"}}')
-      await writeFile(join(bakedDir, 'bun.lock'), '{}')
+      await writeFile(join(configDir, 'bun.lock'), '{"lockfileVersion":1}')
+      await writeFile(join(bakedDir, 'bun.lock'), '{"lockfileVersion":1}')
 
       await ensureOpencodeConfigDeps(configDir, { bakedDir })
 
@@ -31,7 +32,7 @@ describe('ensureOpencodeConfigDeps', () => {
       expect(await readlink(join(configDir, 'node_modules'))).toBe(join(bakedDir, 'node_modules'))
       // …and resolves through to the baked package.
       expect(await exists(join(configDir, 'node_modules', 'replicate'))).toBe(true)
-      // bun.lock copied in so opencode's own install verifies as a no-op.
+      // The matching project lock remains in place for OpenCode's verification.
       expect(await exists(join(configDir, 'bun.lock'))).toBe(true)
     } finally {
       await rm(root, { recursive: true, force: true })
@@ -54,7 +55,7 @@ describe('ensureOpencodeConfigDeps', () => {
     }
   })
 
-  it('leaves an already-satisfied config dir untouched', async () => {
+  it('replaces a stale real node_modules tree when the baked lock matches', async () => {
     const root = await mkdtemp(join(tmpdir(), 'oc-deps-'))
     try {
       const configDir = join(root, 'config')
@@ -62,12 +63,65 @@ describe('ensureOpencodeConfigDeps', () => {
       await mkdir(join(configDir, 'node_modules', 'existing'), { recursive: true })
       await mkdir(join(bakedDir, 'node_modules', 'baked-only'), { recursive: true })
       await writeFile(join(configDir, 'package.json'), '{"dependencies":{"replicate":"^1.4.0"}}')
+      await writeFile(join(configDir, 'bun.lock'), '{"lockfileVersion":1}')
+      await writeFile(join(bakedDir, 'bun.lock'), '{"lockfileVersion":1}')
 
       await ensureOpencodeConfigDeps(configDir, { bakedDir })
 
-      // The pre-existing real node_modules is kept (not replaced by the baked symlink).
-      expect(await exists(join(configDir, 'node_modules', 'existing'))).toBe(true)
+      expect(await readlink(join(configDir, 'node_modules'))).toBe(join(bakedDir, 'node_modules'))
+      expect(await exists(join(configDir, 'node_modules', 'existing'))).toBe(false)
+      expect(await exists(join(configDir, 'node_modules', 'baked-only'))).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('installs a mismatched lock in staging and atomically replaces the stale tree', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oc-deps-'))
+    try {
+      const configDir = join(root, 'config')
+      const bakedDir = join(root, 'baked')
+      await mkdir(join(configDir, 'node_modules', 'stale'), { recursive: true })
+      await mkdir(join(bakedDir, 'node_modules', 'baked-only'), { recursive: true })
+      await writeFile(join(configDir, 'package.json'), '{"dependencies":{"ajv":"^8.0.0"}}')
+      await writeFile(join(configDir, 'bun.lock'), '{"config":"new"}')
+      await writeFile(join(bakedDir, 'bun.lock'), '{"baked":"old"}')
+
+      await ensureOpencodeConfigDeps(configDir, {
+        bakedDir,
+        install: async (stagingDir) => {
+          expect(await exists(join(configDir, 'node_modules', 'stale'))).toBe(true)
+          await mkdir(join(stagingDir, 'node_modules', 'fresh'), { recursive: true })
+        },
+      })
+
+      expect(await exists(join(configDir, 'node_modules', 'stale'))).toBe(false)
+      expect(await exists(join(configDir, 'node_modules', 'fresh'))).toBe(true)
       expect(await exists(join(configDir, 'node_modules', 'baked-only'))).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('removes a stale tree after staged installation fails so OpenCode installs cleanly', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oc-deps-'))
+    try {
+      const configDir = join(root, 'config')
+      const bakedDir = join(root, 'baked')
+      await mkdir(join(configDir, 'node_modules', 'stale'), { recursive: true })
+      await mkdir(join(bakedDir, 'node_modules', 'baked-only'), { recursive: true })
+      await writeFile(join(configDir, 'package.json'), '{"dependencies":{"ajv":"^8.0.0"}}')
+      await writeFile(join(configDir, 'bun.lock'), '{"config":"new"}')
+      await writeFile(join(bakedDir, 'bun.lock'), '{"baked":"old"}')
+
+      await ensureOpencodeConfigDeps(configDir, {
+        bakedDir,
+        install: async () => {
+          throw new Error('offline cache miss')
+        },
+      })
+
+      expect(await exists(join(configDir, 'node_modules'))).toBe(false)
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/apps/kortix-sandbox-agent-server/src/opencode-config-deps.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-config-deps.ts
@@ -1,5 +1,16 @@
 import { execFile } from 'node:child_process'
-import { access, constants, copyFile, symlink } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import {
+  constants,
+  access,
+  copyFile,
+  lstat,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  symlink,
+} from 'node:fs/promises'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { logger } from './logger'
@@ -24,6 +35,53 @@ async function pathExists(p: string): Promise<boolean> {
   }
 }
 
+async function pathEntryExists(p: string): Promise<boolean> {
+  try {
+    await lstat(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function filesMatch(left: string, right: string): Promise<boolean> {
+  try {
+    const [leftBytes, rightBytes] = await Promise.all([readFile(left), readFile(right)])
+    return leftBytes.equals(rightBytes)
+  } catch {
+    return false
+  }
+}
+
+async function replaceNodeModules(configDir: string, replacement: string): Promise<void> {
+  const target = join(configDir, 'node_modules')
+  const backup = join(configDir, `.node_modules-backup-${randomUUID()}`)
+  const hadTarget = await pathEntryExists(target)
+
+  try {
+    if (hadTarget) await rename(target, backup)
+    await rename(replacement, target)
+  } catch (err) {
+    if (hadTarget && (await pathEntryExists(backup))) {
+      await rename(backup, target).catch(() => undefined)
+    }
+    throw err
+  } finally {
+    // A failed rename can leave the staged link/tree at its temporary path.
+    await rm(replacement, { recursive: true, force: true }).catch(() => undefined)
+  }
+  if (hadTarget) await rm(backup, { recursive: true, force: true }).catch(() => undefined)
+}
+
+type InstallDeps = (stagingDir: string) => Promise<void>
+
+async function offlineInstall(stagingDir: string): Promise<void> {
+  await execFileAsync('bun', ['install', '--offline'], {
+    cwd: stagingDir,
+    env: { ...process.env, HOME: OPENCODE_HOME, BUN_INSTALL_CACHE_DIR: BUN_CACHE_DIR },
+  })
+}
+
 /**
  * Make OpenCode's boot-time dependency install free.
  *
@@ -36,46 +94,70 @@ async function pathExists(p: string): Promise<boolean> {
  * normally, and minutes when the registry is contended; it sits squarely on the
  * session boot hot path (it gates `runtimeReady`).
  *
- * Pre-satisfy it deterministically and offline *before* OpenCode starts:
- *   1. fastest — symlink the image-baked, pre-installed node_modules in (+ copy
- *      the matching bun.lock so OpenCode's own install verifies as a no-op);
- *   2. fallback — `bun install --offline` from the pre-warmed Bun cache;
- *   3. last resort — do nothing; OpenCode's own (online) install still works.
+ * Pre-satisfy it deterministically and offline before OpenCode starts:
+ *   1. link image-baked modules only when both lock files match;
+ *   2. otherwise install in a staging directory from the warm Bun cache;
+ *   3. atomically replace node_modules only after installation completes;
+ *   4. remove stale modules after installation failure so OpenCode performs a
+ *      clean online install.
  *
  * Any path turns the network-bound resolve into <0.5s. Never throws: a failure
  * here just means OpenCode falls back to its slower self-install.
  */
 export async function ensureOpencodeConfigDeps(
   configDir: string,
-  opts: { bakedDir?: string } = {},
+  opts: { bakedDir?: string; install?: InstallDeps } = {},
 ): Promise<void> {
   const bakedDir = opts.bakedDir ?? BAKED_DEPS_DIR
+  const install = opts.install ?? offlineInstall
+  const targetModules = join(configDir, 'node_modules')
+  let stagingDir: string | null = null
   try {
     if (!(await pathExists(join(configDir, 'package.json')))) return // no deps declared
-    if (await pathExists(join(configDir, 'node_modules'))) return // already satisfied
 
-    // 1. Restore the image-baked tree (instant, offline, deterministic).
     const bakedModules = join(bakedDir, 'node_modules')
-    if (await pathExists(bakedModules)) {
-      await symlink(bakedModules, join(configDir, 'node_modules'))
-      const bakedLock = join(bakedDir, 'bun.lock')
-      if ((await pathExists(bakedLock)) && !(await pathExists(join(configDir, 'bun.lock')))) {
-        await copyFile(bakedLock, join(configDir, 'bun.lock'))
-      }
+    const bakedLock = join(bakedDir, 'bun.lock')
+    const configLock = join(configDir, 'bun.lock')
+
+    // A matching lock proves that the baked tree satisfies this project. Do
+    // not retain an unverified real tree because OpenCode can update it in
+    // place and leave partially-written package files after interruption.
+    if ((await pathExists(bakedModules)) && (await filesMatch(configLock, bakedLock))) {
+      const stagedLink = join(configDir, `.node_modules-link-${randomUUID()}`)
+      await symlink(bakedModules, stagedLink)
+      await replaceNodeModules(configDir, stagedLink)
       logger.info('[boot] linked baked opencode config deps', { configDir, from: bakedModules })
       return
     }
 
-    // 2. No baked tree (pre-bake image) → offline install from the warm cache.
-    await execFileAsync('bun', ['install', '--offline'], {
-      cwd: configDir,
-      env: { ...process.env, HOME: OPENCODE_HOME, BUN_INSTALL_CACHE_DIR: BUN_CACHE_DIR },
-    })
-    logger.info('[boot] offline-installed opencode config deps', { configDir })
+    // A project-specific lock needs a project-specific tree. Install away
+    // from the live config so OpenCode never observes partial package writes.
+    stagingDir = join(configDir, `.deps-stage-${randomUUID()}`)
+    await mkdir(stagingDir, { recursive: true })
+    await copyFile(join(configDir, 'package.json'), join(stagingDir, 'package.json'))
+    if (await pathExists(configLock)) {
+      await copyFile(configLock, join(stagingDir, 'bun.lock'))
+    }
+    await install(stagingDir)
+    const stagedModules = join(stagingDir, 'node_modules')
+    if (!(await pathEntryExists(stagedModules))) {
+      throw new Error('dependency installation completed without node_modules')
+    }
+    await replaceNodeModules(configDir, stagedModules)
+    const stagedLock = join(stagingDir, 'bun.lock')
+    if (await pathExists(stagedLock)) await copyFile(stagedLock, configLock)
+    logger.info('[boot] staged opencode config deps installed', { configDir })
   } catch (err) {
+    // A stale tree is unsafe after a failed replacement. Remove it so
+    // OpenCode starts from an empty path and performs its own clean install.
+    await rm(targetModules, { recursive: true, force: true }).catch(() => undefined)
     logger.warn('[boot] ensureOpencodeConfigDeps failed; opencode will self-install', {
       configDir,
       err: err instanceof Error ? err.message : String(err),
     })
+  } finally {
+    if (stagingDir) {
+      await rm(stagingDir, { recursive: true, force: true }).catch(() => undefined)
+    }
   }
 }

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -1107,6 +1107,8 @@ describe("gateway.chatCompletions — generation-defaults injection", () => {
 // be treated as a failed candidate — failed over to the next one, and only
 // surfaced to the caller once every candidate has come back empty.
 describe("gateway.chatCompletions — empty-completion failover", () => {
+  const rampRateMessage =
+    "Request rate increased too quickly. To ensure system stability, please adjust your client logic to scale requests more smoothly over time.";
   const emptyJson = JSON.stringify({
     model: "m",
     choices: [],
@@ -1116,6 +1118,11 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     model: "m",
     choices: [{ message: { content: "real answer" } }],
     usage: { prompt_tokens: 5, completion_tokens: 3 },
+  });
+  const softRateLimitJson = JSON.stringify({
+    model: "m",
+    choices: [{ message: { content: rampRateMessage }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 0, completion_tokens: 0 },
   });
 
   function sseResponse(body: string): Response {
@@ -1134,6 +1141,7 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     'data: {"choices":[{"delta":{"content":"real answer"}}]}\n\n' +
     'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3}}\n\n' +
     'data: [DONE]\n\n';
+  const softRateLimitSse = `data: {"choices":[{"delta":{"content":"${rampRateMessage}"},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0}}\n\ndata: [DONE]\n\n`;
 
   // The ai-sdk engine PARSES an upstream SSE stream (via the real
   // @ai-sdk/openai-compatible provider) and RE-SERIALIZES it through this
@@ -1288,6 +1296,60 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     await flush();
     expect(traces[0].ok).toBe(false);
     expect(traces[0].errorCode).toBe("empty_completion");
+  });
+
+  test("non-streaming: a 200 assistant-text rate limit retries in place, then fails over without leaking the text", async () => {
+    const a: UpstreamDescriptor = { ...managed, provider: "a", baseUrl: "https://a.test/v1" };
+    const b: UpstreamDescriptor = { ...managed, provider: "b", baseUrl: "https://b.test/v1" };
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [a, b] });
+    const calls = { a: 0, b: 0 };
+    const fetchImpl: FetchImpl = async (url) => {
+      const provider = new URL(url).hostname === "a.test" ? "a" : "b";
+      calls[provider] += 1;
+      return new Response(provider === "a" ? softRateLimitJson : goodJson, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","messages":[{"role":"user","content":"hi"}]}',
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).choices[0].message.content).toBe("real answer");
+    expect(calls).toEqual({ a: 3, b: 1 });
+    await flush();
+    expect(traces[0].candidatesTried).toEqual(["a", "a", "a", "b"]);
+  });
+
+  test("streaming: a 200 assistant-text rate limit retries in place and returns a real 429 after exhaustion", async () => {
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    let calls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      calls += 1;
+      return sseResponse(softRateLimitSse);
+    };
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true,"messages":[{"role":"user","content":"hi"}]}',
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = await res.json();
+    expect(body.message).toBe(rampRateMessage);
+    expect(body.upstream_code).toBe(429);
+    expect(calls).toBe(3);
+    await flush();
+    expect(traces[0]).toMatchObject({
+      ok: false,
+      status: 429,
+      errorCode: "upstream_error",
+      errorMessage: rampRateMessage,
+    });
   });
 
   // An otherwise-200 stream that carries a structured `{error:{...}}` frame and no

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -19,6 +19,7 @@ import {
   extractUsageFromJson,
   extractUsageFromSseBuffer,
   jsonHasContent,
+  jsonSoftFailureFrame,
 } from '../usage';
 import { gatewayErrorBody, gatewayErrorResponse } from './error-response';
 import { type RoutedUpstreamCandidate, runFailover } from './failover';
@@ -146,7 +147,7 @@ function requestHasImage(body: Record<string, unknown>): boolean {
 // a few times — before falling over to a different candidate, and before ever
 // giving up — resolves the overwhelming majority of these transparently,
 // including the common case where there is only one candidate to begin with.
-const MAX_EMPTY_COMPLETION_ATTEMPTS_PER_CANDIDATE = 3;
+const MAX_INVALID_COMPLETION_ATTEMPTS_PER_CANDIDATE = 3;
 
 function idOf(principal: AuthedPrincipal) {
   return {
@@ -543,16 +544,13 @@ export async function handleChatCompletions(
 
   step('dispatch_upstream', { streaming, candidateCount: candidates.length, routeModels });
 
-  // An upstream can return a syntactically valid 200 with empty `choices`/content
-  // (seen from OpenRouter/z-ai) — a real failure mode, not a legitimate zero-output
-  // turn. That never throws, so runFailover's transport-level retry/failover never
-  // sees it. This loop adds a second failover tier on top: each candidate gets a
-  // few immediate retries in place (below), and only once it's exhausted its own
-  // retries is it excluded so the remaining candidates get a turn — only once
-  // every candidate has produced nothing do we give up and tell the caller,
-  // instead of silently forwarding a blank "stop".
+  // Some upstream failures arrive inside syntactically successful HTTP 200
+  // completions. Known forms are empty completions and an exact rate-limit
+  // sentence encoded as assistant text. The transport retry layer cannot see
+  // either form. This loop validates each completion before relaying bytes.
+  // Each candidate gets three attempts before failover.
   const exhaustedCandidates = new Set<string>();
-  const emptyAttemptsByCandidate = new Map<string, number>();
+  const invalidAttemptsByCandidate = new Map<string, number>();
   const candidateKey = ({ descriptor, routeModel }: RoutedUpstreamCandidate): string =>
     `${routeModel}\u0000${descriptor.provider}\u0000${descriptor.resolvedModel ?? ''}`;
   const sleep = config.retry?.sleep ?? realSleep;
@@ -561,25 +559,23 @@ export async function handleChatCompletions(
   const maxDelayMs = config.retry?.maxDelayMs ?? 8_000;
   const jitter = config.retry?.jitter ?? true;
 
-  // Records an empty completion from a routed candidate. Retries it (via
-  // a short backoff, then `continue`) while it's under budget; once exhausted,
-  // excludes it from `remaining` so the loop moves on to the next candidate (or
-  // to the all-candidates-empty exit if there isn't one).
-  const registerEmptyCompletion = async (
+  const registerInvalidCompletion = async (
     candidate: RoutedUpstreamCandidate,
+    kind: 'empty_completion' | 'rate_limit',
     fields: Record<string, unknown>,
   ): Promise<void> => {
     const key = candidateKey(candidate);
     const { descriptor, routeModel } = candidate;
-    const attempt = (emptyAttemptsByCandidate.get(key) ?? 0) + 1;
-    emptyAttemptsByCandidate.set(key, attempt);
-    const exhausted = attempt >= MAX_EMPTY_COMPLETION_ATTEMPTS_PER_CANDIDATE;
+    const attempt = (invalidAttemptsByCandidate.get(key) ?? 0) + 1;
+    invalidAttemptsByCandidate.set(key, attempt);
+    const exhausted = attempt >= MAX_INVALID_COMPLETION_ATTEMPTS_PER_CANDIDATE;
     logger.warn(
-      `[llm-gateway] empty completion from ${routeModel}@${descriptor.provider} (attempt ${attempt}/${MAX_EMPTY_COMPLETION_ATTEMPTS_PER_CANDIDATE}), ${exhausted ? 'failing over' : 'retrying same candidate'} ${requestId}`,
+      `[llm-gateway] ${kind} from ${routeModel}@${descriptor.provider} (attempt ${attempt}/${MAX_INVALID_COMPLETION_ATTEMPTS_PER_CANDIDATE}), ${exhausted ? 'failing over' : 'retrying same candidate'} ${requestId}`,
     );
-    step('empty_completion_retry', {
+    step('invalid_completion_retry', {
       provider: descriptor.provider,
       routeModel,
+      kind,
       attempt,
       exhausted,
       ...fields,
@@ -588,7 +584,11 @@ export async function handleChatCompletions(
       exhaustedCandidates.add(key);
       return;
     }
-    await sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs, jitter, rand));
+    // A rate-limit rejection needs a slower request ramp than an empty
+    // completion. The injected test sleeper still removes this delay in tests.
+    const retryBaseDelayMs = kind === 'rate_limit' ? Math.max(baseDelayMs, 1_000) : baseDelayMs;
+    const retryMaxDelayMs = kind === 'rate_limit' ? Math.max(maxDelayMs, 8_000) : maxDelayMs;
+    await sleep(backoffDelay(attempt, retryBaseDelayMs, retryMaxDelayMs, jitter, rand));
   };
 
   let upstream: Response | null = null;
@@ -752,7 +752,8 @@ export async function handleChatCompletions(
         provider: chosenDescriptor.provider,
         routeModel: chosenRouteModel,
       });
-      if (jsonHasContent(data)) {
+      const softFailure = jsonSoftFailureFrame(data);
+      if (!softFailure && jsonHasContent(data)) {
         upstream = candidateUpstream;
         descriptor = chosenDescriptor;
         selectedRouteModel = chosenRouteModel;
@@ -763,12 +764,20 @@ export async function handleChatCompletions(
       // (a real generation that came back badly shaped) — capture any usage
       // before discarding the body.
       accumulateDiscardedUsage(extractUsageFromJson(data));
-      await registerEmptyCompletion(chosen, { streaming: false });
+      if (softFailure) lastErrorFrame = softFailure;
+      await registerInvalidCompletion(
+        chosen,
+        softFailure ? 'rate_limit' : 'empty_completion',
+        { streaming: false },
+      );
       continue;
     }
 
     if (!candidateUpstream.body) {
-      await registerEmptyCompletion(chosen, { streaming: true, reason: 'no_body' });
+      await registerInvalidCompletion(chosen, 'empty_completion', {
+        streaming: true,
+        reason: 'no_body',
+      });
       continue;
     }
 
@@ -782,12 +791,11 @@ export async function handleChatCompletions(
       streamProbe = probe;
       break;
     }
-    // A structured error frame is a definitive failure for THIS candidate, not the
-    // transient empty-stop hiccup the same-candidate retry targets — so exclude the
-    // candidate at once (no in-place retry) and remember the real error to surface
-    // if nothing usable ever arrives. Other candidates, if any, still get a turn.
+    // Most structured error frames are terminal for this candidate. A 429 is
+    // transient. Retry a 429 with rate-limit backoff before failover.
     if (probe.errorFrame) {
       lastErrorFrame = probe.errorFrame;
+      await probe.reader.cancel('upstream completion rejected by gateway').catch(() => undefined);
       // `detail` carries the fields that actually identify WHICH part of the
       // request the upstream rejected (OpenAI-shaped backends: `type`/`param`).
       // Without it a body-level rejection logs as a bare "Bad Request" and is
@@ -803,6 +811,14 @@ export async function handleChatCompletions(
         code: probe.errorFrame.code,
         ...(errorDetail ? { detail: errorDetail } : {}),
       });
+      if (statusForErrorFrame(probe.errorFrame) === 429) {
+        await registerInvalidCompletion(chosen, 'rate_limit', {
+          streaming: true,
+          message: probe.errorFrame.message,
+          code: probe.errorFrame.code,
+        });
+        continue;
+      }
       exhaustedCandidates.add(candidateKey(chosen));
       continue;
     }
@@ -826,7 +842,7 @@ export async function handleChatCompletions(
       const decoded = new TextDecoder().decode(concatChunks(probe.chunks));
       accumulateDiscardedUsage(extractUsageFromSseBuffer(decoded));
     }
-    await registerEmptyCompletion(chosen, { streaming: true });
+    await registerInvalidCompletion(chosen, 'empty_completion', { streaming: true });
   }
 
   // Every loop exit above either `return`s (transport failure / all-empty) or

--- a/packages/llm-gateway/src/pipeline/streaming.test.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.test.ts
@@ -172,6 +172,47 @@ describe('probeStream', () => {
     });
     expect(up.cancelled).toBe(true);
   });
+
+  test('holds and classifies the production soft rate-limit completion before relaying bytes', async () => {
+    const up = controllableUpstream();
+    up.push(
+      'data: {"choices":[{"delta":{"content":"Request rate increased too quickly."}}]}\n\n',
+    );
+    up.push(
+      'data: {"choices":[{"delta":{"content":" To ensure system stability, please adjust your client logic to scale requests more smoothly over time."}}]}\n\n',
+    );
+    up.push('data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n');
+    up.push('data: [DONE]\n\n');
+    up.close();
+
+    const result = await probeStream(up.stream);
+
+    expect(result.hasContent).toBe(false);
+    expect(result.errorFrame).toEqual({
+      message:
+        'Request rate increased too quickly. To ensure system stability, please adjust your client logic to scale requests more smoothly over time.',
+      code: 429,
+      detail: { type: 'soft_rate_limit' },
+    });
+  });
+
+  test('does not release a soft-failure prefix at the normal chunk budget', async () => {
+    const up = controllableUpstream();
+    up.push(
+      'data: {"choices":[{"delta":{"content":"Request rate increased too quickly."}}]}\n\n',
+    );
+    for (let index = 0; index < 70; index += 1) up.push(': provider-heartbeat\n\n');
+    up.push(
+      'data: {"choices":[{"delta":{"content":" To ensure system stability, please adjust your client logic to scale requests more smoothly over time."}}]}\n\n',
+    );
+    up.push('data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n');
+    up.close();
+
+    const result = await probeStream(up.stream);
+
+    expect(result.hasContent).toBe(false);
+    expect(result.errorFrame?.code).toBe(429);
+  });
 });
 
 describe('relayStream with a primed reader', () => {

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -4,6 +4,8 @@ import {
   type SseErrorFrame,
   sseErrorFrame,
   sseHasContent,
+  sseMayContainSoftFailure,
+  sseSoftFailureFrame,
 } from '../usage';
 import { gatewayErrorBody } from './error-response';
 
@@ -126,7 +128,22 @@ export async function probeStream(
   let bytes = 0;
 
   for (;;) {
-    if (chunks.length >= PROBE_MAX_CHUNKS || bytes >= PROBE_MAX_BYTES) {
+    const mayContainSoftFailure =
+      sseHasContent(buffer) && sseMayContainSoftFailure(buffer);
+    if (bytes >= PROBE_MAX_BYTES && mayContainSoftFailure) {
+      const message = 'suspected soft-failure stream exceeded the probe byte limit';
+      await reader.cancel(message).catch(() => undefined);
+      return {
+        hasContent: false,
+        readError: { message, code: 'soft_failure_probe_limit' },
+        reader,
+        chunks,
+      };
+    }
+    if (
+      bytes >= PROBE_MAX_BYTES ||
+      (chunks.length >= PROBE_MAX_CHUNKS && !mayContainSoftFailure)
+    ) {
       return { hasContent: true, reader, chunks };
     }
     let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -165,20 +182,29 @@ export async function probeStream(
       };
     }
     const { done, value } = outcome.result;
-    if (done)
+    if (done) {
+      const softFailure = sseSoftFailureFrame(buffer);
       return {
-        hasContent: sseHasContent(buffer),
-        errorFrame: sseErrorFrame(buffer),
+        hasContent: softFailure ? false : sseHasContent(buffer),
+        errorFrame: softFailure ?? sseErrorFrame(buffer),
         reader,
         chunks,
       };
+    }
     if (!value) continue;
     chunks.push(value);
     bytes += value.byteLength;
     buffer += decoder.decode(value, { stream: true });
+    const softFailure = sseSoftFailureFrame(buffer);
+    if (softFailure) {
+      return { hasContent: false, errorFrame: softFailure, reader, chunks };
+    }
     // Content wins over an error frame in the same buffer: real output already
     // streamed, so relay it and let the relay path record any trailing error.
-    if (sseHasContent(buffer)) return { hasContent: true, reader, chunks };
+    // Hold only the exact prefix of the known soft-failure text.
+    if (sseHasContent(buffer) && !sseMayContainSoftFailure(buffer)) {
+      return { hasContent: true, reader, chunks };
+    }
     const errorFrame = sseErrorFrame(buffer);
     if (errorFrame) return { hasContent: false, errorFrame, reader, chunks };
   }

--- a/packages/llm-gateway/src/usage/completion-guard.test.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from 'bun:test';
-import { jsonHasContent, sseErrorFrame, sseHasContent } from './completion-guard';
+import {
+  jsonHasContent,
+  jsonSoftFailureFrame,
+  sseErrorFrame,
+  sseHasContent,
+  sseMayContainSoftFailure,
+  sseSoftFailureFrame,
+} from './completion-guard';
 import { IncrementalSseScanner } from './sse-scanner';
+
+const RAMP_RATE_MESSAGE =
+  'Request rate increased too quickly. To ensure system stability, please adjust your client logic to scale requests more smoothly over time.';
 
 describe('jsonHasContent', () => {
   test('true for a normal message completion', () => {
@@ -65,6 +75,56 @@ describe('sseHasContent', () => {
 
   test('ignores malformed JSON lines instead of throwing', () => {
     expect(sseHasContent('data: {not json\n\n')).toBe(false);
+  });
+});
+
+describe('soft upstream failures encoded as assistant content', () => {
+  test('classifies the production ramp-rate response in a non-streaming completion', () => {
+    expect(
+      jsonSoftFailureFrame({
+        choices: [{ message: { content: RAMP_RATE_MESSAGE }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 0, completion_tokens: 0 },
+      }),
+    ).toEqual({
+      message: RAMP_RATE_MESSAGE,
+      code: 429,
+      detail: { type: 'soft_rate_limit' },
+    });
+  });
+
+  test('does not classify a user-visible discussion of the same sentence', () => {
+    expect(
+      jsonSoftFailureFrame({
+        choices: [
+          {
+            message: {
+              content: `The provider returned: ${RAMP_RATE_MESSAGE}`,
+            },
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test('holds a streaming prefix until the full failure sentence and stop frame arrive', () => {
+    const prefix =
+      'data: {"choices":[{"delta":{"content":"Request rate increased too quickly."}}]}\n\n';
+    expect(sseMayContainSoftFailure(prefix)).toBe(true);
+    expect(sseSoftFailureFrame(prefix)).toBeNull();
+
+    const complete = `${prefix}data: {"choices":[{"delta":{"content":" To ensure system stability, please adjust your client logic to scale requests more smoothly over time."},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n`;
+    expect(sseSoftFailureFrame(complete)).toEqual({
+      message: RAMP_RATE_MESSAGE,
+      code: 429,
+      detail: { type: 'soft_rate_limit' },
+    });
+  });
+
+  test('releases normal content as soon as it diverges from the failure prefix', () => {
+    const normal =
+      'data: {"choices":[{"delta":{"content":"Request rate increased because traffic doubled."}}]}\n\n';
+    expect(sseMayContainSoftFailure(normal)).toBe(false);
+    expect(sseSoftFailureFrame(normal)).toBeNull();
   });
 });
 

--- a/packages/llm-gateway/src/usage/completion-guard.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.ts
@@ -4,7 +4,13 @@
 // the caller a blank "stop" with no text or tool calls.
 
 interface ChoiceLike {
-  message?: { content?: unknown; tool_calls?: unknown };
+  finish_reason?: unknown;
+  message?: {
+    content?: unknown;
+    tool_calls?: unknown;
+    reasoning?: unknown;
+    reasoning_content?: unknown;
+  };
   delta?: {
     content?: unknown;
     tool_calls?: unknown;
@@ -54,6 +60,115 @@ export interface SseErrorFrame {
    * upstream's extra fields survive without this type having to know them.
    */
   detail?: Record<string, unknown>;
+}
+
+const SOFT_RATE_LIMIT_MESSAGE =
+  'Request rate increased too quickly. To ensure system stability, please adjust your client logic to scale requests more smoothly over time.';
+
+const SOFT_RATE_LIMIT_FRAME: SseErrorFrame = {
+  message: SOFT_RATE_LIMIT_MESSAGE,
+  code: 429,
+  detail: { type: 'soft_rate_limit' },
+};
+
+function hasZeroUsage(data: Record<string, unknown>): boolean {
+  const usage = data.usage;
+  if (!usage || typeof usage !== 'object') return false;
+  const values = Object.entries(usage as Record<string, unknown>)
+    .filter(([key]) => key.endsWith('_tokens') || key === 'total_tokens')
+    .map(([, value]) => value);
+  return values.length > 0 && values.every((value) => value === 0);
+}
+
+/**
+ * Detects the exact OpenRouter ramp-rate rejection that one upstream encodes
+ * as a successful assistant message. Zero usage distinguishes the rejection
+ * from a model that quotes the same text in a real completion.
+ */
+export function jsonSoftFailureFrame(data: unknown): SseErrorFrame | null {
+  if (!data || typeof data !== 'object') return null;
+  const body = data as Record<string, unknown>;
+  if (!hasZeroUsage(body)) return null;
+  const choices = body.choices;
+  if (!Array.isArray(choices) || choices.length !== 1) return null;
+  const choice = choices[0];
+  if (!choice || typeof choice !== 'object') return null;
+  const typedChoice = choice as ChoiceLike;
+  if (typedChoice.finish_reason !== 'stop') return null;
+  if (typedChoice.message?.content !== SOFT_RATE_LIMIT_MESSAGE) return null;
+  if (Array.isArray(typedChoice.message.tool_calls) && typedChoice.message.tool_calls.length > 0) {
+    return null;
+  }
+  return SOFT_RATE_LIMIT_FRAME;
+}
+
+interface SseSoftFailureState {
+  text: string;
+  ended: boolean;
+  incompatibleOutput: boolean;
+}
+
+function sseSoftFailureState(buffer: string): SseSoftFailureState {
+  let text = '';
+  let ended = false;
+  let incompatibleOutput = false;
+
+  for (const line of buffer.split('\n')) {
+    if (!line.startsWith('data:')) continue;
+    const payload = line.slice(5).trim();
+    if (!payload) continue;
+    if (payload === '[DONE]') {
+      ended = true;
+      continue;
+    }
+    try {
+      const chunk = JSON.parse(payload) as { choices?: unknown };
+      if (!Array.isArray(chunk.choices)) continue;
+      for (const rawChoice of chunk.choices) {
+        if (!rawChoice || typeof rawChoice !== 'object') continue;
+        const choice = rawChoice as ChoiceLike;
+        if (typeof choice.finish_reason === 'string') ended = true;
+        const delta = choice.delta;
+        if (!delta) continue;
+        if (typeof delta.content === 'string') {
+          text += delta.content;
+        } else if (delta.content !== undefined && delta.content !== null) {
+          incompatibleOutput = true;
+        }
+        if (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0) {
+          incompatibleOutput = true;
+        }
+        if (
+          (typeof delta.reasoning === 'string' && delta.reasoning.length > 0) ||
+          (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0)
+        ) {
+          incompatibleOutput = true;
+        }
+      }
+    } catch {
+      // A partial or malformed data line cannot confirm this exact signature.
+    }
+  }
+  return { text, ended, incompatibleOutput };
+}
+
+/**
+ * Returns true while the buffered assistant text remains an exact prefix of
+ * the known soft rate-limit rejection. The stream probe holds these bytes.
+ */
+export function sseMayContainSoftFailure(buffer: string): boolean {
+  const state = sseSoftFailureState(buffer);
+  if (state.incompatibleOutput) return false;
+  return SOFT_RATE_LIMIT_MESSAGE.startsWith(state.text);
+}
+
+/** Detects the complete soft rate-limit rejection in an SSE completion. */
+export function sseSoftFailureFrame(buffer: string): SseErrorFrame | null {
+  const state = sseSoftFailureState(buffer);
+  if (state.incompatibleOutput || !state.ended || state.text !== SOFT_RATE_LIMIT_MESSAGE) {
+    return null;
+  }
+  return SOFT_RATE_LIMIT_FRAME;
 }
 
 /** First in-stream error frame in an SSE buffer, if any. OpenRouter (and other

--- a/packages/llm-gateway/src/usage/index.ts
+++ b/packages/llm-gateway/src/usage/index.ts
@@ -4,7 +4,14 @@ export type { ExtractedUsage } from './extract';
 export { calculateCost } from './pricing';
 export type { CostBreakdown, TokenUsage } from './pricing';
 
-export { jsonHasContent, sseErrorFrame, sseHasContent } from './completion-guard';
+export {
+  jsonHasContent,
+  jsonSoftFailureFrame,
+  sseErrorFrame,
+  sseHasContent,
+  sseMayContainSoftFailure,
+  sseSoftFailureFrame,
+} from './completion-guard';
 export type { SseErrorFrame } from './completion-guard';
 
 export { IncrementalSseScanner } from './sse-scanner';


### PR DESCRIPTION
## Root cause

- OpenRouter returned HTTP 200 with a rate-limit sentence as assistant content and zero usage.
- The gateway accepted that response as a successful completion.
- OpenCode persisted the sentence with finish=stop and executed zero tools.
- A separate failed session loaded a corrupted Axios module from a stale node_modules tree.

## Fix

- Detect the exact zero-usage soft rate-limit completion.
- Hold matching SSE prefixes before sending bytes.
- Retry each invalid candidate three times with rate-limit backoff.
- Fail over before returning a structured HTTP 429 after total exhaustion.
- Validate the OpenCode dependency lock before reusing baked modules.
- Install mismatched dependencies in staging and atomically replace node_modules.
- Remove stale modules after installation failure.

## Verification

- pnpm --filter @kortix/llm-gateway --filter @kortix/sandbox-agent-server test
  - gateway: 351 passed, 0 failed
  - sandbox agent: 333 passed, 0 failed
- pnpm --filter @kortix/llm-gateway --filter @kortix/sandbox-agent-server typecheck
  - exit 0
- pnpm --filter @kortix/sandbox-agent-server build
  - Built dist/kortix-agent for bun-linux-x64
- Disposable local session smoke
  - project: 17014455-f089-477c-b9ae-3a5356226e2c
  - session: bf1b71e8-76f8-4993-be1a-04badbe29898
  - OpenCode session: ses_050f2034bffe5jIAKbbPciHkP6
  - result: 25 passed, 0 failed
  - assistant text: PONG
- git diff --check
  - exit 0