### PR TITLE
fix(api): support agent scope for version 3 manifests

### DIFF
--- a/apps/api/src/__tests__/unit-agent-config-v2.test.ts
+++ b/apps/api/src/__tests__/unit-agent-config-v2.test.ts
@@ -46,6 +46,25 @@ name = "kortix"
 connectors = "all"
 `;
 
+const V3 = `
+kortix_version: 3
+default_agent: support
+runtimes:
+  opencode:
+    harness: opencode
+    config_dir: .kortix/opencode
+  codex:
+    harness: codex
+    config_dir: .codex
+agents:
+  support:
+    runtime: opencode
+    agent: kortix
+  reviewer:
+    runtime: codex
+    agent: reviewer
+`;
+
 function v2Manifest(body = V2) {
   return parseManifestString(body, 'yaml', 'kortix.yaml');
 }
@@ -239,6 +258,16 @@ agents:
     expect(applied.ok).toBe(false);
     if (applied.ok) return;
     expect(applied.error).toContain('kortix_version 2');
+  });
+
+  test('sets a declared version-3 logical agent', () => {
+    const manifest = parseManifestString(V3, 'yaml', 'kortix.yaml');
+    const applied = applyDefaultAgentV2(manifest, 'reviewer');
+    expect(applied.ok).toBe(true);
+    if (!applied.ok) return;
+    expect(applied.raw.default_agent).toBe('reviewer');
+    expect(applied.raw.runtimes).toEqual(manifest.raw.runtimes);
+    expect(applied.raw.agents).toEqual(manifest.raw.agents);
   });
 });
 

--- a/apps/api/src/projects/lib/agent-config-v2.test.ts
+++ b/apps/api/src/projects/lib/agent-config-v2.test.ts
@@ -8,6 +8,23 @@ const manifest = (agents: Record<string, unknown>) => ({
   raw: { kortix_version: 2, default_agent: 'support', agents },
 });
 
+const manifestV3 = (agents: Record<string, unknown>) => ({
+  schemaVersion: 3,
+  format: 'yaml' as const,
+  path: 'kortix.yaml',
+  raw: {
+    kortix_version: 3,
+    default_agent: 'support',
+    runtimes: {
+      opencode: {
+        harness: 'opencode',
+        config_dir: '.kortix/opencode',
+      },
+    },
+    agents,
+  },
+});
+
 const blockOf = (result: { ok: boolean; raw?: Record<string, unknown> }, name = 'support') =>
   (result as { raw: Record<string, unknown> }).raw.agents as Record<
     string,
@@ -94,5 +111,32 @@ describe('applyAgentScopeV2 — connectors_required', () => {
     expect(res.ok).toBe(true);
     expect(blockOf(res).support.secrets).toBe('all');
     expect(blockOf(res).support.kortix_cli).toEqual(['project.read']);
+  });
+
+  test('updates a version-3 logical agent without removing its runtime identity', () => {
+    const res = applyAgentScopeV2(
+      manifestV3({
+        support: {
+          runtime: 'opencode',
+          agent: 'kortix',
+          connectors: 'all',
+          secrets: 'all',
+        },
+      }),
+      'support',
+      {
+        connectors: ['gmail'],
+        connectorsRequired: ['gmail'],
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    expect(blockOf(res).support).toMatchObject({
+      runtime: 'opencode',
+      agent: 'kortix',
+      connectors: ['gmail'],
+      connectors_required: ['gmail'],
+      secrets: 'all',
+    });
   });
 });

--- a/apps/api/src/projects/lib/agent-config-v2.ts
+++ b/apps/api/src/projects/lib/agent-config-v2.ts
@@ -149,20 +149,60 @@ export type ApplyAgentBlockResult =
   | { ok: true; raw: Record<string, unknown> }
   | { ok: false; error: string; issues?: ManifestIssue[] };
 
+function applyAgentMapBlock(
+  manifest: ParsedManifest,
+  agentName: string,
+  block: Record<string, unknown>,
+): ApplyAgentBlockResult {
+  if (!isValidAgentName(agentName)) {
+    return {
+      ok: false,
+      error: `"${agentName}" is not a valid agent name (lowercase letters, digits, dashes, underscores).`,
+    };
+  }
+  const rawAgents = manifest.raw.agents;
+  if (
+    rawAgents !== undefined &&
+    rawAgents !== null &&
+    (Array.isArray(rawAgents) || typeof rawAgents !== 'object')
+  ) {
+    return { ok: false, error: '`agents` is malformed in this manifest (expected a map).' };
+  }
+  const normalized = normalizeRequiredConnectorAliases(block);
+  if (!normalized.ok) return normalized;
+  pruneRequiredConnectors(normalized.block);
+  const nextAgents: Record<string, unknown> = {
+    ...(rawAgents as Record<string, unknown> | undefined),
+  };
+  nextAgents[agentName] = normalized.block;
+  const nextRaw = { ...manifest.raw, agents: nextAgents };
+
+  const result = validateManifest(nextRaw, manifest.format);
+  const errorIssues = result.issues.filter((issue) => issue.severity === 'error');
+  if (errorIssues.length > 0) {
+    return {
+      ok: false,
+      error: errorIssues.map((issue) => `${issue.path}: ${issue.message}`).join('; '),
+      issues: errorIssues,
+    };
+  }
+  return { ok: true, raw: nextRaw };
+}
+
 /**
  * Change the project-wide default agent without touching any agent block.
  * The manifest validator is the authority: the target must be a declared,
- * enabled v2 agent before the caller is allowed to commit the file.
+ * enabled map-based agent before the caller is allowed to commit the file.
  */
 export function applyDefaultAgentV2(
   manifest: ParsedManifest,
   agentName: string,
 ): ApplyAgentBlockResult {
-  if (manifest.schemaVersion !== 2) {
+  if (manifest.schemaVersion < 2) {
     return {
       ok: false,
       error:
-        'This project uses a kortix_version 1 manifest. Upgrade to kortix_version 2 (kortix.yaml) to set a project default agent.',
+        'This project uses a kortix_version 1 manifest. Upgrade to kortix_version 2 or later (kortix.yaml) to set a project default agent.',
     };
   }
   if (!isValidAgentName(agentName)) {
@@ -211,37 +251,11 @@ export function applyAgentBlockV2(
         'This project uses a kortix_version 1 manifest. Upgrade to kortix_version 2 (kortix.yaml) to edit the full agent configuration.',
     };
   }
-  if (!isValidAgentName(agentName)) {
-    return {
-      ok: false,
-      error: `"${agentName}" is not a valid agent name (lowercase letters, digits, dashes, underscores).`,
-    };
-  }
-  const rawAgents = manifest.raw.agents;
-  if (rawAgents !== undefined && rawAgents !== null && (Array.isArray(rawAgents) || typeof rawAgents !== 'object')) {
-    return { ok: false, error: '`agents` is malformed in this manifest (expected a map).' };
-  }
-  const normalized = normalizeRequiredConnectorAliases(block as Record<string, unknown>);
-  if (!normalized.ok) return normalized;
-  pruneRequiredConnectors(normalized.block);
-  const nextAgents: Record<string, unknown> = { ...(rawAgents as Record<string, unknown> | undefined) };
-  nextAgents[agentName] = normalized.block;
-  const nextRaw = { ...manifest.raw, agents: nextAgents };
-
-  const result = validateManifest(nextRaw, manifest.format);
-  const errorIssues = result.issues.filter((i) => i.severity === 'error');
-  if (errorIssues.length > 0) {
-    return {
-      ok: false,
-      error: errorIssues.map((i) => `${i.path}: ${i.message}`).join('; '),
-      issues: errorIssues,
-    };
-  }
-  return { ok: true, raw: nextRaw };
+  return applyAgentMapBlock(manifest, agentName, block as Record<string, unknown>);
 }
 
 /**
- * Apply a secrets/connectors SCOPE edit to a v2 `agents:` MAP manifest — the v2
+ * Apply a secrets/connectors SCOPE edit to an `agents:` map manifest — the
  * counterpart of `applyAgentScope` in `../agents.ts` (which only handles the v1
  * `[[agents]]` array and would treat a v2 map as an empty array → "agent not
  * found"). Reads the agent's existing governance block, merges in JUST the two
@@ -264,6 +278,13 @@ export function applyAgentScopeV2(
     connectorsRequired?: string[];
   },
 ): ApplyAgentBlockResult & { notFound?: boolean } {
+  if (manifest.schemaVersion < 2) {
+    return {
+      ok: false,
+      error:
+        'This project uses a kortix_version 1 manifest. Upgrade to kortix_version 2 or later (kortix.yaml) to edit agent scope.',
+    };
+  }
   const rawAgents = manifest.raw.agents;
   const existing =
     rawAgents && typeof rawAgents === 'object' && !Array.isArray(rawAgents)
@@ -309,5 +330,5 @@ export function applyAgentScopeV2(
       else merged.connectors_required = kept;
     }
   }
-  return applyAgentBlockV2(manifest, agentName, merged as AgentBlockV2);
+  return applyAgentMapBlock(manifest, agentName, merged);
 }


### PR DESCRIPTION
## Summary
- support connector and secret scope updates for `kortix_version: 3` logical agents
- preserve version-3 `runtime` and native `agent` identity fields during scope writes
- support default-agent changes for version-3 manifests
- keep the OpenCode behavior editor version-2-only because version 3 supports multiple harnesses

## Verification
- `bun test apps/api/src/projects/lib/agent-config-v2.test.ts apps/api/src/__tests__/unit-agent-config-v2.test.ts apps/api/src/__tests__/agent-scope-direct.integration.test.ts` — 39 pass, 0 fail
- `bun apps/api/node_modules/typescript/bin/tsc --noEmit -p apps/api/tsconfig.json` — exit 0
- `bash apps/api/scripts/test.sh` — 4,840 pass, 57 skip, 0 fail