### PR TITLE
Promote main → staging: shadow-region release-gate fix

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -780,6 +780,12 @@ jobs:
   deploy-us-shadow:
     name: Deploy API + gateway to US East 2 shadow
     needs: [version, retag-images, verify-image-commits, migrate-db]
+    # The shadow is dark: Cloudflare routes no user traffic to it. A wedged
+    # shadow (e.g. logical replication stuck) must not block the release
+    # artifacts for the PRIMARY region — that skipped the tag, GitHub Release,
+    # and VERSION sync on v0.10.16 through v0.12.0. Its failure still shows
+    # red on this job; verify-live-version reports shadow drift as a warning.
+    continue-on-error: true
     permissions:
       contents: read
       id-token: write
@@ -1050,8 +1056,8 @@ jobs:
             "origin-api-eks|https://api-eks.kortix.com/v1/health|origin|1"
             "origin-gateway-ecs|https://gateway-ecs-fargate.kortix.com/health/live|origin|0"
             "origin-gateway-eks|https://gateway-eks.kortix.com/health/live|origin|0"
-            "shadow-api-use2|https://api-use2-shadow.kortix.com/v1/health|required|1"
-            "shadow-gateway-use2|https://gateway-use2-shadow.kortix.com/health/live|required|1"
+            "shadow-api-use2|https://api-use2-shadow.kortix.com/v1/health|shadow|1"
+            "shadow-gateway-use2|https://gateway-use2-shadow.kortix.com/health/live|shadow|1"
           )
 
           declare -A live
@@ -1078,7 +1084,9 @@ jobs:
                 echo "($attempt/20) ✓ $name  version=$v commit=${c:-n/a}"
               else
                 echo "($attempt/20) … $name  version=${v:-<unreachable>} commit=${c:-n/a}"
-                all_ok=0
+                if [ "$kind" != "shadow" ]; then
+                  all_ok=0
+                fi
               fi
             done
             if [ "$all_ok" = 1 ]; then
@@ -1103,6 +1111,8 @@ jobs:
             fi
             if [ "$v" = "$VERSION" ] && [ "$commit_mismatch" = 0 ]; then
               continue
+            elif [ "$kind" = "shadow" ]; then
+              echo "::warning::$name ($url) reports version='${v:-<unreachable>}' commit='${c:-n/a}' — the dark US shadow is not serving v${VERSION}. Tolerated; the shadow region blocks nothing, fix it separately."
             elif [ -z "$v" ]; then
               if [ "$kind" = "required" ]; then
                 echo "::error::$name ($url) is unreachable — the PUBLIC endpoint must serve the release. Release blocked."


### PR DESCRIPTION
Carries #5992 (dark US shadow no longer gates release artifacts) into staging so the v0.12.1 release PR brings the fixed deploy-prod.yml to prod. Without this, deploy-prod fails on the wedged shadow replication again and skips the tag/Release/VERSION sync for v0.12.1 exactly as it did for v0.10.16–v0.12.0. One commit; workflow-only.