### PR TITLE
fix(ci): use supported Wrangler secret-list format

### DIFF
--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -47,7 +47,7 @@ jobs:
             any(.result[]; .pattern == "*.apps.kortix.com/*" and .script == "kortix-apps-router")
           ' <<<"$routes"
 
-          secrets="$(npx --yes wrangler@4.34.0 secret list --json)"
+          secrets="$(npx --yes wrangler@4.34.0 secret list --format json)"
           jq -e '
             map(.name) | sort ==
             ["DEV_EDGE_SECRET", "PREVIEW_EDGE_SECRET", "PROD_EDGE_SECRET", "STAGING_EDGE_SECRET"]

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -353,7 +353,7 @@ jobs:
           printf '%s' "$STAGING_EDGE_SECRET" | npx --yes wrangler@4.34.0 secret put STAGING_EDGE_SECRET
           printf '%s' "$PROD_EDGE_SECRET" | npx --yes wrangler@4.34.0 secret put PROD_EDGE_SECRET
           printf '%s' "$PREVIEW_EDGE_SECRET" | npx --yes wrangler@4.34.0 secret put PREVIEW_EDGE_SECRET
-          npx --yes wrangler@4.34.0 secret list --json | jq -e 'map(.name) | sort == ["DEV_EDGE_SECRET", "PREVIEW_EDGE_SECRET", "PROD_EDGE_SECRET", "STAGING_EDGE_SECRET"]'
+          npx --yes wrangler@4.34.0 secret list --format json | jq -e 'map(.name) | sort == ["DEV_EDGE_SECRET", "PREVIEW_EDGE_SECRET", "PROD_EDGE_SECRET", "STAGING_EDGE_SECRET"]'
 
   # ── Move the self-host `:dev` channel tag onto the image that just deployed ─
   # `kortix self-host init/update --tag dev` (or `--channel dev` once that

--- a/tests/unit/apps-edge-workflow.test.ts
+++ b/tests/unit/apps-edge-workflow.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflowPaths = [
+  '../../.github/workflows/configure-apps-edge.yml',
+  '../../.github/workflows/deploy-dev.yml',
+] as const;
+
+describe('Apps edge workflow Wrangler contract', () => {
+  it.each(workflowPaths)('%s uses Wrangler 4.34 secret-list syntax', (workflowPath) => {
+    const workflow = readFileSync(resolve(import.meta.dirname, workflowPath), 'utf8');
+
+    expect(workflow).toContain('wrangler@4.34.0 secret list --format json');
+    expect(workflow).not.toContain('wrangler@4.34.0 secret list --json');
+  });
+});


### PR DESCRIPTION
Wrangler `4.34.0` rejects `secret list --json`. The deployed Apps router workflow failed after it successfully deployed the Worker, route, and four secrets.

This change uses the supported `--format json` flag in both workflow call sites. It adds a contract test that prevents the unsupported flag from returning.

Verification:
- `bunx vitest run --config unit/vitest.config.ts unit/apps-edge-workflow.test.ts` — 2 passed
- `npx --yes wrangler@4.34.0 secret list --help` — lists `--format` with `json` and `pretty` choices
- `actionlint` — clean for both changed workflows