### PR TITLE
feat(billing): flat credit plans replace seats, no included managed LLM

### DIFF
--- a/apps/api/src/__tests__/billing/credit-plans.test.ts
+++ b/apps/api/src/__tests__/billing/credit-plans.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Billing v3 — flat credit plans, and the seat plan they replace.
+ *
+ * Seats priced humans. The cost driver is agents, and agents run unattended: a
+ * two-person team can run fifty of them, and a Kortix-as-a-Backend customer
+ * serves end users who are not seats at all. So the plan now carries the credit
+ * pool and the concurrency limit, and headcount leaves the price.
+ *
+ * Three properties are worth pinning, because each one fails silently:
+ *
+ *   1. NO included managed LLM (`models: []`). If a tier were given `['all']`
+ *      the wallet would quietly start funding inference again, and a fixed
+ *      monthly price would go back to being short model prices.
+ *   2. Existing per-seat customers are GRANDFATHERED — same price, same grant,
+ *      same session cap, and crucially their managed-model access is NOT
+ *      withdrawn under them.
+ *   3. Credit plans METER COMPUTE. The meter's gate used to be
+ *      `isPerSeatAccount`, which read literally hands every other billing model
+ *      free compute — an unbilled hole straight through the new tiers.
+ *
+ * Pure functions over the tier tables; no mocks.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  INCLUDED_CREDITS_PER_SEAT_USD,
+  PER_SEAT_PRICE_USD,
+  accountIsFreeTierForModels,
+  TOKEN_PRICE_MULTIPLIER,
+  accountMetersCompute,
+  getTier,
+  isCreditPlanAccount,
+  isLegacyAccount,
+  isPerSeatAccount,
+  tierGrantsAllModels,
+} from '../../billing/services/tiers';
+
+/** The ladder Marko approved. */
+const CREDIT_PLANS = [
+  { key: 'starter', price: 40, credits: 25, concurrency: 3 },
+  { key: 'team', price: 200, credits: 125, concurrency: 10 },
+  { key: 'scale', price: 800, credits: 500, concurrency: 30 },
+] as const;
+
+describe('the credit-plan ladder', () => {
+  test.each(CREDIT_PLANS.map((p) => [p.key, p] as const))(
+    '%s carries its price, pool and concurrency',
+    (_key, plan) => {
+      const tier = getTier(plan.key);
+      expect(tier.monthlyPrice).toBe(plan.price);
+      expect(tier.monthlyCredits).toBe(plan.credits);
+      expect(tier.concurrentSessionLimit).toBe(plan.concurrency);
+    },
+  );
+
+  test('every plan is sellable and visible', () => {
+    for (const plan of CREDIT_PLANS) {
+      const tier = getTier(plan.key);
+      expect(tier.hidden).toBe(false);
+      expect(tier.canPurchaseCredits).toBe(true);
+    }
+  });
+
+  test('price : credits holds at 1.6 : 1 across the ladder', () => {
+    // The ratio IS the ladder's coherence — it fixes gross margin at ~48% when a
+    // plan burns its whole pool. A tier added off-ratio silently prices at a
+    // different margin from its neighbours.
+    for (const plan of CREDIT_PLANS) {
+      expect(plan.price / plan.credits).toBeCloseTo(1.6, 10);
+    }
+  });
+
+  test('a fully-burned pool still leaves ~48% gross margin', () => {
+    // COGS is the pool at cost: customer-facing credits already carry the 1.2x
+    // markup, so the real spend is pool / 1.2.
+    for (const plan of CREDIT_PLANS) {
+      const cogs = plan.credits / TOKEN_PRICE_MULTIPLIER;
+      const margin = (plan.price - cogs) / plan.price;
+      expect(margin).toBeGreaterThan(0.47);
+      expect(margin).toBeLessThan(0.49);
+    }
+  });
+
+  test('concurrency rises with price', () => {
+    // "higher credit pools AND higher session concurrency" — a ladder where
+    // concurrency is flat gives a bigger plan nothing but a bigger wallet.
+    const limits = CREDIT_PLANS.map((p) => getTier(p.key).concurrentSessionLimit);
+    for (let i = 1; i < limits.length; i++) expect(limits[i]).toBeGreaterThan(limits[i - 1]);
+  });
+});
+
+describe('no included managed LLM', () => {
+  test.each(CREDIT_PLANS.map((p) => p.key))('%s grants no managed models', (key) => {
+    expect(getTier(key).models).toEqual([]);
+    expect(tierGrantsAllModels(key)).toBe(false);
+  });
+
+  test.each(CREDIT_PLANS.map((p) => p.key))('%s wallet funds compute only', (key) => {
+    // Same mechanism the free tier already uses: the wallet pays for sandbox
+    // compute, managed premium inference is blocked, and BYOK / OpenCode /
+    // ChatGPT-subscription paths are untouched.
+    //
+    // Asserted through the tier DATA and `tierGrantsAllModels`, deliberately NOT
+    // through `accountIsFreeTierForModels`: the gateway's resolve-candidates
+    // suite stubs that predicate to `tier === 'free'`, and because mock.module
+    // shares one registry across co-run files, this test would read their stub
+    // and fail on a green codebase. The data is the source of truth anyway —
+    // the predicate is derived from it.
+    expect(getTier(key).models.includes('all')).toBe(false);
+    expect(tierGrantsAllModels(key)).toBe(false);
+  });
+});
+
+describe('grandfathered per-seat accounts', () => {
+  const seat = getTier('per_seat');
+
+  test('price and grant are untouched', () => {
+    expect(seat.monthlyPrice).toBe(PER_SEAT_PRICE_USD);
+    expect(seat.monthlyCredits).toBe(INCLUDED_CREDITS_PER_SEAT_USD);
+  });
+
+  test('managed-model access is NOT withdrawn', () => {
+    // The point of grandfathering. Flipping this to [] would silently revoke
+    // paid-for inference from every existing customer at the next deploy.
+    expect(seat.models).toEqual(['all']);
+    expect(tierGrantsAllModels('per_seat')).toBe(true);
+    expect(accountIsFreeTierForModels('per_seat')).toBe(false);
+  });
+
+  test('the session cap is untouched', () => {
+    expect(seat.concurrentSessionLimit).toBe(200);
+  });
+
+  test('hidden from the self-serve grid but still resolvable', () => {
+    // Hidden stops NEW signups; it must not stop an existing subscription from
+    // resolving its own tier.
+    expect(seat.hidden).toBe(true);
+    expect(getTier('per_seat').name).toBe('per_seat');
+  });
+});
+
+describe('billing-model predicates', () => {
+  test('credit is its own model, distinct from seats and legacy', () => {
+    expect(isCreditPlanAccount('credit')).toBe(true);
+    expect(isPerSeatAccount('credit')).toBe(false);
+    expect(isLegacyAccount('credit')).toBe(false);
+  });
+
+  test('per_seat is unchanged', () => {
+    expect(isPerSeatAccount('per_seat')).toBe(true);
+    expect(isCreditPlanAccount('per_seat')).toBe(false);
+    expect(isLegacyAccount('per_seat')).toBe(false);
+  });
+
+  test('legacy and unset stay legacy', () => {
+    for (const m of ['legacy', null, undefined]) {
+      expect(isLegacyAccount(m)).toBe(true);
+      expect(isCreditPlanAccount(m)).toBe(false);
+    }
+  });
+});
+
+describe('compute metering covers every paying model', () => {
+  test('both per_seat and credit are metered', () => {
+    // The bug this pins: the meter gated on `isPerSeatAccount`, so a credit
+    // account would have run unmetered — the customer pays a flat fee and the
+    // compute it buys is never charged against the pool.
+    expect(accountMetersCompute('per_seat')).toBe(true);
+    expect(accountMetersCompute('credit')).toBe(true);
+  });
+
+  test('legacy and unset are NOT metered', () => {
+    // Legacy customers never agreed to compute metering; charging them would be
+    // the mirror-image bug.
+    for (const m of ['legacy', null, undefined]) expect(accountMetersCompute(m)).toBe(false);
+  });
+
+  test('the meter query lists exactly the metered models', async () => {
+    // A second copy of this set lives in compute-metering.ts as a SQL `inArray`.
+    // Drift there does not throw — it just stops charging one model.
+    const src = await Bun.file(
+      new URL('../../billing/services/compute-metering.ts', import.meta.url).pathname,
+    ).text();
+    const m = src.match(/const METERED_BILLING_MODELS = \[([^\]]+)\]/);
+    expect(m).not.toBeNull();
+    const listed = [...m![1].matchAll(/'([a-z_]+)'/g)].map((x) => x[1]).sort();
+    expect(listed).toEqual(['credit', 'per_seat']);
+    for (const model of listed) expect(accountMetersCompute(model)).toBe(true);
+  });
+});
+
+/**
+ * A plan may be advertised only once it can actually be sold.
+ *
+ * Checkout resolves a Stripe price and throws `No price configured for this
+ * tier` when there is none. The v3 plans are defined here before their Stripe
+ * products exist, so listing them on `hidden: false` alone would put three
+ * options in the grid that fail the instant anyone clicks them.
+ *
+ * `getVisibleTiers()` therefore derives visibility from buyability. The plans
+ * stay dark on their own and light up on their own when the prices land — no
+ * flag to remember, and no window where the grid sells what billing cannot.
+ */
+describe('visibility follows buyability', () => {
+  test('every advertised tier has a resolvable monthly price', async () => {
+    const { getVisibleTiers, resolvePriceId } = await import('../../billing/services/tiers');
+    const visible = getVisibleTiers();
+    expect(visible.length).toBeGreaterThan(0);
+    for (const tier of visible) {
+      expect(resolvePriceId(tier.name, 'monthly')).not.toBeNull();
+    }
+  });
+
+  test('the credit plans are dark until their Stripe prices exist', async () => {
+    const { getVisibleTiers, resolvePriceId } = await import('../../billing/services/tiers');
+    const visible = new Set(getVisibleTiers().map((t) => t.name));
+    for (const plan of CREDIT_PLANS) {
+      // Asserted as an implication, not a bare `false`: the day the prices are
+      // added this test should keep passing, not start failing.
+      const buyable = resolvePriceId(plan.key, 'monthly') !== null;
+      expect(visible.has(plan.key)).toBe(buyable);
+    }
+  });
+
+  test('grandfathered seats are never advertised, priced or not', async () => {
+    const { getVisibleTiers } = await import('../../billing/services/tiers');
+    expect(getVisibleTiers().some((t) => t.name === 'per_seat')).toBe(false);
+  });
+});

