### PR TITLE
Fix local Supabase and test runner dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TESTS := tests
-NPM := npm --prefix $(TESTS)
+TEST_RUN := cd $(TESTS) && bun run
 
 .DEFAULT_GOAL := help
 .PHONY: help install fast all ci-pr ci-main ci-nightly ci-release \
@@ -12,8 +12,8 @@ help: ## Show this help
 	 | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install all test dependencies (node deps + Playwright browsers)
-	$(NPM) install
-	cd $(TESTS) && npx playwright install --with-deps chromium || true
+	cd $(TESTS) && bun install --frozen-lockfile
+	cd $(TESTS) && bunx playwright install --with-deps chromium || true
 
 ## ---- one-shot lanes ---------------------------------------------------------
 fast: lint typecheck unit contract api-coverage ## Fast local loop: no live services
@@ -40,56 +40,56 @@ ci-release: ## Pre-release full gate
 lint: ## Lint all workspaces (best-effort)
 	pnpm -r --if-present lint || true
 typecheck: ## TypeScript type-check the test suite
-	$(NPM) run typecheck
+	$(TEST_RUN) typecheck
 unit: ## Unit tests (vitest)
-	$(NPM) run test:unit:cov
+	$(TEST_RUN) test:unit:cov
 integration: ## Integration tests (vitest + testcontainers)
-	$(NPM) run test:integration
+	$(TEST_RUN) test:integration
 api: ## API tests (ke2e REST suite)
-	$(NPM) run test:api
+	$(TEST_RUN) test:api
 api-coverage: ## API route coverage gate (no live target)
-	$(NPM) run coverage
+	$(TEST_RUN) coverage
 contract: ## Consumer-driven contract tests (Pact)
-	$(NPM) run test:contract
+	$(TEST_RUN) test:contract
 smoke: ## Smoke / liveness checks
-	$(NPM) run test:smoke
+	$(TEST_RUN) test:smoke
 e2e: ## End-to-end UI tests (Playwright)
-	$(NPM) run test:e2e
+	$(TEST_RUN) test:e2e
 visual: ## Visual regression (Playwright snapshots)
-	$(NPM) run test:visual
+	$(TEST_RUN) test:visual
 a11y: ## Accessibility tests (axe + Playwright)
-	$(NPM) run test:a11y
+	$(TEST_RUN) test:a11y
 performance: ## Performance / load (k6, Docker)
-	$(NPM) run test:perf
+	$(TEST_RUN) test:perf
 perf-regression: ## Fail if k6 p95/error-rate regressed >10% vs committed baseline
-	$(NPM) run test:perf:regression
+	$(TEST_RUN) test:perf:regression
 security: ## Static security scans (SAST/deps/secrets/container)
-	$(NPM) run test:security
+	$(TEST_RUN) test:security
 security-fast: ## Fast static security (SAST/deps/secrets — no app image build)
-	$(NPM) run test:security:fast
+	$(TEST_RUN) test:security:fast
 security-dast: ## Dynamic security scan + API fuzz (needs TARGET_URL)
-	$(NPM) run test:security:dast
+	$(TEST_RUN) test:security:dast
 pentest: ## Enterprise black-box pentest probes (needs PENTEST_TARGET_URL)
-	$(NPM) run test:pentest
+	$(TEST_RUN) test:pentest
 strix: ## OSS agentic source/pentest scan (needs LLM_API_KEY)
 	bash $(TESTS)/security/strix/run.sh
 migration: ## Database migration tests (throwaway Postgres)
-	$(NPM) run test:migration
+	$(TEST_RUN) test:migration
 infra: ## Infrastructure / IaC tests (tflint/checkov/kubeconform)
-	$(NPM) run test:infra
+	$(TEST_RUN) test:infra
 chaos: ## Chaos / resilience (Toxiproxy, Docker)
-	$(NPM) run test:chaos
+	$(TEST_RUN) test:chaos
 mutation: ## Mutation testing (Stryker)
