### PR TITLE
fix(release): bound and expose full gate progress

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -152,7 +152,7 @@ jobs:
         if: vars.RELEASE_FAST_TRACK != 'true'
         timeout-minutes: 10
         run: make smoke
-      # The full ke2e API flow suite (~278 live flows) runs against staging-api
+      # The full ke2e API flow suite (~375 live flows) runs against staging-api
       # (QA_API_BASE_URL) as a BLOCKING pre-prod gate, enabled via repo var
       # QA_RUN_API_SUITE=true. It catches HTTP-contract regressions the browser
       # and unit gates miss — e.g. an unmounted route returning 404 (CHN-16, which
@@ -160,7 +160,7 @@ jobs:
       # repo var to false only to temporarily skip it.
       - name: API flow suite
         if: vars.QA_RUN_API_SUITE == 'true' && vars.RELEASE_FAST_TRACK != 'true'
-        timeout-minutes: 45
+        timeout-minutes: 90
         run: make api
 
       - name: Browser regression
@@ -200,7 +200,7 @@ jobs:
           bash tests/scripts/collect-bun-junit.sh || true
           # vitest/pact/bun JUnit -> allure-results.
           npm --prefix tests run allure:junit
-          # ke2e API flows (283) -> allure-results (native exporter, same dir).
+          # ke2e API flows -> allure-results (native exporter, same dir).
           npm --prefix tests run allure || true
           cd tests
           rm -rf test-results/allure-report
@@ -209,11 +209,14 @@ jobs:
       - name: AWS auth for report publish
         id: aws-report-auth
         if: always() && env.QA_REPORTS_ROLE_ARN != '' && env.QA_REPORTS_BUCKET != '' && env.QA_REPORTS_PUBLIC_BASE_URL != ''
+        timeout-minutes: 2
         continue-on-error: true
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.QA_REPORTS_ROLE_ARN }}
           aws-region: ${{ vars.QA_AWS_REGION }}
+          action-timeout-s: 60
+          retry-max-attempts: 3
       - name: Publish release Allure report
         if: always() && steps.aws-report-auth.outcome == 'success'
         run: |

