### PR TITLE
fix(ci): update tests after EKS removal

### DIFF
--- a/apps/web/src/features/session/tool/tools/show-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/show-tool.tsx
@@ -299,7 +299,7 @@ export function ShowTool({ part, sessionId, defaultOpen = false, forceOpen, lock
           variant="accent"
           size="sm"
           data-component="tool-trigger"
-          className="w-fit max-w-full justify-start gap-2 border font-normal"
+          className="border-border w-fit max-w-full justify-start gap-2 border font-normal"
         >
           {/* `Loading`'s base sets `in-data-[slot=button]:text-background`, which
               is invisible on the subtle accent surface. The same trailing-`!`


### PR DESCRIPTION
## Summary

- replace the deleted staging Kubernetes values assertion with the ECS secret-bundle contract
- remove the deleted `deploy-api` job from the production release dependency assertion
- restore the two class tokens required by existing web source-contract tests

## Verification

- `cd tests && pnpm exec vitest run --config unit/vitest.config.ts unit/staging-secret-workflow.test.ts` — 2 passed
- affected web test files — 27 passed
- `git diff --check`

This PR repairs deterministic failures already present on `main`. It is separate from Executor attachment PR #6036.
