### PR TITLE
release(staging): session list rebuild + error boundary copy details

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/page.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { useParams } from 'next/navigation';
 import { ProjectSessionsView } from '@/features/workspace/project-sessions/project-sessions-view';
+import { useParams } from 'next/navigation';
 
 export default function ProjectSessionsPage() {
   const { id: projectId } = useParams<{ id: string }>();
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <ProjectSessionsView projectId={projectId} />
-      </div>
+      <ProjectSessionsView projectId={projectId} />
+    </div>
   );
 }

--- a/apps/web/src/components/common/error-boundary.tsx
+++ b/apps/web/src/components/common/error-boundary.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
+import { Icon } from '@/features/icon/icon';
 import { isRuntimeNotReadyNoiseMessage } from '@/lib/browser-error-noise';
+import { cn } from '@/lib/utils';
+import { CaretRightIcon, CheckIcon } from '@phosphor-icons/react';
 import * as Sentry from '@sentry/nextjs';
 import { useTranslations } from 'next-intl';
 import type { ErrorInfo } from 'react';
-import { Component } from 'react';
-import { ErrorDetails } from './error-details';
+import { Component, useCallback, useMemo, useState } from 'react';
 
 // `children` is typed via the global `React.ReactNode` (not the named import)
 // so it matches the layout's children type — the app pins @types/react@18 but
@@ -14,30 +17,149 @@ import { ErrorDetails } from './error-details';
 // pattern used by ReactQueryProvider.
 export type ErrorBoundaryFallback = (props: { error: Error; reset: () => void }) => React.ReactNode;
 
