### PR TITLE
Surface a stale agent config without a page reload

### DIFF
--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -298,3 +298,16 @@ export const warningToast = (message: string, options?: ToastOptions) => {
     toastData(options, options?.duration || DEFAULT_DURATION, isMobile),
   );
 };
+
+/**
+ * Dismiss a toast by the `id` it was created with.
+ *
+ * Exists so feature code can retract a PERSISTENT toast when the condition it
+ * reports goes away — a `duration: Infinity` notice with an action button has to
+ * be revocable, or it outlives the problem and offers to fix something already
+ * fixed. Wrapped here rather than importing sonner in a feature: this module is
+ * the toast surface.
+ */
+export const dismissToast = (id: string | number) => {
+  toast.dismiss(id);
+};

--- a/apps/web/src/features/session/header/session-config-indicator.tsx
+++ b/apps/web/src/features/session/header/session-config-indicator.tsx
@@ -26,9 +26,10 @@ import {
   type ReloadBusyReason,
   useSessionConfigFreshness,
 } from '@/hooks/projects/use-session-config-freshness';
+import { dismissToast, warningToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
 import { ArrowsClockwiseIcon } from '@phosphor-icons/react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /** The server's two refusals, as something a person would actually read. */
 const BUSY_COPY: Record<ReloadBusyReason, { title: string; body: string; tail: string }> = {
@@ -62,6 +63,50 @@ export function SessionConfigIndicator({
   const [open, setOpen] = useState(false);
 
   const stale = notice.kind === 'stale';
+
+  // A toast as well as the chip, because the chip alone was not found.
+  //
+  // The chip is correct and stays — it is the durable, always-available
+  // affordance, and it is where you look once you know the concept exists. But
+  // it is an icon in a header, and a session that silently runs the wrong agent
+  // is exactly the case where the user does NOT already know to look. So the
+  // arrival of staleness also gets announced once, where new information
+  // belongs.
+  //
+  // Announced ONCE per distinct config version, not once per render and not
+  // again after dismissal: `shownFor` keys on the etag pair, so re-checks of the
+  // same staleness stay quiet and only a genuinely newer config speaks up again.
+  // Persistent (`Infinity`) because it reports a condition, not an event — it
+  // stays true until acted on — and `warningToast` already carries its own close
+  // button, so it is dismissible without being self-dismissing.
+  const toastId = `session-config-stale-${sessionId}`;
+  const shownFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (notice.kind !== 'stale') {
+      // Retract on the way out. After a successful reload the condition is gone,
+      // and a lingering card offering to fix it would be worse than no card.
+      if (shownFor.current !== null) {
+        shownFor.current = null;
+        dismissToast(toastId);
+      }
+      return;
+    }
+    const version = `${notice.running}->${notice.latest}`;
+    if (shownFor.current === version) return;
+    shownFor.current = version;
+    warningToast('Agent config is out of date', {
+      id: toastId,
+      description:
+        'This session is running an older version of the agent config. Your commits and other files are untouched.',
+      duration: Number.POSITIVE_INFINITY,
+      button: (
+        <Button size="sm" disabled={!canReload || isPending} onClick={() => reload()}>
+          {isPending ? <Loading className="size-4 shrink-0" /> : null}
+          Reload config
+        </Button>
+      ),
+    });
+  }, [notice, toastId, reload, canReload, isPending]);
 
   // The confirm is rendered by the header, not here — see `SessionConfigReloadConfirm`.
   // This component may vanish the moment a reload lands, and a dialog that

--- a/apps/web/src/hooks/projects/use-session-config-freshness.test.ts
+++ b/apps/web/src/hooks/projects/use-session-config-freshness.test.ts
@@ -3,7 +3,11 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { SessionConfigState } from '@kortix/sdk';
 
-import { reloadNotAppliedCopy, sessionConfigNotice } from './use-session-config-freshness';
+import {
+  CONFIG_FRESHNESS_STALE_TIME_MS,
+  reloadNotAppliedCopy,
+  sessionConfigNotice,
+} from './use-session-config-freshness';
 
 const state = (over: Partial<SessionConfigState>): SessionConfigState => ({
   base_ref: 'main',
@@ -162,5 +166,27 @@ describe('useReloadSessionConfig — the costly mistakes', () => {
     expect(HOOK_SOURCE).toContain('useState<ReloadBusyReason | null>(null)');
     expect(HOOK_SOURCE).not.toContain('busyReason: busyReasonOf(mutation.error)');
     expect(HOOK_SOURCE).toContain('clearBusy: () => setBusyReason(null)');
+  });
+});
+
+/**
+ * The staleness check is edge-triggered off window focus, and React Query will
+ * NOT refetch on focus while the cached answer is still within `staleTime`.
+ * That made the constant itself the bug: at 5 minutes, the ordinary flow — edit
+ * an agent file in your editor, tab back to the session — showed nothing, and
+ * only a full page reload surfaced the notice, because a reload discards the
+ * cache rather than revalidating it.
+ */
+describe('the freshness answer expires fast enough to be re-asked on focus', () => {
+  test('staleTime is short enough for an edit-and-return round trip', () => {
+    // Editing a file and tabbing back takes far longer than this, so the focus
+    // refetch always fires for the flow this feature exists to serve.
+    expect(CONFIG_FRESHNESS_STALE_TIME_MS).toBeLessThanOrEqual(60_000);
+  });
+
+  test('but not so short that alt-tabbing becomes a git fetch per switch', () => {
+    // Each check drops the project's git-mirror TTL, recompiles the manifest and
+    // reaches into the sandbox. Zero would make focus a hot path.
+    expect(CONFIG_FRESHNESS_STALE_TIME_MS).toBeGreaterThanOrEqual(10_000);
   });
 });

--- a/apps/web/src/hooks/projects/use-session-config-freshness.ts
+++ b/apps/web/src/hooks/projects/use-session-config-freshness.ts
@@ -29,6 +29,22 @@ import {
 } from '@kortix/sdk';
 import { clearRuntimeEnsureGuard } from '@kortix/sdk/react';
 
+/**
+ * How long a freshness answer is trusted before a window-focus refetch will
+ * re-ask.
+ *
+ * Named, exported and asserted in tests because its VALUE is the bug. React
+ * Query skips a focus refetch while the cached value is still fresh, so this
+ * constant is what decides whether "edit an agent file, tab back to the session"
+ * shows anything at all. At the 5 minutes it used to be, it showed nothing, and
+ * a full page reload was the only thing that worked — a reload wipes the cache
+ * instead of revalidating, which is why it looked like the feature worked.
+ *
+ * Raise this and you silently switch the feature off for the flow people
+ * actually use.
+ */
+export const CONFIG_FRESHNESS_STALE_TIME_MS = 30_000;
+
 export function sessionConfigKey(projectId?: string, sessionId?: string) {
   return ['session-config', projectId ?? '', sessionId ?? ''] as const;
 }
@@ -121,9 +137,18 @@ export function useSessionConfigFreshness(projectId?: string, sessionId?: string
     // recompiles the manifest, and reaches into the sandbox — an interval would
     // make one git fetch per open session per tick, forever, to detect a thing
     // that only changes when somebody merges. Staleness is edge-triggered, so
-    // this refetches on mount and on window focus (both off by default here)
-    // and is invalidated explicitly after a reload.
-    staleTime: 5 * 60_000,
+    // this refetches on mount and on window focus, and is invalidated explicitly
+    // after a reload.
+    //
+    // `staleTime` GATES the focus refetch, which is the whole reason it is 30s
+    // and not the 5 minutes it used to be. React Query skips a focus refetch
+    // while the cached value is still fresh, so with a 5-minute window the
+    // ordinary flow — edit an agent file in your editor, tab back — showed
+    // nothing, and a full page reload was the only thing that worked (it wipes
+    // the cache rather than revalidating). 30s is long enough that alt-tabbing
+    // does not turn into a git fetch per switch, short enough that coming back
+    // from an edit always re-asks.
+    staleTime: CONFIG_FRESHNESS_STALE_TIME_MS,
     gcTime: 10 * 60_000,
     refetchOnMount: true,
     refetchOnWindowFocus: true,


### PR DESCRIPTION
Both reported from real use of the shipped feature.

## 1. It only appeared after a full page reload

The freshness query sets `refetchOnWindowFocus`, but **`staleTime` gates that** — React Query skips a focus refetch while the cached answer is still fresh. At the 5 minutes it was set to, the ordinary flow (edit an agent file in your editor, tab back to the session) refetched nothing and showed nothing.

A full page reload "worked" only because it **discards** the cache rather than revalidating it. That is also why this looked fine when it was built: reloading the page is exactly what you do when you're testing it.

Now 30s — longer than an alt-tab, far shorter than an edit. Since the *value is the bug*, it's a named exported constant with a test either side of it rather than a literal someone can quietly raise back to 5 minutes.

## 2. The chip wasn't found

An icon in a header is the right place to **look** once you know the concept exists, and the wrong place to **learn** it — and a session silently running the wrong agent is precisely the case where you don't know to look.

Staleness is now also announced once as a toast, bottom-right, dismissible. The chip stays: it's the durable affordance, and the toast is gone the moment you close it.

- **Once per distinct config version**, keyed on the etag pair — re-checks of the same staleness stay quiet, only a genuinely newer config speaks again.
- **Persistent** (`duration: Infinity`), because it reports a *condition*, not an event. It stays true until acted on.
- **Retracted automatically** when the condition clears, so a successful reload doesn't leave a card offering to fix something already fixed.

`warningToast` already had the close button and the bottom-right default; the only thing missing was retracting by id, added as `dismissToast` so this didn't have to reach past the toast module into sonner.

**Deliberately left alone:** the `unverified` notice ("couldn't check") gets no toast. It's lower signal and usually resolves itself; interrupting for it would train people to dismiss the one that matters.

## Testing

`apps/web` tsc clean on the touched files; `15 pass / 0 fail`.

To check by hand: start a session, push a change to `.kortix/opencode/agents/<name>.md` on the default branch, then tab away and back — the toast should appear **without** reloading the page. Reload from either the toast or the chip, then ask the agent something only the new prompt answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)