### PR TITLE
fix(markdown): make table headers and cells stop wrapping mid-word, restore GFM alignment

### DIFF
--- a/apps/web/src/components/better-markdown/message-markdown.test.tsx
+++ b/apps/web/src/components/better-markdown/message-markdown.test.tsx
@@ -4,10 +4,16 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { MessageMarkdown } from './message-markdown';
 
 const TABLE_MD = ['| Priority | Name |', '| --- | --- |', '| High | G1 |', ''].join('\n');
+const ALIGN_TABLE_MD = ['| Center | Right |', '| :---: | ---: |', '| b | c |', ''].join('\n');
 
 function cellClasses(html: string, tag: 'th' | 'td'): string[] {
   const matches = [...html.matchAll(new RegExp(`<${tag} class="([^"]*)"`, 'g'))];
   return matches.map((m) => m[1]);
+}
+
+function cellTextAligns(html: string, tag: 'th' | 'td'): (string | undefined)[] {
+  const matches = [...html.matchAll(new RegExp(`<${tag}\\s+([^>]*)>`, 'g'))];
+  return matches.map((m) => /text-align:\s*([a-z]+)/.exec(m[1])?.[1]);
 }
 
 describe('MessageMarkdown table cells', () => {
@@ -29,6 +35,38 @@ describe('MessageMarkdown table cells', () => {
     expect(classes.length).toBeGreaterThan(0);
     for (const cls of classes) {
       expect(cls).toContain('break-normal');
+    }
+  });
+
+  test('th forwards alignment without a sanitize step for :---: and ---: columns', () => {
+    const html = renderToStaticMarkup(<MessageMarkdown content={ALIGN_TABLE_MD} />);
+    const aligns = cellTextAligns(html, 'th');
+
+    expect(aligns).toEqual(['center', 'right']);
+  });
+
+  test('td forwards alignment without a sanitize step for :---: and ---: columns', () => {
+    const html = renderToStaticMarkup(<MessageMarkdown content={ALIGN_TABLE_MD} />);
+    const aligns = cellTextAligns(html, 'td');
+
+    expect(aligns).toEqual(['center', 'right']);
+  });
+
+  test('table wrapper scrolls horizontally, not vertically', () => {
+    const html = renderToStaticMarkup(<MessageMarkdown content={TABLE_MD} />);
+
+    expect(html).toContain('overflow-x-auto');
+    expect(html).not.toContain('overflow-y-auto');
+  });
+
+  test('th header band uses bg-muted, not bg-accent', () => {
+    const html = renderToStaticMarkup(<MessageMarkdown content={TABLE_MD} />);
+    const classes = cellClasses(html, 'th');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('bg-muted');
+      expect(cls).not.toContain('bg-accent');
     }
   });
 });

--- a/apps/web/src/components/better-markdown/message-markdown.test.tsx
+++ b/apps/web/src/components/better-markdown/message-markdown.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { MessageMarkdown } from './message-markdown';
+
+const TABLE_MD = ['| Priority | Name |', '| --- | --- |', '| High | G1 |', ''].join('\n');
+
+function cellClasses(html: string, tag: 'th' | 'td'): string[] {
+  const matches = [...html.matchAll(new RegExp(`<${tag} class="([^"]*)"`, 'g'))];
+  return matches.map((m) => m[1]);
+}
+
+describe('MessageMarkdown table cells', () => {
+  test('th carries whitespace-nowrap and break-normal', () => {
+    const html = renderToStaticMarkup(<MessageMarkdown content={TABLE_MD} />);
+    const classes = cellClasses(html, 'th');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('whitespace-nowrap');
+      expect(cls).toContain('break-normal');
+    }
+  });
+
+  test('td carries break-normal', () => {
+    const html = renderToStaticMarkup(<MessageMarkdown content={TABLE_MD} />);
+    const classes = cellClasses(html, 'td');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('break-normal');
+    }
+  });
+});

--- a/apps/web/src/components/better-markdown/message-markdown.test.tsx
+++ b/apps/web/src/components/better-markdown/message-markdown.test.tsx
@@ -16,6 +16,11 @@ function cellTextAligns(html: string, tag: 'th' | 'td'): (string | undefined)[] 
   return matches.map((m) => /text-align:\s*([a-z]+)/.exec(m[1])?.[1]);
 }
 
