### PR TITLE
CLI: stop claiming an invite email was sent when none was

### DIFF
--- a/apps/cli/src/__tests__/access-invite-email.test.ts
+++ b/apps/cli/src/__tests__/access-invite-email.test.ts
@@ -1,0 +1,189 @@
+/**
+ * `kortix access invite` must not claim an email was sent when none was.
+ *
+ * Every deployment without `MAILTRAP_API_TOKEN` — which is every self-hosted
+ * instance — skips the email. The server says so in the SAME response
+ * (`email_sent: false`, a `email_skip_reason`, a `message`, and a working
+ * `invite_url`, which is the only remaining way to reach the person), and the
+ * comment at the route calls that out as deliberate: "we know synchronously
+ * it'll be skipped, so report that honestly".
+ *
+ * The CLI typed the response as `{ status?: string }`, discarded all four
+ * fields, and printed a green tick. The inviter waited for a delivery that never
+ * happened, and the one link that would have worked was thrown away — with no
+ * recovery path, since `--json` was ignored here and `access pending` returns
+ * the invite id without the URL.
+ *
+ * The web dashboard already warns and offers a "Copy link" button for this exact
+ * payload, so a CLI user and a web user doing the same thing were told opposite
+ * things.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runAccess } from '../commands/access.ts';
+import { stripAnsi } from '../style.ts';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_STDOUT_WRITE = process.stdout.write;
+const ORIGINAL_STDERR_WRITE = process.stderr.write;
+
+const ENV_KEYS = [
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_EXECUTOR_TOKEN',
+  'KORTIX_TOKEN',
+  'KORTIX_API_URL',
+  'KORTIX_PROJECT_ID',
+  'KORTIX_DISABLE_SANDBOX_ENV_FILE',
+  'KORTIX_CONFIG_FILE',
+  'KORTIX_AUTH_FILE',
+] as const;
+
+const PROJECT = 'proj-1';
+const INVITE_URL = 'https://app.test/invite/inv_abc123';
+
+let saved: Record<string, string | undefined>;
+let tmp: string;
+let originalCwd: string;
+let stdout = '';
+let stderr = '';
+/** What the mocked invite route answers. Each test sets this. */
+let inviteResponse: Record<string, unknown>;
+
+function writeConfig(): void {
+  const file = join(tmp, 'config.json');
+  writeFileSync(
+    file,
+    JSON.stringify({
+      active: 'test',
+      hosts: {
+        test: {
+          url: 'https://api.test',
+          token: 'tok_test',
+          user_id: 'user_1',
+          user_email: 'user@example.test',
+          account_id: 'account_1',
+          logged_in_at: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    }),
+    'utf8',
+  );
+  process.env.KORTIX_CONFIG_FILE = file;
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
+  originalCwd = process.cwd();
+  tmp = mkdtempSync(join(tmpdir(), 'kortix-invite-test-'));
+  process.chdir(tmp);
+  writeConfig();
+  stdout = '';
+  stderr = '';
+  (process.stdout as any).write = (chunk: unknown) => ((stdout += String(chunk)), true);
+  (process.stderr as any).write = (chunk: unknown) => ((stderr += String(chunk)), true);
+  inviteResponse = {};
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes('/access/invite') && (init?.method ?? 'GET').toUpperCase() === 'POST') {
+      return json(inviteResponse, 201);
+    }
+    return json({ error: `unexpected ${url}` }, 500);
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  (process.stdout as any).write = ORIGINAL_STDOUT_WRITE;
+  (process.stderr as any).write = ORIGINAL_STDERR_WRITE;
+  process.chdir(originalCwd);
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+const invite = (extra: Record<string, unknown>) => ({
+  status: 'invited',
+  email: 'bob@corp.com',
+  invite_id: 'inv_abc123',
+  project_role: 'editor',
+  invite_url: INVITE_URL,
+  ...extra,
+});
+
+describe('kortix access invite — email honesty', () => {
+  test('a SKIPPED email is reported as such, with the link that still works', async () => {
+    inviteResponse = invite({ email_sent: false, email_skip_reason: 'missing_mailtrap_token' });
+
+    const code = await runAccess(['invite', 'bob@corp.com', '--project', PROJECT, '--role', 'editor']);
+    const out = stripAnsi(stdout);
+
+    expect(code).toBe(0);
+    // The claim that used to be printed unconditionally.
+    expect(out).toContain('NO email was sent');
+    // The only remaining delivery channel — discarding it left no recovery path.
+    expect(out).toContain(INVITE_URL);
+    // And it says WHY, so the operator can go fix the deployment.
+    expect(out).toContain('missing_mailtrap_token');
+  });
+
+  test('a SENT email still reads as a plain success', async () => {
+    inviteResponse = invite({ email_sent: true, email_skip_reason: null });
+
+    const code = await runAccess(['invite', 'bob@corp.com', '--project', PROJECT, '--role', 'editor']);
+    const out = stripAnsi(stdout);
+
+    expect(code).toBe(0);
+    expect(out).toContain('Invited');
+    expect(out).toContain('bob@corp.com');
+    expect(out).not.toContain('NO email was sent');
+    // No link needed when it actually went out — printing one would train people
+    // to ignore the warning case.
+    expect(out).not.toContain(INVITE_URL);
+  });
+
+  test('an OLDER API that omits email_sent keeps the previous wording', async () => {
+    // `undefined` is not `false`. Inventing a warning for a server that simply
+    // predates the field would cry wolf on every deployment that is fine.
+    inviteResponse = { status: 'invited' };
+
+    const code = await runAccess(['invite', 'bob@corp.com', '--project', PROJECT, '--role', 'editor']);
+    const out = stripAnsi(stdout);
+
+    expect(code).toBe(0);
+    expect(out).toContain('Invited');
+    expect(out).not.toContain('NO email was sent');
+  });
+
+  test('--json emits the full payload, including the fields the CLI used to drop', async () => {
+    // Previously ignored on this subcommand, so a scripted caller had no way to
+    // detect the skip either.
+    inviteResponse = invite({ email_sent: false, email_skip_reason: 'missing_mailtrap_token' });
+
+    const code = await runAccess([
+      'invite', 'bob@corp.com', '--project', PROJECT, '--role', 'editor', '--json',
+    ]);
+
+    expect(code).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.email_sent).toBe(false);
+    expect(parsed.email_skip_reason).toBe('missing_mailtrap_token');
+    expect(parsed.invite_url).toBe(INVITE_URL);
+  });
+});

--- a/apps/cli/src/commands/access.ts
+++ b/apps/cli/src/commands/access.ts
@@ -109,12 +109,44 @@ export async function runAccess(argv: string[]): Promise<number> {
         const email = positional[0];
         if (!email) return missing('an email');
         if (!checkRole()) return 2;
-        const resp = await ctx.client.post<{ status?: string }>(`${base}/access/invite`, {
+        const resp = await ctx.client.post<{
+          status?: string;
+          /** False when no email left the building — every deployment without
+           *  MAILTRAP_API_TOKEN, which is every self-hosted one. */
+          email_sent?: boolean;
+          email_skip_reason?: string | null;
+          /** The only remaining delivery channel when the email was skipped. */
+          invite_url?: string;
+          message?: string;
+        }>(`${base}/access/invite`, {
           email,
           role,
           ...(f.expires ? { expires_at: f.expires } : {}),
         });
-        process.stdout.write(`${status.ok(`Invited ${C.bold}${email}${C.reset} as ${role}${resp.status === 'invited' ? ' (pending signup)' : ''}`)}\n`);
+        if (json) {
+          emitJson(resp);
+          return 0;
+        }
+        const pending = resp.status === 'invited' ? ' (pending signup)' : '';
+        // The server tells us whether an email actually went out, and hands back
+        // an invite_url precisely so this case is recoverable. Printing a green
+        // tick regardless left the inviter waiting for a delivery that never
+        // happened — and threw away the only link that would have worked. The
+        // web dashboard already warns and offers the link for this same payload,
+        // so a CLI user and a web user were told opposite things.
+        //
+        // `email_sent === undefined` is an older API that predates the field;
+        // keep the previous wording rather than inventing a warning.
+        if (resp.email_sent === false) {
+          process.stdout.write(
+            `${status.warn(`Invited ${C.bold}${email}${C.reset} as ${role}${pending} — but NO email was sent${resp.email_skip_reason ? ` (${resp.email_skip_reason})` : ''}.`)}\n`,
+          );
+          if (resp.invite_url) {
+            process.stdout.write(`  Share this link with them:\n  ${C.bold}${resp.invite_url}${C.reset}\n`);
+          }
+          return 0;
+        }
+        process.stdout.write(`${status.ok(`Invited ${C.bold}${email}${C.reset} as ${role}${pending}`)}\n`);
         return 0;
       }
       case 'grant':


### PR DESCRIPTION
`kortix access invite bob@corp.com --role editor` prints a green `✓ Invited bob@corp.com as editor (pending signup)` and exits 0 — on deployments where **no email was ever sent**.

That's every self-hosted instance: `apps/cli/src/self-host/**` never sets `MAILTRAP_API_TOKEN`, and per the web UI's own comment it also covers "local dev or unconfigured prod". Bob is never contacted. The inviter waits for a delivery that does not exist.

## The server was already honest

In the very same response (`r6.ts:705-720`):

```ts
// Optimistic: send is queued, not awaited. When delivery isn't wired up
// we know synchronously it'll be skipped, so report that honestly.
email_sent: emailConfigured,
email_skip_reason: emailConfigured ? null : 'missing_mailtrap_token',
message: …'Share the invite link with them…',
invite_url: buildInviteUrl(inviteId),
```

The CLI typed that as `{ status?: string }` and discarded all four fields — including `invite_url`, the only remaining delivery channel.

No recovery path either: `--json` was ignored on this subcommand, and `access pending` returns the `invite_id` without the URL.

## Same action, opposite information

`members-view.tsx:326-334` already handles this correctly — a warning toast plus a **Copy link** button. So a CLI user and a web user performing the identical action were told opposite things.

## The fix

Warn, name the reason, print the link:

```
!  Invited bob@corp.com as editor (pending signup) — but NO email was sent (missing_mailtrap_token).
   Share this link with them:
   https://app.test/invite/inv_abc123
```

`--json` now emits the full payload so scripted callers can detect the skip too.

`email_sent === undefined` deliberately keeps the old wording — that's an older API predating the field, and warning there would cry wolf on every deployment that's fine.

## Testing

Black-box through `runAccess` with a mocked API — actual command runs and asserted stdout, not source assertions. Four cases: skipped, sent, older-API, `--json`. Verified by mutation: removing the warning branch fails the skipped case.

**Gates.** `tsc` clean; full CLI suite **443 pass / 0 fail**.

## Provenance

Found by an audit for the bug class behind #6083, #6086 and #6089 — an operation reporting success for something it never verified. This is the same shape at the outermost layer: the data was right there in the response and the presentation layer threw it away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
