### PR TITLE
docs(secrets): use the Kortix Armor organization

### DIFF
--- a/.claude/skills/dotenvx-secrets/SKILL.md
+++ b/.claude/skills/dotenvx-secrets/SKILL.md
@@ -7,30 +7,26 @@ description: "How this repo manages API secrets and the four local-run environme
 
 API secrets are **encrypted in git** with [dotenvx](https://dotenvx.com); the decryption keys live **off-device in Dotenv Armor**. This is mandatory — a plaintext secret never belongs in a tracked file.
 
-## Armor organization and access boundary
+## Armor organization and operational boundary
 
-Armor access is split across two organizations. Always pass the owning team
-explicitly when pushing or pulling; never rely on the CLI's personal-team
-default.
+All API and web profiles belong to the single Armor organization **`kortix`**.
+Always pass `--team kortix` when pushing or pulling. Never rely on the CLI's
+personal-team default.
 
-| Profiles | Owning Armor organization |
-| --- | --- |
-| API + web `.env`, `.env.dev`, and `.env.staging` | **`go-marko-kortix-ai`** |
-| API + web `.env.prod` | **`kortix-ai-prod`** |
-
-Only production-authorized members and automation tokens belong to
-`kortix-ai-prod`. The shared team must not contain either current prod key.
+Production uses the same organization and access token as non-production.
+Keep production pulls as a separate, explicit command. This is an operational
+guardrail, not an authorization boundary.
 
 ## The four environments (local-run secrets)
 
-There are **four environments**, each a separate encrypted file with its **own keypair**. They differ only in *which backend the locally-running API talks to* — same code, different DB / Stripe / keys:
+There are **four environments**, each a separate encrypted file with its **own keypair**. They differ only in _which backend the locally-running API talks to_ — same code, different DB / Stripe / keys:
 
-| `pnpm` command | Env | File | API talks to | private key in `.env.keys` |
-| --- | --- | --- | --- | --- |
-| `pnpm dev` | **local** | `apps/api/.env` | 100% local stack (local Supabase in Docker, test Stripe) + runs web + tunnel | `DOTENV_PRIVATE_KEY` |
-| `pnpm dev:dev-env` | **dev** | `apps/api/.env.dev` | the **dev** stack — dev Supabase DB, **test** Stripe, dev keys (`dev-api.kortix.com`) | `DOTENV_PRIVATE_KEY_DEV` |
+| `pnpm` command         | Env         | File                    | API talks to                                                                                      | private key in `.env.keys`   |
+| ---------------------- | ----------- | ----------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `pnpm dev`             | **local**   | `apps/api/.env`         | 100% local stack (local Supabase in Docker, test Stripe) + runs web + tunnel                      | `DOTENV_PRIVATE_KEY`         |
+| `pnpm dev:dev-env`     | **dev**     | `apps/api/.env.dev`     | the **dev** stack — dev Supabase DB, **test** Stripe, dev keys (`dev-api.kortix.com`)             | `DOTENV_PRIVATE_KEY_DEV`     |
 | `pnpm dev:staging-env` | **staging** | `apps/api/.env.staging` | the **staging** stack — staging Supabase DB, test Stripe, staging keys (`staging-api.kortix.com`) | `DOTENV_PRIVATE_KEY_STAGING` |
-| `pnpm dev:prod-env` | **prod** | `apps/api/.env.prod` | the **prod** stack — prod Supabase DB, **LIVE** Stripe, prod keys (`api.kortix.com`) | `DOTENV_PRIVATE_KEY_PROD` |
+| `pnpm dev:prod-env`    | **prod**    | `apps/api/.env.prod`    | the **prod** stack — prod Supabase DB, **LIVE** Stripe, prod keys (`api.kortix.com`)              | `DOTENV_PRIVATE_KEY_PROD`    |
 
 - `pnpm dev` runs the **full local stack** (web + API + local Supabase + tunnel) via `scripts/dev-local.sh`.
 - `pnpm dev:dev-env` / `pnpm dev:staging-env` / `pnpm dev:prod-env` run the **API only**, locally, against the selected remote backend (`dotenvx run -f apps/api/.env.<environment> -- bun run --hot src/index.ts`). They do not start local Supabase.
@@ -65,16 +61,16 @@ This re-encrypts the file in place (value becomes `KEY=encrypted:…`). Then com
 
 ## Commands
 
-| Task | Command |
-| --- | --- |
-| Run local / dev / staging / prod | `pnpm dev` · `pnpm dev:dev-env` · `pnpm dev:staging-env` · `pnpm dev:prod-env` |
-| Verify all 4 envs decrypt + are separated | `pnpm test:envs` |
-| Read a secret | `dotenvx get KEY -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`) |
-| Add / change a secret | `dotenvx set KEY value -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`), then commit |
-| First time / new machine (shared profiles) | `dotenvx armor login` then, from each app directory, `for f in .env .env.dev .env.staging; do dotenvx armor pull --team go-marko-kortix-ai -f "$f"; done` |
-| Pull prod (production-authorized only) | From each app directory: `dotenvx armor pull --team kortix-ai-prod -f .env.prod` |
-| Share a NEW profile / rotated key | Push non-prod with `--team go-marko-kortix-ai`; push prod with `--team kortix-ai-prod` |
-| Remove a key from the cloud | `dotenvx armor down --team <owning-team> -f <file>` |
+| Task                                         | Command                                                                                                                                       |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Run local / dev / staging / prod             | `pnpm dev` · `pnpm dev:dev-env` · `pnpm dev:staging-env` · `pnpm dev:prod-env`                                                                |
+| Verify all 4 envs decrypt + are separated    | `pnpm test:envs`                                                                                                                              |
+| Read a secret                                | `dotenvx get KEY -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`)                                                             |
+| Add / change a secret                        | `dotenvx set KEY value -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`), then commit                                          |
+| First time / new machine (non-prod profiles) | `dotenvx armor login` then, from each app directory, `for f in .env .env.dev .env.staging; do dotenvx armor pull --team kortix -f "$f"; done` |
+| Pull prod (explicitly)                       | From each app directory: `dotenvx armor pull --team kortix -f .env.prod`                                                                      |
+| Share a NEW profile / rotated key            | Push every profile with `--team kortix`                                                                                                       |
+| Remove a key from the cloud                  | `dotenvx armor down --team kortix -f <file>`                                                                                                  |
 
 ## Armor login security
 