+function tableWrapperClasses(html: string): string {
+  const match = /<div class="([^"]*overflow-x-auto[^"]*)"/.exec(html);
+  return match?.[1] ?? '';
+}
+
 describe('MessageMarkdown table cells', () => {
   test('th carries whitespace-nowrap and break-normal', () => {
     const html = renderToStaticMarkup(<MessageMarkdown content={TABLE_MD} />);
@@ -54,9 +59,10 @@ describe('MessageMarkdown table cells', () => {
 
   test('table wrapper scrolls horizontally, not vertically', () => {
     const html = renderToStaticMarkup(<MessageMarkdown content={TABLE_MD} />);
+    const wrapperClasses = tableWrapperClasses(html);
 
-    expect(html).toContain('overflow-x-auto');
-    expect(html).not.toContain('overflow-y-auto');
+    expect(wrapperClasses).toContain('overflow-x-auto');
+    expect(wrapperClasses).not.toContain('overflow-y-auto');
   });
 
   test('th header band uses bg-muted, not bg-accent', () => {
@@ -68,5 +74,11 @@ describe('MessageMarkdown table cells', () => {
       expect(cls).toContain('bg-muted');
       expect(cls).not.toContain('bg-accent');
     }
+  });
+
+  test('does not leak the react-markdown node prop onto th/td', () => {
+    const html = renderToStaticMarkup(<MessageMarkdown content={TABLE_MD} />);
+
+    expect(html).not.toContain('node=');
   });
 });

--- a/apps/web/src/components/better-markdown/message-markdown.tsx
+++ b/apps/web/src/components/better-markdown/message-markdown.tsx
@@ -104,7 +104,7 @@ const components: Components = {
     </th>
   ),
   tr: ({ children, className }) => (
-    <tr className={cn("border-border bg-background border-b last:border-b-0", className)}>
+    <tr className={cn(className, "border-border bg-background border-b last:border-b-0")}>
       {children}
     </tr>
   ),

--- a/apps/web/src/components/better-markdown/message-markdown.tsx
+++ b/apps/web/src/components/better-markdown/message-markdown.tsx
@@ -95,7 +95,7 @@ const components: Components = {
   th: ({ children, className }) => (
     <th
       className={cn(
-        "bg-accent border-b px-4 py-2 text-left font-semibold [&[align=center]]:text-center [&[align=right]]:text-right",
+        "bg-accent border-b px-4 py-2 text-left font-semibold whitespace-nowrap break-normal [&[align=center]]:text-center [&[align=right]]:text-right",
         className,
       )}
     >
@@ -110,7 +110,7 @@ const components: Components = {
   td: ({ children, className }) => (
     <td
       className={cn(
-        "px-4 py-2 text-left font-normal [&[align=center]]:text-center [&[align=right]]:text-right",
+        "px-4 py-2 text-left font-normal break-normal [&[align=center]]:text-center [&[align=right]]:text-right",
         className,
       )}
     >

--- a/apps/web/src/components/better-markdown/message-markdown.tsx
+++ b/apps/web/src/components/better-markdown/message-markdown.tsx
@@ -95,8 +95,8 @@ const components: Components = {
   th: ({ children, className, node: _node, ...props }) => (
     <th
       className={cn(
-        "bg-muted border-b px-4 py-2 text-left font-semibold whitespace-nowrap break-normal [&[align=center]]:text-center [&[align=right]]:text-right",
         className,
+        "bg-muted border-b px-4 py-2 text-left font-semibold whitespace-nowrap break-normal [&[align=center]]:text-center [&[align=right]]:text-right",
       )}
       {...props}
     >
@@ -111,8 +111,8 @@ const components: Components = {
   td: ({ children, className, node: _node, ...props }) => (
     <td
       className={cn(
-        "px-4 py-2 text-left font-normal break-normal [&[align=center]]:text-center [&[align=right]]:text-right",
         className,
+        "px-4 py-2 text-left font-normal break-normal [&[align=center]]:text-center [&[align=right]]:text-right",
       )}
       {...props}
     >

--- a/apps/web/src/components/better-markdown/message-markdown.tsx
+++ b/apps/web/src/components/better-markdown/message-markdown.tsx
@@ -88,16 +88,17 @@ const components: Components = {
     </blockquote>
   ),
   table: ({ children }) => (
-    <div className="border-border mt-6 w-full overflow-hidden overflow-y-auto rounded-md border">
+    <div className="border-border mt-6 w-full overflow-hidden overflow-x-auto rounded-md border">
       <table className="w-full">{children}</table>
     </div>
   ),
-  th: ({ children, className }) => (
+  th: ({ children, className, node: _node, ...props }) => (
     <th
       className={cn(
-        "bg-accent border-b px-4 py-2 text-left font-semibold whitespace-nowrap break-normal [&[align=center]]:text-center [&[align=right]]:text-right",
+        "bg-muted border-b px-4 py-2 text-left font-semibold whitespace-nowrap break-normal [&[align=center]]:text-center [&[align=right]]:text-right",
         className,
       )}
+      {...props}
     >
       {children}
     </th>
@@ -107,12 +108,13 @@ const components: Components = {
       {children}
     </tr>
   ),
-  td: ({ children, className }) => (
+  td: ({ children, className, node: _node, ...props }) => (
     <td
       className={cn(
         "px-4 py-2 text-left font-normal break-normal [&[align=center]]:text-center [&[align=right]]:text-right",
         className,
       )}
+      {...props}
     >
       {children}
     </td>

--- a/apps/web/src/components/markdown/doc-markdown.test.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.test.tsx
@@ -14,10 +14,16 @@ function withIntl(node: ReactNode) {
 }
 
 const TABLE_MD = ['| Priority | Name |', '| --- | --- |', '| High | G1 |', ''].join('\n');
+const ALIGN_TABLE_MD = ['| Center | Right |', '| :---: | ---: |', '| b | c |', ''].join('\n');
 
 function cellClasses(html: string, tag: 'th' | 'td'): string[] {
   const matches = [...html.matchAll(new RegExp(`<${tag} class="([^"]*)"`, 'g'))];
   return matches.map((m) => m[1]);
+}
+
+function cellTextAligns(html: string, tag: 'th' | 'td'): (string | undefined)[] {
+  const matches = [...html.matchAll(new RegExp(`<${tag}\\s+([^>]*)>`, 'g'))];
+  return matches.map((m) => /text-align:\s*([a-z]+)/.exec(m[1])?.[1]);
 }
 
 describe('DocMarkdown table cells', () => {
@@ -40,5 +46,19 @@ describe('DocMarkdown table cells', () => {
     for (const cls of classes) {
       expect(cls).toContain('break-normal');
     }
+  });
+
+  test('th forwards alignment through sanitize for :---: and ---: columns', () => {
+    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={ALIGN_TABLE_MD} />));
+    const aligns = cellTextAligns(html, 'th');
+
+    expect(aligns).toEqual(['center', 'right']);
+  });
+
+  test('td forwards alignment through sanitize for :---: and ---: columns', () => {
+    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={ALIGN_TABLE_MD} />));
+    const aligns = cellTextAligns(html, 'td');
+
+    expect(aligns).toEqual(['center', 'right']);
   });
 });

--- a/apps/web/src/components/markdown/doc-markdown.test.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.test.tsx
@@ -1,5 +1,5 @@
-import { NextIntlClientProvider } from 'next-intl';
 import { describe, expect, test } from 'bun:test';
+import { NextIntlClientProvider } from 'next-intl';
 import type { ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -67,7 +67,9 @@ describe('DocMarkdown table cells', () => {
   });
 
   test('th keeps whitespace-nowrap and break-normal when a raw HTML class conflicts', () => {
-    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={CONFLICTING_CLASS_TABLE_HTML} />));
+    const html = renderToStaticMarkup(
+      withIntl(<DocMarkdown content={CONFLICTING_CLASS_TABLE_HTML} />),
+    );
     const classes = cellClasses(html, 'th');
 
     expect(classes.length).toBeGreaterThan(0);
@@ -78,12 +80,20 @@ describe('DocMarkdown table cells', () => {
   });
 
   test('td keeps break-normal when a raw HTML class conflicts', () => {
-    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={CONFLICTING_CLASS_TABLE_HTML} />));
+    const html = renderToStaticMarkup(
+      withIntl(<DocMarkdown content={CONFLICTING_CLASS_TABLE_HTML} />),
+    );
     const classes = cellClasses(html, 'td');
 
     expect(classes.length).toBeGreaterThan(0);
     for (const cls of classes) {
       expect(cls).toContain('break-normal');
     }
+  });
+
+  test('does not leak the react-markdown node prop onto th/td', () => {
+    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={TABLE_MD} />));
+
+    expect(html).not.toContain('node=');
   });
 });

--- a/apps/web/src/components/markdown/doc-markdown.test.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.test.tsx
@@ -1,0 +1,44 @@
+import { NextIntlClientProvider } from 'next-intl';
+import { describe, expect, test } from 'bun:test';
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { DocMarkdown } from './doc-markdown';
+
+function withIntl(node: ReactNode) {
+  return (
+    <NextIntlClientProvider locale="en" messages={{}} onError={() => {}}>
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const TABLE_MD = ['| Priority | Name |', '| --- | --- |', '| High | G1 |', ''].join('\n');
+
+function cellClasses(html: string, tag: 'th' | 'td'): string[] {
+  const matches = [...html.matchAll(new RegExp(`<${tag} class="([^"]*)"`, 'g'))];
+  return matches.map((m) => m[1]);
+}
+
+describe('DocMarkdown table cells', () => {
+  test('th carries whitespace-nowrap and break-normal', () => {
+    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={TABLE_MD} />));
+    const classes = cellClasses(html, 'th');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('whitespace-nowrap');
+      expect(cls).toContain('break-normal');
+    }
+  });
+
+  test('td carries break-normal', () => {
+    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={TABLE_MD} />));
+    const classes = cellClasses(html, 'td');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('break-normal');
+    }
+  });
+});

--- a/apps/web/src/components/markdown/doc-markdown.test.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.test.tsx
@@ -15,6 +15,10 @@ function withIntl(node: ReactNode) {
 
 const TABLE_MD = ['| Priority | Name |', '| --- | --- |', '| High | G1 |', ''].join('\n');
 const ALIGN_TABLE_MD = ['| Center | Right |', '| :---: | ---: |', '| b | c |', ''].join('\n');
+const CONFLICTING_CLASS_TABLE_HTML = [
+  '<table><tr><th class="whitespace-normal">Head</th></tr>',
+  '<tr><td class="break-all">cell</td></tr></table>',
+].join('\n');
 
 function cellClasses(html: string, tag: 'th' | 'td'): string[] {
   const matches = [...html.matchAll(new RegExp(`<${tag} class="([^"]*)"`, 'g'))];
@@ -60,5 +64,26 @@ describe('DocMarkdown table cells', () => {
     const aligns = cellTextAligns(html, 'td');
 
     expect(aligns).toEqual(['center', 'right']);
+  });
+
+  test('th keeps whitespace-nowrap and break-normal when a raw HTML class conflicts', () => {
+    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={CONFLICTING_CLASS_TABLE_HTML} />));
+    const classes = cellClasses(html, 'th');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('whitespace-nowrap');
+      expect(cls).toContain('break-normal');
+    }
+  });
+
+  test('td keeps break-normal when a raw HTML class conflicts', () => {
+    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={CONFLICTING_CLASS_TABLE_HTML} />));
+    const classes = cellClasses(html, 'td');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('break-normal');
+    }
   });
 });

