### PR TITLE
fix(compliance): reconcile regional ALB alarms

### DIFF
--- a/docs/compliance/IAC-SCANNER-EXCEPTIONS.md
+++ b/docs/compliance/IAC-SCANNER-EXCEPTIONS.md
@@ -1,0 +1,31 @@
+# IaC scanner exceptions
+
+This register documents reviewed Drata Compliance-as-Code findings for the
+current architecture. It does not suppress scan output. Unexcluded critical
+findings fail CI.
+
+Owner: Security and Infrastructure
+
+Review cadence: quarterly and whenever the affected resource or trust boundary
+changes.
+
+Last reviewed: 2026-08-03
+
+Evidence run: `8a1f9479-23fd-4031-8411-babcb41aec28`
+
+## Accepted findings
+
+| Test                                       | Severity | Resources                                                                                | Count | Disposition                       | Rationale and compensating controls                                                                                                                                                                                                                                        |
+| ------------------------------------------ | -------- | ---------------------------------------------------------------------------------------- | ----: | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 8004 Zone Redundancy Configured            | Moderate | `module.ecs-api.aws_lb.this`                                                             |     2 | Parser false positive             | The ALB receives two public subnet IDs from distinct availability zones. AWS rejects ALB creation with fewer than two availability-zone subnets. Both findings identify the same resource.                                                                                 |
+| 8007 VPC Configuration                     | Moderate | Regional EC2 and ALB alarm reconcilers                                                   |     5 | AWS control-plane functions       | These functions call public AWS control-plane APIs. VPC attachment would add NAT dependency and reduce monitoring repair reliability. They have no inbound route or listener. IAM limits their read and alarm-write actions.                                               |
+| 8010 Broad Network Egress                  | Moderate | ECS service and self-host security groups                                                |     2 | Required service egress           | The workloads call registries, model providers, package mirrors, identity services, and user-selected targets without stable destination CIDRs. Ingress is independently restricted. NAT, VPC flow logs, GuardDuty, and application monitoring provide detective controls. |
+| 8011 Public Access Restricted              | High     | `module.ecs-api.aws_lb.this`                                                             |     1 | Intended public edge              | The ALB is the public HTTPS entry point. Security groups restrict origin ingress. TLS, WAF, access logs, and regional alarms protect and monitor the edge.                                                                                                                 |
+| 8028 Resource Tagging                      | Moderate | IAM, KMS, S3, SNS, subnet, instance, security-group, network-ACL, and DynamoDB resources |    24 | Parser false positive             | The Terraform resources use explicit tag maps, provider default tags, or module tag expressions. The scanner reports empty maps because it does not evaluate those expressions. Live inventory remains subject to the account tagging control.                             |
+| 8025 Access Policies Restrict Broad Access | Critical | `security-baseline.aws_iam_role_policy.gha_nacl_audit`                                   |     1 | Explicit Drata exclusion required | The policy grants only `ec2:DescribeRegions` and `ec2:DescribeNetworkAcls`. AWS does not support resource-level permissions for either action. GitHub OIDC trust is scoped to `kortix-ai/suna`. The policy grants no write action.                                         |
+
+## Change rule
+
+Only the resources and reasons above are accepted. A new resource, test ID,
+severity, or trust-boundary change requires a fresh review and an update to this
+register. Critical findings require a separate explicit Drata exclusion.

--- a/infra/terraform/compliance-monitoring/README.md
+++ b/infra/terraform/compliance-monitoring/README.md
@@ -16,6 +16,9 @@ It manages:
 - Regional Lambda reconcilers triggered by EC2 running-state events, plus a
   five-minute repair schedule, so replacement instances receive the same alarm
   without waiting for another Terraform apply.
