### PR TITLE
fix(web): stop auth cache and markdown prefetch storms

### DIFF
--- a/apps/web/src/components/markdown/unified-markdown-utils.test.ts
+++ b/apps/web/src/components/markdown/unified-markdown-utils.test.ts
@@ -10,6 +10,7 @@ import {
   looksLikeUrl,
   normalizeLanguage,
   shikiWasmAvailable,
+  shouldUseNextLink,
 } from './unified-markdown-utils';
 
 describe('isInternalUrl', () => {
@@ -29,6 +30,22 @@ describe('isInternalUrl', () => {
     expect(isInternalUrl(undefined)).toBe(false);
     expect(isInternalUrl('')).toBe(false);
     expect(isInternalUrl('relative/path')).toBe(false);
+  });
+});
+
+describe('shouldUseNextLink', () => {
+  test('uses Next Link only for trusted app-router hrefs', () => {
+    expect(shouldUseNextLink('/dashboard')).toBe(true);
+    expect(shouldUseNextLink('#section')).toBe(true);
+    expect(shouldUseNextLink('https://kortix.com/legal/terms.')).toBe(false);
+    expect(shouldUseNextLink('http://localhost:3000/dashboard')).toBe(false);
+    expect(shouldUseNextLink('mailto:hi@kortix.ai')).toBe(false);
+    expect(shouldUseNextLink('relative/path')).toBe(false);
+  });
+
+  test('keeps malformed absolute hrefs out of Next Link', () => {
+    expect(shouldUseNextLink('http://:')).toBe(false);
+    expect(shouldUseNextLink('https://:')).toBe(false);
   });
 });
 
