### PR TITLE
fix(sessions): push scope mutation to active sandbox + respawn opencode

### DIFF
--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -554,3 +554,101 @@ export async function pushSessionModelToSandbox(input: {
     return { applied: false, reason };
   }
 }
+
+/**
+ * Re-resolve this session's secrets snapshot and deliver it to the RUNNING
+ * sandbox, restarting opencode so its process env picks up the new set.
+ *
+ * `PUT /sessions/{id}/scope` re-scopes a live session's secrets allowlist. The
+ * row was persisted, but for a long time nothing pushed the new snapshot to the
+ * box: the route returned "Applies from the next prompt." and delegated the
+ * actual delivery to `syncSandboxEnvForPrompt`. That delegation was unreliable:
+ *
+ *   - the per-prompt hot sync has two silent early-returns (`!serviceKey`,
+ *     `!snapshot`/`!row.createdBy`) that skip the POST with no log;
+ *   - it only fires when the prompt routes through `POST :8000
+ *     /session/{id}/{prompt_async|message}` — a prompt sent any other way
+ *     (straight to :4096, the lifecycle queue) slips past it;
+ *   - even when it DID fire, the daemon's env route took the ~51ms dispose
+ *     fast path for a pure secret change, and a dispose re-reads the opencode
+ *     CONFIG file only — it does not re-run `mergeProjectEnv`, so opencode's
+ *     process env stayed on the OLD (0/47) snapshot while `agent-env.sh` got
+ *     the new one (so freshly-started shells saw 47/47). The box reported a
+ *     stale OpenCode PID until something else forced a respawn.
+ *
+ * Pushing here — the same pattern the `/model` PUT already uses — fixes both
+ * halves: the snapshot is re-derived from the freshly-committed allowlist and
+ * POSTed to the daemon, and `refreshModels: true` restarts opencode so
+ * `spawnChild` re-runs `mergeProjectEnv` + `withoutDeniedProviderEnv`. The
+ * LLM-gateway provider strip is re-stamped alongside (it lives in the same
+ * `opencodeEnv`/`llmGatewayDenyEnv` channel), so the 42/47-vs-47/47 split
+ * between the opencode process and tool shells is preserved, and revocation
+ * keeps working (`knownNames` is still tracked in the daemon store, so a
+ * dropped secret is actively cleared on the respawn).
+ *
+ * Best-effort by design, mirroring `pushSessionModelToSandbox`: the row is
+ * already committed, so a sandbox that is down or unreachable simply picks the
+ * new scope up on its next boot. The caller reports `applied_live` so a UI can
+ * tell "in effect now" from "stored, applies at next boot" — the same
+ * distinction the model route makes.
+ */
+export async function pushSessionScopeToSandbox(input: {
+  projectId: string;
+  sessionId: string;
+}): Promise<{ applied: boolean; reason?: string }> {
+  try {
+    const [row] = await db
+      .select({
+        externalId: sessionSandboxes.externalId,
+        provider: sessionSandboxes.provider,
+        config: sessionSandboxes.config,
+      })
+      .from(sessionSandboxes)
+      .where(
+        and(
+          eq(sessionSandboxes.sessionId, input.sessionId),
+          eq(sessionSandboxes.status, 'active'),
+        ),
+      )
+      .limit(1);
+    if (!row?.externalId) return { applied: false, reason: 'no active sandbox' };
+
+    const config = (row.config || {}) as Record<string, unknown>;
+    const serviceKey = typeof config.serviceKey === 'string' ? config.serviceKey : null;
+    if (!serviceKey) return { applied: false, reason: 'sandbox has no service key' };
+
+    // Re-derive from the row the route JUST committed — `resolveOwnerRawEnv`
+    // reads `secretsAllowlist` fresh, so this reflects the new scope, not the
+    // boot snapshot the daemon is still running.
+    const snapshot = await resolveSandboxEnvSnapshot(input.projectId, input.sessionId);
+    if (!snapshot) return { applied: false, reason: 'no env snapshot' };
+
+    const llmGatewayEnabled = await resolveProjectLlmGatewayEnabled(input.projectId);
+    const { url, headers } = await resolveSandboxIngress(row.externalId, {
+      port: SANDBOX_SERVICE_PORT,
+      transport: 'http',
+    });
+    await postEnvToDaemon({
+      previewUrl: url,
+      providerHeaders: headers,
+      serviceKey,
+      snapshot,
+      // Restarts opencode so spawnChild re-runs mergeProjectEnv + the gateway
+      // strip. A dispose cannot refresh the child's process env (project
+      // secrets shape it at spawn, not via the config file), so the respawn is
+      // the load-bearing part — see the daemon-side gate in routes/env.ts.
+      refreshModels: true,
+      llmGatewayEnabled,
+      llmGatewayBaseUrl: llmGatewayEnabled
+        ? llmGatewayBaseUrlForProvider(row.provider as ProviderName)
+        : undefined,
+      llmGatewayDenyEnv: llmGatewayEnabled ? nativeProviderEnvNames().join(',') : '',
+    });
+    await markSandboxLlmGatewayMode(input.sessionId, llmGatewayEnabled);
+    return { applied: true };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`[env-sync] scope push failed for session ${input.sessionId}:`, reason);
+    return { applied: false, reason };
+  }
+}

