### PR TITLE
Validate re-scoped secrets for the session owner, not the caller

### DIFF
--- a/apps/api/src/projects/lib/session-rescope.test.ts
+++ b/apps/api/src/projects/lib/session-rescope.test.ts
@@ -318,3 +318,31 @@ describe('the scope route surfaces the narrowing', () => {
     expect(ROUTE).toContain('rotate them if that matters');
   });
 });
+
+/**
+ * Validation and DELIVERY must resolve secrets for the same principal.
+ *
+ * The per-prompt push keys on the session's `createdBy` — `resolveOwnerRawEnv`
+ * does, and `sessions.ts` spells out why: "a per-user secret override resolves
+ * per principal… if a manager restarted another member's session we'd inject the
+ * MANAGER's personal secret".
+ *
+ * `PUT /scope` validated against the CALLER instead. So a project manager
+ * re-scoping someone else's session could add an identifier that exists only as
+ * the manager's own personal override: the API answered 200 with it listed in
+ * `secrets_allowlist` and "Applies from the next prompt.", and the session never
+ * received it — not on that prompt, not on any later one, with nothing anywhere
+ * saying so.
+ */
+describe('the scope route validates for the session OWNER, not the caller', () => {
+  test('availability is resolved against createdBy', () => {
+    expect(ROUTE).toContain('const secretsPrincipal = visible.row.createdBy ?? loaded.userId');
+    expect(ROUTE).toContain('listResolvedProjectSecrets(projectId, secretsPrincipal)');
+  });
+
+  test('it no longer resolves availability against the caller', () => {
+    // The exact call that made a manager's personal override look in-scope for
+    // somebody else's session.
+    expect(ROUTE).not.toContain('listResolvedProjectSecrets(projectId, loaded.userId)');
+  });
+});

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -2459,7 +2459,23 @@ projectsApp.openapi(
         PROJECT_ACTIONS.PROJECT_SECRET_READ,
       );
       if (nextAllowlist !== null && nextAllowlist.length > 0) {
-        const availableSecrets = await listResolvedProjectSecrets(projectId, loaded.userId);
+        // The SESSION OWNER, not the caller. Delivery resolves per principal —
+        // `resolveOwnerRawEnv` keys the per-prompt push on `createdBy`, and
+        // sessions.ts spells out why: "a per-user secret override resolves per
+        // principal… if a manager restarted another member's session we'd inject
+        // the MANAGER's personal secret".
+        //
+        // Validating against the caller let a project manager re-scoping someone
+        // else's session add an identifier that exists only as the MANAGER's own
+        // personal override. The API answered 200 with it listed in
+        // `secrets_allowlist` and "Applies from the next prompt." — and the
+        // session never received it, on that prompt or any later one, with
+        // nothing anywhere saying so.
+        //
+        // Falls back to the caller only when the row carries no creator, which
+        // matches how every other principal-resolution site degrades.
+        const secretsPrincipal = visible.row.createdBy ?? loaded.userId;
+        const availableSecrets = await listResolvedProjectSecrets(projectId, secretsPrincipal);
         const available = new Set(
           availableSecrets.map((secret) => secret.identifier.toUpperCase()),
         );


### PR DESCRIPTION
A project manager re-scoping **another member's** session can add a secret identifier that exists only as the **manager's own** personal override. The API answers `200` with that identifier listed in `secrets_allowlist` and *"Applies from the next prompt."* — and the session never receives it. Not on that prompt, not on any later one. Nothing ever says so.

## The rule already exists

Secret delivery resolves **per principal**, keyed on the session's `createdBy`. `resolveOwnerRawEnv` does it for the per-prompt push, and `sessions.ts:355` states it outright:

> *The secrets principal is the session's OWNER (`createdBy`) — NOT `input.userId`, which is whoever is provisioning this run… a per-user secret override resolves per principal. If a manager restarted another member's session we'd inject the MANAGER's personal secret at boot.*

`PUT /scope` was the one place that didn't follow it:

```ts
const availableSecrets = await listResolvedProjectSecrets(projectId, loaded.userId);
```

`loaded.userId` is the caller. Delivery uses `createdBy`. So the check passes for a secret the session can never be handed.

At **create** time the two coincide — the creator *is* the caller — which is why this only ever surfaced on re-scope.

## The fix

Resolve availability against `visible.row.createdBy`, falling back to the caller only when the row carries no creator (matching how every other principal-resolution site degrades). An identifier the session can never receive is now refused at save time instead of being reported as in-scope.

## Testing

Route wiring asserted both directions — the new principal is used, and the old caller-keyed call is gone. `src/projects/lib/` **356 pass / 23 fail** (baseline 23, pre-existing cross-file `mock.module` leaks, identical on a clean tree). `tsc` clean.

## Provenance

Found by an audit for the bug class behind #6083, #6086, #6089 and #6090 — an operation reporting success for something it never verified. Here the check and the delivery simply disagreed about *who* the secret belongs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
