### PR TITLE
Release candidate: promote latest main to staging

### DIFF
--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -1,0 +1,138 @@
+name: Configure Kortix Apps Edge
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: configure-kortix-apps-edge
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  configure:
+    name: Configure and verify Apps edge
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
+      APPS_DNS_NAME: '*.apps.kortix.com'
+      APPS_DNS_TARGET: '192.0.2.1'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate Cloudflare configuration
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ZONE_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::${name} is not configured."
+              exit 1
+            fi
+          done
+
+      - name: Verify Worker route and secret bindings
+        working-directory: infra/cloudflare/workers/apps-router
+        run: |
+          set -euo pipefail
+          routes="$({
+            curl --fail-with-body --silent --show-error \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/workers/routes"
+          })"
+          jq -e '
+            .success == true and
+            any(.result[]; .pattern == "*.apps.kortix.com/*" and .script == "kortix-apps-router")
+          ' <<<"$routes"
+
+          secrets="$(npx --yes wrangler@4.34.0 secret list --json)"
+          jq -e '
+            map(.name) | sort ==
+            ["DEV_EDGE_SECRET", "PREVIEW_EDGE_SECRET", "PROD_EDGE_SECRET", "STAGING_EDGE_SECRET"]
+          ' <<<"$secrets"
+
+      - name: Create or verify proxied wildcard DNS
+        run: |
+          set -euo pipefail
+          api="https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/dns_records"
+          records="$({
+            curl --fail-with-body --silent --show-error --get \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              --data-urlencode "name=$APPS_DNS_NAME" \
+              "$api"
+          })"
+          jq -e '.success == true' <<<"$records"
+          count="$(jq '.result | length' <<<"$records")"
+
+          if [ "$count" = 0 ]; then
+            body="$(jq -n \
+              --arg name "$APPS_DNS_NAME" \
+              --arg content "$APPS_DNS_TARGET" \
+              '{type:"A", name:$name, content:$content, ttl:1, proxied:true, comment:"Kortix Apps Worker ingress"}')"
+            created="$({
+              curl --fail-with-body --silent --show-error \
+                --request POST \
+                --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+                --header 'Content-Type: application/json' \
+                --data "$body" \
+                "$api"
+            })"
+            jq -e '
+              .success == true and
+              .result.type == "A" and
+              .result.name == "*.apps.kortix.com" and
+              .result.content == "192.0.2.1" and
+              .result.proxied == true
+            ' <<<"$created"
+            exit 0
+          fi
+
+          if [ "$count" != 1 ]; then
+            echo "::error::Expected at most one $APPS_DNS_NAME record; found $count."
+            exit 1
+          fi
+          jq -e \
+            --arg name "$APPS_DNS_NAME" \
+            --arg content "$APPS_DNS_TARGET" '
+              .result[0].type == "A" and
+              .result[0].name == $name and
+              .result[0].content == $content and
+              .result[0].proxied == true
+            ' <<<"$records"
+
+      - name: Verify public DNS and TLS routing
+        run: |
+          set -euo pipefail
+          host="dev-edge-probe-invalid.apps.kortix.com"
+          for attempt in $(seq 1 30); do
+            answer="$({
+              curl --silent --show-error --get \
+                --header 'accept: application/dns-json' \
+                --data-urlencode "name=$host" \
+                --data-urlencode 'type=A' \
+                'https://cloudflare-dns.com/dns-query'
+            })"
+            if jq -e 'any(.Answer[]?; .type == 1)' <<<"$answer" >/dev/null; then
+              break
+            fi
+            if [ "$attempt" = 30 ]; then
+              echo "::error::$host did not resolve after 5 minutes."
+              exit 1
+            fi
+            sleep 10
+          done
+
+          headers="$(mktemp)"
+          body="$(mktemp)"
+          status="$({
+            curl --silent --show-error \
+              --dump-header "$headers" \
+              --output "$body" \
+              --write-out '%{http_code}' \
+              "https://$host/"
+          })"
+          test "$status" = 404
+          grep -Eiq '^x-kortix-app-environment: dev\r?$' "$headers"
+          jq -e '.error == "App not found"' "$body"

--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -47,7 +47,7 @@ jobs:
             any(.result[]; .pattern == "*.apps.kortix.com/*" and .script == "kortix-apps-router")
           ' <<<"$routes"
 
-          secrets="$(npx --yes wrangler@4.34.0 secret list --json)"
+          secrets="$(npx --yes wrangler@4.34.0 secret list --format json)"
           jq -e '
             map(.name) | sort ==
             ["DEV_EDGE_SECRET", "PREVIEW_EDGE_SECRET", "PROD_EDGE_SECRET", "STAGING_EDGE_SECRET"]

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -353,7 +353,7 @@ jobs:
           printf '%s' "$STAGING_EDGE_SECRET" | npx --yes wrangler@4.34.0 secret put STAGING_EDGE_SECRET
           printf '%s' "$PROD_EDGE_SECRET" | npx --yes wrangler@4.34.0 secret put PROD_EDGE_SECRET
           printf '%s' "$PREVIEW_EDGE_SECRET" | npx --yes wrangler@4.34.0 secret put PREVIEW_EDGE_SECRET
-          npx --yes wrangler@4.34.0 secret list --json | jq -e 'map(.name) | sort == ["DEV_EDGE_SECRET", "PREVIEW_EDGE_SECRET", "PROD_EDGE_SECRET", "STAGING_EDGE_SECRET"]'
+          npx --yes wrangler@4.34.0 secret list --format json | jq -e 'map(.name) | sort == ["DEV_EDGE_SECRET", "PREVIEW_EDGE_SECRET", "PROD_EDGE_SECRET", "STAGING_EDGE_SECRET"]'
 
   # ── Move the self-host `:dev` channel tag onto the image that just deployed ─
   # `kortix self-host init/update --tag dev` (or `--channel dev` once that