+/** Copy the whole error report in one click — the thing a user pastes into a bug report. */
+function CopyErrorButton({ report, label }: { report: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+    navigator.clipboard.writeText(report).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      },
+      (e) => console.error('Failed to copy error details:', e),
+    );
+  }, [report]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={label}
+      className={cn(
+        'text-muted-foreground hover:text-foreground hover:bg-muted-foreground/10',
+        'hit-area-3 inline-flex size-7 shrink-0 items-center justify-center rounded-sm',
+        'focus-visible:ring-kortix-base cursor-pointer outline-none focus-visible:ring-[0.6px]',
+      )}
+    >
+      {/* Fixed-size box so the check/copy swap never shifts the row. */}
+      <span className="inline-flex size-3.5 items-center justify-center">
+        {copied ? (
+          <CheckIcon className="text-foreground size-3.5" />
+        ) : (
+          <Icon.Copy className="size-3.5" />
+        )}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Default in-shell crash card. Deliberately reads like `app/not-found.tsx` and
+ * `app/error.tsx`: a centered column, one headline, one line of body copy, then
+ * the recovery actions. The technical payload (message, error name, digest,
+ * stack frames) is folded into a collapsed `Disclosure` so the calm state stays
+ * calm — a stack trace is never the first thing a user reads.
+ */
 function DefaultAppFallback({ error, reset }: { error: Error; reset: () => void }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const [open, setOpen] = useState(false);
+
+  const digest = (error as Error & { digest?: string }).digest;
+  const message = error.message?.trim() || 'An unexpected error occurred.';
+  // The signature is the one piece of machine detail worth showing collapsed —
+  // it is what an engineer asks for first ("which error, which build?").
+  const signature = `${error.name || 'Error'}${digest ? ` · ${digest}` : ''}`;
+
+  // V8 repeats "Name: message" as the stack's first line; keep only the frames
+  // so the panel doesn't print the message twice. Fall back to raw lines for
+  // engines that format differently.
+  const frames = useMemo(() => {
+    const lines = (error.stack ?? '').split('\n').map((l) => l.trim());
+    const atFrames = lines.filter((l) => l.startsWith('at '));
+    return (atFrames.length ? atFrames : lines.slice(1)).slice(0, 6).join('\n').trim();
+  }, [error.stack]);
+
+  const report = useMemo(
+    () => [signature, message, frames].filter(Boolean).join('\n'),
+    [signature, message, frames],
+  );
+
   return (
-    <div className="flex h-full min-h-[60vh] w-full flex-1 flex-col items-center justify-center gap-4 p-6 text-center">
-      <div className="space-y-1.5">
-        <h2 className="text-foreground text-lg font-medium">
-          {tI18nHardcoded.raw('autoComponentsCommonErrorBoundaryJsxTextSomethingWentWrong1571085c')}
-        </h2>
-        <p className="text-muted-foreground max-w-md text-sm">
-          {tI18nHardcoded.raw('autoComponentsCommonErrorBoundaryJsxTextThisPartOfThe0af7a52e')}
-        </p>
-      </div>
-      <ErrorDetails error={error} />
-      <div className="flex gap-2">
-        <Button variant="outline" onClick={reset}>
-          {tI18nHardcoded.raw('autoComponentsCommonErrorBoundaryJsxTextTryAgain9615ff3f')}
-        </Button>
-        <Button
-          onClick={() => {
-            if (typeof window !== 'undefined') window.location.reload();
-          }}
-        >
-          Reload
-        </Button>
+    <div className="flex h-full min-h-[60vh] w-full flex-1 flex-col items-center justify-center px-6 py-16">
+      <div className="flex w-full max-w-md flex-col items-center gap-7">
+        <div className="space-y-2 text-center">
+          <h2 className="text-foreground text-lg font-semibold text-balance">
+            {tI18nHardcoded.raw(
+              'autoComponentsCommonErrorBoundaryJsxTextSomethingWentWrong1571085c',
+            )}
+          </h2>
+          <p className="text-muted-foreground text-sm leading-relaxed text-pretty">
+            {tI18nHardcoded.raw('autoComponentsCommonErrorBoundaryJsxTextThisPartOfThe0af7a52e')}
+          </p>
+        </div>
+
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+          <Button onClick={reset} size="sm">
+            {tI18nHardcoded.raw('autoComponentsCommonErrorBoundaryJsxTextTryAgain9615ff3f')}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => {
+              if (typeof window !== 'undefined') window.location.reload();
+            }}
+          >
+            {tI18nHardcoded.raw('componentsCommonErrorBoundary.reload')}
+          </Button>
+        </div>
+
+        <div className="w-full">
+          <Disclosure
+            variant="outline"
+            open={open}
+            onOpenChange={setOpen}
+            className="bg-popover w-full overflow-hidden text-left"
+          >
+            <DisclosureTrigger variant="outline">
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-9 w-full justify-between gap-3 rounded-none px-3 font-normal"
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <CaretRightIcon className="text-muted-foreground size-3.5 shrink-0 group-data-[state=open]:rotate-90" />
+                  <span className="text-xs font-medium">
+                    {tI18nHardcoded.raw('componentsCommonErrorBoundary.errorDetails')}
+                  </span>
+                </span>
+                <span className="text-muted-foreground/70 truncate font-mono text-xs">
+                  {signature}
+                </span>
+              </Button>
+            </DisclosureTrigger>
+
+            <DisclosureContent variant="outline" className="overflow-hidden">
+              <div className="border-border space-y-2.5 border-t px-3 py-3">
+                <div className="flex items-start gap-2">
+                  <p className="text-foreground/90 min-w-0 flex-1 text-xs leading-relaxed wrap-break-word">
+                    {message}
+                  </p>
+                  <CopyErrorButton
+                    report={report}
+                    label={tI18nHardcoded.raw('componentsCommonErrorBoundary.copyDetails')}
+                  />
+                </div>
+                {frames ? (
+                  <pre className="bg-muted/50 text-muted-foreground max-h-40 overflow-auto rounded-sm p-2 font-mono text-xs leading-relaxed wrap-break-word whitespace-pre-wrap">
+                    {frames}
+                  </pre>
+                ) : null}
+              </div>
+            </DisclosureContent>
+          </Disclosure>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/features/workspace/customize/sections/component/section-wrapper.tsx
+++ b/apps/web/src/features/workspace/customize/sections/component/section-wrapper.tsx
@@ -1,5 +1,10 @@
+'use client';
+
 import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
+import { useOptionalSidebar } from '@/components/ui/sidebar';
 import { cn } from '@/lib/utils';
+import { SidebarSimpleIcon as PanelLeft } from '@phosphor-icons/react';
 import Link from 'next/link';
 import type React from 'react';
 
@@ -24,7 +29,55 @@ type Props = {
    * to this component's internal class names.
    */
   scrollContainerRef?: React.Ref<HTMLDivElement>;
+  /**
+   * Floating open/collapse control at the top-left of this section. Opt-in —
+   * the project shell no longer mounts a mobile sheet opener, so pages that
+   * sit under this wrapper without their own header toggle need this. Default
+   * off so existing callers keep their layout.
+   */
+  showSidebarToggleButton?: boolean;
 };
+
+/**
+ * Absolute top-left opener. Visibility matches project-home / session header:
+ * always on mobile (sheet has no docked affordance); desktop only while the
+ * panel is undocked — the sidebar header already carries collapse when expanded.
+ */
+function SectionSidebarToggle() {
+  const sidebar = useOptionalSidebar();
+  if (!sidebar) return null;
+  if (!sidebar.isMobile && sidebar.state === 'expanded') return null;
+
+  const label =
+    sidebar.state === 'expanded'
+      ? 'Collapse sidebar'
+      : sidebar.peek
+        ? 'Pin sidebar'
+        : 'Open sidebar';
+
+  return (
+    <Hint label={label} side="bottom">
+      <Button
+        type="button"
+        aria-label={label}
+        variant="ghost"
+        size="icon"
+        onClick={sidebar.toggleSidebar}
+        onPointerEnter={sidebar.state === 'collapsed' ? sidebar.peekEnter : undefined}
+        onPointerLeave={sidebar.state === 'collapsed' ? sidebar.peekLeave : undefined}
+        className="hover:bg-sidebar-accent hover:text-sidebar-foreground absolute top-2 left-2 z-20 shrink-0 cursor-pointer items-center justify-center rounded-md transition-[color,background-color,transform] duration-150 ease-out active:scale-[0.96]"
+      >
+        <PanelLeft className="cn-rtl-flip size-4" />
+      </Button>
+    </Hint>
+  );
+}
+
+function useShowSectionSidebarToggle(enabled: boolean): boolean {
+  const sidebar = useOptionalSidebar();
+  if (!enabled || !sidebar) return false;
+  return sidebar.isMobile || sidebar.state !== 'expanded';
+}
 
 const CustomizeSectionWrapper = ({
   title,
@@ -35,7 +88,10 @@ const CustomizeSectionWrapper = ({
   className,
   fill,
   scrollContainerRef,
+  showSidebarToggleButton = false,
 }: Props) => {
+  const showToggle = useShowSectionSidebarToggle(showSidebarToggleButton);
+
   const heading = (
     <div className="space-y-1">
       <h2 className="text-foreground text-xl font-medium">{title}</h2>
@@ -58,8 +114,15 @@ const CustomizeSectionWrapper = ({
 
   if (fill) {
     return (
-      <div className="flex h-full min-h-0 flex-col">
-        <header className="border-border/60 flex shrink-0 flex-col gap-2 border-b px-4 py-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="relative flex h-full min-h-0 flex-col">
+        {showSidebarToggleButton ? <SectionSidebarToggle /> : null}
+        <header
+          className={cn(
+            'border-border/60 flex shrink-0 flex-col gap-2 border-b px-4 py-2 sm:flex-row sm:items-center sm:justify-between',
+            // Clear the absolute toggle so the title does not sit under it.
+            showToggle && 'pl-12',
+          )}
+        >
           {heading}
           {action ? <div className="mt-2 shrink-0 sm:mt-0">{action}</div> : null}
         </header>
@@ -74,10 +137,15 @@ const CustomizeSectionWrapper = ({
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div className="relative flex h-full min-h-0 flex-col">
+      {showSidebarToggleButton ? <SectionSidebarToggle /> : null}
       <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-y-auto">
         <div
-          className={cn('mx-auto w-full max-w-3xl space-y-5 px-4 py-10 pb-20 lg:py-20', className)}
+          className={cn(
+            'mx-auto w-full max-w-3xl space-y-5 px-4 py-10 pb-20 lg:py-20',
+            // showToggle && 'pl-12',
+            className,
+          )}
         >
           <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             {heading}

--- a/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.test.ts
+++ b/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.test.ts
@@ -2,11 +2,17 @@ import type { ProjectSession } from '@kortix/sdk';
 import { describe, expect, test } from 'bun:test';
 
 import {
+  availableProjectSessionsFilters,
   filterProjectSessions,
+  mapWithConcurrency,
   matchesProjectSessionsFilter,
   projectSessionsFilterCounts,
+  pruneSelection,
   sessionAccessMeta,
+  sessionDetailFields,
   sessionOwnerLabel,
+  summarizeBulkDelete,
+  toggleSelection,
 } from './project-sessions-helpers';
 
 function makeSession(overrides: Partial<ProjectSession> = {}): ProjectSession {
@@ -33,6 +39,8 @@ function makeSession(overrides: Partial<ProjectSession> = {}): ProjectSession {
   };
 }
 
+const FORMATTED = { created: 'Jul 20, 2026, 10:00 AM', updated: 'Jul 21, 2026, 11:00 AM' };
+
 describe('matchesProjectSessionsFilter', () => {
   test('groups every provisioning state with running sessions as active', () => {
     for (const status of ['queued', 'branching', 'provisioning', 'running'] as const) {
@@ -43,16 +51,22 @@ describe('matchesProjectSessionsFilter', () => {
     );
   });
 
-  test('detects automation and viewer-relative shared sessions', () => {
-    const automated = makeSession({ metadata: { trigger_source: 'cron' } });
-    const shared = makeSession({ is_owner: false });
-
-    expect(matchesProjectSessionsFilter(automated, 'automated')).toBe(true);
-    expect(matchesProjectSessionsFilter(shared, 'shared')).toBe(true);
-    expect(matchesProjectSessionsFilter(makeSession(), 'shared')).toBe(false);
+  test('matches each source kind to its own filter', () => {
+    expect(
+      matchesProjectSessionsFilter(makeSession({ metadata: { source: 'slack' } }), 'slack'),
+    ).toBe(true);
+    expect(
+      matchesProjectSessionsFilter(
+        makeSession({ metadata: { trigger_source: 'cron', trigger_type: 'cron' } }),
+        'schedule',
+      ),
+    ).toBe(true);
+    expect(matchesProjectSessionsFilter(makeSession(), 'chat')).toBe(true);
+    expect(matchesProjectSessionsFilter(makeSession(), 'slack')).toBe(false);
   });
 
-  test('separates deleted and inaccessible sessions for inventory debugging', () => {
+  test('separates deleted, shared and inaccessible sessions', () => {
+    expect(matchesProjectSessionsFilter(makeSession({ is_owner: false }), 'shared')).toBe(true);
     expect(
       matchesProjectSessionsFilter(
         makeSession({ deleted_at: '2026-07-20T10:00:00.000Z' }),
@@ -62,6 +76,46 @@ describe('matchesProjectSessionsFilter', () => {
     expect(matchesProjectSessionsFilter(makeSession({ can_access: false }), 'inaccessible')).toBe(
       true,
     );
+  });
+});
+
+describe('availableProjectSessionsFilters', () => {
+  test('omits every zero-count option so the menu has no dead ends', () => {
+    const groups = availableProjectSessionsFilters([
+      makeSession({ status: 'running' }),
+      makeSession({ session_id: 'two', status: 'completed' }),
+    ]);
+
+    const values = groups.flatMap((group) => group.options.map((option) => option.value));
+    expect(values).toEqual(['active', 'completed', 'chat']);
+    expect(values).not.toContain('failed');
+    expect(values).not.toContain('deleted');
+  });
+
+  test('drops an axis entirely rather than rendering an empty section header', () => {
+    const groups = availableProjectSessionsFilters([makeSession({ status: 'running' })]);
+    expect(groups.map((group) => group.axis)).toEqual(['status', 'source']);
+  });
+
+  test('reports the count alongside each surviving option', () => {
+    const groups = availableProjectSessionsFilters([
+      makeSession({ metadata: { source: 'slack' } }),
+      makeSession({ session_id: 'two', metadata: { source: 'slack' } }),
+    ]);
+
+    const slack = groups
+      .flatMap((group) => group.options)
+      .find((option) => option.value === 'slack');
+    expect(slack).toMatchObject({ label: 'Slack', count: 2 });
+  });
+
+  test('keeps the active filter listed even after its last session disappears', () => {
+    const groups = availableProjectSessionsFilters([makeSession({ status: 'running' })], 'failed');
+    const failed = groups
+      .flatMap((group) => group.options)
+      .find((option) => option.value === 'failed');
+
+    expect(failed).toMatchObject({ count: 0 });
   });
 });
 
@@ -78,9 +132,7 @@ describe('session inventory identity and access labels', () => {
       ),
     ).toBe('backend-debugger');
     expect(
-      sessionOwnerLabel(
-        makeSession({ is_owner: false, created_by: 'owner-id', owner_email: null }),
-      ),
+      sessionOwnerLabel(makeSession({ is_owner: false, created_by: 'owner-id', owner_email: null })),
     ).toBe('Unknown owner');
   });
 
@@ -98,6 +150,212 @@ describe('session inventory identity and access labels', () => {
     expect(
       sessionAccessMeta(makeSession({ can_access: true, runtime_status: 'active' })),
     ).toMatchObject({ label: 'Can open', canOpen: true });
+  });
+});
+
+describe('sessionDetailFields', () => {
+  test('never emits a placeholder formatted like real data', () => {
+    const bare = makeSession({
+      // Typed non-nullable, but the API returns empty strings before the
+      // branch and sandbox exist — which is why the old grid fell back to
+      // "Not created" / "Missing" here.
+      branch_name: '',
+      base_ref: '',
+      sandbox_id: '',
+      sandbox_provider: null,
+      agent_name: null,
+      runtime_status: null,
+      opencode_session_id: null,
+      created_by: null,
+      owner_type: undefined,
+    });
+
+    const values = sessionDetailFields(bare, FORMATTED).map((field) => field.value);
+    for (const placeholder of [
+      'Not created',
+      'Missing',
+      'Unattributed',
+      'Not synced',
+      'Not provisioned',
+      'Default branch',
+      'Project default',
+    ]) {
+      expect(values).not.toContain(placeholder);
+    }
+  });
+
+  test('omits trigger fields for a chat and includes them for a trigger fire', () => {
+    const chatLabels = sessionDetailFields(makeSession(), FORMATTED).map((field) => field.label);
+    expect(chatLabels).not.toContain('Trigger');
+    expect(chatLabels).not.toContain('Source');
+
+    const cron = makeSession({
+      metadata: { trigger_source: 'cron', trigger_type: 'cron', trigger_slug: 'nightly-audit' },
+    });
+    const cronFields = sessionDetailFields(cron, FORMATTED);
+    expect(cronFields).toContainEqual({ label: 'Source', value: 'Scheduled', mono: undefined });
+    expect(cronFields).toContainEqual({ label: 'Trigger', value: 'nightly-audit', mono: undefined });
+  });
+
+  test('drops a chat session from 18 fields to a readable handful', () => {
+    const fields = sessionDetailFields(
+      makeSession({
+        branch_name: '',
+        base_ref: '',
+        sandbox_id: '',
+        sandbox_provider: null,
+        agent_name: null,
+        runtime_status: null,
+        opencode_session_id: null,
+        created_by: null,
+        owner_type: undefined,
+      }),
+      FORMATTED,
+    );
+    expect(fields.length).toBeLessThanOrEqual(6);
+  });
+
+  test('prints a shared identifier once, not three times', () => {
+    // The platform sets sandbox_id == session_id and defaults branch to it.
+    const coincident = makeSession({
+      session_id: 'df4276b5-28b7',
+      sandbox_id: 'df4276b5-28b7',
+      branch_name: 'df4276b5-28b7',
+    });
+    const labels = sessionDetailFields(coincident, FORMATTED).map((f) => f.label);
+    expect(labels).toContain('Session ID');
+    expect(labels).not.toContain('Branch');
+    expect(labels).not.toContain('Sandbox ID');
+  });
+
+  test('still shows branch and sandbox when they genuinely differ', () => {
+    const distinct = makeSession({
+      session_id: 'ses-1',
+      sandbox_id: 'sbx-9',
+      branch_name: 'kx/nightly-audit',
+    });
+    const labels = sessionDetailFields(distinct, FORMATTED).map((f) => f.label);
+    expect(labels).toContain('Branch');
+    expect(labels).toContain('Sandbox ID');
+  });
+
+  test('hides "Can open" but surfaces a restricted access state', () => {
+    const open = sessionDetailFields(
+      makeSession({ can_access: true, runtime_status: 'active' }),
+      FORMATTED,
+    );
+    expect(open.map((field) => field.label)).not.toContain('Your access');
+
+    const restricted = sessionDetailFields(makeSession({ can_access: false }), FORMATTED);
+    expect(restricted).toContainEqual({
+      label: 'Your access',
+      value: 'Metadata only',
+      mono: undefined,
+    });
+  });
+
+  test('counts conversations only when the session has any', () => {
+    expect(sessionDetailFields(makeSession(), FORMATTED).map((f) => f.label)).not.toContain(
+      'Conversations',
+    );
+
+    const withConversations = makeSession({
+      opencode_sessions: [
+        { id: 'a', parent_id: null, archived_at: null },
+        { id: 'b', parent_id: 'a', archived_at: '2026-07-20T10:00:00.000Z' },
+      ] as ProjectSession['opencode_sessions'],
+    });
+    expect(sessionDetailFields(withConversations, FORMATTED)).toContainEqual({
+      label: 'Conversations',
+      value: '2 · 1 archived',
+    });
+  });
+});
+
+describe('selection', () => {
+  test('toggles an id on and off without mutating the previous set', () => {
+    const initial = new Set<string>();
+    const withOne = toggleSelection(initial, 'a');
+    expect(withOne.has('a')).toBe(true);
+    expect(initial.size).toBe(0);
+    expect(toggleSelection(withOne, 'a').has('a')).toBe(false);
+  });
+
+  test('prunes ids that scrolled out of the filtered view', () => {
+    const selected = new Set(['a', 'b', 'c']);
+    const pruned = pruneSelection(selected, [
+      makeSession({ session_id: 'a' }),
+      makeSession({ session_id: 'c' }),
+    ]);
+    expect([...pruned].sort()).toEqual(['a', 'c']);
+  });
+
+  test('returns the same reference when nothing was pruned, so React skips a render', () => {
+    const selected = new Set(['a']);
+    expect(pruneSelection(selected, [makeSession({ session_id: 'a' })])).toBe(selected);
+  });
+});
+
+describe('summarizeBulkDelete', () => {
+  test('reports a clean batch', () => {
+    expect(
+      summarizeBulkDelete([
+        { sessionId: 'a', ok: true },
+        { sessionId: 'b', ok: true },
+      ]).message,
+    ).toBe('Deleted 2 sessions');
+  });
+
+  test('singularises a batch of one', () => {
+    expect(summarizeBulkDelete([{ sessionId: 'a', ok: true }]).message).toBe('Deleted 1 session');
+  });
+
+  test('never claims success when part of the batch failed', () => {
+    const summary = summarizeBulkDelete([
+      { sessionId: 'a', ok: true },
+      { sessionId: 'b', ok: false },
+      { sessionId: 'c', ok: false },
+    ]);
+    expect(summary.message).toBe('Deleted 1 of 3. 2 failed.');
+    expect(summary.succeeded).toEqual(['a']);
+    expect(summary.failed).toEqual(['b', 'c']);
+  });
+
+  test('reports a total failure as a failure', () => {
+    expect(
+      summarizeBulkDelete([
+        { sessionId: 'a', ok: false },
+        { sessionId: 'b', ok: false },
+      ]).message,
+    ).toBe('Could not delete 2 sessions');
+  });
+});
+
+describe('mapWithConcurrency', () => {
+  test('preserves input order regardless of completion order', async () => {
+    const results = await mapWithConcurrency([30, 10, 20, 0], 2, async (delay) => {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return delay;
+    });
+    expect(results).toEqual([30, 10, 20, 0]);
+  });
+
+  test('never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let peak = 0;
+
+    await mapWithConcurrency(Array.from({ length: 12 }, (_, i) => i), 3, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+    });
+
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  test('handles an empty batch', async () => {
+    expect(await mapWithConcurrency([], 4, async (x) => x)).toEqual([]);
   });
 });
 
@@ -140,7 +398,7 @@ describe('projectSessionsFilterCounts', () => {
       makeSession({
         session_id: 'three',
         status: 'completed',
-        metadata: { trigger_source: 'cron' },
+        metadata: { trigger_source: 'cron', trigger_type: 'cron' },
       }),
     ]);
 
@@ -150,7 +408,8 @@ describe('projectSessionsFilterCounts', () => {
       completed: 1,
       stopped: 0,
       failed: 1,
-      automated: 1,
+      schedule: 1,
+      chat: 2,
       shared: 1,
       deleted: 0,
       inaccessible: 1,

--- a/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.ts
+++ b/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.ts
@@ -1,6 +1,6 @@
 import type { ProjectSession } from '@kortix/sdk';
 
-import { sessionSource } from '@/components/projects/session-label';
+import { sessionSource, type SessionSourceKind } from '@/components/projects/session-label';
 import {
   getSessionDisplayTitle,
   sortSessionsByLastActivity,
@@ -12,24 +12,44 @@ export type ProjectSessionsFilter =
   | 'completed'
   | 'stopped'
   | 'failed'
-  | 'automated'
+  | 'chat'
+  | 'slack'
+  | 'telegram'
+  | 'email'
+  | 'schedule'
+  | 'webhook'
   | 'shared'
   | 'deleted'
   | 'inaccessible';
 
-export const PROJECT_SESSIONS_FILTERS: Array<{
+/**
+ * The three axes this list filters on. They were previously flattened into one
+ * single-select strip, which asserted that "Failed" and "Shared" were
+ * alternatives. Grouping keeps selection single but makes the axes legible.
+ */
+export type ProjectSessionsFilterAxis = 'status' | 'source' | 'access';
+
+export interface ProjectSessionsFilterOption {
   value: ProjectSessionsFilter;
   label: string;
-}> = [
-  { value: 'all', label: 'All' },
-  { value: 'active', label: 'Active' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'stopped', label: 'Stopped' },
-  { value: 'failed', label: 'Failed' },
-  { value: 'automated', label: 'Automated' },
-  { value: 'shared', label: 'Shared' },
-  { value: 'deleted', label: 'Deleted' },
-  { value: 'inaccessible', label: 'Metadata only' },
+  axis: ProjectSessionsFilterAxis;
+}
+
+export const PROJECT_SESSIONS_FILTERS: ProjectSessionsFilterOption[] = [
+  { value: 'all', label: 'All', axis: 'status' },
+  { value: 'active', label: 'Active', axis: 'status' },
+  { value: 'completed', label: 'Completed', axis: 'status' },
+  { value: 'stopped', label: 'Stopped', axis: 'status' },
+  { value: 'failed', label: 'Failed', axis: 'status' },
+  { value: 'chat', label: 'Chat', axis: 'source' },
+  { value: 'slack', label: 'Slack', axis: 'source' },
+  { value: 'telegram', label: 'Telegram', axis: 'source' },
+  { value: 'email', label: 'Email', axis: 'source' },
+  { value: 'schedule', label: 'Scheduled', axis: 'source' },
+  { value: 'webhook', label: 'Webhook', axis: 'source' },
+  { value: 'shared', label: 'Shared with you', axis: 'access' },
+  { value: 'deleted', label: 'Deleted', axis: 'access' },
+  { value: 'inaccessible', label: 'Metadata only', axis: 'access' },
 ];
 
 const ACTIVE_STATUSES = new Set<ProjectSession['status']>([
@@ -39,17 +59,90 @@ const ACTIVE_STATUSES = new Set<ProjectSession['status']>([
   'running',
 ]);
 
+const SOURCE_FILTERS = new Set<ProjectSessionsFilter>([
+  'chat',
+  'slack',
+  'telegram',
+  'email',
+  'schedule',
+  'webhook',
+]);
+
 export function matchesProjectSessionsFilter(
   session: ProjectSession,
   filter: ProjectSessionsFilter,
 ): boolean {
   if (filter === 'all') return true;
   if (filter === 'active') return ACTIVE_STATUSES.has(session.status);
-  if (filter === 'automated') return sessionSource(session).kind !== 'chat';
+  if (SOURCE_FILTERS.has(filter)) return sessionSource(session).kind === filter;
   if (filter === 'shared') return session.is_owner === false;
   if (filter === 'deleted') return Boolean(session.deleted_at);
   if (filter === 'inaccessible') return session.can_access === false;
   return session.status === filter;
+}
+
+export function projectSessionsFilterCounts(
+  sessions: ProjectSession[],
+): Record<ProjectSessionsFilter, number> {
+  return PROJECT_SESSIONS_FILTERS.reduce(
+    (counts, option) => {
+      counts[option.value] = sessions.filter((session) =>
+        matchesProjectSessionsFilter(session, option.value),
+      ).length;
+      return counts;
+    },
+    {} as Record<ProjectSessionsFilter, number>,
+  );
+}
+
+export interface ProjectSessionsFilterGroup {
+  axis: ProjectSessionsFilterAxis;
+  label: string;
+  options: Array<ProjectSessionsFilterOption & { count: number }>;
+}
+
+const AXIS_LABELS: Record<ProjectSessionsFilterAxis, string> = {
+  status: 'Status',
+  source: 'Source',
+  access: 'Access',
+};
+
+/**
+ * Which filters this session set is worth offering, grouped by axis.
+ *
+ * An option earns a slot only when it matches at least one session — a
+ * "Failed 0" entry is a dead end that costs a row to lead nowhere. This mirrors
+ * `availableSessionFilterOptions()` in `components/projects/session-label.ts`,
+ * the rule the sidebar has always honoured.
+ *
+ * "All" is never grouped and is always offered. An axis with no surviving
+ * option is dropped entirely rather than rendering an empty section header.
+ * The currently active filter is always retained, so selecting the last
+ * "Failed" session's filter and then deleting it does not strand the menu on a
+ * value it no longer lists.
+ */
+export function availableProjectSessionsFilters(
+  sessions: ProjectSession[],
+  activeFilter: ProjectSessionsFilter = 'all',
+): ProjectSessionsFilterGroup[] {
+  const counts = projectSessionsFilterCounts(sessions);
+
+  return (['status', 'source', 'access'] as const)
+    .map((axis) => ({
+      axis,
+      label: AXIS_LABELS[axis],
+      options: PROJECT_SESSIONS_FILTERS.filter(
+        (option) =>
+          option.axis === axis &&
+          option.value !== 'all' &&
+          (counts[option.value] > 0 || option.value === activeFilter),
+      ).map((option) => ({ ...option, count: counts[option.value] })),
+    }))
+    .filter((group) => group.options.length > 0);
+}
+
+export function projectSessionsFilterLabel(filter: ProjectSessionsFilter): string {
+  return PROJECT_SESSIONS_FILTERS.find((option) => option.value === filter)?.label ?? 'All';
 }
 
 export function sessionOwnerLabel(session: ProjectSession): string {
@@ -113,16 +206,168 @@ export function filterProjectSessions(
   );
 }
 
-export function projectSessionsFilterCounts(
-  sessions: ProjectSession[],
-): Record<ProjectSessionsFilter, number> {
-  return PROJECT_SESSIONS_FILTERS.reduce(
-    (counts, option) => {
-      counts[option.value] = sessions.filter((session) =>
-        matchesProjectSessionsFilter(session, option.value),
-      ).length;
-      return counts;
-    },
-    {} as Record<ProjectSessionsFilter, number>,
-  );
+export interface SessionDetailField {
+  label: string;
+  value: string;
+  mono?: boolean;
 }
+
+const OWNER_TYPE_LABELS: Record<string, string> = {
+  user: 'Person',
+  service_account: 'Agent / service account',
+};
+
+/**
+ * The detail fields worth rendering for a session.
+ *
+ * A field is emitted only when it carries a real value. The previous grid
+ * rendered all 18 fields unconditionally, so a plain chat session was roughly
+ * two thirds placeholders — `Not created`, `Missing`, `Unattributed`,
+ * `Not synced`. A placeholder formatted like data reads like data; omitting the
+ * row says the same thing honestly and in less space.
+ */
+export function sessionDetailFields(
+  session: ProjectSession,
+  formatted: { created: string; updated: string },
+): SessionDetailField[] {
+  const source = sessionSource(session);
+  const access = sessionAccessMeta(session);
+  const fields: SessionDetailField[] = [];
+
+  const push = (label: string, value: string | null | undefined, mono?: boolean) => {
+    if (typeof value === 'string' && value.length > 0) fields.push({ label, value, mono });
+  };
+
+  // Trigger metadata is meaningless for a chat a person started; it exists only
+  // once something fired the session.
+  if (source.kind !== 'chat') {
+    push('Source', source.label);
+    push('Trigger', source.triggerSlug);
+  }
+
+  push('Last activity', formatted.updated);
+  push('Created', formatted.created);
+  push('Owner', sessionOwnerLabel(session));
+  push('Owner identity', session.owner_type ? OWNER_TYPE_LABELS[session.owner_type] : null);
+  push('Owner ID', session.created_by, true);
+  // "Can open" is the default; surfacing it on every row is noise.
+  if (!access.canOpen) push('Your access', access.label);
+  push('Agent', session.agent_name);
+  push('Runtime', session.sandbox_provider);
+  push('Runtime state', session.runtime_status);
+
+  const conversationCount = (session.opencode_sessions ?? []).length;
+  if (conversationCount > 0) {
+    const archived = (session.opencode_sessions ?? []).filter((item) => item.archived_at).length;
+    fields.push({
+      label: 'Conversations',
+      value: `${conversationCount}${archived > 0 ? ` · ${archived} archived` : ''}`,
+    });
+  }
+
+  push('Base ref', session.base_ref, true);
+
+  // The platform sets `session_id == sandbox_id` and defaults the branch name
+  // to the session id, so all three routinely hold the SAME 36-char uuid.
+  // Printing it three times is noise for the same reason a placeholder is: a
+  // field earns its row by telling you something you do not already know.
+  if (session.branch_name !== session.session_id) push('Branch', session.branch_name, true);
+  push('Session ID', session.session_id, true);
+  if (session.sandbox_id !== session.session_id) push('Sandbox ID', session.sandbox_id, true);
+  push('Root conversation ID', session.opencode_session_id, true);
+
+  return fields;
+}
+
+/** A session can only be deleted when the viewer owns a live, undeleted record. */
+export function sessionIsDeletable(session: ProjectSession): boolean {
+  return !session.deleted_at && session.can_access !== false;
+}
+
+/** Toggle one id, returning a new set so React sees the change. */
+export function toggleSelection(selected: Set<string>, sessionId: string): Set<string> {
+  const next = new Set(selected);
+  if (!next.delete(sessionId)) next.add(sessionId);
+  return next;
+}
+
+/**
+ * Drop selected ids that are no longer visible.
+ *
+ * Without this, narrowing the filter after selecting leaves `N selected`
+ * counting rows that are off screen, and `Delete N` would destroy sessions the
+ * user cannot see. Selection must never outlive its own visibility.
+ */
+export function pruneSelection(
+  selected: Set<string>,
+  visible: ProjectSession[],
+): Set<string> {
+  const visibleIds = new Set(visible.map((session) => session.session_id));
+  const next = new Set([...selected].filter((id) => visibleIds.has(id)));
+  return next.size === selected.size ? selected : next;
+}
+
+export interface BulkDeleteSummary {
+  succeeded: string[];
+  failed: string[];
+  /** Human sentence for the toast. Never claims a success that did not happen. */
+  message: string;
+}
+
+/**
+ * Fold per-session delete outcomes into one honest result.
+ *
+ * There is no bulk delete endpoint — only
+ * `DELETE /projects/:projectId/sessions/:sessionId` — so a batch can partially
+ * fail. Reporting "Deleted 7 sessions" while two rows survive is worse than
+ * reporting nothing, because the user stops looking.
+ */
+export function summarizeBulkDelete(
+  results: Array<{ sessionId: string; ok: boolean }>,
+): BulkDeleteSummary {
+  const succeeded = results.filter((result) => result.ok).map((result) => result.sessionId);
+  const failed = results.filter((result) => !result.ok).map((result) => result.sessionId);
+  const total = results.length;
+
+  if (failed.length === 0) {
+    return {
+      succeeded,
+      failed,
+      message: `Deleted ${total} ${total === 1 ? 'session' : 'sessions'}`,
+    };
+  }
+  if (succeeded.length === 0) {
+    return {
+      succeeded,
+      failed,
+      message: `Could not delete ${failed.length === 1 ? 'the session' : `${failed.length} sessions`}`,
+    };
+  }
+  return {
+    succeeded,
+    failed,
+    message: `Deleted ${succeeded.length} of ${total}. ${failed.length} failed.`,
+  };
+}
+
+/** Run `task` over `items` with at most `limit` in flight, preserving order. */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await task(items[index]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+export type { SessionSourceKind };

--- a/apps/web/src/features/workspace/project-sessions/project-sessions-view.tsx
+++ b/apps/web/src/features/workspace/project-sessions/project-sessions-view.tsx
@@ -1,38 +1,18 @@
 'use client';
 
-import { sessionSource, type SessionSourceKind } from '@/components/projects/session-label';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { InfoBanner } from '@/components/ui/info-banner';
-import {
-  InputGroupSearch,
-  InputGroupSearchClear,
-  InputGroupSearchIcon,
-  InputGroupSearchInput,
-} from '@/components/ui/input-group';
-import Loading from '@/components/ui/loading';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { FadedScrollArea } from '@/components/ui/faded-scroll-area';
+import Hint from '@/components/ui/hint';
+import { useOptionalSidebar } from '@/components/ui/sidebar';
 import { Skeleton } from '@/components/ui/skeleton';
-import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
-import { errorToast, successToast } from '@/components/ui/toast';
-import { Icon } from '@/features/icon/icon';
+import { errorToast, successToast, warningToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
-import CustomizeSectionWrapper from '@/features/workspace/customize/sections/component/section-wrapper';
 import { RenameSessionModal } from '@/features/workspace/project-sidebar/modal/rename-session-modal';
 import { SessionDeleteModal } from '@/features/workspace/project-sidebar/modal/session-delete-modal';
+import { ShareSessionModal } from '@/features/workspace/project-sidebar/modal/share-session-modal';
 import {
-  sessionVisibilityMeta,
-  ShareSessionModal,
-} from '@/features/workspace/project-sidebar/modal/share-session-modal';
-import {
-  getSessionDisplayTitle,
   sessionLastActivityAt,
   shouldPollProjectSessions,
 } from '@/features/workspace/project-sidebar/project-session-list-helpers';
@@ -40,71 +20,48 @@ import { useIsCreatingProjectSession } from '@/hooks/projects/new-session-guard'
 import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { cn } from '@/lib/utils';
 import {
+  deleteProjectSession,
   listProjectSessions,
   restartProjectSession,
   stopProjectSession,
   type ProjectSession,
-  type ProjectSessionStatus,
 } from '@kortix/sdk';
 import {
-  ArrowCounterClockwiseIcon as RotateCcw,
-  ArrowSquareOutIcon as ExternalLink,
-  CalendarDotsIcon as CalendarClock,
-  CaretDownIcon as ChevronDown,
-  ChatIcon as MessageSquare,
-  DotsThreeIcon as MoreHorizontal,
-  EnvelopeIcon as Mail,
-  GitBranchIcon as GitBranch,
-  MagnifyingGlassIcon as Search,
-  PencilSimpleIcon,
-  PlusIcon as Plus,
-  ShareNetworkIcon as Share,
-  SquareIcon as Square,
-  TrashIcon,
-  WarningIcon as AlertTriangle,
-  WebhooksLogoIcon as Webhook,
+  ChatIcon,
+  MagnifyingGlassIcon,
+  SidebarSimpleIcon as PanelLeft,
+  PlusIcon,
 } from '@phosphor-icons/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { format, formatDistanceToNowStrict } from 'date-fns';
-import Link from 'next/link';
-import { useMemo, useState, type ComponentType } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
+  availableProjectSessionsFilters,
   filterProjectSessions,
-  PROJECT_SESSIONS_FILTERS,
-  projectSessionsFilterCounts,
-  sessionAccessMeta,
-  sessionOwnerLabel,
+  mapWithConcurrency,
+  pruneSelection,
+  sessionIsDeletable,
+  summarizeBulkDelete,
+  toggleSelection,
   type ProjectSessionsFilter,
 } from './project-sessions-helpers';
+import { SessionDetail } from './session-detail';
+import { SessionRow, type SessionRowActions } from './session-row';
+import { SessionsSelectionBar } from './sessions-selection-bar';
+import { SessionsToolbar } from './sessions-toolbar';
 
-const SOURCE_ICONS: Record<SessionSourceKind, ComponentType<{ className?: string }>> = {
-  chat: MessageSquare,
-  slack: Icon.Slack,
-  telegram: Icon.Telegram,
-  email: Mail,
-  schedule: CalendarClock,
-  webhook: Webhook,
-};
+/** Concurrent DELETEs during a bulk removal. There is no bulk endpoint, so a
+ *  27-session batch would otherwise open 27 sockets at once. */
+const DELETE_CONCURRENCY = 4;
 
-const STATUS_META: Record<
-  ProjectSessionStatus,
-  { label: string; variant: 'success' | 'warning' | 'muted' | 'destructive' | 'kortix' }
-> = {
-  queued: { label: 'Queued', variant: 'warning' },
-  branching: { label: 'Branching', variant: 'warning' },
-  provisioning: { label: 'Provisioning', variant: 'warning' },
-  running: { label: 'Running', variant: 'success' },
-  completed: { label: 'Completed', variant: 'kortix' },
-  stopped: { label: 'Stopped', variant: 'muted' },
-  failed: { label: 'Failed', variant: 'destructive' },
-};
+const SESSIONS_QUERY_KEY = (projectId: string) => ['project-session-inventory', projectId];
 
 function formatTimestamp(value: string): { relative: string; exact: string } {
   try {
     const date = new Date(value);
     return {
-      relative: formatDistanceToNowStrict(date, { addSuffix: true }),
+      relative: formatDistanceToNowStrict(date, { addSuffix: false }),
       exact: format(date, 'MMM d, yyyy, h:mm a'),
     };
   } catch {
@@ -115,296 +72,63 @@ function formatTimestamp(value: string): { relative: string; exact: string } {
 function SessionListSkeleton() {
   return (
     <div className="space-y-2" aria-hidden>
-      {Array.from({ length: 6 }).map((_, index) => (
-        <div key={index} className="bg-popover flex items-center gap-3 rounded-md border px-4 py-3">
-          <Skeleton className="size-9 shrink-0 rounded-sm" />
-          <div className="min-w-0 flex-1 space-y-1.5">
-            <Skeleton className={cn('h-3.5 rounded-sm', index % 2 ? 'w-44' : 'w-64')} />
-            <Skeleton className="h-3 w-36 rounded-sm" />
-          </div>
-          <Skeleton className="h-5 w-16 rounded-full" />
+      {Array.from({ length: 8 }).map((_, index) => (
+        <div key={index} className="bg-popover flex h-11 items-center gap-3 rounded-md border px-3">
+          <Skeleton className="size-4 shrink-0 rounded-sm" />
+          <Skeleton className={cn('h-3.5 rounded-sm', index % 2 ? 'w-44' : 'w-64')} />
+          <Skeleton className="ml-auto h-3 w-14 rounded-sm" />
         </div>
       ))}
     </div>
   );
 }
 
-function DetailItem({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+/**
+ * Absolute top-left opener — same rules as project-home / session header.
+ * Inlined here (not via CustomizeSectionWrapper) so this page can own spacing
+ * and layout without the shared shell's constraints.
+ */
+function SessionsSidebarToggle() {
+  const sidebar = useOptionalSidebar();
+  if (!sidebar) return null;
+  if (!sidebar.isMobile && sidebar.state === 'expanded') return null;
+
+  const label =
+    sidebar.state === 'expanded'
+      ? 'Collapse sidebar'
+      : sidebar.peek
+        ? 'Pin sidebar'
+        : 'Open sidebar';
+
   return (
-    <div className="min-w-0 space-y-1">
-      <dt className="text-muted-foreground text-xs">{label}</dt>
-      <dd
-        className={cn(
-          'text-foreground text-sm break-words',
-          mono && 'font-mono text-xs tabular-nums',
-        )}
+    <Hint label={label} side="bottom">
+      <Button
+        type="button"
+        aria-label={label}
+        variant="ghost"
+        size="icon"
+        onClick={sidebar.toggleSidebar}
+        onPointerEnter={sidebar.state === 'collapsed' ? sidebar.peekEnter : undefined}
+        onPointerLeave={sidebar.state === 'collapsed' ? sidebar.peekLeave : undefined}
+        className="hover:bg-sidebar-accent hover:text-sidebar-foreground absolute top-2 left-2 z-20 shrink-0 cursor-pointer items-center justify-center rounded-md transition-[color,background-color,transform] duration-150 ease-out active:scale-[0.96]"
       >
-        {value}
-      </dd>
-    </div>
-  );
-}
-
-function SessionRow({
-  projectId,
-  session,
-  onRename,
-  onShare,
-  onDelete,
-  onRestart,
-  onStop,
-  restarting,
-  stopping,
-}: {
-  projectId: string;
-  session: ProjectSession;
-  onRename: (sessionId: string, currentName: string) => void;
-  onShare: (session: ProjectSession) => void;
-  onDelete: (sessionId: string, label: string) => void;
-  onRestart: (sessionId: string, label: string) => void;
-  onStop: (sessionId: string, label: string) => void;
-  restarting: boolean;
-  stopping: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const title = getSessionDisplayTitle(session);
-  const source = sessionSource(session);
-  const SourceIcon = SOURCE_ICONS[source.kind];
-  const status = STATUS_META[session.status];
-  const visibility = sessionVisibilityMeta(session);
-  const ownerLabel = sessionOwnerLabel(session);
-  const access = sessionAccessMeta(session);
-  const isDeleted = Boolean(session.deleted_at);
-  const canManageSharing = session.can_manage_sharing !== false && !isDeleted;
-  const hasLifecycleActions = access.canOpen && !isDeleted;
-  const hasActions = canManageSharing || hasLifecycleActions;
-  const ownerTypeLabel =
-    session.owner_type === 'user'
-      ? 'Person'
-      : session.owner_type === 'service_account'
-        ? 'Agent / service account'
-        : session.owner_type === 'unknown'
-          ? 'Unknown principal'
-          : 'Unattributed';
-  const created = formatTimestamp(session.created_at);
-  const updated = formatTimestamp(sessionLastActivityAt(session));
-  const conversationCount = (session.opencode_sessions ?? []).length;
-  const archivedConversationCount = (session.opencode_sessions ?? []).filter(
-    (item) => item.archived_at,
-  ).length;
-  const href = `/projects/${projectId}/sessions/${session.session_id}`;
-
-  return (
-    <Disclosure
-      open={open}
-      onOpenChange={setOpen}
-      variant="outline"
-      className="group/session bg-popover overflow-hidden"
-    >
-      <DisclosureTrigger variant="outline">
-        <button
-          type="button"
-          className="hover:bg-muted/40 flex min-h-16 w-full cursor-pointer items-center gap-3 rounded-md px-4 py-3 text-left transition-colors duration-150"
-          aria-label={`${open ? 'Hide' : 'Show'} details for ${title}`}
-        >
-          <span className="bg-kortix-base/20 flex size-9 shrink-0 items-center justify-center rounded-sm">
-            <SourceIcon className="text-foreground size-5" />
-          </span>
-
-          <span className="min-w-0 flex-1">
-            <span className="flex min-w-0 flex-wrap items-center gap-1.5">
-              <span className="text-foreground max-w-full truncate text-sm font-medium">
-                {title}
-              </span>
-              {isDeleted ? (
-                <Badge variant="destructive" size="xs">
-                  Deleted
-                </Badge>
-              ) : session.can_access === false ? (
-                <Badge variant="outline" size="xs">
-                  Metadata only
-                </Badge>
-              ) : session.is_owner === false ? (
-                <Badge variant="kortix" size="xs">
-                  Shared
-                </Badge>
-              ) : null}
-            </span>
-            <span className="text-muted-foreground mt-1 flex min-w-0 flex-wrap items-center gap-1.5 text-xs">
-              <span>
-                {source.triggerSlug ? `${source.label} · ${source.triggerSlug}` : source.label}
-              </span>
-              <span className="text-muted-foreground/40">&bull;</span>
-              <span className="truncate">{ownerLabel}</span>
-              <span className="text-muted-foreground/40">&bull;</span>
-              <span className="tabular-nums" title={updated.exact}>
-                {updated.relative}
-              </span>
-            </span>
-          </span>
-
-          <Badge variant={status.variant} size="sm" className="hidden sm:inline-flex">
-            {status.label}
-          </Badge>
-          <ChevronDown className="text-muted-foreground size-4 shrink-0 transition-transform duration-150 ease-out group-data-[state=open]/session:rotate-180" />
-        </button>
-      </DisclosureTrigger>
-
-      <DisclosureContent variant="outline" contentClassName="border-border border-t">
-        <div className="space-y-5 px-4 py-5">
-          <div className="flex flex-wrap items-center gap-2 sm:hidden">
-            <Badge variant={status.variant} size="sm">
-              {status.label}
-            </Badge>
-            <Badge variant="outline" size="sm">
-              {visibility.label}
-            </Badge>
-          </div>
-
-          <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
-            <DetailItem label="Last activity" value={updated.exact} />
-            <DetailItem label="Status" value={status.label} />
-            <DetailItem
-              label="Source"
-              value={source.triggerSlug ? `${source.label} · ${source.triggerSlug}` : source.label}
-            />
-            <DetailItem label="Session / resource owner" value={ownerLabel} />
-            <DetailItem label="Owner identity" value={ownerTypeLabel} />
-            <DetailItem
-              label="Owner ID"
-              value={session.created_by || 'Unattributed'}
-              mono={Boolean(session.created_by)}
-            />
-            <DetailItem label="Your access" value={access.label} />
-            <DetailItem label="Visibility" value={visibility.label} />
-            <DetailItem label="Created" value={created.exact} />
-            <DetailItem label="Agent" value={session.agent_name || 'Project default'} />
-            <DetailItem label="Runtime" value={session.sandbox_provider || 'Not provisioned'} />
-            <DetailItem
-              label="Runtime resource state"
-              value={session.runtime_status || 'Missing'}
-            />
-            <DetailItem
-              label="Conversations"
-              value={`${conversationCount} OpenCode session${conversationCount === 1 ? '' : 's'}${
-                archivedConversationCount > 0 ? ` · ${archivedConversationCount} archived` : ''
-              }`}
-            />
-            <DetailItem label="Base ref" value={session.base_ref || 'Default branch'} mono />
-            <DetailItem label="Branch" value={session.branch_name || 'Not created'} mono />
-            <DetailItem label="Session ID" value={session.session_id} mono />
-            <DetailItem label="Sandbox ID" value={session.sandbox_id || 'Missing'} mono />
-            <DetailItem
-              label="Root conversation ID"
-              value={session.opencode_session_id || 'Not synced'}
-              mono
-            />
-          </dl>
-
-          {session.error ? (
-            <InfoBanner tone="destructive" icon={AlertTriangle} title="Session error">
-              <span className="break-words">{session.error}</span>
-            </InfoBanner>
-          ) : null}
-
-          {isDeleted ? (
-            <InfoBanner tone="neutral" title="Soft-deleted session">
-              <span>
-                Deleted{' '}
-                {session.deleted_at
-                  ? formatTimestamp(session.deleted_at).exact
-                  : 'at an unknown time'}
-                {session.deleted_by ? ` by ${session.deleted_by}` : ''}. The durable record remains
-                visible here for investigation.
-              </span>
-            </InfoBanner>
-          ) : session.can_access === false ? (
-            <InfoBanner tone="neutral" title="Metadata-only access">
-              You can inspect this inventory record, but the owner has not shared the session
-              content with you.
-            </InfoBanner>
-          ) : null}
-
-          <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
-            <div className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs">
-              <GitBranch className="size-3.5 shrink-0" />
-              <span className="truncate font-mono">
-                {session.branch_name || session.session_id}
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              {access.canOpen ? (
-                <Button variant="outline" size="sm" asChild>
-                  <Link href={href}>
-                    Open session
-                    <ExternalLink className="size-3.5 shrink-0" />
-                  </Link>
-                </Button>
-              ) : (
-                <Button variant="outline" size="sm" disabled>
-                  {access.label}
-                </Button>
-              )}
-              {hasActions ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button type="button" variant="secondary" size="sm">
-                      <MoreHorizontal className="size-3.5 shrink-0" />
-                      Actions
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-44">
-                    {hasLifecycleActions ? (
-                      <DropdownMenuItem onSelect={() => onRename(session.session_id, title)}>
-                        <PencilSimpleIcon />
-                        Rename
-                      </DropdownMenuItem>
-                    ) : null}
-                    {canManageSharing ? (
-                      <DropdownMenuItem onSelect={() => onShare(session)}>
-                        <Share />
-                        Share
-                      </DropdownMenuItem>
-                    ) : null}
-                    {hasLifecycleActions ? (
-                      <DropdownMenuItem
-                        disabled={restarting}
-                        onSelect={() => onRestart(session.session_id, title)}
-                      >
-                        {restarting ? <Loading className="size-4 shrink-0" /> : <RotateCcw />}
-                        Restart
-                      </DropdownMenuItem>
-                    ) : null}
-                    {session.status === 'running' && hasLifecycleActions ? (
-                      <DropdownMenuItem
-                        disabled={stopping}
-                        onSelect={() => onStop(session.session_id, title)}
-                      >
-                        {stopping ? <Loading className="size-4 shrink-0" /> : <Square />}
-                        Stop
-                      </DropdownMenuItem>
-                    ) : null}
-                    {hasLifecycleActions ? (
-                      <DropdownMenuItem onSelect={() => onDelete(session.session_id, title)}>
-                        <TrashIcon />
-                        Delete
-                      </DropdownMenuItem>
-                    ) : null}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : null}
-            </div>
-          </div>
-        </div>
-      </DisclosureContent>
-    </Disclosure>
+        <PanelLeft className="cn-rtl-flip size-4" />
+      </Button>
+    </Hint>
   );
 }
 
 export function ProjectSessionsView({ projectId }: { projectId: string }) {
   const queryClient = useQueryClient();
+  const sidebar = useOptionalSidebar();
+  const showSidebarToggle = sidebar != null && (sidebar.isMobile || sidebar.state !== 'expanded');
   const [filter, setFilter] = useState<ProjectSessionsFilter>('all');
   const [search, setSearch] = useState('');
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
   const [sessionToRename, setSessionToRename] = useState<{ id: string; name: string } | null>(null);
   const [sessionToShare, setSessionToShare] = useState<ProjectSession | null>(null);
   const [sessionToDelete, setSessionToDelete] = useState<{ id: string; label: string } | null>(
@@ -414,28 +138,90 @@ export function ProjectSessionsView({ projectId }: { projectId: string }) {
   const creatingSession = useIsCreatingProjectSession(projectId);
 
   const sessionsQuery = useQuery({
-    queryKey: ['project-session-inventory', projectId],
+    queryKey: SESSIONS_QUERY_KEY(projectId),
     queryFn: () => listProjectSessions(projectId, { scope: 'project' }),
     staleTime: 10_000,
     refetchInterval: (query) =>
       shouldPollProjectSessions(query.state.data as ProjectSession[] | undefined) ? 5_000 : false,
-    refetchOnWindowFocus: false,
+    // The poll stops once every session settles, so without this a session
+    // deleted from another surface would linger here indefinitely.
+    refetchOnWindowFocus: true,
   });
 
+  const invalidateSessions = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: SESSIONS_QUERY_KEY(projectId) });
+    queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+  }, [projectId, queryClient]);
+
   const sessions = useMemo(() => sessionsQuery.data ?? [], [sessionsQuery.data]);
-  const counts = useMemo(() => projectSessionsFilterCounts(sessions), [sessions]);
   const visibleSessions = useMemo(
     () => filterProjectSessions(sessions, filter, search),
     [sessions, filter, search],
   );
+  const filterGroups = useMemo(
+    () => availableProjectSessionsFilters(sessions, filter),
+    [sessions, filter],
+  );
+  const timestamps = useMemo(() => {
+    const map = new Map<string, { relative: string; exact: string }>();
+    for (const session of sessions) {
+      map.set(session.session_id, formatTimestamp(sessionLastActivityAt(session)));
+    }
+    return map;
+  }, [sessions]);
+
+  const selectableSessions = useMemo(
+    () => visibleSessions.filter(sessionIsDeletable),
+    [visibleSessions],
+  );
+
+  // Selection must never outlive its own visibility: narrowing the filter after
+  // selecting would otherwise leave "N selected" counting off-screen rows, and
+  // "Delete N" would destroy sessions the user cannot see.
+  useEffect(() => {
+    setSelected((current) =>
+      current.size === 0 ? current : pruneSelection(current, visibleSessions),
+    );
+  }, [visibleSessions]);
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelected(new Set());
+  }, []);
+
+  useEffect(() => {
+    if (!selectMode) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') exitSelectMode();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [selectMode, exitSelectMode]);
+
+  // "/" focuses search, the way it does in the rest of the product.
+  useEffect(() => {
+    if (searchOpen || selectMode) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== '/' || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.isContentEditable ||
+        ['INPUT', 'TEXTAREA', 'SELECT'].includes(target?.tagName ?? '')
+      )
+        return;
+      event.preventDefault();
+      setSearchOpen(true);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [searchOpen, selectMode]);
 
   const restartMutation = useMutation({
     mutationFn: ({ sessionId }: { sessionId: string; label: string }) =>
       restartProjectSession(projectId, sessionId),
     onSuccess: (_data, { label }) => {
       successToast(`Restarting "${label}"…`);
-      queryClient.invalidateQueries({ queryKey: ['project-session-inventory', projectId] });
-      queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+      invalidateSessions();
     },
     onError: (error) =>
       errorToast(error instanceof Error ? error.message : 'Failed to restart session'),
@@ -446,159 +232,248 @@ export function ProjectSessionsView({ projectId }: { projectId: string }) {
       stopProjectSession(projectId, sessionId),
     onSuccess: (_data, { label }) => {
       successToast(`"${label}" stopped`);
-      queryClient.invalidateQueries({ queryKey: ['project-session-inventory', projectId] });
-      queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+      invalidateSessions();
     },
     onError: (error) =>
       errorToast(error instanceof Error ? error.message : 'Failed to stop session'),
   });
 
-  const action = (
-    <Button
-      type="button"
-      size="sm"
-      variant="secondary"
-      className="gap-1.5"
-      onClick={() => newSession()}
-      disabled={creatingSession}
-      aria-busy={creatingSession}
-    >
-      <Plus className="size-4 shrink-0" />
-      New session
-    </Button>
+  const bulkDeleteMutation = useMutation({
+    mutationFn: async (sessionIds: string[]) => {
+      const results = await mapWithConcurrency(
+        sessionIds,
+        DELETE_CONCURRENCY,
+        async (sessionId) => {
+          try {
+            await deleteProjectSession(projectId, sessionId);
+            return { sessionId, ok: true };
+          } catch {
+            return { sessionId, ok: false };
+          }
+        },
+      );
+      return summarizeBulkDelete(results);
+    },
+    onSuccess: (summary) => {
+      // Partial failure is a real outcome, not an error. Reporting "Deleted 7"
+      // while two rows survive is worse than reporting nothing.
+      if (summary.failed.length === 0) successToast(summary.message);
+      else if (summary.succeeded.length === 0) errorToast(summary.message);
+      else warningToast(summary.message);
+
+      setBulkConfirmOpen(false);
+      exitSelectMode();
+      invalidateSessions();
+    },
+    onError: (error) => {
+      errorToast(error instanceof Error ? error.message : 'Failed to delete sessions');
+      setBulkConfirmOpen(false);
+    },
+  });
+
+  const rowActions: SessionRowActions = useMemo(
+    () => ({
+      onRename: (id, name) => setSessionToRename({ id, name }),
+      onShare: setSessionToShare,
+      onDelete: (id, label) => setSessionToDelete({ id, label }),
+      onRestart: (sessionId, label) => restartMutation.mutate({ sessionId, label }),
+      onStop: (sessionId, label) => stopMutation.mutate({ sessionId, label }),
+    }),
+    [restartMutation, stopMutation],
+  );
+
+  const allSelected = selectableSessions.length > 0 && selected.size === selectableSessions.length;
+
+  const header = selectMode ? (
+    <SessionsSelectionBar
+      selectedCount={selected.size}
+      selectableCount={selectableSessions.length}
+      allSelected={allSelected}
+      onSelectAll={() =>
+        setSelected(new Set(selectableSessions.map((session) => session.session_id)))
+      }
+      onClearSelection={() => setSelected(new Set())}
+      onExit={exitSelectMode}
+      onDelete={() => setBulkConfirmOpen(true)}
+      deleting={bulkDeleteMutation.isPending}
+    />
+  ) : (
+    <SessionsToolbar
+      filter={filter}
+      onFilterChange={setFilter}
+      groups={filterGroups}
+      search={search}
+      onSearchChange={setSearch}
+      searchOpen={searchOpen}
+      onSearchOpenChange={setSearchOpen}
+      onEnterSelectMode={() => setSelectMode(true)}
+      onNewSession={() => newSession()}
+      creatingSession={creatingSession}
+      canSelect={sessions.length > 0}
+    />
   );
 
   return (
-    <CustomizeSectionWrapper
-      title="Sessions"
-      description="Manager inventory of every durable session and its owner, access, and runtime state."
-      action={action}
-      className="max-w-5xl"
-    >
-      <div className="space-y-4">
-        <InputGroupSearch>
-          <InputGroupSearchIcon>
-            <Search />
-          </InputGroupSearchIcon>
-          <InputGroupSearchInput
-            variant="popover"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Search by title, owner, source, branch, agent, or ID"
-            aria-label="Search sessions"
-          />
-          {search ? <InputGroupSearchClear onClick={() => setSearch('')} /> : null}
-        </InputGroupSearch>
-
-        <div className="[scrollbar-width:none] overflow-x-auto pb-1 [&::-webkit-scrollbar]:hidden">
-          <FilterBar className="h-8 rounded-md">
-            {PROJECT_SESSIONS_FILTERS.map((option) => (
-              <FilterBarItem
-                key={option.value}
-                className="h-[calc(100%-4px)] rounded-[calc(var(--radius)-3px)] px-2.5 text-xs"
-                data-state={filter === option.value ? 'active' : 'inactive'}
-                aria-selected={filter === option.value}
-                onClick={() => setFilter(option.value)}
-              >
-                {option.label}
-                <span className="tabular-nums">{counts[option.value]}</span>
-              </FilterBarItem>
-            ))}
-          </FilterBar>
-        </div>
-
-        {sessionsQuery.isLoading ? (
-          <SessionListSkeleton />
-        ) : sessionsQuery.isError ? (
-          <ErrorState
-            size="sm"
-            title="Sessions could not be loaded"
-            description={
-              sessionsQuery.error instanceof Error ? sessionsQuery.error.message : undefined
-            }
-            action={
-              <Button variant="outline" size="sm" onClick={() => sessionsQuery.refetch()}>
-                Retry
-              </Button>
-            }
-          />
-        ) : sessions.length === 0 ? (
-          <EmptyState
-            size="sm"
-            icon={MessageSquare}
-            title="No sessions yet"
-            description="Start a session to give this project its first task."
-            action={
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                onClick={() => newSession()}
-                disabled={creatingSession}
-                aria-busy={creatingSession}
-              >
-                <Plus className="size-3.5 shrink-0" />
-                New session
-              </Button>
-            }
-          />
-        ) : visibleSessions.length === 0 ? (
-          <EmptyState
-            size="sm"
-            icon={Search}
-            title="No matching sessions"
-            description="Try another search or clear the current filter."
-            action={
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setFilter('all');
-                  setSearch('');
-                }}
-              >
-                Clear filters
-              </Button>
-            }
-          />
-        ) : (
-          <div className="space-y-2" aria-live="polite">
-            <p className="text-muted-foreground text-xs tabular-nums">
-              Showing {visibleSessions.length} of {sessions.length}{' '}
-              {sessions.length === 1 ? 'session' : 'sessions'}
-            </p>
-            {visibleSessions.map((session) => (
-              <SessionRow
-                key={session.session_id}
-                projectId={projectId}
-                session={session}
-                onRename={(id, name) => setSessionToRename({ id, name })}
-                onShare={setSessionToShare}
-                onDelete={(id, label) => setSessionToDelete({ id, label })}
-                onRestart={(sessionId, label) => restartMutation.mutate({ sessionId, label })}
-                onStop={(sessionId, label) => stopMutation.mutate({ sessionId, label })}
-                restarting={
-                  restartMutation.isPending &&
-                  restartMutation.variables?.sessionId === session.session_id
-                }
-                stopping={
-                  stopMutation.isPending && stopMutation.variables?.sessionId === session.session_id
-                }
-              />
-            ))}
+    <>
+      {/* Fixed shell: the header is a non-scrolling band and the list below it
+          owns the only scroll container on the page. `overflow-hidden` here
+          stops the app shell from scrolling when the list grows. */}
+      <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
+        <SessionsSidebarToggle />
+        <header
+          className={cn(
+            'mx-auto w-full max-w-4xl shrink-0 px-4 pt-10 pb-5 lg:pt-20',
+            'flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between',
+          )}
+        >
+          <div className="space-y-1">
+            <h2 className="text-foreground text-xl font-medium">Sessions</h2>
           </div>
-        )}
+          <div className="mt-2 shrink-0 sm:mt-0">{header}</div>
+        </header>
+
+        <div className={cn('mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col px-4 pb-4')}>
+          {sessionsQuery.isLoading ? (
+            <div className="pt-4">
+              <SessionListSkeleton />
+            </div>
+          ) : sessionsQuery.isError ? (
+            <ErrorState
+              size="sm"
+              title="Sessions could not be loaded"
+              description={
+                sessionsQuery.error instanceof Error ? sessionsQuery.error.message : undefined
+              }
+              action={
+                <Button variant="outline" size="sm" onClick={() => sessionsQuery.refetch()}>
+                  Retry
+                </Button>
+              }
+            />
+          ) : sessions.length === 0 ? (
+            <EmptyState
+              size="sm"
+              icon={ChatIcon}
+              title="No sessions yet"
+              description="Start a session to give this project its first task."
+              action={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => newSession()}
+                  disabled={creatingSession}
+                  aria-busy={creatingSession}
+                >
+                  <PlusIcon className="size-3.5 shrink-0" />
+                  New session
+                </Button>
+              }
+            />
+          ) : visibleSessions.length === 0 ? (
+            <EmptyState
+              size="sm"
+              icon={MagnifyingGlassIcon}
+              title="No matching sessions"
+              description="Try another search or clear the current filter."
+              action={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setFilter('all');
+                    setSearch('');
+                  }}
+                >
+                  Clear filters
+                </Button>
+              }
+            />
+          ) : (
+            /* The list gets a containing block whose height cannot depend on
+                   its children. `FadedScrollArea` sizes its outer element with
+                   `h-full`, and `height: 100%` only resolves against a definite
+                   height — inside a flex chain still being measured from content it
+                   resolves to `auto`, so the component grows to fit every row and
+                   the whole app shell scrolls instead of the list. An
+                   `absolute inset-0` layer is out of flow, so this parent
+                   contributes no content height and takes only what flexbox gives
+                   it, which makes the percentage definite. */
+            <div className="relative min-h-0 flex-1">
+              <div className="absolute inset-0">
+                <FadedScrollArea fadeColor="from-background" className="pt-4">
+                  <div className="space-y-2 pb-6" aria-live="polite">
+                    {visibleSessions.map((session) => {
+                      const time = timestamps.get(session.session_id) ?? {
+                        relative: '',
+                        exact: '',
+                      };
+                      const isOpen = expanded === session.session_id;
+                      return (
+                        <SessionRow
+                          key={session.session_id}
+                          session={session}
+                          time={time}
+                          open={isOpen}
+                          onOpenChange={(open) => setExpanded(open ? session.session_id : null)}
+                          selectMode={selectMode}
+                          selected={selected.has(session.session_id)}
+                          onToggleSelect={(id) =>
+                            setSelected((current) => toggleSelection(current, id))
+                          }
+                          restarting={
+                            restartMutation.isPending &&
+                            restartMutation.variables?.sessionId === session.session_id
+                          }
+                          stopping={
+                            stopMutation.isPending &&
+                            stopMutation.variables?.sessionId === session.session_id
+                          }
+                          actions={rowActions}
+                        >
+                          {/* Mounted only while expanded — 27 collapsed detail grids
+                              would otherwise all format timestamps on every render. */}
+                          {isOpen ? (
+                            <SessionDetail
+                              projectId={projectId}
+                              session={session}
+                              formatted={{
+                                created: formatTimestamp(session.created_at).exact,
+                                updated: time.exact,
+                                deleted: session.deleted_at
+                                  ? formatTimestamp(session.deleted_at).exact
+                                  : null,
+                              }}
+                            />
+                          ) : null}
+                        </SessionRow>
+                      );
+                    })}
+                  </div>
+                </FadedScrollArea>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
+
+      <ConfirmDialog
+        open={bulkConfirmOpen}
+        onOpenChange={(open) => !bulkDeleteMutation.isPending && setBulkConfirmOpen(open)}
+        title={`Delete ${selected.size} ${selected.size === 1 ? 'session' : 'sessions'}?`}
+        description="This permanently destroys each session's branch and sandbox. It cannot be undone."
+        confirmLabel={`Delete ${selected.size}`}
+        confirmVariant="destructive"
+        isPending={bulkDeleteMutation.isPending}
+        onConfirm={() => bulkDeleteMutation.mutate([...selected])}
+      />
 
       <ShareSessionModal
         projectId={projectId}
         session={sessionToShare}
         open={!!sessionToShare}
         onOpenChange={(open) => !open && setSessionToShare(null)}
-        onSaved={() => {
-          queryClient.invalidateQueries({ queryKey: ['project-session-inventory', projectId] });
-          queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
-        }}
+        onSaved={invalidateSessions}
       />
       <RenameSessionModal
         projectId={projectId}
@@ -613,7 +488,11 @@ export function ProjectSessionsView({ projectId }: { projectId: string }) {
         sessionLabel={sessionToDelete?.label}
         open={!!sessionToDelete}
         onOpenChange={(open) => !open && setSessionToDelete(null)}
+        // Without this the modal invalidates only ['project-sessions'], and the
+        // deleted row survives here until the next poll — which never comes once
+        // every session has settled.
+        onDeleted={invalidateSessions}
       />
-    </CustomizeSectionWrapper>
+    </>
   );
 }

--- a/apps/web/src/features/workspace/project-sessions/session-detail.tsx
+++ b/apps/web/src/features/workspace/project-sessions/session-detail.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { InfoBanner } from '@/components/ui/info-banner';
+import { cn } from '@/lib/utils';
+import type { ProjectSession } from '@kortix/sdk';
+import { ArrowSquareOutIcon, WarningIcon } from '@phosphor-icons/react';
+import Link from 'next/link';
+
+import {
+  sessionAccessMeta,
+  sessionDetailFields,
+  type SessionDetailField,
+} from './project-sessions-helpers';
+
+function DetailItem({ label, value, mono }: SessionDetailField) {
+  return (
+    <div className="min-w-0 space-y-1">
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd
+        className={cn(
+          'text-foreground text-sm break-words',
+          mono && 'font-mono text-xs tabular-nums',
+        )}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+export function SessionDetail({
+  projectId,
+  session,
+  formatted,
+}: {
+  projectId: string;
+  session: ProjectSession;
+  formatted: { created: string; updated: string; deleted: string | null };
+}) {
+  const access = sessionAccessMeta(session);
+  const fields = sessionDetailFields(session, formatted);
+  const href = `/projects/${projectId}/sessions/${session.session_id}`;
+
+  return (
+    <div className="space-y-5 px-4 py-5">
+      <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
+        {fields.map((field) => (
+          <DetailItem key={field.label} {...field} />
+        ))}
+      </dl>
+
+      {session.error ? (
+        <InfoBanner tone="destructive" icon={WarningIcon} title="Session error">
+          <span className="break-words">{session.error}</span>
+        </InfoBanner>
+      ) : null}
+
+      {session.deleted_at ? (
+        <InfoBanner tone="neutral" title="Soft-deleted session">
+          <span>
+            Deleted {formatted.deleted ?? 'at an unknown time'}
+            {session.deleted_by ? ` by ${session.deleted_by}` : ''}. The durable record stays here
+            for investigation.
+          </span>
+        </InfoBanner>
+      ) : session.can_access === false ? (
+        <InfoBanner tone="neutral" title="Metadata-only access">
+          You can inspect this record, but the owner has not shared the session content with you.
+        </InfoBanner>
+      ) : null}
+
+      {access.canOpen ? (
+        <div className="flex justify-end border-t pt-4">
+          <Button variant="outline" size="sm" asChild>
+            <Link href={href}>
+              Open session
+              <ArrowSquareOutIcon className="size-3.5 shrink-0" />
+            </Link>
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/workspace/project-sessions/session-row.tsx
+++ b/apps/web/src/features/workspace/project-sessions/session-row.tsx
@@ -1,0 +1,362 @@
+'use client';
+
+import { sessionSource, type SessionSourceKind } from '@/components/projects/session-label';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import Loading from '@/components/ui/loading';
+import { Icon } from '@/features/icon/icon';
+import {
+  getSessionDisplayTitle,
+  shortRelative,
+} from '@/features/workspace/project-sidebar/project-session-list-helpers';
+import { cn } from '@/lib/utils';
+import type { ProjectSession, ProjectSessionStatus } from '@kortix/sdk';
+import {
+  ArrowCounterClockwiseIcon,
+  CalendarDotsIcon,
+  ChatTeardropTextIcon,
+  DotsThreeIcon,
+  EnvelopeIcon,
+  PencilSimpleIcon,
+  ShareNetworkIcon,
+  SquareIcon,
+  TrashIcon,
+  WebhooksLogoIcon,
+} from '@phosphor-icons/react';
+import { useState, type ComponentType, type ReactNode } from 'react';
+
+import { sessionAccessMeta } from './project-sessions-helpers';
+
+/** Fixed slot shared by relative time and the ⋯ trigger — same overlay swap as
+ *  the sidebar session list so the row never reflows on hover. */
+const SESSION_RELATIVE_TIME_CLASS =
+  'text-muted-foreground block w-10 min-w-10 max-w-10 shrink-0 truncate text-right text-xs tabular-nums';
+
+const SOURCE_ICONS: Record<SessionSourceKind, ComponentType<{ className?: string }>> = {
+  chat: ChatTeardropTextIcon,
+  slack: Icon.Slack,
+  telegram: Icon.Telegram,
+  email: EnvelopeIcon,
+  schedule: CalendarDotsIcon,
+  webhook: WebhooksLogoIcon,
+};
+
+interface StatusTile {
+  label: string;
+  tile: string;
+  icon: string;
+}
+
+/** Resting / idle — secondary surface, muted icon. Matches design-system idle. */
+const SECONDARY_TILE: Pick<StatusTile, 'tile' | 'icon'> = {
+  tile: 'bg-secondary',
+  icon: 'text-muted-foreground',
+};
+
+/**
+ * Status colour on the source-icon tile. Deleted wins over lifecycle status.
+ * Palette follows kortix design-system status tokens.
+ */
+function sessionStatusTile(
+  status: ProjectSessionStatus,
+  options: { deleted: boolean; metadataOnly: boolean },
+): StatusTile {
+  if (options.deleted) {
+    return { label: 'Deleted', tile: 'bg-kortix-red/15', icon: 'text-kortix-red' };
+  }
+  if (options.metadataOnly) {
+    return { label: 'Metadata only', ...SECONDARY_TILE };
+  }
+
+  switch (status) {
+    case 'running':
+      return { label: 'Running', tile: 'bg-kortix-green/15', icon: 'text-kortix-green' };
+    case 'queued':
+      return { label: 'Queued', tile: 'bg-kortix-yellow/15', icon: 'text-kortix-yellow' };
+    case 'branching':
+      return { label: 'Branching', tile: 'bg-kortix-yellow/15', icon: 'text-kortix-yellow' };
+    case 'provisioning':
+      return { label: 'Provisioning', tile: 'bg-kortix-yellow/15', icon: 'text-kortix-yellow' };
+    case 'failed':
+      return { label: 'Failed', tile: 'bg-kortix-red/15', icon: 'text-kortix-red' };
+    case 'completed':
+      return { label: 'Completed', ...SECONDARY_TILE };
+    case 'stopped':
+      return { label: 'Stopped', ...SECONDARY_TILE };
+    default: {
+      const _exhaustive: never = status;
+      throw new Error(`Unhandled session status: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+export interface SessionRowActions {
+  onRename: (sessionId: string, currentName: string) => void;
+  onShare: (session: ProjectSession) => void;
+  onDelete: (sessionId: string, label: string) => void;
+  onRestart: (sessionId: string, label: string) => void;
+  onStop: (sessionId: string, label: string) => void;
+}
+
+export interface SessionRowProps {
+  session: ProjectSession;
+  /** Preformatted last-activity stamp. Formatting stays in the container so
+   *  every row shares one `date-fns` pass instead of one per row. */
+  time: { relative: string; exact: string };
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectMode: boolean;
+  selected: boolean;
+  onToggleSelect: (sessionId: string) => void;
+  restarting: boolean;
+  stopping: boolean;
+  actions: SessionRowActions;
+  /** Detail panel — the container renders it only while expanded. */
+  children: ReactNode;
+}
+
+export function SessionRow({
+  session,
+  time,
+  open,
+  onOpenChange,
+  selectMode,
+  selected,
+  onToggleSelect,
+  restarting,
+  stopping,
+  actions,
+  children,
+}: SessionRowProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const title = getSessionDisplayTitle(session);
+  const source = sessionSource(session);
+  const SourceIcon = SOURCE_ICONS[source.kind];
+  const access = sessionAccessMeta(session);
+  const isDeleted = Boolean(session.deleted_at);
+  const canManageSharing = session.can_manage_sharing !== false && !isDeleted;
+  const hasLifecycleActions = access.canOpen && !isDeleted;
+  const hasActions = canManageSharing || hasLifecycleActions;
+  const relativeLabel = time.relative ? shortRelative(time.relative) : '';
+  const statusTile = sessionStatusTile(session.status, {
+    deleted: isDeleted,
+    metadataOnly: session.can_access === false,
+  });
+
+  const deferAfterClose = (fn: () => void) => {
+    setMenuOpen(false);
+    requestAnimationFrame(() => fn());
+  };
+
+  const identity = (
+    <>
+      <span
+        className={cn(
+          'flex size-8 shrink-0 items-center justify-center rounded-sm',
+          statusTile.tile,
+        )}
+        title={statusTile.label}
+        aria-label={statusTile.label}
+      >
+        <SourceIcon className={cn('size-4', statusTile.icon)} />
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm">
+        {title}
+        {source.triggerSlug ? (
+          <span className="text-muted-foreground"> · {source.triggerSlug}</span>
+        ) : null}
+      </span>
+    </>
+  );
+
+  if (selectMode) {
+    return (
+      // A label, not a button: the row wraps a real Checkbox, and nesting a
+      // button (Radix renders one) inside a button is invalid.
+      <label
+        className={cn(
+          'hover:bg-muted/40 flex h-11 w-full cursor-pointer items-center gap-3 rounded-md px-3 text-left',
+          'transition-colors duration-150',
+          'has-disabled:pointer-events-none has-disabled:opacity-50',
+          selected && 'bg-primary/[0.06]',
+        )}
+      >
+        <Checkbox
+          checked={selected}
+          disabled={isDeleted}
+          onCheckedChange={() => onToggleSelect(session.session_id)}
+          aria-label={title}
+          // The stock checked state is `bg-kortix-blue`, the exact accent this
+          // redesign removes; everything else about the control is inherited.
+          className="data-[state=checked]:border-foreground data-[state=checked]:bg-foreground"
+        />
+        {identity}
+        {relativeLabel ? (
+          <time
+            className={SESSION_RELATIVE_TIME_CLASS}
+            dateTime={time.exact}
+            title={`Last activity: ${time.exact}`}
+          >
+            {relativeLabel}
+          </time>
+        ) : null}
+      </label>
+    );
+  }
+
+  return (
+    <Disclosure
+      open={open}
+      onOpenChange={onOpenChange}
+      variant="outline"
+      className="group/session bg-popover overflow-hidden"
+    >
+      <DisclosureTrigger variant="outline">
+        {/* A div, not a button: DisclosureTrigger clones this child and applies
+            role="button" + tabIndex itself. Nesting a real button here would
+            produce button-in-button. */}
+        <div
+          aria-label={`${open ? 'Hide' : 'Show'} details for ${title}`}
+          className="hover:bg-muted/40 group/row flex w-full cursor-pointer items-center gap-3 rounded-md px-3 py-2 transition-colors duration-150"
+        >
+          {identity}
+
+          {/* Same fixed slot as the sidebar: relative time fades out on hover /
+              open menu; the ⋯ trigger fades in over the same w-10. */}
+          <div className="relative w-10 min-w-10 shrink-0">
+            {relativeLabel ? (
+              <time
+                className={cn(
+                  SESSION_RELATIVE_TIME_CLASS,
+                  'pr-1.5 transition-opacity duration-150',
+                  hasActions &&
+                    cn(
+                      'opacity-100 group-hover/row:opacity-0 group-has-data-[state=open]/row:opacity-0',
+                      // Touch has no hover — cede the slot to the always-visible ⋯.
+                      '[@media(hover:none)]:opacity-0',
+                    ),
+                )}
+                dateTime={time.exact}
+                title={`Last activity: ${time.exact}`}
+                aria-label={`Last activity: ${relativeLabel}`}
+              >
+                {relativeLabel}
+              </time>
+            ) : null}
+
+            {hasActions ? (
+              // Stops the row's toggle from firing when the menu is used.
+              <span
+                onClick={(event) => event.stopPropagation()}
+                onKeyDown={(event) => event.stopPropagation()}
+              >
+                <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label={`Actions for ${title}`}
+                      className={cn(
+                        'absolute top-1/2 right-0.5 -translate-y-1/2 transition-opacity duration-150',
+                        'focus:ring-0 focus-visible:ring-0 active:scale-[0.96]',
+                        relativeLabel
+                          ? cn(
+                              'pointer-events-none opacity-0',
+                              'group-hover/row:pointer-events-auto group-hover/row:opacity-100',
+                              'data-[state=open]:pointer-events-auto data-[state=open]:opacity-100',
+                              // Touch has no hover — keep the only path visible.
+                              '[@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100',
+                            )
+                          : 'opacity-100',
+                      )}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                      }}
+                    >
+                      <DotsThreeIcon className="size-3.5 shrink-0" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-44">
+                    {hasLifecycleActions ? (
+                      <DropdownMenuItem
+                        className="cursor-pointer"
+                        onSelect={() =>
+                          deferAfterClose(() => actions.onRename(session.session_id, title))
+                        }
+                      >
+                        <PencilSimpleIcon />
+                        Rename
+                      </DropdownMenuItem>
+                    ) : null}
+                    {canManageSharing ? (
+                      <DropdownMenuItem
+                        className="cursor-pointer"
+                        onSelect={() => deferAfterClose(() => actions.onShare(session))}
+                      >
+                        <ShareNetworkIcon />
+                        Share
+                      </DropdownMenuItem>
+                    ) : null}
+                    {hasLifecycleActions ? (
+                      <DropdownMenuItem
+                        className="cursor-pointer"
+                        disabled={restarting}
+                        onSelect={() =>
+                          deferAfterClose(() => actions.onRestart(session.session_id, title))
+                        }
+                      >
+                        {restarting ? (
+                          <Loading className="size-4 shrink-0" />
+                        ) : (
+                          <ArrowCounterClockwiseIcon />
+                        )}
+                        Restart
+                      </DropdownMenuItem>
+                    ) : null}
+                    {session.status === 'running' && hasLifecycleActions ? (
+                      <DropdownMenuItem
+                        className="cursor-pointer"
+                        disabled={stopping}
+                        onSelect={() =>
+                          deferAfterClose(() => actions.onStop(session.session_id, title))
+                        }
+                      >
+                        {stopping ? <Loading className="size-4 shrink-0" /> : <SquareIcon />}
+                        Stop
+                      </DropdownMenuItem>
+                    ) : null}
+                    {hasLifecycleActions ? (
+                      <DropdownMenuItem
+                        className="cursor-pointer"
+                        variant="destructive"
+                        onSelect={() =>
+                          deferAfterClose(() => actions.onDelete(session.session_id, title))
+                        }
+                      >
+                        <TrashIcon />
+                        Delete
+                      </DropdownMenuItem>
+                    ) : null}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </DisclosureTrigger>
+
+      <DisclosureContent variant="outline" contentClassName="border-border border-t">
+        {children}
+      </DisclosureContent>
+    </Disclosure>
+  );
+}

--- a/apps/web/src/features/workspace/project-sessions/sessions-selection-bar.tsx
+++ b/apps/web/src/features/workspace/project-sessions/sessions-selection-bar.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
+import Loading from '@/components/ui/loading';
+import { TrashIcon, XIcon } from '@phosphor-icons/react';
+
+export function SessionsSelectionBar({
+  selectedCount,
+  selectableCount,
+  allSelected,
+  onSelectAll,
+  onClearSelection,
+  onExit,
+  onDelete,
+  deleting,
+}: {
+  selectedCount: number;
+  /** Deletable sessions in the CURRENT filtered view, not the whole project. */
+  selectableCount: number;
+  allSelected: boolean;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+  onExit: () => void;
+  onDelete: () => void;
+  deleting: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-medium tabular-nums" aria-live="polite">
+        {selectedCount} selected
+      </span>
+
+      <div className="ml-auto flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={allSelected ? onClearSelection : onSelectAll}
+          disabled={deleting || selectableCount === 0}
+          className="h-8 transition-[scale] duration-150 active:scale-[0.96]"
+        >
+          {allSelected ? 'Clear' : `Select all`}
+        </Button>
+
+        {selectedCount > 0 && (
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={onDelete}
+            disabled={deleting || selectedCount === 0}
+            aria-busy={deleting}
+            className="h-8 gap-1.5 transition-[scale] duration-150 active:scale-[0.96]"
+          >
+            {deleting ? (
+              <Loading className="size-3.5 shrink-0" />
+            ) : (
+              <TrashIcon className="size-3.5 shrink-0" />
+            )}
+            Delete {selectedCount > 0 ? selectedCount : ''}
+          </Button>
+        )}
+
+        <Hint label="Exit selection" side="bottom">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Exit selection"
+            onClick={onExit}
+            disabled={deleting}
+            className="size-8 transition-[scale] duration-150 active:scale-[0.96]"
+          >
+            <XIcon className="size-4 shrink-0" />
+          </Button>
+        </Hint>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/workspace/project-sessions/sessions-toolbar.tsx
+++ b/apps/web/src/features/workspace/project-sessions/sessions-toolbar.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import Hint from '@/components/ui/hint';
+import {
+  InputGroupSearch,
+  InputGroupSearchClear,
+  InputGroupSearchIcon,
+  InputGroupSearchInput,
+} from '@/components/ui/input-group';
+import Loading from '@/components/ui/loading';
+import { cn } from '@/lib/utils';
+import { CaretDownIcon, MagnifyingGlassIcon, PlusIcon } from '@phosphor-icons/react';
+
+import {
+  projectSessionsFilterLabel,
+  type ProjectSessionsFilter,
+  type ProjectSessionsFilterGroup,
+} from './project-sessions-helpers';
+
+export function SessionsToolbar({
+  filter,
+  onFilterChange,
+  groups,
+  search,
+  onSearchChange,
+  searchOpen,
+  onSearchOpenChange,
+  onEnterSelectMode,
+  onNewSession,
+  creatingSession,
+  canSelect,
+}: {
+  filter: ProjectSessionsFilter;
+  onFilterChange: (filter: ProjectSessionsFilter) => void;
+  groups: ProjectSessionsFilterGroup[];
+  search: string;
+  onSearchChange: (search: string) => void;
+  searchOpen: boolean;
+  onSearchOpenChange: (open: boolean) => void;
+  onEnterSelectMode: () => void;
+  onNewSession: () => void;
+  creatingSession: boolean;
+  canSelect: boolean;
+}) {
+  const closeSearch = () => {
+    onSearchChange('');
+    onSearchOpenChange(false);
+  };
+
+  if (searchOpen) {
+    return (
+      // Fixed width, not flex-1: the section header wraps its action slot in
+      // `shrink-0`, so a flex-1 child would collapse to its content width.
+      <div className="flex items-center gap-2">
+        <InputGroupSearch className="w-[min(20rem,60vw)]">
+          <InputGroupSearchIcon>
+            <MagnifyingGlassIcon />
+          </InputGroupSearchIcon>
+          <InputGroupSearchInput
+            autoFocus
+            variant="popover"
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                event.preventDefault();
+                closeSearch();
+              }
+            }}
+            size="xs"
+            placeholder="Search by title, owner, source, branch, agent, or ID"
+            aria-label="Search sessions"
+          />
+          {search ? <InputGroupSearchClear onClick={() => onSearchChange('')} /> : null}
+        </InputGroupSearch>
+        <Button type="button" variant="ghost" size="sm" onClick={closeSearch}>
+          Cancel
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Hint label="Search sessions" side="bottom">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label="Search sessions"
+          onClick={() => onSearchOpenChange(true)}
+          className="size-8 transition-[scale] duration-150 active:scale-[0.96]"
+        >
+          <MagnifyingGlassIcon className="size-4 shrink-0" />
+        </Button>
+      </Hint>
+
+      {groups.length > 0 ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5 transition-[scale] duration-150 active:scale-[0.96]"
+            >
+              <span className="text-muted-foreground">Filter by</span>
+              <span>{projectSessionsFilterLabel(filter)}</span>
+              <CaretDownIcon className="size-3.5 shrink-0" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-52">
+            <DropdownMenuRadioGroup
+              value={filter}
+              onValueChange={(value) => onFilterChange(value as ProjectSessionsFilter)}
+            >
+              <DropdownMenuRadioItem value="all">All</DropdownMenuRadioItem>
+              {groups.map((group) => (
+                <div key={group.axis} className="w-full">
+                  {group.options.map((option) => (
+                    <DropdownMenuRadioItem key={option.value} value={option.value}>
+                      {option.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </div>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+
+      {canSelect ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onEnterSelectMode}
+          className="h-8 transition-[scale] duration-150 active:scale-[0.96]"
+        >
+          Select
+        </Button>
+      ) : null}
+
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        className={cn('h-8 gap-1.5 transition-[scale] duration-150 active:scale-[0.96]')}
+        onClick={onNewSession}
+        disabled={creatingSession}
+        aria-busy={creatingSession}
+      >
+        {creatingSession ? (
+          <Loading className="size-4 shrink-0" />
+        ) : (
+          <PlusIcon className="size-4 shrink-0" />
+        )}
+        New
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/translations/de.json
+++ b/apps/web/translations/de.json
@@ -3900,6 +3900,11 @@
       "line1744JsxTextText": ">",
       "line1745JsxTextContentSearch": "Inhaltssuche"
     },
+    "componentsCommonErrorBoundary": {
+      "reload": "Neu laden",
+      "errorDetails": "Fehlerdetails",
+      "copyDetails": "Fehlerdetails kopieren"
+    },
     "componentsCommonFilePreviewDialog": {
       "line89JsxTextFilePreview": "Dateivorschau:",
       "line122JsxAttrTitleOpenInNewTab": "In neuem Tab öffnen",

--- a/apps/web/translations/en.json
+++ b/apps/web/translations/en.json
@@ -3967,6 +3967,11 @@
       "line1744JsxTextText": ">",
       "line1745JsxTextContentSearch": "content search"
     },
+    "componentsCommonErrorBoundary": {
+      "reload": "Reload",
+      "errorDetails": "Error details",
+      "copyDetails": "Copy error details"
+    },
     "componentsCommonFilePreviewDialog": {
       "line89JsxTextFilePreview": "File Preview:",
       "line122JsxAttrTitleOpenInNewTab": "Open in new tab",

--- a/apps/web/translations/es.json
+++ b/apps/web/translations/es.json
@@ -3900,6 +3900,11 @@
       "line1744JsxTextText": ">",
       "line1745JsxTextContentSearch": "búsqueda de contenido"
     },
+    "componentsCommonErrorBoundary": {
+      "reload": "Recargar",
+      "errorDetails": "Detalles del error",
+      "copyDetails": "Copiar detalles del error"
+    },
     "componentsCommonFilePreviewDialog": {
       "line89JsxTextFilePreview": "Vista previa del archivo:",
       "line122JsxAttrTitleOpenInNewTab": "Abrir en una pestaña nueva",

--- a/apps/web/translations/fr.json
+++ b/apps/web/translations/fr.json
@@ -3903,6 +3903,11 @@
       "line1744JsxTextText": ">",
       "line1745JsxTextContentSearch": "recherche dans le contenu"
     },
+    "componentsCommonErrorBoundary": {
+      "reload": "Recharger",
+      "errorDetails": "Détails de l'erreur",
+      "copyDetails": "Copier les détails de l'erreur"
+    },
     "componentsCommonFilePreviewDialog": {
       "line89JsxTextFilePreview": "Aperçu du fichier :",
       "line122JsxAttrTitleOpenInNewTab": "Ouvrir dans un nouvel onglet",

--- a/apps/web/translations/it.json
+++ b/apps/web/translations/it.json
@@ -3900,6 +3900,11 @@
       "line1744JsxTextText": ">",
       "line1745JsxTextContentSearch": "ricerca nel contenuto"
     },
+    "componentsCommonErrorBoundary": {
+      "reload": "Ricarica",
+      "errorDetails": "Dettagli dell'errore",
+      "copyDetails": "Copia i dettagli dell'errore"
+    },
     "componentsCommonFilePreviewDialog": {
       "line89JsxTextFilePreview": "Anteprima file:",
       "line122JsxAttrTitleOpenInNewTab": "Apri in una nuova scheda",

--- a/apps/web/translations/ja.json
+++ b/apps/web/translations/ja.json
@@ -3900,6 +3900,11 @@
       "line1744JsxTextText": ">",
       "line1745JsxTextContentSearch": "内容検索"
     },
+    "componentsCommonErrorBoundary": {
+      "reload": "再読み込み",
+      "errorDetails": "エラーの詳細",
+      "copyDetails": "エラーの詳細をコピー"
+    },
     "componentsCommonFilePreviewDialog": {
       "line89JsxTextFilePreview": "ファイルプレビュー:",
       "line122JsxAttrTitleOpenInNewTab": "新しいタブで開く",

--- a/apps/web/translations/pt.json
+++ b/apps/web/translations/pt.json
@@ -3900,6 +3900,11 @@
       "line1744JsxTextText": ">",
       "line1745JsxTextContentSearch": "busca no conteúdo"
     },
+    "componentsCommonErrorBoundary": {
+      "reload": "Recarregar",
+      "errorDetails": "Detalhes do erro",
+      "copyDetails": "Copiar detalhes do erro"
+    },
     "componentsCommonFilePreviewDialog": {
       "line89JsxTextFilePreview": "Prévia do arquivo:",
       "line122JsxAttrTitleOpenInNewTab": "Abrir em uma nova aba",

--- a/apps/web/translations/zh.json
+++ b/apps/web/translations/zh.json
@@ -3896,6 +3896,11 @@
       "line1744JsxTextText": ">",
       "line1745JsxTextContentSearch": "内容搜索"
     },
+    "componentsCommonErrorBoundary": {
+      "reload": "重新加载",
+      "errorDetails": "错误详情",
+      "copyDetails": "复制错误详情"
+    },
     "componentsCommonFilePreviewDialog": {
       "line89JsxTextFilePreview": "文件预览：",
       "line122JsxAttrTitleOpenInNewTab": "在新标签页中打开",


### PR DESCRIPTION
Selective release of two `main` commits into `staging`. Cherry-picked onto `origin/staging`; the two commits between them on `main` (#5987, #5988, send-to-agent) are deliberately excluded.

## Commits

| staging SHA | main SHA | Change |
| --- | --- | --- |
| `d577ff427` | `b343c1862` | feat(web): enhance error boundary with copy functionality and improved UI |
| `012eb66dc` | `623523cf0` | feat(web): rebuild the project session list as an everyday list |

**Error boundary** — adds `CopyErrorButton`, moves the stack trace behind a `Disclosure` in `DefaultAppFallback`, adds `componentsCommonErrorBoundary` keys (`reload`, `errorDetails`, `copyDetails`) to all 8 locales.

**Project session list** — rebuilds `/projects/[id]/sessions` as a fixed-header list: 42px single-line rows (down from 64px), status on a tinted source-icon tile instead of a status word, one "Filter by X" dropdown replacing nine chips, collapsible search, select mode with bulk delete, and a detail grid that emits a field only when it holds a value. Also fixes a live bug: `SessionDeleteModal` invalidated only `['project-sessions']` while this view reads `['project-session-inventory']`, so deleted sessions stayed on screen; all mutations now route through one `invalidateSessions()`. `section-wrapper` gains an opt-in `showSidebarToggleButton` prop, default off.

## Test plan

Run against the cherry-picked branch (base `origin/staging` @ `5a2961e84`), Node 22:

- Cherry-picks applied with zero conflicts. `git diff 623523cf0 HEAD` over the picked source files is empty — the `apps/web/src/**` content is byte-identical to `main`. The only delta is in `apps/web/translations/*.json`, and it is pre-existing `staging`/`main` drift (`EditProjectModal` vs `RenameProjectModal` auto-generated keys), not introduced here.
- All 3 new `componentsCommonErrorBoundary` keys present in `en/de/es/fr/it/ja/pt/zh`.
- Every `@/…` import in the picked files resolves against the `staging` tree; named imports verified present.
- `npx tsc --noEmit` — no errors in any picked file (repo-wide `TS2786` React 19↔18 noise excluded per CLAUDE.md).
- `bun test src/features/workspace/project-sessions/project-sessions-helpers.test.ts` — **29 pass, 0 fail, 63 expect() calls**.
- `npx eslint` over all picked paths — clean, exit 0.

Not yet verified: deployed behavior on `staging.kortix.com`. That follows the staging deploy after merge.