--- a/apps/web/src/components/markdown/doc-markdown.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.tsx
@@ -624,13 +624,32 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
           <tbody className="divide-border divide-y">{children}</tbody>
         ),
         tr: ({ children }: { children?: React.ReactNode }) => <tr>{children}</tr>,
-        th: ({ children }: { children?: React.ReactNode }) => (
-          <th className="text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal">
+        th: ({
+          children,
+          className: thClassName,
+          node: _node,
+          ...props
+        }: React.ThHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
+          <th
+            className={cn(
+              'text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal',
+              thClassName,
+            )}
+            {...props}
+          >
             {children}
           </th>
         ),
-        td: ({ children }: { children?: React.ReactNode }) => (
-          <td className="text-foreground px-4 py-2 text-left font-normal break-normal">
+        td: ({
+          children,
+          className: tdClassName,
+          node: _node,
+          ...props
+        }: React.TdHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
+          <td
+            className={cn('text-foreground px-4 py-2 text-left font-normal break-normal', tdClassName)}
+            {...props}
+          >
             {wrapChildrenWithPaths(children)}
           </td>
         ),

--- a/apps/web/src/components/markdown/doc-markdown.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.tsx
@@ -13,13 +13,6 @@ import {
   normalizeClassName,
   prepareMarkdownForKatex,
 } from '@/components/markdown/katex-markdown';
-import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
-import { parseSetupLinkHref } from '@/components/setup-links/util';
-import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
-import { isMermaidCode } from '@/lib/mermaid-utils';
-import { toast } from '@/lib/toast';
-import { cn } from '@/lib/utils';
-import { stripKortixSystemTags } from '@/lib/utils/kortix-system-tags';
 import {
   isInternalUrl,
   isLinkSafeHref,
@@ -29,6 +22,13 @@ import {
   normalizeLanguage,
   shikiWasmAvailable,
 } from '@/components/markdown/unified-markdown-utils';
+import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
+import { parseSetupLinkHref } from '@/components/setup-links/util';
+import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
+import { isMermaidCode } from '@/lib/mermaid-utils';
+import { toast } from '@/lib/toast';
+import { cn } from '@/lib/utils';
+import { stripKortixSystemTags } from '@/lib/utils/kortix-system-tags';
 import { useFilePreviewStore } from '@/stores/file-preview-store';
 import { getActivePanelSessionId, openFileInSessionPanel } from '@/stores/session-browser-store';
 import { autoLinkUrls } from '@kortix/shared';
@@ -624,6 +624,8 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
           <tbody className="divide-border divide-y">{children}</tbody>
         ),
         tr: ({ children }: { children?: React.ReactNode }) => <tr>{children}</tr>,
+        // cn() is twMerge: the last same-group class wins. Static classes go
+        // last here so an incoming className can't strip whitespace-nowrap/break-normal.
         th: ({
           children,
           className: thClassName,
@@ -633,7 +635,7 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
           <th
             className={cn(
               thClassName,
-              'text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal',
+              'text-foreground px-4 py-2 text-left font-semibold break-normal whitespace-nowrap',
             )}
             {...props}
           >
@@ -647,7 +649,10 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
           ...props
         }: React.TdHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
           <td
-            className={cn(tdClassName, 'text-foreground px-4 py-2 text-left font-normal break-normal')}
+            className={cn(
+              tdClassName,
+              'text-foreground px-4 py-2 text-left font-normal break-normal',
+            )}
             {...props}
           >
             {wrapChildrenWithPaths(children)}

--- a/apps/web/src/components/markdown/doc-markdown.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.tsx
@@ -632,8 +632,8 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
         }: React.ThHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
           <th
             className={cn(
-              'text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal',
               thClassName,
+              'text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal',
             )}
             {...props}
           >
@@ -647,7 +647,7 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
           ...props
         }: React.TdHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
           <td
-            className={cn('text-foreground px-4 py-2 text-left font-normal break-normal', tdClassName)}
+            className={cn(tdClassName, 'text-foreground px-4 py-2 text-left font-normal break-normal')}
             {...props}
           >
             {wrapChildrenWithPaths(children)}

--- a/apps/web/src/components/markdown/doc-markdown.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.tsx
@@ -625,10 +625,12 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
         ),
         tr: ({ children }: { children?: React.ReactNode }) => <tr>{children}</tr>,
         th: ({ children }: { children?: React.ReactNode }) => (
-          <th className="text-foreground px-4 py-2 text-left font-semibold">{children}</th>
+          <th className="text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal">
+            {children}
+          </th>
         ),
         td: ({ children }: { children?: React.ReactNode }) => (
-          <td className="text-foreground px-4 py-2 text-left font-normal">
+          <td className="text-foreground px-4 py-2 text-left font-normal break-normal">
             {wrapChildrenWithPaths(children)}
           </td>
         ),

