### PR TITLE
perf(web): make the project Files route open instantly instead of after 5–6s

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/files/files-route-contract.test.ts
+++ b/apps/web/src/app/(app)/projects/[id]/files/files-route-contract.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const WEB_ROOT = resolve(import.meta.dir, '../../../../../..');
+const SKELETON = resolve(
+  WEB_ROOT,
+  'src/features/workspace/project-layout/project-files-skeleton.tsx',
+);
+
+/** Modules too heavy to sit in the loading boundary's payload. */
+const HEAVY = ['@/features/project-files', '@/features/file-viewer'];
+
+/**
+ * The module specifiers a file actually imports — static and dynamic.
+ *
+ * Matching import specifiers rather than raw source text is deliberate. A bare
+ * `not.toContain('@/features/project-files')` cannot tell an import from a
+ * comment ABOUT imports, so it would fail the very doc comment that explains
+ * this rule to the next reader, and the only way to pass would be to make that
+ * comment vaguer. The test must constrain behaviour, not vocabulary.
+ */
+function importedSpecifiers(source: string): string[] {
+  return [
+    ...[...source.matchAll(/import\s[^;]*?from\s+'([^']+)'/g)].map((m) => m[1]),
+    ...[...source.matchAll(/import\s*\(\s*'([^']+)'\s*\)/g)].map((m) => m[1]),
+    // Side-effect import: `import '<specifier>';` — no `from`, so the first
+    // matcher above misses it entirely. Deliberately out of scope: double
+    // quotes, `export ... from`, and `require()`. This repo is single-quote
+    // and ESM-only by lint rule, so those forms don't occur here.
+    ...[...source.matchAll(/import\s+'([^']+)'/g)].map((m) => m[1]),
+  ];
+}
+
+function heavyImports(source: string): string[] {
+  return importedSpecifiers(source).filter((specifier) =>
+    HEAVY.some((heavy) => specifier === heavy || specifier.startsWith(`${heavy}/`)),
+  );
+}
+
+describe('files route loading boundary', () => {
+  test('the route has a loading.tsx navigation boundary', () => {
+    // Without it the click freezes the previous page, AND — because the project
+    // layout reads cookies(), making this route dynamic — Next.js has no
+    // cacheable target for the sidebar's prefetching Link.
+    expect(existsSync(resolve(import.meta.dir, 'loading.tsx'))).toBe(true);
+  });
+
+  test('the loading boundary imports no heavy module', () => {
+    const source = readFileSync(resolve(import.meta.dir, 'loading.tsx'), 'utf8');
+
+    expect(heavyImports(source)).toEqual([]);
+    expect(source).toContain('ProjectFilesSkeleton');
+  });
+
+  test('the shared skeleton imports no heavy module', () => {
+    // It renders inside the loading boundary. Importing the 9k-LOC barrel or
+    // the 1,877-LOC file viewer here would put the heavy chunk back on the
+    // critical path this boundary exists to cover.
+    const source = readFileSync(SKELETON, 'utf8');
+
+    expect(heavyImports(source)).toEqual([]);
+  });
+
+  test('the heavy-import detector actually detects', () => {
+    // Guards the guard: if the regex stops matching, the two tests above pass
+    // vacuously and the constraint silently disappears.
+    expect(heavyImports("import { X } from '@/features/project-files';")).toEqual([
+      '@/features/project-files',
+    ]);
+    expect(heavyImports("const m = await import('@/features/file-viewer/x');")).toEqual([
+      '@/features/file-viewer/x',
+    ]);
+    // Side-effect import — no `from` clause — used to be missed entirely,
+    // silently switching this constraint off for that import form.
+    expect(heavyImports("import '@/features/project-files/some-styles.css';")).toEqual([
+      '@/features/project-files/some-styles.css',
+    ]);
+    expect(heavyImports('// mentions @/features/project-files in prose only')).toEqual([]);
+  });
+});

--- a/apps/web/src/app/(app)/projects/[id]/files/loading.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/files/loading.tsx
@@ -1,0 +1,22 @@
+import { ProjectFilesSkeleton } from '@/features/workspace/project-layout/project-files-skeleton';
+
+/**
+ * Navigation Suspense boundary for /projects/[id]/files.
+ *
+ * Two jobs:
+ *  1. Paint Drive chrome the instant the click lands, instead of leaving the
+ *     previous page frozen while the RSC payload and route chunk arrive.
+ *  2. Give Next.js a cacheable prefetch target. This route is dynamic — the
+ *     project layout awaits cookies() — and for a dynamic route Next.js
+ *     prefetches only as far as the nearest loading boundary. Without this
+ *     file the sidebar's `<Link prefetch>` has nothing to store.
+ *
+ * The wrapper div mirrors `page.tsx` so the handover does not shift layout.
+ */
+export default function ProjectFilesLoading() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <ProjectFilesSkeleton />
+    </div>
+  );
+}

