### PR TITLE
fix(apps): build static Caddy runtime

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,7 +22,8 @@ WORKDIR /runtime
 COPY apps/kortix-app-runtime/go.mod apps/kortix-app-runtime/main.go ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -buildvcs=false -trimpath -ldflags='-s -w' -o /out/kortix-appd . && \
-    GOBIN=/out go install -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOBIN=/out go install \
+      -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4
 
 # ---- Sandbox Agent Stage ----
 # The API builds Daytona layered snapshots at runtime. Those snapshots bake the

--- a/apps/kortix-app-runtime/build_test.go
+++ b/apps/kortix-app-runtime/build_test.go
@@ -25,4 +25,10 @@ func TestBuildPinsPatchedCaddyRelease(t *testing.T) {
 	if strings.Contains(string(dockerfile), "github.com/caddyserver/caddy/v2/cmd/caddy@v2.10.2") {
 		t.Fatal("apps/api/Dockerfile must not build the vulnerable Caddy v2.10.2 release")
 	}
+	if !strings.Contains(
+		string(dockerfile),
+		"CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOBIN=/out go install",
+	) {
+		t.Fatal("apps/api/Dockerfile must build a static Linux amd64 Caddy binary for Alpine App snapshots")
+	}
 }


### PR DESCRIPTION
## Problem

The live Daytona acceptance deployment reached runtime readiness checks, but port `7331` returned `502` for 120 seconds. Direct sandbox inspection showed:

```text
2026/08/07 09:11:01 start caddy: fork/exec /kortix/bin/caddy: no such file or directory
```

`/kortix/bin/caddy` existed and was executable. `apps/api/Dockerfile` built it with CGO enabled in Debian, then the App snapshot ran it in Alpine without glibc.

## Change

- Build Caddy with `CGO_ENABLED=0 GOOS=linux GOARCH=amd64`.
- Add a regression assertion for the static Linux build contract.

## Verification

- Failing regression test reproduced the missing static build contract.
- `go test ./...`: pass.
- `file dist/caddy-linux-amd64`: `ELF 64-bit ... statically linked ... stripped`.
- `bun x vitest run --config unit/vitest.config.ts unit/app-runtime-workflow.test.ts`: 3 passed.

The failed acceptance App was deleted through `kortix apps delete --yes`; no failed Daytona retry remains active.