### PR TITLE
fix(web): align approval indicator with design system

### DIFF
--- a/apps/web/src/features/review-center/executor-approval-contract.test.ts
+++ b/apps/web/src/features/review-center/executor-approval-contract.test.ts
@@ -13,6 +13,12 @@ describe('executor approval review contract', () => {
     expect(source).not.toContain('useResolveApproval');
     expect(source).not.toContain("decision: 'approve'");
     expect(source).not.toContain("decision: 'deny'");
+    expect(source).toContain('<Badge');
+    expect(source).toContain('text-kortix-orange');
+    expect(source).not.toContain('text-amber-');
+    expect(source).not.toContain('bg-amber-');
+    expect(source).not.toContain('text-[');
+    expect(source).not.toContain('h-7');
   });
 
   test('Review Center uses the shared full-parameter component', () => {

--- a/apps/web/src/features/session/header/session-pending-approvals-indicator.tsx
+++ b/apps/web/src/features/session/header/session-pending-approvals-indicator.tsx
@@ -20,7 +20,7 @@ import {
   riskTone,
   useSessionAudit,
 } from '@/features/session/session-audit-shared';
-import { ArrowSquareOutIcon, ShieldWarningIcon as ShieldAlert } from '@phosphor-icons/react';
+import { ArrowSquareOutIcon, ShieldWarningIcon } from '@phosphor-icons/react';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
 
@@ -54,10 +54,10 @@ export function SessionPendingApprovalsIndicator({ sessionId }: { sessionId: str
           aria-label={`${pending.length} action${pending.length === 1 ? '' : 's'} awaiting your approval`}
           className="relative"
         >
-          <ShieldAlert className="size-4 text-amber-500" />
-          <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-600 px-1 text-[10px] leading-none font-semibold text-white">
+          <ShieldWarningIcon className="text-kortix-orange size-4" />
+          <Badge variant="warning" size="tabular" className="absolute -top-1 -right-1">
             {pending.length}
-          </span>
+          </Badge>
         </Button>
       </PopoverTrigger>
 
@@ -89,19 +89,19 @@ export function SessionPendingApprovalsIndicator({ sessionId }: { sessionId: str
                     </Badge>
                   ) : null}
                 </div>
-                <p className="text-muted-foreground mt-0.5 text-[11px]">
+                <p className="text-muted-foreground mt-0.5 text-xs">
                   {a.acted_by_email ?? 'agent'} · {relativeTime(a.at)}
                 </p>
                 <div className="mt-2 flex items-center gap-1.5">
                   {a.approval_url ? (
-                    <Button size="sm" className="h-7 gap-1 px-2 text-xs" asChild>
+                    <Button size="sm" asChild>
                       <a href={a.approval_url}>
                         Review parameters
                         <ArrowSquareOutIcon className="size-3 shrink-0" />
                       </a>
                     </Button>
                   ) : (
-                    <Button size="sm" className="h-7 px-2 text-xs" onClick={openAudit}>
+                    <Button size="sm" onClick={openAudit}>
                       Review in Audit
                     </Button>
                   )}


### PR DESCRIPTION
## Summary
- replace raw amber classes with the Kortix orange token
- replace the hand-built count chip with the shared Badge primitive
- remove custom 28px button overrides and arbitrary text sizes
- pin the design-system contract in the focused approval test

## Verification
- `bun test apps/web/src/features/review-center/executor-approval-contract.test.ts apps/web/src/features/session/header/session-site-header.test.tsx` — 19 pass, 0 fail, 71 expectations
- `pnpm --dir apps/web exec eslint src/features/session/header/session-pending-approvals-indicator.tsx src/features/review-center/executor-approval-contract.test.ts` — exit 0
- `pnpm --dir apps/web exec prettier --check src/features/session/header/session-pending-approvals-indicator.tsx src/features/review-center/executor-approval-contract.test.ts` — exit 0
- `git diff --check` — exit 0