### PR TITLE
fix(web): guard members-view query arrays with toArray before .filter/.map (BS f9603a43)

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/view/members-view-nonarray-guard.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view-nonarray-guard.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { toArray } from '@/features/workspace/customize/shared/utils';
+
+// Regression test for the Better Stack error pattern
+//   `f9603a4344ea892980086cc75a9f15d6457da1e8bfa88ffbcfa7b08f1c2dcb0b` —
+//   `TypeError: (intermediate value)(intermediate value)(intermediate value).filter is not a function`
+// thrown from the project layout chunk
+// (`app/(app)/projects/[id]/layout-b5947ecaa233b0d6.js`) at `Object.useMemo`.
+//
+// Root cause: the `ProjectGroupGrantsCard` component in members-view.tsx
+// derived `groupsWithCustomRole` inside a `useMemo` as
+//   `(policiesQuery.data ?? []).filter(...).map(...)`.
+// The IAM `listPolicies(accountId, { scopeId: projectId })` SDK call is typed
+// to return `IamPolicy[]`, but a 200 whose body yields a non-array `policies`
+// value (a backend shape gap, a partial response, an empty object) is a valid
+// HTTP outcome. `?? []` only absorbs `null`/`undefined`; a defined non-array
+// (e.g. `{}`) passes straight through, so `.filter` throws. The prod build
+// downlevels `??` to a ternary, which is what produces the
+// `(intermediate value)(intermediate value)(intermediate value).filter`
+// wording (three intermediate values = the inlined `(a ?? b).filter` ternary).
+//
+// The fix routes every `query.data ?? []` consumer in members-view.tsx through
+// `toArray(...)` (Array.isArray guard — absorbs undefined, null, AND non-array).
+// These tests (a) reproduce the exact prod throw on the unguarded path and
+// (b) keep a future refactor from silently restoring the `(x ?? []).filter`
+// shape via source-level assertions (same convention as chunk22256-guard.test.ts
+// and policies-panel.test.ts).
+
+const membersViewSource = readFileSync(
+  join(import.meta.dir, 'members-view.tsx'),
+  'utf8',
+);
+
+/**
+ * The exact derivation that threw in prod, lifted out of the useMemo so it can
+ * be exercised without a react-query harness. Mirrors the
+ * `ProjectGroupGrantsCard` `groupsWithCustomRole` derivation: filter the
+ * project-scoped group policies and collect their principal ids.
+ */
+function groupsWithCustomRoleFrom(policiesData: unknown, projectId: string): Set<string> {
+  return new Set(
+    toArray(policiesData)
+      .filter(
+        (p: any) =>
+          p.principal_type === 'group' &&
+          p.scope_type === 'project' &&
+          p.scope_id === projectId,
+      )
+      .map((p: any) => p.principal_id),
+  );
+}
+
+describe('members-view non-array guard — ProjectGroupGrantsCard derivation', () => {
+  test('does NOT throw on the exact prod failure shape: a defined non-array policies value', () => {
+    // The shape that fired in prod: `policiesQuery.data` is a defined non-array
+    // (e.g. an empty object or an error envelope). The old `(data ?? []).filter`
+    // path threw `(intermediate value)...filter is not a function` here.
+    expect(() => groupsWithCustomRoleFrom({}, 'p1')).not.toThrow();
+    expect(() => groupsWithCustomRoleFrom({ error: 'x' }, 'p1')).not.toThrow();
+    expect(() => groupsWithCustomRoleFrom('not-an-array', 'p1')).not.toThrow();
+    expect(() => groupsWithCustomRoleFrom(42, 'p1')).not.toThrow();
+    expect(groupsWithCustomRoleFrom({}, 'p1')).toEqual(new Set());
+  });
+
+  test('absorbs null/undefined (the ?? [] cases) without throwing', () => {
+    expect(() => groupsWithCustomRoleFrom(null, 'p1')).not.toThrow();
+    expect(() => groupsWithCustomRoleFrom(undefined, 'p1')).not.toThrow();
+    expect(groupsWithCustomRoleFrom(null, 'p1')).toEqual(new Set());
+    expect(groupsWithCustomRoleFrom(undefined, 'p1')).toEqual(new Set());
+  });
+
+  test('happy path: filters project-scoped group policies and collects principal ids', () => {
+    const policies = [
+      { principal_type: 'group', scope_type: 'project', scope_id: 'p1', principal_id: 'g1' },
+      { principal_type: 'group', scope_type: 'project', scope_id: 'p2', principal_id: 'g2' },
+      { principal_type: 'member', scope_type: 'project', scope_id: 'p1', principal_id: 'u1' },
+    ];
+    expect(groupsWithCustomRoleFrom(policies, 'p1')).toEqual(new Set(['g1']));
+  });
+});
+
+describe('members-view source guard — no unguarded (query.data ?? []).filter/.map', () => {
+  // The prod throw was a `(policiesQuery.data ?? []).filter(...)` inside a
+  // useMemo. Every query-data-derived array in this file must go through
+  // `toArray(...)` so a non-array response can never reach `.filter` / `.map`.
+  test('imports toArray from the shared customize utils', () => {
+    expect(membersViewSource).toContain('from \'@/features/workspace/customize/shared/utils\'');
+    expect(membersViewSource).toContain('toArray(');
+  });
+
+  test('ProjectGroupGrantsCard groupsWithCustomRole routes through toArray, not (data ?? []).filter', () => {
+    // The exact line that threw in prod.
+    expect(membersViewSource).not.toContain('(policiesQuery.data ?? []).filter(');
+    expect(membersViewSource).toContain('toArray(policiesQuery.data)');
+  });
+
+  test('no remaining unguarded (query.data ?? []).filter or .map in the file', () => {
+    // Any `(X ?? []).filter(` or `(X ?? []).map(` whose receiver is a query data
+    // field would re-open the same class of throw. Catch them all.
+    const unguarded = membersViewSource.match(/\(\w+Query\.data(?:\?\.\w+)? \?\? \[\]\)\.(?:filter|map)\(/g);
+    expect(unguarded).toBeNull();
+  });
+
+  test('no remaining unguarded query.data ?? [] used directly as a filtered/mapped array', () => {
+    // `const x = query.data ?? []` followed by `x.filter(` is safe ONLY for
+    // null/undefined; a non-array still throws. Guard these at the source too.
+    // (The members prop and the grants/policies/roles/agents/groups derivations
+    //  all now use toArray.)
+    const directAssign = membersViewSource.match(/=\s*\w+Query\.data(?:\?\.\w+)?\s*\?\s*\[\]/g);
+    // These are allowed only when the result is never .filter/.map'd directly
+    // (e.g. a `.length` count). Assert none remain that feed a .filter/.map.
+    expect(directAssign).toBeNull();
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
@@ -110,6 +110,7 @@ import {
 import { UsersIcon as UsersSolid } from '@phosphor-icons/react';
 import CustomizeSectionWrapper from '../component/section-wrapper';
 import { sortByRoleThenLabel } from '../member-sort';
+import { toArray } from '@/features/workspace/customize/shared/utils';
 
 const MEMBER_ROW = 'bg-popover flex items-center gap-3 rounded-md border px-4 py-2.5';
 
@@ -174,7 +175,7 @@ export function MembersView({ projectId }: { projectId: string }) {
         projectId={projectId}
         accountId={project?.account_id ?? null}
         canManage={!!canManage}
-        members={accessQuery.data?.members ?? []}
+        members={toArray(accessQuery.data?.members)}
         isLoading={accessQuery.isLoading}
         isError={accessQuery.isError}
         error={accessQuery.error as Error | null}
@@ -200,7 +201,7 @@ export function MembersView({ projectId }: { projectId: string }) {
           projectId={projectId}
           accountId={project.account_id}
           canManage={!!canManage}
-          members={accessQuery.data?.members ?? []}
+          members={toArray(accessQuery.data?.members)}
         />
       )}
 
@@ -209,7 +210,7 @@ export function MembersView({ projectId }: { projectId: string }) {
           projectId={projectId}
           accountId={project.account_id}
           canManage={!!canManage}
-          members={accessQuery.data?.members ?? []}
+          members={toArray(accessQuery.data?.members)}
         />
       )}
     </div>
@@ -1049,7 +1050,7 @@ function PendingAccessRequestsCard({ projectId }: { projectId: string }) {
     onError: (err: Error) => errorToast(err.message || 'Failed to decline request'),
   });
 
-  const requests = requestsQuery.data?.requests ?? [];
+  const requests = toArray(requestsQuery.data?.requests);
 
   if (!requestsQuery.isLoading && requests.length === 0) return null;
 
@@ -1197,7 +1198,7 @@ function PendingInvitesCard({ projectId }: { projectId: string }) {
     onError: (err: Error) => errorToast(err.message || 'Failed to resend invitation'),
   });
 
-  const pending = invitesQuery.data?.pending ?? [];
+  const pending = toArray(invitesQuery.data?.pending);
 
   if (!invitesQuery.isLoading && pending.length === 0) return null;
 
@@ -1383,7 +1384,7 @@ function ProjectGroupGrantsCard({
   const groupsWithCustomRole = useMemo(
     () =>
       new Set(
-        (policiesQuery.data ?? [])
+        toArray(policiesQuery.data)
           .filter(
             (p) =>
               p.principal_type === 'group' &&
@@ -1396,13 +1397,13 @@ function ProjectGroupGrantsCard({
   );
 
   const grants = useMemo(() => {
-    const raw = grantsQuery.data?.grants ?? [];
+    const raw = toArray(grantsQuery.data?.grants);
     return [...raw].sort((a, b) => {
       const t = a.created_at.localeCompare(b.created_at);
       return t !== 0 ? t : a.group_id.localeCompare(b.group_id);
     });
   }, [grantsQuery.data]);
-  const groups: AccountGroup[] = useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
+  const groups: AccountGroup[] = useMemo(() => toArray(groupsQuery.data), [groupsQuery.data]);
   const attachedIds = useMemo(() => new Set(grants.map((g) => g.group_id)), [grants]);
   const available = useMemo(
     () => groups.filter((g) => !attachedIds.has(g.group_id)),
@@ -1834,7 +1835,7 @@ function ResourceAccessCard({
 
   const resources = grantsQuery.data?.resources ?? { agents: [], skills: [], secrets: [] };
   const grants = useMemo(() => {
-    const raw = grantsQuery.data?.grants ?? [];
+    const raw = toArray(grantsQuery.data?.grants);
     return [...raw].sort((a, b) => {
       const t = a.resource_type.localeCompare(b.resource_type);
       if (t !== 0) return t;
@@ -1842,7 +1843,7 @@ function ResourceAccessCard({
       return r !== 0 ? r : a.principal_label.localeCompare(b.principal_label);
     });
   }, [grantsQuery.data]);
-  const groups: AccountGroup[] = useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
+  const groups: AccountGroup[] = useMemo(() => toArray(groupsQuery.data), [groupsQuery.data]);
 
   // Display name for a resource id (falls back to the id itself).
   const resourceName = useMemo(() => {
@@ -2233,23 +2234,23 @@ function ProjectRoleAssignmentsCard({
   // apply too, but they're managed on the account page, not per-project).
   const policies = useMemo(
     () =>
-      (policiesQuery.data ?? []).filter(
+      toArray(policiesQuery.data).filter(
         (p) => p.scope_type === 'project' && p.scope_id === projectId,
       ),
     [policiesQuery.data, projectId],
   );
   const customRoles = useMemo(
-    () => (rolesQuery.data ?? []).filter((r) => !r.is_system),
+    () => toArray(rolesQuery.data).filter((r) => !r.is_system),
     [rolesQuery.data],
   );
-  const groups = useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
+  const groups = useMemo(() => toArray(groupsQuery.data), [groupsQuery.data]);
   const projectAgents = useMemo(
-    () => (agentsQuery.data ?? []).filter((a) => a.project_id === projectId),
+    () => toArray(agentsQuery.data).filter((a) => a.project_id === projectId),
     [agentsQuery.data, projectId],
   );
 
   const roleNameById = useMemo(
-    () => new Map((rolesQuery.data ?? []).map((r) => [r.role_id, r.name])),
+    () => new Map(toArray(rolesQuery.data).map((r) => [r.role_id, r.name])),
     [rolesQuery.data],
   );
   const memberLabelById = useMemo(
@@ -2259,7 +2260,7 @@ function ProjectRoleAssignmentsCard({
   const groupNameById = useMemo(() => new Map(groups.map((g) => [g.group_id, g.name])), [groups]);
   const agentLabelById = useMemo(
     () =>
-      new Map((agentsQuery.data ?? []).map((a) => [a.service_account_id, a.agent_name ?? a.name])),
+      new Map(toArray(agentsQuery.data).map((a) => [a.service_account_id, a.agent_name ?? a.name])),
     [agentsQuery.data],
   );
 


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. The proof is the regression test below: it reproduces the exact prod throw on the unguarded path and confirms `toArray()` absorbs every bad shape.

## Why

A prod `TypeError: (intermediate value)(intermediate value)(intermediate value).filter is not a function` fired once on the project page (Better Stack pattern `f9603a4344ea892980086cc75a9f15d6457da1e8bfa88ffbcfa7b08f1c2dcb0b`, app_id 2346967, 2026-08-02 16:30 UTC, caught by the error boundary). The throw was inside a `useMemo` in the project layout chunk. Root cause: `ProjectGroupGrantsCard` derived `groupsWithCustomRole` as `(policiesQuery.data ?? []).filter(...)`. The `?? []` guard only absorbs `null`/`undefined`; when `listPolicies(accountId, { scopeId: projectId })` returns a **defined non-array** (a backend shape gap / partial response / empty object), `?? []` passes the non-array straight through and `.filter` throws. The prod build downlevels `??` to a ternary, which is what produces the three `(intermediate value)` tokens in the V8 message.

## What changed

Route every query-data-derived array in `apps/web/src/features/workspace/customize/sections/view/members-view.tsx` through the existing `toArray()` helper (`@/features/workspace/customize/shared/utils`), which uses `Array.isArray` to absorb `undefined`, `null`, **and** non-array values. This matches the chunk-22256 guard convention (#4542) and the `PoliciesPanel` `seedDraft` guard (#5410).

Guarded call sites (all `(query.data ?? […])` / `query.data ?? []` consumers that previously reached `.filter` / `.map` / `.sort` / spread):
- `ProjectGroupGrantsCard` — `groupsWithCustomRole` (**the confirmed throw site**), `grants`, `groups`
- `ProjectRoleAssignmentsCard` — `policies`, `customRoles`, `groups`, `projectAgents`, `roleNameById`, `agentLabelById`
- `ResourceAccessCard` — `grants`, `groups`
- `MembersView` — the `members` prop passed to all three cards
- `PendingAccessRequestsCard` — `requests`
- `PendingInvitesCard` — `pending`

## Verification

- **Root-caused from the raw Sentry event** (Better Stack MCP → `s3Cluster(primary, t502678_kortix_frontend_s3)`): the throwing `useMemo` at `layout-b5947ecaa233b0d6.js:1:279396` de-minified to `new Set((null!=(e=m.data)?e:[]).filter(…).map(…))` — exactly `(policiesQuery.data ?? []).filter(…).map(…)` in `ProjectGroupGrantsCard`. Breadcrumbs confirmed the `?c=global` → Customize → Members render path and the preceding `listPolicies` fetch.
- **Reproduced the exact throw shape** before the fix: `({}).filter(…)` throws `(intermediate value)(intermediate value)(intermediate value).filter is not a function` (three intermediate values = the inlined `(a ?? b).filter` ternary). After `toArray({}).filter(…)` returns `[]`.
- **Regression test** (`members-view-nonarray-guard.test.ts`): lifts the `groupsWithCustomRole` derivation into a pure helper and asserts it does NOT throw on the exact prod failure shapes (`{}`, `{ error: 'x' }`, `'not-an-array'`, `42`, `null`, `undefined`), plus the happy path. Also adds source-level guards (no remaining `(query.data ?? []).filter/.map`, `toArray` import present) so a future refactor can't silently regrow the unguarded pattern. All 7 tests pass.
- Existing `toArray` + `chunk22256-guard` tests still pass (8/8).

```sh
bun test apps/web/src/features/workspace/customize/sections/view/members-view-nonarray-guard.test.ts
# 7 pass, 0 fail
bun test apps/web/src/features/workspace/customize/shared/utils.test.ts apps/web/src/features/workspace/customize/shared/chunk22256-guard.test.ts
# 8 pass, 0 fail
```

## Risk / rollback

Purely defensive — `toArray` returns the array unchanged when the value is already a real array, so the happy path is byte-identical. The only behavior change is that a non-array query response degrades to `[]` instead of throwing into Sentry. Rollback = revert the single commit.

## Incident reference

- Better Stack error: https://errors.betterstack.com/team/t502678/errors/f9603a4344ea892980086cc75a9f15d6457da1e8bfa88ffbcfa7b08f1c2dcb0b?s=2346967
- Pattern: `f9603a4344ea892980086cc75a9f15d6457da1e8bfa88ffbcfa7b08f1c2dcb0b`
- Confirm after merge: the Better Stack error should drop to zero new occurrences (the `?c=global` → Customize → Members path no longer throws on a non-array `listPolicies` response).
