### PR TITLE
fix(ci): provide AWS role to staging secret sync

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -95,6 +95,8 @@ jobs:
     name: Sync staging secret bundle
     needs: preflight
     runs-on: ubuntu-latest
+    env:
+      ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
     steps:
       - uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/tests/unit/staging-secret-workflow.test.ts
+++ b/tests/unit/staging-secret-workflow.test.ts
@@ -1,32 +1,60 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
 
-describe('staging secret synchronization', () => {
-  it('preserves the existing staging bundle and uses dev only for first creation', () => {
+describe("staging secret synchronization", () => {
+  it("assumes the staging deploy role before reading or updating the secret bundle", () => {
     const workflow = readFileSync(
-      resolve(import.meta.dirname, '../../.github/workflows/deploy-staging.yml'),
-      'utf8',
+      resolve(
+        import.meta.dirname,
+        "../../.github/workflows/deploy-staging.yml",
+      ),
+      "utf8",
+    );
+    const syncSecretStart = workflow.indexOf("  sync-secret:");
+    const deployStart = workflow.indexOf("  deploy-ecs:");
+    const syncSecretJob = workflow.slice(syncSecretStart, deployStart);
+
+    expect(syncSecretStart).toBeGreaterThan(-1);
+    expect(deployStart).toBeGreaterThan(syncSecretStart);
+    expect(syncSecretJob).toContain(
+      "ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy",
+    );
+    expect(syncSecretJob).toContain("role-to-assume: ${{ env.ROLE }}");
+  });
+
+  it("preserves the existing staging bundle and uses dev only for first creation", () => {
+    const workflow = readFileSync(
+      resolve(
+        import.meta.dirname,
+        "../../.github/workflows/deploy-staging.yml",
+      ),
+      "utf8",
     );
 
-    const preserveStart = workflow.indexOf('if aws secretsmanager describe-secret --secret-id kortix-staging-env');
+    const preserveStart = workflow.indexOf(
+      "if aws secretsmanager describe-secret --secret-id kortix-staging-env",
+    );
     const payloadStart = workflow.indexOf('payload="$(jq -cn');
     const preservationBlock = workflow.slice(preserveStart, payloadStart);
 
     expect(preserveStart).toBeGreaterThan(-1);
     expect(payloadStart).toBeGreaterThan(preserveStart);
-    expect(preservationBlock).toContain('--secret-id kortix-staging-env');
-    expect(preservationBlock).toContain('staging_secret_exists=true');
-    expect(preservationBlock).toContain('else');
-    expect(preservationBlock).toContain('--secret-id kortix-dev-env');
-    expect(preservationBlock).toContain('staging_secret_exists=false');
+    expect(preservationBlock).toContain("--secret-id kortix-staging-env");
+    expect(preservationBlock).toContain("staging_secret_exists=true");
+    expect(preservationBlock).toContain("else");
+    expect(preservationBlock).toContain("--secret-id kortix-dev-env");
+    expect(preservationBlock).toContain("staging_secret_exists=false");
     expect(workflow).toContain('if [ "$staging_secret_exists" = true ]; then');
   });
 
-  it('caps the staging ECS API database pool below the 60-connection database limit', () => {
+  it("caps the staging ECS API database pool below the 60-connection database limit", () => {
     const workflow = readFileSync(
-      resolve(import.meta.dirname, '../../.github/workflows/deploy-staging.yml'),
-      'utf8',
+      resolve(
+        import.meta.dirname,
+        "../../.github/workflows/deploy-staging.yml",
+      ),
+      "utf8",
     );
     expect(workflow).toContain('DB_POOL_MAX: "4"');
   });


### PR DESCRIPTION
The staging deploy failed before any mutation because `sync-secret` referenced `${{ env.ROLE }}` without defining it. The later ECS job already defines the same deploy role.

This adds the missing job-scoped role and a regression test that pins both the role and `role-to-assume` wiring.

Evidence:
- failed run: https://github.com/kortix-ai/suna/actions/runs/30769702823
- focused Vitest: 3 pass / 0 fail
- Prettier check: pass
- `git diff --check`: pass