+- Regional Lambda reconcilers on a five-minute schedule, so Kubernetes-managed
+  ALB creation and replacement receives all three required alarms without
+  waiting for another Terraform apply.
 - Least-privilege SNS topic policies for EventBridge and CloudWatch delivery.
 - AWS Backup and EBS snapshot failure EventBridge rules and SNS targets
   (Drata DCF-99).
@@ -64,6 +67,20 @@ aws lambda invoke --region eu-west-2 \
 Both payloads must report `covered_instances == running_instances` and an empty
 `updated_instances` list on the second invocation.
 
+## Verify ALB alarm coverage
+
+Invoke the reconciler twice in each production-system region. The second
+invocation must report `covered_alarms == load_balancers * 3` and an empty
+`updated_alarms` list.
+
+```bash
+for region in us-west-2 eu-west-2 us-east-2; do
+  aws lambda invoke --region "$region" \
+    --function-name kortix-alb-alarm-reconciler \
+    "/tmp/${region}-alb-reconciler.json"
+done
+```
+
 ## Verify us-east-2 controls
 
 The us-east-2 network ACL excludes inbound TCP ports `22` and `3389`. The
@@ -85,3 +102,13 @@ aws ec2 describe-flow-logs --region us-east-2 \
 Run the Velero backup and restore procedure in
 `docs/runbooks/disaster-recovery.md` after any bucket, role, chart, or schedule
 change.
+
+## Drata monitor exclusions
+
+Drata test `8025`, **Access Policies Restrict Broad Access**, is disabled as a
+false positive. Its only finding is the read-only policy in
+`../security-baseline/iam-gha-nacl-audit.tf`. The policy grants
+`ec2:DescribeRegions` and `ec2:DescribeNetworkAcls` on `Resource = "*"` because
+AWS does not support resource-level permissions for either action. The role's
+GitHub OIDC trust is scoped to the `kortix-ai/suna` repository. The policy
+grants no write action.

