### PR TITLE
mock.module stubs silently delete the exports they omit

### DIFF
--- a/apps/api/scripts/find-stub-export-gaps.ts
+++ b/apps/api/scripts/find-stub-export-gaps.ts
@@ -1,0 +1,164 @@
+/**
+ * Finds `mock.module(...)` stubs that list a module's exports by hand and
+ * therefore DELETE every export they omit — `mock.module` replaces a module
+ * WHOLESALE. Reports each stub whose key set is a strict subset of the real
+ * module's runtime exports and that does not spread the real module.
+ *
+ * Why this matters: the deleted export does not fail where the stub is. It
+ * fails in whatever OTHER file imports the missing name next, as
+ * `SyntaxError: Export named '…' not found`, reported as "Unhandled error
+ * between tests" and attributed to no test at all. It only shows up when files
+ * are co-run — `bun test <dir>` — so the CI gate (scripts/test.sh, which passes
+ * --isolate and gives every file its own process) never sees it, and the blame
+ * lands on whichever innocent file happens to run next.
+ *
+ * The fix at each site is to spread the real module and override only what the
+ * test needs, so a NEW export keeps working by default:
+ *
+ *   import * as realFoo from '../foo';
+ *   mock.module('../foo', () => ({ ...realFoo, bar: () => 'fake' }));
+ *
+ * Two cautions before applying it mechanically:
+ *   - A top-level `import` HOISTS above the file's own `process.env` writes. If
+ *     the file sets env before importing config, use `const real = await
+ *     import('../foo')` placed at the stub instead.
+ *   - Not every module is safe to import for real. `../config` calls
+ *     process.exit(1) on validation failure and `shared/db` builds a live
+ *     handle, so those need per-site judgment rather than a blanket spread.
+ *
+ * Usage (from apps/api):  bun scripts/find-stub-export-gaps.ts .
+ *
+ * Static only: parses with Bun.Transpiler, never executes the target modules.
+ */
+import { Glob } from 'bun';
+import { dirname, resolve, relative } from 'node:path';
+
+const API_SRC = process.argv[2] ?? '.';
+
+/** Runtime export names of a module, minus type-only ones (erased at runtime). */
+async function realExports(file: string): Promise<string[] | null> {
+  let src: string;
+  try {
+    src = await Bun.file(file).text();
+  } catch {
+    return null;
+  }
+  const t = new Bun.Transpiler({ loader: 'ts' });
+  let names: string[];
+  try {
+    names = t.scan(src).exports;
+  } catch {
+    return null;
+  }
+  // Drop `export type X` / `export interface X` / `export type { X }` — erased.
+  const typeOnly = new Set<string>();
+  for (const m of src.matchAll(/^export\s+(?:type|interface)\s+([A-Za-z0-9_$]+)/gm)) typeOnly.add(m[1]);
+  for (const m of src.matchAll(/^export\s+type\s*\{([^}]*)\}/gm)) {
+    for (const part of m[1].split(',')) {
+      const n = part.trim().split(/\s+as\s+/).pop()?.trim();
+      if (n) typeOnly.add(n);
+    }
+  }
+  return names.filter((n) => !typeOnly.has(n));
+}
+
+/** Resolve a mock.module specifier to a file on disk. */
+async function resolveSpec(fromFile: string, spec: string): Promise<string | null> {
+  if (!spec.startsWith('.')) return null; // bare package — out of scope
+  const base = resolve(dirname(fromFile), spec);
+  for (const cand of [`${base}.ts`, `${base}/index.ts`, `${base}.tsx`]) {
+    if (await Bun.file(cand).exists()) return cand;
+  }
+  return null;
+}
+
+/** Top-level keys + whether a spread is present, from a factory object literal. */
+function parseFactory(src: string, openIdx: number): { keys: string[]; hasSpread: boolean } | null {
+  // openIdx points at the `{` that opens the returned object literal.
+  let depth = 0;
+  let end = -1;
+  for (let i = openIdx; i < src.length; i++) {
+    const c = src[i];
+    if (c === '{' || c === '(' || c === '[') depth++;
+    else if (c === '}' || c === ')' || c === ']') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return null;
+  const body = src.slice(openIdx + 1, end);
+
+  const keys: string[] = [];
+  let hasSpread = false;
+  let d = 0;
+  let seg = '';
+  const flush = () => {
+    const s = seg.trim();
+    seg = '';
+    if (!s) return;
+    if (s.startsWith('...')) {
+      hasSpread = true;
+      return;
+    }
+    const m = s.match(/^(?:async\s+)?\*?\s*(?:'([^']+)'|"([^"]+)"|\[[^\]]*\]|([A-Za-z0-9_$]+))/);
+    const name = m?.[1] ?? m?.[2] ?? m?.[3];
+    if (name) keys.push(name);
+  };
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (c === '{' || c === '(' || c === '[') d++;
+    else if (c === '}' || c === ')' || c === ']') d--;
+    if (c === ',' && d === 0) flush();
+    else seg += c;
+  }
+  flush();
+  return { keys, hasSpread };
+}
+
+type Gap = { file: string; line: number; spec: string; missing: string[]; listed: number };
+const gaps: Gap[] = [];
+const glob = new Glob('**/*.{ts,tsx}');
+
+for await (const rel of glob.scan({ cwd: API_SRC })) {
+  const file = resolve(API_SRC, rel);
+  const src = await Bun.file(file).text();
+  if (!src.includes('mock.module(')) continue;
+
+  const re = /mock\.module\(\s*['"]([^'"]+)['"]\s*,\s*\(\)\s*=>\s*\(?\s*\{/g;
+  for (const m of src.matchAll(re)) {
+    const spec = m[1];
+    const target = await resolveSpec(file, spec);
+    if (!target) continue;
+    const exps = await realExports(target);
+    if (!exps || exps.length === 0) continue;
+
+    const openIdx = m.index! + m[0].length - 1;
+    const parsed = parseFactory(src, openIdx);
+    if (!parsed) continue;
+    if (parsed.hasSpread) continue; // already safe
+
+    const missing = exps.filter((e) => !parsed.keys.includes(e));
+    if (missing.length === 0) continue;
+
+    const line = src.slice(0, m.index!).split('\n').length;
+    gaps.push({ file: relative(API_SRC, file), line, spec, missing, listed: parsed.keys.length });
+  }
+}
+
+// Group by the module being stubbed — that is the unit of risk.
+const byTarget = new Map<string, Gap[]>();
+for (const g of gaps) {
+  const key = g.spec.split('/').slice(-2).join('/');
+  byTarget.set(key, [...(byTarget.get(key) ?? []), g]);
+}
+const sorted = [...byTarget.entries()].sort((a, b) => b[1].length - a[1].length);
+for (const [target, list] of sorted) {
+  console.log(`\n### ${target}  — ${list.length} stub(s)`);
+  for (const g of list) {
+    console.log(`  ${g.file}:${g.line}  lists ${g.listed}, MISSING ${g.missing.length}: ${g.missing.join(', ')}`);
+  }
+}
+console.log(`\nTOTAL under-specified stubs: ${gaps.length}`);

--- a/apps/api/src/__tests__/billing/mocks.ts
+++ b/apps/api/src/__tests__/billing/mocks.ts
@@ -6,6 +6,7 @@
  */
 import { mock } from 'bun:test';
 import * as realProviders from '../../platform/providers';
+import * as realSandboxReaper from '../../projects/sandbox-reaper';
 
 // ─── Global Mock Registry ─────────────────────────────────────────────────────
 
@@ -188,7 +189,11 @@ export function registerGlobalMocks() {
     providerAutoStopBackstopMinutes: () => 60,
   }));
 
+  // Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+  // lists exports by hand deletes every export it omits — the failure surfaces in
+  // whatever unrelated file imports the missing name next, attributed to no test.
   mock.module('../../projects/sandbox-reaper', () => ({
+    ...realSandboxReaper,
     isAlreadyNotRunning: (_err: unknown) => false,
     reconcileSandboxStoppedByExternalId: async (_externalId: string) => true,
   }));

--- a/apps/api/src/__tests__/billing/mocks.ts
+++ b/apps/api/src/__tests__/billing/mocks.ts
@@ -5,6 +5,7 @@
  * the same mock.module() registrations without conflicts.
  */
 import { mock } from 'bun:test';
+import * as realProviders from '../../platform/providers';
 
 // ─── Global Mock Registry ─────────────────────────────────────────────────────
 
@@ -175,7 +176,11 @@ export function registerGlobalMocks() {
     hasDatabase: false,
   }));
 
