### PR TITLE
Improve session access scope selection

### DIFF
--- a/apps/web/src/features/session/scope/session-scope-control.test.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.test.tsx
@@ -80,7 +80,7 @@ describe('SessionScopeControlContent', () => {
     expect(html).toContain('type="button"');
   });
 
-  test('renders the active secret allowlist and one authorization selector per connector profile', () => {
+  test('renders compact collapsed summaries for the selected scope', () => {
     const html = renderControl({
       secrets: ['CALENDAR_TOKEN'],
       connector_bindings: {
@@ -89,14 +89,14 @@ describe('SessionScopeControlContent', () => {
       },
     });
 
+    expect(html).toContain('Session access');
+    expect(html).toContain('Share only the secrets and connectors this session needs.');
     expect(html).toContain('1 selected');
-    expect(html).toContain('Calendar token');
-    expect(html).toContain('CRM token');
-    expect(html).toContain('aria-label="Authorization for Calendar"');
-    expect(html).toContain('aria-label="Authorization for CRM"');
-    expect(html).toContain('Private');
-    expect(html).toContain('Project');
-    expect(html).toContain('Saved changes apply to the next prompt or tool call.');
+    expect(html).toContain('2 selected');
+    expect(html.match(/aria-expanded="false"/g)).toHaveLength(2);
+    expect(html).not.toContain('aria-label="Authorization for Calendar"');
+    expect(html).not.toContain('aria-label="Authorization for CRM"');
+    expect(html).toContain('Changes apply to the next prompt.');
   });
 
   test('distinguishes unrestricted secret access from an explicit empty allowlist', () => {
@@ -104,8 +104,8 @@ describe('SessionScopeControlContent', () => {
     const noneHtml = renderControl({ secrets: [], connector_bindings: {} });
 
     expect(allHtml).toContain('All allowed');
-    expect(allHtml.match(/aria-checked="true"/g)).toHaveLength(3);
-    expect(noneHtml).toContain('None allowed');
+    expect(noneHtml).toContain('None selected');
+    expect(allHtml).not.toContain('aria-checked="true"');
     expect(noneHtml).not.toContain('aria-checked="true"');
   });
 
@@ -114,7 +114,7 @@ describe('SessionScopeControlContent', () => {
     const noneHtml = renderControl({ secrets: [], connector_bindings: {} });
 
     expect(unchangedHtml).toContain('Unchanged');
-    expect(noneHtml).toContain('None allowed');
+    expect(noneHtml).toContain('None selected');
   });
 
   test('shows catalog failures without converting them into empty selections', () => {
@@ -130,9 +130,8 @@ describe('SessionScopeControlContent', () => {
       />,
     );
 
-    expect(html).toContain('Secret access is unavailable');
-    expect(html).toContain('Connector access is unavailable');
-    expect(html).not.toContain('None allowed');
+    expect(html.match(/>Unavailable</g)).toHaveLength(2);
+    expect(html).not.toContain('None selected');
   });
 
   test('shows saving state and the non-retroactive warning', () => {

--- a/apps/web/src/features/session/scope/session-scope-control.test.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.test.tsx
@@ -6,6 +6,7 @@ import {
   SessionScopeControlContent,
   setAllSessionSecrets,
   setSessionConnectorAuthorization,
+  setSessionConnectorEnabled,
   toggleSessionSecret,
 } from './session-scope-control';
 import type { SessionScopeDraft, SessionScopeSelectionCatalog } from './session-scope-model';
@@ -188,5 +189,30 @@ describe('session scope control changes', () => {
         crm: { authorization_id: 'authorization-crm' },
       },
     });
+  });
+
+  test('enables a connector with its default authorization and removes it when disabled', () => {
+    const connector =
+      catalog.connector_profiles.status === 'ready'
+        ? catalog.connector_profiles.items[0]
+        : undefined;
+
+    expect(connector).toBeDefined();
+    expect(setSessionConnectorEnabled({ connector_bindings: {} }, connector!, true)).toEqual({
+      connector_bindings: {
+        calendar: { authorization_id: 'authorization-calendar' },
+      },
+    });
+    expect(
+      setSessionConnectorEnabled(
+        {
+          connector_bindings: {
+            calendar: { authorization_id: 'authorization-calendar' },
+          },
+        },
+        connector!,
+        false,
+      ),
+    ).toEqual({ connector_bindings: {} });
   });
 });

--- a/apps/web/src/features/session/scope/session-scope-control.test.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.test.tsx
@@ -214,4 +214,18 @@ describe('session scope control changes', () => {
       ),
     ).toEqual({ connector_bindings: {} });
   });
+
+  test('does not enable a connector without an available authorization', () => {
+    const connector =
+      catalog.connector_profiles.status === 'ready'
+        ? {
+            ...catalog.connector_profiles.items[0],
+            authorizations: [],
+          }
+        : undefined;
+    const draft: SessionScopeDraft = { connector_bindings: {} };
+
+    expect(connector).toBeDefined();
+    expect(setSessionConnectorEnabled(draft, connector!, true)).toBe(draft);
+  });
 });