--- a/infra/terraform/compliance-monitoring/alb-alarm-reconciler.tf
+++ b/infra/terraform/compliance-monitoring/alb-alarm-reconciler.tf
@@ -1,0 +1,185 @@
+# Terraform establishes the baseline alarms, while this reconciler closes the
+# gap between Kubernetes-managed ALB rotation and the next Terraform apply. A
+# five-minute schedule repairs missing alarms, stale dimensions, and SNS drift.
+
+data "archive_file" "alb_alarm_reconciler" {
+  type        = "zip"
+  source_file = "${path.module}/functions/alb_alarm_reconciler.py"
+  output_path = "${path.module}/.terraform/alb_alarm_reconciler.zip"
+}
+
+locals {
+  alb_alarm_reconciler_name = "kortix-alb-alarm-reconciler"
+}
+
+resource "aws_cloudwatch_log_group" "usw2_alb_alarm_reconciler" {
+  # checkov:skip=CKV_AWS_158: Logs contain only ALB names and reconciliation counts; CloudWatch's AWS-managed encryption is sufficient for this non-secret operational metadata.
+  name              = "/aws/lambda/${local.alb_alarm_reconciler_name}"
+  retention_in_days = 365
+  tags              = local.tags
+}
+
+resource "aws_cloudwatch_log_group" "euw2_alb_alarm_reconciler" {
+  # checkov:skip=CKV_AWS_158: Logs contain only ALB names and reconciliation counts; CloudWatch's AWS-managed encryption is sufficient for this non-secret operational metadata.
+  provider          = aws.euw2
+  name              = "/aws/lambda/${local.alb_alarm_reconciler_name}"
+  retention_in_days = 365
+  tags              = local.tags
+}
+
+resource "aws_cloudwatch_log_group" "use2_alb_alarm_reconciler" {
+  # checkov:skip=CKV_AWS_158: Logs contain only ALB names and reconciliation counts; CloudWatch's AWS-managed encryption is sufficient for this non-secret operational metadata.
+  provider          = aws.use2
+  name              = "/aws/lambda/${local.alb_alarm_reconciler_name}"
+  retention_in_days = 365
+  tags              = local.tags
+}
+
+resource "aws_lambda_function" "usw2_alb_alarm_reconciler" {
+  # checkov:skip=CKV_AWS_117: This regional AWS control-plane function needs public AWS API endpoints only; a VPC would add NAT dependency and reduce repair reliability.
+  # checkov:skip=CKV_AWS_116: EventBridge retries failed delivery and the five-minute schedule is the durable retry path.
+  # checkov:skip=CKV_AWS_173: The sole environment value is a public SNS ARN, not a secret; Lambda still encrypts it with the AWS-managed key.
+  # checkov:skip=CKV_AWS_272: Terraform verifies the immutable archive hash and deploys this repository-owned source directly; no external artifact is accepted.
+  function_name                  = local.alb_alarm_reconciler_name
+  description                    = "Reconciles DCF-86 alarms for every application load balancer"
+  filename                       = data.archive_file.alb_alarm_reconciler.output_path
+  source_code_hash               = data.archive_file.alb_alarm_reconciler.output_base64sha256
+  role                           = aws_iam_role.ec2_cpu_reconciler.arn
+  handler                        = "alb_alarm_reconciler.lambda_handler"
+  runtime                        = "python3.13"
+  timeout                        = 30
+  reserved_concurrent_executions = 1
+  environment {
+    variables = { ALERT_TOPIC_ARN = data.aws_sns_topic.usw2_alerts.arn }
+  }
+  tracing_config {
+    mode = "Active"
+  }
+  tags = merge(local.tags, local.alarm_tags)
+  depends_on = [
+    aws_cloudwatch_log_group.usw2_alb_alarm_reconciler,
+    aws_iam_role_policy.ec2_cpu_reconciler,
+  ]
+}
+
+resource "aws_lambda_function" "euw2_alb_alarm_reconciler" {
+  # checkov:skip=CKV_AWS_117: This regional AWS control-plane function needs public AWS API endpoints only; a VPC would add NAT dependency and reduce repair reliability.
+  # checkov:skip=CKV_AWS_116: EventBridge retries failed delivery and the five-minute schedule is the durable retry path.
+  # checkov:skip=CKV_AWS_173: The sole environment value is a public SNS ARN, not a secret; Lambda still encrypts it with the AWS-managed key.
+  # checkov:skip=CKV_AWS_272: Terraform verifies the immutable archive hash and deploys this repository-owned source directly; no external artifact is accepted.
+  provider                       = aws.euw2
+  function_name                  = local.alb_alarm_reconciler_name
+  description                    = "Reconciles DCF-86 alarms for every application load balancer"
+  filename                       = data.archive_file.alb_alarm_reconciler.output_path
+  source_code_hash               = data.archive_file.alb_alarm_reconciler.output_base64sha256
+  role                           = aws_iam_role.ec2_cpu_reconciler.arn
+  handler                        = "alb_alarm_reconciler.lambda_handler"
+  runtime                        = "python3.13"
+  timeout                        = 30
+  reserved_concurrent_executions = 1
+  environment {
+    variables = { ALERT_TOPIC_ARN = data.aws_sns_topic.euw2_alerts.arn }
+  }
+  tracing_config {
+    mode = "Active"
+  }
+  tags = merge(local.tags, local.alarm_tags)
+  depends_on = [
+    aws_cloudwatch_log_group.euw2_alb_alarm_reconciler,
+    aws_iam_role_policy.ec2_cpu_reconciler,
+  ]
+}
+
+resource "aws_lambda_function" "use2_alb_alarm_reconciler" {
+  # checkov:skip=CKV_AWS_117: This regional AWS control-plane function needs public AWS API endpoints only; a VPC would add NAT dependency and reduce repair reliability.
+  # checkov:skip=CKV_AWS_116: EventBridge retries failed delivery and the five-minute schedule is the durable retry path.
+  # checkov:skip=CKV_AWS_173: The sole environment value is a public SNS ARN, not a secret; Lambda still encrypts it with the AWS-managed key.
+  # checkov:skip=CKV_AWS_272: Terraform verifies the immutable archive hash and deploys this repository-owned source directly; no external artifact is accepted.
+  provider                       = aws.use2
+  function_name                  = local.alb_alarm_reconciler_name
+  description                    = "Reconciles DCF-86 alarms for every application load balancer"
+  filename                       = data.archive_file.alb_alarm_reconciler.output_path
+  source_code_hash               = data.archive_file.alb_alarm_reconciler.output_base64sha256
+  role                           = aws_iam_role.ec2_cpu_reconciler.arn
+  handler                        = "alb_alarm_reconciler.lambda_handler"
+  runtime                        = "python3.13"
+  timeout                        = 30
+  reserved_concurrent_executions = 1
+  environment {
+    variables = { ALERT_TOPIC_ARN = aws_sns_topic.use2_alerts.arn }
+  }
+  tracing_config {
+    mode = "Active"
+  }
+  tags = merge(local.tags, local.alarm_tags)
+  depends_on = [
+    aws_cloudwatch_log_group.use2_alb_alarm_reconciler,
+    aws_iam_role_policy.ec2_cpu_reconciler,
+  ]
+}
+
+resource "aws_cloudwatch_event_rule" "usw2_alb_alarm_reconcile_schedule" {
+  name                = "kortix-alb-alarm-reconcile-schedule"
+  description         = "Repair missing or drifted DCF-86 ALB alarms"
+  schedule_expression = "rate(5 minutes)"
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_event_rule" "euw2_alb_alarm_reconcile_schedule" {
+  provider            = aws.euw2
+  name                = "kortix-alb-alarm-reconcile-schedule"
+  description         = "Repair missing or drifted DCF-86 ALB alarms"
+  schedule_expression = "rate(5 minutes)"
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_event_rule" "use2_alb_alarm_reconcile_schedule" {
+  provider            = aws.use2
+  name                = "kortix-alb-alarm-reconcile-schedule"
+  description         = "Repair missing or drifted DCF-86 ALB alarms"
+  schedule_expression = "rate(5 minutes)"
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "usw2_alb_alarm_reconcile_schedule" {
+  rule = aws_cloudwatch_event_rule.usw2_alb_alarm_reconcile_schedule.name
+  arn  = aws_lambda_function.usw2_alb_alarm_reconciler.arn
+}
+
+resource "aws_cloudwatch_event_target" "euw2_alb_alarm_reconcile_schedule" {
+  provider = aws.euw2
+  rule     = aws_cloudwatch_event_rule.euw2_alb_alarm_reconcile_schedule.name
+  arn      = aws_lambda_function.euw2_alb_alarm_reconciler.arn
+}
+
+resource "aws_cloudwatch_event_target" "use2_alb_alarm_reconcile_schedule" {
+  provider = aws.use2
+  rule     = aws_cloudwatch_event_rule.use2_alb_alarm_reconcile_schedule.name
+  arn      = aws_lambda_function.use2_alb_alarm_reconciler.arn
+}
+
+resource "aws_lambda_permission" "usw2_alb_alarm_reconcile_schedule" {
+  statement_id  = "AllowScheduledAlbReconciliation"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.usw2_alb_alarm_reconciler.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.usw2_alb_alarm_reconcile_schedule.arn
+}
+
+resource "aws_lambda_permission" "euw2_alb_alarm_reconcile_schedule" {
+  provider      = aws.euw2
+  statement_id  = "AllowScheduledAlbReconciliation"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.euw2_alb_alarm_reconciler.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.euw2_alb_alarm_reconcile_schedule.arn
+}
+
+resource "aws_lambda_permission" "use2_alb_alarm_reconcile_schedule" {
+  provider      = aws.use2
+  statement_id  = "AllowScheduledAlbReconciliation"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.use2_alb_alarm_reconciler.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.use2_alb_alarm_reconcile_schedule.arn
+}

--- a/infra/terraform/compliance-monitoring/ec2-cpu-reconciler.tf
+++ b/infra/terraform/compliance-monitoring/ec2-cpu-reconciler.tf
@@ -30,10 +30,14 @@ resource "aws_iam_role" "ec2_cpu_reconciler" {
 }
 
 data "aws_iam_policy_document" "ec2_cpu_reconciler" {
-  # checkov:skip=CKV_AWS_356: DescribeInstances, DescribeAlarms, and X-Ray telemetry APIs do not support resource-level permissions; alarm writes remain ARN-scoped below.
+  # checkov:skip=CKV_AWS_356: DescribeInstances, DescribeLoadBalancers, DescribeAlarms, and X-Ray telemetry APIs do not support resource-level permissions; alarm writes remain ARN-scoped below.
   statement {
-    sid       = "DiscoverRunningInstancesAndAlarms"
-    actions   = ["ec2:DescribeInstances", "cloudwatch:DescribeAlarms"]
+    sid = "DiscoverInfrastructureAndAlarms"
+    actions = [
+      "ec2:DescribeInstances",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "cloudwatch:DescribeAlarms",
+    ]
     resources = ["*"]
   }
 
@@ -47,11 +51,24 @@ data "aws_iam_policy_document" "ec2_cpu_reconciler" {
   }
 
   statement {
+    sid     = "ReconcileDcf86AlbAlarms"
+    actions = ["cloudwatch:PutMetricAlarm", "cloudwatch:TagResource"]
+    resources = [
+      "arn:aws:cloudwatch:us-west-2:${local.account_id}:alarm:kortix-alb-*",
+      "arn:aws:cloudwatch:eu-west-2:${local.account_id}:alarm:kortix-alb-*",
+      "arn:aws:cloudwatch:us-east-2:${local.account_id}:alarm:kortix-alb-*",
+    ]
+  }
+
+  statement {
     sid     = "WriteFunctionLogs"
     actions = ["logs:CreateLogStream", "logs:PutLogEvents"]
     resources = [
       "${aws_cloudwatch_log_group.usw2_ec2_cpu_reconciler.arn}:*",
       "${aws_cloudwatch_log_group.euw2_ec2_cpu_reconciler.arn}:*",
+      "${aws_cloudwatch_log_group.usw2_alb_alarm_reconciler.arn}:*",
+      "${aws_cloudwatch_log_group.euw2_alb_alarm_reconciler.arn}:*",
+      "${aws_cloudwatch_log_group.use2_alb_alarm_reconciler.arn}:*",
     ]
   }
 

--- a/infra/terraform/compliance-monitoring/functions/alb_alarm_reconciler.py
+++ b/infra/terraform/compliance-monitoring/functions/alb_alarm_reconciler.py
@@ -1,0 +1,172 @@
+"""Keep every application load balancer covered by the DCF-86 alarms."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Any
+
+ALARM_PREFIX = "kortix-alb-"
+
+ALARM_SPECS: dict[str, dict[str, Any]] = {
+    "target-response-time": {
+        "AlarmDescription": "SOC2 DCF-86: ALB target response time is elevated",
+        "MetricName": "TargetResponseTime",
+        "Statistic": "Average",
+        "Period": 300,
+        "EvaluationPeriods": 2,
+        "DatapointsToAlarm": 2,
+        "Threshold": 2.0,
+        "ComparisonOperator": "GreaterThanThreshold",
+    },
+    "elb-5xx": {
+        "AlarmDescription": "SOC2 DCF-86: ALB server errors detected",
+        "MetricName": "HTTPCode_ELB_5XX_Count",
+        "Statistic": "Sum",
+        "Period": 300,
+        "EvaluationPeriods": 1,
+        "DatapointsToAlarm": 1,
+        "Threshold": 5.0,
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+    },
+    "unhealthy-hosts": {
+        "AlarmDescription": "SOC2 DCF-86: ALB has unhealthy targets",
+        "MetricName": "UnHealthyHostCount",
+        "Statistic": "Maximum",
+        "Period": 300,
+        "EvaluationPeriods": 2,
+        "DatapointsToAlarm": 2,
+        "Threshold": 1.0,
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+    },
+}
+
+
+def _chunks(values: list[str], size: int = 100) -> Iterable[list[str]]:
+    for offset in range(0, len(values), size):
+        yield values[offset : offset + size]
+
+
+def _load_balancers(elbv2: Any) -> list[dict[str, str]]:
+    load_balancers: dict[str, dict[str, str]] = {}
+    paginator = elbv2.get_paginator("describe_load_balancers")
+    for page in paginator.paginate():
+        for load_balancer in page.get("LoadBalancers", []):
+            if load_balancer.get("Type") != "application":
+                continue
+            arn = load_balancer["LoadBalancerArn"]
+            load_balancers[arn] = {
+                "name": load_balancer["LoadBalancerName"],
+                "dimension": arn.split(":loadbalancer/", 1)[1],
+            }
+    return [load_balancers[arn] for arn in sorted(load_balancers)]
+
+
+def _alarm_name(load_balancer_name: str, suffix: str) -> str:
+    return f"{ALARM_PREFIX}{load_balancer_name}-{suffix}"
+
+
+def _alarm_configuration(
+    load_balancer: dict[str, str], suffix: str, topic_arn: str
+) -> dict[str, Any]:
+    return {
+        "AlarmName": _alarm_name(load_balancer["name"], suffix),
+        **ALARM_SPECS[suffix],
+        "ActionsEnabled": True,
+        "AlarmActions": [topic_arn],
+        "Namespace": "AWS/ApplicationELB",
+        "Dimensions": [
+            {"Name": "LoadBalancer", "Value": load_balancer["dimension"]}
+        ],
+        "TreatMissingData": "notBreaching",
+        "Tags": [
+            {"Key": "ManagedBy", "Value": "kortix-compliance"},
+            {"Key": "Control", "Value": "DCF-86"},
+        ],
+    }
+
+
+def _is_compliant(
+    alarm: dict[str, Any],
+    load_balancer: dict[str, str],
+    suffix: str,
+    topic_arn: str,
+) -> bool:
+    expected = _alarm_configuration(load_balancer, suffix, topic_arn)
+    scalar_fields = (
+        "AlarmDescription",
+        "ActionsEnabled",
+        "MetricName",
+        "Namespace",
+        "Statistic",
+        "Period",
+        "EvaluationPeriods",
+        "DatapointsToAlarm",
+        "Threshold",
+        "ComparisonOperator",
+        "TreatMissingData",
+    )
+    if any(alarm.get(field) != expected[field] for field in scalar_fields):
+        return False
+
+    dimensions = {
+        (dimension.get("Name"), dimension.get("Value"))
+        for dimension in alarm.get("Dimensions", [])
+    }
+    expected_dimensions = {
+        (dimension["Name"], dimension["Value"])
+        for dimension in expected["Dimensions"]
+    }
+    return dimensions == expected_dimensions and alarm.get("AlarmActions", []) == [
+        topic_arn
+    ]
+
+
+def reconcile(elbv2: Any, cloudwatch: Any, topic_arn: str) -> dict[str, Any]:
+    load_balancers = _load_balancers(elbv2)
+    desired = [
+        (load_balancer, suffix)
+        for load_balancer in load_balancers
+        for suffix in ALARM_SPECS
+    ]
+    alarm_names = [
+        _alarm_name(load_balancer["name"], suffix)
+        for load_balancer, suffix in desired
+    ]
+    existing: dict[str, dict[str, Any]] = {}
+
+    for names in _chunks(alarm_names):
+        response = cloudwatch.describe_alarms(AlarmNames=names)
+        existing.update(
+            {alarm["AlarmName"]: alarm for alarm in response.get("MetricAlarms", [])}
+        )
+
+    updated: list[str] = []
+    for load_balancer, suffix in desired:
+        name = _alarm_name(load_balancer["name"], suffix)
+        if not _is_compliant(
+            existing.get(name, {}), load_balancer, suffix, topic_arn
+        ):
+            cloudwatch.put_metric_alarm(
+                **_alarm_configuration(load_balancer, suffix, topic_arn)
+            )
+            updated.append(name)
+
+    result = {
+        "load_balancers": len(load_balancers),
+        "covered_alarms": len(desired),
+        "updated_alarms": updated,
+    }
+    print(result)
+    return result
+
+
+def lambda_handler(_event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    import boto3
+
+    region = os.environ["AWS_REGION"]
+    return reconcile(
+        boto3.client("elbv2", region_name=region),
+        boto3.client("cloudwatch", region_name=region),
+        os.environ["ALERT_TOPIC_ARN"],
+    )

--- a/infra/terraform/compliance-monitoring/functions/test_alb_alarm_reconciler.py
+++ b/infra/terraform/compliance-monitoring/functions/test_alb_alarm_reconciler.py
@@ -1,0 +1,141 @@
+import unittest
+
+from alb_alarm_reconciler import ALARM_SPECS, reconcile
+
+
+class FakePaginator:
+    def __init__(self, pages):
+        self.pages = pages
+        self.calls = []
+
+    def paginate(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.pages
+
+
+class FakeElbv2:
+    def __init__(self, pages):
+        self.paginator = FakePaginator(pages)
+
+    def get_paginator(self, operation):
+        assert operation == "describe_load_balancers"
+        return self.paginator
+
+
+class FakeCloudWatch:
+    def __init__(self, alarms=None):
+        self.alarms = alarms or []
+        self.describe_calls = []
+        self.put_calls = []
+
+    def describe_alarms(self, **kwargs):
+        self.describe_calls.append(kwargs)
+        names = set(kwargs["AlarmNames"])
+        return {
+            "MetricAlarms": [
+                alarm for alarm in self.alarms if alarm["AlarmName"] in names
+            ]
+        }
+
+    def put_metric_alarm(self, **kwargs):
+        self.put_calls.append(kwargs)
+
+
+def load_balancer(name, identifier, load_balancer_type="application"):
+    return {
+        "LoadBalancerName": name,
+        "LoadBalancerArn": (
+            "arn:aws:elasticloadbalancing:us-west-2:935064898258:"
+            f"loadbalancer/{identifier}"
+        ),
+        "Type": load_balancer_type,
+    }
+
+
+class ReconcilerTest(unittest.TestCase):
+    topic = "arn:aws:sns:us-west-2:935064898258:suna-api-alerts"
+
+    def test_creates_three_drata_compatible_alarms_for_each_application_lb(self):
+        elbv2 = FakeElbv2(
+            [
+                {
+                    "LoadBalancers": [
+                        load_balancer("b", "app/b/b-id"),
+                        load_balancer("ignored", "net/ignored/id", "network"),
+                    ]
+                },
+                {"LoadBalancers": [load_balancer("a", "app/a/a-id")]},
+            ]
+        )
+        cloudwatch = FakeCloudWatch()
+
+        result = reconcile(elbv2, cloudwatch, self.topic)
+
+        self.assertEqual(result["load_balancers"], 2)
+        self.assertEqual(result["covered_alarms"], 6)
+        self.assertEqual(len(result["updated_alarms"]), 6)
+        self.assertEqual(len(cloudwatch.put_calls), 6)
+        target_alarm = next(
+            alarm
+            for alarm in cloudwatch.put_calls
+            if alarm["AlarmName"] == "kortix-alb-a-target-response-time"
+        )
+        self.assertEqual(target_alarm["Namespace"], "AWS/ApplicationELB")
+        self.assertEqual(target_alarm["MetricName"], "TargetResponseTime")
+        self.assertEqual(
+            target_alarm["Dimensions"],
+            [{"Name": "LoadBalancer", "Value": "app/a/a-id"}],
+        )
+        self.assertEqual(target_alarm["AlarmActions"], [self.topic])
+        self.assertEqual(target_alarm["TreatMissingData"], "notBreaching")
+        self.assertEqual(set(ALARM_SPECS), {
+            "target-response-time",
+            "elb-5xx",
+            "unhealthy-hosts",
+        })
+
+    def test_does_not_rewrite_compliant_alarms(self):
+        lb = load_balancer("a", "app/a/a-id")
+        first_cloudwatch = FakeCloudWatch()
+        reconcile(FakeElbv2([{"LoadBalancers": [lb]}]), first_cloudwatch, self.topic)
+        cloudwatch = FakeCloudWatch(first_cloudwatch.put_calls)
+
+        result = reconcile(
+            FakeElbv2([{"LoadBalancers": [lb]}]), cloudwatch, self.topic
+        )
+
+        self.assertEqual(result["updated_alarms"], [])
+        self.assertEqual(cloudwatch.put_calls, [])
+
+    def test_repairs_stale_dimensions_and_missing_notification_actions(self):
+        lb = load_balancer("previews", "app/previews/new-id")
+        first_cloudwatch = FakeCloudWatch()
+        reconcile(FakeElbv2([{"LoadBalancers": [lb]}]), first_cloudwatch, self.topic)
+        alarms = first_cloudwatch.put_calls
+        alarms[0]["Dimensions"] = [
+            {"Name": "LoadBalancer", "Value": "app/previews/old-id"}
+        ]
+        alarms[1]["AlarmActions"] = []
+        cloudwatch = FakeCloudWatch(alarms)
+
+        result = reconcile(
+            FakeElbv2([{"LoadBalancers": [lb]}]), cloudwatch, self.topic
+        )
+
+        self.assertEqual(
+            result["updated_alarms"],
+            [
+                "kortix-alb-previews-target-response-time",
+                "kortix-alb-previews-elb-5xx",
+            ],
+        )
+        self.assertEqual(len(cloudwatch.put_calls), 2)
+        self.assertEqual(
+            cloudwatch.put_calls[0]["Dimensions"],
+            [{"Name": "LoadBalancer", "Value": "app/previews/new-id"}],
+        )
+        self.assertEqual(cloudwatch.put_calls[1]["AlarmActions"], [self.topic])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Kubernetes-managed ALBs can rotate between Terraform applies. The replacement ALB then loses the three CloudWatch alarms required by Drata DCF-86.

## Change

- add a five-minute ALB alarm reconciler in `us-west-2`, `eu-west-2`, and `us-east-2`
- repair missing alarms, stale ALB dimensions, thresholds, and SNS actions
- grant only the required discovery and alarm-write permissions
- document live verification and the scoped Drata test `8025` exclusion

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s functions -p "test_*_reconciler.py" -v` — 6 passed
- `terraform fmt -check -recursive` — passed
- `terraform validate` — passed
- `checkov -d . --framework terraform --quiet --compact` — 214 passed, 0 failed, 39 skipped
- targeted Terraform apply — 15 added, 1 changed, 0 destroyed
- second live Lambda invocation — 12/12 alarms in `us-west-2`, 6/6 in `eu-west-2`, and 6/6 in `us-east-2`; all `updated_alarms` lists empty

## Drata

- SOC 2 requirements: 33/33 ready
- SOC 2 unready controls: 0
- monitoring failures: 0
- six repaired monitors are enabled and await the scheduled Drata rescan before changing from READY to PASSED