### PR TITLE
Set a safe default frontend build heap

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node scripts/copy-viewer-wasm.mjs && node scripts/copy-emojibase-data.mjs && NODE_OPTIONS='--max-http-header-size=32768' dotenvx run --ignore=MISSING_ENV_FILE -f .env.local -f .env -- next dev --turbopack --port ${WEB_PORT:-3000}",
     "dev:staging-env": "NODE_OPTIONS='--max-http-header-size=32768' dotenvx run --overload -f .env.staging -- next dev --turbopack --port ${WEB_PORT:-3000}",
-    "build": "node scripts/validate-production-supabase-env.mjs && node scripts/copy-viewer-wasm.mjs && node scripts/copy-emojibase-data.mjs && next build",
+    "build": "node scripts/validate-production-supabase-env.mjs && node scripts/copy-viewer-wasm.mjs && node scripts/copy-emojibase-data.mjs && NODE_OPTIONS=\"${NODE_OPTIONS:---max-old-space-size=6144}\" next build",
     "start": "next start",
     "lint": "next lint",
     "catalog:enrich": "bun scripts/enrich-llm-catalog-capabilities.ts",

--- a/apps/web/scripts/validate-production-supabase-env.test.mjs
+++ b/apps/web/scripts/validate-production-supabase-env.test.mjs
@@ -203,6 +203,10 @@ describe('release wiring', () => {
       packageJson.scripts.build,
       /^node scripts\/validate-production-supabase-env\.mjs && /,
     );
+    assert.match(
+      packageJson.scripts.build,
+      /NODE_OPTIONS="\$\{NODE_OPTIONS:---max-old-space-size=6144\}" next build$/,
+    );
   });
 
   it('blocks the GitHub release and banner clear on deployed frontend proof', async () => {


### PR DESCRIPTION
## Summary

- Default the frontend production build heap to 6,144 MB.
- Preserve an explicit `NODE_OPTIONS` value when callers provide one.
- Add regression coverage for the package build contract.

## Verification

- TDD failure: 12 passed and 1 failed before the package change.
- `bun test scripts/validate-production-supabase-env.test.mjs`: 13 passed and 0 failed.
- Prettier: passed.
- ESLint: passed.
- `git diff --check`: passed.
- Production build with no external heap option: exit 0; 196 static pages generated.