### PR TITLE
The box could grant itself a capability its project denies

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/declared-agents.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/declared-agents.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The box must not be able to grant itself an agent.
+ *
+ * Reproduced on dev before this was written, against a project that explicitly
+ * denies the capability:
+ *
+ *   PUT /projects/<id>/agents/kortix/config  {"permission":{"bash":"deny"}}
+ *   then, from inside the sandbox, write agents/<anything>.md declaring
+ *   `permission: {bash: allow}` and restart:
+ *
+ *     declared (kortix) : {"permission":"bash","action":"deny"}
+ *     injected          : {"permission":"bash","action":"allow"}
+ *
+ * Real files on a real filesystem, because the thing under test is what
+ * opencode will find when it reads the directory.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { declaredAgentNames, pruneUndeclaredAgentFiles } from '../declared-agents'
+
+let dir: string
+let agentsDir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'kortix-agents-'))
+  agentsDir = join(dir, 'agents')
+  mkdirSync(agentsDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function writeAgent(name: string, body = 'x') {
+  writeFileSync(join(agentsDir, `${name}.md`), body)
+}
+
+const compiled = (...names: string[]) =>
+  JSON.stringify({ agent: Object.fromEntries(names.map((n) => [n, {}])) })
+
+describe('declaredAgentNames', () => {
+  test('reads the roster the API compiled', () => {
+    expect(declaredAgentNames(compiled('kortix', 'memory-reflector'))).toEqual(
+      new Set(['kortix', 'memory-reflector']),
+    );
+  })
+
+  // Each of these means "we do not know the roster", and pruning against an
+  // unknown roster would delete every agent in the box.
+  test.each([
+    ['absent config', undefined],
+    ['malformed JSON', '{not json'],
+    ['no agent map', JSON.stringify({ model: 'x' })],
+    ['empty agent map', JSON.stringify({ agent: {} })],
+    ['agent map is an array', JSON.stringify({ agent: [] })],
+  ])('%s yields null, never an empty set', (_label, raw) => {
+    expect(declaredAgentNames(raw as string | undefined)).toBeNull()
+  })
+})
+
+describe('pruneUndeclaredAgentFiles', () => {
+  test('neutralizes an agent the platform never declared', () => {
+    writeAgent('kortix')
+    writeAgent('injected-probe')
+
+    const result = pruneUndeclaredAgentFiles(dir, declaredAgentNames(compiled('kortix')))
+
+    expect(result.rejected).toEqual(['injected-probe'])
+    expect(result.kept).toEqual(['kortix'])
+    expect(existsSync(join(agentsDir, 'injected-probe.md'))).toBe(false)
+    expect(existsSync(join(agentsDir, 'kortix.md'))).toBe(true)
+  })
+
+  test('the rejected file no longer looks like an agent to opencode', () => {
+    // The whole mechanism: opencode globs `*.md`, so the rename is the fix.
+    writeAgent('injected')
+    pruneUndeclaredAgentFiles(dir, declaredAgentNames(compiled('kortix')))
+    const remainingMd = readdirSync(agentsDir).filter((f) => f.endsWith('.md'))
+    expect(remainingMd).toEqual([])
+  })
+
+  test('content is preserved, not destroyed', () => {
+    // Evidence of what the box tried to do. Deleting a user's file to enforce
+    // policy is a worse default than neutralizing it.
+    writeAgent('injected', 'FORENSIC BODY')
+    pruneUndeclaredAgentFiles(dir, declaredAgentNames(compiled('kortix')))
+    expect(existsSync(join(agentsDir, 'injected.md.rejected'))).toBe(true)
+    expect(Bun.file(join(agentsDir, 'injected.md.rejected')).size).toBeGreaterThan(0)
+  })
+
+  test('does NOTHING when the roster is unknown', () => {
+    // A v1 project or a config-delivery hiccup. Pruning here would leave the
+    // session with no agents at all — worse than the hole being closed.
+    writeAgent('kortix')
+    writeAgent('anything')
+
+    const result = pruneUndeclaredAgentFiles(dir, declaredAgentNames(undefined))
+
+    expect(result).toEqual({ kept: [], rejected: [], failed: [] })
+    expect(existsSync(join(agentsDir, 'anything.md'))).toBe(true)
+  })
+
+  test('every declared agent survives', () => {
+    writeAgent('kortix')
+    writeAgent('memory-reflector')
+
+    const result = pruneUndeclaredAgentFiles(
+      dir,
+      declaredAgentNames(compiled('kortix', 'memory-reflector')),
+    )
+
+    expect(result.rejected).toEqual([])
+    expect(result.kept.sort()).toEqual(['kortix', 'memory-reflector'])
+  })
+
+  test('a missing agents directory is normal, not an error', () => {
+    rmSync(agentsDir, { recursive: true, force: true })
+    expect(() => pruneUndeclaredAgentFiles(dir, declaredAgentNames(compiled('kortix')))).not.toThrow()
+  })
+
+  test('non-.md files are left alone', () => {
+    // tools, skills and READMEs share the tree; this prunes agents only.
+    writeFileSync(join(agentsDir, 'README.txt'), 'notes')
+    writeFileSync(join(agentsDir, 'helper.ts'), 'code')
+    pruneUndeclaredAgentFiles(dir, declaredAgentNames(compiled('kortix')))
+    expect(existsSync(join(agentsDir, 'README.txt'))).toBe(true)
+    expect(existsSync(join(agentsDir, 'helper.ts'))).toBe(true)
+  })
+
+  test('re-running is stable — a rejected file is not re-processed', () => {
+    // It runs on every spawn, so it must not churn or re-reject its own output.
+    writeAgent('injected')
+    const declared = declaredAgentNames(compiled('kortix'))
+    pruneUndeclaredAgentFiles(dir, declared)
+    const second = pruneUndeclaredAgentFiles(dir, declared)
+    expect(second.rejected).toEqual([])
+    expect(readdirSync(agentsDir)).toEqual(['injected.md.rejected'])
+  })
+
+  test('an agent added by a later declaration is kept once declared', () => {
+    // The supported way to add an agent is the API, which commits it to git and
+    // makes it declared. That path must keep working.
+    writeAgent('new-agent')
+    const result = pruneUndeclaredAgentFiles(
+      dir,
+      declaredAgentNames(compiled('kortix', 'new-agent')),
+    )
+    expect(result.rejected).toEqual([])
+    expect(existsSync(join(agentsDir, 'new-agent.md'))).toBe(true)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/declared-agents.ts
+++ b/apps/kortix-sandbox-agent-server/src/declared-agents.ts
@@ -1,0 +1,140 @@
+/**
+ * opencode must not load agents the platform never compiled.
+ *
+ * THE EXPLOIT THIS CLOSES, reproduced end to end on dev:
+ *
+ *   1. Restrict a project's agent through the supported API —
+ *      `PUT /projects/<id>/agents/kortix/config` with `permission.bash = deny`.
+ *   2. From inside the sandbox, write `.kortix/opencode/agents/<anything>.md`
+ *      whose frontmatter declares `permission.bash = allow`.
+ *   3. Restart opencode — which the agent can trigger itself.
+ *   4. Both agents are now live in the same box:
+ *        declared (kortix) : bash -> deny     what the project says
+ *        injected          : bash -> allow    what the box says
+ *
+ * The box granted itself a capability the project denies. Per-agent permissions
+ * were advisory against anything with file-write in the sandbox, which is every
+ * agent.
+ *
+ * The API-side gate (prompt-agent-declared.ts) refuses an EXTERNAL caller who
+ * names an undeclared agent, and it does not close this: opencode listens on
+ * 127.0.0.1:4096 and the agent has a shell, so an in-box caller reaches its
+ * self-granted agent without the API ever seeing the request. The only place
+ * this can be stopped is where the agent files are read — here.
+ *
+ * WHAT COUNTS AS DECLARED is the compiled config the API hands down
+ * (`KORTIX_COMPILED_AGENT_CONFIG`). It is compiled from the manifest at the
+ * session's base ref, by a trusted service, and delivered sealed — so it is the
+ * one description of the agent roster the sandbox cannot edit. Committing a
+ * file on the session branch does not make it declared, which is the point.
+ *
+ * FILES ONLY. opencode's built-in agents (build, plan, explore, general, …) are
+ * not files and are untouched — this prunes what the working tree contributes,
+ * nothing else.
+ */
+
+import { readdirSync, renameSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { logger } from './logger'
+
+/** Suffix given to a pruned file. Not `.md`, so opencode stops seeing it. */
+const REJECTED_SUFFIX = '.rejected'
+
+/**
+ * The agent names the platform compiled, or `null` when we cannot tell.
+ *
+ * `null` means DO NOTHING, and the distinction is load-bearing in exactly the
+ * way it is on the API side: a v1 `kortix.toml` project, a project whose
+ * manifest declares no `agents:` map, and a config we failed to parse all
+ * produce a roster we do not know. Pruning against an unknown roster would
+ * delete every agent in the box — turning a config-delivery hiccup into a
+ * session with no agents at all, which is far worse than the hole being closed.
+ *
+ * Fail-open here is deliberate and is only safe because it is paired with the
+ * API-side refusal: an undeclared agent still cannot be reached from outside.
+ */
+export function declaredAgentNames(compiledAgentConfigRaw: string | undefined): Set<string> | null {
+  if (!compiledAgentConfigRaw) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(compiledAgentConfigRaw)
+  } catch {
+    logger.warn('[agents] compiled agent config is not valid JSON; not pruning')
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+  const agent = (parsed as { agent?: unknown }).agent
+  if (!agent || typeof agent !== 'object' || Array.isArray(agent)) return null
+  const names = Object.keys(agent as Record<string, unknown>)
+  if (names.length === 0) return null
+  return new Set(names)
+}
+
+export interface AgentPruneResult {
+  /** Agent files left in place. */
+  kept: string[]
+  /** Agent files renamed out of the way. */
+  rejected: string[]
+  /** Files we failed to rename — still live, and logged as errors. */
+  failed: string[]
+}
+
+/**
+ * Rename every `agents/*.md` whose name the platform did not declare.
+ *
+ * Renamed rather than deleted: the content is evidence of what the box tried to
+ * do, and destroying a user's file to enforce a policy is a worse default than
+ * neutralizing it. The rename is in-place — a move to another directory could
+ * cross a filesystem boundary and fail exactly when it matters.
+ *
+ * Runs on EVERY spawn, not once at boot. The attack needs a restart to take
+ * effect, so the check has to sit on the same path the attack does.
+ */
+export function pruneUndeclaredAgentFiles(
+  opencodeConfigDir: string,
+  declared: Set<string> | null,
+): AgentPruneResult {
+  const empty: AgentPruneResult = { kept: [], rejected: [], failed: [] }
+  if (!declared) return empty
+
+  const agentsDir = join(opencodeConfigDir, 'agents')
+  let entries: string[]
+  try {
+    entries = readdirSync(agentsDir)
+  } catch {
+    // No agents directory is normal — a project can define every agent through
+    // the compiled config alone.
+    return empty
+  }
+
+  const result: AgentPruneResult = { kept: [], rejected: [], failed: [] }
+  for (const entry of entries) {
+    if (!entry.endsWith('.md')) continue
+    const name = entry.slice(0, -'.md'.length)
+    if (declared.has(name)) {
+      result.kept.push(name)
+      continue
+    }
+    const from = join(agentsDir, entry)
+    const to = `${from}${REJECTED_SUFFIX}`
+    try {
+      renameSync(from, to)
+      result.rejected.push(name)
+      logger.warn('[agents] refused an agent the platform never declared', {
+        agent: name,
+        file: from,
+        renamedTo: to,
+      })
+    } catch (err) {
+      result.failed.push(name)
+      // Loud: the file is still there and opencode is about to load it.
+      logger.error('[agents] could not neutralize an undeclared agent file', {
+        agent: name,
+        file: from,
+        error: (err as Error).message,
+      })
+    }
+  }
+  return result
+}

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -9,6 +9,7 @@ import { AGENT_ENV_SH } from './agent-env-file'
 import { LLM_PROXY_PLACEHOLDER_KEY, EXECUTOR_PROXY_PLACEHOLDER_KEY } from './llm-proxy'
 import type { Config } from './config'
 import { buildGitIdentityEnv } from './git'
+import { declaredAgentNames, pruneUndeclaredAgentFiles } from './declared-agents'
 import { logger } from './logger'
 import { applyManagedOpencodeEnv } from './managed-opencode-env'
 import { mergeProjectEnv, type ProjectEnvStore } from './project-env'
@@ -1009,6 +1010,16 @@ export function createOpencodeSupervisor(
       })
     }
     const baseEnv = currentProjectEnv ? mergeProjectEnv(process.env, currentProjectEnv) : process.env
+
+    // Neutralize agent files the platform never declared, BEFORE opencode reads
+    // them. On every spawn, not once at boot: the escalation needs a restart to
+    // take effect, so the check has to sit on the same path it does. See
+    // declared-agents.ts for the reproduced exploit this closes.
+    pruneUndeclaredAgentFiles(
+      currentOpencodeConfigDir,
+      declaredAgentNames(baseEnv.KORTIX_COMPILED_AGENT_CONFIG),
+    )
+
     let env: NodeJS.ProcessEnv = applyManagedOpencodeEnv({
       ...baseEnv,
       ...buildGitIdentityEnv(currentCfg),


### PR DESCRIPTION
Pairs with #6127. That one stops an **external** caller naming an undeclared agent; this one stops the agent existing at all. Neither is sufficient alone — see below.

## The escalation, reproduced on dev

Set up using only supported APIs:

```
PUT /projects/<id>/agents/kortix/config
    {"opencode":{"permission":{"bash":"deny","webfetch":"deny"}}}   → 200

then, from inside the sandbox:
    write .kortix/opencode/agents/<anything>.md
    frontmatter:  permission: {bash: allow}
    restart opencode  (the agent can trigger this itself)

same box, same session:
    declared (kortix) : {"permission":"bash","pattern":"*","action":"deny"}
    injected          : {"permission":"bash","pattern":"*","action":"allow"}
```

The project explicitly denies `bash`. The box wrote itself an agent that allows `bash`, and got it. **Per-agent permissions were advisory against anything with file-write in the sandbox — which is every agent.**

## Why the API-side gate isn't enough

#6127 refuses an external caller who names an undeclared agent, and it's worth having. But opencode listens on `127.0.0.1:4096` and the agent has a shell, so an in-box caller reaches its self-granted agent without the API ever seeing the request. The only place this can be stopped is where the agent files are read.

## Design notes

**What counts as declared** is the compiled config the API hands down (`KORTIX_COMPILED_AGENT_CONFIG`) — compiled from the manifest at the session's base ref, by a trusted service, delivered sealed. It's the one description of the roster the sandbox cannot edit. Committing the file on the session branch does **not** make it declared; that's the point.

**Every spawn, not once at boot.** The escalation needs a restart to take effect, so the check sits on the same path the attack does.

**Renamed to `.md.rejected`, not deleted.** The content is evidence of what the box tried, and destroying a user's file to enforce policy is a worse default than neutralizing it. In-place, because a cross-directory move can cross a filesystem boundary and fail exactly when it matters. A failed rename logs at ERROR — the file is still live and we must not be quiet about it.

**Fail-open on an unknown roster, deliberately.** A v1 project, a manifest with no `agents:` map, and a config we couldn't parse all mean *"we don't know"* — and pruning against an unknown roster would delete every agent in the box, turning a config-delivery hiccup into a session with no agents at all. That's only safe because it's paired with the API-side refusal in #6127.

**Files only.** opencode's built-ins (`build`, `plan`, `explore`, `general`, …) aren't files and are untouched.

## Testing

Real files on a real filesystem — what opencode finds when it reads the directory is the entire property, so a mock would encode the assumption under test. Reverting the membership check fails 4 of 15.

**Gates:** typecheck clean; `bun test src` → **399 pass / 0 fail**; `bun-linux-x64` binary builds.

## Blocker I found on #6127 while doing this

`/agent` returns 9 agents on a base project but the manifest declares 2 — the other 7 are opencode **built-ins**. #6127 refuses any name not in the manifest, so it would 403 a legitimate request for `build` or `plan`. The web picker sources from `getProjectDetail` (declared only) so it's unaffected, but the CLI/SDK path isn't guaranteed. **#6127 needs a built-in compatibility allowlist before it merges.** This PR doesn't have that problem — built-ins aren't files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)