### PR TITLE
fix(api): scope PUT pushes the new snapshot to the live sandbox now

### DIFF
--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -554,3 +554,79 @@ export async function pushSessionModelToSandbox(input: {
     return { applied: false, reason };
   }
 }
+
+/**
+ * Push THIS session's freshly re-scoped secret snapshot to its live sandbox.
+ *
+ * The PUT /scope route persisted the new `secretsAllowlist`. The per-prompt hot
+ * sync (`syncSandboxEnvForPrompt`) re-reads that column on the NEXT prompt and
+ * would eventually push it — but "eventually" is not "now": the per-prompt sync
+ * is path-gated (`shouldSyncProjectEnvBeforeProxy` only fires on
+ * `POST /session/:id/(prompt_async|message)` to the daemon port), so a prompt
+ * that takes the direct-opencode path, a session that is not prompted again
+ * right away, or any path that skips the gate leaves the sandbox running the
+ * OLD snapshot. The daemon's agent-env.sh keeps the stale `names`/env, opencode
+ * keeps its old PID, and every shell the agent spawns still sees the pre-scope
+ * secret set — silently, with the API having answered "Applies from the next
+ * prompt."
+ *
+ * Pushing here is idempotent and race-free with the per-prompt sync: both
+ * resolve the snapshot from the same DB row and POST set-semantics to the
+ * daemon, whose `apply` is revision-guarded — a duplicate push (here then on
+ * the next prompt) re-applies the same state and is a no-op the second time.
+ * `refreshModels: true` makes the daemon rewrite the live agent-env file AND
+ * restart opencode, so shells spawned AFTER the rescope see the new secret set
+ * instead of inheriting the old one via BASH_ENV.
+ *
+ * Best-effort by design, matching `pushSessionModelToSandbox`: a sandbox that is
+ * down or unreachable picks the new scope up on its next boot. Returns whether a
+ * live box actually took it, so the route can tell the caller whether the change
+ * is in effect NOW or only from the next turn.
+ */
+export async function pushSessionScopeToSandbox(input: {
+  projectId: string;
+  sessionId: string;
+}): Promise<{ applied: boolean; reason?: string }> {
+  try {
+    const [row] = await db
+      .select({
+        externalId: sessionSandboxes.externalId,
+        config: sessionSandboxes.config,
+      })
+      .from(sessionSandboxes)
+      .where(
+        and(
+          eq(sessionSandboxes.sessionId, input.sessionId),
+          eq(sessionSandboxes.status, 'active'),
+        ),
+      )
+      .limit(1);
+    if (!row?.externalId) return { applied: false, reason: 'no active sandbox' };
+
+    const config = (row.config || {}) as Record<string, unknown>;
+    const serviceKey = typeof config.serviceKey === 'string' ? config.serviceKey : null;
+    if (!serviceKey) return { applied: false, reason: 'sandbox has no service key' };
+
+    const snapshot = await resolveSandboxEnvSnapshot(input.projectId, input.sessionId);
+    if (!snapshot) return { applied: false, reason: 'no env snapshot' };
+
+    const { url, headers } = await resolveSandboxIngress(row.externalId, {
+      port: SANDBOX_SERVICE_PORT,
+      transport: 'http',
+    });
+    await postEnvToDaemon({
+      previewUrl: url,
+      providerHeaders: headers,
+      serviceKey,
+      snapshot,
+      // Restarts opencode so shells spawned after the rescope inherit the new
+      // secret set instead of the old agent-env.sh via BASH_ENV.
+      refreshModels: true,
+    });
+    return { applied: true };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`[env-sync] scope push failed for session ${input.sessionId}:`, reason);
+    return { applied: false, reason };
+  }
+}

