### PR TITLE
feat(marketplace): group use-case runbooks under a browsable Use-case pack project

### DIFF
--- a/apps/api/src/__tests__/unit-marketplace.test.ts
+++ b/apps/api/src/__tests__/unit-marketplace.test.ts
@@ -77,14 +77,37 @@ describe('marketplace catalog', () => {
     expect(deepResearch).toBeTruthy();
     expect(deepResearch!.partOfProject).toBeUndefined();
 
-    // A use-case runbook skill (a use-case template dependency) is not a browse
-    // tile at all…
-    expect(all.find((i) => i.name === 'invoice-math')).toBeUndefined();
-    // …but stays resolvable by id for the use-case install wizard.
-    const invoiceMath = await getCatalogItemDetail('kortix-starter:invoice-math');
+    // A use-case runbook skill is browseable but badged into the Use-case
+    // pack — the explore grid folds it under that tile, never the starter.
+    const invoiceMath = all.find((i) => i.name === 'invoice-math');
     expect(invoiceMath).toBeTruthy();
-    expect(invoiceMath!.useCase).toBe(true);
-    expect(invoiceMath!.partOfProject).toBeUndefined();
+    expect(invoiceMath!.partOfProject).toEqual({
+      id: 'kortix-projects:use-case-pack',
+      title: 'Use-case pack',
+    });
+    expect(starterDetail!.dependencyItems.some((d) => d.name === 'invoice-math')).toBe(false);
+  });
+
+  test('the Use-case pack groups every runbook skill and clones to conventional paths', async () => {
+    const all = await listCatalogItems({ source: 'kortix' });
+    expect(all.find((i) => i.id === 'kortix-projects:use-case-pack')).toBeTruthy();
+
+    const pack = await getCatalogItemDetail('kortix-projects:use-case-pack');
+    expect(pack).toBeTruthy();
+    expect(pack!.type).toBe('registry:project');
+    // Every runbook skill lives in the pack's "what's inside" list — dozens of
+    // them — and none of them leak into the Kortix Starter.
+    expect(pack!.dependencyItems.length).toBeGreaterThan(40);
+    expect(pack!.dependencyItems.some((d) => d.name === 'invoice-math')).toBe(true);
+    expect(pack!.dependencyItems.every((d) => d.type === 'registry:skill')).toBe(true);
+
+    // Clone layout: runbook skills + persona agents land at their conventional
+    // in-project paths (same mapping the install wizard uses), plus a README.
+    const targets = pack!.files.map((f) => f.target);
+    expect(targets).toContain('README.md');
+    expect(targets.some((t) => t.startsWith('.kortix/opencode/skills/'))).toBe(true);
+    expect(targets.some((t) => t.startsWith('.kortix/opencode/agents/'))).toBe(true);
+    expect(targets.every((t) => !t.startsWith('runtime/'))).toBe(true);
   });
 
   test('lists optional Kortix skills through the marketplace', async () => {
@@ -228,13 +251,12 @@ describe('marketplace catalog', () => {
     expect(kortix).toBeTruthy();
     expect(kortix.label).toBe('Kortix');
     expect(kortix.external).toBe(false);
-    // Kortix browses as the "Kortix Starter" project PLUS every individual
-    // kortix-starter skill as its own top-level browse tile — so the facet
-    // count is the full browseable kortix set, not the folded model's single
-    // hero tile (1). Use-case runbook skills (wizard installs) are excluded
-    // from browse, so the count stays in the tens, not the hundreds.
-    expect(kortix.count).toBeGreaterThan(10);
-    expect(kortix.count).toBeLessThan(40);
+    // Kortix browses as the "Kortix Starter" + "Use-case pack" projects PLUS
+    // every individual kortix-starter skill as its own top-level browse tile
+    // (starter-floor and runbook skills carry a partOfProject badge, so the
+    // web folds them under their project tile) — the facet count is the full
+    // browseable kortix set, not the folded model's single hero tile (1).
+    expect(kortix.count).toBeGreaterThan(20);
 
     // The base registries (kortix bundles + kortix-starter skills) collapse to one id…
     expect(marketplaceIdOf('kortix-starter')).toBe('kortix');

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -74,11 +74,9 @@ export interface CatalogItem {
   defaultProjectInstallOrder?: number;
   hidden?: boolean;
   /** Set when this item also ships inside a whole `registry:project` (e.g. a
-   *  starter skill) — the UI badges it "Part of <project>" and links to it. */
+   *  starter skill, or a use-case runbook skill inside the Use-case pack) —
+   *  the UI badges it "Part of <project>" and links to it. */
   partOfProject?: { id: string; title: string };
-  /** A use-case template dependency (runbook skill): installed through the
-   *  guided use-case wizard, resolvable by id, but not a browse tile. */
-  useCase?: boolean;
 }
 
 export interface DependencyItem {
@@ -308,7 +306,6 @@ function entryToCatalogItem(e: CatalogEntry): CatalogItem {
       typeof (e.item.meta.partOfProject as { id?: unknown }).id === "string"
         ? (e.item.meta.partOfProject as { id: string; title: string })
         : undefined,
-    useCase: e.item.meta?.useCase === true ? true : undefined,
   };
 }
 
@@ -393,11 +390,13 @@ function buildStarterRegistry(): RegistryJson {
       primaryPath?.startsWith("runtime/")
     ) {
       // A use-case runbook skill (declared in the marketplace template's
-      // kortix.registry.json): it exists as a use-case template dependency and
-      // installs through the guided wizard. Not starter content, and not a
-      // standalone browse tile — resolvable by id only, like the use-case
-      // templates and agents themselves.
-      item.meta = { ...(item.meta ?? {}), useCase: true };
+      // kortix.registry.json): it ships inside the Use-case pack project, not
+      // the Kortix Starter. Tag it so the explore grid folds it under the
+      // pack tile while it stays resolvable for the use-case install wizard.
+      item.meta = {
+        ...(item.meta ?? {}),
+        partOfProject: { id: USE_CASE_PACK_ITEM_ID, title: USE_CASE_PACK_TITLE },
+      };
     }
     // Remaining marketplace-layer skills (deep-research, search, coding, …)
     // are ordinary standalone browse tiles: optional installs, not part of
@@ -480,6 +479,14 @@ function buildProjectTemplateRegistry(): RegistryItem[] {
 export const STARTER_KIT_ITEM_NAME = "starter";
 export const STARTER_KIT_ITEM_ID = `kortix-projects:${STARTER_KIT_ITEM_NAME}`;
 
+// The second synthetic project: the Use-case pack. One browse tile that groups
+// every use-case runbook skill + persona agent from the marketplace template
+// layer (`packages/starter/templates/marketplace/runtime/**`) — visible and
+// clonable in the marketplace, but never advertised as Kortix Starter content.
+export const USE_CASE_PACK_ITEM_NAME = "use-case-pack";
+export const USE_CASE_PACK_ITEM_ID = `kortix-projects:${USE_CASE_PACK_ITEM_NAME}`;
+export const USE_CASE_PACK_TITLE = "Use-case pack";
+
 const STARTER_KIT_README = `# Kortix Starter
 
 The default Kortix project — a general knowledge worker that's ready to do real
@@ -514,7 +521,10 @@ function buildStarterKitProjectItem(): RegistryItem {
   // do not ship in a cloned starter project.
   const skillNames = (registry.items ?? [])
     .filter(
-      (it) => it.type === "registry:skill" && it.meta?.partOfProject != null,
+      (it) =>
+        it.type === "registry:skill" &&
+        (it.meta?.partOfProject as { id?: string } | undefined)?.id ===
+          STARTER_KIT_ITEM_ID,
     )
     .map((it) => it.name)
     .sort((a, b) => a.localeCompare(b));
@@ -542,6 +552,72 @@ function buildStarterKitProjectItem(): RegistryItem {
   };
 }
 
+const USE_CASE_PACK_README = `# Use-case pack
+
+Every Kortix use-case runbook in one place: the day-to-day operations playbooks
+(sales, finance, support, recruiting, engineering, and more) plus the persona
+agents that run them.
+
+## How to use it
+
+- **Guided (recommended):** each use case installs individually through the
+  [use-case pages](https://kortix.com/use-cases) — the wizard wires the agent,
+  its skill, grants, and any scheduled trigger into your project.
+- **Bulk clone:** clone this pack as a project to get every runbook skill under
+  \`.kortix/opencode/skills/\` and every persona agent file under
+  \`.kortix/opencode/agents/\`. Agent files ship undeclared — add the ones you
+  want to \`kortix.yaml\`'s \`agents:\` map (grants are deny-by-default) before
+  using them.
+
+Everything is plain files in your repo: read, edit, and adapt them to how your
+team actually works.
+`;
+
+/** Rewrite a marketplace-template `runtime/` path to its conventional
+ *  in-project location, mirroring the install wizard's target mapping
+ *  (`@skills/y` → `.kortix/opencode/skills/y`, `@agents/x.md` →
+ *  `.kortix/opencode/agents/x.md`). Non-runtime paths return undefined. */
+function useCasePackRepoPath(path: string): string | undefined {
+  if (path.startsWith("runtime/skills/"))
+    return `.kortix/opencode/skills/${path.slice("runtime/skills/".length)}`;
+  if (path.startsWith("runtime/agents/"))
+    return `.kortix/opencode/agents/${path.slice("runtime/agents/".length)}`;
+  return undefined;
+}
+
+function buildUseCasePackProjectItem(): RegistryItem {
+  const registry = buildStarterRegistry();
+  const skillNames = (registry.items ?? [])
+    .filter(
+      (it) =>
+        it.type === "registry:skill" &&
+        (it.meta?.partOfProject as { id?: string } | undefined)?.id ===
+          USE_CASE_PACK_ITEM_ID,
+    )
+    .map((it) => it.name)
+    .sort((a, b) => a.localeCompare(b));
+  const files = [
+    { path: "README.md", type: "registry:file" as const, content: USE_CASE_PACK_README },
+    ...getMarketplaceFiles().flatMap((f) => {
+      const repoPath = useCasePackRepoPath(f.path);
+      return repoPath
+        ? [{ path: repoPath, type: "registry:file" as const, content: f.content }]
+        : [];
+    }),
+  ];
+  return {
+    name: USE_CASE_PACK_ITEM_NAME,
+    type: "registry:project",
+    title: USE_CASE_PACK_TITLE,
+    description:
+      "Every Kortix use-case runbook and persona agent in one pack — sales, finance, support, recruiting, engineering ops, and more. Install use cases one at a time from the use-case pages, or clone the whole pack.",
+    categories: ["project", "use-case"],
+    registryDependencies: skillNames,
+    files,
+    meta: { source: "kortix", visibility: "global" },
+  };
+}
+
 let BASE: Catalog | null = null;
 
 const KORTIX_REPO = "https://github.com/kortix-ai/suna";
@@ -550,6 +626,8 @@ const KORTIX_REPO = "https://github.com/kortix-ai/suna";
  *  are real files in this repo, not a synthetic/external registry, so "View
  *  source" can point straight at them. */
 function projectTemplateSourceUrl(slug: string): string {
+  if (slug === USE_CASE_PACK_ITEM_NAME)
+    return `${KORTIX_REPO}/tree/main/packages/starter/templates/marketplace`;
   return `${KORTIX_REPO}/tree/main/packages/starter/templates/marketplace-projects/${slug}`;
 }
 
@@ -580,7 +658,11 @@ function getBaseCatalog(): Catalog {
     { name: "kortix-starter", items: buildStarterRegistry().items ?? [] },
     {
       name: "kortix-projects",
-      items: [buildStarterKitProjectItem(), ...buildProjectTemplateRegistry()],
+      items: [
+        buildStarterKitProjectItem(),
+        buildUseCasePackProjectItem(),
+        ...buildProjectTemplateRegistry(),
+      ],
     },
   ];
   const items: CatalogItem[] = [];
@@ -1762,22 +1844,19 @@ function isBrowseableCatalogItem(it: CatalogItem): boolean {
   // live via `kortix skills get`, so they're not browse-and-install cards. They
   // stay installable by id (getCatalogEntry, ungated).
   if (it.managedBy === "kortix") return false;
-  if (it.useCase) return false;
   return MARKETPLACE_VISIBLE_TYPES.has(it.type) && !it.hidden;
 }
 
 /** Resolvable-by-id (detail + file fetch) but not necessarily browse-listed.
- *  Use-case templates, the agents they install, and their runbook skills stay
- *  OUT of the browse grid (that's the use-case pages' job), yet
- *  `kortix marketplace show <id>` / install-session must read them — so they
- *  resolve by id. */
+ *  Use-case templates and the agents they install stay OUT of the browse grid
+ *  (that's the use-case pages' job), yet `kortix marketplace show <id>` /
+ *  install-session must read them — so they resolve by id. Runbook skills are
+ *  ordinary browseable items badged into the Use-case pack, so the web folds
+ *  them under that tile. */
 function isResolvableCatalogItem(it: CatalogItem): boolean {
   if (isBrowseableCatalogItem(it)) return true;
-  if (it.hidden) return false;
   return (
-    it.type === "registry:template" ||
-    it.type === "registry:agent" ||
-    it.useCase === true
+    (it.type === "registry:template" || it.type === "registry:agent") && !it.hidden
   );
 }
 

--- a/apps/api/src/projects/seed-files.test.ts
+++ b/apps/api/src/projects/seed-files.test.ts
@@ -66,6 +66,27 @@ describe('buildProjectSeedFilesFromItem', () => {
     );
   });
 
+  test('clones the Use-case pack to conventional in-repo paths', async () => {
+    const seed = await buildProjectSeedFilesFromItem({
+      id: 'kortix-projects:use-case-pack',
+      projectName: 'Ops Pack',
+      repoFullName: 'acme/ops-pack',
+      extraMarketplaceItems: [],
+      now: '2026-08-06T00:00:00.000Z',
+    });
+
+    const paths = seed.files.map((f) => f.path);
+    // The pack's own README wins over the minimal scaffold's.
+    expect(seed.files.find((f) => f.path === 'README.md')?.content).toContain('Use-case pack');
+    // Runbook skills + persona agents land where the runtime loads them.
+    expect(paths.some((p) => p.startsWith('.kortix/opencode/skills/') && p.endsWith('/SKILL.md'))).toBe(true);
+    expect(paths.some((p) => p.startsWith('.kortix/opencode/agents/') && p.endsWith('.md'))).toBe(true);
+    // No template-internal `runtime/` paths leak into a cloned repo.
+    expect(paths.every((p) => !p.startsWith('runtime/'))).toBe(true);
+    // The scaffold still provides the manifest with a declared default agent.
+    expect(seed.files.find((f) => f.path === 'kortix.yaml')?.content).toContain('default_agent:');
+  });
+
   /**
    * The bundled department projects (SEO / Marketing / Website Studio) were
    * retired — the marketplace leads with the single Kortix Starter project.


### PR DESCRIPTION
## Problem

After #6171 the 61 use-case runbook skills are resolvable by id only — not visible anywhere in the marketplace. Decision (Marko, 2026-08-06): make them visible as **one project tile**, kept separate from the Kortix Starter.

## Change

1. **New synthetic `registry:project` item `kortix-projects:use-case-pack`** ("Use-case pack"): groups every runbook skill + persona agent from `packages/starter/templates/marketplace/runtime/**`. `registryDependencies` = the 61 runbook skills, so the detail page's "What's inside" resolves them typed, same as the starter.
2. **Clonable**: pack files are rewritten to conventional in-repo paths (`runtime/skills/x` → `.kortix/opencode/skills/x`, `runtime/agents/y.md` → `.kortix/opencode/agents/y.md`) — the same mapping the install wizard prompt uses. Persona agents ship undeclared; the pack README explains wiring them into `kortix.yaml` (grants deny-by-default) and points at `/use-cases` as the guided path.
3. **Runbook skills**: `meta.useCase` replaced by `partOfProject → use-case-pack`. They are browseable again but the explore grid folds `partOfProject` items under their project tile — so the grid shows one "Use-case pack" tile, not 61 cards. `CatalogItem.useCase` (added in #6171 this morning, no external consumers) is removed.
4. Starter dependency filter now matches `partOfProject.id === STARTER_KIT_ITEM_ID` (presence alone would have leaked the pack's skills back into the starter).
5. "View source" for the pack points at `packages/starter/templates/marketplace`.

## Verification

- `bun test` (catalog, unit-marketplace, seed-files, install-prompts, e2e-marketplace-http, starter-provision-seed): **59 pass, 0 fail**. New tests pin: pack tile browseable; >40 typed skill dependencies incl. `invoice-math`; runbooks badged to the pack and absent from the starter's dependencyItems; clone lands `.kortix/opencode/{skills,agents}/**` with the pack README and no `runtime/` leakage.
- `tsc --noEmit` clean. No `useCase` references in web/sdk.

## Visible result

- Explore grid: "Kortix Starter" + "Use-case pack" project tiles; runbook cards folded under the pack.
- Pack detail: README, 61 typed skills, file browser, clonable.
- `/use-cases` wizard unchanged (items resolve by id).
