### PR TITLE
feat(web): generate connector profile slugs from names

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/connector-profile-form.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connector-profile-form.test.ts
@@ -8,6 +8,7 @@ import {
   connectorAuthorizationStrategyForProvider,
   connectorAuthorizationStrategyIsEditable,
   connectorAuthorizationUpdateIsPending,
+  connectorProfileSlugAfterNameChange,
   connectorSetupStatus,
   connectorSyncErrorForSlug,
   createOnlyConnectorDraft,
@@ -17,18 +18,40 @@ import {
 } from './connector-profile-form';
 
 describe('connector profile slug proposal', () => {
-  test('uses the provider app slug when the project has no matching profile', () => {
-    expect(proposeConnectorProfileSlug('google_drive', ['slack'])).toBe('google_drive');
+  test('generates the slug from the display name', () => {
+    expect(proposeConnectorProfileSlug('Gmail Read Only', ['slack'])).toBe('gmail-read-only');
   });
 
-  test('increments the suffix when the project has multiple profiles for one app', () => {
+  test('uses the first available numeric suffix after a collision', () => {
     expect(
-      proposeConnectorProfileSlug('google_drive', [
-        'google_drive',
-        'google_drive-2',
-        'google_drive-4',
+      proposeConnectorProfileSlug('Gmail Read Only', [
+        'gmail-read-only',
+        'gmail-read-only-1',
+        'gmail-read-only-3',
       ]),
-    ).toBe('google_drive-3');
+    ).toBe('gmail-read-only-2');
+  });
+
+  test('keeps an edited slug when the display name changes', () => {
+    expect(
+      connectorProfileSlugAfterNameChange({
+        displayName: 'Gmail Read Only',
+        currentSlug: 'private-inbox',
+        existingSlugs: [],
+        slugEdited: true,
+      }),
+    ).toBe('private-inbox');
+  });
+
+  test('updates an unedited slug when the display name changes', () => {
+    expect(
+      connectorProfileSlugAfterNameChange({
+        displayName: 'Gmail Read Only',
+        currentSlug: 'gmail',
+        existingSlugs: ['gmail-read-only'],
+        slugEdited: false,
+      }),
+    ).toBe('gmail-read-only-1');
   });
 
   test('normalizes an edited slug to the manifest format', () => {

--- a/apps/web/src/features/workspace/customize/sections/connector-profile-form.ts
+++ b/apps/web/src/features/workspace/customize/sections/connector-profile-form.ts
@@ -106,13 +106,13 @@ export function isConnectorProfileSlugAvailable(
 }
 
 export function proposeConnectorProfileSlug(
-  appSlug: string,
+  displayName: string,
   existingSlugs: readonly string[],
 ): string {
-  const base = normalizeConnectorProfileSlug(appSlug) || 'connector';
+  const base = normalizeConnectorProfileSlug(displayName) || 'connector';
   if (isConnectorProfileSlugAvailable(base, existingSlugs)) return base;
 
-  for (let index = 2; ; index += 1) {
+  for (let index = 1; ; index += 1) {
     const suffix = `-${index}`;
     const stem = base
       .slice(0, MAX_CONNECTOR_PROFILE_SLUG_LENGTH - suffix.length)
@@ -120,6 +120,20 @@ export function proposeConnectorProfileSlug(
     const candidate = `${stem}${suffix}`;
     if (isConnectorProfileSlugAvailable(candidate, existingSlugs)) return candidate;
   }
+}
+
+export function connectorProfileSlugAfterNameChange({
+  displayName,
+  currentSlug,
+  existingSlugs,
+  slugEdited,
+}: {
+  displayName: string;
+  currentSlug: string;
+  existingSlugs: readonly string[];
+  slugEdited: boolean;
+}): string {
+  return slugEdited ? currentSlug : proposeConnectorProfileSlug(displayName, existingSlugs);
 }
 
 export function buildEmailConnectorProfileSlug(baseInput: string, uniqueId: string): string {

--- a/apps/web/src/features/workspace/customize/sections/connector-profile-form.ts
+++ b/apps/web/src/features/workspace/customize/sections/connector-profile-form.ts
@@ -19,11 +19,7 @@ export interface EasyConnectProfileInput {
 }
 
 export type ConnectorSetupStatus =
-  | 'connected'
-  | 'error'
-  | 'needs_setup'
-  | 'no_auth'
-  | 'user_managed';
+  'connected' | 'error' | 'needs_setup' | 'no_auth' | 'user_managed';
 
 export function connectorAuthorizationQueryKeys(projectId: string) {
   return [

--- a/apps/web/src/features/workspace/customize/sections/connector-profile-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connector-profile-modal.tsx
@@ -26,6 +26,7 @@ import {
 import { cn } from '@/lib/utils';
 
 import {
+  connectorProfileSlugAfterNameChange,
   type EasyConnectProfileInput,
   isConnectorProfileSlugAvailable,
   normalizeConnectorProfileSlug,
@@ -100,6 +101,7 @@ export function ConnectorProfileModal({
 }) {
   const [name, setName] = useState(initialName);
   const [slug, setSlug] = useState(initialSlug);
+  const [slugEdited, setSlugEdited] = useState(false);
   const [authorizationStrategy, setAuthorizationStrategy] =
     useState<ConnectorAuthorizationStrategy>('project');
 
@@ -107,6 +109,7 @@ export function ConnectorProfileModal({
     if (!open) return;
     setName(initialName);
     setSlug(initialSlug);
+    setSlugEdited(false);
     setAuthorizationStrategy('project');
   }, [initialName, initialSlug, open]);
 
@@ -134,7 +137,18 @@ export function ConnectorProfileModal({
                 <Input
                   id={`${idPrefix}-name`}
                   value={name}
-                  onChange={(event) => setName(event.target.value)}
+                  onChange={(event) => {
+                    const displayName = event.target.value;
+                    setName(displayName);
+                    setSlug((currentSlug) =>
+                      connectorProfileSlugAfterNameChange({
+                        displayName,
+                        currentSlug,
+                        existingSlugs,
+                        slugEdited,
+                      }),
+                    );
+                  }}
                   placeholder={initialName}
                   variant="popover"
                   autoFocus
@@ -148,7 +162,10 @@ export function ConnectorProfileModal({
                 <Input
                   id={`${idPrefix}-slug`}
                   value={slug}
-                  onChange={(event) => setSlug(normalizeConnectorProfileSlug(event.target.value))}
+                  onChange={(event) => {
+                    setSlugEdited(true);
+                    setSlug(normalizeConnectorProfileSlug(event.target.value));
+                  }}
                   placeholder={initialSlug}
                   variant="popover"
                   className="font-mono text-xs"

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.discover.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.discover.test.ts
@@ -50,6 +50,7 @@ describe('feature-flagged Discover connector marketplace', () => {
   test('collects an explicit profile before creating either integration type', () => {
     expect(discoverSource).toContain('<ConnectorProfileModal');
     expect(discoverSource).toContain('existingSlugs={existingSlugs}');
+    expect(discoverSource).toContain('proposeConnectorProfileSlug(profileDisplayName, existingSlugs)');
     expect(discoverSource).toContain('createOnlyConnectorDraft(draft)');
     expect(discoverSource).toContain('authorization_strategy: profile.authorizationStrategy');
   });

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.discover.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.discover.test.ts
@@ -50,7 +50,9 @@ describe('feature-flagged Discover connector marketplace', () => {
   test('collects an explicit profile before creating either integration type', () => {
     expect(discoverSource).toContain('<ConnectorProfileModal');
     expect(discoverSource).toContain('existingSlugs={existingSlugs}');
-    expect(discoverSource).toContain('proposeConnectorProfileSlug(profileDisplayName, existingSlugs)');
+    expect(discoverSource).toContain(
+      'proposeConnectorProfileSlug(profileDisplayName, existingSlugs)',
+    );
     expect(discoverSource).toContain('createOnlyConnectorDraft(draft)');
     expect(discoverSource).toContain('authorization_strategy: profile.authorizationStrategy');
   });

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.profile-creation.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.profile-creation.test.ts
@@ -10,6 +10,9 @@ describe('connector profile creation controls', () => {
     expect(source).toContain('buildEasyConnectProfileDraft(selectedApp,');
     expect(source).toContain('<ConnectorProfileModal');
     expect(source).toContain('idPrefix="easy-connect-profile"');
+    expect(source).toContain(
+      'proposeConnectorProfileSlug(selectedApp.name, existingSlugs)',
+    );
     expect(modalSource).toContain('id={`${idPrefix}-name`}');
     expect(modalSource).toContain('id={`${idPrefix}-slug`}');
     expect(modalSource).toContain('maxLength={255}');

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.profile-creation.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.profile-creation.test.ts
@@ -10,9 +10,7 @@ describe('connector profile creation controls', () => {
     expect(source).toContain('buildEasyConnectProfileDraft(selectedApp,');
     expect(source).toContain('<ConnectorProfileModal');
     expect(source).toContain('idPrefix="easy-connect-profile"');
-    expect(source).toContain(
-      'proposeConnectorProfileSlug(selectedApp.name, existingSlugs)',
-    );
+    expect(source).toContain('proposeConnectorProfileSlug(selectedApp.name, existingSlugs)');
     expect(modalSource).toContain('id={`${idPrefix}-name`}');
     expect(modalSource).toContain('id={`${idPrefix}-slug`}');
     expect(modalSource).toContain('maxLength={255}');

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -4096,7 +4096,7 @@ function AppCatalogue({
         description="Create a connector profile for this app. The profile name and slug identify it in sessions and project configuration."
         initialName={selectedApp?.name ?? ''}
         initialSlug={
-          selectedApp ? proposeConnectorProfileSlug(selectedApp.slug, existingSlugs) : ''
+          selectedApp ? proposeConnectorProfileSlug(selectedApp.name, existingSlugs) : ''
         }
         existingSlugs={existingSlugs}
         pending={addApp.isPending}

--- a/apps/web/src/features/workspace/customize/sections/discover-catalogue.tsx
+++ b/apps/web/src/features/workspace/customize/sections/discover-catalogue.tsx
@@ -62,15 +62,6 @@ type DiscoverProfileTarget =
   | { source: 'integration'; item: DiscoverIntegration; variant: DiscoverIntegrationVariant }
   | { source: 'pipedream'; app: PipedreamApp };
 
-function connectorSlug(item: DiscoverIntegration, variant: DiscoverIntegrationVariant): string {
-  return `${item.slug}-${variant.kind}`
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 48);
-}
-
 export function DiscoverCatalogue({
   projectId,
   existingSlugs,
@@ -201,6 +192,10 @@ export function DiscoverCatalogue({
   });
 
   const loading = integrationsQuery.isLoading || (pipedreamEnabled && pipedreamQuery.isLoading);
+  const profileDisplayName =
+    profileTarget?.source === 'pipedream'
+      ? profileTarget.app.name
+      : (profileTarget?.variant.name ?? '');
 
   return (
     <div className="space-y-4">
@@ -437,26 +432,11 @@ export function DiscoverCatalogue({
       <ConnectorProfileModal
         open={profileTarget !== null}
         idPrefix="discover-profile"
-        title={`Add ${
-          profileTarget?.source === 'pipedream'
-            ? profileTarget.app.name
-            : (profileTarget?.variant.name ?? 'integration')
-        }`}
+        title={`Add ${profileDisplayName || 'integration'}`}
         description="Create a connector profile. The display name and slug identify this specific connection in project configuration."
-        initialName={
-          profileTarget?.source === 'pipedream'
-            ? profileTarget.app.name
-            : (profileTarget?.variant.name ?? '')
-        }
+        initialName={profileDisplayName}
         initialSlug={
-          profileTarget
-            ? proposeConnectorProfileSlug(
-                profileTarget.source === 'pipedream'
-                  ? profileTarget.app.slug
-                  : connectorSlug(profileTarget.item, profileTarget.variant),
-                existingSlugs,
-              )
-            : ''
+          profileTarget ? proposeConnectorProfileSlug(profileDisplayName, existingSlugs) : ''
         }
         existingSlugs={existingSlugs}
         pending={addProfile.isPending}


### PR DESCRIPTION
Summary
- Generate the initial connector profile slug from the display name.
- Keep the generated slug synchronized until the user edits it.
- Resolve collisions with the first available numeric suffix, starting at -1.
- Apply the behavior to Easy Connect and Discover profile creation.

Verification
- bun test: 2,604 passed, 0 failed, 7,966 assertions.
- Focused connector tests: 36 passed, 0 failed, 96 assertions.
- Prettier: all changed files pass.
- ESLint: all changed files pass with zero findings.
- Production build: compiled successfully and generated 164 static pages.
- Browser: Gmail Read Only generated gmail-read-only-1 when gmail-read-only existed.
- Browser: a manual private-inbox slug remained unchanged after a display-name edit.