### PR TITLE
fix(web): Manage-models tab shows "0 of N" — pass useModelStore the opts it needs

### DIFF
--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -80,6 +80,7 @@ import { MODEL_SELECTOR_PROVIDER_IDS, ProviderLogo } from '@/features/providers/
 import { DiffDialog } from '@/features/session/diff-dialog';
 import { CompactModal } from '@/features/session/header/compact-modal';
 import { flattenModels } from '@/features/session/session-chat-input';
+import { useConnectedProviders } from '@/features/workspace/customize/sections/llm-provider/use-connected-providers';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
 import { isBillingEnabled } from '@/lib/config';
 import { isLlmGatewayAvailable } from '@/lib/llm-gateway';
@@ -436,7 +437,15 @@ export function CommandPalette() {
   );
 
   const allModels = useMemo(() => flattenModels(providers), [providers]);
-  const modelStore = useModelStore(allModels);
+  // Pass the store the opts it needs, or `isVisible` hides every gateway model
+  // (unless its provider is connected) and resolves an empty "latest" set — the
+  // same "0 shown" bug the Manage-models tab had. See useModelStore's opts doc.
+  const { connectedProviders } = useConnectedProviders(projectId ?? '', open && !!projectId);
+  const connectedProviderIds = useMemo(
+    () => new Set(connectedProviders.map((provider) => provider.id)),
+    [connectedProviders],
+  );
+  const modelStore = useModelStore(allModels, { connectedProviderIds, catalogModels: allModels });
 
   const currentAgentName = useMemo(() => {
     if (!currentSessionId) return undefined;

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
@@ -13,6 +13,7 @@ import { useMemo } from 'react';
 import { ModelCapabilityIcons } from './model-capability-icons';
 import { ModelIdCopyButton } from './model-id-copy-button';
 import { buildModelGroups } from './model-rows';
+import { useConnectedProviders } from './use-connected-providers';
 import { formatPricePerMillion, formatTokenCount } from './utils';
 
 export function ModelsTab({ projectId, search }: { projectId: string; search: string }) {
@@ -24,7 +25,17 @@ export function ModelsTab({ projectId, search }: { projectId: string; search: st
   // switch here decides whether a model is offered in this browser's picker,
   // not a server-enforced enablement.
   const models = useProjectModels(projectId);
-  const modelStore = useModelStore(models);
+  // `useModelStore` hides a gateway model unless its upstream provider is
+  // connected, and resolves the "latest per family" default set from the FULL
+  // catalog — so BOTH `connectedProviderIds` and `catalogModels` must be passed
+  // or the tab renders "0 of N shown" (every model hidden) even though the
+  // session picker shows them. See useModelStore's opts doc comment.
+  const { connectedProviders } = useConnectedProviders(projectId, true);
+  const connectedProviderIds = useMemo(
+    () => new Set(connectedProviders.map((provider) => provider.id)),
+    [connectedProviders],
+  );
+  const modelStore = useModelStore(models, { connectedProviderIds, catalogModels: models });
 
   const groups = useMemo(() => buildModelGroups(models, search), [models, search]);
   const enabledCount = useMemo(


### PR DESCRIPTION
## Bug
The Manage-models tab shows **"0 of 15 shown"** with every toggle off, even though the session picker shows the models and Anthropic is connected.

## Root cause
The reverted tab calls `useModelStore(models)` **with no options**. `useModelStore` hides a gateway-served model unless its upstream provider is in `connectedProviderIds`, and computes the "latest per family" default-visible set from `catalogModels`. With neither passed, **every model resolves to hidden** → "0 of N". The session picker looks fine only because it renders the `/model-picker` list directly (it doesn't use the store).

## Fix
Wire the two opts the store needs (the tab already loads `useConnectedProviders`):
```ts
const { connectedProviders } = useConnectedProviders(projectId, true);
const connectedProviderIds = new Set(connectedProviders.map((p) => p.id));
const modelStore = useModelStore(models, { connectedProviderIds, catalogModels: models });
```
Connected + **latest-per-family** models now show by default — matching the picker and the store's documented usage.

## Verification
- Type-correct: `useConnectedProviders(projectId, true)` → `connectedProviders[].id`; opts match `useModelStore`'s signature.
- **Not yet browser-verified** (fresh worktree has no deps) — a UI default change should be seen before merge.

## Follow-up
`command-palette.tsx` has the same `useModelStore(allModels)` no-opts call and likely the same symptom.