### PR TITLE
fix(channels): bind email sessions to configured agents

### DIFF
--- a/apps/api/src/__tests__/integration-session-connector-profiles.test.ts
+++ b/apps/api/src/__tests__/integration-session-connector-profiles.test.ts
@@ -5,6 +5,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
   accounts,
+  chatChannelBindings,
   chatInstalls,
   executorConnectionProfiles,
   executorConnectorPolicies,
@@ -1104,6 +1105,57 @@ describe('session connector profile isolation', () => {
       .from(executorConnectionProfiles)
       .where(eq(executorConnectionProfiles.profileId, profileB.profileId));
     expect(afterFinal?.status).toBe('revoked');
+  });
+
+  test('AgentMail installation persists and removes its explicit channel-agent binding', async () => {
+    const profileSlug = 'veyris_bound';
+    const inboxId = 'inbox-veyris-bound';
+    await saveAgentMailInstall({
+      projectId: PROJECT_A,
+      profileSlug,
+      inboxId,
+      email: 'veyris-bound@example.test',
+      displayName: 'Veyris bound inbox',
+      apiKey: 'agentmail-key',
+      agentName: 'veyris',
+    });
+
+    const [binding] = await db
+      .select({
+        projectId: chatChannelBindings.projectId,
+        channelId: chatChannelBindings.channelId,
+        channelName: chatChannelBindings.channelName,
+        channelType: chatChannelBindings.channelType,
+        agentName: chatChannelBindings.agentName,
+      })
+      .from(chatChannelBindings)
+      .where(
+        and(
+          eq(chatChannelBindings.platform, 'email'),
+          eq(chatChannelBindings.workspaceId, inboxId),
+          eq(chatChannelBindings.channelId, profileSlug),
+        ),
+      );
+    expect(binding).toEqual({
+      projectId: PROJECT_A,
+      channelId: profileSlug,
+      channelName: 'veyris-bound@example.test',
+      channelType: 'inbox',
+      agentName: 'veyris',
+    });
+
+    await deleteAgentMailInstall(PROJECT_A, profileSlug);
+    const rows = await db
+      .select({ bindingId: chatChannelBindings.bindingId })
+      .from(chatChannelBindings)
+      .where(
+        and(
+          eq(chatChannelBindings.platform, 'email'),
+          eq(chatChannelBindings.workspaceId, inboxId),
+          eq(chatChannelBindings.channelId, profileSlug),
+        ),
+      );
+    expect(rows).toEqual([]);
   });
 
   test('saveAgentMailInstall does not delete another project chat_installs row for the same inbox (pentest 2026-07-27)', async () => {

--- a/apps/api/src/__tests__/integration-session-env-grants.test.ts
+++ b/apps/api/src/__tests__/integration-session-env-grants.test.ts
@@ -40,6 +40,9 @@ const RESTARTER = crypto.randomUUID();
 const OVERRIDE_IDENT = `E2E_OVR_${SUFFIX}`;
 const OVERRIDE_KEY = `E2E_OVR_KEY_${SUFFIX}`;
 const PRINCIPAL_SESSION = `e2e-principal-${crypto.randomUUID()}`;
+const VEYRIS_API_IDENT = `veyris-api-url-${SUFFIX}`;
+const VEYRIS_TOKEN_IDENT = `veyris-agent-token-${SUFFIX}`;
+const VEYRIS_SESSION = `e2e-veyris-${crypto.randomUUID()}`;
 
 beforeAll(async () => {
   const rows = (await db.execute(
@@ -94,18 +97,37 @@ beforeAll(async () => {
     createdBy: OWNER,
     agentName: 'default',
   });
+  await db.insert(projectSessions).values({
+    sessionId: VEYRIS_SESSION,
+    accountId: ctx.accountId,
+    projectId: ctx.projectId,
+    branchName: `kaab-veyris-${SUFFIX}`,
+    createdBy: USER,
+    agentName: 'veyris',
+    // Same two-identifier narrowing Veyris sends on create; the test suffix
+    // keeps this fixture isolated from any real Veyris rows in the local DB.
+    secretsAllowlist: [VEYRIS_API_IDENT, VEYRIS_TOKEN_IDENT],
+  });
 });
 
 afterAll(async () => {
   if (!ctx) return;
   await db.delete(projectSessions).where(eq(projectSessions.sessionId, SESSION_ID));
   await db.delete(projectSessions).where(eq(projectSessions.sessionId, PRINCIPAL_SESSION));
+  await db.delete(projectSessions).where(eq(projectSessions.sessionId, VEYRIS_SESSION));
   await db
     .delete(projectSecrets)
     .where(
       and(
         eq(projectSecrets.projectId, ctx.projectId),
-        inArray(projectSecrets.identifier, [PRIMARY, BACKUP, UNSCOPED, OVERRIDE_IDENT]),
+        inArray(projectSecrets.identifier, [
+          PRIMARY,
+          BACKUP,
+          UNSCOPED,
+          OVERRIDE_IDENT,
+          VEYRIS_API_IDENT,
+          VEYRIS_TOKEN_IDENT,
+        ]),
       ),
     );
 });
@@ -219,6 +241,58 @@ describe('listProjectSecretsSnapshotForUser — session env injection by identif
       llmGatewayEnabled: false,
     });
     expect(env[OVERRIDE_KEY]).toBe('owner-val');
+  });
+
+  test('sandbox boot snapshots the latest committed Veyris capability secrets without caching', async () => {
+    if (!ctx) return;
+    await writeSharedProjectSecret({
+      projectId: ctx.projectId,
+      identifier: VEYRIS_API_IDENT,
+      name: 'VEYRIS_API_URL',
+      value: 'https://stale.veyris.example.test',
+    });
+    await writeSharedProjectSecret({
+      projectId: ctx.projectId,
+      identifier: VEYRIS_TOKEN_IDENT,
+      name: 'VEYRIS_AGENT_TOKEN',
+      value: 'stale-capability',
+    });
+
+    // Mirrors the correct wrapper ordering: both upsert responses have landed
+    // before session create is allowed to snapshot the environment.
+    await Promise.all([
+      writeSharedProjectSecret({
+        projectId: ctx.projectId,
+        identifier: VEYRIS_API_IDENT,
+        name: 'VEYRIS_API_URL',
+        value: 'https://fresh.veyris.example.test',
+      }),
+      writeSharedProjectSecret({
+        projectId: ctx.projectId,
+        identifier: VEYRIS_TOKEN_IDENT,
+        name: 'VEYRIS_AGENT_TOKEN',
+        value: 'fresh-capability',
+      }),
+    ]);
+
+    // defaultBranch omitted deliberately: the session allowlist is still
+    // applied and proves these identifiers survive Suna's boot-time grant fold.
+    const env = await buildSessionSandboxEnvVars({
+      accountId: ctx.accountId,
+      projectId: ctx.projectId,
+      sessionId: VEYRIS_SESSION,
+      userId: USER,
+      repoUrl: 'https://example.test/veyris.git',
+      baseRef: 'main',
+      agentName: 'veyris',
+      llmGatewayEnabled: false,
+    });
+    expect(env.VEYRIS_API_URL).toBe('https://fresh.veyris.example.test');
+    expect(env.VEYRIS_AGENT_TOKEN).toBe('fresh-capability');
+    expect(env.KORTIX_PROJECT_SECRET_NAMES?.split(',').sort()).toEqual([
+      'VEYRIS_AGENT_TOKEN',
+      'VEYRIS_API_URL',
+    ]);
   });
 });
 

