### PR TITLE
fix(release): dark US shadow region no longer gates release artifacts

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -780,6 +780,12 @@ jobs:
   deploy-us-shadow:
     name: Deploy API + gateway to US East 2 shadow
     needs: [version, retag-images, verify-image-commits, migrate-db]
+    # The shadow is dark: Cloudflare routes no user traffic to it. A wedged
+    # shadow (e.g. logical replication stuck) must not block the release
+    # artifacts for the PRIMARY region — that skipped the tag, GitHub Release,
+    # and VERSION sync on v0.10.16 through v0.12.0. Its failure still shows
+    # red on this job; verify-live-version reports shadow drift as a warning.
+    continue-on-error: true
     permissions:
       contents: read
       id-token: write
@@ -1050,8 +1056,8 @@ jobs:
             "origin-api-eks|https://api-eks.kortix.com/v1/health|origin|1"
             "origin-gateway-ecs|https://gateway-ecs-fargate.kortix.com/health/live|origin|0"
             "origin-gateway-eks|https://gateway-eks.kortix.com/health/live|origin|0"
-            "shadow-api-use2|https://api-use2-shadow.kortix.com/v1/health|required|1"
-            "shadow-gateway-use2|https://gateway-use2-shadow.kortix.com/health/live|required|1"
+            "shadow-api-use2|https://api-use2-shadow.kortix.com/v1/health|shadow|1"
+            "shadow-gateway-use2|https://gateway-use2-shadow.kortix.com/health/live|shadow|1"
           )
 
           declare -A live
@@ -1078,7 +1084,9 @@ jobs:
                 echo "($attempt/20) ✓ $name  version=$v commit=${c:-n/a}"
               else
                 echo "($attempt/20) … $name  version=${v:-<unreachable>} commit=${c:-n/a}"
-                all_ok=0
+                if [ "$kind" != "shadow" ]; then
+                  all_ok=0
+                fi
               fi
             done
             if [ "$all_ok" = 1 ]; then
@@ -1103,6 +1111,8 @@ jobs:
             fi
             if [ "$v" = "$VERSION" ] && [ "$commit_mismatch" = 0 ]; then
               continue
+            elif [ "$kind" = "shadow" ]; then
+              echo "::warning::$name ($url) reports version='${v:-<unreachable>}' commit='${c:-n/a}' — the dark US shadow is not serving v${VERSION}. Tolerated; the shadow region blocks nothing, fix it separately."
             elif [ -z "$v" ]; then
               if [ "$kind" = "required" ]; then
                 echo "::error::$name ($url) is unreachable — the PUBLIC endpoint must serve the release. Release blocked."


### PR DESCRIPTION
## Problem

The US East 2 shadow region's logical replication has been wedged since 2026-07-28 (`apply_workers=0`, 101/109 tables ready). `deploy-us-shadow` fails on every deploy-prod run, and because `verify-live-version` needs it (and `github-release` needs that), the tag, GitHub Release, `:prod` retag, VERSION sync, and Slack announce were skipped for v0.10.16, v0.11.0, and v0.12.0 — while primary prod deployed fine every time. v0.12.0 is live on prod with no tag and no Release.

## Change

- `deploy-us-shadow`: `continue-on-error: true` — the shadow is dark (no user traffic routes to it); a shadow wedge must not block primary-region release artifacts. The job still shows red for visibility.
- `verify-live-version`: the two shadow endpoints move from `required` to a new `shadow` kind — mismatch/unreachable reports a `::warning` instead of failing, and shadow no longer holds the 5-minute retry loop open.

Primary prod (ECS router, EKS standby, gateway) verification is unchanged and still hard-gates the release, including the commit-vs-version image check.

## Follow-up (separate)

Unwedge the shadow replication itself: subscription on `kortix-prod-us-east-2` has no running apply worker and 8 tables never reach ready. Needs prod DB access.