### PR TITLE
fix(billing): stop quoting the wrong seat grant and seat price

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -71,7 +71,7 @@ if (SENTRY_DSN) {
       // reporting — these regexes are exact after optional canonical wrappers.
       /^(?:Unhandled promise rejection: )?(?:ApiError: )?Out of credits\. Top up to continue\.$/,
       /^(?:Unhandled promise rejection: )?(?:ApiError: )?No credit account found\. Complete account setup first\.$/,
-      /^(?:Unhandled promise rejection: )?(?:ApiError: )?Subscribe to activate your seat\. \$20\/teammate per month includes wallet credits for compute and LLM usage\.$/,
+      /^(?:Unhandled promise rejection: )?(?:ApiError: )?Subscribe to activate your seat\. \$40\/teammate per month includes wallet credits for compute and LLM usage\.$/,
       // Expected "no compaction model configured" configuration state. The
       // SDK's `useSummarizeOpenCodeSession` mutation throws a sentinel
       // `NoCompactionModelError` (`packages/sdk/src/react/use-opencode-sessions/no-compaction-model-error.ts`)

--- a/apps/web/src/features/billing/compute-pricing.ts
+++ b/apps/web/src/features/billing/compute-pricing.ts
@@ -2,6 +2,19 @@ export const CREDITS_PER_USD = 100;
 export const DEFAULT_COMPUTE_HOURLY_PRICE_USD = 0.201312;
 export const TEAM_CREDITS_PER_SEAT = 2500;
 
+/**
+ * Dollar value of one seat's monthly grant — the API's
+ * `INCLUDED_CREDITS_PER_SEAT_USD` (apps/api/src/billing/services/tiers.ts),
+ * expressed here in the web app's credit terms.
+ *
+ * DERIVED, not typed in a second time. A hardcoded copy of this number in the
+ * post-checkout success toast had drifted to $20 and was quoting customers a
+ * grant $5/seat smaller than the one they had just paid for — the class of
+ * "blatantly wrong info" the seat copy was already corrected for once.
+ * Anything user-facing that states the grant reads it from here.
+ */
+export const SEAT_GRANT_USD = TEAM_CREDITS_PER_SEAT / CREDITS_PER_USD;
+
 export function estimateDefaultCompute(credits: number): {
   creditValueUsd: number;
   runtimeHours: number;

--- a/apps/web/src/features/billing/pricing-copy.test.ts
+++ b/apps/web/src/features/billing/pricing-copy.test.ts
@@ -78,3 +78,48 @@ describe('pricing model billing copy', () => {
     }
   });
 });
+
+/**
+ * The seat grant is stated in two packages and they drift silently.
+ *
+ * apps/api owns the real number (`INCLUDED_CREDITS_PER_SEAT_USD`); apps/web
+ * restates it for the pricing page, the calculator and the post-checkout toast.
+ * Nothing connected them, so the toast sat at a hardcoded $20 while the API
+ * granted $25 — quoting a customer a grant $5/seat smaller than the one they
+ * had just paid for, on the screen right after they paid.
+ *
+ * Read from the API source rather than importing it: apps/web must not take a
+ * build dependency on apps/api, but it can still refuse to disagree with it.
+ */
+describe('seat grant agrees with the API', () => {
+  const apiTiersSource = readFileSync(
+    join(import.meta.dir, '../../../../api/src/billing/services/tiers.ts'),
+    'utf8',
+  );
+
+  function apiConstant(name: string): number {
+    const m = apiTiersSource.match(new RegExp(`export const ${name} = (\\d+(?:\\.\\d+)?)`));
+    if (!m) throw new Error(`${name} not found in apps/api tiers.ts`);
+    return Number(m[1]);
+  }
+
+  test('SEAT_GRANT_USD equals INCLUDED_CREDITS_PER_SEAT_USD', async () => {
+    const { SEAT_GRANT_USD } = await import('./compute-pricing');
+    expect(SEAT_GRANT_USD).toBe(apiConstant('INCLUDED_CREDITS_PER_SEAT_USD'));
+  });
+
+  test('the pooled-credit figure is that grant in credits', async () => {
+    const { TEAM_CREDITS_PER_SEAT, CREDITS_PER_USD } = await import('./compute-pricing');
+    expect(TEAM_CREDITS_PER_SEAT / CREDITS_PER_USD).toBe(
+      apiConstant('INCLUDED_CREDITS_PER_SEAT_USD'),
+    );
+  });
+
+  test('the seat PRICE is not confused with the seat GRANT', () => {
+    // $40 is charged, $25 is granted. Conflating them is the exact error the
+    // seat-management card shipped ("adds $40/mo and grants $40 of credits").
+    expect(apiConstant('PER_SEAT_PRICE_USD')).not.toBe(
+      apiConstant('INCLUDED_CREDITS_PER_SEAT_USD'),
+    );
+  });
+});

--- a/apps/web/src/hooks/billing/use-account-state.ts
+++ b/apps/web/src/hooks/billing/use-account-state.ts
@@ -33,6 +33,7 @@ import {
   type AccountState,
 } from '@kortix/sdk';
 import { dollarsToCredits } from '@kortix/shared';
+import { SEAT_GRANT_USD } from '@/features/billing/compute-pricing';
 
 export type { AccountState };
 