--- a/apps/web/src/components/markdown/unified-markdown.test.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.test.tsx
@@ -15,6 +15,10 @@ function withIntl(node: ReactNode) {
 
 const TABLE_MD = ['| Priority | Name |', '| --- | --- |', '| High | G1 |', ''].join('\n');
 const ALIGN_TABLE_MD = ['| Center | Right |', '| :---: | ---: |', '| b | c |', ''].join('\n');
+const CONFLICTING_CLASS_TABLE_HTML = [
+  '<table><tr><th class="whitespace-normal">Head</th></tr>',
+  '<tr><td class="break-all">cell</td></tr></table>',
+].join('\n');
 
 function cellClasses(html: string, tag: 'th' | 'td'): string[] {
   const matches = [...html.matchAll(new RegExp(`<${tag} class="([^"]*)"`, 'g'))];
@@ -60,5 +64,30 @@ describe('UnifiedMarkdown table cells', () => {
     const aligns = cellTextAligns(html, 'td');
 
     expect(aligns).toEqual(['center', 'right']);
+  });
+
+  test('th keeps whitespace-nowrap and break-normal when a raw HTML class conflicts', () => {
+    const html = renderToStaticMarkup(
+      withIntl(<UnifiedMarkdown content={CONFLICTING_CLASS_TABLE_HTML} />),
+    );
+    const classes = cellClasses(html, 'th');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('whitespace-nowrap');
+      expect(cls).toContain('break-normal');
+    }
+  });
+
+  test('td keeps break-normal when a raw HTML class conflicts', () => {
+    const html = renderToStaticMarkup(
+      withIntl(<UnifiedMarkdown content={CONFLICTING_CLASS_TABLE_HTML} />),
+    );
+    const classes = cellClasses(html, 'td');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('break-normal');
+    }
   });
 });

