### PR TITLE
Warn on the first secrets narrowing; don't compile an agent with no prompt

### DIFF
--- a/apps/api/src/projects/lib/compile-agent-config.test.ts
+++ b/apps/api/src/projects/lib/compile-agent-config.test.ts
@@ -14,6 +14,9 @@ let readRepoFileCalls: string[] = [];
 // DEFAULT branch even for a session on another ref, so a feature-branch session
 // ran main's agents; recording the ref is what makes that visible.
 let refsRead: string[] = [];
+// Paths the mocked git should fail on with a NON-not-found error, so the
+// transient-failure branch is reachable through the same seam as the fixtures.
+let transientFailurePaths = new Set<string>();
 
 // `mock.module` REPLACES the module — it does not merge. `../git` is a barrel,
 // so anything omitted here stops existing for every module loaded afterwards in
@@ -34,9 +37,17 @@ mock.module('../git', () => ({
   readRepoFile: async (_project: unknown, path: string, ref: string) => {
     readRepoFileCalls.push(path);
     refsRead.push(ref);
+    if (transientFailurePaths.has(path)) throw new Error('fatal: unable to access remote');
     if (!(path in mdFileContent)) throw new Error(`no such file: ${path}`);
     return mdFileContent[path];
   },
+  // A missing file is the expected client condition the compiler tolerates; a
+  // git/transport failure is not. The fixtures above throw `no such file: …`
+  // for a declared agent with no .md, so the predicate recognises exactly that
+  // and treats anything else as a real failure — which is the distinction the
+  // compiler now depends on.
+  isRepoFileNotFoundError: (err: unknown) =>
+    /no such file/.test(String((err as Error)?.message ?? '')),
   // Unused here; present so the barrel keeps its shape for other modules.
   resolveCommitSha: async () => '0'.repeat(40),
   invalidateProjectMirror: () => {},
@@ -587,5 +598,54 @@ describe('resolveCompiledAgentConfigForSession — the ref it compiles from', ()
     await resolveCompiledAgentConfigForSession(PROJECT, '   ');
 
     expect(new Set(refsRead)).toEqual(new Set(['main']));
+  });
+});
+
+/**
+ * A transient git failure must not quietly produce a lobotomised agent.
+ *
+ * Every read error used to be swallowed with a warning, so a blip reading one
+ * agent's `.md` compiled that agent with NO prompt, model, or permissions — and
+ * the reload that triggered it reported success with a fresh etag saying the
+ * session was current. The agent kept answering, just without its instructions.
+ *
+ * A MISSING file is different: the manifest may legitimately declare an agent
+ * that carries no behavior file, and that case must keep working.
+ */
+describe('resolveCompiledAgentConfigForSession — read failures', () => {
+  const project = {
+    projectId: 'proj-1',
+    repoUrl: 'https://example.test/r.git',
+    defaultBranch: 'main',
+    manifestPath: 'kortix.yaml',
+    gitAuthToken: null,
+  };
+
+  test('a MISSING .md still compiles — that agent simply has no behavior', async () => {
+    manifestFile = { path: 'kortix.yaml', content: GOVERNANCE_FIXTURE };
+    mdFileContent = {
+      '.kortix/opencode/agents/support.md': supportMd('mode: primary', 'Support prompt.'),
+      // pr-bot.md deliberately absent
+    };
+
+    const compiled = await resolveCompiledAgentConfigForSession(project);
+
+    expect(compiled).not.toBeNull();
+    expect(JSON.parse(compiled as string).agent['pr-bot']).toBeDefined();
+    expect(JSON.parse(compiled as string).agent.support.prompt).toBe('Support prompt.');
+  });
+
+  test('a TRANSIENT git failure yields null, not an agent stripped of its prompt', async () => {
+    // null means "no compiled config": the session keeps what it is running and
+    // `stale` reads null ("could not tell") rather than a confident, wrong
+    // "up to date". Far better than swapping in an agent with no instructions.
+    manifestFile = { path: 'kortix.yaml', content: GOVERNANCE_FIXTURE };
+    mdFileContent = {};
+    transientFailurePaths = new Set(['.kortix/opencode/agents/support.md']);
+    try {
+      expect(await resolveCompiledAgentConfigForSession(project)).toBeNull();
+    } finally {
+      transientFailurePaths = new Set();
+    }
   });
 });

