### PR TITLE
fix(sdk): honor inherited OpenCode session defaults

### DIFF
--- a/apps/web/content/docs/sdk/sessions.mdx
+++ b/apps/web/content/docs/sdk/sessions.mdx
@@ -92,6 +92,16 @@ await s.send('One-off task', { model, agent }); // overrides for this call only
 await s.abort(); // stop the current run
 ```
 
+For OpenCode REST sessions, the first `send()` on a handle reads the model and
+agent persisted on the Kortix session. This prevents a snapshot-inherited
+OpenCode session from reusing stale snapshot defaults.
+
+Prompt choice precedence is:
+
+1. The `send()` call.
+2. The handle's `setModel()` or `setAgent()` value.
+3. The persisted Kortix session default.
+
 `setModel` only chooses what the next local `send` asks for — it never leaves the
 handle. To **persist** a new model for a running session server-side, use
 `changeModel`:

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -3989,3 +3989,38 @@ Rebased local acceptance on `origin/main` `d627167f`:
 
 **Repository delivery shippable to production: NOT YET.** PR merge, Deploy Dev,
 deployed SHA proof, and deployed isolation verification remain.
+
+---
+
+### 2026-07-29 — session `sdk-inherited-session-defaults` follow-up claim
+
+Claimed the live inherited OpenCode session default compatibility follow-up.
+
+Live dev evidence on merge `7a7bb4f16`:
+
+- Three distinct Platinum sandboxes inherited
+  `ses_050fadf1dffeb2XyPZiu0qloal`.
+- SDK routing kept each user marker in its own sandbox transcript.
+- The first SDK prompt used the stale snapshot model
+  `opencode/big-pickle` and produced no assistant message.
+- A direct prompt with the persisted project-session model
+  `kortix/glm-5.2` unblocked each session.
+- Both sessions then passed follow-up, restart, and post-restart SDK sends.
+
+Scope:
+
+- Resolve the persisted project-session model and agent before a default SDK
+  `send`.
+- Keep explicit per-call and handle-level SDK overrides authoritative.
+- Accept an equal inherited OpenCode ID when sandbox and transcript ownership
+  remain isolated.
+- Make the disposable live smoke tolerate project manifest convergence without
+  hiding product failures.
+
+The required `tdd` skill is unavailable in this session.
+The implementation will use the same RED, GREEN, and REFACTOR sequence
+directly.
+
+**Status:** IN PROGRESS.
+
+**SDK package shippable to production: NOT YET.**

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -4024,3 +4024,59 @@ directly.
 **Status:** IN PROGRESS.
 
 **SDK package shippable to production: NOT YET.**
+
+---
+
+### 2026-07-29 — session `sdk-inherited-session-defaults` follow-up completion
+
+Completed the inherited OpenCode session compatibility fix in `a900fc605`.
+
+The SDK now reads the persisted project-session model and agent before the
+first default OpenCode REST `send()` on a handle. Per-call choices override
+handle choices. Handle choices override persisted defaults. `changeModel()`
+invalidates the cached persisted defaults. A failed defaults read clears the
+cache so the next `send()` retries it.
+
+The live smoke now treats the sandbox as the isolation boundary. It accepts an
+equal snapshot-inherited `opencode_session_id` only when the Kortix sessions,
+sandboxes, and transcripts remain isolated. The session-create helper retries
+only the exact `409 ACP_RUNTIME_REQUIRED` manifest-convergence response.
+
+TDD and focused evidence:
+
+- RED: the inherited-session prompt omitted the persisted model and agent.
+- GREEN: the prompt used `kortix/glm-5.2` and agent `kortix`.
+- RED: `changeModel()` left the old persisted model cached.
+- GREEN: the next prompt used the changed model.
+- Focused SDK client suite: `71 pass`, `0 fail`, `258` assertions.
+- Tests package typecheck: exit `0`.
+
+Final SDK gates:
+
+- `pnpm --filter @kortix/sdk typecheck`: exit `0`.
+- `pnpm --filter @kortix/sdk test`: `1385 pass`, `0 fail`, `5978`
+  assertions across `121` files.
+- `pnpm --filter @kortix/sdk run smoke:install`: the packed tarball installed,
+  imported, and constructed successfully.
+
+Live dev Platinum acceptance:
+
+- Evidence:
+  `tests/performance/session-start/results/2026-07-29/opencode-inherited-pin-dev-platinum.json`.
+- Result: `PASS 2/2`.
+- Create-to-ready: `26.022 s` and `35.169 s`.
+- Two distinct Kortix sessions and Platinum sandboxes inherited
+  `ses_050fadf1dffeb2XyPZiu0qloal`.
+- `createKortix().session().ensureReady()` matched the authoritative `/start`
+  pin for both sandboxes.
+- Both sessions passed first response, follow-up response, restart, and
+  post-restart response using only SDK `send()`.
+- Each transcript contained only its own three assistant markers.
+- Fixture cleanup removed the project, sessions, account, and user.
+
+**Status:** COMPLETE.
+
+**SDK package shippable to production: YES.**
+
+**Repository delivery shippable to production: NOT YET.** PR merge, Deploy Dev,
+and deployed SHA proof remain.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -110,6 +110,12 @@ const { opencodeSessionId } = await s.ensureReady();
 await s.runtime.session.prompt({ sessionID: opencodeSessionId, parts });
 ```
 
