### PR TITLE
fix(marketplace): stop listing use-case pack skills as Kortix Starter contents

### DIFF
--- a/apps/api/src/__tests__/unit-marketplace.test.ts
+++ b/apps/api/src/__tests__/unit-marketplace.test.ts
@@ -51,6 +51,41 @@ describe('marketplace catalog', () => {
     expect(starterDetail!.dependencyItems.some((d) => d.name === 'pdf')).toBe(true);
   });
 
+  test('the starter project lists only the starter floor; marketplace-layer skills stay out', async () => {
+    // "What's inside" the Kortix Starter is exactly what a cloned starter repo
+    // ships: the general-knowledge-worker floor. Marketplace-layer extras and
+    // use-case runbook skills must not be badged as starter contents.
+    const starterDetail = await getCatalogItemDetail('kortix-projects:starter');
+    expect(starterDetail!.dependencyItems.map((d) => d.name).sort()).toEqual([
+      'agent-browser',
+      'design-foundations',
+      'docx',
+      'pdf',
+      'presentations',
+      'web-publishing-and-deployments',
+      'webapp',
+      'website-building',
+      'xlsx',
+    ]);
+
+    const all = await listCatalogItems({ source: 'kortix' });
+
+    // A marketplace-layer extra (deep-research) is a standalone browse tile
+    // WITHOUT the "Part of Kortix Starter" badge.
+    const deepResearch = all.find((i) => i.name === 'deep-research');
+    expect(deepResearch).toBeTruthy();
+    expect(deepResearch!.partOfProject).toBeUndefined();
+
+    // A use-case runbook skill (a use-case template dependency) is not a browse
+    // tile at all…
+    expect(all.find((i) => i.name === 'invoice-math')).toBeUndefined();
+    // …but stays resolvable by id for the use-case install wizard.
+    const invoiceMath = await getCatalogItemDetail('kortix-starter:invoice-math');
+    expect(invoiceMath).toBeTruthy();
+    expect(invoiceMath!.useCase).toBe(true);
+    expect(invoiceMath!.partOfProject).toBeUndefined();
+  });
+
   test('lists optional Kortix skills through the marketplace', async () => {
     // agent-browser is browseable alongside every other kortix-starter skill,
     // and it stays fully resolvable by id and shows up inside the starter
@@ -194,9 +229,11 @@ describe('marketplace catalog', () => {
     expect(kortix.external).toBe(false);
     // Kortix browses as the "Kortix Starter" project PLUS every individual
     // kortix-starter skill as its own top-level browse tile — so the facet
-    // count is back to the full browseable kortix set, not the folded model's
-    // single hero tile (1).
-    expect(kortix.count).toBeGreaterThan(20);
+    // count is the full browseable kortix set, not the folded model's single
+    // hero tile (1). Use-case runbook skills (wizard installs) are excluded
+    // from browse, so the count stays in the tens, not the hundreds.
+    expect(kortix.count).toBeGreaterThan(10);
+    expect(kortix.count).toBeLessThan(40);
 
     // The base registries (kortix bundles + kortix-starter skills) collapse to one id…
     expect(marketplaceIdOf('kortix-starter')).toBe('kortix');

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -76,6 +76,9 @@ export interface CatalogItem {
   /** Set when this item also ships inside a whole `registry:project` (e.g. a
    *  starter skill) — the UI badges it "Part of <project>" and links to it. */
   partOfProject?: { id: string; title: string };
+  /** A use-case template dependency (runbook skill): installed through the
+   *  guided use-case wizard, resolvable by id, but not a browse tile. */
+  useCase?: boolean;
 }
 
 export interface DependencyItem {
@@ -305,6 +308,7 @@ function entryToCatalogItem(e: CatalogEntry): CatalogItem {
       typeof (e.item.meta.partOfProject as { id?: unknown }).id === "string"
         ? (e.item.meta.partOfProject as { id: string; title: string })
         : undefined,
+    useCase: e.item.meta?.useCase === true ? true : undefined,
   };
 }
 
@@ -344,20 +348,25 @@ function memSource(map: Map<string, string>): BuildSource {
 }
 
 function buildStarterRegistry(): RegistryJson {
-  const files = [
+  const starterFloorFiles = [
     ...getManagedSkillFiles(),
     ...getStarterFiles({
       projectName: "Kortix Starter",
       template: "general-knowledge-worker",
     }),
-    ...getMarketplaceFiles(),
   ];
+  // The `marketplace` template layer is "listed in the Kortix marketplace but
+  // not part of the starter floor" (see getMarketplaceFiles in @kortix/starter):
+  // standalone optional skills plus the use-case templates' runbook skills.
+  const files = [...starterFloorFiles, ...getMarketplaceFiles()];
+  const starterFloorPaths = new Set(starterFloorFiles.map((f) => f.path));
   const map = new Map(files.map((f) => [f.path, f.content] as const));
   const { registry } = buildRegistry({
     name: "kortix-starter",
     source: memSource(map),
   });
   for (const item of registry.items ?? []) {
+    const primaryPath = item.files?.[0]?.path;
     if (item.type === "registry:skill" && isKortixManagedSkillName(item.name)) {
       item.categories = [
         ...new Set([...(item.categories ?? []), "kortix-managed"]),
@@ -367,15 +376,32 @@ function buildStarterRegistry(): RegistryJson {
         managedBy: "kortix",
         updatePolicy: "kortix-managed",
       };
-    } else if (item.type === "registry:skill") {
-      // A browsable starter skill: it stands on its own in the catalog AND ships
+    } else if (
+      item.type === "registry:skill" &&
+      primaryPath != null &&
+      starterFloorPaths.has(primaryPath)
+    ) {
+      // A starter-floor skill: it stands on its own in the catalog AND ships
       // inside the Kortix Starter project, so tag it so the UI can badge it
       // "Part of Kortix Starter" and link back to the whole project.
       item.meta = {
         ...(item.meta ?? {}),
         partOfProject: { id: STARTER_KIT_ITEM_ID, title: "Kortix Starter" },
       };
+    } else if (
+      item.type === "registry:skill" &&
+      primaryPath?.startsWith("runtime/")
+    ) {
+      // A use-case runbook skill (declared in the marketplace template's
+      // kortix.registry.json): it exists as a use-case template dependency and
+      // installs through the guided wizard. Not starter content, and not a
+      // standalone browse tile — resolvable by id only, like the use-case
+      // templates and agents themselves.
+      item.meta = { ...(item.meta ?? {}), useCase: true };
     }
+    // Remaining marketplace-layer skills (deep-research, search, coding, …)
+    // are ordinary standalone browse tiles: optional installs, not part of
+    // the Kortix Starter project.
     for (const f of item.files ?? []) {
       const content = map.get(f.path);
       if (content != null) f.content = content;
@@ -459,10 +485,12 @@ const STARTER_KIT_README = `# Kortix Starter
 The default Kortix project — a general knowledge worker that's ready to do real
 work from the very first message.
 
-It comes preloaded with the full Kortix skill kit: research and the web,
-documents (PDF, DOCX, XLSX) and slides, coding and web apps, browser automation,
-and a set of editable persona starters (recruiting, marketing, accounting,
-support, product, legal) you can shape into your own operations.
+It comes preloaded with the core Kortix skill floor: documents (PDF, DOCX,
+XLSX) and slides, web apps and websites, browser automation, publishing and
+deployments, and design foundations. The managed Kortix platform skills
+(sessions, memory, the CLI) are injected into every session automatically.
+More skills — research, outreach, and per-role runbooks — are one install away
+in the marketplace.
 
 Everything here is **yours** — plain files in your project's git repo that you
 and your agents can read, edit, extend, and land through change requests. Nothing
@@ -481,9 +509,12 @@ what you do, tailors the kit to your work, and gets you one real result fast.
 
 function buildStarterKitProjectItem(): RegistryItem {
   const registry = buildStarterRegistry();
+  // Only skills tagged as part of the starter (the starter-floor layer) belong
+  // in "what's inside" — marketplace-layer extras and use-case runbook skills
+  // do not ship in a cloned starter project.
   const skillNames = (registry.items ?? [])
     .filter(
-      (it) => it.type === "registry:skill" && !isKortixManagedSkillName(it.name),
+      (it) => it.type === "registry:skill" && it.meta?.partOfProject != null,
     )
     .map((it) => it.name)
     .sort((a, b) => a.localeCompare(b));
@@ -503,7 +534,7 @@ function buildStarterKitProjectItem(): RegistryItem {
     type: "registry:project",
     title: "Kortix Starter",
     description:
-      "The default Kortix project — a general knowledge worker preloaded with the full skill kit (research, documents, slides, spreadsheets, the web, and more), ready to work from the first session.",
+      "The default Kortix project — a general knowledge worker preloaded with the core skill floor (documents, slides, spreadsheets, web apps, browser automation, and more), ready to work from the first session.",
     categories: ["project", "starter"],
     registryDependencies: skillNames,
     files,
@@ -1731,17 +1762,22 @@ function isBrowseableCatalogItem(it: CatalogItem): boolean {
   // live via `kortix skills get`, so they're not browse-and-install cards. They
   // stay installable by id (getCatalogEntry, ungated).
   if (it.managedBy === "kortix") return false;
+  if (it.useCase) return false;
   return MARKETPLACE_VISIBLE_TYPES.has(it.type) && !it.hidden;
 }
 
 /** Resolvable-by-id (detail + file fetch) but not necessarily browse-listed.
- *  Use-case templates and the agents they install stay OUT of the browse grid
- *  (that's the use-case pages' job), yet `kortix marketplace show <id>` /
- *  install-session must read them — so they resolve by id. */
+ *  Use-case templates, the agents they install, and their runbook skills stay
+ *  OUT of the browse grid (that's the use-case pages' job), yet
+ *  `kortix marketplace show <id>` / install-session must read them — so they
+ *  resolve by id. */
 function isResolvableCatalogItem(it: CatalogItem): boolean {
   if (isBrowseableCatalogItem(it)) return true;
+  if (it.hidden) return false;
   return (
-    (it.type === "registry:template" || it.type === "registry:agent") && !it.hidden
+    it.type === "registry:template" ||
+    it.type === "registry:agent" ||
+    it.useCase === true
   );
 }
 


### PR DESCRIPTION
## Problem

The marketplace "Kortix Starter" tile listed **79 skills** — including 61 use-case runbooks ("Snack batching", "AP invoice matching", "Ad performance review", …) and 9 marketplace extras. A cloned starter actually ships the 10-skill floor (#5770). The listing was false, and the runbook pile read as slop under the starter brand.

## Cause

`buildStarterRegistry()` in `apps/api/src/marketplace/catalog.ts` folds the whole `packages/starter/templates/marketplace/` layer (the use-case pack from the "USE CASE MAX" commits, lillyboga) into the `kortix-starter` registry, then blanket-tags every non-managed skill `meta.partOfProject: "Kortix Starter"`. That tag both (a) put all 70 marketplace-layer skills into the starter's `registryDependencies` → the 79-skill "What's inside" list, and (b) hid them from the explore grid (`marketplace-explore.tsx:163` filters `partOfProject` items). `getMarketplaceFiles()` documents this layer as "not part of the starter floor".

## Fix

Classify by template layer inside `buildStarterRegistry()`:

1. **Starter-floor skills** (base + general-knowledge-worker layers): keep the `partOfProject` badge; they are the only skills in the starter's `registryDependencies`. The tile now lists exactly the 9 floor skills a clone ships (plus `kortix-cli`, which stays managed-classified).
2. **Use-case runbook skills** (`runtime/` paths, declared in the marketplace template's `kortix.registry.json`): new `meta.useCase` → `CatalogItem.useCase`. Excluded from browse, still resolvable by id — identical treatment to the use-case templates and agents they belong to (`isResolvableCatalogItem`). The `/use-cases` wizard install path is unchanged.
3. **Marketplace extras** (`deep-research`, `search`, `coding`, `account-research`, `draft-outreach`, `people-search`, `document-review`, `domain-research`, `legal-writer`): plain standalone browse tiles, no starter badge — the documented intent.
4. Starter README + description: describe the real floor; drop the false "research and the web" / "persona starters" claims.

No change to project provisioning or CLI scaffold — both already seed only `getStarterFiles()` (verified: `apps/api/src/projects/starter.ts`, `apps/cli/src/scaffold.ts`).

## Verification

- `bun test src/marketplace/catalog.test.ts src/__tests__/unit-marketplace.test.ts` — 34 pass, 0 fail. New test pins the starter's `dependencyItems` to the exact floor set, asserts `invoice-math` is non-browseable but resolvable with `useCase: true`, and `deep-research` is browseable without a starter badge.
- `KORTIX_URL=… dotenvx run -- bun test seed-files marketplace-install-prompts e2e-marketplace-http integration-starter-provision-seed` — 23 pass, 0 fail (real HTTP route assertions included).
- `tsc --noEmit` (apps/api) — clean.

## Visible result

- Kortix Starter detail: 9 skills (the true floor), same 2 agents.
- Explore grid: gains the 9 standalone extras; the 61 runbooks appear only on `/use-cases` (behind its existing kill-switch flag).
