### PR TITLE
fix(prod): enforce migration-safe ECS recovery

### DIFF
--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -334,12 +334,14 @@ jobs:
           bash infra/scripts/ecs-deploy.sh \
             prod-use2-shadow \
             "kortix/kortix-api:${IMAGE_TAG}" \
-            --version "$VERSION"
+            --version "$VERSION" \
+            --database-migrated
           bash infra/scripts/ecs-deploy.sh \
             prod-use2-shadow \
             "kortix/kortix-gateway:${IMAGE_TAG}" \
             --service gateway \
-            --version "$VERSION"
+            --version "$VERSION" \
+            --database-migrated
 
       - name: Verify ECS capacity and task images
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -788,8 +788,8 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - name: Roll prod ECS (api + gateway) from the prod-env blob
         run: |
-          bash infra/scripts/ecs-deploy.sh prod "kortix/kortix-api:${VERSION}" --version "${VERSION}"
-          bash infra/scripts/ecs-deploy.sh prod "kortix/kortix-gateway:${VERSION}" --service gateway --version "${VERSION}"
+          bash infra/scripts/ecs-deploy.sh prod "kortix/kortix-api:${VERSION}" --version "${VERSION}" --database-migrated
+          bash infra/scripts/ecs-deploy.sh prod "kortix/kortix-gateway:${VERSION}" --service gateway --version "${VERSION}" --database-migrated
 
   # ── Deploy the pre-cutover US East 2 production shadow ──────────────────────
   # The shadow uses the native US East 2 Supabase project and separate ECS

--- a/docs/incidents/2026-08-06-prod-api-oom-and-secret-selector-outage.md
+++ b/docs/incidents/2026-08-06-prod-api-oom-and-secret-selector-outage.md
@@ -1,4 +1,4 @@
-# Production API outage: OOM and stale secret selectors
+# Production API outage: OOM, stale secret selectors, and schema drift
 
 Date: 2026-08-06
 
@@ -69,6 +69,9 @@ All times use UTC.
 - `2026-08-06T20:09:07Z`: The gateway rollout completes with `2/2` tasks.
 - `2026-08-06T20:09:59Z`: The API rollout completes with `3/3` tasks.
 - `2026-08-06T20:17:06Z`: The API reaches steady state after the autoscaling floor changes to three tasks.
+- `2026-08-06T20:44:06Z`: API revision `36` starts from merge commit `8f121bd61a60`.
+- `2026-08-06T20:49:58Z`: Live traffic exposes `18` unapplied database migrations. Project and billing routes return `500` for missing columns.
+- `2026-08-06T20:54:39Z`: All `18` migrations are applied to the primary and disaster-recovery databases. Public API traffic returns `200` again.
 
 ## Recovery
 
@@ -83,14 +86,34 @@ The incident response made these production changes:
 
 Post-recovery verification:
 
-- API revision `35`: rollout `COMPLETED`, desired `3`, running `3`, pending `0`.
-- Gateway revision `29`: rollout `COMPLETED`, desired `2`, running `2`, pending `0`.
+- API revision `36`: rollout `COMPLETED`, desired `3`, running `3`, pending `0`.
+- Gateway revision `30`: rollout `COMPLETED`, desired `2`, running `2`, pending `0`.
 - API target group: three healthy targets.
 - Gateway target group: two healthy targets.
 - Public API health: `20/20` requests returned `200`.
 - Public gateway health: `20/20` requests returned `200`.
 - Public marketplace: `10/10` requests returned `200`.
