### PR TITLE
fix(self-host): make API memory ceiling configurable

### DIFF
--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -354,13 +354,17 @@ describe('full self-host Docker distribution', () => {
     const document = parse(renderFullDockerCompose('kortix-default', { domainConfigured: true, tunnelConfigured: true })) as {
       services: Record<string, { mem_limit?: string; mem_reservation?: string; oom_score_adj?: number }>;
     };
-    const toMb = (value: string) => Number(value.replace(/m$/, ''));
+    const toMb = (value: string) => {
+      const defaultValue = value.match(/:-([0-9]+m)}$/)?.[1] ?? value;
+      return Number(defaultValue.replace(/m$/, ''));
+    };
     for (const [name, service] of Object.entries(document.services)) {
       expect(service.mem_limit, name).toBeDefined();
       expect(service.mem_reservation, name).toBeDefined();
     }
     const db = document.services['supabase-db'];
     expect(db?.oom_score_adj).toBeLessThan(0);
+    expect(document.services['kortix-api']?.mem_limit).toBe('${KORTIX_API_MEMORY_LIMIT:-640m}');
     const analytics = document.services['supabase-analytics'];
     const vector = document.services['supabase-vector'];
     expect(analytics?.oom_score_adj).toBeGreaterThan(0);

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -451,7 +451,7 @@ interface MemSpec {
 
 const MEM_LIMITS: Readonly<Record<string, MemSpec>> = {
   'supabase-db': { limit: '1280m', reservation: '512m', oomScoreAdj: -900 },
-  'kortix-api': { limit: '640m', reservation: '256m' },
+  'kortix-api': { limit: '${KORTIX_API_MEMORY_LIMIT:-640m}', reservation: '256m' },
   'llm-gateway': { limit: '512m', reservation: '128m' },
   frontend: { limit: '512m', reservation: '128m' },
   'kortix-migrate': { limit: '512m', reservation: '128m' },

--- a/apps/web/content/docs/host/index.mdx
+++ b/apps/web/content/docs/host/index.mdx
@@ -95,6 +95,16 @@ kortix self-host env set KORTIX_PUBLIC_WARM_PROJECT_SESSIONS_ENABLED=true
 
 The setting changes only the project index. A prompt still starts a session.
 
+Each API container has a 640 MiB memory limit by default.
+Keep this default on an 8 GiB host.
+Use a 1 GiB limit on a 16 GiB host when API traffic reaches the default limit:
+
+```sh
+kortix self-host env set KORTIX_API_MEMORY_LIMIT=1024m
+```
+
+Confirm the applied limit with `docker stats --no-stream`.
+
 ## Updates
 
 Every instance updates itself automatically. Pin an exact version instead:


### PR DESCRIPTION
## Problem

Essentia runs on a 16 GiB host.
Both API replicas had a fixed 640 MiB container limit.
Live E2B lifecycle tests caused two cgroup OOM kills at 607 MiB and 652 MiB RSS.
The host had 10 GiB available during the test.

## Change

- Keep the 640 MiB default for 8 GiB self-host systems.
- Add the Compose variable `KORTIX_API_MEMORY_LIMIT`.
- Document `1024m` for 16 GiB hosts that reach the default limit.
- Keep the total default memory ceiling below 8 GiB.

## Verification

- `pnpm --filter @kortix/cli test`
  - `611 pass, 0 fail`
- `pnpm --filter @kortix/cli typecheck`
  - exit `0`
- Essentia live override:
  - both API replicas report `memory=1073741824`
  - `https://api.essentia.kortix.cloud/health` returns HTTP `200`
  - live commit remains `b530dbdb79ffbc2743cff335e034828585522934`
