### PR TITLE
fix(apps): build patched Caddy in API image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /runtime
 COPY apps/kortix-app-runtime/go.mod apps/kortix-app-runtime/main.go ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -buildvcs=false -trimpath -ldflags='-s -w' -o /out/kortix-appd . && \
-    GOBIN=/out go install -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.10.2
+    GOBIN=/out go install -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4
 
 # ---- Sandbox Agent Stage ----
 # The API builds Daytona layered snapshots at runtime. Those snapshots bake the

--- a/apps/kortix-app-runtime/build_test.go
+++ b/apps/kortix-app-runtime/build_test.go
@@ -14,4 +14,15 @@ func TestBuildPinsPatchedCaddyRelease(t *testing.T) {
 	if !strings.Contains(string(buildScript), `CADDY_VERSION="v2.11.4"`) {
 		t.Fatal("build.sh must pin Caddy v2.11.4")
 	}
+
+	dockerfile, err := os.ReadFile("../api/Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(dockerfile), "github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4") {
+		t.Fatal("apps/api/Dockerfile must pin Caddy v2.11.4")
+	}
+	if strings.Contains(string(dockerfile), "github.com/caddyserver/caddy/v2/cmd/caddy@v2.10.2") {
+		t.Fatal("apps/api/Dockerfile must not build the vulnerable Caddy v2.10.2 release")
+	}
 }


### PR DESCRIPTION
## Problem

Deploy Dev run `31159454367` built Caddy `v2.10.2` from `apps/api/Dockerfile`. Trivy blocked the API image with five fixable CRITICAL CVEs. PR #6208 updated `build.sh` to `v2.11.4` but did not update the Dockerfile used by Deploy Dev.

## Change

- Pin the API image App runtime stage to Caddy `v2.11.4`.
- Extend the Go regression test to require the same patched version in `build.sh` and `apps/api/Dockerfile`.

## Verification

- `go test ./...` in `apps/kortix-app-runtime`: pass.
- `bun x vitest run --config unit/vitest.config.ts unit/app-runtime-workflow.test.ts`: 3 passed.
- `bash build.sh`: built the Linux amd64 App runtime and Caddy binaries.
- `go version -m dist/caddy-linux-amd64`: Caddy `v2.11.4`, pgx `v5.9.2`, smallstep certificates `v0.30.2`, grpc `v1.81.0`.
- Trivy `0.70.0` CRITICAL scan of `caddy-linux-amd64`: 0 vulnerabilities.

## Live blocker

This PR unblocks the Kortix Apps dev deployment and live acceptance run.