### PR TITLE
fix(sdk): keep the session boot poll running while the tab is in the background

### DIFF
--- a/packages/sdk/src/react/use-session.test.ts
+++ b/packages/sdk/src/react/use-session.test.ts
@@ -75,6 +75,7 @@ import {
   sendStateOnError,
   shouldRetrySessionStart,
   shouldPollSessionStart,
+  SESSION_START_POLL_OPTIONS,
   SESSION_START_POLL_MS,
 } from './use-session';
 import {
@@ -554,5 +555,11 @@ describe('shouldPollSessionStart', () => {
   test('stops on a terminal client error, which polling cannot fix', () => {
     const err = new SessionStartError('gone', { status: 403, terminal: true });
     expect(shouldPollSessionStart(err, at('provisioning'))).toBe(false);
+  });
+});
+
+describe('SESSION_START_POLL_OPTIONS', () => {
+  test('keeps interval fetches active while the document is hidden', () => {
+    expect(SESSION_START_POLL_OPTIONS.refetchIntervalInBackground).toBe(true);
   });
 });

--- a/packages/sdk/src/react/use-session.test.ts
+++ b/packages/sdk/src/react/use-session.test.ts
@@ -74,6 +74,8 @@ import {
   sendStateOnStart,
   sendStateOnError,
   shouldRetrySessionStart,
+  shouldPollSessionStart,
+  SESSION_START_POLL_MS,
 } from './use-session';
 import {
   refreshSessionTitleQueryUntilResolved,
@@ -527,5 +529,30 @@ describe('shouldRetrySessionStart', () => {
     expect(shouldRetrySessionStart(0, transient, 'x')).toBe(true);
     expect(shouldRetrySessionStart(2, transient, 'x')).toBe(true);
     expect(shouldRetrySessionStart(3, transient, 'x')).toBe(false);
+  });
+});
+
+describe('shouldPollSessionStart', () => {
+  const at = (stage: string) => ({ stage }) as never;
+
+  test('keeps polling while the box is still coming up', () => {
+    expect(shouldPollSessionStart(null, at('provisioning'))).toBe(SESSION_START_POLL_MS);
+    expect(shouldPollSessionStart(null, at('starting'))).toBe(SESSION_START_POLL_MS);
+  });
+
+  test('a null payload (transient transport failure) still polls — the box did not go away', () => {
+    expect(shouldPollSessionStart(null, null)).toBe(SESSION_START_POLL_MS);
+    expect(shouldPollSessionStart(null, undefined)).toBe(SESSION_START_POLL_MS);
+  });
+
+  test('stops on every terminal stage', () => {
+    expect(shouldPollSessionStart(null, at('ready'))).toBe(false);
+    expect(shouldPollSessionStart(null, at('failed'))).toBe(false);
+    expect(shouldPollSessionStart(null, at('stopped'))).toBe(false);
+  });
+
+  test('stops on a terminal client error, which polling cannot fix', () => {
+    const err = new SessionStartError('gone', { status: 403, terminal: true });
+    expect(shouldPollSessionStart(err, at('provisioning'))).toBe(false);
   });
 });

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -112,6 +112,29 @@ export function shouldRetrySessionStart(
   return !isSessionStartError(error) && failureCount < 3;
 }
 
