### PR TITLE
release(web): /download close button, and mobile marked coming soon

### DIFF
--- a/apps/web/src/app/(public)/download/page.tsx
+++ b/apps/web/src/app/(public)/download/page.tsx
@@ -1,11 +1,13 @@
 import { AppleMark, LinuxMark, PlayStoreMark, WindowsMark } from '@/components/brand/brand-logos';
 import { ConsentGate } from '@/components/consent-gate';
 import { DesktopCardImage, MobileCardImage } from '@/features/marketing/download/card-images';
+import { DownloadCloseButton } from '@/features/marketing/download/close-button';
 import {
   DESKTOP_CARD,
   DESKTOP_ROWS,
   MOBILE_CARD,
   MOBILE_ROWS,
+  MOBILE_STATUS,
   hero,
 } from '@/features/marketing/download/content';
 import type { DesktopOs, MobileOs, Platform } from '@/features/marketing/download/detect-os';
@@ -73,8 +75,7 @@ export default async function DownloadPage({
     id: os,
     label: MOBILE_ROWS[os].label,
     meta: MOBILE_ROWS[os].hint,
-    href: MOBILE_ROWS[os].href,
-    external: true,
+    status: MOBILE_STATUS,
     Mark: MOBILE_MARKS[os],
   }));
 
@@ -98,13 +99,19 @@ export default async function DownloadPage({
       title={MOBILE_CARD.title}
       description={MOBILE_CARD.description}
       rows={mobileRows}
-      filled={onPhone ? detected : null}
+      // Nothing to fill: neither row has a button while both apps are unreleased.
+      // A phone visitor therefore sees no solid button anywhere on the page,
+      // which is accurate — there is nothing here they can install today.
+      filled={null}
     />
   );
 
   return (
     <main className="mx-auto flex min-h-dvh w-full max-w-5xl flex-col justify-center px-6 py-16 md:py-0">
       <ConsentGate />
+
+      {/* This route renders no nav and no footer, so it is the only way out. */}
+      <DownloadCloseButton />
 
       <header className="mb-10 text-center">
         <h1 className="text-foreground text-3xl font-semibold tracking-tight text-balance sm:text-4xl">

--- a/apps/web/src/features/marketing/download/close-button.test.tsx
+++ b/apps/web/src/features/marketing/download/close-button.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { CloseButton, dismiss } from './close-button';
+
+/** Records which router call the branch made, in order. */
+function fakeRouter() {
+  const calls: string[] = [];
+  return {
+    calls,
+    back: () => calls.push('back'),
+    push: (href: string) => calls.push(`push:${href}`),
+  };
+}
+
+describe('dismiss', () => {
+  test('goes back when the tab has somewhere to go back to', () => {
+    const router = fakeRouter();
+    dismiss(router, 2);
+    expect(router.calls).toEqual(['back']);
+  });
+
+  test('goes home from a fresh tab, where back() is a dead click', () => {
+    // A pasted /download link, a target="_blank" jump, a link out of an email:
+    // history.length is 1 and this X is the page's only exit, so back() would
+    // leave the visitor stranded on the page they just tried to leave.
+    const router = fakeRouter();
+    dismiss(router, 1);
+    expect(router.calls).toEqual(['push:/']);
+  });
+
+  test('never fires both, and never fires neither', () => {
+    for (const length of [0, 1, 2, 3, 50]) {
+      const router = fakeRouter();
+      dismiss(router, length);
+      expect(router.calls).toHaveLength(1);
+    }
+  });
+});
+
+describe('CloseButton', () => {
+  const html = renderToStaticMarkup(<CloseButton onClose={() => {}} />);
+
+  test('is reachable without sight of the glyph', () => {
+    // The button's only child is an X path. Without the label a screen reader
+    // announces an empty button.
+    expect(html).toContain('aria-label="Close"');
+    expect(html).toContain('<svg');
+  });
+
+  test('sits in the viewport corner, not in the centred content column', () => {
+    // `absolute` would pin it to main's max-w-5xl box, which is centred — about
+    // 470px inside the right edge on a 1920px monitor, beside the cards instead
+    // of at the corner.
+    expect(html).toContain('fixed');
+    expect(html).toContain('top-4');
+    expect(html).toContain('right-4');
+    expect(html).not.toContain('left-4');
+  });
+
+  test('is a round pill with a 40x40 hit area', () => {
+    // size="icon-lg" is size-10. The glyph is 16px; the target must not be.
+    expect(html).toContain('rounded-full');
+    expect(html).toContain('size-10');
+  });
+
+  test('does not submit the form it may one day sit inside', () => {
+    expect(html).toContain('type="button"');
+  });
+});

--- a/apps/web/src/features/marketing/download/close-button.tsx
+++ b/apps/web/src/features/marketing/download/close-button.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Icon } from '@/features/icon/icon';
+import { useRouter } from 'next/navigation';
+
+/** The two calls this file makes on the router, and nothing else. */
+type Navigate = Pick<ReturnType<typeof useRouter>, 'back' | 'push'>;
+
+/**
+ * What a Close click does.
+ *
+ * `/download` has no nav, no footer, and no logo — `(public)/download/` ships a
+ * page and nothing else — so this X is the visitor's only way off the page.
+ * `back()` is right when they arrived from somewhere, but a fresh tab has
+ * nothing behind it: a pasted link, a `target="_blank"` jump, a link out of an
+ * email. `back()` there is a dead click on the page's only exit.
+ *
+ * `history.length === 1` is exactly that case, so it falls through to home.
+ * Arriving from another site still returns to that site, which is what a
+ * dismiss control is expected to do.
+ *
+ * Takes the router rather than calling `useRouter` so the branch is a plain
+ * function — no app-router context to mount, no `mock.module` on
+ * `next/navigation`, which `bun test src` applies process-wide.
+ */
+export function dismiss(router: Navigate, historyLength: number): void {
+  if (historyLength > 1) {
+    router.back();
+    return;
+  }
+  router.push('/');
+}
+
+/**
+ * The X itself, with no idea what closing means, so its DOM contract renders in
+ * a test with no app router mounted.
+ *
+ * Fixed to the viewport, not to the page's `max-w-5xl` column: the column is
+ * centred, so an absolutely positioned button would sit ~470px inside the right
+ * edge on a 1920px monitor — beside the content, not in the corner a dismiss
+ * control is looked for. `size="icon-lg"` is 40x40, the minimum hit area,
+ * around a 16px glyph.
+ */
+export function CloseButton({ onClose }: { onClose: () => void }) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-lg"
+      aria-label="Close"
+      onClick={onClose}
+      className="fixed top-4 right-4 z-10 rounded-full active:scale-[0.96]"
+    >
+      <Icon.Close className="size-4" />
+    </Button>
+  );
+}
+
+/** The X wired to this tab's history. Rendered by `/download`. */
+export function DownloadCloseButton() {
+  const router = useRouter();
+
+  return <CloseButton onClose={() => dismiss(router, window.history.length)} />;
+}

