### PR TITLE
Merge main into staging — user menu reorder (#5941)

### DIFF
--- a/apps/web/src/app/(public)/(marketing)/design-system/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/design-system/page.tsx
@@ -2387,7 +2387,7 @@ export default function BrandPage() {
                         <DropdownMenuItem>Duplicate</DropdownMenuItem>
                         <DropdownMenuItem>Archive</DropdownMenuItem>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
+                        <DropdownMenuItem>Delete</DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
                   </DemoContainer>

--- a/apps/web/src/components/iam/service-accounts-card.tsx
+++ b/apps/web/src/components/iam/service-accounts-card.tsx
@@ -176,7 +176,7 @@ export function ServiceAccountsCard({ accountId, canManage }: ServiceAccountsCar
                             Disable
                           </DropdownMenuItem>
                         )}
-                        <DropdownMenuItem onClick={() => setDeleteTarget(sa)} variant="destructive">
+                        <DropdownMenuItem onClick={() => setDeleteTarget(sa)}>
                           <Trash2 className="size-3.5 shrink-0" />
                           Delete permanently
                         </DropdownMenuItem>

--- a/apps/web/src/components/projects/schedule-view.tsx
+++ b/apps/web/src/components/projects/schedule-view.tsx
@@ -974,7 +974,7 @@ function TriggerDetailToolbar({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
-          <DropdownMenuItem onClick={onDelete} variant="destructive">
+          <DropdownMenuItem onClick={onDelete}>
             <TrashIcon className="shrink-0" />
             Delete trigger
           </DropdownMenuItem>

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -2,12 +2,7 @@
 
 import { cn } from '@/lib/utils';
 import { floatingZ, useDialogDepth } from '@/lib/z-stack';
-// import { CaretRightIcon as ChevronRight, CircleIcon as Circle } from '@phosphor-icons/react';
-import {
-  CheckIcon as Check,
-  CaretRightIcon as ChevronRight,
-  CircleIcon as Circle,
-} from '@phosphor-icons/react';
+import { CheckIcon as Check, CaretRightIcon as ChevronRight } from '@phosphor-icons/react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import * as React from 'react';
 import { triggerVariants, type TriggerVariantProps } from './trigger-variants';
@@ -250,10 +245,19 @@ const DropdownMenuRadioItem = React.forwardRef<
     side?: 'left' | 'right';
   }
 >(({ className, children, size = 'sm', side = 'right', ...props }, ref) => {
+  /**
+   * A check, not a dot, and the same check `DropdownMenuCheckboxItem` uses.
+   *
+   * This was `<Circle className="h-2 w-2 fill-current" />`, which could not
+   * work: Phosphor's CircleIcon is a stroked outline, so `fill-current` painted
+   * nothing, and `MENU_ROW_BASE`'s `[&_svg]:size-4` — a descendant selector —
+   * outranked the `h-2 w-2` sitting on the icon itself. The mark rendered as a
+   * hollow ring. No consumer had ever rendered a RadioItem, so nobody saw it.
+   */
   const indicator = (
     <span className="flex size-3.5 shrink-0 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <Check className="text-muted-foreground size-3.5" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
   );

--- a/apps/web/src/features/layout/user-menu.test.tsx
+++ b/apps/web/src/features/layout/user-menu.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Icon } from '@/features/icon/icon';
+
+import { THEME_OPTIONS } from './user-menu';
+
+/**
+ * What is NOT covered here, and why.
+ *
+ * The user menu's row order, the Theme submenu's radio semantics and the
+ * selected-state check all live inside a Radix `DropdownMenuContent`, which
+ * renders nothing until the menu is open and then renders through a portal.
+ * `apps/web` has no DOM harness — no jsdom, no testing-library — and
+ * `renderToStaticMarkup` returns an empty string for portalled content, so none
+ * of that is reachable from a unit test. It is verified by driving the real
+ * menu in a browser.
+ *
+ * What IS reachable is the contract the submenu is built from: the three theme
+ * values, their labels, their order, and the icons they share with the
+ * Appearance tab. That is what this file locks.
+ */
+describe('THEME_OPTIONS', () => {
+  test('offers exactly the three values next-themes accepts', () => {
+    expect(THEME_OPTIONS.map((option) => option.value)).toEqual(['light', 'dark', 'system']);
+  });
+
+  test('keeps System, so the menu can still hand the choice back to the OS', () => {
+    // Dropping this row would silently pin every user to a fixed theme with no
+    // way back to following the system, which is the default for a new account.
+    expect(THEME_OPTIONS.some((option) => option.value === 'system')).toBe(true);
+  });
+
+  test('labels each value the way the Appearance tab labels it', () => {
+    expect(THEME_OPTIONS.map((option) => option.label)).toEqual(['Light', 'Dark', 'System']);
+  });
+
+  test('draws each row with the shared icon the Appearance tab uses', () => {
+    // Identity, not resemblance: the submenu and the settings tab must render
+    // the same component, or the two surfaces drift into different glyphs for
+    // the same choice.
+    expect(THEME_OPTIONS.map((option) => option.Icon)).toEqual([
+      Icon.Sun,
+      Icon.Moon,
+      Icon.Monitor,
+    ]);
+  });
+
+  test('pairs every value with a label and an icon', () => {
+    for (const option of THEME_OPTIONS) {
+      expect(option.label.length).toBeGreaterThan(0);
+      expect(typeof option.Icon).toBe('function');
+    }
+  });
+});

--- a/apps/web/src/features/layout/user-menu.tsx
+++ b/apps/web/src/features/layout/user-menu.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ThemeToggle } from '@/components/home/theme-toggle';
 import { ReferralModal } from '@/components/referrals/referral-modal';
 import {
   AlertDialog,
@@ -18,6 +17,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -61,9 +62,11 @@ import {
 } from '@phosphor-icons/react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
+import { useTheme } from 'next-themes';
 import { useRouter } from 'next/navigation';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
+import { Icon } from '../icon/icon';
 
 export type UserMenuVariant = 'header' | 'sidebar';
 
@@ -106,6 +109,18 @@ const LEGAL_LINKS: MenuLink[] = [
   { label: 'Terms and conditions', href: '/legal?tab=terms', Icon: ScrollIcon },
 ];
 
+/**
+ * The three theme values `next-themes` accepts, in the order the rest of the
+ * product lists them (see the Appearance tab in user settings — same words, same
+ * icons, same order). A person who learns the control in one place should not
+ * have to re-read it in the other.
+ */
+export const THEME_OPTIONS = [
+  { value: 'light', label: 'Light', Icon: Icon.Sun },
+  { value: 'dark', label: 'Dark', Icon: Icon.Moon },
+  { value: 'system', label: 'System', Icon: Icon.Monitor },
+] as const;
+
 export interface UserMenuUser {
   name: string;
   email: string;
@@ -124,6 +139,7 @@ export function UserMenu({
   const tHardcodedUi = useTranslations('hardcodedUi');
   const router = useRouter();
   const sidebar = React.useContext(SidebarContext);
+  const { theme, setTheme, resolvedTheme } = useTheme();
   const { selectedAccountId, setSelectedAccountId } = useCurrentAccountStore();
   const { isOpen: referralOpen, closeDialog: closeReferral } = useReferralDialog();
 
@@ -311,6 +327,53 @@ export function UserMenu({
           {tI18nHardcoded.raw('autoFeaturesLayoutUserMenuJsxTextDownloadApps2765d8e7')}
         </DropdownMenuItem>
 
+        {isBillingEnabled() && canManageBilling && (
+          <DropdownMenuItem
+            onClick={() =>
+              deferAfterClose(() =>
+                useAccountSettingsModalStore.getState().openAccountSettings({ tab: 'billing' }),
+              )
+            }
+            size="sm"
+          >
+            <CreditCard />
+            Billing
+          </DropdownMenuItem>
+        )}
+
+        {/* Theme used to be a segmented control pinned below Log out — the one
+            row in the menu that was not a menu item, sitting under the one row
+            that ends your session. It is a choice between three values, so it is
+            a submenu of three rows like any other, and it sits with Help because
+            both are settings you visit rather than places you go.
+
+            The leading icon shows the theme currently in effect, not the value
+            stored: on `system` it tracks what the OS resolved to, which is the
+            only answer to "what am I looking at right now". */}
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {resolvedTheme === 'dark' ? <Icon.Moon /> : <Icon.Sun />}
+            Theme
+          </DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent className="space-y-0.5" sideOffset={6}>
+              <DropdownMenuRadioGroup value={theme ?? 'system'} onValueChange={setTheme}>
+                {THEME_OPTIONS.map(({ value, label, Icon }) => (
+                  <DropdownMenuRadioItem key={value} value={value}>
+                    {/* RadioItem wraps its children in a single flex-1 span to
+                        push the check to the right edge, so the icon and label
+                        need their own flex row inside it to stay aligned. */}
+                    <span className="flex items-center gap-2">
+                      <Icon />
+                      {label}
+                    </span>
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
+
         {/* Every reference and legal page collapses into one submenu, so the top
             level only carries things you act on rather than eight links. */}
         <DropdownMenuSub>
@@ -329,42 +392,15 @@ export function UserMenu({
           </DropdownMenuPortal>
         </DropdownMenuSub>
 
-        {isBillingEnabled() && canManageBilling && (
-          <DropdownMenuItem
-            onClick={() =>
-              deferAfterClose(() =>
-                useAccountSettingsModalStore.getState().openAccountSettings({ tab: 'billing' }),
-              )
-            }
-            size="sm"
-          >
-            <CreditCard />
-            Billing
-          </DropdownMenuItem>
-        )}
-
-        <DropdownMenuItem variant="destructive" onClick={openLogoutConfirm} size="sm">
-          <LogOut />
-
-          {tHardcodedUi.raw('componentsLayoutUserMenu.line248JsxAttrLabelLogOut')}
-        </DropdownMenuItem>
-
+        {/* Log out is the only row that ends something, so it gets its own
+            group. Nothing sits below it — the last item in a menu is the one a
+            slipped pointer lands on. */}
         <DropdownMenuSeparator />
 
-        {/* Not a menu item: it hosts a toggle rather than being selectable. It
-            still has to sit in the same column as the items above it, hence the
-            shared row geometry. The focus: and data-disabled: rules it used to
-            carry were dead — this div is not focusable and Radix never marks it
-            disabled, so only the ThemeToggle inside ever takes focus. */}
-        <div
-          className={cn(
-            'text-foreground/80 flex cursor-default items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-sm font-normal select-none',
-            '[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
-          )}
-        >
-          Theme
-          <ThemeToggle variant="compact" />
-        </div>
+        <DropdownMenuItem onClick={openLogoutConfirm} size="sm">
+          <LogOut />
+          {tHardcodedUi.raw('componentsLayoutUserMenu.line248JsxAttrLabelLogOut')}
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/features/projects/project-card.tsx
+++ b/apps/web/src/features/projects/project-card.tsx
@@ -85,11 +85,7 @@ const ProjectCard = ({
               Rename
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem
-              variant="destructive"
-              onSelect={onArchive}
-              disabled={archiving || !canManageProject}
-            >
+            <DropdownMenuItem onSelect={onArchive} disabled={archiving || !canManageProject}>
               {archiving ? (
                 <Loading className="size-4 shrink-0" />
               ) : (

--- a/apps/web/src/features/session/header/session-site-header.test.tsx
+++ b/apps/web/src/features/session/header/session-site-header.test.tsx
@@ -90,10 +90,14 @@ describe('SessionSiteHeader trailing cluster — non-technical resting state', (
   });
 });
 
-describe('SessionSiteHeader "more actions" menu — destructive last, technical items subordinate', () => {
-  test('Delete is the last item and the only variant="destructive" entry', () => {
+describe('SessionSiteHeader "more actions" menu — Delete last, technical items subordinate', () => {
+  test('Delete is the last item and no row is styled destructive', () => {
+    // Delete opens SessionDeleteModal; the click itself destroys nothing, so
+    // the red belongs on the dialog's confirm button, not on a menu row that
+    // only asks a question. Position still carries the weight here — Delete
+    // sits last, where a slipped pointer lands on nothing worse.
     const destructiveMatches = source.match(/variant="destructive"/g) ?? [];
-    expect(destructiveMatches.length).toBe(1);
+    expect(destructiveMatches.length).toBe(0);
 
     // `Delete` also appears earlier as a substring of the `SessionDeleteModal`
     // import — anchor on the destructive button's own icon instead.

--- a/apps/web/src/features/session/header/session-site-header.tsx
+++ b/apps/web/src/features/session/header/session-site-header.tsx
@@ -318,7 +318,6 @@ export function SessionSiteHeader({
                     <DropdownMenuItem
                       className="cursor-pointer"
                       onClick={() => setDeleteOpen(true)}
-                      variant="destructive"
                     >
                       <TrashIcon />
                       Delete

--- a/apps/web/src/features/tunnel/tunnel-settings-dialog.tsx
+++ b/apps/web/src/features/tunnel/tunnel-settings-dialog.tsx
@@ -98,7 +98,7 @@ export function TunnelSettingsDialog({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-48">
-                  <DropdownMenuItem onClick={onDelete} variant="destructive">
+                  <DropdownMenuItem onClick={onDelete}>
                     <TrashIcon className="shrink-0" />
                     Delete connection
                   </DropdownMenuItem>

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -924,11 +924,7 @@ function ConnectionRow({
               Use by default{isProjectAuthorization ? ' for the project' : ''}
             </DropdownMenuItem>
           )}
-          {mayMutate && (
-            <DropdownMenuItem variant="destructive" onClick={onDisconnect}>
-              Disconnect
-            </DropdownMenuItem>
-          )}
+          {mayMutate && <DropdownMenuItem onClick={onDisconnect}>Disconnect</DropdownMenuItem>}
         </DropdownMenuContent>
       </DropdownMenu>
     </li>

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-keys.tsx
@@ -180,7 +180,6 @@ export function GatewayKeys({
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end" className="w-44">
                           <DropdownMenuItem
-                            variant="destructive"
                             onClick={() => setRevokeTarget({ key_id: k.key_id, name: k.name })}
                           >
                             <Trash2 className="size-3.5 shrink-0" />

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -478,7 +478,7 @@ function SecretTableRow({
                 {row.configured ? 'Edit secret' : 'Set value'}
               </DropdownMenuItem>
               {row.configured && (
-                <DropdownMenuItem onClick={onDelete} variant="destructive">
+                <DropdownMenuItem onClick={onDelete}>
                   <TrashIcon className="size-3.5 shrink-0" />
                   {tI18nHardcoded.raw(
                     'autoComponentsProjectsCustomizeSectionsSecretsViewJsxTextDeleteSharedd7bb1731',

--- a/apps/web/src/features/workspace/project-sessions/project-sessions-view.tsx
+++ b/apps/web/src/features/workspace/project-sessions/project-sessions-view.tsx
@@ -385,10 +385,7 @@ function SessionRow({
                       </DropdownMenuItem>
                     ) : null}
                     {hasLifecycleActions ? (
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onSelect={() => onDelete(session.session_id, title)}
-                      >
+                      <DropdownMenuItem onSelect={() => onDelete(session.session_id, title)}>
                         <TrashIcon />
                         Delete
                       </DropdownMenuItem>

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -491,7 +491,6 @@ function ProjectSessionRow({
                 <DropdownMenuItem
                   className="cursor-pointer"
                   onSelect={() => deferAfterClose(() => onDelete(session.session_id, displayTitle))}
-                  variant="destructive"
                 >
                   <TrashIcon />
                   Delete

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-58065906"
+  tag: "dev-b1b33ff8"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
Brings `main` up to `staging` ahead of the next production promote.

## Summary

- `de58e07b2` — Reorder the user menu, make Theme a submenu, drop the destructive dropdown variant (#5941)
- `938fbfd93` — `chore(dev-eks)`: deploy dev-b1b33ff8 [skip ci] (GitOps image pin, no app code)

This is the last of the eight commits targeted for this release; the other seven are already on `staging`.

## Test plan

- `git merge-tree origin/staging origin/main` reports no conflicts.
- Build Staging Artifacts + QA - staging must go green on the resulting staging SHA before promote.