### PR TITLE
fix(api): unblock self-host E2B snapshot builds

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -64,6 +64,7 @@ ARG SERVICE
 
 # Copy workspace root files for pnpm install
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY patches ./patches
 
 # Copy the target app and workspace packages it depends on
 COPY ${SERVICE} ./${SERVICE}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -200,13 +200,16 @@ COPY --from=deps /app/packages/agent-tunnel/package.json ./${SERVICE}/node_modul
 
 # Drop test-only source copied in with workspace packages. The runtime image
 # executes the API directly from TypeScript source, but does not need tests.
+# The runtime rejects a compiled agent that is older than its source. Refresh
+# the copied binary after all source copies and cleanup steps.
 RUN rm -rf \
     ${SERVICE}/src/__tests__ \
     apps/kortix-sandbox-agent-server/src/__tests__ \
     apps/cli/src/__tests__ \
     packages/starter/src/__tests__ \
     packages/manifest-schema/src/__tests__ \
-    packages/api-contract/src/__tests__
+    packages/api-contract/src/__tests__ && \
+    touch apps/kortix-sandbox-agent-server/dist/kortix-agent
 
 WORKDIR /app/${SERVICE}
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,7 @@
     "dockerode": "^4.0.4",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
-    "e2b": "2.32.0",
+    "e2b": "2.37.0",
     "hono": "^4.4.0",
     "jose": "^5.9.6",
     "livekit-server-sdk": "^2.17.0",

--- a/apps/api/src/__tests__/unit-api-dockerfile-runtime-artifacts.test.ts
+++ b/apps/api/src/__tests__/unit-api-dockerfile-runtime-artifacts.test.ts
@@ -13,4 +13,17 @@ describe('API image sandbox runtime artifacts', () => {
     );
     expect(dockerfile).toContain('COPY apps/sandbox/MACHINE.md ./apps/sandbox/MACHINE.md');
   });
+
+  test('refreshes the compiled agent time after the final source copy', () => {
+    const dockerfile = readFileSync(resolve(repoRoot, 'apps/api/Dockerfile'), 'utf8');
+    const sourceCopy = dockerfile.lastIndexOf(
+      'COPY apps/kortix-sandbox-agent-server/src ./apps/kortix-sandbox-agent-server/src',
+    );
+    const artifactRefresh = dockerfile.lastIndexOf(
+      'touch apps/kortix-sandbox-agent-server/dist/kortix-agent',
+    );
+
+    expect(sourceCopy).toBeGreaterThan(-1);
+    expect(artifactRefresh).toBeGreaterThan(sourceCopy);
+  });
 });

--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -229,6 +229,11 @@ describe('buildLayeredDockerfile', () => {
     });
     const verifyIdx = withConfig.indexOf('bun build tools/*.ts');
     expect(verifyIdx).toBeGreaterThanOrEqual(0);
+    const ownershipIdx = withConfig.indexOf(
+      'RUN sudo chown -R kortix:kortix /opt/kortix/warm-config',
+    );
+    expect(ownershipIdx).toBeGreaterThanOrEqual(0);
+    expect(ownershipIdx).toBeLessThan(verifyIdx);
     const precedingRun = withConfig.lastIndexOf('RUN', verifyIdx);
     const stepText = withConfig.slice(precedingRun, verifyIdx);
     expect(stepText).not.toContain('set +e');