--- a/apps/web/src/features/project-files/components/file-explorer-page.tsx
+++ b/apps/web/src/features/project-files/components/file-explorer-page.tsx
@@ -89,13 +89,25 @@ export function FileExplorerPage({ embedded = false }: { embedded?: boolean } = 
 
   const { downloadDir, isDownloading: isDirDownloading } = useDirectoryDownload();
 
-  const [showSkeleton, setShowSkeleton] = useState(false);
+  // Seeded from isLoading, not false: the route's loading.tsx has already
+  // painted a skeleton by the time this mounts, so starting at false renders an
+  // empty body for 200ms right where the user is looking. Seeding also avoids a
+  // one-frame skeleton flash when the listing is already cached (isLoading
+  // false on mount). The 200ms anti-flicker delay is for REFETCHES only.
+  const hasLoadedOnce = useRef(false);
+  const [showSkeleton, setShowSkeleton] = useState(isLoading);
   useEffect(() => {
-    if (isLoading) {
-      const timer = setTimeout(() => setShowSkeleton(true), 200);
-      return () => clearTimeout(timer);
+    if (!isLoading) {
+      hasLoadedOnce.current = true;
+      setShowSkeleton(false);
+      return;
     }
-    setShowSkeleton(false);
+    if (!hasLoadedOnce.current) {
+      setShowSkeleton(true);
+      return;
+    }
+    const timer = setTimeout(() => setShowSkeleton(true), 200);
+    return () => clearTimeout(timer);
   }, [isLoading]);
 
   const isRootPath = currentPath === '/' || currentPath === '.' || currentPath === '';

--- a/apps/web/src/features/workspace/project-layout/project-files-skeleton.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-files-skeleton.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+/**
+ * Drive chrome placeholder for the standalone Files page.
+ *
+ * Shared by `projects/[id]/files/loading.tsx` (the navigation Suspense
+ * boundary) and `ProjectFilesView`'s pre-ref state, so the two can never
+ * disagree about layout and the paint does not shift as one hands over to the
+ * other.
+ *
+ * Deliberately imports nothing from `@/features/project-files` (9,291 LOC) or
+ * `@/features/file-viewer` (1,877 LOC): this renders inside the loading
+ * boundary, so anything imported here lands in the very payload that is
+ * supposed to arrive first. `files-route-contract.test.ts` enforces it by
+ * inspecting import specifiers, so naming those modules here is safe.
+ */
+export function ProjectFilesSkeleton() {
+  return (
+    <div className="bg-background flex h-full flex-col" data-slot="project-files-skeleton">
+      {/* DriveHeader — h-12 with a bottom border, matching drive-header.tsx */}
+      <div className="border-border/40 flex h-12 shrink-0 items-center gap-2 border-b px-3">
+        <Skeleton className="size-7 rounded-md" />
+        <Skeleton className="h-4 w-28 rounded" />
+        <div className="ml-auto flex items-center gap-2">
+          <Skeleton className="size-7 rounded-md" />
+          <Skeleton className="size-7 rounded-md" />
+        </div>
+      </div>
+
+      {/* DriveToolbar — breadcrumbs on the left, version selector on the right */}
+      <div className="border-border/40 flex h-10 shrink-0 items-center gap-2 border-b px-3">
+        <Skeleton className="h-4 w-20 rounded" />
+        <Skeleton className="size-3 rounded" />
+        <Skeleton className="h-4 w-24 rounded" />
+        <div className="ml-auto flex items-center gap-2">
+          <Skeleton className="h-7 w-24 rounded-md" />
+          <Skeleton className="size-7 rounded-md" />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-1 p-4">
+        {Array.from({ length: 10 }).map((_, index) => (
+          <Skeleton key={index} className="h-10 w-full rounded" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/workspace/project-layout/project-files-view.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-files-view.tsx
@@ -7,7 +7,7 @@
  * member can open, so it lives outside customization entirely).
  */
 
-import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorState } from '@/features/layout/section/error-state';
 import {
   FileExplorerPage,
   FileExplorerSourceProvider,
@@ -19,33 +19,55 @@ import {
 import { getProject } from '@kortix/sdk';
 import { useQuery } from '@tanstack/react-query';
 
+import { ProjectFilesSkeleton } from './project-files-skeleton';
+import { resolveFilesRef } from './resolve-files-ref';
+
 export function ProjectFilesView({ projectId }: { projectId: string }) {
+  // `['project', id]` is the canonical getProject cache slot — the same one
+  // `useProjectCan` reads (lib/use-project-can.ts:55). The sidebar's Files
+  // entry calls that hook to decide whether to render itself, so this slot is
+  // already populated before the user can click through: first render reads it
+  // synchronously instead of paying a second round trip for identical data.
+  // This view used to own a private `['projects', id, 'meta']` key, which made
+  // that duplicate fetch unavoidable and blocked the whole page behind it.
   const projectQuery = useQuery({
-    queryKey: ['projects', projectId, 'meta'],
+    queryKey: ['project', projectId],
     queryFn: () => getProject(projectId),
+    enabled: !!projectId,
     staleTime: 60_000,
   });
 
   const selectedVersion = useSelectedVersion(projectId);
+  const { ref, defaultBranch, ready } = resolveFilesRef({
+    selectedVersion,
+    project: projectQuery.data,
+  });
 
-  if (projectQuery.isLoading || !projectQuery.data) {
-    return (
-      <div className="flex h-full flex-col">
-        <div className="border-border/40 h-12 border-b" />
-        <div className="space-y-2 p-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Skeleton key={i} className="h-10 w-full rounded" />
-          ))}
-        </div>
-      </div>
-    );
+  // Only the ref is a hard prerequisite (useFileList gates on `enabled: !!ref`).
+  // Everything else the explorer needs it fetches itself, and it renders its own
+  // inner list skeleton, so there is no reason to withhold the Drive chrome.
+  //
+  // But `!ready` is not always "still loading": with no persisted version
+  // selection, `ref` depends entirely on `getProject` resolving. If that query
+  // errors (network failure, 403, ...), `ready` stays false forever with no way
+  // out — the skeleton above would spin indefinitely. Surface the error instead
+  // once there is no usable ref to fall back on.
+  if (!ready) {
+    if (projectQuery.isError) {
+      return (
+        <ErrorState
+          title="Failed to load project"
+          description={
+            projectQuery.error instanceof Error ? projectQuery.error.message : undefined
+          }
+        />
+      );
+    }
+    return <ProjectFilesSkeleton />;
   }
 
-  const defaultBranch = projectQuery.data.default_branch;
-  const activeRef = selectedVersion ?? defaultBranch;
-
   return (
-    <ProjectFilesProvider value={{ projectId, ref: activeRef, defaultBranch }}>
+    <ProjectFilesProvider value={{ projectId, ref, defaultBranch }}>
       <FileExplorerSourceProvider value={gitRefExplorerSource}>
         <FilesStoreProvider>
           <FileExplorerPage />

--- a/apps/web/src/features/workspace/project-layout/resolve-files-ref.test.ts
+++ b/apps/web/src/features/workspace/project-layout/resolve-files-ref.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveFilesRef } from './resolve-files-ref';
+
+describe('resolveFilesRef', () => {
+  test('a persisted version selection wins over the default branch', () => {
+    const result = resolveFilesRef({
+      selectedVersion: 'feature/x',
+      project: { default_branch: 'main' },
+    });
+
+    expect(result.ref).toBe('feature/x');
+    expect(result.defaultBranch).toBe('main');
+    expect(result.ready).toBe(true);
+  });
+
+  test('falls back to the default branch when nothing is selected', () => {
+    const result = resolveFilesRef({
+      selectedVersion: undefined,
+      project: { default_branch: 'main' },
+    });
+
+    expect(result.ref).toBe('main');
+    expect(result.defaultBranch).toBe('main');
+    expect(result.ready).toBe(true);
+  });
+
+  test('is ready from a selection alone, before the project fetch resolves', () => {
+    // The perf-critical case. A persisted selection is enough to mount the
+    // provider and let useFileList fire, so the listing must not wait on
+    // getProject.
+    const result = resolveFilesRef({ selectedVersion: 'feature/x', project: undefined });
+
+    expect(result.ref).toBe('feature/x');
+    expect(result.defaultBranch).toBe('');
+    expect(result.ready).toBe(true);
+  });
+
+  test('is not ready when neither a selection nor a project is available', () => {
+    const result = resolveFilesRef({ selectedVersion: undefined, project: undefined });
+
+    expect(result.ref).toBe('');
+    expect(result.ready).toBe(false);
+  });
+
+  test('treats an empty selected version as absent', () => {
+    // The version store deletes its key rather than storing '', but a stale
+    // persisted payload could hold one, and an empty ref would permanently
+    // disable useFileList's `enabled: !!ref` gate.
+    const result = resolveFilesRef({
+      selectedVersion: '',
+      project: { default_branch: 'main' },
+    });
+
+    expect(result.ref).toBe('main');
+    expect(result.ready).toBe(true);
+  });
+
+  test('is not ready when the project reports an empty default branch', () => {
+    const result = resolveFilesRef({
+      selectedVersion: undefined,
+      project: { default_branch: '' },
+    });
+
+    expect(result.ready).toBe(false);
+  });
+});

--- a/apps/web/src/features/workspace/project-layout/resolve-files-ref.ts
+++ b/apps/web/src/features/workspace/project-layout/resolve-files-ref.ts
@@ -1,0 +1,40 @@
+/**
+ * Resolve the git ref the standalone Files view reads from.
+ *
+ * Split out of `ProjectFilesView` because `ready` is the whole point of Fix C:
+ * `useFileList` gates on `enabled: !!projectId && !!ref && !!dirPath &&
+ * options?.enabled !== false` (src/features/project-files/hooks/use-file-list.ts:31),
+ * so the directory listing cannot start until a ref exists. A persisted version
+ * selection alone is enough to produce one — the project fetch is needed only
+ * for the default-branch fallback — so the view must not block the listing on
+ * `getProject` when a selection is already known.
+ */
+
+export interface ResolveFilesRefInput {
+  /** Persisted per-project Version selection, from `useSelectedVersion`. */
+  selectedVersion: string | undefined;
+  /** Canonical project meta, once the `['project', id]` cache slot has it. */
+  project: { default_branch: string } | undefined;
+}
+
+export interface ResolvedFilesRef {
+  /** The ref to read files from. Empty string means "not resolvable yet". */
+  ref: string;
+  /** The project's default branch, or '' while unknown. Change-request and
+   *  version UI compare against it to tell "on main" from "on a version". */
+  defaultBranch: string;
+  /** True once `ref` is usable, i.e. safe to mount `ProjectFilesProvider`. */
+  ready: boolean;
+}
+
+export function resolveFilesRef({
+  selectedVersion,
+  project,
+}: ResolveFilesRefInput): ResolvedFilesRef {
+  const defaultBranch = project?.default_branch ?? '';
+  // `||` not `??`: an empty-string ref is not a usable ref, and treating one as
+  // present would leave useFileList disabled forever.
+  const ref = selectedVersion || defaultBranch;
+
+  return { ref, defaultBranch, ready: ref !== '' };
+}

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-customize-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-customize-nav.tsx
@@ -2,17 +2,17 @@
 
 import { Config } from '@mynaui/icons-react';
 import { FolderOpen } from 'lucide-react';
-import { useParams, usePathname, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useParams, usePathname } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
 
-import Hint from '@/components/ui/hint';
+import { Kbd, KbdGroup } from '@/components/ui/kbd';
 import { SidebarMenuButton, SidebarMenuItem, useSidebar } from '@/components/ui/sidebar';
+import { useDevice } from '@/hooks/use-device';
+import { useIsMobile } from '@/hooks/utils';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { useProjectCan } from '@/lib/use-project-can';
-import { useIsMobile } from '@/hooks/utils';
 import { useCustomizeStore } from '@/stores/customize-store';
-import { Kbd, KbdGroup } from '@/components/ui/kbd';
-import { useDevice } from '@/hooks/use-device';
 
 export function useCustomizeActivate() {
   const openCustomize = useCustomizeStore((s) => s.openCustomize);
@@ -23,23 +23,6 @@ export function useCustomizeActivate() {
     openCustomize();
     if (isMobile) setOpenMobile(false);
   }, [openCustomize, isMobile, setOpenMobile]);
-}
-
-/** Navigate to the standalone Files page. Files live OUTSIDE customization
- *  (accessible to any member), so this is a top-level route, not a section of
- *  the Customize overlay. */
-export function useFilesActivate() {
-  const router = useRouter();
-  const params = useParams<{ id: string }>();
-  const projectId = params?.id;
-  const isMobile = useIsMobile();
-  const { setOpenMobile } = useSidebar();
-
-  return useCallback(() => {
-    if (!projectId) return;
-    router.push(`/projects/${projectId}/files`);
-    if (isMobile) setOpenMobile(false);
-  }, [router, projectId, isMobile, setOpenMobile]);
 }
 
 /** Mod+, — open the customize overlay (same as the sidebar button). */
@@ -89,56 +72,52 @@ export function ProjectCustomizeNavItem() {
   );
 }
 
-export function ProjectCustomizeRailItem() {
-  const onClick = useCustomizeActivate();
-
-  return (
-    <Hint label="Customize">
-      <SidebarMenuButton type="button" aria-label="Customize" onClick={onClick}>
-        <Config className="size-4.5!" />
-      </SidebarMenuButton>
-    </Hint>
-  );
-}
-
-/** Top-level Files entry — sits ABOVE Customize (files aren't part of
- *  customization). Hidden when the caller lacks `project.file.read`: that leaf
- *  is editor-tier (IAM v1 moved the sensitive file/secret reads off the floor
- *  `member` role), so showing it to a plain member would just land them on a
- *  page whose every read 403s. Optimistic while the probe loads — the entry
- *  only disappears on an explicit deny. */
+/**
+ * Top-level Files entry — sits ABOVE Customize (files aren't part of
+ * customization). Hidden when the caller lacks `project.file.read`: that leaf
+ * is editor-tier (IAM v1 moved the sensitive file/secret reads off the floor
+ * `member` role), so showing it to a plain member would just land them on a
+ * page whose every read 403s. Optimistic while the probe loads — the entry
+ * only disappears on an explicit deny.
+ *
+ * A real `<Link prefetch>`, not `router.push`. The button form could not be
+ * prefetched, so every click paid for the route's RSC payload AND its JS chunk
+ * cold — the bulk of a 5-6s open. `prefetch` needs `files/loading.tsx` to have
+ * something to cache, because the project layout awaits cookies() and the
+ * route is therefore dynamic. Note this is production-only behaviour: Next
+ * disables Link prefetching under `next dev`.
+ */
 export function ProjectFilesNavItem() {
-  const onClick = useFilesActivate();
   const pathname = usePathname();
   const params = useParams<{ id: string }>();
-  const canReadFiles = useProjectCan(params?.id, PROJECT_ACTIONS.PROJECT_FILE_READ);
+  const projectId = params?.id;
+  const isMobile = useIsMobile();
+  const { setOpenMobile } = useSidebar();
+  const canReadFiles = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_FILE_READ);
   const isActive = !!pathname && /^\/projects\/[^/]+\/files(\/|$)/.test(pathname);
 
+  const handleClick = useCallback(() => {
+    if (isMobile) setOpenMobile(false);
+  }, [isMobile, setOpenMobile]);
+
   if (!canReadFiles.allowed && !canReadFiles.isLoading) return null;
+  // No project id means no valid href. The old onClick already no-op'd in this
+  // case, so rendering a dead button was never useful.
+  if (!projectId) return null;
 
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
-        onClick={onClick}
+        asChild
         isActive={isActive}
         tooltip="Files"
         className="text-sm! font-medium [&_svg]:size-4! flex items-center gap-2"
       >
-        <FolderOpen />
-        Files
+        <Link href={`/projects/${projectId}/files`} prefetch onClick={handleClick}>
+          <FolderOpen />
+          Files
+        </Link>
       </SidebarMenuButton>
     </SidebarMenuItem>
-  );
-}
-
-export function ProjectFilesRailItem() {
-  const onClick = useFilesActivate();
-
-  return (
-    <Hint label="Files">
-      <SidebarMenuButton type="button" aria-label="Files" onClick={onClick}>
-        <FolderOpen className="size-4.5!" />
-      </SidebarMenuButton>
-    </Hint>
   );
 }

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-files-nav-contract.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-files-nav-contract.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SOURCE = readFileSync(resolve(import.meta.dir, 'project-customize-nav.tsx'), 'utf8');
+
+/** The ProjectFilesNavItem function body, isolated from its neighbours. */
+function filesNavItemSource(): string {
+  const start = SOURCE.indexOf('export function ProjectFilesNavItem');
+  expect(start).toBeGreaterThan(-1);
+  const after = SOURCE.indexOf('export function', start + 1);
+  return after === -1 ? SOURCE.slice(start) : SOURCE.slice(start, after);
+}
+
+describe('project Files sidebar entry', () => {
+  test('navigates with a prefetching Link, not router.push', () => {
+    // A button + router.push cannot be prefetched, so every click paid for the
+    // RSC payload and the route chunk cold. Reverting to router.push silently
+    // restores a 5-6s navigation; this test is the tripwire.
+    const navItem = filesNavItemSource();
+
+    expect(navItem).toContain('<Link');
+    // toContain('prefetch') alone is vacuous: `prefetch={false}` also contains
+    // the substring "prefetch" and would pass, silently restoring the 5-6s
+    // navigation this test exists to prevent. Require the bare/enabled form and
+    // explicitly reject the disabled form.
+    expect(navItem).toMatch(/prefetch(\s|>|$)/);
+    expect(navItem).not.toContain('prefetch={false}');
+    // href was previously unasserted, so `<Link href="#">` would have passed.
+    expect(navItem).toMatch(/href=\{`\/projects\/\$\{projectId\}\/files`\}/);
+    expect(navItem).toContain('asChild');
+    expect(navItem).not.toContain('router.push');
+  });
+
+  test('still hides itself for callers without project.file.read', () => {
+    const navItem = filesNavItemSource();
+
+    expect(navItem).toContain('PROJECT_FILE_READ');
+    expect(navItem).toContain('!canReadFiles.allowed && !canReadFiles.isLoading');
+  });
+
+  test('still closes the mobile drawer on navigate', () => {
+    const navItem = filesNavItemSource();
+
+    expect(navItem).toContain('setOpenMobile(false)');
+  });
+
+  test('does not retain the router.push helper the rail used', () => {
+    // useFilesActivate was the unprefetchable path. Its last consumer
+    // (ProjectFilesRailItem) is dead code, so keeping it around would just
+    // leave a trap for the next editor.
+    expect(SOURCE).not.toContain('useFilesActivate');
+    expect(SOURCE).not.toContain('ProjectFilesRailItem');
+  });
+});


### PR DESCRIPTION
## Summary

Clicking **Files** in the project sidebar took 5–6 seconds to show the file list. Customize sits directly below it in the same sidebar group and opens instantly, because it is a Zustand store flip with no navigation at all. Files was a route push with nothing prefetched. Same visual weight, two completely different cost classes.

Three serial causes, each fixed:

**1. The Files entry could not be prefetched.** It was a `<button>` calling `router.push`. A repo-wide grep for `router.prefetch` and `prefetch=` across `apps/web` returned zero hits, so every click paid for the route's RSC payload *and* its JS chunk cold. It is now a real `<Link prefetch>` rendered through `SidebarMenuButton asChild`, the pattern already used in `project-sidebar.tsx`.

**2. The route had no `loading.tsx`.** The click left the previous page frozen with no feedback. The new boundary paints Drive chrome immediately — and because this route is dynamic (the project layout awaits `cookies()`), it is also what gives Next.js a cacheable prefetch target: for a dynamic route Next prefetches only as far as the nearest loading boundary. Without it, a prefetching `Link` has nothing to store.

**3. A duplicate `getProject` blocked the whole page, and the file listing was serialized behind it.** `ProjectFilesView` fetched `getProject` under its own `['projects', id, 'meta']` key and showed a full-page skeleton until it resolved. `useFileList` gates on `enabled: !!ref`, and `ref` came from that fetch. But `['project', id]` is the canonical `getProject` slot, `lib/use-project-can.ts` already reads it, and the sidebar's Files entry calls `useProjectCan` to decide whether to render itself — so that slot is **already warm before the user can click through**. Reading it means `default_branch` is there on first render and `listFiles` fires on render 1. Two sequential round trips become zero.

Also fixed, and only visible once the boundary existed: `FileExplorerPage` delayed its own list skeleton by 200 ms as anti-flicker, so the sequence became boundary skeleton → **empty body for 200 ms** → inner skeleton → rows. `showSkeleton` is now seeded from `isLoading`; the delay applies to refetches only.

Two cleanups fall out of this. `useFilesActivate`, `ProjectFilesRailItem` and `ProjectCustomizeRailItem` are deleted — all three were unreferenced (the icon rail went away when the sidebar became offcanvas) and `ProjectFilesRailItem` was the last consumer of the `router.push` path, so leaving them would keep the slow path as a trap. And `ProjectFilesView` now renders `ErrorState` instead of an infinite skeleton when `getProject` errors or 403s.

### One fix was reverted after measuring it

A fifth change moved five closed-on-arrival modules (`FilePreviewModal`, both side panels, the change-request dialog, the history popover) behind `next/dynamic`, to get `@pierre/diffs` and `@/features/file-viewer` (1,877 LOC) out of the route's initial chunk. Reading `.next/app-build-manifest.json` showed it achieved nothing:

| Route entry | Initial JS chunks | Size | `@pierre/diffs` | file viewer |
| --- | --- | --- | --- | --- |
| `projects/[id]/layout` | 70 | 9,892 kB | yes | yes |
| `projects/[id]/page` — where the click starts | 48 | 7,966 kB | yes | yes |
| `projects/[id]/files/page` | 38 | 4,642 kB | yes | yes |
| `projects/[id]/files/loading` | 5 | 631 kB | no | no |

Both modules enter through the **shared project layout** (`ProjectShell` → `features/session/{session-diff-viewer, tool/shared/infrastructure, patch-helpers, write-tool}` → `diff-view`), so they are already downloaded and evaluated before the click. `next/dynamic` cannot defer a module another static path reaches. That change is reverted; the spec records the table and the reachability path so nobody repeats it. The blank-frame fix was the one genuinely useful piece of it and is kept.

### Scope

Deliberately narrow. Untouched: the other `getProject` call sites, `['project-access-boundary', id]` (it needs its own `retry: false` / `showErrors: false` to observe 403/404 for access states), intercepting routes, and server-side `/files` latency.

Two follow-ups this measurement exposed, written into the spec, not addressed here:
- `projects/[id]/layout` ships **9,892 kB across 70 initial chunks to every project route**. That is the real bundle problem on this surface.
- `['project-detail', id]` is written by **two different `queryFn`s** (`getProjectDetail` *and* `getProject`), so its cached shape depends on which observer mounts first. Latent bug, 15 call sites.

Closes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

**Automated**

- `cd apps/web && bun test` → **2,546 pass, 0 fail, 7,361 assertions, 289 files.** Run again after rebasing onto `origin/main`; same result.
- `npx tsc --noEmit` → no errors in any of the 9 touched files. (This package emits ~1,500 pre-existing bogus `TS2786` errors from a React 19↔18 types mismatch; output was grepped for the touched files.)
- `npx eslint` → clean on all 9 touched files.
- `pnpm build` → compiles. Note it needs `NODE_OPTIONS=--max-old-space-size=12288`; the default Node heap OOMs with `Ineffective mark-compacts near heap limit`.

**14 new tests across 3 files**

- `resolve-files-ref.test.ts` — unit tests the ref rule, including the perf-critical case: a persisted version selection alone is enough to mount the provider, so the listing does not wait on `getProject`. Also pins the `||`-not-`??` fallback, since an empty-string ref would leave `useFileList`'s gate disabled forever.
- `project-files-nav-contract.test.ts` — regression tripwire on the nav entry. Asserts the rendered `href` and explicitly rejects `prefetch={false}`, because a bare check for the substring `prefetch` passes on it and would silently restore the whole 5–6 s regression.
- `files-route-contract.test.ts` — enforces that the loading boundary and its skeleton import neither the `project-files` barrel nor the file viewer. It parses import specifiers instead of matching raw source, so a comment that names those modules does not fail the test, and it carries a self-check proving the detector still detects.

**Not verified**

Live click-to-first-row timing. It needs a reachable API and the local one on `:8008` was down, so the 5–6 s figure and any improvement on it are **unmeasured**. The fixes rest on mechanism plus the chunk-graph and query-cache evidence above, not a stopwatch.

Reviewers should also know **Fix 1 does nothing under `pnpm dev`** — Next disables `<Link>` prefetching in development. Judge it on a production build or on `dev.kortix.com`, not locally in dev mode.

To check it by hand:

```bash
cd apps/web && NODE_OPTIONS=--max-old-space-size=12288 pnpm build && pnpm start
```

Open a project, click **Files**, watch the network panel. Two things prove the fixes fired: only **one** `GET /v1/projects/:id` instead of two, and a prefetch request for the files route *before* the click.

## Security & data review

- [x] No secrets, keys, or credentials are committed (diff grepped for `encrypted:`, private-key headers and API-key patterns; 0 matches)
- [x] Authorization checks are in place for any new/changed endpoints (no endpoints added or changed; the sidebar entry keeps its `project.file.read` gate via `useProjectCan`, asserted by a contract test)
- [x] User input is validated and output is safe (no new user input; the only new value is a route `href` built from the existing `params.id`)
- [x] No sensitive data is written to logs (no logging added)
- [x] DB schema / migration changes are reviewed and reversible (none — no migrations, no schema changes)
- [x] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner (none touched; the permission gate is preserved, not modified)

## Rollout / rollback

No migrations, no feature flags, no env vars. Frontend-only, `apps/web`.

Revert is a plain `git revert` of the range — the five commits are independent and each stands alone. The only behavioural coupling worth knowing: reverting the `loading.tsx` commit while keeping the blank-frame commit would leave the inner skeleton showing immediately with nothing before it, which is harmless but no longer the case that fix was written for.

One accepted trade to be aware of on rollout: the boundary skeleton shows list-shaped rows while the default `viewMode` is `grid`, so a grid-mode user sees one shape change. `loading.tsx` renders before hydration and cannot read the persisted `localStorage` `viewMode`, so this is by design.
