### PR TITLE
fix: keep agent config freshness safe and unobtrusive

### DIFF
--- a/apps/api/src/projects/lib/warm-session-refresh.test.ts
+++ b/apps/api/src/projects/lib/warm-session-refresh.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test';
+import { prepareReusedWarmSession } from './warm-session-refresh';
+
+const project = {
+  projectId: 'project-1',
+  repoUrl: 'https://git.example.test/project-1.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+};
+
+const workspace = {
+  status: 'updated' as const,
+  before_sha: 'before',
+  after_sha: 'after',
+};
+
+describe('prepareReusedWarmSession', () => {
+  test('updates the compiled config after refreshing a reused workspace', async () => {
+    const calls: string[] = [];
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => {
+          calls.push('workspace');
+          return workspace;
+        },
+        readRunningConfig: async () => {
+          calls.push('running');
+          return { etag: 'old', reachable: true };
+        },
+        readLatestConfig: async () => {
+          calls.push('latest');
+          return 'new';
+        },
+        pushConfig: async () => {
+          calls.push('push');
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(calls[0]).toBe('workspace');
+    expect(new Set(calls.slice(1, 3))).toEqual(new Set(['running', 'latest']));
+    expect(calls[3]).toBe('push');
+    expect(result).toEqual({
+      workspace,
+      config: { status: 'updated', previous_etag: 'old', latest_etag: 'new' },
+    });
+  });
+
+  test('does not restart a warm runtime that already has the current config', async () => {
+    let pushed = false;
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => ({ status: 'unchanged' }),
+        readRunningConfig: async () => ({ etag: 'same', reachable: true }),
+        readLatestConfig: async () => 'same',
+        pushConfig: async () => {
+          pushed = true;
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(pushed).toBe(false);
+    expect(result.config).toEqual({
+      status: 'current',
+      previous_etag: 'same',
+      latest_etag: 'same',
+    });
+  });
+
+  test('updates a legacy warm runtime that cannot report its running etag', async () => {
+    let pushed = false;
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => ({ status: 'unchanged' }),
+        readRunningConfig: async () => ({ etag: null, reachable: true }),
+        readLatestConfig: async () => 'latest',
+        pushConfig: async () => {
+          pushed = true;
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(pushed).toBe(true);
+    expect(result.config.status).toBe('updated');
+  });
+
+  test('does not report a problem while a warm runtime is still provisioning', async () => {
+    let pushed = false;
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => ({ status: 'skipped' }),
+        readRunningConfig: async () => ({ etag: null, reachable: false }),
+        readLatestConfig: async () => 'latest',
+        pushConfig: async () => {
+          pushed = true;
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(pushed).toBe(false);
+    expect(result.config).toEqual({ status: 'unavailable' });
+  });
+
+  test('does not push anything when the project has no compiled config', async () => {
+    let pushed = false;
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => ({ status: 'unchanged' }),
+        readRunningConfig: async () => ({ etag: null, reachable: true }),
+        readLatestConfig: async () => null,
+        pushConfig: async () => {
+          pushed = true;
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(pushed).toBe(false);
+    expect(result.config).toEqual({ status: 'not-applicable' });
+  });
+
+  test('reports a failed config push without hiding the workspace result', async () => {
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => workspace,
+        readRunningConfig: async () => ({ etag: 'old', reachable: true }),
+        readLatestConfig: async () => 'new',
+        pushConfig: async () => ({
+          applied: false,
+          reason: 'runtime unavailable',
+        }),
+      },
+    );
+
+    expect(result).toEqual({
+      workspace,
+      config: { status: 'failed', reason: 'runtime unavailable' },
+    });
+  });
+});

--- a/apps/api/src/projects/lib/warm-session-refresh.ts
+++ b/apps/api/src/projects/lib/warm-session-refresh.ts
@@ -1,0 +1,120 @@
+import type { GitBackedProject } from '../git';
+import {
+  latestAgentConfigEtag,
+  readSandboxConfigState,
+} from './session-reload';
+import { pushSessionAgentConfigToSandbox } from './sandbox-env-sync';
+import {
+  refreshWarmSessionWorkspace,
+  type WarmSessionWorkspaceRefresh,
+} from './warm-session-workspace';
+
+export type WarmSessionConfigRefresh =
+  | { status: 'current'; previous_etag: string; latest_etag: string }
+  | { status: 'updated'; previous_etag: string | null; latest_etag: string }
+  | { status: 'unavailable' | 'not-applicable' }
+  | { status: 'failed'; reason: string };
+
+interface WarmSessionRefreshDependencies {
+  refreshWorkspace: (
+    project: GitBackedProject,
+    sessionId: string,
+  ) => Promise<WarmSessionWorkspaceRefresh>;
+  readRunningConfig: (sessionId: string) => Promise<{
+    etag: string | null;
+    reachable: boolean;
+  }>;
+  readLatestConfig: (input: {
+    projectId: string;
+    accountId: string;
+    baseRef: string;
+  }) => Promise<string | null>;
+  pushConfig: (input: {
+    projectId: string;
+    sessionId: string;
+    repoUrl: string;
+    defaultBranch: string;
+    manifestPath?: string | null;
+    baseRef: string;
+  }) => Promise<{ applied: boolean; reason?: string }>;
+}
+
+const defaultDependencies: WarmSessionRefreshDependencies = {
+  refreshWorkspace: refreshWarmSessionWorkspace,
+  readRunningConfig: async (sessionId) => readSandboxConfigState({ sessionId }),
+  readLatestConfig: latestAgentConfigEtag,
+  pushConfig: pushSessionAgentConfigToSandbox,
+};
+
+/**
+ * Prepare an unused warm session for display and claim.
+ *
+ * A warm session can sit ready while the project's agent config changes. The
+ * workspace refresh already moves its pristine checkout to the latest base.
+ * The compiled config lives in the runtime environment, so it needs a separate
+ * push. The session is still unclaimed here, which makes this the only safe
+ * time to restart its runtime without interrupting user work.
+ */
+export async function prepareReusedWarmSession(
+  input: {
+    project: GitBackedProject;
+    accountId: string;
+    sessionId: string;
+  },
+  dependencies: WarmSessionRefreshDependencies = defaultDependencies,
+): Promise<{
+  workspace: WarmSessionWorkspaceRefresh;
+  config: WarmSessionConfigRefresh;
+}> {
+  const workspace = await dependencies.refreshWorkspace(
+    input.project,
+    input.sessionId,
+  );
+  const [running, latest] = await Promise.all([
+    dependencies.readRunningConfig(input.sessionId),
+    dependencies.readLatestConfig({
+      projectId: input.project.projectId,
+      accountId: input.accountId,
+      baseRef: input.project.defaultBranch,
+    }),
+  ]);
+
+  if (!running.reachable) return { workspace, config: { status: 'unavailable' } };
+  if (!latest) return { workspace, config: { status: 'not-applicable' } };
+  if (running.etag === latest) {
+    return {
+      workspace,
+      config: {
+        status: 'current',
+        previous_etag: running.etag,
+        latest_etag: latest,
+      },
+    };
+  }
+
+  const pushed = await dependencies.pushConfig({
+    projectId: input.project.projectId,
+    sessionId: input.sessionId,
+    repoUrl: input.project.repoUrl,
+    defaultBranch: input.project.defaultBranch,
+    manifestPath: input.project.manifestPath,
+    baseRef: input.project.defaultBranch,
+  });
+  if (!pushed.applied) {
+    return {
+      workspace,
+      config: {
+        status: 'failed',
+        reason: pushed.reason ?? 'config push did not apply',
+      },
+    };
+  }
+  return {
+    workspace,
+    config: {
+      status: 'updated',
+      previous_etag: running.etag,
+      latest_etag: latest,
+    },
+  };
+}

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -60,7 +60,7 @@ import {
   findAvailableWarmProjectSession,
   withWarmProjectSessionLock,
 } from '../lib/warm-session-store';
-import { refreshWarmSessionWorkspace } from '../lib/warm-session-workspace';
+import { prepareReusedWarmSession } from '../lib/warm-session-refresh';
 import {
   createWarmProjectSessionCoordinator,
   WarmProjectSessionError,
@@ -353,12 +353,23 @@ projectsApp.openapi(
           return sendSessionCreateError(c, requiredConnectionError(missing));
         }
       }
-      const workspaceRefresh = ensured.reused
-        ? await refreshWarmSessionWorkspace(
-            loaded.row,
-            ensured.session.sessionId,
-          )
-        : { status: 'skipped' as const };
+      const warmRefresh = ensured.reused
+        ? await prepareReusedWarmSession({
+            project: loaded.row,
+            accountId: loaded.row.accountId,
+            sessionId: ensured.session.sessionId,
+          })
+        : {
+            workspace: { status: 'skipped' as const },
+            config: { status: 'current' as const },
+          };
+      if (warmRefresh.config.status === 'failed') {
+        console.warn('[warm-session] failed to update compiled agent config', {
+          projectId,
+          sessionId: ensured.session.sessionId,
+          reason: warmRefresh.config.reason,
+        });
+      }
       return c.json(
         {
           session: serializeSession(ensured.session, {
@@ -366,7 +377,7 @@ projectsApp.openapi(
             canManageProject: roleAllows(loaded.effectiveRole, 'manage'),
           }),
           reused: ensured.reused,
-          workspace_refresh: workspaceRefresh,
+          workspace_refresh: warmRefresh.workspace,
         },
         200,
       );

--- a/apps/web/src/features/session/header/session-config-indicator.test.tsx
+++ b/apps/web/src/features/session/header/session-config-indicator.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const source = readFileSync(
+  fileURLToPath(new URL('./session-config-indicator.tsx', import.meta.url)),
+  'utf8',
+);
+
+describe('SessionConfigIndicator notification level', () => {
+  test('keeps stale config in the header instead of opening a persistent toast', () => {
+    expect(source).toContain('<Popover');
+    expect(source).not.toContain("warningToast('Agent config is out of date'");
+    expect(source).not.toContain('duration: Number.POSITIVE_INFINITY');
+  });
+});

--- a/apps/web/src/features/session/header/session-config-indicator.tsx
+++ b/apps/web/src/features/session/header/session-config-indicator.tsx
@@ -26,10 +26,8 @@ import {
   type ReloadBusyReason,
   useSessionConfigFreshness,
 } from '@/hooks/projects/use-session-config-freshness';
-import { dismissToast, warningToast } from '@/components/ui/toast';
-import { cn } from '@/lib/utils';
 import { ArrowsClockwiseIcon } from '@phosphor-icons/react';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 /** The server's two refusals, as something a person would actually read. */
 const BUSY_COPY: Record<ReloadBusyReason, { title: string; body: string; tail: string }> = {
@@ -62,58 +60,12 @@ export function SessionConfigIndicator({
   const { notice } = useSessionConfigFreshness(projectId, sessionId);
   const [open, setOpen] = useState(false);
 
-  const stale = notice.kind === 'stale';
-
-  // A toast as well as the chip, because the chip alone was not found.
-  //
-  // The chip is correct and stays — it is the durable, always-available
-  // affordance, and it is where you look once you know the concept exists. But
-  // it is an icon in a header, and a session that silently runs the wrong agent
-  // is exactly the case where the user does NOT already know to look. So the
-  // arrival of staleness also gets announced once, where new information
-  // belongs.
-  //
-  // Announced ONCE per distinct config version, not once per render and not
-  // again after dismissal: `shownFor` keys on the etag pair, so re-checks of the
-  // same staleness stay quiet and only a genuinely newer config speaks up again.
-  // Persistent (`Infinity`) because it reports a condition, not an event — it
-  // stays true until acted on — and `warningToast` already carries its own close
-  // button, so it is dismissible without being self-dismissing.
-  const toastId = `session-config-stale-${sessionId}`;
-  const shownFor = useRef<string | null>(null);
-  useEffect(() => {
-    if (notice.kind !== 'stale') {
-      // Retract on the way out. After a successful reload the condition is gone,
-      // and a lingering card offering to fix it would be worse than no card.
-      if (shownFor.current !== null) {
-        shownFor.current = null;
-        dismissToast(toastId);
-      }
-      return;
-    }
-    const version = `${notice.running}->${notice.latest}`;
-    if (shownFor.current === version) return;
-    shownFor.current = version;
-    warningToast('Agent config is out of date', {
-      id: toastId,
-      description:
-        'This session is running an older version of the agent config. Your commits and other files are untouched.',
-      duration: Number.POSITIVE_INFINITY,
-      button: (
-        <Button size="sm" disabled={!canReload || isPending} onClick={() => reload()}>
-          {isPending ? <Loading className="size-4 shrink-0" /> : null}
-          Reload config
-        </Button>
-      ),
-    });
-  }, [notice, toastId, reload, canReload, isPending]);
-
   // The confirm is rendered by the header, not here — see `SessionConfigReloadConfirm`.
   // This component may vanish the moment a reload lands, and a dialog that
   // unmounts mid-question is worse than no dialog.
   if (notice.kind === 'hidden') return null;
 
-  const label = stale ? 'Agent config is out of date' : "Can't confirm the agent config";
+  const label = 'Agent config update available';
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -123,12 +75,7 @@ export function SessionConfigIndicator({
             <span className="relative inline-flex">
               <ArrowsClockwiseIcon className="text-foreground size-4" />
               <span
-                className={cn(
-                  'ring-background absolute -top-1 -right-1 size-2 rounded-full ring-2',
-                  // Orange is "needs attention"; a session we merely could not
-                  // ask about has not done anything wrong, so it stays neutral.
-                  stale ? 'bg-kortix-orange' : 'bg-muted-foreground',
-                )}
+                className="ring-background bg-kortix-orange absolute -top-1 -right-1 size-2 rounded-full ring-2"
                 aria-hidden
               />
             </span>
@@ -139,18 +86,7 @@ export function SessionConfigIndicator({
       <PopoverContent align="end" sideOffset={8} className="w-[320px] overflow-hidden p-0">
         <div className="border-border border-b px-4 pt-4 pb-3">
           <div className="flex items-center gap-2.5">
-            <span
-              className={cn(
-                'flex size-8 shrink-0 items-center justify-center rounded-md',
-                // Spelled literally rather than via STATUS_BG/STATUS_TEXT:
-                // those pair a kortix-yellow fill with a raw amber foreground,
-                // which is both off-token and a different colour from every
-                // other "needs attention" surface in the app.
-                stale
-                  ? 'bg-kortix-orange/10 text-kortix-orange'
-                  : 'text-muted-foreground border-border border',
-              )}
-            >
+            <span className="bg-kortix-orange/10 text-kortix-orange flex size-8 shrink-0 items-center justify-center rounded-md">
               <ArrowsClockwiseIcon className="size-4" />
             </span>
             <div className="min-w-0">
@@ -161,24 +97,15 @@ export function SessionConfigIndicator({
           </div>
 
           <p className="text-muted-foreground mt-2.5 text-xs leading-relaxed">
-            {stale
-              ? // Only ONE unconditional promise is made here — that nothing of
-                // yours is lost — because that one is structural: the reload
-                // never moves the branch. Bringing the agent files forward is
-                // deliberately worded as an attempt, since the reload refuses
-                // when this session has edited them itself. The toast afterwards
-                // reports which of the two happened.
-                'This session started with an older version of the agent config. Reloading tries to bring its agent files up to date, and keeps any changes this session made to them. Your commits and other files are untouched.'
-              : "This session's runtime didn't report which agent config it's running, so we can't tell whether it's current. Reloading puts it on the latest."}
+            A newer agent config is available. Reloading restarts the agent runtime and leaves every
+            project file and commit unchanged.
           </p>
 
-          {notice.kind === 'stale' && (
-            <p className="text-muted-foreground mt-2.5 font-mono text-[11px]">
-              <span className="text-foreground/80">{notice.running}</span>
-              {' → '}
-              <span className="text-foreground/80">{notice.latest}</span>
-            </p>
-          )}
+          <p className="text-muted-foreground mt-2.5 font-mono text-[11px]">
+            <span className="text-foreground/80">{notice.running}</span>
+            {' → '}
+            <span className="text-foreground/80">{notice.latest}</span>
+          </p>
         </div>
 
         {canReload ? (

--- a/apps/web/src/hooks/projects/use-session-config-freshness.test.ts
+++ b/apps/web/src/hooks/projects/use-session-config-freshness.test.ts
@@ -1,7 +1,7 @@
+import type { SessionConfigState } from '@kortix/sdk';
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import type { SessionConfigState } from '@kortix/sdk';
 
 import {
   CONFIG_FRESHNESS_STALE_TIME_MS,
@@ -56,14 +56,12 @@ describe('sessionConfigNotice', () => {
     ).toEqual({ kind: 'hidden' });
   });
 
-  test('a live box that reports no etag is UNVERIFIED, not fresh and not stale', () => {
-    // A sandbox provisioned before the etag shipped. We genuinely cannot tell,
-    // and a reload is exactly the fix — so this is the one null worth showing.
+  test('a live box that reports no etag stays quiet instead of presenting an unverifiable error', () => {
     expect(
       sessionConfigNotice(
         state({ stale: null, running_etag: null, latest_etag: 'new1new1new1new1' }),
       ),
-    ).toEqual({ kind: 'unverified' });
+    ).toEqual({ kind: 'hidden' });
   });
 
   test('NO input ever yields a positive "up to date" state', () => {
@@ -85,15 +83,15 @@ describe('sessionConfigNotice', () => {
             );
 
     const kinds = new Set(combos.map((c) => sessionConfigNotice(c).kind));
-    expect([...kinds].sort()).toEqual(['hidden', 'stale', 'unverified']);
+    expect([...kinds].sort()).toEqual(['hidden', 'stale']);
   });
 
   test('stale wins over every explanatory branch', () => {
     // If the server said stale, that is the answer even when the box then went
     // unreachable between the two reads inside the same response.
-    expect(
-      sessionConfigNotice(state({ stale: true, sandbox_reachable: false })).kind,
-    ).toBe('stale');
+    expect(sessionConfigNotice(state({ stale: true, sandbox_reachable: false })).kind).toBe(
+      'stale',
+    );
   });
 });
 
@@ -141,12 +139,14 @@ describe('reloadNotAppliedCopy', () => {
  * Source-asserted: exercising them needs a QueryClientProvider + a real network
  * seam, and this hook's own value is the pure logic above.
  */
-const HOOK_SOURCE = readFileSync(
-  join(import.meta.dir, 'use-session-config-freshness.ts'),
-  'utf8',
-);
+const HOOK_SOURCE = readFileSync(join(import.meta.dir, 'use-session-config-freshness.ts'), 'utf8');
 
 describe('useReloadSessionConfig — the costly mistakes', () => {
+  test('the web reload is config-only and cannot refresh workspace files', () => {
+    const body = HOOK_SOURCE.split('const mutation = useMutation({')[1]?.split('\n  });')[0];
+    expect(body).toContain('refresh_repo: false');
+  });
+
   test('the reload mutation never retries', () => {
     // The app-wide default retries any non-4xx once. The API answers 503 at its
     // own 25s deadline WHILE the reload keeps running server-side, so the

--- a/apps/web/src/hooks/projects/use-session-config-freshness.ts
+++ b/apps/web/src/hooks/projects/use-session-config-freshness.ts
@@ -53,14 +53,12 @@ export function sessionConfigKey(projectId?: string, sessionId?: string) {
  * What, if anything, the UI should say.
  *
  * Deliberately NOT a boolean and deliberately without an `ok` member: the only
- * two things worth rendering are "you are behind" and "we could not check".
- * Everything else — current, still loading, nothing to compare, box asleep —
+ * thing worth rendering is "you are behind". Everything else — current,
+ * still loading, an inconclusive check, nothing to compare, box asleep —
  * collapses to `hidden`, because a session that is fine should cost zero chrome.
  */
 export type SessionConfigNotice =
-  | { kind: 'hidden' }
-  | { kind: 'stale'; running: string; latest: string }
-  | { kind: 'unverified' };
+  { kind: 'hidden' } | { kind: 'stale'; running: string; latest: string };
 
 /**
  * Pure, so the branch order is testable without a DOM or a network.
@@ -81,20 +79,10 @@ export function sessionConfigNotice(state: SessionConfigState | undefined): Sess
       latest: state.latest_etag ?? '—',
     };
   }
-  if (state.stale === false) return { kind: 'hidden' };
-  // From here down `stale` is null and we are deciding whether the user can do
-  // anything about it.
-  //
-  // A sleeping sandbox is not a problem to report: nothing is running the wrong
-  // config because nothing is running. It wakes with the latest.
-  if (!state.sandbox_reachable) return { kind: 'hidden' };
-  // Nothing compiles — a v1 `kortix.toml` project. The concept does not apply,
-  // so saying anything would invent a problem.
-  if (state.latest_etag === null) return { kind: 'hidden' };
-  // The box is up and the config compiles, but the box did not say what it is
-  // running: a sandbox provisioned before this shipped. Worth surfacing, since
-  // a reload is exactly the fix.
-  return { kind: 'unverified' };
+  // `false` is current. `null` is inconclusive: the sandbox is sleeping, the
+  // project has no compiled config, or an older runtime cannot report an etag.
+  // None is an error, and none warrants persistent UI.
+  return { kind: 'hidden' };
 }
 
 /**
@@ -181,9 +169,13 @@ export function useReloadSessionConfig(projectId: string, sessionId: string) {
     // accident.
     retry: false,
     mutationFn: (vars: { force?: boolean } = {}) =>
-      // `refresh_repo` is left to the server default (true). "Reload" means
-      // "catch this session up", and that includes the workspace.
-      reloadProjectSessionConfig(projectId, sessionId, vars.force ? { force: true } : {}),
+      // This web action is named "Reload config", so it only reloads config.
+      // Repository refresh remains an explicit CLI operation. This prevents a
+      // low-priority UI action from changing the project checkout.
+      reloadProjectSessionConfig(projectId, sessionId, {
+        refresh_repo: false,
+        ...(vars.force ? { force: true } : {}),
+      }),
     onSuccess: (result: SessionReloadResult) => {
       // It landed — whatever refusal opened the dialog is answered.
       setBusyReason(null);


### PR DESCRIPTION
## Problem

A newly opened UI session can reuse a prewarmed sandbox whose compiled agent config predates the project config. The session then reports itself as stale immediately.

The web client also showed this low-priority state as a persistent warning toast. Its Reload config action used the API default `refresh_repo: true`, which could change the session checkout despite the button only naming config.

## Changes

- Refresh a reused warm session workspace and compiled agent config before the session is presented for claim.
- Skip the runtime restart when the warm session already has the current config.
- Hide inconclusive and current freshness states.
- Replace the persistent toast with a small header indicator that appears only for confirmed stale state.
- Make the web Reload config action send `refresh_repo: false`.
- Keep the existing busy-turn refusal and explicit destructive confirmation.
- Explain that a manual config reload restarts the agent runtime but does not change project files or commits.

## Verification

- API unit suite: `5630 pass`, `62 skip`, `0 fail`.
- Web unit suite: `4765 pass`, `0 fail`.
- Focused API tests after rebase: `38 pass`, `0 fail`.
- Focused web tests after rebase: `38 pass`, `0 fail`.
- API `tsc --noEmit`: passed.
- Changed frontend files: ESLint passed; filtered TypeScript output is empty.
- Real local API and cloud-sandbox flow:
  - created a warm session and confirmed `stale: false`;
  - committed an agent config change and confirmed `stale: true`;
  - reused the same warm session;
  - confirmed workspace refresh status `updated`;
  - confirmed the running etag changed to the latest etag;
  - confirmed final `stale: false`;
  - removed the temporary session, project, and user.

## Risk controls

- The warm-session refresh runs only for an unclaimed reusable session.
- A provisioning or unreachable warm runtime does not fail session creation.
- A manual reload never retries automatically.
- A manual reload refuses an active or unverified turn unless the user explicitly confirms force.