### PR TITLE
fix(llm-gateway): surface real upstream errors instead of generic Bad Gateway

### DIFF
--- a/packages/llm-gateway/src/http/parse-upstream-error.test.ts
+++ b/packages/llm-gateway/src/http/parse-upstream-error.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  extractUpstreamErrorDetail,
+  isGenericStatusText,
+  parseUpstreamErrorBody,
+} from './parse-upstream-error';
+
+describe('extractUpstreamErrorDetail', () => {
+  test('OpenAI-compatible {error:{message,code}} → real message + code', () => {
+    expect(
+      extractUpstreamErrorDetail({
+        error: { message: 'context length exceeded from messages', code: 'context_length_exceeded' },
+      }),
+    ).toEqual({ message: 'context length exceeded from messages', code: 'context_length_exceeded' });
+  });
+
+  test('OpenAI-compatible with type but no code → code falls back to type', () => {
+    expect(
+      extractUpstreamErrorDetail({
+        error: { message: 'Overloaded', type: 'overloaded_error' },
+      }),
+    ).toEqual({ message: 'Overloaded', code: 'overloaded_error' });
+  });
+
+  test('Anthropic shape {type:"error",error:{type,message}} → real message + type as code', () => {
+    expect(
+      extractUpstreamErrorDetail({
+        type: 'error',
+        error: { type: 'overloaded_error', message: 'Overloaded' },
+      }),
+    ).toEqual({ message: 'Overloaded', code: 'overloaded_error' });
+  });
+
+  test('top-level {message, code} → real message + code', () => {
+    expect(extractUpstreamErrorDetail({ message: 'rate limited', code: 429 })).toEqual({
+      message: 'rate limited',
+      code: 429,
+    });
+  });
+
+  test('numeric code is preserved', () => {
+    expect(
+      extractUpstreamErrorDetail({ error: { message: 'nope', code: 400 } }),
+    ).toEqual({ message: 'nope', code: 400 });
+  });
+
+  test('empty message inside error object → falls through', () => {
+    expect(extractUpstreamErrorDetail({ error: { message: '' } })).toBeNull();
+  });
+
+  test('non-object / null → null', () => {
+    expect(extractUpstreamErrorDetail(null)).toBeNull();
+    expect(extractUpstreamErrorDetail('Bad Request')).toBeNull();
+    expect(extractUpstreamErrorDetail(undefined)).toBeNull();
+  });
+});
+
+describe('parseUpstreamErrorBody', () => {
+  test('JSON OpenAI-shaped body → real message + code', () => {
+    expect(
+      parseUpstreamErrorBody(
+        '{"error":{"message":"context length exceeded from messages","code":"context_length_exceeded"}}',
+      ),
+    ).toEqual({ message: 'context length exceeded from messages', code: 'context_length_exceeded' });
+  });
+
+  test('non-JSON body (HTML/plain) → trimmed raw body, bounded to 2000 chars', () => {
+    const long = '<html>' + 'x'.repeat(3000) + '</html>';
+    const out = parseUpstreamErrorBody(long);
+    expect(out.message.endsWith('…')).toBe(true);
+    expect(out.message.length).toBeLessThanOrEqual(2001);
+    expect(out.code).toBeUndefined();
+  });
+
+  test('empty body → fallback', () => {
+    expect(parseUpstreamErrorBody('', 'Bad Request')).toEqual({ message: 'Bad Request' });
+    expect(parseUpstreamErrorBody('   ')).toEqual({ message: 'Upstream request failed' });
+  });
+
+  test('JSON without an error/message shape → raw body (bounded)', () => {
+    expect(parseUpstreamErrorBody('{"foo":1}')).toEqual({ message: '{"foo":1}' });
+  });
+});
+
+describe('isGenericStatusText', () => {
+  test('recognizes common HTTP status texts the AI SDK falls back to', () => {
+    expect(isGenericStatusText('Bad Request')).toBe(true);
+    expect(isGenericStatusText('bad request')).toBe(true);
+    expect(isGenericStatusText('Internal Server Error')).toBe(true);
+    expect(isGenericStatusText('Bad Gateway')).toBe(true);
+    expect(isGenericStatusText('  Forbidden  ')).toBe(true);
+  });
+
+  test('a real upstream message is NOT treated as generic', () => {
+    expect(isGenericStatusText('context length exceeded from messages')).toBe(false);
+    expect(isGenericStatusText('Incorrect API key provided')).toBe(false);
+    expect(isGenericStatusText('Bad Request: missing field')).toBe(false);
+    expect(isGenericStatusText('')).toBe(false);
+    expect(isGenericStatusText(undefined)).toBe(false);
+  });
+});

