### PR TITLE
Add CLI session access controls

### DIFF
--- a/apps/cli/src/__tests__/session-overrides.test.ts
+++ b/apps/cli/src/__tests__/session-overrides.test.ts
@@ -18,6 +18,10 @@ describe('parseSessionOverrides', () => {
       'STRIPE_KEY',
       '--connector',
       'gmail=prof-1',
+      '--require-connector',
+      'gmail',
+      '--require-connector',
+      'gmail',
       '--context',
       'tier=pro',
       'positional',
@@ -27,6 +31,7 @@ describe('parseSessionOverrides', () => {
       model: 'anthropic/claude-opus-4-8',
       secrets: ['GMAIL_TOKEN', 'STRIPE_KEY'],
       connectors: { gmail: { authorization_id: 'prof-1' } },
+      requiredConnectors: ['gmail'],
       runtimeContext: { tier: 'pro' },
     });
     // Only the override flags are consumed; the positional survives.
@@ -78,5 +83,16 @@ describe('parseSessionOverrides', () => {
 
   test('rejects --secret together with --no-secrets', () => {
     expect(() => parseSessionOverrides(['--secret', 'X', '--no-secrets'])).toThrow(/not both/);
+  });
+
+  test('--no-connectors creates an explicit empty binding map', () => {
+    expect(parseSessionOverrides(['--no-connectors']).connectors).toEqual({});
+    expect(parseSessionOverrides([]).connectors).toBeUndefined();
+  });
+
+  test('rejects --connector together with --no-connectors', () => {
+    expect(() =>
+      parseSessionOverrides(['--connector', 'gmail=prof-1', '--no-connectors']),
+    ).toThrow(/not both/);
   });
 });

--- a/apps/cli/src/__tests__/sessions-scope-blackbox.test.ts
+++ b/apps/cli/src/__tests__/sessions-scope-blackbox.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const CLI_ENTRY = join(resolve(import.meta.dir, "..", ".."), "src", "index.ts");
+const PROJECT_ID = "00000000-0000-4000-a000-000000000111";
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+const ACCOUNT_ID = "00000000-0000-4000-a000-000000000222";
+
+let root = "";
+let server: ReturnType<typeof Bun.serve> | null = null;
+let requests: Array<{ method: string; path: string; body?: unknown }> = [];
+
+const currentScope = {
+  secrets_allowlist: ["CURRENT_SECRET"],
+  required_connectors: ["gmail"],
+  connector_bindings: { gmail: { authorization_id: "AUTH-CURRENT" } },
+  dropped_secrets: [],
+  added_secrets: [],
+  dropped_bindings: [],
+  retroactive: true,
+  detail: "Current session scope.",
+};
+
+function session() {
+  return {
+    session_id: SESSION_ID,
+    account_id: ACCOUNT_ID,
+    project_id: PROJECT_ID,
+    branch_name: SESSION_ID,
+    base_ref: "main",
+    sandbox_provider: "daytona",
+    sandbox_id: SESSION_ID,
+    sandbox_url: null,
+    opencode_session_id: null,
+    name: "Scope target",
+    agent_name: "default",
+    status: "running",
+    error: null,
+    metadata: {},
+    created_at: "2026-08-03T00:00:00.000Z",
+    updated_at: "2026-08-03T00:00:00.000Z",
+  };
+}
+
+async function runCli(args: string[]) {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    KORTIX_CONFIG_FILE: join(root, "config.json"),
+    KORTIX_NO_UPDATE_CHECK: "1",
+    KORTIX_DISABLE_SANDBOX_ENV_FILE: "1",
+    NO_COLOR: "1",
+    FORCE_COLOR: "0",
+  };
+  for (const key of [
+    "KORTIX_API_URL",
+    "KORTIX_CLI_TOKEN",
+    "KORTIX_EXECUTOR_TOKEN",
+    "KORTIX_PROJECT_ID",
+    "KORTIX_TOKEN",
+    "BASH_ENV",
+  ]) {
+    delete env[key];
+  }
+  const processHandle = Bun.spawn({
+    cmd: [process.execPath, CLI_ENTRY, ...args],
+    cwd: root,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const timeout = setTimeout(() => processHandle.kill(), 10_000);
+  const [code, stdout, stderr] = await Promise.all([
+    processHandle.exited,
+    new Response(processHandle.stdout).text(),
+    new Response(processHandle.stderr).text(),
+  ]).finally(() => clearTimeout(timeout));
+  return { code, stdout, stderr };
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "kortix-session-scope-cli-"));
+  requests = [];
+  mkdirSync(join(root, ".kortix"), { recursive: true });
+  writeFileSync(
+    join(root, ".kortix", "link.json"),
+    JSON.stringify({
+      project_id: PROJECT_ID,
+      account_id: ACCOUNT_ID,
+      host: "test",
+      host_url: "http://127.0.0.1",
+      linked_at: "2026-08-03T00:00:00.000Z",
+    }),
+  );
+  server = Bun.serve({
+    port: 0,
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      const entry: { method: string; path: string; body?: unknown } = {
+        method: request.method,
+        path: url.pathname,
+      };
+      if (request.method === "PUT") entry.body = await request.json();
+      requests.push(entry);
+      if (
+        request.method === "GET" &&
+        url.pathname === `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}`
+      ) {
+        return Response.json(session());
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname ===
+          `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/scope`
+      ) {
+        return Response.json(currentScope);
+      }
+      if (
+        request.method === "PUT" &&
+        url.pathname ===
+          `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/scope`
+      ) {
+        const body = entry.body as {
+          secrets?: string[] | null;
+          connector_bindings?: Record<string, { authorization_id: string }>;
+          require_connectors?: string[] | null;
+        };
+        const requiredConnectors = Object.hasOwn(body, "require_connectors")
+          ? body.require_connectors?.length
+            ? body.require_connectors
+            : null
+          : currentScope.required_connectors;
+        return Response.json({
+          ...currentScope,
+          secrets_allowlist: body.secrets ?? currentScope.secrets_allowlist,
+          required_connectors: requiredConnectors,
+          connector_bindings:
+            body.connector_bindings ?? currentScope.connector_bindings,
+          dropped_secrets: ["CURRENT_SECRET"],
+          added_secrets: body.secrets ?? [],
+          dropped_bindings: ["gmail"],
+          retroactive: false,
+          detail: "Changes apply to the next prompt.",
+        });
+      }
+      return Response.json(
+        { error: `not found ${url.pathname}` },
+        { status: 404 },
+      );
+    },
+  });
+  writeFileSync(
+    join(root, "config.json"),
+    JSON.stringify({
+      active: "test",
+      hosts: {
+        test: {
+          url: `http://127.0.0.1:${server.port}`,
+          token: "test-token",
+          user_id: "user-1",
+          user_email: "user@example.test",
+          account_id: ACCOUNT_ID,
+          logged_in_at: "2026-08-03T00:00:00.000Z",
+        },
+      },
+    }),
+  );
+});
+
+afterEach(() => {
+  server?.stop(true);
+  server = null;
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe("kortix sessions scope", () => {
+  test("reads the authoritative scope as JSON", async () => {
+    const result = await runCli(["sessions", "scope", SESSION_ID, "--json"]);
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(currentScope);
+    expect(requests).toEqual([
+      {
+        method: "GET",
+        path: `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}`,
+      },
+      {
+        method: "GET",
+        path: `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/scope`,
+      },
+    ]);
+  });
+
+  test("replaces each requested scope category through one atomic request", async () => {
+    const result = await runCli([
+      "sessions",
+      "scope",
+      SESSION_ID,
+      "--secret",
+      "MAIL_KEY",
+      "--secret",
+      "BILLING_KEY",
+      "--connector",
+      "gmail=AUTH-NEW",
+      "--require-connector",
+      "slack",
+      "--json",
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      secrets_allowlist: ["MAIL_KEY", "BILLING_KEY"],
+      required_connectors: ["slack"],
+      connector_bindings: { gmail: { authorization_id: "AUTH-NEW" } },
+      retroactive: false,
+    });
+    expect(requests.at(-1)).toEqual({
+      method: "PUT",
+      path: `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/scope`,
+      body: {
+        secrets: ["MAIL_KEY", "BILLING_KEY"],
+        connector_bindings: { gmail: { authorization_id: "AUTH-NEW" } },
+        require_connectors: ["slack"],
+      },
+    });
+  });
+
+  test("supports explicit inherited and empty scope states", async () => {
+    const result = await runCli([
+      "sessions",
+      "scope",
+      SESSION_ID,
+      "--inherit-secrets",
+      "--no-connectors",
+      "--no-required-connectors",
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("required   None");
+    expect(result.stdout).toContain("Changes apply to the next prompt.");
+    expect(result.stdout).toContain(
+      "Secret values already read cannot be removed from existing context.",
+    );
+    expect(requests.at(-1)?.body).toEqual({
+      secrets: null,
+      connector_bindings: {},
+      require_connectors: [],
+    });
+  });
+
+  test("leaves omitted categories unchanged", async () => {
+    const result = await runCli([
+      "sessions",
+      "scope",
+      SESSION_ID,
+      "--no-secrets",
+      "--json",
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(requests.at(-1)?.body).toEqual({ secrets: [] });
+  });
+
+  test("rejects conflicting secret modes before a network request", async () => {
+    const result = await runCli([
+      "sessions",
+      "scope",
+      SESSION_ID,
+      "--secret",
+      "MAIL_KEY",
+      "--no-secrets",
+    ]);
+
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("Choose one secrets mode");
+    expect(requests).toEqual([]);
+  });
+});

--- a/apps/cli/src/__tests__/sessions-scope-blackbox.test.ts
+++ b/apps/cli/src/__tests__/sessions-scope-blackbox.test.ts
@@ -175,6 +175,18 @@ afterEach(() => {
 });
 
 describe("kortix sessions scope", () => {
+  test("limits the create-time backend-token notice to secret flags", async () => {
+    const result = await runCli(["sessions", "--help"]);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Session access at creation:");
+    expect(result.stdout).toContain("backend token required");
+    expect(result.stdout).not.toContain(
+      "Backend overrides (require a backend token",
+    );
+    expect(requests).toEqual([]);
+  });
+
   test("reads the authoritative scope as JSON", async () => {
     const result = await runCli(["sessions", "scope", SESSION_ID, "--json"]);
 

--- a/apps/cli/src/__tests__/sessions.e2e.test.ts
+++ b/apps/cli/src/__tests__/sessions.e2e.test.ts
@@ -247,6 +247,23 @@ describe('sessions new CLI flow', () => {
     expect(sessionCreateBody).not.toHaveProperty('agent_name');
   });
 
+  test('creates a session with explicit connector scope', async () => {
+    const code = await runSessions([
+      'new',
+      '--no-connectors',
+      '--require-connector',
+      'gmail',
+      '--require-connector',
+      'gmail',
+    ]);
+
+    expect(code).toBe(0);
+    expect(sessionCreateBody).toMatchObject({
+      connector_bindings: {},
+      require_connectors: ['gmail'],
+    });
+  });
+
   test('a removed session attribution option exits before an API request', async () => {
     const removedFlag = ['--', 'origin', '-ref'].join('');
     const code = await runSessions(['new', removedFlag, 'customer-42']);

--- a/apps/cli/src/commands/sessions-scope.ts
+++ b/apps/cli/src/commands/sessions-scope.ts
@@ -1,0 +1,202 @@
+import type { SessionScope, SessionScopeInput } from "@kortix/sdk";
+
+import {
+  emitJson,
+  locateSessionAnywhere,
+  surfaceApiError,
+  takeFlagBool,
+  takeFlagValue,
+  takeFlagValues,
+} from "../command-helpers.ts";
+import { kortixFromAuth } from "../api/sdk.ts";
+import { C, help, status } from "../style.ts";
+
+const HELP = help`Usage: kortix sessions scope <session-id> [options]
+
+Read or replace a session's secret and connector access. Changes apply to the
+next prompt. Omitted categories remain unchanged. Repeated values form the full
+replacement for that category.
+
+Options:
+  --secret <identifier>          Replace the secret allowlist (repeatable).
+  --no-secrets                   Allow no project secrets.
+  --inherit-secrets              Remove session narrowing; use the agent grant.
+  --connector <alias>=<auth-id>  Replace connector bindings (repeatable).
+  --no-connectors                Replace explicit connector bindings with none.
+  --require-connector <alias>    Replace required connector aliases (repeatable).
+  --no-required-connectors       Require no connector aliases.
+  --json                         Print the authoritative scope as JSON.
+  --project <id>                 Operate on this project id.
+  --host <name>                  Operate on this logged-in host.
+  -h, --help                     Show this help.
+`;
+
+interface ScopeCommand {
+  sessionId: string;
+  project?: string;
+  host?: string;
+  json: boolean;
+  input: SessionScopeInput;
+  update: boolean;
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function parseBindings(
+  values: string[],
+): Record<string, { authorization_id: string }> {
+  const bindings: Record<string, { authorization_id: string }> = {};
+  for (const pair of values) {
+    const separator = pair.indexOf("=");
+    if (separator <= 0 || separator === pair.length - 1) {
+      throw new Error(
+        `--connector expects alias=authorization_id, got "${pair}"`,
+      );
+    }
+    bindings[pair.slice(0, separator)] = {
+      authorization_id: pair.slice(separator + 1),
+    };
+  }
+  return bindings;
+}
+
+function parseScopeCommand(argv: string[]): ScopeCommand | "help" {
+  const rest = [...argv];
+  if (takeFlagBool(rest, ["-h", "--help"])) return "help";
+
+  const project = takeFlagValue(rest, ["--project"]);
+  const host = takeFlagValue(rest, ["--host"]);
+  const json = takeFlagBool(rest, ["--json"]);
+  const secrets = takeFlagValues(rest, ["--secret"]);
+  const noSecrets = takeFlagBool(rest, ["--no-secrets"]);
+  const inheritSecrets = takeFlagBool(rest, ["--inherit-secrets"]);
+  const connectorPairs = takeFlagValues(rest, ["--connector"]);
+  const noConnectors = takeFlagBool(rest, ["--no-connectors"]);
+  const requiredConnectors = takeFlagValues(rest, ["--require-connector"]);
+  const noRequiredConnectors = takeFlagBool(rest, ["--no-required-connectors"]);
+
+  const secretModes =
+    Number(secrets.length > 0) + Number(noSecrets) + Number(inheritSecrets);
+  if (secretModes > 1) {
+    throw new Error(
+      "Choose one secrets mode: --secret, --no-secrets, or --inherit-secrets.",
+    );
+  }
+  if (connectorPairs.length > 0 && noConnectors) {
+    throw new Error("Choose either --connector or --no-connectors.");
+  }
+  if (requiredConnectors.length > 0 && noRequiredConnectors) {
+    throw new Error(
+      "Choose either --require-connector or --no-required-connectors.",
+    );
+  }
+
+  const sessionId = rest.shift();
+  if (!sessionId) throw new Error("Pass a session id.");
+  if (rest.length > 0) throw new Error(`Unknown option "${rest[0]}".`);
+
+  const input: SessionScopeInput = {};
+  if (secrets.length > 0) input.secrets = unique(secrets);
+  else if (noSecrets) input.secrets = [];
+  else if (inheritSecrets) input.secrets = null;
+  if (connectorPairs.length > 0)
+    input.connector_bindings = parseBindings(connectorPairs);
+  else if (noConnectors) input.connector_bindings = {};
+  if (requiredConnectors.length > 0)
+    input.require_connectors = unique(requiredConnectors);
+  else if (noRequiredConnectors) input.require_connectors = [];
+
+  return {
+    sessionId,
+    project,
+    host,
+    json,
+    input,
+    update: Object.keys(input).length > 0,
+  };
+}
+
+function secretScopeLabel(values: string[] | null): string {
+  if (values === null) return "Agent grant";
+  if (values.length === 0) return "None";
+  return values.join(", ");
+}
+
+function listScopeLabel(values: string[] | null): string {
+  if (!values || values.length === 0) return "None";
+  return values.join(", ");
+}
+
+function printScope(
+  scope: SessionScope,
+  sessionId: string,
+  updated: boolean,
+): void {
+  const bindings = Object.entries(scope.connector_bindings);
+  process.stdout.write("\n");
+  process.stdout.write(
+    `  ${C.bold}Session access${C.reset} ${C.dim}${sessionId}${C.reset}\n`,
+  );
+  process.stdout.write(
+    `  ${C.dim}secrets    ${C.reset}${secretScopeLabel(scope.secrets_allowlist)}\n`,
+  );
+  process.stdout.write(
+    `  ${C.dim}required   ${C.reset}${listScopeLabel(scope.required_connectors)}\n`,
+  );
+  process.stdout.write(
+    `  ${C.dim}connectors ${C.reset}${bindings.length === 0 ? "None" : ""}\n`,
+  );
+  for (const [alias, binding] of bindings) {
+    process.stdout.write(
+      `               ${alias} ${C.dim}→ ${binding.authorization_id}${C.reset}\n`,
+    );
+  }
+  process.stdout.write("\n");
+  process.stdout.write(
+    `${updated ? status.ok(scope.detail) : status.info(scope.detail)}\n`,
+  );
+  if (!scope.retroactive) {
+    process.stdout.write(
+      `${status.warn("Secret values already read cannot be removed from existing context.")}\n`,
+    );
+  }
+  process.stdout.write("\n");
+}
+
+export async function runSessionsScope(argv: string[]): Promise<number> {
+  let command: ScopeCommand | "help";
+  try {
+    command = parseScopeCommand(argv);
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 2;
+  }
+  if (command === "help") {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  const located = await locateSessionAnywhere(
+    command.sessionId,
+    { projectArg: command.project, hostArg: command.host },
+    (host) => `kortix sessions scope ${command.sessionId} --host ${host}`,
+  );
+  if (!located) return 1;
+  const { auth, projectId } = located.located;
+  const session = kortixFromAuth(auth).session(projectId, command.sessionId);
+
+  let scope: SessionScope;
+  try {
+    scope = command.update
+      ? await session.rescope(command.input)
+      : await session.scope();
+  } catch (error) {
+    return surfaceApiError(error);
+  }
+
+  if (command.json) emitJson(scope);
+  else printScope(scope, command.sessionId, command.update);
+  return 0;
+}

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -13,6 +13,7 @@ import { runSessionsAnswer, runSessionsApprove, runSessionsPending } from './ses
 import { runSessionsChat, runSessionsLog, runSessionsStatus } from './sessions-chat.ts';
 import { runSessionsConnect } from './sessions-connect.ts';
 import { runSessionsDigest } from './sessions-digest.ts';
+import { runSessionsScope } from './sessions-scope.ts';
 import { runSessionsShell } from './sessions-shell.ts';
 import { C, help, pad, status } from '../style.ts';
 import { sessionWebUrl } from '../web-url.ts';
@@ -45,6 +46,11 @@ Subcommands:
                                     --connector <alias>=<authorization-id>
                                       bind a connector authorization
                                       (repeatable).
+                                    --no-connectors          use no connector
+                                      authorizations.
+                                    --require-connector <alias>
+                                      require a connected authorization before
+                                      provisioning (repeatable).
                                     --context <key>=<value>  runtime context
                                       (repeatable).
   chat [<session-id>]               Talk to a session's agent (REPL, or
@@ -73,6 +79,13 @@ Subcommands:
                                     stripped. --since <7d>, --json.
                                     Aliases: review, summary.
   info <session-id>                 Show one session. --json.
+  scope <session-id>                Read or replace the session's secret and
+                                    connector access. Changes apply to the next
+                                    prompt. --secret, --no-secrets,
+                                    --inherit-secrets, --connector,
+                                    --no-connectors, --require-connector,
+                                    --no-required-connectors, --json.
+                                    Alias: access.
   preview <session-id> [port]       Print a clickable preview URL for a port
                                     in the session's sandbox (default 3000).
                                     Root-served (assets work). --port, --json.
@@ -131,6 +144,9 @@ export async function runSessions(argv: string[]): Promise<number> {
   }
   if (sub === 'answer') {
     return runSessionsAnswer(argv.slice(1));
+  }
+  if (sub === 'scope' || sub === 'access') {
+    return runSessionsScope(argv.slice(1));
   }
   const rest = argv.slice(1);
   // None of the subcommands below (ls/new/info/preview/restart/rename/rm/
@@ -205,6 +221,7 @@ export type SessionOverrides = {
   model?: string;
   secrets?: string[];
   connectors?: Record<string, { authorization_id: string }>;
+  requiredConnectors?: string[];
   runtimeContext?: Record<string, string>;
 };
 
@@ -223,16 +240,28 @@ export function parseSessionOverrides(argv: string[]): SessionOverrides {
   // from omitting the field (agent's normal set); --no-secrets expresses it.
   if (secrets.length) out.secrets = secrets;
   else if (noSecrets) out.secrets = [];
-  for (const pair of takeFlagValues(argv, ['--connector'])) {
+  const connectorPairs = takeFlagValues(argv, ['--connector']);
+  const noConnectors = takeFlagBool(argv, ['--no-connectors']);
+  if (connectorPairs.length && noConnectors) {
+    throw new Error('pass either --connector <alias>=<authorization-id> or --no-connectors, not both');
+  }
+  for (const pair of connectorPairs) {
     const eq = pair.indexOf('=');
-    if (eq <= 0) throw new Error(`--connector expects alias=authorization_id, got "${pair}"`);
+    if (eq <= 0 || eq === pair.length - 1) {
+      throw new Error(`--connector expects alias=authorization_id, got "${pair}"`);
+    }
     (out.connectors ??= {})[pair.slice(0, eq)] = {
       authorization_id: pair.slice(eq + 1),
     };
   }
+  if (noConnectors) out.connectors = {};
+  const requiredConnectors = takeFlagValues(argv, ['--require-connector']);
+  if (requiredConnectors.length) out.requiredConnectors = [...new Set(requiredConnectors)];
   for (const pair of takeFlagValues(argv, ['--context'])) {
     const eq = pair.indexOf('=');
-    if (eq <= 0) throw new Error(`--context expects key=value, got "${pair}"`);
+    if (eq <= 0 || eq === pair.length - 1) {
+      throw new Error(`--context expects key=value, got "${pair}"`);
+    }
     (out.runtimeContext ??= {})[pair.slice(0, eq)] = pair.slice(eq + 1);
   }
   return out;
@@ -298,7 +327,10 @@ async function sessionsNew(
   if (agent) body.agent_name = agent;
   if (overrides.model) body.opencode_model = overrides.model;
   if (overrides.secrets !== undefined) body.secrets = overrides.secrets;
-  if (overrides.connectors) body.connector_bindings = overrides.connectors;
+  if (overrides.connectors !== undefined) body.connector_bindings = overrides.connectors;
+  if (overrides.requiredConnectors !== undefined) {
+    body.require_connectors = overrides.requiredConnectors;
+  }
   if (overrides.runtimeContext) body.runtime_context = overrides.runtimeContext;
 
   const prepared = await prepareClientCreatedBranch(ctx, body);

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -37,12 +37,13 @@ Subcommands:
                                     --wait blocks until it's running; --json
                                     prints the session object (capture
                                     session_id to orchestrate).
-                                    Backend overrides (require a backend token —
-                                    see docs/KORTIX_AS_A_BACKEND_GUIDE.md):
+                                    Session access at creation:
                                     --secret <id>           narrow injected
-                                      secrets to these identifiers (repeatable).
+                                      secrets to these identifiers (repeatable;
+                                      backend token required).
                                     --no-secrets            inject zero project
-                                      secrets into the session.
+                                      secrets into the session (backend token
+                                      required).
                                     --connector <alias>=<authorization-id>
                                       bind a connector authorization
                                       (repeatable).

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -241,7 +241,7 @@ Each session runs in one sandbox on its own branch.
 | `kortix sessions ls` | List every session on the project. |
 | `kortix sessions status [--all] [--json]` | Every session and what its agent is doing right now. Aliases: `overview`, `ps`. |
 | `kortix sessions info <id> [--json]` | Detail view: status, branch, agent, sandbox URL. |
-| `kortix sessions new [--prompt "<text>"] [--agent <name>] [--model <id>] [--wait] [--json]` | Start a session. `--model <id>` overrides the project's default model. `--wait` blocks until it is running (up to ~5 minutes); a timeout is a hard failure (exit 1), not a silent success. Use `--secret <id>` (repeatable) or `--no-secrets` to narrow project-secret delivery; these flags require a backend token. Use `--connector <alias>=<authorization-id>` to select connector authorizations. Use `--context <key>=<value>` for non-secret runtime context. |
+| `kortix sessions new [--prompt "<text>"] [--agent <name>] [--model <id>] [--wait] [--json]` | Start a session. `--model <id>` overrides the project's default model. `--wait` blocks until it is running (up to ~5 minutes). Use `--secret <id>` or `--no-secrets` to narrow Secret access. These Secret flags require a backend token. Use `--connector <alias>=<authorization-id>` or `--no-connectors` to set Connector access. Use `--require-connector <alias>` to require an authorization before provisioning. Scope flags are repeatable. Use `--context <key>=<value>` for non-secret runtime context. |
 | `kortix sessions chat [<id>] [--prompt "<text>"] [--new] [--agent <name>] [--json]` | Talk to a session's agent. Interactive by default. Alias: `talk`. Top-level `kortix chat` also works. |
 | `kortix sessions connect [<id>] [-- <opencode args>]` | Attach your local OpenCode TUI to the OpenCode REST compatibility process in the sandbox. Alias: `attach`. |
 | `kortix sessions shell [<id>] [--new]` | Open a raw interactive terminal in the sandbox, with no agent. Aliases: `terminal`, `ssh`. |
@@ -250,6 +250,7 @@ Each session runs in one sandbox on its own branch.
 | `kortix sessions approve <id> [<req-id>] [--always] [--reject] [--message "<text>"]` | Answer a permission prompt. |
 | `kortix sessions answer <id> [<req-id>] [--option <v>]... [--text "<text>"] [--reject]` | Answer a question prompt. |
 | `kortix sessions digest [--since <7d>] [--json]` | Compact multi-session review. Aliases: `review`, `summary`. |
+| `kortix sessions scope <id> [scope options] [--json]` | Read or replace Secret and Connector access. Alias: `access`. Use `--secret <id>`, `--no-secrets`, or `--inherit-secrets` for Secrets. Use `--connector <alias>=<authorization-id>` or `--no-connectors` for Connector bindings. Use `--require-connector <alias>` or `--no-required-connectors` for required Connectors. Provided categories replace their current values. Omitted categories remain unchanged. Changes apply to the next prompt. Removed Secret values remain in existing context if the session already read them. |
 | `kortix sessions preview <id> [port] [--port <n>] [--json]` | Print a clickable preview URL for a sandbox port. Default port: `3000`. |
 | `kortix sessions restart <id>` | Restart the session's sandbox. |
 | `kortix sessions rename <id> <name>` | Set a session's name. Pass `""` to clear it. |


### PR DESCRIPTION
## Summary
- add a CLI command to read or replace session Secret and Connector access
- add explicit create-time Connector scope flags
- document replacement and next-prompt behavior

## Verification
- `bun test src/__tests__/session-overrides.test.ts src/__tests__/sessions-scope-blackbox.test.ts`
- `bun run typecheck`
- `pnpm lint:sdk-boundary && bun test` (624 passed)
- `pnpm build`
- `bun run src/index.ts sessions scope --help`