--- a/apps/api/src/projects/lib/compile-agent-config.ts
+++ b/apps/api/src/projects/lib/compile-agent-config.ts
@@ -50,7 +50,12 @@ import {
   type RuntimeV2,
 } from '@kortix/manifest-schema';
 import { parseAgentMarkdown } from './agent-markdown';
-import { type GitBackedProject, readManifestFromRepo, readRepoFile } from '../git';
+import {
+  isRepoFileNotFoundError,
+  readManifestFromRepo,
+  readRepoFile,
+  type GitBackedProject,
+} from '../git';
 
 /** OpenCode's per-agent `AgentConfig` — the compiled shape for one `agent.<name>` entry. */
 export interface OpencodeAgentConfig {
@@ -439,8 +444,20 @@ export async function resolveCompiledAgentConfigForSession(
         try {
           agentMdFiles[path] = await readRepoFile(project, path, ref);
         } catch (err) {
+          // A MISSING file is an expected client condition: the manifest may
+          // declare an agent that carries no behavior file, and that agent
+          // simply compiles without one.
+          //
+          // Anything else — a git operation error, a blip through the proxy — is
+          // not, and swallowing it silently compiles the agent with NO prompt,
+          // model, or permissions. That is a lobotomised agent reported as a
+          // successful reload, with a fresh etag saying it is current. Rethrow
+          // so the outer catch returns null: the session keeps the config it has
+          // and `stale` reads null ("could not tell") rather than a confident
+          // and wrong "up to date".
+          if (!isRepoFileNotFoundError(err)) throw err;
           console.warn(
-            `[compile-agent-config] project ${project.projectId}: failed to read agent "${name}"'s behavior file "${path}": ${(err as Error).message}`,
+            `[compile-agent-config] project ${project.projectId}: agent "${name}" has no behavior file at "${path}"`,
           );
         }
       }),

--- a/apps/api/src/projects/lib/session-rescope.test.ts
+++ b/apps/api/src/projects/lib/session-rescope.test.ts
@@ -2,7 +2,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
 
