### PR TITLE
fix(web): show recoverable session failure payload

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -2,11 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 
-import {
-  ArrowCounterClockwiseIcon as RotateCcw,
-  CopyIcon as Copy,
-  TrashIcon as Trash,
-} from '@phosphor-icons/react';
+import { ArrowCounterClockwiseIcon as RotateCcw } from '@phosphor-icons/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
@@ -18,6 +14,7 @@ import Loading from '@/components/ui/loading';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { useAuth } from '@/features/providers/auth-provider';
 import { InstantSessionShell } from '@/features/session/instant-session-shell';
+import { ProviderFailureRecovery } from '@/features/session/provider-failure-recovery';
 import {
   pendingSessionPromptFromMetadata,
   provisioningFailurePresentation,
@@ -168,7 +165,6 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
   });
   const currentProjectSession = projectSessions?.find((item) => item.session_id === sessionId);
   const pendingPrompt = pendingSessionPromptFromMetadata(currentProjectSession?.metadata);
-  const pendingAttachmentCount = pendingPrompt?.attachment_names?.length ?? 0;
   const initialOpenCodeSessionId = findInitialSessionPin(projectSessions, sessionId);
 
   // ONE hook owns the runtime: POST /start (idempotent provision/resume + the
@@ -417,6 +413,37 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
   const sandboxLabel = sandbox?.sandbox_id
     ? `session ${sandbox.sandbox_id.slice(0, 8)}`
     : undefined;
