### PR TITLE
fix(e2b): bound permanent sandbox removal

### DIFF
--- a/apps/api/src/platform/providers/e2b.test.ts
+++ b/apps/api/src/platform/providers/e2b.test.ts
@@ -21,6 +21,10 @@ let listed: Array<{ sandboxId: string; startedAt: Date | null }> = [];
 let listOpts: Record<string, unknown> | undefined;
 let connectFactory: (sandboxId: string) => FakeSandbox | Promise<FakeSandbox> = (sandboxId) => fakeSandbox(sandboxId);
 let createFactory: () => FakeSandbox = () => fakeSandbox('sb-created');
+let killFactory: (sandboxId: string) => boolean | Promise<boolean> = (sandboxId) => {
+  killed.push(sandboxId);
+  return true;
+};
 
 class FakeSandboxNotFoundError extends Error {}
 
@@ -88,8 +92,7 @@ class FakeSandboxApi {
   }
 
   static async kill(sandboxId: string) {
-    killed.push(sandboxId);
-    return true;
+    return killFactory(sandboxId);
   }
 
   static async getInfo() {
@@ -136,6 +139,10 @@ beforeEach(() => {
   listOpts = undefined;
   connectFactory = (sandboxId) => fakeSandbox(sandboxId);
   createFactory = () => fakeSandbox('sb-created');
+  killFactory = (sandboxId) => {
+    killed.push(sandboxId);
+    return true;
+  };
 });
 
 describe('E2B provider admission and registry', () => {
@@ -339,8 +346,25 @@ describe('E2B provider lifecycle', () => {
     const provider = new E2BProvider();
     infoState = 'missing';
     expect(await provider.getStatus('sb-missing')).toBe('removed');
+
     await provider.remove('sb-remove');
     expect(killed).toEqual(['sb-remove']);
+
+    killFactory = () => {
+      throw new FakeSandboxNotFoundError('sandbox not found');
+    };
+    await expect(provider.remove('sb-remove')).resolves.toBeUndefined();
+  });
+
+  test('permanent removal rejects within its outer timeout when the E2B SDK never settles', async () => {
+    killFactory = () => new Promise<boolean>(() => {});
+    const provider = new E2BProvider(25);
+
+    const startedAt = performance.now();
+    await expect(provider.remove('sb-hung')).rejects.toThrow(
+      'E2B kill(sb-hung) timed out after 25ms',
+    );
+    expect(performance.now() - startedAt).toBeLessThan(500);
   });
 
   test('the orphan reaper list is scoped to Kortix and the current environment', async () => {

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -2,6 +2,7 @@
 
 import { Sandbox, SandboxNotFoundError, type Sandbox as E2BSandbox } from 'e2b';
 import { config, SANDBOX_VERSION } from '../../config';
+import { configuredTimeoutMs, withTimeout } from '../../shared/with-timeout';
 import { serviceKeyForExternalId } from '../service-key';
 import { sandboxFrontendBaseUrl } from '../sandbox-frontend-url';
 import type {
@@ -31,6 +32,13 @@ const KORTIX_HEALTH_WAIT =
   'sleep 1; done; exit 1';
 const MANAGED_METADATA = 'kortix_managed';
 const ENV_METADATA = 'kortix_env';
+// The E2B SDK accepts requestTimeoutMs, but a live kill call remained pending
+// after that budget. This outer timer bounds all permanent-removal call sites.
+const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs(
+  'KORTIX_E2B_REMOVE_TIMEOUT_MS',
+  25_000,
+  1_000,
+);
 
 function apiOpts() {
   return { apiKey: config.E2B_API_KEY, requestTimeoutMs: 20_000 } as const;
@@ -138,6 +146,8 @@ async function ensureKortixEntrypoint(
 export class E2BProvider implements SandboxProvider {
   readonly name: ProviderName = 'e2b';
   readonly requiresPublicCallback = true;
+
+  constructor(private readonly removeTimeoutMs = E2B_REMOVE_TIMEOUT_MS) {}
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
@@ -268,7 +278,11 @@ export class E2BProvider implements SandboxProvider {
   async remove(externalId: string): Promise<void> {
     connectedSandboxes.delete(externalId);
     try {
-      await Sandbox.kill(externalId, apiOpts());
+      await withTimeout(
+        Sandbox.kill(externalId, apiOpts()),
+        this.removeTimeoutMs,
+        `E2B kill(${externalId})`,
+      );
     } catch (error) {
       if (!isMissingSandboxError(error)) throw error;
     }


### PR DESCRIPTION
## Problem

An E2B `Sandbox.kill()` call remained pending after the SDK `requestTimeoutMs` value. Awaited cleanup paths could remain pending without a wall-clock bound.

## Change

- Add a 25-second outer timeout to permanent E2B sandbox removal.
- Keep removal idempotent when E2B reports a missing sandbox.
- Add a regression test for a never-settling E2B SDK promise.

## Verification

- `cd apps/api && bun test src/platform/providers/e2b.test.ts src/shared/with-timeout.test.ts` — 28 pass, 0 fail.
- `cd apps/api && bun run typecheck` — exit 0.
- `git diff --check` — exit 0.