### PR TITLE
fix: refresh session governance before provisioning

### DIFF
--- a/apps/api/src/__tests__/integration-session-create-required-connectors.test.ts
+++ b/apps/api/src/__tests__/integration-session-create-required-connectors.test.ts
@@ -4,14 +4,9 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import {
-  accounts,
-  executorConnectors,
-  projectSessions,
-  projects,
-  type Project,
-} from '@kortix/db';
+import { type Project, accounts, executorConnectors, projectSessions, projects } from '@kortix/db';
 import { and, eq } from 'drizzle-orm';
+import { loadProjectAgents } from '../projects/agents';
 import { createProjectSession } from '../projects/lib/sessions';
 import { db } from '../shared/db';
 
@@ -53,7 +48,6 @@ beforeAll(async () => {
       'agents:',
       '  support:',
       '    connectors: [project_records, user_records]',
-      '    connectors_required: [project_records, user_records]',
       '',
     ].join('\n'),
     'utf8',
@@ -105,6 +99,23 @@ beforeAll(async () => {
       authorizationStrategy: 'user',
     },
   ]);
+
+  await loadProjectAgents(project);
+  writeFileSync(
+    join(repository, 'kortix.yaml'),
+    [
+      'kortix_version: 2',
+      'default_agent: support',
+      'agents:',
+      '  support:',
+      '    connectors: [project_records, user_records]',
+      '    connectors_required: [project_records, user_records]',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  git(['add', 'kortix.yaml'], repository);
+  git(['commit', '-m', 'require connectors'], repository);
 });
 
 afterAll(async () => {
@@ -156,10 +167,7 @@ describe('createProjectSession required connector authorization gate', () => {
       .select({ sessionId: projectSessions.sessionId })
       .from(projectSessions)
       .where(
-        and(
-          eq(projectSessions.projectId, PROJECT_ID),
-          eq(projectSessions.sessionId, SESSION_ID),
-        ),
+        and(eq(projectSessions.projectId, PROJECT_ID), eq(projectSessions.sessionId, SESSION_ID)),
       );
     expect(rows).toEqual([]);
   });

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -260,7 +260,7 @@ function extractAgentsV2(raw: unknown, manifest: ParsedManifest, filename: strin
  */
 export async function loadProjectAgents(
   project: GitBackedProject,
-  opts?: { rethrowReadErrors?: boolean },
+  opts?: { forceRefresh?: boolean; rethrowReadErrors?: boolean },
 ): Promise<LoadedAgents> {
   const { readManifest, synthesizeBlankManifest } = await import('./triggers');
   let manifest: ParsedManifest | null;

--- a/apps/api/src/projects/git/files.ts
+++ b/apps/api/src/projects/git/files.ts
@@ -164,13 +164,14 @@ export async function readManifestFromRepo(
   project: GitBackedProject,
   candidatePaths: string[],
   ref?: string,
+  opts?: { forceRefresh?: boolean },
 ): Promise<{ path: string; content: string; sha: string; candidatePaths: string[] } | null> {
   const normalized = candidatePaths
     .map((p) => normalizeTreePath(p))
     .filter((p): p is string => !!p);
   if (normalized.length === 0) return null;
   const treeRef = validateRef(ref || project.defaultBranch);
-  const repoPath = await refreshMirror(project);
+  const repoPath = await refreshMirror(project, opts?.forceRefresh);
   // A pathspec-scoped ls-tree prints only the candidates present at this ref
   // (order-agnostic), so we pick the highest-priority one ourselves.
   const listed = await runGitCapture(['ls-tree', treeRef, '--', ...normalized], repoPath);

--- a/apps/api/src/projects/git/manifest-refresh.integration.test.ts
+++ b/apps/api/src/projects/git/manifest-refresh.integration.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { loadProjectAgents, requiredConnectorsForAgent } from '../agents';
+import type { GitBackedProject } from './types';
+
+const exec = promisify(execFile);
+
+let testRoot = '';
+let remotePath = '';
+let repositoryPath = '';
+let project: GitBackedProject;
+let previousCacheDir: string | undefined;
+let previousRefreshInterval: string | undefined;
+
+async function git(args: string[], cwd?: string): Promise<void> {
+  await exec('git', args, { cwd });
+}
+
+async function writeManifest(required: boolean): Promise<void> {
+  await writeFile(
+    join(repositoryPath, 'kortix.yaml'),
+    [
+      'kortix_version: 2',
+      'default_agent: support',
+      'agents:',
+      '  support:',
+      '    connectors: [required-check]',
+      ...(required ? ['    connectors_required: [required-check]'] : []),
+      '',
+    ].join('\n'),
+  );
+}
+
+beforeEach(async () => {
+  testRoot = await mkdtemp(join(tmpdir(), 'kortix-manifest-refresh-'));
+  remotePath = join(testRoot, 'remote.git');
+  repositoryPath = join(testRoot, 'repository');
+  previousCacheDir = process.env.KORTIX_GIT_CACHE_DIR;
+  previousRefreshInterval = process.env.KORTIX_GIT_REFRESH_INTERVAL_MS;
+  process.env.KORTIX_GIT_CACHE_DIR = join(testRoot, 'git-cache');
+  process.env.KORTIX_GIT_REFRESH_INTERVAL_MS = '3600000';
+
+  await mkdir(repositoryPath);
+  await git(['init', '--bare', remotePath]);
+  await git(['init', '--initial-branch=main', repositoryPath]);
+  await git(['config', 'user.name', 'Kortix Test'], repositoryPath);
+  await git(['config', 'user.email', 'test@kortix.invalid'], repositoryPath);
+  await writeManifest(false);
+  await git(['add', 'kortix.yaml'], repositoryPath);
+  await git(['commit', '-m', 'seed manifest'], repositoryPath);
+  await git(['remote', 'add', 'origin', remotePath], repositoryPath);
+  await git(['push', 'origin', 'main'], repositoryPath);
+  await git(['symbolic-ref', 'HEAD', 'refs/heads/main'], remotePath);
+
+  project = {
+    projectId: `manifest-refresh-${crypto.randomUUID()}`,
+    repoUrl: remotePath,
+    defaultBranch: 'main',
+    manifestPath: 'kortix.yaml',
+    gitAuthToken: 'local-test',
+  };
+});
+
+afterEach(async () => {
+  if (previousCacheDir === undefined) delete process.env.KORTIX_GIT_CACHE_DIR;
+  else process.env.KORTIX_GIT_CACHE_DIR = previousCacheDir;
+  if (previousRefreshInterval === undefined) delete process.env.KORTIX_GIT_REFRESH_INTERVAL_MS;
+  else process.env.KORTIX_GIT_REFRESH_INTERVAL_MS = previousRefreshInterval;
+  await rm(testRoot, { recursive: true, force: true });
+});
+
+describe('manifest refresh', () => {
+  test('a forced agent load observes a remote governance update during the cache interval', async () => {
+    const initial = await loadProjectAgents(project);
+    expect(requiredConnectorsForAgent('support', initial)).toEqual([]);
+
+    await writeManifest(true);
+    await git(['add', 'kortix.yaml'], repositoryPath);
+    await git(['commit', '-m', 'require connector'], repositoryPath);
+    await git(['push', 'origin', 'main'], repositoryPath);
+
+    const cached = await loadProjectAgents(project);
+    expect(requiredConnectorsForAgent('support', cached)).toEqual([]);
+
+    const refreshed = await loadProjectAgents(project, { forceRefresh: true } as never);
+    expect(requiredConnectorsForAgent('support', refreshed)).toEqual(['required-check']);
+  });
+});

--- a/apps/api/src/projects/git/manifest-refresh.integration.test.ts
+++ b/apps/api/src/projects/git/manifest-refresh.integration.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { loadProjectAgents, requiredConnectorsForAgent } from '../agents';
+import { refreshMirror } from './mirror';
 import type { GitBackedProject } from './types';
 
 const exec = promisify(execFile);
@@ -33,6 +34,13 @@ async function writeManifest(required: boolean): Promise<void> {
       '',
     ].join('\n'),
   );
+}
+
+async function pushRequiredManifest(): Promise<void> {
+  await writeManifest(true);
+  await git(['add', 'kortix.yaml'], repositoryPath);
+  await git(['commit', '-m', 'require connector'], repositoryPath);
+  await git(['push', 'origin', 'main'], repositoryPath);
 }
 
 beforeEach(async () => {
@@ -78,15 +86,22 @@ describe('manifest refresh', () => {
     const initial = await loadProjectAgents(project);
     expect(requiredConnectorsForAgent('support', initial)).toEqual([]);
 
-    await writeManifest(true);
-    await git(['add', 'kortix.yaml'], repositoryPath);
-    await git(['commit', '-m', 'require connector'], repositoryPath);
-    await git(['push', 'origin', 'main'], repositoryPath);
+    await pushRequiredManifest();
 
     const cached = await loadProjectAgents(project);
     expect(requiredConnectorsForAgent('support', cached)).toEqual([]);
 
-    const refreshed = await loadProjectAgents(project, { forceRefresh: true } as never);
+    const refreshed = await loadProjectAgents(project, { forceRefresh: true });
+    expect(requiredConnectorsForAgent('support', refreshed)).toEqual(['required-check']);
+  });
+
+  test('a forced refresh remains forced when a cached refresh already holds the lock', async () => {
+    await loadProjectAgents(project);
+    await pushRequiredManifest();
+
+    await Promise.all([refreshMirror(project), refreshMirror(project, true)]);
+
+    const refreshed = await loadProjectAgents(project);
     expect(requiredConnectorsForAgent('support', refreshed)).toEqual(['required-check']);
   });
 });

--- a/apps/api/src/projects/git/mirror.ts
+++ b/apps/api/src/projects/git/mirror.ts
@@ -16,7 +16,7 @@ import type { GitBackedProject } from './types';
 
 export const execFileAsync = promisify(execFile);
 
-const refreshLocks = new Map<string, Promise<string>>();
+const refreshLocks = new Map<string, { promise: Promise<string>; forced: boolean }>();
 const lastRefreshAt = new Map<string, number>();
 
 /**
@@ -428,7 +428,11 @@ async function doRefreshMirror(project: GitBackedProject, force = false) {
 
 export async function refreshMirror(project: GitBackedProject, force = false) {
   const current = refreshLocks.get(project.projectId);
-  if (current) return current;
+  if (current) {
+    if (!force || current.forced) return current.promise;
+    await current.promise;
+    return refreshMirror(project, true);
+  }
   const next = doRefreshMirror(project, force)
     .then(async (repoPath) => {
       // Bump the mirror dir's mtime on EVERY access (warm hits included) — the
@@ -438,8 +442,12 @@ export async function refreshMirror(project: GitBackedProject, force = false) {
       await utimes(repoPath, now, now).catch(() => {});
       return repoPath;
     })
-    .finally(() => refreshLocks.delete(project.projectId));
-  refreshLocks.set(project.projectId, next);
+    .finally(() => {
+      if (refreshLocks.get(project.projectId)?.promise === next) {
+        refreshLocks.delete(project.projectId);
+      }
+    });
+  refreshLocks.set(project.projectId, { promise: next, forced: force });
   return next;
 }
 

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -724,7 +724,10 @@ export async function createProjectSession(input: {
     };
   }
   if (runtimeAgent) agentName = runtimeAgent.name;
-  const loadedAgents = await loadProjectAgents(project);
+  const loadedAgents = await loadProjectAgents(project, {
+    forceRefresh: true,
+    rethrowReadErrors: true,
+  });
 
   const freeModelsOnly = config.KORTIX_BILLING_INTERNAL_ENABLED
     ? !tierGrantsAllModels(await getCachedAccountTier(accountId))

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -231,7 +231,7 @@ export interface LoadedTriggers {
  */
 export async function readManifest(
   project: GitBackedProject,
-  opts?: { rethrowReadErrors?: boolean },
+  opts?: { forceRefresh?: boolean; rethrowReadErrors?: boolean },
 ): Promise<ParsedManifest | null> {
   let found: Awaited<ReturnType<typeof readManifestFromRepo>>;
   try {
@@ -242,7 +242,9 @@ export async function readManifest(
     // per-agent env/connector scoping ON for a yaml-only project (a missing
     // `agents:` read = grants resolve to null = unrestricted).
     const candidates = manifestCandidatePaths(project.manifestPath).map((c) => c.path);
-    found = await readManifestFromRepo(project, candidates, project.defaultBranch);
+    found = await readManifestFromRepo(project, candidates, project.defaultBranch, {
+      forceRefresh: opts?.forceRefresh,
+    });
   } catch (err) {
     // `readManifestFromRepo` returns null for a genuinely ABSENT file and only
     // THROWS when the read itself failed (mirror refresh, git-proxy hop,


### PR DESCRIPTION
## Summary

- force a remote manifest refresh before session governance checks
- preserve forced refresh intent across an existing mirror refresh lock
- fail closed when session governance cannot read or parse the manifest
- cover stale cross-replica mirror behavior with real Git integration tests

## Verification

- `bun test --isolate --env-file=scripts/test.env src/projects/git/manifest-refresh.integration.test.ts src/projects/agents.test.ts` — 13 pass, 0 fail
- database-backed required connector session test — 1 pass, 0 fail
- `bun run typecheck` — exit 0
- `bash scripts/test.sh` — 4,837 pass, 57 skip, 0 fail across 476 files