### PR TITLE
fix(sessions): recognize Veyris title placeholder

### DIFF
--- a/apps/api/src/__tests__/integration-session-title-claim.test.ts
+++ b/apps/api/src/__tests__/integration-session-title-claim.test.ts
@@ -92,6 +92,10 @@ describe('persistTitle — compare-and-set', () => {
     await persistTitle(row, 'Generated Title');
     expect((await metadataOf(row.sessionId)).name).toBe('Generated Title');
 
+    const veyris = await seed({ name: 'New agent' });
+    await persistTitle(veyris, 'Generated Veyris Title');
+    expect((await metadataOf(veyris.sessionId)).name).toBe('Generated Veyris Title');
+
     // …but a real title that merely starts with the word "New" is not.
     const near = await seed({ name: 'New sessions of work' });
     await persistTitle(near, 'Generated Title');

--- a/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
+++ b/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
@@ -213,6 +213,11 @@ describe('serializeSession ⇄ ProjectSessionSchema', () => {
     );
     expect(placeholder.name).toBeNull();
 
+    const veyrisPlaceholder = ProjectSessionSchema.strict().parse(
+      serializeSession(sessionRow({ metadata: { name: 'New agent' } })),
+    );
+    expect(veyrisPlaceholder.name).toBeNull();
+
     const real = ProjectSessionSchema.strict().parse(
       serializeSession(sessionRow({ metadata: { name: 'Set Up MS Graph' } })),
     );

--- a/apps/api/src/__tests__/unit-session-title-generate.test.ts
+++ b/apps/api/src/__tests__/unit-session-title-generate.test.ts
@@ -50,6 +50,7 @@ describe('sanitizeGeneratedTitle', () => {
     expect(sanitizeGeneratedTitle('   ')).toBeNull();
     expect(sanitizeGeneratedTitle(null)).toBeNull();
     expect(sanitizeGeneratedTitle('New session - 2026-07-28')).toBeNull();
+    expect(sanitizeGeneratedTitle('New agent')).toBeNull();
   });
 });
 
@@ -147,6 +148,11 @@ describe('PLACEHOLDER_TITLE_SQL_PATTERN', () => {
       'New sessions of work',
       'Newsession',
       'New session planning doc',
+      'New agent',
+      'NEW AGENT',
+      'New agent - Aug 3',
+      'New agents at work',
+      'New agent planning doc',
       'Set Up MS Graph',
       '',
     ];
@@ -242,7 +248,7 @@ describe('generateSessionTitleFromFirstPrompt', () => {
     expect(h.generateCalls()).toBe(0);
   });
 
-  it('skips a user-named session (custom_name) but re-titles a placeholder name', async () => {
+  it('skips a user-named session (custom_name) but re-titles placeholder names', async () => {
     const custom = harness({
       row: row({ custom_name: 'My Name', opencode_model: 'codex/gpt-5.6-sol' }),
     });
@@ -254,6 +260,12 @@ describe('generateSessionTitleFromFirstPrompt', () => {
     });
     await generateSessionTitleFromFirstPrompt(input, placeholder.options);
     expect(placeholder.persisted).toEqual(['Set Up MS Graph']);
+
+    const veyrisPlaceholder = harness({
+      row: row({ name: 'New agent', opencode_model: 'codex/gpt-5.6-sol' }),
+    });
+    await generateSessionTitleFromFirstPrompt(input, veyrisPlaceholder.options);
+    expect(veyrisPlaceholder.persisted).toEqual(['Set Up MS Graph']);
   });
 
   it('falls back to a resolved SERVABLE model when neither the turn nor the row names one', async () => {

--- a/apps/api/src/projects/lib/opencode-title.ts
+++ b/apps/api/src/projects/lib/opencode-title.ts
@@ -1,5 +1,6 @@
 /**
- * OpenCode's default title for a brand-new session ("New session - <date>").
+ * Default titles for a brand-new session ("New session - <date>" and the
+ * historical Veyris "New agent").
  * It is NOT a real title: OpenCode stamps it before its summarizer produces the
  * real one, and if it were persisted as `metadata.name` it would freeze junk
  * into the sidebar. Session titles are now Kortix-owned (see
@@ -8,7 +9,7 @@
  * the serializer and the title generator.
  */
 export function isPlaceholderOpencodeTitle(title: string | null | undefined): boolean {
-  return typeof title === 'string' && /^new session\b/i.test(title.trim());
+  return typeof title === 'string' && /^new (?:session|agent)\b/i.test(title.trim());
 }
 
 /**
@@ -17,4 +18,4 @@ export function isPlaceholderOpencodeTitle(title: string | null | undefined): bo
  * `[^[:alnum:]_]` is the POSIX spelling of JavaScript's `\b` word boundary.
  * Kept in lockstep by unit test.
  */
-export const PLACEHOLDER_TITLE_SQL_PATTERN = '^new session([^[:alnum:]_]|$)';
+export const PLACEHOLDER_TITLE_SQL_PATTERN = '^new (session|agent)([^[:alnum:]_]|$)';

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -4249,9 +4249,30 @@ same RED, GREEN, and REFACTOR sequence directly.
 
 Required SDK gates are typecheck, the full test suite, and packed-install smoke.
 
-**Status:** IN PROGRESS.
+RED evidence:
 
-**SDK package shippable to production: NOT YET.**
+- The focused SDK test failed because `New agent` stopped the refresh loop.
+- The focused API tests failed because serializers and title generation treated
+  `New agent` as a real title.
+
+GREEN evidence:
+
+- `pnpm --filter @kortix/sdk typecheck`: exit `0`.
+- `pnpm --filter @kortix/sdk test`: `1390 pass`, `0 fail`, and
+  `5971 expect() calls` across `117` files.
+- `pnpm --filter @kortix/sdk run smoke:install`: exit `0`.
+- API unit suite: `5074 pass`, `62 skip`, `0 fail`, and
+  `20505 expect() calls` across `500` files.
+- Focused real-PostgreSQL integration:
+  `11 pass`, `0 fail`, and `27 expect() calls`.
+
+No public field, type, export, or signature changed.
+
+**Status:** COMPLETE.
+
+**SDK package shippable to production: YES.**
+
+**Repository code shippable to production: YES.**
 
 ---
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -5357,3 +5357,24 @@ SDK gates:
 
 **Repository delivery shippable to production: NOT YET.**
 The PR, merge, Deploy Dev, and Essentia verification remain.
+
+---
+
+### 2026-08-03 — session `session-title-source-of-truth` claim
+
+No **Now** task claimed. This is a narrow cross-host session-title bug fix.
+
+Scope:
+
+- Treat Veyris's historical `New agent` name as a Kortix placeholder.
+- Keep the SDK title-refresh loop active until Kortix replaces that placeholder.
+- Preserve all published names and signatures.
+
+The required `tdd` skill is unavailable in this session. The work will use the
+same RED, GREEN, and REFACTOR sequence directly.
+
+Required SDK gates are typecheck, the full test suite, and packed-install smoke.
+
+**Status:** IN PROGRESS.
+
+**SDK package shippable to production: NOT YET.**

--- a/packages/sdk/src/react/session-title-sync.test.ts
+++ b/packages/sdk/src/react/session-title-sync.test.ts
@@ -54,6 +54,17 @@ describe('reconcileHydratedSessionTitle', () => {
     ]);
   });
 
+  test("keeps refetching Veyris's historical New agent placeholder", async () => {
+    const { client, refetched } = titleQueryClient('New agent');
+
+    const resolved = await reconcileHydratedSessionTitle(client, 'project-1', 'session-1', 1, {
+      delaysMs: [0],
+    });
+
+    expect(resolved).toBe(true);
+    expect(refetched).toHaveLength(2);
+  });
+
   test('does not poll an empty conversation or a session that already has a title', async () => {
     const empty = titleQueryClient(null);
     const titled = titleQueryClient('Existing Title');

--- a/packages/sdk/src/react/session-title-sync.ts
+++ b/packages/sdk/src/react/session-title-sync.ts
@@ -12,7 +12,7 @@ const DEFAULT_TITLE_REFRESH_DELAYS_MS = [0, 5_000, 5_000, 10_000, 10_000, 15_000
 
 function readRealTitle(value: unknown): string | null {
   const title = typeof value === 'string' ? value.trim() : '';
-  if (!title || /^new session\b/i.test(title)) return null;
+  if (!title || /^new (?:session|agent)\b/i.test(title)) return null;
   return title;
 }
 


### PR DESCRIPTION
## Problem

Veyris historically created Kortix sessions with `name: "New agent"`. Kortix treated that placeholder as a completed title, so first-prompt title generation and SDK refresh stopped.

## Changes

- Treat `New agent` as a placeholder in API serialization, generation, and compare-and-set persistence.
- Keep the SDK title-refresh loop active for this placeholder.
- Add API, SDK, serializer, SQL integration, and regression coverage.

## Verification

- `pnpm --filter @kortix/sdk typecheck`
- `pnpm --filter @kortix/sdk test` — 1390 passed
- `pnpm --filter @kortix/sdk run smoke:install`
- API unit suite — 5074 passed, 62 skipped
- PostgreSQL integration — 11 passed, 27 assertions

**SDK package shippable to production: YES.**