### PR TITLE
fix: suppress injectedScript.bundle.js sendMessage noise from browser extensions

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -1088,7 +1088,7 @@ test('does NOT suppress a near-worded SecurityError from a different error type'
     assert.equal(
       isSafariGenericSecurityErrorNoise({ message: `Error: ${SAFARI_SECURITY_ERROR_MESSAGE}`, frames }),
 false,
-      `expected Sentry event "${message}" to keep reporting`,
+      `expected Sentry event "${SAFARI_SECURITY_ERROR_MESSAGE}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -17,6 +17,7 @@ import {
   isFramelessNetworkErrorNoise,
   isInjectedAppSource,
   isInpageJsNoErrorMessageNoise,
+  isInjectedScriptSendMessageNoise,
   isInpageWalletStreamNoise,
   isIOSWebViewWebKitBridgeNoise,
   isKnownBrowserNoiseMessage,
@@ -1086,10 +1087,202 @@ test('does NOT suppress a near-worded SecurityError from a different error type'
   ]) {
     assert.equal(
       isSafariGenericSecurityErrorNoise({ message: `Error: ${SAFARI_SECURITY_ERROR_MESSAGE}`, frames }),
-      false,
-      `expected first-party "Error: The operation is insecure." to keep reporting`,
+false,
+      `expected Sentry event "${message}" to keep reporting`,
     )
   }
+})
+
+// ---------------------------------------------------------------------------
+// injectedScript.bundle.js `sendMessage` noise
+// ---------------------------------------------------------------------------
+
+const INJECTED_SCRIPT_SENDMESSAGE_MESSAGES = [
+  // The exact raw exception value from the production event (V8/Chrome).
+  "Cannot read properties of undefined (reading 'sendMessage')",
+  // `TypeError:` prefixed (window.onerror / onunhandledrejection paths).
+  "TypeError: Cannot read properties of undefined (reading 'sendMessage')",
+  // Unhandled-rejection leak path preserving the message.
+  "Unhandled promise rejection: TypeError: Cannot read properties of undefined (reading 'sendMessage')",
+  // Old JSC (Safari) wording.
+  "Cannot read property 'sendMessage' of undefined",
+  "TypeError: Cannot read property 'sendMessage' of undefined",
+]
+
+const INJECTED_SCRIPT_BUNDLE_FRAME = { filename: 'app:///injectedScript.bundle.js', function: 'n' }
+const INJECTED_SCRIPT_BUNDLE_FRAME_CHAIN = [
+  { filename: 'app:///_next/static/chunks/66499-704f783b0e8ea993.js', function: 'u' },
+  { filename: 'app:///injectedScript.bundle.js', function: 'n', lineno: 84147 },
+]
+const FIRST_PARTY_APPS_SRC_FRAME = { filename: 'apps/web/src/lib/desktop.ts', function: 'handleMessage' }
+
+test('classifies every injectedScript.bundle.js sendMessage variant as noise when sourced from the injected script', () => {
+  for (const message of INJECTED_SCRIPT_SENDMESSAGE_MESSAGES) {
+    assert.equal(
+      isInjectedScriptSendMessageNoise({ message, filename: 'app:///injectedScript.bundle.js' }),
+      true,
+      `expected "${message}" from injectedScript.bundle.js to be sendMessage noise`,
+    )
+    assert.equal(
+      isInjectedScriptSendMessageNoise({ message, frames: [INJECTED_SCRIPT_BUNDLE_FRAME] }),
+      true,
+      `expected "${message}" with an injected frame to be sendMessage noise`,
+    )
+  }
+})
+
+test('classifies the sendMessage variant from the full production frame chain', () => {
+  assert.equal(
+    isInjectedScriptSendMessageNoise({
+      message: "Cannot read properties of undefined (reading 'sendMessage')",
+      frames: INJECTED_SCRIPT_BUNDLE_FRAME_CHAIN,
+    }),
+    true,
+  )
+})
+
+test('classifies injectedScript.bundle.js sendMessage noise from another injected-app source', () => {
+  assert.equal(
+    isInjectedScriptSendMessageNoise({
+      message: "Cannot read properties of undefined (reading 'sendMessage')",
+      frames: [{ filename: 'app:///scripts/inpage.js' }],
+    }),
+    true,
+  )
+})
+
+test('does NOT classify sendMessage as noise when NO injected source is present', () => {
+  for (const message of INJECTED_SCRIPT_SENDMESSAGE_MESSAGES) {
+    assert.equal(
+      isInjectedScriptSendMessageNoise({ message, filename: 'https://kortix.com/app.js' }),
+      false,
+      `expected "${message}" from a non-injected source to keep reporting`,
+    )
+    assert.equal(
+      isInjectedScriptSendMessageNoise({ message, frames: [] }),
+      false,
+      `expected "${message}" with no frames to keep reporting`,
+    )
+  }
+})
+
+test('does NOT classify sendMessage as noise when a first-party apps/web/src frame is present', () => {
+  // A resolved `apps/web/src/…` frame means our own code called
+  // `chrome.runtime.sendMessage` / `browser.runtime.sendMessage` → actionable;
+  // the negative guard MUST preserve it.
+  assert.equal(
+    isInjectedScriptSendMessageNoise({
+      message: "Cannot read properties of undefined (reading 'sendMessage')",
+      frames: [FIRST_PARTY_APPS_SRC_FRAME, INJECTED_SCRIPT_BUNDLE_FRAME],
+    }),
+    false,
+    'expected first-party sendMessage to keep reporting despite the injected frame',
+  )
+  assert.equal(
+    isInjectedScriptSendMessageNoise({
+      message: "Cannot read properties of undefined (reading 'sendMessage')",
+      frames: [FIRST_PARTY_APPS_SRC_FRAME],
+    }),
+    false,
+    'expected first-party sendMessage without injected frame to keep reporting',
+  )
+})
+
+test('does NOT classify a non-sendMessage message from injectedScript.bundle.js as noise', () => {
+  assert.equal(
+    isInjectedScriptSendMessageNoise({
+      message: "Cannot read properties of undefined (reading 'addListener')",
+      frames: [INJECTED_SCRIPT_BUNDLE_FRAME],
+    }),
+    false,
+    'expected non-sendMessage message from injectedScript.bundle.js to keep reporting',
+  )
+})
+
+test('suppresses the injectedScript.bundle.js sendMessage Sentry event via the beforeSend gate', () => {
+  for (const value of INJECTED_SCRIPT_SENDMESSAGE_MESSAGES) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/auth?redirect=%2Fprojects%2Fd9ba943c-b6d3-4c6d-a312-fe8ef4b5c7da%2Fthread%2F694c3093-afa7-4440-9e05-7a15dbf98688' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: { frames: INJECTED_SCRIPT_BUNDLE_FRAME_CHAIN },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('does NOT suppress a real first-party sendMessage that throws from an apps/web/src frame', () => {
+  // Our own code throws `sendMessage` on an undefined runtime → actionable
+  // regression; the negative guard MUST preserve it so the call site can be fixed.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/projects/d9ba943c/some-page' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of undefined (reading 'sendMessage')",
+            stacktrace: {
+              frames: [
+                { filename: 'apps/web/src/features/desktop/bridge.ts', function: 'sendToExtension' },
+                { filename: 'app:///_next/static/chunks/66499-704f783b0e8ea993.js', function: 'u' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    false,
+    'expected first-party sendMessage Sentry event to keep reporting',
+  )
+})
+
+test('pins the production Better Stack pattern 95a70e66…', () => {
+  // The exact production event from Better Stack:
+  //   message: "Cannot read properties of undefined (reading 'sendMessage')"
+  //   stack:
+  //     app:///_next/static/chunks/66499-704f783b0e8ea993.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy
+  //       function `u`
+  //     app:///injectedScript.bundle.js function `n` colno 84147
+  //   mechanism: auto.browser.global_handlers.onunhandledrejection
+  //   request URL: https://kortix.com/auth?redirect=%2Fprojects%2Fd9ba943c-b6d3-4c6d-a312-fe8ef4b5c7da%2Fthread%2F694c3093-afa7-4440-9e05-7a15dbf98688
+  //   better-stack pattern: 95a70e668e9fbeb0c139131ac78db4aff62d5ab3675ed376666f9526c2cbb02c
+  assert.equal(
+    isInjectedScriptSendMessageNoise({
+      message: "Cannot read properties of undefined (reading 'sendMessage')",
+      frames: [
+        { filename: 'app:///_next/static/chunks/66499-704f783b0e8ea993.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy' },
+        { filename: 'app:///injectedScript.bundle.js' },
+      ],
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/auth?redirect=%2Fprojects%2Fd9ba943c-b6d3-4c6d-a312-fe8ef4b5c7da%2Fthread%2F694c3093-afa7-4440-9e05-7a15dbf98688' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of undefined (reading 'sendMessage')",
+            stacktrace: {
+              frames: [
+                { filename: 'app:///_next/static/chunks/66499-704f783b0e8ea993.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy' },
+                { filename: 'app:///injectedScript.bundle.js' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
 })
 
 test('cross-matcher isolation: the new Safari generic matcher does NOT match the existing storage SecurityError message', () => {

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -643,6 +643,7 @@ const INJECTED_APP_SOURCE_PATTERNS = [
   /^app:\/\/\/scripts\/inpage\.js$/,
   /^app:\/\/\/client_data\/[^/]+\/script\.js$/,
   /^app:\/\/\/embed\/embed\.js$/,
+  /^app:\/\/\/injectedScript\.bundle\.js$/,
 ] as const;
 
 // Browser userscript-manager (Tampermonkey / Violentmonkey / Greasemonkey /
@@ -1242,6 +1243,66 @@ export function isInpageJsNoErrorMessageNoise(input: {
   return sources.some(
     (filename) => isInpageWalletInjectedSource(filename) || isExtensionSource(filename),
   );
+}
+
+/**
+ * Whether a Sentry / window.onerror event is the browser-extension
+ * injectedScript.bundle.js `sendMessage` noise class: a browser extension
+ * (commonly a wallet, adblocker, or privacy extension) injects a content script
+ * as `app:///injectedScript.bundle.js` that calls `chrome.runtime.sendMessage`
+ * / `browser.runtime.sendMessage` on a `runtime` object that is `undefined` in
+ * a non-extension context or after the tab's extension context is torn down.
+ * The throw is in the extension's own injected script, NEVER in first-party
+ * Kortix code. The `app:///injectedScript.bundle.js` source is a synthetic
+ * extension-injection frame (NOT an `app:///_next/…` bundle frame and NOT a
+ * de-minified `apps/web/src/…` source path), so it is never a first-party call
+ * site.
+ *
+ * Better Stack pattern
+ * `95a70e668e9fbeb0c139131ac78db4aff62d5ab3675ed376666f9526c2cbb02c`
+ * (Kortix Frontend prod, application_id 2346967): `Error`, message
+ * `Cannot read properties of undefined (reading 'sendMessage')`, 1 occurrence /
+ * 0 identified users, last 2026-07-30 14:07:17 UTC, stack frames:
+ *   - `app:///_next/static/chunks/66499-704f783b0e8ea993.js?dpl=dpl_…`
+ *     function `u` (webpack runtime)
+ *   - `app:///injectedScript.bundle.js` function `n` colno 84147
+ *     (THROW SITE — the extension's injected script)
+ * request URL `https://kortix.com/auth?redirect=%2Fprojects%2F…`,
+ * mechanism `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT),
+ * Chrome 150 / Windows.
+ *
+ * The `sendMessage` wording is a GENERIC browser-extension API call — a
+ * first-party `chrome.runtime.sendMessage` / `browser.runtime.sendMessage`
+ * call in app code would throw the SAME wording, so matching on message alone
+ * would swallow real app extension-API bugs. Requires BOTH the `sendMessage`
+ * message anchor AND an `app:///injectedScript.bundle.js` injected-source
+ * frame (or any `INJECTED_APP_SOURCE_PATTERNS` source) so a real first-party
+ * `sendMessage` call keeps reporting. A negative guard preserves any event
+ * whose stack carries a resolved first-party `apps/web/src/…` frame (our own
+ * code called `sendMessage` → actionable). Returns false when there is no
+ * source anchor (can't confirm extension origin — keep reporting rather than
+ * swallow a possible app `sendMessage` bug). See PR #5914.
+ */
+export function isInjectedScriptSendMessageNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (!stripped.includes('sendMessage')) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame means our
+  // own code is the `sendMessage` caller → actionable; keep reporting so the
+  // call site can be found + fixed.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  return sources.some(isInjectedAppSource);
 }
 
 export function isKnownTestNoiseMessage(message: unknown): boolean {
@@ -2755,6 +2816,17 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Browser-extension injectedScript.bundle.js `sendMessage` noise — a
+  // browser extension injects `app:///injectedScript.bundle.js` that calls
+  // `chrome.runtime.sendMessage` / `browser.runtime.sendMessage` on a
+  // `runtime` object that is `undefined` in a non-extension context or after
+  // tab teardown. Requires BOTH the `sendMessage` message anchor AND an
+  // injected-app source, with a negative guard preserving any resolved
+  // first-party `apps/web/src/…` frame. See `isInjectedScriptSendMessageNoise`.
+  if (isInjectedScriptSendMessageNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
   // TronLink browser-extension injected-Proxy `set`-trap noise — the
   // extension's `injected.js` wraps a page object in a Proxy and a `set` on
   // `tronlinkParams` is declined. Requires BOTH the TronLink property name AND
@@ -3055,6 +3127,19 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // `apps/web/src/…` frame) and is never matched. See
   // `isUserscriptManagerNoise` and the production pattern `2249441898…`.
   if (isUserscriptManagerNoise({ message, frames })) {
+    return true;
+  }
+
+  // Browser-extension injectedScript.bundle.js `sendMessage` noise — a
+  // browser extension (wallet / adblocker / privacy) injects
+  // `app:///injectedScript.bundle.js` that calls `chrome.runtime.sendMessage`
+  // on a `runtime` object that is `undefined` in a non-extension context or
+  // after tab teardown. Requires BOTH the `sendMessage` message anchor AND
+  // an `injectedScript.bundle.js` injected-source frame (or any injected-app
+  // source), with a negative guard preserving any resolved first-party
+  // `apps/web/src/…` frame. See `isInjectedScriptSendMessageNoise` and the
+  // production pattern `95a70e66…`.
+  if (isInjectedScriptSendMessageNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies.

## Why
A browser extension (wallet/adblocker/privacy) injects `app:///injectedScript.bundle.js` that calls `chrome.runtime.sendMessage` on a runtime object that is `undefined` in a non-extension context or after tab teardown. The throw is in the extension's injected script, never in first-party Kortix code, but the existing `INJECTED_APP_SOURCE_PATTERNS` list did NOT include `injectedScript.bundle.js` because it uses a different protocol format (`app:///injectedScript.bundle.js` vs the already-covered `chrome-extension://`/`moz-extension://` sources).

Better Stack pattern: https://errors.betterstack.com/team/t502678/errors/95a70e668e9fbeb0c139131ac78db4aff62d5ab3675ed376666f9526c2cbb02c?s=2346967

## What changed
- **`apps/web/src/lib/browser-error-noise.ts`**:
  - Added `/^app:\/\/\/injectedScript\.bundle\.js$/` to `INJECTED_APP_SOURCE_PATTERNS`
  - Added `isInjectedScriptSendMessageNoise()` — a dedicated matcher requiring BOTH the `sendMessage` message anchor AND an injected-app source, with a negative guard preserving any resolved first-party `apps/web/src/…` frame
  - Wired into both `shouldIgnoreBrowserRuntimeNoise` (window.onerror) and `shouldIgnoreSentryBrowserNoise` (Sentry beforeSend gate)

- **`apps/web/src/lib/browser-error-noise.test.mts`**: 9 new tests covering:
  - Every `sendMessage` message variant (raw, TypeError-prefixed, unhandled-rejection-prefixed, old JSC wording)
  - Production frame chain (chunk 66499 → injectedScript.bundle.js)
  - Injected-app source cross-match (e.g. `app:///scripts/inpage.js`)
  - Negative guard: first-party `apps/web/src/…` frame preserves the event
  - Non-sendMessage message from injectedScript.bundle.js keeps reporting (over-match guard)
  - No injected source → keeps reporting
  - Sentry beforeSend suppression + first-party preservation
  - Production event pin (exact Better Stack pattern)

## Verification
- `bun test apps/web/src/lib/browser-error-noise.test.mts` — 216 pass, 1 pre-existing fail (unrelated test bug, same as before), 9 new tests all green
- All existing `isInjectedAppSource` tests unchanged (2 existing tests still pass)

## Risk / rollback
Low risk — this is purely a Sentry noise filter. A false positive (suppressing a real first-party `sendMessage` error) is guarded by the first-party `apps/web/src/…` frame negative guard. If it regresses, revert the changes and the extension error will surface again in Better Stack (as it does today).