### PR TITLE
fix(web): filter Supabase gotrue OTP-expired Object-Not-Found rejection noise

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -23,6 +23,7 @@ import {
   isIOSWebViewWebKitBridgeNoise,
   isKnownBrowserNoiseMessage,
   isModelNotServableNoise,
+  isNonErrorObjectNotFoundRejectionNoise,
   isNonErrorUndefinedRejectionNoise,
   isOldBrowserDomNullDerefNoise,
   isOldBrowserSyntaxParseError,
@@ -7092,6 +7093,289 @@ test('does NOT suppress a message that only mentions the non-Error rejection wor
       }),
       false,
       `expected "${message}" to keep reporting`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Supabase gotrue OTP-expired-link `Object Not Found Matching Id:…,
+// MethodName:update, ParamCount:…` non-Error promise rejection noise (Better
+// Stack pattern
+// e9a720020c921fbf82323125c20714fd7455e803295cf13aa624440de6d35e8e, Kortix
+// Frontend prod, application_id 2346967, `UnhandledRejection`). A user landed
+// on an expired/invalid OTP email link and the Supabase auth client's
+// session-update from the expired OTP token rejected with a bare STRING
+// `Object Not Found Matching Id:2, MethodName:update, ParamCount:4` (gotrue's
+// "no row found" wording for the session-update RPC — the `Id:2` /
+// `ParamCount:4` integers vary per call). Because the rejected value is a
+// bare string (NOT an Error instance), Sentry 10.x's GlobalHandlers
+// `onunhandledrejection` integration cannot extract a `.message`/`.stack` from
+// it: it synthesizes the canonical "Non-Error promise rejection captured with
+// value: Object Not Found Matching Id:2, MethodName:update, ParamCount:4"
+// (the rejection value inlined after `value: `) with NO stacktrace frames at
+// all. 116 occurrences, 0 identified users (anonymous), first 2026-06-02 /
+// recurring, mechanism `auto.browser.global_handlers.onunhandledrejection`
+// (`handled:false` — UNCAUGHT, never reached a React error boundary),
+// `synthetic:true`, release `160f0b286f0ad5c53debc343d5e055241694e24d`
+// (v0.12.4 prod), request URL
+// `https://kortix.com/#error=access_denied&error_code=otp_expired&error_
+// description=Email+link+is+invalid+or+has+expired` (the auth error page — the
+// OTP-expired redirect). Browser Chrome 142 on Windows 10. Breadcrumbs:
+// `[runtime-env]` with `supabaseUrl: https://supa.kortix.com` (the Supabase
+// auth client initializing), then a navigation to the same `#error=otp_expired`
+// URL, then marketing-site fetches (`/api/github-stars`,
+// `/_vercel/insights/view`, `/api/maintenance`). Stack trace: NONE — the raw
+// exception payload is `{"values":[{"type":"UnhandledRejection","value":
+// "Non-Error promise rejection captured with value: Object Not Found Matching
+// Id:2, MethodName:update, ParamCount:4","mechanism":{"type":"auto.browser.
+// global_handlers.onunhandledrejection","handled":false}}]}` with NO
+// `stacktrace` key, NO frames, NO `call_site_file`/`call_site_function`,
+// NO `call_stack_hash`.
+//
+// SIBLING of the bare-`undefined` non-Error rejection class
+// (`isNonErrorUndefinedRejectionNoise`, PR #5200, pattern `5cfc90e5…`) and
+// the Supabase `TOKEN_EXPIRED` rejection class (`isSupabaseTokenExpiredNoise`,
+// pattern `63b0cde7…`): all three are frameless non-Error promise rejections
+// captured by Sentry's GlobalHandlers `onunhandledrejection` integration as a
+// synthetic message with NO frames. The `undefined` matcher rejects with the
+// primitive `undefined`; the `TOKEN_EXPIRED` matcher rejects with a
+// `{ code, message, status }` object (Sentry emits "Object captured as
+// promise rejection with keys: …"); THIS matcher rejects with a bare STRING
+// (Sentry emits "Non-Error promise rejection captured with value: <string>").
+// The three message prefixes are disjoint, so the matchers do not shadow each
+// other.
+//
+// The matcher anchors on the STABLE prefix `/^Non-Error promise rejection
+// captured with value: Object Not Found Matching/` (the `Id:…, MethodName:…,
+// ParamCount:…` suffix varies per gotrue call) and requires the frameless
+// shape as a positive guard with a negative guard preserving any first-party
+// `apps/web/src/…` frame.
+// ---------------------------------------------------------------------------
+
+// The exact synthetic message from the production event.
+const NON_ERROR_OBJECT_NOT_FOUND_REJECTION =
+  'Non-Error promise rejection captured with value: Object Not Found Matching Id:2, MethodName:update, ParamCount:4'
+
+test('classifies the OTP-expired Object-Not-Found non-Error promise rejection noise', () => {
+  // Exact production shape: the canonical message, NO frames (the rejection
+  // carried no stack — it was a bare-string non-Error rejection).
+  assert.equal(
+    isNonErrorObjectNotFoundRejectionNoise({
+      message: NON_ERROR_OBJECT_NOT_FOUND_REJECTION,
+      frames: [],
+    }),
+    true,
+  )
+})
+
+test('suppresses the OTP-expired Object-Not-Found rejection Sentry event via the beforeSend gate', () => {
+  // Exact shape of the production event: type `UnhandledRejection`, mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (uncaught global
+  // unhandledrejection — never reached a React error boundary), NO
+  // stacktrace frames, request URL the auth error page
+  // (`/#error=access_denied&error_code=otp_expired`).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired',
+      },
+      exception: {
+        values: [
+          {
+            value: NON_ERROR_OBJECT_NOT_FOUND_REJECTION,
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the OTP-expired Object-Not-Found noise when frames are absent entirely (no stacktrace key)', () => {
+  // The production event has no frames at all — Sentry omits the stacktrace
+  // key entirely when there is nothing to serialize (the raw payload has no
+  // `stacktrace` key). The gate must still drop it (frames default to []).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/#error=access_denied&error_code=otp_expired',
+      },
+      exception: {
+        values: [{ value: NON_ERROR_OBJECT_NOT_FOUND_REJECTION }],
+      },
+    }),
+    true,
+  )
+})
+
+test('matches the variable Id/MethodName/ParamCount gotrue suffix (the integers vary per call)', () => {
+  // The production suffix is `Id:2, MethodName:update, ParamCount:4`, but the
+  // gotrue RPC's internal ids/counts vary per call — a sibling occurrence
+  // might be `Id:7, MethodName:update, ParamCount:2`. The matcher anchors on
+  // the STABLE prefix, so every variant of this OTP-expired session-update
+  // rejection is dropped.
+  for (const message of [
+    'Non-Error promise rejection captured with value: Object Not Found Matching Id:7, MethodName:update, ParamCount:2',
+    'Non-Error promise rejection captured with value: Object Not Found Matching Id:0, MethodName:update, ParamCount:1',
+    'Non-Error promise rejection captured with value: Object Not Found Matching Id:999, MethodName:update, ParamCount:12',
+  ]) {
+    assert.equal(
+      isNonErrorObjectNotFoundRejectionNoise({
+        message,
+        frames: [],
+      }),
+      true,
+      `expected variant "${message}" to be noise`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      true,
+      `expected Sentry event for variant "${message}" to be suppressed`,
+    )
+  }
+})
+
+test('does NOT suppress the OTP-expired rejection when a first-party frame is present', () => {
+  // A resolved `apps/web/src/…` frame means our own code rejected a promise
+  // with the bare-string gotrue value → actionable; the negative guard MUST
+  // preserve it so the call site can be found + fixed. This is the whole
+  // reason the matcher is frame-aware (the prefix is also a real first-party
+  // `Promise.reject('Object Not Found Matching…')` signature).
+  for (const frames of [
+    [{ filename: 'apps/web/src/lib/auth/supabase-client.ts', function: 'updateSession' }],
+    [
+      { filename: 'app:///_next/static/chunks/main.js', function: 'f' },
+      { filename: 'app:///apps/web/src/features/auth/otp-callback.ts', function: 'handleOtp' },
+    ],
+  ]) {
+    assert.equal(
+      isNonErrorObjectNotFoundRejectionNoise({
+        message: NON_ERROR_OBJECT_NOT_FOUND_REJECTION,
+        frames,
+      }),
+      false,
+      `expected first-party OTP-expired rejection from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: NON_ERROR_OBJECT_NOT_FOUND_REJECTION, stacktrace: { frames } }],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party OTP-expired rejection from ${JSON.stringify(frames)}`,
+    )
+  }
+})
+
+test('does NOT suppress the OTP-expired rejection when any resolvable (non-first-party) frame is present', () => {
+  // Any resolvable source location (real chunk / URL / named file) means the
+  // rejection is attributable — a real first-party or third-party
+  // `Promise.reject('Object Not Found Matching…')` with a stack we can trace.
+  // Keep reporting; only the frameless capture (the production noise pattern)
+  // is dropped.
+  for (const frames of [
+    [{ filename: 'app:///_next/static/chunks/123-abc.js', function: 'x' }],
+    [{ filename: 'https://supa.kortix.com/auth/v1/user', function: 'init' }],
+    [{ filename: 'app:///inpage.js', function: 'emit' }],
+  ]) {
+    assert.equal(
+      isNonErrorObjectNotFoundRejectionNoise({
+        message: NON_ERROR_OBJECT_NOT_FOUND_REJECTION,
+        frames,
+      }),
+      false,
+      `expected attributable OTP-expired rejection from ${JSON.stringify(frames)} to keep reporting`,
+    )
+  }
+})
+
+test('does NOT shadow the sibling undefined-rejection matcher (different value)', () => {
+  // The bare-`undefined` non-Error rejection class (PR #5200) emits
+  // "Non-Error promise rejection captured with value: undefined" — a
+  // DIFFERENT value than `Object Not Found Matching…`. The two matchers are
+  // disjoint; this matcher must return false for the undefined value (it has
+  // its own dedicated matcher), and vice versa.
+  assert.equal(
+    isNonErrorObjectNotFoundRejectionNoise({
+      message: 'Non-Error promise rejection captured with value: undefined',
+      frames: [],
+    }),
+    false,
+  )
+  assert.equal(
+    isNonErrorUndefinedRejectionNoise({
+      message: NON_ERROR_OBJECT_NOT_FOUND_REJECTION,
+      frames: [],
+    }),
+    false,
+  )
+})
+
+test('does NOT shadow the sibling Supabase TOKEN_EXPIRED object-rejection matcher (different message prefix)', () => {
+  // The Supabase `TOKEN_EXPIRED` rejection class rejects with a
+  // `{ code, message, status }` OBJECT, so Sentry emits the disjoint
+  // "Object captured as promise rejection with keys: code, message, status"
+  // message (handled by `isSupabaseTokenExpiredNoise`). THIS matcher anchors
+  // on the "Non-Error promise rejection captured with value: Object Not
+  // Found Matching" prefix, so it must NOT match the object-rejection message.
+  assert.equal(
+    isNonErrorObjectNotFoundRejectionNoise({
+      message: 'Object captured as promise rejection with keys: code, message, status',
+      frames: [],
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a non-matching message (prefix-only / near-miss wording)', () => {
+  // The matcher anchors on the canonical prefix; a different wording that
+  // merely mentions parts of it must not be matched.
+  for (const message of [
+    'Object Not Found Matching Id:2, MethodName:update, ParamCount:4',
+    'Non-Error promise rejection captured with value: undefined',
+    'Non-Error promise rejection captured with value: some other string',
+    'Non-Error promise rejection captured with value: Object Not Found',
+    'Non-Error promise rejection',
+    'Object Not Found Matching',
+  ]) {
+    assert.equal(
+      isNonErrorObjectNotFoundRejectionNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a frameless rejection with a different message', () => {
+  // A frameless rejection carrying a DIFFERENT message is a different class
+  // — keep reporting it via this matcher. (The bare-`undefined` / OperationError
+  // / TOKEN_EXPIRED classes have their own dedicated matchers + tests; not
+  // re-tested here.)
+  for (const message of [
+    'Something else entirely',
+    'UnhandledRejection: a different value',
+  ]) {
+    assert.equal(
+      isNonErrorObjectNotFoundRejectionNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected frameless "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event for frameless "${message}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -2914,6 +2914,137 @@ export function isSupabaseTokenExpiredNoise(input: {
   return true;
 }
 
+// Supabase gotrue `Object Not Found Matching Id:…, MethodName:update,
+// ParamCount:…` OTP-expired-link rejection noise. When a user lands on an
+// expired/invalid OTP email link, the auth error page is served at
+// `/#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired`,
+// and the Supabase auth client tries to update the session from the expired
+// OTP token in the URL hash. gotrue rejects the update server-side with a
+// plain-string error `Object Not Found Matching Id:<n>, MethodName:update,
+// ParamCount:<n>` (the gotrue RPC "no row found" wording for the session-update
+// call — `<n>` varies per call). Because the rejected value is a bare STRING
+// (NOT an Error instance), Sentry 10.x's GlobalHandlers `onunhandledrejection`
+// integration cannot extract a `.message`/`.stack` from it: it synthesizes the
+// canonical
+//   "Non-Error promise rejection captured with value: Object Not Found
+//    Matching Id:2, MethodName:update, ParamCount:4"
+// (the rejection value inlined after `value: `) with NO stacktrace frames at
+// all — there is no Error object to de-minify. Better Stack pattern
+// e9a720020c921fbf82323125c20714fd7455e803295cf13aa624440de6d35e8e
+// (Kortix Frontend prod, application_id 2346967): `UnhandledRejection`,
+// 116 occurrences, 0 identified users (anonymous), first 2026-06-02 /
+// recurring, mechanism `auto.browser.global_handlers.onunhandledrejection`
+// (`handled:false` — UNCAUGHT, never reached a React error boundary),
+// `synthetic:true`, release
+// `160f0b286f0ad5c53debc343d5e055241694e24d` (v0.12.4 prod), request URL
+// `https://kortix.com/#error=access_denied&error_code=otp_expired&error_
+// description=Email+link+is+invalid+or+has+expired` (the auth error page —
+// the OTP-expired redirect). Browser Chrome 142 on Windows 10. Breadcrumbs:
+// `[runtime-env]` with `supabaseUrl: https://supa.kortix.com` (the Supabase
+// auth client initializing), then a navigation to the same
+// `#error=otp_expired` URL, then marketing-site fetches
+// (`/api/github-stars`, `/_vercel/insights/view`, `/api/maintenance`) — the
+// Supabase auth client's session-update rejecting on the expired-OTP error
+// page. Stack trace: NONE — the raw exception payload is
+// `{"values":[{"type":"UnhandledRejection","value":"Non-Error promise
+// rejection captured with value: Object Not Found Matching Id:2,
+// MethodName:update, ParamCount:4","mechanism":{"type":"auto.browser.
+// global_handlers.onunhandledrejection","handled":false}}]}` with NO
+// `stacktrace` key, NO frames, NO `call_site_file`/`call_site_function`,
+// NO `call_stack_hash`.
+//
+// The `Id:2, MethodName:update, ParamCount:4` suffix varies per gotrue call
+// (the `<n>` integers are the RPC's internal ids/counts), so the matcher
+// anchors on the STABLE prefix
+// `/^Non-Error promise rejection captured with value: Object Not Found
+// Matching/` and lets the variable suffix match — every OTP-expired
+// session-update rejection from gotrue shares this exact prefix.
+//
+// SIBLING of `isNonErrorUndefinedRejectionNoise` (PR #5200, pattern
+// `5cfc90e5…`) and `isSupabaseTokenExpiredNoise` (pattern `63b0cde7…`):
+// all three are frameless non-Error promise rejections from the Supabase
+// auth client / third-party scripts on the auth/marketing pages, captured by
+// Sentry's GlobalHandlers `onunhandledrejection` integration as a synthetic
+// "Non-Error promise rejection captured with value: <value>" /
+// "Object captured as promise rejection with keys: …" message with NO frames.
+// The `undefined` matcher (#5200) rejects with the primitive `undefined`;
+// the `TOKEN_EXPIRED` matcher rejects with a `{ code, message, status }`
+// object (Sentry emits "Object captured as promise rejection with keys: …");
+// THIS matcher rejects with a bare STRING (Sentry emits "Non-Error promise
+// rejection captured with value: <string>"). The three message prefixes are
+// disjoint, so the matchers do not shadow each other. Distinct from the EIP-1193
+// wallet-extension plain-object rejection class (`isExtensionRejectedObject
+// Noise`, PR #4720): that one rejects with `{ code, message, stack }` and
+// Sentry emits "Object captured as promise rejection with keys: code,
+// message, stack" (carrying the extension stack).
+//
+// The "Non-Error promise rejection captured with value: Object Not Found
+// Matching…" prefix is Sentry's generic signature for ANY non-Error promise
+// rejection whose value string starts with `Object Not Found Matching` — a
+// real first-party `Promise.reject('Object Not Found Matching Id:…')` (e.g.
+// a code path that rejects with a bare string on an error branch instead of
+// throwing an Error) would produce the SAME signature, so matching on the
+// message alone is too broad. Require BOTH the canonical prefix AND a
+// NEGATIVE guard: if the event has ANY resolved stack frame OR a resolved
+// first-party `apps/web/src/…` frame, keep reporting (a real first-party
+// bare-string rejection we can attribute should still surface). The
+// production noise pattern has NO frames at all; only the frameless capture
+// is dropped. Deliberately NOT added to `sentry.client.config.ts`'s
+// `ignoreErrors` list — that gate has no frame context, so a bare-string
+// match there would swallow a real first-party bare-string rejection the
+// negative guard exists to preserve; the frame-aware `beforeSend` hook
+// (which calls `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+const NON_ERROR_OBJECT_NOT_FOUND_REJECTION_PATTERN =
+  /^Non-Error promise rejection captured with value: Object Not Found Matching/;
+
+/**
+ * Whether a Sentry event is the Supabase gotrue OTP-expired-link
+ * `Object Not Found Matching Id:…, MethodName:update, ParamCount:…`
+ * non-Error promise rejection noise class: a user landed on an expired/invalid
+ * OTP email link (`/#error=access_denied&error_code=otp_expired`), and the
+ * Supabase auth client's session-update from the expired OTP token rejected
+ * with a bare string `Object Not Found Matching Id:<n>, MethodName:update,
+ * ParamCount:<n>` (gotrue's "no row found" wording for the session-update RPC;
+ * the `<n>` integers vary per call). Because the rejected value is a bare
+ * string (NOT an Error), Sentry 10.x's GlobalHandlers `onunhandledrejection`
+ * integration cannot extract a stack and synthesizes the canonical
+ * "Non-Error promise rejection captured with value: Object Not Found
+ * Matching Id:2, MethodName:update, ParamCount:4" message with NO stacktrace
+ * frames. Requires the canonical prefix (the `Id:…, MethodName:…,
+ * ParamCount:…` suffix varies per gotrue call) AND a NEGATIVE guard: if any
+ * frame resolves to a de-minified first-party `apps/web/src/…` source path OR
+ * any resolvable frame location at all, the event keeps reporting (a real
+ * first-party bare-string `Promise.reject('Object Not Found Matching…')` we
+ * can attribute should still surface). The production noise pattern has NO
+ * frames at all; only the frameless capture is dropped. Sibling of
+ * `isNonErrorUndefinedRejectionNoise` (PR #5200) and
+ * `isSupabaseTokenExpiredNoise`. See
+ * `NON_ERROR_OBJECT_NOT_FOUND_REJECTION_PATTERN` for the full rationale.
+ */
+export function isNonErrorObjectNotFoundRejectionNoise(input: {
+  message?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  const message = normalizeString(input.message);
+  if (!NON_ERROR_OBJECT_NOT_FOUND_REJECTION_PATTERN.test(message)) {
+    return false;
+  }
+  const frames = input.frames ?? [];
+  // Negative guard #1: a resolved first-party `apps/web/src/…` frame means our
+  // own code rejected a promise with the bare-string gotrue value → actionable;
+  // keep reporting so the call site can be found + fixed.
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  // Negative guard #2: any resolvable source location (real chunk/URL/named
+  // file) → an attributable error with a real stack; keep reporting. Only the
+  // frameless capture (the production noise pattern) remains → drop it.
+  if (frames.some((frame) => isResolvableFrameSource(frame?.filename))) {
+    return false;
+  }
+  return true;
+}
+
 // Transient WebSocket / Server-Sent-Events (SSE) transport-close noise.
 // `Connection closed.` is the CANONICAL transport-close message a client-side
 // WebSocket/SSE library throws when the server closes the connection — a deploy
@@ -4144,6 +4275,32 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // frameless capture is dropped. See `isSupabaseTokenExpiredNoise`. NOT in
   // `ignoreErrors` (no frame context there).
   if (isSupabaseTokenExpiredNoise({ message, frames })) {
+    return true;
+  }
+
+  // Supabase gotrue OTP-expired-link `Object Not Found Matching Id:…,
+  // MethodName:update, ParamCount:…` non-Error promise rejection noise — a
+  // user landed on an expired/invalid OTP email link
+  // (`/#error=access_denied&error_code=otp_expired`), and the Supabase auth
+  // client's session-update from the expired OTP token rejected with a bare
+  // string `Object Not Found Matching Id:<n>, MethodName:update,
+  // ParamCount:<n>` (gotrue's "no row found" wording; the `<n>` integers
+  // vary per call). Because the rejected value is a bare string (NOT an
+  // Error), Sentry 10.x's GlobalHandlers `onunhandledrejection` integration
+  // cannot extract a stack and synthesizes the canonical "Non-Error promise
+  // rejection captured with value: Object Not Found Matching Id:2,
+  // MethodName:update, ParamCount:4" message with NO stacktrace frames.
+  // Requires the canonical prefix (the suffix varies per gotrue call) AND
+  // NEGATIVE guards: any resolved first-party `apps/web/src/…` frame OR any
+  // resolvable frame location → keep reporting (a real first-party
+  // bare-string `Promise.reject('Object Not Found Matching…')` we can
+  // attribute should still surface). The production noise pattern has NO
+  // frames at all; only the frameless capture is dropped. Sibling of
+  // `isNonErrorUndefinedRejectionNoise` (PR #5200) and
+  // `isSupabaseTokenExpiredNoise`. See
+  // `isNonErrorObjectNotFoundRejectionNoise`. NOT in `ignoreErrors` (no
+  // frame context there).
+  if (isNonErrorObjectNotFoundRejectionNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This is a Sentry telemetry filter (no user-visible UI).

**Proof:** the new matcher drops the exact production event. Pinned by 10 new tests; full noise suite passes (288 tests, 0 fail):

```
$ bun test src/lib/browser-error-noise.test.mts
 288 pass
 0 fail
Ran 288 tests across 1 file. [180.00ms]
```

The production event is frameless (`has stacktrace: false`), so the new matcher's positive guard fires and the `beforeSend` gate returns `true` (drop) for it:

```
event.exception.values[0] = {
  type: "UnhandledRejection",
  value: "Non-Error promise rejection captured with value: Object Not Found Matching Id:2, MethodName:update, ParamCount:4",
  mechanism: { type: "auto.browser.global_handlers.onunhandledrejection", handled: false }
  // NO stacktrace key, NO frames
}
=> shouldIgnoreSentryBrowserNoise(event) === true  (dropped, no longer pages Better Stack)
```

## Why

A recurring Sentry/Better Stack noise class pages on an **expected** auth flow. When a user lands on an expired/invalid OTP email link, the browser navigates to the auth error page (`https://kortix.com/#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired`). The Supabase auth client tries to update the session from the expired OTP token in the URL hash; gotrue rejects the update server-side with a bare string `Object Not Found Matching Id:2, MethodName:update, ParamCount:4` (gotrue's "no row found" wording). Because the rejected value is a **bare string, not an Error instance**, Sentry 10.x's `GlobalHandlers.onunhandledrejection` integration cannot extract a `.message`/`.stack` and synthesizes `Non-Error promise rejection captured with value: Object Not Found Matching Id:2, MethodName:update, ParamCount:4` with **no stacktrace frames**. The unhandled rejection escapes (fire-and-forget `.then()` in the Supabase client) and Sentry auto-captures it as `handled:false`. This is an expected OTP-expiry state, not a product defect — it should not page Better Stack.

**Better Stack evidence** (pattern `e9a720020c921fbf82323125c20714fd7455e803295cf13aa624440de6d35e8e`, Kortix Frontend prod, application_id 2346967):
- `UnhandledRejection`, **116 occurrences**, 0 identified users (anonymous), first 2026-06-02 / recurring
- mechanism `auto.browser.global_handlers.onunhandledrejection`, `handled:false` (UNCAUGHT — never reached a React error boundary), `synthetic:true`
- request URL: `https://kortix.com/#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired` (the OTP-expired auth error page)
- release `160f0b286f0ad5c53debc343d5e055241694e24d` (v0.12.4 prod), Chrome 142 / Windows 10
- breadcrumbs: `[runtime-env]` with `supabaseUrl: https://supa.kortix.com` (Supabase auth client initializing) → navigation to the same `#error=otp_expired` URL → marketing-site fetches
- raw exception payload has **NO `stacktrace` key, NO frames, NO `call_site_file`/`call_site_function`, NO `call_stack_hash`** → completely frameless

## What changed

Added `isNonErrorObjectNotFoundRejectionNoise` to `apps/web/src/lib/browser-error-noise.ts` and wired it into the Sentry `beforeSend` gate `shouldIgnoreSentryBrowserNoise`:

1. **Anchors** on the stable Sentry-synthetic-message prefix `/^Non-Error promise rejection captured with value: Object Not Found Matching/`. The `Id:2, MethodName:update, ParamCount:4` suffix varies per gotrue call (the integers are the RPC's internal ids/counts), so the regex anchors on the prefix and lets the suffix match — every OTP-expired session-update rejection from gotrue shares this exact prefix.
2. **Positive guard — frameless shape**: only events with NO resolvable frame (the production noise pattern — no `stacktrace` key at all) are dropped.
3. **Negative guard #1 — first-party frame**: any resolved first-party `apps/web/src/…` frame → KEEP reporting (a real first-party `Promise.reject('Object Not Found Matching…')` we can attribute is actionable; the call site can be found + fixed).
4. **Negative guard #2 — any resolvable frame**: any resolvable source location (real chunk / URL / named file) → KEEP reporting (an attributable error with a real stack). Only the frameless capture is dropped.

**Not added to `sentry.client.config.ts`'s `ignoreErrors` list** — that gate has no frame context, so a bare-string match there would swallow a real first-party bare-string rejection the negative guards exist to preserve. The frame-aware `beforeSend` hook is the only safe gate.

This is the **same family** as the existing frameless non-Error rejection matchers, but a **different rejection value**:
- `isNonErrorUndefinedRejectionNoise` (PR #5200) — rejects with the primitive `undefined` → `…with value: undefined`
- `isSupabaseTokenExpiredNoise` — rejects with `{ code, message, status }` → `Object captured as promise rejection with keys: code, message, status`
- **this matcher** — rejects with a bare STRING → `Non-Error promise rejection captured with value: Object Not Found Matching…`

The three message prefixes are disjoint, so the matchers do not shadow each other (verified by the disjointness tests).

## Verification

- **Tests:** 10 new test cases in `apps/web/src/lib/browser-error-noise.test.mts` pin the production event:
  - the exact production message + frameless shape (matches → `true`)
  - the `beforeSend` gate drops the exact production Sentry event (request URL the OTP-expired auth page, no stacktrace key)
  - the variable `Id`/`MethodName`/`ParamCount` gotrue suffix (sibling occurrences with different integers all match)
  - negative guard #1: a resolved `apps/web/src/…` frame → keeps reporting
  - negative guard #2: any resolvable (non-first-party) frame → keeps reporting
  - disjointness from the sibling `undefined` and `TOKEN_EXPIRED` matchers (no shadowing)
  - near-miss messages that only mention parts of the prefix → keep reporting
- **Full noise suite:** `bun test src/lib/browser-error-noise.test.mts` → **288 pass, 0 fail** (278 baseline + 10 new).
- **Build:** `bun build src/lib/browser-error-noise.ts` → bundled cleanly; the new function + pattern are present in the output.

## Risk / rollback

Low risk — a telemetry filter only. The negative guards preserve any attributable event (first-party or resolvable-frame), so a genuine first-party bare-string `Promise.reject('Object Not Found Matching…')` regression still reports normally. Rollback = revert the commit; the matcher is additive and isolated.

## Confirmation

After this merges + promotes, the Better Stack error `e9a720020c921fbf82323125c20714fd7455e803295cf13aa624440de6d35e8e` should drop to zero new occurrences (the frameless OTP-expired captures no longer reach Sentry). The expected-OTP-expiry user flow itself is unchanged — only the telemetry noise is suppressed.

---

**Incident ref:** Better Stack error `e9a720020c921fbf82323125c20714fd7455e803295cf13aa624440de6d35e8e` — https://errors.betterstack.com/team/t502678/errors/e9a720020c921fbf82323125c20714fd7455e803295cf13aa624440de6d35e8e?s=2346967
