### PR TITLE
fix(sandbox): target the managed interpreter by path in the floor install

### DIFF
--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -113,7 +113,9 @@ describe('buildLayeredDockerfile', () => {
     expect(merged).toContain(`agent-browser@${AGENT_BROWSER_VERSION}`);
     expect(merged).toContain('uv python install --default 3.12.13');
     expect(merged).not.toContain('uv venv');
-    expect(merged).toContain('uv pip install --system --break-system-packages');
+    expect(merged).toContain(
+      'uv pip install --python /home/kortix/.local/bin/python3 --break-system-packages',
+    );
     expect(merged).toContain(`"pillow==${PYTHON_PACKAGE_FLOOR.pillow}"`);
     expect(merged).toContain('python package floor OK');
     expect(merged).toContain('COPY kortix-agent.gz /tmp/kortix-agent.gz');

--- a/apps/sandbox/Dockerfile
+++ b/apps/sandbox/Dockerfile
@@ -131,9 +131,11 @@ RUN UV_VERSION="$(sed -n 's/.*"uv": "\([^"]*\)".*/\1/p' /tmp/kortix-runtime-vers
 # `uv run --with` stays the escape hatch for packages outside the floor.
 # `--break-system-packages` overrides uv's externally-managed marker on the
 # interpreter installed above — our frozen build-time interpreter, not a
-# distro Python. Unquoted $(...) expansion is safe here: pins contain no
-# whitespace, and the `markitdown[pptx]` glob matches no file in this cwd.
-RUN uv pip install --system --break-system-packages \
+# distro Python. The interpreter is named by EXPLICIT PATH: `--system` skips
+# uv-managed interpreters and would resolve the distro python3 that
+# LibreOffice's apt deps drag in. Unquoted $(...) expansion is safe here: pins
+# contain no whitespace, and the `markitdown[pptx]` glob matches no file here.
+RUN uv pip install --python /home/kortix/.local/bin/python3 --break-system-packages \
         $(python3 -c "import json; print(' '.join(f'{k}=={v}' for k, v in sorted(json.load(open('/tmp/kortix-runtime-versions.json'))['pythonPackages'].items())))") \
     && python3 -c "import importlib; [importlib.import_module(m) for m in ['PIL', 'docx', 'fitz', 'lxml', 'markitdown', 'openpyxl', 'pandas', 'pdf2docx', 'pdf2image', 'pdfplumber', 'playwright', 'pptx', 'pypdf', 'pypdfium2', 'pytesseract', 'reportlab']]; print('python package floor OK')"
 

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -49,7 +49,7 @@ RUN case "$(uname -m)" in \\
     && python -c 'import sys; assert sys.version_info[:3] == (3, 12, 13); print("managed python:", sys.version)' \\
     && python3 -c 'import sys; assert sys.version_info[:3] == (3, 12, 13)'
 
-RUN uv pip install --system --break-system-packages \\
+RUN uv pip install --python /home/kortix/.local/bin/python3 --break-system-packages \\
         "lxml==6.1.1" \\
         "markitdown[pptx]==0.1.7" \\
         "openpyxl==3.1.5" \\
@@ -223,7 +223,7 @@ RUN case "$(uname -m)" in \\
     && python -c 'import sys; assert sys.version_info[:3] == (3, 12, 13); print("managed python:", sys.version)' \\
     && python3 -c 'import sys; assert sys.version_info[:3] == (3, 12, 13)'
 
-RUN uv pip install --system --break-system-packages \\
+RUN uv pip install --python /home/kortix/.local/bin/python3 --break-system-packages \\
         "lxml==6.1.1" \\
         "markitdown[pptx]==0.1.7" \\
         "openpyxl==3.1.5" \\
@@ -398,7 +398,7 @@ RUN case "$(uname -m)" in \\
     && python -c 'import sys; assert sys.version_info[:3] == (3, 12, 13); print("managed python:", sys.version)' \\
     && python3 -c 'import sys; assert sys.version_info[:3] == (3, 12, 13)'
 
-RUN uv pip install --system --break-system-packages \\
+RUN uv pip install --python /home/kortix/.local/bin/python3 --break-system-packages \\
         "lxml==6.1.1" \\
         "markitdown[pptx]==0.1.7" \\
         "openpyxl==3.1.5" \\

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -133,7 +133,10 @@ describe('the Python runtime is managed by uv', () => {
   test('does not install or mutate the distro Python', () => {
     expect(toolchain).not.toContain('python3 python3-dev python3-pip python3-venv');
     expect(toolchain.match(/uv pip install/g)).toHaveLength(1);
-    expect(toolchain).toContain('uv pip install --system --break-system-packages');
+    expect(toolchain).toContain(
+      'uv pip install --python /home/kortix/.local/bin/python3 --break-system-packages',
+    );
+    expect(toolchain).not.toContain('uv pip install --system');
   });
 
   test('bakes every floor package exactly-pinned into the managed Python', () => {

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -480,10 +480,17 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // this layer. python-playwright is pinned to the SAME version as the Node
     // playwright that bakes Chromium below, so both resolve the identical
     // browser revision under PLAYWRIGHT_BROWSERS_PATH.
+    // The install targets the managed interpreter by EXPLICIT PATH, never by
+    // discovery: `--system` skips uv-managed interpreters by design, and the
+    // apt floor above drags in Ubuntu's distro python3 via LibreOffice — so
+    // `--system` resolved /usr/bin/python3, where `kortix` cannot write, and
+    // the v39 bake failed on every provider (dev, 2026-08-03). The local-repro
+    // gap: a test container without the apt floor has no distro python, so
+    // `--system` happens to fall back to the managed shim and "passes".
     // The import check is a single-line `python3 -c` on purpose: E2B's
     // Dockerfile parser reads a heredoc body's first line as an instruction
     // and aborts the build.
-    'RUN uv pip install --system --break-system-packages \\',
+    'RUN uv pip install --python /home/kortix/.local/bin/python3 --break-system-packages \\',
     ...Object.entries(PYTHON_PACKAGE_FLOOR).map(
       ([pkg, version]) => `        "${pkg}==${version}" \\`,
     ),


### PR DESCRIPTION
Fix-forward for #6080. The v39 snapshot bake failed on all providers: `uv pip install --system` skips uv-managed interpreters and resolved the distro python3 that LibreOffice's apt deps install (`/usr`, 3.12.3, not writable by `kortix`) — exit 2, sessions served last-known-good v38 (dev CloudWatch `/ecs/kortix-dev`, 20:34–21:05Z). Fix targets the interpreter by explicit path. Verified in a repro container WITH distro python3 present: floor installs into managed 3.12.13, bare `python3` imports pillow, distro python untouched. shared 283 pass, api layer tests pass, goldens regenerated.