### PR TITLE
fix(whitelabel): preserve session list shape in mock

### DIFF
--- a/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
+++ b/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
@@ -291,6 +291,11 @@ export function createMockUpstream(expectedAuthToken: string): MockUpstream {
         }
       }
 
+      const sessionsMatch = p.match(/^projects\/([^/]+)\/sessions$/);
+      if (sessionsMatch && method === 'GET') {
+        return Response.json([]);
+      }
+
       // Any other `projects/:id/...` sub-path (sessions, files, connectors, …) —
       // generic forwarded-OK, recorded for assertion.
       if (/^projects\/[^/]+(\/.*)?$/.test(p)) {

--- a/apps/whitelabel-demo/tests/e2e/new-session-overrides.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/new-session-overrides.test.ts
@@ -140,6 +140,14 @@ describe('starting a session with overrides', () => {
     expect(body.session_id).toBe('00000000-0000-4000-8000-00000000a003');
   });
 
+  test('the mock returns the session collection shape used by the project page', async () => {
+    const sessions = await createTestKortix(app, token)
+      .project(projectId)
+      .sessions.list();
+
+    expect(sessions).toEqual([]);
+  });
+
   test('the picker offers the project connection and only the project connection', async () => {
     const slack = (await connectorChoices()).find((c) => c.alias === 'slack')!;
     expect(slack.connections.map((c) => c.authorizationId)).toEqual([


### PR DESCRIPTION
## Summary

- return an array from the mock session-list endpoint
- add a black-box SDK contract test for the project-page response shape
- preserve the generic mock response for other project subpaths

## Verification

- `pnpm --filter @kortix/whitelabel-demo test`
  - 281 pass, 3 opt-in skips, 0 fail, 5,215 expectations
  - SDK boundary: 0 violations
- `pnpm --filter @kortix/whitelabel-demo typecheck`
  - exit 0
  - SDK boundary: 0 violations
- `pnpm --filter @kortix/whitelabel-demo build`
  - exit 0
  - Next.js production build completed
- Browser smoke against the production Next.js server and mock upstream
  - project page rendered with no console errors
  - new-session dialog rendered project-connection copy
  - old team-connection copy was absent