### PR TITLE
fix(billing): decouple enterprise entitlements from per-seat billing tier

### DIFF
--- a/apps/api/src/__tests__/billing/e2e-per-seat-webhooks.test.ts
+++ b/apps/api/src/__tests__/billing/e2e-per-seat-webhooks.test.ts
@@ -354,4 +354,167 @@ describe('legacy → per-seat adoption (regression)', () => {
     // Second delivery short-circuits before any reconciliation.
     expect(grantCreditsCalls.length).toBe(1);
   });
+
+  // ── Enterprise + per-seat coexistence (contract-readiness regression) ──────
+  //
+  // A deal that is BOTH Enterprise (entitlements) AND per-seat (billing) — a
+  // flat Enterprise fee plus per-seat billing with pooled per-seat credits —
+  // must hold both at once. The previous webhook
+  // reconciliation unconditionally set `updates.tier = 'per_seat'` on any
+  // per-seat subscription item (webhooks.ts syncSubscriptionState), which
+  // clobbered a sales-assigned `tier='enterprise'` (or an
+  // `enterprise_entitled` account) on the very first per-seat webhook AND on
+  // every subsequent seat-quantity update, silently stripping SSO/SCIM/RBAC/
+  // audit. These tests lock the fix: the per-seat billing semantics
+  // (billing_model, seatCount, seat grant) are still reconciled, but `tier` is
+  // left untouched so the enterprise identity entitlements (sourced from
+  // `tier='enterprise'` or `enterprise_entitled`) survive.
+  describe('enterprise + per-seat coexistence — tier not clobbered', () => {
+    test('enterprise_entitled=true + per-seat sub update → billing_model reconciled, tier NOT set to per_seat', async () => {
+      // The contracted shape: enterprise entitlements (via flag)
+      // + a per-seat Stripe subscription. An ordinary seat-quantity update lands.
+      mockRegistry.getCreditAccount = async () =>
+        createMockCreditAccount({
+          tier: 'enterprise',
+          enterpriseEntitled: true,
+          billingModel: 'per_seat',
+          seatCount: 2,
+          seatSubscriptionItemId: 'si_seat_123',
+          stripeSubscriptionId: 'sub_seat_123',
+          autoTopupCustomized: true,
+        });
+
+      // Webhook fires for a seat-count change 2 → 4 — the ordinary update path
+      // that used to strip enterprise entitlements.
+      const sub = perSeatSubscription(4);
+      const event = createMockStripeEvent('customer.subscription.updated', sub);
+
+      await processStripeWebhook(JSON.stringify(event), 'whsec_test');
+
+      const persisted = [...updateCalls, ...upsertCalls.map((u) => ({ accountId: u.accountId, data: u.data }))]
+        .find((c) => c.data.seatCount !== undefined);
+      expect(persisted).toBeDefined();
+      // Per-seat billing semantics ARE reconciled:
+      expect(persisted?.data.billingModel).toBe('per_seat');
+      expect(persisted?.data.seatCount).toBe(4);
+      expect(persisted?.data.seatSubscriptionItemId).toBe('si_seat_123');
+      // But tier is NOT clobbered to 'per_seat' — the key fix. The update must
+      // not carry a `tier` write at all (enterprise tier is preserved).
+      expect(persisted?.data.tier).toBeUndefined();
+    });
+
+    test('enterprise_entitled=true + per-seat sub update → seat grant still emitted (delta funded)', async () => {
+      // The no-clobber guard must not break the per-seat credit grant: a
+      // seat-count increase still funds the new seats from the pooled wallet.
+      mockRegistry.getCreditAccount = async () =>
+        createMockCreditAccount({
+          tier: 'enterprise',
+          enterpriseEntitled: true,
+          billingModel: 'per_seat',
+          seatCount: 2,
+          seatSubscriptionItemId: 'si_seat_123',
+          stripeSubscriptionId: 'sub_seat_123',
+          autoTopupCustomized: true,
+        });
+
+      const sub = perSeatSubscription(5); // +3 seats
+      const event = createMockStripeEvent('customer.subscription.updated', sub);
+
+      await processStripeWebhook(JSON.stringify(event), 'whsec_test');
+
+      // Delta = 5 - 2 = 3 seats → grant $75 (INCLUDED_CREDITS_PER_SEAT_USD $25 × 3).
+      expect(grantCreditsCalls.length).toBe(1);
+      const [, amount, type, , , idempotencyKey] = grantCreditsCalls[0];
+      expect(amount).toBe(75);
+      expect(type).toBe('seat_grant');
+      expect(String(idempotencyKey)).toContain(':seats:');
+      expect(String(idempotencyKey).endsWith(':5')).toBe(true);
+    });
+
+    test('tier=enterprise (no flag) + per-seat sub update → tier NOT clobbered', async () => {
+      // The legacy sales-assigned path (tier='enterprise' without the new flag)
+      // must also be protected — the guard keys off tier='enterprise' too.
+      mockRegistry.getCreditAccount = async () =>
+        createMockCreditAccount({
+          tier: 'enterprise',
+          enterpriseEntitled: false,
+          billingModel: 'per_seat',
+          seatCount: 1,
+          seatSubscriptionItemId: 'si_seat_123',
+          stripeSubscriptionId: 'sub_seat_123',
+          autoTopupCustomized: true,
+        });
+
+      const sub = perSeatSubscription(3);
+      const event = createMockStripeEvent('customer.subscription.updated', sub);
+
+      await processStripeWebhook(JSON.stringify(event), 'whsec_test');
+
+      const persisted = [...updateCalls, ...upsertCalls.map((u) => ({ accountId: u.accountId, data: u.data }))]
+        .find((c) => c.data.seatCount !== undefined);
+      expect(persisted).toBeDefined();
+      expect(persisted?.data.billingModel).toBe('per_seat');
+      expect(persisted?.data.seatCount).toBe(3);
+      expect(persisted?.data.tier).toBeUndefined();
+    });
+
+    test('non-enterprise per-seat account → tier still set to per_seat (unchanged behaviour)', async () => {
+      // The guard must NOT change behaviour for ordinary per-seat accounts
+      // (no enterprise entitlement): tier='per_seat' is still written, exactly
+      // as before. This is the regression guard for the common case.
+      mockRegistry.getCreditAccount = async () =>
+        createMockCreditAccount({
+          tier: 'free',
+          enterpriseEntitled: false,
+          billingModel: 'per_seat',
+          seatCount: 1,
+          seatSubscriptionItemId: 'si_seat_123',
+          stripeSubscriptionId: 'sub_seat_123',
+          autoTopupCustomized: true,
+        });
+
+      const sub = perSeatSubscription(3);
+      const event = createMockStripeEvent('customer.subscription.updated', sub);
+
+      await processStripeWebhook(JSON.stringify(event), 'whsec_test');
+
+      const persisted = [...updateCalls, ...upsertCalls.map((u) => ({ accountId: u.accountId, data: u.data }))]
+        .find((c) => c.data.seatCount !== undefined);
+      expect(persisted).toBeDefined();
+      expect(persisted?.data.billingModel).toBe('per_seat');
+      expect(persisted?.data.seatCount).toBe(3);
+      // tier IS clobbered to per_seat for ordinary accounts — unchanged.
+      expect(persisted?.data.tier).toBe('per_seat');
+    });
+
+    test('enterprise_entitled=true, no existing per-seat → first per-seat webhook still does NOT set tier', async () => {
+      // An operator flags the account enterprise_entitled at sign-up (tier is
+      // still 'free', no per-seat sub yet). The customer then buys a per-seat
+      // subscription. The activation webhook must adopt the sub + reconcile
+      // billing, but NOT flip tier to per_seat.
+      mockRegistry.getCreditAccount = async () =>
+        createMockCreditAccount({
+          tier: 'free',
+          enterpriseEntitled: true,
+          billingModel: 'legacy',
+          seatCount: 0,
+          stripeSubscriptionId: null,
+          autoTopupCustomized: false,
+        });
+
+      const sub = perSeatSubscription(2);
+      const event = createMockStripeEvent('customer.subscription.created', sub);
+
+      await processStripeWebhook(JSON.stringify(event), 'whsec_test');
+
+      const persisted = [...updateCalls, ...upsertCalls.map((u) => ({ accountId: u.accountId, data: u.data }))]
+        .find((c) => c.data.billingModel === 'per_seat');
+      expect(persisted).toBeDefined();
+      expect(persisted?.data.billingModel).toBe('per_seat');
+      expect(persisted?.data.seatCount).toBe(2);
+      // The free → per_seat activation must NOT clobber tier for an
+      // enterprise-entitled account; entitlements stay sourced from the flag.
+      expect(persisted?.data.tier).toBeUndefined();
+    });
+  });
 });

