### PR TITLE
fix: also allow me_message subtype through Slack webhook gate

### DIFF
--- a/apps/api/src/__tests__/unit-slack-classify-event.test.ts
+++ b/apps/api/src/__tests__/unit-slack-classify-event.test.ts
@@ -120,6 +120,31 @@ describe('classifyEvent — a message that @-mentions the bot is a mention', () 
     const cls = await classifyEvent('T1', ev({ subtype: 'file_share', channel_type: 'channel', text: '<@B1> transcribe this', files: [{ id: 'F1', mimetype: 'audio/wav', name: 'voice.wav', size: 9999, url_private_download: 'https://...' }] }), BOT);
     expect(cls).toBe('mention');
   });
+
+  test('me_message in a DM is a dm', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'me_message', channel_type: 'im', text: 'waves hello' }), BOT);
+    expect(cls).toBe('dm');
+  });
+
+  test('me_message with a bot mention is a mention', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'me_message', channel_type: 'channel', text: '<@B1> laughs at your joke' }), BOT);
+    expect(cls).toBe('mention');
+  });
+
+  test('me_message in a channel without mention is ignored (no pickup)', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'me_message', channel_type: 'channel', text: 'waves goodbye' }), BOT);
+    expect(cls).toBe('ignore');
+  });
+
+  test('other subtypes like thread_broadcast are still ignored', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'thread_broadcast', channel_type: 'channel', text: 'broadcast' }), BOT);
+    expect(cls).toBe('ignore');
+  });
+
+  test('other subtypes like message_changed are still ignored', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'message_changed', channel_type: 'channel', text: 'edited' }), BOT);
+    expect(cls).toBe('ignore');
+  });
 });
 
 describe('classifyEvent — non-mention routing is unchanged', () => {

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -431,11 +431,19 @@ export async function classifyEvent(
   if (event.type === 'app_mention') return 'mention';
   if (event.type !== 'message') return 'ignore';
   if (event.subtype) {
-    // Allow file_share events through (audio messages, images, documents, etc.)
-    // The agent will see the file info in the prompt and can download/process it.
-    // All other subtypes (message_changed, message_deleted, bot_message, etc.)
-    // remain ignored.
-    if (event.subtype !== 'file_share' || !event.files?.length) return 'ignore';
+    // Allow these user-generated subtypes through:
+    //   file_share   — audio messages, images, documents, etc. (agent sees file info)
+    //   me_message   — /me actions (e.g. "/me waves hello")
+    // All other subtypes (message_changed, message_deleted, bot_message,
+    // thread_broadcast, channel_join, etc.) remain ignored to avoid loops,
+    // redundancy, or system noise.
+    if (event.subtype === 'file_share' && event.files?.length) {
+      // pass through
+    } else if (event.subtype === 'me_message') {
+      // pass through — user-generated /me action
+    } else {
+      return 'ignore';
+    }
   }
   // A `message` that @-mentions the bot IS a mention. Slack does NOT reliably
   // deliver an `app_mention` for a mention made INSIDE an existing thread —


### PR DESCRIPTION
## Audit of all 34 Slack message subtypes

I systematically researched every possible `subtype` on a Slack `message` event. Here's the full analysis:

| Subtype | User content? | Should process? | Why |
|---|---|---|---|
| *(none)* | Yes | ✅ Already handled | Standard messages |
| `file_share` | Yes | ✅ Already handled (#6028) | Audio, images, docs |
| `me_message` | Yes | ✅ **NEW — was missed** | /me actions |
| `bot_message` | Yes | ❌ Not safe | We have a separate `bot_id` gate already |
| `thread_broadcast` | Yes | ❌ Redundant | Original message already processed |
| `message_changed` | Yes | ❌ Loop risk | Bot edits would re-trigger |
| `message_replied` | Yes | ❌ Loop risk | Bot's own replies would re-trigger |
| `message_deleted` | No | ❌ Correctly ignored | No content |
| `channel_join` / `channel_leave` etc. | No | ❌ Correctly ignored | System events |
| All other 20+ subtypes | No | ❌ Correctly ignored | System/archive/rename events |

**Changes:**
- Added `me_message` to the allowlist in classifyEvent
- Refactored the subtype check to explicit allow-list pattern (cleaner, safer)
- Added 5 test cases: `me_message` in DM, with @mention, in channel, plus guards for `thread_broadcast` and `message_changed` staying ignored

**Testing:** All 209 Slack unit tests pass (+5 from previous, 17 files, 0 failures).