### PR TITLE
fix: process Slack audio messages (file_share subtype) through webhook

### DIFF
--- a/apps/api/src/__tests__/unit-slack-classify-event.test.ts
+++ b/apps/api/src/__tests__/unit-slack-classify-event.test.ts
@@ -100,6 +100,26 @@ describe('classifyEvent — a message that @-mentions the bot is a mention', () 
     const cls = await classifyEvent('T1', ev({ subtype: 'message_changed', thread_ts: '90.0', text: '<@B1> edited' }), BOT);
     expect(cls).toBe('ignore');
   });
+
+  test('file_share with no files is ignored', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'file_share', channel_type: 'im', text: '' }), BOT);
+    expect(cls).toBe('ignore');
+  });
+
+  test('file_share with files in a DM passes through', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'file_share', channel_type: 'im', text: '', files: [{ id: 'F1', mimetype: 'audio/wav', name: 'voice-message.wav', size: 12345, url_private_download: 'https://...' }] }), BOT);
+    expect(cls).toBe('dm');
+  });
+
+  test('file_share with files in a channel passes through', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'file_share', channel_type: 'channel', text: 'listen to this', files: [{ id: 'F1', mimetype: 'audio/mp4', name: 'audio.m4a', size: 54321, url_private_download: 'https://...' }] }), BOT);
+    expect(cls).toBe('ignore');
+  });
+
+  test('file_share with files and a bot mention is a mention', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'file_share', channel_type: 'channel', text: '<@B1> transcribe this', files: [{ id: 'F1', mimetype: 'audio/wav', name: 'voice.wav', size: 9999, url_private_download: 'https://...' }] }), BOT);
+    expect(cls).toBe('mention');
+  });
 });
 
 describe('classifyEvent — non-mention routing is unchanged', () => {

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -184,7 +184,7 @@ export async function maybePostPicker(
   const event = envelope.event;
   if (!event || !event.channel || event.bot_id) return;
   const isMention = event.type === 'app_mention';
-  const isDm = event.type === 'message' && event.channel_type === 'im' && !event.subtype;
+  const isDm = event.type === 'message' && event.channel_type === 'im' && (!event.subtype || event.subtype === 'file_share');
   if (!isMention && !isDm) return;
 
   await postProjectPicker({
@@ -430,7 +430,13 @@ export async function classifyEvent(
 ): Promise<EventClass> {
   if (event.type === 'app_mention') return 'mention';
   if (event.type !== 'message') return 'ignore';
-  if (event.subtype) return 'ignore';
+  if (event.subtype) {
+    // Allow file_share events through (audio messages, images, documents, etc.)
+    // The agent will see the file info in the prompt and can download/process it.
+    // All other subtypes (message_changed, message_deleted, bot_message, etc.)
+    // remain ignored.
+    if (event.subtype !== 'file_share' || !event.files?.length) return 'ignore';
+  }
   // A `message` that @-mentions the bot IS a mention. Slack does NOT reliably
   // deliver an `app_mention` for a mention made INSIDE an existing thread —
   // notably a thread that predates the bot joining the channel — there it arrives
@@ -552,7 +558,10 @@ export async function dispatchSlackEvent(projectId: string, envelope: SlackEnvel
   const msgKey = inboundMessageKey(teamId, event);
   if (msgKey && !(await claimInboundMessage(msgKey))) return;
 
-  if (eventClass === 'mention' && !stripMentions(event.text ?? '')) {
+  // A bare @mention with no text is a "what now?" prompt — post help text.
+  // But if the user attached files (e.g. an audio message), the files are the
+  // content, so don't stop here — send them to the agent.
+  if (eventClass === 'mention' && !stripMentions(event.text ?? '') && !event.files?.length) {
     if (config.SLACK_REQUIRE_USER_IDENTITY) {
       const [project] = await db
         .select({ accountId: projects.accountId })

--- a/apps/api/src/channels/slack/session.ts
+++ b/apps/api/src/channels/slack/session.ts
@@ -339,6 +339,25 @@ const TURN_INSTRUCTIONS = [
   '- One `slack send` per turn. It finalizes the live stream and can\'t be undone.',
 ].join('\n');
 
+function renderFileInfo(event: SlackEvent): string {
+  if (!event.files?.length) return '';
+  const lines: string[] = ['', 'The user also attached files:'];
+  for (const file of event.files) {
+    const name = file.name ?? file.title ?? file.id;
+    lines.push(`  • ${name} (${file.mimetype}, ${file.filetype}, ${formatFileSize(file.size)})`);
+    lines.push(`    Download: ${file.url_private_download}`);
+  }
+  lines.push('', 'Use `slack download --url "<url>" --out <path>` to download each file.');
+  lines.push('For audio files, process them as needed (e.g. transcribe with whisper or another ASR tool).');
+  return lines.join('\n');
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export function renderFollowUpPrompt(envelope: SlackEnvelope, event: SlackEvent): string {
   const user = event.user ?? 'unknown';
   const text = event.text ?? '';
@@ -346,6 +365,7 @@ export function renderFollowUpPrompt(envelope: SlackEnvelope, event: SlackEvent)
     `New message from ${user} in the same Slack thread:`,
     '',
     text,
+    renderFileInfo(event),
     '',
     TURN_INSTRUCTIONS,
   ].join('\n');
@@ -378,6 +398,6 @@ function renderAgentPrompt(
     `User:       ${user}`,
   );
   if (threadTs) lines.push(`Thread ts:  ${threadTs}`);
-  lines.push('', 'Message:', text, '', TURN_INSTRUCTIONS);
+  lines.push('', 'Message:', text, renderFileInfo(event), '', TURN_INSTRUCTIONS);
   return lines.join('\n');
 }

--- a/apps/api/src/channels/slack/types.ts
+++ b/apps/api/src/channels/slack/types.ts
@@ -57,6 +57,22 @@ export interface SlackEnvelope {
   event?: SlackEvent;
 }
 
+export interface SlackFile {
+  id: string;
+  created: number;
+  timestamp: number;
+  mimetype: string;
+  filetype: string;
+  pretty_type: string;
+  user: string;
+  size: number;
+  mode: string;
+  url_private: string;
+  url_private_download: string;
+  name?: string;
+  title?: string;
+}
+
 export interface SlackEvent {
   type: string;
   user?: string;
@@ -64,6 +80,7 @@ export interface SlackEvent {
   channel?: string;
   channel_type?: string;
   text?: string;
+  files?: SlackFile[];
   ts?: string;
   thread_ts?: string;
   subtype?: string;


### PR DESCRIPTION
Slack voice messages arrive as `message` events with `subtype: 'file_share'` and a `files` array. The `classifyEvent` gate had a blanket `if (event.subtype) return 'ignore'` that dropped every file_share event — including audio messages — before they could reach the agent.

**Changes:**
- **types.ts**: Add `SlackFile` interface and `files` field to `SlackEvent`
- **dispatch.ts**: Allow `file_share` subtype through when files are present; skip empty-mention help-text when files are attached (the files are the content)
- **session.ts**: Include file metadata in the agent prompt (name, type, size, download URL) so the agent can download and process audio
- **tests**: Cover file_share with/without files, in DMs, channels, and with bot mentions

**Testing:** All 204 Slack unit tests pass (17 files, 0 failures).