-- Marketplace response: `7,248` items, `loading: false`, `pending: 0`.
+- Marketplace response: `7,250` items, `loading: false`, `pending: 0`.
+- API health reached all three instances. Every instance reported commit `8f121bd61a60`.
+- Both production databases reported `No migrations to run`.
+
+## Recovery regression: schema drift
+
+The emergency ECS rollout used `infra/scripts/ecs-deploy.sh` directly because the GitHub-hosted production workflow was queued.
+That path registered the new image without running the workflow's `migrate-db` job.
+The image required `18` migrations that production had not applied.
+
+The migration runner then found two production-only schema differences:
+
+- `credit_accounts` did not contain the legacy `kortix_credit_accounts_billing_model_check` constraint.
+- The disaster-recovery logical publication still published `project_session_connector_bindings.profile_id`.
+
+The billing migration now drops the old constraint with `IF EXISTS` before installing the canonical constraint.
+The connector migration now detaches explicit logical publications, removes `profile_id`, and re-adds the table with its canonical column list in one transaction.
+The primary publication now includes `connection_id` and excludes `profile_id`.
+Live production ECS rolls now require `--database-migrated`.
+Both production workflows pass this assertion only after their migration steps.
+A direct emergency ECS roll without the migration assertion exits before it calls AWS.
 
 ## Permanent prevention
 

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -115,6 +115,28 @@ describe('api-router worker', () => {
     );
   });
 
+  test('requires an explicit database migration gate for live production ECS rolls', () => {
+    const ecsDeploy = readFileSync(
+      new URL('../../../scripts/ecs-deploy.sh', import.meta.url),
+      'utf8',
+    );
+    const prodWorkflow = readFileSync(
+      new URL('../../../../.github/workflows/deploy-prod.yml', import.meta.url),
+      'utf8',
+    );
+    const shadowWorkflow = readFileSync(
+      new URL(
+        '../../../../.github/workflows/deploy-prod-us-east-2-shadow.yml',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+
+    expect(ecsDeploy).toContain('refusing live $ENV rollout without --database-migrated');
+    expect(prodWorkflow.match(/--database-migrated/g)?.length).toBe(2);
+    expect(shadowWorkflow.match(/--database-migrated/g)?.length).toBe(2);
+  });
+
   test('keeps production API tasks at the incident-tested 4 GiB and three-task floor', () => {
     const prodTerraform = readFileSync(
       new URL('../../../terraform/environments/prod/main.tf', import.meta.url),

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -10,7 +10,7 @@
 #
 # Usage:
 #   ecs-deploy.sh <env> <image> [--service api|gateway] [--version X.Y.Z]
-#                 [--no-wait] [--dry-run]
+#                 [--database-migrated] [--no-wait] [--dry-run]
 #
 #   env        dev | staging | prod | prod-use2-shadow
 #   image      full image ref to pin, e.g. kortix/kortix-api:dev-481dc551
@@ -26,6 +26,11 @@
 #              job assert the public endpoint serves the released version.
 #   --dry-run  render + print the task-def override, then exit WITHOUT
 #              registering or rolling anything.
+#   --database-migrated
+#              required for a live prod or prod-use2-shadow rollout. This is an
+#              explicit assertion that the environment's migration job passed.
+#              It prevents an emergency direct ECS roll from silently bypassing
+#              the database gate.
 #
 # Requires: awscli v2, jq. Assumes the ECS cluster/service/ALB/target-group and
 # the exec/task IAM roles already exist (Terraform owns those).
@@ -54,11 +59,13 @@ shift 2
 SVC_KIND="api"
 WAIT=1
 DRY_RUN=0
+DATABASE_MIGRATED=0
 VERSION_OVERRIDE=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --service) SVC_KIND="$2"; shift 2 ;;
     --version) VERSION_OVERRIDE="$2"; shift 2 ;;
+    --database-migrated) DATABASE_MIGRATED=1; shift ;;
     --no-wait) WAIT=0; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
@@ -91,6 +98,13 @@ case "$ENV" in
     ;;
   *) echo "unknown env: $ENV" >&2; exit 2 ;;
 esac
+
+if [ "$DRY_RUN" != "1" ] \
+  && { [ "$ENV" = "prod" ] || [ "$ENV" = "prod-use2-shadow" ]; } \
+  && [ "$DATABASE_MIGRATED" != "1" ]; then
+  echo "refusing live $ENV rollout without --database-migrated; apply and verify all database migrations first" >&2
+  exit 2
+fi
 
 # Each service lives in its own cluster (the ecs-api module names cluster==service):
 #   api     → cluster/service <service-prefix>,         container "api"

