### PR TITLE
fix(projects): bound large repository branch listing

### DIFF
--- a/apps/api/src/projects/git/branches-listing.test.ts
+++ b/apps/api/src/projects/git/branches-listing.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { listBranches } from './branches';
+import { repoCachePath } from './mirror';
+
+const exec = promisify(execFile);
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanupPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+async function createRemoteWithBranches(branchCount: number) {
+  const root = await mkdtemp(join(tmpdir(), 'kortix-branch-listing-'));
+  cleanupPaths.push(root);
+  const work = join(root, 'work');
+  const remote = join(root, 'remote.git');
+  const cache = join(root, 'cache');
+
+  await exec('git', ['init', work]);
+  await exec('git', ['-C', work, 'config', 'user.name', 'Kortix Test']);
+  await exec('git', ['-C', work, 'config', 'user.email', 'test@kortix.ai']);
+  await Bun.write(join(work, 'README.md'), '# test\n');
+  await exec('git', ['-C', work, 'add', 'README.md']);
+  await exec('git', ['-C', work, 'commit', '-m', 'initial']);
+  await exec('git', ['-C', work, 'branch', '-M', 'main']);
+  const { stdout } = await exec('git', ['-C', work, 'rev-parse', 'HEAD']);
+  const tip = stdout.trim();
+
+  await exec('git', ['init', '--bare', remote]);
+  await exec('git', ['-C', work, 'remote', 'add', 'origin', remote]);
+  await exec('git', ['-C', work, 'push', 'origin', 'main']);
+  await Promise.all(
+    Array.from({ length: branchCount }, (_, index) =>
+      exec('git', [
+        '--git-dir',
+        remote,
+        'update-ref',
+        `refs/heads/session-${String(index).padStart(4, '0')}`,
+        tip,
+      ]),
+    ),
+  );
+
+  return { cache, remote, tip };
+}
+
+describe('listBranches', () => {
+  test('lists a large remote without creating a full repository mirror', async () => {
+    const { cache, remote, tip } = await createRemoteWithBranches(250);
+    const previousCacheDir = process.env.KORTIX_GIT_CACHE_DIR;
+    process.env.KORTIX_GIT_CACHE_DIR = cache;
+
+    try {
+      const project = {
+        projectId: 'branch-listing-regression',
+        repoUrl: remote,
+        defaultBranch: 'main',
+        manifestPath: 'kortix.yaml',
+      };
+      const branches = await listBranches(project);
+
+      expect(branches).toHaveLength(251);
+      expect(branches[0]).toMatchObject({
+        name: 'main',
+        is_default: true,
+        tip,
+        tip_short: tip.slice(0, 7),
+        ahead: 0,
+        behind: 0,
+      });
+      expect(branches.at(-1)?.name).toBe('session-0249');
+      expect(await Bun.file(join(repoCachePath(project), 'HEAD')).exists()).toBe(false);
+    } finally {
+      if (previousCacheDir === undefined) delete process.env.KORTIX_GIT_CACHE_DIR;
+      else process.env.KORTIX_GIT_CACHE_DIR = previousCacheDir;
+    }
+  });
+});

