### PR TITLE
fix(web): de-noise old-browser DOM null-deref on marketing homepage (scrollLeft / appendChild)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -22,6 +22,7 @@ import {
   isIOSWebViewWebKitBridgeNoise,
   isKnownBrowserNoiseMessage,
   isNonErrorUndefinedRejectionNoise,
+  isOldBrowserDomNullDerefNoise,
   isOldBrowserSyntaxParseError,
   isOldWebkitRegexNoiseMessage,
   isOperationErrorPopErrorScopeNoise,
@@ -2248,6 +2249,572 @@ test('does NOT suppress a real app SyntaxError from a de-minified first-party fr
       filename: 'app:///apps/web/src/features/foo.tsx',
     }),
     false,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Old-browser third-party-library DOM null-deref noise on the marketing
+// homepage — two SIBLING Better Stack prod patterns (Kortix Frontend prod,
+// application_id 2346967), both `TypeError: Cannot read properties of null
+// (reading '<X>')` (V8 wording) from minified third-party library internals
+// running on VERY OLD browsers (Windows 7 Chrome, Chrome 95 Linux) hitting
+// `https://kortix.com/` (marketing homepage). UNCAUGHT global `onerror`
+// (`auto.browser.global_handlers.onerror`, `handled:false` — never reached a
+// React error boundary). 2 occurrences each, 0 identified users, marketing
+// page only — browser-compatibility noise, not a product defect.
+//
+//   Pattern 1: e02e022f7433a02c7acdc9ae33c3dd1bdec938eeb694f0bf83d290c1d696d853
+//   `Cannot read properties of null (reading 'scrollLeft')`, call site
+//   function `measureScroll` in chunk `0d5wqj98qv1e9.js` (minified). Last
+//   2026-08-06 11:11:14 UTC.
+//
+//   Pattern 2: 8ab4ae816505dc3a17c7b8258e6894b3964ab7d10056afc47477833824fa8648
+//   `Cannot read properties of null (reading 'appendChild')`, call site
+//   function `ft` in chunk `0foj1ouh5ijrj.js` (minified). Same timestamp.
+//
+// `scrollLeft` and `appendChild` are STANDARD DOM API method names that
+// first-party React code DOES call, so the matcher requires BOTH the exact
+// message AND a NEGATIVE guard (any resolved first-party `apps/web/src/…`
+// frame → keep reporting). The prod events carry only minified chunk frames +
+// `<anonymous>`, so the negative guard does NOT fire for them.
+// ---------------------------------------------------------------------------
+
+const MEASURE_SCROLL_CHUNK = 'app:///_next/static/chunks/0d5wqj98qv1e9.js'
+const APPEND_CHILD_CHUNK = 'app:///_next/static/chunks/0foj1ouh5ijrj.js'
+
+test('classifies the production scrollLeft measureScroll noise (Pattern 1, exact prod frames)', () => {
+  // Exact shape of Better Stack pattern e02e022f…: V8 wording, `measureScroll`
+  // in the minified `0d5wqj98qv1e9` chunk + an `<anonymous>` frame, UNCAUGHT.
+  const frames = [
+    { filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' },
+    { filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' },
+    { filename: '<anonymous>', function: '?' },
+  ]
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "TypeError: Cannot read properties of null (reading 'scrollLeft')",
+      frames,
+    }),
+    true,
+  )
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "Cannot read properties of null (reading 'scrollLeft')",
+      frames,
+    }),
+    true,
+  )
+  // The Sentry `beforeSend` gate suppresses it.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of null (reading 'scrollLeft')",
+            stacktrace: { frames },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('classifies the production appendChild ft noise (Pattern 2, exact prod frames)', () => {
+  // Exact shape of Better Stack pattern 8ab4ae81…: V8 wording, `ft` in the
+  // minified `0foj1ouh5ijrj` chunk, 3 frames, UNCAUGHT.
+  const frames = [
+    { filename: APPEND_CHILD_CHUNK, function: 'ft' },
+    { filename: APPEND_CHILD_CHUNK, function: 'ft' },
+    { filename: APPEND_CHILD_CHUNK, function: 'ft' },
+  ]
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "TypeError: Cannot read properties of null (reading 'appendChild')",
+      frames,
+    }),
+    true,
+  )
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "Cannot read properties of null (reading 'appendChild')",
+      frames,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of null (reading 'appendChild')",
+            stacktrace: { frames },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses both old-browser DOM null-deref patterns through all three capture-path wrappers', () => {
+  // `stripErrorWrappers` strips `Unhandled promise rejection: ` and
+  // `<Word>Error: ` (e.g. `TypeError: `) prefixes so all capture paths
+  // (window.onerror, onunhandledrejection, Sentry exception) classify
+  // consistently.
+  const chunkFrame = { filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' }
+  for (const message of [
+    "Cannot read properties of null (reading 'scrollLeft')",
+    "TypeError: Cannot read properties of null (reading 'scrollLeft')",
+    "Unhandled promise rejection: TypeError: Cannot read properties of null (reading 'scrollLeft')",
+  ]) {
+    assert.equal(
+      isOldBrowserDomNullDerefNoise({ message, frames: [chunkFrame] }),
+      true,
+      `expected "${message}" to be classified as old-browser DOM null-deref noise`,
+    )
+  }
+  const appendFrame = { filename: APPEND_CHILD_CHUNK, function: 'ft' }
+  for (const message of [
+    "Cannot read properties of null (reading 'appendChild')",
+    "TypeError: Cannot read properties of null (reading 'appendChild')",
+    "Unhandled promise rejection: TypeError: Cannot read properties of null (reading 'appendChild')",
+  ]) {
+    assert.equal(
+      isOldBrowserDomNullDerefNoise({ message, frames: [appendFrame] }),
+      true,
+      `expected "${message}" to be classified as old-browser DOM null-deref noise`,
+    )
+  }
+})
+
+test('classifies the old-JSC wording variants of both sibling patterns (different engine, same class)', () => {
+  // Old JSC (old Safari/iOS) phrases a null property access as
+  // `Cannot read property '<X>' of null` — different engine, same old-browser
+  // DOM null-deref class. The matcher must catch both engine wordings.
+  const chunkFrame = { filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' }
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "Cannot read property 'scrollLeft' of null",
+      frames: [chunkFrame],
+    }),
+    true,
+  )
+  const appendFrame = { filename: APPEND_CHILD_CHUNK, function: 'ft' }
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "Cannot read property 'appendChild' of null",
+      frames: [appendFrame],
+    }),
+    true,
+  )
+})
+
+test('classifies the frameless window.onerror variant as noise (message alone is specific)', () => {
+  // A frameless window.onerror capture carries the exact message + no
+  // `filename`. `measureScroll` and the minified `ft` are third-party library
+  // internals, and a real first-party `el.scrollLeft` / `parent.appendChild`
+  // null-deref almost always has a resolvable frame with a stack, so a
+  // frameless capture with one of these exact messages is safe to drop.
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "Cannot read properties of null (reading 'scrollLeft')",
+    }),
+    true,
+  )
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "Cannot read properties of null (reading 'appendChild')",
+    }),
+    true,
+  )
+  // The runtime (window.onerror) gate suppresses a frameless capture too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "TypeError: Cannot read properties of null (reading 'scrollLeft')",
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "TypeError: Cannot read properties of null (reading 'appendChild')",
+    }),
+    true,
+  )
+})
+
+test('suppresses the old-browser DOM null-deref noise via the runtime (window.onerror) gate with a chunk filename', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "TypeError: Cannot read properties of null (reading 'scrollLeft')",
+      filename: MEASURE_SCROLL_CHUNK,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "Cannot read properties of null (reading 'appendChild')",
+      filename: APPEND_CHILD_CHUNK,
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the old-browser DOM null-deref when a first-party frame is present (real regression)', () => {
+  // `scrollLeft` and `appendChild` are STANDARD DOM API method names that
+  // first-party React code DOES call (e.g. `apps/web/src/hooks/use-proximity-
+  // hover.ts` reads `container.scrollLeft`, portal/tooltip ref-callbacks call
+  // `appendChild`). A real first-party null-deref de-minifies (via Sentry's
+  // sourcemap resolution) to a frame whose filename contains `apps/web/src/`
+  // and MUST keep reporting — the negative guard is the load-bearing over-match
+  // protection.
+  const firstPartyFrames = [
+    { filename: 'app:///apps/web/src/hooks/use-proximity-hover.ts' },
+    { filename: 'apps/web/src/features/workspace/project-sidebar/session-title.tsx' },
+    { filename: 'app:///apps/web/src/components/ui/portal.tsx' },
+  ]
+  for (const frames of [
+    [firstPartyFrames[0]],
+    [firstPartyFrames[1]],
+    [firstPartyFrames[2]],
+    // A stack that mixes a first-party frame with the minified chunk frame
+    // STILL keeps reporting — the first-party frame is the actionable anchor.
+    [firstPartyFrames[0], { filename: MEASURE_SCROLL_CHUNK }],
+    [{ filename: APPEND_CHILD_CHUNK }, firstPartyFrames[2]],
+  ]) {
+    assert.equal(
+      isOldBrowserDomNullDerefNoise({
+        message: "Cannot read properties of null (reading 'scrollLeft')",
+        frames,
+      }),
+      false,
+      `expected first-party scrollLeft null-deref with frames ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      isOldBrowserDomNullDerefNoise({
+        message: "Cannot read properties of null (reading 'appendChild')",
+        frames,
+      }),
+      false,
+      `expected first-party appendChild null-deref with frames ${JSON.stringify(frames)} to keep reporting`,
+    )
+  }
+  // And via the Sentry `beforeSend` gate.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of null (reading 'scrollLeft')",
+            stacktrace: {
+              frames: [{ filename: 'app:///apps/web/src/hooks/use-proximity-hover.ts' }],
+            },
+          },
+        ],
+      },
+    }),
+    false,
+  )
+  // And via the runtime (window.onerror) gate with a first-party filename.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "TypeError: Cannot read properties of null (reading 'appendChild')",
+      filename: 'app:///apps/web/src/components/ui/portal.tsx',
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a near-worded null-deref message (over-match guard)', () => {
+  // Only the EXACT V8/old-JSC messages for `scrollLeft` and `appendChild` are
+  // noise. A different DOM method, a different access pattern, or a near-
+  // worded regression keeps reporting.
+  const chunkFrame = { filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' }
+  for (const message of [
+    // Different DOM method on null — not the two anchored methods.
+    "Cannot read properties of null (reading 'scrollTop')",
+    "Cannot read properties of null (reading 'removeChild')",
+    "Cannot read properties of null (reading 'appendChild') extra",
+    // `undefined` (not `null`) — a different null-deref class.
+    "Cannot read properties of undefined (reading 'scrollLeft')",
+    "Cannot read properties of undefined (reading 'appendChild')",
+    // A real first-party-shaped message that happens to mention the method.
+    "Cannot read properties of null (reading 'appendChild') in portal mount",
+    // Substring without the exact wrapper.
+    "scrollLeft is null",
+    "appendChild failed",
+  ]) {
+    assert.equal(
+      isOldBrowserDomNullDerefNoise({ message, frames: [chunkFrame] }),
+      false,
+      `expected near-worded message "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a non-V8/JSC engine wording (over-match guard)', () => {
+  // SpiderMonkey (Firefox) phrases a null property access as
+  // `null is not an object (evaluating '<expr>')` or
+  // `can't access property "<m>"<…>` — different engine wordings the matcher
+  // does NOT anchor on (the prod events are V8/old-JSC from Chrome). Keep
+  // reporting so a genuine Firefox null-deref regression stays observable.
+  const chunkFrame = { filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' }
+  for (const message of [
+    "null is not an object (evaluating 'el.scrollLeft')",
+    "null is not an object (evaluating 'parent.appendChild')",
+    'can\'t access property "scrollLeft" of null',
+    'can\'t access property "appendChild" of null',
+  ]) {
+    assert.equal(
+      isOldBrowserDomNullDerefNoise({ message, frames: [chunkFrame] }),
+      false,
+      `expected non-V8/JSC message "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('suppresses the scrollLeft noise when the only frame is the <anonymous> throw site (prod shape)', () => {
+  // The prod Pattern 1 stack ends with an `<anonymous>` frame after the two
+  // `measureScroll` chunk frames. A capture that surfaces ONLY the
+  // `<anonymous>` throw site (e.g. a truncated stack) still classifies as
+  // noise — `<anonymous>` is not a resolved first-party source, so the
+  // negative guard does not fire.
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "Cannot read properties of null (reading 'scrollLeft')",
+      frames: [{ filename: '<anonymous>', function: '?' }],
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of null (reading 'scrollLeft')",
+            stacktrace: { frames: [{ filename: '<anonymous>', function: '?' }] },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the appendChild noise when the stack is fully minified chunk frames (prod shape)', () => {
+  // The prod Pattern 2 stack is 3 frames all in the `0foj1ouh5ijrj` chunk.
+  // None resolve to a first-party `apps/web/src/…` path, so the negative
+  // guard does not fire.
+  const frames = [
+    { filename: APPEND_CHILD_CHUNK, function: 'ft' },
+    { filename: APPEND_CHILD_CHUNK, function: 'ft' },
+    { filename: APPEND_CHILD_CHUNK, function: 'ft' },
+  ]
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: "TypeError: Cannot read properties of null (reading 'appendChild')",
+            stacktrace: { frames },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the old-JSC wording variants through both gates (runtime + beforeSend)', () => {
+  // The old-JSC wording `Cannot read property '<X>' of null` must also be
+  // suppressed by both the runtime (window.onerror) gate and the Sentry
+  // `beforeSend` gate, not just the matcher.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "Cannot read property 'scrollLeft' of null",
+      filename: MEASURE_SCROLL_CHUNK,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read property 'appendChild' of null",
+            stacktrace: { frames: [{ filename: APPEND_CHILD_CHUNK, function: 'ft' }] },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a null-deref on a DIFFERENT DOM method (over-match guard, first-party stays observable)', () => {
+  // Only `scrollLeft` and `appendChild` are anchored. A null-deref on any
+  // other DOM method — even from a minified chunk on an old browser — keeps
+  // reporting, because it is not one of the two observed prod patterns and
+  // may be a real first-party or third-party regression worth triaging.
+  const chunkFrame = { filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' }
+  for (const message of [
+    "Cannot read properties of null (reading 'scrollTop')",
+    "Cannot read properties of null (reading 'scrollWidth')",
+    "Cannot read properties of null (reading 'removeChild')",
+    "Cannot read properties of null (reading 'insertBefore')",
+    "Cannot read properties of null (reading 'appendChild')x", // trailing char
+    "Cannot read properties of null (reading 'el.scrollLeft')", // dotted expr
+    "Cannot read properties of null (reading 'parent.appendChild')", // dotted
+  ]) {
+    assert.equal(
+      isOldBrowserDomNullDerefNoise({ message, frames: [chunkFrame] }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a frameless non-matching message even with the scrollLeft/appendChild substring (over-match guard)', () => {
+  // The matcher anchors on the EXACT V8/old-JSC message, not a substring. A
+  // frameless capture with a message that merely CONTAINS `scrollLeft` or
+  // `appendChild` (but is not the exact null-deref wording) keeps reporting.
+  for (const message of [
+    "Cannot read properties of undefined (reading 'scrollLeft')",
+    "Cannot read properties of null (reading 'el.scrollLeft')",
+    "el.scrollLeft is null",
+    "Cannot read properties of null (reading 'parent.appendChild')",
+    "TypeError: parent.appendChild is not a function",
+  ]) {
+    assert.equal(
+      isOldBrowserDomNullDerefNoise({ message }),
+      false,
+      `expected frameless "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message }),
+      false,
+      `expected runtime "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a non-first-party but resolvable chunk URL for a different message shape (regression guard)', () => {
+  // A Vercel `?dpl=dpl_…` chunk URL is NOT a first-party `apps/web/src/…`
+  // path, so it does not trip the negative guard. But the matcher only
+  // suppresses the EXACT `scrollLeft`/`appendChild` null-deref wording — a
+  // different message from the same chunk URL keeps reporting.
+  const vercelChunk = 'https://kortix.com/_next/static/chunks/0d5wqj98qv1e9.js?dpl=dpl_abc123'
+  for (const message of [
+    "Cannot read properties of null (reading 'foo')",
+    'Something completely different',
+    "Cannot read properties of null (reading 'appendChild')", // <- this one IS noise
+  ]) {
+    const expected = message === "Cannot read properties of null (reading 'appendChild')"
+    assert.equal(
+      isOldBrowserDomNullDerefNoise({ message, frames: [{ filename: vercelChunk }] }),
+      expected,
+      `expected "${message}" from Vercel chunk to ${expected ? 'be noise' : 'keep reporting'}`,
+    )
+  }
+})
+
+test('the two prod patterns classify as noise independently (sibling isolation)', () => {
+  // Each sibling pattern must classify as noise on its own — the matcher is
+  // not coupled to both being present. This pins the independence so a future
+  // refactor that, say, only handles `scrollLeft` does not silently let
+  // `appendChild` leak back to Better Stack.
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "Cannot read properties of null (reading 'scrollLeft')",
+      frames: [{ filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' }],
+    }),
+    true,
+  )
+  assert.equal(
+    isOldBrowserDomNullDerefNoise({
+      message: "Cannot read properties of null (reading 'appendChild')",
+      frames: [{ filename: APPEND_CHILD_CHUNK, function: 'ft' }],
+    }),
+    true,
+  )
+})
+
+test('suppresses both prod patterns through the runtime gate with the exact prod chunk filename', () => {
+  // End-to-end pin: the exact production Better Stack shapes — message + the
+  // prod chunk filename — are suppressed by the runtime (window.onerror)
+  // gate, which is the gate that actually receives the UNCAUGHT global
+  // `onerror` captures (`auto.browser.global_handlers.onerror`).
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "TypeError: Cannot read properties of null (reading 'scrollLeft')",
+      filename: MEASURE_SCROLL_CHUNK,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "TypeError: Cannot read properties of null (reading 'appendChild')",
+      filename: APPEND_CHILD_CHUNK,
+    }),
+    true,
+  )
+})
+
+test('suppresses both prod patterns through the Sentry beforeSend gate with the exact prod stack', () => {
+  // End-to-end pin: the exact production Better Stack shapes — message + the
+  // prod stack frames — are suppressed by the Sentry `beforeSend` gate.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of null (reading 'scrollLeft')",
+            stacktrace: {
+              frames: [
+                { filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' },
+                { filename: MEASURE_SCROLL_CHUNK, function: 'measureScroll' },
+                { filename: '<anonymous>', function: '?' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of null (reading 'appendChild')",
+            stacktrace: {
+              frames: [
+                { filename: APPEND_CHILD_CHUNK, function: 'ft' },
+                { filename: APPEND_CHILD_CHUNK, function: 'ft' },
+                { filename: APPEND_CHILD_CHUNK, function: 'ft' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
   )
 })
 

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -389,6 +389,78 @@ const OLD_BROWSER_SYNTAX_PARSE_NOISE_PATTERNS: ReadonlyArray<RegExp> = [
   /^Cannot use import statement outside a module$/,
 ];
 
+// Old-browser third-party-library DOM null-deref noise on the marketing
+// homepage. Two SIBLING patterns, both `TypeError: Cannot read properties of
+// null (reading '<X>')` (V8 wording; old JSC says `Cannot read property '<X>'
+// of null`) from minified third-party library internals running on VERY OLD
+// browsers hitting the marketing homepage (`https://kortix.com/`):
+//
+//   Pattern 1 (2 occurrences, last 2026-08-06 11:11:14 UTC):
+//     Better Stack pattern
+//     e02e022f7433a02c7acdc9ae33c3dd1bdec938eeb694f0bf83d290c1d696d853
+//     `Cannot read properties of null (reading 'scrollLeft')`, call site
+//     function `measureScroll` in chunk `0d5wqj98qv1e9.js` (minified). User
+//     agents: Windows 7 Chrome (very old) + Chrome 95 Linux (very old).
+//     Mechanism `auto.browser.global_handlers.onerror` (UNCAUGHT,
+//     `handled:false` — never reached a React error boundary).
+//
+//   Pattern 2 (2 occurrences — sibling, same timestamp):
+//     Better Stack pattern
+//     8ab4ae816505dc3a17c7b8258e6894b3964ab7d10056afc47477833824fa8648
+//     `Cannot read properties of null (reading 'appendChild')`, call site
+//     function `ft` in chunk `0foj1ouh5ijrj.js` (minified). Same old UAs, same
+//     UNCAUGHT global `onerror`, same marketing homepage.
+//
+// Classification: browser-compatibility noise. `measureScroll` and `ft` are
+// THIRD-PARTY library internals (a smooth-scroll / scroll-measurement library
+// and an animation/DOM-manipulation helper respectively), not first-party
+// Kortix code — the minified call-site function names (`measureScroll`, `ft`)
+// do not appear in `apps/web/src/…` source. The throws happen because very old
+// browsers (Win7 Chrome, Chrome 95) have quirkier DOM behavior: a scroll-
+// measurement helper reaches for a DOM element that resolved to `null` (the
+// element was not in the DOM yet, or the old browser returned `null` from a
+// `querySelector`/`getBoundingClientRect` path), then accesses `.scrollLeft` on
+// it → `TypeError`. Same for `appendChild`: an animation library calls
+// `parent.appendChild(child)` on a `parent` that resolved to `null` in the old
+// browser. These are 2 occurrences each, 0 identified users, marketing page
+// only — not a product flow, not a deterministic app regression.
+//
+// `scrollLeft` and `appendChild` are STANDARD DOM API method names that
+// first-party React code DOES call (e.g. `apps/web/src/hooks/use-proximity-
+// hover.ts` reads `container.scrollLeft`, `apps/web/src/features/workspace/
+// project-sidebar/session-title.tsx` sets `el.scrollLeft`, ref-callback
+// `appendChild` calls exist in portal/tooltip code), so matching on the bare
+// message would swallow a real first-party null-deref regression. The matcher
+// therefore requires BOTH the exact V8/old-JSC message AND a NEGATIVE guard:
+// if ANY frame (or the window.onerror `filename`) resolves to a de-minified
+// first-party `apps/web/src/…` source path, the event KEEPS reporting — that
+// means our own code is the null-deref culprit and is actionable to fix. The
+// prod events carry only minified `app:///_next/static/chunks/…` chunk frames
+// (the third-party library internals) + an `<anonymous>` frame, so the
+// negative guard does NOT fire for them. A frameless capture with one of these
+// exact messages still classifies as noise: `measureScroll` and the minified
+// `ft` are third-party library internals, and the messages are specific
+// enough (the DOM method names `scrollLeft`/`appendChild` paired with `null`
+// access) that a frameless capture is safe to drop — a real first-party
+// `el.scrollLeft` / `parent.appendChild` null-deref almost always has a
+// resolvable frame with a stack. Deliberately NOT added to
+// `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame
+// context, so a bare-string match there would swallow a real first-party
+// null-deref regression the negative guard exists to preserve; the frame-aware
+// `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`) is the only
+// safe gate. The runtime `window.onerror` gate
+// (`shouldIgnoreBrowserRuntimeNoise`) is also wired so a frameless onerror
+// capture with the exact message + no first-party `filename` drops.
+const OLD_BROWSER_DOM_NULL_DEREF_NOISE_PATTERNS: ReadonlyArray<RegExp> = [
+  // V8 (Chrome/Edge/Opera): the observed production wording for both siblings.
+  /^Cannot read properties of null \(reading 'scrollLeft'\)$/,
+  /^Cannot read properties of null \(reading 'appendChild'\)$/,
+  // Old JSC (old Safari/iOS): `Cannot read property '<X>' of null` — different
+  // engine, same old-browser DOM null-deref class.
+  /^Cannot read property 'scrollLeft' of null$/,
+  /^Cannot read property 'appendChild' of null$/,
+];
+
 // Android System WebView native-bridge instrumentation noise. The Android
 // WebView injects a synthetic `app://navigation_performance_logger_android`
 // script that records navigation timing (FBNavResponseStart / FBNavDomContent-
@@ -1647,6 +1719,65 @@ export function isOldBrowserSyntaxParseError(input: {
     ...(input.frames ?? []).map((frame) => frame?.filename),
   ];
   return sources.some((filename) => isMinifiedChunkSource(filename));
+}
+
+/**
+ * Whether a Sentry / window.onerror event is the old-browser third-party-
+ * library DOM null-deref noise class: a `TypeError: Cannot read properties of
+ * null (reading 'scrollLeft')` / `… (reading 'appendChild')` (V8 wording; old
+ * JSC says `Cannot read property '<X>' of null`) thrown from minified
+ * THIRD-PARTY library internals (`measureScroll` in a scroll-measurement
+ * library, `ft` in an animation/DOM-manipulation helper) running on VERY OLD
+ * browsers (Windows 7 Chrome, Chrome 95 Linux) hitting the marketing
+ * homepage. The browser's quirkier DOM behavior returns `null` where modern
+ * browsers return an element, and the library accesses `.scrollLeft` /
+ * `.appendChild` on the `null` → `TypeError`. UNCAUGHT global `onerror`
+ * (`handled:false` — never reaches a React error boundary), 2 occurrences
+ * each, 0 identified users, marketing page only — browser-compatibility
+ * noise, not a product defect.
+ *
+ * `scrollLeft` and `appendChild` are STANDARD DOM API method names that
+ * first-party React code DOES call (e.g. `use-proximity-hover.ts` reads
+ * `container.scrollLeft`, `session-title.tsx` sets `el.scrollLeft`, portal/
+ * tooltip ref-callbacks call `appendChild`), so the matcher requires BOTH the
+ * exact V8/old-JSC message AND a NEGATIVE guard: if ANY frame (or the
+ * window.onerror `filename`) resolves to a de-minified first-party
+ * `apps/web/src/…` source path, the event KEEPS reporting — our own code is
+ * the null-deref culprit and is actionable to fix. The production noise
+ * events carry only minified `app:///_next/static/chunks/…` chunk frames
+ * (the third-party library internals) + an `<anonymous>` frame, so the
+ * negative guard does NOT fire for them. A frameless capture with one of
+ * these exact messages still classifies as noise — `measureScroll` and the
+ * minified `ft` are third-party library internals, and a real first-party
+ * `el.scrollLeft` / `parent.appendChild` null-deref almost always has a
+ * resolvable frame with a stack. See
+ * `OLD_BROWSER_DOM_NULL_DEREF_NOISE_PATTERNS` for the full rationale and the
+ * two production Better Stack patterns.
+ */
+export function isOldBrowserDomNullDerefNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const message = normalizeString(input.message);
+  if (!message) return false;
+  const stripped = stripErrorWrappers(message);
+  if (!OLD_BROWSER_DOM_NULL_DEREF_NOISE_PATTERNS.some((re) => re.test(stripped))) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame (or
+  // window.onerror `filename`) means our own code is the null-deref culprit →
+  // actionable; keep reporting so the call site can be found + fixed. A real
+  // first-party `el.scrollLeft` / `parent.appendChild` null-deref de-minifies to
+  // `apps/web/src/…` and is never hidden.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -2950,6 +3081,19 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Old-browser third-party-library DOM null-deref noise on the marketing
+  // homepage — `Cannot read properties of null (reading 'scrollLeft')` /
+  // `… (reading 'appendChild')` (V8) / `Cannot read property '<X>' of null`
+  // (old JSC) from minified third-party library internals (`measureScroll`,
+  // `ft`) on very old browsers (Win7 Chrome, Chrome 95). Requires the exact
+  // message AND a NEGATIVE guard: a resolved first-party `apps/web/src/…`
+  // filename means our own code is the null-deref culprit → actionable; keep
+  // reporting. A frameless window.onerror capture with the exact message + no
+  // first-party filename drops. See `isOldBrowserDomNullDerefNoise`.
+  if (isOldBrowserDomNullDerefNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
   // Android System WebView native-bridge instrumentation noise — the WebView's
   // injected `app://navigation_performance_logger_android` script
   // `sendDataToNative` → `postMessage` to a GC'd Java bridge object. Requires
@@ -3238,6 +3382,26 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // SyntaxErrors. The `beforeSend` hook (which calls this helper) is the only
   // safe gate because it can anchor on the chunk frame.
   if (isOldBrowserSyntaxParseError({ message, frames })) {
+    return true;
+  }
+
+  // Old-browser third-party-library DOM null-deref noise on the marketing
+  // homepage — `Cannot read properties of null (reading 'scrollLeft')` /
+  // `… (reading 'appendChild')` (V8) / `Cannot read property '<X>' of null`
+  // (old JSC) from minified third-party library internals (`measureScroll`,
+  // `ft`) on very old browsers (Win7 Chrome, Chrome 95). Requires the exact
+  // message AND a NEGATIVE guard: a resolved first-party `apps/web/src/…`
+  // frame means our own code is the null-deref culprit → actionable; keep
+  // reporting. The prod events carry only minified `app:///_next/static/
+  // chunks/…` chunk frames + `<anonymous>`, so the negative guard does NOT
+  // fire for them. A frameless capture with one of these exact messages still
+  // classifies as noise. NOTE: deliberately NOT added to
+  // `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame
+  // context, so a bare-string match there would swallow a real first-party
+  // `el.scrollLeft` / `parent.appendChild` null-deref the negative guard
+  // exists to preserve; the frame-aware `beforeSend` hook (which calls this
+  // helper) is the only safe gate. See `isOldBrowserDomNullDerefNoise`.
+  if (isOldBrowserDomNullDerefNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo

Non-visual change — telemetry noise-classification gate. No screen recording applies. Proof: 256 noise-tests pass (was 238), including 18 new tests pinning both production events through both the Sentry `beforeSend` gate and the runtime `window.onerror` gate.

```
bun test src/lib/browser-error-noise.test.mts
# 256 pass
# 0 fail
# Ran 256 tests across 1 file.
```

## Why

Two sibling Better Stack production error patterns (Kortix Frontend prod, `application_id 2346967`) were paging as UNCAUGHT global `onerror` errors from very old browsers hitting the marketing homepage. They are browser-compatibility noise from third-party library internals, not product defects — they should never page Better Stack.

| Pattern | Better Stack id | Message | Call site | Count |
|---|---|---|---|---|
| 1 | `e02e022f7433a02c7acdc9ae33c3dd1bdec938eeb694f0bf83d290c1d696d853` | `Cannot read properties of null (reading 'scrollLeft')` | `measureScroll` in `0d5wqj98qv1e9.js` | 2 |
| 2 | `8ab4ae816505dc3a17c7b8258e6894b3964ab7d10056afc47477833824fa8648` | `Cannot read properties of null (reading 'appendChild')` | `ft` in `0foj1ouh5ijrj.js` | 2 |

- **Mechanism:** `auto.browser.global_handlers.onerror` (UNCAUGHT, `handled:false`) — never reached a React error boundary.
- **User agents:** Windows 7 Chrome (very old) + Chrome 95 Linux (very old).
- **Request URL:** `https://kortix.com/` (marketing homepage only — not a product flow).
- **Last seen:** 2026-08-06 11:11:14 UTC (both siblings, same timestamp).
- **Volume:** 2 occurrences each, 0 identified users — low-volume browser noise.

`measureScroll` and `ft` are minified **third-party library internals** (a scroll-measurement helper and an animation/DOM-manipulation helper respectively) — their minified call-site function names do not appear in `apps/web/src/…` source. The throws happen because very old browsers have quirkier DOM behavior: a scroll-measurement helper reaches for a DOM element that resolved to `null` (the element was not in the DOM yet, or the old browser returned `null` from a `querySelector`/`getBoundingClientRect` path), then accesses `.scrollLeft` on it → `TypeError`. Same for `appendChild`: an animation library calls `parent.appendChild(child)` on a `parent` that resolved to `null`.

## What changed

`apps/web/src/lib/browser-error-noise.ts`:

- Add `OLD_BROWSER_DOM_NULL_DEREF_NOISE_PATTERNS` — anchored on the **exact** V8 wording (`Cannot read properties of null (reading 'scrollLeft')` / `… (reading 'appendChild')`) plus the old-JSC wording (`Cannot read property '<X>' of null`) for the same old-browser DOM null-deref class. Exact-match regexes (not loose prefixes) so a different DOM method, a dotted expression, or a near-worded regression keeps reporting.
- Add `isOldBrowserDomNullDerefNoise(input)` — requires the exact message AND a **negative guard**: if any frame (or the window.onerror `filename`) resolves to a de-minified first-party `apps/web/src/…` source path, the event **keeps reporting** (our own code is the null-deref culprit → actionable). `scrollLeft` and `appendChild` are standard DOM API method names that first-party React code DOES call (`use-proximity-hover.ts` reads `container.scrollLeft`, `session-title.tsx` sets `el.scrollLeft`, portal/tooltip ref-callbacks call `appendChild`), so the negative guard is load-bearing — a real first-party null-deref de-minifies to `apps/web/src/…` and must never be hidden.
- Wire it into `shouldIgnoreSentryBrowserNoise` (the Sentry `beforeSend` gate) and `shouldIgnoreBrowserRuntimeNoise` (the runtime `window.onerror` gate). A frameless `onerror` capture with the exact message + no first-party `filename` also drops (`measureScroll`/`ft` are third-party internals, and a real first-party null-deref almost always has a resolvable frame with a stack).
- Deliberately **NOT** added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there would swallow a real first-party `el.scrollLeft` / `parent.appendChild` null-deref the negative guard exists to preserve. The frame-aware `beforeSend` hook is the only safe gate (mirrors the existing `isStorageSecurityErrorNoise` / `isConnectionClosedNoise` / `isSafariGenericSecurityErrorNoise` pattern).

## Verification

- `bun test src/lib/browser-error-noise.test.mts` → **256 pass / 0 fail** (was 238; +18 new tests).
- New tests pin both production Better Stack events through both gates:
  - Pattern 1 (`scrollLeft` / `measureScroll` / chunk `0d5wqj98qv1e9.js`): exact prod frames (2× `measureScroll` chunk frame + `<anonymous>`) classified as noise through the matcher, the `beforeSend` gate, and the runtime `onerror` gate.
  - Pattern 2 (`appendChild` / `ft` / chunk `0foj1ouh5ijrj.js`): exact prod frames (3× `ft` chunk frames) classified as noise through all three paths.
  - Both V8 and old-JSC engine wordings.
  - All three capture-path wrappers (`TypeError: `, `Unhandled promise rejection: TypeError: `).
- Over-match guards (keep reporting):
  - A null-deref on a **different** DOM method (`scrollTop`, `removeChild`, `insertBefore`, dotted expressions like `el.scrollLeft`).
  - **Non-V8/JSC** engine wordings (SpiderMonkey `null is not an object (evaluating …)`, `can't access property "…" of null`).
  - Near-worded messages (trailing char, suffix text, substring mentions).
- Negative guard (keep reporting):
  - A first-party `apps/web/src/…` frame anywhere in the stack — including a mix of first-party + minified chunk frames — keeps reporting through the matcher, the `beforeSend` gate, and the runtime `onerror` gate.
  - First-party `filename` on `shouldIgnoreBrowserRuntimeNoise` keeps reporting.
- Sibling-isolation test: each pattern classifies as noise independently.
- `tsc --noEmit -p tsconfig.json` for `apps/web` — no errors in the changed files (pre-existing sandbox `node_modules` resolution errors elsewhere are unrelated and unaffected by this change; the noise matcher + tests have only `node:test` / `node:assert` imports).

## Risk / rollback

- **Risk:** very low. The matcher is anchored on the exact V8/old-JSC messages for two specific DOM method names, with a first-party negative guard. It only suppresses events that have NO resolved first-party `apps/web/src/…` frame. A real first-party `el.scrollLeft` / `parent.appendChild` null-deref regression de-minifies to `apps/web/src/…` and stays observable.
- **Rollback:** revert the single commit — the matcher is additive and wired into two existing gate functions; removal restores prior behavior exactly.

## Confirmation

After this merges + promotes, the two Better Stack patterns should drop to zero new occurrences:
- `e02e022f7433a02c7acdc9ae33c3dd1bdec938eeb694f0bf83d290c1d696d853` (`scrollLeft` / `measureScroll`)
- `8ab4ae816505dc3a17c7b8258e6894b3964ab7d10056afc47477833824fa8648` (`appendChild` / `ft`)

Better Stack auto-resolves them once they are no longer seen. The `beforeSend` gate drops the Sentry event before it is sent, so the counts stop incrementing immediately on deploy.
