### PR TITLE
fix(gateway): require zero usage for soft rate limits

### DIFF
--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -1142,6 +1142,7 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3}}\n\n' +
     'data: [DONE]\n\n';
   const softRateLimitSse = `data: {"choices":[{"delta":{"content":"${rampRateMessage}"},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0}}\n\ndata: [DONE]\n\n`;
+  const validQuotedRateLimitSse = `data: {"choices":[{"delta":{"content":"${rampRateMessage}"},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":20,"total_tokens":32}}\n\ndata: [DONE]\n\n`;
 
   // The ai-sdk engine PARSES an upstream SSE stream (via the real
   // @ai-sdk/openai-compatible provider) and RE-SERIALIZES it through this
@@ -1350,6 +1351,32 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
       errorCode: "upstream_error",
       errorMessage: rampRateMessage,
     });
+  });
+
+  test("streaming: the exact rate-limit sentence with non-zero usage is relayed without retry", async () => {
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    let calls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      calls += 1;
+      return sseResponse(validQuotedRateLimitSse);
+    };
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true,"messages":[{"role":"user","content":"quote the rate-limit message"}]}',
+    });
+
+    expect(res.status).toBe(200);
+    const text = await new Response(res.body).text();
+    expect(sseText(text)).toEqual({ content: rampRateMessage, finishReason: "stop" });
+    expect(calls).toBe(1);
+    await flush();
+    expect(traces[0]).toMatchObject({
+      ok: true,
+      status: 200,
+      provider: "openrouter",
+    });
+    expect(traces[0].candidatesTried).toEqual(["openrouter"]);
   });
 
   // An otherwise-200 stream that carries a structured `{error:{...}}` frame and no

--- a/packages/llm-gateway/src/pipeline/streaming.test.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.test.ts
@@ -181,7 +181,9 @@ describe('probeStream', () => {
     up.push(
       'data: {"choices":[{"delta":{"content":" To ensure system stability, please adjust your client logic to scale requests more smoothly over time."}}]}\n\n',
     );
-    up.push('data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n');
+    up.push(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}\n\n',
+    );
     up.push('data: [DONE]\n\n');
     up.close();
 
@@ -196,6 +198,23 @@ describe('probeStream', () => {
     });
   });
 
