### PR TITLE
docs: remove reverted per-project model enablement section

### DIFF
--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -58,21 +58,6 @@ If you see credit charges on a BYOK-only project, check these two causes
 before reporting a billing bug.
 </Callout>
 
-## Per-project model enablement
-
-The gateway enforces which models a project may use. By default, the newest
-model of each family is offered automatically. Model families you connect
-through a provider key or that Kortix manages are offered by default — a guard
-never prunes a managed model or one your project's routing policy references.
-
-You can override the default for individual models on the **Manage models**
-page (Customize → Models). An exception is stored per project and takes effect
-immediately. The model picker, chat, Slack, triggers, and the raw API all
-respect the same enabled set.
-
-A model that is not enabled is refused everywhere and hidden from the picker.
-The gateway never falls back to a disabled model.
-
 ## Shared, not private, keys
 
 A connected provider key applies to the whole project. There is no private,


### PR DESCRIPTION
## docs: remove reverted per-project model enablement section

Docs-only fix from the autonomous `docs-maintainer` run (2026-08-01).

### Audit window
- `kortix-ai/suna`: `79962ec52` (2026-07-31 checkpoint) → `29b834888` (origin/main). 92 reachable commits.

### Fix
**Per-project model enablement section stale (HIGH):** `project/models.mdx` still carried the "Per-project model enablement" section added in the 2026-07-29 sweep. The feature was reverted by `6c168ee2` (revert(models): remove server-side per-project model enablement #5932). `apps/api/src/llm-gateway/model-enablement.ts` is gone; the model picker no longer stamps an `enabled` flag; no `resolveEnablement` function exists. The section claimed gateway-enforced enablement, Manage models overrides, and "never prunes" — none of which is true after the revert. Removed the entire 15-line section.

### Verification
- `check-fumadocs.mjs` PASS (28 pages, 6 nav, 28 routes).
- `git diff --check` PASS.
- Grep gates PASS (no `Per-project model enablement`, no `Manage models`, no `never prunes`).
- This PR is docs-only — 1 file under `apps/web/content/docs/**`.