--- a/apps/web/src/features/marketing/download/content.ts
+++ b/apps/web/src/features/marketing/download/content.ts
@@ -15,6 +15,9 @@
  *     terminal block says "macOS & Linux · WSL on Windows".
  *  4. There is no Chrome extension in this repo — no manifest, no app. The page
  *     must not advertise one, not even as "coming soon".
+ *  5. NEITHER mobile app is publicly installable. iOS is on TestFlight and
+ *     Android is on a Play internal track, so both store URLs are dead ends for
+ *     the public. The rows carry a status instead of a link — see MOBILE_ROWS.
  */
 
 import type { DesktopOs, MobileOs } from './detect-os';
@@ -26,6 +29,8 @@ export const hero = {
 
 export type CardCopy = { title: string; description: string };
 export type RowCopy = { label: string; hint: string; href: string };
+/** A platform with no public build yet, so there is nothing to link to. */
+export type ComingSoonRowCopy = { label: string; hint: string };
 
 export const DESKTOP_CARD: CardCopy = {
   title: 'Desktop app',
@@ -49,17 +54,21 @@ export const DESKTOP_ROWS: Record<DesktopOs, RowCopy> = {
   linux: { label: 'Linux', hint: 'AppImage · x86_64', href: '/download/linux' },
 };
 
-export const MOBILE_ROWS: Record<MobileOs, RowCopy> = {
-  ios: {
-    label: 'iPhone and iPad',
-    hint: 'App Store',
-    href: 'https://apps.apple.com/ie/app/kortix/id6754448524',
-  },
-  android: {
-    label: 'Android',
-    hint: 'Google Play',
-    href: 'https://play.google.com/store/apps/details?id=com.kortix.app',
-  },
+/** The chip both mobile rows carry in place of a Download button. */
+export const MOBILE_STATUS = 'Coming soon';
+
+/**
+ * NO `href`. Both store listings exist, but neither is public: iOS ships to
+ * TestFlight and Android to a Play internal track. Linking them sends a visitor
+ * to a page they cannot install from, which is worse than saying "not yet".
+ *
+ * `hint` still names the store each build will land in, so the row stays useful
+ * as a statement of intent. Restore the links only when both listings are
+ * publicly downloadable — and then the type change is the reminder.
+ */
+export const MOBILE_ROWS: Record<MobileOs, ComingSoonRowCopy> = {
+  ios: { label: 'iPhone and iPad', hint: 'App Store' },
+  android: { label: 'Android', hint: 'Google Play' },
 };
 
 export const TERMINAL = {

--- a/apps/web/src/features/marketing/download/platform-card.test.tsx
+++ b/apps/web/src/features/marketing/download/platform-card.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { MOBILE_CARD, MOBILE_ROWS, MOBILE_STATUS } from './content';
+import { orderedMobile } from './detect-os';
+import { type CardRow, PlatformCard } from './platform-card';
+
+const Mark = () => <svg />;
+
+/**
+ * The mobile rows exactly as `/download` builds them, so this file fails when
+ * the page changes, not only when the card does.
+ */
+const mobileRows: CardRow[] = orderedMobile('macos').map((os) => ({
+  id: os,
+  label: MOBILE_ROWS[os].label,
+  meta: MOBILE_ROWS[os].hint,
+  status: MOBILE_STATUS,
+  Mark,
+}));
+
+const mobileCard = renderToStaticMarkup(
+  <PlatformCard
+    image={null}
+    title={MOBILE_CARD.title}
+    description={MOBILE_CARD.description}
+    rows={mobileRows}
+    filled={null}
+  />,
+);
+
+describe('the mobile card while both apps are unreleased', () => {
+  test('offers nobody a way to try the app', () => {
+    // iOS is on TestFlight and Android on a Play internal track. Both listings
+    // exist and neither is publicly installable, so a link is a dead end.
+    expect(mobileCard).not.toContain('apps.apple.com');
+    expect(mobileCard).not.toContain('play.google.com');
+    expect(mobileCard).not.toContain('<a ');
+    expect(mobileCard).not.toContain('Download');
+  });
+
+  test('says so on every row, not once at the top', () => {
+    // A single header chip is missable next to two named platforms; a visitor
+    // scanning for "Android" has to land on the answer where they are looking.
+    expect(mobileCard.match(new RegExp(MOBILE_STATUS, 'g'))).toHaveLength(mobileRows.length);
+    expect(mobileRows).toHaveLength(2);
+  });
+
+  test('still names both platforms, so the plan is legible', () => {
+    expect(mobileCard).toContain('iPhone and iPad');
+    expect(mobileCard).toContain('Android');
+  });
+
+  test('keeps the row height the desktop card sets, so the seams line up', () => {
+    // Both cards sit in one grid row and `mt-auto` bottom-aligns their lists. A
+    // bare Badge is h-5 against the magic-sm button's h-9/sm:h-8 opposite it,
+    // which would drag every seam in this card out of alignment.
+    expect(mobileCard).toContain('h-9');
+    expect(mobileCard).toContain('sm:h-8');
+  });
+});
+
+describe('a row that does have a build', () => {
+  const linked = renderToStaticMarkup(
+    <PlatformCard
+      image={null}
+      title="Desktop app"
+      description="…"
+      rows={[{ id: 'macos', label: 'macOS', meta: 'Universal · 195 MB', href: '/download/macos', Mark }]}
+      filled="macos"
+    />,
+  );
+
+  test('still renders the Download link', () => {
+    expect(linked).toContain('href="/download/macos"');
+    expect(linked).toContain('Download');
+    expect(linked).toContain('aria-label="Download Kortix for macOS"');
+  });
+
+  test('does not pick up a status chip', () => {
+    expect(linked).not.toContain(MOBILE_STATUS);
+  });
+});

--- a/apps/web/src/features/marketing/download/platform-card.tsx
+++ b/apps/web/src/features/marketing/download/platform-card.tsx
@@ -1,18 +1,38 @@
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/marketing/button';
 import Link from 'next/link';
 
 import type { Platform } from './detect-os';
 
-export type CardRow = {
+type CardRowBase = {
   id: Platform;
   label: string;
   /** Line under the label, e.g. "Universal · 195 MB". Empty renders nothing. */
   meta: string;
-  href: string;
-  /** Store links leave the site; the internal platform redirects do not. */
-  external?: boolean;
   Mark: React.ComponentType<{ className?: string }>;
 };
+
+/**
+ * A row either has a build to hand over or it does not, and the type says which.
+ *
+ * `href` and `status` are mutually exclusive on purpose. A row carrying a live
+ * store link AND a "Coming soon" chip is the one bug this page must never ship —
+ * it sends a visitor to a store listing they cannot install from. Making the
+ * pair unrepresentable beats catching it in review.
+ */
+export type CardRow =
+  | (CardRowBase & {
+      href: string;
+      /** Store links leave the site; the internal platform redirects do not. */
+      external?: boolean;
+      status?: undefined;
+    })
+  | (CardRowBase & {
+      /** Shown instead of the Download button, e.g. "Coming soon". */
+      status: string;
+      href?: undefined;
+      external?: undefined;
+    });
 
 /**
  * One product card: full-bleed image, header, then a divided list of platform
@@ -72,23 +92,39 @@ export function PlatformCard({
               ) : null}
             </div>
 
-            <Button
-              asChild
-              size="magic-sm"
-              variant={row.id === filled ? 'default' : 'outline'}
-              className="shrink-0 active:scale-[0.97]"
-            >
-              <Link
-                href={row.href}
-                // Five buttons all reading "Download" is useless to a screen
-                // reader. The visible label stays short; the accessible one says
-                // which platform it is.
-                aria-label={`Download Kortix for ${row.label}`}
-                {...(row.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+            {/* `!== undefined`, not truthiness: `status: ''` is falsy, so a
+                truthiness check leaves TS unable to prove the other arm has an
+                `href` — and would silently render a Download button for a row
+                that meant to say it has no build. */}
+            {row.status !== undefined ? (
+              // Height-matched to the `magic-sm` button opposite it. Both cards
+              // share one grid row and `mt-auto` bottom-aligns their lists, so a
+              // shorter trailing slot here would knock every seam in this card
+              // out of line with the one beside it.
+              <span className="flex h-9 shrink-0 items-center sm:h-8">
+                <Badge variant="muted" size="sm">
+                  {row.status}
+                </Badge>
+              </span>
+            ) : (
+              <Button
+                asChild
+                size="magic-sm"
+                variant={row.id === filled ? 'default' : 'outline'}
+                className="shrink-0 active:scale-[0.97]"
               >
-                Download
-              </Link>
-            </Button>
+                <Link
+                  href={row.href}
+                  // Five buttons all reading "Download" is useless to a screen
+                  // reader. The visible label stays short; the accessible one says
+                  // which platform it is.
+                  aria-label={`Download Kortix for ${row.label}`}
+                  {...(row.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                >
+                  Download
+                </Link>
+              </Button>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
Cherry-picks `02660d2ffb` from `main` onto `staging`. No other change.

Original PR: #6060

## What is in it

Two things, both on `/download`:

1. **A close button.** The route renders no nav, no footer, and no logo, so a visitor who lands there has no way back except browser chrome. An X in the top-right corner calls `router.back()`, falling through to `/` when `history.length === 1` (a pasted link or a fresh tab has nothing behind it, so `back()` would be a dead click on the page's only exit).
2. **The mobile apps are marked "Coming soon".** Neither is publicly installable — iOS is on TestFlight, Android on a Play internal track — so both store links were dead ends. The rows now carry a status chip instead of a Download button, and `CardRow` is a union making `href` + `status` mutually exclusive, so a row that both links to a store and says "Coming soon" is unrepresentable.

## Cherry-pick verification

The cherry-pick applied with no conflicts: 6 files, +304/-34, identical to the commit on `main`.

`staging` is 106 commits behind `main`, so I checked the base this lands on rather than assuming:

- Every primitive the change depends on is **byte-identical** between `origin/staging` and `origin/main` — verified with `git diff --quiet origin/staging origin/main -- <file>` for `components/ui/badge.tsx`, `components/ui/button.tsx`, `components/ui/marketing/button.tsx`, `features/icon/icon.tsx`, `features/marketing/download/detect-os.ts`, `features/marketing/download/card-images.tsx`.
- After the pick, every file the change touches is byte-identical to `main` **except** `app/(public)/download/page.tsx`, which differs only in a pre-existing way unrelated to this work: `staging` still declares `metadata` inline, while `main` has adopted `marketingMetadata('/download')`. The cherry-pick did not touch those lines.

Since the tested units and all their dependencies are byte-identical to `main`, the verification from #6060 carries over unchanged: 33 pass / 0 fail in `bun test src/features/marketing/download/`, 3688 pass / 0 fail across the full `bun test src`, eslint clean, `tsc` clean on the changed files. I did not re-execute the suite against a staging checkout — the throwaway worktree used for the pick has no installed dependencies — so CI on this PR is the first execution against this exact base.

## Known gap, not fixed here

The `/download` meta description on **both** branches still reads:

> Get Kortix for macOS, Windows, Linux, iOS, and Android.

So the page body now says iOS and Android are coming soon while the search result, the OG card, and `llms.txt` still advertise them as available. It is a different edit on each branch — `lib/seo/public-content.ts` on `main`, the inline `metadata` object in `page.tsx` on `staging` — so folding it in here would stop this being a clean cherry-pick. Worth a follow-up on `main` first.

## Merge note

Per repo convention, staging PRs merge by **rebase**.