--- a/packages/llm-gateway/src/http/parse-upstream-error.ts
+++ b/packages/llm-gateway/src/http/parse-upstream-error.ts
@@ -1,0 +1,126 @@
+// Shared extraction of the REAL human-readable message + code from an upstream
+// error body, used by BOTH the non-streaming failover path (parseUpstreamBody
+// there already inlined a simpler version of this) and the streaming SSE path
+// (transports/ai-sdk/sse.ts), so an upstream's actual rejection reason — e.g.
+// "context length exceeded from messages" — reaches the caller instead of being
+// buried under a generic HTTP status text like "Bad Request".
+//
+// Why this exists: the AI SDK (`@ai-sdk/provider-utils`'s
+// `createJsonErrorResponseHandler`) wraps a non-2xx upstream response in an
+// `APICallError` whose `.message` is the upstream's `error.message` ONLY when
+// the body parses against the provider's error schema; if it doesn't (a
+// non-OpenAI-shaped error, an HTML error page, a plain string, ...) the
+// `.message` falls back to `response.statusText` ("Bad Request", "Internal
+// Server Error", ...) — generic and useless. The actionable text then lives
+// ONLY in `.responseBody` (raw) / `.data` (parsed when the schema matched).
+// Without mining those, the gateway forwards the generic message and (for the
+// streaming path) classifies it as a blanket 502 "Bad Gateway" — the live
+// defect this module fixes (2026-08-01: upstream 400 surfaced as "Bad
+// Gateway" instead of "context length exceeded from messages").
+
+/** Result of mining an upstream error body for the real message + code. */
+export interface UpstreamErrorDetail {
+  /** The most specific human-readable message we could extract. */
+  message: string;
+  /** The upstream's own error code/type if one is present (string or number). */
+  code?: string | number;
+}
+
+/**
+ * Mine a PARSED upstream error object (the shape `{error:{message,code,type,
+ * param}}` OpenAI-compatible upstreams use, the Anthropic shape
+ * `{type:"error",error:{type,message}}`, or a top-level `{message,code}`) for
+ * the real message + code. Returns `{message}` with `code` only when a real
+ * one is present — never throws.
+ */
+export function extractUpstreamErrorDetail(parsed: unknown): UpstreamErrorDetail | null {
+  if (!parsed || typeof parsed !== 'object') return null;
+  const root = parsed as Record<string, unknown>;
+
+  // OpenAI-compatible: `{error:{message,type,param,code}}`.
+  const nestedError = root.error;
+  if (nestedError && typeof nestedError === 'object') {
+    const err = nestedError as Record<string, unknown>;
+    const message = typeof err.message === 'string' ? err.message : undefined;
+    if (message && message.length > 0) {
+      const code =
+        typeof err.code === 'string' || typeof err.code === 'number'
+          ? err.code
+          : typeof err.type === 'string' && err.type.length > 0
+            ? err.type
+            : undefined;
+      return { message, ...(code !== undefined ? { code } : {}) };
+    }
+  }
+
+  // Top-level `{message, code}` / `{message, type}`.
+  const message = typeof root.message === 'string' ? root.message : undefined;
+  if (message && message.length > 0) {
+    const code =
+      typeof root.code === 'string' || typeof root.code === 'number'
+        ? root.code
+        : typeof root.type === 'string' && root.type.length > 0
+          ? root.type
+          : undefined;
+    return { message, ...(code !== undefined ? { code } : {}) };
+  }
+
+  return null;
+}
+
+/**
+ * Parse a raw upstream response BODY string for the real message + code.
+ * Mirrors `extractUpstreamErrorDetail` over the JSON-parsed body; falls back to
+ * the raw body text itself only when it is non-empty (an HTML/plain error page
+ * is still more useful than a generic status text), and to `fallback` when the
+ * body is empty. Never throws.
+ */
+export function parseUpstreamErrorBody(body: string, fallback = 'Upstream request failed'): UpstreamErrorDetail {
+  if (!body || !body.trim()) return { message: fallback };
+  try {
+    const parsed = JSON.parse(body);
+    const detail = extractUpstreamErrorDetail(parsed);
+    if (detail) return detail;
+  } catch {
+    // Not JSON — the raw body (an HTML error page, a plain string) is the most
+    // specific message we have; trim a potentially huge body so it never blows
+    // up a client-facing error.
+    return { message: body.length > 2000 ? `${body.slice(0, 2000)}…` : body };
+  }
+  return { message: body.length > 2000 ? `${body.slice(0, 2000)}…` : body };
+}
+
+/**
+ * The HTTP status text the AI SDK falls back to when an upstream body fails its
+ * error-schema parse — these are the generic messages that should be REPLACED
+ * by a real message mined from the body/data whenever one is available. Keened
+ * lowercase + trimmed for case-insensitive `startsWith` matching, and bounded
+ * to short phrases so a genuine upstream message that happens to start with
+ * "bad request:" (with a colon) is NOT mistaken for a status text.
+ */
+const GENERIC_STATUS_TEXTS = new Set([
+  'bad request',
+  'forbidden',
+  'unauthorized',
+  'not found',
+  'internal server error',
+  'bad gateway',
+  'service unavailable',
+  'gateway timeout',
+  'request timeout',
+  'too many requests',
+  'conflict',
+  'unprocessable entity',
+  'payment required',
+]);
+
+/**
+ * True when `message` is a generic HTTP status text the AI SDK uses as a
+ * last-resort `.message` (e.g. "Bad Request") — i.e. NOT the upstream's real
+ * rejection reason. Used to decide whether to replace it with a message mined
+ * from `responseBody`/`data`.
+ */
+export function isGenericStatusText(message: string | undefined | null): boolean {
+  if (!message) return false;
+  return GENERIC_STATUS_TEXTS.has(message.trim().toLowerCase());
+}

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -7,6 +7,7 @@ import type {
 } from '../domain';
 import { CircuitOpenError, ClientAbortError, UpstreamHttpError } from '../errors';
 import { type FetchImpl, callUpstream } from '../http';
