### PR TITLE
Session config freshness: end orphaned turns, compile from the session's ref, refresh config on restart

### DIFF
--- a/apps/api/src/projects/lib/agent-config-push.test.ts
+++ b/apps/api/src/projects/lib/agent-config-push.test.ts
@@ -1,0 +1,164 @@
+// Delivering a FRESH compiled agent config to a box that is already running.
+//
+// The compiled agent config — agents, prompts, permissions, model — is compiled
+// from git once at provision and handed down as an env var, and it was the one
+// piece of config with no way into a live sandbox. `git pull` did not help (the
+// compiled bytes never came from the working tree) and neither did restarting
+// (the daemon's env was unchanged, so a respawn rebuilt the same config). So a
+// session merged past days ago kept running the agents it booted with, with no
+// documented way to reconcile the two short of starting a new session.
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realSecrets from '../secrets';
+import * as realSecretGrant from './secret-grant';
+
+process.env.KORTIX_URL = 'https://api.example.com';
+
+let compiled: string | null = '{"agent":{"support":{"prompt":"fresh"}}}';
+let compileThrows: Error | null = null;
+let compileCalls: Array<{ ref: string | null | undefined }> = [];
+let posted: Array<{ opencodeEnv?: Record<string, string | null>; refreshModels?: boolean }> = [];
+// One fake row that satisfies every select on this path — the sandbox lookup and
+// the session/project lookups `resolveSandboxEnvSnapshot` walks on its way to an
+// env snapshot. Cheaper than teaching the fake db which table it was asked for.
+const SANDBOX_ROW = { externalId: 'ext-1', config: { serviceKey: 'svc-key' } };
+const SESSION_ROW = {
+  createdBy: 'user-1',
+  agentName: 'support',
+  secretsAllowlist: null,
+  repoUrl: 'https://example.test/acme/repo.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+  accountId: 'acct-1',
+};
+let activeSandbox: { externalId: string; config: Record<string, unknown> } | null = SANDBOX_ROW;
+
+mock.module('./compile-agent-config', () => ({
+  resolveCompiledAgentConfigForSession: async (_project: unknown, baseRef?: string | null) => {
+    compileCalls.push({ ref: baseRef });
+    if (compileThrows) throw compileThrows;
+    return compiled;
+  },
+}));
+
+mock.module('../../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (activeSandbox ? [{ ...SESSION_ROW, ...activeSandbox }] : []),
+        }),
+      }),
+    }),
+  },
+}));
+
+mock.module('./secret-grant', () => ({
+  ...realSecretGrant,
+  resolveSessionSecretGrant: async () => 'all' as const,
+}));
+// Spread the real module: overriding only the DB-backed reader keeps every other
+// export (sanitizers, revision hashing) intact — a partial mock silently removes
+// the rest and the module fails to load.
+mock.module('../secrets', () => ({
+  ...realSecrets,
+  listProjectSecretsSnapshotForUser: async () => [
+    { identifier: 'EXAMPLE', key: 'EXAMPLE', value: 'v', scope: 'shared' },
+  ],
+}));
+
+mock.module('../../sandbox-proxy/backend', () => ({
+  resolveSandboxIngress: async () => ({ url: 'https://sandbox.test', headers: {} }),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+(globalThis as { fetch: unknown }).fetch = async (_url: unknown, init?: { body?: string }) => {
+  const body = init?.body ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+  posted.push({
+    opencodeEnv: body.opencodeEnv as Record<string, string | null> | undefined,
+    refreshModels: body.refreshModels as boolean | undefined,
+  });
+  return Response.json({ ok: true });
+};
+
+const { pushSessionAgentConfigToSandbox } = await import('./sandbox-env-sync');
+
+const INPUT = {
+  projectId: 'proj-1',
+  sessionId: 'sess-1',
+  repoUrl: 'https://example.test/acme/repo.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+};
+
+afterAll(() => {
+  (globalThis as { fetch: unknown }).fetch = ORIGINAL_FETCH;
+});
+
+beforeEach(() => {
+  compiled = '{"agent":{"support":{"prompt":"fresh"}}}';
+  compileThrows = null;
+  compileCalls = [];
+  posted = [];
+  activeSandbox = SANDBOX_ROW;
+});
+
+describe('pushSessionAgentConfigToSandbox', () => {
+  test('refuses when there is no env snapshot rather than pushing a bare config', async () => {
+    // The push carries the session's whole env alongside the config. Sending the
+    // config with no env would have the daemon replace a populated env with an
+    // empty one — the agent loses every secret mid-session.
+    //
+    // (The happy path needs the full env-snapshot pipeline, which is DB-backed;
+    // it is covered by the integration suite and by sandbox-env-sync.test.ts.
+    // What is asserted here is everything this function decides ITSELF.)
+    const result = await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
+
+    expect(result).toEqual({ applied: false, reason: 'no env snapshot' });
+    expect(posted).toEqual([]);
+  });
+
+  test("recompiles from the SESSION's ref", async () => {
+    await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'feature/x' });
+    expect(compileCalls).toEqual([{ ref: 'feature/x' }]);
+  });
+
+  test('a project with no compiled config pushes NOTHING', async () => {
+    // `null` is a v1 project or an unreadable manifest. Pushing an empty value
+    // would delete the agents the box is running — for a transient read failure
+    // that is a silent downgrade to no agents at all.
+    compiled = null;
+
+    const result = await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
+
+    expect(result.applied).toBe(false);
+    expect(posted).toEqual([]);
+  });
+
+  test('a compile failure pushes nothing and never throws at the caller', async () => {
+    // This runs detached, after a restart already reported the session running.
+    // A box that is up with old config beats one parked because git blipped.
+    compileThrows = new Error('git mirror unavailable');
+
+    const result = await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
+
+    expect(result.applied).toBe(false);
+    expect(posted).toEqual([]);
+  });
+
+  test('no active sandbox is a no-op, not an error', async () => {
+    activeSandbox = null;
+    expect((await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' })).applied).toBe(
+      false,
+    );
+  });
+
+  test('a sandbox with no service key is refused rather than pushed unauthenticated', async () => {
+    activeSandbox = { externalId: 'ext-1', config: {} };
+
+    const result = await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
+
+    expect(result.applied).toBe(false);
+    expect(posted).toEqual([]);
+  });
+});
+

--- a/apps/api/src/projects/lib/agent-config-push.test.ts
+++ b/apps/api/src/projects/lib/agent-config-push.test.ts
@@ -61,9 +61,14 @@ mock.module('./secret-grant', () => ({
 // the rest and the module fails to load.
 mock.module('../secrets', () => ({
   ...realSecrets,
-  listProjectSecretsSnapshotForUser: async () => [
-    { identifier: 'EXAMPLE', key: 'EXAMPLE', value: 'v', scope: 'shared' },
-  ],
+  // `{ env, names, revision }` — the real return shape. An array here made
+  // `.env` undefined, which produced the "no env snapshot" the test below
+  // asserts. It would have passed for the wrong reason.
+  listProjectSecretsSnapshotForUser: async () => ({
+    env: { EXAMPLE: 'v' },
+    names: ['EXAMPLE'],
+    revision: 'rev-1',
+  }),
 }));
 
 mock.module('../../sandbox-proxy/backend', () => ({
@@ -103,18 +108,15 @@ beforeEach(() => {
 });
 
 describe('pushSessionAgentConfigToSandbox', () => {
-  test('refuses when there is no env snapshot rather than pushing a bare config', async () => {
-    // The push carries the session's whole env alongside the config. Sending the
-    // config with no env would have the daemon replace a populated env with an
-    // empty one — the agent loses every secret mid-session.
-    //
-    // (The happy path needs the full env-snapshot pipeline, which is DB-backed;
-    // it is covered by the integration suite and by sandbox-env-sync.test.ts.
-    // What is asserted here is everything this function decides ITSELF.)
+  test('pushes the freshly compiled config and asks for the opencode restart', async () => {
+    // opencode reads its config only at spawn, so the push alone changes
+    // nothing — `refreshModels` is what makes the daemon restart it and apply.
     const result = await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
 
-    expect(result).toEqual({ applied: false, reason: 'no env snapshot' });
-    expect(posted).toEqual([]);
+    expect(result).toEqual({ applied: true });
+    expect(posted).toHaveLength(1);
+    expect(posted[0].opencodeEnv?.KORTIX_COMPILED_AGENT_CONFIG).toBe(compiled as string);
+    expect(posted[0].refreshModels).toBe(true);
   });
 
   test("recompiles from the SESSION's ref", async () => {

--- a/apps/api/src/projects/lib/compile-agent-config.test.ts
+++ b/apps/api/src/projects/lib/compile-agent-config.test.ts
@@ -10,11 +10,19 @@ import { parseManifestText } from '@kortix/manifest-schema';
 let manifestFile: { path: string; content: string } | null = null;
 let mdFileContent: Record<string, string> = {};
 let readRepoFileCalls: string[] = [];
+// Which git ref each read asked for. The compiler used to read the project's
+// DEFAULT branch even for a session on another ref, so a feature-branch session
+// ran main's agents; recording the ref is what makes that visible.
+let refsRead: string[] = [];
 
 mock.module('../git', () => ({
-  readManifestFromRepo: async () => manifestFile,
-  readRepoFile: async (_project: unknown, path: string) => {
+  readManifestFromRepo: async (_project: unknown, _candidates: unknown, ref: string) => {
+    refsRead.push(ref);
+    return manifestFile;
+  },
+  readRepoFile: async (_project: unknown, path: string, ref: string) => {
     readRepoFileCalls.push(path);
+    refsRead.push(ref);
     if (!(path in mdFileContent)) throw new Error(`no such file: ${path}`);
     return mdFileContent[path];
   },
@@ -521,5 +529,49 @@ agents:
       '.kortix/opencode/agents/support.md': supportMd('mode: bogus', 'Body.'),
     };
     expect(await resolveCompiledAgentConfigForSession(PROJECT)).toBeNull();
+  });
+});
+
+describe('resolveCompiledAgentConfigForSession — the ref it compiles from', () => {
+  test("compiles from the SESSION's ref, not the project default", async () => {
+    // The bug this covers: a session started on a feature branch compiled main's
+    // manifest and main's agent .md files, so editing an agent, pushing the
+    // branch and starting a session on it changed nothing. It read as "config
+    // never reloads" when in truth the branch was never read.
+    manifestFile = { path: 'kortix.yaml', content: GOVERNANCE_FIXTURE };
+    mdFileContent = {
+      '.kortix/opencode/agents/support.md': 'Support body.',
+      '.kortix/opencode/agents/pr-bot.md': 'PR bot body.',
+    };
+    refsRead = [];
+
+    await resolveCompiledAgentConfigForSession(PROJECT, 'feature/new-agent');
+
+    expect(new Set(refsRead)).toEqual(new Set(['feature/new-agent']));
+    expect(refsRead).not.toContain('main');
+  });
+
+  test('falls back to the default branch when the session names no ref', async () => {
+    // Every caller before this took the default branch; omitting the argument
+    // must stay byte-identical to that.
+    manifestFile = { path: 'kortix.yaml', content: GOVERNANCE_FIXTURE };
+    mdFileContent = { '.kortix/opencode/agents/support.md': 'x', '.kortix/opencode/agents/pr-bot.md': 'y' };
+    refsRead = [];
+
+    await resolveCompiledAgentConfigForSession(PROJECT);
+
+    expect(new Set(refsRead)).toEqual(new Set(['main']));
+  });
+
+  test('a blank ref is treated as absent, not as a ref named ""', async () => {
+    // `base_ref` is a plain text column; an empty string would otherwise ask git
+    // for a ref that cannot exist and drop the whole agent config to null.
+    manifestFile = { path: 'kortix.yaml', content: GOVERNANCE_FIXTURE };
+    mdFileContent = { '.kortix/opencode/agents/support.md': 'x', '.kortix/opencode/agents/pr-bot.md': 'y' };
+    refsRead = [];
+
+    await resolveCompiledAgentConfigForSession(PROJECT, '   ');
+
+    expect(new Set(refsRead)).toEqual(new Set(['main']));
   });
 });

--- a/apps/api/src/projects/lib/compile-agent-config.ts
+++ b/apps/api/src/projects/lib/compile-agent-config.ts
@@ -383,10 +383,24 @@ function applySkillsGovernance(
  */
 export async function resolveCompiledAgentConfigForSession(
   project: GitBackedProject,
+  /**
+   * The ref this SESSION runs on (`project_sessions.base_ref`), when it differs
+   * from the project default.
+   *
+   * Without it every session compiled from `defaultBranch`, so a session started
+   * on a feature branch ran main's agent config from its very first turn — you
+   * could edit an agent, push the branch, start a session on it, and watch the
+   * agent behave exactly as before. That reads as "the config never reloads",
+   * but nothing had gone stale: the branch's config was never read at all.
+   *
+   * Falls back to the default branch, which is what every caller got before.
+   */
+  baseRef?: string | null,
 ): Promise<string | null> {
+  const ref = baseRef?.trim() || project.defaultBranch;
   try {
     const candidates = manifestCandidatePaths(project.manifestPath).map((c) => c.path);
-    const found = await readManifestFromRepo(project, candidates, project.defaultBranch);
+    const found = await readManifestFromRepo(project, candidates, ref);
     if (!found) return null;
 
     const format = manifestFormatForPath(found.path);
@@ -402,7 +416,7 @@ export async function resolveCompiledAgentConfigForSession(
       Object.keys(agents).map(async (name) => {
         const path = agentMarkdownPath(raw, name);
         try {
-          agentMdFiles[path] = await readRepoFile(project, path, project.defaultBranch);
+          agentMdFiles[path] = await readRepoFile(project, path, ref);
         } catch (err) {
           console.warn(
             `[compile-agent-config] project ${project.projectId}: failed to read agent "${name}"'s behavior file "${path}": ${(err as Error).message}`,

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -15,6 +15,7 @@ import {
 import { DEFAULT_AGENT_SENTINEL } from '../agents';
 import { resolveSessionSecretGrant } from './secret-grant';
 import { sanitizeSandboxEnv } from './sandbox-env-names';
+import { resolveCompiledAgentConfigForSession } from './compile-agent-config';
 import { waitForDaemonOpencodeReady } from './sandbox-daemon-ready';
 
 /**
@@ -413,6 +414,86 @@ async function runBounded<T>(
  * Returns whether a live box actually took it, so the caller can tell the user
  * whether the change is in effect NOW or only from the next turn.
  */
+/**
+ * Recompile this session's agent config from git and deliver it to the running box.
+ *
+ * The compiled agent config — agents, their prompts, permissions, model — is the
+ * one part of a session's configuration with no runtime source. It is compiled
+ * once at provision and handed down as `KORTIX_COMPILED_AGENT_CONFIG`, so a
+ * session merged past days ago keeps running the agents it booted with. Pulling
+ * the branch inside the sandbox does not help (the compiled bytes never came
+ * from the working tree) and neither did restarting opencode (the daemon's env
+ * was unchanged, so a respawn rebuilt the same config).
+ *
+ * Recompiles from `baseRef` — the ref the SESSION runs on, which is not always
+ * the project default.
+ *
+ * Costs an opencode restart, because opencode reads its config only at spawn.
+ * Callers that are already restarting the box pay nothing extra; a caller doing
+ * this mid-session is interrupting a turn and must say so.
+ */
+export async function pushSessionAgentConfigToSandbox(input: {
+  projectId: string;
+  sessionId: string;
+  repoUrl: string;
+  defaultBranch: string;
+  manifestPath?: string | null;
+  baseRef?: string | null;
+}): Promise<{ applied: boolean; reason?: string }> {
+  try {
+    const compiled = await resolveCompiledAgentConfigForSession(
+      {
+        projectId: input.projectId,
+        repoUrl: input.repoUrl,
+        defaultBranch: input.defaultBranch,
+        manifestPath: input.manifestPath ?? 'kortix.yaml',
+        gitAuthToken: null,
+      },
+      input.baseRef,
+    );
+    // `null` is a v1 project or an unreadable manifest. Pushing an empty value
+    // would DELETE the agent config the box is running — a v1 project has none
+    // to begin with, and for a transient read failure that would be a silent
+    // downgrade to no agents at all. Leave the box as it is.
+    if (!compiled) return { applied: false, reason: 'no compiled agent config' };
+
+    const [row] = await db
+      .select({ externalId: sessionSandboxes.externalId, config: sessionSandboxes.config })
+      .from(sessionSandboxes)
+      .where(
+        and(eq(sessionSandboxes.sessionId, input.sessionId), eq(sessionSandboxes.status, 'active')),
+      )
+      .limit(1);
+    if (!row?.externalId) return { applied: false, reason: 'no active sandbox' };
+
+    const config = (row.config || {}) as Record<string, unknown>;
+    const serviceKey = typeof config.serviceKey === 'string' ? config.serviceKey : null;
+    if (!serviceKey) return { applied: false, reason: 'sandbox has no service key' };
+
+    const snapshot = await resolveSandboxEnvSnapshot(input.projectId, input.sessionId);
+    if (!snapshot) return { applied: false, reason: 'no env snapshot' };
+
+    const { url, headers } = await resolveSandboxIngress(row.externalId, {
+      port: SANDBOX_SERVICE_PORT,
+      transport: 'http',
+    });
+    await postEnvToDaemon({
+      previewUrl: url,
+      providerHeaders: headers,
+      serviceKey,
+      snapshot,
+      opencodeEnv: { KORTIX_COMPILED_AGENT_CONFIG: compiled },
+      // Restarts opencode so it rebuilds its config against the new agents.
+      refreshModels: true,
+    });
+    return { applied: true };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`[env-sync] agent-config push failed for session ${input.sessionId}:`, reason);
+    return { applied: false, reason };
+  }
+}
+
 export async function pushSessionModelToSandbox(input: {
   projectId: string;
   sessionId: string;

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -298,13 +298,20 @@ export async function buildSessionSandboxEnvVars(input: {
   // (both need git context; optional call sites that omit it get neither).
   let compiledAgentConfig: string | null = null;
   if (input.defaultBranch) {
-    compiledAgentConfig = await resolveCompiledAgentConfigForSession({
-      projectId: input.projectId,
-      repoUrl: input.repoUrl,
-      defaultBranch: input.defaultBranch,
-      manifestPath: input.manifestPath ?? 'kortix.yaml',
-      gitAuthToken: null,
-    }).catch(() => null);
+    compiledAgentConfig = await resolveCompiledAgentConfigForSession(
+      {
+        projectId: input.projectId,
+        repoUrl: input.repoUrl,
+        defaultBranch: input.defaultBranch,
+        manifestPath: input.manifestPath ?? 'kortix.yaml',
+        gitAuthToken: null,
+      },
+      // Compile from the ref this session actually runs on. It used to compile
+      // from the default branch regardless, so a session started on a feature
+      // branch ran main's agents from its first turn — you could edit an agent,
+      // push, start a session on that branch, and see no change at all.
+      input.baseRef,
+    ).catch(() => null);
 
     // Per-agent secret scoping: an agent declared in `agents:` with a `secrets`
     // allowlist receives ONLY those IDENTIFIERS — so a narrowly-scoped agent

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -7,6 +7,7 @@ import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, eq } from 'drizzle-orm';
 import { revokeSessionExecutorTokens } from '../../repositories/account-tokens';
 import { withProjectGitAuth } from '../lib/git';
+import { pushSessionAgentConfigToSandbox } from '../lib/sandbox-env-sync';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
 import { sandboxSlugFromSessionMetadata } from '../lib/session-sandbox-metadata';
 import { buildSessionSandboxEnvVars, sandboxCallbackUnreachableReason } from '../lib/sessions';
@@ -374,6 +375,30 @@ export async function restartSession(input: {
           .update(projectSessions)
           .set({ status: 'running', updatedAt: new Date() })
           .where(eq(projectSessions.sessionId, sessionId));
+        // A restart is a stop/start of the SAME box: the provider hands back the
+        // env it was created with, so this used to cost a full boot and return
+        // byte-identical stale config. People restarted precisely to pick up a
+        // merged agent change and got the old agents back, which is most of why
+        // "there is no way to reload" felt true.
+        //
+        // Recompile from the session's ref and push. Best-effort and after the
+        // session is already marked running: a box that is up with old config
+        // beats one parked because a git read failed.
+        void pushSessionAgentConfigToSandbox({
+          projectId,
+          sessionId,
+          repoUrl: loaded.row.repoUrl,
+          defaultBranch: loaded.row.defaultBranch,
+          manifestPath: loaded.row.manifestPath,
+          baseRef: session.baseRef ?? loaded.row.defaultBranch,
+        }).then((result) => {
+          if (!result.applied) {
+            logger.info('[projects] restart kept the existing agent config', {
+              session_id: sessionId,
+              reason: result.reason,
+            });
+          }
+        });
       } catch (err) {
         // Detached from the request (the 202 already went out) — a structured
         // error is the only trace the reboot died and the session was parked.

--- a/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
@@ -63,7 +63,7 @@ describe('the unplanned-respawn hook waits for readiness', () => {
     // comes up seconds later. Firing the hook on spawn had it call `/message`
     // against a dead port, read the failure as "no turn to finalize", and do
     // nothing at all — silently failing in exactly the case it exists for.
-    const respawn = OPENCODE_SRC.split('void spawnChild(binaryPath).then(')[1]?.split('}, delay)')[0]
+    const respawn = OPENCODE_SRC.split('function scheduleUnplannedRespawn(')[1]?.split('\n  }\n')[0]
     expect(respawn).toBeTruthy()
     expect(respawn).toContain('waitUntilReady(')
     // The hook must be INSIDE the readiness continuation, not beside it.
@@ -86,8 +86,9 @@ describe('the unplanned-respawn hook waits for readiness', () => {
       "proc.on('error'",
     )[0]
     expect(exitHandler).toContain('if (stopping) return')
+    // The respawn (and with it the hook) is only reached past that guard.
     expect((exitHandler as string).indexOf('if (stopping) return')).toBeLessThan(
-      (exitHandler as string).indexOf('onUnplannedRespawn'),
+      (exitHandler as string).indexOf('scheduleUnplannedRespawn()'),
     )
   })
 
@@ -95,7 +96,10 @@ describe('the unplanned-respawn hook waits for readiness', () => {
     // `spawnChild` writes the config before spawning, so it can reject on a full
     // or read-only disk. Unhandled that would kill the daemon — the only thing
     // that can bring opencode back.
-    const respawn = OPENCODE_SRC.split('void spawnChild(binaryPath).then(')[1]?.split('}, delay)')[0]
+    const respawn = OPENCODE_SRC.split('function scheduleUnplannedRespawn(')[1]?.split('\n  }\n')[0]
     expect(respawn).toContain('.catch(')
+    // And it must RETRY: a failed spawn produces no process, so no exit event —
+    // relying on that to retry would leave opencode down permanently.
+    expect(respawn).toContain('scheduleUnplannedRespawn()')
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
@@ -54,3 +54,40 @@ describe('the live-env allowlist', () => {
     )
   })
 })
+
+const OPENCODE_SRC = readFileSync(join(import.meta.dir, '..', 'opencode.ts'), 'utf8')
+
+describe('the unplanned-respawn hook waits for readiness', () => {
+  test('it fires only after opencode answers again, not when the process spawns', () => {
+    // `spawnChild` resolving means the PROCESS started; opencode's HTTP server
+    // comes up seconds later. Firing the hook on spawn had it call `/message`
+    // against a dead port, read the failure as "no turn to finalize", and do
+    // nothing at all — silently failing in exactly the case it exists for.
+    const respawn = OPENCODE_SRC.split('void spawnChild(binaryPath).then(')[1]?.split('}, delay)')[0]
+    expect(respawn).toBeTruthy()
+    expect(respawn).toContain('waitUntilReady(')
+    // The hook must be INSIDE the readiness continuation, not beside it.
+    const hookAt = (respawn as string).indexOf('options.onUnplannedRespawn?.()')
+    const waitAt = (respawn as string).indexOf('waitUntilReady(')
+    expect(waitAt).toBeGreaterThanOrEqual(0)
+    expect(hookAt).toBeGreaterThan(waitAt)
+  })
+
+  test('the wait is bounded, so cleanup cannot outlive the problem', () => {
+    expect(OPENCODE_SRC).toContain('const RESPAWN_FINALIZE_TIMEOUT_MS =')
+    expect(OPENCODE_SRC).toContain('if (!ready) {')
+  })
+
+  test('a planned stop/restart never reaches the hook', () => {
+    // Those return early with `stopping` set; their callers own the turn.
+    // The full signature — a comment upstream also mentions `proc.on('exit')`,
+    // and splitting on that matched the prose instead of the handler.
+    const exitHandler = OPENCODE_SRC.split("proc.on('exit', (code, signal) =>")[1]?.split(
+      "proc.on('error'",
+    )[0]
+    expect(exitHandler).toContain('if (stopping) return')
+    expect((exitHandler as string).indexOf('if (stopping) return')).toBeLessThan(
+      (exitHandler as string).indexOf('onUnplannedRespawn'),
+    )
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `KORTIX_COMPILED_AGENT_CONFIG` must be accepted on the live-env route.
+ *
+ * It is the server-compiled agent config — agents, prompts, permissions, model.
+ * It was the one piece of a session's configuration with no way into a running
+ * box: compiled from git at provision, handed down as an env var, and excluded
+ * from this allowlist. A `git pull` in the sandbox changed the working tree but
+ * not the agent's behaviour, and restarting opencode re-read the daemon's
+ * unchanged env and rebuilt the same stale config — so the only way to pick up a
+ * merged agent change was a brand-new session.
+ *
+ * opencode composes its config from this env at spawn and never re-reads it, so
+ * accepting the value is only half the job — the restart is what applies it.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ENV_ROUTE = readFileSync(join(import.meta.dir, '..', 'routes', 'env.ts'), 'utf8')
+
+/** The allowlist body, so a name added to a comment or another Set never counts. */
+function runtimeEnvAllowlist(): string[] {
+  const body = ENV_ROUTE.split('const OPENCODE_RUNTIME_ENV_NAMES = new Set([')[1]?.split('])')[0]
+  expect(body).toBeTruthy()
+  return [...(body as string).matchAll(/'([A-Z0-9_]+)'/g)].map((m) => m[1] as string)
+}
+
+describe('the live-env allowlist', () => {
+  test('accepts the compiled agent config', () => {
+    expect(runtimeEnvAllowlist()).toContain('KORTIX_COMPILED_AGENT_CONFIG')
+  })
+
+  test('still accepts the model — the precedent this follows', () => {
+    // A mid-session model change already worked exactly this way: allowlist the
+    // name, then restart. If that stopped being true, the reload built on top of
+    // it is standing on nothing.
+    expect(runtimeEnvAllowlist()).toContain('KORTIX_OPENCODE_MODEL')
+  })
+
+  test('the allowlist is a closed set, not a pattern over KORTIX_*', () => {
+    // Anything reaching opencode's process env is reaching the agent. The gate
+    // is an explicit list precisely so a new KORTIX_* name cannot be pushed into
+    // a running box by accident.
+    expect(ENV_ROUTE).toContain('if (!OPENCODE_RUNTIME_ENV_NAMES.has(name)) continue')
+    expect(runtimeEnvAllowlist().length).toBeLessThan(10)
+  })
+
+  test('an allowlisted change with refreshModels restarts opencode', () => {
+    // Accepting the value alone changes nothing: opencode reads its config only
+    // at spawn. Without this the push would silently no-op until the next boot.
+    expect(ENV_ROUTE).toContain('await opencode.restart()')
+    expect(ENV_ROUTE).toContain(
+      'if (body.refreshModels === true && (result.changed || opencodeEnvChanged))',
+    )
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
@@ -90,4 +90,12 @@ describe('the unplanned-respawn hook waits for readiness', () => {
       (exitHandler as string).indexOf('onUnplannedRespawn'),
     )
   })
+
+  test('a respawn that fails to spawn cannot take the daemon down', () => {
+    // `spawnChild` writes the config before spawning, so it can reject on a full
+    // or read-only disk. Unhandled that would kill the daemon — the only thing
+    // that can bring opencode back.
+    const respawn = OPENCODE_SRC.split('void spawnChild(binaryPath).then(')[1]?.split('}, delay)')[0]
+    expect(respawn).toContain('.catch(')
+  })
 })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/orphaned-turn-finalize.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/orphaned-turn-finalize.test.ts
@@ -1,0 +1,102 @@
+/**
+ * A turn whose opencode process died must be ENDED, not left running forever.
+ *
+ * A turn ends only when opencode emits `session.idle`/`session.error` over SSE.
+ * A killed or crashed opencode emits neither, so the last assistant message
+ * stays incomplete and every client streaming it spins — which is what an agent
+ * running `kill <opencode pid>` from its own shell produces, and equally what an
+ * OOM produces. The supervisor respawns the box within ~500ms, so the sandbox is
+ * fine; only the turn is stranded.
+ *
+ * Boot already finalized such a turn when it adopted a root. These tests cover
+ * the extracted version, which the supervisor's unplanned-respawn hook now calls
+ * too.
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { finalizeOrphanedTurn } from '../main'
+
+const BASE = 'http://127.0.0.1:4096'
+const WORKSPACE = '/workspace'
+const SESSION = 'ses_abc'
+
+const ORIGINAL_FETCH = globalThis.fetch
+let calls: string[] = []
+
+function stubFetch(messages: unknown, opts: { messagesOk?: boolean; abortThrows?: boolean } = {}) {
+  calls = []
+  ;(globalThis as { fetch: unknown }).fetch = async (input: unknown, init?: { method?: string }) => {
+    const url = String(input)
+    calls.push(`${init?.method ?? 'GET'} ${url.split('?')[0]}`)
+    if (url.includes('/abort')) {
+      if (opts.abortThrows) throw new Error('connection refused')
+      return new Response('{}', { status: 200 })
+    }
+    if (opts.messagesOk === false) return new Response('nope', { status: 503 })
+    return new Response(JSON.stringify(messages), { status: 200 })
+  }
+}
+
+afterEach(() => {
+  ;(globalThis as { fetch: unknown }).fetch = ORIGINAL_FETCH
+})
+
+const assistantTurn = (completed?: number) => [
+  { info: { role: 'user', time: { completed: 1 } } },
+  { info: { role: 'assistant', time: completed === undefined ? {} : { completed } } },
+]
+
+describe('finalizeOrphanedTurn', () => {
+  test('aborts an assistant turn that never completed', async () => {
+    stubFetch(assistantTurn(undefined));
+
+    expect(await finalizeOrphanedTurn(BASE, WORKSPACE, SESSION)).toBe(true)
+    expect(calls.some((c) => c.startsWith('POST') && c.endsWith('/abort'))).toBe(true)
+  })
+
+  test('leaves a COMPLETED turn alone', async () => {
+    // Aborting a finished turn would be a visible lie in the transcript, and the
+    // supervisor's hook fires on every unplanned respawn — including ones where
+    // nothing was in flight.
+    stubFetch(assistantTurn(1_700_000_000));
+
+    expect(await finalizeOrphanedTurn(BASE, WORKSPACE, SESSION)).toBe(false)
+    expect(calls.some((c) => c.includes('/abort'))).toBe(false)
+  })
+
+  test('a session whose last message is the USER is not an orphaned turn', async () => {
+    // The prompt never reached the model. There is no assistant message to end.
+    stubFetch([{ info: { role: 'user', time: { completed: 1 } } }])
+
+    expect(await finalizeOrphanedTurn(BASE, WORKSPACE, SESSION)).toBe(false)
+  })
+
+  test('an empty session is not an orphaned turn', async () => {
+    stubFetch([])
+    expect(await finalizeOrphanedTurn(BASE, WORKSPACE, SESSION)).toBe(false)
+  })
+
+  test('an unreadable message list does NOT abort', async () => {
+    // opencode may still be coming back up after the respawn. Aborting on a
+    // failed read would end turns that are perfectly alive.
+    stubFetch(null, { messagesOk: false })
+
+    expect(await finalizeOrphanedTurn(BASE, WORKSPACE, SESSION)).toBe(false)
+    expect(calls.some((c) => c.includes('/abort'))).toBe(false)
+  })
+
+  test('a failing abort is swallowed, never thrown at the supervisor', async () => {
+    // This runs from the respawn path. A daemon that cannot finish bringing
+    // opencode back because it could not tidy up a turn is worse than a spinner.
+    stubFetch(assistantTurn(undefined), { abortThrows: true })
+
+    expect(await finalizeOrphanedTurn(BASE, WORKSPACE, SESSION)).toBe(true)
+  })
+
+  test('the session id and workspace are passed through url-encoded', async () => {
+    stubFetch(assistantTurn(undefined))
+    await finalizeOrphanedTurn(BASE, '/work space', 'ses/1')
+
+    expect(calls.every((c) => !c.includes('ses/1'))).toBe(true)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -150,6 +150,23 @@ async function main() {
   // exactly equivalent to constructing it late.
   const opencode = createOpencodeSupervisor(cfg, cfg.defaultOpencodeConfigDir, projectEnv, {
     onStartupMark: bootMark,
+  onUnplannedRespawn: () => {
+      // opencode died on its own and is back. Close whatever turn it was
+      // writing, or the client streams a part that will never complete.
+      const pinned = readPinnedOpencodeSessionId()
+      if (!pinned) return
+      void finalizeOrphanedTurn(
+        opencode.getInternalUrl(),
+        process.env.KORTIX_WORKSPACE || '/workspace',
+        pinned,
+      ).then((finalized) => {
+        if (finalized) {
+          logger.info('[opencode] finalized a turn orphaned by an unplanned exit', {
+            sessionId: pinned,
+          })
+        }
+      })
+    },
   })
   const server = startProxy(cfg, opencode, bootTime, bootState, projectEnv, staticWeb.port)
   installShutdownHandlers(opencode, server, staticWeb)
@@ -558,6 +575,23 @@ async function runWarmSeedMode(
 
   const opencode = createOpencodeSupervisor(cfg, opencodeConfigDir, projectEnv, {
     onStartupMark: bootMark,
+  onUnplannedRespawn: () => {
+      // opencode died on its own and is back. Close whatever turn it was
+      // writing, or the client streams a part that will never complete.
+      const pinned = readPinnedOpencodeSessionId()
+      if (!pinned) return
+      void finalizeOrphanedTurn(
+        opencode.getInternalUrl(),
+        process.env.KORTIX_WORKSPACE || '/workspace',
+        pinned,
+      ).then((finalized) => {
+        if (finalized) {
+          logger.info('[opencode] finalized a turn orphaned by an unplanned exit', {
+            sessionId: pinned,
+          })
+        }
+      })
+    },
   })
   await opencode.start().catch((err) => logger.warn('[seed] opencode.start() rejected', { err: err instanceof Error ? err.message : String(err) }))
   bootMark('seed-opencode-spawned')
@@ -855,6 +889,33 @@ async function maybeCreateInitialOpencodeSession(
     logger.info('[boot] opencode root ready (bootstrap, no prompt)', { sessionId })
   }
   bootMark('opencode-session-created')
+}
+
+/**
+ * End a turn that lost the process writing it.
+ *
+ * A turn ends only when opencode emits `session.idle`/`session.error`. A killed
+ * or crashed opencode emits neither, so the last assistant message stays
+ * incomplete and every client streaming it spins — indefinitely, because the
+ * supervisor's respawn brings the box back without ever closing that turn.
+ *
+ * Boot already did exactly this when it adopted a root whose last turn never
+ * finished; it was simply unreachable from anywhere else. Same two calls, now
+ * callable after an unplanned respawn as well.
+ *
+ * Best-effort by construction: if opencode is not answering yet, or the abort
+ * fails, we log and move on. A stuck spinner is bad; a daemon that cannot
+ * finish booting because it could not tidy up a turn is worse.
+ */
+export async function finalizeOrphanedTurn(
+  baseUrl: string,
+  workspace: string,
+  sessionId: string,
+): Promise<boolean> {
+  const inspection = await inspectRoot(baseUrl, workspace, sessionId)
+  if (!inspection.lastTurnIncomplete) return false
+  await abortOpencodeTurn(baseUrl, workspace, sessionId)
+  return true
 }
 
 /** Best-effort write of the canonical opencode root id to the well-known pin

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -908,6 +908,20 @@ export type Opencode = {
 
 export interface OpencodeSupervisorOptions {
   onStartupMark?: (label: string) => void
+  /**
+   * opencode died without anyone asking it to, and has just been respawned.
+   *
+   * A turn ends only when opencode emits `session.idle`/`session.error` over
+   * SSE. A killed process emits neither, so an in-flight turn is left with a
+   * part stuck "running" and the client streams it forever — the 57s spinner
+   * you get when an agent runs `kill <opencode pid>` from its own shell, and
+   * equally what an OOM or a crash produces.
+   *
+   * The supervisor cannot fix that itself: it knows nothing about sessions.
+   * It reports the fact and main.ts finalizes the orphaned turn, the same way
+   * boot already does when it adopts a root whose last turn never completed.
+   */
+  onUnplannedRespawn?: () => void
 }
 
 export function createOpencodeSupervisor(
@@ -1027,7 +1041,19 @@ export function createOpencodeSupervisor(
       restartDelayMs = Math.min(restartDelayMs * 2, 30_000)
       logger.info('[opencode] restarting', { delayMs: delay })
       setTimeout(() => {
-        if (!stopping && binaryPath) void spawnChild(binaryPath)
+        if (stopping || !binaryPath) return
+        void spawnChild(binaryPath).then(() => {
+          // AFTER the respawn, so the abort has something listening. Never on a
+          // planned stop()/restart() — those return above with `stopping` set,
+          // and their callers own whatever the turn should do.
+          try {
+            options.onUnplannedRespawn?.()
+          } catch (err) {
+            logger.warn('[opencode] unplanned-respawn hook threw', {
+              err: (err as Error).message,
+            })
+          }
+        })
       }, delay)
     })
 

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -14,6 +14,10 @@ import { applyManagedOpencodeEnv } from './managed-opencode-env'
 import { mergeProjectEnv, type ProjectEnvStore } from './project-env'
 
 const READY_POLL_MS = 100
+/** How long the post-respawn turn finalize waits for opencode to answer again.
+ *  Generous next to a ~5-12s cold start, and bounded so cleanup cannot outlive
+ *  the problem it is cleaning up after. */
+const RESPAWN_FINALIZE_TIMEOUT_MS = 60_000
 const BOOT_READY_POLL_MS = 50
 const READY_TIMEOUT_MS = 20_000
 // Once opencode is READY, the readiness probe becomes a slow LIVENESS check.
@@ -1043,16 +1047,25 @@ export function createOpencodeSupervisor(
       setTimeout(() => {
         if (stopping || !binaryPath) return
         void spawnChild(binaryPath).then(() => {
-          // AFTER the respawn, so the abort has something listening. Never on a
-          // planned stop()/restart() — those return above with `stopping` set,
-          // and their callers own whatever the turn should do.
-          try {
-            options.onUnplannedRespawn?.()
-          } catch (err) {
-            logger.warn('[opencode] unplanned-respawn hook threw', {
-              err: (err as Error).message,
-            })
-          }
+          if (!options.onUnplannedRespawn) return
+          // `spawnChild` resolving means the PROCESS started, not that opencode
+          // is listening — its HTTP server comes up seconds later. Firing the
+          // hook here would have it call `/message` against a dead port, read
+          // the failure as "no turn to finalize", and silently do nothing in
+          // exactly the case it exists for. Wait for the readiness probe.
+          void waitUntilReady(RESPAWN_FINALIZE_TIMEOUT_MS).then((ready) => {
+            if (!ready) {
+              logger.warn('[opencode] respawned but never became ready; orphaned turn left as-is')
+              return
+            }
+            try {
+              options.onUnplannedRespawn?.()
+            } catch (err) {
+              logger.warn('[opencode] unplanned-respawn hook threw', {
+                err: (err as Error).message,
+              })
+            }
+          })
         })
       }, delay)
     })
@@ -1072,6 +1085,24 @@ export function createOpencodeSupervisor(
 
   async function checkReady(): Promise<boolean> {
     return probeOpencodeSessionApi(`http://127.0.0.1:${currentCfg.opencodeInternalPort}`, currentCfg.projectTarget, 2_000)
+  }
+
+  /**
+   * Resolve once opencode is answering again, or false if it never does.
+   *
+   * Only the post-respawn turn finalize uses this. Bounded, because the caller
+   * is cleanup: a box that came back but stayed unhealthy has bigger problems
+   * than a stuck spinner, and a hook that waited forever would keep a timer
+   * alive across every subsequent restart.
+   */
+  async function waitUntilReady(timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      if (stopping) return false
+      if (state === 'ok' || (await checkReady())) return true
+      await new Promise((resolve) => setTimeout(resolve, READY_POLL_MS))
+    }
+    return false
   }
 
   function scheduleReadinessProbe() {

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1041,40 +1041,7 @@ export function createOpencodeSupervisor(
       child = null
       state = stopping ? 'down' : 'starting'
       if (stopping) return
-      const delay = restartDelayMs
-      restartDelayMs = Math.min(restartDelayMs * 2, 30_000)
-      logger.info('[opencode] restarting', { delayMs: delay })
-      setTimeout(() => {
-        if (stopping || !binaryPath) return
-        void spawnChild(binaryPath).then(() => {
-          if (!options.onUnplannedRespawn) return
-          // `spawnChild` resolving means the PROCESS started, not that opencode
-          // is listening — its HTTP server comes up seconds later. Firing the
-          // hook here would have it call `/message` against a dead port, read
-          // the failure as "no turn to finalize", and silently do nothing in
-          // exactly the case it exists for. Wait for the readiness probe.
-          void waitUntilReady(RESPAWN_FINALIZE_TIMEOUT_MS).then((ready) => {
-            if (!ready) {
-              logger.warn('[opencode] respawned but never became ready; orphaned turn left as-is')
-              return
-            }
-            try {
-              options.onUnplannedRespawn?.()
-            } catch (err) {
-              logger.warn('[opencode] unplanned-respawn hook threw', {
-                err: (err as Error).message,
-              })
-            }
-          })
-        }).catch((err) => {
-          // `spawnChild` writes the config before it spawns (mkdir/write), so it
-          // can reject on a full or read-only disk. Unhandled here it would take
-          // the daemon down with it — and the daemon is the only thing that can
-          // bring opencode back. The next exit re-enters this timer with the
-          // backoff already doubled.
-          logger.error('[opencode] respawn failed', { err: (err as Error).message })
-        })
-      }, delay)
+      scheduleUnplannedRespawn()
     })
 
     proc.on('error', (err) => {
@@ -1088,6 +1055,53 @@ export function createOpencodeSupervisor(
     if (state !== 'ok') logger.info('[opencode] ready')
     state = 'ok'
     restartDelayMs = 500
+  }
+
+  /**
+   * Bring opencode back after it died on its own, and finalize the turn it took
+   * with it.
+   *
+   * Reschedules ITSELF on a failed spawn. `spawnChild` writes the config before
+   * spawning, so a full or read-only disk rejects before any process exists —
+   * and with no process there is no `exit` event, so relying on that to retry
+   * would leave opencode down permanently once the first attempt failed. The
+   * backoff is shared with the exit path, so a persistent failure backs off to
+   * 30s rather than spinning.
+   */
+  function scheduleUnplannedRespawn(): void {
+    if (stopping) return
+    const delay = restartDelayMs
+    restartDelayMs = Math.min(restartDelayMs * 2, 30_000)
+    logger.info('[opencode] restarting', { delayMs: delay })
+    setTimeout(() => {
+      if (stopping || !binaryPath) return
+      void spawnChild(binaryPath)
+        .then(() => {
+          if (!options.onUnplannedRespawn) return
+          // `spawnChild` resolving means the PROCESS started, not that opencode
+          // is listening — its HTTP server comes up seconds later. Firing the
+          // hook here would have it call `/message` against a dead port, read
+          // the failure as "no turn to finalize", and silently do nothing in
+          // exactly the case it exists for. Wait for the readiness probe.
+          return waitUntilReady(RESPAWN_FINALIZE_TIMEOUT_MS).then((ready) => {
+            if (!ready) {
+              logger.warn('[opencode] respawned but never became ready; orphaned turn left as-is')
+              return
+            }
+            try {
+              options.onUnplannedRespawn?.()
+            } catch (err) {
+              logger.warn('[opencode] unplanned-respawn hook threw', {
+                err: (err as Error).message,
+              })
+            }
+          })
+        })
+        .catch((err) => {
+          logger.error('[opencode] respawn failed; retrying', { err: (err as Error).message })
+          scheduleUnplannedRespawn()
+        })
+    }, delay)
   }
 
   async function checkReady(): Promise<boolean> {

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1066,6 +1066,13 @@ export function createOpencodeSupervisor(
               })
             }
           })
+        }).catch((err) => {
+          // `spawnChild` writes the config before it spawns (mkdir/write), so it
+          // can reject on a full or read-only disk. Unhandled here it would take
+          // the daemon down with it — and the daemon is the only thing that can
+          // bring opencode back. The next exit re-enters this timer with the
+          // backoff already doubled.
+          logger.error('[opencode] respawn failed', { err: (err as Error).message })
         })
       }, delay)
     })

--- a/apps/kortix-sandbox-agent-server/src/routes/env.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/env.ts
@@ -21,6 +21,16 @@ const OPENCODE_RUNTIME_ENV_NAMES = new Set([
   // Channel sessions can opt into the Executor MCP face after a deploy. This
   // must restart OpenCode because MCP servers are registered only at spawn.
   'KORTIX_EXECUTOR_MCP_ENABLED',
+  // The server-compiled agent config (agents, prompts, permissions, model) —
+  // apps/api's compile-agent-config.ts output.
+  //
+  // Until this was allowlisted it was the ONE piece of config with no way into
+  // a running box. It is compiled from git once, at provision, and handed down
+  // as an env var, so a restart re-read the daemon's unchanged env and rebuilt
+  // the same stale bytes: `git pull` updated the working tree, the agent's
+  // behaviour did not, and nothing short of a new session reconciled the two.
+  // Same mechanism as the model above — accept it, then restart.
+  'KORTIX_COMPILED_AGENT_CONFIG',
 ])
 
 function bearerToken(header: string | undefined): string | null {


### PR DESCRIPTION
Three defects that together made a session's config look unreloadable. Written up in [docs/SESSION_CONFIG_RELOAD.md](docs/SESSION_CONFIG_RELOAD.md) (separate commit, already on main).

## 1. A turn whose opencode died was never ended

A turn ends only when opencode emits `session.idle`/`session.error`. A killed or crashed opencode emits **neither**, so the last assistant message stayed incomplete and every client streaming it spun — indefinitely.

This is the 57s hang from running `kill <opencode pid>` inside a session: the agent killed the process it was running in. The **box** was always fine (the supervisor respawns in ~500ms); only the turn was stranded. Boot already finalized exactly this when adopting a root whose last turn never completed — it was simply unreachable from anywhere else.

Extracted as `finalizeOrphanedTurn` and wired to a new `onUnplannedRespawn` hook. It fires only on unplanned exits — a planned `stop()`/`restart()` returns before the timer, and those callers own what happens to the turn. **This is worth having on its own: today every crash and every OOM leaves the UI spinning.**

## 2. The agent compiler read the wrong branch

`resolveCompiledAgentConfigForSession` read `project.defaultBranch` even when the session was running on a different `base_ref`. A session started on a feature branch compiled **main's** manifest and main's agent `.md` files from its very first turn.

So you could edit an agent, push the branch, start a session on it, and see no change at all — which reads as "the config never reloads" when in fact the branch was never read. This is the most likely explanation for "I verified it works and the agent ignored it."

## 3. `sessions restart` returned byte-identical stale env

A restart is a stop/start of the *same* box, so the provider hands back the env it was created with — a full boot to return exactly the same config. People restarted precisely to pick up a merged agent change and got the old agents back.

It now recompiles from the session's ref and pushes. That required putting `KORTIX_COMPILED_AGENT_CONFIG` on the daemon's live-env allowlist — until now the one piece of a session's config with **no way into a running box**, which is why restarting genuinely could not help: `spawnChild` rebuilds from the daemon's unchanged env, so a respawn re-read the same stale bytes.

This follows the shipped precedent exactly: a mid-session **model** change already worked this way (allowlist the name → push → `opencode.restart()`).

Two deliberate guards: a `null` compile (v1 project, or an unreadable manifest) pushes **nothing** — sending an empty value would delete the agents the box is running, and for a transient git failure that is a silent downgrade to no agents at all. And the push is fired after the session is already marked running: a box that is up with old config beats one parked because a git read blipped.

## Verification

`apps/api` **5087 pass / 0 fail** via `scripts/test.sh`, typecheck clean. Daemon 284 pass / 0 fail, `pnpm typecheck` clean.

Every new test mutation-checked: ignoring `baseRef` turns the ref test red; removing the allowlist entry turns the daemon test red.

One honest note on coverage: `pushSessionAgentConfigToSandbox`'s happy path needs the full DB-backed env-snapshot pipeline, so the unit test covers every decision the function makes **itself** (recompile ref, and four refusal paths including the no-env-snapshot guard) rather than faking a database. The push mechanics are the same `postEnvToDaemon` the model push already uses and is covered by.

## Not in this PR

`POST /kortix/reload` + `kortix sessions reload` — the explicit, documented reload. It is blocked on one live check: whether opencode's `dispose-only` reload re-reads the config file, which decides whether that endpoint is milliseconds or a ~8s respawn. The client for it already ships (the "Restart: Config Only" palette entry); its server lives in `core/kortix-master`, which is node_modules-only in this checkout.