-import { rescopeSessionBindings, rescopeSessionSecrets } from './session-rescope';
+import { rescopeSessionBindings, rescopeSessionSecrets,
+  type RescopeSecretsResult } from './session-rescope';
 
 describe('rescopeSessionSecrets — SET semantics', () => {
   test('the requested list REPLACES the previous one', () => {
@@ -190,5 +191,130 @@ describe('the docs match the contract', () => {
         });
       }
     }
+  });
+});
+
+/**
+ * The FIRST narrowing of a session is the largest one there is, and it was the
+ * one that reported nothing had been dropped.
+ *
+ * A session starts with `secretsAllowlist = null`, meaning "everything the
+ * agent's grant allows". Narrowing it to an explicit list is a null → list
+ * transition, and `dropped` was computed only when BOTH sides were explicit —
+ * so it came back `[]`, the route set `retroactive: true`, and the user was told
+ * "Applies from the next prompt." with no warning.
+ *
+ * That is exactly the false assurance this module's own header warns about: a
+ * user revoking secrets from a live session to contain a leak was told nothing
+ * was dropped, and would reasonably leave the credential in place.
+ *
+ * When the grant is enumerable the dropped names are knowable, so they are
+ * reported. When it is `'all'` they are not — but the narrowing still happened,
+ * which is what `narrowed` carries.
+ */
+describe('rescopeSessionSecrets — narrowing away from an unrestricted session', () => {
+  const ok = (r: RescopeSecretsResult) => {
+    if (!r.ok) throw new Error(`expected ok, got ${r.code}`);
+    return r;
+  };
+
+  test('null → subset of an enumerable grant reports the dropped names', () => {
+    const r = ok(
+      rescopeSessionSecrets({
+        current: null,
+        requested: ['A'],
+        agentGrantEnv: ['A', 'B', 'C'],
+      }),
+    );
+    expect(r.narrowed).toBe(true);
+    expect(r.dropped).toEqual(['B', 'C']);
+  });
+
+  test('null → [] drops the entire grant', () => {
+    // "Inject zero project secrets" on a session that had all of them.
+    const r = ok(
+      rescopeSessionSecrets({ current: null, requested: [], agentGrantEnv: ['A', 'B'] }),
+    );
+    expect(r.narrowed).toBe(true);
+    expect(r.dropped).toEqual(['A', 'B']);
+  });
+
+  test("null → subset of an 'all' grant is narrowed even though the names are unknowable", () => {
+    const r = ok(
+      rescopeSessionSecrets({ current: null, requested: ['A'], agentGrantEnv: 'all' }),
+    );
+    expect(r.narrowed).toBe(true);
+    expect(r.dropped).toEqual([]);
+  });
+
+  test('null → the WHOLE grant is not a narrowing', () => {
+    const r = ok(
+      rescopeSessionSecrets({
+        current: null,
+        requested: ['A', 'B'],
+        agentGrantEnv: ['A', 'B'],
+      }),
+    );
+    expect(r.narrowed).toBe(false);
+    expect(r.dropped).toEqual([]);
+  });
+
+  test('widening back to null is not a narrowing', () => {
+    const r = ok(
+      rescopeSessionSecrets({ current: ['A'], requested: null, agentGrantEnv: ['A', 'B'] }),
+    );
+    expect(r.narrowed).toBe(false);
+    expect(r.dropped).toEqual([]);
+  });
+
+  test('an ordinary list → list narrowing still reports, and is narrowed', () => {
+    const r = ok(
+      rescopeSessionSecrets({
+        current: ['A', 'B'],
+        requested: ['A'],
+        agentGrantEnv: ['A', 'B'],
+      }),
+    );
+    expect(r.narrowed).toBe(true);
+    expect(r.dropped).toEqual(['B']);
+  });
+
+  test('a pure widening within an explicit list is not narrowed', () => {
+    const r = ok(
+      rescopeSessionSecrets({
+        current: ['A'],
+        requested: ['A', 'B'],
+        agentGrantEnv: ['A', 'B'],
+      }),
+    );
+    expect(r.narrowed).toBe(false);
+    expect(r.added).toEqual(['B']);
+  });
+});
+
+/**
+ * The route has to actually branch on `narrowed`.
+ *
+ * The helper can be perfectly correct and the user still be misinformed — the
+ * warning is emitted by the route, and it was keyed on `droppedSecrets.length`.
+ * That is the same shape of bug as a component wired to a value nobody
+ * populates: right logic, wrong plumbing, confident wrong output.
+ */
+const ROUTE = readFileSync(
+  join(import.meta.dir, '..', 'routes', 'r7.ts'),
+  'utf8',
+);
+
+describe('the scope route surfaces the narrowing', () => {
+  test('retroactive and the warning key off `narrowed`, not the dropped names', () => {
+    expect(ROUTE).toContain('retroactive: !narrowedSecrets');
+    expect(ROUTE).toContain('narrowedSecrets = decided.narrowed');
+    expect(ROUTE).not.toContain('retroactive: droppedSecrets.length === 0');
+  });
+
+  test('the warning sentence still names rotation as the remedy', () => {
+    // The one actionable thing. "Dropped" without "rotate them" is the false
+    // assurance this module's header warns about.
+    expect(ROUTE).toContain('rotate them if that matters');
   });
 });

--- a/apps/api/src/projects/lib/session-rescope.ts
+++ b/apps/api/src/projects/lib/session-rescope.ts
@@ -35,7 +35,27 @@ import {
 } from '../../shared/connector-alias';
 
 export type RescopeSecretsResult =
