### PR TITLE
fix(api): execute email sender regex with RE2

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,6 +44,7 @@
     "jose": "^5.9.6",
     "livekit-server-sdk": "^2.17.0",
     "postgres": "^3.4.8",
+    "re2js": "2.8.6",
     "smol-toml": "^1.6.1",
     "stripe": "^14.0.0",
     "yaml": "^2.8.2",

--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -1,29 +1,29 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { createHmac } from 'node:crypto';
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHmac } from "node:crypto";
 import {
   AgentMailApiError,
   createAgentMailInbox,
   createAgentMailWebhook,
   isAgentMailInboxLimitError,
   resolveAgentMailApiKey,
-} from '../channels/agentmail-api';
-import type { AgentMailMessageReceivedEvent } from '../channels/email/types';
-import { verifyAgentMailSignature } from '../channels/email/verify';
-import { config } from '../config';
+} from "../channels/agentmail-api";
+import type { AgentMailMessageReceivedEvent } from "../channels/email/types";
+import { verifyAgentMailSignature } from "../channels/email/verify";
+import { config } from "../config";
 
 let dbResults: unknown[][] = [];
 
 function makeChain(): any {
   const chain: any = {};
   for (const m of [
-    'from',
-    'innerJoin',
-    'where',
-    'limit',
-    'set',
-    'values',
-    'onConflictDoNothing',
-    'returning',
+    "from",
+    "innerJoin",
+    "where",
+    "limit",
+    "set",
+    "values",
+    "onConflictDoNothing",
+    "returning",
   ]) {
     chain[m] = () => chain;
   }
@@ -32,7 +32,7 @@ function makeChain(): any {
   return chain;
 }
 
-mock.module('../shared/db', () => ({
+mock.module("../shared/db", () => ({
   db: {
     select: () => makeChain(),
     insert: () => makeChain(),
@@ -50,7 +50,7 @@ let continueCalls: Array<{
 let createCalls: Array<any> = [];
 
 function expectExecutorEmailPrompt(prompt: string) {
-  for (const tool of ['connectors', 'discover', 'describe', 'call']) {
+  for (const tool of ["connectors", "discover", "describe", "call"]) {
     expect(prompt).toContain(`\`${tool}\``);
   }
   expect(prompt).toContain('"connector":"email"');
@@ -58,38 +58,39 @@ function expectExecutorEmailPrompt(prompt: string) {
   expect(prompt).toContain('"inbox_id":"inb-1"');
   expect(prompt).toContain('"message_id":"msg-1"');
   expect(prompt).toContain('"text":"<reply>"');
-  expect(prompt).toContain('Use `html` instead of `text` only when needed.');
-  expect(prompt).not.toContain('call `email.reply_message`');
+  expect(prompt).toContain("Use `html` instead of `text` only when needed.");
+  expect(prompt).not.toContain("call `email.reply_message`");
 }
 
 const {
   dispatchAgentMailEvent,
   isAgentMailSenderAllowedForTest,
   resetEmailSessionLifecycleForTest,
+  setEmailSenderPolicyLoaderForTest,
   setEmailSessionLifecycleForTest,
-} = await import('../channels/email/session');
-const { emailWebhookApp } = await import('../channels/email/app');
-await import('../channels/email/routes');
+} = await import("../channels/email/session");
+const { emailWebhookApp } = await import("../channels/email/app");
+await import("../channels/email/routes");
 
 const event: AgentMailMessageReceivedEvent = {
-  type: 'event',
-  event_type: 'message.received',
-  event_id: 'evt-1',
+  type: "event",
+  event_type: "message.received",
+  event_id: "evt-1",
   message: {
-    inbox_id: 'inb-1',
-    thread_id: 'thr-1',
-    message_id: 'msg-1',
-    from: 'Customer <customer@example.com>',
-    to: ['agent@example.com'],
-    subject: 'Need help',
-    text: 'Can you help?',
-    extracted_text: 'Can you help?',
+    inbox_id: "inb-1",
+    thread_id: "thr-1",
+    message_id: "msg-1",
+    from: "Customer <customer@example.com>",
+    to: ["agent@example.com"],
+    subject: "Need help",
+    text: "Can you help?",
+    extracted_text: "Can you help?",
     attachments: [],
   },
   thread: {
-    inbox_id: 'inb-1',
-    thread_id: 'thr-1',
-    subject: 'Need help',
+    inbox_id: "inb-1",
+    thread_id: "thr-1",
+    subject: "Need help",
     message_count: 1,
   },
 };
@@ -104,35 +105,35 @@ beforeEach(() => {
   continueCalls = [];
   createCalls = [];
   setEmailSessionLifecycleForTest({
-    resolveProjectAutomationActor: async () => 'user-1',
+    resolveProjectAutomationActor: async () => "user-1",
     continueSession: async (input) => {
       continueCalls.push({
         sessionId: input.sessionId,
         text: input.text,
         opencodeEnv: input.opencodeEnv,
       });
-      return 'delivered';
+      return "delivered";
     },
     createSession: async (input) => {
       createCalls.push(input);
       return {
-        status: 'created',
-        sessionId: 'sess-1',
-        row: { sessionId: 'sess-1' } as any,
+        status: "created",
+        sessionId: "sess-1",
+        row: { sessionId: "sess-1" } as any,
       };
     },
   });
 });
 
-describe('AgentMail webhook verification', () => {
-  test('accepts valid Svix v1 signatures and rejects tampering', () => {
-    const secret = `whsec_${Buffer.from('test-signing-key').toString('base64')}`;
+describe("AgentMail webhook verification", () => {
+  test("accepts valid Svix v1 signatures and rejects tampering", () => {
+    const secret = `whsec_${Buffer.from("test-signing-key").toString("base64")}`;
     const rawBody = JSON.stringify({ ok: true });
-    const svixId = 'msg_123';
+    const svixId = "msg_123";
     const svixTimestamp = String(Math.floor(Date.now() / 1000));
-    const sig = createHmac('sha256', Buffer.from('test-signing-key'))
+    const sig = createHmac("sha256", Buffer.from("test-signing-key"))
       .update(`${svixId}.${svixTimestamp}.${rawBody}`)
-      .digest('base64');
+      .digest("base64");
 
     expect(
       verifyAgentMailSignature({
@@ -154,28 +155,31 @@ describe('AgentMail webhook verification', () => {
     ).toBe(false);
   });
 
-  test('webhook route fails closed when signing is missing or invalid', async () => {
+  test("webhook route fails closed when signing is missing or invalid", async () => {
     const originalSecret = config.AGENTMAIL_WEBHOOK_SECRET;
     const rawBody = JSON.stringify(event);
     try {
-      (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
-        undefined;
-      const missingSecret = await emailWebhookApp.request('/agentmail', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
+      (
+        config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }
+      ).AGENTMAIL_WEBHOOK_SECRET = undefined;
+      const missingSecret = await emailWebhookApp.request("/agentmail", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
         body: rawBody,
       });
       expect(missingSecret.status).toBe(503);
 
-      (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
-        `whsec_${Buffer.from('test-signing-key').toString('base64')}`;
-      const invalidSignature = await emailWebhookApp.request('/agentmail', {
-        method: 'POST',
+      (
+        config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }
+      ).AGENTMAIL_WEBHOOK_SECRET =
+        `whsec_${Buffer.from("test-signing-key").toString("base64")}`;
+      const invalidSignature = await emailWebhookApp.request("/agentmail", {
+        method: "POST",
         headers: {
-          'content-type': 'application/json',
-          'svix-id': 'msg_123',
-          'svix-timestamp': String(Math.floor(Date.now() / 1000)),
-          'svix-signature': 'v1,not-valid',
+          "content-type": "application/json",
+          "svix-id": "msg_123",
+          "svix-timestamp": String(Math.floor(Date.now() / 1000)),
+          "svix-signature": "v1,not-valid",
         },
         body: rawBody,
       });
@@ -184,58 +188,64 @@ describe('AgentMail webhook verification', () => {
       // A malformed unsigned body (missing event_type/inbox_id) must NOT be
       // acked with 200 — that let an unauthenticated caller poison ack/monitoring
       // with `{}` -> 200 ok. Now rejected with 400 before any signature check.
-      const malformed = await emailWebhookApp.request('/agentmail', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
+      const malformed = await emailWebhookApp.request("/agentmail", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
         body: JSON.stringify({}),
       });
       expect(malformed.status).toBe(400);
     } finally {
-      (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
-        originalSecret;
+      (
+        config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }
+      ).AGENTMAIL_WEBHOOK_SECRET = originalSecret;
     }
   });
 });
 
-describe('AgentMail credential resolution', () => {
-  test('supports both project BYO keys and server-managed fallback keys', () => {
+describe("AgentMail credential resolution", () => {
+  test("supports both project BYO keys and server-managed fallback keys", () => {
     const original = config.AGENTMAIL_API_KEY;
     try {
       (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY =
-        'server-managed-key';
-      expect(resolveAgentMailApiKey('project-byo-key')).toBe('project-byo-key');
-      expect(resolveAgentMailApiKey(null)).toBe('server-managed-key');
-      expect(resolveAgentMailApiKey(undefined)).toBe('server-managed-key');
+        "server-managed-key";
+      expect(resolveAgentMailApiKey("project-byo-key")).toBe("project-byo-key");
+      expect(resolveAgentMailApiKey(null)).toBe("server-managed-key");
+      expect(resolveAgentMailApiKey(undefined)).toBe("server-managed-key");
 
-      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY = undefined;
+      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY =
+        undefined;
       expect(resolveAgentMailApiKey(null)).toBeNull();
     } finally {
-      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY = original;
+      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY =
+        original;
     }
   });
 });
 
-describe('AgentMail webhook provisioning', () => {
-  test('subscribes new inbox webhooks to normal and unauthenticated inbound mail', async () => {
+describe("AgentMail webhook provisioning", () => {
+  test("subscribes new inbox webhooks to normal and unauthenticated inbound mail", async () => {
     const originalFetch = globalThis.fetch;
     let requestBody: any = null;
     globalThis.fetch = (async (_url, init) => {
-      requestBody = JSON.parse(String(init?.body ?? '{}'));
-      return new Response(JSON.stringify({ webhook_id: 'wh-1', secret: 'whsec_test' }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      });
+      requestBody = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(
+        JSON.stringify({ webhook_id: "wh-1", secret: "whsec_test" }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
     }) as typeof fetch;
     try {
       await createAgentMailWebhook({
-        apiKey: 'am_test',
-        inboxId: 'inb-1',
-        url: 'https://api.kortix.test/v1/webhooks/email/agentmail',
-        clientId: 'kortix-email-proj-1',
+        apiKey: "am_test",
+        inboxId: "inb-1",
+        url: "https://api.kortix.test/v1/webhooks/email/agentmail",
+        clientId: "kortix-email-proj-1",
       });
       expect(requestBody.event_types).toEqual([
-        'message.received',
-        'message.received.unauthenticated',
+        "message.received",
+        "message.received.unauthenticated",
       ]);
     } finally {
       globalThis.fetch = originalFetch;
@@ -243,26 +253,26 @@ describe('AgentMail webhook provisioning', () => {
   });
 });
 
-describe('AgentMail provider errors', () => {
-  test('preserves upstream status and detects inbox quota failures', async () => {
+describe("AgentMail provider errors", () => {
+  test("preserves upstream status and detects inbox quota failures", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          message: 'Maximum number of inboxes reached for this workspace',
+          message: "Maximum number of inboxes reached for this workspace",
         }),
         {
           status: 403,
-          headers: { 'content-type': 'application/json' },
+          headers: { "content-type": "application/json" },
         },
       )) as unknown as typeof fetch;
     try {
       try {
         await createAgentMailInbox({
-          apiKey: 'am_test',
-          username: 'support',
-          displayName: 'Support',
-          clientId: 'kortix-project-proj-1',
+          apiKey: "am_test",
+          username: "support",
+          displayName: "Support",
+          clientId: "kortix-project-proj-1",
         });
       } catch (err) {
         expect(err).toBeInstanceOf(AgentMailApiError);
@@ -270,36 +280,36 @@ describe('AgentMail provider errors', () => {
         expect(isAgentMailInboxLimitError(err)).toBe(true);
         return;
       }
-      throw new Error('Expected AgentMail inbox create to fail');
+      throw new Error("Expected AgentMail inbox create to fail");
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 });
 
-describe('dispatchAgentMailEvent', () => {
-  test('first message creates one project-visible session bound to the email thread', async () => {
+describe("dispatchAgentMailEvent", () => {
+  test("first message creates one project-visible session bound to the email thread", async () => {
     dbResults = [
-      [{ eventId: 'email:event:evt-1' }],
-      [{ projectId: 'proj-1' }],
+      [{ eventId: "email:event:evt-1" }],
+      [{ projectId: "proj-1" }],
       [],
-      [{ eventId: 'email:msg:inb-1:msg-1' }],
+      [{ eventId: "email:msg:inb-1:msg-1" }],
       [],
       [
         {
-          projectId: 'proj-1',
-          accountId: 'acc-1',
-          defaultBranch: 'main',
-          name: 'Support',
+          projectId: "proj-1",
+          accountId: "acc-1",
+          defaultBranch: "main",
+          name: "Support",
         },
       ],
-      [{ agentName: 'veyris', opencodeModel: null }],
-      [{ eventId: 'email:threadcreate:inb-1:thr-1' }],
+      [{ agentName: "veyris", opencodeModel: null }],
+      [{ eventId: "email:threadcreate:inb-1:thr-1" }],
       [
         {
-          profileId: 'profile-email-1',
-          metadata: { inbox_id: 'inb-1' },
-          status: 'active',
+          profileId: "profile-email-1",
+          metadata: { inbox_id: "inb-1" },
+          status: "active",
         },
       ],
     ];
@@ -308,28 +318,28 @@ describe('dispatchAgentMailEvent', () => {
 
     expect(continueCalls).toHaveLength(0);
     expect(createCalls).toHaveLength(1);
-    expect(createCalls[0].source).toBe('email');
+    expect(createCalls[0].source).toBe("email");
     expect(createCalls[0].postCreate).toEqual([
       {
-        type: 'bind_chat_thread',
-        platform: 'email',
-        workspaceId: 'inb-1',
-        threadId: 'thr-1',
+        type: "bind_chat_thread",
+        platform: "email",
+        workspaceId: "inb-1",
+        threadId: "thr-1",
       },
       expect.objectContaining({
-        type: 'deliver_prompt',
-        source: 'email',
-        userId: 'user-1',
+        type: "deliver_prompt",
+        source: "email",
+        userId: "user-1",
       }),
     ]);
-    expect(createCalls[0].postCreate[1].text).toContain('Need help');
+    expect(createCalls[0].postCreate[1].text).toContain("Need help");
     expectExecutorEmailPrompt(createCalls[0].postCreate[1].text);
-    expect(createCalls[0].extraEnvVars.KORTIX_EMAIL_INBOX_ID).toBe('inb-1');
-    expect(createCalls[0].extraEnvVars.KORTIX_EXECUTOR_MCP_ENABLED).toBe('1');
+    expect(createCalls[0].extraEnvVars.KORTIX_EMAIL_INBOX_ID).toBe("inb-1");
+    expect(createCalls[0].extraEnvVars.KORTIX_EXECUTOR_MCP_ENABLED).toBe("1");
     expect(createCalls[0].body.connector_bindings).toEqual({
-      email: { authorization_id: 'profile-email-1' },
+      email: { authorization_id: "profile-email-1" },
     });
-    expect(createCalls[0].body.agent_name).toBe('veyris');
+    expect(createCalls[0].body.agent_name).toBe("veyris");
     expect(createCalls[0].body.initial_prompt).toBeUndefined();
   });
 
@@ -337,35 +347,35 @@ describe('dispatchAgentMailEvent', () => {
     const { type: _type, thread: _thread, ...unwrappedEvent } = event;
     const actualAgentMailPayload: AgentMailMessageReceivedEvent = {
       ...unwrappedEvent,
-      event_id: 'evt-unwrapped',
+      event_id: "evt-unwrapped",
       message: {
         ...event.message,
-        thread_id: 'thr-unwrapped',
-        message_id: 'msg-unwrapped',
-        subject: 'Actual AgentMail payload',
+        thread_id: "thr-unwrapped",
+        message_id: "msg-unwrapped",
+        subject: "Actual AgentMail payload",
       },
     };
     dbResults = [
-      [{ eventId: 'email:event:evt-unwrapped' }],
-      [{ projectId: 'proj-1' }],
+      [{ eventId: "email:event:evt-unwrapped" }],
+      [{ projectId: "proj-1" }],
       [],
-      [{ eventId: 'email:msg:inb-1:msg-unwrapped' }],
+      [{ eventId: "email:msg:inb-1:msg-unwrapped" }],
       [],
       [
         {
-          projectId: 'proj-1',
-          accountId: 'acc-1',
-          defaultBranch: 'main',
-          name: 'Support',
+          projectId: "proj-1",
+          accountId: "acc-1",
+          defaultBranch: "main",
+          name: "Support",
         },
       ],
       [],
-      [{ eventId: 'email:threadcreate:inb-1:thr-unwrapped' }],
+      [{ eventId: "email:threadcreate:inb-1:thr-unwrapped" }],
       [
         {
-          profileId: 'profile-email-1',
-          metadata: { inbox_id: 'inb-1' },
-          status: 'active',
+          profileId: "profile-email-1",
+          metadata: { inbox_id: "inb-1" },
+          status: "active",
         },
       ],
     ];
@@ -373,80 +383,112 @@ describe('dispatchAgentMailEvent', () => {
     await dispatchAgentMailEvent(actualAgentMailPayload);
 
     expect(createCalls).toHaveLength(1);
-    expect(createCalls[0].metadata.email.subject).toBe('Actual AgentMail payload');
-    expect(createCalls[0].postCreate[1].text).toContain('Thread ID:  thr-unwrapped');
+    expect(createCalls[0].metadata.email.subject).toBe(
+      "Actual AgentMail payload",
+    );
+    expect(createCalls[0].postCreate[1].text).toContain(
+      "Thread ID:  thr-unwrapped",
+    );
   });
 
-  test('routes unauthenticated inbound mail through the same sender policy and session path', async () => {
+  test("routes unauthenticated inbound mail through the same sender policy and session path", async () => {
     const unauthenticatedEvent: AgentMailMessageReceivedEvent = {
       ...event,
-      event_type: 'message.received.unauthenticated',
-      event_id: 'evt-unauth',
-      message: { ...event.message, message_id: 'msg-unauth' },
+      event_type: "message.received.unauthenticated",
+      event_id: "evt-unauth",
+      message: { ...event.message, message_id: "msg-unauth" },
     };
     dbResults = [
-      [{ eventId: 'email:event:evt-unauth' }],
-      [{ projectId: 'proj-1' }],
+      [{ eventId: "email:event:evt-unauth" }],
+      [{ projectId: "proj-1" }],
       [],
-      [{ eventId: 'email:msg:inb-1:msg-unauth' }],
-      [{ sessionId: 'sess-1' }],
+      [{ eventId: "email:msg:inb-1:msg-unauth" }],
+      [{ sessionId: "sess-1" }],
       [
         {
-          profileId: 'profile-email-1',
-          metadata: { inbox_id: 'inb-1' },
-          status: 'active',
+          profileId: "profile-email-1",
+          metadata: { inbox_id: "inb-1" },
+          status: "active",
         },
       ],
-      [{ accountId: 'acc-1', connectorId: 'conn-email' }],
-      [{ accountId: 'acc-1' }],
+      [{ accountId: "acc-1", connectorId: "conn-email" }],
+      [{ accountId: "acc-1" }],
       [],
-      [{ profileId: 'profile-email-1' }],
+      [{ profileId: "profile-email-1" }],
     ];
 
     await dispatchAgentMailEvent(unauthenticatedEvent);
 
     expect(createCalls).toHaveLength(0);
     expect(continueCalls).toHaveLength(1);
-    expect(continueCalls[0].sessionId).toBe('sess-1');
-    expect(continueCalls[0].opencodeEnv).toEqual({ KORTIX_EXECUTOR_MCP_ENABLED: '1' });
+    expect(continueCalls[0].sessionId).toBe("sess-1");
+    expect(continueCalls[0].opencodeEnv).toEqual({
+      KORTIX_EXECUTOR_MCP_ENABLED: "1",
+    });
   });
 
-  test('known thread routes a new email into the existing session', async () => {
+  test("known thread routes a new email into the existing session", async () => {
     dbResults = [
-      [{ eventId: 'email:event:evt-1' }],
-      [{ projectId: 'proj-1' }],
+      [{ eventId: "email:event:evt-1" }],
+      [{ projectId: "proj-1" }],
       [],
-      [{ eventId: 'email:msg:inb-1:msg-1' }],
-      [{ sessionId: 'sess-1' }],
+      [{ eventId: "email:msg:inb-1:msg-1" }],
+      [{ sessionId: "sess-1" }],
       [
         {
-          profileId: 'profile-email-1',
-          metadata: { inbox_id: 'inb-1' },
-          status: 'active',
+          profileId: "profile-email-1",
+          metadata: { inbox_id: "inb-1" },
+          status: "active",
         },
       ],
-      [{ accountId: 'acc-1', connectorId: 'conn-email' }],
-      [{ accountId: 'acc-1' }],
+      [{ accountId: "acc-1", connectorId: "conn-email" }],
+      [{ accountId: "acc-1" }],
       [],
-      [{ profileId: 'profile-email-1' }],
+      [{ profileId: "profile-email-1" }],
     ];
 
     await dispatchAgentMailEvent(event);
 
     expect(createCalls).toHaveLength(0);
     expect(continueCalls).toHaveLength(1);
-    expect(continueCalls[0].sessionId).toBe('sess-1');
-    expect(continueCalls[0].opencodeEnv).toEqual({ KORTIX_EXECUTOR_MCP_ENABLED: '1' });
-    expect(continueCalls[0].text).toContain('Customer <customer@example.com>');
+    expect(continueCalls[0].sessionId).toBe("sess-1");
+    expect(continueCalls[0].opencodeEnv).toEqual({
+      KORTIX_EXECUTOR_MCP_ENABLED: "1",
+    });
+    expect(continueCalls[0].text).toContain("Customer <customer@example.com>");
     expectExecutorEmailPrompt(continueCalls[0].text);
   });
 
-  test('sender allow policy supports exact emails, domains, and regex', () => {
+  test("a rejected sender never claims the message or creates or continues a session", async () => {
+    setEmailSenderPolicyLoaderForTest(async () => ({
+      mode: "restricted",
+      allowedEmails: ["approved@example.com"],
+      allowedDomains: [],
+      allowedRegex: null,
+    }));
+    dbResults = [
+      [{ eventId: "email:event:evt-1" }],
+      [{ projectId: "proj-1" }],
+      // If dispatch moves past policy enforcement, these sentinels would let
+      // it claim the inbound message and create a new thread/session.
+      [],
+      [{ eventId: "email:msg:inb-1:msg-1" }],
+      [],
+    ];
+
+    await dispatchAgentMailEvent(event);
+
+    expect(createCalls).toHaveLength(0);
+    expect(continueCalls).toHaveLength(0);
+    expect(dbResults).toHaveLength(3);
+  });
+
+  test("sender allow policy supports exact emails, domains, and regex", () => {
     const policy = {
-      mode: 'restricted' as const,
-      allowedEmails: ['customer@example.com'],
-      allowedDomains: ['kortix.com'],
-      allowedRegex: '^vip-[0-9]+@example\\.org$',
+      mode: "restricted" as const,
+      allowedEmails: ["customer@example.com"],
+      allowedDomains: ["kortix.com"],
+      allowedRegex: "^vip-[0-9]+@example\\.org$",
     };
 
     expect(isAgentMailSenderAllowedForTest(event, policy)).toBe(true);
@@ -456,7 +498,7 @@ describe('dispatchAgentMailEvent', () => {
           ...event,
           message: {
             ...event.message,
-            from: 'Teammate <person@ops.kortix.com>',
+            from: "Teammate <person@ops.kortix.com>",
           },
         },
         policy,
@@ -466,7 +508,7 @@ describe('dispatchAgentMailEvent', () => {
       isAgentMailSenderAllowedForTest(
         {
           ...event,
-          message: { ...event.message, from: 'vip-12@example.org' },
+          message: { ...event.message, from: "vip-12@example.org" },
         },
         policy,
       ),
@@ -475,15 +517,15 @@ describe('dispatchAgentMailEvent', () => {
       isAgentMailSenderAllowedForTest(
         {
           ...event,
-          message: { ...event.message, from: 'Other <other@external.test>' },
+          message: { ...event.message, from: "Other <other@external.test>" },
         },
         policy,
       ),
     ).toBe(false);
   });
 
-  test('sender regex runtime stays linear for ambiguous repetition and fails closed on unsupported syntax', () => {
-    const adversarialSender = `${'a'.repeat(50_000)}!@example.com`;
+  test("sender regex runtime stays linear for ambiguous repetition and fails closed on unsupported syntax", () => {
+    const adversarialSender = `${"a".repeat(50_000)}!@example.com`;
     const allowed = (allowedRegex: string) =>
       isAgentMailSenderAllowedForTest(
         {
@@ -495,7 +537,7 @@ describe('dispatchAgentMailEvent', () => {
           },
         },
         {
-          mode: 'restricted',
+          mode: "restricted",
           allowedEmails: [],
           allowedDomains: [],
           allowedRegex,
@@ -503,69 +545,83 @@ describe('dispatchAgentMailEvent', () => {
       );
     const startedAt = performance.now();
 
-    expect(allowed('^(a{1,3})+@example\\.com$')).toBe(false);
-    expect(allowed('^(a|aa)+@example\\.com$')).toBe(false);
-    expect(allowed('^(?=a)a+@example\\.com$')).toBe(false);
+    expect(allowed("^(a{1,3})+@example\\.com$")).toBe(false);
+    expect(allowed("^(a|aa)+@example\\.com$")).toBe(false);
+    expect(allowed("^(?=a)a+@example\\.com$")).toBe(false);
     expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 
-  test('sender allow policy rejects ambiguous or attacker-controlled From values', () => {
+  test("sender allow policy rejects ambiguous or attacker-controlled From values", () => {
     const policy = {
-      mode: 'restricted' as const,
-      allowedEmails: ['customer@example.com'],
+      mode: "restricted" as const,
+      allowedEmails: ["customer@example.com"],
       allowedDomains: [],
       allowedRegex: null,
     };
-    const allowed = (from: AgentMailMessageReceivedEvent['message']['from']) =>
+    const allowed = (from: AgentMailMessageReceivedEvent["message"]["from"]) =>
       isAgentMailSenderAllowedForTest(
         { ...event, message: { ...event.message, from, from_: undefined } },
         policy,
       );
 
-    expect(allowed('Customer <customer@example.com>')).toBe(true);
-    expect(allowed('customer@example.com')).toBe(true);
-    expect(allowed('customer@example.com <attacker@evil.test>')).toBe(false);
-    expect(allowed('Attacker <attacker@evil.test>, customer@example.com')).toBe(false);
-    expect(allowed('Customer <customer@example.com> trailing')).toBe(false);
-    expect(allowed('Customer customer@example.com')).toBe(false);
+    expect(allowed("Customer <customer@example.com>")).toBe(true);
+    expect(allowed("customer@example.com")).toBe(true);
+    expect(allowed("customer@example.com <attacker@evil.test>")).toBe(false);
+    expect(allowed("Attacker <attacker@evil.test>, customer@example.com")).toBe(
+      false,
+    );
+    expect(allowed("Customer <customer@example.com> trailing")).toBe(false);
+    expect(allowed("Customer customer@example.com")).toBe(false);
   });
 
-  test('sender allow policy requires exactly one structured From mailbox', () => {
+  test("sender allow policy requires exactly one structured From mailbox", () => {
     const policy = {
-      mode: 'restricted' as const,
-      allowedEmails: ['customer@example.com'],
+      mode: "restricted" as const,
+      allowedEmails: ["customer@example.com"],
       allowedDomains: [],
       allowedRegex: null,
     };
-    const allowed = (from_: AgentMailMessageReceivedEvent['message']['from_']) =>
+    const allowed = (
+      from_: AgentMailMessageReceivedEvent["message"]["from_"],
+    ) =>
       isAgentMailSenderAllowedForTest(
         { ...event, message: { ...event.message, from: undefined, from_ } },
         policy,
       );
 
-    expect(allowed([{ email: 'customer@example.com', name: 'Customer' }])).toBe(true);
-    expect(allowed([{ address: 'customer@example.com' }])).toBe(true);
+    expect(allowed([{ email: "customer@example.com", name: "Customer" }])).toBe(
+      true,
+    );
+    expect(allowed([{ address: "customer@example.com" }])).toBe(true);
     expect(
       allowed([
         {
-          email: ' Customer@Example.COM ',
-          address: 'customer@example.com',
+          email: " Customer@Example.COM ",
+          address: "customer@example.com",
         },
       ]),
     ).toBe(true);
-    expect(allowed([{ email: '', address: 'customer@example.com' }])).toBe(true);
-    expect(allowed([{ email: 'customer@example.com', address: 'attacker@evil.test' }])).toBe(false);
-    expect(allowed([{ email: 'not a mailbox', address: 'customer@example.com' }])).toBe(false);
-    expect(allowed([{ name: 'customer@example.com' }])).toBe(false);
-    expect(allowed(['customer@example.com', 'attacker@evil.test'])).toBe(false);
+    expect(allowed([{ email: "", address: "customer@example.com" }])).toBe(
+      true,
+    );
+    expect(
+      allowed([
+        { email: "customer@example.com", address: "attacker@evil.test" },
+      ]),
+    ).toBe(false);
+    expect(
+      allowed([{ email: "not a mailbox", address: "customer@example.com" }]),
+    ).toBe(false);
+    expect(allowed([{ name: "customer@example.com" }])).toBe(false);
+    expect(allowed(["customer@example.com", "attacker@evil.test"])).toBe(false);
     expect(
       isAgentMailSenderAllowedForTest(
         {
           ...event,
           message: {
             ...event.message,
-            from: 'customer@example.com',
-            from_: 'attacker@evil.test',
+            from: "customer@example.com",
+            from_: "attacker@evil.test",
           },
         },
         policy,

--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -66,6 +66,7 @@ const {
   dispatchAgentMailEvent,
   isAgentMailSenderAllowedForTest,
   resetEmailSessionLifecycleForTest,
+  setEmailSenderPolicyLoaderForTest,
   setEmailSessionLifecycleForTest,
 } = await import('../channels/email/session');
 const { emailWebhookApp } = await import('../channels/email/app');
@@ -439,6 +440,30 @@ describe('dispatchAgentMailEvent', () => {
     expect(continueCalls[0].opencodeEnv).toEqual({ KORTIX_EXECUTOR_MCP_ENABLED: '1' });
     expect(continueCalls[0].text).toContain('Customer <customer@example.com>');
     expectExecutorEmailPrompt(continueCalls[0].text);
+  });
+
+  test('a rejected sender never claims the message or creates or continues a session', async () => {
+    setEmailSenderPolicyLoaderForTest(async () => ({
+      mode: 'restricted',
+      allowedEmails: ['approved@example.com'],
+      allowedDomains: [],
+      allowedRegex: null,
+    }));
+    dbResults = [
+      [{ eventId: 'email:event:evt-1' }],
+      [{ projectId: 'proj-1' }],
+      // If dispatch moves past policy enforcement, these sentinels would let
+      // it claim the inbound message and create a new thread/session.
+      [],
+      [{ eventId: 'email:msg:inb-1:msg-1' }],
+      [],
+    ];
+
+    await dispatchAgentMailEvent(event);
+
+    expect(createCalls).toHaveLength(0);
+    expect(continueCalls).toHaveLength(0);
+    expect(dbResults).toHaveLength(3);
   });
 
   test('sender allow policy supports exact emails, domains, and regex', () => {

--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { createHmac } from 'node:crypto';
-import { config } from '../config';
 import {
   AgentMailApiError,
   createAgentMailInbox,
@@ -8,8 +7,9 @@ import {
   isAgentMailInboxLimitError,
   resolveAgentMailApiKey,
 } from '../channels/agentmail-api';
-import { verifyAgentMailSignature } from '../channels/email/verify';
 import type { AgentMailMessageReceivedEvent } from '../channels/email/types';
+import { verifyAgentMailSignature } from '../channels/email/verify';
+import { config } from '../config';
 
 let dbResults: unknown[][] = [];
 
@@ -480,6 +480,33 @@ describe('dispatchAgentMailEvent', () => {
         policy,
       ),
     ).toBe(false);
+  });
+
+  test('sender regex runtime stays linear for ambiguous repetition and fails closed on unsupported syntax', () => {
+    const adversarialSender = `${'a'.repeat(50_000)}!@example.com`;
+    const allowed = (allowedRegex: string) =>
+      isAgentMailSenderAllowedForTest(
+        {
+          ...event,
+          message: {
+            ...event.message,
+            from: adversarialSender,
+            from_: undefined,
+          },
+        },
+        {
+          mode: 'restricted',
+          allowedEmails: [],
+          allowedDomains: [],
+          allowedRegex,
+        },
+      );
+    const startedAt = performance.now();
+
+    expect(allowed('^(a{1,3})+@example\\.com$')).toBe(false);
+    expect(allowed('^(a|aa)+@example\\.com$')).toBe(false);
+    expect(allowed('^(?=a)a+@example\\.com$')).toBe(false);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 
   test('sender allow policy rejects ambiguous or attacker-controlled From values', () => {

--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -1,29 +1,29 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { createHmac } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { createHmac } from 'node:crypto';
 import {
   AgentMailApiError,
   createAgentMailInbox,
   createAgentMailWebhook,
   isAgentMailInboxLimitError,
   resolveAgentMailApiKey,
-} from "../channels/agentmail-api";
-import type { AgentMailMessageReceivedEvent } from "../channels/email/types";
-import { verifyAgentMailSignature } from "../channels/email/verify";
-import { config } from "../config";
+} from '../channels/agentmail-api';
+import type { AgentMailMessageReceivedEvent } from '../channels/email/types';
+import { verifyAgentMailSignature } from '../channels/email/verify';
+import { config } from '../config';
 
 let dbResults: unknown[][] = [];
 
 function makeChain(): any {
   const chain: any = {};
   for (const m of [
-    "from",
-    "innerJoin",
-    "where",
-    "limit",
-    "set",
-    "values",
-    "onConflictDoNothing",
-    "returning",
+    'from',
+    'innerJoin',
+    'where',
+    'limit',
+    'set',
+    'values',
+    'onConflictDoNothing',
+    'returning',
   ]) {
     chain[m] = () => chain;
   }
@@ -32,7 +32,7 @@ function makeChain(): any {
   return chain;
 }
 
-mock.module("../shared/db", () => ({
+mock.module('../shared/db', () => ({
   db: {
     select: () => makeChain(),
     insert: () => makeChain(),
@@ -50,7 +50,7 @@ let continueCalls: Array<{
 let createCalls: Array<any> = [];
 
 function expectExecutorEmailPrompt(prompt: string) {
-  for (const tool of ["connectors", "discover", "describe", "call"]) {
+  for (const tool of ['connectors', 'discover', 'describe', 'call']) {
     expect(prompt).toContain(`\`${tool}\``);
   }
   expect(prompt).toContain('"connector":"email"');
@@ -58,39 +58,38 @@ function expectExecutorEmailPrompt(prompt: string) {
   expect(prompt).toContain('"inbox_id":"inb-1"');
   expect(prompt).toContain('"message_id":"msg-1"');
   expect(prompt).toContain('"text":"<reply>"');
-  expect(prompt).toContain("Use `html` instead of `text` only when needed.");
-  expect(prompt).not.toContain("call `email.reply_message`");
+  expect(prompt).toContain('Use `html` instead of `text` only when needed.');
+  expect(prompt).not.toContain('call `email.reply_message`');
 }
 
 const {
   dispatchAgentMailEvent,
   isAgentMailSenderAllowedForTest,
   resetEmailSessionLifecycleForTest,
-  setEmailSenderPolicyLoaderForTest,
   setEmailSessionLifecycleForTest,
-} = await import("../channels/email/session");
-const { emailWebhookApp } = await import("../channels/email/app");
-await import("../channels/email/routes");
+} = await import('../channels/email/session');
+const { emailWebhookApp } = await import('../channels/email/app');
+await import('../channels/email/routes');
 
 const event: AgentMailMessageReceivedEvent = {
-  type: "event",
-  event_type: "message.received",
-  event_id: "evt-1",
+  type: 'event',
+  event_type: 'message.received',
+  event_id: 'evt-1',
   message: {
-    inbox_id: "inb-1",
-    thread_id: "thr-1",
-    message_id: "msg-1",
-    from: "Customer <customer@example.com>",
-    to: ["agent@example.com"],
-    subject: "Need help",
-    text: "Can you help?",
-    extracted_text: "Can you help?",
+    inbox_id: 'inb-1',
+    thread_id: 'thr-1',
+    message_id: 'msg-1',
+    from: 'Customer <customer@example.com>',
+    to: ['agent@example.com'],
+    subject: 'Need help',
+    text: 'Can you help?',
+    extracted_text: 'Can you help?',
     attachments: [],
   },
   thread: {
-    inbox_id: "inb-1",
-    thread_id: "thr-1",
-    subject: "Need help",
+    inbox_id: 'inb-1',
+    thread_id: 'thr-1',
+    subject: 'Need help',
     message_count: 1,
   },
 };
@@ -105,35 +104,35 @@ beforeEach(() => {
   continueCalls = [];
   createCalls = [];
   setEmailSessionLifecycleForTest({
-    resolveProjectAutomationActor: async () => "user-1",
+    resolveProjectAutomationActor: async () => 'user-1',
     continueSession: async (input) => {
       continueCalls.push({
         sessionId: input.sessionId,
         text: input.text,
         opencodeEnv: input.opencodeEnv,
       });
-      return "delivered";
+      return 'delivered';
     },
     createSession: async (input) => {
       createCalls.push(input);
       return {
-        status: "created",
-        sessionId: "sess-1",
-        row: { sessionId: "sess-1" } as any,
+        status: 'created',
+        sessionId: 'sess-1',
+        row: { sessionId: 'sess-1' } as any,
       };
     },
   });
 });
 
-describe("AgentMail webhook verification", () => {
-  test("accepts valid Svix v1 signatures and rejects tampering", () => {
-    const secret = `whsec_${Buffer.from("test-signing-key").toString("base64")}`;
+describe('AgentMail webhook verification', () => {
+  test('accepts valid Svix v1 signatures and rejects tampering', () => {
+    const secret = `whsec_${Buffer.from('test-signing-key').toString('base64')}`;
     const rawBody = JSON.stringify({ ok: true });
-    const svixId = "msg_123";
+    const svixId = 'msg_123';
     const svixTimestamp = String(Math.floor(Date.now() / 1000));
-    const sig = createHmac("sha256", Buffer.from("test-signing-key"))
+    const sig = createHmac('sha256', Buffer.from('test-signing-key'))
       .update(`${svixId}.${svixTimestamp}.${rawBody}`)
-      .digest("base64");
+      .digest('base64');
 
     expect(
       verifyAgentMailSignature({
@@ -155,31 +154,28 @@ describe("AgentMail webhook verification", () => {
     ).toBe(false);
   });
 
-  test("webhook route fails closed when signing is missing or invalid", async () => {
+  test('webhook route fails closed when signing is missing or invalid', async () => {
     const originalSecret = config.AGENTMAIL_WEBHOOK_SECRET;
     const rawBody = JSON.stringify(event);
     try {
-      (
-        config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }
-      ).AGENTMAIL_WEBHOOK_SECRET = undefined;
-      const missingSecret = await emailWebhookApp.request("/agentmail", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
+      (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
+        undefined;
+      const missingSecret = await emailWebhookApp.request('/agentmail', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
         body: rawBody,
       });
       expect(missingSecret.status).toBe(503);
 
-      (
-        config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }
-      ).AGENTMAIL_WEBHOOK_SECRET =
-        `whsec_${Buffer.from("test-signing-key").toString("base64")}`;
-      const invalidSignature = await emailWebhookApp.request("/agentmail", {
-        method: "POST",
+      (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
+        `whsec_${Buffer.from('test-signing-key').toString('base64')}`;
+      const invalidSignature = await emailWebhookApp.request('/agentmail', {
+        method: 'POST',
         headers: {
-          "content-type": "application/json",
-          "svix-id": "msg_123",
-          "svix-timestamp": String(Math.floor(Date.now() / 1000)),
-          "svix-signature": "v1,not-valid",
+          'content-type': 'application/json',
+          'svix-id': 'msg_123',
+          'svix-timestamp': String(Math.floor(Date.now() / 1000)),
+          'svix-signature': 'v1,not-valid',
         },
         body: rawBody,
       });
@@ -188,64 +184,58 @@ describe("AgentMail webhook verification", () => {
       // A malformed unsigned body (missing event_type/inbox_id) must NOT be
       // acked with 200 — that let an unauthenticated caller poison ack/monitoring
       // with `{}` -> 200 ok. Now rejected with 400 before any signature check.
-      const malformed = await emailWebhookApp.request("/agentmail", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
+      const malformed = await emailWebhookApp.request('/agentmail', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
         body: JSON.stringify({}),
       });
       expect(malformed.status).toBe(400);
     } finally {
-      (
-        config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }
-      ).AGENTMAIL_WEBHOOK_SECRET = originalSecret;
+      (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
+        originalSecret;
     }
   });
 });
 
-describe("AgentMail credential resolution", () => {
-  test("supports both project BYO keys and server-managed fallback keys", () => {
+describe('AgentMail credential resolution', () => {
+  test('supports both project BYO keys and server-managed fallback keys', () => {
     const original = config.AGENTMAIL_API_KEY;
     try {
       (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY =
-        "server-managed-key";
-      expect(resolveAgentMailApiKey("project-byo-key")).toBe("project-byo-key");
-      expect(resolveAgentMailApiKey(null)).toBe("server-managed-key");
-      expect(resolveAgentMailApiKey(undefined)).toBe("server-managed-key");
+        'server-managed-key';
+      expect(resolveAgentMailApiKey('project-byo-key')).toBe('project-byo-key');
+      expect(resolveAgentMailApiKey(null)).toBe('server-managed-key');
+      expect(resolveAgentMailApiKey(undefined)).toBe('server-managed-key');
 
-      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY =
-        undefined;
+      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY = undefined;
       expect(resolveAgentMailApiKey(null)).toBeNull();
     } finally {
-      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY =
-        original;
+      (config as { AGENTMAIL_API_KEY: string | undefined }).AGENTMAIL_API_KEY = original;
     }
   });
 });
 
-describe("AgentMail webhook provisioning", () => {
-  test("subscribes new inbox webhooks to normal and unauthenticated inbound mail", async () => {
+describe('AgentMail webhook provisioning', () => {
+  test('subscribes new inbox webhooks to normal and unauthenticated inbound mail', async () => {
     const originalFetch = globalThis.fetch;
     let requestBody: any = null;
     globalThis.fetch = (async (_url, init) => {
-      requestBody = JSON.parse(String(init?.body ?? "{}"));
-      return new Response(
-        JSON.stringify({ webhook_id: "wh-1", secret: "whsec_test" }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
-      );
+      requestBody = JSON.parse(String(init?.body ?? '{}'));
+      return new Response(JSON.stringify({ webhook_id: 'wh-1', secret: 'whsec_test' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
     }) as typeof fetch;
     try {
       await createAgentMailWebhook({
-        apiKey: "am_test",
-        inboxId: "inb-1",
-        url: "https://api.kortix.test/v1/webhooks/email/agentmail",
-        clientId: "kortix-email-proj-1",
+        apiKey: 'am_test',
+        inboxId: 'inb-1',
+        url: 'https://api.kortix.test/v1/webhooks/email/agentmail',
+        clientId: 'kortix-email-proj-1',
       });
       expect(requestBody.event_types).toEqual([
-        "message.received",
-        "message.received.unauthenticated",
+        'message.received',
+        'message.received.unauthenticated',
       ]);
     } finally {
       globalThis.fetch = originalFetch;
@@ -253,26 +243,26 @@ describe("AgentMail webhook provisioning", () => {
   });
 });
 
-describe("AgentMail provider errors", () => {
-  test("preserves upstream status and detects inbox quota failures", async () => {
+describe('AgentMail provider errors', () => {
+  test('preserves upstream status and detects inbox quota failures', async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          message: "Maximum number of inboxes reached for this workspace",
+          message: 'Maximum number of inboxes reached for this workspace',
         }),
         {
           status: 403,
-          headers: { "content-type": "application/json" },
+          headers: { 'content-type': 'application/json' },
         },
       )) as unknown as typeof fetch;
     try {
       try {
         await createAgentMailInbox({
-          apiKey: "am_test",
-          username: "support",
-          displayName: "Support",
-          clientId: "kortix-project-proj-1",
+          apiKey: 'am_test',
+          username: 'support',
+          displayName: 'Support',
+          clientId: 'kortix-project-proj-1',
         });
       } catch (err) {
         expect(err).toBeInstanceOf(AgentMailApiError);
@@ -280,36 +270,36 @@ describe("AgentMail provider errors", () => {
         expect(isAgentMailInboxLimitError(err)).toBe(true);
         return;
       }
-      throw new Error("Expected AgentMail inbox create to fail");
+      throw new Error('Expected AgentMail inbox create to fail');
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 });
 
-describe("dispatchAgentMailEvent", () => {
-  test("first message creates one project-visible session bound to the email thread", async () => {
+describe('dispatchAgentMailEvent', () => {
+  test('first message creates one project-visible session bound to the email thread', async () => {
     dbResults = [
-      [{ eventId: "email:event:evt-1" }],
-      [{ projectId: "proj-1" }],
+      [{ eventId: 'email:event:evt-1' }],
+      [{ projectId: 'proj-1' }],
       [],
-      [{ eventId: "email:msg:inb-1:msg-1" }],
+      [{ eventId: 'email:msg:inb-1:msg-1' }],
       [],
       [
         {
-          projectId: "proj-1",
-          accountId: "acc-1",
-          defaultBranch: "main",
-          name: "Support",
+          projectId: 'proj-1',
+          accountId: 'acc-1',
+          defaultBranch: 'main',
+          name: 'Support',
         },
       ],
-      [{ agentName: "veyris", opencodeModel: null }],
-      [{ eventId: "email:threadcreate:inb-1:thr-1" }],
+      [{ agentName: 'veyris', opencodeModel: null }],
+      [{ eventId: 'email:threadcreate:inb-1:thr-1' }],
       [
         {
-          profileId: "profile-email-1",
-          metadata: { inbox_id: "inb-1" },
-          status: "active",
+          profileId: 'profile-email-1',
+          metadata: { inbox_id: 'inb-1' },
+          status: 'active',
         },
       ],
     ];
@@ -318,28 +308,28 @@ describe("dispatchAgentMailEvent", () => {
 
     expect(continueCalls).toHaveLength(0);
     expect(createCalls).toHaveLength(1);
-    expect(createCalls[0].source).toBe("email");
+    expect(createCalls[0].source).toBe('email');
     expect(createCalls[0].postCreate).toEqual([
       {
-        type: "bind_chat_thread",
-        platform: "email",
-        workspaceId: "inb-1",
-        threadId: "thr-1",
+        type: 'bind_chat_thread',
+        platform: 'email',
+        workspaceId: 'inb-1',
+        threadId: 'thr-1',
       },
       expect.objectContaining({
-        type: "deliver_prompt",
-        source: "email",
-        userId: "user-1",
+        type: 'deliver_prompt',
+        source: 'email',
+        userId: 'user-1',
       }),
     ]);
-    expect(createCalls[0].postCreate[1].text).toContain("Need help");
+    expect(createCalls[0].postCreate[1].text).toContain('Need help');
     expectExecutorEmailPrompt(createCalls[0].postCreate[1].text);
-    expect(createCalls[0].extraEnvVars.KORTIX_EMAIL_INBOX_ID).toBe("inb-1");
-    expect(createCalls[0].extraEnvVars.KORTIX_EXECUTOR_MCP_ENABLED).toBe("1");
+    expect(createCalls[0].extraEnvVars.KORTIX_EMAIL_INBOX_ID).toBe('inb-1');
+    expect(createCalls[0].extraEnvVars.KORTIX_EXECUTOR_MCP_ENABLED).toBe('1');
     expect(createCalls[0].body.connector_bindings).toEqual({
-      email: { authorization_id: "profile-email-1" },
+      email: { authorization_id: 'profile-email-1' },
     });
-    expect(createCalls[0].body.agent_name).toBe("veyris");
+    expect(createCalls[0].body.agent_name).toBe('veyris');
     expect(createCalls[0].body.initial_prompt).toBeUndefined();
   });
 
@@ -347,35 +337,35 @@ describe("dispatchAgentMailEvent", () => {
     const { type: _type, thread: _thread, ...unwrappedEvent } = event;
     const actualAgentMailPayload: AgentMailMessageReceivedEvent = {
       ...unwrappedEvent,
-      event_id: "evt-unwrapped",
+      event_id: 'evt-unwrapped',
       message: {
         ...event.message,
-        thread_id: "thr-unwrapped",
-        message_id: "msg-unwrapped",
-        subject: "Actual AgentMail payload",
+        thread_id: 'thr-unwrapped',
+        message_id: 'msg-unwrapped',
+        subject: 'Actual AgentMail payload',
       },
     };
     dbResults = [
-      [{ eventId: "email:event:evt-unwrapped" }],
-      [{ projectId: "proj-1" }],
+      [{ eventId: 'email:event:evt-unwrapped' }],
+      [{ projectId: 'proj-1' }],
       [],
-      [{ eventId: "email:msg:inb-1:msg-unwrapped" }],
+      [{ eventId: 'email:msg:inb-1:msg-unwrapped' }],
       [],
       [
         {
-          projectId: "proj-1",
-          accountId: "acc-1",
-          defaultBranch: "main",
-          name: "Support",
+          projectId: 'proj-1',
+          accountId: 'acc-1',
+          defaultBranch: 'main',
+          name: 'Support',
         },
       ],
       [],
-      [{ eventId: "email:threadcreate:inb-1:thr-unwrapped" }],
+      [{ eventId: 'email:threadcreate:inb-1:thr-unwrapped' }],
       [
         {
-          profileId: "profile-email-1",
-          metadata: { inbox_id: "inb-1" },
-          status: "active",
+          profileId: 'profile-email-1',
+          metadata: { inbox_id: 'inb-1' },
+          status: 'active',
         },
       ],
     ];
@@ -383,112 +373,80 @@ describe("dispatchAgentMailEvent", () => {
     await dispatchAgentMailEvent(actualAgentMailPayload);
 
     expect(createCalls).toHaveLength(1);
-    expect(createCalls[0].metadata.email.subject).toBe(
-      "Actual AgentMail payload",
-    );
-    expect(createCalls[0].postCreate[1].text).toContain(
-      "Thread ID:  thr-unwrapped",
-    );
+    expect(createCalls[0].metadata.email.subject).toBe('Actual AgentMail payload');
+    expect(createCalls[0].postCreate[1].text).toContain('Thread ID:  thr-unwrapped');
   });
 
-  test("routes unauthenticated inbound mail through the same sender policy and session path", async () => {
+  test('routes unauthenticated inbound mail through the same sender policy and session path', async () => {
     const unauthenticatedEvent: AgentMailMessageReceivedEvent = {
       ...event,
-      event_type: "message.received.unauthenticated",
-      event_id: "evt-unauth",
-      message: { ...event.message, message_id: "msg-unauth" },
+      event_type: 'message.received.unauthenticated',
+      event_id: 'evt-unauth',
+      message: { ...event.message, message_id: 'msg-unauth' },
     };
     dbResults = [
-      [{ eventId: "email:event:evt-unauth" }],
-      [{ projectId: "proj-1" }],
+      [{ eventId: 'email:event:evt-unauth' }],
+      [{ projectId: 'proj-1' }],
       [],
-      [{ eventId: "email:msg:inb-1:msg-unauth" }],
-      [{ sessionId: "sess-1" }],
+      [{ eventId: 'email:msg:inb-1:msg-unauth' }],
+      [{ sessionId: 'sess-1' }],
       [
         {
-          profileId: "profile-email-1",
-          metadata: { inbox_id: "inb-1" },
-          status: "active",
+          profileId: 'profile-email-1',
+          metadata: { inbox_id: 'inb-1' },
+          status: 'active',
         },
       ],
-      [{ accountId: "acc-1", connectorId: "conn-email" }],
-      [{ accountId: "acc-1" }],
+      [{ accountId: 'acc-1', connectorId: 'conn-email' }],
+      [{ accountId: 'acc-1' }],
       [],
-      [{ profileId: "profile-email-1" }],
+      [{ profileId: 'profile-email-1' }],
     ];
 
     await dispatchAgentMailEvent(unauthenticatedEvent);
 
     expect(createCalls).toHaveLength(0);
     expect(continueCalls).toHaveLength(1);
-    expect(continueCalls[0].sessionId).toBe("sess-1");
-    expect(continueCalls[0].opencodeEnv).toEqual({
-      KORTIX_EXECUTOR_MCP_ENABLED: "1",
-    });
+    expect(continueCalls[0].sessionId).toBe('sess-1');
+    expect(continueCalls[0].opencodeEnv).toEqual({ KORTIX_EXECUTOR_MCP_ENABLED: '1' });
   });
 
-  test("known thread routes a new email into the existing session", async () => {
+  test('known thread routes a new email into the existing session', async () => {
     dbResults = [
-      [{ eventId: "email:event:evt-1" }],
-      [{ projectId: "proj-1" }],
+      [{ eventId: 'email:event:evt-1' }],
+      [{ projectId: 'proj-1' }],
       [],
-      [{ eventId: "email:msg:inb-1:msg-1" }],
-      [{ sessionId: "sess-1" }],
+      [{ eventId: 'email:msg:inb-1:msg-1' }],
+      [{ sessionId: 'sess-1' }],
       [
         {
-          profileId: "profile-email-1",
-          metadata: { inbox_id: "inb-1" },
-          status: "active",
+          profileId: 'profile-email-1',
+          metadata: { inbox_id: 'inb-1' },
+          status: 'active',
         },
       ],
-      [{ accountId: "acc-1", connectorId: "conn-email" }],
-      [{ accountId: "acc-1" }],
+      [{ accountId: 'acc-1', connectorId: 'conn-email' }],
+      [{ accountId: 'acc-1' }],
       [],
-      [{ profileId: "profile-email-1" }],
+      [{ profileId: 'profile-email-1' }],
     ];
 
     await dispatchAgentMailEvent(event);
 
     expect(createCalls).toHaveLength(0);
     expect(continueCalls).toHaveLength(1);
-    expect(continueCalls[0].sessionId).toBe("sess-1");
-    expect(continueCalls[0].opencodeEnv).toEqual({
-      KORTIX_EXECUTOR_MCP_ENABLED: "1",
-    });
-    expect(continueCalls[0].text).toContain("Customer <customer@example.com>");
+    expect(continueCalls[0].sessionId).toBe('sess-1');
+    expect(continueCalls[0].opencodeEnv).toEqual({ KORTIX_EXECUTOR_MCP_ENABLED: '1' });
+    expect(continueCalls[0].text).toContain('Customer <customer@example.com>');
     expectExecutorEmailPrompt(continueCalls[0].text);
   });
 
-  test("a rejected sender never claims the message or creates or continues a session", async () => {
-    setEmailSenderPolicyLoaderForTest(async () => ({
-      mode: "restricted",
-      allowedEmails: ["approved@example.com"],
-      allowedDomains: [],
-      allowedRegex: null,
-    }));
-    dbResults = [
-      [{ eventId: "email:event:evt-1" }],
-      [{ projectId: "proj-1" }],
-      // If dispatch moves past policy enforcement, these sentinels would let
-      // it claim the inbound message and create a new thread/session.
-      [],
-      [{ eventId: "email:msg:inb-1:msg-1" }],
-      [],
-    ];
-
-    await dispatchAgentMailEvent(event);
-
-    expect(createCalls).toHaveLength(0);
-    expect(continueCalls).toHaveLength(0);
-    expect(dbResults).toHaveLength(3);
-  });
-
-  test("sender allow policy supports exact emails, domains, and regex", () => {
+  test('sender allow policy supports exact emails, domains, and regex', () => {
     const policy = {
-      mode: "restricted" as const,
-      allowedEmails: ["customer@example.com"],
-      allowedDomains: ["kortix.com"],
-      allowedRegex: "^vip-[0-9]+@example\\.org$",
+      mode: 'restricted' as const,
+      allowedEmails: ['customer@example.com'],
+      allowedDomains: ['kortix.com'],
+      allowedRegex: '^vip-[0-9]+@example\\.org$',
     };
 
     expect(isAgentMailSenderAllowedForTest(event, policy)).toBe(true);
@@ -498,7 +456,7 @@ describe("dispatchAgentMailEvent", () => {
           ...event,
           message: {
             ...event.message,
-            from: "Teammate <person@ops.kortix.com>",
+            from: 'Teammate <person@ops.kortix.com>',
           },
         },
         policy,
@@ -508,7 +466,7 @@ describe("dispatchAgentMailEvent", () => {
       isAgentMailSenderAllowedForTest(
         {
           ...event,
-          message: { ...event.message, from: "vip-12@example.org" },
+          message: { ...event.message, from: 'vip-12@example.org' },
         },
         policy,
       ),
@@ -517,15 +475,15 @@ describe("dispatchAgentMailEvent", () => {
       isAgentMailSenderAllowedForTest(
         {
           ...event,
-          message: { ...event.message, from: "Other <other@external.test>" },
+          message: { ...event.message, from: 'Other <other@external.test>' },
         },
         policy,
       ),
     ).toBe(false);
   });
 
-  test("sender regex runtime stays linear for ambiguous repetition and fails closed on unsupported syntax", () => {
-    const adversarialSender = `${"a".repeat(50_000)}!@example.com`;
+  test('sender regex runtime stays linear for ambiguous repetition and fails closed on unsupported syntax', () => {
+    const adversarialSender = `${'a'.repeat(50_000)}!@example.com`;
     const allowed = (allowedRegex: string) =>
       isAgentMailSenderAllowedForTest(
         {
@@ -537,7 +495,7 @@ describe("dispatchAgentMailEvent", () => {
           },
         },
         {
-          mode: "restricted",
+          mode: 'restricted',
           allowedEmails: [],
           allowedDomains: [],
           allowedRegex,
@@ -545,83 +503,69 @@ describe("dispatchAgentMailEvent", () => {
       );
     const startedAt = performance.now();
 
-    expect(allowed("^(a{1,3})+@example\\.com$")).toBe(false);
-    expect(allowed("^(a|aa)+@example\\.com$")).toBe(false);
-    expect(allowed("^(?=a)a+@example\\.com$")).toBe(false);
+    expect(allowed('^(a{1,3})+@example\\.com$')).toBe(false);
+    expect(allowed('^(a|aa)+@example\\.com$')).toBe(false);
+    expect(allowed('^(?=a)a+@example\\.com$')).toBe(false);
     expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 
-  test("sender allow policy rejects ambiguous or attacker-controlled From values", () => {
+  test('sender allow policy rejects ambiguous or attacker-controlled From values', () => {
     const policy = {
-      mode: "restricted" as const,
-      allowedEmails: ["customer@example.com"],
+      mode: 'restricted' as const,
+      allowedEmails: ['customer@example.com'],
       allowedDomains: [],
       allowedRegex: null,
     };
-    const allowed = (from: AgentMailMessageReceivedEvent["message"]["from"]) =>
+    const allowed = (from: AgentMailMessageReceivedEvent['message']['from']) =>
       isAgentMailSenderAllowedForTest(
         { ...event, message: { ...event.message, from, from_: undefined } },
         policy,
       );
 
-    expect(allowed("Customer <customer@example.com>")).toBe(true);
-    expect(allowed("customer@example.com")).toBe(true);
-    expect(allowed("customer@example.com <attacker@evil.test>")).toBe(false);
-    expect(allowed("Attacker <attacker@evil.test>, customer@example.com")).toBe(
-      false,
-    );
-    expect(allowed("Customer <customer@example.com> trailing")).toBe(false);
-    expect(allowed("Customer customer@example.com")).toBe(false);
+    expect(allowed('Customer <customer@example.com>')).toBe(true);
+    expect(allowed('customer@example.com')).toBe(true);
+    expect(allowed('customer@example.com <attacker@evil.test>')).toBe(false);
+    expect(allowed('Attacker <attacker@evil.test>, customer@example.com')).toBe(false);
+    expect(allowed('Customer <customer@example.com> trailing')).toBe(false);
+    expect(allowed('Customer customer@example.com')).toBe(false);
   });
 
-  test("sender allow policy requires exactly one structured From mailbox", () => {
+  test('sender allow policy requires exactly one structured From mailbox', () => {
     const policy = {
-      mode: "restricted" as const,
-      allowedEmails: ["customer@example.com"],
+      mode: 'restricted' as const,
+      allowedEmails: ['customer@example.com'],
       allowedDomains: [],
       allowedRegex: null,
     };
-    const allowed = (
-      from_: AgentMailMessageReceivedEvent["message"]["from_"],
-    ) =>
+    const allowed = (from_: AgentMailMessageReceivedEvent['message']['from_']) =>
       isAgentMailSenderAllowedForTest(
         { ...event, message: { ...event.message, from: undefined, from_ } },
         policy,
       );
 
-    expect(allowed([{ email: "customer@example.com", name: "Customer" }])).toBe(
-      true,
-    );
-    expect(allowed([{ address: "customer@example.com" }])).toBe(true);
+    expect(allowed([{ email: 'customer@example.com', name: 'Customer' }])).toBe(true);
+    expect(allowed([{ address: 'customer@example.com' }])).toBe(true);
     expect(
       allowed([
         {
-          email: " Customer@Example.COM ",
-          address: "customer@example.com",
+          email: ' Customer@Example.COM ',
+          address: 'customer@example.com',
         },
       ]),
     ).toBe(true);
-    expect(allowed([{ email: "", address: "customer@example.com" }])).toBe(
-      true,
-    );
-    expect(
-      allowed([
-        { email: "customer@example.com", address: "attacker@evil.test" },
-      ]),
-    ).toBe(false);
-    expect(
-      allowed([{ email: "not a mailbox", address: "customer@example.com" }]),
-    ).toBe(false);
-    expect(allowed([{ name: "customer@example.com" }])).toBe(false);
-    expect(allowed(["customer@example.com", "attacker@evil.test"])).toBe(false);
+    expect(allowed([{ email: '', address: 'customer@example.com' }])).toBe(true);
+    expect(allowed([{ email: 'customer@example.com', address: 'attacker@evil.test' }])).toBe(false);
+    expect(allowed([{ email: 'not a mailbox', address: 'customer@example.com' }])).toBe(false);
+    expect(allowed([{ name: 'customer@example.com' }])).toBe(false);
+    expect(allowed(['customer@example.com', 'attacker@evil.test'])).toBe(false);
     expect(
       isAgentMailSenderAllowedForTest(
         {
           ...event,
           message: {
             ...event.message,
-            from: "customer@example.com",
-            from_: "attacker@evil.test",
+            from: 'customer@example.com',
+            from_: 'attacker@evil.test',
           },
         },
         policy,

--- a/apps/api/src/channels/email/sender-policy-regex.test.ts
+++ b/apps/api/src/channels/email/sender-policy-regex.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  MAX_EMAIL_SENDER_REGEX_LENGTH,
+  compileEmailSenderRegex,
+  matchesEmailSenderRegex,
+} from './sender-policy-regex';
+
+describe('email sender regex', () => {
+  test('preserves useful case-insensitive and unanchored matching', () => {
+    for (const pattern of [
+      '.*@example\\.com$',
+      '^(alice|bob)@example\\.com$',
+      '^vendor-[0-9]{1,4}@example\\.org$',
+    ]) {
+      expect(() => compileEmailSenderRegex(pattern)).not.toThrow();
+    }
+
+    expect(matchesEmailSenderRegex('advisor@example\\.com', 'Senior.Advisor@EXAMPLE.COM')).toBe(
+      true,
+    );
+    expect(matchesEmailSenderRegex('^alice@example\\.com$', 'malice@example.com')).toBe(false);
+  });
+
+  test('rejects unsupported backtracking-only syntax and oversized patterns', () => {
+    expect(() => compileEmailSenderRegex('^(?=alice)alice@example\\.com$')).toThrow(
+      'unsupported by the safe RE2 engine',
+    );
+    expect(() => compileEmailSenderRegex('^(a)\\1@example\\.com$')).toThrow(
+      'unsupported by the safe RE2 engine',
+    );
+    expect(() => compileEmailSenderRegex('a'.repeat(MAX_EMAIL_SENDER_REGEX_LENGTH + 1))).toThrow(
+      `at most ${MAX_EMAIL_SENDER_REGEX_LENGTH} characters`,
+    );
+  });
+
+  test('executes counted repetition and overlapping alternation in bounded time', () => {
+    const adversarialInput = `${'a'.repeat(50_000)}!@example.com`;
+    const patterns = ['^(a{1,3})+@example\\.com$', '^(a|aa)+@example\\.com$'];
+    const startedAt = performance.now();
+
+    for (const pattern of patterns) {
+      expect(() => compileEmailSenderRegex(pattern)).not.toThrow();
+      expect(matchesEmailSenderRegex(pattern, adversarialInput)).toBe(false);
+    }
+
+    // Native JavaScript RegExp can take exponentially long on these failures.
+    // RE2JS is linear; this generous ceiling catches accidental fallback to
+    // the backtracking engine without making ordinary CI scheduling flaky.
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+
+  test('fails closed for an unsupported legacy stored pattern', () => {
+    expect(matchesEmailSenderRegex('^(?=alice)alice@example\\.com$', 'alice@example.com')).toBe(
+      false,
+    );
+  });
+});

--- a/apps/api/src/channels/email/sender-policy-regex.ts
+++ b/apps/api/src/channels/email/sender-policy-regex.ts
@@ -1,0 +1,67 @@
+import { RE2JS } from 're2js';
+
+/**
+ * Sender patterns are customer-controlled and run on every inbound email.
+ * Keep both storage validation and webhook execution on the same linear-time
+ * RE2-compatible engine; JavaScript's backtracking RegExp engine can hang on
+ * patterns such as `^(a{1,3})+$` and `^(a|aa)+$`.
+ */
+export const MAX_EMAIL_SENDER_REGEX_LENGTH = 256;
+
+const COMPILED_REGEX_CACHE_LIMIT = 256;
+const compiledRegexCache = new Map<string, RE2JS | null>();
+
+export class EmailSenderRegexError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EmailSenderRegexError';
+  }
+}
+
+export function compileEmailSenderRegex(pattern: string): RE2JS {
+  if (!pattern) throw new EmailSenderRegexError('Email sender regex is required');
+  if (pattern.length > MAX_EMAIL_SENDER_REGEX_LENGTH) {
+    throw new EmailSenderRegexError(
+      `Email sender regex must be at most ${MAX_EMAIL_SENDER_REGEX_LENGTH} characters`,
+    );
+  }
+
+  try {
+    return RE2JS.compile(pattern, RE2JS.CASE_INSENSITIVE);
+  } catch {
+    throw new EmailSenderRegexError(
+      'Email sender regex is invalid or uses syntax unsupported by the safe RE2 engine',
+    );
+  }
+}
+
+function cachedEmailSenderRegex(pattern: string): RE2JS | null {
+  if (compiledRegexCache.has(pattern)) return compiledRegexCache.get(pattern) ?? null;
+
+  let compiled: RE2JS | null = null;
+  try {
+    compiled = compileEmailSenderRegex(pattern);
+  } catch {
+    // Stored policies from before RE2 enforcement may contain unsupported or
+    // unsafe patterns. They fail closed at runtime rather than falling back to
+    // JavaScript RegExp execution.
+  }
+
+  if (compiledRegexCache.size >= COMPILED_REGEX_CACHE_LIMIT) {
+    const oldest = compiledRegexCache.keys().next().value;
+    if (oldest !== undefined) compiledRegexCache.delete(oldest);
+  }
+  compiledRegexCache.set(pattern, compiled);
+  return compiled;
+}
+
+/** Case-insensitive, unanchored matching, preserving the existing API contract. */
+export function matchesEmailSenderRegex(pattern: string, email: string): boolean {
+  const compiled = cachedEmailSenderRegex(pattern);
+  if (!compiled) return false;
+  try {
+    return compiled.matcher(email).find();
+  } catch {
+    return false;
+  }
+}

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -29,6 +29,7 @@ const defaultEmailSessionLifecycle = {
 };
 
 let emailSessionLifecycle = defaultEmailSessionLifecycle;
+let emailSenderPolicyLoader = loadAgentMailSenderPolicyForInbox;
 
 export function setEmailSessionLifecycleForTest(
   overrides: Partial<typeof defaultEmailSessionLifecycle>,
@@ -38,6 +39,13 @@ export function setEmailSessionLifecycleForTest(
 
 export function resetEmailSessionLifecycleForTest() {
   emailSessionLifecycle = defaultEmailSessionLifecycle;
+  emailSenderPolicyLoader = loadAgentMailSenderPolicyForInbox;
+}
+
+export function setEmailSenderPolicyLoaderForTest(
+  loader: typeof loadAgentMailSenderPolicyForInbox,
+) {
+  emailSenderPolicyLoader = loader;
 }
 
 export async function resolveProjectForAgentMailInbox(inboxId: string): Promise<string | null> {
@@ -60,7 +68,7 @@ export async function dispatchAgentMailEvent(event: AgentMailMessageReceivedEven
     });
     return;
   }
-  const policy = await loadAgentMailSenderPolicyForInbox(projectId, event.message.inbox_id);
+  const policy = await emailSenderPolicyLoader(projectId, event.message.inbox_id);
   if (!senderAllowed(event, policy)) {
     console.warn('[email-webhook] sender rejected by AgentMail inbox policy', {
       inboxId: event.message.inbox_id,

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -19,6 +19,7 @@ import {
 import { db } from '../../shared/db';
 import { type AgentMailSenderPolicy, loadAgentMailSenderPolicyForInbox } from '../install-store';
 import { EMAIL_EVENT_DEDUPE_TTL_MS } from './app';
+import { matchesEmailSenderRegex } from './sender-policy-regex';
 import type { AgentMailMessageReceivedEvent } from './types';
 
 const defaultEmailSessionLifecycle = {
@@ -538,11 +539,7 @@ export function isAgentMailSenderAllowedForTest(
     return true;
   }
   if (policy.allowedRegex) {
-    try {
-      return new RegExp(policy.allowedRegex, 'i').test(email);
-    } catch {
-      return false;
-    }
+    return matchesEmailSenderRegex(policy.allowedRegex, email);
   }
   return false;
 }

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -4,23 +4,26 @@ import {
   chatInstalls,
   chatThreads,
   projects,
-} from '@kortix/db';
-import { and, eq } from 'drizzle-orm';
-import { config } from '../../config';
+} from "@kortix/db";
+import { and, eq } from "drizzle-orm";
+import { config } from "../../config";
 import {
   ensureEmailSessionBinding,
   loadEmailInstallProfileId,
-} from '../../projects/lib/session-connector-bindings';
+} from "../../projects/lib/session-connector-bindings";
 import {
   continueSession as continueLifecycleSession,
   createSession as createLifecycleSession,
   resolveProjectAutomationActor as resolveLifecycleAutomationActor,
-} from '../../projects/session-lifecycle';
-import { db } from '../../shared/db';
-import { type AgentMailSenderPolicy, loadAgentMailSenderPolicyForInbox } from '../install-store';
-import { EMAIL_EVENT_DEDUPE_TTL_MS } from './app';
-import { matchesEmailSenderRegex } from './sender-policy-regex';
-import type { AgentMailMessageReceivedEvent } from './types';
+} from "../../projects/session-lifecycle";
+import { db } from "../../shared/db";
+import {
+  type AgentMailSenderPolicy,
+  loadAgentMailSenderPolicyForInbox,
+} from "../install-store";
+import { EMAIL_EVENT_DEDUPE_TTL_MS } from "./app";
+import { matchesEmailSenderRegex } from "./sender-policy-regex";
+import type { AgentMailMessageReceivedEvent } from "./types";
 
 const defaultEmailSessionLifecycle = {
   continueSession: continueLifecycleSession,
@@ -29,6 +32,7 @@ const defaultEmailSessionLifecycle = {
 };
 
 let emailSessionLifecycle = defaultEmailSessionLifecycle;
+let emailSenderPolicyLoader = loadAgentMailSenderPolicyForInbox;
 
 export function setEmailSessionLifecycleForTest(
   overrides: Partial<typeof defaultEmailSessionLifecycle>,
@@ -38,31 +42,52 @@ export function setEmailSessionLifecycleForTest(
 
 export function resetEmailSessionLifecycleForTest() {
   emailSessionLifecycle = defaultEmailSessionLifecycle;
+  emailSenderPolicyLoader = loadAgentMailSenderPolicyForInbox;
 }
 
-export async function resolveProjectForAgentMailInbox(inboxId: string): Promise<string | null> {
+export function setEmailSenderPolicyLoaderForTest(
+  loader: typeof loadAgentMailSenderPolicyForInbox,
+) {
+  emailSenderPolicyLoader = loader;
+}
+
+export async function resolveProjectForAgentMailInbox(
+  inboxId: string,
+): Promise<string | null> {
   const [row] = await db
     .select({ projectId: chatInstalls.projectId })
     .from(chatInstalls)
-    .where(and(eq(chatInstalls.platform, 'email'), eq(chatInstalls.workspaceId, inboxId)))
+    .where(
+      and(
+        eq(chatInstalls.platform, "email"),
+        eq(chatInstalls.workspaceId, inboxId),
+      ),
+    )
     .limit(1);
   return row?.projectId ?? null;
 }
 
-export async function dispatchAgentMailEvent(event: AgentMailMessageReceivedEvent): Promise<void> {
+export async function dispatchAgentMailEvent(
+  event: AgentMailMessageReceivedEvent,
+): Promise<void> {
   if (!isInboundMessageEvent(event.event_type)) return;
   if (await alreadyHandled(`email:event:${event.event_id}`)) return;
-  const projectId = await resolveProjectForAgentMailInbox(event.message.inbox_id);
+  const projectId = await resolveProjectForAgentMailInbox(
+    event.message.inbox_id,
+  );
   if (!projectId) {
-    console.warn('[email-webhook] no project install for AgentMail inbox', {
+    console.warn("[email-webhook] no project install for AgentMail inbox", {
       inboxId: event.message.inbox_id,
       eventId: event.event_id,
     });
     return;
   }
-  const policy = await loadAgentMailSenderPolicyForInbox(projectId, event.message.inbox_id);
+  const policy = await emailSenderPolicyLoader(
+    projectId,
+    event.message.inbox_id,
+  );
   if (!senderAllowed(event, policy)) {
-    console.warn('[email-webhook] sender rejected by AgentMail inbox policy', {
+    console.warn("[email-webhook] sender rejected by AgentMail inbox policy", {
       inboxId: event.message.inbox_id,
       eventId: event.event_id,
       sender: messageSender(event),
@@ -86,7 +111,7 @@ async function spawnEmailAgentTurn(
     .from(chatThreads)
     .where(
       and(
-        eq(chatThreads.platform, 'email'),
+        eq(chatThreads.platform, "email"),
         eq(chatThreads.workspaceId, inboxId),
         eq(chatThreads.threadId, threadId),
       ),
@@ -101,36 +126,39 @@ async function spawnEmailAgentTurn(
         inboxId,
       }))
     ) {
-      console.error('[email-webhook] could not bind existing session to inbox profile', {
-        projectId,
-        sessionId: existing.sessionId,
-        inboxId,
-      });
+      console.error(
+        "[email-webhook] could not bind existing session to inbox profile",
+        {
+          projectId,
+          sessionId: existing.sessionId,
+          inboxId,
+        },
+      );
       return;
     }
     const outcome = await emailSessionLifecycle.continueSession({
-      source: 'email',
+      source: "email",
       sessionId: existing.sessionId,
       text: renderFollowUpPrompt(event),
-      opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: '1' },
+      opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: "1" },
     });
-    if (outcome === 'delivered') {
+    if (outcome === "delivered") {
       await db
         .update(chatThreads)
         .set({ lastMessageAt: new Date() })
         .where(
           and(
-            eq(chatThreads.platform, 'email'),
+            eq(chatThreads.platform, "email"),
             eq(chatThreads.workspaceId, inboxId),
             eq(chatThreads.threadId, threadId),
           ),
         );
-    } else if (outcome === 'no-session') {
+    } else if (outcome === "no-session") {
       await db
         .delete(chatThreads)
         .where(
           and(
-            eq(chatThreads.platform, 'email'),
+            eq(chatThreads.platform, "email"),
             eq(chatThreads.workspaceId, inboxId),
             eq(chatThreads.threadId, threadId),
           ),
@@ -169,15 +197,17 @@ async function createThreadSession(
     .where(
       and(
         eq(chatChannelBindings.projectId, projectId),
-        eq(chatChannelBindings.platform, 'email'),
+        eq(chatChannelBindings.platform, "email"),
         eq(chatChannelBindings.workspaceId, inboxId),
       ),
     )
     .limit(1);
 
-  const userId = await emailSessionLifecycle.resolveProjectAutomationActor(project.accountId);
+  const userId = await emailSessionLifecycle.resolveProjectAutomationActor(
+    project.accountId,
+  );
   if (!userId) {
-    console.warn('[email-webhook] no actor for project', projectId);
+    console.warn("[email-webhook] no actor for project", projectId);
     return;
   }
 
@@ -185,19 +215,24 @@ async function createThreadSession(
   if (!(await claimThreadCreate(claimKey))) {
     const sessionId = await waitForThreadSession(inboxId, threadId);
     if (sessionId) {
-      if (!(await ensureEmailSessionBinding({ projectId, sessionId, inboxId }))) {
-        console.error('[email-webhook] could not bind claimed session to inbox profile', {
-          projectId,
-          sessionId,
-          inboxId,
-        });
+      if (
+        !(await ensureEmailSessionBinding({ projectId, sessionId, inboxId }))
+      ) {
+        console.error(
+          "[email-webhook] could not bind claimed session to inbox profile",
+          {
+            projectId,
+            sessionId,
+            inboxId,
+          },
+        );
         return;
       }
       await emailSessionLifecycle.continueSession({
-        source: 'email',
+        source: "email",
         sessionId,
         text: renderFollowUpPrompt(event),
-        opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: '1' },
+        opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: "1" },
       });
     }
     return;
@@ -206,21 +241,23 @@ async function createThreadSession(
   const initialPrompt = renderAgentPrompt(event, revived);
   const emailProfileId = await loadEmailInstallProfileId(projectId, inboxId);
   if (!emailProfileId) {
-    console.error('[email-webhook] no active connection profile for inbox', {
+    console.error("[email-webhook] no active connection profile for inbox", {
       projectId,
       inboxId,
     });
     return;
   }
   const result = await emailSessionLifecycle.createSession({
-    source: 'email',
+    source: "email",
     project,
     userId,
-    requestingPrincipalType: 'human',
+    requestingPrincipalType: "human",
     body: {
       base_ref: project.defaultBranch,
-      agent_name: selection?.agentName || 'default',
-      ...(selection?.opencodeModel ? { opencode_model: selection.opencodeModel } : {}),
+      agent_name: selection?.agentName || "default",
+      ...(selection?.opencodeModel
+        ? { opencode_model: selection.opencodeModel }
+        : {}),
       connector_bindings: {
         email: { authorization_id: emailProfileId },
       },
@@ -230,30 +267,30 @@ async function createThreadSession(
     },
     enforceAccountCap: false,
     mayManageSystemConnectorProfiles: true,
-    queuePolicy: 'on_backpressure',
+    queuePolicy: "on_backpressure",
     idempotencyKey: claimKey,
     postCreate: [
       {
-        type: 'bind_chat_thread',
-        platform: 'email',
+        type: "bind_chat_thread",
+        platform: "email",
         workspaceId: inboxId,
         threadId,
       },
       {
-        type: 'deliver_prompt',
-        source: 'email',
+        type: "deliver_prompt",
+        source: "email",
         text: initialPrompt,
         userId,
       },
     ],
-    visibility: 'project',
+    visibility: "project",
     metadata: {
-      source: 'email',
+      source: "email",
       email: {
         inbox_id: inboxId,
         thread_id: threadId,
         message_id: event.message.message_id,
-        address: event.message.to?.[0] ?? '',
+        address: event.message.to?.[0] ?? "",
         from: messageSender(event),
         subject: messageSubject(event),
       },
@@ -261,17 +298,17 @@ async function createThreadSession(
     extraEnvVars: {
       // Email delivery cannot depend on a shell fallback. Enable the
       // session-scoped MCP face so OpenCode exposes the bound inbox as tools.
-      KORTIX_EXECUTOR_MCP_ENABLED: '1',
+      KORTIX_EXECUTOR_MCP_ENABLED: "1",
       KORTIX_EMAIL_INBOX_ID: inboxId,
       KORTIX_EMAIL_THREAD_ID: threadId,
       KORTIX_EMAIL_MESSAGE_ID: event.message.message_id,
-      KORTIX_EMAIL_ADDRESS: event.message.to?.[0] ?? '',
+      KORTIX_EMAIL_ADDRESS: event.message.to?.[0] ?? "",
       KORTIX_FRONTEND_URL: config.FRONTEND_URL,
     },
   });
 
   if (result.error) {
-    console.error('[email-webhook] createProjectSession failed', {
+    console.error("[email-webhook] createProjectSession failed", {
       status: result.error.status,
       body: result.error.body,
     });
@@ -290,12 +327,14 @@ async function alreadyHandled(key: string): Promise<boolean> {
       .returning({ eventId: chatEventDedup.eventId });
     return inserted.length === 0;
   } catch (err) {
-    console.warn('[email-webhook] event dedup check failed', err);
+    console.warn("[email-webhook] event dedup check failed", err);
     return false;
   }
 }
 
-async function claimInboundMessage(event: AgentMailMessageReceivedEvent): Promise<boolean> {
+async function claimInboundMessage(
+  event: AgentMailMessageReceivedEvent,
+): Promise<boolean> {
   const key = `email:msg:${event.message.inbox_id}:${event.message.message_id}`;
   try {
     const inserted = await db
@@ -308,7 +347,10 @@ async function claimInboundMessage(event: AgentMailMessageReceivedEvent): Promis
       .returning({ eventId: chatEventDedup.eventId });
     return inserted.length > 0;
   } catch (err) {
-    console.error('[email-webhook] inbound message claim failed (fail-open)', err);
+    console.error(
+      "[email-webhook] inbound message claim failed (fail-open)",
+      err,
+    );
     return true;
   }
 }
@@ -325,12 +367,15 @@ async function claimThreadCreate(key: string): Promise<boolean> {
       .returning({ eventId: chatEventDedup.eventId });
     return inserted.length > 0;
   } catch (err) {
-    console.warn('[email-webhook] thread-create claim failed (fail-open)', err);
+    console.warn("[email-webhook] thread-create claim failed (fail-open)", err);
     return true;
   }
 }
 
-async function waitForThreadSession(inboxId: string, threadId: string): Promise<string | null> {
+async function waitForThreadSession(
+  inboxId: string,
+  threadId: string,
+): Promise<string | null> {
   const deadline = Date.now() + 8_000;
   for (;;) {
     const [row] = await db
@@ -338,7 +383,7 @@ async function waitForThreadSession(inboxId: string, threadId: string): Promise<
       .from(chatThreads)
       .where(
         and(
-          eq(chatThreads.platform, 'email'),
+          eq(chatThreads.platform, "email"),
           eq(chatThreads.workspaceId, inboxId),
           eq(chatThreads.threadId, threadId),
         ),
@@ -352,73 +397,81 @@ async function waitForThreadSession(inboxId: string, threadId: string): Promise<
 
 function emailTurnInstructions(event: AgentMailMessageReceivedEvent): string {
   const readThreadCall = JSON.stringify({
-    connector: 'email',
-    action: 'get_thread',
+    connector: "email",
+    action: "get_thread",
     args: {
       inbox_id: event.message.inbox_id,
       thread_id: event.message.thread_id,
     },
   });
   const replyCall = JSON.stringify({
-    connector: 'email',
-    action: 'reply_message',
+    connector: "email",
+    action: "reply_message",
     args: {
       inbox_id: event.message.inbox_id,
       message_id: event.message.message_id,
-      text: '<reply>',
+      text: "<reply>",
     },
   });
   return [
-    'How to work:',
-    '- You are operating an AgentMail inbox assigned to this Kortix project.',
-    '- Use the Executor MCP meta-tools `connectors`, `discover`, `describe`, and `call`. Connector actions are not direct tools.',
-    '- Start with `connectors`. Use `discover` to find an action and `describe` to confirm its input schema before the first call.',
+    "How to work:",
+    "- You are operating an AgentMail inbox assigned to this Kortix project.",
+    "- Use the Executor MCP meta-tools `connectors`, `discover`, `describe`, and `call`. Connector actions are not direct tools.",
+    "- Start with `connectors`. Use `discover` to find an action and `describe` to confirm its input schema before the first call.",
     `- Read the current thread with \`call\`: \`${readThreadCall}\`.`,
     `- Reply in the same conversation with \`call\`: \`${replyCall}\`. Use \`html\` instead of \`text\` only when needed.`,
-    '- Start a new outbound email with `call`, connector `email`, action `send_message`, and args containing `inbox_id`, `to`, `subject`, and `text` or `html`.',
-    '- The AgentMail API key is resolved server-side. Do not look for it in the sandbox.',
-    '- If you need the user to clarify something, reply by email and end the turn. Their next reply will resume this same session.',
-  ].join('\n');
+    "- Start a new outbound email with `call`, connector `email`, action `send_message`, and args containing `inbox_id`, `to`, `subject`, and `text` or `html`.",
+    "- The AgentMail API key is resolved server-side. Do not look for it in the sandbox.",
+    "- If you need the user to clarify something, reply by email and end the turn. Their next reply will resume this same session.",
+  ].join("\n");
 }
 
 function renderFollowUpPrompt(event: AgentMailMessageReceivedEvent): string {
   return [
     `New email reply from ${messageSender(event)} in the same thread:`,
-    '',
+    "",
     messageSummary(event),
-    '',
+    "",
     emailTurnInstructions(event),
-  ].join('\n');
+  ].join("\n");
 }
 
-function renderAgentPrompt(event: AgentMailMessageReceivedEvent, revived: boolean): string {
+function renderAgentPrompt(
+  event: AgentMailMessageReceivedEvent,
+  revived: boolean,
+): string {
   const lines: string[] = [];
   if (revived) {
     lines.push(
-      'NOTE: This email thread had an earlier conversation, but that session was deleted.',
-      'Pick the thread back up from the current email context.',
-      '',
+      "NOTE: This email thread had an earlier conversation, but that session was deleted.",
+      "Pick the thread back up from the current email context.",
+      "",
     );
   }
   lines.push(
     "You're answering an email thread as the Kortix agent.",
-    '',
+    "",
     `Inbox ID:   ${event.message.inbox_id}`,
     `Thread ID:  ${event.message.thread_id}`,
     `Message ID: ${event.message.message_id}`,
     `From:       ${messageSender(event)}`,
-    `To:         ${(event.message.to ?? []).join(', ')}`,
-    `Subject:    ${messageSubject(event) ?? '(no subject)'}`,
-    '',
+    `To:         ${(event.message.to ?? []).join(", ")}`,
+    `Subject:    ${messageSubject(event) ?? "(no subject)"}`,
+    "",
     messageSummary(event),
-    '',
+    "",
     emailTurnInstructions(event),
   );
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
-function isInboundMessageEvent(eventType: AgentMailMessageReceivedEvent['event_type']): boolean {
-  return eventType === 'message.received' || eventType === 'message.received.unauthenticated';
+function isInboundMessageEvent(
+  eventType: AgentMailMessageReceivedEvent["event_type"],
+): boolean {
+  return (
+    eventType === "message.received" ||
+    eventType === "message.received.unauthenticated"
+  );
 }
 
 function messageSubject(event: AgentMailMessageReceivedEvent): string | null {
@@ -426,37 +479,44 @@ function messageSubject(event: AgentMailMessageReceivedEvent): string | null {
 }
 
 function messageSummary(event: AgentMailMessageReceivedEvent): string {
-  const body = event.message.extracted_text || event.message.text || event.message.preview || '';
+  const body =
+    event.message.extracted_text ||
+    event.message.text ||
+    event.message.preview ||
+    "";
   const attachments = event.message.attachments?.length
     ? [
-        '',
-        'Attachments:',
+        "",
+        "Attachments:",
         ...event.message.attachments.map(
           (a) =>
-            `- ${a.filename ?? a.attachment_id} (${a.content_type ?? 'unknown'}, ${a.size} bytes)`,
+            `- ${a.filename ?? a.attachment_id} (${a.content_type ?? "unknown"}, ${a.size} bytes)`,
         ),
-      ].join('\n')
-    : '';
-  return ['Email body:', body || '(empty)', attachments].filter(Boolean).join('\n');
+      ].join("\n")
+    : "";
+  return ["Email body:", body || "(empty)", attachments]
+    .filter(Boolean)
+    .join("\n");
 }
 
 function messageSender(event: AgentMailMessageReceivedEvent): string {
-  if (typeof event.message.from === 'string' && event.message.from.trim()) {
+  if (typeof event.message.from === "string" && event.message.from.trim()) {
     return event.message.from.trim();
   }
   const from = event.message.from_;
-  if (typeof from === 'string') return from.trim();
+  if (typeof from === "string") return from.trim();
   if (Array.isArray(from)) {
     const first = from[0];
-    if (typeof first === 'string') return first.trim();
-    if (first && typeof first === 'object') {
-      return (first.email ?? first.address ?? first.name ?? '').trim();
+    if (typeof first === "string") return first.trim();
+    if (first && typeof first === "object") {
+      return (first.email ?? first.address ?? first.name ?? "").trim();
     }
   }
-  return '';
+  return "";
 }
 
-const MAILBOX_PATTERN = /[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+/gi;
+const MAILBOX_PATTERN =
+  /[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+/gi;
 
 /**
  * Resolve the one canonical From mailbox AgentMail delivered.
@@ -471,25 +531,28 @@ function senderEmail(event: AgentMailMessageReceivedEvent): string | null {
   const primary = event.message.from;
   const alternate = event.message.from_;
   const primaryMailbox =
-    typeof primary === 'string' && primary.trim() ? canonicalMailbox(primary) : null;
+    typeof primary === "string" && primary.trim()
+      ? canonicalMailbox(primary)
+      : null;
   const alternateMailbox = canonicalStructuredMailbox(alternate);
   if (primaryMailbox && alternate !== undefined) {
     return alternateMailbox === primaryMailbox ? primaryMailbox : null;
   }
-  if (typeof primary === 'string' && primary.trim()) return primaryMailbox;
+  if (typeof primary === "string" && primary.trim()) return primaryMailbox;
   return alternateMailbox;
 }
 
 function canonicalStructuredMailbox(
-  from: AgentMailMessageReceivedEvent['message']['from_'],
+  from: AgentMailMessageReceivedEvent["message"]["from_"],
 ): string | null {
   if (Array.isArray(from)) {
     if (from.length !== 1) return null;
     const [first] = from;
-    if (typeof first === 'string') return canonicalMailbox(first);
-    if (!first || typeof first !== 'object') return null;
-    const rawEmail = typeof first.email === 'string' ? first.email.trim() : '';
-    const rawAddress = typeof first.address === 'string' ? first.address.trim() : '';
+    if (typeof first === "string") return canonicalMailbox(first);
+    if (!first || typeof first !== "object") return null;
+    const rawEmail = typeof first.email === "string" ? first.email.trim() : "";
+    const rawAddress =
+      typeof first.address === "string" ? first.address.trim() : "";
     const email = rawEmail ? canonicalMailbox(rawEmail) : null;
     const address = rawAddress ? canonicalMailbox(rawAddress) : null;
     // AgentMail payload variants have used both keys. Treat them as aliases,
@@ -499,7 +562,7 @@ function canonicalStructuredMailbox(
     if (email && address && email !== address) return null;
     return email ?? address;
   }
-  return typeof from === 'string' ? canonicalMailbox(from) : null;
+  return typeof from === "string" ? canonicalMailbox(from) : null;
 }
 
 function canonicalMailbox(value: string): string | null {
@@ -510,13 +573,13 @@ function canonicalMailbox(value: string): string | null {
   if (!mailbox) return null;
   if (sender === mailbox) return mailbox;
 
-  const open = sender.indexOf('<');
-  const close = sender.indexOf('>');
+  const open = sender.indexOf("<");
+  const close = sender.indexOf(">");
   if (
     open <= 0 ||
     close !== sender.length - 1 ||
-    sender.indexOf('<', open + 1) !== -1 ||
-    sender.indexOf('>', close + 1) !== -1 ||
+    sender.indexOf("<", open + 1) !== -1 ||
+    sender.indexOf(">", close + 1) !== -1 ||
     sender.slice(open + 1, close).trim() !== mailbox
   ) {
     return null;
@@ -528,13 +591,15 @@ export function isAgentMailSenderAllowedForTest(
   event: AgentMailMessageReceivedEvent,
   policy: AgentMailSenderPolicy,
 ): boolean {
-  if (policy.mode !== 'restricted') return true;
+  if (policy.mode !== "restricted") return true;
   const email = senderEmail(event);
   if (!email) return false;
   if (policy.allowedEmails.includes(email)) return true;
-  const domain = email.split('@')[1] ?? '';
+  const domain = email.split("@")[1] ?? "";
   if (
-    policy.allowedDomains.some((allowed) => domain === allowed || domain.endsWith(`.${allowed}`))
+    policy.allowedDomains.some(
+      (allowed) => domain === allowed || domain.endsWith(`.${allowed}`),
+    )
   ) {
     return true;
   }

--- a/apps/api/src/channels/email/session.ts
+++ b/apps/api/src/channels/email/session.ts
@@ -4,26 +4,23 @@ import {
   chatInstalls,
   chatThreads,
   projects,
-} from "@kortix/db";
-import { and, eq } from "drizzle-orm";
-import { config } from "../../config";
+} from '@kortix/db';
+import { and, eq } from 'drizzle-orm';
+import { config } from '../../config';
 import {
   ensureEmailSessionBinding,
   loadEmailInstallProfileId,
-} from "../../projects/lib/session-connector-bindings";
+} from '../../projects/lib/session-connector-bindings';
 import {
   continueSession as continueLifecycleSession,
   createSession as createLifecycleSession,
   resolveProjectAutomationActor as resolveLifecycleAutomationActor,
-} from "../../projects/session-lifecycle";
-import { db } from "../../shared/db";
-import {
-  type AgentMailSenderPolicy,
-  loadAgentMailSenderPolicyForInbox,
-} from "../install-store";
-import { EMAIL_EVENT_DEDUPE_TTL_MS } from "./app";
-import { matchesEmailSenderRegex } from "./sender-policy-regex";
-import type { AgentMailMessageReceivedEvent } from "./types";
+} from '../../projects/session-lifecycle';
+import { db } from '../../shared/db';
+import { type AgentMailSenderPolicy, loadAgentMailSenderPolicyForInbox } from '../install-store';
+import { EMAIL_EVENT_DEDUPE_TTL_MS } from './app';
+import { matchesEmailSenderRegex } from './sender-policy-regex';
+import type { AgentMailMessageReceivedEvent } from './types';
 
 const defaultEmailSessionLifecycle = {
   continueSession: continueLifecycleSession,
@@ -32,7 +29,6 @@ const defaultEmailSessionLifecycle = {
 };
 
 let emailSessionLifecycle = defaultEmailSessionLifecycle;
-let emailSenderPolicyLoader = loadAgentMailSenderPolicyForInbox;
 
 export function setEmailSessionLifecycleForTest(
   overrides: Partial<typeof defaultEmailSessionLifecycle>,
@@ -42,52 +38,31 @@ export function setEmailSessionLifecycleForTest(
 
 export function resetEmailSessionLifecycleForTest() {
   emailSessionLifecycle = defaultEmailSessionLifecycle;
-  emailSenderPolicyLoader = loadAgentMailSenderPolicyForInbox;
 }
 
-export function setEmailSenderPolicyLoaderForTest(
-  loader: typeof loadAgentMailSenderPolicyForInbox,
-) {
-  emailSenderPolicyLoader = loader;
-}
-
-export async function resolveProjectForAgentMailInbox(
-  inboxId: string,
-): Promise<string | null> {
+export async function resolveProjectForAgentMailInbox(inboxId: string): Promise<string | null> {
   const [row] = await db
     .select({ projectId: chatInstalls.projectId })
     .from(chatInstalls)
-    .where(
-      and(
-        eq(chatInstalls.platform, "email"),
-        eq(chatInstalls.workspaceId, inboxId),
-      ),
-    )
+    .where(and(eq(chatInstalls.platform, 'email'), eq(chatInstalls.workspaceId, inboxId)))
     .limit(1);
   return row?.projectId ?? null;
 }
 
-export async function dispatchAgentMailEvent(
-  event: AgentMailMessageReceivedEvent,
-): Promise<void> {
+export async function dispatchAgentMailEvent(event: AgentMailMessageReceivedEvent): Promise<void> {
   if (!isInboundMessageEvent(event.event_type)) return;
   if (await alreadyHandled(`email:event:${event.event_id}`)) return;
-  const projectId = await resolveProjectForAgentMailInbox(
-    event.message.inbox_id,
-  );
+  const projectId = await resolveProjectForAgentMailInbox(event.message.inbox_id);
   if (!projectId) {
-    console.warn("[email-webhook] no project install for AgentMail inbox", {
+    console.warn('[email-webhook] no project install for AgentMail inbox', {
       inboxId: event.message.inbox_id,
       eventId: event.event_id,
     });
     return;
   }
-  const policy = await emailSenderPolicyLoader(
-    projectId,
-    event.message.inbox_id,
-  );
+  const policy = await loadAgentMailSenderPolicyForInbox(projectId, event.message.inbox_id);
   if (!senderAllowed(event, policy)) {
-    console.warn("[email-webhook] sender rejected by AgentMail inbox policy", {
+    console.warn('[email-webhook] sender rejected by AgentMail inbox policy', {
       inboxId: event.message.inbox_id,
       eventId: event.event_id,
       sender: messageSender(event),
@@ -111,7 +86,7 @@ async function spawnEmailAgentTurn(
     .from(chatThreads)
     .where(
       and(
-        eq(chatThreads.platform, "email"),
+        eq(chatThreads.platform, 'email'),
         eq(chatThreads.workspaceId, inboxId),
         eq(chatThreads.threadId, threadId),
       ),
@@ -126,39 +101,36 @@ async function spawnEmailAgentTurn(
         inboxId,
       }))
     ) {
-      console.error(
-        "[email-webhook] could not bind existing session to inbox profile",
-        {
-          projectId,
-          sessionId: existing.sessionId,
-          inboxId,
-        },
-      );
+      console.error('[email-webhook] could not bind existing session to inbox profile', {
+        projectId,
+        sessionId: existing.sessionId,
+        inboxId,
+      });
       return;
     }
     const outcome = await emailSessionLifecycle.continueSession({
-      source: "email",
+      source: 'email',
       sessionId: existing.sessionId,
       text: renderFollowUpPrompt(event),
-      opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: "1" },
+      opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: '1' },
     });
-    if (outcome === "delivered") {
+    if (outcome === 'delivered') {
       await db
         .update(chatThreads)
         .set({ lastMessageAt: new Date() })
         .where(
           and(
-            eq(chatThreads.platform, "email"),
+            eq(chatThreads.platform, 'email'),
             eq(chatThreads.workspaceId, inboxId),
             eq(chatThreads.threadId, threadId),
           ),
         );
-    } else if (outcome === "no-session") {
+    } else if (outcome === 'no-session') {
       await db
         .delete(chatThreads)
         .where(
           and(
-            eq(chatThreads.platform, "email"),
+            eq(chatThreads.platform, 'email'),
             eq(chatThreads.workspaceId, inboxId),
             eq(chatThreads.threadId, threadId),
           ),
@@ -197,17 +169,15 @@ async function createThreadSession(
     .where(
       and(
         eq(chatChannelBindings.projectId, projectId),
-        eq(chatChannelBindings.platform, "email"),
+        eq(chatChannelBindings.platform, 'email'),
         eq(chatChannelBindings.workspaceId, inboxId),
       ),
     )
     .limit(1);
 
-  const userId = await emailSessionLifecycle.resolveProjectAutomationActor(
-    project.accountId,
-  );
+  const userId = await emailSessionLifecycle.resolveProjectAutomationActor(project.accountId);
   if (!userId) {
-    console.warn("[email-webhook] no actor for project", projectId);
+    console.warn('[email-webhook] no actor for project', projectId);
     return;
   }
 
@@ -215,24 +185,19 @@ async function createThreadSession(
   if (!(await claimThreadCreate(claimKey))) {
     const sessionId = await waitForThreadSession(inboxId, threadId);
     if (sessionId) {
-      if (
-        !(await ensureEmailSessionBinding({ projectId, sessionId, inboxId }))
-      ) {
-        console.error(
-          "[email-webhook] could not bind claimed session to inbox profile",
-          {
-            projectId,
-            sessionId,
-            inboxId,
-          },
-        );
+      if (!(await ensureEmailSessionBinding({ projectId, sessionId, inboxId }))) {
+        console.error('[email-webhook] could not bind claimed session to inbox profile', {
+          projectId,
+          sessionId,
+          inboxId,
+        });
         return;
       }
       await emailSessionLifecycle.continueSession({
-        source: "email",
+        source: 'email',
         sessionId,
         text: renderFollowUpPrompt(event),
-        opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: "1" },
+        opencodeEnv: { KORTIX_EXECUTOR_MCP_ENABLED: '1' },
       });
     }
     return;
@@ -241,23 +206,21 @@ async function createThreadSession(
   const initialPrompt = renderAgentPrompt(event, revived);
   const emailProfileId = await loadEmailInstallProfileId(projectId, inboxId);
   if (!emailProfileId) {
-    console.error("[email-webhook] no active connection profile for inbox", {
+    console.error('[email-webhook] no active connection profile for inbox', {
       projectId,
       inboxId,
     });
     return;
   }
   const result = await emailSessionLifecycle.createSession({
-    source: "email",
+    source: 'email',
     project,
     userId,
-    requestingPrincipalType: "human",
+    requestingPrincipalType: 'human',
     body: {
       base_ref: project.defaultBranch,
-      agent_name: selection?.agentName || "default",
-      ...(selection?.opencodeModel
-        ? { opencode_model: selection.opencodeModel }
-        : {}),
+      agent_name: selection?.agentName || 'default',
+      ...(selection?.opencodeModel ? { opencode_model: selection.opencodeModel } : {}),
       connector_bindings: {
         email: { authorization_id: emailProfileId },
       },
@@ -267,30 +230,30 @@ async function createThreadSession(
     },
     enforceAccountCap: false,
     mayManageSystemConnectorProfiles: true,
-    queuePolicy: "on_backpressure",
+    queuePolicy: 'on_backpressure',
     idempotencyKey: claimKey,
     postCreate: [
       {
-        type: "bind_chat_thread",
-        platform: "email",
+        type: 'bind_chat_thread',
+        platform: 'email',
         workspaceId: inboxId,
         threadId,
       },
       {
-        type: "deliver_prompt",
-        source: "email",
+        type: 'deliver_prompt',
+        source: 'email',
         text: initialPrompt,
         userId,
       },
     ],
-    visibility: "project",
+    visibility: 'project',
     metadata: {
-      source: "email",
+      source: 'email',
       email: {
         inbox_id: inboxId,
         thread_id: threadId,
         message_id: event.message.message_id,
-        address: event.message.to?.[0] ?? "",
+        address: event.message.to?.[0] ?? '',
         from: messageSender(event),
         subject: messageSubject(event),
       },
@@ -298,17 +261,17 @@ async function createThreadSession(
     extraEnvVars: {
       // Email delivery cannot depend on a shell fallback. Enable the
       // session-scoped MCP face so OpenCode exposes the bound inbox as tools.
-      KORTIX_EXECUTOR_MCP_ENABLED: "1",
+      KORTIX_EXECUTOR_MCP_ENABLED: '1',
       KORTIX_EMAIL_INBOX_ID: inboxId,
       KORTIX_EMAIL_THREAD_ID: threadId,
       KORTIX_EMAIL_MESSAGE_ID: event.message.message_id,
-      KORTIX_EMAIL_ADDRESS: event.message.to?.[0] ?? "",
+      KORTIX_EMAIL_ADDRESS: event.message.to?.[0] ?? '',
       KORTIX_FRONTEND_URL: config.FRONTEND_URL,
     },
   });
 
   if (result.error) {
-    console.error("[email-webhook] createProjectSession failed", {
+    console.error('[email-webhook] createProjectSession failed', {
       status: result.error.status,
       body: result.error.body,
     });
@@ -327,14 +290,12 @@ async function alreadyHandled(key: string): Promise<boolean> {
       .returning({ eventId: chatEventDedup.eventId });
     return inserted.length === 0;
   } catch (err) {
-    console.warn("[email-webhook] event dedup check failed", err);
+    console.warn('[email-webhook] event dedup check failed', err);
     return false;
   }
 }
 
-async function claimInboundMessage(
-  event: AgentMailMessageReceivedEvent,
-): Promise<boolean> {
+async function claimInboundMessage(event: AgentMailMessageReceivedEvent): Promise<boolean> {
   const key = `email:msg:${event.message.inbox_id}:${event.message.message_id}`;
   try {
     const inserted = await db
@@ -347,10 +308,7 @@ async function claimInboundMessage(
       .returning({ eventId: chatEventDedup.eventId });
     return inserted.length > 0;
   } catch (err) {
-    console.error(
-      "[email-webhook] inbound message claim failed (fail-open)",
-      err,
-    );
+    console.error('[email-webhook] inbound message claim failed (fail-open)', err);
     return true;
   }
 }
@@ -367,15 +325,12 @@ async function claimThreadCreate(key: string): Promise<boolean> {
       .returning({ eventId: chatEventDedup.eventId });
     return inserted.length > 0;
   } catch (err) {
-    console.warn("[email-webhook] thread-create claim failed (fail-open)", err);
+    console.warn('[email-webhook] thread-create claim failed (fail-open)', err);
     return true;
   }
 }
 
-async function waitForThreadSession(
-  inboxId: string,
-  threadId: string,
-): Promise<string | null> {
+async function waitForThreadSession(inboxId: string, threadId: string): Promise<string | null> {
   const deadline = Date.now() + 8_000;
   for (;;) {
     const [row] = await db
@@ -383,7 +338,7 @@ async function waitForThreadSession(
       .from(chatThreads)
       .where(
         and(
-          eq(chatThreads.platform, "email"),
+          eq(chatThreads.platform, 'email'),
           eq(chatThreads.workspaceId, inboxId),
           eq(chatThreads.threadId, threadId),
         ),
@@ -397,81 +352,73 @@ async function waitForThreadSession(
 
 function emailTurnInstructions(event: AgentMailMessageReceivedEvent): string {
   const readThreadCall = JSON.stringify({
-    connector: "email",
-    action: "get_thread",
+    connector: 'email',
+    action: 'get_thread',
     args: {
       inbox_id: event.message.inbox_id,
       thread_id: event.message.thread_id,
     },
   });
   const replyCall = JSON.stringify({
-    connector: "email",
-    action: "reply_message",
+    connector: 'email',
+    action: 'reply_message',
     args: {
       inbox_id: event.message.inbox_id,
       message_id: event.message.message_id,
-      text: "<reply>",
+      text: '<reply>',
     },
   });
   return [
-    "How to work:",
-    "- You are operating an AgentMail inbox assigned to this Kortix project.",
-    "- Use the Executor MCP meta-tools `connectors`, `discover`, `describe`, and `call`. Connector actions are not direct tools.",
-    "- Start with `connectors`. Use `discover` to find an action and `describe` to confirm its input schema before the first call.",
+    'How to work:',
+    '- You are operating an AgentMail inbox assigned to this Kortix project.',
+    '- Use the Executor MCP meta-tools `connectors`, `discover`, `describe`, and `call`. Connector actions are not direct tools.',
+    '- Start with `connectors`. Use `discover` to find an action and `describe` to confirm its input schema before the first call.',
     `- Read the current thread with \`call\`: \`${readThreadCall}\`.`,
     `- Reply in the same conversation with \`call\`: \`${replyCall}\`. Use \`html\` instead of \`text\` only when needed.`,
-    "- Start a new outbound email with `call`, connector `email`, action `send_message`, and args containing `inbox_id`, `to`, `subject`, and `text` or `html`.",
-    "- The AgentMail API key is resolved server-side. Do not look for it in the sandbox.",
-    "- If you need the user to clarify something, reply by email and end the turn. Their next reply will resume this same session.",
-  ].join("\n");
+    '- Start a new outbound email with `call`, connector `email`, action `send_message`, and args containing `inbox_id`, `to`, `subject`, and `text` or `html`.',
+    '- The AgentMail API key is resolved server-side. Do not look for it in the sandbox.',
+    '- If you need the user to clarify something, reply by email and end the turn. Their next reply will resume this same session.',
+  ].join('\n');
 }
 
 function renderFollowUpPrompt(event: AgentMailMessageReceivedEvent): string {
   return [
     `New email reply from ${messageSender(event)} in the same thread:`,
-    "",
+    '',
     messageSummary(event),
-    "",
+    '',
     emailTurnInstructions(event),
-  ].join("\n");
+  ].join('\n');
 }
 
-function renderAgentPrompt(
-  event: AgentMailMessageReceivedEvent,
-  revived: boolean,
-): string {
+function renderAgentPrompt(event: AgentMailMessageReceivedEvent, revived: boolean): string {
   const lines: string[] = [];
   if (revived) {
     lines.push(
-      "NOTE: This email thread had an earlier conversation, but that session was deleted.",
-      "Pick the thread back up from the current email context.",
-      "",
+      'NOTE: This email thread had an earlier conversation, but that session was deleted.',
+      'Pick the thread back up from the current email context.',
+      '',
     );
   }
   lines.push(
     "You're answering an email thread as the Kortix agent.",
-    "",
+    '',
     `Inbox ID:   ${event.message.inbox_id}`,
     `Thread ID:  ${event.message.thread_id}`,
     `Message ID: ${event.message.message_id}`,
     `From:       ${messageSender(event)}`,
-    `To:         ${(event.message.to ?? []).join(", ")}`,
-    `Subject:    ${messageSubject(event) ?? "(no subject)"}`,
-    "",
+    `To:         ${(event.message.to ?? []).join(', ')}`,
+    `Subject:    ${messageSubject(event) ?? '(no subject)'}`,
+    '',
     messageSummary(event),
-    "",
+    '',
     emailTurnInstructions(event),
   );
-  return lines.join("\n");
+  return lines.join('\n');
 }
 
-function isInboundMessageEvent(
-  eventType: AgentMailMessageReceivedEvent["event_type"],
-): boolean {
-  return (
-    eventType === "message.received" ||
-    eventType === "message.received.unauthenticated"
-  );
+function isInboundMessageEvent(eventType: AgentMailMessageReceivedEvent['event_type']): boolean {
+  return eventType === 'message.received' || eventType === 'message.received.unauthenticated';
 }
 
 function messageSubject(event: AgentMailMessageReceivedEvent): string | null {
@@ -479,44 +426,37 @@ function messageSubject(event: AgentMailMessageReceivedEvent): string | null {
 }
 
 function messageSummary(event: AgentMailMessageReceivedEvent): string {
-  const body =
-    event.message.extracted_text ||
-    event.message.text ||
-    event.message.preview ||
-    "";
+  const body = event.message.extracted_text || event.message.text || event.message.preview || '';
   const attachments = event.message.attachments?.length
     ? [
-        "",
-        "Attachments:",
+        '',
+        'Attachments:',
         ...event.message.attachments.map(
           (a) =>
-            `- ${a.filename ?? a.attachment_id} (${a.content_type ?? "unknown"}, ${a.size} bytes)`,
+            `- ${a.filename ?? a.attachment_id} (${a.content_type ?? 'unknown'}, ${a.size} bytes)`,
         ),
-      ].join("\n")
-    : "";
-  return ["Email body:", body || "(empty)", attachments]
-    .filter(Boolean)
-    .join("\n");
+      ].join('\n')
+    : '';
+  return ['Email body:', body || '(empty)', attachments].filter(Boolean).join('\n');
 }
 
 function messageSender(event: AgentMailMessageReceivedEvent): string {
-  if (typeof event.message.from === "string" && event.message.from.trim()) {
+  if (typeof event.message.from === 'string' && event.message.from.trim()) {
     return event.message.from.trim();
   }
   const from = event.message.from_;
-  if (typeof from === "string") return from.trim();
+  if (typeof from === 'string') return from.trim();
   if (Array.isArray(from)) {
     const first = from[0];
-    if (typeof first === "string") return first.trim();
-    if (first && typeof first === "object") {
-      return (first.email ?? first.address ?? first.name ?? "").trim();
+    if (typeof first === 'string') return first.trim();
+    if (first && typeof first === 'object') {
+      return (first.email ?? first.address ?? first.name ?? '').trim();
     }
   }
-  return "";
+  return '';
 }
 
-const MAILBOX_PATTERN =
-  /[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+/gi;
+const MAILBOX_PATTERN = /[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+/gi;
 
 /**
  * Resolve the one canonical From mailbox AgentMail delivered.
@@ -531,28 +471,25 @@ function senderEmail(event: AgentMailMessageReceivedEvent): string | null {
   const primary = event.message.from;
   const alternate = event.message.from_;
   const primaryMailbox =
-    typeof primary === "string" && primary.trim()
-      ? canonicalMailbox(primary)
-      : null;
+    typeof primary === 'string' && primary.trim() ? canonicalMailbox(primary) : null;
   const alternateMailbox = canonicalStructuredMailbox(alternate);
   if (primaryMailbox && alternate !== undefined) {
     return alternateMailbox === primaryMailbox ? primaryMailbox : null;
   }
-  if (typeof primary === "string" && primary.trim()) return primaryMailbox;
+  if (typeof primary === 'string' && primary.trim()) return primaryMailbox;
   return alternateMailbox;
 }
 
 function canonicalStructuredMailbox(
-  from: AgentMailMessageReceivedEvent["message"]["from_"],
+  from: AgentMailMessageReceivedEvent['message']['from_'],
 ): string | null {
   if (Array.isArray(from)) {
     if (from.length !== 1) return null;
     const [first] = from;
-    if (typeof first === "string") return canonicalMailbox(first);
-    if (!first || typeof first !== "object") return null;
-    const rawEmail = typeof first.email === "string" ? first.email.trim() : "";
-    const rawAddress =
-      typeof first.address === "string" ? first.address.trim() : "";
+    if (typeof first === 'string') return canonicalMailbox(first);
+    if (!first || typeof first !== 'object') return null;
+    const rawEmail = typeof first.email === 'string' ? first.email.trim() : '';
+    const rawAddress = typeof first.address === 'string' ? first.address.trim() : '';
     const email = rawEmail ? canonicalMailbox(rawEmail) : null;
     const address = rawAddress ? canonicalMailbox(rawAddress) : null;
     // AgentMail payload variants have used both keys. Treat them as aliases,
@@ -562,7 +499,7 @@ function canonicalStructuredMailbox(
     if (email && address && email !== address) return null;
     return email ?? address;
   }
-  return typeof from === "string" ? canonicalMailbox(from) : null;
+  return typeof from === 'string' ? canonicalMailbox(from) : null;
 }
 
 function canonicalMailbox(value: string): string | null {
@@ -573,13 +510,13 @@ function canonicalMailbox(value: string): string | null {
   if (!mailbox) return null;
   if (sender === mailbox) return mailbox;
 
-  const open = sender.indexOf("<");
-  const close = sender.indexOf(">");
+  const open = sender.indexOf('<');
+  const close = sender.indexOf('>');
   if (
     open <= 0 ||
     close !== sender.length - 1 ||
-    sender.indexOf("<", open + 1) !== -1 ||
-    sender.indexOf(">", close + 1) !== -1 ||
+    sender.indexOf('<', open + 1) !== -1 ||
+    sender.indexOf('>', close + 1) !== -1 ||
     sender.slice(open + 1, close).trim() !== mailbox
   ) {
     return null;
@@ -591,15 +528,13 @@ export function isAgentMailSenderAllowedForTest(
   event: AgentMailMessageReceivedEvent,
   policy: AgentMailSenderPolicy,
 ): boolean {
-  if (policy.mode !== "restricted") return true;
+  if (policy.mode !== 'restricted') return true;
   const email = senderEmail(event);
   if (!email) return false;
   if (policy.allowedEmails.includes(email)) return true;
-  const domain = email.split("@")[1] ?? "";
+  const domain = email.split('@')[1] ?? '';
   if (
-    policy.allowedDomains.some(
-      (allowed) => domain === allowed || domain.endsWith(`.${allowed}`),
-    )
+    policy.allowedDomains.some((allowed) => domain === allowed || domain.endsWith(`.${allowed}`))
   ) {
     return true;
   }

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -8,11 +8,11 @@ import {
 import {
   executorConnectionProfiles,
   executorConnectors,
+  projectSessionConnectorBindings,
   projectSessions,
   projectTriggerRuntime,
   projects,
   sessionSandboxes,
-  projectSessionConnectorBindings,
 } from '@kortix/db';
 import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { getCachedAccountTier } from '../../billing/services/entitlements';
@@ -24,6 +24,7 @@ import {
   isAgentMailInboxLimitError,
   resolveAgentMailApiKey,
 } from '../../channels/agentmail-api';
+import { compileEmailSenderRegex } from '../../channels/email/sender-policy-regex';
 import {
   type AgentMailSenderPolicy,
   deleteAgentMailInstall,
@@ -58,8 +59,6 @@ import {
   relayTurnStep,
 } from '../../channels/turn-relay';
 import { setProjectBotName } from '../../channels/voice-identity';
-import { callerKortixSessionId } from '../lib/caller-session';
-import { sessionMayEnumerateProfile } from '../lib/connector-profile-visibility';
 import { config } from '../../config';
 import { upsertProfileCredential, upsertProfileOAuth2Credential } from '../../executor/credentials';
 import { revokeProfileOAuth2 } from '../../executor/oauth2-store';
@@ -75,9 +74,9 @@ import { setContextField } from '../../lib/request-context';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { resolveEnablement } from '../../llm-gateway/model-enablement';
 import { gatewayModelCatalog } from '../../llm-gateway/models/catalog-models';
-import { platformDefaultModelId } from '../../llm-gateway/models/served-managed-models';
 import { projectPickerCatalog } from '../../llm-gateway/models/picker-catalog';
 import { runtimeModelCatalog } from '../../llm-gateway/models/runtime-catalog';
+import { platformDefaultModelId } from '../../llm-gateway/models/served-managed-models';
 import {
   invalidateAccountModelDefaults,
   isModelServableForAccount,
@@ -101,14 +100,15 @@ import {
   loadProjectForUser,
   projectCapabilityAllowed,
 } from '../lib/access';
-import { shortenSandboxDeadlineOnTurnEnd } from '../sandbox-deadline';
 import { AnyObject, TriggerSchema, projectsApp } from '../lib/app';
+import { callerKortixSessionId } from '../lib/caller-session';
 import {
-  connectorAuthorizationMatchesStrategy,
-  isTrustedManagedChannelAuthorization,
   type ConnectorAuthorizationOwnerType,
   type ConnectorAuthorizationStrategy,
+  connectorAuthorizationMatchesStrategy,
+  isTrustedManagedChannelAuthorization,
 } from '../lib/connector-authorization-strategy';
+import { sessionMayEnumerateProfile } from '../lib/connector-profile-visibility';
 import { withProjectGitAuth } from '../lib/git';
 import { metadataMerge } from '../lib/metadata-merge';
 import { sandboxTokenMayActOnSession } from '../lib/sandbox-token-session';
@@ -131,6 +131,7 @@ import {
   triggersPausedForProject,
   upsertTriggerInManifest,
 } from '../lib/triggers';
+import { shortenSandboxDeadlineOnTurnEnd } from '../sandbox-deadline';
 import { listProjectSecretsSnapshot } from '../secrets';
 import { reconcileProjectTriggerRuntime } from '../trigger-runtime-catalog';
 import { type ParsedManifest, extractTriggers, loadProjectTriggers } from '../triggers';
@@ -2142,33 +2143,11 @@ function normalizeAgentMailUsername(input: string | null | undefined): string | 
   return trimmed || null;
 }
 
-// Small static check for the classic catastrophic-backtracking shapes —
-// a quantified sub-group repeated by an outer quantifier (e.g. (x+)+, (x*)*)
-// or an ambiguous repeated alternation (e.g. (a|a)*) — before the pattern is
-// persisted and later run against every inbound email sender.
-const NESTED_QUANTIFIER_RE = /\([^()]*[+*][^()]*\)\s*[+*]/;
-const DUPLICATE_ALTERNATION_RE = /\(([^()|]+)\|\1\)\s*[+*]/;
-
-function hasCatastrophicBacktracking(pattern: string): boolean {
-  return NESTED_QUANTIFIER_RE.test(pattern) || DUPLICATE_ALTERNATION_RE.test(pattern);
-}
-
 function parseSenderPolicyBody(
   input: Partial<AgentMailSenderPolicy> | undefined,
 ): AgentMailSenderPolicy {
   const policy = normalizeSenderPolicy(input);
-  if (policy.allowedRegex) {
-    try {
-      new RegExp(policy.allowedRegex);
-    } catch {
-      throw new Error('Email sender regex is invalid');
-    }
-    if (hasCatastrophicBacktracking(policy.allowedRegex)) {
-      throw new Error(
-        'Email sender regex is not allowed: nested or ambiguous repetition can cause catastrophic backtracking (ReDoS)',
-      );
-    }
-  }
+  if (policy.allowedRegex) compileEmailSenderRegex(policy.allowedRegex);
   return policy;
 }
 

--- a/packages/sdk/src/core/rest/projects-client/channels.ts
+++ b/packages/sdk/src/core/rest/projects-client/channels.ts
@@ -150,6 +150,10 @@ export interface EmailSenderPolicy {
   mode: 'allow_all' | 'restricted';
   allowedEmails: string[];
   allowedDomains: string[];
+  /**
+   * Case-insensitive, unanchored RE2-compatible pattern (maximum 256
+   * characters). Backreferences and look-around are intentionally unsupported.
+   */
   allowedRegex: string | null;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       postgres:
         specifier: ^3.4.8
         version: 3.4.9
+      re2js:
+        specifier: 2.8.6
+        version: 2.8.6
       smol-toml:
         specifier: ^1.6.1
         version: 1.7.0
@@ -22822,6 +22825,11 @@ packages:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  /re2js@2.8.6:
+    resolution: {integrity: sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==}
+    engines: {node: '>=18.0.0'}
+    dev: false
 
   /react-day-picker@8.10.2(date-fns@3.6.0)(react@19.1.0):
     resolution: {integrity: sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==}


### PR DESCRIPTION
## Summary

- execute customer-defined email sender patterns with the linear-time pure-JS RE2JS engine
- validate persistence through the same compiler, cap patterns at 256 characters, and fail closed for unsupported legacy patterns
- preserve case-insensitive, unanchored matching while documenting the RE2-compatible SDK contract
- add adversarial coverage for counted repetition and overlapping alternation

## Security

This removes JavaScript backtracking regex execution from the inbound AgentMail authorization path. Patterns using look-around or backreferences are rejected because RE2 does not support them; ordinary groups, alternation, wildcard patterns, character classes, and counted repetition remain available.

## Verification

- `bun test --isolate --env-file=scripts/test.env --reporter=dot src/channels/email/sender-policy-regex.test.ts src/__tests__/unit-email-channel.test.ts` (17 pass, 94 assertions)
- `pnpm --filter kortix-api typecheck`
- `pnpm --filter kortix-api test`
- `pnpm --filter @kortix/sdk typecheck`
- `pnpm --filter @kortix/sdk test` (1,387 pass, 2 skip, 0 fail)
- Bun runtime import/match smoke for `re2js`
- `git diff --check`