### PR TITLE
Finalize the turn a planned restart kills

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/spawn-failure-recovery.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/spawn-failure-recovery.test.ts
@@ -76,3 +76,57 @@ describe('start(): a failed spawn schedules a respawn', () => {
     expect(SRC).toContain('restartDelayMs = 500')
   })
 })
+
+/**
+ * A PLANNED restart strands its turn exactly like a crash does.
+ *
+ * Only the crash path was cleaning up. `proc.on('exit')` returns early while
+ * `stopping` is set — which `stop()` sets and `restart()` goes through — so
+ * `onUnplannedRespawn`, and with it the orphaned-turn finalize, never fired for
+ * a restart we asked for.
+ *
+ * A turn ends only when opencode emits `session.idle`/`session.error` over SSE.
+ * The opencode we killed emits neither, so the last assistant message stays
+ * incomplete and every client streaming it spins forever. `reload --force` is
+ * the sharpest case: it exists precisely to reload DURING a turn, and its
+ * confirmation tells the user it "ends the turn that's running right now" —
+ * then left it spinning instead of ended. `/kortix/refresh` (restart on by
+ * default) and `sessions restart` reach the same place.
+ */
+describe('restart(): the turn it kills gets finalized', () => {
+  function restartBody(): string {
+    const body = SRC.split('    async restart() {')[1]?.split('\n    },')[0]
+    expect(body).toBeTruthy()
+    // Guard the extraction — this must still cover the stop/start pair.
+    expect(body).toContain("await this.stop('SIGTERM')")
+    expect(body).toContain('await this.start()')
+    return body as string
+  }
+
+  test('it fires the finalize hook the crash path uses', () => {
+    expect(restartBody()).toContain('options.onUnplannedRespawn()')
+  })
+
+  test('it waits for readiness first, like the crash path does', () => {
+    // Firing before opencode is listening makes the hook read "no turn to
+    // finalize" and silently do nothing in the exact case it exists for.
+    const body = restartBody()
+    const hookAt = body.indexOf('options.onUnplannedRespawn()')
+    const readyAt = body.indexOf('waitUntilReady(')
+    expect(readyAt).toBeGreaterThanOrEqual(0)
+    expect(readyAt).toBeLessThan(hookAt)
+  })
+
+  test('a hook that throws cannot break the restart', () => {
+    // This runs after the runtime is already back up; failing to tidy a turn
+    // must not turn a successful restart into an error.
+    expect(restartBody()).toContain('catch')
+  })
+
+  test('the exit handler still skips the crash-path respawn on a planned stop', () => {
+    // The early return is correct for RESPAWNING — `restart()` starts the new
+    // process itself, and a shutdown must not be fought. Only the finalize was
+    // missing, so that early return must stay.
+    expect(SRC).toContain('if (stopping) return\n      scheduleUnplannedRespawn()')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1318,6 +1318,40 @@ export function createOpencodeSupervisor(
       await this.stop('SIGTERM')
       restartDelayMs = 500
       await this.start()
+      // A PLANNED restart strands its turn exactly like a crash does, and only
+      // the crash path was cleaning up: `proc.on('exit')` returns early while
+      // `stopping` is set — which `stop()` sets and this goes through — so
+      // `onUnplannedRespawn`, and with it the orphaned-turn finalize, never
+      // fired for a restart we asked for.
+      //
+      // A turn ends only when opencode emits `session.idle`/`session.error` over
+      // SSE. The opencode we just killed emits neither, so the last assistant
+      // message stays incomplete and every client streaming it spins forever.
+      // `reload --force` is the sharpest case: it exists precisely to reload
+      // DURING a turn, and its confirmation tells the user it "ends the turn
+      // that's running right now" — then left it spinning instead of ended.
+      // `/kortix/refresh` (restart on by default) and `sessions restart` reach
+      // the same place.
+      //
+      // Unconditional because `finalizeOrphanedTurn` already distinguishes: it
+      // aborts only a last message that is an assistant turn with no completion
+      // time, and leaves a completed turn, a user-last session, and an empty one
+      // alone. Readiness is awaited first for the reason the crash path
+      // documents — firing before opencode listens makes the hook read "no turn
+      // to finalize" and silently do nothing in the exact case it exists for.
+      if (!options.onUnplannedRespawn) return
+      const ready = await waitUntilReady(RESPAWN_FINALIZE_TIMEOUT_MS)
+      if (!ready) {
+        logger.warn('[opencode] restarted but never became ready; orphaned turn left as-is')
+        return
+      }
+      try {
+        options.onUnplannedRespawn()
+      } catch (err) {
+        logger.warn('[opencode] post-restart finalize hook threw', {
+          err: (err as Error).message,
+        })
+      }
     },
 
     /**


### PR DESCRIPTION
The orphaned-turn work covered **crashes only**. A restart we ask for strands its turn just as badly, and nothing cleaned up.

## The bug

```ts
proc.on('exit', (code, signal) => {
  child = null
  state = stopping ? 'down' : 'starting'
  if (stopping) return          // ← planned stop/restart exits here
  scheduleUnplannedRespawn()    // ← only this path reaches onUnplannedRespawn
})
```

`stop()` sets `stopping`, and `restart()` goes through it — so `onUnplannedRespawn`, and with it `finalizeOrphanedTurn`, never fired for a planned restart.

A turn ends only when opencode emits `session.idle` / `session.error` over SSE. The opencode we just killed emits neither, so the last assistant message stays incomplete and **every client streaming it spins forever**. That's the same forever-spinner the finalize was built to prevent, now reachable from four planned paths instead of a crash.

**`reload --force` is the sharpest case.** It exists precisely to reload *during* a turn, and its confirmation dialog says it "ends the turn that's running right now" — then left it spinning instead of ended. `/kortix/refresh` (restart on by default) and `sessions restart` land in the same place.

## The fix

`restart()` fires the same hook after the new process is ready.

**Unconditional**, because `finalizeOrphanedTurn` already distinguishes — it aborts only a last message that is an assistant turn with no completion time, and leaves a completed turn, a user-last session, and an empty one alone.

**Readiness awaited first**, for the reason the crash path already documents: firing before opencode is listening makes the hook read "no turn to finalize" and silently do nothing in the exact case it exists for.

**A throwing hook can't fail the restart** — the runtime is already back up by then.

**The exit handler's early return stays.** It's correct for *respawning*: `restart()` starts the new process itself, and a shutdown must not be fought. Only the finalize was missing, and a test pins that so a future reader doesn't "simplify" it away.

## Testing

Verified by mutation: removing the block fails three of the four new assertions. The extraction guards itself against a refactor of `restart()`.

**Gates.** `bun run typecheck` clean; daemon suite **326 pass / 0 fail**; `BUN_COMPILE_TARGET=bun-linux-x64 bun run build` produces the binary.

## Provenance

Found while auditing destructive paths after the sweep behind #6083, #6086, #6089, #6090, #6091. Related to #6089, which fixed the other half of the same handler — a spawn that fails produces no process, so no exit fires at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)