+/**
+ * Gap between `/start` polls. The server long-polls each tick, so this is the
+ * pause between holds, not the latency to observe `ready`.
+ */
+export const SESSION_START_POLL_MS = 1_500;
+
+/**
+ * Should the `/start` boot poll fire again, given the last tick's outcome?
+ * `false` = stop: a terminal stage, or a terminal client error that no amount
+ * of polling can fix. Everything else keeps polling — including a `null`
+ * payload from a transient transport failure, since the box is still coming up.
+ */
+export function shouldPollSessionStart(
+  error: unknown,
+  data: SessionStartResult | null | undefined,
+): number | false {
+  if (isSessionStartError(error)) return false;
+  const stage = data?.stage;
+  return stage === 'ready' || stage === 'failed' || stage === 'stopped'
+    ? false
+    : SESSION_START_POLL_MS;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Send-error classification. `send`/the reply actions below never throw for
 // back-compat (`send`) or so a host doesn't need a try/catch for the common
@@ -420,11 +443,24 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
       isSessionStartError(error) && error.status === 404
         ? FRESH_START_404_RETRY_DELAY_MS
         : Math.min(1000 * 2 ** failureCount, 5000),
-    refetchInterval: (q) => {
-      if (isSessionStartError(q.state.error)) return false;
-      const stage = (q.state.data as SessionStartResult | null | undefined)?.stage;
-      return stage === 'ready' || stage === 'failed' || stage === 'stopped' ? false : 1500;
-    },
+    refetchInterval: (q) =>
+      shouldPollSessionStart(q.state.error, q.state.data as SessionStartResult | null | undefined),
+    // Keep polling while the tab is in the background. React Query gates
+    // `refetchInterval` on its focus manager, which reads
+    // `document.visibilityState` — and that reads 'hidden' for a browser window
+    // merely COVERED by another app (Chrome's occlusion detection on macOS), not
+    // just for a switched-away tab. With the default (`false`) the sequence is:
+    // the first `/start` returns `provisioning` (normal — a box takes ~30s), the
+    // user looks at something else, the poll freezes on that answer, and the
+    // page sits on "Provisioning your computer" with the clock ticking long
+    // after the sandbox came up. Nothing downstream recovers it, because the
+    // runtime switch, the SSE stream and the queued-prompt hand-off all gate on
+    // `stage === 'ready'` — so a prompt typed during boot just sits in the
+    // stash. Only a reload (a first fetch is not focus-gated) or returning to
+    // the tab unsticks it. This poll is bounded: it stops itself as soon as the
+    // stage is terminal, so running it in the background costs a handful of
+    // requests, not battery.
+    refetchIntervalInBackground: true,
   });
   const startData = start.data ?? null;
   const startError = isSessionStartError(start.error) ? start.error : null;

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -135,6 +135,21 @@ export function shouldPollSessionStart(
     : SESSION_START_POLL_MS;
 }
 
+/**
+ * TanStack Query pauses interval fetches while the document is hidden unless
+ * this option is true. Session readiness must continue because it gates the
+ * runtime switch, event stream, and queued-prompt replay.
+ */
+export const SESSION_START_POLL_OPTIONS = {
+  refetchInterval: (query: {
+    state: {
+      error: unknown;
+      data: SessionStartResult | null | undefined;
+    };
+  }) => shouldPollSessionStart(query.state.error, query.state.data),
+  refetchIntervalInBackground: true,
+} as const;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Send-error classification. `send`/the reply actions below never throw for
 // back-compat (`send`) or so a host doesn't need a try/catch for the common
@@ -443,24 +458,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
       isSessionStartError(error) && error.status === 404
         ? FRESH_START_404_RETRY_DELAY_MS
         : Math.min(1000 * 2 ** failureCount, 5000),
-    refetchInterval: (q) =>
-      shouldPollSessionStart(q.state.error, q.state.data as SessionStartResult | null | undefined),
-    // Keep polling while the tab is in the background. React Query gates
-    // `refetchInterval` on its focus manager, which reads
-    // `document.visibilityState` — and that reads 'hidden' for a browser window
-    // merely COVERED by another app (Chrome's occlusion detection on macOS), not
-    // just for a switched-away tab. With the default (`false`) the sequence is:
-    // the first `/start` returns `provisioning` (normal — a box takes ~30s), the
-    // user looks at something else, the poll freezes on that answer, and the
-    // page sits on "Provisioning your computer" with the clock ticking long
-    // after the sandbox came up. Nothing downstream recovers it, because the
-    // runtime switch, the SSE stream and the queued-prompt hand-off all gate on
-    // `stage === 'ready'` — so a prompt typed during boot just sits in the
-    // stash. Only a reload (a first fetch is not focus-gated) or returning to
-    // the tab unsticks it. This poll is bounded: it stops itself as soon as the
-    // stage is terminal, so running it in the background costs a handful of
-    // requests, not battery.
-    refetchIntervalInBackground: true,
+    ...SESSION_START_POLL_OPTIONS,
   });
   const startData = start.data ?? null;
   const startError = isSessionStartError(start.error) ? start.error : null;


