### PR TITLE
fix(web): de-noise model_not_servable unhandled rejection (BS 9784f440)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -21,6 +21,7 @@ import {
   isInpageWalletStreamNoise,
   isIOSWebViewWebKitBridgeNoise,
   isKnownBrowserNoiseMessage,
+  isModelNotServableNoise,
   isNonErrorUndefinedRejectionNoise,
   isOldBrowserSyntaxParseError,
   isOldWebkitRegexNoiseMessage,
@@ -615,6 +616,177 @@ test('does NOT suppress a real compaction mutation failure (network / 5xx)', () 
   ]) {
     assert.equal(
       isExpectedCompactionNoModelMessage(value),
+      false,
+      `expected real error "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected real error "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message: value }),
+      false,
+      `expected real error "${value}" to keep reporting`,
+    )
+  }
+})
+
+// Reproduces Better Stack error
+// 9784f440a71c4430667ed3aca8b727c065f38c226ecad3f33f37c7a86476a576
+// (Kortix Frontend prod): `ApiError`, message
+// `Model "openai/gpt-5.4-mini" is not available for this account`, 7
+// occurrences / 0 identified users, first 2026-08-06 05:09 UTC (ALL post-v0.12.4),
+// request URL `https://kortix.com/projects/377b3ef0-…/sessions/d3d542…` (co-
+// worker session page), browser Android Chrome mobile, mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT,
+// `handled:false`). PR #6082 added an SDK classification gate in
+// `packages/sdk/src/core/http/api-client.ts` `makeRequest` that silences the
+// typed 409 `code === 'model_not_servable'` from `onError` (Sentry), and added
+// an `onError` handler to `useModelDefaults`'s `setMutation` that surfaces a
+// user-facing toast. BUT the 7 occurrences STILL reached Sentry as UNCAUGHT
+// `onunhandledrejection` because every call site fire-and-forgets the
+// returned promise — `void setAccountDefault(...)` / `void setAgentDefault
+// (...)` / `void setProjectDefault(...)` in `session-chat.tsx:3416/3422/3426`,
+// `agents-view.tsx:297`, `gateway-view.tsx:137`, and `models-tab.tsx:156`.
+// The chain: `setModelDefault` → `unwrap(backendApi.put(...))` THROWS the
+// `ApiError` on `!res.success` → `mutateAsync` rejects → the `async` wrapper's
+// promise rejects → `void` discards the rejected promise with no `.catch()` →
+// unhandled rejection → Sentry's `onunhandledrejection`. The `setMutation`
+// `onError` swallows the rejection inside react-query (the toast fires), but
+// react-query v5's `onError` does NOT prevent `mutateAsync`'s returned promise
+// from rejecting, so the `void`-discarded promise still surfaces as an
+// uncaught global rejection. The SDK `makeRequest` gate silences `onError`
+// (the Sentry callback), but the unhandled rejection happens at the `.then()`
+// / `void` level — AFTER `makeRequest` returned — so the gate never sees it.
+// This matcher is the leak-path backstop, sibling to the billing-gate /
+// compaction-no-model matchers (also `ApiError`/Error throws that leak via
+// `void` fire-and-forget → `onunhandledrejection`). The model name varies, so
+// the match is a REGEX anchored on the EXACT API wording
+// `Model "…" is not available for this account` (the same template across all
+// four emitting routes — `r4.ts:3045`, `channel-bindings.ts:288`, `r7.ts:2811`,
+// `sessions.ts:741`), with the canonical `ApiError: ` / `Unhandled promise
+// rejection: ` wrappers, so a longer real error that merely mentions the
+// phrase is never matched.
+const MODEL_NOT_SERVABLE_EVENTS = [
+  // The bare API message — the SDK `ApiError.message` — for the assigned
+  // prod pattern (`openai/gpt-5.4-mini`).
+  'Model "openai/gpt-5.4-mini" is not available for this account',
+  // A different model id (BYOK `provider/model` shape) — the prior prod
+  // recurrence (`nvidia/minimaxai/minimax-m3`, pattern `ed07f6c5…`). The
+  // matcher must anchor on the wording, not a specific model.
+  'Model "nvidia/minimaxai/minimax-m3" is not available for this account',
+  // An `ApiError:`-prefixed wrapper (e.g. Sentry's exception `value`
+  // formatting, or a console/error-boundary re-throw).
+  'ApiError: Model "openai/gpt-5.4-mini" is not available for this account',
+  // An unhandled-rejection wrapper preserving the message (Sentry
+  // `onunhandledrejection` auto-capture, `handled:false` — the prod shape).
+  'Unhandled promise rejection: Model "openai/gpt-5.4-mini" is not available for this account',
+  // An unhandled-rejection wrapper around an `ApiError:`-prefixed re-throw
+  // (the full wrapper stack).
+  'Unhandled promise rejection: ApiError: Model "openai/gpt-5.4-mini" is not available for this account',
+]
+
+test('classifies the model-not-servable validation state as expected', () => {
+  for (const message of MODEL_NOT_SERVABLE_EVENTS) {
+    assert.equal(
+      isModelNotServableNoise(message),
+      true,
+      `expected "${message}" to be classified as model-not-servable noise`,
+    )
+  }
+})
+
+test('suppresses a model-not-servable Sentry event regardless of capture path', () => {
+  for (const value of MODEL_NOT_SERVABLE_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/projects/p/sessions/s' },
+        exception: {
+          values: [
+            {
+              value,
+              // The unhandled-rejection stack DOES carry resolved first-party
+              // `apps/web/src/…` call-site frames (the `void setXxxDefault(...)`
+              // call sites in session-chat.tsx / agents-view.tsx / gateway-view.tsx).
+              // The matcher is deliberately message-only (NO first-party
+              // negative guard) — mirroring the billing-gate / compaction-no-model
+              // matchers — so a first-party call-site frame does NOT veto
+              // suppression (that's the whole point: the prod noise carries
+              // first-party frames and must still be dropped).
+              stacktrace: {
+                frames: [
+                  { filename: 'app:///_next/static/chunks/sdk.js' },
+                  { filename: 'apps/web/src/features/session/session-chat.tsx' },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses a model-not-servable unhandled rejection from the browser', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message:
+        'Unhandled promise rejection: Model "openai/gpt-5.4-mini" is not available for this account',
+    }),
+    true,
+  )
+  // The runtime gate also receives the raw `reason` (the `ApiError` instance),
+  // whose `message` is the bare API string — the `extractMessage` path must
+  // classify it too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      reason: { message: 'Model "openai/gpt-5.4-mini" is not available for this account' },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a longer real error containing the model-not-servable wording', () => {
+  for (const value of [
+    'Failed to set default: Model "openai/gpt-5.4-mini" is not available for this account',
+    'Model "openai/gpt-5.4-mini" is not available for this account while saving',
+    'ApiError: Model "openai/gpt-5.4-mini" is not available for this account and more',
+    'Unhandled promise rejection: Something else: Model "x" is not available for this account',
+  ]) {
+    assert.equal(
+      isModelNotServableNoise(value),
+      false,
+      `expected longer message "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected longer Sentry event "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message: value }),
+      false,
+      `expected longer runtime error "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a real model-defaults mutation failure (network / 5xx)', () => {
+  for (const value of [
+    'Internal server error',
+    'HTTP 500: Internal Server Error',
+    'TypeError: Cannot read properties of undefined (reading modelID)',
+    'Failed to fetch',
+  ]) {
+    assert.equal(
+      isModelNotServableNoise(value),
       false,
       `expected real error "${value}" to keep reporting`,
     )

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -173,6 +173,92 @@ const COMPACTION_NO_MODEL_EXPECTED_MESSAGES = [
   'No model available for compaction. Please configure a model in settings.',
 ] as const;
 
+// Expected "model not available for this account" UI validation state. The API
+// returns a TYPED 409 with `code: 'model_not_servable'`
+// (`apps/api/src/projects/routes/r4.ts:3045` and `channel-bindings.ts:288`, both
+// via `isModelServableForAccount`) when a user picks a model their account
+// can't use — a free-tier managed model, or a BYOK model whose provider isn't
+// connected. The SAME wording is also returned as a 400 with
+// `code: 'INVALID_SESSION_MODEL'` (`apps/api/src/projects/routes/r7.ts:2811`
+// and `apps/api/src/projects/lib/sessions.ts:741`) for an explicit session
+// model. Both are EXPECTED, user-facing validation states — the SDK's
+// `useModelDefaults` `setMutation` `onError` already branches on the typed
+// 409 code and surfaces a user-facing toast via `platformConfig().onToast`,
+// and `makeRequest` already classifies the typed 409 as SILENT to `onError`
+// (Sentry) — see `MODEL_NOT_SERVABLE_CODE` in
+// `packages/sdk/src/core/http/api-client.ts` (PR #6082).
+//
+// BUT every call site fire-and-forgets the returned promise —
+// `void setAccountDefault(...)` / `void setAgentDefault(...)` /
+// `void setProjectDefault(...)` in `session-chat.tsx:3416/3422/3426`,
+// `agents-view.tsx:297`, `gateway-view.tsx:137`, and `models-tab.tsx:156`.
+// The chain: `setModelDefault` → `unwrap(backendApi.put(...))` THROWS the
+// `ApiError` on `!res.success` → `mutateAsync` rejects → the `async` wrapper's
+// (`setAccountDefault`/…) promise rejects → `void` discards the rejected
+// promise with no `.catch()` → UNHANDLED rejection → Sentry's
+// `onunhandledrejection` global handler auto-captures it. The `setMutation`
+// `onError` SWALLOWS the rejection inside react-query (the toast fires), but
+// react-query v5's `onError` does NOT prevent `mutateAsync`'s returned
+// promise from rejecting, so the `void`-discarded promise still surfaces as
+// an uncaught global rejection. The SDK `makeRequest` gate silences the
+// `onError` (Sentry) callback, but the unhandled rejection happens at the
+// `.then()`/`void` level — AFTER `makeRequest` returned — so the gate never
+// sees it. This left the 7 occurrences STILL reaching Sentry as UNCAUGHT
+// `onunhandledrejection` (`handled:false`) post-#6082.
+//
+// Better Stack pattern
+// 9784f440a71c4430667ed3aca8b727c065f38c226ecad3f33f37c7a86476a576
+// (Kortix Frontend prod, application_id 2346967): `ApiError`, message
+// `Model "openai/gpt-5.4-mini" is not available for this account`, 7
+// occurrences / 0 identified users, first 2026-08-06 05:09 UTC (ALL
+// post-v0.12.4, release `160f0b286f0ad5c53debc343d5e055241694e24d`),
+// request URL `https://kortix.com/projects/377b3ef0-…/sessions/d3d542…`
+// (co-worker session page), browser Android Chrome mobile, mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT,
+// `handled:false`).
+//
+// This is the leak-path backstop for the #6082 SDK gate, sibling to
+// `isExpectedBillingGateMessage` / `isExpectedCompactionNoModelMessage`
+// (also `ApiError`/Error throws that leak via `void` fire-and-forget →
+// `onunhandledrejection`). The model name varies (e.g.
+// `openai/gpt-5.4-mini`, `nvidia/minimaxai/minimax-m3`), so — unlike the
+// billing-gate / compaction exact-string matchers — this is a REGEX anchored
+// on the EXACT API wording `Model "…" is not available for this account`
+// (the `Model "` prefix and `is not available for this account` suffix are
+// the API's own canonical strings across all four emitting routes), with the
+// canonical `ApiError: ` / `Unhandled promise rejection: ` wrappers stripped
+// so all capture paths (window.onerror, onunhandledrejection, Sentry
+// exception) classify consistently. Deliberately message-only with NO
+// first-party frame negative guard — mirroring the billing-gate / compaction
+// matchers — because (a) the message is the API's own canonical wording
+// (never a coincidental app-logic phrase), (b) the SDK gate already handles
+// the `onError` path, and (c) the unhandled-rejection stack DOES carry
+// resolved first-party `apps/web/src/…` call-site frames (the `void`
+// call sites in `session-chat.tsx`/`agents-view.tsx`/`gateway-view.tsx`), so a
+// first-party negative guard would FAIL to suppress the actual prod noise.
+// A genuine first-party `throw new Error('Model "…" is not available for this
+// account')` regression is vanishingly unlikely (the wording is the API's,
+// not app logic) AND is already covered by the SDK's `onError` Sentry
+// capture for non-409 cases. NOT added to `sentry.client.config.ts`'s
+// `ignoreErrors` list as a bare regex — that gate has no frame context and
+// the message is specific enough that the `beforeSend` hook
+// (`shouldIgnoreSentryBrowserNoise`) is the safe gate; the anchored regex
+// below covers frameless `onunhandledrejection` captures too.
+const MODEL_NOT_SERVABLE_NOISE_PATTERNS: ReadonlyArray<RegExp> = [
+  // The bare API message (the SDK `ApiError.message`), with any non-empty
+  // model id between the quotes.
+  /^Model "[^"]+" is not available for this account$/,
+  // `ApiError: `-prefixed wrapper (e.g. a console/error-boundary re-throw, or
+  // Sentry's exception `value` formatting).
+  /^ApiError: Model "[^"]+" is not available for this account$/,
+  // An unhandled-rejection wrapper preserving the message (Sentry
+  // `onunhandledrejection` auto-capture, `handled:false`).
+  /^Unhandled promise rejection: Model "[^"]+" is not available for this account$/,
+  // An unhandled-rejection wrapper around an `ApiError:`-prefixed re-throw
+  // (the full wrapper stack).
+  /^Unhandled promise rejection: ApiError: Model "[^"]+" is not available for this account$/,
+];
+
 // Stale Next.js webpack runtime chunk after a deploy. A long-lived tab (or
 // cached HTML) holds app chunks from one Vercel deployment (`?dpl=dpl_…`) while
 // the webpack runtime chunk is served from a different deployment, so
@@ -1430,6 +1516,35 @@ export function isExpectedCompactionNoModelMessage(message: unknown): boolean {
       || normalized === `Unhandled promise rejection: ${expected}`
       || normalized === `Unhandled promise rejection: Error: ${expected}`,
   );
+}
+
+/**
+ * Whether a message is the EXPECTED "model not available for this account"
+ * UI validation state — the typed 409 `code: 'model_not_servable'` the API
+ * returns (`apps/api/src/projects/routes/r4.ts` + `channel-bindings.ts` via
+ * `isModelServableForAccount`, plus the 400 `INVALID_SESSION_MODEL` sibling in
+ * `r7.ts` + `sessions.ts`) when a user picks a model their account can't use.
+ * The SDK's `useModelDefaults` `setMutation` `onError` already surfaces a
+ * user-facing toast, and `makeRequest` already classifies the typed 409 as
+ * SILENT to `onError` (Sentry) — see `MODEL_NOT_SERVABLE_CODE` (PR #6082) —
+ * but every call site fire-and-forgets the returned promise
+ * (`void setAccountDefault(...)` / `void setAgentDefault(...)` /
+ * `void setProjectDefault(...)`), so the rejected `mutateAsync` becomes an
+ * UNHANDLED rejection → Sentry's `onunhandledrejection` (`handled:false`),
+ * which the #6082 SDK gate never sees (it's past the `makeRequest` return).
+ * This is the leak-path backstop. The model name varies, so the match is a
+ * REGEX anchored on the EXACT API wording `Model "…" is not available for
+ * this account`, with the canonical `ApiError: ` / `Unhandled promise
+ * rejection: ` wrappers, so a longer real error that merely mentions the
+ * phrase is never matched. Sibling to `isExpectedBillingGateMessage` /
+ * `isExpectedCompactionNoModelMessage` (also `ApiError`/Error throws that
+ * leak via `void` fire-and-forget); deliberately message-only with NO
+ * first-party frame negative guard — see `MODEL_NOT_SERVABLE_NOISE_PATTERNS`
+ * for the full rationale. See Better Stack pattern `9784f440…`.
+ */
+export function isModelNotServableNoise(message: unknown): boolean {
+  const normalized = normalizeString(message).trim();
+  return MODEL_NOT_SERVABLE_NOISE_PATTERNS.some((re) => re.test(normalized));
 }
 
 /**
@@ -2925,6 +3040,21 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Expected "model not available for this account" UI validation state — the
+  // API returns a typed 409 `code: 'model_not_servable'` when a user picks a
+  // model their account can't use. The SDK's `useModelDefaults` `setMutation`
+  // `onError` already surfaces a user-facing toast, and `makeRequest` already
+  // classifies the typed 409 as SILENT to `onError` (Sentry) — but every call
+  // site fire-and-forgets the returned promise (`void setXxxDefault(...)`), so
+  // the rejected `mutateAsync` becomes an UNHANDLED rejection →
+  // `onunhandledrejection`, which the #6082 SDK gate never sees (it's past the
+  // `makeRequest` return). Drop it here so the expected validation state never
+  // pages Better Stack. See `isModelNotServableNoise` and Better Stack pattern
+  // `9784f440…`.
+  if (isModelNotServableNoise(message)) {
+    return true;
+  }
+
   // Old-WebKit (< 16.4) lookbehind parse failure from bundled third-party
   // deps — WebKit-specific wording, only old Safari/iOS visitors hit it.
   if (isOldWebkitRegexNoiseMessage(message)) {
@@ -3190,6 +3320,26 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // so the expected config state never pages Better Stack. See
   // `isExpectedCompactionNoModelMessage`.
   if (isExpectedCompactionNoModelMessage(message)) {
+    return true;
+  }
+
+  // Expected "model not available for this account" UI validation state — the
+  // API returns a typed 409 `code: 'model_not_servable'` (and a 400
+  // `INVALID_SESSION_MODEL` sibling with the SAME message) when a user picks a
+  // model their account can't use. The SDK's `useModelDefaults` `setMutation`
+  // `onError` already surfaces a user-facing toast, and `makeRequest` already
+  // classifies the typed 409 as SILENT to `onError` (Sentry) (PR #6082), but
+  // every call site fire-and-forgets the returned promise
+  // (`void setXxxDefault(...)`), so the rejected `mutateAsync` becomes an
+  // UNHANDLED rejection → Sentry's `onunhandledrejection` (`handled:false`),
+  // which the #6082 SDK gate never sees (it's past the `makeRequest` return).
+  // It can also leak through `<ClientErrorBoundary>` / route / system-fault
+  // boundaries. Drop it here so the expected validation state never pages
+  // Better Stack. The match is a REGEX (model name varies) anchored on the
+  // exact API wording, with canonical wrappers; a longer real error that
+  // merely mentions the phrase keeps reporting. See `isModelNotServableNoise`
+  // and Better Stack pattern `9784f440…`.
+  if (isModelNotServableNoise(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Demo

Non-visual change — telemetry/noise gate. Proof: the new `isModelNotServableNoise` matcher + its tests pass (`bun test apps/web/src/lib/browser-error-noise.test.mts` → 243 pass / 0 fail), and a standalone assertion harness exercising the matcher against the exact prod message shapes (bare, `ApiError:`-prefixed, `Unhandled promise rejection:`-wrapped, via `reason.message`) confirms all positive + negative cases classify correctly.

## Why

PR #6082 (commit `4ed08828`, v0.12.3) added an SDK classification gate in `packages/sdk/src/core/http/api-client.ts` `makeRequest` that silences a typed 409 `code === 'model_not_servable'` from `onError` (Sentry), and added an `onError` handler to `useModelDefaults`'s `setMutation` that surfaces a user-facing toast. **But the 7 occurrences are STILL reaching Sentry** as UNCAUGHT `onunhandledrejection` (`handled:false`) — because the fire-and-forget `void setAccountDefault(...)` / `void setAgentDefault(...)` / `void setProjectDefault(...)` call sites discard the promise **before** the mutation's `onError` can catch it. The rejection propagates to the global `onunhandledrejection` handler → Sentry.

The SDK gate silences `onError` (the Sentry callback), but the UNCAUGHT rejection happens at the `.then()` / `void` level — the `ApiError` is thrown by `unwrap()`, the `async` wrapper rejects, and `void` discards the rejected promise with no `.catch()`. This all happens **after** `makeRequest` returned, so the #6082 gate never sees it.

## What changed

Added `isModelNotServableNoise` to `apps/web/src/lib/browser-error-noise.ts` and wired it into **both** noise gates:
- `shouldIgnoreBrowserRuntimeNoise` (the runtime `onunhandledrejection` / `onerror` gate in `browser-noise-guard.tsx`)
- `shouldIgnoreSentryBrowserNoise` (the Sentry `beforeSend` gate in `sentry.client.config.ts`)

The matcher is a **regex** anchored on the EXACT API wording `Model "…" is not available for this account` (the model id varies — e.g. `openai/gpt-5.4-mini`, `nvidia/minimaxai/minimax-m3` — so unlike the billing-gate / compaction exact-string matchers, this needs a regex). The same template is emitted by all four API routes: `r4.ts:3045`, `channel-bindings.ts:288` (both 409 `model_not_servable`), and `r7.ts:2811`, `sessions.ts:741` (both 400 `INVALID_SESSION_MODEL`). The four patterns cover the bare message + the canonical `ApiError: ` / `Unhandled promise rejection: ` / stacked wrappers, so all capture paths (window.onerror, onunhandledrejection, Sentry exception) classify consistently.

**Deliberately message-only with NO first-party frame negative guard** — mirroring the proven `isExpectedBillingGateMessage` / `isExpectedCompactionNoModelMessage` matchers (the closest analogues: also `ApiError`/Error throws that leak via `void` fire-and-forget → `onunhandledrejection`). A first-party frame guard would be **wrong** here: the unhandled-rejection stack DOES carry resolved first-party `apps/web/src/…` call-site frames (the `void` call sites in `session-chat.tsx`/`agents-view.tsx`/`gateway-view.tsx`), so a negative guard would FAIL to suppress the actual prod noise. The message is the API's own canonical wording (never a coincidental app-logic phrase), the SDK gate already handles the `onError` path, and a longer real error that merely mentions the phrase is never matched (anchored regex).

This is the **leak-path backstop** for the #6082 SDK gate — it catches every fire-and-forget path without needing to find/touch each `void setXxxDefault(...)` call site, and it's the same pattern used for the other noise classes.

## Verification

- `bun test apps/web/src/lib/browser-error-noise.test.mts` → **243 pass / 0 fail** (includes 5 new test blocks: positive classification, Sentry-gate suppression with first-party frames, runtime-gate suppression via `message` + `reason`, longer-message negative, real-failure negative)
- `bun test packages/sdk/src/core/http/api-client.test.ts` → **22 pass / 0 fail** (the existing #6082 SDK gate is unchanged)
- `bun test packages/sdk/src/core/rest/projects-client/model-defaults.test.ts` → **2 pass / 0 fail**
- Standalone assertion harness exercising the matcher against the exact prod message shapes (bare, `ApiError:`-prefixed, `Unhandled promise rejection:`-wrapped, via `reason.message`, empty-model-id negative, longer-message negative, real-5xx negative) → all 13 assertions pass

## Incident reference

- **Better Stack error id:** `9784f440a71c4430667ed3aca8b727c065f38c226ecad3f33f37c7a86476a576`
- **App:** Kortix Frontend prod (application_id 2346967)
- **Message:** `Model "openai/gpt-5.4-mini" is not available for this account`
- **Mechanism:** `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT, `handled:false`)
- **Count:** 7 occurrences, first 2026-08-06 05:09 UTC (ALL post-v0.12.4)
- **Release:** `160f0b286f0ad5c53debc343d5e055241694e24d` (v0.12.4)

## Confirm (post-merge)

After this merges + promotes, the Better Stack pattern `9784f440…` should drop to zero new occurrences (the `onunhandledrejection` path is now gated at both the runtime `preventDefault` and the Sentry `beforeSend` `null`-return). The user-facing toast (from `useModelDefaults`'s `setMutation` `onError`, added in #6082) continues to fire — only the Sentry/Better Stack telemetry is suppressed.

## Risk / rollback

Low. The matcher is purely additive (a new noise class in `shouldIgnore*`); it only drops Sentry/Better Stack telemetry for the exact `Model "…" is not available for this account` API validation message, which is already a user-facing toast. No app behavior changes. Revert is a clean single-commit revert.