--- a/apps/api/src/__tests__/billing/mocks.ts
+++ b/apps/api/src/__tests__/billing/mocks.ts
@@ -264,6 +264,11 @@ export function createMockCreditAccount(overrides: Record<string, any> = {}) {
     lastRenewalPeriodStart: null,
     paymentStatus: 'active',
     lastPaymentFailure: null,
+    // Enterprise entitlement overrides — default off so existing per-seat/legacy
+    // tests are unaffected; per-seat webhook tests can override to assert the
+    // no-clobber guard for enterprise-entitled accounts.
+    enterpriseEntitled: false,
+    demoEnterprise: false,
     revenuecatCustomerId: null,
     revenuecatSubscriptionId: null,
     revenuecatCancelledAt: null,

--- a/apps/api/src/__tests__/unit-entitlements-enterprise-entitled.test.ts
+++ b/apps/api/src/__tests__/unit-entitlements-enterprise-entitled.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+// `enterprise_entitled` is the per-account, contracted-cloud Enterprise flag:
+// when true the account resolves ALL enterprise entitlements (SAML SSO, SCIM,
+// RBAC, audit access) regardless of its billing `tier`. This is the seam that
+// lets a deal which is BOTH Enterprise (entitlements) AND per-seat (billing)
+// hold both at once — `tier`/`billing_model` can be `per_seat` for Stripe seat
+// reconciliation while `enterprise_entitled=true` keeps the identity surface on.
+// Without it the per-seat Stripe webhook reconciliation clobbers `tier` to
+// `per_seat` and strips SSO/SCIM/RBAC/audit on every ordinary subscription
+// update. These invariants ARE the contract's access-control policy — the IAM
+// route guards (requireEntitlement) and the SCIM data-plane middleware both
+// call accountHasEntitlement / getAccountEntitlements.
+
+// Stub the credit-account repo before loading the resolver, so we exercise the
+// enterprise_entitled override branch without a database. `fakeRow` stands in
+// for the row that getCreditAccount() would return.
+let fakeRow:
+  | { tier?: string; enterpriseEntitled?: boolean; demoEnterprise?: boolean }
+  | null = null;
+mock.module('../billing/repositories/credit-accounts', () => ({
+  getCreditAccount: async () => fakeRow,
+}));
+
+// Self-host ENTERPRISE_LICENSE_AVAILABLE bypass — a getter so each test can
+// flip it without re-mocking the module. Everything else entitlements.ts might
+// read from config stays absent; it only ever touches this one field.
+let enterpriseLicenseAvailable = false;
+mock.module('../config', () => ({
+  config: {
+    get ENTERPRISE_LICENSE_AVAILABLE() {
+      return enterpriseLicenseAvailable;
+    },
+  },
+}));
+
+const { accountHasEntitlement, getAccountEntitlements } = await import(
+  '../billing/services/entitlements'
+);
+
+// The contracted-Enterprise flag must unlock the ENTIRE enterprise surface
+// regardless of billing tier, stay fail-closed when off / unprovisioned, never
+// suppress a genuine `tier='enterprise'`, and coexist with the self-serve demo
+// flag. Resolution order: license → enterprise_entitled → demo_enterprise → tier.
+describe('enterprise_entitled — contracted cloud Enterprise override', () => {
+  test('flag on → every entitlement unlocked even when billing tier is per_seat', async () => {
+    // The contracted shape: enterprise entitlements + per-seat billing.
+    fakeRow = { tier: 'per_seat', enterpriseEntitled: true, demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(true);
+    expect(await accountHasEntitlement('acct', 'scim')).toBe(true);
+    expect(await accountHasEntitlement('acct', 'rbac')).toBe(true);
+    expect(await accountHasEntitlement('acct', 'auditAccess')).toBe(true);
+    const ent = await getAccountEntitlements('acct');
+    expect(ent).toEqual({ sso: true, scim: true, rbac: true, auditAccess: true });
+  });
+
+  test('flag on → every entitlement unlocked even when billing tier is free', async () => {
+    // An operator can flag the account at sign-up before any subscription exists.
+    fakeRow = { tier: 'free', enterpriseEntitled: true, demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(true);
+    expect((await getAccountEntitlements('acct')).scim).toBe(true);
+  });
+
+  test('flag off → falls back to tier gating (per_seat is fully gated)', async () => {
+    fakeRow = { tier: 'per_seat', enterpriseEntitled: false, demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(false);
+    expect((await getAccountEntitlements('acct')).sso).toBe(false);
+    expect((await getAccountEntitlements('acct')).scim).toBe(false);
+  });
+
+  test('no billing row → fail closed', async () => {
+    fakeRow = null;
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(false);
+    expect((await getAccountEntitlements('acct')).scim).toBe(false);
+  });
+
+  test('genuine enterprise tier still unlocks without the flag', async () => {
+    // The legacy sales-assigned path (tier='enterprise') is untouched.
+    fakeRow = { tier: 'enterprise', enterpriseEntitled: false, demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(true);
+    expect((await getAccountEntitlements('acct')).scim).toBe(true);
+  });
+
+  test('flag on + demo on → still unlocked (flag is a superset; no conflict)', async () => {
+    fakeRow = { tier: 'per_seat', enterpriseEntitled: true, demoEnterprise: true };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(true);
+    expect((await getAccountEntitlements('acct')).auditAccess).toBe(true);
+  });
+
+  test('flag on + tier=enterprise → still unlocked (both sources agree)', async () => {
+    fakeRow = { tier: 'enterprise', enterpriseEntitled: true, demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'rbac')).toBe(true);
+  });
+});
+
+// Resolution order: ENTERPRISE_LICENSE_AVAILABLE takes precedence over the
+// per-account flag (a licensed self-host operator never needs to also flip the
+// per-account flag), which in turn takes precedence over demo_enterprise, which
+// takes precedence over the billing tier.
+describe('enterprise_entitled resolution order vs license / demo / tier', () => {
+  afterEach(() => {
+    enterpriseLicenseAvailable = false;
+  });
+
+  test('license on → unlocked even when enterprise_entitled is false', async () => {
+    enterpriseLicenseAvailable = true;
+    fakeRow = { tier: 'per_seat', enterpriseEntitled: false, demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(true);
+  });
+
+  test('license on → unlocked even with no billing row', async () => {
+    enterpriseLicenseAvailable = true;
+    fakeRow = null;
+    const ent = await getAccountEntitlements('acct');
+    expect(ent).toEqual({ sso: true, scim: true, rbac: true, auditAccess: true });
+  });
+
+  test('license off, flag on, demo off, tier per_seat → flag wins (entitlements on)', async () => {
+    enterpriseLicenseAvailable = false;
+    fakeRow = { tier: 'per_seat', enterpriseEntitled: true, demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(true);
+  });
+
+  test('license off, flag off, demo on → demo wins (entitlements on)', async () => {
+    enterpriseLicenseAvailable = false;
+    fakeRow = { tier: 'per_seat', enterpriseEntitled: false, demoEnterprise: true };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(true);
+  });
+
+  test('license off, flag off, demo off, tier per_seat → all gated (the bug shape, fixed)', async () => {
+    enterpriseLicenseAvailable = false;
+    fakeRow = { tier: 'per_seat', enterpriseEntitled: false, demoEnterprise: false };
+    expect(await accountHasEntitlement('acct', 'sso')).toBe(false);
+    expect(await accountHasEntitlement('acct', 'scim')).toBe(false);
+    expect(await accountHasEntitlement('acct', 'rbac')).toBe(false);
+    expect(await accountHasEntitlement('acct', 'auditAccess')).toBe(false);
+  });
+});

--- a/apps/api/src/admin/index.ts
+++ b/apps/api/src/admin/index.ts
@@ -493,6 +493,85 @@ adminApp.openapi(
   },
 );
 
+// ── Set account contracted-Enterprise entitlement flag ────────────────────────
+// `enterprise_entitled` decouples a contracted cloud Enterprise customer's
+// feature entitlements (SAML SSO, SCIM, RBAC, audit access) from the billing
+// tier. Set this when an account signs an Enterprise agreement that is ALSO
+// per-seat billed (a flat Enterprise fee plus per-seat billing): the
+// per-seat Stripe webhook reconciliation will then populate
+// billing_model/seats/credits from the subscription WITHOUT clobbering the
+// enterprise identity entitlements (it leaves `tier` untouched when this flag
+// is on). Clear it when the Enterprise term ends. For a pure-Enterprise (no
+// per-seat) deal, `tier='enterprise'` alone is still sufficient; this flag is
+// the additional, independent entitlement source for the hybrid case.
+adminApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/api/accounts/{id}/enterprise-entitlement',
+    tags: ['admin'],
+    summary: "Set the account's contracted-Enterprise entitlement flag",
+    ...auth,
+    request: {
+      params: z.object({ id: z.string() }),
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({ enabled: z.boolean() }),
+          },
+        },
+      },
+    },
+    responses: {
+      200: json(z.object({ ok: z.boolean(), enabled: z.boolean() }), 'Updated entitlement flag'),
+      400: json(z.record(z.string(), z.any()), 'Bad request'),
+      500: json(z.record(z.string(), z.any()), 'Server error'),
+      ...errors(401, 403),
+    },
+  }),
+  async (c: any) => {
+    try {
+      const accountId = c.req.param('id');
+      const actorUserId = c.get('userId') as string | undefined;
+      const body = await c.req.json().catch(() => ({}));
+      const enabled = body.enabled;
+      if (typeof enabled !== 'boolean') {
+        return c.json({ error: 'enabled must be a boolean' }, 400);
+      }
+
+      const {
+        isEnterpriseEntitled,
+        setEnterpriseEntitled,
+      } = await import('../billing/repositories/credit-accounts');
+      const before = await isEnterpriseEntitled(accountId);
+      await setEnterpriseEntitled(accountId, enabled);
+
+      // The per-request entitlement read (SSO/SCIM gates) is uncached and sees
+      // the change immediately; no tier-cache invalidation needed because
+      // enterprise_entitled is resolved independently of the cached tier.
+      try {
+        const { recordAuditEvent } = await import('../shared/audit');
+        await recordAuditEvent({
+          accountId,
+          actorUserId,
+          action: 'admin.account.enterprise_entitlement.set',
+          resourceType: 'credit_account',
+          resourceId: accountId,
+          before: { enterprise_entitled: before },
+          after: { enterprise_entitled: enabled },
+          ip: c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || null,
+          userAgent: c.req.header('user-agent') || null,
+        });
+      } catch {
+        /* audit is best-effort — never block the entitlement change */
+      }
+
+      return c.json({ ok: true, enabled });
+    } catch (e: any) {
+      return c.json({ error: e?.message || String(e) }, 500);
+    }
+  },
+);
+
 // ── Set account concurrent-session override ─────────────────────────────────
 // `null` restores the tier-derived limit. Operators use this route for account
 // policy changes and for bounded end-to-end limit verification.

