### PR TITLE
fix(db): generated migrations get the safety header, unblock the squawk gate

### DIFF
--- a/packages/db/MIGRATIONS.md
+++ b/packages/db/MIGRATIONS.md
@@ -126,7 +126,7 @@ Target a specific DB (secrets never go through the shell): the adapter reads `DA
 - Never edit a migration that has been applied anywhere. Not even a typo. Write a new one. (Tracking is by name — there's no checksum to catch you. Discipline matters. The `immutability` CI job enforces this at PR time.)
 - One logical change per migration.
 - Generated/hand-written SQL is reviewed by a human before it touches a database.
-- Every migration needs `lock_timeout`/`statement_timeout` set (squawk: `require-timeout-settings`) — the template pre-fills this.
+- Every migration needs `lock_timeout`/`statement_timeout` set (squawk: `require-timeout-settings`) — **both** `migrate:create` and `migrate:generate` pre-fill this. (`migrate:generate` did not until 2026-08-05; it renamed drizzle-kit's output through unchanged, so generated migrations were born failing the rule.)
 - Any migration that **drops or alters** a constraint, unique index, column, or enum value needs a `-- mixed-version-safe: <justification>` (or `-- enum-value-checked: <justification>` for `ADD VALUE`) comment, or CI fails it — see [Zero-downtime rules](#zero-downtime-rules-checklist). Same rule for `.concurrent.ts` (e.g. a `DROP INDEX CONCURRENTLY`) — use a `//` comment there instead of `--`.
 
 ---
@@ -201,6 +201,25 @@ ever added to it.
 See `packages/db/SQUAWK_BASELINE.md` for the one-time squawk retro-lint
 report over the pre-existing corpus (178 findings, none fixed, none blocking
 — informational only).
+
+### When a migration merges red: `squawk-waivers.json`
+
+The squawk check is **not** a required status check, so a PR can merge with it
+failing. That leaves a hole the grandfather list cannot cover: squawk lints file
+TEXT, merged migrations are immutable, and squawk's target set is *every*
+non-exempt file rather than the ones a PR adds. So one red merge fails the lint
+on every unrelated PR from then on, and there is no way to fix the file.
+
+`packages/db/squawk-waivers.json` is the escape hatch, deliberately **separate**
+from `grandfathered-migrations.json` — that file means "existed before
+2026-07-16" and must keep meaning only that. A waiver entry names the file,
+states every finding, why it cannot be fixed, and what root cause was fixed so
+it does not recur. `scripts/squawk-lint.ts` prints the whole waiver list on
+every run, so the debt stays visible.
+
+Adding a **new** migration to this list is almost always wrong: fix it in the PR
+that adds it, while the file is still mutable. Today it holds exactly one entry
+(`20260805030712000_enterprise_entitled_flag.sql`, merged in #6120).
 
 ---
 

--- a/packages/db/scripts/generate-safety-header.test.ts
+++ b/packages/db/scripts/generate-safety-header.test.ts
@@ -1,0 +1,64 @@
+/**
+ * A GENERATED migration must be born with the same safety header a
+ * hand-written one gets.
+ *
+ * `migrate:create` has pre-filled `set lock_timeout` / `set statement_timeout`
+ * since the zero-downtime policy landed. `migrate:generate` did not — it
+ * renamed drizzle-kit's output into migrations/ untouched. So every generated
+ * migration started life failing squawk's `require-timeout-settings`, and only
+ * passed if the author noticed and pasted the header in by hand.
+ *
+ * That is not a hypothetical: 20260805030712000_enterprise_entitled_flag.sql
+ * was generated, shipped without the header, merged with the check red, and
+ * then failed the lint on every unrelated PR afterwards — because squawk's
+ * target set is "every non-exempt migration", not "the ones this PR adds".
+ *
+ * The two scripts hold the header text separately, so these tests pin the part
+ * that must not drift: the timeout statements themselves.
+ */
+import { describe, expect, test } from 'bun:test';
+
+const GENERATE = await Bun.file(new URL('./generate.ts', import.meta.url).pathname).text();
+const CREATE = await Bun.file(new URL('./create-migration.ts', import.meta.url).pathname).text();
+
+/** The `set <name> = '<value>';` statements a template emits into the SQL. */
+function timeouts(src: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const m of src.matchAll(/set (lock_timeout|statement_timeout) = '([^']+)'/g)) {
+    out[m[1]] = m[2];
+  }
+  return out;
+}
+
+describe('generate.ts safety header', () => {
+  test('emits both timeout statements', () => {
+    const t = timeouts(GENERATE);
+    expect(t.lock_timeout).toBeDefined();
+    expect(t.statement_timeout).toBeDefined();
+  });
+
+  test('uses the SAME values as the hand-written template', () => {
+    // Two headers that disagree would make "which command did you use?" a
+    // silent input to how safe the migration is.
+    expect(timeouts(GENERATE)).toEqual(timeouts(CREATE));
+  });
+
+  test('prepends the header to the generated file, not just prints it', () => {
+    // The original bug was cosmetic-looking and total: the script only ever
+    // renamed drizzle's file. Advice on stdout does not reach the linter.
+    expect(GENERATE).toContain('safetyHeader(slug)');
+    expect(GENERATE).toContain('writeFileSync');
+  });
+
+  test('the header carries the enforced annotation lines', () => {
+    // lint-migrations.ts fails any DROP/RENAME/ALTER TYPE without these, and a
+    // generated diff is exactly where an unreviewed one appears.
+    expect(GENERATE).toContain('mixed-version-safe:');
+    expect(GENERATE).toContain('enum-value-checked:');
+  });
+
+  test('tells the author to review the generated SQL', () => {
+    // drizzle knows the target shape, not how to reach it without downtime.
+    expect(GENERATE).toContain('REVIEW THE GENERATED SQL');
+  });
+});

