### PR TITLE
docs: fix project home reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,7 +397,7 @@ gate, not polish:
   dense-but-legible UI, black/white plus one earned accent, token-driven spacing,
   and no decorative color, glow, or one-off rounded boxes.
 - Use recent product surfaces as references before editing: `/design-system`,
-  `apps/web/src/features/co-worker/project-layout/project-home.tsx`,
+  `apps/web/src/features/workspace/project-layout/project-home.tsx`,
   `apps/web/src/components/ui/wallpaper-background.tsx`, and the account/IAM
   screens called out by the design-system skill.
 - Verify visual work in the browser and include the exact lint/typecheck commands


### PR DESCRIPTION
## Summary

Update the AGENTS.md design-reference path from the removed `co-worker` directory to the current `workspace` directory.

UnRot v0.5.4 identified the stale reference during an open-source agent-config scan. I verified the replacement file exists at `apps/web/src/features/workspace/project-layout/project-home.tsx`.

No related issue.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

- Confirmed the replacement file exists in the current repository tree.
- Ran `unrot check . --rules broken-refs`; the stale path is no longer reported.

## Security & data review

- [x] No secrets, keys, or credentials are committed (verified by review)
- [ ] Authorization checks are in place for any new/changed endpoints (not applicable)
- [ ] User input is validated and output is safe (not applicable)
- [x] No sensitive data is written to logs; no runtime code changed
- [ ] DB schema / migration changes are reviewed and reversible (not applicable)
- [ ] Touches auth / IAM / crypto / billing / migrations (not applicable)

## Rollout / rollback

Documentation-only. Revert this commit to roll back.

## Reviewer checklist

- [ ] Change is scoped and understandable
- [ ] Tests/CI pass and cover the change
- [ ] Security & data review above is satisfied