--- a/apps/api/src/projects/git/branches.ts
+++ b/apps/api/src/projects/git/branches.ts
@@ -10,6 +10,7 @@ import { createBranchRef, getBranchCommitSha, parseGitHubRepoUrl } from '../gith
 import { isMissingRemoteBranchError } from '../managed-repo-seed';
 import { FIELD_SEP } from './commits';
 import {
+  existingProjectMirrorPath,
   hostFromRepoUrl,
   invalidateProjectMirror,
   isGitOperationError,
@@ -25,6 +26,9 @@ import type { GitBackedProject, GitBranchInfo } from './types';
 // install wall-clock time without spawning an unbounded pile of `git
 // hash-object` subprocesses per commit.
 const HASH_CONCURRENCY = 8;
+const BRANCH_COMPARE_CONCURRENCY = 8;
+const BRANCH_COMPARE_LIMIT = 100;
+const BRANCH_LIST_TIMEOUT_MS = 15_000;
 
 export interface ExpectedFileRevision {
   path: string;
@@ -100,8 +104,40 @@ export async function hashBlobs(
   );
 }
 
-export async function listBranches(project: GitBackedProject): Promise<GitBranchInfo[]> {
-  const repoPath = await refreshMirror(project);
+function branchFromRemoteRef(name: string, tip: string, defaultBranch: string): GitBranchInfo {
+  const isDefault = name === defaultBranch;
+  return {
+    name,
+    is_default: isDefault,
+    tip,
+    tip_short: tip.slice(0, 7),
+    subject: '',
+    committer_name: '',
+    committer_email: '',
+    committed_at: '',
+    ahead: isDefault ? 0 : null,
+    behind: isDefault ? 0 : null,
+  };
+}
+
+export function parseRemoteBranches(stdout: string, defaultBranch: string): GitBranchInfo[] {
+  const branches = stdout
+    .split('\n')
+    .map((line) => line.trim().match(/^([0-9a-f]{40})\s+refs\/heads\/(.+)$/))
+    .filter((match): match is RegExpMatchArray => match !== null)
+    .map((match) => branchFromRemoteRef(match[2] ?? '', match[1] ?? '', defaultBranch));
+
+  branches.sort((a, b) => {
+    if (a.is_default !== b.is_default) return a.is_default ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  return branches;
+}
+
+async function readCachedBranchMetadata(
+  repoPath: string,
+  baseRef: string,
+): Promise<Map<string, GitBranchInfo>> {
   const format = [
     '%(refname:short)',
     '%(objectname)',
@@ -117,7 +153,6 @@ export async function listBranches(project: GitBackedProject): Promise<GitBranch
     false,
   );
   const lines = result.stdout.split('\n').filter(Boolean);
-  const baseRef = project.defaultBranch;
 
   const branches = lines
     .map<GitBranchInfo | null>((line) => {
@@ -139,32 +174,73 @@ export async function listBranches(project: GitBackedProject): Promise<GitBranch
     })
     .filter((b): b is GitBranchInfo => b !== null);
 
-  // Compute ahead/behind vs default in parallel (skip the default itself).
-  await Promise.all(
-    branches.map(async (b) => {
-      if (b.is_default) {
-        b.ahead = 0;
-        b.behind = 0;
-        return;
+  // Exact ahead/behind requires one revision walk per branch on the Git
+  // versions available in our runtime. Bound both process concurrency and the
+  // total comparison count. A repository with thousands of session branches
+  // must never spawn thousands of child processes from one HTTP request.
+  const comparable =
+    branches.length <= BRANCH_COMPARE_LIMIT
+      ? branches
+      : branches.filter((branch) => branch.is_default);
+  await mapLimit(comparable, BRANCH_COMPARE_CONCURRENCY, async (b) => {
+    if (b.is_default) {
+      b.ahead = 0;
+      b.behind = 0;
+      return;
+    }
+    try {
+      const rl = await runGit(
+        ['rev-list', '--left-right', '--count', `${baseRef}...${b.name}`],
+        repoPath,
+        false,
+      );
+      const match = rl.stdout.trim().match(/^(\d+)\s+(\d+)/);
+      if (match) {
+        b.behind = Number(match[1]);
+        b.ahead = Number(match[2]);
       }
-      try {
-        const rl = await runGit(
-          ['rev-list', '--left-right', '--count', `${baseRef}...${b.name}`],
-          repoPath,
-          false,
-        );
-        const match = rl.stdout.trim().match(/^(\d+)\s+(\d+)/);
-        if (match) {
-          b.behind = Number(match[1]);
-          b.ahead = Number(match[2]);
-        }
-      } catch {
-        // Default branch missing or unreachable — leave ahead/behind null.
-      }
-    }),
-  );
+    } catch {
+      // Default branch missing or unreachable — leave ahead/behind null.
+    }
+  });
 
-  return branches;
+  return new Map(branches.map((branch) => [branch.name, branch]));
+}
+
+/**
+ * List the remote branch refs without cloning repository history.
+ *
+ * The old path called `refreshMirror()` first. A cold request cloned the full
+ * repository and then started one `git rev-list` process per branch. That
+ * cannot fit inside the API or SDK deadline for repositories with thousands
+ * of branches. One `git ls-remote --heads` call returns the authoritative refs
+ * without transferring commit history. A valid warm mirror may enrich the
+ * response with commit metadata, but this read never creates or refreshes it.
+ */
+export async function listBranches(project: GitBackedProject): Promise<GitBranchInfo[]> {
+  const result = await runGit(
+    ['ls-remote', '--heads', project.repoUrl],
+    undefined,
+    true,
+    project.gitAuthToken,
+    undefined,
+    hostFromRepoUrl(project.repoUrl),
+    BRANCH_LIST_TIMEOUT_MS,
+    project.gitAuthHeaders,
+  );
+  const branches = parseRemoteBranches(result.stdout, project.defaultBranch);
+  const repoPath = existingProjectMirrorPath(project);
+  if (!repoPath || branches.length === 0) return branches;
+
+  const cached = await readCachedBranchMetadata(repoPath, project.defaultBranch).catch(() => null);
+  if (!cached) return branches;
+
+  return branches.map((branch) => {
+    const metadata = cached.get(branch.name);
+    // Only reuse metadata for the same remote tip. A stale mirror must not
+    // attach the previous commit's subject, date, or comparison counts.
+    return metadata?.tip === branch.tip ? metadata : branch;
+  });
 }
 
 /**

--- a/apps/api/src/projects/git/mirror.ts
+++ b/apps/api/src/projects/git/mirror.ts
@@ -355,6 +355,17 @@ function looksLikeBareMirror(repoPath: string): boolean {
   );
 }
 
+/**
+ * Return the existing usable mirror without cloning or fetching it.
+ *
+ * Latency-sensitive remote-ref reads use this to enrich results from a warm
+ * cache. A cache miss must stay a cache miss on those request paths.
+ */
+export function existingProjectMirrorPath(project: GitBackedProject): string | null {
+  const repoPath = repoCachePath(project);
+  return looksLikeBareMirror(repoPath) ? repoPath : null;
+}
+
 async function doRefreshMirror(project: GitBackedProject, force = false) {
   const repoPath = repoCachePath(project);
   await mkdir(dirname(repoPath), { recursive: true });

--- a/tests/spec/end-to-end.md
+++ b/tests/spec/end-to-end.md
@@ -264,7 +264,7 @@ Repo files are read-only over the project API; live edits happen in the sandbox 
 `FILE-3` `GET /projects/:id/files/search?q=&content=1&ref=&limit=` → filename + grep.
 `FILE-4` `GET /projects/:id/files/history?path=` → commit history for path.
 `FILE-5` `GET /projects/:id/files/archive?path=&ref=` → zip stream.
-`FILE-6` `GET /projects/:id/branches` → branches.
+`FILE-6` `GET /projects/:id/branches` → authoritative remote branch refs without cloning repository history. A warm server mirror can add commit metadata and ahead/behind counts. Cold responses keep those optional display fields empty or `null`.
 `FILE-7` `GET /projects/:id/commits?ref=&path=` · `GET …/commits/:sha` · `GET …/commits/:sha/diff`.
 `FILE-8` `GET /projects/:id/version-diff?from=|head=&into=|base=` → diff between two refs (params are `from`/`head` and `into`/`base` — there is **no `to`**).
 `FILE-9` live file CRUD inside sandbox → through proxy to OpenCode file API on `:8000` (create/read/update/delete/list). Durable truth = git repo; sandbox tree is ephemeral.

--- a/tests/src/flows/files.flow.ts
+++ b/tests/src/flows/files.flow.ts
@@ -173,12 +173,18 @@ flow(
   "FILE-6",
   { domain: "files", tags: ["smoke"], routes: ["GET /v1/projects/:projectId/branches"] },
   async (ctx) => {
-    const p = await ctx.fixtures.sharedProject();
-    await ctx.step("OWNER lists branches → 200 with default_branch", async () => {
+    const p = await ctx.fixtures.sharedSeededProject();
+    await ctx.step("OWNER lists seeded default branch → 200 with remote tip", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .get("/v1/projects/:projectId/branches", { params: { projectId: p.id } });
-      r.status(200).body().exists("$.default_branch").exists("$.branches");
+      const body = r.json<{ default_branch: string }>();
+      r.status(200)
+        .body()
+        .exists("$.default_branch")
+        .has("$.branches[0].name", body.default_branch)
+        .has("$.branches[0].is_default", true)
+        .exists("$.branches[0].tip");
     });
     await ctx.step("NONMEMBER → 403/404", async () => {
       const r = await ctx.client


### PR DESCRIPTION
## Problem

GET /v1/projects/:projectId/branches cloned or fetched the full repository. It then started one git rev-list process per non-default branch. The affected GitHub repository has 2,052 branches. The route exceeded the 30-second request deadline, and the client retried the failed read.

## Fix

- Read authoritative branch refs with one git ls-remote --heads call.
- Enforce a 15-second timeout for the remote ref read.
- Never create or refresh a Git mirror during branch listing.
- Enrich exact remote tips from an existing warm mirror only.
- Bound ahead/behind work to concurrency 8 and repositories with at most 100 branches.
- Cover a 251-branch remote with a regression test.
- Strengthen ke2e FILE-6 to assert the seeded default branch and remote tip.
- Document cold and warm response metadata behavior.

## Verification

- Affected dev repository: 2,052 branches in 972 ms; default branch main; no mirror created.
- Git module suite: 44 passed, 0 failed.
- API suite: 5,335 passed, 62 skipped, 0 failed.
- API typecheck: passed.
- Tests typecheck: passed.
- Local ke2e FILE-6: 1 passed in 4.2 seconds; positive route request 683 ms; HTTP 200 with main and the real tip SHA.
- git diff --check: passed.