### PR TITLE
fix(web): post-auth signups land in their project, never on /projects

### DIFF
--- a/apps/web/src/app/(auth)/auth/callback/route.ts
+++ b/apps/web/src/app/(auth)/auth/callback/route.ts
@@ -8,6 +8,8 @@ import {
 } from '@/lib/auth/return-url';
 import {
   LAST_PROJECT_COOKIE,
+  POST_AUTH_INTENT_COOKIE,
+  POST_AUTH_INTENT_MAX_AGE,
   PROJECT_LANDING_PATH,
   parseLastProjectForUser,
   projectPathFromId,
@@ -269,6 +271,17 @@ export async function GET(request: NextRequest) {
       redirectUrl.searchParams.set('auth_event', authEvent);
       redirectUrl.searchParams.set('auth_method', authMethod);
       const response = NextResponse.redirect(redirectUrl);
+
+      // Authentication just completed, and this redirect is about to land on
+      // the landing door with whatever referrer the magic link / IdP hop
+      // carried — usually a cross-origin one. The marker is what lets the door
+      // provision a first project anyway; without it a webmail signup is
+      // demoted to the projects list. See navigationMayCreateProject.
+      response.cookies.set(POST_AUTH_INTENT_COOKIE, '1', {
+        maxAge: POST_AUTH_INTENT_MAX_AGE,
+        path: '/',
+        sameSite: 'lax',
+      });
 
       // Clear stale legacy instance cookie so repo-first sessions do not inherit it after login.
       response.cookies.set(ACTIVE_INSTANCE_COOKIE, '', { maxAge: 0, path: '/' });

--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -32,6 +32,7 @@ import { useAuth } from '@/features/providers/auth-provider';
 import { invalidateTokenCache, setBootstrapAuthToken } from '@/lib/auth-token';
 import { buildMobileSessionHandoffUrl } from '@/lib/auth/mobile-handoff';
 import { sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
+import { markPostAuthIntent } from '@/lib/onboarding/post-auth-intent';
 import { isSessionExpired } from '@/lib/auth/session-expiry';
 import {
   type CredentialsMode,
@@ -236,6 +237,10 @@ function AuthCardForm({
       }
     }
 
+    // Client-side navigation keeps the referrer /auth itself loaded with —
+    // often a search engine — so the landing door cannot read intent from it.
+    // The marker is what proves "this user just signed in" to the door.
+    markPostAuthIntent();
     const dest = result?.redirectTo || returnUrl;
     router.push(dest);
     router.refresh();

--- a/apps/web/src/lib/onboarding/ensure-first-project.ts
+++ b/apps/web/src/lib/onboarding/ensure-first-project.ts
@@ -1,6 +1,7 @@
 import { type KortixProject, listProjectsForAccount, provisionProject } from '@kortix/sdk';
 
 import { isValidProjectId } from '@/lib/onboarding/landing-destination';
+import { hasPostAuthIntent } from '@/lib/onboarding/post-auth-intent';
 
 export type FirstProjectAutoCreateState = {
   activeAccountId: string | null;
@@ -63,9 +64,16 @@ export function clearAutoProjectSuppression(): void {
  * list — gate creation on this. Opening an EXISTING project stays allowed from
  * anywhere.
  *
- * A same-origin referrer covers the real entry points (`/auth/callback`, `/`,
- * in-app links). An EMPTY referrer covers a typed URL or a bookmark, which is
- * genuine user intent. A referrer naming another origin is what we refuse.
+ * Intent is proven by any ONE of:
+ *  - the post-auth marker — authentication completed moments ago on this
+ *    browser. This is what admits every real signup: a magic link opened from
+ *    webmail, an OAuth/SSO hop, and the `/auth` page's client-side redirect
+ *    all arrive with a CROSS-origin (or stale) `document.referrer`, and a
+ *    referrer-only version of this gate demoted exactly those users to the
+ *    projects list instead of their project.
+ *  - a same-origin referrer — `/`, in-app links.
+ *  - an EMPTY referrer — a typed URL or a bookmark.
+ * A referrer naming another origin, with no fresh sign-in, is what we refuse.
  *
  * This is defense in depth, not a complete control: an attacker can send
  * `referrerpolicy="no-referrer"` and be indistinguishable from a typed
@@ -76,6 +84,7 @@ export function clearAutoProjectSuppression(): void {
  */
 export function navigationMayCreateProject(): boolean {
   if (typeof document === 'undefined') return false;
+  if (hasPostAuthIntent()) return true;
   const referrer = document.referrer;
   if (!referrer) return true;
   try {

--- a/apps/web/src/lib/onboarding/landing-destination.ts
+++ b/apps/web/src/lib/onboarding/landing-destination.ts
@@ -15,6 +15,26 @@ export const PROJECT_LANDING_PATH = '/projects/start';
 /** Non-httpOnly so middleware can read it and the project page can set it. */
 export const LAST_PROJECT_COOKIE = 'kortix_last_project';
 
+/**
+ * Set at the moment authentication completes — by the `/auth/callback` route
+ * on its redirect response, and by the `/auth` page before its client-side
+ * redirect. It marks the navigation that follows as "the user just signed
+ * in", which is the strongest possible proof of intent the landing door can
+ * ask for before provisioning a first project.
+ *
+ * This exists because `document.referrer` cannot carry that proof: a magic
+ * link opened from Gmail arrives with a `https://mail.google.com/` referrer,
+ * an OAuth signup arrives from the IdP, and a client-side redirect keeps
+ * whatever referrer `/auth` itself was loaded with (often a search engine).
+ * All of those are cross-origin, so a referrer-only CSRF gate demoted exactly
+ * the users it must never demote — brand-new signups — to the projects list.
+ * A cross-site attacker can strip a referrer, but cannot set this cookie.
+ */
+export const POST_AUTH_INTENT_COOKIE = 'kortix_post_auth';
+
+/** Short-lived on purpose: it only has to outlive the post-auth redirect. */
+export const POST_AUTH_INTENT_MAX_AGE = 60 * 5;
+
 /** One year. The value is a project id, not a credential. */
 export const LAST_PROJECT_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
 

--- a/apps/web/src/lib/onboarding/post-auth-intent.test.ts
+++ b/apps/web/src/lib/onboarding/post-auth-intent.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { POST_AUTH_INTENT_COOKIE } from './landing-destination';
+import { navigationMayCreateProject } from './ensure-first-project';
+import { hasPostAuthIntent, markPostAuthIntent } from './post-auth-intent';
+
+/**
+ * The landing door's CSRF gate must admit every real signup.
+ *
+ * `document.referrer` is cross-origin on the flows that create most accounts:
+ * a magic link opened from webmail (https://mail.google.com/), an OAuth/SSO
+ * IdP hop, and the /auth page's client-side redirect (which keeps the referrer
+ * /auth was loaded with — often a search engine). A referrer-only gate demoted
+ * exactly those users from /projects/start to the projects list. The post-auth
+ * marker is the non-forgeable signal that admits them: only our own auth
+ * completion code can set the cookie; a cross-site link cannot.
+ */
+
+type MutableGlobals = { document?: unknown; window?: unknown };
+const g = globalThis as MutableGlobals;
+const originalDocument = g.document;
+const originalWindow = g.window;
+
+function stubBrowser({ referrer, cookie = '' }: { referrer: string; cookie?: string }) {
+  const state = { cookie };
+  g.document = {
+    referrer,
+    get cookie() {
+      return state.cookie;
+    },
+    set cookie(value: string) {
+      const pair = value.split(';')[0];
+      state.cookie = state.cookie ? `${state.cookie}; ${pair}` : pair;
+    },
+  };
+  g.window = { location: { origin: 'https://dev.kortix.com', protocol: 'https:' } };
+  return state;
+}
+
+afterEach(() => {
+  g.document = originalDocument;
+  g.window = originalWindow;
+});
+
+describe('navigationMayCreateProject', () => {
+  test('cross-origin referrer without the marker is refused', () => {
+    stubBrowser({ referrer: 'https://evil.example/' });
+    expect(navigationMayCreateProject()).toBe(false);
+  });
+
+  test('a webmail magic-link arrival provisions once the marker is set', () => {
+    stubBrowser({
+      referrer: 'https://mail.google.com/',
+      cookie: `${POST_AUTH_INTENT_COOKIE}=1`,
+    });
+    expect(navigationMayCreateProject()).toBe(true);
+  });
+
+  test('empty referrer (typed URL, bookmark) is genuine intent', () => {
+    stubBrowser({ referrer: '' });
+    expect(navigationMayCreateProject()).toBe(true);
+  });
+
+  test('same-origin referrer is genuine intent', () => {
+    stubBrowser({ referrer: 'https://dev.kortix.com/auth' });
+    expect(navigationMayCreateProject()).toBe(true);
+  });
+
+  test('no DOM (server render) never creates', () => {
+    g.document = undefined;
+    expect(navigationMayCreateProject()).toBe(false);
+  });
+});
+
+describe('post-auth intent marker', () => {
+  test('markPostAuthIntent writes the cookie hasPostAuthIntent reads', () => {
+    stubBrowser({ referrer: 'https://accounts.google.com/' });
+    expect(hasPostAuthIntent()).toBe(false);
+    expect(navigationMayCreateProject()).toBe(false);
+    markPostAuthIntent();
+    expect(hasPostAuthIntent()).toBe(true);
+    expect(navigationMayCreateProject()).toBe(true);
+  });
+
+  test('a cookie with any other value does not count', () => {
+    stubBrowser({
+      referrer: 'https://mail.google.com/',
+      cookie: `${POST_AUTH_INTENT_COOKIE}=evil`,
+    });
+    expect(hasPostAuthIntent()).toBe(false);
+    expect(navigationMayCreateProject()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/onboarding/post-auth-intent.ts
+++ b/apps/web/src/lib/onboarding/post-auth-intent.ts
@@ -1,0 +1,27 @@
+import {
+  POST_AUTH_INTENT_COOKIE,
+  POST_AUTH_INTENT_MAX_AGE,
+} from '@/lib/onboarding/landing-destination';
+
+/**
+ * Browser-side access to the post-auth intent marker.
+ *
+ * A cookie and not sessionStorage because the server-side `/auth/callback`
+ * route must be able to set it on its redirect response — magic-link and
+ * OAuth signups never execute client code before landing on the door. The
+ * value carries no identity and no token; it is a boolean with an expiry.
+ */
+export function markPostAuthIntent(): void {
+  if (typeof document === 'undefined') return;
+  const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie =
+    `${POST_AUTH_INTENT_COOKIE}=1` +
+    `; Path=/; Max-Age=${POST_AUTH_INTENT_MAX_AGE}; SameSite=Lax${secure}`;
+}
+
+export function hasPostAuthIntent(): boolean {
+  if (typeof document === 'undefined' || typeof document.cookie !== 'string') return false;
+  return document.cookie
+    .split('; ')
+    .some((entry) => entry === `${POST_AUTH_INTENT_COOKIE}=1`);
+}


### PR DESCRIPTION
## Problem

Fresh signups on dev.kortix.com land on the `/projects` list instead of inside their project. The default destination is a PROJECT; the list must never be a landing.

## Root cause

`navigationMayCreateProject()` (the CWE-352 gate in `ensure-first-project.ts`) only accepted a same-origin or empty `document.referrer`. But the flows that create most accounts arrive cross-origin:

- a magic link clicked in webmail arrives with `https://mail.google.com/` (HTTPS→HTTPS keeps the origin under `strict-origin-when-cross-origin`)
- OAuth/SSO arrives from the IdP hop
- the `/auth` page's client-side redirect keeps whatever referrer `/auth` was loaded with — often a search engine, because SPA navigations never update `document.referrer`

With the gate refusing `allowCreate`, `ensureFirstProject` returns null for a zero-project account and the landing door (`/projects/start`) falls back to `router.replace('/projects')`.

Local repro: signup via PKCE magic link with a forged `https://mail.google.com/` referrer → demoted to `/projects`. (A plain local repro passes, because HTTPS→HTTP strips the referrer — dev is HTTPS end to end.)

## Fix

Auth completion mints a 5-minute `kortix_post_auth=1` cookie (`SameSite=Lax`):

- `/auth/callback/route.ts` sets it on the redirect response (magic link, OAuth, SSO)
- `/auth/page.tsx` sets it in `establishSessionAndRedirect` (password + OTP-code flows)

`navigationMayCreateProject()` accepts the marker as proof of intent, in addition to the existing same-origin/empty-referrer checks. A cross-site attacker can strip a referrer but cannot set this cookie, so the gate still refuses cross-site provisioning links. Residual risk is unchanged: creation only fires for zero-project accounts, capped at 1 project on free tier.

## Verification

- `cd apps/web && bun test src/lib/onboarding/` — 44 pass, 0 fail (new: `post-auth-intent.test.ts`, 7 cases incl. the Gmail-referrer regression)
- `npx eslint` on all 6 touched files — clean; `tsc --noEmit` — no errors in touched files
- Live local stack, fresh user, real PKCE magic-link email, `initScript` forging `document.referrer = https://mail.google.com/`:
  - before: lands on `http://localhost:3000/projects`
  - after: lands on `http://localhost:3000/projects/fe1eead5-…` with `kortix_post_auth=1` and `kortix_last_project` set, project onboarding renders
