### PR TITLE
A failed spawn must schedule a respawn, not kill the session

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/spawn-failure-recovery.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/spawn-failure-recovery.test.ts
@@ -1,0 +1,78 @@
+/**
+ * A spawn that FAILS must schedule a respawn. Nothing else recovers it.
+ *
+ * The supervisor's whole recovery story hangs off the child's `exit` event. A
+ * failed spawn produces no child, so no exit ever fires and that path never
+ * runs. `start()` logged the error and carried on, which is survivable at BOOT
+ * — nothing was running yet — and fatal on a RESTART, because `restart()` stops
+ * the working opencode first.
+ *
+ * So a restart whose spawn failed (a full disk, a PID or memory ceiling) killed
+ * a healthy session permanently: `/kortix/health` reported `starting` with
+ * `opencode_pid: null` forever, every prompt 503'd, and the readiness probe just
+ * re-marked `starting` on a loop. Meanwhile `/kortix/env` had answered
+ * `ok: true` and the reload reported success — so nothing anywhere said the
+ * restart was what killed it, and the only escape was a new session.
+ *
+ * The recovery already existed for crashes: `scheduleUnplannedRespawn` retries
+ * with backoff to 30s and re-schedules itself on repeated failure. The planned
+ * path simply never called it.
+ *
+ * Asserted against the source. `spawnChild` and `scheduleUnplannedRespawn` are
+ * closure-private, there is no seam to inject a failing spawn, and the honest
+ * alternative — spawning a real 129MB opencode and filling a disk — is not a
+ * unit test. This pins the wiring; the backoff behaviour it delegates to is
+ * covered by its own comments and the exit path that has always used it.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SRC = readFileSync(join(import.meta.dir, '..', 'opencode.ts'), 'utf8')
+
+/** The body of the `start()` method on the returned supervisor. */
+function startBody(): string {
+  const body = SRC.split('async start() {')[1]?.split('\n    },')[0]
+  expect(body).toBeTruthy()
+  // Guard the extraction: if this stops covering the spawn, every assertion
+  // below passes vacuously.
+  expect(body).toContain('await spawnChild(bin)')
+  return body as string
+}
+
+describe('start(): a failed spawn schedules a respawn', () => {
+  test('the catch calls scheduleUnplannedRespawn, not just a log', () => {
+    const body = startBody()
+    const caught = body.slice(body.indexOf('} catch (err) {'))
+    expect(caught).toContain('scheduleUnplannedRespawn()')
+  })
+
+  test('it marks the runtime down rather than leaving it "starting"', () => {
+    // The readiness probe re-marks `starting` on every tick, so without this the
+    // box reports a boot that is never going to finish.
+    const body = startBody()
+    const caught = body.slice(body.indexOf('} catch (err) {'))
+    expect(caught).toContain("state = 'down'")
+  })
+
+  test('the recovery it uses re-schedules itself, so one failure is not terminal', () => {
+    // The property that makes this a fix rather than a single extra attempt.
+    const respawn = SRC.split('function scheduleUnplannedRespawn(): void {')[1]?.split('\n  }\n')[0]
+    expect(respawn).toBeTruthy()
+    expect(respawn).toContain('scheduleUnplannedRespawn()')
+    expect(respawn).toContain('Math.min(restartDelayMs * 2, 30_000)')
+  })
+
+  test('it still refuses to fight a deliberate shutdown', () => {
+    // `stop()` sets `stopping`; a respawn loop that ignored it would resurrect
+    // opencode during shutdown and hang the container.
+    const respawn = SRC.split('function scheduleUnplannedRespawn(): void {')[1]?.split('\n  }\n')[0]
+    expect(respawn).toContain('if (stopping) return')
+  })
+
+  test('the successful path resets the backoff', () => {
+    // Otherwise a session that recovered from one blip would carry a 30s delay
+    // into its next restart for the rest of its life.
+    expect(SRC).toContain('restartDelayMs = 500')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1252,7 +1252,21 @@ export function createOpencodeSupervisor(
       try {
         await spawnChild(bin)
       } catch (err) {
-        logger.error('[opencode] initial spawn failed', err)
+        // A failed spawn produces NO process, so no 'exit' ever fires and the
+        // crash path that normally rescues opencode never runs. Left as a bare
+        // log, this permanently killed the session: `restart()` stops the
+        // WORKING opencode first, so a spawn that then fails — a full disk, a
+        // PID/memory ceiling — leaves the box reporting `starting` forever with
+        // every prompt 503ing, while `/kortix/env` answered ok:true and the
+        // reload reported success. Recovering needed a whole new session, with
+        // nothing anywhere saying the restart was what killed it.
+        //
+        // `scheduleUnplannedRespawn` is exactly the right recovery and already
+        // self-reschedules with backoff up to 30s; the planned path simply
+        // never called it.
+        logger.error('[opencode] spawn failed; scheduling respawn', err)
+        state = 'down'
+        scheduleUnplannedRespawn()
       }
       scheduleReadinessProbe()
     },


### PR DESCRIPTION
The last confirmed finding from the audit for the bug class behind #6083 and #6086: **an operation reporting success for something it never verified.**

## The bug

The supervisor's entire recovery story hangs off the child's `exit` event. A spawn that **fails** produces no child, so no exit ever fires and that path never runs:

```ts
try {
  await spawnChild(bin)
} catch (err) {
  logger.error('[opencode] initial spawn failed', err)   // ← and that was all
}
scheduleReadinessProbe()
```

Survivable at **boot** — nothing was running yet. Fatal on a **restart**, because `restart()` stops the working opencode first.

So a restart whose spawn failed — a full disk, a PID or memory ceiling — killed a healthy session permanently:

- `/kortix/health` reported `starting`, `opencode_pid: null`, **forever**
- every prompt 503'd
- the readiness probe just re-marked `starting` on a loop
- `/kortix/env` had already answered `ok: true`, and the reload reported success

Nothing anywhere said the restart was what killed it. And clicking Reload again couldn't recover it: with opencode gone the turn probe returns `null`, so the API answers 409 *"Could not confirm this session is idle"* — telling the user their session is busy when its runtime no longer exists. The only escape was a new session.

## The fix

`scheduleUnplannedRespawn` is exactly the right recovery, and it already re-schedules itself with backoff to 30s and refuses to fight a deliberate `stop()`. The planned path simply never called it.

Also marks the runtime `down`, so the readiness probe stops reporting a boot that is never going to finish.

## Testing

Source-asserted, and the file says why: `spawnChild` and `scheduleUnplannedRespawn` are closure-private with no injection seam, and the honest alternative — spawning a real 129MB opencode and filling a disk — isn't a unit test. The assertions guard their own extraction, so they can't pass vacuously if `start()` is refactored.

Verified by mutation: restoring the bare log fails both new assertions.

**Gates.** `bun run typecheck` clean; full daemon suite **322 pass / 0 fail**; `BUN_COMPILE_TARGET=bun-linux-x64 bun run build` produces the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