--- a/packages/db/scripts/generate.ts
+++ b/packages/db/scripts/generate.ts
@@ -14,7 +14,7 @@ import { spawnSync } from 'node:child_process';
  * For hand-written SQL (RLS, functions, data) use instead:
  *   node-pg-migrate create <slug> -m migrations -j sql --migration-filename-format utc
  */
-import { existsSync, readdirSync, renameSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const DB_ROOT = join(import.meta.dir, '..');
@@ -33,6 +33,47 @@ function utcStamp(): string {
     p(d.getUTCSeconds()) +
     p(d.getUTCMilliseconds(), 3)
   );
+}
+
+/**
+ * The house-rules safety header, prepended to drizzle's raw output.
+ *
+ * `migrate:create` has pre-filled this since the zero-downtime policy landed,
+ * but `migrate:generate` did not — it renamed drizzle's file through unchanged.
+ * So every GENERATED migration was born failing squawk's
+ * `require-timeout-settings`, and only passed if the author happened to paste
+ * the header in by hand. One that didn't (20260805030712000_enterprise_
+ * entitled_flag.sql) merged red and then failed the lint on every unrelated PR
+ * afterwards, because the gate's exemption list is a fixed snapshot.
+ *
+ * Kept deliberately in sync with the `-- SAFETY HEADER` block in
+ * create-migration.ts; scripts/generate.test.ts asserts the timeouts match.
+ */
+function safetyHeader(name: string): string {
+  return `-- Migration: ${name}
+--
+-- SAFETY HEADER (house rules -- see packages/db/MIGRATIONS.md#zero-downtime-rules).
+-- Tune these down further for large/hot tables; raise statement_timeout only
+-- for an operation you've deliberately reasoned about (e.g. a NOT VALID
+-- constraint's later VALIDATE, or a batched backfill with its own paging).
+set lock_timeout = '2s';
+set statement_timeout = '30s';
+
+-- REVIEW THE GENERATED SQL BELOW. drizzle-kit writes it from the diff between
+-- kortix.ts and the snapshot; it knows the target shape, not how to reach it
+-- without downtime. Check the same list \`migrate:create\` prints:
+--   [ ] Bare NOT NULL added to an existing populated table (needs a backfill first).
+--   [ ] Plain CREATE INDEX / DROP INDEX on an EXISTING table -- move it to
+--       \`pnpm migrate:create <slug> --concurrent\`; it blocks writes here.
+--   [ ] New FK/constraint on an existing table -- add NOT VALID, VALIDATE after.
+--   [ ] A DROP/RENAME/ALTER ... TYPE the generator proposed from a STALE
+--       snapshot. Delete anything already applied by an earlier migration.
+--   [ ] Any DROP/RENAME/ALTER ... TYPE/DROP NOT NULL needs the enforced line:
+-- mixed-version-safe: <why old code tolerates this change, or why it cannot still be running>
+--   [ ] Any ALTER TYPE ... ADD VALUE needs:
+-- enum-value-checked: <how you verified every env, including any faked baseline, has this value>
+
+`;
 }
 
 const slug = process.argv[2] ?? '';
