### PR TITLE
Point systemReload at endpoints that exist

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/dispose-reload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/dispose-reload.test.ts
@@ -59,7 +59,12 @@ describe('tryDisposeReload', () => {
     // otherwise be read as "reloaded" and skip the fallback, leaving the old
     // config running while we reported success.
     const body = disposeReloadBody()
-    expect(body).toContain("includes('application/json')")
+    // Matched case-insensitively, not by substring: header values are
+    // case-insensitive and `application/<vendor>+json` is JSON. A false
+    // negative here would cost a needless ~8s respawn.
+    expect(body).toContain('json')
+    expect(body).toContain('/i.test(')
+    expect(body).not.toContain("includes('application/json')")
     expect(body).toContain('body === true')
   })
 

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1143,7 +1143,11 @@ export function createOpencodeSupervisor(
       )
       // Content-type matters: the SPA catch-all also answers 200, so a status
       // check alone cannot tell the real endpoint from the web UI.
-      const isJson = (res.headers.get('content-type') ?? '').includes('application/json')
+      // Case-insensitive, and `application/<vendor>+json` counts — a false
+      // negative here would fall back to an ~8s respawn for no reason.
+      const isJson = /^application\/([\w.+-]+\+)?json\b/i.test(
+        (res.headers.get('content-type') ?? '').trim(),
+      )
       // And the BODY matters: the endpoint answers `true` on success. A JSON
       // `false` (or an error object) with a 200 would otherwise be read as
       // "reloaded" and skip the fallback, leaving the old config running while

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -1148,6 +1148,11 @@ export function CommandPalette() {
     });
   }, [close]);
 