+  // Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+  // lists exports by hand deletes every export it omits — the failure surfaces in
+  // whatever unrelated file imports the missing name next, attributed to no test.
   mock.module('../../platform/providers', () => ({
+    ...realProviders,
     getProvider: (_name: string) => ({
       stop: async (_externalId: string) => undefined,
     }),

--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -17,6 +17,8 @@ import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { runWithContext } from '../lib/request-context';
 import { classifyPtyWebSocketPath } from '../platform/providers/pty-ingress';
+import * as realProviders from '../platform/providers';
+import * as realPreviewOwnership from '../shared/preview-ownership';
 
 // ─── Mock state ──────────────────────────────────────────────────────────────
 
@@ -206,6 +208,7 @@ mock.module('../iam', () => ({
 }));
 
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   // Mirrors the REAL narrowing (executor/share.ts): a session-bound caller — a
   // sandbox token — may reach only its OWN session. Without this the mock
   // ignored callerSessionId entirely, so a test could pass one and prove
@@ -258,7 +261,11 @@ mock.module('../shared/daytona', () => ({
   }),
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../platform/providers', () => ({
+  ...realProviders,
   // Whole-module replacement: every export the graph touches must be present or
   // the file loads to 0 tests (see the secrets mock above).
   SandboxTemplateNotFoundError: class SandboxTemplateNotFoundError extends Error {},

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -439,7 +439,12 @@ mock.module('../projects/opencode-mapping', () => ({
   }),
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
+const realComputeMetering = await import('../billing/services/compute-metering');
 mock.module('../billing/services/compute-metering', () => ({
+  ...realComputeMetering,
   reopenComputeForSandbox: async () => {
     computeReopenCalls += 1;
   },

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -370,7 +370,14 @@ mock.module('../platform/services/session-sandbox', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
+// `await import`, not a top-level `import`: the latter hoists above the
+// process.env writes here, and the barrel pulls in config, which reads them once.
+const realProviders = await import('../platform/providers');
 mock.module('../platform/providers', () => ({
+  ...realProviders,
   WarmRuntimeUnavailableError: class WarmRuntimeUnavailableError extends Error {
     constructor(message: string) {
       super(message);

--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -286,7 +286,14 @@ mock.module('../platform/services/provider-balancer', () => ({
   selectProvider: async () => 'daytona',
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
+// `await import`, not a top-level `import`: the latter hoists above the
+// process.env writes here, and the barrel pulls in config, which reads them once.
+const realProviders = await import('../platform/providers');
 mock.module('../platform/providers', () => ({
+  ...realProviders,
   getProvider: () => ({ requiresPublicCallback: false }),
 }));
 

--- a/apps/api/src/__tests__/unit-audit-transaction.test.ts
+++ b/apps/api/src/__tests__/unit-audit-transaction.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test';
+import * as realRequestContext from '../lib/request-context';
 
 const calls: string[] = [];
 let auditFails = false;
@@ -60,7 +61,13 @@ mock.module('../shared/audit-webhooks', () => ({
   dispatchAuditEvent: () => calls.push('dispatch'),
 }));
 
-mock.module('../lib/request-context', () => ({ getRequestContext: () => null }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
+mock.module('../lib/request-context', () => ({
+  ...realRequestContext,
+  getRequestContext: () => null,
+}));
 
 const { runAuditedTransaction } = await import('../shared/audit');
 

--- a/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
+++ b/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
+import * as realPreviewOwnership from '../shared/preview-ownership';
+import * as realRequestContext from '../lib/request-context';
 
 let secretKeyValidations: string[] = [];
 
@@ -42,7 +44,11 @@ mock.module('../shared/supabase', () => ({
   }),
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   canAccessPreviewSandbox: async ({ accountId }: { accountId?: string }) =>
     accountId === 'acct-1',
   // No project-scoped PATs in this suite — stub so the real module's shape
@@ -56,7 +62,7 @@ mock.module('../shared/auth-audit', () => ({
 }));
 
 mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
-mock.module('../lib/request-context', () => ({ setContextField: () => {} }));
+mock.module('../lib/request-context', () => ({ ...realRequestContext, setContextField: () => {} }));
 mock.module('../iam/sso-sync', () => ({ syncSsoMembership: async () => {} }));
 
 const { combinedAuth, supabaseAuth } = await import('../middleware/auth');

--- a/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
+++ b/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
 import * as realPreviewOwnership from '../shared/preview-ownership';
 import * as realRequestContext from '../lib/request-context';
+import * as realAuthAudit from '../shared/auth-audit';
+import * as realSentry from '../lib/sentry';
+import * as realSsoSync from '../iam/sso-sync';
 
 let secretKeyValidations: string[] = [];
 
@@ -56,14 +59,18 @@ mock.module('../shared/preview-ownership', () => ({
   resolveSandboxProjectId: async () => null,
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../shared/auth-audit', () => ({
+  ...realAuthAudit,
   auditLoginSuccess: () => {},
   auditLoginFail: () => {},
 }));
 
-mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
+mock.module('../lib/sentry', () => ({ ...realSentry, setSentryUser: () => {} }));
 mock.module('../lib/request-context', () => ({ ...realRequestContext, setContextField: () => {} }));
-mock.module('../iam/sso-sync', () => ({ syncSsoMembership: async () => {} }));
+mock.module('../iam/sso-sync', () => ({ ...realSsoSync, syncSsoMembership: async () => {} }));
 
 const { combinedAuth, supabaseAuth } = await import('../middleware/auth');
 

--- a/apps/api/src/__tests__/unit-opencode-mapping.test.ts
+++ b/apps/api/src/__tests__/unit-opencode-mapping.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 
 import { projectSessions } from '@kortix/db';
+import * as realPreviewOwnership from '../shared/preview-ownership';
 
 const dbUpdates: Array<Record<string, unknown>> = [];
 mock.module('../shared/db', () => ({
@@ -25,7 +26,11 @@ mock.module('../sandbox-proxy/backend', () => ({
   }),
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   resolvePreviewUserContext: async () => null,
   // Not exercised by this suite — stub so the real module's shape stays
   // satisfied for anything else that imports it in the same test run.

--- a/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
+++ b/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realPreviewOwnership from '../shared/preview-ownership';
 
 const SANDBOX_ID = 'sandbox-xyz';
 let allowedAccounts = new Set<string>(['acct-owner']);
@@ -93,7 +94,11 @@ mock.module('../shared/supabase', () => ({
   }),
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   canAccessPreviewSandbox: async ({ userId, accountId }: { userId?: string; accountId?: string }) => {
     if (accountId && allowedAccounts.has(accountId)) return true;
     if (userId && allowedUsers.has(userId)) return true;

--- a/apps/api/src/__tests__/unit-preview-auth.test.ts
+++ b/apps/api/src/__tests__/unit-preview-auth.test.ts
@@ -1,13 +1,18 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import * as realPreviewOwnership from '../shared/preview-ownership';
 
 let mockSandboxAccountId: string | null = 'acct-owner';
 let mockResolvedAccountId = 'acct-owner';
 let mockSupabaseUser: { id: string; email?: string } | null = null;
 let mockAdminAccounts = new Set<string>();
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   canAccessPreviewSandbox: async ({ accountId, userId }: { accountId?: string; userId?: string }) => {
     if (!mockSandboxAccountId) return false;
     if (accountId && mockAdminAccounts.has(accountId)) return true;

--- a/apps/api/src/__tests__/unit-project-oauth-delete.test.ts
+++ b/apps/api/src/__tests__/unit-project-oauth-delete.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { projectSecrets } from '@kortix/db';
+import * as realAccess from '../projects/lib/access';
 
 const PROJECT_ID = '33333333-3333-4333-8333-333333333333';
 const ACCOUNT_ID = '44444444-4444-4444-8444-444444444444';
@@ -33,7 +34,11 @@ mock.module('../shared/db', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../projects/lib/access', () => ({
+  ...realAccess,
   loadProjectForUser: async (c: any) => ({
     row: { accountId: ACCOUNT_ID, projectId: PROJECT_ID },
     userId: c.get('userId'),

--- a/apps/api/src/__tests__/unit-project-secret-strategy-route.test.ts
+++ b/apps/api/src/__tests__/unit-project-secret-strategy-route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSecrets } from '@kortix/db';
 import { Hono } from 'hono';
+import * as realAccess from '../projects/lib/access';
 
 const PROJECT_ID = '33333333-3333-4333-8333-333333333333';
 const ACCOUNT_ID = '44444444-4444-4444-8444-444444444444';
@@ -118,7 +119,11 @@ const databaseMock = {
 
 mock.module('../shared/db', () => ({ hasDatabase: true, db: databaseMock }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../projects/lib/access', () => ({
+  ...realAccess,
   loadProjectForUser: async () => ({
     row: { accountId: ACCOUNT_ID, projectId: PROJECT_ID },
     userId: USER_ID,

--- a/apps/api/src/__tests__/unit-sandbox-backend.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-backend.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realPreviewOwnership from '../shared/preview-ownership';
 
 let mockPayload: { userId: string; sandboxId: string } | null = null;
 
@@ -23,7 +24,11 @@ mock.module('../shared/daytona', () => ({
 mock.module('../projects/disk-quota-guard', () => ({
   triggerEmergencyDiskArchiveSweep: () => {},
 }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   resolvePreviewUserContext: async (sandboxId: string, userId?: string) =>
     mockPayload ? { ...mockPayload, sandboxId, userId } : null,
   // Not exercised by this suite — stub so the real module's shape stays

--- a/apps/api/src/__tests__/unit-slack-access-request.test.ts
+++ b/apps/api/src/__tests__/unit-slack-access-request.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realAccess from '../projects/lib/access';
 
 // Stage A of the Slack access-flow redesign: connecting your Kortix account is
 // decoupled from having access, and a connected-but-no-access user requests
@@ -26,7 +27,11 @@ mock.module('../shared/db', () => ({
 }));
 
 // lookupEmailsByUserIds hits Supabase — mock it so the 'created' path stays offline.
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../projects/lib/access', () => ({
+  ...realAccess,
   lookupEmailsByUserIds: async () => new Map<string, string | null>(),
   grantProjectRole: async () => {},
   ensureOrgMembership: async () => 'member',

--- a/apps/api/src/__tests__/unit-slack-oauth.test.ts
+++ b/apps/api/src/__tests__/unit-slack-oauth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realExecutorSync from '../executor/sync';
 
 const PROJECT_ID = '4967754f-867c-45b1-b647-da56f99a55d9';
 const USER_ID = '49851790-41b5-4c3e-a39e-a022d0976255';
@@ -45,7 +46,11 @@ mock.module('../channels/install-store', () => ({
   loadSlackTokenForProject: async () => null,
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../executor/sync', () => ({
+  ...realExecutorSync,
   reconcileChannelConnectors: async () => undefined,
 }));
 

--- a/apps/api/src/__tests__/unit-slack-participants.test.ts
+++ b/apps/api/src/__tests__/unit-slack-participants.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realAccess from '../projects/lib/access';
 
 let dbResults: unknown[][] = [];
 const inserts: unknown[] = [];
@@ -37,7 +38,11 @@ mock.module('../channels/slack-api', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../projects/lib/access', () => ({
+  ...realAccess,
   lookupEmailsByUserIds: async (ids: string[]) => new Map(ids.map((id) => [id, `${id}@example.com`])),
 }));
 

--- a/apps/api/src/billing/services/account-deletion.test.ts
+++ b/apps/api/src/billing/services/account-deletion.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realProviders from '../../platform/providers';
+import * as realSandboxReaper from '../../projects/sandbox-reaper';
 
 let sandboxRows: Array<{ sandboxId: string; provider: string; externalId: string | null }> = [];
 let sandboxQueryError: Error | null = null;
@@ -35,7 +36,11 @@ mock.module('../../platform/providers', () => ({
   }),
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../projects/sandbox-reaper', () => ({
+  ...realSandboxReaper,
   isAlreadyNotRunning: (err: unknown) =>
     err instanceof Error && err.message.toLowerCase().includes('already stopped'),
   reconcileSandboxStoppedByExternalId: async (externalId: string) => {

--- a/apps/api/src/billing/services/account-deletion.test.ts
+++ b/apps/api/src/billing/services/account-deletion.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realProviders from '../../platform/providers';
 
 let sandboxRows: Array<{ sandboxId: string; provider: string; externalId: string | null }> = [];
 let sandboxQueryError: Error | null = null;
@@ -20,7 +21,11 @@ mock.module('../../shared/db', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../platform/providers', () => ({
+  ...realProviders,
   getProvider: (_name: string) => ({
     stop: async (externalId: string) => {
       stops.push(externalId);

--- a/apps/api/src/billing/services/compute-metering.test.ts
+++ b/apps/api/src/billing/services/compute-metering.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realProviders from '../../platform/providers';
 
 let billingEnabled = true;
 
@@ -103,7 +104,11 @@ interface FakeSandboxRow {
 let sandboxRows: FakeSandboxRow[] = [];
 let providerStatusById: Record<string, string> = {};
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../platform/providers', () => ({
+  ...realProviders,
   // 60 minutes — the provider's own idle auto-stop, which is also the ceiling on
   // how long a compute window may bill past its last liveness observation
   // (services/compute-liveness.ts).

--- a/apps/api/src/executor/manifest-crud-create-only.test.ts
+++ b/apps/api/src/executor/manifest-crud-create-only.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realExecutorSync from './sync';
 
 let storedConnectors: Record<string, unknown>[] = [];
 let commitCalls = 0;
@@ -112,7 +113,11 @@ mock.module('../projects/index', () => ({
     }
   },
 }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('./sync', () => ({
+  ...realExecutorSync,
   syncProjectConnectors: async () => {
     syncCalls += 1;
     return { synced: storedConnectors.length, errors: [] };

--- a/apps/api/src/middleware/auth-sso-sync.test.ts
+++ b/apps/api/src/middleware/auth-sso-sync.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realRequestContext from '../lib/request-context';
 
 let verifyResult: unknown;
 let networkUser: unknown;
@@ -24,7 +25,10 @@ mock.module('../iam/sso-sync', () => ({
 
 mock.module('../shared/auth-audit', () => ({ auditLoginSuccess: () => {}, auditLoginFail: () => {} }));
 mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
-mock.module('../lib/request-context', () => ({ setContextField: () => {} }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
+mock.module('../lib/request-context', () => ({ ...realRequestContext, setContextField: () => {} }));
 
 const { supabaseAuth, combinedAuth } = await import('./auth');
 

--- a/apps/api/src/middleware/auth-sso-sync.test.ts
+++ b/apps/api/src/middleware/auth-sso-sync.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realRequestContext from '../lib/request-context';
+import * as realAuthAudit from '../shared/auth-audit';
+import * as realSentry from '../lib/sentry';
+import * as realSsoSync from '../iam/sso-sync';
 
 let verifyResult: unknown;
 let networkUser: unknown;
@@ -17,14 +20,18 @@ mock.module('../shared/supabase', () => ({
 
 const syncCalls: Array<{ userId: string; email: string; jwtPayload: unknown }> = [];
 mock.module('../iam/sso-sync', () => ({
+  ...realSsoSync,
   syncSsoMembership: async (args: { userId: string; email: string; jwtPayload: unknown }) => {
     syncCalls.push(args);
     return { skipped: false, memberCreated: true };
   },
 }));
 
-mock.module('../shared/auth-audit', () => ({ auditLoginSuccess: () => {}, auditLoginFail: () => {} }));
-mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
+mock.module('../shared/auth-audit', () => ({ ...realAuthAudit, ...realAuthAudit, auditLoginSuccess: () => {}, auditLoginFail: () => {} }));
+mock.module('../lib/sentry', () => ({ ...realSentry, setSentryUser: () => {} }));
 // Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
 // lists exports by hand deletes every export it omits — the failure surfaces in
 // whatever unrelated file imports the missing name next, attributed to no test.

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
+import * as realPreviewOwnership from '../shared/preview-ownership';
+import * as realRequestContext from '../lib/request-context';
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 // Two projects under the same account, each with its own sandbox — this is
@@ -67,7 +69,11 @@ mock.module('../shared/supabase', () => ({
 
 // Sandbox → project resolution, keyed by sandboxId the same way the real
 // session_sandboxes lookup would be (uuid/externalId → project_id).
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   canAccessPreviewSandbox: async () => true,
   resolveSandboxProjectId: async (sandboxId: string) =>
     sandboxProjectByOwnSandboxId[sandboxId] ?? null,
@@ -79,7 +85,7 @@ mock.module('../shared/auth-audit', () => ({
 }));
 
 mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
-mock.module('../lib/request-context', () => ({ setContextField: () => {} }));
+mock.module('../lib/request-context', () => ({ ...realRequestContext, setContextField: () => {} }));
 mock.module('../iam/sso-sync', () => ({ syncSsoMembership: async () => {} }));
 
 const { combinedAuth } = await import('./auth');

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
 import * as realPreviewOwnership from '../shared/preview-ownership';
 import * as realRequestContext from '../lib/request-context';
+import * as realAuthAudit from '../shared/auth-audit';
+import * as realSentry from '../lib/sentry';
+import * as realSsoSync from '../iam/sso-sync';
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 // Two projects under the same account, each with its own sandbox — this is
@@ -79,14 +82,18 @@ mock.module('../shared/preview-ownership', () => ({
     sandboxProjectByOwnSandboxId[sandboxId] ?? null,
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../shared/auth-audit', () => ({
+  ...realAuthAudit,
   auditLoginSuccess: () => {},
   auditLoginFail: () => {},
 }));
 
-mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
+mock.module('../lib/sentry', () => ({ ...realSentry, setSentryUser: () => {} }));
 mock.module('../lib/request-context', () => ({ ...realRequestContext, setContextField: () => {} }));
-mock.module('../iam/sso-sync', () => ({ syncSsoMembership: async () => {} }));
+mock.module('../iam/sso-sync', () => ({ ...realSsoSync, syncSsoMembership: async () => {} }));
 
 const { combinedAuth } = await import('./auth');
 

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -38,6 +38,7 @@ import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import { PROVISIONING_SESSION_STATUSES } from '../../projects/lib/session-status';
 import * as realProviders from '../providers';
+import * as realComputeMetering from '../../billing/services/compute-metering';
 
 const dialect = new PgDialect();
 
@@ -241,7 +242,11 @@ mock.module('./provider-events', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../billing/services/compute-metering', () => ({
+  ...realComputeMetering,
   startComputeSession: async (input: { sandboxId: string; accountId: string; provider: string }) => {
     computeSessionsOpened.push(input);
     onComputeOpened?.();

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -37,6 +37,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import { PROVISIONING_SESSION_STATUSES } from '../../projects/lib/session-status';
+import * as realProviders from '../providers';
 
 const dialect = new PgDialect();
 
@@ -173,7 +174,11 @@ mock.module('../../shared/db', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../providers', () => ({
+  ...realProviders,
   getProvider: (name: string) => {
     providerNamesRequested.push(name);
     return {

--- a/apps/api/src/platform/webhooks/sandbox-webhooks.test.ts
+++ b/apps/api/src/platform/webhooks/sandbox-webhooks.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { createHmac } from 'node:crypto';
+import * as realSandboxReaper from '../../projects/sandbox-reaper';
 
 const cfg: { DAYTONA_WEBHOOK_SECRET?: string; PLATINUM_WEBHOOK_SECRET?: string } = {};
 let stoppedCalls: string[] = [];
@@ -14,7 +15,11 @@ mock.module('../../billing/services/webhook-concurrency', () => ({
     return true;
   },
 }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../projects/sandbox-reaper', () => ({
+  ...realSandboxReaper,
   reconcileSandboxStoppedByExternalId: async (externalId: string) => {
     stoppedCalls.push(externalId);
     return true;

--- a/apps/api/src/projects/lib/sandbox-env-sync.test.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.test.ts
@@ -16,7 +16,14 @@ delete process.env.LLM_GATEWAY_PROXY_TARGET;
 
 // Fakes a same-machine provider (only local-docker implements this today) vs.
 // every remote cloud provider, which omits sandboxFacingApiOrigin entirely.
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
+// `await import`, not a top-level `import`: the latter hoists above the
+// process.env writes here, and the barrel pulls in config, which reads them once.
+const realProviders = await import('../../platform/providers');
 mock.module('../../platform/providers', () => ({
+  ...realProviders,
   getProvider: (name: string) =>
     name === 'local-docker'
       ? { sandboxFacingApiOrigin: () => 'http://kortix-api:8008' }

--- a/apps/api/src/projects/maintenance.test.ts
+++ b/apps/api/src/projects/maintenance.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
+import * as realComputeMetering from '../billing/services/compute-metering';
+import * as realSandboxReaper from './sandbox-reaper';
+import * as realAttachments from '../executor/attachments';
 
 // maintenance.ts pulls in the real config module (which validates the real,
 // dotenvx-encrypted process.env and calls process.exit on a bare `bun test`
@@ -9,6 +12,7 @@ import { describe, expect, mock, test } from 'bun:test';
 mock.module('../config', () => ({ config: {} }));
 mock.module('@kortix/db', () => ({ projectSessions: {}, projects: {} }));
 mock.module('../executor/attachments', () => ({
+  ...realAttachments,
   cleanupExpiredExecutorAttachments: async () => ({ deleted: 0, errors: 0 }),
 }));
 // sweepExpiredSessionBranches() (unlike the other maintenance subtasks) isn't
@@ -32,7 +36,11 @@ mock.module('../shared/db', () => ({
   },
 }));
 mock.module('./git', () => ({ deleteRemoteSessionBranch: async () => false }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../billing/services/compute-metering', () => ({
+  ...realComputeMetering,
   reopenComputeForSandbox: async () => undefined,
   tickRunningComputeCharges: async () => ({ settled: 0, reconciled: 0 }),
 }));
@@ -69,6 +77,7 @@ mock.module('./session-lifecycle/undelivered-prompts', () => ({
 }));
 
 mock.module('./sandbox-reaper', () => ({
+  ...realSandboxReaper,
   reapAndReconcileSandboxes: () => reapAndReconcileSandboxesImpl(),
   reconcileOrphanComputeSessions: async () => ({ checked: 0, closed: 0, errors: 0 }),
   reconcileStuckActiveSessions: async () => ({

--- a/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
+++ b/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
@@ -13,6 +13,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
+import * as realComputeMetering from '../../billing/services/compute-metering';
 
 type UpdateCall = { table: unknown; updates: Record<string, unknown>; inTransaction: boolean };
 
@@ -62,7 +63,11 @@ mock.module('../../sandbox-proxy', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../billing/services/compute-metering', () => ({
+  ...realComputeMetering,
   pauseComputeSession: async (sandboxId: string) => {
     events.push(`pause:${sandboxId}`);
   },
@@ -146,6 +151,7 @@ describe('applyStoppedState', () => {
 
   test('a billing failure never blocks the stop', async () => {
     mock.module('../../billing/services/compute-metering', () => ({
+      ...realComputeMetering,
       pauseComputeSession: async () => {
         throw new Error('wallet unreachable');
       },
@@ -159,6 +165,7 @@ describe('applyStoppedState', () => {
     } finally {
       console.warn = warn;
       mock.module('../../billing/services/compute-metering', () => ({
+        ...realComputeMetering,
         pauseComputeSession: async (sandboxId: string) => {
           events.push(`pause:${sandboxId}`);
         },

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sandboxComputeSessions, sessionSandboxes } from '@kortix/db';
 import * as realProviders from '../platform/providers';
+import * as realComputeMetering from '../billing/services/compute-metering';
 
 // ── mock state ──────────────────────────────────────────────────────────────
 let candidates: any[] = [];
@@ -218,7 +219,11 @@ mock.module('../sandbox-proxy', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../billing/services/compute-metering', () => ({
+  ...realComputeMetering,
   reopenComputeForSandbox: async () => undefined,
   markComputeSessionAlive: async (sandboxId: string, at: Date) => {
     livenessStamps.push({ sandboxId, at });

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sandboxComputeSessions, sessionSandboxes } from '@kortix/db';
+import * as realProviders from '../platform/providers';
 
 // ── mock state ──────────────────────────────────────────────────────────────
 let candidates: any[] = [];
@@ -188,7 +189,11 @@ mock.module('../shared/db', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../platform/providers', () => ({
+  ...realProviders,
   // 60 minutes — the provider's own idle auto-stop, and therefore the ceiling
   // on how long a window may bill past its last liveness observation.
   providerAutoStopBackstopMinutes: () => 60,

--- a/apps/api/src/projects/session-lifecycle/__tests__/stop.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/stop.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
+import * as realProviders from '../../../platform/providers';
 
 let sandboxRow: Record<string, unknown> | null = null;
 let stopCalls: string[] = [];
@@ -57,7 +58,11 @@ mock.module('../../../shared/db', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../../platform/providers', () => ({
+  ...realProviders,
   getProvider: (_name: string) => ({
     stop: async (externalId: string) => {
       stopCalls.push(externalId);

--- a/apps/api/src/projects/session-lifecycle/__tests__/stop.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/stop.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import * as realProviders from '../../../platform/providers';
+import * as realComputeMetering from '../../../billing/services/compute-metering';
 
 let sandboxRow: Record<string, unknown> | null = null;
 let stopCalls: string[] = [];
@@ -71,7 +72,11 @@ mock.module('../../../platform/providers', () => ({
   }),
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../../billing/services/compute-metering', () => ({
+  ...realComputeMetering,
   reopenComputeForSandbox: async () => undefined,
   pauseComputeSession: async (sandboxId: string) => {
     pausedCompute.push(sandboxId);

--- a/apps/api/src/router/routes/usage-cost-by-project-http.test.ts
+++ b/apps/api/src/router/routes/usage-cost-by-project-http.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import * as realAccess from '../../projects/lib/access';
 
 const ACCOUNT_ID = '00000000-0000-4000-a000-000000000001';
 const PROJECT_ID = '00000000-0000-4000-a000-000000000002';
@@ -55,7 +56,11 @@ mock.module('../../shared/resolve-account', () => ({
 // never calls into it, but the static import still has to resolve — the real
 // module pulls in resolveAccountId from the mocked resolve-account above,
 // which does not export it.
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../projects/lib/access', () => ({
+  ...realAccess,
   loadProjectForUser: async () => {
     throw new Error('loadProjectForUser should not be called from cost-by-project tests');
   },

--- a/apps/api/src/router/routes/usage-cost-summary-http.test.ts
+++ b/apps/api/src/router/routes/usage-cost-summary-http.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import * as realAccess from '../../projects/lib/access';
 
 const ACCOUNT_ID = '00000000-0000-4000-a000-000000000001';
 const PROJECT_ID = '00000000-0000-4000-a000-000000000002';
@@ -55,7 +56,11 @@ mock.module('../../shared/resolve-account', () => ({
   resolveScopedAccountId: async (c: TestContext) => c.req.query('account_id') || ACCOUNT_ID,
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../projects/lib/access', () => ({
+  ...realAccess,
   loadProjectForUser: async (_c: TestContext, projectId: string, action: string) => {
     projectAccessInput = { projectId, action };
     return { userId: USER_ID, row: { accountId: SECONDARY_ACCOUNT_ID } };

--- a/apps/api/src/router/routes/usage-session-costs-http.test.ts
+++ b/apps/api/src/router/routes/usage-session-costs-http.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import * as realAccess from '../../projects/lib/access';
 
 const ACCOUNT_ID = '00000000-0000-4000-a000-000000000001';
 const PROJECT_ID = '00000000-0000-4000-a000-000000000002';
@@ -82,7 +83,11 @@ mock.module('../../shared/resolve-account', () => ({
   resolveScopedAccountId: async (c: TestContext) => c.req.query('account_id') || ACCOUNT_ID,
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../projects/lib/access', () => ({
+  ...realAccess,
   loadProjectForUser: async (_c: TestContext, projectId: string, action: string) => {
     projectAccessInput = { projectId, action };
     return { userId: USER_ID, row: { accountId: SECONDARY_ACCOUNT_ID } };

--- a/apps/api/src/sandbox-proxy/backend-case-insensitive.test.ts
+++ b/apps/api/src/sandbox-proxy/backend-case-insensitive.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
+import * as realProviders from '../platform/providers';
+import * as realPreviewOwnership from '../shared/preview-ownership';
 
 let queryCount = 0;
 
@@ -17,13 +19,18 @@ const canonicalRow = {
 
 mock.module('../config', () => ({ config: {} }));
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   resolvePreviewUserContext: async () => null,
 }));
 mock.module('../shared/kortix-user-context', () => ({
   KORTIX_USER_CONTEXT_HEADER: 'x-kortix-user-context',
   encodeKortixUserContext: () => '',
 }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../platform/providers', () => ({
+  ...realProviders,
   getProvider: () => ({
     resolveIngress: async () => {
       throw new Error('not used');

--- a/apps/api/src/sandbox-proxy/backend.test.ts
+++ b/apps/api/src/sandbox-proxy/backend.test.ts
@@ -15,10 +15,13 @@
 // own file, same caveat other sandbox-proxy tests document.
 import { describe, expect, test } from 'bun:test';
 import { mock } from 'bun:test';
+import * as realProviders from '../platform/providers';
+import * as realPreviewOwnership from '../shared/preview-ownership';
 
 mock.module('../config', () => ({ config: {} }));
 mock.module('../shared/db', () => ({ db: {} }));
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   resolvePreviewUserContext: async () => null,
 }));
 mock.module('../shared/kortix-user-context', () => ({
@@ -28,7 +31,11 @@ mock.module('../shared/kortix-user-context', () => ({
 
 let resolveCalls: Array<{ port: number; transport?: string; path?: string }> = [];
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../platform/providers', () => ({
+  ...realProviders,
   getProvider: () => ({
     async resolveIngress(_externalId: string, request: { port: number; transport?: string; path?: string }) {
       resolveCalls.push(request);

--- a/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
@@ -13,6 +13,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mock } from 'bun:test';
 import * as realRequestContext from '../../lib/request-context';
+import * as realPreviewOwnership from '../../shared/preview-ownership';
 
 const ACTIVE_RECORD = {
   status: 'active',
@@ -33,7 +34,11 @@ mock.module('../../lib/request-context', () => ({
 mock.module('../../shared/kortix-user-context', () => ({
   KORTIX_USER_CONTEXT_HEADER: 'x-kortix-user-context',
 }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   canAccessPreviewSandbox: async () => true,
   canAccessSandboxSession: async () => true,
 }));

--- a/apps/api/src/sandbox-proxy/routes/preview-agent-authz.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview-agent-authz.test.ts
@@ -12,6 +12,7 @@
 // side-effecting, and the re-mint is the thing that grants B.
 import { afterAll, beforeEach, expect, mock, test } from 'bun:test';
 import * as realRequestContext from '../../lib/request-context';
+import * as realPreviewOwnership from '../../shared/preview-ownership';
 
 const ACTIVE_RECORD = {
   status: 'active',
@@ -38,7 +39,11 @@ mock.module('../../lib/request-context', () => ({
 mock.module('../../shared/kortix-user-context', () => ({
   KORTIX_USER_CONTEXT_HEADER: 'x-kortix-user-context',
 }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   canAccessPreviewSandbox: async () => true,
   canAccessSandboxSession: async () => true,
 }));

--- a/apps/api/src/sandbox-proxy/routes/preview-connector-required.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview-connector-required.test.ts
@@ -14,6 +14,7 @@
 // message silently dropped — a worse bug than the one being fixed.
 import { afterAll, beforeEach, expect, mock, test } from 'bun:test';
 import * as realRequestContext from '../../lib/request-context';
+import * as realPreviewOwnership from '../../shared/preview-ownership';
 
 const ACTIVE_RECORD = {
   status: 'active',
@@ -53,7 +54,11 @@ mock.module('../../lib/request-context', () => ({
 mock.module('../../shared/kortix-user-context', () => ({
   KORTIX_USER_CONTEXT_HEADER: 'x-kortix-user-context',
 }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   canAccessPreviewSandbox: async () => true,
   canAccessSandboxSession: async () => true,
 }));

--- a/apps/api/src/sandbox-proxy/routes/preview-deadline.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview-deadline.test.ts
@@ -18,6 +18,7 @@
 // `mock.module` is process-global in bun, so this lives in its own file.
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realRequestContext from '../../lib/request-context';
+import * as realPreviewOwnership from '../../shared/preview-ownership';
 
 const ACTIVE_RECORD = {
   sandboxId: 'sb-1',
@@ -48,7 +49,11 @@ mock.module('../../lib/request-context', () => ({
 mock.module('../../shared/kortix-user-context', () => ({
   KORTIX_USER_CONTEXT_HEADER: 'x-kortix-user-context',
 }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   canAccessPreviewSandbox: async () => true,
   canAccessSandboxSession: async () => true,
 }));

--- a/apps/api/src/sandbox-proxy/wake-deadline-guard.test.ts
+++ b/apps/api/src/sandbox-proxy/wake-deadline-guard.test.ts
@@ -8,19 +8,26 @@
 //
 // `mock.module` is process-global in bun, so this lives in its own file.
 import { describe, expect, mock, test } from 'bun:test';
+import * as realProviders from '../platform/providers';
+import * as realPreviewOwnership from '../shared/preview-ownership';
 
 let ensureRunningCalls: string[] = [];
 let deadlineAt: Date | null = new Date(Date.now() + 60 * 60_000);
 
 mock.module('../config', () => ({ config: {} }));
 mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
   resolvePreviewUserContext: async () => null,
 }));
 mock.module('../shared/kortix-user-context', () => ({
   KORTIX_USER_CONTEXT_HEADER: 'x-kortix-user-context',
   encodeKortixUserContext: () => '',
 }));
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../platform/providers', () => ({
+  ...realProviders,
   getProvider: () => ({
     async ensureRunning(externalId: string) {
       ensureRunningCalls.push(externalId);

--- a/apps/api/src/shared/session-costs-service.test.ts
+++ b/apps/api/src/shared/session-costs-service.test.ts
@@ -3,6 +3,7 @@ import { gatewayRequestLogs, projectSessions, sandboxComputeSessions } from '@ko
 import { Column, SQL, type SQLWrapper, Table, getTableColumns, is, sql } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import type { CostSort } from './cost-window';
+import * as realAccess from '../projects/lib/access';
 
 type QueryRecord = {
   fields: Record<string, unknown>;
@@ -225,7 +226,11 @@ mock.module('./db', () => ({
   },
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../projects/lib/access', () => ({
+  ...realAccess,
   resolveSessionOwnerIdentities: async (ownerIds: string[]) =>
     new Map(
       ownerIds.map((ownerId) => [

--- a/apps/api/src/snapshots/builder-list-templates.test.ts
+++ b/apps/api/src/snapshots/builder-list-templates.test.ts
@@ -17,6 +17,7 @@
  */
 import { describe, expect, mock, test } from 'bun:test';
 import { listSandboxTemplates, type SandboxTemplateView } from './builder';
+import * as realSnapshotProviders from './providers';
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
 
@@ -107,7 +108,11 @@ const mockProvider = {
   getSnapshotState: async () => 'active',
 };
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('./providers', () => ({
+  ...realSnapshotProviders,
   getSandboxProvider: () => mockProvider,
 }));
 


### PR DESCRIPTION
## The bug

`mock.module` replaces a module **WHOLESALE**. 62 stubs across `apps/api` listed their target's exports by hand, so every export they did not name stopped existing for anything that imported the module *after* the stub was installed.

Reproduced on `origin/main`, from `apps/api` — the exact command from the report:

```
KORTIX_URL=https://localhost dotenvx run --quiet -- bun test src/sandbox-proxy
30 pass / 6 fail / 6 errors
```

All six are `# Unhandled error between tests`, attributed to **no test**:

```
SyntaxError: Export named 'SandboxTemplateNotFoundError' not found in
  module '.../src/platform/providers/index.ts'        (x5)
SyntaxError: Export named 'canAccessPreviewSandbox' not found in
  module '.../src/shared/preview-ownership.ts'        (x1)
```

Same directory after this PR:

```
84 pass / 0 fail / 0 errors
```

The count rises 36 → 84 because the leak **aborted whole files before their tests ran**. 48 tests were not passing; they were not executing.

## Why CI never caught it

`scripts/test.sh` runs `bun test --isolate` — one process per file — so a stub cannot reach another file. The trap is local- and agent-facing: `bun test <dir>` co-runs, the error names no test, and it lands in a file unrelated to whatever you just changed. It makes an innocent edit look like the cause.

## The fix

The idiom from #6094 (which fixed this class for `shared/kortix-user-context`): spread the real module, override only what the file needs, so a **new** export keeps working by default.

```ts
import * as realProviders from '../platform/providers';

mock.module('../platform/providers', () => ({
  ...realProviders,
  getProvider: () => ({ /* the test's fake */ }),
}));
```

Applied to every under-specified stub of the 12 barrels whose omissions actually break a co-run: `platform/providers` (13), `shared/preview-ownership` (14), `billing/services/compute-metering` (8), `projects/lib/access` (8), `lib/request-context` (4), `projects/sandbox-reaper` (4), `shared/auth-audit` (3), `lib/sentry` (3), `iam/sso-sync` (3), `executor/sync` (2), `snapshots/providers` (1), `executor/attachments` (1).

**Three files use `await import` instead of a top-level `import`.** A static import hoists above the file's own `process.env` writes, and these barrels pull in `config`, which reads the environment exactly once at module load. This is not theoretical — it broke 8 tests in `e2e-project-session-contract` and `sandbox-env-sync` on the first pass, and the deferred form is what fixes them.

`lib/sentry` is safe to spread: `Sentry.init()` is guarded by `if (SENTRY_DSN)` and `scripts/test.env` sets no `BETTERSTACK_API_SENTRY_DSN`, so importing it for real initializes nothing and sends nothing.

## Gates

- `bun run typecheck` — clean.
- `./scripts/test.sh` (the CI gate) — **byte-identical to its pre-change baseline**: `5277 pass / 62 skip / 0 fail / 20987 expect() calls` across 510 files, exit 0. Measured before and after.
- `bun test src/sandbox-proxy` co-run — `84 pass / 0 fail`, `grep -c "Export named"` → **0**.

## What is NOT fixed, and why

The detector added here reports **441 further under-specified stubs**:

```
cd apps/api && bun scripts/find-stub-export-gaps.ts .
```

They are not in this PR for two reasons:

1. **The two biggest are unsafe to spread.** `../config` (66 stubs) calls `process.exit(1)` on validation failure; `shared/db` (40) builds a live handle. Both need per-site judgment, not a codemod.
2. **The co-run leak set is order-dependent.** Fixing leaks lets more files run, which exposes the next latent one — after this PR a `channels/slack/identity` leak surfaces that was previously unreachable. Converging needs the full sweep, not another round of whack-a-mole.

Also unrelated to this PR, and verified rather than assumed: the **full** non-isolated `bun test` hangs at `src/snapshots/providers/daytona-errors.test.ts`. Reproduced identically on a clean `origin/main` worktree, so it is pre-existing.

## Conflict note

#6094 is still open and touches 7 of the same files with the same idiom for `shared/kortix-user-context`. Expect a small conflict at the import block and the stub object; the resolution is to keep both imports and both spreads.