### PR TITLE
chore(connectors): align project connection terminology

### DIFF
--- a/apps/api/src/projects/lib/connector-profile-visibility.test.ts
+++ b/apps/api/src/projects/lib/connector-profile-visibility.test.ts
@@ -39,24 +39,24 @@ describe('sessionMayEnumerateProfile', () => {
     );
   });
 
-  test('team-shared connections stay visible — the project already publishes them', () => {
-    // A connector may hold several TEAM connections (support@, sales@) and they
+  test('project connections stay visible — the project already publishes them', () => {
+    // A connector may hold several project connections (support@, sales@) and they
     // are visible to every project member by design. Hiding them from a sandbox
     // would break connector use without protecting anything.
-    expect(sessionMayEnumerateProfile(profile('p-team', 'project'), BOUND)).toBe(true);
+    expect(sessionMayEnumerateProfile(profile('p-project', 'project'), BOUND)).toBe(true);
   });
 
   test('someone’s PRIVATE member connection is hidden unless bound', () => {
     expect(sessionMayEnumerateProfile(profile('p-private', 'member', 'human-1'), BOUND)).toBe(false);
   });
 
-  test('an EMPTY bound set hides everything except team connections', () => {
+  test('an EMPTY bound set hides everything except project connections', () => {
     // A session with no bindings at all is the common KaaB case. Empty must mean
     // "bound to nothing", not "unbound, so show everything" — treating an empty
     // set as absent is exactly how this kind of guard fails open.
     const none: ReadonlySet<string> = new Set();
     expect(sessionMayEnumerateProfile(profile('p-x', 'external', 'b'), none)).toBe(false);
-    expect(sessionMayEnumerateProfile(profile('p-team', 'project'), none)).toBe(true);
+    expect(sessionMayEnumerateProfile(profile('p-project', 'project'), none)).toBe(true);
   });
 
   test('an unknown owner_type is hidden, not shown', () => {

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -401,9 +401,9 @@ export type ConnectorAuthorization = z.infer<typeof ConnectorAuthorizationSchema
 export const ReconcileConnectorAuthorizationInputSchema = z
   .object({
     connector_alias: z.string().regex(/^[a-z][a-z0-9_-]{0,127}$/),
-    // `project` = a TEAM-shared connection (several are allowed per connector,
+    // `project` = a project-shared connection (several are allowed per connector,
     // distinguished by label); it takes no owner_id. Every other owner type
-    // requires one. Creating a team connection needs the profiles-manage
+    // requires one. Creating a project connection needs the profiles-manage
     // capability — enforced at the route.
     owner_type: z.enum(['project', 'agent', 'member', 'subject', 'external']),
     owner_id: z.string().trim().min(1).max(512).optional(),

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -4113,8 +4113,8 @@ export const executorConnectionProfiles = kortixSchema.table(
       table.profileId,
     ),
     // A connector may hold MANY connections (e.g. support@ and sales@ for the
-    // team, plus each member's own). The default marker is therefore scoped PER
-    // OWNER, not per connector: exactly one team default, and at most one default
+    // project, plus each member's own). The default marker is therefore scoped PER
+    // OWNER, not per connector: exactly one project default, and at most one default
     // per member/agent/external owner. Split into two partial indexes so the
     // project case (owner_id IS NULL, where SQL NULLs would compare distinct)
     // is still capped at one.
@@ -4132,7 +4132,7 @@ export const executorConnectionProfiles = kortixSchema.table(
       .on(table.connectorId, table.ownerType, table.ownerId, table.label)
       .where(sql`${table.ownerId} is not null`),
     // Project-owned rows carry owner_id NULL, so the index above (partial on
-    // owner_id IS NOT NULL) can't dedupe them. Several TEAM connections per
+    // owner_id IS NOT NULL) can't dedupe them. Several project connections per
     // connector are allowed, distinguished by label — this keeps that set unique.
     uniqueIndex('idx_executor_connection_profiles_project_label')
       .on(table.connectorId, table.label)


### PR DESCRIPTION
## Summary

- describe project-owned connector authorizations as project connections
- align schema comments with the `owner_type: "project"` contract
- align connector-profile visibility test names and fixtures

## Verification

- `pnpm --filter kortix-api test`
  - 4,840 pass, 57 skip, 0 fail, 19,909 expectations
- `pnpm --filter kortix-api exec bun test --isolate src/projects/lib/connector-profile-visibility.test.ts`
  - 7 pass, 0 fail
- `pnpm --filter @kortix/api-contract test`
  - 54 pass, 0 fail
- `pnpm --filter @kortix/db test`
  - 160 pass, 3 skip, 0 fail
- `pnpm --filter @kortix/api-contract typecheck`
  - exit 0
- `pnpm --filter @kortix/db typecheck`
  - exit 0
- terminology search
  - only two intentional negative assertions retain the old phrases