### PR TITLE
fix(email): enable Executor MCP for channel sessions

### DIFF
--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -42,8 +42,25 @@ mock.module('../shared/db', () => ({
   hasDatabase: () => true,
 }));
 
-let continueCalls: Array<{ sessionId: string; text: string }> = [];
+let continueCalls: Array<{
+  sessionId: string;
+  text: string;
+  opencodeEnv?: Record<string, string | null>;
+}> = [];
 let createCalls: Array<any> = [];
+
+function expectExecutorEmailPrompt(prompt: string) {
+  for (const tool of ['connectors', 'discover', 'describe', 'call']) {
+    expect(prompt).toContain(`\`${tool}\``);
+  }
+  expect(prompt).toContain('"connector":"email"');
+  expect(prompt).toContain('"action":"reply_message"');
+  expect(prompt).toContain('"inbox_id":"inb-1"');
+  expect(prompt).toContain('"message_id":"msg-1"');
+  expect(prompt).toContain('"text":"<reply>"');
+  expect(prompt).toContain('Use `html` instead of `text` only when needed.');
+  expect(prompt).not.toContain('call `email.reply_message`');
+}
 
 const {
   dispatchAgentMailEvent,
@@ -89,7 +106,11 @@ beforeEach(() => {
   setEmailSessionLifecycleForTest({
     resolveProjectAutomationActor: async () => 'user-1',
     continueSession: async (input) => {
-      continueCalls.push({ sessionId: input.sessionId, text: input.text });
+      continueCalls.push({
+        sessionId: input.sessionId,
+        text: input.text,
+        opencodeEnv: input.opencodeEnv,
+      });
       return 'delivered';
     },
     createSession: async (input) => {
@@ -302,7 +323,9 @@ describe('dispatchAgentMailEvent', () => {
       }),
     ]);
     expect(createCalls[0].postCreate[1].text).toContain('Need help');
+    expectExecutorEmailPrompt(createCalls[0].postCreate[1].text);
     expect(createCalls[0].extraEnvVars.KORTIX_EMAIL_INBOX_ID).toBe('inb-1');
+    expect(createCalls[0].extraEnvVars.KORTIX_EXECUTOR_MCP_ENABLED).toBe('1');
     expect(createCalls[0].body.connector_bindings).toEqual({
       email: { authorization_id: 'profile-email-1' },
     });
@@ -385,6 +408,7 @@ describe('dispatchAgentMailEvent', () => {
     expect(createCalls).toHaveLength(0);
     expect(continueCalls).toHaveLength(1);
     expect(continueCalls[0].sessionId).toBe('sess-1');
+    expect(continueCalls[0].opencodeEnv).toEqual({ KORTIX_EXECUTOR_MCP_ENABLED: '1' });
   });
 
   test('known thread routes a new email into the existing session', async () => {
@@ -412,7 +436,9 @@ describe('dispatchAgentMailEvent', () => {
     expect(createCalls).toHaveLength(0);
     expect(continueCalls).toHaveLength(1);
     expect(continueCalls[0].sessionId).toBe('sess-1');
+    expect(continueCalls[0].opencodeEnv).toEqual({ KORTIX_EXECUTOR_MCP_ENABLED: '1' });
     expect(continueCalls[0].text).toContain('Customer <customer@example.com>');
+    expectExecutorEmailPrompt(continueCalls[0].text);
   });
 
   test('sender allow policy supports exact emails, domains, and regex', () => {

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -111,6 +111,7 @@ async function spawnEmailAgentTurn(
       source: 'email',
       sessionId: existing.sessionId,
       text: renderFollowUpPrompt(event),
+      opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: '1' },
     });
     if (outcome === 'delivered') {
       await db
@@ -195,6 +196,7 @@ async function createThreadSession(
         source: 'email',
         sessionId,
         text: renderFollowUpPrompt(event),
+        opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: '1' },
       });
     }
     return;
@@ -250,11 +252,15 @@ async function createThreadSession(
         inbox_id: inboxId,
         thread_id: threadId,
         message_id: event.message.message_id,
+        address: event.message.to?.[0] ?? '',
         from: messageSender(event),
         subject: messageSubject(event),
       },
     },
     extraEnvVars: {
+      // Email delivery cannot depend on a shell fallback. Enable the
+      // session-scoped MCP face so OpenCode exposes the bound inbox as tools.
+      KORTIX_EXECUTOR_MCP_ENABLED: '1',
       KORTIX_EMAIL_INBOX_ID: inboxId,
       KORTIX_EMAIL_THREAD_ID: threadId,
       KORTIX_EMAIL_MESSAGE_ID: event.message.message_id,
@@ -343,15 +349,36 @@ async function waitForThreadSession(inboxId: string, threadId: string): Promise<
   }
 }
 
-const EMAIL_TURN_INSTRUCTIONS = [
-  'How to work:',
-  '- You are operating an AgentMail inbox assigned to this Kortix project.',
-  '- Use the built-in `email` Executor connector for inbox operations. The AgentMail API key is resolved server-side; do not look for it in the sandbox.',
-  '- Read the current thread before replying when context matters: `email.get_thread` with `inbox_id` and `thread_id`.',
-  '- To answer in the same conversation, call `email.reply_message` with `inbox_id`, `message_id`, `text` or `html`, and attachments when needed.',
-  '- For a brand-new outbound email, call `email.send_message` with `inbox_id`, `to`, `subject`, and body.',
-  '- If you need the user to clarify something, reply by email and end the turn. Their next reply will resume this same session.',
-].join('\n');
+function emailTurnInstructions(event: AgentMailMessageReceivedEvent): string {
+  const readThreadCall = JSON.stringify({
+    connector: 'email',
+    action: 'get_thread',
+    args: {
+      inbox_id: event.message.inbox_id,
+      thread_id: event.message.thread_id,
+    },
+  });
+  const replyCall = JSON.stringify({
+    connector: 'email',
+    action: 'reply_message',
+    args: {
+      inbox_id: event.message.inbox_id,
+      message_id: event.message.message_id,
+      text: '<reply>',
+    },
+  });
+  return [
+    'How to work:',
+    '- You are operating an AgentMail inbox assigned to this Kortix project.',
+    '- Use the Executor MCP meta-tools `connectors`, `discover`, `describe`, and `call`. Connector actions are not direct tools.',
+    '- Start with `connectors`. Use `discover` to find an action and `describe` to confirm its input schema before the first call.',
+    `- Read the current thread with \`call\`: \`${readThreadCall}\`.`,
+    `- Reply in the same conversation with \`call\`: \`${replyCall}\`. Use \`html\` instead of \`text\` only when needed.`,
+    '- Start a new outbound email with `call`, connector `email`, action `send_message`, and args containing `inbox_id`, `to`, `subject`, and `text` or `html`.',
+    '- The AgentMail API key is resolved server-side. Do not look for it in the sandbox.',
+    '- If you need the user to clarify something, reply by email and end the turn. Their next reply will resume this same session.',
+  ].join('\n');
+}
 
 function renderFollowUpPrompt(event: AgentMailMessageReceivedEvent): string {
   return [
@@ -359,7 +386,7 @@ function renderFollowUpPrompt(event: AgentMailMessageReceivedEvent): string {
     '',
     messageSummary(event),
     '',
-    EMAIL_TURN_INSTRUCTIONS,
+    emailTurnInstructions(event),
   ].join('\n');
 }
 
@@ -384,7 +411,7 @@ function renderAgentPrompt(event: AgentMailMessageReceivedEvent, revived: boolea
     '',
     messageSummary(event),
     '',
-    EMAIL_TURN_INSTRUCTIONS,
+    emailTurnInstructions(event),
   );
   return lines.join('\n');
 }

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -209,6 +209,8 @@ export async function syncSandboxEnvForPrompt(args: {
    *  grant is resolved from THIS, not from the session's create-time agent —
    *  see resolveOwnerRawEnv. Null/'default' means "the session's own agent". */
   requestedAgent?: string | null;
+  /** Runtime env the daemon applies before the prompt reaches OpenCode. */
+  opencodeEnv?: Record<string, string | null>;
 }): Promise<void> {
   if (!args.serviceKey) return;
   const snapshot = await resolveSandboxEnvSnapshot(
@@ -224,6 +226,7 @@ export async function syncSandboxEnvForPrompt(args: {
     serviceKey: args.serviceKey,
     snapshot,
     refreshModels: true,
+    opencodeEnv: args.opencodeEnv,
     llmGatewayEnabled,
     llmGatewayBaseUrl: llmGatewayEnabled ? llmGatewayBaseUrlForProvider(args.providerName) : undefined,
     llmGatewayDenyEnv: llmGatewayEnabled ? nativeProviderEnvNames().join(',') : '',

--- a/apps/api/src/projects/lib/session-channel-env.test.ts
+++ b/apps/api/src/projects/lib/session-channel-env.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { sessionChannelEnvFromMetadata } from './session-channel-env';
+
+describe('sessionChannelEnvFromMetadata', () => {
+  test('restores Slack and email runtime bindings for a cold reprovision', () => {
+    expect(
+      sessionChannelEnvFromMetadata({
+        slack: {
+          team_id: 'team-1',
+          channel: 'channel-1',
+          thread_ts: 'thread-1',
+          user: 'user-1',
+        },
+        email: {
+          inbox_id: 'inbox-1',
+          thread_id: 'thread-email-1',
+          message_id: 'message-1',
+          address: 'agent@example.com',
+        },
+      }),
+    ).toEqual({
+      SLACK_TEAM_ID: 'team-1',
+      SLACK_CHANNEL_ID: 'channel-1',
+      SLACK_THREAD_TS: 'thread-1',
+      SLACK_USER_ID: 'user-1',
+      KORTIX_EXECUTOR_MCP_ENABLED: '1',
+      KORTIX_EMAIL_INBOX_ID: 'inbox-1',
+      KORTIX_EMAIL_THREAD_ID: 'thread-email-1',
+      KORTIX_EMAIL_MESSAGE_ID: 'message-1',
+      KORTIX_EMAIL_ADDRESS: 'agent@example.com',
+    });
+  });
+
+  test('uses legacy email metadata as the MCP upgrade marker', () => {
+    expect(sessionChannelEnvFromMetadata({ email: { inbox_id: 'inbox-legacy' } })).toEqual({
+      KORTIX_EXECUTOR_MCP_ENABLED: '1',
+      KORTIX_EMAIL_INBOX_ID: 'inbox-legacy',
+    });
+  });
+
+  test('ignores malformed and non-channel metadata', () => {
+    expect(sessionChannelEnvFromMetadata(null)).toEqual({});
+    expect(sessionChannelEnvFromMetadata({ email: 'invalid', slack: [] })).toEqual({});
+    expect(sessionChannelEnvFromMetadata({ source: 'ui' })).toEqual({});
+  });
+});

--- a/apps/api/src/projects/lib/session-channel-env.ts
+++ b/apps/api/src/projects/lib/session-channel-env.ts
@@ -1,0 +1,35 @@
+/**
+ * Reconstruct channel runtime env from the durable session metadata.
+ *
+ * Create-time extraEnvVars are not persisted as a standalone record. A cold
+ * reprovision must therefore derive the channel contract from metadata.
+ */
+export function sessionChannelEnvFromMetadata(metadata: unknown): Record<string, string> {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {};
+  const channels = metadata as {
+    slack?: Record<string, unknown>;
+    email?: Record<string, unknown>;
+  };
+  const env: Record<string, string> = {};
+
+  const slack = channels.slack;
+  if (slack && typeof slack === 'object' && !Array.isArray(slack)) {
+    if (typeof slack.team_id === 'string') env.SLACK_TEAM_ID = slack.team_id;
+    if (typeof slack.channel === 'string') env.SLACK_CHANNEL_ID = slack.channel;
+    if (typeof slack.thread_ts === 'string') env.SLACK_THREAD_TS = slack.thread_ts;
+    if (typeof slack.user === 'string') env.SLACK_USER_ID = slack.user;
+  }
+
+  const email = channels.email;
+  if (email && typeof email === 'object' && !Array.isArray(email)) {
+    // The metadata itself is the durable email-origin marker. This also
+    // upgrades sessions created before the explicit MCP flag existed.
+    env.KORTIX_EXECUTOR_MCP_ENABLED = '1';
+    if (typeof email.inbox_id === 'string') env.KORTIX_EMAIL_INBOX_ID = email.inbox_id;
+    if (typeof email.thread_id === 'string') env.KORTIX_EMAIL_THREAD_ID = email.thread_id;
+    if (typeof email.message_id === 'string') env.KORTIX_EMAIL_MESSAGE_ID = email.message_id;
+    if (typeof email.address === 'string') env.KORTIX_EMAIL_ADDRESS = email.address;
+  }
+
+  return env;
+}

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -73,6 +73,7 @@ import {
   sessionConnectorBindingsRequirePrivateVisibility,
   validateSessionConnectorBindings,
 } from './session-connector-bindings';
+import { sessionChannelEnvFromMetadata } from './session-channel-env';
 import {
   TITLE_SOURCE_MAX_CHARS,
   generateSessionTitleFromFirstPrompt,
@@ -222,11 +223,7 @@ export async function checkConcurrentSessionCap(
 
 export { RESERVED_SANDBOX_ENV_NAMES, isReservedSandboxEnvName };
 
-/**
- * Re-derive a session's chat-channel env (SLACK_*) from its persisted binding so
- * any (re)provision restores it. Best-effort: a non-channel session (no
- * metadata.slack) returns {}, and a read failure never blocks provisioning.
- */
+/** Re-derive persisted channel env so every cold reprovision restores it. */
 async function buildSessionChannelEnv(sessionId: string): Promise<Record<string, string>> {
   try {
     const [row] = await db
@@ -234,14 +231,7 @@ async function buildSessionChannelEnv(sessionId: string): Promise<Record<string,
       .from(projectSessions)
       .where(eq(projectSessions.sessionId, sessionId))
       .limit(1);
-    const slack = (row?.metadata as { slack?: Record<string, unknown> } | null)?.slack;
-    if (!slack) return {};
-    const env: Record<string, string> = {};
-    if (typeof slack.team_id === 'string') env.SLACK_TEAM_ID = slack.team_id;
-    if (typeof slack.channel === 'string') env.SLACK_CHANNEL_ID = slack.channel;
-    if (typeof slack.thread_ts === 'string') env.SLACK_THREAD_TS = slack.thread_ts;
-    if (typeof slack.user === 'string') env.SLACK_USER_ID = slack.user;
-    return env;
+    return sessionChannelEnvFromMetadata(row?.metadata);
   } catch (err) {
     console.warn('[session-env] failed to restore channel binding', {
       sessionId,

--- a/apps/api/src/projects/session-lifecycle/__tests__/continue-session-deleted-guard.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/continue-session-deleted-guard.test.ts
@@ -30,9 +30,10 @@ const PROJECT_ID = 'proj-1';
 let sessionRow: Record<string, unknown> | null = null;
 let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
 
-mock.module('../../../config', () => ({ config: {} }));
+mock.module('../../../config', () => ({ config: {}, SANDBOX_VERSION: 'test' }));
 
 mock.module('../../../shared/db', () => ({
+  hasDatabase: () => true,
   db: {
     select: (_proj: unknown) => ({
       from: (table: unknown) => ({

--- a/apps/api/src/projects/session-lifecycle/__tests__/continue-session-runtime-env.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/continue-session-runtime-env.test.ts
@@ -1,0 +1,131 @@
+// A channel follow-up must enable its OpenCode runtime features before the
+// prompt is delivered. This test isolates engine.ts because Bun mocks are
+// process-global; run this file separately from other engine mock tests.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { projectSessions, projects } from '@kortix/db';
+
+const SESSION_ID = 'sess-runtime-env-1';
+const ACCOUNT_ID = 'acct-1';
+const PROJECT_ID = 'proj-1';
+const EXTERNAL_ID = 'sandbox-1';
+const events: string[] = [];
+
+mock.module('../../../config', () => ({ config: { KORTIX_URL: 'https://api.test' } }));
+
+mock.module('../../../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: async () => {
+            if (table === projectSessions)
+              return [
+                {
+                  accountId: ACCOUNT_ID,
+                  projectId: PROJECT_ID,
+                  status: 'running',
+                  sandboxProvider: 'daytona',
+                  baseRef: 'main',
+                  agentName: 'email-agent',
+                  opencodeSessionId: 'oc-1',
+                  metadata: { email: { inbox_id: 'inbox-1' } },
+                },
+              ];
+            if (table === projects) return [{ projectId: PROJECT_ID, accountId: ACCOUNT_ID }];
+            return [];
+          },
+        }),
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => {} }) }),
+  },
+}));
+
+mock.module('../../session-title-generate', () => ({
+  generateSessionTitleFromFirstPrompt: async () => {},
+}));
+
+mock.module('../../routes/shared', () => ({
+  openSession: async () => {
+    events.push('open');
+    return {
+      stage: 'ready',
+      sandbox: { external_id: EXTERNAL_ID, provider: 'daytona' },
+      opencode_session_id: 'oc-1',
+    };
+  },
+}));
+
+mock.module('../../../sandbox-proxy/backend', () => ({
+  resolveSandboxIngress: async () => ({ url: 'https://sandbox.test', headers: {} }),
+}));
+
+mock.module('../../../platform/service-key', () => ({
+  serviceKeyForExternalId: async () => 'service-key-1',
+}));
+
+mock.module('../../lib/sandbox-env-sync', () => ({
+  syncSandboxEnvForPrompt: async (input: Record<string, unknown>) => {
+    events.push('sync');
+    expect(input).toMatchObject({
+      projectId: PROJECT_ID,
+      sessionId: SESSION_ID,
+      serviceKey: 'service-key-1',
+      previewUrl: 'https://sandbox.test',
+      providerName: 'daytona',
+      opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: '1' },
+    });
+  },
+}));
+
+mock.module('../../../sandbox-proxy/routes/preview', () => ({
+  forwardToSandbox: async () => {
+    events.push('prompt');
+    return new Response(null, { status: 204 });
+  },
+}));
+
+mock.module('../../lib/sessions', () => ({
+  createProjectSession: async () => {
+    throw new Error('not expected');
+  },
+}));
+mock.module('../actor', () => ({
+  resolveProjectAutomationActor: async () => 'automation-user-1',
+}));
+mock.module('../backpressure', () => ({
+  sessionBackpressureState: async () => ({ shouldQueue: false, reason: null }),
+}));
+mock.module('../store', () => ({
+  claimCreateSessionCommand: async () => {
+    throw new Error('not expected');
+  },
+  claimDueLifecycleCommands: async () => [],
+  enqueueContinueSessionCommand: async () => {},
+  markCommandFailed: async () => {},
+  markCommandQueued: async () => {},
+  markCommandSucceeded: async () => {},
+  resultFromExistingCommand: () => {
+    throw new Error('not expected');
+  },
+}));
+
+const { continueSession } = await import('../engine');
+
+beforeEach(() => {
+  events.length = 0;
+});
+
+describe('continueSession runtime env', () => {
+  test('syncs OpenCode env after runtime readiness and before prompt delivery', async () => {
+    expect(
+      await continueSession({
+        source: 'email',
+        sessionId: SESSION_ID,
+        text: 'new email',
+        opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: '1' },
+      }),
+    ).toBe('delivered');
+    expect(events).toEqual(['open', 'sync', 'prompt']);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/__tests__/continue-session-title.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/continue-session-title.test.ts
@@ -14,9 +14,10 @@ let sessionRow: Record<string, unknown> | null = null;
 let titleCalls: Array<Record<string, unknown>> = [];
 let actor: string | null = 'automation-user-1';
 
-mock.module('../../../config', () => ({ config: {} }));
+mock.module('../../../config', () => ({ config: {}, SANDBOX_VERSION: 'test' }));
 
 mock.module('../../../shared/db', () => ({
+  hasDatabase: () => true,
   db: {
     select: (_proj: unknown) => ({
       from: (table: unknown) => ({

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -4,6 +4,9 @@ import { bindChatThread } from '../../channels/slack/binding';
 import { config } from '../../config';
 import { mayRequeueFailedCreate } from './requeue-policy';
 import { forwardToSandbox } from '../../sandbox-proxy/routes/preview';
+import { resolveSandboxIngress } from '../../sandbox-proxy/backend';
+import { serviceKeyForExternalId } from '../../platform/service-key';
+import type { ProviderName } from '../../platform/providers';
 import { db } from '../../shared/db';
 import { connectorBindingPayloadConflicts } from '../lib/session-connector-bindings';
 import { secretsAllowlistPayloadConflicts } from '../secrets';
@@ -12,6 +15,7 @@ import {
   runtimeContextConflicts,
 } from './idempotency-conflicts';
 import { createProjectSession } from '../lib/sessions';
+import { syncSandboxEnvForPrompt } from '../lib/sandbox-env-sync';
 import { openSession } from '../routes/shared';
 import { generateSessionTitleFromFirstPrompt } from '../session-title-generate';
 import { resolveProjectAutomationActor } from './actor';
@@ -411,6 +415,45 @@ export async function continueSession(
     await sleep(POLL_INTERVAL_MS);
   }
 
+  if (command.opencodeEnv) {
+    const sandbox = opened.sandbox as {
+      external_id?: string | null;
+      provider?: string | null;
+    } | null;
+    const externalId = sandbox?.external_id ?? null;
+    const providerName = sandbox?.provider ?? null;
+    if (!externalId || !isProviderName(providerName)) {
+      console.warn('[session-lifecycle] runtime env sync target is incomplete', {
+        sessionId,
+        hasExternalId: !!externalId,
+        provider: providerName,
+      });
+      return 'pending';
+    }
+    try {
+      const [serviceKey, ingress] = await Promise.all([
+        serviceKeyForExternalId(externalId),
+        resolveSandboxIngress(externalId, { port: DAEMON_PORT, transport: 'http' }),
+      ]);
+      if (!serviceKey) throw new Error('sandbox service key is unavailable');
+      await syncSandboxEnvForPrompt({
+        projectId: session.projectId,
+        sessionId,
+        serviceKey,
+        previewUrl: ingress.url,
+        providerHeaders: ingress.headers,
+        providerName,
+        opencodeEnv: command.opencodeEnv,
+      });
+    } catch (err) {
+      console.warn('[session-lifecycle] runtime env sync failed before prompt delivery', {
+        sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return 'pending';
+    }
+  }
+
   // Runtime is ready — hand off the prompt, healing + retrying through the
   // transient failures a freshly-woken sandbox throws (rotated opencode session
   // 404, daemon 5xx while it binds, externalId/opencode_session_id briefly
@@ -739,6 +782,15 @@ function sandboxExternalId(
   result: NonNullable<Awaited<ReturnType<typeof openSession>>>,
 ): string | null {
   return (result.sandbox as { external_id?: string } | null)?.external_id ?? null;
+}
+
+function isProviderName(value: string | null): value is ProviderName {
+  return (
+    value === 'daytona' ||
+    value === 'platinum' ||
+    value === 'e2b' ||
+    value === 'local-docker'
+  );
 }
 
 async function postPrompt(

--- a/apps/api/src/projects/session-lifecycle/types.ts
+++ b/apps/api/src/projects/session-lifecycle/types.ts
@@ -92,6 +92,8 @@ export interface ContinueSessionCommand {
   sessionId: string;
   text: string;
   userId?: string | null;
+  /** Allow-listed env applied to OpenCode before server-side prompt delivery. */
+  opencodeEnv?: Record<string, string | null>;
 }
 
 export interface StartSessionCommand {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -945,6 +945,60 @@ describe('daemon proxy auth gate', () => {
     }
   })
 
+  it('enables Executor MCP in a running session and restarts opencode once', async () => {
+    let restartCalls = 0
+    const previous = process.env.KORTIX_EXECUTOR_MCP_ENABLED
+    delete process.env.KORTIX_EXECUTOR_MCP_ENABLED
+    const store = createProjectEnvStore({} as NodeJS.ProcessEnv)
+    const app = buildOpencodeApp(
+      baseConfig(),
+      fakeOpencode('ok', { restart: () => { restartCalls += 1 } }),
+      Date.now(),
+      { repoMaterializationError: null, timeline: [] },
+      store,
+    )
+
+    const request = () =>
+      app.request('/kortix/env', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${TEST_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          revision: 'rev-email-mcp',
+          env: {},
+          names: [],
+          refreshModels: true,
+          opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: '1' },
+        }),
+      })
+
+    try {
+      const enabled = await request()
+      expect(enabled.status).toBe(200)
+      expect(await enabled.json()).toMatchObject({
+        ok: true,
+        opencode_env_changed: true,
+        opencode_env_names: ['KORTIX_EXECUTOR_MCP_ENABLED'],
+      })
+      expect(process.env.KORTIX_EXECUTOR_MCP_ENABLED as string | undefined).toBe('1')
+      expect(restartCalls).toBe(1)
+
+      const replay = await request()
+      expect(replay.status).toBe(200)
+      expect(await replay.json()).toMatchObject({
+        ok: true,
+        opencode_env_changed: false,
+        opencode_env_names: [],
+      })
+      expect(restartCalls).toBe(1)
+    } finally {
+      if (previous === undefined) delete process.env.KORTIX_EXECUTOR_MCP_ENABLED
+      else process.env.KORTIX_EXECUTOR_MCP_ENABLED = previous
+    }
+  })
+
   it('flips the provider-key deny-list with llm gateway mode (BYOK works when off)', async () => {
     const saved = {
       key: process.env.KORTIX_LLM_API_KEY,

--- a/apps/kortix-sandbox-agent-server/src/routes/env.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/env.ts
@@ -18,6 +18,9 @@ const OPENCODE_RUNTIME_ENV_NAMES = new Set([
   // (opencode.ts), so accepting it here + restarting is what makes a mid-session
   // model change take effect on a box that is already up.
   'KORTIX_OPENCODE_MODEL',
+  // Channel sessions can opt into the Executor MCP face after a deploy. This
+  // must restart OpenCode because MCP servers are registered only at spawn.
+  'KORTIX_EXECUTOR_MCP_ENABLED',
 ])
 
 function bearerToken(header: string | undefined): string | null {


### PR DESCRIPTION
## Summary

- enable the Executor MCP meta-tool surface for new AgentMail sessions
- synchronize the MCP runtime flag into legacy running sessions before follow-up delivery
- restore email runtime bindings from durable session metadata after cold reprovision
- replace nonexistent direct email tool instructions with the real `connectors` / `discover` / `describe` / `call` contract

## Security

- preserve the existing session-scoped Executor token, agent grant, and email profile binding
- allow-list only `KORTIX_EXECUTOR_MCP_ENABLED` for mid-session OpenCode runtime updates
- fail closed before prompt delivery when the runtime env sync cannot be authenticated or completed

## Verification

- API focused suite: 40 passed
- sandbox Executor/proxy suite: 69 passed
- post-rebase focused smoke: 20 passed
- `pnpm --filter kortix-api typecheck`: passed
- `pnpm --filter @kortix/sandbox-agent-server typecheck`: passed
- `git diff --check`: passed