### PR TITLE
fix(executor): align catalog with session connector scope

### DIFF
--- a/apps/api/src/__tests__/e2e-slack-cli.test.ts
+++ b/apps/api/src/__tests__/e2e-slack-cli.test.ts
@@ -372,6 +372,16 @@ describe('slack CLI', () => {
     expect(world.manifests).toEqual(['Test Slack App']);
   });
 
+  test('manifest reports one /v1 mount when KORTIX_API_URL already includes /v1', async () => {
+    const origin = apiUrl;
+    apiUrl = `${origin}/v1`;
+
+    const manifest = asObject(await runSlack(['manifest']));
+
+    expect(manifest.webhook_url).toBe(`${origin}/v1/webhooks/slack/${PROJECT}`);
+    expect(String(manifest.webhook_url)).not.toContain('/v1/v1/');
+  });
+
   test('falls back to legacy slack only while the reserved channel connector rolls out', async () => {
     world.reservedFailure = 'action_not_found';
     const out = asObject(await runSlack(['thread', '--channel', 'C1', '--ts', '111.222']));

--- a/apps/api/src/__tests__/integration-executor-catalog-inherit-unbound.test.ts
+++ b/apps/api/src/__tests__/integration-executor-catalog-inherit-unbound.test.ts
@@ -1,26 +1,11 @@
 /**
- * Regression: `kortix executor connectors` / `kortix executor call` returned an
- * EMPTY catalog (and `connector_not_found`) for sessions created with
- * `connector_bindings` set but `inherit_unbound` absent.
+ * Regression for the Executor catalog/call profile-resolution contract.
  *
- * Root cause: `resolveSessionConnectorProfile` returns `null` for every alias
- * with NO explicit binding when the session has
- * `connector_bindings_configured = true` AND `connector_bindings_inherit_unbound
- * = false` (session-connector-bindings.ts:806). The create path defaulted an
- * ABSENT `inherit_unbound` to `false`, so any caller that sent
- * `connector_bindings: {...}` without `inherit_unbound` hid every unbound
- * connector. `listCatalog` (db-deps.ts) then filtered all those nulls away.
- *
- * Two-layer fix, both exercised here:
- *  1. sessions.ts: an ABSENT `inherit_unbound` now defaults to `true` — only an
- *     EXPLICIT `inherit_unbound: false` opts into fail-closed (the composer's
- *     "I picked these specific connections, turn the others off" signal).
- *  2. db-deps.ts `listCatalog`: a SAFETY NET for sessions created before the
- *     create-path default fix — when the primary resolution returns null, fall
- *     back to the PROJECT DEFAULT profile for aliases with NO durable binding
- *     row. A present-but-revoked binding still fails closed (the security
- *     invariant): the safety net never runs for a connector that HAS a
- *     binding row.
+ * `connector_bindings_configured = true` with `inherit_unbound = false` is an
+ * explicit fail-closed session scope. The catalog and call resolver must both
+ * hide every unbound alias. An earlier catalog-only safety net bypassed that
+ * stored scope, so discovery advertised project-default connectors while every
+ * call returned `connector_not_found`.
  *
  * Real-Postgres tenant contract — run with DATABASE_URL pointed at an isolated
  * migrated database (mirrors integration-session-connector-profiles.test.ts).
@@ -37,6 +22,7 @@ import {
 } from '@kortix/db';
 import { eq } from 'drizzle-orm';
 import { dbExecutorRouterDeps } from '../executor/db-deps';
+import { createExecutorRouter } from '../executor/router';
 import {
   resolveProjectDefaultConnectorProfile,
   resolveSessionConnectorProfile,
@@ -58,9 +44,10 @@ const PROFILE_UNBOUND_MEMBER = crypto.randomUUID();
 const PROFILE_REVOKED_DEFAULT = crypto.randomUUID();
 const PROFILE_REVOKED_MEMBER = crypto.randomUUID();
 
-// The bug-condition session: bindings configured, inherit_unbound FALSE, binds
-// only veyris. Pre-fix this emptied the catalog.
+// A partial explicit fail-closed scope. Only veyris remains callable.
 const SESSION_BUG = crypto.randomUUID();
+// Exact production incident shape: explicit fail-closed scope with zero rows.
+const SESSION_EMPTY = crypto.randomUUID();
 // The fixed create-path default: bindings configured, inherit_unbound TRUE
 // (what an ABSENT inherit_unbound now becomes), binds only veyris.
 const SESSION_INHERIT = crypto.randomUUID();
@@ -214,6 +201,16 @@ beforeAll(async () => {
   ]);
   await db.insert(projectSessions).values([
     {
+      sessionId: SESSION_EMPTY,
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      branchName: SESSION_EMPTY,
+      createdBy: USER,
+      visibility: 'private',
+      connectorBindingsConfigured: true,
+      connectorBindingsInheritUnbound: false,
+    },
+    {
       // The bug condition: configured + NOT inherit_unbound. Only veyris is bound.
       sessionId: SESSION_BUG,
       accountId: ACCOUNT,
@@ -245,9 +242,8 @@ beforeAll(async () => {
       visibility: 'private',
     },
   ]);
-  // SESSION_BUG and SESSION_INHERIT both bind veyris (to USER's member profile)
-  // AND bind `revoked` to a member profile that we then REVOKE below — proving
-  // the safety net never resurrects a present-but-revoked binding.
+  // SESSION_BUG and SESSION_INHERIT both bind veyris to USER's member profile.
+  // SESSION_BUG also binds `revoked` to a profile that is revoked below.
   await db.insert(projectSessionConnectorBindings).values([
     {
       sessionId: SESSION_BUG,
@@ -306,48 +302,61 @@ afterAll(async () => {
   await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT));
 });
 
-describe('executor catalog — inherit_unbound safety net', () => {
-  test('the bug condition resolves null for every UNBOUND alias (root-cause reproduction)', async () => {
-    // SESSION_BUG is configured + NOT inherit_unbound. Its unbound alias
-    // (`unbound`, no binding row) resolves to null — that is the line-806 gate,
-    // and it is what emptied the catalog before the safety net.
+describe('executor catalog and call resolver use one session scope', () => {
+  test('an explicit empty scope hides every connector from catalog and calls', async () => {
     const unbound = await resolveSessionConnectorProfile({
       accountId: ACCOUNT,
       projectId: PROJECT,
-      sessionId: SESSION_BUG,
+      sessionId: SESSION_EMPTY,
       alias: 'unbound',
       actingUserId: USER,
     });
     expect(unbound).toBeNull();
+
+    const catalog = await dbExecutorRouterDeps.listCatalog(principalFor(SESSION_EMPTY));
+    expect(catalog).toEqual([]);
+
+    const deps = dbExecutorRouterDeps.makeGatewayDeps(principalFor(SESSION_EMPTY));
+    expect(await deps.loadConnectorBySlug(PROJECT, 'unbound')).toBeNull();
   });
 
-  test('the safety net surfaces the project default for an UNBOUND alias on a pre-fix session', async () => {
-    // The catalog for SESSION_BUG must NOT be empty: the `unbound` connector
-    // has no binding row, so the safety net falls back to its project-default
-    // profile. `veyris` (bound + connected) is listed too. `revoked` (bound but
-    // revoked) is NOT listed — the safety net never runs for a connector that
-    // HAS a binding row, so the revoked binding fails closed.
+  test('the real project-explicit HTTP routes expose the same empty scope', async () => {
+    const principal = principalFor(SESSION_EMPTY);
+    const app = createExecutorRouter({
+      ...dbExecutorRouterDeps,
+      resolvePrincipal: async () => principal,
+      resolveProjectPrincipal: async (_c, projectId) => (projectId === PROJECT ? principal : null),
+    });
+
+    const catalogResponse = await app.request(`/projects/${PROJECT}/catalog`);
+    expect(catalogResponse.status).toBe(200);
+    expect(await catalogResponse.json()).toEqual({ connectors: [] });
+
+    const callResponse = await app.request(`/projects/${PROJECT}/call`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ connector: 'unbound', action: 'read', args: {} }),
+    });
+    expect(callResponse.status).toBe(404);
+    expect(await callResponse.json()).toEqual({
+      ok: false,
+      status: 'denied',
+      reason: 'connector_not_found',
+    });
+  });
+
+  test('a partial fail-closed scope exposes only its active explicit binding', async () => {
     const catalog = await dbExecutorRouterDeps.listCatalog(principalFor(SESSION_BUG));
     const slugs = catalog.map((c) => c.slug).sort();
-    expect(slugs).toEqual(['unbound', 'veyris']);
-    expect(slugs).not.toContain('revoked');
-  });
+    expect(slugs).toEqual(['veyris']);
 
-  test('the explicit-binding still wins over the safety-net project default', async () => {
-    // SESSION_BUG binds veyris to PROFILE_BOUND_MEMBER. The catalog must reflect
-    // the bound profile, not the project default — the safety net only runs
-    // when the PRIMARY resolution returns null, and a connected binding does
-    // not. Load the gateway connector to confirm the resolved profile id.
     const deps = dbExecutorRouterDeps.makeGatewayDeps(principalFor(SESSION_BUG));
     const conn = await deps.loadConnectorBySlug(PROJECT, 'veyris');
     expect(conn?.profileId).toBe(PROFILE_BOUND_MEMBER);
+    expect(await deps.loadConnectorBySlug(PROJECT, 'unbound')).toBeNull();
   });
 
   test('a present-but-REVOKED binding fails closed (the safety net does not resurrect it)', async () => {
-    // `revoked` has a binding row on SESSION_BUG pointing at a REVOKED profile.
-    // The primary resolution returns null (revoked), and because the connector
-    // HAS a durable binding, the safety net does NOT run — it stays null. This
-    // is the security invariant from session-connector-bindings.ts:669-671.
     const revoked = await resolveSessionConnectorProfile({
       accountId: ACCOUNT,
       projectId: PROJECT,
@@ -363,9 +372,8 @@ describe('executor catalog — inherit_unbound safety net', () => {
       alias: 'revoked',
       actingUserId: USER,
     });
-    // The project default DOES exist for `revoked` (a separate default profile) —
-    // proving the catalog omits it because of the binding-row guard, not because
-    // there is no fallback available.
+    // A different active project default exists. The explicit revoked binding
+    // still fails closed instead of falling through to it.
     expect(projectDefault?.profileId).toBe(PROFILE_REVOKED_DEFAULT);
 
     const catalog = await dbExecutorRouterDeps.listCatalog(principalFor(SESSION_BUG));
@@ -373,11 +381,6 @@ describe('executor catalog — inherit_unbound safety net', () => {
   });
 
   test('the fixed create-path default (inherit_unbound=true) lists unbound aliases without the safety net', async () => {
-    // SESSION_INHERIT is configured + inherit_unbound=true (what an ABSENT
-    // inherit_unbound now defaults to). Its unbound alias resolves directly via
-    // the project-default branch — no safety net needed. Every connected
-    // connector lists (the bound one via its binding, the unbound ones via the
-    // project default).
     const unbound = await resolveSessionConnectorProfile({
       accountId: ACCOUNT,
       projectId: PROJECT,
@@ -390,6 +393,11 @@ describe('executor catalog — inherit_unbound safety net', () => {
     const catalog = await dbExecutorRouterDeps.listCatalog(principalFor(SESSION_INHERIT));
     const slugs = catalog.map((c) => c.slug).sort();
     expect(slugs).toEqual(['revoked', 'unbound', 'veyris']);
+
+    const deps = dbExecutorRouterDeps.makeGatewayDeps(principalFor(SESSION_INHERIT));
+    expect((await deps.loadConnectorBySlug(PROJECT, 'unbound'))?.profileId).toBe(
+      PROFILE_UNBOUND_MEMBER,
+    );
   });
 
   test('a legacy session with no bindings configured lists every connected connector', async () => {
@@ -400,5 +408,10 @@ describe('executor catalog — inherit_unbound safety net', () => {
     // `revoked`'s member profile is revoked, but its DEFAULT profile is active
     // and connected, so a legacy session sees it via the project default.
     expect(slugs).toEqual(['revoked', 'unbound', 'veyris']);
+
+    const deps = dbExecutorRouterDeps.makeGatewayDeps(principalFor(SESSION_LEGACY));
+    expect((await deps.loadConnectorBySlug(PROJECT, 'unbound'))?.profileId).toBe(
+      PROFILE_UNBOUND_MEMBER,
+    );
   });
 });

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -6,7 +6,6 @@ import {
   executorExecutions,
   executorProjectPolicies,
   executorProjectSettings,
-  projectSessionConnectorBindings,
   projectSessions,
   projects,
 } from '@kortix/db';
@@ -57,7 +56,6 @@ import { connectorAuthorizationMatchesStrategy } from '../projects/lib/connector
 import {
   canonicalConnectorAlias,
   publicConnectorAlias,
-  resolveProjectDefaultConnectorProfile,
   resolveSessionConnectorProfile,
 } from '../projects/lib/session-connector-bindings';
 import { validateAccountToken } from '../repositories/account-tokens';
@@ -386,6 +384,24 @@ function toGatewayConnector(
   };
 }
 
+/**
+ * Resolve the one active connector profile this principal may use.
+ *
+ * Catalog discovery and call execution must use this same function. A session
+ * with an explicit fail-closed scope cannot advertise a project-default profile
+ * in the catalog and then lose it when the gateway resolves the call.
+ */
+async function resolveActiveConnectorProfile(principal: ExecutorPrincipal, row: ConnectorRow) {
+  const profile = await resolveSessionConnectorProfile({
+    accountId: principal.accountId,
+    projectId: row.projectId,
+    sessionId: principal.sessionId,
+    alias: row.slug,
+    actingUserId: principal.userId,
+  });
+  return profile?.status === 'active' ? profile : null;
+}
+
 const nodeFetch: FetchImpl = async (url, init) => {
   const res = await fetch(url, {
     method: init.method,
@@ -406,14 +422,8 @@ export function makeDbGatewayDeps(principal: ExecutorPrincipal): GatewayDeps {
         .where(and(eq(executorConnectors.projectId, projectId), eq(executorConnectors.slug, slug)))
         .limit(1);
       if (!row) return null;
-      const profile = await resolveSessionConnectorProfile({
-        accountId: principal.accountId,
-        projectId,
-        sessionId: principal.sessionId,
-        alias: slug,
-        actingUserId: principal.userId,
-      });
-      if (!profile || profile.status !== 'active') return null;
+      const profile = await resolveActiveConnectorProfile(principal, row);
+      if (!profile) return null;
       return toGatewayConnector(row, profile);
     },
     loadAction: async (connectorId, relPath) => {
@@ -878,22 +888,6 @@ async function listCatalog(p: ExecutorPrincipal): Promise<CatalogConnector[]> {
     loadDefaultModeFor(p.projectId),
   ]);
 
-  // SAFETY NET — the durable binding aliases this session has explicitly bound.
-  // A session created before the create-path `inherit_unbound` default fix
-  // (absent → `false`) with `connector_bindings` set would have
-  // `connector_bindings_configured = true, inherit_unbound = false`, and
-  // `resolveSessionConnectorProfile` returns null for EVERY unbound alias,
-  // emptying the catalog. For those, we fall back to the PROJECT DEFAULT
-  // profile — but ONLY for aliases with NO durable binding row. A present
-  // binding that resolves to null because it is revoked/error/strategy-
-  // mismatched still fails closed (the security invariant: a present but
-  // revoked/error binding never falls through to a project default). Loading
-  // the bound-alias set once here keeps the per-connector fallback a cheap
-  // set lookup rather than an extra query per connector.
-  const boundAliases: Set<string> | null = p.sessionId
-    ? await loadSessionBoundAliases(p.accountId, p.projectId, p.sessionId)
-    : null;
-
   const out: CatalogConnector[] = [];
   for (const row of conns) {
     // Per-agent assignment: an agent only sees connectors its grant lists —
@@ -902,30 +896,8 @@ async function listCatalog(p: ExecutorPrincipal): Promise<CatalogConnector[]> {
     // every human with project access (no per-connector member scoping).
     // Canonical on both sides — the grant is canonicalized at construction.
     if (!agentMayUseConnector(p.agentGrant ?? null, canonicalConnectorAlias(row.slug))) continue;
-    let profile = await resolveSessionConnectorProfile({
-      accountId: p.accountId,
-      projectId: p.projectId,
-      sessionId: p.sessionId,
-      alias: row.slug,
-      actingUserId: p.userId,
-    });
-    // Safety net: a pre-fix session (configured + not-inherit-unbound) hides
-    // unbound aliases. For an alias with NO durable binding, fall back to the
-    // project default so the catalog isn't empty. An alias WITH a binding that
-    // resolved null stays null (revoked/error fails closed).
-    if ((!profile || profile.status !== 'active') && boundAliases !== null) {
-      const alias = canonicalConnectorAlias(row.slug);
-      if (!boundAliases.has(alias)) {
-        const fallback = await resolveProjectDefaultConnectorProfile({
-          accountId: p.accountId,
-          projectId: p.projectId,
-          alias: row.slug,
-          actingUserId: p.userId,
-        });
-        if (fallback && fallback.status === 'active') profile = fallback;
-      }
-    }
-    if (!profile || profile.status !== 'active') continue;
+    const profile = await resolveActiveConnectorProfile(p, row);
+    if (!profile) continue;
     const { hasAuth } = authOf(row);
     if (hasAuth) {
       // Always the shared credential — `per_user` was removed 2026-07-05.
@@ -964,31 +936,6 @@ async function listCatalog(p: ExecutorPrincipal): Promise<CatalogConnector[]> {
     });
   }
   return out;
-}
-
-/**
- * The canonical aliases a session has explicitly bound (durable
- * `project_session_connector_bindings` rows). Used by `listCatalog`'s safety
- * net to distinguish "no binding → fall back to project default" from
- * "present-but-null binding → fail closed". Returns null only when there is
- * no session in scope.
- */
-async function loadSessionBoundAliases(
-  accountId: string,
-  projectId: string,
-  sessionId: string,
-): Promise<Set<string>> {
-  const rows = await db
-    .select({ alias: projectSessionConnectorBindings.connectorAlias })
-    .from(projectSessionConnectorBindings)
-    .where(
-      and(
-        eq(projectSessionConnectorBindings.sessionId, sessionId),
-        eq(projectSessionConnectorBindings.accountId, accountId),
-        eq(projectSessionConnectorBindings.projectId, projectId),
-      ),
-    );
-  return new Set(rows.map((r) => canonicalConnectorAlias(r.alias)));
 }
 
 async function resolveProjectUserWith(

--- a/apps/api/src/projects/lib/session-connector-bindings.ts
+++ b/apps/api/src/projects/lib/session-connector-bindings.ts
@@ -834,13 +834,10 @@ export async function resolveSessionConnectorProfile(input: {
  * authorization strategy, the session's visibility, and is actually
  * connected, and stamps it `source: 'default'`.
  *
- * Extracted from `resolveSessionConnectorProfile` so the Executor catalog can
- * apply it as a SAFETY NET: a session created before the create-path default
- * fix (`inherit_unbound` absent → `false`) would otherwise hide every unbound
- * connector. Listing falls back to the project default for aliases with NO
- * durable session binding — a present-but-revoked binding still fails closed
- * (the catalog safety net never runs for a connector that HAS a binding row;
- * see `listCatalog` in db-deps.ts).
+ * Kept separate from `resolveSessionConnectorProfile` so callers that need the
+ * project default can resolve it directly. Executor discovery and execution do
+ * not call this helper. They use `resolveSessionConnectorProfile`, which also
+ * enforces the stored session scope.
  */
 export async function resolveProjectDefaultConnectorProfile(input: {
   accountId: string;

--- a/apps/cli/src/__tests__/channels.test.ts
+++ b/apps/cli/src/__tests__/channels.test.ts
@@ -58,7 +58,7 @@ let state: MockState;
 let installationGets = 0;
 let teamsInstall: typeof TEAMS_INSTALLATION | null = null;
 
-function writeConfig(): void {
+function writeConfig(url = 'https://api.test'): void {
   const file = join(tmp, 'config.json');
   writeFileSync(
     file,
@@ -66,7 +66,7 @@ function writeConfig(): void {
       active: 'test',
       hosts: {
         test: {
-          url: 'https://api.test',
+          url,
           token: 'tok_test',
           user_id: 'user_1',
           user_email: 'user@example.test',
@@ -271,6 +271,18 @@ describe('kortix channels status', () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.connected).toBe(true);
     expect(parsed.installation.workspaceId).toBe('T012AB3CD');
+  });
+
+  test('prints one /v1 mount when the configured host already includes /v1', async () => {
+    writeConfig('https://api.test/v1');
+    state.installation = INSTALLATION;
+
+    const code = await runChannels(['status']);
+
+    expect(code).toBe(0);
+    const out = stripAnsi(stdout);
+    expect(out).toContain('https://api.test/v1/webhooks/slack/proj_1');
+    expect(out).not.toContain('/v1/v1/');
   });
 });
 

--- a/apps/cli/src/commands/channels.ts
+++ b/apps/cli/src/commands/channels.ts
@@ -336,9 +336,13 @@ async function connectManual(ctx: ProjectCtx, opts: ConnectOpts): Promise<number
   return 0;
 }
 
+function apiV1Base(url: string): string {
+  return `${url.trim().replace(/\/+$/, '').replace(/\/v1$/, '')}/v1`;
+}
+
 function printInstall(ctx: ProjectCtx, install: SlackInstallation, headline: string): void {
   const name = install.workspaceName ?? install.workspaceId;
-  const webhookUrl = `${ctx.client.apiBase.replace(/\/$/, '')}/v1/webhooks/slack/${ctx.projectId}`;
+  const webhookUrl = `${apiV1Base(ctx.client.apiBase)}/webhooks/slack/${ctx.projectId}`;
   process.stdout.write(
     `${headline}  ${C.bold}${name}${C.reset}\n` +
       `         team       ${C.dim}${install.workspaceId}${C.reset}\n` +
@@ -367,8 +371,7 @@ async function channelsManifest(
   const ctx = await resolveProjectContext(ctxOpts);
   if (!ctx) return 1;
 
-  const baseUrl = ctx.client.apiBase.replace(/\/$/, '');
-  const requestUrl = `${baseUrl}/v1/webhooks/slack/${ctx.projectId}`;
+  const requestUrl = `${apiV1Base(ctx.client.apiBase)}/webhooks/slack/${ctx.projectId}`;
 
   const manifest = {
     display_information: {

--- a/apps/sandbox/slack-cli/channels/slack.ts
+++ b/apps/sandbox/slack-cli/channels/slack.ts
@@ -399,7 +399,10 @@ async function manifest(opts: { url?: string; projectId?: string; name?: string 
   if (opts.name) params.name = opts.name;
   const m = await kortixGet<unknown>(`/webhooks/slack/${projectId}/manifest`, params);
 
-  const publicUrl = (opts.url || getEnv('KORTIX_API_URL') || '').replace(/\/$/, '');
+  const publicUrl = (opts.url || getEnv('KORTIX_API_URL') || '')
+    .trim()
+    .replace(/\/+$/, '')
+    .replace(/\/v1$/, '');
   const webhookUrl = publicUrl ? `${publicUrl}/v1/webhooks/slack/${projectId}` : undefined;
   return { ok: true, manifest: m, webhook_url: webhookUrl };
 }


### PR DESCRIPTION
## Root cause

An explicit empty session connector scope is fail-closed by design. The call resolver enforced that scope. The catalog added a project-default fallback and advertised connectors the session could not call.

## Fix

- Resolve catalog and call profiles through the same session-scoped resolver.
- Preserve explicit empty and partial fail-closed scopes.
- Normalize Slack webhook URLs when the API base already ends in `/v1`.
- Add real-Postgres, HTTP-route, CLI, and sandbox CLI regression coverage.

## Verification

- API focused suite: 137 pass, 0 fail
- CLI focused suite: 21 pass, 0 fail
- API typecheck: pass
- CLI typecheck: pass
- CLI SDK boundary: 0 violations
- Real local HTTP: project control catalog lists `scope_probe`; explicit empty scope returns an empty catalog; forced call returns 404 `connector_not_found`
