### PR TITLE
test(api): retarget slash-command + manifest tests at the shipped design

### DIFF
--- a/apps/api/src/__tests__/unit-slack-commands.test.ts
+++ b/apps/api/src/__tests__/unit-slack-commands.test.ts
@@ -36,6 +36,46 @@ mock.module('../channels/slack/selection', () => ({
   setChannelConversationPolicy: async () => undefined,
 }));
 
+// Model decisions no longer read a hardcoded RECOMMENDED_MODELS list off the
+// selection module. They resolve the channel's project/account through
+// `model-gate`, then list the REAL served catalog (managed + connected BYOK)
+// through the picker, so a pick can never 404. Mock that graph — mocking only
+// `selection` leaves `channelModelContext` unmocked, it returns null against no
+// DB, and every model command answers "connect a project first" instead of
+// exercising what these tests are about.
+let modelGate: unknown = {
+  projectId: 'p1',
+  accountId: 'a1',
+  ownerUserId: 'u1',
+  freeManagedOnly: false,
+};
+mock.module('../channels/slack/model-gate', () => ({
+  // The gate follows the binding: an unbound channel has no project.
+  channelModelContext: async () => (selection ? modelGate : null),
+}));
+let servable = true;
+mock.module('../llm-gateway/resolution/default-model', () => ({
+  isModelServableForAccount: async () => servable,
+  resolveEffectiveModel: async () => ({ model: 'anthropic/claude-opus-4-8', source: 'project' }),
+}));
+mock.module('../llm-gateway/models/picker', () => ({
+  listPickerModels: async () => ({
+    models: [
+      {
+        id: 'anthropic/claude-opus-4-8',
+        label: 'Claude Opus 4.8',
+        provider: 'anthropic',
+        managed: false,
+        hint: 'Most capable',
+      },
+      { id: 'kortix/glm-5.2', label: 'GLM 5.2', provider: 'kortix', managed: true, hint: null },
+    ],
+    projectDefault: { model: 'kortix/glm-5.2', source: 'project', label: 'GLM 5.2' },
+  }),
+  labelForModelRef: (id: string) =>
+    id === 'anthropic/claude-opus-4-8' ? 'Claude Opus 4.8' : id,
+}));
+
 // Identity layer — kept out of the db chain so it doesn't disturb dbResults
 // ordering. Controllable per-test via `identityRow`.
 let identityRow: { userId: string } | null = null;