@@ -314,7 +315,7 @@ export function useCreatePerSeatCheckout() {
         useUpgradeDialogStore.getState().closeUpgradeDialog();
         await invalidateAccountState(queryClient, true, true, accountId);
         successToast('Subscription activated', {
-          description: `${data.seat_count} seat${data.seat_count === 1 ? '' : 's'} active · $${20 * data.seat_count} of usage credit deposited.`,
+          description: `${data.seat_count} seat${data.seat_count === 1 ? '' : 's'} active · $${SEAT_GRANT_USD * data.seat_count} of usage credit deposited.`,
         });
         return;
       }

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -411,6 +411,14 @@ const BILLING_GATE_EXPECTED_EVENTS = [
   // The other two billing-gate 402 reasons — same expected business state,
   // same leak paths, same fix (prevents the next noise pattern).
   'No credit account found. Complete account setup first.',
+  'Subscribe to activate your seat. $40/teammate per month includes wallet credits for compute and LLM usage.',
+]
+
+// The seat price lives in apps/api and this filter matches the rendered string,
+// so the two drift silently: the API moved to $40, this list stayed at $20, and
+// an expected billing state paged as an error until someone read the Sentry
+// volume. A stale price must fail the suite, not the on-call rotation.
+const SUPERSEDED_BILLING_GATE_MESSAGES = [
   'Subscribe to activate your seat. $20/teammate per month includes wallet credits for compute and LLM usage.',
 ]
 
@@ -420,6 +428,18 @@ test('classifies every billing-gate 402 message as an expected business state', 
       isExpectedBillingGateMessage(message),
       true,
       `expected ${message} to be classified as an expected billing-gate message`,
+    )
+  }
+})
+
+test('a superseded seat price is NOT still carried as an expected message', () => {
+  // Keeping the old string "working" is what hides the drift: the filter looks
+  // healthy while the message the API actually sends sails past it.
+  for (const message of SUPERSEDED_BILLING_GATE_MESSAGES) {
+    assert.equal(
+      isExpectedBillingGateMessage(message),
+      false,
+      `stale seat price still allow-listed: ${message}`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -143,7 +143,10 @@ const BILLING_GATE_EXPECTED_MESSAGES = [
   // `no_account` — no credit account found.
   'No credit account found. Complete account setup first.',
   // `subscription_required` — per-seat account with no active subscription.
-  'Subscribe to activate your seat. $20/teammate per month includes wallet credits for compute and LLM usage.',
+  // Must match apps/api/src/billing/services/billing-gate.ts VERBATIM. The seat
+  // price moved to $40 there and this copy was left at $20, so the filter
+  // stopped matching and an expected billing state has been paging as an error.
+  'Subscribe to activate your seat. $40/teammate per month includes wallet credits for compute and LLM usage.',
 ] as const;
 
 // Expected "no compaction model configured" configuration state. The SDK's


### PR DESCRIPTION
Marko flagged the seat copy as "blatantly wrong info". The exact card he quoted
was removed in #6132 — but the same class of error is still live in three places,
because the seat numbers are restated per package with nothing tying them to the
API constants.

## What is wrong

| Where | Says | Actual |
|---|---|---|
| `use-account-state.ts:317` post-checkout toast | `$20 × seats` deposited | `INCLUDED_CREDITS_PER_SEAT_USD = 25` |
| `browser-error-noise.ts:146` | `$20/teammate` | API sends `$40/teammate` |
| `sentry.client.config.ts:74` | `$20/teammate` | same |

The toast one is the worst: it is the screen shown **immediately after the
customer pays**, and it quotes a grant $5/seat smaller than the one they just
bought.

The Sentry pair is a live noise bug rather than a copy bug. The seat price moved
to $40 in `billing-gate.ts` and these two filters stayed at $20, so
`subscription_required` — an expected billing state — stopped matching and has
been reporting as an error ever since.

Worth being precise about the two numbers, because conflating them is what
produced the original card: **$40 is charged, $25 is granted.** The other $15 is
platform margin.

## Fix

`SEAT_GRANT_USD` is derived in `compute-pricing.ts` (`TEAM_CREDITS_PER_SEAT /
CREDITS_PER_USD`) and the toast reads it. Both Sentry strings now match the API
verbatim.

Two guards, because restating the number is the actual defect:

- `pricing-copy.test.ts` reads `INCLUDED_CREDITS_PER_SEAT_USD` and
  `PER_SEAT_PRICE_USD` out of `apps/api/src/billing/services/tiers.ts` and
  refuses to disagree — including an explicit assertion that the price and the
  grant are not the same number. It reads the source rather than importing it,
  so `apps/web` takes no build dependency on `apps/api`.
- The superseded `$20/teammate` string must now classify as **not** expected.
  Leaving it allow-listed is what hid the drift: the filter looks healthy while
  the message the API actually sends sails past it.

## Verification

```
$ node --test src/lib/browser-error-noise.test.mts
# pass 255   # fail 0

$ bun test src/features/billing/pricing-copy.test.ts
7 pass, 0 fail
```

Drift guard proven by injecting the exact historical drift
(`TEAM_CREDITS_PER_SEAT` 2500 → 2000, i.e. $25 → $20):

```
(fail) seat grant agrees with the API > SEAT_GRANT_USD equals INCLUDED_CREDITS_PER_SEAT_USD
(fail) seat grant agrees with the API > the pooled-credit figure is that grant in credits
5 pass, 2 fail
```

Restored → 7 pass.

`tsc --noEmit` reports nothing in any changed file. The 25 errors in
`src/app/a1o/die-scene.tsx` (missing `@react-three/fiber` / `cannon-es`) are
present on untouched `main` — confirmed by stashing.

## Not in this PR

Marko's other two billing points are pricing-model changes, not copy fixes, and
they need his numbers before anything ships. Summarised in the PR discussion.
