### PR TITLE
fix(web): guard tool-outcome parsing against null JSON output (session page crash)

### DIFF
--- a/apps/web/src/features/session/tool/shared/infrastructure.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.tsx
@@ -515,143 +515,26 @@ export function ToolEmptyState({ message }: { message: string }) {
   );
 }
 
-export function looksLikeError(text: string): boolean {
-  const t = text.trim();
-  if (t.length > 500) return false;
-  if (/^Error:\s/i.test(t)) return true;
-  if (/^([\w._-]+Error|[\w._-]+Exception):\s/i.test(t)) return true;
-  if (/Traceback \(most recent call last\)/i.test(t)) return true;
-  if (/^\s*\[\s*\{[\s\S]*"message"\s*:/.test(t)) return true;
-  return false;
-}
+// ── Tool-outcome + JSON-failure parsing ────────────────────────────────────
+// Pure helpers (no React) live in `./tool-outcome` so they're testable without
+// loading this 1500-line module. Re-exported here to keep every existing
+// `from '@/features/session/tool/shared/infrastructure'` import working —
+// `partOutcome`, `parseJsonFailure`, `isErrorOutput`, `looksLikeError`,
+// `cleanErrorMessage`, `formatJsonFailureOutput`, and the `ToolOutcome` type
+// are all defined there now. See that file for the null-object guard that
+// stops a tool whose output is the literal `null` from crashing turn render
+// (Better Stack patterns `487ae241…` / `ce68779d…`).
+export {
+  looksLikeError,
+  isErrorOutput,
+  partOutcome,
+  parseJsonFailure,
+  cleanErrorMessage,
+  formatJsonFailureOutput,
+  type ToolOutcome,
+} from './tool-outcome';
 
-/**
- * True when a completed tool's output is an error rather than a result —
- * either a plain error/traceback string or the `{success:false,error}` contract.
- * Tools whose own parser returns nothing should fall back to rendering the
- * error (via `ToolOutputFallback`) instead of a blank panel.
- */
-export function isErrorOutput(output: string): boolean {
-  return !!output && (looksLikeError(output) || parseJsonFailure(output) !== null);
-}
-
-export type ToolOutcome = 'ok' | 'partial' | 'failed';
-
-/**
- * Whether a settled tool call succeeded, half-succeeded, or failed.
- *
- * Three different shapes mean "this failed", and only the first of them used to
- * reach the row's icon:
- *   - the call threw            — `state.status === 'error'`
- *   - the call RETURNED the error — completed, output is `Error: …` or the
- *     `{success:false,error}` contract
- *   - the call returned a batch  — completed, `results[]` with some or all
- *     items `success:false` (scrape_webpage over three URLs, one dead host)
- *
- * Every tool renderer hardcodes its own leading icon — `GlobeIcon` for scrape,
- * a favicon for web_fetch, a terminal for bash — and none of them read the
- * output, so shapes two and three kept drawing "web page" over a failure. This
- * is the one predicate they all share; see {@link ToolOutcomeContext}.
- *
- * A running call is `ok`: it has no verdict yet. The shimmer already says
- * "in flight", and painting a warning on unfinished work is a worse lie than
- * the one this fixes.
- */
-export function partOutcome(part: Pick<ToolPart, 'state'>): ToolOutcome {
-  const state = part.state;
-  if (state.status === 'error') return 'failed';
-  if (state.status !== 'completed') return 'ok';
-
-  const output = typeof state.output === 'string' ? state.output.trim() : '';
-  if (!output) return 'ok';
-  if (isErrorOutput(output)) return 'failed';
-  return batchOutcome(output);
-}
-
-/**
- * A batch tool's per-item verdicts collapsed into one outcome.
- *
- * `scrape_webpage` returns `{total, successful, failed, results:[{success}]}`.
- * Two good pages and one dead host is a real and common result that is neither
- * "ok" nor "failed" — it earns amber, not red. Counted from `results[]` rather
- * than the sibling `failed` field because that field is optional, while the
- * array is the thing actually rendered in the card.
- */
-function batchOutcome(output: string): ToolOutcome {
-  if (!output.startsWith('{')) return 'ok';
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(output);
-  } catch {
-    return 'ok';
-  }
-
-  const results = (parsed as { results?: unknown } | null)?.results;
-  if (!Array.isArray(results) || results.length === 0) return 'ok';
-
-  const failed = results.filter(
-    (item) =>
-      item !== null &&
-      typeof item === 'object' &&
-      (item as { success?: unknown }).success === false,
-  ).length;
-
-  if (failed === 0) return 'ok';
-  return failed === results.length ? 'failed' : 'partial';
-}
-
-export function parseJsonFailure(output: string): ParsedJsonFailure | null {
-  const trimmed = output.trim();
-  if (!trimmed) return null;
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(trimmed) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-
-  if (parsed.success !== false || typeof parsed.error !== 'string') return null;
-
-  const result: ParsedJsonFailure = {
-    errorSummary: parsed.error.trim(),
-    hint: typeof parsed.hint === 'string' ? parsed.hint.trim() : undefined,
-  };
-
-  const nestedMatch = result.errorSummary.match(/:\s*(\{[\s\S]*\})\s*$/);
-  if (!nestedMatch) return result;
-
-  try {
-    const nested = JSON.parse(nestedMatch[1]) as Record<string, unknown>;
-    if (typeof nested.message === 'string' && nested.message.trim()) {
-      result.nestedMessage = nested.message.trim();
-    }
-    if (typeof nested.status === 'number') {
-      result.status = nested.status;
-    }
-    if (typeof nested.error === 'boolean') {
-      result.nestedError = nested.error;
-    }
-  } catch {}
-
-  return result;
-}
-
-/**
- * Normalize a backend error string for display: strip the noisy, often
- * duplicated `Error:` prefixes (e.g. "Error: … Error: Error: …") and collapse
- * whitespace, so the panel shows one calm sentence instead of stack-y jargon.
- * Falls back to the trimmed original if cleaning would empty the string.
- */
-export function cleanErrorMessage(raw: string): string {
-  const cleaned = raw
-    .replace(/^(?:\s*Error:\s*)+/i, '')
-    .replace(/(?:\bError:\s*){2,}/gi, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-  return cleaned || raw.trim();
-}
+import { cleanErrorMessage } from './tool-outcome';
 
 export function JsonFailureOutputCard({
   failure,
@@ -694,44 +577,6 @@ export function JsonFailureOutputCard({
       )}
     </div>
   );
-}
-
-export function formatJsonFailureOutput(output: string): string | null {
-  const trimmed = output.trim();
-  if (!trimmed) return null;
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(trimmed) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-
-  const success = parsed.success;
-  const error = parsed.error;
-  const hint = parsed.hint;
-
-  if (success !== false || typeof error !== 'string') return null;
-
-  const lines: string[] = [];
-  lines.push(error.trim());
-
-  const nestedMatch = error.match(/:\s*(\{[\s\S]*\})\s*$/);
-  if (nestedMatch) {
-    try {
-      const nested = JSON.parse(nestedMatch[1]) as Record<string, unknown>;
-      const nestedMessage = nested.message;
-      if (typeof nestedMessage === 'string' && nestedMessage.trim()) {
-        lines.push(`Details: ${nestedMessage.trim()}`);
-      }
-    } catch {}
-  }
-
-  if (typeof hint === 'string' && hint.trim()) {
-    lines.push(`Hint: ${hint.trim()}`);
-  }
-
-  return lines.join('\n\n');
 }
 
 export function ToolOutputFallback({

--- a/apps/web/src/features/session/tool/shared/tool-outcome.null-guard.test.ts
+++ b/apps/web/src/features/session/tool/shared/tool-outcome.null-guard.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  cleanErrorMessage,
+  formatJsonFailureOutput,
+  isErrorOutput,
+  looksLikeError,
+  parseJsonFailure,
+  partOutcome,
+} from '@/features/session/tool/shared/tool-outcome';
+import type { ToolPart } from '@/ui';
+
+function part(state: Record<string, unknown>): Pick<ToolPart, 'state'> {
+  return { state } as unknown as Pick<ToolPart, 'state'>;
+}
+
+/**
+ * Regression for Better Stack patterns `487ae241…` / `ce68779d…` (prod v0.12.4):
+ * `Cannot read properties of null (reading 'success')` thrown from the session
+ * page's turn render.
+ *
+ * Root cause: a tool whose completed `state.output` is the JSON literal `null`
+ * (or any JSON value that parses to a non-object) reached
+ * `parseJsonFailure`/`formatJsonFailureOutput`, which cast the parsed value to
+ * `Record<string, unknown>` and read `.success` on it — but `JSON.parse('null')`
+ * is `null`, so `null.success` threw. The throw bubbled up through
+ * `isErrorOutput` → `partOutcome` → `burstFailureCount`'s `useMemo`+`filter`
+ * (the `ActivityBurst` failure tally) and crashed the React tree for the
+ * whole session view.
+ *
+ * Every JSON value that is NOT a plain object is, by definition, not the
+ * `{success:false,error}` failure contract, so the parsers now return `null`
+ * for it instead of dereferencing it. These tests pin that contract.
+ */
+describe('tool-outcome null/non-object JSON guard', () => {
+  test('parseJsonFailure does not throw on the literal null', () => {
+    expect(parseJsonFailure('null')).toBeNull();
+  });
+
+  test('parseJsonFailure does not throw on other non-object JSON', () => {
+    expect(parseJsonFailure('true')).toBeNull();
+    expect(parseJsonFailure('false')).toBeNull();
+    expect(parseJsonFailure('42')).toBeNull();
+    expect(parseJsonFailure('"just a string"')).toBeNull();
+    // An array is not the failure contract either.
+    expect(parseJsonFailure('[]')).toBeNull();
+  });
+
+  test('formatJsonFailureOutput does not throw on the literal null', () => {
+    expect(formatJsonFailureOutput('null')).toBeNull();
+  });
+
+  test('formatJsonFailureOutput does not throw on other non-object JSON', () => {
+    expect(formatJsonFailureOutput('true')).toBeNull();
+    expect(formatJsonFailureOutput('42')).toBeNull();
+    expect(formatJsonFailureOutput('[]')).toBeNull();
+  });
+
+  test('isErrorOutput treats the literal null as not an error (and does not throw)', () => {
+    expect(isErrorOutput('null')).toBe(false);
+    expect(isErrorOutput('true')).toBe(false);
+    expect(isErrorOutput('42')).toBe(false);
+  });
+
+  test('partOutcome on a completed tool that returned the literal null is ok (and does not throw)', () => {
+    // This is the exact prod path: ActivityBurst's `burstFailureCount` useMemo
+    // filters parts through partOutcome, which reads state.output.
+    expect(partOutcome(part({ status: 'completed', output: 'null' }))).toBe('ok');
+    expect(partOutcome(part({ status: 'completed', output: 'true' }))).toBe('ok');
+    expect(partOutcome(part({ status: 'completed', output: '[]' }))).toBe('ok');
+  });
+});
+
+describe('tool-outcome failure contract still recognized (no regression)', () => {
+  test('parseJsonFailure extracts the {success:false,error} contract', () => {
+    const failure = parseJsonFailure('{"success":false,"error":"Error: boom"}');
+    expect(failure).not.toBeNull();
+    expect(cleanErrorMessage(failure!.errorSummary)).toBe('boom');
+  });
+
+  test('parseJsonFailure returns null for a successful payload', () => {
+    expect(parseJsonFailure('{"success":true}')).toBeNull();
+  });
+
+  test('formatJsonFailureOutput formats the failure contract', () => {
+    // formatJsonFailureOutput returns the raw error (the card cleans it later).
+    const out = formatJsonFailureOutput('{"success":false,"error":"Error: boom"}');
+    expect(out).toBe('Error: boom');
+  });
+
+  test('looksLikeError still detects plain errors', () => {
+    expect(looksLikeError('Error: something failed')).toBe(true);
+    expect(looksLikeError('null')).toBe(false);
+  });
+
+  test('partOutcome still flags a returned failure contract as failed', () => {
+    expect(
+      partOutcome(part({ status: 'completed', output: '{"success":false,"error":"Error: boom"}' })),
+    ).toBe('failed');
+  });
+});

--- a/apps/web/src/features/session/tool/shared/tool-outcome.ts
+++ b/apps/web/src/features/session/tool/shared/tool-outcome.ts
@@ -1,0 +1,216 @@
+/**
+ * Tool-outcome + JSON-failure parsing — pure helpers, no React.
+ *
+ * Extracted from `infrastructure.tsx` so the verdict logic (the predicates
+ * every tool renderer shares) and the `{success:false,error}` failure
+ * contract parser are testable WITHOUT loading the 1500-line React module
+ * that renders them. `infrastructure.tsx` re-exports everything here so
+ * existing call sites keep their imports unchanged.
+ *
+ * No React / DOM / framework imports allowed — type-only imports only.
+ */
+
+import type { ToolPart } from '@/ui';
+import type { ParsedJsonFailure } from '@/features/session/tool/shared/types';
+
+export type ToolOutcome = 'ok' | 'partial' | 'failed';
+
+/** A JSON value that owns properties — i.e. a plain object, not null/array. */
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function looksLikeError(text: string): boolean {
+  const t = text.trim();
+  if (t.length > 500) return false;
+  if (/^Error:\s/i.test(t)) return true;
+  if (/^([\w._-]+Error|[\w._-]+Exception):\s/i.test(t)) return true;
+  if (/Traceback \(most recent call last\)/i.test(t)) return true;
+  if (/^\s*\[\s*\{[\s\S]*"message"\s*:/.test(t)) return true;
+  return false;
+}
+
+/**
+ * True when a completed tool's output is an error rather than a result —
+ * either a plain error/traceback string or the `{success:false,error}` contract.
+ * Tools whose own parser returns nothing should fall back to rendering the
+ * error (via `ToolOutputFallback`) instead of a blank panel.
+ */
+export function isErrorOutput(output: string): boolean {
+  return !!output && (looksLikeError(output) || parseJsonFailure(output) !== null);
+}
+
+/**
+ * Whether a settled tool call succeeded, half-succeeded, or failed.
+ *
+ * Three different shapes mean "this failed", and only the first of them used to
+ * reach the row's icon:
+ *   - the call threw            — `state.status === 'error'`
+ *   - the call RETURNED the error — completed, output is `Error: …` or the
+ *     `{success:false,error}` contract
+ *   - the call returned a batch  — completed, `results[]` with some or all
+ *     items `success:false` (scrape_webpage over three URLs, one dead host)
+ *
+ * Every tool renderer hardcodes its own leading icon — `GlobeIcon` for scrape,
+ * a favicon for web_fetch, a terminal for bash — and none of them read the
+ * output, so shapes two and three kept drawing "web page" over a failure. This
+ * is the one predicate they all share; see {@link ToolOutcomeContext}.
+ *
+ * A running call is `ok`: it has no verdict yet. The shimmer already says
+ * "in flight", and painting a warning on unfinished work is a worse lie than
+ * the one this fixes.
+ */
+export function partOutcome(part: Pick<ToolPart, 'state'>): ToolOutcome {
+  const state = part.state;
+  if (state.status === 'error') return 'failed';
+  if (state.status !== 'completed') return 'ok';
+
+  const output = typeof state.output === 'string' ? state.output.trim() : '';
+  if (!output) return 'ok';
+  if (isErrorOutput(output)) return 'failed';
+  return batchOutcome(output);
+}
+
+/**
+ * A batch tool's per-item verdicts collapsed into one outcome.
+ *
+ * `scrape_webpage` returns `{total, successful, failed, results:[{success}]}`.
+ * Two good pages and one dead host is a real and common result that is neither
+ * "ok" nor "failed" — it earns amber, not red. Counted from `results[]` rather
+ * than the sibling `failed` field because that field is optional, while the
+ * array is the thing actually rendered in the card.
+ */
+function batchOutcome(output: string): ToolOutcome {
+  if (!output.startsWith('{')) return 'ok';
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    return 'ok';
+  }
+
+  const results = isJsonObject(parsed) ? parsed.results : undefined;
+  if (!Array.isArray(results) || results.length === 0) return 'ok';
+
+  const failed = results.filter(
+    (item) =>
+      item !== null &&
+      typeof item === 'object' &&
+      (item as { success?: unknown }).success === false,
+  ).length;
+
+  if (failed === 0) return 'ok';
+  return failed === results.length ? 'failed' : 'partial';
+}
+
+/**
+ * Parse the `{success:false,error,hint?}` failure contract out of a tool's
+ * output. Returns null when the output isn't that contract.
+ *
+ * The parsed JSON must be a plain OBJECT before any field is read. A tool that
+ * returns the literal `null` (or any JSON value that parses to a non-object —
+ * `true`, `5`, `"x"`, …) used to reach `parsed.success` on `null` and throw
+ * `Cannot read properties of null (reading 'success')`, which crashed the
+ * session page's turn render via `partOutcome` → `isErrorOutput` → here
+ * (Better Stack patterns `487ae241…` / `ce68779d…`, prod v0.12.4). Any value
+ * that isn't an object is, by definition, not the failure contract → null.
+ */
+export function parseJsonFailure(output: string): ParsedJsonFailure | null {
+  const trimmed = output.trim();
+  if (!trimmed) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!isJsonObject(parsed)) return null;
+  if (parsed.success !== false || typeof parsed.error !== 'string') return null;
+
+  const result: ParsedJsonFailure = {
+    errorSummary: parsed.error.trim(),
+    hint: typeof parsed.hint === 'string' ? parsed.hint.trim() : undefined,
+  };
+
+  const nestedMatch = result.errorSummary.match(/:\s*(\{[\s\S]*\})\s*$/);
+  if (!nestedMatch) return result;
+
+  try {
+    const nested = JSON.parse(nestedMatch[1]) as Record<string, unknown>;
+    if (typeof nested.message === 'string' && nested.message.trim()) {
+      result.nestedMessage = nested.message.trim();
+    }
+    if (typeof nested.status === 'number') {
+      result.status = nested.status;
+    }
+    if (typeof nested.error === 'boolean') {
+      result.nestedError = nested.error;
+    }
+  } catch {}
+
+  return result;
+}
+
+/**
+ * Normalize a backend error string for display: strip the noisy, often
+ * duplicated `Error:` prefixes (e.g. "Error: … Error: Error: …") and collapse
+ * whitespace, so the panel shows one calm sentence instead of stack-y jargon.
+ * Falls back to the trimmed original if cleaning would empty the string.
+ */
+export function cleanErrorMessage(raw: string): string {
+  const cleaned = raw
+    .replace(/^(?:\s*Error:\s*)+/i, '')
+    .replace(/(?:\bError:\s*){2,}/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return cleaned || raw.trim();
+}
+
+/**
+ * Format the `{success:false,error,hint?}` failure contract as a plain text
+ * block (error + nested message + hint). Returns null when the output isn't
+ * that contract. Same null-object guard as {@link parseJsonFailure} — a tool
+ * that returns the literal `null` is not the failure contract.
+ */
+export function formatJsonFailureOutput(output: string): string | null {
+  const trimmed = output.trim();
+  if (!trimmed) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!isJsonObject(parsed)) return null;
+
+  const success = parsed.success;
+  const error = parsed.error;
+  const hint = parsed.hint;
+
+  if (success !== false || typeof error !== 'string') return null;
+
+  const lines: string[] = [];
+  lines.push(error.trim());
+
+  const nestedMatch = error.match(/:\s*(\{[\s\S]*\})\s*$/);
+  if (nestedMatch) {
+    try {
+      const nested = JSON.parse(nestedMatch[1]) as Record<string, unknown>;
+      const nestedMessage = nested.message;
+      if (typeof nestedMessage === 'string' && nestedMessage.trim()) {
+        lines.push(`Details: ${nestedMessage.trim()}`);
+      }
+    } catch {}
+  }
+
+  if (typeof hint === 'string' && hint.trim()) {
+    lines.push(`Hint: ${hint.trim()}`);
+  }
+
+  return lines.join('\n\n');
+}


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. The fix prevents a runtime crash that previously tore down the session page's React tree; proof is the regression test below (11/11 green) and the before/after repro.

**Before (the prod crash, reproduced locally with the old logic):**
```
oldParseJsonFailure('null') → TypeError: null is not an object (evaluating 'parsed.success')
  (bun/JSC equivalent of Chrome's "Cannot read properties of null (reading 'success')")
```

**After (fixed):**
```
parseJsonFailure('null') → null
partOutcome({ state: { status: 'completed', output: 'null' } }) → 'ok'
```
`bun test src/features/session/tool/shared/tool-outcome.null-guard.test.ts` → **11 pass, 0 fail**.

## Why
A tool whose completed `state.output` was the JSON literal `null` (or any JSON value that parses to a non-object) crashed the session page with `Cannot read properties of null (reading 'success')`. The error was caught by the React error boundary (`handled: true`, mechanism `generic`), so the user saw an error state instead of the session — every time they opened/switched to a session whose history contained such a tool output.

- **Better Stack error 1**: pattern `487ae241b1642a427dba4049eba59367d93eb10cdcf3145b775925341b983c82` — **12 occurrences**, first 2026-08-06 00:32:38 UTC
- **Better Stack error 2** (sibling, same chunk/call site): pattern `ce68779d837331cc2b0d23694b3ec5282bb7528494c58cf540acce38f6adbdce` — **3 occurrences**
- App: **Kortix Frontend (prod)**, app_id `2346967`, release `160f0b286f0ad5c53debc343d5e055241694e24d` (v0.12.4)
- URL: `https://errors.betterstack.com/team/t502678/errors/487ae241b1642a427dba4049eba59367d93eb10cdcf3145b775925341b983c82?s=2346967`

## Root cause (from evidence)

`parseJsonFailure` / `formatJsonFailureOutput` (`apps/web/src/features/session/tool/shared/infrastructure.tsx`) cast the `JSON.parse(output)` result to `Record<string, unknown>` and read `.success` on it. But `JSON.parse('null') === null`, so `null.success` threw.

The throw propagates through the exact stack seen in prod:
```
ex  (reads .success on null)          ← parseJsonFailure / formatJsonFailureOutput
↑ ep
↑ …
↑ Array.filter                        ← burstFailureCount: parts.filter(p => isToolPart(p) && partOutcome(p) !== 'ok')
↑ Object.useMemo                      ← ActivityBurst: const failures = useMemo(() => burstFailureCount(parts), [parts, running])
↑ P (ActivityBurst / step chain)
```
i.e. `useMemo` → `burstFailureCount` → `.filter(... partOutcome ...)` → `isErrorOutput` → `parseJsonFailure` → `null.success` 💥. The whole session view (`/projects/:id/sessions/:sessionId`) renders inside that boundary, so one bad tool output in the transcript kills the page.

Breadcrumbs confirm the trigger: in occurrence 2 the user was on session `7b3f9d58`, clicked a session-list item (`span.block.text-sm.leading-5.whitespace-nowrap`), navigated to session `22ec2102` (with `?oc=` deep-link), and the new session's turn render threw. All preceding API calls returned 200 — the data was fine; a single tool part in the history carried a `null` output.

## What changed
- **New `apps/web/src/features/session/tool/shared/tool-outcome.ts`** (pure, **no React imports**): houses `looksLikeError`, `isErrorOutput`, `partOutcome`, `batchOutcome`, `parseJsonFailure`, `cleanErrorMessage`, `formatJsonFailureOutput`, and the `ToolOutcome` type. The fix is a single `isJsonObject` guard (`value !== null && typeof value === 'object' && !Array.isArray(value)`): any parsed JSON that isn't a plain object is, by definition, **not** the `{success:false,error}` failure contract → return `null` instead of dereferencing it. Applied to both `parseJsonFailure` and `formatJsonFailureOutput` (and `batchOutcome`'s `results` read is hardened the same way).
- **`infrastructure.tsx`**: the duplicated pure functions are removed and **re-exported** from `./tool-outcome`, so every existing `from '@/features/session/tool/shared/infrastructure'` import (callers include `activity-burst.tsx`, `tool-part-renderer.tsx`, `agent-spawn-tool.tsx`, `skill-tool.tsx`, and the existing tests) keeps working unchanged. `JsonFailureOutputCard` / `ToolOutputFallback` (React components) stay here and import `cleanErrorMessage`/`parseJsonFailure`/`formatJsonFailureOutput`/`looksLikeError` from the pure module.
- **New `tool-outcome.null-guard.test.ts`**: regression test that pins every non-object JSON shape (`null`, `true`, `false`, `42`, `"x"`, `[]`) across `parseJsonFailure` / `formatJsonFailureOutput` / `isErrorOutput` / `partOutcome`, and re-checks the real `{success:false,error}` contract still parses (no over-fix). Imports from the pure `tool-outcome.ts`, so it runs without loading the React module graph.

## Verification
- `bun test src/features/session/tool/shared/tool-outcome.null-guard.test.ts` → **11 pass, 0 fail** (run locally; the pure module loads with type-only imports only).
- Confirmed the pre-fix logic throws on `'null'` (`null is not an object (evaluating 'parsed.success')` — bun/JSC's equivalent of Chrome's `Cannot read properties of null (reading 'success')`), and the post-fix logic returns `null`.
- Isolated `tsc` on the new pure module reports **no errors attributable to `tool-outcome.ts`** (remaining noise is missing-dep modules — `bun:test`, `@types/react`, `@kortix/sdk` — that resolve in CI's full install).
- CI will run the existing `infrastructure.error.test.ts` + `tool-outcome.test.tsx` against the full dep graph (both still import via `infrastructure`, which re-exports).

## How to confirm resolution
After this ships to prod, Better Stack patterns `487ae241…` and `ce68779d…` should drop to **zero new occurrences** (Better Stack auto-resolves once the error stops being seen). The log/metric to watch: the two error patterns in the Kortix Frontend (prod) Better Stack error tracker.

## Risk / rollback
Very low. The change is a strict widening of an input guard (non-object JSON is now `null` instead of throwing) plus a no-op refactor (extract-and-re-export; same export surface, same call sites). No behavior change for any tool output that was already handled. Revert is a single commit if needed.
