### PR TITLE
fix(api): use E2B_DOMAIN for template APIs

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -477,10 +477,13 @@ const envSchema = z.object({
   // once at registration). Optional — same backstop story as Daytona's.
   PLATINUM_WEBHOOK_SECRET: optStr,
 
-  // ── E2B Cloud — sandbox provisioning (conditional: required if enabled) ──
+  // ── E2B — sandbox provisioning (conditional: required if enabled) ────────
+  // E2B_DOMAIN is the base E2B domain without a protocol. The default uses
+  // E2B Cloud. A self-hosted deployment uses its own base domain.
   // E2B_TEMPLATE is an optional ready fallback template. Project-specific
   // templates built by the shared snapshot system take precedence.
   E2B_API_KEY: optStr,
+  E2B_DOMAIN: optStrDefault('e2b.dev'),
   E2B_TEMPLATE: optStr,
 
   // ── Local Docker — EXPERIMENTAL sandbox provider (same-machine only) ────
@@ -1033,6 +1036,7 @@ export const config = {
   PLATINUM_TEMPLATE: env.PLATINUM_TEMPLATE,
   PLATINUM_WEBHOOK_SECRET: env.PLATINUM_WEBHOOK_SECRET,
   E2B_API_KEY: env.E2B_API_KEY,
+  E2B_DOMAIN: env.E2B_DOMAIN,
   E2B_TEMPLATE: env.E2B_TEMPLATE,
   LOCAL_DOCKER_NETWORK: env.LOCAL_DOCKER_NETWORK,
   LOCAL_DOCKER_SOCKET_PATH: env.LOCAL_DOCKER_SOCKET_PATH,

--- a/apps/api/src/snapshots/providers/e2b.test.ts
+++ b/apps/api/src/snapshots/providers/e2b.test.ts
@@ -37,7 +37,10 @@ mock.module('e2b', () => ({
   waitForProcess: (processName: string) => `wait-for-process:${processName}`,
 }));
 mock.module('../../config', () => ({
-  config: { E2B_API_KEY: 'e2b-test-key' },
+  config: {
+    E2B_API_KEY: 'e2b-test-key',
+    E2B_DOMAIN: 'e2b.essentia.kortix.com',
+  },
 }));
 mock.module('../build-context', () => ({
   DEFAULT_CPU: 2,
@@ -165,9 +168,10 @@ describe('E2B template adapter', () => {
     await e2bProvider.deleteSnapshot('kortix-e2b-template');
 
     expect(requests.at(-1)).toEqual({
-      url: 'https://api.e2b.dev/templates/tpl-target',
+      url: 'https://api.e2b.essentia.kortix.com/templates/tpl-target',
       method: 'DELETE',
       apiKey: 'e2b-test-key',
     });
+    expect(requests[0]?.url).toBe('https://api.e2b.essentia.kortix.com/templates');
   });
 });

--- a/apps/api/src/snapshots/providers/e2b.ts
+++ b/apps/api/src/snapshots/providers/e2b.ts
@@ -28,8 +28,15 @@ function connectionOpts() {
   return { apiKey: config.E2B_API_KEY, requestTimeoutMs: 30_000 } as const;
 }
 
+function apiBaseUrl(): string {
+  const domain = config.E2B_DOMAIN.trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/+$/, '');
+  return `https://api.${domain}`;
+}
+
 async function listTemplates(): Promise<E2BTemplateView[]> {
-  const response = await fetch('https://api.e2b.dev/templates', {
+  const response = await fetch(`${apiBaseUrl()}/templates`, {
     headers: { 'X-API-KEY': config.E2B_API_KEY },
     signal: AbortSignal.timeout(30_000),
   });
@@ -116,11 +123,14 @@ class E2BAdapter implements SandboxProviderAdapter {
     try {
       const template = (await listTemplates()).find((item) => matchesTemplate(item, snapshotName));
       if (!template) return;
-      const response = await fetch(`https://api.e2b.dev/templates/${encodeURIComponent(template.templateID)}`, {
-        method: 'DELETE',
-        headers: { 'X-API-KEY': config.E2B_API_KEY },
-        signal: AbortSignal.timeout(30_000),
-      });
+      const response = await fetch(
+        `${apiBaseUrl()}/templates/${encodeURIComponent(template.templateID)}`,
+        {
+          method: 'DELETE',
+          headers: { 'X-API-KEY': config.E2B_API_KEY },
+          signal: AbortSignal.timeout(30_000),
+        },
+      );
       if (!response.ok && response.status !== 404) {
         throw new Error(`E2B delete template ${snapshotName} -> ${response.status} ${(await response.text()).slice(0, 300)}`);
       }


### PR DESCRIPTION
## Problem

The E2B runtime SDK reads `E2B_DOMAIN`. The snapshot adapter still calls `api.e2b.dev` directly. A Kortix instance cannot list or delete templates on a self-hosted E2B control plane.

## Change

- Add `E2B_DOMAIN` to API configuration.
- Default the value to `e2b.dev`.
- Route template list and delete calls through `https://api.<E2B_DOMAIN>`.
- Add a self-hosted domain assertion.

## Verification

- `bun test apps/api/src/snapshots/providers/e2b.test.ts` -> 5 pass, 0 fail.
- `pnpm --filter kortix-api typecheck` -> exit 0.

## Live target

This change enables `E2B_DOMAIN=e2b.essentia.kortix.com` on `essentia.kortix.cloud`.