### PR TITLE
fix(api): convert assertAllowedSourceAddress throw to typed 400 (BS f5c0ce61)

### DIFF
--- a/apps/api/src/__tests__/unit-executor-invalid-source-address.test.ts
+++ b/apps/api/src/__tests__/unit-executor-invalid-source-address.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * Regression for Better Stack API prod pattern `f5c0ce61…` —
+ * `Error: Only https registry URLs on public hosts are allowed.`
+ * (mechanism `generic`, `handled:true`), call site `assertAllowedSourceAddress`
+ * in `apps/api/src/marketplace/catalog.ts`, on
+ * `POST /v1/executor/projects/:id/connectors` (8 occurrences, last 2026-08-04).
+ *
+ * Root cause: `assertAllowedSourceAddress` (the marketplace LFI/SSRF guard)
+ * throws a bare `Error` when a user submits a non-https or non-public URL as a
+ * connector source. The throw is a VALID security validation, NOT a server
+ * defect — but the executor `POST /connectors` route handler called
+ * `deps.discoverConnectorAuth(projectId, body)` (which invokes
+ * `discoverConnectorAuthFromSource` → `assertAllowedSourceAddress`) with NO
+ * try/catch, so the throw propagated uncaught through the executor sync path
+ * → `app.onError` → generic `captureException` → Sentry → Better Stack.
+ *
+ * This is the SAME antipattern as PR #5240 (bare 501 "not supported" → typed
+ * `feature_not_supported` envelope + SDK classification) and #5652
+ * (`RepoFileNotFoundError` typed throw + route catch): an EXPECTED user-input
+ * validation state must NOT page like a server defect.
+ *
+ * The fix:
+ *  1. `assertAllowedSourceAddress` now throws a TYPED
+ *     `AllowedSourceValidationError` (stable `code: 'invalid_source_address'`),
+ *     exported from `marketplace/catalog.ts` (mirrors `RepoFileNotFoundError`).
+ *  2. The `POST /connectors` + `POST /connectors/auth-discovery` route handlers
+ *     catch the typed error and return a STRUCTURED 400
+ *     `{ error: 'invalid_source_address', code, message }` instead of letting
+ *     it propagate to `app.onError`/Sentry.
+ *  3. `invalid_source_address` is in `SENTRY_IGNORE_ERRORS` (defense in depth).
+ *
+ * These tests drive the REAL executor router with a `discoverConnectorAuth`
+ * dep that throws the typed `AllowedSourceValidationError` (the exact prod
+ * failure shape), and assert:
+ *   - the route returns 400 (NOT 500),
+ *   - the body is the structured `invalid_source_address` envelope,
+ *   - a NON-validation error (a genuine server failure) still propagates
+ *     (re-thrown) so the generic `app.onError` + Sentry path stays loud.
+ */
+import {
+  AllowedSourceValidationError,
+  assertAllowedSourceAddress,
+  isAllowedSourceValidationError,
+} from '../marketplace/catalog';
+import {
+  createExecutorRouter,
+  type ExecutorPrincipal,
+  type ExecutorRouterDeps,
+} from '../executor/router';
+
+const PROJECT = 'proj-1';
+const ALICE = 'user-alice';
+
+/** The exact prod failure shape: `assertAllowedSourceAddress` throws the typed
+ *  error for a non-https URL. Pin the typed contract first so the route
+ *  handler's `isAllowedSourceValidationError` branch stays anchored on the
+ *  real class. */
+describe('assertAllowedSourceAddress throws a typed AllowedSourceValidationError', () => {
+  test('non-https URL (the BS f5c0ce61 message)', () => {
+    let caught: unknown;
+    try {
+      assertAllowedSourceAddress('http://example.com/registry.json');
+    } catch (err) {
+      caught = err;
+    }
+    expect(isAllowedSourceValidationError(caught)).toBe(true);
+    expect(caught).toBeInstanceOf(AllowedSourceValidationError);
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as AllowedSourceValidationError).code).toBe(
+      'invalid_source_address',
+    );
+    expect((caught as AllowedSourceValidationError).message).toBe(
+      'Only https registry URLs on public hosts are allowed.',
+    );
+    expect((caught as AllowedSourceValidationError).name).toBe(
+      'AllowedSourceValidationError',
+    );
+  });
+
+  test('local-folder source (LFI guard)', () => {
+    expect(() => assertAllowedSourceAddress('./local-folder')).toThrow(
+      AllowedSourceValidationError,
+    );
+    let caught: unknown;
+    try {
+      assertAllowedSourceAddress('/etc');
+    } catch (err) {
+      caught = err;
+    }
+    expect(isAllowedSourceValidationError(caught)).toBe(true);
+    expect((caught as AllowedSourceValidationError).code).toBe(
+      'invalid_source_address',
+    );
+  });
+
+  test('private host (SSRF guard)', () => {
+    expect(() =>
+      assertAllowedSourceAddress('http://169.254.169.254/latest/meta-data'),
+    ).toThrow(AllowedSourceValidationError);
+    expect(() =>
+      assertAllowedSourceAddress('https://192.168.1.10/registry.json'),
+    ).toThrow(AllowedSourceValidationError);
+  });
+
+  test('unparseable address', () => {
+    let caught: unknown;
+    try {
+      assertAllowedSourceAddress(':::not-a-url:::');
+    } catch (err) {
+      caught = err;
+    }
+    expect(isAllowedSourceValidationError(caught)).toBe(true);
+  });
+
+  test('allowed sources do NOT throw', () => {
+    expect(() => assertAllowedSourceAddress('anthropics/skills')).not.toThrow();
+    expect(() =>
+      assertAllowedSourceAddress('https://example.com/registry.json'),
+    ).not.toThrow();
+  });
+
+  test('isAllowedSourceValidationError narrows (negative cases)', () => {
+    expect(isAllowedSourceValidationError(new Error('x'))).toBe(false);
+    expect(isAllowedSourceValidationError(null)).toBe(false);
+    expect(isAllowedSourceValidationError(undefined)).toBe(false);
+    expect(isAllowedSourceValidationError('x')).toBe(false);
+  });
+});
+
+// ── Route-level regression: the typed throw becomes a 400, not a 500 ────────
+
+/** Build an executor router whose `discoverConnectorAuth` throws the EXACT prod
+ *  failure shape (the typed `AllowedSourceValidationError`). The route handler
+ *  must catch it and return a structured 400 — NOT let it reach `app.onError`. */
+function buildRouter(throwFromCreate = false): {
+  app: ReturnType<typeof createExecutorRouter>;
+  createConnectorCalls: number;
+} {
+  let createConnectorCalls = 0;
+  const deps: ExecutorRouterDeps = {
+    resolvePrincipal: async (c) => {
+      const u = c.req.header('x-test-user');
+      return u ? ({ accountId: 'acct-1', userId: u } as ExecutorPrincipal) : null;
+    },
+    resolveProjectPrincipal: async (_c, _projectId) => null,
+    makeGatewayDeps: (() => ({} as unknown)) as ExecutorRouterDeps['makeGatewayDeps'],
+    listCatalog: async () => [],
+    resolveAdmin: async (c) => {
+      const u = c.req.header('x-test-admin');
+      return u ? { accountId: 'acct-1', userId: u } : null;
+    },
+    listConnectors: async () => [],
+    syncConnectors: async () => ({ synced: 0, errors: [] }),
+    discoverConnectorAuth: async () => {
+      // The exact prod failure shape: the auth-discovery path calls
+      // assertAllowedSourceAddress on the draft endpoint, which throws the
+      // typed validation error for a non-https / private / local source.
+      throw new AllowedSourceValidationError(
+        'Only https registry URLs on public hosts are allowed.',
+      );
+    },
+    createConnector: async () => {
+      createConnectorCalls += 1;
+      if (throwFromCreate) {
+        // The sync path (resolveCatalog / loadSourceText) ALSO calls
+        // assertAllowedSourceAddress on re-materialize — same typed throw.
+        throw new AllowedSourceValidationError(
+          'Only https registry URLs on public hosts are allowed.',
+        );
+      }
+      return { ok: true, sync: { synced: 1, errors: [] } };
+    },
+  };
+  return { app: createExecutorRouter(deps), createConnectorCalls };
+}
+
+const admin = { 'x-test-admin': ALICE };
+
+describe('executor router: assertAllowedSourceAddress throw → structured 400 (not 500)', () => {
+  test('POST /connectors/auth-discovery returns a typed 400 invalid_source_address', async () => {
+    const { app } = buildRouter();
+    const req = (path: string, init: RequestInit = {}) =>
+      app.fetch(new Request(`http://x${path}`, init));
+    const res = await req(`/projects/${PROJECT}/connectors/auth-discovery`, {
+      method: 'POST',
+      headers: { ...admin, 'content-type': 'application/json' },
+      body: JSON.stringify({ provider: 'mcp', url: 'http://example.com/sse' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('invalid_source_address');
+    expect(body.code).toBe('invalid_source_address');
+    expect(body.message).toBe(
+      'Only https registry URLs on public hosts are allowed.',
+    );
+  });
+
+  test('POST /connectors (create) returns a typed 400 when discoverConnectorAuth throws', async () => {
+    const { app, createConnectorCalls } = buildRouter();
+    const req = (path: string, init: RequestInit = {}) =>
+      app.fetch(new Request(`http://x${path}`, init));
+    const res = await req(`/projects/${PROJECT}/connectors`, {
+      method: 'POST',
+      headers: { ...admin, 'content-type': 'application/json' },
+      // No explicit auth → the route calls discoverConnectorAuth first, which
+      // throws the typed validation error. The route must catch it → 400,
+      // NOT call createConnector, NOT 500.
+      body: JSON.stringify({
+        slug: 'private-api',
+        provider: 'mcp',
+        url: 'http://169.254.169.254/latest',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('invalid_source_address');
+    expect(body.code).toBe('invalid_source_address');
+    expect(body.message).toBe(
+      'Only https registry URLs on public hosts are allowed.',
+    );
+    // createConnector must NOT be reached when discovery throws — the 400
+    // short-circuits before the manifest write.
+    expect(createConnectorCalls).toBe(0);
+  });
+
+  test('POST /connectors (create) returns a typed 400 when createConnector throws (sync path)', async () => {
+    const { app } = buildRouter(true);
+    const req = (path: string, init: RequestInit = {}) =>
+      app.fetch(new Request(`http://x${path}`, init));
+    const res = await req(`/projects/${PROJECT}/connectors`, {
+      method: 'POST',
+      headers: { ...admin, 'content-type': 'application/json' },
+      // Explicit auth → discoverConnectorAuth is skipped; createConnector
+      // itself throws the typed validation error (the sync path's
+      // resolveCatalog/loadSourceText calls assertAllowedSourceAddress).
+      body: JSON.stringify({
+        slug: 'private-api',
+        provider: 'openapi',
+        spec: 'http://192.168.1.5/openapi.json',
+        auth: { type: 'none' },
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe('invalid_source_address');
+    expect(body.message).toBe(
+      'Only https registry URLs on public hosts are allowed.',
+    );
+  });
+
+  test('a NON-validation error still propagates (does NOT get swallowed as 400)', async () => {
+    // A genuine server failure (not an AllowedSourceValidationError) must
+    // still propagate to app.onError → captureException → Sentry — the catch
+    // is narrow to the typed validation error, so unexpected failures stay
+    // loud. Hono's default error handler converts the unhandled throw into a
+    // 500 (in production the global app.onError does this + captureException).
+    // The assertion: a non-validation error is NOT caught as a 400
+    // invalid_source_address envelope — it surfaces as a 500 (the path the
+    // production app.onError → captureException → Sentry would take).
+    const deps: ExecutorRouterDeps = {
+      resolvePrincipal: async () => null,
+      resolveProjectPrincipal: async () => null,
+      makeGatewayDeps: (() => ({} as unknown)) as ExecutorRouterDeps['makeGatewayDeps'],
+      listCatalog: async () => [],
+      resolveAdmin: async (c) => {
+        const u = c.req.header('x-test-admin');
+        return u ? { accountId: 'acct-1', userId: u } : null;
+      },
+      listConnectors: async () => [],
+      syncConnectors: async () => ({ synced: 0, errors: [] }),
+      discoverConnectorAuth: async () => {
+        // A genuine server failure — NOT an AllowedSourceValidationError.
+        throw new Error('genuine upstream failure');
+      },
+      createConnector: async () => ({ ok: true, sync: { synced: 0, errors: [] } }),
+    };
+    const app = createExecutorRouter(deps);
+    const res = await app.fetch(
+      new Request(`http://x/projects/${PROJECT}/connectors/auth-discovery`, {
+        method: 'POST',
+        headers: { ...admin, 'content-type': 'application/json' },
+        body: JSON.stringify({ provider: 'mcp', url: 'http://x' }),
+      }),
+    );
+    // The genuine error must NOT be caught as a 400 invalid_source_address —
+    // Hono's default error handler surfaces it as a 500 (the production
+    // app.onError → captureException → Sentry path).
+    expect(res.status).toBe(500);
+    // The body is Hono's generic "Internal Server Error" text, NOT the typed
+    // invalid_source_address validation envelope.
+    const text = await res.text();
+    expect(text).not.toContain('invalid_source_address');
+  });
+});

--- a/apps/api/src/executor/router.ts
+++ b/apps/api/src/executor/router.ts
@@ -27,6 +27,9 @@ import type { AgentGrant } from '@kortix/db';
 import { SLUG_RE } from '@kortix/manifest-schema';
 import type { Context } from 'hono';
 import { agentMayUseConnector } from '../iam/agent-scope';
+import {
+  isAllowedSourceValidationError,
+} from '../marketplace/catalog';
 import { auth, errors, json, makeOpenApiApp } from '../openapi';
 import { canonicalConnectorAlias } from '../projects/lib/session-connector-bindings';
 import {
@@ -480,6 +483,34 @@ async function readAttachmentBytes(c: Context): Promise<Uint8Array> {
     offset += chunk.byteLength;
   }
   return bytes;
+}
+
+/**
+ * Structured 400 for an EXPECTED source-address validation rejection from
+ * {@link assertAllowedSourceAddress} (the LFI/SSRF guard — non-https URL,
+ * private host, local-folder path). The throw is a typed
+ * {@link AllowedSourceValidationError} (stable `code: 'invalid_source_address'`)
+ * so this helper converts it to a clean 400 without letting it propagate to
+ * `app.onError` → `captureException` → Sentry (Better Stack pattern
+ * `f5c0ce61…`). Mirrors the `feature_not_supported` (#5240) +
+ * `RepoFileNotFoundError` (#5652) typed-error pattern: an expected user-input
+ * validation state must NOT page like a server defect. Returns the 400
+ * response when the error matches, otherwise `null` so the caller re-throws /
+ * falls through to the generic handler for a genuine server failure.
+ */
+function allowedSourceValidationResponse(
+  c: Context,
+  err: unknown,
+): Response | null {
+  if (!isAllowedSourceValidationError(err)) return null;
+  return c.json(
+    {
+      error: err.code,
+      code: err.code,
+      message: err.message,
+    },
+    400,
+  );
 }
 
 export function createExecutorRouter(deps: ExecutorRouterDeps): OpenAPIHono {
@@ -945,7 +976,19 @@ export function createExecutorRouter(deps: ExecutorRouterDeps): OpenAPIHono {
       } catch {
         return c.json({ error: 'invalid_json' }, 400);
       }
-      return c.json(await deps.discoverConnectorAuth(projectId, body));
+      // `discoverConnectorAuth` calls `assertAllowedSourceAddress` (the LFI/SSRF
+      // guard) on the draft's endpoint/spec URL, which throws a typed
+      // `AllowedSourceValidationError` for a non-https / private / local source.
+      // That's an EXPECTED user-input validation state — catch it here and
+      // return a structured 400 instead of letting it propagate to
+      // `app.onError` → Sentry (Better Stack pattern `f5c0ce61…`).
+      try {
+        return c.json(await deps.discoverConnectorAuth(projectId, body));
+      } catch (err) {
+        const validation = allowedSourceValidationResponse(c, err);
+        if (validation) return validation;
+        throw err;
+      }
     },
   );
 
@@ -984,13 +1027,33 @@ export function createExecutorRouter(deps: ExecutorRouterDeps): OpenAPIHono {
       }
       let authDiscovery: ConnectorAuthDiscovery | undefined;
       if (body.auth === undefined && deps.discoverConnectorAuth) {
-        authDiscovery = await deps.discoverConnectorAuth(projectId, body);
-        if (authDiscovery.recommended) body.auth = authDiscovery.recommended;
+        // `discoverConnectorAuth` → `discoverConnectorAuthFromSource` calls
+        // `assertAllowedSourceAddress` on the draft's endpoint URL, which
+        // throws a typed `AllowedSourceValidationError` for a non-https /
+        // private / local source. That's an EXPECTED user-input validation
+        // state — catch it here and return a structured 400 instead of
+        // letting it propagate to `app.onError` → Sentry (Better Stack
+        // pattern `f5c0ce61…`). Same guard wraps `createConnector` below
+        // (the sync path also asserts the source on re-materialize).
+        try {
+          authDiscovery = await deps.discoverConnectorAuth(projectId, body);
+          if (authDiscovery.recommended) body.auth = authDiscovery.recommended;
+        } catch (err) {
+          const validation = allowedSourceValidationResponse(c, err);
+          if (validation) return validation;
+          throw err;
+        }
       }
-      const result = await deps.createConnector(projectId, admin.accountId, body);
-      return result.ok
-        ? c.json({ ok: true, sync: result.sync, authDiscovery })
-        : c.json({ error: result.error }, result.status as 400 | 409 | 502);
+      try {
+        const result = await deps.createConnector(projectId, admin.accountId, body);
+        return result.ok
+          ? c.json({ ok: true, sync: result.sync, authDiscovery })
+          : c.json({ error: result.error }, result.status as 400 | 409 | 502);
+      } catch (err) {
+        const validation = allowedSourceValidationResponse(c, err);
+        if (validation) return validation;
+        throw err;
+      }
     },
   );
 

--- a/apps/api/src/lib/sentry.ts
+++ b/apps/api/src/lib/sentry.ts
@@ -87,6 +87,18 @@ export const SENTRY_IGNORE_ERRORS = [
   // patterns 721b7efe… (API) + b38179c5… (frontend symptom).
   'max clients reached in session mode',
   'EMAXCONNSESSION',
+  // Expected source-address validation rejection from
+  // `assertAllowedSourceAddress` (the marketplace LFI/SSRF guard — non-https
+  // URL, private host, local-folder path). The throw is now a TYPED
+  // `AllowedSourceValidationError` (code `invalid_source_address`) that the
+  // executor `POST /connectors` + `POST /connectors/auth-discovery` route
+  // handlers catch and convert to a structured 400 (Better Stack pattern
+  // `f5c0ce61…`). This entry is defense in depth — mirrors the #5487
+  // pool-exhaustion ignore — so any residual `assertAllowedSourceAddress`
+  // throw that slips a route-level catch (a future call site, a
+  // fire-and-forget path) stops paging instead of surfacing as an unhandled
+  // 500. The guard is a VALID security validation, not a server defect.
+  'Only https registry URLs on public hosts are allowed.',
 ] as const;
 
 /**

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -799,20 +799,61 @@ function isAllowedSourceRef(ref: RegistryRef): boolean {
   return false;
 }
 
+/**
+ * Stable error code for the expected "user supplied a source address we refuse
+ * to fetch / read" validation state (non-https URL, private host, local-folder
+ * path). Surfaced on the typed {@link AllowedSourceValidationError} so the
+ * executor route handlers can catch it and return a structured 400 instead of
+ * letting the throw propagate to `app.onError` → `captureException` → Sentry
+ * (Better Stack pattern `f5c0ce61…`). Mirrors the `feature_not_supported`
+ * (#5240) + `RepoFileNotFoundError` (#5652) typed-error pattern: an EXPECTED
+ * user-input validation state must NOT page like a server defect.
+ */
+export const INVALID_SOURCE_ADDRESS_CODE = "invalid_source_address";
+
+/**
+ * Typed error thrown by {@link assertAllowedSourceAddress} when a source
+ * address isn't a safe source to add (the LFI/SSRF guard). Carries a stable
+ * `code` so route handlers branch on it (400) without swallowing genuine
+ * server failures. Distinct from a bare `Error` so callers catch the expected
+ * validation case and let real errors fall through.
+ */
+export class AllowedSourceValidationError extends Error {
+  readonly code = INVALID_SOURCE_ADDRESS_CODE;
+  constructor(message: string) {
+    super(message);
+    this.name = "AllowedSourceValidationError";
+  }
+}
+
+/** Narrow an unknown to {@link AllowedSourceValidationError} (the typed
+ *  validation throw from {@link assertAllowedSourceAddress}). */
+export function isAllowedSourceValidationError(
+  err: unknown,
+): err is AllowedSourceValidationError {
+  return err instanceof AllowedSourceValidationError;
+}
+
 /** Throw with a clear reason if an address isn't a safe source to add (LFI/SSRF guard). */
 export function assertAllowedSourceAddress(address: string): void {
   let ref: RegistryRef;
   try {
     ref = parseRegistryAddress(address);
   } catch (err) {
-    throw new Error(`Unrecognized source address: ${(err as Error).message}`);
+    throw new AllowedSourceValidationError(
+      `Unrecognized source address: ${(err as Error).message}`,
+    );
   }
   if (isAllowedSourceRef(ref)) return;
   if (ref.kind === "local")
-    throw new Error("Local-folder sources are not allowed on this server.");
+    throw new AllowedSourceValidationError(
+      "Local-folder sources are not allowed on this server.",
+    );
   if (ref.kind === "url")
-    throw new Error("Only https registry URLs on public hosts are allowed.");
-  throw new Error("This source type is not allowed.");
+    throw new AllowedSourceValidationError(
+      "Only https registry URLs on public hosts are allowed.",
+    );
+  throw new AllowedSourceValidationError("This source type is not allowed.");
 }
 
 /** Start (or join) a build of the external catalog — resolves when every source


### PR DESCRIPTION
## Demo

Non-visual change — backend error-handling fix. Proof is the regression test + the typed 400 response shape:

```bash
$ bun test --env-file=scripts/test.env src/__tests__/unit-executor-invalid-source-address.test.ts
 10 pass
 0 fail
 32 expect() calls
```

The affected route now returns a structured 400 for a non-https / private / local connector source instead of a 500 that pages Sentry:

```json
POST /v1/executor/projects/:id/connectors
{ "slug": "private-api", "provider": "mcp", "url": "http://169.254.169.254/latest" }

< 400 Bad Request
{ "error": "invalid_source_address", "code": "invalid_source_address", "message": "Only https registry URLs on public hosts are allowed." }
```

## Why

Better Stack API prod pattern `f5c0ce61e31d41d220fa3f606ad524d7cc406f4eca103ee6d9363be4de7d0f2a` (app 2346961) — `Error: Only https registry URLs on public hosts are allowed.`, 8 occurrences, last 2026-08-04 18:04 UTC, on `POST /v1/executor/projects/de8fd0c4-.../connectors`. The marketplace LFI/SSRF guard `assertAllowedSourceAddress` threw a *valid* security validation error, but the executor `POST /connectors` route called `deps.discoverConnectorAuth` (which invokes the guard) with no try/catch, so the throw propagated uncaught → `app.onError` → `captureException` → Sentry, paging like a server defect. This is the same antipattern as PR #5240 (bare 501 → typed `feature_not_supported`) and #5652 (`RepoFileNotFoundError` typed throw + route catch): an expected user-input validation state must not page.

## What changed

1. **`apps/api/src/marketplace/catalog.ts`** — `assertAllowedSourceAddress` now throws a typed `AllowedSourceValidationError` (stable `code: 'invalid_source_address'`) + `isAllowedSourceValidationError` guard, mirroring the `RepoFileNotFoundError` pattern. Subclasses `Error` so existing callers that read `(err as Error).message` (marketplace `POST /sources`, audit-webhooks, accounts/audit) keep working unchanged.
2. **`apps/api/src/executor/router.ts`** — `POST /connectors` and `POST /connectors/auth-discovery` catch the typed error via `allowedSourceValidationResponse()` and return a structured 400 `{ error, code, message }` instead of letting it propagate. A non-validation error still re-throws so genuine server failures stay loud (→ `app.onError` → Sentry).
3. **`apps/api/src/lib/sentry.ts`** — Added `Only https registry URLs on public hosts are allowed.` to `SENTRY_IGNORE_ERRORS` as defense in depth (mirrors #5487 pool-exhaustion), so any residual `assertAllowedSourceAddress` throw that slips a route-level catch stops paging.
4. **`apps/api/src/__tests__/unit-executor-invalid-source-address.test.ts`** (new) — Regression test: pins the typed-error contract (`assertAllowedSourceAddress` throws `AllowedSourceValidationError` with the exact prod message + code), then drives the real executor router with a `discoverConnectorAuth`/`createConnector` that throws the typed error and asserts 400 (not 500) + the `invalid_source_address` envelope + `createConnector` not reached on discovery failure; asserts a genuine (non-validation) error still propagates as a 500.

## Verification

- **Affected tests pass:** `bun test --env-file=scripts/test.env` on the new test (10 pass), `unit-executor-feature-not-supported.test.ts` (6 pass), `unit-marketplace.test.ts` (23 pass — the existing `assertAllowedSourceAddress('...').toThrow()` assertions still hold since the typed error extends `Error`), `catalog.test.ts` (10 pass), `e2e-executor.test.ts` (45 pass — the `omitted auth applies the source recommendation` + `explicit none` flows still work).
- **Typecheck:** `tsc --noEmit` introduces ZERO new errors in the changed files (the 242 pre-existing `AppEnv`/`OpenAPIHono` type mismatches are a monorepo-wide `@hono/zod-openapi` version artifact unrelated to this change; confirmed identical count with the change stashed).
- **Backward compatibility:** the 3 existing `assertAllowedSourceAddress` callers that already catch it (`marketplace/index.ts` POST /sources → 400, `accounts/audit.ts` → 400, `shared/audit-webhooks.ts` → recordFailure) all read `(err as Error).message`, which is preserved on the typed subclass — no behavior change for them, and they now have a stable `.code` they could branch on if desired.

## Root cause confirmation

Call chain (verified in the worktree):
- `POST /v1/executor/projects/:projectId/connectors` → `router.ts:836-868` route handler
- → `deps.discoverConnectorAuth(projectId, body)` at line 851 (no try/catch before this PR)
- → `discoverDraftConnectorAuth` → `discoverConnectorAuthFromSource` (`sync.ts:94-163`)
- → `assertAllowedSourceAddress(endpoint)` at `sync.ts:149` — THREW the bare `Error`
- → propagated uncaught → `app.onError` (`index.ts:876`) → generic `captureException` (`index.ts:1099`) → Sentry → Better Stack pattern `f5c0ce61…`

The same throw can also originate from the sync path (`createConnector` → `syncProjectConnectors` → `resolveCatalog`/`loadSourceText` → `assertAllowedSourceAddress` at `sync.ts:731/763/781/843/867/918`), so the `createConnector` call is wrapped too.

## Risk / rollback

Low risk — the guard itself is unchanged (same URLs rejected, same messages). The only behavioral change is that the *expected* validation rejection now returns a clean 400 instead of a 500 + Sentry page; genuine server failures still propagate. Rollback is `git revert`. The `SENTRY_IGNORE_ERRORS` entry is a substring match on the exact message, so it only suppresses this specific validation message, not generic errors.

## Confirmation plan

After merge + promote, the Better Stack error group `f5c0ce61…` should drop to zero new occurrences (the `POST /connectors` path no longer reaches `captureException` for this validation class). The defense-in-depth `SENTRY_IGNORE_ERRORS` entry ensures any residual throw from a future call site or fire-and-forget path also stops paging.

---

Better Stack error: https://errors.betterstack.com/team/t502678/errors/f5c0ce61e31d41d220fa3f606ad524d7cc406f4eca103ee6d9363be4de7d0f2a?s=2346961
