### PR TITLE
fix(web): keep standalone output off Vercel

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -136,8 +136,7 @@ function resolveTurbopackMemoryEviction(): false | 'auto' | 'full' {
 
 // Local `pnpm preview` (scripts/dev-local.sh --build) sets KORTIX_PREVIEW_BUILD=1
 // to trade prod-build fidelity for speed: skip the `standalone` file-tracing pass
-// (next start never reads .next/standalone) and skip ESLint. Prod/CI/Vercel builds
-// don't set this flag, so they are completely unaffected.
+// (next start never reads .next/standalone) and skip ESLint.
 const IS_PREVIEW_BUILD = process.env.KORTIX_PREVIEW_BUILD === '1';
 
 // --- Cross-origin dev / preview access -----------------------------------
@@ -180,10 +179,12 @@ const nextConfig = (): NextConfig => ({
   // The frontend data layer lives in the @kortix/sdk workspace package (TS
   // source), so Next must transpile it.
   transpilePackages: ['@kortix/sdk'],
-  // Standalone bundles the app for Docker/Vercel via a slow monorepo-wide
-  // file-tracing pass. `next start` (what `pnpm preview` uses) ignores it, so
-  // skip it locally for a faster build.
-  output: IS_PREVIEW_BUILD ? undefined : 'standalone',
+  // Standalone bundles the app for Docker via a slow monorepo-wide file-tracing
+  // pass. Vercel injects a Next adapter. Next 16.3 does not emit the whole-app
+  // NFT for adapter builds, but its standalone finalizer still requires that
+  // file. Disable standalone on Vercel, where the platform does not use it.
+  // See https://github.com/vercel/next.js/issues/96646.
+  output: IS_PREVIEW_BUILD || process.env.VERCEL ? undefined : 'standalone',
   // Inline the resolved version so NEXT_PUBLIC_KORTIX_VERSION is available in
   // both the server (runtime-config) and client bundles, even on Vercel.
   env: {
@@ -269,8 +270,8 @@ const nextConfig = (): NextConfig => ({
   //   · import.meta.glob is a Turbopack capability, available without a flag.
   //   · Immutable static assets reusable across deploys is an ADAPTER feature
   //     (/docs/app/api-reference/adapters/immutable-static-assets). This app
-  //     ships `output: 'standalone'` on Vercel + a runner-only Docker image and
-  //     wires no custom adapter, so there is nothing to opt into here.
+  //     uses Vercel's injected adapter and `standalone` only for Docker, so
+  //     there is no custom adapter to configure here.
   //
   // Turbopack configuration
   turbopack: {

--- a/apps/web/src/config/next-output.test.ts
+++ b/apps/web/src/config/next-output.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, test } from 'bun:test';
+
+const nextConfig = readFileSync(new URL('../../next.config.ts', import.meta.url), 'utf8');
+
+describe('Next output mode', () => {
+  test('disables standalone output when the Vercel adapter runs', () => {
+    expect(nextConfig).toMatch(
+      /output:\s*IS_PREVIEW_BUILD\s*\|\|\s*process\.env\.VERCEL\s*\?\s*undefined\s*:\s*'standalone'/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- disable Next standalone output only when Vercel injects its adapter
- preserve standalone output for Docker and self-hosted images
- add a regression test for the platform split

## Root cause

Next 16.3 stops emitting the whole-app NFT during adapter builds. Its standalone finalizer still reads that file. Vercel injects the adapter, so main deployments fail after compilation with ENOENT for apps/web/.next/next-server.js.nft.json.

Upstream: https://github.com/vercel/next.js/issues/96646

## Verification

- bun test src/config/next-output.test.ts: 1 pass, 0 fail
- npx eslint next.config.ts src/config/next-output.test.ts: exit 0
- VERCEL=1 pnpm --filter ./apps/web build: Next 16.3.0, 195/195 pages, exit 0
- Vercel-mode build has no .next/standalone directory
- non-Vercel pnpm --filter ./apps/web build: Next 16.3.0, 195/195 pages, exit 0
- Docker-mode build emits apps/web/.next/standalone/apps/web/server.js