### PR TITLE
fix(web): make sidebar docking instant instead of a 200ms layout morph

### DIFF
--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -25,13 +25,15 @@ describe('SidebarEdgePeek', () => {
   });
 });
 
+const slotClass = (html: string, slot: string) =>
+  html.match(new RegExp(`data-slot="${slot}"[^>]*class="([^"]*)"`))?.[1] ?? '';
+
 describe('Sidebar offcanvas peek styling', () => {
   test('collapsed sidebar parks off-screen already in flyout geometry', () => {
     const html = renderShell(false);
     expect(html).toContain('data-collapsible="offcanvas"');
     expect(html).toContain('-translate-x-[calc(100%+2rem)]');
     expect(html).toContain('top-13');
-    expect(html).toContain('transition-[left,right,top,bottom,width,translate]');
     expect(html).not.toContain('data-peek');
   });
 
@@ -41,10 +43,59 @@ describe('Sidebar offcanvas peek styling', () => {
     expect(html).not.toContain('top-13');
   });
 
-  test('collapsed container uses the drawer easing, expanded keeps linear docking', () => {
-    const containerClass = (html: string) =>
-      html.match(/data-slot="sidebar-container"[^>]*class="([^"]*)"/)?.[1] ?? '';
-    expect(containerClass(renderShell(false))).toContain('ease-[cubic-bezier(0.32,0.72,0,1)]');
-    expect(containerClass(renderShell(true))).not.toContain('ease-[cubic-bezier(0.32,0.72,0,1)]');
+  test('collapsed container uses the drawer easing, expanded declares none', () => {
+    expect(slotClass(renderShell(false), 'sidebar-container')).toContain(
+      'ease-[cubic-bezier(0.32,0.72,0,1)]',
+    );
+    expect(slotClass(renderShell(true), 'sidebar-container')).not.toContain(
+      'ease-[cubic-bezier(0.32,0.72,0,1)]',
+    );
+  });
+});
+
+/**
+ * Docking the sidebar (collapsed → expanded) must land in a single frame. A
+ * CSS transition is read off the DESTINATION style, so the docked branch is
+ * only instant while it declares no transition at all — and the collapsed
+ * branch is only cheap while its transition covers transform alone. Both are
+ * load-bearing: the janky version this replaced glided the gap's `width` and
+ * the container's `top`/`bottom`/`left`, reflowing the whole content subtree
+ * every frame for 200ms.
+ */
+describe('Sidebar docking is instant', () => {
+  test('docked container declares no transition, so every geometry change snaps', () => {
+    expect(slotClass(renderShell(true), 'sidebar-container')).not.toContain('transition');
+  });
+
+  test('the content gap never animates its width', () => {
+    for (const open of [true, false]) {
+      expect(slotClass(renderShell(open), 'sidebar-gap')).not.toContain('transition');
+    }
+  });
+
+  test('the panel card never animates its radius or shadow', () => {
+    for (const open of [true, false]) {
+      expect(slotClass(renderShell(open), 'sidebar-inner')).not.toContain('transition');
+    }
+  });
+
+  test('the collapsed container animates transform only, never a layout property', () => {
+    const cls = slotClass(renderShell(false), 'sidebar-container');
+    expect(cls).toContain('transition-transform');
+    // Guards the regression directly: no transition may name a property that
+    // triggers layout.
+    for (const layoutProp of ['left', 'right', 'top', 'bottom', 'width', 'height']) {
+      expect(cls).not.toContain(`transition-[${layoutProp}`);
+      expect(cls).not.toContain(`,${layoutProp}]`);
+      expect(cls).not.toContain(`,${layoutProp},`);
+    }
+  });
+
+  test('the undock slide stays on the compositor at 220ms', () => {
+    const cls = slotClass(renderShell(false), 'sidebar-container');
+    expect(cls).toContain('-translate-x-[calc(100%+2rem)]');
+    expect(cls).toContain('duration-[220ms]');
+    expect(cls).toContain('will-change-transform');
+    expect(cls).toContain('motion-reduce:transition-none');
   });
 });

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -269,11 +269,15 @@ function Sidebar({
       data-peek={peeking ? '' : undefined}
       data-slot="sidebar"
     >
-      {/* This is what handles the sidebar gap on desktop */}
+      {/* This is what handles the sidebar gap on desktop. Its width snaps —
+          it must NOT transition. This box is what pushes the content over, so
+          animating its width reflows the entire page subtree (resizable panel
+          group, virtualized message list) on every frame for the whole
+          duration. Docking is a one-frame layout change instead. */}
       <div
         data-slot="sidebar-gap"
         className={cn(
-          'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
+          'relative w-(--sidebar-width) bg-transparent',
           'group-data-[collapsible=offcanvas]:w-0',
           'group-data-[side=right]:rotate-180',
           variant === 'floating' || variant === 'inset'
@@ -286,7 +290,7 @@ function Sidebar({
         onPointerEnter={peekable ? peekEnter : undefined}
         onPointerLeave={peekable ? peekLeave : undefined}
         className={cn(
-          'fixed z-10 hidden w-(--sidebar-width) transition-[left,right,top,bottom,width,translate] duration-200 ease-linear motion-reduce:transition-none md:flex',
+          'fixed z-10 hidden w-(--sidebar-width) md:flex',
           // Peek-capable: the panel keeps one static position (flyout
           // geometry, below the shell's top-left toggle) and hides by
           // translating off-screen — hidden ↔ flyout is a compositor-only
@@ -295,11 +299,24 @@ function Sidebar({
           // lifecycle so the exit slide stays above the content headers.
           // Timing is asymmetric per CSS rules — the destination state's
           // duration governs, so enter runs 280ms and exit 220ms (~80%),
-          // both on the iOS drawer curve. Docking keeps the base linear
-          // timing to stay in sync with the sidebar-gap width.
+          // both on the iOS drawer curve.
+          //
+          // The transition lives HERE, not on the base, and covers transform
+          // only. Two consequences, both deliberate:
+          //   1. Docking (collapsed → expanded) lands on the branch below,
+          //      which declares no transition at all — and a transition is
+          //      read off the destination style, so top/bottom/left/width and
+          //      the h-auto → h-svh swap all snap in one frame. Those are
+          //      layout properties; gliding them was the whole jank, and the
+          //      height could never transition anyway, so it snapped mid-glide.
+          //   2. Undocking still slides: geometry snaps to the flyout card,
+          //      then transform carries it off-screen in 220ms on the
+          //      compositor. That is the cue for where the panel went — the
+          //      left edge is where hovering brings it back.
           peekable
             ? cn(
-                'top-13 bottom-2 left-2 z-40 h-auto ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform',
+                'top-13 bottom-2 left-2 z-40 h-auto',
+                'transition-transform ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform motion-reduce:transition-none',
                 peeking
                   ? 'translate-x-0 duration-[280ms]'
                   : '-translate-x-[calc(100%+2rem)] duration-[220ms]',
@@ -320,13 +337,15 @@ function Sidebar({
           data-slot="sidebar-inner"
           className={cn(
             'bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm',
-            // 200ms so the radius/shadow fade lands together with the 200ms
-            // dock morph when pinning — no trailing style change.
-            'transition-[border-radius,box-shadow] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none',
             // Gated on peekable (not peeking) so hidden ↔ flyout swaps no
             // styles at all — the panel slides in and out as a rigid card.
             // border-border, not border-sidebar-border: the sidebar token is
             // pure white in dark mode and reads as a glowing edge.
+            //
+            // No transition on the radius/shadow: peekable only flips at the
+            // dock moment, so this was purely the dock morph's fourth
+            // concurrent timeline. It now snaps with the geometry above, in
+            // the same frame.
             peekable && 'border-border overflow-hidden rounded-lg border shadow-xl',
           )}
         >

--- a/apps/web/src/features/session/header/session-site-header.tsx
+++ b/apps/web/src/features/session/header/session-site-header.tsx
@@ -157,7 +157,11 @@ export function SessionSiteHeader({
         <div className={cn('flex items-center justify-between p-2', sidebarHidden && 'pt-[12px]')}>
           <div
             className={cn(
-              'pointer-events-auto flex items-center gap-0.5 transition-[margin] duration-200 ease-linear',
+              // No margin transition: this indent only changes when the
+              // sidebar docks/undocks, and gliding it made the row a fourth
+              // competing timeline in that toggle. Docking is one frame now,
+              // so the indent snaps with the panel and the gap.
+              'pointer-events-auto flex items-center gap-0.5',
               // Below md the shell floats an always-on sheet opener at this
               // row's left end (see ProjectSheelLayout) — indent past it.
               // 'max-md:ml-[34px]',


### PR DESCRIPTION
## Summary

Docking the sidebar (clicking the toggle while the hover flyout is up, or `⌘B`) played a janky 200ms morph. Four transitions fired at once, three of them on properties that force layout and paint every frame:

| Slot | Animated | Cost |
| --- | --- | --- |
| `sidebar-gap` | `width` `0 → 16rem` | reflows the whole content subtree (resizable panel group, virtualized message list) every frame for 200ms |
| `sidebar-container` | `top`, `bottom`, `left` | layout + paint per frame; the simultaneous `h-auto → h-svh` swap cannot transition, so height snapped mid-glide |
| `sidebar-inner` | `border-radius`, `box-shadow` | repaint under a moving panel |
| session header leading cluster | `margin` | fourth competing timeline |

A CSS transition is read off the **destination** style. So moving the container's transition into the collapsed-only branch is enough to make docking instant with no JS flag — the docked branch declares no transition, and every geometry change lands in one frame.

Undocking still slides: geometry snaps to the flyout card, then `transform` alone carries it off-screen in 220ms on the compositor. That keeps the cue for where the panel went, since the left edge is where hovering brings it back. The hover flyout itself is untouched.

```
EXPAND      layout snap · panel snap        → one frame
COLLAPSE    layout snap · slide left 220ms  → transform only
HOVER       unchanged (280ms in / 220ms out)
```

No behaviour change beyond timing: no new state, no new renders, no API change. Net −16/+90 lines, most of it tests and comments.

### Files

- `apps/web/src/components/ui/sidebar.tsx` — removed the gap's `width` transition and the inner's `border-radius,box-shadow` transition; moved the container's transition out of the base class into the collapsed branch, narrowed to `transition-transform`.
- `apps/web/src/features/session/header/session-site-header.tsx` — removed `transition-[margin]` from the leading cluster.
- `apps/web/src/components/ui/sidebar.test.tsx` — replaced the assertion pinning the old transition string with a `Sidebar docking is instant` block.

## Test plan

Automated:

- [x] `bun test src/components/ui/sidebar.test.tsx --isolate` → **10 pass, 0 fail, 39 expect() calls**. The new `Sidebar docking is instant` block asserts the docked container carries no `transition` at all, the gap and inner carry none in either state, and the collapsed container carries `transition-transform` while containing no `transition-[left|right|top|bottom|width|height` — that last one guards the regression directly.
- [x] `npx eslint` on all three files → exit 0, no output.
- [x] `npx tsc --noEmit` filtered to the touched files (excluding the repo's known bogus `TS2786` React 19↔18 noise) → no diagnostics.
- [x] Confirmed Tailwind 4.3.2's `transition-transform` expands to `transform, translate, scale, rotate` by grepping `apps/web/node_modules/tailwindcss/dist/lib.js`. This matters: `-translate-x-[calc(100%+2rem)]` sets the `translate` property in v4, not `transform`, so a narrower `transition-[transform]` would have silently killed the flyout slide.

Manual, to check on the deploy:

- [ ] Collapse the sidebar, hover the left edge → flyout still slides in over ~280ms, out over ~220ms. Unchanged.
- [ ] With the flyout up, click the toggle → sidebar docks with no visible animation, content reflows in one frame.
- [ ] `⌘B` from collapsed with the pointer away from the edge → docks instantly, no slide-in.
- [ ] `⌘B` from docked → content snaps to full width immediately, panel card slides left off-screen over ~220ms.
- [ ] Desktop (Electron) shell with the sidebar hidden → the session header's leading cluster indent snaps with the panel instead of gliding. This is the one path not exercised locally.
- [ ] `prefers-reduced-motion: reduce` → flyout does not slide (`motion-reduce:transition-none` retained on the collapsed branch).
