### PR TITLE
docs: record the connector 'Connected' badge gap and its tradeoff

### DIFF
--- a/docs/KAAB_HARDENING_AUDIT.md
+++ b/docs/KAAB_HARDENING_AUDIT.md
@@ -217,3 +217,62 @@ All 17 below were adversarially verified on `kaab-hardening-docs` (== origin/mai
 
 **Doc line only (accepted capability / threat-model note — no code change unless policy changes):**
 - #17 record in the KaaB threat model that every project CI PAT is a `backend` vouching credential able to set `origin_ref`/`secrets`; decide whether to narrow the predicate.
+
+---
+
+## Addendum 2026-08-04 — "reported success it never verified" sweep
+
+A five-lens audit for one bug class: **an operation reporting success for
+something it never checked.** Eight confirmed (one a duplicate). Seven fixed and
+merged; one is left below because it is a genuine cost/design tradeoff, not an
+oversight.
+
+**Fixed:** #6083 (session reload changed the etag but not the agent opencode
+reads; repo-controlled git pathspec; `auth.json` stale after a dispose),
+#6086 (first secrets narrowing warned about nothing; transient git failure
+compiled an agent with no prompt; secret-identifier disclosure), #6089 (a failed
+spawn permanently killed the session), #6090 (`kortix access invite` claimed an
+email was sent when none was), #6091 (`PUT /scope` validated for the caller while
+delivery resolves for the session owner).
+
+### OPEN — a connector reads "Connected" before any credential exists
+
+**What a user sees.** Open the Pipedream connect dialog, close it without
+authorizing. The profile appears in the roster with a green **Connected** badge,
+and shows up as a selectable connection in the session-scope picker. Selecting it
+and saving is then refused with `CONNECTOR_PROFILE_INACTIVE` — *"Connector
+authorization for alias "x" is not connected"* — an error about a connection the
+UI listed as active one click earlier.
+
+**Cause.** `GET /projects/{id}/connector-profiles` (`r4.ts:347`) returns the row's
+`status` column, which is set to active when the profile row is *reconciled* —
+before any credential lands. The enforcement path does not trust that column: it
+calls `connectorAuthorizationIsConnected`
+(`lib/session-connector-bindings.ts:85`) in five places. So the gate is right and
+only the *display* is wrong. Row status is provenance, not connectivity.
+
+**Why it is not a one-liner.** The predicate does per-profile I/O —
+`profileCredentialExists`, plus `loadSlackInstall` / `loadTeamsInstall` /
+`loadAgentMailInstall` for channel connectors. The list route is currently a
+single joined query with no per-profile work, and the UI polls it. Calling the
+predicate per row turns one query into N+1.
+
+**Two options, and the choice is a real one:**
+
+1. **Compute `connected` in the list route.** Add it as a field beside `status`
+   and have the badge and the scope picker read it. Correct at the read side and
+   leaves stored state alone. Cost: N per-profile lookups on a polled route —
+   mitigable by resolving the per-project channel installs once per request and
+   batching the credential-existence check into a single `IN (…)` query, which
+   would keep it to ~2 extra queries rather than N.
+2. **Do not store a reconciled-but-unauthorized profile as active.** Insert it
+   with a pending status and let finalize flip it. Free at read time and correct
+   at the source, but it changes the meaning of a stored column that other
+   consumers already read — needs an audit of every `status` reader first.
+
+(1) is the smaller blast radius; (2) is the more honest data model. Either way
+the badge and the scope picker must stop reading `status` as connectivity.
+
+**Do not "fix" this by having the scope picker hide non-connected profiles
+only.** The badge is the thing that tells a user their setup is done; leaving it
+green while quietly filtering the picker trades one confusing surface for two.


### PR DESCRIPTION
The last finding from the sweep behind #6083, #6086, #6089, #6090 and #6091 — **an operation reporting success for something it never verified**. Left open deliberately, with the analysis written down so the decision is cheap for whoever takes it.

## The bug

Open the Pipedream connect dialog, close it without authorizing. The profile shows a green **Connected** badge and appears as a selectable connection in the session-scope picker. Selecting it and saving is then refused with `CONNECTOR_PROFILE_INACTIVE` — *"not connected"* — about a connection the UI listed as active one click earlier.

`GET /connector-profiles` returns the row's `status`, which goes active when the profile is **reconciled**, before any credential lands. The enforcement path doesn't trust that column — it calls `connectorAuthorizationIsConnected` in five places. So the gate is right; only the display lies. Row status is provenance, not connectivity.

## Why I didn't just fix it

The predicate does per-profile I/O (`profileCredentialExists`, plus Slack/Teams/email install loads). The list route is currently **one joined query with no per-profile work**, and the UI polls it. Calling the predicate per row makes it N+1.

Two real options, both written up in the doc with their costs:

1. **Compute a `connected` field in the list route** — correct at the read side, leaves stored state alone. Batchable to ~2 extra queries (resolve channel installs once per request, fold the credential check into one `IN (…)`).
2. **Don't store a reconciled-but-unauthorized profile as active** — free at read time, more honest data model, but changes the meaning of a column other consumers already read and needs an audit of every reader first.

(1) is the smaller blast radius; (2) is the better model. That's a judgment call about the connector UX, not something to guess at unattended — so it's documented rather than shipped.

Also recorded: **don't** "fix" this by filtering the scope picker alone. Leaving the badge green while quietly hiding the entry trades one confusing surface for two.

Issues are disabled on this repo, so findings live in `docs/KAAB_HARDENING_AUDIT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)