### PR TITLE
fix(sessions): recover from sandbox provider failures

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1748,6 +1748,57 @@ describe('project session API contract', () => {
     expect(sandboxProvisionCalls).toBe(0);
   });
 
+  test('dashboard start upgrades a stored E2B placement failure to the capacity contract', async () => {
+    const app = createApp();
+    sessionRow = {
+      ...sessionRow!,
+      status: 'failed',
+      sandboxProvider: 'e2b',
+      error: 'The sandbox provider could not start this session. Try again.',
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'e2b',
+        externalId: null,
+        baseUrl: null,
+        status: 'error',
+        config: {},
+        metadata: {
+          initStatus: 'failed',
+          initAttempts: 3,
+          initMaxAttempts: 3,
+          failureCategory: 'sandbox-provider',
+          errorMessage: 'The sandbox provider could not start this session. Try again.',
+          lastProvisioningError: '500: Failed to place sandbox',
+        },
+        lastUsedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const response = await app.request(
+      `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`,
+      { method: 'POST' },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      stage: 'failed',
+      retriable: false,
+      failure: {
+        category: 'provider-capacity',
+        message: 'The sandbox provider is at capacity right now. Try again in a minute.',
+        retryable: true,
+      },
+    });
+    expect(sandboxProvisionCalls).toBe(0);
+  });
+
   test('dashboard start retires abandoned no-external-id provisioning rows and reallocates', async () => {
     const app = createApp();
     sessionRow = {

--- a/apps/api/src/platform/services/sandbox-provisioning-error.test.ts
+++ b/apps/api/src/platform/services/sandbox-provisioning-error.test.ts
@@ -13,6 +13,7 @@ describe('classifySandboxProvisioningFailure', () => {
     'too many sandboxes starting on this node',
     'No available runners can satisfy the request',
     '429 Too Many Requests',
+    '500: Failed to place sandbox',
   ])('maps provider capacity text to one provider-neutral contract: %s', (message) => {
     expect(classifySandboxProvisioningFailure(new Error(message))).toEqual({
       category: 'provider-capacity',

--- a/apps/api/src/platform/services/sandbox-provisioning-error.ts
+++ b/apps/api/src/platform/services/sandbox-provisioning-error.ts
@@ -17,7 +17,7 @@ export const SANDBOX_PROVIDER_FAILURE_MESSAGE =
   'The sandbox provider could not start this session. Try again.';
 
 const CAPACITY_PATTERN =
-  /no available runner|no runners available|no capacity|out of capacity|capacity exceeded|rate ?limit|too many requests|maximum number of concurrent (?:e2b )?sandboxes|max(?:imum)? number of running sandboxes(?: on node)? reached|too many sandboxes starting on this node/i;
+  /no available runner|no runners available|no capacity|out of capacity|capacity exceeded|failed to place sandbox|rate ?limit|too many requests|maximum number of concurrent (?:e2b )?sandboxes|max(?:imum)? number of running sandboxes(?: on node)? reached|too many sandboxes starting on this node/i;
 
 const GIT_AUTH_PATTERN =
   /could not read Username|terminal prompts disabled|Authentication failed|fatal: could not read|Invalid username or password|remote: Repository not found|HTTP 401|HTTP 403|access denied|Permission denied \(publickey\)/i;

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -376,7 +376,7 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
   });
 
   test('capacity failure records one attempt and provider-neutral failure metadata', async () => {
-    providerCreateErrors.e2b = 'Maximum number of concurrent E2B sandboxes reached';
+    providerCreateErrors.e2b = '500: Failed to place sandbox';
     const failed = waitFor((resolve) => {
       onProviderEvent = resolve;
     });

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -7,6 +7,7 @@ import type {
 } from '@kortix/api-contract';
 import { auth, json } from '../../openapi';
 import { getProvider, type SandboxStatus } from '../../platform/providers';
+import { classifySandboxProvisioningFailure } from '../../platform/services/sandbox-provisioning-error';
 import { db } from '../../shared/db';
 import { resolveBranchTip } from '../git';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
@@ -501,16 +502,31 @@ export function sessionStartFailureFromSandbox(
   if (row.status !== 'error') return null;
   const metadata = sandboxMetadata(row);
   const rawCategory = metadata.failureCategory;
-  const category =
+  const storedCategory =
     rawCategory === 'provider-capacity' ||
     rawCategory === 'git-auth' ||
     rawCategory === 'sandbox-provider'
       ? rawCategory
       : 'sandbox-provider';
+  const rawProviderError =
+    typeof metadata.lastProvisioningError === 'string'
+      ? metadata.lastProvisioningError
+      : typeof metadata.provisioningError === 'string'
+        ? metadata.provisioningError
+        : null;
+  const inferredFailure = rawProviderError
+    ? classifySandboxProvisioningFailure(rawProviderError)
+    : null;
+  const inferredSpecificFailure =
+    storedCategory === 'sandbox-provider' && inferredFailure?.category !== 'sandbox-provider'
+      ? inferredFailure
+      : null;
+  const category = inferredSpecificFailure?.category ?? storedCategory;
   const message =
-    typeof metadata.errorMessage === 'string' && metadata.errorMessage.length > 0
+    inferredSpecificFailure?.userMessage ??
+    (typeof metadata.errorMessage === 'string' && metadata.errorMessage.length > 0
       ? metadata.errorMessage
-      : 'The sandbox provider could not start this session. Try again.';
+      : 'The sandbox provider could not start this session. Try again.');
   return { category, message, retryable: true };
 }
 

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -210,7 +210,7 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
     setResumeAttempts(0);
     restart.restart();
   };
-  const handleCapacityRetry = () => {
+  const handleProvisioningRetry = () => {
     if (pendingPrompt) {
       writeStartStash(sessionId, startStashFromPendingSessionPrompt(pendingPrompt));
     }
@@ -524,59 +524,55 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
             title={failure.title}
             message={failure.message}
             action={
-              failure.isCapacity ? (
-                <div className="flex flex-col items-center gap-2">
-                  <p className="text-muted-foreground text-xs">
-                    {pendingPrompt ? 'Your prompt is saved.' : 'No prompt was attached.'}
+              <div className="flex flex-col items-center gap-2">
+                <p className="text-muted-foreground text-xs">
+                  {pendingPrompt ? 'Your prompt is saved.' : 'No prompt was attached.'}
+                </p>
+                {pendingAttachmentCount > 0 ? (
+                  <p className="text-muted-foreground/70 text-xs">
+                    {pendingAttachmentCount}{' '}
+                    {pendingAttachmentCount === 1
+                      ? 'attachment is listed. Reattach it after a reload.'
+                      : 'attachments are listed. Reattach them after a reload.'}
                   </p>
-                  {pendingAttachmentCount > 0 ? (
-                    <p className="text-muted-foreground/70 text-xs">
-                      {pendingAttachmentCount}{' '}
-                      {pendingAttachmentCount === 1
-                        ? 'attachment is listed. Reattach it after a reload.'
-                        : 'attachments are listed. Reattach them after a reload.'}
-                    </p>
-                  ) : null}
-                  <div className="flex flex-wrap items-center justify-center gap-2">
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={handleCapacityRetry}
-                      disabled={restart.isPending}
-                      aria-busy={restart.isPending}
-                    >
-                      {restart.isPending ? (
-                        <Loading className="size-3.5 shrink-0" />
-                      ) : (
-                        <RotateCcw className="size-3.5 shrink-0" />
-                      )}
-                      {restart.isPending ? 'Retrying…' : 'Retry'}
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={() => void copyPendingPrompt()}
-                      disabled={!pendingPrompt}
-                    >
-                      <Copy className="size-3.5 shrink-0" />
-                      Copy prompt
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="destructive"
-                      onClick={() => setDeleteOpen(true)}
-                    >
-                      <Trash className="size-3.5 shrink-0" />
-                      Delete
-                    </Button>
-                  </div>
+                ) : null}
+                <div className="flex flex-wrap items-center justify-center gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={handleProvisioningRetry}
+                    disabled={restart.isPending}
+                    aria-busy={restart.isPending}
+                  >
+                    {restart.isPending ? (
+                      <Loading className="size-3.5 shrink-0" />
+                    ) : (
+                      <RotateCcw className="size-3.5 shrink-0" />
+                    )}
+                    {restart.isPending ? 'Retrying…' : 'Retry'}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void copyPendingPrompt()}
+                    disabled={!pendingPrompt}
+                  >
+                    <Copy className="size-3.5 shrink-0" />
+                    Copy prompt
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => setDeleteOpen(true)}
+                  >
+                    <Trash className="size-3.5 shrink-0" />
+                    Delete
+                  </Button>
                 </div>
-              ) : failure.retryable ? (
-                <RestartSessionButton restart={restart} onRestart={handleRestart} />
-              ) : undefined
+              </div>
             }
           />
         );

--- a/apps/web/src/features/session/provisioning-failure.test.ts
+++ b/apps/web/src/features/session/provisioning-failure.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 import {
   pendingSessionPromptFromMetadata,
@@ -18,7 +20,6 @@ describe('provisioningFailurePresentation', () => {
       title: 'Sandbox capacity is full',
       message: 'The sandbox provider is at capacity right now. Try again in a minute.',
       retryable: true,
-      isCapacity: true,
     });
   });
 
@@ -30,6 +31,7 @@ describe('provisioningFailurePresentation', () => {
 
     expect(result.title).toBe('Git access failed');
     expect(result.message).toBe('Check the Git credentials.');
+    expect(result.retryable).toBe(true);
   });
 
   test('uses provider-neutral fallback copy', () => {
@@ -37,8 +39,26 @@ describe('provisioningFailurePresentation', () => {
       title: "Couldn't start Essentia runtime",
       message: 'The sandbox provider could not start this session. Try again.',
       retryable: true,
-      isCapacity: false,
     });
+  });
+});
+
+describe('project session provider-failure recovery', () => {
+  const pageSource = readFileSync(
+    resolve(import.meta.dir, '../../app/(app)/projects/[id]/sessions/[sessionId]/page.tsx'),
+    'utf8',
+  );
+  const failureStart = pageSource.indexOf("if (sandbox?.status === 'error')");
+  const failureEnd = pageSource.indexOf('// Stopped but resumable', failureStart);
+  const failureSurface = pageSource.slice(failureStart, failureEnd);
+
+  test('does not reserve prompt-safe recovery controls for capacity errors', () => {
+    expect(failureStart).toBeGreaterThan(-1);
+    expect(failureEnd).toBeGreaterThan(failureStart);
+    expect(failureSurface).not.toContain('failure.isCapacity');
+    expect(failureSurface).toContain('onClick={handleProvisioningRetry}');
+    expect(failureSurface).toContain('Copy prompt');
+    expect(failureSurface).toContain('onClick={() => setDeleteOpen(true)}');
   });
 });
 

--- a/apps/web/src/features/session/provisioning-failure.ts
+++ b/apps/web/src/features/session/provisioning-failure.ts
@@ -5,7 +5,6 @@ export interface ProvisioningFailurePresentation {
   title: string;
   message: string;
   retryable: boolean;
-  isCapacity: boolean;
 }
 
 /** Build stable error-card copy from API-owned sandbox failure metadata. */
@@ -20,18 +19,17 @@ export function provisioningFailurePresentation(
     'The sandbox provider could not start this session. Try again.';
 
   if (category === 'provider-capacity') {
-    return { title: 'Sandbox capacity is full', message, retryable: true, isCapacity: true };
+    return { title: 'Sandbox capacity is full', message, retryable: true };
   }
 
   if (category === 'git-auth') {
-    return { title: 'Git access failed', message, retryable: true, isCapacity: false };
+    return { title: 'Git access failed', message, retryable: true };
   }
 
   return {
     title: `Couldn't start ${sandboxLabel}`,
     message,
     retryable: true,
-    isCapacity: false,
   };
 }
 

--- a/docs/specs/2026-08-01-session-capacity-and-prompt-recovery.md
+++ b/docs/specs/2026-08-01-session-capacity-and-prompt-recovery.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This contract prevents prompt loss when a sandbox provider has no capacity.
+This contract prevents prompt loss when a sandbox provider cannot start a session.
 It also stops automatic retries that cannot make progress.
 
 ## Capacity authority
@@ -12,6 +12,13 @@ A separate capacity check cannot replace the provider create operation.
 Concurrent requests can pass a separate check at the same time.
 
 The API classifies the provider error after the provider rejects the create operation.
+The API maps known errors to stable user messages.
+The API maps an unknown provider error to the generic `sandbox-provider` category.
+The API keeps the raw provider error in diagnostic metadata.
+Self-hosted E2B returns `500: Failed to place sandbox` when its scheduler cannot place the sandbox.
+The API maps this response to `provider-capacity`.
+The `/start` response also normalizes stored generic placement failures at read time.
+Existing failed sessions therefore use the capacity card without a database migration.
 The API does not expose the raw provider error as user text.
 
 ## Retry policy
@@ -61,14 +68,14 @@ The UI does not show a startup spinner for this state.
 2. The create request also stores `pending_prompt` in session metadata.
 3. The API does not add `pending_prompt` to `KORTIX_INITIAL_PROMPT`.
 4. The API does not send `pending_prompt` to the runtime.
-5. A capacity failure keeps `pending_prompt` unchanged.
+5. A terminal provider failure keeps `pending_prompt` unchanged.
 6. The Retry action copies `pending_prompt` into the browser start stash.
 7. The Retry action starts one explicit restart operation.
 8. The runtime sends the prompt through the normal message path.
 9. The web clears `pending_prompt` only after the runtime ACK.
 
 This sequence prevents an unexpected delayed send.
-A user action is necessary after every terminal capacity rejection.
+A user action is necessary after every terminal provider rejection.
 
 ## Attachment rule
 
@@ -76,19 +83,21 @@ Session metadata stores attachment names only.
 The contract accepts a file-only request with an empty text field.
 The current browser tab keeps the local `File` objects in the pending-files store.
 A page reload can remove the local file bytes.
-The capacity card tells the user to reattach files after a reload.
+The provider failure card tells the user to reattach files after a reload.
 
 Cross-device attachment-byte recovery is not part of this contract.
 That feature needs durable file upload before sandbox admission.
 
-## Capacity card
+## Provider failure card
 
-The terminal capacity card shows these controls:
+Every terminal provider failure card shows these controls:
 
 - `Retry` starts one explicit recovery attempt.
 - `Copy prompt` copies the durable prompt text.
 - `Delete` uses the standard session deletion path.
 
+The title and message come from the API error mapping.
+Capacity, Git authentication, and unknown provider errors use the same recovery controls.
 The card states that the prompt is saved.
 The card shows the attachment count when attachment names exist.
 
@@ -102,7 +111,8 @@ The existing deletion path owns provider cleanup and database cleanup.
 
 The release test must fill all eight E2B slots.
 The ninth create must fail after one provider call.
-The ninth session must show the capacity card without a spinner.
+The ninth session must show the provider failure card without a spinner.
+Git authentication and unknown provider failures must show the same recovery controls.
 The prompt must remain available through Copy prompt.
 Retry must start only after the user selects Retry.
 Retry must succeed after one running sandbox stops.


### PR DESCRIPTION
## Problem

Self-hosted E2B returns `500: Failed to place sandbox` when no compute node can place a sandbox. Kortix classified this response as a generic provider failure and retried it three times. Generic provider failures also lacked the prompt-safe recovery controls.

## Changes

- Classify E2B placement failure as `provider-capacity`.
- Stop automatic create retries after one capacity rejection.
- Normalize existing generic placement failures through `POST /start`.
- Show Retry, Copy prompt, and Delete for every terminal sandbox-provider failure.
- Keep provider-specific titles and safe API messages.
- Preserve the raw provider error in diagnostic metadata.
- Document the provider-failure and prompt-recovery contract.

## Verification

- Focused API and web tests: `27 pass`, `0 fail`.
- Project-session HTTP contract: `51 pass`, `0 fail`, `374 expect()` calls.
- `pnpm --filter kortix-api typecheck`: exit `0`.
- Web ESLint for changed web files: exit `0`.

## Live evidence

Essentia session `fd954e5c-1ba3-441e-ac0f-6161d572bf41` returned:

- `lastProvisioningError: 500: Failed to place sandbox`
- `failureCategory: sandbox-provider`
- `initAttempts: 3`

This PR changes new responses to `failureCategory: provider-capacity` and `initAttempts: 1`. It also normalizes the existing stored response to `provider-capacity` when `/start` reads it.