### PR TITLE
fix(web): restore sidebar switcher width

### DIFF
--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar-header.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar-header.test.ts
@@ -34,6 +34,7 @@ describe('project sidebar header', () => {
   // the project name and search that looked clickable and was not.
   test('the control takes the row, so there is no dead strip beside it', () => {
     expect(header).toContain('className="min-w-0 flex-1"');
+    expect(header).not.toContain('max-w-full');
     expect(header).not.toContain('w-fit');
   });
 

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -194,7 +194,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
             name still opens the switcher, and the whole row between them is
             live instead of inert. */}
         <div className="flex w-full items-center gap-1">
-          <ProjectSwitcher variant="sidebar" className="max-w-full min-w-0" />
+          <ProjectSwitcher variant="sidebar" className="min-w-0 flex-1" />
           <div className="ml-auto flex shrink-0 items-center gap-0.5">
             {/* Search is the palette's only pointer-reachable entry point —
                 ⌘K is otherwise the whole discovery story. Renders on mobile


### PR DESCRIPTION
## Problem

Commit `70346426d` changed the sidebar switcher class from `flex-1` to `max-w-full`. The existing project-sidebar test then failed on `main`. The new class also restores the inert strip beside the switcher.

## Change

Restore `min-w-0 flex-1` on the sidebar `ProjectSwitcher`.

## Verification

- `cd apps/web && bun test src/features/workspace/project-sidebar/project-sidebar-header.test.ts` — 7 pass, 0 fail.
- `cd apps/web && npx eslint src/features/workspace/project-sidebar/project-sidebar.tsx src/features/workspace/project-sidebar/project-sidebar-header.test.ts` — exit 0.
- `git diff --check` — exit 0.