### PR TITLE
fix(prod): harden API recovery after OOM incident

### DIFF
--- a/apps/api/src/__tests__/unit-marketplace.test.ts
+++ b/apps/api/src/__tests__/unit-marketplace.test.ts
@@ -412,4 +412,44 @@ describe('marketplace external registries (skills.sh / GitHub path)', () => {
       _resetExternalCache();
     }
   });
+
+  test.serial('bounds concurrent external registry loads', async () => {
+    const sourceCount = 12;
+    let active = 0;
+    let maxActive = 0;
+    const fetchStub = (async (url: unknown) => {
+      const href = typeof url === 'object' && url && 'url' in url ? String((url as Request).url) : String(url);
+      if (!href.endsWith('/registry.json')) return new Response('not found', { status: 404 });
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Bun.sleep(10);
+      active -= 1;
+      const source = new URL(href).pathname.split('/')[2] ?? 'unknown';
+      return new Response(
+        JSON.stringify({
+          name: source,
+          items: [{ name: `skill-${source}`, type: 'registry:skill', title: source, files: [] }],
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+    globalThis.fetch = fetchStub;
+    githubLoaderOptions.fetchImpl = fetchStub;
+    process.env.KORTIX_MARKETPLACE_REGISTRIES = Array.from(
+      { length: sourceCount },
+      (_, index) => `github:mockorg/source-${index}`,
+    ).join(',');
+    _resetExternalCache();
+
+    try {
+      const all = await listCatalogItems();
+      expect(all.filter((item) => item.name.startsWith('skill-source-'))).toHaveLength(sourceCount);
+      expect(maxActive).toBeGreaterThan(1);
+      expect(maxActive).toBeLessThanOrEqual(4);
+    } finally {
+      restoreFetch();
+      delete process.env.KORTIX_MARKETPLACE_REGISTRIES;
+      _resetExternalCache();
+    }
+  });
 });

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,10 +1,13 @@
 import { PLATFORM_DEFAULT_MODEL_ID } from '@kortix/llm-catalog';
+import { hydrateEnvironmentSecret } from '@kortix/shared';
 import { z } from 'zod';
 import { SLACK_BOT_SCOPES } from './channels/slack-manifest';
 import {
   DEFAULT_LLM_GATEWAY_FALLBACK_POLICIES,
   parseFallbackPolicies,
 } from './llm-gateway/routing/policy-config';
+
+hydrateEnvironmentSecret();
 
 /**
  * Running sandbox version.

--- a/apps/api/src/environment-secret.ts
+++ b/apps/api/src/environment-secret.ts
@@ -1,0 +1,5 @@
+import { hydrateEnvironmentSecret } from '@kortix/shared';
+
+// This module must be the first import in index.ts. Observability and provider
+// modules read process.env during module evaluation.
+hydrateEnvironmentSecret();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,7 @@
-// ─── Observability (must be first — instruments before other imports) ────────
+// Expand the aggregate ECS secret before any module reads process.env.
+import './environment-secret';
+
+// ─── Observability (must follow environment hydration) ───────────────────────
 import './lib/sentry';
 import { captureException, flushSentry, addBreadcrumb, isSentryIgnoredError } from './lib/sentry';
 import { logger as appLogger, isLoggingTransportError } from './lib/logger';

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -687,6 +687,8 @@ function getBaseCatalog(): Catalog {
 
 // ── external catalog (async, cached, progressive) ──────────────────────────
 const EXTERNAL_TTL_MS = 24 * 60 * 60 * 1000; // 24h — sources rarely change; refresh lazily
+const EXTERNAL_REFRESH_JITTER_MS = 60 * 60 * 1000;
+export const MARKETPLACE_EXTERNAL_BUILD_CONCURRENCY = 4;
 
 // The cache lives on globalThis so it survives `bun --hot` reloads in dev
 // (otherwise every edit re-scans every source → the "so slow"). External sources
@@ -703,6 +705,7 @@ export interface SourceStatus {
 interface MarketplaceCache {
   external: Catalog | null; // last fully-resolved external catalog (the 24h cache)
   externalAt: number;
+  externalRefreshAt: number;
   partial: Catalog | null; // in-progress accumulator on a COLD build (grows per source)
   pending: number; // sources still resolving this round
   building: boolean;
@@ -719,6 +722,7 @@ const CACHE: MarketplaceCache = ((
 ).__kortixMarketplaceCache2 ??= {
   external: null,
   externalAt: 0,
+  externalRefreshAt: 0,
   partial: null,
   pending: 0,
   building: false,
@@ -973,7 +977,8 @@ export function assertAllowedSourceAddress(address: string): void {
  *  is in. Sets `building`/`partial` SYNCHRONOUSLY so progressive readers see the
  *  loading state on the very first call. */
 function startExternalBuild(): Promise<Catalog> {
-  if (CACHE.external && Date.now() - CACHE.externalAt < EXTERNAL_TTL_MS)
+  const refreshAt = CACHE.externalRefreshAt || CACHE.externalAt + EXTERNAL_TTL_MS;
+  if (CACHE.external && Date.now() < refreshAt)
     return Promise.resolve(CACHE.external);
   // Coalesce concurrent cold callers onto ONE build (no re-scan stampede).
   if (CACHE.inflight) return CACHE.inflight;
@@ -992,6 +997,25 @@ function startExternalBuild(): Promise<Catalog> {
 }
 
 type LoadedRegistry = Awaited<ReturnType<typeof loadRegistry>>;
+
+async function forEachWithConcurrency<T>(
+  values: readonly T[],
+  concurrency: number,
+  operation: (value: T, index: number) => Promise<void>,
+): Promise<void> {
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (nextIndex < values.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        await operation(values[index]!, index);
+      }
+    },
+  );
+  await Promise.all(workers);
+}
 
 async function buildExternalCatalog(): Promise<Catalog> {
   const refs = await externalRefs();
@@ -1018,8 +1042,10 @@ async function buildExternalCatalog(): Promise<Catalog> {
   // Resolve sources concurrently with isolation — one slow/huge/dead source
   // neither blocks the others nor sinks the catalog; each folds in the instant
   // it arrives so the list streams Kortix-first, then source-by-source.
-  await Promise.allSettled(
-    refs.map(async ({ ref, sourceId }, i) => {
+  await forEachWithConcurrency(
+    refs,
+    MARKETPLACE_EXTERNAL_BUILD_CONCURRENCY,
+    async ({ ref, sourceId }, i) => {
       try {
         addRegistryToCatalog(
           acc,
@@ -1037,10 +1063,14 @@ async function buildExternalCatalog(): Promise<Catalog> {
         CACHE.pending = Math.max(0, CACHE.pending - 1);
         CACHE.gen++; // a source landed → next read re-merges and streams it in
       }
-    }),
+    },
   );
   CACHE.external = acc;
   CACHE.externalAt = Date.now();
+  CACHE.externalRefreshAt =
+    CACHE.externalAt +
+    EXTERNAL_TTL_MS +
+    Math.floor(Math.random() * EXTERNAL_REFRESH_JITTER_MS);
   return acc;
 }
 
@@ -2162,6 +2192,7 @@ async function readExternalFile(
 export function _resetExternalCache(): void {
   CACHE.external = null;
   CACHE.externalAt = 0;
+  CACHE.externalRefreshAt = 0;
   CACHE.partial = null;
   CACHE.pending = 0;
   CACHE.building = false;

--- a/apps/llm-gateway/src/config.ts
+++ b/apps/llm-gateway/src/config.ts
@@ -1,3 +1,7 @@
+import { hydrateEnvironmentSecret } from '@kortix/shared';
+
+hydrateEnvironmentSecret();
+
 function required(name: string): string {
   const value = process.env[name];
   if (!value) throw new Error(`${name} is required`);

--- a/apps/llm-gateway/src/environment-secret.ts
+++ b/apps/llm-gateway/src/environment-secret.ts
@@ -1,0 +1,5 @@
+import { hydrateEnvironmentSecret } from '@kortix/shared';
+
+// This module must be the first import in main.ts. Server and observability
+// modules read process.env during module evaluation.
+hydrateEnvironmentSecret();

--- a/apps/llm-gateway/src/main.ts
+++ b/apps/llm-gateway/src/main.ts
@@ -1,3 +1,4 @@
+import './environment-secret';
 import { config } from './config';
 import { buildServer } from './server';
 

--- a/docs/incidents/2026-08-06-prod-api-oom-and-secret-selector-outage.md
+++ b/docs/incidents/2026-08-06-prod-api-oom-and-secret-selector-outage.md
@@ -1,0 +1,132 @@
+# Production API outage: OOM and stale secret selectors
+
+Date: 2026-08-06
+
+Service: `api.kortix.com`
+
+Severity: production outage
+
+## Impact
+
+`GET https://api.kortix.com/health` returned `504` after both API tasks stopped.
+Better Stack opened the incident at `2026-08-06T19:51:39Z`.
+
+The public API recovered at `2026-08-06T19:59:24Z`.
+
+## Root cause
+
+Two independent failures combined into the outage.
+
+1. Both `2 GiB` API tasks exhausted memory during the same marketplace catalog refresh.
+   ECS recorded exit code `137` and `OutOfMemoryError: container killed due to memory usage` for both API containers.
+   Both task logs stopped while loading external marketplace registries.
+   The production catalog contained `7,248` items.
+   `buildExternalCatalog()` started every external registry load through one unbounded `Promise.allSettled()` call.
+
+2. ECS could not start replacement capacity.
+   Task definition `kortix-prod:33` referenced individual JSON keys in `kortix-prod-env`.
+   Six optional Mailtrap keys had been removed from the secret one day earlier.
+   ECS rejected replacement task `e169687efae44e6e9c47f80f0f7ac8a5` before container startup because `MAILTRAP_ACCOUNT_ID` no longer existed.
+
+The Mailtrap removal did not crash a running container.
+The stale task-definition selector prevented ECS from replacing a failed container.
+
+## Evidence
+
+- Failed API tasks:
+  - `6ca084bb125844d5b75306080f05c288`
+  - `f0ab890ddb2c4e1c8443e21857e8917b`
+- Both tasks used `kortix-prod:33`.
+- Both API containers exited with code `137`.
+- Both ECS container reasons were `OutOfMemoryError: container killed due to memory usage`.
+- Replacement task `e169687efae44e6e9c47f80f0f7ac8a5` failed with `TaskFailedToStart`.
+- Its ECS reason named the missing `MAILTRAP_ACCOUNT_ID` JSON key.
+- CloudTrail event `f561aa00-1e1b-4002-be6e-617023662724` records `PutSecretValue` for `kortix-prod-env` at `2026-08-05T20:21:43Z` in `us-west-2`.
+- The previous secret version had `137` keys.
+- The current secret version had `131` keys.
+- Removed keys:
+  - `MAILTRAP_ACCOUNT_ID`
+  - `MAILTRAP_API_TOKEN`
+  - `MAILTRAP_BUSINESS_SIGNUPS_LIST_ID`
+  - `MAILTRAP_SENDER_EMAIL`
+  - `MAILTRAP_SENDER_NAME`
+  - `MAILTRAP_SIGNUPS_LIST_ID`
+
+## Timeline
+
+All times use UTC.
+
+- `2026-08-05T20:21:43Z`: The production secret update removes six Mailtrap keys.
+- `2026-08-06T19:49:56Z`: ECS creates extra task `e169687efae44e6e9c47f80f0f7ac8a5`.
+- `2026-08-06T19:50:20Z`: Both existing API log streams stop during external marketplace registry loading.
+- `2026-08-06T19:50:52Z`: The extra ECS task stops before startup because `MAILTRAP_ACCOUNT_ID` is absent.
+- `2026-08-06T19:51:39Z`: Better Stack reports `504` from the production health endpoint.
+- `2026-08-06T19:56:17Z`: Task definition `kortix-prod:34` registers without the deleted Mailtrap selectors.
+- `2026-08-06T19:59:24Z`: The public health endpoint returns `200` again.
+- `2026-08-06T20:01:52Z`: ECS reports the recovery deployment complete.
+- `2026-08-06T20:05:40Z`: Task definition `kortix-prod:35` registers with `4 GiB` memory.
+- `2026-08-06T20:05:41Z`: Gateway task definition `kortix-prod-gateway:29` registers without the deleted selectors.
+- `2026-08-06T20:09:07Z`: The gateway rollout completes with `2/2` tasks.
+- `2026-08-06T20:09:59Z`: The API rollout completes with `3/3` tasks.
+- `2026-08-06T20:17:06Z`: The API reaches steady state after the autoscaling floor changes to three tasks.
+
+## Recovery
+
+The incident response made these production changes:
+
+- Registered API revision `34` without the six deleted Mailtrap selectors.
+- Restored three healthy API tasks.
+- Registered API revision `35` with `4096 MiB` task memory.
+- Registered gateway revision `29` without the deleted Mailtrap selectors.
+- Set the production API autoscaling floor to three tasks.
+- Repaired the ALB metric dimensions and installed zero-healthy-host alarms for the API and gateway.
+
+Post-recovery verification:
+
+- API revision `35`: rollout `COMPLETED`, desired `3`, running `3`, pending `0`.
+- Gateway revision `29`: rollout `COMPLETED`, desired `2`, running `2`, pending `0`.
+- API target group: three healthy targets.
+- Gateway target group: two healthy targets.
+- Public API health: `20/20` requests returned `200`.
+- Public gateway health: `20/20` requests returned `200`.
+- Public marketplace: `10/10` requests returned `200`.
+- Marketplace response: `7,248` items, `loading: false`, `pending: 0`.
+
+## Permanent prevention
+
+This change removes each failure class.
+
+### Secret deletion safety
+
+ECS now injects the full environment secret through one stable `KORTIX_ENV_JSON` selector.
+The API and gateway expand the JSON before any configuration or observability module reads `process.env`.
+Explicit task-definition environment variables override values from the secret.
+
+Adding or removing an optional JSON key no longer invalidates an existing ECS task definition.
+
+### Marketplace memory control
+
+External marketplace registry loading now uses at most four concurrent loads per API task.
+Completed refreshes receive up to one hour of random jitter beyond the 24-hour cache lifetime.
+The jitter prevents replicas deployed together from refreshing together every day.
+
+### Capacity and detection
+
+Production and disaster-recovery API tasks use `4096 MiB` memory.
+The active production API keeps a minimum of three tasks.
+The ALB alarm reconciler now creates a `HealthyHostCount < 1` alarm for every target group.
+Target health and response-time alarms now use the required target-group and load-balancer dimensions.
+
+## Verification gates
+
+- `bun test packages/shared/src/environment-secret.test.ts`
+- `bun test apps/api/src/__tests__/unit-marketplace.test.ts --timeout 30000`
+- `bun test infra/cloudflare/workers/api-router/worker.test.mjs`
+- `python3 -m unittest test_alb_alarm_reconciler.py`
+- `pnpm --filter kortix-api typecheck`
+- `pnpm --filter @kortix/llm-gateway-server typecheck`
+- `pnpm --filter @kortix/shared test`
+- `terraform fmt -check` for all changed Terraform files
+- `terraform validate` for the ECS module, production root, and disaster-recovery root
+- `bash -n infra/scripts/ecs-deploy.sh`
+- Production API and gateway `--dry-run` task-definition renders

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -91,6 +91,47 @@ describe('api-router worker', () => {
     );
   });
 
+  test('injects the environment secret as one JSON blob instead of per-key selectors', () => {
+    const ecsDeploy = readFileSync(
+      new URL('../../../scripts/ecs-deploy.sh', import.meta.url),
+      'utf8',
+    );
+    const apiEntry = readFileSync(
+      new URL('../../../../apps/api/src/index.ts', import.meta.url),
+      'utf8',
+    );
+    const gatewayEntry = readFileSync(
+      new URL('../../../../apps/llm-gateway/src/main.ts', import.meta.url),
+      'utf8',
+    );
+
+    expect(ecsDeploy).toContain('name: "KORTIX_ENV_JSON"');
+    expect(ecsDeploy).not.toContain('keys\n      | map({ name: .');
+    expect(apiEntry.indexOf("import './environment-secret';")).toBeLessThan(
+      apiEntry.indexOf("import './lib/sentry';"),
+    );
+    expect(gatewayEntry.indexOf("import './environment-secret';")).toBeLessThan(
+      gatewayEntry.indexOf("import { config } from './config';"),
+    );
+  });
+
+  test('keeps production API tasks at the incident-tested 4 GiB and three-task floor', () => {
+    const prodTerraform = readFileSync(
+      new URL('../../../terraform/environments/prod/main.tf', import.meta.url),
+      'utf8',
+    );
+    const shadowTerraform = readFileSync(
+      new URL('../../../terraform/environments/prod-us-east-2-shadow/main.tf', import.meta.url),
+      'utf8',
+    );
+
+    expect(prodTerraform).toMatch(/module "api"[\s\S]*?task_memory\s*=\s*4096/);
+    expect(prodTerraform).toMatch(/module "api"[\s\S]*?desired_count\s*=\s*3/);
+    expect(prodTerraform).toMatch(/module "api"[\s\S]*?min_capacity\s*=\s*3/);
+    expect(shadowTerraform).toMatch(/module "api"[\s\S]*?task_memory\s*=\s*4096/);
+    expect(shadowTerraform).toMatch(/module "api"[\s\S]*?secrets_blob_arn\s*=\s*var\.secret_arn/);
+  });
+
   test('runs privileged US workflows only from the protected prod branch', () => {
     const workflows = [
       'activate-prod-us-east-2-writers.yml',

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -4,9 +4,9 @@
 # fresh from Secrets Manager, so the ECS env can never drift from the EKS env.
 #
 # The env contract lives in ONE place per environment: the Secrets Manager blob
-# `kortix-<env>-env` (the same blob external-secrets syncs into EKS). We read its
-# keys and wire every one into the task-def as a `secrets` entry pointing back at
-# that blob's JSON key — no hand-maintained secret list, no drift.
+# `kortix-<env>-env`. ECS injects the complete JSON document through one stable
+# selector. Application startup expands it into process.env. Adding or removing
+# an optional JSON key cannot invalidate an already-registered task definition.
 #
 # Usage:
 #   ecs-deploy.sh <env> <image> [--service api|gateway] [--version X.Y.Z]
@@ -128,15 +128,15 @@ SECRET_ARN="$(aws secretsmanager describe-secret --region "$REGION" \
   --secret-id "$SECRET_NAME" --query 'ARN' --output text)"
 [ -n "$SECRET_ARN" ] && [ "$SECRET_ARN" != "None" ] || { echo "secret $SECRET_NAME not found in $REGION" >&2; exit 1; }
 
-# every key in the blob -> a task-def secret entry pointing at that JSON key
-SECRETS_JSON="$(aws secretsmanager get-secret-value --region "$REGION" \
-  --secret-id "$SECRET_ARN" --query 'SecretString' --output text \
-  | jq --arg arn "$SECRET_ARN" '
-      keys
-      | map({ name: ., valueFrom: ($arn + ":" + . + "::") })')"
-KEYCOUNT="$(echo "$SECRETS_JSON" | jq 'length')"
+# Validate the blob without printing it. The task definition references only the
+# secret ARN, so its selector remains valid when optional keys change later.
+SECRET_VALUE="$(aws secretsmanager get-secret-value --region "$REGION" \
+  --secret-id "$SECRET_ARN" --query 'SecretString' --output text)"
+KEYCOUNT="$(printf '%s' "$SECRET_VALUE" | jq 'if type == "object" and all(.[]; type == "string") then length else error("secret must be a JSON object of strings") end')"
 [ "$KEYCOUNT" -gt 0 ] || { echo "blob $SECRET_NAME has 0 keys — refusing to deploy" >&2; exit 1; }
-echo "▶ wired $KEYCOUNT secret keys from $SECRET_NAME"
+unset SECRET_VALUE
+SECRETS_JSON="$(jq -cn --arg arn "$SECRET_ARN" '[{name: "KORTIX_ENV_JSON", valueFrom: $arn}]')"
+echo "▶ wired $KEYCOUNT environment values through KORTIX_ENV_JSON from $SECRET_NAME"
 
 # ── base task-def = the service's current one, with runtime fields stripped ──
 CURRENT_TD="$(aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" \

--- a/infra/terraform/compliance-monitoring/functions/alb_alarm_reconciler.py
+++ b/infra/terraform/compliance-monitoring/functions/alb_alarm_reconciler.py
@@ -7,6 +7,11 @@ from collections.abc import Iterable
 from typing import Any
 
 ALARM_PREFIX = "kortix-alb-"
+TARGET_GROUP_METRICS = {
+    "target-response-time",
+    "unhealthy-hosts",
+    "zero-healthy-hosts",
+}
 
 ALARM_SPECS: dict[str, dict[str, Any]] = {
     "target-response-time": {
@@ -39,6 +44,16 @@ ALARM_SPECS: dict[str, dict[str, Any]] = {
         "Threshold": 1.0,
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
     },
+    "zero-healthy-hosts": {
+        "AlarmDescription": "SOC2 DCF-86: ALB has zero healthy targets",
+        "MetricName": "HealthyHostCount",
+        "Statistic": "Minimum",
+        "Period": 60,
+        "EvaluationPeriods": 2,
+        "DatapointsToAlarm": 2,
+        "Threshold": 1.0,
+        "ComparisonOperator": "LessThanThreshold",
+    },
 }
 
 
@@ -47,37 +62,74 @@ def _chunks(values: list[str], size: int = 100) -> Iterable[list[str]]:
         yield values[offset : offset + size]
 
 
-def _load_balancers(elbv2: Any) -> list[dict[str, str]]:
-    load_balancers: dict[str, dict[str, str]] = {}
+def _load_balancers(elbv2: Any) -> list[dict[str, Any]]:
+    load_balancers: dict[str, dict[str, Any]] = {}
     paginator = elbv2.get_paginator("describe_load_balancers")
     for page in paginator.paginate():
         for load_balancer in page.get("LoadBalancers", []):
             if load_balancer.get("Type") != "application":
                 continue
             arn = load_balancer["LoadBalancerArn"]
+            target_groups = elbv2.describe_target_groups(LoadBalancerArn=arn).get(
+                "TargetGroups", []
+            )
             load_balancers[arn] = {
                 "name": load_balancer["LoadBalancerName"],
                 "dimension": arn.split(":loadbalancer/", 1)[1],
+                "target_groups": [
+                    {
+                        "name": target_group["TargetGroupName"],
+                        "dimension": target_group["TargetGroupArn"].split(":", 5)[5],
+                    }
+                    for target_group in sorted(
+                        target_groups,
+                        key=lambda target_group: target_group["TargetGroupArn"],
+                    )
+                ],
             }
     return [load_balancers[arn] for arn in sorted(load_balancers)]
 
 
-def _alarm_name(load_balancer_name: str, suffix: str) -> str:
-    return f"{ALARM_PREFIX}{load_balancer_name}-{suffix}"
+def _alarm_name(
+    load_balancer_name: str,
+    suffix: str,
+    target_group: dict[str, str] | None = None,
+    target_group_count: int = 1,
+) -> str:
+    target_group_segment = (
+        f"-{target_group['name']}"
+        if target_group is not None and target_group_count > 1
+        else ""
+    )
+    return f"{ALARM_PREFIX}{load_balancer_name}{target_group_segment}-{suffix}"
 
 
 def _alarm_configuration(
-    load_balancer: dict[str, str], suffix: str, topic_arn: str
+    load_balancer: dict[str, Any],
+    suffix: str,
+    topic_arn: str,
+    target_group: dict[str, str] | None = None,
 ) -> dict[str, Any]:
+    dimensions = [{"Name": "LoadBalancer", "Value": load_balancer["dimension"]}]
+    if suffix in TARGET_GROUP_METRICS:
+        if target_group is None:
+            raise ValueError(f"{suffix} requires a target group")
+        dimensions.insert(
+            0,
+            {"Name": "TargetGroup", "Value": target_group["dimension"]},
+        )
     return {
-        "AlarmName": _alarm_name(load_balancer["name"], suffix),
+        "AlarmName": _alarm_name(
+            load_balancer["name"],
+            suffix,
+            target_group,
+            len(load_balancer["target_groups"]),
+        ),
         **ALARM_SPECS[suffix],
         "ActionsEnabled": True,
         "AlarmActions": [topic_arn],
         "Namespace": "AWS/ApplicationELB",
-        "Dimensions": [
-            {"Name": "LoadBalancer", "Value": load_balancer["dimension"]}
-        ],
+        "Dimensions": dimensions,
         "TreatMissingData": "notBreaching",
         "Tags": [
             {"Key": "ManagedBy", "Value": "kortix-compliance"},
@@ -88,11 +140,12 @@ def _alarm_configuration(
 
 def _is_compliant(
     alarm: dict[str, Any],
-    load_balancer: dict[str, str],
+    load_balancer: dict[str, Any],
     suffix: str,
     topic_arn: str,
+    target_group: dict[str, str] | None = None,
 ) -> bool:
-    expected = _alarm_configuration(load_balancer, suffix, topic_arn)
+    expected = _alarm_configuration(load_balancer, suffix, topic_arn, target_group)
     scalar_fields = (
         "AlarmDescription",
         "ActionsEnabled",
@@ -114,8 +167,7 @@ def _is_compliant(
         for dimension in alarm.get("Dimensions", [])
     }
     expected_dimensions = {
-        (dimension["Name"], dimension["Value"])
-        for dimension in expected["Dimensions"]
+        (dimension["Name"], dimension["Value"]) for dimension in expected["Dimensions"]
     }
     return dimensions == expected_dimensions and alarm.get("AlarmActions", []) == [
         topic_arn
@@ -124,14 +176,24 @@ def _is_compliant(
 
 def reconcile(elbv2: Any, cloudwatch: Any, topic_arn: str) -> dict[str, Any]:
     load_balancers = _load_balancers(elbv2)
-    desired = [
-        (load_balancer, suffix)
-        for load_balancer in load_balancers
-        for suffix in ALARM_SPECS
-    ]
+    desired: list[tuple[dict[str, Any], str, dict[str, str] | None]] = []
+    for load_balancer in load_balancers:
+        for suffix in ALARM_SPECS:
+            if suffix in TARGET_GROUP_METRICS:
+                desired.extend(
+                    (load_balancer, suffix, target_group)
+                    for target_group in load_balancer["target_groups"]
+                )
+            else:
+                desired.append((load_balancer, suffix, None))
     alarm_names = [
-        _alarm_name(load_balancer["name"], suffix)
-        for load_balancer, suffix in desired
+        _alarm_name(
+            load_balancer["name"],
+            suffix,
+            target_group,
+            len(load_balancer["target_groups"]),
+        )
+        for load_balancer, suffix, target_group in desired
     ]
     existing: dict[str, dict[str, Any]] = {}
 
@@ -142,13 +204,27 @@ def reconcile(elbv2: Any, cloudwatch: Any, topic_arn: str) -> dict[str, Any]:
         )
 
     updated: list[str] = []
-    for load_balancer, suffix in desired:
-        name = _alarm_name(load_balancer["name"], suffix)
+    for load_balancer, suffix, target_group in desired:
+        name = _alarm_name(
+            load_balancer["name"],
+            suffix,
+            target_group,
+            len(load_balancer["target_groups"]),
+        )
         if not _is_compliant(
-            existing.get(name, {}), load_balancer, suffix, topic_arn
+            existing.get(name, {}),
+            load_balancer,
+            suffix,
+            topic_arn,
+            target_group,
         ):
             cloudwatch.put_metric_alarm(
-                **_alarm_configuration(load_balancer, suffix, topic_arn)
+                **_alarm_configuration(
+                    load_balancer,
+                    suffix,
+                    topic_arn,
+                    target_group,
+                )
             )
             updated.append(name)
 

--- a/infra/terraform/compliance-monitoring/functions/test_alb_alarm_reconciler.py
+++ b/infra/terraform/compliance-monitoring/functions/test_alb_alarm_reconciler.py
@@ -14,12 +14,26 @@ class FakePaginator:
 
 
 class FakeElbv2:
-    def __init__(self, pages):
+    def __init__(self, pages, target_groups=None):
         self.paginator = FakePaginator(pages)
+        self.target_groups = target_groups or {
+            load_balancer["LoadBalancerArn"]: [
+                target_group(
+                    f"{load_balancer['LoadBalancerName']}-tg",
+                    f"{load_balancer['LoadBalancerName']}-tg-id",
+                )
+            ]
+            for page in pages
+            for load_balancer in page.get("LoadBalancers", [])
+            if load_balancer.get("Type") == "application"
+        }
 
     def get_paginator(self, operation):
         assert operation == "describe_load_balancers"
         return self.paginator
+
+    def describe_target_groups(self, **kwargs):
+        return {"TargetGroups": self.target_groups.get(kwargs["LoadBalancerArn"], [])}
 
 
 class FakeCloudWatch:
@@ -52,10 +66,20 @@ def load_balancer(name, identifier, load_balancer_type="application"):
     }
 
 
+def target_group(name, identifier):
+    return {
+        "TargetGroupName": name,
+        "TargetGroupArn": (
+            "arn:aws:elasticloadbalancing:us-west-2:935064898258:"
+            f"targetgroup/{name}/{identifier}"
+        ),
+    }
+
+
 class ReconcilerTest(unittest.TestCase):
     topic = "arn:aws:sns:us-west-2:935064898258:suna-api-alerts"
 
-    def test_creates_three_drata_compatible_alarms_for_each_application_lb(self):
+    def test_creates_four_drata_compatible_alarms_for_each_application_lb(self):
         elbv2 = FakeElbv2(
             [
                 {
@@ -72,9 +96,9 @@ class ReconcilerTest(unittest.TestCase):
         result = reconcile(elbv2, cloudwatch, self.topic)
 
         self.assertEqual(result["load_balancers"], 2)
-        self.assertEqual(result["covered_alarms"], 6)
-        self.assertEqual(len(result["updated_alarms"]), 6)
-        self.assertEqual(len(cloudwatch.put_calls), 6)
+        self.assertEqual(result["covered_alarms"], 8)
+        self.assertEqual(len(result["updated_alarms"]), 8)
+        self.assertEqual(len(cloudwatch.put_calls), 8)
         target_alarm = next(
             alarm
             for alarm in cloudwatch.put_calls
@@ -84,15 +108,67 @@ class ReconcilerTest(unittest.TestCase):
         self.assertEqual(target_alarm["MetricName"], "TargetResponseTime")
         self.assertEqual(
             target_alarm["Dimensions"],
-            [{"Name": "LoadBalancer", "Value": "app/a/a-id"}],
+            [
+                {"Name": "TargetGroup", "Value": "targetgroup/a-tg/a-tg-id"},
+                {"Name": "LoadBalancer", "Value": "app/a/a-id"},
+            ],
         )
         self.assertEqual(target_alarm["AlarmActions"], [self.topic])
         self.assertEqual(target_alarm["TreatMissingData"], "notBreaching")
-        self.assertEqual(set(ALARM_SPECS), {
-            "target-response-time",
-            "elb-5xx",
-            "unhealthy-hosts",
-        })
+        self.assertEqual(
+            set(ALARM_SPECS),
+            {
+                "target-response-time",
+                "elb-5xx",
+                "unhealthy-hosts",
+                "zero-healthy-hosts",
+            },
+        )
+        zero_healthy_alarm = next(
+            alarm
+            for alarm in cloudwatch.put_calls
+            if alarm["AlarmName"] == "kortix-alb-a-zero-healthy-hosts"
+        )
+        self.assertEqual(zero_healthy_alarm["MetricName"], "HealthyHostCount")
+        self.assertEqual(zero_healthy_alarm["Statistic"], "Minimum")
+        self.assertEqual(zero_healthy_alarm["Period"], 60)
+        self.assertEqual(zero_healthy_alarm["ComparisonOperator"], "LessThanThreshold")
+        self.assertEqual(
+            zero_healthy_alarm["Dimensions"],
+            [
+                {"Name": "TargetGroup", "Value": "targetgroup/a-tg/a-tg-id"},
+                {"Name": "LoadBalancer", "Value": "app/a/a-id"},
+            ],
+        )
+
+    def test_creates_distinct_target_alarms_for_multiple_target_groups(self):
+        lb = load_balancer("a", "app/a/a-id")
+        elbv2 = FakeElbv2(
+            [{"LoadBalancers": [lb]}],
+            {
+                lb["LoadBalancerArn"]: [
+                    target_group("blue", "blue-id"),
+                    target_group("green", "green-id"),
+                ]
+            },
+        )
+        cloudwatch = FakeCloudWatch()
+
+        result = reconcile(elbv2, cloudwatch, self.topic)
+
+        self.assertEqual(result["covered_alarms"], 7)
+        self.assertEqual(
+            set(result["updated_alarms"]),
+            {
+                "kortix-alb-a-elb-5xx",
+                "kortix-alb-a-blue-target-response-time",
+                "kortix-alb-a-blue-unhealthy-hosts",
+                "kortix-alb-a-blue-zero-healthy-hosts",
+                "kortix-alb-a-green-target-response-time",
+                "kortix-alb-a-green-unhealthy-hosts",
+                "kortix-alb-a-green-zero-healthy-hosts",
+            },
+        )
 
     def test_does_not_rewrite_compliant_alarms(self):
         lb = load_balancer("a", "app/a/a-id")
@@ -100,9 +176,7 @@ class ReconcilerTest(unittest.TestCase):
         reconcile(FakeElbv2([{"LoadBalancers": [lb]}]), first_cloudwatch, self.topic)
         cloudwatch = FakeCloudWatch(first_cloudwatch.put_calls)
 
-        result = reconcile(
-            FakeElbv2([{"LoadBalancers": [lb]}]), cloudwatch, self.topic
-        )
+        result = reconcile(FakeElbv2([{"LoadBalancers": [lb]}]), cloudwatch, self.topic)
 
         self.assertEqual(result["updated_alarms"], [])
         self.assertEqual(cloudwatch.put_calls, [])
@@ -118,9 +192,7 @@ class ReconcilerTest(unittest.TestCase):
         alarms[1]["AlarmActions"] = []
         cloudwatch = FakeCloudWatch(alarms)
 
-        result = reconcile(
-            FakeElbv2([{"LoadBalancers": [lb]}]), cloudwatch, self.topic
-        )
+        result = reconcile(FakeElbv2([{"LoadBalancers": [lb]}]), cloudwatch, self.topic)
 
         self.assertEqual(
             result["updated_alarms"],
@@ -132,7 +204,13 @@ class ReconcilerTest(unittest.TestCase):
         self.assertEqual(len(cloudwatch.put_calls), 2)
         self.assertEqual(
             cloudwatch.put_calls[0]["Dimensions"],
-            [{"Name": "LoadBalancer", "Value": "app/previews/new-id"}],
+            [
+                {
+                    "Name": "TargetGroup",
+                    "Value": "targetgroup/previews-tg/previews-tg-id",
+                },
+                {"Name": "LoadBalancer", "Value": "app/previews/new-id"},
+            ],
         )
         self.assertEqual(cloudwatch.put_calls[1]["AlarmActions"], [self.topic])
 

--- a/infra/terraform/environments/prod-us-east-2-shadow/main.tf
+++ b/infra/terraform/environments/prod-us-east-2-shadow/main.tf
@@ -76,12 +76,13 @@ module "api" {
   environment = {
     KORTIX_VERSION = "0.10.14"
   }
-  secrets = local.secrets
+  secrets          = local.secrets
+  secrets_blob_arn = var.secret_arn
 
   alb_ingress_cidrs = var.alb_ingress_cidrs
 
   task_cpu           = 1024
-  task_memory        = 2048
+  task_memory        = 4096
   desired_count      = 2
   min_capacity       = 2
   max_capacity       = 10
@@ -115,7 +116,8 @@ module "gateway" {
     KORTIX_API_URL = "https://${var.api_shadow_hostname}"
     KORTIX_VERSION = "0.10.14"
   }
-  secrets = local.secrets
+  secrets          = local.secrets
+  secrets_blob_arn = var.secret_arn
 
   alb_ingress_cidrs = var.alb_ingress_cidrs
 

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -1,12 +1,12 @@
 # ── prod environment — api.kortix.com on ECS Fargate (autoscaled, HA) ─────────
 #
 #   api.kortix.com → Cloudflare (proxied, Full strict) → ALB → ECS Fargate
-#   service (autoscaled on CPU/memory, min 2 tasks across 2 AZs) in private
+#   service (autoscaled on CPU/memory, min 3 tasks across 2 AZs) in private
 #   subnets, egress via per-AZ NAT.
 #
 # SAME modules as dev (../dev) — prod just runs bigger numbers, no Spot, a NAT
-# per AZ, and Container Insights on. min_capacity=2 across AZs gives the
-# availability + horizontal autoscaling expected for SOC 2. Not applied
+# per AZ, and Container Insights on. min_capacity=3 preserves one healthy
+# replica if two tasks fail together. Not applied
 # automatically. See README.md.
 
 terraform {
@@ -81,9 +81,10 @@ module "acm" {
   }
 }
 
-# The env secret blob is the source of truth for which secrets exist:
-# ecs-deploy.sh wires every key in it into each task-def revision. Looked up by
-# name so the random ARN suffix is never hard-coded.
+# The env secret blob is the source of truth for the container environment.
+# ECS injects the complete JSON document through one stable selector. The
+# application expands it before any configuration module reads process.env.
+# Looked up by name so the random ARN suffix is never hard-coded.
 data "aws_secretsmanager_secret" "env" {
   name = "kortix-prod-env"
 }
@@ -113,9 +114,9 @@ module "api" {
 
   # prod sizing: bigger tasks, HA floor of 2, no spot, insights on
   task_cpu           = 1024
-  task_memory        = 2048
-  desired_count      = 2
-  min_capacity       = 2
+  task_memory        = 4096
+  desired_count      = 3
+  min_capacity       = 3
   max_capacity       = 10
   use_fargate_spot   = false
   container_insights = true

--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -113,13 +113,11 @@ resource "aws_iam_role_policy_attachment" "execution" {
 
 # Let the execution role pull the values behind any injected secrets.
 #
-# Prefer secrets_blob_arn. ecs-deploy.sh builds every task-def revision by
-# reading EVERY key out of the kortix-<env>-env blob, so the blob — not this
-# module — is the source of truth for which secrets exist. Enumerating them in
-# var.secrets as well means keeping a second copy by hand, and that copy is
-# already wrong: prod's blob holds 132 keys against 100 in tfvars, and staging
-# has 106 with no tfvars at all. Granting on the blob ARN covers every key
-# forever and deletes the drift rather than tracking it.
+# Prefer secrets_blob_arn. ECS injects the complete secret JSON through one
+# stable task-definition selector. The application expands it into process.env
+# at startup. Adding or removing an optional JSON key does not invalidate an
+# existing task definition. Granting on the blob ARN covers every key without a
+# second hand-maintained selector list.
 #
 # var.secrets remains only as the fallback for callers that have not been
 # given a blob yet; it resolves to the same base ARNs.
@@ -426,7 +424,9 @@ resource "aws_ecs_task_definition" "this" {
       protocol      = "tcp"
     }]
     environment = [for k, v in local.environment : { name = k, value = v }]
-    secrets     = [for k, v in var.secrets : { name = k, valueFrom = v }]
+    secrets = var.secrets_blob_arn != "" ? [
+      { name = "KORTIX_ENV_JSON", valueFrom = var.secrets_blob_arn }
+    ] : [for k, v in var.secrets : { name = k, valueFrom = v }]
     logConfiguration = {
       logDriver = "awslogs"
       options = {

--- a/infra/terraform/modules/ecs-api/variables.tf
+++ b/infra/terraform/modules/ecs-api/variables.tf
@@ -176,10 +176,9 @@ variable "tags" {
 variable "secrets_blob_arn" {
   description = <<-EOT
     ARN of the environment's Secrets Manager blob (kortix-<env>-env). The
-    execution role is granted GetSecretValue on it, which covers every key the
-    blob holds. Preferred over enumerating `secrets`, because ecs-deploy.sh
-    derives task-def secrets from the blob's keys — so the blob is the source
-    of truth and a second hand-maintained list can only drift from it.
+    execution role is granted GetSecretValue on it. ECS injects the complete
+    JSON document through KORTIX_ENV_JSON. This stable selector survives
+    optional key additions and removals.
   EOT
   type        = string
   default     = ""

--- a/packages/shared/src/environment-secret.test.ts
+++ b/packages/shared/src/environment-secret.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { hydrateEnvironmentSecret } from "./environment-secret";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("hydrateEnvironmentSecret", () => {
+  test("hydrates string values and removes the aggregate secret", () => {
+    process.env.KORTIX_ENV_JSON = JSON.stringify({
+      DATABASE_URL: "postgres://example",
+      OPTIONAL_PROVIDER_TOKEN: "token",
+    });
+
+    expect(hydrateEnvironmentSecret()).toBe(2);
+    expect(process.env.DATABASE_URL).toBe("postgres://example");
+    expect(process.env.OPTIONAL_PROVIDER_TOKEN).toBe("token");
+    expect(process.env.KORTIX_ENV_JSON).toBeUndefined();
+  });
+
+  test("keeps explicit task environment overrides", () => {
+    process.env.KORTIX_VERSION = "0.12.4";
+    process.env.KORTIX_ENV_JSON = JSON.stringify({ KORTIX_VERSION: "stale" });
+
+    expect(hydrateEnvironmentSecret()).toBe(0);
+    expect(process.env.KORTIX_VERSION).toBe("0.12.4");
+  });
+
+  test("rejects malformed or non-string secret values", () => {
+    process.env.KORTIX_ENV_JSON = "not-json";
+    expect(() => hydrateEnvironmentSecret()).toThrow("KORTIX_ENV_JSON must contain a JSON object");
+
+    process.env.KORTIX_ENV_JSON = JSON.stringify({ PORT: 8000 });
+    expect(() => hydrateEnvironmentSecret()).toThrow('KORTIX_ENV_JSON key "PORT" must be a string');
+  });
+});

--- a/packages/shared/src/environment-secret.ts
+++ b/packages/shared/src/environment-secret.ts
@@ -1,0 +1,35 @@
+export const KORTIX_ENV_JSON = "KORTIX_ENV_JSON";
+
+/**
+ * Expand the aggregate ECS environment secret before application config reads
+ * process.env. Explicit task-definition values win over values in the blob.
+ */
+export function hydrateEnvironmentSecret(
+  environment: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = environment[KORTIX_ENV_JSON];
+  if (raw === undefined) return 0;
+  delete environment[KORTIX_ENV_JSON];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`${KORTIX_ENV_JSON} must contain a JSON object`);
+  }
+  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error(`${KORTIX_ENV_JSON} must contain a JSON object`);
+  }
+
+  let hydrated = 0;
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value !== "string") {
+      throw new Error(`${KORTIX_ENV_JSON} key "${key}" must be a string`);
+    }
+    if (environment[key] === undefined) {
+      environment[key] = value;
+      hydrated += 1;
+    }
+  }
+  return hydrated;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,4 +12,5 @@ export * from "./constants/auto-topup";
 export * from "./runtime-versions";
 export * from "./project-glyphs";
 export * from "./meta-agent";
+export * from "./environment-secret";
 export * from "./utils/format-relative";


### PR DESCRIPTION
## Incident

At 2026-08-06T19:50Z, both production API tasks exhausted their 2 GiB memory limits during the same external marketplace refresh. Both containers exited with code 137.

ECS could not start replacement capacity. Task definition `kortix-prod:33` still referenced six Mailtrap JSON keys removed from `kortix-prod-env` on 2026-08-05. ECS rejected replacement tasks before container startup.

Production recovered at 2026-08-06T19:59:24Z. API revision `35` now runs 3/3 tasks with 4 GiB each. Gateway revision `29` runs 2/2 tasks.

## Changes

- Inject the complete Secrets Manager JSON document through one stable `KORTIX_ENV_JSON` selector.
- Hydrate API and gateway `process.env` before configuration and observability imports.
- Keep explicit task-definition environment values authoritative.
- Limit marketplace registry loading to four concurrent operations.
- Add up to one hour of refresh jitter after the 24-hour cache lifetime.
- Set production and disaster-recovery API memory to 4096 MiB.
- Set the active production API floor to three tasks.
- Add zero-healthy-host alarms.
- Repair target-group dimensions on ALB health and response-time alarms.
- Add the incident report and recovery evidence.

## Verification

- `pnpm --filter kortix-api typecheck` — pass
- `pnpm --filter @kortix/llm-gateway-server typecheck` — pass
- `pnpm --filter @kortix/shared test` — 288 pass
- `bun test apps/api/src/__tests__/unit-marketplace.test.ts --timeout 30000` — 15 pass
- `bun test infra/cloudflare/workers/api-router/worker.test.mjs` — 21 pass
- focused gateway tests — 26 pass
- ALB reconciler unit tests — 4 pass
- `black --check` and `ruff check` — pass
- Terraform format and validation for all three changed roots — pass
- API and gateway ECS deploy dry-runs — one aggregate selector each
- API production-secret config probe — 162 variables, 0 warnings
- Gateway production-secret black-box boot — `/health/live` returned 200

## Live production proof

- API ECS rollout: `COMPLETED`, desired 3, running 3, pending 0
- Gateway ECS rollout: `COMPLETED`, desired 2, running 2, pending 0
- API target group: 3 healthy targets
- Gateway target group: 2 healthy targets
- Public API health: 20/20 returned 200
- Public gateway health: 20/20 returned 200
- Public marketplace: 10/10 returned 200
- API zero-healthy-host alarm: OK with datapoint 3.0
- Gateway zero-healthy-host alarm: OK with datapoint 2.0
