### PR TITLE
fix(api): gracefully skip broken sandbox templates instead of failing the full listing

### DIFF
--- a/apps/api/src/snapshots/builder-list-templates.test.ts
+++ b/apps/api/src/snapshots/builder-list-templates.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Regression coverage for `listSandboxTemplates` resilience against individual
+ * template failures.
+ *
+ * Incident: Better Stack Frontend error (pattern b82b59c0…)
+ *   "Failed to list sandbox templates: Sandbox template "kortix-dockerfile-sandbox":
+ *    Dockerfile ... is empty"
+ *
+ * Root cause: `resolveUserDockerfile` in `templates.ts` throws when a template's
+ * Dockerfile is empty (or becomes empty after `normalizeUserDockerfileForSnapshot`
+ * strips the legacy starter block). The old `listSandboxTemplates` used
+ * `Promise.all([…].map(toView))`, so a single broken template failed the ENTIRE
+ * listing — returning a 500 to the frontend that surfaced as a Sentry `ApiError`.
+ *
+ * Fix: use `Promise.allSettled` and `console.warn`-skip templates that fail
+ * resolution, returning the healthy subset.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import { listSandboxTemplates, type SandboxTemplateView } from './builder';
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const HEALTHY_TEMPLATE = {
+  templateId: 'tpl-1',
+  projectId: 'proj-1',
+  slug: 'default',
+  name: 'Default',
+  isShared: true,
+  source: 'platform' as const,
+  provider: 'daytona',
+  image: null,
+  dockerfilePath: null,
+  entrypoint: null,
+  cpu: 1,
+  memoryGb: 2,
+  diskGb: 10,
+  providerState: 'active',
+  providerSnapshotName: 'kortix-default-abc',
+  contentHash: 'a'.repeat(64),
+  builtFromCommit: null,
+  swapKey: null,
+};
+
+const BROKEN_TEMPLATE = {
+  ...HEALTHY_TEMPLATE,
+  templateId: 'tpl-2',
+  slug: 'kortix-dockerfile-sandbox',
+  name: 'Dockerfile Sandbox',
+  isShared: false,
+  source: 'toml' as const,
+  dockerfilePath: 'Dockerfile',
+  image: null,
+};
+
+const ANOTHER_HEALTHY_TEMPLATE = {
+  ...HEALTHY_TEMPLATE,
+  templateId: 'tpl-3',
+  slug: 'python-3-12',
+  name: 'Python 3.12',
+  isShared: false,
+  source: 'ui' as const,
+  image: 'python:3.12-slim',
+  dockerfilePath: null,
+};
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockTemplatesList: any[] = [];
+
+mock.module('./templates', () => ({
+  listTemplatesForProject: async () => mockTemplatesList,
+  computeTemplateIdentity: async (_project: any, template: any) => {
+    // Simulate the exact error from resolveUserDockerfile when the Dockerfile
+    // is empty or gets stripped to empty by normalizeUserDockerfileForSnapshot.
+    if (template.slug === 'kortix-dockerfile-sandbox') {
+      throw new Error(
+        `Sandbox template "${template.slug}": Dockerfile ${template.dockerfilePath} is empty`,
+      );
+    }
+    return {
+      snapshotName: `kortix-tpl-${template.slug}-abc123`,
+      contentHash: 'a'.repeat(64),
+      shortHash: 'abc123',
+      runtimeFingerprint: 'test-runtime-fp',
+      userDockerfile: 'FROM ubuntu:24.04\n',
+      builtFromCommit: null,
+      swapKey: 'test-swap-key',
+    };
+  },
+  recordTemplateBuilt: async () => {},
+  recordTemplateFailed: async () => {},
+  refreshTemplateState: async () => {},
+  resolveTemplateBySlug: async () => HEALTHY_TEMPLATE,
+  resolveTemplateForBuildSlug: async () => HEALTHY_TEMPLATE,
+}));
+
+mock.module('../config', () => ({
+  config: {
+    isProviderEnabled: () => true,
+    sandboxProvider: 'daytona',
+    host: 'test',
+  },
+}));
+
+const mockProvider = {
+  isConfigured: () => true,
+  getSnapshotState: async () => 'active',
+};
+
+mock.module('./providers', () => ({
+  getSandboxProvider: () => mockProvider,
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('listSandboxTemplates resilience', () => {
+  test('returns all templates when all are healthy', async () => {
+    mockTemplatesList.length = 0;
+    mockTemplatesList.push(HEALTHY_TEMPLATE, ANOTHER_HEALTHY_TEMPLATE);
+
+    const result = await listSandboxTemplates({} as any, {});
+    expect(result).toHaveLength(2);
+    expect(result[0]!.slug).toBe('default');
+    expect(result[1]!.slug).toBe('python-3-12');
+  });
+
+  test('skips a broken template and returns the rest', async () => {
+    mockTemplatesList.length = 0;
+    mockTemplatesList.push(HEALTHY_TEMPLATE, BROKEN_TEMPLATE, ANOTHER_HEALTHY_TEMPLATE);
+
+    const result = await listSandboxTemplates({} as any, {});
+    // The broken template should be skipped, returning the two healthy ones
+    expect(result).toHaveLength(2);
+    expect(result[0]!.slug).toBe('default');
+    expect(result[1]!.slug).toBe('python-3-12');
+  });
+
+  test('returns empty array when ALL templates are broken', async () => {
+    mockTemplatesList.length = 0;
+    mockTemplatesList.push(BROKEN_TEMPLATE);
+
+    const result = await listSandboxTemplates({} as any, {});
+    expect(result).toHaveLength(0);
+  });
+
+  test('returns empty array when there are no templates', async () => {
+    mockTemplatesList.length = 0;
+
+    const result = await listSandboxTemplates({} as any, {});
+    expect(result).toHaveLength(0);
+  });
+
+  test('does not throw from a broken template — the error is caught and logged', async () => {
+    mockTemplatesList.length = 0;
+    mockTemplatesList.push(BROKEN_TEMPLATE);
+
+    // listSandboxTemplates should never throw — it catches per-template errors
+    await expect(
+      listSandboxTemplates({} as any, {}),
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -635,7 +635,18 @@ export async function listSandboxTemplates(
   } = {},
 ): Promise<SandboxTemplateView[]> {
   const items = await listTemplatesForProject(project);
-  return Promise.all(items.map((t) => toView(project, t, opts)));
+  const results = await Promise.allSettled(items.map((t) => toView(project, t, opts)));
+  const views: SandboxTemplateView[] = [];
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r.status === 'fulfilled') {
+      views.push(r.value);
+    } else {
+      const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      console.warn(`[sandbox-templates] skipping template "${items[i]!.slug}": ${reason}`);
+    }
+  }
+  return views;
 }
 
 async function toView(


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This is a backend API fix that converts a 500 -> filtered-out broken template.

## Why

Better Stack Frontend error (pattern `b82b59c0...`) - 3 occurrences, last 2026-07-30:
> **ApiError** - Failed to list sandbox templates: Sandbox template "kortix-dockerfile-sandbox": Dockerfile ... is empty

A single project template with an empty/invalid Dockerfile caused the entire sandbox template list to return a 500 error, which the frontend surfaced as an opaque `ApiError` in Sentry.

**Better Stack URL:** https://errors.betterstack.com/team/t502678/errors/b82b59c053c76fd7eaa33b38aae1b10cea9891d9419c54647e88c97787ad94d5?s=2346967

## What changed

**Root cause:** `resolveUserDockerfile` in `apps/api/src/snapshots/templates.ts` throws when a template's Dockerfile is empty (or becomes empty after `normalizeUserDockerfileForSnapshot` strips the legacy starter block). The old `listSandboxTemplates` used `Promise.all(items.map(toView))`, so a single broken template failed the ENTIRE listing - returning a 500 to the frontend.

`listSandboxTemplates` is called by 4 routes (`/sandboxes`, `/snapshots`, `/sandbox-health`, `/sandbox-templates`). The `/snapshots` route and `buildSandboxHealth` already catch per-template errors gracefully. The `/sandboxes` and `/sandbox-templates` routes did not - they hit the `catch` block and returned 500.

**Fix:**
- `apps/api/src/snapshots/builder.ts` - `listSandboxTemplates` now uses `Promise.allSettled` and `console.warn`-skips templates that fail resolution (empty Dockerfile, missing file, commit SHA lookup failure), returning the healthy subset. If all templates are broken, returns an empty array.

## Verification

- Typecheck (tsc --noEmit) passes cleanly
- 5 regression tests pass (all healthy, partial failure, all broken, empty list, never-throws invariant)
- Existing builder-provider-dedupe tests still pass (6/6)

## Risk / rollback

Low risk. The change is a pure resilience improvement - it converts a hard failure (500 -> Sentry error) into a graceful degradation (broken template is skipped with a warning log). If the fix itself has a bug, the worst case is that a template is silently dropped from the listing, which is strictly better than the current behavior of failing the entire listing.

To rollback: revert this single commit.