### PR TITLE
fix(web): show triggers as active when they are active

### DIFF
--- a/apps/web/src/components/projects/schedule-view.tsx
+++ b/apps/web/src/components/projects/schedule-view.tsx
@@ -71,6 +71,7 @@ import { getEnv } from '@/lib/env-config';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
+import { triggerBadgeState } from './trigger-status';
 import {
   type ProjectTrigger,
   type UpdateProjectTriggerInput,
@@ -106,6 +107,12 @@ import {
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+
+const TRIGGER_BADGE_ICONS = {
+  clock: AlarmClockSolid,
+  webhook: Webhook,
+  pause: PauseSolid,
+} as const;
 
 /* ─── Cron presets ──────────────────────────────────────────────────────── */
 
@@ -698,6 +705,8 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
                     const name = getTriggerName(trigger);
                     const subtitle = getTriggerSubtitle(trigger);
                     const lastFired = trigger.last_fired_at;
+                    const badge = triggerBadgeState(trigger.enabled, type);
+                    const BadgeIcon = TRIGGER_BADGE_ICONS[badge.icon];
 
                     return (
                       <TableRow
@@ -709,16 +718,16 @@ export function ScheduleView({ projectId, type }: { projectId: string; type: Tri
                           <div
                             className={cn(
                               'inline-flex size-8 shrink-0 items-center justify-center rounded-sm border font-semibold',
-                              !trigger.enabled
-                                ? 'bg-kortix-green/10 text-kortix-green'
-                                : 'bg-kortix-red/10 text-kortix-red',
+                              badge.className,
                             )}
+                            title={badge.label}
                           >
-                            {!trigger.enabled ? (
-                              <AlarmClockSolid className="size-5 shrink-0" />
-                            ) : (
-                              <PauseSolid className="size-6 shrink-0" />
-                            )}
+                            <BadgeIcon
+                              className={cn(
+                                'shrink-0',
+                                badge.icon === 'pause' ? 'size-6' : 'size-5',
+                              )}
+                            />
                           </div>
                         </TableCell>
                         <TableCell className="max-w-[200px]">

--- a/apps/web/src/components/projects/trigger-status.test.ts
+++ b/apps/web/src/components/projects/trigger-status.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { triggerBadgeState } from './trigger-status';
+
+const viewSource = readFileSync(
+  fileURLToPath(new URL('./schedule-view.tsx', import.meta.url)),
+  'utf8',
+);
+
+describe('triggerBadgeState', () => {
+  test('an enabled cron trigger reads as active, never paused', () => {
+    const badge = triggerBadgeState(true, 'cron');
+    expect(badge.status).toBe('active');
+    expect(badge.icon).toBe('clock');
+    expect(badge.label).toBe('Active');
+    expect(badge.className).toContain('kortix-green');
+  });
+
+  test('an enabled webhook trigger reads as active with the webhook icon', () => {
+    const badge = triggerBadgeState(true, 'webhook');
+    expect(badge.status).toBe('active');
+    expect(badge.icon).toBe('webhook');
+  });
+
+  test('a disabled trigger of either type reads as paused', () => {
+    for (const type of ['cron', 'webhook'] as const) {
+      const badge = triggerBadgeState(false, type);
+      expect(badge.status).toBe('paused');
+      expect(badge.icon).toBe('pause');
+      expect(badge.label).toBe('Paused');
+      expect(badge.className).not.toContain('kortix-green');
+    }
+  });
+
+  test('the pause icon is reserved for disabled triggers', () => {
+    const paused = [true, false]
+      .flatMap((enabled) => (['cron', 'webhook'] as const).map((t) => [enabled, t] as const))
+      .filter(([enabled, type]) => triggerBadgeState(enabled, type).icon === 'pause')
+      .map(([enabled]) => enabled);
+    expect(paused).toEqual([false, false]);
+  });
+});
+
+describe('schedule-view list badge wiring', () => {
+  test('the list row renders the badge through triggerBadgeState', () => {
+    expect(viewSource).toContain("from './trigger-status'");
+    expect(viewSource).toContain('triggerBadgeState(trigger.enabled, type)');
+  });
+
+  test('the row never branches its badge on the negated enabled flag', () => {
+    expect(viewSource).not.toContain('!trigger.enabled ?');
+  });
+});

--- a/apps/web/src/components/projects/trigger-status.ts
+++ b/apps/web/src/components/projects/trigger-status.ts
@@ -1,0 +1,30 @@
+/**
+ * Row badge state for a trigger in the schedules / webhooks list.
+ *
+ * The list badge shows what the trigger IS (active / paused), not the action
+ * you can take on it — the action lives on the detail sheet button. Getting
+ * these two backwards makes an active trigger read as a stopped one.
+ */
+export type TriggerBadgeState = {
+  status: 'active' | 'paused';
+  icon: 'clock' | 'webhook' | 'pause';
+  className: string;
+  label: string;
+};
+
+export function triggerBadgeState(enabled: boolean, type: 'cron' | 'webhook'): TriggerBadgeState {
+  if (!enabled) {
+    return {
+      status: 'paused',
+      icon: 'pause',
+      className: 'bg-muted text-muted-foreground',
+      label: 'Paused',
+    };
+  }
+  return {
+    status: 'active',
+    icon: type === 'cron' ? 'clock' : 'webhook',
+    className: 'bg-kortix-green/10 text-kortix-green',
+    label: 'Active',
+  };
+}


### PR DESCRIPTION
The schedules and webhooks lists branched their row badge on the negated enabled flag, so an **enabled** trigger rendered the red pause badge and a **paused** one rendered the green clock. Both surfaces share the list, so both read backwards. The detail sheet was always correct, since its Pause button is an action rather than a state.

## Fix

State mapping moved into a pure triggerBadgeState helper:

- Active: green badge, alarm clock for schedules, webhook glyph for webhooks (previously every row got the clock).
- Paused: muted badge, pause glyph. Paused is a deliberate state, not a failure, so it no longer borrows the error red.
- Both states carry a title attribute for hover.

## Tests

New co-located trigger-status.test.ts covers both trigger types in both states, asserts the pause glyph only ever appears for disabled triggers, and pins the wiring against the .tsx source so the inversion cannot quietly return.

6/6 pass, tsc --noEmit clean, biome reports the same 7 pre-existing errors in schedule-view.tsx as on a stashed baseline.

## Not included

When the whole project is paused via triggers_paused, rows still show Active; the banner above the table communicates that. Making rows reflect the effective state would contradict the detail sheet button, which reads only trigger.enabled. Worth unifying separately.