--- a/apps/api/src/__tests__/unit-request-deadline.test.ts
+++ b/apps/api/src/__tests__/unit-request-deadline.test.ts
@@ -32,6 +32,7 @@ function makeApp() {
   app.get('/v1/projects/x/turn-stream', slow);      // JSON relay, bounded
   app.get('/v1/router/chat/completions', slow);      // exempt prefix
   app.get('/v1/llm/chat/completions', slow);          // exempt prefix (LLM streaming)
+  app.post('/v1/connectors/projects/x/connectors', slow); // exempt prefix (git + provider sync)
   app.post('/v1/billing/webhooks/stripe', slow);      // exempt prefix (webhook)
   app.post('/v1/projects/x/sessions/y/start', slow);  // exempt fragment (long sync op)
   app.post('/v1/projects/x/oauth/openai/start', slow); // exempt fragment (OAuth device flow — start can be slow on a cold replica)
@@ -77,6 +78,13 @@ describe('requestDeadline', () => {
 
   it('exempts the LLM completions prefix from the deadline', async () => {
     const res = await makeApp().request('/v1/llm/chat/completions');
+    expect(res.status).toBe(200);
+  });
+
+  it('exempts connector routes that can perform git and provider synchronization', async () => {
+    const res = await makeApp().request('/v1/connectors/projects/x/connectors', {
+      method: 'POST',
+    });
     expect(res.status).toBe(200);
   });
 

--- a/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
@@ -52,6 +52,7 @@ describe('sandbox init state helpers', () => {
         if (attempts < 3) throw new Error(`attempt-${attempts}`);
         return { externalId: 'machine-123', baseUrl: 'https://sandbox.example', metadata: { daytonaSandboxId: 'abc' } };
       },
+      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
@@ -84,6 +85,7 @@ describe('sandbox init state helpers', () => {
         attempts += 1;
         throw new Error('Maximum number of concurrent E2B sandboxes reached');
       },
+      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},

--- a/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
@@ -21,9 +21,7 @@ describe('sandbox init state helpers', () => {
     const meta = buildSandboxInitFailureMetadata({}, new Error('boom'), 3, false);
     expect(meta.initStatus).toBe('failed');
     expect(meta.lastInitError).toBe('boom');
-    expect(meta.errorMessage).toBe(
-      'Initialization failed after 3 attempts. Reinitialize to retry.',
-    );
+    expect(meta.errorMessage).toBe('Initialization failed after 3 attempts. Reinitialize to retry.');
   });
 
   test('records the active capacity retry limit in retry metadata', () => {
@@ -37,11 +35,7 @@ describe('sandbox init state helpers', () => {
   });
 
   test('marks successful initialization as ready', () => {
-    const meta = buildSandboxInitSuccessMetadata(
-      { serverType: 'basic' },
-      { provisioningStage: 'server_creating' },
-      2,
-    );
+    const meta = buildSandboxInitSuccessMetadata({ serverType: 'basic' }, { provisioningStage: 'server_creating' }, 2);
     expect(meta.initStatus).toBe('ready');
     expect(meta.initAttempts).toBe(2);
     expect(meta.serverType).toBe('basic');
@@ -56,32 +50,17 @@ describe('sandbox init state helpers', () => {
       async create() {
         attempts += 1;
         if (attempts < 3) throw new Error(`attempt-${attempts}`);
-        return {
-          externalId: 'machine-123',
-          baseUrl: 'https://sandbox.example',
-          metadata: { daytonaSandboxId: 'abc' },
-        };
+        return { externalId: 'machine-123', baseUrl: 'https://sandbox.example', metadata: { daytonaSandboxId: 'abc' } };
       },
-      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
-      async getStatus() {
-        return 'unknown' as const;
-      },
-      async resolveEndpoint() {
-        return { url: '', headers: {} };
-      },
-      routeIngress(request: { port: number }) {
-        return { effectivePort: request.port };
-      },
-      async resolveIngress(_externalId: string, request: { port: number }) {
-        return { url: '', headers: {}, effectivePort: request.port };
-      },
+      async getStatus() { return 'unknown' as const; },
+      async resolveEndpoint() { return { url: '', headers: {} }; },
+      routeIngress(request: { port: number }) { return { effectivePort: request.port }; },
+      async resolveIngress(_externalId: string, request: { port: number }) { return { url: '', headers: {}, effectivePort: request.port }; },
       async ensureRunning() {},
-      async getProvisioningStatus() {
-        return null;
-      },
+      async getProvisioningStatus() { return null; },
     };
 
     const result = await retrySandboxProvisionCreate(provider, {
@@ -105,26 +84,15 @@ describe('sandbox init state helpers', () => {
         attempts += 1;
         throw new Error('Maximum number of concurrent E2B sandboxes reached');
       },
-      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
-      async getStatus() {
-        return 'unknown' as const;
-      },
-      async resolveEndpoint() {
-        return { url: '', headers: {} };
-      },
-      routeIngress(request: { port: number }) {
-        return { effectivePort: request.port };
-      },
-      async resolveIngress(_externalId: string, request: { port: number }) {
-        return { url: '', headers: {}, effectivePort: request.port };
-      },
+      async getStatus() { return 'unknown' as const; },
+      async resolveEndpoint() { return { url: '', headers: {} }; },
+      routeIngress(request: { port: number }) { return { effectivePort: request.port }; },
+      async resolveIngress(_externalId: string, request: { port: number }) { return { url: '', headers: {}, effectivePort: request.port }; },
       async ensureRunning() {},
-      async getProvisioningStatus() {
-        return null;
-      },
+      async getProvisioningStatus() { return null; },
     };
 
     await expect(

--- a/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
@@ -21,7 +21,9 @@ describe('sandbox init state helpers', () => {
     const meta = buildSandboxInitFailureMetadata({}, new Error('boom'), 3, false);
     expect(meta.initStatus).toBe('failed');
     expect(meta.lastInitError).toBe('boom');
-    expect(meta.errorMessage).toBe('Initialization failed after 3 attempts. Reinitialize to retry.');
+    expect(meta.errorMessage).toBe(
+      'Initialization failed after 3 attempts. Reinitialize to retry.',
+    );
   });
 
   test('records the active capacity retry limit in retry metadata', () => {
@@ -35,7 +37,11 @@ describe('sandbox init state helpers', () => {
   });
 
   test('marks successful initialization as ready', () => {
-    const meta = buildSandboxInitSuccessMetadata({ serverType: 'basic' }, { provisioningStage: 'server_creating' }, 2);
+    const meta = buildSandboxInitSuccessMetadata(
+      { serverType: 'basic' },
+      { provisioningStage: 'server_creating' },
+      2,
+    );
     expect(meta.initStatus).toBe('ready');
     expect(meta.initAttempts).toBe(2);
     expect(meta.serverType).toBe('basic');
@@ -50,17 +56,32 @@ describe('sandbox init state helpers', () => {
       async create() {
         attempts += 1;
         if (attempts < 3) throw new Error(`attempt-${attempts}`);
-        return { externalId: 'machine-123', baseUrl: 'https://sandbox.example', metadata: { daytonaSandboxId: 'abc' } };
+        return {
+          externalId: 'machine-123',
+          baseUrl: 'https://sandbox.example',
+          metadata: { daytonaSandboxId: 'abc' },
+        };
       },
+      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
-      async getStatus() { return 'unknown' as const; },
-      async resolveEndpoint() { return { url: '', headers: {} }; },
-      routeIngress(request: { port: number }) { return { effectivePort: request.port }; },
-      async resolveIngress(_externalId: string, request: { port: number }) { return { url: '', headers: {}, effectivePort: request.port }; },
+      async getStatus() {
+        return 'unknown' as const;
+      },
+      async resolveEndpoint() {
+        return { url: '', headers: {} };
+      },
+      routeIngress(request: { port: number }) {
+        return { effectivePort: request.port };
+      },
+      async resolveIngress(_externalId: string, request: { port: number }) {
+        return { url: '', headers: {}, effectivePort: request.port };
+      },
       async ensureRunning() {},
-      async getProvisioningStatus() { return null; },
+      async getProvisioningStatus() {
+        return null;
+      },
     };
 
     const result = await retrySandboxProvisionCreate(provider, {
@@ -84,15 +105,26 @@ describe('sandbox init state helpers', () => {
         attempts += 1;
         throw new Error('Maximum number of concurrent E2B sandboxes reached');
       },
+      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
-      async getStatus() { return 'unknown' as const; },
-      async resolveEndpoint() { return { url: '', headers: {} }; },
-      routeIngress(request: { port: number }) { return { effectivePort: request.port }; },
-      async resolveIngress(_externalId: string, request: { port: number }) { return { url: '', headers: {}, effectivePort: request.port }; },
+      async getStatus() {
+        return 'unknown' as const;
+      },
+      async resolveEndpoint() {
+        return { url: '', headers: {} };
+      },
+      routeIngress(request: { port: number }) {
+        return { effectivePort: request.port };
+      },
+      async resolveIngress(_externalId: string, request: { port: number }) {
+        return { url: '', headers: {}, effectivePort: request.port };
+      },
       async ensureRunning() {},
-      async getProvisioningStatus() { return null; },
+      async getProvisioningStatus() {
+        return null;
+      },
     };
 
     await expect(

--- a/apps/api/src/apps/artifacts.test.ts
+++ b/apps/api/src/apps/artifacts.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as tar from 'tar';
 import {
+  MAX_ARCHIVE_BYTES,
   appArtifactObjectPath,
   extractAppArchive,
   inspectAppArchive,
@@ -17,6 +18,10 @@ afterEach(async () => {
 });
 
 describe('App artifacts', () => {
+  test('keeps source archives within the managed Supabase Storage limit', () => {
+    expect(MAX_ARCHIVE_BYTES).toBe(50 * 1024 * 1024);
+  });
+
   test('uses account, project, and artifact identity in the private object path', () => {
     expect(appArtifactObjectPath('account-1', 'project-1', 'artifact-1')).toBe(
       'account-1/project-1/artifact-1/source.tar.gz',

--- a/apps/api/src/apps/artifacts.ts
+++ b/apps/api/src/apps/artifacts.ts
@@ -6,7 +6,10 @@ import * as tar from 'tar';
 import { getSupabase } from '../shared/supabase';
 
 export const APP_ARTIFACT_BUCKET = 'app-artifacts';
-export const MAX_ARCHIVE_BYTES = 250 * 1024 * 1024;
+// Managed Supabase Storage rejects bucket limits above the project's global
+// fileSizeLimit. Kortix cloud currently exposes the standard 50 MiB tier.
+// OCI deployments bypass this source-archive limit.
+export const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
 export const MAX_EXTRACTED_BYTES = 1024 * 1024 * 1024;
 export const MAX_ARCHIVE_FILES = 100_000;
 export const MAX_ARCHIVE_PATH_BYTES = 1024;

--- a/apps/api/src/apps/hosting.test.ts
+++ b/apps/api/src/apps/hosting.test.ts
@@ -14,6 +14,7 @@ const secret = 'test-secret-at-least-sixteen-characters';
 function dependencies() {
   const builds: any[] = [];
   const creates: any[] = [];
+  const appRuntimeStarts: string[] = [];
   const ingressCalls: any[] = [];
   const fetchCalls: any[] = [];
   const snapshot = {
@@ -33,6 +34,8 @@ function dependencies() {
       };
     },
     start: async () => {},
+    ensureRunning: async () => {},
+    ensureAppRuntimeStarted: async (externalId: string) => { appRuntimeStarts.push(externalId); },
     stop: async () => {},
     remove: async () => {},
   } as unknown as SandboxProvider;
@@ -51,7 +54,7 @@ function dependencies() {
     fetch: fetch as typeof globalThis.fetch,
     sleep: async () => {},
   });
-  return { hosting, builds, creates, ingressCalls, fetchCalls };
+  return { hosting, builds, creates, appRuntimeStarts, ingressCalls, fetchCalls };
 }
 
 describe('AppHostingProvider', () => {
@@ -88,7 +91,7 @@ describe('AppHostingProvider', () => {
   });
 
   test('creates an App workload with only the derived appd token', async () => {
-    const { hosting, creates } = dependencies();
+    const { hosting, creates, appRuntimeStarts } = dependencies();
     const result = await hosting.createRuntime({
       provider: 'daytona',
       runtimeId: 'runtime-1',
@@ -110,6 +113,16 @@ describe('AppHostingProvider', () => {
     expect(result.controlTokenHash).toBe(
       appControlTokenHash(appControlToken('runtime-1', secret)),
     );
+    expect(appRuntimeStarts).toEqual(['box-1']);
+  });
+
+  test('restarts the App runtime daemon after provider start and cold wake', async () => {
+    const { hosting, appRuntimeStarts } = dependencies();
+
+    await hosting.start('daytona', 'box-1');
+    await hosting.ensureRunning('daytona', 'box-1');
+
+    expect(appRuntimeStarts).toEqual(['box-1', 'box-1']);
   });
 
   test('polls authenticated appd status until the runtime is ready', async () => {

--- a/apps/api/src/apps/hosting.test.ts
+++ b/apps/api/src/apps/hosting.test.ts
@@ -14,13 +14,10 @@ const secret = 'test-secret-at-least-sixteen-characters';
 function dependencies() {
   const builds: any[] = [];
   const creates: any[] = [];
-  const appRuntimeStarts: string[] = [];
   const ingressCalls: any[] = [];
   const fetchCalls: any[] = [];
   const snapshot = {
-    buildSnapshot: async (...args: any[]) => {
-      builds.push(args);
-    },
+    buildSnapshot: async (...args: any[]) => { builds.push(args); },
   } as unknown as SandboxProviderAdapter;
   const runtime = {
     create: async (input: any) => {
@@ -36,10 +33,6 @@ function dependencies() {
       };
     },
     start: async () => {},
-    ensureRunning: async () => {},
-    ensureAppRuntimeStarted: async (externalId: string) => {
-      appRuntimeStarts.push(externalId);
-    },
     stop: async () => {},
     remove: async () => {},
   } as unknown as SandboxProvider;
@@ -58,7 +51,7 @@ function dependencies() {
     fetch: fetch as typeof globalThis.fetch,
     sleep: async () => {},
   });
-  return { hosting, builds, creates, appRuntimeStarts, ingressCalls, fetchCalls };
+  return { hosting, builds, creates, ingressCalls, fetchCalls };
 }
 
 describe('AppHostingProvider', () => {
@@ -95,7 +88,7 @@ describe('AppHostingProvider', () => {
   });
 
   test('creates an App workload with only the derived appd token', async () => {
-    const { hosting, creates, appRuntimeStarts } = dependencies();
+    const { hosting, creates } = dependencies();
     const result = await hosting.createRuntime({
       provider: 'daytona',
       runtimeId: 'runtime-1',
@@ -114,17 +107,9 @@ describe('AppHostingProvider', () => {
       envVars: { KORTIX_APPD_TOKEN: appControlToken('runtime-1', secret) },
     });
     expect(creates[0].envVars.KORTIX_SANDBOX_TOKEN).toBeUndefined();
-    expect(result.controlTokenHash).toBe(appControlTokenHash(appControlToken('runtime-1', secret)));
-    expect(appRuntimeStarts).toEqual(['box-1']);
-  });
-
-  test('restarts the App runtime daemon after provider start and cold wake', async () => {
-    const { hosting, appRuntimeStarts } = dependencies();
-
-    await hosting.start('daytona', 'box-1');
-    await hosting.ensureRunning('daytona', 'box-1');
-
-    expect(appRuntimeStarts).toEqual(['box-1', 'box-1']);
+    expect(result.controlTokenHash).toBe(
+      appControlTokenHash(appControlToken('runtime-1', secret)),
+    );
   });
 
   test('polls authenticated appd status until the runtime is ready', async () => {

--- a/apps/api/src/apps/hosting.test.ts
+++ b/apps/api/src/apps/hosting.test.ts
@@ -14,10 +14,13 @@ const secret = 'test-secret-at-least-sixteen-characters';
 function dependencies() {
   const builds: any[] = [];
   const creates: any[] = [];
+  const appRuntimeStarts: string[] = [];
   const ingressCalls: any[] = [];
   const fetchCalls: any[] = [];
   const snapshot = {
-    buildSnapshot: async (...args: any[]) => { builds.push(args); },
+    buildSnapshot: async (...args: any[]) => {
+      builds.push(args);
+    },
   } as unknown as SandboxProviderAdapter;
   const runtime = {
     create: async (input: any) => {
@@ -33,6 +36,10 @@ function dependencies() {
       };
     },
     start: async () => {},
+    ensureRunning: async () => {},
+    ensureAppRuntimeStarted: async (externalId: string) => {
+      appRuntimeStarts.push(externalId);
+    },
     stop: async () => {},
     remove: async () => {},
   } as unknown as SandboxProvider;
@@ -51,7 +58,7 @@ function dependencies() {
     fetch: fetch as typeof globalThis.fetch,
     sleep: async () => {},
   });
-  return { hosting, builds, creates, ingressCalls, fetchCalls };
+  return { hosting, builds, creates, appRuntimeStarts, ingressCalls, fetchCalls };
 }
 
 describe('AppHostingProvider', () => {
@@ -88,7 +95,7 @@ describe('AppHostingProvider', () => {
   });
 
   test('creates an App workload with only the derived appd token', async () => {
-    const { hosting, creates } = dependencies();
+    const { hosting, creates, appRuntimeStarts } = dependencies();
     const result = await hosting.createRuntime({
       provider: 'daytona',
       runtimeId: 'runtime-1',
@@ -107,9 +114,17 @@ describe('AppHostingProvider', () => {
       envVars: { KORTIX_APPD_TOKEN: appControlToken('runtime-1', secret) },
     });
     expect(creates[0].envVars.KORTIX_SANDBOX_TOKEN).toBeUndefined();
-    expect(result.controlTokenHash).toBe(
-      appControlTokenHash(appControlToken('runtime-1', secret)),
-    );
+    expect(result.controlTokenHash).toBe(appControlTokenHash(appControlToken('runtime-1', secret)));
+    expect(appRuntimeStarts).toEqual(['box-1']);
+  });
+
+  test('restarts the App runtime daemon after provider start and cold wake', async () => {
+    const { hosting, appRuntimeStarts } = dependencies();
+
+    await hosting.start('daytona', 'box-1');
+    await hosting.ensureRunning('daytona', 'box-1');
+
+    expect(appRuntimeStarts).toEqual(['box-1', 'box-1']);
   });
 
   test('polls authenticated appd status until the runtime is ready', async () => {

--- a/apps/api/src/apps/hosting.ts
+++ b/apps/api/src/apps/hosting.ts
@@ -123,7 +123,8 @@ export class AppHostingProvider {
 
   async createRuntime(input: StartAppRuntimeInput): Promise<AppRuntimeHandle> {
     const token = appControlToken(input.runtimeId, this.dependencies.controlSecret);
-    const result = await this.dependencies.runtimeProvider(input.provider).create({
+    const provider = this.dependencies.runtimeProvider(input.provider);
+    const result = await provider.create({
       accountId: input.accountId,
       userId: input.userId,
       name: input.name,
@@ -134,6 +135,12 @@ export class AppHostingProvider {
       publishedPorts: [APP_CONTROL_PORT, APP_INGRESS_PORT],
       envVars: { ...input.envVars, KORTIX_APPD_TOKEN: token },
     });
+    try {
+      await provider.ensureAppRuntimeStarted(result.externalId);
+    } catch (error) {
+      await provider.remove(result.externalId).catch(() => {});
+      throw error;
+    }
     return {
       ...result,
       provider: input.provider,
@@ -143,11 +150,15 @@ export class AppHostingProvider {
   }
 
   async start(provider: SandboxProviderName, externalId: string): Promise<void> {
-    await this.dependencies.runtimeProvider(provider).start(externalId);
+    const runtimeProvider = this.dependencies.runtimeProvider(provider);
+    await runtimeProvider.start(externalId);
+    await runtimeProvider.ensureAppRuntimeStarted(externalId);
   }
 
   async ensureRunning(provider: SandboxProviderName, externalId: string): Promise<void> {
-    await this.dependencies.runtimeProvider(provider).ensureRunning(externalId);
+    const runtimeProvider = this.dependencies.runtimeProvider(provider);
+    await runtimeProvider.ensureRunning(externalId);
+    await runtimeProvider.ensureAppRuntimeStarted(externalId);
   }
 
   async stop(provider: SandboxProviderName, externalId: string): Promise<void> {

--- a/apps/api/src/apps/hosting.ts
+++ b/apps/api/src/apps/hosting.ts
@@ -123,7 +123,8 @@ export class AppHostingProvider {
 
   async createRuntime(input: StartAppRuntimeInput): Promise<AppRuntimeHandle> {
     const token = appControlToken(input.runtimeId, this.dependencies.controlSecret);
-    const result = await this.dependencies.runtimeProvider(input.provider).create({
+    const provider = this.dependencies.runtimeProvider(input.provider);
+    const result = await provider.create({
       accountId: input.accountId,
       userId: input.userId,
       name: input.name,
@@ -134,6 +135,12 @@ export class AppHostingProvider {
       publishedPorts: [APP_CONTROL_PORT, APP_INGRESS_PORT],
       envVars: { ...input.envVars, KORTIX_APPD_TOKEN: token },
     });
+    try {
+      await provider.ensureAppRuntimeStarted(result.externalId);
+    } catch (error) {
+      await provider.remove(result.externalId).catch(() => {});
+      throw error;
+    }
     return {
       ...result,
       provider: input.provider,
@@ -143,11 +150,15 @@ export class AppHostingProvider {
   }
 
   async start(provider: SandboxProviderName, externalId: string): Promise<void> {
-    await this.dependencies.runtimeProvider(provider).start(externalId);
+    const runtimeProvider = this.dependencies.runtimeProvider(provider);
+    await runtimeProvider.start(externalId);
+    await runtimeProvider.ensureAppRuntimeStarted(externalId);
   }
 
   async ensureRunning(provider: SandboxProviderName, externalId: string): Promise<void> {
-    await this.dependencies.runtimeProvider(provider).ensureRunning(externalId);
+    const runtimeProvider = this.dependencies.runtimeProvider(provider);
+    await runtimeProvider.ensureRunning(externalId);
+    await runtimeProvider.ensureAppRuntimeStarted(externalId);
   }
 
   async stop(provider: SandboxProviderName, externalId: string): Promise<void> {
@@ -176,7 +187,9 @@ export class AppHostingProvider {
   ): Promise<AppdStatus> {
     const response = await this.controlRequest(provider, externalId, runtimeId, '/v1/status');
     if (!response.ok) {
-      throw new Error(`kortix-appd status returned ${response.status}: ${(await response.text()).slice(0, 300)}`);
+      throw new Error(
+        `kortix-appd status returned ${response.status}: ${(await response.text()).slice(0, 300)}`,
+      );
     }
     return response.json() as Promise<AppdStatus>;
   }
@@ -199,7 +212,9 @@ export class AppHostingProvider {
       `/v1/logs?${query}`,
     );
     if (!response.ok) {
-      throw new Error(`kortix-appd logs returned ${response.status}: ${(await response.text()).slice(0, 300)}`);
+      throw new Error(
+        `kortix-appd logs returned ${response.status}: ${(await response.text()).slice(0, 300)}`,
+      );
     }
     return response.json();
   }

--- a/apps/api/src/apps/hosting.ts
+++ b/apps/api/src/apps/hosting.ts
@@ -123,8 +123,7 @@ export class AppHostingProvider {
 
   async createRuntime(input: StartAppRuntimeInput): Promise<AppRuntimeHandle> {
     const token = appControlToken(input.runtimeId, this.dependencies.controlSecret);
-    const provider = this.dependencies.runtimeProvider(input.provider);
-    const result = await provider.create({
+    const result = await this.dependencies.runtimeProvider(input.provider).create({
       accountId: input.accountId,
       userId: input.userId,
       name: input.name,
@@ -135,12 +134,6 @@ export class AppHostingProvider {
       publishedPorts: [APP_CONTROL_PORT, APP_INGRESS_PORT],
       envVars: { ...input.envVars, KORTIX_APPD_TOKEN: token },
     });
-    try {
-      await provider.ensureAppRuntimeStarted(result.externalId);
-    } catch (error) {
-      await provider.remove(result.externalId).catch(() => {});
-      throw error;
-    }
     return {
       ...result,
       provider: input.provider,
@@ -150,15 +143,11 @@ export class AppHostingProvider {
   }
 
   async start(provider: SandboxProviderName, externalId: string): Promise<void> {
-    const runtimeProvider = this.dependencies.runtimeProvider(provider);
-    await runtimeProvider.start(externalId);
-    await runtimeProvider.ensureAppRuntimeStarted(externalId);
+    await this.dependencies.runtimeProvider(provider).start(externalId);
   }
 
   async ensureRunning(provider: SandboxProviderName, externalId: string): Promise<void> {
-    const runtimeProvider = this.dependencies.runtimeProvider(provider);
-    await runtimeProvider.ensureRunning(externalId);
-    await runtimeProvider.ensureAppRuntimeStarted(externalId);
+    await this.dependencies.runtimeProvider(provider).ensureRunning(externalId);
   }
 
   async stop(provider: SandboxProviderName, externalId: string): Promise<void> {
@@ -187,9 +176,7 @@ export class AppHostingProvider {
   ): Promise<AppdStatus> {
     const response = await this.controlRequest(provider, externalId, runtimeId, '/v1/status');
     if (!response.ok) {
-      throw new Error(
-        `kortix-appd status returned ${response.status}: ${(await response.text()).slice(0, 300)}`,
-      );
+      throw new Error(`kortix-appd status returned ${response.status}: ${(await response.text()).slice(0, 300)}`);
     }
     return response.json() as Promise<AppdStatus>;
   }
@@ -212,9 +199,7 @@ export class AppHostingProvider {
       `/v1/logs?${query}`,
     );
     if (!response.ok) {
-      throw new Error(
-        `kortix-appd logs returned ${response.status}: ${(await response.text()).slice(0, 300)}`,
-      );
+      throw new Error(`kortix-appd logs returned ${response.status}: ${(await response.text()).slice(0, 300)}`);
     }
     return response.json();
   }

--- a/apps/api/src/apps/public-proxy.test.ts
+++ b/apps/api/src/apps/public-proxy.test.ts
@@ -9,6 +9,7 @@ const {
   appEdgeSignature,
   appUpstreamHeaders,
   resolveAppHost,
+  resolveAppRequest,
   verifyAppEdgeRequest,
 } = await import('./public-proxy');
 
@@ -40,6 +41,34 @@ describe('Apps public edge', () => {
     });
     expect(verifyAppEdgeRequest(request, new URL(request.url), false)).toBe(true);
     expect(verifyAppEdgeRequest(request, new URL(`https://${host}/api/other`), false)).toBe(false);
+  });
+
+  test('resolves and verifies the signed public host after the Worker forwards to the API host', () => {
+    const timestamp = String(Date.now());
+    const publicHost = 'dev-hello-aaaaaaaaaaaaaaaa.apps.kortix.com';
+    const secret = 'edge-secret-at-least-sixteen';
+    process.env.KORTIX_APPS_EDGE_SECRET = secret;
+    const signature = appEdgeSignature(timestamp, publicHost, 'GET', '/assets/app.js?q=1', secret);
+    const request = new Request('https://dev-api.kortix.com/assets/app.js?q=1', {
+      headers: {
+        'x-kortix-app-host': publicHost,
+        'x-kortix-app-timestamp': timestamp,
+        'x-kortix-app-signature': signature,
+      },
+    });
+
+    const resolved = resolveAppRequest(request, new URL(request.url));
+    expect(resolved).toEqual({
+      routeKey: 'aaaaaaaaaaaaaaaa',
+      local: false,
+      publicHost,
+    });
+    expect(verifyAppEdgeRequest(
+      request,
+      new URL(request.url),
+      false,
+      resolved!.publicHost,
+    )).toBe(true);
   });
 
   test('allows direct local development without Cloudflare headers', () => {

--- a/apps/api/src/apps/public-proxy.ts
+++ b/apps/api/src/apps/public-proxy.ts
@@ -37,6 +37,10 @@ export interface ResolvedAppHost {
   local: boolean;
 }
 
+export interface ResolvedAppRequest extends ResolvedAppHost {
+  publicHost: string;
+}
+
 export function resolveAppHost(hostname: string): ResolvedAppHost | null {
   const host = hostname.toLowerCase().replace(/\.$/, '');
   const local = /^([a-f0-9]{16})\.apps\.localhost$/.exec(host);
@@ -50,6 +54,14 @@ export function resolveAppHost(hostname: string): ResolvedAppHost | null {
   const match = /^(dev|staging|prod|preview)-[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?-([a-f0-9]{16})$/.exec(label);
   if (!match || match[1] !== config.INTERNAL_KORTIX_ENV) return null;
   return { routeKey: match[2]!, local: false };
+}
+
+export function resolveAppRequest(request: Request, url: URL): ResolvedAppRequest | null {
+  const publicHost = (request.headers.get(EDGE_HOST_HEADER) || url.hostname)
+    .toLowerCase()
+    .replace(/\.$/, '');
+  const matched = resolveAppHost(publicHost);
+  return matched ? { ...matched, publicHost } : null;
 }
 
 function edgeSecret(): string {
@@ -74,14 +86,19 @@ function safeEqual(left: string, right: string): boolean {
   return a.length === b.length && timingSafeEqual(a, b);
 }
 
-export function verifyAppEdgeRequest(request: Request, url: URL, local: boolean): boolean {
+export function verifyAppEdgeRequest(
+  request: Request,
+  url: URL,
+  local: boolean,
+  publicHost = url.hostname,
+): boolean {
   if (local && (process.env.KORTIX_APPS_ALLOW_LOCAL_EDGE !== 'false')) return true;
   if (process.env.KORTIX_APPS_ALLOW_DIRECT_EDGE === 'true') return true;
   const host = request.headers.get(EDGE_HOST_HEADER);
   const timestamp = request.headers.get(EDGE_TIMESTAMP_HEADER);
   const signature = request.headers.get(EDGE_SIGNATURE_HEADER);
   if (!host || !timestamp || !signature) return false;
-  if (host.toLowerCase() !== url.hostname.toLowerCase()) return false;
+  if (host.toLowerCase() !== publicHost.toLowerCase()) return false;
   const time = Number(timestamp);
   if (!Number.isFinite(time) || Math.abs(Date.now() - time) > EDGE_MAX_SKEW_MS) return false;
   return safeEqual(
@@ -267,9 +284,9 @@ export function appUpstreamHeaders(request: Request, providerHeaders: Record<str
 
 export async function handleAppPublicRequest(request: Request): Promise<Response | null> {
   const url = new URL(request.url);
-  const matched = resolveAppHost(url.hostname);
+  const matched = resolveAppRequest(request, url);
   if (!matched) return null;
-  if (!verifyAppEdgeRequest(request, url, matched.local)) {
+  if (!verifyAppEdgeRequest(request, url, matched.local, matched.publicHost)) {
     return Response.json({ error: 'Invalid App edge signature' }, { status: 403 });
   }
   const loaded = await loadPublicApp(matched.routeKey);
@@ -302,7 +319,7 @@ export async function handleAppPublicRequest(request: Request): Promise<Response
   try {
     upstream = await fetch(upstreamUrl, {
       method: request.method,
-      headers: appUpstreamHeaders(request, ingress.headers, url.host),
+      headers: appUpstreamHeaders(request, ingress.headers, matched.publicHost),
       body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
       redirect: 'manual',
       duplex: 'half',

--- a/apps/api/src/apps/ws-proxy.ts
+++ b/apps/api/src/apps/ws-proxy.ts
@@ -8,7 +8,7 @@ import {
   appUpstreamHeaders,
   ensureAppRuntimeRunning,
   loadPublicApp,
-  resolveAppHost,
+  resolveAppRequest,
   verifyAppEdgeRequest,
 } from './public-proxy';
 
@@ -55,9 +55,9 @@ export async function prepareAppWsUpgrade(
   request: Request,
   url: URL,
 ): Promise<{ ok: true; data: AppWsData } | { ok: false; status: number; message: string }> {
-  const matched = resolveAppHost(url.hostname);
+  const matched = resolveAppRequest(request, url);
   if (!matched) return { ok: false, status: 404, message: 'not an App hostname' };
-  if (!verifyAppEdgeRequest(request, url, matched.local)) {
+  if (!verifyAppEdgeRequest(request, url, matched.local, matched.publicHost)) {
     return { ok: false, status: 403, message: 'Invalid App edge signature' };
   }
   const loaded = await loadPublicApp(matched.routeKey);
@@ -71,7 +71,7 @@ export async function prepareAppWsUpgrade(
       runtime.externalId,
       'websocket',
     );
-    const headers = appUpstreamHeaders(request, ingress.headers, url.host);
+    const headers = appUpstreamHeaders(request, ingress.headers, matched.publicHost);
     const headerObject = Object.fromEntries(headers.entries());
     return {
       ok: true,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -89,7 +89,7 @@ import {
 import { startProjectMaintenance, stopProjectMaintenance } from './projects/maintenance';
 import { kickStartupPreBuild } from './snapshots/builder';
 import { registerSunaMigrationRoutes } from './projects/suna-migration/suna-migration-routes';
-import { handleAppPublicRequest, resolveAppHost } from './apps/public-proxy';
+import { handleAppPublicRequest, resolveAppRequest } from './apps/public-proxy';
 import { appWsHandlers, prepareAppWsUpgrade } from './apps/ws-proxy';
 import {
   startSunaMigrationWorker,
@@ -1432,7 +1432,7 @@ export default {
     // Matches `p{port}-{sandboxId}.localhost:{apiPort}` regardless of path.
     // Same per-request long-poll/SSE timeout posture as /v1/p/.
     const host = req.headers.get('host') || '';
-    if (resolveAppHost(url.hostname)) {
+    if (resolveAppRequest(req, url)) {
       server.timeout(req, 0);
       if (isWsUpgrade) {
         const prepared = await prepareAppWsUpgrade(req, url);

--- a/apps/api/src/middleware/request-deadline.ts
+++ b/apps/api/src/middleware/request-deadline.ts
@@ -58,7 +58,7 @@ const EXEMPT_PREFIXES = [
   '/v1/router',   // LLM gateway — streamed chat completions
   '/v1/llm',      // LLM chat completions (streamed; p99 >10s is normal)
   '/v1/llm-gateway', // reverse proxy to the standalone gateway (streamed SSE)
-  '/v1/connector', // connector proxy — forwards to arbitrary upstream APIs
+  '/v1/connectors', // connector calls + git/provider sync — arbitrary upstream latency
   '/v1/webhooks', // inbound webhooks (Slack, …) — callers retry, don't truncate
   '/v1/billing/webhooks',   // Stripe webhook processing (observed >60s, legit)
   '/v1/billing/revenuecat', // RevenueCat sync — batch reconcile, legit-long

--- a/apps/api/src/platform/providers/daytona-eager-preview.test.ts
+++ b/apps/api/src/platform/providers/daytona-eager-preview.test.ts
@@ -16,6 +16,7 @@ mock.module('../../config', () => ({
 mock.module('../../shared/db', () => ({ db: {} }));
 
 let previewLinkCalls: number[] = [];
+let processCommands: Array<{ command: string; timeout: number | undefined }> = [];
 let previewLinkImpl: (port: number) => Promise<unknown> = async (port) => {
   previewLinkCalls.push(port);
   return { url: 'https://preview.example.com', token: 'tok' };
@@ -26,6 +27,14 @@ mock.module('../../shared/daytona', () => ({
     create: async () => ({
       id: 'sbx-eager-1',
       getPreviewLink: (port: number) => previewLinkImpl(port),
+    }),
+    get: async () => ({
+      process: {
+        executeCommand: async (command: string, _cwd?: string, _env?: Record<string, string>, timeout?: number) => {
+          processCommands.push({ command, timeout });
+          return { exitCode: 0, result: 'started' };
+        },
+      },
     }),
   }),
   archiveDaytonaSandboxById: async () => ({ ok: true }),
@@ -98,4 +107,15 @@ test('provisioning does not wait on the warm — create resolves before the link
     previewLinkCalls.push(port);
     return { url: 'https://preview.example.com', token: 'tok' };
   };
+});
+
+test('App workload bootstrap starts kortix-appd through the Daytona toolbox', async () => {
+  processCommands = [];
+
+  await new DaytonaProvider().ensureAppRuntimeStarted('sbx-eager-1');
+
+  expect(processCommands).toHaveLength(1);
+  expect(processCommands[0]?.command).toContain('/kortix/bin/kortix-appd');
+  expect(processCommands[0]?.command).toContain('/tmp/kortix-appd.pid');
+  expect(processCommands[0]?.timeout).toBe(15);
 });

--- a/apps/api/src/platform/providers/daytona-eager-preview.test.ts
+++ b/apps/api/src/platform/providers/daytona-eager-preview.test.ts
@@ -16,6 +16,7 @@ mock.module('../../config', () => ({
 mock.module('../../shared/db', () => ({ db: {} }));
 
 let previewLinkCalls: number[] = [];
+let processCommands: Array<{ command: string; timeout: number | undefined }> = [];
 let previewLinkImpl: (port: number) => Promise<unknown> = async (port) => {
   previewLinkCalls.push(port);
   return { url: 'https://preview.example.com', token: 'tok' };
@@ -26,6 +27,19 @@ mock.module('../../shared/daytona', () => ({
     create: async () => ({
       id: 'sbx-eager-1',
       getPreviewLink: (port: number) => previewLinkImpl(port),
+    }),
+    get: async () => ({
+      process: {
+        executeCommand: async (
+          command: string,
+          _cwd?: string,
+          _env?: Record<string, string>,
+          timeout?: number,
+        ) => {
+          processCommands.push({ command, timeout });
+          return { exitCode: 0, result: 'started' };
+        },
+      },
     }),
   }),
   archiveDaytonaSandboxById: async () => ({ ok: true }),
@@ -38,7 +52,9 @@ mock.module('../../projects/disk-quota-guard', () => ({
 }));
 
 mock.module('../service-key', () => ({ serviceKeyForExternalId: async () => null }));
-mock.module('../sandbox-frontend-url', () => ({ sandboxFrontendBaseUrl: () => 'https://app.example.com' }));
+mock.module('../sandbox-frontend-url', () => ({
+  sandboxFrontendBaseUrl: () => 'https://app.example.com',
+}));
 
 const { DaytonaProvider } = await import('./daytona');
 
@@ -98,4 +114,15 @@ test('provisioning does not wait on the warm — create resolves before the link
     previewLinkCalls.push(port);
     return { url: 'https://preview.example.com', token: 'tok' };
   };
+});
+
+test('App workload bootstrap starts kortix-appd through the Daytona toolbox', async () => {
+  processCommands = [];
+
+  await new DaytonaProvider().ensureAppRuntimeStarted('sbx-eager-1');
+
+  expect(processCommands).toHaveLength(1);
+  expect(processCommands[0]?.command).toContain('/kortix/bin/kortix-appd');
+  expect(processCommands[0]?.command).toContain('/tmp/kortix-appd.pid');
+  expect(processCommands[0]?.timeout).toBe(15);
 });

--- a/apps/api/src/platform/providers/daytona-eager-preview.test.ts
+++ b/apps/api/src/platform/providers/daytona-eager-preview.test.ts
@@ -16,7 +16,6 @@ mock.module('../../config', () => ({
 mock.module('../../shared/db', () => ({ db: {} }));
 
 let previewLinkCalls: number[] = [];
-let processCommands: Array<{ command: string; timeout: number | undefined }> = [];
 let previewLinkImpl: (port: number) => Promise<unknown> = async (port) => {
   previewLinkCalls.push(port);
   return { url: 'https://preview.example.com', token: 'tok' };
@@ -27,19 +26,6 @@ mock.module('../../shared/daytona', () => ({
     create: async () => ({
       id: 'sbx-eager-1',
       getPreviewLink: (port: number) => previewLinkImpl(port),
-    }),
-    get: async () => ({
-      process: {
-        executeCommand: async (
-          command: string,
-          _cwd?: string,
-          _env?: Record<string, string>,
-          timeout?: number,
-        ) => {
-          processCommands.push({ command, timeout });
-          return { exitCode: 0, result: 'started' };
-        },
-      },
     }),
   }),
   archiveDaytonaSandboxById: async () => ({ ok: true }),
@@ -52,9 +38,7 @@ mock.module('../../projects/disk-quota-guard', () => ({
 }));
 
 mock.module('../service-key', () => ({ serviceKeyForExternalId: async () => null }));
-mock.module('../sandbox-frontend-url', () => ({
-  sandboxFrontendBaseUrl: () => 'https://app.example.com',
-}));
+mock.module('../sandbox-frontend-url', () => ({ sandboxFrontendBaseUrl: () => 'https://app.example.com' }));
 
 const { DaytonaProvider } = await import('./daytona');
 
@@ -114,15 +98,4 @@ test('provisioning does not wait on the warm — create resolves before the link
     previewLinkCalls.push(port);
     return { url: 'https://preview.example.com', token: 'tok' };
   };
-});
-
-test('App workload bootstrap starts kortix-appd through the Daytona toolbox', async () => {
-  processCommands = [];
-
-  await new DaytonaProvider().ensureAppRuntimeStarted('sbx-eager-1');
-
-  expect(processCommands).toHaveLength(1);
-  expect(processCommands[0]?.command).toContain('/kortix/bin/kortix-appd');
-  expect(processCommands[0]?.command).toContain('/tmp/kortix-appd.pid');
-  expect(processCommands[0]?.timeout).toBe(15);
 });

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -289,6 +289,40 @@ export class DaytonaProvider implements SandboxProvider {
     };
   }
 
+  /**
+   * Daytona runs its own `/usr/local/bin/daytona` entrypoint and does not run
+   * the image ENTRYPOINT. Start appd through the toolbox after every create or
+   * wake. The PID-file check makes concurrent and repeated calls idempotent.
+   */
+  async ensureAppRuntimeStarted(externalId: string): Promise<void> {
+    const daytona = getDaytona();
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId}) for App bootstrap`,
+    );
+    const command = [
+      'pid_file=/tmp/kortix-appd.pid',
+      'if [ -r "$pid_file" ]; then',
+      '  IFS= read -r appd_pid < "$pid_file" || true',
+      '  if [ -n "${appd_pid:-}" ] && kill -0 "$appd_pid" 2>/dev/null; then exit 0; fi',
+      'fi',
+      "trap '' HUP",
+      '/kortix/bin/kortix-appd >>/tmp/kortix-appd-bootstrap.log 2>&1 </dev/null &',
+      'echo "$!" > "$pid_file"',
+    ].join('\n');
+    const result = await withTimeout(
+      sandbox.process.executeCommand(command, undefined, undefined, 15),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona App bootstrap(${externalId})`,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Daytona App bootstrap failed for ${externalId}: exit ${result.exitCode}: ${result.result.slice(0, 500)}`,
+      );
+    }
+  }
+
   async start(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -42,11 +42,7 @@ import { withTimeout, configuredTimeoutMs } from '../../shared/with-timeout';
 // Every method below that awaits the SDK directly is bounded with
 // `withTimeout` so a hung upstream fails fast and observably instead of
 // hanging for up to a day.
-const PROVIDER_CALL_TIMEOUT_MS = configuredTimeoutMs(
-  'KORTIX_DAYTONA_CALL_TIMEOUT_MS',
-  20_000,
-  1_000,
-);
+const PROVIDER_CALL_TIMEOUT_MS = configuredTimeoutMs('KORTIX_DAYTONA_CALL_TIMEOUT_MS', 20_000, 1_000);
 // listManagedRunningSandboxes() pages through the org's whole managed fleet —
 // a large fleet can legitimately take longer than one single-call budget to
 // fully list, and PROVIDER_CALL_TIMEOUT_MS would then look identical to a
@@ -116,6 +112,8 @@ import type {
 const STATUS_CACHE_TTL_MS = 1500;
 const runningStatusCache = new Map<string, number>(); // externalId → cachedAt (ms)
 
+
+
 function isMissingSandboxError(error: unknown): boolean {
   const err = error as
     | { status?: unknown; statusCode?: unknown; code?: unknown; message?: unknown }
@@ -172,7 +170,9 @@ export class DaytonaProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [{ id: 'creating', progress: 50, message: 'Creating sandbox...' }],
+    stages: [
+      { id: 'creating', progress: 50, message: 'Creating sandbox...' },
+    ],
   };
 
   async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
@@ -184,7 +184,8 @@ export class DaytonaProvider implements SandboxProvider {
     // KORTIX_URL is the public API base URL the sandbox calls back on. Strip
     // any route suffix so older env files that included /v1 or /v1/router still
     // resolve to the bare origin.
-    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL
+      .replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
 
@@ -221,30 +222,28 @@ export class DaytonaProvider implements SandboxProvider {
     if (!snapshot) {
       throw new Error(
         'Daytona create() called without opts.snapshot. ' +
-          'Every sandbox must boot from a per-project snapshot built by ' +
-          'apps/api/src/snapshots/builder.ts. There is no shared fallback.',
+        'Every sandbox must boot from a per-project snapshot built by ' +
+        'apps/api/src/snapshots/builder.ts. There is no shared fallback.',
       );
     }
 
     const daytona = getDaytona();
-    const daytonaSandbox = await daytona
-      .create(
-        {
-          snapshot,
-          envVars,
-          // Idle → stop → archive → delete. See daytonaLifecycle(): auto-stop is
-          // clamped to >= 1 so a normal session box can never be created persistent,
-          // a large auto-archive (default 3 days) keeps a hibernated box in the
-          // fast-resume "stopped" tier, and a finite auto-delete reclaims it if the
-          // API/tunnel that created it dies. Intervals are env-tunable
-          // (KORTIX_SANDBOX_AUTO*).
-          ...daytonaLifecycle(opts.autoStopInterval),
-          labels: managedSandboxLabels(workloadType),
-          public: false,
-        },
-        { timeout: createTimeoutSeconds },
-      )
-      .catch((err) => reportIfDiskQuotaError(err, 'create'));
+    const daytonaSandbox = await daytona.create(
+      {
+        snapshot,
+        envVars,
+        // Idle → stop → archive → delete. See daytonaLifecycle(): auto-stop is
+        // clamped to >= 1 so a normal session box can never be created persistent,
+        // a large auto-archive (default 3 days) keeps a hibernated box in the
+        // fast-resume "stopped" tier, and a finite auto-delete reclaims it if the
+        // API/tunnel that created it dies. Intervals are env-tunable
+        // (KORTIX_SANDBOX_AUTO*).
+        ...daytonaLifecycle(opts.autoStopInterval),
+        labels: managedSandboxLabels(workloadType),
+        public: false,
+      },
+      { timeout: createTimeoutSeconds },
+    ).catch((err) => reportIfDiskQuotaError(err, 'create'));
 
     const externalId = daytonaSandbox.id;
     const apiBase = sandboxApiBase;
@@ -290,79 +289,27 @@ export class DaytonaProvider implements SandboxProvider {
     };
   }
 
-  /**
-   * Daytona runs its own `/usr/local/bin/daytona` entrypoint and does not run
-   * the image ENTRYPOINT. Start appd through the toolbox after every create or
-   * wake. The PID-file check makes concurrent and repeated calls idempotent.
-   */
-  async ensureAppRuntimeStarted(externalId: string): Promise<void> {
-    const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId}) for App bootstrap`,
-    );
-    const command = [
-      'pid_file=/tmp/kortix-appd.pid',
-      'if [ -r "$pid_file" ]; then',
-      '  IFS= read -r appd_pid < "$pid_file" || true',
-      '  if [ -n "${appd_pid:-}" ] && kill -0 "$appd_pid" 2>/dev/null; then exit 0; fi',
-      'fi',
-      "trap '' HUP",
-      '/kortix/bin/kortix-appd >>/tmp/kortix-appd-bootstrap.log 2>&1 </dev/null &',
-      'echo "$!" > "$pid_file"',
-    ].join('\n');
-    const result = await withTimeout(
-      sandbox.process.executeCommand(command, undefined, undefined, 15),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona App bootstrap(${externalId})`,
-    );
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Daytona App bootstrap failed for ${externalId}: exit ${result.exitCode}: ${result.result.slice(0, 500)}`,
-      );
-    }
-  }
-
   async start(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId})`,
+    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+    await withTimeout(sandbox.start(), PROVIDER_CALL_TIMEOUT_MS, `Daytona start(${externalId})`).catch((err) =>
+      reportIfDiskQuotaError(err, 'resume'),
     );
-    await withTimeout(
-      sandbox.start(),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona start(${externalId})`,
-    ).catch((err) => reportIfDiskQuotaError(err, 'resume'));
   }
 
   async stop(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId})`,
-    );
+    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
     await withTimeout(sandbox.stop(), PROVIDER_CALL_TIMEOUT_MS, `Daytona stop(${externalId})`);
   }
 
   async remove(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId})`,
-    );
-    await withTimeout(
-      daytona.delete(sandbox),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona delete(${externalId})`,
-    );
+    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+    await withTimeout(daytona.delete(sandbox), PROVIDER_CALL_TIMEOUT_MS, `Daytona delete(${externalId})`);
   }
 
   /**
@@ -372,9 +319,7 @@ export class DaytonaProvider implements SandboxProvider {
    * createdAt so the reaper can age-gate (never stop a box inside its grace
    * window, which would race a box mid-provision before its DB row lands).
    */
-  async listManagedRunningSandboxes(): Promise<
-    Array<{ externalId: string; createdAt: Date | null }>
-  > {
+  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
     // Bounds the WHOLE paginated iteration, not just one page — the async
     // generator can page indefinitely if a later page's request hangs.
     return withTimeout(
@@ -405,11 +350,7 @@ export class DaytonaProvider implements SandboxProvider {
     if (cachedAt !== undefined && Date.now() - cachedAt < STATUS_CACHE_TTL_MS) return 'running';
     try {
       const daytona = getDaytona();
-      const sandbox = await withTimeout(
-        daytona.get(externalId),
-        PROVIDER_CALL_TIMEOUT_MS,
-        `Daytona get(${externalId})`,
-      );
+      const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
       const status = classifyDaytonaState(sandbox.state);
       if (status === 'running') {
         runningStatusCache.set(externalId, Date.now());
@@ -424,16 +365,9 @@ export class DaytonaProvider implements SandboxProvider {
     }
   }
 
-  async resolveIngress(
-    externalId: string,
-    request: SandboxIngressRequest,
-  ): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
     const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId})`,
-    );
+    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
     const link: any = await withTimeout(
       (sandbox as any).getPreviewLink(request.port),
       PROVIDER_CALL_TIMEOUT_MS,

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -42,7 +42,11 @@ import { withTimeout, configuredTimeoutMs } from '../../shared/with-timeout';
 // Every method below that awaits the SDK directly is bounded with
 // `withTimeout` so a hung upstream fails fast and observably instead of
 // hanging for up to a day.
-const PROVIDER_CALL_TIMEOUT_MS = configuredTimeoutMs('KORTIX_DAYTONA_CALL_TIMEOUT_MS', 20_000, 1_000);
+const PROVIDER_CALL_TIMEOUT_MS = configuredTimeoutMs(
+  'KORTIX_DAYTONA_CALL_TIMEOUT_MS',
+  20_000,
+  1_000,
+);
 // listManagedRunningSandboxes() pages through the org's whole managed fleet —
 // a large fleet can legitimately take longer than one single-call budget to
 // fully list, and PROVIDER_CALL_TIMEOUT_MS would then look identical to a
@@ -112,8 +116,6 @@ import type {
 const STATUS_CACHE_TTL_MS = 1500;
 const runningStatusCache = new Map<string, number>(); // externalId → cachedAt (ms)
 
-
-
 function isMissingSandboxError(error: unknown): boolean {
   const err = error as
     | { status?: unknown; statusCode?: unknown; code?: unknown; message?: unknown }
@@ -170,9 +172,7 @@ export class DaytonaProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [
-      { id: 'creating', progress: 50, message: 'Creating sandbox...' },
-    ],
+    stages: [{ id: 'creating', progress: 50, message: 'Creating sandbox...' }],
   };
 
   async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
@@ -184,8 +184,7 @@ export class DaytonaProvider implements SandboxProvider {
     // KORTIX_URL is the public API base URL the sandbox calls back on. Strip
     // any route suffix so older env files that included /v1 or /v1/router still
     // resolve to the bare origin.
-    const sandboxApiBase = config.KORTIX_URL
-      .replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
 
@@ -222,28 +221,30 @@ export class DaytonaProvider implements SandboxProvider {
     if (!snapshot) {
       throw new Error(
         'Daytona create() called without opts.snapshot. ' +
-        'Every sandbox must boot from a per-project snapshot built by ' +
-        'apps/api/src/snapshots/builder.ts. There is no shared fallback.',
+          'Every sandbox must boot from a per-project snapshot built by ' +
+          'apps/api/src/snapshots/builder.ts. There is no shared fallback.',
       );
     }
 
     const daytona = getDaytona();
-    const daytonaSandbox = await daytona.create(
-      {
-        snapshot,
-        envVars,
-        // Idle → stop → archive → delete. See daytonaLifecycle(): auto-stop is
-        // clamped to >= 1 so a normal session box can never be created persistent,
-        // a large auto-archive (default 3 days) keeps a hibernated box in the
-        // fast-resume "stopped" tier, and a finite auto-delete reclaims it if the
-        // API/tunnel that created it dies. Intervals are env-tunable
-        // (KORTIX_SANDBOX_AUTO*).
-        ...daytonaLifecycle(opts.autoStopInterval),
-        labels: managedSandboxLabels(workloadType),
-        public: false,
-      },
-      { timeout: createTimeoutSeconds },
-    ).catch((err) => reportIfDiskQuotaError(err, 'create'));
+    const daytonaSandbox = await daytona
+      .create(
+        {
+          snapshot,
+          envVars,
+          // Idle → stop → archive → delete. See daytonaLifecycle(): auto-stop is
+          // clamped to >= 1 so a normal session box can never be created persistent,
+          // a large auto-archive (default 3 days) keeps a hibernated box in the
+          // fast-resume "stopped" tier, and a finite auto-delete reclaims it if the
+          // API/tunnel that created it dies. Intervals are env-tunable
+          // (KORTIX_SANDBOX_AUTO*).
+          ...daytonaLifecycle(opts.autoStopInterval),
+          labels: managedSandboxLabels(workloadType),
+          public: false,
+        },
+        { timeout: createTimeoutSeconds },
+      )
+      .catch((err) => reportIfDiskQuotaError(err, 'create'));
 
     const externalId = daytonaSandbox.id;
     const apiBase = sandboxApiBase;
@@ -289,27 +290,79 @@ export class DaytonaProvider implements SandboxProvider {
     };
   }
 
+  /**
+   * Daytona runs its own `/usr/local/bin/daytona` entrypoint and does not run
+   * the image ENTRYPOINT. Start appd through the toolbox after every create or
+   * wake. The PID-file check makes concurrent and repeated calls idempotent.
+   */
+  async ensureAppRuntimeStarted(externalId: string): Promise<void> {
+    const daytona = getDaytona();
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId}) for App bootstrap`,
+    );
+    const command = [
+      'pid_file=/tmp/kortix-appd.pid',
+      'if [ -r "$pid_file" ]; then',
+      '  IFS= read -r appd_pid < "$pid_file" || true',
+      '  if [ -n "${appd_pid:-}" ] && kill -0 "$appd_pid" 2>/dev/null; then exit 0; fi',
+      'fi',
+      "trap '' HUP",
+      '/kortix/bin/kortix-appd >>/tmp/kortix-appd-bootstrap.log 2>&1 </dev/null &',
+      'echo "$!" > "$pid_file"',
+    ].join('\n');
+    const result = await withTimeout(
+      sandbox.process.executeCommand(command, undefined, undefined, 15),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona App bootstrap(${externalId})`,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Daytona App bootstrap failed for ${externalId}: exit ${result.exitCode}: ${result.result.slice(0, 500)}`,
+      );
+    }
+  }
+
   async start(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
-    await withTimeout(sandbox.start(), PROVIDER_CALL_TIMEOUT_MS, `Daytona start(${externalId})`).catch((err) =>
-      reportIfDiskQuotaError(err, 'resume'),
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId})`,
     );
+    await withTimeout(
+      sandbox.start(),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona start(${externalId})`,
+    ).catch((err) => reportIfDiskQuotaError(err, 'resume'));
   }
 
   async stop(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId})`,
+    );
     await withTimeout(sandbox.stop(), PROVIDER_CALL_TIMEOUT_MS, `Daytona stop(${externalId})`);
   }
 
   async remove(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
-    await withTimeout(daytona.delete(sandbox), PROVIDER_CALL_TIMEOUT_MS, `Daytona delete(${externalId})`);
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId})`,
+    );
+    await withTimeout(
+      daytona.delete(sandbox),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona delete(${externalId})`,
+    );
   }
 
   /**
@@ -319,7 +372,9 @@ export class DaytonaProvider implements SandboxProvider {
    * createdAt so the reaper can age-gate (never stop a box inside its grace
    * window, which would race a box mid-provision before its DB row lands).
    */
-  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
+  async listManagedRunningSandboxes(): Promise<
+    Array<{ externalId: string; createdAt: Date | null }>
+  > {
     // Bounds the WHOLE paginated iteration, not just one page — the async
     // generator can page indefinitely if a later page's request hangs.
     return withTimeout(
@@ -350,7 +405,11 @@ export class DaytonaProvider implements SandboxProvider {
     if (cachedAt !== undefined && Date.now() - cachedAt < STATUS_CACHE_TTL_MS) return 'running';
     try {
       const daytona = getDaytona();
-      const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+      const sandbox = await withTimeout(
+        daytona.get(externalId),
+        PROVIDER_CALL_TIMEOUT_MS,
+        `Daytona get(${externalId})`,
+      );
       const status = classifyDaytonaState(sandbox.state);
       if (status === 'running') {
         runningStatusCache.set(externalId, Date.now());
@@ -365,9 +424,16 @@ export class DaytonaProvider implements SandboxProvider {
     }
   }
 
-  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(
+    externalId: string,
+    request: SandboxIngressRequest,
+  ): Promise<ResolvedSandboxIngress> {
     const daytona = getDaytona();
-    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId})`,
+    );
     const link: any = await withTimeout(
       (sandbox as any).getPreviewLink(request.port),
       PROVIDER_CALL_TIMEOUT_MS,

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -294,6 +294,10 @@ export class E2BProvider implements SandboxProvider {
     }
   }
 
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // E2B honors the image ENTRYPOINT and resumes the existing process tree.
+  }
+
   async start(externalId: string): Promise<void> {
     const inFlight = startOperations.get(externalId);
     if (inFlight) return inFlight;

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -24,7 +24,8 @@ import { assertWorkloadCredential, sandboxWorkloadType } from './index';
 // backstop and must not make sandbox creation plan-dependent.
 const E2B_RUNTIME_BACKSTOP_MS = 60 * 60 * 1000;
 const KORTIX_ENTRYPOINT = '/usr/local/bin/kortix-entrypoint';
-const KORTIX_ENTRYPOINT_COMMAND = `exec flock -n /run/kortix-entrypoint.lock ${KORTIX_ENTRYPOINT}`;
+const KORTIX_ENTRYPOINT_COMMAND =
+  `exec flock -n /run/kortix-entrypoint.lock ${KORTIX_ENTRYPOINT}`;
 const RUNTIME_ENV_PATH = '/etc/kortix/runtime-env.json';
 const KORTIX_HEALTH_WAIT =
   'for attempt in $(seq 1 180); do ' +
@@ -42,7 +43,11 @@ const MANAGED_METADATA = 'kortix_managed';
 const ENV_METADATA = 'kortix_env';
 // The E2B SDK accepts requestTimeoutMs, but a live kill call remained pending
 // after that budget. This outer timer bounds all permanent-removal call sites.
-const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs('KORTIX_E2B_REMOVE_TIMEOUT_MS', 25_000, 1_000);
+const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs(
+  'KORTIX_E2B_REMOVE_TIMEOUT_MS',
+  25_000,
+  1_000,
+);
 
 function apiOpts() {
   return { apiKey: config.E2B_API_KEY, requestTimeoutMs: 20_000 } as const;
@@ -50,12 +55,7 @@ function apiOpts() {
 
 function isMissingSandboxError(error: unknown): boolean {
   if (error instanceof SandboxNotFoundError) return true;
-  const err = error as {
-    status?: unknown;
-    statusCode?: unknown;
-    code?: unknown;
-    message?: unknown;
-  } | null;
+  const err = error as { status?: unknown; statusCode?: unknown; code?: unknown; message?: unknown } | null;
   if (err?.status === 404 || err?.statusCode === 404 || err?.code === 404) return true;
   return /not found|does not exist|no such sandbox/i.test(String(err?.message ?? error ?? ''));
 }
@@ -75,9 +75,7 @@ function validateRuntimeEnv(value: unknown, externalId: string): Record<string, 
   const envs: Record<string, string> = {};
   for (const [key, item] of Object.entries(value)) {
     if (typeof item !== 'string') {
-      throw new Error(
-        `[e2b] sandbox ${externalId} has a non-string persisted runtime environment value`,
-      );
+      throw new Error(`[e2b] sandbox ${externalId} has a non-string persisted runtime environment value`);
     }
     envs[key] = item;
   }
@@ -89,7 +87,10 @@ function validateRuntimeEnv(value: unknown, externalId: string): Record<string, 
   return envs;
 }
 
-async function persistRuntimeEnv(sandbox: E2BSandbox, envs: Record<string, string>): Promise<void> {
+async function persistRuntimeEnv(
+  sandbox: E2BSandbox,
+  envs: Record<string, string>,
+): Promise<void> {
   await sandbox.files.write(RUNTIME_ENV_PATH, JSON.stringify(envs), {
     user: 'root',
     requestTimeoutMs: 10_000,
@@ -116,7 +117,9 @@ async function loadRuntimeEnv(sandbox: E2BSandbox): Promise<Record<string, strin
 
 function requirePrivateTrafficToken(sandbox: E2BSandbox): string {
   if (!sandbox.trafficAccessToken) {
-    throw new Error(`[e2b] sandbox ${sandbox.sandboxId} has no private traffic access token`);
+    throw new Error(
+      `[e2b] sandbox ${sandbox.sandboxId} has no private traffic access token`,
+    );
   }
   return sandbox.trafficAccessToken;
 }
@@ -126,8 +129,8 @@ async function ensureKortixEntrypoint(
   envs?: Record<string, string>,
 ): Promise<void> {
   const processes = await sandbox.commands.list({ requestTimeoutMs: 10_000 });
-  const alreadyRunning = processes.some((process) =>
-    `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_ENTRYPOINT),
+  const alreadyRunning = processes.some(
+    (process) => `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_ENTRYPOINT),
   );
   if (!alreadyRunning) {
     // The guest lock is the cross-process/cross-replica authority. Two API
@@ -156,8 +159,8 @@ async function ensureAppEntrypoint(
   envs: Record<string, string>,
 ): Promise<void> {
   const processes = await sandbox.commands.list({ requestTimeoutMs: 10_000 });
-  const alreadyRunning = processes.some((process) =>
-    `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_APPD),
+  const alreadyRunning = processes.some(
+    (process) => `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_APPD),
   );
   if (!alreadyRunning) {
     await sandbox.commands.run(KORTIX_APPD_COMMAND, {
@@ -198,7 +201,8 @@ export class E2BProvider implements SandboxProvider {
       );
     }
 
-    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL
+      .replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
     const envVars: Record<string, string> = {
@@ -252,9 +256,7 @@ export class E2BProvider implements SandboxProvider {
     } catch (error) {
       connectedSandboxes.delete(sandbox.sandboxId);
       await sandbox.kill({ requestTimeoutMs: 20_000 }).catch(() => false);
-      throw new Error(
-        `[e2b] failed to launch Kortix entrypoint: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      throw new Error(`[e2b] failed to launch Kortix entrypoint: ${error instanceof Error ? error.message : String(error)}`);
     }
 
     const externalId = sandbox.sandboxId;
@@ -290,10 +292,6 @@ export class E2BProvider implements SandboxProvider {
       connectedSandboxes.delete(externalId);
       throw error;
     }
-  }
-
-  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
-    // E2B honors the image ENTRYPOINT and resumes the existing process tree.
   }
 
   async start(externalId: string): Promise<void> {
@@ -372,10 +370,7 @@ export class E2BProvider implements SandboxProvider {
 
   async resolveEndpoint(externalId: string): Promise<ResolvedEndpoint> {
     const ingress = await this.resolveIngress(externalId, { port: 8000, transport: 'http' });
-    const headers: Record<string, string> = {
-      ...ingress.headers,
-      'Content-Type': 'application/json',
-    };
+    const headers: Record<string, string> = { ...ingress.headers, 'Content-Type': 'application/json' };
     const serviceKey = await serviceKeyForExternalId(externalId).catch(() => null);
     if (serviceKey) headers.Authorization = `Bearer ${serviceKey}`;
     return { url: ingress.url, headers };
@@ -387,9 +382,7 @@ export class E2BProvider implements SandboxProvider {
     if (status === 'stopped') await this.start(externalId);
   }
 
-  async listManagedRunningSandboxes(): Promise<
-    Array<{ externalId: string; createdAt: Date | null }>
-  > {
+  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
     const paginator = Sandbox.list({
       ...apiOpts(),
       limit: 100,

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -24,8 +24,7 @@ import { assertWorkloadCredential, sandboxWorkloadType } from './index';
 // backstop and must not make sandbox creation plan-dependent.
 const E2B_RUNTIME_BACKSTOP_MS = 60 * 60 * 1000;
 const KORTIX_ENTRYPOINT = '/usr/local/bin/kortix-entrypoint';
-const KORTIX_ENTRYPOINT_COMMAND =
-  `exec flock -n /run/kortix-entrypoint.lock ${KORTIX_ENTRYPOINT}`;
+const KORTIX_ENTRYPOINT_COMMAND = `exec flock -n /run/kortix-entrypoint.lock ${KORTIX_ENTRYPOINT}`;
 const RUNTIME_ENV_PATH = '/etc/kortix/runtime-env.json';
 const KORTIX_HEALTH_WAIT =
   'for attempt in $(seq 1 180); do ' +
@@ -43,11 +42,7 @@ const MANAGED_METADATA = 'kortix_managed';
 const ENV_METADATA = 'kortix_env';
 // The E2B SDK accepts requestTimeoutMs, but a live kill call remained pending
 // after that budget. This outer timer bounds all permanent-removal call sites.
-const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs(
-  'KORTIX_E2B_REMOVE_TIMEOUT_MS',
-  25_000,
-  1_000,
-);
+const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs('KORTIX_E2B_REMOVE_TIMEOUT_MS', 25_000, 1_000);
 
 function apiOpts() {
   return { apiKey: config.E2B_API_KEY, requestTimeoutMs: 20_000 } as const;
@@ -55,7 +50,12 @@ function apiOpts() {
 
 function isMissingSandboxError(error: unknown): boolean {
   if (error instanceof SandboxNotFoundError) return true;
-  const err = error as { status?: unknown; statusCode?: unknown; code?: unknown; message?: unknown } | null;
+  const err = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    message?: unknown;
+  } | null;
   if (err?.status === 404 || err?.statusCode === 404 || err?.code === 404) return true;
   return /not found|does not exist|no such sandbox/i.test(String(err?.message ?? error ?? ''));
 }
@@ -75,7 +75,9 @@ function validateRuntimeEnv(value: unknown, externalId: string): Record<string, 
   const envs: Record<string, string> = {};
   for (const [key, item] of Object.entries(value)) {
     if (typeof item !== 'string') {
-      throw new Error(`[e2b] sandbox ${externalId} has a non-string persisted runtime environment value`);
+      throw new Error(
+        `[e2b] sandbox ${externalId} has a non-string persisted runtime environment value`,
+      );
     }
     envs[key] = item;
   }
@@ -87,10 +89,7 @@ function validateRuntimeEnv(value: unknown, externalId: string): Record<string, 
   return envs;
 }
 
-async function persistRuntimeEnv(
-  sandbox: E2BSandbox,
-  envs: Record<string, string>,
-): Promise<void> {
+async function persistRuntimeEnv(sandbox: E2BSandbox, envs: Record<string, string>): Promise<void> {
   await sandbox.files.write(RUNTIME_ENV_PATH, JSON.stringify(envs), {
     user: 'root',
     requestTimeoutMs: 10_000,
@@ -117,9 +116,7 @@ async function loadRuntimeEnv(sandbox: E2BSandbox): Promise<Record<string, strin
 
 function requirePrivateTrafficToken(sandbox: E2BSandbox): string {
   if (!sandbox.trafficAccessToken) {
-    throw new Error(
-      `[e2b] sandbox ${sandbox.sandboxId} has no private traffic access token`,
-    );
+    throw new Error(`[e2b] sandbox ${sandbox.sandboxId} has no private traffic access token`);
   }
   return sandbox.trafficAccessToken;
 }
@@ -129,8 +126,8 @@ async function ensureKortixEntrypoint(
   envs?: Record<string, string>,
 ): Promise<void> {
   const processes = await sandbox.commands.list({ requestTimeoutMs: 10_000 });
-  const alreadyRunning = processes.some(
-    (process) => `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_ENTRYPOINT),
+  const alreadyRunning = processes.some((process) =>
+    `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_ENTRYPOINT),
   );
   if (!alreadyRunning) {
     // The guest lock is the cross-process/cross-replica authority. Two API
@@ -159,8 +156,8 @@ async function ensureAppEntrypoint(
   envs: Record<string, string>,
 ): Promise<void> {
   const processes = await sandbox.commands.list({ requestTimeoutMs: 10_000 });
-  const alreadyRunning = processes.some(
-    (process) => `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_APPD),
+  const alreadyRunning = processes.some((process) =>
+    `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_APPD),
   );
   if (!alreadyRunning) {
     await sandbox.commands.run(KORTIX_APPD_COMMAND, {
@@ -201,8 +198,7 @@ export class E2BProvider implements SandboxProvider {
       );
     }
 
-    const sandboxApiBase = config.KORTIX_URL
-      .replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
     const envVars: Record<string, string> = {
@@ -256,7 +252,9 @@ export class E2BProvider implements SandboxProvider {
     } catch (error) {
       connectedSandboxes.delete(sandbox.sandboxId);
       await sandbox.kill({ requestTimeoutMs: 20_000 }).catch(() => false);
-      throw new Error(`[e2b] failed to launch Kortix entrypoint: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `[e2b] failed to launch Kortix entrypoint: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
 
     const externalId = sandbox.sandboxId;
@@ -292,6 +290,10 @@ export class E2BProvider implements SandboxProvider {
       connectedSandboxes.delete(externalId);
       throw error;
     }
+  }
+
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // E2B honors the image ENTRYPOINT and resumes the existing process tree.
   }
 
   async start(externalId: string): Promise<void> {
@@ -370,7 +372,10 @@ export class E2BProvider implements SandboxProvider {
 
   async resolveEndpoint(externalId: string): Promise<ResolvedEndpoint> {
     const ingress = await this.resolveIngress(externalId, { port: 8000, transport: 'http' });
-    const headers: Record<string, string> = { ...ingress.headers, 'Content-Type': 'application/json' };
+    const headers: Record<string, string> = {
+      ...ingress.headers,
+      'Content-Type': 'application/json',
+    };
     const serviceKey = await serviceKeyForExternalId(externalId).catch(() => null);
     if (serviceKey) headers.Authorization = `Bearer ${serviceKey}`;
     return { url: ingress.url, headers };
@@ -382,7 +387,9 @@ export class E2BProvider implements SandboxProvider {
     if (status === 'stopped') await this.start(externalId);
   }
 
-  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
+  async listManagedRunningSandboxes(): Promise<
+    Array<{ externalId: string; createdAt: Date | null }>
+  > {
     const paginator = Sandbox.list({
       ...apiOpts(),
       limit: 100,

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -196,6 +196,13 @@ export interface SandboxProvider {
 
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;
   /**
+   * Ensure the Kortix App supervisor is running after create or resume.
+   * Providers that honor the image ENTRYPOINT implement this as a no-op.
+   * Providers that replace ENTRYPOINT must start `/kortix/bin/kortix-appd`
+   * through their native process API. The operation must be idempotent.
+   */
+  ensureAppRuntimeStarted(externalId: string): Promise<void>;
+  /**
    * FIX-A: boot a sandbox from an EXACT provider template id (not a name). The
    * boot path uses this to honor a project's activated
    * `active_sandbox_external_template_id` pin, so the running sandbox is the

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -196,6 +196,13 @@ export interface SandboxProvider {
 
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;
   /**
+   * Ensure the Kortix App supervisor is running after create or resume.
+   * Providers that honor the image ENTRYPOINT implement this as a no-op.
+   * Providers that replace ENTRYPOINT must start `/kortix/bin/kortix-appd`
+   * through their native process API. The operation must be idempotent.
+   */
+  ensureAppRuntimeStarted(externalId: string): Promise<void>;
+  /**
    * FIX-A: boot a sandbox from an EXACT provider template id (not a name). The
    * boot path uses this to honor a project's activated
    * `active_sandbox_external_template_id` pin, so the running sandbox is the
@@ -207,7 +214,10 @@ export interface SandboxProvider {
    * so the caller can fall back to a name-boot; a transient 5xx throws a normal
    * (retryable) error and MUST NOT be turned into a name fallback.
    */
-  createFromExternalId?(externalTemplateId: string, opts: CreateSandboxOpts): Promise<ProvisionResult>;
+  createFromExternalId?(
+    externalTemplateId: string,
+    opts: CreateSandboxOpts,
+  ): Promise<ProvisionResult>;
   start(externalId: string): Promise<void>;
   stop(externalId: string): Promise<void>;
   remove(externalId: string): Promise<void>;
@@ -229,7 +239,10 @@ export interface SandboxProvider {
    * silently broke every other provider's runtime connection (502/503). Keeping
    * it on the interface makes that regression a compile error.
    */
-  resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress>;
+  resolveIngress(
+    externalId: string,
+    request: SandboxIngressRequest,
+  ): Promise<ResolvedSandboxIngress>;
   ensureRunning(externalId: string): Promise<void>;
   getProvisioningStatus(sandboxId: string): Promise<ProvisioningStatus | null>;
   /**

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -196,13 +196,6 @@ export interface SandboxProvider {
 
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;
   /**
-   * Ensure the Kortix App supervisor is running after create or resume.
-   * Providers that honor the image ENTRYPOINT implement this as a no-op.
-   * Providers that replace ENTRYPOINT must start `/kortix/bin/kortix-appd`
-   * through their native process API. The operation must be idempotent.
-   */
-  ensureAppRuntimeStarted(externalId: string): Promise<void>;
-  /**
    * FIX-A: boot a sandbox from an EXACT provider template id (not a name). The
    * boot path uses this to honor a project's activated
    * `active_sandbox_external_template_id` pin, so the running sandbox is the
@@ -214,10 +207,7 @@ export interface SandboxProvider {
    * so the caller can fall back to a name-boot; a transient 5xx throws a normal
    * (retryable) error and MUST NOT be turned into a name fallback.
    */
-  createFromExternalId?(
-    externalTemplateId: string,
-    opts: CreateSandboxOpts,
-  ): Promise<ProvisionResult>;
+  createFromExternalId?(externalTemplateId: string, opts: CreateSandboxOpts): Promise<ProvisionResult>;
   start(externalId: string): Promise<void>;
   stop(externalId: string): Promise<void>;
   remove(externalId: string): Promise<void>;
@@ -239,10 +229,7 @@ export interface SandboxProvider {
    * silently broke every other provider's runtime connection (502/503). Keeping
    * it on the interface makes that regression a compile error.
    */
-  resolveIngress(
-    externalId: string,
-    request: SandboxIngressRequest,
-  ): Promise<ResolvedSandboxIngress>;
+  resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress>;
   ensureRunning(externalId: string): Promise<void>;
   getProvisioningStatus(sandboxId: string): Promise<ProvisioningStatus | null>;
   /**

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -336,6 +336,10 @@ export class LocalDockerProvider implements SandboxProvider {
     };
   }
 
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // Docker starts the image ENTRYPOINT on create and container restart.
+  }
+
   async start(externalId: string): Promise<void> {
     const docker = getDockerClient();
     await assertDockerReachable(docker);

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -65,10 +65,7 @@ const DEFAULT_MEMORY_GB = Number.parseFloat(process.env.LOCAL_DOCKER_MEMORY_GB |
 // daytona.ts's managedSandboxLabels() exactly — the reaper's
 // listManagedRunningSandboxes() scoping logic is provider-agnostic and reads
 // the SAME two labels regardless of provider.
-function managedLabels(
-  externalId: string,
-  workloadType: 'session' | 'app',
-): Record<string, string> {
+function managedLabels(externalId: string, workloadType: 'session' | 'app'): Record<string, string> {
   return {
     'kortix.managed': 'true',
     'kortix.env': config.INTERNAL_KORTIX_ENV,
@@ -136,9 +133,9 @@ async function assertDockerReachable(docker: Docker): Promise<void> {
     const detail = err instanceof Error ? err.message : String(err);
     throw new Error(
       `[local-docker] Docker daemon is not reachable (${detail}). The local-docker sandbox ` +
-        `provider requires the host's Docker socket mounted into kortix-api (self-host: select ` +
-        `"local-docker" at \`kortix self-host init\`, which wires this automatically) — or, ` +
-        `outside self-host, set LOCAL_DOCKER_SOCKET_PATH / DOCKER_HOST to a reachable Docker Engine.`,
+      `provider requires the host's Docker socket mounted into kortix-api (self-host: select ` +
+      `"local-docker" at \`kortix self-host init\`, which wires this automatically) — or, ` +
+      `outside self-host, set LOCAL_DOCKER_SOCKET_PATH / DOCKER_HOST to a reachable Docker Engine.`,
     );
   }
 }
@@ -192,8 +189,7 @@ function isMissingContainerError(err: unknown): boolean {
 function toStatus(info: Docker.ContainerInspectInfo): SandboxStatus {
   const state = info.State;
   if (state?.Running) return 'running';
-  if (state?.Status === 'exited' || state?.Status === 'created' || state?.Status === 'dead')
-    return 'stopped';
+  if (state?.Status === 'exited' || state?.Status === 'created' || state?.Status === 'dead') return 'stopped';
   return 'unknown';
 }
 
@@ -208,7 +204,9 @@ export class LocalDockerProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [{ id: 'creating', progress: 50, message: 'Starting local container...' }],
+    stages: [
+      { id: 'creating', progress: 50, message: 'Starting local container...' },
+    ],
   };
 
   /**
@@ -236,7 +234,7 @@ export class LocalDockerProvider implements SandboxProvider {
     if (!snapshot) {
       throw new Error(
         'local-docker create() called without opts.snapshot. Every sandbox must boot from a ' +
-          'per-project image built by apps/api/src/snapshots/builder.ts. There is no shared fallback.',
+        'per-project image built by apps/api/src/snapshots/builder.ts. There is no shared fallback.',
       );
     }
     assertWorkloadCredential(this.name, opts, opts.envVars ?? {});
@@ -280,9 +278,9 @@ export class LocalDockerProvider implements SandboxProvider {
     }
     const env = Object.entries(envVars).map(([k, v]) => `${k}=${v}`);
 
-    const publishedPorts = Array.from(
-      new Set(opts.publishedPorts ?? (workloadType === 'app' ? [7331, 8080] : [AGENT_PORT])),
-    );
+    const publishedPorts = Array.from(new Set(
+      opts.publishedPorts ?? (workloadType === 'app' ? [7331, 8080] : [AGENT_PORT]),
+    ));
     const exposedPorts = Object.fromEntries(publishedPorts.map((port) => [`${port}/tcp`, {}]));
     const portBindings = Object.fromEntries(
       publishedPorts.map((port) => [`${port}/tcp`, [{ HostIp: '127.0.0.1', HostPort: '0' }]]),
@@ -338,10 +336,6 @@ export class LocalDockerProvider implements SandboxProvider {
     };
   }
 
-  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
-    // Docker starts the image ENTRYPOINT on create and container restart.
-  }
-
   async start(externalId: string): Promise<void> {
     const docker = getDockerClient();
     await assertDockerReachable(docker);
@@ -389,10 +383,7 @@ export class LocalDockerProvider implements SandboxProvider {
     }
   }
 
-  async resolveIngress(
-    externalId: string,
-    request: SandboxIngressRequest,
-  ): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
     // `pnpm worktree` runs kortix-api directly on the macOS host. The host
     // cannot resolve a container name from Docker's private DNS, so use the
     // loopback-only published port in that explicit development mode. Inspect
@@ -461,9 +452,7 @@ export class LocalDockerProvider implements SandboxProvider {
    * cross-provider logic uniform (and safe if a laptop ever runs two
    * kortix-api instances against the same daemon, e.g. dev + a worktree).
    */
-  async listManagedRunningSandboxes(): Promise<
-    Array<{ externalId: string; createdAt: Date | null }>
-  > {
+  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
     const docker = getDockerClient();
     await assertDockerReachable(docker);
     const containers = await docker.listContainers({
@@ -473,10 +462,7 @@ export class LocalDockerProvider implements SandboxProvider {
       }),
     });
     return containers.map((c) => ({
-      externalId:
-        c.Labels?.['kortix.sandbox'] ||
-        c.Names?.[0]?.replace(/^\//, '').replace(CONTAINER_PREFIX, '') ||
-        c.Id,
+      externalId: c.Labels?.['kortix.sandbox'] || c.Names?.[0]?.replace(/^\//, '').replace(CONTAINER_PREFIX, '') || c.Id,
       createdAt: c.Created ? new Date(c.Created * 1000) : null,
     }));
   }

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -65,7 +65,10 @@ const DEFAULT_MEMORY_GB = Number.parseFloat(process.env.LOCAL_DOCKER_MEMORY_GB |
 // daytona.ts's managedSandboxLabels() exactly — the reaper's
 // listManagedRunningSandboxes() scoping logic is provider-agnostic and reads
 // the SAME two labels regardless of provider.
-function managedLabels(externalId: string, workloadType: 'session' | 'app'): Record<string, string> {
+function managedLabels(
+  externalId: string,
+  workloadType: 'session' | 'app',
+): Record<string, string> {
   return {
     'kortix.managed': 'true',
     'kortix.env': config.INTERNAL_KORTIX_ENV,
@@ -133,9 +136,9 @@ async function assertDockerReachable(docker: Docker): Promise<void> {
     const detail = err instanceof Error ? err.message : String(err);
     throw new Error(
       `[local-docker] Docker daemon is not reachable (${detail}). The local-docker sandbox ` +
-      `provider requires the host's Docker socket mounted into kortix-api (self-host: select ` +
-      `"local-docker" at \`kortix self-host init\`, which wires this automatically) — or, ` +
-      `outside self-host, set LOCAL_DOCKER_SOCKET_PATH / DOCKER_HOST to a reachable Docker Engine.`,
+        `provider requires the host's Docker socket mounted into kortix-api (self-host: select ` +
+        `"local-docker" at \`kortix self-host init\`, which wires this automatically) — or, ` +
+        `outside self-host, set LOCAL_DOCKER_SOCKET_PATH / DOCKER_HOST to a reachable Docker Engine.`,
     );
   }
 }
@@ -189,7 +192,8 @@ function isMissingContainerError(err: unknown): boolean {
 function toStatus(info: Docker.ContainerInspectInfo): SandboxStatus {
   const state = info.State;
   if (state?.Running) return 'running';
-  if (state?.Status === 'exited' || state?.Status === 'created' || state?.Status === 'dead') return 'stopped';
+  if (state?.Status === 'exited' || state?.Status === 'created' || state?.Status === 'dead')
+    return 'stopped';
   return 'unknown';
 }
 
@@ -204,9 +208,7 @@ export class LocalDockerProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [
-      { id: 'creating', progress: 50, message: 'Starting local container...' },
-    ],
+    stages: [{ id: 'creating', progress: 50, message: 'Starting local container...' }],
   };
 
   /**
@@ -234,7 +236,7 @@ export class LocalDockerProvider implements SandboxProvider {
     if (!snapshot) {
       throw new Error(
         'local-docker create() called without opts.snapshot. Every sandbox must boot from a ' +
-        'per-project image built by apps/api/src/snapshots/builder.ts. There is no shared fallback.',
+          'per-project image built by apps/api/src/snapshots/builder.ts. There is no shared fallback.',
       );
     }
     assertWorkloadCredential(this.name, opts, opts.envVars ?? {});
@@ -278,9 +280,9 @@ export class LocalDockerProvider implements SandboxProvider {
     }
     const env = Object.entries(envVars).map(([k, v]) => `${k}=${v}`);
 
-    const publishedPorts = Array.from(new Set(
-      opts.publishedPorts ?? (workloadType === 'app' ? [7331, 8080] : [AGENT_PORT]),
-    ));
+    const publishedPorts = Array.from(
+      new Set(opts.publishedPorts ?? (workloadType === 'app' ? [7331, 8080] : [AGENT_PORT])),
+    );
     const exposedPorts = Object.fromEntries(publishedPorts.map((port) => [`${port}/tcp`, {}]));
     const portBindings = Object.fromEntries(
       publishedPorts.map((port) => [`${port}/tcp`, [{ HostIp: '127.0.0.1', HostPort: '0' }]]),
@@ -336,6 +338,10 @@ export class LocalDockerProvider implements SandboxProvider {
     };
   }
 
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // Docker starts the image ENTRYPOINT on create and container restart.
+  }
+
   async start(externalId: string): Promise<void> {
     const docker = getDockerClient();
     await assertDockerReachable(docker);
@@ -383,7 +389,10 @@ export class LocalDockerProvider implements SandboxProvider {
     }
   }
 
-  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(
+    externalId: string,
+    request: SandboxIngressRequest,
+  ): Promise<ResolvedSandboxIngress> {
     // `pnpm worktree` runs kortix-api directly on the macOS host. The host
     // cannot resolve a container name from Docker's private DNS, so use the
     // loopback-only published port in that explicit development mode. Inspect
@@ -452,7 +461,9 @@ export class LocalDockerProvider implements SandboxProvider {
    * cross-provider logic uniform (and safe if a laptop ever runs two
    * kortix-api instances against the same daemon, e.g. dev + a worktree).
    */
-  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
+  async listManagedRunningSandboxes(): Promise<
+    Array<{ externalId: string; createdAt: Date | null }>
+  > {
     const docker = getDockerClient();
     await assertDockerReachable(docker);
     const containers = await docker.listContainers({
@@ -462,7 +473,10 @@ export class LocalDockerProvider implements SandboxProvider {
       }),
     });
     return containers.map((c) => ({
-      externalId: c.Labels?.['kortix.sandbox'] || c.Names?.[0]?.replace(/^\//, '').replace(CONTAINER_PREFIX, '') || c.Id,
+      externalId:
+        c.Labels?.['kortix.sandbox'] ||
+        c.Names?.[0]?.replace(/^\//, '').replace(CONTAINER_PREFIX, '') ||
+        c.Id,
       createdAt: c.Created ? new Date(c.Created * 1000) : null,
     }));
   }

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -266,6 +266,11 @@ export class PlatinumProvider implements SandboxProvider {
     };
   }
 
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // Platinum honors the image ENTRYPOINT on create and resumes its process
+    // tree on wake. appd is therefore already running.
+  }
+
   async start(externalId: string): Promise<void> {
     await platinumJson(`/v1/sandboxes/${externalId}/start`, { method: 'POST' });
   }

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -86,9 +86,7 @@ export class PlatinumProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [
-      { id: 'creating', progress: 50, message: 'Creating sandbox...' },
-    ],
+    stages: [{ id: 'creating', progress: 50, message: 'Creating sandbox...' }],
   };
 
   async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
@@ -104,7 +102,7 @@ export class PlatinumProvider implements SandboxProvider {
     if (!template) {
       throw new Error(
         'Platinum create() has no template: pass opts.snapshot or set PLATINUM_TEMPLATE ' +
-        '(a ready Platinum template id, e.g. kortix-computer).',
+          '(a ready Platinum template id, e.g. kortix-computer).',
       );
     }
     return this.provisionFromTemplate(template, opts);
@@ -118,7 +116,10 @@ export class PlatinumProvider implements SandboxProvider {
    * boot path can fall back to a name-boot; a transient 5xx (or any other error)
    * propagates UNCHANGED so it is surfaced/retried, never silently name-booted.
    */
-  async createFromExternalId(externalTemplateId: string, opts: CreateSandboxOpts): Promise<ProvisionResult> {
+  async createFromExternalId(
+    externalTemplateId: string,
+    opts: CreateSandboxOpts,
+  ): Promise<ProvisionResult> {
     if (!externalTemplateId || externalTemplateId.trim() === '') {
       throw new Error('[platinum] createFromExternalId called without a template id');
     }
@@ -134,10 +135,12 @@ export class PlatinumProvider implements SandboxProvider {
     }
   }
 
-  private async provisionFromTemplate(template: string, opts: CreateSandboxOpts): Promise<ProvisionResult> {
+  private async provisionFromTemplate(
+    template: string,
+    opts: CreateSandboxOpts,
+  ): Promise<ProvisionResult> {
     const workloadType = sandboxWorkloadType(opts);
-    const sandboxApiBase = config.KORTIX_URL
-      .replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
 
@@ -223,13 +226,19 @@ export class PlatinumProvider implements SandboxProvider {
     let exposedUrl = '';
     const _tExpose0 = Date.now();
     try {
-      const exposed = await platinumJson<PlatinumExposedPort>(`/v1/sandboxes/${externalId}/expose`, {
-        method: 'POST',
-        body: JSON.stringify({ port: ingressPort, public: true }),
-      });
+      const exposed = await platinumJson<PlatinumExposedPort>(
+        `/v1/sandboxes/${externalId}/expose`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ port: ingressPort, public: true }),
+        },
+      );
       exposedUrl = (exposed.url ?? '').replace(/\/$/, '');
     } catch (err) {
-      console.warn(`[platinum] eager expose ${externalId}:${AGENT_PORT} failed (lazy fallback):`, err);
+      console.warn(
+        `[platinum] eager expose ${externalId}:${AGENT_PORT} failed (lazy fallback):`,
+        err,
+      );
     }
     const _exposeMs = Date.now() - _tExpose0;
 
@@ -250,7 +259,7 @@ export class PlatinumProvider implements SandboxProvider {
     // becomes usable without any create-path hang.
     console.log(
       `[platinum-timing] ${externalId} vm-running=${_vmMs}ms expose=${_exposeMs}ms ` +
-      `edge=${exposedUrl ? 'ready' : 'lazy'} total=${Date.now() - _t0}ms (runtime-ready deferred to FE poll, like daytona)`,
+        `edge=${exposedUrl ? 'ready' : 'lazy'} total=${Date.now() - _t0}ms (runtime-ready deferred to FE poll, like daytona)`,
     );
 
     return {
@@ -264,6 +273,11 @@ export class PlatinumProvider implements SandboxProvider {
         workloadType,
       },
     };
+  }
+
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // Platinum honors the image ENTRYPOINT on create and resumes its process
+    // tree on wake. appd is therefore already running.
   }
 
   async start(externalId: string): Promise<void> {
@@ -330,18 +344,22 @@ export class PlatinumProvider implements SandboxProvider {
     return 'recovering';
   }
 
-  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(
+    externalId: string,
+    request: SandboxIngressRequest,
+  ): Promise<ResolvedSandboxIngress> {
     const route = this.routeIngress(request);
     const effectivePort = route.effectivePort;
     // Expose the requested port through Platinum's edge → https://<port>-<id>.sbx…
     // No preview token: the sandbox is gated by the serviceKey bearer the proxy
     // already adds. Idempotent — re-exposing returns the same URL.
-    const exposed = await platinumJson<PlatinumExposedPort>(
-      `/v1/sandboxes/${externalId}/expose`,
-      { method: 'POST', body: JSON.stringify({ port: effectivePort, public: true }) },
-    );
+    const exposed = await platinumJson<PlatinumExposedPort>(`/v1/sandboxes/${externalId}/expose`, {
+      method: 'POST',
+      body: JSON.stringify({ port: effectivePort, public: true }),
+    });
     const url = (exposed.url ?? '').replace(/\/$/, '');
-    if (!url) throw new Error(`[platinum] expose returned no URL for ${externalId}:${effectivePort}`);
+    if (!url)
+      throw new Error(`[platinum] expose returned no URL for ${externalId}:${effectivePort}`);
     return {
       url,
       headers: {},
@@ -375,7 +393,10 @@ export class PlatinumProvider implements SandboxProvider {
     // {url,port,...} — the array {expose:[...]} shape is only valid on the
     // create route's inline expose. Sending the array here 400s.
     const ingress = await this.resolveIngress(externalId, { port: AGENT_PORT, transport: 'http' });
-    const headers: Record<string, string> = { ...ingress.headers, 'Content-Type': 'application/json' };
+    const headers: Record<string, string> = {
+      ...ingress.headers,
+      'Content-Type': 'application/json',
+    };
     try {
       const serviceKey = await serviceKeyForExternalId(externalId);
       if (serviceKey) headers['Authorization'] = `Bearer ${serviceKey}`;

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -86,7 +86,9 @@ export class PlatinumProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [{ id: 'creating', progress: 50, message: 'Creating sandbox...' }],
+    stages: [
+      { id: 'creating', progress: 50, message: 'Creating sandbox...' },
+    ],
   };
 
   async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
@@ -102,7 +104,7 @@ export class PlatinumProvider implements SandboxProvider {
     if (!template) {
       throw new Error(
         'Platinum create() has no template: pass opts.snapshot or set PLATINUM_TEMPLATE ' +
-          '(a ready Platinum template id, e.g. kortix-computer).',
+        '(a ready Platinum template id, e.g. kortix-computer).',
       );
     }
     return this.provisionFromTemplate(template, opts);
@@ -116,10 +118,7 @@ export class PlatinumProvider implements SandboxProvider {
    * boot path can fall back to a name-boot; a transient 5xx (or any other error)
    * propagates UNCHANGED so it is surfaced/retried, never silently name-booted.
    */
-  async createFromExternalId(
-    externalTemplateId: string,
-    opts: CreateSandboxOpts,
-  ): Promise<ProvisionResult> {
+  async createFromExternalId(externalTemplateId: string, opts: CreateSandboxOpts): Promise<ProvisionResult> {
     if (!externalTemplateId || externalTemplateId.trim() === '') {
       throw new Error('[platinum] createFromExternalId called without a template id');
     }
@@ -135,12 +134,10 @@ export class PlatinumProvider implements SandboxProvider {
     }
   }
 
-  private async provisionFromTemplate(
-    template: string,
-    opts: CreateSandboxOpts,
-  ): Promise<ProvisionResult> {
+  private async provisionFromTemplate(template: string, opts: CreateSandboxOpts): Promise<ProvisionResult> {
     const workloadType = sandboxWorkloadType(opts);
-    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL
+      .replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
 
@@ -226,19 +223,13 @@ export class PlatinumProvider implements SandboxProvider {
     let exposedUrl = '';
     const _tExpose0 = Date.now();
     try {
-      const exposed = await platinumJson<PlatinumExposedPort>(
-        `/v1/sandboxes/${externalId}/expose`,
-        {
-          method: 'POST',
-          body: JSON.stringify({ port: ingressPort, public: true }),
-        },
-      );
+      const exposed = await platinumJson<PlatinumExposedPort>(`/v1/sandboxes/${externalId}/expose`, {
+        method: 'POST',
+        body: JSON.stringify({ port: ingressPort, public: true }),
+      });
       exposedUrl = (exposed.url ?? '').replace(/\/$/, '');
     } catch (err) {
-      console.warn(
-        `[platinum] eager expose ${externalId}:${AGENT_PORT} failed (lazy fallback):`,
-        err,
-      );
+      console.warn(`[platinum] eager expose ${externalId}:${AGENT_PORT} failed (lazy fallback):`, err);
     }
     const _exposeMs = Date.now() - _tExpose0;
 
@@ -259,7 +250,7 @@ export class PlatinumProvider implements SandboxProvider {
     // becomes usable without any create-path hang.
     console.log(
       `[platinum-timing] ${externalId} vm-running=${_vmMs}ms expose=${_exposeMs}ms ` +
-        `edge=${exposedUrl ? 'ready' : 'lazy'} total=${Date.now() - _t0}ms (runtime-ready deferred to FE poll, like daytona)`,
+      `edge=${exposedUrl ? 'ready' : 'lazy'} total=${Date.now() - _t0}ms (runtime-ready deferred to FE poll, like daytona)`,
     );
 
     return {
@@ -273,11 +264,6 @@ export class PlatinumProvider implements SandboxProvider {
         workloadType,
       },
     };
-  }
-
-  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
-    // Platinum honors the image ENTRYPOINT on create and resumes its process
-    // tree on wake. appd is therefore already running.
   }
 
   async start(externalId: string): Promise<void> {
@@ -344,22 +330,18 @@ export class PlatinumProvider implements SandboxProvider {
     return 'recovering';
   }
 
-  async resolveIngress(
-    externalId: string,
-    request: SandboxIngressRequest,
-  ): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
     const route = this.routeIngress(request);
     const effectivePort = route.effectivePort;
     // Expose the requested port through Platinum's edge → https://<port>-<id>.sbx…
     // No preview token: the sandbox is gated by the serviceKey bearer the proxy
     // already adds. Idempotent — re-exposing returns the same URL.
-    const exposed = await platinumJson<PlatinumExposedPort>(`/v1/sandboxes/${externalId}/expose`, {
-      method: 'POST',
-      body: JSON.stringify({ port: effectivePort, public: true }),
-    });
+    const exposed = await platinumJson<PlatinumExposedPort>(
+      `/v1/sandboxes/${externalId}/expose`,
+      { method: 'POST', body: JSON.stringify({ port: effectivePort, public: true }) },
+    );
     const url = (exposed.url ?? '').replace(/\/$/, '');
-    if (!url)
-      throw new Error(`[platinum] expose returned no URL for ${externalId}:${effectivePort}`);
+    if (!url) throw new Error(`[platinum] expose returned no URL for ${externalId}:${effectivePort}`);
     return {
       url,
       headers: {},
@@ -393,10 +375,7 @@ export class PlatinumProvider implements SandboxProvider {
     // {url,port,...} — the array {expose:[...]} shape is only valid on the
     // create route's inline expose. Sending the array here 400s.
     const ingress = await this.resolveIngress(externalId, { port: AGENT_PORT, transport: 'http' });
-    const headers: Record<string, string> = {
-      ...ingress.headers,
-      'Content-Type': 'application/json',
-    };
+    const headers: Record<string, string> = { ...ingress.headers, 'Content-Type': 'application/json' };
     try {
       const serviceKey = await serviceKeyForExternalId(externalId);
       if (serviceKey) headers['Authorization'] = `Bearer ${serviceKey}`;

--- a/apps/api/src/projects/lib/warm-session-refresh.test.ts
+++ b/apps/api/src/projects/lib/warm-session-refresh.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test';
+import { prepareReusedWarmSession } from './warm-session-refresh';
+
+const project = {
+  projectId: 'project-1',
+  repoUrl: 'https://git.example.test/project-1.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+};
+
+const workspace = {
+  status: 'updated' as const,
+  before_sha: 'before',
+  after_sha: 'after',
+};
+
+describe('prepareReusedWarmSession', () => {
+  test('updates the compiled config after refreshing a reused workspace', async () => {
+    const calls: string[] = [];
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => {
+          calls.push('workspace');
+          return workspace;
+        },
+        readRunningConfig: async () => {
+          calls.push('running');
+          return { etag: 'old', reachable: true };
+        },
+        readLatestConfig: async () => {
+          calls.push('latest');
+          return 'new';
+        },
+        pushConfig: async () => {
+          calls.push('push');
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(calls[0]).toBe('workspace');
+    expect(new Set(calls.slice(1, 3))).toEqual(new Set(['running', 'latest']));
+    expect(calls[3]).toBe('push');
+    expect(result).toEqual({
+      workspace,
+      config: { status: 'updated', previous_etag: 'old', latest_etag: 'new' },
+    });
+  });
+
+  test('does not restart a warm runtime that already has the current config', async () => {
+    let pushed = false;
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => ({ status: 'unchanged' }),
+        readRunningConfig: async () => ({ etag: 'same', reachable: true }),
+        readLatestConfig: async () => 'same',
+        pushConfig: async () => {
+          pushed = true;
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(pushed).toBe(false);
+    expect(result.config).toEqual({
+      status: 'current',
+      previous_etag: 'same',
+      latest_etag: 'same',
+    });
+  });
+
+  test('updates a legacy warm runtime that cannot report its running etag', async () => {
+    let pushed = false;
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => ({ status: 'unchanged' }),
+        readRunningConfig: async () => ({ etag: null, reachable: true }),
+        readLatestConfig: async () => 'latest',
+        pushConfig: async () => {
+          pushed = true;
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(pushed).toBe(true);
+    expect(result.config.status).toBe('updated');
+  });
+
+  test('does not report a problem while a warm runtime is still provisioning', async () => {
+    let pushed = false;
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => ({ status: 'skipped' }),
+        readRunningConfig: async () => ({ etag: null, reachable: false }),
+        readLatestConfig: async () => 'latest',
+        pushConfig: async () => {
+          pushed = true;
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(pushed).toBe(false);
+    expect(result.config).toEqual({ status: 'unavailable' });
+  });
+
+  test('does not push anything when the project has no compiled config', async () => {
+    let pushed = false;
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => ({ status: 'unchanged' }),
+        readRunningConfig: async () => ({ etag: null, reachable: true }),
+        readLatestConfig: async () => null,
+        pushConfig: async () => {
+          pushed = true;
+          return { applied: true };
+        },
+      },
+    );
+
+    expect(pushed).toBe(false);
+    expect(result.config).toEqual({ status: 'not-applicable' });
+  });
+
+  test('reports a failed config push without hiding the workspace result', async () => {
+    const result = await prepareReusedWarmSession(
+      { project, accountId: 'account-1', sessionId: 'session-1' },
+      {
+        refreshWorkspace: async () => workspace,
+        readRunningConfig: async () => ({ etag: 'old', reachable: true }),
+        readLatestConfig: async () => 'new',
+        pushConfig: async () => ({
+          applied: false,
+          reason: 'runtime unavailable',
+        }),
+      },
+    );
+
+    expect(result).toEqual({
+      workspace,
+      config: { status: 'failed', reason: 'runtime unavailable' },
+    });
+  });
+});

--- a/apps/api/src/projects/lib/warm-session-refresh.ts
+++ b/apps/api/src/projects/lib/warm-session-refresh.ts
@@ -1,0 +1,120 @@
+import type { GitBackedProject } from '../git';
+import {
+  latestAgentConfigEtag,
+  readSandboxConfigState,
+} from './session-reload';
+import { pushSessionAgentConfigToSandbox } from './sandbox-env-sync';
+import {
+  refreshWarmSessionWorkspace,
+  type WarmSessionWorkspaceRefresh,
+} from './warm-session-workspace';
+
+export type WarmSessionConfigRefresh =
+  | { status: 'current'; previous_etag: string; latest_etag: string }
+  | { status: 'updated'; previous_etag: string | null; latest_etag: string }
+  | { status: 'unavailable' | 'not-applicable' }
+  | { status: 'failed'; reason: string };
+
+interface WarmSessionRefreshDependencies {
+  refreshWorkspace: (
+    project: GitBackedProject,
+    sessionId: string,
+  ) => Promise<WarmSessionWorkspaceRefresh>;
+  readRunningConfig: (sessionId: string) => Promise<{
+    etag: string | null;
+    reachable: boolean;
+  }>;
+  readLatestConfig: (input: {
+    projectId: string;
+    accountId: string;
+    baseRef: string;
+  }) => Promise<string | null>;
+  pushConfig: (input: {
+    projectId: string;
+    sessionId: string;
+    repoUrl: string;
+    defaultBranch: string;
+    manifestPath?: string | null;
+    baseRef: string;
+  }) => Promise<{ applied: boolean; reason?: string }>;
+}
+
+const defaultDependencies: WarmSessionRefreshDependencies = {
+  refreshWorkspace: refreshWarmSessionWorkspace,
+  readRunningConfig: async (sessionId) => readSandboxConfigState({ sessionId }),
+  readLatestConfig: latestAgentConfigEtag,
+  pushConfig: pushSessionAgentConfigToSandbox,
+};
+
+/**
+ * Prepare an unused warm session for display and claim.
+ *
+ * A warm session can sit ready while the project's agent config changes. The
+ * workspace refresh already moves its pristine checkout to the latest base.
+ * The compiled config lives in the runtime environment, so it needs a separate
+ * push. The session is still unclaimed here, which makes this the only safe
+ * time to restart its runtime without interrupting user work.
+ */
+export async function prepareReusedWarmSession(
+  input: {
+    project: GitBackedProject;
+    accountId: string;
+    sessionId: string;
+  },
+  dependencies: WarmSessionRefreshDependencies = defaultDependencies,
+): Promise<{
+  workspace: WarmSessionWorkspaceRefresh;
+  config: WarmSessionConfigRefresh;
+}> {
+  const workspace = await dependencies.refreshWorkspace(
+    input.project,
+    input.sessionId,
+  );
+  const [running, latest] = await Promise.all([
+    dependencies.readRunningConfig(input.sessionId),
+    dependencies.readLatestConfig({
+      projectId: input.project.projectId,
+      accountId: input.accountId,
+      baseRef: input.project.defaultBranch,
+    }),
+  ]);
+
+  if (!running.reachable) return { workspace, config: { status: 'unavailable' } };
+  if (!latest) return { workspace, config: { status: 'not-applicable' } };
+  if (running.etag === latest) {
+    return {
+      workspace,
+      config: {
+        status: 'current',
+        previous_etag: running.etag,
+        latest_etag: latest,
+      },
+    };
+  }
+
+  const pushed = await dependencies.pushConfig({
+    projectId: input.project.projectId,
+    sessionId: input.sessionId,
+    repoUrl: input.project.repoUrl,
+    defaultBranch: input.project.defaultBranch,
+    manifestPath: input.project.manifestPath,
+    baseRef: input.project.defaultBranch,
+  });
+  if (!pushed.applied) {
+    return {
+      workspace,
+      config: {
+        status: 'failed',
+        reason: pushed.reason ?? 'config push did not apply',
+      },
+    };
+  }
+  return {
+    workspace,
+    config: {
+      status: 'updated',
+      previous_etag: running.etag,
+      latest_etag: latest,
+    },
+  };
+}

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -60,7 +60,7 @@ import {
   findAvailableWarmProjectSession,
   withWarmProjectSessionLock,
 } from '../lib/warm-session-store';
-import { refreshWarmSessionWorkspace } from '../lib/warm-session-workspace';
+import { prepareReusedWarmSession } from '../lib/warm-session-refresh';
 import {
   createWarmProjectSessionCoordinator,
   WarmProjectSessionError,
@@ -353,12 +353,23 @@ projectsApp.openapi(
           return sendSessionCreateError(c, requiredConnectionError(missing));
         }
       }
-      const workspaceRefresh = ensured.reused
-        ? await refreshWarmSessionWorkspace(
-            loaded.row,
-            ensured.session.sessionId,
-          )
-        : { status: 'skipped' as const };
+      const warmRefresh = ensured.reused
+        ? await prepareReusedWarmSession({
+            project: loaded.row,
+            accountId: loaded.row.accountId,
+            sessionId: ensured.session.sessionId,
+          })
+        : {
+            workspace: { status: 'skipped' as const },
+            config: { status: 'current' as const },
+          };
+      if (warmRefresh.config.status === 'failed') {
+        console.warn('[warm-session] failed to update compiled agent config', {
+          projectId,
+          sessionId: ensured.session.sessionId,
+          reason: warmRefresh.config.reason,
+        });
+      }
       return c.json(
         {
           session: serializeSession(ensured.session, {
@@ -366,7 +377,7 @@ projectsApp.openapi(
             canManageProject: roleAllows(loaded.effectiveRole, 'manage'),
           }),
           reused: ensured.reused,
-          workspace_refresh: workspaceRefresh,
+          workspace_refresh: warmRefresh.workspace,
         },
         200,
       );

--- a/apps/web/src/features/session/header/session-config-indicator.test.tsx
+++ b/apps/web/src/features/session/header/session-config-indicator.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const source = readFileSync(
+  fileURLToPath(new URL('./session-config-indicator.tsx', import.meta.url)),
+  'utf8',
+);
+
+describe('SessionConfigIndicator notification level', () => {
+  test('keeps stale config in the header instead of opening a persistent toast', () => {
+    expect(source).toContain('<Popover');
+    expect(source).not.toContain("warningToast('Agent config is out of date'");
+    expect(source).not.toContain('duration: Number.POSITIVE_INFINITY');
+  });
+});

--- a/apps/web/src/features/session/header/session-config-indicator.tsx
+++ b/apps/web/src/features/session/header/session-config-indicator.tsx
@@ -26,10 +26,8 @@ import {
   type ReloadBusyReason,
   useSessionConfigFreshness,
 } from '@/hooks/projects/use-session-config-freshness';
-import { dismissToast, warningToast } from '@/components/ui/toast';
-import { cn } from '@/lib/utils';
 import { ArrowsClockwiseIcon } from '@phosphor-icons/react';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 /** The server's two refusals, as something a person would actually read. */
 const BUSY_COPY: Record<ReloadBusyReason, { title: string; body: string; tail: string }> = {
@@ -62,58 +60,12 @@ export function SessionConfigIndicator({
   const { notice } = useSessionConfigFreshness(projectId, sessionId);
   const [open, setOpen] = useState(false);
 
-  const stale = notice.kind === 'stale';
-
-  // A toast as well as the chip, because the chip alone was not found.
-  //
-  // The chip is correct and stays — it is the durable, always-available
-  // affordance, and it is where you look once you know the concept exists. But
-  // it is an icon in a header, and a session that silently runs the wrong agent
-  // is exactly the case where the user does NOT already know to look. So the
-  // arrival of staleness also gets announced once, where new information
-  // belongs.
-  //
-  // Announced ONCE per distinct config version, not once per render and not
-  // again after dismissal: `shownFor` keys on the etag pair, so re-checks of the
-  // same staleness stay quiet and only a genuinely newer config speaks up again.
-  // Persistent (`Infinity`) because it reports a condition, not an event — it
-  // stays true until acted on — and `warningToast` already carries its own close
-  // button, so it is dismissible without being self-dismissing.
-  const toastId = `session-config-stale-${sessionId}`;
-  const shownFor = useRef<string | null>(null);
-  useEffect(() => {
-    if (notice.kind !== 'stale') {
-      // Retract on the way out. After a successful reload the condition is gone,
-      // and a lingering card offering to fix it would be worse than no card.
-      if (shownFor.current !== null) {
-        shownFor.current = null;
-        dismissToast(toastId);
-      }
-      return;
-    }
-    const version = `${notice.running}->${notice.latest}`;
-    if (shownFor.current === version) return;
-    shownFor.current = version;
-    warningToast('Agent config is out of date', {
-      id: toastId,
-      description:
-        'This session is running an older version of the agent config. Your commits and other files are untouched.',
-      duration: Number.POSITIVE_INFINITY,
-      button: (
-        <Button size="sm" disabled={!canReload || isPending} onClick={() => reload()}>
-          {isPending ? <Loading className="size-4 shrink-0" /> : null}
-          Reload config
-        </Button>
-      ),
-    });
-  }, [notice, toastId, reload, canReload, isPending]);
-
   // The confirm is rendered by the header, not here — see `SessionConfigReloadConfirm`.
   // This component may vanish the moment a reload lands, and a dialog that
   // unmounts mid-question is worse than no dialog.
   if (notice.kind === 'hidden') return null;
 
-  const label = stale ? 'Agent config is out of date' : "Can't confirm the agent config";
+  const label = 'Agent config update available';
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -123,12 +75,7 @@ export function SessionConfigIndicator({
             <span className="relative inline-flex">
               <ArrowsClockwiseIcon className="text-foreground size-4" />
               <span
-                className={cn(
-                  'ring-background absolute -top-1 -right-1 size-2 rounded-full ring-2',
-                  // Orange is "needs attention"; a session we merely could not
-                  // ask about has not done anything wrong, so it stays neutral.
-                  stale ? 'bg-kortix-orange' : 'bg-muted-foreground',
-                )}
+                className="ring-background bg-kortix-orange absolute -top-1 -right-1 size-2 rounded-full ring-2"
                 aria-hidden
               />
             </span>
@@ -139,18 +86,7 @@ export function SessionConfigIndicator({
       <PopoverContent align="end" sideOffset={8} className="w-[320px] overflow-hidden p-0">
         <div className="border-border border-b px-4 pt-4 pb-3">
           <div className="flex items-center gap-2.5">
-            <span
-              className={cn(
-                'flex size-8 shrink-0 items-center justify-center rounded-md',
-                // Spelled literally rather than via STATUS_BG/STATUS_TEXT:
-                // those pair a kortix-yellow fill with a raw amber foreground,
-                // which is both off-token and a different colour from every
-                // other "needs attention" surface in the app.
-                stale
-                  ? 'bg-kortix-orange/10 text-kortix-orange'
-                  : 'text-muted-foreground border-border border',
-              )}
-            >
+            <span className="bg-kortix-orange/10 text-kortix-orange flex size-8 shrink-0 items-center justify-center rounded-md">
               <ArrowsClockwiseIcon className="size-4" />
             </span>
             <div className="min-w-0">
@@ -161,24 +97,15 @@ export function SessionConfigIndicator({
           </div>
 
           <p className="text-muted-foreground mt-2.5 text-xs leading-relaxed">
-            {stale
-              ? // Only ONE unconditional promise is made here — that nothing of
-                // yours is lost — because that one is structural: the reload
-                // never moves the branch. Bringing the agent files forward is
-                // deliberately worded as an attempt, since the reload refuses
-                // when this session has edited them itself. The toast afterwards
-                // reports which of the two happened.
-                'This session started with an older version of the agent config. Reloading tries to bring its agent files up to date, and keeps any changes this session made to them. Your commits and other files are untouched.'
-              : "This session's runtime didn't report which agent config it's running, so we can't tell whether it's current. Reloading puts it on the latest."}
+            A newer agent config is available. Reloading restarts the agent runtime and leaves every
+            project file and commit unchanged.
           </p>
 
-          {notice.kind === 'stale' && (
-            <p className="text-muted-foreground mt-2.5 font-mono text-[11px]">
-              <span className="text-foreground/80">{notice.running}</span>
-              {' → '}
-              <span className="text-foreground/80">{notice.latest}</span>
-            </p>
-          )}
+          <p className="text-muted-foreground mt-2.5 font-mono text-[11px]">
+            <span className="text-foreground/80">{notice.running}</span>
+            {' → '}
+            <span className="text-foreground/80">{notice.latest}</span>
+          </p>
         </div>
 
         {canReload ? (

--- a/apps/web/src/hooks/projects/use-session-config-freshness.test.ts
+++ b/apps/web/src/hooks/projects/use-session-config-freshness.test.ts
@@ -1,7 +1,7 @@
+import type { SessionConfigState } from '@kortix/sdk';
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import type { SessionConfigState } from '@kortix/sdk';
 
 import {
   CONFIG_FRESHNESS_STALE_TIME_MS,
@@ -56,14 +56,12 @@ describe('sessionConfigNotice', () => {
     ).toEqual({ kind: 'hidden' });
   });
 
-  test('a live box that reports no etag is UNVERIFIED, not fresh and not stale', () => {
-    // A sandbox provisioned before the etag shipped. We genuinely cannot tell,
-    // and a reload is exactly the fix — so this is the one null worth showing.
+  test('a live box that reports no etag stays quiet instead of presenting an unverifiable error', () => {
     expect(
       sessionConfigNotice(
         state({ stale: null, running_etag: null, latest_etag: 'new1new1new1new1' }),
       ),
-    ).toEqual({ kind: 'unverified' });
+    ).toEqual({ kind: 'hidden' });
   });
 
   test('NO input ever yields a positive "up to date" state', () => {
@@ -85,15 +83,15 @@ describe('sessionConfigNotice', () => {
             );
 
     const kinds = new Set(combos.map((c) => sessionConfigNotice(c).kind));
-    expect([...kinds].sort()).toEqual(['hidden', 'stale', 'unverified']);
+    expect([...kinds].sort()).toEqual(['hidden', 'stale']);
   });
 
   test('stale wins over every explanatory branch', () => {
     // If the server said stale, that is the answer even when the box then went
     // unreachable between the two reads inside the same response.
-    expect(
-      sessionConfigNotice(state({ stale: true, sandbox_reachable: false })).kind,
-    ).toBe('stale');
+    expect(sessionConfigNotice(state({ stale: true, sandbox_reachable: false })).kind).toBe(
+      'stale',
+    );
   });
 });
 
@@ -141,12 +139,14 @@ describe('reloadNotAppliedCopy', () => {
  * Source-asserted: exercising them needs a QueryClientProvider + a real network
  * seam, and this hook's own value is the pure logic above.
  */
-const HOOK_SOURCE = readFileSync(
-  join(import.meta.dir, 'use-session-config-freshness.ts'),
-  'utf8',
-);
+const HOOK_SOURCE = readFileSync(join(import.meta.dir, 'use-session-config-freshness.ts'), 'utf8');
 
 describe('useReloadSessionConfig — the costly mistakes', () => {
+  test('the web reload is config-only and cannot refresh workspace files', () => {
+    const body = HOOK_SOURCE.split('const mutation = useMutation({')[1]?.split('\n  });')[0];
+    expect(body).toContain('refresh_repo: false');
+  });
+
   test('the reload mutation never retries', () => {
     // The app-wide default retries any non-4xx once. The API answers 503 at its
     // own 25s deadline WHILE the reload keeps running server-side, so the

--- a/apps/web/src/hooks/projects/use-session-config-freshness.ts
+++ b/apps/web/src/hooks/projects/use-session-config-freshness.ts
@@ -53,14 +53,12 @@ export function sessionConfigKey(projectId?: string, sessionId?: string) {
  * What, if anything, the UI should say.
  *
  * Deliberately NOT a boolean and deliberately without an `ok` member: the only
- * two things worth rendering are "you are behind" and "we could not check".
- * Everything else — current, still loading, nothing to compare, box asleep —
+ * thing worth rendering is "you are behind". Everything else — current,
+ * still loading, an inconclusive check, nothing to compare, box asleep —
  * collapses to `hidden`, because a session that is fine should cost zero chrome.
  */
 export type SessionConfigNotice =
-  | { kind: 'hidden' }
-  | { kind: 'stale'; running: string; latest: string }
-  | { kind: 'unverified' };
+  { kind: 'hidden' } | { kind: 'stale'; running: string; latest: string };
 
 /**
  * Pure, so the branch order is testable without a DOM or a network.
@@ -81,20 +79,10 @@ export function sessionConfigNotice(state: SessionConfigState | undefined): Sess
       latest: state.latest_etag ?? '—',
     };
   }
-  if (state.stale === false) return { kind: 'hidden' };
-  // From here down `stale` is null and we are deciding whether the user can do
-  // anything about it.
-  //
-  // A sleeping sandbox is not a problem to report: nothing is running the wrong
-  // config because nothing is running. It wakes with the latest.
-  if (!state.sandbox_reachable) return { kind: 'hidden' };
-  // Nothing compiles — a v1 `kortix.toml` project. The concept does not apply,
-  // so saying anything would invent a problem.
-  if (state.latest_etag === null) return { kind: 'hidden' };
-  // The box is up and the config compiles, but the box did not say what it is
-  // running: a sandbox provisioned before this shipped. Worth surfacing, since
-  // a reload is exactly the fix.
-  return { kind: 'unverified' };
+  // `false` is current. `null` is inconclusive: the sandbox is sleeping, the
+  // project has no compiled config, or an older runtime cannot report an etag.
+  // None is an error, and none warrants persistent UI.
+  return { kind: 'hidden' };
 }
 
 /**
@@ -181,9 +169,13 @@ export function useReloadSessionConfig(projectId: string, sessionId: string) {
     // accident.
     retry: false,
     mutationFn: (vars: { force?: boolean } = {}) =>
-      // `refresh_repo` is left to the server default (true). "Reload" means
-      // "catch this session up", and that includes the workspace.
-      reloadProjectSessionConfig(projectId, sessionId, vars.force ? { force: true } : {}),
+      // This web action is named "Reload config", so it only reloads config.
+      // Repository refresh remains an explicit CLI operation. This prevents a
+      // low-priority UI action from changing the project checkout.
+      reloadProjectSessionConfig(projectId, sessionId, {
+        refresh_repo: false,
+        ...(vars.force ? { force: true } : {}),
+      }),
     onSuccess: (result: SessionReloadResult) => {
       // It landed — whatever refusal opened the dialog is answered.
       setBusyReason(null);

--- a/infra/cloudflare/workers/apps-router/README.md
+++ b/infra/cloudflare/workers/apps-router/README.md
@@ -12,6 +12,11 @@ Required Cloudflare resources:
 - The `DEV_EDGE_SECRET`, `STAGING_EDGE_SECRET`, `PROD_EDGE_SECRET`, and
   `PREVIEW_EDGE_SECRET` Worker secrets.
 
+Run the `Configure Kortix Apps Edge` GitHub workflow after the Worker deploys.
+The workflow creates the proxied wildcard DNS record when it is absent. It
+refuses to replace a conflicting record. It also verifies the Worker route,
+secret bindings, public DNS, TLS, and the signed Dev routing path.
+
 Each API environment must receive the corresponding value as
 `KORTIX_APPS_EDGE_SECRET`. The API falls back to its existing `API_KEY_SECRET`
 when the dedicated value is absent. Do not store secret values in

--- a/tests/unit/apps-edge-workflow.test.ts
+++ b/tests/unit/apps-edge-workflow.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflowPaths = [
+  '../../.github/workflows/configure-apps-edge.yml',
+  '../../.github/workflows/deploy-dev.yml',
+] as const;
+
+describe('Apps edge workflow Wrangler contract', () => {
+  it.each(workflowPaths)('%s uses Wrangler 4.34 secret-list syntax', (workflowPath) => {
+    const workflow = readFileSync(resolve(import.meta.dirname, workflowPath), 'utf8');
+
+    expect(workflow).toContain('wrangler@4.34.0 secret list --format json');
+    expect(workflow).not.toContain('wrangler@4.34.0 secret list --json');
+  });
+});


### PR DESCRIPTION
Promotes the current `main` tip `de2c99fd11df3682ad40f300fbcd3c8c980baec9` to staging.

This candidate includes PRs #6201 and #6202, which merged after #6200. It also contains the unified Kortix SDK and Connector CLI release work plus the GHAS fixes from #6199.

After merge, staging must pass QA, image builds, DB migrations, ECS rollout, Vercel deployment, and live SHA verification before production promotion.