@@ -69,7 +110,9 @@ if (created.length > 1) {
 }
 
 const target = `${utcStamp()}_${slug}.sql`;
-renameSync(join(DRIZZLE_DIR, created[0]), join(MIGRATIONS_DIR, target));
+const targetPath = join(MIGRATIONS_DIR, target);
+renameSync(join(DRIZZLE_DIR, created[0]), targetPath);
+writeFileSync(targetPath, safetyHeader(slug) + readFileSync(targetPath, 'utf8'));
 console.log(`\nGenerated: packages/db/migrations/${target}`);
 console.log('Review the SQL, then commit it AND the updated packages/db/drizzle/ snapshot.');
 console.log('Apply with: pnpm migrate');

--- a/packages/db/scripts/squawk-lint.ts
+++ b/packages/db/scripts/squawk-lint.ts
@@ -29,6 +29,7 @@ const DB_ROOT = join(import.meta.dir, '..');
 const MIGRATIONS_DIR = join(DB_ROOT, 'migrations');
 const CONFIG_PATH = join(DB_ROOT, '.squawk.toml');
 const GRANDFATHER_FILE = join(DB_ROOT, 'grandfathered-migrations.json');
+const WAIVER_FILE = join(DB_ROOT, 'squawk-waivers.json');
 
 // Pinned release + per-platform sha256. Upstream doesn't publish checksum
 // files, so these were computed by us at pin time (2026-07-16, squawk v2.59.0)
@@ -106,6 +107,30 @@ function loadGrandfatherSet(): Set<string> {
   }
 }
 