--- a/apps/web/src/components/markdown/unified-markdown.test.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.test.tsx
@@ -14,10 +14,16 @@ function withIntl(node: ReactNode) {
 }
 
 const TABLE_MD = ['| Priority | Name |', '| --- | --- |', '| High | G1 |', ''].join('\n');
+const ALIGN_TABLE_MD = ['| Center | Right |', '| :---: | ---: |', '| b | c |', ''].join('\n');
 
 function cellClasses(html: string, tag: 'th' | 'td'): string[] {
   const matches = [...html.matchAll(new RegExp(`<${tag} class="([^"]*)"`, 'g'))];
   return matches.map((m) => m[1]);
+}
+
+function cellTextAligns(html: string, tag: 'th' | 'td'): (string | undefined)[] {
+  const matches = [...html.matchAll(new RegExp(`<${tag}\\s+([^>]*)>`, 'g'))];
+  return matches.map((m) => /text-align:\s*([a-z]+)/.exec(m[1])?.[1]);
 }
 
 describe('UnifiedMarkdown table cells', () => {
@@ -40,5 +46,19 @@ describe('UnifiedMarkdown table cells', () => {
     for (const cls of classes) {
       expect(cls).toContain('break-normal');
     }
+  });
+
+  test('th forwards alignment through sanitize for :---: and ---: columns', () => {
+    const html = renderToStaticMarkup(withIntl(<UnifiedMarkdown content={ALIGN_TABLE_MD} />));
+    const aligns = cellTextAligns(html, 'th');
+
+    expect(aligns).toEqual(['center', 'right']);
+  });
+
+  test('td forwards alignment through sanitize for :---: and ---: columns', () => {
+    const html = renderToStaticMarkup(withIntl(<UnifiedMarkdown content={ALIGN_TABLE_MD} />));
+    const aligns = cellTextAligns(html, 'td');
+
+    expect(aligns).toEqual(['center', 'right']);
   });
 });

