### PR TITLE
fix(session): stop a session with history opening on the empty new-session shell

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -23,6 +23,11 @@ import {
 import { isAutoResuming, isSandboxResumable } from '@/features/session/session-resume';
 import { canPollSessionStart } from '@/features/session/session-start-gate';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
+import {
+  resolveSessionOverlay,
+  shouldForgetNewSessionHint,
+  shouldMountSessionChat,
+} from '@/features/session/session-surface';
 import { isUnmaterializedSessionFailure } from '@/features/session/session-terminal-state';
 import { useAccountState } from '@/hooks/billing';
 import { useSandboxConnection } from '@/hooks/platform/use-sandbox-connection';
@@ -50,12 +55,12 @@ import {
 import { clearSessionFresh, isSessionFresh } from '@kortix/sdk/fresh-sessions';
 import { setActiveInstanceCookie } from '@kortix/sdk/instance-routes';
 import {
+  type UseSessionResult,
   clearRuntimeEnsureGuard,
   migrateStash,
   readStartStash,
   useRuntimeConnectionStore,
   useSession,
-  type UseSessionResult,
 } from '@kortix/sdk/react';
 
 /**
@@ -72,10 +77,40 @@ import {
  * — purely for MID-SESSION reconnect detection (the box dropping after it was
  * healthy), which drives the reconnect/offline UI. The URL stays at
  * `/projects/<id>/sessions/<sessionId>` the whole time.
+ *
+ * The route itself is deliberately thin: it reads the ids and hands them to a
+ * view KEYED by session id. See {@link ProjectSessionView} for why that key is
+ * load-bearing rather than tidy.
  */
 export default function ProjectSessionPage() {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
   const { id: projectId, sessionId } = useParams<{ id: string; sessionId: string }>();
+  if (!projectId || !sessionId) return null;
+  return (
+    <ProjectSessionView
+      key={`${projectId}/${sessionId}`}
+      projectId={projectId}
+      sessionId={sessionId}
+    />
+  );
+}
+
+/**
+ * One session's view. Every piece of per-session state below is created by React
+ * on mount, because the route above keys this component by session id.
+ *
+ * It used to be one component instance reused across session switches, resetting
+ * itself from a render-phase block: two refs mutated mid-render alongside three
+ * `setState` calls in the same pass. Client navigation is a transition, React may
+ * throw a transition render away and start over, and the two halves do not
+ * survive that equally — the ref writes persist, the queued state updates do not.
+ * When they came apart the route latched onto the previous session's brand-new
+ * shell and could not get out of it (see `session-surface.ts` for the deadlock),
+ * so clicking a session with hours of history painted the empty project-home
+ * surface until a hard reload. A key makes the whole class of desync
+ * unrepresentable: switching sessions remounts, and a remount cannot half-apply.
+ */
+function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessionId: string }) {
+  const tI18nHardcoded = useTranslations('hardcodedUi');
   const { user, isLoading: authLoading } = useAuth();
   const queryClient = useQueryClient();
   const searchParams = useSearchParams();
@@ -199,38 +234,56 @@ export default function ProjectSessionPage() {
     openUpgradeDialog(billingDialogArgs(billingState, accountState, projectAccountId));
   }, [billingBlocked, billingState, accountState, openUpgradeDialog, projectAccountId]);
 
-  // ── Crossfade: the instant shell fades out as the real chat fades in ──────
-  // A fully-interactive shell (welcome wallpaper + live input) renders at a SINGLE
-  // stable tree position for the whole pre-ready lifecycle, so it never remounts.
+  // ── Crossfade: the overlay fades out as the real chat fades in ────────────
+  // The overlay (a fully-interactive new-session shell, or the boot loader for a
+  // resume) occupies a SINGLE stable tree position for the whole pre-ready
+  // lifecycle, so nothing under it remounts as the boot advances.
   const [chatReady, setChatReady] = useState(false);
   const [loaderMounted, setLoaderMounted] = useState(true);
