### PR TITLE
fix(web): hide the regressed capability pages behind a flag

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/(capabilities)/commands/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/(capabilities)/commands/page.tsx
@@ -2,6 +2,8 @@
 
 import { useParams } from 'next/navigation';
 
+import { CapabilityRouteGate } from '@/features/workspace/capabilities/shared/capability-route-gate';
+
 import { CommandsPage } from '@/features/workspace/capabilities/commands/commands-page';
 
 /**
@@ -13,8 +15,10 @@ export default function ProjectCommandsPage() {
   const { id: projectId } = useParams<{ id: string }>();
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <CommandsPage projectId={projectId} />
-    </div>
+    <CapabilityRouteGate projectId={projectId} section="commands">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <CommandsPage projectId={projectId} />
+      </div>
+    </CapabilityRouteGate>
   );
 }

--- a/apps/web/src/app/(app)/projects/[id]/(capabilities)/connectors/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/(capabilities)/connectors/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useParams } from 'next/navigation';
+
+import { CapabilityRouteGate } from '@/features/workspace/capabilities/shared/capability-route-gate';
 import { Suspense } from 'react';
 
 import { CapabilitiesSkeleton } from '@/features/workspace/capabilities/shared/capability-skeleton';
@@ -21,10 +23,12 @@ export default function ProjectConnectorsPage() {
   const { id: projectId } = useParams<{ id: string }>();
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <Suspense fallback={<CapabilitiesSkeleton />}>
-        <ConnectorsPage projectId={projectId} />
-      </Suspense>
-    </div>
+    <CapabilityRouteGate projectId={projectId} section="connectors">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <Suspense fallback={<CapabilitiesSkeleton />}>
+          <ConnectorsPage projectId={projectId} />
+        </Suspense>
+      </div>
+    </CapabilityRouteGate>
   );
 }

--- a/apps/web/src/app/(app)/projects/[id]/(capabilities)/skills/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/(capabilities)/skills/page.tsx
@@ -2,6 +2,8 @@
 
 import { useParams } from 'next/navigation';
 
+import { CapabilityRouteGate } from '@/features/workspace/capabilities/shared/capability-route-gate';
+
 import { SkillsPage } from '@/features/workspace/capabilities/skills/skills-page';
 
 /**
@@ -12,8 +14,10 @@ export default function ProjectSkillsPage() {
   const { id: projectId } = useParams<{ id: string }>();
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <SkillsPage projectId={projectId} />
-    </div>
+    <CapabilityRouteGate projectId={projectId} section="skills">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <SkillsPage projectId={projectId} />
+      </div>
+    </CapabilityRouteGate>
   );
 }

--- a/apps/web/src/features/workspace/capabilities/shared/capability-route-gate.tsx
+++ b/apps/web/src/features/workspace/capabilities/shared/capability-route-gate.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+/**
+ * Closes the direct route into a standalone capability page while #6054 is
+ * flagged off.
+ *
+ * Gating the navigation (`capabilityTabHref`) stops the product LINKING here,
+ * but not a bookmark, a pasted URL, a command-palette entry with a literal
+ * href, or a browser-history entry from before the flag was turned off. Those
+ * would otherwise land on the regressed page that is supposed to be hidden, so
+ * the route itself has to bounce.
+ *
+ * Sends you to the Customize overlay on the same section — the surface these
+ * pages replaced — so the destination still answers what you came for.
+ */
+import { useRouter } from 'next/navigation';
+import { type ReactNode, useEffect } from 'react';
+
+import { CapabilitiesSkeleton } from '@/features/workspace/capabilities/shared/capability-skeleton';
+import { type CapabilitySection, capabilityPagesEnabled } from '@/lib/capability-pages';
+
+export function CapabilityRouteGate({
+  projectId,
+  section,
+  children,
+}: {
+  projectId: string;
+  section: CapabilitySection;
+  children: ReactNode;
+}) {
+  const router = useRouter();
+  const enabled = capabilityPagesEnabled();
+
+  useEffect(() => {
+    if (enabled) return;
+    // `replace`, not `push`: the hidden page must not sit in history where Back
+    // would return to it.
+    router.replace(`/projects/${projectId}/customize/${section}`);
+  }, [enabled, projectId, section, router]);
+
+  // Render the skeleton rather than the page during the redirect — mounting the
+  // real page would fire its queries and flash the surface we are hiding.
+  if (!enabled) return <CapabilitiesSkeleton />;
+
+  return <>{children}</>;
+}