--- a/apps/api/src/projects/lib/scope-push.test.ts
+++ b/apps/api/src/projects/lib/scope-push.test.ts
@@ -1,0 +1,248 @@
+// Delivering a FRESH secrets scope to a box that is already running.
+//
+// `PUT /sessions/{id}/scope` re-scopes a live session's secrets allowlist. The
+// row was persisted, but for a long time the route returned "Applies from the
+// next prompt." and delegated delivery to the per-prompt hot sync. That
+// delegation was unreliable (silent early-returns; only fires when the prompt
+// routes through :8000 /session/{id}/{prompt_async|message}; and even then the
+// daemon took the dispose fast path, which does not refresh opencode's process
+// env). `pushSessionScopeToSandbox` is the fix: re-derive the snapshot from the
+// freshly-committed row, POST it to the daemon, and restart opencode so
+// spawnChild re-runs mergeProjectEnv + the gateway strip.
+//
+// These tests mirror `agent-config-push.test.ts` for the model/config push.
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realSecrets from '../secrets';
+import * as realSecretGrant from './secret-grant';
+
+process.env.KORTIX_URL = 'https://api.example.com';
+
+// `getProvider('daytona')` throws when DAYTONA_API_KEY is unset (the unit suite
+// runs off fake env). `llmGatewayBaseUrlForProvider` calls it when the gateway
+// is on, so stub the provider to a no-validate shim. Spread the real module:
+// `mock.module` replaces it WHOLESALE, so a stub that lists exports by hand
+// deletes every export it omits. `await import` (not top-level) so it loads
+// AFTER the process.env write above — the barrel pulls in config, which reads
+// env once.
+const realProviders = await import('../../platform/providers');
+mock.module('../../platform/providers', () => ({
+  ...realProviders,
+  getProvider: (name: string) =>
+    name === 'daytona'
+      ? { sandboxFacingApiOrigin: () => 'http://kortix-api:8008' }
+      : realProviders.getProvider(name as never),
+}));
+
+let posted: Array<{
+  revision?: string;
+  env?: Record<string, string>;
+  names?: string[];
+  refreshModels?: boolean;
+  opencodeEnv?: Record<string, string | null>;
+  llmGatewayEnabled?: boolean;
+  llmGatewayDenyEnv?: string;
+}> = [];
+// One fake row that satisfies every select on this path — the sandbox lookup
+// and the session/project lookups `resolveSandboxEnvSnapshot` walks on its way
+// to an env snapshot. Cheaper than teaching the fake db which table it was
+// asked for. Rebuilt in `beforeEach` so a test that mutates it (e.g. the
+// no-createdBy case) cannot leak into the next.
+const SANDBOX_ROW = { externalId: 'ext-1', provider: 'daytona', config: { serviceKey: 'svc-key' } };
+let SESSION_ROW: {
+  createdBy: string;
+  agentName: string;
+  secretsAllowlist: string[] | null;
+  repoUrl: string;
+  defaultBranch: string;
+  manifestPath: string;
+  accountId: string;
+};
+let activeSandbox: { externalId: string; provider: string; config: Record<string, unknown> } | null;
+let gatewayEnabled = false;
+
+function freshSessionRow(): typeof SESSION_ROW {
+  return {
+    createdBy: 'user-1',
+    agentName: 'kortix',
+    secretsAllowlist: null,
+    repoUrl: 'https://example.test/acme/repo.git',
+    defaultBranch: 'main',
+    manifestPath: 'kortix.yaml',
+    accountId: 'acct-1',
+  };
+}
+
+// Spread the real modules: `mock.module` replaces them WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits — the failure surfaces in
+// whatever unrelated file imports the missing name next, attributed to no test.
+mock.module('../../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          // One row satisfies BOTH the session lookup (resolveOwnerRawEnv) and
+          // the sandbox lookup (the active-sandbox select) — the fake merges
+          // them. The sandbox's externalId/provider/config overlay wins.
+          limit: async () => (activeSandbox ? [{ ...SESSION_ROW, ...activeSandbox }] : []),
+        }),
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  },
+}));
+
+mock.module('./secret-grant', () => ({
+  ...realSecretGrant,
+  resolveSessionSecretGrant: async () => 'all' as const,
+}));
+mock.module('../secrets', () => ({
+  ...realSecrets,
+  // `{ env, names, revision }` — the real return shape. An array here made
+  // `.env` undefined, which produced the "no env snapshot" the test below
+  // asserts. It would have passed for the wrong reason.
+  listProjectSecretsSnapshotForUser: async () => ({
+    env: { EXAMPLE: 'v' },
+    names: ['EXAMPLE'],
+    revision: 'rev-1',
+  }),
+}));
+
+mock.module('../../llm-gateway/enablement', () => ({
+  projectLlmGatewayEnabled: async () => gatewayEnabled,
+}));
+
+mock.module('../../sandbox-proxy/backend', () => ({
+  resolveSandboxIngress: async () => ({ url: 'https://sandbox.test', headers: {} }),
+}));
+
+type RecordedPost = (typeof posted)[number];
+function recordingFetch(): (u: unknown, init?: { body?: string }) => Promise<Response> {
+  return async (_url: unknown, init?: { body?: string }) => {
+    const body = init?.body ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+    posted.push({
+      revision: body.revision as string | undefined,
+      env: body.env as Record<string, string> | undefined,
+      names: body.names as string[] | undefined,
+      refreshModels: body.refreshModels as boolean | undefined,
+      opencodeEnv: body.opencodeEnv as Record<string, string | null> | undefined,
+      llmGatewayEnabled: body.llmGatewayEnabled as boolean | undefined,
+      llmGatewayDenyEnv: body.llmGatewayDenyEnv as string | undefined,
+    } satisfies RecordedPost);
+    return Response.json({ ok: true, opencode: 'ok' });
+  };
+}
+
+const ORIGINAL_FETCH = globalThis.fetch;
+(globalThis as { fetch: unknown }).fetch = recordingFetch();
+
+const { pushSessionScopeToSandbox } = await import('./sandbox-env-sync');
+
+const INPUT = {
+  projectId: 'proj-1',
+  sessionId: 'sess-1',
+};
+
+afterAll(() => {
+  (globalThis as { fetch: unknown }).fetch = ORIGINAL_FETCH;
+});
+
+beforeEach(() => {
+  posted = [];
+  activeSandbox = SANDBOX_ROW;
+  SESSION_ROW = freshSessionRow();
+  gatewayEnabled = false;
+  // Each test starts from the recording fetch; a test that swaps it restores
+  // it itself.
+  (globalThis as { fetch: unknown }).fetch = recordingFetch();
+});
+
+describe('pushSessionScopeToSandbox', () => {
+  test('pushes the re-derived snapshot and asks for the opencode restart', async () => {
+    // opencode's process env is shaped at spawn, so the snapshot alone changes
+    // nothing — `refreshModels: true` is what makes the daemon respawn it and
+    // re-run mergeProjectEnv. This is the load-bearing part of the fix: the
+    // daemon-side gate turns that into a respawn (not a dispose) because the
+    // project-secret set moved.
+    const result = await pushSessionScopeToSandbox(INPUT);
+
+    expect(result).toEqual({ applied: true });
+    expect(posted).toHaveLength(1);
+    expect(posted[0].env).toEqual({ EXAMPLE: 'v' });
+    expect(posted[0].names).toEqual(['EXAMPLE']);
+    expect(posted[0].refreshModels).toBe(true);
+  });
+
+  test('re-derives from the freshly-committed allowlist, not a cached snapshot', async () => {
+    // The route JUST committed `secretsAllowlist = null` (widening [] -> null).
+    // `resolveOwnerRawEnv` reads the row fresh, so this reflects the new scope.
+    // Narrowing to a single identifier must shrink the pushed env to that one.
+    SESSION_ROW.secretsAllowlist = ['EXAMPLE'];
+    // A different snapshot that the grant+allowlist intersection resolves to.
+    // (The mocked listProjectSecretsSnapshotForUser returns the same set for
+    // every call, so this test asserts the snapshot IS read through the same
+    // resolver as the per-prompt path — i.e. the helper does not cache.)
+    const result = await pushSessionScopeToSandbox(INPUT);
+
+    expect(result).toEqual({ applied: true });
+    expect(posted).toHaveLength(1);
+    expect(posted[0].env).toEqual({ EXAMPLE: 'v' });
+  });
+
+  test('no active sandbox is a no-op, not an error', async () => {
+    // The row is already committed; a sandbox that is down picks the new scope
+    // up on its next boot. Mirrors pushSessionModelToSandbox.
+    activeSandbox = null;
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(false);
+    expect(result.reason).toBe('no active sandbox');
+    expect(posted).toEqual([]);
+  });
+
+  test('a sandbox with no service key is refused rather than pushed unauthenticated', async () => {
+    activeSandbox = { externalId: 'ext-1', provider: 'daytona', config: {} };
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(false);
+    expect(result.reason).toBe('sandbox has no service key');
+    expect(posted).toEqual([]);
+  });
+
+  test('a snapshot the owner cannot resolve (no createdBy) is a no-op', async () => {
+    // resolveOwnerRawEnv returns null when the session row has no createdBy;
+    // resolveSandboxEnvSnapshot then returns null. The push is skipped, not
+    // thrown — mirroring the per-prompt path's silent early-return, but
+    // reported back so the caller can tell the user it applies at next boot.
+    SESSION_ROW.createdBy = '';
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(false);
+    expect(result.reason).toBe('no env snapshot');
+    expect(posted).toEqual([]);
+  });
+
+  test('stamps the LLM-gateway strip alongside the snapshot when gateway is on', async () => {
+    // The 42/47-vs-47/47 split between opencode and shells comes from
+    // KORTIX_OPENCODE_DENY_ENV. The scope push must re-stamp it so a respin
+    // does not silently drop the gateway routing back to native provider keys.
+    gatewayEnabled = true;
+    const result = await pushSessionScopeToSandbox(INPUT);
+
+    expect(result).toEqual({ applied: true });
+    expect(posted).toHaveLength(1);
+    expect(posted[0].llmGatewayEnabled).toBe(true);
+    // nativeProviderEnvNames() reads the live model catalog; we only assert
+    // the field was forwarded, not its exact contents (catalog-dependent).
+    expect(typeof posted[0].llmGatewayDenyEnv).toBe('string');
+  });
+
+  test('a fetch failure is reported, not thrown at the caller', async () => {
+    // This runs after the row is committed and the route already answered, so
+    // a transient daemon error must never throw to the caller — the row is the
+    // source of truth and the next boot reconciles.
+    (globalThis as { fetch: unknown }).fetch = async () => {
+      throw new Error('daemon unreachable');
+    };
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(false);
+    expect(result.reason).toContain('daemon unreachable');
+    // beforeEach restores the recording fetch for any subsequent test.
+  });
+});

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -39,7 +39,7 @@ import {
   modelChangeResult,
   validateModelChangeShape,
 } from '../lib/session-model-change';
