### PR TITLE
fix(sessions): retry title generation with fallback model

### DIFF
--- a/apps/api/src/__tests__/unit-session-title-generate.test.ts
+++ b/apps/api/src/__tests__/unit-session-title-generate.test.ts
@@ -229,6 +229,25 @@ describe('generateSessionTitleFromFirstPrompt', () => {
     expect(h.models).toEqual(['glm-5.2']);
   });
 
+  it('retries once with the servable fallback when the session model is rejected', async () => {
+    const attempts: string[] = [];
+    const h = harness({
+      row: row({ opencode_model: 'anthropic/claude-opus-4-8' }),
+      fallbackModel: async () => 'glm-5.2',
+      generate: async (model) => {
+        attempts.push(model);
+        return model === 'glm-5.2' ? '"Fallback Title"' : null;
+      },
+    });
+
+    await generateSessionTitleFromFirstPrompt(input, h.options);
+
+    expect(attempts).toEqual(['anthropic/claude-opus-4-8', 'glm-5.2']);
+    expect(h.persisted).toEqual(['Fallback Title']);
+    expect(h.minted).toEqual(['k']);
+    expect(h.revoked).toEqual(['key-1']);
+  });
+
   it('generates, sanitizes, and persists a title; always revokes the key', async () => {
     const h = harness();
     await generateSessionTitleFromFirstPrompt(

--- a/apps/api/src/projects/session-title-generate.ts
+++ b/apps/api/src/projects/session-title-generate.ts
@@ -256,7 +256,10 @@ function platformDefaultModel(): string | null {
  * session untitled anyway. Skipping cheaply is the honest outcome.
  *
  */
-async function resolveFallbackModel(input: GenerateSessionTitleInput): Promise<string | null> {
+async function resolveFallbackModel(
+  input: GenerateSessionTitleInput,
+  excludedModel?: string,
+): Promise<string | null> {
   const [{ getCachedAccountTier }, { tierGrantsAllModels }, resolution] = await Promise.all([
     import('../billing/services/entitlements'),
     import('../billing/services/tiers'),
@@ -271,10 +274,14 @@ async function resolveFallbackModel(input: GenerateSessionTitleInput): Promise<s
       : false,
   };
   const resolved = await resolution.resolveEffectiveModel({ ...scope, explicit: null });
-  const candidate = resolved.model ?? platformDefaultModel();
-  if (!candidate) return null;
-  const model = toWireModel(candidate);
-  return (await resolution.isModelServableForAccount({ ...scope, model })) ? model : null;
+  const candidates = [resolved.model, platformDefaultModel()];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const model = toWireModel(candidate);
+    if (model === excludedModel) continue;
+    if (await resolution.isModelServableForAccount({ ...scope, model })) return model;
+  }
+  return null;
 }
 
 /** The model the session was started with, in gateway wire form. */
@@ -346,7 +353,10 @@ export interface GenerateSessionTitleOptions {
   ) => Promise<{ secret: string; keyId: string } | null>;
   revokeKey?: (projectId: string, keyId: string) => Promise<void>;
   persist?: (row: ProjectSessionRow, title: string) => Promise<void>;
-  fallbackModel?: (input: GenerateSessionTitleInput) => Promise<string | null>;
+  fallbackModel?: (
+    input: GenerateSessionTitleInput,
+    excludedModel?: string,
+  ) => Promise<string | null>;
 }
 
 /**
@@ -415,6 +425,19 @@ export async function generateSessionTitleFromFirstPrompt(
     let title: string | null = null;
     try {
       title = sanitizeGeneratedTitle(await generate(model, `Bearer ${minted.secret}`, promptText));
+      if (!title) {
+        const retryModel = await fallbackModel(input, model);
+        if (retryModel && retryModel !== model) {
+          appLogger.warn('[title-generate] retrying with servable fallback model', {
+            sessionId: input.sessionId,
+            rejectedModel: model,
+            retryModel,
+          });
+          title = sanitizeGeneratedTitle(
+            await generate(retryModel, `Bearer ${minted.secret}`, promptText),
+          );
+        }
+      }
     } finally {
       await revoke(input.projectId, minted.keyId).catch(() => {});
     }


### PR DESCRIPTION
## Problem

The session title hook uses the active session model. A gateway rejection leaves the canonical title empty, so Veyris keeps showing `New agent`.

## Change

- retry title generation once when the session model returns no valid title
- prefer the account default when it differs from the rejected model
- fall back to the servable platform default
- reuse and revoke the same temporary gateway key

## Verification

- `bun test src/__tests__/unit-session-title-generate.test.ts`: 25 pass, 0 fail
- full API suite: 5075 pass, 62 skip, 0 fail
- API typecheck: pass
- TDD red proof: the new test first observed only `anthropic/claude-opus-4-8` before the retry implementation