--- a/apps/web/src/components/markdown/unified-markdown.test.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.test.tsx
@@ -1,5 +1,5 @@
-import { NextIntlClientProvider } from 'next-intl';
 import { describe, expect, test } from 'bun:test';
+import { NextIntlClientProvider } from 'next-intl';
 import type { ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -89,5 +89,11 @@ describe('UnifiedMarkdown table cells', () => {
     for (const cls of classes) {
       expect(cls).toContain('break-normal');
     }
+  });
+
+  test('does not leak the react-markdown node prop onto th/td', () => {
+    const html = renderToStaticMarkup(withIntl(<UnifiedMarkdown content={TABLE_MD} />));
+
+    expect(html).not.toContain('node=');
   });
 });

--- a/apps/web/src/components/markdown/unified-markdown.test.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.test.tsx
@@ -1,0 +1,44 @@
+import { NextIntlClientProvider } from 'next-intl';
+import { describe, expect, test } from 'bun:test';
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { UnifiedMarkdown } from './unified-markdown';
+
+function withIntl(node: ReactNode) {
+  return (
+    <NextIntlClientProvider locale="en" messages={{}} onError={() => {}}>
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const TABLE_MD = ['| Priority | Name |', '| --- | --- |', '| High | G1 |', ''].join('\n');
+
+function cellClasses(html: string, tag: 'th' | 'td'): string[] {
+  const matches = [...html.matchAll(new RegExp(`<${tag} class="([^"]*)"`, 'g'))];
+  return matches.map((m) => m[1]);
+}
+
+describe('UnifiedMarkdown table cells', () => {
+  test('th carries whitespace-nowrap and break-normal', () => {
+    const html = renderToStaticMarkup(withIntl(<UnifiedMarkdown content={TABLE_MD} />));
+    const classes = cellClasses(html, 'th');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('whitespace-nowrap');
+      expect(cls).toContain('break-normal');
+    }
+  });
+
+  test('td carries break-normal', () => {
+    const html = renderToStaticMarkup(withIntl(<UnifiedMarkdown content={TABLE_MD} />));
+    const classes = cellClasses(html, 'td');
+
+    expect(classes.length).toBeGreaterThan(0);
+    for (const cls of classes) {
+      expect(cls).toContain('break-normal');
+    }
+  });
+});

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -631,8 +631,8 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
         }: React.ThHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
           <th
             className={cn(
-              'text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal',
               thClassName,
+              'text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal',
             )}
             {...props}
           >
