### PR TITLE
blog: the only moat that matters — data flywheels, not static software

### DIFF
--- a/apps/web/src/lib/blog-posts.ts
+++ b/apps/web/src/lib/blog-posts.ts
@@ -1750,6 +1750,128 @@ $ kortix hosts use cloud
   ],
 };
 
+const theOnlyMoatThatMatters: BlogPostEntry = {
+  slug: 'the-only-moat-that-matters',
+  title: 'The only moat that matters: why your AI platform needs a learning loop, not a better model',
+  description:
+    'Every AI product is converging on the same architecture. The only defensible advantage is a data flywheel — a learning loop where every interaction makes your system better. Here is what that means, and why Kortix is built for it.',
+  date: '2026-08-02',
+  author: 'marko',
+  cover: '/banner.png',
+  tags: ['Vision', 'Architecture', 'Open Source'],
+  readingTime: 10,
+  blocks: [
+    {
+      type: 'lead',
+      text: 'There is a convergence happening in AI right now that is barely discussed. Open any agent platform — Perplexity Computer, Manus, GenSpark, OpenClaw, Hermes, Claude Cowork, Notion AI, Lovable, Cursor, Replit — and architecturally, they are nearly identical. An LLM with tools, a sandboxed execution environment, a memory layer, and a multi-step loop. The marginal differences are UX, a handful of custom integrations, and how they handle memory. None of that takes more than a few months to replicate.',
+    },
+    {
+      type: 'p',
+      text: 'This is not a problem for any one company. It is a structural reality of the market. Static software — code you write once and run forever — no longer creates a defensible advantage. Anyone can copy it, and with AI-assisted coding, they can do it faster than ever. Writer.com, a company valued at over a billion dollars, built a significant portion of their enterprise platform by cloning open-source code. The code was not the moat. The code was the starting line.',
+    },
+    {
+      type: 'callout',
+      text: 'Static software has no moat. The only defensible advantage in the AI era is a data flywheel — a learning loop where every interaction makes your system better, and more usage compounds into a gap that is genuinely hard to close.',
+    },
+    {
+      type: 'p',
+      text: 'Consider why autonomous coding agents actually work. The reason they are viable today is that the environment — bash, a file system, a running process — provides a deterministic pass/fail signal. Did the test pass? Did the API call return 200? Did the build succeed? The answer is a boolean. The agent writes code, runs it, gets a signal, and iterates. The environment is the feedback loop, and the feedback loop is what makes the agent improve.',
+    },
+    {
+      type: 'p',
+      text: 'The same principle applies at the company level. The moat is not the model. The moat is the system that captures what worked, why it worked, and what context mattered — and feeds that back into the next run. Every completed task, every rejected proposal, every human override is a training signal. The company that captures that signal and builds it into its agents\' behavior is compounding. The company that treats each session as a fresh context window is starting from zero every time.',
+    },
+    { type: 'h2', text: 'Human capital meets token capital' },
+    {
+      type: 'p',
+      text: 'Satya Nadella recently wrote about the need for every company to build two kinds of capital: human capital and token capital. Human capital is the knowledge, judgment, relationships, and pattern recognition of your people. Token capital is the AI capability your company builds and owns — the skills, the workflows, the persistent memory, the private evaluation datasets that capture what "good" means for your specific business.',
+    },
+    {
+      type: 'p',
+      text: 'The key insight: human capital does not become less valuable as token capital grows. It becomes more valuable. Humans set the ambitious goals, connect dots across domains, build relationships, recognize patterns that matter. Without human direction, you have compute running in circles. The learning loop between people and AI systems is what compounds.',
+    },
+    {
+      type: 'p',
+      text: 'Offload a task, or even a job, but never offload the learning. The company that builds a system to capture that learning, encode it, and feed it back into its AI workforce is building the only real moat left.',
+    },
+    { type: 'h2', text: 'The test: can you swap the model without losing what you built?' },
+    {
+      type: 'p',
+      text: 'Satya proposed a test that every company should run on its AI platform: can you switch out the model without losing the institutional expertise you have built? If your state lives in a context window, you lose it when the model changes. If your workflows are embedded in a proprietary vendor\'s toolchain, you do not own them. If your company\'s knowledge is training data for a model you do not control, you have not built a moat — you have donated your IP.',
+    },
+    {
+      type: 'p',
+      text: 'This is the architectural question that matters more than any model benchmark. A platform is sovereign when:',
+    },
+    {
+      type: 'ul',
+      items: [
+        'Your agents\' skills and memory are stored in files you own, not in a vendor\'s database.',
+        'You can swap the underlying model without rebuilding the system.',
+        'Your company\'s private evaluation datasets are yours, and they determine what "good" means.',
+        'The feedback loop — the signal that improves your agents — stays inside your perimeter.',
+        'You can self-host the entire stack on your own infrastructure.',
+      ],
+    },
+    {
+      type: 'p',
+      text: 'If any of those is false, you are not building a moat. You are renting one.',
+    },
+    { type: 'h2', text: 'How Kortix is built for the data flywheel' },
+    {
+      type: 'p',
+      text: 'Kortix was designed from the ground up around this thesis. Every architectural decision — the git-native model, the model-agnostic gateway, the isolated sandbox environment, the skill system — is aimed at one thing: enabling your company to build a learning loop that compounds. Here is how each layer works.',
+    },
+    {
+      type: 'p',
+      text: '**Everything is files in a git repo.** The manifest, the agents, the skills, the connectors, the policies, the memory. Versioned, diffable, reviewable, owned by you. When an agent learns something, it goes into a file. When you want to see what changed, you read a diff. Your company\'s AI operation is not a pile of settings in someone else\'s dashboard — it is a repository you control. That means your institutional knowledge is never locked into a proprietary format or a vendor\'s database.',
+    },
+    {
+      type: 'p',
+      text: '**Any model, your keys.** The gateway is model-agnostic by design. Route a cheap open-weight model for bulk work and a frontier model for the hard calls. Switch them without touching your agents. The reasoning engine is replaceable; the platform around it is the product. This is the test Satya described — model independence is the foundation of sovereignty.',
+    },
+    {
+      type: 'p',
+      text: '**The sandbox is the feedback loop.** Every session runs in an isolated Linux machine with a file system, a terminal, and network access. The agent proposes, and the environment verifies. That deterministic signal — pass or fail — is what makes the learning loop work. The more sessions you run, the more signal you generate, the better your agents get. And because every session is isolated, you can run thousands in parallel without the chaos of shared state.',
+    },
+    {
+      type: 'p',
+      text: '**Skills are procedural memory.** A skill in Kortix is a file: purpose, preconditions, steps, policies, examples, tests, version, and provenance. An agent can propose a new skill, but it ships through review. Over time, your company accumulates a library of proven, tested, versioned capabilities that encode exactly how your business works. That library is your token capital. And it compounds — every skill that gets used generates more signal, which improves the next skill.',
+    },
+    {
+      type: 'p',
+      text: 'None of this requires a frontier model. It requires a platform that treats the learning loop as a first-class architectural concern. The model is the reasoning engine. The platform is where the value accumulates.',
+    },
+    { type: 'h2', text: 'The frontier ecosystem, not the frontier model' },
+    {
+      type: 'p',
+      text: 'Satya\'s essay ends with a warning that is worth repeating: "There is no societal permission for an AI future that hollows out entire industries." If all the value is captured by a small number of models, the political economy will not tolerate it. The priority has to be building a frontier ecosystem — one where every company, every industry, every country can own the learning loop that encodes its institutional knowledge.',
+    },
+    {
+      type: 'p',
+      text: 'This is the ethos open-source has always represented: platforms that enable more value on top than they capture inside. Kortix is open-source, self-hostable, and model-agnostic by design. We want every company that uses Kortix to build its own compounding advantage — not to make Kortix the only company that gets smarter.',
+    },
+    {
+      type: 'p',
+      text: 'That is the only stable equilibrium. And it is the only moat that actually lasts.',
+    },
+    { type: 'h2', text: 'What this means for your company' },
+    {
+      type: 'p',
+      text: 'If you are building with AI today, or planning to, the question is not whether your model is better. The model will be equalized in months. The question is whether your system gets better with every interaction. Do you capture the signal? Do you own the learning loop? Can you change the model without losing what you have built?',
+    },
+    {
+      type: 'p',
+      text: 'The companies that win the next decade will not be the ones with the best model. They will be the ones that built the best learning loop, compounded it fastest, and owned their own token capital. The moat is not in the code. It is in the curve.',
+    },
+    {
+      type: 'cta',
+      title: 'Start building your learning loop today.',
+      body: 'Kortix is the open-source AI operating system where your company\'s knowledge compounds. Connect your tools, deploy an agent, and start accumulating your own token capital. Free to start, free to self-host.',
+    },
+  ],
+};
+
 export const BLOG_POSTS: BlogPostEntry[] = [
   openSourceAiManagementSystem,
   kortixVsPoetic,
@@ -1761,4 +1883,5 @@ export const BLOG_POSTS: BlogPostEntry[] = [
   personalAgentsVsCompanyOs,
   beyondTheChatBox,
   introducingKortix,
+  theOnlyMoatThatMatters,
 ];


### PR DESCRIPTION
## Demo

Non-visual change — blog post content only, no UI change.

## Why

This post synthesises Marko's thesis interview with Sam and Satya Nadella's
frontier-ecosystem essay into a standalone customer-facing piece: the only
durable AI advantage is a data flywheel, and the architecture that enables
it is the only real moat.

## What changed

- Added `theOnlyMoatThatMatters` entry to `apps/web/src/lib/blog-posts.ts`
  (123 lines, slug: `the-only-moat-that-matters`)
- Registered in the `BLOG_POSTS` export array

## Verification

- `npx tsc --noEmit` in apps/web — no blog-related errors (existing test
  infrastructure errors are pre-existing and unrelated)
- Post renders in the existing blog template at `/blog/the-only-moat-that-matters`
- RSS feed auto-includes the new post

## Risk / rollback

Zero risk — pure data addition. No routing, component, or build config
changes. Revert by removing the entry.