### PR TITLE
fix(apps): update Caddy security release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
             api:
               - *pnpm
               - 'apps/api/**'
+              - 'apps/kortix-app-runtime/**'
               - 'packages/agent-tunnel/**'
               - 'packages/api-contract/**'
               - 'packages/db/**'
@@ -85,6 +86,7 @@ jobs:
             self_host:
               - *pnpm
               - 'apps/api/Dockerfile'
+              - 'apps/kortix-app-runtime/**'
               - 'apps/api/src/snapshots/builder.ts'
               - 'apps/api/src/config.ts'
               - 'packages/db/**'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -54,6 +54,7 @@ jobs:
           filters: |
             api:
               - 'apps/api/**'
+              - 'apps/kortix-app-runtime/**'
               - 'apps/kortix-sandbox-agent-server/**'
               - 'apps/sandbox/**'
               - 'apps/cli/**'          # baked into the API image (sandbox kortix CLI)

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - "infra/**"
       - "apps/*/Dockerfile"
+      - "apps/kortix-app-runtime/**"
       - ".github/workflows/security-scan.yml"
       - ".gitleaks.toml"
   workflow_dispatch:

--- a/apps/kortix-app-runtime/build.sh
+++ b/apps/kortix-app-runtime/build.sh
@@ -15,7 +15,7 @@ mkdir -p "${runtime_dir}/dist"
 
 # Keep the ingress binary reproducible. The Go checksum database verifies the
 # module contents. Provider build contexts consume this exact staged binary.
-CADDY_VERSION="v2.10.2"
+CADDY_VERSION="v2.11.4"
 build_gopath="$(mktemp -d)"
 trap 'rm -rf "${build_gopath}"' EXIT
 GOMODCACHE="$(go env GOMODCACHE)" GOPATH="${build_gopath}" \

--- a/apps/kortix-app-runtime/build_test.go
+++ b/apps/kortix-app-runtime/build_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestBuildPinsPatchedCaddyRelease(t *testing.T) {
+	buildScript, err := os.ReadFile("build.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(buildScript), `CADDY_VERSION="v2.11.4"`) {
+		t.Fatal("build.sh must pin Caddy v2.11.4")
+	}
+}

--- a/tests/unit/app-runtime-workflow.test.ts
+++ b/tests/unit/app-runtime-workflow.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflowPaths = [
+  '../../.github/workflows/ci.yml',
+  '../../.github/workflows/deploy-dev.yml',
+  '../../.github/workflows/security-scan.yml',
+] as const;
+
+describe('app runtime workflow coverage', () => {
+  it.each(workflowPaths)('%s watches the app runtime build inputs', (workflowPath) => {
+    const workflow = readFileSync(resolve(import.meta.dirname, workflowPath), 'utf8');
+
+    expect(workflow).toContain('apps/kortix-app-runtime/**');
+  });
+});


### PR DESCRIPTION
## Summary

- update the app runtime Caddy pin from `v2.10.2` to `v2.11.4`
- remove five fixable critical Go dependency findings from the API image
- add regression coverage for the patched Caddy release floor

## Verification

- `docker run --rm -v "$PWD/apps/kortix-app-runtime:/src" -w /src golang:1.25-bookworm sh -c "go test ./..."`
- `docker run --rm -v trivy-cache:/root/.cache/trivy -v "$PWD/apps/kortix-app-runtime/dist:/target:ro" aquasec/trivy:0.70.0 rootfs --scanners vuln --severity CRITICAL --ignore-unfixed --exit-code 1 /target`
- Trivy result: `caddy-linux-amd64: 0`, `kortix-appd-linux-amd64: 0`
- `git diff --check`