+export interface SquawkWaiver {
+  file: string;
+  reason: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Migrations that merged red and can no longer be fixed — see
+ * squawk-waivers.json for why the hatch exists and why it is debt.
+ *
+ * Separate from the grandfather snapshot on purpose. That file means "existed
+ * before 2026-07-16" and has to keep meaning only that; folding merged-red
+ * files into it would make the baseline a dumping ground and erase the
+ * distinction between "predates the policy" and "violated the policy".
+ */
+export function loadWaivers(): SquawkWaiver[] {
+  try {
+    const data = JSON.parse(readFileSync(WAIVER_FILE, 'utf8')) as { files: SquawkWaiver[] };
+    return Array.isArray(data.files) ? data.files : [];
+  } catch {
+    return [];
+  }
+}
+
 async function main(): Promise<void> {
   const lintAll = process.argv.includes('--all');
   const grandfathered = loadGrandfatherSet();
@@ -115,7 +140,20 @@ async function main(): Promise<void> {
     .filter((f) => f.endsWith('.sql'))
     .sort();
 
-  const targets = lintAll ? allSqlFiles : allSqlFiles.filter((f) => !grandfathered.has(f));
+  const waivers = loadWaivers();
+  const waived = new Set(waivers.map((w) => w.file));
+
+  const targets = lintAll
+    ? allSqlFiles
+    : allSqlFiles.filter((f) => !grandfathered.has(f) && !waived.has(f));
+
+  // Printed every run, on purpose. A waiver is unfixed debt that shipped; the
+  // moment it goes quiet it stops being debt and starts being the new normal.
+  if (waivers.length > 0 && !lintAll) {
+    console.log(`squawk-lint: ${waivers.length} WAIVED migration(s) — merged red, now immutable:`);
+    for (const w of waivers) console.log(`  ! ${w.file}\n      ${w.reason}`);
+    console.log('    (see packages/db/squawk-waivers.json)');
+  }
 
   if (targets.length === 0) {
     console.log('squawk-lint: no new migrations to lint (everything is grandfathered).');
@@ -136,7 +174,12 @@ async function main(): Promise<void> {
   process.exit(result.status ?? 1);
 }
 
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : err);
-  process.exit(1);
-});
+// Guarded so the module can be imported for its helpers (squawk-lint.test.ts)
+// without running the lint — and, more to the point, without the `process.exit`
+// at the end of main() killing the test runner.
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/packages/db/scripts/squawk-waivers.test.ts
+++ b/packages/db/scripts/squawk-waivers.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The waiver list for migrations that merged red.
+ *
+ * Squawk lints file TEXT, and merged migrations are immutable (CI job
+ * "Migrations are immutable"). So a finding in a merged migration can never be
+ * fixed — not by editing it, not by a follow-up migration. And because squawk's
+ * target set is every non-exempt file rather than the ones a PR adds, one red
+ * merge fails the lint on every unrelated PR from then on.
+ *
+ * Hence a waiver. The risk of a waiver list is that it quietly becomes the
+ * place findings go to die, so these tests pin the properties that keep it
+ * honest: every entry explains itself, it stays separate from the grandfather
+ * snapshot, and the lint prints it on every run.
+ */
+import { describe, expect, test } from 'bun:test';
+import { loadWaivers } from './squawk-lint';
+
+const waivers = loadWaivers();
+const LINT = await Bun.file(new URL('./squawk-lint.ts', import.meta.url).pathname).text();
+
+describe('squawk-waivers.json', () => {
+  test('parses and is non-empty only for real, named files', async () => {
+    for (const w of waivers) {
+      expect(w.file).toMatch(/^\d{17}_[a-z0-9_]+\.sql$/);
+      const exists = await Bun.file(
+        new URL(`../migrations/${w.file}`, import.meta.url).pathname,
+      ).exists();
+      expect(exists).toBe(true);
+    }
+  });
+
+  test('every entry states what is wrong and why it cannot be fixed', () => {
+    // A bare filename would make the list indistinguishable from a mute button.
+    for (const w of waivers) {
+      expect(typeof w.reason).toBe('string');
+      expect(w.reason.length).toBeGreaterThan(40);
+      expect(typeof w.unfixableBecause).toBe('string');
+    }
+  });
+
+  test('no file is both grandfathered and waived', async () => {
+    // The two lists mean different things — "predates the policy" versus
+    // "violated the policy". An overlap would blur exactly that distinction.
+    const gf = (await Bun.file(
+      new URL('../grandfathered-migrations.json', import.meta.url).pathname,
+    ).json()) as { files: string[] };
+    const gfSet = new Set(gf.files);
+    for (const w of waivers) expect(gfSet.has(w.file)).toBe(false);
+  });
+});
+
+describe('squawk-lint waiver handling', () => {
+  test('excludes waived files from the lint targets', () => {
+    expect(LINT).toContain('waived.has(f)');
+  });
+
+  test('prints the waived list on every run', () => {
+    // Debt that stops being visible stops being debt and becomes the norm.
+    expect(LINT).toContain('WAIVED migration(s)');
+  });
+
+  test('keeps the grandfather set as a separate input', () => {
+    expect(LINT).toContain('loadGrandfatherSet');
+    expect(LINT).toContain('loadWaivers');
+  });
+});

--- a/packages/db/squawk-waivers.json
+++ b/packages/db/squawk-waivers.json
@@ -1,0 +1,35 @@
+{
+  "_comment": [
+    "Already-MERGED migrations that fail squawk and can no longer be fixed.",
+    "",
+    "This is NOT grandfathered-migrations.json. That file is a fixed snapshot of",
+    "what existed before the zero-downtime guard landed (2026-07-16) and its",
+    "meaning must stay exactly that. This file is the escape hatch for the other",
+    "case: a migration written AFTER the guard that merged red anyway.",
+    "",
+    "Why the hatch has to exist. Migrations are immutable (CI job 'Migrations are",
+    "immutable' rejects any edit to a merged file), and squawk lints file TEXT, so",
+    "a finding in a merged migration cannot be fixed by a follow-up migration. But",
+    "squawk's target set is every non-exempt file, not just the ones a PR adds --",
+    "so one red merge fails the lint on every unrelated PR from then on. Without a",
+    "waiver the only ways out are to corrupt the grandfather snapshot's meaning or",
+    "to leave the gate red for everybody.",
+    "",
+    "Adding an entry here is DEBT, not absolution: the finding is real and it",
+    "shipped. Every entry states what is wrong and why it is unfixable, and",
+    "squawk-lint prints the whole list on each run so it cannot go quiet.",
+    "",
+    "Adding a NEW migration here is almost always the wrong move -- fix the file",
+    "in the PR that adds it, while it is still mutable."
+  ],
+  "files": [
+    {
+      "file": "20260805030712000_enterprise_entitled_flag.sql",
+      "mergedIn": "#6120",
+      "reason": "Merged with the squawk check red. Three findings: no lock_timeout and no statement_timeout before ALTER TABLE kortix.credit_accounts ADD COLUMN (require-timeout-settings x2), and a DROP COLUMN in its 'Down Migration' section (ban-drop-column).",
+      "unfixableBecause": "The file is merged and immutable, and squawk lints file text -- no follow-up migration can clear a finding in it.",
+      "rootCauseFixed": "scripts/generate.ts now prepends the safety header that scripts/create-migration.ts always had, so drizzle-generated migrations no longer start life missing the timeouts. The repo does not write 'Down Migration' sections (see create-migration.ts); this file's was hand-added.",
+      "realRisk": "ADD COLUMN with a constant DEFAULT does not rewrite the table on PG11+, but it still takes a brief ACCESS EXCLUSIVE lock. With no lock_timeout that ALTER waits behind any long transaction on credit_accounts and every query queues behind it. This has run on dev; it has NOT run on prod yet."
+    }
+  ]
+}


### PR DESCRIPTION
## The problem

`main` fails **Squawk (zero-downtime lint) on new migrations**, and has since
2026-08-05. It fails on every PR that runs the job, regardless of what that PR
changes:

```
warning[require-timeout-settings]: Missing `set lock_timeout` before potentially slow operations
  ╭▸ packages/db/migrations/20260805030712000_enterprise_entitled_flag.sql:26:1
warning[require-timeout-settings]: Missing `set statement_timeout` ...
warning[ban-drop-column]: Dropping a column may break existing clients.
Found 3 issues in 1 file (checked 52 source files)
```

## Root cause

`migrate:create` writes a `-- SAFETY HEADER` block with `set lock_timeout` /
`set statement_timeout`. `migrate:generate` did not — [generate.ts](packages/db/scripts/generate.ts)
renamed drizzle-kit's output into `migrations/` untouched.

So every **generated** migration was born failing `require-timeout-settings`,
and passed only if the author noticed and pasted the header in by hand.
`20260805030712000_enterprise_entitled_flag.sql` (#6120) is one that didn't.

It then became permanent, for two compounding reasons:

1. Squawk is not a required status check, so the PR merged red.
2. `squawk-lint.ts` targets *every non-grandfathered file*, not the files a PR
   adds. `grandfathered-migrations.json` is a fixed 2026-07-16 snapshot, so a
   file written after that date is never exempt.

Migrations are immutable (the `Migrations are immutable` job rejects any edit to
a merged file) and squawk lints file **text**, so no follow-up migration can
clear a finding in it.

## The fix

**`generate.ts` prepends the same safety header** — the root cause, so this
cannot recur for generated migrations.

**`squawk-waivers.json`** carries the one file that can no longer be fixed. It is
deliberately separate from `grandfathered-migrations.json`: that list means
"existed before the policy" and must keep meaning only that, and MIGRATIONS.md
states nothing is ever added to it. Each waiver names every finding, why it is
unfixable, and what root cause was fixed. `squawk-lint` prints the list on every
run so the debt does not go quiet.

## Verification

Header reaches the file, end to end — added a throwaway column, ran the real
`migrate:generate`, then reverted:

```
Generated: packages/db/migrations/20260805200543689_probe_header_check.sql

-- Migration: probe_header_check
-- SAFETY HEADER (house rules -- see packages/db/MIGRATIONS.md#zero-downtime-rules).
set lock_timeout = '2s';
set statement_timeout = '30s';
...
ALTER TABLE "kortix"."session_pending_questions" ADD COLUMN "probe_header_check" text;
```

The counterfactual, same DDL with the header stripped — i.e. what `generate.ts`
produced before this change:

| generated file | `bun scripts/squawk-lint.ts` |
| --- | --- |
| with header (this PR) | `Found 0 issues in 52 files` |
| header stripped (before) | `Found 2 issues in 1 file` — both `require-timeout-settings` |

Gate green, and the waiver prints:

```
$ pnpm --filter @kortix/db lint
squawk-lint: 1 WAIVED migration(s) — merged red, now immutable:
  ! 20260805030712000_enterprise_entitled_flag.sql
Found 0 issues in 51 files 🎉
```

```
$ bun test scripts/      # packages/db
94 pass, 3 skip, 0 fail
```

Probe fully reverted — no residue in `kortix.ts`, `migrations/`, or the drizzle
snapshot/journal.

## Still open, needs a decision

The waived `ALTER TABLE kortix.credit_accounts ADD COLUMN` **has not run on prod
yet**. On PG11+ a constant `DEFAULT` means no table rewrite, but it still takes
a brief `ACCESS EXCLUSIVE` lock, and with no `lock_timeout` it waits behind any
long transaction on `credit_accounts` while every later query queues behind it.
`scripts/migrate.ts` sets no timeout at the runner level either, so nothing
bounds it. A runner-level `lock_timeout` would cover this file and every
grandfathered one; not done here because it changes behaviour for all
migrations and deserves its own review.

Separately: this whole class exists because Squawk can merge red. Making it a
required check would have stopped it at #6120.
