### PR TITLE
fix(web): break the async import cycle between file-source and the project-files barrel

### DIFF
--- a/apps/web/src/features/files/file-source.test.ts
+++ b/apps/web/src/features/files/file-source.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// `workspaceFileSource` is a module constant, so every import in this file is read
+// at module-evaluation time. Pulling FilePathBreadcrumbs from the
+// `@/features/project-files` barrel drags the whole feature — and its
+// `@kortix/sdk/projects-client` leg, a webpack async module — into an import cycle
+// with `@/features/files`, which crashes SSR with
+// `Cannot read properties of undefined (reading 'A')` on every authenticated
+// project render. Keep the import concrete.
+test('file-source imports FilePathBreadcrumbs directly, never through the barrel', () => {
+  const source = readFileSync(join(import.meta.dir, 'file-source.tsx'), 'utf8');
+  expect(source).toContain("from '@/features/project-files/components/file-breadcrumbs'");
+  expect(source).not.toMatch(/from '@\/features\/project-files';/);
+});

--- a/apps/web/src/features/files/file-source.test.ts
+++ b/apps/web/src/features/files/file-source.test.ts
@@ -2,13 +2,9 @@ import { expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-// `workspaceFileSource` is a module constant, so every import in this file is read
-// at module-evaluation time. Pulling FilePathBreadcrumbs from the
-// `@/features/project-files` barrel drags the whole feature — and its
-// `@kortix/sdk/projects-client` leg, a webpack async module — into an import cycle
-// with `@/features/files`, which crashes SSR with
-// `Cannot read properties of undefined (reading 'A')` on every authenticated
-// project render. Keep the import concrete.
+// The project-files barrel re-enters features/files through useChangeRequests.
+// Keep this import concrete because workspaceFileSource reads it during module
+// evaluation.
 test('file-source imports FilePathBreadcrumbs directly, never through the barrel', () => {
   const source = readFileSync(join(import.meta.dir, 'file-source.tsx'), 'utf8');
   expect(source).toContain("from '@/features/project-files/components/file-breadcrumbs'");

--- a/apps/web/src/features/files/file-source.tsx
+++ b/apps/web/src/features/files/file-source.tsx
@@ -4,7 +4,19 @@ import type { FileSource } from '@/features/file-viewer';
 import { useFileContent } from './hooks';
 import { useBinaryBlob } from './hooks/use-binary-blob';
 import { downloadFile, uploadFile } from './api/runtime-files';
-import { FilePathBreadcrumbs } from '@/features/project-files';
+// Deliberately NOT `@/features/project-files` (the barrel). This module builds
+// `workspaceFileSource` as a module constant, so it READS every imported binding
+// at evaluation time — and the barrel re-exports the whole feature, including
+// change-request-detail-dialog -> `@kortix/sdk/projects-client`. That barrel also
+// comes back here via project-files/hooks/use-change-requests.ts ->
+// @/features/files/hooks/use-git-status, so the two form an import cycle.
+// Harmless on its own — except the SDK leg is a webpack ASYNC module
+// (`__webpack_require__.a`), which registers its re-export getters before its
+// `var` bindings are assigned. Evaluating the object literal below mid-cycle then
+// reads an unassigned binding and throws `Cannot read properties of undefined
+// (reading 'A')` during SSR on every authenticated project render. Importing the
+// component directly keeps the cycle out entirely.
+import { FilePathBreadcrumbs } from '@/features/project-files/components/file-breadcrumbs';
 
 /**
  * Live-workspace data source for the shared file viewer/modal. The hooks are

--- a/apps/web/src/features/files/file-source.tsx
+++ b/apps/web/src/features/files/file-source.tsx
@@ -4,18 +4,9 @@ import type { FileSource } from '@/features/file-viewer';
 import { useFileContent } from './hooks';
 import { useBinaryBlob } from './hooks/use-binary-blob';
 import { downloadFile, uploadFile } from './api/runtime-files';
-// Deliberately NOT `@/features/project-files` (the barrel). This module builds
-// `workspaceFileSource` as a module constant, so it READS every imported binding
-// at evaluation time — and the barrel re-exports the whole feature, including
-// change-request-detail-dialog -> `@kortix/sdk/projects-client`. That barrel also
-// comes back here via project-files/hooks/use-change-requests.ts ->
-// @/features/files/hooks/use-git-status, so the two form an import cycle.
-// Harmless on its own — except the SDK leg is a webpack ASYNC module
-// (`__webpack_require__.a`), which registers its re-export getters before its
-// `var` bindings are assigned. Evaluating the object literal below mid-cycle then
-// reads an unassigned binding and throws `Cannot read properties of undefined
-// (reading 'A')` during SSR on every authenticated project render. Importing the
-// component directly keeps the cycle out entirely.
+// Do not import this component through the project-files barrel. The barrel
+// reaches useGitStatus through useChangeRequests and re-enters features/files.
+// Webpack cannot evaluate that async cycle while building this module constant.
 import { FilePathBreadcrumbs } from '@/features/project-files/components/file-breadcrumbs';
 
 /**


### PR DESCRIPTION
## What breaks

Every server render of an authenticated project route throws:

```
 ⨯ TypeError: Cannot read properties of undefined (reading 'A')
   digest: '2151523997'
```

Three times per `/projects/[id]/customize` load. React treats it as a failed Suspense boundary — minified **error #419** in the browser console — and silently falls back to client-only rendering.

Because the page still works, this is easy to miss. What it actually costs: that whole subtree loses SSR on every visit, and the server log gets three identical unattributable stacks per page view.

## Root cause

Minified server chunks give unusable column offsets here, so I rebuilt once with `experimental.serverSourceMaps` and ran the server with `--enable-source-maps`. That resolves to:

```
at Object.AY (packages/sdk/src/core/rest/projects-client/files.ts:99)
at <unknown> (apps/web/src/features/files/file-source.tsx:19:3)
at 954762  (apps/web/src/features/files/file-source.tsx:14:17)
```

`file-source.tsx` builds `workspaceFileSource` as a **module constant** — its own comment says so — which means it reads every imported binding at module-evaluation time:

```ts
export const workspaceFileSource: FileSource = {
  useFileContent,
  useBinaryBlob,
  download: downloadFile,
  upload: uploadFile,
  Breadcrumbs: FilePathBreadcrumbs,   // ← read at eval time
};
```

And it reaches `FilePathBreadcrumbs` through the **barrel**, `@/features/project-files`, which re-exports the entire feature — including `change-request-detail-dialog` → `@kortix/sdk/projects-client`.

The other half of the cycle:

```
apps/web/src/features/project-files/hooks/use-change-requests.ts:26
  → import { gitStatusKeys } from '@/features/files/hooks/use-git-status';
```

So `features/files` ⇄ `features/project-files` is an import cycle. A plain ESM cycle here would be harmless — but the `@kortix/sdk/projects-client` leg makes the chain a webpack **async module** (`__webpack_require__.a`), and an async module registers its re-export getters *before* assigning its `var` bindings:

```js
c.a(a, async (a, d) => { try {
  c.d(b, { AY: () => g.A, … });   // getters registered here
  var e = c(483301), f = c(729659); … var g = c(706686);   // g assigned later
  … await …
```

Re-entered mid-cycle, `AY` exists but `g` is still `undefined`, so `g.A` throws exactly the error above.

## The change

Import the component from its own module instead of the barrel:

```diff
-import { FilePathBreadcrumbs } from '@/features/project-files';
+import { FilePathBreadcrumbs } from '@/features/project-files/components/file-breadcrumbs';
```

`file-breadcrumbs.tsx` imports only `react`, `lucide-react`, the files store, the tab store, `cn`, and a sibling `./file-icon` — nothing that re-enters either feature — so the cycle disappears rather than being papered over. One line, no behaviour change.

## Tests

`apps/web/src/features/files/file-source.test.ts` (new) asserts the import stays concrete and never returns to the bare barrel — this line looks like an untidy import and is exactly the kind of thing a later cleanup would "fix" back.

## Verification

Same page, same account, same navigation, production config (source maps were only the diagnostic, and are reverted):

| | server `⨯` per `/customize` load | client React #419 |
|---|---|---|
| before | 3 | every load |
| after | 0 | 0 |
