### PR TITLE
fix(web): cache capability tab navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Kortix project
 
+## Linear tracking
+
+Capability-page work uses Team `Jay`, project `customize`, and the milestone that
+matches the active phase. Search before creating issues. Move the active issue to
+`In Progress` before editing. Mark it `Done` only after the change is merged,
+deployed to dev, and verified there.
+
 ## What "ownership" means
 
 The words "can you own this?", "are you on it?", and "can you take care of this?"

--- a/apps/web/src/features/workspace/capabilities/connectors/connectors-page.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/connectors-page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { listConnectors, type AdminConnector } from '@kortix/sdk';
+import { type AdminConnector } from '@kortix/sdk';
 import { MagnifyingGlassIcon, PlugIcon, PlusIcon } from '@phosphor-icons/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
@@ -35,6 +35,7 @@ import {
   ConnectorConnectedMark,
   ConnectorStatusBadge,
 } from './connector-identity';
+import { projectConnectorsQuery } from './project-connectors-query';
 import { providerLabel } from './provider-label';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { useProjectCan } from '@/lib/use-project-can';
@@ -196,11 +197,7 @@ export function ConnectorsPage({ projectId }: { projectId: string }) {
     [replaceParams],
   );
 
-  const connectorsQuery = useQuery({
-    queryKey: ['project-connectors', projectId],
-    queryFn: () => listConnectors(projectId),
-    staleTime: 10_000,
-  });
+  const connectorsQuery = useQuery(projectConnectorsQuery(projectId));
   const projectQuery = useQuery(projectDetailQuery(projectId));
 
   const connectors = useMemo(() => connectorsQuery.data?.connectors ?? [], [connectorsQuery.data]);

--- a/apps/web/src/features/workspace/capabilities/connectors/project-connectors-query.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/project-connectors-query.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+
+import { PROJECT_CONNECTORS_STALE_MS, projectConnectorsQuery } from './project-connectors-query';
+
+describe('projectConnectorsQuery', () => {
+  test('reuses cached connectors and refreshes them after ten seconds', () => {
+    const options = projectConnectorsQuery('project-1');
+
+    expect(options.queryKey).toEqual(['project-connectors', 'project-1']);
+    expect(options.staleTime).toBe(PROJECT_CONNECTORS_STALE_MS);
+    expect(options.refetchOnMount).toBe(true);
+  });
+});

--- a/apps/web/src/features/workspace/capabilities/connectors/project-connectors-query.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/project-connectors-query.ts
@@ -1,0 +1,12 @@
+import { listConnectors } from '@kortix/sdk';
+
+export const PROJECT_CONNECTORS_STALE_MS = 10_000;
+
+export function projectConnectorsQuery(projectId: string) {
+  return {
+    queryKey: ['project-connectors', projectId],
+    queryFn: () => listConnectors(projectId),
+    staleTime: PROJECT_CONNECTORS_STALE_MS,
+    refetchOnMount: true,
+  };
+}

--- a/apps/web/src/features/workspace/capabilities/shared/capability-tabs.test.ts
+++ b/apps/web/src/features/workspace/capabilities/shared/capability-tabs.test.ts
@@ -82,6 +82,18 @@ describe('CapabilityTabs Global rules control', () => {
   });
 });
 