-  const [shellSubmitted, setShellSubmitted] = useState(false);
-  const freshRef = useRef<boolean>(false);
-  const lifecycleForRef = useRef<string | null>(null);
-  if (lifecycleForRef.current !== sessionId) {
-    lifecycleForRef.current = sessionId;
-    if (chatReady) setChatReady(false);
-    if (!loaderMounted) setLoaderMounted(true);
-    let fresh = false;
-    let pending = false;
-    if (typeof window !== 'undefined') {
-      // Was two raw legacy-key checks (`opencode_pending_prompt:<id>` /
-      // `project_pending_prompt:<id>`) — now that every producer stashes
-      // canonically under the route id (see the `migrateStash` call below),
-      // `readStartStash` is the one check that still sees a stash from any of
-      // them (canonical or legacy shape) without knowing which key it lives
-      // under.
-      pending = !!readStartStash(sessionId)?.prompt;
-      fresh = pending || isSessionFresh(sessionId);
-    }
-    freshRef.current = fresh;
-    setShellSubmitted(pending);
-    if (resumeAttempts !== 0) setResumeAttempts(0);
-  }
-  const isFresh = freshRef.current;
+  // Seeded ONCE, on mount, in a single initializer — both halves of the hand-off
+  // are read in the same pass and land in the same commit, so they cannot come
+  // apart the way the old render-phase ref/setState pair could. There is no
+  // per-session reset to hand-roll: the route keys this component by session id.
+  //
+  // `readStartStash` is one check that sees a stash from every producer
+  // (canonical `kortix:start:<id>` or either legacy shape) without knowing which
+  // key it lives under — it replaced two raw legacy-key checks
+  // (`opencode_pending_prompt:<id>` / `project_pending_prompt:<id>`).
+  const [handoff] = useState(() => {
+    if (typeof window === 'undefined') return { pending: false, newSessionHint: false };
+    const pending = !!readStartStash(sessionId)?.prompt;
+    return { pending, newSessionHint: pending || isSessionFresh(sessionId) };
+  });
+  const [submittedOnShell, setSubmittedOnShell] = useState(false);
+  // Arriving with a stashed prompt counts as submitted for the purpose of
+  // mounting the chat (the message is already committed and needs a runtime to
+  // send it), but NOT for holding the shell in place — a stash can outlive the
+  // hand-off it describes, and only a send made HERE means the user is watching
+  // their own optimistic bubble on this shell.
+  const shellSubmitted = handoff.pending || submittedOnShell;
+
+  // Transcript evidence — the veto that keeps a stale hint from stranding a real
+  // session on the empty new-session surface. It comes from `useSession`'s own
+  // sync, which paints from the local IndexedDB cache WITHOUT waiting for the
+  // sandbox, so it lands while a hibernated box is still waking and without the
+  // chat having mounted. Latched: the store only ever grows for a live session,
+  // but a transient empty read must never resurrect the shell.
+  const [sawTranscript, setSawTranscript] = useState(false);
   useEffect(() => {
-    if (chatReady) clearSessionFresh(sessionId);
-  }, [chatReady, sessionId]);
+    if (session.messages.length > 0) setSawTranscript(true);
+  }, [session.messages.length]);
+  const hasTranscript = session.messages.length > 0 || sawTranscript;
+  const surface = { newSessionHint: handoff.newSessionHint, hasTranscript };
+  const overlay = resolveSessionOverlay({ ...surface, submittedOnShell });
+
+  // Drop the local hint as soon as it has done its job OR been proven wrong.
+  // This used to wait on `chatReady`, which the hint itself could withhold — so
+  // a wrong hint kept itself alive for the whole tab.
+  useEffect(() => {
+    if (shouldForgetNewSessionHint({ chatReady, hasTranscript, submitted: shellSubmitted })) {
+      clearSessionFresh(sessionId);
+    }
+  }, [chatReady, hasTranscript, shellSubmitted, sessionId]);
 
   // Terminal/gated states fully REPLACE the content (no chat to fade to).
   const gated = !authLoading && !!user && billingBlocked;
