### PR TITLE
fix(secrets): make session writes visible to agents

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -23,6 +23,7 @@ const PROJECT_ID = '00000000-0000-4000-a000-000000000201';
 const SESSION_ID = '00000000-0000-4000-a000-000000000301';
 const TEST_GITHUB_OWNER = 'kortix-org';
 const PROJECT_RUNTIME_PAT = 'kortix_pat_project_runtime';
+const SESSION_AGENT_PAT = 'kortix_pat_session_agent';
 const PROJECT_SANDBOX_TOKEN = 'kortix_sb_project_runtime';
 const PROJECT_SA_TOKEN = 'kortix_sa_backend_wrapper';
 const ORIGINAL_KORTIX_GITHUB_OWNER = process.env.KORTIX_GITHUB_OWNER;
@@ -188,6 +189,23 @@ mock.module('../middleware/auth', () => ({
       c.set('accountId', ACCOUNT_ID);
       c.set('tokenProjectId', PROJECT_ID);
       c.set('iamTokenId', '00000000-0000-4000-a000-000000000901');
+      await next();
+      return;
+    }
+    if (c.req.header('Authorization') === `Bearer ${SESSION_AGENT_PAT}`) {
+      c.set('userId', USER_ID);
+      c.set('userEmail', '');
+      c.set('authType', 'pat');
+      c.set('accountId', ACCOUNT_ID);
+      c.set('tokenProjectId', PROJECT_ID);
+      c.set('sessionId', SESSION_ID);
+      c.set('iamTokenId', '00000000-0000-4000-a000-000000000903');
+      c.set('agentGrant', {
+        agent: 'contract-agent',
+        connectors: 'all',
+        kortixCli: 'all',
+        env: 'all',
+      });
       await next();
       return;
     }
@@ -1034,6 +1052,37 @@ describe('project session API contract', () => {
     expect(deleteRes.status).toBe(200);
     expect(await deleteRes.json()).toEqual({ ok: true });
     expect(secretRows).toHaveLength(0);
+  });
+
+  test('a session agent can verify writes when runtime delivery is narrowed to zero secrets', async () => {
+    sessionRow = { ...sessionRow!, secretsAllowlist: [] };
+    const app = createApp();
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${SESSION_AGENT_PAT}`,
+    };
+
+    const writeRes = await app.request(`/v1/projects/${PROJECT_ID}/secrets`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ name: 'ANTHROPIC_API_KEY', value: 'test-secret' }),
+    });
+    expect(writeRes.status).toBe(200);
+    expect(await writeRes.json()).toMatchObject({
+      identifier: 'ANTHROPIC_API_KEY',
+      configured: true,
+    });
+
+    const listRes = await app.request(`/v1/projects/${PROJECT_ID}/secrets`, { headers });
+    expect(listRes.status).toBe(200);
+    expect(await listRes.json()).toMatchObject({
+      items: [
+        expect.objectContaining({
+          identifier: 'ANTHROPIC_API_KEY',
+          configured: true,
+        }),
+      ],
+    });
   });
 
   test('stores provider-neutral git credentials outside runtime project secrets', async () => {

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -15,7 +15,7 @@ import { propagateProjectSecretsToActiveSandboxes } from '../lib/sandbox-env-syn
 import { isGatewayManagedEnv } from '../../llm-gateway/sandbox-credentials';
 import { seedProjectDefaultModelOnConnect } from '../../llm-gateway/models/seed-default';
 import { createRoute, z } from '@hono/zod-openapi';
-import { projectSecrets, projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import { projectSecrets, projects, sessionSandboxes } from '@kortix/db';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { loadProjectForUser, assertProjectCapability } from '../lib/access';
 import { AnyObject, SecretSchema, projectsApp } from '../lib/app';
@@ -407,7 +407,18 @@ projectsApp.openapi(
         params: z.object({ projectId: z.string() }),
       },
     responses: {
-        200: json(z.array(SecretSchema), 'Secrets'),
+        200: json(
+          z.object({
+            items: z.array(SecretSchema),
+            required: z.array(z.string()),
+            optional: z.array(z.string()),
+            can_manage: z.boolean(),
+            manifest_status: z.enum(['loaded', 'missing', 'error']),
+            manifest_path: z.string(),
+            manifest_error: z.string().optional(),
+          }),
+          'Secret configuration metadata',
+        ),
         ...errors(404),
     },
   }),
@@ -444,41 +455,19 @@ projectsApp.openapi(
   }
 
   // Per-agent secrets scoping: a scoped agent token only sees the IDENTIFIERS
-  // it's granted (mirrors the env-injection narrowing), so it can't enumerate
-  // secrets outside its allowlist. No-op for non-agent tokens / 'all' / null
-  // grants. This is the ONLY gate — every project member with read access sees
-  // every secret; there is no per-secret member/group sharing.
+  // in its standing agent grant. A session secretsAllowlist is a delivery
+  // policy, not a configuration-plane read policy. Applying it here made a
+  // session with `secrets_allowlist: []` accept a shared write and then hide the
+  // written row from the same caller. Runtime materialization still intersects
+  // the agent grant with the session allowlist in sandbox-env-sync.ts.
+  //
+  // This route returns metadata only. It never returns a secret value. The
+  // standing agent grant remains the enumeration ceiling for agent tokens.
   const agentGrant = getAgentGrant(c);
-
-  // KaaB per-session narrowing: a session-bound token (the executor PAT carries
-  // sessionId) must not ENUMERATE identifiers its session allowlist hides —
-  // otherwise the narrowing that scrubs those secrets from $ENV still leaks
-  // their names/metadata here. Mirror the env-injection intersection.
-  const boundSessionId = c.get('sessionId') as string | undefined;
-  let sessionAllowUpper: Set<string> | null = null;
-  if (boundSessionId) {
-    const [sessionRow] = await db
-      .select({ secretsAllowlist: projectSessions.secretsAllowlist })
-      .from(projectSessions)
-      .where(
-        and(
-          eq(projectSessions.sessionId, boundSessionId),
-          eq(projectSessions.projectId, projectId),
-        ),
-      )
-      .limit(1);
-    // Any non-null allowlist narrows the enumeration — including the empty array
-    // (`[]` = enumerate ZERO secrets). Guard on `!= null`, not truthiness alone,
-    // to make that intent explicit (an empty Set filters everything out below).
-    if (sessionRow?.secretsAllowlist != null) {
-      sessionAllowUpper = new Set(sessionRow.secretsAllowlist.map((id) => id.toUpperCase()));
-    }
-  }
 
   const items = (await loadSecretViewsForUser(projectId, loaded.userId, canManageShared))
     .filter((item) => !item.system)
-    .filter((item) => agentMayUseEnv(agentGrant, item.identifier))
-    .filter((item) => !sessionAllowUpper || sessionAllowUpper.has(item.identifier.toUpperCase()));
+    .filter((item) => agentMayUseEnv(agentGrant, item.identifier));
 
   return c.json({
     items,

--- a/apps/cli/src/__tests__/hosts-auth.test.ts
+++ b/apps/cli/src/__tests__/hosts-auth.test.ts
@@ -83,13 +83,29 @@ function captureOutput() {
   };
 }
 
-function mockApi(accounts: typeof ACCOUNTS = ACCOUNTS) {
+function mockApi(
+  accounts: typeof ACCOUNTS = ACCOUNTS,
+  tokenContext?: {
+    auth_type: string | null;
+    project_id: string | null;
+    session_id: string | null;
+    agent: string | null;
+    connectors: string[] | 'all' | null;
+    kortix_cli: string[] | 'all' | null;
+    env: string[] | 'all' | null;
+  },
+) {
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input);
     requests.push(url);
     if (url.endsWith('/v1/accounts/me')) {
       return new Response(
-        JSON.stringify({ user_id: 'user_1', email: 'user@example.test', accounts }),
+        JSON.stringify({
+          user_id: 'user_1',
+          email: 'user@example.test',
+          ...(tokenContext ? { token_context: tokenContext } : {}),
+          accounts,
+        }),
         { status: 200, headers: JSON_HEADERS },
       );
     }
@@ -178,6 +194,26 @@ describe('kortix hosts login', () => {
     const code = await runLogin(['--token', 'kortix_pat_alias', '--no-project']);
     expect(code).toBe(0);
     expect(getHost('test')?.token).toBe('kortix_pat_alias');
+  });
+
+  test('labels an agent session token and its initiating user', async () => {
+    writeConfig('');
+    mockApi(ACCOUNTS, {
+      auth_type: 'pat',
+      project_id: 'project_1',
+      session_id: 'session_1',
+      agent: 'veyris-internal',
+      connectors: 'all',
+      kortix_cli: 'all',
+      env: 'all',
+    });
+
+    const code = await runLogin(['--token', 'kortix_pat_agent', '--no-project']);
+
+    expect(code).toBe(0);
+    expect(stripAnsi(stdout)).toContain(
+      'Logged in to host test as agent veyris-internal (initiator: user@example.test)',
+    );
   });
 });
 

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -208,8 +208,12 @@ export async function performLogin(opts: PerformLoginOptions): Promise<number> {
     /* makeActive */ true,
   );
 
+  const loginIdentity = me.token_context?.agent
+    ? `agent ${C.bold}${me.token_context.agent}${C.reset} ` +
+      `(initiator: ${C.bold}${me.email || me.user_id}${C.reset})`
+    : C.bold + (me.email || me.user_id) + C.reset;
   process.stdout.write(
-    `\n${status.ok(`Logged in to host ${C.bold}${hostName}${C.reset} as ${C.bold}${me.email || me.user_id}${C.reset}`)}\n`,
+    `\n${status.ok(`Logged in to host ${C.bold}${hostName}${C.reset} as ${loginIdentity}`)}\n`,
   );
 
   // The account step of the funnel: exactly one → auto-select; several →

--- a/apps/web/content/docs/project/secrets.mdx
+++ b/apps/web/content/docs/project/secrets.mdx
@@ -80,6 +80,11 @@ session only receives the secrets its agent is granted.
 Run `kortix secrets ls` to see which secrets a project declares and which
 ones have a value set.
 
+The list is configuration metadata. It never returns secret values. A scoped
+agent token sees only identifiers in its agent grant. A session-specific
+`secrets_allowlist` controls delivery into that session, but it does not hide
+configuration metadata that the agent grant permits.
+
 ## Rotate a secret
 
 <Steps>


### PR DESCRIPTION
## Problem

A session-scoped agent token could write a shared project secret and receive `configured: true`, then receive `items: []` from the list route. The list route applied the session runtime delivery allowlist after the standing agent grant. An explicit empty session allowlist therefore hid every configuration row.

## Changes

- Apply only the standing agent grant to secret configuration metadata.
- Keep the session allowlist on runtime materialization.
- Remove one database query from every secret list request.
- Correct the OpenAPI response schema for `GET /projects/{projectId}/secrets`.
- Label agent session tokens in CLI login output with the agent and initiator.
- Document configuration metadata versus session delivery.

## Verification

- API contract: 50 pass, 0 fail, 371 expectations.
- CLI suite: 612 pass, 0 fail, 2053 expectations.
- API typecheck: pass.
- CLI typecheck: pass.
- Real local HTTP: POST returned 200/configured true; GET returned the same item with a session `secrets_allowlist` of `[]`.
- Real local CLI: login showed the agent and initiator; set/list/unset passed; cleanup left 0 rows.

## Security boundary

The endpoint returns metadata only. It never returns secret values. The agent grant remains the enumeration ceiling. The session allowlist still narrows sandbox delivery.