### PR TITLE
Guarantee accessible public MDX images

### DIFF
--- a/apps/web/src/app/(public)/(seo)/use-cases/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/(seo)/use-cases/[slug]/page.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/use-cases/mdx';
 import { UseTemplateButton } from '@/components/use-cases/template-install-dialog';
 import { UseCaseCard, UseCaseCover } from '@/components/use-cases/use-case-card';
+import { UseCaseMdxImage } from '@/components/use-cases/use-case-mdx-image';
 import { UseCaseToc, type TocItem } from '@/components/use-cases/use-case-toc';
 import { UseCasesCta } from '@/components/use-cases/use-cases-cta';
 import { resolveAuthor } from '@/lib/blog';
@@ -43,7 +44,7 @@ const mdxComponents = {
         {children}
       </a>
     ),
-  img: (props: any) => <img loading="lazy" {...props} />,
+  img: UseCaseMdxImage,
   // Case-study kit — authors compose these directly in the .mdx body.
   KeyFacts,
   Fact,

--- a/apps/web/src/components/use-cases/use-case-mdx-image.test.tsx
+++ b/apps/web/src/components/use-cases/use-case-mdx-image.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { UseCaseMdxImage } from './use-case-mdx-image';
+
+describe('UseCaseMdxImage', () => {
+  it('renders no element without a source', () => {
+    expect(renderToStaticMarkup(<UseCaseMdxImage />)).toBe('');
+  });
+
+  it('uses an empty alt value for decorative images', () => {
+    const markup = renderToStaticMarkup(<UseCaseMdxImage src="/diagram.png" />);
+
+    expect(markup).toContain('alt=""');
+    expect(markup).toContain('loading="lazy"');
+  });
+
+  it('preserves a meaningful alt value', () => {
+    const markup = renderToStaticMarkup(
+      <UseCaseMdxImage src="/diagram.png" alt="Agent workflow diagram" />,
+    );
+
+    expect(markup).toContain('alt="Agent workflow diagram"');
+  });
+});

--- a/apps/web/src/components/use-cases/use-case-mdx-image.tsx
+++ b/apps/web/src/components/use-cases/use-case-mdx-image.tsx
@@ -1,0 +1,29 @@
+import type { ComponentProps } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export function UseCaseMdxImage({
+  src,
+  alt = '',
+  loading = 'lazy',
+  className,
+  ...props
+}: ComponentProps<'img'>) {
+  if (!src || typeof src !== 'string') return null;
+
+  return (
+    <span className="my-5 block">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        {...props}
+        src={src}
+        alt={alt}
+        loading={loading}
+        className={cn(
+          'h-auto max-w-full rounded-lg outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10',
+          className,
+        )}
+      />
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Render public use-case images through a typed component.
- Preserve meaningful alternative text and default decorative images to `alt=""`.
- Apply the established Kortix image outline pattern.
- Add render-level regression coverage.

## Verification

- TDD failure: the component import failed before implementation.
- Focused image and public-content tests: 17 passed and 0 failed.
- Full frontend suite: 3,729 passed and 0 failed.
- Prettier: passed.
- ESLint: passed.
- `git diff --check`: passed.