@@ -76,15 +116,20 @@ beforeEach(() => {
   setModelResult = true;
   setAgentCalls.length = 0;
   setModelCalls.length = 0;
+  servable = true;
 });
 
 describe('help', () => {
-  test('lists the new agents / models / session commands', async () => {
+  // Discovery moved into the one `/kortix` panel; help now documents the
+  // typed shortcuts that survived it. Asserting the retired `agents`/`models`
+  // list here just pinned the old design.
+  test('points at the panel and lists the typed shortcuts', async () => {
     const resp = await handleSlashCommand('help', '', ctx);
     const txt = allText(resp);
-    expect(txt).toContain('agents');
-    expect(txt).toContain('models');
-    expect(txt).toContain('session');
+    expect(txt).toContain('control panel');
+    for (const shortcut of ['model <id>', 'agent <name>', 'switch', 'policy', 'sessions']) {
+      expect(txt).toContain(shortcut);
+    }
   });
 });
 
@@ -130,16 +175,25 @@ describe('/kortix models', () => {
     // current model is marked
     expect(allText(resp)).toContain('✓ ');
   });
-  test('unbound channel → prompts to switch', async () => {
+  test('unbound channel → prompts to connect one', async () => {
     selection = null;
     const resp = await handleSlashCommand('models', '', ctx);
-    expect(allText(resp)).toContain('No project bound');
+    expect(allText(resp)).toContain('No project is connected to this channel yet');
   });
 });
 
 describe('/kortix model <id>', () => {
-  test('rejects a malformed id without writing', async () => {
+  // Shape is no longer the gate — servability is, so an id that cannot be
+  // served is refused whatever it looks like. The property under test is
+  // unchanged and is the one that matters: nothing unusable is ever stored.
+  test('refuses an unservable id without writing', async () => {
+    servable = false;
     const resp = await handleSlashCommand('model', 'not-a-model', ctx);
+    expect(resp.text).toContain("isn't available for this workspace");
+    expect(setModelCalls.length).toBe(0);
+  });
+  test('still refuses an id with whitespace on shape alone', async () => {
+    const resp = await handleSlashCommand('model', 'not a model', ctx);
     expect(resp.text).toContain("doesn't look like a model id");
     expect(setModelCalls.length).toBe(0);
   });
@@ -153,10 +207,10 @@ describe('/kortix model <id>', () => {
     expect(setModelCalls).toEqual([null]);
     expect(resp.text).toContain('reset');
   });
-  test('unbound channel → prompts to switch, no write', async () => {
+  test('unbound channel → prompts to connect one, no write', async () => {
     selection = null;
     const resp = await handleSlashCommand('model', 'anthropic/claude-opus-4-8', ctx);
-    expect(resp.text).toContain('Bind a project first');
+    expect(resp.text).toContain('Connect a project first');
     expect(setModelCalls.length).toBe(0);
   });
 });

--- a/apps/api/src/__tests__/unit-trigger-dsl.test.ts
+++ b/apps/api/src/__tests__/unit-trigger-dsl.test.ts
@@ -51,8 +51,12 @@ describe('kortix manifest — schema versioning', () => {
     expect(parsed.schemaVersion).toBe(2);
   });
 
-  test('a version above the v2 ceiling is still rejected', () => {
-    expect(() => parseManifestString(`kortix_version = 3\n${MIN_PROJECT}`)).toThrow(/Unsupported kortix\.toml schema version 3/);
+  // The ceiling is KNOWN_SCHEMA_VERSION in packages/manifest-schema — now 3, so
+  // v3 parses. What must stay true is that anything ABOVE the ceiling is refused
+  // rather than silently half-understood, so this pins v3-ok / v4-rejected.
+  test('the current ceiling parses and anything above it is still rejected', () => {
+    expect(parseManifestString(`kortix_version = 3\n${MIN_PROJECT}`).schemaVersion).toBe(3);
+    expect(() => parseManifestString(`kortix_version = 4\n${MIN_PROJECT}`)).toThrow(/schema version 4/);
   });
 
   test('serialize always emits kortix_version as the first key', () => {

--- a/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
+++ b/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
@@ -7,7 +7,16 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 process.env.SLACK_REQUIRE_USER_IDENTITY = 'false';
 
 mock.module('../../../config', () => ({
-  config: { FRONTEND_URL: 'https://app.test', SLACK_REQUIRE_USER_IDENTITY: false },
+  // KORTIX_MANAGED_PROVIDER_ENABLED must be on: RUNTIME_MANAGED_MODELS is empty
+  // without it, so `isRuntimeManagedModelId('glm-5.2')` is false and
+  // `toOpencodeModelRef` skips the `kortix/` prefix — which silently defeats the
+  // canonicalization this file exists to pin. (scripts/test.env sets it, but a
+  // config mock replaces the module, so it has to be restated here.)
+  config: {
+    FRONTEND_URL: 'https://app.test',
+    SLACK_REQUIRE_USER_IDENTITY: false,
+    KORTIX_MANAGED_PROVIDER_ENABLED: true,
+  },
 }));
 
 // FIFO db mock — slashPanel reads one project row.


### PR DESCRIPTION
test(api): retarget slash-command + manifest tests at the shipped design

Ten failures where the code moved and the test kept asserting the old design.
Each is retargeted at what the feature guarantees TODAY; none is weakened, and
where an assertion was carrying a property worth keeping, that property is kept
(and in one case split into its own test).

unit-slack-commands (8)
  Model commands stopped reading a hardcoded RECOMMENDED_MODELS list off
  `selection` and now resolve project/account via `model-gate` and list the
  REAL served catalog via `listPickerModels` — so a pick can never 404. The
  test still mocked only `selection`, which left `channelModelContext`
  unmocked; against no DB it returns null and every model command answered
  "connect a project first", so eight tests were asserting against a
  code path that no longer ran. Mocks now cover the real graph.

  Copy that moved with it: an unbound channel says "No project is connected
  to this channel yet" / "Connect a project first", not "No project bound" /
  "Bind a project first". `help` no longer lists `agents`/`models` — discovery
  lives in the one `/kortix` panel — so it now asserts the panel pointer plus
  the typed shortcuts that survived.

  `rejects a malformed id` was pinning shape validation that has been replaced
  by a servability gate (strictly stronger: it refuses anything that would 404,
  whatever it looks like). Kept as "refuses an unservable id without writing" —
  the real property was always "nothing unusable is stored", and that is
  unchanged — and ADDED a case for the whitespace-shape rejection that still
  exists, so no coverage is lost in the swap.

commands-panel (1)
  The file's own `config` mock omitted KORTIX_MANAGED_PROVIDER_ENABLED.
  RUNTIME_MANAGED_MODELS is empty without it, so isRuntimeManagedModelId
  ('glm-5.2') was false and toOpencodeModelRef skipped the `kortix/` prefix —
  the mock silently defeated the canonicalization this file exists to pin.
  scripts/test.env sets the flag, but a config mock replaces the module.

unit-trigger-dsl (1)
  KNOWN_SCHEMA_VERSION is 3, so "a version above the v2 ceiling is rejected"
  pinned a ceiling that no longer exists. Now pins the invariant that actually
  matters at whatever the ceiling is: v3 parses, v4 is refused rather than
  silently half-understood.

Suite on this base (main @ d6413c2f8, loader fixes already in): 4611 pass /
32 fail, down from 43. Measured 42 -> 31 before rebasing; main gained one
failure in between, so the delta this PR is responsible for is 11.

Cumulative with #5863, against where main started: 4397 pass / 50 fail /
17 load errors  ->  4611 pass / 32 fail / 0 load errors.

Deliberately NOT touched — these need their subsystem's judgment, not an
edited expectation:
  - unit-oauth-consent: authorize answers 400 where 302 is expected, at the
    first step. Probably a newly-required parameter, but "is the auth flow
    hardened or broken" is not a question to settle by editing the test.
  - unit-hosted-deployment-vendor-removal: the retired-vendor guard is finding
    live capability copy ("deploys them as live apps", "deployed sites") in
    packages/starter templates/managed and embedded.generated.json. If app
    deployment really is retired, agents are advertising a capability they do
    not have and the copy should go — that is a product call, and silencing
    the guard would bury exactly what it was written to catch.
  - unit-stripe-webhook-canonicalization, unit-platinum-snapshot-size,
    unit-dockerfile-layer, unit-project-config-agents, unit-sentry-noise-filter,
    unit-opencode-session-snapshot, unit-slack-install-store, e2e-billing-routes.
  - 13 in e2e-* files that need real infrastructure (ECONNREFUSED, "Daytona
    provider requires DAYTONA_API_KEY"). scripts/test.sh sweeps `e2e-*` into a
    gate that deliberately holds no credentials; excluding them the way
    `integration-*` already is looks right, but that is #5838's call.