--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -272,6 +272,7 @@ describe('dispatchAgentMailEvent', () => {
           name: 'Support',
         },
       ],
+      [{ agentName: 'veyris', opencodeModel: null }],
       [{ eventId: 'email:threadcreate:inb-1:thr-1' }],
       [
         {
@@ -305,6 +306,7 @@ describe('dispatchAgentMailEvent', () => {
     expect(createCalls[0].body.connector_bindings).toEqual({
       email: { authorization_id: 'profile-email-1' },
     });
+    expect(createCalls[0].body.agent_name).toBe('veyris');
     expect(createCalls[0].body.initial_prompt).toBeUndefined();
   });
 
@@ -334,6 +336,7 @@ describe('dispatchAgentMailEvent', () => {
           name: 'Support',
         },
       ],
+      [],
       [{ eventId: 'email:threadcreate:inb-1:thr-unwrapped' }],
       [
         {

--- a/apps/api/src/__tests__/unit-session-agent-resolution.test.ts
+++ b/apps/api/src/__tests__/unit-session-agent-resolution.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveSessionAgentName } from '../projects/lib/sessions';
+
+describe('resolveSessionAgentName', () => {
+  test('uses an explicit concrete agent before every default', () => {
+    expect(
+      resolveSessionAgentName({
+        requestedAgent: 'writer',
+        manifestDefaultAgent: 'veyris',
+        mirroredDefaultAgent: 'kortix',
+      }),
+    ).toBe('writer');
+  });
+
+  test('treats the default sentinel as non-binding and trusts the v2 manifest', () => {
+    expect(
+      resolveSessionAgentName({
+        requestedAgent: 'default',
+        manifestDefaultAgent: 'veyris',
+        mirroredDefaultAgent: 'kortix',
+      }),
+    ).toBe('veyris');
+  });
+
+  test('keeps the database mirror as the legacy fallback when no manifest default exists', () => {
+    expect(
+      resolveSessionAgentName({
+        requestedAgent: null,
+        manifestDefaultAgent: null,
+        mirroredDefaultAgent: 'kortix',
+      }),
+    ).toBe('kortix');
+  });
+});

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -1,4 +1,10 @@
-import { chatEventDedup, chatInstalls, chatThreads, projects } from '@kortix/db';
+import {
+  chatChannelBindings,
+  chatEventDedup,
+  chatInstalls,
+  chatThreads,
+  projects,
+} from '@kortix/db';
 import { and, eq } from 'drizzle-orm';
 import { config } from '../../config';
 import {
@@ -149,6 +155,24 @@ async function createThreadSession(
     .limit(1);
   if (!project) return;
 
+  // An AgentMail inbox is a first-class channel. Its binding selects the
+  // concrete project agent exactly like Slack and Teams bindings do. Older
+  // installs have no binding row and fall through to the project default.
+  const [selection] = await db
+    .select({
+      agentName: chatChannelBindings.agentName,
+      opencodeModel: chatChannelBindings.opencodeModel,
+    })
+    .from(chatChannelBindings)
+    .where(
+      and(
+        eq(chatChannelBindings.projectId, projectId),
+        eq(chatChannelBindings.platform, 'email'),
+        eq(chatChannelBindings.workspaceId, inboxId),
+      ),
+    )
+    .limit(1);
+
   const userId = await emailSessionLifecycle.resolveProjectAutomationActor(project.accountId);
   if (!userId) {
     console.warn('[email-webhook] no actor for project', projectId);
@@ -192,7 +216,8 @@ async function createThreadSession(
     requestingPrincipalType: 'human',
     body: {
       base_ref: project.defaultBranch,
-      agent_name: 'default',
+      agent_name: selection?.agentName || 'default',
+      ...(selection?.opencodeModel ? { opencode_model: selection.opencodeModel } : {}),
       connector_bindings: {
         email: { authorization_id: emailProfileId },
       },

--- a/apps/api/src/channels/install-store.ts
+++ b/apps/api/src/channels/install-store.ts
@@ -1,4 +1,4 @@
-import { chatInstalls, projectSecrets } from '@kortix/db';
+import { chatChannelBindings, chatInstalls, projectSecrets } from '@kortix/db';
 import { and, eq, inArray, isNull, like } from 'drizzle-orm';
 import { decryptProjectSecret, encryptProjectSecret } from '../projects/secrets';
 import { db } from '../shared/db';
@@ -94,6 +94,8 @@ export interface AgentMailInstallInput {
   webhookId?: string | null;
   webhookSecret?: string | null;
   senderPolicy?: AgentMailSenderPolicy | null;
+  /** Concrete agent for inbound messages. Null inherits the project default. */
+  agentName?: string | null;
 }
 
 function agentMailProfileSuffix(profileSlug?: string | null): string {
@@ -215,6 +217,16 @@ export async function saveAgentMailInstall(
   }
   if (previous?.inboxId) {
     await db
+      .delete(chatChannelBindings)
+      .where(
+        and(
+          eq(chatChannelBindings.platform, 'email'),
+          eq(chatChannelBindings.projectId, projectId),
+          eq(chatChannelBindings.workspaceId, previous.inboxId),
+          eq(chatChannelBindings.channelId, profileSlug),
+        ),
+      );
+    await db
       .delete(chatInstalls)
       .where(
         and(
@@ -244,6 +256,24 @@ export async function saveAgentMailInstall(
     .onConflictDoNothing({
       target: [chatInstalls.platform, chatInstalls.workspaceId, chatInstalls.projectId],
     });
+  await db
+    .insert(chatChannelBindings)
+    .values({
+      platform: 'email',
+      workspaceId: input.inboxId,
+      channelId: profileSlug,
+      projectId,
+      channelName: input.email,
+      channelType: 'inbox',
+      agentName: input.agentName ?? null,
+    })
+    .onConflictDoNothing({
+      target: [
+        chatChannelBindings.platform,
+        chatChannelBindings.workspaceId,
+        chatChannelBindings.channelId,
+      ],
+    });
   return {
     profileSlug,
     inboxId: input.inboxId,
@@ -268,6 +298,19 @@ export async function deleteAgentMailInstall(
   }
   if (install?.inboxId) {
     await db
+      .delete(chatChannelBindings)
+      .where(
+        and(
+          eq(chatChannelBindings.platform, 'email'),
+          eq(chatChannelBindings.projectId, projectId),
+          eq(chatChannelBindings.workspaceId, install.inboxId),
+          eq(
+            chatChannelBindings.channelId,
+            (profileSlug || 'kortix_email').trim() || 'kortix_email',
+          ),
+        ),
+      );
+    await db
       .delete(chatInstalls)
       .where(
         and(
@@ -277,6 +320,14 @@ export async function deleteAgentMailInstall(
         ),
       );
   } else if (!profileSlug || profileSlug === 'kortix_email') {
+    await db
+      .delete(chatChannelBindings)
+      .where(
+        and(
+          eq(chatChannelBindings.platform, 'email'),
+          eq(chatChannelBindings.projectId, projectId),
+        ),
+      );
     await db
       .delete(chatInstalls)
       .where(and(eq(chatInstalls.platform, 'email'), eq(chatInstalls.projectId, projectId)));

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -102,6 +102,24 @@ export function sendSessionCreateError(c: Context, error: SessionCreateError) {
   return c.json(error.body, error.status as any);
 }
 
+/**
+ * Resolve the concrete agent stored on a new session.
+ *
+ * A v2 manifest is durable project truth. `project.metadata.default_agent` is
+ * only a read mirror and can lag an external git push, so it must never
+ * override the manifest value. The mirror remains the legacy fallback for v1
+ * projects, whose manifests do not declare a top-level default.
+ */
+export function resolveSessionAgentName(input: {
+  requestedAgent: string | null;
+  manifestDefaultAgent: string | null;
+  mirroredDefaultAgent: string | null;
+}): string {
+  const explicit =
+    input.requestedAgent && input.requestedAgent !== 'default' ? input.requestedAgent : null;
+  return explicit ?? input.manifestDefaultAgent ?? input.mirroredDefaultAgent ?? 'default';
+}
+
 export async function countActiveProjectSessions(accountId: string): Promise<number> {
   const [row] = await db
     .select({ activeCount: sql<number>`count(*)::int` })
@@ -658,20 +676,22 @@ export async function createProjectSession(input: {
   }
 
   const baseRef = normalizeString(body.base_ref ?? body.baseRef) ?? project.defaultBranch;
+  const loadedAgents = await loadProjectAgents(project, {
+    forceRefresh: true,
+    rethrowReadErrors: true,
+  });
   // The literal "default" is a non-binding legacy sentinel. It must not block
   // the configured project default. This rule applies to every caller,
   // including older triggers and channel adapters that still send the sentinel.
   const requestedAgent = normalizeString(body.agent_name ?? body.agentName);
-  const projectDefaultAgent = normalizeString(
+  const mirroredDefaultAgent = normalizeString(
     (project.metadata as Record<string, unknown> | null | undefined)?.default_agent,
   );
-  const agentName =
-    (requestedAgent && requestedAgent !== 'default' ? requestedAgent : null) ??
-    projectDefaultAgent ??
-    'default';
-  const loadedAgents = await loadProjectAgents(project, {
-    forceRefresh: true,
-    rethrowReadErrors: true,
+  const projectDefaultAgent = normalizeString(loadedAgents.defaultAgent) ?? mirroredDefaultAgent;
+  const agentName = resolveSessionAgentName({
+    requestedAgent,
+    manifestDefaultAgent: normalizeString(loadedAgents.defaultAgent),
+    mirroredDefaultAgent,
   });
 
   const freeModelsOnly = config.KORTIX_BILLING_INTERNAL_ENABLED

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -95,6 +95,7 @@ import {
   setProjectModelOverrides,
 } from '../../repositories/project-routing-policies';
 import { db } from '../../shared/db';
+import { loadProjectAgents } from '../agents';
 import {
   assertProjectCapability,
   loadProjectForUser,
@@ -1891,6 +1892,8 @@ projectsApp.openapi(
       display_name?: string;
       displayName?: string;
       sender_policy?: Partial<AgentMailSenderPolicy>;
+      agent_name?: string | null;
+      agentName?: string | null;
     };
     try {
       body = (await c.req.json()) as typeof body;
@@ -1905,6 +1908,27 @@ projectsApp.openapi(
 
     const connectorSlug =
       (body.connector_slug ?? body.profile_slug ?? 'kortix_email').trim() || 'kortix_email';
+    const requestedAgent = body.agent_name ?? body.agentName;
+    const agentName =
+      typeof requestedAgent === 'string' && requestedAgent.trim() ? requestedAgent.trim() : null;
+    if (requestedAgent !== undefined && requestedAgent !== null && !agentName) {
+      return c.json({ error: 'agent_name cannot be blank', code: 'invalid_agent' }, 400);
+    }
+    if (agentName) {
+      const loadedAgents = await loadProjectAgents(loaded.row, {
+        forceRefresh: true,
+        rethrowReadErrors: true,
+      });
+      if (!loadedAgents.specs.some((agent) => agent.enabled && agent.name === agentName)) {
+        return c.json(
+          {
+            error: `Agent "${agentName}" is not declared or is disabled`,
+            code: 'invalid_agent',
+          },
+          400,
+        );
+      }
+    }
     const displayName = (
       body.display_name ??
       body.displayName ??
@@ -1997,6 +2021,7 @@ projectsApp.openapi(
       webhookId,
       webhookSecret,
       senderPolicy,
+      agentName,
     });
     await reconcileChannelConnectors(projectId);
     return c.json({

--- a/packages/sdk/src/core/rest/projects-client/sessions.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.ts
@@ -90,7 +90,14 @@ export type SessionConnectorBindingInput =
     };
 export type SessionConnectorBindingsInput = Record<string, SessionConnectorBindingInput>;
 
-/** Public body for POST /projects/:projectId/sessions. */
+/**
+ * Public body for POST /projects/:projectId/sessions.
+ *
+ * Session create immediately begins runtime provisioning; it is not a deferred
+ * metadata-only create. Callers that rotate project secrets or connector
+ * credentials for the new session must await those writes before creating it.
+ * The later `/start` call is an idempotent readiness/resume operation.
+ */
 export interface CreateProjectSessionInput {
   base_ref?: string;
   agent_name?: string;
@@ -273,6 +280,14 @@ export async function revokeSessionPublicShare(
   );
 }
 
+/**
+ * Create a session and immediately kick its runtime provisioning.
+ *
+ * Await any project-secret or connector-credential mutations that the runtime
+ * must observe before calling this function. `startProjectSession` does not
+ * establish a commit barrier for writes raced against this request; it only
+ * provisions/resumes idempotently and reports readiness.
+ */
 export async function createProjectSession(projectId: string, input?: CreateProjectSessionInput) {
   const session = unwrap(
     await backendApi.post<ProjectSession>(`/projects/${projectId}/sessions`, input ?? {}),


### PR DESCRIPTION
## Summary
- persist AgentMail inbox-to-agent bindings and resolve them for inbound sessions
- prefer authoritative v2 manifest defaults over stale project metadata
- document immediate SDK session provisioning and add secret/env regression coverage

## Verification
- focused email/session units: 13 passed
- connector-profile integration: 37 passed
- session-env integration: 9 passed
- SDK session tests: 28 passed
- API and SDK typechecks passed
- git diff --check passed