### PR TITLE
fix(snapshots): attest sandbox CLI artifacts

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -168,6 +168,7 @@ COPY --from=deps /app/packages/registry/tsconfig.json ./packages/registry/tsconf
 # Copy runtime artifacts used by the layered snapshot builder.
 COPY --from=sandbox-agent /agent/dist/kortix-agent ./apps/kortix-sandbox-agent-server/dist/kortix-agent
 COPY --from=sandbox-cli /cli/apps/cli/dist/kortix ./apps/cli/dist/kortix
+COPY --from=sandbox-cli /cli/apps/cli/dist/kortix-executor-runtime.attestation.json ./apps/cli/dist/kortix-executor-runtime.attestation.json
 COPY apps/sandbox/entrypoint.sh ./apps/sandbox/entrypoint.sh
 COPY apps/sandbox/opencode-warmup.sh ./apps/sandbox/opencode-warmup.sh
 COPY apps/sandbox/MACHINE.md ./apps/sandbox/MACHINE.md

--- a/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
@@ -3,7 +3,11 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { chmod, mkdir, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import {
+  buildCliExecutorSourceDigest,
+  buildFileSha256,
+} from '@kortix/shared/sandbox-runtime-artifact';
 
 function setTestEnv(name: string, value: string): void {
   if (!process.env[name] || process.env[name]?.startsWith('encrypted:')) {
@@ -26,6 +30,7 @@ setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
 const fixtureRoot = mkdtempSync(join(tmpdir(), 'kortix-daytona-context-test-'));
 const agentPath = join(fixtureRoot, 'kortix-agent');
 const cliPath = join(fixtureRoot, 'kortix');
+const cliAttestationPath = join(fixtureRoot, 'kortix-executor-runtime.attestation.json');
 const entrypointPath = join(fixtureRoot, 'entrypoint.sh');
 const slackCliPath = join(fixtureRoot, 'slack-cli');
 const executorSdkPath = join(fixtureRoot, 'executor-sdk');
@@ -34,6 +39,17 @@ const opencodeConfigPath = join(fixtureRoot, 'opencode-config');
 writeFileSync(agentPath, '#!/bin/sh\n');
 writeFileSync(cliPath, '#!/bin/sh\n');
 writeFileSync(entrypointPath, '#!/bin/sh\n');
+writeFileSync(
+  cliAttestationPath,
+  `${JSON.stringify({
+    schema_version: 1,
+    source_sha256: await buildCliExecutorSourceDigest(
+      resolve(import.meta.dir, '../../../cli'),
+    ),
+    binary_sha256: await buildFileSha256(cliPath),
+    target: 'bun-linux-x64',
+  })}\n`,
+);
 await chmod(agentPath, 0o755);
 await chmod(cliPath, 0o755);
 await chmod(entrypointPath, 0o755);
@@ -52,6 +68,7 @@ await mkdir(opencodeConfigPath, { recursive: true });
 beforeEach(() => {
   process.env.KORTIX_SNAPSHOT_AGENT_BIN_PATH = agentPath;
   process.env.KORTIX_SNAPSHOT_CLI_BIN_PATH = cliPath;
+  process.env.KORTIX_SNAPSHOT_CLI_ATTESTATION_PATH = cliAttestationPath;
   process.env.KORTIX_SNAPSHOT_ENTRYPOINT_PATH = entrypointPath;
   process.env.KORTIX_SNAPSHOT_SLACK_CLI_PATH = slackCliPath;
   process.env.KORTIX_SNAPSHOT_EXECUTOR_SDK_PATH = executorSdkPath;

--- a/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
+++ b/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
@@ -1,12 +1,17 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { chmod, mkdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
+import {
+  buildCliExecutorSourceDigest,
+  buildFileSha256,
+} from '@kortix/shared/sandbox-runtime-artifact';
 
 const fixtureRoot = mkdtempSync(join(tmpdir(), 'kortix-platinum-size-test-'));
 const agentPath = join(fixtureRoot, 'kortix-agent');
 const cliPath = join(fixtureRoot, 'kortix');
+const cliAttestationPath = join(fixtureRoot, 'kortix-executor-runtime.attestation.json');
 const entrypointPath = join(fixtureRoot, 'entrypoint.sh');
 const slackCliPath = join(fixtureRoot, 'slack-cli');
 const executorSdkPath = join(fixtureRoot, 'executor-sdk');
@@ -15,6 +20,17 @@ const opencodeConfigPath = join(fixtureRoot, 'opencode-config');
 writeFileSync(agentPath, '#!/bin/sh\n');
 writeFileSync(cliPath, '#!/bin/sh\n');
 writeFileSync(entrypointPath, '#!/bin/sh\n');
+writeFileSync(
+  cliAttestationPath,
+  `${JSON.stringify({
+    schema_version: 1,
+    source_sha256: await buildCliExecutorSourceDigest(
+      resolve(import.meta.dir, '../../../cli'),
+    ),
+    binary_sha256: await buildFileSha256(cliPath),
+    target: 'bun-linux-x64',
+  })}\n`,
+);
 await chmod(agentPath, 0o755);
 await chmod(cliPath, 0o755);
 await chmod(entrypointPath, 0o755);
@@ -48,6 +64,9 @@ mock.module('../shared/platinum', () => ({
         ? [{ id: 'tpl-1', name: registeredTemplateName, state: 'ready' }]
         : [];
     }
+    if (path === '/v1/templates/tpl-1') {
+      return { id: 'tpl-1', name: registeredTemplateName, state: 'ready' };
+    }
     throw new Error(`unexpected Platinum path: ${path}`);
   },
 }));
@@ -71,6 +90,7 @@ beforeEach(() => {
   // keeps this suite's fixtures from leaking into sibling suites in combined runs.
   process.env.KORTIX_SNAPSHOT_AGENT_BIN_PATH = agentPath;
   process.env.KORTIX_SNAPSHOT_CLI_BIN_PATH = cliPath;
+  process.env.KORTIX_SNAPSHOT_CLI_ATTESTATION_PATH = cliAttestationPath;
   process.env.KORTIX_SNAPSHOT_ENTRYPOINT_PATH = entrypointPath;
   process.env.KORTIX_SNAPSHOT_SLACK_CLI_PATH = slackCliPath;
   process.env.KORTIX_SNAPSHOT_EXECUTOR_SDK_PATH = executorSdkPath;

--- a/apps/api/src/snapshots/__tests__/cli-executor-closure.test.ts
+++ b/apps/api/src/snapshots/__tests__/cli-executor-closure.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { CLI_EXECUTOR_RUNTIME_FILES } from '@kortix/shared/sandbox-runtime-artifact';
 
 // Scope guard for the in-sandbox `kortix executor` fingerprint (templates.ts
 // CLI_EXECUTOR_CLOSURE).
@@ -23,16 +24,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../../../..');
 const CLI_SRC = resolve(REPO_ROOT, 'apps/cli/src');
 
-// Must mirror CLI_EXECUTOR_CLOSURE in apps/api/src/snapshots/templates.ts.
-const HASHED_CLOSURE = [
-  'executor',
-  'commands/executor.ts',
-  'api/auth.ts',
-  'api/client.ts',
-  'api/config.ts',
-  'api/sandbox-env.ts',
-  'project-link.ts',
-] as const;
+const HASHED_CLOSURE = CLI_EXECUTOR_RUNTIME_FILES.map((entry) => entry.replace(/^src\//, ''));
 
 // Entrypoints the sandbox actually invokes (`kortix executor …`). The `index.ts`
 // dispatcher is deliberately NOT an entrypoint here: it imports EVERY subcommand
@@ -61,7 +53,8 @@ function importClosure(entrypoints: string[]): Set<string> {
   const stack = entrypoints.map((e) => resolve(CLI_SRC, e));
   const importRe = /from\s+['"](\.[^'"]+)['"]/g;
   while (stack.length) {
-    const file = stack.pop()!;
+    const file = stack.pop();
+    if (!file) continue;
     if (seen.has(file) || !existsSync(file)) continue;
     seen.add(file);
     const src = readFileSync(file, 'utf8');

--- a/apps/api/src/snapshots/build-context.ts
+++ b/apps/api/src/snapshots/build-context.ts
@@ -25,6 +25,7 @@ import { buildLayeredDockerfile, buildPerProjectWarmFromBaseDockerfile } from '.
 import { buildStarterFiles, DEFAULT_STARTER_TEMPLATE_ID } from '../projects/starter';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { assertCliArtifactAttested } from './cli-artifact-attestation';
 const execFileAsyncBC = promisify(execFile);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -38,6 +39,8 @@ const agentBinPath = () => process.env.KORTIX_SNAPSHOT_AGENT_BIN_PATH
   || resolve(REPO_ROOT, 'apps/kortix-sandbox-agent-server/dist/kortix-agent');
 const cliBinPath = () => process.env.KORTIX_SNAPSHOT_CLI_BIN_PATH
   || resolve(REPO_ROOT, 'apps/cli/dist/kortix');
+const cliAttestationPath = () => process.env.KORTIX_SNAPSHOT_CLI_ATTESTATION_PATH
+  || resolve(REPO_ROOT, 'apps/cli/dist/kortix-executor-runtime.attestation.json');
 const entrypointSrcPath = () => process.env.KORTIX_SNAPSHOT_ENTRYPOINT_PATH
   || resolve(REPO_ROOT, 'apps/sandbox/entrypoint.sh');
 const slackCliSrcPath = () => process.env.KORTIX_SNAPSHOT_SLACK_CLI_PATH
@@ -412,6 +415,7 @@ export async function stageBuildContext(
 ): Promise<StagedContext> {
   const AGENT_BIN_PATH = agentBinPath();
   const CLI_BIN_PATH = cliBinPath();
+  const CLI_ATTESTATION_PATH = cliAttestationPath();
   const ENTRYPOINT_PATH = entrypointSrcPath();
   const SLACK_CLI_SRC_PATH = slackCliSrcPath();
   const EXECUTOR_SDK_SRC_PATH = executorSdkSrcPath();
@@ -444,6 +448,15 @@ export async function stageBuildContext(
       );
     }
   }
+  // The snapshot identity hashes CLI SOURCE, but the image bakes this compiled
+  // binary. Refuse source/binary skew before the provider sees a context. A
+  // local API with edited CLI source and stale dist previously poisoned the
+  // shared content-addressed image under the NEW source hash.
+  await assertCliArtifactAttested({
+    cliRoot: resolve(REPO_ROOT, 'apps/cli'),
+    binaryPath: CLI_BIN_PATH,
+    attestationPath: CLI_ATTESTATION_PATH,
+  });
 
   const contextDir = await mkdtemp(join(tmpdir(), 'kortix-snap-'));
   await gzipFile(AGENT_BIN_PATH, join(contextDir, 'kortix-agent.gz'));

--- a/apps/api/src/snapshots/cli-artifact-attestation.test.ts
+++ b/apps/api/src/snapshots/cli-artifact-attestation.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  CLI_EXECUTOR_RUNTIME_FILES,
+  buildCliExecutorSourceDigest,
+  buildFileSha256,
+} from '@kortix/shared/sandbox-runtime-artifact';
+import { assertCliArtifactAttested } from './cli-artifact-attestation';
+
+const roots: string[] = [];
+
+async function createCliFixture(): Promise<{
+  cliRoot: string;
+  binaryPath: string;
+  attestationPath: string;
+}> {
+  const cliRoot = await mkdtemp(join(tmpdir(), 'kortix-cli-artifact-'));
+  roots.push(cliRoot);
+  for (const relativePath of CLI_EXECUTOR_RUNTIME_FILES) {
+    const filePath =
+      relativePath === 'src/executor'
+        ? join(cliRoot, relativePath, 'gateway.ts')
+        : join(cliRoot, relativePath);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, `${relativePath}:v1\n`);
+  }
+  await writeFile(join(cliRoot, 'package.json'), '{"name":"fixture"}\n');
+  const binaryPath = join(cliRoot, 'dist', 'kortix');
+  const attestationPath = join(cliRoot, 'dist', 'kortix-executor-runtime.attestation.json');
+  await mkdir(dirname(attestationPath), { recursive: true });
+  await writeFile(binaryPath, 'binary:v1\n');
+  return { cliRoot, binaryPath, attestationPath };
+}
+
+async function writeAttestation(
+  fixture: Awaited<ReturnType<typeof createCliFixture>>,
+): Promise<string> {
+  const digest = await buildCliExecutorSourceDigest(fixture.cliRoot);
+  await writeFile(
+    fixture.attestationPath,
+    `${JSON.stringify({
+      schema_version: 1,
+      source_sha256: digest,
+      binary_sha256: await buildFileSha256(fixture.binaryPath),
+      target: 'bun-linux-x64',
+    })}\n`,
+  );
+  return digest;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('sandbox CLI artifact attestation', () => {
+  test('accepts the digest produced from the current Executor source', async () => {
+    const fixture = await createCliFixture();
+    const digest = await writeAttestation(fixture);
+
+    await expect(assertCliArtifactAttested(fixture)).resolves.toBe(digest);
+  });
+
+  test('rejects a compiled artifact after Executor source changes', async () => {
+    const fixture = await createCliFixture();
+    await writeAttestation(fixture);
+    await writeFile(join(fixture.cliRoot, 'src/commands/executor.ts'), 'executor:v2\n');
+
+    await expect(assertCliArtifactAttested(fixture)).rejects.toThrow(
+      'Compiled sandbox CLI is stale',
+    );
+  });
+
+  test('rejects a binary that does not match its attestation', async () => {
+    const fixture = await createCliFixture();
+    await writeAttestation(fixture);
+    await writeFile(fixture.binaryPath, 'binary:v2\n');
+
+    await expect(assertCliArtifactAttested(fixture)).rejects.toThrow(
+      'Compiled sandbox CLI does not match its attestation',
+    );
+  });
+
+  test('rejects a non-Linux compile target', async () => {
+    const fixture = await createCliFixture();
+    await writeAttestation(fixture);
+    const value = JSON.parse(await readFile(fixture.attestationPath, 'utf8'));
+    value.target = 'bun-darwin-arm64';
+    await writeFile(fixture.attestationPath, `${JSON.stringify(value)}\n`);
+
+    await expect(assertCliArtifactAttested(fixture)).rejects.toThrow(
+      'Invalid CLI artifact attestation',
+    );
+  });
+
+  test('rejects a missing attestation', async () => {
+    const fixture = await createCliFixture();
+
+    await expect(assertCliArtifactAttested(fixture)).rejects.toThrow(
+      'Required CLI artifact attestation missing',
+    );
+  });
+});

--- a/apps/api/src/snapshots/cli-artifact-attestation.ts
+++ b/apps/api/src/snapshots/cli-artifact-attestation.ts
@@ -1,0 +1,77 @@
+import { readFile } from 'node:fs/promises';
+import {
+  buildCliExecutorSourceDigest,
+  buildFileSha256,
+} from '@kortix/shared/sandbox-runtime-artifact';
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+const LINUX_BUN_TARGET = /^bun-linux-(x64|arm64)$/;
+
+interface CliArtifactAttestation {
+  schema_version: 1;
+  source_sha256: string;
+  binary_sha256: string;
+  target: string;
+}
+
+function parseAttestation(path: string, raw: string): CliArtifactAttestation {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      `Invalid CLI artifact attestation at ${path}. Run \`bun run build\` in apps/cli before building a sandbox snapshot.`,
+    );
+  }
+  if (
+    !value
+    || typeof value !== 'object'
+    || (value as Record<string, unknown>).schema_version !== 1
+    || !SHA256_HEX.test(String((value as Record<string, unknown>).source_sha256 ?? ''))
+    || !SHA256_HEX.test(String((value as Record<string, unknown>).binary_sha256 ?? ''))
+    || !LINUX_BUN_TARGET.test(String((value as Record<string, unknown>).target ?? ''))
+  ) {
+    throw new Error(
+      `Invalid CLI artifact attestation at ${path}. Run \`bun run build\` in apps/cli before building a sandbox snapshot.`,
+    );
+  }
+  return value as CliArtifactAttestation;
+}
+
+/**
+ * Prove that the compiled CLI belongs to the source used by snapshot identity.
+ *
+ * The compiled binary is not deterministic across Bun builds. The snapshot
+ * identity therefore hashes source. The CLI build records the source digest,
+ * binary digest, and Linux compile target. Any mismatch fails before upload.
+ */
+export async function assertCliArtifactAttested(input: {
+  cliRoot: string;
+  binaryPath: string;
+  attestationPath: string;
+}): Promise<string> {
+  let raw: string;
+  try {
+    raw = await readFile(input.attestationPath, 'utf8');
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Required CLI artifact attestation missing: ${input.attestationPath} (${reason}). Run \`bun run build\` in apps/cli before building a sandbox snapshot.`,
+    );
+  }
+
+  const recorded = parseAttestation(input.attestationPath, raw);
+  const current = await buildCliExecutorSourceDigest(input.cliRoot);
+  if (recorded.source_sha256 !== current) {
+    throw new Error(
+      `Compiled sandbox CLI is stale: attested source ${recorded.source_sha256}, current source ${current}. Run \`bun run build\` in apps/cli before building a sandbox snapshot.`,
+    );
+  }
+  const binarySha256 = await buildFileSha256(input.binaryPath);
+  if (recorded.binary_sha256 !== binarySha256) {
+    throw new Error(
+      `Compiled sandbox CLI does not match its attestation: attested binary ${recorded.binary_sha256}, current binary ${binarySha256}. Run \`bun run build\` in apps/cli before building a sandbox snapshot.`,
+    );
+  }
+  return current;
+}

--- a/apps/api/src/snapshots/runtime-fingerprint.ts
+++ b/apps/api/src/snapshots/runtime-fingerprint.ts
@@ -1,103 +1,15 @@
-import { createHash, type Hash } from 'node:crypto';
-import { constants } from 'node:fs';
-import { lstat, open, readdir, readlink } from 'node:fs/promises';
-import { join } from 'node:path';
-
-interface RuntimeArtifact {
-  label: string;
-  path: string;
-  /**
-   * Directory entry names to skip when walking this artifact. Lets callers
-   * exclude generated/install state like `node_modules` (pnpm symlink targets
-   * can shift across installs even when the source hasn't changed, which would
-   * otherwise flip the fingerprint and force every project to rebuild).
-   */
-  excludeNames?: readonly string[];
-}
-
-interface RuntimeArtifactFingerprintInput {
-  sandboxVersion: string;
-  opencodeVersion: string;
-  artifacts: RuntimeArtifact[];
-}
-
 /**
- * True for a directory entry that holds test sources only. `__tests__` dirs and
- * `*.test.ts` / `*.spec.ts` files are excluded from the runtime fingerprint: they
- * are never copied into a sandbox image nor compiled into the CLI/agent binary, so
- * editing them can't change what a session runs — but hashing them re-minted every
- * template's identity on every test change, defeating the warm cache. Matches by
- * entry name so it works both for `__tests__` subdirs and loose colocated tests.
+ * Re-export shim. Runtime artifact hashing is shared by the API snapshot
+ * identity and the CLI build attestation.
  */
-function isTestEntry(name: string): boolean {
-  return name === '__tests__' || /\.(test|spec)\.[cm]?tsx?$/.test(name);
-}
-
-export async function buildRuntimeArtifactFingerprint(
-  input: RuntimeArtifactFingerprintInput,
-): Promise<string> {
-  const hash = createHash('sha256');
-  hash.update(`sandbox_version\0${input.sandboxVersion}\0`);
-  hash.update(`opencode_version\0${input.opencodeVersion}\0`);
-
-  for (const artifact of [...input.artifacts].sort((a, b) => a.label.localeCompare(b.label))) {
-    await hashPath(hash, artifact.path, artifact.label, artifact.excludeNames);
-  }
-
-  return `kortix-runtime:${input.sandboxVersion}:artifacts:${hash.digest('hex')}`;
-}
-
-async function hashPath(
-  hash: Hash,
-  path: string,
-  logicalPath: string,
-  excludeNames?: readonly string[],
-): Promise<void> {
-  if (await hashFileIfRegular(hash, path, logicalPath)) return;
-
-  const stats = await lstat(path);
-  if (stats.isDirectory()) {
-    hash.update(`dir\0${logicalPath}\0`);
-    const entries = await readdir(path, { withFileTypes: true });
-    entries.sort((a, b) => a.name.localeCompare(b.name));
-    for (const entry of entries) {
-      if (excludeNames && excludeNames.includes(entry.name)) continue;
-      // Test sources never ship into a sandbox image (nothing COPYs `__tests__`
-      // or `*.test.ts`, and `bun build` doesn't compile them into the CLI/agent
-      // binary), so they can't change what a session runs — yet hashing them made
-      // every test edit re-mint every project's runtime identity, forcing a mass
-      // cache miss. Skip them so the fingerprint moves only on real runtime code.
-      if (isTestEntry(entry.name)) continue;
-      await hashPath(hash, join(path, entry.name), `${logicalPath}/${entry.name}`, excludeNames);
-    }
-    return;
-  }
-
-  if (stats.isSymbolicLink()) {
-    hash.update(`symlink\0${logicalPath}\0${await readlink(path)}\0`);
-    return;
-  }
-
-  hash.update(`other\0${logicalPath}\0`);
-}
-
-async function hashFileIfRegular(hash: Hash, path: string, logicalPath: string): Promise<boolean> {
-  let file;
-  try {
-    file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
-  } catch {
-    return false;
-  }
-
-  try {
-    const stats = await file.stat();
-    if (!stats.isFile()) return false;
-    const contents = await file.readFile();
-    hash.update(`file\0${logicalPath}\0${stats.size}\0`);
-    hash.update(contents);
-    hash.update('\0');
-    return true;
-  } finally {
-    await file.close();
-  }
-}
+export {
+  buildArtifactContentDigest,
+  buildCliExecutorSourceDigest,
+  buildRuntimeArtifactFingerprint,
+  CLI_EXECUTOR_RUNTIME_FILES,
+  cliExecutorRuntimeArtifacts,
+} from '@kortix/shared/sandbox-runtime-artifact';
+export type {
+  RuntimeArtifact,
+  RuntimeArtifactFingerprintInput,
+} from '@kortix/shared/sandbox-runtime-artifact';

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -51,7 +51,10 @@ import {
   SANDBOX_SPEC_LIMITS,
 } from './dockerfile-layer';
 import { computeSnapshotHash } from './hash';
-import { buildRuntimeArtifactFingerprint } from './runtime-fingerprint';
+import {
+  buildRuntimeArtifactFingerprint,
+  cliExecutorRuntimeArtifacts,
+} from './runtime-fingerprint';
 import { getSandboxProvider, type SandboxProviderAdapter } from './providers';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -92,19 +95,7 @@ const EXECUTOR_SDK_SRC_PATH = process.env.KORTIX_SNAPSHOT_EXECUTOR_SDK_PATH
 // stale in-sandbox executor. packages/starter (scaffolding) and packages/
 // manifest-schema (only reached by laptop-side `ship`/`validate`) are likewise
 // never in the sandbox and are deliberately not fingerprinted.
-const CLI_SRC_DIR = resolve(REPO_ROOT, 'apps/cli/src');
-// The in-sandbox `kortix executor` closure (see comment above). Relative to
-// CLI_SRC_DIR; the guard test keeps this in sync with the real import graph.
-const CLI_EXECUTOR_CLOSURE = [
-  'executor',
-  'commands/executor.ts',
-  'api/auth.ts',
-  'api/client.ts',
-  'api/config.ts',
-  'api/sandbox-env.ts',
-  'project-link.ts',
-] as const;
-const CLI_PKG_JSON = resolve(REPO_ROOT, 'apps/cli/package.json');
+const CLI_ROOT = resolve(REPO_ROOT, 'apps/cli');
 const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'] as const;
 
 // Bump when the rendered Kortix Dockerfile layer changes (the Dockerfile text
@@ -225,7 +216,9 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // daemon can start all four harnesses without a request-time package download.
 // v35: pin Pi's internal 0.x packages to the same version as pi-coding-agent.
 // v36: install Pi with npm because pnpm 11 isolates each global root graph.
-const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v36';
+// v37: require a source digest beside the compiled sandbox CLI. This invalidates
+// the poisoned v36 snapshot whose new source identity contained an old binary.
+const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v37';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);
@@ -921,14 +914,9 @@ const NON_AGENT_RUNTIME_ARTIFACTS = [
   { label: 'kortix-slack-cli', path: SLACK_CLI_SRC_PATH, excludeNames: FINGERPRINT_EXCLUDES },
   { label: 'kortix-executor-sdk', path: EXECUTOR_SDK_SRC_PATH, excludeNames: FINGERPRINT_EXCLUDES },
   // Only the in-sandbox `kortix executor` closure (NOT the whole apps/cli/src) —
-  // see CLI_EXECUTOR_CLOSURE. Labels carry the relative path so two files can't
-  // collide, and the set is sorted by label in buildRuntimeArtifactFingerprint.
-  ...CLI_EXECUTOR_CLOSURE.map((rel) => ({
-    label: `kortix-cli-${rel}`,
-    path: join(CLI_SRC_DIR, rel),
-    excludeNames: FINGERPRINT_EXCLUDES,
-  })),
-  { label: 'kortix-cli-pkg', path: CLI_PKG_JSON },
+  // see CLI_EXECUTOR_RUNTIME_FILES in @kortix/shared. Labels carry the relative
+  // path so two files cannot collide.
+  ...cliExecutorRuntimeArtifacts(CLI_ROOT),
 ];
 // Both version strings fold in the layer/opencode/browser/sandbox constants — all
 // NON-agent inputs (bumped when the layer/opencode/browser change, not the agent

--- a/apps/cli/scripts/build.sh
+++ b/apps/cli/scripts/build.sh
@@ -55,7 +55,18 @@ compile_with_retry() {
 # `bun build --compile`; see packages/starter/scripts/generate-embedded.ts).
 bun run ../../packages/starter/scripts/generate-embedded.ts
 
+# Record the exact in-sandbox Executor source before compilation. The final
+# attestation binds that source to the output binary and Linux compile target.
+source_digest="$(bun run scripts/sandbox-runtime-attestation.ts print-source)"
+attestation_tmp="dist/.kortix-executor-runtime.attestation.json.tmp"
+attestation_final="dist/kortix-executor-runtime.attestation.json"
 compile_with_retry
+bun run scripts/sandbox-runtime-attestation.ts write \
+  "$attestation_tmp" \
+  "dist/kortix" \
+  "$source_digest" \
+  "$target"
+mv "$attestation_tmp" "$attestation_final"
 chmod +x dist/kortix
 size="$(stat -f%z dist/kortix 2>/dev/null || stat -c%s dist/kortix)"
-echo "Built dist/kortix for ${target} (${size} bytes)"
+echo "Built dist/kortix for ${target} (${size} bytes; attestation ${attestation_final})"

--- a/apps/cli/scripts/sandbox-runtime-attestation.ts
+++ b/apps/cli/scripts/sandbox-runtime-attestation.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import {
+  buildCliExecutorSourceDigest,
+  buildFileSha256,
+} from '@kortix/shared/sandbox-runtime-artifact';
+
+const cliRoot = resolve(import.meta.dir, '..');
+const [command, rawPath, rawBinaryPath, expectedSourceDigest, target] = process.argv.slice(2);
+
+function usage(): never {
+  console.error(
+    'usage: bun run scripts/sandbox-runtime-attestation.ts print-source | write <attestation-path> <binary-path> <expected-source-sha256> <target>',
+  );
+  process.exit(2);
+}
+
+const digest = await buildCliExecutorSourceDigest(cliRoot);
+
+if (command === 'print-source') {
+  console.log(digest);
+  process.exit(0);
+}
+
+if (command !== 'write' || !rawPath || !rawBinaryPath || !expectedSourceDigest || !target) {
+  usage();
+}
+
+if (digest !== expectedSourceDigest) {
+  console.error(
+    `CLI source changed during compilation: expected ${expectedSourceDigest}, current ${digest}`,
+  );
+  process.exit(1);
+}
+
+const attestationPath = resolve(process.cwd(), rawPath);
+const binaryPath = resolve(process.cwd(), rawBinaryPath);
+const binarySha256 = await buildFileSha256(binaryPath);
+const attestation = {
+  schema_version: 1,
+  source_sha256: digest,
+  binary_sha256: binarySha256,
+  target,
+};
+await writeFile(attestationPath, `${JSON.stringify(attestation, null, 2)}\n`, 'utf8');
+console.log(
+  `Wrote ${attestationPath} (source ${digest}; binary ${binarySha256}; target ${target})`,
+);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,8 @@
     "./constants": "./src/constants/upload-limits.ts",
     "./harnesses": "./src/harnesses.ts",
     "./runtime-versions": "./src/runtime-versions.ts",
-    "./sandbox": "./src/sandbox/index.ts"
+    "./sandbox": "./src/sandbox/index.ts",
+    "./sandbox-runtime-artifact": "./src/sandbox-runtime-artifact.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/shared/src/sandbox-runtime-artifact.test.ts
+++ b/packages/shared/src/sandbox-runtime-artifact.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  CLI_EXECUTOR_RUNTIME_FILES,
+  buildCliExecutorSourceDigest,
+  buildFileSha256,
+} from './sandbox-runtime-artifact';
+
+const roots: string[] = [];
+
+async function createCliFixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'kortix-cli-attestation-'));
+  roots.push(root);
+  for (const relativePath of CLI_EXECUTOR_RUNTIME_FILES) {
+    const filePath =
+      relativePath === 'src/executor'
+        ? join(root, relativePath, 'gateway.ts')
+        : join(root, relativePath);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, `${relativePath}:v1\n`);
+  }
+  await writeFile(join(root, 'package.json'), '{"name":"fixture"}\n');
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('sandbox CLI source digest', () => {
+  test('changes when an in-sandbox Executor source file changes', async () => {
+    const root = await createCliFixture();
+    const before = await buildCliExecutorSourceDigest(root);
+
+    await writeFile(join(root, 'src/commands/executor.ts'), 'executor:v2\n');
+
+    expect(await buildCliExecutorSourceDigest(root)).not.toBe(before);
+  });
+
+  test('does not change for a laptop-only CLI command', async () => {
+    const root = await createCliFixture();
+    const before = await buildCliExecutorSourceDigest(root);
+
+    await writeFile(join(root, 'src/commands/ship.ts'), 'ship:v2\n');
+
+    expect(await buildCliExecutorSourceDigest(root)).toBe(before);
+  });
+
+  test('changes when a compiled artifact changes', async () => {
+    const root = await createCliFixture();
+    const binaryPath = join(root, 'dist', 'kortix');
+    await mkdir(dirname(binaryPath), { recursive: true });
+    await writeFile(binaryPath, 'binary:v1\n');
+    const before = await buildFileSha256(binaryPath);
+
+    await writeFile(binaryPath, 'binary:v2\n');
+
+    expect(await buildFileSha256(binaryPath)).not.toBe(before);
+  });
+});

--- a/packages/shared/src/sandbox-runtime-artifact.ts
+++ b/packages/shared/src/sandbox-runtime-artifact.ts
@@ -1,0 +1,154 @@
+import { type Hash, createHash } from 'node:crypto';
+import { constants, createReadStream } from 'node:fs';
+import { type FileHandle, lstat, open, readdir, readlink } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export interface RuntimeArtifact {
+  label: string;
+  path: string;
+  /**
+   * Directory entry names to skip when walking this artifact.
+   * This excludes generated state that does not enter the runtime artifact.
+   */
+  excludeNames?: readonly string[];
+}
+
+export interface RuntimeArtifactFingerprintInput {
+  sandboxVersion: string;
+  opencodeVersion: string;
+  artifacts: RuntimeArtifact[];
+}
+
+/**
+ * Files that can change `kortix executor` inside a sandbox.
+ *
+ * Paths are relative to `apps/cli`. The snapshot identity and the compiled
+ * binary attestation both use this one list.
+ */
+export const CLI_EXECUTOR_RUNTIME_FILES = [
+  'src/executor',
+  'src/commands/executor.ts',
+  'src/api/auth.ts',
+  'src/api/client.ts',
+  'src/api/config.ts',
+  'src/api/sandbox-env.ts',
+  'src/project-link.ts',
+] as const;
+
+const CLI_RUNTIME_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'] as const;
+
+export function cliExecutorRuntimeArtifacts(cliRoot: string): RuntimeArtifact[] {
+  return [
+    ...CLI_EXECUTOR_RUNTIME_FILES.map((relativePath) => ({
+      // Preserve the existing snapshot-fingerprint labels. The paths moved
+      // from an apps/cli/src-relative list to this apps/cli-relative list.
+      label: `kortix-cli-${relativePath.replace(/^src\//, '')}`,
+      path: join(cliRoot, relativePath),
+      excludeNames: CLI_RUNTIME_EXCLUDES,
+    })),
+    { label: 'kortix-cli-pkg', path: join(cliRoot, 'package.json') },
+  ];
+}
+
+/**
+ * Deterministic digest of the source that defines the in-sandbox Executor CLI.
+ *
+ * The CLI build writes this digest beside the compiled binary. The snapshot
+ * builder recomputes it before upload and rejects a stale binary.
+ */
+export function buildCliExecutorSourceDigest(cliRoot: string): Promise<string> {
+  return buildArtifactContentDigest(cliExecutorRuntimeArtifacts(cliRoot));
+}
+
+/**
+ * SHA-256 digest of one compiled runtime artifact.
+ */
+export async function buildFileSha256(path: string): Promise<string> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) {
+    hash.update(chunk);
+  }
+  return hash.digest('hex');
+}
+
+/**
+ * Deterministic content digest for a labeled artifact set.
+ */
+export async function buildArtifactContentDigest(artifacts: RuntimeArtifact[]): Promise<string> {
+  const hash = createHash('sha256');
+  await hashArtifacts(hash, artifacts);
+  return hash.digest('hex');
+}
+
+export async function buildRuntimeArtifactFingerprint(
+  input: RuntimeArtifactFingerprintInput,
+): Promise<string> {
+  const hash = createHash('sha256');
+  hash.update(`sandbox_version\0${input.sandboxVersion}\0`);
+  hash.update(`opencode_version\0${input.opencodeVersion}\0`);
+  await hashArtifacts(hash, input.artifacts);
+  return `kortix-runtime:${input.sandboxVersion}:artifacts:${hash.digest('hex')}`;
+}
+
+async function hashArtifacts(hash: Hash, artifacts: RuntimeArtifact[]): Promise<void> {
+  for (const artifact of [...artifacts].sort((a, b) => a.label.localeCompare(b.label))) {
+    await hashPath(hash, artifact.path, artifact.label, artifact.excludeNames);
+  }
+}
+
+/**
+ * True for a directory entry that holds test sources only.
+ */
+function isTestEntry(name: string): boolean {
+  return name === '__tests__' || /\.(test|spec)\.[cm]?tsx?$/.test(name);
+}
+
+async function hashPath(
+  hash: Hash,
+  path: string,
+  logicalPath: string,
+  excludeNames?: readonly string[],
+): Promise<void> {
+  if (await hashFileIfRegular(hash, path, logicalPath)) return;
+
+  const stats = await lstat(path);
+  if (stats.isDirectory()) {
+    hash.update(`dir\0${logicalPath}\0`);
+    const entries = await readdir(path, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (excludeNames?.includes(entry.name)) continue;
+      if (isTestEntry(entry.name)) continue;
+      await hashPath(hash, join(path, entry.name), `${logicalPath}/${entry.name}`, excludeNames);
+    }
+    return;
+  }
+
+  if (stats.isSymbolicLink()) {
+    hash.update(`symlink\0${logicalPath}\0${await readlink(path)}\0`);
+    return;
+  }
+
+  hash.update(`other\0${logicalPath}\0`);
+}
+
+async function hashFileIfRegular(hash: Hash, path: string, logicalPath: string): Promise<boolean> {
+  let file: FileHandle;
+  try {
+    file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch {
+    return false;
+  }
+
+  try {
+    const stats = await file.stat();
+    if (!stats.isFile()) return false;
+    const contents = await file.readFile();
+    hash.update(`file\0${logicalPath}\0${stats.size}\0`);
+    hash.update(contents);
+    hash.update('\0');
+    return true;
+  } finally {
+    await file.close();
+  }
+}


### PR DESCRIPTION
## Problem

The snapshot identity hashed Executor CLI source. `stageBuildContext()` copied `apps/cli/dist/kortix` without proving that the binary came from that source.

A local API process used new source with an old compiled binary. It created the shared Platinum template `kortix-default-4aa45e8346ec` under the new source-derived identity. Fresh sandboxes then returned the old CLI parser error as `connector_not_assigned`.

## Change

- Define the in-sandbox Executor source closure once in `@kortix/shared`.
- Write a build attestation containing the source SHA-256, binary SHA-256, and Bun Linux target.
- Verify the attestation before `stageBuildContext()` creates or uploads a provider context.
- Verify overridden CLI binary paths instead of bypassing the guard.
- Copy the attestation into the API runner image beside the CLI binary.
- Bump the runtime layer identity from `v36` to `v37`.
- Add missing exact-ID behavior to the Platinum sizing fixture.

## Verification

- `bun test --isolate --env-file=apps/api/scripts/test.env apps/api/src/snapshots apps/api/src/__tests__/unit-snapshot-runtime-fingerprint.test.ts apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts`
  - `288 pass`, `1 skip`, `0 fail`
- `bun test packages/shared/src/sandbox-runtime-artifact.test.ts apps/cli/src/__tests__/executor-call-input.test.ts apps/cli/src/__tests__/executor-builtin-channels.test.ts apps/cli/src/__tests__/sandbox-auth.test.ts`
  - `22 pass`, `0 fail`
- `pnpm --filter @kortix/shared typecheck`
  - exit `0`
- `pnpm --filter @kortix/cli typecheck`
  - exit `0`
- `pnpm --filter kortix-api typecheck`
  - exit `0`
- `bun run build` in `apps/cli`
  - source `ac8888e175ac0fc0225f3b88f310ac22b9a48ddca8ec875d97a1ae666f1736ab`
- `docker build --platform linux/amd64 --target runner --build-arg SERVICE=apps/api -f apps/api/Dockerfile -t kortix-api-cli-attestation:final-amd64 .`
  - exit `0`
- The AMD64 runner executes `kortix --version`.
- The runner binary SHA-256 equals the attested binary SHA-256: `a2f76287f387b9ef3f45fc68ea70d90c769c9ce31202d3d4083d802989bdd7fc`.
- The API guard accepts the runner artifact and returns source digest `ac8888e175ac0fc0225f3b88f310ac22b9a48ddca8ec875d97a1ae666f1736ab`.
