### PR TITLE
fix(connectors): lock the authorization owner after creation

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/connector-authorization-lock.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connector-authorization-lock.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * The authorization owner is settled once a connector exists.
+ *
+ * Switching it afterwards silently changes WHOSE account every future session
+ * runs as, and orphans the connection profiles and permission rules already
+ * stored under the old owner — a change shaped like a toggle that behaves like a
+ * migration.
+ *
+ * Locked in the UI ONLY: the mutation and its route are deliberately left in
+ * place so re-enabling is deleting one prop. These assertions exist so that
+ * "leave the backend for later" does not quietly become "the backend rotted".
+ */
+const SECTIONS = import.meta.dir;
+const VIEW = readFileSync(join(SECTIONS, 'connectors-view.tsx'), 'utf8');
+const MODAL = readFileSync(join(SECTIONS, 'connector-profile-modal.tsx'), 'utf8');
+
+describe('connector authorization owner is locked after creation', () => {
+  test('the detail page passes a lockedReason', () => {
+    expect(VIEW).toContain('lockedReason=');
+  });
+
+  test('exactly ONE call site is locked — the create flow must stay editable', () => {
+    // Two call sites exist: the existing-connector detail page and the
+    // custom-connector draft. Locking the draft too would make it impossible to
+    // pick an owner at all.
+    expect(VIEW.match(/lockedReason=/g)?.length ?? 0).toBe(1);
+  });
+
+  test('a lockedReason forces the control off even when disabled is false', () => {
+    // Guards the mechanism, not the copy: passing the reason must be sufficient
+    // on its own, so a future caller cannot lock the text while leaving the
+    // select live.
+    expect(MODAL).toContain('disabled={disabled || pending || locked}');
+  });
+
+  test('the lock REPLACES the description rather than leaving stale help text', () => {
+    // A disabled select under unchanged help reads as a bug — the user tries it,
+    // nothing happens, nothing says why.
+    expect(MODAL).toContain('{lockedReason ??');
+  });
+
+  test('the backend path is still wired, so this stays a one-prop revert', () => {
+    expect(VIEW).toContain('updateAuthorizationStrategy');
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/connector-profile-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connector-profile-modal.tsx
@@ -38,14 +38,24 @@ export function AuthorizationStrategyField({
   onChange,
   disabled = false,
   pending = false,
+  lockedReason,
 }: {
   idPrefix: string;
   value: ConnectorAuthorizationStrategy;
   onChange: (value: ConnectorAuthorizationStrategy) => void;
   disabled?: boolean;
   pending?: boolean;
+  /**
+   * Set on a connector that already exists, where the choice is settled.
+   *
+   * Forces the control off AND replaces the description, because a disabled
+   * select with unchanged help text reads as a bug: the user tries it, nothing
+   * happens, and nothing says why. The reason belongs where the control is.
+   */
+  lockedReason?: string;
 }) {
   const id = `${idPrefix}-authorization-strategy`;
+  const locked = Boolean(lockedReason);
   return (
     <Field>
       <div className="flex items-center justify-between gap-2">
@@ -54,7 +64,7 @@ export function AuthorizationStrategyField({
       </div>
       <Select
         value={value}
-        disabled={disabled || pending}
+        disabled={disabled || pending || locked}
         onValueChange={(next) => onChange(next as ConnectorAuthorizationStrategy)}
       >
         <SelectTrigger id={id}>
@@ -66,9 +76,10 @@ export function AuthorizationStrategyField({
         </SelectContent>
       </Select>
       <FieldDescription className="text-pretty">
-        {value === 'project'
-          ? 'One project-managed account is available to allowed sessions.'
-          : 'Each user authorizes their own account for private sessions.'}
+        {lockedReason ??
+          (value === 'project'
+            ? 'One project-managed account is available to allowed sessions.'
+            : 'Each user authorizes their own account for private sessions.')}
       </FieldDescription>
     </Field>
   );

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -1556,6 +1556,15 @@ function ConnectorDetail({
                 updateAuthorizationStrategy.mutate(next);
               }}
               disabled={!canWrite || !authorizationStrategyEditable}
+              // Settled once the connector exists. Switching owner after the
+              // fact silently changes WHOSE account every future session runs
+              // as, and orphans the profiles and permission rules already
+              // attached under the old owner — a change that looks like a
+              // toggle and behaves like a migration.
+              //
+              // UI-only: `updateAuthorizationStrategy` below and its route are
+              // left intact, so re-enabling is deleting this one prop.
+              lockedReason="Set when the connector was created. Remove and re-add the connector to change it — switching now would orphan the connections and permission rules already stored under the current owner."
               pending={strategyUpdating}
             />
           </div>


### PR DESCRIPTION
The **Authorization owner** select on an existing connector's detail page is now read-only. UI only — the mutation and its route are untouched.

## Why it should not be editable there

Switching owner after the fact silently changes *whose account* every future session runs as, and orphans the connection profiles and permission rules already stored under the old owner. It is a control shaped like a toggle that behaves like a migration.

The create flow is unaffected — that is where the choice belongs, and it stays editable.

## The disabled control explains itself

A greyed-out select under unchanged help text reads as a bug: you click it, nothing happens, and nothing says why. So `lockedReason` both forces the control off **and** replaces the description with the reason and the remedy — remove and re-add the connector.

Forcing off is done inside the component (`disabled || pending || locked`), not by the caller passing both props, so a future call site cannot lock the copy while leaving the select live.

## Left reversible on purpose

`updateAuthorizationStrategy` and its route are intact. Re-enabling is deleting one prop.

Four assertions pin that: the detail page is locked, **exactly one** call site is locked (locking the create draft too would make the owner unpickable), the lock is sufficient on its own, and the mutation is still wired — so "leave the backend for later" does not quietly become "the backend rotted".

## Verification

5 tests, mutation-checked: removing the `lockedReason` prop turns 2 of them red. `tsc --noEmit` clean for both changed files.

Note the pre-existing `@phosphor-icons/react` resolution errors elsewhere in `apps/web` — those are unrelated to this change and present before it.