### PR TITLE
fix(whitelabel): use project connection terminology

### DIFF
--- a/apps/whitelabel-demo/src/app/api/connections/route.ts
+++ b/apps/whitelabel-demo/src/app/api/connections/route.ts
@@ -2,7 +2,7 @@
  * Connections this wrapper may bind to a new session, grouped by connector
  * alias.
  *
- * Provider-neutral and pre-filtered: a wrapper can only bind TEAM connections
+ * Provider-neutral and pre-filtered: a wrapper can only bind project connections
  * (see `selectBindableConnections`), so the client is never shown an option that
  * would fail at session create. Aliases with NOTHING bindable are still
  * returned, carrying the reason — the client has to be able to say "a teammate

--- a/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
+++ b/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
@@ -84,7 +84,7 @@ function ProjectHome() {
   // resolves to server-side anyway.
   const [bindings, setBindings] = useState<Record<string, string>>({});
 
-  // Only TEAM connections are offered: a wrapper has no personal identity
+  // Only project connections are offered: a wrapper has no personal identity
   // upstream, so a member's private connection cannot be bound at all. The
   // alias used to be hardcoded here, which meant exactly one connector could
   // ever be bound from this screen.

--- a/apps/whitelabel-demo/src/components/connector-bindings.tsx
+++ b/apps/whitelabel-demo/src/components/connector-bindings.tsx
@@ -5,7 +5,7 @@
  * has connections for, not one hardcoded alias.
  *
  * Two states, and the difference between them is the thing people get wrong:
- *  - team connections exist → pick one (or leave it on the project default)
+ *  - project connections exist → pick one (or leave it on the project default)
  *  - none do → say so, and say that a TEAMMATE is the one who can change it.
  *    There is deliberately no "connect it yourself" button; a wrapper has no
  *    personal upstream identity, and the interactive flow that would connect

--- a/apps/whitelabel-demo/src/components/new-session-dialog.tsx
+++ b/apps/whitelabel-demo/src/components/new-session-dialog.tsx
@@ -251,7 +251,7 @@ function NewSessionForm({
             <Label>Connections</Label>
             <p className="mt-0.5 text-xs text-muted-foreground">
               Which shared account each connector acts as. Sessions started here
-              can only use connections shared with the team.
+              can only use project connections.
             </p>
           </div>
           <ConnectorBindingFields

--- a/apps/whitelabel-demo/src/lib/call-snippets.ts
+++ b/apps/whitelabel-demo/src/lib/call-snippets.ts
@@ -203,7 +203,7 @@ function connectionsList(ctx: SnippetContext): CallSnippet {
     serverInjected: [],
     notes: [
       'Runs SERVER-side (`src/app/api/connections/route.ts`), and the browser never gets the raw reply: `selectBindableConnections` narrows it first, so the picker cannot offer an option that would fail at create.',
-      'Only TEAM connections (`owner_type: "project"`, `status: "active"`) survive that filter. A wrapper acts under one credential for many end users and has no personal upstream identity, so a connection a member authorized for themselves is not its to spend — and a revoked one binds fine and then fails at the first tool call.',
+      'Only project connections (`owner_type: "project"`, `status: "active"`) survive that filter. A wrapper acts under one credential for many end users and has no personal upstream identity, so a connection a member authorized for themselves is not its to spend — and a revoked one binds fine and then fails at the first tool call.',
       'An alias with nothing bindable is still returned, carrying its reason, so the picker can say "a teammate has to share this one" instead of pretending the connector does not exist. There is deliberately no "connect it yourself" button: the interactive flow that would is refused 403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY for a wrapper credential.',
       'The chosen `authorization_id` is sent in `connector_bindings`. The scope endpoint can replace it later.',
     ],

--- a/apps/whitelabel-demo/src/lib/connector-binding.ts
+++ b/apps/whitelabel-demo/src/lib/connector-binding.ts
@@ -3,7 +3,7 @@ import type { ConnectorBindingChoice } from '@/server/bindable-connections';
 /**
  * What to tell someone about a connector they cannot bind.
  *
- * "Your own account" vs "a teammate's team-shared account" is the thing people
+ * "Your own account" vs "a project connection" is the thing people
  * get wrong about connectors in wrapper mode, so the copy names the distinction
  * instead of saying "no connections available".
  *
@@ -25,17 +25,17 @@ export function connectorBindingNotice(
 ): ConnectorBindingNotice | null {
   if (choice.connections.length > 0) return null;
 
-  if (choice.unavailable === 'team_connection_inactive') {
+  if (choice.unavailable === 'project_connection_inactive') {
     return {
       title: `${choice.alias} needs reconnecting`,
-      detail: `The team's ${choice.alias} connection is revoked or failing, so it cannot be used. A teammate has to reconnect it — it becomes available here as soon as they do.`,
+      detail: `The project's ${choice.alias} connection is revoked or failing, so it cannot be used. A teammate has to reconnect it. It becomes available here when they do.`,
       selfServiceAction: null,
     };
   }
 
   return {
     title: `No shared ${choice.alias} account yet`,
-    detail: `${choice.alias} is only connected to people's own accounts, which sessions started here cannot use. Once a teammate shares a ${choice.alias} connection with the team, it appears in this list.`,
+    detail: `${choice.alias} is only connected to people's own accounts, which sessions started here cannot use. When a teammate shares a ${choice.alias} connection with the project, it appears in this list.`,
     selfServiceAction: null,
   };
 }

--- a/apps/whitelabel-demo/src/lib/session-scope.ts
+++ b/apps/whitelabel-demo/src/lib/session-scope.ts
@@ -143,8 +143,8 @@ export function sessionScopeRows(
           : bound.map(([alias, label]) => `${alias}: ${label}`).join(', '),
       detail:
         bound.length === 0
-          ? 'Every connector this agent uses resolves to the project’s default connection. Bind a specific team authorization from the scope bar.'
-          : 'Change these from the scope bar under the composer. Unlike secrets a binding change is fully retroactive — connections resolve server-side on each tool call, so the next call already uses the new one. Only TEAM connections can be bound, never a teammate’s private one.',
+          ? 'Every connector this agent uses resolves to the project’s default connection. Bind a specific project connection from the scope bar.'
+          : 'Change these from the scope bar under the composer. Unlike secrets a binding change is fully retroactive — connections resolve server-side on each tool call, so the next call already uses the new one. Only project connections can be bound, never a teammate’s private one.',
       control: null,
     },
   ];

--- a/apps/whitelabel-demo/src/server/bindable-connections.ts
+++ b/apps/whitelabel-demo/src/server/bindable-connections.ts
@@ -4,7 +4,7 @@ import type { ConnectionProfile } from '@kortix/sdk';
  * Which connections a WRAPPER may bind to a session it starts.
  *
  * A wrapper acts under one credential for many end-users, so it has no personal
- * identity upstream. It can therefore bind only TEAM (`project`-owned)
+ * identity upstream. It can therefore bind only project-owned
  * connections — never a member's private one, and never another wrapper's
  * `external` one. `require_connectors`, which resolves the *acting user's own*
  * connection, is refused outright for the same reason
@@ -29,7 +29,7 @@ export interface BindableConnection {
  * — the interactive flow that would — is refused for it outright.
  */
 export type ConnectorBindingUnavailable =
-  'private_only' | 'team_connection_inactive';
+  'private_only' | 'project_connection_inactive';
 
 export interface ConnectorBindingChoice {
   alias: string;
@@ -46,7 +46,7 @@ export function selectBindableConnections(
     .filter(
       (profile) =>
         profile.connector_alias === connectorAlias &&
-        // Team-shared only — see above.
+        // Project-owned only — see above.
         profile.owner_type === 'project' &&
         // A revoked or errored connection binds "successfully" and then fails at
         // the first tool call, which is a worse experience than not offering it.
@@ -89,8 +89,8 @@ export function selectConnectorBindingChoices(
     const connections = selectBindableConnections(profiles, alias);
     if (connections.length > 0)
       return { alias, connections, unavailable: null };
-    // A revoked/errored TEAM connection is a different ask than a private one:
-    // the team connection exists and needs reconnecting, rather than never
+    // A revoked or errored project connection is a different ask than a private one:
+    // the project connection exists and needs reconnecting, rather than never
     // having been shared. Same actor either way — a teammate.
     // `member` is the only owner type a wrapper genuinely cannot reach — it is
     // one person's private connection. Everything else (`project`, `agent`,
@@ -108,7 +108,7 @@ export function selectConnectorBindingChoices(
       alias,
       connections,
       unavailable: hasNonMemberProfile
-        ? 'team_connection_inactive'
+        ? 'project_connection_inactive'
         : 'private_only',
     };
   });

--- a/apps/whitelabel-demo/tests/e2e/bindable-connections.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/bindable-connections.test.ts
@@ -15,7 +15,7 @@ const profile = (over: Record<string, unknown> = {}) =>
   }) as never;
 
 describe('selectBindableConnections', () => {
-  test('offers team connections for the requested connector', () => {
+  test('offers project connections for the requested connector', () => {
     const rows = selectBindableConnections([profile()], 'gmail');
     expect(rows.map((r) => r.label)).toEqual(['Support']);
   });

--- a/apps/whitelabel-demo/tests/e2e/connector-binding-choices.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/connector-binding-choices.test.ts
@@ -36,11 +36,11 @@ describe('selectConnectorBindingChoices', () => {
     expect(choice!.unavailable).toBe('private_only');
   });
 
-  test('a revoked TEAM connection is a different ask than a private one', () => {
+  test('a revoked project connection is a different ask than a private one', () => {
     const [choice] = selectConnectorBindingChoices([
       profile({ status: 'revoked' }),
     ]);
-    expect(choice!.unavailable).toBe('team_connection_inactive');
+    expect(choice!.unavailable).toBe('project_connection_inactive');
   });
 
   test('a bindable connection wins over any unbindable sibling on the same alias', () => {
@@ -90,11 +90,13 @@ describe('connectorBindingNotice', () => {
     expect(notice.detail).toContain('own accounts');
   });
 
-  test('a revoked team connection asks for a reconnect, not a first-time share', () => {
+  test('a revoked project connection asks for a reconnect, not a first-time share', () => {
     const notice = connectorBindingNotice(
-      choiceFor({ unavailable: 'team_connection_inactive' }),
+      choiceFor({ unavailable: 'project_connection_inactive' }),
     )!;
     expect(notice.detail).toContain('reconnect');
+    expect(notice.detail).toContain('project');
+    expect(notice.detail.toLowerCase()).not.toContain('team connection');
   });
 
   test('neither case offers a self-connect action', () => {
@@ -102,7 +104,7 @@ describe('connectorBindingNotice', () => {
     // interactive flow that would connect one is refused for it outright
     // (403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY) — so a "connect it yourself"
     // button could only ever lead to that refusal.
-    for (const unavailable of ['private_only', 'team_connection_inactive']) {
+    for (const unavailable of ['private_only', 'project_connection_inactive']) {
       expect(
         connectorBindingNotice(choiceFor({ unavailable }))!.selfServiceAction,
       ).toBeNull();
@@ -110,7 +112,7 @@ describe('connectorBindingNotice', () => {
   });
 
   test('no notice ever tells the reader to connect the account themselves', () => {
-    for (const unavailable of ['private_only', 'team_connection_inactive']) {
+    for (const unavailable of ['private_only', 'project_connection_inactive']) {
       const notice = connectorBindingNotice(choiceFor({ unavailable }))!;
       expect(`${notice.title} ${notice.detail}`.toLowerCase()).not.toContain(
         'connect your',
@@ -139,7 +141,7 @@ describe('unavailable reason must not mislabel a shared connection (F4)', () => 
     const choices = selectConnectorBindingChoices([
       profile('external', 'revoked'),
     ]);
-    expect(choices[0]?.unavailable).toBe('team_connection_inactive');
+    expect(choices[0]?.unavailable).toBe('project_connection_inactive');
   });
 
   test('only a MEMBER-owned connection is genuinely private to one person', () => {
@@ -149,7 +151,7 @@ describe('unavailable reason must not mislabel a shared connection (F4)', () => 
     expect(choices[0]?.unavailable).toBe('private_only');
   });
 
-  test('an active team connection is offered, not reported unavailable', () => {
+  test('an active project connection is offered, not reported unavailable', () => {
     const choices = selectConnectorBindingChoices([profile('project')]);
     expect(choices[0]?.unavailable).toBeNull();
     expect(choices[0]?.connections).toHaveLength(1);

--- a/apps/whitelabel-demo/tests/e2e/connector-binding-choices.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/connector-binding-choices.test.ts
@@ -46,10 +46,10 @@ describe('selectConnectorBindingChoices', () => {
   test('a bindable connection wins over any unbindable sibling on the same alias', () => {
     const [choice] = selectConnectorBindingChoices([
       profile({ profile_id: 'mine', owner_type: 'member', owner_id: 'u1' }),
-      profile({ profile_id: 'team', label: 'Team inbox' }),
+      profile({ profile_id: 'project', label: 'Project inbox' }),
     ]);
     expect(choice!.unavailable).toBeNull();
-    expect(choice!.connections.map((c) => c.authorizationId)).toEqual(['team']);
+    expect(choice!.connections.map((c) => c.authorizationId)).toEqual(['project']);
   });
 
   test('no profiles is no connectors, not a crash', () => {

--- a/apps/whitelabel-demo/tests/e2e/new-session-overrides.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/new-session-overrides.test.ts
@@ -140,14 +140,14 @@ describe('starting a session with overrides', () => {
     expect(body.session_id).toBe('00000000-0000-4000-8000-00000000a003');
   });
 
-  test('the picker offers the team connection and only the team connection', async () => {
+  test('the picker offers the project connection and only the project connection', async () => {
     const slack = (await connectorChoices()).find((c) => c.alias === 'slack')!;
     expect(slack.connections.map((c) => c.authorizationId)).toEqual([
       'slack_team',
     ]);
   });
 
-  test('an alias with no team connection is offered as "ask a teammate"', async () => {
+  test('an alias with no project connection is offered as "ask a teammate"', async () => {
     // The private connection exists upstream; it must never appear as an
     // option, and the alias must not silently vanish either.
     const gmail = (await connectorChoices()).find((c) => c.alias === 'gmail')!;

--- a/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/scope-bar.test.ts
@@ -274,7 +274,7 @@ describe('scopeBarConnectors', () => {
     expect(row!.notice!.selfServiceAction).toBeNull();
   });
 
-  test('a revoked TEAM connection asks for a reconnect, not a first-time share', () => {
+  test('a revoked project connection asks for a reconnect, not a first-time share', () => {
     const choices = selectConnectorBindingChoices([
       profile({ status: 'revoked' }),
     ]);

--- a/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
@@ -79,6 +79,10 @@ describe('sessionScopeRows', () => {
     expect(row('connections').value).toBe(
       'The project default for every connector',
     );
+    expect(row('connections').detail).toContain('project connection');
+    expect(row('connections').detail.toLowerCase()).not.toContain(
+      'team authorization',
+    );
   });
 
   test('a bound session is told unbound connectors still fall back to the default', () => {


### PR DESCRIPTION
## Summary
- replace the legacy team_connection_inactive state with project_connection_inactive
- describe shared connector authorizations as project connections
- align session scope, setup notices, and API examples with the profile ownership contract
- preserve teammate wording only for the person who can repair a project connection

## Verification
- focused white-label tests — 76 pass, 0 fail
- pnpm --filter @kortix/whitelabel-demo test — 280 pass, 3 opt-in skips, 0 fail
- pnpm --filter @kortix/whitelabel-demo typecheck — exit 0
- white-label SDK boundary — 0 violations