### PR TITLE
fix(sandbox): preserve capacity retry diagnostics

### DIFF
--- a/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  buildSandboxInitAttemptMetadata,
   buildSandboxInitFailureMetadata,
   buildSandboxInitSuccessMetadata,
   deriveSandboxHealthStatus,
@@ -21,6 +22,16 @@ describe('sandbox init state helpers', () => {
     expect(meta.initStatus).toBe('failed');
     expect(meta.lastInitError).toBe('boom');
     expect(meta.errorMessage).toBe('Initialization failed after 3 attempts. Reinitialize to retry.');
+  });
+
+  test('records the active capacity retry limit in retry metadata', () => {
+    const attempt = buildSandboxInitAttemptMetadata({}, 18, 'retrying', null, null, 30);
+    const failure = buildSandboxInitFailureMetadata({}, new Error('rate limit'), 18, true, 30);
+    const success = buildSandboxInitSuccessMetadata({}, {}, 18, 30);
+
+    expect(attempt.initMaxAttempts).toBe(30);
+    expect(failure.initMaxAttempts).toBe(30);
+    expect(success.initMaxAttempts).toBe(30);
   });
 
   test('marks successful initialization as ready', () => {

--- a/apps/api/src/platform/services/sandbox-init-state.ts
+++ b/apps/api/src/platform/services/sandbox-init-state.ts
@@ -110,6 +110,7 @@ export function buildSandboxInitAttemptMetadata(
   status: Extract<SandboxInitStatus, 'provisioning' | 'retrying'>,
   provisioningStage?: string | null,
   provisioningMessage?: string | null,
+  maxAttempts = SANDBOX_INIT_MAX_ATTEMPTS,
 ): Record<string, unknown> {
   const now = new Date().toISOString();
   const next = stripSandboxInitFailureMetadata(metadata);
@@ -117,7 +118,7 @@ export function buildSandboxInitAttemptMetadata(
     ...next,
     initStatus: status,
     initAttempts: attempt,
-    initMaxAttempts: SANDBOX_INIT_MAX_ATTEMPTS,
+    initMaxAttempts: maxAttempts,
     lastInitError: null,
     initUpdatedAt: now,
     initStartedAt: typeof next.initStartedAt === 'string' ? next.initStartedAt : now,
@@ -131,6 +132,7 @@ export function buildSandboxInitSuccessMetadata(
   metadata: Record<string, unknown> | null | undefined,
   resultMetadata: Record<string, unknown>,
   attempt: number,
+  maxAttempts = SANDBOX_INIT_MAX_ATTEMPTS,
 ): Record<string, unknown> {
   const now = new Date().toISOString();
   return {
@@ -138,7 +140,7 @@ export function buildSandboxInitSuccessMetadata(
     ...resultMetadata,
     initStatus: 'ready' as SandboxInitStatus,
     initAttempts: attempt,
-    initMaxAttempts: SANDBOX_INIT_MAX_ATTEMPTS,
+    initMaxAttempts: maxAttempts,
     lastInitError: null,
     initSucceededAt: now,
     initUpdatedAt: now,
@@ -151,6 +153,7 @@ export function buildSandboxInitFailureMetadata(
   error: unknown,
   attempt: number,
   willRetry: boolean,
+  maxAttempts = SANDBOX_INIT_MAX_ATTEMPTS,
 ): Record<string, unknown> {
   const message = errorMessage(error);
   const now = new Date().toISOString();
@@ -160,7 +163,7 @@ export function buildSandboxInitFailureMetadata(
       ...next,
       initStatus: 'retrying' as SandboxInitStatus,
       initAttempts: attempt,
-      initMaxAttempts: SANDBOX_INIT_MAX_ATTEMPTS,
+      initMaxAttempts: maxAttempts,
       lastInitError: message,
       initFailedAt: now,
       initUpdatedAt: now,
@@ -172,7 +175,7 @@ export function buildSandboxInitFailureMetadata(
     ...next,
     initStatus: 'failed' as SandboxInitStatus,
     initAttempts: attempt,
-    initMaxAttempts: SANDBOX_INIT_MAX_ATTEMPTS,
+    initMaxAttempts: maxAttempts,
     lastInitError: message,
     initFailedAt: now,
     initUpdatedAt: now,
@@ -187,8 +190,13 @@ export async function retrySandboxProvisionCreate(
   provider: SandboxProvider,
   createOpts: CreateSandboxOpts,
   hooks: {
-    onAttemptStart?: (attempt: number) => Promise<void> | void;
-    onAttemptFailure?: (attempt: number, error: unknown, willRetry: boolean) => Promise<void> | void;
+    onAttemptStart?: (attempt: number, maxAttempts: number) => Promise<void> | void;
+    onAttemptFailure?: (
+      attempt: number,
+      error: unknown,
+      willRetry: boolean,
+      maxAttempts: number,
+    ) => Promise<void> | void;
   } = {},
   // FIX-A: how a single attempt boots. Defaults to the provider's name-based
   // create(); the boot path passes a createFromExternalId-backed fn to boot the
@@ -199,8 +207,9 @@ export async function retrySandboxProvisionCreate(
   let lastError: unknown;
   // Outer bound is the longest patience-window we'd extend for any retry class.
   const HARD_CAP = Math.max(SNAPSHOT_BUILDING_MAX_ATTEMPTS, PROVIDER_CAPACITY_MAX_ATTEMPTS);
+  let currentMaxAttempts = SANDBOX_INIT_MAX_ATTEMPTS;
   for (let attempt = 1; attempt <= HARD_CAP; attempt++) {
-    await hooks.onAttemptStart?.(attempt);
+    await hooks.onAttemptStart?.(attempt, currentMaxAttempts);
     try {
       const result = await createFn(createOpts);
       return { result, attempts: attempt };
@@ -214,7 +223,7 @@ export async function retrySandboxProvisionCreate(
       // likewise non-retryable here — fail fast so the boot path falls back to a
       // name-boot immediately, rather than burning retries on an id that is gone.
       if (error instanceof WarmRuntimeUnavailableError || error instanceof SandboxTemplateNotFoundError) {
-        await hooks.onAttemptFailure?.(attempt, error, false);
+        await hooks.onAttemptFailure?.(attempt, error, false, currentMaxAttempts);
         throw error;
       }
       const snapshotStillBuilding = isSnapshotStillBuilding(error);
@@ -224,8 +233,9 @@ export async function retrySandboxProvisionCreate(
         : capacityLimited
           ? PROVIDER_CAPACITY_MAX_ATTEMPTS
           : SANDBOX_INIT_MAX_ATTEMPTS;
+      currentMaxAttempts = maxAttempts;
       const willRetry = attempt < maxAttempts;
-      await hooks.onAttemptFailure?.(attempt, error, willRetry);
+      await hooks.onAttemptFailure?.(attempt, error, willRetry, maxAttempts);
       if (!willRetry) throw error;
       // Generic retries use exponential backoff from RETRY_DELAY_BASE_MS,
       // capped at RETRY_DELAY_MAX_MS. Snapshot-building and provider-capacity

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -514,6 +514,8 @@ export async function provisionSessionSandbox(opts: {
       );
     }
     let idBootDisabled = false;
+    let lastProvisionAttempt = SANDBOX_INIT_MAX_ATTEMPTS;
+    let lastProvisionMaxAttempts = SANDBOX_INIT_MAX_ATTEMPTS;
     provisioning: while (true) {
     try {
       const branch = opts.baseRef || opts.gitProject.defaultBranch;
@@ -576,7 +578,9 @@ export async function provisionSessionSandbox(opts: {
       let attempts: number;
       try {
       ({ result, attempts } = await retrySandboxProvisionCreate(provider, providerCreateInput, {
-        onAttemptStart: async (attempt) => {
+        onAttemptStart: async (attempt, maxAttempts) => {
+          lastProvisionAttempt = attempt;
+          lastProvisionMaxAttempts = maxAttempts;
           await db
             .update(sessionSandboxes)
             .set({
@@ -585,13 +589,16 @@ export async function provisionSessionSandbox(opts: {
                 attempt,
                 attempt === 1 ? 'provisioning' : 'retrying',
                 firstStage?.id,
-                attempt === 1 ? firstStage?.message : `Retrying initialization (${attempt}/${SANDBOX_INIT_MAX_ATTEMPTS})…`,
+                attempt === 1 ? firstStage?.message : `Retrying initialization (${attempt}/${maxAttempts})…`,
+                maxAttempts,
               ),
               updatedAt: new Date(),
             })
             .where(eq(sessionSandboxes.sandboxId, sandbox.sandboxId));
         },
-        onAttemptFailure: async (attempt, error, willRetry) => {
+        onAttemptFailure: async (attempt, error, willRetry, maxAttempts) => {
+          lastProvisionAttempt = attempt;
+          lastProvisionMaxAttempts = maxAttempts;
           await db
             .update(sessionSandboxes)
             .set({
@@ -601,6 +608,7 @@ export async function provisionSessionSandbox(opts: {
                 error,
                 attempt,
                 willRetry,
+                maxAttempts,
               ),
               updatedAt: new Date(),
             })
@@ -695,6 +703,7 @@ export async function provisionSessionSandbox(opts: {
                   providerExternalId: result.externalId,
                 },
                 attempts,
+                lastProvisionMaxAttempts,
               ),
               stoppedDuringProvisioning: true,
               stoppedAt: new Date().toISOString(),
@@ -767,6 +776,7 @@ export async function provisionSessionSandbox(opts: {
             },
           },
           attempts,
+          lastProvisionMaxAttempts,
         ),
         config: { serviceKey: sandboxKey.secretKey, llmGatewayEnabled: !!gatewayLlmKey },
         lastUsedAt: new Date(),
@@ -966,8 +976,9 @@ export async function provisionSessionSandbox(opts: {
               ...buildSandboxInitFailureMetadata(
                 sandbox.metadata as Record<string, unknown> | null,
                 bgErr,
-                SANDBOX_INIT_MAX_ATTEMPTS,
+                lastProvisionAttempt,
                 false,
+                lastProvisionMaxAttempts,
               ),
               errorMessage: userMessage,
               lastProvisioningError: bgMessage.slice(0, 500),

--- a/apps/cli/src/self-host/__tests__/secrets.test.ts
+++ b/apps/cli/src/self-host/__tests__/secrets.test.ts
@@ -69,6 +69,10 @@ describe('secrets-registry pure helpers', () => {
     expect(servicesForKeys([])).toEqual([]);
   });
 
+  test('servicesForKeys restarts the frontend when the warm-session flag changes', () => {
+    expect(servicesForKeys(['KORTIX_PUBLIC_WARM_PROJECT_SESSIONS_ENABLED'])).toEqual(['frontend']);
+  });
+
   test('ROTATABLE_GENERATED_KEYS excludes the internal Supabase-infra encryption keys', () => {
     for (const infraKey of ['SECRET_KEY_BASE', 'REALTIME_DB_ENC_KEY', 'VAULT_ENC_KEY', 'PG_META_CRYPTO_KEY']) {
       expect(ROTATABLE_GENERATED_KEYS).not.toContain(infraKey);

--- a/apps/cli/src/self-host/secrets-registry.ts
+++ b/apps/cli/src/self-host/secrets-registry.ts
@@ -260,6 +260,9 @@ export const KEY_SERVICE_MAP: Record<string, readonly string[]> = {
   PLATINUM_TEMPLATE: ['kortix-api'],
   PLATINUM_WEBHOOK_SECRET: ['kortix-api'],
 
+  // Frontend runtime configuration
+  KORTIX_PUBLIC_WARM_PROJECT_SESSIONS_ENABLED: ['frontend'],
+
   // Managed git
   MANAGED_GIT_GITHUB_OWNER: ['kortix-api'],
   MANAGED_GIT_GITHUB_TOKEN: ['kortix-api'],


### PR DESCRIPTION
## Problem

Live Essentia capacity testing found two defects.

- The self-host CLI regenerated the warm-session frontend variable but restarted only the API.
- Capacity retries stored initMaxAttempts=3 while the active retry window was 30 attempts.

## Changes

- Restart the frontend when KORTIX_PUBLIC_WARM_PROJECT_SESSIONS_ENABLED changes.
- Pass the active retry limit through attempt, failure, success, and terminal metadata.
- Keep the terminal attempt count after all capacity retries.

## Verification

- pnpm --filter @kortix/cli test: 611 passed.
- pnpm --filter @kortix/cli typecheck: passed.
- Focused API sandbox tests: 15 passed.
- API typecheck: passed.
- Live Essentia test: seven sessions started.
- Live Essentia test: two sessions stored failureCategory=provider-capacity at the eight-sandbox limit.