+describe('CapabilityTabs route prefetch', () => {
+  test('fully prefetches every capability page behind the loading boundary', () => {
+    const body = code(source);
+    const tabsStart = body.indexOf('export function CapabilityTabs');
+    const tabs = body.slice(tabsStart);
+
+    expect(tabs).toMatch(
+      /<Link\s+href=\{capabilityTabHref\(projectId, tab\.key\)\}\s+prefetch=\{true\}>/,
+    );
+  });
+});
+
 /**
  * The tab bar is pinned by LAYOUT, not by `position`. Two classes carry that,
  * in two different files, and neither reads as load-bearing on its own — which

--- a/apps/web/src/features/workspace/capabilities/shared/capability-tabs.tsx
+++ b/apps/web/src/features/workspace/capabilities/shared/capability-tabs.tsx
@@ -143,7 +143,9 @@ export function CapabilityTabs({ projectId }: { projectId: string }) {
               asChild
               className="w-fit flex-none px-1 py-3"
             >
-              <Link href={capabilityTabHref(projectId, tab.key)}>{tab.label}</Link>
+              <Link href={capabilityTabHref(projectId, tab.key)} prefetch={true}>
+                {tab.label}
+              </Link>
             </TabsTrigger>
           ))}
         </TabsList>

--- a/apps/web/src/features/workspace/capabilities/shared/project-detail-query.test.ts
+++ b/apps/web/src/features/workspace/capabilities/shared/project-detail-query.test.ts
@@ -1,0 +1,76 @@
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
+import { describe, expect, test } from 'bun:test';
+
+import { PROJECT_DETAIL_STALE_MS, projectDetailQuery } from './project-detail-query';
+
+describe('projectDetailQuery', () => {
+  test('refreshes stale cached data when a capability page remounts', () => {
+    const options = projectDetailQuery('project-1');
+
+    expect(options.staleTime).toBe(PROJECT_DETAIL_STALE_MS);
+    expect(options.refetchOnMount).toBe(true);
+  });
+
+  test('keeps stale data visible while concurrent observers share one refresh', async () => {
+    const cached = { value: 'cached' };
+    const fresh = { value: 'fresh' };
+    let fetchCount = 0;
+    let resolveFetch: (value: typeof fresh) => void = () => {};
+    const fetchResult = new Promise<typeof fresh>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnMount: false } },
+    });
+    const options = {
+      ...projectDetailQuery('project-1'),
+      queryFn: () => {
+        fetchCount += 1;
+        return fetchResult;
+      },
+    };
+    queryClient.setQueryData(options.queryKey, cached, {
+      updatedAt: Date.now() - PROJECT_DETAIL_STALE_MS - 1,
+    });
+    const first = new QueryObserver(queryClient, options);
+    const second = new QueryObserver(queryClient, options);
+    const unsubscribeFirst = first.subscribe(() => {});
+    const unsubscribeSecond = second.subscribe(() => {});
+
+    expect(first.getCurrentResult().data).toEqual(cached);
+    expect(second.getCurrentResult().data).toEqual(cached);
+    expect(fetchCount).toBe(1);
+
+    resolveFetch(fresh);
+    await fetchResult;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(first.getCurrentResult().data).toEqual(fresh);
+    expect(second.getCurrentResult().data).toEqual(fresh);
+
+    unsubscribeFirst();
+    unsubscribeSecond();
+  });
+
+  test('does not refresh data inside the freshness window', () => {
+    let fetchCount = 0;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnMount: false } },
+    });
+    const options = {
+      ...projectDetailQuery('project-1'),
+      queryFn: async () => {
+        fetchCount += 1;
+        return { value: 'fresh' };
+      },
+    };
+    queryClient.setQueryData(options.queryKey, { value: 'cached' });
+    const observer = new QueryObserver(queryClient, options);
+    const unsubscribe = observer.subscribe(() => {});
+
+    expect(observer.getCurrentResult().data).toEqual({ value: 'cached' });
+    expect(fetchCount).toBe(0);
+
+    unsubscribe();
+  });
+});

--- a/apps/web/src/features/workspace/capabilities/shared/project-detail-query.ts
+++ b/apps/web/src/features/workspace/capabilities/shared/project-detail-query.ts
@@ -24,6 +24,7 @@ export function projectDetailQuery(projectId: string) {
     queryKey: ['project-detail', projectId],
     queryFn: () => getProjectDetail(projectId),
     staleTime: PROJECT_DETAIL_STALE_MS,
+    refetchOnMount: true,
   };
 }
 

--- a/docs/superpowers/specs/2026-08-06-capability-navigation-cache-design.md
+++ b/docs/superpowers/specs/2026-08-06-capability-navigation-cache-design.md
@@ -1,0 +1,52 @@
+# Capability Navigation Cache Design
+
+**Linear project:** `customize` (team `Jay`)
+
+**Linear milestone:** `5 · Navigation performance`
+
+**Plan:** [Capability navigation cache optimization plan](https://linear.app/sutharjay/document/capability-navigation-cache-optimization-plan-cda21e94acd7)
+
+## Problem
+
+Switching between Connectors, Skills, and Commands displays the full capability
+skeleton. Returning to a visited tab displays it again even while React Query
+still holds the page data.
+
+## Cause
+
+The routes are dynamic and use a shared `loading.tsx` boundary. Next.js 16 gives
+dynamic page segments a client-cache TTL of zero by default. Normal Link
+prefetching stops at the loading boundary.
+
+The shared `project-detail` query has a 10-second freshness window. The global
+QueryClient disables remount refetching, so stale capability data does not
+refresh when a user returns to Skills or Commands.
+
+## Design
+
+Every visible capability tab uses full route prefetching. This warms the route
+payload and client chunk under Next.js's five-minute static client-cache window.
+The change remains local to these three links.
+
+Capability query options explicitly refresh on mount when their cached data is
+stale. TanStack Query continues to return cached data during that background
+request. Cold loads retain the existing skeleton, error, and retry states.
+
+The connector catalogs retain their existing source-specific freshness windows.
+This change covers only `project-detail` and the project connector list.
+
+## Verification
+
+Tests cover full prefetch on all capability links and the query freshness
+contracts. Browser verification covers Connectors to Skills to Commands to
+Skills, visible content during stale refresh, and request counts.
+
+The change ships through a scoped PR, Deploy Dev, and repeated DOM and network
+assertions on `dev.kortix.com`.
+
+## Non-Goals
+
+- Do not merge the routes into one client page.
+- Do not enable global dynamic-route caching.
+- Do not enable Cache Components or partial prefetching.
+- Do not change connector catalog pagination or freshness.


### PR DESCRIPTION
## Summary\n- fully prefetch Connectors, Skills, and Commands route payloads\n- keep cached project and connector data visible during stale background refreshes\n- add query-cache and route-prefetch regression coverage\n\n## Test plan\n- bun test: 4,546 passed, 0 failed\n- focused cache tests: 17 passed, 0 failed\n- Next.js production build completed\n- production browser trace: 0 capability skeletons on warmed tab switches and 1 stale refresh after 10.2 seconds\n- changed-file ESLint: 0 errors, 1 pre-existing warning