-	$(NPM) run test:mutation
+	$(TEST_RUN) test:mutation
 
 ## ---- reporting & gates ------------------------------------------------------
 coverage: ## Unit tests with coverage report
-	$(NPM) run test:unit:cov
+	$(TEST_RUN) test:unit:cov
 gates: ## Evaluate quality gates over test-results/
-	$(NPM) run quality-gates
+	$(TEST_RUN) quality-gates
 report: ## Build the Allure report + catalog from latest results
-	$(NPM) run allure
-	$(NPM) run catalog
+	$(TEST_RUN) allure
+	$(TEST_RUN) catalog
 publish: ## History-carried Allure report + archive to S3 (set S3_BUCKET; local-only without it)
 	bash $(TESTS)/scripts/publish-allure.sh
 portal-up: ## Start the local Allure portal (localhost:5051)

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "dotenv-expand": "^12",
     "node-pg-migrate": "^8",
     "pg": "^8",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "supabase": "2.111.0"
   },
   "packageManager": "pnpm@8.11.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      supabase:
+        specifier: 2.111.0
+        version: 2.111.0
 
   apps/api:
     dependencies:
@@ -3511,6 +3514,15 @@ packages:
     resolution: {integrity: sha512-zBWLsaqStLwa8fQn5TTKh0/D69Ghto4zpteGcF8ZQ45FRuWxdJkAvK1//TTAhEDH3bJ46cO525TpKIDu01ejng==}
     dev: false
 
+  /@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0):
+    resolution: {integrity: sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==}
+    engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
+    peerDependencies:
+      '@noble/ciphers': ^1.0.0
+    dependencies:
+      '@noble/ciphers': 1.3.0
+    dev: true
+
   /@egjs/hammerjs@2.0.17:
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
@@ -6017,6 +6029,23 @@ packages:
       react: 19.1.0
       third-party-capital: 1.0.20
     dev: false
+
+  /@noble/ciphers@1.3.0:
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+    dev: true
+
+  /@noble/curves@1.9.7:
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+    dependencies:
+      '@noble/hashes': 1.8.0
+    dev: true
+
+  /@noble/hashes@1.8.0:
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+    dev: true
 
   /@nodable/entities@3.0.0:
     resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
@@ -10459,6 +10488,70 @@ packages:
     dependencies:
       tslib: 2.8.1
     dev: false
