### PR TITLE
fix: also allow bot_message subtype through Slack webhook gate

### DIFF
--- a/apps/api/src/__tests__/unit-slack-classify-event.test.ts
+++ b/apps/api/src/__tests__/unit-slack-classify-event.test.ts
@@ -120,6 +120,31 @@ describe('classifyEvent — a message that @-mentions the bot is a mention', () 
     const cls = await classifyEvent('T1', ev({ subtype: 'file_share', channel_type: 'channel', text: '<@B1> transcribe this', files: [{ id: 'F1', mimetype: 'audio/wav', name: 'voice.wav', size: 9999, url_private_download: 'https://...' }] }), BOT);
     expect(cls).toBe('mention');
   });
+
+  test('me_message in a DM is a dm', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'me_message', channel_type: 'im', text: 'waves hello' }), BOT);
+    expect(cls).toBe('dm');
+  });
+
+  test('me_message with a bot mention is a mention', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'me_message', channel_type: 'channel', text: '<@B1> laughs at your joke' }), BOT);
+    expect(cls).toBe('mention');
+  });
+
+  test('me_message in a channel without mention is ignored (no pickup)', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'me_message', channel_type: 'channel', text: 'waves goodbye' }), BOT);
+    expect(cls).toBe('ignore');
+  });
+
+  test('other subtypes like thread_broadcast are still ignored', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'thread_broadcast', channel_type: 'channel', text: 'broadcast' }), BOT);
+    expect(cls).toBe('ignore');
+  });
+
+  test('other subtypes like message_changed are still ignored', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'message_changed', channel_type: 'channel', text: 'edited' }), BOT);
+    expect(cls).toBe('ignore');
+  });
 });
 
 describe('classifyEvent — non-mention routing is unchanged', () => {

--- a/apps/api/src/__tests__/unit-slack-classify-event.test.ts
+++ b/apps/api/src/__tests__/unit-slack-classify-event.test.ts
@@ -136,6 +136,21 @@ describe('classifyEvent — a message that @-mentions the bot is a mention', () 
     expect(cls).toBe('ignore');
   });
 
+  test('bot_message in a DM is a dm', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'bot_message', channel_type: 'im', text: 'hello from another bot', bot_id: 'B999' }), BOT);
+    expect(cls).toBe('dm');
+  });
+
+  test('bot_message with a bot mention is a mention', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'bot_message', channel_type: 'channel', text: '<@B1> analyze this report', bot_id: 'B999' }), BOT);
+    expect(cls).toBe('mention');
+  });
+
+  test('bot_message without mention in a channel is ignored (no pickup)', async () => {
+    const cls = await classifyEvent('T1', ev({ subtype: 'bot_message', channel_type: 'channel', text: 'other bot chatter', bot_id: 'B999' }), BOT);
+    expect(cls).toBe('ignore');
+  });
+
   test('other subtypes like thread_broadcast are still ignored', async () => {
     const cls = await classifyEvent('T1', ev({ subtype: 'thread_broadcast', channel_type: 'channel', text: 'broadcast' }), BOT);
     expect(cls).toBe('ignore');

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -434,13 +434,16 @@ export async function classifyEvent(
     // Allow these user-generated subtypes through:
     //   file_share   — audio messages, images, documents, etc. (agent sees file info)
     //   me_message   — /me actions (e.g. "/me waves hello")
-    // All other subtypes (message_changed, message_deleted, bot_message,
-    // thread_broadcast, channel_join, etc.) remain ignored to avoid loops,
-    // redundancy, or system noise.
+    //   bot_message  — messages from OTHER bots (our own bot is blocked by the
+    //                  separate bot_id/user===botUserId gate in dispatchSlackEvent)
+    // All other subtypes (message_changed, message_deleted, thread_broadcast,
+    // channel_join, etc.) remain ignored to avoid loops, redundancy, or system noise.
     if (event.subtype === 'file_share' && event.files?.length) {
       // pass through
     } else if (event.subtype === 'me_message') {
       // pass through — user-generated /me action
+    } else if (event.subtype === 'bot_message') {
+      // pass through — other bots' messages (our bot_id gate prevents self-loops)
     } else {
       return 'ignore';
     }

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -431,11 +431,19 @@ export async function classifyEvent(
   if (event.type === 'app_mention') return 'mention';
   if (event.type !== 'message') return 'ignore';
   if (event.subtype) {
-    // Allow file_share events through (audio messages, images, documents, etc.)
-    // The agent will see the file info in the prompt and can download/process it.
-    // All other subtypes (message_changed, message_deleted, bot_message, etc.)
-    // remain ignored.
-    if (event.subtype !== 'file_share' || !event.files?.length) return 'ignore';
+    // Allow these user-generated subtypes through:
+    //   file_share   — audio messages, images, documents, etc. (agent sees file info)
+    //   me_message   — /me actions (e.g. "/me waves hello")
+    // All other subtypes (message_changed, message_deleted, bot_message,
+    // thread_broadcast, channel_join, etc.) remain ignored to avoid loops,
+    // redundancy, or system noise.
+    if (event.subtype === 'file_share' && event.files?.length) {
+      // pass through
+    } else if (event.subtype === 'me_message') {
+      // pass through — user-generated /me action
+    } else {
+      return 'ignore';
+    }
   }
   // A `message` that @-mentions the bot IS a mention. Slack does NOT reliably
   // deliver an `app_mention` for a mention made INSIDE an existing thread —


### PR DESCRIPTION
 from other bots is safe because our own bot's messages are already blocked by the separate  /  gate in  (line 538). No self-loop risk.

**Changes:**
- Added  to the allowlist in 
- 3 new test cases: bot_message in DM, with @mention, and in channel without mention

**Testing:** All 212 Slack unit tests pass (17 files, 0 failures).