+For OpenCode REST sessions, `send()` reads the persisted session model and
+agent before the first prompt on a handle. This prevents a snapshot-inherited
+OpenCode session from reusing stale snapshot defaults. A per-call choice
+overrides a `setModel()` or `setAgent()` choice. A handle choice overrides the
+persisted session default.
+
 ### React runtime transport
 
 `useSession(projectId, sessionId)` uses the transport selected by `POST /start`.

--- a/packages/sdk/src/core/client/kortix.test.ts
+++ b/packages/sdk/src/core/client/kortix.test.ts
@@ -719,6 +719,194 @@ test('two session handles resolve independent runtimes: A.send never crosses to 
   expect(aAbortCall?.url).not.toContain('sb-B');
 });
 
+test('send applies persisted session defaults when the OpenCode pin came from a snapshot', async () => {
+  globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+    const url = requestUrl(input);
+    const request = input instanceof Request ? input : null;
+    const bodyText = request ? await request.clone().text() : String(init?.body ?? '');
+    calls.push({
+      url,
+      method: request?.method ?? init?.method ?? 'GET',
+      body: bodyText ? JSON.parse(bodyText) : undefined,
+    });
+    if (url.includes('/sessions/SESS-INHERITED/start')) {
+      return jsonResponse(sessionStartPayload('sb-inherited', 'shared-snapshot-pin'));
+    }
+    if (url.endsWith('/projects/PROJ/sessions/SESS-INHERITED')) {
+      return jsonResponse({
+        session_id: 'SESS-INHERITED',
+        agent_name: 'kortix',
+        metadata: { opencode_model: 'kortix/glm-5.2' },
+      });
+    }
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({
+    backendUrl: 'http://test.local',
+    getToken: async () => 'tok',
+  });
+  await k.session('PROJ', 'SESS-INHERITED').send('hello from inherited state');
+
+  const promptCall = calls.find((call) => call.url.includes('/p/sb-inherited/8000/session/shared-snapshot-pin/message') && call.method === 'POST');
+  expect(promptCall?.body).toMatchObject({
+    agent: 'kortix',
+    model: { providerID: 'kortix', modelID: 'glm-5.2' },
+    parts: [{ type: 'text', text: 'hello from inherited state' }],
+  });
+});
+
+test('changeModel invalidates the persisted default before the next send', async () => {
+  let persistedModel = 'kortix/glm-5.2';
+  globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+    const url = requestUrl(input);
+    const request = input instanceof Request ? input : null;
+    const bodyText = request ? await request.clone().text() : String(init?.body ?? '');
+    const body = bodyText ? JSON.parse(bodyText) : undefined;
+    calls.push({
+      url,
+      method: request?.method ?? init?.method ?? 'GET',
+      body,
+    });
+    if (url.includes('/sessions/SESS-MODEL-CHANGE/start')) {
+      return jsonResponse(sessionStartPayload('sb-model-change', 'shared-snapshot-pin'));
+    }
+    if (url.endsWith('/projects/PROJ/sessions/SESS-MODEL-CHANGE/model')) {
+      persistedModel = body.opencode_model;
+      return jsonResponse({
+        opencode_model: persistedModel,
+        applied_live: true,
+      });
+    }
+    if (url.endsWith('/projects/PROJ/sessions/SESS-MODEL-CHANGE')) {
+      return jsonResponse({
+        session_id: 'SESS-MODEL-CHANGE',
+        agent_name: 'kortix',
+        metadata: { opencode_model: persistedModel },
+      });
+    }
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({
+    backendUrl: 'http://test.local',
+    getToken: async () => 'tok',
+  });
+  const handle = k.session('PROJ', 'SESS-MODEL-CHANGE');
+  await handle.send('before change');
+  await handle.changeModel('kortix/gpt-5.6-mini');
+  await handle.send('after change');
+
+  const prompts = calls.filter((call) => call.url.includes('/p/sb-model-change/8000/session/shared-snapshot-pin/message') && call.method === 'POST');
+  expect(prompts.map((call) => call.body)).toEqual([
+    expect.objectContaining({
+      model: { providerID: 'kortix', modelID: 'glm-5.2' },
+    }),
+    expect.objectContaining({
+      model: { providerID: 'kortix', modelID: 'gpt-5.6-mini' },
+    }),
+  ]);
+});
+
+test('per-call and handle prompt choices override persisted session defaults', async () => {
+  globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+    const url = requestUrl(input);
+    const request = input instanceof Request ? input : null;
+    const bodyText = request ? await request.clone().text() : String(init?.body ?? '');
+    calls.push({
+      url,
+      method: request?.method ?? init?.method ?? 'GET',
+      body: bodyText ? JSON.parse(bodyText) : undefined,
+    });
+    if (url.includes('/sessions/SESS-OVERRIDES/start')) {
+      return jsonResponse(sessionStartPayload('sb-overrides', 'shared-snapshot-pin'));
+    }
+    if (url.endsWith('/projects/PROJ/sessions/SESS-OVERRIDES')) {
+      return jsonResponse({
+        session_id: 'SESS-OVERRIDES',
+        agent_name: 'persisted-agent',
+        metadata: { opencode_model: 'persisted/model' },
+      });
+    }
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({
+    backendUrl: 'http://test.local',
+    getToken: async () => 'tok',
+  });
+  const handle = k.session('PROJ', 'SESS-OVERRIDES');
+  await handle.send('persisted');
+  handle.setModel({ providerID: 'sticky', modelID: 'model' });
+  handle.setAgent('sticky-agent');
+  await handle.send('sticky');
+  await handle.send('per-call', {
+    model: { providerID: 'per-call', modelID: 'model' },
+    agent: 'per-call-agent',
+  });
+
+  const prompts = calls.filter((call) => call.url.includes('/p/sb-overrides/8000/session/shared-snapshot-pin/message') && call.method === 'POST');
+  expect(prompts.map((call) => call.body)).toEqual([
+    expect.objectContaining({
+      model: { providerID: 'persisted', modelID: 'model' },
+      agent: 'persisted-agent',
+    }),
+    expect.objectContaining({
+      model: { providerID: 'sticky', modelID: 'model' },
+      agent: 'sticky-agent',
+    }),
+    expect.objectContaining({
+      model: { providerID: 'per-call', modelID: 'model' },
+      agent: 'per-call-agent',
+    }),
+  ]);
+  expect(calls.filter((call) => call.url.endsWith('/projects/PROJ/sessions/SESS-OVERRIDES') && call.method === 'GET')).toHaveLength(1);
+});
+
+test('a failed persisted-default read is retried by the next send', async () => {
+  let sessionReads = 0;
+  globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+    const url = requestUrl(input);
+    const request = input instanceof Request ? input : null;
+    const bodyText = request ? await request.clone().text() : String(init?.body ?? '');
+    calls.push({
+      url,
+      method: request?.method ?? init?.method ?? 'GET',
+      body: bodyText ? JSON.parse(bodyText) : undefined,
+    });
+    if (url.includes('/sessions/SESS-DEFAULT-RETRY/start')) {
+      return jsonResponse(sessionStartPayload('sb-default-retry', 'shared-snapshot-pin'));
+    }
+    if (url.endsWith('/projects/PROJ/sessions/SESS-DEFAULT-RETRY')) {
+      sessionReads += 1;
+      if (sessionReads <= 3) throw new TypeError('transient session read failure');
+      return jsonResponse({
+        session_id: 'SESS-DEFAULT-RETRY',
+        agent_name: 'persisted-agent',
+        metadata: { opencode_model: 'persisted/model' },
+      });
+    }
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({
+    backendUrl: 'http://test.local',
+    getToken: async () => 'tok',
+  });
+  const handle = k.session('PROJ', 'SESS-DEFAULT-RETRY');
+  await expect(handle.send('first')).rejects.toThrow('transient session read failure');
+  await handle.send('second');
+
+  expect(sessionReads).toBe(4);
+  const prompts = calls.filter((call) => call.url.includes('/p/sb-default-retry/8000/session/shared-snapshot-pin/message') && call.method === 'POST');
+  expect(prompts).toHaveLength(1);
+  expect(prompts[0]?.body).toMatchObject({
+    model: { providerID: 'persisted', modelID: 'model' },
+    agent: 'persisted-agent',
+    parts: [{ type: 'text', text: 'second' }],
+  });
+});
+
 test('previewUrl uses the handle\'s own sandbox id, not whichever session resolved last', async () => {
   globalThis.fetch = mockTwoSessionRuntimes();
   const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });

--- a/packages/sdk/src/core/client/kortix.ts
+++ b/packages/sdk/src/core/client/kortix.ts
@@ -654,6 +654,51 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
     let _ready: SessionRuntimeEntry | null = null;
     let _model: SessionModel | undefined;
     let _agent: string | undefined;
+    let _persistedPromptDefaults: Promise<{
+      model?: SessionModel;
+      agent?: string;
+    }> | null = null;
+
+    /**
+     * Resolve the server-owned prompt defaults once per handle.
+     *
+     * A stateful snapshot can contain an existing OpenCode session. OpenCode
+     * then reuses that session's last model unless every prompt specifies the
+     * current project-session model. Read the persisted Kortix session so the
+     * first SDK prompt cannot inherit stale snapshot configuration.
+     */
+    async function persistedPromptDefaults(): Promise<{
+      model?: SessionModel;
+      agent?: string;
+    }> {
+      if (!_persistedPromptDefaults) {
+        _persistedPromptDefaults = P.getProjectSession(projectId, sessionId, {
+          showErrors: false,
+        }).then((projectSession) => {
+          const modelReference =
+            typeof projectSession.metadata?.opencode_model === 'string'
+              ? projectSession.metadata.opencode_model.trim()
+              : '';
+          const separator = modelReference.indexOf('/');
+          const model =
+            separator > 0 && separator < modelReference.length - 1
+              ? {
+                  providerID: modelReference.slice(0, separator),
+                  modelID: modelReference.slice(separator + 1),
+                }
+              : undefined;
+          const agent = projectSession.agent_name?.trim() || undefined;
+          return { model, agent };
+        });
+      }
+      try {
+        return await _persistedPromptDefaults;
+      } catch (error) {
+        // A transient read must not poison every later send on this handle.
+        _persistedPromptDefaults = null;
+        throw error;
+      }
+    }
 
     /**
      * Adopt an already-resolved runtime for THIS (projectId, sessionId) from
@@ -887,7 +932,11 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
        * turn ends. `applied_live` reports whether a running session took it now
        * or whether it applies at next start.
        */
