### PR TITLE
The API ran turns as agents it never compiled

### DIFF
--- a/apps/api/src/projects/lib/prompt-agent-declared.test.ts
+++ b/apps/api/src/projects/lib/prompt-agent-declared.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The sandbox can create agents, so the API must not run turns as names the
+ * project never declared.
+ *
+ * Reproduced on dev before this was written: a `.md` uploaded into the working
+ * tree's `.kortix/opencode/agents/` — never in git, never compiled — appeared
+ * in `/agent` as `mode: primary` with the permissions its own frontmatter
+ * declared, and `prompt_async` naming it returned 204.
+ *
+ * The tests that matter here are the three verdicts that LOOK like approval and
+ * are not: a v1 project, an unreadable manifest, and the `default` sentinel.
+ * Collapsing any of them into "fine" either breaks every existing session or
+ * reopens the hole.
+ */
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+const projectRow = {
+  repoUrl: 'https://git.test/p.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+};
+
+let dbRow: typeof projectRow | undefined = projectRow;
+let dbThrows: Error | null = null;
+let loadResult: { specs: Array<{ name: string; enabled: boolean }> } | null = null;
+let loadThrows: Error | null = null;
+
+mock.module('../../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            if (dbThrows) throw dbThrows;
+            return dbRow ? [dbRow] : [];
+          },
+        }),
+      }),
+    }),
+  },
+}));
+
+mock.module('../agents', () => ({
+  loadProjectAgents: async () => {
+    if (loadThrows) throw loadThrows;
+    return loadResult ?? { specs: [], errors: [], defaultAgent: null };
+  },
+}));
+
+const { checkPromptAgentDeclared } = await import('./prompt-agent-declared');
+
+afterEach(() => {
+  dbRow = projectRow;
+  dbThrows = null;
+  loadResult = null;
+  loadThrows = null;
+});
+
+const declaring = (...names: string[]) => ({
+  specs: names.map((name) => ({ name, enabled: true })),
+});
+
+describe('checkPromptAgentDeclared', () => {
+  test('refuses an agent the project never declared', async () => {
+    // The injected-agent case, exactly.
+    loadResult = declaring('kortix', 'build');
+    const verdict = await checkPromptAgentDeclared({
+      projectId: 'p1',
+      requestedAgent: 'injected-probe-1785926232',
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict).toMatchObject({ kind: 'undeclared', agent: 'injected-probe-1785926232' });
+  });
+
+  test('allows an agent the project declares', async () => {
+    loadResult = declaring('kortix', 'build');
+    expect(await checkPromptAgentDeclared({ projectId: 'p1', requestedAgent: 'build' })).toEqual({
+      ok: true,
+    });
+  });
+
+  test('a DISABLED declared agent is not declared', async () => {
+    loadResult = { specs: [{ name: 'kortix', enabled: true }, { name: 'retired', enabled: false }] };
+    const verdict = await checkPromptAgentDeclared({ projectId: 'p1', requestedAgent: 'retired' });
+    expect(verdict).toMatchObject({ kind: 'undeclared' });
+  });
+
+  test('the `default` sentinel is not a concrete name and is never refused', async () => {
+    // Every session created without an explicit agent carries this. Refusing it
+    // would break all of them, and it names no agent to inject.
+    loadResult = declaring('kortix');
+    expect(await checkPromptAgentDeclared({ projectId: 'p1', requestedAgent: 'default' })).toEqual({
+      ok: true,
+    });
+  });
+
+  test('no requested agent is nothing to check', async () => {
+    loadResult = declaring('kortix');
+    expect(await checkPromptAgentDeclared({ projectId: 'p1', requestedAgent: null })).toEqual({
+      ok: true,
+    });
+  });
+
+  test('a project that declares NO agents lets any name through', async () => {
+    // A v1 `kortix.toml` project, or a v2 manifest with no `agents:` map. There
+    // is no declared set to be outside of, and inventing one here would break
+    // every existing v1 session to close a hole they do not have.
+    loadResult = { specs: [] };
+    expect(await checkPromptAgentDeclared({ projectId: 'p1', requestedAgent: 'anything' })).toEqual(
+      { ok: true },
+    );
+  });
+
+  test('an UNREADABLE manifest is unresolved, never an empty declaration', async () => {
+    // The distinction the whole file turns on. `loadProjectAgents` swallows a
+    // read error into a synthesized manifest by default; if that reached us it
+    // would look like "declares nothing", which we treat as "any name is fine".
+    loadThrows = new Error('git mirror unavailable');
+    const verdict = await checkPromptAgentDeclared({
+      projectId: 'p1',
+      requestedAgent: 'injected',
+    });
+    expect(verdict).toMatchObject({ kind: 'unresolved' });
+    expect(verdict.ok).toBe(false);
+  });
+
+  test('a project row read failure is unresolved, not permission', async () => {
+    dbThrows = new Error('db down');
+    const verdict = await checkPromptAgentDeclared({ projectId: 'p1', requestedAgent: 'injected' });
+    expect(verdict).toMatchObject({ kind: 'unresolved' });
+  });
+
+  test('a project with no default branch has no manifest to read', async () => {
+    dbRow = { ...projectRow, defaultBranch: null as unknown as string };
+    expect(await checkPromptAgentDeclared({ projectId: 'p1', requestedAgent: 'anything' })).toEqual(
+      { ok: true },
+    );
+  });
+
+  test('whitespace around the requested name does not smuggle a name past the check', async () => {
+    loadResult = declaring('kortix');
+    const verdict = await checkPromptAgentDeclared({
+      projectId: 'p1',
+      requestedAgent: '  injected  ',
+    });
+    expect(verdict).toMatchObject({ kind: 'undeclared', agent: 'injected' });
+  });
+});

--- a/apps/api/src/projects/lib/prompt-agent-declared.ts
+++ b/apps/api/src/projects/lib/prompt-agent-declared.ts
@@ -1,0 +1,122 @@
+/**
+ * Refuse a prompt that names an agent this project never declared.
+ *
+ * THE SANDBOX CAN CREATE AGENTS. A `.md` written into the working tree's
+ * `.kortix/opencode/agents/` directory becomes a live, selectable agent the
+ * next time opencode restarts. Verified on dev: a file that was never in git —
+ * never read by the compiler, never in the config the API pushes — appeared in
+ * `/agent` as `mode: primary` carrying the permissions its own frontmatter
+ * declared, and the API accepted a turn as it (HTTP 204).
+ *
+ * `agentSwitchRefusal` could not catch that, and the reason is subtle: its
+ * authorization branch only runs for a PROHIBITED SWITCH, and
+ * `isProhibitedAgentSwitch` returns false whenever the session is bound to the
+ * `default` sentinel — which is every session created without an explicit
+ * agent, i.e. the common path. So the IAM check existed and was simply never
+ * reached for the case that matters.
+ *
+ * This asks a different and much simpler question, one that does not depend on
+ * what the session happens to be bound to:
+ *
+ *   > Is the requested name an agent this PROJECT declares?
+ *
+ * That matters beyond running one turn. Every per-agent control we have —
+ * connector grants, the secrets `agent_scope` filter, Kortix CLI capabilities —
+ * keys on agent identity. If the box can mint a name, those controls are
+ * reasoning about an identity the box chose.
+ *
+ * DELIBERATELY NOT an authorization check. `authorize(PROJECT_AGENT_READ)`
+ * already exists on the switch path; widening when it runs is a separate change
+ * with its own blast radius. This closes the injection hole without touching
+ * IAM semantics.
+ */
+
+import { projects } from '@kortix/db';
+import { eq } from 'drizzle-orm';
+import { db } from '../../shared/db';
+import { loadProjectAgents } from '../agents';
+
+/** The sentinel a session carries when it is not bound to a concrete agent. */
+const DEFAULT_AGENT_SENTINEL = 'default';
+
+export type AgentDeclaredVerdict =
+  | { ok: true }
+  /** The project declares agents and this is not one of them. */
+  | { ok: false; kind: 'undeclared'; agent: string; declared: string[] }
+  /** We could not establish the declared set. Never treated as permission. */
+  | { ok: false; kind: 'unresolved'; detail: string };
+
+/**
+ * Is `requestedAgent` declared by this project?
+ *
+ * Returns `ok` — meaning "nothing to refuse" — in three cases that are NOT
+ * approval and must stay distinct from it:
+ *   - no concrete agent was requested (null, or the `default` sentinel),
+ *   - the project has no default branch, so there is no manifest to read,
+ *   - the project declares no agents at all (a v1 `kortix.toml` project, or a
+ *     v2 manifest with no `agents:` map). Inventing a policy for those would
+ *     break every existing session to close a hole they do not have.
+ *
+ * A manifest we cannot READ is different from a manifest that declares nothing,
+ * and is reported as `unresolved` so the caller can fail closed. Collapsing the
+ * two would turn a transient git error into "any agent name is fine", which is
+ * precisely the hole this exists to close.
+ */
+export async function checkPromptAgentDeclared(input: {
+  projectId: string;
+  requestedAgent: string | null;
+}): Promise<AgentDeclaredVerdict> {
+  const requested = input.requestedAgent?.trim();
+  if (!requested || requested === DEFAULT_AGENT_SENTINEL) return { ok: true };
+
+  let project: { repoUrl: string; defaultBranch: string | null; manifestPath: string | null } | undefined;
+  try {
+    [project] = await db
+      .select({
+        repoUrl: projects.repoUrl,
+        defaultBranch: projects.defaultBranch,
+        manifestPath: projects.manifestPath,
+      })
+      .from(projects)
+      .where(eq(projects.projectId, input.projectId))
+      .limit(1);
+  } catch (err) {
+    return { ok: false, kind: 'unresolved', detail: errorText(err) };
+  }
+
+  if (!project?.defaultBranch || !project.repoUrl) return { ok: true };
+
+  let declared: string[];
+  try {
+    // `rethrowReadErrors` is load-bearing, for the same reason it is in the
+    // connector pre-flight: by default `loadProjectAgents` swallows an
+    // unreadable manifest into a synthesized one, which here would read as
+    // "this project declares nothing" — and a project that declares nothing is
+    // one we let every agent name through. A read failure must reach the caller
+    // as a failure, not as an empty declaration.
+    const loaded = await loadProjectAgents(
+      {
+        projectId: input.projectId,
+        repoUrl: project.repoUrl,
+        defaultBranch: project.defaultBranch,
+        manifestPath: project.manifestPath ?? 'kortix.yaml',
+        gitAuthToken: null,
+      },
+      { rethrowReadErrors: true },
+    );
+    declared = loaded.specs.filter((spec) => spec.enabled).map((spec) => spec.name);
+  } catch (err) {
+    return { ok: false, kind: 'unresolved', detail: errorText(err) };
+  }
+
+  // No declared agents — a v1 project, or a v2 manifest without an `agents:`
+  // map. There is no declared set to be outside of.
+  if (declared.length === 0) return { ok: true };
+
+  if (declared.includes(requested)) return { ok: true };
+  return { ok: false, kind: 'undeclared', agent: requested, declared };
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -5,6 +5,7 @@ import { PROJECT_ACTIONS, authorize } from '../../iam';
 import { getTraceHeaders } from '../../lib/request-context';
 import type { ProviderName } from '../../platform/providers';
 import { callerKortixSessionId } from '../../projects/lib/caller-session';
+import { checkPromptAgentDeclared } from '../../projects/lib/prompt-agent-declared';
 import {
   PromptConnectorPreflightUnresolved,
   type PromptConnectorVerdict,
@@ -468,6 +469,57 @@ async function agentSwitchRefusal(
 }
 
 /**
+ * Refuse a turn naming an agent the project never declared, or 503 when we
+ * could not establish the declared set.
+ *
+ * 403 rather than 409: this is not a state conflict the caller can resolve by
+ * starting a new session — the name is not one this project has. 503 for
+ * `unresolved`, matching the connector pre-flight: failing to ESTABLISH the
+ * answer must not read as approval, and a client retries a 503 while it never
+ * retries a 4xx.
+ */
+async function undeclaredAgentRefusal(
+  record: { projectId: string },
+  requestedAgent: string | null,
+  sandboxId: string,
+  origin?: string,
+): Promise<Response | null> {
+  const verdict = await checkPromptAgentDeclared({
+    projectId: record.projectId,
+    requestedAgent,
+  });
+  if (verdict.ok) return null;
+
+  if (verdict.kind === 'unresolved') {
+    console.warn(
+      `[PREVIEW] Could not resolve declared agents for ${sandboxId}: ${verdict.detail}`,
+    );
+    return jsonProxyError(
+      {
+        error: 'Could not verify the requested agent against this project.',
+        code: 'AGENT_DECLARATION_UNRESOLVED',
+      },
+      503,
+      origin,
+    );
+  }
+
+  console.warn(
+    `[PREVIEW] Refused prompt on ${sandboxId}: agent '${verdict.agent}' is not declared by this project`,
+  );
+  return jsonProxyError(
+    {
+      error: `The agent '${verdict.agent}' is not declared in this project.`,
+      message: `The agent '${verdict.agent}' is not declared in this project.`,
+      code: 'AGENT_NOT_DECLARED',
+      requested_agent: verdict.agent,
+    },
+    403,
+    origin,
+  );
+}
+
+/**
  * The refusal body, or null to let the turn through.
  *
  * The shape is byte-identical to what session CREATE returns for the same two
@@ -879,6 +931,13 @@ export async function forwardToSandbox(
     // caller who may not run it should be able to enumerate by asking.
     const unauthorized = await agentSwitchRefusal(record, promptAgent, userId, sandboxId, origin);
     if (unauthorized) return unauthorized;
+    // Before the connector gate for the same reason the authorization check is:
+    // the gate's refusal enumerates the agent's required connectors, and an
+    // agent this project never declared should not be able to answer questions
+    // about itself. See prompt-agent-declared.ts for why this cannot be folded
+    // into agentSwitchRefusal.
+    const undeclared = await undeclaredAgentRefusal(record, promptAgent, sandboxId, origin);
+    if (undeclared) return undeclared;
     const refusal = await connectorGateRefusal(record, promptAgent, origin);
     if (refusal) return refusal;
   }


### PR DESCRIPTION
## The sandbox can create agents

A `.md` written into the working tree's `.kortix/opencode/agents/` becomes a live, selectable agent the next time opencode restarts. Reproduced end-to-end on dev:

```
agents BEFORE : kortix, build, compaction, explore, general, memory-reflector, plan, summary, title
upload        : agents/injected-probe-<stamp>.md        ← never in git
restart       : 200
agents AFTER  : … + injected-probe-<stamp>
                mode: primary
                description: from MY frontmatter
                permission: bash/edit/webfetch allow, exactly as MY file declared
prompt_async naming it → HTTP 204, accepted
```

The compiler never saw that file. The config the API pushes never contained it. The API ran a turn as it anyway.

## Why the existing gate missed it

`agentSwitchRefusal` *does* hold the right check — `authorize(PROJECT_AGENT_READ)` on the requested agent. But it only runs inside a **prohibited switch**, and `isProhibitedAgentSwitch` returns false whenever the session is bound to the `default` sentinel:

```ts
if (sessionAgent === DEFAULT_AGENT_SENTINEL) return false;
```

That's every session created without an explicit agent — the common path. So the authorization existed and was never reached for the case that matters.

## What this adds

A different question that doesn't depend on what the session is bound to: **is the requested name one this project declares?**

Deliberately **not** an authorization change. Widening when `authorize` runs has its own blast radius and belongs in its own PR. This closes the injection without touching IAM semantics.

It matters past running one turn: connector grants, the secrets `agent_scope` filter and Kortix CLI capabilities all key on agent identity. If the box can mint a name, every one of those is reasoning about an identity the box chose.

## The three verdicts that look like approval and aren't

This is where the care went — each would either break existing sessions or reopen the hole:

| case | why it must pass | why it isn't approval |
|---|---|---|
| the `default` sentinel | every session without an explicit agent carries it | it names no agent, so nothing to inject |
| project declares **no** agents (v1 `kortix.toml`, or v2 with no `agents:`) | there's no declared set to be outside of | inventing a policy would break every v1 session to close a hole they don't have |
| manifest **unreadable** | — | returns `unresolved` → **503**, never silent approval |

`rethrowReadErrors: true` is load-bearing on that last row: without it `loadProjectAgents` synthesizes an empty manifest on a git hiccup, which reads as "declares nothing" — which we treat as "any agent name is fine". That's precisely the hole being closed, re-opened by a transient error.

Placed before the connector gate for the same reason the authorization check is: that gate's refusal enumerates an agent's required connectors, and an agent this project never declared shouldn't get to answer questions about itself.

## Testing

Reverting the membership test fails 3 of the 10 tests (undeclared, disabled-agent, whitespace-trimmed).

**Gates:** apps/api `tsc` clean on the changed files; `prompt-agent-declared` **10 pass / 0 fail**; preview + warm-session suites **39 pass / 0 fail**.

## Not fixed here

The box can still *create* the agent — this stops the API running turns as it. Constraining which `agents/*.md` opencode may load is the follow-up, and it's the part [the materialization spec](docs/specs/2026-08-05-agent-environment-materialization.md) is really about.

I also have **not** demonstrated capability *gain*: the base template sets `"permission": "allow"` globally, so the injected agent may hold no more than the default one. A project with restrictive per-agent permissions would settle that, and is worth checking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)