### PR TITLE
feat(llm-catalog): add Kimi K3 as a managed Kortix model via AsterLab

### DIFF
--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -140,7 +140,7 @@ describe('gatewayModelCatalog — free-tier visibility', () => {
 
   test('free tier sees no managed Kortix models', () => {
     expect(freeFull.auto).toBeUndefined();
-    for (const id of ['claude-opus-4.8', 'claude-sonnet-4.6', 'glm-5.2', 'deepseek-v4-flash']) {
+    for (const id of ['claude-opus-4.8', 'claude-sonnet-4.6', 'glm-5.2', 'kimi-k3', 'deepseek-v4-flash']) {
       expect(freeFull[id], id).toBeUndefined();
     }
   });

--- a/apps/kortix-sandbox-agent-server/src/__tests__/fallback-catalog-capabilities.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/fallback-catalog-capabilities.test.ts
@@ -6,6 +6,13 @@ describe('MINIMAL_FALLBACK_MODELS capability metadata', () => {
     expect(MINIMAL_FALLBACK_MODELS['openai/gpt-5.5']?.temperature).toBe(false)
   })
 
+  // Kimi K3 (managed, aster transport) is temperature:false on models.dev —
+  // advertising support would make OpenCode send a `temperature` and 400 the
+  // turn, the same regression class as the OpenAI reasoning-model guard below.
+  test('kimi-k3 (managed aster) does not advertise temperature support', () => {
+    expect(MINIMAL_FALLBACK_MODELS['kimi-k3']?.temperature).toBe(false)
+  })
+
   test('no OpenAI reasoning model in the fallback catalog claims temperature support', () => {
     const offenders = Object.entries(MINIMAL_FALLBACK_MODELS)
       .filter(([id, model]) => id.startsWith('openai/') && model.reasoning && model.temperature)
@@ -20,6 +27,7 @@ describe('MINIMAL_FALLBACK_MODELS capability metadata', () => {
   test('every fallback model carries an explicit `provider` field matching its wire id', () => {
     expect(MINIMAL_FALLBACK_MODELS['claude-opus-4.8']?.provider).toBe('kortix')
     expect(MINIMAL_FALLBACK_MODELS['glm-5.2']?.provider).toBe('kortix')
+    expect(MINIMAL_FALLBACK_MODELS['kimi-k3']?.provider).toBe('kortix')
     expect(MINIMAL_FALLBACK_MODELS['openai/gpt-5.5']?.provider).toBe('openai')
     expect(MINIMAL_FALLBACK_MODELS['google/gemini-3.5-flash']?.provider).toBe('google')
     expect(MINIMAL_FALLBACK_MODELS['deepseek/deepseek-v4-flash']?.provider).toBe('deepseek')

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -700,6 +700,21 @@ export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
     temperature: true,
     limit: { context: 1_000_000, output: 131_072 },
   },
+  // Second Kortix-managed AsterLab model (Kimi K3). Same `kortix` provider
+  // branding + `aster` transport (ASTER_API_KEY) as GLM 5.2.
+  // `temperature:false` — models.dev advertises Kimi K3 as
+  // `temperature:false` (it rejects a client-sent temperature), matching
+  // capabilitiesOf() in the served catalog. Must NOT advertise temperature
+  // support or OpenCode sends one and 400s the turn.
+  'kimi-k3': {
+    name: 'Kimi K3',
+    provider: 'kortix',
+    reasoning: true,
+    tool_call: true,
+    attachment: true,
+    temperature: false,
+    limit: { context: 1_048_576, output: 131_072 },
+  },
   'openai/gpt-5.5': {
     name: 'GPT-5.5',
     provider: 'openai',

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -557,6 +557,32 @@ export const MANAGED_MODELS: ManagedModel[] = [
     limit: { context: 1_000_000, output: 131_072 },
   },
   {
+    // Kimi K3 (Moonshot AI) served through AsterLab's OpenAI-compatible
+    // endpoint — same `aster` transport + ASTER_API_KEY as GLM 5.2, so no new
+    // credential is needed. AsterLab accepts the bare `kimi-k3` slug on
+    // https://api.asterlab.ai/v1/chat/completions. `pricingRef` resolves to a
+    // REAL models.dev entry (moonshotai/kimi-k3), so capability lookups borrow
+    // the real reasoning_options (toggle + effort low/high/max) and
+    // temperature:false (K3 rejects a client-sent temperature) instead of the
+    // permissive synthetic fallback. `pricing` is the published Moonshot
+    // upstream rate ($3/$15, $0.30 cache read); Aster is an OpenAI-compatible
+    // proxy — verify against Aster's own price list and adjust via the
+    // LLM_GATEWAY_MANAGED_MODELS overlay if Aster's rate differs.
+    id: 'kimi-k3',
+    name: 'Kimi K3',
+    upstreamModelId: 'kimi-k3',
+    transport: 'aster',
+    pricingRef: 'moonshotai/kimi-k3',
+    pricing: {
+      inputPerMillion: 3,
+      cachedInputPerMillion: 0.3,
+      outputPerMillion: 15,
+    },
+    tier: 'balanced',
+    vision: true,
+    limit: { context: 1_048_576, output: 131_072 },
+  },
+  {
     id: 'deepseek-v4-flash',
     name: 'DeepSeek V4 Flash',
     upstreamModelId: 'deepseek/deepseek-v4-flash',

--- a/packages/llm-catalog/src/managed.test.ts
+++ b/packages/llm-catalog/src/managed.test.ts
@@ -15,6 +15,7 @@ describe('managed catalog', () => {
       'claude-opus-4.8',
       'claude-sonnet-4.6',
       'glm-5.2',
+      'kimi-k3',
       'deepseek-v4-flash',
     ]);
   });
@@ -102,8 +103,10 @@ describe('managed catalog', () => {
         // OpenRouter slugs are provider/model.
         expect(m.upstreamModelId, `${m.id} OpenRouter slug`).toContain('/');
       } else {
+        // AsterLab accepts a bare, slash-free upstream model id on its
+        // OpenAI-compatible endpoint (e.g. `glm-5.2`, `kimi-k3`).
         expect(m.transport, `${m.id} transport`).toBe('aster');
-        expect(m.upstreamModelId, `${m.id} AsterLab model`).toBe('glm-5.2');
+        expect(m.upstreamModelId, `${m.id} AsterLab slug`).toMatch(/^[^/]+$/);
       }
     }
   });
@@ -128,6 +131,16 @@ describe('managed resolution + back-compat aliases', () => {
       cachedInputPerMillion: 0.2,
       cacheWritePerMillion: 1,
       outputPerMillion: 4,
+    });
+    expect(getManagedModel('kimi-k3')?.name).toBe('Kimi K3');
+    expect(getManagedModel('kimi-k3')?.transport).toBe('aster');
+    expect(getManagedModel('kimi-k3')?.upstreamModelId).toBe('kimi-k3');
+    expect(getManagedModel('kimi-k3')?.vision).toBe(true);
+    expect(getManagedModel('kimi-k3')?.limit).toEqual({ context: 1_048_576, output: 131_072 });
+    expect(getManagedModel('kimi-k3')?.pricing).toEqual({
+      inputPerMillion: 3,
+      cachedInputPerMillion: 0.3,
+      outputPerMillion: 15,
     });
     expect(getManagedModel('deepseek-v4-flash')?.providerBrand).toBeUndefined();
     expect(getManagedModel('deepseek-v4-flash')?.pricing).toEqual({

--- a/packages/sdk/playground/chat/14-change-default-model.ts
+++ b/packages/sdk/playground/chat/14-change-default-model.ts
@@ -29,6 +29,7 @@ const MODEL_IDS = [
   "claude-opus-4.8",
   "claude-sonnet-4.6",
   "glm-5.2",
+  "kimi-k3",
   "deepseek-v4-flash",
 ] as const;
 


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. This adds a managed model catalog entry; the proof is the test run + the served `/v1/models` catalog.

**Proof — `kimi-k3` resolves as a managed Kortix model via the `aster` transport:**
```
$ bun test --filter @kortix/llm-catalog
  72 pass, 0 fail   (managed lineup now lists kimi-k3; transport-shape test passes;
                      getManagedModel('kimi-k3') → {transport:'aster', upstream:'kimi-k3', vision:true, ...})

$ bun test apps/api .../managed-models,managed-transport-credential-missing,picker,catalog-models,model-pricing
  61 pass, 0 fail   (kimi-k3 served when ASTER_API_KEY present, dropped when absent — same gate as glm-5.2;
                      free-tier paywall covers kimi-k3)

$ bun test apps/kortix-sandbox-agent-server fallback-catalog-capabilities
  6 pass, 0 fail    (kimi-k3 in MINIMAL_FALLBACK_MODELS, provider='kortix', temperature=false)
```

On the preview, `kortix/kimi-k3` will appear in the model picker under the Kortix managed group and resolve through `ASTER_API_KEY` → `https://api.asterlab.ai/v1/chat/completions` with `model: "kimi-k3"`.

## Why
Marko asked to add Kimi K3 via Aster to the managed Kortix lineup (Slack). AsterLab already serves GLM 5.2 as a managed model over the `aster` transport; Kimi K3 uses the same transport and the same `ASTER_API_KEY`, so it slots in with zero new credentials.

## What changed
- `packages/llm-catalog/src/index.ts` — new `kimi-k3` entry in `MANAGED_MODELS`, mirroring `glm-5.2`: `transport:'aster'`, `upstreamModelId:'kimi-k3'`, `pricingRef:'moonshotai/kimi-k3'` (a real models.dev entry → real `reasoning_options` + `temperature:false`), pricing `$3/$15` per M / `$0.30` cache read, `vision:true`, 1M context / 131_072 output, `tier:'balanced'`.
- `apps/kortix-sandbox-agent-server/src/opencode.ts` — added `kimi-k3` to `MINIMAL_FALLBACK_MODELS` (`provider:'kortix'`, `temperature:false` per models.dev, `attachment:true`).
- `packages/llm-catalog/src/managed.test.ts` — lineup now includes `kimi-k3`; the `transport matches upstream id shape` test now matches a bare slash-free aster slug (was pinned to exactly `'glm-5.2'`); added resolution + pricing/vision/limit assertions for `kimi-k3`.
- `apps/api/src/llm-gateway/models/catalog-models.test.ts` — free-tier paywall enumeration includes `kimi-k3`.
- `apps/kortix-sandbox-agent-server/src/__tests__/fallback-catalog-capabilities.test.ts` — asserts `kimi-k3` provider + `temperature:false`.
- `packages/sdk/playground/chat/14-change-default-model.ts` — `MODEL_IDS` const (cross-checked against `MANAGED_MODELS` at runtime) includes `kimi-k3`.

Everything else (picker, SDK model-store, model-grouping, starter template guard, served catalog, billing/usage) derives dynamically from `MANAGED_MODELS` / `DEFAULT_MANAGED_MODEL_IDS`, so it picks up `kimi-k3` with no further edits.

## Verification
- `pnpm --filter @kortix/llm-catalog run typecheck` ✅
- `pnpm --filter @kortix/llm-catalog test` ✅ (72 pass)
- `pnpm --filter @kortix/sandbox-agent-server run typecheck` ✅
- `bun test apps/kortix-sandbox-agent-server src/__tests__/fallback-catalog-capabilities.test.ts` ✅ (6 pass)
- `pnpm --filter kortix-api run typecheck` ✅
- `bun test --env-file=scripts/test.env apps/api …/managed-models,managed-transport-credential-missing,managed-provider-disabled,picker,catalog-models,model-pricing` ✅ (61 pass)
- `bun test --env-file=scripts/test.env apps/api src/llm-gateway/resolution/` ✅ (84 pass)
- `pnpm --filter @kortix/starter test` ✅ (70 pass)
- `bun test apps/web …/model-pricing,gateway-routing,generation-controls,llm-provider/utils` ✅ (46 pass)
- The single CLI `--origin-ref` test failure is **pre-existing on `main`** (verified by `git stash` + rerun) and unrelated to this change.

## Risk / rollback
Low. One new catalog entry on an existing, credentialed transport (`aster`); no schema, migration, or new credential. If Aster's real price differs from Moonshot's published `$3/$15`, operators override via `LLM_GATEWAY_MANAGED_MODELS` without a redeploy of code. Revert is a single-commit `git revert`.