+import { parseUpstreamErrorBody } from '../http/parse-upstream-error';
 import type { CircuitBreaker } from '../resilience';
 import { gatewayErrorBody } from './error-response';
 import { applyGenerationDefaults } from './generation-defaults';
@@ -28,33 +29,14 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-function parseUpstreamBody(body: string): { message: string; code?: string } {
-  if (!body) return { message: 'Upstream request failed' };
-  try {
-    const parsed = JSON.parse(body) as Record<string, unknown>;
-    const nested = parsed.error;
-    if (typeof nested === 'string') {
-      return { message: nested, code: typeof parsed.code === 'string' ? parsed.code : undefined };
-    }
-    if (nested && typeof nested === 'object') {
-      const error = nested as Record<string, unknown>;
-      return {
-        message: typeof error.message === 'string' ? error.message : body,
-        code:
-          typeof error.code === 'string'
-            ? error.code
-            : typeof error.type === 'string'
-              ? error.type
-              : undefined,
-      };
-    }
-    return {
-      message: typeof parsed.message === 'string' ? parsed.message : body,
-      code: typeof parsed.code === 'string' ? parsed.code : undefined,
-    };
-  } catch {
-    return { message: body };
-  }
+// Mines the REAL human-readable message + code from an upstream error's
+// response body (the raw `UpstreamHttpError.body` the AI SDK populates with
+// `responseBody`). Delegates to the shared `parseUpstreamErrorBody` so the
+// non-streaming and streaming paths surface the same message for the same
+// upstream failure — e.g. "context length exceeded from messages" instead of a
+// generic "Bad Request"/"Bad Gateway" (2026-08-01 defect).
+function parseUpstreamBody(body: string): { message: string; code?: string | number } {
+  return parseUpstreamErrorBody(body);
 }
 
 function suggestionFor(status: number): string {

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -1509,6 +1509,49 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     expect(res.status).toBe(502);
   });
 