--- a/apps/api/src/billing/repositories/credit-accounts.ts
+++ b/apps/api/src/billing/repositories/credit-accounts.ts
@@ -37,6 +37,40 @@ export async function setDemoEnterprise(accountId: string, enabled: boolean): Pr
     });
 }
 
+/** Whether the account is flagged as a contracted cloud Enterprise customer.
+ *  When true the account resolves all enterprise entitlements (SSO/SCIM/RBAC/
+ *  audit) regardless of its billing tier — decoupling feature entitlements
+ *  from the commercial billing model. Set by an operator when a contract is
+ *  signed. Distinct from the self-serve demo flag (`isDemoEnterprise`). */
+export async function isEnterpriseEntitled(accountId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ enterpriseEntitled: creditAccounts.enterpriseEntitled })
+    .from(creditAccounts)
+    .where(eq(creditAccounts.accountId, accountId))
+    .limit(1);
+  return row?.enterpriseEntitled ?? false;
+}
+
+/**
+ * Set the contracted-Enterprise entitlement flag. Upserts the credit row so a
+ * brand-new account (no billing row yet) can be flagged at sign-up — all other
+ * columns fall back to their schema defaults (tier 'free', legacy billing, …)
+ * and the Stripe webhook reconciliation will populate billing_model/tier/seat
+ * fields from the customer's subscription without clobbering this entitlement.
+ */
+export async function setEnterpriseEntitled(
+  accountId: string,
+  enabled: boolean,
+): Promise<void> {
+  await db
+    .insert(creditAccounts)
+    .values({ accountId, enterpriseEntitled: enabled })
+    .onConflictDoUpdate({
+      target: creditAccounts.accountId,
+      set: { enterpriseEntitled: enabled, updatedAt: new Date().toISOString() },
+    });
+}
+
 export async function getCreditBalance(accountId: string) {
   const [row] = await db
     .select({

--- a/apps/api/src/billing/services/account-state.ts
+++ b/apps/api/src/billing/services/account-state.ts
@@ -248,6 +248,13 @@ export async function buildMinimalAccountState(accountId: string): Promise<Accou
       entitlements,
     },
     enterprise_license_available: config.ENTERPRISE_LICENSE_AVAILABLE,
+    // Surface the per-account contracted-Enterprise flag so the admin console
+    // and the frontend can distinguish a real Enterprise contract (entitlements
+    // sourced from `enterprise_entitled`, independent of billing tier) from a
+    // self-serve demo or a self-host license. When true, the frontend hides
+    // the self-serve "Enterprise features — Demo" toggle (a real contract
+    // supersedes the demo) and the admin console shows the contract state.
+    enterprise_entitled: !!sub?.enterpriseEntitled,
     models: [],
     auto_topup: autoTopup,
     instances,
@@ -339,6 +346,9 @@ export function buildLocalAccountState(): AccountStateResponse {
       entitlements: getTierEntitlements('free'),
     },
     enterprise_license_available: config.ENTERPRISE_LICENSE_AVAILABLE,
+    // No-DB local mode has no credit_accounts row, so the contracted-Enterprise
+    // flag is false by construction (fail-closed).
+    enterprise_entitled: false,
     models: [],
     auto_topup: {
       enabled: false,

--- a/apps/api/src/billing/services/entitlements.ts
+++ b/apps/api/src/billing/services/entitlements.ts
@@ -69,15 +69,27 @@ export async function getAccountEntitlements(
   // Self-host enterprise license: an operator holding a Kortix Enterprise
   // license unlocks every enterprise entitlement platform-wide, regardless of
   // billing tier — self-host has no Stripe-backed tier to assign 'enterprise'
-  // to. Checked before the per-account demo override so a licensed operator
-  // never needs to also flip the per-account demo toggle.
+  // to. Checked before the per-account overrides so a licensed operator never
+  // needs to also flip a per-account flag.
   if (config.ENTERPRISE_LICENSE_AVAILABLE) return getTierEntitlements('enterprise');
   const acct = prefetchedAccount !== undefined ? prefetchedAccount : await getCreditAccount(accountId);
+  // Contracted cloud Enterprise: an operator sets `enterprise_entitled` when
+  // an account signs an Enterprise agreement. This grants the full enterprise
+  // entitlement set (SSO/SCIM/RBAC/audit) regardless of `tier`, so a deal that
+  // is BOTH Enterprise (entitlements) AND per-seat (billing) can hold both at
+  // once — `tier`/`billing_model` may be `per_seat` for Stripe seat
+  // reconciliation while enterprise identity surfaces stay on. Without this,
+  // the per-seat webhook reconciliation clobbers `tier` to `per_seat` and
+  // strips entitlements on every ordinary subscription update. Distinct from
+  // the demo flag below: this is the real-contract flag, set out-of-band by an
+  // operator at sign-up time.
+  if (acct?.enterpriseEntitled) return getTierEntitlements('enterprise');
   // Demo/dogfood override: an account can self-enable an interactive demo of the
   // enterprise surface from account settings. When on, it unlocks EVERY
   // enterprise entitlement — whatever the `enterprise` tier grants — regardless
   // of billing tier, so gates added later are covered automatically. This is a
-  // preview, NOT a real Enterprise plan (which is sales-assigned).
+  // preview, NOT a real Enterprise plan (which is sales-assigned or set via
+  // `enterprise_entitled`).
   if (acct?.demoEnterprise) return getTierEntitlements('enterprise');
   return getTierEntitlements(acct?.tier ?? 'none');
 }
@@ -89,6 +101,7 @@ export async function accountHasEntitlement(
 ): Promise<boolean> {
   if (config.ENTERPRISE_LICENSE_AVAILABLE) return true;
   const acct = await getCreditAccount(accountId);
+  if (acct?.enterpriseEntitled) return true;
   if (acct?.demoEnterprise) return true;
   return tierHasEntitlement(acct?.tier ?? 'none', key);
 }

--- a/apps/api/src/billing/services/webhooks.ts
+++ b/apps/api/src/billing/services/webhooks.ts
@@ -375,6 +375,22 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
       (perSeatPriceId && item.price?.id === perSeatPriceId) ||
       subscription.metadata?.billing_model === 'per_seat',
   );
+  // Whether this account's enterprise entitlements are sourced independently of
+  // `tier` — either because an operator set `enterprise_entitled` (a contracted
+  // cloud Enterprise deal) or because the account already carries the
+  // sales-assigned `tier='enterprise'`. In either case the per-seat billing
+  // reconciliation below must NOT clobber `tier` to `per_seat`: doing so would
+  // strip the enterprise identity surface (SSO/SCIM/RBAC/audit) on every
+  // ordinary subscription update. The per-seat billing semantics live on
+  // `billing_model='per_seat'` (set unconditionally below), which is the correct
+  // independent carrier — seat grants, auto-topup, and compute metering all key
+  // off `billing_model`, never `tier`. Keeping `tier='enterprise'` (or whatever
+  // the operator set) while `billing_model='per_seat'` is exactly the contract
+  // shape a deal that is BOTH Enterprise AND per-seat needs. See
+  // entitlements.ts (enterprise_entitled override) and the
+  // enterprise-per-seat-entitlement-coupling design note.
+  const accountIsEnterpriseEntitled =
+    !!account && (account.enterpriseEntitled || account.tier === 'enterprise');
   let perSeatDelta = 0;
   let perSeatNewSeats = 0;
   if (perSeatItem) {
@@ -385,7 +401,22 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     updates.billingModel = 'per_seat';
     updates.seatCount = newSeats;
     updates.seatSubscriptionItemId = perSeatItem.id;
-    updates.tier = 'per_seat';
+    // Only flip `tier` to `per_seat` when the account is NOT enterprise-entitled.
+    // For an enterprise-entitled account, `billing_model='per_seat'` already
+    // carries the per-seat billing semantics; leaving `tier` untouched preserves
+    // the enterprise identity entitlements that key off it (or off
+    // `enterprise_entitled`). The previous unconditional `updates.tier =
+    // 'per_seat'` here downgraded a sales-assigned `tier='enterprise'` (or an
+    // `enterprise_entitled` account) on the very first per-seat webhook and on
+    // every subsequent seat-quantity update, silently removing SSO/SCIM/RBAC/audit.
+    if (!accountIsEnterpriseEntitled) {
+      updates.tier = 'per_seat';
+    } else if (updates.tier === 'per_seat') {
+      // `resolvedTier` above may have resolved to 'per_seat' from the price id
+      // before we knew the account was enterprise-entitled. Drop that tier
+      // write so we don't clobber the enterprise tier/entitlements.
+      delete updates.tier;
+    }
 
     // Apply scaled auto-topup defaults if the user hasn't customised them.
     if (!account?.autoTopupCustomized) {

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -220,6 +220,14 @@ export interface AccountStateResponse {
    *  any "Request enterprise access" upsell — there's nothing to demo-enable
    *  or upsell when the license already turned it on unconditionally. */
   enterprise_license_available: boolean;
+  /** True when an operator has flagged this account as a contracted cloud
+   *  Enterprise customer via `credit_accounts.enterprise_entitled`. The
+   *  account then resolves all enterprise entitlements (SSO/SCIM/RBAC/audit)
+   *  regardless of its billing tier, so a deal that is BOTH Enterprise
+   *  (entitlements) AND per-seat (billing) can hold both at once. Surfaced
+   *  for the admin console and for the frontend to hide the self-serve demo
+   *  toggle (a real Enterprise contract supersedes the demo). */
+  enterprise_entitled: boolean;
   /** @deprecated Model gates moved into provider configuration and sandbox model discovery. */
   models: ModelInfo[];
   auto_topup: {

--- a/packages/db/migrations/20260805030712000_enterprise_entitled_flag.sql
+++ b/packages/db/migrations/20260805030712000_enterprise_entitled_flag.sql
@@ -1,0 +1,32 @@
+-- Up Migration
+--
+-- Per-account "enterprise entitled" flag for contracted cloud Enterprise
+-- customers. When true, the account resolves ALL enterprise entitlements
+-- (SAML SSO, SCIM, RBAC, audit access) regardless of its billing tier —
+-- decoupling feature entitlements from the commercial billing model.
+--
+-- WHY. A deal that is BOTH Enterprise (entitlements) AND per-seat (billing) —
+-- e.g. a flat Enterprise fee plus per-seat billing with pooled per-seat
+-- credits — could not previously hold both at once:
+--   - Enterprise entitlements require credit_accounts.tier='enterprise' (the
+--     only tier whose static TierEntitlements are all-true; see tiers.ts).
+--   - Per-seat Stripe webhook reconciliation (webhooks.ts syncSubscriptionState)
+--     unconditionally sets tier='per_seat' on every subscription update for a
+--     per-seat item — clobbering a sales-assigned tier='enterprise' and
+--     stripping SSO/SCIM/RBAC/audit on ordinary subscription updates.
+-- `enterprise_entitled` is an independent, operator-set entitlement source
+-- (mirrors the shape of the existing `demo_enterprise` self-serve demo flag,
+-- but for a real signed contract). tier/billing_model stay free to carry the
+-- billing model the deal needs; the entitlement is no longer coupled to them.
+--
+-- Default false → existing accounts are unaffected and it fails closed. The
+-- admin route (POST /v1/admin/api/accounts/:id/enterprise-entitlement) is the
+-- documented setter, used when a contract is signed.
+
+ALTER TABLE "kortix"."credit_accounts"
+  ADD COLUMN "enterprise_entitled" boolean NOT NULL DEFAULT false;
+
+-- Down Migration
+
+ALTER TABLE "kortix"."credit_accounts"
+  DROP COLUMN "enterprise_entitled";

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -2729,6 +2729,22 @@ export const creditAccounts = kortixSchema.table(
     // the enterprise surface. NOT a real Enterprise plan (sales-assigned);
     // production use requires a signed agreement. Default false → fail-closed.
     demoEnterprise: boolean('demo_enterprise').default(false).notNull(),
+    // Operator-set "enterprise entitled" flag for a contracted cloud Enterprise
+    // customer. When true the account resolves ALL enterprise entitlements
+    // (SAML SSO, SCIM, RBAC, audit) regardless of its billing tier — decoupling
+    // feature entitlements from the billing model. This is what lets a deal
+    // that is BOTH Enterprise (entitlements) AND per-seat (billing) hold both
+    // at once: `tier`/`billing_model` can be `per_seat` for Stripe seat
+    // reconciliation while `enterprise_entitled=true` keeps SSO/SCIM/RBAC/audit
+    // on. Without it, the per-seat Stripe webhook reconciliation clobbers
+    // `tier` to `per_seat` (see webhooks.ts syncSubscriptionState) and strips
+    // the enterprise identity surface on every ordinary subscription update.
+    // Set out-of-band by an operator (admin route / migration), like the
+    // `tier='enterprise'` sales-assignment, but independent of it. Default
+    // false → fail-closed. Distinct from `demo_enterprise` (a self-serve
+    // preview) and from `config.ENTERPRISE_LICENSE_AVAILABLE` (a platform-wide
+    // self-host license): this is the per-account, real-contract flag.
+    enterpriseEntitled: boolean('enterprise_entitled').default(false).notNull(),
     // Operator-set concurrent-session cap for this account. NULL (the default)
     // means "no override" — the account's plan tier decides the limit
     // (TierConfig.concurrentSessionLimit). When set, it takes precedence over

--- a/packages/sdk/src/core/rest/projects-client/billing.ts
+++ b/packages/sdk/src/core/rest/projects-client/billing.ts
@@ -138,6 +138,13 @@ export interface AccountState {
    *  hides the self-serve "Enterprise features — Demo" toggle and any
    *  "Request enterprise access" upsell when this is true. */
   enterprise_license_available?: boolean;
+  /** True when an operator flagged this account as a contracted cloud
+   *  Enterprise customer (`credit_accounts.enterprise_entitled`). The account
+   *  then resolves all enterprise entitlements regardless of billing tier, so
+   *  a deal that is BOTH Enterprise AND per-seat can hold both at once. The
+   *  frontend uses this to hide the self-serve demo toggle (a real contract
+   *  supersedes the demo). */
+  enterprise_entitled?: boolean;
   auto_topup?: {
     enabled: boolean;
     threshold: number;


### PR DESCRIPTION
## Problem

An account could hold Enterprise entitlements (`tier='enterprise'`) **or** per-seat billing reconciliation (`tier='per_seat'`), but not both. The per-seat Stripe webhook (`webhooks.ts syncSubscriptionState`) set `tier='per_seat'` on every subscription update carrying a per-seat item, clobbering a sales-assigned `tier='enterprise'` and stripping SSO/SCIM/RBAC/audit on ordinary seat-quantity updates. A contract shaped as a flat Enterprise fee plus per-seat billing could not be provisioned.

The per-seat billing semantics (seat grants, auto-topup, compute metering) all key off `billing_model='per_seat'`, never `tier` — the tier clobber was a coupling defect, not a billing requirement.

## Fix

- **`credit_accounts.enterprise_entitled`** (new column, migration `20260805030712000`) — operator-set boolean for a contracted cloud Enterprise customer. Mirrors the existing `demo_enterprise` column shape but for a real signed contract, not a self-serve demo. Default `false` → fail-closed.
- **`entitlements.ts`** — `enterprise_entitled` joins the resolution order: when true, the account resolves all enterprise entitlements regardless of `tier`.
- **`webhooks.ts` `syncSubscriptionState`** — per-seat reconciliation no longer overwrites `tier` when the account is enterprise-entitled (via the flag or `tier='enterprise'`). It still sets `billing_model='per_seat'`, `seat_count`, `seat_subscription_item_id`, the seat credit grant, and auto-topup.
- **Admin route `POST /v1/admin/api/accounts/:id/enterprise-entitlement`** — sets/clears the flag, with audit event `admin.account.enterprise_entitlement.set`. Mirrors the existing `set-tier` admin route.
- **`AccountStateResponse` + SDK type** — surfaces `enterprise_entitled` so admin console and frontend can distinguish a real contract from a self-serve demo.

## Verification

- `apps/api/src/__tests__/billing/e2e-per-seat-webhooks.test.ts` — 16 pass, 0 fail, incl. 5 new enterprise + per-seat coexistence no-clobber tests:
  - `enterprise_entitled=true` + per-seat seat update → `billing_model` reconciled, `tier` NOT set to `per_seat`
  - `enterprise_entitled=true` + seat increase → seat credit grant still emitted
  - `tier='enterprise'` (no flag) + per-seat update → `tier` NOT clobbered
  - non-enterprise per-seat account → `tier` still set to `per_seat` (unchanged)
  - `enterprise_entitled=true`, free→per-seat activation → `tier` NOT clobbered
- `apps/api/src/__tests__/unit-entitlements-enterprise-entitled.test.ts` — 12 pass, 0 fail.

## Safety

- Webhook guard is behavior-preserving for every non-enterprise account: the enterprise-entitled check is false for all `tier != 'enterprise'` and `enterprise_entitled != true` accounts, so the `updates.tier = 'per_seat'` write fires exactly as before (locked by regression test).
- No commercial pricing change: `PER_SEAT_PRICE_USD`, `INCLUDED_CREDITS_PER_SEAT_USD`, and the wallet credit unit are untouched.
- Migration adds one nullable-defaulted boolean column; no backfill, no index change.
