### PR TITLE
feat(connectors): read-only authorization owner instead of a dead select

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/connector-authorization-lock.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connector-authorization-lock.test.ts
@@ -30,17 +30,21 @@ describe('connector authorization owner is locked after creation', () => {
     expect(VIEW.match(/lockedReason=/g)?.length ?? 0).toBe(1);
   });
 
-  test('a lockedReason forces the control off even when disabled is false', () => {
-    // Guards the mechanism, not the copy: passing the reason must be sufficient
-    // on its own, so a future caller cannot lock the text while leaving the
-    // select live.
-    expect(MODAL).toContain('disabled={disabled || pending || locked}');
+  test('a lockedReason renders a STATEMENT, returning before any Select', () => {
+    // Stronger than disabling: a disabled select keeps its chevron, focus ring
+    // and hover, so it still invites a click that does nothing. The locked path
+    // returns its own read-only block first, so no select exists to click.
+    const lockedBranch = MODAL.indexOf('if (lockedReason) {');
+    const firstSelect = MODAL.indexOf('<Select');
+    expect(lockedBranch).toBeGreaterThan(-1);
+    expect(lockedBranch).toBeLessThan(firstSelect);
   });
 
-  test('the lock REPLACES the description rather than leaving stale help text', () => {
-    // A disabled select under unchanged help reads as a bug — the user tries it,
-    // nothing happens, nothing says why.
-    expect(MODAL).toContain('{lockedReason ??');
+  test('the locked block states the reason and which owner is in force', () => {
+    // Both halves matter: WHICH owner (the thing being read) and WHY it cannot
+    // move (the thing that stops a support ticket).
+    expect(MODAL).toContain('{lockedReason}');
+    expect(MODAL).toContain("isProject ? 'Project' : 'User'");
   });
 
   test('the backend path is still wired, so this stays a one-prop revert', () => {

--- a/apps/web/src/features/workspace/customize/sections/connector-profile-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connector-profile-modal.tsx
@@ -3,6 +3,7 @@
 import type { ConnectorAuthorizationStrategy } from '@kortix/sdk';
 import { useEffect, useState } from 'react';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
@@ -24,6 +25,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
+import { User, UsersThree } from '@phosphor-icons/react';
 
 import {
   connectorProfileSlugAfterNameChange,
@@ -55,7 +57,47 @@ export function AuthorizationStrategyField({
   lockedReason?: string;
 }) {
   const id = `${idPrefix}-authorization-strategy`;
-  const locked = Boolean(lockedReason);
+
+  // Settled connectors get a STATEMENT, not a dead input. A disabled select
+  // still looks operable — it keeps the chevron, the focus ring and the hover —
+  // so it invites a click that does nothing. Reading the value out plainly is
+  // both calmer and more honest about the fact that there is no decision left.
+  if (lockedReason) {
+    const isProject = value === 'project';
+    return (
+      <Field>
+        <FieldLabel>Authorization owner</FieldLabel>
+        <div className="bg-popover flex items-start gap-3 rounded-md border px-3 py-2.5">
+          <span
+            className={cn(
+              'flex size-9 shrink-0 items-center justify-center rounded-sm',
+              isProject ? 'bg-kortix-blue/15' : 'bg-kortix-purple/15',
+            )}
+          >
+            {isProject ? (
+              <UsersThree className="text-kortix-blue size-4" weight="duotone" />
+            ) : (
+              <User className="text-kortix-purple size-4" weight="duotone" />
+            )}
+          </span>
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">{isProject ? 'Project' : 'User'}</span>
+              <Badge variant="outline" size="xs">
+                Fixed
+              </Badge>
+            </div>
+            <p className="text-muted-foreground text-xs text-pretty">
+              {isProject
+                ? 'One project-managed account, shared with allowed sessions.'
+                : 'Each member authorizes their own account, private to their sessions.'}
+            </p>
+          </div>
+        </div>
+        <FieldDescription className="text-pretty">{lockedReason}</FieldDescription>
+      </Field>
+    );
+  }
   return (
     <Field>
       <div className="flex items-center justify-between gap-2">
@@ -64,7 +106,7 @@ export function AuthorizationStrategyField({
       </div>
       <Select
         value={value}
-        disabled={disabled || pending || locked}
+        disabled={disabled || pending}
         onValueChange={(next) => onChange(next as ConnectorAuthorizationStrategy)}
       >
         <SelectTrigger id={id}>
@@ -76,10 +118,9 @@ export function AuthorizationStrategyField({
         </SelectContent>
       </Select>
       <FieldDescription className="text-pretty">
-        {lockedReason ??
-          (value === 'project'
-            ? 'One project-managed account is available to allowed sessions.'
-            : 'Each user authorizes their own account for private sessions.')}
+        {value === 'project'
+          ? 'One project-managed account is available to allowed sessions.'
+          : 'Each user authorizes their own account for private sessions.'}
       </FieldDescription>
     </Field>
   );


### PR DESCRIPTION
Follow-up to #5922. That PR locked the **Authorization owner** by disabling the select — which still *looks* operable. A disabled select keeps its chevron, focus ring and hover, so it invites a click that does nothing.

A settled connector should show a **statement**, not a dead input.

## What it renders now

A tinted icon tile, the owner, a `Fixed` badge, and one line saying what that owner means:

- **Project** — `kortix-blue` tile, `UsersThree` — *"One project-managed account, shared with allowed sessions."*
- **User** — `kortix-purple` tile, `User` — *"Each member authorizes their own account, private to their sessions."*

The reason it cannot change stays underneath, where the help text was.

Follows the house entity-row pattern (`size-9` tinted `rounded-sm` tile, `Badge variant="outline" size="xs"`, `bg-popover rounded-md border`) — the same shape `changes-view` uses.

## On wording

Asked for "user type or team type". I used **Project**, not Team, because that is the word this app already uses everywhere else for `owner_type === 'project'` (*"Shared with the project"*, the `project`/`user` select values). Introducing "Team" here would have made a third name for one concept. The meaning is carried by the description line instead. Say the word and I will switch it globally, but not in one panel only.

## Structure

The locked path `return`s its own block **before** any `<Select>` is constructed, so there is no disabled control to click — stronger than `disabled`, and the test asserts the ordering rather than the styling.

## Verification

5 tests, mutation-checked: neutering the locked branch turns one red; two of them had to be *rewritten* because they pinned the old disable-the-select mechanism and correctly failed when I changed it.

`tsc --noEmit` clean for both changed files — and this time with dependencies actually installed. `@phosphor-icons/react` was unresolved after the 355-commit pull, which would have made any typecheck of this change vacuous, so I ran `pnpm install` first rather than reporting a pass that proved nothing.