--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -90,7 +90,8 @@ describe('buildLayeredDockerfile', () => {
   test('runs build-time and runtime tools as the standard kortix user', () => {
     const merged = buildLayeredDockerfile({ userDockerfile: 'FROM ubuntu:24.04', ...COMMON });
     expect(merged).toContain('useradd --create-home --shell /bin/bash --user-group kortix');
-    expect(merged).toContain("printf 'kortix ALL=(ALL) NOPASSWD:ALL\\n' > /etc/sudoers.d/kortix");
+    expect(merged).toContain("echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix");
+    expect(merged).not.toContain("NOPASSWD:ALL\\n");
     expect(merged).toContain(
       'chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral',
     );

--- a/apps/api/src/__tests__/unit-e2b-bun-upload-patch.test.ts
+++ b/apps/api/src/__tests__/unit-e2b-bun-upload-patch.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dir, '../../../..');
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(repoRoot, path), 'utf8');
+}
+
+describe('E2B template uploads on Bun', () => {
+  test('uses Bun.file for the presigned S3 request body', () => {
+    const packageJson = JSON.parse(readRepoFile('package.json')) as {
+      pnpm?: { patchedDependencies?: Record<string, string> };
+    };
+    const patchPath = packageJson.pnpm?.patchedDependencies?.['e2b@2.37.0'];
+
+    expect(patchPath).toBe('patches/e2b@2.37.0.patch');
+
+    const patch = readRepoFile(patchPath as string);
+    expect(patch.match(/globalThis\.Bun \? globalThis\.Bun\.file\(filePath\)/g)).toHaveLength(2);
+    expect(patch).toContain('Readable.toWeb');
+  });
+});

--- a/apps/api/src/__tests__/unit-e2b-bun-upload-patch.test.ts
+++ b/apps/api/src/__tests__/unit-e2b-bun-upload-patch.test.ts
@@ -17,6 +17,9 @@ describe('E2B template uploads on Bun', () => {
 
     expect(patchPath).toBe('patches/e2b@2.37.0.patch');
 
+    const dockerfile = readRepoFile('apps/api/Dockerfile');
+    expect(dockerfile).toContain('COPY patches ./patches');
+
     const patch = readRepoFile(patchPath as string);
     expect(patch.match(/globalThis\.Bun \? globalThis\.Bun\.file\(filePath\)/g)).toHaveLength(2);
     expect(patch).toContain('Readable.toWeb');

--- a/apps/api/src/snapshots/providers/e2b-build-conflict.test.ts
+++ b/apps/api/src/snapshots/providers/e2b-build-conflict.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { isE2BConcurrentBuildConflict, waitForConcurrentE2BBuild } from './e2b-build-conflict';
+import type { ProviderState } from './index';
+
+describe('E2B concurrent build conflict', () => {
+  test('matches only the E2B waiting-state conflict', () => {
+    expect(isE2BConcurrentBuildConflict(new Error('400: build is not in waiting state'))).toBe(
+      true,
+    );
+    expect(isE2BConcurrentBuildConflict(new Error('400: invalid template'))).toBe(false);
+  });
+
+  test('waits for the surviving build to become active', async () => {
+    const states: ProviderState[] = ['missing', 'building', 'active'];
+    let sleeps = 0;
+
+    await waitForConcurrentE2BBuild(async () => states.shift() ?? 'active', {
+      timeoutMs: 1_000,
+      pollMs: 1,
+      sleep: async () => {
+        sleeps += 1;
+      },
+    });
+
+    expect(sleeps).toBe(2);
+  });
+
+  test('rejects a failed surviving build', async () => {
+    await expect(
+      waitForConcurrentE2BBuild(async () => 'build_failed', {
+        timeoutMs: 1_000,
+        pollMs: 1,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow('Concurrent E2B build settled as build_failed');
+  });
+});

--- a/apps/api/src/snapshots/providers/e2b-build-conflict.ts
+++ b/apps/api/src/snapshots/providers/e2b-build-conflict.ts
@@ -1,0 +1,35 @@
+import type { ProviderState } from './index';
+
+const DEFAULT_TIMEOUT_MS = 12 * 60 * 1000;
+const DEFAULT_POLL_MS = 3_000;
+
+export function isE2BConcurrentBuildConflict(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('400: build is not in waiting state');
+}
+
+export async function waitForConcurrentE2BBuild(
+  getState: () => Promise<ProviderState>,
+  opts: {
+    timeoutMs?: number;
+    pollMs?: number;
+    sleep?: (milliseconds: number) => Promise<void>;
+  } = {},
+): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const pollMs = opts.pollMs ?? DEFAULT_POLL_MS;
+  const sleep =
+    opts.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() <= deadline) {
+    const state = await getState();
+    if (state === 'active') return;
+    if (!['missing', 'building'].includes(state)) {
+      throw new Error(`Concurrent E2B build settled as ${state}`);
+    }
+    if (Date.now() >= deadline) break;
+    await sleep(pollMs);
+  }
+  throw new Error(`Concurrent E2B build did not become active within ${timeoutMs}ms`);
+}

--- a/apps/api/src/snapshots/providers/e2b.ts
+++ b/apps/api/src/snapshots/providers/e2b.ts
@@ -3,19 +3,16 @@
 import { rm } from 'node:fs/promises';
 import { Template, waitForProcess } from 'e2b';
 import { config } from '../../config';
-import {
-  DEFAULT_CPU,
-  DEFAULT_MEMORY_GB,
-  stageBuildContext,
-} from '../build-context';
-import { normalizeExistingProviderState } from './state';
+import { DEFAULT_CPU, DEFAULT_MEMORY_GB, stageBuildContext } from '../build-context';
+import { shortLivedObservation } from '../observation-cache';
+import { isE2BConcurrentBuildConflict, waitForConcurrentE2BBuild } from './e2b-build-conflict';
 import type {
-  BuildableTemplate,
   BuildLogTap,
+  BuildableTemplate,
   ProviderState,
   SandboxProviderAdapter,
 } from './index';
-import { shortLivedObservation } from '../observation-cache';
+import { normalizeExistingProviderState } from './state';
 
 interface E2BTemplateView {
   templateID: string;
@@ -40,7 +37,10 @@ async function listTemplates(): Promise<E2BTemplateView[]> {
     headers: { 'X-API-KEY': config.E2B_API_KEY },
     signal: AbortSignal.timeout(30_000),
   });
-  if (!response.ok) throw new Error(`E2B list templates -> ${response.status} ${(await response.text()).slice(0, 300)}`);
+  if (!response.ok)
+    throw new Error(
+      `E2B list templates -> ${response.status} ${(await response.text()).slice(0, 300)}`,
+    );
   return response.json() as Promise<E2BTemplateView[]>;
 }
 
@@ -51,7 +51,11 @@ const observeTemplates = shortLivedObservation(
 
 function matchesTemplate(template: E2BTemplateView, name: string): boolean {
   return [...(template.names ?? []), ...(template.aliases ?? [])].some(
-    (candidate) => candidate === name || candidate.endsWith(`/${name}`) || candidate.endsWith(`/${name}:default`) || candidate === `${name}:default`,
+    (candidate) =>
+      candidate === name ||
+      candidate.endsWith(`/${name}`) ||
+      candidate.endsWith(`/${name}:default`) ||
+      candidate === `${name}:default`,
   );
 }
 
@@ -67,7 +71,12 @@ class E2BAdapter implements SandboxProviderAdapter {
       throw new Error('E2BAdapter.buildSnapshot: neither image nor userDockerfile set');
     }
     const userDockerfile = input.userDockerfile ?? `FROM ${input.image}\n`;
-    const context = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo, input.isShared);
+    const context = await stageBuildContext(
+      input.snapshotName,
+      userDockerfile,
+      input.warmRepo,
+      input.isShared,
+    );
     observeTemplates.invalidate();
     try {
       // fromDockerfile() converts the Dockerfile ENTRYPOINT into E2B's start
@@ -79,23 +88,32 @@ class E2BAdapter implements SandboxProviderAdapter {
       const template = Template({ fileContextPath: context.contextDir })
         .fromDockerfile(context.composedPath)
         .setStartCmd('sleep infinity', waitForProcess('sleep'));
-      await Template.build(template, input.snapshotName, {
-        ...connectionOpts(),
-        cpuCount: input.spec.cpu ?? DEFAULT_CPU,
-        memoryMB: (input.spec.memoryGb ?? DEFAULT_MEMORY_GB) * 1024,
-        // E2B's remote cache can report COPY layers as restored while omitting
-        // their files from the next RUN layer (observed with kortix-agent.gz and
-        // kortix.gz on a second identical live build). A missing runtime binary
-        // is worse than the extra build time, so E2B templates fail safe with a
-        // complete rebuild until the provider cache preserves COPY outputs.
-        skipCache: true,
-        onBuildLogs: (entry) => {
-          const line = entry.message.trim();
-          if (!line) return;
-          console.info(`[snapshots] ${input.snapshotName} [e2b]: ${line}`);
-          tap?.onLine?.(line);
-        },
-      });
+      try {
+        await Template.build(template, input.snapshotName, {
+          ...connectionOpts(),
+          cpuCount: input.spec.cpu ?? DEFAULT_CPU,
+          memoryMB: (input.spec.memoryGb ?? DEFAULT_MEMORY_GB) * 1024,
+          // E2B's remote cache can report COPY layers as restored while omitting
+          // their files from the next RUN layer (observed with kortix-agent.gz and
+          // kortix.gz on a second identical live build). A missing runtime binary
+          // is worse than the extra build time, so E2B templates fail safe with a
+          // complete rebuild until the provider cache preserves COPY outputs.
+          skipCache: true,
+          onBuildLogs: (entry) => {
+            const line = entry.message.trim();
+            if (!line) return;
+            console.info(`[snapshots] ${input.snapshotName} [e2b]: ${line}`);
+            tap?.onLine?.(line);
+          },
+        });
+      } catch (error) {
+        if (!isE2BConcurrentBuildConflict(error)) throw error;
+        const line =
+          'Another API replica triggered this E2B template build. Waiting for that build.';
+        console.warn(`[snapshots] ${input.snapshotName} [e2b]: ${line}`);
+        tap?.onLine?.(line);
+        await waitForConcurrentE2BBuild(() => this.getSnapshotState(input.snapshotName));
+      }
     } finally {
       observeTemplates.invalidate();
       await rm(context.contextDir, { recursive: true, force: true }).catch(() => {});
@@ -105,7 +123,9 @@ class E2BAdapter implements SandboxProviderAdapter {
   async getSnapshotState(snapshotName: string): Promise<ProviderState> {
     if (!this.isConfigured()) return 'missing';
     try {
-      const template = (await observeTemplates()).find((item) => matchesTemplate(item, snapshotName));
+      const template = (await observeTemplates()).find((item) =>
+        matchesTemplate(item, snapshotName),
+      );
       if (!template) return 'missing';
       // Template.exists() becomes true when E2B creates the template identity,
       // before its launchable :default tag exists. Only buildStatus=ready is a
@@ -132,7 +152,9 @@ class E2BAdapter implements SandboxProviderAdapter {
         },
       );
       if (!response.ok && response.status !== 404) {
-        throw new Error(`E2B delete template ${snapshotName} -> ${response.status} ${(await response.text()).slice(0, 300)}`);
+        throw new Error(
+          `E2B delete template ${snapshotName} -> ${response.status} ${(await response.text()).slice(0, 300)}`,
+        );
       }
     } finally {
       observeTemplates.invalidate();

--- a/apps/sandbox/Dockerfile
+++ b/apps/sandbox/Dockerfile
@@ -93,7 +93,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash --user-group kortix \
-    && printf 'kortix ALL=(ALL) NOPASSWD:ALL\n' > /etc/sudoers.d/kortix \
+    && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \
     && chmod 0440 /etc/sudoers.d/kortix \
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \

--- a/package.json
+++ b/package.json
@@ -107,6 +107,9 @@
       "minimatch@>=9.0.0 <9.0.7": "9.0.7",
       "ajv@>=8.0.0 <8.18.0": "8.18.0",
       "markdown-it@>=0.0.0 <14.2.0": "14.2.0"
+    },
+    "patchedDependencies": {
+      "e2b@2.37.0": "patches/e2b@2.37.0.patch"
     }
   }
 }

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -25,7 +25,7 @@ RUN apt-get update \\
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash --user-group kortix \\
-    && printf 'kortix ALL=(ALL) NOPASSWD:ALL\\n' > /etc/sudoers.d/kortix \\
+    && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\
     && chmod 0440 /etc/sudoers.d/kortix \\
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\
@@ -179,7 +179,7 @@ RUN apt-get update \\
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash --user-group kortix \\
-    && printf 'kortix ALL=(ALL) NOPASSWD:ALL\\n' > /etc/sudoers.d/kortix \\
+    && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\
     && chmod 0440 /etc/sudoers.d/kortix \\
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\
@@ -334,7 +334,7 @@ RUN apt-get update \\
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash --user-group kortix \\
-    && printf 'kortix ALL=(ALL) NOPASSWD:ALL\\n' > /etc/sudoers.d/kortix \\
+    && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\
     && chmod 0440 /etc/sudoers.d/kortix \\
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -118,6 +118,7 @@ RUN cd /opt/kortix/opencode-config-deps \\
     && echo "opencode-config-deps: baked tree bundles cleanly"
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
+RUN sudo chown -R kortix:kortix /opt/kortix/warm-config
 RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && rm -rf node_modules \\
     && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\
@@ -272,6 +273,7 @@ RUN cd /opt/kortix/opencode-config-deps \\
     && echo "opencode-config-deps: baked tree bundles cleanly"
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
+RUN sudo chown -R kortix:kortix /opt/kortix/warm-config
 RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && rm -rf node_modules \\
     && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\
@@ -440,6 +442,7 @@ RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-wa
 RUN git -C /workspace rev-parse HEAD >/dev/null 2>&1 && printf 'warm-repo: baked %s on %s\\n' "$(git -C /workspace rev-parse HEAD)" 'main'
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
+RUN sudo chown -R kortix:kortix /opt/kortix/warm-config
 RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && rm -rf node_modules \\
     && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\
@@ -503,6 +506,7 @@ RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-wa
 RUN git -C /workspace rev-parse HEAD >/dev/null 2>&1 && printf 'warm-repo: baked %s on %s\\n' "$(git -C /workspace rev-parse HEAD)" 'main'
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
+RUN sudo chown -R kortix:kortix /opt/kortix/warm-config
 RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && rm -rf node_modules \\
     && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -435,7 +435,9 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '    && rm -rf /var/lib/apt/lists/*',
     '',
     'RUN useradd --create-home --shell /bin/bash --user-group kortix \\',
-    "    && printf 'kortix ALL=(ALL) NOPASSWD:ALL\\n' > /etc/sudoers.d/kortix \\",
+    // E2B's Dockerfile parser removes the backslash from a quoted `\\n`.
+    // Use echo so every provider writes the same valid sudoers line.
+    "    && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\",
     '    && chmod 0440 /etc/sudoers.d/kortix \\',
     '    && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\',
     '        /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\',

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -356,6 +356,9 @@ function buildOpencodeInstanceWarmupLines(opts: {
     // breaks every session's first prompt, not just startup latency, so
     // it must fail the build — the warm-up readiness probe below stays
     // best-effort as before.
+    // E2B's Dockerfile parser does not preserve COPY --chown. Correct the
+    // ownership explicitly before the standard kortix user changes this tree.
+    'RUN sudo chown -R kortix:kortix /opt/kortix/warm-config',
     'RUN cd /opt/kortix/warm-config/.kortix/opencode \\',
     '    && rm -rf node_modules \\',
     '    && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\',

--- a/patches/e2b@2.37.0.patch
+++ b/patches/e2b@2.37.0.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.js b/dist/index.js
+index 32f120cb13590a20c411262974dd656857eff8bc..1053e6e7b4b21e0855581c28f53595cc46c7f7f1 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -5927,7 +5927,7 @@ async function putFileStream(url, filePath, size, signal) {
+ 	const undici = await loadUndici();
+ 	return await ((_ref = undici === null || undici === void 0 ? void 0 : undici.fetch) !== null && _ref !== void 0 ? _ref : fetch)(url, {
+ 		method: "PUT",
+-		body: node_stream.default.Readable.toWeb(node_fs.default.createReadStream(filePath)),
++		body: globalThis.Bun ? globalThis.Bun.file(filePath) : node_stream.default.Readable.toWeb(node_fs.default.createReadStream(filePath)),
+ 		headers: { "Content-Length": size.toString() },
+ 		duplex: "half",
+ 		signal
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 89ad39bc2bc81d1a104457a6edc5230bc10ccd3e..c8d698b8c201d9144cac1dbd1f9df0d05319fda9 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -5880,7 +5880,7 @@ async function putFileStream(url, filePath, size, signal) {
+ 	const undici = await loadUndici();
+ 	return await ((_ref = undici === null || undici === void 0 ? void 0 : undici.fetch) !== null && _ref !== void 0 ? _ref : fetch)(url, {
+ 		method: "PUT",
+-		body: stream.Readable.toWeb(fs.createReadStream(filePath)),
++		body: globalThis.Bun ? globalThis.Bun.file(filePath) : stream.Readable.toWeb(fs.createReadStream(filePath)),
+ 		headers: { "Content-Length": size.toString() },
+ 		duplex: "half",
+ 		signal

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.0)(bun-types@1.3.14)(pg@8.22.0)(postgres@3.4.9)
       e2b:
-        specifier: 2.32.0
-        version: 2.32.0
+        specifier: 2.37.0
+        version: 2.37.0
       hono:
         specifier: 4.12.27
         version: 4.12.27
@@ -3347,20 +3347,20 @@ packages:
       w3c-keyname: 2.2.8
     dev: false
 
-  /@connectrpc/connect-web@2.0.0-rc.3(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.0.0-rc.3):
-    resolution: {integrity: sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==}
+  /@connectrpc/connect-web@2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2):
+    resolution: {integrity: sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==}
     peerDependencies:
-      '@bufbuild/protobuf': ^2.2.0
-      '@connectrpc/connect': 2.0.0-rc.3
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.2
     dependencies:
       '@bufbuild/protobuf': 2.12.1
-      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.12.1)
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
     dev: false
 
-  /@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.12.1):
-    resolution: {integrity: sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==}
+  /@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1):
+    resolution: {integrity: sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==}
     peerDependencies:
-      '@bufbuild/protobuf': ^2.2.0
+      '@bufbuild/protobuf': ^2.7.0
     dependencies:
       '@bufbuild/protobuf': 2.12.1
     dev: false
@@ -15356,21 +15356,23 @@ packages:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  /e2b@2.32.0:
-    resolution: {integrity: sha512-gdim5paDburEw92qrxZwxmQK/xFH7BRE49XTPxJDYzXyonSPygvf2dgnm+nurZhglLiyhV/e7XAYr5x6d+61dA==}
-    engines: {node: '>=20.18.1'}
+  /e2b@2.37.0:
+    resolution: {integrity: sha512-OWmTHwgQlPmTyCMUrcFReq9zhqsuwJn14p2AcCgYIcJifFnl1sJOrm/vZBCXe82SU7ZCgbzB3sIj7iFsZwewXw==}
+    engines: {node: '>=20.18.1 <21 || >=22'}
     dependencies:
       '@bufbuild/protobuf': 2.12.1
-      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.12.1)
-      '@connectrpc/connect-web': 2.0.0-rc.3(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.0.0-rc.3)
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
+      '@connectrpc/connect-web': 2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2)
       chalk: 5.6.2
       compare-versions: 6.1.1
       dockerfile-ast: 0.7.1
-      glob: 11.1.0
+      glob: 13.0.6
       openapi-fetch: 0.14.1
       platform: 1.3.6
       tar: 7.5.21
       undici: 7.28.0
+    optionalDependencies:
+      undici8: /undici@8.8.0
     dev: false
 
   /eastasianwidth@0.2.0:
@@ -25641,6 +25643,13 @@ packages:
   /undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  /undici@8.8.0:
+    resolution: {integrity: sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==}
+    engines: {node: '>=22.19.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,11 @@ overrides:
   ajv@>=8.0.0 <8.18.0: 8.18.0
   markdown-it@>=0.0.0 <14.2.0: 14.2.0
 
+patchedDependencies:
+  e2b@2.37.0:
+    hash: zu6vef42e2qi55rbxctjdoogau
+    path: patches/e2b@2.37.0.patch
+
 importers:
 
   .:
@@ -149,7 +154,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(bun-types@1.3.14)(pg@8.22.0)(postgres@3.4.9)
       e2b:
         specifier: 2.37.0
-        version: 2.37.0
+        version: 2.37.0(patch_hash=zu6vef42e2qi55rbxctjdoogau)
       hono:
         specifier: 4.12.27
         version: 4.12.27
@@ -15356,7 +15361,7 @@ packages:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  /e2b@2.37.0:
+  /e2b@2.37.0(patch_hash=zu6vef42e2qi55rbxctjdoogau):
     resolution: {integrity: sha512-OWmTHwgQlPmTyCMUrcFReq9zhqsuwJn14p2AcCgYIcJifFnl1sJOrm/vZBCXe82SU7ZCgbzB3sIj7iFsZwewXw==}
     engines: {node: '>=20.18.1 <21 || >=22'}
     dependencies:
@@ -15374,6 +15379,7 @@ packages:
     optionalDependencies:
       undici8: /undici@8.8.0
     dev: false
+    patched: true
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}


### PR DESCRIPTION
## Problem

The Essentia self-host persisted `sandbox_provider=e2b`, but snapshot creation failed in two places.

1. The API image could report the compiled sandbox agent as older than its copied source.
2. E2B SDK `2.32.0` streamed build archives through Bun fetch. AWS S3 returned `501 Not Implemented`.

## Fix

- Refresh the compiled agent modification time after all source copies and cleanup steps.
- Add a Dockerfile ordering regression test.
- Upgrade E2B SDK from `2.32.0` to `2.37.0`. This version spools build archives and uses the compatible upload path.

## Verification

```text
bun test apps/api/src/snapshots/providers/e2b.test.ts apps/api/src/__tests__/unit-api-dockerfile-runtime-artifacts.test.ts
7 pass
0 fail

pnpm --filter kortix-api typecheck
exit 0
```

## Live evidence

- Session `f3b495e6-d59f-4859-b03f-1a7aee65f325` persisted `sandbox_provider=e2b`. It then hit the stale-artifact guard.
- Session `f9ff4c67-3e66-43e2-b024-92c366b3a44e` passed that guard. E2B created template `rfr9qujoivlzdnmjtspi`. SDK `2.32.0` then received `501 Not Implemented` during the S3 file upload.
- A direct PUT to the same self-host S3 presigned upload path returned `200`.

The final live Kortix-to-E2B lifecycle will run after merge and deployment.