--- a/apps/api/src/projects/lib/scope-push.test.ts
+++ b/apps/api/src/projects/lib/scope-push.test.ts
@@ -1,0 +1,256 @@
+// Delivering a freshly re-scoped secret snapshot to a box that is already
+// running.
+//
+// The PUT /scope route persists the new `secretsAllowlist` and used to rely
+// ENTIRELY on the per-prompt hot sync (`syncSandboxEnvForPrompt`) to push it to
+// the live sandbox. That sync is path-gated — it only fires on
+// `POST /session/:id/(prompt_async|message)` to the daemon port — so a prompt
+// that takes the direct-opencode path, a session not prompted again right
+// away, or any path that skips the gate left the sandbox running the OLD
+// snapshot: the daemon's agent-env.sh kept the stale `names`, opencode kept its
+// PID, and every shell the agent spawned still saw the pre-scope secret set,
+// while the API answered "Applies from the next prompt."
+//
+// `pushSessionScopeToSandbox` is the immediate push the route now makes after the
+// DB write — same shape as `pushSessionModelToSandbox`, but it pushes the
+// resolved secret snapshot (no model override) and asks the daemon to
+// `refreshModels` so opencode restarts and shells spawned after the rescope
+// inherit the new secret set instead of the old agent-env.sh via BASH_ENV.
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as realSecrets from '../secrets';
+import * as realSecretGrant from './secret-grant';
+
+process.env.KORTIX_URL = 'https://api.example.com';
+
+let snapshot: { env: Record<string, string>; names: string[]; revision: string } | null = {
+  env: { MAIL_TOKEN: 'redacted-do-not-assert-values', ISSUE_TOKEN: 'redacted' },
+  names: ['MAIL_TOKEN', 'ISSUE_TOKEN'],
+  revision: 'rev-after-rescope',
+};
+let posted: Array<{
+  snapshot: { env: unknown; names: unknown; revision: unknown } | undefined;
+  opencodeEnv: Record<string, string | null> | undefined;
+  refreshModels: boolean | undefined;
+}> = [];
+// One fake row that satisfies every select on this path — the sandbox lookup
+// and the session/project lookups `resolveSandboxEnvSnapshot` walks on its way
+// to an env snapshot. Cheaper than teaching the fake db which table it was
+// asked for.
+const SANDBOX_ROW = { externalId: 'ext-1', config: { serviceKey: 'svc-key' } };
+const SESSION_ROW_BASE = {
+  createdBy: 'user-1' as string | null,
+  agentName: 'support',
+  secretsAllowlist: null,
+  repoUrl: 'https://example.test/acme/repo.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+  accountId: 'acct-1',
+};
+// Per-test override of the session row (e.g. `createdBy: null` to exercise the
+// no-env-snapshot path). `null` means no row matches at all.
+let sessionRow: typeof SESSION_ROW_BASE | null = SESSION_ROW_BASE;
+let activeSandbox: { externalId: string; config: Record<string, unknown> } | null = SANDBOX_ROW;
+
+mock.module('../../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            // The sandbox lookup needs the sandbox's externalId + config; the
+            // session/project lookups `resolveOwnerRawEnv` walks need the
+            // session row. A single fused row carries both, but the
+            // no-sandbox and no-session cases must be independently nullable.
+            if (!activeSandbox) return [];
+            return sessionRow ? [{ ...sessionRow, ...activeSandbox }] : [];
+          },
+        }),
+      }),
+    }),
+  },
+}));
+
+mock.module('./secret-grant', () => ({
+  ...realSecretGrant,
+  resolveSessionSecretGrant: async () => 'all' as const,
+}));
+// Spread the real module: overriding only the DB-backed reader keeps every other
+// export (sanitizers, revision hashing) intact — a partial mock silently removes
+// the rest and the module fails to load.
+mock.module('../secrets', () => ({
+  ...realSecrets,
+  // `{ env, names, revision }` — the real return shape. An array here made
+  // `.env` undefined, which produced the "no env snapshot" the test below
+  // asserts. It would have passed for the wrong reason.
+  listProjectSecretsSnapshotForUser: async () => {
+    if (!snapshot) return { env: {}, names: [], revision: '' };
+    return snapshot;
+  },
+}));
+
+mock.module('../../sandbox-proxy/backend', () => ({
+  resolveSandboxIngress: async () => ({ url: 'https://sandbox.test', headers: {} }),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+let fetchShouldFail = false;
+(globalThis as { fetch: unknown }).fetch = async (_url: unknown, init?: { body?: string }) => {
+  if (fetchShouldFail) throw new Error('daemon unreachable');
+  const body = init?.body ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+  posted.push({
+    snapshot: {
+      env: body.env,
+      names: body.names,
+      revision: body.revision,
+    },
+    opencodeEnv: body.opencodeEnv as Record<string, string | null> | undefined,
+    refreshModels: body.refreshModels as boolean | undefined,
+  });
+  return Response.json({ ok: true, opencode: 'starting' });
+};
+
+const { pushSessionScopeToSandbox } = await import('./sandbox-env-sync');
+
+const INPUT = {
+  projectId: 'proj-1',
+  sessionId: 'sess-1',
+};
+
+afterAll(() => {
+  (globalThis as { fetch: unknown }).fetch = ORIGINAL_FETCH;
+});
+
+beforeEach(() => {
+  snapshot = {
+    env: { MAIL_TOKEN: 'redacted-do-not-assert-values', ISSUE_TOKEN: 'redacted' },
+    names: ['MAIL_TOKEN', 'ISSUE_TOKEN'],
+    revision: 'rev-after-rescope',
+  };
+  posted = [];
+  sessionRow = SESSION_ROW_BASE;
+  activeSandbox = SANDBOX_ROW;
+  fetchShouldFail = false;
+});
+
+describe('pushSessionScopeToSandbox', () => {
+  test('pushes the re-scoped snapshot and asks for the opencode restart', async () => {
+    // opencode reads agent-env.sh via BASH_ENV on every shell spawn, but the
+    // file is only re-rendered when the daemon's env store changes; and the
+    // opencode PROCESS keeps its old env until it restarts. `refreshModels` is
+    // what makes the daemon rewrite the live agent-env file AND restart
+    // opencode, so shells spawned AFTER the rescope see the new secret set
+    // instead of the old one.
+    const result = await pushSessionScopeToSandbox(INPUT);
+
+    expect(result).toEqual({ applied: true });
+    expect(posted).toHaveLength(1);
+    expect(posted[0].refreshModels).toBe(true);
+    // The pushed snapshot carries the resolved env (the new allowlist ∩ the
+    // agent grant). `resolveSandboxEnvSnapshot` re-hashes the env into the
+    // revision (projectSecretsRevision), so the posted revision is a real hash
+    // of the env, not the fake `revision` field — the daemon's revision-guarded
+    // `apply` makes a duplicate push (here then on the next prompt) a no-op,
+    // so there is no race.
+    expect(typeof posted[0].snapshot?.revision).toBe('string');
+    expect(posted[0].snapshot?.revision).not.toBe('');
+    // `sanitizeSandboxEnv` sorts names alphabetically (uppercase), so the
+    // pushed names arrive in canonical order regardless of the snapshot's
+    // insertion order.
+    expect(posted[0].snapshot?.names).toEqual(['ISSUE_TOKEN', 'MAIL_TOKEN']);
+    // A scope push sends NO opencodeEnv override (unlike the model push, which
+    // sets KORTIX_OPENCODE_MODEL). It only re-delivers the secret snapshot.
+    expect(posted[0].opencodeEnv).toBeUndefined();
+  });
+
+  test('does not expose secret values through its return value', async () => {
+    // Regression guard for the "do not expose values" constraint: the snapshot
+    // IS the values (they have to reach the daemon over the server-to-server
+    // /kortix/env endpoint), but the helper's RETURN value — and the route's
+    // response — never carry them. The helper returns a bare
+    // { applied } / { applied, reason }; the route returns the SessionScope
+    // shape (allowlist NAMES, not values). Pin that no env value leaks out.
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result).toEqual({ applied: true });
+    expect(JSON.stringify(result)).not.toContain('redacted');
+    expect(JSON.stringify(result)).not.toContain('MAIL_TOKEN');
+    expect(JSON.stringify(result)).not.toContain('ISSUE_TOKEN');
+  });
+
+  test('no active sandbox is a no-op, not an error', async () => {
+    // A session with no live box picks the new scope up on its next boot —
+    // failing the PUT over that would roll back a perfectly good DB write.
+    activeSandbox = null;
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(false);
+    expect(posted).toEqual([]);
+  });
+
+  test('a sandbox with no service key is refused rather than pushed unauthenticated', async () => {
+    activeSandbox = { externalId: 'ext-1', config: {} };
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(false);
+    expect(posted).toEqual([]);
+  });
+
+  test('a session with no env snapshot pushes nothing', async () => {
+    // `resolveSandboxEnvSnapshot` returns null when `resolveOwnerRawEnv`
+    // returns null — which happens when the session row has no `createdBy`
+    // (the owner-principal the snapshot is resolved for). Pushing an empty
+    // snapshot would DELETE the box's live secret env, so the helper refuses.
+    sessionRow = { ...SESSION_ROW_BASE, createdBy: null };
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(false);
+    expect(posted).toEqual([]);
+  });
+
+  test('a daemon failure is caught and reported, never thrown at the caller', async () => {
+    // Best-effort by design: the DB write already landed, so a transient
+    // daemon miss must not 500 the PUT. The per-prompt sync (or the next
+    // boot) still converges the box.
+    fetchShouldFail = true;
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(false);
+    expect(result.reason).toContain('daemon unreachable');
+  });
+});
+
+/**
+ * The route has to actually call the push after the DB write.
+ *
+ * The helper can be perfectly correct and the sandbox still run the OLD
+ * snapshot — the route is the one that decides to push, and it used to
+ * deliberately NOT push (the "No push needed" comment relied on the
+ * per-prompt sync, which is path-gated and not guaranteed to fire). Same shape
+ * of bug as a correct helper wired to nothing: right logic, wrong plumbing.
+ * Pin the wiring so a future refactor can't silently drop it.
+ */
+const ROUTE = readFileSync(join(import.meta.dir, '..', 'routes', 'r7.ts'), 'utf8');
+
+describe('the scope route pushes the new snapshot to the live sandbox', () => {
+  test('imports and calls pushSessionScopeToSandbox after the DB transaction', () => {
+    expect(ROUTE).toContain('pushSessionScopeToSandbox');
+    // The push must come AFTER the DB transaction commits, not before —
+    // pushing a scope that failed to persist would hand the box a state the
+    // route then rolls back. The transaction block ends just above this call.
+    expect(ROUTE).toMatch(/await pushSessionScopeToSandbox\(\{ projectId, sessionId \}\)/);
+  });
+
+  test('only pushes when the secrets axis actually changed', () => {
+    // A no-op PUT (re-sending the same allowlist) must NOT restart opencode —
+    // that costs the user their in-flight turn for nothing. The gate is
+    // `wantsSecrets` AND a real delta between the new and previous allowlist.
+    expect(ROUTE).toContain('wantsSecrets');
+    expect(ROUTE).toMatch(
+      /JSON\.stringify\(nextAllowlist\) !== JSON\.stringify\(visible\.row\.secretsAllowlist \?\? null\)/,
+    );
+  });
+
+  test('no longer claims the per-prompt sync alone is enough', () => {
+    // The old comment — "No push needed: the per-prompt hot sync re-reads
+    // secretsAllowlist ... on the NEXT prompt" — was the buggy assumption this
+    // fix replaces. It must not come back.
+    expect(ROUTE).not.toContain('No push needed');
+  });
+});

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -39,7 +39,7 @@ import {
   modelChangeResult,
   validateModelChangeShape,
 } from '../lib/session-model-change';
-import { pushSessionModelToSandbox } from '../lib/sandbox-env-sync';
+import { pushSessionModelToSandbox, pushSessionScopeToSandbox } from '../lib/sandbox-env-sync';
 import { isModelServableForAccount } from '../../llm-gateway/resolution/default-model';
 import { toOpencodeModelRef } from '../../llm-gateway/resolution/effective';
 import { loadProjectForUser, loadVisibleSession, lookupEmailsByUserIds, parseExpiresAtBody, assertProjectCapability, isUuid, projectCapabilityAllowed, resolveSessionOwnerIdentities } from '../lib/access';
@@ -2671,9 +2671,24 @@ projectsApp.openapi(
       );
     }
 
-    // No push needed: the per-prompt hot sync re-reads secretsAllowlist and
-    // re-resolves the whole env on the NEXT prompt, and connector bindings are
-    // resolved server-side at call time. Pushing here would race that.
+    // Push the new secret snapshot to the live sandbox NOW, instead of waiting
+    // for the per-prompt hot sync. The hot sync (`syncSandboxEnvForPrompt`) is
+    // path-gated — it only fires on `POST /session/:id/(prompt_async|message)`
+    // to the daemon port — so a prompt that takes the direct-opencode path, a
+    // session not prompted again right away, or any path that skips the gate
+    // left the sandbox running the OLD snapshot: the daemon's agent-env.sh kept
+    // the stale `names`, opencode kept its PID, and every shell the agent spawned
+    // still saw the pre-scope secret set, while the API answered "Applies from
+    // the next prompt." Pushing here is idempotent and race-free with the
+    // per-prompt sync (both resolve from the same DB row; the daemon's `apply`
+    // is revision-guarded, so a duplicate push on the next prompt is a no-op).
+    // Connector bindings need no push — they resolve server-side at call time.
+    // Best-effort, like pushSessionModelToSandbox: a down/unreachable sandbox
+    // picks the new scope up on its next boot.
+    if (wantsSecrets && JSON.stringify(nextAllowlist) !== JSON.stringify(visible.row.secretsAllowlist ?? null)) {
+      await pushSessionScopeToSandbox({ projectId, sessionId });
+    }
+
     return c.json({
       secrets_allowlist: nextAllowlist,
       required_connectors: nextRequired,


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This fixes what the sandbox actually does after a `PUT /sessions/:id/scope` (the daemon's `/kortix/env` push + opencode restart), with no safe way to show the broken "next prompt didn't sync" state for a before/after. Smallest useful proof:

**New regression tests** — `bun test --isolate --env-file=scripts/test.env src/projects/lib/scope-push.test.ts`:
```
9 pass, 0 fail — scope-push.test.ts
```
covering `pushSessionScopeToSandbox` (pushes the snapshot with `refreshModels: true`; no active sandbox / no service key / no env snapshot / daemon failure are no-ops; return value exposes no secret values) + a source-contract test pinning the route wires the push.

**Focused suite** — `scope-push.test.ts` + `session-rescope.test.ts`: `35 pass, 0 fail`.
**API typecheck** (CI gate) — `tsc --noEmit`: exit 0.
**Full API unit suite** (`scripts/test.sh`, the CI `bun unit tests (kortix-api)` gate): `5321 pass, 62 skip, 6 fail` — the 6 failures are **pre-existing** (`e2e-executor-faces` CLI/MCP/sandbox-agent tests needing a real DB/CLI binary; they fail identically on a clean tree without these changes). Zero new failures.

## Why

After `PUT /sessions/:id/scope` changed an active session's `secrets_allowlist` (e.g. `[]` → `null`), the API answered "Applies from the next prompt" but the next user prompt did NOT invoke `/kortix/env`: the daemon log stayed on the old `names=0` revision and opencode's PID did not change, while the box kept running the pre-scope secret set.

Root cause: the scope PUT route persisted the new allowlist but **deliberately did not push** — a "No push needed" comment relied on the per-prompt hot sync (`syncSandboxEnvForPrompt`) to re-read the column on the NEXT prompt. That sync is **path-gated** (`shouldSyncProjectEnvBeforeProxy` only fires on `POST /session/:id/(prompt_async|message)` to the daemon port), so a prompt that takes the direct-opencode path, a session not prompted again right away, or any path that skips the gate leaves the sandbox running the OLD snapshot indefinitely.

## What changed

- **`apps/api/src/projects/lib/sandbox-env-sync.ts`** — add `pushSessionScopeToSandbox`, mirroring `pushSessionModelToSandbox`: resolve the active sandbox + service key + secret snapshot, POST it to the daemon with `refreshModels: true` so the daemon rewrites the live `agent-env.sh` AND restarts opencode. Best-effort (a down/unreachable box picks the new scope up on its next boot; a daemon failure is caught and never 500s the PUT).
- **`apps/api/src/projects/routes/r7.ts`** — after the DB transaction commits, call `pushSessionScopeToSandbox` when the secrets axis actually changed (`wantsSecrets && nextAllowlist !== previous`). Replaced the "No push needed" comment. Connector bindings need no push (resolved server-side at call time).
- **`apps/api/src/projects/lib/scope-push.test.ts`** — new regression test for the helper + a source-contract test pinning the route wiring.

### Race-free with the per-prompt sync
Both the route's push and the per-prompt sync resolve the snapshot from the same DB row and POST set-semantics to the daemon, whose `apply` is revision-guarded — a duplicate push (here then on the next prompt) re-applies the same state and is a no-op the second time. No new response field or contract change (the push is server-side; the existing `SessionScope` response shape is unchanged).

## Verification

- `bun test src/projects/lib/scope-push.test.ts src/projects/lib/session-rescope.test.ts` → 35 pass / 0 fail.
- `pnpm --filter kortix-api typecheck` (CI API typecheck gate) → exit 0.
- Full API unit suite (`scripts/test.sh`) → 5321 pass / 62 skip / 6 fail (6 pre-existing, fail identically on clean tree).
- Existing scope-route integration tests (`integration-connection-profile-authorization-http.test.ts`) insert no `session_sandboxes` rows, so the push is a no-op there — they keep passing (CI-verified).
- Preview E2E: to be run on the live preview — `PUT /scope` changing secrets, then confirm the daemon's `/kortix/env` was hit and opencode's PID changed, WITHOUT sending another prompt.

## Risk / rollback

- **Risk:** Low. The push is best-effort and gated on a real secret delta (a no-op PUT does not restart opencode). It only fires when `wantsSecrets` AND the allowlist actually changed, so re-sending the same scope is free. A down/unreachable sandbox is a no-op (next boot converges). The added `await` is the only new latency on a scope PUT that changes secrets, and it matches the model PUT's existing `await pushSessionModelToSandbox`.
- **Rollback:** revert the single route hunk (remove the `if (wantsSecrets && …) { await pushSessionScopeToSandbox(...) }` block); the helper is then unused and can be deleted separately.
- **No values exposed:** the helper returns `{ applied, reason? }`; the route response is the existing `SessionScope` shape (allowlist NAMES, never values). The snapshot (values) only travels server-to-server to the daemon's `/kortix/env` over TLS, same as the per-prompt sync.
