### PR TITLE
fix(api): catch RepoFileNotFoundError in files/content route (BS 5b40ec1a)

### DIFF
--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -176,7 +176,18 @@ mock.module('../projects/git', () => ({
   readRepoFile: async (project: ProjectRow, path: string, ref: string) => {
     readRepoFileCalls.push({ projectId: project.projectId, path, ref });
     if (path === 'missing.txt') {
+      // The legacy `GitOperationError` shape: a raw `fatal: path … does not
+      // exist in …` message. `isMissingGitPathError` matches this → 404.
       throw new Error("fatal: path 'missing.txt' does not exist in 'feature'");
+    }
+    if (path === 'not-found.txt') {
+      // The typed shape `readRepoFile` actually throws in prod (files.ts:127) —
+      // a `RepoFileNotFoundError` whose message does NOT match the
+      // `isMissingGitPathError` regex. Without the route branching on
+      // `isRepoFileNotFoundError`, this leaked as an uncaught 500 (Better Stack
+      // pattern `5b40ec1a…`). Throw the REAL class so the regression test
+      // exercises the exact prod code path, not a string lookalike.
+      throw new actualGit.RepoFileNotFoundError(path, ref);
     }
     return `content:${path}@${ref}`;
   },
@@ -534,6 +545,23 @@ describe('projects API contract', () => {
     expect(missingFile.status).toBe(404);
     expect(await missingFile.json()).toEqual({ error: 'File not found' });
     expect(readRepoFileCalls.at(-1)).toEqual({ projectId: PROJECT_ID, path: 'missing.txt', ref: 'feature' });
+
+    // Regression (Better Stack pattern `5b40ec1a…`): `readRepoFile` now throws a
+    // typed `RepoFileNotFoundError` (message `file not found in repository at
+    // '<ref>:<path>'`) instead of the raw `fatal: path … does not exist in …`
+    // `GitOperationError`. The route's catch block only matched the OLD regex
+    // (`isMissingGitPathError`), so the typed error leaked uncaught to
+    // `app.onError` → 500 → captureException → Sentry. The mock above throws
+    // the REAL `RepoFileNotFoundError` class for `not-found.txt`, so this
+    // exercises the exact prod code path. The fix makes the route branch on
+    // `isRepoFileNotFoundError` and return 404 — a 404 here proves the typed
+    // error no longer reaches the 500/Sentry path.
+    const typedMissingFile = await app.request(
+      `/v1/projects/${PROJECT_ID}/files/content?path=not-found.txt&ref=feature`,
+    );
+    expect(typedMissingFile.status).toBe(404);
+    expect(await typedMissingFile.json()).toEqual({ error: 'File not found' });
+    expect(readRepoFileCalls.at(-1)).toEqual({ projectId: PROJECT_ID, path: 'not-found.txt', ref: 'feature' });
 
     const read = await app.request(`/v1/projects/${PROJECT_ID}`);
     expect(read.status).toBe(200);

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -8,6 +8,7 @@ import {
   getCommitDiff,
   getFileHistory,
   grepRepoFiles,
+  isRepoFileNotFoundError,
   listBranches,
   listCommits,
   listRepoFiles,
@@ -371,7 +372,14 @@ projectsApp.openapi(
     const content = await readRepoFile(await withProjectGitAuth(loaded.row), path, ref);
     return c.json({ path, ref, content });
   } catch (error) {
-    if (isMissingGitPathError(error)) {
+    // `readRepoFile` converts a `git show` "path does not exist" failure into a
+    // typed `RepoFileNotFoundError` (message: `file not found in repository at
+    // '<ref>:<path>'`), which the `isMissingGitPathError` regex below does NOT
+    // match — without this branch the typed error leaked as an uncaught 500
+    // (Better Stack pattern `5b40ec1a…`). Keep `isMissingGitPathError` as a
+    // backstop for genuine `GitOperationError`s carrying the raw `fatal: path
+    // … does not exist in …` message from callers that bypass `readRepoFile`.
+    if (isRepoFileNotFoundError(error) || isMissingGitPathError(error)) {
       return c.json({ error: 'File not found' }, 404);
     }
     throw error;


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. Proof: the regression test asserts `GET /v1/projects/:id/files/content` returns **404** (not 500) when `readRepoFile` throws a `RepoFileNotFoundError`.

```
# without fix (reproduces the prod 500):
expect(typedMissingFile.status).toBe(404) → Received: 500  ❌
# with fix:    bun test src/__tests__/e2e-projects-contract.test.ts → 30 pass, 0 fail  ✅
```

Preview backend live and serving this exact commit:
```
$ curl -s https://pr-5971.preview-api.kortix.com/v1/health
{"status":"ok","environment":"preview","version":"pr-5971","commit":"d0dca89a71134df1b2d36399eeb083f8e6641e2a",...}
$ curl -s -o /dev/null -w "%{http_code}\n" "https://pr-5971.preview-api.kortix.com/v1/projects/<id>/files/content?path=x&ref=main"
401   # route correctly wired (auth gate), not 500
```

## Why
Better Stack error `5b40ec1a9601686917272ce6a538d1cdc7f2be7044624994e0957a54eeadd571` — `RepoFileNotFoundError` leaking as an uncaught 500 from `GET /v1/projects/:projectId/files/content` in prod (Kortix API, app_id 2346961, last 2026-08-01 02:33:57 UTC). The error is `handled:true` / `chained` — it reaches `app.onError` → `captureException` → Sentry, paging like a real defect when it is actually an expected client condition (a path that simply is not in the repo at the requested ref).

PR #5652 (commit `985b7db018`) introduced the typed `RepoFileNotFoundError` thrown by `readRepoFile` in `apps/api/src/projects/git/files.ts` when a `git show` fails with "path does not exist in". The intent was to let callers branch on this expected condition and return 404 instead of 500. But the `r5.ts` route handler catches errors with a local `isMissingGitPathError(error)` helper that regex-matches `^fatal: path .+.+does not exist in .+$` on the message. The new `RepoFileNotFoundError` message is `file not found in repository at main:...`, which does **not** match that regex → the catch block misses it → the typed error propagates uncaught → 500 → Sentry.

## What changed
**`apps/api/src/projects/routes/r5.ts`** (the `GET /:projectId/files/content` route, catch block ~line 382):
- Import `isRepoFileNotFoundError` from `../git` (already exported via the barrel in `apps/api/src/projects/git.ts`).
- Add `isRepoFileNotFoundError(error)` as an OR condition alongside `isMissingGitPathError(error)` so the typed error maps to the same `404 { error: "File not found" }` as the legacy message:
  ```ts
  if (isRepoFileNotFoundError(error) || isMissingGitPathError(error)) {
    return c.json({ error: 'File not found' }, 404);
  }
  ```
- `isMissingGitPathError` is kept as a backstop for genuine `GitOperationError`s carrying the raw `fatal: path … does not exist in …` message from callers that bypass `readRepoFile`.

**`apps/api/src/__tests__/e2e-projects-contract.test.ts`** (regression test):
- The existing `readRepoFile` mock threw the OLD `fatal: path …` message for `missing.txt` — which `isMissingGitPathError` matches, so it never exercised the new code path the route actually hits in prod. Added a `not-found.txt` case that throws the **real** `RepoFileNotFoundError` class (`new actualGit.RepoFileNotFoundError(path, ref)`) — the exact shape `readRepoFile` throws in prod (`files.ts:127`).
- Asserts the route returns **404** (not 500) and `{ error: 'File not found' }`. A 404 here is proof of no `captureException`: `app.onError` (which calls `captureException` and returns 500) is only reached for uncaught errors.

## Verification
- **Reproduced first**: with the fix reverted, the new test fails exactly as prod — `expect(typedMissingFile.status).toBe(404)` → `Received: 500` (the uncaught `RepoFileNotFoundError` hits `app.onError` → 500). With the fix, 30 pass / 0 fail.
- `tsc --noEmit` (apps/api) — clean (exit 0); `API typecheck` CI check — pass.
- `bun test src/projects/git/files.test.ts src/__tests__/e2e-projects-contract.test.ts` — 30 pass, 0 fail.
- **`bun unit tests (kortix-api)` CI check — PASS** (this is the gate for the API change and includes the regression test).
- Preview backend live at `https://pr-5971.preview-api.kortix.com` serving commit `d0dca89a71` (`environment: preview`); the files/content route is correctly wired (401 at the auth gate, not 500).

### Pre-existing, unrelated failure
`bun unit tests (packages + apps)` is **red on a pre-existing `main` breakage**, not this change: 2 frontend layout tests in `apps/web/src/features/workspace/project-sidebar/` (`project-switcher-control.test.ts` "the seam only appears on hover" and `project-sidebar-header.test.ts` "the control takes the row, so there is no dead strip beside it") fail from test/component drift in the recent brand/switcher refactor at `main` HEAD (`77d18d5be6` "merge the Kortix mark and project switcher" / `c3133b4bc8` "clean up ProjectSwitcher"). They fail identically on a clean checkout of `c3133b4bc8` (this PR's base) with no api/ changes applied. This PR touches only `apps/api/` (one route + one api test) and cannot affect `apps/web` layout snapshots. That failure is owned by the brand/switcher work, not this fix.

## Risk / rollback
Tiny, surgical, additive. One new OR-branch in an existing catch; no behavior change for any path that previously returned 404 or 500 correctly. Rollback = revert the single commit. The only observable change is that a request that previously 500'd (and paged Sentry) now 404's — the intended prod behavior.

## Incident
- Better Stack error: https://errors.betterstack.com/team/t502678/errors/5b40ec1a9601686917272ce6a538d1cdc7f2be7044624994e0957a54eeadd571?s=2346961
- Pattern: `5b40ec1a9601686917272ce6a538d1cdc7f2be7044624994e0957a54eeadd571`
- Call site: `readRepoFile` in `apps/api/src/projects/git/files.ts`, surfaced via `GET /v1/projects/:id/files/content`
- Confirm: after merge + promote, new occurrences of this pattern should drop to zero (Better Stack auto-resolves once it stops seeing it).