### PR TITLE
fix(ci): clear v0.12.5 security findings

### DIFF
--- a/apps/api/src/__tests__/integration-connector-credential-mode-migration.test.ts
+++ b/apps/api/src/__tests__/integration-connector-credential-mode-migration.test.ts
@@ -16,7 +16,7 @@
 import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
 import { sql, eq, inArray } from 'drizzle-orm';
 import { db } from '../shared/db';
-import { projects, connectors, connectionCredentials } from '@kortix/db';
+import { connectors, connectionCredentials } from '@kortix/db';
 
 const CONN_SHARED_ALREADY = 'bbbbbbbb-1111-4000-8000-000000000001';
 const CONN_PER_USER_WITH_SHARED = 'bbbbbbbb-1111-4000-8000-000000000002';

--- a/apps/api/src/billing/services/account-state.test.ts
+++ b/apps/api/src/billing/services/account-state.test.ts
@@ -279,4 +279,4 @@ describe('effectiveTierForLimits', () => {
   test('a null tier defaults to free rather than throwing', () => {
     expect(effectiveTierForLimits(null, null)).toBe('free');
   });
-})
+});

--- a/apps/kortix-sandbox-agent-server/src/__tests__/connector-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/connector-mcp-config.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { buildConnectorMcpConfigContent, buildOpencodeConfigContent } from '../opencode'
+import { buildOpencodeConfigContent } from '../opencode'
 
 const ENV = { KORTIX_CLI_TOKEN: 'tok-123', KORTIX_API_URL: 'https://api.kortix.test/v1' }
 

--- a/apps/mobile/components/agents/AgentDrawer.tsx
+++ b/apps/mobile/components/agents/AgentDrawer.tsx
@@ -44,10 +44,7 @@ import { EntityList } from '@/components/shared/EntityList';
 import { useSearch } from '@/lib/utils/search';
 import { useAvailableModels } from '@/lib/models';
 import type { Agent, Model } from '@/api/types';
-import {
-  AppBubble,
-  ConnectionsPageContent,
-} from '@/components/settings/ConnectionsPage';
+import { ConnectionsPageContent } from '@/components/settings/ConnectionsPage';
 import { ComposioAppsContent } from '@/components/settings/connections/ComposioAppsList';
 import { ComposioAppDetailContent } from '@/components/settings/connections/ComposioAppDetail';
 import { ComposioConnectorContent } from '@/components/settings/connections/ComposioConnector';

--- a/apps/mobile/components/settings/ConnectionsPage.tsx
+++ b/apps/mobile/components/settings/ConnectionsPage.tsx
@@ -43,7 +43,6 @@ import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-na
 import { SettingsHeader } from './SettingsHeader';
 import { AppIcon } from './connections/AppIcon';
 import { ManageConnectionSheet } from './connections/ManageConnectionSheet';
-import { CustomMcpDialog } from './connections/CustomMcpDialog';
 import { AnimatedPageWrapper } from '@/components/shared/AnimatedPageWrapper';
 import { useLanguage } from '@/contexts';
 import { useRouter } from 'expo-router';


### PR DESCRIPTION
## Summary

- remove four unused imports reported by CodeQL
- add the missing test-file semicolon reported by CodeQL
- clear the five unresolved findings blocking release PR #6188

## Verification

- `bun test src/billing/services/account-state.test.ts`: 13 passed, 0 failed
- `bun test src/__tests__/connector-mcp-config.test.ts`: 36 passed, 0 failed
- `pnpm --filter kortix-api typecheck`: passed
- `pnpm --filter @kortix/sandbox-agent-server typecheck`: passed
- `git diff --check`: passed

## Release

This PR unblocks the v0.12.5 release candidate. After merge, promote `main` to `staging` and refresh release PR #6188.
