### PR TITLE
fix: repair dev migration order

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -137,6 +137,7 @@ COPY --from=deps /app/packages/db/tsconfig.json ./packages/db/tsconfig.json
 # Kortix cloud applies them in the deploy pipeline's migrate-db job instead.
 COPY --from=deps /app/packages/db/migrations ./packages/db/migrations
 COPY --from=deps /app/packages/db/scripts/migrate.ts ./packages/db/scripts/migrate.ts
+COPY --from=deps /app/packages/db/scripts/migration-ledger-repair.ts ./packages/db/scripts/migration-ledger-repair.ts
 # Non-kortix bootstrap (basejump + credit RPCs + signup triggers) for FRESH
 # self-host databases. `migrate.ts bootstrap` applies this before `up` when
 # basejump is absent (no-op on provisioned cloud/dev DBs).

--- a/packages/db/migrations/20260730064010447_repair_sandbox_deadline_guard.sql
+++ b/packages/db/migrations/20260730064010447_repair_sandbox_deadline_guard.sql
@@ -1,0 +1,67 @@
+-- Migration: repair_sandbox_deadline_guard
+--
+set lock_timeout = '2s';
+set statement_timeout = '30s';
+
+-- A previous merge renamed an already-applied migration after its trigger
+-- function had changed. The ledger repair maps the applied name to the renamed
+-- file. This roll-forward migration ensures every existing environment receives
+-- the final trigger behavior. CREATE OR REPLACE keeps the existing trigger live.
+CREATE OR REPLACE FUNCTION "kortix"."session_sandboxes_anchor_guard"()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  derived boolean := false;
+  meta jsonb;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    NEW.active_since := now();
+    IF NEW.deadline_at <= NEW.active_since THEN
+      NEW.deadline_at := now() + interval '20 minutes';
+    END IF;
+    IF jsonb_typeof(NEW.metadata) = 'object' THEN
+      NEW.metadata := NEW.metadata - 'stretchParkedAt';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  NEW.active_since := OLD.active_since;
+
+  meta := CASE WHEN jsonb_typeof(NEW.metadata) = 'object' THEN NEW.metadata ELSE '{}'::jsonb END;
+  IF jsonb_typeof(OLD.metadata) = 'object' AND OLD.metadata ? 'stretchParkedAt' THEN
+    meta := meta || jsonb_build_object('stretchParkedAt', OLD.metadata -> 'stretchParkedAt');
+  ELSE
+    meta := meta - 'stretchParkedAt';
+  END IF;
+  NEW.metadata := meta;
+
+  IF OLD.status = 'active'
+     AND (NEW.status IN ('stopped', 'error', 'archived')
+          OR (NEW.status = 'provisioning' AND NEW.external_id IS NULL)) THEN
+    NEW.metadata := NEW.metadata || jsonb_build_object('stretchParkedAt', to_jsonb(now()));
+  END IF;
+
+  IF OLD.status <> 'active' AND NEW.status = 'active' THEN
+    IF jsonb_typeof(OLD.metadata) = 'object' AND OLD.metadata ? 'stretchParkedAt' THEN
+      NEW.active_since := now();
+      NEW.metadata := NEW.metadata - 'stretchParkedAt';
+    ELSIF NEW.active_since + interval '24 hours' < now() + interval '20 minutes' THEN
+      NEW.active_since := now();
+    END IF;
+    IF NEW.deadline_at IS NOT DISTINCT FROM OLD.deadline_at THEN
+      NEW.deadline_at := GREATEST(OLD.deadline_at, now() + interval '20 minutes');
+      derived := true;
+    ELSIF NEW.deadline_at <= now() THEN
+      NEW.deadline_at := now() + interval '20 minutes';
+      derived := true;
+    END IF;
+  END IF;
+
+  IF derived THEN
+    NEW.deadline_at := LEAST(NEW.deadline_at, NEW.active_since + interval '24 hours');
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON COLUMN "kortix"."session_sandboxes"."active_since" IS
+  'Start of this box''s current continuous running stretch. Anchor operand of the 24h cap. Assigned ONLY by kortix.session_sandboxes_anchor_guard(); never movable by application code in any state, and re-anchored only on resume of a park the trigger itself witnessed.';

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -22,6 +22,10 @@ import { join } from 'node:path';
  */
 import { runner } from 'node-pg-migrate';
 import pg from 'pg';
