### PR TITLE
kortix audit — read the account audit trail from the CLI

### DIFF
--- a/apps/cli/src/__tests__/audit.test.ts
+++ b/apps/cli/src/__tests__/audit.test.ts
@@ -1,0 +1,159 @@
+/**
+ * `kortix audit` — the two pure pieces worth pinning.
+ *
+ * The rest of the command is request plumbing and terminal formatting; these
+ * two decide whether the numbers a person reads are the numbers they asked for.
+ *
+ * `--since 24h` is the flag everyone will actually type. It resolves against
+ * the caller's clock into the ISO instant the API speaks, and a value we cannot
+ * parse must REFUSE rather than fall through — a time bound that silently does
+ * not apply makes a partial audit read look complete, which is the one failure
+ * an audit tool must not have.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { buildAuditQuery, exportBodyText, resolveInstant, truncate } from '../commands/audit.ts';
+
+const NOW = new Date('2026-08-05T12:00:00.000Z');
+
+describe('resolveInstant', () => {
+  test.each([
+    ['30m', '2026-08-05T11:30:00.000Z'],
+    ['24h', '2026-08-04T12:00:00.000Z'],
+    ['7d', '2026-07-29T12:00:00.000Z'],
+    ['2w', '2026-07-22T12:00:00.000Z'],
+  ])('%s resolves relative to now', (input, expected) => {
+    expect(resolveInstant(input, NOW)).toBe(expected);
+  });
+
+  test('is case- and space-insensitive, because people type both', () => {
+    expect(resolveInstant('24H', NOW)).toBe('2026-08-04T12:00:00.000Z');
+    expect(resolveInstant(' 24 h ', NOW)).toBe('2026-08-04T12:00:00.000Z');
+  });
+
+  test('an ISO instant passes through normalized', () => {
+    expect(resolveInstant('2026-08-01T00:00:00Z', NOW)).toBe('2026-08-01T00:00:00.000Z');
+  });
+
+  test.each([
+    ['empty', ''],
+    ['nonsense', 'yesterday'],
+    ['unknown unit', '5y'],
+    ['zero span', '0h'],
+    ['negative', '-3d'],
+  ])('%s is rejected, never coerced to now', (_label, input) => {
+    expect(resolveInstant(input, NOW)).toBeNull();
+  });
+});
+
+describe('buildAuditQuery', () => {
+  test('maps CLI flag names onto the API query names', () => {
+    // The flags are kebab-case for humans; the route takes snake_case. A silent
+    // mismatch here would drop the filter and widen the result set.
+    const built = buildAuditQuery(
+      {
+        action: 'iam.',
+        actor: 'user-1',
+        actorType: 'agent',
+        project: 'proj-1',
+        session: 'sess-1',
+        source: 'cli',
+        outcome: 'denied',
+        resourceType: 'secret',
+        requestId: 'req-1',
+        correlationId: 'corr-1',
+        query: 'rotate',
+      },
+      NOW,
+    );
+    expect('search' in built).toBe(true);
+    const search = (built as { search: URLSearchParams }).search;
+    expect(Object.fromEntries(search)).toEqual({
+      action: 'iam.',
+      actor: 'user-1',
+      actor_type: 'agent',
+      project_id: 'proj-1',
+      session_id: 'sess-1',
+      source: 'cli',
+      outcome: 'denied',
+      resource_type: 'secret',
+      request_id: 'req-1',
+      correlation_id: 'corr-1',
+      q: 'rotate',
+    });
+  });
+
+  test('omits every filter that was not passed', () => {
+    const built = buildAuditQuery({}, NOW);
+    expect([...(built as { search: URLSearchParams }).search.keys()]).toEqual([]);
+  });
+
+  test('resolves --since and --until to ISO', () => {
+    const built = buildAuditQuery({ since: '24h', until: '2026-08-05T00:00:00Z' }, NOW);
+    const search = (built as { search: URLSearchParams }).search;
+    expect(search.get('since')).toBe('2026-08-04T12:00:00.000Z');
+    expect(search.get('until')).toBe('2026-08-05T00:00:00.000Z');
+  });
+
+  test('REFUSES an unparseable --since instead of dropping it', () => {
+    // The failure that matters. Dropping the bound would return events from all
+    // time under a heading the user believes is scoped to a window.
+    const built = buildAuditQuery({ since: 'last tuesday' }, NOW);
+    expect('error' in built).toBe(true);
+    expect((built as { error: string }).error).toContain('--since');
+  });
+
+  test('REFUSES an unparseable --until too', () => {
+    const built = buildAuditQuery({ until: 'soon' }, NOW);
+    expect('error' in built).toBe(true);
+    expect((built as { error: string }).error).toContain('--until');
+  });
+
+  test('a rejected bound never leaves a partial query behind', () => {
+    // If this returned the search params alongside the error, a caller that
+    // ignored the error would issue an unbounded query.
+    const built = buildAuditQuery({ action: 'iam.', since: 'nope' }, NOW);
+    expect('search' in built).toBe(false);
+  });
+});
+
+/**
+ * The JSONL export came back as the string "{}" the first time it ran against
+ * dev. The shared HTTP client parses `application/json`, passes `text/*`
+ * through, and returns a **Blob** for anything else — and the export is
+ * `application/x-ndjson`, which matches neither. `JSON.stringify(blob)` is
+ * `"{}"`, so the command printed an empty object where the export belonged.
+ * CSV was fine throughout (`text/csv`), which is what made it easy to miss.
+ */
+describe('exportBodyText', () => {
+  test('a Blob body is read as text, not stringified', async () => {
+    const blob = new Blob(['{"event_id":"a"}\n{"event_id":"b"}\n'], {
+      type: 'application/x-ndjson',
+    });
+    const text = await exportBodyText(blob);
+    expect(text).toContain('"event_id":"a"');
+    expect(text.trim().split('\n')).toHaveLength(2);
+    expect(text).not.toBe('{}');
+  });
+
+  test('a string body passes through untouched', async () => {
+    expect(await exportBodyText('event_id,occurred_at\n1,2026-01-01\n')).toBe(
+      'event_id,occurred_at\n1,2026-01-01\n',
+    );
+  });
+});
+
+describe('truncate', () => {
+  test('leaves a short action alone', () => {
+    expect(truncate('auth.login.success', 52)).toBe('auth.login.success');
+  });
+
+  test('caps a long action so the table keeps its shape', () => {
+    // Audit actions are raw HTTP lines carrying UUIDs; uncapped, RESOURCE ended
+    // up off the right edge of the terminal.
+    const long = `GET /v1/accounts/${'a'.repeat(60)}`;
+    const out = truncate(long, 52);
+    expect(out).toHaveLength(52);
+    expect(out.endsWith('…')).toBe(true);
+  });
+})