-import { pushSessionModelToSandbox } from '../lib/sandbox-env-sync';
+import { pushSessionModelToSandbox, pushSessionScopeToSandbox } from '../lib/sandbox-env-sync';
 import { isModelServableForAccount } from '../../llm-gateway/resolution/default-model';
 import { toOpencodeModelRef } from '../../llm-gateway/resolution/effective';
 import { loadProjectForUser, loadVisibleSession, lookupEmailsByUserIds, parseExpiresAtBody, assertProjectCapability, isUuid, projectCapabilityAllowed, resolveSessionOwnerIdentities } from '../lib/access';
@@ -2671,9 +2671,41 @@ projectsApp.openapi(
       );
     }
 
-    // No push needed: the per-prompt hot sync re-reads secretsAllowlist and
-    // re-resolves the whole env on the NEXT prompt, and connector bindings are
-    // resolved server-side at call time. Pushing here would race that.
+    // Connector bindings are resolved server-side at call time, so they need no
+    // push. Secrets are different: the allowlist narrows what the sandbox
+    // receives, and for a long time this route just persisted the row and told
+    // the caller "Applies from the next prompt." — delegating delivery to the
+    // per-prompt hot sync. That delegation was unreliable. The hot sync has
+    // silent early-returns (`!serviceKey`, `!snapshot`), only fires when the
+    // prompt routes through `POST :8000 /session/{id}/{prompt_async|message}`
+    // (a prompt sent any other way slips past it), and even when it fired the
+    // daemon took the ~51ms dispose fast path for a pure secret change — and a
+    // dispose re-reads the opencode config file only, NOT the child's process
+    // env, so opencode kept its stale 0/47 PID while `agent-env.sh` got the new
+    // set. The box reported a stale OpenCode until something else forced a
+    // respawn.
+    //
+    // Push here, the same pattern the `/model` PUT uses: re-derive the snapshot
+    // from the row we just committed, POST it to the daemon, and restart
+    // opencode so `spawnChild` re-runs `mergeProjectEnv` + the gateway strip.
+    // Only when the effective set actually moved — a no-op re-scope (same
+    // allowlist) must not restart opencode and kill an in-flight turn for
+    // nothing. `applied_live` tells the caller whether it is in effect NOW or
+    // only at the next boot, exactly like the model route.
+    let scopeAppliedLive = false;
+    let scopePushFailed = false;
+    let scopePushReason: string | undefined;
+    const scopeSecretsChanged =
+      wantsSecrets && (narrowedSecrets || addedSecrets.length > 0 || droppedSecrets.length > 0);
+    if (scopeSecretsChanged) {
+      const push = await pushSessionScopeToSandbox({ projectId, sessionId });
+      scopeAppliedLive = push.applied;
+      if (!push.applied) {
+        scopePushFailed = true;
+        scopePushReason = push.reason;
+      }
+    }
+
     return c.json({
       secrets_allowlist: nextAllowlist,
       required_connectors: nextRequired,
@@ -2698,9 +2730,17 @@ projectsApp.openapi(
       // this warning on exactly that case, telling a user revoking every secret
       // from a live session that nothing had been dropped.
       retroactive: !narrowedSecrets,
-      detail: narrowedSecrets
-        ? 'Dropped secrets stop being delivered from the next prompt. Values the agent already read remain in its context and in shells it already started — rotate them if that matters.'
-        : 'Applies from the next prompt.',
+      applied_live: scopeAppliedLive,
+      ...(scopePushFailed ? { push_failed: true as const, push_reason: scopePushReason } : {}),
+      detail: scopeSecretsChanged
+        ? narrowedSecrets
+          ? scopeAppliedLive
+            ? 'Dropped secrets are cleared from the running sandbox now; new shells and the OpenCode process no longer see them. Values the agent already read remain in its context and in shells it already started — rotate them if that matters.'
+            : 'Dropped secrets stop being delivered from the next prompt. Values the agent already read remain in its context and in shells it already started — rotate them if that matters.'
+          : scopeAppliedLive
+            ? 'Applied to the running sandbox now — the OpenCode process and new shells see the new scope.'
+            : 'Applies from the next prompt.'
+        : 'No change to the secrets scope.',
     });
   },
 );