+import {
+  migrationLedgerRepairExecutorName,
+  repairMigrationLedger,
+} from './migration-ledger-repair';
 
 const MIGRATIONS_DIR = join(import.meta.dir, '..', 'migrations');
 const BOOTSTRAP_SQL = join(import.meta.dir, '..', 'drizzle', '0000_bootstrap.sql');
@@ -205,15 +209,36 @@ async function main() {
 
   console.log(`node-pg-migrate ${cmd}  DB: ${fmtUrl(databaseUrl)}`);
 
+  const repairAppliedMigrationRenames = async () => {
+    const repaired = await repairMigrationLedger({
+      databaseUrl,
+      migrationsDir: MIGRATIONS_DIR,
+      applyExecutorMigration: async () => {
+        await runner({
+          ...base,
+          direction: 'up',
+          count: 1,
+          checkOrder: false,
+          file: migrationLedgerRepairExecutorName,
+        });
+      },
+    });
+    if (repaired) {
+      console.log('[migrate] reconciled renamed sandbox deadline migration records.');
+    }
+  };
+
   switch (cmd) {
     case 'up':
       await autoBaselineIfNeeded(base, databaseUrl);
+      await repairAppliedMigrationRenames();
       await runner({ ...base, direction: 'up', count: Number.POSITIVE_INFINITY });
       return;
     case 'bootstrap':
       // Fresh-DB convenience for self-host: prereqs → then `up`.
       await selfHostBootstrapIfFresh(databaseUrl);
       await autoBaselineIfNeeded(base, databaseUrl);
+      await repairAppliedMigrationRenames();
       await runner({ ...base, direction: 'up', count: Number.POSITIVE_INFINITY });
       return;
     case 'fake':

--- a/packages/db/scripts/migration-ledger-repair.integration.test.ts
+++ b/packages/db/scripts/migration-ledger-repair.integration.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { runner } from 'node-pg-migrate';
+import pg from 'pg';
+import {
+  migrationLedgerRepairExecutorName,
+  repairMigrationLedger,
+} from './migration-ledger-repair';
+
+const adminUrl = process.env.MIGRATION_REPAIR_ADMIN_URL;
+const suite = adminUrl ? describe : describe.skip;
+const migrationsDir = join(import.meta.dir, '..', 'migrations');
+const databaseName = `kortix_migration_repair_${process.pid}_${Date.now()}`;
+const databaseUrl = adminUrl ? new URL(adminUrl) : null;
+if (databaseUrl) databaseUrl.pathname = `/${databaseName}`;
+
+let admin: pg.Client;
+
+suite('migration ledger rename repair', () => {
+  beforeAll(async () => {
+    admin = new pg.Client({ connectionString: adminUrl });
+    await admin.connect();
+    await admin.query(`create database "${databaseName}"`);
+
+    const client = new pg.Client({ connectionString: databaseUrl?.toString() });
+    await client.connect();
+    try {
+      await client.query(`
+        create schema kortix;
+        create schema kortix_migrations;
+        create table kortix.executor_connection_policies (id integer);
+        create table kortix.executor_connector_policies (id integer);
+        create table kortix.executor_project_policies (id integer);
+        create table kortix_migrations.pgmigrations (
+          id serial primary key,
+          name varchar(255) not null,
+          run_on timestamp not null
+        );
+      `);
+
+      const migrationNames = readdirSync(migrationsDir)
+        .filter((filename) => filename.endsWith('.sql') || filename.endsWith('.concurrent.ts'))
+        .sort()
+        .map((filename) => filename.replace(/\.sql$/, '').replace(/\.ts$/, ''));
+      const executorIndex = migrationNames.indexOf(migrationLedgerRepairExecutorName);
+      expect(executorIndex).toBeGreaterThan(0);
+
+      for (const [index, name] of migrationNames.slice(0, executorIndex).entries()) {
+        await client.query(
+          `insert into kortix_migrations.pgmigrations (name, run_on)
+           values ($1, $2::timestamptz)`,
+          [name, new Date(Date.UTC(2026, 6, 1, 0, 0, index)).toISOString()],
+        );
+      }
+      await client.query(
+        `insert into kortix_migrations.pgmigrations (name, run_on)
+         values
+           ('20260729181733802_sandbox_deadline', '2026-07-29T16:46:37.325Z'),
+           ('20260729181804675_sandbox_deadline_index.concurrent', '2026-07-29T16:46:39.752Z')`,
+      );
+    } finally {
+      await client.end();
+    }
+  });
+
+  afterAll(async () => {
+    await admin.query(`drop database if exists "${databaseName}" with (force)`);
+    await admin.end();
+  });
+
+  test('applies the missing migration and restores strict ledger order', async () => {
+    const runnerOptions = {
+      databaseUrl: databaseUrl?.toString(),
+      dir: migrationsDir,
+      migrationsTable: 'pgmigrations',
+      migrationsSchema: 'kortix_migrations',
+      createMigrationsSchema: true,
+      singleTransaction: true,
+      logger: console,
+    } as const;
+
+    const repaired = await repairMigrationLedger({
+      databaseUrl: databaseUrl?.toString() ?? '',
+      migrationsDir,
+      applyExecutorMigration: async () => {
+        await runner({
+          ...runnerOptions,
+          direction: 'up',
+          count: 1,
+          checkOrder: false,
+          file: migrationLedgerRepairExecutorName,
+        });
+      },
+    });
+
+    expect(repaired).toBe(true);
+    expect(
+      await repairMigrationLedger({
+        databaseUrl: databaseUrl?.toString() ?? '',
+        migrationsDir,
+        applyExecutorMigration: async () => {
+          throw new Error('already-repaired ledgers must not reapply migrations');
+        },
+      }),
+    ).toBe(false);
+
+    const pending = await runner({
+      ...runnerOptions,
+      direction: 'up',
+      count: Number.POSITIVE_INFINITY,
+      checkOrder: true,
+      dryRun: true,
+    });
+    const pendingNames = pending.map((migration) => migration.name);
+    expect(pendingNames).not.toContain(migrationLedgerRepairExecutorName);
+    expect(pendingNames).not.toContain('20260730000452547_sandbox_deadline');
+    expect(pendingNames).not.toContain('20260730000452600_sandbox_deadline_index.concurrent');
+
+    const client = new pg.Client({ connectionString: databaseUrl?.toString() });
+    await client.connect();
+    try {
+      const ledger = await client.query<{ name: string }>(
+        `select name
+           from kortix_migrations.pgmigrations
+          order by run_on, id`,
+      );
+      expect(ledger.rows.slice(-3).map((row) => row.name)).toEqual([
+        migrationLedgerRepairExecutorName,
+        '20260730000452547_sandbox_deadline',
+        '20260730000452600_sandbox_deadline_index.concurrent',
+      ]);
+
+      const columns = await client.query<{ count: number }>(
+        `select count(*)::int
+           from information_schema.columns
+          where table_schema = 'kortix'
+            and table_name like 'executor_%_policies'
+            and column_name = 'conditions'`,
+      );
+      expect(columns.rows[0]?.count).toBe(3);
+    } finally {
+      await client.end();
+    }
+  });
+});

--- a/packages/db/scripts/migration-ledger-repair.test.ts
+++ b/packages/db/scripts/migration-ledger-repair.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { type MigrationLedgerRow, planMigrationLedgerRepair } from './migration-ledger-repair';
+
+const LEGACY_SQL = '20260729181733802_sandbox_deadline';
+const LEGACY_INDEX = '20260729181804675_sandbox_deadline_index.concurrent';
+const CURRENT_SQL = '20260730000452547_sandbox_deadline';
+const EXECUTOR = '20260729215216867_executor_policy_arg_conditions';
+const RUN_ON = new Date('2026-07-29T16:46:37.325Z');
+
+function row(name: string, runOn = RUN_ON): MigrationLedgerRow {
+  return { name, runOn };
+}
+
+describe('planMigrationLedgerRepair', () => {
+  test('does nothing for a fresh or already-repaired ledger', () => {
+    expect(planMigrationLedgerRepair([])).toBeNull();
+    expect(planMigrationLedgerRepair([row(EXECUTOR), row(CURRENT_SQL)])).toBeNull();
+  });
+
+  test('plans the dev repair and identifies the missing executor migration', () => {
+    const plan = planMigrationLedgerRepair([
+      row(LEGACY_SQL),
+      row(LEGACY_INDEX, new Date('2026-07-29T16:46:39.752Z')),
+    ]);
+
+    expect(plan).toEqual({
+      executorMigrationIsMissing: true,
+      legacyRunOn: RUN_ON,
+      renames: [
+        { legacyName: LEGACY_SQL, currentName: CURRENT_SQL },
+        {
+          legacyName: LEGACY_INDEX,
+          currentName: '20260730000452600_sandbox_deadline_index.concurrent',
+        },
+      ],
+    });
+  });
+
+  test('does not reapply an executor migration that already exists', () => {
+    const plan = planMigrationLedgerRepair([row(EXECUTOR), row(LEGACY_SQL)]);
+
+    expect(plan?.executorMigrationIsMissing).toBe(false);
+    expect(plan?.renames).toEqual([{ legacyName: LEGACY_SQL, currentName: CURRENT_SQL }]);
+  });
+
+  test('rejects a ledger that contains both names for one migration', () => {
+    expect(() => planMigrationLedgerRepair([row(LEGACY_SQL), row(CURRENT_SQL)])).toThrow(
+      'contains both',
+    );
+  });
+
+  test('rejects a legacy index without its table migration', () => {
+    expect(() => planMigrationLedgerRepair([row(LEGACY_INDEX)])).toThrow(
+      'without its table migration',
+    );
+  });
+});

--- a/packages/db/scripts/migration-ledger-repair.ts
+++ b/packages/db/scripts/migration-ledger-repair.ts
@@ -1,0 +1,193 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import pg from 'pg';
+
+const EXECUTOR_POLICY_MIGRATION = {
+  name: '20260729215216867_executor_policy_arg_conditions',
+  filename: '20260729215216867_executor_policy_arg_conditions.sql',
+  sha256: 'd2e803a5957df0740fb348f93bab2b5f06609ed2f1c1b9cf8592c634d68066e4',
+} as const;
+
+const SANDBOX_DEADLINE_RENAMES = [
+  {
+    legacyName: '20260729181733802_sandbox_deadline',
+    currentName: '20260730000452547_sandbox_deadline',
+    filename: '20260730000452547_sandbox_deadline.sql',
+    sha256: '9230a593b5dad5d7e405b0271725f0dfaa09f98f7002a171d8edcdd4d00af392',
+  },
+  {
+    legacyName: '20260729181804675_sandbox_deadline_index.concurrent',
+    currentName: '20260730000452600_sandbox_deadline_index.concurrent',
+    filename: '20260730000452600_sandbox_deadline_index.concurrent.ts',
+    sha256: '3904ab96efd91f084296ee70a409b76407a36bf1a82859018e44496cc694c2b5',
+  },
+] as const;
+
+const REPAIR_NAMES = [
+  EXECUTOR_POLICY_MIGRATION.name,
+  ...SANDBOX_DEADLINE_RENAMES.flatMap(({ legacyName, currentName }) => [legacyName, currentName]),
+];
+
+export interface MigrationLedgerRow {
+  name: string;
+  runOn: Date;
+}
+
+export interface MigrationLedgerRepairPlan {
+  executorMigrationIsMissing: boolean;
+  legacyRunOn: Date;
+  renames: Array<{ legacyName: string; currentName: string }>;
+}
+
+export function planMigrationLedgerRepair(
+  rows: MigrationLedgerRow[],
+): MigrationLedgerRepairPlan | null {
+  const byName = new Map(rows.map((row) => [row.name, row]));
+  const renames = SANDBOX_DEADLINE_RENAMES.filter(({ legacyName }) => byName.has(legacyName)).map(
+    ({ legacyName, currentName }) => ({ legacyName, currentName }),
+  );
+
+  if (renames.length === 0) return null;
+
+  for (const rename of SANDBOX_DEADLINE_RENAMES) {
+    if (byName.has(rename.legacyName) && byName.has(rename.currentName)) {
+      throw new Error(
+        `Migration ledger contains both ${rename.legacyName} and ${rename.currentName}.`,
+      );
+    }
+  }
+
+  if (
+    byName.has(SANDBOX_DEADLINE_RENAMES[1].legacyName) &&
+    !byName.has(SANDBOX_DEADLINE_RENAMES[0].legacyName)
+  ) {
+    throw new Error(
+      'Migration ledger contains the legacy deadline index without its table migration.',
+    );
+  }
+
+  const legacyRunOn = renames
+    .map(({ legacyName }) => byName.get(legacyName)?.runOn)
+    .filter((runOn): runOn is Date => runOn instanceof Date)
+    .reduce((earliest, runOn) => (runOn < earliest ? runOn : earliest));
+
+  return {
+    executorMigrationIsMissing: !byName.has(EXECUTOR_POLICY_MIGRATION.name),
+    legacyRunOn,
+    renames,
+  };
+}
+
+function verifyRepairArtifacts(migrationsDir: string): void {
+  const artifacts = [EXECUTOR_POLICY_MIGRATION, ...SANDBOX_DEADLINE_RENAMES];
+  for (const artifact of artifacts) {
+    const path = join(migrationsDir, artifact.filename);
+    const actual = createHash('sha256').update(readFileSync(path)).digest('hex');
+    if (actual !== artifact.sha256) {
+      throw new Error(
+        `Migration ledger repair checksum mismatch for ${artifact.filename}: ${actual}.`,
+      );
+    }
+  }
+}
+
+async function readRepairRows(client: pg.Client): Promise<MigrationLedgerRow[]> {
+  const tableResult = await client.query<{ exists: boolean }>(
+    "select to_regclass('kortix_migrations.pgmigrations') is not null as exists",
+  );
+  if (!tableResult.rows[0]?.exists) return [];
+
+  const result = await client.query<{ name: string; run_on: Date }>(
+    `select name, run_on
+       from kortix_migrations.pgmigrations
+      where name = any($1::text[])
+      order by run_on, id`,
+    [REPAIR_NAMES],
+  );
+  return result.rows.map((row) => ({ name: row.name, runOn: row.run_on }));
+}
+
+async function inspectRepairPlan(databaseUrl: string): Promise<MigrationLedgerRepairPlan | null> {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    return planMigrationLedgerRepair(await readRepairRows(client));
+  } finally {
+    await client.end();
+  }
+}
+
+async function reconcileRepairPlan(databaseUrl: string): Promise<boolean> {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    await client.query('begin');
+    await client.query('lock table kortix_migrations.pgmigrations in exclusive mode');
+    const plan = planMigrationLedgerRepair(await readRepairRows(client));
+    if (!plan) {
+      await client.query('commit');
+      return false;
+    }
+    if (plan.executorMigrationIsMissing) {
+      throw new Error(
+        `Migration ledger repair requires ${EXECUTOR_POLICY_MIGRATION.name} to be applied first.`,
+      );
+    }
+
+    for (const { legacyName, currentName } of plan.renames) {
+      const result = await client.query(
+        `update kortix_migrations.pgmigrations
+            set name = $2
+          where name = $1
+            and not exists (
+              select 1
+                from kortix_migrations.pgmigrations
+               where name = $2
+            )`,
+        [legacyName, currentName],
+      );
+      if (result.rowCount !== 1) {
+        throw new Error(`Migration ledger repair could not rename ${legacyName}.`);
+      }
+    }
+
+    const orderResult = await client.query(
+      `update kortix_migrations.pgmigrations
+          set run_on = $2::timestamptz - interval '1 millisecond'
+        where name = $1`,
+      [EXECUTOR_POLICY_MIGRATION.name, plan.legacyRunOn.toISOString()],
+    );
+    if (orderResult.rowCount !== 1) {
+      throw new Error(
+        `Migration ledger repair could not reorder ${EXECUTOR_POLICY_MIGRATION.name}.`,
+      );
+    }
+
+    await client.query('commit');
+    return true;
+  } catch (error) {
+    await client.query('rollback');
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+export async function repairMigrationLedger(options: {
+  databaseUrl: string;
+  migrationsDir: string;
+  applyExecutorMigration: () => Promise<void>;
+}): Promise<boolean> {
+  const initialPlan = await inspectRepairPlan(options.databaseUrl);
+  if (!initialPlan) return false;
+
+  verifyRepairArtifacts(options.migrationsDir);
+  if (initialPlan.executorMigrationIsMissing) {
+    await options.applyExecutorMigration();
+  }
+
+  return reconcileRepairPlan(options.databaseUrl);
+}
+
+export const migrationLedgerRepairExecutorName = EXECUTOR_POLICY_MIGRATION.name;

--- a/packages/db/scripts/sandbox-deadline-trigger.integration.test.ts
+++ b/packages/db/scripts/sandbox-deadline-trigger.integration.test.ts
@@ -107,6 +107,17 @@ describe.skipIf(!dockerAvailable)('session_sandboxes anchor guard — real Postg
     if (!triggerAndCheck.includes('session_sandboxes_deadline_within_cap')) {
       throw new Error('migration text no longer contains the trigger + CHECK section');
     }
+    const repairMigration = await Bun.file(
+      resolve(
+        import.meta.dir,
+        '..',
+        'migrations',
+        '20260730064010447_repair_sandbox_deadline_guard.sql',
+      ),
+    ).text();
+    if (!repairMigration.includes('CREATE OR REPLACE FUNCTION')) {
+      throw new Error('repair migration no longer replaces the deadline guard');
+    }
 
     psql(`
       CREATE SCHEMA kortix;
@@ -127,6 +138,15 @@ describe.skipIf(!dockerAvailable)('session_sandboxes anchor guard — real Postg
         updated_at timestamptz NOT NULL DEFAULT now()
       );
       ${triggerAndCheck}
+
+      CREATE OR REPLACE FUNCTION kortix.session_sandboxes_anchor_guard()
+      RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        RETURN NEW;
+      END;
+      $$;
+
+      ${repairMigration}
     `);
   }, 60_000);
 


### PR DESCRIPTION
## Failure

Deploy Dev rejected migration 20260729215216867_executor_policy_arg_conditions because two already-applied sandbox deadline migrations were renamed past it.

## Change

- Reconcile the two known ledger names only after SHA-256 verification.
- Apply the missing executor policy migration before restoring strict migration order.
- Add a roll-forward migration for the final sandbox deadline trigger function.
- Keep the repair idempotent for fresh and repaired databases.

## Verification

- bun test packages/db/scripts/migration-ledger-repair.test.ts: 5 pass, 0 fail
- MIGRATION_REPAIR_ADMIN_URL set against local PostgreSQL; bun test packages/db/scripts/migration-ledger-repair.integration.test.ts: 1 pass, 0 fail
- bun test packages/db/scripts/sandbox-deadline-trigger.integration.test.ts: 30 pass, 0 fail
- pnpm --filter @kortix/db test: 160 pass, 3 intentional skips, 0 fail
- pnpm --filter @kortix/db typecheck: pass
- pnpm --filter @kortix/db lint: 109 migration files pass; 0 Squawk issues
- pnpm exec biome check on changed test and helper files: pass