### PR TITLE
feat(web): update secrets optimistically

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/view/secret-optimistic-cache.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-optimistic-cache.test.ts
@@ -1,0 +1,176 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, test } from 'bun:test';
+
+import type { ProjectSecret, ProjectSecretsResponse } from '@kortix/sdk';
+import {
+  applyProjectSecretResponse,
+  beginOptimisticProjectSecretSave,
+  rollbackOptimisticProjectSecretSave,
+  type OptimisticProjectSecretInput,
+} from './secret-optimistic-cache';
+
+const QUERY_KEY = ['project-secrets', 'p1'];
+
+function secret(overrides: Partial<ProjectSecret> = {}): ProjectSecret {
+  return {
+    identifier: 'EXAMPLE_TOKEN',
+    name: 'EXAMPLE_TOKEN',
+    project_id: 'p1',
+    secret_id: 'secret-1',
+    created_by: 'user-1',
+    created_at: '2026-08-01T00:00:00.000Z',
+    updated_at: '2026-08-01T00:00:00.000Z',
+    configured: true,
+    mine: null,
+    effective_source: 'shared',
+    can_manage_shared: true,
+    strategy: 'runtime',
+    consumer: 'sandbox',
+    delivery_status: 'available',
+    egress_policy: null,
+    requires_rotation: false,
+    ...overrides,
+  };
+}
+
+function response(items: ProjectSecret[]): ProjectSecretsResponse {
+  return {
+    items,
+    required: ['REQUIRED_TOKEN'],
+    optional: ['OPTIONAL_TOKEN'],
+    can_manage: true,
+    manifest_status: 'loaded',
+    manifest_path: 'kortix.yaml',
+  };
+}
+
+function input(
+  overrides: Partial<OptimisticProjectSecretInput> = {},
+): OptimisticProjectSecretInput {
+  return {
+    projectId: 'p1',
+    identifier: 'NEW_TOKEN',
+    name: 'NEW_TOKEN',
+    strategy: 'broker',
+    consumer: 'http_broker',
+    deliveryStatus: 'available',
+    egressPolicy: {
+      rules: [{ host: 'httpbingo.org', methods: ['GET'], path: '/headers' }],
+      inject: { kind: 'header', name: 'authorization', template: 'Bearer {{secret}}' },
+    },
+    ...overrides,
+  };
+}
+
+describe('beginOptimisticProjectSecretSave', () => {
+  test('adds a configured row to the cache before the request finishes', () => {
+    const queryClient = new QueryClient();
+    const original = response([secret()]);
+    queryClient.setQueryData(QUERY_KEY, original);
+
+    const context = beginOptimisticProjectSecretSave(queryClient, QUERY_KEY, input());
+
+    expect(context.previous).toBe(original);
+    const cached = queryClient.getQueryData<ProjectSecretsResponse>(QUERY_KEY);
+    expect(cached?.items).toHaveLength(2);
+    expect(cached?.items[1]).toMatchObject({
+      identifier: 'NEW_TOKEN',
+      configured: true,
+      strategy: 'broker',
+      consumer: 'http_broker',
+      effective_source: 'shared',
+    });
+    expect(cached?.required).toEqual(['REQUIRED_TOKEN']);
+    expect(cached?.can_manage).toBe(true);
+  });
+
+  test('updates an existing row without duplicating it', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(QUERY_KEY, response([secret()]));
+
+    beginOptimisticProjectSecretSave(
+      queryClient,
+      QUERY_KEY,
+      input({
+        identifier: 'EXAMPLE_TOKEN',
+        name: 'EXAMPLE_TOKEN',
+        strategy: 'denied',
+        consumer: null,
+        deliveryStatus: 'disabled',
+        egressPolicy: null,
+      }),
+    );
+
+    const cached = queryClient.getQueryData<ProjectSecretsResponse>(QUERY_KEY);
+    expect(cached?.items).toHaveLength(1);
+    expect(cached?.items[0]).toMatchObject({
+      identifier: 'EXAMPLE_TOKEN',
+      secret_id: 'secret-1',
+      strategy: 'denied',
+      consumer: null,
+      delivery_status: 'disabled',
+    });
+  });
+
+  test('preserves the legacy bare-array cache shape', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData<ProjectSecret[]>(QUERY_KEY, [secret()]);
+
+    beginOptimisticProjectSecretSave(queryClient, QUERY_KEY, input());
+
+    const cached = queryClient.getQueryData<ProjectSecret[]>(QUERY_KEY);
+    expect(Array.isArray(cached)).toBe(true);
+    expect(cached?.map((item) => item.identifier)).toEqual(['EXAMPLE_TOKEN', 'NEW_TOKEN']);
+  });
+
+  test('an empty cache stays empty and returns no snapshot', () => {
+    const queryClient = new QueryClient();
+
+    const context = beginOptimisticProjectSecretSave(queryClient, QUERY_KEY, input());
+
+    expect(context.previous).toBeUndefined();
+    expect(queryClient.getQueryData(QUERY_KEY)).toBeUndefined();
+  });
+});
+
+describe('rollbackOptimisticProjectSecretSave', () => {
+  test('restores the exact content that existed before the optimistic write', () => {
+    const queryClient = new QueryClient();
+    const original = response([secret()]);
+    queryClient.setQueryData(QUERY_KEY, original);
+    const { previous } = beginOptimisticProjectSecretSave(queryClient, QUERY_KEY, input());
+    expect(queryClient.getQueryData<ProjectSecretsResponse>(QUERY_KEY)?.items).toHaveLength(2);
+
+    rollbackOptimisticProjectSecretSave(queryClient, QUERY_KEY, previous);
+
+    expect(queryClient.getQueryData(QUERY_KEY)).toEqual(original);
+  });
+});
+
+describe('applyProjectSecretResponse', () => {
+  test('replaces the optimistic row with the authoritative response', () => {
+    const optimistic = response([
+      secret({
+        identifier: 'NEW_TOKEN',
+        name: 'NEW_TOKEN',
+        secret_id: null,
+        updated_at: null,
+        strategy: 'broker',
+        consumer: 'http_broker',
+      }),
+    ]);
+    const server = secret({
+      identifier: 'NEW_TOKEN',
+      name: 'NEW_TOKEN',
+      secret_id: 'secret-server',
+      updated_at: '2026-08-06T12:00:00.000Z',
+      strategy: 'broker',
+      consumer: 'http_broker',
+    });
+
+    const result = applyProjectSecretResponse(optimistic, server);
+
+    expect(Array.isArray(result)).toBe(false);
+    expect((result as ProjectSecretsResponse).items[0]).toEqual(server);
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/view/secret-optimistic-cache.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-optimistic-cache.ts
@@ -1,0 +1,99 @@
+import type { ProjectSecret, ProjectSecretsResponse } from '@kortix/sdk';
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+
+export type ProjectSecretsCache = ProjectSecretsResponse | ProjectSecret[];
+
+export type OptimisticProjectSecretInput = {
+  projectId: string;
+  identifier: string;
+  name: string;
+  strategy: ProjectSecret['strategy'];
+  consumer: ProjectSecret['consumer'];
+  deliveryStatus: NonNullable<ProjectSecret['delivery_status']>;
+  egressPolicy: ProjectSecret['egress_policy'];
+  valueChanged?: boolean;
+};
+
+function items(cache: ProjectSecretsCache): ProjectSecret[] {
+  return Array.isArray(cache) ? cache : cache.items;
+}
+
+function withItems(cache: ProjectSecretsCache, nextItems: ProjectSecret[]): ProjectSecretsCache {
+  return Array.isArray(cache) ? nextItems : { ...cache, items: nextItems };
+}
+
+function replaceOrAppend(
+  cache: ProjectSecretsCache,
+  identifier: string,
+  nextSecret: ProjectSecret,
+): ProjectSecretsCache {
+  const currentItems = items(cache);
+  const index = currentItems.findIndex((secret) => secret.identifier === identifier);
+  if (index === -1) return withItems(cache, [...currentItems, nextSecret]);
+  const nextItems = currentItems.slice();
+  nextItems[index] = nextSecret;
+  return withItems(cache, nextItems);
+}
+
+export function applyOptimisticProjectSecretSave(
+  cache: ProjectSecretsCache,
+  input: OptimisticProjectSecretInput,
+): ProjectSecretsCache {
+  const existing = items(cache).find((secret) => secret.identifier === input.identifier);
+  const nextSecret: ProjectSecret = {
+    identifier: input.identifier,
+    name: input.name,
+    project_id: existing?.project_id ?? input.projectId,
+    secret_id: existing?.secret_id ?? null,
+    created_by: existing?.created_by ?? null,
+    created_at: existing?.created_at ?? null,
+    updated_at: existing?.updated_at ?? null,
+    system: existing?.system ?? false,
+    readonly: existing?.readonly ?? false,
+    purpose: existing?.purpose ?? null,
+    can_rotate: existing?.can_rotate ?? true,
+    managed_by: existing?.managed_by ?? null,
+    configured: true,
+    mine: existing?.mine ?? null,
+    effective_source: 'shared',
+    can_manage_shared: existing?.can_manage_shared ?? true,
+    strategy: input.strategy,
+    consumer: input.consumer,
+    delivery_status: input.deliveryStatus,
+    egress_policy: input.egressPolicy,
+    strategy_locked: existing?.strategy_locked ?? false,
+    last_rotated_at: existing?.last_rotated_at ?? null,
+    requires_rotation: input.valueChanged ? false : (existing?.requires_rotation ?? false),
+  };
+  return replaceOrAppend(cache, input.identifier, nextSecret);
+}
+
+export function beginOptimisticProjectSecretSave(
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+  input: OptimisticProjectSecretInput,
+): { previous: ProjectSecretsCache | undefined } {
+  const previous = queryClient.getQueryData<ProjectSecretsCache>(queryKey);
+  if (previous) {
+    queryClient.setQueryData<ProjectSecretsCache>(
+      queryKey,
+      applyOptimisticProjectSecretSave(previous, input),
+    );
+  }
+  return { previous };
+}
+
+export function rollbackOptimisticProjectSecretSave(
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+  previous: ProjectSecretsCache | undefined,
+): void {
+  if (previous) queryClient.setQueryData(queryKey, previous);
+}
+
+export function applyProjectSecretResponse(
+  cache: ProjectSecretsCache,
+  updated: ProjectSecret,
+): ProjectSecretsCache {
+  return replaceOrAppend(cache, updated.identifier, updated);
+}

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -75,8 +75,8 @@ import {
   type SecretEgressPolicy,
   deleteProjectSecret,
   getProjectDetail,
-  listProjectSecrets,
   listConnectors,
+  listProjectSecrets,
   setConnectorSecretBinding,
   setProjectSecretStrategy,
   upsertProjectSecret,
@@ -96,6 +96,13 @@ import {
   secretDeliveryOptions,
   secretDeliveryPresentation,
 } from './secret-delivery';
+import {
+  type OptimisticProjectSecretInput,
+  type ProjectSecretsCache,
+  applyProjectSecretResponse,
+  beginOptimisticProjectSecretSave,
+  rollbackOptimisticProjectSecretSave,
+} from './secret-optimistic-cache';
 
 const SECRET_NAME_REGEX = /^[A-Z_][A-Z0-9_]{0,63}$/;
 const IDENTIFIER_REGEX = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/;
@@ -124,6 +131,19 @@ interface SecretRow {
   egressPolicy: SecretEgressPolicy | null;
   requiresRotation: boolean;
 }
+
+type SecretSavePlan = {
+  finalKey: string;
+  finalIdentifier: string;
+  strategy: SecretDeliveryStrategy;
+  nextConsumer: SecretConsumer | null;
+  value: string | undefined;
+  hasValueChange: boolean;
+  shouldSetStrategy: boolean;
+  egressPolicy: SecretEgressPolicy | undefined;
+  bindingChanges: { bind: string[]; unbind: string[] };
+  optimistic: OptimisticProjectSecretInput;
+};
 
 export function SecretsView({ projectId }: { projectId: string }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -316,7 +336,7 @@ export function SecretsView({ projectId }: { projectId: string }) {
               )}
 
               <SecretDialog
-                key={dialogOpen ? (dialogRow?.identifier ?? 'new') : 'closed'}
+                key={dialogRow?.identifier ?? 'new'}
                 open={dialogOpen}
                 onOpenChange={setDialogOpen}
                 projectId={projectId}
@@ -608,6 +628,33 @@ function SecretDialog({
     currentInjection?.kind === 'header' ? (currentInjection.template ?? '') : '',
   );
 
+  const resetForm = () => {
+    setIdentifier(row?.identifier ?? '');
+    setKey(row?.key ?? '');
+    setValue('');
+    setStrategy(row?.strategy ?? 'runtime');
+    setBrokerConsumer(
+      row?.consumer === 'llm_gateway' ||
+        row?.consumer === 'connector' ||
+        row?.consumer === 'executor'
+        ? row.consumer
+        : 'http_broker',
+    );
+    setSelectedConnectorSlugs(null);
+    setBrokerHosts(currentPolicy?.rules.map((rule) => rule.host).join('\n') ?? '');
+    setBrokerMethods(currentPolicy?.rules[0]?.methods?.join(', ') ?? 'POST');
+    setBrokerPath(currentPolicy?.rules[0]?.path ?? '/');
+    setInjectionKind(currentInjection?.kind ?? 'header');
+    setInjectionTarget(
+      currentInjection?.kind === 'json_body_field'
+        ? currentInjection.path
+        : (currentInjection?.name ?? 'authorization'),
+    );
+    setInjectionTemplate(
+      currentInjection?.kind === 'header' ? (currentInjection.template ?? '') : '',
+    );
+  };
+
   const requiresValue = !row?.configured;
   const brokerPolicy = buildBrokerPolicy({
     hosts: brokerHosts,
@@ -618,72 +665,110 @@ function SecretDialog({
     template: injectionTemplate,
   });
 
-  const save = useMutation({
-    mutationFn: async () => {
-      const finalKey = (row?.key ?? key).trim().toUpperCase();
-      const finalIdentifier = (row?.identifier ?? identifier).trim() || finalKey;
-      const nextConnectorSlugs =
-        strategy === 'broker' && brokerConsumer === 'connector'
-          ? effectiveSelectedConnectorSlugs
-          : [];
-      const bindingChanges = connectorBindingChanges(
-        connectors,
-        finalIdentifier,
-        nextConnectorSlugs,
-      );
-      if (!SECRET_NAME_REGEX.test(finalKey)) {
-        throw new Error('Key: use A-Z, 0-9, _ only. Must start with a letter or _. Max 64 chars.');
-      }
-      if (!IDENTIFIER_REGEX.test(finalIdentifier)) {
-        throw new Error('Identifier: letters, numbers, _, ., - only. Max 128 chars.');
-      }
-      if (requiresValue && !value.trim()) {
-        throw new Error('Value is required.');
-      }
-      if (finalKey.startsWith('KORTIX_')) {
-        throw new Error('KORTIX_* keys are reserved for platform variables');
-      }
-      if (strategy === 'runtime' && row?.requiresRotation && !value.trim()) {
-        throw new Error('Enter a new value before making this secret readable in the sandbox.');
-      }
-      if (strategy === 'broker' && brokerConsumer === 'http_broker' && !brokerPolicy) {
-        throw new Error('Complete the broker destination and credential placement.');
-      }
-      if (
-        strategy === 'broker' &&
-        brokerConsumer === 'connector' &&
-        nextConnectorSlugs.length === 0
-      ) {
-        throw new Error('Select at least one connector.');
-      }
+  const prepareSavePlan = (): SecretSavePlan => {
+    const finalKey = (row?.key ?? key).trim().toUpperCase();
+    const finalIdentifier = (row?.identifier ?? identifier).trim() || finalKey;
+    const nextConnectorSlugs =
+      strategy === 'broker' && brokerConsumer === 'connector'
+        ? effectiveSelectedConnectorSlugs
+        : [];
+    const bindingChanges = connectorBindingChanges(connectors, finalIdentifier, nextConnectorSlugs);
+    if (!SECRET_NAME_REGEX.test(finalKey)) {
+      throw new Error('Key: use A-Z, 0-9, _ only. Must start with a letter or _. Max 64 chars.');
+    }
+    if (!IDENTIFIER_REGEX.test(finalIdentifier)) {
+      throw new Error('Identifier: letters, numbers, _, ., - only. Max 128 chars.');
+    }
+    if (requiresValue && !value.trim()) {
+      throw new Error('Value is required.');
+    }
+    if (finalKey.startsWith('KORTIX_')) {
+      throw new Error('KORTIX_* keys are reserved for platform variables');
+    }
+    if (strategy === 'runtime' && row?.requiresRotation && !value.trim()) {
+      throw new Error('Enter a new value before making this secret readable in the sandbox.');
+    }
+    if (strategy === 'broker' && brokerConsumer === 'http_broker' && !brokerPolicy) {
+      throw new Error('Complete the broker destination and credential placement.');
+    }
+    if (
+      strategy === 'broker' &&
+      brokerConsumer === 'connector' &&
+      nextConnectorSlugs.length === 0
+    ) {
+      throw new Error('Select at least one connector.');
+    }
 
-      if (!(strategy === 'broker' && brokerConsumer === 'connector')) {
+    const nextConsumer: SecretConsumer | null =
+      strategy === 'runtime'
+        ? 'sandbox'
+        : strategy === 'denied'
+          ? null
+          : strategy === 'egress'
+            ? 'network'
+            : brokerConsumer;
+    const hasValueChange = Boolean(value.trim()) || !row?.configured;
+    const egressPolicy =
+      strategy === 'broker' && brokerConsumer === 'http_broker' && brokerPolicy
+        ? brokerPolicy
+        : undefined;
+    const shouldSetStrategy =
+      strategy !== (row?.strategy ?? 'runtime') ||
+      nextConsumer !== (row?.consumer ?? 'sandbox') ||
+      strategy === 'broker';
+    return {
+      finalKey,
+      finalIdentifier,
+      strategy,
+      nextConsumer,
+      value: value.trim() ? value : undefined,
+      hasValueChange,
+      shouldSetStrategy,
+      egressPolicy,
+      bindingChanges,
+      optimistic: {
+        projectId,
+        identifier: finalIdentifier,
+        name: finalKey,
+        strategy,
+        consumer: nextConsumer,
+        deliveryStatus: strategy === 'denied' ? 'disabled' : 'available',
+        egressPolicy: egressPolicy ?? null,
+        valueChanged: Boolean(value.trim()),
+      },
+    };
+  };
+
+  const save = useMutation({
+    mutationFn: async (plan: SecretSavePlan) => {
+      const {
+        finalKey,
+        finalIdentifier,
+        strategy,
+        nextConsumer,
+        value: nextValue,
+        hasValueChange,
+        shouldSetStrategy,
+        egressPolicy,
+        bindingChanges,
+      } = plan;
+
+      if (!(strategy === 'broker' && nextConsumer === 'connector')) {
         await Promise.all(
           bindingChanges.unbind.map((slug) => setConnectorSecretBinding(projectId, slug, null)),
         );
       }
 
-      const nextConsumer: SecretConsumer | null =
-        strategy === 'runtime'
-          ? 'sandbox'
-          : strategy === 'denied'
-            ? null
-            : strategy === 'egress'
-              ? 'network'
-              : brokerConsumer;
-      const hasValueChange = Boolean(value.trim()) || !row?.configured;
       if (hasValueChange) {
         const result = await upsertProjectSecret(projectId, {
           name: finalKey,
           identifier: finalIdentifier,
-          ...(value.trim() ? { value } : {}),
+          ...(nextValue ? { value: nextValue } : {}),
           strategy,
           consumer: nextConsumer,
-          ...(strategy === 'broker' && brokerConsumer === 'http_broker' && brokerPolicy
-            ? { egress_policy: brokerPolicy }
-            : {}),
+          ...(egressPolicy ? { egress_policy: egressPolicy } : {}),
         });
-        if (strategy === 'broker' && brokerConsumer === 'connector') {
+        if (strategy === 'broker' && nextConsumer === 'connector') {
           await Promise.all([
             ...bindingChanges.unbind.map((slug) =>
               setConnectorSecretBinding(projectId, slug, null),
@@ -695,18 +780,12 @@ function SecretDialog({
         }
         return result;
       }
-      if (
-        strategy !== (row?.strategy ?? 'runtime') ||
-        nextConsumer !== (row?.consumer ?? 'sandbox') ||
-        strategy === 'broker'
-      ) {
+      if (shouldSetStrategy) {
         const result = await setProjectSecretStrategy(projectId, finalIdentifier, strategy, {
           consumer: nextConsumer,
-          ...(strategy === 'broker' && brokerConsumer === 'http_broker' && brokerPolicy
-            ? { egress_policy: brokerPolicy }
-            : {}),
+          ...(egressPolicy ? { egress_policy: egressPolicy } : {}),
         });
-        if (strategy === 'broker' && brokerConsumer === 'connector') {
+        if (strategy === 'broker' && nextConsumer === 'connector') {
           await Promise.all([
             ...bindingChanges.unbind.map((slug) =>
               setConnectorSecretBinding(projectId, slug, null),
@@ -720,22 +799,48 @@ function SecretDialog({
       }
       return null;
     },
-    onSuccess: () => {
-      successToast(
-        `Saved ${(row?.identifier ?? identifier).trim() || (row?.key ?? key).trim().toUpperCase()}`,
-      );
+    onMutate: async (plan) => {
+      const queryKey = ['project-secrets', projectId] as const;
+      await queryClient.cancelQueries({ queryKey });
+      const context = beginOptimisticProjectSecretSave(queryClient, queryKey, plan.optimistic);
+      onOpenChange(false);
+      return context;
+    },
+    onSuccess: (result, plan) => {
+      if (result) {
+        queryClient.setQueryData<ProjectSecretsCache>(['project-secrets', projectId], (cache) =>
+          cache ? applyProjectSecretResponse(cache, result) : cache,
+        );
+      }
+      successToast(`Saved ${plan.finalIdentifier}`);
+      resetForm();
       onSaved();
       queryClient.invalidateQueries({ queryKey: ['project-connectors', projectId] });
-      onOpenChange(false);
     },
-    onError: (err: Error) => errorToast(err.message || 'Failed to save secret'),
+    onError: (err: Error, _plan, context) => {
+      rollbackOptimisticProjectSecretSave(
+        queryClient,
+        ['project-secrets', projectId],
+        context?.previous,
+      );
+      onOpenChange(true);
+      errorToast(err.message || 'Failed to save secret');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
+      queryClient.invalidateQueries({ queryKey: ['project-connectors', projectId] });
+    },
   });
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (save.isPending) return;
     if (!isEdit && !key.trim()) return;
-    save.mutate();
+    try {
+      save.mutate(prepareSavePlan());
+    } catch (error) {
+      errorToast(error instanceof Error ? error.message : 'Failed to save secret');
+    }
   }
 
   const title = !row
@@ -775,6 +880,7 @@ function SecretDialog({
       open={open}
       onOpenChange={(next) => {
         if (save.isPending) return;
+        if (!next) resetForm();
         onOpenChange(next);
       }}
     >


### PR DESCRIPTION
## Summary

- Show a configured secret row before the save request finishes.
- Reconcile the optimistic row with the authoritative API response.
- Restore the previous cache and reopen the form when a save fails.
- Keep connector binding decisions stable throughout the mutation.

## Verification

- `bun test apps/web/src/features/workspace/customize/sections/view/secret-optimistic-cache.test.ts apps/web/src/features/workspace/customize/sections/view/secret-delivery.test.ts` — 23 pass, 0 fail.
- `pnpm --dir apps/web exec eslint ...` — pass.
- `pnpm --dir apps/web exec prettier --check ...` — pass.
- Local browser: the row appeared in 321 ms, the form closed, the success toast appeared, and the API returned `200`.
- Full web suite: 4,546 pass; one existing generated docs timestamp mismatch remains on `main`.
- Web typecheck: no changed-file diagnostics; 15 existing test-typing diagnostics remain.