--- a/tests/bin/ke2e.ts
+++ b/tests/bin/ke2e.ts
@@ -141,12 +141,6 @@ async function main() {
   const htmlPath = resolve(outDir, "report.html");
   writeResults(result, jsonPath, htmlPath);
 
-  for (const f of result.flows) {
-    if (f.status === "pass") log.pass(`${f.id} ${log.dim((f.durationMs / 1000).toFixed(2) + "s")}`);
-    else if (f.status === "fail") log.fail(`${f.id} — ${f.reason}`);
-    else if (f.status === "skip") log.skip(`${f.id} — ${f.reason}`);
-    else log.skip(`${f.id} (todo) — ${f.reason}`);
-  }
   const s = result.summary;
   log.info("");
   log.info(`${log.bold("results")}: ${s.passed}/${s.total} passed · ${s.failed} failed · ${s.skipped} skipped · ${s.todo} todo · ${(s.durationMs / 1000).toFixed(1)}s`);

--- a/tests/src/core/progress.ts
+++ b/tests/src/core/progress.ts
@@ -1,5 +1,12 @@
 import type { FlowResult } from './result';
 
+const SENSITIVE_QUERY_VALUE =
+  /([?&](?:token|access_token|refresh_token|code|sig|signature|api_key|client_secret|password|secret|credential)=)[^&#\s]*/gi;
+
+export function redactSensitiveLogText(text: string): string {
+  return text.replace(SENSITIVE_QUERY_VALUE, '$1[REDACTED]');
+}
+
 export function formatFlowProgress(
   result: FlowResult,
   completed: number,
@@ -8,6 +15,6 @@ export function formatFlowProgress(
   const status = result.status.toUpperCase();
   const duration = `${(result.durationMs / 1000).toFixed(1)}s`;
   const attempts = result.attempts > 1 ? ` attempts=${result.attempts}` : '';
-  const reason = result.reason ? ` — ${result.reason}` : '';
+  const reason = result.reason ? ` — ${redactSensitiveLogText(result.reason)}` : '';
   return `[${completed}/${total}] ${status} ${result.id} ${duration}${attempts}${reason}`;
 }

--- a/tests/src/core/progress.ts
+++ b/tests/src/core/progress.ts
@@ -1,0 +1,13 @@
+import type { FlowResult } from './result';
+
+export function formatFlowProgress(
+  result: FlowResult,
+  completed: number,
+  total: number,
+): string {
+  const status = result.status.toUpperCase();
+  const duration = `${(result.durationMs / 1000).toFixed(1)}s`;
+  const attempts = result.attempts > 1 ? ` attempts=${result.attempts}` : '';
+  const reason = result.reason ? ` — ${result.reason}` : '';
+  return `[${completed}/${total}] ${status} ${result.id} ${duration}${attempts}${reason}`;
+}

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -16,6 +16,7 @@ import {
 } from "./flow";
 import { loadEnv, type Env } from "./env";
 import { log } from "./log";
+import { formatFlowProgress } from "./progress";
 import { partitionParallelFlows } from "./lanes";
 import { mapWithConcurrency } from "./concurrency";
 import { ke2eRetryDelayMs } from "./client";
@@ -151,6 +152,10 @@ async function runOneFlow(
       // Never retry assertion failures — only infra signals.
       const retryable = !(err instanceof AssertionError) && (err as any)?.ke2eRetryable === true;
       if (!retryable || attempt >= maxAttempts) break;
+      log.warn(
+        `retry ${f.id} after attempt ${attempt}/${maxAttempts}: ` +
+          `${(err as Error)?.message ?? String(err)}`,
+      );
       await new Promise((resolve) => setTimeout(resolve, ke2eRetryDelayMs(err)));
     }
   }
@@ -236,12 +241,34 @@ export async function runSuite(opts: RunOptions): Promise<RunResult> {
     const globalLane = flows.filter((f) => f.meta.global);
 
     const out: FlowResult[] = [];
+    let started = 0;
+    let completed = 0;
+    const runTrackedFlow = async (flow: RegisteredFlow): Promise<FlowResult> => {
+      started += 1;
+      log.step(`[${started}/${flows.length}] START ${flow.id}`);
+      try {
+        const result = await runOneFlow(flow, env, world, routesHit);
+        completed += 1;
+        const progress = formatFlowProgress(result, completed, flows.length);
+        if (result.status === "pass") log.pass(progress);
+        else if (result.status === "fail") log.fail(progress);
+        else log.skip(progress);
+        return result;
+      } catch (error) {
+        completed += 1;
+        log.fail(
+          `[${completed}/${flows.length}] ERROR ${flow.id} — ` +
+            `${(error as Error)?.message ?? String(error)}`,
+        );
+        throw error;
+      }
+    };
     if (opts.workers !== undefined) {
       const workers = positiveWorkerCount(opts.workers, 4);
       log.info(`lanes: ${parallelLane.length} parallel flows · ${workers} explicit workers`);
       out.push(
         ...(await mapWithConcurrency(parallelLane, workers, (f) =>
-          runOneFlow(f, env, world, routesHit),
+          runTrackedFlow(f),
         )),
       );
     } else {
@@ -259,15 +286,15 @@ export async function runSuite(opts: RunOptions): Promise<RunResult> {
           `${sandboxLane.length} sandbox flows × ${sandboxWorkers} workers`,
       );
       const [apiResults, sandboxResults] = await Promise.all([
-        mapWithConcurrency(apiLane, apiWorkers, (f) => runOneFlow(f, env, world, routesHit)),
+        mapWithConcurrency(apiLane, apiWorkers, runTrackedFlow),
         mapWithConcurrency(sandboxLane, sandboxWorkers, (f) =>
-          runOneFlow(f, env, world, routesHit),
+          runTrackedFlow(f),
         ),
       ]);
       out.push(...apiResults, ...sandboxResults);
     }
-    for (const f of serialLane) out.push(await runOneFlow(f, env, world, routesHit));
-    for (const f of globalLane) out.push(await runOneFlow(f, env, world, routesHit));
+    for (const f of serialLane) out.push(await runTrackedFlow(f));
+    for (const f of globalLane) out.push(await runTrackedFlow(f));
 
     out.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
     const durationMs = performance.now() - start;

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -16,7 +16,7 @@ import {
 } from "./flow";
 import { loadEnv, type Env } from "./env";
 import { log } from "./log";
-import { formatFlowProgress } from "./progress";
+import { formatFlowProgress, redactSensitiveLogText } from "./progress";
 import { partitionParallelFlows } from "./lanes";
 import { mapWithConcurrency } from "./concurrency";
 import { ke2eRetryDelayMs } from "./client";
@@ -154,7 +154,7 @@ async function runOneFlow(
       if (!retryable || attempt >= maxAttempts) break;
       log.warn(
         `retry ${f.id} after attempt ${attempt}/${maxAttempts}: ` +
-          `${(err as Error)?.message ?? String(err)}`,
+          `${redactSensitiveLogText((err as Error)?.message ?? String(err))}`,
       );
       await new Promise((resolve) => setTimeout(resolve, ke2eRetryDelayMs(err)));
     }
@@ -258,7 +258,7 @@ export async function runSuite(opts: RunOptions): Promise<RunResult> {
         completed += 1;
         log.fail(
           `[${completed}/${flows.length}] ERROR ${flow.id} — ` +
-            `${(error as Error)?.message ?? String(error)}`,
+            `${redactSensitiveLogText((error as Error)?.message ?? String(error))}`,
         );
         throw error;
       }

--- a/tests/unit/release-workflow-timeouts.test.ts
+++ b/tests/unit/release-workflow-timeouts.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/qa-release.yml'),
+  'utf8',
+);
+
+function step(name: string): string {
+  const start = workflow.indexOf(`- name: ${name}`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const next = workflow.indexOf('\n      - name:', start + 1);
+  return workflow.slice(start, next < 0 ? undefined : next);
+}
+
+describe('release workflow timeout contract', () => {
+  it('gives the complete live API suite enough time to finish', () => {
+    expect(step('API flow suite')).toContain('timeout-minutes: 90');
+  });
+
+  it('bounds AWS report authentication independently of the release gate', () => {
+    const awsAuth = step('AWS auth for report publish');
+
+    expect(awsAuth).toContain('timeout-minutes: 2');
+    expect(awsAuth).toContain('action-timeout-s: 60');
+    expect(awsAuth).toContain('retry-max-attempts: 3');
+  });
+});

--- a/tests/unit/runner-lanes.test.ts
+++ b/tests/unit/runner-lanes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { RegisteredFlow } from '../src/core/flow';
 import { partitionParallelFlows } from '../src/core/lanes';
 import { mapWithConcurrency } from '../src/core/concurrency';
+import { formatFlowProgress } from '../src/core/progress';
 
 function registeredFlow(
   id: string,
@@ -40,5 +41,24 @@ describe('ke2e parallel lanes', () => {
 
     expect(maxActive).toBe(2);
     expect(results).toEqual([30, 10, 20, 40]);
+  });
+
+  it('renders bounded per-flow completion diagnostics', () => {
+    expect(
+      formatFlowProgress(
+        {
+          id: 'SESS-1',
+          domain: 'sessions',
+          tags: [],
+          status: 'fail',
+          reason: 'flow SESS-1 exceeded 120000ms',
+          durationMs: 240_123,
+          attempts: 2,
+          steps: [],
+        },
+        17,
+        375,
+      ),
+    ).toBe('[17/375] FAIL SESS-1 240.1s attempts=2 — flow SESS-1 exceeded 120000ms');
   });
 });

--- a/tests/unit/runner-lanes.test.ts
+++ b/tests/unit/runner-lanes.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { RegisteredFlow } from '../src/core/flow';
 import { partitionParallelFlows } from '../src/core/lanes';
 import { mapWithConcurrency } from '../src/core/concurrency';
-import { formatFlowProgress } from '../src/core/progress';
+import { formatFlowProgress, redactSensitiveLogText } from '../src/core/progress';
 
 function registeredFlow(
   id: string,
@@ -60,5 +60,38 @@ describe('ke2e parallel lanes', () => {
         375,
       ),
     ).toBe('[17/375] FAIL SESS-1 240.1s attempts=2 — flow SESS-1 exceeded 120000ms');
+  });
+
+  it('redacts secret query values from progress diagnostics', () => {
+    const reason =
+      'network error GET https://preview.test/path?token=share-secret&code=oauth-secret&safe=value: timed out';
+
+    const redacted = redactSensitiveLogText(reason);
+
+    expect(redacted).not.toContain('share-secret');
+    expect(redacted).not.toContain('oauth-secret');
+    expect(redacted).toContain('token=[REDACTED]');
+    expect(redacted).toContain('code=[REDACTED]');
+    expect(redacted).toContain('safe=value');
+  });
+
+  it('redacts secret query values in formatted failure reasons', () => {
+    const output = formatFlowProgress(
+      {
+        id: 'RUN-8',
+        domain: 'sessions',
+        tags: [],
+        status: 'fail',
+        reason: 'GET https://preview.test/?access_token=runtime-secret failed',
+        durationMs: 1_000,
+        attempts: 1,
+        steps: [],
+      },
+      1,
+      1,
+    );
+
+    expect(output).not.toContain('runtime-secret');
+    expect(output).toContain('access_token=[REDACTED]');
   });
 });


### PR DESCRIPTION
## Problem

The v0.12.5 release gate timed out after 45 minutes while running 375 live flows. The runner did not emit per-flow progress. The report AWS authentication step then remained active for more than 20 minutes.

## Changes

- Give the complete API flow suite 90 minutes.
- Emit one start and one completion line per flow.
- Emit retry reasons and attempt counts.
- Cap report AWS authentication at 2 minutes, 60 seconds inside the action, and 3 attempts.
- Add workflow and progress contract tests.

## Verification

- `pnpm run test:unit`: 44/44 passed.
- `pnpm run typecheck`: passed.
- Live staging: `KE2E_API_URL=https://staging-api.kortix.com/v1 KE2E_TARGET=staging ~/.bun/bin/bun bin/ke2e.ts run --domain system`: 9/9 passed in 4.0s.
- `actionlint .github/workflows/qa-release.yml`: only the two existing SC2221/SC2222 warnings in the target guard.
- AWS action v6 manifest confirms `action-timeout-s` and `retry-max-attempts` inputs.