+  test('relays the exact soft-failure sentence when streaming usage is non-zero', async () => {
+    const up = controllableUpstream();
+    up.push(
+      'data: {"choices":[{"delta":{"content":"Request rate increased too quickly. To ensure system stability, please adjust your client logic to scale requests more smoothly over time."}}]}\n\n',
+    );
+    up.push(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":20,"total_tokens":32}}\n\n',
+    );
+    up.push('data: [DONE]\n\n');
+    up.close();
+
+    const result = await probeStream(up.stream);
+
+    expect(result.hasContent).toBe(true);
+    expect(result.errorFrame).toBeUndefined();
+  });
+
   test('does not release a soft-failure prefix at the normal chunk budget', async () => {
     const up = controllableUpstream();
     up.push(
@@ -205,7 +224,9 @@ describe('probeStream', () => {
     up.push(
       'data: {"choices":[{"delta":{"content":" To ensure system stability, please adjust your client logic to scale requests more smoothly over time."}}]}\n\n',
     );
-    up.push('data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n');
+    up.push(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}\n\n',
+    );
     up.close();
 
     const result = await probeStream(up.stream);

--- a/packages/llm-gateway/src/usage/completion-guard.test.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.test.ts
@@ -112,12 +112,24 @@ describe('soft upstream failures encoded as assistant content', () => {
     expect(sseMayContainSoftFailure(prefix)).toBe(true);
     expect(sseSoftFailureFrame(prefix)).toBeNull();
 
-    const complete = `${prefix}data: {"choices":[{"delta":{"content":" To ensure system stability, please adjust your client logic to scale requests more smoothly over time."},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n`;
+    const complete = `${prefix}data: {"choices":[{"delta":{"content":" To ensure system stability, please adjust your client logic to scale requests more smoothly over time."},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}\n\ndata: [DONE]\n\n`;
     expect(sseSoftFailureFrame(complete)).toEqual({
       message: RAMP_RATE_MESSAGE,
       code: 429,
       detail: { type: 'soft_rate_limit' },
     });
+  });
+
+  test('does not classify the exact sentence when streaming usage is non-zero', () => {
+    const valid = `data: {"choices":[{"delta":{"content":"${RAMP_RATE_MESSAGE}"},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":20,"total_tokens":32}}\n\ndata: [DONE]\n\n`;
+
+    expect(sseSoftFailureFrame(valid)).toBeNull();
+  });
+
+  test('does not classify the exact sentence when streaming usage is absent', () => {
+    const unverified = `data: {"choices":[{"delta":{"content":"${RAMP_RATE_MESSAGE}"},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n`;
+
+    expect(sseSoftFailureFrame(unverified)).toBeNull();
   });
 
   test('releases normal content as soon as it diverges from the failure prefix', () => {

--- a/packages/llm-gateway/src/usage/completion-guard.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.ts
@@ -71,12 +71,16 @@ const SOFT_RATE_LIMIT_FRAME: SseErrorFrame = {
   detail: { type: 'soft_rate_limit' },
 };
 
-function hasZeroUsage(data: Record<string, unknown>): boolean {
+function tokenUsageValues(data: Record<string, unknown>): unknown[] {
   const usage = data.usage;
-  if (!usage || typeof usage !== 'object') return false;
-  const values = Object.entries(usage as Record<string, unknown>)
+  if (!usage || typeof usage !== 'object') return [];
+  return Object.entries(usage as Record<string, unknown>)
     .filter(([key]) => key.endsWith('_tokens') || key === 'total_tokens')
     .map(([, value]) => value);
+}
+
+function hasZeroUsage(data: Record<string, unknown>): boolean {
+  const values = tokenUsageValues(data);
   return values.length > 0 && values.every((value) => value === 0);
 }
 
@@ -106,12 +110,16 @@ interface SseSoftFailureState {
   text: string;
   ended: boolean;
   incompatibleOutput: boolean;
+  zeroUsageKnown: boolean;
+  zeroUsage: boolean;
 }
 
 function sseSoftFailureState(buffer: string): SseSoftFailureState {
   let text = '';
   let ended = false;
   let incompatibleOutput = false;
+  let zeroUsageKnown = false;
+  let zeroUsage = true;
 
   for (const line of buffer.split('\n')) {
     if (!line.startsWith('data:')) continue;
@@ -122,7 +130,12 @@ function sseSoftFailureState(buffer: string): SseSoftFailureState {
       continue;
     }
     try {
-      const chunk = JSON.parse(payload) as { choices?: unknown };
+      const chunk = JSON.parse(payload) as Record<string, unknown> & { choices?: unknown };
+      const usageValues = tokenUsageValues(chunk);
+      if (usageValues.length > 0) {
+        zeroUsageKnown = true;
+        if (usageValues.some((value) => value !== 0)) zeroUsage = false;
+      }
       if (!Array.isArray(chunk.choices)) continue;
       for (const rawChoice of chunk.choices) {
         if (!rawChoice || typeof rawChoice !== 'object') continue;
@@ -149,7 +162,7 @@ function sseSoftFailureState(buffer: string): SseSoftFailureState {
       // A partial or malformed data line cannot confirm this exact signature.
     }
   }
-  return { text, ended, incompatibleOutput };
+  return { text, ended, incompatibleOutput, zeroUsageKnown, zeroUsage };
 }
 
 /**
@@ -159,13 +172,20 @@ function sseSoftFailureState(buffer: string): SseSoftFailureState {
 export function sseMayContainSoftFailure(buffer: string): boolean {
   const state = sseSoftFailureState(buffer);
   if (state.incompatibleOutput) return false;
+  if (state.zeroUsageKnown && !state.zeroUsage) return false;
   return SOFT_RATE_LIMIT_MESSAGE.startsWith(state.text);
 }
 
 /** Detects the complete soft rate-limit rejection in an SSE completion. */
 export function sseSoftFailureFrame(buffer: string): SseErrorFrame | null {
   const state = sseSoftFailureState(buffer);
-  if (state.incompatibleOutput || !state.ended || state.text !== SOFT_RATE_LIMIT_MESSAGE) {
+  if (
+    state.incompatibleOutput ||
+    !state.ended ||
+    state.text !== SOFT_RATE_LIMIT_MESSAGE ||
+    !state.zeroUsageKnown ||
+    !state.zeroUsage
+  ) {
     return null;
   }
   return SOFT_RATE_LIMIT_FRAME;


### PR DESCRIPTION
## Summary

- require known zero token usage before classifying streamed assistant text as a soft rate limit
- relay the exact sentence when usage is non-zero or absent
- cover classifier, stream probe, and gateway retry behavior

## Security finding

Resolves the LOW CWE-670 finding reported on #5840. The `handler.ts` comment describes the retry consequence of the same classifier defect.

## Verification

- `pnpm --filter @kortix/llm-gateway test` — 356 passed, 0 failed
- `pnpm --filter @kortix/llm-gateway typecheck` — exit 0
- `pnpm exec biome check packages/llm-gateway/src/usage/completion-guard.ts` — clean
- `git diff --check` — exit 0