@@ -646,7 +646,7 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
           ...props
         }: React.TdHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
           <td
-            className={cn('text-foreground px-4 py-2 text-left font-normal break-normal', tdClassName)}
+            className={cn(tdClassName, 'text-foreground px-4 py-2 text-left font-normal break-normal')}
             {...props}
           >
             {wrapChildrenWithPaths(children)}

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -623,13 +623,32 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
           <tbody className="divide-border divide-y">{children}</tbody>
         ),
         tr: ({ children }: { children?: React.ReactNode }) => <tr>{children}</tr>,
-        th: ({ children }: { children?: React.ReactNode }) => (
-          <th className="text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal">
+        th: ({
+          children,
+          className: thClassName,
+          node: _node,
+          ...props
+        }: React.ThHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
+          <th
+            className={cn(
+              'text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal',
+              thClassName,
+            )}
+            {...props}
+          >
             {children}
           </th>
         ),
-        td: ({ children }: { children?: React.ReactNode }) => (
-          <td className="text-foreground px-4 py-2 text-left font-normal break-normal">
+        td: ({
+          children,
+          className: tdClassName,
+          node: _node,
+          ...props
+        }: React.TdHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
+          <td
+            className={cn('text-foreground px-4 py-2 text-left font-normal break-normal', tdClassName)}
+            {...props}
+          >
             {wrapChildrenWithPaths(children)}
           </td>
         ),

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -623,6 +623,8 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
           <tbody className="divide-border divide-y">{children}</tbody>
         ),
         tr: ({ children }: { children?: React.ReactNode }) => <tr>{children}</tr>,
+        // cn() is twMerge: the last same-group class wins. Static classes go
+        // last here so an incoming className can't strip whitespace-nowrap/break-normal.
         th: ({
           children,
           className: thClassName,
@@ -632,7 +634,7 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
           <th
             className={cn(
               thClassName,
-              'text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal',
+              'text-foreground px-4 py-2 text-left font-semibold break-normal whitespace-nowrap',
             )}
             {...props}
           >
@@ -646,7 +648,10 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
           ...props
         }: React.TdHTMLAttributes<HTMLTableCellElement> & { node?: unknown }) => (
           <td
-            className={cn(tdClassName, 'text-foreground px-4 py-2 text-left font-normal break-normal')}
+            className={cn(
+              tdClassName,
+              'text-foreground px-4 py-2 text-left font-normal break-normal',
+            )}
             {...props}
           >
             {wrapChildrenWithPaths(children)}

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -624,10 +624,12 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
         ),
         tr: ({ children }: { children?: React.ReactNode }) => <tr>{children}</tr>,
         th: ({ children }: { children?: React.ReactNode }) => (
-          <th className="text-foreground px-4 py-2 text-left font-semibold">{children}</th>
+          <th className="text-foreground px-4 py-2 text-left font-semibold whitespace-nowrap break-normal">
+            {children}
+          </th>
         ),
         td: ({ children }: { children?: React.ReactNode }) => (
-          <td className="text-foreground px-4 py-2 text-left font-normal">
+          <td className="text-foreground px-4 py-2 text-left font-normal break-normal">
             {wrapChildrenWithPaths(children)}
           </td>
         ),


### PR DESCRIPTION
## Summary

Fixes three located regressions in the markdown table renderers. A table rendered in a narrow reading column was breaking headers mid-word (`Priority` → `Pri` / `ori` / `ty`) and fragmenting short tokens (`G1` → `G` / `1`).

**Wrap control.** `streamdown`'s default `th` ships `whitespace-nowrap`; the app's `components.table` override replaced it and dropped that class. Restored, plus an explicit `break-normal` on `th`/`td`.

The `break-normal` matters more than it looks. `UnifiedMarkdown`'s own root element (`.kortix-markdown`) sets `[overflow-wrap:anywhere]`, and `overflow-wrap` is inherited — it reaches every cell through five intervening elements. The cell-level reset is the only point in that chain that stops it.

**GFM column alignment was dead.** Every `th`/`td` override destructured only `children`, so `align` and `style` from remark-rehype never reached the DOM. `| :---: |` and `| ---: |` rendered left-aligned everywhere. `message-markdown.tsx` even carried `[&[align=center]]:text-center` selectors that could never match. Now forwarded — which also means `colspan`, `rowspan` and `scope` from raw HTML reach the DOM for the first time; they were being silently dropped.

**Two smaller fixes in `message-markdown.tsx`:** `overflow-y-auto` → `overflow-x-auto` (wide tables overflowed instead of scrolling), and `bg-accent` → `bg-muted` on the header row (in dark mode `--accent` is byte-identical to `--card`, so the header band was invisible against the surface it sat on).

### Notes for reviewers

`cn()` here is `twMerge(clsx(...))`, so the **last** same-group class wins. The `th`/`td` call sites deliberately use `cn(incoming, STATIC)` — inverted relative to the neighbouring `div`/`span` overrides — so an incoming `className` cannot strip the layout-critical classes. `allowHtml` defaults to `true` and the sanitize schema permits `className` on `*`, so a raw `<th class="whitespace-normal">` in scraped content otherwise reverts the fix. There is a comment at the call site and a regression test covering it.

No `katexSanitizeSchema` change was needed. `align` already passes the default allowlist, and `hast-util-to-jsx-runtime` converts it to an inline `style` after the whole rehype pipeline — sanitize never sees it.

`unified-markdown.tsx` and `doc-markdown.tsx` are changed in parallel rather than deduplicated; extraction is tracked separately.

### Known limitations

- Cells containing **inline code** still fragment. The cell-level reset reaches `<code>` only by inheritance, and three directly-matching rules beat it. Tracked separately.
- The two `message-markdown.tsx` fixes are currently dormant: `write-tool.tsx`, `edit-tool.tsx` and `read-tool.tsx` pass `language={ext}`, so a `.md` file yields `"md"` while `better-code-block.tsx` tests `=== 'markdown'`. That branch never fires. Tracked separately; the unit tests hold these fixes in place until it does.

## Test plan

**Unit** — 21 pass / 0 fail / 50 `expect()` calls across three co-located suites:

```
bun test src/components/markdown/unified-markdown.test.tsx \
         src/components/markdown/doc-markdown.test.tsx \
         src/components/better-markdown/message-markdown.test.tsx
```

Every new assertion was confirmed to fail against the pre-fix code by stashing the change and re-running.

**Browser** — driven against a live stack, measured with `getComputedStyle` and `Range.getClientRects()` rather than eyeballed. Covered the chat message body, the Files/Customize modal and the Easy panel viewer:

- `th` "Priority": `white-space: nowrap`, height `35.21875px` = line-height `20` + 16px padding — one line
- `td` "G1": `getClientRects().length === 1` — no fragmentation
- Alignment: computed `center` on the `:---:` column, `right` on both `---:` columns, arriving as inline `style`
- No `node="[object Object]"` attributes anywhere in the table; zero unknown-prop console warnings
- `scrollWidth === innerWidth` at 1280 / 768 / 375 — the page body never scrolls horizontally. At 375 the table scrolls inside its own wrapper (`scrollWidth 599` vs `clientWidth 350`)

**Lint** — `npx eslint` clean on all changed files (one pre-existing unrelated `no-img-element` warning). `npx prettier --check` clean on the four files this branch touched.