+  // Defect (2026-08-01, live-reported in Slack): an upstream 400 "context
+  // length exceeded from messages" surfaced to the user as a generic "Bad
+  // Gateway" instead of the real error + real status. Root cause was in
+  // transports/ai-sdk/sse.ts: when the AI SDK wrapped a non-2xx upstream
+  // response in an APICallError whose `.message` was the generic HTTP status
+  // text (the upstream's body failed the provider's error-schema parse), the
+  // streaming adapter emitted that generic message as the client-facing
+  // `message` and carried the real message only in `detail` — and a numeric
+  // status code reached statusForErrorFrame as a STRING or undefined, so it
+  // fell through to a blanket 502. Fixed in sse.ts (mines the real message +
+  // numeric status from responseBody/data); this test pins the END-TO-END
+  // client-facing contract the fix produces: a numeric 4xx code on the error
+  // frame surfaces as that status with the real message, NOT a 502 "Bad
+  // Gateway". This is the post-fix shape the ai-sdk transport now emits.
+  const contextLengthSse =
+    'data: {"error":{"message":"context length exceeded from messages","code":400}}\n\n' +
+    "data: [DONE]\n\n";
+
+  test("streaming: a numeric 4xx error-frame code surfaces as that status with the real message — not a blanket 502 Bad Gateway", async () => {
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    const fetchImpl: FetchImpl = async () => sseResponse(contextLengthSse);
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true,"messages":[{"role":"user","content":"hi"}]}',
+    });
+
+    // 400, the upstream's real status — NOT a generic 502 "Bad Gateway".
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("upstream_error");
+    // The REAL upstream message reaches the caller, not a generic "Bad Request".
+    expect(body.message).toBe("context length exceeded from messages");
+    expect(body.error.message).toBe("context length exceeded from messages");
+    expect(body.upstream_code).toBe(400);
+    expect(body.suggestion).toContain("switch to another model");
+    await flush();
+    expect(traces[0].ok).toBe(false);
+    expect(traces[0].status).toBe(400);
+    expect(traces[0].errorCode).toBe("upstream_error");
+    expect(traces[0].errorMessage).toBe("context length exceeded from messages");
+  });
+
   test("streaming: an error frame from candidate A still fails over to a healthy candidate B", async () => {
     const a: UpstreamDescriptor = { ...managed, provider: "a", baseUrl: "https://a.test/v1" };
     const b: UpstreamDescriptor = { ...managed, provider: "b", baseUrl: "https://b.test/v1" };

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -1502,6 +1502,43 @@ describe('ai-sdk streaming error frame — defect 4 (401 surfaces cleanly, no ha
     // invoked exactly once, not retried internally.
     expect(calls).toBe(1);
   });
+
+  // Defect (2026-08-01, live-reported): an upstream 400 "context length
+  // exceeded from messages" surfaced to the user as a generic "Bad Gateway"
+  // instead of the real error + real status. The AI SDK wraps a non-2xx HTTP
+  // response in an APICallError whose `.message` is the generic HTTP status
+  // text ("Bad Request") — the actionable message ("context length exceeded
+  // from messages") lives in `.responseBody` (the raw upstream JSON), and the
+  // numeric status in `.statusCode`. The streaming adapter (sse.ts) threaded
+  // `.responseBody` into the frame's `detail` but used the generic
+  // `.message` as the client-facing message, AND only emitted a numeric
+  // `code` for terminal-auth failures — so a 400 reached the pipeline's
+  // statusForErrorFrame as `code: undefined`, which falls through to a blanket
+  // 502 "Bad Gateway". Both the real message and the real status were lost.
+  // This test pins the defect at the SSE-frame layer; the handler-layer test
+  // (handler.test.ts) pins the end-to-end client-facing response.
+  it('an APICallError with a generic message + real responseBody surfaces the real upstream message and status', async () => {
+    const sse = await readAll(
+      openAiSseFromFullStream(
+        parts({
+          type: 'error',
+          error: Object.assign(new Error('Bad Request'), {
+            statusCode: 400,
+            responseBody:
+              '{"error":{"message":"context length exceeded from messages","type":"invalid_request_error","code":"context_length_exceeded"}}',
+          }),
+        }),
+        CTX,
+      ),
+    );
+    const frame = sseErrorFrame(sse);
+    // REAL upstream message must reach the client, not the generic "Bad Request".
+    expect(frame?.message).toBe('context length exceeded from messages');
+    // The numeric upstream status must be carried so the pipeline classifies
+    // it as 400, not a blanket 502.
+    expect(frame?.code).toBe(400);
+    expect(sseHasContent(sse)).toBe(false);
+  });
 });
 
 // Piece B (2026-07-17): AI-SDK ⇄ native request PARITY AUDIT + fix.

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -132,7 +132,19 @@ export function toTransportError(err: unknown, provider: string): Error {
         ? e.cause.statusCode
         : undefined;
   if (typeof statusCode === 'number') {
-    return new UpstreamHttpError(statusCode, e.responseBody ?? e.message ?? '', provider);
+    // `responseBody` is the RAW upstream body — the actionable text lives there
+    // when the AI SDK's own `.message` fell back to `response.statusText`
+    // (generic "Bad Request"/"Internal Server Error") because the body failed
+    // the provider's error-schema parse. Prefer it whenever it is non-empty;
+    // only fall back to the AI SDK's `.message` (which may itself be the real
+    // `error.message` when the schema DID match) when no body was captured.
+    // The downstream `parseUpstreamBody` (failover.ts → parseUpstreamErrorBody)
+    // mines the real `error.message`/`error.code` out of this raw body.
+    const body =
+      typeof e.responseBody === 'string' && e.responseBody.trim().length > 0
+        ? e.responseBody
+        : (e.message ?? '');
+    return new UpstreamHttpError(statusCode, body, provider);
   }
   const message = e?.message ?? (err instanceof Error ? err.message : String(err));
   if (looksLikeTerminalAuthFailure(message)) {

--- a/packages/llm-gateway/src/transports/ai-sdk/sse.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/sse.ts
@@ -1,5 +1,10 @@
 import type { FinishReason, LanguageModelUsage, ProviderMetadata } from 'ai';
 import { looksLikeTerminalAuthFailure } from '../../errors';
+import {
+  extractUpstreamErrorDetail,
+  isGenericStatusText,
+  parseUpstreamErrorBody,
+} from '../../http/parse-upstream-error';
 
 // Adapts the AI SDK's provider-neutral stream/result back into the OpenAI
 // chat.completions SSE + JSON shapes the gateway pipeline (probe, relay, usage
@@ -261,7 +266,7 @@ export function openAiSseFromFullStream(
               // structurally rather than assuming one specific class.
               const errObj =
                 err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
-              const message =
+              const rawMessage =
                 err instanceof Error
                   ? err.message
                   : typeof err === 'string'
@@ -278,17 +283,48 @@ export function openAiSseFromFullStream(
               const code =
                 typeof rawCode === 'number' || typeof rawCode === 'string'
                   ? rawCode
-                  : looksLikeTerminalAuthFailure(message)
+                  : looksLikeTerminalAuthFailure(rawMessage)
                     ? 401
                     : undefined;
               // `@ai-sdk/*` wraps an HTTP failure in an APICallError whose
-              // `.message` is generic ("Bad Request") — the actionable part (WHICH
-              // field the upstream rejected) lives in `.responseBody` (raw string)
-              // / `.data` (parsed) / `.url`. Dropping those is exactly why Codex
-              // 400s read as an opaque "Bad Request" and had to be root-caused by
-              // git archaeology. Thread them into the emitted frame's error object
-              // so `sseErrorFrame`'s `detail` carries them to the logs. Bounded so
-              // a huge upstream body can't blow up a log line.
+              // `.message` is the upstream's real `error.message` ONLY when the
+              // body parsed against the provider's error schema; if it didn't (a
+              // non-OpenAI-shaped error, an HTML error page, a plain string,
+              // ...) the AI SDK falls back to `response.statusText` — a generic
+              // "Bad Request" / "Internal Server Error" / "Bad Gateway" that
+              // tells the caller nothing. The actionable message then lives
+              // ONLY in `.responseBody` (raw) / `.data` (parsed when the schema
+              // matched). Mine those for the real message whenever the
+              // `.message` is a generic status text, so the caller sees "context
+              // length exceeded from messages" (and the gateway classifies a
+              // 400 as 400) instead of a useless "Bad Gateway". Keep the
+              // original generic message + the raw body in `detail` so a
+              // diagnosis that needs them still can. (2026-08-01: upstream 400
+              // surfaced as "Bad Gateway".)
+              let message = rawMessage;
+              let detailCode: string | number | undefined;
+              if (err instanceof Error && isGenericStatusText(rawMessage)) {
+                // `.data` is the schema-PARSED body (only present when it matched
+                // the provider's error schema — in which case `.message` would
+                // usually already be the real one, but mine it anyway in case a
+                // custom errorToMessage returned a generic value); `.responseBody`
+                // is the RAW string, the reliable source for everything else.
+                const fromData = extractUpstreamErrorDetail(errObj?.data);
+                const fromBody =
+                  typeof errObj?.responseBody === 'string' && errObj.responseBody.length > 0
+                    ? parseUpstreamErrorBody(errObj.responseBody, rawMessage)
+                    : null;
+                const mined = fromData ?? fromBody;
+                if (mined && mined.message && !isGenericStatusText(mined.message)) {
+                  message = mined.message;
+                  detailCode = mined.code;
+                }
+              }
+              // `@ai-sdk/*`'s APICallError also stashes the actionable fields
+              // (`.responseBody` raw, `.data` parsed, `.url`) here — keep them
+              // on the emitted frame's `detail` so `sseErrorFrame` carries them
+              // to the logs. Bounded so a huge upstream body can't blow up a log
+              // line.
               const detail: Record<string, unknown> = {};
               const responseBody = errObj?.responseBody;
               if (typeof responseBody === 'string' && responseBody.length > 0) {
@@ -296,11 +332,22 @@ export function openAiSseFromFullStream(
               }
               if (errObj?.data !== undefined) detail.data = errObj.data;
               if (typeof errObj?.url === 'string') detail.url = errObj.url;
+              // If a body-mined STRING code is present AND there is no numeric
+              // status code, the string IS the frame's code (preserves the
+              // existing contract for plain-object error parts like the
+              // "overloaded_error" frame — `upstream_code` stays the string).
+              // When a numeric status code IS available (the APICallError case),
+              // it MUST win as `code` so the pipeline's statusForErrorFrame
+              // classifies the HTTP status correctly (a 400 as 400, not a blanket
+              // 502 "Bad Gateway"); the upstream's own string code survives in
+              // `detail` (responseBody/data) for anything that needs it.
+              const finalCode =
+                typeof code === 'number' || detailCode === undefined ? code : detailCode;
               emit(
                 sse({
                   error: {
                     message,
-                    ...(code != null ? { code } : {}),
+                    ...(finalCode != null ? { code: finalCode } : {}),
                     ...(Object.keys(detail).length > 0 ? detail : {}),
                   },
                 }),


### PR DESCRIPTION
## Demo

**Non-visual change — backend error-surfacing contract.** Before/after of the gateway's client-facing response for the reported failure (an upstream `400 "context length exceeded from messages"` whose body failed the AI SDK's error-schema parse):

```
# BEFORE — what the user saw ("Bad Gateway", no actionable cause)
HTTP/1.1 502 Bad Gateway
{ "message": "Bad Request", "code": "upstream_error", "upstream_code": undefined }

# AFTER — real status + real message
HTTP/1.1 400
{ "message": "context length exceeded from messages", "code": "upstream_error", "upstream_code": 400 }
```

Verified end-to-end with a new handler test (`streaming: a numeric 4xx error-frame code surfaces as that status with the real message — not a blanket 502 Bad Gateway`) plus an ai-sdk transport test pinning the SSE-frame layer. All 375 `packages/llm-gateway` tests green; SDK turn-error tests green.

## Why

Live-reported in Slack: an upstream `400 "context length exceeded from messages"` surfaced to users as a generic **"Bad Gateway"** instead of the real error + real status. The root cause is in the LLM gateway's streaming error path:

`@ai-sdk/provider-utils`'s `createJsonErrorResponseHandler` builds the `APICallError` with `message = errorToMessage(parsed)` **only when the upstream body parses against the provider's error schema**. When it doesn't (a non-OpenAI-shaped error, an HTML error page, a plain string), `.message` falls back to `response.statusText` — a generic "Bad Request"/"Internal Server Error"/"Bad Gateway". The actionable text then lives **only** in `.responseBody` (raw) / `.data` (parsed).

The streaming adapter (`transports/ai-sdk/sse.ts`) emitted that generic `.message` as the client-facing `message`, and a numeric `statusCode` reached the pipeline's `statusForErrorFrame` as a string/`undefined` → fell through to a blanket **502 "Bad Gateway"**. Both the real message and the real status were lost. (The non-streaming path was mostly OK — `failover.ts` already mined `err.body` — but only when `responseBody` was non-empty.)

## What changed

- **`packages/llm-gateway/src/http/parse-upstream-error.ts`** (new): a shared helper that mines the real `{message, code}` from an upstream error body / parsed object. Handles OpenAI-compatible `{error:{message,code,type}}`, Anthropic `{type:"error",error:{type,message}}`, top-level `{message,code}`, non-JSON bodies (bounded), and an `isGenericStatusText()` classifier for the HTTP status texts the AI SDK falls back to. Fully unit-tested.
- **`packages/llm-gateway/src/transports/ai-sdk/sse.ts`**: when an `error` part's `.message` is a generic status text, mine the real message + code from `responseBody`/`data` and use that as the client-facing `message`. Always carry a numeric `statusCode` as the frame `code` (so `statusForErrorFrame` returns the real HTTP status — 400 as 400, not 502); the upstream's own string code survives in `detail`. Preserves the existing contract for plain-object error parts (e.g. the `overloaded_error` frame keeps `upstream_code` as the string).
- **`packages/llm-gateway/src/transports/ai-sdk/index.ts`** (`toTransportError`): prefer a non-empty `responseBody` over the generic `.message` when building the `UpstreamHttpError` body, so the non-streaming path's `parseUpstreamBody` has the real text to mine even when the AI SDK's `.message` was the status text.
- **`packages/llm-gateway/src/pipeline/failover.ts`**: delegate `parseUpstreamBody` to the shared helper so streaming and non-streaming surface the same message for the same upstream failure.

## Verification

- `cd packages/llm-gateway && bun test` → **375 pass, 0 fail**
- `cd packages/llm-gateway && bun run typecheck` → clean
- `cd packages/sdk && bun test src/core/turns/errors.test.ts src/core/turns/classify.test.ts` → 49 pass (the SDK's `extractGatewayErrorDetails` already reads the gateway envelope; it now receives the real message + status)
- New tests:
  - `parse-upstream-error.test.ts` — 13 tests covering the helper's extraction + classification
  - `ai-sdk.test.ts` — `an APICallError with a generic message + real responseBody surfaces the real upstream message and status` (pins the SSE-frame layer; fails before the fix with `Received: "Bad Request"`)
  - `handler.test.ts` — `streaming: a numeric 4xx error-frame code surfaces as that status with the real message — not a blanket 502 Bad Gateway` (pins the end-to-end client-facing response)

## Risk / rollback

Low — only the error-surfacing path changes; happy-path completions are untouched. The `overloaded_error`/`invalid_api_key`/numeric-429/numeric-5xx existing contracts are all covered by passing tests. The Anthropic-Messages ingress (`create-gateway.ts` / `anthropic-messages.ts`) and the standalone gateway pod (`apps/llm-gateway`, same `createGateway`) inherit the fix automatically since they sit on top of the same pipeline.
