### PR TITLE
Preserve hydrated session content after runtime lookup misses

### DIFF
--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -209,6 +209,7 @@ import {
 import { SandboxUrlDetector } from './sandbox-url-detector';
 import { sessionComposerReadiness } from './session-composer-readiness';
 import { captureTurnScrollAnchor, restoreTurnScrollAnchor } from './session-history-scroll';
+import { resolveSessionContentState } from './session-load-state';
 import { shouldLoadOlderHistory } from './session-older-autoload';
 
 // ============================================================================
@@ -2140,9 +2141,7 @@ function SameToolGroup({
               {durationLabel}
             </span>
           )}
-          {anyRunning && (
-            <Loading className="text-muted-foreground/40 size-3 flex-shrink-0" />
-          )}
+          {anyRunning && <Loading className="text-muted-foreground/40 size-3 flex-shrink-0" />}
           <ChevronRight
             className={cn(
               'size-3 flex-shrink-0 transition-transform',
@@ -5330,20 +5329,24 @@ export function SessionChat({
   // This eliminates the loader for empty sessions entirely: instead of
   // spinning while we wait to confirm "0 messages", we show the welcome
   // screen right away.
-  const hasMessages = messages && messages.length > 0;
+  const hasMessages = Boolean(messages?.length);
   // "Not found" is a TERMINAL answer, never a loading guess. It's only true once
   // the runtime is connected AND the session lookup has actually run and come
   // back empty. While the runtime is still connecting (the query is disabled and
   // therefore reports isLoading=false) or the lookup is in flight, we know
   // nothing yet — so we must show the loading state, not the error. This is what
   // stops the "This session is not accessible right now." flash on boot.
-  const sessionResolved = runtimeReady && sessionFetched;
   const composerReadiness = sessionComposerReadiness({ runtimeReady });
-  const isNotFound = !session && sessionResolved && !optimisticPrompt;
+  const { isNotFound, isDataLoading } = resolveSessionContentState({
+    runtimeReady,
+    sessionFetched,
+    hasRuntimeSession: Boolean(session),
+    hasMessages,
+    hasOptimisticPrompt: Boolean(optimisticPrompt),
+  });
   // Everything that isn't "we have content" and isn't the terminal not-found
   // state is loading — including the boot window where the query is still
   // disabled (isLoading=false) waiting on the runtime.
-  const isDataLoading = !session && !isNotFound && !hasMessages && !optimisticPrompt;
   const showOptimistic = !!optimisticPrompt && !hasMessages;
   const isTransitioningFromWelcome = !prevHasChatContentRef.current && hasChatContent;
   // The welcome wallpaper is the EMPTY-STATE backdrop for a *resolved* session.

--- a/apps/web/src/features/session/session-load-state.test.ts
+++ b/apps/web/src/features/session/session-load-state.test.ts
@@ -4,6 +4,7 @@ import {
   canMountSessionChat,
   canShowSessionChat,
   findInitialSessionPin,
+  resolveSessionContentState,
 } from './session-load-state';
 
 describe('session load state', () => {
@@ -46,5 +47,65 @@ describe('session load state', () => {
         runtimeBootError: null,
       }),
     ).toBe(true);
+  });
+
+  test('keeps hydrated messages visible after a runtime session lookup miss', () => {
+    expect(
+      resolveSessionContentState({
+        runtimeReady: true,
+        sessionFetched: true,
+        hasRuntimeSession: false,
+        hasMessages: true,
+        hasOptimisticPrompt: false,
+      }),
+    ).toEqual({
+      isNotFound: false,
+      isDataLoading: false,
+    });
+  });
+
+  test('reports a terminal lookup miss when the session has no content', () => {
+    expect(
+      resolveSessionContentState({
+        runtimeReady: true,
+        sessionFetched: true,
+        hasRuntimeSession: false,
+        hasMessages: false,
+        hasOptimisticPrompt: false,
+      }),
+    ).toEqual({
+      isNotFound: true,
+      isDataLoading: false,
+    });
+  });
+
+  test('keeps an unresolved session on the loading surface', () => {
+    expect(
+      resolveSessionContentState({
+        runtimeReady: false,
+        sessionFetched: false,
+        hasRuntimeSession: false,
+        hasMessages: false,
+        hasOptimisticPrompt: false,
+      }),
+    ).toEqual({
+      isNotFound: false,
+      isDataLoading: true,
+    });
+  });
+
+  test('keeps an optimistic prompt visible during a runtime session lookup miss', () => {
+    expect(
+      resolveSessionContentState({
+        runtimeReady: true,
+        sessionFetched: true,
+        hasRuntimeSession: false,
+        hasMessages: false,
+        hasOptimisticPrompt: true,
+      }),
+    ).toEqual({
+      isNotFound: false,
+      isDataLoading: false,
+    });
   });
 });

--- a/apps/web/src/features/session/session-load-state.ts
+++ b/apps/web/src/features/session/session-load-state.ts
@@ -24,3 +24,19 @@ export function canShowSessionChat(input: {
 }) {
   return Boolean(input.chatSessionId || input.runtimeError || input.runtimeBootError);
 }
+
+export function resolveSessionContentState(input: {
+  runtimeReady: boolean;
+  sessionFetched: boolean;
+  hasRuntimeSession: boolean;
+  hasMessages: boolean;
+  hasOptimisticPrompt: boolean;
+}) {
+  const sessionResolved = input.runtimeReady && input.sessionFetched;
+  const isNotFound =
+    !input.hasRuntimeSession && sessionResolved && !input.hasMessages && !input.hasOptimisticPrompt;
+  const isDataLoading =
+    !input.hasRuntimeSession && !isNotFound && !input.hasMessages && !input.hasOptimisticPrompt;
+
+  return { isNotFound, isDataLoading };
+}

--- a/apps/web/src/session-engine-boundary.test.ts
+++ b/apps/web/src/session-engine-boundary.test.ts
@@ -25,4 +25,12 @@ describe('project session engine boundary', () => {
     expect(chatSource).not.toContain('@/stores/opencode-compaction-store');
     expect(chatSource).toContain('sessionState?.isCompacting ?? false');
   });
+
+  test('SessionChat preserves hydrated content after a runtime lookup miss', () => {
+    expect(chatSource).toContain('resolveSessionContentState({');
+    expect(chatSource).toContain('hasMessages,');
+    expect(chatSource).not.toContain(
+      'const isNotFound = !session && sessionResolved && !optimisticPrompt',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- keep hydrated transcript messages visible when runtime session metadata lookup resolves empty
- preserve terminal not-found behavior for sessions with no messages or optimistic prompt
- add unit and source-boundary regression coverage

## Verification
- `bun test src/features/session/session-load-state.test.ts src/session-engine-boundary.test.ts` — 11 pass, 0 fail
- `bun test` — 2725 pass, 0 fail across 307 files
- `pnpm exec eslint src/features/session/session-chat.tsx src/features/session/session-load-state.ts src/features/session/session-load-state.test.ts src/session-engine-boundary.test.ts` — exit 0
- `pnpm exec prettier --check ...` — exit 0
- `pnpm exec tsc --noEmit --pretty false` — existing baseline: 23 errors, none in changed files
- localhost REST session — 3 reloads and 2 route remounts retained transcript content; context reported 2 messages and 12,095 tokens

## Local runtime evidence
- runtime message request returned 200
- transcript marker remained visible after every reload and route remount
- not-accessible state remained absent
- both local test sandboxes were stopped after verification