### PR DESCRIPTION
## What breaks

Open a session, look at something else while the sandbox provisions, come back. The page is still showing **"Provisioning your computer"** with the elapsed clock ticking — I've watched it reach 7 minutes — and any prompt typed during boot is sitting undelivered in the start-stash. Meanwhile the backend has the session `running`, the sandbox `active`, and the OpenCode pin resolved. A browser reload fixes it instantly, and the queued prompt fires and runs.

This is not a self-host quirk. Nothing in the mechanism depends on the deployment; it is just easiest to notice when provisioning is slow enough that you look away.

## Why

`useSession` drives `/start` purely through `refetchInterval`:

```ts
refetchInterval: (q) => {
  if (isSessionStartError(q.state.error)) return false;
  const stage = (q.state.data as SessionStartResult | null | undefined)?.stage;
  return stage === 'ready' || stage === 'failed' || stage === 'stopped' ? false : 1500;
},
```

React Query gates `refetchInterval` on its focus manager unless `refetchIntervalInBackground` is set, and the focus manager reads `document.visibilityState`. On macOS Chrome reports `hidden` for a window that is merely **covered by another application** — no tab switch required. So:

1. the first `/start` returns `provisioning` (normal — a box takes ~30s);
2. the window loses foreground, and the poll freezes on that answer;
3. `stage` stays `provisioning` indefinitely while the 1s boot clock in `session-starting-loader` keeps ticking — which is why the elapsed timer grows without bound;
4. the runtime switch, the SSE stream, and the queued-prompt hand-off all gate on `stage === 'ready'`, so none of them fire;
5. only a reload (a query's *first* fetch is not focus-gated) or refocusing the window recovers it.

Step 4 is what makes this more than cosmetic: the user's first message never leaves the browser.

## Evidence

Measured by wrapping `fetch` in the page and recording every `/start`:

**Before** — tab `hidden` throughout:

```
t=14.0s    REQ  POST …/start
t=14.1s    RES  200  stage=provisioning
t=14s…126s      no requests at all — UI timer still counting up
t=126.4s   document.visibilityState forced to 'visible'
t=127.1s   REQ  POST …/start?wait_ms=15000
t=127.2s   RES  200  stage=ready + external_id + opencode pin
                → the queued prompt was delivered and executed immediately
```

112 seconds with zero polls, ended only by making the document visible.

**After** — tab `hidden` for the entire run, no reload, no refocus:

```
t=40.0s    RES  200  stage=provisioning
t=46.4s    RES  200  stage=ready + external_id + opencode pin   (long-poll, 4.8s)
                → queued prompt delivered and executed
           poll stops here: 2 calls total
```

## The change

- `refetchIntervalInBackground: true` on that one query. The poll is **bounded** — it stops itself the moment the stage is terminal — so running it in the background costs a handful of requests, not battery. (Confirmed above: 2 calls total, then silence.)
- Extract the interval decision into `shouldPollSessionStart`, mirroring the existing `shouldRetrySessionStart` next to it, so the rule is testable rather than inline in the hook.

No behaviour change while the tab is focused.

## Tests

`packages/sdk/src/react/use-session.test.ts` — four cases on the extracted predicate:

- non-terminal stages (`provisioning`, `starting`) keep polling;
- a `null` payload (transient transport failure) keeps polling — the box didn't go away;
- all three terminal stages (`ready`, `failed`, `stopped`) stop;
- a terminal client error stops, since polling cannot fix a 4xx.
