### PR TITLE
fix(daemon): stop auto-answering questions outside a channel session

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -1267,10 +1267,14 @@ function slackRelayContext(): SandboxRelayContext | null {
 // session metadata: a Slack session is tagged `metadata.slack` at creation, and
 // the API projects that into SLACK_THREAD_TS / SLACK_CHANNEL_ID on EVERY
 // (re)provision (buildSessionChannelEnv). A web/dashboard session has no such
-// metadata, so it has no such env — `slackRelayContext()` returns null and we
-// return WITHOUT touching opencode's question. That's the whole fix: the
-// dashboard answers `question.asked` interactively over opencode's own SSE, and
-// auto-answering it here was the "every question is auto-answered even outside
+// metadata, so it has no such env and `slackRelayContext()` returns null.
+//
+// That distinction now gates RESOLVING the question, not reporting it. Every
+// session reports it, so the control plane can persist it and the ask survives
+// the box being parked. Only a channel session auto-answers opencode's blocking
+// call, because only there does the reply arrive out of band. The dashboard
+// answers `question.asked` interactively over opencode's own SSE, and
+// auto-answering it here is the "every question is auto-answered even outside
 // Slack" bug. No round-trip, no status codes — the env is the source of truth.
 async function relayQuestionToApi(req: QuestionRequest, cfg: Config): Promise<void> {
   // EVERY session, not just Slack ones.
@@ -1311,9 +1315,33 @@ async function relayQuestionToApi(req: QuestionRequest, cfg: Config): Promise<vo
     logger.warn('[opencode-events] turn-question post failed (non-fatal)', { err: (err as Error).message })
   }
 
-  // Resume opencode's (blocking) question tool with a sentinel so the turn ends;
-  // the user's reply / button click lands as a new turn. ALWAYS reply — a Slack
-  // question must never hang (that was "stuck until I kill it manually").
+  // PERSISTING the question is for every session. RESOLVING it here is not.
+  //
+  // In a channel session the reply genuinely arrives out of band — the user
+  // types in the Slack thread and it reaches the agent as a new turn — so the
+  // blocking call must be released or the turn hangs ("stuck until I kill it
+  // manually").
+  //
+  // A dashboard session is the opposite: the UI answers `question.asked`
+  // interactively over opencode's own SSE, so the call SHOULD keep blocking
+  // while the box is alive. Auto-answering it here is the "every question is
+  // auto-answered even outside Slack" bug described above — which the relay
+  // ungate silently brought back, because the sentinel then fired for every
+  // session. Seen live on dev 2026-08-05: a web session's agent was told
+  // "Posted to the Slack thread" (it was not) and replied "I'll use `slack
+  // send` for questions in this environment going forward instead of the
+  // `question` tool" — the tool park-and-restore exists to make reliable.
+  //
+  // If the box is parked while the question is still open, the control plane
+  // has it (persisted above) and POST /sessions/:id/question delivers the answer
+  // as a follow-up turn. Nothing is lost by leaving this one blocked.
+  if (!slackRelayContext()) {
+    logger.info('[opencode-events] question persisted; left open for the UI', {
+      requestId: req.id,
+    })
+    return
+  }
+
   const sentinel =
     '(Posted to the Slack thread. In Slack, questions are async — the user replies ' +
     'as a normal message, which reaches you as a NEW turn with full context. Do NOT ' +

--- a/apps/kortix-sandbox-agent-server/src/question-relay-scope.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/question-relay-scope.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Reporting a question and RESOLVING it are separate decisions.
+ *
+ * The park-and-restore change made `relayQuestionToApi` run for every session
+ * (it used to bail without SLACK_THREAD_TS), so the control plane could persist
+ * the ask and it would survive the box being parked. That part is right.
+ *
+ * What came with it by accident: the sentinel auto-answer below the POST then
+ * fired for every session too. That is the "every question is auto-answered
+ * even outside Slack" bug the function's own header describes — a dashboard
+ * session answers `question.asked` interactively over opencode's SSE, so the
+ * blocking call must stay blocked while the box is alive.
+ *
+ * Seen live on dev 2026-08-05: a web session's agent was told "Posted to the
+ * Slack thread" — it was not — and answered "I'll use `slack send` for questions
+ * in this environment going forward instead of the `question` tool", i.e. the
+ * sentinel talked the agent out of the tool park-and-restore exists to make
+ * reliable.
+ *
+ * Asserted on source: the relay is one branch inside a 4k-line daemon with no
+ * seam to import, and what matters is which context each half reads.
+ */
+import { describe, expect, test } from 'bun:test';
+
+const SRC = await Bun.file(new URL('./main.ts', import.meta.url).pathname).text();
+
+/** `relayQuestionToApi`'s body, up to the next top-level declaration. */
+function relayBody(): string {
+  const start = SRC.indexOf('async function relayQuestionToApi');
+  expect(start).toBeGreaterThan(-1);
+  const rest = SRC.slice(start);
+  const end = rest.indexOf('\n// Relay a turn ending');
+  return end > 0 ? rest.slice(0, end) : rest;
+}
+
+/** Body with comments stripped — the prose names both helpers. */
+function code(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n');
+}
+
+describe('relayQuestionToApi', () => {
+  const body = code(relayBody());
+
+  test('REPORTS on every session, via the channel-agnostic context', () => {
+    // sandboxRelayContext() has no Slack requirement — that ungate is what lets
+    // a web session's question be persisted at all.
+    expect(body).toContain('sandboxRelayContext()');
+    expect(body).toContain('turn-question');
+  });
+
+  test('the POST is not gated on a Slack context', () => {
+    // The regression this guards: reintroducing `slackRelayContext()` as the
+    // early return would silently stop persisting web questions again, and
+    // nothing user-visible fails until a box parks.
+    const postAt = body.indexOf('turn-question');
+    const slackGateAt = body.indexOf('slackRelayContext()');
+    expect(slackGateAt).toBeGreaterThan(postAt);
+  });
+
+  test('RESOLVES only when a channel carries the reply out of band', () => {
+    expect(body).toContain('if (!slackRelayContext())');
+  });
+
+  test('the Slack-worded sentinel is unreachable without a Slack context', () => {
+    // The false "Posted to the Slack thread" line a web session received.
+    const gateAt = body.indexOf('if (!slackRelayContext())');
+    const sentinelAt = body.indexOf('Posted to the Slack thread');
+    expect(gateAt).toBeGreaterThan(-1);
+    expect(sentinelAt).toBeGreaterThan(gateAt);
+  });
+
+  test('a non-channel question is left open, not replied to', () => {
+    const gateAt = body.indexOf('if (!slackRelayContext())');
+    const replyAt = body.indexOf('/reply?directory=');
+    expect(replyAt).toBeGreaterThan(gateAt);
+  });
+});


### PR DESCRIPTION
Found while verifying park-and-restore on dev (#6145, merged as `b42257b1`).
This is a regression that PR introduced.

## What broke

`relayQuestionToApi` does two things: it **reports** the question to the control
plane, and it **resolves** opencode's blocking `question` call with a sentinel.

Making it run for every session was correct for the first — the control plane has
to persist the ask so it survives the box being parked. But it also switched on
the second, for every session. That is exactly the bug the function's own header
warns about:

> auto-answering it here was the "every question is auto-answered even outside
> Slack" bug

A dashboard session answers `question.asked` interactively over opencode's own
SSE. That call must stay blocked while the box is alive.

## Observed on dev

A plain web session, transcript read back through the runtime proxy:

```
[assistant] TOOL question -> completed
[assistant] "Understood. I'll use `slack send` for questions in this environment
             going forward instead of the `question` tool."
```

The sentinel it received:

> (Posted to the Slack thread. … Next time, just ask with `slack send` rather
> than the question tool.)

There was no Slack thread. The message is false for a web session, and it talked
the agent out of the tool this work exists to make reliable.

## The fix

Split the two decisions:

- **Report** — every session, via `sandboxRelayContext()`. Unchanged.
- **Resolve** — only when `slackRelayContext()` is non-null, i.e. only where the
  reply genuinely arrives out of band and the turn would otherwise hang.

If a box is parked with a question still open, the control plane has it and
`POST /v1/projects/:id/sessions/:id/question` delivers the answer as a follow-up
turn — verified live on dev. Nothing is lost by leaving the call blocked.

## Verification

```
$ bun test src/question-relay-scope.test.ts
5 pass, 0 fail

$ bun run build            # tsc --noEmit + compile
Built dist/kortix-agent for bun-linux-x64 (94988416 bytes)
```

The tests pin the split by ordering: the POST must come *before* any
`slackRelayContext()` gate, and both the Slack-worded sentinel and the
`/reply` call must come *after* it.

## Note on rollout

This is a daemon change, so it reaches only sandboxes built from a new snapshot.
While verifying #6145 I hit the related trap: the first session created after the
deploy still ran the **old** daemon because the warm pool hands out boxes
pre-warmed from the previous snapshot (`session_start_timeline.totalMs` was
868ms — sub-second means a warm box). A session created ~10 minutes later picked
up the new daemon. Expect the same lag here.
