### PR TITLE
Allow agent switches within one session

### DIFF
--- a/apps/api/src/config-agent-switch.test.ts
+++ b/apps/api/src/config-agent-switch.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test';
+
+// config.ts validates the complete process environment during import. Supply
+// inert local values so this test covers the schema default without depending
+// on a developer's dotenv files or CI secrets.
+process.env.DATABASE_URL ??= 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+process.env.SUPABASE_URL ??= 'http://127.0.0.1:54321';
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= 'test-service-role-key';
+process.env.API_KEY_SECRET ??= 'test-api-key-secret';
+process.env.KORTIX_URL ??= 'http://127.0.0.1:8008';
+process.env.TUNNEL_ENABLED = 'false';
+delete process.env.KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK;
+
+const { config } = await import('./config');
+
+test('agent secret-grant switching is allowed when the lock is not explicitly enabled', () => {
+  expect(config.KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK).toBe(false);
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -256,17 +256,13 @@ const envSchema = z.object({
   // the executor token is re-minted per requested agent before tool execution.
   KORTIX_ENFORCE_SESSION_AGENT_LOCK: optBoolFalse,
 
-  // The NARROWER lock that IS on by default: refuse only an in-session agent
-  // switch that would change which project SECRETS are in scope. Ordinary
-  // switching between agents with the same `secrets` grant stays free, so this
-  // doesn't reintroduce the false-positives that gated the name-based lock
-  // above off. It exists because a sandbox's env is provisioned for ONE grant:
-  // re-scoping it on a later turn cannot un-read what the previous agent
-  // already pulled into the box's tmpfs env file, its shells, and its context.
-  // Turning it off degrades to re-scoping onto the running agent's grant — it
-  // never restores the old behavior of resolving from the session's stale
-  // create-time agent. See projects/lib/secret-grant.ts.
-  KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK: optBoolTrue,
+  // Optional strict lock for operators that require one immutable secret grant
+  // per sandbox. OFF by default: an in-session agent switch re-resolves the
+  // running agent's grant, replaces the OpenCode env, and re-mints the session
+  // token's connector/Kortix-CLI grant before the prompt is forwarded. Enabling
+  // this flag refuses only switches whose secret grants differ. See
+  // projects/lib/secret-grant.ts.
+  KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK: optBoolFalse,
 
   // Mandatory declared agents (docs/specs/2026-07-05-agent-first-config-unification.md
   // §2.1/§3 Phase 2). GATED OFF platform-wide by default — flipping it on would

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -71,7 +71,9 @@ async function resolveOwnerRawEnv(
   // re-pushed the broad agent's full env on every turn. A switch that would
   // change the grant now throws AgentSecretGrantMismatchError (→ 409) rather
   // than quietly re-scoping, because a later narrowing cannot un-read what the
-  // previous agent already pulled into the box.
+  // previous agent already pulled into the box when the optional strict lock
+  // is enabled. By default, the hot push replaces the env with the running
+  // agent's grant before the prompt is forwarded.
   const [project] = await db
     .select({
       repoUrl: projects.repoUrl,

--- a/apps/api/src/projects/lib/secret-grant.test.ts
+++ b/apps/api/src/projects/lib/secret-grant.test.ts
@@ -263,6 +263,28 @@ describe('resolveSessionSecretGrant', () => {
     ).rejects.toThrow(AgentSecretGrantMismatchError);
   });
 
+  test('re-scopes to the running agent when the optional strict lock is disabled', async () => {
+    loadProjectAgentsImpl = async () =>
+      loaded([
+        spec('narrow', ['NPM_TOKEN'], { connectors: ['registry'], kortixCli: [] }),
+        spec('broad', 'all', { connectors: 'all', kortixCli: 'all' }),
+      ]);
+
+    const grant = await resolveSessionAgentGrant({
+      ...PROJECT,
+      sessionAgent: 'narrow',
+      requestedAgent: 'broad',
+      enforceGrantLock: false,
+    });
+
+    expect(grant).toMatchObject({
+      agent: 'broad',
+      env: 'all',
+      connectors: 'all',
+      kortixCli: 'all',
+    });
+  });
+
   test('ALLOWS a switch that changes only the connector grant', async () => {
     // Identical secrets, different connectors. This must NOT 409: per-agent
     // `connectors:` with no `secrets:` declared is the most ordinary manifest

--- a/apps/api/src/projects/lib/secret-grant.ts
+++ b/apps/api/src/projects/lib/secret-grant.ts
@@ -19,12 +19,10 @@
  *      (`preview.ts`: a prompt's `agent` field is forwarded untouched), so a
  *      session born under a broad agent could run a narrow one and still be
  *      handed the broad agent's full env. The grant is now resolved from the
- *      agent the prompt actually RUNS (`effectiveRunningAgent`), and a switch
- *      that would cross a secret boundary is refused outright
- *      (`AgentSecretGrantMismatchError` → 409) because narrowing the env on a
- *      later turn cannot un-read what the previous agent already read: the
- *      secrets are in the box's tmpfs env file, in every shell it spawned, and
- *      in its own context.
+ *      agent the prompt actually RUNS (`effectiveRunningAgent`). The default
+ *      path replaces future secret delivery with that agent's grant. Operators
+ *      can enable the strict grant lock to refuse a boundary switch because a
+ *      later narrowing cannot un-read what the previous agent already read.
  *
  * The pure helpers below carry the policy; `resolveSessionSecretGrant` is the
  * single I/O entry point both call sites use.

--- a/apps/api/src/projects/lib/session-token-grant.ts
+++ b/apps/api/src/projects/lib/session-token-grant.ts
@@ -15,15 +15,12 @@
  *       -> the token still carries A's grant
  *       -> B calls A's connectors, including ones its own manifest denies it
  *
- * Secrets are handled the opposite way, deliberately (see `secret-grant.ts`): a
- * secret-boundary switch is REFUSED, because by the time the switch is observed
- * the previous agent's secrets are already in the box's tmpfs env file, in every
- * shell it spawned, and in its own context — narrowing later cannot un-read
- * them. Connector and CLI grants have no such residue: they are checked against
- * this row at CALL time, so rewriting it genuinely re-scopes every subsequent
- * call. And refusing them instead would 409 the most ordinary manifest shape
- * there is — per-agent `connectors:` with no `secrets:` declared at all — on a
- * switch the dashboard's own UI offers.
+ * Secrets are replaced through the pre-prompt env sync (see `secret-grant.ts`).
+ * An operator can enable the strict secret-grant lock to refuse a boundary
+ * switch because narrowing later cannot un-read a value the previous agent
+ * already consumed. Connector and CLI grants have no such residue: they are
+ * checked against this row at CALL time, so rewriting it genuinely re-scopes
+ * every subsequent call.
  */
 
 import { and, eq, isNull } from 'drizzle-orm';

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -874,9 +874,9 @@ export async function forwardToSandbox(
             // projects/lib/secret-grant.ts.
             requestedAgent,
           });
-          // The env sync above already refused a secret-boundary switch, so
-          // reaching here means the switch is legal. Re-point the token's
-          // connector/CLI grant at the agent that will actually run — it was
+          // The env sync above applied the running agent's secret grant, or
+          // refused it when the optional strict lock is enabled. Re-point the
+          // token's connector/CLI grant at the agent that will actually run — it was
           // frozen at mint from the BOOT agent, and those gates read it at call
           // time. Only on a real switch: an ordinary turn resolves to the
           // session's own agent and skips the manifest read entirely.

--- a/apps/web/src/features/workspace/project-layout/new-session-create.ts
+++ b/apps/web/src/features/workspace/project-layout/new-session-create.ts
@@ -11,12 +11,10 @@ export interface NewSessionCreateInput {
 /**
  * Build the session-create payload from the composer's send options.
  *
- * A project session's boot agent is IMMUTABLE and bound at creation. The API
- * preview proxy rejects any prompt whose `agent` differs from the session's
- * bound agent with 409 AGENT_SWITCH_REQUIRES_NEW_SESSION — and the bound agent
- * defaults to "default" when none is set at create. So the agent the composer
- * will send on the very first prompt MUST be bound here, at session birth, or
- * the first message fails to start the task at all.
+ * A project session chooses its boot agent at creation. The first prompt uses
+ * the same agent so initial provisioning applies the intended grants. Later
+ * prompts can switch agents after server-side re-scoping. The boot agent
+ * defaults to "default" when none is set at create.
  *
  * `agent_name` therefore mirrors `options.agent` exactly: the create-time bind
  * and the first-prompt send read the same value, so they can never disagree.

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -65,9 +65,8 @@ import { prefetchSessionStart } from '@kortix/sdk/react';
  */
 /**
  * Options for a new-session start.
- * `agent_name` binds the session's immutable boot agent at birth. It MUST match
- * the agent the composer sends on the first prompt — the API proxy rejects any
- * prompt whose `agent` differs with 409 AGENT_SWITCH_REQUIRES_NEW_SESSION.
+ * `agent_name` chooses the session's boot agent. Later prompts can name another
+ * agent; the API re-scopes its grants before forwarding the prompt.
  * `connector_bindings` binds specific connection profiles; `inherit_unbound`
  * keeps the project-default fallback for every OTHER connector so binding one
  * doesn't null the rest. `require_connectors` names connectors that must resolve

--- a/apps/whitelabel-demo/src/components/chat/scope-bar-model.ts
+++ b/apps/whitelabel-demo/src/components/chat/scope-bar-model.ts
@@ -49,7 +49,7 @@ const COPY: Record<ScopeControlKey, { badge: string; note: string }> = {
   },
   agent: {
     badge: 'Per message',
-    note: 'Each message names the agent that runs it, and the composer above picks it. An agent whose SECRET access differs from the one this session booted with is refused — only a new session can run it.',
+    note: 'Each message names the agent that runs it, and the composer above picks it. A switch re-scopes future secret delivery, connector access, and Kortix CLI access to the selected agent.',
   },
   secrets: {
     badge: 'Changeable',

--- a/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
@@ -257,10 +257,8 @@ function Thread({ session: c }: { session: UseSessionResult }) {
               a typed sendError — read it, and name the KaaB refusals the
               generic message would otherwise swallow. */}
           {agentSwitch ? (
-            // The one refusal where retrying is guaranteed to fail: this
-            // sandbox's env is provisioned for the agent it booted with, and
-            // re-scoping now cannot un-read what that agent already loaded.
-            // Offer the only thing that works instead of an error.
+            // Operators can opt into an immutable secret-grant boundary. When
+            // they do, retrying the same switch cannot succeed in this session.
             <div className="mx-4 mb-2 rounded-lg border border-brand/40 bg-brand/5 px-3 py-2.5">
               <div className="text-sm font-medium">
                 {agentSwitch.requestedAgent

--- a/apps/whitelabel-demo/src/lib/call-snippets.ts
+++ b/apps/whitelabel-demo/src/lib/call-snippets.ts
@@ -277,7 +277,7 @@ function sessionPrompt(ctx: SnippetContext): CallSnippet {
     serverInjected: [],
     notes: [
       'The agent is per MESSAGE, not per session: `send(text, { agent })` overrides the sticky pick for that one turn.',
-      'A switch to an agent with a DIFFERENT secrets grant is refused 409 AGENT_SWITCH_REQUIRES_NEW_SESSION. Retrying cannot work — the sandbox is already provisioned for the agent it booted with, and re-scoping now cannot un-read what that agent loaded. The remedy is a new session.',
+      'A switch re-scopes secret delivery plus connector and Kortix CLI grants before the prompt runs. This only affects future access; it cannot erase a secret an earlier agent already read. Operators can opt into a strict immutable-grant mode that returns 409 AGENT_SWITCH_REQUIRES_NEW_SESSION.',
     ],
   };
 }

--- a/apps/whitelabel-demo/src/lib/mid-session-change.ts
+++ b/apps/whitelabel-demo/src/lib/mid-session-change.ts
@@ -7,10 +7,10 @@
  *
  * - MODEL — changeable. `PUT /sessions/{id}/model` re-points the running runtime.
  *   Restarts it, so the in-flight turn ends.
- * - AGENT — changeable PER PROMPT: each message names the agent it runs. But a
- *   switch to an agent with a DIFFERENT secrets grant is refused
- *   (409 AGENT_SWITCH_REQUIRES_NEW_SESSION), because re-scoping now cannot
- *   un-read what the session's original agent already pulled into the box.
+ * - AGENT — changeable PER PROMPT: each message names the agent it runs. The
+ *   proxy re-scopes secret delivery and the server-side token grant before it
+ *   forwards the prompt. An optional strict operator lock can still return
+ *   409 AGENT_SWITCH_REQUIRES_NEW_SESSION for a secret-grant boundary.
  * - SECRETS and CONNECTOR BINDINGS — changeable, with SET semantics:
  *   `PUT /projects/{id}/sessions/{sid}/scope` REPLACES the list with the one
  *   sent, and it takes effect from the next prompt (the per-prompt env sync
@@ -99,9 +99,8 @@ interface UpstreamError {
 /**
  * Classify a prompt rejected because of the agent it asked to run.
  *
- * `AGENT_SWITCH_REQUIRES_NEW_SESSION` is not a failure to retry — retrying with
- * the same agent will always fail. The only resolution is a new session, so the
- * UI must offer that rather than a retry button.
+ * `AGENT_SWITCH_REQUIRES_NEW_SESSION` is only emitted when an operator enables
+ * the optional strict grant lock. Retrying with the same agent will always fail.
  *
  * `AGENT_SECRET_GRANT_UNRESOLVED` is the opposite: the sandbox is fine and only
  * our ability to VERIFY entitlement failed, so retrying IS correct (503).
@@ -126,9 +125,9 @@ export function classifyAgentSwitch(body: UpstreamError | null): AgentSwitchOutc
 /** A refused agent switch, with the agents the server named. */
 export interface AgentSwitchRefusal {
   message: string;
-  /** The agent the message asked for — the one that needs a new session. */
+  /** The agent the message asked for. */
   requestedAgent: string | null;
-  /** The agent this session's sandbox is provisioned for. */
+  /** The agent this session started with. */
   expectedAgent: string | null;
 }
 
@@ -155,8 +154,7 @@ function stringOrNull(value: unknown): string | null {
 }
 
 /**
- * Recognise a send that was refused because the message named an agent whose
- * secret grant differs from the one this session booted with.
+ * Recognise a send refused by an operator's strict immutable-grant policy.
  *
  * Returns null for every other failure: the caller offers "start a new session"
  * ONLY here, because that is the only resolution — retrying the same send fails

--- a/apps/whitelabel-demo/src/lib/session-scope.ts
+++ b/apps/whitelabel-demo/src/lib/session-scope.ts
@@ -118,8 +118,8 @@ export function sessionScopeRows(
       badge: 'Per message',
       value: agentLabel,
       detail: agent
-        ? `Messages run as ${agent} unless another agent is picked in the composer. An agent whose SECRET access differs from ${agent}'s is refused — re-scoping now cannot un-read what ${agent} already loaded — and only a new session can run it.`
-        : "Messages run as the project's default agent unless another is picked in the composer. An agent with different SECRET access is refused and needs a new session; different connector or CLI access is fine.",
+        ? `Messages run as ${agent} unless another agent is picked in the composer. A switch re-scopes future secret delivery, connector access, and Kortix CLI access to the selected agent.`
+        : "Messages run as the project's default agent unless another is picked in the composer. A switch re-scopes future secret delivery, connector access, and Kortix CLI access to the selected agent.",
       control: null,
     },
     {

--- a/apps/whitelabel-demo/tests/e2e/mid-session-change.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/mid-session-change.test.ts
@@ -28,9 +28,9 @@ describe('what can change mid-session', () => {
 });
 
 describe('classifyAgentSwitch', () => {
-  test('a grant-crossing switch needs a NEW SESSION, not a retry', () => {
-    // Retrying with the same agent fails forever — re-scoping cannot un-read
-    // what the session's original agent already pulled into the sandbox.
+  test('an operator-enforced strict switch lock needs a NEW SESSION, not a retry', () => {
+    // Retrying with the same agent fails while the operator's strict policy is
+    // enabled for this session.
     const result = classifyAgentSwitch({
       code: 'AGENT_SWITCH_REQUIRES_NEW_SESSION',
       error: 'agent switch requires a new session',

--- a/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
@@ -51,9 +51,9 @@ describe('sessionScopeRows', () => {
   test("the agent row names this session's agent, in both directions", () => {
     const scoped = row('agent', { agentName: 'support' });
     expect(scoped.value).toBe('support');
-    // The refusal is about SECRET access specifically — connector and CLI
-    // grants may differ freely — so the row has to say which.
-    expect(scoped.detail).toContain('SECRET access');
+    expect(scoped.detail).toContain('re-scopes future secret delivery');
+    expect(scoped.detail).toContain('connector access');
+    expect(scoped.detail).toContain('Kortix CLI access');
     expect(scoped.detail).toContain('support');
     expect(row('agent').value).toBe('The project default agent');
   });

--- a/docs/specs/2026-07-26-agent-scoped-secret-injection.md
+++ b/docs/specs/2026-07-26-agent-scoped-secret-injection.md
@@ -116,16 +116,20 @@ so OpenCode resolves its own `default_agent`), so it maps to the session's agent
 rather than triggering a fresh sentinel lookup. Without that, every ordinary turn
 on a concretely-bound session would recompute its grant against `'default'`.
 
-### Refuse a grant-changing switch
+### Re-scope a grant-changing switch
 
 Re-scoping the env on a later turn **cannot undo the disclosure**. By the time a
 switch is observed, the previous agent's secrets are already in
 `/dev/shm/kortix/agent-env.sh`, exported into every shell it spawned, and in its
 own context. Narrowing the next push does not retract any of that.
 
-So a switch whose `secrets` grant differs from the session's is refused:
-`AgentSecretGrantMismatchError` → the existing
-`409 AGENT_SWITCH_REQUIRES_NEW_SESSION`.
+The default product behavior accepts the switch. Before forwarding the prompt,
+the proxy replaces OpenCode's environment with the running agent's grant and
+re-mints the session token's connector and Kortix CLI grant.
+
+An operator can enable `KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK`. In that strict
+mode, a switch whose `secrets` grant differs from the session's is refused:
+`AgentSecretGrantMismatchError` → `409 AGENT_SWITCH_REQUIRES_NEW_SESSION`.
 
 This is deliberately **narrower than `KORTIX_ENFORCE_SESSION_AGENT_LOCK`**, which
 409s on any name change and is gated off precisely because it false-positived on
@@ -140,18 +144,10 @@ actually active**: `SESSION_AGENT_LOCK_ENABLED` is hardcoded `false`
 always null and `agentSelectorLocked` is always false. Users *can* switch agents
 inside an open session today.
 
-So this does change behavior for one population: **projects that declare
-different `secrets` grants per agent**. A mid-session switch across that boundary
-now returns 409 where it previously succeeded. That is the boundary those
-projects declared, so enforcing it is the point — but the UI currently surfaces
-it as a generic error rather than a designed "start a new session" flow.
-
-Everyone else is unaffected: a project with no `agents:` map, or with uniform
-grants, never trips it (see the `undefined ≡ 'all'` note below).
-
-Making this a designed experience means flipping `SESSION_AGENT_LOCK_ENABLED` to
-true so the selector greys out inside a bound session. That is a product
-decision, not a security one, and is deliberately not bundled here.
+Projects can switch between agents with different grants. The switch changes
+future delivery only. It cannot erase a secret that an earlier agent already
+read or remove it from an existing shell process. Operators that require that
+stronger isolation must enable the strict lock or create a new session.
 
 ### `undefined` and `'all'` are one authority
 
@@ -167,12 +163,12 @@ prompting with a concrete agent that omits `secrets`. `grantEnvKey` collapses
 them. An explicit list stays distinct from both — that is a declared narrowing,
 and the project's secret set can change under it.
 
-### Kill switch
+### Strict lock
 
-`KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` (default **on**). Turning it off
-degrades to re-scoping onto the *running* agent's grant — it does **not** restore
-resolution from the stale create-time column. Enforcement off trades the hard
-refusal for a soft narrowing; the original widening is not reachable either way.
+`KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` defaults **off**. The normal path
+re-scopes onto the *running* agent's grant. It does **not** restore resolution
+from the stale create-time column. Set the flag to `true` to refuse switches
+whose secret grants differ.
 
 ## Files
 

--- a/docs/specs/2026-07-26-secret-delivery-policy.md
+++ b/docs/specs/2026-07-26-secret-delivery-policy.md
@@ -152,21 +152,20 @@ time. A running box that already received a secret in `env` mode still holds it 
 same residue problem as agent-scope switching. Changing a secret's policy should
 be treated as requiring a new sandbox.
 
-## Related open gap: the executor token
+## Executor token resolution
 
-Agent identity has two halves, and #5514 only fixed one.
+Agent identity has two halves: secret delivery and the executor token grant.
 
 `mintExecutorToken` (`apps/api/src/platform/services/session-sandbox.ts:129`) has
 exactly **one** call site — at sandbox provision. It stamps the token with
-`agentGrant` from the session's create-time agent, carrying that agent's
-`connectors` and `kortix_cli` grants; the grant is persisted on the token row and
-read back by auth middleware to gate routes. **It is never re-minted.**
+`agentGrant` from the session's create-time agent. The proxy rewrites the
+persisted grant when a later prompt switches agents.
 
-So re-scoping *env* per prompt is not sufficient on its own: a switched-to agent
-would still hold the original agent's powers. This is why
-`KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` ships **on** — the 409 is currently the
-only thing preventing that escalation. Once identity is re-resolved per prompt,
-the lock can relax to plain re-scoping.
+Re-scoping *env* per prompt is not sufficient on its own. The proxy now also
+re-mints every active session token's `agent_grant` before it forwards a switched
+prompt. Connector and Kortix CLI authorization therefore follow the running
+agent. `KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` defaults off; operators can set
+it to true when they require immutable secret grants per sandbox.
 
 There is also a live fail-open on that path: `session-sandbox.ts:143` does
 `resolveAgentGrant(...).catch(() => null)`, and `null` means unrestricted. It
@@ -175,26 +174,23 @@ failure synthesizes a manifest granting `connectors: 'all'` + `kortix_cli: 'all'
 This is the same bug class #5514 fixed for env, still open for the token — and
 the plumbing to fix it (`rethrowReadErrors`) is already on main.
 
-*Design question to settle first:* re-mint a new token and push it into a live
-sandbox, vs. keep one token and re-resolve its grant server-side at auth time.
-The latter avoids rotating a credential into a running box and is likely the
-right call.
+The implementation keeps the token value stable and rewrites its server-side
+grant row. The sandbox does not receive a replacement credential.
 
-## Suggested sequencing
+## Delivery-policy sequencing
 
-1. **Token grant fail-closed** — apply `rethrowReadErrors` to
-   `resolveAgentGrant`. Small, contained, closes a live fail-open with machinery
-   already on main.
+1. **Token grant fail-closed** — remove the remaining boot-time
+   `resolveAgentGrant(...).catch(() => null)` fallback.
 2. **Delivery policy, `env` + `gateway` only** — one migration, no egress work,
    no TLS interception. Models what is already true and closes the BYOK-key-in-env
    hole: a key connected through the LLM Providers modal stops being readable as
    `$ANTHROPIC_API_KEY` inside the box.
-3. **Identity re-resolved per prompt** — token grant follows the running agent;
-   the grant lock relaxes.
+3. **Identity re-resolved per prompt** — complete. The env and token grant follow
+   the running agent. The strict grant lock defaults off.
 4. **`proxy` mode** — CA provisioning, forced egress, per-provider network
    config. The real project, and the marketable one.
 
-Steps 1–2 are days. Steps 3–4 each deserve their own spec.
+Steps 1–2 and 4 remain delivery-policy work. Step 3 is complete.
 
 ## Sources
 


### PR DESCRIPTION
## Problem

`POST /prompt_async` returned `409 AGENT_SWITCH_REQUIRES_NEW_SESSION` when a user selected an agent with a different secret grant. The product supports per-message agent selection, but `KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` defaulted to enabled.

## Change

- Default `KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` to disabled.
- Keep the strict immutable-grant mode available as an explicit operator opt-in.
- Continue resolving the requested agent's secret grant before every prompt.
- Continue replacing the OpenCode environment and rewriting the active token's connector and Kortix CLI grant.
- Update web comments, demo copy, tests, and specs to match the runtime contract.

## Verification

- `122` API and proxy tests passed.
- `60` whitelabel contract tests passed.
- `pnpm --filter kortix-api typecheck` passed.
- Real local Daytona smoke passed in one OpenCode session:
  - `mike` prompt returned `204` and could not read `SWITCH_PROBE`.
  - `kortix` switch returned `204` and could read `SWITCH_PROBE`.
  - The stored token grant changed to `kortix`.
  - The switch back to `mike` returned `204` and removed future secret delivery.
  - The stored token grant changed back to `mike`.

## Security boundary

The switch changes future secret delivery. It cannot erase a secret from earlier model context or an already-running shell. Operators that require one immutable secret grant per sandbox can set `KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK=true`.
