### PR TITLE
ci(apps): provision nested wildcard certificate

### DIFF
--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -14,12 +14,13 @@ jobs:
   configure:
     name: Configure and verify Apps edge
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
       APPS_DNS_NAME: '*.apps.kortix.com'
       APPS_DNS_TARGET: '192.0.2.1'
+      APPS_CERT_HOST: '*.apps.kortix.com'
     steps:
       - uses: actions/checkout@v7
 
@@ -101,6 +102,86 @@ jobs:
               .result[0].content == $content and
               .result[0].proxied == true
             ' <<<"$records"
+
+      - name: Create or verify nested wildcard certificate
+        run: |
+          set -euo pipefail
+          api="https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/ssl/certificate_packs"
+          auth=(--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
+
+          list_packs() {
+            curl --fail-with-body --silent --show-error "${auth[@]}" "$api"
+          }
+
+          packs="$(list_packs)"
+          jq -e '.success == true' <<<"$packs"
+          pack_id="$(jq -r --arg host "$APPS_CERT_HOST" '
+            [.result[]
+              | select(.type == "advanced")
+              | select((.hosts // []) | index($host))
+              | select(.status != "expired" and .status != "deleted" and .status != "pending_deletion")
+            ][0].id // empty
+          ' <<<"$packs")"
+
+          if [ -n "$pack_id" ]; then
+            status="$(jq -r --arg id "$pack_id" '.result[] | select(.id == $id) | .status' <<<"$packs")"
+            if [ "$status" = validation_timed_out ]; then
+              restarted="$({
+                curl --fail-with-body --silent --show-error \
+                  --request PATCH \
+                  "${auth[@]}" \
+                  --header 'Content-Type: application/json' \
+                  --data '{"cloudflare_branding":false}' \
+                  "$api/$pack_id"
+              })"
+              jq -e '.success == true' <<<"$restarted"
+            fi
+          else
+            order="$(jq -n '{
+              type: "advanced",
+              hosts: ["kortix.com", "apps.kortix.com", "*.apps.kortix.com"],
+              validation_method: "txt",
+              validity_days: 90,
+              certificate_authority: "lets_encrypt",
+              cloudflare_branding: false
+            }')"
+            created="$({
+              curl --fail-with-body --silent --show-error \
+                --request POST \
+                "${auth[@]}" \
+                --header 'Content-Type: application/json' \
+                --data "$order" \
+                "$api/order"
+            })"
+            jq -e '.success == true' <<<"$created"
+            pack_id="$(jq -er '.result.id' <<<"$created")"
+          fi
+
+          for attempt in $(seq 1 90); do
+            packs="$(list_packs)"
+            status="$(jq -r --arg id "$pack_id" '.result[] | select(.id == $id) | .status' <<<"$packs")"
+            case "$status" in
+              active)
+                jq -e --arg id "$pack_id" --arg host "$APPS_CERT_HOST" '
+                  any(.result[];
+                    .id == $id and
+                    .status == "active" and
+                    ((.hosts // []) | index($host))
+                  )
+                ' <<<"$packs"
+                exit 0
+                ;;
+              validation_timed_out|expired|deleted)
+                echo "::error::Certificate pack $pack_id reached terminal status $status."
+                exit 1
+                ;;
+            esac
+            if [ "$attempt" = 90 ]; then
+              echo "::error::Certificate pack $pack_id stayed in status $status for 15 minutes."
+              exit 1
+            fi
+            sleep 10
+          done
 
       - name: Verify public DNS and TLS routing
         run: |


### PR DESCRIPTION
## Summary
- reuse or order an Advanced Certificate Manager pack for `*.apps.kortix.com`
- restart timed-out validation and wait for active issuance
- verify the nested wildcard before the existing public TLS probe

## Verification
- `actionlint .github/workflows/configure-apps-edge.yml`
- `git diff --check`
- Cloudflare request schema checked against the current official OpenAPI contract