### PR TITLE
fix(gateway): Bedrock adaptive thinking + region-prefix normalization

### DIFF
--- a/apps/api/src/llm-gateway/resolution/descriptors.test.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.test.ts
@@ -21,9 +21,12 @@ const getModelPricing = mock(
 );
 mock.module('../../router/config/model-pricing', () => ({ getModelPricing }));
 
-const { livePricing, managedCandidates, stripBedrockInferenceProfilePrefix } = await import(
-  './descriptors'
-);
+const {
+  livePricing,
+  managedCandidates,
+  stripBedrockInferenceProfilePrefix,
+  normalizeBedrockInferenceProfileRegion,
+} = await import('./descriptors');
 
 beforeEach(() => {
   getModelPricing.mockClear();
@@ -75,6 +78,65 @@ describe('stripBedrockInferenceProfilePrefix', () => {
 
   test('a bare prefix with nothing after the dot is left untouched (no empty result)', () => {
     expect(stripBedrockInferenceProfilePrefix('us.')).toBe('us.');
+  });
+});
+
+describe('normalizeBedrockInferenceProfileRegion', () => {
+  test('rewrites a wrong-geography profile to the endpoint region (the Essentia jp.→us. incident)', () => {
+    // 41 sessions on a us-east-1 box were pinned to jp.anthropic.claude-opus-5,
+    // which Bedrock 400s "The provided model identifier is invalid."
+    expect(
+      normalizeBedrockInferenceProfileRegion('jp.anthropic.claude-opus-5', 'us-east-1'),
+    ).toBe('us.anthropic.claude-opus-5');
+  });
+
+  test('maps each endpoint geography from its region (us / eu / apac / us-gov)', () => {
+    expect(normalizeBedrockInferenceProfileRegion('jp.anthropic.claude-opus-5', 'us-west-2')).toBe(
+      'us.anthropic.claude-opus-5',
+    );
+    expect(normalizeBedrockInferenceProfileRegion('jp.anthropic.claude-opus-5', 'eu-west-1')).toBe(
+      'eu.anthropic.claude-opus-5',
+    );
+    expect(
+      normalizeBedrockInferenceProfileRegion('us.anthropic.claude-opus-5', 'ap-northeast-1'),
+    ).toBe('apac.anthropic.claude-opus-5');
+    expect(
+      normalizeBedrockInferenceProfileRegion('jp.anthropic.claude-opus-5', 'us-gov-east-1'),
+    ).toBe('us-gov.anthropic.claude-opus-5');
+  });
+
+  test('is a no-op when the geography already matches the endpoint region', () => {
+    expect(
+      normalizeBedrockInferenceProfileRegion('us.anthropic.claude-sonnet-5', 'us-east-1'),
+    ).toBe('us.anthropic.claude-sonnet-5');
+  });
+
+  test('leaves bare ids, global. profiles, and non-Anthropic families untouched', () => {
+    expect(normalizeBedrockInferenceProfileRegion('anthropic.claude-opus-5', 'us-east-1')).toBe(
+      'anthropic.claude-opus-5',
+    );
+    expect(
+      normalizeBedrockInferenceProfileRegion('global.anthropic.claude-sonnet-5', 'us-east-1'),
+    ).toBe('global.anthropic.claude-sonnet-5');
+    expect(normalizeBedrockInferenceProfileRegion('jp.amazon.nova-pro-v1:0', 'us-east-1')).toBe(
+      'jp.amazon.nova-pro-v1:0',
+    );
+  });
+
+  test('skips normalization for an unrecognized region rather than guessing a prefix', () => {
+    // ca-central-1 has no validated geography mapping → leave the id as-is.
+    expect(
+      normalizeBedrockInferenceProfileRegion('jp.anthropic.claude-opus-5', 'ca-central-1'),
+    ).toBe('jp.anthropic.claude-opus-5');
+  });
+
+  test('falls back to the default BYOK region (us-east-1) when region is unset', () => {
+    expect(normalizeBedrockInferenceProfileRegion('jp.anthropic.claude-opus-5', undefined)).toBe(
+      'us.anthropic.claude-opus-5',
+    );
+    expect(normalizeBedrockInferenceProfileRegion('eu.anthropic.claude-opus-5', '')).toBe(
+      'us.anthropic.claude-opus-5',
+    );
   });
 });
 

--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -67,6 +67,59 @@ export function stripBedrockInferenceProfilePrefix(modelId: string): string {
   return modelId;
 }
 
+// The geography prefixes a CONFIGURED Anthropic-on-Bedrock model id might
+// already carry. Broader than the pricing-strip list above: it also includes
+// the region-specific `jp` (Tokyo) and `au` (Sydney) profiles, which are
+// exactly the ones that end up mismatched against a us-/eu- endpoint.
+const BEDROCK_ANTHROPIC_GEO_PREFIXES = ['us-gov', 'us', 'eu', 'apac', 'jp', 'au'] as const;
+
+// AWS region → the Bedrock cross-region inference-profile geography prefix its
+// endpoint accepts. A profile's geography MUST match the endpoint region's
+// geography — invoking `jp.anthropic.*` against a us-east-1 endpoint 400s "The
+// provided model identifier is invalid." (verified against real Bedrock). Only
+// geographies Kortix has validated are mapped; an unrecognized region returns
+// undefined so normalization is skipped — never rewrite toward a prefix we
+// can't vouch for.
+function regionInferenceGeoPrefix(region: string): string | undefined {
+  const r = region.trim().toLowerCase();
+  if (r.startsWith('us-gov-')) return 'us-gov';
+  if (r.startsWith('us-')) return 'us';
+  if (r.startsWith('eu-')) return 'eu';
+  if (r.startsWith('ap-')) return 'apac';
+  return undefined;
+}
+
+/**
+ * Normalize an Anthropic-on-Bedrock model id's cross-region inference-profile
+ * geography prefix to match the endpoint `region`. A configured id can arrive
+ * with a stale/wrong geography — a picked catalog variant, an old account
+ * default, a session pin (e.g. `jp.anthropic.claude-opus-5` on a us-east-1
+ * box) — which Bedrock rejects with an opaque `400 The provided model
+ * identifier is invalid.` before the turn even starts. Rewriting the prefix to
+ * the endpoint's geography makes a region-mismatched pick self-heal.
+ *
+ * Safe by construction: only rewrites a KNOWN geography prefix to a KNOWN
+ * target geography, and only for `*.anthropic.*` ids. Leaves bare ids,
+ * `global.` profiles, non-Anthropic families, and ids under an unrecognized
+ * region untouched — so it can only ever turn an id that WOULD 400 on this
+ * endpoint into the one that works, never break an already-valid id.
+ * Bedrock-scoped: call only for `kind === 'bedrock'`.
+ */
+export function normalizeBedrockInferenceProfileRegion(
+  modelId: string,
+  region: string | null | undefined,
+): string {
+  const target = regionInferenceGeoPrefix(region?.trim() || DEFAULT_BEDROCK_BYOK_REGION);
+  if (!target) return modelId;
+  for (const prefix of BEDROCK_ANTHROPIC_GEO_PREFIXES) {
+    const withDot = `${prefix}.anthropic.`;
+    if (modelId.startsWith(withDot)) {
+      return prefix === target ? modelId : `${target}.anthropic.${modelId.slice(withDot.length)}`;
+    }
+  }
+  return modelId;
+}
+
 export function livePricing(
   providerId: string,
   modelId: string,

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -80,6 +80,26 @@ mock.module('./descriptors', () => ({
   },
   stripBedrockInferenceProfilePrefix: (modelId: string) =>
     modelId.replace(/^(us-gov|us|eu|apac)\.(?=.)/, ''),
+  // Mirrors the real normalizeBedrockInferenceProfileRegion (descriptors.ts):
+  // rewrites a wrong-geography Anthropic inference-profile prefix to the
+  // endpoint region's geography (us-east-1 → us.); unit-tested directly in
+  // descriptors.test.ts.
+  normalizeBedrockInferenceProfileRegion: (modelId: string, region: string | null | undefined) => {
+    const r = (region?.trim() || 'us-east-1').toLowerCase();
+    const target = r.startsWith('us-gov-')
+      ? 'us-gov'
+      : r.startsWith('us-')
+        ? 'us'
+        : r.startsWith('eu-')
+          ? 'eu'
+          : r.startsWith('ap-')
+            ? 'apac'
+            : undefined;
+    if (!target) return modelId;
+    const m = modelId.match(/^(us-gov|us|eu|apac|jp|au)\.anthropic\.(.+)$/);
+    if (!m) return modelId;
+    return m[1] === target ? modelId : `${target}.anthropic.${m[2]}`;
+  },
   managedCandidates: (managed: { id: string }) => [
     {
       provider: 'kortix-managed',
@@ -262,7 +282,9 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
       kind: 'bedrock',
       baseUrl: 'https://bedrock-runtime.eu-west-1.amazonaws.com',
       apiKey: 'bedrock-bearer-key',
-      resolvedModel: 'us.anthropic.claude-opus-4-8',
+      // Region-normalized: a `us.` inference profile 400s on an eu-west-1
+      // endpoint, so the invoke id is rewritten to the endpoint's geography.
+      resolvedModel: 'eu.anthropic.claude-opus-4-8',
     });
     // The bearer token AND the region are each looked up under their own
     // AWS-standard secret name, project-wide (shared) only — there is no
@@ -287,8 +309,10 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
   // catalogs the BASE Bedrock model id, never the cross-region
   // inference-profile id the user actually requests — so the PRICING lookup
   // must strip the `us./eu./apac./us-gov.` prefix while `resolvedModel` (what
-  // actually gets invoked) keeps the full profile id untouched.
-  test('BYOK Bedrock: pricing lookup strips the cross-region inference-profile prefix, resolvedModel keeps it', async () => {
+  // actually gets invoked) keeps a full profile id. Here the requested `us.`
+  // profile is first region-normalized to `eu.` (eu-west-1 endpoint), then the
+  // pricing lookup strips THAT to the same base id.
+  test('BYOK Bedrock: resolvedModel is region-normalized, pricing still strips to the base id', async () => {
     catalogUpstream = { envVar: 'AWS_BEARER_TOKEN_BEDROCK', kind: 'bedrock' };
     secretsByName = { AWS_BEARER_TOKEN_BEDROCK: 'bedrock-bearer-key', AWS_REGION: 'eu-west-1' };
     const p = principal();
@@ -296,8 +320,22 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
 
     const candidates = await resolveCandidates(p, 'amazon-bedrock/us.anthropic.claude-opus-4-8');
 
-    expect(candidates[0]).toMatchObject({ resolvedModel: 'us.anthropic.claude-opus-4-8' });
+    expect(candidates[0]).toMatchObject({ resolvedModel: 'eu.anthropic.claude-opus-4-8' });
     expect(livePricingCalls).toEqual(['amazon-bedrock/anthropic.claude-opus-4-8']);
+  });
+
+  // The Essentia incident, at the resolve-candidates layer: a session pinned to
+  // a `jp.` opus profile on a us-east-1 box must resolve to the `us.` invoke id
+  // so it stops 400ing "The provided model identifier is invalid."
+  test('BYOK Bedrock: a wrong-geography jp. pin on a us-east-1 box is normalized to us.', async () => {
+    catalogUpstream = { envVar: 'AWS_BEARER_TOKEN_BEDROCK', kind: 'bedrock' };
+    secretsByName = { AWS_BEARER_TOKEN_BEDROCK: 'bedrock-bearer-key', AWS_REGION: 'us-east-1' };
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    const candidates = await resolveCandidates(p, 'amazon-bedrock/jp.anthropic.claude-opus-5');
+
+    expect(candidates[0]).toMatchObject({ resolvedModel: 'us.anthropic.claude-opus-5' });
   });
 
   test('BYOK non-Bedrock provider: pricing lookup is never run through the Bedrock prefix-strip', async () => {

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -17,6 +17,7 @@ import {
   codexDescriptor,
   livePricing,
   managedCandidates,
+  normalizeBedrockInferenceProfileRegion,
   stripBedrockInferenceProfilePrefix,
 } from './descriptors';
 
@@ -167,6 +168,15 @@ export async function resolveCandidates(
           ? await getProjectSecretValue(principal.projectId, BEDROCK_REGION_ENV_VAR)
           : undefined;
       const baseUrl = byok.kind === 'bedrock' ? bedrockByokBaseUrl(bedrockRegion) : byok.baseUrl;
+      // Bedrock invoke id: normalize a wrong-geography cross-region
+      // inference-profile prefix (e.g. a `jp.` pick that got stored as an
+      // account default / session pin on a us-east-1 box) to the endpoint's own
+      // region, so it stops 400ing "The provided model identifier is invalid."
+      // No-op for every other provider and for already-correct ids.
+      const invokeModelId =
+        byok.kind === 'bedrock'
+          ? normalizeBedrockInferenceProfileRegion(resolvedModelId, bedrockRegion)
+          : resolvedModelId;
       const byokDescriptor: UpstreamDescriptor = {
         provider,
         kind: byok.kind,
@@ -177,17 +187,17 @@ export async function resolveCandidates(
         billingMode:
           config.KORTIX_BILLING_INTERNAL_ENABLED && !isFreeTier ? 'platform-fee' : 'none',
         markup: isFreeTier ? 0 : PLATFORM_FEE_MARKUP,
-        resolvedModel: resolvedModelId,
+        resolvedModel: invokeModelId,
         // Bedrock-only: the id used to INVOKE stays the full cross-region
-        // inference-profile id (resolvedModel above) — only the id used to
-        // LOOK UP pricing gets the geography prefix stripped, since the
-        // models.dev catalog only knows the base model id. See
+        // inference-profile id (resolvedModel above, region-normalized) — only
+        // the id used to LOOK UP pricing gets the geography prefix stripped,
+        // since the models.dev catalog only knows the base model id. See
         // stripBedrockInferenceProfilePrefix's doc comment.
         pricing: livePricing(
           provider,
           byok.kind === 'bedrock'
-            ? stripBedrockInferenceProfilePrefix(resolvedModelId)
-            : resolvedModelId,
+            ? stripBedrockInferenceProfilePrefix(invokeModelId)
+            : invokeModelId,
         ),
         reasoning: capabilities.reasoning,
         temperature: capabilities.temperature,

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -604,27 +604,61 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
     expect(args.maxOutputTokens).toBe(4096);
   });
 
-  it('bedrock: reasoning_effort maps to providerOptions.bedrock.reasoningConfig, never providerOptions.anthropic', () => {
+  it('bedrock: reasoning_effort maps to adaptive reasoningConfig + effort (never enabled/budgetTokens), never providerOptions.anthropic', () => {
     const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'medium' }, 'bedrock');
     expect(args.providerOptions).toMatchObject({
-      bedrock: { reasoningConfig: { type: 'enabled', budgetTokens: 8192 } },
+      bedrock: { reasoningConfig: { type: 'adaptive', maxReasoningEffort: 'medium' } },
     });
+    // Current-gen Bedrock Claude (Sonnet 5, Opus 4.5+) 400s on the legacy
+    // enabled/budgetTokens shape — it must NEVER be sent (verified against real
+    // Bedrock us-east-1). Adaptive carries no budget to clamp.
+    expect((args.providerOptions as any)?.bedrock?.reasoningConfig?.type).not.toBe('enabled');
+    expect((args.providerOptions as any)?.bedrock?.reasoningConfig?.budgetTokens).toBeUndefined();
     expect(args.providerOptions).not.toHaveProperty('anthropic');
-    expect((args.providerOptions as any)?.bedrock?.reasoningEffort).toBeUndefined();
     expect(args.maxOutputTokens).toBe(32000);
   });
 
-  it('bedrock: clamps budgetTokens below an explicit small max_tokens (Converse rejects budget >= max)', () => {
+  it('bedrock: max effort maps to adaptive+max even with a small explicit max_tokens (no budget clamp, no enabled)', () => {
     const args = buildAiSdkArgs(
       { messages: [], reasoning_effort: 'max', max_tokens: 2000 },
       'bedrock',
     );
     expect(args.maxOutputTokens).toBe(2000);
-    // max(1024, 2000-1024) = 1024 < the max-effort 32000 budget → clamped to 1024.
+    // Adaptive has no budget to clamp against max_tokens — the whole class of
+    // "budget >= max_tokens" Converse 400s disappears with adaptive.
     expect((args.providerOptions as any)?.bedrock?.reasoningConfig).toEqual({
-      type: 'enabled',
-      budgetTokens: 1024,
+      type: 'adaptive',
+      maxReasoningEffort: 'max',
     });
+  });
+
+  it('bedrock: every reasoning_effort level maps to an adaptive effort tier and NEVER emits type:"enabled" (minimal folds to low)', () => {
+    const cases: Array<[string, string]> = [
+      ['minimal', 'low'],
+      ['low', 'low'],
+      ['medium', 'medium'],
+      ['high', 'high'],
+      ['xhigh', 'xhigh'],
+      ['max', 'max'],
+    ];
+    for (const [effort, tier] of cases) {
+      const args = buildAiSdkArgs({ messages: [], reasoning_effort: effort }, 'bedrock');
+      expect((args.providerOptions as any)?.bedrock?.reasoningConfig).toEqual({
+        type: 'adaptive',
+        maxReasoningEffort: tier,
+      });
+    }
+  });
+
+  it('bedrock: a raw body.thinking:{type:"enabled",budget_tokens} is normalized to adaptive (never forwarded verbatim)', () => {
+    const args = buildAiSdkArgs(
+      { messages: [], thinking: { type: 'enabled', budget_tokens: 5000 } },
+      'bedrock',
+    );
+    // The old enabled/budgetTokens shape current-gen Bedrock Claude rejects must
+    // never reach the wire — even when the client itself sent it.
+    expect((args.providerOptions as any)?.bedrock?.reasoningConfig?.type).toBe('adaptive');
+    expect((args.providerOptions as any)?.bedrock?.reasoningConfig?.budgetTokens).toBeUndefined();
   });
 
   it('does not set thinking/reasoningConfig or bump maxOutputTokens for openai/openai-compatible families', () => {

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -620,16 +620,24 @@ function applyAnthropicThinking(
   return { thinking: { type: 'adaptive' }, effort: resolved.effort };
 }
 
-// @ai-sdk/amazon-bedrock — Bedrock's Converse API still uses the
-// `reasoningConfig: {type:"enabled", budgetTokens}` shape (it has NOT adopted
-// Anthropic's adaptive/output_config surface). Converse rejects
-// budgetTokens >= max output tokens, so clamp below the answer headroom.
+// @ai-sdk/amazon-bedrock — current-gen Bedrock Claude (Sonnet 5, Opus 4.5+/4.8)
+// REJECTS the legacy `reasoningConfig:{type:"enabled", budgetTokens}` shape with
+// the SAME 400 as direct Anthropic ("`thinking.type.enabled` is not supported
+// for this model. Use `thinking.type.adaptive` and `output_config.effort`").
+// Bedrock's Converse API HAS adopted the adaptive surface: @ai-sdk/amazon-bedrock
+// serializes `reasoningConfig:{type:"adaptive", maxReasoningEffort}` to the wire's
+// `additionalModelRequestFields.thinking={type:"adaptive"}` + `output_config.effort`
+// — the exact pair the error demands. So mirror `applyAnthropicThinking`: drive
+// extended thinking through ADAPTIVE + an effort tier (the model manages its own
+// budget; the caller's maxOutputTokens bump gives thinking + answer headroom).
+// Verified against real Bedrock (us-east-1): `enabled` 400s on Sonnet 5 / Opus
+// 4.6 / 4.8; `adaptive` + effort returns 200 on all three. Every managed Bedrock
+// Claude is >= 4.6 (adaptive-capable) and pre-adaptive Claude (3.7) is EOL on
+// Bedrock, so no served model still needs the old `enabled` shape.
 function applyBedrockThinking(
   resolved: ResolvedThinking,
-  maxTokens: number,
 ): Pick<BedrockProviderOptions, 'reasoningConfig'> {
-  const budgetTokens = Math.min(resolved.budgetTokens, Math.max(1024, maxTokens - 1024));
-  return { reasoningConfig: { type: 'enabled', budgetTokens } };
+  return { reasoningConfig: { type: 'adaptive', maxReasoningEffort: resolved.effort } };
 }
 
 const ANTHROPIC_CACHE_CONTROL = { type: 'ephemeral' } as const;
@@ -931,16 +939,10 @@ const bedrockAdapter: ProviderAdapter = {
   buildProviderOptions(req) {
     const options: BedrockProviderOptions = {};
     const thinking = resolveThinkingRequest(req.raw, req.reasoningEffort);
-    if (thinking) {
-      // Mirrors this adapter's own `defaultMaxTokens`: when a thinking budget
-      // is present, the EFFECTIVE max tokens for this request is always
-      // `explicitMaxTokens ?? DEFAULT_MAX_TOKENS_WITH_THINKING` (the plain
-      // 4096 default never applies once thinking is on) — needed here too so
-      // the budget clamp below matches the ceiling the orchestrator actually
-      // sends as `maxOutputTokens`.
-      const maxTokens = req.explicitMaxTokens ?? DEFAULT_MAX_TOKENS_WITH_THINKING;
-      Object.assign(options, applyBedrockThinking(thinking, maxTokens));
-    }
+    // Adaptive thinking carries no token budget to clamp — the model manages
+    // its own. `defaultMaxTokens` below still bumps maxOutputTokens so thinking
+    // + answer share enough headroom.
+    if (thinking) Object.assign(options, applyBedrockThinking(thinking));
     return options;
   },
   defaultMaxTokens(req) {


### PR DESCRIPTION
## Two Bedrock-provider bugs hitting Essentia (both confirmed against real Bedrock)

Reproduced and fixed each against live `bedrock-runtime` (us-east-1) via the Essentia AWS profile.

### 1. Adaptive thinking — every high/Max-effort Bedrock turn 400s
`applyBedrockThinking` emitted `reasoningConfig:{type:'enabled',budgetTokens}`. Current-gen Bedrock Claude (Sonnet 5, Opus 4.5+) rejects it:

> `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort"`

The `anthropic` sibling already switched to adaptive; the `bedrock` adapter was missed. Now emits `reasoningConfig:{type:'adaptive',maxReasoningEffort}`.

**Proof (real Bedrock, us-east-1):**
| shape | Sonnet 5 | Opus 4.6 | Opus 4.8 |
|---|---|---|---|
| `enabled+budgetTokens` (old) | 400 | — | — |
| `adaptive+maxReasoningEffort` (new) | 200 | 200 | 200 |

Also proven end-to-end through the real `@ai-sdk/amazon-bedrock@5.0.24` provider: old shape → 400 (exact error), new shape → 200. No served model needs the old shape (all managed Bedrock Claude ≥ 4.6; Claude 3.7 is EOL on Bedrock).

### 2. Region-prefix mismatch — opaque "invalid model identifier"
A configured cross-region inference-profile id with the wrong geography (e.g. `jp.anthropic.claude-opus-5` on a us-east-1 box) reached Bedrock verbatim → `400 The provided model identifier is invalid.` This hit the Essentia account default + 41 session pins + title-generate.

`normalizeBedrockInferenceProfileRegion` rewrites the geography prefix to the endpoint region (`jp.`→`us.`) in `resolve-candidates`, so a mismatched pick self-heals. **Safe by construction:** only rewrites a known geography prefix to a known target geography; leaves bare ids, `global.` profiles, non-Anthropic families, and unrecognized regions untouched — it can only turn an id that WOULD 400 on this endpoint into the one that works, never break a valid id.

**Proof:** `jp.anthropic.claude-opus-5` → 400; `us.anthropic.claude-opus-5` → 200 (real Bedrock).

## Tests
- `ai-sdk.test.ts`: adaptive tier mapping (minimal→low … max→max) + never-emit-`enabled` regression guard + raw `thinking:{type:'enabled'}` normalized to adaptive.
- `descriptors.test.ts`: normalizer matrix (us/eu/apac/us-gov, no-op-when-matched, bare/global/non-Anthropic/unknown-region untouched, unset→default us-east-1).
- `resolve-candidates.test.ts`: `jp.`→`us.` normalization in the BYOK Bedrock descriptor.

All green locally. `bunx tsc --noEmit` clean on the gateway package.

## Scope
Gateway-only. Does **not** touch model enablement (separate revert PR).
