### PR TITLE
fix(ke2e): AUD-5 360s budget; COVD-1 manifest-read retry

### DIFF
--- a/tests/src/flows/audit.flow.ts
+++ b/tests/src/flows/audit.flow.ts
@@ -218,6 +218,10 @@ flow(
       'PATCH /v1/accounts/:accountId/audit/webhooks/:webhookId',
       'DELETE /v1/accounts/:accountId/audit/webhooks/:webhookId',
     ],
+    // 26 steps over an enterprise-team fixture, and every audit list/export
+    // query scans a table that now grows with each API request (centralized
+    // audit log) — measured 242s on staging against the 120s default.
+    timeoutMs: 360_000,
   },
   async (ctx) => {
     const team = await ctx.fixtures.team({ enterprise: true });

--- a/tests/src/flows/connectors.flow.ts
+++ b/tests/src/flows/connectors.flow.ts
@@ -660,13 +660,26 @@ flow(
           { params: { projectId: p.id } },
         );
       seeded.status(200).body().has('$.ok', true);
-      const flipped = await ctx.client
+      // The strategy route re-reads the manifest from the repo; the connector
+      // create's commit is not always visible immediately (manifest push
+      // races), so retry the 404 briefly instead of failing on read lag.
+      let flipped = await ctx.client
         .as(ctx.P.OWNER)
         .put(
           '/v1/executor/projects/:projectId/connectors/:slug/authorization-strategy',
           { authorization_strategy: 'user' },
           { params: { projectId: p.id, slug: userSlug } },
         );
+      for (let attempt = 0; attempt < 5 && flipped.statusCode === 404; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 3_000));
+        flipped = await ctx.client
+          .as(ctx.P.OWNER)
+          .put(
+            '/v1/executor/projects/:projectId/connectors/:slug/authorization-strategy',
+            { authorization_strategy: 'user' },
+            { params: { projectId: p.id, slug: userSlug } },
+          );
+      }
       flipped.status(200).body().has('$.ok', true);
       const r = await ctx.client
         .as(ctx.P.OWNER)


### PR DESCRIPTION
Final two v0.12.0 release-gate failures (run 30639331287, 380/392):

- **AUD-5** timed out at 120s with every step passing — measured 242s: 26 steps on an enterprise-team fixture, and audit list/export queries now scan a per-request-growing table (centralized audit log). Flow budget raised to 360s.
- **COVD-1** hit a manifest-read race: `PUT …/authorization-strategy` 404'd ('connector not found') one request after the connector create returned 200 — the strategy route re-reads the manifest from the repo and the create's commit was not yet visible. The flow now retries the 404 up to 5×3s.

Both test-only. `bunx tsc --noEmit` clean (pre-existing pg TS7016 noise only).