### PR TITLE
fix(apps): honor managed storage upload limit

### DIFF
--- a/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
@@ -52,6 +52,7 @@ describe('sandbox init state helpers', () => {
         if (attempts < 3) throw new Error(`attempt-${attempts}`);
         return { externalId: 'machine-123', baseUrl: 'https://sandbox.example', metadata: { daytonaSandboxId: 'abc' } };
       },
+      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
@@ -84,6 +85,7 @@ describe('sandbox init state helpers', () => {
         attempts += 1;
         throw new Error('Maximum number of concurrent E2B sandboxes reached');
       },
+      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},

--- a/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
@@ -21,9 +21,7 @@ describe('sandbox init state helpers', () => {
     const meta = buildSandboxInitFailureMetadata({}, new Error('boom'), 3, false);
     expect(meta.initStatus).toBe('failed');
     expect(meta.lastInitError).toBe('boom');
-    expect(meta.errorMessage).toBe(
-      'Initialization failed after 3 attempts. Reinitialize to retry.',
-    );
+    expect(meta.errorMessage).toBe('Initialization failed after 3 attempts. Reinitialize to retry.');
   });
 
   test('records the active capacity retry limit in retry metadata', () => {
@@ -37,11 +35,7 @@ describe('sandbox init state helpers', () => {
   });
 
   test('marks successful initialization as ready', () => {
-    const meta = buildSandboxInitSuccessMetadata(
-      { serverType: 'basic' },
-      { provisioningStage: 'server_creating' },
-      2,
-    );
+    const meta = buildSandboxInitSuccessMetadata({ serverType: 'basic' }, { provisioningStage: 'server_creating' }, 2);
     expect(meta.initStatus).toBe('ready');
     expect(meta.initAttempts).toBe(2);
     expect(meta.serverType).toBe('basic');
@@ -56,32 +50,17 @@ describe('sandbox init state helpers', () => {
       async create() {
         attempts += 1;
         if (attempts < 3) throw new Error(`attempt-${attempts}`);
-        return {
-          externalId: 'machine-123',
-          baseUrl: 'https://sandbox.example',
-          metadata: { daytonaSandboxId: 'abc' },
-        };
+        return { externalId: 'machine-123', baseUrl: 'https://sandbox.example', metadata: { daytonaSandboxId: 'abc' } };
       },
-      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
-      async getStatus() {
-        return 'unknown' as const;
-      },
-      async resolveEndpoint() {
-        return { url: '', headers: {} };
-      },
-      routeIngress(request: { port: number }) {
-        return { effectivePort: request.port };
-      },
-      async resolveIngress(_externalId: string, request: { port: number }) {
-        return { url: '', headers: {}, effectivePort: request.port };
-      },
+      async getStatus() { return 'unknown' as const; },
+      async resolveEndpoint() { return { url: '', headers: {} }; },
+      routeIngress(request: { port: number }) { return { effectivePort: request.port }; },
+      async resolveIngress(_externalId: string, request: { port: number }) { return { url: '', headers: {}, effectivePort: request.port }; },
       async ensureRunning() {},
-      async getProvisioningStatus() {
-        return null;
-      },
+      async getProvisioningStatus() { return null; },
     };
 
     const result = await retrySandboxProvisionCreate(provider, {
@@ -105,26 +84,15 @@ describe('sandbox init state helpers', () => {
         attempts += 1;
         throw new Error('Maximum number of concurrent E2B sandboxes reached');
       },
-      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
-      async getStatus() {
-        return 'unknown' as const;
-      },
-      async resolveEndpoint() {
-        return { url: '', headers: {} };
-      },
-      routeIngress(request: { port: number }) {
-        return { effectivePort: request.port };
-      },
-      async resolveIngress(_externalId: string, request: { port: number }) {
-        return { url: '', headers: {}, effectivePort: request.port };
-      },
+      async getStatus() { return 'unknown' as const; },
+      async resolveEndpoint() { return { url: '', headers: {} }; },
+      routeIngress(request: { port: number }) { return { effectivePort: request.port }; },
+      async resolveIngress(_externalId: string, request: { port: number }) { return { url: '', headers: {}, effectivePort: request.port }; },
       async ensureRunning() {},
-      async getProvisioningStatus() {
-        return null;
-      },
+      async getProvisioningStatus() { return null; },
     };
 
     await expect(

--- a/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
@@ -21,7 +21,9 @@ describe('sandbox init state helpers', () => {
     const meta = buildSandboxInitFailureMetadata({}, new Error('boom'), 3, false);
     expect(meta.initStatus).toBe('failed');
     expect(meta.lastInitError).toBe('boom');
-    expect(meta.errorMessage).toBe('Initialization failed after 3 attempts. Reinitialize to retry.');
+    expect(meta.errorMessage).toBe(
+      'Initialization failed after 3 attempts. Reinitialize to retry.',
+    );
   });
 
   test('records the active capacity retry limit in retry metadata', () => {
@@ -35,7 +37,11 @@ describe('sandbox init state helpers', () => {
   });
 
   test('marks successful initialization as ready', () => {
-    const meta = buildSandboxInitSuccessMetadata({ serverType: 'basic' }, { provisioningStage: 'server_creating' }, 2);
+    const meta = buildSandboxInitSuccessMetadata(
+      { serverType: 'basic' },
+      { provisioningStage: 'server_creating' },
+      2,
+    );
     expect(meta.initStatus).toBe('ready');
     expect(meta.initAttempts).toBe(2);
     expect(meta.serverType).toBe('basic');
@@ -50,17 +56,32 @@ describe('sandbox init state helpers', () => {
       async create() {
         attempts += 1;
         if (attempts < 3) throw new Error(`attempt-${attempts}`);
-        return { externalId: 'machine-123', baseUrl: 'https://sandbox.example', metadata: { daytonaSandboxId: 'abc' } };
+        return {
+          externalId: 'machine-123',
+          baseUrl: 'https://sandbox.example',
+          metadata: { daytonaSandboxId: 'abc' },
+        };
       },
+      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
-      async getStatus() { return 'unknown' as const; },
-      async resolveEndpoint() { return { url: '', headers: {} }; },
-      routeIngress(request: { port: number }) { return { effectivePort: request.port }; },
-      async resolveIngress(_externalId: string, request: { port: number }) { return { url: '', headers: {}, effectivePort: request.port }; },
+      async getStatus() {
+        return 'unknown' as const;
+      },
+      async resolveEndpoint() {
+        return { url: '', headers: {} };
+      },
+      routeIngress(request: { port: number }) {
+        return { effectivePort: request.port };
+      },
+      async resolveIngress(_externalId: string, request: { port: number }) {
+        return { url: '', headers: {}, effectivePort: request.port };
+      },
       async ensureRunning() {},
-      async getProvisioningStatus() { return null; },
+      async getProvisioningStatus() {
+        return null;
+      },
     };
 
     const result = await retrySandboxProvisionCreate(provider, {
@@ -84,15 +105,26 @@ describe('sandbox init state helpers', () => {
         attempts += 1;
         throw new Error('Maximum number of concurrent E2B sandboxes reached');
       },
+      async ensureAppRuntimeStarted() {},
       async start() {},
       async stop() {},
       async remove() {},
-      async getStatus() { return 'unknown' as const; },
-      async resolveEndpoint() { return { url: '', headers: {} }; },
-      routeIngress(request: { port: number }) { return { effectivePort: request.port }; },
-      async resolveIngress(_externalId: string, request: { port: number }) { return { url: '', headers: {}, effectivePort: request.port }; },
+      async getStatus() {
+        return 'unknown' as const;
+      },
+      async resolveEndpoint() {
+        return { url: '', headers: {} };
+      },
+      routeIngress(request: { port: number }) {
+        return { effectivePort: request.port };
+      },
+      async resolveIngress(_externalId: string, request: { port: number }) {
+        return { url: '', headers: {}, effectivePort: request.port };
+      },
       async ensureRunning() {},
-      async getProvisioningStatus() { return null; },
+      async getProvisioningStatus() {
+        return null;
+      },
     };
 
     await expect(

--- a/apps/api/src/apps/artifacts.test.ts
+++ b/apps/api/src/apps/artifacts.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as tar from 'tar';
 import {
+  MAX_ARCHIVE_BYTES,
   appArtifactObjectPath,
   extractAppArchive,
   inspectAppArchive,
@@ -17,6 +18,10 @@ afterEach(async () => {
 });
 
 describe('App artifacts', () => {
+  test('keeps source archives within the managed Supabase Storage limit', () => {
+    expect(MAX_ARCHIVE_BYTES).toBe(50 * 1024 * 1024);
+  });
+
   test('uses account, project, and artifact identity in the private object path', () => {
     expect(appArtifactObjectPath('account-1', 'project-1', 'artifact-1')).toBe(
       'account-1/project-1/artifact-1/source.tar.gz',

--- a/apps/api/src/apps/artifacts.ts
+++ b/apps/api/src/apps/artifacts.ts
@@ -6,7 +6,10 @@ import * as tar from 'tar';
 import { getSupabase } from '../shared/supabase';
 
 export const APP_ARTIFACT_BUCKET = 'app-artifacts';
-export const MAX_ARCHIVE_BYTES = 250 * 1024 * 1024;
+// Managed Supabase Storage rejects bucket limits above the project's global
+// fileSizeLimit. Kortix cloud currently exposes the standard 50 MiB tier.
+// OCI deployments bypass this source-archive limit.
+export const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
 export const MAX_EXTRACTED_BYTES = 1024 * 1024 * 1024;
 export const MAX_ARCHIVE_FILES = 100_000;
 export const MAX_ARCHIVE_PATH_BYTES = 1024;

--- a/apps/api/src/apps/hosting.test.ts
+++ b/apps/api/src/apps/hosting.test.ts
@@ -14,6 +14,7 @@ const secret = 'test-secret-at-least-sixteen-characters';
 function dependencies() {
   const builds: any[] = [];
   const creates: any[] = [];
+  const appRuntimeStarts: string[] = [];
   const ingressCalls: any[] = [];
   const fetchCalls: any[] = [];
   const snapshot = {
@@ -33,6 +34,8 @@ function dependencies() {
       };
     },
     start: async () => {},
+    ensureRunning: async () => {},
+    ensureAppRuntimeStarted: async (externalId: string) => { appRuntimeStarts.push(externalId); },
     stop: async () => {},
     remove: async () => {},
   } as unknown as SandboxProvider;
@@ -51,7 +54,7 @@ function dependencies() {
     fetch: fetch as typeof globalThis.fetch,
     sleep: async () => {},
   });
-  return { hosting, builds, creates, ingressCalls, fetchCalls };
+  return { hosting, builds, creates, appRuntimeStarts, ingressCalls, fetchCalls };
 }
 
 describe('AppHostingProvider', () => {
@@ -88,7 +91,7 @@ describe('AppHostingProvider', () => {
   });
 
   test('creates an App workload with only the derived appd token', async () => {
-    const { hosting, creates } = dependencies();
+    const { hosting, creates, appRuntimeStarts } = dependencies();
     const result = await hosting.createRuntime({
       provider: 'daytona',
       runtimeId: 'runtime-1',
@@ -110,6 +113,16 @@ describe('AppHostingProvider', () => {
     expect(result.controlTokenHash).toBe(
       appControlTokenHash(appControlToken('runtime-1', secret)),
     );
+    expect(appRuntimeStarts).toEqual(['box-1']);
+  });
+
+  test('restarts the App runtime daemon after provider start and cold wake', async () => {
+    const { hosting, appRuntimeStarts } = dependencies();
+
+    await hosting.start('daytona', 'box-1');
+    await hosting.ensureRunning('daytona', 'box-1');
+
+    expect(appRuntimeStarts).toEqual(['box-1', 'box-1']);
   });
 
   test('polls authenticated appd status until the runtime is ready', async () => {

--- a/apps/api/src/apps/hosting.test.ts
+++ b/apps/api/src/apps/hosting.test.ts
@@ -14,13 +14,10 @@ const secret = 'test-secret-at-least-sixteen-characters';
 function dependencies() {
   const builds: any[] = [];
   const creates: any[] = [];
-  const appRuntimeStarts: string[] = [];
   const ingressCalls: any[] = [];
   const fetchCalls: any[] = [];
   const snapshot = {
-    buildSnapshot: async (...args: any[]) => {
-      builds.push(args);
-    },
+    buildSnapshot: async (...args: any[]) => { builds.push(args); },
   } as unknown as SandboxProviderAdapter;
   const runtime = {
     create: async (input: any) => {
@@ -36,10 +33,6 @@ function dependencies() {
       };
     },
     start: async () => {},
-    ensureRunning: async () => {},
-    ensureAppRuntimeStarted: async (externalId: string) => {
-      appRuntimeStarts.push(externalId);
-    },
     stop: async () => {},
     remove: async () => {},
   } as unknown as SandboxProvider;
@@ -58,7 +51,7 @@ function dependencies() {
     fetch: fetch as typeof globalThis.fetch,
     sleep: async () => {},
   });
-  return { hosting, builds, creates, appRuntimeStarts, ingressCalls, fetchCalls };
+  return { hosting, builds, creates, ingressCalls, fetchCalls };
 }
 
 describe('AppHostingProvider', () => {
@@ -95,7 +88,7 @@ describe('AppHostingProvider', () => {
   });
 
   test('creates an App workload with only the derived appd token', async () => {
-    const { hosting, creates, appRuntimeStarts } = dependencies();
+    const { hosting, creates } = dependencies();
     const result = await hosting.createRuntime({
       provider: 'daytona',
       runtimeId: 'runtime-1',
@@ -114,17 +107,9 @@ describe('AppHostingProvider', () => {
       envVars: { KORTIX_APPD_TOKEN: appControlToken('runtime-1', secret) },
     });
     expect(creates[0].envVars.KORTIX_SANDBOX_TOKEN).toBeUndefined();
-    expect(result.controlTokenHash).toBe(appControlTokenHash(appControlToken('runtime-1', secret)));
-    expect(appRuntimeStarts).toEqual(['box-1']);
-  });
-
-  test('restarts the App runtime daemon after provider start and cold wake', async () => {
-    const { hosting, appRuntimeStarts } = dependencies();
-
-    await hosting.start('daytona', 'box-1');
-    await hosting.ensureRunning('daytona', 'box-1');
-
-    expect(appRuntimeStarts).toEqual(['box-1', 'box-1']);
+    expect(result.controlTokenHash).toBe(
+      appControlTokenHash(appControlToken('runtime-1', secret)),
+    );
   });
 
   test('polls authenticated appd status until the runtime is ready', async () => {

--- a/apps/api/src/apps/hosting.test.ts
+++ b/apps/api/src/apps/hosting.test.ts
@@ -14,10 +14,13 @@ const secret = 'test-secret-at-least-sixteen-characters';
 function dependencies() {
   const builds: any[] = [];
   const creates: any[] = [];
+  const appRuntimeStarts: string[] = [];
   const ingressCalls: any[] = [];
   const fetchCalls: any[] = [];
   const snapshot = {
-    buildSnapshot: async (...args: any[]) => { builds.push(args); },
+    buildSnapshot: async (...args: any[]) => {
+      builds.push(args);
+    },
   } as unknown as SandboxProviderAdapter;
   const runtime = {
     create: async (input: any) => {
@@ -33,6 +36,10 @@ function dependencies() {
       };
     },
     start: async () => {},
+    ensureRunning: async () => {},
+    ensureAppRuntimeStarted: async (externalId: string) => {
+      appRuntimeStarts.push(externalId);
+    },
     stop: async () => {},
     remove: async () => {},
   } as unknown as SandboxProvider;
@@ -51,7 +58,7 @@ function dependencies() {
     fetch: fetch as typeof globalThis.fetch,
     sleep: async () => {},
   });
-  return { hosting, builds, creates, ingressCalls, fetchCalls };
+  return { hosting, builds, creates, appRuntimeStarts, ingressCalls, fetchCalls };
 }
 
 describe('AppHostingProvider', () => {
@@ -88,7 +95,7 @@ describe('AppHostingProvider', () => {
   });
 
   test('creates an App workload with only the derived appd token', async () => {
-    const { hosting, creates } = dependencies();
+    const { hosting, creates, appRuntimeStarts } = dependencies();
     const result = await hosting.createRuntime({
       provider: 'daytona',
       runtimeId: 'runtime-1',
@@ -107,9 +114,17 @@ describe('AppHostingProvider', () => {
       envVars: { KORTIX_APPD_TOKEN: appControlToken('runtime-1', secret) },
     });
     expect(creates[0].envVars.KORTIX_SANDBOX_TOKEN).toBeUndefined();
-    expect(result.controlTokenHash).toBe(
-      appControlTokenHash(appControlToken('runtime-1', secret)),
-    );
+    expect(result.controlTokenHash).toBe(appControlTokenHash(appControlToken('runtime-1', secret)));
+    expect(appRuntimeStarts).toEqual(['box-1']);
+  });
+
+  test('restarts the App runtime daemon after provider start and cold wake', async () => {
+    const { hosting, appRuntimeStarts } = dependencies();
+
+    await hosting.start('daytona', 'box-1');
+    await hosting.ensureRunning('daytona', 'box-1');
+
+    expect(appRuntimeStarts).toEqual(['box-1', 'box-1']);
   });
 
   test('polls authenticated appd status until the runtime is ready', async () => {

--- a/apps/api/src/apps/hosting.ts
+++ b/apps/api/src/apps/hosting.ts
@@ -123,7 +123,8 @@ export class AppHostingProvider {
 
   async createRuntime(input: StartAppRuntimeInput): Promise<AppRuntimeHandle> {
     const token = appControlToken(input.runtimeId, this.dependencies.controlSecret);
-    const result = await this.dependencies.runtimeProvider(input.provider).create({
+    const provider = this.dependencies.runtimeProvider(input.provider);
+    const result = await provider.create({
       accountId: input.accountId,
       userId: input.userId,
       name: input.name,
@@ -134,6 +135,12 @@ export class AppHostingProvider {
       publishedPorts: [APP_CONTROL_PORT, APP_INGRESS_PORT],
       envVars: { ...input.envVars, KORTIX_APPD_TOKEN: token },
     });
+    try {
+      await provider.ensureAppRuntimeStarted(result.externalId);
+    } catch (error) {
+      await provider.remove(result.externalId).catch(() => {});
+      throw error;
+    }
     return {
       ...result,
       provider: input.provider,
@@ -143,11 +150,15 @@ export class AppHostingProvider {
   }
 
   async start(provider: SandboxProviderName, externalId: string): Promise<void> {
-    await this.dependencies.runtimeProvider(provider).start(externalId);
+    const runtimeProvider = this.dependencies.runtimeProvider(provider);
+    await runtimeProvider.start(externalId);
+    await runtimeProvider.ensureAppRuntimeStarted(externalId);
   }
 
   async ensureRunning(provider: SandboxProviderName, externalId: string): Promise<void> {
-    await this.dependencies.runtimeProvider(provider).ensureRunning(externalId);
+    const runtimeProvider = this.dependencies.runtimeProvider(provider);
+    await runtimeProvider.ensureRunning(externalId);
+    await runtimeProvider.ensureAppRuntimeStarted(externalId);
   }
 
   async stop(provider: SandboxProviderName, externalId: string): Promise<void> {

--- a/apps/api/src/apps/hosting.ts
+++ b/apps/api/src/apps/hosting.ts
@@ -123,7 +123,8 @@ export class AppHostingProvider {
 
   async createRuntime(input: StartAppRuntimeInput): Promise<AppRuntimeHandle> {
     const token = appControlToken(input.runtimeId, this.dependencies.controlSecret);
-    const result = await this.dependencies.runtimeProvider(input.provider).create({
+    const provider = this.dependencies.runtimeProvider(input.provider);
+    const result = await provider.create({
       accountId: input.accountId,
       userId: input.userId,
       name: input.name,
@@ -134,6 +135,12 @@ export class AppHostingProvider {
       publishedPorts: [APP_CONTROL_PORT, APP_INGRESS_PORT],
       envVars: { ...input.envVars, KORTIX_APPD_TOKEN: token },
     });
+    try {
+      await provider.ensureAppRuntimeStarted(result.externalId);
+    } catch (error) {
+      await provider.remove(result.externalId).catch(() => {});
+      throw error;
+    }
     return {
       ...result,
       provider: input.provider,
@@ -143,11 +150,15 @@ export class AppHostingProvider {
   }
 
   async start(provider: SandboxProviderName, externalId: string): Promise<void> {
-    await this.dependencies.runtimeProvider(provider).start(externalId);
+    const runtimeProvider = this.dependencies.runtimeProvider(provider);
+    await runtimeProvider.start(externalId);
+    await runtimeProvider.ensureAppRuntimeStarted(externalId);
   }
 
   async ensureRunning(provider: SandboxProviderName, externalId: string): Promise<void> {
-    await this.dependencies.runtimeProvider(provider).ensureRunning(externalId);
+    const runtimeProvider = this.dependencies.runtimeProvider(provider);
+    await runtimeProvider.ensureRunning(externalId);
+    await runtimeProvider.ensureAppRuntimeStarted(externalId);
   }
 
   async stop(provider: SandboxProviderName, externalId: string): Promise<void> {
@@ -176,7 +187,9 @@ export class AppHostingProvider {
   ): Promise<AppdStatus> {
     const response = await this.controlRequest(provider, externalId, runtimeId, '/v1/status');
     if (!response.ok) {
-      throw new Error(`kortix-appd status returned ${response.status}: ${(await response.text()).slice(0, 300)}`);
+      throw new Error(
+        `kortix-appd status returned ${response.status}: ${(await response.text()).slice(0, 300)}`,
+      );
     }
     return response.json() as Promise<AppdStatus>;
   }
@@ -199,7 +212,9 @@ export class AppHostingProvider {
       `/v1/logs?${query}`,
     );
     if (!response.ok) {
-      throw new Error(`kortix-appd logs returned ${response.status}: ${(await response.text()).slice(0, 300)}`);
+      throw new Error(
+        `kortix-appd logs returned ${response.status}: ${(await response.text()).slice(0, 300)}`,
+      );
     }
     return response.json();
   }

--- a/apps/api/src/apps/hosting.ts
+++ b/apps/api/src/apps/hosting.ts
@@ -123,8 +123,7 @@ export class AppHostingProvider {
 
   async createRuntime(input: StartAppRuntimeInput): Promise<AppRuntimeHandle> {
     const token = appControlToken(input.runtimeId, this.dependencies.controlSecret);
-    const provider = this.dependencies.runtimeProvider(input.provider);
-    const result = await provider.create({
+    const result = await this.dependencies.runtimeProvider(input.provider).create({
       accountId: input.accountId,
       userId: input.userId,
       name: input.name,
@@ -135,12 +134,6 @@ export class AppHostingProvider {
       publishedPorts: [APP_CONTROL_PORT, APP_INGRESS_PORT],
       envVars: { ...input.envVars, KORTIX_APPD_TOKEN: token },
     });
-    try {
-      await provider.ensureAppRuntimeStarted(result.externalId);
-    } catch (error) {
-      await provider.remove(result.externalId).catch(() => {});
-      throw error;
-    }
     return {
       ...result,
       provider: input.provider,
@@ -150,15 +143,11 @@ export class AppHostingProvider {
   }
 
   async start(provider: SandboxProviderName, externalId: string): Promise<void> {
-    const runtimeProvider = this.dependencies.runtimeProvider(provider);
-    await runtimeProvider.start(externalId);
-    await runtimeProvider.ensureAppRuntimeStarted(externalId);
+    await this.dependencies.runtimeProvider(provider).start(externalId);
   }
 
   async ensureRunning(provider: SandboxProviderName, externalId: string): Promise<void> {
-    const runtimeProvider = this.dependencies.runtimeProvider(provider);
-    await runtimeProvider.ensureRunning(externalId);
-    await runtimeProvider.ensureAppRuntimeStarted(externalId);
+    await this.dependencies.runtimeProvider(provider).ensureRunning(externalId);
   }
 
   async stop(provider: SandboxProviderName, externalId: string): Promise<void> {
@@ -187,9 +176,7 @@ export class AppHostingProvider {
   ): Promise<AppdStatus> {
     const response = await this.controlRequest(provider, externalId, runtimeId, '/v1/status');
     if (!response.ok) {
-      throw new Error(
-        `kortix-appd status returned ${response.status}: ${(await response.text()).slice(0, 300)}`,
-      );
+      throw new Error(`kortix-appd status returned ${response.status}: ${(await response.text()).slice(0, 300)}`);
     }
     return response.json() as Promise<AppdStatus>;
   }
@@ -212,9 +199,7 @@ export class AppHostingProvider {
       `/v1/logs?${query}`,
     );
     if (!response.ok) {
-      throw new Error(
-        `kortix-appd logs returned ${response.status}: ${(await response.text()).slice(0, 300)}`,
-      );
+      throw new Error(`kortix-appd logs returned ${response.status}: ${(await response.text()).slice(0, 300)}`);
     }
     return response.json();
   }

--- a/apps/api/src/platform/providers/daytona-eager-preview.test.ts
+++ b/apps/api/src/platform/providers/daytona-eager-preview.test.ts
@@ -16,6 +16,7 @@ mock.module('../../config', () => ({
 mock.module('../../shared/db', () => ({ db: {} }));
 
 let previewLinkCalls: number[] = [];
+let processCommands: Array<{ command: string; timeout: number | undefined }> = [];
 let previewLinkImpl: (port: number) => Promise<unknown> = async (port) => {
   previewLinkCalls.push(port);
   return { url: 'https://preview.example.com', token: 'tok' };
@@ -26,6 +27,14 @@ mock.module('../../shared/daytona', () => ({
     create: async () => ({
       id: 'sbx-eager-1',
       getPreviewLink: (port: number) => previewLinkImpl(port),
+    }),
+    get: async () => ({
+      process: {
+        executeCommand: async (command: string, _cwd?: string, _env?: Record<string, string>, timeout?: number) => {
+          processCommands.push({ command, timeout });
+          return { exitCode: 0, result: 'started' };
+        },
+      },
     }),
   }),
   archiveDaytonaSandboxById: async () => ({ ok: true }),
@@ -98,4 +107,15 @@ test('provisioning does not wait on the warm — create resolves before the link
     previewLinkCalls.push(port);
     return { url: 'https://preview.example.com', token: 'tok' };
   };
+});
+
+test('App workload bootstrap starts kortix-appd through the Daytona toolbox', async () => {
+  processCommands = [];
+
+  await new DaytonaProvider().ensureAppRuntimeStarted('sbx-eager-1');
+
+  expect(processCommands).toHaveLength(1);
+  expect(processCommands[0]?.command).toContain('/kortix/bin/kortix-appd');
+  expect(processCommands[0]?.command).toContain('/tmp/kortix-appd.pid');
+  expect(processCommands[0]?.timeout).toBe(15);
 });

--- a/apps/api/src/platform/providers/daytona-eager-preview.test.ts
+++ b/apps/api/src/platform/providers/daytona-eager-preview.test.ts
@@ -16,6 +16,7 @@ mock.module('../../config', () => ({
 mock.module('../../shared/db', () => ({ db: {} }));
 
 let previewLinkCalls: number[] = [];
+let processCommands: Array<{ command: string; timeout: number | undefined }> = [];
 let previewLinkImpl: (port: number) => Promise<unknown> = async (port) => {
   previewLinkCalls.push(port);
   return { url: 'https://preview.example.com', token: 'tok' };
@@ -26,6 +27,19 @@ mock.module('../../shared/daytona', () => ({
     create: async () => ({
       id: 'sbx-eager-1',
       getPreviewLink: (port: number) => previewLinkImpl(port),
+    }),
+    get: async () => ({
+      process: {
+        executeCommand: async (
+          command: string,
+          _cwd?: string,
+          _env?: Record<string, string>,
+          timeout?: number,
+        ) => {
+          processCommands.push({ command, timeout });
+          return { exitCode: 0, result: 'started' };
+        },
+      },
     }),
   }),
   archiveDaytonaSandboxById: async () => ({ ok: true }),
@@ -38,7 +52,9 @@ mock.module('../../projects/disk-quota-guard', () => ({
 }));
 
 mock.module('../service-key', () => ({ serviceKeyForExternalId: async () => null }));
-mock.module('../sandbox-frontend-url', () => ({ sandboxFrontendBaseUrl: () => 'https://app.example.com' }));
+mock.module('../sandbox-frontend-url', () => ({
+  sandboxFrontendBaseUrl: () => 'https://app.example.com',
+}));
 
 const { DaytonaProvider } = await import('./daytona');
 
@@ -98,4 +114,15 @@ test('provisioning does not wait on the warm — create resolves before the link
     previewLinkCalls.push(port);
     return { url: 'https://preview.example.com', token: 'tok' };
   };
+});
+
+test('App workload bootstrap starts kortix-appd through the Daytona toolbox', async () => {
+  processCommands = [];
+
+  await new DaytonaProvider().ensureAppRuntimeStarted('sbx-eager-1');
+
+  expect(processCommands).toHaveLength(1);
+  expect(processCommands[0]?.command).toContain('/kortix/bin/kortix-appd');
+  expect(processCommands[0]?.command).toContain('/tmp/kortix-appd.pid');
+  expect(processCommands[0]?.timeout).toBe(15);
 });

--- a/apps/api/src/platform/providers/daytona-eager-preview.test.ts
+++ b/apps/api/src/platform/providers/daytona-eager-preview.test.ts
@@ -16,7 +16,6 @@ mock.module('../../config', () => ({
 mock.module('../../shared/db', () => ({ db: {} }));
 
 let previewLinkCalls: number[] = [];
-let processCommands: Array<{ command: string; timeout: number | undefined }> = [];
 let previewLinkImpl: (port: number) => Promise<unknown> = async (port) => {
   previewLinkCalls.push(port);
   return { url: 'https://preview.example.com', token: 'tok' };
@@ -27,19 +26,6 @@ mock.module('../../shared/daytona', () => ({
     create: async () => ({
       id: 'sbx-eager-1',
       getPreviewLink: (port: number) => previewLinkImpl(port),
-    }),
-    get: async () => ({
-      process: {
-        executeCommand: async (
-          command: string,
-          _cwd?: string,
-          _env?: Record<string, string>,
-          timeout?: number,
-        ) => {
-          processCommands.push({ command, timeout });
-          return { exitCode: 0, result: 'started' };
-        },
-      },
     }),
   }),
   archiveDaytonaSandboxById: async () => ({ ok: true }),
@@ -52,9 +38,7 @@ mock.module('../../projects/disk-quota-guard', () => ({
 }));
 
 mock.module('../service-key', () => ({ serviceKeyForExternalId: async () => null }));
-mock.module('../sandbox-frontend-url', () => ({
-  sandboxFrontendBaseUrl: () => 'https://app.example.com',
-}));
+mock.module('../sandbox-frontend-url', () => ({ sandboxFrontendBaseUrl: () => 'https://app.example.com' }));
 
 const { DaytonaProvider } = await import('./daytona');
 
@@ -114,15 +98,4 @@ test('provisioning does not wait on the warm — create resolves before the link
     previewLinkCalls.push(port);
     return { url: 'https://preview.example.com', token: 'tok' };
   };
-});
-
-test('App workload bootstrap starts kortix-appd through the Daytona toolbox', async () => {
-  processCommands = [];
-
-  await new DaytonaProvider().ensureAppRuntimeStarted('sbx-eager-1');
-
-  expect(processCommands).toHaveLength(1);
-  expect(processCommands[0]?.command).toContain('/kortix/bin/kortix-appd');
-  expect(processCommands[0]?.command).toContain('/tmp/kortix-appd.pid');
-  expect(processCommands[0]?.timeout).toBe(15);
 });

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -289,6 +289,40 @@ export class DaytonaProvider implements SandboxProvider {
     };
   }
 
+  /**
+   * Daytona runs its own `/usr/local/bin/daytona` entrypoint and does not run
+   * the image ENTRYPOINT. Start appd through the toolbox after every create or
+   * wake. The PID-file check makes concurrent and repeated calls idempotent.
+   */
+  async ensureAppRuntimeStarted(externalId: string): Promise<void> {
+    const daytona = getDaytona();
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId}) for App bootstrap`,
+    );
+    const command = [
+      'pid_file=/tmp/kortix-appd.pid',
+      'if [ -r "$pid_file" ]; then',
+      '  IFS= read -r appd_pid < "$pid_file" || true',
+      '  if [ -n "${appd_pid:-}" ] && kill -0 "$appd_pid" 2>/dev/null; then exit 0; fi',
+      'fi',
+      "trap '' HUP",
+      '/kortix/bin/kortix-appd >>/tmp/kortix-appd-bootstrap.log 2>&1 </dev/null &',
+      'echo "$!" > "$pid_file"',
+    ].join('\n');
+    const result = await withTimeout(
+      sandbox.process.executeCommand(command, undefined, undefined, 15),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona App bootstrap(${externalId})`,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Daytona App bootstrap failed for ${externalId}: exit ${result.exitCode}: ${result.result.slice(0, 500)}`,
+      );
+    }
+  }
+
   async start(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -42,11 +42,7 @@ import { withTimeout, configuredTimeoutMs } from '../../shared/with-timeout';
 // Every method below that awaits the SDK directly is bounded with
 // `withTimeout` so a hung upstream fails fast and observably instead of
 // hanging for up to a day.
-const PROVIDER_CALL_TIMEOUT_MS = configuredTimeoutMs(
-  'KORTIX_DAYTONA_CALL_TIMEOUT_MS',
-  20_000,
-  1_000,
-);
+const PROVIDER_CALL_TIMEOUT_MS = configuredTimeoutMs('KORTIX_DAYTONA_CALL_TIMEOUT_MS', 20_000, 1_000);
 // listManagedRunningSandboxes() pages through the org's whole managed fleet —
 // a large fleet can legitimately take longer than one single-call budget to
 // fully list, and PROVIDER_CALL_TIMEOUT_MS would then look identical to a
@@ -116,6 +112,8 @@ import type {
 const STATUS_CACHE_TTL_MS = 1500;
 const runningStatusCache = new Map<string, number>(); // externalId → cachedAt (ms)
 
+
+
 function isMissingSandboxError(error: unknown): boolean {
   const err = error as
     | { status?: unknown; statusCode?: unknown; code?: unknown; message?: unknown }
@@ -172,7 +170,9 @@ export class DaytonaProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [{ id: 'creating', progress: 50, message: 'Creating sandbox...' }],
+    stages: [
+      { id: 'creating', progress: 50, message: 'Creating sandbox...' },
+    ],
   };
 
   async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
@@ -184,7 +184,8 @@ export class DaytonaProvider implements SandboxProvider {
     // KORTIX_URL is the public API base URL the sandbox calls back on. Strip
     // any route suffix so older env files that included /v1 or /v1/router still
     // resolve to the bare origin.
-    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL
+      .replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
 
@@ -221,30 +222,28 @@ export class DaytonaProvider implements SandboxProvider {
     if (!snapshot) {
       throw new Error(
         'Daytona create() called without opts.snapshot. ' +
-          'Every sandbox must boot from a per-project snapshot built by ' +
-          'apps/api/src/snapshots/builder.ts. There is no shared fallback.',
+        'Every sandbox must boot from a per-project snapshot built by ' +
+        'apps/api/src/snapshots/builder.ts. There is no shared fallback.',
       );
     }
 
     const daytona = getDaytona();
-    const daytonaSandbox = await daytona
-      .create(
-        {
-          snapshot,
-          envVars,
-          // Idle → stop → archive → delete. See daytonaLifecycle(): auto-stop is
-          // clamped to >= 1 so a normal session box can never be created persistent,
-          // a large auto-archive (default 3 days) keeps a hibernated box in the
-          // fast-resume "stopped" tier, and a finite auto-delete reclaims it if the
-          // API/tunnel that created it dies. Intervals are env-tunable
-          // (KORTIX_SANDBOX_AUTO*).
-          ...daytonaLifecycle(opts.autoStopInterval),
-          labels: managedSandboxLabels(workloadType),
-          public: false,
-        },
-        { timeout: createTimeoutSeconds },
-      )
-      .catch((err) => reportIfDiskQuotaError(err, 'create'));
+    const daytonaSandbox = await daytona.create(
+      {
+        snapshot,
+        envVars,
+        // Idle → stop → archive → delete. See daytonaLifecycle(): auto-stop is
+        // clamped to >= 1 so a normal session box can never be created persistent,
+        // a large auto-archive (default 3 days) keeps a hibernated box in the
+        // fast-resume "stopped" tier, and a finite auto-delete reclaims it if the
+        // API/tunnel that created it dies. Intervals are env-tunable
+        // (KORTIX_SANDBOX_AUTO*).
+        ...daytonaLifecycle(opts.autoStopInterval),
+        labels: managedSandboxLabels(workloadType),
+        public: false,
+      },
+      { timeout: createTimeoutSeconds },
+    ).catch((err) => reportIfDiskQuotaError(err, 'create'));
 
     const externalId = daytonaSandbox.id;
     const apiBase = sandboxApiBase;
@@ -290,79 +289,27 @@ export class DaytonaProvider implements SandboxProvider {
     };
   }
 
-  /**
-   * Daytona runs its own `/usr/local/bin/daytona` entrypoint and does not run
-   * the image ENTRYPOINT. Start appd through the toolbox after every create or
-   * wake. The PID-file check makes concurrent and repeated calls idempotent.
-   */
-  async ensureAppRuntimeStarted(externalId: string): Promise<void> {
-    const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId}) for App bootstrap`,
-    );
-    const command = [
-      'pid_file=/tmp/kortix-appd.pid',
-      'if [ -r "$pid_file" ]; then',
-      '  IFS= read -r appd_pid < "$pid_file" || true',
-      '  if [ -n "${appd_pid:-}" ] && kill -0 "$appd_pid" 2>/dev/null; then exit 0; fi',
-      'fi',
-      "trap '' HUP",
-      '/kortix/bin/kortix-appd >>/tmp/kortix-appd-bootstrap.log 2>&1 </dev/null &',
-      'echo "$!" > "$pid_file"',
-    ].join('\n');
-    const result = await withTimeout(
-      sandbox.process.executeCommand(command, undefined, undefined, 15),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona App bootstrap(${externalId})`,
-    );
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Daytona App bootstrap failed for ${externalId}: exit ${result.exitCode}: ${result.result.slice(0, 500)}`,
-      );
-    }
-  }
-
   async start(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId})`,
+    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+    await withTimeout(sandbox.start(), PROVIDER_CALL_TIMEOUT_MS, `Daytona start(${externalId})`).catch((err) =>
+      reportIfDiskQuotaError(err, 'resume'),
     );
-    await withTimeout(
-      sandbox.start(),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona start(${externalId})`,
-    ).catch((err) => reportIfDiskQuotaError(err, 'resume'));
   }
 
   async stop(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId})`,
-    );
+    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
     await withTimeout(sandbox.stop(), PROVIDER_CALL_TIMEOUT_MS, `Daytona stop(${externalId})`);
   }
 
   async remove(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId})`,
-    );
-    await withTimeout(
-      daytona.delete(sandbox),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona delete(${externalId})`,
-    );
+    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+    await withTimeout(daytona.delete(sandbox), PROVIDER_CALL_TIMEOUT_MS, `Daytona delete(${externalId})`);
   }
 
   /**
@@ -372,9 +319,7 @@ export class DaytonaProvider implements SandboxProvider {
    * createdAt so the reaper can age-gate (never stop a box inside its grace
    * window, which would race a box mid-provision before its DB row lands).
    */
-  async listManagedRunningSandboxes(): Promise<
-    Array<{ externalId: string; createdAt: Date | null }>
-  > {
+  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
     // Bounds the WHOLE paginated iteration, not just one page — the async
     // generator can page indefinitely if a later page's request hangs.
     return withTimeout(
@@ -405,11 +350,7 @@ export class DaytonaProvider implements SandboxProvider {
     if (cachedAt !== undefined && Date.now() - cachedAt < STATUS_CACHE_TTL_MS) return 'running';
     try {
       const daytona = getDaytona();
-      const sandbox = await withTimeout(
-        daytona.get(externalId),
-        PROVIDER_CALL_TIMEOUT_MS,
-        `Daytona get(${externalId})`,
-      );
+      const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
       const status = classifyDaytonaState(sandbox.state);
       if (status === 'running') {
         runningStatusCache.set(externalId, Date.now());
@@ -424,16 +365,9 @@ export class DaytonaProvider implements SandboxProvider {
     }
   }
 
-  async resolveIngress(
-    externalId: string,
-    request: SandboxIngressRequest,
-  ): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
     const daytona = getDaytona();
-    const sandbox = await withTimeout(
-      daytona.get(externalId),
-      PROVIDER_CALL_TIMEOUT_MS,
-      `Daytona get(${externalId})`,
-    );
+    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
     const link: any = await withTimeout(
       (sandbox as any).getPreviewLink(request.port),
       PROVIDER_CALL_TIMEOUT_MS,

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -42,7 +42,11 @@ import { withTimeout, configuredTimeoutMs } from '../../shared/with-timeout';
 // Every method below that awaits the SDK directly is bounded with
 // `withTimeout` so a hung upstream fails fast and observably instead of
 // hanging for up to a day.
-const PROVIDER_CALL_TIMEOUT_MS = configuredTimeoutMs('KORTIX_DAYTONA_CALL_TIMEOUT_MS', 20_000, 1_000);
+const PROVIDER_CALL_TIMEOUT_MS = configuredTimeoutMs(
+  'KORTIX_DAYTONA_CALL_TIMEOUT_MS',
+  20_000,
+  1_000,
+);
 // listManagedRunningSandboxes() pages through the org's whole managed fleet —
 // a large fleet can legitimately take longer than one single-call budget to
 // fully list, and PROVIDER_CALL_TIMEOUT_MS would then look identical to a
@@ -112,8 +116,6 @@ import type {
 const STATUS_CACHE_TTL_MS = 1500;
 const runningStatusCache = new Map<string, number>(); // externalId → cachedAt (ms)
 
-
-
 function isMissingSandboxError(error: unknown): boolean {
   const err = error as
     | { status?: unknown; statusCode?: unknown; code?: unknown; message?: unknown }
@@ -170,9 +172,7 @@ export class DaytonaProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [
-      { id: 'creating', progress: 50, message: 'Creating sandbox...' },
-    ],
+    stages: [{ id: 'creating', progress: 50, message: 'Creating sandbox...' }],
   };
 
   async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
@@ -184,8 +184,7 @@ export class DaytonaProvider implements SandboxProvider {
     // KORTIX_URL is the public API base URL the sandbox calls back on. Strip
     // any route suffix so older env files that included /v1 or /v1/router still
     // resolve to the bare origin.
-    const sandboxApiBase = config.KORTIX_URL
-      .replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
 
@@ -222,28 +221,30 @@ export class DaytonaProvider implements SandboxProvider {
     if (!snapshot) {
       throw new Error(
         'Daytona create() called without opts.snapshot. ' +
-        'Every sandbox must boot from a per-project snapshot built by ' +
-        'apps/api/src/snapshots/builder.ts. There is no shared fallback.',
+          'Every sandbox must boot from a per-project snapshot built by ' +
+          'apps/api/src/snapshots/builder.ts. There is no shared fallback.',
       );
     }
 
     const daytona = getDaytona();
-    const daytonaSandbox = await daytona.create(
-      {
-        snapshot,
-        envVars,
-        // Idle → stop → archive → delete. See daytonaLifecycle(): auto-stop is
-        // clamped to >= 1 so a normal session box can never be created persistent,
-        // a large auto-archive (default 3 days) keeps a hibernated box in the
-        // fast-resume "stopped" tier, and a finite auto-delete reclaims it if the
-        // API/tunnel that created it dies. Intervals are env-tunable
-        // (KORTIX_SANDBOX_AUTO*).
-        ...daytonaLifecycle(opts.autoStopInterval),
-        labels: managedSandboxLabels(workloadType),
-        public: false,
-      },
-      { timeout: createTimeoutSeconds },
-    ).catch((err) => reportIfDiskQuotaError(err, 'create'));
+    const daytonaSandbox = await daytona
+      .create(
+        {
+          snapshot,
+          envVars,
+          // Idle → stop → archive → delete. See daytonaLifecycle(): auto-stop is
+          // clamped to >= 1 so a normal session box can never be created persistent,
+          // a large auto-archive (default 3 days) keeps a hibernated box in the
+          // fast-resume "stopped" tier, and a finite auto-delete reclaims it if the
+          // API/tunnel that created it dies. Intervals are env-tunable
+          // (KORTIX_SANDBOX_AUTO*).
+          ...daytonaLifecycle(opts.autoStopInterval),
+          labels: managedSandboxLabels(workloadType),
+          public: false,
+        },
+        { timeout: createTimeoutSeconds },
+      )
+      .catch((err) => reportIfDiskQuotaError(err, 'create'));
 
     const externalId = daytonaSandbox.id;
     const apiBase = sandboxApiBase;
@@ -289,27 +290,79 @@ export class DaytonaProvider implements SandboxProvider {
     };
   }
 
+  /**
+   * Daytona runs its own `/usr/local/bin/daytona` entrypoint and does not run
+   * the image ENTRYPOINT. Start appd through the toolbox after every create or
+   * wake. The PID-file check makes concurrent and repeated calls idempotent.
+   */
+  async ensureAppRuntimeStarted(externalId: string): Promise<void> {
+    const daytona = getDaytona();
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId}) for App bootstrap`,
+    );
+    const command = [
+      'pid_file=/tmp/kortix-appd.pid',
+      'if [ -r "$pid_file" ]; then',
+      '  IFS= read -r appd_pid < "$pid_file" || true',
+      '  if [ -n "${appd_pid:-}" ] && kill -0 "$appd_pid" 2>/dev/null; then exit 0; fi',
+      'fi',
+      "trap '' HUP",
+      '/kortix/bin/kortix-appd >>/tmp/kortix-appd-bootstrap.log 2>&1 </dev/null &',
+      'echo "$!" > "$pid_file"',
+    ].join('\n');
+    const result = await withTimeout(
+      sandbox.process.executeCommand(command, undefined, undefined, 15),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona App bootstrap(${externalId})`,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Daytona App bootstrap failed for ${externalId}: exit ${result.exitCode}: ${result.result.slice(0, 500)}`,
+      );
+    }
+  }
+
   async start(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
-    await withTimeout(sandbox.start(), PROVIDER_CALL_TIMEOUT_MS, `Daytona start(${externalId})`).catch((err) =>
-      reportIfDiskQuotaError(err, 'resume'),
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId})`,
     );
+    await withTimeout(
+      sandbox.start(),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona start(${externalId})`,
+    ).catch((err) => reportIfDiskQuotaError(err, 'resume'));
   }
 
   async stop(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId})`,
+    );
     await withTimeout(sandbox.stop(), PROVIDER_CALL_TIMEOUT_MS, `Daytona stop(${externalId})`);
   }
 
   async remove(externalId: string): Promise<void> {
     runningStatusCache.delete(externalId);
     const daytona = getDaytona();
-    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
-    await withTimeout(daytona.delete(sandbox), PROVIDER_CALL_TIMEOUT_MS, `Daytona delete(${externalId})`);
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId})`,
+    );
+    await withTimeout(
+      daytona.delete(sandbox),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona delete(${externalId})`,
+    );
   }
 
   /**
@@ -319,7 +372,9 @@ export class DaytonaProvider implements SandboxProvider {
    * createdAt so the reaper can age-gate (never stop a box inside its grace
    * window, which would race a box mid-provision before its DB row lands).
    */
-  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
+  async listManagedRunningSandboxes(): Promise<
+    Array<{ externalId: string; createdAt: Date | null }>
+  > {
     // Bounds the WHOLE paginated iteration, not just one page — the async
     // generator can page indefinitely if a later page's request hangs.
     return withTimeout(
@@ -350,7 +405,11 @@ export class DaytonaProvider implements SandboxProvider {
     if (cachedAt !== undefined && Date.now() - cachedAt < STATUS_CACHE_TTL_MS) return 'running';
     try {
       const daytona = getDaytona();
-      const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+      const sandbox = await withTimeout(
+        daytona.get(externalId),
+        PROVIDER_CALL_TIMEOUT_MS,
+        `Daytona get(${externalId})`,
+      );
       const status = classifyDaytonaState(sandbox.state);
       if (status === 'running') {
         runningStatusCache.set(externalId, Date.now());
@@ -365,9 +424,16 @@ export class DaytonaProvider implements SandboxProvider {
     }
   }
 
-  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(
+    externalId: string,
+    request: SandboxIngressRequest,
+  ): Promise<ResolvedSandboxIngress> {
     const daytona = getDaytona();
-    const sandbox = await withTimeout(daytona.get(externalId), PROVIDER_CALL_TIMEOUT_MS, `Daytona get(${externalId})`);
+    const sandbox = await withTimeout(
+      daytona.get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId})`,
+    );
     const link: any = await withTimeout(
       (sandbox as any).getPreviewLink(request.port),
       PROVIDER_CALL_TIMEOUT_MS,

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -294,6 +294,10 @@ export class E2BProvider implements SandboxProvider {
     }
   }
 
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // E2B honors the image ENTRYPOINT and resumes the existing process tree.
+  }
+
   async start(externalId: string): Promise<void> {
     const inFlight = startOperations.get(externalId);
     if (inFlight) return inFlight;

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -24,7 +24,8 @@ import { assertWorkloadCredential, sandboxWorkloadType } from './index';
 // backstop and must not make sandbox creation plan-dependent.
 const E2B_RUNTIME_BACKSTOP_MS = 60 * 60 * 1000;
 const KORTIX_ENTRYPOINT = '/usr/local/bin/kortix-entrypoint';
-const KORTIX_ENTRYPOINT_COMMAND = `exec flock -n /run/kortix-entrypoint.lock ${KORTIX_ENTRYPOINT}`;
+const KORTIX_ENTRYPOINT_COMMAND =
+  `exec flock -n /run/kortix-entrypoint.lock ${KORTIX_ENTRYPOINT}`;
 const RUNTIME_ENV_PATH = '/etc/kortix/runtime-env.json';
 const KORTIX_HEALTH_WAIT =
   'for attempt in $(seq 1 180); do ' +
@@ -42,7 +43,11 @@ const MANAGED_METADATA = 'kortix_managed';
 const ENV_METADATA = 'kortix_env';
 // The E2B SDK accepts requestTimeoutMs, but a live kill call remained pending
 // after that budget. This outer timer bounds all permanent-removal call sites.
-const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs('KORTIX_E2B_REMOVE_TIMEOUT_MS', 25_000, 1_000);
+const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs(
+  'KORTIX_E2B_REMOVE_TIMEOUT_MS',
+  25_000,
+  1_000,
+);
 
 function apiOpts() {
   return { apiKey: config.E2B_API_KEY, requestTimeoutMs: 20_000 } as const;
@@ -50,12 +55,7 @@ function apiOpts() {
 
 function isMissingSandboxError(error: unknown): boolean {
   if (error instanceof SandboxNotFoundError) return true;
-  const err = error as {
-    status?: unknown;
-    statusCode?: unknown;
-    code?: unknown;
-    message?: unknown;
-  } | null;
+  const err = error as { status?: unknown; statusCode?: unknown; code?: unknown; message?: unknown } | null;
   if (err?.status === 404 || err?.statusCode === 404 || err?.code === 404) return true;
   return /not found|does not exist|no such sandbox/i.test(String(err?.message ?? error ?? ''));
 }
@@ -75,9 +75,7 @@ function validateRuntimeEnv(value: unknown, externalId: string): Record<string, 
   const envs: Record<string, string> = {};
   for (const [key, item] of Object.entries(value)) {
     if (typeof item !== 'string') {
-      throw new Error(
-        `[e2b] sandbox ${externalId} has a non-string persisted runtime environment value`,
-      );
+      throw new Error(`[e2b] sandbox ${externalId} has a non-string persisted runtime environment value`);
     }
     envs[key] = item;
   }
@@ -89,7 +87,10 @@ function validateRuntimeEnv(value: unknown, externalId: string): Record<string, 
   return envs;
 }
 
-async function persistRuntimeEnv(sandbox: E2BSandbox, envs: Record<string, string>): Promise<void> {
+async function persistRuntimeEnv(
+  sandbox: E2BSandbox,
+  envs: Record<string, string>,
+): Promise<void> {
   await sandbox.files.write(RUNTIME_ENV_PATH, JSON.stringify(envs), {
     user: 'root',
     requestTimeoutMs: 10_000,
@@ -116,7 +117,9 @@ async function loadRuntimeEnv(sandbox: E2BSandbox): Promise<Record<string, strin
 
 function requirePrivateTrafficToken(sandbox: E2BSandbox): string {
   if (!sandbox.trafficAccessToken) {
-    throw new Error(`[e2b] sandbox ${sandbox.sandboxId} has no private traffic access token`);
+    throw new Error(
+      `[e2b] sandbox ${sandbox.sandboxId} has no private traffic access token`,
+    );
   }
   return sandbox.trafficAccessToken;
 }
@@ -126,8 +129,8 @@ async function ensureKortixEntrypoint(
   envs?: Record<string, string>,
 ): Promise<void> {
   const processes = await sandbox.commands.list({ requestTimeoutMs: 10_000 });
-  const alreadyRunning = processes.some((process) =>
-    `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_ENTRYPOINT),
+  const alreadyRunning = processes.some(
+    (process) => `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_ENTRYPOINT),
   );
   if (!alreadyRunning) {
     // The guest lock is the cross-process/cross-replica authority. Two API
@@ -156,8 +159,8 @@ async function ensureAppEntrypoint(
   envs: Record<string, string>,
 ): Promise<void> {
   const processes = await sandbox.commands.list({ requestTimeoutMs: 10_000 });
-  const alreadyRunning = processes.some((process) =>
-    `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_APPD),
+  const alreadyRunning = processes.some(
+    (process) => `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_APPD),
   );
   if (!alreadyRunning) {
     await sandbox.commands.run(KORTIX_APPD_COMMAND, {
@@ -198,7 +201,8 @@ export class E2BProvider implements SandboxProvider {
       );
     }
 
-    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL
+      .replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
     const envVars: Record<string, string> = {
@@ -252,9 +256,7 @@ export class E2BProvider implements SandboxProvider {
     } catch (error) {
       connectedSandboxes.delete(sandbox.sandboxId);
       await sandbox.kill({ requestTimeoutMs: 20_000 }).catch(() => false);
-      throw new Error(
-        `[e2b] failed to launch Kortix entrypoint: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      throw new Error(`[e2b] failed to launch Kortix entrypoint: ${error instanceof Error ? error.message : String(error)}`);
     }
 
     const externalId = sandbox.sandboxId;
@@ -290,10 +292,6 @@ export class E2BProvider implements SandboxProvider {
       connectedSandboxes.delete(externalId);
       throw error;
     }
-  }
-
-  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
-    // E2B honors the image ENTRYPOINT and resumes the existing process tree.
   }
 
   async start(externalId: string): Promise<void> {
@@ -372,10 +370,7 @@ export class E2BProvider implements SandboxProvider {
 
   async resolveEndpoint(externalId: string): Promise<ResolvedEndpoint> {
     const ingress = await this.resolveIngress(externalId, { port: 8000, transport: 'http' });
-    const headers: Record<string, string> = {
-      ...ingress.headers,
-      'Content-Type': 'application/json',
-    };
+    const headers: Record<string, string> = { ...ingress.headers, 'Content-Type': 'application/json' };
     const serviceKey = await serviceKeyForExternalId(externalId).catch(() => null);
     if (serviceKey) headers.Authorization = `Bearer ${serviceKey}`;
     return { url: ingress.url, headers };
@@ -387,9 +382,7 @@ export class E2BProvider implements SandboxProvider {
     if (status === 'stopped') await this.start(externalId);
   }
 
-  async listManagedRunningSandboxes(): Promise<
-    Array<{ externalId: string; createdAt: Date | null }>
-  > {
+  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
     const paginator = Sandbox.list({
       ...apiOpts(),
       limit: 100,

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -24,8 +24,7 @@ import { assertWorkloadCredential, sandboxWorkloadType } from './index';
 // backstop and must not make sandbox creation plan-dependent.
 const E2B_RUNTIME_BACKSTOP_MS = 60 * 60 * 1000;
 const KORTIX_ENTRYPOINT = '/usr/local/bin/kortix-entrypoint';
-const KORTIX_ENTRYPOINT_COMMAND =
-  `exec flock -n /run/kortix-entrypoint.lock ${KORTIX_ENTRYPOINT}`;
+const KORTIX_ENTRYPOINT_COMMAND = `exec flock -n /run/kortix-entrypoint.lock ${KORTIX_ENTRYPOINT}`;
 const RUNTIME_ENV_PATH = '/etc/kortix/runtime-env.json';
 const KORTIX_HEALTH_WAIT =
   'for attempt in $(seq 1 180); do ' +
@@ -43,11 +42,7 @@ const MANAGED_METADATA = 'kortix_managed';
 const ENV_METADATA = 'kortix_env';
 // The E2B SDK accepts requestTimeoutMs, but a live kill call remained pending
 // after that budget. This outer timer bounds all permanent-removal call sites.
-const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs(
-  'KORTIX_E2B_REMOVE_TIMEOUT_MS',
-  25_000,
-  1_000,
-);
+const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs('KORTIX_E2B_REMOVE_TIMEOUT_MS', 25_000, 1_000);
 
 function apiOpts() {
   return { apiKey: config.E2B_API_KEY, requestTimeoutMs: 20_000 } as const;
@@ -55,7 +50,12 @@ function apiOpts() {
 
 function isMissingSandboxError(error: unknown): boolean {
   if (error instanceof SandboxNotFoundError) return true;
-  const err = error as { status?: unknown; statusCode?: unknown; code?: unknown; message?: unknown } | null;
+  const err = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    message?: unknown;
+  } | null;
   if (err?.status === 404 || err?.statusCode === 404 || err?.code === 404) return true;
   return /not found|does not exist|no such sandbox/i.test(String(err?.message ?? error ?? ''));
 }
@@ -75,7 +75,9 @@ function validateRuntimeEnv(value: unknown, externalId: string): Record<string, 
   const envs: Record<string, string> = {};
   for (const [key, item] of Object.entries(value)) {
     if (typeof item !== 'string') {
-      throw new Error(`[e2b] sandbox ${externalId} has a non-string persisted runtime environment value`);
+      throw new Error(
+        `[e2b] sandbox ${externalId} has a non-string persisted runtime environment value`,
+      );
     }
     envs[key] = item;
   }
@@ -87,10 +89,7 @@ function validateRuntimeEnv(value: unknown, externalId: string): Record<string, 
   return envs;
 }
 
-async function persistRuntimeEnv(
-  sandbox: E2BSandbox,
-  envs: Record<string, string>,
-): Promise<void> {
+async function persistRuntimeEnv(sandbox: E2BSandbox, envs: Record<string, string>): Promise<void> {
   await sandbox.files.write(RUNTIME_ENV_PATH, JSON.stringify(envs), {
     user: 'root',
     requestTimeoutMs: 10_000,
@@ -117,9 +116,7 @@ async function loadRuntimeEnv(sandbox: E2BSandbox): Promise<Record<string, strin
 
 function requirePrivateTrafficToken(sandbox: E2BSandbox): string {
   if (!sandbox.trafficAccessToken) {
-    throw new Error(
-      `[e2b] sandbox ${sandbox.sandboxId} has no private traffic access token`,
-    );
+    throw new Error(`[e2b] sandbox ${sandbox.sandboxId} has no private traffic access token`);
   }
   return sandbox.trafficAccessToken;
 }
@@ -129,8 +126,8 @@ async function ensureKortixEntrypoint(
   envs?: Record<string, string>,
 ): Promise<void> {
   const processes = await sandbox.commands.list({ requestTimeoutMs: 10_000 });
-  const alreadyRunning = processes.some(
-    (process) => `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_ENTRYPOINT),
+  const alreadyRunning = processes.some((process) =>
+    `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_ENTRYPOINT),
   );
   if (!alreadyRunning) {
     // The guest lock is the cross-process/cross-replica authority. Two API
@@ -159,8 +156,8 @@ async function ensureAppEntrypoint(
   envs: Record<string, string>,
 ): Promise<void> {
   const processes = await sandbox.commands.list({ requestTimeoutMs: 10_000 });
-  const alreadyRunning = processes.some(
-    (process) => `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_APPD),
+  const alreadyRunning = processes.some((process) =>
+    `${process.cmd} ${process.args.join(' ')}`.includes(KORTIX_APPD),
   );
   if (!alreadyRunning) {
     await sandbox.commands.run(KORTIX_APPD_COMMAND, {
@@ -201,8 +198,7 @@ export class E2BProvider implements SandboxProvider {
       );
     }
 
-    const sandboxApiBase = config.KORTIX_URL
-      .replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
     const envVars: Record<string, string> = {
@@ -256,7 +252,9 @@ export class E2BProvider implements SandboxProvider {
     } catch (error) {
       connectedSandboxes.delete(sandbox.sandboxId);
       await sandbox.kill({ requestTimeoutMs: 20_000 }).catch(() => false);
-      throw new Error(`[e2b] failed to launch Kortix entrypoint: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `[e2b] failed to launch Kortix entrypoint: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
 
     const externalId = sandbox.sandboxId;
@@ -292,6 +290,10 @@ export class E2BProvider implements SandboxProvider {
       connectedSandboxes.delete(externalId);
       throw error;
     }
+  }
+
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // E2B honors the image ENTRYPOINT and resumes the existing process tree.
   }
 
   async start(externalId: string): Promise<void> {
@@ -370,7 +372,10 @@ export class E2BProvider implements SandboxProvider {
 
   async resolveEndpoint(externalId: string): Promise<ResolvedEndpoint> {
     const ingress = await this.resolveIngress(externalId, { port: 8000, transport: 'http' });
-    const headers: Record<string, string> = { ...ingress.headers, 'Content-Type': 'application/json' };
+    const headers: Record<string, string> = {
+      ...ingress.headers,
+      'Content-Type': 'application/json',
+    };
     const serviceKey = await serviceKeyForExternalId(externalId).catch(() => null);
     if (serviceKey) headers.Authorization = `Bearer ${serviceKey}`;
     return { url: ingress.url, headers };
@@ -382,7 +387,9 @@ export class E2BProvider implements SandboxProvider {
     if (status === 'stopped') await this.start(externalId);
   }
 
-  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
+  async listManagedRunningSandboxes(): Promise<
+    Array<{ externalId: string; createdAt: Date | null }>
+  > {
     const paginator = Sandbox.list({
       ...apiOpts(),
       limit: 100,

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -196,6 +196,13 @@ export interface SandboxProvider {
 
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;
   /**
+   * Ensure the Kortix App supervisor is running after create or resume.
+   * Providers that honor the image ENTRYPOINT implement this as a no-op.
+   * Providers that replace ENTRYPOINT must start `/kortix/bin/kortix-appd`
+   * through their native process API. The operation must be idempotent.
+   */
+  ensureAppRuntimeStarted(externalId: string): Promise<void>;
+  /**
    * FIX-A: boot a sandbox from an EXACT provider template id (not a name). The
    * boot path uses this to honor a project's activated
    * `active_sandbox_external_template_id` pin, so the running sandbox is the

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -196,6 +196,13 @@ export interface SandboxProvider {
 
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;
   /**
+   * Ensure the Kortix App supervisor is running after create or resume.
+   * Providers that honor the image ENTRYPOINT implement this as a no-op.
+   * Providers that replace ENTRYPOINT must start `/kortix/bin/kortix-appd`
+   * through their native process API. The operation must be idempotent.
+   */
+  ensureAppRuntimeStarted(externalId: string): Promise<void>;
+  /**
    * FIX-A: boot a sandbox from an EXACT provider template id (not a name). The
    * boot path uses this to honor a project's activated
    * `active_sandbox_external_template_id` pin, so the running sandbox is the
@@ -207,7 +214,10 @@ export interface SandboxProvider {
    * so the caller can fall back to a name-boot; a transient 5xx throws a normal
    * (retryable) error and MUST NOT be turned into a name fallback.
    */
-  createFromExternalId?(externalTemplateId: string, opts: CreateSandboxOpts): Promise<ProvisionResult>;
+  createFromExternalId?(
+    externalTemplateId: string,
+    opts: CreateSandboxOpts,
+  ): Promise<ProvisionResult>;
   start(externalId: string): Promise<void>;
   stop(externalId: string): Promise<void>;
   remove(externalId: string): Promise<void>;
@@ -229,7 +239,10 @@ export interface SandboxProvider {
    * silently broke every other provider's runtime connection (502/503). Keeping
    * it on the interface makes that regression a compile error.
    */
-  resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress>;
+  resolveIngress(
+    externalId: string,
+    request: SandboxIngressRequest,
+  ): Promise<ResolvedSandboxIngress>;
   ensureRunning(externalId: string): Promise<void>;
   getProvisioningStatus(sandboxId: string): Promise<ProvisioningStatus | null>;
   /**

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -196,13 +196,6 @@ export interface SandboxProvider {
 
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;
   /**
-   * Ensure the Kortix App supervisor is running after create or resume.
-   * Providers that honor the image ENTRYPOINT implement this as a no-op.
-   * Providers that replace ENTRYPOINT must start `/kortix/bin/kortix-appd`
-   * through their native process API. The operation must be idempotent.
-   */
-  ensureAppRuntimeStarted(externalId: string): Promise<void>;
-  /**
    * FIX-A: boot a sandbox from an EXACT provider template id (not a name). The
    * boot path uses this to honor a project's activated
    * `active_sandbox_external_template_id` pin, so the running sandbox is the
@@ -214,10 +207,7 @@ export interface SandboxProvider {
    * so the caller can fall back to a name-boot; a transient 5xx throws a normal
    * (retryable) error and MUST NOT be turned into a name fallback.
    */
-  createFromExternalId?(
-    externalTemplateId: string,
-    opts: CreateSandboxOpts,
-  ): Promise<ProvisionResult>;
+  createFromExternalId?(externalTemplateId: string, opts: CreateSandboxOpts): Promise<ProvisionResult>;
   start(externalId: string): Promise<void>;
   stop(externalId: string): Promise<void>;
   remove(externalId: string): Promise<void>;
@@ -239,10 +229,7 @@ export interface SandboxProvider {
    * silently broke every other provider's runtime connection (502/503). Keeping
    * it on the interface makes that regression a compile error.
    */
-  resolveIngress(
-    externalId: string,
-    request: SandboxIngressRequest,
-  ): Promise<ResolvedSandboxIngress>;
+  resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress>;
   ensureRunning(externalId: string): Promise<void>;
   getProvisioningStatus(sandboxId: string): Promise<ProvisioningStatus | null>;
   /**

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -336,6 +336,10 @@ export class LocalDockerProvider implements SandboxProvider {
     };
   }
 
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // Docker starts the image ENTRYPOINT on create and container restart.
+  }
+
   async start(externalId: string): Promise<void> {
     const docker = getDockerClient();
     await assertDockerReachable(docker);

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -65,10 +65,7 @@ const DEFAULT_MEMORY_GB = Number.parseFloat(process.env.LOCAL_DOCKER_MEMORY_GB |
 // daytona.ts's managedSandboxLabels() exactly — the reaper's
 // listManagedRunningSandboxes() scoping logic is provider-agnostic and reads
 // the SAME two labels regardless of provider.
-function managedLabels(
-  externalId: string,
-  workloadType: 'session' | 'app',
-): Record<string, string> {
+function managedLabels(externalId: string, workloadType: 'session' | 'app'): Record<string, string> {
   return {
     'kortix.managed': 'true',
     'kortix.env': config.INTERNAL_KORTIX_ENV,
@@ -136,9 +133,9 @@ async function assertDockerReachable(docker: Docker): Promise<void> {
     const detail = err instanceof Error ? err.message : String(err);
     throw new Error(
       `[local-docker] Docker daemon is not reachable (${detail}). The local-docker sandbox ` +
-        `provider requires the host's Docker socket mounted into kortix-api (self-host: select ` +
-        `"local-docker" at \`kortix self-host init\`, which wires this automatically) — or, ` +
-        `outside self-host, set LOCAL_DOCKER_SOCKET_PATH / DOCKER_HOST to a reachable Docker Engine.`,
+      `provider requires the host's Docker socket mounted into kortix-api (self-host: select ` +
+      `"local-docker" at \`kortix self-host init\`, which wires this automatically) — or, ` +
+      `outside self-host, set LOCAL_DOCKER_SOCKET_PATH / DOCKER_HOST to a reachable Docker Engine.`,
     );
   }
 }
@@ -192,8 +189,7 @@ function isMissingContainerError(err: unknown): boolean {
 function toStatus(info: Docker.ContainerInspectInfo): SandboxStatus {
   const state = info.State;
   if (state?.Running) return 'running';
-  if (state?.Status === 'exited' || state?.Status === 'created' || state?.Status === 'dead')
-    return 'stopped';
+  if (state?.Status === 'exited' || state?.Status === 'created' || state?.Status === 'dead') return 'stopped';
   return 'unknown';
 }
 
@@ -208,7 +204,9 @@ export class LocalDockerProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [{ id: 'creating', progress: 50, message: 'Starting local container...' }],
+    stages: [
+      { id: 'creating', progress: 50, message: 'Starting local container...' },
+    ],
   };
 
   /**
@@ -236,7 +234,7 @@ export class LocalDockerProvider implements SandboxProvider {
     if (!snapshot) {
       throw new Error(
         'local-docker create() called without opts.snapshot. Every sandbox must boot from a ' +
-          'per-project image built by apps/api/src/snapshots/builder.ts. There is no shared fallback.',
+        'per-project image built by apps/api/src/snapshots/builder.ts. There is no shared fallback.',
       );
     }
     assertWorkloadCredential(this.name, opts, opts.envVars ?? {});
@@ -280,9 +278,9 @@ export class LocalDockerProvider implements SandboxProvider {
     }
     const env = Object.entries(envVars).map(([k, v]) => `${k}=${v}`);
 
-    const publishedPorts = Array.from(
-      new Set(opts.publishedPorts ?? (workloadType === 'app' ? [7331, 8080] : [AGENT_PORT])),
-    );
+    const publishedPorts = Array.from(new Set(
+      opts.publishedPorts ?? (workloadType === 'app' ? [7331, 8080] : [AGENT_PORT]),
+    ));
     const exposedPorts = Object.fromEntries(publishedPorts.map((port) => [`${port}/tcp`, {}]));
     const portBindings = Object.fromEntries(
       publishedPorts.map((port) => [`${port}/tcp`, [{ HostIp: '127.0.0.1', HostPort: '0' }]]),
@@ -338,10 +336,6 @@ export class LocalDockerProvider implements SandboxProvider {
     };
   }
 
-  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
-    // Docker starts the image ENTRYPOINT on create and container restart.
-  }
-
   async start(externalId: string): Promise<void> {
     const docker = getDockerClient();
     await assertDockerReachable(docker);
@@ -389,10 +383,7 @@ export class LocalDockerProvider implements SandboxProvider {
     }
   }
 
-  async resolveIngress(
-    externalId: string,
-    request: SandboxIngressRequest,
-  ): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
     // `pnpm worktree` runs kortix-api directly on the macOS host. The host
     // cannot resolve a container name from Docker's private DNS, so use the
     // loopback-only published port in that explicit development mode. Inspect
@@ -461,9 +452,7 @@ export class LocalDockerProvider implements SandboxProvider {
    * cross-provider logic uniform (and safe if a laptop ever runs two
    * kortix-api instances against the same daemon, e.g. dev + a worktree).
    */
-  async listManagedRunningSandboxes(): Promise<
-    Array<{ externalId: string; createdAt: Date | null }>
-  > {
+  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
     const docker = getDockerClient();
     await assertDockerReachable(docker);
     const containers = await docker.listContainers({
@@ -473,10 +462,7 @@ export class LocalDockerProvider implements SandboxProvider {
       }),
     });
     return containers.map((c) => ({
-      externalId:
-        c.Labels?.['kortix.sandbox'] ||
-        c.Names?.[0]?.replace(/^\//, '').replace(CONTAINER_PREFIX, '') ||
-        c.Id,
+      externalId: c.Labels?.['kortix.sandbox'] || c.Names?.[0]?.replace(/^\//, '').replace(CONTAINER_PREFIX, '') || c.Id,
       createdAt: c.Created ? new Date(c.Created * 1000) : null,
     }));
   }

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -65,7 +65,10 @@ const DEFAULT_MEMORY_GB = Number.parseFloat(process.env.LOCAL_DOCKER_MEMORY_GB |
 // daytona.ts's managedSandboxLabels() exactly — the reaper's
 // listManagedRunningSandboxes() scoping logic is provider-agnostic and reads
 // the SAME two labels regardless of provider.
-function managedLabels(externalId: string, workloadType: 'session' | 'app'): Record<string, string> {
+function managedLabels(
+  externalId: string,
+  workloadType: 'session' | 'app',
+): Record<string, string> {
   return {
     'kortix.managed': 'true',
     'kortix.env': config.INTERNAL_KORTIX_ENV,
@@ -133,9 +136,9 @@ async function assertDockerReachable(docker: Docker): Promise<void> {
     const detail = err instanceof Error ? err.message : String(err);
     throw new Error(
       `[local-docker] Docker daemon is not reachable (${detail}). The local-docker sandbox ` +
-      `provider requires the host's Docker socket mounted into kortix-api (self-host: select ` +
-      `"local-docker" at \`kortix self-host init\`, which wires this automatically) — or, ` +
-      `outside self-host, set LOCAL_DOCKER_SOCKET_PATH / DOCKER_HOST to a reachable Docker Engine.`,
+        `provider requires the host's Docker socket mounted into kortix-api (self-host: select ` +
+        `"local-docker" at \`kortix self-host init\`, which wires this automatically) — or, ` +
+        `outside self-host, set LOCAL_DOCKER_SOCKET_PATH / DOCKER_HOST to a reachable Docker Engine.`,
     );
   }
 }
@@ -189,7 +192,8 @@ function isMissingContainerError(err: unknown): boolean {
 function toStatus(info: Docker.ContainerInspectInfo): SandboxStatus {
   const state = info.State;
   if (state?.Running) return 'running';
-  if (state?.Status === 'exited' || state?.Status === 'created' || state?.Status === 'dead') return 'stopped';
+  if (state?.Status === 'exited' || state?.Status === 'created' || state?.Status === 'dead')
+    return 'stopped';
   return 'unknown';
 }
 
@@ -204,9 +208,7 @@ export class LocalDockerProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [
-      { id: 'creating', progress: 50, message: 'Starting local container...' },
-    ],
+    stages: [{ id: 'creating', progress: 50, message: 'Starting local container...' }],
   };
 
   /**
@@ -234,7 +236,7 @@ export class LocalDockerProvider implements SandboxProvider {
     if (!snapshot) {
       throw new Error(
         'local-docker create() called without opts.snapshot. Every sandbox must boot from a ' +
-        'per-project image built by apps/api/src/snapshots/builder.ts. There is no shared fallback.',
+          'per-project image built by apps/api/src/snapshots/builder.ts. There is no shared fallback.',
       );
     }
     assertWorkloadCredential(this.name, opts, opts.envVars ?? {});
@@ -278,9 +280,9 @@ export class LocalDockerProvider implements SandboxProvider {
     }
     const env = Object.entries(envVars).map(([k, v]) => `${k}=${v}`);
 
-    const publishedPorts = Array.from(new Set(
-      opts.publishedPorts ?? (workloadType === 'app' ? [7331, 8080] : [AGENT_PORT]),
-    ));
+    const publishedPorts = Array.from(
+      new Set(opts.publishedPorts ?? (workloadType === 'app' ? [7331, 8080] : [AGENT_PORT])),
+    );
     const exposedPorts = Object.fromEntries(publishedPorts.map((port) => [`${port}/tcp`, {}]));
     const portBindings = Object.fromEntries(
       publishedPorts.map((port) => [`${port}/tcp`, [{ HostIp: '127.0.0.1', HostPort: '0' }]]),
@@ -336,6 +338,10 @@ export class LocalDockerProvider implements SandboxProvider {
     };
   }
 
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // Docker starts the image ENTRYPOINT on create and container restart.
+  }
+
   async start(externalId: string): Promise<void> {
     const docker = getDockerClient();
     await assertDockerReachable(docker);
@@ -383,7 +389,10 @@ export class LocalDockerProvider implements SandboxProvider {
     }
   }
 
-  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(
+    externalId: string,
+    request: SandboxIngressRequest,
+  ): Promise<ResolvedSandboxIngress> {
     // `pnpm worktree` runs kortix-api directly on the macOS host. The host
     // cannot resolve a container name from Docker's private DNS, so use the
     // loopback-only published port in that explicit development mode. Inspect
@@ -452,7 +461,9 @@ export class LocalDockerProvider implements SandboxProvider {
    * cross-provider logic uniform (and safe if a laptop ever runs two
    * kortix-api instances against the same daemon, e.g. dev + a worktree).
    */
-  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
+  async listManagedRunningSandboxes(): Promise<
+    Array<{ externalId: string; createdAt: Date | null }>
+  > {
     const docker = getDockerClient();
     await assertDockerReachable(docker);
     const containers = await docker.listContainers({
@@ -462,7 +473,10 @@ export class LocalDockerProvider implements SandboxProvider {
       }),
     });
     return containers.map((c) => ({
-      externalId: c.Labels?.['kortix.sandbox'] || c.Names?.[0]?.replace(/^\//, '').replace(CONTAINER_PREFIX, '') || c.Id,
+      externalId:
+        c.Labels?.['kortix.sandbox'] ||
+        c.Names?.[0]?.replace(/^\//, '').replace(CONTAINER_PREFIX, '') ||
+        c.Id,
       createdAt: c.Created ? new Date(c.Created * 1000) : null,
     }));
   }

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -266,6 +266,11 @@ export class PlatinumProvider implements SandboxProvider {
     };
   }
 
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // Platinum honors the image ENTRYPOINT on create and resumes its process
+    // tree on wake. appd is therefore already running.
+  }
+
   async start(externalId: string): Promise<void> {
     await platinumJson(`/v1/sandboxes/${externalId}/start`, { method: 'POST' });
   }

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -86,9 +86,7 @@ export class PlatinumProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [
-      { id: 'creating', progress: 50, message: 'Creating sandbox...' },
-    ],
+    stages: [{ id: 'creating', progress: 50, message: 'Creating sandbox...' }],
   };
 
   async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
@@ -104,7 +102,7 @@ export class PlatinumProvider implements SandboxProvider {
     if (!template) {
       throw new Error(
         'Platinum create() has no template: pass opts.snapshot or set PLATINUM_TEMPLATE ' +
-        '(a ready Platinum template id, e.g. kortix-computer).',
+          '(a ready Platinum template id, e.g. kortix-computer).',
       );
     }
     return this.provisionFromTemplate(template, opts);
@@ -118,7 +116,10 @@ export class PlatinumProvider implements SandboxProvider {
    * boot path can fall back to a name-boot; a transient 5xx (or any other error)
    * propagates UNCHANGED so it is surfaced/retried, never silently name-booted.
    */
-  async createFromExternalId(externalTemplateId: string, opts: CreateSandboxOpts): Promise<ProvisionResult> {
+  async createFromExternalId(
+    externalTemplateId: string,
+    opts: CreateSandboxOpts,
+  ): Promise<ProvisionResult> {
     if (!externalTemplateId || externalTemplateId.trim() === '') {
       throw new Error('[platinum] createFromExternalId called without a template id');
     }
@@ -134,10 +135,12 @@ export class PlatinumProvider implements SandboxProvider {
     }
   }
 
-  private async provisionFromTemplate(template: string, opts: CreateSandboxOpts): Promise<ProvisionResult> {
+  private async provisionFromTemplate(
+    template: string,
+    opts: CreateSandboxOpts,
+  ): Promise<ProvisionResult> {
     const workloadType = sandboxWorkloadType(opts);
-    const sandboxApiBase = config.KORTIX_URL
-      .replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
 
@@ -223,13 +226,19 @@ export class PlatinumProvider implements SandboxProvider {
     let exposedUrl = '';
     const _tExpose0 = Date.now();
     try {
-      const exposed = await platinumJson<PlatinumExposedPort>(`/v1/sandboxes/${externalId}/expose`, {
-        method: 'POST',
-        body: JSON.stringify({ port: ingressPort, public: true }),
-      });
+      const exposed = await platinumJson<PlatinumExposedPort>(
+        `/v1/sandboxes/${externalId}/expose`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ port: ingressPort, public: true }),
+        },
+      );
       exposedUrl = (exposed.url ?? '').replace(/\/$/, '');
     } catch (err) {
-      console.warn(`[platinum] eager expose ${externalId}:${AGENT_PORT} failed (lazy fallback):`, err);
+      console.warn(
+        `[platinum] eager expose ${externalId}:${AGENT_PORT} failed (lazy fallback):`,
+        err,
+      );
     }
     const _exposeMs = Date.now() - _tExpose0;
 
@@ -250,7 +259,7 @@ export class PlatinumProvider implements SandboxProvider {
     // becomes usable without any create-path hang.
     console.log(
       `[platinum-timing] ${externalId} vm-running=${_vmMs}ms expose=${_exposeMs}ms ` +
-      `edge=${exposedUrl ? 'ready' : 'lazy'} total=${Date.now() - _t0}ms (runtime-ready deferred to FE poll, like daytona)`,
+        `edge=${exposedUrl ? 'ready' : 'lazy'} total=${Date.now() - _t0}ms (runtime-ready deferred to FE poll, like daytona)`,
     );
 
     return {
@@ -264,6 +273,11 @@ export class PlatinumProvider implements SandboxProvider {
         workloadType,
       },
     };
+  }
+
+  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
+    // Platinum honors the image ENTRYPOINT on create and resumes its process
+    // tree on wake. appd is therefore already running.
   }
 
   async start(externalId: string): Promise<void> {
@@ -330,18 +344,22 @@ export class PlatinumProvider implements SandboxProvider {
     return 'recovering';
   }
 
-  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(
+    externalId: string,
+    request: SandboxIngressRequest,
+  ): Promise<ResolvedSandboxIngress> {
     const route = this.routeIngress(request);
     const effectivePort = route.effectivePort;
     // Expose the requested port through Platinum's edge → https://<port>-<id>.sbx…
     // No preview token: the sandbox is gated by the serviceKey bearer the proxy
     // already adds. Idempotent — re-exposing returns the same URL.
-    const exposed = await platinumJson<PlatinumExposedPort>(
-      `/v1/sandboxes/${externalId}/expose`,
-      { method: 'POST', body: JSON.stringify({ port: effectivePort, public: true }) },
-    );
+    const exposed = await platinumJson<PlatinumExposedPort>(`/v1/sandboxes/${externalId}/expose`, {
+      method: 'POST',
+      body: JSON.stringify({ port: effectivePort, public: true }),
+    });
     const url = (exposed.url ?? '').replace(/\/$/, '');
-    if (!url) throw new Error(`[platinum] expose returned no URL for ${externalId}:${effectivePort}`);
+    if (!url)
+      throw new Error(`[platinum] expose returned no URL for ${externalId}:${effectivePort}`);
     return {
       url,
       headers: {},
@@ -375,7 +393,10 @@ export class PlatinumProvider implements SandboxProvider {
     // {url,port,...} — the array {expose:[...]} shape is only valid on the
     // create route's inline expose. Sending the array here 400s.
     const ingress = await this.resolveIngress(externalId, { port: AGENT_PORT, transport: 'http' });
-    const headers: Record<string, string> = { ...ingress.headers, 'Content-Type': 'application/json' };
+    const headers: Record<string, string> = {
+      ...ingress.headers,
+      'Content-Type': 'application/json',
+    };
     try {
       const serviceKey = await serviceKeyForExternalId(externalId);
       if (serviceKey) headers['Authorization'] = `Bearer ${serviceKey}`;

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -86,7 +86,9 @@ export class PlatinumProvider implements SandboxProvider {
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
-    stages: [{ id: 'creating', progress: 50, message: 'Creating sandbox...' }],
+    stages: [
+      { id: 'creating', progress: 50, message: 'Creating sandbox...' },
+    ],
   };
 
   async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
@@ -102,7 +104,7 @@ export class PlatinumProvider implements SandboxProvider {
     if (!template) {
       throw new Error(
         'Platinum create() has no template: pass opts.snapshot or set PLATINUM_TEMPLATE ' +
-          '(a ready Platinum template id, e.g. kortix-computer).',
+        '(a ready Platinum template id, e.g. kortix-computer).',
       );
     }
     return this.provisionFromTemplate(template, opts);
@@ -116,10 +118,7 @@ export class PlatinumProvider implements SandboxProvider {
    * boot path can fall back to a name-boot; a transient 5xx (or any other error)
    * propagates UNCHANGED so it is surfaced/retried, never silently name-booted.
    */
-  async createFromExternalId(
-    externalTemplateId: string,
-    opts: CreateSandboxOpts,
-  ): Promise<ProvisionResult> {
+  async createFromExternalId(externalTemplateId: string, opts: CreateSandboxOpts): Promise<ProvisionResult> {
     if (!externalTemplateId || externalTemplateId.trim() === '') {
       throw new Error('[platinum] createFromExternalId called without a template id');
     }
@@ -135,12 +134,10 @@ export class PlatinumProvider implements SandboxProvider {
     }
   }
 
-  private async provisionFromTemplate(
-    template: string,
-    opts: CreateSandboxOpts,
-  ): Promise<ProvisionResult> {
+  private async provisionFromTemplate(template: string, opts: CreateSandboxOpts): Promise<ProvisionResult> {
     const workloadType = sandboxWorkloadType(opts);
-    const sandboxApiBase = config.KORTIX_URL.replace(/\/+$/, '')
+    const sandboxApiBase = config.KORTIX_URL
+      .replace(/\/+$/, '')
       .replace(/\/v1\/router$/, '')
       .replace(/\/v1$/, '');
 
@@ -226,19 +223,13 @@ export class PlatinumProvider implements SandboxProvider {
     let exposedUrl = '';
     const _tExpose0 = Date.now();
     try {
-      const exposed = await platinumJson<PlatinumExposedPort>(
-        `/v1/sandboxes/${externalId}/expose`,
-        {
-          method: 'POST',
-          body: JSON.stringify({ port: ingressPort, public: true }),
-        },
-      );
+      const exposed = await platinumJson<PlatinumExposedPort>(`/v1/sandboxes/${externalId}/expose`, {
+        method: 'POST',
+        body: JSON.stringify({ port: ingressPort, public: true }),
+      });
       exposedUrl = (exposed.url ?? '').replace(/\/$/, '');
     } catch (err) {
-      console.warn(
-        `[platinum] eager expose ${externalId}:${AGENT_PORT} failed (lazy fallback):`,
-        err,
-      );
+      console.warn(`[platinum] eager expose ${externalId}:${AGENT_PORT} failed (lazy fallback):`, err);
     }
     const _exposeMs = Date.now() - _tExpose0;
 
@@ -259,7 +250,7 @@ export class PlatinumProvider implements SandboxProvider {
     // becomes usable without any create-path hang.
     console.log(
       `[platinum-timing] ${externalId} vm-running=${_vmMs}ms expose=${_exposeMs}ms ` +
-        `edge=${exposedUrl ? 'ready' : 'lazy'} total=${Date.now() - _t0}ms (runtime-ready deferred to FE poll, like daytona)`,
+      `edge=${exposedUrl ? 'ready' : 'lazy'} total=${Date.now() - _t0}ms (runtime-ready deferred to FE poll, like daytona)`,
     );
 
     return {
@@ -273,11 +264,6 @@ export class PlatinumProvider implements SandboxProvider {
         workloadType,
       },
     };
-  }
-
-  async ensureAppRuntimeStarted(_externalId: string): Promise<void> {
-    // Platinum honors the image ENTRYPOINT on create and resumes its process
-    // tree on wake. appd is therefore already running.
   }
 
   async start(externalId: string): Promise<void> {
@@ -344,22 +330,18 @@ export class PlatinumProvider implements SandboxProvider {
     return 'recovering';
   }
 
-  async resolveIngress(
-    externalId: string,
-    request: SandboxIngressRequest,
-  ): Promise<ResolvedSandboxIngress> {
+  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
     const route = this.routeIngress(request);
     const effectivePort = route.effectivePort;
     // Expose the requested port through Platinum's edge → https://<port>-<id>.sbx…
     // No preview token: the sandbox is gated by the serviceKey bearer the proxy
     // already adds. Idempotent — re-exposing returns the same URL.
-    const exposed = await platinumJson<PlatinumExposedPort>(`/v1/sandboxes/${externalId}/expose`, {
-      method: 'POST',
-      body: JSON.stringify({ port: effectivePort, public: true }),
-    });
+    const exposed = await platinumJson<PlatinumExposedPort>(
+      `/v1/sandboxes/${externalId}/expose`,
+      { method: 'POST', body: JSON.stringify({ port: effectivePort, public: true }) },
+    );
     const url = (exposed.url ?? '').replace(/\/$/, '');
-    if (!url)
-      throw new Error(`[platinum] expose returned no URL for ${externalId}:${effectivePort}`);
+    if (!url) throw new Error(`[platinum] expose returned no URL for ${externalId}:${effectivePort}`);
     return {
       url,
       headers: {},
@@ -393,10 +375,7 @@ export class PlatinumProvider implements SandboxProvider {
     // {url,port,...} — the array {expose:[...]} shape is only valid on the
     // create route's inline expose. Sending the array here 400s.
     const ingress = await this.resolveIngress(externalId, { port: AGENT_PORT, transport: 'http' });
-    const headers: Record<string, string> = {
-      ...ingress.headers,
-      'Content-Type': 'application/json',
-    };
+    const headers: Record<string, string> = { ...ingress.headers, 'Content-Type': 'application/json' };
     try {
       const serviceKey = await serviceKeyForExternalId(externalId);
       if (serviceKey) headers['Authorization'] = `Bearer ${serviceKey}`;


### PR DESCRIPTION
## Problem

The first live Dev App deploy returned `500` before artifact upload. CloudWatch reported `StorageApiError: The object exceeded the maximum allowed size`. The Dev Supabase Management API reports `fileSizeLimit: 52428800`.

## Change

- cap source archives and the private `app-artifacts` bucket at 50 MiB
- retain unrestricted OCI image deployments
- add a regression test for the managed Storage limit

## Verification

- RED: focused test expected `52428800`, received `262144000`
- GREEN: `6 pass`, `0 fail`, `14 expect()`
- `pnpm --filter kortix typecheck`
- `git diff --check`