@@ -100,7 +96,7 @@ token, making an authorization check look broader than the automation token
 really is. Verify token scope with an explicit team pull instead:
 
 ```sh
-dotenvx armor pull --token "$DOTENVX_ARMOR_TOKEN" --team <owning-team> -f <file>
+dotenvx armor pull --token "$DOTENV_ARMOR_TOKEN" --team kortix -f <file>
 dotenvx run --no-armor -f <file> -- <command>
 ```
 
@@ -117,7 +113,7 @@ login/push/pull use the current global CLI.
 `rotate --no-armor` deliberately leaves a transitional `old,new` value in
 `.env.keys`. Armor accepts exactly one private key, so **never push that combined
 value**. After proving the new ciphertext decrypts, retain only the new private
-key, push it explicitly to the profile's owning team, then prove a clean Armor
+key, push it explicitly to the `kortix` organization, then prove a clean Armor
 pull matches the local key before merging. Remove the old armored key only after
 the rotated ciphertext is merged and available to every authorized consumer.
 
@@ -133,7 +129,7 @@ Need a different value just on your machine? Put it in the gitignored `apps/api/
 ## Guardrails (don't bypass)
 
 - `apps/api/.env.keys`, `apps/api/.env.local`, `apps/web/.env`, `supabase/.env` are gitignored.
-- Version-controlled git hooks in `.githooks/` (enable per clone: `git config core.hooksPath .githooks`). **Every committable `.env` is dotenvx-managed, no exceptions:** the pre-commit hook discovers *any* staged `.env`/`.env.<env>` (new services included) and **auto-encrypts** it (`--no-armor`, mints a keypair into the adjacent `.env.keys` for new files), then blocks the commit if any unencrypted, non-gitignored `.env` remains; pre-push re-checks. Excluded: `.env.keys` (private keys) and `.env.example` (templates); gitignored files like `.env.local` / `supabase/.env` are never staged so they're untouched.
+- Version-controlled git hooks in `.githooks/` (enable per clone: `git config core.hooksPath .githooks`). **Every committable `.env` is dotenvx-managed, no exceptions:** the pre-commit hook discovers _any_ staged `.env`/`.env.<env>` (new services included) and **auto-encrypts** it (`--no-armor`, mints a keypair into the adjacent `.env.keys` for new files), then blocks the commit if any unencrypted, non-gitignored `.env` remains; pre-push re-checks. Excluded: `.env.keys` (private keys) and `.env.example` (templates); gitignored files like `.env.local` / `supabase/.env` are never staged so they're untouched.
 - `.gitleaks.toml` allowlists the encrypted `apps/api/.env*` so `secret-scan` passes while still catching real plaintext anywhere else.
 - GitHub secret-scanning **push protection** is enabled on the repo.
 
@@ -141,7 +137,7 @@ If a guard fires, the fix is to **encrypt the value**, never to bypass it.
 
 ## The web app (apps/web) — same setup
 
-`apps/web` has the **same four encrypted profiles** (`apps/web/.env` / `.env.dev` / `.env.staging` / `.env.prod`) and its own keypairs in `apps/web/.env.keys`. Its local/dev/staging keys live in `go-marko-kortix-ai`; its prod key lives in `kortix-ai-prod`. Decrypted the same way: `pnpm dev` (via `load_local_env`) and the environment-specific web scripts.
+`apps/web` has the **same four encrypted profiles** (`apps/web/.env` / `.env.dev` / `.env.staging` / `.env.prod`) and its own keypairs in `apps/web/.env.keys`. All keys live in the `kortix` Armor organization. Decrypted the same way: `pnpm dev` (via `load_local_env`) and the environment-specific web scripts.
 
 Maintenance flags are **DB-backed** now (was Vercel Edge Config): stored in `kortix.platform_settings['maintenance_config']`, read via public `GET /v1/system/maintenance`, written via admin-only `PUT /v1/system/maintenance`, set from `/admin/utils`. The `EDGE_CONFIG`/`EDGE_CONFIG_ID`/`VERCEL_API_TOKEN` secrets + the `@vercel/edge-config` dep are gone.
 

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -195,7 +195,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
             live instead of inert. */}
         <div className="flex w-full items-center gap-1">
           <ProjectSwitcher variant="sidebar" className="min-w-0 flex-1" />
-          <div className="flex shrink-0 items-center gap-0.5 ml-auto">
+          <div className="ml-auto flex shrink-0 items-center gap-0.5">
             {/* Search is the palette's only pointer-reachable entry point —
                 ⌘K is otherwise the whole discovery story. Renders on mobile
                 too: there is no keystroke to fall back on there. */}

--- a/apps/web/src/features/workspace/project-sidebar/project-switcher-control.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-switcher-control.test.ts
@@ -54,6 +54,7 @@ describe('merged brand/switcher control', () => {
   // A seam that is always drawn makes the shell read as two boxes again.
   test('the seam only appears on hover', () => {
     expect(control).toContain('bg-border/0 group-hover/switcher:bg-border/70');
+    expect(control).not.toContain('group-hover/switcher:bg-border ');
   });
 
   // kortix-design-system: @phosphor-icons/react is the only icon source in


### PR DESCRIPTION
## Demo
Preview: https://suna-6l7ugy8x0-kortixai.vercel.app (backend: https://pr-5974.preview-api.kortix.com)

Primarily a non-visual secrets-configuration documentation change. Verified all eight API/web dotenvx profiles pull and decrypt from the `kortix` Armor organization with the configured automation token. The PR also fixes two same-main-sha sidebar assertions that blocked the repository quality gate; 15 focused tests pass.

## Why
The repository still documented obsolete `go-marko-kortix-ai` and `kortix-ai-prod` organizations. The current single organization is `kortix`. Two newly merged sidebar tests were also failing on `main`; this PR restores their intended full-width control and hover-only seam contracts so CI can complete green.

## What changed
- document `kortix` as the single Armor organization
- use explicit `--team kortix` for every pull, push, and removal example
- preserve production as a separate operational step, not an authorization boundary
- align the automation example with `DOTENV_ARMOR_TOKEN`
- restore the merged sidebar switcher layout and seam assertions

## Verification
- real Armor pulls succeeded for all eight API/web local, dev, staging, and prod profiles
- `dotenvx run --no-armor` decrypted all eight profiles without printing values
- focused sidebar tests: 15 passed, 0 failed
- all GitHub checks green, including full package unit tests, frontend build, QA, CodeQL, and secret scans
- preview backend health reports `environment=preview`, `version=pr-5974`
- `pnpm exec prettier --check ...`
- `git diff --check`

## Risk / rollback
Low. Documentation plus two token-level sidebar class corrections covered by source-contract tests. Revert these commits if the Armor organization or sidebar design contract changes.