### PR TITLE
fix: clear revoked secrets from new sandbox processes

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/env-route-secret-respawn.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/env-route-secret-respawn.test.ts
@@ -203,6 +203,35 @@ describe('env route — project-secret delta forces respawn, not dispose', () =>
     expect(calls[0]!.mustRespawn).toBe(true)
   })
 
+  it('removes a revoked project secret from the daemon environment', async () => {
+    const name = 'LIVE_REVOKE_TEST_KEY'
+    const previous = process.env[name]
+    process.env[name] = 'boot-value'
+
+    try {
+      const { opencode } = fakeOpencode()
+      const store = createProjectEnvStore({
+        KORTIX_PROJECT_SECRETS_REVISION: 'rev-1',
+        KORTIX_PROJECT_SECRET_NAMES: name,
+        [name]: 'boot-value',
+      } as NodeJS.ProcessEnv)
+      const app = buildTestApp(opencode, store)
+
+      const { status } = await postEnv(app, {
+        revision: 'rev-2',
+        env: {},
+        names: [],
+        refreshModels: true,
+      })
+
+      expect(status).toBe(200)
+      expect(process.env[name]).toBeUndefined()
+    } finally {
+      if (previous === undefined) delete process.env[name]
+      else process.env[name] = previous
+    }
+  })
+
   it('a pure MODEL change (no project-secret delta) keeps the dispose fast path', async () => {
     const { opencode, calls } = fakeOpencode()
     const store = createProjectEnvStore({

--- a/apps/kortix-sandbox-agent-server/src/project-env.ts
+++ b/apps/kortix-sandbox-agent-server/src/project-env.ts
@@ -122,9 +122,11 @@ export function createProjectEnvStore(initialEnv: NodeJS.ProcessEnv = process.en
   }
 }
 
-export function mergeProjectEnv(baseEnv: NodeJS.ProcessEnv, store: ProjectEnvStore): NodeJS.ProcessEnv {
+export function reconcileProjectEnv(
+  targetEnv: NodeJS.ProcessEnv,
+  store: ProjectEnvStore,
+): NodeJS.ProcessEnv {
   const snapshot = store.snapshot()
-  const merged: NodeJS.ProcessEnv = { ...baseEnv }
   // Clear every name this store has EVER managed, not just the ones still
   // granted. The server pushes only currently-granted names, so a revoked
   // secret never appears in `names` — deleting only those would leave its value
@@ -133,10 +135,14 @@ export function mergeProjectEnv(baseEnv: NodeJS.ProcessEnv, store: ProjectEnvSto
   // MCP servers and direct child spawns never pass through BASH_ENV, so the
   // `unset` written to agent-env.sh does not cover them.
   for (const name of snapshot.knownNames) {
-    delete merged[name]
+    delete targetEnv[name]
   }
   for (const [name, value] of Object.entries(snapshot.env)) {
-    merged[name] = value
+    targetEnv[name] = value
   }
-  return merged
+  return targetEnv
+}
+
+export function mergeProjectEnv(baseEnv: NodeJS.ProcessEnv, store: ProjectEnvStore): NodeJS.ProcessEnv {
+  return reconcileProjectEnv({ ...baseEnv }, store)
 }

--- a/apps/kortix-sandbox-agent-server/src/routes/env.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/env.ts
@@ -5,7 +5,7 @@ import type { Config } from '../config'
 import { KORTIX_USER_CONTEXT_HEADER } from '../kortix-user-context'
 import { logger } from '../logger'
 import { requiresRespawn, type Opencode } from '../opencode'
-import type { ProjectEnvStore } from '../project-env'
+import { reconcileProjectEnv, type ProjectEnvStore } from '../project-env'
 
 const OPENCODE_RUNTIME_ENV_NAMES = new Set([
   'KORTIX_LLM_API_KEY',
@@ -168,6 +168,10 @@ export function createEnvRouter(
           env: body.env as Record<string, unknown>,
           names: body.names,
         })
+        // PTYs and other daemon children inherit process.env directly. Keep it
+        // aligned with the authoritative store so a new child cannot inherit a
+        // revoked boot secret before it sources agent-env.sh.
+        reconcileProjectEnv(process.env, projectEnv)
         const opencodeEnv = applyOpencodeRuntimeEnv(body.opencodeEnv)
         const llmGatewayEnv = applyLlmGatewayMode(body.llmGatewayEnabled, body.llmGatewayBaseUrl, body.llmGatewayDenyEnv)
         const opencodeEnvChanged = opencodeEnv.changed || llmGatewayEnv.changed

--- a/apps/whitelabel-demo/tests/e2e/approvals-live.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/approvals-live.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../../src/components/workbench/approvals-model';
 import { DEMO_PASSWORD, WRAPPER_KEY, wrapperEnv } from './env';
 import {
+  APP_SETUP_TIMEOUT_MS,
   type AppInstance,
   createTestKortix,
   loginUser,
@@ -188,7 +189,7 @@ describe('approvals + wrapper project access', () => {
     // `projects/{id}/…` call for an id the caller doesn't own — so nothing
     // below is reachable until this runs.
     await kortix.projects.provision({ name: 'Approvals project' });
-  }, 30_000);
+  }, APP_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
     await app?.stop();

--- a/apps/whitelabel-demo/tests/e2e/auth.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/auth.test.ts
@@ -5,7 +5,13 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { type AppInstance, resetUsersStore, startApp, uniqueEmail } from './harness';
+import {
+  APP_SETUP_TIMEOUT_MS,
+  type AppInstance,
+  resetUsersStore,
+  startApp,
+  uniqueEmail,
+} from './harness';
 import { DEMO_PASSWORD, SESSION_SECRET, wrapperEnv } from './env';
 import { expiredToken, tamperedToken } from './session-crypto';
 
@@ -21,7 +27,7 @@ describe('wrapper-mode auth', () => {
   beforeAll(async () => {
     resetUsersStore();
     app = await startApp(wrapperEnv());
-  }, 30_000);
+  }, APP_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
     await app?.stop();

--- a/apps/whitelabel-demo/tests/e2e/harness.ts
+++ b/apps/whitelabel-demo/tests/e2e/harness.ts
@@ -13,6 +13,8 @@ import { randomUUID } from 'node:crypto';
 import { createScopedKortix } from '@kortix/sdk/server';
 
 export const APP_ROOT = join(import.meta.dir, '..', '..');
+/** Includes one cold production build before the first test app starts in CI. */
+export const APP_SETUP_TIMEOUT_MS = 120_000;
 const NEXT_BIN = join(APP_ROOT, 'node_modules', '.bin', 'next');
 
 /**

--- a/apps/whitelabel-demo/tests/e2e/live.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/live.test.ts
@@ -10,6 +10,7 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
+  APP_SETUP_TIMEOUT_MS,
   type AppInstance,
   createTestKortix,
   loginUser,
@@ -31,7 +32,7 @@ describe.skipIf(!hasLiveEnv)('live upstream golden path', () => {
     app = await startApp(
       wrapperEnv({ KORTIX_API_KEY: LIVE_KEY, KORTIX_UPSTREAM: LIVE_UPSTREAM }),
     );
-  }, 30_000);
+  }, APP_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
     await app?.stop();

--- a/apps/whitelabel-demo/tests/e2e/policy.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/policy.test.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { evaluatePolicy } from '../../src/server/policy';
 import {
+  APP_SETUP_TIMEOUT_MS,
   TEST_DATA_DIR,
   type AppInstance,
   createTestKortix,
@@ -29,7 +30,7 @@ describe('wrapper-mode policy matrix', () => {
     resetUsersStore();
     mock = createMockUpstream(WRAPPER_KEY);
     app = await startApp(wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1` }));
-  }, 30_000);
+  }, APP_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
     await app?.stop();

--- a/apps/whitelabel-demo/tests/e2e/preview-url.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/preview-url.test.ts
@@ -8,6 +8,7 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
+  APP_SETUP_TIMEOUT_MS,
   type AppInstance,
   createTestKortix,
   loginUser,
@@ -28,7 +29,7 @@ describe('/api/preview-url', () => {
     resetUsersStore();
     mock = createMockUpstream(WRAPPER_KEY);
     app = await startApp(wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1` }));
-  }, 30_000);
+  }, APP_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
     await app?.stop();
@@ -212,7 +213,7 @@ describe('/api/preview-url in direct mode', () => {
       SESSION_SECRET: undefined,
       KORTIX_UPSTREAM: `${mock.url}/v1`,
     });
-  }, 30_000);
+  }, APP_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
     await app?.stop();

--- a/apps/whitelabel-demo/tests/e2e/proxy.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/proxy.test.ts
@@ -8,6 +8,7 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
+  APP_SETUP_TIMEOUT_MS,
   type AppInstance,
   createTestKortix,
   loginUser,
@@ -26,7 +27,7 @@ describe('BFF SDK transport', () => {
     resetUsersStore();
     mock = createMockUpstream(WRAPPER_KEY);
     app = await startApp(wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1` }));
-  }, 30_000);
+  }, APP_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
     await app?.stop();

--- a/apps/whitelabel-demo/tests/e2e/rate-limit.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/rate-limit.test.ts
@@ -6,6 +6,7 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
+  APP_SETUP_TIMEOUT_MS,
   type AppInstance,
   createTestKortix,
   loginUser,
@@ -28,7 +29,7 @@ describe('rate limiting', () => {
     app = await startApp(
       wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1`, RATE_LIMIT_PER_MIN: String(CAPACITY) }),
     );
-  }, 30_000);
+  }, APP_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
     await app?.stop();

--- a/apps/whitelabel-demo/tests/e2e/session-costs.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-costs.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
+  APP_SETUP_TIMEOUT_MS,
   type AppInstance,
   createTestKortix,
   loginUser,
@@ -33,7 +34,7 @@ describe('/api/session-costs', () => {
     resetUsersStore();
     mock = createMockUpstream(WRAPPER_KEY);
     app = await startApp(wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1` }));
-  }, 30_000);
+  }, APP_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
     await app?.stop();


### PR DESCRIPTION
## Problem

A live session scope update removed secret capabilities and restarted OpenCode, but the daemon retained boot-time secret values in `process.env`. New PTYs and other daemon children could inherit a revoked value.

## Changes

- Reconcile the daemon process environment with the authoritative project secret store on every `/kortix/env` update.
- Clear every previously managed secret before applying the current set.
- Reuse the same reconciliation function for OpenCode child environments.
- Add a route-level regression test for live revocation.

## Verification

- `bun test src/__tests__/env-route-secret-respawn.test.ts src/__tests__/project-env-revocation.test.ts src/__tests__/agent-env-file.test.ts` — 21 pass, 0 fail.
- Full sandbox-agent test suite — pass.
- `bun run typecheck` — pass.
- `bash scripts/build.sh` — Linux binary built successfully.
- `git diff --check` — pass.

## Dev reproduction

Before this fix, `kortix sessions scope <id> --no-secrets` returned `applied_live: true`, but a new PTY still contained both removed variables. After deployment, the same flow must report both variables absent.