### PR TITLE
feat(api): materialize restricted agent environments

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1420,6 +1420,17 @@ describe('project session API contract', () => {
     expect(await sandboxCloneRes.json()).toMatchObject({
       error: 'sandbox workspace does not allow repository access',
     });
+
+    for (const suffix of ['diff', 'merge-preview']) {
+      const crRes = await app.request(
+        `/v1/projects/${PROJECT_ID}/change-requests/00000000-0000-4000-a000-000000000801/${suffix}`,
+        { headers: { Authorization: `Bearer ${SESSION_AGENT_PAT}` } },
+      );
+      expect(crRes.status).toBe(403);
+      expect(await crRes.json()).toMatchObject({
+        message: 'session workspace does not allow repository access',
+      });
+    }
   });
 
   test('rejects removed session attribution fields', async () => {

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -596,6 +596,9 @@ mock.module('../shared/db', () => ({
             if (table === projects) return [projectRow];
             if (table === accountMembers) return [{ accountId: ACCOUNT_ID, accountRole: 'owner' }];
             if (table === projectMembers) return [];
+            if (table === projectSessions && fields?.sessionMetadata) {
+              return sessionRow ? [{ sessionMetadata: sessionRow.metadata }] : [];
+            }
             if (table === projectSessions) return sessionRow ? [sessionRow] : [];
             return [];
           },
@@ -1369,6 +1372,54 @@ describe('project session API contract', () => {
     expect(patBody.origin).toBe('backend');
     expect(patBody).not.toHaveProperty('end_user_ref');
     expect(patBody).not.toHaveProperty('origin_ref');
+  });
+
+  test('runtime workspaces deny repository metadata and clone credentials to both session tokens', async () => {
+    sessionRow!.metadata = { workspace_mode: 'runtime' };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'daytona',
+        externalId: null,
+        baseUrl: null,
+        status: 'active',
+        config: {},
+        metadata: {},
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-02T00:00:00Z'),
+        updatedAt: new Date('2026-01-02T00:00:00Z'),
+      },
+    ];
+    const app = createApp();
+
+    const projectRes = await app.request(`/v1/projects/${PROJECT_ID}`, {
+      headers: { Authorization: `Bearer ${SESSION_AGENT_PAT}` },
+    });
+    expect(projectRes.status).toBe(403);
+    expect(await projectRes.json()).toMatchObject({
+      message: 'session workspace does not allow repository access',
+    });
+
+    const patCloneRes = await app.request(
+      `/v1/projects/${PROJECT_ID}/git/clone-credential`,
+      { headers: { Authorization: `Bearer ${SESSION_AGENT_PAT}` } },
+    );
+    expect(patCloneRes.status).toBe(403);
+    expect(await patCloneRes.json()).toMatchObject({
+      message: 'session workspace does not allow repository access',
+    });
+
+    const sandboxCloneRes = await app.request(
+      `/v1/projects/${PROJECT_ID}/git/clone-credential`,
+      { headers: { Authorization: `Bearer ${PROJECT_SANDBOX_TOKEN}` } },
+    );
+    expect(sandboxCloneRes.status).toBe(403);
+    expect(await sandboxCloneRes.json()).toMatchObject({
+      error: 'sandbox workspace does not allow repository access',
+    });
   });
 
   test('rejects removed session attribution fields', async () => {

--- a/apps/api/src/__tests__/integration-session-create-required-connectors.test.ts
+++ b/apps/api/src/__tests__/integration-session-create-required-connectors.test.ts
@@ -25,6 +25,7 @@ const PROJECT_ID = crypto.randomUUID();
 const USER_ID = crypto.randomUUID();
 const SESSION_ID = crypto.randomUUID();
 const UNAVAILABLE_SESSION_ID = crypto.randomUUID();
+const READ_WORKSPACE_SESSION_ID = crypto.randomUUID();
 const PROJECT_CONNECTOR_ID = crypto.randomUUID();
 const USER_CONNECTOR_ID = crypto.randomUUID();
 
@@ -153,6 +154,8 @@ beforeAll(async () => {
       '  mixed_failures:',
       '    connectors: [ghost_one, project_records]',
       '    connectors_required: [ghost_one, project_records]',
+      '  restricted_reader:',
+      '    workspace: read',
       '',
     ].join('\n'),
     'utf8',
@@ -169,6 +172,69 @@ afterAll(async () => {
 });
 
 describe('createProjectSession required connection gate', () => {
+  test('rejects read mode before creating a session row', async () => {
+    const result = await createProjectSession({
+      project,
+      userId: USER_ID,
+      requestingPrincipalType: 'human',
+      body: {
+        session_id: READ_WORKSPACE_SESSION_ID,
+        agent_name: 'restricted_reader',
+      },
+      enforceAccountCap: false,
+      authType: 'supabase',
+    });
+
+    expect(result).toEqual({
+      error: {
+        status: 409,
+        body: {
+          error: 'workspace mode "read" requires restricted workspace artifacts',
+          code: 'WORKSPACE_MODE_UNAVAILABLE',
+        },
+      },
+    });
+
+    const rows = await db
+      .select({ sessionId: projectSessions.sessionId })
+      .from(projectSessions)
+      .where(
+        and(
+          eq(projectSessions.projectId, PROJECT_ID),
+          eq(projectSessions.sessionId, READ_WORKSPACE_SESSION_ID),
+        ),
+      );
+    expect(rows).toEqual([]);
+  });
+
+  test('returns the read-mode refusal through the session HTTP route', async () => {
+    const sessionId = crypto.randomUUID();
+    const response = await app.request(`/v1/projects/${PROJECT_ID}/sessions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        session_id: sessionId,
+        agent_name: 'restricted_reader',
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: 'workspace mode "read" requires restricted workspace artifacts',
+      code: 'WORKSPACE_MODE_UNAVAILABLE',
+    });
+    const rows = await db
+      .select({ sessionId: projectSessions.sessionId })
+      .from(projectSessions)
+      .where(
+        and(eq(projectSessions.projectId, PROJECT_ID), eq(projectSessions.sessionId, sessionId)),
+      );
+    expect(rows).toEqual([]);
+  });
+
   test('returns every missing connection and creates no session row', async () => {
     const result = await createProjectSession({
       project,

--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -20,6 +20,7 @@ const OTHER_ACCOUNT = 'acct-other';
 let projectRow: Record<string, unknown> | null = null;
 let patResult: Record<string, unknown> = {};
 let apiKeyResult: Record<string, unknown> = {};
+let sandboxRow: Record<string, unknown> | null = null;
 let authorizeAllowed = false;
 let authorizeCalls: Array<{
   userId: string;
@@ -30,11 +31,17 @@ let authorizeCalls: Array<{
 
 mock.module('../shared/db', () => ({
   db: {
-    select: () => ({
-      from: () => ({
-        where: () => ({ limit: async () => (projectRow ? [projectRow] : []) }),
-      }),
-    }),
+    select: (fields?: Record<string, unknown>) => {
+      const rows = fields?.sessionMetadata
+        ? () => (sandboxRow ? [sandboxRow] : [])
+        : () => (projectRow ? [projectRow] : []);
+      return {
+        from: () => ({
+          innerJoin: () => ({ where: () => ({ limit: async () => rows() }) }),
+          where: () => ({ limit: async () => rows() }),
+        }),
+      };
+    },
   },
   hasDatabase: true,
 }));
@@ -74,6 +81,7 @@ beforeEach(() => {
   projectRow = { projectId: PROJECT_ID, accountId: OWNER_ACCOUNT, status: 'active' };
   patResult = { isValid: true, accountId: OWNER_ACCOUNT, userId: 'user-1', tokenId: 'tok-1' };
   apiKeyResult = { isValid: false };
+  sandboxRow = null;
   authorizeAllowed = false;
   authorizeCalls = [];
 });
@@ -179,5 +187,51 @@ describe('authorizeGitProxy — account API key', () => {
   test('a non-Kortix credential is 401', async () => {
     const res = await authorizeGitProxy('ghp_something', PROJECT_ID, 'read');
     expect(res).toMatchObject({ ok: false, status: 401 });
+  });
+});
+
+describe('authorizeGitProxy — sandbox token', () => {
+  beforeEach(() => {
+    patResult = { isValid: false };
+    apiKeyResult = {
+      isValid: true,
+      accountId: OWNER_ACCOUNT,
+      type: 'sandbox',
+      sandboxId: 'sandbox-1',
+    };
+  });
+
+  test('runtime sessions cannot read Git objects', async () => {
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'runtime' },
+    };
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'read');
+
+    expect(res).toMatchObject({
+      ok: false,
+      status: 403,
+      message: 'sandbox workspace does not allow Git access',
+    });
+  });
+
+  test('branch sessions retain Git access', async () => {
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+  });
+
+  test('legacy sessions without a workspace mode retain Git access', async () => {
+    sandboxRow = { sandboxId: 'sandbox-1', sessionMetadata: {} };
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'read');
+
+    expect(res.ok).toBe(true);
   });
 });

--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -93,6 +93,29 @@ describe('authorizeGitProxy — CLI PAT', () => {
     expect(authorizeCalls).toHaveLength(0);
   });
 
+  test('a session PAT for a runtime workspace is denied before account ownership can allow it', async () => {
+    patResult = {
+      isValid: true,
+      accountId: OWNER_ACCOUNT,
+      userId: 'user-1',
+      tokenId: 'tok-1',
+      projectId: PROJECT_ID,
+      sessionId: 'sandbox-1',
+    };
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'runtime' },
+    };
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'read');
+
+    expect(res).toMatchObject({
+      ok: false,
+      status: 403,
+      message: 'session workspace does not allow repository access',
+    });
+  });
+
   test('a PAT on another account passes when the user holds the git capability', async () => {
     patResult = { isValid: true, accountId: OTHER_ACCOUNT, userId: 'user-1', tokenId: 'tok-1' };
     authorizeAllowed = true;

--- a/apps/api/src/__tests__/unit-slack-start-error.test.ts
+++ b/apps/api/src/__tests__/unit-slack-start-error.test.ts
@@ -28,6 +28,16 @@ describe('startErrorMessage', () => {
     expect(m).toContain('/kortix login');
   });
 
+  test('WORKSPACE_MODE_UNAVAILABLE explains the configuration change instead of login', () => {
+    const m = startErrorMessage(409, {
+      code: 'WORKSPACE_MODE_UNAVAILABLE',
+      error: 'workspace mode "read" requires restricted workspace artifacts',
+    });
+    expect(m).toContain('`read`');
+    expect(m).toContain('`runtime` or `branch`');
+    expect(m).not.toContain('/kortix login');
+  });
+
   test('403 → permission, ask an admin', () => {
     const m = startErrorMessage(403, {});
     expect(m.toLowerCase()).toContain('permission');

--- a/apps/api/src/channels/slack/start-error.ts
+++ b/apps/api/src/channels/slack/start-error.ts
@@ -27,6 +27,8 @@ export function startErrorMessage(status: number | undefined, body: unknown): st
       return "I couldn't start a session — the sandbox template configured for this project no longer exists. Update it in the project's Kortix settings, then send your message again.";
     case 'KORTIX_URL_UNREACHABLE':
       return "I couldn't start a session — Kortix couldn't reach the sandbox runtime just now. This is usually a brief infrastructure hiccup; give it a moment and send your message again.";
+    case 'WORKSPACE_MODE_UNAVAILABLE':
+      return "I couldn't start a session because the agent uses the `read` workspace mode. Restricted workspace artifacts are not enabled yet. Set the agent's workspace to `runtime` or `branch`, then send your message again.";
   }
 
   // Then HTTP status.

--- a/apps/api/src/projects/agents.test.ts
+++ b/apps/api/src/projects/agents.test.ts
@@ -38,6 +38,7 @@ const {
   manifestHashForAgent,
   resolveGovernedAgentGrant,
   requiredConnectorsForAgent,
+  workspaceFromLoadedAgents,
 } =
   await import('./agents');
 
@@ -233,5 +234,31 @@ describe('connectors_required — v2 agent required-connector declaration', () =
     expect(
       manifestHashForAgent({ ...base, connectorsRequired: ['gmail'] }),
     ).not.toBe(manifestHashForAgent(base));
+  });
+});
+
+describe('workspace — v2 agent workspace declaration', () => {
+  test('resolves the selected and default agent workspace modes', async () => {
+    manifestFile = {
+      path: 'kortix.yaml',
+      content: [
+        'kortix_version: 2',
+        'default_agent: support',
+        'agents:',
+        '  support:',
+        '    workspace: runtime',
+        '  engineer:',
+        '    workspace: branch',
+        '',
+      ].join('\n'),
+    };
+
+    const loaded = await loadProjectAgents(fakeProject());
+
+    expect(loaded.errors).toEqual([]);
+    expect(workspaceFromLoadedAgents('support', loaded)).toBe('runtime');
+    expect(workspaceFromLoadedAgents(DEFAULT_AGENT_SENTINEL, loaded)).toBe('runtime');
+    expect(workspaceFromLoadedAgents('engineer', loaded)).toBe('branch');
+    expect(workspaceFromLoadedAgents('missing', loaded)).toBeNull();
   });
 });

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -35,7 +35,13 @@ import type { ParsedManifest } from './triggers';
 import { PROJECT_ACTIONS, VALID_ACTIONS } from '../iam/actions';
 import type { GitBackedProject } from './git';
 import type { AgentGrant } from '@kortix/db';
-import { resolveGrantSet, SLUG_RE, type GrantSetV2 } from '@kortix/manifest-schema';
+import {
+  resolveGrantSet,
+  SLUG_RE,
+  WORKSPACE_MODES_V2,
+  type GrantSetV2,
+  type WorkspaceModeV2,
+} from '@kortix/manifest-schema';
 import { normalizeRequiredConnectorAliases } from './lib/agent-config-v2';
 
 const MANIFEST_FILENAME = 'kortix.toml';
@@ -109,6 +115,8 @@ export interface AgentSpec {
   model: string | null;
   /** Default sandbox template slug for sessions started with this agent. */
   sandbox?: string | null;
+  /** Project file delivery mode for sessions started with this agent. */
+  workspace?: WorkspaceModeV2 | null;
 }
 
 export interface AgentParseError {
@@ -408,6 +416,18 @@ export function sandboxFromLoadedAgents(agentName: string, loaded: LoadedAgents)
   return loaded.specs.find((spec) => spec.name === concreteName && spec.enabled)?.sandbox ?? null;
 }
 
+/** Resolve the selected agent's project file delivery mode without repository I/O. */
+export function workspaceFromLoadedAgents(
+  agentName: string,
+  loaded: LoadedAgents,
+): WorkspaceModeV2 | null {
+  const concreteName =
+    agentName === DEFAULT_AGENT_SENTINEL && loaded.defaultAgent
+      ? loaded.defaultAgent
+      : agentName;
+  return loaded.specs.find((spec) => spec.name === concreteName && spec.enabled)?.workspace ?? null;
+}
+
 /**
  * Resolve the connectors that the selected agent requires at session start.
  * Each connector controls which connection owner is valid.
@@ -590,6 +610,7 @@ export function manifestHashForAgent(spec: AgentSpec): string {
     kortixCli: spec.kortixCli,
     env: spec.env,
     file: spec.file,
+    workspace: spec.workspace,
   });
   return createHash('sha256').update(canonical).digest('hex');
 }
@@ -644,6 +665,7 @@ function parseAgentEntry(entry: unknown, index: number, filename: string = MANIF
       file,
       model,
       sandbox: null,
+      workspace: null,
     },
   };
 }
@@ -691,6 +713,15 @@ function parseAgentEntryV2(name: string, block: unknown, filename: string): Pars
     typeof normalizedRow.sandbox === 'string' && normalizedRow.sandbox.trim()
       ? normalizedRow.sandbox.trim()
       : null;
+  const workspaceRaw = normalizedRow.workspace;
+  if (
+    workspaceRaw !== undefined &&
+    (typeof workspaceRaw !== 'string' ||
+      !(WORKSPACE_MODES_V2 as readonly string[]).includes(workspaceRaw))
+  ) {
+    return err(name, `agents.${name}.workspace must be one of: ${WORKSPACE_MODES_V2.join(', ')}`);
+  }
+  const workspace = (workspaceRaw as WorkspaceModeV2 | undefined) ?? null;
 
   const connectorsResolved = resolveGrantSet(normalizedRow.connectors, 'none');
 
@@ -735,6 +766,7 @@ function parseAgentEntryV2(name: string, block: unknown, filename: string): Pars
       file,
       model,
       sandbox,
+      workspace,
     },
   };
 }

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -26,6 +26,10 @@ import { FREE_TIER_PROJECT_LIMIT, maxProjectsForAccount } from '../../shared/acc
 import { getAccountMembership } from './git';
 import { ProjectRow, ProjectSessionRow, normalizeString } from './serializers';
 import { mergeSessionOwnerIdentities, type SessionOwnerIdentity } from './session-inventory';
+import {
+  isRepositoryProjectAction,
+  sessionWorkspaceAllowsRepositoryAccess,
+} from './session-workspace-access';
 
 // Enforce the per-account project cap (free → 1, paid → effectively uncapped).
 // Returns a 403 Response to send, or null when the account may create another
@@ -441,6 +445,9 @@ export async function assertProjectCapability(
   // resource-grants.ts). Used by the agent/skill launch gates.
   resource?: { type: 'agent' | 'skill'; id: string },
 ): Promise<void> {
+  if (isRepositoryProjectAction(action)) {
+    await assertAgentSessionWorkspaceAllowsRepository(c, accountId, projectId);
+  }
   const actingTokenId =
     ((c as unknown as { get(k: string): unknown }).get('iamTokenId') as string | undefined) ?? undefined;
   await assertAuthorized(
@@ -470,6 +477,12 @@ export async function projectCapabilityAllowed(
   projectId: string,
   action: string,
 ): Promise<boolean> {
+  if (
+    isRepositoryProjectAction(action) &&
+    !(await agentSessionWorkspaceAllowsRepository(c, accountId, projectId))
+  ) {
+    return false;
+  }
   const actingTokenId =
     ((c as unknown as { get(k: string): unknown }).get('iamTokenId') as string | undefined) ?? undefined;
   const verdict = await authorize(
@@ -481,6 +494,33 @@ export async function projectCapabilityAllowed(
     deriveRequestContext(c),
   );
   return verdict.allowed;
+}
+
+function agentSessionIdFromRequest(c: Context): string | null {
+  if (c.get('authType') !== 'pat') return null;
+  const sessionId = c.get('sessionId');
+  return typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : null;
+}
+
+export async function agentSessionWorkspaceAllowsRepository(
+  c: Context,
+  accountId: string,
+  projectId: string,
+): Promise<boolean> {
+  const sessionId = agentSessionIdFromRequest(c);
+  if (!sessionId) return true;
+  return sessionWorkspaceAllowsRepositoryAccess({ sessionId, accountId, projectId });
+}
+
+export async function assertAgentSessionWorkspaceAllowsRepository(
+  c: Context,
+  accountId: string,
+  projectId: string,
+): Promise<void> {
+  if (await agentSessionWorkspaceAllowsRepository(c, accountId, projectId)) return;
+  throw new HTTPException(403, {
+    message: 'session workspace does not allow repository access',
+  });
 }
 
 // `projects.project_id` is a Postgres `uuid` column, so a malformed id

--- a/apps/api/src/projects/lib/agent-config-push.test.ts
+++ b/apps/api/src/projects/lib/agent-config-push.test.ts
@@ -16,8 +16,9 @@ process.env.KORTIX_URL = 'https://api.example.com';
 
 let compiled: string | null = '{"agent":{"support":{"prompt":"fresh"}}}';
 let compileThrows: Error | null = null;
-let compileCalls: Array<{ ref: string | null | undefined }> = [];
+let compileCalls: Array<{ ref: string | null | undefined; agent?: string }> = [];
 let posted: Array<{ opencodeEnv?: Record<string, string | null>; refreshModels?: boolean }> = [];
+let sessionMetadata: Record<string, unknown> | null = null;
 // One fake row that satisfies every select on this path — the sandbox lookup and
 // the session/project lookups `resolveSandboxEnvSnapshot` walks on its way to an
 // env snapshot. Cheaper than teaching the fake db which table it was asked for.
@@ -36,7 +37,7 @@ const SESSION_ROW = {
   accountId: 'acct-1',
 };
 let activeSandbox: { externalId: string; config: Record<string, unknown> } | null = SANDBOX_ROW;
-let daemonProof = true
+let daemonProof = true;
 let daemonReload: string | null = 'restarted';
 
 // Spread: the module also exports `agentConfigEtag`, which sandbox-env-sync now
@@ -48,6 +49,15 @@ mock.module('./compile-agent-config', () => ({
     if (compileThrows) throw compileThrows;
     return compiled;
   },
+  resolveSelectedAgentConfigForSession: async (
+    _project: unknown,
+    agentName: string,
+    baseRef?: string | null,
+  ) => {
+    compileCalls.push({ ref: baseRef, agent: agentName });
+    if (compileThrows) throw compileThrows;
+    return compiled;
+  },
 }));
 
 mock.module('../../shared/db', () => ({
@@ -55,7 +65,9 @@ mock.module('../../shared/db', () => ({
     select: () => ({
       from: () => ({
         where: () => {
-          const rows = activeSandbox ? [{ ...SESSION_ROW, ...activeSandbox }] : [];
+          const rows = activeSandbox
+            ? [{ ...SESSION_ROW, metadata: sessionMetadata, ...activeSandbox }]
+            : [];
           return {
             limit: async () => rows,
             then: (resolve: (value: typeof rows) => unknown, reject?: (reason: unknown) => unknown) =>
@@ -133,6 +145,7 @@ beforeEach(() => {
   activeSandbox = SANDBOX_ROW;
   daemonProof = true;
   daemonReload = 'restarted';
+  sessionMetadata = null;
 });
 
 describe('propagateProjectSecretsToActiveSandboxes', () => {
@@ -211,6 +224,14 @@ describe('pushSessionAgentConfigToSandbox', () => {
   test("recompiles from the SESSION's ref", async () => {
     await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'feature/x' });
     expect(compileCalls).toEqual([{ ref: 'feature/x' }]);
+  });
+
+  test('keeps runtime sessions on selected-agent compilation', async () => {
+    sessionMetadata = { workspace_mode: 'runtime' };
+
+    await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
+
+    expect(compileCalls).toEqual([{ ref: 'main', agent: 'support' }]);
   });
 
   test('a project with no compiled config pushes NOTHING', async () => {

--- a/apps/api/src/projects/lib/agent-config-push.test.ts
+++ b/apps/api/src/projects/lib/agent-config-push.test.ts
@@ -234,6 +234,14 @@ describe('pushSessionAgentConfigToSandbox', () => {
     expect(compileCalls).toEqual([{ ref: 'main', agent: 'support' }]);
   });
 
+  test('keeps historical read sessions on selected-agent compilation', async () => {
+    sessionMetadata = { workspace_mode: 'read' };
+
+    await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
+
+    expect(compileCalls).toEqual([{ ref: 'main', agent: 'support' }]);
+  });
+
   test('a project with no compiled config pushes NOTHING', async () => {
     // `null` is a v1 project or an unreadable manifest. Pushing an empty value
     // would delete the agents the box is running — for a transient read failure

--- a/apps/api/src/projects/lib/compile-agent-config.test.ts
+++ b/apps/api/src/projects/lib/compile-agent-config.test.ts
@@ -61,6 +61,7 @@ const {
   agentMarkdownPath,
   compileAgentConfig,
   resolveCompiledAgentConfigForSession,
+  resolveSelectedAgentConfigForSession,
 } = await import('./compile-agent-config');
 type OpencodeConfig = Awaited<ReturnType<typeof compileAgentConfig>> & object;
 
@@ -647,5 +648,49 @@ describe('resolveCompiledAgentConfigForSession — read failures', () => {
     } finally {
       transientFailurePaths = new Set();
     }
+  });
+});
+
+describe('resolveSelectedAgentConfigForSession', () => {
+  test('reads and emits only the selected agent', async () => {
+    manifestFile = { path: 'kortix.yaml', content: GOVERNANCE_FIXTURE };
+    mdFileContent = {
+      '.kortix/opencode/agents/support.md': supportMd(
+        'model: anthropic/claude-sonnet-4-5',
+        'Support body.',
+      ),
+      '.kortix/opencode/agents/pr-bot.md': 'PR bot body.',
+    };
+    readRepoFileCalls = [];
+
+    const result = await resolveSelectedAgentConfigForSession(PROJECT, 'support', 'main');
+    const parsed = JSON.parse(result) as OpencodeConfig;
+
+    expect(Object.keys(parsed.agent)).toEqual(['support']);
+    expect(parsed.agent.support.prompt).toBe('Support body.');
+    expect(parsed.model).toBe('anthropic/claude-sonnet-4-5');
+    expect(readRepoFileCalls).toEqual(['.kortix/opencode/agents/support.md']);
+  });
+
+  test('fails closed when the selected agent configuration cannot be read', async () => {
+    manifestFile = { path: 'kortix.yaml', content: GOVERNANCE_FIXTURE };
+    mdFileContent = {};
+    transientFailurePaths = new Set(['.kortix/opencode/agents/support.md']);
+
+    try {
+      await expect(
+        resolveSelectedAgentConfigForSession(PROJECT, 'support', 'main'),
+      ).rejects.toThrow('fatal: unable to access remote');
+    } finally {
+      transientFailurePaths = new Set();
+    }
+  });
+
+  test('fails closed when the selected agent is not declared', async () => {
+    manifestFile = { path: 'kortix.yaml', content: GOVERNANCE_FIXTURE };
+
+    await expect(
+      resolveSelectedAgentConfigForSession(PROJECT, 'missing', 'main'),
+    ).rejects.toThrow('not declared');
   });
 });

--- a/apps/api/src/projects/lib/compile-agent-config.ts
+++ b/apps/api/src/projects/lib/compile-agent-config.ts
@@ -251,6 +251,43 @@ export function compileAgentConfig(
   };
 }
 
+/** Compile one selected v2 agent for a restricted session environment. */
+export function compileSelectedAgentConfig(
+  manifest: Record<string, unknown>,
+  agentName: string,
+  runtime: RuntimeV2 = 'opencode',
+  agentMdFiles: Record<string, string> = {},
+): OpencodeConfig {
+  if (manifestSchemaVersion(manifest) !== 2) {
+    throw new CompileAgentConfigError('Selected-agent compilation requires kortix_version 2.');
+  }
+  if (runtime !== 'opencode') {
+    throw new CompileAgentConfigError(
+      `Unsupported compiler runtime "${runtime}" — only "opencode" is implemented today.`,
+    );
+  }
+
+  const v2 = manifest as unknown as ManifestV2;
+  const rawAgents =
+    v2.agents && typeof v2.agents === 'object' && !Array.isArray(v2.agents)
+      ? v2.agents
+      : {};
+  const block = rawAgents[agentName];
+  if (!block) {
+    throw new CompileAgentConfigError(`Agent "${agentName}" is not declared.`, agentName);
+  }
+  if (block.enabled === false) {
+    throw new CompileAgentConfigError(`Agent "${agentName}" is disabled.`, agentName);
+  }
+
+  const mdPath = agentMarkdownPath(manifest, agentName);
+  const compiledAgent = compileAgentBlock(agentName, block, mdPath, agentMdFiles[mdPath]);
+  return {
+    ...(compiledAgent.model ? { model: compiledAgent.model } : {}),
+    agent: { [agentName]: compiledAgent },
+  };
+}
+
 /**
  * Compile one agent: parse its `.md` (if supplied), copy every recognized
  * behavioral frontmatter field through unchanged, then overlay Kortix
@@ -471,4 +508,42 @@ export async function resolveCompiledAgentConfigForSession(
     );
     return null;
   }
+}
+
+/** Resolve one selected agent for a restricted session. Every failure is fatal. */
+export async function resolveSelectedAgentConfigForSession(
+  project: GitBackedProject,
+  agentName: string,
+  baseRef?: string | null,
+): Promise<string> {
+  const ref = baseRef?.trim() || project.defaultBranch;
+  const candidates = manifestCandidatePaths(project.manifestPath).map(
+    (candidate) => candidate.path,
+  );
+  const found = await readManifestFromRepo(project, candidates, ref);
+  if (!found) {
+    throw new CompileAgentConfigError(
+      `Project ${project.projectId} has no manifest for selected-agent compilation.`,
+      agentName,
+    );
+  }
+
+  const format = manifestFormatForPath(found.path);
+  const raw = parseManifestText(found.content, format);
+  if (manifestSchemaVersion(raw) !== 2) {
+    throw new CompileAgentConfigError(
+      `Project ${project.projectId} must use kortix_version 2 for selected-agent compilation.`,
+      agentName,
+    );
+  }
+
+  const path = agentMarkdownPath(raw, agentName);
+  const agentMdFiles: Record<string, string> = {};
+  try {
+    agentMdFiles[path] = await readRepoFile(project, path, ref);
+  } catch (err) {
+    if (!isRepoFileNotFoundError(err)) throw err;
+  }
+
+  return JSON.stringify(compileSelectedAgentConfig(raw, agentName, 'opencode', agentMdFiles));
 }

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -12,7 +12,7 @@ import {
   getProjectSecretValueForConsumer,
 } from '../secrets';
 import { recordAuditEvent } from '../../shared/audit';
-import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, projectGitConnections, projectGitCredentials, projects, sessionSandboxes } from '@kortix/db';
+import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, projectGitConnections, projectGitCredentials, projectSessions, projects, sessionSandboxes } from '@kortix/db';
 import { and, eq, gt, inArray, isNull } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { ttlMemo } from '../../shared/ttl-memo';
@@ -25,6 +25,7 @@ import { authorize } from '../../iam/dispatcher';
 import type { RequestContext } from '../../iam/engine';
 import { registerPrincipalScopedMemo } from '../../iam/cache-invalidation';
 import { PROJECT_GIT_AUTH_SECRET_NAME, ProjectGitConnectionRow, ProjectGitCredentialRow, ProjectRow, normalizeJsonObject, normalizeString } from './serializers';
+import { workspaceModeFromSessionMetadata } from './session-sandbox-metadata';
 
 // Memoized briefly (positive hits only): this runs on every project-scoped
 // request. Each DB statement is a fast same-region roundtrip (~3ms measured,
@@ -708,8 +709,12 @@ export async function authorizeGitProxy(
         return { ok: false, status: 403, message: 'sandbox token missing a sandbox scope' };
       }
       const [sandbox] = await db
-        .select({ sandboxId: sessionSandboxes.sandboxId })
+        .select({
+          sandboxId: sessionSandboxes.sandboxId,
+          sessionMetadata: projectSessions.metadata,
+        })
         .from(sessionSandboxes)
+        .innerJoin(projectSessions, eq(projectSessions.sessionId, sessionSandboxes.sessionId))
         .where(and(
           eq(sessionSandboxes.sandboxId, result.sandboxId),
           eq(sessionSandboxes.projectId, projectId),
@@ -719,6 +724,9 @@ export async function authorizeGitProxy(
         .limit(1);
       if (!sandbox) {
         return { ok: false, status: 403, message: 'sandbox token is not scoped to this project' };
+      }
+      if (workspaceModeFromSessionMetadata(sandbox.sessionMetadata) === 'runtime') {
+        return { ok: false, status: 403, message: 'sandbox workspace does not allow Git access' };
       }
       return { ok: true, project };
     }

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -25,7 +25,10 @@ import { authorize } from '../../iam/dispatcher';
 import type { RequestContext } from '../../iam/engine';
 import { registerPrincipalScopedMemo } from '../../iam/cache-invalidation';
 import { PROJECT_GIT_AUTH_SECRET_NAME, ProjectGitConnectionRow, ProjectGitCredentialRow, ProjectRow, normalizeJsonObject, normalizeString } from './serializers';
-import { workspaceModeFromSessionMetadata } from './session-sandbox-metadata';
+import {
+  sessionWorkspaceAllowsRepositoryAccess,
+  workspaceMetadataAllowsRepositoryAccess,
+} from './session-workspace-access';
 
 // Memoized briefly (positive hits only): this runs on every project-scoped
 // request. Each DB statement is a fast same-region roundtrip (~3ms measured,
@@ -689,6 +692,20 @@ export async function authorizeGitProxy(
     if (result.projectId && result.projectId !== projectId) {
       return { ok: false, status: 403, message: 'token is scoped to a different project' };
     }
+    if (
+      result.sessionId &&
+      !(await sessionWorkspaceAllowsRepositoryAccess({
+        sessionId: result.sessionId,
+        accountId: result.accountId,
+        projectId,
+      }))
+    ) {
+      return {
+        ok: false,
+        status: 403,
+        message: 'session workspace does not allow repository access',
+      };
+    }
     if (result.accountId !== project.accountId) {
       // Thread the acting token so the agent-grant fold fires (userRole ∩ grant)
       // — a bare authorize() would silently skip it.
@@ -714,7 +731,14 @@ export async function authorizeGitProxy(
           sessionMetadata: projectSessions.metadata,
         })
         .from(sessionSandboxes)
-        .innerJoin(projectSessions, eq(projectSessions.sessionId, sessionSandboxes.sessionId))
+        .innerJoin(
+          projectSessions,
+          and(
+            eq(projectSessions.sessionId, sessionSandboxes.sessionId),
+            eq(projectSessions.projectId, sessionSandboxes.projectId),
+            eq(projectSessions.accountId, sessionSandboxes.accountId),
+          ),
+        )
         .where(and(
           eq(sessionSandboxes.sandboxId, result.sandboxId),
           eq(sessionSandboxes.projectId, projectId),
@@ -725,7 +749,7 @@ export async function authorizeGitProxy(
       if (!sandbox) {
         return { ok: false, status: 403, message: 'sandbox token is not scoped to this project' };
       }
-      if (workspaceModeFromSessionMetadata(sandbox.sessionMetadata) === 'runtime') {
+      if (!workspaceMetadataAllowsRepositoryAccess(sandbox.sessionMetadata)) {
         return { ok: false, status: 403, message: 'sandbox workspace does not allow Git access' };
       }
       return { ok: true, project };

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -22,7 +22,10 @@ import {
 } from './compile-agent-config';
 import { waitForDaemonOpencodeReady } from './sandbox-daemon-ready';
 import { SECRET_CAPABILITIES_ENV_NAME } from '../secret-capabilities';
-import { workspaceModeFromSessionMetadata } from './session-sandbox-metadata';
+import {
+  workspaceModeAllowsFullRepository,
+  workspaceModeFromSessionMetadata,
+} from './session-sandbox-metadata';
 
 /**
  * The origin THIS sandbox should reach kortix-api's LLM-gateway surface at —
@@ -673,7 +676,8 @@ export async function pushSessionAgentConfigToSandbox(input: {
       gitAuthToken: null,
     };
     const compiled =
-      workspaceModeFromSessionMetadata(session?.metadata) === 'runtime' && session?.agentName
+      !workspaceModeAllowsFullRepository(workspaceModeFromSessionMetadata(session?.metadata)) &&
+      session?.agentName
         ? await resolveSelectedAgentConfigForSession(
             gitProject,
             session.agentName,

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -18,9 +18,11 @@ import { sanitizeSandboxEnv } from './sandbox-env-names';
 import {
   agentConfigEtag,
   resolveCompiledAgentConfigForSession,
+  resolveSelectedAgentConfigForSession,
 } from './compile-agent-config';
 import { waitForDaemonOpencodeReady } from './sandbox-daemon-ready';
 import { SECRET_CAPABILITIES_ENV_NAME } from '../secret-capabilities';
+import { workspaceModeFromSessionMetadata } from './session-sandbox-metadata';
 
 /**
  * The origin THIS sandbox should reach kortix-api's LLM-gateway surface at —
@@ -655,16 +657,29 @@ export async function pushSessionAgentConfigToSandbox(input: {
   baseRef?: string | null;
 }): Promise<{ applied: boolean; reason?: string; opencodeReload?: 'disposed' | 'restarted' | 'kept-old' | null }> {
   try {
-    const compiled = await resolveCompiledAgentConfigForSession(
-      {
-        projectId: input.projectId,
-        repoUrl: input.repoUrl,
-        defaultBranch: input.defaultBranch,
-        manifestPath: input.manifestPath ?? 'kortix.yaml',
-        gitAuthToken: null,
-      },
-      input.baseRef,
-    );
+    const [session] = await db
+      .select({
+        agentName: projectSessions.agentName,
+        metadata: projectSessions.metadata,
+      })
+      .from(projectSessions)
+      .where(eq(projectSessions.sessionId, input.sessionId))
+      .limit(1);
+    const gitProject = {
+      projectId: input.projectId,
+      repoUrl: input.repoUrl,
+      defaultBranch: input.defaultBranch,
+      manifestPath: input.manifestPath ?? 'kortix.yaml',
+      gitAuthToken: null,
+    };
+    const compiled =
+      workspaceModeFromSessionMetadata(session?.metadata) === 'runtime' && session?.agentName
+        ? await resolveSelectedAgentConfigForSession(
+            gitProject,
+            session.agentName,
+            input.baseRef,
+          )
+        : await resolveCompiledAgentConfigForSession(gitProject, input.baseRef);
     // `null` is a v1 project or an unreadable manifest. Pushing an empty value
     // would DELETE the agent config the box is running — a v1 project has none
     // to begin with, and for a transient read failure that would be a silent

--- a/apps/api/src/projects/lib/session-reload.ts
+++ b/apps/api/src/projects/lib/session-reload.ts
@@ -40,7 +40,10 @@ import {
   resolveSelectedAgentConfigForSession,
 } from './compile-agent-config';
 import { pushSessionAgentConfigToSandbox } from './sandbox-env-sync';
-import { workspaceModeFromSessionMetadata } from './session-sandbox-metadata';
+import {
+  workspaceModeAllowsFullRepository,
+  workspaceModeFromSessionMetadata,
+} from './session-sandbox-metadata';
 
 const SANDBOX_SERVICE_PORT = 8000;
 
@@ -287,7 +290,8 @@ export async function latestAgentConfigEtag(input: {
   // very commit the caller is asking about.
   invalidateProjectMirror(input.projectId);
   const compiled = await (
-    workspaceModeFromSessionMetadata(session?.metadata) === 'runtime' && session?.agentName
+    !workspaceModeAllowsFullRepository(workspaceModeFromSessionMetadata(session?.metadata)) &&
+    session?.agentName
       ? resolveSelectedAgentConfigForSession(gitProject, session.agentName, input.baseRef)
       : resolveCompiledAgentConfigForSession(gitProject, input.baseRef)
   ).catch(() => null);

--- a/apps/api/src/projects/lib/session-reload.ts
+++ b/apps/api/src/projects/lib/session-reload.ts
@@ -30,12 +30,17 @@
  */
 
 import { and, eq } from 'drizzle-orm';
-import { projects, sessionSandboxes } from '@kortix/db';
+import { projects, projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../../shared/db';
 import { resolveSandboxIngress } from '../../sandbox-proxy/backend';
 import { invalidateProjectMirror, type GitBackedProject } from '../git';
-import { agentConfigEtag, resolveCompiledAgentConfigForSession } from './compile-agent-config';
+import {
+  agentConfigEtag,
+  resolveCompiledAgentConfigForSession,
+  resolveSelectedAgentConfigForSession,
+} from './compile-agent-config';
 import { pushSessionAgentConfigToSandbox } from './sandbox-env-sync';
+import { workspaceModeFromSessionMetadata } from './session-sandbox-metadata';
 
 const SANDBOX_SERVICE_PORT = 8000;
 
@@ -246,17 +251,30 @@ export async function readSandboxConfigState(input: {
 export async function latestAgentConfigEtag(input: {
   projectId: string;
   accountId: string;
+  sessionId?: string;
   baseRef?: string | null;
 }): Promise<string | null> {
-  const [project] = await db
-    .select({
-      repoUrl: projects.repoUrl,
-      defaultBranch: projects.defaultBranch,
-      manifestPath: projects.manifestPath,
-    })
-    .from(projects)
-    .where(and(eq(projects.projectId, input.projectId), eq(projects.accountId, input.accountId)))
-    .limit(1);
+  const [[project], [session]] = await Promise.all([
+    db
+      .select({
+        repoUrl: projects.repoUrl,
+        defaultBranch: projects.defaultBranch,
+        manifestPath: projects.manifestPath,
+      })
+      .from(projects)
+      .where(and(eq(projects.projectId, input.projectId), eq(projects.accountId, input.accountId)))
+      .limit(1),
+    input.sessionId
+      ? db
+          .select({
+            agentName: projectSessions.agentName,
+            metadata: projectSessions.metadata,
+          })
+          .from(projectSessions)
+          .where(eq(projectSessions.sessionId, input.sessionId))
+          .limit(1)
+      : Promise.resolve([]),
+  ]);
   if (!project?.defaultBranch) return null;
   const gitProject: GitBackedProject = {
     projectId: input.projectId,
@@ -268,9 +286,11 @@ export async function latestAgentConfigEtag(input: {
   // Without this, `stale: false` is answerable from a cache that predates the
   // very commit the caller is asking about.
   invalidateProjectMirror(input.projectId);
-  const compiled = await resolveCompiledAgentConfigForSession(gitProject, input.baseRef).catch(
-    () => null,
-  );
+  const compiled = await (
+    workspaceModeFromSessionMetadata(session?.metadata) === 'runtime' && session?.agentName
+      ? resolveSelectedAgentConfigForSession(gitProject, session.agentName, input.baseRef)
+      : resolveCompiledAgentConfigForSession(gitProject, input.baseRef)
+  ).catch(() => null);
   return agentConfigEtag(compiled);
 }
 
@@ -370,6 +390,7 @@ export async function reloadSessionConfig(input: {
   const latest = await latestAgentConfigEtag({
     projectId: input.projectId,
     accountId: input.accountId,
+    sessionId: input.sessionId,
     baseRef: input.baseRef,
   });
 

--- a/apps/api/src/projects/lib/session-runtime-env.test.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.test.ts
@@ -50,7 +50,7 @@ describe('buildSessionRuntimeEnv — KORTIX_COMPILED_AGENT_CONFIG', () => {
 });
 
 describe('buildSessionRuntimeEnv — workspace mode', () => {
-  test('runtime mode disables the project clone', () => {
+  test('runtime mode removes every project Git coordinate', () => {
     const env = buildSessionRuntimeEnv({
       ...BASE_INPUT,
       workspaceMode: 'runtime',
@@ -58,13 +58,22 @@ describe('buildSessionRuntimeEnv — workspace mode', () => {
 
     expect(env.KORTIX_WORKSPACE_MODE).toBe('runtime');
     expect(env.KORTIX_PROJECT_AUTO_CLONE).toBe('0');
+    expect(env).not.toHaveProperty('KORTIX_REPO_URL');
+    expect(env).not.toHaveProperty('KORTIX_DEFAULT_BRANCH');
+    expect(env).not.toHaveProperty('KORTIX_BASE_REF');
+    expect(env).not.toHaveProperty('KORTIX_BRANCH_NAME');
   });
 
-  test('legacy and branch sessions keep the project clone', () => {
-    expect(buildSessionRuntimeEnv(BASE_INPUT).KORTIX_PROJECT_AUTO_CLONE).toBe('1');
-    expect(
-      buildSessionRuntimeEnv({ ...BASE_INPUT, workspaceMode: 'branch' })
-        .KORTIX_PROJECT_AUTO_CLONE,
-    ).toBe('1');
+  test('legacy and branch sessions keep the project clone and Git coordinates', () => {
+    for (const env of [
+      buildSessionRuntimeEnv(BASE_INPUT),
+      buildSessionRuntimeEnv({ ...BASE_INPUT, workspaceMode: 'branch' }),
+    ]) {
+      expect(env.KORTIX_PROJECT_AUTO_CLONE).toBe('1');
+      expect(env.KORTIX_REPO_URL).toBe(BASE_INPUT.repoUrl);
+      expect(env.KORTIX_DEFAULT_BRANCH).toBe(BASE_INPUT.baseRef);
+      expect(env.KORTIX_BASE_REF).toBe(BASE_INPUT.baseRef);
+      expect(env.KORTIX_BRANCH_NAME).toBe(BASE_INPUT.sessionId);
+    }
   });
 });

--- a/apps/api/src/projects/lib/session-runtime-env.test.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.test.ts
@@ -48,3 +48,23 @@ describe('buildSessionRuntimeEnv — KORTIX_COMPILED_AGENT_CONFIG', () => {
     expect(env).not.toHaveProperty('KORTIX_ORIGIN_REF');
   });
 });
+
+describe('buildSessionRuntimeEnv — workspace mode', () => {
+  test('runtime mode disables the project clone', () => {
+    const env = buildSessionRuntimeEnv({
+      ...BASE_INPUT,
+      workspaceMode: 'runtime',
+    });
+
+    expect(env.KORTIX_WORKSPACE_MODE).toBe('runtime');
+    expect(env.KORTIX_PROJECT_AUTO_CLONE).toBe('0');
+  });
+
+  test('legacy and branch sessions keep the project clone', () => {
+    expect(buildSessionRuntimeEnv(BASE_INPUT).KORTIX_PROJECT_AUTO_CLONE).toBe('1');
+    expect(
+      buildSessionRuntimeEnv({ ...BASE_INPUT, workspaceMode: 'branch' })
+        .KORTIX_PROJECT_AUTO_CLONE,
+    ).toBe('1');
+  });
+});

--- a/apps/api/src/projects/lib/session-runtime-env.test.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.test.ts
@@ -64,6 +64,20 @@ describe('buildSessionRuntimeEnv — workspace mode', () => {
     expect(env).not.toHaveProperty('KORTIX_BRANCH_NAME');
   });
 
+  test('read mode cannot clone before exact-path artifacts are implemented', () => {
+    const env = buildSessionRuntimeEnv({
+      ...BASE_INPUT,
+      workspaceMode: 'read',
+    });
+
+    expect(env.KORTIX_WORKSPACE_MODE).toBe('read');
+    expect(env.KORTIX_PROJECT_AUTO_CLONE).toBe('0');
+    expect(env).not.toHaveProperty('KORTIX_REPO_URL');
+    expect(env).not.toHaveProperty('KORTIX_DEFAULT_BRANCH');
+    expect(env).not.toHaveProperty('KORTIX_BASE_REF');
+    expect(env).not.toHaveProperty('KORTIX_BRANCH_NAME');
+  });
+
   test('legacy and branch sessions keep the project clone and Git coordinates', () => {
     for (const env of [
       buildSessionRuntimeEnv(BASE_INPUT),

--- a/apps/api/src/projects/lib/session-runtime-env.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.ts
@@ -1,5 +1,6 @@
 import { agentConfigEtag } from './compile-agent-config';
 import type { WorkspaceModeV2 } from '@kortix/manifest-schema';
+import { workspaceModeAllowsFullRepository } from './session-sandbox-metadata';
 
 export interface SessionRuntimeEnvInput {
   projectId: string;
@@ -21,15 +22,16 @@ export interface SessionRuntimeEnvInput {
 }
 
 export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<string, string> {
+  const allowsFullRepository = workspaceModeAllowsFullRepository(input.workspaceMode);
   const projectGitEnv: Record<string, string> =
-    input.workspaceMode === 'runtime'
-      ? {}
-      : {
+    allowsFullRepository
+      ? {
           KORTIX_REPO_URL: input.repoUrl,
           KORTIX_DEFAULT_BRANCH: input.baseRef,
           KORTIX_BASE_REF: input.baseRef,
           KORTIX_BRANCH_NAME: input.sessionId,
-        };
+        }
+      : {};
   return {
     ...projectGitEnv,
     KORTIX_PROJECT_ID: input.projectId,
@@ -37,7 +39,7 @@ export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<st
     KORTIX_SERVICE_PORT: '8000',
     KORTIX_AGENT_NAME: input.agentName,
     KORTIX_API_URL: input.apiUrl,
-    KORTIX_PROJECT_AUTO_CLONE: input.workspaceMode === 'runtime' ? '0' : '1',
+    KORTIX_PROJECT_AUTO_CLONE: allowsFullRepository ? '1' : '0',
     ...(input.workspaceMode ? { KORTIX_WORKSPACE_MODE: input.workspaceMode } : {}),
     // Frontend base for user-facing dashboard links — the agent/CLI must never
     // surface KORTIX_API_URL (the API host) to a human. See sandboxFrontendBaseUrl().

--- a/apps/api/src/projects/lib/session-runtime-env.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.ts
@@ -1,4 +1,5 @@
 import { agentConfigEtag } from './compile-agent-config';
+import type { WorkspaceModeV2 } from '@kortix/manifest-schema';
 
 export interface SessionRuntimeEnvInput {
   projectId: string;
@@ -11,6 +12,8 @@ export interface SessionRuntimeEnvInput {
   frontendUrl?: string;
   initialPrompt?: string | null;
   opencodeModel?: string | null;
+  /** Project file delivery mode selected by the session's agent. */
+  workspaceMode?: WorkspaceModeV2 | null;
   /** Server-compiled OpenCode agent config (JSON string) for a `kortix_version:
    *  2` project — see `compile-agent-config.ts`. `null`/omitted for a v1
    *  project: no key is emitted, so v1 sandbox env is byte-for-byte unchanged. */
@@ -28,6 +31,8 @@ export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<st
     KORTIX_SERVICE_PORT: '8000',
     KORTIX_AGENT_NAME: input.agentName,
     KORTIX_API_URL: input.apiUrl,
+    KORTIX_PROJECT_AUTO_CLONE: input.workspaceMode === 'runtime' ? '0' : '1',
+    ...(input.workspaceMode ? { KORTIX_WORKSPACE_MODE: input.workspaceMode } : {}),
     // Frontend base for user-facing dashboard links — the agent/CLI must never
     // surface KORTIX_API_URL (the API host) to a human. See sandboxFrontendBaseUrl().
     ...(input.frontendUrl ? { KORTIX_FRONTEND_URL: input.frontendUrl } : {}),

--- a/apps/api/src/projects/lib/session-runtime-env.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.ts
@@ -21,11 +21,17 @@ export interface SessionRuntimeEnvInput {
 }
 
 export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<string, string> {
+  const projectGitEnv: Record<string, string> =
+    input.workspaceMode === 'runtime'
+      ? {}
+      : {
+          KORTIX_REPO_URL: input.repoUrl,
+          KORTIX_DEFAULT_BRANCH: input.baseRef,
+          KORTIX_BASE_REF: input.baseRef,
+          KORTIX_BRANCH_NAME: input.sessionId,
+        };
   return {
-    KORTIX_REPO_URL: input.repoUrl,
-    KORTIX_DEFAULT_BRANCH: input.baseRef,
-    KORTIX_BASE_REF: input.baseRef,
-    KORTIX_BRANCH_NAME: input.sessionId,
+    ...projectGitEnv,
     KORTIX_PROJECT_ID: input.projectId,
     KORTIX_SESSION_ID: input.sessionId,
     KORTIX_SERVICE_PORT: '8000',

--- a/apps/api/src/projects/lib/session-sandbox-metadata.test.ts
+++ b/apps/api/src/projects/lib/session-sandbox-metadata.test.ts
@@ -5,6 +5,11 @@ import {
   sandboxSlugFromSessionMetadata,
   workspaceModeFromSessionMetadata,
 } from './session-sandbox-metadata';
+import {
+  isRepositoryProjectAction,
+  workspaceMetadataAllowsRepositoryAccess,
+} from './session-workspace-access';
+import { PROJECT_ACTIONS } from '../../iam/actions';
 
 describe('sandboxSlugFromSessionMetadata', () => {
   test('returns a persisted template slug', () => {
@@ -30,6 +35,24 @@ describe('workspaceModeFromSessionMetadata', () => {
     expect(workspaceModeFromSessionMetadata(null)).toBeUndefined();
     expect(workspaceModeFromSessionMetadata({})).toBeUndefined();
     expect(workspaceModeFromSessionMetadata({ workspace_mode: 'all' })).toBeUndefined();
+  });
+});
+
+describe('runtime workspace repository boundary', () => {
+  test('runtime metadata denies repository access while branch and legacy metadata allow it', () => {
+    expect(workspaceMetadataAllowsRepositoryAccess({ workspace_mode: 'runtime' })).toBe(false);
+    expect(workspaceMetadataAllowsRepositoryAccess({ workspace_mode: 'branch' })).toBe(true);
+    expect(workspaceMetadataAllowsRepositoryAccess({})).toBe(true);
+  });
+
+  test('classifies every repository-backed project capability', () => {
+    expect(isRepositoryProjectAction(PROJECT_ACTIONS.PROJECT_FILE_READ)).toBe(true);
+    expect(isRepositoryProjectAction(PROJECT_ACTIONS.PROJECT_FILE_WRITE)).toBe(true);
+    expect(isRepositoryProjectAction(PROJECT_ACTIONS.PROJECT_GITOPS_READ)).toBe(true);
+    expect(isRepositoryProjectAction(PROJECT_ACTIONS.PROJECT_GITOPS_PUSH)).toBe(true);
+    expect(isRepositoryProjectAction(PROJECT_ACTIONS.PROJECT_GITOPS_MERGE)).toBe(true);
+    expect(isRepositoryProjectAction(PROJECT_ACTIONS.PROJECT_SECRET_READ)).toBe(false);
+    expect(isRepositoryProjectAction(PROJECT_ACTIONS.PROJECT_CONNECTOR_READ)).toBe(false);
   });
 });
 

--- a/apps/api/src/projects/lib/session-sandbox-metadata.test.ts
+++ b/apps/api/src/projects/lib/session-sandbox-metadata.test.ts
@@ -31,16 +31,19 @@ describe('workspaceModeFromSessionMetadata', () => {
     expect(workspaceModeFromSessionMetadata({ workspace_mode: 'branch' })).toBe('branch');
   });
 
-  test('rejects missing and invalid metadata values', () => {
+  test('keeps missing metadata legacy-compatible and maps invalid stored modes to runtime', () => {
     expect(workspaceModeFromSessionMetadata(null)).toBeUndefined();
     expect(workspaceModeFromSessionMetadata({})).toBeUndefined();
-    expect(workspaceModeFromSessionMetadata({ workspace_mode: 'all' })).toBeUndefined();
+    expect(workspaceModeFromSessionMetadata({ workspace_mode: 'all' })).toBe('runtime');
+    expect(workspaceModeFromSessionMetadata({ workspace_mode: null })).toBe('runtime');
   });
 });
 
-describe('runtime workspace repository boundary', () => {
-  test('runtime metadata denies repository access while branch and legacy metadata allow it', () => {
+describe('restricted workspace repository boundary', () => {
+  test('restricted metadata denies repository access while branch and legacy metadata allow it', () => {
     expect(workspaceMetadataAllowsRepositoryAccess({ workspace_mode: 'runtime' })).toBe(false);
+    expect(workspaceMetadataAllowsRepositoryAccess({ workspace_mode: 'read' })).toBe(false);
+    expect(workspaceMetadataAllowsRepositoryAccess({ workspace_mode: 'all' })).toBe(false);
     expect(workspaceMetadataAllowsRepositoryAccess({ workspace_mode: 'branch' })).toBe(true);
     expect(workspaceMetadataAllowsRepositoryAccess({})).toBe(true);
   });

--- a/apps/api/src/projects/lib/session-sandbox-metadata.test.ts
+++ b/apps/api/src/projects/lib/session-sandbox-metadata.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   resolveSessionSandboxSlug,
   sandboxSlugFromSessionMetadata,
+  workspaceModeFromSessionMetadata,
 } from './session-sandbox-metadata';
 
 describe('sandboxSlugFromSessionMetadata', () => {
@@ -15,6 +16,20 @@ describe('sandboxSlugFromSessionMetadata', () => {
     expect(sandboxSlugFromSessionMetadata(null)).toBeUndefined();
     expect(sandboxSlugFromSessionMetadata({})).toBeUndefined();
     expect(sandboxSlugFromSessionMetadata({ sandbox_slug: '../escape' })).toBeUndefined();
+  });
+});
+
+describe('workspaceModeFromSessionMetadata', () => {
+  test('returns a persisted workspace mode', () => {
+    expect(workspaceModeFromSessionMetadata({ workspace_mode: 'runtime' })).toBe('runtime');
+    expect(workspaceModeFromSessionMetadata({ workspace_mode: 'read' })).toBe('read');
+    expect(workspaceModeFromSessionMetadata({ workspace_mode: 'branch' })).toBe('branch');
+  });
+
+  test('rejects missing and invalid metadata values', () => {
+    expect(workspaceModeFromSessionMetadata(null)).toBeUndefined();
+    expect(workspaceModeFromSessionMetadata({})).toBeUndefined();
+    expect(workspaceModeFromSessionMetadata({ workspace_mode: 'all' })).toBeUndefined();
   });
 });
 

--- a/apps/api/src/projects/lib/session-sandbox-metadata.ts
+++ b/apps/api/src/projects/lib/session-sandbox-metadata.ts
@@ -1,3 +1,5 @@
+import { WORKSPACE_MODES_V2, type WorkspaceModeV2 } from '@kortix/manifest-schema';
+
 /** Read the server-owned resolved template from durable session metadata. */
 export function sandboxSlugFromSessionMetadata(metadata: unknown): string | undefined {
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return undefined;
@@ -5,6 +7,15 @@ export function sandboxSlugFromSessionMetadata(metadata: unknown): string | unde
   if (typeof value !== 'string') return undefined;
   const slug = value.trim();
   return /^[a-z0-9][a-z0-9_-]{0,127}$/.test(slug) ? slug : undefined;
+}
+
+/** Read the server-owned agent workspace mode from durable session metadata. */
+export function workspaceModeFromSessionMetadata(metadata: unknown): WorkspaceModeV2 | undefined {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return undefined;
+  const value = (metadata as Record<string, unknown>).workspace_mode;
+  return typeof value === 'string' && (WORKSPACE_MODES_V2 as readonly string[]).includes(value)
+    ? (value as WorkspaceModeV2)
+    : undefined;
 }
 
 /** Apply the session sandbox precedence contract. */

--- a/apps/api/src/projects/lib/session-sandbox-metadata.ts
+++ b/apps/api/src/projects/lib/session-sandbox-metadata.ts
@@ -12,10 +12,19 @@ export function sandboxSlugFromSessionMetadata(metadata: unknown): string | unde
 /** Read the server-owned agent workspace mode from durable session metadata. */
 export function workspaceModeFromSessionMetadata(metadata: unknown): WorkspaceModeV2 | undefined {
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return undefined;
-  const value = (metadata as Record<string, unknown>).workspace_mode;
+  const record = metadata as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(record, 'workspace_mode')) return undefined;
+  const value = record.workspace_mode;
   return typeof value === 'string' && (WORKSPACE_MODES_V2 as readonly string[]).includes(value)
     ? (value as WorkspaceModeV2)
-    : undefined;
+    : 'runtime';
+}
+
+/** Only branch and legacy sessions may receive repository bytes or credentials. */
+export function workspaceModeAllowsFullRepository(
+  mode: WorkspaceModeV2 | null | undefined,
+): boolean {
+  return mode === undefined || mode === null || mode === 'branch';
 }
 
 /** Apply the session sandbox precedence contract. */

--- a/apps/api/src/projects/lib/session-workspace-access.ts
+++ b/apps/api/src/projects/lib/session-workspace-access.ts
@@ -1,0 +1,42 @@
+import { projectSessions } from '@kortix/db';
+import { and, eq } from 'drizzle-orm';
+
+import { PROJECT_ACTIONS } from '../../iam/actions';
+import { db } from '../../shared/db';
+import { workspaceModeFromSessionMetadata } from './session-sandbox-metadata';
+
+const REPOSITORY_ACTIONS = new Set<string>([
+  PROJECT_ACTIONS.PROJECT_FILE_READ,
+  PROJECT_ACTIONS.PROJECT_FILE_WRITE,
+  PROJECT_ACTIONS.PROJECT_GITOPS_READ,
+  PROJECT_ACTIONS.PROJECT_GITOPS_PUSH,
+  PROJECT_ACTIONS.PROJECT_GITOPS_MERGE,
+]);
+
+export function isRepositoryProjectAction(action: string): boolean {
+  return REPOSITORY_ACTIONS.has(action);
+}
+
+export function workspaceMetadataAllowsRepositoryAccess(metadata: unknown): boolean {
+  return workspaceModeFromSessionMetadata(metadata) !== 'runtime';
+}
+
+export async function sessionWorkspaceAllowsRepositoryAccess(input: {
+  sessionId: string;
+  accountId: string;
+  projectId: string;
+}): Promise<boolean> {
+  const [session] = await db
+    .select({ sessionMetadata: projectSessions.metadata })
+    .from(projectSessions)
+    .where(
+      and(
+        eq(projectSessions.sessionId, input.sessionId),
+        eq(projectSessions.accountId, input.accountId),
+        eq(projectSessions.projectId, input.projectId),
+      ),
+    )
+    .limit(1);
+  if (!session) return false;
+  return workspaceMetadataAllowsRepositoryAccess(session.sessionMetadata);
+}

--- a/apps/api/src/projects/lib/session-workspace-access.ts
+++ b/apps/api/src/projects/lib/session-workspace-access.ts
@@ -3,7 +3,10 @@ import { and, eq } from 'drizzle-orm';
 
 import { PROJECT_ACTIONS } from '../../iam/actions';
 import { db } from '../../shared/db';
-import { workspaceModeFromSessionMetadata } from './session-sandbox-metadata';
+import {
+  workspaceModeAllowsFullRepository,
+  workspaceModeFromSessionMetadata,
+} from './session-sandbox-metadata';
 
 const REPOSITORY_ACTIONS = new Set<string>([
   PROJECT_ACTIONS.PROJECT_FILE_READ,
@@ -18,7 +21,7 @@ export function isRepositoryProjectAction(action: string): boolean {
 }
 
 export function workspaceMetadataAllowsRepositoryAccess(metadata: unknown): boolean {
-  return workspaceModeFromSessionMetadata(metadata) !== 'runtime';
+  return workspaceModeAllowsFullRepository(workspaceModeFromSessionMetadata(metadata));
 }
 
 export async function sessionWorkspaceAllowsRepositoryAccess(input: {

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -41,6 +41,7 @@ import {
   requiredConnectorsForAgent,
   resolveGovernedAgentGrant,
   sandboxFromLoadedAgents,
+  workspaceFromLoadedAgents,
 } from '../agents';
 import { createRemoteSessionBranch, resolveCommitSha } from '../git';
 import { resolveSessionSecretGrant } from './secret-grant';
@@ -53,7 +54,11 @@ import {
   secretKeyCollisionInAllowlist,
 } from '../secrets';
 import { SECRET_CAPABILITIES_ENV_NAME } from '../secret-capabilities';
-import { resolveCompiledAgentConfigForSession } from './compile-agent-config';
+import {
+  resolveCompiledAgentConfigForSession,
+  resolveSelectedAgentConfigForSession,
+} from './compile-agent-config';
+import type { WorkspaceModeV2 } from '@kortix/manifest-schema';
 import { withProjectGitAuth } from './git';
 import { resolveSessionProvider } from './provider-precedence';
 import { RESERVED_SANDBOX_ENV_NAMES, isReservedSandboxEnvName } from './sandbox-env-names';
@@ -286,6 +291,7 @@ export async function buildSessionSandboxEnvVars(input: {
   manifestPath?: string;
   /** The reserved platform coordinator receives no project checkout or secrets. */
   platformMetaAgent?: boolean;
+  workspaceMode?: WorkspaceModeV2 | null;
 }): Promise<Record<string, string>> {
   // Only user runtime secrets belong here. The sandbox-scoped KORTIX_TOKEN is
   // minted by provisionSessionSandbox() and injected at the provider boundary,
@@ -308,20 +314,24 @@ export async function buildSessionSandboxEnvVars(input: {
     ? buildPlatformMetaOpenCodeConfig()
     : null;
   if (input.defaultBranch && !input.platformMetaAgent) {
-    compiledAgentConfig = await resolveCompiledAgentConfigForSession(
-      {
-        projectId: input.projectId,
-        repoUrl: input.repoUrl,
-        defaultBranch: input.defaultBranch,
-        manifestPath: input.manifestPath ?? 'kortix.yaml',
-        gitAuthToken: null,
-      },
-      // Compile from the ref this session actually runs on. It used to compile
-      // from the default branch regardless, so a session started on a feature
-      // branch ran main's agents from its first turn — you could edit an agent,
-      // push, start a session on that branch, and see no change at all.
-      input.baseRef,
-    ).catch(() => null);
+    const gitProject = {
+      projectId: input.projectId,
+      repoUrl: input.repoUrl,
+      defaultBranch: input.defaultBranch,
+      manifestPath: input.manifestPath ?? 'kortix.yaml',
+      gitAuthToken: null,
+    };
+    compiledAgentConfig =
+      input.workspaceMode === 'runtime'
+        ? await resolveSelectedAgentConfigForSession(
+            gitProject,
+            input.agentName,
+            input.baseRef,
+          )
+          : await resolveCompiledAgentConfigForSession(
+              gitProject,
+              input.baseRef,
+            ).catch(() => null);
 
     // Per-agent secret scoping: an agent declared in `agents:` with a `secrets`
     // allowlist receives ONLY those IDENTIFIERS — so a narrowly-scoped agent
@@ -445,8 +455,6 @@ export async function buildSessionSandboxEnvVars(input: {
     // Runtime-delivered provider keys may reach the sandbox for user code.
     // OpenCode must not receive them because it would bypass the gateway.
     KORTIX_OPENCODE_DENY_ENV: input.llmGatewayEnabled ? nativeProviderEnvNames().join(',') : '',
-    KORTIX_PROJECT_AUTO_CLONE: input.platformMetaAgent ? '0' : '1',
-    ...(input.platformMetaAgent ? { KORTIX_META_AGENT: '1' } : {}),
     // No partial-clone filter. Blobless (`blob:none`) defers file blobs to
     // on-demand fetches, which stall through the Kortix git proxy when its
     // partial-clone capability isn't advertised consistently — the clone then
@@ -480,7 +488,14 @@ export async function buildSessionSandboxEnvVars(input: {
       // and as the session's OpenCode config default.
       opencodeModel: input.opencodeModel,
       compiledAgentConfig,
+      workspaceMode: input.workspaceMode,
     }),
+    // The platform coordinator uses API-level delegation and never receives a
+    // project checkout. Keep this override after buildSessionRuntimeEnv so the
+    // agent workspace mode cannot re-enable the daemon's automatic clone.
+    ...(input.platformMetaAgent
+      ? { KORTIX_PROJECT_AUTO_CLONE: '0', KORTIX_META_AGENT: '1' }
+      : {}),
   };
 }
 
@@ -758,6 +773,7 @@ export async function createProjectSession(input: {
       },
     };
   }
+  const workspaceMode = workspaceFromLoadedAgents(agentName, loadedAgents) ?? 'branch';
 
   const freeModelsOnly = config.KORTIX_BILLING_INTERNAL_ENABLED
     ? !tierGrantsAllModels(await getCachedAccountTier(accountId))
@@ -1129,6 +1145,7 @@ export async function createProjectSession(input: {
     // with it, and the turn-end deadline shortener stops child sandboxes on a
     // tight grace so finished workers don't idle at full compute.
     ...(input.callerSessionId ? { spawned_by_session: input.callerSessionId } : {}),
+    workspace_mode: workspaceMode,
     sandbox_slug: sandboxSlug,
   };
 
@@ -1301,6 +1318,7 @@ export async function createProjectSession(input: {
           baseSha,
           defaultBranch: project.defaultBranch,
           manifestPath: project.manifestPath,
+          workspaceMode,
         }),
         )
         .then((envVars) => {

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -88,7 +88,10 @@ import {
 } from '../session-title-generate';
 import { canOverride, resolveSessionOrigin } from './session-origin';
 import { sessionCreatedAuditEvent } from './session-audit';
-import { resolveSessionSandboxSlug } from './session-sandbox-metadata';
+import {
+  resolveSessionSandboxSlug,
+  workspaceModeAllowsFullRepository,
+} from './session-sandbox-metadata';
 import { projectSessionMetadataMerge } from './session-metadata-merge';
 import {
   buildSessionRuntimeContextEnv,
@@ -322,7 +325,7 @@ export async function buildSessionSandboxEnvVars(input: {
       gitAuthToken: null,
     };
     compiledAgentConfig =
-      input.workspaceMode === 'runtime'
+      !workspaceModeAllowsFullRepository(input.workspaceMode)
         ? await resolveSelectedAgentConfigForSession(
             gitProject,
             input.agentName,
@@ -774,6 +777,17 @@ export async function createProjectSession(input: {
     };
   }
   const workspaceMode = workspaceFromLoadedAgents(agentName, loadedAgents) ?? 'branch';
+  if (workspaceMode === 'read') {
+    return {
+      error: {
+        status: 409,
+        body: {
+          error: 'workspace mode "read" requires restricted workspace artifacts',
+          code: 'WORKSPACE_MODE_UNAVAILABLE',
+        },
+      },
+    };
+  }
 
   const freeModelsOnly = config.KORTIX_BILLING_INTERNAL_ENABLED
     ? !tierGrantsAllModels(await getCachedAccountTier(accountId))

--- a/apps/api/src/projects/routes/agent-config.ts
+++ b/apps/api/src/projects/routes/agent-config.ts
@@ -43,7 +43,11 @@ import { resolveTemplateBySlug } from '../../snapshots/templates';
 import { extractAgents } from '../agents';
 import { readRepoFile } from '../git';
 import { GitFileRevisionConflictError, commitMultipleFilesToBranch } from '../git/branches';
-import { assertProjectCapability, loadProjectForUser } from '../lib/access';
+import {
+  assertAgentSessionWorkspaceAllowsRepository,
+  assertProjectCapability,
+  loadProjectForUser,
+} from '../lib/access';
 import {
   applyAgentBlockV2,
   applyDefaultAgentV2,
@@ -163,6 +167,7 @@ projectsApp.openapi(
     const agentName = c.req.param('agentName');
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertAgentSessionWorkspaceAllowsRepository(c, loaded.row.accountId, projectId);
 
     let manifest;
     try {
@@ -227,6 +232,7 @@ projectsApp.openapi(
     const projectId = c.req.param('projectId');
     const loaded = await loadProjectForUser(c, projectId, 'manage');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertAgentSessionWorkspaceAllowsRepository(c, loaded.row.accountId, projectId);
     await assertProjectCapability(
       c,
       loaded.userId,
@@ -325,6 +331,7 @@ projectsApp.openapi(
     const agentName = c.req.param('agentName');
     const loaded = await loadProjectForUser(c, projectId, 'manage');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertAgentSessionWorkspaceAllowsRepository(c, loaded.row.accountId, projectId);
     await assertProjectCapability(
       c,
       loaded.userId,

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -26,10 +26,15 @@ import {
   sessionSandboxes,
 } from '@kortix/db';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
-import { loadProjectForUser, assertProjectCapability } from '../lib/access';
+import {
+  assertAgentSessionWorkspaceAllowsRepository,
+  loadProjectForUser,
+  assertProjectCapability,
+} from '../lib/access';
 import { AnyObject, SecretSchema, projectsApp } from '../lib/app';
 import { getProjectGitConnection, getProjectGitRemote, hasServerManagedGitAuth, loadGitProject, resolveProjectGitAuth, resolveProjectUpstream, upsertProjectGitConnection, upsertProjectGitCredential, withProjectGitAuth } from '../lib/git';
 import { CODEX_AUTH_JSON_SECRET_NAME, isSystemProjectSecretName, loadSecretViewsForUser, normalizeString, readBody, serializeProjectGitConnection } from '../lib/serializers';
+import { sessionWorkspaceAllowsRepositoryAccess } from '../lib/session-workspace-access';
 
 type ProjectSecretConsumer = z.infer<typeof SecretConsumerSchema>;
 
@@ -275,6 +280,7 @@ projectsApp.openapi(
     }
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertAgentSessionWorkspaceAllowsRepository(c, loaded.row.accountId, projectId);
     projectRow = loaded.row;
   } else if (authType === 'apiKey' && (c as any).get('apiKeyType') === 'sandbox') {
     const accountId = (c as any).get('accountId') as string | undefined;
@@ -283,7 +289,10 @@ projectsApp.openapi(
       return c.json({ error: 'clone credentials require a sandbox token' }, 403);
     }
     const [sandbox] = await db
-      .select({ sandboxId: sessionSandboxes.sandboxId })
+      .select({
+        sandboxId: sessionSandboxes.sandboxId,
+        sessionId: sessionSandboxes.sessionId,
+      })
       .from(sessionSandboxes)
       .where(and(
         eq(sessionSandboxes.sandboxId, sandboxId),
@@ -294,6 +303,15 @@ projectsApp.openapi(
       .limit(1);
     if (!sandbox) {
       return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
+    }
+    if (
+      !(await sessionWorkspaceAllowsRepositoryAccess({
+        sessionId: sandbox.sessionId,
+        accountId,
+        projectId,
+      }))
+    ) {
+      return c.json({ error: 'sandbox workspace does not allow repository access' }, 403);
     }
     const [row] = await db
       .select()

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -67,6 +67,11 @@ projectsApp.openapi(
 
   const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
+  await assertAgentSessionWorkspaceAllowsRepository(
+    c,
+    loaded.row.accountId,
+    projectId,
+  );
 
   await db
     .update(projects)

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -19,7 +19,12 @@ import {
 import { createRoute, z } from '@hono/zod-openapi';
 import { projects } from '@kortix/db';
 import { eq, type SQL } from 'drizzle-orm';
-import { assertProjectCapability, loadProjectForUser, projectCapabilityAllowed } from '../lib/access';
+import {
+  assertAgentSessionWorkspaceAllowsRepository,
+  assertProjectCapability,
+  loadProjectForUser,
+  projectCapabilityAllowed,
+} from '../lib/access';
 import { metadataMerge } from '../lib/metadata-merge';
 import { normalizeProjectIcon } from '../lib/project-icon';
 import { normalizeProjectGlyph } from '../lib/project-glyph';
@@ -96,6 +101,11 @@ projectsApp.openapi(
   const projectId = c.req.param('projectId');
   const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
+  await assertAgentSessionWorkspaceAllowsRepository(
+    c,
+    loaded.row.accountId,
+    projectId,
+  );
 
   const gitProject = await withProjectGitAuth(loaded.row);
   let files: Awaited<ReturnType<typeof listRepoFiles>> = [];

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -2231,7 +2231,12 @@ projectsApp.openapi(
     const baseRef = visible.row.baseRef ?? loaded.row.defaultBranch;
     const [running, latest] = await Promise.all([
       readSandboxConfigState({ sessionId }),
-      latestAgentConfigEtag({ projectId, accountId: loaded.row.accountId, baseRef }),
+      latestAgentConfigEtag({
+        projectId,
+        accountId: loaded.row.accountId,
+        sessionId,
+        baseRef,
+      }),
     ]);
     return c.json({
       base_ref: baseRef,

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -19,7 +19,12 @@ import {
 import { createRoute, z } from '@hono/zod-openapi';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, desc, eq } from 'drizzle-orm';
-import { loadProjectForUser, loadVisibleSession, assertProjectCapability } from '../lib/access';
+import {
+  assertAgentSessionWorkspaceAllowsRepository,
+  assertProjectCapability,
+  loadProjectForUser,
+  loadVisibleSession,
+} from '../lib/access';
 import { assertAgentScope } from '../../iam/agent-scope';
 import { PROJECT_ACTIONS } from '../../iam';
 import { callerKortixSessionId } from '../lib/caller-session';
@@ -765,6 +770,7 @@ projectsApp.openapi(
     const crId = c.req.param('crId');
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertAgentSessionWorkspaceAllowsRepository(c, loaded.row.accountId, projectId);
 
     const cr = await getCrById(crId, projectId);
     if (!cr) return c.json({ error: 'Change request not found' }, 404);
@@ -822,6 +828,7 @@ projectsApp.openapi(
     const crId = c.req.param('crId');
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertAgentSessionWorkspaceAllowsRepository(c, loaded.row.accountId, projectId);
 
     const cr = await getCrById(crId, projectId);
     if (!cr) return c.json({ error: 'Change request not found' }, 404);

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -16,7 +16,10 @@ import { and, eq, sql } from 'drizzle-orm';
 import { withProjectGitAuth } from '../lib/git';
 import { ProjectRow, serializeSessionSandboxConfig } from '../lib/serializers';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
-import { sandboxSlugFromSessionMetadata } from '../lib/session-sandbox-metadata';
+import {
+  sandboxSlugFromSessionMetadata,
+  workspaceModeFromSessionMetadata,
+} from '../lib/session-sandbox-metadata';
 import { buildSessionSandboxEnvVars, sandboxCallbackUnreachableReason } from '../lib/sessions';
 import { ensureOpencodeSessionPin } from '../opencode-mapping';
 import { inspectSandboxRuntime } from '../runtime-inspection';
@@ -270,6 +273,7 @@ export async function allocateRuntimeOnOpen(
         defaultBranch: loaded.row.defaultBranch,
         manifestPath: loaded.row.manifestPath,
         llmGatewayEnabled: projectLlmGatewayEnabled(loaded.row.metadata),
+        workspaceMode: workspaceModeFromSessionMetadata(session.metadata),
       }),
     resolveGitProject: async () => withProjectGitAuth(loaded.row),
   });

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -10,7 +10,10 @@ import { revokeSessionConnectorTokens } from '../../repositories/account-tokens'
 import { withProjectGitAuth } from '../lib/git';
 import { pushSessionAgentConfigToSandbox } from '../lib/sandbox-env-sync';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
-import { sandboxSlugFromSessionMetadata } from '../lib/session-sandbox-metadata';
+import {
+  sandboxSlugFromSessionMetadata,
+  workspaceModeFromSessionMetadata,
+} from '../lib/session-sandbox-metadata';
 import { buildSessionSandboxEnvVars, sandboxCallbackUnreachableReason } from '../lib/sessions';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { isMissingRuntimeError } from '../routes/shared';
@@ -230,6 +233,7 @@ export async function restartSession(input: {
           // meta agent config, so the daemon clones the project over the meta
           // workspace and wipes /workspace/AGENTS.md.
           platformMetaAgent: isMetaAgentName(session.agentName ?? ''),
+          workspaceMode: workspaceModeFromSessionMetadata(session.metadata),
         }),
       resolveGitProject: async () => withProjectGitAuth(loaded.row as any),
     });

--- a/docs/specs/2026-08-05-agent-environment-materialization.md
+++ b/docs/specs/2026-08-05-agent-environment-materialization.md
@@ -1,0 +1,351 @@
+# Agent Environment Materialization
+
+- **Status:** Proposed
+- **Date:** 2026-08-05
+- **Related:** `docs/specs/2026-06-28-project-authorization-runtime-governance.md`, `docs/specs/2026-07-05-agent-first-config-unification.md`
+
+## Decision
+
+Kortix constructs each session environment on the API. The sandbox receives only
+the selected agent's runtime files, permitted project files, declared data mounts,
+and short-lived capabilities.
+
+The sandbox still starts the selected harness. The sandbox does not discover or
+compile project policy from a repository clone.
+
+This design makes one rule enforceable:
+
+> If a file enters a sandbox, assume the agent can read, copy, change, and disclose
+> it. Do not deliver a file that the agent cannot access.
+
+## Problem
+
+Kortix already enforces secrets, connectors, and Kortix CLI permissions at the
+API. These controls terminate at a trusted service.
+
+Project files and harness configuration do not have the same boundary today:
+
+- The sandbox receives a project clone by default.
+- The clone contains every agent prompt, skill, tool, harness extension, grant,
+  project memory file, and project file on the selected branch.
+- The sandbox daemon resolves repository-local harness configuration after the
+  clone.
+- The manifest accepts `workspace: runtime|read|branch`, but no workspace
+  materializer enforces those values.
+- The Git proxy grants repository-level `read` or `write`. It does not grant
+  path-level access.
+- The server compiler emits the complete agent map. A compile failure can return
+  no compiled configuration and still permit a legacy session boot.
+
+Prompt instructions, harness permission globs, sparse checkout, and UNIX file
+permissions do not solve this problem. The agent has a shell. A clone credential
+can expose Git objects outside the visible working tree.
+
+## Scope
+
+The environment includes more than files:
+
+- Selected harness and harness configuration.
+- Agent prompt, skills, tools, and harness extensions.
+- Project workspace files.
+- Sandbox template, CPU, memory, disk, and runtime image.
+- Secret and connector references.
+- Kortix CLI capabilities.
+- Network egress policy.
+- Memory and volume mounts.
+
+Environment variables remain encrypted in the Kortix data plane. This design
+does not move configuration or secret values into volumes. Git remains the
+authoring and review source for agent definitions. Volumes carry working data.
+
+## Requirements resolved
+
+| Concern                                                      | Decision                                                                                             |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| Every sandbox receives the complete Git state                | Restricted modes receive a generated `WorkspaceArtifact`, not a clone.                               |
+| Agent configuration is assembled inside the governed sandbox | The API compiles one signed `SessionSpec`; the sandbox only materializes and starts it.              |
+| Harness and environment remain coupled                       | One normalized policy compiles through a harness adapter. The harness still runs inside the sandbox. |
+| An agent needs no project repository                         | `runtime` mode delivers only generated runtime files.                                                |
+| Agent switching can change file access                       | One agent is locked to one session. An access change creates a new sandbox.                          |
+| Per-agent templates can create an unbounded template count   | Shared base images remain generic. Content-addressed artifacts carry per-agent state.                |
+| Agents need different machine sizes                          | Each agent selects a permitted sandbox resource profile.                                             |
+| Volumes and data need agent ownership and sharing            | Volumes are separate resources with explicit agent ACLs and mount modes.                             |
+| Per-agent learning must coexist with shared project memory   | Memory has session, agent-private, project-shared, and reviewed classes.                             |
+| Multiple harness configurations need clean organization      | Root configuration imports data-only agent definitions and harness-specific files.                   |
+| Unpublished configuration can conflict with a session branch | `policy_sha` and `workspace_sha` are separate immutable references.                                  |
+| A meta-agent needs to coordinate specialized agents          | Every child receives an independent environment and delegated capability intersection.               |
+
+## Trust boundary
+
+Treat the following components as trusted:
+
+- Kortix API authorization.
+- Agent environment compiler.
+- Workspace materializer.
+- Secret, connector, Git, patch, volume, and network brokers.
+- Sandbox provider isolation.
+
+Treat the following components as untrusted:
+
+- Agent prompts and model output.
+- Harnesses and harness extensions.
+- Repository content.
+- Shell commands and processes inside the sandbox.
+- A sandbox user with administrative access inside that sandbox.
+
+Every remote capability must terminate at a Kortix broker. A harness permission
+is defense in depth. It is not the authorization boundary.
+
+## Core objects
+
+### AgentDefinition
+
+`AgentDefinition` is the Git-authored request for an agent environment. It can
+reference separate files to keep a large project manageable.
+
+One root `kortix.yaml` remains the entry point. It can import data-only agent
+definitions. Imports use repository-relative paths and deterministic merge rules.
+The compiler rejects import cycles, duplicate agent identifiers, path escapes,
+and excessive import depth or size.
+
+Do not use executable TypeScript configuration for the first version. Executable
+configuration introduces network access, non-deterministic output, dependency
+installation, and compiler escape risks.
+
+### SessionSpec
+
+The API compiles one `SessionSpec` from:
+
+- `project_id`, `session_id`, and selected `agent_id`.
+- Launching human or service principal.
+- Immutable policy and workspace Git SHAs.
+- Agent definition and resource grants.
+- Session-level narrowing.
+- Platform policy and compiler versions.
+
+The signed, content-addressed result contains:
+
+- One selected agent and one harness adapter output.
+- Workspace mode and workspace artifact digest.
+- Sandbox resource profile.
+- Permitted secret and connector identifiers.
+- Kortix CLI actions.
+- Network policy.
+- Memory and volume mount declarations.
+- Expiry, nonce, schema version, and content hash.
+
+`SessionSpec` contains no secret values, connector credentials, or bearer tokens.
+
+### WorkspaceArtifact
+
+The workspace materializer reads project files at an exact SHA. It produces a
+content-addressed artifact with permitted paths, file modes, and hashes.
+
+The materializer excludes `.git` for restricted modes. It rejects absolute paths,
+`..` traversal, escaping symbolic links, hard links, device files, case-folding
+collisions, and Unicode-normalization collisions. Submodules and Git LFS objects
+require explicit declarations and pinned revisions.
+
+### SessionToken
+
+The API issues a short-lived `SessionToken`. Its claims bind it to:
+
+- `account_id`, `project_id`, `session_id`, `sandbox_id`, and `agent_id`.
+- `SessionSpec` hash and policy revision.
+- Allowed broker audiences and actions.
+- Expiry and nonce.
+
+Every broker checks the token and current resource authorization. Copying the
+token to another sandbox or project must fail.
+
+## Workspace modes
+
+| Mode      | Files in sandbox                                     | Git credential | Use                                                           |
+| --------- | ---------------------------------------------------- | -------------- | ------------------------------------------------------------- |
+| `runtime` | Generated agent and harness files only               | No             | Connector work, reports, support, orchestration               |
+| `read`    | Read-only artifact containing selected project paths | No             | Analysis and document processing                              |
+| `patch`   | Writable artifact containing selected project paths  | No             | Restricted code and content changes                           |
+| `branch`  | Full project checkout                                | Yes            | Explicitly trusted engineering and project-maintenance agents |
+
+`runtime` becomes the default for new agents. Existing projects can retain a
+documented legacy full-clone mode during migration.
+
+Standard Git cannot provide confidential path-level access. Sparse checkout only
+changes the working tree. Reachable commits, trees, and blobs can still expose
+excluded content. Therefore `read` and `patch` never receive a Git credential.
+
+In `patch` mode, the agent submits a patch to the Kortix patch broker. The broker
+validates every create, update, delete, and rename against the allowed path set.
+It then applies the complete patch atomically to a change-request branch.
+
+`branch` means full repository read access. The Git proxy still restricts allowed
+refs, pushes, force pushes, tags, and protected branches. The product must label
+this mode as high trust.
+
+## Session creation flow
+
+1. The API resolves the launching human or service principal.
+2. The API locks one agent to the session.
+3. The API resolves `policy_sha` and `workspace_sha` once.
+4. The compiler loads only the selected agent and its declared dependencies.
+5. Authorization intersects the principal, project role, agent grant, session
+   narrowing, trigger delegation, and live resource grants. Denials win.
+6. The materializer creates the exact `WorkspaceArtifact` for the workspace mode.
+7. The API creates and signs `SessionSpec`.
+8. The API provisions a shared base sandbox with the selected resource profile.
+9. The sandbox verifies the signature and artifact hashes before readiness.
+10. The sandbox writes the selected harness files and starts the harness.
+11. The agent uses brokers for secrets, connectors, Kortix CLI, Git, patches, and
+    controlled network access.
+12. Session termination revokes tokens, unmounts data, and destroys writable
+    runtime state.
+
+This flow supports OpenCode, Codex, Claude Code, Pi, and future harnesses. The
+compiler produces one normalized policy. A harness adapter produces the harness
+files. The harness remains inside the sandbox.
+
+## Configuration and unpublished changes
+
+Use separate immutable references:
+
+- `policy_sha` selects reviewed agent policy and harness configuration.
+- `workspace_sha` selects project files for the session branch.
+
+An agent can propose a policy change through a change request. The change does
+not alter its running session. Previewing unreviewed policy requires a separate
+human permission and an explicit session option. Scheduled and webhook sessions
+must use reviewed policy.
+
+A behavior-only update, such as a prompt or model change, can produce a new
+signed `SessionSpec` generation and reload at an idle boundary. Any change to
+files, credentials, network, volumes, or capabilities creates a new sandbox.
+Removing access cannot make an existing sandbox forget bytes it already received.
+
+Agent switching follows the same rule. The safe default is a new session and a
+new sandbox. The previous transcript is not copied automatically because it can
+contain data that the next agent cannot access.
+
+## Per-agent resources
+
+### Sandbox profile and startup latency
+
+Each `AgentDefinition` selects a permitted sandbox profile. The API applies the
+project and account ceilings before provisioning.
+
+Do not create one immutable sandbox image per agent. That produces stale images
+and an unbounded template count. Use shared base images and content-addressed
+`SessionSpec` and `WorkspaceArtifact` delivery. Warm pools can be keyed by base
+image and sandbox profile. They must contain no project data.
+
+`runtime` agents can use smaller profiles because they do not clone or initialize
+a project repository.
+
+### Volumes
+
+A volume is an independently authorized resource. Its declaration defines owner,
+allowed agents, mount path, read or write access, quota, encryption, retention,
+and cross-session sharing.
+
+A shared volume is an explicit data-sharing edge between agents. It must never
+carry agent policy or the core harness configuration.
+
+### Memory
+
+Memory uses explicit resource classes:
+
+- Session scratch memory.
+- Agent-private memory.
+- Project-shared memory.
+- Reviewed, published project memory.
+
+An agent receives only declared memory resources. Per-agent learning does not
+require a separate repository. Agent-private and shared memory can coexist in one
+project when materialization and access are explicit.
+
+### Meta-agent and child sessions
+
+A meta-agent orchestrates child sessions through the Kortix CLI. Each child gets
+its own sandbox, `SessionSpec`, `WorkspaceArtifact`, and `SessionToken`.
+
+Child access is the intersection of the parent's delegatable access and the child
+agent's grants. The parent transfers inputs through explicit artifacts. A shared
+full repository or volume is not the default delegation mechanism.
+
+## Edge cases
+
+| Case                                           | Required behavior                                                                                                         |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Branch moves during compilation                | Resolve once and compile from the resulting SHA.                                                                          |
+| Branch is deleted or force-pushed              | Running artifacts remain immutable. New compilation fails if source objects are unavailable.                              |
+| Agent edits its policy                         | Current authority does not change. Activation requires reviewed policy or explicit preview permission.                    |
+| Config import is missing, cyclic, or ambiguous | Compilation fails closed with a precise error.                                                                            |
+| Server compilation fails                       | Restricted session creation fails. It never falls back to full clone or unrestricted config.                              |
+| Harness adapter version differs                | Sandbox rejects unsupported `SessionSpec` versions.                                                                       |
+| Symbolic link escapes an allowed path          | Materializer rejects the artifact.                                                                                        |
+| Rename crosses the allowed path boundary       | Patch broker validates source and destination, then rejects the patch.                                                    |
+| Submodule or LFS file is selected              | Compiler resolves the explicitly pinned object. The sandbox receives no extra credential.                                 |
+| Agent requests Git in `read` or `patch`        | Request is rejected. These modes have no Git credential.                                                                  |
+| Agent changes during a session                 | Start a new session and sandbox. Do not reuse the transcript by default.                                                  |
+| Access is revoked                              | Brokers reject new calls immediately. Terminate and rebuild to remove local files or runtime secrets.                     |
+| Runtime secret is required                     | Mark it as high risk. Never record its value. Destroy the sandbox after revocation.                                       |
+| Secret appears in logs or crashes              | Redact before transport and storage. Treat agent output as potentially sensitive.                                         |
+| Network destination redirects                  | Revalidate every destination. Block loopback, private networks, metadata services, and DNS rebinding.                     |
+| Harness extension executes code                | Treat it as code execution. Require a pinned artifact and explicit grant.                                                 |
+| Shared volume contains restricted data         | Volume ACLs and mount declarations must authorize every receiving agent.                                                  |
+| Warm sandbox is reused                         | Remove processes, writable layers, caches, mounts, credentials, and network sessions before use. New sandboxes are safer. |
+| Session token is copied or replayed            | Audience, sandbox, session, agent, hash, expiry, and nonce checks reject it.                                              |
+| Scheduled or webhook session starts            | Use a service principal and explicit trigger delegation. Never select an account owner implicitly.                        |
+| Concurrent sessions use one agent              | Give each session independent artifacts, tokens, scratch storage, and audit records.                                      |
+| Artifact is too large                          | Enforce path count, byte, compression-ratio, and compilation-time limits.                                                 |
+| Project is archived during a session           | Revoke brokers and terminate the runtime under project retention policy.                                                  |
+
+## Audit and explainability
+
+Store the `SessionSpec`, source SHAs, compiler version, artifact hashes, principal,
+selected agent, effective resource identifiers, token lifecycle, broker decisions,
+denials, sandbox verification, and termination reason.
+
+Do not store secret values, bearer tokens, or decrypted connector credentials.
+Record their version identifiers instead.
+
+The product must explain why each file or resource is present or absent. The
+session UI and CLI should show requested access, effective access, denied access,
+workspace mode, policy SHA, workspace SHA, and `SessionSpec` hash.
+
+## Implementation sequence
+
+1. Define and version `SessionSpec`, compiler inputs, and authorization decisions.
+2. Lock one agent to one session. Compile only that agent. Fail closed for
+   restricted projects.
+3. Bind sandbox and broker tokens to the selected agent and `SessionSpec` hash.
+4. Implement `runtime` mode without a repository clone or upstream Git credential.
+5. Implement `read` with a validated, read-only `WorkspaceArtifact`.
+6. Implement `patch` with server-side path validation and change-request output.
+7. Define `branch` as explicit full-repository access and restrict Git refs and
+   write operations.
+8. Add per-agent sandbox profiles, volumes, memory, and network policy.
+9. Add environment preview, decision explanations, and complete audit events.
+10. Migrate existing projects explicitly. Make `runtime` the new-agent default.
+
+## Verification gates
+
+- Compiler output is deterministic for identical inputs.
+- One agent's artifact contains no other agent prompt, skill, tool, or memory.
+- `runtime` starts with no project files, `.git`, or Git credential.
+- `read` cannot recover excluded files through Git objects, links, archives, or
+  alternate paths.
+- `patch` rejects denied creates, updates, deletes, and renames atomically.
+- `branch` exposes the full-read warning and rejects unauthorized refs and pushes.
+- A forged or replayed token fails every broker.
+- A revoked grant blocks the next broker call.
+- A policy change cannot expand a running session.
+- Agent switching creates a clean sandbox and does not copy restricted context.
+- Warm-pool reuse exposes no prior process, file, mount, cache, or credential.
+- Audit records reconstruct the effective environment without storing secrets.
+
+## Result
+
+Git remains the reviewable source for agent definitions. The Kortix API becomes
+the compiler and policy boundary. The sandbox becomes a disposable target that
+receives one exact environment. Harness choice, sandbox size, project files,
+memory, volumes, and remote resources become explicit per-agent decisions.


### PR DESCRIPTION
## Purpose

Kortix currently gives every session sandbox a full project clone. A restricted agent can read every file after those bytes enter the sandbox. Permission checks cannot restore file isolation after delivery.

This PR adds a server-enforced workspace boundary. The API decides which repository material a session can receive before the sandbox starts.

## Implemented checkpoints

| Commit | Checkpoint | Result |
| --- | --- | --- |
| `15ad3d01b7` | Architecture specification | Defines environment materialization, workspace modes, policy conflicts, delegation, audit, and verification gates. |
| `5d7f54998f` | Runtime workspace execution | Parses and persists `workspace: runtime`, disables the project clone, and compiles only the selected agent. |
| `cddc368342` | Git credential boundary | Removes Git coordinates and rejects runtime sandbox tokens at the Git proxy. |
| `a630948325` | Repository API boundary | Rejects runtime session PATs on Git, file, detail, and agent-config repository paths. |
| `e5ae3f98c6` | Credential bypass closure | Rejects project metadata and upstream clone credentials for both session credentials. |
| `a8a8d6a3c3` | Change-request content boundary | Rejects change-request patches and merge previews for runtime session PATs. |
| `68c0627cc6` | Read-mode fail-closed boundary | Rejects new `read` sessions until exact artifacts exist and protects historical `read` sessions from repository access. |

## Session flow

1. The API loads the selected agent declaration.
2. The API resolves and persists the workspace mode.
3. `workspace: runtime` disables the project clone.
4. `workspace: read` fails before session persistence until exact artifacts exist.
5. The API compiles only the selected agent configuration.
6. The sandbox receives no project clone or Git coordinates.
7. Repository-backed API routes re-check the persisted workspace mode.
8. A missing or mismatched session record fails closed.

## Workspace behavior

| Mode | Current behavior |
| --- | --- |
| `runtime` | Enforced. No project clone, Git coordinates, repository metadata, clone credentials, Git proxy access, file API access, repository detail, raw agent configuration, change-request patches, or merge previews. |
| `branch` | Preserves the existing full-clone behavior. |
| Unspecified | Preserves the existing branch behavior for migration safety. |
| `read` | Accepted by the manifest. Session creation returns `409 WORKSPACE_MODE_UNAVAILABLE` until exact artifact materialization exists. Historical rows receive no clone, Git coordinates, or repository API access. |
| `patch` | Defined in the specification. Patch-only materialization is not implemented in this PR. |

## Security properties

- Restricted workspace isolation applies even when the agent grant contains repository actions.
- Both sandbox tokens and session PATs are denied.
- Session lookup matches `session_id`, `project_id`, and `account_id`.
- Restart, reopen, reload, and freshness checks preserve the workspace mode.
- Runtime compilation fails closed.
- An invalid stored workspace mode resolves to the restricted runtime boundary.
- Missing legacy metadata remains compatible.
- Human JWT and ordinary PAT behavior remains unchanged.

If a file enters a sandbox, assume the agent can read, copy, change, and disclose it. Restricted agents therefore need server-built artifacts without `.git` data or upstream repository credentials.

## Verification

- API typecheck: exit `0`.
- Focused workspace and authorization tests: `162` passed. Two unrelated HTTP harness cases returned a blank `404`; their direct service-level equivalents passed.
- Full API suite: `5,695` passed, `64` skipped, `0` failed, `22,115` assertions.
- `ke2e` route coverage: `536/546` covered, `10` allowlisted, `0` uncovered.
- Live Daytona runtime session received no Git repository coordinates.
- The live session PAT received `403` from Git, file-content, project-detail, agent-config, project-metadata, clone-credential, change-request diff, and merge-preview routes.
- The live sandbox token received `403` from the clone-credential route.
- The same human JWT received `200` from the file-content route.
- A live local HTTP request for a `read` agent returned `409 WORKSPACE_MODE_UNAVAILABLE` and persisted `0` session rows.
- Slack maps the read-mode refusal to an actionable workspace configuration message instead of login guidance.
- Temporary project, user, database, and Daytona resources were removed.

## Remaining implementation

- Build signed, exact artifacts for `workspace: read`.
- Build patch-only artifacts and output validation for `workspace: patch`.
- Add signed session specifications and artifact attestations.
- Extend reconstruction audit events across materialization and patch application.