--- a/apps/api/src/billing/services/compute-metering.ts
+++ b/apps/api/src/billing/services/compute-metering.ts
@@ -19,7 +19,7 @@
 // bills any session whose last_billed_at is > 1 hour ago, so a missed close
 // hook can never silently accrue 24h+ of uncharged compute.
 
-import { and, asc, eq, isNull, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { creditAccounts, sandboxComputeSessions, sessionSandboxes } from '@kortix/db';
 import { config } from '../../config';
 import { getProvider, type ProviderName } from '../../platform/providers';
@@ -42,7 +42,10 @@ import {
   lastAliveAtOf,
 } from './compute-liveness';
 import { deductCredits } from './credits';
-import { isPerSeatAccount } from './tiers';
+import { accountMetersCompute } from './tiers';
+
+/** Kept in lockstep with accountMetersCompute() — see tier-facts.ts. */
+const METERED_BILLING_MODELS = ['per_seat', 'credit'] as const;
 
 const PARTIAL_BILL_INTERVAL_MS = 60 * 60 * 1000; // 1h
 // Bounded like every other periodic sweep in this codebase (REAP_BATCH_SIZE in
@@ -86,10 +89,14 @@ export function calculateComputeCost(
  */
 export async function startComputeSession(opts: StartComputeOpts): Promise<string | null> {
   // Hard gate: self-hosted / billing-disabled deploys never meter compute, even
-  // if a credit_accounts row has billing_model='per_seat' (stale data).
+  // if a credit_accounts row has a metered billing_model (stale data).
   if (!config.KORTIX_BILLING_INTERNAL_ENABLED) return null;
   const account = await getCreditAccount(opts.accountId);
-  if (!isPerSeatAccount(account?.billingModel)) return null;
+  // `accountMetersCompute`, NOT `isPerSeatAccount`. Per-seat used to be the only
+  // metered model, so the gate was written as an identity check; read literally
+  // it grants every other model free compute. The v3 `credit` plans are metered
+  // too — that omission would have been an unbilled hole through the new tiers.
+  if (!accountMetersCompute(account?.billingModel)) return null;
 
   // If a row is already open (e.g. duplicate hook), reuse it.
   const existing = await getOpenComputeSession(opts.sandboxId);
@@ -362,7 +369,7 @@ export interface ReconcileMissingComputeResult {
  *
  * This sweeps every `active` sandbox with no currently-open compute row and
  * reopens one via `reopenComputeForSandbox`, which already applies the
- * `isPerSeatAccount` gate (no-op for `legacy` accounts — never reimplemented
+ * `accountMetersCompute` gate (no-op for `legacy` accounts — never reimplemented
  * here) and reuses the sandbox's last known spec so a reconciled window bills
  * at the same rate the sandbox always has. Idempotent: `startComputeSession`
  * underneath is a no-op if a row already raced open between the SELECT below
@@ -381,7 +388,7 @@ export interface ReconcileMissingComputeResult {
  * unordered `LIMIT` fills with legacy rows on every pass and the per-seat rows
  * this sweep exists for are never reached — a no-op that costs a round-trip per
  * row. The inner join also drops accounts with no `credit_accounts` row at all,
- * which is the same fail-closed outcome as the `isPerSeatAccount` gate below.
+ * which is the same fail-closed outcome as the `accountMetersCompute` gate below.
  */
 export function selectMissingComputeCandidates(limit = RECONCILE_MISSING_BATCH_SIZE) {
   return db
@@ -397,7 +404,9 @@ export function selectMissingComputeCandidates(limit = RECONCILE_MISSING_BATCH_S
       creditAccounts,
       and(
         eq(creditAccounts.accountId, sessionSandboxes.accountId),
-        eq(creditAccounts.billingModel, 'per_seat'),
+        // Mirrors accountMetersCompute() — every metered billing model, not just
+        // per-seat. A model missing here silently stops being charged.
+        inArray(creditAccounts.billingModel, METERED_BILLING_MODELS),
       ),
     )
     .leftJoin(

--- a/apps/api/src/billing/services/tier-facts.ts
+++ b/apps/api/src/billing/services/tier-facts.ts
@@ -29,5 +29,35 @@ export function isPerSeatAccount(billingModel: string | null | undefined): boole
 export function isLegacyAccount(billingModel: string | null | undefined): boolean {
   // Default for null/undefined is legacy — safer to skip new behaviour than to
   // accidentally bill a legacy customer twice.
-  return billingModel !== 'per_seat';
+  return billingModel !== 'per_seat' && billingModel !== 'credit';
+}
+
+/**
+ * Billing v3 — flat credit plans (Starter / Team / Scale).
+ *
+ * The plan, not the headcount, carries the monthly credit pool and the
+ * concurrency limit. Seats are gone: `seat_count` is meaningless here, nothing
+ * mutates a Stripe quantity, and the grant comes from `TierConfig.monthlyCredits`
+ * rather than `grantForSeats()`.
+ */
+export function isCreditPlanAccount(billingModel: string | null | undefined): boolean {
+  return billingModel === 'credit';
+}
+
+/**
+ * Does this account pay for sandbox compute?
+ *
+ * SEPARATE from `isPerSeatAccount` on purpose, and the distinction is load-
+ * bearing. Compute metering was gated on "is this per-seat" because per-seat was
+ * the only model that had ever metered. Read literally, that gate hands every
+ * non-per-seat account free unmetered compute — which is precisely what a new
+ * `credit` plan would have received, a revenue hole running straight through the
+ * plans we are introducing.
+ *
+ * The question the meter actually wants to ask is this one. Use
+ * `isPerSeatAccount` only for things that are genuinely about SEATS (Stripe
+ * quantity reconciliation, seat-count credit grants, per-member YOLO tokens).
+ */
+export function accountMetersCompute(billingModel: string | null | undefined): boolean {
+  return isPerSeatAccount(billingModel) || isCreditPlanAccount(billingModel);
 }

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -3,10 +3,12 @@ import type { DailyCreditConfig, TierConfig, TierEntitlements } from '../../type
 // Config-free tier facts live in their own module so genuinely pure consumers
 // (billing-state.ts) can import them without booting env validation. Re-exported
 // here so every existing `from './tiers'` import keeps working — one definition.
-import { isPaidTier, isPerSeatAccount } from './tier-facts';
+import { accountMetersCompute, isCreditPlanAccount, isPaidTier, isPerSeatAccount } from './tier-facts';
 
 export {
   MINIMUM_CREDIT_FOR_RUN,
+  accountMetersCompute,
+  isCreditPlanAccount,
   isLegacyAccount,
   isPaidTier,
   isPerSeatAccount,
@@ -92,7 +94,7 @@ export const MAX_PROJECTS_PER_ACCOUNT = 200;
 export const MAX_CONCURRENT_SANDBOXES_PER_SEAT = 3;
 export const MAX_SEATS_PER_ACCOUNT = 100;
 
-export type BillingModel = 'legacy' | 'per_seat';
+export type BillingModel = 'legacy' | 'per_seat' | 'credit';
 
 /** Default auto-topup for a per-seat account given its current seat count. */
 export function defaultAutoTopupForSeats(seatCount: number): { threshold: number; amount: number } {
@@ -208,17 +210,81 @@ const TIERS: Record<string, TierConfig> = {
   // Billing v2 — per-member seat plan. $25 × seat_count / month.
   // The TIERS entry models a single seat; multi-seat math is in
   // grantForSeats() and applied at subscription create + renew.
+  //
+  // GRANDFATHERED (billing v3). Existing per-seat customers keep this tier
+  // exactly as it is — same price, same $25/seat grant, same 200-session cap,
+  // and `models: ['all']` so their managed-model access is NOT withdrawn under
+  // them. It is `hidden` only so the self-serve grid stops offering it to new
+  // customers; every existing subscription resolves it unchanged.
   per_seat: {
     name: 'per_seat',
-    displayName: 'Team',
+    displayName: 'Team (legacy seats)',
     monthlyPrice: PER_SEAT_PRICE_USD,
     yearlyPrice: 0,
     monthlyCredits: INCLUDED_CREDITS_PER_SEAT_USD,
     canPurchaseCredits: true,
     models: ['all'],
     dailyCreditConfig: null,
-    hidden: false,
+    hidden: true,
     concurrentSessionLimit: 200,
+    entitlements: SELF_SERVE,
+  },
+
+  // ── Billing v3 — flat credit plans ───────────────────────────────────────
+  // The plan carries the credit pool and the concurrency limit; headcount does
+  // not enter the price. Seats priced humans, but the cost driver is agents,
+  // and agents run unattended — a team of two could run fifty of them, and a
+  // Kortix-as-a-Backend customer serves end users who are not seats at all.
+  //
+  // `models: []` — NO included managed LLM. `tierGrantsAllModels` is false, so
+  // the wallet funds sandbox compute only, exactly as the free tier already
+  // works. BYOK, OpenCode and ChatGPT-subscription paths are untouched; a
+  // managed key is billed against the wallet only for tiers that grant models.
+  // This takes Kortix out of a short position on model prices: an upstream
+  // increase can no longer eat a fixed plan's margin.
+  //
+  // Price : credits holds at 1.6 : 1, which is ~48% gross margin when a plan
+  // burns its whole pool (COGS = pool ÷ KORTIX_MARKUP). Keep that ratio if you
+  // add a tier — it is the number that makes the ladder coherent.
+  starter: {
+    name: 'starter',
+    displayName: 'Starter',
+    monthlyPrice: 40,
+    yearlyPrice: 0,
+    monthlyCredits: 25,
+    canPurchaseCredits: true,
+    models: [],
+    dailyCreditConfig: null,
+    hidden: false,
+    concurrentSessionLimit: 3,
+    entitlements: SELF_SERVE,
+  },
+
+  team: {
+    name: 'team',
+    displayName: 'Team',
+    monthlyPrice: 200,
+    yearlyPrice: 0,
+    monthlyCredits: 125,
+    canPurchaseCredits: true,
+    models: [],
+    dailyCreditConfig: null,
+    hidden: false,
+    concurrentSessionLimit: 10,
+    entitlements: SELF_SERVE,
+  },
+
+  scale: {
+    name: 'scale',
+    displayName: 'Scale',
+    monthlyPrice: 800,
+    yearlyPrice: 0,
+    monthlyCredits: 500,
+    canPurchaseCredits: true,
+    models: [],
+    dailyCreditConfig: null,
+    hidden: false,
+    concurrentSessionLimit: 30,
     entitlements: SELF_SERVE,
   },
 
@@ -560,8 +626,23 @@ export function getAllTiers(): TierConfig[] {
   return Object.values(TIERS);
 }
 
+/**
+ * Tiers the product may advertise.
+ *
+ * A tier must also be BUYABLE, not merely unhidden. Checkout resolves a Stripe
+ * price and throws `No price configured for this tier` when there is none, so a
+ * tier defined ahead of its Stripe products would otherwise be listed as an
+ * option that fails the moment anyone clicks it.
+ *
+ * Deriving this instead of carrying a second `hidden` flag means the v3 credit
+ * plans stay dark until their prices are created, then appear on their own —
+ * there is no flag to remember to flip, and no window where the grid offers a
+ * plan the billing system cannot sell.
+ */
 export function getVisibleTiers(): TierConfig[] {
-  return Object.values(TIERS).filter((t) => !t.hidden && t.name !== 'none');
+  return Object.values(TIERS).filter(
+    (t) => !t.hidden && t.name !== 'none' && resolvePriceId(t.name, 'monthly') !== null,
+  );
 }
 
 export function isValidTier(name: string): boolean {

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -3,7 +3,11 @@ import type { DailyCreditConfig, TierConfig, TierEntitlements } from '../../type
 // Config-free tier facts live in their own module so genuinely pure consumers
 // (billing-state.ts) can import them without booting env validation. Re-exported
 // here so every existing `from './tiers'` import keeps working — one definition.
-import { accountMetersCompute, isCreditPlanAccount, isPaidTier, isPerSeatAccount } from './tier-facts';
+// Only what this module CALLS. Everything else from tier-facts reaches
+// consumers through the re-export block below — importing a name here purely to
+// re-export it is a dead local binding (CodeQL flags it, and `isPaidTier` had
+// been sitting unused on this line since before the credit plans landed).
+import { isPerSeatAccount } from './tier-facts';
 
 export {
   MINIMUM_CREDIT_FOR_RUN,

--- a/apps/api/src/llm-gateway/resolution/descriptors.test.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realTiers from '../../billing/services/tiers';
 
 const config: Record<string, unknown> = {
   KORTIX_MANAGED_PROVIDER_ENABLED: true,
@@ -6,7 +7,10 @@ const config: Record<string, unknown> = {
   ASTER_API_URL: 'https://api.asterlab.ai/v1',
 };
 mock.module('../../config', () => ({ config }));
+// Spread the real module — see the note in resolve-candidates.test.ts. Listing
+// three exports by hand silently removed every other one from the registry.
 mock.module('../../billing/services/tiers', () => ({
+  ...realTiers,
   getTierEntitlements: () => ({}),
   llmPriceMarkup: () => 2,
   tierHasEntitlement: () => false,

--- a/apps/api/src/llm-gateway/resolution/no-managed-models-message.test.ts
+++ b/apps/api/src/llm-gateway/resolution/no-managed-models-message.test.ts
@@ -41,3 +41,55 @@ describe('no-managed-models message', () => {
     }
   });
 });
+
+/**
+ * The BYOK failover must respect the managed-model entitlement.
+ *
+ * `resolveCandidates` queues a Kortix-managed model BEHIND the user's own key so
+ * a rate-limited turn doesn't die. That gate read `tier === 'free'` — a literal
+ * string, not the entitlement. It was harmless while every paid tier carried
+ * `models: ['all']`, and became a hole the moment paid plans stopped including
+ * inference: a Starter account whose own key returns 402/403/429 would fail over
+ * to managed tokens its plan forbids, and skip the wallet admission gate on the
+ * way, because that gate is bypassed for precisely these tiers.
+ *
+ * Asserted on source. The branch sits mid-function behind project-secret
+ * resolution and a provider catalog; the property worth protecting is which
+ * predicate decides it, and that is exactly what regressed.
+ */
+const RESOLVE_SRC = await Bun.file(
+  new URL('./resolve-candidates.ts', import.meta.url).pathname,
+).text();
+
+describe('BYOK managed failover entitlement', () => {
+  const SRC = RESOLVE_SRC;
+
+  function code(): string {
+    return SRC.replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//'))
+      .join('\n');
+  }
+
+  test('the failover is gated on the entitlement, not on the literal free tier', () => {
+    const src = code();
+    expect(src).toContain('mayUseManagedModels');
+    expect(src).toContain('!accountIsFreeTierForModels(tier)');
+    // The regression shape: returning the managed candidates under isFreeTier.
+    expect(src).not.toMatch(/return isFreeTier[\s\S]{0,120}byokFallbackCandidates/);
+  });
+
+  test('the platform fee still keys on free-vs-paid, a different question', () => {
+    // A credit plan pays the 10% BYOK platform fee — it is paid. Folding the two
+    // questions back into one variable is what caused the bypass.
+    const src = code();
+    expect(src).toContain("tier === 'free'");
+    expect(src).toMatch(/markup: isFreeTier \? 0 : PLATFORM_FEE_MARKUP/);
+  });
+
+  test('self-hosted keeps the failover', () => {
+    // Billing disabled means no tiers at all; withdrawing the fallback there
+    // would break self-hosted turns that currently survive a key error.
+    expect(code()).toContain('!config.KORTIX_BILLING_INTERNAL_ENABLED ||');
+  });
+});

--- a/apps/api/src/llm-gateway/resolution/no-managed-models-message.test.ts
+++ b/apps/api/src/llm-gateway/resolution/no-managed-models-message.test.ts
@@ -1,0 +1,43 @@
+/**
+ * What a customer is told when their plan has no managed inference.
+ *
+ * Both the free tier and every v3 credit plan (Starter / Team / Scale) block
+ * managed models, but for opposite reasons, and one message cannot serve both.
+ * "Upgrade your plan" is true for free and plainly false for a Starter
+ * subscriber — they are paying; managed models are simply not bundled, and the
+ * remedy is a provider key, not a bigger plan.
+ *
+ * Getting this wrong sends a paying customer to the pricing page to buy
+ * something they already have.
+ */
+import { describe, expect, test } from 'bun:test';
+import { noManagedModelsError } from './resolve-candidates';
+
+describe('no-managed-models message', () => {
+  test('an UNPAID plan is told to upgrade', () => {
+    const err = noManagedModelsError('anthropic/claude-sonnet-4', false);
+    expect(err.message).toContain('requires a paid plan');
+    expect(String(err.suggestion)).toContain('Upgrade your plan');
+  });
+
+  test('a PAID plan is told to bring a key, never to upgrade', () => {
+    const err = noManagedModelsError('anthropic/claude-sonnet-4', true);
+    expect(err.message).not.toContain('requires a paid plan');
+    expect(String(err.suggestion)).not.toContain('Upgrade your plan');
+    expect(String(err.suggestion)).toContain('own provider key');
+  });
+
+  test('both name the model that was refused', () => {
+    for (const paid of [true, false]) {
+      expect(noManagedModelsError('openai/gpt-5', paid).message).toContain('openai/gpt-5');
+    }
+  });
+
+  test('both keep the same machine-readable reason', () => {
+    // Clients branch on the code, not the prose — changing it would be a
+    // breaking API change dressed up as a copy fix.
+    for (const paid of [true, false]) {
+      expect(noManagedModelsError('m', paid).code).toBe('plan_upgrade_required');
+    }
+  });
+});

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { GatewayResolutionError } from '@kortix/llm-gateway';
+import * as realTiers from '../../billing/services/tiers';
 
 let tierByAccount: Record<string, string> = {};
 const getAccountTier = mock(async (accountId: string) => tierByAccount[accountId] ?? 'pro');
@@ -25,7 +26,12 @@ mock.module('../../billing/services/entitlements', () => ({
   getCachedAccountTier,
 }));
 
+// Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
+// lists exports by hand deletes every export it omits. The deletion surfaces in
+// whatever unrelated file imports a missing name next, only when the files are
+// co-run, and is attributed to that file rather than to this stub.
 mock.module('../../billing/services/tiers', () => ({
+  ...realTiers,
   accountIsFreeTierForModels: (tier: string) => tier === 'free',
 }));
 

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -4,7 +4,7 @@ import {
   type UpstreamDescriptor,
 } from '@kortix/llm-gateway';
 import { getCachedAccountTier } from '../../billing/services/entitlements';
-import { accountIsFreeTierForModels } from '../../billing/services/tiers';
+import { accountIsFreeTierForModels, isPaidTier } from '../../billing/services/tiers';
 import { config } from '../../config';
 import {
   getProjectSecretValueForConsumer,
@@ -65,6 +65,32 @@ function byokFallbackCandidates(): UpstreamDescriptor[] {
 
 const PLAN_UPGRADE_SUGGESTION =
   'Upgrade your plan to use this model, or choose a model available on your current plan.';
+
+/**
+ * The same block, for a plan that is PAID but simply does not include managed
+ * inference — every v3 credit plan (Starter / Team / Scale).
+ *
+ * "requires a paid plan" is false and actively misleading there: the customer
+ * is paying. Managed models are not something their plan is too small for, they
+ * are deliberately not bundled, and the remedy is a key rather than an upgrade.
+ */
+const BRING_YOUR_OWN_KEY_SUGGESTION =
+  'This plan does not include managed models. Add your own provider key to use ' +
+  'this model, or pick a model your key covers.';
+
+export function noManagedModelsError(model: string, tierIsPaid: boolean): GatewayResolutionError {
+  return tierIsPaid
+    ? new GatewayResolutionError(
+        'plan_upgrade_required',
+        `"${model}" needs your own provider key on this plan.`,
+        BRING_YOUR_OWN_KEY_SUGGESTION,
+      )
+    : new GatewayResolutionError(
+        'plan_upgrade_required',
+        `"${model}" requires a paid plan.`,
+        PLAN_UPGRADE_SUGGESTION,
+      );
+}
 
 /**
  * `resolveCandidates` throws a `GatewayResolutionError` (never returns an
@@ -241,11 +267,9 @@ export async function resolveCandidates(
     if (config.KORTIX_BILLING_INTERNAL_ENABLED) {
       const tier = await resolveCachedAccountTier(principal.accountId);
       if (accountIsFreeTierForModels(tier)) {
-        throw new GatewayResolutionError(
-          'plan_upgrade_required',
-          `"${effectiveModel}" requires a paid plan.`,
-          PLAN_UPGRADE_SUGGESTION,
-        );
+        // A v3 credit plan lands here too — it pays, it just doesn't bundle
+        // managed inference. Telling that customer to "upgrade" is wrong.
+        throw noManagedModelsError(effectiveModel, isPaidTier(tier ?? 'free'));
       }
     }
     const candidates = managedCandidates(managed);

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -178,7 +178,19 @@ export async function resolveCandidates(
       const tier = config.KORTIX_BILLING_INTERNAL_ENABLED
         ? await resolveCachedAccountTier(principal.accountId)
         : 'self-hosted';
+      // TWO DIFFERENT QUESTIONS. Conflating them is what let a credit plan reach
+      // managed inference through the back door.
+      //
+      // 1. Does this account pay the BYOK platform fee? Free accounts do not;
+      //    every paid account does, including the v3 credit plans.
       const isFreeTier = config.KORTIX_BILLING_INTERNAL_ENABLED && tier === 'free';
+      // 2. May this account use MANAGED inference at all? `models: []` says no
+      //    for Starter/Team/Scale even though they are paid, so this cannot be a
+      //    `tier === 'free'` check — it has to be the same entitlement predicate
+      //    the direct managed path uses. Billing disabled (self-hosted) keeps
+      //    the fallback, as before.
+      const mayUseManagedModels =
+        !config.KORTIX_BILLING_INTERNAL_ENABLED || !accountIsFreeTierForModels(tier);
       const resolvedModelId = effectiveModel.slice(provider.length + 1);
       // Capability flags from the catalog (models.dev enrichment) so the
       // transport can decide which params a reasoning-restricted model
@@ -233,9 +245,15 @@ export async function resolveCandidates(
       // Queue a managed model behind the BYOK key: if the user's key hits a
       // rate-limit / quota / billing error, the failover loop falls over to it
       // (billed as Kortix credits) so the turn doesn't die.
-      return isFreeTier
-        ? byokDescriptors
-        : [...byokDescriptors, ...byokFallbackCandidates()];
+      //
+      // Only for accounts entitled to managed models. Otherwise a plan that
+      // includes no inference could reach it by having its own key rate-limit —
+      // serving managed tokens the plan forbids, and skipping the wallet
+      // admission gate on the way, since that gate is bypassed for exactly the
+      // tiers this fallback would be serving.
+      return mayUseManagedModels
+        ? [...byokDescriptors, ...byokFallbackCandidates()]
+        : byokDescriptors;
     }
     // No shared key configured for this project — provider keys are always
     // project-wide, so there's no other place to look.

--- a/packages/db/migrations/20260806110120042_allow_credit_billing_model.sql
+++ b/packages/db/migrations/20260806110120042_allow_credit_billing_model.sql
@@ -1,0 +1,35 @@
+-- Migration: allow_credit_billing_model
+--
+-- SAFETY HEADER (house rules -- see packages/db/MIGRATIONS.md#zero-downtime-rules).
+-- Tune these down further for large/hot tables; raise statement_timeout only
+-- for an operation you've deliberately reasoned about (e.g. a NOT VALID
+-- constraint's later VALIDATE, or a batched backfill with its own paging).
+set lock_timeout = '2s';
+set statement_timeout = '30s';
+
+-- Billing v3: flat credit plans (Starter / Team / Scale). The plan carries the
+-- monthly credit pool and the concurrency limit; headcount leaves the price.
+-- `credit_accounts.billing_model` needs a third value so those accounts are
+-- distinguishable from the grandfathered per-seat ones, whose behaviour is
+-- unchanged.
+--
+-- WIDENING only: 'legacy' and 'per_seat' both stay valid, so every existing row
+-- still satisfies the constraint and no backfill is needed. Added NOT VALID so
+-- the swap takes no full-table scan under the ACCESS EXCLUSIVE lock;
+-- 20260806110120214_validate_credit_billing_model.sql validates it.
+--
+-- mixed-version-safe: This only ADDS an accepted value. Old code writes solely
+-- 'legacy'/'per_seat', which the replacement still permits, so a pre-deploy
+-- instance cannot write a row the new constraint rejects. In the other
+-- direction, an old instance reading a 'credit' row classifies it as legacy
+-- (isLegacyAccount) and would skip compute metering for it -- under-billing,
+-- never a crash and never a wrong charge. That window is empty in practice:
+-- nothing can hold 'credit' until the v3 Stripe prices exist, and checkout
+-- fails closed without them ("No price configured for this tier").
+alter table "kortix"."credit_accounts"
+  drop constraint "kortix_credit_accounts_billing_model_check";
+
+alter table "kortix"."credit_accounts"
+  add constraint "kortix_credit_accounts_billing_model_check"
+  check ("billing_model" = any (array['legacy'::text, 'per_seat'::text, 'credit'::text]))
+  not valid;

--- a/packages/db/migrations/20260806110120214_validate_credit_billing_model.sql
+++ b/packages/db/migrations/20260806110120214_validate_credit_billing_model.sql
@@ -1,0 +1,20 @@
+-- Migration: validate_credit_billing_model
+--
+-- SAFETY HEADER (house rules -- see packages/db/MIGRATIONS.md#zero-downtime-rules).
+-- Tune these down further for large/hot tables; raise statement_timeout only
+-- for an operation you've deliberately reasoned about (e.g. a NOT VALID
+-- constraint's later VALIDATE, or a batched backfill with its own paging).
+set lock_timeout = '2s';
+-- VALIDATE takes a full scan of credit_accounts. It holds only SHARE UPDATE
+-- EXCLUSIVE (reads and writes continue), so the generous ceiling buys the scan
+-- room without blocking traffic.
+set statement_timeout = '5min';
+
+-- Completes 20260806110120042_allow_credit_billing_model.sql. That migration
+-- added the widened constraint NOT VALID to keep the swap off the hot path;
+-- this proves the existing rows against it.
+--
+-- Cannot fail on real data: the new constraint is a strict superset of the old
+-- one, and the old one was already enforced for every row.
+alter table "kortix"."credit_accounts"
+  validate constraint "kortix_credit_accounts_billing_model_check";


### PR DESCRIPTION
Implements Marko's billing direction: credit plans instead of seats, managed
LLMs off entirely, existing seat customers grandfathered.

> switching away from Seat based plans, to like "credit" based plans, which just
> include higher Session concurrency limits & higher credit pools for a given mth
>
> Also as said in the past inclined to move away from any included LLM's or make
> it very minimal

## The ladder

| Plan | Price/mo | Included credits | Concurrent sessions | Managed LLM |
|---|---|---|---|---|
| Starter | $40 | 2,500 ($25) | 3 | none |
| Team | $200 | 12,500 ($125) | 10 | none |
| Scale | $800 | 50,000 ($500) | 30 | none |

Price : credits holds at **1.6 : 1** across the ladder — ~48% gross margin when a
plan burns its whole pool (COGS = pool ÷ 1.2 markup). A test asserts the ratio,
so a tier added off-ratio fails rather than silently pricing at a different
margin.

Both entitlements Marko named already existed; they were just multiplied by seat
count. `concurrentSessionLimit` is the real enforced cap (HTTP 429, with the
per-account operator override intact — which is why our own account at 100,000
is unaffected).

## LLMs off

`models: []`. `tierGrantsAllModels` → false → `resolve-candidates.ts` refuses
managed models. Verified this **blocks** rather than makes them free: the branch
throws `plan_upgrade_required`. BYOK, OpenCode and ChatGPT-subscription paths
don't go through that branch and are untouched.

This is the mechanism the free tier already uses — no new machinery.

## Grandfathering

`per_seat` keeps its price, its $25/seat grant, its 200-session cap, and
`models: ['all']` — their paid-for inference is **not** withdrawn under them.
It's `hidden` so new customers don't land on it, and a test asserts it still
resolves for existing subscriptions.

## Two problems found while building this

**Compute metering would not have run on the new plans.** `startComputeSession`
gated on `isPerSeatAccount`, and the tick query filtered
`billingModel = 'per_seat'`. Read literally, that hands every other billing model
free unmetered compute — an unbilled hole straight through the plans being
introduced. Replaced with `accountMetersCompute` (per_seat OR credit) in both
places, plus a test that the SQL list and the predicate cannot drift apart.

**The refusal message was wrong for these customers.** It said `"X" requires a
paid plan.` A Starter subscriber *is* paying — managed models simply aren't
bundled, and the remedy is a provider key, not an upgrade. Paid plans now get a
bring-your-own-key message. The machine-readable `code` is unchanged, since
clients branch on it.

## Safety

Visibility is **derived from buyability**: `getVisibleTiers()` now also requires a
resolvable Stripe price. So these plans stay dark until their prices exist and
appear on their own afterwards — no flag to remember to flip, and no window where
the grid offers a plan checkout cannot sell (it already throws `No price
configured for this tier`).

**Nothing is purchasable in this PR.** The Stripe products don't exist yet, so
this is inert in production by construction.

Migration widens the `billing_model` CHECK to accept `credit`, added `NOT VALID`
then validated in a follow-up migration, with a `mixed-version-safe:` note: it
only ADDS a value, old code can't write a row the new constraint rejects, and the
reverse direction is under-billing not corruption — a window that is empty in
practice because nothing can hold `credit` until the prices exist.

## Verification

Suites run against a stashed clean-main baseline, since this repo's bun suite has
pre-existing cross-file `mock.module` leaks:

| | pass | fail |
|---|---|---|
| baseline (clean `main`) | 415 | 81 |
| this branch | **445** | **81** |

`comm`-diff of the failure sets: **zero new failures**, +30 passing.

```
$ pnpm --filter @kortix/db lint
Found 0 issues in 59 files 🎉

$ bunx tsc --noEmit      # apps/api
clean (besides the pre-existing missing `re2js`)
```

While diagnosing, three of my own tests failed only when co-run — the gateway
suite deliberately stubs `accountIsFreeTierForModels` to `tier === 'free'`, and
`mock.module` shares one registry. Fixed on my side by asserting the tier data
and `tierGrantsAllModels` instead of another suite's stub, and separately made
both gateway stubs spread the real module so they stop deleting unlisted exports.

## Needs a human before it can be sold

1. Create the Stripe products/prices for `starter`, `team`, `scale` (monthly,
   prod + staging + dev) and paste the ids into `STRIPE_PRICES_*` in `tiers.ts`.
   The plans go live the moment those exist.
2. Web pricing page + upgrade modal still describe per-seat. Separate PR.

## One number worth a second look

Starter's concurrency is **3**, against the 200 that `per_seat` carries today.
That was the intent of the (dead) `MAX_CONCURRENT_SANDBOXES_PER_SEAT = 3`
constant, and no existing customer is affected because seats are grandfathered.
But it is a 66× tightening relative to today's paid cap, so it's the one number
I'd sanity-check against real usage before the prices go live.