+
+  /@supabase/cli-darwin-arm64@2.111.0:
+    resolution: {integrity: sha512-H1ucZ+9Z37Ha7uqYrKHfAy1vXWMVsN4gNlKaOpjKUYoHwDEbueEHVIDA1/PBIUd4HX+usJfpq+R+gWqzM/FKqQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@supabase/cli-darwin-x64@2.111.0:
+    resolution: {integrity: sha512-4iMYm/XaAZJ8YzdJ2HBRVc7i9SRIwE6VQrnSt968WTt83M1y6knC7UENCKjMtO+As4QeZkICpUk50CeathqxbA==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@supabase/cli-linux-arm64-musl@2.111.0:
+    resolution: {integrity: sha512-RnvbVlJ4TX/UIwLiglBVQ2eL4GAl9SfWZmM5LENXyIaohBcRZHDva5t2OyK+BPGBtngjVGpb3QyfLdvkt9yJcw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@supabase/cli-linux-arm64@2.111.0:
+    resolution: {integrity: sha512-2KSHITFMXe2u5yALupBWHGeQ1IY4C8GkcIWPWgNFdtAPo03pgs1hLWgL1eeqSh/a0wB/6rgUlM1fQR/hAgCyCA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@supabase/cli-linux-x64-musl@2.111.0:
+    resolution: {integrity: sha512-2QVpsy/3v+TzqE5GgTCPruoxTlF3d8QPGirjcnah8hP66nxXStB9yTvxmJq+LtO3gwMt1Kpm7is0roZVkV55Pw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@supabase/cli-linux-x64@2.111.0:
+    resolution: {integrity: sha512-NwwNhiZZT4WYEPDXAbgZL+l77z/hoJ+w5t+52WBN1VlmoxwDmf2NP+UERM8wuCGFe/tmBlUuFE1eJYZfab0/qA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@supabase/cli-windows-arm64@2.111.0:
+    resolution: {integrity: sha512-twawKY5xfU2dNOnZrKDmrudxRG/XIKcBxOb6X2lMGJU3N1Hd+8oWpI9TwM5Qv+eXehtlsKDmUvbitStXvJr/xQ==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@supabase/cli-windows-x64@2.111.0:
+    resolution: {integrity: sha512-1F+X5tAYxAGx93ZZoIQBnIQ2Q2NnplKqjpigAS/zpTsNaWAjNi7EnxmuQKaEoAdqOHKbLhegVVDiw1+us3ZVpA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@supabase/functions-js@2.110.0:
     resolution: {integrity: sha512-Fde5wlY8ZZy+9yqrWlQHo8MacSyUBArBEtN2boB4thJQigPnQD/cc61qZN0n3I1L0gwhWtHYwIMnOBKxSvF6Hw==}
@@ -15394,6 +15487,16 @@ packages:
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  /eciesjs@0.5.0:
+    resolution: {integrity: sha512-s0J9SEVYAEPg7J63GFMApLYzPH9VNIQIyC6s15JpnqVc0TqcKWdbgFlnAweEBRyMmko2dcs2sfC83Hj4J43tuA==}
+    engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
+    dependencies:
+      '@ecies/ciphers': 0.2.6(@noble/ciphers@1.3.0)
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+    dev: true
+
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -18928,7 +19031,6 @@ packages:
 
   /jose@6.2.5:
     resolution: {integrity: sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==}
-    dev: false
 
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -25077,6 +25179,23 @@ packages:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /supabase@2.111.0:
+    resolution: {integrity: sha512-0cjCRdYNV1h2XXa0wm04mdct7QuDU7sMul/NwETRJmN3+HCsdEu6u5n0oygL97fdf6sDrGmnAdBh8E4wsv1ayg==}
+    hasBin: true
+    dependencies:
+      eciesjs: 0.5.0
+      jose: 6.2.5
+    optionalDependencies:
+      '@supabase/cli-darwin-arm64': 2.111.0
+      '@supabase/cli-darwin-x64': 2.111.0
+      '@supabase/cli-linux-arm64': 2.111.0
+      '@supabase/cli-linux-arm64-musl': 2.111.0
+      '@supabase/cli-linux-x64': 2.111.0
+      '@supabase/cli-linux-x64-musl': 2.111.0
+      '@supabase/cli-windows-arm64': 2.111.0
+      '@supabase/cli-windows-x64': 2.111.0
     dev: true
 
   /supports-color@5.5.0:

--- a/scripts/worktree/__tests__/contract.test.ts
+++ b/scripts/worktree/__tests__/contract.test.ts
@@ -7,6 +7,9 @@ const REPO = join(import.meta.dir, '..', '..', '..');
 const dbPkg = JSON.parse(readFileSync(join(REPO, 'packages', 'db', 'package.json'), 'utf8')) as {
   scripts?: Record<string, string>;
 };
+const rootPkg = JSON.parse(readFileSync(join(REPO, 'package.json'), 'utf8')) as {
+  devDependencies?: Record<string, string>;
+};
 const LIB_DIR = join(import.meta.dir, '..', 'lib');
 const libSrc = readdirSync(LIB_DIR)
   .filter((f) => f.endsWith('.ts'))
@@ -53,6 +56,18 @@ describe('dependency contract — every external binary the worktree spawns is d
     for (const bin of spawned) {
       expect(allowed.has(bin), `lib.ts spawns "${bin}" but it is not in DEPS/allowed`).toBe(true);
     }
+  });
+});
+
+describe('supabase CLI contract', () => {
+  test('the repository pins a CLI version that supports the configured PostgreSQL 17 stack', () => {
+    const config = readFileSync(join(REPO, 'supabase', 'config.toml'), 'utf8');
+    expect(config).toMatch(/major_version\s*=\s*17/);
+
+    const version = rootPkg.devDependencies?.supabase;
+    expect(version).toMatch(/^\d+\.\d+\.\d+$/);
+    const versionNumber = version!.split('.').reduce((score, part) => score * 1000 + Number(part), 0);
+    expect(versionNumber).toBeGreaterThanOrEqual(2_111_000);
   });
 });
 

--- a/tests/unit/test-runner-contract.test.ts
+++ b/tests/unit/test-runner-contract.test.ts
@@ -1,0 +1,17 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '../..');
+const makefile = readFileSync(resolve(root, 'Makefile'), 'utf8');
+
+describe('local test runner contract', () => {
+  it('uses the committed Bun lockfile for installation and test commands', () => {
+    expect(existsSync(resolve(root, 'tests/bun.lock'))).toBe(true);
+    expect(existsSync(resolve(root, 'tests/package-lock.json'))).toBe(false);
+    expect(makefile).toContain('TEST_RUN := cd $(TESTS) && bun run');
+    expect(makefile).toContain('cd $(TESTS) && bun install --frozen-lockfile');
+    expect(makefile).toContain('cd $(TESTS) && bunx playwright install --with-deps chromium');
+    expect(makefile).not.toContain('npm --prefix $(TESTS)');
+  });
+});

--- a/tests/unit/test-runner-contract.test.ts
+++ b/tests/unit/test-runner-contract.test.ts
@@ -1,17 +1,23 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
 
-const root = resolve(import.meta.dirname, '../..');
-const makefile = readFileSync(resolve(root, 'Makefile'), 'utf8');
+const root = resolve(import.meta.dirname, "../..");
+const makefile = readFileSync(resolve(root, "Makefile"), "utf8");
 
-describe('local test runner contract', () => {
-  it('uses the committed Bun lockfile for installation and test commands', () => {
-    expect(existsSync(resolve(root, 'tests/bun.lock'))).toBe(true);
-    expect(existsSync(resolve(root, 'tests/package-lock.json'))).toBe(false);
-    expect(makefile).toContain('TEST_RUN := cd $(TESTS) && bun run');
-    expect(makefile).toContain('cd $(TESTS) && bun install --frozen-lockfile');
-    expect(makefile).toContain('cd $(TESTS) && bunx playwright install --with-deps chromium');
-    expect(makefile).not.toContain('npm --prefix $(TESTS)');
+describe("local test runner contract", () => {
+  it("uses the committed Bun lockfile for installation and test commands", () => {
+    expect(existsSync(resolve(root, "tests/bun.lock"))).toBe(true);
+    expect(existsSync(resolve(root, "tests/package-lock.json"))).toBe(false);
+    expect(makefile).toMatch(
+      /TEST_RUN\s*:=\s*cd\s+\$\(TESTS\)\s*&&\s*bun\s+run/,
+    );
+    expect(makefile).toMatch(
+      /cd\s+\$\(TESTS\)\s*&&\s*bun\s+install\s+--frozen-lockfile/,
+    );
+    expect(makefile).toMatch(
+      /cd\s+\$\(TESTS\)\s*&&\s*bunx\s+playwright\s+install\s+--with-deps\s+chromium/,
+    );
+    expect(makefile).not.toContain("npm --prefix $(TESTS)");
   });
 });


### PR DESCRIPTION
## Summary

- Pin Supabase CLI 2.111.0 for the repository PostgreSQL 17 configuration.
- Run the Bun-locked test harness through Bun from the root Makefile.
- Add regression tests for both dependency contracts.

## Verification

- `bun test scripts/worktree/__tests__`: 66 passed, 0 failed.
- `make fast`: 40 unit tests and 1 Pact contract passed.
- `make fast`: API route coverage reported 515/525 covered, 10 allowlisted, and 0 uncovered.
- Local Supabase started with PostgreSQL 17.6.1.156.
- `GET http://localhost:14308/v1/health`: HTTP 200 with `status=ok`.
- `GET http://localhost:14300`: HTTP 200.