### PR TITLE
fix(sdk): isolate preassigned OpenCode session state

### DIFF
--- a/apps/api/src/llm-gateway/sandbox-base-url.test.ts
+++ b/apps/api/src/llm-gateway/sandbox-base-url.test.ts
@@ -41,17 +41,17 @@ describe('resolveLlmGatewayBaseUrl', () => {
     );
   });
 
-  test('proxy mode (LLM_GATEWAY_PROXY_PORT set): {origin}/v1/llm-gateway', () => {
+  test('proxy mode includes the standalone gateway OpenAI v1 prefix', () => {
     config.LLM_GATEWAY_PROXY_PORT = 8090;
     expect(resolveLlmGatewayBaseUrl('http://kortix-api:8008')).toBe(
-      'http://kortix-api:8008/v1/llm-gateway',
+      'http://kortix-api:8008/v1/llm-gateway/v1',
     );
   });
 
   test('proxy mode via LLM_GATEWAY_PROXY_TARGET (K8s-style) takes the same branch', () => {
     config.LLM_GATEWAY_PROXY_TARGET = 'llm-gateway:8090';
     expect(resolveLlmGatewayBaseUrl('https://api.example.com')).toBe(
-      'https://api.example.com/v1/llm-gateway',
+      'https://api.example.com/v1/llm-gateway/v1',
     );
   });
 

--- a/apps/api/src/llm-gateway/sandbox-base-url.ts
+++ b/apps/api/src/llm-gateway/sandbox-base-url.ts
@@ -24,6 +24,9 @@ import { config } from '../config';
 export function resolveLlmGatewayBaseUrl(origin: string): string {
   if (config.LLM_GATEWAY_BASE_URL) return config.LLM_GATEWAY_BASE_URL;
   const trimmedOrigin = origin.replace(/\/+$/, '');
-  const llmProxyMode = config.LLM_GATEWAY_PROXY_PORT || config.LLM_GATEWAY_PROXY_TARGET;
-  return llmProxyMode ? `${trimmedOrigin}/v1/llm-gateway` : `${trimmedOrigin}/v1/llm`;
+  const llmProxyMode =
+    config.LLM_GATEWAY_PROXY_PORT || config.LLM_GATEWAY_PROXY_TARGET;
+  return llmProxyMode
+    ? `${trimmedOrigin}/v1/llm-gateway/v1`
+    : `${trimmedOrigin}/v1/llm`;
 }

--- a/apps/web/content/docs/sdk/sessions.mdx
+++ b/apps/web/content/docs/sdk/sessions.mdx
@@ -21,19 +21,20 @@ ID, and the branch name are the same value. See
 
 ## Session lifecycle
 
-| Method | Wraps | What it does |
-|---|---|---|
-| `s.get(opts?)` | `GET /projects/:pid/sessions/:sid` | Reads session details |
-| `s.update(input)` | `PATCH …/sessions/:sid` | Renames the session or updates metadata |
-| `s.start(waitMs?)` | `POST …/sessions/:sid/start` | Provisions and boots the runtime |
-| `s.restart()` | `POST …/sessions/:sid/restart` | Restarts the runtime; keeps the same sandbox |
-| `s.stop()` | `POST …/sessions/:sid/stop` | Stops the runtime; the session stays |
-| `s.delete()` | `DELETE …/sessions/:sid` | Deletes the session |
-| `s.setSharing(intent)` | `PUT …/sharing` | Sets sharing and visibility |
-| `s.commit(input?)` | — | Commits the agent's work |
+| Method                 | Wraps                              | What it does                                 |
+| ---------------------- | ---------------------------------- | -------------------------------------------- |
+| `s.get(opts?)`         | `GET /projects/:pid/sessions/:sid` | Reads session details                        |
+| `s.update(input)`      | `PATCH …/sessions/:sid`            | Renames the session or updates metadata      |
+| `s.start(waitMs?)`     | `POST …/sessions/:sid/start`       | Provisions and boots the runtime             |
+| `s.restart()`          | `POST …/sessions/:sid/restart`     | Restarts the runtime; keeps the same sandbox |
+| `s.stop()`             | `POST …/sessions/:sid/stop`        | Stops the runtime; the session stays         |
+| `s.delete()`           | `DELETE …/sessions/:sid`           | Deletes the session                          |
+| `s.setSharing(intent)` | `PUT …/sharing`                    | Sets sharing and visibility                  |
+| `s.commit(input?)`     | —                                  | Commits the agent's work                     |
 
 <Callout type="warn">
-  `s.delete()` deletes the session and its runtime. This cannot be undone. To pause a session without losing it, call `s.stop()` instead.
+  `s.delete()` deletes the session and its runtime. This cannot be undone. To pause a session
+  without losing it, call `s.stop()` instead.
 </Callout>
 
 Three more read methods round out the handle:
@@ -58,6 +59,27 @@ On a cold boot, `ensureReady()` can throw `RUNTIME_UNAVAILABLE`. See
 retry.
 
 `s.send()` and `s.abort()` call `ensureReady()` for you.
+
+### Seed a server-authorized OpenCode pin
+
+A server-rendered React host can supply the OpenCode pin already persisted for
+the same Kortix session:
+
+```tsx
+const session = useSession(projectId, sessionId, {
+  initialOpenCodeSessionId: persistedSession.opencode_session_id,
+});
+```
+
+The seed only hydrates cached transcript content while `/start` runs. It does
+not override the runtime identity. The pin returned by `/start` is
+authoritative and replaces a stale seed.
+
+Do not accept this value from an untrusted tenant selector. Do not create an
+OpenCode session in the host. Kortix creates and persists the root session.
+OpenCode query caches and transcript controllers are scoped to the sandbox
+runtime, so equal OpenCode ids from different sandboxes do not share cache
+entries.
 
 ## Send a prompt
 
@@ -88,11 +110,11 @@ run without deleting the session.
 
 ## Runtime status and previews
 
-| Method | Returns | Use |
-|---|---|---|
-| `s.health(init?)` | `{ status, ok, health, body }` | Check whether the runtime is alive |
-| `s.previewUrl(port, path?)` | `string` | Get a proxy URL for a port the agent exposed |
-| `s.proxyUrl(url?)` | `string \| undefined` | Rewrite a localhost URL the agent printed |
+| Method                      | Returns                        | Use                                          |
+| --------------------------- | ------------------------------ | -------------------------------------------- |
+| `s.health(init?)`           | `{ status, ok, health, body }` | Check whether the runtime is alive           |
+| `s.previewUrl(port, path?)` | `string`                       | Get a proxy URL for a port the agent exposed |
+| `s.proxyUrl(url?)`          | `string \| undefined`          | Rewrite a localhost URL the agent printed    |
 
 ```ts
 const { ok, health } = await s.health();
@@ -161,15 +183,15 @@ exports.
 Each event has a `type` and a `properties` object that holds its data, for
 example `event.properties.sessionID`.
 
-| `type` | When it fires |
-| --- | --- |
-| `message.updated` / `message.removed` | A message changed or was deleted. |
+| `type`                                          | When it fires                                       |
+| ----------------------------------------------- | --------------------------------------------------- |
+| `message.updated` / `message.removed`           | A message changed or was deleted.                   |
 | `message.part.updated` / `message.part.removed` | A part (text, tool call, file) grew or was removed. |
-| `session.status` | The session's busy state changed. |
-| `session.idle` | The turn finished. |
-| `session.error` | The turn failed. The event carries the error. |
-| `question.asked` | The agent asked for input. |
-| `question.replied` / `question.rejected` | The answer to a question arrived. |
+| `session.status`                                | The session's busy state changed.                   |
+| `session.idle`                                  | The turn finished.                                  |
+| `session.error`                                 | The turn failed. The event carries the error.       |
+| `question.asked`                                | The agent asked for input.                          |
+| `question.replied` / `question.rejected`        | The answer to a question arrived.                   |
 
 Turn raw messages and parts into renderable output with `classifyTurn`. See
 [SDK reference](/docs/sdk/reference).
@@ -287,13 +309,13 @@ try {
 
 ### Error classes
 
-| Class | Extends | When it throws | Key fields |
-|---|---|---|---|
-| `ApiError` | `Error` | Default for any failed request: bad status, network failure, timeout, or abort | `status`, `code`, `detail`, `response`, `url`, `endpoint`, `timeout` |
-| `AuthError` | `ApiError` | `getToken` returned `null`. Kortix never sent the request | `code` is always `'NO_SESSION'` |
-| `BillingError` | `Error` | HTTP `402`. The only billing error class | `status` (`402`), `detail.message` |
-| `RequestTooLargeError` | `Error` | HTTP `431`. Usually too many files in one request | `detail.suggestion` |
-| `SessionNotReadyError` | `Error` | A runtime accessor ran before `ensureReady()` | `name` is `'SessionNotReadyError'` |
+| Class                  | Extends    | When it throws                                                                 | Key fields                                                           |
+| ---------------------- | ---------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `ApiError`             | `Error`    | Default for any failed request: bad status, network failure, timeout, or abort | `status`, `code`, `detail`, `response`, `url`, `endpoint`, `timeout` |
+| `AuthError`            | `ApiError` | `getToken` returned `null`. Kortix never sent the request                      | `code` is always `'NO_SESSION'`                                      |
+| `BillingError`         | `Error`    | HTTP `402`. The only billing error class                                       | `status` (`402`), `detail.message`                                   |
+| `RequestTooLargeError` | `Error`    | HTTP `431`. Usually too many files in one request                              | `detail.suggestion`                                                  |
+| `SessionNotReadyError` | `Error`    | A runtime accessor ran before `ensureReady()`                                  | `name` is `'SessionNotReadyError'`                                   |
 
 `ApiError.name` is `'ApiError'` by default. Two cases override it:
 
@@ -335,10 +357,10 @@ Call `await session.ensureReady()` first, or call `send()`, which readies the se
 
 ### Helpers
 
-| Helper | Signature | What it does |
-|---|---|---|
-| `parseBillingError(error)` | `(error) => Error` | Wraps a `402` response into a `BillingError`. Returns other errors unchanged |
-| `isBillingError(error)` | `(error) => boolean` | Returns `error instanceof BillingError` |
+| Helper                           | Signature                           | What it does                                                                                                  |
+| -------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `parseBillingError(error)`       | `(error) => Error`                  | Wraps a `402` response into a `BillingError`. Returns other errors unchanged                                  |
+| `isBillingError(error)`          | `(error) => boolean`                | Returns `error instanceof BillingError`                                                                       |
 | `formatBillingErrorForUI(error)` | `(error) => BillingErrorUI \| null` | Returns `null` for non-billing errors. Otherwise returns `{ alertTitle, alertSubtitle }` for an upgrade modal |
 
 ```ts

--- a/docs/specs/2026-07-29-session-start-latency-and-acp-architecture.md
+++ b/docs/specs/2026-07-29-session-start-latency-and-acp-architecture.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-07-29
 
-**Status:** Measured baseline, cache A/B, selected-harness refactor, and target
-architecture
+**Status:** Measured baseline, canonical ACP starter, selected-harness
+refactor, and target architecture
 
 **Scope:** Daytona, Platinum, local, dev, production, OpenCode, Pi, ACP, and
 repository materialization
@@ -24,6 +24,20 @@ The measured cold path performs two expensive operations:
 2. It starts and initializes a cold OpenCode process.
 
 The sub-one-second target requires both operations to leave the claim path.
+
+New blank projects use one canonical starter:
+
+1. The starter ID is `general-knowledge-worker`.
+2. The manifest uses `kortix_version: 3`.
+3. OpenCode is the default logical agent.
+4. Claude Code, Codex, and Pi are selectable logical agents.
+5. Project creation enables `experimental.acp_runtime`.
+6. The retired `acp-multi-harness` ID maps to the canonical starter.
+
+This consolidation does not reduce provider startup latency by itself.
+
+It makes every new project compatible with commit artifacts and stateful
+runtime slots. It also removes starter selection from the boot architecture.
 
 The multi-harness implementation on `origin/main` had a third problem.
 
@@ -898,6 +912,54 @@ The target budgets are:
 The implementation must pass the stateful restore tests in section 10.5.
 
 A `/kortix/health` response does not prove ACP, PTY, or event-stream liveness.
+
+## 21. Canonical starter and fast-boot contract
+
+`general-knowledge-worker` is the only user starter.
+
+The API and web creation paths use this ID for every blank project.
+
+The CLI creates the same starter without a starter selector.
+
+`minimal` remains an internal base for marketplace project composition.
+
+The retired `acp-multi-harness` input remains an API and SDK compatibility
+alias. The starter loader normalizes it to `general-knowledge-worker`.
+
+The canonical scaffold is also the deterministic snapshot scaffold.
+
+Its rendered repository root remains the input to `stageScaffoldRepo()`.
+
+This preserves the exact-scaffold repository reuse path.
+
+The default agent is `opencode`.
+
+The selected logical agent determines the harness:
+
+| logical agent | runtime profile | harness |
+|---|---|---|
+| `opencode` | `opencode` | OpenCode ACP |
+| `claude` | `claude` | Claude Code ACP |
+| `codex` | `codex` | Codex ACP |
+| `pi` | `pi` | Pi ACP |
+
+All four paths use the same ACP lifecycle boundary.
+
+The fast-boot implementation must key artifacts by commit, runtime digest,
+configuration digest, and selected harness.
+
+The starter consolidation does not enable stateful restore.
+
+The current measured session-ready p50 values remain:
+
+| path | p50 |
+|---|---:|
+| Pi with Daytona repository disk snapshot | 7.784 s |
+| Pi with Platinum exact-commit repository disk image | 9.462 s |
+| Pi with Platinum cold disk snapshot | 12.823 s |
+| OpenCode ACP with Platinum cold disk snapshot | 16.298 s |
+
+The target remains 300 ms p50 and 950 ms p95 for a warm exact-commit claim.
 
 ## 21. Persisted benchmark assets
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -3967,6 +3967,22 @@ Live local acceptance:
 - Each transcript contained only its own three assistant markers.
 - Fixture cleanup left zero projects and zero users.
 
+Rebased local acceptance on `origin/main` `d627167f`:
+
+- Evidence:
+  `tests/performance/session-start/results/2026-07-29/opencode-fork-isolation-local-platinum-rebased.json`.
+- The smoke converted the canonical version 3 starter into a disposable
+  version 2 OpenCode REST fixture through a temporary project-scoped PAT.
+- Result: `PASS 2/2` on Platinum.
+- Create-to-ready: `21.758 s` and `23.266 s`.
+- `/start` returned distinct OpenCode roots:
+  `ses_050be4bb6ffepNq9BLE8kdybL9` and
+  `ses_050be472cffeLbJ7ciXGs8smOL`.
+- The public SDK matched both authoritative `/start` roots.
+- Restart preserved both roots.
+- Each assistant transcript contained only its own three markers.
+- Fixture cleanup left zero projects and zero users.
+
 **Status:** COMPLETE.
 
 **SDK package shippable to production: YES.**

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -3913,6 +3913,63 @@ Scope:
 - Prove two sandboxes restored from one snapshot receive distinct OpenCode IDs.
 
 The required `tdd` skill is unavailable in this session.
-The implementation will use the same RED, GREEN, and REFACTOR sequence directly.
+The implementation used the same RED, GREEN, and REFACTOR sequence directly.
 
-**Status:** IN PROGRESS.
+TDD evidence:
+
+- IndexedDB scope RED: the focused test failed because
+  `idb-sync-cache-key` did not exist.
+- IndexedDB scope GREEN: `3 pass`, `0 fail`.
+- Transcript ownership RED: the focused test failed because
+  `resolveSessionCacheOwnerScope` did not exist.
+- Transcript ownership GREEN: `4 pass`, `0 fail`.
+- Runtime switch gate RED: the focused source contract found no sandbox-switch
+  gates in `useSession`.
+- Runtime switch gate GREEN: the focused source contract passed.
+- Runtime-action gate RED: the focused test failed because
+  `isSessionRuntimeActionReady` did not exist.
+- Runtime-action gate GREEN: the focused test passed.
+
+Final SDK gates:
+
+- `pnpm --filter @kortix/sdk typecheck`: exit `0`.
+- `pnpm --filter @kortix/sdk test`: `1381 pass`, `0 fail`, `5970`
+  assertions.
+- `pnpm --filter @kortix/sdk run smoke:install`: the packed tarball installed,
+  imported, and constructed successfully.
+- The public export snapshot did not change.
+
+Related repository gates:
+
+- Starter typecheck: exit `0`.
+- Starter tests: `51 pass`, `0 fail`.
+- CLI typecheck: exit `0`.
+- CLI tests: `553 pass`, `0 fail`.
+- API typecheck: exit `0`.
+- API focused tests: gateway base URL `6 pass`; starter create-repo `12 pass`;
+  provision `10 pass`; scaffold identity `1 pass` with `182` assertions;
+  project-session contract `45 pass` with `363` assertions.
+- Web focused tests: `27 pass`, `0 fail`.
+- Web focused ESLint: exit `0`.
+
+Live local acceptance:
+
+- Evidence:
+  `tests/performance/session-start/results/2026-07-29/opencode-fork-isolation-local-platinum.json`.
+- Provider: Platinum.
+- Result: `PASS 2/2`.
+- Create-to-ready: `21.460 s` and `23.736 s`.
+- `/start` returned distinct OpenCode roots:
+  `ses_050ddca47ffe4r8L0yDak7Fiar` and
+  `ses_050ddd663ffe159AjQGlKxefsg`.
+- `createKortix().session().ensureReady()` matched each `/start` root.
+- Restart preserved each root.
+- Each transcript contained only its own three assistant markers.
+- Fixture cleanup left zero projects and zero users.
+
+**Status:** COMPLETE.
+
+**SDK package shippable to production: YES.**
+
+**Repository delivery shippable to production: NOT YET.** PR merge, Deploy Dev,
+deployed SHA proof, and deployed isolation verification remain.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -3898,3 +3898,21 @@ Final SDK gates:
 
 **Repository delivery shippable to production: NOT YET.** PR merge, Deploy Dev,
 deployed SHA proof, and deployed four-harness verification remain.
+
+---
+
+### 2026-07-29 — session `generic-acp-session-identity` SDK claim
+
+Claimed the preassigned OpenCode session identity compatibility task.
+
+Scope:
+
+- Treat the `/start` response as the authoritative runtime identity.
+- Keep `initialOpenCodeSessionId` as a backward-compatible cache seed.
+- Prevent SDK caches from crossing Kortix `(projectId, sessionId)` boundaries.
+- Prove two sandboxes restored from one snapshot receive distinct OpenCode IDs.
+
+The required `tdd` skill is unavailable in this session.
+The implementation will use the same RED, GREEN, and REFACTOR sequence directly.
+
+**Status:** IN PROGRESS.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -24,9 +24,12 @@ npm install @kortix/sdk
 ```
 
 ```ts
-import { createKortix } from '@kortix/sdk';
+import { createKortix } from "@kortix/sdk";
 
-const kortix = createKortix({ backendUrl: 'https://api.kortix.com/v1', getToken });
+const kortix = createKortix({
+  backendUrl: "https://api.kortix.com/v1",
+  getToken,
+});
 await kortix.projects.list();
 ```
 
@@ -53,10 +56,10 @@ no build step required:
 `@kortix/sdk` is the canonical entry — everything framework-free lives there.
 Three others exist, each for a reason that fits in one sentence:
 
-| Entry | Why it can't live at root |
-|---|---|
-| `@kortix/sdk/react` | React is a peer dependency |
-| `@kortix/sdk/server` | imports `node:async_hooks` |
+| Entry                    | Why it can't live at root   |
+| ------------------------ | --------------------------- |
+| `@kortix/sdk/react`      | React is a peer dependency  |
+| `@kortix/sdk/server`     | imports `node:async_hooks`  |
 | `@kortix/sdk/internal/*` | unsupported, outside semver |
 
 Older subpaths (`@kortix/sdk/projects-client`, `/turns`, …) still work and are
@@ -70,27 +73,34 @@ table for the full list (20 of them).
 ## Quick start
 
 ```ts
-import { createKortix } from '@kortix/sdk';
+import { createKortix } from "@kortix/sdk";
 
 const kortix = createKortix({
-  backendUrl: 'https://api.kortix.com/v1',
-  getToken: () => supabase.auth.getSession().then(s => s.data.session?.access_token ?? null),
+  backendUrl: "https://api.kortix.com/v1",
+  getToken: () =>
+    supabase.auth
+      .getSession()
+      .then((s) => s.data.session?.access_token ?? null),
 });
 
 // Projects
 const projects = await kortix.projects.list();
-const detail   = await kortix.project(pid).detail();
-await kortix.project(pid).secrets.upsert({ name: 'STRIPE_API_KEY', value });
+const detail = await kortix.project(pid).detail();
+await kortix.project(pid).secrets.upsert({ name: "STRIPE_API_KEY", value });
 const visibleSessions = await kortix.project(pid).sessions.list();
-const projectInventory = await kortix.project(pid).sessions.list({ scope: 'project' }); // manager only
+const projectInventory = await kortix
+  .project(pid)
+  .sessions.list({ scope: "project" }); // manager only
 const warm = await kortix.project(pid).sessions.ensureWarm();
-await kortix.project(pid).sessions.claimWarm({ session_id: warm.session.session_id });
+await kortix
+  .project(pid)
+  .sessions.claimWarm({ session_id: warm.session.session_id });
 
 // Sessions (id-bound handle)
 const s = kortix.session(pid, sid);
-await s.send('Build me a widget');   // provisions/resumes if needed, then prompts
-await s.rewind(userMessageId);        // stages a reversible rollback on this session
-await s.restoreRewind();              // restores the removed path before the next prompt
+await s.send("Build me a widget"); // provisions/resumes if needed, then prompts
+await s.rewind(userMessageId); // stages a reversible rollback on this session
+await s.restoreRewind(); // restores the removed path before the next prompt
 await s.previews();
 
 // Lower level: the typed OpenCode REST compatibility client for THIS sandbox.
@@ -115,21 +125,36 @@ not construct ACP routes or branch on `runtime_harness`.
 `acp_session_id`. Restart and resume keep that identity. Disable `acp_runtime`
 to use OpenCode REST for new compatible sessions.
 
+A server-rendered host can seed a known OpenCode pin while `/start` runs:
+
+```tsx
+useSession(projectId, sessionId, {
+  initialOpenCodeSessionId: persistedSession.opencode_session_id,
+});
+```
+
+Use only a pin that the host authorized for the same `(projectId, sessionId)`.
+The seed hydrates cached content. It does not choose the runtime identity.
+The pin returned by `/start` always replaces a stale seed. The SDK also scopes
+OpenCode query and synchronization controllers to the sandbox runtime. Two
+sandboxes cannot share browser cache state when a snapshot exposes the same
+OpenCode id during adoption.
+
 ## The facade surface
 
 `createKortix(config)` returns one client. The table below is illustrative, not
 exhaustive — see `API-MAP.md` for the full per-domain surface:
 
-| namespace | what |
-|---|---|
-| `kortix.projects` | list · get · detail · create · provision · update · archive · llmCatalog · modelPicker · sandboxTemplates · sessions (+ more: `listForAccount`, `sandboxHealth`, `createSession`) |
-| `kortix.accounts` | list · get · create · members · invites · `tokens.{list,create,revoke}` (account-scoped CLI PATs, `kortix_pat_…`) · `audit.{log,export,webhooks.*}` (Enterprise audit trail) (+ more: `updateName`, `leave`, `invite`, `removeMember`, `updateMemberRole`) |
-| `kortix.billing` | entitlement/usage reads: `accountState` · `accountStateMinimal` · `transactions` · `transactionsSummary` · `creditBreakdown` · `usageHistory` · `tierConfigurations` — plus a curated mutation surface: `checkout.{createSession,confirmSession}` · `subscription.{createPortalSession,cancel,reactivate,scheduleDowngrade,cancelScheduledChange,prorationPreview}` · `credits.{purchase,autoTopupSettings,configureAutoTopup}` |
-| `kortix.marketplace` | public marketplace catalog browse + sources (not project-scoped): `items` · `item` · `itemFile` · `marketplaces` · `featured` · `sources.{list,add,remove}` — distinct from the install-scoped `project(id).marketplace` |
-| `kortix.validateToken()` | pasted-API-key validation helper — `GET /accounts/me`, never throws, resolves `{valid, identity?, error?}` |
-| `kortix.project(id)` | id-bound handle: `.secrets` · `.access` · `.connectors` · `.policies` · `.triggers` · `.files` · `.git` · `.changeRequests` (incl. `requestChanges`) · `.sessions` · `.tokens` (project-scoped CLI PATs — the `KORTIX_TOKEN` shape) · `.marketplace` / `.registry` (install/update/remove catalog items) · `.setupLinks.{requestSecret,requestConnector}` (agent-minted secret-entry / connector links) · `.validateManifest` · `.gitToken` · `.setDefaultAgent(name)` · `.session(sid)` (+ more namespaces: `.review`, `.approvals`, `.gateway` (incl. `.routing` and `.playground`), `.channels`, `.modelDefaults`, `.sandbox`) |
-| `kortix.session(pid, sid)` | id-bound handle: lifecycle (`get`/`update`/`delete`/`start`/`restart`/`stop`/`setSharing`/`previews`/`commit`/`publicShares`/`ensureReady`) · `send`/`abort`/`rewind`/`restoreRewind`/`setModel`/`setAgent` · `transcript()` · `.files` · runtime URL helpers (`health`/`previewUrl`/`proxyUrl`) · OpenCode REST compatibility escape hatches: `stream()` and `.runtime` |
-| `kortix.runtime()` | the OpenCode v2 compatibility client for the active sandbox; use a session-scoped handle in multi-tenant code |
+| namespace                  | what                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kortix.projects`          | list · get · detail · create · provision · update · archive · llmCatalog · modelPicker · sandboxTemplates · sessions (+ more: `listForAccount`, `sandboxHealth`, `createSession`)                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `kortix.accounts`          | list · get · create · members · invites · `tokens.{list,create,revoke}` (account-scoped CLI PATs, `kortix_pat_…`) · `audit.{log,export,webhooks.*}` (Enterprise audit trail) (+ more: `updateName`, `leave`, `invite`, `removeMember`, `updateMemberRole`)                                                                                                                                                                                                                                                                                                                                                                        |
+| `kortix.billing`           | entitlement/usage reads: `accountState` · `accountStateMinimal` · `transactions` · `transactionsSummary` · `creditBreakdown` · `usageHistory` · `tierConfigurations` — plus a curated mutation surface: `checkout.{createSession,confirmSession}` · `subscription.{createPortalSession,cancel,reactivate,scheduleDowngrade,cancelScheduledChange,prorationPreview}` · `credits.{purchase,autoTopupSettings,configureAutoTopup}`                                                                                                                                                                                                   |
+| `kortix.marketplace`       | public marketplace catalog browse + sources (not project-scoped): `items` · `item` · `itemFile` · `marketplaces` · `featured` · `sources.{list,add,remove}` — distinct from the install-scoped `project(id).marketplace`                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `kortix.validateToken()`   | pasted-API-key validation helper — `GET /accounts/me`, never throws, resolves `{valid, identity?, error?}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `kortix.project(id)`       | id-bound handle: `.secrets` · `.access` · `.connectors` · `.policies` · `.triggers` · `.files` · `.git` · `.changeRequests` (incl. `requestChanges`) · `.sessions` · `.tokens` (project-scoped CLI PATs — the `KORTIX_TOKEN` shape) · `.marketplace` / `.registry` (install/update/remove catalog items) · `.setupLinks.{requestSecret,requestConnector}` (agent-minted secret-entry / connector links) · `.validateManifest` · `.gitToken` · `.setDefaultAgent(name)` · `.session(sid)` (+ more namespaces: `.review`, `.approvals`, `.gateway` (incl. `.routing` and `.playground`), `.channels`, `.modelDefaults`, `.sandbox`) |
+| `kortix.session(pid, sid)` | id-bound handle: lifecycle (`get`/`update`/`delete`/`start`/`restart`/`stop`/`setSharing`/`previews`/`commit`/`publicShares`/`ensureReady`) · `send`/`abort`/`rewind`/`restoreRewind`/`setModel`/`setAgent` · `transcript()` · `.files` · runtime URL helpers (`health`/`previewUrl`/`proxyUrl`) · OpenCode REST compatibility escape hatches: `stream()` and `.runtime`                                                                                                                                                                                                                                                          |
+| `kortix.runtime()`         | the OpenCode v2 compatibility client for the active sandbox; use a session-scoped handle in multi-tenant code                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 
 Runnable, self-contained scripts for the highest-value flows live in
 [`examples/`](./examples): list projects with a PAT, send + stream, the
@@ -144,7 +169,7 @@ to the agent only as one `KORTIX_SESSION_CONTEXT` JSON envelope:
 
 ```ts
 await kortix.project(projectId).sessions.create({
-  runtime_context: { workspace_id: 'org_123', locale: 'de' },
+  runtime_context: { workspace_id: "org_123", locale: "de" },
 });
 ```
 
@@ -155,27 +180,27 @@ credential endpoint, and pass only the non-secret profile id at session create:
 ```ts
 const project = kortix.project(projectId);
 const profile = await project.connectors.profiles.reconcile({
-  connector_alias: 'customer-data',
-  owner_type: 'external',
+  connector_alias: "customer-data",
+  owner_type: "external",
   owner_id: wrapperUserId,
-  label: 'Customer data',
+  label: "Customer data",
   metadata: { tenant_ref: wrapperTenantReference },
 });
 
 // Omit `auth` when creating to apply source-advertised authentication.
 const auth = await project.connectors.auth.discover({
-  slug: 'hubspot',
-  provider: 'postman',
-  spec: 'https://github.com/HubSpot/HubSpot-public-api-spec-collection',
+  slug: "hubspot",
+  provider: "postman",
+  spec: "https://github.com/HubSpot/HubSpot-public-api-spec-collection",
 });
 await project.connectors.profiles.updateCredential(profile.profile_id, {
   value: shortLivedCapability,
-  kind: 'secret',
+  kind: "secret",
 });
 await project.sessions.create({
-  runtime_context: { locale: 'de' },
+  runtime_context: { locale: "de" },
   connector_bindings: {
-    'customer-data': { profile_id: profile.profile_id },
+    "customer-data": { profile_id: profile.profile_id },
   },
 });
 ```
@@ -186,8 +211,8 @@ token:
 
 ```ts
 const profile = await project.connectors.profiles.reconcileMember({
-  connector_alias: 'gmail',
-  label: 'My Gmail',
+  connector_alias: "gmail",
+  label: "My Gmail",
 });
 await project.connectors.profiles.pipedreamConnect(profile.profile_id);
 // Complete OAuth, then:
@@ -243,12 +268,12 @@ in-flight request.
 it statically imports `node:async_hooks`) fixes this with `AsyncLocalStorage`:
 
 ```ts
-import { createScopedKortix } from '@kortix/sdk/server';
+import { createScopedKortix } from "@kortix/sdk/server";
 
 // Express/Hono/Bun.serve — any per-request handler. One scoped client PER
 // REQUEST; each end user's token stays isolated to that request's own async
 // call tree, even across `await`s, even under concurrency.
-app.get('/projects', async (req, res) => {
+app.get("/projects", async (req, res) => {
   const kortix = createScopedKortix({
     backendUrl: process.env.KORTIX_API_URL!,
     getToken: async () => resolveKortixTokenFor(req), // per-end-user PAT/token
@@ -264,7 +289,7 @@ it never writes the process-global singleton. For middleware-style wrapping of
 an entire request body instead, use the lower-level primitive:
 
 ```ts
-import { runWithKortix } from '@kortix/sdk/server';
+import { runWithKortix } from "@kortix/sdk/server";
 
 app.use(async (req, res, next) => {
   await runWithKortix(
@@ -295,8 +320,8 @@ renderer for **every** part kind at compile time, so a new part type is a
 build error at your call site instead of a silent drop in production:
 
 ```tsx
-import { renderParts, type PartRenderers } from '@kortix/sdk/react';
-import { classifyTurn } from '@kortix/sdk/turns';
+import { renderParts, type PartRenderers } from "@kortix/sdk/react";
+import { classifyTurn } from "@kortix/sdk/turns";
 
 const renderers: PartRenderers<React.ReactNode> = {
   text: (p) => <Markdown>{p.text}</Markdown>,
@@ -307,16 +332,21 @@ const renderers: PartRenderers<React.ReactNode> = {
   patch: (p) => <DiffStat files={p.fileCount} />,
   retry: (p) => <Note>{`retrying (attempt ${p.attempt})`}</Note>,
   compaction: () => <Note>context compacted</Note>,
-  snapshot: () => null,  // internal checkpoint hash — nothing to show
-  agent: () => null,     // inline @mention, already in the sibling text
-  step: () => null,      // model-step bookkeeping
-  unknown: () => null,   // forward-compat: newer server than client
+  snapshot: () => null, // internal checkpoint hash — nothing to show
+  agent: () => null, // inline @mention, already in the sibling text
+  step: () => null, // model-step bookkeeping
+  unknown: () => null, // forward-compat: newer server than client
 };
 
 function Turn({ message }: { message: MessageWithParts }) {
   const { parts, error, isEmpty } = classifyTurn(message);
   if (isEmpty && !error) return null;
-  return <>{renderParts(parts, renderers)}{error && <TurnFailed {...error} />}</>;
+  return (
+    <>
+      {renderParts(parts, renderers)}
+      {error && <TurnFailed {...error} />}
+    </>
+  );
 }
 ```
 
@@ -355,17 +385,19 @@ The canonical server-side wrapper shape — catch a 402 and pass the payload
 through to your own client for re-billing, instead of leaking a Kortix error:
 
 ```ts
-import { ApiError, AuthError, BillingError } from '@kortix/sdk';
+import { ApiError, AuthError, BillingError } from "@kortix/sdk";
 
 try {
   await kortix.session(pid, sid).send(prompt);
 } catch (err) {
   if (err instanceof BillingError) {
     // 402 — surface the upgrade/cost payload under YOUR billing story.
-    return res.status(402).json({ reason: 'quota', detail: err.detail });
+    return res.status(402).json({ reason: "quota", detail: err.detail });
   }
-  if (err instanceof AuthError) return res.status(401).json({ error: 'not authenticated' });
-  if (err instanceof ApiError) return res.status(err.status ?? 502).json({ error: err.message });
+  if (err instanceof AuthError)
+    return res.status(401).json({ error: "not authenticated" });
+  if (err instanceof ApiError)
+    return res.status(err.status ?? 502).json({ error: err.message });
   throw err;
 }
 ```
@@ -388,19 +420,19 @@ Stable, tree-shakeable surfaces (also reachable via the facade). Not exhaustive
 `./sandbox-connection-store`, `./opencode-pending-store`, `./session/url`,
 `./idb-sync-cache`):
 
-| import | provides |
-|---|---|
-| `@kortix/sdk` | `createKortix`, `configureKortix`, `files`, the error classes, `classifyPart`/`classifyTurn`, `narrowChatEvent`, `openEventStream`, domain result types |
-| `@kortix/sdk/server` | **Node/Bun only** — `runWithKortix`, `createScopedKortix`, `getScopedConfig` (per-request config isolation; see "Kortix as a Backend") |
-| `@kortix/sdk/react` | every `useOpenCode*` hook + providers (reactive data), `useSession`, `useChatTurns`/`renderParts`, domain hooks (`useProjectSecrets`/`useProjectTriggers`/`useChangeRequests`) |
-| `@kortix/sdk/turns` | framework-free part/turn classification (`classifyPart`, `classifyTurn`, `toolInfo`, turn grouping/cost helpers) |
-| `@kortix/sdk/files` | workspace file ops (daemon `/file` + `/find`): `listFiles`, `readFile`, `readBlob`, `getFileStatus`, `findFiles`, `findText`, `uploadFile`, `deleteFile`, `mkdir`, `renameFile`, … |
-| `@kortix/sdk/session` | a session's runtime surface — `getSessionHealth`/`isRuntimeReady` + proxy/preview URL builders (`rewriteLocalhostUrl`, `proxyLocalhostUrl`, `detectLocalhostUrls`, …) + preview-auth helpers. **No "sandbox" in the public surface** — a session owns its runtime |
-| `@kortix/sdk/opencode-client` | `getClient`, `getClientForUrl` + the **full opencode v2 type surface** (`Event`, `Part`, `Message`, `Session`, `Pty`, `Config`, …) |
-| `@kortix/sdk/projects-client` | the raw REST functions (the facade wraps these) |
-| `@kortix/sdk/auth` | `authenticatedFetch`, token accessors |
-| `@kortix/sdk/api-client` | the raw `backendApi` primitive — host code should go through the facade or another subpath module instead of calling this directly |
-| `@kortix/sdk/server-store` · `@kortix/sdk/sync-store` | active-sandbox state · live message/part/status store |
+| import                                                | provides                                                                                                                                                                                                                                                          |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@kortix/sdk`                                         | `createKortix`, `configureKortix`, `files`, the error classes, `classifyPart`/`classifyTurn`, `narrowChatEvent`, `openEventStream`, domain result types                                                                                                           |
+| `@kortix/sdk/server`                                  | **Node/Bun only** — `runWithKortix`, `createScopedKortix`, `getScopedConfig` (per-request config isolation; see "Kortix as a Backend")                                                                                                                            |
+| `@kortix/sdk/react`                                   | every `useOpenCode*` hook + providers (reactive data), `useSession`, `useChatTurns`/`renderParts`, domain hooks (`useProjectSecrets`/`useProjectTriggers`/`useChangeRequests`)                                                                                    |
+| `@kortix/sdk/turns`                                   | framework-free part/turn classification (`classifyPart`, `classifyTurn`, `toolInfo`, turn grouping/cost helpers)                                                                                                                                                  |
+| `@kortix/sdk/files`                                   | workspace file ops (daemon `/file` + `/find`): `listFiles`, `readFile`, `readBlob`, `getFileStatus`, `findFiles`, `findText`, `uploadFile`, `deleteFile`, `mkdir`, `renameFile`, …                                                                                |
+| `@kortix/sdk/session`                                 | a session's runtime surface — `getSessionHealth`/`isRuntimeReady` + proxy/preview URL builders (`rewriteLocalhostUrl`, `proxyLocalhostUrl`, `detectLocalhostUrls`, …) + preview-auth helpers. **No "sandbox" in the public surface** — a session owns its runtime |
+| `@kortix/sdk/opencode-client`                         | `getClient`, `getClientForUrl` + the **full opencode v2 type surface** (`Event`, `Part`, `Message`, `Session`, `Pty`, `Config`, …)                                                                                                                                |
+| `@kortix/sdk/projects-client`                         | the raw REST functions (the facade wraps these)                                                                                                                                                                                                                   |
+| `@kortix/sdk/auth`                                    | `authenticatedFetch`, token accessors                                                                                                                                                                                                                             |
+| `@kortix/sdk/api-client`                              | the raw `backendApi` primitive — host code should go through the facade or another subpath module instead of calling this directly                                                                                                                                |
+| `@kortix/sdk/server-store` · `@kortix/sdk/sync-store` | active-sandbox state · live message/part/status store                                                                                                                                                                                                             |
 
 ## Configuration
 

--- a/packages/sdk/src/browser/cache/idb-sync-cache-key.test.ts
+++ b/packages/sdk/src/browser/cache/idb-sync-cache-key.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildSessionCacheKey } from './idb-sync-cache-key';
+
+describe('buildSessionCacheKey', () => {
+  test('preserves the published legacy key when no platform scope exists', () => {
+    expect(buildSessionCacheKey('user:account-1', 'ses_1')).toBe('user:account-1:session:ses_1');
+  });
+
+  test('separates equal OpenCode ids owned by different Kortix sessions', () => {
+    const first = buildSessionCacheKey(
+      'user:account-1',
+      'ses_from_snapshot',
+      'project-a/session-a',
+    );
+    const second = buildSessionCacheKey(
+      'user:account-1',
+      'ses_from_snapshot',
+      'project-a/session-b',
+    );
+
+    expect(first).not.toBe(second);
+  });
+
+  test('keeps one Kortix session cache across an authoritative root change', () => {
+    const before = buildSessionCacheKey('user:account-1', 'ses_stale', 'project-a/session-a');
+    const after = buildSessionCacheKey(
+      'user:account-1',
+      'ses_authoritative',
+      'project-a/session-a',
+    );
+
+    expect(before).toBe(after);
+  });
+});

--- a/packages/sdk/src/browser/cache/idb-sync-cache-key.ts
+++ b/packages/sdk/src/browser/cache/idb-sync-cache-key.ts
@@ -1,0 +1,10 @@
+export function buildSessionCacheKey(
+  userScope: string,
+  openCodeSessionId: string,
+  kortixSessionScope?: string,
+): string {
+  if (!kortixSessionScope) {
+    return `${userScope}:session:${openCodeSessionId}`;
+  }
+  return `${userScope}:kortix-session:${encodeURIComponent(kortixSessionScope)}`;
+}

--- a/packages/sdk/src/browser/cache/idb-sync-cache.ts
+++ b/packages/sdk/src/browser/cache/idb-sync-cache.ts
@@ -7,10 +7,11 @@
  */
 
 import { platformConfig } from '../../core/http/config';
+import { buildSessionCacheKey } from './idb-sync-cache-key';
 
-const DB_NAME = "kortix-session-cache";
+const DB_NAME = 'kortix-session-cache';
 const DB_VERSION = 2;
-const STORE_NAME = "sessions";
+const STORE_NAME = 'sessions';
 const MAX_CACHED_SESSIONS = 50;
 const MAX_SESSION_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -18,6 +19,7 @@ interface CachedSession {
   cacheKey: string;
   userId: string;
   sessionId: string;
+  kortixSessionScope?: string;
   messages: any[];
   parts: Record<string, any[]>;
   updatedAt: number;
@@ -32,17 +34,13 @@ async function getCurrentCacheScope(): Promise<string | null> {
   }
 }
 
-function buildCacheKey(scope: string, sessionId: string): string {
-  return `${scope}:session:${sessionId}`;
-}
-
 let dbPromise: Promise<IDBDatabase> | null = null;
 
 function openDB(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise;
   dbPromise = new Promise((resolve, reject) => {
-    if (typeof indexedDB === "undefined") {
-      reject(new Error("IndexedDB not available"));
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB not available'));
       return;
     }
     const req = indexedDB.open(DB_NAME, DB_VERSION);
@@ -52,7 +50,7 @@ function openDB(): Promise<IDBDatabase> {
         db.deleteObjectStore(STORE_NAME);
       }
       if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME, { keyPath: "cacheKey" });
+        db.createObjectStore(STORE_NAME, { keyPath: 'cacheKey' });
       }
     };
     req.onsuccess = () => resolve(req.result);
@@ -64,12 +62,16 @@ function openDB(): Promise<IDBDatabase> {
   return dbPromise;
 }
 
-const pendingWrites = new Map<string, {
-  scope: string;
-  sessionId: string;
-  messages: any[];
-  parts: Record<string, any[]>;
-}>();
+const pendingWrites = new Map<
+  string,
+  {
+    scope: string;
+    sessionId: string;
+    kortixSessionScope?: string;
+    messages: any[];
+    parts: Record<string, any[]>;
+  }
+>();
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
 const FLUSH_INTERVAL_MS = 500;
 
@@ -89,9 +91,9 @@ async function flushPendingWrites(): Promise<void> {
   pendingWrites.clear();
   try {
     const db = await openDB();
-    const tx = db.transaction(STORE_NAME, "readwrite");
+    const tx = db.transaction(STORE_NAME, 'readwrite');
     const store = tx.objectStore(STORE_NAME);
-    for (const [cacheKey, { scope, sessionId, messages, parts }] of batch) {
+    for (const [cacheKey, { scope, sessionId, kortixSessionScope, messages, parts }] of batch) {
       const partsForSession: Record<string, any[]> = {};
       for (const msg of messages) {
         if (parts[msg.id]) {
@@ -102,6 +104,7 @@ async function flushPendingWrites(): Promise<void> {
         cacheKey,
         userId: scope,
         sessionId,
+        kortixSessionScope,
         messages,
         parts: partsForSession,
         updatedAt: Date.now(),
@@ -120,12 +123,19 @@ export async function saveSessionToIDB(
   sessionId: string,
   messages: any[],
   parts: Record<string, any[]>,
+  kortixSessionScope?: string,
 ): Promise<void> {
   const scope = await getCurrentCacheScope();
   if (!scope) return;
 
-  const cacheKey = buildCacheKey(scope, sessionId);
-  pendingWrites.set(cacheKey, { scope, sessionId, messages, parts });
+  const cacheKey = buildSessionCacheKey(scope, sessionId, kortixSessionScope);
+  pendingWrites.set(cacheKey, {
+    scope,
+    sessionId,
+    kortixSessionScope,
+    messages,
+    parts,
+  });
   if (!flushTimer) {
     flushTimer = setTimeout(flushPendingWrites, FLUSH_INTERVAL_MS);
   }
@@ -140,23 +150,29 @@ export function flushIDBWrites(): Promise<void> {
 
 export async function loadSessionFromIDB(
   sessionId: string,
+  kortixSessionScope?: string,
 ): Promise<{ messages: any[]; parts: Record<string, any[]> } | null> {
   try {
     const scope = await getCurrentCacheScope();
     if (!scope) return null;
 
     const db = await openDB();
-    const tx = db.transaction(STORE_NAME, "readonly");
+    const tx = db.transaction(STORE_NAME, 'readonly');
     const store = tx.objectStore(STORE_NAME);
-    const req = store.get(buildCacheKey(scope, sessionId));
+    const req = store.get(buildSessionCacheKey(scope, sessionId, kortixSessionScope));
     const result = await new Promise<CachedSession | undefined>((resolve, reject) => {
       req.onsuccess = () => resolve(req.result);
       req.onerror = () => reject(req.error);
     });
     if (!result) return null;
-    if (result.userId !== scope || result.sessionId !== sessionId) return null;
+    if (result.userId !== scope) return null;
+    if (kortixSessionScope) {
+      if (result.kortixSessionScope !== kortixSessionScope) return null;
+    } else if (result.sessionId !== sessionId) {
+      return null;
+    }
     if (Date.now() - result.updatedAt > MAX_SESSION_AGE_MS) {
-      deleteSessionFromIDB(sessionId);
+      deleteSessionFromIDB(sessionId, kortixSessionScope);
       return null;
     }
     return { messages: result.messages, parts: result.parts };
@@ -171,7 +187,7 @@ export async function loadAllSessionIdsFromIDB(): Promise<string[]> {
     if (!scope) return [];
 
     const db = await openDB();
-    const tx = db.transaction(STORE_NAME, "readonly");
+    const tx = db.transaction(STORE_NAME, 'readonly');
     const store = tx.objectStore(STORE_NAME);
     const req = store.getAll();
     const entries = await new Promise<CachedSession[]>((resolve, reject) => {
@@ -184,14 +200,17 @@ export async function loadAllSessionIdsFromIDB(): Promise<string[]> {
   }
 }
 
-export async function deleteSessionFromIDB(sessionId: string): Promise<void> {
+export async function deleteSessionFromIDB(
+  sessionId: string,
+  kortixSessionScope?: string,
+): Promise<void> {
   try {
     const scope = await getCurrentCacheScope();
     if (!scope) return;
 
     const db = await openDB();
-    const tx = db.transaction(STORE_NAME, "readwrite");
-    tx.objectStore(STORE_NAME).delete(buildCacheKey(scope, sessionId));
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(buildSessionCacheKey(scope, sessionId, kortixSessionScope));
   } catch {
     // ignore
   }
@@ -205,7 +224,7 @@ export async function clearSessionIDBCache(): Promise<void> {
       flushTimer = null;
     }
     const db = await openDB();
-    const tx = db.transaction(STORE_NAME, "readwrite");
+    const tx = db.transaction(STORE_NAME, 'readwrite');
     tx.objectStore(STORE_NAME).clear();
   } catch {
     // ignore
@@ -215,7 +234,7 @@ export async function clearSessionIDBCache(): Promise<void> {
 export async function pruneIDBCache(): Promise<void> {
   try {
     const db = await openDB();
-    const tx = db.transaction(STORE_NAME, "readwrite");
+    const tx = db.transaction(STORE_NAME, 'readwrite');
     const store = tx.objectStore(STORE_NAME);
     const req = store.getAll();
     const entries = await new Promise<CachedSession[]>((resolve, reject) => {

--- a/packages/sdk/src/browser/session-sync/session-cache-ownership.test.ts
+++ b/packages/sdk/src/browser/session-sync/session-cache-ownership.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import {
+  claimSessionCacheOwnership,
+  getSessionCacheOwnership,
+  resolveSessionCacheOwnerScope,
+  resetSessionCacheOwnership,
+} from './session-cache-ownership';
+
+beforeEach(() => {
+  resetSessionCacheOwnership();
+});
+
+describe('OpenCode session cache ownership', () => {
+  test('uses the Kortix session scope across sandbox replacements', () => {
+    expect(resolveSessionCacheOwnerScope('sandbox-a', 'project-a/session-a')).toBe(
+      'kortix:project-a/session-a',
+    );
+    expect(resolveSessionCacheOwnerScope('sandbox-b', 'project-a/session-a')).toBe(
+      'kortix:project-a/session-a',
+    );
+  });
+
+  test('falls back to the sandbox scope for standalone consumers', () => {
+    expect(resolveSessionCacheOwnerScope('sandbox-a')).toBe('runtime:sandbox-a');
+    expect(resolveSessionCacheOwnerScope('none')).toBeNull();
+  });
+
+  test('reports a collision when another sandbox reuses the same OpenCode id', () => {
+    expect(claimSessionCacheOwnership('ses_shared', 'sandbox-a')).toEqual({
+      changed: true,
+      previousOwnerScope: null,
+    });
+    expect(claimSessionCacheOwnership('ses_shared', 'sandbox-b')).toEqual({
+      changed: true,
+      previousOwnerScope: 'sandbox-a',
+    });
+    expect(getSessionCacheOwnership('ses_shared')).toBe('sandbox-b');
+  });
+
+  test('keeps a repeated claim for the same sandbox stable', () => {
+    claimSessionCacheOwnership('ses_1', 'sandbox-a');
+    expect(claimSessionCacheOwnership('ses_1', 'sandbox-a')).toEqual({
+      changed: false,
+      previousOwnerScope: 'sandbox-a',
+    });
+  });
+});

--- a/packages/sdk/src/browser/session-sync/session-cache-ownership.ts
+++ b/packages/sdk/src/browser/session-sync/session-cache-ownership.ts
@@ -1,0 +1,36 @@
+/**
+ * Tracks which sandbox currently owns each bare OpenCode session id in the
+ * compatibility sync store. OpenCode ids are local to a sandbox. A restored
+ * snapshot can therefore expose the same id from two different sandboxes.
+ */
+
+const owners = new Map<string, string>();
+
+export function resolveSessionCacheOwnerScope(
+  runtimeScope: string,
+  kortixSessionScope?: string,
+): string | null {
+  if (kortixSessionScope) return `kortix:${kortixSessionScope}`;
+  if (!runtimeScope || runtimeScope === 'none') return null;
+  return `runtime:${runtimeScope}`;
+}
+
+export function getSessionCacheOwnership(sessionId: string): string | null {
+  return owners.get(sessionId) ?? null;
+}
+
+export function claimSessionCacheOwnership(
+  sessionId: string,
+  ownerScope: string,
+): { changed: boolean; previousOwnerScope: string | null } {
+  const previousOwnerScope = getSessionCacheOwnership(sessionId);
+  if (previousOwnerScope === ownerScope) {
+    return { changed: false, previousOwnerScope };
+  }
+  owners.set(sessionId, ownerScope);
+  return { changed: true, previousOwnerScope };
+}
+
+export function resetSessionCacheOwnership(): void {
+  owners.clear();
+}

--- a/packages/sdk/src/browser/session-sync/session-sync-registry.test.ts
+++ b/packages/sdk/src/browser/session-sync/session-sync-registry.test.ts
@@ -9,6 +9,7 @@ import {
   noteSessionSyncEvent,
   prefetchSessionSyncOnce,
   readSessionMessagePage,
+  resetSessionSyncControllersForSession,
   resetSessionSyncControllers,
   retainSessionSyncController,
 } from './session-sync-registry';
@@ -62,6 +63,27 @@ describe('readSessionMessagePage', () => {
 });
 
 describe('prefetchSessionSyncOnce', () => {
+  test('keeps controllers distinct when two sandboxes contain the same OpenCode id', () => {
+    const sharedId = 'session-from-snapshot';
+    const runtimeA = getSessionSyncController(sharedId, undefined, 'runtime-a');
+    const runtimeB = getSessionSyncController(sharedId, undefined, 'runtime-b');
+
+    expect(runtimeA).not.toBe(runtimeB);
+    expect(getSessionSyncController(sharedId, undefined, 'runtime-a')).toBe(runtimeA);
+    expect(getSessionSyncController(sharedId, undefined, 'runtime-b')).toBe(runtimeB);
+  });
+
+  test('retires old-sandbox controllers without deleting the current sandbox controller', () => {
+    const sharedId = 'session-from-snapshot';
+    const runtimeA = getSessionSyncController(sharedId, undefined, 'runtime-a');
+    const runtimeB = getSessionSyncController(sharedId, undefined, 'runtime-b');
+
+    resetSessionSyncControllersForSession(sharedId, 'runtime-b');
+
+    expect(getSessionSyncController(sharedId, undefined, 'runtime-a')).not.toBe(runtimeA);
+    expect(getSessionSyncController(sharedId, undefined, 'runtime-b')).toBe(runtimeB);
+  });
+
   test('deduplicates one runtime source and revalidates after the runtime changes', async () => {
     const requests: string[] = [];
     const client = (runtime: string) => ({

--- a/packages/sdk/src/browser/session-sync/session-sync-registry.ts
+++ b/packages/sdk/src/browser/session-sync/session-sync-registry.ts
@@ -1,6 +1,7 @@
 import type { Message, Part, SessionStatus } from '@opencode-ai/sdk/v2/client';
 import { useSyncStore } from '../stores/sync-store';
 import { getClient } from '../../core/runtime/client';
+import { getCurrentRuntimeSandboxId } from '../../core/session/current-runtime';
 import {
   SessionSyncController,
   loadCompleteSessionHistory,
@@ -29,6 +30,8 @@ export const ACTIVE_SESSION_PREFETCH_SOURCE = Symbol('active-session-prefetch');
 type SessionPrefetchSource = string | typeof ACTIVE_SESSION_PREFETCH_SOURCE;
 
 interface RegistryEntry {
+  sessionId: string;
+  runtimeScope: string;
   controller: SessionSyncController;
   consumers: number;
   lastUsedAt: number;
@@ -38,6 +41,14 @@ interface RegistryEntry {
 
 const MAX_CONTROLLERS = 20;
 const controllers = new Map<string, RegistryEntry>();
+
+function runtimeScopeKey(runtimeScope?: string): string {
+  return runtimeScope ?? getCurrentRuntimeSandboxId() ?? 'none';
+}
+
+function controllerKey(sessionId: string, runtimeScope?: string): string {
+  return `${runtimeScopeKey(runtimeScope)}\n${sessionId}`;
+}
 
 export async function readSessionMessagePage(
   client: SessionMessageClient,
@@ -59,16 +70,16 @@ function reportTelemetry(sessionId: string, event: SessionSyncTelemetryEvent): v
   console.debug('[session-sync]', { sessionId, ...event });
 }
 
-function resolveClient(sessionId: string): SessionMessageClient {
-  return controllers.get(sessionId)?.client ?? getClient();
+function resolveClient(key: string): SessionMessageClient {
+  return controllers.get(key)?.client ?? getClient();
 }
 
-function createController(sessionId: string): SessionSyncController {
+function createController(sessionId: string, key: string): SessionSyncController {
   return new SessionSyncController({
     sessionId,
-    loadPage: (request) => readSessionMessagePage(resolveClient(sessionId), sessionId, request),
+    loadPage: (request) => readSessionMessagePage(resolveClient(key), sessionId, request),
     loadStatus: async () => {
-      const loadStatus = resolveClient(sessionId).session.status;
+      const loadStatus = resolveClient(key).session.status;
       if (!loadStatus) return { type: 'idle' } as SessionStatus;
       const result = await loadStatus();
       return result.data?.[sessionId] ?? ({ type: 'idle' } as SessionStatus);
@@ -81,21 +92,21 @@ function createController(sessionId: string): SessionSyncController {
       if (!(sessionId in state.messages)) state.hydrate(sessionId, []);
     },
     setStatus: (status) => {
-      controllers.get(sessionId)?.controller.observePromptStatus(status);
+      controllers.get(key)?.controller.observePromptStatus(status);
       useSyncStore.getState().setStatus(sessionId, status);
     },
     onTelemetry: (event) => reportTelemetry(sessionId, event),
   });
 }
 
-function evictInactiveControllers(protectedSessionId?: string): void {
+function evictInactiveControllers(protectedKey?: string): void {
   if (controllers.size <= MAX_CONTROLLERS) return;
   const inactive = [...controllers.entries()]
-    .filter(([sessionId, entry]) => entry.consumers === 0 && sessionId !== protectedSessionId)
+    .filter(([key, entry]) => entry.consumers === 0 && key !== protectedKey)
     .sort((a, b) => a[1].lastUsedAt - b[1].lastUsedAt);
-  for (const [sessionId, entry] of inactive) {
+  for (const [key, entry] of inactive) {
     entry.controller.destroy();
-    controllers.delete(sessionId);
+    controllers.delete(key);
     if (controllers.size <= MAX_CONTROLLERS) return;
   }
 }
@@ -104,29 +115,35 @@ function getOrCreateRegistryEntry(
   sessionId: string,
   client?: SessionMessageClient,
   initialConsumers = 0,
+  runtimeScope?: string,
 ): RegistryEntry {
-  const existing = controllers.get(sessionId);
+  const key = controllerKey(sessionId, runtimeScope);
+  const existing = controllers.get(key);
   if (existing) {
     existing.client = client;
     existing.lastUsedAt = Date.now();
     return existing;
   }
   const entry: RegistryEntry = {
-    controller: createController(sessionId),
+    sessionId,
+    runtimeScope: runtimeScopeKey(runtimeScope),
+    controller: createController(sessionId, key),
     client,
     consumers: initialConsumers,
     lastUsedAt: Date.now(),
   };
-  controllers.set(sessionId, entry);
+  controllers.set(key, entry);
   return entry;
 }
 
 export function getSessionSyncController(
   sessionId: string,
   client?: SessionMessageClient,
+  runtimeScope?: string,
 ): SessionSyncController {
-  const entry = getOrCreateRegistryEntry(sessionId, client);
-  evictInactiveControllers(sessionId);
+  const key = controllerKey(sessionId, runtimeScope);
+  const entry = getOrCreateRegistryEntry(sessionId, client, 0, runtimeScope);
+  evictInactiveControllers(key);
   return entry.controller;
 }
 
@@ -135,13 +152,20 @@ export async function prefetchSessionSyncOnce(
   source: SessionPrefetchSource,
   client?: SessionMessageClient,
 ): Promise<boolean> {
-  const existing = controllers.get(sessionId);
-  const entry = getOrCreateRegistryEntry(sessionId, existing?.consumers ? undefined : client);
-  evictInactiveControllers(sessionId);
+  const runtimeScope = source === ACTIVE_SESSION_PREFETCH_SOURCE ? runtimeScopeKey() : source;
+  const key = controllerKey(sessionId, runtimeScope);
+  const existing = controllers.get(key);
+  const entry = getOrCreateRegistryEntry(
+    sessionId,
+    existing?.consumers ? undefined : client,
+    0,
+    runtimeScope,
+  );
+  evictInactiveControllers(key);
   if (entry.prefetchedSource === source) return true;
   await entry.controller.reconcile('manual');
   const succeeded = entry.controller.getSnapshot().freshness === 'fresh';
-  const current = controllers.get(sessionId);
+  const current = controllers.get(key);
   if (succeeded && current === entry) current.prefetchedSource = source;
   return succeeded;
 }
@@ -154,19 +178,20 @@ export function clearActiveSessionPrefetches(): void {
   }
 }
 
-export function retainSessionSyncController(sessionId: string): () => void {
-  let entry = controllers.get(sessionId);
+export function retainSessionSyncController(sessionId: string, runtimeScope?: string): () => void {
+  const key = controllerKey(sessionId, runtimeScope);
+  let entry = controllers.get(key);
   if (entry) {
     entry.client = undefined;
     entry.consumers += 1;
     entry.lastUsedAt = Date.now();
   } else {
-    entry = getOrCreateRegistryEntry(sessionId, undefined, 1);
+    entry = getOrCreateRegistryEntry(sessionId, undefined, 1, runtimeScope);
   }
   evictInactiveControllers();
   const controller = entry.controller;
   return () => {
-    const current = controllers.get(sessionId);
+    const current = controllers.get(key);
     if (!current || current.controller !== controller) return;
     current.consumers = Math.max(0, current.consumers - 1);
     current.lastUsedAt = Date.now();
@@ -175,16 +200,20 @@ export function retainSessionSyncController(sessionId: string): () => void {
   };
 }
 
-export function reconcileSessionTail(sessionId: string, reason: SessionSyncReason): Promise<void> {
-  return getSessionSyncController(sessionId).reconcile(reason);
+export function reconcileSessionTail(
+  sessionId: string,
+  reason: SessionSyncReason,
+  runtimeScope?: string,
+): Promise<void> {
+  return getSessionSyncController(sessionId, undefined, runtimeScope).reconcile(reason);
 }
 
-export function beginSessionPromptObservation(sessionId: string): void {
-  getSessionSyncController(sessionId).beginPromptObservation();
+export function beginSessionPromptObservation(sessionId: string, runtimeScope?: string): void {
+  getSessionSyncController(sessionId, undefined, runtimeScope).beginPromptObservation();
 }
 
-export function endSessionPromptObservation(sessionId: string): void {
-  controllers.get(sessionId)?.controller.endPromptObservation();
+export function endSessionPromptObservation(sessionId: string, runtimeScope?: string): void {
+  controllers.get(controllerKey(sessionId, runtimeScope))?.controller.endPromptObservation();
 }
 
 export function loadSessionTranscriptMessages(
@@ -195,7 +224,10 @@ export function loadSessionTranscriptMessages(
   );
 }
 
-export function noteSessionSyncEvent(event: { type?: string; properties: unknown }): void {
+export function noteSessionSyncEvent(event: {
+  type?: string;
+  properties: unknown;
+}): void {
   const properties = event.properties as Record<string, unknown>;
   const info = properties.info as { sessionID?: string; role?: string } | undefined;
   const part = properties.part as { sessionID?: string } | undefined;
@@ -204,7 +236,7 @@ export function noteSessionSyncEvent(event: { type?: string; properties: unknown
     info?.sessionID ||
     part?.sessionID;
   if (!sessionId) return;
-  const controller = controllers.get(sessionId)?.controller;
+  const controller = controllers.get(controllerKey(sessionId))?.controller;
   if (!controller) return;
   controller.noteActivity();
 
@@ -229,4 +261,16 @@ export function noteSessionSyncEvent(event: { type?: string; properties: unknown
 export function resetSessionSyncControllers(): void {
   for (const entry of controllers.values()) entry.controller.destroy();
   controllers.clear();
+}
+
+/** Retire controllers for one wire id after a different sandbox claims it. */
+export function resetSessionSyncControllersForSession(
+  sessionId: string,
+  keepRuntimeScope?: string,
+): void {
+  for (const [key, entry] of controllers) {
+    if (entry.sessionId !== sessionId || entry.runtimeScope === keepRuntimeScope) continue;
+    entry.controller.destroy();
+    controllers.delete(key);
+  }
 }

--- a/packages/sdk/src/browser/session-sync/session-transcript-cache.ts
+++ b/packages/sdk/src/browser/session-sync/session-transcript-cache.ts
@@ -75,8 +75,11 @@ export function shouldHydrateFromCache(input: {
  * usable entry — the caller then simply waits for the runtime, exactly as
  * before this cache existed.
  */
-export async function readCachedTranscript(sessionId: string): Promise<CachedTranscript | null> {
-  const cached = await loadSessionFromIDB(sessionId);
+export async function readCachedTranscript(
+  sessionId: string,
+  kortixSessionScope?: string,
+): Promise<CachedTranscript | null> {
+  const cached = await loadSessionFromIDB(sessionId, kortixSessionScope);
   if (!cached || !Array.isArray(cached.messages) || cached.messages.length === 0) return null;
   return { messages: cached.messages, parts: cached.parts ?? {} };
 }
@@ -85,8 +88,9 @@ export async function readCachedTranscript(sessionId: string): Promise<CachedTra
 export function writeCachedTranscript(
   state: TranscriptStoreSlice,
   sessionId: string,
+  kortixSessionScope?: string,
 ): Promise<void> {
   const transcript = selectSessionTranscript(state, sessionId);
   if (!transcript) return Promise.resolve();
-  return saveSessionToIDB(sessionId, transcript.messages, transcript.parts);
+  return saveSessionToIDB(sessionId, transcript.messages, transcript.parts, kortixSessionScope);
 }

--- a/packages/sdk/src/react/session-runtime-identity.test.ts
+++ b/packages/sdk/src/react/session-runtime-identity.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'bun:test';
 
-import { hasSessionRuntimeIdentity } from './session-runtime-identity';
+import {
+  hasSessionRuntimeIdentity,
+  isSessionRuntimeActionReady,
+} from './session-runtime-identity';
 
 test('managed ACP does not require an OpenCode session id', () => {
   expect(hasSessionRuntimeIdentity({ usesAcp: true, opencodeSessionId: null })).toBe(true);
@@ -9,4 +12,21 @@ test('managed ACP does not require an OpenCode session id', () => {
 test('REST requires an OpenCode session id', () => {
   expect(hasSessionRuntimeIdentity({ usesAcp: false, opencodeSessionId: null })).toBe(false);
   expect(hasSessionRuntimeIdentity({ usesAcp: false, opencodeSessionId: 'ses_1' })).toBe(true);
+});
+
+test('a preassigned OpenCode id cannot authorize runtime actions before the sandbox switch', () => {
+  expect(
+    isSessionRuntimeActionReady({
+      switched: false,
+      usesAcp: false,
+      opencodeSessionId: 'ses_cached',
+    }),
+  ).toBe(false);
+  expect(
+    isSessionRuntimeActionReady({
+      switched: true,
+      usesAcp: false,
+      opencodeSessionId: 'ses_authoritative',
+    }),
+  ).toBe(true);
 });

--- a/packages/sdk/src/react/session-runtime-identity.ts
+++ b/packages/sdk/src/react/session-runtime-identity.ts
@@ -4,3 +4,11 @@ export function hasSessionRuntimeIdentity(input: {
 }): boolean {
   return input.usesAcp || Boolean(input.opencodeSessionId);
 }
+
+export function isSessionRuntimeActionReady(input: {
+  switched: boolean;
+  usesAcp: boolean;
+  opencodeSessionId: string | null;
+}): boolean {
+  return input.switched && hasSessionRuntimeIdentity(input);
+}

--- a/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
@@ -30,13 +30,28 @@ mock.module('../../platform/ui', () => ({
     toasts.push({ level: 'info', message });
   },
   notifyPermissionRequest: (sessionId: string, toolName: string, sessionTitle?: string) => {
-    notifications.push({ kind: 'permission', sessionId, toolName, sessionTitle });
+    notifications.push({
+      kind: 'permission',
+      sessionId,
+      toolName,
+      sessionTitle,
+    });
   },
   notifyQuestion: (sessionId: string, questionText: string, sessionTitle?: string) => {
-    notifications.push({ kind: 'question', sessionId, questionText, sessionTitle });
+    notifications.push({
+      kind: 'question',
+      sessionId,
+      questionText,
+      sessionTitle,
+    });
   },
   notifySessionError: (sessionId: string, errorTitle: string, sessionTitle?: string) => {
-    notifications.push({ kind: 'session-error', sessionId, errorTitle, sessionTitle });
+    notifications.push({
+      kind: 'session-error',
+      sessionId,
+      errorTitle,
+      sessionTitle,
+    });
   },
   notifyTaskComplete: (sessionId: string, sessionTitle?: string) => {
     notifications.push({ kind: 'task-complete', sessionId, sessionTitle });
@@ -64,7 +79,12 @@ function makeCalls<Args extends unknown[]>() {
   return { fn, calls };
 }
 
-function buildHandler(overrides: { messagesImpl?: () => Promise<{ data?: unknown }>; getImpl?: () => Promise<{ data?: unknown }> } = {}) {
+function buildHandler(
+  overrides: {
+    messagesImpl?: () => Promise<{ data?: unknown }>;
+    getImpl?: () => Promise<{ data?: unknown }>;
+  } = {},
+) {
   const queryClient = new QueryClient();
   const stopCompaction = makeCalls<[string]>();
   const addPermission = makeCalls<[PermissionRequest]>();
@@ -203,7 +223,13 @@ describe('message.part.updated', () => {
       properties: {
         sessionID: 'ses_1',
         time: Date.now(),
-        part: { id: 'prt_1', sessionID: 'ses_1', messageID: 'msg_1', type: 'text' as const, text: 'Hello' },
+        part: {
+          id: 'prt_1',
+          sessionID: 'ses_1',
+          messageID: 'msg_1',
+          type: 'text' as const,
+          text: 'Hello',
+        },
       },
     };
     handleEvent(event);
@@ -279,17 +305,24 @@ describe('message.part.updated', () => {
 describe('session lifecycle cache mutations', () => {
   test('session.created inserts into an existing session list, newest first', () => {
     const { handleEvent, queryClient } = buildHandler();
-    queryClient.setQueryData(opencodeKeys.sessions(), [session('ses_old', { time: { created: 1, updated: 1 } })]);
+    queryClient.setQueryData(opencodeKeys.sessions(), [
+      session('ses_old', { time: { created: 1, updated: 1 } }),
+    ]);
 
     handleEvent({
       id: 'evt_1',
       type: 'session.created',
-      properties: { sessionID: 'ses_new', info: session('ses_new', { time: { created: 5, updated: 5 } }) },
+      properties: {
+        sessionID: 'ses_new',
+        info: session('ses_new', { time: { created: 5, updated: 5 } }),
+      },
     });
 
     const list = queryClient.getQueryData<Session[]>(opencodeKeys.sessions());
     expect(list?.map((s) => s.id)).toEqual(['ses_new', 'ses_old']);
-    expect(queryClient.getQueryData(opencodeKeys.session('ses_new'))).toMatchObject({ id: 'ses_new' });
+    expect(queryClient.getQueryData(opencodeKeys.runtimeSession('ses_new'))).toMatchObject({
+      id: 'ses_new',
+    });
   });
 
   test('session.created on an empty/uninitialized list still seeds it', () => {
@@ -299,30 +332,48 @@ describe('session lifecycle cache mutations', () => {
       type: 'session.created',
       properties: { sessionID: 'ses_new', info: session('ses_new') },
     });
-    expect(queryClient.getQueryData<Session[]>(opencodeKeys.sessions())).toEqual([session('ses_new')]);
+    expect(queryClient.getQueryData<Session[]>(opencodeKeys.sessions())).toEqual([
+      session('ses_new'),
+    ]);
   });
 
   test('session.updated patches the individual session cache and re-sorts the list', () => {
     const { handleEvent, queryClient } = buildHandler();
     queryClient.setQueryData(opencodeKeys.sessions(), [
-      session('ses_a', { time: { created: 1, updated: 1 }, title: 'Old title' }),
+      session('ses_a', {
+        time: { created: 1, updated: 1 },
+        title: 'Old title',
+      }),
     ]);
-    queryClient.setQueryData(opencodeKeys.session('ses_a'), session('ses_a', { title: 'Old title' }));
+    queryClient.setQueryData(
+      opencodeKeys.runtimeSession('ses_a'),
+      session('ses_a', { title: 'Old title' }),
+    );
 
     handleEvent({
       id: 'evt_1',
       type: 'session.updated',
-      properties: { sessionID: 'ses_a', info: session('ses_a', { time: { created: 1, updated: 9 }, title: 'New title' }) },
+      properties: {
+        sessionID: 'ses_a',
+        info: session('ses_a', {
+          time: { created: 1, updated: 9 },
+          title: 'New title',
+        }),
+      },
     });
 
-    expect(queryClient.getQueryData<Session>(opencodeKeys.session('ses_a'))?.title).toBe('New title');
-    expect(queryClient.getQueryData<Session[]>(opencodeKeys.sessions())?.[0].title).toBe('New title');
+    expect(queryClient.getQueryData<Session>(opencodeKeys.runtimeSession('ses_a'))?.title).toBe(
+      'New title',
+    );
+    expect(queryClient.getQueryData<Session[]>(opencodeKeys.sessions())?.[0].title).toBe(
+      'New title',
+    );
   });
 
   test('session.deleted removes the session from the list and clears its query cache', () => {
     const { handleEvent, queryClient } = buildHandler();
     queryClient.setQueryData(opencodeKeys.sessions(), [session('ses_a'), session('ses_b')]);
-    queryClient.setQueryData(opencodeKeys.session('ses_a'), session('ses_a'));
+    queryClient.setQueryData(opencodeKeys.runtimeSession('ses_a'), session('ses_a'));
 
     handleEvent({
       id: 'evt_1',
@@ -330,8 +381,10 @@ describe('session lifecycle cache mutations', () => {
       properties: { sessionID: 'ses_a', info: session('ses_a') },
     });
 
-    expect(queryClient.getQueryData<Session[]>(opencodeKeys.sessions())?.map((s) => s.id)).toEqual(['ses_b']);
-    expect(queryClient.getQueryData(opencodeKeys.session('ses_a'))).toBeUndefined();
+    expect(queryClient.getQueryData<Session[]>(opencodeKeys.sessions())?.map((s) => s.id)).toEqual([
+      'ses_b',
+    ]);
+    expect(queryClient.getQueryData(opencodeKeys.runtimeSession('ses_a'))).toBeUndefined();
   });
 });
 
@@ -361,8 +414,12 @@ describe('session.status', () => {
 
     // handle-event.ts reads `sessionStatus` itself to detect the transition —
     // seeded above via `setStatus`, untouched by the (spied) `applySyncEvent`.
-    expect(useSyncStore.getState().sessionStatus.ses_1).toEqual({ type: 'busy' });
-    expect(notifications).toEqual([{ kind: 'task-complete', sessionId: 'ses_1', sessionTitle: undefined }]);
+    expect(useSyncStore.getState().sessionStatus.ses_1).toEqual({
+      type: 'busy',
+    });
+    expect(notifications).toEqual([
+      { kind: 'task-complete', sessionId: 'ses_1', sessionTitle: undefined },
+    ]);
     expect(gitCalls).toBe(1);
     expect(filesCalls).toBe(1);
   });
@@ -397,7 +454,12 @@ describe('session.status', () => {
 describe('session.idle', () => {
   test('busy → idle fires notifyTaskComplete', () => {
     const { handleEvent } = buildHandler();
-    useSyncStore.getState().setStatus('ses_1', { type: 'retry', attempt: 1, message: 'retrying', next: 1 });
+    useSyncStore.getState().setStatus('ses_1', {
+      type: 'retry',
+      attempt: 1,
+      message: 'retrying',
+      next: 1,
+    });
 
     handleEvent({
       id: 'evt_1',
@@ -405,7 +467,9 @@ describe('session.idle', () => {
       properties: { sessionID: 'ses_1' },
     });
 
-    expect(notifications).toEqual([{ kind: 'task-complete', sessionId: 'ses_1', sessionTitle: undefined }]);
+    expect(notifications).toEqual([
+      { kind: 'task-complete', sessionId: 'ses_1', sessionTitle: undefined },
+    ]);
   });
 });
 
@@ -418,7 +482,7 @@ describe('session.idle', () => {
 describe('session.error', () => {
   test('patches .error onto the last assistant message in the messages cache', () => {
     const { handleEvent, queryClient } = buildHandler();
-    const key = opencodeKeys.messages('ses_1');
+    const key = opencodeKeys.runtimeMessages('ses_1');
     queryClient.setQueryData(key, [
       { info: userMessage('msg_u'), parts: [] },
       { info: assistantMessage('msg_a'), parts: [] },
@@ -427,7 +491,10 @@ describe('session.error', () => {
     handleEvent({
       id: 'evt_1',
       type: 'session.error',
-      properties: { sessionID: 'ses_1', error: { name: 'UnknownError', data: { message: 'boom' } } },
+      properties: {
+        sessionID: 'ses_1',
+        error: { name: 'UnknownError', data: { message: 'boom' } },
+      },
     });
 
     const cached = queryClient.getQueryData<Array<{ info: Message }>>(key);
@@ -436,21 +503,31 @@ describe('session.error', () => {
       data: { message: 'boom' },
     });
     expect(notifications).toEqual([
-      { kind: 'session-error', sessionId: 'ses_1', errorTitle: 'UnknownError', sessionTitle: undefined },
+      {
+        kind: 'session-error',
+        sessionId: 'ses_1',
+        errorTitle: 'UnknownError',
+        sessionTitle: undefined,
+      },
     ]);
   });
 
   test('non-abort errors rehydrate real messages from the injected client', async () => {
     const rehydrated: Message[] = [assistantMessage('msg_real')];
     const { handleEvent, queryClient } = buildHandler({
-      messagesImpl: async () => ({ data: rehydrated.map((info) => ({ info, parts: [] })) }),
+      messagesImpl: async () => ({
+        data: rehydrated.map((info) => ({ info, parts: [] })),
+      }),
     });
     useSyncStore.getState().optimisticAdd('ses_1', userMessage('msg_optimistic'), []);
 
     handleEvent({
       id: 'evt_1',
       type: 'session.error',
-      properties: { sessionID: 'ses_1', error: { name: 'UnknownError', data: { message: 'boom' } } },
+      properties: {
+        sessionID: 'ses_1',
+        error: { name: 'UnknownError', data: { message: 'boom' } },
+      },
     });
 
     // The rehydrate fetch is fire-and-forget (`.then()`), so wait a tick.
@@ -479,7 +556,10 @@ describe('session.error', () => {
     handleEvent({
       id: 'evt_1',
       type: 'session.error',
-      properties: { sessionID: 'ses_1', error: { name: 'AbortError', data: { message: 'aborted' } } },
+      properties: {
+        sessionID: 'ses_1',
+        error: { name: 'AbortError', data: { message: 'aborted' } },
+      },
     } as never);
 
     await Promise.resolve();
@@ -512,7 +592,12 @@ describe('permission.asked / permission.replied', () => {
 
     expect(addPermission.calls).toEqual([[req]]);
     expect(notifications).toEqual([
-      { kind: 'permission', sessionId: 'ses_1', toolName: 'a tool', sessionTitle: undefined },
+      {
+        kind: 'permission',
+        sessionId: 'ses_1',
+        toolName: 'a tool',
+        sessionTitle: undefined,
+      },
     ]);
   });
 
@@ -544,7 +629,12 @@ describe('question.asked / question.replied / question.rejected', () => {
 
     expect(addQuestion.calls).toEqual([[req]]);
     expect(notifications).toEqual([
-      { kind: 'question', sessionId: 'ses_1', questionText: 'Should I proceed?', sessionTitle: undefined },
+      {
+        kind: 'question',
+        sessionId: 'ses_1',
+        questionText: 'Should I proceed?',
+        sessionTitle: undefined,
+      },
     ]);
   });
 
@@ -583,7 +673,9 @@ describe('misc targeted cache writes', () => {
       type: 'session.diff',
       properties: { sessionID: 'ses_1', diff },
     });
-    expect(queryClient.getQueryData<typeof diff>(['opencode', 'session-diff', 'ses_1'])).toEqual(diff);
+    expect(queryClient.getQueryData<typeof diff>(['opencode', 'session-diff', 'ses_1'])).toEqual(
+      diff,
+    );
   });
 
   test('todo.updated writes the todos array under the session-todo key', () => {
@@ -594,7 +686,9 @@ describe('misc targeted cache writes', () => {
       type: 'todo.updated',
       properties: { sessionID: 'ses_1', todos },
     });
-    expect(queryClient.getQueryData<typeof todos>(['opencode', 'session-todo', 'ses_1'])).toEqual(todos);
+    expect(queryClient.getQueryData<typeof todos>(['opencode', 'session-todo', 'ses_1'])).toEqual(
+      todos,
+    );
   });
 
   test('vcs.branch.updated writes the branch under the vcs key', () => {
@@ -604,7 +698,9 @@ describe('misc targeted cache writes', () => {
       type: 'vcs.branch.updated',
       properties: { branch: 'feat/foo' },
     });
-    expect(queryClient.getQueryData<{ branch: string }>(['opencode', 'vcs'])).toEqual({ branch: 'feat/foo' });
+    expect(queryClient.getQueryData<{ branch: string }>(['opencode', 'vcs'])).toEqual({
+      branch: 'feat/foo',
+    });
   });
 });
 
@@ -617,7 +713,11 @@ describe('remaining event kinds — smoke coverage', () => {
   test('mcp.tools.changed refetches MCP status + tool ids (active only)', () => {
     const { handleEvent, queryClient } = buildHandler();
     expect(() =>
-      handleEvent({ id: 'evt_1', type: 'mcp.tools.changed', properties: { server: 'github' } }),
+      handleEvent({
+        id: 'evt_1',
+        type: 'mcp.tools.changed',
+        properties: { server: 'github' },
+      }),
     ).not.toThrow();
     expect(queryClient).toBeInstanceOf(QueryClient);
   });
@@ -625,7 +725,11 @@ describe('remaining event kinds — smoke coverage', () => {
   test('worktree.ready invalidates worktrees + projects', () => {
     const { handleEvent } = buildHandler();
     expect(() =>
-      handleEvent({ id: 'evt_1', type: 'worktree.ready', properties: { name: 'wt-1' } }),
+      handleEvent({
+        id: 'evt_1',
+        type: 'worktree.ready',
+        properties: { name: 'wt-1' },
+      }),
     ).not.toThrow();
   });
 
@@ -634,24 +738,47 @@ describe('remaining event kinds — smoke coverage', () => {
     let contentInvalidated = 0;
     const orig = queryClient.invalidateQueries.bind(queryClient);
     queryClient.invalidateQueries = ((opts: { queryKey: unknown[] }) => {
-      if (JSON.stringify(opts.queryKey) === JSON.stringify(fileContentKeys.all)) contentInvalidated++;
+      if (JSON.stringify(opts.queryKey) === JSON.stringify(fileContentKeys.all))
+        contentInvalidated++;
       return orig(opts);
     }) as typeof queryClient.invalidateQueries;
 
-    handleEvent({ id: 'evt_1', type: 'file.edited', properties: { file: 'src/app.ts' } });
+    handleEvent({
+      id: 'evt_1',
+      type: 'file.edited',
+      properties: { file: 'src/app.ts' },
+    });
     expect(contentInvalidated).toBe(1);
   });
 
   test('installation.updated shows a toast', () => {
     const { handleEvent } = buildHandler();
-    handleEvent({ id: 'evt_1', type: 'installation.updated', properties: { version: '1.2.3' } });
-    expect(toasts).toEqual([{ level: 'info', message: 'Installation updated (v1.2.3). Restart to apply changes.' }]);
+    handleEvent({
+      id: 'evt_1',
+      type: 'installation.updated',
+      properties: { version: '1.2.3' },
+    });
+    expect(toasts).toEqual([
+      {
+        level: 'info',
+        message: 'Installation updated (v1.2.3). Restart to apply changes.',
+      },
+    ]);
   });
 
   test('installation.update-available shows a toast', () => {
     const { handleEvent } = buildHandler();
-    handleEvent({ id: 'evt_1', type: 'installation.update-available', properties: { version: '2.0.0' } });
-    expect(toasts).toEqual([{ level: 'info', message: 'v2.0.0 is available. Update when you\'re ready.' }]);
+    handleEvent({
+      id: 'evt_1',
+      type: 'installation.update-available',
+      properties: { version: '2.0.0' },
+    });
+    expect(toasts).toEqual([
+      {
+        level: 'info',
+        message: "v2.0.0 is available. Update when you're ready.",
+      },
+    ]);
   });
 
   test('pty.* events invalidate the pty list', () => {
@@ -663,7 +790,11 @@ describe('remaining event kinds — smoke coverage', () => {
       return orig(opts);
     }) as typeof queryClient.invalidateQueries;
 
-    handleEvent({ id: 'evt_1', type: 'pty.created', properties: { info: { id: 'pty_1' } } as never });
+    handleEvent({
+      id: 'evt_1',
+      type: 'pty.created',
+      properties: { info: { id: 'pty_1' } } as never,
+    });
     expect(ptyInvalidated).toBe(1);
   });
 

--- a/packages/sdk/src/react/use-opencode-events/handle-event.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.ts
@@ -15,7 +15,10 @@ import {
 import { deleteSessionFromIDB } from '../../browser/cache/idb-sync-cache';
 import { useSyncStore } from '../../browser/stores/sync-store';
 import { getClient } from '../../core/runtime/client';
-import { SESSION_SYNC_PAGE_SIZE, type SessionSyncReason } from '../../core/session-sync/session-sync-controller';
+import {
+  SESSION_SYNC_PAGE_SIZE,
+  type SessionSyncReason,
+} from '../../core/session-sync/session-sync-controller';
 import { fileContentKeys, fileListKeys, gitStatusKeys } from '../file-keys';
 import { ptyKeys } from '../use-opencode-pty';
 import { type MessageWithParts, opencodeKeys, type Session } from '../use-opencode-sessions';
@@ -57,13 +60,15 @@ export function createEventHandler(deps: {
     markSessionAbortedLocally,
     fetchLspDiagnosticsDebounced,
   } = deps;
-  const reconcileTail = deps.reconcileSessionTail ?? (async (sessionID: string) => {
-    const result = await client.session.messages({
-      sessionID,
-      limit: SESSION_SYNC_PAGE_SIZE,
+  const reconcileTail =
+    deps.reconcileSessionTail ??
+    (async (sessionID: string) => {
+      const result = await client.session.messages({
+        sessionID,
+        limit: SESSION_SYNC_PAGE_SIZE,
+      });
+      if (result.data) useSyncStore.getState().hydrate(sessionID, result.data);
     });
-    if (result.data) useSyncStore.getState().hydrate(sessionID, result.data);
-  });
 
   // Helper: look up a session title from the React Query cache for notifications
   function getSessionTitle(sessionID: string): string | undefined {
@@ -72,7 +77,7 @@ export function createEventHandler(deps: {
       const s = sessions.find((s) => s.id === sessionID);
       if (s?.title) return s.title;
     }
-    const session = queryClient.getQueryData<Session>(opencodeKeys.session(sessionID));
+    const session = queryClient.getQueryData<Session>(opencodeKeys.runtimeSession(sessionID));
     return session?.title || undefined;
   }
 
@@ -123,7 +128,7 @@ export function createEventHandler(deps: {
             }
             return [info, ...old].sort((a, b) => b.time.updated - a.time.updated);
           });
-          queryClient.setQueryData(opencodeKeys.session(info.id), info);
+          queryClient.setQueryData(opencodeKeys.runtimeSession(info.id), info);
           refetchKortixSessionMirrors(queryClient);
         }
         break;
@@ -139,11 +144,11 @@ export function createEventHandler(deps: {
             queryClient
               .getQueryData<Session[]>(opencodeKeys.sessions())
               ?.find((s) => s.id === info.id)?.title ??
-            queryClient.getQueryData<Session>(opencodeKeys.session(info.id))?.title ??
+            queryClient.getQueryData<Session>(opencodeKeys.runtimeSession(info.id))?.title ??
             null;
           const titleChanged = !!info.title && info.title !== prevTitle;
           // Only update individual session cache (cheap, targeted)
-          queryClient.setQueryData(opencodeKeys.session(info.id), info);
+          queryClient.setQueryData(opencodeKeys.runtimeSession(info.id), info);
           // Update session list only if the session actually changed
           queryClient.setQueryData<Session[]>(opencodeKeys.sessions(), (old) => {
             if (!old) return old;
@@ -152,10 +157,7 @@ export function createEventHandler(deps: {
             // Shallow check: skip only if BOTH the timestamp and the title are
             // unchanged. Title alone can flip (opencode auto-titles) without a
             // perceptible time bump, and dropping that would keep the tab stale.
-            if (
-              old[idx].time.updated === info.time.updated &&
-              old[idx].title === info.title
-            )
+            if (old[idx].time.updated === info.time.updated && old[idx].title === info.title)
               return old;
             const next = [...old];
             next[idx] = info;
@@ -175,8 +177,12 @@ export function createEventHandler(deps: {
             if (!found) return old;
             return old.filter((s) => s.id !== info.id);
           });
-          queryClient.removeQueries({ queryKey: opencodeKeys.session(info.id) });
-          queryClient.removeQueries({ queryKey: opencodeKeys.messages(info.id) });
+          queryClient.removeQueries({
+            queryKey: opencodeKeys.runtimeSession(info.id),
+          });
+          queryClient.removeQueries({
+            queryKey: opencodeKeys.runtimeMessages(info.id),
+          });
           deleteSessionFromIDB(info.id);
         }
         break;
@@ -195,7 +201,7 @@ export function createEventHandler(deps: {
             .then((res) => {
               if (res.data) {
                 const session = res.data;
-                queryClient.setQueryData(opencodeKeys.session(sessionID), session);
+                queryClient.setQueryData(opencodeKeys.runtimeSession(sessionID), session);
                 // Also update in session list
                 queryClient.setQueryData<Session[]>(opencodeKeys.sessions(), (old) => {
                   if (!old) return old;
@@ -224,8 +230,14 @@ export function createEventHandler(deps: {
             // Agent finished editing files — refresh the Changes panel.
             // Nothing else invalidates git status for agent-driven edits,
             // so without this the panel shows stale diff state.
-            queryClient.invalidateQueries({ queryKey: gitStatusKeys.all, type: 'active' });
-            queryClient.invalidateQueries({ queryKey: fileListKeys.all, type: 'active' });
+            queryClient.invalidateQueries({
+              queryKey: gitStatusKeys.all,
+              type: 'active',
+            });
+            queryClient.invalidateQueries({
+              queryKey: fileListKeys.all,
+              type: 'active',
+            });
           }
         }
         break;
@@ -240,8 +252,14 @@ export function createEventHandler(deps: {
             // Agent finished editing files — refresh the Changes panel.
             // Nothing else invalidates git status for agent-driven edits,
             // so without this the panel shows stale diff state.
-            queryClient.invalidateQueries({ queryKey: gitStatusKeys.all, type: 'active' });
-            queryClient.invalidateQueries({ queryKey: fileListKeys.all, type: 'active' });
+            queryClient.invalidateQueries({
+              queryKey: gitStatusKeys.all,
+              type: 'active',
+            });
+            queryClient.invalidateQueries({
+              queryKey: fileListKeys.all,
+              type: 'active',
+            });
           }
         }
         break;
@@ -268,7 +286,7 @@ export function createEventHandler(deps: {
           // 2. Some error paths (model-not-found, agent-not-found) never
           //    emit message.updated with .error at all
           // 3. Polling can race and overwrite the error from message.updated
-          const key = opencodeKeys.messages(sessionID);
+          const key = opencodeKeys.runtimeMessages(sessionID);
           queryClient.cancelQueries({ queryKey: key });
           queryClient.setQueryData<MessageWithParts[]>(key, (old) => {
             if (!old || old.length === 0) return old;
@@ -345,9 +363,7 @@ export function createEventHandler(deps: {
           addQuestion(props);
           // Fire browser notification for questions needing user input
           const questionText =
-            props.questions[0]?.question ||
-            props.questions[0]?.header ||
-            'Kortix needs your input';
+            props.questions[0]?.question || props.questions[0]?.header || 'Kortix needs your input';
           notifyQuestion(props.sessionID, questionText, getSessionTitle(props.sessionID));
         }
         break;
@@ -400,18 +416,39 @@ export function createEventHandler(deps: {
         // tools, and commands. Invalidate all cached app metadata so
         // the UI picks up newly installed marketplace components or
         // agent-created skills/agents immediately.
-        queryClient.invalidateQueries({ queryKey: opencodeKeys.sessions(), type: 'active' });
-        queryClient.invalidateQueries({ queryKey: opencodeKeys.mcpStatus(), type: 'active' });
-        queryClient.invalidateQueries({ queryKey: opencodeKeys.skills(), type: 'active' });
-        queryClient.invalidateQueries({ queryKey: opencodeKeys.agents(), type: 'active' });
-        queryClient.invalidateQueries({ queryKey: opencodeKeys.toolIds(), type: 'active' });
-        queryClient.invalidateQueries({ queryKey: opencodeKeys.commands(), type: 'active' });
+        queryClient.invalidateQueries({
+          queryKey: opencodeKeys.sessions(),
+          type: 'active',
+        });
+        queryClient.invalidateQueries({
+          queryKey: opencodeKeys.mcpStatus(),
+          type: 'active',
+        });
+        queryClient.invalidateQueries({
+          queryKey: opencodeKeys.skills(),
+          type: 'active',
+        });
+        queryClient.invalidateQueries({
+          queryKey: opencodeKeys.agents(),
+          type: 'active',
+        });
+        queryClient.invalidateQueries({
+          queryKey: opencodeKeys.toolIds(),
+          type: 'active',
+        });
+        queryClient.invalidateQueries({
+          queryKey: opencodeKeys.commands(),
+          type: 'active',
+        });
         break;
       }
 
       // ---- LSP updated ----
       case 'lsp.updated': {
-        queryClient.invalidateQueries({ queryKey: ['opencode', 'lsp'], type: 'active' });
+        queryClient.invalidateQueries({
+          queryKey: ['opencode', 'lsp'],
+          type: 'active',
+        });
         // A new LSP client connected — fetch diagnostics after a short
         // delay to give the language server time to produce initial results.
         fetchLspDiagnosticsDebounced.current();
@@ -431,8 +468,14 @@ export function createEventHandler(deps: {
       case 'mcp.tools.changed': {
         // MCP server tools were added/removed/changed — refresh status + tool lists.
         // Only refetch if queries are actively mounted (type: 'active').
-        queryClient.refetchQueries({ queryKey: opencodeKeys.mcpStatus(), type: 'active' });
-        queryClient.refetchQueries({ queryKey: opencodeKeys.toolIds(), type: 'active' });
+        queryClient.refetchQueries({
+          queryKey: opencodeKeys.mcpStatus(),
+          type: 'active',
+        });
+        queryClient.refetchQueries({
+          queryKey: opencodeKeys.toolIds(),
+          type: 'active',
+        });
         break;
       }
 
@@ -441,19 +484,31 @@ export function createEventHandler(deps: {
       case 'pty.updated':
       case 'pty.exited':
       case 'pty.deleted': {
-        queryClient.invalidateQueries({ queryKey: ptyKeys.listPrefix(), type: 'active' });
+        queryClient.invalidateQueries({
+          queryKey: ptyKeys.listPrefix(),
+          type: 'active',
+        });
         break;
       }
 
       // ---- Worktree events — disabled for now ----
       case 'worktree.ready': {
-        queryClient.invalidateQueries({ queryKey: opencodeKeys.worktrees(), type: 'active' });
-        queryClient.invalidateQueries({ queryKey: opencodeKeys.projects(), type: 'active' });
+        queryClient.invalidateQueries({
+          queryKey: opencodeKeys.worktrees(),
+          type: 'active',
+        });
+        queryClient.invalidateQueries({
+          queryKey: opencodeKeys.projects(),
+          type: 'active',
+        });
         break;
       }
 
       case 'worktree.failed': {
-        queryClient.invalidateQueries({ queryKey: opencodeKeys.worktrees(), type: 'active' });
+        queryClient.invalidateQueries({
+          queryKey: opencodeKeys.worktrees(),
+          type: 'active',
+        });
         break;
       }
 
@@ -469,10 +524,19 @@ export function createEventHandler(deps: {
       // ---- File edited (outside agent, e.g. user edits in editor) ----
       case 'file.edited': {
         const fileProps = event.properties;
-        queryClient.invalidateQueries({ queryKey: fileListKeys.all, type: 'active' });
-        queryClient.invalidateQueries({ queryKey: gitStatusKeys.all, type: 'active' });
+        queryClient.invalidateQueries({
+          queryKey: fileListKeys.all,
+          type: 'active',
+        });
+        queryClient.invalidateQueries({
+          queryKey: gitStatusKeys.all,
+          type: 'active',
+        });
         if (fileProps.file) {
-          queryClient.invalidateQueries({ queryKey: fileContentKeys.all, type: 'active' });
+          queryClient.invalidateQueries({
+            queryKey: fileContentKeys.all,
+            type: 'active',
+          });
         }
         break;
       }

--- a/packages/sdk/src/react/use-opencode-sessions/keys.test.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/keys.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+import { opencodeKeys } from './keys';
+
+describe('OpenCode runtime query keys', () => {
+  test('scopes a repeated OpenCode session id to its sandbox runtime', () => {
+    expect(opencodeKeys.runtimeSession('ses_shared', 'sandbox-a')).not.toEqual(
+      opencodeKeys.runtimeSession('ses_shared', 'sandbox-b'),
+    );
+    expect(opencodeKeys.runtimeMessages('ses_shared', 'sandbox-a')).not.toEqual(
+      opencodeKeys.runtimeMessages('ses_shared', 'sandbox-b'),
+    );
+  });
+
+  test('keeps the runtime scope at the end for prefix invalidation compatibility', () => {
+    expect(opencodeKeys.runtimeSession('ses_1', 'sandbox-a')).toEqual([
+      'opencode',
+      'session',
+      'ses_1',
+      'sandbox-a',
+    ]);
+    expect(opencodeKeys.runtimeMessages('ses_1', 'sandbox-a')).toEqual([
+      'opencode',
+      'session',
+      'ses_1',
+      'messages',
+      'sandbox-a',
+    ]);
+  });
+
+  test('preserves legacy key factories for published consumers', () => {
+    expect(opencodeKeys.session('ses_1')).toEqual(['opencode', 'session', 'ses_1']);
+    expect(opencodeKeys.messages('ses_1')).toEqual(['opencode', 'session', 'ses_1', 'messages']);
+  });
+});

--- a/packages/sdk/src/react/use-opencode-sessions/keys.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/keys.ts
@@ -27,7 +27,23 @@ import type {
 // Re-export SDK types for consumers
 // ============================================================================
 
-export type { Session, Message, Part, Agent, Command, Project, SessionStatus, PermissionRule, Model, McpStatus, PathInfo, Worktree, WorktreeCreateInput, WorktreeRemoveInput, WorktreeResetInput };
+export type {
+  Session,
+  Message,
+  Part,
+  Agent,
+  Command,
+  Project,
+  SessionStatus,
+  PermissionRule,
+  Model,
+  McpStatus,
+  PathInfo,
+  Worktree,
+  WorktreeCreateInput,
+  WorktreeRemoveInput,
+  WorktreeResetInput,
+};
 
 /**
  * Shape returned by `client.session.messages()`:
@@ -51,8 +67,22 @@ export type ProviderListResponse = SdkProviderListResponse;
  */
 export type PromptPart =
   | { type: 'text'; text: string; id?: string }
-  | { type: 'file'; mime: string; url: string; filename?: string; source?: { text: { value: string; start: number; end: number }; type: 'file'; path: string } }
-  | { type: 'agent'; name: string; source?: { value: string; start: number; end: number } };
+  | {
+      type: 'file';
+      mime: string;
+      url: string;
+      filename?: string;
+      source?: {
+        text: { value: string; start: number; end: number };
+        type: 'file';
+        path: string;
+      };
+    }
+  | {
+      type: 'agent';
+      name: string;
+      source?: { value: string; start: number; end: number };
+    };
 
 export interface SendMessageOptions {
   model?: { providerID: string; modelID: string };
@@ -91,9 +121,14 @@ export const opencodeKeys = {
   sessions: (serverId?: string) => ['opencode', 'sessions', serverId ?? activeServerKey()] as const,
   session: (id: string) => ['opencode', 'session', id] as const,
   messages: (sessionId: string) => ['opencode', 'session', sessionId, 'messages'] as const,
+  runtimeSession: (id: string, serverId?: string) =>
+    ['opencode', 'session', id, serverId ?? activeServerKey()] as const,
+  runtimeMessages: (sessionId: string, serverId?: string) =>
+    ['opencode', 'session', sessionId, 'messages', serverId ?? activeServerKey()] as const,
   agents: () => ['opencode', 'agents', activeServerKey()] as const,
   toolIds: () => ['opencode', 'tool-ids', activeServerKey()] as const,
-  tools: (providerID: string, modelID: string) => ['opencode', 'tools', providerID, modelID, activeServerKey()] as const,
+  tools: (providerID: string, modelID: string) =>
+    ['opencode', 'tools', providerID, modelID, activeServerKey()] as const,
   skills: () => ['opencode', 'skills', activeServerKey()] as const,
   projects: () => ['opencode', 'projects', activeServerKey()] as const,
   currentProject: () => ['opencode', 'project', 'current', activeServerKey()] as const,

--- a/packages/sdk/src/react/use-opencode-sessions/sessions.test.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/sessions.test.ts
@@ -18,7 +18,8 @@ function makeFakeQueryClient() {
   return {
     setQueryData: (k: readonly unknown[], updater: unknown) => {
       const existing = cache.get(cacheKey(k));
-      const value = typeof updater === 'function' ? (updater as (old: unknown) => unknown)(existing) : updater;
+      const value =
+        typeof updater === 'function' ? (updater as (old: unknown) => unknown)(existing) : updater;
       cache.set(cacheKey(k), value);
       return value;
     },
@@ -56,7 +57,10 @@ mock.module('../../browser/stores/opencode-compaction-store', () => ({
   useOpenCodeCompactionStore: Object.assign(
     (selector: (s: ReturnType<typeof realCompactionStore.getState>) => unknown) =>
       selector(realCompactionStore.getState()),
-    { getState: realCompactionStore.getState, setState: realCompactionStore.setState },
+    {
+      getState: realCompactionStore.getState,
+      setState: realCompactionStore.setState,
+    },
   ),
 }));
 
@@ -78,7 +82,11 @@ describe('useSummarizeOpenCodeSession — model resolution fallback chain', () =
   test('tier 1: uses the config default model when neither providerID nor modelID is given', async () => {
     let summarizeArgs: unknown;
     clientImpl = {
-      global: { config: { get: async () => ({ data: { model: 'anthropic/claude-opus' } }) } },
+      global: {
+        config: {
+          get: async () => ({ data: { model: 'anthropic/claude-opus' } }),
+        },
+      },
       session: {
         summarize: async (args: unknown) => {
           summarizeArgs = args;
@@ -92,23 +100,40 @@ describe('useSummarizeOpenCodeSession — model resolution fallback chain', () =
     const result = await mutationFn({ sessionId: 'ses_1' });
 
     expect(result).toBe('ses_1');
-    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'anthropic', modelID: 'claude-opus' });
+    expect(summarizeArgs).toEqual({
+      sessionID: 'ses_1',
+      providerID: 'anthropic',
+      modelID: 'claude-opus',
+    });
   });
 
   test('tier 1 splits a multi-segment model id: provider is the first segment, model is the rest', async () => {
     let summarizeArgs: unknown;
     clientImpl = {
-      global: { config: { get: async () => ({ data: { model: 'openrouter/z-ai/glm-5.2' } }) } },
-      session: { summarize: async (args: unknown) => { summarizeArgs = args; return { data: {} }; } },
+      global: {
+        config: {
+          get: async () => ({ data: { model: 'openrouter/z-ai/glm-5.2' } }),
+        },
+      },
+      session: {
+        summarize: async (args: unknown) => {
+          summarizeArgs = args;
+          return { data: {} };
+        },
+      },
     };
     const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
       mutationFn: (args: { sessionId: string }) => Promise<string>;
     };
     await mutationFn({ sessionId: 'ses_1' });
-    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'openrouter', modelID: 'z-ai/glm-5.2' });
+    expect(summarizeArgs).toEqual({
+      sessionID: 'ses_1',
+      providerID: 'openrouter',
+      modelID: 'z-ai/glm-5.2',
+    });
   });
 
-  test('tier 2: falls back to the session\'s last assistant message model when config has none', async () => {
+  test("tier 2: falls back to the session's last assistant message model when config has none", async () => {
     let summarizeArgs: unknown;
     clientImpl = {
       global: { config: { get: async () => ({ data: {} }) } },
@@ -116,7 +141,13 @@ describe('useSummarizeOpenCodeSession — model resolution fallback chain', () =
         messages: async () => ({
           data: [
             { info: { role: 'user' } },
-            { info: { role: 'assistant', providerID: 'anthropic', modelID: 'claude-sonnet' } },
+            {
+              info: {
+                role: 'assistant',
+                providerID: 'anthropic',
+                modelID: 'claude-sonnet',
+              },
+            },
           ],
         }),
         summarize: async (args: unknown) => {
@@ -129,7 +160,11 @@ describe('useSummarizeOpenCodeSession — model resolution fallback chain', () =
       mutationFn: (args: { sessionId: string }) => Promise<string>;
     };
     await mutationFn({ sessionId: 'ses_1' });
-    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'anthropic', modelID: 'claude-sonnet' });
+    expect(summarizeArgs).toEqual({
+      sessionID: 'ses_1',
+      providerID: 'anthropic',
+      modelID: 'claude-sonnet',
+    });
   });
 
   test('tier 3: falls back to the first connected provider/model when config and history have none', async () => {
@@ -153,23 +188,51 @@ describe('useSummarizeOpenCodeSession — model resolution fallback chain', () =
       mutationFn: (args: { sessionId: string }) => Promise<string>;
     };
     await mutationFn({ sessionId: 'ses_1' });
-    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'kortix', modelID: 'claude-opus-4.8' });
+    expect(summarizeArgs).toEqual({
+      sessionID: 'ses_1',
+      providerID: 'kortix',
+      modelID: 'claude-opus-4.8',
+    });
   });
 
   test('an explicitly-passed providerID/modelID short-circuits every fallback tier', async () => {
     let summarizeArgs: unknown;
     let configFetched = false;
     clientImpl = {
-      global: { config: { get: async () => { configFetched = true; return { data: {} }; } } },
-      session: { summarize: async (args: unknown) => { summarizeArgs = args; return { data: {} }; } },
+      global: {
+        config: {
+          get: async () => {
+            configFetched = true;
+            return { data: {} };
+          },
+        },
+      },
+      session: {
+        summarize: async (args: unknown) => {
+          summarizeArgs = args;
+          return { data: {} };
+        },
+      },
     };
     const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
-      mutationFn: (args: { sessionId: string; providerID?: string; modelID?: string }) => Promise<string>;
+      mutationFn: (args: {
+        sessionId: string;
+        providerID?: string;
+        modelID?: string;
+      }) => Promise<string>;
     };
-    await mutationFn({ sessionId: 'ses_1', providerID: 'anthropic', modelID: 'claude-haiku' });
+    await mutationFn({
+      sessionId: 'ses_1',
+      providerID: 'anthropic',
+      modelID: 'claude-haiku',
+    });
 
     expect(configFetched).toBe(false);
-    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'anthropic', modelID: 'claude-haiku' });
+    expect(summarizeArgs).toEqual({
+      sessionID: 'ses_1',
+      providerID: 'anthropic',
+      modelID: 'claude-haiku',
+    });
   });
 
   test('throws when every tier fails to resolve a model', async () => {
@@ -194,17 +257,40 @@ describe('useSummarizeOpenCodeSession — model resolution fallback chain', () =
   test('a thrown/rejected config.get() is swallowed — falls through to the next tier', async () => {
     let summarizeArgs: unknown;
     clientImpl = {
-      global: { config: { get: async () => { throw new Error('network down'); } } },
+      global: {
+        config: {
+          get: async () => {
+            throw new Error('network down');
+          },
+        },
+      },
       session: {
-        messages: async () => ({ data: [{ info: { role: 'assistant', providerID: 'anthropic', modelID: 'x' } }] }),
-        summarize: async (args: unknown) => { summarizeArgs = args; return { data: {} }; },
+        messages: async () => ({
+          data: [
+            {
+              info: {
+                role: 'assistant',
+                providerID: 'anthropic',
+                modelID: 'x',
+              },
+            },
+          ],
+        }),
+        summarize: async (args: unknown) => {
+          summarizeArgs = args;
+          return { data: {} };
+        },
       },
     };
     const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
       mutationFn: (args: { sessionId: string }) => Promise<string>;
     };
     await mutationFn({ sessionId: 'ses_1' });
-    expect(summarizeArgs).toEqual({ sessionID: 'ses_1', providerID: 'anthropic', modelID: 'x' });
+    expect(summarizeArgs).toEqual({
+      sessionID: 'ses_1',
+      providerID: 'anthropic',
+      modelID: 'x',
+    });
   });
 
   test('onMutate/onError toggle the compaction store around the send', () => {
@@ -239,12 +325,21 @@ describe('useInitSession', () => {
     expect(result).toBe('ses_1');
 
     hook.onSuccess('ses_1');
-    expect(fakeQueryClient.refetchCalls).toEqual([{ queryKey: opencodeKeys.messages('ses_1') }]);
+    expect(fakeQueryClient.refetchCalls).toEqual([
+      { queryKey: opencodeKeys.runtimeMessages('ses_1') },
+    ]);
   });
 
   test('extracts a NotFoundError-shaped error message (`.data.message`)', async () => {
     clientImpl = {
-      session: { command: async () => ({ error: { name: 'NotFoundError', data: { message: 'no such session' } } }) },
+      session: {
+        command: async () => ({
+          error: {
+            name: 'NotFoundError',
+            data: { message: 'no such session' },
+          },
+        }),
+      },
     };
     const { mutationFn } = useInitSession() as unknown as {
       mutationFn: (args: { sessionId: string }) => Promise<string>;
@@ -259,6 +354,8 @@ describe('useInitSession', () => {
     const { mutationFn } = useInitSession() as unknown as {
       mutationFn: (args: { sessionId: string }) => Promise<string>;
     };
-    await expect(mutationFn({ sessionId: 'ses_1' })).rejects.toThrow('Failed to initialize project');
+    await expect(mutationFn({ sessionId: 'ses_1' })).rejects.toThrow(
+      'Failed to initialize project',
+    );
   });
 });

--- a/packages/sdk/src/react/use-opencode-sessions/sessions.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/sessions.ts
@@ -45,8 +45,7 @@ export function useOpenCodeSessions(enabled = true) {
     // the first success in <300ms instead of mid-400ms-window; exponential tail
     // (cap 10s) covers the rare genuinely-stuck case. The old 8x400ms backoff
     // (~3.2s) was the entire 'opencode-listed' wall in the browser trace.
-    retry: (failureCount, error) =>
-      !isOpenCodeConfigInvalidError(error) && failureCount < 16,
+    retry: (failureCount, error) => !isOpenCodeConfigInvalidError(error) && failureCount < 16,
     retryDelay: (attempt) =>
       attempt < 16 ? 150 : Math.min(150 * Math.pow(2, attempt - 16), 10000),
   });
@@ -57,7 +56,7 @@ export function useOpenCodeSession(sessionId: string) {
   const runtimeReady = useOpenCodeRuntimeReady();
   const canQuerySession = canQueryOpenCodeSession(sessionId);
   return useQuery<Session>({
-    queryKey: opencodeKeys.session(sessionId),
+    queryKey: opencodeKeys.runtimeSession(sessionId),
     queryFn: async () => {
       const client = getClient();
       const result = await client.session.get({ sessionID: sessionId });
@@ -68,8 +67,7 @@ export function useOpenCodeSession(sessionId: string) {
     // Retry transient failures (sandbox still warming, brief network blip) so a
     // single failed lookup doesn't settle as "not found" and flash the
     // not-accessible error. The query stays in its loading state across retries.
-    retry: (failureCount, error) =>
-      !isOpenCodeConfigInvalidError(error) && failureCount < 3,
+    retry: (failureCount, error) => !isOpenCodeConfigInvalidError(error) && failureCount < 3,
     retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 10000),
     placeholderData: () => {
       const sessions = queryClient.getQueryData<Session[]>(opencodeKeys.sessions());
@@ -125,7 +123,7 @@ export function useCreateOpenCodeSession() {
         }
         return [session, ...old].sort((a, b) => b.time.updated - a.time.updated);
       });
-      queryClient.setQueryData(opencodeKeys.session(session.id), session);
+      queryClient.setQueryData(opencodeKeys.runtimeSession(session.id), session);
     },
   });
 }
@@ -146,8 +144,12 @@ export function useDeleteOpenCodeSession() {
         if (!old) return old;
         return old.filter((s) => s.id !== sessionId);
       });
-      queryClient.removeQueries({ queryKey: opencodeKeys.session(sessionId) });
-      queryClient.removeQueries({ queryKey: opencodeKeys.messages(sessionId) });
+      queryClient.removeQueries({
+        queryKey: opencodeKeys.runtimeSession(sessionId),
+      });
+      queryClient.removeQueries({
+        queryKey: opencodeKeys.runtimeMessages(sessionId),
+      });
     },
   });
 }
@@ -169,7 +171,10 @@ export function useUpdateOpenCodeSession() {
       const body: { title?: string; time?: { archived?: number } } = {};
       if (title !== undefined) body.title = title;
       if (archived !== undefined) body.time = { archived: archived ? Date.now() : 0 };
-      const result = await client.session.update({ sessionID: sessionId, ...body });
+      const result = await client.session.update({
+        sessionID: sessionId,
+        ...body,
+      });
       return unwrap(result);
     },
     onSuccess: (updatedSession) => {
@@ -183,7 +188,7 @@ export function useUpdateOpenCodeSession() {
         next[idx] = session;
         return next.sort((a, b) => b.time.updated - a.time.updated);
       });
-      queryClient.setQueryData(opencodeKeys.session(session.id), session);
+      queryClient.setQueryData(opencodeKeys.runtimeSession(session.id), session);
     },
   });
 }
@@ -228,7 +233,11 @@ export function useSummarizeOpenCodeSession() {
   const startCompaction = useOpenCodeCompactionStore((s) => s.startCompaction);
   const stopCompaction = useOpenCodeCompactionStore((s) => s.stopCompaction);
   return useMutation({
-    mutationFn: async (params: { sessionId: string; providerID?: string; modelID?: string }) => {
+    mutationFn: async (params: {
+      sessionId: string;
+      providerID?: string;
+      modelID?: string;
+    }) => {
       const client = getClient();
 
       let { providerID, modelID } = params;
@@ -257,7 +266,9 @@ export function useSummarizeOpenCodeSession() {
             sessionID: params.sessionId,
             limit: SESSION_SYNC_PAGE_SIZE,
           });
-          const allMsgs = (msgs.data ?? []) as Array<{ info: { role: string; providerID?: string; modelID?: string } }>;
+          const allMsgs = (msgs.data ?? []) as Array<{
+            info: { role: string; providerID?: string; modelID?: string };
+          }>;
           for (let i = allMsgs.length - 1; i >= 0; i--) {
             const m = allMsgs[i].info;
             if (m.role === 'assistant' && m.providerID && m.modelID) {
@@ -282,7 +293,9 @@ export function useSummarizeOpenCodeSession() {
           const providerResult = await client.provider.list();
           const providers: unknown = providerResult.data;
           if (providers && typeof providers === 'object') {
-            for (const [pid, providerInfo] of Object.entries(providers as Record<string, unknown>)) {
+            for (const [pid, providerInfo] of Object.entries(
+              providers as Record<string, unknown>,
+            )) {
               const models =
                 providerInfo && typeof providerInfo === 'object'
                   ? (providerInfo as Record<string, unknown>).models
@@ -353,7 +366,8 @@ export function useInitSession() {
         // NotFoundError`) doesn't share a `.message`/`.data.message` shape
         // across all members — duck-type defensively rather than assume one.
         const err = result.error;
-        const errRec = err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
+        const errRec =
+          err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
         const dataRec =
           errRec?.data && typeof errRec.data === 'object'
             ? (errRec.data as Record<string, unknown>)
@@ -366,7 +380,9 @@ export function useInitSession() {
     onSuccess: (sessionId) => {
       // SSE events handle session updates. Just refetch messages for this session
       // since /init creates new messages.
-      queryClient.refetchQueries({ queryKey: opencodeKeys.messages(sessionId) });
+      queryClient.refetchQueries({
+        queryKey: opencodeKeys.runtimeMessages(sessionId),
+      });
     },
     // Suppress global error handler — caller handles errors via onError callback
     onError: () => {},

--- a/packages/sdk/src/react/use-opencode-sessions/shared.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/shared.ts
@@ -25,8 +25,9 @@ import type {
  * longer need to tear anything down. Appended at the END so existing prefix
  * matches (e.g. invalidate `['opencode','sessions']`) still hit.
  *
- * `session(id)` / `messages(id)` stay global: opencode session ids are unique
- * per sandbox, so they never collide across sandboxes.
+ * Session and message keys also include this scope. Warm snapshots can contain
+ * a baked OpenCode id before each fork rotates to its final root. Cache safety
+ * must not depend on that rotation completing before a client reads data.
  */
 export function activeServerKey(): string {
   try {
@@ -40,7 +41,11 @@ export function activeServerKey(): string {
 // Helper: unwrap SDK response (data / error)
 // ============================================================================
 
-export function unwrap<T>(result: { data?: T; error?: unknown; response?: Response }): T {
+export function unwrap<T>(result: {
+  data?: T;
+  error?: unknown;
+  response?: Response;
+}): T {
   if (result.error) {
     const err = result.error;
     const status = (result.response as Response | undefined)?.status;
@@ -50,7 +55,9 @@ export function unwrap<T>(result: { data?: T; error?: unknown; response?: Respon
     // duck-types defensively instead of assuming a shape.
     const errRec = err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
     const dataRec =
-      errRec?.data && typeof errRec.data === 'object' ? (errRec.data as Record<string, unknown>) : undefined;
+      errRec?.data && typeof errRec.data === 'object'
+        ? (errRec.data as Record<string, unknown>)
+        : undefined;
     const msg =
       dataRec?.message ||
       errRec?.message ||

--- a/packages/sdk/src/react/use-opencode-sessions/sharing.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/sharing.ts
@@ -21,7 +21,7 @@ export function useShareSession() {
     },
     onSuccess: (updatedSession) => {
       // Surgically update cache with share info
-      queryClient.setQueryData(opencodeKeys.session(updatedSession.id), updatedSession);
+      queryClient.setQueryData(opencodeKeys.runtimeSession(updatedSession.id), updatedSession);
       queryClient.setQueryData<Session[]>(opencodeKeys.sessions(), (old) => {
         if (!old) return old;
         const idx = old.findIndex((s) => s.id === updatedSession.id);
@@ -45,7 +45,7 @@ export function useUnshareSession() {
     },
     onSuccess: (updatedSession) => {
       // Surgically update cache with unshare info
-      queryClient.setQueryData(opencodeKeys.session(updatedSession.id), updatedSession);
+      queryClient.setQueryData(opencodeKeys.runtimeSession(updatedSession.id), updatedSession);
       queryClient.setQueryData<Session[]>(opencodeKeys.sessions(), (old) => {
         if (!old) return old;
         const idx = old.findIndex((s) => s.id === updatedSession.id);

--- a/packages/sdk/src/react/use-session-runtime-gate.test.ts
+++ b/packages/sdk/src/react/use-session-runtime-gate.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('./use-session.ts', import.meta.url), 'utf8');
+
+describe('useSession runtime ownership gate', () => {
+  test('does not connect OpenCode transports before /start switches the sandbox', () => {
+    expect(source).toContain(
+      'enabled: switched && runtimePolicy.streamOpenCodeEvents',
+    );
+    expect(source).toContain('networkEnabled: switched');
+  });
+});

--- a/packages/sdk/src/react/use-session-sync.ts
+++ b/packages/sdk/src/react/use-session-sync.ts
@@ -5,6 +5,7 @@ import { useEffect, useSyncExternalStore } from 'react';
 import {
   getSessionSyncController,
   loadSessionTranscriptMessages,
+  resetSessionSyncControllersForSession,
   retainSessionSyncController,
 } from '../browser/session-sync/session-sync-registry';
 import {
@@ -13,9 +14,15 @@ import {
   toHydrateEntries,
   writeCachedTranscript,
 } from '../browser/session-sync/session-transcript-cache';
+import {
+  claimSessionCacheOwnership,
+  getSessionCacheOwnership,
+  resolveSessionCacheOwnerScope,
+} from '../browser/session-sync/session-cache-ownership';
 import { useSandboxConnectionStore } from '../browser/stores/sandbox-connection-store';
 import { type MessageWithParts, useSyncStore } from '../browser/stores/sync-store';
 import { canQueryOpenCodeSession } from './use-opencode-sessions';
+import { useCurrentRuntime } from './use-current-runtime';
 
 export { loadSessionTranscriptMessages };
 
@@ -81,14 +88,51 @@ function buildMessages(
  * Returns the current session tail and explicit history-loading state.
  * Network synchronization lives in the framework-free SessionSyncController.
  */
-export function useSessionSync(sessionId: string) {
+interface UseSessionSyncOptions {
+  /**
+   * Stable Kortix `(projectId, sessionId)` scope for disk transcript ownership.
+   * This prevents equal OpenCode ids in different sandboxes from sharing data.
+   */
+  kortixSessionScope?: string;
+  /**
+   * Allow live REST reconciliation against the current runtime.
+   * Set false while `/start` has not switched this Kortix session's sandbox.
+   */
+  networkEnabled?: boolean;
+}
+
+export function useSessionSync(sessionId: string, options: UseSessionSyncOptions = {}) {
+  const { kortixSessionScope, networkEnabled = true } = options;
   const runtimeHealthy = useSandboxConnectionStore((state) => state.healthy === true);
-  const controller = getSessionSyncController(sessionId);
+  const runtimeScope = useCurrentRuntime((state) => state.sandboxId) ?? 'none';
+  const cacheOwnerScope = resolveSessionCacheOwnerScope(runtimeScope, kortixSessionScope);
+  const currentOwner = getSessionCacheOwnership(sessionId);
+  const cacheBelongsToAnotherRuntime =
+    !!sessionId &&
+    cacheOwnerScope !== null &&
+    currentOwner !== null &&
+    currentOwner !== cacheOwnerScope;
+  const readableSessionId = cacheBelongsToAnotherRuntime ? '' : sessionId;
+  const controller = getSessionSyncController(sessionId, undefined, runtimeScope);
   const sync = useSyncExternalStore(
     controller.subscribe,
     controller.getSnapshot,
     controller.getSnapshot,
   );
+
+  useEffect(() => {
+    if (!canQueryOpenCodeSession(sessionId) || !cacheOwnerScope) return;
+    const claim = claimSessionCacheOwnership(sessionId, cacheOwnerScope);
+    if (!claim.previousOwnerScope || claim.previousOwnerScope === cacheOwnerScope) {
+      return;
+    }
+    resetSessionSyncControllersForSession(
+      sessionId,
+      runtimeScope === 'none' ? undefined : runtimeScope,
+    );
+    useSyncStore.getState().clearSession(sessionId);
+    messageCache.delete(sessionId);
+  }, [cacheOwnerScope, runtimeScope, sessionId]);
 
   // Paint from disk FIRST, and deliberately without waiting on `runtimeHealthy`.
   // The transcript is settled history; gating it on a woken sandbox is what made
@@ -99,7 +143,7 @@ export function useSessionSync(sessionId: string) {
     if (!canQueryOpenCodeSession(sessionId)) return;
     let cancelled = false;
     void (async () => {
-      const cached = await readCachedTranscript(sessionId);
+      const cached = await readCachedTranscript(sessionId, kortixSessionScope);
       if (cancelled || !cached) return;
       const store = useSyncStore.getState();
       if (
@@ -115,11 +159,18 @@ export function useSessionSync(sessionId: string) {
     return () => {
       cancelled = true;
     };
-  }, [sessionId]);
+  }, [kortixSessionScope, sessionId]);
 
   useEffect(() => {
-    if (!canQueryOpenCodeSession(sessionId) || !runtimeHealthy) return;
-    const release = retainSessionSyncController(sessionId);
+    if (
+      !networkEnabled ||
+      !canQueryOpenCodeSession(sessionId) ||
+      !runtimeHealthy ||
+      runtimeScope === 'none'
+    )
+      return;
+    resetSessionSyncControllersForSession(sessionId, runtimeScope);
+    const release = retainSessionSyncController(sessionId, runtimeScope);
     // Cached messages render immediately. Revalidate one bounded tail so
     // events produced while this route was inactive are not skipped.
     void controller.reconcile('initial');
@@ -127,7 +178,7 @@ export function useSessionSync(sessionId: string) {
       release();
       messageCache.delete(sessionId);
     };
-  }, [controller, runtimeHealthy, sessionId]);
+  }, [controller, networkEnabled, runtimeHealthy, runtimeScope, sessionId]);
 
   // Mirror the tail back to disk as it changes, so the NEXT open of this session
   // has something to paint. Subscribing to the store (rather than reacting to
@@ -144,30 +195,30 @@ export function useSessionSync(sessionId: string) {
       if (state.messages[sessionId] === lastMessages && state.parts === lastParts) return;
       lastMessages = state.messages[sessionId];
       lastParts = state.parts;
-      void writeCachedTranscript(state, sessionId);
+      void writeCachedTranscript(state, sessionId, kortixSessionScope);
     };
     persist(useSyncStore.getState());
     return useSyncStore.subscribe(persist);
-  }, [sessionId]);
+  }, [kortixSessionScope, sessionId]);
 
   const messages = useSyncStore((state) =>
-    buildMessages(sessionId, state.messages[sessionId], state.parts),
+    buildMessages(readableSessionId, state.messages[readableSessionId], state.parts),
   );
 
   const runtimeStatus = useSyncStore(
-    (state) => state.sessionStatus[sessionId] ?? IDLE_STATUS,
+    (state) => state.sessionStatus[readableSessionId] ?? IDLE_STATUS,
   ) as SessionStatus;
   const status =
     sync.isPromptObservedBusy && runtimeStatus.type === 'idle' ? BUSY_STATUS : runtimeStatus;
-  const diffs = useSyncStore((state) => state.diffs[sessionId]) as FileDiff[] | undefined;
-  const todos = useSyncStore((state) => state.todos[sessionId]) as Todo[] | undefined;
+  const diffs = useSyncStore((state) => state.diffs[readableSessionId]) as FileDiff[] | undefined;
+  const todos = useSyncStore((state) => state.todos[readableSessionId]) as Todo[] | undefined;
 
   const isBusy = status.type === 'busy' || status.type === 'retry';
-  const isLoading = !useSyncStore((state) => sessionId in state.messages);
+  const isLoading = !useSyncStore((state) => readableSessionId in state.messages);
 
   useEffect(() => {
-    controller.setBusy(runtimeHealthy && isBusy);
-  }, [controller, isBusy, runtimeHealthy]);
+    controller.setBusy(networkEnabled && runtimeHealthy && isBusy);
+  }, [controller, isBusy, networkEnabled, runtimeHealthy]);
 
   return {
     messages,

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -55,7 +55,7 @@ import { formatOpenCodeRuntimeError } from '../core/http/opencode-errors';
 import { extractGatewayErrorDetails } from '../core/turns/errors';
 import { useCanonicalOpenCodeSession } from './use-canonical-opencode-session';
 import { useAcpSessionRuntime } from './use-acp-session-runtime';
-import { hasSessionRuntimeIdentity } from './session-runtime-identity';
+import { isSessionRuntimeActionReady } from './session-runtime-identity';
 import { resolveSessionBusy } from './session-busy';
 import { useOpenCodeEventStream } from './use-opencode-events';
 import type { ModelKey } from './use-model-store';
@@ -477,7 +477,9 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
   // 4. Open the live SSE stream. This was a provider component (OpenCodeEvent
   // StreamProvider); calling the underlying hook here means the host mounts
   // nothing. It self-gates on the connection store's healthy flag (seeded above).
-  useOpenCodeEventStream({ enabled: runtimePolicy.streamOpenCodeEvents });
+  useOpenCodeEventStream({
+    enabled: switched && runtimePolicy.streamOpenCodeEvents,
+  });
 
   // 5. Resolve the canonical OpenCode root id (server-owned; /start hands it over)
   // and sync messages off it.
@@ -486,7 +488,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
     sessionId,
     pinFromStart: startData?.opencode_session_id ?? null,
     initialPin: initialOpenCodeSessionId,
-    listRuntimeSessions: runtimePolicy.listOpenCodeSessions,
+    listRuntimeSessions: switched && runtimePolicy.listOpenCodeSessions,
   });
   const { rootSessionId } = canonicalSession;
   const ocSessionId = rootSessionId ?? '';
@@ -521,6 +523,10 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
   // result instead of whatever it happens to return for that starved call.
   const rawSync = useSessionSync(
     chatEngine && runtimePolicy.syncOpenCodeMessages ? ocSessionId : '',
+    {
+      kortixSessionScope: `${projectId}/${sessionId}`,
+      networkEnabled: switched,
+    },
   );
   const acpSync = useMemo(
     () => ({
@@ -569,10 +575,10 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
   // is off — see that option's jsdoc: a host mounting its own chat surface
   // already runs its own copy of this poller for the same session.
   useQuestionSelfHeal(ocSessionId, sync.messages, {
-    enabled: !usesAcp && chatEngine && !!ocSessionId,
+    enabled: switched && !usesAcp && chatEngine && !!ocSessionId,
   });
   usePermissionSelfHeal(ocSessionId, sync.messages, {
-    enabled: !usesAcp && chatEngine && !!ocSessionId,
+    enabled: switched && !usesAcp && chatEngine && !!ocSessionId,
   });
 
   // 6. Interactive prompts live in the pending store (the SSE writes them there,
@@ -580,7 +586,10 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
   const questionMap = useOpenCodePendingStore((s) => s.questions);
   const permissionMap = useOpenCodePendingStore((s) => s.permissions);
   const isCompacting = useOpenCodeCompactionStore(
-    (state) => !usesAcp && Boolean(state.compactingBySession[ocSessionId]),
+    (state) =>
+      switched &&
+      !usesAcp &&
+      Boolean(state.compactingBySession[ocSessionId]),
   );
   const removeQuestion = useOpenCodePendingStore((s) => s.removeQuestion);
   const removePermission = useOpenCodePendingStore((s) => s.removePermission);
@@ -588,16 +597,26 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
     () =>
       usesAcp
         ? acpRuntime.projection.questions
-        : Object.values(questionMap).filter((q) => q.sessionID === ocSessionId),
-    [usesAcp, acpRuntime.projection.questions, questionMap, ocSessionId],
+        : switched
+          ? Object.values(questionMap).filter((q) => q.sessionID === ocSessionId)
+          : [],
+    [usesAcp, acpRuntime.projection.questions, questionMap, ocSessionId, switched],
   );
   const permissions = useMemo(
     () =>
       usesAcp
         ? acpRuntime.projection.permissions
-        : Object.values(permissionMap).filter((p) => p.sessionID === ocSessionId),
-    [usesAcp, acpRuntime.projection.permissions, permissionMap, ocSessionId],
+        : switched
+          ? Object.values(permissionMap).filter((p) => p.sessionID === ocSessionId)
+          : [],
+    [usesAcp, acpRuntime.projection.permissions, permissionMap, ocSessionId, switched],
   );
+
+  const runtimeActionReady = isSessionRuntimeActionReady({
+    switched,
+    usesAcp,
+    opencodeSessionId: rootSessionId,
+  });
 
   // 7. Server-side capabilities + per-session picks (all pre-runtime — no sandbox).
   const models = useProjectModels(projectId);
@@ -643,7 +662,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
       directory?: string | null;
     },
   ): Promise<void> => {
-    if (!hasSessionRuntimeIdentity({ usesAcp, opencodeSessionId: rootSessionId })) {
+    if (!runtimeActionReady) {
       throw new RuntimeNotReadyError();
     }
     titleRefreshAbortRef.current?.abort();
@@ -702,7 +721,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
       variant?: string | null;
     },
   ) => {
-    if (!hasSessionRuntimeIdentity({ usesAcp, opencodeSessionId: rootSessionId })) return;
+    if (!runtimeActionReady) return;
     pendingBaseCount.current = userMsgCount;
     if (!usesAcp) beginRestPromptObservation(ocSessionId);
     setSendState(sendStateOnStart(text));
@@ -718,7 +737,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
     args: string,
     options: SessionCommandOptions = {},
   ): Promise<void> => {
-    if (!hasSessionRuntimeIdentity({ usesAcp, opencodeSessionId: rootSessionId })) {
+    if (!runtimeActionReady) {
       return Promise.resolve();
     }
     if (usesAcp) {
@@ -733,7 +752,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
   };
 
   const rewind = async (messageId: string): Promise<void> => {
-    if (!hasSessionRuntimeIdentity({ usesAcp, opencodeSessionId: rootSessionId })) {
+    if (!runtimeActionReady) {
       throw new RuntimeNotReadyError();
     }
     if (!messageId) throw new Error('Session rewind requires a message id');
@@ -759,7 +778,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
   };
 
   const restoreRewind = async (): Promise<void> => {
-    if (!ocSessionId) throw new RuntimeNotReadyError();
+    if (!runtimeActionReady) throw new RuntimeNotReadyError();
     if (!rewindMessageId || rewindPending) return;
     setRewindPending(true);
     setRewindError(null);
@@ -781,7 +800,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
 
   // The one true cancel: abort the run AND drop any pending prompt + open prompts.
   const cancel = () => {
-    if (hasSessionRuntimeIdentity({ usesAcp, opencodeSessionId: rootSessionId })) {
+    if (runtimeActionReady) {
       if (usesAcp) void acpRuntime.cancel();
       else {
         endRestPromptObservation(ocSessionId);

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,22 +54,22 @@ tests/
 
 ### Playwright E2E Specs (`tests/e2e/specs/`)
 
-| Spec | Tests | What it verifies |
-|------|-------|------------------|
-| `01-containers` | 6 | All Docker containers running |
-| `02-services` | 4 | HTTP health checks on all ports |
-| `03-frontend-config` | 4 | Runtime config URLs correct (no placeholders) |
-| `04-auth-flow` | 4 | API auth + browser login |
-| `08-accounts-project-access` | 4 | Accounts, invites, project access, and no legacy route leaks |
-| `09-admin-ops` | 2 | Admin overview and operations dashboard |
-| `10-production-golden-paths` | gated | SPEC 10.5 golden paths when enabled |
-| `11-production-boundaries` | gated | SPEC 10.6/10.7 boundaries, SLOs, and negative-space probes |
-| `12-sandbox-templates` | gated | Sandbox template and snapshot behavior |
+| Spec                         | Tests | What it verifies                                             |
+| ---------------------------- | ----- | ------------------------------------------------------------ |
+| `01-containers`              | 6     | All Docker containers running                                |
+| `02-services`                | 4     | HTTP health checks on all ports                              |
+| `03-frontend-config`         | 4     | Runtime config URLs correct (no placeholders)                |
+| `04-auth-flow`               | 4     | API auth + browser login                                     |
+| `08-accounts-project-access` | 4     | Accounts, invites, project access, and no legacy route leaks |
+| `09-admin-ops`               | 2     | Admin overview and operations dashboard                      |
+| `10-production-golden-paths` | gated | SPEC 10.5 golden paths when enabled                          |
+| `11-production-boundaries`   | gated | SPEC 10.6/10.7 boundaries, SLOs, and negative-space probes   |
+| `12-sandbox-templates`       | gated | Sandbox template and snapshot behavior                       |
 
 ### Shell Checks (`tests/shell/`)
 
-| Suite | What it verifies |
-|-------|------------------|
+| Suite                 | What it verifies                               |
+| --------------------- | ---------------------------------------------- |
 | `vps/test-vps-e2e.sh` | Caddy HTTPS, basic auth, firewall (run on VPS) |
 
 ## pnpm Scripts
@@ -86,13 +86,13 @@ pnpm --filter @kortix/tests test:shell:vps               # VPS checks
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `E2E_OWNER_EMAIL` | `test-e2e@kortix.ai` | Test owner email |
-| `E2E_OWNER_PASSWORD` | `e2e-testpass-123` | Test owner password |
-| `E2E_BASE_URL` | `http://localhost:13737` | Frontend URL |
-| `E2E_API_URL` | `http://localhost:13738/v1` | API URL |
-| `E2E_SUPABASE_URL` | `http://localhost:13740` | Supabase URL |
+| Variable             | Default                     | Description         |
+| -------------------- | --------------------------- | ------------------- |
+| `E2E_OWNER_EMAIL`    | `test-e2e@kortix.ai`        | Test owner email    |
+| `E2E_OWNER_PASSWORD` | `e2e-testpass-123`          | Test owner password |
+| `E2E_BASE_URL`       | `http://localhost:13737`    | Frontend URL        |
+| `E2E_API_URL`        | `http://localhost:13738/v1` | API URL             |
+| `E2E_SUPABASE_URL`   | `http://localhost:13740`    | Supabase URL        |
 
 ## ACP Multi-Harness Protocol Smoke
 
@@ -121,15 +121,32 @@ pnpm exec dotenvx run --ignore=MISSING_ENV_FILE \
 The script creates a disposable user and project. It stops every created
 session and archives the project in `finally`.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `E2E_ACP_MULTI_HARNESS_HARNESSES` | All four harnesses | Comma-separated harness subset |
-| `E2E_ACP_MULTI_HARNESS_PROVIDER` | Project default | Sandbox provider |
-| `E2E_ACP_MULTI_HARNESS_MODEL` | Harness default | Explicit session model |
-| `E2E_ACP_MULTI_HARNESS_OPENAI_API_KEY` | Unset | Temporary direct key for the disposable project |
-| `E2E_KEEP_ACP_MULTI_HARNESS_FIXTURE` | `0` | Set to `1` to preserve the fixture for debugging |
-| `E2E_ACP_MULTI_HARNESS_REUSE_PROJECT_ID` | Unset | Reuse an existing test project |
-| `E2E_ACP_MULTI_HARNESS_REUSE_EMAIL` | Unset | Login email for the reused project; both reuse variables are required together |
+Set `E2E_ACP_MULTI_HARNESS_READINESS_ONLY=1` to stop after ACP session
+readiness. Each harness prints `create_to_session_ready_ms`. This mode excludes
+prompt dispatch and model latency.
+
+Set `E2E_ACP_OPENCODE_FORK_ISOLATION=1` to create two OpenCode sessions in
+parallel from one version 2 compatibility-project snapshot. Version 3 projects
+use ACP identity instead of `opencode_session_id`. This mode verifies distinct
+Kortix session, sandbox, provider, and OpenCode identities. It also sends unique
+markers and rejects cross-session transcript content. The public
+`createKortix().session().ensureReady()` result must match each authoritative
+`/start` `opencode_session_id`.
+
+Set `E2E_ACP_MULTI_HARNESS_RESULT_PATH` to save the identity and timing evidence
+as JSON. The path is relative to the repository root.
+
+| Variable                                 | Default            | Description                                                                    |
+| ---------------------------------------- | ------------------ | ------------------------------------------------------------------------------ |
+| `E2E_ACP_MULTI_HARNESS_HARNESSES`        | All four harnesses | Comma-separated harness subset                                                 |
+| `E2E_ACP_MULTI_HARNESS_PROVIDER`         | Project default    | Sandbox provider                                                               |
+| `E2E_ACP_MULTI_HARNESS_MODEL`            | Harness default    | Explicit session model                                                         |
+| `E2E_ACP_MULTI_HARNESS_OPENAI_API_KEY`   | Unset              | Temporary direct key for the disposable project                                |
+| `E2E_ACP_OPENCODE_FORK_ISOLATION`        | `0`                | Run the two-session OpenCode snapshot-isolation proof                          |
+| `E2E_ACP_MULTI_HARNESS_RESULT_PATH`      | Unset              | Persist non-secret JSON evidence                                               |
+| `E2E_KEEP_ACP_MULTI_HARNESS_FIXTURE`     | `0`                | Set to `1` to preserve the fixture for debugging                               |
+| `E2E_ACP_MULTI_HARNESS_REUSE_PROJECT_ID` | Unset              | Reuse an existing test project                                                 |
+| `E2E_ACP_MULTI_HARNESS_REUSE_EMAIL`      | Unset              | Login email for the reused project; both reuse variables are required together |
 
 Do not use the gateway provider verification endpoint as harness acceptance.
 Run the exact harness and model. The smoke must receive a real assistant reply

--- a/tests/e2e/scripts/acp-multi-harness-smoke.ts
+++ b/tests/e2e/scripts/acp-multi-harness-smoke.ts
@@ -230,24 +230,36 @@ function seedCredits(accountId: string): void {
   assert(result.exitCode === 0, `credit seed failed: ${result.stderr.toString().trim()}`);
 }
 
-function runGit(args: string[], authHeader: string, cwd?: string): void {
-  const result = Bun.spawnSync(['git', '-c', `http.extraHeader=${authHeader}`, ...args], {
+function runGit(args: string[], cwd?: string): void {
+  const result = Bun.spawnSync(['git', ...args], {
     cwd,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
     stdout: 'pipe',
     stderr: 'pipe',
   });
-  assert(result.exitCode === 0, `git ${args[0]} failed: ${result.stderr.toString().trim()}`);
+  const stderr = result.stderr
+    .toString()
+    .trim()
+    .replace(/https:\/\/[^@\s]+@/g, 'https://[credentials]@');
+  assert(result.exitCode === 0, `git ${args[0]} failed: ${stderr}`);
 }
 
-function rewriteProjectAsOpenCodeRestFixture(project: Project, token: string): void {
+async function rewriteProjectAsOpenCodeRestFixture(project: Project, token: string): Promise<void> {
   const checkout = mkdtempSync(resolve(tmpdir(), 'kortix-opencode-rest-fixture-'));
-  const authHeader = `Authorization: Basic ${Buffer.from(`x-access-token:${token}`).toString(
-    'base64',
-  )}`;
+  const credential = await api<{ token_id: string; secret_key: string }>(
+    token,
+    'POST',
+    `/projects/${project.project_id}/cli-token`,
+    { name: 'OpenCode REST isolation smoke' },
+    201,
+  );
+  const authenticatedOrigin = new URL(project.git_origin_url);
+  authenticatedOrigin.username = 'x-access-token';
+  authenticatedOrigin.password = credential.secret_key;
   try {
-    runGit(['clone', '--depth', '1', project.git_origin_url, checkout], authHeader);
+    runGit(['clone', '--depth', '1', authenticatedOrigin.toString(), checkout]);
     writeFileSync(resolve(checkout, 'kortix.yaml'), legacyOpenCodeManifest);
-    runGit(['add', 'kortix.yaml'], authHeader, checkout);
+    runGit(['add', 'kortix.yaml'], checkout);
     runGit(
       [
         '-c',
@@ -258,12 +270,18 @@ function rewriteProjectAsOpenCodeRestFixture(project: Project, token: string): v
         '-m',
         'test: use OpenCode REST compatibility manifest',
       ],
-      authHeader,
       checkout,
     );
-    runGit(['push', 'origin', 'HEAD'], authHeader, checkout);
+    runGit(['push', authenticatedOrigin.toString(), 'HEAD'], checkout);
   } finally {
     rmSync(checkout, { recursive: true, force: true });
+    const revoked = await apiResult(
+      apiBase,
+      token,
+      'DELETE',
+      `/projects/${project.project_id}/cli-token/${credential.token_id}`,
+    );
+    assert(revoked.status === 200, `temporary project token revoke returned ${revoked.status}`);
   }
 }
 
@@ -773,7 +791,7 @@ async function main(): Promise<void> {
       'starter project did not expose the expected ACP & Multi-Harness state',
     );
     if (assertOpenCodeForkIsolation) {
-      rewriteProjectAsOpenCodeRestFixture(project, token);
+      await rewriteProjectAsOpenCodeRestFixture(project, token);
     }
 
     const seededManifestResult = await waitFor(

--- a/tests/e2e/scripts/acp-multi-harness-smoke.ts
+++ b/tests/e2e/scripts/acp-multi-harness-smoke.ts
@@ -1,19 +1,21 @@
 #!/usr/bin/env bun
 
-import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
 
-import { createAcpClient } from "../../../packages/sdk/src/core/acp/client";
+import { createKortix } from '../../../packages/sdk/src/index';
+import { createAcpClient } from '../../../packages/sdk/src/core/acp/client';
 import {
   type AcpSessionController,
   createAcpSessionController,
-} from "../../../packages/sdk/src/core/acp/session-controller";
-import { buildProjectAcpEndpoint } from "../../../packages/sdk/src/core/session/runtime-transport";
-import { apiResult, createApiJsonClient } from "../helpers/http";
+} from '../../../packages/sdk/src/core/acp/session-controller';
+import { buildProjectAcpEndpoint } from '../../../packages/sdk/src/core/session/runtime-transport';
+import { apiResult, createApiJsonClient } from '../helpers/http';
 
-type Harness = "claude" | "codex" | "opencode" | "pi";
-type SandboxProvider = "daytona" | "platinum" | "e2b" | "local-docker";
+type Harness = 'claude' | 'codex' | 'opencode' | 'pi';
+type SandboxProvider = 'daytona' | 'platinum' | 'e2b' | 'local-docker';
 
 type Project = {
   project_id: string;
@@ -43,7 +45,7 @@ type ProjectSession = {
   session_id: string;
   agent_name: string | null;
   sandbox_provider?: SandboxProvider;
-  runtime_transport?: "acp" | "rest";
+  runtime_transport?: 'acp' | 'rest';
   runtime_harness?: Harness;
   native_agent?: string | null;
   acp_server_id?: string | null;
@@ -51,9 +53,10 @@ type ProjectSession = {
 };
 
 type SessionStart = ProjectSession & {
-  stage: "provisioning" | "starting" | "ready" | "failed" | "stopped";
+  stage: 'provisioning' | 'starting' | 'ready' | 'failed' | 'stopped';
   retriable: boolean;
   error?: string | null;
+  opencode_session_id?: string | null;
   sandbox: {
     status: string;
     external_id: string;
@@ -61,55 +64,82 @@ type SessionStart = ProjectSession & {
   } | null;
 };
 
-const repoRoot = resolve(import.meta.dir, "../../..");
-const apiBase = process.env.E2E_API_URL || "http://localhost:8008/v1";
-const supabaseUrl = process.env.E2E_SUPABASE_URL || "http://127.0.0.1:54321";
-const databaseUrl =
-  process.env.E2E_DATABASE_URL || process.env.DATABASE_URL || "";
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
-const anonKey =
-  process.env.SUPABASE_ANON_KEY ||
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-  "";
-const password = "AcpMultiHarness123!";
-const keepFixture = process.env.E2E_KEEP_ACP_MULTI_HARNESS_FIXTURE === "1";
-const reuseProjectId =
-  process.env.E2E_ACP_MULTI_HARNESS_REUSE_PROJECT_ID?.trim() || "";
-const reuseUserEmail =
-  process.env.E2E_ACP_MULTI_HARNESS_REUSE_EMAIL?.trim() || "";
+type HarnessEvidence = {
+  harness: Harness;
+  project_session_id: string;
+  sandbox_id: string;
+  sandbox_external_id: string;
+  opencode_session_id: string;
+  sdk_opencode_session_id: string;
+  acp_server_id: string;
+  acp_session_id: string;
+  markers: string[];
+  transcript: string;
+  create_to_session_ready_ms: number;
+  host_timing: unknown;
+  guest_timing: unknown;
+};
+
+const repoRoot = resolve(import.meta.dir, '../../..');
+const apiBase = process.env.E2E_API_URL || 'http://localhost:8008/v1';
+const supabaseUrl = process.env.E2E_SUPABASE_URL || 'http://127.0.0.1:54321';
+const databaseUrl = process.env.E2E_DATABASE_URL || process.env.DATABASE_URL || '';
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const anonKey = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+const password = 'AcpMultiHarness123!';
+const keepFixture = process.env.E2E_KEEP_ACP_MULTI_HARNESS_FIXTURE === '1';
+const readinessOnly = process.env.E2E_ACP_MULTI_HARNESS_READINESS_ONLY === '1';
+const assertOpenCodeForkIsolation = process.env.E2E_ACP_OPENCODE_FORK_ISOLATION === '1';
+const resultPath = process.env.E2E_ACP_MULTI_HARNESS_RESULT_PATH?.trim() || '';
+const reuseProjectId = process.env.E2E_ACP_MULTI_HARNESS_REUSE_PROJECT_ID?.trim() || '';
+const reuseUserEmail = process.env.E2E_ACP_MULTI_HARNESS_REUSE_EMAIL?.trim() || '';
 const sandboxProvider =
-  (process.env.E2E_ACP_MULTI_HARNESS_PROVIDER?.trim() as
-    SandboxProvider | undefined) || undefined;
-const runtimeModel = process.env.E2E_ACP_MULTI_HARNESS_MODEL?.trim() || "";
-const directOpenAiKey =
-  process.env.E2E_ACP_MULTI_HARNESS_OPENAI_API_KEY?.trim() || "";
+  (process.env.E2E_ACP_MULTI_HARNESS_PROVIDER?.trim() as SandboxProvider | undefined) || undefined;
+const runtimeModel = process.env.E2E_ACP_MULTI_HARNESS_MODEL?.trim() || '';
+const directOpenAiKey = process.env.E2E_ACP_MULTI_HARNESS_OPENAI_API_KEY?.trim() || '';
 const manifest = readFileSync(
-  resolve(repoRoot, "packages/starter/templates/base/kortix.yaml"),
-  "utf8",
+  resolve(repoRoot, 'packages/starter/templates/base/kortix.yaml'),
+  'utf8',
 );
+const legacyOpenCodeManifest = `# OpenCode REST compatibility fixture.
+kortix_version: 2
+default_agent: kortix
+
+project:
+  name: OpenCode fork isolation
+  description: Disposable OpenCode REST compatibility project.
+
+opencode:
+  config_dir: .kortix/opencode
+
+agents:
+  kortix:
+    connectors: all
+    secrets: all
+    skills: all
+    kortix_cli: all
+`;
 const api = createApiJsonClient(apiBase);
-const supportedHarnesses: Harness[] = ["opencode", "claude", "codex", "pi"];
+const supportedHarnesses: Harness[] = ['opencode', 'claude', 'codex', 'pi'];
 const requestedHarnesses =
-  process.env.E2E_ACP_MULTI_HARNESS_HARNESSES?.split(",")
+  process.env.E2E_ACP_MULTI_HARNESS_HARNESSES?.split(',')
     .map((value) => value.trim())
     .filter(Boolean) ?? [];
 const invalidHarnesses = requestedHarnesses.filter(
   (value) => !supportedHarnesses.includes(value as Harness),
 );
-assert(
-  invalidHarnesses.length === 0,
-  `Unsupported harnesses: ${invalidHarnesses.join(", ")}`,
-);
-const harnesses: Harness[] =
-  requestedHarnesses.length > 0
+assert(invalidHarnesses.length === 0, `Unsupported harnesses: ${invalidHarnesses.join(', ')}`);
+const harnesses: Harness[] = assertOpenCodeForkIsolation
+  ? ['opencode', 'opencode']
+  : requestedHarnesses.length > 0
     ? requestedHarnesses.map((value) => value as Harness)
     : supportedHarnesses;
 
-let userId = "";
-let userEmail = "";
-let accessToken = "";
-let projectId = "";
-let accountId = "";
+let userId = '';
+let userEmail = '';
+let accessToken = '';
+let projectId = '';
+let accountId = '';
 const sessionIds: string[] = [];
 const controllers = new Set<AcpSessionController>();
 
@@ -122,14 +152,14 @@ function assert(condition: unknown, message: string): asserts condition {
 }
 
 async function createUserAndSignIn(email: string): Promise<string> {
-  assert(serviceRoleKey, "SUPABASE_SERVICE_ROLE_KEY is required");
-  assert(anonKey, "SUPABASE_ANON_KEY is required");
+  assert(serviceRoleKey, 'SUPABASE_SERVICE_ROLE_KEY is required');
+  assert(anonKey, 'SUPABASE_ANON_KEY is required');
   const created = await fetch(`${supabaseUrl}/auth/v1/admin/users`, {
-    method: "POST",
+    method: 'POST',
     headers: {
       apikey: serviceRoleKey,
       Authorization: `Bearer ${serviceRoleKey}`,
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       email,
@@ -138,40 +168,31 @@ async function createUserAndSignIn(email: string): Promise<string> {
     }),
   });
   const createdText = await created.text();
-  assert(
-    created.status === 200,
-    `Supabase user create returned ${created.status}: ${createdText}`,
-  );
+  assert(created.status === 200, `Supabase user create returned ${created.status}: ${createdText}`);
   const createdBody = JSON.parse(createdText) as {
     id?: string;
     user?: { id?: string };
   };
-  userId = createdBody.user?.id ?? createdBody.id ?? "";
-  assert(userId, "Supabase user create returned no user id");
+  userId = createdBody.user?.id ?? createdBody.id ?? '';
+  assert(userId, 'Supabase user create returned no user id');
 
   return signIn(email);
 }
 
 async function signIn(email: string): Promise<string> {
-  assert(anonKey, "SUPABASE_ANON_KEY is required");
-  const signedIn = await fetch(
-    `${supabaseUrl}/auth/v1/token?grant_type=password`,
-    {
-      method: "POST",
-      headers: {
-        apikey: anonKey,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ email, password }),
+  assert(anonKey, 'SUPABASE_ANON_KEY is required');
+  const signedIn = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: {
+      apikey: anonKey,
+      'Content-Type': 'application/json',
     },
-  );
+    body: JSON.stringify({ email, password }),
+  });
   const signedInText = await signedIn.text();
-  assert(
-    signedIn.status === 200,
-    `Supabase sign-in returned ${signedIn.status}: ${signedInText}`,
-  );
+  assert(signedIn.status === 200, `Supabase sign-in returned ${signedIn.status}: ${signedInText}`);
   const session = JSON.parse(signedInText) as { access_token?: string };
-  assert(session.access_token, "Supabase sign-in returned no access_token");
+  assert(session.access_token, 'Supabase sign-in returned no access_token');
   return session.access_token;
 }
 
@@ -188,72 +209,133 @@ async function waitFor<T>(
     value = await read();
   }
   if (!accept(value)) {
-    throw new Error(
-      `${label} timed out: ${JSON.stringify(value).slice(0, 1_000)}`,
-    );
+    throw new Error(`${label} timed out: ${JSON.stringify(value).slice(0, 1_000)}`);
   }
   return value;
 }
 
 function seedCredits(accountId: string): void {
   if (!databaseUrl) {
-    log(
-      "credits",
-      "E2E_DATABASE_URL is unset; using the account state from the API",
-    );
+    log('credits', 'E2E_DATABASE_URL is unset; using the account state from the API');
     return;
   }
-  assert(
-    /^[0-9a-f-]{36}$/i.test(accountId),
-    `invalid account id for credit seed: ${accountId}`,
-  );
+  assert(/^[0-9a-f-]{36}$/i.test(accountId), `invalid account id for credit seed: ${accountId}`);
   const sql = `INSERT INTO kortix.credit_accounts (account_id, balance, tier)
     VALUES ('${accountId}', 1000, 'tier_2_20')
     ON CONFLICT (account_id) DO UPDATE SET balance = 1000, tier = 'tier_2_20';`;
-  const result = Bun.spawnSync(
-    ["psql", databaseUrl, "-v", "ON_ERROR_STOP=1", "-c", sql],
-    {
-      stdout: "pipe",
-      stderr: "pipe",
-    },
-  );
-  assert(
-    result.exitCode === 0,
-    `credit seed failed: ${result.stderr.toString().trim()}`,
-  );
+  const result = Bun.spawnSync(['psql', databaseUrl, '-v', 'ON_ERROR_STOP=1', '-c', sql], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  assert(result.exitCode === 0, `credit seed failed: ${result.stderr.toString().trim()}`);
 }
 
-function hardDeleteFixtureRows(projectId: string, accountId: string): void {
-  assert(databaseUrl, "DATABASE_URL is required for complete fixture cleanup");
-  assert(
-    /^[0-9a-f-]{36}$/i.test(projectId),
-    `invalid cleanup project id: ${projectId}`,
-  );
-  assert(
-    /^[0-9a-f-]{36}$/i.test(accountId),
-    `invalid cleanup account id: ${accountId}`,
-  );
+function runGit(args: string[], authHeader: string, cwd?: string): void {
+  const result = Bun.spawnSync(['git', '-c', `http.extraHeader=${authHeader}`, ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  assert(result.exitCode === 0, `git ${args[0]} failed: ${result.stderr.toString().trim()}`);
+}
+
+function rewriteProjectAsOpenCodeRestFixture(project: Project, token: string): void {
+  const checkout = mkdtempSync(resolve(tmpdir(), 'kortix-opencode-rest-fixture-'));
+  const authHeader = `Authorization: Basic ${Buffer.from(`x-access-token:${token}`).toString(
+    'base64',
+  )}`;
+  try {
+    runGit(['clone', '--depth', '1', project.git_origin_url, checkout], authHeader);
+    writeFileSync(resolve(checkout, 'kortix.yaml'), legacyOpenCodeManifest);
+    runGit(['add', 'kortix.yaml'], authHeader, checkout);
+    runGit(
+      [
+        '-c',
+        'user.name=Kortix E2E',
+        '-c',
+        'user.email=e2e@kortix.ai',
+        'commit',
+        '-m',
+        'test: use OpenCode REST compatibility manifest',
+      ],
+      authHeader,
+      checkout,
+    );
+    runGit(['push', 'origin', 'HEAD'], authHeader, checkout);
+  } finally {
+    rmSync(checkout, { recursive: true, force: true });
+  }
+}
+
+async function hardDeleteFixtureRows(projectId: string, accountId: string): Promise<void> {
+  assert(databaseUrl, 'DATABASE_URL is required for complete fixture cleanup');
+  assert(/^[0-9a-f-]{36}$/i.test(projectId), `invalid cleanup project id: ${projectId}`);
+  assert(/^[0-9a-f-]{36}$/i.test(accountId), `invalid cleanup account id: ${accountId}`);
   const sql = `BEGIN;
     DELETE FROM kortix.projects WHERE project_id = '${projectId}';
     DELETE FROM kortix.accounts WHERE account_id = '${accountId}';
     COMMIT;`;
-  const result = Bun.spawnSync(
-    ["psql", databaseUrl, "-v", "ON_ERROR_STOP=1", "-c", sql],
-    {
-      stdout: "pipe",
-      stderr: "pipe",
-    },
-  );
-  assert(
-    result.exitCode === 0,
-    `fixture row cleanup failed: ${result.stderr.toString().trim()}`,
-  );
+  let lastError = '';
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const result = Bun.spawnSync(['psql', databaseUrl, '-v', 'ON_ERROR_STOP=1', '-c', sql], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    if (result.exitCode === 0) return;
+    lastError = result.stderr.toString().trim();
+    if (
+      !lastError.includes('remaining connection slots') &&
+      !lastError.includes('too many clients')
+    ) {
+      break;
+    }
+    log('cleanup', `database connection unavailable; retrying fixture row cleanup (${attempt}/5)`);
+    await Bun.sleep(attempt * 1_000);
+  }
+  throw new Error(`fixture row cleanup failed: ${lastError}`);
+}
+
+function readHostTiming(sessionId: string): unknown {
+  if (!databaseUrl) return null;
+  assert(/^[0-9a-f-]{36}$/i.test(sessionId), `invalid session id for timing query: ${sessionId}`);
+  const sql = `SELECT jsonb_build_object(
+      'provider', ss.provider::text,
+      'image', ss.metadata -> 'runtimeArtifact',
+      'provision_timeline', ss.metadata -> 'provisionTimeline',
+      'session_start_timeline', ps.metadata -> 'session_start_timeline'
+    )::text
+    FROM kortix.session_sandboxes ss
+    JOIN kortix.project_sessions ps ON ps.session_id = ss.session_id
+    WHERE ss.session_id = '${sessionId}'
+    LIMIT 1;`;
+  const result = Bun.spawnSync(['psql', databaseUrl, '-At', '-v', 'ON_ERROR_STOP=1', '-c', sql], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  assert(result.exitCode === 0, `timing query failed: ${result.stderr.toString().trim()}`);
+  const raw = result.stdout.toString().trim();
+  return raw ? JSON.parse(raw) : null;
+}
+
+async function readGuestTiming(token: string, externalId: string): Promise<unknown> {
+  const response = await fetch(`${apiBase}/p/${externalId}/8000/kortix/health`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(15_000),
+  });
+  const raw = await response.text();
+  assert(response.ok, `guest timing health returned ${response.status}: ${raw}`);
+  const health = JSON.parse(raw) as Record<string, unknown>;
+  return {
+    runtimeReady: health.runtimeReady,
+    runtime_harness: health.runtime_harness,
+    boot_timeline: health.boot_timeline,
+  };
 }
 
 function authorizedFetch(token: string): typeof fetch {
   return (async (input: RequestInfo | URL, init: RequestInit = {}) => {
     const headers = new Headers(init.headers);
-    headers.set("Authorization", `Bearer ${token}`);
+    headers.set('Authorization', `Bearer ${token}`);
     return fetch(input, { ...init, headers });
   }) as typeof fetch;
 }
@@ -261,13 +343,11 @@ function authorizedFetch(token: string): typeof fetch {
 function assistantProjectionText(controller: AcpSessionController): string {
   return controller
     .getSnapshot()
-    .projection.messages.filter((message) => message.info.role === "assistant")
+    .projection.messages.filter((message) => message.info.role === 'assistant')
     .flatMap((message) =>
-      message.parts
-        .filter((part) => part.type === "text")
-        .map((part) => part.text),
+      message.parts.filter((part) => part.type === 'text').map((part) => part.text),
     )
-    .join("\n");
+    .join('\n');
 }
 
 function controllerFor(
@@ -275,10 +355,10 @@ function controllerFor(
   sessionId: string,
   start: SessionStart,
 ): AcpSessionController {
-  assert(start.sandbox?.external_id, "session has no sandbox external_id");
-  assert(start.acp_server_id, "session has no acp_server_id");
-  assert(start.acp_session_id, "session has no acp_session_id");
-  assert(start.runtime_harness, "session has no runtime_harness");
+  assert(start.sandbox?.external_id, 'session has no sandbox external_id');
+  assert(start.acp_server_id, 'session has no acp_server_id');
+  assert(start.acp_session_id, 'session has no acp_session_id');
+  assert(start.runtime_harness, 'session has no runtime_harness');
   const client = createAcpClient({
     endpoint: buildProjectAcpEndpoint(apiBase, projectId, sessionId),
     fetch: authorizedFetch(token),
@@ -297,15 +377,8 @@ function controllerFor(
   return controller;
 }
 
-async function readSession(
-  token: string,
-  sessionId: string,
-): Promise<ProjectSession> {
-  return api<ProjectSession>(
-    token,
-    "GET",
-    `/projects/${projectId}/sessions/${sessionId}`,
-  );
+async function readSession(token: string, sessionId: string): Promise<ProjectSession> {
+  return api<ProjectSession>(token, 'GET', `/projects/${projectId}/sessions/${sessionId}`);
 }
 
 async function waitForReady(
@@ -317,28 +390,47 @@ async function waitForReady(
     async () => {
       const result = await api<SessionStart>(
         token,
-        "POST",
+        'POST',
         `/projects/${projectId}/sessions/${sessionId}/start?wait_ms=8000`,
         {},
       );
-      if (result.stage === "failed") {
-        throw new Error(
-          `${harness} runtime failed: ${result.error || "unknown error"}`,
-        );
+      if (result.stage === 'failed') {
+        throw new Error(`${harness} runtime failed: ${result.error || 'unknown error'}`);
       }
       return result;
     },
     (value) =>
-      value.stage === "ready" &&
-      value.sandbox?.status === "active" &&
+      value.stage === 'ready' &&
+      value.sandbox?.status === 'active' &&
       Boolean(value.sandbox.external_id) &&
-      value.runtime_transport === "acp" &&
-      value.runtime_harness === harness &&
-      value.acp_server_id === sessionId &&
-      Boolean(value.acp_session_id),
+      (assertOpenCodeForkIsolation
+        ? value.runtime_transport === 'rest' && Boolean(value.opencode_session_id)
+        : value.runtime_transport === 'acp' &&
+          value.runtime_harness === harness &&
+          value.acp_server_id === sessionId &&
+          Boolean(value.acp_session_id)),
     `${harness} runtime readiness`,
     12 * 60_000,
   );
+}
+
+async function readRestTranscript(
+  session: ReturnType<ReturnType<typeof createKortix>['session']>,
+  openCodeSessionId: string,
+): Promise<string> {
+  const result = await session.runtime.session.messages({
+    sessionID: openCodeSessionId,
+  });
+  const messages = (result.data ?? []) as Array<{
+    info?: { role?: string };
+    parts?: Array<{ type?: string; text?: string }>;
+  }>;
+  return messages
+    .filter((message) => message.info?.role === 'assistant')
+    .flatMap((message) =>
+      (message.parts ?? []).filter((part) => part.type === 'text').map((part) => part.text ?? ''),
+    )
+    .join('\n');
 }
 
 async function waitForMarker(
@@ -354,19 +446,24 @@ async function waitForMarker(
   );
 }
 
-async function verifyHarness(token: string, harness: Harness): Promise<void> {
-  const expectedNativeAgent = harness === "opencode" ? "kortix" : null;
-  const firstMarker = `${harness.toUpperCase()}_FIRST_${Date.now()}`;
-  const secondMarker = `${harness.toUpperCase()}_FOLLOWUP_${Date.now()}`;
-  const restartMarker = `${harness.toUpperCase()}_RESTART_${Date.now()}`;
+async function verifyHarness(token: string, harness: Harness): Promise<HarnessEvidence> {
+  const expectedNativeAgent =
+    !assertOpenCodeForkIsolation && harness === 'opencode' ? 'kortix' : null;
+  const markerSuffix = randomUUID().replaceAll('-', '').slice(0, 12);
+  const firstMarker = `${harness.toUpperCase()}_FIRST_${markerSuffix}`;
+  const secondMarker = `${harness.toUpperCase()}_FOLLOWUP_${markerSuffix}`;
+  const restartMarker = `${harness.toUpperCase()}_RESTART_${markerSuffix}`;
+  const createStartedAt = performance.now();
   const created = await api<ProjectSession>(
     token,
-    "POST",
+    'POST',
     `/projects/${projectId}/sessions`,
     {
       name: `${harness} ACP smoke`,
-      agent_name: harness,
-      initial_prompt: `Reply with exactly ${firstMarker}`,
+      agent_name: assertOpenCodeForkIsolation ? 'kortix' : harness,
+      ...(!assertOpenCodeForkIsolation
+        ? { initial_prompt: `Reply with exactly ${firstMarker}` }
+        : {}),
       ...(sandboxProvider ? { provider: sandboxProvider } : {}),
       ...(runtimeModel ? { opencode_model: runtimeModel } : {}),
     },
@@ -380,34 +477,118 @@ async function verifyHarness(token: string, harness: Harness): Promise<void> {
   );
 
   const started = await waitForReady(token, sessionId, harness);
-  assert(started.agent_name === harness, `${harness}: agent_name changed`);
+  const sessionReadyMs = Math.round(performance.now() - createStartedAt);
+  assert(
+    started.agent_name === (assertOpenCodeForkIsolation ? 'kortix' : harness),
+    `${harness}: agent_name changed`,
+  );
   assert(
     started.native_agent === expectedNativeAgent,
     `${harness}: native_agent was not the immutable manifest value`,
   );
+  assert(started.opencode_session_id, `${harness}: /start returned no opencode_session_id`);
+  const sdk = createKortix({
+    backendUrl: apiBase,
+    getToken: async () => token,
+  });
+  const sdkSession = sdk.session(projectId, sessionId);
+  const sdkReady = await sdkSession.ensureReady({ readyTimeoutMs: 180_000 });
+  assert(
+    sdkReady.opencodeSessionId === started.opencode_session_id,
+    `${harness}: public SDK did not preserve the authoritative /start pin`,
+  );
+  assert(
+    sdkReady.sandboxId === started.sandbox?.external_id,
+    `${harness}: public SDK resolved a different sandbox`,
+  );
+  const hostTiming = readHostTiming(sessionId);
+  const guestTiming = await readGuestTiming(token, started.sandbox?.external_id ?? '');
   const identity = {
     runtime_transport: started.runtime_transport,
     runtime_harness: started.runtime_harness,
     native_agent: started.native_agent,
+    opencode_session_id: started.opencode_session_id,
     acp_server_id: started.acp_server_id,
     acp_session_id: started.acp_session_id,
   };
+  log(
+    harness,
+    `READY create_to_session_ready_ms=${sessionReadyMs} project_session_id=${sessionId} runtime_harness=${identity.runtime_harness}`,
+  );
+  log(
+    harness,
+    `TIMING ${JSON.stringify({
+      create_to_session_ready_ms: sessionReadyMs,
+      host: hostTiming,
+      guest: guestTiming,
+    })}`,
+  );
+  const evidenceBase = {
+    harness,
+    project_session_id: sessionId,
+    sandbox_id: started.sandbox?.sandbox_id ?? '',
+    sandbox_external_id: started.sandbox?.external_id ?? '',
+    opencode_session_id: started.opencode_session_id,
+    sdk_opencode_session_id: sdkReady.opencodeSessionId,
+    acp_server_id: started.acp_server_id ?? '',
+    acp_session_id: started.acp_session_id ?? '',
+    markers: [firstMarker, secondMarker, restartMarker],
+    create_to_session_ready_ms: sessionReadyMs,
+    host_timing: hostTiming,
+    guest_timing: guestTiming,
+  };
+  if (readinessOnly) return { ...evidenceBase, transcript: '' };
+
+  if (assertOpenCodeForkIsolation) {
+    const readTranscript = () => readRestTranscript(sdkSession, started.opencode_session_id!);
+    await sdkSession.send(`Reply with exactly ${firstMarker}`);
+    await waitFor(
+      readTranscript,
+      (text) => text.includes(firstMarker),
+      'OpenCode REST first SDK response',
+      5 * 60_000,
+    );
+    await sdkSession.send(`Reply with exactly ${secondMarker}`);
+    await waitFor(
+      readTranscript,
+      (text) => text.includes(secondMarker),
+      'OpenCode REST follow-up response',
+      5 * 60_000,
+    );
+
+    await sdkSession.restart();
+    const restarted = await waitForReady(token, sessionId, harness);
+    assert(
+      restarted.opencode_session_id === started.opencode_session_id,
+      'OpenCode REST root changed after restart',
+    );
+    const restartedReady = await sdkSession.ensureReady({
+      readyTimeoutMs: 180_000,
+    });
+    assert(
+      restartedReady.opencodeSessionId === started.opencode_session_id,
+      'Public SDK changed the authoritative OpenCode pin after restart',
+    );
+    await sdkSession.send(`Reply with exactly ${restartMarker}`);
+    const finalTranscript = await waitFor(
+      readTranscript,
+      (text) =>
+        text.includes(firstMarker) && text.includes(secondMarker) && text.includes(restartMarker),
+      'OpenCode REST response after restart',
+      5 * 60_000,
+    );
+    log(
+      harness,
+      `PASS project_session_id=${sessionId} opencode_session_id=${started.opencode_session_id}`,
+    );
+    return { ...evidenceBase, transcript: finalTranscript };
+  }
 
   const controller = controllerFor(token, sessionId, started);
   await controller.connect();
-  await waitForMarker(
-    controller,
-    firstMarker,
-    `${harness} initial headless response`,
-  );
-  await controller.send([
-    { type: "text", text: `Reply with exactly ${secondMarker}` },
-  ]);
-  await waitForMarker(
-    controller,
-    secondMarker,
-    `${harness} follow-up response`,
-  );
+  await waitForMarker(controller, firstMarker, `${harness} initial headless response`);
+  await controller.send([{ type: 'text', text: `Reply with exactly ${secondMarker}` }]);
+  await waitForMarker(controller, secondMarker, `${harness} follow-up response`);
   controller.close();
   controllers.delete(controller);
 
@@ -424,27 +605,22 @@ async function verifyHarness(token: string, harness: Harness): Promise<void> {
   const immutableAttempt = await apiResult<{ error?: string }>(
     apiBase,
     token,
-    "PATCH",
+    'PATCH',
     `/projects/${projectId}/sessions/${sessionId}`,
-    { agent_name: harness === "codex" ? "pi" : "codex" },
+    { agent_name: harness === 'codex' ? 'pi' : 'codex' },
   );
   assert(
     immutableAttempt.status === 400,
     `${harness}: agent_name mutation returned ${immutableAttempt.status}`,
   );
 
-  await api(
-    token,
-    "POST",
-    `/projects/${projectId}/sessions/${sessionId}/restart`,
-    {},
-    202,
-  );
+  await api(token, 'POST', `/projects/${projectId}/sessions/${sessionId}/restart`, {}, 202);
   const restarted = await waitForReady(token, sessionId, harness);
   assert(
     restarted.runtime_transport === identity.runtime_transport &&
       restarted.runtime_harness === identity.runtime_harness &&
       restarted.native_agent === identity.native_agent &&
+      restarted.opencode_session_id === identity.opencode_session_id &&
       restarted.acp_server_id === identity.acp_server_id &&
       restarted.acp_session_id === identity.acp_session_id,
     `${harness}: runtime identity changed after restart`,
@@ -452,14 +628,8 @@ async function verifyHarness(token: string, harness: Harness): Promise<void> {
 
   const afterRestart = controllerFor(token, sessionId, restarted);
   await afterRestart.connect();
-  await afterRestart.send([
-    { type: "text", text: `Reply with exactly ${restartMarker}` },
-  ]);
-  await waitForMarker(
-    afterRestart,
-    restartMarker,
-    `${harness} response after restart`,
-  );
+  await afterRestart.send([{ type: 'text', text: `Reply with exactly ${restartMarker}` }]);
+  await waitForMarker(afterRestart, restartMarker, `${harness} response after restart`);
   const finalTranscript = assistantProjectionText(afterRestart);
   assert(
     finalTranscript.includes(firstMarker) &&
@@ -481,46 +651,100 @@ async function verifyHarness(token: string, harness: Harness): Promise<void> {
     harness,
     `PASS project_session_id=${sessionId} acp_server_id=${identity.acp_server_id} acp_session_id=${identity.acp_session_id}`,
   );
+  return { ...evidenceBase, transcript: finalTranscript };
+}
+
+function verifyOpenCodeForkIsolation(evidence: HarnessEvidence[]): void {
+  assert(
+    evidence.length === 2 && evidence.every((item) => item.harness === 'opencode'),
+    'OpenCode fork isolation requires exactly two OpenCode sessions',
+  );
+  const [first, second] = evidence;
+  assert(
+    first.project_session_id !== second.project_session_id,
+    'OpenCode fork sessions share one Kortix session_id',
+  );
+  assert(first.sandbox_id !== second.sandbox_id, 'OpenCode fork sessions share one sandbox_id');
+  assert(
+    first.sandbox_external_id !== second.sandbox_external_id,
+    'OpenCode fork sessions share one sandbox external_id',
+  );
+  assert(
+    first.opencode_session_id !== second.opencode_session_id,
+    'OpenCode fork sessions share one /start opencode_session_id',
+  );
+  if (!readinessOnly) {
+    assert(
+      second.markers.every((marker) => !first.transcript.includes(marker)),
+      'The first OpenCode transcript contains a marker from the second session',
+    );
+    assert(
+      first.markers.every((marker) => !second.transcript.includes(marker)),
+      'The second OpenCode transcript contains a marker from the first session',
+    );
+  }
+  log(
+    'opencode-fork-isolation',
+    `PASS session_a=${first.project_session_id} opencode_a=${first.opencode_session_id} session_b=${second.project_session_id} opencode_b=${second.opencode_session_id}`,
+  );
+}
+
+function writeEvidence(evidence: HarnessEvidence[]): void {
+  if (!resultPath) return;
+  const absolutePath = resolve(repoRoot, resultPath);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(
+    absolutePath,
+    `${JSON.stringify(
+      {
+        measured_at: new Date().toISOString(),
+        api_base: apiBase,
+        project_id: projectId,
+        provider: sandboxProvider ?? null,
+        readiness_only: readinessOnly,
+        open_code_fork_isolation: assertOpenCodeForkIsolation,
+        sessions: evidence,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  log('evidence', absolutePath);
 }
 
 async function main(): Promise<void> {
   log(
-    "target",
-    `${apiBase} with ${harnesses.join(", ")} on ${sandboxProvider ?? "the project default provider"} using ${runtimeModel || "each harness default model"}`,
+    'target',
+    `${apiBase} with ${harnesses.join(', ')} on ${sandboxProvider ?? 'the project default provider'} using ${runtimeModel || 'each harness default model'}`,
   );
   assert(
     (reuseProjectId && reuseUserEmail) || (!reuseProjectId && !reuseUserEmail),
-    "E2E_ACP_MULTI_HARNESS_REUSE_PROJECT_ID and E2E_ACP_MULTI_HARNESS_REUSE_EMAIL must be set together",
+    'E2E_ACP_MULTI_HARNESS_REUSE_PROJECT_ID and E2E_ACP_MULTI_HARNESS_REUSE_EMAIL must be set together',
   );
   const email =
-    reuseUserEmail ||
-    `acp-multi-harness-${Date.now()}-${randomUUID().slice(0, 8)}@example.test`;
+    reuseUserEmail || `acp-multi-harness-${Date.now()}-${randomUUID().slice(0, 8)}@example.test`;
   userEmail = email;
-  accessToken = reuseProjectId
-    ? await signIn(email)
-    : await createUserAndSignIn(email);
+  accessToken = reuseProjectId ? await signIn(email) : await createUserAndSignIn(email);
   const token = accessToken;
 
   if (reuseProjectId) {
     projectId = reuseProjectId;
-    log("fixture", `reusing project=${projectId}`);
+    log('fixture', `reusing project=${projectId}`);
   } else {
-    const accounts = await api<
-      Array<{ account_id: string; personal_account?: boolean }>
-    >(token, "GET", "/accounts");
-    const account =
-      accounts.find((item) => item.personal_account) ?? accounts[0];
-    assert(
-      account?.account_id,
-      "No personal account exists for the smoke user",
+    const accounts = await api<Array<{ account_id: string; personal_account?: boolean }>>(
+      token,
+      'GET',
+      '/accounts',
     );
+    const account = accounts.find((item) => item.personal_account) ?? accounts[0];
+    assert(account?.account_id, 'No personal account exists for the smoke user');
     accountId = account.account_id;
     seedCredits(accountId);
 
     const project = await api<Project>(
       token,
-      "POST",
-      "/projects/provision",
+      'POST',
+      '/projects/provision',
       {
         account_id: accountId,
         name: `Multi-harness ${Date.now()}`,
@@ -529,179 +753,204 @@ async function main(): Promise<void> {
       201,
     );
     projectId = project.project_id;
+    assert(project.account_id === accountId, 'Project response account_id changed');
+    assert(project.git_origin_url, 'Project response has no git_origin_url');
     assert(
-      project.account_id === accountId,
-      "Project response account_id changed",
-    );
-    assert(project.git_origin_url, "Project response has no git_origin_url");
-    assert(
-      project.metadata.experimental?.acp_runtime === true,
-      "starter project metadata did not enable acp_runtime",
+      Boolean(project.metadata.experimental?.acp_runtime) === true,
+      'starter project metadata has an unexpected acp_runtime state',
     );
     assert(
       project.experimental.acp_runtime === true,
-      "starter project did not enable acp_runtime",
+      'starter project has an unexpected acp_runtime state',
     );
     assert(
       project.experimental_features.some(
         (feature) =>
-          feature.key === "acp_runtime" &&
-          feature.name === "ACP & Multi-Harness" &&
-          feature.enabled,
+          feature.key === 'acp_runtime' &&
+          feature.name === 'ACP & Multi-Harness' &&
+          feature.enabled === true,
       ),
-      "starter project did not expose the enabled ACP & Multi-Harness feature",
+      'starter project did not expose the expected ACP & Multi-Harness state',
     );
+    if (assertOpenCodeForkIsolation) {
+      rewriteProjectAsOpenCodeRestFixture(project, token);
+    }
 
-    const seededManifest = await waitFor(
+    const seededManifestResult = await waitFor(
       () =>
-        api<{ content?: string }>(
+        apiResult<{ content?: string }>(
+          apiBase,
           token,
-          "GET",
+          'GET',
           `/projects/${projectId}/files/content?path=kortix.yaml`,
         ),
-      (value) => value.content?.includes("kortix_version: 3") === true,
-      "seeded ACP multi-harness manifest",
+      (value) =>
+        value.status === 200 &&
+        value.json?.content?.includes(
+          `kortix_version: ${assertOpenCodeForkIsolation ? '2' : '3'}`,
+        ) === true,
+      'seeded ACP multi-harness manifest',
     );
+    const seededManifest = seededManifestResult.json;
+    assert(seededManifest, 'seeded manifest response has no JSON body');
     const validation = await api<{ valid: boolean; issues: unknown[] }>(
       token,
-      "POST",
+      'POST',
       `/projects/${projectId}/manifest/validate`,
-      { raw: seededManifest.content ?? manifest, format: "yaml" },
+      { raw: seededManifest.content ?? manifest, format: 'yaml' },
     );
     assert(
       validation.valid && validation.issues.length === 0,
       `manifest validation failed: ${JSON.stringify(validation.issues)}`,
     );
-    await api(
-      token,
-      "POST",
-      `/executor/projects/${projectId}/connectors/sync`,
-      {},
-    );
+    await api(token, 'POST', `/executor/projects/${projectId}/connectors/sync`, {});
     if (directOpenAiKey) {
-      await api(token, "POST", `/projects/${projectId}/secrets`, {
-        name: "OPENAI_API_KEY",
+      await api(token, 'POST', `/projects/${projectId}/secrets`, {
+        name: 'OPENAI_API_KEY',
         value: directOpenAiKey,
       });
-      log(
-        "credential",
-        "seeded temporary OPENAI_API_KEY for this disposable fixture",
-      );
+      log('credential', 'seeded temporary OPENAI_API_KEY for this disposable fixture');
     }
   }
 
   const detail = await waitFor(
-    () => api<ProjectDetail>(token, "GET", `/projects/${projectId}/detail`),
+    () => api<ProjectDetail>(token, 'GET', `/projects/${projectId}/detail`),
     (value) =>
-      harnesses.every((harness) =>
-        value.config.agents.some(
-          (agent) =>
-            agent.name === harness &&
-            agent.runtime === harness &&
-            agent.harness === harness,
-        ),
-      ),
-    "four-agent runtime catalog",
+      assertOpenCodeForkIsolation
+        ? value.config.agents.some((agent) => agent.name === 'kortix')
+        : harnesses.every((harness) =>
+            value.config.agents.some(
+              (agent) =>
+                agent.name === harness && agent.runtime === harness && agent.harness === harness,
+            ),
+          ),
+    'four-agent runtime catalog',
   );
   assert(
     (detail.config.default_agent ?? detail.config.open_code_default_agent) ===
-      "opencode",
+      (assertOpenCodeForkIsolation ? 'kortix' : 'opencode'),
     `unexpected default_agent: ${detail.config.default_agent ?? detail.config.open_code_default_agent}`,
   );
 
-  const enabled = reuseProjectId
-    ? await api<Project>(
-        token,
-        "PATCH",
-        `/projects/${projectId}/experimental`,
-        {
-          feature: "acp_runtime",
-          enabled: true,
-        },
-      )
-    : await api<Project>(token, "GET", `/projects/${projectId}`);
+  const enabled =
+    reuseProjectId || assertOpenCodeForkIsolation
+      ? await api<Project>(token, 'PATCH', `/projects/${projectId}/experimental`, {
+          feature: 'acp_runtime',
+          enabled: !assertOpenCodeForkIsolation,
+        })
+      : await api<Project>(token, 'GET', `/projects/${projectId}`);
   assert(
-    enabled.experimental.acp_runtime === true,
-    "acp_runtime did not enable",
+    enabled.experimental.acp_runtime === !assertOpenCodeForkIsolation,
+    `acp_runtime did not ${assertOpenCodeForkIsolation ? 'disable' : 'enable'}`,
   );
   assert(
     enabled.experimental_features.some(
       (feature) =>
-        feature.key === "acp_runtime" &&
-        feature.name === "ACP & Multi-Harness" &&
-        feature.enabled,
+        feature.key === 'acp_runtime' &&
+        feature.name === 'ACP & Multi-Harness' &&
+        feature.enabled === !assertOpenCodeForkIsolation,
     ),
-    "experimental catalog did not expose ACP & Multi-Harness",
+    'experimental catalog did not expose the expected ACP & Multi-Harness state',
   );
 
-  for (const harness of harnesses) {
-    await verifyHarness(token, harness);
-  }
-  log("result", `PASS ${harnesses.length}/${harnesses.length} harnesses`);
-  log("fixture", `project=${projectId}`);
+  const evidence = assertOpenCodeForkIsolation
+    ? await Promise.all(harnesses.map((harness) => verifyHarness(token, harness)))
+    : await harnesses.reduce<Promise<HarnessEvidence[]>>(
+        async (pending, harness) => [...(await pending), await verifyHarness(token, harness)],
+        Promise.resolve([]),
+      );
+  if (assertOpenCodeForkIsolation) verifyOpenCodeForkIsolation(evidence);
+  writeEvidence(evidence);
+  log('result', `PASS ${harnesses.length}/${harnesses.length} harnesses`);
+  log('fixture', `project=${projectId}`);
 }
 
 async function cleanup(): Promise<void> {
+  const cleanupErrors: unknown[] = [];
   for (const controller of controllers) controller.close();
   controllers.clear();
   if (keepFixture) {
-    log(
-      "fixture",
-      `kept project=${projectId} sessions=${sessionIds.join(",")}`,
-    );
-    log("login", `email=${userEmail} password=${password}`);
+    log('fixture', `kept project=${projectId} sessions=${sessionIds.join(',')}`);
+    log('login', `email=${userEmail} password=${password}`);
   } else if (accessToken && projectId) {
     for (const sessionId of sessionIds) {
-      const stopped = await apiResult(
-        apiBase,
-        accessToken,
-        "DELETE",
-        `/projects/${projectId}/sessions/${sessionId}`,
-      );
-      assert(
-        stopped.status === 200 || stopped.status === 404,
-        `session cleanup returned ${stopped.status} for ${sessionId}`,
-      );
+      try {
+        const stopped = await apiResult(
+          apiBase,
+          accessToken,
+          'DELETE',
+          `/projects/${projectId}/sessions/${sessionId}`,
+        );
+        assert(
+          stopped.status === 200 || stopped.status === 404,
+          `session cleanup returned ${stopped.status} for ${sessionId}`,
+        );
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
     }
     if (!reuseProjectId) {
-      const purged = await apiResult<{ repo_deleted?: boolean }>(
-        apiBase,
-        accessToken,
-        "DELETE",
-        `/projects/${projectId}?purge=true`,
-      );
-      assert(purged.status === 200, `project purge returned ${purged.status}`);
-      assert(
-        purged.json?.repo_deleted === true,
-        "project purge did not delete the managed repo",
-      );
-      hardDeleteFixtureRows(projectId, accountId);
+      try {
+        const purged = await apiResult<{ repo_deleted?: boolean }>(
+          apiBase,
+          accessToken,
+          'DELETE',
+          `/projects/${projectId}?purge=true`,
+        );
+        assert(purged.status === 200, `project purge returned ${purged.status}`);
+        assert(purged.json?.repo_deleted === true, 'project purge did not delete the managed repo');
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+      try {
+        await hardDeleteFixtureRows(projectId, accountId);
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
     }
   }
   if (!keepFixture && !reuseProjectId && userId && serviceRoleKey) {
-    const deletedUser = await fetch(
-      `${supabaseUrl}/auth/v1/admin/users/${userId}`,
-      {
-        method: "DELETE",
+    try {
+      const deletedUser = await fetch(`${supabaseUrl}/auth/v1/admin/users/${userId}`, {
+        method: 'DELETE',
         headers: {
           apikey: serviceRoleKey,
           Authorization: `Bearer ${serviceRoleKey}`,
         },
-      },
-    );
-    assert(
-      deletedUser.status === 200 ||
-        deletedUser.status === 204 ||
-        deletedUser.status === 404,
-      `Supabase user cleanup returned ${deletedUser.status}: ${await deletedUser.text()}`,
-    );
+      });
+      assert(
+        deletedUser.status === 200 || deletedUser.status === 204 || deletedUser.status === 404,
+        `Supabase user cleanup returned ${deletedUser.status}: ${await deletedUser.text()}`,
+      );
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
   }
-  if (!keepFixture && !reuseProjectId && projectId && accountId)
-    log("cleanup", "removed project, sessions, account, and user");
+  if (!keepFixture && !reuseProjectId && projectId && accountId && cleanupErrors.length === 0)
+    log('cleanup', 'removed project, sessions, account, and user');
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(cleanupErrors, 'fixture cleanup failed');
+  }
 }
 
+let mainError: unknown;
 try {
   await main();
-} finally {
-  await cleanup();
+} catch (error) {
+  mainError = error;
 }
+
+let cleanupError: unknown;
+try {
+  await cleanup();
+} catch (error) {
+  cleanupError = error;
+}
+
+if (mainError) {
+  if (cleanupError) {
+    console.error('[acp-multi-harness] cleanup failed after smoke failure', cleanupError);
+  }
+  throw mainError;
+}
+if (cleanupError) throw cleanupError;

--- a/tests/e2e/scripts/acp-multi-harness-smoke.ts
+++ b/tests/e2e/scripts/acp-multi-harness-smoke.ts
@@ -711,6 +711,7 @@ function writeEvidence(evidence: HarnessEvidence[]): void {
   if (!resultPath) return;
   const absolutePath = resolve(repoRoot, resultPath);
   mkdirSync(dirname(absolutePath), { recursive: true });
+  // lgtm[js/http-to-file-access] This local benchmark artifact contains non-secret API timing and session identity evidence.
   writeFileSync(
     absolutePath,
     `${JSON.stringify(

--- a/tests/performance/session-start/results/2026-07-29/generic-acp-canonical-local-platinum.json
+++ b/tests/performance/session-start/results/2026-07-29/generic-acp-canonical-local-platinum.json
@@ -1,0 +1,106 @@
+{
+  "measured_at": "2026-07-29T17:14:28Z",
+  "environment": "local",
+  "api": "http://localhost:13308/v1",
+  "provider": "platinum",
+  "starter_template": "general-knowledge-worker",
+  "manifest_version": 3,
+  "default_agent": "opencode",
+  "boundary": "POST session creation to ACP session readiness",
+  "excludes": [
+    "prompt dispatch",
+    "model execution",
+    "first token"
+  ],
+  "runtime_artifact": {
+    "provider_artifact_ref": "kortix-default-6ebe2014635b",
+    "artifact_type": "platinum_template",
+    "content_hash": "6ebe2014635b9878cbf9cf41d62aa043facdc8e42161b5d9901acb8ca0525d28",
+    "is_platform_default": true
+  },
+  "attempts": [
+    {
+      "status": "pass",
+      "pi_create_to_session_ready_ms": 17213,
+      "opencode_create_to_session_ready_ms": 32581,
+      "attribution": false
+    },
+    {
+      "status": "instrumentation_error_after_pi_ready",
+      "pi_create_to_session_ready_ms": 16838,
+      "error": "The timing probe consumed the health response body twice.",
+      "attribution": false
+    },
+    {
+      "status": "pass",
+      "attribution": true,
+      "samples": [
+        {
+          "harness": "pi",
+          "create_to_session_ready_ms": 15503,
+          "session_start_timeline": {
+            "marks": [
+              { "label": "git-auth", "at_ms": 5, "delta_ms": 5 },
+              { "label": "env-vars", "at_ms": 38, "delta_ms": 33 },
+              { "label": "kicked", "at_ms": 117, "delta_ms": 78 }
+            ],
+            "total_ms": 117
+          },
+          "provision_timeline": {
+            "marks": [
+              { "label": "row+tokens", "at_ms": 78, "delta_ms": 78 },
+              { "label": "image-cached", "at_ms": 3081, "delta_ms": 3003 },
+              { "label": "provider-create:1x", "at_ms": 6212, "delta_ms": 3131 }
+            ],
+            "total_ms": 6212
+          },
+          "guest_boot_timeline": [
+            { "label": "static-web", "at_ms": 22 },
+            { "label": "git-identity", "at_ms": 56 },
+            { "label": "proxy-up", "at_ms": 67 },
+            { "label": "repo-materialized", "at_ms": 2354 },
+            { "label": "selected-harness-config-ready", "at_ms": 2356 },
+            { "label": "opencode-skipped", "at_ms": 2360 },
+            { "label": "runtime-process-spawned", "at_ms": 2364 },
+            { "label": "runtime-acp-first-output", "at_ms": 2796 },
+            { "label": "runtime-acp-initialized", "at_ms": 2797 },
+            { "label": "acp-runtime-ready", "at_ms": 2797 }
+          ]
+        },
+        {
+          "harness": "opencode",
+          "create_to_session_ready_ms": 62577,
+          "session_start_timeline": {
+            "marks": [
+              { "label": "git-auth", "at_ms": 7, "delta_ms": 7 },
+              { "label": "env-vars", "at_ms": 46, "delta_ms": 39 },
+              { "label": "kicked", "at_ms": 121, "delta_ms": 75 }
+            ],
+            "total_ms": 121
+          },
+          "provision_timeline": {
+            "marks": [
+              { "label": "row+tokens", "at_ms": 75, "delta_ms": 75 },
+              { "label": "image-cached", "at_ms": 3571, "delta_ms": 3496 },
+              { "label": "provider-create:1x", "at_ms": 5865, "delta_ms": 2294 }
+            ],
+            "total_ms": 5865
+          },
+          "guest_boot_timeline": [
+            { "label": "static-web", "at_ms": 22 },
+            { "label": "git-identity", "at_ms": 53 },
+            { "label": "proxy-up", "at_ms": 64 },
+            { "label": "repo-materialized", "at_ms": 2794 },
+            { "label": "selected-harness-config-ready", "at_ms": 2798 },
+            { "label": "opencode-skipped", "at_ms": 2802 },
+            { "label": "runtime-process-spawned", "at_ms": 2807 },
+            { "label": "runtime-acp-first-output", "at_ms": 52960 },
+            { "label": "runtime-acp-initialized", "at_ms": 53712 },
+            { "label": "acp-runtime-ready", "at_ms": 53712 }
+          ]
+        }
+      ]
+    }
+  ],
+  "cleanup": "All disposable sessions, projects, accounts, and users were removed."
+}

--- a/tests/performance/session-start/results/2026-07-29/opencode-fork-isolation-local-platinum-rebased.json
+++ b/tests/performance/session-start/results/2026-07-29/opencode-fork-isolation-local-platinum-rebased.json
@@ -1,0 +1,304 @@
+{
+  "measured_at": "2026-07-29T19:02:40.921Z",
+  "api_base": "http://localhost:13308/v1",
+  "project_id": "c8265213-376e-4ccc-9cd9-a23b73de3b93",
+  "provider": "platinum",
+  "readiness_only": false,
+  "open_code_fork_isolation": true,
+  "sessions": [
+    {
+      "harness": "opencode",
+      "project_session_id": "d919dbe2-5d9d-445e-ba8a-abb361816a86",
+      "sandbox_id": "d919dbe2-5d9d-445e-ba8a-abb361816a86",
+      "sandbox_external_id": "sbx_01KYQM2VN6BFB8BG61C6KN7NY2",
+      "opencode_session_id": "ses_050be472cffeLbJ7ciXGs8smOL",
+      "sdk_opencode_session_id": "ses_050be472cffeLbJ7ciXGs8smOL",
+      "acp_server_id": "",
+      "acp_session_id": "",
+      "markers": [
+        "OPENCODE_FIRST_2143b5a19efe",
+        "OPENCODE_FOLLOWUP_2143b5a19efe",
+        "OPENCODE_RESTART_2143b5a19efe"
+      ],
+      "create_to_session_ready_ms": 23266,
+      "host_timing": {
+        "image": {
+          "branch": "main",
+          "provider": "platinum",
+          "contentHash": "6ebe2014635b9878cbf9cf41d62aa043facdc8e42161b5d9901acb8ca0525d28",
+          "sandboxSlug": "default",
+          "artifactType": "platinum_template",
+          "isPlatformDefault": true,
+          "providerArtifactRef": "kortix-default-6ebe2014635b"
+        },
+        "provider": "platinum",
+        "provision_timeline": {
+          "id": "d919dbe2-5d9d-445e-ba8a-abb361816a86",
+          "kind": "provision",
+          "marks": [
+            {
+              "atMs": 102,
+              "label": "row+tokens",
+              "deltaMs": 102
+            },
+            {
+              "atMs": 2517,
+              "label": "image-cached",
+              "deltaMs": 2415
+            },
+            {
+              "atMs": 4565,
+              "label": "provider-create:1x",
+              "deltaMs": 2049
+            }
+          ],
+          "totalMs": 4565
+        },
+        "session_start_timeline": {
+          "id": "d919dbe2-5d9d-445e-ba8a-abb361816a86",
+          "kind": "session-create",
+          "marks": [
+            {
+              "atMs": 9,
+              "label": "git-auth",
+              "deltaMs": 9
+            },
+            {
+              "atMs": 58,
+              "label": "env-vars",
+              "deltaMs": 49
+            },
+            {
+              "atMs": 160,
+              "label": "kicked",
+              "deltaMs": 102
+            }
+          ],
+          "totalMs": 160
+        }
+      },
+      "guest_timing": {
+        "runtimeReady": true,
+        "runtime_harness": "opencode",
+        "boot_timeline": [
+          {
+            "label": "static-web",
+            "atMs": 20
+          },
+          {
+            "label": "git-identity",
+            "atMs": 52
+          },
+          {
+            "label": "proxy-up",
+            "atMs": 63
+          },
+          {
+            "label": "repo-materialized",
+            "atMs": 3512
+          },
+          {
+            "label": "config-deps",
+            "atMs": 3516
+          },
+          {
+            "label": "runtime-binary-resolved",
+            "atMs": 3522
+          },
+          {
+            "label": "runtime-cwd-resolved",
+            "atMs": 3523
+          },
+          {
+            "label": "runtime-config-ready",
+            "atMs": 3621
+          },
+          {
+            "label": "runtime-process-spawned",
+            "atMs": 3624
+          },
+          {
+            "label": "runtime-acp-first-output",
+            "atMs": 13699
+          },
+          {
+            "label": "runtime-acp-initialized",
+            "atMs": 14319
+          },
+          {
+            "label": "opencode-spawned",
+            "atMs": 14320
+          },
+          {
+            "label": "opencode-answering",
+            "atMs": 14765
+          },
+          {
+            "label": "runtime-session-new-requested",
+            "atMs": 14765
+          },
+          {
+            "label": "opencode-root-ready",
+            "atMs": 17388
+          },
+          {
+            "label": "opencode-session-created",
+            "atMs": 17389
+          },
+          {
+            "label": "opencode-ready",
+            "atMs": 17389
+          }
+        ]
+      },
+      "transcript": "OPENCODE_FIRST_2143b5a19efe\nOPENCODE_FOLLOWUP_2143b5a19efe\nOPENCODE_RESTART_2143b5a19efe"
+    },
+    {
+      "harness": "opencode",
+      "project_session_id": "b6397b55-950b-4f71-804e-f37ad19f414f",
+      "sandbox_id": "b6397b55-950b-4f71-804e-f37ad19f414f",
+      "sandbox_external_id": "sbx_01KYQM2VWY7X6PKK720HRF26WA",
+      "opencode_session_id": "ses_050be4bb6ffepNq9BLE8kdybL9",
+      "sdk_opencode_session_id": "ses_050be4bb6ffepNq9BLE8kdybL9",
+      "acp_server_id": "",
+      "acp_session_id": "",
+      "markers": [
+        "OPENCODE_FIRST_a26da18a0169",
+        "OPENCODE_FOLLOWUP_a26da18a0169",
+        "OPENCODE_RESTART_a26da18a0169"
+      ],
+      "create_to_session_ready_ms": 21758,
+      "host_timing": {
+        "image": {
+          "branch": "main",
+          "provider": "platinum",
+          "contentHash": "6ebe2014635b9878cbf9cf41d62aa043facdc8e42161b5d9901acb8ca0525d28",
+          "sandboxSlug": "default",
+          "artifactType": "platinum_template",
+          "isPlatformDefault": true,
+          "providerArtifactRef": "kortix-default-6ebe2014635b"
+        },
+        "provider": "platinum",
+        "provision_timeline": {
+          "id": "b6397b55-950b-4f71-804e-f37ad19f414f",
+          "kind": "provision",
+          "marks": [
+            {
+              "atMs": 119,
+              "label": "row+tokens",
+              "deltaMs": 119
+            },
+            {
+              "atMs": 2832,
+              "label": "image-cached",
+              "deltaMs": 2713
+            },
+            {
+              "atMs": 4931,
+              "label": "provider-create:1x",
+              "deltaMs": 2099
+            }
+          ],
+          "totalMs": 4931
+        },
+        "session_start_timeline": {
+          "id": "b6397b55-950b-4f71-804e-f37ad19f414f",
+          "kind": "session-create",
+          "marks": [
+            {
+              "atMs": 10,
+              "label": "git-auth",
+              "deltaMs": 10
+            },
+            {
+              "atMs": 42,
+              "label": "env-vars",
+              "deltaMs": 32
+            },
+            {
+              "atMs": 161,
+              "label": "kicked",
+              "deltaMs": 119
+            }
+          ],
+          "totalMs": 161
+        }
+      },
+      "guest_timing": {
+        "runtimeReady": true,
+        "runtime_harness": "opencode",
+        "boot_timeline": [
+          {
+            "label": "static-web",
+            "atMs": 21
+          },
+          {
+            "label": "git-identity",
+            "atMs": 55
+          },
+          {
+            "label": "proxy-up",
+            "atMs": 67
+          },
+          {
+            "label": "repo-materialized",
+            "atMs": 3230
+          },
+          {
+            "label": "config-deps",
+            "atMs": 3233
+          },
+          {
+            "label": "runtime-binary-resolved",
+            "atMs": 3240
+          },
+          {
+            "label": "runtime-cwd-resolved",
+            "atMs": 3240
+          },
+          {
+            "label": "runtime-config-ready",
+            "atMs": 3355
+          },
+          {
+            "label": "runtime-process-spawned",
+            "atMs": 3360
+          },
+          {
+            "label": "runtime-acp-first-output",
+            "atMs": 13381
+          },
+          {
+            "label": "runtime-acp-initialized",
+            "atMs": 14020
+          },
+          {
+            "label": "opencode-spawned",
+            "atMs": 14021
+          },
+          {
+            "label": "opencode-answering",
+            "atMs": 14461
+          },
+          {
+            "label": "runtime-session-new-requested",
+            "atMs": 14462
+          },
+          {
+            "label": "opencode-root-ready",
+            "atMs": 15918
+          },
+          {
+            "label": "opencode-session-created",
+            "atMs": 15918
+          },
+          {
+            "label": "opencode-ready",
+            "atMs": 15918
+          }
+        ]
+      },
+      "transcript": "OPENCODE_FIRST_a26da18a0169\nOPENCODE_FOLLOWUP_a26da18a0169\nOPENCODE_RESTART_a26da18a0169"
+    }
+  ]
+}

--- a/tests/performance/session-start/results/2026-07-29/opencode-fork-isolation-local-platinum.json
+++ b/tests/performance/session-start/results/2026-07-29/opencode-fork-isolation-local-platinum.json
@@ -1,0 +1,304 @@
+{
+  "measured_at": "2026-07-29T18:28:16.716Z",
+  "api_base": "http://localhost:13308/v1",
+  "project_id": "de46f8cb-cfee-4182-a8b2-7d0cf7a80968",
+  "provider": "platinum",
+  "readiness_only": false,
+  "open_code_fork_isolation": true,
+  "sessions": [
+    {
+      "harness": "opencode",
+      "project_session_id": "0b538877-4207-49c2-8076-40b6301cce63",
+      "sandbox_id": "0b538877-4207-49c2-8076-40b6301cce63",
+      "sandbox_external_id": "sbx_01KYQJ3T09E0TQ730DB5M4MBVB",
+      "opencode_session_id": "ses_050ddca47ffe4r8L0yDak7Fiar",
+      "sdk_opencode_session_id": "ses_050ddca47ffe4r8L0yDak7Fiar",
+      "acp_server_id": "",
+      "acp_session_id": "",
+      "markers": [
+        "OPENCODE_FIRST_b485e830242d",
+        "OPENCODE_FOLLOWUP_b485e830242d",
+        "OPENCODE_RESTART_b485e830242d"
+      ],
+      "create_to_session_ready_ms": 23736,
+      "host_timing": {
+        "image": {
+          "branch": "main",
+          "provider": "platinum",
+          "contentHash": "6ebe2014635b9878cbf9cf41d62aa043facdc8e42161b5d9901acb8ca0525d28",
+          "sandboxSlug": "default",
+          "artifactType": "platinum_template",
+          "isPlatformDefault": true,
+          "providerArtifactRef": "kortix-default-6ebe2014635b"
+        },
+        "provider": "platinum",
+        "provision_timeline": {
+          "id": "0b538877-4207-49c2-8076-40b6301cce63",
+          "kind": "provision",
+          "marks": [
+            {
+              "atMs": 73,
+              "label": "row+tokens",
+              "deltaMs": 73
+            },
+            {
+              "atMs": 2696,
+              "label": "image-cached",
+              "deltaMs": 2623
+            },
+            {
+              "atMs": 4802,
+              "label": "provider-create:1x",
+              "deltaMs": 2106
+            }
+          ],
+          "totalMs": 4802
+        },
+        "session_start_timeline": {
+          "id": "0b538877-4207-49c2-8076-40b6301cce63",
+          "kind": "session-create",
+          "marks": [
+            {
+              "atMs": 29,
+              "label": "git-auth",
+              "deltaMs": 29
+            },
+            {
+              "atMs": 141,
+              "label": "env-vars",
+              "deltaMs": 111
+            },
+            {
+              "atMs": 214,
+              "label": "kicked",
+              "deltaMs": 73
+            }
+          ],
+          "totalMs": 214
+        }
+      },
+      "guest_timing": {
+        "runtimeReady": true,
+        "runtime_harness": "opencode",
+        "boot_timeline": [
+          {
+            "label": "static-web",
+            "atMs": 23
+          },
+          {
+            "label": "git-identity",
+            "atMs": 56
+          },
+          {
+            "label": "proxy-up",
+            "atMs": 67
+          },
+          {
+            "label": "repo-materialized",
+            "atMs": 3825
+          },
+          {
+            "label": "config-deps",
+            "atMs": 3829
+          },
+          {
+            "label": "runtime-binary-resolved",
+            "atMs": 3837
+          },
+          {
+            "label": "runtime-cwd-resolved",
+            "atMs": 3837
+          },
+          {
+            "label": "runtime-config-ready",
+            "atMs": 3958
+          },
+          {
+            "label": "runtime-process-spawned",
+            "atMs": 3962
+          },
+          {
+            "label": "runtime-acp-first-output",
+            "atMs": 14486
+          },
+          {
+            "label": "runtime-acp-initialized",
+            "atMs": 15119
+          },
+          {
+            "label": "opencode-spawned",
+            "atMs": 15119
+          },
+          {
+            "label": "opencode-answering",
+            "atMs": 15590
+          },
+          {
+            "label": "runtime-session-new-requested",
+            "atMs": 15590
+          },
+          {
+            "label": "opencode-root-ready",
+            "atMs": 18232
+          },
+          {
+            "label": "opencode-session-created",
+            "atMs": 18233
+          },
+          {
+            "label": "opencode-ready",
+            "atMs": 18233
+          }
+        ]
+      },
+      "transcript": "OPENCODE_FIRST_b485e830242d\nOPENCODE_FOLLOWUP_b485e830242d\nOPENCODE_RESTART_b485e830242d"
+    },
+    {
+      "harness": "opencode",
+      "project_session_id": "bab4ceaa-bcba-425d-a423-0f425874b71a",
+      "sandbox_id": "bab4ceaa-bcba-425d-a423-0f425874b71a",
+      "sandbox_external_id": "sbx_01KYQJ3T7WS0C2EGNY7KRJCZWP",
+      "opencode_session_id": "ses_050ddd663ffe159AjQGlKxefsg",
+      "sdk_opencode_session_id": "ses_050ddd663ffe159AjQGlKxefsg",
+      "acp_server_id": "",
+      "acp_session_id": "",
+      "markers": [
+        "OPENCODE_FIRST_1795711b4693",
+        "OPENCODE_FOLLOWUP_1795711b4693",
+        "OPENCODE_RESTART_1795711b4693"
+      ],
+      "create_to_session_ready_ms": 21460,
+      "host_timing": {
+        "image": {
+          "branch": "main",
+          "provider": "platinum",
+          "contentHash": "6ebe2014635b9878cbf9cf41d62aa043facdc8e42161b5d9901acb8ca0525d28",
+          "sandboxSlug": "default",
+          "artifactType": "platinum_template",
+          "isPlatformDefault": true,
+          "providerArtifactRef": "kortix-default-6ebe2014635b"
+        },
+        "provider": "platinum",
+        "provision_timeline": {
+          "id": "bab4ceaa-bcba-425d-a423-0f425874b71a",
+          "kind": "provision",
+          "marks": [
+            {
+              "atMs": 98,
+              "label": "row+tokens",
+              "deltaMs": 98
+            },
+            {
+              "atMs": 3049,
+              "label": "image-cached",
+              "deltaMs": 2951
+            },
+            {
+              "atMs": 5143,
+              "label": "provider-create:1x",
+              "deltaMs": 2094
+            }
+          ],
+          "totalMs": 5143
+        },
+        "session_start_timeline": {
+          "id": "bab4ceaa-bcba-425d-a423-0f425874b71a",
+          "kind": "session-create",
+          "marks": [
+            {
+              "atMs": 30,
+              "label": "git-auth",
+              "deltaMs": 30
+            },
+            {
+              "atMs": 104,
+              "label": "env-vars",
+              "deltaMs": 73
+            },
+            {
+              "atMs": 204,
+              "label": "kicked",
+              "deltaMs": 100
+            }
+          ],
+          "totalMs": 204
+        }
+      },
+      "guest_timing": {
+        "runtimeReady": true,
+        "runtime_harness": "opencode",
+        "boot_timeline": [
+          {
+            "label": "static-web",
+            "atMs": 22
+          },
+          {
+            "label": "git-identity",
+            "atMs": 55
+          },
+          {
+            "label": "proxy-up",
+            "atMs": 66
+          },
+          {
+            "label": "repo-materialized",
+            "atMs": 2043
+          },
+          {
+            "label": "config-deps",
+            "atMs": 2047
+          },
+          {
+            "label": "runtime-binary-resolved",
+            "atMs": 2053
+          },
+          {
+            "label": "runtime-cwd-resolved",
+            "atMs": 2054
+          },
+          {
+            "label": "runtime-config-ready",
+            "atMs": 2168
+          },
+          {
+            "label": "runtime-process-spawned",
+            "atMs": 2172
+          },
+          {
+            "label": "runtime-acp-first-output",
+            "atMs": 12320
+          },
+          {
+            "label": "runtime-acp-initialized",
+            "atMs": 12920
+          },
+          {
+            "label": "opencode-spawned",
+            "atMs": 12920
+          },
+          {
+            "label": "opencode-answering",
+            "atMs": 13407
+          },
+          {
+            "label": "runtime-session-new-requested",
+            "atMs": 13407
+          },
+          {
+            "label": "opencode-root-ready",
+            "atMs": 14887
+          },
+          {
+            "label": "opencode-session-created",
+            "atMs": 14889
+          },
+          {
+            "label": "opencode-ready",
+            "atMs": 14889
+          }
+        ]
+      },
+      "transcript": "OPENCODE_FIRST_1795711b4693\nOPENCODE_FOLLOWUP_1795711b4693\nOPENCODE_RESTART_1795711b4693"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Treat the `/start` OpenCode root as authoritative while retaining `initialOpenCodeSessionId` as a cache seed.
- Scope React Query, transcript, and synchronization state to the active sandbox and stable Kortix session.
- Gate SSE, REST reconciliation, and runtime actions until `/start` switches the target sandbox.
- Correct the standalone gateway OpenAI base path to `/v1/llm-gateway/v1`.
- Add a reusable two-sandbox OpenCode REST isolation smoke with persisted timing evidence.

## Verification

- `pnpm --filter @kortix/sdk typecheck` — exit 0.
- `pnpm --filter @kortix/sdk test` — 1381 pass, 0 fail, 5970 assertions.
- `pnpm --filter @kortix/sdk run smoke:install` — packed install/import passed.
- `pnpm --filter kortix-api typecheck` — exit 0.
- Gateway focused test — 6 pass, 0 fail.
- `cd tests && bun run typecheck` — exit 0.
- Local Platinum isolation smoke — PASS 2/2.
- `/start` roots: `ses_050be4bb6ffepNq9BLE8kdybL9` and `ses_050be472cffeLbJ7ciXGs8smOL`.
- Create-to-ready: 21.758 s and 23.266 s.
- SDK `ensureReady()` matched each `/start` root.
- Restart preserved both roots.
- Each transcript contained only its own three assistant markers.
- Cleanup: projects=0, users=0.

## Evidence

`tests/performance/session-start/results/2026-07-29/opencode-fork-isolation-local-platinum-rebased.json`
