### PR TITLE
fix(api): support pinned secret broker requests on Bun 1.2

### DIFF
--- a/apps/api/src/secrets/http-broker.test.ts
+++ b/apps/api/src/secrets/http-broker.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import type { SecretBrokerRequest } from '@kortix/api-contract';
 import type { SecretEgressPolicy } from '@kortix/db';
 import {
-  createPinnedLookup,
+  createPinnedRequestOptions,
   executeSecretBrokerRequest,
   prepareSecretBrokerRequest,
   redactSecretFromResponse,
@@ -170,19 +170,27 @@ test('redactSecretFromResponse handles repeated literal values', () => {
   expect(redacted.toString('utf8')).toBe('[REDACTED]:[REDACTED]');
 });
 
-test('createPinnedLookup returns an array when the runtime requests all addresses', async () => {
-  const lookup = createPinnedLookup({ address: '203.0.113.10', family: 4 });
-  const result = await new Promise<{ address: unknown; family: number | undefined }>(
-    (resolve, reject) => {
-      lookup('api.example.com', { all: true }, (error, address, family) => {
-        if (error) reject(error);
-        else resolve({ address, family });
-      });
-    },
+test('pinned transport connects to the verified IP without a runtime DNS lookup', () => {
+  const prepared = prepareSecretBrokerRequest(
+    policy({ rules: [{ host: 'api.example.com', methods: ['POST'], path: '/v1/*' }] }),
+    SECRET,
+    request({ url: 'https://api.example.com:8443/v1/messages' }),
   );
-
-  expect(result).toEqual({
-    address: [{ address: '203.0.113.10', family: 4 }],
-    family: undefined,
+  const options = createPinnedRequestOptions(prepared, {
+    address: '203.0.113.10',
+    family: 4,
   });
+
+  expect(options).toMatchObject({
+    hostname: '203.0.113.10',
+    port: '8443',
+    path: '/v1/messages',
+    method: 'POST',
+    servername: 'api.example.com',
+    headers: {
+      authorization: `Bearer ${SECRET}`,
+      host: 'api.example.com:8443',
+    },
+  });
+  expect('lookup' in options).toBe(false);
 });

--- a/apps/api/src/secrets/http-broker.ts
+++ b/apps/api/src/secrets/http-broker.ts
@@ -1,7 +1,6 @@
 import { lookup as dnsLookup } from 'node:dns/promises';
-import { request as httpsRequest } from 'node:https';
+import { request as httpsRequest, type RequestOptions } from 'node:https';
 import { isIP } from 'node:net';
-import type { LookupFunction } from 'node:net';
 import type {
   SecretBrokerRequest,
   SecretBrokerResponse,
@@ -252,13 +251,22 @@ async function resolvePinnedAddress(url: URL): Promise<{ address: string; family
   return { address: selected.address, family: selected.family === 6 ? 6 : 4 };
 }
 
-export function createPinnedLookup(pinned: { address: string; family: 4 | 6 }): LookupFunction {
-  return (_hostname, options, callback) => {
-    if (options.all) {
-      callback(null, [pinned]);
-      return;
-    }
-    callback(null, pinned.address, pinned.family);
+export function createPinnedRequestOptions(
+  prepared: PreparedBrokerRequest,
+  pinned: { address: string; family: 4 | 6 },
+): RequestOptions {
+  return {
+    protocol: 'https:',
+    hostname: pinned.address,
+    family: pinned.family,
+    port: prepared.url.port || 443,
+    path: `${prepared.url.pathname}${prepared.url.search}`,
+    method: prepared.method,
+    headers: {
+      ...prepared.headers,
+      host: prepared.url.host,
+    },
+    servername: isIP(prepared.url.hostname) === 0 ? prepared.url.hostname : undefined,
   };
 }
 
@@ -274,16 +282,7 @@ export async function pinnedHttpsTransport(
       reject(error);
     };
     const request = httpsRequest(
-      {
-        protocol: 'https:',
-        hostname: prepared.url.hostname,
-        port: prepared.url.port || 443,
-        path: `${prepared.url.pathname}${prepared.url.search}`,
-        method: prepared.method,
-        headers: prepared.headers,
-        servername: isIP(prepared.url.hostname) === 0 ? prepared.url.hostname : undefined,
-        lookup: createPinnedLookup(pinned),
-      },
+      createPinnedRequestOptions(prepared, pinned),
       (response) => {
         const chunks: Buffer[] = [];
         let size = 0;


### PR DESCRIPTION
## Summary

- Connect HTTPS broker requests to the SSRF-verified IP address.
- Preserve the original host for TLS SNI and the HTTP Host header.
- Avoid the Bun 1.2 custom DNS lookup failure that returned HTTP 502.

## Verification

- `bun test --isolate --env-file=apps/api/scripts/test.env apps/api/src/secrets/http-broker.test.ts apps/api/src/__tests__/unit-project-secret-broker-route.test.ts` — 18 pass, 0 fail.
- `pnpm --filter kortix-api typecheck` — exit 0.
- `pnpm --filter kortix-api test` — 5,577 pass, 62 skip, 0 fail.
- `cd tests && bun bin/ke2e.ts coverage` — 519/529 routes covered, 10 allowlisted, 0 uncovered.
- `oven/bun:1.2-slim` HTTPS request with pinned IP, SNI, and Host header — HTTP 200.