### PR TITLE
fix(web): regenerate stale content timestamp manifest

### DIFF
--- a/apps/web/src/lib/seo/content-timestamps.json
+++ b/apps/web/src/lib/seo/content-timestamps.json
@@ -2,7 +2,7 @@
   "marketing:index": "2026-08-02T16:58:04.000Z",
   "marketing:about": "2026-07-30T23:40:07.000Z",
   "marketing:contact": "2026-07-31T00:17:00.000Z",
-  "marketing:developers": "2026-08-05T17:26:39.000Z",
+  "marketing:developers": "2026-08-05T19:23:01.000Z",
   "marketing:enterprise": "2026-07-31T01:17:03.000Z",
   "marketing:pricing": "2026-07-31T01:17:03.000Z",
   "marketing:marketplace": "2026-08-02T16:58:04.000Z",


### PR DESCRIPTION
## Summary

`content timestamp manifest > matches the current git history` is currently **failing on `main`**, which turns the `Test apps` step of `package-tests.yml` red on every open PR.

**Cause.** #6146 (`bbe5fe6dd9`) edited `src/app/(public)/(marketing)/developers/page.tsx` but shipped `src/lib/seo/content-timestamps.json` unregenerated, so the manifest still carries the pre-#6146 commit time.

```diff
-  "marketing:developers": "2026-08-05T17:26:39.000Z",
+  "marketing:developers": "2026-08-05T19:23:01.000Z",
```

Regenerated with `scripts/build-content-timestamps.mjs`. No hand-editing. One line.

**Not cosmetic.** `public-content.ts` feeds this into the `last_modified` field on `/api/ai` and `/llms.txt`, so recency-aware answer engines were being told the developers page is older than it is — the exact deprioritization the manifest exists to prevent.

**Why it reached `main`.** The frontend CI job runs only `sdk-boundary.test.ts` + `eslint src --quiet`, and `next build` calls `refreshContentTimestamps()` from `next.config.ts` — so the build silently self-heals the file and never fails on it. The only job that catches this is the `Test apps` step in `package-tests.yml`. Worth a follow-up: a page edit shouldn't be able to land a stale manifest that only one non-obvious job detects.

## Test plan

- [x] `bun test src/lib/seo/` — **19 pass, 0 fail** (was 1 fail before this change)
- [x] Regenerated via the script, not by hand; re-running it produces no further diff
- [x] Branched directly off `origin/main` — this PR is the one-line change and nothing else