--- a/apps/web/src/features/workspace/capabilities/shared/capability-tab-routes.test.ts
+++ b/apps/web/src/features/workspace/capabilities/shared/capability-tab-routes.test.ts
@@ -8,8 +8,20 @@ describe('CAPABILITY_TABS', () => {
 });
 
 describe('capabilityTabHref', () => {
-  test('builds a project-scoped path', () => {
-    expect(capabilityTabHref('p1', 'skills')).toBe('/projects/p1/skills');
+  test('builds a project-scoped path to wherever the section currently lives', () => {
+    // Flag-dependent since #6054 was put behind NEXT_PUBLIC_CAPABILITY_PAGES:
+    // this is the one choke point the sidebar, the tab strip and project home
+    // all use, so it points at the overlay while the pages are hidden.
+    const previous = process.env.NEXT_PUBLIC_CAPABILITY_PAGES;
+    try {
+      process.env.NEXT_PUBLIC_CAPABILITY_PAGES = 'true';
+      expect(capabilityTabHref('p1', 'skills')).toBe('/projects/p1/skills');
+      process.env.NEXT_PUBLIC_CAPABILITY_PAGES = 'false';
+      expect(capabilityTabHref('p1', 'skills')).toBe('/projects/p1/customize/skills');
+    } finally {
+      if (previous === undefined) delete process.env.NEXT_PUBLIC_CAPABILITY_PAGES;
+      else process.env.NEXT_PUBLIC_CAPABILITY_PAGES = previous;
+    }
   });
 });
 

--- a/apps/web/src/features/workspace/capabilities/shared/capability-tab-routes.ts
+++ b/apps/web/src/features/workspace/capabilities/shared/capability-tab-routes.ts
@@ -1,3 +1,5 @@
+import { capabilitySectionHref } from '@/lib/capability-pages';
+
 /**
  * The three capability pages that graduated out of the Customize overlay.
  * Order is the tab order; it is also the order the sidebar lists them in.
@@ -13,8 +15,17 @@ export const CAPABILITY_TABS: readonly CapabilityTab[] = [
   { key: 'commands', label: 'Commands' },
 ];
 
+/**
+ * Where a capability tab points.
+ *
+ * The single choke point for the sidebar, the tab strip and project home, so
+ * gating it here is what stops the product linking anyone into the standalone
+ * pages while they are flagged off (#6054). With the flag off the same click
+ * opens the Customize overlay on that section instead — the surface those
+ * pages replaced.
+ */
 export function capabilityTabHref(projectId: string, key: CapabilityTab['key']): string {
-  return `/projects/${projectId}/${key}`;
+  return capabilitySectionHref(projectId, key);
 }
 
 export function activeCapabilityTab(pathname: string): CapabilityTab['key'] | null {

--- a/apps/web/src/features/workspace/customize/customize-panel.tsx
+++ b/apps/web/src/features/workspace/customize/customize-panel.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import dynamic from 'next/dynamic';
+
 import { ScheduleView } from '@/components/projects/schedule-view';
+import Loading from '@/components/ui/loading';
 import { Button } from '@/components/ui/button';
 import { FadedScrollArea } from '@/components/ui/faded-scroll-area';
 import { Label } from '@/components/ui/label';
@@ -9,6 +12,36 @@ import { Close } from '@/features/icon/icons/close';
 import { MarketplaceView } from '@/features/marketplace/marketplace-view';
 import { useReviewSessionSummary } from '@/features/review-center/hooks/use-review-session-summary';
 import { AgentsView } from '@/features/workspace/customize/sections/view/agents-view';
+// Restored overlay sections while the standalone capability pages are flagged
+// off (#6054). Loaded lazily — `connectors-view.tsx` alone is ~5k lines, and
+// the overlay opens on `agents`, so none of this belongs in its first chunk.
+// Same components the capability pages render.
+const ConnectorsView = dynamic(
+  () =>
+    import('@/features/workspace/customize/sections/connectors-view').then((m) => m.ConnectorsView),
+  { ssr: false, loading: () => <SectionChunkFallback /> },
+);
+const SkillsView = dynamic(
+  () =>
+    import('@/features/workspace/customize/sections/view/skills-view').then((m) => m.SkillsView),
+  { ssr: false, loading: () => <SectionChunkFallback /> },
+);
+const CommandsView = dynamic(
+  () =>
+    import('@/features/workspace/customize/sections/view/commands-view').then(
+      (m) => m.CommandsView,
+    ),
+  { ssr: false, loading: () => <SectionChunkFallback /> },
+);
+
+/** Holds the section's space while its chunk arrives. */
+function SectionChunkFallback() {
+  return (
+    <div className="flex min-h-64 items-center justify-center">
+      <Loading className="size-5 shrink-0" />
+    </div>
+  );
+}
 import { ChannelsView } from '@/features/workspace/customize/sections/view/channels-view';
 import { ComputersView } from '@/features/workspace/customize/sections/view/computers-view';
 import { GitView } from '@/features/workspace/customize/sections/view/git-view';
@@ -376,6 +409,15 @@ function SectionContent({
   switch (section) {
     case 'agents':
       return <AgentsView projectId={projectId} />;
+    // Back in the overlay while the standalone capability pages are flagged off
+    // (#6054). These are the SAME view components the new pages render, so the
+    // flag decides the shell, not the functionality.
+    case 'connectors':
+      return <ConnectorsView projectId={projectId} />;
+    case 'skills':
+      return <SkillsView projectId={projectId} />;
+    case 'commands':
+      return <CommandsView projectId={projectId} />;
     case 'marketplace':
       return <MarketplaceView projectId={projectId} />;
     case 'secrets':

--- a/apps/web/src/lib/capability-pages.test.ts
+++ b/apps/web/src/lib/capability-pages.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The #6054 kill-switch, in both positions.
+ *
+ * Marko asked for the regressed capability pages to be removed or flagged off
+ * "until not optimal". A half-applied flag is worse than none: if the nav stops
+ * linking to a page but the route still serves it, a bookmark or a stale
+ * history entry still lands on the surface that was supposed to be hidden, and
+ * whoever flipped the switch believes it worked.
+ *
+ * So these pin both directions at every entry point:
+ *   OFF — nothing points at the pages, deep links open the overlay, and the
+ *         three sections are overlay sections again.
+ *   ON  — #6054 exactly as merged.
+ *
+ * Plain loops rather than `test.each`: the repo's `@types/bun` does not type
+ * `test.each`, and the three files using it are a known `tsc` wart. No need for
+ * a fourth.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+
+const KEY = 'NEXT_PUBLIC_CAPABILITY_PAGES';
+const SECTIONS = ['connectors', 'skills', 'commands'] as const;
+const original = process.env[KEY];
+
+afterEach(() => {
+  if (original === undefined) delete process.env[KEY];
+  else process.env[KEY] = original;
+});
+
+function setFlag(on: boolean | undefined) {
+  if (on === undefined) delete process.env[KEY];
+  else process.env[KEY] = String(on);
+}
+
+/** The modules read the flag per call, so one import serves both positions. */
+async function mods() {
+  return { ...(await import('./capability-pages')), ...(await import('./customize-sections')) };
+}
+
+describe('capabilityPagesEnabled', () => {
+  test('defaults to OFF when unset', async () => {
+    setFlag(undefined);
+    expect((await mods()).capabilityPagesEnabled()).toBe(false);
+  });
+
+  test('an unset env must never expose the pages', async () => {
+    // The whole point of the switch: a default of ON would mean a fresh deploy
+    // silently ships the regressed surface.
+    setFlag(undefined);
+    const { capabilitySectionHref } = await mods();
+    expect(capabilitySectionHref('p1', 'skills')).toBe('/projects/p1/customize/skills');
+  });
+
+  test('turns on explicitly', async () => {
+    setFlag(true);
+    expect((await mods()).capabilityPagesEnabled()).toBe(true);
+  });
+});
+
+describe('where a capability section lives', () => {
+  test('OFF points every section at the Customize overlay', async () => {
+    setFlag(false);
+    const { capabilitySectionHref } = await mods();
+    for (const section of SECTIONS) {
+      expect(capabilitySectionHref('p1', section)).toBe(`/projects/p1/customize/${section}`);
+    }
+  });
+
+  test('ON points every section at its standalone page', async () => {
+    setFlag(true);
+    const { capabilitySectionHref } = await mods();
+    for (const section of SECTIONS) {
+      expect(capabilitySectionHref('p1', section)).toBe(`/projects/p1/${section}`);
+    }
+  });
+});
+
+describe('deep links into /customize/<section>', () => {
+  test('OFF does NOT redirect them away from the overlay', async () => {
+    setFlag(false);
+    const { legacyCustomizeRedirect } = await mods();
+    for (const section of SECTIONS) {
+      expect(legacyCustomizeRedirect('p1', section)).toBeNull();
+    }
+  });
+
+  test('ON redirects them to the standalone pages', async () => {
+    setFlag(true);
+    const { legacyCustomizeRedirect } = await mods();
+    for (const section of SECTIONS) {
+      expect(legacyCustomizeRedirect('p1', section)).toBe(`/projects/p1/${section}`);
+    }
+  });
+
+  test('Files and Changes always redirect, in both positions', async () => {
+    // They left the overlay in an earlier, unrelated change. This flag governs
+    // #6054 only — sweeping them in would revert someone else's work.
+    for (const on of [true, false]) {
+      setFlag(on);
+      const { legacyCustomizeRedirect } = await mods();
+      expect(legacyCustomizeRedirect('p1', 'files')).toBe('/projects/p1/files');
+      expect(legacyCustomizeRedirect('p1', 'changes')).toBe(
+        '/projects/p1/files?panel=proposed-changes',
+      );
+    }
+  });
+});
+
+describe('the overlay can host the sections again', () => {
+  test('each one parses as a real overlay section', async () => {
+    setFlag(false);
+    const { parseCustomizeSection, CUSTOMIZE_SECTIONS } = await mods();
+    for (const section of SECTIONS) {
+      // Without this the deep-link page falls through to `openCustomize(undefined)`
+      // and silently reopens on whatever section you last viewed.
+      expect(parseCustomizeSection(section)).toBe(section);
+      expect(CUSTOMIZE_SECTIONS).toContain(section);
+    }
+  });
+
+  test('every overlay section has an access gate', async () => {
+    // `CUSTOMIZE_SECTION_ACCESS` is a total Record over CustomizeSection, so
+    // re-adding a section without a gate entry is a type error — and would
+    // render that section ungated if the type were ever loosened.
+    const { CUSTOMIZE_SECTIONS } = await mods();
+    const { CUSTOMIZE_SECTION_ACCESS } = await import('./project-actions');
+    for (const section of CUSTOMIZE_SECTIONS) {
+      expect(CUSTOMIZE_SECTION_ACCESS[section]?.read).toBeTruthy();
+    }
+  });
+});
+
+describe('command-palette href resolution', () => {
+  test('OFF opens the overlay', async () => {
+    setFlag(false);
+    const { resolveCustomizeOverlayHref } = await mods();
+    for (const section of SECTIONS) {
+      expect(resolveCustomizeOverlayHref(`/projects/p1/customize/${section}`)).toEqual({
+        opensOverlay: true,
+        section,
+      });
+    }
+  });
+
+  test('ON navigates instead, so the route can forward', async () => {
+    setFlag(true);
+    const { resolveCustomizeOverlayHref } = await mods();
+    for (const section of SECTIONS) {
+      expect(resolveCustomizeOverlayHref(`/projects/p1/customize/${section}`)).toEqual({
+        opensOverlay: false,
+      });
+    }
+  });
+
+  test('a normal overlay section is unaffected by the flag', async () => {
+    for (const on of [true, false]) {
+      setFlag(on);
+      const { resolveCustomizeOverlayHref } = await mods();
+      expect(resolveCustomizeOverlayHref('/projects/p1/customize/agents')).toEqual({
+        opensOverlay: true,
+        section: 'agents',
+      });
+    }
+  });
+});

--- a/apps/web/src/lib/capability-pages.ts
+++ b/apps/web/src/lib/capability-pages.ts
@@ -1,0 +1,51 @@
+/**
+ * Kill-switch for the standalone capability pages (#6054).
+ *
+ * #6054 moved Connectors, Skills and Commands out of the Customize overlay into
+ * their own browsable pages. The rework regressed the experience, so it is
+ * hidden until it clears the bar — Marko: "rm it for now / put behind feature
+ * flag or similar until not optimal".
+ *
+ * OFF (the default) restores the previous behaviour exactly: the three sections
+ * live in the Customize overlay again, the standalone routes bounce there, and
+ * nothing in the product links to them. ON gives you #6054 as merged.
+ *
+ * Nothing was deleted or reverted — the pages and their tests stay in the tree,
+ * and the new page components already render the same underlying views, so the
+ * flag only decides which shell you get.
+ *
+ * Enable with `NEXT_PUBLIC_CAPABILITY_PAGES=true`.
+ *
+ * Deliberately web-local rather than a `@kortix/sdk` FeatureFlags entry: the
+ * SDK's exported names are a published API contract, and this switch is a
+ * temporary rollout gate for one web surface, not a capability the SDK offers.
+ * It reuses the SDK's parser so the env-var semantics match every other flag.
+ */
+import { parseFlagOverride } from '@kortix/sdk';
+
+/**
+ * Whether the standalone Connectors / Skills / Commands pages are live.
+ *
+ * Read through a function, not a module-level const: `NEXT_PUBLIC_*` is inlined
+ * at build time, but a const captured at module eval would also freeze the
+ * value for tests that set the variable per-case.
+ */
+export function capabilityPagesEnabled(): boolean {
+  return parseFlagOverride(process.env.NEXT_PUBLIC_CAPABILITY_PAGES) ?? false;
+}
+
+/** The three sections #6054 moved. Everything gated by this flag is one of these. */
+export const CAPABILITY_SECTIONS = ['connectors', 'skills', 'commands'] as const;
+
+export type CapabilitySection = (typeof CAPABILITY_SECTIONS)[number];
+
+export function isCapabilitySection(value: string | null | undefined): value is CapabilitySection {
+  return !!value && (CAPABILITY_SECTIONS as readonly string[]).includes(value);
+}
+
+/** Where a capability section lives right now, given the flag. */
+export function capabilitySectionHref(projectId: string, section: CapabilitySection): string {
+  return capabilityPagesEnabled()
+    ? `/projects/${projectId}/${section}`
+    : `/projects/${projectId}/customize/${section}`;
+}

--- a/apps/web/src/lib/customize-sections.test.ts
+++ b/apps/web/src/lib/customize-sections.test.ts
@@ -8,6 +8,24 @@ import {
   resolveCustomizeOverlayHref,
 } from './customize-sections';
 
+
+/**
+ * #6054 was put behind NEXT_PUBLIC_CAPABILITY_PAGES, so three of the
+ * assertions below are flag-dependent. They assert the ON position — the
+ * behaviour #6054 shipped — and `capability-pages.test.ts` covers OFF plus
+ * both positions of every other entry point.
+ */
+function withCapabilityPages<T>(on: boolean, fn: () => T): T {
+  const previous = process.env.NEXT_PUBLIC_CAPABILITY_PAGES;
+  process.env.NEXT_PUBLIC_CAPABILITY_PAGES = String(on);
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) delete process.env.NEXT_PUBLIC_CAPABILITY_PAGES;
+    else process.env.NEXT_PUBLIC_CAPABILITY_PAGES = previous;
+  }
+}
+
 describe('customize sections', () => {
   test('files is not a customize section — it lives on the standalone files page', () => {
     expect(parseCustomizeSection('files')).toBeNull();
@@ -21,13 +39,14 @@ describe('customize sections', () => {
     expect(CUSTOMIZE_SECTIONS).not.toContain('dev');
   });
 
-  test('connectors, skills, and commands graduated out of the overlay', () => {
-    expect(CUSTOMIZE_SECTIONS).not.toContain('connectors');
-    expect(CUSTOMIZE_SECTIONS).not.toContain('skills');
-    expect(CUSTOMIZE_SECTIONS).not.toContain('commands');
-    expect(parseCustomizeSection('connectors')).toBeNull();
-    expect(parseCustomizeSection('skills')).toBeNull();
-    expect(parseCustomizeSection('commands')).toBeNull();
+  test('connectors, skills, and commands are overlay sections again', () => {
+    // They graduated in #6054 and came back when it was flagged off: the
+    // overlay has to be able to host them, or a deep link with the flag off
+    // resolves to nothing and reopens on the last-viewed section.
+    for (const section of ['connectors', 'skills', 'commands'] as const) {
+      expect(CUSTOMIZE_SECTIONS).toContain(section);
+      expect(parseCustomizeSection(section)).toBe(section);
+    }
   });
 
   test('parses every canonical section and rejects unknowns', () => {
@@ -47,10 +66,12 @@ describe('legacyCustomizeRedirect', () => {
       '/projects/p1/files?panel=proposed-changes',
     );
   });
-  test('routes the graduated sections to their own pages', () => {
-    expect(legacyCustomizeRedirect('p1', 'connectors')).toBe('/projects/p1/connectors');
-    expect(legacyCustomizeRedirect('p1', 'skills')).toBe('/projects/p1/skills');
-    expect(legacyCustomizeRedirect('p1', 'commands')).toBe('/projects/p1/commands');
+  test('routes the graduated sections to their own pages when the flag is ON', () => {
+    withCapabilityPages(true, () => {
+      expect(legacyCustomizeRedirect('p1', 'connectors')).toBe('/projects/p1/connectors');
+      expect(legacyCustomizeRedirect('p1', 'skills')).toBe('/projects/p1/skills');
+      expect(legacyCustomizeRedirect('p1', 'commands')).toBe('/projects/p1/commands');
+    });
   });
   test('leaves overlay sections alone', () => {
     expect(legacyCustomizeRedirect('p1', 'agents')).toBeNull();
@@ -87,13 +108,15 @@ describe('resolveCustomizeOverlayHref', () => {
     // an unresolvable segment fell back to `openCustomize(undefined)`, which
     // silently opened the overlay on whatever section the user last viewed
     // instead of navigating anywhere.
-    expect(resolveCustomizeOverlayHref('/projects/p1/customize/skills')).toEqual({
-      opensOverlay: false,
+    withCapabilityPages(true, () => {
+      expect(resolveCustomizeOverlayHref('/projects/p1/customize/skills')).toEqual({
+        opensOverlay: false,
+      });
+      expect(resolveCustomizeOverlayHref('/projects/p1/customize/commands')).toEqual({
+        opensOverlay: false,
+      });
     });
-    expect(resolveCustomizeOverlayHref('/projects/p1/customize/commands')).toEqual({
-      opensOverlay: false,
-    });
-    expect(resolveCustomizeOverlayHref('/projects/p1/customize/connectors')).toEqual({
+    expect(resolveCustomizeOverlayHref('/projects/p1/customize/nope')).toEqual({
       opensOverlay: false,
     });
     expect(resolveCustomizeOverlayHref('/projects/p1/customize/nonsense')).toEqual({

--- a/apps/web/src/lib/customize-sections.ts
+++ b/apps/web/src/lib/customize-sections.ts
@@ -1,3 +1,5 @@
+import { capabilityPagesEnabled, isCapabilitySection } from '@/lib/capability-pages';
+
 /**
  * Customize section identifiers + helpers.
  *
@@ -18,6 +20,12 @@ export type CustomizeSection =
   | 'git'
   | 'review'
   | 'agents'
+  // Connectors/Skills/Commands are overlay sections again while the standalone
+  // capability pages (#6054) are behind NEXT_PUBLIC_CAPABILITY_PAGES. With the
+  // flag ON they are still reachable here — the deep link just redirects out.
+  | 'connectors'
+  | 'skills'
+  | 'commands'
   | 'marketplace'
   | 'secrets'
   | 'llm-management'
@@ -43,6 +51,9 @@ export const CUSTOMIZE_SECTIONS: readonly CustomizeSection[] = [
   'git',
   'review',
   'agents',
+  'connectors',
+  'skills',
+  'commands',
   'marketplace',
   'secrets',
   'llm-management',
@@ -71,6 +82,16 @@ export const CUSTOMIZE_SECTIONS: readonly CustomizeSection[] = [
 const GRADUATED: Record<string, (projectId: string) => string> = {
   files: (p) => `/projects/${p}/files`,
   changes: (p) => `/projects/${p}/files?panel=proposed-changes`,
+};
+
+/**
+ * Graduated only while the capability pages are enabled (#6054).
+ *
+ * Files and Changes left the overlay in an earlier, unrelated change and always
+ * redirect. These three are the ones the flag governs: with it OFF the deep
+ * link must fall through and open the overlay, which is where they live again.
+ */
+const GRADUATED_BEHIND_FLAG: Record<string, (projectId: string) => string> = {
   connectors: (p) => `/projects/${p}/connectors`,
   skills: (p) => `/projects/${p}/skills`,
   commands: (p) => `/projects/${p}/commands`,
@@ -81,7 +102,9 @@ export function legacyCustomizeRedirect(
   rawSection: string | null | undefined,
 ): string | null {
   if (!rawSection) return null;
-  const build = GRADUATED[rawSection];
+  const build =
+    GRADUATED[rawSection] ??
+    (capabilityPagesEnabled() ? GRADUATED_BEHIND_FLAG[rawSection] : undefined);
   return build ? build(projectId) : null;
 }
 
@@ -115,5 +138,12 @@ export function resolveCustomizeOverlayHref(href: string): CustomizeOverlayMatch
   if (!match) return { opensOverlay: false };
   if (!match[1]) return { opensOverlay: true, section: undefined };
   const section = parseCustomizeSection(match[1]);
-  return section ? { opensOverlay: true, section } : { opensOverlay: false };
+  if (!section) return { opensOverlay: false };
+  // Connectors/Skills/Commands are overlay sections only while the standalone
+  // capability pages are flagged off (#6054). With the flag ON the caller must
+  // fall through to a normal navigation so the deep-link route can forward to
+  // the real page, instead of the palette opening an overlay section that is
+  // no longer where those live.
+  if (isCapabilitySection(section) && capabilityPagesEnabled()) return { opensOverlay: false };
+  return { opensOverlay: true, section };
 }

--- a/apps/web/src/lib/menu-registry.test.ts
+++ b/apps/web/src/lib/menu-registry.test.ts
@@ -129,15 +129,22 @@ describe('graduated capability entries are not shadowed by Customize', () => {
     expect(matchesPaletteQuery(customizeItem!, 'agents')).toBe(true);
   });
 
-  test('the Connectors/Skills/Commands entries navigate to the standalone pages, not /customize/*', () => {
-    expect(skillsItem!.href).toBe('/projects/{projectId}/skills');
-    expect(commandsItem!.href).toBe('/projects/{projectId}/commands');
-    expect(connectorsItem!.href).toBe('/projects/{projectId}/connectors');
+  test('the Connectors/Skills/Commands entries point at the flag-aware deep link', () => {
+    // These were literal `/projects/{projectId}/<section>` hrefs until #6054
+    // went behind NEXT_PUBLIC_CAPABILITY_PAGES. A registry href is a static
+    // string and cannot read the flag, so it now targets the /customize/<section>
+    // deep link, which resolves to the standalone page when the flag is ON and
+    // opens the overlay when it is OFF. One href, correct in both positions.
+    expect(skillsItem!.href).toBe('/projects/{projectId}/customize/skills');
+    expect(commandsItem!.href).toBe('/projects/{projectId}/customize/commands');
+    expect(connectorsItem!.href).toBe('/projects/{projectId}/customize/connectors');
   });
 
-  test('proj-connectors-policies no longer advertises a Customize destination it cannot reach', () => {
+  test('proj-connectors-policies still does not promise a destination it cannot reach', () => {
+    // The label must not claim a Policies tab. The href follows the same
+    // flag-aware deep link as the other capability entries.
     expect(policiesItem).toBeDefined();
-    expect(policiesItem!.href).toBe('/projects/{projectId}/connectors');
-    expect(policiesItem!.label).not.toContain('Customize');
+    expect(policiesItem!.href).toBe('/projects/{projectId}/customize/connectors');
+    expect(policiesItem!.label).not.toContain('Policies tab');
   });
 });

--- a/apps/web/src/lib/menu-registry.ts
+++ b/apps/web/src/lib/menu-registry.ts
@@ -416,7 +416,7 @@ export const menuRegistry: MenuItemDef[] = [
     group: 'navigation',
     showIn: ['commandPalette'],
     kind: 'navigate',
-    href: '/projects/{projectId}/skills',
+    href: '/projects/{projectId}/customize/skills',
     requiresProject: true,
     keywords: 'skills project customize abilities',
   },
@@ -427,7 +427,7 @@ export const menuRegistry: MenuItemDef[] = [
     group: 'navigation',
     showIn: ['commandPalette'],
     kind: 'navigate',
-    href: '/projects/{projectId}/commands',
+    href: '/projects/{projectId}/customize/commands',
     requiresProject: true,
     keywords: 'commands slash project customize',
   },
@@ -449,7 +449,7 @@ export const menuRegistry: MenuItemDef[] = [
     group: 'navigation',
     showIn: ['commandPalette'],
     kind: 'navigate',
-    href: '/projects/{projectId}/connectors',
+    href: '/projects/{projectId}/customize/connectors',
     requiresProject: true,
     keywords:
       'connectors integrations pipedream mcp openapi postman collections apps executor project customize',
@@ -466,7 +466,7 @@ export const menuRegistry: MenuItemDef[] = [
     showIn: ['commandPalette'],
     kind: 'navigate',
     // TODO(capabilities): restore deep link to Global rules once the connectors page hosts PoliciesPanel
-    href: '/projects/{projectId}/connectors',
+    href: '/projects/{projectId}/customize/connectors',
     requiresProject: true,
     keywords:
       'policies approval block require_approval rules tools executor guardrails project customize',

--- a/apps/web/src/lib/project-actions.ts
+++ b/apps/web/src/lib/project-actions.ts
@@ -81,6 +81,19 @@ export const CUSTOMIZE_SECTION_ACCESS: Record<
   { read: ProjectAction; write?: ProjectAction }
 > = {
   agents: { read: PROJECT_ACTIONS.PROJECT_AGENT_READ, write: PROJECT_ACTIONS.PROJECT_AGENT_WRITE },
+  // Overlay sections again while the standalone capability pages are flagged
+  // off (#6054). Same leaves the pages themselves assert — connectors-page,
+  // skills-page and commands-page each gate their write affordances on the
+  // `.write` below — so the overlay grants exactly what the page would.
+  connectors: {
+    read: PROJECT_ACTIONS.PROJECT_CONNECTOR_READ,
+    write: PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+  },
+  skills: { read: PROJECT_ACTIONS.PROJECT_SKILL_READ, write: PROJECT_ACTIONS.PROJECT_SKILL_WRITE },
+  commands: {
+    read: PROJECT_ACTIONS.PROJECT_COMMAND_READ,
+    write: PROJECT_ACTIONS.PROJECT_COMMAND_WRITE,
+  },
   secrets: {
     read: PROJECT_ACTIONS.PROJECT_SECRET_READ,
     write: PROJECT_ACTIONS.PROJECT_SECRET_WRITE,


### PR DESCRIPTION
> Marko: can u do something about the regressed Agent Config stuff / rm it for
> now / put behind feature flag or similar until not optimal

#6054 moved **Connectors, Skills and Commands** out of the Customize overlay
into standalone capability pages. `NEXT_PUBLIC_CAPABILITY_PAGES` now decides
which surface ships. **It defaults OFF** — the overlay behaviour those pages
replaced.

## Not a revert

The new pages, their components and their tests all stay in the tree, and they
already render the same underlying views (`connectors-page.tsx` lazy-imports
`customize/sections/connectors-view`). So the flag chooses the *shell*, not the
functionality — nobody loses work, and `NEXT_PUBLIC_CAPABILITY_PAGES=true` gives
back #6054 exactly as merged.

## Every entry point, not just the nav

A half-applied flag is worse than none: stop the nav linking but leave the route
serving, and a bookmark still lands on the surface you believed was hidden.

| Entry point | Handling |
| --- | --- |
| Sidebar, tab strip, project home | All three go through `capabilityTabHref` — one choke point, gated there |
| Direct route / bookmark / back button | `CapabilityRouteGate` replaces into the overlay, and renders the skeleton meanwhile so the hidden page never flashes or fires its queries |
| `/customize/<section>` deep links | `legacyCustomizeRedirect` forwards only when ON |
| Command palette | Entries now use the `/customize/<section>` deep link, which resolves correctly in **both** positions — a static registry href needs no flag logic |
| Overlay hosting | The three are `CustomizeSection` values again, with panel cases and `CUSTOMIZE_SECTION_ACCESS` gate entries |

Files and Changes are deliberately **not** swept in — they left the overlay in an
earlier, unrelated change. Reverting those would undo someone else's work.

The restored overlay views load lazily. `connectors-view.tsx` alone is ~5k lines
and the overlay opens on `agents`, so none of it belongs in that first chunk.

## Access gates

Re-adding the sections made `CUSTOMIZE_SECTION_ACCESS` (a total `Record` over
`CustomizeSection`) incomplete — a type error, caught by `tsc`. They now carry
the same leaves the pages assert: `project.connector.*`, `project.skill.*`,
`project.command.*`. A test walks every overlay section and asserts a read gate
exists, so a future section cannot be added ungated.

## Verification

Against a stashed clean-`main` baseline:

| | pass | fail | `tsc` errors |
| --- | --- | --- | --- |
| baseline (clean `main`) | 1272 | 16 | 50 |
| this branch | **1285** | **16** | **50** |

`comm`-diff of both the failure set and the `tsc` error set: **zero new
failures, zero new type errors**, +13 passing.

The 16 failures and 50 type errors are pre-existing (`die-scene.tsx` missing
`@react-three/fiber`, `fumadocs`, `frimousse`, and the known `@types/bun`
`test.each` files). The new suite avoids `test.each` deliberately rather than
becoming a fourth file in that known-broken set.

#6054's own tests asserted the graduated behaviour unconditionally, so they now
assert it in the **ON** position; the new suite covers **OFF** at every entry
point above.

## Turning it back on

Set `NEXT_PUBLIC_CAPABILITY_PAGES=true` in the web env for the target
environment. No code change, no redeploy of anything else.
