### PR TITLE
release: refresh staging with current main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
             api:
               - *pnpm
               - 'apps/api/**'
+              - 'apps/kortix-app-runtime/**'
               - 'packages/agent-tunnel/**'
               - 'packages/api-contract/**'
               - 'packages/db/**'
@@ -85,6 +86,7 @@ jobs:
             self_host:
               - *pnpm
               - 'apps/api/Dockerfile'
+              - 'apps/kortix-app-runtime/**'
               - 'apps/api/src/snapshots/builder.ts'
               - 'apps/api/src/config.ts'
               - 'packages/db/**'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -54,6 +54,7 @@ jobs:
           filters: |
             api:
               - 'apps/api/**'
+              - 'apps/kortix-app-runtime/**'
               - 'apps/kortix-sandbox-agent-server/**'
               - 'apps/sandbox/**'
               - 'apps/cli/**'          # baked into the API image (sandbox kortix CLI)

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - "infra/**"
       - "apps/*/Dockerfile"
+      - "apps/kortix-app-runtime/**"
       - ".github/workflows/security-scan.yml"
       - ".gitleaks.toml"
   workflow_dispatch:

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /runtime
 COPY apps/kortix-app-runtime/go.mod apps/kortix-app-runtime/main.go ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -buildvcs=false -trimpath -ldflags='-s -w' -o /out/kortix-appd . && \
-    GOBIN=/out go install -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.10.2
+    GOBIN=/out go install -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4
 
 # ---- Sandbox Agent Stage ----
 # The API builds Daytona layered snapshots at runtime. Those snapshots bake the

--- a/apps/kortix-app-runtime/build.sh
+++ b/apps/kortix-app-runtime/build.sh
@@ -15,7 +15,7 @@ mkdir -p "${runtime_dir}/dist"
 
 # Keep the ingress binary reproducible. The Go checksum database verifies the
 # module contents. Provider build contexts consume this exact staged binary.
-CADDY_VERSION="v2.10.2"
+CADDY_VERSION="v2.11.4"
 build_gopath="$(mktemp -d)"
 trap 'rm -rf "${build_gopath}"' EXIT
 GOMODCACHE="$(go env GOMODCACHE)" GOPATH="${build_gopath}" \

--- a/apps/kortix-app-runtime/build_test.go
+++ b/apps/kortix-app-runtime/build_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestBuildPinsPatchedCaddyRelease(t *testing.T) {
+	buildScript, err := os.ReadFile("build.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(buildScript), `CADDY_VERSION="v2.11.4"`) {
+		t.Fatal("build.sh must pin Caddy v2.11.4")
+	}
+}

--- a/apps/kortix-app-runtime/build_test.go
+++ b/apps/kortix-app-runtime/build_test.go
@@ -14,4 +14,15 @@ func TestBuildPinsPatchedCaddyRelease(t *testing.T) {
 	if !strings.Contains(string(buildScript), `CADDY_VERSION="v2.11.4"`) {
 		t.Fatal("build.sh must pin Caddy v2.11.4")
 	}
+
+	dockerfile, err := os.ReadFile("../api/Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(dockerfile), "github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4") {
+		t.Fatal("apps/api/Dockerfile must pin Caddy v2.11.4")
+	}
+	if strings.Contains(string(dockerfile), "github.com/caddyserver/caddy/v2/cmd/caddy@v2.10.2") {
+		t.Fatal("apps/api/Dockerfile must not build the vulnerable Caddy v2.10.2 release")
+	}
 }

--- a/tests/unit/app-runtime-workflow.test.ts
+++ b/tests/unit/app-runtime-workflow.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflowPaths = [
+  '../../.github/workflows/ci.yml',
+  '../../.github/workflows/deploy-dev.yml',
+  '../../.github/workflows/security-scan.yml',
+] as const;
+
+describe('app runtime workflow coverage', () => {
+  it.each(workflowPaths)('%s watches the app runtime build inputs', (workflowPath) => {
+    const workflow = readFileSync(resolve(import.meta.dirname, workflowPath), 'utf8');
+
+    expect(workflow).toContain('apps/kortix-app-runtime/**');
+  });
+});


### PR DESCRIPTION
## Scope

Promote the current `main` candidate into `staging`.

This refresh adds the Apps runtime security fixes merged after PR #6203:

- #6208 updates the pinned Caddy security release and deploy workflow coverage.
- #6209 builds the patched Caddy binary in the API image.

The candidate retains #6206, which fixes signed Apps hostname routing and the plural `/v1/connectors` deadline exemption.

## Existing staging evidence

Candidate `39c66b2986c630493ac72db12aeca913edc77510` passed QA Staging, Build Staging, DB migrations, ECS, Vercel, live SHA verification, and the agent-token CLI matrix (`105 passed, 0 failed`).

This PR requires a fresh staging deploy and the same live verification before production promotion.

## Known compliance result

Drata finding `8025` is the documented AWS Describe-only false positive in `docs/compliance/IAC-SCANNER-EXCEPTIONS.md`.