--- a/apps/web/src/features/session/scope/session-scope-control.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.tsx
@@ -20,7 +20,11 @@ import {
   WarningIcon as TriangleAlert,
 } from '@phosphor-icons/react';
 
-import type { SessionScopeDraft, SessionScopeSelectionCatalog } from './session-scope-model';
+import type {
+  SessionScopeConnectorOption,
+  SessionScopeDraft,
+  SessionScopeSelectionCatalog,
+} from './session-scope-model';
 
 const NO_AUTHORIZATION = '__no_authorization__';
 
@@ -95,6 +99,28 @@ export function setSessionConnectorAuthorization(
     ...draft,
     connector_bindings: connectorBindings,
   };
+}
+
+export function setSessionConnectorEnabled(
+  draft: SessionScopeDraft,
+  connector: SessionScopeConnectorOption,
+  enabled: boolean,
+): SessionScopeDraft {
+  if (!enabled) {
+    return setSessionConnectorAuthorization(draft, connector.slug, null);
+  }
+
+  if (draft.connector_bindings?.[connector.slug]) {
+    return draft;
+  }
+
+  const authorization =
+    connector.authorizations.find((candidate) => candidate.is_default) ??
+    connector.authorizations[0];
+
+  return authorization
+    ? setSessionConnectorAuthorization(draft, connector.slug, authorization.authorization_id)
+    : draft;
 }
 
 function secretSummary(draft: SessionScopeDraft): string {

--- a/apps/web/src/features/session/scope/session-scope-control.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.tsx
@@ -3,6 +3,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { InfoBanner } from '@/components/ui/info-banner';
 import Loading from '@/components/ui/loading';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -14,19 +15,19 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import {
+  CaretDownIcon as ChevronDown,
   KeyIcon as KeyRound,
   PlugIcon as PlugZap,
   SlidersHorizontalIcon as SlidersHorizontal,
   WarningIcon as TriangleAlert,
 } from '@phosphor-icons/react';
+import { useState } from 'react';
 
 import type {
   SessionScopeConnectorOption,
   SessionScopeDraft,
   SessionScopeSelectionCatalog,
 } from './session-scope-model';
-
-const NO_AUTHORIZATION = '__no_authorization__';
 
 export interface SessionScopeControlContentProps {
   draft: SessionScopeDraft;
@@ -126,8 +127,14 @@ export function setSessionConnectorEnabled(
 function secretSummary(draft: SessionScopeDraft): string {
   if (draft.secrets === null) return 'All allowed';
   if (draft.secrets === undefined) return 'Unchanged';
-  if (draft.secrets.length === 0) return 'None allowed';
+  if (draft.secrets.length === 0) return 'None selected';
   return `${draft.secrets.length} selected`;
+}
+
+function connectorSummary(draft: SessionScopeDraft): string {
+  if (draft.connector_bindings === undefined) return 'Unchanged';
+  const count = Object.keys(draft.connector_bindings).length;
+  return count === 0 ? 'None selected' : `${count} selected`;
 }
 
 export function SessionScopeControlContent({
@@ -141,181 +148,234 @@ export function SessionScopeControlContent({
   onSave,
 }: SessionScopeControlContentProps) {
   const controlsDisabled = disabled || saving;
+  const [openSection, setOpenSection] = useState<'secrets' | 'connectors' | null>(null);
 
   return (
-    <div className="flex max-h-[min(560px,calc(100vh-2rem))] flex-col">
-      <div className="border-border border-b px-4 pt-4 pb-3">
-        <h3 className="text-foreground text-sm font-semibold tracking-tight text-balance">
-          Session scope
-        </h3>
+    <div className="flex max-h-[min(500px,calc(100vh-2rem))] flex-col">
+      <div className="border-border border-b px-4 py-3.5">
+        <h3 className="text-foreground text-sm font-medium text-balance">Session access</h3>
         <p className="text-muted-foreground mt-1 text-xs leading-relaxed text-pretty">
-          Choose the secrets and connector authorizations available to this session.
+          Share only the secrets and connectors this session needs.
         </p>
       </div>
 
-      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-4 py-4">
-        <section aria-labelledby="session-scope-secrets" className="space-y-2.5">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex min-w-0 items-center gap-2">
-              <KeyRound className="text-muted-foreground size-3.5 shrink-0" />
-              <h4 id="session-scope-secrets" className="text-foreground text-sm font-medium">
-                Secrets
-              </h4>
-            </div>
-            {catalog.secrets.status === 'ready' ? (
-              <Badge variant="outline" size="xs" className="tabular-nums">
-                {secretSummary(draft)}
+      <div className="min-h-0 flex-1 space-y-2 overflow-y-auto px-3 py-3">
+        <Disclosure
+          open={openSection === 'secrets'}
+          onOpenChange={(open) => setOpenSection(open ? 'secrets' : null)}
+          variant="outline"
+          className="overflow-hidden"
+        >
+          <DisclosureTrigger variant="outline">
+            <Button
+              type="button"
+              variant="popover"
+              className="min-h-12 w-full justify-start rounded-none px-3 py-2 text-left"
+            >
+              <span className="bg-foreground/5 flex size-8 shrink-0 items-center justify-center rounded-sm">
+                <KeyRound className="text-muted-foreground size-4" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="text-foreground block truncate text-sm font-medium">Secrets</span>
+                <span className="text-muted-foreground mt-0.5 block truncate text-xs font-normal">
+                  Environment values
+                </span>
+              </span>
+              <Badge variant="secondary" size="xs" className="tabular-nums">
+                {catalog.secrets.status === 'ready' ? secretSummary(draft) : 'Unavailable'}
               </Badge>
-            ) : null}
-          </div>
+              <ChevronDown className="text-muted-foreground size-3.5 transition-transform group-data-[state=open]:rotate-180" />
+            </Button>
+          </DisclosureTrigger>
+          <DisclosureContent variant="outline" contentClassName="border-border border-t">
+            {catalog.secrets.status === 'unavailable' ? (
+              <div className="p-2">
+                <InfoBanner tone="neutral" title="Secret access is unavailable">
+                  The current secret selection stays unchanged.
+                </InfoBanner>
+              </div>
+            ) : (
+              <div className="p-1">
+                <Checkbox
+                  checked={draft.secrets === null}
+                  disabled={controlsDisabled}
+                  className="min-h-10"
+                  label="Allow every available secret"
+                  onCheckedChange={(checked) =>
+                    onChange(setAllSessionSecrets(draft, checked === true))
+                  }
+                />
+                {catalog.secrets.items.length > 0 ? (
+                  <div className="border-border mt-1 border-t pt-1">
+                    {catalog.secrets.items.map((secret) => {
+                      const checked =
+                        draft.secrets === null ||
+                        draft.secrets?.includes(secret.identifier) === true;
+                      return (
+                        <Checkbox
+                          key={secret.identifier}
+                          checked={checked}
+                          disabled={controlsDisabled}
+                          className="min-h-10"
+                          label={
+                            <span className="flex min-w-0 flex-col gap-0.5">
+                              <span className="text-foreground truncate">{secret.name}</span>
+                              {secret.name !== secret.identifier ? (
+                                <code className="text-muted-foreground truncate text-xs">
+                                  {secret.identifier}
+                                </code>
+                              ) : null}
+                            </span>
+                          }
+                          onCheckedChange={(nextChecked) =>
+                            onChange(
+                              toggleSessionSecret(
+                                draft,
+                                catalog,
+                                secret.identifier,
+                                nextChecked === true,
+                              ),
+                            )
+                          }
+                        />
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground border-border mt-1 border-t px-3 py-3 text-xs text-pretty">
+                    No secrets are available for this agent.
+                  </p>
+                )}
+              </div>
+            )}
+          </DisclosureContent>
+        </Disclosure>
 
-          {catalog.secrets.status === 'unavailable' ? (
-            <InfoBanner tone="neutral" title="Secret access is unavailable">
-              The current secret selection stays unchanged.
-            </InfoBanner>
-          ) : (
-            <div className="bg-popover overflow-hidden rounded-md border">
-              <Checkbox
-                checked={draft.secrets === null}
-                disabled={controlsDisabled}
-                className="min-h-10 rounded-none px-3 py-2"
-                label="Allow every available secret"
-                onCheckedChange={(checked) =>
-                  onChange(setAllSessionSecrets(draft, checked === true))
-                }
-              />
-              {catalog.secrets.items.length > 0 ? (
-                <div className="border-border border-t px-1 py-1">
-                  {catalog.secrets.items.map((secret) => {
-                    const checked =
-                      draft.secrets === null || draft.secrets?.includes(secret.identifier) === true;
-                    return (
-                      <Checkbox
-                        key={secret.identifier}
-                        checked={checked}
-                        disabled={controlsDisabled}
-                        className="min-h-10"
-                        label={
-                          <span className="flex min-w-0 flex-col gap-0.5">
-                            <span className="text-foreground truncate">{secret.name}</span>
-                            <code className="text-muted-foreground truncate text-xs">
-                              {secret.identifier}
-                            </code>
-                          </span>
-                        }
-                        onCheckedChange={(nextChecked) =>
-                          onChange(
-                            toggleSessionSecret(
-                              draft,
-                              catalog,
-                              secret.identifier,
-                              nextChecked === true,
-                            ),
-                          )
-                        }
-                      />
-                    );
-                  })}
-                </div>
-              ) : (
-                <p className="text-muted-foreground border-border border-t px-3 py-3 text-xs text-pretty">
-                  No secrets are available for this agent.
-                </p>
-              )}
-            </div>
-          )}
-        </section>
-
-        <section aria-labelledby="session-scope-connectors" className="space-y-2.5">
-          <div className="flex items-center gap-2">
-            <PlugZap className="text-muted-foreground size-3.5 shrink-0" />
-            <h4 id="session-scope-connectors" className="text-foreground text-sm font-medium">
-              Connectors
-            </h4>
-          </div>
-
-          {catalog.connector_profiles.status === 'unavailable' ? (
-            <InfoBanner tone="neutral" title="Connector access is unavailable">
-              The current connector selection stays unchanged.
-            </InfoBanner>
-          ) : catalog.connector_profiles.items.length === 0 ? (
-            <div className="bg-popover rounded-md border px-3 py-3">
-              <p className="text-muted-foreground text-xs text-pretty">
+        <Disclosure
+          open={openSection === 'connectors'}
+          onOpenChange={(open) => setOpenSection(open ? 'connectors' : null)}
+          variant="outline"
+          className="overflow-hidden"
+        >
+          <DisclosureTrigger variant="outline">
+            <Button
+              type="button"
+              variant="popover"
+              className="min-h-12 w-full justify-start rounded-none px-3 py-2 text-left"
+            >
+              <span className="bg-foreground/5 flex size-8 shrink-0 items-center justify-center rounded-sm">
+                <PlugZap className="text-muted-foreground size-4" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="text-foreground block truncate text-sm font-medium">
+                  Connectors
+                </span>
+                <span className="text-muted-foreground mt-0.5 block truncate text-xs font-normal">
+                  Authorized accounts
+                </span>
+              </span>
+              <Badge variant="secondary" size="xs" className="tabular-nums">
+                {catalog.connector_profiles.status === 'ready'
+                  ? connectorSummary(draft)
+                  : 'Unavailable'}
+              </Badge>
+              <ChevronDown className="text-muted-foreground size-3.5 transition-transform group-data-[state=open]:rotate-180" />
+            </Button>
+          </DisclosureTrigger>
+          <DisclosureContent variant="outline" contentClassName="border-border border-t">
+            {catalog.connector_profiles.status === 'unavailable' ? (
+              <div className="p-2">
+                <InfoBanner tone="neutral" title="Connector access is unavailable">
+                  The current connector selection stays unchanged.
+                </InfoBanner>
+              </div>
+            ) : catalog.connector_profiles.items.length === 0 ? (
+              <p className="text-muted-foreground px-3 py-3 text-xs text-pretty">
                 No connector profiles are available for this agent.
               </p>
-            </div>
-          ) : (
-            <ul className="space-y-2">
-              {catalog.connector_profiles.items.map((connector) => {
-                const currentAuthorization =
-                  draft.connector_bindings?.[connector.slug]?.authorization_id;
-                const currentAuthorizationIsAvailable = connector.authorizations.some(
-                  (authorization) => authorization.authorization_id === currentAuthorization,
-                );
+            ) : (
+              <ul className="space-y-1 p-1">
+                {catalog.connector_profiles.items.map((connector) => {
+                  const currentAuthorization =
+                    draft.connector_bindings?.[connector.slug]?.authorization_id;
+                  const currentAuthorizationIsAvailable = connector.authorizations.some(
+                    (authorization) => authorization.authorization_id === currentAuthorization,
+                  );
+                  const selected = currentAuthorization !== undefined;
+                  const canSelect = selected || connector.authorizations.length > 0;
 
-                return (
-                  <li
-                    key={connector.slug}
-                    className="bg-popover flex min-h-10 items-center gap-3 rounded-md border px-3 py-2"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-1.5">
-                        <p className="text-foreground truncate text-sm font-medium">
-                          {connector.name}
-                        </p>
-                        <Badge variant="outline" size="xs">
-                          {connector.authorization_strategy === 'user' ? 'Private' : 'Project'}
-                        </Badge>
-                      </div>
-                      <p className="text-muted-foreground mt-0.5 truncate font-mono text-xs">
-                        {connector.slug}
-                      </p>
-                    </div>
-
-                    <Select
-                      value={currentAuthorization ?? NO_AUTHORIZATION}
-                      disabled={controlsDisabled}
-                      onValueChange={(authorizationId) =>
-                        onChange(
-                          setSessionConnectorAuthorization(
-                            draft,
-                            connector.slug,
-                            authorizationId === NO_AUTHORIZATION ? null : authorizationId,
-                          ),
-                        )
-                      }
-                    >
-                      <SelectTrigger
-                        size="sm"
-                        className="w-40 shrink-0"
-                        aria-label={`Authorization for ${connector.name}`}
-                      >
-                        <SelectValue placeholder="No authorization" />
-                      </SelectTrigger>
-                      <SelectContent align="end">
-                        <SelectItem value={NO_AUTHORIZATION}>No authorization</SelectItem>
-                        {currentAuthorization && !currentAuthorizationIsAvailable ? (
-                          <SelectItem value={currentAuthorization}>
-                            Current authorization
-                          </SelectItem>
-                        ) : null}
-                        {connector.authorizations.map((authorization) => (
-                          <SelectItem
-                            key={authorization.authorization_id}
-                            value={authorization.authorization_id}
+                  return (
+                    <li key={connector.slug}>
+                      <Checkbox
+                        checked={selected}
+                        disabled={controlsDisabled || !canSelect}
+                        className="min-h-10"
+                        label={
+                          <span className="flex min-w-0 items-center gap-1.5">
+                            <span className="text-foreground truncate">{connector.name}</span>
+                            <Badge variant="outline" size="xs">
+                              {connector.authorization_strategy === 'user' ? 'Private' : 'Project'}
+                            </Badge>
+                            {!canSelect ? (
+                              <span className="text-muted-foreground truncate text-xs font-normal">
+                                No authorization
+                              </span>
+                            ) : null}
+                          </span>
+                        }
+                        onCheckedChange={(checked) =>
+                          onChange(setSessionConnectorEnabled(draft, connector, checked === true))
+                        }
+                      />
+                      {selected ? (
+                        <div className="pr-2 pb-2 pl-10">
+                          <Select
+                            value={currentAuthorization}
+                            disabled={controlsDisabled}
+                            onValueChange={(authorizationId) =>
+                              onChange(
+                                setSessionConnectorAuthorization(
+                                  draft,
+                                  connector.slug,
+                                  authorizationId,
+                                ),
+                              )
+                            }
                           >
-                            {authorization.label}
-                            {authorization.is_default ? ' · Default' : ''}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </section>
+                            <SelectTrigger
+                              size="md"
+                              variant="outline"
+                              className="w-full"
+                              aria-label={`Authorization for ${connector.name}`}
+                            >
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent align="end">
+                              {currentAuthorization && !currentAuthorizationIsAvailable ? (
+                                <SelectItem value={currentAuthorization}>
+                                  Current authorization
+                                </SelectItem>
+                              ) : null}
+                              {connector.authorizations.map((authorization) => (
+                                <SelectItem
+                                  key={authorization.authorization_id}
+                                  value={authorization.authorization_id}
+                                >
+                                  {authorization.label}
+                                  {authorization.is_default ? ' · Default' : ''}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </DisclosureContent>
+        </Disclosure>
 
         {retroactive === false ? (
           <InfoBanner tone="warning" icon={TriangleAlert} title="Existing context is unchanged">
@@ -326,11 +386,11 @@ export function SessionScopeControlContent({
 
       <div className="border-border flex items-center justify-between gap-3 border-t px-4 py-3">
         <p className="text-muted-foreground text-xs leading-relaxed text-pretty">
-          Saved changes apply to the next prompt or tool call.
+          Changes apply to the next prompt.
         </p>
         <Button
           type="button"
-          size="sm"
+          className="h-10 px-4"
           disabled={controlsDisabled || saveDisabled}
           onClick={onSave}
         >
@@ -364,7 +424,7 @@ export function SessionScopeControl({
         side="top"
         align="start"
         sideOffset={8}
-        className="w-[380px] max-w-[calc(100vw-2rem)] overflow-hidden p-0 shadow-md"
+        className="w-[352px] max-w-[calc(100vw-2rem)] overflow-hidden p-0 shadow-md"
       >
         <SessionScopeControlContent {...contentProps} />
       </PopoverContent>

--- a/apps/web/src/features/session/scope/session-scope-model.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.test.ts
@@ -131,7 +131,7 @@ describe('createSessionScopeDraft', () => {
 });
 
 describe('createNewSessionScopeDraft', () => {
-  test('starts from unrestricted secrets and each strategy-compatible default authorization', () => {
+  test('starts with no secrets or connector authorizations selected', () => {
     const catalog = buildSessionScopeSelectionCatalog({
       secrets: ready([secret('MAIL_TOKEN')]),
       connectors: ready([connector('mail-read', 'project'), connector('issues', 'user')]),
@@ -145,11 +145,8 @@ describe('createNewSessionScopeDraft', () => {
     });
 
     expect(createNewSessionScopeDraft(catalog)).toEqual({
-      secrets: null,
-      connector_bindings: {
-        'mail-read': { authorization_id: 'authorization-mail-default' },
-        issues: { authorization_id: 'authorization-issues-only' },
-      },
+      secrets: [],
+      connector_bindings: {},
     });
   });
 

--- a/apps/web/src/features/session/scope/session-scope-model.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.ts
@@ -96,19 +96,10 @@ export function createNewSessionScopeDraft(
 ): SessionScopeDraft {
   const draft: SessionScopeDraft = {};
   if (catalog.secrets.status === 'ready') {
-    draft.secrets = null;
+    draft.secrets = [];
   }
   if (catalog.connector_profiles.status === 'ready') {
-    draft.connector_bindings = Object.fromEntries(
-      catalog.connector_profiles.items.flatMap((connector) => {
-        const authorization =
-          connector.authorizations.find((candidate) => candidate.is_default) ??
-          connector.authorizations[0];
-        return authorization
-          ? [[connector.slug, { authorization_id: authorization.authorization_id }]]
-          : [];
-      }),
-    );
+    draft.connector_bindings = {};
   }
   return draft;
 }

--- a/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
@@ -2,7 +2,11 @@ import type { SessionScope, SessionScopeInput } from '@kortix/sdk';
 import { describe, expect, test } from 'bun:test';
 
 import type { SessionScopeSelectionCatalog } from './session-scope-model';
-import { commitSessionScopeDraft, getSessionScopeAvailability } from './session-scope-toolbar';
+import {
+  commitSessionScopeDraft,
+  createNewSessionScopeInitialization,
+  getSessionScopeAvailability,
+} from './session-scope-toolbar';
 
 const scope = (overrides: Partial<SessionScope> = {}): SessionScope => ({
   secrets_allowlist: ['MAIL_TOKEN'],
@@ -55,6 +59,50 @@ describe('getSessionScopeAvailability', () => {
     ).toEqual({
       secrets: false,
       connector_bindings: true,
+    });
+  });
+});
+
+describe('createNewSessionScopeInitialization', () => {
+  test('commits default-deny scope before the first prompt', () => {
+    expect(createNewSessionScopeInitialization(catalog())).toEqual({
+      draft: {
+        secrets: [],
+        connector_bindings: {},
+      },
+      commit: {
+        draft: {
+          secrets: [],
+          connector_bindings: {},
+        },
+        availability: {
+          secrets: true,
+          connector_bindings: true,
+        },
+      },
+    });
+  });
+
+  test('commits only catalog axes that are available', () => {
+    expect(
+      createNewSessionScopeInitialization(
+        catalog({
+          secrets: { status: 'unavailable' },
+        }),
+      ),
+    ).toEqual({
+      draft: {
+        connector_bindings: {},
+      },
+      commit: {
+        draft: {
+          connector_bindings: {},
+        },
+        availability: {
+          secrets: false,
+          connector_bindings: true,
+        },
+      },
     });
   });
 });

--- a/apps/web/src/features/session/scope/session-scope-toolbar.tsx
+++ b/apps/web/src/features/session/scope/session-scope-toolbar.tsx
@@ -69,6 +69,25 @@ function canonicalDraftFromReplacement(replacement: SessionScopeInput): SessionS
   return draft;
 }
 
+export function createNewSessionScopeInitialization(catalog: SessionScopeSelectionCatalog): {
+  draft: SessionScopeDraft;
+  commit: SessionScopeCommit | undefined;
+} {
+  const availability = getSessionScopeAvailability(catalog);
+  const draft = createNewSessionScopeDraft(catalog);
+  if (!hasAvailableScopeAxis(availability)) {
+    return { draft, commit: undefined };
+  }
+  const replacement = buildSessionScopeReplacement(draft, undefined, availability);
+  return {
+    draft,
+    commit: {
+      draft: canonicalDraftFromReplacement(replacement),
+      availability,
+    },
+  };
+}
+
 export async function commitSessionScopeDraft({
   sessionId,
   draft,
@@ -142,16 +161,21 @@ export function SessionScopeToolbar({
 
   useEffect(() => {
     if (!catalog || !initializationKey) return;
+    if (draftState.key === initializationKey) return;
+    const initialization =
+      sessionId && scope
+        ? {
+            draft: createSessionScopeDraft(scope, catalog),
+            commit: undefined,
+          }
+        : createNewSessionScopeInitialization(catalog);
     setDraftState({
       key: initializationKey,
-      draft:
-        sessionId && scope
-          ? createSessionScopeDraft(scope, catalog)
-          : createNewSessionScopeDraft(catalog),
+      draft: initialization.draft,
     });
     setRetroactive(sessionId ? scope?.retroactive : undefined);
-    if (!sessionId) committedDraftRef.current?.(undefined);
-  }, [catalog, initializationKey, scope, sessionId]);
+    if (!sessionId) committedDraftRef.current?.(initialization.commit);
+  }, [catalog, draftState.key, initializationKey, scope, sessionId]);
 
   const activeCatalog = catalog ?? unavailableCatalog;
   const availability = getSessionScopeAvailability(activeCatalog);


### PR DESCRIPTION
## Summary

- Default new sessions to no secrets and no connector authorizations.
- Replace the large scope panel with compact, collapsed access sections.
- Require an explicit connector selection before showing its authorization picker.
- Preserve existing session scope and unavailable catalog axes.

## Type of change

- [x] New feature
- [x] Refactor / chore

## How was this tested?

- `bun test src/features/session/scope/*.test.ts*` — 41 pass, 0 fail.
- `bun test` — 2,727 pass, 0 fail.
- `bunx prettier --check ...` — passed.
- `bunx eslint ...` — passed.
- `git diff --check` — passed.
- `bunx tsc --noEmit --pretty false` — 15 existing errors in unrelated test files. No error references a changed file.
- Verified the selector on localhost at desktop and 390 px mobile widths.
- Verified secret and connector selection, exclusive section expansion, save feedback, and responsive fit.
- Created a real localhost session from the project page. API read-back returned `secrets_allowlist: []` and `connector_bindings: {}`.

## Security & data review

- [x] No secrets, keys, or credentials are committed.
- [x] No endpoint or authorization logic changes.
- [x] No sensitive data is written to logs.
- [x] No database schema or migration changes.

## Rollout / rollback

- No migration, environment variable, or feature flag is required.
- Revert the three commits to restore the previous default and panel.