--- a/apps/kortix-sandbox-agent-server/src/__tests__/env-route-secret-respawn.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/env-route-secret-respawn.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Regression for the active-session env-refresh defect: a project-secret
+ * delta delivered to the daemon's `/kortix/env` must force a full opencode
+ * RESPAWN, not the ~51ms dispose fast path.
+ *
+ * Why this is load-bearing: the opencode child's PROCESS env is shaped at
+ * SPAWN via `mergeProjectEnv` (opencode.ts) — project secrets are NOT in the
+ * opencode config file. A dispose re-reads the config file only and never
+ * re-runs `mergeProjectEnv` for the child's process env, so after a pure
+ * secret-scope change opencode's PID keeps its stale (e.g. 0/47) snapshot
+ * while `agent-env.sh` gets the new one (freshly-started shells see 47/47).
+ * The box then reports a stale OpenCode until something else forces a respawn.
+ *
+ * The route's `mustRespawn` is therefore `projectSecretsMoved ||
+ * requiresRespawn(opencodeEnvNames)`. The dispose fast path is preserved for
+ * pure model/auth/deny changes that touch no project secret.
+ */
+import { describe, expect, it } from 'bun:test'
+import type { Config } from '../config'
+import type { Opencode } from '../opencode'
+import { createProjectEnvStore } from '../project-env'
+import { buildOpencodeApp } from '../proxy'
+
+const TEST_TOKEN = 'respawn-test-kortix-token-32-chars'
+
+function baseConfig(): Config {
+  return {
+    servicePort: 8000,
+    opencodeInternalPort: 4096,
+    staticPort: 3211,
+    workspace: '/workspace',
+    projectTarget: '/workspace',
+    defaultBranch: 'main',
+    branchFetchAttempts: 60,
+    branchFetchDelaySec: 0.25,
+    defaultOpencodeConfigDir: '/ephemeral/opencode',
+    autoClone: false,
+    projectId: 'project-1',
+    apiUrl: 'http://api.test/v1',
+    repoUrl: undefined,
+    branchName: undefined,
+    sessionFresh: false,
+    baseSha: undefined,
+    sandboxToken: TEST_TOKEN,
+    gitUserName: 'Kortix Agent',
+    gitUserEmail: 'agent@kortix.ai',
+    cloneFilter: '',
+    cloneDepth: 1,
+  }
+}
+
+type ReloadCall = { mustRespawn: boolean }
+
+function fakeOpencode(): { opencode: Opencode; calls: ReloadCall[] } {
+  const calls: ReloadCall[] = []
+  const opencode = {
+    getState: () => 'ok' as const,
+    getPid: () => 123,
+    getInternalUrl: () => 'http://127.0.0.1:1',
+    restart: async () => {},
+    reloadConfig: async (opts: { mustRespawn?: boolean } = {}) => {
+      calls.push({ mustRespawn: Boolean(opts.mustRespawn) })
+      return 'restarted' as const
+    },
+  } as unknown as Opencode
+  return { opencode, calls }
+}
+
+async function postEnv(
+  app: ReturnType<typeof buildOpencodeApp>,
+  body: Record<string, unknown>,
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await app.request('/kortix/env', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${TEST_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+  return { status: res.status, json: (await res.json()) as Record<string, unknown> }
+}
+
+describe('env route — project-secret delta forces respawn, not dispose', () => {
+  it('a project-secret CHANGE (value moved) forces a respawn', async () => {
+    const { opencode, calls } = fakeOpencode()
+    // Boot store already has API_KEY=v1.
+    const store = createProjectEnvStore({
+      KORTIX_PROJECT_SECRETS_REVISION: 'rev-1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY',
+      API_KEY: 'v1',
+    } as NodeJS.ProcessEnv)
+    const app = buildOpencodeApp(baseConfig(), opencode, Date.now(), {
+      repoMaterializationError: null,
+      timeline: [],
+    }, store)
+
+    // Push a new revision where API_KEY's value moved. refreshModels=true asks
+    // for the reload; the project-secret delta is what demands a RESPAWN.
+    const { status, json } = await postEnv(app, {
+      revision: 'rev-2',
+      env: { API_KEY: 'v2' },
+      names: ['API_KEY'],
+      refreshModels: true,
+    })
+
+    expect(status).toBe(200)
+    expect(json.changed).toBe(true)
+    // Exactly one reload, and it MUST have been a respawn (mustRespawn=true).
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.mustRespawn).toBe(true)
+  })
+
+  it('a project-secret ADD (new secret granted) forces a respawn', async () => {
+    const { opencode, calls } = fakeOpencode()
+    const store = createProjectEnvStore({
+      KORTIX_PROJECT_SECRETS_REVISION: 'rev-1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY',
+      API_KEY: 'v1',
+    } as NodeJS.ProcessEnv)
+    const app = buildOpencodeApp(baseConfig(), opencode, Date.now(), {
+      repoMaterializationError: null,
+      timeline: [],
+    }, store)
+
+    // The allowlist widens: a brand-new secret STRIPE_KEY is granted. The
+    // opencode process env did not have it before, so a respawn is required to
+    // run mergeProjectEnv and add it.
+    const { status, json } = await postEnv(app, {
+      revision: 'rev-2',
+      env: { API_KEY: 'v1', STRIPE_KEY: 'sk_live_new' },
+      names: ['API_KEY', 'STRIPE_KEY'],
+      refreshModels: true,
+    })
+
+    expect(status).toBe(200)
+    expect(json.changed).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.mustRespawn).toBe(true)
+  })
+
+  it('a project-secret REVOCATION (secret dropped) forces a respawn', async () => {
+    const { opencode, calls } = fakeOpencode()
+    const store = createProjectEnvStore({
+      KORTIX_PROJECT_SECRETS_REVISION: 'rev-1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY,STRIPE_KEY',
+      API_KEY: 'v1',
+      STRIPE_KEY: 'sk_live_old',
+    } as NodeJS.ProcessEnv)
+    const app = buildOpencodeApp(baseConfig(), opencode, Date.now(), {
+      repoMaterializationError: null,
+      timeline: [],
+    }, store)
+
+    // STRIPE_KEY is revoked: it leaves the env. The opencode process env still
+    // holds it from spawn, so a respawn is required to clear it via
+    // mergeProjectEnv's knownNames delete pass.
+    const { status, json } = await postEnv(app, {
+      revision: 'rev-2',
+      env: { API_KEY: 'v1' },
+      names: ['API_KEY'],
+      refreshModels: true,
+    })
+
+    expect(status).toBe(200)
+    expect(json.changed).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.mustRespawn).toBe(true)
+  })
+
+  it('a pure MODEL change (no project-secret delta) keeps the dispose fast path', async () => {
+    const { opencode, calls } = fakeOpencode()
+    const store = createProjectEnvStore({
+      KORTIX_PROJECT_SECRETS_REVISION: 'rev-1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY',
+      API_KEY: 'v1',
+    } as NodeJS.ProcessEnv)
+    const app = buildOpencodeApp(baseConfig(), opencode, Date.now(), {
+      repoMaterializationError: null,
+      timeline: [],
+    }, store)
+
+    // Only the model moves; project secrets are byte-identical. This is the
+    // case the dispose fast path is FOR — mustRespawn must stay false so
+    // reloadConfig can take the ~51ms dispose path.
+    const { status, json } = await postEnv(app, {
+      revision: 'rev-1',
+      env: { API_KEY: 'v1' },
+      names: ['API_KEY'],
+      refreshModels: true,
+      opencodeEnv: { KORTIX_OPENCODE_MODEL: 'kortix/claude-sonnet-4' },
+    })
+
+    expect(status).toBe(200)
+    expect(json.changed).toBe(false)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.mustRespawn).toBe(false)
+  })
+
+  it('a gateway deny-list change forces a respawn even with no project-secret delta', async () => {
+    // KORTIX_OPENCODE_DENY_ENV is a RESPAWN_REQUIRED name: a dispose cannot
+    // re-run withoutDeniedProviderEnv, so the strip would be stale. This
+    // predates and is independent of the project-secret fix; it must still
+    // hold now that project secrets are OR'd into the same gate.
+    const { opencode, calls } = fakeOpencode()
+    const store = createProjectEnvStore({
+      KORTIX_PROJECT_SECRETS_REVISION: 'rev-1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY',
+      API_KEY: 'v1',
+    } as NodeJS.ProcessEnv)
+    const app = buildOpencodeApp(baseConfig(), opencode, Date.now(), {
+      repoMaterializationError: null,
+      timeline: [],
+    }, store)
+
+    const { status } = await postEnv(app, {
+      revision: 'rev-1',
+      env: { API_KEY: 'v1' },
+      names: ['API_KEY'],
+      refreshModels: true,
+      opencodeEnv: { KORTIX_OPENCODE_DENY_ENV: 'ANTHROPIC_API_KEY,OPENAI_API_KEY' },
+    })
+
+    expect(status).toBe(200)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.mustRespawn).toBe(true)
+  })
+
+  it('a byte-identical push (no change at all) does not reload opencode', async () => {
+    // The boot-revision-matches guard is unchanged: nothing moved, nothing to
+    // reload. This is the contract the proxy-auth "matches the boot revision"
+    // test also asserts.
+    const { opencode, calls } = fakeOpencode()
+    const store = createProjectEnvStore({
+      KORTIX_PROJECT_SECRETS_REVISION: 'rev-boot',
+      KORTIX_PROJECT_SECRET_NAMES: 'BOOT_SECRET',
+      BOOT_SECRET: 'already-loaded',
+    } as NodeJS.ProcessEnv)
+    const app = buildOpencodeApp(baseConfig(), opencode, Date.now(), {
+      repoMaterializationError: null,
+      timeline: [],
+    }, store)
+
+    const { status, json } = await postEnv(app, {
+      revision: 'rev-boot',
+      env: { BOOT_SECRET: 'already-loaded' },
+      names: ['BOOT_SECRET'],
+      refreshModels: true,
+    })
+
+    expect(status).toBe(200)
+    expect(json.changed).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('a project-secret change WITHOUT refreshModels does not reload opencode', async () => {
+    // refreshModels is the gate for the whole reloadConfig block. A plain
+    // secret-CRUD fan-out propagates with refreshModels=false (only the
+    // per-prompt and scope/model paths send true), so the env file is
+    // rewritten but opencode is not disturbed. Tool shells still pick the
+    // new value up via BASH_ENV on the next bash -c.
+    const { opencode, calls } = fakeOpencode()
+    const store = createProjectEnvStore({
+      KORTIX_PROJECT_SECRETS_REVISION: 'rev-1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY',
+      API_KEY: 'v1',
+    } as NodeJS.ProcessEnv)
+    const app = buildOpencodeApp(baseConfig(), opencode, Date.now(), {
+      repoMaterializationError: null,
+      timeline: [],
+    }, store)
+
+    const { status, json } = await postEnv(app, {
+      revision: 'rev-2',
+      env: { API_KEY: 'v2' },
+      names: ['API_KEY'],
+      // refreshModels omitted -> false
+    })
+
+    expect(status).toBe(200)
+    expect(json.changed).toBe(true)
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/routes/env.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/env.ts
@@ -192,7 +192,19 @@ export function createEnvRouter(cfg: Config, opencode: Opencode, projectEnv: Pro
           // Keyed on the value DELTA, not the allowlist — `result.names` is the
           // full set, so using it would respawn on every push for any project
           // that merely has one of these secrets.
-          const mustRespawn = requiresRespawn([...opencodeEnvNames, ...result.changedNames])
+          //
+          // Project secrets (the `result.changedNames` half) shape the opencode
+          // child's PROCESS env at spawn via `mergeProjectEnv` (opencode.ts) —
+          // they are NOT in the config file a dispose re-reads. So any non-empty
+          // `changedNames` means opencode's process env is stale and a dispose
+          // would report success while the PID kept the old (e.g. 0/47) set. The
+          // only correct reload for a project-secret delta is a full respawn.
+          // The ~8s cost is the price of correctness; the dispose fast path is
+          // preserved for pure model/auth/deny changes that touch no project
+          // secret. Revocation is preserved too: `knownNames` is tracked in the
+          // store, so a respawn clears a dropped secret via `mergeProjectEnv`.
+          const projectSecretsMoved = result.changedNames.length > 0
+          const mustRespawn = projectSecretsMoved || requiresRespawn(opencodeEnvNames)
           const how = await opencode.reloadConfig({ mustRespawn })
           logger.info('[env] config-affecting env changed; applied to opencode', {
             projectRevision: result.revision,

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -832,6 +832,64 @@ describe('session scope contracts', () => {
       }).success,
     ).toBe(false);
   });
+
+  test('reports applied_live when the scope was pushed to the running sandbox', () => {
+    // Mirrors the model route's applied_live: the caller can tell "in effect
+    // now" from "stored, applies at next boot". The field is optional so a
+    // response that omits it (e.g. a secrets-untouched re-scope) still parses.
+    const value = {
+      secrets_allowlist: null,
+      required_connectors: null,
+      connector_bindings: {},
+      dropped_secrets: [],
+      added_secrets: ['STRIPE_KEY'],
+      dropped_bindings: [],
+      retroactive: true,
+      applied_live: true,
+      detail: 'Applied to the running sandbox now — the OpenCode process and new shells see the new scope.',
+    };
+    expect(SessionScopeSchema.parse(value)).toEqual(value);
+  });
+
+  test('reports push_failed when a required live push failed (half-applied change)', () => {
+    // The row is written but the running harness still answers from the OLD
+    // scope. `applied_live: false` alone cannot express this (it is also the
+    // benign no-active-sandbox answer), so a client must read push_failed to
+    // tell a half-applied change from a stored one. Mirrors the model route's
+    // push_failed.
+    const value = {
+      secrets_allowlist: null,
+      required_connectors: null,
+      connector_bindings: {},
+      dropped_secrets: [],
+      added_secrets: ['STRIPE_KEY'],
+      dropped_bindings: [],
+      retroactive: true,
+      applied_live: false,
+      push_failed: true as const,
+      push_reason: 'daemon unreachable',
+      detail: 'Applies from the next prompt.',
+    };
+    expect(SessionScopeSchema.parse(value)).toEqual(value);
+  });
+
+  test('rejects an unknown extra field even with the new optional ones', () => {
+    // .strict() is preserved: adding a field the schema does not name fails,
+    // so the contract stays exhaustive.
+    const value = {
+      secrets_allowlist: null,
+      required_connectors: null,
+      connector_bindings: {},
+      dropped_secrets: [],
+      added_secrets: [],
+      dropped_bindings: [],
+      retroactive: true,
+      applied_live: false,
+      detail: 'No change to the secrets scope.',
+      surprise: true,
+    };
+    expect(SessionScopeSchema.safeParse(value).success).toBe(false);
+  });
 });
 
 describe('connector authorization required contracts', () => {

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -348,6 +348,23 @@ export const SessionScopeSchema = z
     added_secrets: z.array(z.string()),
     dropped_bindings: z.array(z.string()),
     retroactive: z.boolean(),
+    /**
+     * True when the new secrets scope was pushed to the live sandbox and
+     * OpenCode was restarted to pick it up — the change is in effect NOW.
+     * False when there was no active sandbox to push to (the change is stored
+     * and applies at the next boot), or when `secrets` was not part of this
+     * request. Mirrors the model route's `applied_live`.
+     */
+    applied_live: z.boolean().optional(),
+    /**
+     * Present only when a live push was REQUIRED (the secrets scope changed and
+     * an active sandbox exists) and FAILED — the row is written but the running
+     * harness still answers from the OLD scope. `applied_live: false` cannot
+     * express this on its own (it is also the benign no-active-sandbox answer),
+     * so a client must read THIS to tell a half-applied change from a stored one.
+     */
+    push_failed: z.literal(true).optional(),
+    push_reason: z.string().optional(),
     detail: z.string(),
   })
   .strict();


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. A scope PUT is a backend-only control-plane mutation; the fix is in the env-delivery path. Smallest useful proof: the new tests pin both halves of the fix.

**Daemon env-route respawn gate** (`apps/kortix-sandbox-agent-server/src/__tests__/env-route-secret-respawn.test.ts`):
```
7 pass, 0 fail — a project-secret delta (change/add/revoke) forces a full
opencode RESPAWN (mustRespawn=true); a pure model change keeps the ~51ms
dispose fast path (mustRespawn=false); a byte-identical push does not reload
opencode; a project-secret change without refreshModels rewrites agent-env.sh
only (tool shells still pick it up via BASH_ENV).
```

**Scope push helper** (`apps/api/src/projects/lib/scope-push.test.ts`):
```
7 pass, 0 fail — pushSessionScopeToSandbox re-derives the snapshot from the
freshly-committed allowlist, POSTs it with refreshModels:true, re-stamps the
gateway deny-list, and reports applied_live / push_failed; no active sandbox
and no service key are no-ops, not errors.
```

## Why
A confirmed active-session env refresh defect: a scope PUT that changed `secrets_allowlist` from `[]` to `null` returned "Applies from next prompt" but left the OpenCode PID stale at 0/47 project secrets, while the daemon and `kortix-agent` had 47/47 and tool shells got 47/47. A controlled authenticated local `POST /kortix/env` restarted OpenCode, which then got 42/47 (5 gateway-provider credentials intentionally stripped) and shells got 47/47 — proving the daemon machinery works when POSTed directly; the bug was the scope PUT + next prompt never syncing.

Root cause (two compounding failure points):
1. **The scope PUT handler did not push to the live sandbox** — by design it delegated to the per-prompt hot sync (`syncSandboxEnvForPrompt`), which is unreliable: it has silent early-returns (`!serviceKey`, `!snapshot`), only fires when the prompt routes through `POST :8000 /session/{id}/{prompt_async|message}` (a prompt sent any other way slips past it), and even when it fired…
2. …the daemon's env route took the **~51ms dispose fast path** for a pure secret change. A dispose re-reads the opencode config file only — it does NOT re-run `mergeProjectEnv` for the child's process env (shaped at spawn), so opencode kept its stale 0/47 PID while `agent-env.sh` got the new set.

## What changed
- **`apps/api/src/projects/lib/sandbox-env-sync.ts`** — new `pushSessionScopeToSandbox`: re-derives the snapshot from the freshly-committed allowlist, POSTs it to the daemon with `refreshModels: true` and the LLM-gateway strip, and marks the sandbox's gateway mode. Best-effort (mirrors `pushSessionModelToSandbox`): a down/unreachable sandbox picks the new scope up at next boot.
- **`apps/api/src/projects/routes/r7.ts`** — the `PUT /sessions/{id}/scope` handler now pushes the new snapshot to the active sandbox when the effective secret set actually moved (widening or narrowing), and reports `applied_live` / `push_failed` (mirroring the `/model` PUT). A no-op re-scope (same allowlist) does NOT restart opencode. Connector bindings are unchanged (resolved server-side at call time, already retroactive).
- **`apps/kortix-sandbox-agent-server/src/routes/env.ts`** — a project-secret delta (`result.changedNames.length > 0`) now forces a full opencode **respawn**, not a dispose. Project secrets shape the child's process env at spawn via `mergeProjectEnv`, not via the config file a dispose re-reads. The dispose fast path is preserved for pure model/auth/deny changes that touch no project secret. Revocation is preserved (`knownNames` clears dropped secrets on respawn); the gateway provider strip (`KORTIX_OPENCODE_DENY_ENV`) is unaffected (still in `RESPAWN_REQUIRED_ENV_NAMES`).
- **`packages/api-contract/src/index.ts`** — `SessionScopeSchema` gains optional `applied_live`, `push_failed`, `push_reason` (`.strict()` preserved).

## Verification
- `bun run typecheck` clean for `apps/api`, `apps/kortix-sandbox-agent-server`, `packages/api-contract`.
- New tests: `env-route-secret-respawn.test.ts` (7), `scope-push.test.ts` (7), extended `schemas.test.ts` (+3). All green.
- Existing tests still pass: `dispose-reload.test.ts`, `env-sync-curl.e2e.test.ts`, `project-env-revocation.test.ts`, `session-rescope.test.ts`, `sandbox-env-sync.test.ts`, `agent-config-push.test.ts`, and the full `apps/api/src/projects/lib/` suite (396 pass, 0 fail) + the contract suite (65 pass, 0 fail). (A handful of pre-existing network/catalog flakes in `proxy-auth.test.ts` / `resolve-opencode-model.test.ts` / `boot-latency.test.ts` fail identically on clean `main` — unrelated to this change.)
- Preview E2E: will verify the scope-PUT → live sandbox sync + opencode restart on the preview once it's live.

## Risk / rollback
- Behavior change: a secrets-affecting scope PUT now restarts the running OpenCode (~8s) to pick up the new env, where before it deferred to the next prompt. This is the intended fix; it matches the existing `/model` PUT behavior and the documented contract ("from the next prompt" was the unreliable path). Connector-only and no-op scopes do not restart.
- The daemon respawn-on-secret-delta is a ~8s cost vs ~51ms dispose on the per-prompt sync path that sends `refreshModels:true` AND moves a project secret. The per-prompt hot sync normally re-pushes the SAME snapshot (revision unchanged → `result.changed=false` → no reload), so steady-state prompts are unaffected; the cost is paid only when a secret actually moves.
- Revert is the single commit; no schema migration, no DB change (the `secrets_allowlist` column is unchanged).