### PR TITLE
fix: attribute CLI actions in centralized audit logs

### DIFF
--- a/apps/api/src/__tests__/e2e-audit-events.test.ts
+++ b/apps/api/src/__tests__/e2e-audit-events.test.ts
@@ -76,6 +76,49 @@ describe('audit event middleware', () => {
     expect(auditRows[0]?.durationMs).toBeNumber();
   });
 
+  test('records an authenticated CLI request as CLI traffic', async () => {
+    const app = new Hono();
+    app.use('/v1/*', auditApiRequest);
+    app.patch('/v1/projects/:projectId/secrets/:identifier/strategy', async (c) => {
+      (c as any).set('userId', '00000000-0000-4000-a000-000000000001');
+      (c as any).set('accountId', '00000000-0000-4000-a000-000000000101');
+      (c as any).set('authType', 'pat');
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request(
+      '/v1/projects/00000000-0000-4000-a000-000000000201/secrets/demo/strategy',
+      { method: 'PATCH', headers: { 'X-Kortix-Client': 'cli' }, body: '{}' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]).toMatchObject({
+      actorType: 'human',
+      source: 'cli',
+      outcome: 'success',
+    });
+  });
+
+  test('does not accept an unknown client source label', async () => {
+    const app = new Hono();
+    app.use('/v1/*', auditApiRequest);
+    app.get('/v1/projects/:projectId/detail', async (c) => {
+      (c as any).set('userId', '00000000-0000-4000-a000-000000000001');
+      (c as any).set('accountId', '00000000-0000-4000-a000-000000000101');
+      (c as any).set('authType', 'pat');
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request(
+      '/v1/projects/00000000-0000-4000-a000-000000000201/detail',
+      { headers: { 'X-Kortix-Client': 'forged-source' } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(auditRows[0]).toMatchObject({ source: 'api' });
+  });
+
   test('records failed mutations with a failure outcome', async () => {
     const app = new Hono();
     app.use('/v1/*', auditApiRequest);
@@ -185,7 +228,7 @@ describe('audit event middleware', () => {
       projectId: '00000000-0000-4000-a000-000000000201',
       actorUserId: '00000000-0000-4000-a000-000000000001',
       actorType: 'human',
-      source: 'api',
+      source: 'cli',
       outcome: 'success',
       httpStatus: 201,
       correlationId: 'project-create-1',

--- a/apps/api/src/shared/audit.ts
+++ b/apps/api/src/shared/audit.ts
@@ -6,6 +6,7 @@ import { dispatchAuditEvent, type AuditWebhookPayload } from './audit-webhooks';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SKIPPED_PATHS = new Set(['/v1/health', '/v1/openapi.json', '/v1/docs']);
+const CLIENT_SOURCES = new Set(['api', 'cli', 'mobile', 'web']);
 
 export type AuditActorType = 'human' | 'agent' | 'service_account' | 'system';
 export type AuditOutcome = 'success' | 'failure' | 'denied' | 'pending';
@@ -110,6 +111,8 @@ function inferActorType(c: Context, actorUserId: string | null): AuditActorType 
 export function inferAuditSource(c: Context, actorType: AuditActorType | null): string {
   if (actorType === 'service_account') return 'automation';
   if (actorType === 'agent') return 'agent';
+  const clientSource = c.req.header('x-kortix-client')?.trim().toLowerCase();
+  if (clientSource && CLIENT_SOURCES.has(clientSource)) return clientSource;
   if ((c as any).get('authType') === 'supabase') return 'web';
   return 'api';
 }

--- a/apps/cli/src/api/sdk.test.ts
+++ b/apps/cli/src/api/sdk.test.ts
@@ -83,6 +83,11 @@ describe('withKortixScope', () => {
     expect(token).toBe('kortix_pat_test');
   });
 
+  test('identifies scoped backend requests as CLI traffic', async () => {
+    const source = await withKortixScope(auth(), async () => platformConfig().clientSource);
+    expect(source).toBe('cli');
+  });
+
   test('isolates concurrent scopes so a multi-host scan never crosses tokens', async () => {
     const [first, second] = await Promise.all([
       withKortixScope(auth({ api_base: 'https://one.kortix.com', token: 'one' }), async () => {

--- a/apps/cli/src/api/sdk.ts
+++ b/apps/cli/src/api/sdk.ts
@@ -35,6 +35,7 @@ export function sdkConfigFromAuth(auth: Auth): KortixPlatformConfig {
   return {
     backendUrl: sdkBackendUrl(auth.api_base),
     getToken: async () => token || null,
+    clientSource: 'cli',
   };
 }
 

--- a/apps/web/content/docs/sdk/auth.mdx
+++ b/apps/web/content/docs/sdk/auth.mdx
@@ -18,6 +18,10 @@ const kortix = createKortix({
 `backendUrl` and `getToken` are required. The SDK caches nothing: it calls
 `getToken` on every request, so your app owns token storage and refresh.
 
+Set `clientSource` to `api`, `cli`, `mobile`, or `web` when your host needs a
+separate source in the centralized audit log. This value identifies the client
+surface. It does not change the authenticated actor or their permissions.
+
 ## Personal access tokens
 
 A personal access token (PAT) is the credential for the SDK, the CLI, and CI.

--- a/apps/web/src/lib/seo/content-timestamps.json
+++ b/apps/web/src/lib/seo/content-timestamps.json
@@ -50,7 +50,7 @@
   "docs:project/models": "2026-08-01T15:15:19.000Z",
   "docs:project/secrets": "2026-08-02T01:08:17.000Z",
   "docs:quickstart": "2026-07-22T02:58:51.000Z",
-  "docs:sdk/auth": "2026-07-22T02:58:51.000Z",
+  "docs:sdk/auth": "2026-08-06T07:19:37.000Z",
   "docs:sdk/example": "2026-08-05T18:59:48.000Z",
   "docs:sdk": "2026-07-30T12:52:42.000Z",
   "docs:sdk/react": "2026-07-30T12:26:34.000Z",

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -28,9 +28,45 @@ same RED, GREEN, and REFACTOR sequence directly.
 
 Required SDK gates are typecheck, the full test suite, and packed-install smoke.
 
-**Status:** IN PROGRESS.
+**Status:** COMPLETE.
 
-**SDK package shippable to production: NOT YET.**
+**SDK package shippable to production: YES.**
+
+### 2026-08-05 — session `cli-audit-source` completion
+
+Added the optional `clientSource` platform configuration field. The SDK sends
+the validated value on authenticated backend and session-runtime requests. The
+CLI sets the value to `cli`. Explicit request headers still take precedence.
+The API preserves agent and service-account attribution before it considers the
+client surface. Unknown source labels fall back to `api`.
+
+RED:
+
+- SDK tests expected the `cli` request header and received no header.
+- CLI tests expected `clientSource: "cli"` and received no value.
+- API tests expected a CLI audit event and received source `api`.
+
+GREEN:
+
+- Focused SDK tests: `37 pass`, `0 fail`, and `90 expect()` calls.
+- Focused CLI tests: `13 pass`, `0 fail`, and `16 expect()` calls.
+- Focused API tests: `8 pass`, `0 fail`, and `28 expect()` calls.
+- `pnpm --filter @kortix/sdk typecheck`: exit `0`.
+- `pnpm --filter @kortix/sdk test`: `1544 pass`, `0 fail`, and `6321 expect()`
+  calls across `121` files.
+- `pnpm --filter @kortix/sdk run smoke:install`: exit `0`; the packed tarball
+  imported and `createKortix` constructed successfully.
+- The complete CLI suite passed `701` tests. The complete API suite passed
+  `5476` tests and skipped `62` tests. Both typechecks exited `0`.
+- A real localhost CLI `projects ls --json` request produced a central audit
+  event with source `cli`, actor type `human`, outcome `success`, and HTTP `200`.
+
+The public configuration type changed additively. No export was removed or
+renamed. The package version was not edited.
+
+**Status:** COMPLETE.
+
+**SDK package shippable to production: YES.**
 
 ---
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,28 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-05 — session `cli-audit-source` claim
+
+No **Now** task claimed. This is a narrow additive transport-metadata fix.
+
+Scope:
+
+- Let an SDK host identify its client surface without replacing the transport.
+- Send the client surface on every SDK-authenticated Kortix request.
+- Mark the Kortix CLI as `cli` so central audit filters reconstruct its actions.
+- Preserve every published name and existing configuration field.
+
+The listed `tdd` skill is unavailable in this session. This work will use the
+same RED, GREEN, and REFACTOR sequence directly.
+
+Required SDK gates are typecheck, the full test suite, and packed-install smoke.
+
+**Status:** IN PROGRESS.
+
+**SDK package shippable to production: NOT YET.**
+
+---
+
 ### 2026-08-05 — session `better-queue` completion
 
 No **Now** task claimed. This is an additive module for a host-side defect: a

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -450,6 +450,7 @@ Stable, tree-shakeable surfaces (also reachable via the facade). Not exhaustive
 interface KortixPlatformConfig {
   backendUrl: string;
   getToken: () => Promise<string | null>;
+  clientSource?: 'api' | 'cli' | 'mobile' | 'web';
   getUserId?: () => Promise<string | null>;
   billingEnabled?: boolean;
   sandboxId?: string | null;
@@ -459,6 +460,10 @@ interface KortixPlatformConfig {
   featureFlags?: KortixFeatureFlagOverrides; // per-flag overrides for non-Next.js hosts
 }
 ```
+
+Set `clientSource` when a non-web host needs its requests separated in the
+centralized audit log. The SDK sends the validated value as request metadata.
+Actor identity and permissions still come from the bearer token.
 
 The SDK is host-agnostic: no Next.js / web coupling in the core. The host injects
 its token getter and toast/notify sinks; the SDK does the rest. Today that's proven

--- a/packages/sdk/src/core/http/api-client.test.ts
+++ b/packages/sdk/src/core/http/api-client.test.ts
@@ -64,6 +64,21 @@ describe('makeRequest admin-bypass header', () => {
       stub.restore();
     }
   });
+
+  test('attaches the configured client surface to backend requests', async () => {
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'test-token',
+      clientSource: 'cli',
+    });
+    const stub = stubFetch();
+    try {
+      await backendApi.get('/projects/abc/detail');
+      expect(stub.getHeaders()?.['X-Kortix-Client']).toBe('cli');
+    } finally {
+      stub.restore();
+    }
+  });
 });
 
 // Regression for prod TypeError "t.message.includes is not a function": a

--- a/packages/sdk/src/core/http/api-client.ts
+++ b/packages/sdk/src/core/http/api-client.ts
@@ -1,6 +1,7 @@
-import { platformConfig } from './config';
+import { normalizeClientSource } from '../../platform/auth-core';
 import { getSupabaseAccessTokenWithRetry } from './auth';
 import { ApiError, AuthError, parseBillingError, RequestTooLargeError } from './api/errors';
+import { platformConfig } from './config';
 
 const getApiUrl = () => platformConfig().backendUrl || '';
 
@@ -150,6 +151,14 @@ async function makeRequest<T = any>(
 
     // Merge with any headers from fetchOptions
     Object.assign(headers, fetchOptions.headers as Record<string, string>);
+
+    const clientSource = normalizeClientSource(platformConfig().clientSource);
+    const hasClientSource = Object.keys(headers).some(
+      (name) => name.toLowerCase() === 'x-kortix-client',
+    );
+    if (clientSource && !hasClientSource) {
+      headers['X-Kortix-Client'] = clientSource;
+    }
 
     if (adminBypassEnabled) {
       headers['x-kortix-admin-bypass'] = '1';

--- a/packages/sdk/src/core/http/auth.test.ts
+++ b/packages/sdk/src/core/http/auth.test.ts
@@ -124,6 +124,21 @@ test('buildAuthHeaders injects the Bearer token without clobbering an existing A
 	expect(preset.get('Authorization')).toBe('Bearer mine');
 });
 
+test('buildAuthHeaders identifies the configured client surface', () => {
+	const headers = buildAuthHeaders('http://x.test/', undefined, 'tok', 'cli');
+	expect(headers.get('x-kortix-client')).toBe('cli');
+});
+
+test('buildAuthHeaders preserves an explicit client surface header', () => {
+	const headers = buildAuthHeaders(
+		'http://x.test/',
+		{ headers: { 'X-Kortix-Client': 'mobile' } },
+		'tok',
+		'cli',
+	);
+	expect(headers.get('x-kortix-client')).toBe('mobile');
+});
+
 test('the synthetic 401 is a JSON fetch-semantics Response (no network call implied)', async () => {
 	const res = syntheticUnauthenticatedResponse();
 	expect(res.status).toBe(401);

--- a/packages/sdk/src/core/http/auth.test.ts
+++ b/packages/sdk/src/core/http/auth.test.ts
@@ -139,6 +139,11 @@ test('buildAuthHeaders preserves an explicit client surface header', () => {
 	expect(headers.get('x-kortix-client')).toBe('mobile');
 });
 
+test('buildAuthHeaders omits an unknown configured client surface', () => {
+	const headers = buildAuthHeaders('http://x.test/', undefined, 'tok', 'forged-source');
+	expect(headers.has('x-kortix-client')).toBe(false);
+});
+
 test('the synthetic 401 is a JSON fetch-semantics Response (no network call implied)', async () => {
 	const res = syntheticUnauthenticatedResponse();
 	expect(res.status).toBe(401);

--- a/packages/sdk/src/core/http/auth.ts
+++ b/packages/sdk/src/core/http/auth.ts
@@ -176,7 +176,8 @@ export async function authenticatedFetch(
     return syntheticUnauthenticatedResponse();
   }
 
-  const headers = buildAuthHeaders(input, init, token);
+  const clientSource = platformConfig().clientSource;
+  const headers = buildAuthHeaders(input, init, token, clientSource);
   // 30s default timeout for everything EXCEPT the long-lived SSE event
   // stream (see `withDefaultTimeout`) — a "Kortix as a Backend" wrapper must
   // never have a hung sandbox/daemon request wedge its handler forever.
@@ -199,7 +200,7 @@ export async function authenticatedFetch(
       invalidateTokenCache();
       const newToken = await getAuthTokenWithRetry({ attempts: 2, baseDelayMs: 200 });
       if (newToken && newToken !== token) {
-        const retryHeaders = buildAuthHeaders(input, init, newToken);
+        const retryHeaders = buildAuthHeaders(input, init, newToken, clientSource);
         return fetchWithAuth(input, init, retryHeaders, signal);
       }
     }

--- a/packages/sdk/src/core/http/config.ts
+++ b/packages/sdk/src/core/http/config.ts
@@ -25,6 +25,8 @@ export interface KortixPlatformConfig {
   backendUrl: string;
   /** Returns the current bearer (Supabase JWT, PAT, or API key) — or null if unauthenticated. */
   getToken: () => Promise<string | null>;
+  /** Identifies the host surface in centralized audit events. */
+  clientSource?: 'api' | 'cli' | 'mobile' | 'web';
   /** Optional UI error sink (toast/log). No-op by default. */
   onError?: (error: unknown, context?: unknown) => void;
   /** Default sandbox id for local/single-sandbox hosts (was `getEnv().SANDBOX_ID`). */

--- a/packages/sdk/src/platform/auth-core.ts
+++ b/packages/sdk/src/platform/auth-core.ts
@@ -20,6 +20,13 @@ export interface TokenRetryOptions {
 	invalidateBetweenAttempts?: boolean;
 }
 
+const CLIENT_SOURCES = new Set(['api', 'cli', 'mobile', 'web']);
+
+export function normalizeClientSource(value?: string): string | null {
+	const normalized = value?.trim().toLowerCase();
+	return normalized && CLIENT_SOURCES.has(normalized) ? normalized : null;
+}
+
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -99,6 +106,7 @@ export function buildAuthHeaders(
 	input: RequestInfo | URL,
 	init?: RequestInit,
 	token?: string | null,
+	clientSource?: string,
 ): Headers {
 	const headers = new Headers(input instanceof Request ? input.headers : undefined);
 	if (init?.headers) {
@@ -108,6 +116,10 @@ export function buildAuthHeaders(
 	}
 	if (token && !headers.has('Authorization')) {
 		headers.set('Authorization', `Bearer ${token}`);
+	}
+	const normalizedClientSource = normalizeClientSource(clientSource);
+	if (normalizedClientSource && !headers.has('X-Kortix-Client')) {
+		headers.set('X-Kortix-Client', normalizedClientSource);
 	}
 	return headers;
 }


### PR DESCRIPTION
## Summary

- Add validated SDK client-source metadata for authenticated requests.
- Mark every CLI SDK request as `cli` in the centralized audit trail.
- Preserve agent and service-account attribution precedence.
- Ignore unknown source labels and retain the `api` fallback.

## Verification

- SDK: 1,544 passed; 0 failed; typecheck and packed-install smoke passed.
- CLI: 701 passed; 0 failed; typecheck passed.
- API: 5,476 passed; 62 skipped; 0 failed; typecheck passed.
- Localhost black-box: the real CLI listed 11 projects.
- Localhost audit query returned `GET /v1/projects`, source `cli`, actor `human`, outcome `success`, HTTP `200`.

## Compatibility

- The SDK configuration change is additive.
- No exported name changed.
- Explicit request headers still take precedence.
- The package version is unchanged.