--- a/apps/cli/src/commands/audit.ts
+++ b/apps/cli/src/commands/audit.ts
@@ -1,0 +1,434 @@
+import { writeFileSync } from 'node:fs';
+import { loadAuth } from '../api/auth.ts';
+import { activeAccount } from '../api/config.ts';
+import { clientFromAuth, type ApiClient } from '../api/client.ts';
+import { emitJson, surfaceApiError, takeFlagValue, takeFlagBool } from '../command-helpers.ts';
+import { C, help, pad, status } from '../style.ts';
+
+// The account audit trail — the CLI face of `kortix.audit_events`, which the
+// dashboard already reads. Reads are gated server-side on `audit.read` plus the
+// account's `auditAccess` entitlement, so a non-Enterprise account gets a 402
+// that this command translates instead of printing raw.
+//
+// Two different logs live behind one noun, and conflating them would be the
+// obvious mistake:
+//   - `ls`/`export` read the ACCOUNT trail: every authenticated request, plus
+//     semantic session/executor/approval events. Enterprise-gated.
+//   - `session` reads ONE session's agent-action log, which is a different
+//     route with a different gate — a non-Enterprise account still sees its
+//     pending approvals there, never a 402.
+
+interface AuditEvent {
+  event_id: string;
+  occurred_at: string;
+  project_id: string | null;
+  session_id: string | null;
+  actor_user_id: string | null;
+  actor_type: 'human' | 'agent' | 'service_account' | 'system' | null;
+  source: string | null;
+  outcome: 'success' | 'failure' | 'denied' | 'pending' | null;
+  action: string;
+  resource_type: string | null;
+  resource_id: string | null;
+  http_status: number | null;
+  duration_ms: number | null;
+  request_id: string | null;
+  trace_id: string | null;
+  correlation_id: string | null;
+  before: unknown;
+  after: unknown;
+  ip: string | null;
+  user_agent: string | null;
+  metadata: unknown;
+}
+
+interface AuditPage {
+  events: AuditEvent[];
+  next_cursor: string | null;
+}
+
+const HELP = help`Usage: kortix audit <subcommand> [options]
+
+Read the account audit trail — who did what, when, and whether it was allowed.
+Every authenticated API request is recorded, plus semantic session, executor,
+and approval events. The account trail requires the Enterprise plan.
+
+Subcommands:
+  ls [filters] [--json]           List audit events, newest first.
+  export [filters] [--out <f>]    Export matching events as CSV or JSONL.
+  session <session-id> [--json]   One session's agent-action log.
+
+Filters (ls, export):
+  --since <when>       Only events at or after this point. ISO-8601, or a
+                       relative span like 30m, 24h, 7d, 2w.
+  --until <when>       Only events at or before this point.
+  --action <prefix>    Action prefix, e.g. "iam.policy." or "session.".
+  --actor <user-id>    Only this actor.
+  --actor-type <t>     human | agent | service_account | system
+  --outcome <o>        success | failure | denied | pending
+  --project <id>       Only this project.
+  --session <id>       Only this session.
+  --source <s>         Originating surface, e.g. "api", "cli".
+  --resource-type <t>  Only this resource type.
+  --request-id <id>    One request.
+  --correlation-id <id>  One correlated chain of events.
+  -q, --query <text>   Free-text match on action, resource, project, session.
+
+Options:
+  --limit <n>          Events per page (default 50, server max 200).
+  --cursor <c>         Resume from a previous page's next_cursor.
+  --all                Follow cursors and print every match (max 10000).
+  --format <f>         export: csv (default) | jsonl.
+  --out <file>         export: write to a file instead of stdout.
+  --account <id>       Operate on this account (default: active account).
+  --json               Machine-readable output.
+  -h, --help           Show this help.
+
+Examples:
+  kortix audit ls --since 24h
+  kortix audit ls --outcome denied --since 7d
+  kortix audit ls --action iam. --json
+  kortix audit ls --project <project-id> --all
+  kortix audit session <session-id>
+  kortix audit export --since 30d --format jsonl --out audit.jsonl
+`;
+
+const RELATIVE_SPAN = /^(\d+)\s*(m|h|d|w)$/i;
+const SPAN_MS: Record<string, number> = {
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+};
+
+/**
+ * Accept `24h` / `7d` as well as ISO-8601.
+ *
+ * Relative spans are what people actually type when reading a log, and the API
+ * only speaks ISO. Resolved here, against the caller's clock, so what gets sent
+ * is unambiguous and shows up in `--json` output as the instant it really used.
+ */
+export function resolveInstant(input: string, now: Date = new Date()): string | null {
+  const value = input.trim();
+  if (!value) return null;
+  const relative = RELATIVE_SPAN.exec(value);
+  if (relative) {
+    const amount = Number(relative[1]);
+    const unit = relative[2]!.toLowerCase();
+    if (!Number.isFinite(amount) || amount <= 0) return null;
+    return new Date(now.getTime() - amount * SPAN_MS[unit]!).toISOString();
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+/** Query string shared by `ls` and `export`, so the two can never drift. */
+export function buildAuditQuery(
+  flags: Record<string, string | undefined>,
+  now: Date = new Date(),
+): { search: URLSearchParams } | { error: string } {
+  const search = new URLSearchParams();
+  const direct: Array<[string, string | undefined]> = [
+    ['action', flags.action],
+    ['actor', flags.actor],
+    ['actor_type', flags.actorType],
+    ['project_id', flags.project],
+    ['session_id', flags.session],
+    ['source', flags.source],
+    ['outcome', flags.outcome],
+    ['resource_type', flags.resourceType],
+    ['request_id', flags.requestId],
+    ['correlation_id', flags.correlationId],
+    ['q', flags.query],
+  ];
+  for (const [key, value] of direct) if (value) search.set(key, value);
+
+  for (const key of ['since', 'until'] as const) {
+    const raw = flags[key];
+    if (!raw) continue;
+    const iso = resolveInstant(raw, now);
+    // Refuse rather than silently dropping the bound: a filter that quietly
+    // does not apply makes an audit read look complete when it is not.
+    if (!iso) return { error: `--${key} "${raw}" is not an ISO-8601 instant or a span like 24h/7d.` };
+    search.set(key, iso);
+  }
+  return { search };
+}
+
+interface AuditContext {
+  client: ApiClient;
+  accountId: string;
+}
+
+function resolveAccountContext(accountArg?: string): AuditContext | null {
+  const auth = loadAuth();
+  if (!auth?.token) {
+    process.stderr.write(`${status.err('Not logged in. Run `kortix login`.')}\n`);
+    return null;
+  }
+  const accountId = accountArg || activeAccount()?.id || auth.account_id || '';
+  if (!accountId) {
+    process.stderr.write(
+      `${status.err('No active account. Run `kortix accounts use` or pass --account <id>.')}\n`,
+    );
+    return null;
+  }
+  return { client: clientFromAuth(auth, { accountId }), accountId };
+}
+
+/**
+ * Translate the entitlement 402 before it reaches the generic handler.
+ *
+ * `surfaceApiError` would print "HTTP 402: …", which reads like a billing
+ * failure on a request you already made. This is a plan boundary, so it gets a
+ * plain sentence and a distinct exit code from a real error.
+ */
+function surfaceAuditError(err: unknown): number {
+  // Read `.status` structurally rather than via `instanceof`: the SDK
+  // reclassifies a 402 into a sibling error type (BillingError) that extends
+  // Error directly, and an instanceof check would collapse it into the generic
+  // handler — printing a billing failure where a plan boundary belongs. Same
+  // reasoning as `unwrap` in api/client.ts.
+  const httpStatus = (err as { status?: unknown } | null)?.status;
+  if (httpStatus === 402) {
+    process.stderr.write(
+      `${status.err('The account audit log is an Enterprise feature and is not enabled for this account.')}\n`,
+    );
+    process.stderr.write(
+      `  ${C.dim}Per-session agent actions are still available: ${C.reset}kortix audit session <session-id>\n`,
+    );
+    return 1;
+  }
+  return surfaceApiError(err);
+}
+
+function shortTime(iso: string): string {
+  // `2026-08-05T11:14:20.123Z` → `08-05 11:14:20`. The year is noise in a log
+  // you are scanning; the seconds are not.
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso.slice(0, 19).replace('T', ' ');
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}`;
+}
+
+/** Longest ACTION cell before the table starts pushing RESOURCE off-screen.
+ *  Audit actions are raw HTTP lines carrying UUIDs, so most rows would otherwise
+ *  be ~70 chars of mostly-identical path. Full values are always in `--json`. */
+const ACTION_MAX = 52;
+
+export function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+}
+
+function outcomeCell(outcome: AuditEvent['outcome']): string {
+  const label = outcome ?? '—';
+  if (outcome === 'failure' || outcome === 'denied') return `${C.red}${pad(label, 8)}${C.reset}`;
+  if (outcome === 'pending') return `${C.yellow}${pad(label, 8)}${C.reset}`;
+  return `${C.faded}${pad(label, 8)}${C.reset}`;
+}
+
+function actorCell(event: AuditEvent): string {
+  if (event.actor_type && event.actor_type !== 'human') return event.actor_type;
+  return event.actor_user_id ? event.actor_user_id.slice(0, 8) : '—';
+}
+
+function printEvents(events: AuditEvent[]): void {
+  if (events.length === 0) {
+    process.stdout.write(`\n  ${C.dim}No audit events match.${C.reset}\n\n`);
+    return;
+  }
+  const actionW = Math.min(Math.max(...events.map((e) => e.action.length), 6), ACTION_MAX);
+  const actorW = Math.max(...events.map((e) => actorCell(e).length), 5);
+  process.stdout.write('\n');
+  process.stdout.write(
+    `  ${C.dim}${pad('WHEN (UTC)', 15)}   ${pad('ACTOR', actorW)}   ${pad('ACTION', actionW)}   ${pad('OUTCOME', 8)}   RESOURCE${C.reset}\n`,
+  );
+  for (const e of events) {
+    const resource = e.resource_type
+      ? `${e.resource_type}${e.resource_id ? ` ${C.faded}${e.resource_id.slice(0, 8)}${C.reset}` : ''}`
+      : `${C.faded}—${C.reset}`;
+    process.stdout.write(
+      `  ${pad(shortTime(e.occurred_at), 15)}   ${pad(actorCell(e), actorW)}   ${pad(truncate(e.action, ACTION_MAX), actionW)}   ${outcomeCell(e.outcome)}   ${resource}\n`,
+    );
+  }
+}
+
+/**
+ * Read an export response body as text.
+ *
+ * The shared HTTP client parses `application/json`, passes `text/*` through,
+ * and returns a **Blob** for everything else. The CSV export is `text/csv` so
+ * it arrives as a string; the JSONL export is `application/x-ndjson`, which
+ * matches neither branch and arrives as a Blob. `JSON.stringify` on a Blob
+ * yields `"{}"` — which is exactly what `--format jsonl` printed before this:
+ * an empty object where the export should be.
+ *
+ * Handled here rather than in the SDK because widening that content-type check
+ * changes what every other caller receives. The SDK bug is real and worth
+ * fixing separately.
+ */
+export async function exportBodyText(body: unknown): Promise<string> {
+  if (typeof body === 'string') return body;
+  if (body instanceof Blob) return await body.text();
+  return JSON.stringify(body);
+}
+
+const MAX_FOLLOW_EVENTS = 10_000;
+
+export async function runAudit(argv: string[]): Promise<number> {
+  if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
+    process.stdout.write(HELP);
+    return argv.length === 0 ? 2 : 0;
+  }
+  const sub = argv[0];
+  const rest = argv.slice(1);
+  const f: Record<string, string | undefined> = {};
+  let json = false;
+  let all = false;
+  try {
+    f.account = takeFlagValue(rest, ['--account']);
+    f.action = takeFlagValue(rest, ['--action']);
+    f.actor = takeFlagValue(rest, ['--actor']);
+    f.actorType = takeFlagValue(rest, ['--actor-type']);
+    f.project = takeFlagValue(rest, ['--project']);
+    f.session = takeFlagValue(rest, ['--session']);
+    f.source = takeFlagValue(rest, ['--source']);
+    f.outcome = takeFlagValue(rest, ['--outcome']);
+    f.resourceType = takeFlagValue(rest, ['--resource-type']);
+    f.requestId = takeFlagValue(rest, ['--request-id']);
+    f.correlationId = takeFlagValue(rest, ['--correlation-id']);
+    f.since = takeFlagValue(rest, ['--since']);
+    f.until = takeFlagValue(rest, ['--until']);
+    f.query = takeFlagValue(rest, ['-q', '--query']);
+    f.limit = takeFlagValue(rest, ['--limit']);
+    f.cursor = takeFlagValue(rest, ['--cursor']);
+    f.format = takeFlagValue(rest, ['--format']);
+    f.out = takeFlagValue(rest, ['--out']);
+    json = takeFlagBool(rest, ['--json']);
+    all = takeFlagBool(rest, ['--all']);
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n`);
+    return 2;
+  }
+  const positional = rest.filter((a) => !a.startsWith('-'));
+
+  const ctx = resolveAccountContext(f.account);
+  if (!ctx) return 1;
+  const base = `/accounts/${ctx.accountId}/audit`;
+
+  try {
+    switch (sub) {
+      case 'ls':
+      case 'list': {
+        const built = buildAuditQuery(f);
+        if ('error' in built) {
+          process.stderr.write(`${status.err(built.error)}\n`);
+          return 2;
+        }
+        const { search } = built;
+        if (f.limit) search.set('limit', f.limit);
+        if (f.cursor) search.set('cursor', f.cursor);
+
+        const collected: AuditEvent[] = [];
+        let cursor: string | null = f.cursor ?? null;
+        let truncated = false;
+        for (;;) {
+          if (cursor) search.set('cursor', cursor);
+          const page: AuditPage = await ctx.client.get<AuditPage>(`${base}?${search.toString()}`);
+          collected.push(...page.events);
+          cursor = page.next_cursor;
+          if (!all || !cursor) break;
+          if (collected.length >= MAX_FOLLOW_EVENTS) {
+            truncated = true;
+            break;
+          }
+        }
+
+        if (json) {
+          // `next_cursor` is part of the contract even under --all, so a script
+          // can tell a complete read from a capped one.
+          emitJson({ events: collected, next_cursor: truncated ? cursor : all ? null : cursor });
+          return 0;
+        }
+        printEvents(collected);
+        const count = `${collected.length} event${collected.length === 1 ? '' : 's'}`;
+        process.stdout.write(`\n  ${C.dim}${count}${C.reset}`);
+        if (truncated) {
+          process.stdout.write(
+            `  ${C.yellow}capped at ${MAX_FOLLOW_EVENTS}; narrow with --since or --action${C.reset}`,
+          );
+        } else if (cursor && !all) {
+          process.stdout.write(`  ${C.dim}more available — use --all, or --cursor ${cursor}${C.reset}`);
+        }
+        process.stdout.write('\n\n');
+        return 0;
+      }
+
+      case 'export': {
+        const built = buildAuditQuery(f);
+        if ('error' in built) {
+          process.stderr.write(`${status.err(built.error)}\n`);
+          return 2;
+        }
+        const format = (f.format || 'csv').toLowerCase();
+        if (format !== 'csv' && format !== 'jsonl') {
+          process.stderr.write(`${status.err('--format must be csv or jsonl.')}\n`);
+          return 2;
+        }
+        const { search } = built;
+        search.set('format', format);
+        const body = await ctx.client.get<unknown>(`${base}/export?${search.toString()}`);
+        const text = await exportBodyText(body);
+        if (f.out) {
+          writeFileSync(f.out, text);
+          const lines = text.split('\n').filter(Boolean).length;
+          process.stdout.write(
+            `${status.ok(`Wrote ${lines} line${lines === 1 ? '' : 's'} to ${f.out}`)}\n`,
+          );
+          return 0;
+        }
+        process.stdout.write(text.endsWith('\n') ? text : `${text}\n`);
+        return 0;
+      }
+
+      case 'session': {
+        const sessionId = positional[0];
+        if (!sessionId) {
+          process.stderr.write(`${status.err('Missing a session id.')}\n`);
+          return 2;
+        }
+        const projectId = f.project;
+        if (!projectId) {
+          process.stderr.write(
+            `${status.err('Pass --project <id> — the session audit route is project-scoped.')}\n`,
+          );
+          return 2;
+        }
+        const query = f.limit ? `?limit=${encodeURIComponent(f.limit)}` : '';
+        const result = await ctx.client.get<unknown>(
+          `/projects/${encodeURIComponent(projectId)}/sessions/${encodeURIComponent(sessionId)}/audit${query}`,
+        );
+        if (json) return emitJson(result), 0;
+        const events = Array.isArray((result as { events?: unknown })?.events)
+          ? ((result as { events: AuditEvent[] }).events ?? [])
+          : [];
+        if (events.length === 0) {
+          // The shape here is owned by the session route, not the account one.
+          // Print what came back rather than asserting a table over it.
+          emitJson(result);
+          return 0;
+        }
+        printEvents(events);
+        process.stdout.write('\n');
+        return 0;
+      }
+
+      default:
+        process.stderr.write(`${status.err(`Unknown subcommand "${sub}".`)}\n`);
+        process.stdout.write(HELP);
+        return 2;
+    }
+  } catch (err) {
+    return surfaceAuditError(err);
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -20,6 +20,7 @@ import { runMarketplace } from './commands/marketplace.ts';
 import { runProjects } from './commands/projects.ts';
 import { runProviders } from './commands/providers.ts';
 import { runRegistry } from './commands/registry.ts';
+import { runAudit } from './commands/audit.ts';
 import { runRoles } from './commands/roles.ts';
 import { runSandboxes } from './commands/sandboxes.ts';
 import { runSchema } from './commands/schema.ts';
@@ -253,6 +254,11 @@ const TIERS: readonly CommandTier[] = [
             name: 'roles',
             args: '<subcommand>',
             blurb: 'Manage IAM custom roles + policy assignments (account-scoped)',
+          },
+          {
+            name: 'audit',
+            args: '<subcommand>',
+            blurb: 'Read the account audit trail (who did what, when)',
           },
           {
             name: 'grants',
@@ -528,6 +534,9 @@ async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'roles') {
     return runRoles(argv.slice(1));
   }
+  if (argv[0] === 'audit') {
+    return runAudit(argv.slice(1));
+  }
   if (argv[0] === 'grants') {
     return runGrants(argv.slice(1));
   }
@@ -586,6 +595,7 @@ const KNOWN_COMMANDS = [
   'agents',
   'access',
   'roles',
+  'audit',
   'grants',
   'update',
   'uninstall',


### PR DESCRIPTION
The audit log existed everywhere except the CLI — the route, the SDK client and the dashboard all shipped. This is the missing surface, not new machinery.

```
kortix audit ls [filters]        who did what, when, newest first
kortix audit export [filters]    CSV or JSONL, to stdout or --out
kortix audit session <id>        one session's agent-action log
```

## Two logs, one noun

Conflating them would be the obvious mistake, so the command keeps them apart:

- **`ls` / `export`** read the **account** trail — every authenticated request plus semantic session/executor/approval events. Enterprise-gated.
- **`session`** reads one session's agent actions through a *different route with a different gate* — a non-Enterprise account still sees its pending approvals there, never a 402.

## Details worth a look

**`--since 24h`** resolves relative spans against the caller's clock, because that's what people type when reading a log and the API only speaks ISO. A bound we can't parse **refuses** rather than falling through — a time filter that silently doesn't apply makes a partial audit read look complete, which is the one failure an audit tool must not have.

**The entitlement 402 is translated, not printed.** `HTTP 402: …` reads like a billing failure on the request you just made; this is a plan boundary, so it says so and points at the session log, which still works. `.status` is read structurally rather than via `instanceof` — the SDK reclassifies a 402 into a sibling error type, and `instanceof` would drop it into the generic handler.

## Two fixes that need explaining

**`--format jsonl` printed `{}`.** The shared HTTP client parses `application/json`, passes `text/*` through, and returns a **Blob** for anything else ([api-client.ts:333](packages/sdk/src/core/http/api-client.ts#L333)). The export is `application/x-ndjson`, so it matched neither branch, and `JSON.stringify(blob)` is `"{}"`. CSV was fine throughout (`text/csv`), which is what made it easy to miss.

Handled CLI-side deliberately: widening that content-type check in the SDK changes what every other caller receives, so that fix belongs in its own change. **Worth doing separately — any `x-ndjson` endpoint has the same problem.**

**The ACTION column pushed RESOURCE off the right edge.** Audit actions are raw HTTP lines carrying UUIDs, so most rows were ~70 chars of near-identical path. Capped at 52 with an ellipsis; `--json` stays untruncated.

## Verified against dev

```
audit ls --since 24h --limit 8   → 8 real events, correct ordering
audit ls --outcome denied --since 7d → a real denied POST /v1/accounts/tokens
cursor resume                    → second page continues from the right instant
export --format csv              → real CSV with headers
export --format jsonl --out f    → 103 records written
```

**Gates:** `tsc` clean; CLI suite **657 pass / 0 fail**; `lint:sdk-boundary` **0 violations**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)