### PR TITLE
fix(apps,connectors): repair edge routing and long sync calls

### DIFF
--- a/apps/api/src/__tests__/unit-request-deadline.test.ts
+++ b/apps/api/src/__tests__/unit-request-deadline.test.ts
@@ -32,6 +32,7 @@ function makeApp() {
   app.get('/v1/projects/x/turn-stream', slow);      // JSON relay, bounded
   app.get('/v1/router/chat/completions', slow);      // exempt prefix
   app.get('/v1/llm/chat/completions', slow);          // exempt prefix (LLM streaming)
+  app.post('/v1/connectors/projects/x/connectors', slow); // exempt prefix (git + provider sync)
   app.post('/v1/billing/webhooks/stripe', slow);      // exempt prefix (webhook)
   app.post('/v1/projects/x/sessions/y/start', slow);  // exempt fragment (long sync op)
   app.post('/v1/projects/x/oauth/openai/start', slow); // exempt fragment (OAuth device flow — start can be slow on a cold replica)
@@ -77,6 +78,13 @@ describe('requestDeadline', () => {
 
   it('exempts the LLM completions prefix from the deadline', async () => {
     const res = await makeApp().request('/v1/llm/chat/completions');
+    expect(res.status).toBe(200);
+  });
+
+  it('exempts connector routes that can perform git and provider synchronization', async () => {
+    const res = await makeApp().request('/v1/connectors/projects/x/connectors', {
+      method: 'POST',
+    });
     expect(res.status).toBe(200);
   });
 

--- a/apps/api/src/apps/public-proxy.test.ts
+++ b/apps/api/src/apps/public-proxy.test.ts
@@ -9,6 +9,7 @@ const {
   appEdgeSignature,
   appUpstreamHeaders,
   resolveAppHost,
+  resolveAppRequest,
   verifyAppEdgeRequest,
 } = await import('./public-proxy');
 
@@ -40,6 +41,34 @@ describe('Apps public edge', () => {
     });
     expect(verifyAppEdgeRequest(request, new URL(request.url), false)).toBe(true);
     expect(verifyAppEdgeRequest(request, new URL(`https://${host}/api/other`), false)).toBe(false);
+  });
+
+  test('resolves and verifies the signed public host after the Worker forwards to the API host', () => {
+    const timestamp = String(Date.now());
+    const publicHost = 'dev-hello-aaaaaaaaaaaaaaaa.apps.kortix.com';
+    const secret = 'edge-secret-at-least-sixteen';
+    process.env.KORTIX_APPS_EDGE_SECRET = secret;
+    const signature = appEdgeSignature(timestamp, publicHost, 'GET', '/assets/app.js?q=1', secret);
+    const request = new Request('https://dev-api.kortix.com/assets/app.js?q=1', {
+      headers: {
+        'x-kortix-app-host': publicHost,
+        'x-kortix-app-timestamp': timestamp,
+        'x-kortix-app-signature': signature,
+      },
+    });
+
+    const resolved = resolveAppRequest(request, new URL(request.url));
+    expect(resolved).toEqual({
+      routeKey: 'aaaaaaaaaaaaaaaa',
+      local: false,
+      publicHost,
+    });
+    expect(verifyAppEdgeRequest(
+      request,
+      new URL(request.url),
+      false,
+      resolved!.publicHost,
+    )).toBe(true);
   });
 
   test('allows direct local development without Cloudflare headers', () => {

--- a/apps/api/src/apps/public-proxy.ts
+++ b/apps/api/src/apps/public-proxy.ts
@@ -37,6 +37,10 @@ export interface ResolvedAppHost {
   local: boolean;
 }
 
+export interface ResolvedAppRequest extends ResolvedAppHost {
+  publicHost: string;
+}
+
 export function resolveAppHost(hostname: string): ResolvedAppHost | null {
   const host = hostname.toLowerCase().replace(/\.$/, '');
   const local = /^([a-f0-9]{16})\.apps\.localhost$/.exec(host);
@@ -50,6 +54,14 @@ export function resolveAppHost(hostname: string): ResolvedAppHost | null {
   const match = /^(dev|staging|prod|preview)-[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?-([a-f0-9]{16})$/.exec(label);
   if (!match || match[1] !== config.INTERNAL_KORTIX_ENV) return null;
   return { routeKey: match[2]!, local: false };
+}
+
+export function resolveAppRequest(request: Request, url: URL): ResolvedAppRequest | null {
+  const publicHost = (request.headers.get(EDGE_HOST_HEADER) || url.hostname)
+    .toLowerCase()
+    .replace(/\.$/, '');
+  const matched = resolveAppHost(publicHost);
+  return matched ? { ...matched, publicHost } : null;
 }
 
 function edgeSecret(): string {
@@ -74,14 +86,19 @@ function safeEqual(left: string, right: string): boolean {
   return a.length === b.length && timingSafeEqual(a, b);
 }
 
-export function verifyAppEdgeRequest(request: Request, url: URL, local: boolean): boolean {
+export function verifyAppEdgeRequest(
+  request: Request,
+  url: URL,
+  local: boolean,
+  publicHost = url.hostname,
+): boolean {
   if (local && (process.env.KORTIX_APPS_ALLOW_LOCAL_EDGE !== 'false')) return true;
   if (process.env.KORTIX_APPS_ALLOW_DIRECT_EDGE === 'true') return true;
   const host = request.headers.get(EDGE_HOST_HEADER);
   const timestamp = request.headers.get(EDGE_TIMESTAMP_HEADER);
   const signature = request.headers.get(EDGE_SIGNATURE_HEADER);
   if (!host || !timestamp || !signature) return false;
-  if (host.toLowerCase() !== url.hostname.toLowerCase()) return false;
+  if (host.toLowerCase() !== publicHost.toLowerCase()) return false;
   const time = Number(timestamp);
   if (!Number.isFinite(time) || Math.abs(Date.now() - time) > EDGE_MAX_SKEW_MS) return false;
   return safeEqual(
@@ -267,9 +284,9 @@ export function appUpstreamHeaders(request: Request, providerHeaders: Record<str
 
 export async function handleAppPublicRequest(request: Request): Promise<Response | null> {
   const url = new URL(request.url);
-  const matched = resolveAppHost(url.hostname);
+  const matched = resolveAppRequest(request, url);
   if (!matched) return null;
-  if (!verifyAppEdgeRequest(request, url, matched.local)) {
+  if (!verifyAppEdgeRequest(request, url, matched.local, matched.publicHost)) {
     return Response.json({ error: 'Invalid App edge signature' }, { status: 403 });
   }
   const loaded = await loadPublicApp(matched.routeKey);
@@ -302,7 +319,7 @@ export async function handleAppPublicRequest(request: Request): Promise<Response
   try {
     upstream = await fetch(upstreamUrl, {
       method: request.method,
-      headers: appUpstreamHeaders(request, ingress.headers, url.host),
+      headers: appUpstreamHeaders(request, ingress.headers, matched.publicHost),
       body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
       redirect: 'manual',
       duplex: 'half',

--- a/apps/api/src/apps/ws-proxy.ts
+++ b/apps/api/src/apps/ws-proxy.ts
@@ -8,7 +8,7 @@ import {
   appUpstreamHeaders,
   ensureAppRuntimeRunning,
   loadPublicApp,
-  resolveAppHost,
+  resolveAppRequest,
   verifyAppEdgeRequest,
 } from './public-proxy';
 
@@ -55,9 +55,9 @@ export async function prepareAppWsUpgrade(
   request: Request,
   url: URL,
 ): Promise<{ ok: true; data: AppWsData } | { ok: false; status: number; message: string }> {
-  const matched = resolveAppHost(url.hostname);
+  const matched = resolveAppRequest(request, url);
   if (!matched) return { ok: false, status: 404, message: 'not an App hostname' };
-  if (!verifyAppEdgeRequest(request, url, matched.local)) {
+  if (!verifyAppEdgeRequest(request, url, matched.local, matched.publicHost)) {
     return { ok: false, status: 403, message: 'Invalid App edge signature' };
   }
   const loaded = await loadPublicApp(matched.routeKey);
@@ -71,7 +71,7 @@ export async function prepareAppWsUpgrade(
       runtime.externalId,
       'websocket',
     );
-    const headers = appUpstreamHeaders(request, ingress.headers, url.host);
+    const headers = appUpstreamHeaders(request, ingress.headers, matched.publicHost);
     const headerObject = Object.fromEntries(headers.entries());
     return {
       ok: true,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -89,7 +89,7 @@ import {
 import { startProjectMaintenance, stopProjectMaintenance } from './projects/maintenance';
 import { kickStartupPreBuild } from './snapshots/builder';
 import { registerSunaMigrationRoutes } from './projects/suna-migration/suna-migration-routes';
-import { handleAppPublicRequest, resolveAppHost } from './apps/public-proxy';
+import { handleAppPublicRequest, resolveAppRequest } from './apps/public-proxy';
 import { appWsHandlers, prepareAppWsUpgrade } from './apps/ws-proxy';
 import {
   startSunaMigrationWorker,
@@ -1432,7 +1432,7 @@ export default {
     // Matches `p{port}-{sandboxId}.localhost:{apiPort}` regardless of path.
     // Same per-request long-poll/SSE timeout posture as /v1/p/.
     const host = req.headers.get('host') || '';
-    if (resolveAppHost(url.hostname)) {
+    if (resolveAppRequest(req, url)) {
       server.timeout(req, 0);
       if (isWsUpgrade) {
         const prepared = await prepareAppWsUpgrade(req, url);

--- a/apps/api/src/middleware/request-deadline.ts
+++ b/apps/api/src/middleware/request-deadline.ts
@@ -58,7 +58,7 @@ const EXEMPT_PREFIXES = [
   '/v1/router',   // LLM gateway — streamed chat completions
   '/v1/llm',      // LLM chat completions (streamed; p99 >10s is normal)
   '/v1/llm-gateway', // reverse proxy to the standalone gateway (streamed SSE)
-  '/v1/connector', // connector proxy — forwards to arbitrary upstream APIs
+  '/v1/connectors', // connector calls + git/provider sync — arbitrary upstream latency
   '/v1/webhooks', // inbound webhooks (Slack, …) — callers retry, don't truncate
   '/v1/billing/webhooks',   // Stripe webhook processing (observed >60s, legit)
   '/v1/billing/revenuecat', // RevenueCat sync — batch reconcile, legit-long


### PR DESCRIPTION
Two live staging defects block the release.

1. The Apps Worker forwards requests to the API hostname and signs the original public hostname in `x-kortix-app-host`. The API resolved only `request.url.hostname`, so every edge request bypassed the App proxy and returned the generic API `404`. The API now resolves and verifies the signed public host for HTTP and WebSocket requests.

2. The request deadline exempted `/v1/connector`, but the real route prefix is `/v1/connectors`. A real agent-token `connectors add --apply` completed its manifest write, then returned `503` at 25.6 seconds. The corrected prefix permits legitimate git and provider synchronization to finish.

Live evidence before the fixes:
- App edge HTTP reached the Worker but returned the generic API body `{"error":true,"message":"Not found","status":404}`.
- The full staging agent-PAT matrix reported `104 passed, 1 failed`; the failure log was `Request exceeded the 25s server processing deadline`.

Verification:
- `bun test --isolate --env-file=apps/api/scripts/test.env apps/api/src/__tests__/unit-request-deadline.test.ts apps/api/src/apps/public-proxy.test.ts` — 22 passed
- `bun test infra/cloudflare/workers/apps-router/worker.test.mjs` — 3 passed
- `pnpm --filter kortix typecheck` — passed