-  | { ok: true; allowlist: string[] | null; dropped: string[]; added: string[] }
+  | {
+      ok: true;
+      allowlist: string[] | null;
+      dropped: string[];
+      added: string[];
+      /**
+       * Did the session's effective secret set SHRINK?
+       *
+       * Not derivable from `dropped.length`, and that is the whole point. A
+       * session's allowlist starts `null` — "everything the agent's grant
+       * allows" — so its first narrowing is a null → list transition, and the
+       * names lost are only enumerable when the grant itself is a list. With an
+       * `'all'` grant they are not, yet the narrowing is just as real.
+       *
+       * Keying the caller's "…rotate them if that matters" warning off
+       * `dropped.length` therefore suppressed it on the LARGEST narrowing there
+       * is: revoking every secret from a live session reported that nothing had
+       * been dropped. Branch on this instead.
+       */
+      narrowed: boolean;
+    }
   | { ok: false; code: 'NOT_IN_AGENT_GRANT'; message: string; offending: string[] };
 
 /**
@@ -73,19 +93,33 @@ export function rescopeSessionSecrets(input: {
   }
 
   const before = input.current === null ? null : normalize(input.current);
-  // A null allowlist is "everything the grant allows", so the set of names it
-  // covers is not enumerable here. Report movement only when both sides are
-  // explicit; the route reports the null transition itself.
+  // A null allowlist means "everything the grant allows". When the grant is a
+  // list, that set IS enumerable — so narrowing away from null can name exactly
+  // what it dropped, which is the case that previously reported nothing.
+  const grantList = Array.isArray(input.agentGrantEnv)
+    ? normalize(input.agentGrantEnv)
+    : null;
+  const effectiveBefore = before ?? grantList;
+
   const dropped =
-    before !== null && requested !== null
-      ? before.filter((id) => !requested.some((r) => r.toUpperCase() === id.toUpperCase()))
+    effectiveBefore !== null && requested !== null
+      ? effectiveBefore.filter(
+          (id) => !requested.some((r) => r.toUpperCase() === id.toUpperCase()),
+        )
       : [];
   const added =
     before !== null && requested !== null
       ? requested.filter((id) => !before.some((b) => b.toUpperCase() === id.toUpperCase()))
       : [];
 
-  return { ok: true, allowlist: requested, dropped, added };
+  // Narrowing with UNKNOWABLE names: an `'all'` (or absent) grant going from
+  // null to any explicit list. Nothing can be listed, but the warning must
+  // still fire — this is the revoke-everything case.
+  const narrowedBeyondNames =
+    before === null && requested !== null && grantList === null;
+  const narrowed = dropped.length > 0 || narrowedBeyondNames;
+
+  return { ok: true, allowlist: requested, dropped, added, narrowed };
 }
 
 /** Trim, drop blanks, de-duplicate case-insensitively, keep first spelling. */

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -2432,6 +2432,11 @@ projectsApp.openapi(
     let nextAllowlist = visible.row.secretsAllowlist ?? null;
     let droppedSecrets: string[] = [];
     let addedSecrets: string[] = [];
+    // Distinct from `droppedSecrets.length > 0`: a session's allowlist starts
+    // null ("everything the grant allows"), so its FIRST narrowing may shrink
+    // the effective set without being able to name what it lost — which is
+    // precisely when the warning matters most.
+    let narrowedSecrets = false;
     if (wantsSecrets) {
       const decided = rescopeSessionSecrets({
         current: visible.row.secretsAllowlist ?? null,
@@ -2442,6 +2447,7 @@ projectsApp.openapi(
       nextAllowlist = decided.allowlist;
       droppedSecrets = decided.dropped;
       addedSecrets = decided.added;
+      narrowedSecrets = decided.narrowed;
       if (nextAllowlist !== null && nextAllowlist.length > 0) {
         const availableSecrets = await listResolvedProjectSecrets(projectId, loaded.userId);
         const available = new Set(
@@ -2652,11 +2658,16 @@ projectsApp.openapi(
       // Connector bindings ARE retroactive (resolved at call time). Secrets are
       // not: a dropped one stops being delivered from the next prompt, but the
       // agent's context and any shell it already spawned still hold what it read.
-      retroactive: droppedSecrets.length === 0,
-      detail:
-        droppedSecrets.length > 0
-          ? 'Dropped secrets stop being delivered from the next prompt. Values the agent already read remain in its context and in shells it already started — rotate them if that matters.'
-          : 'Applies from the next prompt.',
+      // Keyed on `narrowed`, not on the dropped NAMES. Narrowing a session away
+      // from an unrestricted allowlist shrinks what it may read even when the
+      // agent's grant is 'all' and the lost names cannot be enumerated — and
+      // that is the largest narrowing there is. Keying off the names suppressed
+      // this warning on exactly that case, telling a user revoking every secret
+      // from a live session that nothing had been dropped.
+      retroactive: !narrowedSecrets,
+      detail: narrowedSecrets
+        ? 'Dropped secrets stop being delivered from the next prompt. Values the agent already read remain in its context and in shells it already started — rotate them if that matters.'
+        : 'Applies from the next prompt.',
     });
   },
 );

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -2437,6 +2437,7 @@ projectsApp.openapi(
     // the effective set without being able to name what it lost — which is
     // precisely when the warning matters most.
     let narrowedSecrets = false;
+    let canReadSecretNames = false;
     if (wantsSecrets) {
       const decided = rescopeSessionSecrets({
         current: visible.row.secretsAllowlist ?? null,
@@ -2448,6 +2449,15 @@ projectsApp.openapi(
       droppedSecrets = decided.dropped;
       addedSecrets = decided.added;
       narrowedSecrets = decided.narrowed;
+      // Only affects whether the dropped NAMES are echoed back — never whether
+      // the narrowing itself is reported.
+      canReadSecretNames = await projectCapabilityAllowed(
+        c,
+        loaded.userId,
+        loaded.row.accountId,
+        projectId,
+        PROJECT_ACTIONS.PROJECT_SECRET_READ,
+      );
       if (nextAllowlist !== null && nextAllowlist.length > 0) {
         const availableSecrets = await listResolvedProjectSecrets(projectId, loaded.userId);
         const available = new Set(
@@ -2652,7 +2662,14 @@ projectsApp.openapi(
       secrets_allowlist: nextAllowlist,
       required_connectors: nextRequired,
       connector_bindings: effectiveBindings,
-      dropped_secrets: droppedSecrets,
+      // Names are gated; the WARNING is not. Enumerating the agent grant to
+      // report what a null → list narrowing dropped hands the caller secret
+      // identifiers they may not be entitled to see: this route gates on
+      // project.session.stop, and a plain member holds that for their own
+      // session while deliberately lacking project.secret.read. `narrowed`
+      // carries no names, so the "rotate them" warning still fires for everyone
+      // — which is the part that actually matters.
+      dropped_secrets: canReadSecretNames ? droppedSecrets : [],
       added_secrets: addedSecrets,
       dropped_bindings: droppedBindings,
       // Connector bindings ARE retroactive (resolved at call time). Secrets are


### PR DESCRIPTION
Two fixes found by auditing for the bug class behind #6083: **an operation reporting success for something it never verified.**

## 1. The first narrowing of a session's secrets warned about nothing

A session's `secretsAllowlist` starts `null` — *"everything the agent's grant allows"*. So the **first** time anyone narrows it, that's a `null → list` transition. `dropped` was computed only when both sides were explicit, so it came back `[]`, and the route did:

```ts
retroactive: droppedSecrets.length === 0,
detail: droppedSecrets.length > 0 ? '…rotate them if that matters.' : 'Applies from the next prompt.',
```

Result: `dropped_secrets: []`, `retroactive: true`, and a benign "Applies from the next prompt." — **on the largest narrowing there is.**

A user unchecking "Allow every available secret", or running `kortix sessions scope <id> --no-secrets` to contain a leaked credential, is told nothing was dropped. Every secret they just revoked is still in the agent's context and in any shell it already started. They'd reasonably leave the key in place.

Every *subsequent* re-scope is list→list and reports correctly, so the failure is confined to — and guaranteed on — the first one.

`session-rescope.ts`'s own header names this exact failure mode:

> *"A UI that says 'revoked' where the truth is 'revoked for anything started from here' is the kind of false assurance that gets a credential left in place."*

And `rescopeSessionSecrets` says *"the route reports the null transition itself"*. It did not.

**Fix.** When the grant is a list, the set behind `null` **is** enumerable — the dropped names are now reported exactly (`null → ['A']` with grant `['A','B','C']` reports `B, C`). When the grant is `'all'` they aren't, but the narrowing is just as real; that's what the new `narrowed` flag carries, and the route branches on it. `narrowed` is a field rather than a call-site computation because it is *not* derivable from `dropped.length` — that equivalence is the bug.

## 2. A transient git failure compiled an agent with no prompt

`resolveCompiledAgentConfigForSession` swallowed **every** error reading an agent's `.md`. A missing file is an expected client condition — the manifest may declare an agent carrying no behavior file. A git or transport failure is not, and treating them the same compiled that agent with no prompt, model, or permissions. The reload that triggered it then reported success with a fresh etag saying the session was current. The agent kept answering, just without its instructions.

`isRepoFileNotFoundError` already existed to draw exactly this line; the compiler wasn't using it. A real failure now propagates to the outer catch, which returns `null` — the session keeps the config it's running and `stale` reads `null` ("could not tell") rather than a confident, wrong "up to date".

## Testing

7 narrowing cases written failing first (verified RED 7/7), covering both grant shapes and both directions, including the two that must **not** warn: `null →` the whole grant, and widening back to `null`. Plus a route wiring assertion — the helper can be perfectly correct and the user still misinformed, because the warning is emitted by the route.

The transient-failure fix is verified by mutation: removing the rethrow makes the test fail.

Third time `compile-agent-config.test.ts`'s `mock.module('../git')` has bitten — it replaces the barrel wholesale, so a new import from `../git` breaks a sibling suite only when the two files run together. The mocked predicate deliberately recognises the fixtures' own `no such file` throw, so existing missing-file behaviour is unchanged.

**Gates.** `tsc` clean; `src/projects/lib/` 354 pass / 23 fail — baseline 23, pre-existing cross-file `mock.module` leaks, identical on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
