### PR TITLE
Port 3211 served another session's credentials to any account member

### DIFF
--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -55,7 +55,7 @@ import {
   proxyAttemptTimeoutMs,
 } from '../preview-retry-budget';
 import { claimPromptDelivery, promptDeliveryKey, releasePromptDelivery } from '../prompt-dedupe';
-import { carriesSessionData } from '../session-data-ports';
+import { carriesSessionData, requiresSessionVisibility } from '../session-data-ports';
 
 // `userId` is set by combinedAuth (mounted in ../index.ts) before this route.
 // `apiKeyType` is read to decide whether a request may extend the sandbox's
@@ -816,7 +816,7 @@ export async function forwardToSandbox(
   // whose access was revoked/downgraded replays captured ids on the data path.
   if (
     access.kind === 'principal' &&
-    carriesSessionData(upstreamPort) &&
+    requiresSessionVisibility(upstreamPort) &&
     !(await canAccessSandboxSession({
       sessionId: record.sessionId,
       projectId: record.projectId,
@@ -1500,7 +1500,7 @@ export async function resolvePreviewWsUpstream(opts: {
   // PTY/opencode WS leg ungated there — the same hole this PR closes on the HTTP
   // side, one function further down the file.
   if (
-    carriesSessionData(upstreamPort) &&
+    requiresSessionVisibility(upstreamPort) &&
     !(await canAccessSandboxSession({
       sessionId: record.sessionId,
       projectId: record.projectId,

--- a/apps/api/src/sandbox-proxy/session-data-ports.ts
+++ b/apps/api/src/sandbox-proxy/session-data-ports.ts
@@ -29,3 +29,29 @@ export const SESSION_DATA_PORTS: ReadonlySet<number> = new Set([8000, 4096]);
 export function carriesSessionData(upstreamPort: number): boolean {
   return SESSION_DATA_PORTS.has(upstreamPort);
 }
+
+/**
+ * The in-box static-file listener (3211).
+ *
+ * It serves files out of the session's own workspace and has NO authentication
+ * of its own — it trusts that whoever reached the port was allowed to. That
+ * assumption held while it sat behind `/proxy/3211` inside the box; it does not
+ * hold on the public path proxy, which accepts any port a caller names.
+ */
+export const STATIC_FILE_PORT = 3211;
+
+/**
+ * True when the port must pass the per-SESSION visibility gate, not merely the
+ * account-membership check.
+ *
+ * Deliberately wider than `carriesSessionData`. 3211 needs the session gate for
+ * the same reason 8000 does — it reads that session's workspace — but it must
+ * NOT join SESSION_DATA_PORTS, because that set also drives
+ * `shouldAutoResumeStoppedSandbox`, where membership means "only a non-GET may
+ * wake the box". Static file serving is all GETs, so folding 3211 in there
+ * would stop a parked box from ever waking for a preview: a real regression,
+ * and an unrelated one. Two questions, two predicates.
+ */
+export function requiresSessionVisibility(upstreamPort: number): boolean {
+  return carriesSessionData(upstreamPort) || upstreamPort === STATIC_FILE_PORT;
+}

--- a/apps/kortix-sandbox-agent-server/src/__tests__/static-web-credential-read.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/static-web-credential-read.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The :3211 static server must not serve the session's credentials.
+ *
+ * It has NO authentication of its own — it trusts that whoever reached the port
+ * was allowed to — and its allowed roots included `/home`, which is exactly
+ * where the daemon writes:
+ *
+ *   ~/.config/kortix-opencode.json          the session's LLM gateway key and,
+ *                                           on Daytona, its executor PAT
+ *   ~/.local/share/opencode/auth.json       the account's Codex/OpenCode
+ *                                           subscription credential
+ *
+ * Mode 0600 was no defence: this listener runs as the same user that wrote
+ * them, so the permission bits were satisfied. And the file's own header
+ * comment claimed it binds localhost while it binds 0.0.0.0 — part of why the
+ * exposure went unnoticed.
+ *
+ * These run against the REAL server on a real temp directory, because the
+ * property under test is what the process hands back over HTTP, not what a
+ * predicate returns.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { startStaticWebServer } from '../static-web'
+
+let server: ReturnType<typeof startStaticWebServer>
+let base: string
+let scratch: string
+
+beforeAll(() => {
+  server = startStaticWebServer(0)
+  base = `http://127.0.0.1:${server.port}`
+  // Explicitly under `/tmp` — an allowed root. NOT os.tmpdir(), which on macOS
+  // is /var/folders/... and would put the fixture outside the roots, making the
+  // "still works" tests fail for a reason that has nothing to do with the code.
+  scratch = mkdtempSync('/tmp/kortix-staticweb-')
+})
+
+afterAll(() => {
+  server.stop?.()
+  rmSync(scratch, { recursive: true, force: true })
+})
+
+async function get(path: string): Promise<{ status: number; body: string }> {
+  const res = await fetch(`${base}${path}`, { signal: AbortSignal.timeout(5000) })
+  return { status: res.status, body: await res.text() }
+}
+
+describe('the credential files are not readable', () => {
+  // The real paths, from opencode.ts. Written for whatever user the daemon runs
+  // as, so the test asserts on the ROUTE being refused rather than on a file it
+  // would have to create in a real home directory.
+  const CREDENTIAL_PATHS = [
+    '/home/kortix/.config/kortix-opencode.json',
+    '/home/kortix/.local/share/opencode/auth.json',
+    '/root/.config/kortix-opencode.json',
+    '/home/kortix/.ssh/id_ed25519',
+    '/home/kortix/.aws/credentials',
+    '/home/kortix/.netrc',
+    '/home/kortix/.git-credentials',
+  ]
+
+  test.each(CREDENTIAL_PATHS)('/abs%s is refused', async (path) => {
+    const { status } = await get(`/abs${path}`)
+    expect(status).toBe(403)
+  })
+
+  test.each(CREDENTIAL_PATHS)('/open?path=%s is refused', async (path) => {
+    const { status } = await get(`/open?path=${encodeURIComponent(path)}`)
+    expect(status).toBe(403)
+  })
+
+  test('a traversal back into a credential directory is refused', async () => {
+    // `normalize()` collapses this to /home/kortix/.config/... before the check,
+    // which is why the deny list is matched on the normalized path.
+    const { status } = await get(
+      '/abs/workspace/../home/kortix/.config/kortix-opencode.json',
+    )
+    expect(status).toBe(403)
+  })
+
+  test('the whole /home root is gone, not just the credential paths', async () => {
+    const { status } = await get('/abs/home/kortix/notes.txt')
+    expect(status).toBe(403)
+  })
+
+  test('/opt is gone too', async () => {
+    const { status } = await get('/abs/opt/anything.html')
+    expect(status).toBe(403)
+  })
+})
+
+describe('serving agent output still works', () => {
+  test('an HTML file under /tmp is served', async () => {
+    // The purpose of this server. If this breaks, the narrowing went too far.
+    const dir = join(scratch, 'preview')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'report.html'), '<html><body>REPORT_OK</body></html>')
+
+    const { status, body } = await get(`/abs${dir}/report.html`)
+    expect(status).toBe(200)
+    expect(body).toContain('REPORT_OK')
+  })
+
+  test('a dotfile that is NOT a credential directory is still served', async () => {
+    // Build output lives in dot-directories (`.next`, `.output`). A blanket
+    // "refuse any dot component" rule would have been simpler and would have
+    // broken them, so the deny list names credential directories specifically.
+    const dir = join(scratch, '.next', 'static')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'app.html'), '<html><body>BUILD_OK</body></html>')
+
+    const { status, body } = await get(`/abs${dir}/app.html`)
+    expect(status).toBe(200)
+    expect(body).toContain('BUILD_OK')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/static-web-credential-read.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/static-web-credential-read.test.ts
@@ -20,7 +20,7 @@
  * predicate returns.
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { startStaticWebServer } from '../static-web'
@@ -115,5 +115,78 @@ describe('serving agent output still works', () => {
     const { status, body } = await get(`/abs${dir}/app.html`)
     expect(status).toBe(200)
     expect(body).toContain('BUILD_OK')
+  })
+})
+
+/**
+ * A symlink out of the allowed roots must not be followed.
+ *
+ * `normalize()` collapses `..` but does NOT follow links, while `readFileSync`
+ * does — so the authorization check and the read were looking at two different
+ * files. The agent can write to every allowed root, so it can make the link
+ * itself:
+ *
+ *   ln -s /home/kortix/.config /workspace/x
+ *   GET /abs/workspace/x/kortix-opencode.json     ->  the session's PAT
+ *
+ * That defeated the root narrowing completely, which is the argument for why
+ * the fix could not stop at the roots.
+ */
+describe('symlinks cannot smuggle a path back out', () => {
+  test('a link into a credential directory is refused', async () => {
+    const fakeHome = mkdtempSync('/tmp/kortix-fake-home-')
+    mkdirSync(join(fakeHome, '.config'), { recursive: true })
+    writeFileSync(join(fakeHome, '.config', 'kortix-opencode.json'), '{"apiKey":"SECRET-KEY"}')
+
+    // The link sits inside an allowed root, so the literal path check passes
+    // and only resolving it can refuse the read.
+    const link = join(scratch, 'escape-config')
+    symlinkSync(join(fakeHome, '.config'), link)
+
+    const { status, body } = await get(`/abs${link}/kortix-opencode.json`)
+    expect(status).toBe(403)
+    expect(body).not.toContain('SECRET-KEY')
+
+    rmSync(fakeHome, { recursive: true, force: true })
+  })
+
+  test('a link reaching outside every allowed root is refused', async () => {
+    const outside = mkdtempSync(join(process.env.TMPDIR || '/var/tmp', 'kortix-outside-'))
+    writeFileSync(join(outside, 'secret.txt'), 'SECRET-PAYLOAD')
+
+    const link = join(scratch, 'escape-file.txt')
+    symlinkSync(join(outside, 'secret.txt'), link)
+
+    const { status, body } = await get(`/abs${link}`)
+    expect(status).toBe(403)
+    expect(body).not.toContain('SECRET-PAYLOAD')
+
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  test('an ordinary file is still served after the resolve step', async () => {
+    // The resolve must not break the normal path it sits in front of.
+    const dir = join(scratch, 'plain')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'ok.html'), '<html><body>PLAIN_OK</body></html>')
+
+    const { status, body } = await get(`/abs${dir}/ok.html`)
+    expect(status).toBe(200)
+    expect(body).toContain('PLAIN_OK')
+  })
+
+  test('a link that stays inside the allowed roots still works', async () => {
+    // Symlinks are not banned — only ones that leave the roots. A build output
+    // symlinked within /tmp or /workspace is legitimate.
+    const real = join(scratch, 'real')
+    mkdirSync(real, { recursive: true })
+    writeFileSync(join(real, 'in.html'), '<html><body>INSIDE_OK</body></html>')
+
+    const link = join(scratch, 'inside-link')
+    symlinkSync(real, link)
+
+    const { status, body } = await get(`/abs${link}/in.html`)
+    expect(status).toBe(200)
+    expect(body).toContain('INSIDE_OK')
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/static-web.ts
+++ b/apps/kortix-sandbox-agent-server/src/static-web.ts
@@ -7,7 +7,9 @@ import { logger } from './logger'
  * Static Web Server — ported from main's `core/services/static-web.js`
  * (formerly an always-on s6 service on port 3211). The new architecture has no
  * s6: the single `kortix-agent` daemon owns the sandbox, so this runs
- * in-process as a second Bun.serve listener bound to localhost:3211.
+ * in-process as a second Bun.serve listener on port 3211. NOTE it binds
+ * 0.0.0.0, not localhost — this comment claimed localhost for a long time and
+ * it was never true, which is part of how the exposure below went unnoticed.
  *
  * It is reachable from the app exactly as before — through the agent server's
  * `/proxy/3211/*` reverse proxy and the `p3211-<sandboxId>` subdomain route.
@@ -24,7 +26,42 @@ import { logger } from './logger'
 
 const DEFAULT_STATIC_PORT = 3211
 
-const ALLOWED_ROOTS = ['/workspace', '/tmp', '/home', '/opt']
+/**
+ * Where agent OUTPUT lives. This server exists to serve HTML the agent
+ * produced (see the header comment), and that lands in the repo or in scratch.
+ *
+ * `/home` and `/opt` used to be here, and `/home` is where the daemon writes
+ * the session's credentials — `~/.config/kortix-opencode.json` holds the
+ * session's LLM gateway key and executor PAT, `~/.local/share/opencode/auth.json`
+ * holds the account's Codex/OpenCode subscription credential. This listener has
+ * no authentication of its own, so any caller who reached port 3211 could read
+ * both. Mode 0600 was no defence: the reader IS the process that wrote them.
+ *
+ * Removing them is a deliberate narrowing. If some flow genuinely serves a
+ * preview out of the home directory it will now 403 — that is the intended
+ * trade, and the file API on :8000 (authenticated, session-scoped) remains the
+ * way to read anything outside these roots.
+ */
+const ALLOWED_ROOTS = ['/workspace', '/tmp']
+
+/**
+ * Paths refused no matter which root they sit under.
+ *
+ * Redundant with ALLOWED_ROOTS today, and that is the point: this holds even if
+ * someone later widens the roots again, which is exactly how the leak got in.
+ * Matched on the normalized absolute path, so `/workspace/../home/...` cannot
+ * dodge it — `normalize()` has already collapsed the traversal.
+ */
+const DENIED_PATH_SEGMENTS = [
+  '/.config/',
+  '/.local/share/opencode/',
+  '/.ssh/',
+  '/.aws/',
+  '/.gnupg/',
+  '/.netrc',
+  '/.git-credentials',
+  '/.kortix/secrets',
+]
 
 const MIME_TYPES: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -79,6 +116,10 @@ function toAbsPath(rawPath: string): string | null {
 }
 
 function isAllowed(absPath: string): boolean {
+  // Denies win. `absPath` is already normalized, so a traversal has collapsed
+  // before it gets here and cannot smuggle a denied segment past this.
+  const probe = `${absPath}/`
+  if (DENIED_PATH_SEGMENTS.some((segment) => probe.includes(segment))) return false
   return ALLOWED_ROOTS.some((root) => absPath === root || absPath.startsWith(root + '/'))
 }
 

--- a/apps/kortix-sandbox-agent-server/src/static-web.ts
+++ b/apps/kortix-sandbox-agent-server/src/static-web.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { dirname, extname, join, normalize } from 'node:path'
 
 import { logger } from './logger'
@@ -115,12 +115,51 @@ function toAbsPath(rawPath: string): string | null {
   return normalize(decoded)
 }
 
-function isAllowed(absPath: string): boolean {
-  // Denies win. `absPath` is already normalized, so a traversal has collapsed
-  // before it gets here and cannot smuggle a denied segment past this.
+function isDenied(absPath: string): boolean {
+  // `absPath` is normalized, so a traversal has collapsed before it gets here
+  // and cannot smuggle a denied segment past this.
   const probe = `${absPath}/`
-  if (DENIED_PATH_SEGMENTS.some((segment) => probe.includes(segment))) return false
-  return ALLOWED_ROOTS.some((root) => absPath === root || absPath.startsWith(root + '/'))
+  return DENIED_PATH_SEGMENTS.some((segment) => probe.includes(segment))
+}
+
+function underAny(absPath: string, roots: readonly string[]): boolean {
+  return roots.some((root) => absPath === root || absPath.startsWith(root + '/'))
+}
+
+function isAllowed(absPath: string): boolean {
+  if (isDenied(absPath)) return false
+  return underAny(absPath, ALLOWED_ROOTS)
+}
+
+/**
+ * The allowed roots with their OWN symlinks resolved.
+ *
+ * Needed because the post-resolve check compares a fully resolved file path,
+ * and a root can itself be a link — macOS `/tmp` is a link to `/private/tmp`,
+ * so comparing a resolved path against the literal roots refused every
+ * legitimate file under it. A container could do the same to `/workspace`.
+ * Resolve both sides or the comparison is not like-for-like.
+ *
+ * Computed once; the roots do not move while the process runs.
+ */
+let resolvedRootsCache: string[] | null = null
+function resolvedRoots(): string[] {
+  if (resolvedRootsCache) return resolvedRootsCache
+  resolvedRootsCache = ALLOWED_ROOTS.map((root) => {
+    try {
+      return realpathSync(root)
+    } catch {
+      // A root that does not exist on this box cannot match anything anyway.
+      return root
+    }
+  })
+  return resolvedRootsCache
+}
+
+/** Is the path we are about to OPEN — links followed — inside the roots? */
+function isAllowedResolved(realPath: string): boolean {
+  if (isDenied(realPath)) return false
+  return underAny(realPath, ALLOWED_ROOTS) || underAny(realPath, resolvedRoots())
 }
 
 function stripTrailingSlash(value: string): string {
@@ -273,13 +312,44 @@ function serveDirectory(absPath: string, baseUrl: string): Response {
   })
 }
 
+function forbidden(): Response {
+  return new Response(`Forbidden path. Allowed roots: ${ALLOWED_ROOTS.join(', ')}`, {
+    status: 403,
+    headers: { 'Content-Type': 'text/plain; charset=utf-8', ...corsHeaders },
+  })
+}
+
 function serveFile(absPath: string, baseUrl: string, injectBaseTag = false): Response {
   try {
-    if (!isAllowed(absPath)) {
-      return new Response(`Forbidden path. Allowed roots: ${ALLOWED_ROOTS.join(', ')}`, {
-        status: 403,
-        headers: { 'Content-Type': 'text/plain; charset=utf-8', ...corsHeaders },
+    if (!isAllowed(absPath)) return forbidden()
+
+    // AUTHORIZE THE PATH THAT WILL ACTUALLY BE OPENED.
+    //
+    // `normalize()` collapses `..` but does NOT follow symlinks, while
+    // `readFileSync` does — so the check above and the read below could be
+    // looking at two different files. The agent can write to every allowed
+    // root, so it can also create the link:
+    //
+    //   ln -s /home/kortix/.config /workspace/x
+    //   GET /abs/workspace/x/kortix-opencode.json   ->  the session's PAT
+    //
+    // Re-checking the resolved path closes that. The literal check stays in
+    // front of it so an obviously out-of-bounds request is still refused
+    // without touching the filesystem.
+    let realPath: string
+    try {
+      realPath = realpathSync(absPath)
+    } catch (err) {
+      const code = (err as { code?: string })?.code
+      if (code === 'ENOENT' || code === 'ENOTDIR') return notFound(absPath)
+      throw err
+    }
+    if (realPath !== absPath && !isAllowedResolved(realPath)) {
+      logger.warn('[static-web] refused a link out of the allowed roots', {
+        requested: absPath,
+        resolved: realPath,
       })
+      return forbidden()
     }
 
     const mime = getMime(absPath)
@@ -287,14 +357,14 @@ function serveFile(absPath: string, baseUrl: string, injectBaseTag = false): Res
     // For HTML loaded via /open?path=, inject a <base> tag so relative asset
     // references (CSS, JS, images) resolve through the /abs/ route.
     if (injectBaseTag && isHtml(absPath)) {
-      const raw = readFileSync(absPath, 'utf-8')
+      const raw = readFileSync(realPath, 'utf-8')
       const patched = injectBase(raw, absPath, baseUrl)
       return new Response(patched, {
         headers: { 'Content-Type': mime, ...corsHeaders },
       })
     }
 
-    const data = readFileSync(absPath)
+    const data = readFileSync(realPath)
     return new Response(data, {
       headers: { 'Content-Type': mime, ...corsHeaders },
     })


### PR DESCRIPTION
Third finding from the same audit as #6094 and #6096, and the widest of the three. Two independent defects that compose into **cross-session credential theft**.

## 1. The static server has no auth and served `/home`

`static-web` (:3211) exists to serve HTML the agent produced. Its allowed roots were `/workspace`, `/tmp`, **`/home`** and `/opt` — and it authenticates *nothing*. It trusts that whoever reached the port was allowed to.

`/home` is where the daemon writes the session's credentials:

| path | what it holds |
|---|---|
| `~/.config/kortix-opencode.json` | the session's LLM gateway key and, on Daytona, its executor PAT |
| `~/.local/share/opencode/auth.json` | the account's Codex/OpenCode subscription credential |

Mode `0600` was no defence: the listener runs as the same user that wrote them, so the permission bits were satisfied.

Roots are now `/workspace` and `/tmp` — where agent output actually lands. A deny list for credential directories sits in front of that, deliberately redundant, because it has to hold if someone widens the roots again — which is exactly how this got in. It matches on the normalized path, so a traversal can't smuggle a segment past it.

The deny list names credential directories rather than refusing every dot-component. The blanket rule was tempting and would have broken `.next` / `.output` build previews; there's a test for that.

## 2. The API didn't treat 3211 as session data

`carriesSessionData` covered 8000 and 4096, so 3211 got **account-membership only** and the per-session gate never ran. Any account member — and any in-box agent holding a token for *any* sandbox in the account — could read another session's entire workspace plus the credentials above.

3211 deliberately does **not** join `SESSION_DATA_PORTS`. That set also drives `shouldAutoResumeStoppedSandbox`, where membership means "only a non-GET may wake the box". Static serving is all GETs, so folding it in would stop a parked box waking for a preview — a real and unrelated regression. Two questions, two predicates: `requiresSessionVisibility` is the wider one, and it's what the visibility gate now asks, on the HTTP **and** WebSocket legs.

## A comment that was actively misleading

`static-web.ts` claimed this listener "binds localhost". It binds `0.0.0.0` (line 430) and always has. That false claim is part of why the exposure went unnoticed — and it's the same wrong assumption Strix caught in the web-proxy guard on #6096, where the daemon's `0.0.0.0` bind meant a loopback-only check missed the box's own address. Fixed here.

## Testing

Tests drive the real server over HTTP rather than calling the predicate, and assert **both** directions — credentials refused, agent output still served. The second half matters: this change narrows what the product can serve, and without it a later "just re-add /home" would look harmless.

**Gates:** daemon typecheck clean + **373 pass / 0 fail**; apps/api preview suite **26 pass / 0 fail**; apps/api `tsc` clean on the changed files.

## Remaining from the sweep

`/kortix/git/commit-push` is still bearer-only (the #6094 class exactly) and writes to the customer's git remote; and `callerSessionId` is never set for a `kortix_sb_` token, so the KaaB per-end-user narrowing never fires — isolation there currently rests on the `private` column default rather than the check written for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)