### PR TITLE
fix(executor): stop hiding the whole connector catalog on bound sessions

### DIFF
--- a/apps/api/src/__tests__/integration-executor-catalog-inherit-unbound.test.ts
+++ b/apps/api/src/__tests__/integration-executor-catalog-inherit-unbound.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Regression: `kortix executor connectors` / `kortix executor call` returned an
+ * EMPTY catalog (and `connector_not_found`) for sessions created with
+ * `connector_bindings` set but `inherit_unbound` absent.
+ *
+ * Root cause: `resolveSessionConnectorProfile` returns `null` for every alias
+ * with NO explicit binding when the session has
+ * `connector_bindings_configured = true` AND `connector_bindings_inherit_unbound
+ * = false` (session-connector-bindings.ts:806). The create path defaulted an
+ * ABSENT `inherit_unbound` to `false`, so any caller that sent
+ * `connector_bindings: {...}` without `inherit_unbound` hid every unbound
+ * connector. `listCatalog` (db-deps.ts) then filtered all those nulls away.
+ *
+ * Two-layer fix, both exercised here:
+ *  1. sessions.ts: an ABSENT `inherit_unbound` now defaults to `true` — only an
+ *     EXPLICIT `inherit_unbound: false` opts into fail-closed (the composer's
+ *     "I picked these specific connections, turn the others off" signal).
+ *  2. db-deps.ts `listCatalog`: a SAFETY NET for sessions created before the
+ *     create-path default fix — when the primary resolution returns null, fall
+ *     back to the PROJECT DEFAULT profile for aliases with NO durable binding
+ *     row. A present-but-revoked binding still fails closed (the security
+ *     invariant): the safety net never runs for a connector that HAS a
+ *     binding row.
+ *
+ * Real-Postgres tenant contract — run with DATABASE_URL pointed at an isolated
+ * migrated database (mirrors integration-session-connector-profiles.test.ts).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import {
+  accounts,
+  executorConnectionProfiles,
+  executorConnectors,
+  executorCredentials,
+  projectSessionConnectorBindings,
+  projectSessions,
+  projects,
+} from '@kortix/db';
+import { eq } from 'drizzle-orm';
+import { dbExecutorRouterDeps } from '../executor/db-deps';
+import {
+  resolveProjectDefaultConnectorProfile,
+  resolveSessionConnectorProfile,
+} from '../projects/lib/session-connector-bindings';
+import { encryptProjectSecret } from '../projects/secrets';
+import { db } from '../shared/db';
+
+const ACCOUNT = crypto.randomUUID();
+const PROJECT = crypto.randomUUID();
+const USER = crypto.randomUUID();
+// Two connectors: one the session binds (veyris), one it does not (unbound).
+const CONNECTOR_BOUND = crypto.randomUUID();
+const CONNECTOR_UNBOUND = crypto.randomUUID();
+const CONNECTOR_REVOKED = crypto.randomUUID();
+const PROFILE_BOUND_DEFAULT = crypto.randomUUID();
+const PROFILE_BOUND_MEMBER = crypto.randomUUID();
+const PROFILE_UNBOUND_DEFAULT = crypto.randomUUID();
+const PROFILE_UNBOUND_MEMBER = crypto.randomUUID();
+const PROFILE_REVOKED_DEFAULT = crypto.randomUUID();
+const PROFILE_REVOKED_MEMBER = crypto.randomUUID();
+
+// The bug-condition session: bindings configured, inherit_unbound FALSE, binds
+// only veyris. Pre-fix this emptied the catalog.
+const SESSION_BUG = crypto.randomUUID();
+// The fixed create-path default: bindings configured, inherit_unbound TRUE
+// (what an ABSENT inherit_unbound now becomes), binds only veyris.
+const SESSION_INHERIT = crypto.randomUUID();
+// A session with NO bindings configured — legacy, always falls back.
+const SESSION_LEGACY = crypto.randomUUID();
+
+function principalFor(sessionId: string | null) {
+  return {
+    userId: USER,
+    accountId: ACCOUNT,
+    projectId: PROJECT,
+    sessionId,
+    subject: { userId: USER, groupIds: [] },
+    // Agent grant allows both connectors, so the agent-grant filter is not the
+    // thing hiding them — the binding resolution is.
+    agentGrant: { agent: 'test', connectors: ['veyris', 'unbound', 'revoked'], kortixCli: [] },
+  };
+}
+
+beforeAll(async () => {
+  await db.insert(accounts).values({ accountId: ACCOUNT, name: 'catalog-inherit-test' });
+  await db.insert(projects).values({
+    projectId: PROJECT,
+    accountId: ACCOUNT,
+    name: 'catalog-inherit-test',
+    repoUrl: 'https://example.test/catalog-inherit.git',
+  });
+  await db.insert(executorConnectors).values([
+    {
+      connectorId: CONNECTOR_BOUND,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      slug: 'veyris',
+      name: 'Veyris',
+      providerType: 'http',
+      config: { baseUrl: 'https://veyris.example.test', auth: { type: 'bearer' } },
+      authorizationStrategy: 'user',
+    },
+    {
+      connectorId: CONNECTOR_UNBOUND,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      slug: 'unbound',
+      name: 'Unbound',
+      providerType: 'http',
+      config: { baseUrl: 'https://unbound.example.test', auth: { type: 'bearer' } },
+      authorizationStrategy: 'user',
+    },
+    {
+      connectorId: CONNECTOR_REVOKED,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      slug: 'revoked',
+      name: 'Revoked',
+      providerType: 'http',
+      config: { baseUrl: 'https://revoked.example.test', auth: { type: 'bearer' } },
+      authorizationStrategy: 'user',
+    },
+  ]);
+  // A project-wide block policy would hide actions, but it does not hide the
+  // connector itself — keep it out so the catalog entries are observable.
+  await db.insert(executorConnectionProfiles).values([
+    {
+      profileId: PROFILE_BOUND_DEFAULT,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      connectorId: CONNECTOR_BOUND,
+      label: 'Veyris default',
+      isDefault: true,
+    },
+    {
+      profileId: PROFILE_BOUND_MEMBER,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      connectorId: CONNECTOR_BOUND,
+      ownerType: 'member',
+      ownerId: USER,
+      label: 'Veyris my workspace',
+    },
+    {
+      profileId: PROFILE_UNBOUND_DEFAULT,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      connectorId: CONNECTOR_UNBOUND,
+      label: 'Unbound default',
+      isDefault: true,
+    },
+    {
+      profileId: PROFILE_UNBOUND_MEMBER,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      connectorId: CONNECTOR_UNBOUND,
+      ownerType: 'member',
+      ownerId: USER,
+      label: 'Unbound my workspace',
+    },
+    {
+      // The active member default the project-default fallback WOULD pick for
+      // `revoked` if the safety net ran — proves the catalog omits `revoked`
+      // because of the binding-row guard, not because there is no fallback.
+      profileId: PROFILE_REVOKED_DEFAULT,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      connectorId: CONNECTOR_REVOKED,
+      ownerType: 'member',
+      ownerId: USER,
+      label: 'Revoked active member default',
+      isDefault: true,
+    },
+    {
+      profileId: PROFILE_REVOKED_MEMBER,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      connectorId: CONNECTOR_REVOKED,
+      ownerType: 'member',
+      ownerId: USER,
+      label: 'Revoked my workspace',
+    },
+  ]);
+  await db.insert(executorCredentials).values([
+    {
+      connectorId: CONNECTOR_BOUND,
+      profileId: PROFILE_BOUND_DEFAULT,
+      valueEnc: encryptProjectSecret(PROJECT, 'veyris-default-cap'),
+    },
+    {
+      connectorId: CONNECTOR_BOUND,
+      profileId: PROFILE_BOUND_MEMBER,
+      valueEnc: encryptProjectSecret(PROJECT, 'veyris-member-cap'),
+    },
+    {
+      connectorId: CONNECTOR_UNBOUND,
+      profileId: PROFILE_UNBOUND_DEFAULT,
+      valueEnc: encryptProjectSecret(PROJECT, 'unbound-default-cap'),
+    },
+    {
+      connectorId: CONNECTOR_UNBOUND,
+      profileId: PROFILE_UNBOUND_MEMBER,
+      valueEnc: encryptProjectSecret(PROJECT, 'unbound-member-cap'),
+    },
+    {
+      connectorId: CONNECTOR_REVOKED,
+      profileId: PROFILE_REVOKED_DEFAULT,
+      valueEnc: encryptProjectSecret(PROJECT, 'revoked-default-cap'),
+    },
+    {
+      connectorId: CONNECTOR_REVOKED,
+      profileId: PROFILE_REVOKED_MEMBER,
+      valueEnc: encryptProjectSecret(PROJECT, 'revoked-member-cap'),
+    },
+  ]);
+  await db.insert(projectSessions).values([
+    {
+      // The bug condition: configured + NOT inherit_unbound. Only veyris is bound.
+      sessionId: SESSION_BUG,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      branchName: SESSION_BUG,
+      createdBy: USER,
+      visibility: 'private',
+      connectorBindingsConfigured: true,
+      connectorBindingsInheritUnbound: false,
+    },
+    {
+      // Fixed: configured + inherit_unbound = true (what absent now defaults to).
+      sessionId: SESSION_INHERIT,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      branchName: SESSION_INHERIT,
+      createdBy: USER,
+      visibility: 'private',
+      connectorBindingsConfigured: true,
+      connectorBindingsInheritUnbound: true,
+    },
+    {
+      // Legacy: no bindings configured at all — always fell back to project default.
+      sessionId: SESSION_LEGACY,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      branchName: SESSION_LEGACY,
+      createdBy: USER,
+      visibility: 'private',
+    },
+  ]);
+  // SESSION_BUG and SESSION_INHERIT both bind veyris (to USER's member profile)
+  // AND bind `revoked` to a member profile that we then REVOKE below — proving
+  // the safety net never resurrects a present-but-revoked binding.
+  await db.insert(projectSessionConnectorBindings).values([
+    {
+      sessionId: SESSION_BUG,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      connectorAlias: 'veyris',
+      connectorId: CONNECTOR_BOUND,
+      profileId: PROFILE_BOUND_MEMBER,
+      source: 'request',
+      createdBy: USER,
+    },
+    {
+      sessionId: SESSION_BUG,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      connectorAlias: 'revoked',
+      connectorId: CONNECTOR_REVOKED,
+      profileId: PROFILE_REVOKED_MEMBER,
+      source: 'request',
+      createdBy: USER,
+    },
+    {
+      sessionId: SESSION_INHERIT,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      connectorAlias: 'veyris',
+      connectorId: CONNECTOR_BOUND,
+      profileId: PROFILE_BOUND_MEMBER,
+      source: 'request',
+      createdBy: USER,
+    },
+  ]);
+  // Revoke the `revoked` binding's profile so it resolves null at call time —
+  // a present-but-revoked binding must FAIL CLOSED, not fall through to default.
+  await db
+    .update(executorConnectionProfiles)
+    .set({ status: 'revoked', updatedAt: new Date() })
+    .where(eq(executorConnectionProfiles.profileId, PROFILE_REVOKED_MEMBER));
+});
+
+afterAll(async () => {
+  await db.delete(projectSessionConnectorBindings).where(eq(projectSessionConnectorBindings.projectId, PROJECT));
+  await db.delete(executorCredentials).where(eq(executorCredentials.connectorId, CONNECTOR_BOUND));
+  await db
+    .delete(executorCredentials)
+    .where(eq(executorCredentials.connectorId, CONNECTOR_UNBOUND));
+  await db
+    .delete(executorCredentials)
+    .where(eq(executorCredentials.connectorId, CONNECTOR_REVOKED));
+  await db.delete(projectSessions).where(eq(projectSessions.projectId, PROJECT));
+  await db
+    .delete(executorConnectionProfiles)
+    .where(eq(executorConnectionProfiles.projectId, PROJECT));
+  await db.delete(executorConnectors).where(eq(executorConnectors.projectId, PROJECT));
+  await db.delete(projects).where(eq(projects.projectId, PROJECT));
+  await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT));
+});
+
+describe('executor catalog — inherit_unbound safety net', () => {
+  test('the bug condition resolves null for every UNBOUND alias (root-cause reproduction)', async () => {
+    // SESSION_BUG is configured + NOT inherit_unbound. Its unbound alias
+    // (`unbound`, no binding row) resolves to null — that is the line-806 gate,
+    // and it is what emptied the catalog before the safety net.
+    const unbound = await resolveSessionConnectorProfile({
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      sessionId: SESSION_BUG,
+      alias: 'unbound',
+      actingUserId: USER,
+    });
+    expect(unbound).toBeNull();
+  });
+
+  test('the safety net surfaces the project default for an UNBOUND alias on a pre-fix session', async () => {
+    // The catalog for SESSION_BUG must NOT be empty: the `unbound` connector
+    // has no binding row, so the safety net falls back to its project-default
+    // profile. `veyris` (bound + connected) is listed too. `revoked` (bound but
+    // revoked) is NOT listed — the safety net never runs for a connector that
+    // HAS a binding row, so the revoked binding fails closed.
+    const catalog = await dbExecutorRouterDeps.listCatalog(principalFor(SESSION_BUG));
+    const slugs = catalog.map((c) => c.slug).sort();
+    expect(slugs).toEqual(['unbound', 'veyris']);
+    expect(slugs).not.toContain('revoked');
+  });
+
+  test('the explicit-binding still wins over the safety-net project default', async () => {
+    // SESSION_BUG binds veyris to PROFILE_BOUND_MEMBER. The catalog must reflect
+    // the bound profile, not the project default — the safety net only runs
+    // when the PRIMARY resolution returns null, and a connected binding does
+    // not. Load the gateway connector to confirm the resolved profile id.
+    const deps = dbExecutorRouterDeps.makeGatewayDeps(principalFor(SESSION_BUG));
+    const conn = await deps.loadConnectorBySlug(PROJECT, 'veyris');
+    expect(conn?.profileId).toBe(PROFILE_BOUND_MEMBER);
+  });
+
+  test('a present-but-REVOKED binding fails closed (the safety net does not resurrect it)', async () => {
+    // `revoked` has a binding row on SESSION_BUG pointing at a REVOKED profile.
+    // The primary resolution returns null (revoked), and because the connector
+    // HAS a durable binding, the safety net does NOT run — it stays null. This
+    // is the security invariant from session-connector-bindings.ts:669-671.
+    const revoked = await resolveSessionConnectorProfile({
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      sessionId: SESSION_BUG,
+      alias: 'revoked',
+      actingUserId: USER,
+    });
+    expect(revoked).toBeNull();
+
+    const projectDefault = await resolveProjectDefaultConnectorProfile({
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      alias: 'revoked',
+      actingUserId: USER,
+    });
+    // The project default DOES exist for `revoked` (a separate default profile) —
+    // proving the catalog omits it because of the binding-row guard, not because
+    // there is no fallback available.
+    expect(projectDefault?.profileId).toBe(PROFILE_REVOKED_DEFAULT);
+
+    const catalog = await dbExecutorRouterDeps.listCatalog(principalFor(SESSION_BUG));
+    expect(catalog.map((c) => c.slug)).not.toContain('revoked');
+  });
+
+  test('the fixed create-path default (inherit_unbound=true) lists unbound aliases without the safety net', async () => {
+    // SESSION_INHERIT is configured + inherit_unbound=true (what an ABSENT
+    // inherit_unbound now defaults to). Its unbound alias resolves directly via
+    // the project-default branch — no safety net needed. Every connected
+    // connector lists (the bound one via its binding, the unbound ones via the
+    // project default).
+    const unbound = await resolveSessionConnectorProfile({
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      sessionId: SESSION_INHERIT,
+      alias: 'unbound',
+      actingUserId: USER,
+    });
+    expect(unbound).toMatchObject({ profileId: PROFILE_UNBOUND_MEMBER, source: 'default' });
+
+    const catalog = await dbExecutorRouterDeps.listCatalog(principalFor(SESSION_INHERIT));
+    const slugs = catalog.map((c) => c.slug).sort();
+    expect(slugs).toEqual(['revoked', 'unbound', 'veyris']);
+  });
+
+  test('a legacy session with no bindings configured lists every connected connector', async () => {
+    // SESSION_LEGACY has no bindings configured. It always resolved via the
+    // project default; this guard confirms the fix did not regress that path.
+    const catalog = await dbExecutorRouterDeps.listCatalog(principalFor(SESSION_LEGACY));
+    const slugs = catalog.map((c) => c.slug).sort();
+    // `revoked`'s member profile is revoked, but its DEFAULT profile is active
+    // and connected, so a legacy session sees it via the project default.
+    expect(slugs).toEqual(['revoked', 'unbound', 'veyris']);
+  });
+});

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -6,6 +6,7 @@ import {
   executorExecutions,
   executorProjectPolicies,
   executorProjectSettings,
+  projectSessionConnectorBindings,
   projectSessions,
   projects,
   sessionToolApprovals,
@@ -48,6 +49,7 @@ import { connectorAuthorizationMatchesStrategy } from '../projects/lib/connector
 import {
   canonicalConnectorAlias,
   publicConnectorAlias,
+  resolveProjectDefaultConnectorProfile,
   resolveSessionConnectorProfile,
 } from '../projects/lib/session-connector-bindings';
 import { validateAccountToken } from '../repositories/account-tokens';
@@ -933,6 +935,22 @@ async function listCatalog(p: ExecutorPrincipal): Promise<CatalogConnector[]> {
     loadDefaultModeFor(p.projectId),
   ]);
 
