### PR TITLE
fix(sessions): bound title generation fallback

### DIFF
--- a/apps/api/src/__tests__/unit-session-title-generate.test.ts
+++ b/apps/api/src/__tests__/unit-session-title-generate.test.ts
@@ -248,6 +248,48 @@ describe('generateSessionTitleFromFirstPrompt', () => {
     expect(h.revoked).toEqual(['key-1']);
   });
 
+  it('uses the first prompt as a deterministic title when both model attempts fail', async () => {
+    const h = harness({
+      row: row({ opencode_model: 'anthropic/claude-opus-4-8' }),
+      fallbackModel: async () => 'glm-5.2',
+      generate: async () => null,
+    });
+
+    await generateSessionTitleFromFirstPrompt(input, h.options);
+
+    expect(h.persisted).toEqual(['Please set up the MS Graph OAuth2 connector']);
+    expect(h.revoked).toEqual(['key-1']);
+  });
+
+  it('never turns a placeholder-shaped first prompt back into the placeholder', async () => {
+    const h = harness({ generate: async () => null });
+
+    await generateSessionTitleFromFirstPrompt(
+      { ...input, firstPromptText: 'New agent planning document' },
+      h.options,
+    );
+
+    expect(h.persisted).toEqual(['Topic: New agent planning document']);
+  });
+
+  it(
+    'bounds model attempts and uses the deterministic title when the gateway hangs',
+    async () => {
+      const h = harness({
+        row: row({ opencode_model: 'anthropic/claude-opus-4-8' }),
+        fallbackModel: async () => 'glm-5.2',
+        generate: async () => new Promise<string | null>(() => {}),
+      });
+      const options = { ...h.options, generationTimeoutMs: 5 } as GenerateSessionTitleOptions;
+
+      await generateSessionTitleFromFirstPrompt(input, options);
+
+      expect(h.persisted).toEqual(['Please set up the MS Graph OAuth2 connector']);
+      expect(h.revoked).toEqual(['key-1']);
+    },
+    200,
+  );
+
   it('generates, sanitizes, and persists a title; always revokes the key', async () => {
     const h = harness();
     await generateSessionTitleFromFirstPrompt(
@@ -299,13 +341,13 @@ describe('generateSessionTitleFromFirstPrompt', () => {
 
   it('spends NOTHING when no model is servable — free tier, or no managed provider', async () => {
     // The unconditional platform default is a managed id: on a free tier (or a
-    // deployment with no managed provider) the gateway refuses it, so minting a
-    // key and calling would be a doomed, billed, untitled loop on every prompt.
+    // deployment with no managed provider) the gateway refuses it. The prompt
+    // excerpt still titles the session without minting a key or calling a model.
     const h = harness({ row: row({}), fallbackModel: async () => null });
     await generateSessionTitleFromFirstPrompt(input, h.options);
     expect(h.models).toEqual([]);
     expect(h.minted).toEqual([]);
-    expect(h.persisted).toEqual([]);
+    expect(h.persisted).toEqual(['Please set up the MS Graph OAuth2 connector']);
   });
 
   it('precedence: modelHint beats opencode_model beats the resolved fallback', async () => {
@@ -405,7 +447,7 @@ describe('generateSessionTitleFromFirstPrompt', () => {
       },
     });
     await generateSessionTitleFromFirstPrompt(input, h.options);
-    expect(h.persisted).toEqual([]);
+    expect(h.persisted).toEqual(['Please set up the MS Graph OAuth2 connector']);
     expect(h.revoked).toEqual(['key-1']);
   });
 

--- a/apps/api/src/projects/session-title-generate.ts
+++ b/apps/api/src/projects/session-title-generate.ts
@@ -23,13 +23,15 @@ import { projectSessionMetadataMerge } from './lib/session-metadata-merge';
 //     baked into the sandbox and runs in-guest, so create is its only chance;
 //   - first HTTP prompt: sessions created empty (the whole web UI, warm claim,
 //     CLI/SDK) carry their first prompt as an OpenCode REST request body.
-// One short call to the internal LLM gateway over just that text. Nothing else
-// writes `metadata.name`.
+// At most two bounded calls to the internal LLM gateway use only that text. A
+// deterministic prompt excerpt guarantees a title when both calls fail.
+// Nothing else writes `metadata.name`.
 //
 // Fire-and-forget by contract: idempotent, best-effort, and it never blocks or
 // fails the request it hangs off.
 
 const MAX_TITLE_LENGTH = 64;
+const DEFAULT_GENERATION_TIMEOUT_MS = 15_000;
 // OpenAI-compatible reasoning models count hidden reasoning and visible text
 // against the same output ceiling. A 24-token ceiling let the managed
 // DeepSeek fallback spend every token on reasoning and return empty content.
@@ -82,6 +84,29 @@ export function sanitizeGeneratedTitle(raw: string | null | undefined): string |
   if (title.length > MAX_TITLE_LENGTH) title = title.slice(0, MAX_TITLE_LENGTH).trim();
   if (!title || isPlaceholderOpencodeTitle(title)) return null;
   return title;
+}
+
+/** Last-resort title when every configured model fails. Keep the first prompt
+ * recognizable, but bound it to a sidebar-sized phrase. */
+function deterministicTitleFromPrompt(raw: string): string | null {
+  const normalized = raw
+    .replace(/^[\s#>*`"'-]+/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized) return null;
+
+  const words = normalized.split(' ');
+  let candidate = '';
+  for (const word of words.slice(0, 8)) {
+    const next = candidate ? `${candidate} ${word}` : word;
+    if (next.length > MAX_TITLE_LENGTH) break;
+    candidate = next;
+  }
+  if (!candidate) candidate = normalized.slice(0, MAX_TITLE_LENGTH);
+  candidate = candidate.replace(/[\s.,!?;:'"`-]+$/, '').trim();
+  if (!candidate) return null;
+  if (isPlaceholderOpencodeTitle(candidate)) candidate = `Topic: ${candidate}`;
+  return sanitizeGeneratedTitle(candidate);
 }
 
 export interface PromptInfo {
@@ -252,8 +277,8 @@ function platformDefaultModel(): string | null {
  * ever a model the gateway will actually serve for this account+project. The
  * unconditional platform default is a trap: it is a MANAGED id, so on a free
  * tier (or a deployment with no managed provider) the gateway refuses it and
- * every prompt pays a mint → doomed completion → revoke, forever, leaving the
- * session untitled anyway. Skipping cheaply is the honest outcome.
+ * every prompt pays a mint → doomed completion → revoke. The caller skips that
+ * spend and persists its deterministic prompt excerpt instead.
  *
  */
 async function resolveFallbackModel(
@@ -357,6 +382,41 @@ export interface GenerateSessionTitleOptions {
     input: GenerateSessionTitleInput,
     excludedModel?: string,
   ) => Promise<string | null>;
+  generationTimeoutMs?: number;
+}
+
+async function generateWithDeadline(
+  generate: NonNullable<GenerateSessionTitleOptions['generate']>,
+  model: string,
+  authorization: string,
+  promptText: string,
+  sessionId: string,
+  timeoutMs: number,
+): Promise<string | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  try {
+    const timeout = new Promise<null>((resolve) => {
+      timer = setTimeout(() => {
+        timedOut = true;
+        resolve(null);
+      }, Math.max(1, timeoutMs));
+    });
+    const result = await Promise.race([generate(model, authorization, promptText), timeout]);
+    if (timedOut) {
+      appLogger.warn('[title-generate] model attempt timed out', { sessionId, model, timeoutMs });
+    }
+    return result;
+  } catch (err) {
+    appLogger.warn('[title-generate] model attempt failed', {
+      sessionId,
+      model,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /**
@@ -396,6 +456,7 @@ export async function generateSessionTitleFromFirstPrompt(
   const revoke =
     options.revokeKey ?? ((projectId, keyId) => deleteGatewayKey(projectId, keyId).then(() => {}));
   const fallbackModel = options.fallbackModel ?? resolveFallbackModel;
+  const generationTimeoutMs = options.generationTimeoutMs ?? DEFAULT_GENERATION_TIMEOUT_MS;
 
   try {
     const row = await load(input.sessionId, input.projectId);
@@ -413,33 +474,57 @@ export async function generateSessionTitleFromFirstPrompt(
     // only the last resort has to prove itself.
     const model =
       input.modelHint?.trim() || sessionModel(row) || (await fallbackModel(input)) || null;
+    let title: string | null = null;
     if (!model) {
       appLogger.warn('[title-generate] no servable model to title with', {
         sessionId: input.sessionId,
       });
-      return;
-    }
-
-    const minted = await mint(input.accountId, input.projectId, input.userId);
-    if (!minted) return;
-    let title: string | null = null;
-    try {
-      title = sanitizeGeneratedTitle(await generate(model, `Bearer ${minted.secret}`, promptText));
-      if (!title) {
-        const retryModel = await fallbackModel(input, model);
-        if (retryModel && retryModel !== model) {
-          appLogger.warn('[title-generate] retrying with servable fallback model', {
-            sessionId: input.sessionId,
-            rejectedModel: model,
-            retryModel,
-          });
+    } else {
+      const minted = await mint(input.accountId, input.projectId, input.userId);
+      if (minted) {
+        try {
           title = sanitizeGeneratedTitle(
-            await generate(retryModel, `Bearer ${minted.secret}`, promptText),
+            await generateWithDeadline(
+              generate,
+              model,
+              `Bearer ${minted.secret}`,
+              promptText,
+              input.sessionId,
+              generationTimeoutMs,
+            ),
           );
+          if (!title) {
+            const retryModel = await fallbackModel(input, model);
+            if (retryModel && retryModel !== model) {
+              appLogger.warn('[title-generate] retrying with servable fallback model', {
+                sessionId: input.sessionId,
+                rejectedModel: model,
+                retryModel,
+              });
+              title = sanitizeGeneratedTitle(
+                await generateWithDeadline(
+                  generate,
+                  retryModel,
+                  `Bearer ${minted.secret}`,
+                  promptText,
+                  input.sessionId,
+                  generationTimeoutMs,
+                ),
+              );
+            }
+          }
+        } finally {
+          await revoke(input.projectId, minted.keyId).catch(() => {});
         }
       }
-    } finally {
-      await revoke(input.projectId, minted.keyId).catch(() => {});
+    }
+    if (!title) {
+      title = deterministicTitleFromPrompt(promptText);
+      if (title) {
+        appLogger.warn('[title-generate] using deterministic prompt fallback', {
+          sessionId: input.sessionId,
+        });
+      }
     }
     if (!title) return;
 


### PR DESCRIPTION
## Problem

The session model returns 400. The servable fallback can hang indefinitely. The title worker then keeps its in-flight lock and the canonical title stays empty.

## Change

- bound each model attempt to 15 seconds
- retry once with a different servable model
- persist a bounded first-prompt excerpt when both attempts fail or no model is servable
- preserve compare-and-set rename safety
- delete the temporary gateway key after the bounded attempts

## Verification

- focused title suite: 28 pass, 0 fail
- full API suite: 5078 pass, 62 skip, 0 fail
- API typecheck: pass
- TDD red proof: the hanging-gateway test timed out at 200ms before the deadline implementation
- CloudWatch live evidence: session model returned 400 and `glm-5.2` fallback remained unresolved