### PR TITLE
Fix Executor email attachments from local artifacts

### DIFF
--- a/apps/api/src/__tests__/e2e-executor-faces.test.ts
+++ b/apps/api/src/__tests__/e2e-executor-faces.test.ts
@@ -4,7 +4,9 @@
  * invocation against a live Hono router backed by the real gateway path.
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { dirname, resolve } from 'node:path';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createExecutorClient } from '../../../../packages/executor-sdk/src/index';
 import { createExecutorRouter, type CatalogConnector, type ExecutorPrincipal, type ExecutorRouterDeps } from '../executor/router';
@@ -53,6 +55,20 @@ const action: GatewayAction = {
   binding: { kind: 'http', method: 'GET', path: '/anything' },
 };
 
+const attachmentAction: GatewayAction = {
+  path: 'echo.reply',
+  relPath: 'reply',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      text: { type: 'string' },
+      attachments: { type: 'array' },
+    },
+  },
+  risk: 'write',
+  binding: { kind: 'http', method: 'POST', path: '/reply' },
+};
+
 function principal(): ExecutorPrincipal {
   return {
     userId: USER,
@@ -74,20 +90,24 @@ function catalogFor(_p: ExecutorPrincipal): CatalogConnector[] {
     name: 'Echo',
     provider: connector.provider,
     status: 'active',
-    actions: [{
-      path: action.relPath,
-      name: action.path,
-      description: 'Echo a query value',
-      risk: action.risk,
-      inputSchema: action.inputSchema,
-    }],
+    actions: [action, attachmentAction].map((item) => ({
+      path: item.relPath,
+      name: item.path,
+      description: item === action ? 'Echo a query value' : 'Echo a message with attachments',
+      risk: item.risk,
+      inputSchema: item.inputSchema,
+    })),
   }];
 }
 
 function makeDeps(): ExecutorRouterDeps {
   const gateway: GatewayDeps = {
     loadConnectorBySlug: async (_projectId, slug) => (slug === connector.slug ? connector : null),
-    loadAction: async (connectorId, relPath) => (connectorId === connector.connectorId && relPath === action.relPath ? action : null),
+    loadAction: async (connectorId, relPath) => {
+      if (connectorId !== connector.connectorId) return null;
+      if (relPath === action.relPath) return action;
+      return relPath === attachmentAction.relPath ? attachmentAction : null;
+    },
     resolveCredential: async () => SERVER_SECRET,
     loadPolicies: async () => [],
     recordExecution: async (rec) => { world.executions.push(rec); return null; },
@@ -154,7 +174,8 @@ async function requestMcp(proc: Bun.Subprocess<'pipe', 'pipe', 'pipe'>, reader: 
     line += decoder.decode(chunk.value);
   }
   const [first] = line.split('\n');
-  const json = JSON.parse(first!);
+  if (!first) throw new Error('MCP process returned an empty response');
+  const json = JSON.parse(first);
   if (json.error) throw new Error(json.error.message);
   return json.result;
 }
@@ -200,19 +221,21 @@ describe('TS SDK face', () => {
 
     const [match] = await sdk.discover('query value', { limit: 1 });
     expect(match).toMatchObject({ tool: 'echo.get', connector: 'echo', action: 'get' });
+    if (!match) throw new Error('expected Executor discovery match');
 
-    const schema = await sdk.describe(match!.tool);
+    const schema = await sdk.describe(match.tool);
     expect(schema?.inputSchema).toMatchObject({
       type: 'object',
       properties: { q: { type: 'string', 'x-in': 'query' } },
     });
 
-    const first = await sdk.call<{ auth: string; url: string }>(match!.connector, match!.action, { q: 'step-1' });
+    const first = await sdk.call<{ auth: string; url: string }>(match.connector, match.action, { q: 'step-1' });
     expect(first.ok).toBe(true);
     expect(first.data?.auth).toBe(`Bearer ${SERVER_SECRET}`);
+    if (!first.data) throw new Error('expected first Executor call data');
 
-    const nextQuery = first.data!.url.endsWith('step-1') ? 'step-2' : 'unexpected';
-    const second = await sdk.call<{ auth: string; url: string }>(match!.connector, match!.action, { q: nextQuery });
+    const nextQuery = first.data.url.endsWith('step-1') ? 'step-2' : 'unexpected';
+    const second = await sdk.call<{ auth: string; url: string }>(match.connector, match.action, { q: nextQuery });
     expect(second.ok).toBe(true);
     expect(second.data?.url).toBe('https://example.test/anything?q=step-2');
 
@@ -226,7 +249,10 @@ describe('TS SDK face', () => {
 
 describe('CLI face', () => {
   test('connectors, discover, describe, and call work as an executable', async () => {
-    expect((await runCli(['connectors'])).connectors[0]).toMatchObject({ slug: 'echo', tools: ['echo.get'] });
+    expect((await runCli(['connectors'])).connectors[0]).toMatchObject({
+      slug: 'echo',
+      tools: ['echo.get', 'echo.reply'],
+    });
     expect((await runCli(['discover', 'query'])).matches[0]).toMatchObject({ tool: 'echo.get', risk: 'read' });
     expect((await runCli(['describe', 'echo.get'])).inputSchema).toMatchObject({ type: 'object' });
     const call = await runCli(['call', 'echo', 'get', '{"q":"cli"}']);
@@ -305,7 +331,10 @@ describe('Project-explicit gateway face (the local-executor unlock)', () => {
     // .kortix/link.json or --project) makes `kortix executor` use the routes that
     // accept a plain user token. Same command, same result as in-sandbox.
     const connectors = await runCli(['connectors'], { KORTIX_PROJECT_ID: PROJECT });
-    expect(connectors.connectors[0]).toMatchObject({ slug: 'echo', tools: ['echo.get'] });
+    expect(connectors.connectors[0]).toMatchObject({
+      slug: 'echo',
+      tools: ['echo.get', 'echo.reply'],
+    });
     const call = await runCli(['call', 'echo', 'get', '{"q":"proj-cli"}'], { KORTIX_PROJECT_ID: PROJECT });
     expect(call).toMatchObject({ ok: true, risk: 'read' });
     expect(call.data.url).toBe('https://example.test/anything?q=proj-cli');
@@ -355,7 +384,7 @@ describe('MCP face', () => {
       const connectors = JSON.parse(
         (await requestMcp(proc, reader, 3, 'tools/call', { name: 'connectors', arguments: {} })).content[0].text,
       );
-      expect(connectors.connectors[0]).toMatchObject({ slug: 'echo', provider: 'http', tools: 1 });
+      expect(connectors.connectors[0]).toMatchObject({ slug: 'echo', provider: 'http', tools: 2 });
 
       // discover → intent search across usable tools.
       const discovered = JSON.parse(
@@ -381,6 +410,62 @@ describe('MCP face', () => {
     } finally {
       proc.kill();
       await proc.exited;
+    }
+  });
+
+  test('reads attachment_files inside the MCP process and sends encoded attachments', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'kortix-executor-mcp-'));
+    const output = join(workspace, 'output');
+    const memo = join(output, 'memo.pdf');
+    await mkdir(output);
+    await writeFile(memo, 'real-pdf-bytes');
+
+    const proc = Bun.spawn({
+      cmd: ['bun', CLI_ENTRY, 'executor', 'mcp'],
+      cwd: REPO_ROOT,
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        KORTIX_API_URL: apiUrl,
+        KORTIX_EXECUTOR_TOKEN: TOKEN,
+        KORTIX_INTERNAL_WORKSPACE_ROOT: workspace,
+      },
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const reader = proc.stdout.getReader();
+    try {
+      const listed = await requestMcp(proc, reader, 1, 'tools/list');
+      const callTool = listed.tools.find((tool: { name: string }) => tool.name === 'call');
+      expect(callTool.inputSchema.properties.attachment_files.items.required).toEqual(['path']);
+
+      const called = await requestMcp(proc, reader, 2, 'tools/call', {
+        name: 'call',
+        arguments: {
+          connector: 'echo',
+          action: 'reply',
+          args: { text: 'attached' },
+          attachment_files: [{ path: memo, filename: 'Investment Memo.pdf' }],
+        },
+      });
+      expect(called.isError).toBe(false);
+      const payload = JSON.parse(called.content[0].text);
+      expect(payload.data.body).toEqual({
+        text: 'attached',
+        attachments: [
+          {
+            filename: 'Investment Memo.pdf',
+            content_type: 'application/pdf',
+            content_disposition: 'attachment',
+            content: Buffer.from('real-pdf-bytes').toString('base64'),
+          },
+        ],
+      });
+    } finally {
+      proc.kill();
+      await proc.exited;
+      await rm(workspace, { recursive: true, force: true });
     }
   });
 });

--- a/apps/api/src/__tests__/unit-executor-channels.test.ts
+++ b/apps/api/src/__tests__/unit-executor-channels.test.ts
@@ -124,9 +124,9 @@ describe('channelCatalog(email)', () => {
       method: 'POST',
       path: '/inboxes/{inbox_id}/messages/{message_id}/reply',
     });
-    const props = objectSchema(a.inputSchema).properties as Record<string, any>;
-    expect(props.inbox_id['x-in']).toBe('path');
-    expect(props.message_id['x-in']).toBe('path');
+    const props = objectSchema(a.inputSchema).properties;
+    expect(props.inbox_id).toMatchObject({ 'x-in': 'path' });
+    expect(props.message_id).toMatchObject({ 'x-in': 'path' });
     expect(a.risk).toBe('write');
   });
 
@@ -141,6 +141,26 @@ describe('channelCatalog(email)', () => {
     expect(objectSchema(action('reply_message').inputSchema).required ?? []).toEqual([
       'message_id',
     ]);
+  });
+
+  test('describes both supported AgentMail attachment transports', () => {
+    for (const path of ['send_message', 'reply_message', 'reply_all_message']) {
+      const props = objectSchema(action(path).inputSchema).properties;
+      const attachments = props.attachments as {
+        items: {
+          required: string[];
+          anyOf: Array<{ required: string[] }>;
+          properties: Record<string, { description: string }>;
+        };
+      };
+      expect(attachments.items.required).toEqual(['filename']);
+      expect(attachments.items.anyOf).toEqual([
+        { required: ['content'] },
+        { required: ['url'] },
+      ]);
+      expect(attachments.items.properties.content?.description).toContain('Base64');
+      expect(attachments.items.properties.url?.description).toContain('URL');
+    }
   });
 
   test('api base + default slug', () => {

--- a/apps/api/src/executor/channels.ts
+++ b/apps/api/src/executor/channels.ts
@@ -113,9 +113,33 @@ interface ChannelActionDef {
   description: string;
   risk: Risk;
   /** JSON-schema properties using Slack's NATIVE param names (passed through verbatim). */
-  properties: Record<string, { type: string; description: string }>;
+  properties: Record<string, Record<string, unknown> & { type: string; description: string }>;
   required: string[];
 }
+
+const EMAIL_ATTACHMENT_SCHEMA = {
+  type: 'array',
+  description:
+    'Optional attachments. Each item must include filename plus either base64 content or a fetchable URL.',
+  items: {
+    type: 'object',
+    properties: {
+      filename: { type: 'string', description: 'Filename shown to the recipient.' },
+      content_type: { type: 'string', description: 'MIME type of the attachment.' },
+      content_disposition: {
+        type: 'string',
+        enum: ['attachment', 'inline'],
+        description: 'How the recipient email client should display the file.',
+      },
+      content_id: { type: 'string', description: 'Optional content ID for an inline attachment.' },
+      content: { type: 'string', description: 'Base64-encoded file content.' },
+      url: { type: 'string', description: 'Public URL from which AgentMail can fetch the file.' },
+    },
+    required: ['filename'],
+    anyOf: [{ required: ['content'] }, { required: ['url'] }],
+    additionalProperties: false,
+  },
+} satisfies Record<string, unknown> & { type: string; description: string };
 
 /**
  * The Slack catalog — one entry per native Web API method the `slack` CLI
@@ -344,7 +368,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       subject: { type: 'string', description: 'Email subject.' },
       text: { type: 'string', description: 'Plain text body.' },
       html: { type: 'string', description: 'HTML body.' },
-      attachments: { type: 'array', description: 'Optional AgentMail send attachments.' },
+      attachments: EMAIL_ATTACHMENT_SCHEMA,
     },
     required: ['to'],
   },
@@ -364,7 +388,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       bcc: { type: 'array', description: 'Optional BCC recipients.' },
       text: { type: 'string', description: 'Plain text body.' },
       html: { type: 'string', description: 'HTML body.' },
-      attachments: { type: 'array', description: 'Optional AgentMail send attachments.' },
+      attachments: EMAIL_ATTACHMENT_SCHEMA,
     },
     required: ['message_id'],
   },
@@ -380,7 +404,7 @@ const EMAIL_ACTIONS: ChannelActionDef[] = [
       message_id: { type: 'string', description: 'Message ID to reply-all to.' },
       text: { type: 'string', description: 'Plain text body.' },
       html: { type: 'string', description: 'HTML body.' },
-      attachments: { type: 'array', description: 'Optional AgentMail send attachments.' },
+      attachments: EMAIL_ATTACHMENT_SCHEMA,
     },
     required: ['message_id'],
   },

--- a/apps/cli/src/__tests__/executor-mcp-attachments.test.ts
+++ b/apps/cli/src/__tests__/executor-mcp-attachments.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { encodeAttachmentFiles } from '../executor/mcp';
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'kortix-email-attachments-'));
+  await mkdir(join(root, 'output'));
+  await mkdir(join(root, 'artifacts'));
+  return root;
+}
+
+describe('Executor MCP attachment_files', () => {
+  test('encodes multiple generated files without putting base64 in the tool call', async () => {
+    const root = await fixture();
+    const pdf = join(root, 'output', 'memo.pdf');
+    const xlsx = join(root, 'artifacts', 'model.xlsx');
+    await writeFile(pdf, 'pdf-bytes');
+    await writeFile(xlsx, 'xlsx-bytes');
+
+    const result = await encodeAttachmentFiles([{ path: pdf, filename: 'Investment Memo.pdf' }, { path: xlsx }], {
+      workspaceRoot: root,
+    });
+
+    expect(result).toEqual([
+      {
+        filename: 'Investment Memo.pdf',
+        content_type: 'application/pdf',
+        content_disposition: 'attachment',
+        content: Buffer.from('pdf-bytes').toString('base64'),
+      },
+      {
+        filename: 'model.xlsx',
+        content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        content_disposition: 'attachment',
+        content: Buffer.from('xlsx-bytes').toString('base64'),
+      },
+    ]);
+  });
+
+  test('rejects files outside generated-artifact directories, including symlinks', async () => {
+    const root = await fixture();
+    const secret = join(root, 'secret.txt');
+    const link = join(root, 'output', 'report.txt');
+    await writeFile(secret, 'do-not-send');
+    await symlink(secret, link);
+
+    await expect(encodeAttachmentFiles([{ path: link }], { workspaceRoot: root })).rejects.toThrow('must be inside /workspace/{output,artifacts,reports,deliverables}');
+  });
+
+  test('rejects aggregate payloads over the local safety limit', async () => {
+    const root = await fixture();
+    const first = join(root, 'output', 'one.txt');
+    const second = join(root, 'output', 'two.txt');
+    await writeFile(first, '12345');
+    await writeFile(second, '67890');
+
+    await expect(
+      encodeAttachmentFiles([{ path: first }, { path: second }], {
+        workspaceRoot: root,
+        maxBytes: 9,
+      }),
+    ).rejects.toThrow('aggregate limit');
+  });
+});

--- a/apps/cli/src/__tests__/executor-mcp-attachments.test.ts
+++ b/apps/cli/src/__tests__/executor-mcp-attachments.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -47,7 +47,27 @@ describe('Executor MCP attachment_files', () => {
     await writeFile(secret, 'do-not-send');
     await symlink(secret, link);
 
-    await expect(encodeAttachmentFiles([{ path: link }], { workspaceRoot: root })).rejects.toThrow('must be inside /workspace/{output,artifacts,reports,deliverables}');
+    await expect(encodeAttachmentFiles([{ path: link }], { workspaceRoot: root })).rejects.toThrow(
+      'must not be a symbolic link',
+    );
+  });
+
+  test('rejects a path that changes after the file descriptor is opened', async () => {
+    const root = await fixture();
+    const report = join(root, 'output', 'report.txt');
+    const secret = join(root, 'secret.txt');
+    await writeFile(report, 'safe-report');
+    await writeFile(secret, 'do-not-send');
+
+    await expect(
+      encodeAttachmentFiles([{ path: report }], {
+        workspaceRoot: root,
+        afterOpen: async () => {
+          await rm(report);
+          await symlink(secret, report);
+        },
+      }),
+    ).rejects.toThrow('must be inside /workspace/{output,artifacts,reports,deliverables}');
   });
 
   test('rejects aggregate payloads over the local safety limit', async () => {

--- a/apps/cli/src/executor/mcp.ts
+++ b/apps/cli/src/executor/mcp.ts
@@ -20,7 +20,8 @@
  * skips the host/update notices for `executor`, so this stays clean.
  */
 import type { ExecutorClient } from '@kortix/executor-sdk';
-import { readFile, realpath, stat } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { open, realpath, stat } from 'node:fs/promises';
 import { basename, extname, isAbsolute, relative, resolve, sep } from 'node:path';
 import {
   addConnector,
@@ -114,7 +115,11 @@ function localAttachment(value: unknown, index: number): LocalAttachmentFile {
 
 export async function encodeAttachmentFiles(
   value: unknown,
-  options: { workspaceRoot?: string; maxBytes?: number } = {},
+  options: {
+    workspaceRoot?: string;
+    maxBytes?: number;
+    afterOpen?: (path: string, index: number) => Promise<void>;
+  } = {},
 ): Promise<EncodedAttachment[]> {
   if (!Array.isArray(value) || value.length === 0) {
     throw new Error('attachment_files must be a non-empty array');
@@ -136,35 +141,49 @@ export async function encodeAttachmentFiles(
     if (!isAbsolute(item.path)) {
       throw new Error(`attachment_files[${index}].path must be absolute`);
     }
-    const path = await realpath(item.path);
-    if (!allowedRoots.some((root) => isWithinRoot(path, root))) {
-      throw new Error(
-        `attachment_files[${index}].path must be inside /workspace/{${DEFAULT_ATTACHMENT_ROOTS.join(',')}}`,
-      );
-    }
-    const details = await stat(path);
-    if (!details.isFile()) throw new Error(`attachment_files[${index}].path is not a file`);
-    totalBytes += details.size;
-    if (totalBytes > maxBytes) {
-      throw new Error(
-        `attachment_files exceeds the ${Math.floor(maxBytes / (1024 * 1024))} MiB aggregate limit`,
-      );
-    }
-
-    const filename = item.filename || basename(path);
-    if (!filename || filename === '.' || filename === '..' || filename.includes('/') || filename.includes('\\')) {
-      throw new Error(`attachment_files[${index}].filename must be a plain filename`);
-    }
-    const contentType =
-      item.content_type || ATTACHMENT_CONTENT_TYPES[extname(filename).toLowerCase()] || 'application/octet-stream';
-    const content = (await readFile(path)).toString('base64');
-    encoded.push({
-      filename,
-      content_type: contentType,
-      content_disposition: item.content_disposition ?? 'attachment',
-      ...(item.content_id ? { content_id: item.content_id } : {}),
-      content,
+    const file = await open(item.path, constants.O_RDONLY | constants.O_NOFOLLOW).catch((error: unknown) => {
+      if (asRecord(error).code === 'ELOOP') {
+        throw new Error(`attachment_files[${index}].path must not be a symbolic link`);
+      }
+      throw error;
     });
+    try {
+      await options.afterOpen?.(item.path, index);
+      const path = await realpath(item.path);
+      if (!allowedRoots.some((root) => isWithinRoot(path, root))) {
+        throw new Error(
+          `attachment_files[${index}].path must be inside /workspace/{${DEFAULT_ATTACHMENT_ROOTS.join(',')}}`,
+        );
+      }
+      const [details, pathDetails] = await Promise.all([file.stat(), stat(path)]);
+      if (!details.isFile()) throw new Error(`attachment_files[${index}].path is not a file`);
+      if (details.dev !== pathDetails.dev || details.ino !== pathDetails.ino) {
+        throw new Error(`attachment_files[${index}].path changed while it was being opened`);
+      }
+      totalBytes += details.size;
+      if (totalBytes > maxBytes) {
+        throw new Error(
+          `attachment_files exceeds the ${Math.floor(maxBytes / (1024 * 1024))} MiB aggregate limit`,
+        );
+      }
+
+      const filename = item.filename || basename(path);
+      if (!filename || filename === '.' || filename === '..' || filename.includes('/') || filename.includes('\\')) {
+        throw new Error(`attachment_files[${index}].filename must be a plain filename`);
+      }
+      const contentType =
+        item.content_type || ATTACHMENT_CONTENT_TYPES[extname(filename).toLowerCase()] || 'application/octet-stream';
+      const content = (await file.readFile()).toString('base64');
+      encoded.push({
+        filename,
+        content_type: contentType,
+        content_disposition: item.content_disposition ?? 'attachment',
+        ...(item.content_id ? { content_id: item.content_id } : {}),
+        content,
+      });
+    } finally {
+      await file.close();
+    }
   }
   return encoded;
 }

--- a/apps/cli/src/executor/mcp.ts
+++ b/apps/cli/src/executor/mcp.ts
@@ -20,6 +20,8 @@
  * skips the host/update notices for `executor`, so this stays clean.
  */
 import type { ExecutorClient } from '@kortix/executor-sdk';
+import { readFile, realpath, stat } from 'node:fs/promises';
+import { basename, extname, isAbsolute, relative, resolve, sep } from 'node:path';
 import {
   addConnector,
   callPausingForApproval,
@@ -39,6 +41,133 @@ interface JsonRpcRequest {
 // The MCP server identity is kept as `kortix-executor` (unchanged from the old
 // standalone shim) so the agent's tool names and registration key don't move.
 const SERVER_INFO = { name: 'kortix-executor', version: '0.3.0' };
+
+const MAX_ATTACHMENT_FILES = 20;
+const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+const DEFAULT_ATTACHMENT_ROOTS = ['output', 'artifacts', 'reports', 'deliverables'];
+
+const ATTACHMENT_CONTENT_TYPES: Record<string, string> = {
+  '.csv': 'text/csv',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.json': 'application/json',
+  '.md': 'text/markdown',
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.txt': 'text/plain',
+  '.webp': 'image/webp',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.zip': 'application/zip',
+};
+
+interface LocalAttachmentFile {
+  path: string;
+  filename?: string;
+  content_type?: string;
+  content_disposition?: 'attachment' | 'inline';
+  content_id?: string;
+}
+
+interface EncodedAttachment {
+  filename: string;
+  content_type: string;
+  content_disposition: 'attachment' | 'inline';
+  content_id?: string;
+  content: string;
+}
+
+function isWithinRoot(path: string, root: string): boolean {
+  const offset = relative(root, path);
+  return offset !== '' && !offset.startsWith(`..${sep}`) && offset !== '..' && !isAbsolute(offset);
+}
+
+function localAttachment(value: unknown, index: number): LocalAttachmentFile {
+  const row = asRecord(value);
+  const path = stringField(row, 'path').trim();
+  if (!path) throw new Error(`attachment_files[${index}].path is required`);
+  const disposition = row.content_disposition;
+  if (disposition !== undefined && disposition !== 'attachment' && disposition !== 'inline') {
+    throw new Error(
+      `attachment_files[${index}].content_disposition must be "attachment" or "inline"`,
+    );
+  }
+  return {
+    path,
+    ...(stringField(row, 'filename').trim()
+      ? { filename: stringField(row, 'filename').trim() }
+      : {}),
+    ...(stringField(row, 'content_type').trim()
+      ? { content_type: stringField(row, 'content_type').trim() }
+      : {}),
+    ...(disposition ? { content_disposition: disposition } : {}),
+    ...(stringField(row, 'content_id').trim()
+      ? { content_id: stringField(row, 'content_id').trim() }
+      : {}),
+  };
+}
+
+export async function encodeAttachmentFiles(
+  value: unknown,
+  options: { workspaceRoot?: string; maxBytes?: number } = {},
+): Promise<EncodedAttachment[]> {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('attachment_files must be a non-empty array');
+  }
+  if (value.length > MAX_ATTACHMENT_FILES) {
+    throw new Error(`attachment_files supports at most ${MAX_ATTACHMENT_FILES} files`);
+  }
+
+  const workspaceRoot = await realpath(
+    options.workspaceRoot ?? process.env.KORTIX_INTERNAL_WORKSPACE_ROOT ?? '/workspace',
+  );
+  const allowedRoots = DEFAULT_ATTACHMENT_ROOTS.map((name) => resolve(workspaceRoot, name));
+  const maxBytes = options.maxBytes ?? MAX_ATTACHMENT_BYTES;
+  let totalBytes = 0;
+  const encoded: EncodedAttachment[] = [];
+
+  for (let index = 0; index < value.length; index++) {
+    const item = localAttachment(value[index], index);
+    if (!isAbsolute(item.path)) {
+      throw new Error(`attachment_files[${index}].path must be absolute`);
+    }
+    const path = await realpath(item.path);
+    if (!allowedRoots.some((root) => isWithinRoot(path, root))) {
+      throw new Error(
+        `attachment_files[${index}].path must be inside /workspace/{${DEFAULT_ATTACHMENT_ROOTS.join(',')}}`,
+      );
+    }
+    const details = await stat(path);
+    if (!details.isFile()) throw new Error(`attachment_files[${index}].path is not a file`);
+    totalBytes += details.size;
+    if (totalBytes > maxBytes) {
+      throw new Error(
+        `attachment_files exceeds the ${Math.floor(maxBytes / (1024 * 1024))} MiB aggregate limit`,
+      );
+    }
+
+    const filename = item.filename || basename(path);
+    if (!filename || filename === '.' || filename === '..' || filename.includes('/') || filename.includes('\\')) {
+      throw new Error(`attachment_files[${index}].filename must be a plain filename`);
+    }
+    const contentType =
+      item.content_type || ATTACHMENT_CONTENT_TYPES[extname(filename).toLowerCase()] || 'application/octet-stream';
+    const content = (await readFile(path)).toString('base64');
+    encoded.push({
+      filename,
+      content_type: contentType,
+      content_disposition: item.content_disposition ?? 'attachment',
+      ...(item.content_id ? { content_id: item.content_id } : {}),
+      content,
+    });
+  }
+  return encoded;
+}
 
 /**
  * The fixed meta-tool surface. Stable regardless of how many connectors or
@@ -90,7 +219,7 @@ const META_TOOLS = [
   {
     name: 'call',
     description:
-      'Run a tool. The gateway resolves the credential server-side, enforces sharing + policy, executes the call, and audits it. Returns { ok, data, risk } on success, or a denial / pending-approval result. GraphQL tools take selected fields via an "__select" arg, e.g. {"id":"1","__select":"id name email"}.',
+      'Run a tool. The gateway resolves the credential server-side, enforces sharing + policy, executes the call, and audits it. Returns { ok, data, risk } on success, or a denial / pending-approval result. For email attachments, pass small local file references in attachment_files; this MCP reads and encodes the files outside the model tool payload. GraphQL tools take selected fields via an "__select" arg, e.g. {"id":"1","__select":"id name email"}.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -102,6 +231,28 @@ const META_TOOLS = [
         args: {
           type: 'object',
           description: "Arguments matching the tool's input schema (see describe). Defaults to {}.",
+        },
+        attachment_files: {
+          type: 'array',
+          description:
+            'Local files for an email action that supports attachments. Paths must be absolute and inside /workspace/output, /workspace/artifacts, /workspace/reports, or /workspace/deliverables. The MCP encodes them after the tool call, so never paste base64 into args.',
+          items: {
+            type: 'object',
+            properties: {
+              path: { type: 'string', description: 'Absolute local file path.' },
+              filename: { type: 'string', description: 'Optional recipient-visible filename.' },
+              content_type: { type: 'string', description: 'Optional MIME type.' },
+              content_disposition: {
+                type: 'string',
+                enum: ['attachment', 'inline'],
+                description: 'Defaults to attachment.',
+              },
+              content_id: { type: 'string', description: 'Optional inline content ID.' },
+            },
+            required: ['path'],
+            additionalProperties: false,
+          },
+          maxItems: MAX_ATTACHMENT_FILES,
         },
       },
       required: ['connector', 'action'],
@@ -298,7 +449,40 @@ async function runMetaTool(executor: ExecutorClient, name: string, args: Record<
           isError: true,
         };
       }
-      const callArgs = asRecord(args.args);
+      let callArgs = asRecord(args.args);
+      if (args.attachment_files !== undefined) {
+        const described = await executor.describe(`${connector}.${action}`);
+        const schema = asRecord(described?.inputSchema);
+        const properties = asRecord(schema.properties);
+        if (!described || !properties.attachments) {
+          return {
+            content: content({
+              ok: false,
+              error: `${connector}.${action} does not accept attachments`,
+            }),
+            isError: true,
+          };
+        }
+        try {
+          const files = await encodeAttachmentFiles(args.attachment_files);
+          const existing = callArgs.attachments;
+          if (existing !== undefined && !Array.isArray(existing)) {
+            throw new Error('args.attachments must be an array when attachment_files is used');
+          }
+          callArgs = {
+            ...callArgs,
+            attachments: [...(Array.isArray(existing) ? existing : []), ...files],
+          };
+        } catch (err) {
+          return {
+            content: content({
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+            isError: true,
+          };
+        }
+      }
       // Pauses the run for human approval (indefinite poll, like a question) —
       // shared with `kortix executor call`, see callPausingForApproval.
       const result = await callPausingForApproval(executor, connector, action, callArgs);


### PR DESCRIPTION
## Problem

The Veyris agent tried to embed 313 KB of base64 JSON in one MCP tool call. The model payload truncated before AgentMail received it. The agent then sent two attachment-free replies and misreported an email size limit.

The three files totaled 234,579 binary bytes. AgentMail accepts them.

## Fix

- Add explicit AgentMail schemas for base64 and URL attachment transports.
- Add `call.attachment_files` to `kortix executor mcp`.
- Read and encode local artifacts inside the MCP process, outside the model-generated tool payload.
- Restrict files to `/workspace/output`, `/workspace/artifacts`, `/workspace/reports`, and `/workspace/deliverables`.
- Reject symlink escapes with `realpath`.
- Enforce 20 files and 25 MiB aggregate input.
- Infer common document and image MIME types.
- Merge local files with existing `args.attachments` entries.

## Verification

- API typecheck: pass.
- CLI typecheck: pass.
- Biome lint on all five changed files: pass.
- API suite: 5,059 pass, 62 skip, 0 fail across 499 files.
- CLI suite: 615 pass, 0 fail across 56 files.
- Real subprocess test: `kortix executor mcp` reads a local PDF path and sends the expected filename, MIME type, disposition, and base64 bytes through the gateway.
- Live incident correction: AgentMail read-back confirmed PDF 105,745 bytes, XLSX 17,887 bytes, and DOCX 110,947 bytes.