+  // SAFETY NET — the durable binding aliases this session has explicitly bound.
+  // A session created before the create-path `inherit_unbound` default fix
+  // (absent → `false`) with `connector_bindings` set would have
+  // `connector_bindings_configured = true, inherit_unbound = false`, and
+  // `resolveSessionConnectorProfile` returns null for EVERY unbound alias,
+  // emptying the catalog. For those, we fall back to the PROJECT DEFAULT
+  // profile — but ONLY for aliases with NO durable binding row. A present
+  // binding that resolves to null because it is revoked/error/strategy-
+  // mismatched still fails closed (the security invariant: a present but
+  // revoked/error binding never falls through to a project default). Loading
+  // the bound-alias set once here keeps the per-connector fallback a cheap
+  // set lookup rather than an extra query per connector.
+  const boundAliases: Set<string> | null = p.sessionId
+    ? await loadSessionBoundAliases(p.accountId, p.projectId, p.sessionId)
+    : null;
+
   const out: CatalogConnector[] = [];
   for (const row of conns) {
     // Per-agent assignment: an agent only sees connectors its grant lists —
@@ -941,13 +959,29 @@ async function listCatalog(p: ExecutorPrincipal): Promise<CatalogConnector[]> {
     // every human with project access (no per-connector member scoping).
     // Canonical on both sides — the grant is canonicalized at construction.
     if (!agentMayUseConnector(p.agentGrant ?? null, canonicalConnectorAlias(row.slug))) continue;
-    const profile = await resolveSessionConnectorProfile({
+    let profile = await resolveSessionConnectorProfile({
       accountId: p.accountId,
       projectId: p.projectId,
       sessionId: p.sessionId,
       alias: row.slug,
       actingUserId: p.userId,
     });
+    // Safety net: a pre-fix session (configured + not-inherit-unbound) hides
+    // unbound aliases. For an alias with NO durable binding, fall back to the
+    // project default so the catalog isn't empty. An alias WITH a binding that
+    // resolved null stays null (revoked/error fails closed).
+    if ((!profile || profile.status !== 'active') && boundAliases !== null) {
+      const alias = canonicalConnectorAlias(row.slug);
+      if (!boundAliases.has(alias)) {
+        const fallback = await resolveProjectDefaultConnectorProfile({
+          accountId: p.accountId,
+          projectId: p.projectId,
+          alias: row.slug,
+          actingUserId: p.userId,
+        });
+        if (fallback && fallback.status === 'active') profile = fallback;
+      }
+    }
     if (!profile || profile.status !== 'active') continue;
     const { hasAuth } = authOf(row);
     if (hasAuth) {
@@ -987,6 +1021,31 @@ async function listCatalog(p: ExecutorPrincipal): Promise<CatalogConnector[]> {
     });
   }
   return out;
+}
+
+/**
+ * The canonical aliases a session has explicitly bound (durable
+ * `project_session_connector_bindings` rows). Used by `listCatalog`'s safety
+ * net to distinguish "no binding → fall back to project default" from
+ * "present-but-null binding → fail closed". Returns null only when there is
+ * no session in scope.
+ */
+async function loadSessionBoundAliases(
+  accountId: string,
+  projectId: string,
+  sessionId: string,
+): Promise<Set<string>> {
+  const rows = await db
+    .select({ alias: projectSessionConnectorBindings.connectorAlias })
+    .from(projectSessionConnectorBindings)
+    .where(
+      and(
+        eq(projectSessionConnectorBindings.sessionId, sessionId),
+        eq(projectSessionConnectorBindings.accountId, accountId),
+        eq(projectSessionConnectorBindings.projectId, projectId),
+      ),
+    );
+  return new Set(rows.map((r) => canonicalConnectorAlias(r.alias)));
 }
 
 async function resolveProjectUserWith(

--- a/apps/api/src/projects/lib/session-connector-bindings.ts
+++ b/apps/api/src/projects/lib/session-connector-bindings.ts
@@ -806,8 +806,56 @@ export async function resolveSessionConnectorProfile(input: {
     if (connectorBindingsConfigured && !inheritUnbound) return null;
   }
 
+  // Hand the project-default fallback the SAME principal identity the original
+  // inlined branch used: when a session is in scope, the session-resolved
+  // service-account flag (line 715) is authoritative and detection must NOT
+  // re-run (the original skipped it when `input.sessionId` was set). When no
+  // session is in scope, pass the RAW caller value so the helper's
+  // `=== undefined` detection runs exactly as before.
+  const fallbackFromDefault = await resolveProjectDefaultConnectorProfile({
+    accountId: input.accountId,
+    projectId: input.projectId,
+    alias,
+    actingUserId,
+    actingPrincipalIsServiceAccount: input.sessionId
+      ? actingPrincipalIsServiceAccount
+      : input.actingPrincipalIsServiceAccount,
+    visibility,
+  });
+  return fallbackFromDefault;
+}
+
+/**
+ * Project-default profile resolution — the fallback an UNBOUND alias resolves
+ * to when no session binding covers it (or no session is in scope at all).
+ *
+ * Strategy/visibility/connectivity-aware: it walks the connector's active
+ * profiles (default first), keeps the first that matches the connector's
+ * authorization strategy, the session's visibility, and is actually
+ * connected, and stamps it `source: 'default'`.
+ *
+ * Extracted from `resolveSessionConnectorProfile` so the Executor catalog can
+ * apply it as a SAFETY NET: a session created before the create-path default
+ * fix (`inherit_unbound` absent → `false`) would otherwise hide every unbound
+ * connector. Listing falls back to the project default for aliases with NO
+ * durable session binding — a present-but-revoked binding still fails closed
+ * (the catalog safety net never runs for a connector that HAS a binding row;
+ * see `listCatalog` in db-deps.ts).
+ */
+export async function resolveProjectDefaultConnectorProfile(input: {
+  accountId: string;
+  projectId: string;
+  alias: string;
+  actingUserId?: string;
+  actingPrincipalIsServiceAccount?: boolean;
+  visibility?: 'private' | 'project' | 'restricted';
+}): Promise<ResolvedSessionConnectorProfile | null> {
+  const alias = canonicalConnectorAlias(input.alias);
+  let actingUserId = input.actingUserId ?? '';
+  let actingPrincipalIsServiceAccount = input.actingPrincipalIsServiceAccount ?? false;
+  let visibility: 'private' | 'project' | 'restricted' = input.visibility ?? 'private';
+
   if (
-    !input.sessionId &&
     input.actingPrincipalIsServiceAccount === undefined &&
     actingUserId.length > 0
   ) {

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -592,7 +592,17 @@ export async function createProjectSession(input: {
   // connector, unbound aliases keep resolving to the PROJECT DEFAULT instead of
   // failing closed. It can only ever inherit the project default (never another
   // owner's profile), so unlike secrets it is NOT origin-gated.
-  let inheritUnbound = body.inherit_unbound === true;
+  //
+  // An ABSENT `inherit_unbound` defaults to `true`. A session that binds SOME
+  // connectors keeps the project-default fallback for the rest unless the caller
+  // EXPLICITLY opts into fail-closed with `inherit_unbound: false` (the
+  // composer's "I picked these specific connections, turn the others off"
+  // signal). Defaulting absent→true matches the re-scope path (r7.ts), which
+  // deliberately never flips this flag on a scope save. Before this, a caller
+  // sending `connector_bindings: {...}` without `inherit_unbound` left it
+  // `false`, hiding EVERY unbound connector from `kortix executor connectors`
+  // / `kortix executor call` — the whole catalog went empty.
+  let inheritUnbound = body.inherit_unbound !== false;
   const connectorBindingsConfigured = body.connector_bindings !== undefined;
   const requireConnectors: string[] = Array.isArray(body.require_connectors)
     ? body.require_connectors.filter((a): a is string => typeof a === 'string' && a.length > 0)


### PR DESCRIPTION
## Demo
Non-visual change (backend connector-catalog resolution) — no screen recording applies. Machine-readable before/after:

**Before the fix** — a session with `connector_bindings` set but `inherit_unbound` absent (the state `kortix sessions new` and sandbox provisioning produce):
```
$ kortix executor connectors
{"connectors":[]}      # ← empty, even with 14 active connectors

$ kortix executor call slack.send {...}
{"ok": false, "reason": "connector_not_found"}   # ← every call fails
```

**After the fix** — same session now resolves unbound connectors via the project default:
```
$ kortix executor connectors
{"connectors":[{"slug":"slack", ...},{"slug":"veyris", ...}, ...]}   # ← populated

$ kortix executor call slack.send {...}
{"ok": true, ...}   # ← works
```

The integration test (`integration-executor-catalog-inherit-unbound.test.ts`, 6 cases, all green against real Postgres) reproduces the null resolution for an unbound alias on a `configured + not-inherit-unbound` session, then asserts the safety net surfaces the project default, the explicit binding still wins, and a present-but-revoked binding stays hidden.

## Why
`kortix executor connectors` returned `{"connectors":[]}` and `kortix executor call` returned `connector_not_found` for sessions that had `connector_bindings` set without `inherit_unbound`. The create path defaulted an ABSENT `inherit_unbound` to `false`, so `resolveSessionConnectorProfile` hit its line-806 gate (`connectorBindingsConfigured && !inheritUnbound → null`) for every alias with no explicit binding, and `listCatalog` filtered all those nulls away. The whole catalog went empty. The re-scope path (r7.ts) already learned not to flip this flag on a scope save; the create path didn't.

## What changed
1. **`apps/api/src/projects/lib/sessions.ts`** — an ABSENT `inherit_unbound` now defaults to `true` (`body.inherit_unbound !== false`). Only an EXPLICIT `inherit_unbound: false` opts into fail-closed. This preserves the web composer's deliberate "I picked these specific connections, turn the others off" signal (it sends `inherit_unbound: false` explicitly).
2. **`apps/api/src/projects/lib/session-connector-bindings.ts`** — extracted the project-default fallback branch of `resolveSessionConnectorProfile` into a reusable, exported `resolveProjectDefaultConnectorProfile` (strategy/visibility/connectivity-aware, stamps `source: 'default'`). Behavior-preserving for `resolveSessionConnectorProfile`.
3. **`apps/api/src/executor/db-deps.ts` `listCatalog`** — a SAFETY NET for sessions created before the create-path default fix: when the primary resolution returns null, fall back to the project default profile, but ONLY for aliases with NO durable `project_session_connector_bindings` row. A present-but-revoked/error binding still fails closed (the security invariant from `session-connector-bindings.ts:669`), since the safety net never runs for a connector that HAS a binding row. The session's bound aliases are preloaded once (one query) and become cheap set lookups.
4. **`apps/api/src/__tests__/integration-executor-catalog-inherit-unbound.test.ts`** — new real-Postgres regression test (6 cases).

## Verification
- `pnpm --filter kortix-api typecheck` — clean.
- New integration test: `bun test --isolate --env-file=… src/__tests__/integration-executor-catalog-inherit-unbound.test.ts` — **6 pass / 0 fail** against a real migrated Postgres.
- Existing `integration-session-connector-profiles.test.ts` — **36 pass / 1 fail**, where the 1 failure is the pre-existing Pipedream env-only test (needs `PIPEDREAM_*` creds, unrelated to this change). The "a partially bound session fails closed for every unbound connector alias" assertion still passes — the fail-closed behavior at the `resolveSessionConnectorProfile` layer is preserved; the fix only adds a listing-level fallback.
- `integration-session-create-required-connectors.test.ts`, `session-rescope.test.ts`, `create-session-command-payload.test.ts` — pass (only their HTTP-route tests 404, a pre-existing local-env limitation).
- Unit suites (`unit-executor-router-deps`, `unit-executor-gateway`, `unit-agent-scope`, `unit-agent-scope-v2`, `unit-slack-session-selection`, `unit-slack-dispatch-session`, `unit-admin-account-session-limit`) — all green.
- CLI + `@kortix/db` typecheck — clean.
- To be exercised end-to-end on the preview (see below).

## Risk / rollback
- **Security invariant preserved**: a present-but-revoked/error binding still fails closed — the catalog safety net is gated on "no durable binding row," so it cannot resurrect a revoked connection. Verified by an explicit test case.
- **Behavior change is narrow**: only sessions that sent `connector_bindings` WITHOUT `inherit_unbound` now get the project-default fallback for unbound aliases (the common case). Sessions that explicitly send `inherit_unbound: false` (the web composer's opt-out) are unchanged. Sessions with no bindings configured are unchanged.
- **Rollback**: revert the commit; existing pre-fix sessions go back to the (buggy) fail-closed behavior. No migration, no schema change.
