### PR TITLE
fix(tests): drop leftover public routines in db-reset so re-apply matches a fresh DB

### DIFF
--- a/tests/migration/scripts/db-reset.sh
+++ b/tests/migration/scripts/db-reset.sh
@@ -7,6 +7,12 @@ source "${SCRIPT_DIR}/env.sh"
 # clean database in the SAME running container (no teardown), then re-applies
 # from scratch. Use between test runs to get a fresh apply without paying the
 # container start cost. For a full teardown (container + volume), use db-down.sh.
+#
+# Migrations also create routines directly in public (the credit RPCs). Those
+# survive the schema drops, and a later migration can change their parameter
+# defaults — then the baseline's CREATE OR REPLACE fails with 42P13 ("cannot
+# remove parameter defaults"). Drop every non-extension routine in public so a
+# reset re-applies onto the same state as a fresh database.
 
 log "Resetting test database ${TEST_DB_NAME}"
 
@@ -16,6 +22,23 @@ DROP SCHEMA IF EXISTS basejump CASCADE;
 DROP SCHEMA IF EXISTS kortix_migrations CASCADE;
 DROP TABLE IF EXISTS public.daily_refresh_tracking CASCADE;
 DROP TABLE IF EXISTS public.renewal_processing CASCADE;
+DO \$\$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    WHERE p.pronamespace = 'public'::regnamespace
+      AND p.prokind IN ('f', 'p')
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.deptype = 'e'
+      )
+  LOOP
+    EXECUTE format('DROP ROUTINE %s CASCADE', r.sig);
+  END LOOP;
+END
+\$\$;
 " >/dev/null
 
 log "Re-applying migrations from scratch"


### PR DESCRIPTION
## Problem

QA-staging `db migration tests` fail on every run since `20260730012238065_credit_use_credits_single_overload` landed (first red: staging run 30626038034, blocking the v0.12.0 promote).

- Migrations create the credit RPCs directly in `public`. `db-reset.sh` drops only the `kortix`/`basejump`/`kortix_migrations` schemas, so those routines survive a reset.
- `20260730012238065` adds parameter defaults to `public.atomic_use_credits(uuid,numeric,text,text)`.
- On re-apply, the baseline's `CREATE OR REPLACE` of the same signature **without** defaults fails: `42P13 cannot remove parameter defaults from existing function`.

Forward-only environments (dev/staging/prod) never re-apply the baseline — this breaks only the reset path in the test harness. The fresh-DB bootstrap is unaffected.

## Fix

`db-reset.sh` now also drops every non-extension routine in `public` (prokind f/p, no `pg_depend` extension edge), so a reset re-applies onto the same state as a fresh database. Generic — the next migration that changes a public routine signature cannot re-break it.

## Verification

- `cd tests && npm run test:migration` → exit 0, all 14 cases green, including `db-reset drops and re-applies cleanly` and `schema present again after reset (105 tables)`.
- Reproduced the failure first on unfixed main with the same command (exit 1, 42P13).
