### PR TITLE
release: promote main c7023f12 to staging

### DIFF
--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -46,6 +46,7 @@ let provisioningSessionCount = 0;
 let secretRows: Array<typeof projectSecrets.$inferSelect>;
 let manifestReadCalls = 0;
 let mirrorInvalidationCalls = 0;
+let manifestCommitConflictsRemaining = 0;
 let modelDefaults: {
   account: string | null;
   agents: Record<string, string>;
@@ -95,6 +96,7 @@ function resetState() {
   secretRows = [];
   manifestReadCalls = 0;
   mirrorInvalidationCalls = 0;
+  manifestCommitConflictsRemaining = 0;
   modelDefaults = { account: null, agents: {}, projects: {} };
   projectRow.metadata = {};
   secretValues.clear();
@@ -145,7 +147,14 @@ mock.module('../projects/git', () => ({
     manifestReadCalls += 1;
     for (const path of candidatePaths) {
       const content = repoFiles.get(path);
-      if (content !== undefined) return { path, content };
+      if (content !== undefined) {
+        return {
+          path,
+          content,
+          sha: `sha-${path}`,
+          candidatePaths,
+        };
+      }
     }
     return null;
   },
@@ -166,6 +175,12 @@ mock.module('../projects/git', () => ({
   previewMerge: async () => ({ canMerge: true, conflicts: [] }),
   mergeBranches: async () => ({ mergedSha: 'a'.repeat(40) }),
   commitFileToBranch: async (_project: unknown, opts: { path: string; content: string; message: string }) => {
+    if (manifestCommitConflictsRemaining > 0) {
+      manifestCommitConflictsRemaining -= 1;
+      const error = new Error(`File "${opts.path}" changed since it was read`);
+      error.name = 'GitFileRevisionConflictError';
+      throw error;
+    }
     repoFiles.set(opts.path, opts.content);
     commitCalls.push({ path: opts.path, message: opts.message });
     return { commitSha: 'a'.repeat(40) };
@@ -913,6 +928,29 @@ describe('git-backed triggers — CRUD', () => {
     expect(body.triggers[0].webhook_url).toContain(`/v1/webhooks/projects/${PROJECT_ID}/slack-hook`);
   });
 
+  test('POST /triggers reloads and retries one manifest revision conflict', async () => {
+    seedManifest();
+    manifestCommitConflictsRemaining = 1;
+
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Daily Digest',
+        type: 'cron',
+        cron: '0 0 9 * * 1-5',
+        timezone: 'UTC',
+        prompt_template: 'Pull the deploy logs.',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(manifestReadCalls).toBe(3);
+    expect(commitCalls).toHaveLength(1);
+    expect(repoFiles.get(MANIFEST_PATH)).toContain('slug: daily-digest');
+  });
+
   test('POST /triggers rejects duplicate slugs', async () => {
     seedManifest(cronEntry({
       slug: 'daily-digest',
@@ -1045,6 +1083,32 @@ describe('git-backed triggers — CRUD', () => {
     expect(updated).toContain('old prompt');
   });
 
+  test('PATCH /triggers/:slug reloads and retries one manifest revision conflict', async () => {
+    seedManifest(cronEntry({
+      slug: 'one',
+      name: 'Old name',
+      agent: 'default',
+      enabled: true,
+      cron: '0 */15 * * * *',
+      timezone: 'UTC',
+      prompt: 'old prompt',
+    }));
+    manifestCommitConflictsRemaining = 1;
+
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers/one`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'New name', enabled: false }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(manifestReadCalls).toBe(3);
+    expect(commitCalls).toHaveLength(1);
+    expect(repoFiles.get(MANIFEST_PATH)).toContain('name: New name');
+    expect(repoFiles.get(MANIFEST_PATH)).toContain('enabled: false');
+  });
+
   test('POST /triggers accepts and returns a pinned model', async () => {
     const app = createApp();
     const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers`, {
@@ -1128,6 +1192,25 @@ describe('git-backed triggers — CRUD', () => {
     const updated = repoFiles.get(MANIFEST_PATH)!;
     expect(updated).not.toContain('slug: one');
     expect(updated).toContain('slug: two');
+  });
+
+  test('DELETE /triggers/:slug reloads and retries one manifest revision conflict', async () => {
+    seedManifest(
+      cronEntry({ slug: 'one', name: 'One', cron: '* * * * * *', prompt: 'body' }),
+      cronEntry({ slug: 'two', name: 'Two', cron: '* * * * * *', prompt: 'body' }),
+    );
+    manifestCommitConflictsRemaining = 1;
+
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers/one`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(200);
+    expect(manifestReadCalls).toBe(2);
+    expect(commitCalls).toHaveLength(1);
+    expect(repoFiles.get(MANIFEST_PATH)).not.toContain('slug: one');
+    expect(repoFiles.get(MANIFEST_PATH)).toContain('slug: two');
   });
 
   test('DELETE /triggers/:slug returns 404 when the entry is already gone', async () => {

--- a/apps/api/src/connectors/manifest-mutation.ts
+++ b/apps/api/src/connectors/manifest-mutation.ts
@@ -1,4 +1,4 @@
-import { commitManifest, loadManifestForEdit } from '../projects/index';
+import { commitManifest, loadManifestForEdit } from '../projects/lib/triggers';
 
 export type ManifestMutationResult =
   | { ok: true; commitMessage: string | null }
@@ -23,7 +23,7 @@ function isRevisionConflict(result: ManifestCommitResult): boolean {
 export async function mutateManifestWithRetry(
   project: ManifestProject,
   operation: string,
-  mutate: (manifest: EditableManifest) => ManifestMutationResult,
+  mutate: (manifest: EditableManifest) => ManifestMutationResult | Promise<ManifestMutationResult>,
 ): Promise<ManifestCommitResult> {
   for (let attempt = 0; attempt < 2; attempt += 1) {
     let manifest: EditableManifest;
@@ -37,7 +37,7 @@ export async function mutateManifestWithRetry(
       };
     }
 
-    const change = mutate(manifest);
+    const change = await mutate(manifest);
     if (!change.ok) return change;
     if (change.commitMessage === null) return { ok: true };
 

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -65,6 +65,7 @@ import {
   upsertConnectionCredential,
   upsertConnectionOAuth2Credential,
 } from '../../connectors/credentials';
+import { mutateManifestWithRetry } from '../../connectors/manifest-mutation';
 import { revokeConnectionOAuth2 } from '../../connectors/oauth2-store';
 import {
   finalizePipedreamConnectionAuthorization,
@@ -132,10 +133,8 @@ import {
   loadEmailInstallConnectionId,
 } from '../lib/session-connector-bindings';
 import {
-  commitManifest,
   draftToSpec,
   fireGitTrigger,
-  loadManifestForEdit,
   loadTriggersForResponse,
   markGitTriggerFired,
   parseTriggerDraft,
@@ -1103,28 +1102,29 @@ projectsApp.openapi(
       }
     }
 
-    let manifest: ParsedManifest;
-    try {
-      manifest = await loadManifestForEdit(loaded.row);
-    } catch (err) {
-      return c.json({ error: (err as Error).message || 'Failed to read manifest' }, 400);
-    }
-
-    if (extractTriggers(manifest).specs.some((s) => s.slug === draft.slug)) {
-      return c.json(
-        {
-          error: `A trigger with slug "${draft.slug}" already exists. Pick a different name.`,
-        },
-        409,
-      );
-    }
-
-    const next = upsertTriggerInManifest(manifest, draftToSpec(draft, manifest.path));
-    const result = await commitManifest(loaded.row, next, `chore: add trigger ${draft.slug}`);
-    if ('error' in result) {
+    let committedManifest: ParsedManifest | undefined;
+    const result = await mutateManifestWithRetry(
+      loaded.row,
+      `trigger ${draft.slug} was being created`,
+      (manifest) => {
+        if (extractTriggers(manifest).specs.some((s) => s.slug === draft.slug)) {
+          return {
+            ok: false,
+            error: `A trigger with slug "${draft.slug}" already exists. Pick a different name.`,
+            status: 409,
+          };
+        }
+        const next = upsertTriggerInManifest(manifest, draftToSpec(draft, manifest.path));
+        manifest.raw = next.raw;
+        committedManifest = manifest;
+        return { ok: true, commitMessage: `chore: add trigger ${draft.slug}` };
+      },
+    );
+    if (!result.ok) {
       return c.json({ error: result.error }, result.status as 400 | 409 | 502);
     }
-    await reconcileProjectTriggerRuntime(projectId, extractTriggers(next).specs);
+    if (!committedManifest) throw new Error('trigger create completed without a manifest');
+    await reconcileProjectTriggerRuntime(projectId, extractTriggers(committedManifest).specs);
 
     return c.json(await loadTriggersForResponse(projectId, loaded.row), 201);
   },
@@ -1225,58 +1225,64 @@ projectsApp.openapi(
       PROJECT_ACTIONS.PROJECT_TRIGGER_UPDATE,
     );
 
-    let manifest: ParsedManifest;
-    try {
-      manifest = await loadManifestForEdit(loaded.row);
-    } catch (err) {
-      return c.json({ error: (err as Error).message || 'Failed to read manifest' }, 400);
-    }
-    const current = extractTriggers(manifest).specs.find((s) => s.slug === slug);
-    if (!current) return c.json({ error: 'Not found' }, 404);
-
     // Only commit the repo manifest when a manifest field actually changed; a
     // PATCH that touches none is a no-op that skips git entirely.
     const touchesManifest = TRIGGER_MANIFEST_KEYS.some((k) => k in body);
-    if (touchesManifest) {
-      // Merge the patch onto the current spec so callers can send partial bodies
-      // (e.g. just `{ enabled: false }`). The parsed result becomes the new entry.
-      const base = specToBody(current);
-      // Setting a `session_key` is itself the opt-in to keyed sessions (see
-      // parseTriggerDraft). The merge base always carries an explicit
-      // `session_mode`, which would outvote a caller that sent ONLY a key — so
-      // drop it and let the key decide. An explicit mode in the patch still wins.
-      const patchesKey = 'session_key' in body || 'sessionKey' in body;
-      const patchesMode = 'session_mode' in body || 'sessionMode' in body;
-      if (patchesKey && !patchesMode) delete base.session_mode;
-      const draft = parseTriggerDraft({ ...base, ...body, slug: slug }, { existingSlug: slug });
-      if ('error' in draft) return c.json({ error: draft.error }, 400);
+    let committedManifest: ParsedManifest | undefined;
+    const result = await mutateManifestWithRetry(
+      loaded.row,
+      `trigger ${slug} was being updated`,
+      async (manifest) => {
+        const current = extractTriggers(manifest).specs.find((s) => s.slug === slug);
+        if (!current) return { ok: false, error: 'Not found', status: 404 };
+        if (!touchesManifest) return { ok: true, commitMessage: null };
 
-      // A `pinned` trigger may only target a session that belongs to THIS project.
-      if (draft.sessionMode === 'pinned' && draft.pinnedSessionId) {
-        const [pinned] = await db
-          .select({ sessionId: projectSessions.sessionId })
-          .from(projectSessions)
-          .where(
-            and(
-              eq(projectSessions.sessionId, draft.pinnedSessionId),
-              eq(projectSessions.projectId, projectId),
-            ),
-          )
-          .limit(1);
-        if (!pinned) {
-          return c.json(
-            { error: `Pinned session "${draft.pinnedSessionId}" was not found in this project.` },
-            400,
-          );
+        // Merge the patch onto the current spec so callers can send partial bodies
+        // (e.g. just `{ enabled: false }`). The parsed result becomes the new entry.
+        const base = specToBody(current);
+        // Setting a `session_key` is itself the opt-in to keyed sessions (see
+        // parseTriggerDraft). The merge base always carries an explicit
+        // `session_mode`, which would outvote a caller that sent ONLY a key — so
+        // drop it and let the key decide. An explicit mode in the patch still wins.
+        const patchesKey = 'session_key' in body || 'sessionKey' in body;
+        const patchesMode = 'session_mode' in body || 'sessionMode' in body;
+        if (patchesKey && !patchesMode) delete base.session_mode;
+        const draft = parseTriggerDraft({ ...base, ...body, slug: slug }, { existingSlug: slug });
+        if ('error' in draft) return { ok: false, error: draft.error, status: 400 };
+
+        // A `pinned` trigger may only target a session that belongs to THIS project.
+        if (draft.sessionMode === 'pinned' && draft.pinnedSessionId) {
+          const [pinned] = await db
+            .select({ sessionId: projectSessions.sessionId })
+            .from(projectSessions)
+            .where(
+              and(
+                eq(projectSessions.sessionId, draft.pinnedSessionId),
+                eq(projectSessions.projectId, projectId),
+              ),
+            )
+            .limit(1);
+          if (!pinned) {
+            return {
+              ok: false,
+              error: `Pinned session "${draft.pinnedSessionId}" was not found in this project.`,
+              status: 400,
+            };
+          }
         }
-      }
 
-      const next = upsertTriggerInManifest(manifest, draftToSpec(draft, manifest.path));
-      const result = await commitManifest(loaded.row, next, `chore: update trigger ${slug}`);
-      if ('error' in result) {
-        return c.json({ error: result.error }, result.status as 400 | 409 | 502);
-      }
-      await reconcileProjectTriggerRuntime(projectId, extractTriggers(next).specs);
+        const next = upsertTriggerInManifest(manifest, draftToSpec(draft, manifest.path));
+        manifest.raw = next.raw;
+        committedManifest = manifest;
+        return { ok: true, commitMessage: `chore: update trigger ${slug}` };
+      },
+    );
+    if (!result.ok) {
+      return c.json({ error: result.error }, result.status as 400 | 404 | 409 | 502);
+    }
+    if (touchesManifest) {
+      if (!committedManifest) throw new Error('trigger update completed without a manifest');
+      await reconcileProjectTriggerRuntime(projectId, extractTriggers(committedManifest).specs);
     }
 
     return c.json(await loadTriggersForResponse(projectId, loaded.row));
@@ -1317,20 +1323,20 @@ projectsApp.openapi(
       return c.json({ error: 'Invalid slug' }, 400);
     }
 
-    let manifest: ParsedManifest;
-    try {
-      manifest = await loadManifestForEdit(loaded.row);
-    } catch (err) {
-      return c.json({ error: (err as Error).message || 'Failed to read manifest' }, 400);
-    }
-    if (!extractTriggers(manifest).specs.some((s) => s.slug === slug)) {
-      return c.json({ error: 'Not found' }, 404);
-    }
-
-    const next = removeTriggerFromManifest(manifest, slug);
-    const result = await commitManifest(loaded.row, next, `chore: delete trigger ${slug}`);
-    if ('error' in result) {
-      return c.json({ error: result.error }, result.status as 400 | 409 | 502);
+    const result = await mutateManifestWithRetry(
+      loaded.row,
+      `trigger ${slug} was being deleted`,
+      (manifest) => {
+        if (!extractTriggers(manifest).specs.some((s) => s.slug === slug)) {
+          return { ok: false, error: 'Not found', status: 404 };
+        }
+        const next = removeTriggerFromManifest(manifest, slug);
+        manifest.raw = next.raw;
+        return { ok: true, commitMessage: `chore: delete trigger ${slug}` };
+      },
+    );
+    if (!result.ok) {
+      return c.json({ error: result.error }, result.status as 400 | 404 | 409 | 502);
     }
 
     // Drop runtime state too — a re-created trigger of the same slug should

--- a/tests/src/core/flow.ts
+++ b/tests/src/core/flow.ts
@@ -10,6 +10,8 @@ export interface RegisteredFlow {
   fn: FlowFn;
 }
 
+export const DEFAULT_FLOW_ATTEMPTS = 3;
+
 const registry = new Map<string, RegisteredFlow>();
 
 /**

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -8,7 +8,12 @@ import { resolve } from "node:path";
 import { Client } from "./client";
 import { withRecorder, type StepRecorder } from "./context";
 import { AssertionError } from "./expect";
-import { allFlows, clearRegistry, type RegisteredFlow } from "./flow";
+import {
+  allFlows,
+  clearRegistry,
+  DEFAULT_FLOW_ATTEMPTS,
+  type RegisteredFlow,
+} from "./flow";
 import { loadEnv, type Env } from "./env";
 import { log } from "./log";
 import { partitionParallelFlows } from "./lanes";
@@ -93,7 +98,7 @@ async function runOneFlow(
   const flowStart = performance.now();
   // Every flow gets one clean retry for errors explicitly marked as
   // infrastructure failures. Assertion failures never retry.
-  const maxAttempts = f.meta.retry?.attempts ?? 2;
+  const maxAttempts = f.meta.retry?.attempts ?? DEFAULT_FLOW_ATTEMPTS;
 
   // Capability gating → skip with reason.
   const missing = (f.meta.requires ?? []).filter((cap) => !env.capabilities[cap]);

--- a/tests/unit/release-gate-resilience.test.ts
+++ b/tests/unit/release-gate-resilience.test.ts
@@ -6,6 +6,7 @@ import {
   isKe2eTransientGatewayResponse,
   ke2eRetryDelayMs,
 } from '../src/core/client';
+import { DEFAULT_FLOW_ATTEMPTS } from '../src/core/flow';
 import { waitFor } from '../src/core/poll';
 import type { Captured } from '../src/core/result';
 
@@ -40,6 +41,10 @@ function capturedResponse(status: number, headers: Record<string, string>): Res 
 }
 
 describe('release gate transient failure resilience', () => {
+  it('allows three attempts for transient flow failures by default', () => {
+    expect(DEFAULT_FLOW_ATTEMPTS).toBe(3);
+  });
+
   beforeEach(async () => {
     vi.stubEnv('KE2E_PROVISION_CONCURRENCY', '2');
     vi.stubEnv('KE2E_PROVISION_MIN_INTERVAL_MS', '0');


### PR DESCRIPTION
## Candidate

- Source: `main`
- Source SHA: `c7023f129b7962fc1cdb882582f927bd4b44c129`
- Previous staging SHA: `e7898b7ea2f782ca1cb2e11f847b9c5b8672f6f7`

## Scope

This promotion adds the release-gate resilience fix from PR #6192. It retries transient KE2E infrastructure failures three times and retries one trigger manifest revision conflict.

## Required proof

- Build Staging passes.
- QA Staging passes.
- Deploy Staging applies migrations to the staging data plane and reports source SHA `c7023f129b7962fc1cdb882582f927bd4b44c129`.
- Staging API and gateway report the exact source SHA.