### PR TITLE
fix(email): accept standard webhook signature headers

### DIFF
--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -183,6 +183,23 @@ describe('AgentMail webhook verification', () => {
       });
       expect(invalidSignature.status).toBe(401);
 
+      const standardId = 'msg_standard_123';
+      const standardTimestamp = String(Math.floor(Date.now() / 1000));
+      const standardSignature = createHmac('sha256', Buffer.from('test-signing-key'))
+        .update(`${standardId}.${standardTimestamp}.${rawBody}`)
+        .digest('base64');
+      const standardHeaders = await emailWebhookApp.request('/agentmail', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'webhook-id': standardId,
+          'webhook-timestamp': standardTimestamp,
+          'webhook-signature': `v1,${standardSignature}`,
+        },
+        body: rawBody,
+      });
+      expect(standardHeaders.status).toBe(200);
+
       // A malformed unsigned body (missing event_type/inbox_id) must NOT be
       // acked with 200 — that let an unauthenticated caller poison ack/monitoring
       // with `{}` -> 200 ok. Now rejected with 400 before any signature check.

--- a/apps/api/src/channels/email/routes.ts
+++ b/apps/api/src/channels/email/routes.ts
@@ -46,14 +46,32 @@ emailWebhookApp.openapi(
     if (!secret) {
       return c.json({ error: 'AgentMail webhook signing is not configured' }, 503);
     }
+    // AgentMail documents the legacy `svix-*` names, while newer Svix /
+    // Standard Webhooks deliveries may use the equivalent `webhook-*` names.
+    // Accept both without weakening verification: the same raw body, timestamp,
+    // message id, signature and per-inbox secret are still required.
+    const svixId = c.req.header('svix-id') ?? c.req.header('webhook-id') ?? '';
+    const svixTimestamp = c.req.header('svix-timestamp') ?? c.req.header('webhook-timestamp') ?? '';
+    const svixSignature = c.req.header('svix-signature') ?? c.req.header('webhook-signature') ?? '';
     const ok = verifyAgentMailSignature({
       rawBody,
       secret,
-      svixId: c.req.header('svix-id') ?? '',
-      svixTimestamp: c.req.header('svix-timestamp') ?? '',
-      svixSignature: c.req.header('svix-signature') ?? '',
+      svixId,
+      svixTimestamp,
+      svixSignature,
     });
-    if (!ok) return c.json({ error: 'Invalid signature' }, 401);
+    if (!ok) {
+      console.warn('[email-webhook] signature verification failed', {
+        inboxId: event.message.inbox_id,
+        hasSvixId: Boolean(c.req.header('svix-id')),
+        hasWebhookId: Boolean(c.req.header('webhook-id')),
+        hasSvixTimestamp: Boolean(c.req.header('svix-timestamp')),
+        hasWebhookTimestamp: Boolean(c.req.header('webhook-timestamp')),
+        hasSvixSignature: Boolean(c.req.header('svix-signature')),
+        hasWebhookSignature: Boolean(c.req.header('webhook-signature')),
+      });
+      return c.json({ error: 'Invalid signature' }, 401);
+    }
 
     void dispatchAgentMailEvent(event).catch((err) => {
       console.error('[email-webhook] handler failed', err);


### PR DESCRIPTION
## Summary
- accept Standard Webhooks `webhook-*` signature header aliases in addition to Svix `svix-*` headers
- preserve raw-body HMAC verification with the per-inbox signing secret
- log header presence only when verification fails, without exposing signature values
- cover a valid `webhook-*` delivery in the AgentMail unit suite

## Verification
- `pnpm --filter kortix-api typecheck`
- dotenvx-backed `bun test apps/api/src/__tests__/unit-email-channel.test.ts` (15 pass)
- `pnpm exec biome format ...`
- `git diff --check`