@@ -203,8 +220,7 @@ describe('shikiWasmAvailable', () => {
     try {
       // Simulate a browser/context that blocks or disables WebAssembly.
       // `delete` mirrors how such runtimes expose no WebAssembly global at all.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      delete (globalThis as any).WebAssembly;
+      delete (globalThis as { WebAssembly?: unknown }).WebAssembly;
       expect(shikiWasmAvailable()).toBe(false);
     } finally {
       // Restore — other tests (and the live Shiki init) need WebAssembly.

--- a/apps/web/src/components/markdown/unified-markdown-utils.ts
+++ b/apps/web/src/components/markdown/unified-markdown-utils.ts
@@ -71,6 +71,11 @@ export function isLinkSafeHref(href: string | undefined): boolean {
   return true;
 }
 
+/** Route only trusted app paths through Next.js Link and its prefetcher. */
+export function shouldUseNextLink(href: string | undefined): boolean {
+  return isInternalUrl(href) && isLinkSafeHref(href);
+}
+
 /**
  * Fenced-code language hints that are not the id the highlighter preloads.
  *

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -11,7 +11,7 @@ import {
   normalizeClassName,
   prepareMarkdownForKatex,
 } from '@/components/markdown/katex-markdown';
-import { isInternalUrl, isLinkSafeHref } from '@/components/markdown/unified-markdown-utils';
+import { isInternalUrl, shouldUseNextLink } from '@/components/markdown/unified-markdown-utils';
 import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
 import { parseSetupLinkHref } from '@/components/setup-links/util';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
@@ -122,10 +122,11 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
             '[overflow-wrap:anywhere]',
           );
 
-          // A malformed absolute href (e.g. `http://:` from an unsubstituted
-          // `${HOST}:${PORT}` template in content) must not reach next/link —
-          // its prefetch path throws `Cannot prefetch '...'` (see isLinkSafeHref).
-          if (!isLinkSafeHref(resolvedHref)) {
+          // Markdown can contain arbitrary same-origin absolute URLs. Next.js
+          // treats those as app routes and prefetches them, including typos such
+          // as `/legal/terms.`. Only trusted root-relative/hash paths belong in
+          // the app router; every other href stays a plain anchor.
+          if (!shouldUseNextLink(resolvedHref)) {
             return (
               <a
                 href={resolvedHref}

--- a/apps/web/src/lib/kortix-config.ts
+++ b/apps/web/src/lib/kortix-config.ts
@@ -33,9 +33,9 @@ export function ensureKortixConfigured(): void {
     getUserId: async () => {
       try {
         const {
-          data: { user },
-        } = await createClient().auth.getUser();
-        return user?.id ?? null;
+          data: { session },
+        } = await createClient().auth.getSession();
+        return session?.user?.id ?? null;
       } catch {
         return null;
       }

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,27 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-04 — session `auth-cache-link-prefetch` claim
+
+No **Now** task claimed. This is a narrow browser cache identity fix.
+
+Scope:
+
+- Resolve the offline transcript cache scope once per authenticated browser session.
+- Invalidate the resolved scope when the host clears the session cache.
+- Preserve all published names, signatures, and cache key formats.
+
+The required `tdd` skill is unavailable in this session. The work will use the
+same RED, GREEN, and REFACTOR sequence directly.
+
+Required SDK gates are typecheck, the full test suite, and packed-install smoke.
+
+**Status:** IN PROGRESS.
+
+**SDK package shippable to production: NOT YET.**
+
+---
+
 ## Who may edit what
 
 | Section                     | Agents may…                                            | Agents may **not**…                                                                                         |

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -33,6 +33,34 @@ Required SDK gates are typecheck, the full test suite, and packed-install smoke.
 
 ---
 
+### 2026-08-04 — session `auth-cache-link-prefetch` completion
+
+The IndexedDB transcript cache now memoizes one authenticated user scope across
+stream writes. `clearSessionIDBCache()` invalidates the scope before clearing
+pending writes and IndexedDB, so sign-out and account changes cannot reuse it.
+Null scopes are not retained, which preserves late authentication hydration.
+
+RED:
+
+- Four concurrent `saveSessionToIDB()` calls performed `4` identity reads; the
+  regression expected `1`.
+
+GREEN:
+
+- `pnpm --filter @kortix/sdk typecheck`: exit `0`.
+- `pnpm --filter @kortix/sdk test`: `1456 pass`, `2 skip`, `0 fail`, and
+  `6133 expect()` calls across `120` files.
+- `pnpm --filter @kortix/sdk run smoke:install`: exit `0`; the packed tarball
+  imported and `createKortix` constructed successfully.
+
+No public export name, signature, cache key, or public-surface snapshot changed.
+
+**Status:** COMPLETE.
+
+**SDK package shippable to production: YES.**
+
+---
+
 ## Who may edit what
 
 | Section                     | Agents may…                                            | Agents may **not**…                                                                                         |

--- a/packages/sdk/src/browser/cache/idb-sync-cache.test.ts
+++ b/packages/sdk/src/browser/cache/idb-sync-cache.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { configureKortix } from '../../core/http/config';
+import { clearSessionIDBCache, saveSessionToIDB } from './idb-sync-cache';
+
+describe('IndexedDB cache identity scope', () => {
+  beforeEach(async () => {
+    await clearSessionIDBCache();
+  });
+
+  test('resolves the current user once across repeated transcript writes', async () => {
+    let identityReads = 0;
+    configureKortix({
+      backendUrl: 'https://api.example.test/v1',
+      getToken: async () => null,
+      getUserId: async () => {
+        identityReads += 1;
+        return 'user-1';
+      },
+    });
+
+    await Promise.all([
+      saveSessionToIDB('session-1', [], {}),
+      saveSessionToIDB('session-1', [], {}),
+      saveSessionToIDB('session-1', [], {}),
+      saveSessionToIDB('session-1', [], {}),
+    ]);
+
+    expect(identityReads).toBe(1);
+  });
+
+  test('resolves the identity again after the session cache is cleared', async () => {
+    let identityReads = 0;
+    configureKortix({
+      backendUrl: 'https://api.example.test/v1',
+      getToken: async () => null,
+      getUserId: async () => {
+        identityReads += 1;
+        return identityReads === 1 ? 'user-1' : 'user-2';
+      },
+    });
+
+    await saveSessionToIDB('session-1', [], {});
+    await clearSessionIDBCache();
+    await saveSessionToIDB('session-2', [], {});
+
+    expect(identityReads).toBe(2);
+  });
+
+  test('does not retain an unauthenticated scope', async () => {
+    let identityReads = 0;
+    configureKortix({
+      backendUrl: 'https://api.example.test/v1',
+      getToken: async () => null,
+      getUserId: async () => {
+        identityReads += 1;
+        return identityReads === 1 ? null : 'user-1';
+      },
+    });
+
+    await saveSessionToIDB('session-1', [], {});
+    await saveSessionToIDB('session-1', [], {});
+
+    expect(identityReads).toBe(2);
+  });
+});

--- a/packages/sdk/src/browser/cache/idb-sync-cache.ts
+++ b/packages/sdk/src/browser/cache/idb-sync-cache.ts
@@ -25,13 +25,31 @@ interface CachedSession {
   updatedAt: number;
 }
 
-async function getCurrentCacheScope(): Promise<string | null> {
-  try {
-    const userId = (await platformConfig().getUserId?.()) ?? null;
-    return userId ? `user:${userId}` : null;
-  } catch {
-    return null;
-  }
+let cacheScopePromise: Promise<string | null> | null = null;
+
+function getCurrentCacheScope(): Promise<string | null> {
+  if (cacheScopePromise) return cacheScopePromise;
+
+  const pending = (async () => {
+    try {
+      const userId = (await platformConfig().getUserId?.()) ?? null;
+      return userId ? `user:${userId}` : null;
+    } catch {
+      return null;
+    }
+  })();
+  cacheScopePromise = pending;
+
+  // Authentication can hydrate after the first cache access. Retain a real
+  // user scope for this browser session, but let an unauthenticated lookup be
+  // retried instead of pinning `null` until reload.
+  void pending.then((scope) => {
+    if (!scope && cacheScopePromise === pending) {
+      cacheScopePromise = null;
+    }
+  });
+
+  return pending;
 }
 
 let dbPromise: Promise<IDBDatabase> | null = null;
@@ -217,6 +235,9 @@ export async function deleteSessionFromIDB(
 }
 
 export async function clearSessionIDBCache(): Promise<void> {
+  // The host calls this on sign-out and account changes. Invalidate identity
+  // before touching IndexedDB so the next write cannot reuse the previous user.
+  cacheScopePromise = null;
   try {
     pendingWrites.clear();
     if (flushTimer) {


### PR DESCRIPTION
## Problem

Every transcript store update resolved the IndexedDB user scope through Supabase auth.getUser(). A streaming answer therefore issued one /auth/v1/user request per message or part update until Chromium returned ERR_INSUFFICIENT_RESOURCES.

UnifiedMarkdown also passed arbitrary absolute URLs through Next.js Link. A same-origin typo such as https://kortix.com/legal/terms. triggered an app-router RSC prefetch and a visible 404 request.

## Fix

- Memoize the authenticated IndexedDB cache scope across transcript writes.
- Invalidate the memoized scope when the session cache is cleared.
- Do not retain null scopes during authentication hydration.
- Read the local Supabase session for offline cache identity.
- Use Next.js Link only for root-relative and hash markdown hrefs.
- Render arbitrary absolute, protocol, and relative markdown hrefs as plain anchors.

## Verification

- SDK RED: 4 concurrent writes performed 4 identity reads; expected 1.
- SDK focused: 3 pass, 0 fail.
- SDK typecheck: exit 0.
- SDK full suite: 1456 pass, 2 skip, 0 fail.
- SDK packed-install smoke: exit 0.
- Web focused markdown: 34 pass, 0 fail.
- Web full suite: 3772 pass, 0 fail.
- Changed-file ESLint: 0 errors, 0 warnings.
- Local API health: HTTP 200 on localhost:18108/v1/health.
- Local web auth page: HTTP 200 on localhost:18100/auth.

## Browser limitation

The configured browser runtime exposed zero browsers. DOM and request-panel proof could not run locally. The regression tests pin both routing and request-count behavior.