+  const sessionMissing = session.startError?.status === 404 && !sandbox;
+  const recoverableFailure = (() => {
+    if (sessionMissing) return null;
+    const metadata = (sandbox?.metadata as Record<string, unknown>) ?? {};
+    if (session.failure) {
+      return provisioningFailurePresentation(
+        {
+          ...metadata,
+          failureCategory: session.failure.category,
+          errorMessage: session.failure.message,
+        },
+        sandboxLabel ?? 'session',
+      );
+    }
+    if (sandbox?.status === 'error') {
+      return provisioningFailurePresentation(metadata, sandboxLabel ?? 'session');
+    }
+    if (unmaterializedFailure) {
+      return provisioningFailurePresentation({}, sandboxLabel ?? 'session');
+    }
+    if (session.startError) {
+      return provisioningFailurePresentation(
+        {
+          failureCategory: 'sandbox-provider',
+          errorMessage: session.startError.message,
+        },
+        sandboxLabel ?? 'session',
+      );
+    }
+    return null;
+  })();
   const inner = (() => {
     if (sessionSwitchLoading) {
       return (
@@ -466,27 +493,30 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
       );
     }
 
-    if (session.startError) {
-      const sessionMissing = session.startError.status === 404;
+    if (sessionMissing) {
       return (
         <InlineSessionError
           title="Couldn't start session"
-          message={
-            sessionMissing
-              ? 'This session is no longer available, or you do not have access to it.'
-              : session.startError.message
-          }
+          message="This session is no longer available, or you do not have access to it."
         />
       );
     }
 
-    if (unmaterializedFailure) {
+    if (recoverableFailure) {
       return (
         <InlineSessionError
-          title="Couldn't start session"
-          message="Provisioning this session's computer failed. Restart the session to try again."
+          title={recoverableFailure.title}
+          message={recoverableFailure.message}
           detail={restart.errorMessage ?? undefined}
-          action={<RestartSessionButton restart={restart} onRestart={handleRestart} />}
+          action={
+            <ProviderFailureRecovery
+              pendingPrompt={pendingPrompt}
+              isRetrying={restart.isPending}
+              onRetry={handleProvisioningRetry}
+              onCopy={() => void copyPendingPrompt()}
+              onDelete={() => setDeleteOpen(true)}
+            />
+          }
         />
       );
     }
@@ -507,76 +537,6 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
     }
 
     if (fatal) {
-      const meta = (sandbox?.metadata as Record<string, unknown>) ?? {};
-      if (sandbox?.status === 'error') {
-        const failure = provisioningFailurePresentation(
-          session.failure
-            ? {
-                ...meta,
-                failureCategory: session.failure.category,
-                errorMessage: session.failure.message,
-              }
-            : meta,
-          sandboxLabel ?? 'session',
-        );
-        return (
-          <InlineSessionError
-            title={failure.title}
-            message={failure.message}
-            action={
-              <div className="flex flex-col items-center gap-2">
-                <p className="text-muted-foreground text-xs">
-                  {pendingPrompt ? 'Your prompt is saved.' : 'No prompt was attached.'}
-                </p>
-                {pendingAttachmentCount > 0 ? (
-                  <p className="text-muted-foreground/70 text-xs">
-                    {pendingAttachmentCount}{' '}
-                    {pendingAttachmentCount === 1
-                      ? 'attachment is listed. Reattach it after a reload.'
-                      : 'attachments are listed. Reattach them after a reload.'}
-                  </p>
-                ) : null}
-                <div className="flex flex-wrap items-center justify-center gap-2">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={handleProvisioningRetry}
-                    disabled={restart.isPending}
-                    aria-busy={restart.isPending}
-                  >
-                    {restart.isPending ? (
-                      <Loading className="size-3.5 shrink-0" />
-                    ) : (
-                      <RotateCcw className="size-3.5 shrink-0" />
-                    )}
-                    {restart.isPending ? 'Retrying…' : 'Retry'}
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={() => void copyPendingPrompt()}
-                    disabled={!pendingPrompt}
-                  >
-                    <Copy className="size-3.5 shrink-0" />
-                    Copy prompt
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="destructive"
-                    onClick={() => setDeleteOpen(true)}
-                  >
-                    <Trash className="size-3.5 shrink-0" />
-                    Delete
-                  </Button>
-                </div>
-              </div>
-            }
-          />
-        );
-      }
       // Stopped but resumable → we're auto-waking it. Show the boot loader, not a
       // dead-end, so the user just sees it come back (as a hard refresh would).
       if (autoResuming) {

--- a/apps/web/src/features/session/provider-failure-recovery.tsx
+++ b/apps/web/src/features/session/provider-failure-recovery.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import {
+  ArrowCounterClockwiseIcon,
+  CopyIcon,
+  TrashIcon,
+} from '@phosphor-icons/react';
+
+import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
+import type { PendingSessionPrompt } from '@kortix/sdk';
+
+interface ProviderFailureRecoveryProps {
+  pendingPrompt: PendingSessionPrompt | null;
+  isRetrying: boolean;
+  onRetry: () => void;
+  onCopy: () => void;
+  onDelete: () => void;
+}
+
+/** One recovery surface for every terminal sandbox-provider failure. */
+export function ProviderFailureRecovery({
+  pendingPrompt,
+  isRetrying,
+  onRetry,
+  onCopy,
+  onDelete,
+}: ProviderFailureRecoveryProps) {
+  const attachmentNames = pendingPrompt?.attachment_names ?? [];
+
+  return (
+    <div className="flex w-full max-w-md flex-col items-center gap-3">
+      {pendingPrompt ? (
+        <div className="border-border/60 bg-muted/40 w-full rounded-md border px-3 py-2.5 text-left">
+          <p className="text-muted-foreground mb-1 text-xs font-medium">Saved prompt</p>
+          {pendingPrompt.text ? (
+            <p className="text-foreground/90 max-h-40 overflow-y-auto whitespace-pre-wrap break-words text-xs leading-relaxed">
+              {pendingPrompt.text}
+            </p>
+          ) : (
+            <p className="text-muted-foreground/70 text-xs">No text prompt was attached.</p>
+          )}
+          {attachmentNames.length > 0 ? (
+            <div className="border-border/60 mt-2 border-t pt-2">
+              <p className="text-muted-foreground mb-1 text-xs font-medium">
+                {attachmentNames.length === 1 ? 'Attachment' : 'Attachments'}
+              </p>
+              <ul className="text-muted-foreground/70 space-y-0.5 text-xs">
+                {attachmentNames.map((name, index) => (
+                  <li key={`${name}-${index}`} className="break-all">
+                    {name}
+                  </li>
+                ))}
+              </ul>
+              <p className="text-muted-foreground/70 mt-1 text-xs">
+                Reattach these files after a reload.
+              </p>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-xs">No saved prompt is available.</p>
+      )}
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={onRetry}
+          disabled={isRetrying}
+          aria-busy={isRetrying}
+        >
+          {isRetrying ? (
+            <Loading className="size-3.5 shrink-0" />
+          ) : (
+            <ArrowCounterClockwiseIcon className="size-3.5 shrink-0" />
+          )}
+          {isRetrying ? 'Retrying…' : 'Retry'}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={onCopy}
+          disabled={!pendingPrompt?.text}
+        >
+          <CopyIcon className="size-3.5 shrink-0" />
+          Copy prompt
+        </Button>
+        <Button type="button" size="sm" variant="destructive" onClick={onDelete}>
+          <TrashIcon className="size-3.5 shrink-0" />
+          Delete
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/session/provisioning-failure.test.ts
+++ b/apps/web/src/features/session/provisioning-failure.test.ts
@@ -48,17 +48,26 @@ describe('project session provider-failure recovery', () => {
     resolve(import.meta.dir, '../../app/(app)/projects/[id]/sessions/[sessionId]/page.tsx'),
     'utf8',
   );
-  const failureStart = pageSource.indexOf("if (sandbox?.status === 'error')");
-  const failureEnd = pageSource.indexOf('// Stopped but resumable', failureStart);
-  const failureSurface = pageSource.slice(failureStart, failureEnd);
+  const recoverySource = readFileSync(
+    resolve(import.meta.dir, './provider-failure-recovery.tsx'),
+    'utf8',
+  );
 
-  test('does not reserve prompt-safe recovery controls for capacity errors', () => {
-    expect(failureStart).toBeGreaterThan(-1);
-    expect(failureEnd).toBeGreaterThan(failureStart);
-    expect(failureSurface).not.toContain('failure.isCapacity');
-    expect(failureSurface).toContain('onClick={handleProvisioningRetry}');
-    expect(failureSurface).toContain('Copy prompt');
-    expect(failureSurface).toContain('onClick={() => setDeleteOpen(true)}');
+  test('routes structured provider failures and generic start errors through one surface', () => {
+    expect(pageSource).toContain('const recoverableFailure =');
+    expect(pageSource).toContain('session.failure');
+    expect(pageSource).toContain('session.startError');
+    expect(pageSource).toContain('if (unmaterializedFailure)');
+    expect(pageSource).toContain('<ProviderFailureRecovery');
+  });
+
+  test('shows the saved prompt and exposes one-click recovery controls', () => {
+    expect(recoverySource).toContain('Saved prompt');
+    expect(recoverySource).toContain('{pendingPrompt.text}');
+    expect(recoverySource).toContain('whitespace-pre-wrap');
+    expect(recoverySource).toContain('Copy prompt');
+    expect(recoverySource).toContain('onClick={onRetry}');
+    expect(recoverySource).toContain('onClick={onDelete}');
   });
 });
 

--- a/docs/specs/2026-08-01-session-capacity-and-prompt-recovery.md
+++ b/docs/specs/2026-08-01-session-capacity-and-prompt-recovery.md
@@ -98,8 +98,10 @@ Every terminal provider failure card shows these controls:
 
 The title and message come from the API error mapping.
 Capacity, Git authentication, and unknown provider errors use the same recovery controls.
-The card states that the prompt is saved.
-The card shows the attachment count when attachment names exist.
+The card shows the saved prompt text.
+The card shows each attachment name when attachment names exist.
+The card uses the same recovery controls for a non-404 `/start` error.
+A `404` response keeps the separate missing-session message.
 
 ## Deletion rule
 


### PR DESCRIPTION
## Problem

Terminal sandbox failures use different frontend cards. The current card hides the saved prompt text. A non-404 `/start` error has no Retry, Copy prompt, or Delete controls.

## Change

- Route structured provider failures, sandbox error rows, unmaterialized failures, and non-404 `/start` errors through one recovery surface.
- Show the saved prompt text and attachment names.
- Keep Retry, Copy prompt, and Delete available on the shared surface.
- Keep the missing-session 404 state separate.
- Update the session capacity and prompt recovery contract.

## Verification

- `bun test apps/web/src/features/session/provisioning-failure.test.ts apps/web/src/features/session/session-terminal-state.test.ts` -> 21 pass, 0 fail.
- `npx eslint src/app/\(app\)/projects/\[id\]/sessions/\[sessionId\]/page.tsx src/features/session/provider-failure-recovery.tsx src/features/session/provisioning-failure.ts src/features/session/provisioning-failure.test.ts` -> exit 0.
- `npx tsc --noEmit` produced no errors for the changed files.
- Browser proof is pending because no browser instance is available in this session.