-      changeModel: (model: string) => P.setProjectSessionModel(projectId, sessionId, model),
+      changeModel: async (model: string) => {
+        const result = await P.setProjectSessionModel(projectId, sessionId, model);
+        _persistedPromptDefaults = null;
+        return result;
+      },
       /** Re-scope a running session — set semantics; see setProjectSessionScope. */
       rescope: (scope: P.SessionScopeInput) =>
         P.setProjectSessionScope(projectId, sessionId, scope),
@@ -902,8 +951,11 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
        */
       send: async (text: string, opts?: { model?: SessionModel; agent?: string }) => {
         const { opencodeSessionId, runtimeUrl } = await ensureReady();
-        const model = opts?.model ?? _model;
-        const agent = opts?.agent ?? _agent;
+        const selectedModel = opts?.model ?? _model;
+        const selectedAgent = opts?.agent ?? _agent;
+        const persisted = selectedModel && selectedAgent ? {} : await persistedPromptDefaults();
+        const model = selectedModel ?? persisted.model;
+        const agent = selectedAgent ?? persisted.agent;
         return getClientForUrl(runtimeUrl).session.prompt({
           sessionID: opencodeSessionId,
           parts: [{ type: 'text', text }],

--- a/tests/README.md
+++ b/tests/README.md
@@ -128,8 +128,9 @@ prompt dispatch and model latency.
 Set `E2E_ACP_OPENCODE_FORK_ISOLATION=1` to create two OpenCode sessions in
 parallel from one version 2 compatibility-project snapshot. Version 3 projects
 use ACP identity instead of `opencode_session_id`. This mode verifies distinct
-Kortix session, sandbox, provider, and OpenCode identities. It also sends unique
-markers and rejects cross-session transcript content. The public
+Kortix session and sandbox identities. It accepts an equal snapshot-inherited
+`opencode_session_id` only when the sandbox-scoped transcripts remain isolated.
+It sends unique markers and rejects cross-session transcript content. The public
 `createKortix().session().ensureReady()` result must match each authoritative
 `/start` `opencode_session_id`.
 

--- a/tests/e2e/scripts/acp-multi-harness-smoke.ts
+++ b/tests/e2e/scripts/acp-multi-harness-smoke.ts
@@ -80,6 +80,11 @@ type HarnessEvidence = {
   guest_timing: unknown;
 };
 
+type SessionCreateError = {
+  error?: string;
+  code?: string;
+};
+
 const repoRoot = resolve(import.meta.dir, '../../..');
 const apiBase = process.env.E2E_API_URL || 'http://localhost:8008/v1';
 const supabaseUrl = process.env.E2E_SUPABASE_URL || 'http://127.0.0.1:54321';
@@ -399,6 +404,39 @@ async function readSession(token: string, sessionId: string): Promise<ProjectSes
   return api<ProjectSession>(token, 'GET', `/projects/${projectId}/sessions/${sessionId}`);
 }
 
+async function createSessionAfterManifestConvergence(
+  token: string,
+  harness: Harness,
+  body: Record<string, unknown>,
+): Promise<ProjectSession> {
+  const maxAttempts = 15;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = await apiResult<ProjectSession & SessionCreateError>(
+      apiBase,
+      token,
+      'POST',
+      `/projects/${projectId}/sessions`,
+      body,
+    );
+    if (result.status === 201 && result.json?.session_id) return result.json;
+
+    const isManifestConvergence =
+      result.status === 409 && result.json?.code === 'ACP_RUNTIME_REQUIRED';
+    if (!isManifestConvergence || attempt === maxAttempts) {
+      throw new Error(
+        `${harness} session create returned ${result.status}: ${JSON.stringify(result.json)}`,
+      );
+    }
+
+    log(
+      harness,
+      `manifest convergence returned 409 ACP_RUNTIME_REQUIRED; retrying create (${attempt}/${maxAttempts})`,
+    );
+    await Bun.sleep(1_000);
+  }
+  throw new Error(`${harness} session create exhausted the manifest convergence retry`);
+}
+
 async function waitForReady(
   token: string,
   sessionId: string,
@@ -472,21 +510,15 @@ async function verifyHarness(token: string, harness: Harness): Promise<HarnessEv
   const secondMarker = `${harness.toUpperCase()}_FOLLOWUP_${markerSuffix}`;
   const restartMarker = `${harness.toUpperCase()}_RESTART_${markerSuffix}`;
   const createStartedAt = performance.now();
-  const created = await api<ProjectSession>(
-    token,
-    'POST',
-    `/projects/${projectId}/sessions`,
-    {
-      name: `${harness} ACP smoke`,
-      agent_name: assertOpenCodeForkIsolation ? 'kortix' : harness,
-      ...(!assertOpenCodeForkIsolation
-        ? { initial_prompt: `Reply with exactly ${firstMarker}` }
-        : {}),
-      ...(sandboxProvider ? { provider: sandboxProvider } : {}),
-      ...(runtimeModel ? { opencode_model: runtimeModel } : {}),
-    },
-    201,
-  );
+  const created = await createSessionAfterManifestConvergence(token, harness, {
+    name: `${harness} ACP smoke`,
+    agent_name: assertOpenCodeForkIsolation ? 'kortix' : harness,
+    ...(!assertOpenCodeForkIsolation
+      ? { initial_prompt: `Reply with exactly ${firstMarker}` }
+      : {}),
+    ...(sandboxProvider ? { provider: sandboxProvider } : {}),
+    ...(runtimeModel ? { opencode_model: runtimeModel } : {}),
+  });
   const sessionId = created.session_id;
   sessionIds.push(sessionId);
   assert(
@@ -687,10 +719,6 @@ function verifyOpenCodeForkIsolation(evidence: HarnessEvidence[]): void {
     first.sandbox_external_id !== second.sandbox_external_id,
     'OpenCode fork sessions share one sandbox external_id',
   );
-  assert(
-    first.opencode_session_id !== second.opencode_session_id,
-    'OpenCode fork sessions share one /start opencode_session_id',
-  );
   if (!readinessOnly) {
     assert(
       second.markers.every((marker) => !first.transcript.includes(marker)),
@@ -703,7 +731,7 @@ function verifyOpenCodeForkIsolation(evidence: HarnessEvidence[]): void {
   }
   log(
     'opencode-fork-isolation',
-    `PASS session_a=${first.project_session_id} opencode_a=${first.opencode_session_id} session_b=${second.project_session_id} opencode_b=${second.opencode_session_id}`,
+    `PASS session_a=${first.project_session_id} opencode_a=${first.opencode_session_id} session_b=${second.project_session_id} opencode_b=${second.opencode_session_id} inherited_pin_equal=${first.opencode_session_id === second.opencode_session_id}`,
   );
 }
 

--- a/tests/performance/session-start/results/2026-07-29/opencode-inherited-pin-dev-platinum.json
+++ b/tests/performance/session-start/results/2026-07-29/opencode-inherited-pin-dev-platinum.json
@@ -1,0 +1,304 @@
+{
+  "measured_at": "2026-07-29T20:13:37.518Z",
+  "api_base": "https://dev-api.kortix.com/v1",
+  "project_id": "f191d834-faad-4b69-a23b-aab425ebe90b",
+  "provider": "platinum",
+  "readiness_only": false,
+  "open_code_fork_isolation": true,
+  "sessions": [
+    {
+      "harness": "opencode",
+      "project_session_id": "d3552750-0b3d-4755-8fdf-f92612d8f47c",
+      "sandbox_id": "d3552750-0b3d-4755-8fdf-f92612d8f47c",
+      "sandbox_external_id": "sbx_01KYQR3PSF68T8248QJDSWK30Q",
+      "opencode_session_id": "ses_050fadf1dffeb2XyPZiu0qloal",
+      "sdk_opencode_session_id": "ses_050fadf1dffeb2XyPZiu0qloal",
+      "acp_server_id": "",
+      "acp_session_id": "",
+      "markers": [
+        "OPENCODE_FIRST_b184169d3dd5",
+        "OPENCODE_FOLLOWUP_b184169d3dd5",
+        "OPENCODE_RESTART_b184169d3dd5"
+      ],
+      "create_to_session_ready_ms": 35169,
+      "host_timing": {
+        "image": {
+          "branch": "main",
+          "provider": "platinum",
+          "contentHash": "d51c06b16b521e90fffa293fa7536366251f3f7646cc2643fb309f03959928be",
+          "sandboxSlug": "default",
+          "artifactType": "platinum_template",
+          "isPlatformDefault": true,
+          "providerArtifactRef": "kortix-default-d51c06b16b52"
+        },
+        "provider": "platinum",
+        "provision_timeline": {
+          "id": "d3552750-0b3d-4755-8fdf-f92612d8f47c",
+          "kind": "provision",
+          "marks": [
+            {
+              "atMs": 311,
+              "label": "row+tokens",
+              "deltaMs": 311
+            },
+            {
+              "atMs": 409,
+              "label": "image-cached",
+              "deltaMs": 98
+            },
+            {
+              "atMs": 12396,
+              "label": "provider-create:1x",
+              "deltaMs": 11987
+            }
+          ],
+          "totalMs": 12396
+        },
+        "session_start_timeline": {
+          "id": "d3552750-0b3d-4755-8fdf-f92612d8f47c",
+          "kind": "session-create",
+          "marks": [
+            {
+              "atMs": 243,
+              "label": "git-auth",
+              "deltaMs": 243
+            },
+            {
+              "atMs": 442,
+              "label": "env-vars",
+              "deltaMs": 199
+            },
+            {
+              "atMs": 754,
+              "label": "kicked",
+              "deltaMs": 312
+            }
+          ],
+          "totalMs": 754
+        }
+      },
+      "guest_timing": {
+        "runtimeReady": true,
+        "runtime_harness": "opencode",
+        "boot_timeline": [
+          {
+            "label": "static-web",
+            "atMs": 22
+          },
+          {
+            "label": "git-identity",
+            "atMs": 57
+          },
+          {
+            "label": "proxy-up",
+            "atMs": 69
+          },
+          {
+            "label": "repo-materialized",
+            "atMs": 8661
+          },
+          {
+            "label": "config-deps",
+            "atMs": 9195
+          },
+          {
+            "label": "runtime-binary-resolved",
+            "atMs": 9201
+          },
+          {
+            "label": "runtime-cwd-resolved",
+            "atMs": 9201
+          },
+          {
+            "label": "runtime-config-ready",
+            "atMs": 9301
+          },
+          {
+            "label": "runtime-process-spawned",
+            "atMs": 9304
+          },
+          {
+            "label": "runtime-acp-first-output",
+            "atMs": 15824
+          },
+          {
+            "label": "runtime-acp-initialized",
+            "atMs": 16356
+          },
+          {
+            "label": "opencode-spawned",
+            "atMs": 16356
+          },
+          {
+            "label": "opencode-answering",
+            "atMs": 16885
+          },
+          {
+            "label": "runtime-session-resume-requested",
+            "atMs": 16885
+          },
+          {
+            "label": "opencode-root-ready",
+            "atMs": 18419
+          },
+          {
+            "label": "opencode-session-created",
+            "atMs": 18419
+          },
+          {
+            "label": "opencode-ready",
+            "atMs": 18419
+          }
+        ]
+      },
+      "transcript": "OPENCODE_FIRST_b184169d3dd5\nOPENCODE_FOLLOWUP_b184169d3dd5\nOPENCODE_RESTART_b184169d3dd5"
+    },
+    {
+      "harness": "opencode",
+      "project_session_id": "cf7f9a74-0297-43c5-8e89-475b6b57f2ae",
+      "sandbox_id": "cf7f9a74-0297-43c5-8e89-475b6b57f2ae",
+      "sandbox_external_id": "sbx_01KYQR3PJ1ZG0Q9ARHV7QBMN37",
+      "opencode_session_id": "ses_050fadf1dffeb2XyPZiu0qloal",
+      "sdk_opencode_session_id": "ses_050fadf1dffeb2XyPZiu0qloal",
+      "acp_server_id": "",
+      "acp_session_id": "",
+      "markers": [
+        "OPENCODE_FIRST_dd824103321c",
+        "OPENCODE_FOLLOWUP_dd824103321c",
+        "OPENCODE_RESTART_dd824103321c"
+      ],
+      "create_to_session_ready_ms": 26022,
+      "host_timing": {
+        "image": {
+          "branch": "main",
+          "provider": "platinum",
+          "contentHash": "d51c06b16b521e90fffa293fa7536366251f3f7646cc2643fb309f03959928be",
+          "sandboxSlug": "default",
+          "artifactType": "platinum_template",
+          "isPlatformDefault": true,
+          "providerArtifactRef": "kortix-default-d51c06b16b52"
+        },
+        "provider": "platinum",
+        "provision_timeline": {
+          "id": "cf7f9a74-0297-43c5-8e89-475b6b57f2ae",
+          "kind": "provision",
+          "marks": [
+            {
+              "atMs": 767,
+              "label": "row+tokens",
+              "deltaMs": 767
+            },
+            {
+              "atMs": 863,
+              "label": "image-cached",
+              "deltaMs": 96
+            },
+            {
+              "atMs": 3305,
+              "label": "provider-create:1x",
+              "deltaMs": 2442
+            }
+          ],
+          "totalMs": 3305
+        },
+        "session_start_timeline": {
+          "id": "cf7f9a74-0297-43c5-8e89-475b6b57f2ae",
+          "kind": "session-create",
+          "marks": [
+            {
+              "atMs": 199,
+              "label": "git-auth",
+              "deltaMs": 199
+            },
+            {
+              "atMs": 547,
+              "label": "env-vars",
+              "deltaMs": 347
+            },
+            {
+              "atMs": 1314,
+              "label": "kicked",
+              "deltaMs": 767
+            }
+          ],
+          "totalMs": 1314
+        }
+      },
+      "guest_timing": {
+        "runtimeReady": true,
+        "runtime_harness": "opencode",
+        "boot_timeline": [
+          {
+            "label": "static-web",
+            "atMs": 23
+          },
+          {
+            "label": "git-identity",
+            "atMs": 57
+          },
+          {
+            "label": "proxy-up",
+            "atMs": 69
+          },
+          {
+            "label": "repo-materialized",
+            "atMs": 10319
+          },
+          {
+            "label": "config-deps",
+            "atMs": 10902
+          },
+          {
+            "label": "runtime-binary-resolved",
+            "atMs": 10908
+          },
+          {
+            "label": "runtime-cwd-resolved",
+            "atMs": 10908
+          },
+          {
+            "label": "runtime-config-ready",
+            "atMs": 10982
+          },
+          {
+            "label": "runtime-process-spawned",
+            "atMs": 10985
+          },
+          {
+            "label": "runtime-acp-first-output",
+            "atMs": 15525
+          },
+          {
+            "label": "runtime-acp-initialized",
+            "atMs": 16025
+          },
+          {
+            "label": "opencode-spawned",
+            "atMs": 16025
+          },
+          {
+            "label": "opencode-answering",
+            "atMs": 16586
+          },
+          {
+            "label": "runtime-session-resume-requested",
+            "atMs": 16586
+          },
+          {
+            "label": "opencode-root-ready",
+            "atMs": 18181
+          },
+          {
+            "label": "opencode-session-created",
+            "atMs": 18181
+          },
+          {
+            "label": "opencode-ready",
+            "atMs": 18181
+          }
+        ]
+      },
+      "transcript": "OPENCODE_FIRST_dd824103321c\nOPENCODE_FOLLOWUP_dd824103321c\nOPENCODE_RESTART_dd824103321c"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Read the persisted session model and agent before the first default OpenCode REST `send()` on each SDK handle.
- Preserve per-call overrides over handle overrides, and handle overrides over persisted defaults.
- Invalidate persisted defaults after `changeModel()` and retry a failed defaults read on the next `send()`.
- Treat the sandbox as the isolation boundary when snapshots expose an equal inherited OpenCode ID.
- Retry only `409 ACP_RUNTIME_REQUIRED` during disposable manifest convergence.

## Verification

- `pnpm --filter @kortix/sdk typecheck`: exit 0.
- `pnpm --filter @kortix/sdk test`: 1385 pass, 0 fail, 5978 assertions, 121 files.
- `pnpm --filter @kortix/sdk run smoke:install`: passed.
- `pnpm --dir tests typecheck`: exit 0.
- Dev Platinum smoke: PASS 2/2.
- Both sandboxes inherited `ses_050fadf1dffeb2XyPZiu0qloal`.
- Both SDK handles matched the `/start` pin.
- Both sessions passed first response, follow-up, restart, and post-restart response.
- Each transcript contained only its own markers.
- Fixture cleanup removed the project, sessions, account, and user.

Evidence: `tests/performance/session-start/results/2026-07-29/opencode-inherited-pin-dev-platinum.json`.

SDK shippable to production: YES.
