### PR TITLE
fix(web): filter Android WebView postEvent setTimeout-captured noise (BS f50ed590)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -3497,6 +3497,159 @@ test('does NOT suppress a same-worded message from a different bridge / non-Andr
   )
 })
 
+// --- 2026-08-01 sibling: the `BrowserApiErrors.setTimeout`-captured variant
+// (BS pattern `f50ed590…`). The `postEvent` Android WebView bridge-GC throw
+// surfaced via Sentry's `BrowserApiErrors` setTimeout auto-wrapper, which
+// records the SCHEDULING frame (the Next.js webpack runtime chunk where
+// `setTimeout` was REGISTERED) as frame #1 and the actual THROW SITE
+// (`<anonymous>`, the anonymous timer callback = the WebView bridge hop) as
+// frame #2. The #5181 matcher's resolvable-frame negative guard rejected
+// this event because frame #1 (`app:///_next/…`) is resolvable, so it leaked.
+// The fix recognizes the `<anonymous>` throw-site frame as a positive anchor
+// and relaxes the resolvable-frame negative guard so the incidental
+// webpack-runtime scheduling frame does NOT veto suppression. See
+// `ANDROID_WEBVIEW_BRIDGE_THROW_SITE_FRAME` for the rationale.
+//
+// The EXACT production event frames from BS `f50ed590…` (release
+// `c330eda4d96e7aee557618254a86df7d16ba5d9b`, v0.12.0, Chrome 150 Android 16,
+// mechanism `auto.browser.browserapierrors.setTimeout`, UNCAUGHT `handled:false`,
+// URL `https://kortix.com/`). Frame #1 is the webpack runtime chunk
+// (`__webpack_require__`'s module-init `setTimeout` registration, minified
+// function `u`); frame #2 is the `<anonymous>` throw site (function `?`).
+const SETTIMEOUT_PROD_SCHEDULING_FRAME =
+  'app:///_next/static/chunks/86784-d4b6544b8ad14b3b.js?dpl=dpl_vkPg62H2TNxvxAUgEDzEoaANndoK'
+const SETTIMEOUT_PROD_THROW_SITE_FRAME = '<anonymous>'
+
+test('classifies the BrowserApiErrors.setTimeout-captured postEvent noise (exact prod frames)', () => {
+  // The exact production capture shape — frame #1 is the webpack runtime
+  // SCHEDULING frame (where `setTimeout` was registered), frame #2 is the
+  // `<anonymous>` THROW SITE (the anonymous timer callback = the WebView
+  // bridge hop). Both `in_app:true`.
+  for (const message of ANDROID_WEBVIEW_BRIDGE_POSTEVENT_EVENTS) {
+    assert.equal(
+      isAndroidWebViewNativeBridgePostEventNoise({
+        message,
+        frames: [
+          { filename: SETTIMEOUT_PROD_SCHEDULING_FRAME, function: 'u' },
+          { filename: SETTIMEOUT_PROD_THROW_SITE_FRAME, function: '?' },
+        ],
+      }),
+      true,
+      `expected setTimeout-captured "${message}" (webpack-runtime + <anonymous> throw site) to be noise`,
+    )
+    // The scheduling frame alone (no `<anonymous>` throw site) must STILL keep
+    // reporting — an incidental webpack chunk frame with NO `<anonymous>`
+    // throw-site anchor is not the WebView bridge shape; it is an
+    // attributable app/webpack error. Only the `<anonymous>` throw-site frame
+    // is the positive anchor.
+    assert.equal(
+      isAndroidWebViewNativeBridgePostEventNoise({
+        message,
+        frames: [{ filename: SETTIMEOUT_PROD_SCHEDULING_FRAME, function: 'u' }],
+      }),
+      false,
+      `expected scheduling-frame-only "${message}" (no <anonymous> throw site) to keep reporting`,
+    )
+  }
+})
+
+test('classifies the <anonymous> throw-site frame as noise even with an incidental app-chunk scheduling frame', () => {
+  // The positive `<anonymous>` throw-site anchor must fire regardless of
+  // which incidental scheduling frame the BrowserApiErrors wrapper recorded
+  // (a generic `app:///_next/…` chunk, a URL, or any non-first-party source).
+  for (const schedulingFrame of [
+    'app:///_next/static/chunks/66499-704f783b0e8ea993.js',
+    'app:///_next/static/chunks/webpack-abc123.js',
+    'https://kortix.com/_next/static/chunks/main-123.js',
+  ]) {
+    assert.equal(
+      isAndroidWebViewNativeBridgePostEventNoise({
+        message: 'Error invoking postEvent: Java object is gone',
+        frames: [
+          { filename: schedulingFrame },
+          { filename: '<anonymous>', function: '?' },
+        ],
+      }),
+      true,
+      `expected <anonymous> throw site + incidental scheduling frame ${schedulingFrame} to be noise`,
+    )
+  }
+  // The `<anonymous>` throw site is also noise via the runtime (window.onerror)
+  // gate when it is the filename itself.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Error invoking postEvent: Java object is gone',
+      filename: '<anonymous>',
+    }),
+    true,
+    'expected runtime gate to suppress <anonymous> throw-site postEvent',
+  )
+})
+
+test('suppresses the BrowserApiErrors.setTimeout-captured postEvent noise via the Sentry beforeSend gate', () => {
+  // The exact production Sentry event shape — exception value + 2-frame
+  // stacktrace (webpack-runtime scheduling + `<anonymous>` throw site).
+  for (const value of ANDROID_WEBVIEW_BRIDGE_POSTEVENT_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: {
+                frames: [
+                  { filename: SETTIMEOUT_PROD_SCHEDULING_FRAME, function: 'u' },
+                  { filename: SETTIMEOUT_PROD_THROW_SITE_FRAME, function: '?' },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry gate to suppress setTimeout-captured "${value}"`,
+    )
+  }
+})
+
+test('still does NOT suppress a real first-party postEvent failure (regression guard for the relaxed matcher)', () => {
+  // The first-party `apps/web/src/…` negative guard MUST still fire even when
+  // an incidental `<anonymous>` frame is present alongside a first-party frame.
+  // A real first-party `postEvent`/`dispatchEvent` regression de-minifies to
+  // `apps/web/src/…` and must never be hidden by the relaxed `<anonymous>`
+  // throw-site anchor.
+  const firstPartyFrames = [
+    { filename: 'apps/web/src/features/messaging/event-bridge.ts', function: 'dispatchBridgeEvent' },
+    { filename: '<anonymous>', function: '?' },
+  ]
+  assert.equal(
+    isAndroidWebViewNativeBridgePostEventNoise({
+      message: 'Error invoking postEvent: Java object is gone',
+      frames: firstPartyFrames,
+    }),
+    false,
+    'expected first-party postEvent regression with an incidental <anonymous> frame to keep reporting',
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [{ value: 'Error invoking postEvent: Java object is gone', stacktrace: { frames: firstPartyFrames } }],
+      },
+    }),
+    false,
+    'expected Sentry gate to keep reporting first-party postEvent regression',
+  )
+  // Via the runtime gate: a first-party filename keeps reporting.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Error invoking postEvent: Java object is gone',
+      filename: 'apps/web/src/features/messaging/event-bridge.ts',
+    }),
+    false,
+  )
+})
+
 // ---------------------------------------------------------------------------
 // iOS WebKit (WKWebView) in-app-browser native-bridge `messageHandlers` noise
 // — the iOS sibling of the Android WebView bridge classes above.

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -472,9 +472,70 @@ function isAndroidNavPerfLoggerFrame(filename: unknown): boolean {
 // swallow a real first-party event-dispatch failure; the frame-aware
 // `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`) is the only
 // safe gate.
+//
+// --- 2026-08-01 sibling (BS pattern `f50ed590…`, the `setTimeout`-captured
+// variant) — TWO ADDITIONAL frame shapes must classify as noise ---
+// Better Stack pattern
+// f50ed59002e8507f8226d63104e7351416eadbc8eb2532977f70fc55a2807e6b
+// (Kortix Frontend prod, application_id 2346967): `Error`, message
+// `Error invoking postEvent: Java object is gone`, 1 occurrence / 0 identified
+// users, last 2026-08-01 08:35:32 UTC, release
+// `c330eda4d96e7aee557618254a86df7d16ba5d9b` (v0.12.0 prod), transaction `/`
+// (marketing homepage), URL `https://kortix.com/`, browser Chrome 150.0.7871
+// on Android 16 (mobile, UA
+// `Mozilla/5.0 (Linux; Android 16; K) AppleWebKit/537.36 (KHTML, like Gecko)
+// Chrome/150.0.7871.181 Mobile Safari/537.36`), mechanism
+// `auto.browser.browserapierrors.setTimeout` (UNCAUGHT — `handled:false`,
+// Sentry's `BrowserApiErrors` integration auto-wraps `setTimeout` and
+// captures the throw from the timer callback). Stack (2 frames, BOTH
+// `in_app:true`):
+//   1. `app:///_next/static/chunks/86784-d4b6544b8ad14b3b.js?dpl=dpl_…`
+//      function `u` (the Next.js webpack runtime chunk — the SCHEDULING frame
+//      where `setTimeout` was REGISTERED, NOT the throw site)
+//   2. `<anonymous>` function `?` (THE THROW SITE — the anonymous setTimeout
+//      callback where the GC'd Android WebView `JavaBridge.postEvent` throws)
+//
+// This is the SAME `postEvent` Android WebView bridge-GC noise class as
+// `a6795db2…` (#5181), but surfaced via a DIFFERENT Sentry capture path: the
+// `BrowserApiErrors.setTimeout` auto-wrapper records the frame that SCHEDULED
+// the timer (the webpack runtime chunk, where `__webpack_require__`'s module
+// init code registered a `setTimeout`) as frame #1, and the actual throw site
+// (the anonymous callback = the WebView bridge hop) as frame #2 `<anonymous>`.
+// The #5181 matcher's negative guard #2 (`isResolvableFrameSource`) rejected
+// this event because frame #1 (`app:///_next/…`) is a "resolvable" source, so
+// it leaked to Better Stack.
+//
+// The throw STILL originates at the `<anonymous>` Android WebView bridge hop
+// — frame #1 is an INCIDENTAL scheduling frame (where the timer was
+// registered), not the throw site. `Java object is gone` is the canonical
+// Android System WebView Java-bridge-GC'd message; it is never raised by
+// first-party app code or by desktop Chrome, so the `<anonymous>` throw-site
+// frame is a specific positive anchor for this class. The fix:
+//   1. Treat `<anonymous>` (the canonical Android WebView bridge throw-site
+//      frame) as a POSITIVE anchor — a `<anonymous>` / `?` frame is where the
+//      GC'd `postEvent` actually throws, never a first-party call site.
+//   2. Relax negative guard #2 so an INCIDENTAL webpack-runtime chunk frame
+//      (the `BrowserApiErrors.setTimeout` scheduling frame, an `app:///_next/`
+//      chunk that is NOT a resolved first-party `apps/web/src/…` path) does NOT
+//      veto suppression. The first-party `apps/web/src/…` negative guard #1 is
+//      unchanged — a real first-party `postEvent`/`dispatchEvent` regression
+//      de-minifies to `apps/web/src/…` and is still preserved.
 const ANDROID_WEBVIEW_NATIVE_BRIDGE_POSTEVENT_NOISE_MESSAGES = [
   'Error invoking postEvent: Java object is gone',
 ] as const;
+
+// The canonical Android WebView `JavaBridge` throw-site frame: `<anonymous>`
+// with function `?` (Sentry's placeholder for a frame whose function name was
+// stripped during minification). When the `BrowserApiErrors.setTimeout`
+// (or `addEventListener`) auto-wrapper captures a `postEvent: Java object is
+// gone` throw, the actual throw originates from the anonymous callback (the
+// WebView bridge hop), so this frame is the specific positive anchor. A
+// first-party `postEvent`/`dispatchEvent` throw surfaces with a NAMED function
+// (or a de-minified `apps/web/src/…` filename), never the bare `<anonymous>`
+// throw-site shape — so anchoring on `<anonymous>` here is conservative for
+// this exact message. (Distinct from the `app://navigation_performance_logger_
+// android` synthetic source used by the `postMessage` sibling #4610.)
+const ANDROID_WEBVIEW_BRIDGE_THROW_SITE_FRAME = '<anonymous>';
 
 // iOS WebKit (WKWebView) in-app-browser native-bridge instrumentation noise.
 // The iOS sibling of the Android System WebView bridge noise above
@@ -1629,17 +1690,34 @@ export function isAndroidWebViewNativeBridgePostMessageNoise(input: {
  * injected `JavaBridge` calls `postEvent` on a native Java bridge whose
  * backing `JavaObject` has been garbage-collected (page navigation / WebView
  * teardown / in-app browser dismiss). This is the WebView's OWN bridge
- * plumbing, not first-party code. Unlike the `postMessage` sibling (PR #4610),
- * the `postEvent` variant is observed as a FRAMELESS capture
- * (`<anonymous>` / `?` call site, no resolvable stack), so it cannot be
- * anchored on the synthetic `app://navigation_performance_logger_android`
- * frame. Instead — like the iOS-WebKit stack-overflow frameless class — it
- * requires BOTH the exact message AND a frameless/injected-WebView origin:
- * suppress only when there is NO resolvable source location OR the frame is
- * the Android nav-performance-logger bridge source. A genuine first-party
- * `postEvent` / `dispatchEvent` failure throws from an app chunk or a
- * de-minified `apps/web/src/…` frame and is preserved by the negative guard.
- * Never page Better Stack for this class. See
+ * plumbing, not first-party code. The `postEvent` variant surfaces in TWO
+ * capture shapes, both anchored on the exact message:
+ *   1. FRAMELESS (PR #5181, BS `a6795db2…`): `<anonymous>` / `?` call site,
+ *      no resolvable stack, captured by Sentry's global `onerror`/
+ *      `onunhandledrejection`.
+ *   2. `setTimeout`-wrapped (BS `f50ed590…`): Sentry's `BrowserApiErrors`
+ *      integration auto-wraps `setTimeout` and records the SCHEDULING frame
+ *      (an `app:///_next/…` webpack runtime chunk where the timer was
+ *      registered) as frame #1, plus the actual THROW SITE (`<anonymous>`,
+ *      the anonymous timer callback = the WebView bridge hop) as frame #2.
+ *      The scheduling frame is incidental — it is where `setTimeout` was
+ *      called, NOT where the throw originates.
+ * Both shapes carry the `<anonymous>` throw-site frame (the Android WebView
+ * bridge hop, never a first-party call site). `Java object is gone` is the
+ * canonical Android System WebView Java-bridge-GC'd message; it is never
+ * raised by first-party app code or by desktop Chrome, so the `<anonymous>`
+ * throw-site frame is a specific positive anchor. The matcher suppresses
+ * when: the frame is the synthetic `app://navigation_performance_logger_
+ * android` bridge source (the #4610 sibling shape), OR the throw site is the
+ * canonical `<anonymous>` bridge frame, OR the capture is frameless (no
+ * resolvable source at all). A genuine first-party `postEvent` /
+ * `dispatchEvent` failure throws from a NAMED function in an `app:///_next/…`
+ * chunk or a de-minified `apps/web/src/…` frame (never the bare `<anonymous>`
+ * throw-site shape) and is preserved by the first-party negative guard. An
+ * INCIDENTAL webpack-runtime scheduling frame (`app:///_next/static/chunks/
+ * webpack-…` or any non-first-party `app:///_next/…` chunk) does NOT veto
+ * suppression — it is where the timer was registered, not where the throw
+ * originated. Never page Better Stack for this class. See
  * `ANDROID_WEBVIEW_NATIVE_BRIDGE_POSTEVENT_NOISE_MESSAGES` for the full
  * rationale.
  */
@@ -1660,22 +1738,36 @@ export function isAndroidWebViewNativeBridgePostEventNoise(input: {
     input.filename,
     ...(input.frames ?? []).map((frame) => frame?.filename),
   ];
-  // Positive anchor: the synthetic Android nav-performance-logger bridge
+  // Positive anchor #1: the synthetic Android nav-performance-logger bridge
   // source (the framed sibling shape, forward-compat with #4610's evidence).
   if (sources.some((filename) => isAndroidNavPerfLoggerFrame(filename))) {
     return true;
   }
   // Negative guard #1: a resolved first-party `apps/web/src/…` frame → our
   // own event-dispatch code is failing; keep reporting so the call site can
-  // be found + fixed.
+  // be found + fixed. A real first-party `postEvent`/`dispatchEvent`
+  // regression de-minifies to `apps/web/src/…` and is never hidden.
   if (sources.some(isFirstPartyResolvedSource)) {
     return false;
   }
-  // Negative guard #2: any resolvable source location (real app chunk, URL,
-  // or named file) → an actionable event-dispatch error with a real stack;
-  // keep reporting. Only the frameless synthetic-`undefined`/`<anonymous>`
-  // global-onerror/onunhandledrejection capture remains → Android WebView
-  // native-bridge GC noise.
+  // Positive anchor #2: the canonical Android WebView `JavaBridge` throw-site
+  // frame `<anonymous>` (function `?`). The `BrowserApiErrors.setTimeout` /
+  // `addEventListener` auto-wrapper records the SCHEDULING frame (an
+  // `app:///_next/…` webpack chunk where the timer was REGISTERED) as the
+  // first frame, but the actual throw originates at the `<anonymous>`
+  // callback — the WebView bridge hop, never a first-party call site. `Java
+  // object is gone` is uniquely an Android WebView internal message, so the
+  // `<anonymous>` throw-site frame is a specific positive anchor for this
+  // exact message. (BS `f50ed590…`.)
+  if (sources.some((filename) => normalizeString(filename) === ANDROID_WEBVIEW_BRIDGE_THROW_SITE_FRAME)) {
+    return true;
+  }
+  // Negative guard #2: any OTHER resolvable source location (real app chunk
+  // with a NAMED function, URL, or named file — NOT the `<anonymous>` throw
+  // site already matched above, NOT a first-party `apps/web/src/…` path
+  // already matched by guard #1) → an actionable event-dispatch error with a
+  // real, attributable stack; keep reporting. Only the frameless capture
+  // (the #5181 shape) remains → Android WebView native-bridge GC noise.
   if (sources.some(isResolvableFrameSource)) {
     return false;
   }


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. Proof: the 4 new noise-tests pin the exact production event (`postEvent` message + `<anonymous>` throw-site frame + webpack-runtime scheduling frame + Android UA) and assert it now classifies as noise at both the matcher and the `beforeSend` gate, while a real first-party `postEvent` regression (with a de-minified `apps/web/src/...` frame) still keeps reporting.

```
node --experimental-strip-types --test apps/web/src/lib/browser-error-noise.test.mts
# tests 229   # pass 229   # fail 0
```

## Why

Better Stack surfaced a new production error (1 occurrence, 0 users, Android Chrome 150, `https://kortix.com/`, `v0.12.0`):

- **Pattern:** `f50ed59002e8507f8226d63104e7351416eadbc8eb2532977f70fc55a2807e6b`
- **URL:** https://errors.betterstack.com/team/t502678/errors/f50ed59002e8507f8226d63104e7351416eadbc8eb2532977f70fc55a2807e6b?s=2346967
- **Message:** `Error invoking postEvent: Java object is gone`
- **Mechanism:** `auto.browser.browserapierrors.setTimeout` (UNCAUGHT — `handled:false`)
- **Stack (2 frames, both `in_app:true`):**
  1. `app:///_next/static/chunks/86784-d4b6544b8ad14b3b.js?dpl=dpl_...` function `u` — the **webpack runtime chunk** (where `setTimeout` was *registered*)
  2. `<anonymous>` function `?` — **the throw site** (the anonymous `setTimeout` callback where the GC'd Android WebView `JavaBridge.postEvent` throws)

This is a **sibling** of the Android WebView native-bridge noise already covered by PR #5181 (`isAndroidWebViewNativeBridgePostEventNoise`, BS `a6795db2...`). Both are the canonical `Java object is gone` Android System WebView Java-bridge-GC'd message — the WebView's own bridge plumbing, never first-party code. The #5181 matcher handled the **frameless** capture (`<anonymous>`/`?`, no resolvable stack). This new event surfaced via a **different Sentry capture path**: Sentry's `BrowserApiErrors` integration auto-wraps `setTimeout` and records the *scheduling* frame (the webpack runtime chunk) as frame #1, plus the actual throw site (`<anonymous>`) as frame #2.

**Root cause of the leak:** the #5181 matcher's negative guard #2 (`isResolvableFrameSource`) rejected this event because frame #1 (`app:///_next/...`) is a "resolvable" source, so it returned `false` and the event reached Better Stack. The throw *still* originates at the `<anonymous>` Android WebView bridge hop — frame #1 is an **incidental** scheduling frame (where the timer was registered), not the throw site.

## What changed

`apps/web/src/lib/browser-error-noise.ts` — extended `isAndroidWebViewNativeBridgePostEventNoise` to cover the `BrowserApiErrors.setTimeout`-captured variant:

1. Added a **positive anchor #2**: the canonical Android WebView `JavaBridge` throw-site frame `<anonymous>` (function `?`). `Java object is gone` is uniquely an Android WebView internal message (never raised by first-party app code or desktop Chrome), so the `<anonymous>` throw-site frame is a specific positive anchor for this exact message. When the `setTimeout`/`addEventListener` auto-wrapper records an incidental scheduling frame as frame #1, the actual throw still originates at the `<anonymous>` callback — the WebView bridge hop.
2. The **first-party negative guard #1** (`apps/web/src/...`) is **unchanged** — a real first-party `postEvent`/`dispatchEvent` regression de-minifies to `apps/web/src/...` and is still preserved (verified by a dedicated regression-guard test).
3. The resolvable-frame negative guard #2 still fires for any *other* resolvable, attributable source (real app chunk with a named function, URL, named file) — only the frameless capture (#5181 shape) and the `<anonymous>` throw-site shape are dropped.

No changes to `sentry.client.config.ts`'s `ignoreErrors` — the frame-aware `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`) remains the only safe gate, since it can anchor on the `<anonymous>` throw-site frame.

## Verification

- **Noise tests:** `node --experimental-strip-types --test apps/web/src/lib/browser-error-noise.test.mts` → **229 pass / 0 fail** (225 prior + 4 new). Also confirmed via `bun test` → 229 pass.
- **New tests pin the production event:**
  - `classifies the BrowserApiErrors.setTimeout-captured postEvent noise (exact prod frames)` — the exact 2-frame prod stack (webpack-runtime scheduling + `<anonymous>` throw site) classifies as noise; the scheduling frame *alone* (no `<anonymous>` throw site) still keeps reporting.
  - `classifies the <anonymous> throw-site frame as noise even with an incidental app-chunk scheduling frame` — the `<anonymous>` anchor fires for any incidental scheduling frame (generic chunk, webpack chunk, URL).
  - `suppresses the BrowserApiErrors.setTimeout-captured postEvent noise via the Sentry beforeSend gate` — the full `shouldIgnoreSentryBrowserNoise` gate suppresses the prod event shape.
  - `still does NOT suppress a real first-party postEvent failure (regression guard for the relaxed matcher)` — a first-party `apps/web/src/...` frame alongside an incidental `<anonymous>` frame still keeps reporting.
- **Typecheck:** `tsc --noEmit` on `browser-error-noise.ts` with strict mode → clean (exit 0). The test file's isolated-minimal-config "errors" are pre-existing `node:`/`function`-prop patterns present on the unmodified file too (the real `next build` config + `@types/node` accept them).

## Risk / rollback

Low. The change is scoped to a single noise-matcher and only *adds* a positive anchor (`<anonymous>` throw site) for an exact-message Android WebView class; it never widens the match to a generic message. The first-party negative guard is untouched, so a real first-party `postEvent` regression is never hidden. Revert is a single commit. Once this ships + promotes, the `f50ed590...` Better Stack error should drop to zero new occurrences and auto-resolve.

## CI note (one red check is pre-existing on `main`, unrelated to this PR)

`bun unit tests (packages + apps)` fails on **2 pre-existing tests** broken by the recent ProjectSwitcher refactor that landed directly on `main` AFTER the last green `package-tests.yml` run (2026-07-31 15:30 UTC @ `e362e429d6`):
- `project sidebar header > the control takes the row, so there is no dead strip beside it` (`src/features/workspace/project-sidebar/project-sidebar-header.test.ts`)
- `merged brand/switcher control > the seam only appears on hover` (`src/features/workspace/project-sidebar/project-switcher-control.test.ts`)

These fail on plain `main` HEAD (`c3133b4bc8`, the base of this branch) — verified locally. This PR changes ONLY `apps/web/src/lib/browser-error-noise.ts` + its test; it does not touch any `project-sidebar`/`ProjectSwitcher`/`Hint` file. All other checks are green: **Frontend build** (the `next build` typecheck gate) ✅, **all 229 noise-tests** ✅ (incl. the 4 new ones), **gitleaks / CodeQL / Strix / fast checks / every change ships with tests** ✅. The 2 failing tests need a separate fix to the ProjectSwitcher refactor's test expectations (out of scope for this noise-suppression PR).

