### PR TITLE
fix(api): use patched Caddy in runtime image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /runtime
 COPY apps/kortix-app-runtime/go.mod apps/kortix-app-runtime/main.go ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -buildvcs=false -trimpath -ldflags='-s -w' -o /out/kortix-appd . && \
-    GOBIN=/out go install -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.10.2
+    GOBIN=/out go install -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4
 
 # ---- Sandbox Agent Stage ----
 # The API builds Daytona layered snapshots at runtime. Those snapshots bake the

--- a/apps/kortix-app-runtime/build_test.go
+++ b/apps/kortix-app-runtime/build_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -13,5 +14,18 @@ func TestBuildPinsPatchedCaddyRelease(t *testing.T) {
 	}
 	if !strings.Contains(string(buildScript), `CADDY_VERSION="v2.11.4"`) {
 		t.Fatal("build.sh must pin Caddy v2.11.4")
+	}
+
+	dockerfile, err := os.ReadFile("../api/Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	versionPattern := regexp.MustCompile(`github\.com/caddyserver/caddy/v2/cmd/caddy@(v[0-9]+\.[0-9]+\.[0-9]+)`)
+	match := versionPattern.FindStringSubmatch(string(dockerfile))
+	if len(match) != 2 {
+		t.Fatal("API Dockerfile must pin a Caddy release")
+	}
+	if match[1] != "v2.11.4" {
+		t.Fatalf("API Dockerfile must pin Caddy v2.11.4, got %s", match[1])
 	}
 }


### PR DESCRIPTION
## Summary

- update the API Docker build stage to Caddy v2.11.4
- verify the Dockerfile pin in the app runtime test
- prevent the standalone build script and deployed API image from drifting

## Verification

- `docker run --rm -v "$PWD/apps/kortix-app-runtime:/runtime" -v "$PWD/apps/api:/api:ro" -w /runtime golang:1.25-bookworm go test ./...`
- `docker build --target app-runtime --no-cache -f apps/api/Dockerfile -t kortix-api-app-runtime:caddy-v2.11.4 .`
- Trivy 0.70.0: 0 fixable CRITICAL vulnerabilities in the rebuilt stage
- `git diff --check`