+  // A rejected promise is not guaranteed to carry an Error, and a toast reading
+  // "undefined" is worse than a generic one.
+  const reloadErrorMessage = (err: unknown): string =>
+    err instanceof Error && err.message ? err.message : 'Restart failed';
+
   const handleRestartConfig = useCallback(() => {
     close();
     systemReload('dispose-only')
@@ -1156,7 +1161,7 @@ export function CommandPalette() {
           ? successToast('Config reloaded')
           : errorToast(r.errors[0] ?? 'The sandbox did not confirm the reload'),
       )
-      .catch((err: Error) => errorToast(err.message));
+      .catch((err: unknown) => errorToast(reloadErrorMessage(err)));
   }, [close]);
 
   const handleRestartFull = useCallback(() => {
@@ -1167,7 +1172,7 @@ export function CommandPalette() {
           ? successToast('Workspace pulled and runtime restarted')
           : errorToast(r.errors[0] ?? 'The sandbox did not confirm the restart'),
       )
-      .catch((err: Error) => errorToast(err.message));
+      .catch((err: unknown) => errorToast(reloadErrorMessage(err)));
   }, [close]);
 
   const actionHandlers: Record<string, () => void> = useMemo(

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -1151,15 +1151,23 @@ export function CommandPalette() {
   const handleRestartConfig = useCallback(() => {
     close();
     systemReload('dispose-only')
-      .then(() => successToast('Config reloaded'))
-      .catch(() => errorToast('Restart failed'));
+      .then((r) =>
+        r.success
+          ? successToast('Config reloaded')
+          : errorToast(r.errors[0] ?? 'The sandbox did not confirm the reload'),
+      )
+      .catch((err: Error) => errorToast(err.message));
   }, [close]);
 
   const handleRestartFull = useCallback(() => {
     close();
     systemReload('full')
-      .then(() => successToast('Full restart initiated'))
-      .catch(() => errorToast('Restart failed'));
+      .then((r) =>
+        r.success
+          ? successToast('Workspace pulled and runtime restarted')
+          : errorToast(r.errors[0] ?? 'The sandbox did not confirm the restart'),
+      )
+      .catch((err: Error) => errorToast(err.message));
   }, [close]);
 
   const actionHandlers: Record<string, () => void> = useMemo(

--- a/apps/web/src/lib/menu-registry.ts
+++ b/apps/web/src/lib/menu-registry.ts
@@ -316,13 +316,16 @@ export const menuRegistry: MenuItemDef[] = [
   },
   {
     id: 'restart-full',
-    label: 'Restart: Full',
+    // Says what it does. This maps to the daemon's /kortix/refresh, which pulls
+    // the workspace AND restarts the runtime — "Full" alone did not warn that it
+    // touches the working tree, or that it ends the turn in flight.
+    label: 'Restart: Pull & Restart Runtime',
     icon: RefreshCw,
     group: 'actions',
     showIn: ['commandPalette'],
     kind: 'action',
     actionId: 'restartFull',
-    keywords: 'reload restart full services kill nuclear',
+    keywords: 'reload restart full services kill nuclear pull refresh workspace',
   },
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/docs/SESSION_CONFIG_RELOAD.md
+++ b/docs/SESSION_CONFIG_RELOAD.md
@@ -136,9 +136,11 @@ after the edit. The clean run above is the one to trust.
 2. The mid-session model change, the compiled-agent-config push, and
    `kortix sessions reload` all take the fast path. When dispose wins they **no
    longer sever an in-flight turn**, because nothing restarts.
-3. **`systemReload()` in the SDK is broken** — `packages/sdk/src/core/runtime/client.ts`
-   POSTs `/kortix/services/system/reload`, gets 200 + HTML, and throws on
-   `response.json()`. Its only caller is the web command palette's
-   "Restart: Config Only" (`apps/web/src/lib/menu-registry.ts`). Mobile never used
-   it — it POSTs `/global/dispose` directly, which is why mobile works and web
-   does not. Left as a separate follow-up rather than widened into this change.
+3. **`systemReload()` in the SDK was broken and is now fixed.** It POSTed
+   `/kortix/services/system/reload`, got 200 + HTML, and threw on
+   `response.json()` — so both command-palette entries built on it had never
+   worked. Mobile was unaffected: it POSTs `/global/dispose` directly.
+   `'dispose-only'` now targets `/global/dispose` and `'full'` targets
+   `/kortix/refresh` (the only client-reachable path that restarts the runtime —
+   it pulls the workspace too, and the palette label says so). Both check
+   `content-type` before trusting a 200, for the reason above.

--- a/packages/sdk/src/core/runtime/client.test.ts
+++ b/packages/sdk/src/core/runtime/client.test.ts
@@ -169,22 +169,60 @@ function captureRawFetchCalls(response: () => Response) {
   return calls;
 }
 
-test('systemReload POSTs {url}/kortix/services/system/reload with the mode and returns the parsed result', async () => {
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+test("dispose-only POSTs /global/dispose — the endpoint that exists", async () => {
+  // It used to POST /kortix/services/system/reload, which is not a route. That
+  // path hits opencode's SPA catch-all, so the call got 200 + HTML and died on
+  // response.json() — the command palette's "Restart: Config Only" never worked.
   setCurrentRuntime('http://sbx.test', 'active-sbx');
-  const calls = captureRawFetchCalls(
-    () =>
-      new Response(JSON.stringify({ success: true, mode: 'dispose-only', steps: ['a'], errors: [] }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      }),
-  );
+  const calls = captureRawFetchCalls(() => jsonResponse(true));
 
   const result = await systemReload('dispose-only');
 
-  expect(calls[0].url).toBe('http://sbx.test/kortix/services/system/reload');
+  expect(calls[0].url).toBe('http://sbx.test/global/dispose');
   expect(calls[0].method).toBe('POST');
-  expect(JSON.parse(calls[0].body!)).toEqual({ mode: 'dispose-only' });
-  expect(result).toEqual({ success: true, mode: 'dispose-only', steps: ['a'], errors: [] });
+  expect(result.success).toBe(true);
+  expect(result.mode).toBe('dispose-only');
+});
+
+test('full POSTs /kortix/refresh — the only client-reachable runtime restart', async () => {
+  setCurrentRuntime('http://sbx.test', 'active-sbx');
+  const calls = captureRawFetchCalls(() => jsonResponse({ ok: true }));
+
+  const result = await systemReload('full');
+
+  expect(calls[0].url).toBe('http://sbx.test/kortix/refresh');
+  expect(result.success).toBe(true);
+});
+
+test('a 200 with HTML is the SPA catch-all, NOT a reload', async () => {
+  // The whole bug in one assertion: this server answers 200 for every unknown
+  // path. Trusting the status alone is what made a dead endpoint look alive.
+  setCurrentRuntime('http://sbx.test', 'active-sbx');
+  captureRawFetchCalls(
+    () => new Response('<!doctype html><html></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    }),
+  );
+
+  await expect(systemReload('dispose-only')).rejects.toThrow('unavailable on this sandbox');
+});
+
+test('a JSON body that does not confirm reports failure instead of success', async () => {
+  setCurrentRuntime('http://sbx.test', 'active-sbx');
+  captureRawFetchCalls(() => jsonResponse(false));
+
+  const result = await systemReload('dispose-only');
+
+  expect(result.success).toBe(false);
+  expect(result.errors).toHaveLength(1);
+  expect(result.steps).toEqual([]);
 });
 
 test('systemReload throws when the active runtime url is not ready', async () => {

--- a/packages/sdk/src/core/runtime/client.test.ts
+++ b/packages/sdk/src/core/runtime/client.test.ts
@@ -214,6 +214,32 @@ test('a 200 with HTML is the SPA catch-all, NOT a reload', async () => {
   await expect(systemReload('dispose-only')).rejects.toThrow('unavailable on this sandbox');
 });
 
+test('an uppercase or vendor JSON content-type still counts', async () => {
+  // Header values are case-insensitive and `application/<vendor>+json` is JSON.
+  // A false negative here would report a working endpoint as missing.
+  setCurrentRuntime('http://sbx.test', 'active-sbx');
+  captureRawFetchCalls(
+    () => new Response('true', { status: 200, headers: { 'content-type': 'Application/JSON; charset=utf-8' } }),
+  );
+  expect((await systemReload('dispose-only')).success).toBe(true);
+
+  captureRawFetchCalls(
+    () => new Response('true', { status: 200, headers: { 'content-type': 'application/vnd.kortix+json' } }),
+  );
+  expect((await systemReload('dispose-only')).success).toBe(true);
+});
+
+test('a JSON content-type with an unparseable body throws, rather than reporting a decline', async () => {
+  // That is a protocol regression, not a reload that said no — flattening it
+  // into "did not confirm" would hide it and lose the parse detail.
+  setCurrentRuntime('http://sbx.test', 'active-sbx');
+  captureRawFetchCalls(
+    () => new Response('{not json', { status: 200, headers: { 'content-type': 'application/json' } }),
+  );
+
+  await expect(systemReload('dispose-only')).rejects.toThrow('malformed JSON');
+});
+
 test('a JSON body that does not confirm reports failure instead of success', async () => {
   setCurrentRuntime('http://sbx.test', 'active-sbx');
   captureRawFetchCalls(() => jsonResponse(false));

--- a/packages/sdk/src/core/runtime/client.ts
+++ b/packages/sdk/src/core/runtime/client.ts
@@ -245,6 +245,9 @@ export async function systemReload(mode: SystemReloadMode): Promise<SystemReload
 	const path = mode === 'full' ? '/kortix/refresh' : '/global/dispose';
 	const response = await authenticatedFetch(`${url}${path}`, { method: 'POST' });
 	const contentType = response.headers.get('content-type') ?? '';
+	// Case-insensitive, and `application/<vendor>+json` counts. A false negative
+	// here would report a working endpoint as missing.
+	const isJson = /^application\/([\w.+-]+\+)?json\b/i.test(contentType.trim());
 	if (!response.ok) {
 		throw new ApiError(`System reload failed (${response.status}): ${await daemonErrorMessage(response)}`, {
 			status: response.status,
@@ -252,7 +255,7 @@ export async function systemReload(mode: SystemReloadMode): Promise<SystemReload
 			code: 'RUNTIME_UNAVAILABLE',
 		});
 	}
-	if (!contentType.includes('application/json')) {
+	if (!isJson) {
 		// A 200 with HTML is opencode's SPA catch-all — the route is not there.
 		throw new ApiError(`System reload endpoint is unavailable on this sandbox (${path})`, {
 			status: response.status,
@@ -260,7 +263,18 @@ export async function systemReload(mode: SystemReloadMode): Promise<SystemReload
 			code: 'RUNTIME_UNAVAILABLE',
 		});
 	}
-	const body = (await response.json().catch(() => null)) as unknown;
+	let body: unknown;
+	try {
+		body = await response.json();
+	} catch (err) {
+		// JSON content-type with an unparseable body is a protocol regression, not
+		// a reload that declined. Surface it with the parse detail instead of
+		// flattening it into a generic "did not confirm".
+		throw new ApiError(
+			`System reload returned malformed JSON from ${path}: ${err instanceof Error ? err.message : String(err)}`,
+			{ status: response.status, response, code: 'RUNTIME_UNAVAILABLE' },
+		);
+	}
 	// `/global/dispose` answers a bare `true`; `/kortix/refresh` answers an
 	// object with `ok`. Neither matches SystemReloadResult, so build it here
 	// rather than changing a shape callers already consume.

--- a/packages/sdk/src/core/runtime/client.ts
+++ b/packages/sdk/src/core/runtime/client.ts
@@ -215,11 +215,25 @@ export interface SystemReloadResult {
 }
 
 /**
- * Reload the in-sandbox Kortix services daemon (opencode + its plugins).
- * `'dispose-only'` tears down and re-creates config without a full process
- * restart; `'full'` restarts the whole daemon process. Hits the active
- * runtime's `POST /kortix/services/system/reload` — same auth path as every
- * other sandbox call (`authenticatedFetch` via the active server URL).
+ * Apply the sandbox's current config to its running agent runtime.
+ *
+ * `'dispose-only'` — `POST /global/dispose`. opencode re-reads its config FILE
+ * from disk, in-process: same pid, ~51ms, and an in-flight turn survives.
+ * `'full'` — `POST /kortix/refresh`. The daemon pulls the workspace and restarts
+ * opencode. Slower (~8s) and it DOES end the turn in flight, but it is the only
+ * client-reachable path that re-runs spawn-time setup.
+ *
+ * Both endpoints were verified against the pinned opencode (1.17.11) on
+ * 2026-08-03 — see docs/SESSION_CONFIG_RELOAD.md.
+ *
+ * This used to POST `/kortix/services/system/reload`, which does not exist. That
+ * path falls through to opencode's SPA catch-all, so the call got `200` with an
+ * HTML body and died on `response.json()` — both command-palette entries built
+ * on it have never worked. Mobile was unaffected because it calls
+ * `/global/dispose` directly.
+ *
+ * The `ok`-plus-`content-type` check below is why that failure is not
+ * repeatable: against this server a 200 alone does not mean the route exists.
  */
 export async function systemReload(mode: SystemReloadMode): Promise<SystemReloadResult> {
 	const url = getActiveOpenCodeUrl();
@@ -228,11 +242,9 @@ export async function systemReload(mode: SystemReloadMode): Promise<SystemReload
 			code: 'RUNTIME_UNAVAILABLE',
 		});
 	}
-	const response = await authenticatedFetch(`${url}/kortix/services/system/reload`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ mode }),
-	});
+	const path = mode === 'full' ? '/kortix/refresh' : '/global/dispose';
+	const response = await authenticatedFetch(`${url}${path}`, { method: 'POST' });
+	const contentType = response.headers.get('content-type') ?? '';
 	if (!response.ok) {
 		throw new ApiError(`System reload failed (${response.status}): ${await daemonErrorMessage(response)}`, {
 			status: response.status,
@@ -240,5 +252,23 @@ export async function systemReload(mode: SystemReloadMode): Promise<SystemReload
 			code: 'RUNTIME_UNAVAILABLE',
 		});
 	}
-	return response.json() as Promise<SystemReloadResult>;
+	if (!contentType.includes('application/json')) {
+		// A 200 with HTML is opencode's SPA catch-all — the route is not there.
+		throw new ApiError(`System reload endpoint is unavailable on this sandbox (${path})`, {
+			status: response.status,
+			response,
+			code: 'RUNTIME_UNAVAILABLE',
+		});
+	}
+	const body = (await response.json().catch(() => null)) as unknown;
+	// `/global/dispose` answers a bare `true`; `/kortix/refresh` answers an
+	// object with `ok`. Neither matches SystemReloadResult, so build it here
+	// rather than changing a shape callers already consume.
+	const success = body === true || (typeof body === 'object' && body !== null && (body as { ok?: unknown }).ok === true);
+	return {
+		success,
+		mode,
+		steps: success ? [mode === 'full' ? 'refreshed workspace and restarted runtime' : 'reloaded config in place'] : [],
+		errors: success ? [] : [`the sandbox did not confirm the reload (${path})`],
+	};
 }


### PR DESCRIPTION
Follow-up to #6062, which found this while probing the pinned opencode.

## The bug

`systemReload()` POSTed `/kortix/services/system/reload`. **That route does not exist.** It falls through to opencode's SPA catch-all, so the call got `200` with an HTML body and threw on `response.json()`.

Its only callers are the command palette's **"Restart: Config Only"** and **"Restart: Full"** — so neither has ever worked; both just showed "Restart failed". Mobile was unaffected because it POSTs `/global/dispose` directly.

## The fix

| mode | endpoint | behaviour |
|---|---|---|
| `dispose-only` | `POST /global/dispose` | in-process config re-read, ~51ms, **survives an in-flight turn** |
| `full` | `POST /kortix/refresh` | pulls the workspace and restarts the runtime (~8s, ends the turn) |

Both verified against opencode-ai@1.17.11 in #6062.

`/kortix/refresh` is the only client-reachable path that restarts the runtime — the daemon mounts no dedicated restart route. It also pulls the workspace, so **"Restart: Full" is renamed "Restart: Pull & Restart Runtime"**: the old label implied a side-effect-free restart and warned about neither the working tree nor the turn it ends.

**Both modes check `content-type` before trusting a 200.** That is the entire bug in one line — against this server a 200 does not mean the route ran. A JSON body that does not confirm (`false`, or an error object) now returns `success: false` rather than being reported as a win, and the palette reads that flag instead of treating any resolved promise as success.

`SystemReloadResult` is built in the client, since neither endpoint returns that shape and callers already consume it. No public export changed — surface snapshots are untouched.

## Verification

SDK 1406 pass / 1 fail — that one failure (`fetchCostExportCsv`) is **pre-existing on clean main**, verified by stashing. `apps/web` 3704 pass / 0 fail. Typechecks clean; `apps/web` at its 17-error baseline with nothing in the touched files.

Mutation-checked: restoring the dead endpoint turns two tests red; removing the content-type guard turns the SPA-catch-all test red.