### PR TITLE
fix(approvals): require full one-call review

### DIFF
--- a/apps/api/src/__tests__/integration-approvals.test.ts
+++ b/apps/api/src/__tests__/integration-approvals.test.ts
@@ -12,6 +12,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
   accountMembers,
   executorExecutions,
+  projectMembers,
   projectSessions,
   sessionLifecycleCommands,
 } from '@kortix/db';
@@ -30,6 +31,8 @@ let ctx: { projectId: string; accountId: string; userId: string } | null = null;
 let secret = '';
 let humanToken = '';
 let humanUserId = '';
+let readOnlyToken = '';
+let readOnlyUserId = '';
 let priorDemoEnterprise = false;
 
 beforeAll(async () => {
@@ -97,6 +100,50 @@ beforeAll(async () => {
     createdBy: humanUserId,
     visibility: 'private',
   });
+  const readOnlyEmail = `approvals-reader-${crypto.randomUUID()}@example.test`;
+  const readOnlyPassword = `Approval-Reader-${crypto.randomUUID()}-aA1!`;
+  const readOnlyCreated = await fetch(`${config.SUPABASE_URL}/auth/v1/admin/users`, {
+    method: 'POST',
+    headers: {
+      apikey: config.SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${config.SUPABASE_SERVICE_ROLE_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: readOnlyEmail,
+      password: readOnlyPassword,
+      email_confirm: true,
+    }),
+  });
+  expect(readOnlyCreated.status).toBe(200);
+  const readOnlyCreatedBody = (await readOnlyCreated.json()) as {
+    id?: string;
+    user?: { id?: string };
+  };
+  readOnlyUserId = readOnlyCreatedBody.user?.id ?? readOnlyCreatedBody.id ?? '';
+  expect(readOnlyUserId).not.toBe('');
+  await db.insert(accountMembers).values({
+    accountId: ctx.accountId,
+    userId: readOnlyUserId,
+    accountRole: 'member',
+  });
+  await db.insert(projectMembers).values({
+    accountId: ctx.accountId,
+    projectId: ctx.projectId,
+    userId: readOnlyUserId,
+    projectRole: 'member',
+  });
+  const readOnlySignedIn = await fetch(`${config.SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: {
+      apikey: config.SUPABASE_SERVICE_ROLE_KEY,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email: readOnlyEmail, password: readOnlyPassword }),
+  });
+  expect(readOnlySignedIn.status).toBe(200);
+  readOnlyToken = ((await readOnlySignedIn.json()) as { access_token?: string }).access_token ?? '';
+  expect(readOnlyToken).not.toBe('');
   // The full-trail assertions below need the auditAccess entitlement; flip the
   // enterprise demo on for the suite (restored in afterAll). The unentitled
   // contract has its own dedicated test that toggles it off.
@@ -118,6 +165,25 @@ afterAll(async () => {
         sql`${accountMembers.accountId} = ${ctx.accountId} and ${accountMembers.userId} = ${humanUserId}`,
       );
     await fetch(`${config.SUPABASE_URL}/auth/v1/admin/users/${humanUserId}`, {
+      method: 'DELETE',
+      headers: {
+        apikey: config.SUPABASE_SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${config.SUPABASE_SERVICE_ROLE_KEY}`,
+      },
+    });
+  }
+  if (ctx && readOnlyUserId) {
+    await db
+      .delete(projectMembers)
+      .where(
+        sql`${projectMembers.projectId} = ${ctx.projectId} and ${projectMembers.userId} = ${readOnlyUserId}`,
+      );
+    await db
+      .delete(accountMembers)
+      .where(
+        sql`${accountMembers.accountId} = ${ctx.accountId} and ${accountMembers.userId} = ${readOnlyUserId}`,
+      );
+    await fetch(`${config.SUPABASE_URL}/auth/v1/admin/users/${readOnlyUserId}`, {
       method: 'DELETE',
       headers: {
         apikey: config.SUPABASE_SERVICE_ROLE_KEY,
@@ -159,6 +225,10 @@ const authPost = (path: string, body: unknown) =>
     headers: { Authorization: `Bearer ${humanToken}`, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+const readOnlyGet = (path: string) =>
+  app.request(path, { headers: { Authorization: `Bearer ${readOnlyToken}` } });
+const patGet = (path: string) =>
+  app.request(path, { headers: { Authorization: `Bearer ${secret}` } });
 const patPost = (path: string, body: unknown) =>
   app.request(path, {
     method: 'POST',
@@ -298,6 +368,51 @@ describe('approvals inbox + resolution', () => {
       review_complete: true,
       args_preview: { repo: 'kortix-ai/suna' },
     });
+  });
+
+  test('Review Center exposes parameters only to a human who can resolve the approval', async () => {
+    if (!ctx) return;
+    const execId = await seedPending();
+    const path = `/v1/projects/${ctx.projectId}/review/items`;
+
+    const owner = await authGet(path);
+    expect(owner.status).toBe(200);
+    const ownerBody = (await owner.json()) as {
+      review_items: Array<{ review_item_id: string; detail: Record<string, unknown> }>;
+    };
+    const ownerItem = ownerBody.review_items.find(
+      (item) => item.review_item_id === `exec:${execId}`,
+    );
+    expect(ownerItem?.detail).toMatchObject({
+      args_preview: { repo: 'kortix-ai/suna' },
+      args_preview_complete: true,
+      args_preview_authorized: true,
+    });
+
+    const readOnly = await readOnlyGet(path);
+    expect(readOnly.status).toBe(200);
+    const readOnlyBody = (await readOnly.json()) as {
+      review_items: Array<{ review_item_id: string; detail: Record<string, unknown> }>;
+    };
+    const readOnlyItem = readOnlyBody.review_items.find(
+      (item) => item.review_item_id === `exec:${execId}`,
+    );
+    expect(readOnlyItem?.detail).not.toHaveProperty('args_preview');
+    expect(readOnlyItem?.detail).toMatchObject({
+      args_preview_complete: false,
+      args_preview_authorized: false,
+    });
+
+    const automated = await patGet(path);
+    expect(automated.status).toBe(200);
+    const automatedBody = (await automated.json()) as {
+      review_items: Array<{ review_item_id: string; detail: Record<string, unknown> }>;
+    };
+    const automatedItem = automatedBody.review_items.find(
+      (item) => item.review_item_id === `exec:${execId}`,
+    );
+    expect(automatedItem?.detail).not.toHaveProperty('args_preview');
+    expect(automatedItem?.detail).toMatchObject({ args_preview_authorized: false });
   });
 
   test('an incomplete parameter preview blocks approve but still permits deny', async () => {

--- a/apps/api/src/__tests__/unit-review-adapters.test.ts
+++ b/apps/api/src/__tests__/unit-review-adapters.test.ts
@@ -75,7 +75,10 @@ describe('executorExecutionToReviewItem', () => {
     expect(item.kind).toBe('approval');
     expect(item.status).toBe('needs_you');
     expect(item.title).toBe('Approve: gmail.messages.send');
-    expect(item.detail).toMatchObject({ execution_id: 'ex-1', action_path: 'gmail.messages.send' });
+    expect(item.detail).toMatchObject({
+      execution_id: 'ex-1',
+      action_path: 'gmail.messages.send',
+    });
   });
 
   test('maps executor risk → review risk (read/write/destructive → low/medium/high)', () => {
@@ -83,6 +86,47 @@ describe('executorExecutionToReviewItem', () => {
     expect(executorExecutionToReviewItem({ ...baseExec, risk: 'write' }).risk).toBe('medium');
     expect(executorExecutionToReviewItem({ ...baseExec, risk: 'destructive' }).risk).toBe('high');
     expect(executorExecutionToReviewItem({ ...baseExec, risk: null }).risk).toBe('medium');
+  });
+
+  test('carries the complete redacted parameter preview into Review Center', () => {
+    const argsPreview = {
+      to: ['reviewer@example.com'],
+      subject: 'Approval contract',
+      body: 'The approver must see this body before deciding.',
+      access_token: '[redacted]',
+    };
+    const item = executorExecutionToReviewItem(
+      {
+        ...baseExec,
+        resultSummary: {
+          args_preview: argsPreview,
+          args_preview_complete: true,
+        },
+      },
+      { includeArgsPreview: true },
+    );
+
+    expect(item.detail).toMatchObject({
+      args_preview: argsPreview,
+      args_preview_complete: true,
+      args_preview_authorized: true,
+    });
+  });
+
+  test('withholds sensitive parameters when the caller lacks approval authority', () => {
+    const item = executorExecutionToReviewItem({
+      ...baseExec,
+      resultSummary: {
+        args_preview: { to: ['private@example.com'], body: 'private body' },
+        args_preview_complete: true,
+      },
+    });
+
+    expect(item.detail).not.toHaveProperty('args_preview');
+    expect(item.detail).toMatchObject({
+      args_preview_complete: false,
+      args_preview_authorized: false,
+    });
   });
 });
 
@@ -94,7 +138,11 @@ describe('changeRequestToReviewItem', () => {
     expect(item.status).toBe('needs_you');
     expect(item.title).toBe('Refresh the pricing page');
     expect(item.summary).toBe('#7 · session/pricing → main');
-    expect(item.detail).toMatchObject({ cr_id: 'cr-1', number: 7, base_ref: 'main' });
+    expect(item.detail).toMatchObject({
+      cr_id: 'cr-1',
+      number: 7,
+      base_ref: 'main',
+    });
     expect(item.acted_at).toBeNull();
     expect(item.created_at).toBe('2026-06-30T10:00:00.000Z');
   });
@@ -112,7 +160,11 @@ describe('changeRequestToReviewItem', () => {
   });
 
   test('a closed CR maps to rejected', () => {
-    const item = changeRequestToReviewItem({ ...baseCr, status: 'closed', closedBy: 'user-3' });
+    const item = changeRequestToReviewItem({
+      ...baseCr,
+      status: 'closed',
+      closedBy: 'user-3',
+    });
     expect(item.status).toBe('rejected');
     expect(item.acted_by).toBe('user-3');
   });
@@ -122,8 +174,16 @@ describe('changeRequestToReviewItem', () => {
       ...baseCr,
       metadata: {
         requested_changes: [
-          { text: 'Fix the first one', by: 'user-9', at: '2026-06-30T11:00:00.000Z' },
-          { text: 'Capitalize each word', by: 'user-9', at: '2026-06-30T12:00:00.000Z' },
+          {
+            text: 'Fix the first one',
+            by: 'user-9',
+            at: '2026-06-30T11:00:00.000Z',
+          },
+          {
+            text: 'Capitalize each word',
+            by: 'user-9',
+            at: '2026-06-30T12:00:00.000Z',
+          },
         ],
       },
     });

--- a/apps/api/src/__tests__/unit-review-items.test.ts
+++ b/apps/api/src/__tests__/unit-review-items.test.ts
@@ -4,8 +4,9 @@
  * ke2e review flow).
  */
 import { describe, expect, test } from 'bun:test';
-import type { reviewItems } from '@kortix/db';
+import type { executorExecutions, reviewItems } from '@kortix/db';
 import {
+  collectInboxItems,
   isReviewVerdict,
   isSubmittableKind,
   serializeReviewItem,
@@ -13,6 +14,7 @@ import {
 } from '../projects/review-items';
 
 type ReviewItemRow = typeof reviewItems.$inferSelect;
+type ExecutorExecutionRow = typeof executorExecutions.$inferSelect;
 
 describe('statusesForSegment', () => {
   test('needs_you / waiting are single-status; done is every terminal status', () => {
@@ -104,5 +106,53 @@ describe('serializeReviewItem', () => {
     const out = serializeReviewItem({ ...base, detail: null as never, metadata: null });
     expect(out.detail).toEqual({});
     expect(out.metadata).toEqual({});
+  });
+});
+
+describe('collectInboxItems executor preview authorization', () => {
+  const execution: ExecutorExecutionRow = {
+    executionId: 'exec-sensitive',
+    accountId: 'acc-1',
+    projectId: 'proj-1',
+    connectorId: null,
+    profileId: null,
+    actionPath: 'gmail.send_email',
+    actingUserId: 'user-1',
+    sessionId: null,
+    status: 'pending_approval',
+    risk: 'write',
+    requestDigest: 'digest',
+    resultSummary: {
+      args_preview: { to: ['private@example.com'], body: 'sensitive body' },
+      args_preview_complete: true,
+    },
+    approvedBy: null,
+    createdAt: new Date('2026-06-30T10:00:00.000Z'),
+    resolvedAt: null,
+  };
+  const sources = {
+    native: async () => [],
+    changeRequests: async () => [],
+    executorApprovals: async () => [execution],
+  };
+
+  test('fails closed when no preview-authority callback is provided', async () => {
+    const [item] = await collectInboxItems(sources);
+    expect(item.detail).not.toHaveProperty('args_preview');
+    expect(item.detail).toMatchObject({
+      args_preview_authorized: false,
+      args_preview_complete: false,
+    });
+  });
+
+  test('includes the full redacted preview only for an authorized execution', async () => {
+    const [item] = await collectInboxItems(sources, {
+      canExposeExecutorPreview: (row) => row.executionId === execution.executionId,
+    });
+    expect(item.detail).toMatchObject({
+      args_preview: { to: ['private@example.com'], body: 'sensitive body' },
+      args_preview_authorized: true,
+      args_preview_complete: true,
+    });
   });
 });

--- a/apps/api/src/projects/review-adapters.ts
+++ b/apps/api/src/projects/review-adapters.ts
@@ -41,7 +41,21 @@ const EXEC_RISK: Record<'read' | 'write' | 'destructive', ReviewItemDTO['risk']>
  * A pending-approval executor tool call, presented as an `approval` review item.
  * (Only `pending_approval` executions are adapted; the rest are terminal audit.)
  */
-export function executorExecutionToReviewItem(ex: ExecutorExecutionRow): ReviewItemDTO {
+export function executorExecutionToReviewItem(
+  ex: ExecutorExecutionRow,
+  options: { includeArgsPreview?: boolean } = {},
+): ReviewItemDTO {
+  const includeArgsPreview = options.includeArgsPreview === true;
+  const summary =
+    ex.resultSummary && typeof ex.resultSummary === 'object' && !Array.isArray(ex.resultSummary)
+      ? ex.resultSummary
+      : {};
+  const argsPreview =
+    summary.args_preview &&
+    typeof summary.args_preview === 'object' &&
+    !Array.isArray(summary.args_preview)
+      ? summary.args_preview
+      : null;
   return {
     review_item_id: `${EXEC_ID_PREFIX}${ex.executionId}`,
     account_id: ex.accountId,
@@ -58,6 +72,10 @@ export function executorExecutionToReviewItem(ex: ExecutorExecutionRow): ReviewI
       action_path: ex.actionPath,
       connector_id: ex.connectorId,
       request_digest: ex.requestDigest,
+      risk: ex.risk,
+      ...(includeArgsPreview ? { args_preview: argsPreview } : {}),
+      args_preview_complete: includeArgsPreview && summary.args_preview_complete === true,
+      args_preview_authorized: includeArgsPreview,
     },
     agent: '',
     created_by: ex.actingUserId ?? '',

--- a/apps/api/src/projects/review-items.ts
+++ b/apps/api/src/projects/review-items.ts
@@ -157,7 +157,11 @@ function safeMap<T, R>(label: string, rows: T[], fn: (row: T) => R): R[] {
  */
 export async function collectInboxItems(
   sources: InboxSources,
-  opts: { segment?: ReviewSegment; kind?: ReviewItemRow['kind'] } = {},
+  opts: {
+    segment?: ReviewSegment;
+    kind?: ReviewItemRow['kind'];
+    canExposeExecutorPreview?: (row: ExecutorExecutionRow) => boolean;
+  } = {},
 ) {
   const [nativeRows, crRows, execRows] = await Promise.all([
     safeSource('native', sources.native),
@@ -167,7 +171,11 @@ export async function collectInboxItems(
   const items = [
     ...safeMap('native', nativeRows, serializeReviewItem),
     ...safeMap('change_requests', crRows, changeRequestToReviewItem),
-    ...safeMap('executor_executions', execRows, executorExecutionToReviewItem),
+    ...safeMap('executor_executions', execRows, (row) =>
+      executorExecutionToReviewItem(row, {
+        includeArgsPreview: opts.canExposeExecutorPreview?.(row) === true,
+      }),
+    ),
   ];
   const segmentStatuses = opts.segment ? statusesForSegment(opts.segment) : null;
   return items
@@ -181,12 +189,15 @@ export async function collectInboxItems(
 
 export async function listInboxItems(
   projectId: string,
-  opts: { segment?: ReviewSegment; kind?: ReviewItemRow['kind'] } = {},
+  opts: {
+    segment?: ReviewSegment;
+    kind?: ReviewItemRow['kind'];
+    canExposeExecutorPreview?: (row: ExecutorExecutionRow) => boolean;
+  } = {},
 ) {
   return collectInboxItems(
     {
-      native: () =>
-        db.select().from(reviewItems).where(eq(reviewItems.projectId, projectId)),
+      native: () => db.select().from(reviewItems).where(eq(reviewItems.projectId, projectId)),
       changeRequests: () =>
         db.select().from(changeRequests).where(eq(changeRequests.projectId, projectId)),
       executorApprovals: () =>

--- a/apps/api/src/projects/routes/r11.ts
+++ b/apps/api/src/projects/routes/r11.ts
@@ -5,8 +5,8 @@
 // in by adapters later. See docs/REVIEW_CENTER_DESIGN.md.
 
 import { createRoute, z } from '@hono/zod-openapi';
-import { projectSessions } from '@kortix/db';
-import { and, eq } from 'drizzle-orm';
+import { executorExecutions, projectSessions } from '@kortix/db';
+import { and, eq, inArray } from 'drizzle-orm';
 import { relayReviewCard } from '../../channels/turn-relay';
 import { PROJECT_ACTIONS } from '../../iam';
 import { assertAgentScope } from '../../iam/agent-scope';
@@ -14,6 +14,8 @@ import { auth, errors, json } from '../../openapi';
 import { db } from '../../shared/db';
 import { assertProjectCapability, loadProjectForUser } from '../lib/access';
 import { AnyObject, projectsApp } from '../lib/app';
+import { mayResolveApproval } from '../lib/approval-authority';
+import { callerKortixSessionId } from '../lib/caller-session';
 import { normalizeString, readBody } from '../lib/serializers';
 import { isAdaptedId } from '../review-adapters';
 import {
@@ -53,7 +55,13 @@ projectsApp.openapi(
     const projectId = c.req.param('projectId');
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
-    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_REVIEW_READ);
+    await assertProjectCapability(
+      c,
+      loaded.userId,
+      loaded.row.accountId,
+      projectId,
+      PROJECT_ACTIONS.PROJECT_REVIEW_READ,
+    );
 
     const segment = normalizeString(c.req.query('segment'))?.toLowerCase();
     if (segment && !SEGMENTS.includes(segment as (typeof SEGMENTS)[number])) {
@@ -64,9 +72,83 @@ projectsApp.openapi(
       return c.json({ error: 'Invalid kind' }, 400);
     }
 
+    // `args_preview` can contain email bodies, recipients, URLs, and other
+    // sensitive values. The broad `project.review.read` leaf may list the row,
+    // but only the same human authority that can resolve the exact approval may
+    // receive its parameters. New rows that race this query fail closed because
+    // their execution id will not be present in this set.
+    let isManager = false;
+    try {
+      await assertProjectCapability(
+        c,
+        loaded.userId,
+        loaded.row.accountId,
+        projectId,
+        PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE,
+      );
+      isManager = true;
+    } catch {
+      isManager = false;
+    }
+    const pendingExecutions = await db
+      .select({
+        executionId: executorExecutions.executionId,
+        sessionId: executorExecutions.sessionId,
+        actingUserId: executorExecutions.actingUserId,
+      })
+      .from(executorExecutions)
+      .where(
+        and(
+          eq(executorExecutions.projectId, projectId),
+          eq(executorExecutions.status, 'pending_approval'),
+        ),
+      );
+    const sessionIds = [
+      ...new Set(
+        pendingExecutions
+          .map((execution) => execution.sessionId)
+          .filter((sessionId): sessionId is string => Boolean(sessionId)),
+      ),
+    ];
+    const sessions = sessionIds.length
+      ? await db
+          .select({
+            sessionId: projectSessions.sessionId,
+            createdBy: projectSessions.createdBy,
+            origin: projectSessions.origin,
+          })
+          .from(projectSessions)
+          .where(
+            and(
+              eq(projectSessions.projectId, projectId),
+              inArray(projectSessions.sessionId, sessionIds),
+            ),
+          )
+      : [];
+    const sessionById = new Map(sessions.map((session) => [session.sessionId, session]));
+    const previewExecutionIds = new Set(
+      pendingExecutions
+        .filter((execution) => {
+          const session = execution.sessionId
+            ? sessionById.get(String(execution.sessionId))
+            : undefined;
+          return mayResolveApproval({
+            isManager,
+            targetSessionOrigin: session?.origin ?? (execution.sessionId ? null : 'user'),
+            targetSessionCreatedBy:
+              session?.createdBy ?? (execution.sessionId ? null : execution.actingUserId),
+            callerUserId: loaded.userId,
+            callerAuthType: (c.get('authType') as string | undefined) ?? null,
+            callerSessionId: callerKortixSessionId(c),
+          }).allowed;
+        })
+        .map((execution) => execution.executionId),
+    );
+
     const items = await listInboxItems(projectId, {
       segment: segment as ReviewSegment | undefined,
       kind: kind as (typeof KINDS)[number] | undefined,
+      canExposeExecutorPreview: (execution) => previewExecutionIds.has(execution.executionId),
     });
     return c.json({ review_items: items });
   },
@@ -92,7 +174,13 @@ projectsApp.openapi(
     const projectId = c.req.param('projectId');
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
-    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_REVIEW_READ);
+    await assertProjectCapability(
+      c,
+      loaded.userId,
+      loaded.row.accountId,
+      projectId,
+      PROJECT_ACTIONS.PROJECT_REVIEW_READ,
+    );
 
     const item = await getReviewItemById(c.req.param('reviewItemId'), projectId);
     if (!item) return c.json({ error: 'Review item not found' }, 404);
@@ -124,7 +212,13 @@ projectsApp.openapi(
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     // Human gate: submitting a reviewable needs project.review.submit. Every
     // built-in role holds it; a custom role that unchecks it is denied here.
-    await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_REVIEW_SUBMIT);
+    await assertProjectCapability(
+      c,
+      loaded.userId,
+      loaded.row.accountId,
+      projectId,
+      PROJECT_ACTIONS.PROJECT_REVIEW_SUBMIT,
+    );
     // Agent-side gate: submitting a reviewable is the agent's intended path.
     assertAgentScope(c, 'project.review.submit');
 

--- a/apps/web/src/components/approvals/approval-request.test.tsx
+++ b/apps/web/src/components/approvals/approval-request.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ApprovalRequest } from './approval-request';
+
+const request = {
+  action: 'gmail.send_email',
+  risk: 'write',
+  projectName: 'Approval proof',
+  requestedAt: '2026-08-06T00:00:00.000Z',
+  argsPreview: {
+    to: ['marko@kortix.ai'],
+    cc: ['audit@kortix.ai'],
+    subject: 'Review this exact email',
+    body: 'The approver must see the complete email content.',
+    access_token: '[redacted]',
+  },
+  reviewComplete: true,
+  pending: true,
+};
+
+describe('ApprovalRequest', () => {
+  test('shows every redacted parameter and only one-call decisions', () => {
+    const html = renderToStaticMarkup(
+      <ApprovalRequest request={request} onDecision={() => undefined} />,
+    );
+
+    expect(html).toContain('gmail.send_email');
+    expect(html).toContain('marko@kortix.ai');
+    expect(html).toContain('audit@kortix.ai');
+    expect(html).toContain('Review this exact email');
+    expect(html).toContain('The approver must see the complete email content.');
+    expect(html).toContain('Hidden credential');
+    expect(html).toContain('Approve this call');
+    expect(html).toContain('Deny');
+    expect(html).not.toContain('Allow for session');
+    expect(html).not.toContain('Allow everything');
+    expect(html).not.toContain('Always allow');
+  });
+
+  test('blocks approval when the complete parameter preview is unavailable', () => {
+    const html = renderToStaticMarkup(
+      <ApprovalRequest
+        request={{ ...request, reviewComplete: false }}
+        onDecision={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('complete parameters are not available');
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>[\s\S]*Approve this call/);
+  });
+});

--- a/apps/web/src/features/review-center/executor-approval-contract.test.ts
+++ b/apps/web/src/features/review-center/executor-approval-contract.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (path: string) => readFileSync(resolve(import.meta.dir, path), 'utf8');
+
+describe('executor approval review contract', () => {
+  test('the session header links to parameter review and cannot resolve directly', () => {
+    const source = read('../session/header/session-pending-approvals-indicator.tsx');
+
+    expect(source).toContain('Review parameters');
+    expect(source).toContain('approval_url');
+    expect(source).not.toContain('useResolveApproval');
+    expect(source).not.toContain("decision: 'approve'");
+    expect(source).not.toContain("decision: 'deny'");
+  });
+
+  test('Review Center uses the shared full-parameter component', () => {
+    const modal = read('./review-detail-modal.tsx');
+    const center = read('./review-center.tsx');
+
+    expect(modal).toContain('<ApprovalRequest');
+    expect(modal).toContain('argsPreview: adaptedAction.rawArgsPreview');
+    expect(modal).not.toContain('Always allow this');
+    expect(center).not.toContain('Approve all safe');
+    expect(center).toContain("item.kind !== 'approval'");
+  });
+});

--- a/apps/web/src/features/review-center/map.test.ts
+++ b/apps/web/src/features/review-center/map.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from 'bun:test';
 import type { ApiReviewItem } from '@kortix/sdk';
+import { describe, expect, test } from 'bun:test';
 import {
   PRIMARY_ACTION,
   agentInitials,
@@ -115,7 +115,17 @@ describe('mapApiReviewItem', () => {
         title: 'Approve: gmail.messages.send',
         risk: 'high',
         // connector_id is an opaque UUID — the connector NAME comes from the path.
-        detail: { execution_id: 'ex-1', action_path: 'gmail.messages.send', connector_id: 'uuid-x' },
+        detail: {
+          execution_id: 'ex-1',
+          action_path: 'gmail.messages.send',
+          connector_id: 'uuid-x',
+          args_preview: {
+            to: ['approver@example.com'],
+            subject: 'Review this exact email',
+            body: 'Complete email content',
+          },
+          args_preview_complete: true,
+        },
       },
       'P',
     );
@@ -129,6 +139,12 @@ describe('mapApiReviewItem', () => {
       action: 'messages.send',
       connector: 'gmail',
       risk: 'high',
+      rawArgsPreview: {
+        to: ['approver@example.com'],
+        subject: 'Review this exact email',
+        body: 'Complete email content',
+      },
+      reviewComplete: true,
     });
   });
 

--- a/apps/web/src/features/review-center/map.ts
+++ b/apps/web/src/features/review-center/map.ts
@@ -5,8 +5,8 @@
  * labels and the actor are derived from the kind + agent. See review-center.tsx.
  */
 
-import type { ApiReviewItem, ReviewVerdict } from '@kortix/sdk';
 import { looksLikeMarkdown } from '@/lib/markdown-detect';
+import type { ApiReviewItem, ReviewVerdict } from '@kortix/sdk';
 import type {
   ApprovalAction,
   ApprovalActionIcon,
@@ -104,7 +104,13 @@ function changeDetail(d: AnyRec, row: ApiReviewItem): ChangeDetail {
     !native && description && looksLikeMarkdown(description) ? description : undefined;
   const whatChanged =
     native ??
-    (descriptionMarkdown ? [] : description ? lines(description) : row.summary ? [row.summary] : []);
+    (descriptionMarkdown
+      ? []
+      : description
+        ? lines(description)
+        : row.summary
+          ? [row.summary]
+          : []);
   return {
     crId: str(d.cr_id),
     number: typeof d.number === 'number' ? d.number : undefined,
@@ -151,6 +157,17 @@ function approvalDetail(d: AnyRec, row: ApiReviewItem): ApprovalDetail {
   // `connector_id` is an opaque UUID, so we take the connector NAME from the path.
   const path = str(d.action_path) ?? '';
   const { connector, action } = splitActionPath(path);
+  const rawArgsPreview = rec(d.args_preview);
+  const hasArgsPreview = Object.keys(rawArgsPreview).length > 0;
+  const argsPreview = Object.entries(rawArgsPreview).map(([key, value]) => ({
+    key,
+    value:
+      value === '[redacted]'
+        ? 'Hidden credential'
+        : typeof value === 'string'
+          ? value
+          : JSON.stringify(value, null, 2),
+  }));
   return {
     actions: [
       {
@@ -161,7 +178,11 @@ function approvalDetail(d: AnyRec, row: ApiReviewItem): ApprovalDetail {
         consequence: 'Runs against the real connector once you approve',
         risk: row.risk,
         icon: 'generic',
-        argsPreview: [],
+        argsPreview,
+        actionPath: path,
+        rawArgsPreview: hasArgsPreview ? rawArgsPreview : undefined,
+        reviewComplete: d.args_preview_complete === true,
+        executorRisk: str(d.risk) ?? null,
         policySource: 'Requires approval',
       },
     ],

--- a/apps/web/src/features/review-center/review-actions.test.ts
+++ b/apps/web/src/features/review-center/review-actions.test.ts
@@ -81,13 +81,13 @@ describe('formatItemAge', () => {
 });
 
 describe('isQuickDecidableApproval', () => {
-  test('a single-action executor approval is quick-decidable', () => {
+  test('a single-action executor approval requires the parameter-review modal', () => {
     expect(
       isQuickDecidableApproval({ kind: 'approval', id: 'exec:e1', detail: { actions: [{}] } }),
-    ).toBe(true);
+    ).toBe(false);
   });
-  test('an approval with no detail (defensive) is quick-decidable', () => {
-    expect(isQuickDecidableApproval({ kind: 'approval', id: 'exec:e1' })).toBe(true);
+  test('an approval with no detail is not quick-decidable', () => {
+    expect(isQuickDecidableApproval({ kind: 'approval', id: 'exec:e1' })).toBe(false);
   });
   test('a multi-action approval needs the modal', () => {
     expect(
@@ -130,21 +130,22 @@ describe('resolveBulkOutcome', () => {
     expect(out.skippedRisky).toEqual([]);
   });
 
-  test('approve sweeps only safe exec approvals; risky ones are skipped', () => {
+  test('approve sweeps never answer executor approvals without individual parameter review', () => {
     const out = resolveBulkOutcome(
       ['exec:safe', 'exec:risky', 'rv-1'],
       'approve',
       risk({ 'exec:safe': 'low', 'exec:risky': 'high' }),
     );
-    expect(out.act).toEqual(['exec:safe', 'rv-1']);
-    expect(out.skippedRisky).toEqual(['exec:risky']);
-    expect(out.skippedApprovals).toEqual([]);
+    expect(out.act).toEqual(['rv-1']);
+    expect(out.skippedRisky).toEqual([]);
+    expect(out.skippedApprovals).toEqual(['exec:safe', 'exec:risky']);
   });
 
-  test('an exec approval with unknown risk is treated as risky on approve', () => {
+  test('an exec approval with unknown risk still requires individual review', () => {
     const out = resolveBulkOutcome(['exec:mystery'], 'approve', risk({}));
     expect(out.act).toEqual([]);
-    expect(out.skippedRisky).toEqual(['exec:mystery']);
+    expect(out.skippedRisky).toEqual([]);
+    expect(out.skippedApprovals).toEqual(['exec:mystery']);
   });
 
   test('Change Requests are skipped under any verdict', () => {

--- a/apps/web/src/features/review-center/review-actions.ts
+++ b/apps/web/src/features/review-center/review-actions.ts
@@ -8,7 +8,7 @@
  * endpoint, which 409s on them by design (see review-center-connected.tsx).
  */
 
-import { type ReviewItem, type ReviewRisk, isSafeRisk } from './types';
+import type { ReviewItem, ReviewRisk } from './types';
 
 export const CR_ID_PREFIX = 'cr:';
 export const EXEC_ID_PREFIX = 'exec:';
@@ -27,11 +27,8 @@ export function crChangeRequestId(id: string): string | null {
 }
 
 /**
- * True when the row can show Approve/Deny buttons directly — no modal hop —
- * because the item resolves to exactly one clear decision: a single-action
- * executor approval. Multi-action approvals (the prototype's bulk-approval
- * shape) still need the detail modal, since one button pair can't represent
- * several independent decisions.
+ * Executor approvals are never quick-decidable. The approver must open the
+ * parameter-review modal before either decision becomes available.
  */
 export function isQuickDecidableApproval(
   // `detail` is `unknown` (not `{ actions?: ... }`) so every ReviewItem union
@@ -39,11 +36,8 @@ export function isQuickDecidableApproval(
   // weak object type would reject them at the call sites.
   item: Pick<ReviewItem, 'kind' | 'id'> & { detail?: unknown },
 ): boolean {
-  if (item.kind !== 'approval') return false;
-  if (execExecutionId(item.id) === null) return false;
-  const detail = item.detail as { actions?: readonly unknown[] } | undefined;
-  const count = detail?.actions?.length ?? 0;
-  return count <= 1;
+  void item;
+  return false;
 }
 
 /** Build the deep link that lands the user exactly where they can act on an
@@ -61,7 +55,7 @@ export function itemDeepLink(
 /**
  * Split a set of selected ids into the ones a bulk verdict can cover
  * natively (`/review/bulk`) vs. ones that need their own per-item resolve
- * call (executor approvals) vs. ones with no bulk path at all (Change
+ * review (executor approvals) vs. ones with no bulk path at all (Change
  * Requests — merging in bulk needs full diff context per item, so they're
  * excluded rather than silently no-op'd).
  */
@@ -87,15 +81,14 @@ export function planBulkAction(ids: Iterable<string>): BulkActionPlan {
  * What a bulk verdict on a connected selection will REALLY do, decided before
  * any optimistic UI update so the toast/removal can never claim more than the
  * server was asked. The rules the buckets encode:
- *  - Executor approvals are a live question to the agent: "dismiss" doesn't
- *    answer it, so they're KEPT (never mapped to a deny) under any non-approve
- *    verdict, and an approve sweep still respects the safe-risk floor.
+ *  - Executor approvals are a live question to the agent. Bulk verdicts never
+ *    answer them. Each exact call needs a complete parameter review.
  *  - Change Requests have no bulk path at all (merging needs the diff in view).
  */
 export interface BulkOutcome {
   /** Ids the verdict genuinely acts on — safe to optimistically update. */
   act: string[];
-  /** Exec approvals blocked by the approve safe-risk floor. */
+  /** Retained for compatibility with native bulk-outcome consumers. */
   skippedRisky: string[];
   /** Exec approvals kept under a non-approve verdict (dismiss ≠ deny). */
   skippedApprovals: string[];
@@ -108,6 +101,7 @@ export function resolveBulkOutcome(
   verdict: 'approve' | 'dismiss',
   riskOf: (id: string) => ReviewRisk | undefined,
 ): BulkOutcome {
+  void riskOf;
   const act: string[] = [];
   const skippedRisky: string[] = [];
   const skippedApprovals: string[] = [];
@@ -116,9 +110,7 @@ export function resolveBulkOutcome(
     if (crChangeRequestId(id) !== null) {
       skippedChanges.push(id);
     } else if (execExecutionId(id) !== null) {
-      if (verdict !== 'approve') skippedApprovals.push(id);
-      else if (!isSafeRisk(riskOf(id) ?? 'high')) skippedRisky.push(id);
-      else act.push(id);
+      skippedApprovals.push(id);
     } else {
       act.push(id);
     }
@@ -133,7 +125,7 @@ export function bulkSkipMessage(outcome: BulkOutcome): string {
   const plural = (n: number, s: string, p: string) => (n === 1 ? s : p);
   if (outcome.skippedApprovals.length > 0)
     parts.push(
-      `${outcome.skippedApprovals.length} ${plural(outcome.skippedApprovals.length, 'approval', 'approvals')} kept — dismissing doesn't answer the agent; approve or deny ${plural(outcome.skippedApprovals.length, 'it', 'them')}`,
+      `${outcome.skippedApprovals.length} ${plural(outcome.skippedApprovals.length, 'approval', 'approvals')} kept — review the parameters and decide ${plural(outcome.skippedApprovals.length, 'it', 'each one')} individually`,
     );
   if (outcome.skippedRisky.length > 0)
     parts.push(

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -7,9 +7,8 @@
  * items act through THEIR OWN source flow — a Change Request ships via merge,
  * is dismissed via close, and "request changes" persists the feedback + delivers
  * it to the change's agent (the review `/act` endpoint 409s on adapted ids by
- * design). Executor approvals (`exec:`) resolve directly via `resolveApproval` —
- * the same client call the in-session approval prompt uses
- * (session-approval-prompt.tsx) — so Approve/Deny work inline in the inbox too.
+ * design). Executor approvals (`exec:`) open the shared full-parameter review
+ * component. That component resolves one exact call through `resolveApproval`.
  * The presentational inbox (review-center.tsx) is shared with the mock
  * prototype. See docs/REVIEW_CENTER_DESIGN.md.
  */
@@ -38,7 +37,6 @@ import {
 import { mapApiReviewItem } from './map';
 import { crChangeRequestId, execExecutionId, itemDeepLink, planBulkAction } from './review-actions';
 import { ReviewCenter } from './review-center';
-import { isSafeRisk } from './types';
 
 export function ReviewCenterConnected({
   projectName,
@@ -111,10 +109,7 @@ export function ReviewCenterConnected({
   }
 
   function handleAct(id: string, verdict: ReviewVerdict, feedback?: string) {
-    // Executor approvals resolve directly — the same call + payload the
-    // in-session approval prompt uses (resolveApproval, 'once' scope: this
-    // acts on the one call the row represents, not "for the rest of the
-    // session" — that broader grant stays a session-view affordance).
+    // The shared parameter-review component calls this for one exact action.
     const executionId = execExecutionId(id);
     if (executionId) {
       resolve.mutate(
@@ -199,30 +194,22 @@ export function ReviewCenterConnected({
 
   // Bulk (multi-select) verdicts: the presentational layer pre-filters the
   // selection through `resolveBulkOutcome` (same pure helper), so what
-  // arrives here is already actionable — native ids for any verdict, exec
-  // approvals only under an APPROVE that passed the safe-risk floor. The
+  // arrives here is already actionable. Only native ids can reach the bulk
+  // mutation. The
   // guards below are defense in depth, not the primary filter:
   //  - an executor approval is a live question to the agent; a bulk
   //    "dismiss" must NEVER answer it with a deny, so exec ids resolve only
-  //    on an explicit approve (single-item Deny goes through handleAct).
-  //  - the safe-risk floor is re-checked before each resolve.
+  //    from a bulk action. Each exact call needs its own parameter review.
   //  - Change Requests have no bulk path (merging needs the diff in view).
   function handleBulkAct(ids: string[], verdict: ReviewVerdict) {
     const { native, resolvable, unsupported } = planBulkAction(ids);
     if (native.length > 0) {
       bulk.mutate({ ids: native, verdict }, { onError: (e) => errorToast(e.message) });
     }
-    if (resolvable.length > 0 && verdict === 'approve') {
-      const riskById = new Map(items.map((i) => [i.id, i.risk]));
-      for (const id of resolvable) {
-        if (!isSafeRisk(riskById.get(id) ?? 'high')) continue;
-        const executionId = execExecutionId(id);
-        if (executionId)
-          resolve.mutate(
-            { executionId, decision: 'approve' },
-            { onError: (e) => errorToast(e.message) },
-          );
-      }
+    if (resolvable.length > 0) {
+      infoToast(
+        `${resolvable.length} ${resolvable.length === 1 ? 'approval needs' : 'approvals need'} individual parameter review.`,
+      );
     }
     if (unsupported.length > 0) {
       infoToast(

--- a/apps/web/src/features/review-center/review-center.tsx
+++ b/apps/web/src/features/review-center/review-center.tsx
@@ -44,7 +44,6 @@ import {
   TrayIcon as InboxSolid,
   StackIcon as Layers,
   MagnifyingGlassIcon as Search,
-  ShieldCheckIcon as ShieldCheckSolid,
   XIcon as X,
 } from '@phosphor-icons/react';
 import { AnimatePresence, m, useReducedMotion } from 'motion/react';
@@ -53,6 +52,7 @@ import { statusToVerdict } from './map';
 import { MOCK_ITEMS } from './mock-data';
 import {
   bulkSkipMessage,
+  execExecutionId,
   formatItemAge,
   isQuickDecidableApproval,
   resolveBulkOutcome,
@@ -60,13 +60,11 @@ import {
 import { type ReviewActions, ReviewDetailModal } from './review-detail-modal';
 import { KIND_META, RISK_BAR, RISK_META, SOURCE_META, STATUS_META } from './review-meta';
 import {
-  approveAllSafe,
   bulkSetStatus,
   countsBySegment,
   decideApprovalAction,
   filterItems,
   groupBySession,
-  safePendingCount,
   sessionOptions,
   setStatus,
 } from './review-reducer';
@@ -149,6 +147,7 @@ function ItemRow({
   onToggleSelect,
   onQuickApprove,
   onQuickDeny,
+  bulkSelectable = true,
 }: {
   item: ReviewItem;
   idx: number;
@@ -159,8 +158,7 @@ function ItemRow({
   fresh: boolean;
   /** prefers-reduced-motion: collapse enter/stagger to instant. */
   reduce: boolean;
-  /** A single-action approval with a real client-side resolve path (an
-   *  executor approval) — show Approve/Deny right on the row, no modal hop. */
+  /** Whether this row exposes inline decisions. Executor approvals are false. */
   quickDecidable: boolean;
   /** 'approve' | 'deny' while this row's own resolve mutation is in flight. */
   pendingDecision?: 'approve' | 'deny' | null;
@@ -172,6 +170,7 @@ function ItemRow({
   onToggleSelect: () => void;
   onQuickApprove?: () => void;
   onQuickDeny?: () => void;
+  bulkSelectable?: boolean;
 }) {
   const kind = KIND_META[item.kind];
   const Source = SOURCE_META[item.source];
@@ -205,7 +204,7 @@ function ItemRow({
         fresh && 'bg-kortix-blue/[0.05]',
       )}
     >
-      {segment === 'needs_you' && (
+      {segment === 'needs_you' && bulkSelectable && (
         <Checkbox
           checked={selected}
           onCheckedChange={onToggleSelect}
@@ -391,7 +390,6 @@ export function ReviewCenter({
     () => filterItems(items, segment, kindFilter, query, sessionFilter),
     [items, segment, kindFilter, query, sessionFilter],
   );
-  const visibleSafePending = useMemo(() => safePendingCount(visible), [visible]);
   const kindCounts = useMemo(() => {
     // Respect the active session filter so the kind-tab badges never contradict
     // the visible list when scoped to one session.
@@ -531,7 +529,6 @@ export function ReviewCenter({
     },
     decideAction: (itemId, actionId, decision) =>
       setItems(decideApprovalAction(items, itemId, actionId, decision)),
-    approveAllSafe: (itemId) => setItems(approveAllSafe(items, itemId)),
     openSession: onOpenSession,
     recoverChange: onRecoverChange,
     recoveringCrId,
@@ -540,8 +537,8 @@ export function ReviewCenter({
     pendingDecision,
   };
 
-  /** Row-level Approve/Deny for a single-action executor approval — resolves
-   *  it directly via `actions.resolve`, no modal hop. */
+  /** Legacy quick-decision handler. The eligibility helper currently returns
+   *  false because Executor approvals require the parameter-review modal. */
   const quickDecide = (item: ReviewItem, decision: 'approve' | 'deny') => {
     actions.resolve(
       item.id,
@@ -589,8 +586,7 @@ export function ReviewCenter({
 
   /** Connected mode: decide up-front what the verdict will really act on so
    *  the optimistic removal + toast never claim more than the server was
-   *  asked (exec approvals are never denied by a dismiss; risky approvals
-   *  survive an approve sweep; CRs each need their own review). */
+   *  asked. Bulk verdicts skip executor approvals and Change Requests. */
   const connectedBulkOutcome = (ids: string[], verdict: 'approve' | 'dismiss') => {
     const riskById = new Map(items.map((i) => [i.id, i.risk]));
     return resolveBulkOutcome(ids, verdict, (id) => riskById.get(id));
@@ -643,7 +639,7 @@ export function ReviewCenter({
     for (const id of ids) {
       const it = items.find((x) => x.id === id);
       if (!it) continue;
-      next = it.kind === 'approval' ? approveAllSafe(next, id) : setStatus(next, id, 'approved');
+      next = setStatus(next, id, 'approved');
     }
     apply(
       next,
@@ -654,22 +650,15 @@ export function ReviewCenter({
     setSelectedIds(new Set());
   };
 
-  const toggleSelect = (id: string) =>
+  const toggleSelect = (id: string) => {
+    const item = items.find((candidate) => candidate.id === id);
+    if (item?.kind === 'approval' || (connected && execExecutionId(id))) return;
     setSelectedIds((prev) => {
       const n = new Set(prev);
       if (n.has(id)) n.delete(id);
       else n.add(id);
       return n;
     });
-
-  const onApproveAllSafeGlobal = () => {
-    const ids = visible.filter((i) => i.kind === 'approval').map((i) => i.id);
-    let next = items;
-    for (const id of ids) next = approveAllSafe(next, id);
-    commit(
-      next,
-      `Approved ${visibleSafePending} safe ${visibleSafePending === 1 ? 'action' : 'actions'}`,
-    );
   };
 
   // ── Keyboard shortcuts ──────────────────────────────────────────────────
@@ -920,39 +909,6 @@ export function ReviewCenter({
               </div>
             )}
 
-            {/* Bulk bar (safe approvals across the current view). Prototype-only:
-                connected mode already surfaces "approve all safe" per-item via
-                each approval's own inline Approve/Deny + the floating
-                multi-select bar below, so this global banner would be a
-                second, redundant safe-approve entry point there. */}
-            <AnimatePresence initial={false}>
-              {!connected &&
-                segment === 'needs_you' &&
-                visibleSafePending > 0 &&
-                selectionCount === 0 && (
-                  <m.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                    transition={{ duration: 0.2, ease: EASE }}
-                    className="overflow-hidden"
-                  >
-                    <div className="bg-kortix-green/10 border-kortix-green/25 flex flex-wrap items-center gap-3 rounded-md border px-4 py-2.5">
-                      <ShieldCheckSolid
-                        weight="fill"
-                        className="text-kortix-green size-5 shrink-0"
-                      />
-                      <span className="text-foreground min-w-0 flex-1 text-sm text-pretty">
-                        {visibleSafePending} safe {visibleSafePending === 1 ? 'action' : 'actions'}{' '}
-                        can be approved together. Risky ones stay for you to decide.
-                      </span>
-                      <Button size="sm" onClick={onApproveAllSafeGlobal}>
-                        Approve all safe
-                      </Button>
-                    </div>
-                  </m.div>
-                )}
-            </AnimatePresence>
           </div>
 
           {/* List */}
@@ -1052,6 +1008,10 @@ export function ReviewCenter({
                           reduce={reduce}
                           quickDecidable={connected && isQuickDecidableApproval(item)}
                           pendingDecision={pendingId === item.id ? pendingDecision : null}
+                          bulkSelectable={
+                            item.kind !== 'approval' &&
+                            (!connected || execExecutionId(item.id) === null)
+                          }
                           onOpen={() => setSelectedId(item.id)}
                           onToggleSelect={() => toggleSelect(item.id)}
                           onQuickApprove={() => quickDecide(item, 'approve')}
@@ -1086,6 +1046,9 @@ export function ReviewCenter({
                   reduce={reduce}
                   quickDecidable={connected && isQuickDecidableApproval(item)}
                   pendingDecision={pendingId === item.id ? pendingDecision : null}
+                  bulkSelectable={
+                    item.kind !== 'approval' && (!connected || execExecutionId(item.id) === null)
+                  }
                   sessionLabel={item.sessionId ? labelFor(item.sessionId) : undefined}
                   onOpen={() => setSelectedId(item.id)}
                   onToggleSelect={() => toggleSelect(item.id)}

--- a/apps/web/src/features/review-center/review-detail-modal.tsx
+++ b/apps/web/src/features/review-center/review-detail-modal.tsx
@@ -8,6 +8,10 @@
  * Actions mutate parent state optimistically via the passed handlers.
  */
 
+import {
+  type ApprovalDecisionValue,
+  ApprovalRequest,
+} from '@/components/approvals/approval-request';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
@@ -38,7 +42,7 @@ import { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ChangeFilesModal } from './change-files';
-import { formatItemAgeLong } from './review-actions';
+import { execExecutionId, formatItemAgeLong } from './review-actions';
 import {
   APPROVAL_ACTION_ICON,
   KIND_META,
@@ -51,12 +55,10 @@ import { type ApprovalAction, type ReviewItem, type ReviewStatus, isSafeRisk } f
 export interface ReviewActions {
   resolve: (id: string, status: ReviewStatus, toast?: string, feedback?: string) => void;
   decideAction: (itemId: string, actionId: string, decision: 'approved' | 'denied') => void;
-  approveAllSafe: (itemId: string) => void;
   /** Open the item's originating session (e.g. to watch the agent revise). */
   openSession?: (sessionId: string) => void;
-  /** Live-data mode: executor approvals resolve inline via `resolve()` too
-   *  (the same `resolveApproval` call the in-session prompt uses), not just
-   *  native/CR items. */
+  /** Live-data mode. The shared Executor parameter review submits its exact
+   *  decision through `resolve()`. */
   connected?: boolean;
   /** The review item id currently mid-mutation, if any — drives the
    *  per-item `Loading` state on Approve/Deny while connected. */
@@ -337,7 +339,6 @@ function ApprovalActionRow({
   readOnly,
   onApprove,
   onDeny,
-  onAlwaysAllow,
   onOpenSession,
 }: {
   action: ApprovalAction;
@@ -349,7 +350,6 @@ function ApprovalActionRow({
   readOnly?: boolean;
   onApprove: () => void;
   onDeny: () => void;
-  onAlwaysAllow: () => void;
   onOpenSession?: () => void;
 }) {
   const Icon = APPROVAL_ACTION_ICON[action.icon];
@@ -429,14 +429,6 @@ function ApprovalActionRow({
                   See it in the session
                   <ArrowUpRight className="size-3" />
                 </button>
-              ) : !connected ? (
-                <button
-                  type="button"
-                  onClick={onAlwaysAllow}
-                  className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
-                >
-                  Always allow this
-                </button>
               ) : null}
             </div>
           )}
@@ -454,42 +446,51 @@ function ApprovalBody({
   actions: ReviewActions;
 }) {
   const list = item.detail.actions ?? [];
-  const safePending = list.filter((a) => isSafeRisk(a.risk) && !a.decided);
+  const adaptedExecutionId = execExecutionId(item.id);
+  const adaptedAction = adaptedExecutionId ? list[0] : null;
+  if (actions.connected && adaptedAction) {
+    const busyDecision: ApprovalDecisionValue | null =
+      actions.pendingId === item.id ? (actions.pendingDecision ?? null) : null;
+    return (
+      <ApprovalRequest
+        request={{
+          action: adaptedAction.actionPath ?? adaptedAction.title,
+          risk: adaptedAction.executorRisk ?? adaptedAction.risk,
+          projectName: item.project,
+          requestedAt: item.createdAt,
+          argsPreview: adaptedAction.rawArgsPreview ?? null,
+          reviewComplete: adaptedAction.reviewComplete === true,
+          pending: item.status === 'needs_you',
+          resolution:
+            item.status === 'approved' ? 'approve' : item.status === 'rejected' ? 'deny' : null,
+          status:
+            item.status === 'approved'
+              ? 'ok'
+              : item.status === 'rejected'
+                ? 'denied'
+                : 'pending_approval',
+        }}
+        onDecision={(decision) =>
+          actions.resolve(
+            item.id,
+            decision === 'approve' ? 'approved' : 'rejected',
+            decision === 'approve' ? 'Approved — the agent will continue' : 'Denied',
+          )
+        }
+        busyDecision={busyDecision}
+      />
+    );
+  }
   const openSession =
     actions.openSession && item.sessionId
       ? () => actions.openSession?.(item.sessionId as string)
       : undefined;
-  // Connected mode resolves each action for real via `resolve()` (routes to
-  // `resolveApproval` — the same call the in-session prompt uses), so the row
-  // pending state is keyed off the shared `pendingId` rather than local proto
-  // state. Prototype mode keeps the instant local `decideAction` + "Always
-  // allow this" full-allow affordance.
+  // Adapted Executor approvals return through ApprovalRequest above. This
+  // native/prototype branch keeps its existing whole-item decision behavior.
   return (
     <>
-      {!actions.connected && safePending.length > 0 && (
-        <InfoBanner
-          tone="success"
-          title={`${safePending.length} ${safePending.length === 1 ? 'action is' : 'actions are'} safe to approve together`}
-          action={
-            <Button
-              size="sm"
-              onClick={() => {
-                actions.approveAllSafe(item.id);
-                successToast(`Approved ${safePending.length} safe actions`);
-              }}
-            >
-              Approve all safe
-            </Button>
-          }
-        >
-          Reads and low-risk writes. Risky actions stay below for you to decide one by one.
-        </InfoBanner>
-      )}
-      {/* A connected item resolves as ONE unit (`/act` and `resolveApproval`
-          take a single verdict for the whole item), so with several pending
-          actions the per-row button pairs would misrepresent their granularity
-          — clicking Approve on one row would green-light all of them. Rows go
-          display-only and one clearly-labeled decision bar carries the verdict. */}
+      {/* Native multi-action approvals resolve as one item. Adapted Executor
+          approvals cannot reach this branch. */}
       {(() => {
         const wholeItem = !!actions.connected && list.filter((a) => !a.decided).length > 1;
         const busy = actions.connected && actions.pendingId === item.id;
@@ -519,10 +520,6 @@ function ApprovalBody({
                     }
                     actions.decideAction(item.id, a.id, 'denied');
                     infoToast(`Denied · ${a.title}`);
-                  }}
-                  onAlwaysAllow={() => {
-                    actions.decideAction(item.id, a.id, 'approved');
-                    infoToast(`Saved — ${a.connector} ${a.action} won’t ask again`);
                   }}
                 />
               ))}
@@ -796,15 +793,6 @@ function Footer({
   if (item.kind === 'approval') {
     return (
       <ModalFooter className="border-border/60 border-t pt-4">
-        <Button
-          variant="ghost"
-          onClick={() => {
-            actions.resolve(item.id, 'rejected', 'Denied all remaining actions');
-            onClose();
-          }}
-        >
-          Deny all
-        </Button>
         <Button variant="outline-ghost" onClick={onClose}>
           Close
         </Button>

--- a/apps/web/src/features/review-center/types.ts
+++ b/apps/web/src/features/review-center/types.ts
@@ -97,6 +97,11 @@ export interface ApprovalAction {
   risk: ReviewRisk;
   icon: ApprovalActionIcon;
   argsPreview: { key: string; value: string }[];
+  /** Exact action path and redacted record used by the shared one-call approval UI. */
+  actionPath?: string;
+  rawArgsPreview?: Record<string, unknown>;
+  reviewComplete?: boolean;
+  executorRisk?: string | null;
   policySource: string;
   decided?: 'approved' | 'denied'; // prototype-local decision state
 }
@@ -155,7 +160,7 @@ export function segmentForStatus(status: ReviewStatus): ReviewSegment {
   return 'done';
 }
 
-/** A low/none-risk approval action is eligible for "Approve all safe". */
+/** Prototype/native approval actions can use the safe-risk helper. Executor approvals cannot. */
 export function isSafeRisk(risk: ReviewRisk): boolean {
   return risk === 'none' || risk === 'low';
 }

--- a/apps/web/src/features/session/header/session-pending-approvals-indicator.tsx
+++ b/apps/web/src/features/session/header/session-pending-approvals-indicator.tsx
@@ -5,30 +5,22 @@
  *
  * Always mounted in the session header; renders nothing until this session has
  * an action awaiting a decision, then shows a count badge + popover so the
- * launcher notices even with the side panel closed. Resolve inline, or jump to
- * the full "Audit" tab. Shares its query with {@link SessionAuditPanel} (same
- * key) so the two never disagree.
+ * launcher notices even with the side panel closed. It links to the full
+ * parameter review instead of exposing a parameter-blind decision shortcut.
+ * It shares its query with {@link SessionAuditPanel} so the two never disagree.
  */
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import Loading from '@/components/ui/loading';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { errorToast, successToast } from '@/components/ui/toast';
 import { openSessionQuickView } from '@/features/session/open-session-quick-view';
 import {
   isPendingAction,
   relativeTime,
   riskTone,
-  useResolveApproval,
   useSessionAudit,
 } from '@/features/session/session-audit-shared';
-import { cn } from '@/lib/utils';
-import {
-  CheckIcon as Check,
-  ShieldWarningIcon as ShieldAlert,
-  XIcon as X,
-} from '@phosphor-icons/react';
+import { ArrowSquareOutIcon, ShieldWarningIcon as ShieldAlert } from '@phosphor-icons/react';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
 
@@ -42,30 +34,10 @@ export function SessionPendingApprovalsIndicator({ sessionId }: { sessionId: str
   }>();
 
   const { data } = useSessionAudit(projectId, projectSessionId, { silent: true });
-  const resolve = useResolveApproval(projectId, projectSessionId);
-  const [busy, setBusy] = useState<Record<string, 'approve' | 'deny'>>({});
   const [open, setOpen] = useState(false);
 
   const pending = (data?.actions ?? []).filter(isPendingAction);
   if (pending.length === 0) return null;
-
-  const decide = (executionId: string, decision: 'approve' | 'deny') => {
-    setBusy((b) => ({ ...b, [executionId]: decision }));
-    resolve.mutate(
-      { executionId, decision },
-      {
-        onSuccess: () => successToast(decision === 'approve' ? 'Action approved' : 'Action denied'),
-        onError: (e: unknown) =>
-          errorToast(e instanceof Error ? e.message : 'Failed to resolve approval'),
-        onSettled: () =>
-          setBusy((b) => {
-            const next = { ...b };
-            delete next[executionId];
-            return next;
-          }),
-      },
-    );
-  };
 
   const openAudit = () => {
     // Same Advanced-only `viewBySession` dead end as the other chips.
@@ -102,7 +74,6 @@ export function SessionPendingApprovalsIndicator({ sessionId }: { sessionId: str
 
         <div className="divide-border max-h-64 divide-y overflow-auto">
           {pending.map((a) => {
-            const b = busy[a.execution_id];
             return (
               <div key={a.execution_id} className="px-4 py-2.5">
                 <div className="flex items-center gap-2">
@@ -122,33 +93,18 @@ export function SessionPendingApprovalsIndicator({ sessionId }: { sessionId: str
                   {a.acted_by_email ?? 'agent'} · {relativeTime(a.at)}
                 </p>
                 <div className="mt-2 flex items-center gap-1.5">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className={cn('h-7 gap-1 px-2 text-xs')}
-                    disabled={!!b}
-                    onClick={() => decide(a.execution_id, 'deny')}
-                  >
-                    {b === 'deny' ? (
-                      <Loading className="size-3" />
-                    ) : (
-                      <X className="size-3" />
-                    )}
-                    Deny
-                  </Button>
-                  <Button
-                    size="sm"
-                    className="h-7 gap-1 px-2 text-xs"
-                    disabled={!!b}
-                    onClick={() => decide(a.execution_id, 'approve')}
-                  >
-                    {b === 'approve' ? (
-                      <Loading className="size-3" />
-                    ) : (
-                      <Check className="size-3" />
-                    )}
-                    Approve
-                  </Button>
+                  {a.approval_url ? (
+                    <Button size="sm" className="h-7 gap-1 px-2 text-xs" asChild>
+                      <a href={a.approval_url}>
+                        Review parameters
+                        <ArrowSquareOutIcon className="size-3 shrink-0" />
+                      </a>
+                    </Button>
+                  ) : (
+                    <Button size="sm" className="h-7 px-2 text-xs" onClick={openAudit}>
+                      Review in Audit
+                    </Button>
+                  )}
                 </div>
               </div>
             );

--- a/docs/REVIEW_CENTER_DESIGN.md
+++ b/docs/REVIEW_CENTER_DESIGN.md
@@ -2,7 +2,7 @@
 
 **Status:** Design + clickable prototype + **native-items vertical slice implemented** (DB · API · web data layer).
 **Owner:** ino@kortix.ai
-**Related:** KORTIX-207 (Executor approval / full-allow UX), KORTIX-208 (sandbox git authorization / CR-only main merge path)
+**Related:** KORTIX-207 (one-call Executor approval UX), KORTIX-208 (sandbox git authorization / CR-only main merge path)
 **Prototype:** `apps/web/src/features/review-center/*`, route `/review` (mock data only).
 
 ### Implementation status (this branch)
@@ -25,7 +25,8 @@ Also built since:
   project's `review_center` experimental flag is on.
 - **Adapters** — the inbox read model (`listInboxItems`) now **folds in real Change Requests** (`kind:change`,
   id `cr:<id>`) and **executor pending-approvals** (`kind:approval`, id `exec:<id>`) via `review-adapters.ts`
-  (unit-tested). Adapted items are read-only in the inbox; acting routes to their source view (act → 409).
+  (unit-tested). Change Requests act through their source routes. Executor decisions use the shared
+  full-parameter approval component and the one-call approval route.
 - **Slack** — full in-thread bridge wired. `channels/slack/review-cards.ts`: the Block Kit **review-card
   builder** + the `review_<verb>_<id>` action-id codec + `reviewVerbToVerdict` (unit-tested).
   `channels/slack/review.ts` **`postReviewCard`** posts the card into a live Slack thread (the
@@ -36,14 +37,10 @@ Also built since:
 - **UX/UI polish** — fluid `motion` (row reflow, animated bars, rolling counts, tactile press), calmer
   `StatusBadge` risk pills, faded empty state.
 
-**Remaining integration** (specced, needs a runtime to verify — not built blind):
-- Executor **202→resume** (KORTIX-207): persist the pending call + a resume/poll so an approval re-runs it
-  and returns the result to the waiting agent. (Note: the executor SDK already returns the structured 202
-  `pending_approval` body — `res.ok` is true for 202 — so the gap is the resume plumbing, not the SDK.)
+**Remaining integration:**
+
 - Slack **App Home**: a "Needs you (N)" section listing pending items (the sender + `handleReviewAction`
   card flow is now built; only the App Home surface remains).
-- Adapter **act-dispatch**: let the inbox merge/close a CR and approve/deny an executor call directly
-  (currently 409 → source view).
 
 ---
 
@@ -65,7 +62,7 @@ in plain language, from the web or from Slack.
 | Capability | State today | Files |
 | --- | --- | --- |
 | Change Requests | **Mature backend**, technical UI. `changeRequests` table; full `/v1/projects/:id/change-requests/*` API (list/detail/diff/merge-preview/merge/close/reopen); IAM gates `project.cr.merge`, `project.gitops.merge`; reusable hooks. UI exposes branch UUIDs, SHAs, merge-mode jargon, raw conflicts, diff hunks. | `apps/api/src/projects/change-requests.ts`, `routes/r8.ts`, `routes/r9.ts`, `git/merge.ts`; `apps/web/src/features/project-files/components/change-request-detail-dialog.tsx`, `change-requests-panel.tsx`; `hooks/use-change-requests.ts` |
-| Tool-call approvals (Executor) | **Stub.** Policy resolves `always_run \| require_approval \| block`; on `require_approval` the gateway records `pending_approval` and returns **HTTP 202** — **no UI, no bulk, no resume**. This is the KORTIX-207 gap. | `apps/api/src/executor/gateway.ts`, `policy.ts`; tables `executorExecutions`, `executorProjectPolicies`, `executorConnectorPolicies` |
+| Tool-call approvals (Executor) | **Implemented.** `require_approval` records one exact pending call and returns HTTP `202` with an authenticated `approval_url`. The standalone page, session Audit panel, and Review Center use the same full-parameter component. Approve or deny creates one durable session callback. | `apps/api/src/executor/gateway.ts`, `setup-links/approval-app.ts`, `projects/routes/r7.ts`; `apps/web/src/components/approvals/approval-request.tsx` |
 | Permission approvals (Tunnel) | **The one real structured approval surface.** `tunnelPermissionRequests` table (pending/approved/denied/expired) + SSE stream + approve/deny/scoped/expiry dialog. The reuse template. | `apps/api/src/tunnel/routes/permission-requests.ts`; `apps/web/src/features/tunnel/tunnel-permission-request-dialog.tsx`; `hooks/tunnel/use-tunnel.ts` |
 | Agent outputs / tasks | **Proto-primitive already exists.** `KortixTask` has statuses `awaiting_review` and `input_needed`, a `result`, a `blocking_question`, an events timeline, and an approve endpoint. But no generic "submit an artifact/decision for review" separate from a code diff. | `apps/web/src/hooks/kortix/use-kortix-tasks.ts`; `components/kortix/task-*.tsx`; `lib/kortix/task-meta.ts` |
 | Slack | Agent questions render as Block Kit **buttons**; a click resumes the agent via `spawnAgentTurn`. No pending-items surface; App Home shows projects only. | `apps/api/src/channels/slack/questions.ts`, `interactivity.ts`, `home.ts` |
@@ -112,8 +109,8 @@ interface ReviewItem {
 The five kinds map onto the existing systems:
 
 - **`change`** → a Change Request. Friendly wrapper over `changeRequests`.
-- **`approval`** → a pending action needing go-ahead. Adapts executor `require_approval` records **and**
-  tunnel permission requests into one shape. Carries one or more `ApprovalAction`s (enables bulk).
+- **`approval`** → a pending action needing go-ahead. An executor `require_approval` row maps to one
+  exact action. Executor approvals never support bulk decisions or persistent allow shortcuts.
 - **`output`** → an artifact/result the agent submits for feedback (landing page, document, API result,
   image, dataset). The genuinely new capability.
 - **`decision`** → a question / "input needed" — the agent is blocked on a human choice. Mirrors the
@@ -174,21 +171,18 @@ plainly, a **risk pill**, and the **consequence** spelled out ("Sends a real ema
 
 **Actions:**
 
-- **Approve** / **Deny** per action.
-- **Approve all safe** — bulk-approves every `none`/`low` risk action (reads, idempotent calls). Risky
-  (`medium`/`high`) actions are **excluded from bulk and flagged**, never silently swept in. This is the
-  "approve all safe actions, deny specific risky ones" pattern from the brief.
-- **Always allow this** — writes a policy so the action never asks again: maps to `executorProjectPolicies`
-  with `action=allow` (or a connector policy). This is the **"full-allow"** of KORTIX-207.
+- **Approve this call** authorizes one exact request digest once.
+- **Deny** rejects that one call.
+- The inbox does not expose row-level or bulk executor decisions. Opening the detail is mandatory.
+- The decision surface does not create an `always_run` policy or a session-wide grant.
 
-**Per-action detail:** args preview, the policy source that triggered the ask ("Project policy · write
-actions need approval"), scope (reuse the tunnel scoped pattern — e.g. "this recipient only"), and optional
-expiry ("this session" / "always").
+**Per-action detail:** the shared `ApprovalRequest` component shows every redacted connector parameter.
+Recipients, subject, body, channel, URL, and nested values remain visible without truncation. If the preview
+is incomplete, approval is disabled and denial remains available.
 
-**Resume (the missing plumbing):** today the executor returns HTTP 202 and the agent waits with no callback.
-The design adds an approval record + a resume signal that mirrors the two patterns that already work — the
-tunnel `approve → notify` relay and the Slack `answer → spawnAgentTurn` follow-up. Approving an action
-unblocks the waiting `/v1/executor/call`. (Specified here; implemented in Phase A.)
+**Resume:** the decision route updates the execution and inserts one `continue_session` lifecycle command
+in the same transaction. It then starts the lifecycle queue drain. The original Executor HTTP call already
+ended with `202`, so no agent request remains blocked while the human decides.
 
 ---
 
@@ -268,7 +262,7 @@ tangible during review.
 | "Agent output awaiting review" + events timeline + approve | `KortixTask` (`awaiting_review`/`input_needed`, `use-kortix-tasks.ts`, `task-meta.ts`) |
 | Friendly CR data + actions | `useChangeRequests` / `useMergeChangeRequest` / `useCloseChangeRequest` |
 | Decision options + resume | Slack question primitive (`questions.ts`, `interactivity.ts`, `spawnAgentTurn`) |
-| Policy / full-allow | `executorProjectPolicies` + `policy.ts` `resolveEffectiveAction` |
+| Explicit unattended policy | connector policies + `policy.ts` `resolveEffectiveAction` |
 | Inbox UI | `<ul>` entity rows, tinted icon tiles, `Badge`, `TabsListCompact`, `EmptyState`, `Modal`, `Disclosure`, `Loading`, `InfoBanner`, `StatusBadge`/`StatusDot` (per `changes-view.tsx`) |
 
 ---
@@ -280,7 +274,7 @@ tangible during review.
 - **Phase B — web Review Center.** Productionize the prototype against the real read model + the
   tunnel/kortix-task hooks. Add a nav entry. A11y + visual tests.
 - **Phase C — Slack.** ✅ Review cards in-thread (`postReviewCard`) + `handleReviewAction` (verdict +
-  resume) built. Remaining: App Home "Needs you (N)", bulk approve from Slack.
+  resume) built. Remaining: App Home "Needs you (N)". Executor approvals stay one action per decision.
 - Each phase follows the repo testing discipline (unit/integration/contract/api/e2e as the change demands).
 
 ---
@@ -300,7 +294,7 @@ shareable/clickable without login; mock data only, safe to expose).
   (`j`/`k` move, `Enter` open, `a` approve/ship, `e` ask-changes, `d` dismiss, `x` select, `1`–`3` switch
   lists, `/` search, `?` help), **every action is undoable** (toast with Undo), **multi-select + bulk
   approve/dismiss**, live **search**, sticky controls, per-row summaries and a focus cursor. **Needs you /
-  Waiting / Done** segments and kind filters carry live counts; the **Approve all safe** bulk bar stays.
+  Waiting / Done** segments and kind filters carry live counts. Bulk actions exclude Executor approvals.
 - `features/review-center/review-detail-modal.tsx` — per-kind friendly detail in a `Modal`, each with an
   **Advanced** disclosure and a Slack-preview. Implements the friendly-conflict flow (disabled "Ship it" +
   "Resolve with agent") and an optional **feedback composer** that returns free-text to the agent.


### PR DESCRIPTION
## Problem

Executor approval shortcuts let approvers decide without seeing the complete connector parameters. Review Center also exposed bulk and persistent-allow affordances that conflict with the one-call approval contract.

## Changes

- Pass the complete redacted `args_preview`, completeness flag, action path, and risk into Review Center for authorized human approvers.
- Apply the same `mayResolveApproval` authorization rule to Review Center preview reads and standalone approval-link reads.
- Withhold sensitive preview values from read-only members, PATs, service accounts, API keys, and session credentials.
- Render the shared `ApprovalRequest` component in Review Center.
- Remove Executor row-level and bulk decision paths.
- Remove the session-header approve and deny shortcuts.
- Keep one exact `approve` or `deny` decision on the authenticated approval page or shared detail component.
- Block approval when the parameter preview is incomplete. Keep denial available.
- Update the Review Center design document.

## Verification

- Focused API units — 17 pass, 0 fail, 71 assertions.
- Approval HTTP integration — 11 pass, 0 fail, 49 assertions.
- The HTTP security case proves: authorized human owner sees the preview; read-only human member and owner PAT do not.
- Focused web tests — 41 pass, 0 fail, 114 assertions.
- API typecheck — exit 0.
- Targeted web ESLint — 0 errors, 4 existing React Compiler warnings in `review-center.tsx`.
- Local Playwright proof covered standalone approve, deny, repeat 409, redaction, Review Center detail, and missing row/bulk shortcuts.

## Screenshots

- `test-results/approval-policy-local/01-pending-approve.png`
- `test-results/approval-policy-local/02-approved.png`
- `test-results/approval-policy-local/03-denied.png`
- `test-results/approval-policy-local/04-review-center-detail.png`