@@ -256,6 +309,15 @@ export default function ProjectSessionPage() {
     sessionId,
     sessionContentAvailable,
   );
+  // Leaving mid-switch used to strand the target in the store: nothing cleared
+  // it, so the NEXT open of that session opened straight onto the full-screen
+  // switch loader. Compare-and-clear, so a rapid click-through never clears the
+  // newer target (see `completeSwitch`).
+  useEffect(() => {
+    return () => {
+      useSessionSwitchStore.getState().completeSwitch(sessionId);
+    };
+  }, [sessionId]);
   useEffect(() => {
     if (switchingToSessionId !== sessionId) return;
     if (sessionContentAvailable || session.startError || unmaterializedFailure || fatal || gated) {
@@ -279,9 +341,16 @@ export default function ProjectSessionPage() {
   // or wrote that cache, so every open waited out a full VM wake to show text
   // the user already had.)
   const canMountChat = sessionContentAvailable;
-  // For a fresh session, hold the real chat until the user actually sends their
-  // first message — the instant shell is the typing surface until then.
-  const mountChat = canMountChat && (!isFresh || shellSubmitted);
+  // For a genuinely new session, hold the real chat until the user actually sends
+  // their first message — the instant shell is the typing surface until then, and
+  // a second composer underneath it would fight for focus. `shouldMountSessionChat`
+  // owns the rule that makes that hold safe: transcript evidence outranks the
+  // hint, so a session with history is never held back (session-surface.ts).
+  const mountChat = shouldMountSessionChat({
+    ...surface,
+    contentAvailable: canMountChat,
+    submitted: shellSubmitted,
+  });
 
   // `sandbox_id` is nullable on the wire: the `/start` path always serves a
   // non-null id (it serializes the `session_sandboxes` uuid PK), but the
@@ -466,12 +535,12 @@ export default function ProjectSessionPage() {
               chatReady ? 'pointer-events-none opacity-0' : 'opacity-100',
             )}
           >
-            {isFresh ? (
+            {overlay === 'new-session-shell' ? (
               <InstantSessionShell
                 projectId={projectId}
                 sessionId={sessionId}
                 stage={authLoading || !user ? 'provisioning' : startStage}
-                onSubmit={() => setShellSubmitted(true)}
+                onSubmit={() => setSubmittedOnShell(true)}
               />
             ) : (
               <SessionStartingLoader
@@ -583,28 +652,36 @@ function ActiveSessionChat({
   const selectedSession = selectedOpenCodeSessionId
     ? runtimeSessions.find((session) => session.id === selectedOpenCodeSessionId)
     : null;
-  const pinRef = useRef<{ sid: string; id: string | null }>({ sid: sessionId, id: null });
-  if (pinRef.current.sid !== sessionId) pinRef.current = { sid: sessionId, id: null };
-  if (!pinRef.current.id && rootSessionId) pinRef.current.id = rootSessionId;
-  const chatSessionId = selectedSession?.id ?? pinRef.current.id ?? rootSessionId ?? null;
+  // Pin the first resolved root id so the chat keeps its identity if the live
+  // value blips back to null mid-session. State, not a ref written during
+  // render: this component is already keyed per session by the route, so there
+  // is no cross-session reset to hand-roll, and a discarded render can no longer
+  // leave a pin behind that the state it belongs to never saw.
+  const [pinnedRootSessionId, setPinnedRootSessionId] = useState<string | null>(null);
+  useEffect(() => {
+    if (!pinnedRootSessionId && rootSessionId) setPinnedRootSessionId(rootSessionId);
+  }, [pinnedRootSessionId, rootSessionId]);
+  const chatSessionId = selectedSession?.id ?? pinnedRootSessionId ?? rootSessionId ?? null;
 
-  // Migrate the home-composer prompt onto the canonical SDK start-stash DURING
-  // RENDER — every producer (project-home composer, `useConfigureThread`, the
-  // instant shell) stashes under the ROUTE session id (before the canonical
-  // OpenCode session exists); once it resolves, hand the stash off to
-  // `chatSessionId`'s stash, which `readStartStash` (SessionChat's
-  // pending-prompt effect, or `useSession`'s own replay) reads uniformly.
-  // `migrateStash` understands both the canonical shape and any producer that
-  // still writes the older bare-prompt legacy shape at the route id.
-  const promptMigratedForRef = useRef<string | null>(null);
-  if (
-    typeof window !== 'undefined' &&
-    chatSessionId &&
-    promptMigratedForRef.current !== chatSessionId
-  ) {
-    promptMigratedForRef.current = chatSessionId;
+  // Migrate the home-composer prompt onto the canonical SDK start-stash. Every
+  // producer (project-home composer, `useConfigureThread`, the instant shell)
+  // stashes under the ROUTE session id, before the canonical OpenCode session
+  // exists; once it resolves, hand the stash off to `chatSessionId`'s stash,
+  // which `readStartStash` (SessionChat's pending-prompt effect, or
+  // `useSession`'s own replay) reads uniformly. `migrateStash` understands both
+  // the canonical shape and any producer that still writes the older bare-prompt
+  // legacy shape at the route id.
+  //
+  // In an effect, not during render — SessionChat's replay retries the read
+  // across exactly this write race (`writeRaceAttempts`), so arriving a tick
+  // later costs nothing, and a render React discards can no longer move a user's
+  // prompt into a namespace the surviving state knows nothing about. This
+  // component only mounts once a fresh session's first message has been stashed
+  // (see `shouldMountSessionChat`), so mount-time is never too early.
+  useEffect(() => {
+    if (!chatSessionId) return;
     migrateStash(sessionId, chatSessionId);
-  }
+  }, [sessionId, chatSessionId]);
 
   // ── Readiness benchmarking marks ───────────────────────────────────────
   useEffect(() => {

--- a/apps/web/src/features/session/session-surface.test.ts
+++ b/apps/web/src/features/session/session-surface.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  isNewSessionSurface,
+  resolveSessionOverlay,
+  shouldForgetNewSessionHint,
+  shouldMountSessionChat,
+} from './session-surface';
+
+describe('isNewSessionSurface', () => {
+  test('a session this tab just created has no transcript and gets the shell', () => {
+    expect(isNewSessionSurface({ newSessionHint: true, hasTranscript: false })).toBe(true);
+  });
+
+  test('transcript evidence revokes a stale new-session hint', () => {
+    expect(isNewSessionSurface({ newSessionHint: true, hasTranscript: true })).toBe(false);
+  });
+
+  test('a resumed session is never the new-session surface', () => {
+    expect(isNewSessionSurface({ newSessionHint: false, hasTranscript: false })).toBe(false);
+    expect(isNewSessionSurface({ newSessionHint: false, hasTranscript: true })).toBe(false);
+  });
+});
+
+describe('shouldMountSessionChat', () => {
+  test('a brand-new session holds the chat until the first message is sent', () => {
+    const shell = {
+      newSessionHint: true,
+      hasTranscript: false,
+      contentAvailable: true,
+      submitted: false,
+    };
+    expect(shouldMountSessionChat(shell)).toBe(false);
+    expect(shouldMountSessionChat({ ...shell, submitted: true })).toBe(true);
+  });
+
+  test('THE REGRESSION: a stuck new-session hint cannot withhold an existing transcript', () => {
+    // The production failure. A hint left over from another session (an
+    // in-memory fresh-mark, or a start-stash that was never consumed) said
+    // "brand new" about a session with hours of history. The chat was then
+    // never mounted, so it could never report ready, so the hint was never
+    // cleared: the session painted the empty project-home surface until a hard
+    // reload. Transcript evidence has to beat the hint, unconditionally.
+    expect(
+      shouldMountSessionChat({
+        newSessionHint: true,
+        hasTranscript: true,
+        contentAvailable: true,
+        submitted: false,
+      }),
+    ).toBe(true);
+  });
+
+  test('no deadlock exists: mounting never depends on a signal the chat produces', () => {
+    // Enumerate every hint/submitted combination a session WITH history can be
+    // in. If any of them withholds the chat, the surface can strand again —
+    // because `chatReady` (and everything downstream of it) is produced by the
+    // very chat being withheld.
+    const withheld = [true, false].flatMap((newSessionHint) =>
+      [true, false]
+        .map((submitted) => ({
+          newSessionHint,
+          submitted,
+          hasTranscript: true,
+          contentAvailable: true,
+        }))
+        .filter((input) => !shouldMountSessionChat(input)),
+    );
+    expect(withheld).toEqual([]);
+  });
+
+  test('without a transcript pin there is nothing to mount on', () => {
+    expect(
+      shouldMountSessionChat({
+        newSessionHint: false,
+        hasTranscript: true,
+        contentAvailable: false,
+        submitted: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('resolveSessionOverlay', () => {
+  test('a resuming session boots under the loader, never the empty home surface', () => {
+    expect(
+      resolveSessionOverlay({
+        newSessionHint: false,
+        hasTranscript: false,
+        submittedOnShell: false,
+      }),
+    ).toBe('boot-loader');
+  });
+
+  test('a session with history never shows the new-session shell', () => {
+    expect(
+      resolveSessionOverlay({ newSessionHint: true, hasTranscript: true, submittedOnShell: false }),
+    ).toBe('boot-loader');
+  });
+
+  test('a genuinely new session gets the typeable shell', () => {
+    expect(
+      resolveSessionOverlay({
+        newSessionHint: true,
+        hasTranscript: false,
+        submittedOnShell: false,
+      }),
+    ).toBe('new-session-shell');
+  });
+
+  test('the shell keeps the floor once the user has sent from it', () => {
+    // Their first message lands in the transcript store before the chat has
+    // crossfaded in. Without this the overlay would swap the optimistic bubble
+    // they are looking at for a boot spinner, mid-send.
+    expect(
+      resolveSessionOverlay({ newSessionHint: true, hasTranscript: true, submittedOnShell: true }),
+    ).toBe('new-session-shell');
+  });
+});
+
+describe('shouldForgetNewSessionHint', () => {
+  test('a wrong hint is dropped by transcript evidence, not by the chat it blocks', () => {
+    expect(
+      shouldForgetNewSessionHint({ chatReady: false, hasTranscript: true, submitted: false }),
+    ).toBe(true);
+  });
+
+  test('kept only while the session still looks new and untouched', () => {
+    expect(
+      shouldForgetNewSessionHint({ chatReady: false, hasTranscript: false, submitted: false }),
+    ).toBe(false);
+  });
+
+  test('dropped once the chat paints or the user sends', () => {
+    expect(
+      shouldForgetNewSessionHint({ chatReady: true, hasTranscript: false, submitted: false }),
+    ).toBe(true);
+    expect(
+      shouldForgetNewSessionHint({ chatReady: false, hasTranscript: false, submitted: true }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/features/session/session-surface.ts
+++ b/apps/web/src/features/session/session-surface.ts
@@ -1,0 +1,111 @@
+/**
+ * What the session route paints, as one pure decision.
+ *
+ * The route used to decide this inline, from a pair of refs mutated DURING
+ * RENDER (`lifecycleForRef` / `freshRef`) next to `setState` calls made in that
+ * same render pass. Those two halves are not equally durable. Every client-side
+ * navigation runs inside a transition, and React is free to throw a transition
+ * render away and start over — a ref write survives that, a queued state update
+ * does not. So the halves could disagree: `freshRef` saying "brand-new session"
+ * while `shellSubmitted` was still false. And that pair DEADLOCKED —
+ *
+ *   the new-session shell suppressed mounting the chat
+ *     → the chat was the only thing that could report readiness
+ *       → readiness was the only thing that dismissed the shell
+ *
+ * — so an existing session with a full transcript painted the empty "give this
+ * project something to work on" surface, and stayed there until a hard reload.
+ * That is the bug this module exists to make unrepresentable. Two rules:
+ *
+ *  1. The new-session surface is DERIVED, never latched. Any evidence that this
+ *     session already has a transcript revokes it, immediately.
+ *  2. Nothing about that surface can permanently withhold the chat. The only
+ *     thing gating the chat is whether there is a transcript pin to mount it on.
+ *
+ * The route feeds these from state it seeds once per session (it is keyed by
+ * session id, so a switch remounts it) plus live data, and never from a ref it
+ * edits mid-render.
+ */
+
+export interface SessionSurfaceInput {
+  /**
+   * This tab created this session, or arrived carrying its first prompt — i.e.
+   * the local, optimistic "this is brand new" hint. Deliberately a hint: it
+   * comes from in-memory/session-storage state that outlives the thing it
+   * describes, so it is never trusted on its own.
+   */
+  newSessionHint: boolean;
+  /** Any transcript content is known for this session (live runtime OR cache). */
+  hasTranscript: boolean;
+}
+
+/**
+ * Is this the brand-new-session surface (the instant shell) rather than a
+ * session being resumed?
+ *
+ * `hasTranscript` is the veto, and it is the whole point: a stale hint can now
+ * only ever cost a beat of the wrong overlay, never a dead end. The transcript
+ * reaches the route from `useSession`'s own sync — which paints from the local
+ * IndexedDB cache without waiting on a sandbox — so the veto lands even while
+ * the box is still booting, and does not depend on the chat having mounted.
+ */
+export function isNewSessionSurface(input: SessionSurfaceInput): boolean {
+  return input.newSessionHint && !input.hasTranscript;
+}
+
+export interface MountSessionChatInput extends SessionSurfaceInput {
+  /** A transcript pin is known, so the chat has something to mount on. */
+  contentAvailable: boolean;
+  /** The user committed a first message on the instant shell. */
+  submitted: boolean;
+}
+
+/**
+ * May the real chat mount?
+ *
+ * A brand-new session holds it back until the user actually sends something —
+ * the instant shell is the typing surface until then, and mounting a second
+ * composer underneath it would fight for focus. That hold is safe ONLY because
+ * {@link isNewSessionSurface} is revoked by transcript evidence: a session with
+ * history is never "brand new", so it can never be held back.
+ */
+export function shouldMountSessionChat(input: MountSessionChatInput): boolean {
+  if (!input.contentAvailable) return false;
+  return !isNewSessionSurface(input) || input.submitted;
+}
+
+/** The pre-chat overlay: the typeable new-session shell, or the boot loader. */
+export type SessionOverlay = 'new-session-shell' | 'boot-loader';
+
+/**
+ * Which overlay covers the chat while it cannot paint yet. The caller decides
+ * WHETHER an overlay is up (it fades out on `chatReady`); this decides WHICH.
+ *
+ * `submittedOnShell` holds the shell in place once the user has typed into it:
+ * their message is rendering there optimistically, and the moment it reaches the
+ * transcript store `hasTranscript` would otherwise swap their own words out for
+ * a boot spinner a beat before the chat crossfades in.
+ */
+export function resolveSessionOverlay(
+  input: SessionSurfaceInput & { submittedOnShell: boolean },
+): SessionOverlay {
+  if (input.submittedOnShell) return 'new-session-shell';
+  return isNewSessionSurface(input) ? 'new-session-shell' : 'boot-loader';
+}
+
+/**
+ * Should the local "brand new session" hint be forgotten?
+ *
+ * The hint used to be dropped only once the chat reported ready — which never
+ * happened on exactly the sessions where the hint was wrong, so a wrong hint was
+ * self-preserving. Any of these means the hint has done its job (or was wrong):
+ * the chat painted, the session turned out to have history, or the user sent
+ * their first message.
+ */
+export function shouldForgetNewSessionHint(input: {
+  chatReady: boolean;
+  hasTranscript: boolean;
+  submitted: boolean;
+}): boolean {
+  return input.chatReady || input.hasTranscript || input.submitted;
+}

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -132,6 +132,11 @@ export function useNewProjectSession(
             projectId,
             buildWarmSessionClaimInput(selectedWarmSession, opts?.create),
           );
+          // A claimed warm session is every bit as new to the user as a minted
+          // one — mark it, so the session page opens the instant typeable shell
+          // on the strength of THIS signal rather than inferring newness from a
+          // stashed prompt (which outlives the hand-off it describes).
+          markSessionFresh(claimed.session_id);
           return claimed.session_id;
         } catch (error) {
           if (shouldFallbackFromWarmClaim(error)) {


### PR DESCRIPTION
Clicking a session in the sidebar could paint the brand-new-session surface — the project-home welcome heading and hero composer — over a session with hours of transcript, and leave it there. Not a flash: it stayed until a hard reload, so the session read as broken and its history as gone. Reported on prod; it reproduced most often coming from the project home, and never on a refresh.

That surface is `InstantSessionShell`, so the route believed an existing session had just been created. Two faults, both in the session page.

**1. Render-phase ref writes next to render-phase `setState`.** The page was ONE component instance reused across session switches, resetting itself in a mid-render block: two refs mutated during render (`lifecycleForRef`, `freshRef`) alongside three `setState` calls in the same pass. Client navigation runs inside a transition, and React may throw a transition render away and start over — **a ref write survives that, a queued state update does not**. So `freshRef` could latch "brand new" while the `setShellSubmitted` beside it was lost, with `lifecycleForRef` already advanced so the block never ran again to correct itself. A hard reload mounts fresh and cannot half-apply, which is exactly why it was the only way out.

**2. The resulting state was a deadlock, not a wrong frame.**

```
mountChat = canMountChat && (!isFresh || shellSubmitted)
  → no chat mounts → nothing produces chatReady
  → chatReady was the only thing that dismissed the shell
    AND the only caller of clearSessionFresh
```

A wrong "fresh" hint kept itself alive for the whole tab.

## The fix

Structural, not a guard on the symptom:

- The route is thin and renders `<ProjectSessionView key={projectId/sessionId}>`. Per-session state now comes from `useState` initializers on mount; the hand-rolled reset block, both refs, and the whole desync class are gone — a remount cannot half-apply.
- The decision moved into a pure, tested `features/session/session-surface.ts` holding two invariants: **transcript evidence vetoes the local new-session hint**, and **nothing about the overlay can withhold the chat**. The veto reads `session.messages` at page level, which paints from the IndexedDB cache without waiting for a sandbox (#5837) — so it lands while a hibernated box is still waking, and without the chat having mounted.
- The hint is forgotten on transcript/submit/ready instead of only on `chatReady`, which the hint itself could withhold.
- `migrateStash` and the chat's root-id pin moved out of the render phase into effects. A discarded render can no longer move a user's prompt into a namespace the surviving state knows nothing about; `SessionChat`'s replay already retries the read across that write race.
- Leaving mid-switch no longer strands `targetSessionId` in the switch store — a stranded target opened the *next* visit to that session straight onto the full-screen switch loader.
- `useNewProjectSession` marks a **claimed warm session** fresh. Only the minted path did, so the warm path inferred newness from a leftover start-stash — a signal that outlives the hand-off it describes, and one of the ways a stale hint reached an old session in the first place.

## Tests

`session-surface.test.ts` covers the invariants, including an enumeration asserting no hint/submitted combination can withhold the chat from a session with history. The regression test **fails against the shipped predicate** (verified by running it against the old expression verbatim) and passes here.

- `bun test src/features/session src/hooks/projects src/stores` → 782 pass, 0 fail
- `tsc --noEmit` → no errors in any changed file

Not covered by automated tests: the discarded-transition-render mechanism itself isn't reproducible in a unit test, so the proof there is structural — no render-phase mutation remains on this path.
