### PR TITLE
fix(web): new session scope defaults to null secrets, not explicit zero

### DIFF
--- a/apps/web/src/features/session/scope/create-scoped-session.test.ts
+++ b/apps/web/src/features/session/scope/create-scoped-session.test.ts
@@ -96,4 +96,56 @@ describe('createScopedSession', () => {
 
     expect(calls).toEqual(['replace']);
   });
+
+  test('a new-session draft with null secrets PUTs null, not an explicit zero', async () => {
+    // Regression: a browser-created session starts with no user override, which
+    // is `secrets: null` — "inherit everything the agent's grant allows". The
+    // scope replacement MUST carry `null`, because `[]` is the opposite ("inject
+    // zero project secrets") and silently denied every browser session its grant.
+    let replacement: SessionScopeInput | undefined;
+
+    await createScopedSession({
+      create: async () => 'session-4',
+      draft: { secrets: null, connector_bindings: {}, require_connectors: [] },
+      availability: { secrets: true, connector_bindings: true },
+      readScope: async () => scope,
+      replaceScope: async (_id, input) => {
+        replacement = input;
+      },
+      onReady: () => {},
+    });
+
+    expect(replacement).toEqual({
+      secrets: null,
+      connector_bindings: {},
+      require_connectors: [],
+    });
+    expect(replacement?.secrets).toBeNull();
+  });
+
+  test('an explicit zero-secrets draft still PUTs [] (deliberate deselect is preserved)', async () => {
+    // The flip side of the regression: a user who deliberately deselected every
+    // secret MUST still get `[]` — that is a real, explicit "inject zero project
+    // secrets", not a no-op. Conflating it with null would silently re-grant a
+    // secret the user meant to withhold.
+    let replacement: SessionScopeInput | undefined;
+
+    await createScopedSession({
+      create: async () => 'session-5',
+      draft: { secrets: [], connector_bindings: {}, require_connectors: [] },
+      availability: { secrets: true, connector_bindings: true },
+      readScope: async () => scope,
+      replaceScope: async (_id, input) => {
+        replacement = input;
+      },
+      onReady: () => {},
+    });
+
+    expect(replacement).toEqual({
+      secrets: [],
+      connector_bindings: {},
+      require_connectors: [],
+    });
+    expect(replacement?.secrets).toEqual([]);
+  });
 });

