### PR TITLE
fix: all managed models group under Kortix in the picker, not Anthropic/DeepSeek

### DIFF
--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -9,8 +9,8 @@ import { catalogModelForWireModel, gatewayModelCatalog } from './catalog-models'
 describe('gatewayModelCatalog — served catalog', () => {
   const full = gatewayModelCatalog('proj');
 
-  test('brands managed DeepSeek V4 Flash with the DeepSeek provider', () => {
-    expect(full['deepseek-v4-flash']?.provider).toBe('deepseek');
+  test('brands managed DeepSeek V4 Flash with the Kortix provider', () => {
+    expect(full['deepseek-v4-flash']?.provider).toBe('kortix');
   });
 
   test('serves Aster GLM pricing instead of a models.dev provider price', () => {

--- a/apps/api/src/llm-gateway/models/picker-catalog.ts
+++ b/apps/api/src/llm-gateway/models/picker-catalog.ts
@@ -54,7 +54,7 @@ function catalogState(): PickerCatalogState {
 // (most recently released), so a wrong/renamed guess is dropped rather than
 // offered — the list can never drift into a lie.
 const FLAGSHIP_CANDIDATES: Record<string, string[]> = {
-  anthropic: ['claude-opus-4.8', 'claude-opus-4-8', 'claude-sonnet-4.6', 'claude-sonnet-4-6'],
+  anthropic: ['claude-opus-4-8', 'claude-sonnet-4-6'],
   openai: ['gpt-5.5', 'gpt-5.1', 'gpt-5', 'gpt-4.1'],
   google: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.0-flash'],
   'x-ai': ['grok-4', 'grok-3'],

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -569,7 +569,6 @@ export const MANAGED_MODELS: ManagedModel[] = [
       outputPerMillion: 0.1876,
     },
     tier: 'balanced',
-    providerBrand: 'deepseek',
     vision: false,
     limit: { context: 1_048_576, output: 64_000 },
     // 21 OpenRouter endpoints serve this slug and they are NOT interchangeable.

--- a/packages/llm-catalog/src/managed.test.ts
+++ b/packages/llm-catalog/src/managed.test.ts
@@ -129,7 +129,7 @@ describe('managed resolution + back-compat aliases', () => {
       cacheWritePerMillion: 1,
       outputPerMillion: 4,
     });
-    expect(getManagedModel('deepseek-v4-flash')?.providerBrand).toBe('deepseek');
+    expect(getManagedModel('deepseek-v4-flash')?.providerBrand).toBeUndefined();
     expect(getManagedModel('deepseek-v4-flash')?.pricing).toEqual({
       inputPerMillion: 0.0938,
       cachedInputPerMillion: 0.01876,


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. The fix is verified by the
existing test suite (all 109 tests pass) and the logic is pure data flow.

## Why

The model picker showed 2 of 4 Kortix-managed models under the wrong provider
group:
- `deepseek-v4-flash` appeared under "DeepSeek" instead of "Kortix"
- `claude-opus-4.8` and `claude-sonnet-4.6` (the dotted Kortix-managed ids)
  appeared under "Anthropic" in the BYOK flagship candidates

All four managed models are Kortix-billed (credits, not BYOK) and should group
under "Kortix".

## What changed

1. **`packages/llm-catalog/src/index.ts`**: Removed `providerBrand: "deepseek"`
   from `deepseek-v4-flash`. The `providerBrand` field is a UI hint for
   picker grouping — every managed model runs through Kortix keys and is
   billed as Kortix credits, so they should all fall through to the default
   `KORTIX_PROVIDER_ID` ("kortix").

2. **`apps/api/src/llm-gateway/models/picker-catalog.ts`**: Removed the dotted
   Kortix-managed model ids (`claude-opus-4.8`, `claude-sonnet-4.6`) from the
   `anthropic` FLAGSHIP_CANDIDATES list. These are Kortix-managed model ids,
   not BYOK Anthropic models.dev ids. The dashed variants (`claude-opus-4-8`,
   `claude-sonnet-4-6`) are the real models.dev catalog ids for the BYOK
   Anthropic provider and are kept.

3. **`packages/llm-catalog/src/managed.test.ts`**: Updated the assertion to
   expect `providerBrand` to be `undefined` instead of `"deepseek"`.

## Verification

- `pnpm --filter @kortix/llm-catalog typecheck` — ✅
- `pnpm --filter @kortix/llm-catalog test` — 72 pass, 0 fail
- `pnpm --filter @kortix/sdk typecheck` — ✅
- `pnpm --filter kortix-api typecheck` — ✅
- `pnpm --filter kortix-api` managed-model tests — 26 pass, 0 fail
- `pnpm --filter kortix-api` picker tests — 11 pass, 0 fail

## Risk / rollback

Trivial — revert the two data lines and the test assertion. No schema changes,
no migration, no behavioral risk at runtime.