### PR TITLE
fix(web): rebuild the project access gate UX

### DIFF
--- a/apps/web/src/components/projects/project-access-boundary.test.ts
+++ b/apps/web/src/components/projects/project-access-boundary.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  errorStatus,
+  gateCopyKeys,
+  gateStateForError,
+  gateStateForRequestResult,
+  resolveGateState,
+  shouldPollForApproval,
+  type AccessGateState,
+} from './project-access-boundary';
+
+const componentSource = readFileSync(
+  fileURLToPath(new URL('./project-access-boundary.tsx', import.meta.url)),
+  'utf8',
+);
+
+const ALL_STATES: AccessGateState[] = [
+  'request',
+  'sent',
+  'alreadyRequested',
+  'notFound',
+  'unavailable',
+];
+
+const LOCALES = ['en', 'de', 'es', 'fr', 'it', 'ja', 'pt', 'zh'];
+
+function copyBlock(locale: string): Record<string, string> {
+  const path = fileURLToPath(new URL(`../../../translations/${locale}.json`, import.meta.url));
+  return JSON.parse(readFileSync(path, 'utf8')).hardcodedUi?.projectAccessBoundary ?? {};
+}
+
+const en = copyBlock('en');
+
+/** The English the user actually reads on a given screen. */
+function englishCopy(state: AccessGateState) {
+  const keys = gateCopyKeys(state);
+  return { heading: en[keys.heading], body: en[keys.body] };
+}
+
+describe('errorStatus', () => {
+  test('reads the status off both SDK error shapes', () => {
+    expect(errorStatus({ status: 403 })).toBe(403);
+    expect(errorStatus({ response: { status: 404 } })).toBe(404);
+    expect(errorStatus({ status: 403, response: { status: 500 } })).toBe(403);
+  });
+
+  test('returns undefined for errors that carry no status', () => {
+    expect(errorStatus(new Error('network down'))).toBeUndefined();
+    expect(errorStatus(null)).toBeUndefined();
+    expect(errorStatus(undefined)).toBeUndefined();
+  });
+});
+
+describe('gateStateForError', () => {
+  test('403 is the only status that offers the request form', () => {
+    expect(gateStateForError({ status: 403 })).toBe('request');
+    expect(gateStateForError({ response: { status: 403 } })).toBe('request');
+  });
+
+  test('404 reports the project as gone', () => {
+    expect(gateStateForError({ status: 404 })).toBe('notFound');
+  });
+
+  test('never offers a form for a failure that asking cannot fix', () => {
+    // A form on a 401 or a 500 would send a request that can only fail again,
+    // so anything unrecognised has to land on `unavailable`.
+    for (const status of [401, 402, 429, 500, 502, 503]) {
+      expect(gateStateForError({ status })).toBe('unavailable');
+    }
+    expect(gateStateForError(new Error('offline'))).toBe('unavailable');
+    expect(gateStateForError(null)).toBe('unavailable');
+  });
+});
+
+describe('gateStateForRequestResult', () => {
+  // Exhaustiveness is a compile-time guarantee, not a runtime one: the function
+  // switches over RequestProjectAccessResult['status'] with no default, so a
+  // fourth SDK status fails `tsc` here rather than falling through to null.
+  test('distinguishes a new request from one that was already waiting', () => {
+    // The previous screen collapsed these two, so a user with a pending request
+    // was told "Request sent." again on every attempt.
+    expect(gateStateForRequestResult('created')).toBe('sent');
+    expect(gateStateForRequestResult('pending')).toBe('alreadyRequested');
+  });
+
+  test('returns null for already_has_access so the caller re-fetches the project', () => {
+    expect(gateStateForRequestResult('already_has_access')).toBeNull();
+  });
+});
+
+describe('shouldPollForApproval', () => {
+  test('polls exactly the states whose copy promises the page self-opens', () => {
+    expect(ALL_STATES.filter(shouldPollForApproval)).toEqual(['sent', 'alreadyRequested']);
+  });
+});
+
+describe('resolveGateState', () => {
+  test('a sent request survives every transient failure', () => {
+    // The 15s poll runs unattended. If an expired JWT (401), a 500, or an
+    // offline window could outrank the request, the user would come back to a
+    // blank form and re-send something the manager already has.
+    for (const transient of [
+      gateStateForError({ status: 401 }),
+      gateStateForError({ status: 500 }),
+      gateStateForError(new Error('offline')),
+      gateStateForError({ status: 403 }),
+    ]) {
+      expect(resolveGateState('sent', transient)).toBe('sent');
+      expect(resolveGateState('alreadyRequested', transient)).toBe('alreadyRequested');
+    }
+  });
+
+  test('a deleted project outranks a request that is still waiting', () => {
+    // The opposite failure: without this, deleting the project mid-wait leaves
+    // the user on "Waiting on approval." forever, polling something that is
+    // gone. notFound is terminal — asking harder cannot bring it back.
+    expect(resolveGateState('sent', 'notFound')).toBe('notFound');
+    expect(resolveGateState('alreadyRequested', 'notFound')).toBe('notFound');
+  });
+
+  test('with no request in flight the error decides the screen', () => {
+    expect(resolveGateState(null, 'request')).toBe('request');
+    expect(resolveGateState(null, 'notFound')).toBe('notFound');
+    expect(resolveGateState(null, 'unavailable')).toBe('unavailable');
+  });
+
+  test('falls back to the error screen rather than a form it cannot justify', () => {
+    expect(resolveGateState(null, null)).toBe('unavailable');
+  });
+});
+
+describe('polling lifecycle', () => {
+  test('the poll stops as soon as the project becomes readable', () => {
+    // This boundary wraps the project shell for the whole session, so a poll
+    // that only checks `waiting` keeps calling getProject every 15s while the
+    // user works. The guard must include the success case.
+    expect(componentSource).toContain('const polling = !query.isSuccess && shouldPollForApproval');
+    expect(componentSource).toMatch(/if \(!polling\) return;/);
+  });
+
+  test('the background poll never drives the user-facing pending state', () => {
+    // `query.isFetching` is true for the automatic poll too, so binding the
+    // button to it makes "Check now" disable itself every 15 seconds.
+    expect(componentSource).not.toContain('rechecking={query.isFetching}');
+    expect(componentSource).toContain('rechecking={manualRecheck}');
+  });
+
+  test('neither the note field nor the submit button is `disabled` while in flight', () => {
+    // Disabling a focused element drops keyboard focus to <body>. The field
+    // uses readOnly and the button uses aria-disabled + a guard in onSubmit.
+    // The lookbehind matters: `aria-disabled={…}` contains `disabled={…}`.
+    expect(componentSource).not.toMatch(/(?<!aria-)disabled=\{requestMutation\.isPending\}/);
+    expect(componentSource).toContain('aria-disabled={requestMutation.isPending}');
+    expect(componentSource).toContain('if (requestMutation.isPending) return;');
+  });
+});
+
+describe('copy wiring', () => {
+  test('every state resolves to real English copy', () => {
+    for (const state of ALL_STATES) {
+      const { heading, body } = englishCopy(state);
+      expect(heading?.trim().length ?? 0).toBeGreaterThan(0);
+      expect(body?.trim().length ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  test('every locale carries every key this component renders', () => {
+    // The component resolves keys at runtime, so a locale missing one renders
+    // the raw key path to the user. next-intl's `raw()` does not throw on a
+    // miss, so nothing else in the repo catches this.
+    //
+    // The key list is READ OUT OF THE COMPONENT, not hand-maintained here: a
+    // literal `t.raw('projectAccessBoundary.x')` is scraped by regex, and the
+    // template-literal call sites are covered by gateCopyKeys.
+    const used = new Set<string>();
+    for (const match of componentSource.matchAll(/projectAccessBoundary\.(\w+)/g)) {
+      used.add(match[1]);
+    }
+    for (const state of ALL_STATES) {
+      const keys = gateCopyKeys(state);
+      used.add(keys.heading).add(keys.body);
+    }
+    // Sanity-check the scrape itself, so a refactor that stops matching the
+    // regex fails loudly instead of silently testing an empty set.
+    expect(used.size).toBeGreaterThanOrEqual(18);
+
+    for (const locale of LOCALES) {
+      const block = copyBlock(locale);
+      const missing = [...used].filter((key) => !block[key]?.trim());
+      expect({ locale, missing }).toEqual({ locale, missing: [] });
+    }
+  });
+
+  test('non-English locales are actually translated, not English copies', () => {
+    for (const locale of LOCALES.filter((l) => l !== 'en')) {
+      const block = copyBlock(locale);
+      const untranslated = ALL_STATES.map((state) => gateCopyKeys(state).heading)
+        .filter((key, i, all) => all.indexOf(key) === i)
+        .filter((key) => block[key] === en[key]);
+      expect({ locale, untranslated }).toEqual({ locale, untranslated: [] });
+    }
+  });
+});
+
+describe('copy quality', () => {
+  test('the heading never restates the description', () => {
+    // The old screen said the same thing three times over one form: an eyebrow,
+    // a hero headline, and a panel title. This dialect has no eyebrow at all,
+    // so the only way to regress is a description that repeats the heading.
+    for (const state of ALL_STATES) {
+      const { heading, body } = englishCopy(state);
+      const stem = heading.replace(/[.!]$/, '').toLowerCase();
+      expect(body.toLowerCase()).not.toContain(stem);
+    }
+  });
+
+  test('every heading is one sentence that fits two lines of the column', () => {
+    // StepHeader renders the title at text-2xl (24px) font-medium inside
+    // AuthFrame's 380px column (the px-6 gutter sits outside it). At ~0.5em
+    // average advance that is ~12px per glyph, so ~31 characters per line and
+    // ~62 over two. Capped at 56 for margin. An estimate, but a reproducible
+    // one, and the longest shipped translation has real headroom under it.
+    //
+    // ja/zh are excluded from the character cap, not the punctuation check: a
+    // full-width glyph is roughly double the advance, so counting characters
+    // says nothing useful about how wide the line renders.
+    const headingKeys = [...new Set(ALL_STATES.map((state) => gateCopyKeys(state).heading))];
+    for (const locale of LOCALES) {
+      const block = copyBlock(locale);
+      for (const key of headingKeys) {
+        expect(block[key]).toMatch(/[.!。！]$/);
+        if (locale === 'ja' || locale === 'zh') continue;
+        expect({ locale, key, length: block[key].length }).toEqual({
+          locale,
+          key,
+          length: Math.min(block[key].length, 56),
+        });
+      }
+    }
+  });
+
+  test('no internal navigation paths or product jargon reach the user', () => {
+    // "Customize → Members" and "Kortix workspace" both shipped in the previous
+    // copy. Neither means anything to someone who cannot open the project.
+    const banned = [
+      /customize/i,
+      /workspace/i,
+      /→/,
+      /viewer/i,
+      /endpoint/i,
+      /\b403\b/,
+      /boundary/i,
+    ];
+    for (const state of ALL_STATES) {
+      const { heading, body } = englishCopy(state);
+      const text = `${heading} ${body}`;
+      for (const pattern of banned) {
+        expect({ state, text: text.match(pattern)?.[0] ?? null }).toEqual({ state, text: null });
+      }
+    }
+  });
+
+  test('only the polling states claim the page opens by itself', () => {
+    // Guard both ways, so rewording the promise out of the copy fails the test
+    // rather than silently making it pass.
+    const claims = ALL_STATES.filter((state) =>
+      /on its own|automatically/.test(englishCopy(state).body),
+    );
+    expect(claims.length).toBeGreaterThan(0);
+    for (const state of claims) expect(shouldPollForApproval(state)).toBe(true);
+  });
+
+  test('the two waiting states share a heading but not a reason', () => {
+    // Sharing the heading key keeps the header still when a duplicate request
+    // resolves to `pending` instead of `created`; the description carries the
+    // difference between "we just sent it" and "you already asked".
+    expect(gateCopyKeys('sent').heading).toBe(gateCopyKeys('alreadyRequested').heading);
+    expect(gateCopyKeys('sent').body).not.toBe(gateCopyKeys('alreadyRequested').body);
+    expect(englishCopy('sent').body).not.toBe(englishCopy('alreadyRequested').body);
+  });
+});
+
+describe('house dialect', () => {
+  // This screen sits beside /auth, /cli/authorize and /oauth/authorize. It must
+  // be composed from their shared vocabulary, not from a bespoke frame — that
+  // is the whole reason the previous split-hero version looked foreign.
+  test('is built from the shared auth consent primitives', () => {
+    expect(componentSource).toContain("from '@/features/auth/auth-card-shell'");
+    expect(componentSource).toContain("from '@/features/auth/auth-consent'");
+    expect(componentSource).toContain("from '@/features/auth/auth-primitives'");
+    for (const primitive of [
+      '<AuthFrame>',
+      '<StepHeader',
+      '<DetailPanel>',
+      '<ErrorStrip ',
+      '<Rise',
+    ]) {
+      expect({ primitive, present: componentSource.includes(primitive) }).toEqual({
+        primitive,
+        present: true,
+      });
+    }
+    // The quiet spinner every other auth sub-surface shows while it resolves.
+    expect(componentSource).toContain('<AuthPendingScreen />');
+  });
+
+  test('does not re-introduce a bespoke frame, card or wallpaper', () => {
+    // The auth dialect is flat on the plain background. A card, a wallpaper or
+    // a backdrop-blur here is the exact drift this screen was rebuilt to undo.
+    for (const banned of [
+      'WallpaperBackground',
+      'backdrop-blur',
+      'rounded-2xl',
+      'fixed inset-0',
+      'KortixHyperLogo',
+      'InfoBanner',
+    ]) {
+      expect({ banned, present: componentSource.includes(banned) }).toEqual({
+        banned,
+        present: false,
+      });
+    }
+  });
+
+  test('uses no raw Tailwind palette colours', () => {
+    // kortix-* tokens and semantic tokens only.
+    const palette =
+      /(?:bg|text|border|ring)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d/;
+    expect(componentSource.match(palette)?.[0] ?? null).toBeNull();
+  });
+
+  test('never uses an icon as a spinner', () => {
+    // `Loading` is the codebase's only spinner.
+    expect(componentSource).toContain("import Loading from '@/components/ui/loading'");
+    expect(componentSource.match(/CircleNotch|SpinnerIcon|animate-spin/)?.[0] ?? null).toBeNull();
+  });
+});

--- a/apps/web/src/components/projects/project-access-boundary.tsx
+++ b/apps/web/src/components/projects/project-access-boundary.tsx
@@ -1,139 +1,180 @@
 'use client';
 
-import {
-  WarningCircleIcon as AlertCircle,
-  ArrowLeftIcon as ArrowLeft,
-  CheckCircleIcon as CheckCircle2,
-  LockIcon as LockKeyhole,
-  ArrowClockwiseIcon as RefreshCw,
-  PaperPlaneTiltIcon as Send,
-  ShieldWarningIcon as ShieldAlert,
-  UserCircleIcon as UserRound,
-} from '@phosphor-icons/react';
+import { ShieldWarningIcon } from '@phosphor-icons/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react';
 
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import { InfoBanner } from '@/components/ui/info-banner';
-import { KortixHyperLogo } from '@/components/ui/marketing/kortix-hyper-logo';
-import { Textarea } from '@/components/ui/textarea';
-import { WallpaperBackground } from '@/components/ui/wallpaper-background';
 import Loading from '@/components/ui/loading';
+import { Textarea } from '@/components/ui/textarea';
+import { AuthFrame } from '@/features/auth/auth-card-shell';
+import { AuthPendingScreen, DetailPanel, DetailRow } from '@/features/auth/auth-consent';
+import { ErrorStrip, Rise, StepHeader } from '@/features/auth/auth-primitives';
 import { useAuth } from '@/features/providers/auth-provider';
-import { clearLastProjectId, readLastProjectId } from '@/lib/onboarding/last-project-cookie';
 import { useAdminRole } from '@/hooks/admin/use-admin-role';
+import { clearLastProjectId, readLastProjectId } from '@/lib/onboarding/last-project-cookie';
+import { focusWithoutScroll } from '@/lib/utils/focus-without-scroll';
 import { getProject, requestProjectAccess, setAdminBypass } from '@kortix/sdk';
-import { cn } from '@/lib/utils';
 
-interface ProjectAccessBoundaryProps {
-  projectId: string;
-  children: ReactNode;
+const QUERY_KEY = 'project-access-boundary';
+
+/** How often the waiting screen re-checks whether a manager approved the request. */
+const APPROVAL_POLL_MS = 15_000;
+
+/** Matches the server's own ceiling (apps/api projects access-requests route). */
+const MESSAGE_MAX_LENGTH = 2_000;
+
+/** Derived from the SDK so a new result status becomes a type error here. */
+type RequestResultStatus = Awaited<ReturnType<typeof requestProjectAccess>>['status'];
+
+// ─── State machine (pure — see project-access-boundary.test.ts) ───────────────
+
+/**
+ * Every screen this boundary can show. Each state owns exactly one heading,
+ * which is what stops the three-headings-for-one-form problem.
+ */
+export type AccessGateState = 'request' | 'sent' | 'alreadyRequested' | 'notFound' | 'unavailable';
+
+/** The two states where the user has asked and is waiting on a human. */
+export type WaitingGateState = Extract<AccessGateState, 'sent' | 'alreadyRequested'>;
+
+/**
+ * Translation keys under `hardcodedUi.projectAccessBoundary`. The copy lives in
+ * translations/*.json; keeping the keys here lets the test resolve them against
+ * en.json and assert the real English reads correctly.
+ *
+ * There is no eyebrow/kicker: the auth dialect this screen belongs to is a
+ * mark, a heading and a description, and nothing else.
+ */
+export interface AccessGateCopyKeys {
+  heading: string;
+  body: string;
 }
 
-function errorStatus(error: unknown): number | undefined {
+const GATE_COPY_KEYS: Record<AccessGateState, AccessGateCopyKeys> = {
+  request: { heading: 'privateHeading', body: 'privateBody' },
+  sent: { heading: 'waitingHeading', body: 'sentBody' },
+  alreadyRequested: { heading: 'waitingHeading', body: 'alreadyBody' },
+  notFound: { heading: 'notFoundHeading', body: 'notFoundBody' },
+  unavailable: { heading: 'errorHeading', body: 'errorBody' },
+};
+
+export function gateCopyKeys(state: AccessGateState): AccessGateCopyKeys {
+  return GATE_COPY_KEYS[state];
+}
+
+/** Pulls the HTTP status off either error shape the SDK can surface. */
+export function errorStatus(error: unknown): number | undefined {
   return (
     (error as { status?: number; response?: { status?: number } } | null)?.status ??
     (error as { response?: { status?: number } } | null)?.response?.status
   );
 }
 
+/**
+ * Maps a failed `getProject` to the screen it should show. 403 is the only
+ * status that leads to the request form — every other failure is terminal, so
+ * an unknown status must never render a form whose request cannot succeed.
+ */
+export function gateStateForError(error: unknown): AccessGateState {
+  const status = errorStatus(error);
+  if (status === 403) return 'request';
+  if (status === 404) return 'notFound';
+  return 'unavailable';
+}
+
+/**
+ * Maps `requestProjectAccess`'s three-way result to the next screen.
+ * `already_has_access` returns null: the caller re-fetches instead, because the
+ * project is readable now and the right screen is the project itself.
+ */
+export function gateStateForRequestResult(status: RequestResultStatus): WaitingGateState | null {
+  switch (status) {
+    case 'created':
+      return 'sent';
+    case 'pending':
+      return 'alreadyRequested';
+    case 'already_has_access':
+      return null;
+  }
+}
+
+/** True while the screen should keep polling for an approval. */
+export function shouldPollForApproval(state: AccessGateState): boolean {
+  return state === 'sent' || state === 'alreadyRequested';
+}
+
+/**
+ * Decides which screen wins when the user has a request in flight AND the
+ * project fetch is failing.
+ *
+ * A sent request has to survive a *transient* failure — an expired JWT, a 500,
+ * a tunnel drop — or an unattended waiting screen silently turns back into a
+ * blank request form for a request that was already sent. It must NOT survive a
+ * *terminal* one: if the project is deleted while the user waits, telling them
+ * to keep waiting means polling forever against something that no longer
+ * exists.
+ */
+export function resolveGateState(
+  waiting: WaitingGateState | null,
+  errorState: AccessGateState | null,
+): AccessGateState {
+  if (errorState === 'notFound') return 'notFound';
+  return waiting ?? errorState ?? 'unavailable';
+}
+
+// ─── Boundary ────────────────────────────────────────────────────────────────
+
+interface ProjectAccessBoundaryProps {
+  projectId: string;
+  children: ReactNode;
+}
+
 export function ProjectAccessBoundary({ projectId, children }: ProjectAccessBoundaryProps) {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
+  const { user } = useAuth();
+  // A submitted request is held HERE, above the error branch, so a transient
+  // 401/500/offline poll result cannot unmount the waiting screen and hand the
+  // user a fresh request form for a request they already sent.
+  const [waiting, setWaiting] = useState<WaitingGateState | null>(null);
+
   const query = useQuery({
-    queryKey: ['project-access-boundary', projectId],
+    queryKey: [QUERY_KEY, projectId],
     queryFn: () => getProject(projectId, { showErrors: false }),
     enabled: !!projectId,
     retry: false,
   });
 
-  if (query.isLoading) {
-    return <ProjectAccessLoading />;
-  }
+  const { refetch } = query;
+  // Background poll: silent, and must never touch the button's pending state.
+  const recheck = useCallback(() => void refetch(), [refetch]);
 
-  if (query.isError) {
-    const status = errorStatus(query.error);
-    if (status === 403) {
-      return <ForbiddenProjectState projectId={projectId} />;
-    }
+  // The user's own "Check now" press, tracked separately so the 15s background
+  // poll cannot disable the button under their cursor.
+  const [manualRecheck, setManualRecheck] = useState(false);
+  const recheckNow = useCallback(() => {
+    setManualRecheck(true);
+    void refetch().finally(() => setManualRecheck(false));
+  }, [refetch]);
 
-    if (status === 404) {
-      return (
-        <ProjectAccessStateFrame
-          icon={<AlertCircle className="size-5" />}
-          eyebrow={tI18nHardcoded.raw(
-            'autoComponentsProjectsProjectAccessBoundaryJsxAttrEyebrowProjectUnavailablea0231815',
-          )}
-          title={tI18nHardcoded.raw(
-            'autoComponentsProjectsProjectAccessBoundaryJsxAttrTitleProjectNotc66b9822',
-          )}
-          description={tI18nHardcoded.raw(
-            'autoComponentsProjectsProjectAccessBoundaryJsxAttrDescriptionThisProject92b78195',
-          )}
-        />
-      );
-    }
+  const errorState = query.isError ? gateStateForError(query.error) : null;
+  const state = resolveGateState(waiting, errorState);
+  // Stop the moment access lands, or the interval outlives the gate: this
+  // component wraps the shell for the whole session, so a poll that ignores
+  // success keeps calling getProject every 15s while the user works.
+  const polling = !query.isSuccess && shouldPollForApproval(state);
 
-    return (
-      <ProjectAccessStateFrame
-        icon={<AlertCircle className="size-5" />}
-        eyebrow={tI18nHardcoded.raw(
-          'autoComponentsProjectsProjectAccessBoundaryJsxAttrEyebrowProjectUnavailablea0231815',
-        )}
-        title={tI18nHardcoded.raw(
-          'autoComponentsProjectsProjectAccessBoundaryJsxAttrTitleCouldnT870a862d',
-        )}
-        description={tI18nHardcoded.raw(
-          'autoComponentsProjectsProjectAccessBoundaryJsxAttrDescriptionSomethingWent8997618a',
-        )}
-        footer={
-          <Button type="button" variant="outline" onClick={() => query.refetch()}>
-            <RefreshCw className="size-4" />
-            Retry
-          </Button>
-        }
-      />
-    );
-  }
+  // Poll while waiting so "this page opens on its own" is a fact, not a promise
+  // the user has to keep by reloading. `recheck` is stable, so the interval is
+  // a true 15s cadence rather than 15s-since-the-last-render.
+  useEffect(() => {
+    if (!polling) return;
+    const id = setInterval(recheck, APPROVAL_POLL_MS);
+    return () => clearInterval(id);
+  }, [polling, recheck]);
 
-  return <>{children}</>;
-}
-
-function ProjectAccessLoading() {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
-  return (
-    <div
-      className="bg-background flex min-h-screen items-center justify-center"
-      role="status"
-      aria-label={tI18nHardcoded.raw(
-        'autoComponentsProjectsProjectAccessBoundaryJsxAttrAriaLabelLoading21cf6b95',
-      )}
-    >
-      <KortixHyperLogo size={34} startOnView={false} animateOnHover={false} />
-    </div>
-  );
-}
-
-function ForbiddenProjectState({ projectId }: { projectId: string }) {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
-  const router = useRouter();
-  const queryClient = useQueryClient();
-  const { user } = useAuth();
-  const { data: adminRole } = useAdminRole();
-  const [message, setMessage] = useState('');
-  const [sent, setSent] = useState(false);
-  const [inlineError, setInlineError] = useState<string | null>(null);
-  const [bypassError, setBypassError] = useState<string | null>(null);
+  const forbidden = errorState === 'request';
 
   // Stop this screen from becoming the user's permanent landing page. If the
   // remembered project is one they cannot read, every `/` hit and every sign-in
@@ -141,276 +182,230 @@ function ForbiddenProjectState({ projectId }: { projectId: string }) {
   // this case: a private project is a legitimate 403 surface, not a failed
   // fetch. Forget it and let the landing door resolve a project they can open.
   useEffect(() => {
+    if (!forbidden) return;
     if (readLastProjectId(user?.id) !== projectId) return;
     clearLastProjectId();
-  }, [projectId, user?.id]);
+  }, [forbidden, projectId, user?.id]);
+
+  if (query.isSuccess) return <>{children}</>;
+
+  // The same quiet spinner every auth sub-surface shows while it resolves.
+  if (query.isLoading) return <AuthPendingScreen />;
+
+  return (
+    <AccessGateScreen
+      projectId={projectId}
+      state={state}
+      rechecking={manualRecheck}
+      onRecheck={recheckNow}
+      onWaiting={setWaiting}
+    />
+  );
+}
+
+// ─── Screen ──────────────────────────────────────────────────────────────────
+
+/**
+ * Composed from the auth consent vocabulary (AuthFrame / Rise / StepHeader /
+ * DetailPanel / ErrorStrip) so this reads as the same product as the CLI and
+ * OAuth consent screens. Flat on the background, left-aligned, 380px — no card,
+ * no wallpaper.
+ */
+function AccessGateScreen({
+  projectId,
+  state,
+  rechecking,
+  onRecheck,
+  onWaiting,
+}: {
+  projectId: string;
+  state: AccessGateState;
+  rechecking: boolean;
+  onRecheck: () => void;
+  onWaiting: (state: WaitingGateState) => void;
+}) {
+  const t = useTranslations('hardcodedUi');
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const { data: adminRole } = useAdminRole();
+  const noteId = useId();
+  const [message, setMessage] = useState('');
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [bypassError, setBypassError] = useState<string | null>(null);
+
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const shownState = useRef(state);
+
+  // Submitting replaces the form, which would otherwise strand keyboard focus
+  // on <body> with nothing announced. Focusing the body block reads the new
+  // step aloud. preventScroll is mandatory — a bare focus() into this animated
+  // layer scrolls the overflow ancestor. Guarded so it never fires on mount.
+  useEffect(() => {
+    if (shownState.current === state) return;
+    shownState.current = state;
+    focusWithoutScroll(bodyRef.current);
+  }, [state]);
 
   const requestMutation = useMutation({
     mutationFn: () => requestProjectAccess(projectId, message),
     onMutate: () => setInlineError(null),
     onSuccess: (result) => {
-      if (result.status === 'already_has_access') {
-        void queryClient.invalidateQueries({
-          queryKey: ['project-access-boundary', projectId],
-        });
+      const next = gateStateForRequestResult(result.status);
+      if (next) {
+        onWaiting(next);
         return;
       }
-      setSent(true);
+      // already_has_access — the project is readable now, so show the project.
+      void queryClient.invalidateQueries({ queryKey: [QUERY_KEY, projectId] });
     },
-    onError: (error: Error) => {
-      setInlineError(error.message || 'Could not send access request.');
-    },
+    onError: (error: Error) =>
+      setInlineError(error.message || t.raw('projectAccessBoundary.requestFailed')),
   });
 
-  // Platform-admin escape hatch: flips the client-wide admin-bypass header
-  // on, then re-fetches this same ['project-access-boundary', projectId] query so the
-  // boundary above (which shares this query cache) picks up the result and
-  // renders the actual project. Read-only server-side (see
-  // apps/api/src/projects/lib/access.ts) and audit-logged against the
-  // project's own account on every use.
+  // Platform-admin escape hatch: flips the client-wide admin-bypass header on,
+  // then re-fetches the shared [QUERY_KEY, projectId] query so the boundary
+  // above renders the actual project. Read-only server-side (see
+  // apps/api/src/projects/lib/access.ts) and audit-logged against the project's
+  // own account on every use.
   const bypassMutation = useMutation({
     mutationFn: async () => {
       setAdminBypass(true);
       return queryClient.fetchQuery({
-        queryKey: ['project-access-boundary', projectId],
+        queryKey: [QUERY_KEY, projectId],
         queryFn: () => getProject(projectId, { showErrors: false }),
       });
     },
     onMutate: () => setBypassError(null),
     onError: (error: Error) => {
       setAdminBypass(false);
-      setBypassError(error.message || 'Admin bypass failed.');
+      setBypassError(error.message || t.raw('projectAccessBoundary.bypassFailed'));
     },
   });
 
-  return (
-    <ProjectAccessStateFrame
-      icon={<LockKeyhole className="size-5" />}
-      cornerAction={
-        adminRole?.isAdmin ? (
-          <div className="flex flex-col items-end gap-1.5">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="border-amber-500/50 text-amber-700 hover:bg-amber-500/10 dark:text-amber-400"
-              onClick={() => bypassMutation.mutate()}
-              disabled={bypassMutation.isPending}
-            >
-              {bypassMutation.isPending ? (
-                <Loading className="size-3.5" />
-              ) : (
-                <ShieldAlert className="size-3.5" />
-              )}
-              ADMIN BYPASS
-            </Button>
-            {bypassError ? <p className="text-destructive text-xs">{bypassError}</p> : null}
-          </div>
-        ) : null
-      }
-      eyebrow={tI18nHardcoded.raw(
-        'autoComponentsProjectsProjectAccessBoundaryJsxAttrEyebrowPrivateProjectd5b1951c',
-      )}
-      title={sent ? 'Request sent.' : 'Request access to this project.'}
-      description={
-        sent
-          ? 'A project manager can approve you from the Members screen. Keep this page open and check again once they approve the request.'
-          : 'This Kortix workspace is private. Send a short note and a project manager can add you as a viewer.'
-      }
-      panelTitle={sent ? 'Waiting for approval' : 'Access request'}
-      panelDescription={
-        sent
-          ? 'Managers have the request in Customize → Members.'
-          : 'A little context helps the manager approve the right account.'
-      }
-      content={
-        <div className="space-y-4">
-          {sent ? (
-            <InfoBanner
-              tone="success"
-              icon={CheckCircle2}
-              title={tI18nHardcoded.raw(
-                'autoComponentsProjectsProjectAccessBoundaryJsxAttrTitleRequestSent6567e02d',
-              )}
-            >
-              {tI18nHardcoded.raw(
-                'autoComponentsProjectsProjectAccessBoundaryJsxTextProjectManagersWill08e33ff7',
-              )}
-            </InfoBanner>
-          ) : (
-            <>
-              <InfoBanner
-                tone="neutral"
-                icon={UserRound}
-                title={tI18nHardcoded.raw(
-                  'autoComponentsProjectsProjectAccessBoundaryJsxAttrTitleSignedIna3165363',
-                )}
-              >
-                <span className="text-muted-foreground">
-                  {tI18nHardcoded.raw(
-                    'autoComponentsProjectsProjectAccessBoundaryJsxTextRequestingAccessAs09b70479',
-                  )}{' '}
-                  <span className="text-foreground font-medium">
-                    {user?.email ?? user?.id ?? 'this account'}
-                  </span>
-                  .
-                </span>
-              </InfoBanner>
-
-              <div className="space-y-2">
-                <label
-                  className="text-foreground text-sm font-medium"
-                  htmlFor="project-access-message"
-                >
-                  Message <span className="text-muted-foreground font-normal">optional</span>
-                </label>
-                <Textarea
-                  id="project-access-message"
-                  value={message}
-                  onChange={(event) => setMessage(event.target.value)}
-                  minHeight={96}
-                  maxHeight={160}
-                  placeholder={tI18nHardcoded.raw(
-                    'autoComponentsProjectsProjectAccessBoundaryJsxAttrPlaceholderTellThec2bb0f7d',
-                  )}
-                  disabled={requestMutation.isPending}
-                />
-                {inlineError ? <p className="text-destructive text-xs">{inlineError}</p> : null}
-              </div>
-            </>
-          )}
-        </div>
-      }
-      footer={
-        <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-between">
-          <Button type="button" variant="ghost" onClick={() => router.push('/projects')}>
-            <ArrowLeft className="size-4" />
-            {tI18nHardcoded.raw(
-              'autoComponentsProjectsProjectAccessBoundaryJsxTextBackToProjects9ad9ccd3',
-            )}
-          </Button>
-          {sent ? (
-            <Button type="button" variant="outline" onClick={() => window.location.reload()}>
-              <RefreshCw className="size-4" />
-              {tI18nHardcoded.raw(
-                'autoComponentsProjectsProjectAccessBoundaryJsxTextCheckAgain9f1e6458',
-              )}
-            </Button>
-          ) : (
-            <Button
-              type="button"
-              onClick={() => requestMutation.mutate()}
-              disabled={requestMutation.isPending}
-            >
-              {requestMutation.isPending ? (
-                <Loading className="size-4" />
-              ) : (
-                <Send className="size-4" />
-              )}
-              {tI18nHardcoded.raw(
-                'autoComponentsProjectsProjectAccessBoundaryJsxTextRequestAccess870ec6e1',
-              )}
-            </Button>
-          )}
-        </div>
-      }
-    />
-  );
-}
-
-function ProjectAccessStateFrame({
-  icon,
-  eyebrow = 'Project access',
-  title,
-  description,
-  panelTitle,
-  panelDescription,
-  content,
-  footer,
-  cornerAction,
-}: {
-  icon: ReactNode;
-  eyebrow?: string;
-  title: string;
-  description: string;
-  panelTitle?: string;
-  panelDescription?: string;
-  content?: ReactNode;
-  footer?: ReactNode;
-  cornerAction?: ReactNode;
-}) {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
-  const router = useRouter();
-  const action = footer ?? (
-    <Button type="button" variant="outline" onClick={() => router.push('/projects')}>
-      <ArrowLeft className="size-4" />
-      {tI18nHardcoded.raw(
-        'autoComponentsProjectsProjectAccessBoundaryJsxTextBackToProjects9ad9ccd3',
-      )}
-    </Button>
-  );
+  const copy = gateCopyKeys(state);
+  const forbidden = state === 'request' || shouldPollForApproval(state);
 
   return (
-    <div className="bg-background relative flex min-h-screen overflow-hidden px-4 py-10">
-      <div className="pointer-events-none absolute inset-0 opacity-60" aria-hidden="true">
-        <WallpaperBackground />
-      </div>
-      <div
-        className="bg-background/85 dark:bg-background/80 pointer-events-none absolute inset-0"
-        aria-hidden="true"
-      />
+    <AuthFrame>
+      {/*
+        Keyed on `state` so a step change replays the same two-part rise the
+        auth flow uses everywhere else: header first, body 60ms behind.
+      */}
+      <Rise key={`h-${state}`}>
+        <StepHeader
+          title={t.raw(`projectAccessBoundary.${copy.heading}`)}
+          description={t.raw(`projectAccessBoundary.${copy.body}`)}
+        />
+      </Rise>
 
-      {cornerAction ? (
-        <div className="absolute top-4 right-4 z-20 sm:top-6 sm:right-6">{cornerAction}</div>
-      ) : null}
+      <Rise key={`b-${state}`} delay={0.06}>
+        <div ref={bodyRef} tabIndex={-1} className="outline-none">
+          {inlineError ? <ErrorStrip message={inlineError} /> : null}
+          {bypassError ? <ErrorStrip message={bypassError} /> : null}
 
-      <main className="relative z-10 mx-auto flex w-full max-w-4xl items-center">
-        <div
-          className={cn(
-            'grid w-full gap-6',
-            content ? 'lg:grid-cols-2 lg:items-start' : 'max-w-2xl',
-          )}
-        >
-          <section className="space-y-5">
-            <div className="border-border/70 bg-card text-foreground flex size-11 items-center justify-center rounded-2xl border shadow-2xs">
-              {icon}
-            </div>
-
-            <div className="space-y-3">
-              <Badge variant="outline" size="sm" className="w-fit">
-                {eyebrow}
-              </Badge>
-              <div className="space-y-3">
-                <h1 className="text-foreground text-3xl font-semibold tracking-tight text-balance sm:text-4xl">
-                  {title}
-                </h1>
-                <p className="text-muted-foreground max-w-xl text-base leading-relaxed">
-                  {description}
-                </p>
-              </div>
-            </div>
-
-            {!content ? <div className="pt-1">{action}</div> : null}
-          </section>
-
-          {content ? (
-            <Card className="border-border/70 bg-card/90 gap-0 overflow-hidden rounded-2xl py-0 shadow-2xs backdrop-blur-sm">
-              <CardHeader className="border-border/60 border-b px-6 py-4">
-                <CardTitle className="text-base">{panelTitle ?? 'Request access'}</CardTitle>
-                {panelDescription ? (
-                  <CardDescription className="text-xs leading-relaxed">
-                    {panelDescription}
-                  </CardDescription>
-                ) : null}
-              </CardHeader>
-              <CardContent className="px-6 py-5">{content}</CardContent>
-              <CardFooter className="border-border/60 bg-muted/30 border-t px-6 py-3">
-                {action}
-              </CardFooter>
-            </Card>
+          {forbidden ? (
+            <DetailPanel>
+              <DetailRow
+                label={t.raw('projectAccessBoundary.accountLabel')}
+                value={user?.email ?? t.raw('projectAccessBoundary.thisAccount')}
+              />
+              <DetailRow
+                label={t.raw('projectAccessBoundary.projectLabel')}
+                value={projectId}
+                mono
+              />
+            </DetailPanel>
           ) : null}
+
+          {state === 'request' ? (
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                // The button is aria-disabled rather than disabled so it keeps
+                // focus in flight, which means it stays clickable and the guard
+                // has to live here.
+                if (requestMutation.isPending) return;
+                requestMutation.mutate();
+              }}
+            >
+              <label
+                htmlFor={noteId}
+                className="text-muted-foreground mt-5 mb-2 block text-sm font-medium"
+              >
+                {t.raw('projectAccessBoundary.noteLabel')}
+              </label>
+              <Textarea
+                id={noteId}
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                maxLength={MESSAGE_MAX_LENGTH}
+                minHeight={76}
+                maxHeight={140}
+                placeholder={t.raw('projectAccessBoundary.notePlaceholder')}
+                // Deliberately NOT disabled while pending: disabling a focused
+                // element drops keyboard focus to <body>. read-only:opacity-60
+                // supplies the state the `disabled:` styles would have.
+                readOnly={requestMutation.isPending}
+                className="read-only:cursor-default read-only:opacity-60"
+              />
+              <Button
+                type="submit"
+                size="lg"
+                className="mt-5 w-full aria-disabled:pointer-events-none aria-disabled:opacity-50"
+                aria-disabled={requestMutation.isPending}
+              >
+                {requestMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
+                {t.raw('projectAccessBoundary.requestAction')}
+              </Button>
+            </form>
+          ) : (
+            <Button
+              type="button"
+              size="lg"
+              variant={shouldPollForApproval(state) ? 'secondary' : 'default'}
+              className="mt-5 w-full"
+              onClick={onRecheck}
+              disabled={rechecking}
+            >
+              {rechecking ? <Loading className="size-4 shrink-0" /> : null}
+              {shouldPollForApproval(state)
+                ? t.raw('projectAccessBoundary.checkNowAction')
+                : t.raw('projectAccessBoundary.tryAgainAction')}
+            </Button>
+          )}
+
+          <div className="text-muted-foreground mt-8 space-y-2 text-sm">
+            {forbidden ? <p>{t.raw('projectAccessBoundary.approvalNote')}</p> : null}
+            <div className="flex items-center justify-between gap-3">
+              <button
+                type="button"
+                onClick={() => router.push('/projects')}
+                className="hover:text-foreground -my-2 inline-block cursor-pointer py-2 underline-offset-4 transition-colors hover:underline"
+              >
+                {t.raw('projectAccessBoundary.projectsAction')}
+              </button>
+              {adminRole?.isAdmin ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="text-kortix-orange hover:text-kortix-orange hover:bg-kortix-orange/10 -mr-2 h-7 shrink-0 px-2 text-xs"
+                  onClick={() => bypassMutation.mutate()}
+                  disabled={bypassMutation.isPending}
+                >
+                  {bypassMutation.isPending ? (
+                    <Loading className="size-3.5 shrink-0" />
+                  ) : (
+                    <ShieldWarningIcon className="size-3.5 shrink-0" />
+                  )}
+                  {t.raw('projectAccessBoundary.openAsAdmin')}
+                </Button>
+              ) : null}
+            </div>
+          </div>
         </div>
-      </main>
-    </div>
+      </Rise>
+    </AuthFrame>
   );
 }

--- a/apps/web/src/features/session/sandbox-loading-boundary.test.ts
+++ b/apps/web/src/features/session/sandbox-loading-boundary.test.ts
@@ -31,9 +31,12 @@ describe('session navigation loading boundaries', () => {
   });
 
   test('first project access still keeps its intentional full-page loader', () => {
-    expect(projectAccessSource).toContain('function ProjectAccessLoading()');
-    expect(projectAccessSource).toContain('<KortixHyperLogo');
-    expect(projectAccessSource).toContain('min-h-screen');
+    // The mirror of the `return null` rule above: a runtime-not-ready RETRY
+    // must stay invisible, but the very FIRST project fetch owns the whole
+    // viewport, so it has to show something rather than a blank screen.
+    expect(projectAccessSource).toContain('if (query.isLoading)');
+    expect(projectAccessSource).toContain('<AuthPendingScreen />');
+    expect(projectAccessSource).not.toMatch(/query\.isLoading\)\s*return null/);
   });
 
   test('the access boundary uses the lightweight project route', () => {
@@ -42,7 +45,11 @@ describe('session navigation loading boundaries', () => {
   });
 
   test('project home does not start the members query before Customize opens', () => {
-    expect(projectAccessSource).toContain("queryKey: ['project-access-boundary', projectId]");
+    // The boundary reads the lightweight project route under its own key. The
+    // key is a constant now because three call sites share it, so assert the
+    // constant's value and its use rather than one inlined literal.
+    expect(projectAccessSource).toContain("const QUERY_KEY = 'project-access-boundary'");
+    expect(projectAccessSource).toContain('queryKey: [QUERY_KEY, projectId]');
     expect(projectAccessSource).not.toContain("queryKey: ['project-access', projectId]");
     expect(projectHomeSource).not.toContain("queryKey: ['project-access', projectId]");
     expect(projectHomeSource).not.toContain('listProjectAccess(projectId');

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -3823,6 +3823,7 @@ export function SessionChat({
         });
       },
       onSuccess: () => {
+        if (!projectId || !projectSessionId) return;
         void updateProjectSession(projectId, projectSessionId, {
           metadata: { pending_prompt: null },
         }).catch((error) => {

--- a/apps/web/translations/de.json
+++ b/apps/web/translations/de.json
@@ -1217,6 +1217,30 @@
     }
   },
   "hardcodedUi": {
+    "projectAccessBoundary": {
+      "privateHeading": "Bitten Sie um Zugriff.",
+      "privateBody": "Nur Mitglieder können dieses Projekt öffnen. Senden Sie eine Nachricht, dann kann ein Projektmanager Sie hinzufügen.",
+      "waitingHeading": "Warten auf Genehmigung.",
+      "sentBody": "Ihre Anfrage liegt bei den Projektmanagern. Sobald einer von ihnen sie genehmigt, öffnet sich diese Seite von selbst.",
+      "alreadyBody": "Sie haben den Zugriff bereits angefragt. Ein Projektmanager muss ihn noch genehmigen.",
+      "notFoundHeading": "Dieses Projekt ist weg.",
+      "notFoundBody": "Der Link ist möglicherweise falsch, oder jemand hat das Projekt gelöscht.",
+      "errorHeading": "Dieses Projekt wurde nicht geladen.",
+      "errorBody": "Die Anfrage ist fehlgeschlagen, bevor wir Ihren Zugriff prüfen konnten.",
+      "noteLabel": "Nachricht an den Projektmanager",
+      "notePlaceholder": "Warum Sie Zugriff benötigen (optional)",
+      "requestAction": "Zugriff anfordern",
+      "checkNowAction": "Jetzt prüfen",
+      "tryAgainAction": "Erneut versuchen",
+      "projectsAction": "Zurück zu den Projekten",
+      "accountLabel": "Konto",
+      "projectLabel": "Projekt",
+      "approvalNote": "Jeder, der dieses Projekt verwaltet, kann Ihre Anfrage genehmigen.",
+      "openAsAdmin": "Als Admin öffnen",
+      "requestFailed": "Die Anfrage konnte nicht gesendet werden.",
+      "bypassFailed": "Admin-Bypass fehlgeschlagen.",
+      "thisAccount": "dieses Konto"
+    },
     "appHomeAppPage": {
       "line86JsxTextKortixForMobile": "Kortix für Mobilgeräte",
       "line89JsxTextYourAiWorkerInYourPocket": "Dein KI-Worker für die Hosentasche.",

--- a/apps/web/translations/en.json
+++ b/apps/web/translations/en.json
@@ -1220,6 +1220,30 @@
     }
   },
   "hardcodedUi": {
+    "projectAccessBoundary": {
+      "privateHeading": "Ask for access.",
+      "privateBody": "Only members can open this project. Send a note and a project manager can add you.",
+      "waitingHeading": "Waiting on approval.",
+      "sentBody": "Your request is with the project's managers. This page opens on its own once one of them approves it.",
+      "alreadyBody": "You asked for access earlier. A project manager still has to approve it.",
+      "notFoundHeading": "This project is gone.",
+      "notFoundBody": "The link may be wrong, or someone deleted the project.",
+      "errorHeading": "This project didn't load.",
+      "errorBody": "The request failed before we could check your access.",
+      "noteLabel": "Note to the project manager",
+      "notePlaceholder": "Why you need access (optional)",
+      "requestAction": "Request access",
+      "checkNowAction": "Check now",
+      "tryAgainAction": "Try again",
+      "projectsAction": "Back to projects",
+      "accountLabel": "Account",
+      "projectLabel": "Project",
+      "approvalNote": "Anyone who manages this project can approve your request.",
+      "openAsAdmin": "Open as admin",
+      "requestFailed": "Could not send the request.",
+      "bypassFailed": "Admin bypass failed.",
+      "thisAccount": "this account"
+    },
     "appHomeAppPage": {
       "line86JsxTextKortixForMobile": "Kortix for Mobile",
       "line89JsxTextYourAiWorkerInYourPocket": "Your AI Worker, in your pocket.",

--- a/apps/web/translations/es.json
+++ b/apps/web/translations/es.json
@@ -1217,6 +1217,30 @@
     }
   },
   "hardcodedUi": {
+    "projectAccessBoundary": {
+      "privateHeading": "Pide acceso.",
+      "privateBody": "Solo los miembros pueden abrir este proyecto. Envía una nota y un gestor del proyecto podrá añadirte.",
+      "waitingHeading": "Esperando aprobación.",
+      "sentBody": "Tu solicitud está con los gestores del proyecto. Esta página se abrirá sola en cuanto uno de ellos la apruebe.",
+      "alreadyBody": "Ya pediste acceso antes. Un gestor del proyecto todavía tiene que aprobarlo.",
+      "notFoundHeading": "Este proyecto ya no existe.",
+      "notFoundBody": "Puede que el enlace sea incorrecto o que alguien haya eliminado el proyecto.",
+      "errorHeading": "Este proyecto no se cargó.",
+      "errorBody": "La solicitud falló antes de que pudiéramos comprobar tu acceso.",
+      "noteLabel": "Nota para el gestor del proyecto",
+      "notePlaceholder": "Por qué necesitas acceso (opcional)",
+      "requestAction": "Solicitar acceso",
+      "checkNowAction": "Comprobar ahora",
+      "tryAgainAction": "Intentar de nuevo",
+      "projectsAction": "Volver a proyectos",
+      "accountLabel": "Cuenta",
+      "projectLabel": "Proyecto",
+      "approvalNote": "Cualquiera que gestione este proyecto puede aprobar tu solicitud.",
+      "openAsAdmin": "Abrir como administrador",
+      "requestFailed": "No se pudo enviar la solicitud.",
+      "bypassFailed": "Falló el acceso como administrador.",
+      "thisAccount": "esta cuenta"
+    },
     "appHomeAppPage": {
       "line86JsxTextKortixForMobile": "Kortix para móvil",
       "line89JsxTextYourAiWorkerInYourPocket": "Tu trabajador de IA, en tu bolsillo.",

--- a/apps/web/translations/fr.json
+++ b/apps/web/translations/fr.json
@@ -1220,6 +1220,30 @@
     }
   },
   "hardcodedUi": {
+    "projectAccessBoundary": {
+      "privateHeading": "Demandez l’accès.",
+      "privateBody": "Seuls les membres peuvent ouvrir ce projet. Envoyez un mot et un chef de projet pourra vous ajouter.",
+      "waitingHeading": "En attente d’approbation.",
+      "sentBody": "Votre demande est entre les mains des chefs de projet. Cette page s’ouvrira d’elle-même dès que l’un d’eux l’approuvera.",
+      "alreadyBody": "Vous avez déjà demandé l’accès. Un chef de projet doit encore l’approuver.",
+      "notFoundHeading": "Ce projet n’existe plus.",
+      "notFoundBody": "Le lien est peut-être erroné, ou quelqu’un a supprimé le projet.",
+      "errorHeading": "Ce projet n’a pas pu être chargé.",
+      "errorBody": "La requête a échoué avant que nous puissions vérifier votre accès.",
+      "noteLabel": "Mot pour le chef de projet",
+      "notePlaceholder": "Pourquoi vous avez besoin d’un accès (facultatif)",
+      "requestAction": "Demander l’accès",
+      "checkNowAction": "Vérifier maintenant",
+      "tryAgainAction": "Réessayer",
+      "projectsAction": "Retour aux projets",
+      "accountLabel": "Compte",
+      "projectLabel": "Projet",
+      "approvalNote": "Toute personne qui gère ce projet peut approuver votre demande.",
+      "openAsAdmin": "Ouvrir en tant qu’admin",
+      "requestFailed": "Impossible d’envoyer la demande.",
+      "bypassFailed": "Le contournement admin a échoué.",
+      "thisAccount": "ce compte"
+    },
     "appHomeAppPage": {
       "line86JsxTextKortixForMobile": "Kortix pour mobile",
       "line89JsxTextYourAiWorkerInYourPocket": "Votre travailleur IA, dans votre poche.",

--- a/apps/web/translations/it.json
+++ b/apps/web/translations/it.json
@@ -1217,6 +1217,30 @@
     }
   },
   "hardcodedUi": {
+    "projectAccessBoundary": {
+      "privateHeading": "Chiedi l'accesso.",
+      "privateBody": "Solo i membri possono aprire questo progetto. Invia una nota e un project manager potrà aggiungerti.",
+      "waitingHeading": "In attesa di approvazione.",
+      "sentBody": "La tua richiesta è nelle mani dei project manager. Questa pagina si aprirà da sola non appena uno di loro la approverà.",
+      "alreadyBody": "Hai già chiesto l'accesso in precedenza. Un project manager deve ancora approvarlo.",
+      "notFoundHeading": "Questo progetto non esiste più.",
+      "notFoundBody": "Il collegamento potrebbe essere errato oppure qualcuno ha eliminato il progetto.",
+      "errorHeading": "Questo progetto non si è caricato.",
+      "errorBody": "La richiesta non è riuscita prima che potessimo verificare il tuo accesso.",
+      "noteLabel": "Nota per il project manager",
+      "notePlaceholder": "Perché ti serve l'accesso (facoltativo)",
+      "requestAction": "Richiedi l'accesso",
+      "checkNowAction": "Controlla ora",
+      "tryAgainAction": "Riprova",
+      "projectsAction": "Torna ai progetti",
+      "accountLabel": "Account",
+      "projectLabel": "Progetto",
+      "approvalNote": "Chiunque gestisca questo progetto può approvare la tua richiesta.",
+      "openAsAdmin": "Apri come amministratore",
+      "requestFailed": "Impossibile inviare la richiesta.",
+      "bypassFailed": "Bypass amministratore non riuscito.",
+      "thisAccount": "questo account"
+    },
     "appHomeAppPage": {
       "line86JsxTextKortixForMobile": "Kortix per dispositivi mobili",
       "line89JsxTextYourAiWorkerInYourPocket": "Il tuo worker IA, sempre in tasca.",

--- a/apps/web/translations/ja.json
+++ b/apps/web/translations/ja.json
@@ -1217,6 +1217,30 @@
     }
   },
   "hardcodedUi": {
+    "projectAccessBoundary": {
+      "privateHeading": "アクセスをリクエストしてください。",
+      "privateBody": "このプロジェクトを開けるのはメンバーだけです。メッセージを送ると、プロジェクトマネージャーがあなたを追加できます。",
+      "waitingHeading": "承認をお待ちください。",
+      "sentBody": "リクエストはプロジェクトマネージャーに届いています。いずれかのマネージャーが承認すると、このページは自動的に開きます。",
+      "alreadyBody": "以前にアクセスをリクエスト済みです。プロジェクトマネージャーの承認がまだ必要です。",
+      "notFoundHeading": "このプロジェクトはありません。",
+      "notFoundBody": "リンクが間違っているか、誰かがこのプロジェクトを削除した可能性があります。",
+      "errorHeading": "プロジェクトを読み込めませんでした。",
+      "errorBody": "アクセスを確認する前にリクエストが失敗しました。",
+      "noteLabel": "プロジェクトマネージャーへのメッセージ",
+      "notePlaceholder": "アクセスが必要な理由（任意）",
+      "requestAction": "アクセスをリクエスト",
+      "checkNowAction": "今すぐ確認",
+      "tryAgainAction": "再試行",
+      "projectsAction": "プロジェクト一覧に戻る",
+      "accountLabel": "アカウント",
+      "projectLabel": "プロジェクト",
+      "approvalNote": "このプロジェクトを管理している人なら誰でも、あなたのリクエストを承認できます。",
+      "openAsAdmin": "管理者として開く",
+      "requestFailed": "リクエストを送信できませんでした。",
+      "bypassFailed": "管理者バイパスに失敗しました。",
+      "thisAccount": "このアカウント"
+    },
     "appHomeAppPage": {
       "line86JsxTextKortixForMobile": "モバイル版Kortix",
       "line89JsxTextYourAiWorkerInYourPocket": "あなたのAIワーカーを、ポケットに。",

--- a/apps/web/translations/pt.json
+++ b/apps/web/translations/pt.json
@@ -1217,6 +1217,30 @@
     }
   },
   "hardcodedUi": {
+    "projectAccessBoundary": {
+      "privateHeading": "Peça acesso.",
+      "privateBody": "Somente membros podem abrir este projeto. Envie uma mensagem e um gerente de projeto poderá adicionar você.",
+      "waitingHeading": "Aguardando aprovação.",
+      "sentBody": "Sua solicitação está com os gerentes do projeto. Esta página abre sozinha assim que um deles aprovar.",
+      "alreadyBody": "Você já pediu acesso antes. Um gerente de projeto ainda precisa aprovar.",
+      "notFoundHeading": "Este projeto não existe mais.",
+      "notFoundBody": "O link pode estar errado, ou alguém excluiu o projeto.",
+      "errorHeading": "Este projeto não carregou.",
+      "errorBody": "A solicitação falhou antes de conseguirmos verificar seu acesso.",
+      "noteLabel": "Mensagem para o gerente de projeto",
+      "notePlaceholder": "Por que você precisa de acesso (opcional)",
+      "requestAction": "Solicitar acesso",
+      "checkNowAction": "Verificar agora",
+      "tryAgainAction": "Tentar novamente",
+      "projectsAction": "Voltar para projetos",
+      "accountLabel": "Conta",
+      "projectLabel": "Projeto",
+      "approvalNote": "Qualquer pessoa que gerencie este projeto pode aprovar sua solicitação.",
+      "openAsAdmin": "Abrir como administrador",
+      "requestFailed": "Não foi possível enviar a solicitação.",
+      "bypassFailed": "O acesso de administrador falhou.",
+      "thisAccount": "esta conta"
+    },
     "appHomeAppPage": {
       "line86JsxTextKortixForMobile": "Kortix para dispositivos móveis",
       "line89JsxTextYourAiWorkerInYourPocket": "Seu worker de IA, no seu bolso.",

--- a/apps/web/translations/zh.json
+++ b/apps/web/translations/zh.json
@@ -1213,6 +1213,30 @@
     }
   },
   "hardcodedUi": {
+    "projectAccessBoundary": {
+      "privateHeading": "请求访问权限。",
+      "privateBody": "只有成员才能打开这个项目。发送一条说明，项目经理就能把你添加进来。",
+      "waitingHeading": "等待批准。",
+      "sentBody": "你的请求已发送给项目经理。其中任何一位批准后，本页面会自动打开。",
+      "alreadyBody": "你之前已经请求过访问权限。项目经理仍需批准。",
+      "notFoundHeading": "这个项目已经不在了。",
+      "notFoundBody": "链接可能有误，或者有人删除了这个项目。",
+      "errorHeading": "这个项目未能加载。",
+      "errorBody": "在检查你的访问权限之前，请求就失败了。",
+      "noteLabel": "给项目经理的说明",
+      "notePlaceholder": "你为什么需要访问权限（可选）",
+      "requestAction": "请求访问权限",
+      "checkNowAction": "立即检查",
+      "tryAgainAction": "重试",
+      "projectsAction": "返回项目列表",
+      "accountLabel": "账户",
+      "projectLabel": "项目",
+      "approvalNote": "任何管理这个项目的人都可以批准你的请求。",
+      "openAsAdmin": "以管理员身份打开",
+      "requestFailed": "无法发送请求。",
+      "bypassFailed": "管理员绕过失败。",
+      "thisAccount": "此账户"
+    },
     "appHomeAppPage": {
       "line86JsxTextKortixForMobile": "Kortix 移动版",
       "line89JsxTextYourAiWorkerInYourPocket": "你的 AI Worker，随身携带。",


### PR DESCRIPTION
## Summary

The project 403 screen was a two-column split that stated the same thing three times (eyebrow, hero headline, panel title) and matched no other full-page surface in the app. This rebuilds it on the shared auth consent vocabulary — `AuthFrame`, `Rise`, `StepHeader`, `DetailPanel`, `ErrorStrip`, `AuthPendingScreen` — so it reads as the same product as `/auth`, `/cli/authorize` and `/oauth/authorize`.

Behaviour fixed along the way:

- **A duplicate request no longer lies.** `requestProjectAccess` returns `created | pending | already_has_access`; the screen collapsed the first two, so someone with a pending request was told "Request sent." again on every attempt.
- **The page opens itself.** It polls every 15s instead of asking the user to reload, and stops polling once the project is readable — the boundary wraps the shell for the whole session, so a poll that ignored success kept calling `getProject` while the user worked.
- **A transient failure no longer erases a sent request.** A 401/500/offline poll result used to wipe the waiting state and hand back an empty form. A 404 still supersedes it, so a deleted project doesn't leave the user waiting forever.
- **No request form for statuses that asking cannot fix.** Only 403 offers the form.
- **No WebGL on a permission screen.** The default `wallpaperId` is a Paper Shader.
- **Keyboard focus survives submit.** Disabling a focused element moves focus to `<body>`, so the note field uses `readOnly` and the button uses `aria-disabled` with a guard in `onSubmit`.
- **`kortix-orange` replaces raw `amber-500/700/400`** on the admin escape hatch, and `ADMIN BYPASS` becomes "Open as admin".

Copy moved to `hardcodedUi.projectAccessBoundary` across all 8 locales, dropping the internal navigation path ("Customize → Members") and the "Kortix workspace" wording for a project.

## Test plan

- [x] `bun test src/components/projects/project-access-boundary.test.ts` — 27 pass, 0 fail
- [x] `bun test src/components/projects src/features/session` — 870 pass, 0 fail across 84 files
- [x] `npx eslint` on the changed files — exit 0
- [x] `npx prettier --check` on the component, its test and all 8 locale files — clean
- [x] `npx tsc --noEmit` — no errors in the changed files
- [x] All 8 locales verified for the new key block: 22 keys each, 0 missing / 0 stale / 0 extra
- [ ] **Manual, not yet run:** open `/projects/<id>` for a project you are not a member of. Check light and dark. Submit once, then submit again from a second tab to hit the `pending` path. This branch has no browser verification.

Two tests pin the dialect so it cannot drift back: one asserts the file is composed from the auth primitives, the other fails if `WallpaperBackground`, `backdrop-blur`, `rounded-2xl`, `fixed inset-0` or `InfoBanner` reappear in it.
