### PR TITLE
fix(email): require one canonical sender mailbox

### DIFF
--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -481,4 +481,57 @@ describe('dispatchAgentMailEvent', () => {
       ),
     ).toBe(false);
   });
+
+  test('sender allow policy rejects ambiguous or attacker-controlled From values', () => {
+    const policy = {
+      mode: 'restricted' as const,
+      allowedEmails: ['customer@example.com'],
+      allowedDomains: [],
+      allowedRegex: null,
+    };
+    const allowed = (from: AgentMailMessageReceivedEvent['message']['from']) =>
+      isAgentMailSenderAllowedForTest(
+        { ...event, message: { ...event.message, from, from_: undefined } },
+        policy,
+      );
+
+    expect(allowed('Customer <customer@example.com>')).toBe(true);
+    expect(allowed('customer@example.com')).toBe(true);
+    expect(allowed('customer@example.com <attacker@evil.test>')).toBe(false);
+    expect(allowed('Attacker <attacker@evil.test>, customer@example.com')).toBe(false);
+    expect(allowed('Customer <customer@example.com> trailing')).toBe(false);
+    expect(allowed('Customer customer@example.com')).toBe(false);
+  });
+
+  test('sender allow policy requires exactly one structured From mailbox', () => {
+    const policy = {
+      mode: 'restricted' as const,
+      allowedEmails: ['customer@example.com'],
+      allowedDomains: [],
+      allowedRegex: null,
+    };
+    const allowed = (from_: AgentMailMessageReceivedEvent['message']['from_']) =>
+      isAgentMailSenderAllowedForTest(
+        { ...event, message: { ...event.message, from: undefined, from_ } },
+        policy,
+      );
+
+    expect(allowed([{ email: 'customer@example.com', name: 'Customer' }])).toBe(true);
+    expect(allowed([{ address: 'customer@example.com' }])).toBe(true);
+    expect(allowed([{ name: 'customer@example.com' }])).toBe(false);
+    expect(allowed(['customer@example.com', 'attacker@evil.test'])).toBe(false);
+    expect(
+      isAgentMailSenderAllowedForTest(
+        {
+          ...event,
+          message: {
+            ...event.message,
+            from: 'customer@example.com',
+            from_: 'attacker@evil.test',
+          },
+        },
+        policy,
+      ),
+    ).toBe(false);
+  });
 });

--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -518,6 +518,17 @@ describe('dispatchAgentMailEvent', () => {
 
     expect(allowed([{ email: 'customer@example.com', name: 'Customer' }])).toBe(true);
     expect(allowed([{ address: 'customer@example.com' }])).toBe(true);
+    expect(
+      allowed([
+        {
+          email: ' Customer@Example.COM ',
+          address: 'customer@example.com',
+        },
+      ]),
+    ).toBe(true);
+    expect(allowed([{ email: '', address: 'customer@example.com' }])).toBe(true);
+    expect(allowed([{ email: 'customer@example.com', address: 'attacker@evil.test' }])).toBe(false);
+    expect(allowed([{ email: 'not a mailbox', address: 'customer@example.com' }])).toBe(false);
     expect(allowed([{ name: 'customer@example.com' }])).toBe(false);
     expect(allowed(['customer@example.com', 'attacker@evil.test'])).toBe(false);
     expect(

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -455,10 +455,63 @@ function messageSender(event: AgentMailMessageReceivedEvent): string {
   return '';
 }
 
+const MAILBOX_PATTERN = /[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+/gi;
+
+/**
+ * Resolve the one canonical From mailbox AgentMail delivered.
+ *
+ * A substring match is not an authorization boundary: a crafted value such
+ * as `allowed@example.com <attacker@evil.test>` contains an allowlisted
+ * address even though the actual mailbox is the value in angle brackets.
+ * Accept either a bare address or one ordinary `Display Name <address>`
+ * mailbox, and reject ambiguous/multi-address values entirely.
+ */
 function senderEmail(event: AgentMailMessageReceivedEvent): string | null {
-  const sender = messageSender(event).toLowerCase();
-  const match = sender.match(/[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+/i);
-  return match?.[0]?.toLowerCase() ?? null;
+  const primary = event.message.from;
+  const alternate = event.message.from_;
+  const primaryMailbox =
+    typeof primary === 'string' && primary.trim() ? canonicalMailbox(primary) : null;
+  const alternateMailbox = canonicalStructuredMailbox(alternate);
+  if (primaryMailbox && alternate !== undefined) {
+    return alternateMailbox === primaryMailbox ? primaryMailbox : null;
+  }
+  if (typeof primary === 'string' && primary.trim()) return primaryMailbox;
+  return alternateMailbox;
+}
+
+function canonicalStructuredMailbox(
+  from: AgentMailMessageReceivedEvent['message']['from_'],
+): string | null {
+  if (Array.isArray(from)) {
+    if (from.length !== 1) return null;
+    const [first] = from;
+    if (typeof first === 'string') return canonicalMailbox(first);
+    if (!first || typeof first !== 'object') return null;
+    return canonicalMailbox(first.email ?? first.address ?? '');
+  }
+  return typeof from === 'string' ? canonicalMailbox(from) : null;
+}
+
+function canonicalMailbox(value: string): string | null {
+  const sender = value.trim().toLowerCase();
+  const matches = [...sender.matchAll(MAILBOX_PATTERN)];
+  if (matches.length !== 1) return null;
+  const mailbox = matches[0]?.[0];
+  if (!mailbox) return null;
+  if (sender === mailbox) return mailbox;
+
+  const open = sender.indexOf('<');
+  const close = sender.indexOf('>');
+  if (
+    open <= 0 ||
+    close !== sender.length - 1 ||
+    sender.indexOf('<', open + 1) !== -1 ||
+    sender.indexOf('>', close + 1) !== -1 ||
+    sender.slice(open + 1, close).trim() !== mailbox
+  ) {
+    return null;
+  }
+  return mailbox;
 }
 
 export function isAgentMailSenderAllowedForTest(

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -487,7 +487,16 @@ function canonicalStructuredMailbox(
     const [first] = from;
     if (typeof first === 'string') return canonicalMailbox(first);
     if (!first || typeof first !== 'object') return null;
-    return canonicalMailbox(first.email ?? first.address ?? '');
+    const rawEmail = typeof first.email === 'string' ? first.email.trim() : '';
+    const rawAddress = typeof first.address === 'string' ? first.address.trim() : '';
+    const email = rawEmail ? canonicalMailbox(rawEmail) : null;
+    const address = rawAddress ? canonicalMailbox(rawAddress) : null;
+    // AgentMail payload variants have used both keys. Treat them as aliases,
+    // but never choose one silently when a malformed or conflicting second
+    // value is present: either condition makes the sender ambiguous.
+    if ((rawEmail && !email) || (rawAddress && !address)) return null;
+    if (email && address && email !== address) return null;
+    return email ?? address;
   }
   return typeof from === 'string' ? canonicalMailbox(from) : null;
 }


### PR DESCRIPTION
Rejects ambiguous or multi-address AgentMail From values before applying exact/domain/regex sender policies. This closes the case where an allowlisted address appears as attacker-controlled display text before the real mailbox.\n\nVerification:\n- bun test apps/api/src/__tests__/unit-email-channel.test.ts (12 pass)\n- pnpm --filter kortix-api typecheck\n- Biome formatting on both changed files