### PR TITLE
release(staging): /legal/terms → specific Drive file (#6123)

### DIFF
--- a/apps/web/src/lib/legal-terms-links.test.ts
+++ b/apps/web/src/lib/legal-terms-links.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 
 /**
  * Terms-of-Service links must point at the stable `/legal/terms` path, which
- * the middleware permanently 308-redirects to the public Drive folder. The
+ * the middleware permanently 308-redirects to the public Drive file. The
  * legacy `/legal?tab=terms` query form must not appear in any source link — it
  * only still works because the middleware redirects it, but new links should
  * use the stable path. Privacy and imprint stay local on `/legal?tab=…`.

--- a/apps/web/src/lib/legal-terms-redirect.test.ts
+++ b/apps/web/src/lib/legal-terms-redirect.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import { LEGAL_TERMS_DRIVE_BASE, legalTermsRedirectUrl } from '@/lib/legal-terms-redirect';
 
 describe('legalTermsRedirectUrl', () => {
-  describe('redirects Terms requests to the Drive folder', () => {
+  describe('redirects Terms requests to the Drive file', () => {
     const termsCases: Array<{ name: string; pathname: string; search: string }> = [
       { name: 'stable /legal/terms', pathname: '/legal/terms', search: '' },
       { name: 'stable /legal/terms with usp=sharing', pathname: '/legal/terms', search: '?usp=sharing' },
@@ -25,7 +25,7 @@ describe('legalTermsRedirectUrl', () => {
         const dest = legalTermsRedirectUrl(pathname, params);
         expect(dest).not.toBeNull();
         expect(dest!.origin).toBe('https://drive.google.com');
-        expect(dest!.pathname).toBe('/drive/folders/1UZuRrBGhzACGBgi2J47BS-I6VMNnqIHN');
+        expect(dest!.pathname).toBe('/file/d/1KJ4lLxz6LQosk0DZIosSAf01GK8PdQ54/view');
         // usp=sharing is always present and never overridden.
         expect(dest!.searchParams.get('usp')).toBe('sharing');
       });
@@ -112,7 +112,7 @@ describe('legalTermsRedirectUrl', () => {
 
   test('exposes the canonical Drive base URL', () => {
     expect(LEGAL_TERMS_DRIVE_BASE).toBe(
-      'https://drive.google.com/drive/folders/1UZuRrBGhzACGBgi2J47BS-I6VMNnqIHN',
+      'https://drive.google.com/file/d/1KJ4lLxz6LQosk0DZIosSAf01GK8PdQ54/view',
     );
   });
 });

--- a/apps/web/src/lib/legal-terms-redirect.ts
+++ b/apps/web/src/lib/legal-terms-redirect.ts
@@ -1,13 +1,13 @@
 /**
  * Permanent (308) redirect of every Terms-of-Service URL to the canonical
- * public Google Drive folder that now owns the Terms document.
+ * public Google Drive file that now owns the Terms document.
  *
  * The legal page (`/legal`) used to host three tabs — imprint, terms, and
- * privacy. Terms moved out to an externally-owned Drive folder; the legal page
+ * privacy. Terms moved out to an externally-owned Drive file; the legal page
  * now only renders imprint and privacy. Both the new stable path
  * (`/legal/terms`) and the legacy tab query (`/legal?tab=terms`), including
  * every supported locale prefix (`/de/legal/terms`, `/de/legal?tab=terms`, …),
- * must permanently redirect to that folder so existing links and bookmarks
+ * must permanently redirect to that file so existing links and bookmarks
  * keep resolving.
  *
  * The redirect is a 308 (Permanent Redirect) which preserves the request method
@@ -18,13 +18,14 @@
 import { locales, type Locale } from '@/i18n/config';
 
 /**
- * Canonical public Google Drive folder that owns the Terms of Service.
- * The `usp=sharing` param is what lets Drive render the folder publicly
+ * Canonical public Google Drive file that owns the Terms of Service
+ * (Kortix Terms of Service - Version 2026-07-14.pdf).
+ * The `usp=sharing` param is what lets Drive render the file publicly
  * without forcing a sign-in — it must always be present on the destination
  * and must never be overwritten by an incoming `usp` value.
  */
 export const LEGAL_TERMS_DRIVE_BASE =
-  'https://drive.google.com/drive/folders/1UZuRrBGhzACGBgi2J47BS-I6VMNnqIHN';
+  'https://drive.google.com/file/d/1KJ4lLxz6LQosk0DZIosSAf01GK8PdQ54/view';
 
 /**
  * Query params that are dropped when building the redirect destination:
@@ -53,10 +54,10 @@ function isLegalPath(pathname: string): boolean {
 }
 
 /**
- * Build the permanent Drive-folder destination URL for a Terms request.
+ * Build the permanent Drive-file destination URL for a Terms request.
  *
  * Rules:
- * 1. The base is the canonical Drive folder.
+ * 1. The base is the canonical Drive file.
  * 2. `usp=sharing` is always set and never overridden by an incoming `usp`.
  * 3. `tab` is always dropped.
  * 4. Every other incoming query param is preserved (sorted for a stable,

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -193,8 +193,8 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // ── Terms of Service → public Drive folder (permanent 308) ──────────────
-  // The Terms document moved to an externally-owned Google Drive folder. Both
+  // ── Terms of Service → public Drive file (permanent 308) ────────────────
+  // The Terms document moved to an externally-owned Google Drive file. Both
   // the new stable path (`/legal/terms`) and the legacy tab query
   // (`/legal?tab=terms`), including every supported locale prefix
   // (`/de/legal/terms`, `/de/legal?tab=terms`, …), permanently redirect there


### PR DESCRIPTION
## Problem

#6114 pointed `/legal/terms` at the whole public Drive folder. Visitors land on a folder listing instead of the Terms document.

## Change

- `apps/web/src/lib/legal-terms-redirect.ts`: `LEGAL_TERMS_DRIVE_BASE` now points at the Terms PDF itself: `https://drive.google.com/file/d/1KJ4lLxz6LQosk0DZIosSAf01GK8PdQ54/view`.
- Param handling is unchanged: drop `tab`, force `usp=sharing`, preserve other params in sorted order.
- Tests updated to pin the file URL; comment wording folder -> file in `middleware.ts` and the two test files.

## Verification

- Drive file is public: `curl -sI ".../file/d/1KJ4lLxz6LQosk0DZIosSAf01GK8PdQ54/view?usp=sharing"` returns 200, title "Kortix Terms of Service - Version 2026-07-14.pdf".
- `bun test src/lib/legal-terms-redirect.test.ts src/lib/legal-terms-links.test.ts` — 34 pass, 0 fail.
- Real middleware on `next dev`:
  - `/legal/terms` -> 308 `https://drive.google.com/file/d/1KJ4lLxz6LQosk0DZIosSAf01GK8PdQ54/view?usp=sharing`
  - `/legal?tab=terms` -> 308 same destination
  - `/de/legal/terms` -> 308 same destination
- `npx eslint` on the 4 touched files: 0 errors.
- `npx tsc --noEmit`: only the known 15 `test.each` baseline errors in the 3 known files.