--- a/apps/web/src/features/session/scope/session-scope-model.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.test.ts
@@ -133,7 +133,13 @@ describe('createSessionScopeDraft', () => {
 });
 
 describe('createNewSessionScopeDraft', () => {
-  test('starts with no secrets or connector authorizations selected', () => {
+  test('starts with unrestricted secrets (null) and no connector authorizations selected', () => {
+    // `null` is the no-override state — "inherit everything the agent's grant
+    // allows", identical to how a server-created session starts. `[]` would be an
+    // explicit "inject zero project secrets", which silently denied every
+    // browser-created session its grant. A user who deliberately wants zero can
+    // still get `[]` via `setAllSessionSecrets(draft, false)`; the two are
+    // opposite and must not be conflated.
     const catalog = buildSessionScopeSelectionCatalog({
       secrets: ready([secret('MAIL_TOKEN')]),
       connectors: ready([connector('mail-read', 'project'), connector('issues', 'user')]),
@@ -147,7 +153,26 @@ describe('createNewSessionScopeDraft', () => {
     });
 
     expect(createNewSessionScopeDraft(catalog)).toEqual({
-      secrets: [],
+      secrets: null,
+      connector_bindings: {},
+      require_connectors: [],
+    });
+  });
+
+  test('preserves null secrets even when the secret catalog is ready but empty', () => {
+    // An empty (but loaded) secret catalog is still "no override" for a new
+    // session — the grant ceiling happens to list nothing, so `null` and `[]`
+    // happen to deliver the same set, but the SEMANTICS differ and a later grant
+    // expansion must widen a `null` session automatically. Stay `null`.
+    const catalog = buildSessionScopeSelectionCatalog({
+      secrets: ready([]),
+      connectors: ready([]),
+      authorizations: ready([]),
+      grants: { secrets: 'all', connectors: 'all' },
+    });
+
+    expect(createNewSessionScopeDraft(catalog)).toEqual({
+      secrets: null,
       connector_bindings: {},
       require_connectors: [],
     });
@@ -204,6 +229,24 @@ describe('buildSessionScopeReplacement', () => {
     // about them. Omitted and empty are opposite here, exactly as for secrets.
     expect(buildSessionScopeReplacement({ connector_bindings: {} })).toEqual({
       connector_bindings: {},
+    });
+  });
+
+  test('a new-session draft with null secrets stays null in the replacement', () => {
+    // Regression: `createNewSessionScopeDraft` returns `secrets: null` (no
+    // override). The replacement MUST carry `null` — "stop narrowing, inherit the
+    // grant" — not `[]` ("inject zero project secrets"). The two are opposite, and
+    // flipping null to [] silently denied every browser-created session its grant.
+    expect(
+      buildSessionScopeReplacement({
+        secrets: null,
+        connector_bindings: {},
+        require_connectors: [],
+      }),
+    ).toEqual({
+      secrets: null,
+      connector_bindings: {},
+      require_connectors: [],
     });
   });
 

--- a/apps/web/src/features/session/scope/session-scope-model.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.ts
@@ -110,7 +110,13 @@ export function createNewSessionScopeDraft(
 ): SessionScopeDraft {
   const draft: SessionScopeDraft = {};
   if (catalog.secrets.status === 'ready') {
-    draft.secrets = [];
+    // No user override yet. `null` means "inherit everything the agent's grant
+    // allows" — the same state a server-created session starts in. `[]` would be
+    // an EXPLICIT "inject zero project secrets", which silently denied every
+    // browser-created session its grant on the first prompt. The user can still
+    // deliberately deselect all (see `setAllSessionSecrets`) to get `[]`; the
+    // two are opposite and must not be conflated.
+    draft.secrets = null;
   }
   if (catalog.connector_profiles.status === 'ready') {
     draft.connector_bindings = {};

--- a/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
@@ -65,16 +65,21 @@ describe('getSessionScopeAvailability', () => {
 });
 
 describe('createNewSessionScopeInitialization', () => {
-  test('commits default-deny scope before the first prompt', () => {
+  test('commits an unrestricted (null) secrets scope before the first prompt', () => {
+    // `null` is the no-override state — the session inherits the agent's grant,
+    // exactly like a server-created session. `[]` would be an explicit "inject
+    // zero project secrets", which silently denied every browser-created session
+    // its grant. The connector axes stay opt-in (empty defaults) per the scope
+    // opt-in design; only secrets default to unrestricted.
     expect(createNewSessionScopeInitialization(catalog())).toEqual({
       draft: {
-        secrets: [],
+        secrets: null,
         connector_bindings: {},
         require_connectors: [],
       },
       commit: {
         draft: {
-          secrets: [],
+          secrets: null,
           connector_bindings: {},
           require_connectors: [],
         },


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This is a data-contract fix (what the web writes to the session scope on a new browser session), with no safe way to reproduce the broken `[]` state for a "before" screenshot without persisting a zero-secrets session. Smallest useful proof:

**Focused tests** (the four touched files) — `bun test src/features/session/scope/`:
```
50 pass, 0 fail, 99 expect() calls — 5 files
```
including the two new regression tests:
- `createScopedSession` › `a new-session draft with null secrets PUTs null, not an explicit zero`
- `createScopedSession` › `an explicit zero-secrets draft still PUTs [] (deliberate deselect is preserved)`

**CI typecheck gate** — `pnpm --filter ./apps/web build` (the real `next build`):
```
✓ Compiled successfully in 37.3s   (exit 0)
```
**Lint** — `eslint src/features/session/scope/**` (changed files): clean (exit 0).
**API contract intact** — `apps/api` `session-rescope.test.ts` (the server-side `null` vs `[]` vs omitted contract): `26 pass, 0 fail` (unchanged — this PR touches no API code).

## Why

Every normal browser-created session was silently persisted with `secrets_allowlist = []` — the explicit "inject zero project secrets" instruction — instead of `null` ("inherit everything the agent's grant allows"). The server re-applies the allowlist on **every** prompt (`intersectSecretGrants`: `[]` → `[]`), so affected sessions were permanently denied their entire agent grant, not just at boot. A user starting a session from the web composer got a session that could read zero project secrets, with no indication.

## What changed

`createNewSessionScopeDraft` (`apps/web/src/features/session/scope/session-scope-model.ts`) initialized a new session's secret draft to `[]` when the secrets catalog was ready. The session-scope-toolbar auto-committed that draft, and `createScopedSession` PUT it to the r7 scope route, which persisted `secrets_allowlist = []`.

One semantic line: initialize the no-override state to `null` (matching how a server-created session starts), with an explanatory comment. A user who deliberately deselects every secret still gets `[]` via `setAllSessionSecrets(draft, false)` — that path is untouched, so explicit zero is preserved.

- `session-scope-model.ts` — `createNewSessionScopeDraft`: `secrets: []` → `secrets: null`.
- `session-scope-model.test.ts` — updated the existing assertion to `null`; added a "ready but empty catalog stays null" test and a "null draft stays null in the replacement" regression test.
- `session-scope-toolbar.test.ts` — `createNewSessionScopeInitialization` now expects `secrets: null`.
- `create-scoped-session.test.ts` — two new tests locking both halves: a `null` secrets draft PUTs `null` (not `[]`), and a deliberate `[]` still PUTs `[]`.

The server-side `null` vs `[]` vs omitted contract was already exhaustively locked (`session-rescope.test.ts`, the SDK `SessionScopeInput` docstring, `e2e-project-session-contract.test.ts`) and is unchanged — this is a web-only fix. No API/SDK code changed.

## Verification

- `bun test src/features/session/scope/` → 50 pass, 0 fail.
- Full web suite `bun test` → 3978 pass, 0 fail (no regressions elsewhere).
- `pnpm --filter ./apps/web build` (CI Frontend build / typecheck) → ✓ Compiled successfully, exit 0.
- `eslint` on changed files → clean.
- `apps/api` `session-rescope.test.ts` → 26 pass, 0 fail (server-side contract intact).
- Preview E2E: to be run on the live preview once the `preview` label spins it up — start a new session from the web composer, GET `/v1/projects/{p}/sessions/{s}/scope`, and confirm `secrets_allowlist` is `null` (not `[]`).

## Risk / rollback

- **Risk:** Low and narrow. A new browser session now starts with the "Allow every available secret" checkbox checked (it was unchecked before). This is the correct default — it matches the server's create-time default (`null`) and the original pre-opt-in behavior for secrets. The connector axes stay opt-in (empty defaults) per the existing scope opt-in design; only secrets default to unrestricted. A user can still narrow to `[]` deliberately.
- **Rollback:** revert the single-line change in `createNewSessionScopeDraft` (`null` → `[]`).
- **Data:** This PR does NOT touch existing rows. Affected rows already persisted with `[]` are **sticky** (re-applied each prompt) and **row-level indistinguishable** from deliberate `[]` (CLI `--no-secrets`, UI deselect, backend zero-scope) — there is no scope-change audit trail to tell them apart. **Do NOT blanket-convert `[]` → `null`**: that would silently re-grant secrets to sessions whose owners deliberately withheld them (a security regression). The frontend fix stops *new* `[]` sessions; existing affected rows, if remediation is justified, require a narrow targeted `dry-run SELECT → human review → UPDATE` restricted to `origin='user' AND secrets_allowlist='[]' AND created_at IN <bug window> AND no connector bindings AND updated_at≈created_at`, accepting residual risk. Preferred: ship this fix + notify users to re-save scope on in-flight sessions.
