### PR TITLE
feat(experimental): add meta_agent feature flag

### DIFF
--- a/apps/api/src/__tests__/unit-experimental-features.test.ts
+++ b/apps/api/src/__tests__/unit-experimental-features.test.ts
@@ -23,6 +23,7 @@ describe('isExperimentalFeatureKey', () => {
     expect(isExperimentalFeatureKey('agentmail_email')).toBe(true);
     expect(isExperimentalFeatureKey('teams')).toBe(true);
     expect(isExperimentalFeatureKey('llm_gateway')).toBe(true);
+    expect(isExperimentalFeatureKey('meta_agent')).toBe(true);
     expect(isExperimentalFeatureKey('nope')).toBe(false);
     expect(isExperimentalFeatureKey(undefined)).toBe(false);
     expect(isExperimentalFeatureKey(42)).toBe(false);

--- a/apps/api/src/experimental/features.ts
+++ b/apps/api/src/experimental/features.ts
@@ -156,6 +156,15 @@ const FEATURES: readonly ExperimentalFeatureDef[] = [
     // Explicit opt-in: hidden unless a project enables it in Settings.
     platformDefault: () => false,
   },
+  {
+    key: 'meta_agent',
+    name: 'Meta Agent',
+    description:
+      'A reserved coordinator agent that spawns and manages specialized sessions, transfers files between them, and orchestrates multi-step work across the project. Adds a platform-owned meta agent to the project and changes the default agent for new sessions without an explicit --agent flag.',
+    stability: 'experimental',
+    available: () => true,
+    platformDefault: () => false,
+  },
 ];
 
 const FEATURE_BY_KEY: Record<ExperimentalFeatureKey, ExperimentalFeatureDef> = Object.fromEntries(

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -107,6 +107,7 @@ function projectFixture(overrides: Record<string, unknown> = {}) {
       voice: false,
       llm_gateway: true,
       review_center: false,
+      meta_agent: false,
     },
     experimental_features: [],
     default_sandbox_provider: null,
@@ -586,6 +587,7 @@ describe('envelopes', () => {
       'voice',
       'llm_gateway',
       'review_center',
+      'meta_agent',
     ]);
   });
 

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -53,6 +53,7 @@ export const ExperimentalFeatureMapSchema = z.object({
   voice: z.boolean(),
   llm_gateway: z.boolean(),
   review_center: z.boolean(),
+  meta_agent: z.boolean(),
 });
 export type ExperimentalFeatureMap = z.infer<typeof ExperimentalFeatureMapSchema>;
 

--- a/packages/sdk/src/core/rest/projects-client/projects.ts
+++ b/packages/sdk/src/core/rest/projects-client/projects.ts
@@ -21,7 +21,8 @@ export type ExperimentalFeatureKey =
   | 'teams'
   | 'voice'
   | 'llm_gateway'
-  | 'review_center';
+  | 'review_center'
+  | 'meta_agent';
 
 /** One experimental feature as described by the API catalog. */
 export interface ExperimentalFeatureView {


### PR DESCRIPTION
## What

Add `meta_agent` to the experimental feature catalog. Off by default, per-project opt-in via Customize → Settings → Experimental.

## Why

PR #5960 adds a meta coordinator agent. This PR adds the feature flag so it can be gated behind a per-project opt-in. When the flag is off, projects see zero change.

## Changes

- Add `meta_agent` to `ExperimentalFeatureMapSchema` (api-contract)
- Add registry entry in `features.ts` (available: true, platformDefault: false)
- Update SDK type mirror, test fixtures, and unit tests

## Relationship to #5960

This PR only adds the feature flag to the catalog. The actual gating code (checking the flag before injecting the meta agent) will be added in a follow-up PR after #5960 is merged.

## Risk / rollback

Additive only — no behavior change. The flag is off by default.