--- a/packages/db/migrations/20260806110120042_allow_credit_billing_model.sql
+++ b/packages/db/migrations/20260806110120042_allow_credit_billing_model.sql
@@ -27,7 +27,7 @@ set statement_timeout = '30s';
 -- nothing can hold 'credit' until the v3 Stripe prices exist, and checkout
 -- fails closed without them ("No price configured for this tier").
 alter table "kortix"."credit_accounts"
-  drop constraint "kortix_credit_accounts_billing_model_check";
+  drop constraint if exists "kortix_credit_accounts_billing_model_check";
 
 alter table "kortix"."credit_accounts"
   add constraint "kortix_credit_accounts_billing_model_check"

--- a/packages/db/migrations/20260806150353417_connector_compat_removal.sql
+++ b/packages/db/migrations/20260806150353417_connector_compat_removal.sql
@@ -40,8 +40,57 @@ ALTER TABLE kortix.project_session_connector_bindings
   ALTER COLUMN connection_id SET NOT NULL;
 ALTER TABLE kortix.project_session_connector_bindings
   DROP CONSTRAINT project_session_connector_bindings_profile_tenant_fk;
+
+-- Logical publications with explicit column lists depend on every published
+-- column. Detach this table before removing profile_id, then re-add it with the
+-- canonical post-cutover columns. The publication change and column removal
+-- commit atomically with this migration.
+CREATE TEMP TABLE connector_binding_publications ON COMMIT DROP AS
+SELECT pg_publication.pubname
+FROM pg_publication
+JOIN pg_publication_rel
+  ON pg_publication_rel.prpubid = pg_publication.oid
+WHERE pg_publication_rel.prrelid =
+  'kortix.project_session_connector_bindings'::regclass;
+
+DO $do$
+DECLARE
+  publication record;
+BEGIN
+  FOR publication IN SELECT pubname FROM connector_binding_publications LOOP
+    EXECUTE format(
+      'ALTER PUBLICATION %I DROP TABLE kortix.project_session_connector_bindings',
+      publication.pubname
+    );
+  END LOOP;
+END
+$do$;
+
 -- squawk-ignore ban-drop-column
 ALTER TABLE kortix.project_session_connector_bindings DROP COLUMN profile_id;
+
+DO $do$
+DECLARE
+  publication record;
+  column_list text;
+BEGIN
+  SELECT string_agg(format('%I', column_name), ', ' ORDER BY ordinal_position)
+  INTO column_list
+  FROM information_schema.columns
+  WHERE table_schema = 'kortix'
+    AND table_name = 'project_session_connector_bindings'
+    AND is_generated = 'NEVER';
+
+  FOR publication IN SELECT pubname FROM connector_binding_publications LOOP
+    EXECUTE format(
+      'ALTER PUBLICATION %I ADD TABLE kortix.project_session_connector_bindings (%s)',
+      publication.pubname,
+      column_list
+    );
+  END LOOP;
+END
+$do$;
+
 ALTER TABLE kortix.project_session_connector_bindings
   DROP CONSTRAINT project_session_connector_bindings_connection_not_null;
 


### PR DESCRIPTION
## Incident

The emergency ECS rollout bypassed `migrate-db`. Production then served code against 18 pending migrations. Two production-only schema differences stopped the migration runner.

## Fix

- tolerate the absent legacy billing constraint
- detach and restore logical-publication membership around the connector column cutover
- require `--database-migrated` for live production and DR ECS rolls
- pass the guard only from workflows that run migrations first
- record the schema-drift recovery in the incident report

## Verification

- production primary: no pending migrations
- production DR: no pending migrations
- DB package: 175 pass, 6 skipped, 0 fail
- DB typecheck: pass
- migration lint and Squawk: pass
- API-router tests: 22 pass, 0 fail
- `bash -n infra/scripts/ecs-deploy.sh`: pass
- unguarded production deploy: exits 2 before AWS
- public API: 20/20 HTTP 200
- public gateway: 20/20 HTTP 200
- public marketplace: 10/10 HTTP 200