### PR TITLE
CLI: stop reporting failure while a cross-account fallback is still pending

### DIFF
--- a/apps/cli/src/__tests__/project-bind.test.ts
+++ b/apps/cli/src/__tests__/project-bind.test.ts
@@ -157,6 +157,35 @@ describe('ensureDefaultProjectBinding', () => {
     expect(out).not.toContain('your first');
   });
 
+  it('stays SILENT on a FAILED project list too, not just an empty one', async () => {
+    // `quiet` promises silence on every path that ends unbound. It first only
+    // covered the empty-account branch, so a caller with a fallback still got a
+    // "could not list projects" line before its scan succeeded.
+    mockProjects({ status: 500 });
+
+    const outcome = await ensureDefaultProjectBinding(AUTH, { quiet: true });
+
+    expect(outcome.project).toBeNull();
+    expect(stderrChunks.join('')).toBe('');
+  });
+
+  it('stays SILENT on a non-TTY with several projects', async () => {
+    mockProjects([project('proj_a', 'A'), project('proj_b', 'B')]);
+
+    const outcome = await ensureDefaultProjectBinding(AUTH, { quiet: true });
+
+    expect(outcome.project).toBeNull();
+    expect(stderrChunks.join('')).toBe('');
+  });
+
+  it('still SPEAKS on those paths without quiet', async () => {
+    // The flag must not become a blanket gag: a caller with no fallback needs
+    // to know why nothing bound.
+    mockProjects({ status: 500 });
+    await ensureDefaultProjectBinding(AUTH);
+    expect(stderrChunks.join('')).toContain('Could not list projects');
+  });
+
   it('stays SILENT when the caller has a fallback', async () => {
     // `locateSessionAnywhere` scans the host's other accounts next and usually
     // finds the session. Announcing "no projects" first reports a failure that

--- a/apps/cli/src/__tests__/project-bind.test.ts
+++ b/apps/cli/src/__tests__/project-bind.test.ts
@@ -143,6 +143,33 @@ describe('ensureDefaultProjectBinding', () => {
     expect(stderrChunks.join('')).toContain('kortix init');
   });
 
+  it('says "in this account", not "your first" — the user may have projects elsewhere', async () => {
+    // The old wording told someone with four projects under a sibling account to
+    // create their first one. It is also the line that makes a command look
+    // failed right before its cross-account fallback succeeds.
+    mockProjects([]);
+
+    await ensureDefaultProjectBinding(AUTH);
+
+    const out = stderrChunks.join('');
+    expect(out).toContain('No projects in this account');
+    expect(out).toContain('kortix accounts use');
+    expect(out).not.toContain('your first');
+  });
+
+  it('stays SILENT when the caller has a fallback', async () => {
+    // `locateSessionAnywhere` scans the host's other accounts next and usually
+    // finds the session. Announcing "no projects" first reports a failure that
+    // has not happened — the command goes on to succeed, but the output reads
+    // as an error.
+    mockProjects([]);
+
+    const outcome = await ensureDefaultProjectBinding(AUTH, { quiet: true });
+
+    expect(outcome.project).toBeNull();
+    expect(stderrChunks.join('')).toBe('');
+  });
+
   it('does not prompt or bind on a non-TTY when several projects exist', async () => {
     mockProjects([project('proj_a', 'A'), project('proj_b', 'B')]);
 

--- a/apps/cli/src/command-helpers.ts
+++ b/apps/cli/src/command-helpers.ts
@@ -11,6 +11,16 @@ interface ProjectContextOpts {
   projectArg?: string;
   /** Override active host for this invocation via --host flag. */
   hostArg?: string;
+  /**
+   * Do not print "No project linked" when nothing resolves.
+   *
+   * Set by callers that have a fallback — `locateSessionAnywhere` goes on to
+   * scan the host's other accounts, and usually finds the session. Printing a
+   * red ✗ first announces a failure that has not happened yet: the command then
+   * succeeds, but anyone reading the output (or piping it through `head`)
+   * concludes it failed. The fallback prints its own error if it runs dry.
+   */
+  quietWhenUnresolved?: boolean;
 }
 
 /**
@@ -65,14 +75,17 @@ export async function resolveProjectContext(
     // non-TTY it degrades to a hint and the error below.)
     const outcome = await ensureDefaultProjectBinding(auth, {
       promptTitle: 'No project bound — pick one for this command',
+      quiet: opts.quietWhenUnresolved,
     });
     projectId = outcome.project?.project_id ?? null;
   }
   if (!projectId) {
-    process.stderr.write(
-      `${status.err('No project linked.')} Run \`kortix projects use\`, ` +
-        `\`kortix projects link\`, or pass ${C.cyan}--project <id>${C.reset}.\n`,
-    );
+    if (!opts.quietWhenUnresolved) {
+      process.stderr.write(
+        `${status.err('No project linked.')} Run \`kortix projects use\`, ` +
+          `\`kortix projects link\`, or pass ${C.cyan}--project <id>${C.reset}.\n`,
+      );
+    }
     return null;
   }
   return { client: clientFromAuth(auth), projectId, auth };
@@ -135,7 +148,9 @@ export async function locateSessionAnywhere(
   // either — resolveProjectContext already explained that below.
   const hostPinnedButLoggedOut = Boolean(opts.hostArg) && !loadAuthForHost(opts.hostArg!)?.token;
 
-  const ctx = await resolveProjectContext(opts);
+  // Quiet: the cross-account scan below is the real answer for a user whose
+  // active account holds no projects, and it usually finds the session.
+  const ctx = await resolveProjectContext({ ...opts, quietWhenUnresolved: true });
   if (ctx) {
     const probed = await probeSession(ctx.client, ctx.projectId, sessionId);
     if (probed !== false && !(probed instanceof ApiError)) {

--- a/apps/cli/src/project-bind.ts
+++ b/apps/cli/src/project-bind.ts
@@ -40,7 +40,19 @@ function bindableAccountId(auth: Auth): string | undefined {
  */
 export async function ensureDefaultProjectBinding(
   auth: Auth,
-  opts: { promptTitle?: string } = {},
+  opts: {
+    promptTitle?: string;
+    /**
+     * Say nothing when no project can be bound.
+     *
+     * For a caller that has a FALLBACK — `locateSessionAnywhere` scans the
+     * account's siblings next — the "no projects here" note is not the
+     * outcome, it is a step. Printing it announces a failure that is about to
+     * be recovered from, which reads as the command having failed even when it
+     * goes on to succeed.
+     */
+    quiet?: boolean;
+  } = {},
 ): Promise<BindOutcome> {
   const existing = defaultProject();
   if (existing) return { project: existing, bound: false };
@@ -58,9 +70,14 @@ export async function ensureDefaultProjectBinding(
   }
 
   if (projects.length === 0) {
-    process.stderr.write(
-      `${C.dim}No projects in this account yet — create your first with ${C.reset}${C.cyan}kortix init <name>${C.reset}${C.dim} then ${C.reset}${C.cyan}kortix ship${C.reset}${C.dim}.${C.reset}\n`,
-    );
+    // "in this account" matters: the user may well have projects, just under a
+    // different account on the same host. Telling them to create their first
+    // one would be wrong, and this message used to say exactly that.
+    if (!opts.quiet) {
+      process.stderr.write(
+        `${C.dim}No projects in this account — create one with ${C.reset}${C.cyan}kortix init <name>${C.reset}${C.dim}, or switch accounts with ${C.reset}${C.cyan}kortix accounts use${C.reset}${C.dim}.${C.reset}\n`,
+      );
+    }
     return { project: null, bound: false };
   }
 

--- a/apps/cli/src/project-bind.ts
+++ b/apps/cli/src/project-bind.ts
@@ -43,7 +43,9 @@ export async function ensureDefaultProjectBinding(
   opts: {
     promptTitle?: string;
     /**
-     * Say nothing when no project can be bound.
+     * Say nothing on ANY path that ends without a bound project — an empty
+     * account, a failed list, a declined picker, a non-TTY with several to
+     * choose from.
      *
      * For a caller that has a FALLBACK — `locateSessionAnywhere` scans the
      * account's siblings next — the "no projects here" note is not the
@@ -63,9 +65,11 @@ export async function ensureDefaultProjectBinding(
       ProjectSummary[]
     >('/projects');
   } catch (err) {
-    process.stderr.write(
-      `${C.dim}Could not list projects to bind a default: ${(err as Error).message}${C.reset}\n`,
-    );
+    if (!opts.quiet) {
+      process.stderr.write(
+        `${C.dim}Could not list projects to bind a default: ${(err as Error).message}${C.reset}\n`,
+      );
+    }
     return { project: null, bound: false };
   }
 
@@ -90,15 +94,19 @@ export async function ensureDefaultProjectBinding(
       items: projects.map((p) => ({ value: p, label: p.name, sublabel: p.project_id })),
     });
     if (!picked) {
-      process.stderr.write(
-        `${C.dim}Skipped. Bind one any time with ${C.reset}${C.cyan}kortix projects use${C.reset}${C.dim}.${C.reset}\n`,
-      );
+      if (!opts.quiet) {
+        process.stderr.write(
+          `${C.dim}Skipped. Bind one any time with ${C.reset}${C.cyan}kortix projects use${C.reset}${C.dim}.${C.reset}\n`,
+        );
+      }
       return { project: null, bound: false };
     }
   } else {
-    process.stderr.write(
-      `${C.dim}No default project bound. Run ${C.reset}${C.cyan}kortix projects use${C.reset}${C.dim} to pick one.${C.reset}\n`,
-    );
+    if (!opts.quiet) {
+      process.stderr.write(
+        `${C.dim}No default project bound. Run ${C.reset}${C.cyan}kortix projects use${C.reset}${C.dim} to pick one.${C.reset}\n`,
+      );
+    }
     return { project: null, bound: false };
   }
 


### PR DESCRIPTION
## What I actually found

I told you `kortix sessions reload` needed `--project`. **That was wrong** — I truncated the output with `head -4` and mistook a working fallback for a failure. The command works fine without it.

But the thing that fooled me is real, and it will fool users:

```
host kortix-internal-dev (https://dev-api.kortix.com, …)
No projects in this account yet — create your first with kortix init <name> then kortix ship.
  ✗  No project linked. Run `kortix projects use`, `kortix projects link`, or pass --project <id>.
Not in the active project — checking other accounts on "kortix-internal-dev"…
  ✓  Up to date (9f7176c11d6cec9f).
```

Two alarming lines — one a red ✗ — followed by success. Both are *steps*, not outcomes: `locateSessionAnywhere` goes on to scan the host's sibling accounts and usually finds the session.

This is easy to hit. My dev login bound to one of several accounts the user belongs to; all four of their projects live under a different one. Nothing is misconfigured.

## The fix

`resolveProjectContext` takes `quietWhenUnresolved`, set by the one caller that has a fallback. The fallback still prints its own error if it runs dry, so nothing gets swallowed:

```
host kortix-internal-dev (https://dev-api.kortix.com, …)
Not in the active project — checking other accounts on "kortix-internal-dev"…
  !  Sandbox unreachable — cannot tell whether this session is current.
```

Separately, the zero-projects hint said **"create your first"** to someone with four projects under a sibling account. It now says "No projects in this account" and points at `kortix accounts use`.

## Verified live on dev

- `sessions reload --status` and `sessions info` — clean output, fallback still finds the session
- A command with **no** fallback (`secrets ls`) still shows the `✗ No project linked` error
- A genuinely missing session still fails: `✗ Session … not found in any project you can access`

CLI 627 pass / 0 fail, typecheck clean. Both new tests mutation-checked — ignoring `quiet` turns one red, restoring the old wording turns the other red.