### PR TITLE
fix(web): give the landing code panels a keyboard tab stop

### DIFF
--- a/apps/web/src/features/marketing/how-it-work/step/scrollable-panel-a11y.test.ts
+++ b/apps/web/src/features/marketing/how-it-work/step/scrollable-panel-a11y.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const STEP_DIR = resolve(import.meta.dir);
+
+/**
+ * A region the pointer can scroll but the keyboard cannot reach is a WCAG 2.1.1
+ * failure — axe reports it as `scrollable-region-focusable` at `serious`, and
+ * the landing-page audit in tests/accessibility/landing.a11y.spec.ts treats
+ * serious violations as blocking.
+ *
+ * The step panels render fixed snippets with no interactive child, so nothing
+ * inside them can take focus on the container's behalf. Each scrollable `<pre>`
+ * therefore has to carry the tab stop itself.
+ *
+ * This reads source rather than rendering because axe only flags the panel that
+ * actually overflows at the audited viewport — the browser audit cannot see a
+ * sibling that happens to fit, and that sibling is exactly what regresses at the
+ * next breakpoint.
+ */
+function stepSources(): { file: string; source: string }[] {
+  return readdirSync(STEP_DIR)
+    .filter((file) => file.endsWith('.tsx'))
+    .map((file) => ({ file, source: readFileSync(resolve(STEP_DIR, file), 'utf8') }));
+}
+
+/** Each `<pre …>` open tag, attributes included, comments already stripped. */
+function preOpenTags(source: string): string[] {
+  const withoutComments = source.replace(/\{\/\*[\s\S]*?\*\/\}/g, '');
+  return [...withoutComments.matchAll(/<pre\b[^>]*>/g)].map((match) => match[0]);
+}
+
+describe('how-it-works step panels', () => {
+  test('the step folder still has panels to check', () => {
+    const tags = stepSources().flatMap(({ source }) => preOpenTags(source));
+    expect(tags.length).toBeGreaterThan(0);
+  });
+
+  test('every scrollable <pre> is keyboard focusable', () => {
+    const offenders = stepSources().flatMap(({ file, source }) =>
+      preOpenTags(source)
+        .filter((tag) => tag.includes('overflow-x-auto'))
+        .filter((tag) => !/tabIndex=\{0\}/.test(tag))
+        .map((tag) => `${file}: ${tag}`),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/src/features/marketing/how-it-work/step/step-harness.tsx
+++ b/apps/web/src/features/marketing/how-it-work/step/step-harness.tsx
@@ -58,7 +58,12 @@ export function StepHarness(): ReactNode {
           }
         >
           <div className="bg-background px-4 py-3">
-            <pre className="overflow-x-auto font-mono text-[11.5px] leading-[1.75]">
+            {/* `overflow-x-auto` makes this a scrollable region, and a region
+                a pointer can scroll but a keyboard cannot is a WCAG 2.1.1
+                failure (axe `scrollable-region-focusable`, serious). The
+                snippet holds no interactive child to carry focus, so the
+                container takes the tab stop itself and arrow keys scroll it. */}
+            <pre tabIndex={0} className="overflow-x-auto font-mono text-[11.5px] leading-[1.75]">
               <code>
                 {CONFIG.map((entry, index) => (
                   <div

--- a/apps/web/src/features/marketing/how-it-work/step/step-source-of-truth.tsx
+++ b/apps/web/src/features/marketing/how-it-work/step/step-source-of-truth.tsx
@@ -87,7 +87,11 @@ export function StepSourceOfTruth(): ReactNode {
       <div className="grid gap-3 sm:grid-cols-2">
         <Panel title="kortix.yaml" count="omit a grant and it is none">
           <div className="bg-background px-4 py-3">
-            <pre className="overflow-x-auto font-mono text-[11.5px] leading-[1.75]">
+            {/* Same scrollable-region tab stop as step-harness: axe only flags
+                the panel that actually overflows at the audited viewport, so
+                the identical sibling is fixed too rather than left to trip the
+                gate at the next breakpoint. */}
+            <pre tabIndex={0} className="overflow-x-auto font-mono text-[11.5px] leading-[1.75]">
               <code>
                 {MANIFEST.map((entry, index) => (
                   <div


### PR DESCRIPTION
## Summary

Fixes the `QA - staging` failure that has blocked a clean promote since `c135400766` — the commit production is currently serving as v0.12.2.

Both `how-it-works` step panels render their snippet in a `<pre className="overflow-x-auto …">`. That makes each a scrollable region, and neither contains an interactive child that could take focus, so a pointer can scroll them and a keyboard cannot reach them. axe reports it as `scrollable-region-focusable` at **serious**, and `tests/accessibility/landing.a11y.spec.ts` treats serious violations as blocking.

`tabIndex={0}` on the `<pre>` is Deque's recommended remedy: the container takes the tab stop itself, and arrow keys scroll it.

**Both panels are fixed, not just the one axe named.** The rule only fires on an element that actually overflows at the audited viewport, so the identical sibling in `step-source-of-truth.tsx` is invisible to the browser audit today and would trip the gate at the next breakpoint.

A source-level contract test pins the invariant across the whole step folder. It reads source rather than rendering, because a sibling that merely *fits* at the audited viewport is exactly the regression the rendered audit structurally cannot catch.

### Why this instead of another fast-track

v0.12.2 and the release before it were both promoted with `skip_green: true`, disclosing this failure in the public notes. Two releases have now shipped past it. It is a one-attribute fix to a real keyboard-access bug on the public landing page, so it is fixed here.

## Test plan

| Gate | Command | Result |
| --- | --- | --- |
| New contract test | `bun test src/features/marketing/how-it-work/` | 2 pass, 0 fail |
| **Red check** | removed `tabIndex` from `step-harness.tsx`, re-ran | **1 fail**, naming `step-harness.tsx: <pre className="overflow-x-auto …">` — the test has teeth |
| Lint | `npx eslint` on all 3 changed files | clean |
| Typecheck | `npx tsc --noEmit` | 15 errors, the documented `@types/bun` baseline only; none in the changed files; 0 `TS2786` |

The authoritative check is `QA - staging` on this commit once merged: `landing.a11y.spec.ts` should go from 1 failed / 1 passed to 2 passed.

## Not verified locally

The axe assertion itself needs a real browser, so the a11y result is verified by CI rather than locally. The contract test is the local guard.
