### PR TITLE
test(api): stop partial module mocks from killing whole test files

### DIFF
--- a/apps/api/src/__tests__/billing/mocks.ts
+++ b/apps/api/src/__tests__/billing/mocks.ts
@@ -156,6 +156,9 @@ export function registerGlobalMocks() {
   // default here is simply "no active sandboxes" — a harmless no-op for every
   // existing test, and enough for stopAccountSandboxes' static imports to
   // resolve without needing a real DB/provider.
+  // A module mock REPLACES the whole module, so every export the code under
+  // test imports has to appear here — a missing one is not a silent undefined,
+  // it is a hard `SyntaxError: Export named 'x' not found` that kills the file.
   mock.module('../../shared/db', () => ({
     db: {
       select: () => ({
@@ -164,12 +167,20 @@ export function registerGlobalMocks() {
         }),
       }),
     },
+    // Real shape is a boolean const, not a function. FALSE on purpose: these
+    // billing tests drive the no-DB path, and the stub `db` above answers only
+    // `select().from().where()`. Flipping this to true sends the code down real
+    // persistence branches this mock cannot serve (8 createCheckoutSession
+    // tests fail with "Stripe API error" — verified).
+    hasDatabase: false,
   }));
 
   mock.module('../../platform/providers', () => ({
     getProvider: (_name: string) => ({
       stop: async (_externalId: string) => undefined,
     }),
+    // Real contract: no args, always a number >= 60.
+    providerAutoStopBackstopMinutes: () => 60,
   }));
 
   mock.module('../../projects/sandbox-reaper', () => ({

--- a/apps/api/src/__tests__/e2e-project-limit.test.ts
+++ b/apps/api/src/__tests__/e2e-project-limit.test.ts
@@ -67,7 +67,9 @@ const stubBackend = {
   seedFiles: async () => { backendCalls.push('seedFiles'); },
 };
 
+const actualGitBackends = await import('../projects/git-backends');
 mock.module('../projects/git-backends', () => ({
+  ...actualGitBackends,
   hasBackend: (provider: string) => provider === 'github',
   getBackend: () => stubBackend,
   getDefaultManagedBackend: () => stubBackend,
@@ -109,7 +111,9 @@ mock.module('../middleware/auth', () => ({
 mockIamEngineAllowAll();
 mockIamMembershipSyncNoop();
 
+const actualGit = await import('../projects/git');
 mock.module('../projects/git', () => ({
+  ...actualGit,
   grepRepoFiles: async () => [],
   searchRepoFileNames: async () => [],
   createRemoteSessionBranch: async () => undefined,

--- a/apps/api/src/__tests__/e2e-project-maintenance.test.ts
+++ b/apps/api/src/__tests__/e2e-project-maintenance.test.ts
@@ -50,7 +50,9 @@ mock.module('../shared/db', () => ({
   },
 }));
 
+const actualProviders = await import('../platform/providers');
 mock.module('../platform/providers', () => ({
+  ...actualProviders,
   WarmRuntimeUnavailableError: class WarmRuntimeUnavailableError extends Error {
     constructor(message: string) {
       super(message);
@@ -108,7 +110,14 @@ mock.module('../projects/session-lifecycle/undelivered-prompts', () => ({
   reconcileUndeliveredPrompts: async () => ({ claimed: 0, succeeded: 0, failed: 0, queued: 0 }),
 }));
 
+// Spread the real module rather than hand-listing its surface: a mock REPLACES
+// the module, so every export the code under test imports must exist here, and
+// hand-maintained lists rot into `SyntaxError: Export named 'x' not found` the
+// moment the module grows one. Neither of these modules connects to anything at
+// import time, so pulling the real one in stays hermetic.
+const actualReaper = await import('../projects/sandbox-reaper');
 mock.module('../projects/sandbox-reaper', () => ({
+  ...actualReaper,
   reapAndReconcileSandboxes: async () => ({
     candidates: 0,
     stopped: 0,

--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -112,7 +112,9 @@ mock.module('../middleware/auth', () => ({
   },
 }));
 
+const actualGit = await import('../projects/git');
 mock.module('../projects/git', () => ({
+  ...actualGit,
   grepRepoFiles: async () => [],
   searchRepoFileNames: async () => [],
   createRemoteSessionBranch: async () => {

--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -158,7 +158,9 @@ mock.module('../middleware/auth', () => ({
   },
 }));
 
+const actualGit = await import('../projects/git');
 mock.module('../projects/git', () => ({
+  ...actualGit,
   grepRepoFiles: async () => [],
   searchRepoFileNames: async () => [],
   createRemoteSessionBranch: async () => undefined,
@@ -245,7 +247,9 @@ mock.module("../snapshots/builder", () => ({
   DEFAULT_SANDBOX_SLUG: "default",
 }));
 
+const actualGithub = await import('../projects/github');
 mock.module('../projects/github', () => ({
+  ...actualGithub,
   parseGitHubRepoUrl: () => null,
   isOrgAccount: async () => false,
   buildGitHubAppInstallUrl: () => 'https://github.com/apps/kortix-test/installations/new',

--- a/apps/api/src/__tests__/unit-auto-claim-invites.test.ts
+++ b/apps/api/src/__tests__/unit-auto-claim-invites.test.ts
@@ -55,7 +55,9 @@ const fakeDb = {
   }),
 };
 
+const actualDrizzle = await import('drizzle-orm');
 mock.module('drizzle-orm', () => ({
+  ...actualDrizzle,
   and: (...parts: unknown[]) => ({ op: 'and', parts }),
   eq: (column: unknown, value: unknown) => ({ op: 'eq', column, value }),
   gt: (column: unknown, value: unknown) => ({ op: 'gt', column, value }),

--- a/apps/api/src/__tests__/unit-billing-cron-auth.test.ts
+++ b/apps/api/src/__tests__/unit-billing-cron-auth.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, mock, test } from 'bun:test';
 
+const actualConfig = await import('../config');
 mock.module('../config', () => ({
+  ...actualConfig,
   config: {
     KORTIX_BILLING_INTERNAL_ENABLED: false,
     INTERNAL_SERVICE_KEY: 'internal-test-key',

--- a/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
+++ b/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
@@ -16,7 +16,9 @@ let allowedAccounts = new Set<string>(['acct-owner']);
 let allowedUsers = new Set<string>(['user-owner', 'sa-owner', 'pat-user-owner', 'user-fallback-owner']);
 let mockSupabaseUser: { id: string } | null = null;
 
+const actualCrypto = await import('../shared/crypto');
 mock.module('../shared/crypto', () => ({
+  ...actualCrypto,
   isAccountToken: (t: string) => t.startsWith('kortix_pat_'),
   isServiceAccountToken: (t: string) => t.startsWith('kortix_sa_'),
   isKortixToken: (t: string) => t.startsWith('kortix_'),

--- a/apps/api/src/__tests__/unit-slack-interactivity-selection.test.ts
+++ b/apps/api/src/__tests__/unit-slack-interactivity-selection.test.ts
@@ -13,7 +13,9 @@ function makeChain(): any {
 mock.module('../shared/db', () => ({ db: { select: () => makeChain() }, hasDatabase: () => true }));
 
 // Stub the dispatch graph so importing interactivity stays light.
+const actualDispatch = await import('../channels/slack/dispatch');
 mock.module('../channels/slack/dispatch', () => ({
+  ...actualDispatch,
   dispatchSlackEvent: async () => {},
   pendingPickers: new Map(),
   spawnAgentTurn: async () => {},

--- a/apps/api/src/__tests__/unit-slack-questions.test.ts
+++ b/apps/api/src/__tests__/unit-slack-questions.test.ts
@@ -15,7 +15,9 @@ const record = (fn: string) => (...args: unknown[]) => {
 
 let postBlocksResult: string | null = '99.99';
 let postMessageResult: string | null = '88.88';
+const actualSlackApi = await import('../channels/slack-api');
 mock.module('../channels/slack-api', () => ({
+  ...actualSlackApi,
   openDmChannel: async () => null,
   postEphemeral: async (...a: unknown[]) => record('postEphemeral')(...a),
   postBlocks: async (...a: unknown[]) => {
@@ -31,7 +33,9 @@ mock.module('../channels/slack-api', () => ({
 
 // ─── turn.ts (consumed by questions.ts) ───────────────────────────────────────
 let activeTurn: Record<string, unknown> | null = null;
+const actualTurn = await import('../channels/slack/turn');
 mock.module('../channels/slack/turn', () => ({
+  ...actualTurn,
   loadTurn: async () => activeTurn,
   finalizeTurn: async (...a: unknown[]) => record('finalizeTurn')(...a),
   deleteTurn: async (...a: unknown[]) => record('deleteTurn')(...a),
@@ -39,7 +43,9 @@ mock.module('../channels/slack/turn', () => ({
 
 // ─── dispatch.ts (consumed by interactivity.ts) ───────────────────────────────
 let spawnArgs: unknown[] | null = null;
+const actualDispatch = await import('../channels/slack/dispatch');
 mock.module('../channels/slack/dispatch', () => ({
+  ...actualDispatch,
   spawnAgentTurn: async (...a: unknown[]) => {
     spawnArgs = a;
   },

--- a/apps/api/src/llm-gateway/internal-routes.test.ts
+++ b/apps/api/src/llm-gateway/internal-routes.test.ts
@@ -12,11 +12,15 @@ mock.module('../lib/logger', () => ({
     debug: mock(() => {}),
   },
 }));
+const actualBillingGate = await import('../billing/services/billing-gate');
 mock.module('../billing/services/billing-gate', () => ({
+  ...actualBillingGate,
   assertBillingActive: async () => undefined,
 }));
 mock.module('./budgets', () => ({ checkBudget: async () => ({ exceeded: false }) }));
+const actualHooks = await import('./hooks');
 mock.module('./hooks', () => ({
+  ...actualHooks,
   authenticatePrincipal: async () => null,
   authorizeRequest: async () => ({ ok: true }),
   persistGatewayTrace: async () => {},

--- a/apps/api/src/projects/session-lifecycle/__tests__/continue-session-deleted-guard.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/continue-session-deleted-guard.test.ts
@@ -76,7 +76,9 @@ mock.module('../actor', () => ({
 mock.module('../backpressure', () => ({
   sessionBackpressureState: async () => ({ shouldQueue: false, reason: null }),
 }));
+const actualStore = await import('../store');
 mock.module('../store', () => ({
+  ...actualStore,
   claimCreateSessionCommand: async () => {
     throw new Error('not expected in this test');
   },

--- a/apps/api/src/snapshots/providers/local-docker.test.ts
+++ b/apps/api/src/snapshots/providers/local-docker.test.ts
@@ -11,7 +11,9 @@ process.env.LOCAL_DOCKER_NETWORK = 'kortix-local-docker-test';
 
 let stagedContexts: Array<{ snapshotName: string; userDockerfile: string }> = [];
 
+const actualBuildContext = await import('../build-context');
 mock.module('../build-context', () => ({
+  ...actualBuildContext,
   DEFAULT_CPU: 2,
   DEFAULT_MEMORY_GB: 6,
   DEFAULT_DISK_GB: 20,


### PR DESCRIPTION
test(api): stop partial module mocks from killing whole test files

17 test files in the kortix-api suite were not running at all. Each died at
import with

  SyntaxError: Export named 'x' not found in module '.../y.ts'

and the export always existed. `mock.module()` REPLACES a module, so the mock
factory has to return every export the code under test imports. These mocks
hand-listed a subset, which is fine on the day it is written and rots the
moment the real module grows an export — then the file stops running, silently.

Silently is the important part: a file that dies before its first test simply
vanishes from the count. #5838 turned this suite on for pull requests and the
job went red; underneath the visible failures, ~195 tests had not executed in
a long time.

Fixed by spreading the real module into the mock and overriding only what the
test actually needs, so the mock tracks the module surface automatically:

  const actualGit = await import('../projects/git');
  mock.module('../projects/git', () => ({ ...actualGit, readRepoFile: fake }));

None of these modules connect to anything at import time, so the suite stays
hermetic (it runs off scripts/test.env with no secrets). Where a spread was
not appropriate — the shared billing mock registry — the two missing exports
are restated explicitly with their real shapes: `hasDatabase` is a boolean
const, not a function, and `providerAutoStopBackstopMinutes` takes no args and
returns a number >= 60.

Effect on `pnpm --filter kortix-api test`:

                     before      after
  tests executing      4504       4699   (+195)
  passing              4397       4600
  failing                50         42
  load errors            17          0

No assertion is changed, no test is skipped or removed — the diff only adds
mock plumbing.

`hasDatabase` is deliberately `false`: these billing tests drive the no-DB
path and the stub `db` answers only `select().from().where()`. Setting it true
sends the code down real persistence branches the mock cannot serve, which
fails 8 createCheckoutSession tests with "Stripe API error" — verified both
ways before choosing.

This does NOT turn the gate green. 42 assertion failures remain — the same
ones as before plus the ones these newly-running files surface — concentrated
in Slack commands, project triggers, billing subscriptions, and the session
contract. They need per-subsystem judgment about whether the code or the
expectation is wrong, and are being triaged separately rather than edited
until they pass.
