### PR TITLE
feat(daemon): verified opencode reload — boot the new one, then retire the old

### DIFF
--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -12,6 +12,7 @@
  *     (added as a header in resolveEndpoint, same effective auth as Daytona).
  */
 
+import { isOpencodePort } from '../../shared/opencode-ports';
 import { platinumJson } from '../../shared/platinum';
 import { serviceKeyForExternalId } from '../service-key';
 import { sandboxFrontendBaseUrl } from '../sandbox-frontend-url';
@@ -359,7 +360,11 @@ export class PlatinumProvider implements SandboxProvider {
     const ptyWebsocket =
       request.transport === 'websocket' && classifyPtyWebSocketPath(request.path) !== null;
     return {
-      effectivePort: request.port === 4096 || ptyWebsocket ? AGENT_PORT : request.port,
+      // Either half of the opencode pair rewrites to the agent bridge —
+      // Platinum cannot expose opencode's port directly. After a verified
+      // reload the live half may be the standby, and matching only 4096 would
+      // send it upstream unrewritten (see shared/opencode-ports).
+      effectivePort: isOpencodePort(request.port) || ptyWebsocket ? AGENT_PORT : request.port,
       websocket: ptyWebsocket
         ? {
             userContextQueryParam: '__kortix_user_context',

--- a/apps/api/src/projects/lib/agent-config-push.test.ts
+++ b/apps/api/src/projects/lib/agent-config-push.test.ts
@@ -36,7 +36,8 @@ const SESSION_ROW = {
   accountId: 'acct-1',
 };
 let activeSandbox: { externalId: string; config: Record<string, unknown> } | null = SANDBOX_ROW;
-let daemonProof = true;
+let daemonProof = true
+let daemonReload: string | null = 'restarted';
 
 // Spread: the module also exports `agentConfigEtag`, which sandbox-env-sync now
 // imports. A partial mock silently drops it and the module fails to load.
@@ -103,6 +104,9 @@ const ORIGINAL_FETCH = globalThis.fetch;
     managed: 1,
     withheld: 0,
     agent_env_written: daemonProof,
+    // How the daemon applied it. 'kept-old' is the verified swap declining a
+    // config that would not boot — the push landed, the config did not.
+    opencode_reload: daemonReload,
   });
 };
 
@@ -128,6 +132,7 @@ beforeEach(() => {
   posted = [];
   activeSandbox = SANDBOX_ROW;
   daemonProof = true;
+  daemonReload = 'restarted';
 });
 
 describe('propagateProjectSecretsToActiveSandboxes', () => {
@@ -180,10 +185,27 @@ describe('pushSessionAgentConfigToSandbox', () => {
     // nothing — `refreshModels` is what makes the daemon restart it and apply.
     const result = await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
 
-    expect(result).toEqual({ applied: true });
+    expect(result).toMatchObject({ applied: true, opencodeReload: 'restarted' });
     expect(posted).toHaveLength(1);
     expect(posted[0].opencodeEnv?.KORTIX_COMPILED_AGENT_CONFIG).toBe(compiled as string);
     expect(posted[0].refreshModels).toBe(true);
+  });
+
+  test('a declined swap is reported, not hidden behind applied:true', async () => {
+    // The verified reload booted the new opencode, it never served, so the box
+    // kept the one it had. We DID push — `applied` stays true — but the config
+    // did not take, and only `opencodeReload` can say so. Collapsing this to a
+    // bare success is exactly the silent no-op the swap exists to prevent.
+    daemonReload = 'kept-old';
+    const result = await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
+    expect(result.applied).toBe(true);
+    expect(result.opencodeReload).toBe('kept-old');
+  });
+
+  test('an older daemon that says nothing reports null, never success', async () => {
+    daemonReload = null;
+    const result = await pushSessionAgentConfigToSandbox({ ...INPUT, baseRef: 'main' });
+    expect(result.opencodeReload).toBeNull();
   });
 
   test("recompiles from the SESSION's ref", async () => {

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -212,6 +212,13 @@ async function postEnvToDaemon(args: {
   managed: number | null;
   withheld: number | null;
   agentEnvWritten: boolean;
+  /**
+   * How the daemon applied the config, or null when it did not say (an older
+   * daemon, or no reload was needed). 'kept-old' is the verified swap
+   * declining: the new opencode never came up and the previous one still
+   * serves — the push landed, the config did not.
+   */
+  opencodeReload: 'disposed' | 'restarted' | 'kept-old' | null;
 }> {
   if (!isSecureOrPrivateTarget(args.previewUrl)) {
     throw new Error('refusing to push secrets over insecure transport (non-TLS public host)');
@@ -260,6 +267,7 @@ async function postEnvToDaemon(args: {
     withheld?: unknown;
     agent_env_written?: unknown;
     opencode?: unknown;
+    opencode_reload?: unknown;
   } | null;
   const expectedExported = Object.keys(args.snapshot.env).length;
   if (args.requireAgentEnvProof) {
@@ -276,6 +284,14 @@ async function postEnvToDaemon(args: {
   }
   return {
     opencodeState: typeof body?.opencode === 'string' ? body.opencode : null,
+    // How the daemon applied the config. 'kept-old' means the verified swap
+    // declined: the new opencode never came up, so the running one still
+    // serves and the change did NOT take. An older daemon omits the field
+    // entirely — null, meaning "could not tell", never "it worked".
+    opencodeReload:
+      typeof body?.opencode_reload === 'string'
+        ? (body.opencode_reload as 'disposed' | 'restarted' | 'kept-old')
+        : null,
     revision: typeof body?.revision === 'string' ? body.revision : args.snapshot.revision,
     exported: typeof body?.exported === 'number' ? body.exported : expectedExported,
     managed: typeof body?.managed === 'number' ? body.managed : null,
@@ -637,7 +653,7 @@ export async function pushSessionAgentConfigToSandbox(input: {
   defaultBranch: string;
   manifestPath?: string | null;
   baseRef?: string | null;
-}): Promise<{ applied: boolean; reason?: string }> {
+}): Promise<{ applied: boolean; reason?: string; opencodeReload?: 'disposed' | 'restarted' | 'kept-old' | null }> {
   try {
     const compiled = await resolveCompiledAgentConfigForSession(
       {
@@ -675,7 +691,7 @@ export async function pushSessionAgentConfigToSandbox(input: {
       port: SANDBOX_SERVICE_PORT,
       transport: 'http',
     });
-    await postEnvToDaemon({
+    const pushed = await postEnvToDaemon({
       previewUrl: url,
       providerHeaders: headers,
       serviceKey,
@@ -689,7 +705,10 @@ export async function pushSessionAgentConfigToSandbox(input: {
       // Restarts opencode so it rebuilds its config against the new agents.
       refreshModels: true,
     });
-    return { applied: true };
+    // `applied` means WE pushed it. Whether opencode actually took it is
+    // `opencodeReload` — a declined swap leaves the old config running, and
+    // reporting a bare `applied: true` for that is the lie this field prevents.
+    return { applied: true, opencodeReload: pushed.opencodeReload };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     console.warn(`[env-sync] agent-config push failed for session ${input.sessionId}:`, reason);

--- a/apps/api/src/projects/lib/session-reload.test.ts
+++ b/apps/api/src/projects/lib/session-reload.test.ts
@@ -184,6 +184,7 @@ describe('reloadDetail', () => {
     etag: 'bbbb',
     repo_refreshed: true,
     commit_sha: null,
+    opencode_reload: null,
   } as const;
 
   test('claims the agent changed ONLY for "updated"', () => {
@@ -233,6 +234,7 @@ describe('reloadNeedsAttention', () => {
     etag: 'bbbb',
     repo_refreshed: true,
     commit_sha: null,
+    opencode_reload: null,
   } as const;
 
   test('the three success outcomes are NOT warnings', () => {

--- a/apps/api/src/projects/lib/session-reload.ts
+++ b/apps/api/src/projects/lib/session-reload.ts
@@ -112,6 +112,18 @@ export interface SessionReloadResult {
    * classified real successes as warnings and vice versa.
    */
   agent_files: ReloadAgentFiles;
+  /**
+   * How the box applied the new config, when it said.
+   *
+   * `kept-old` is the verified swap declining: the daemon booted the new
+   * opencode, it never started serving, so the previous one was left running.
+   * The push landed and the config did NOT take — which is a FAILED reload with
+   * a healthy session, a combination `applied` alone cannot express.
+   *
+   * `null` means the box did not say (a daemon older than the verified swap, or
+   * no reload was needed) — never "it worked".
+   */
+  opencode_reload: 'disposed' | 'restarted' | 'kept-old' | null;
   /** Present when nothing was applied. */
   reason?: string;
 }
@@ -305,6 +317,7 @@ export async function reloadSessionConfig(input: {
       repo_refreshed: false,
       commit_sha: null,
       agent_files: 'unknown',
+      opencode_reload: null,
       reason: 'no reachable sandbox',
     };
   }
@@ -322,6 +335,7 @@ export async function reloadSessionConfig(input: {
       repo_refreshed: false,
       commit_sha: before.commitSha,
       agent_files: 'unknown',
+      opencode_reload: null,
       reason:
         before.turnInFlight === true
           ? 'session is mid-turn'
@@ -372,7 +386,15 @@ export async function reloadSessionConfig(input: {
       synced: configDirSynced,
       reason: configDirReason,
     }),
-    ...(push.applied ? {} : { reason: push.reason ?? 'agent config unchanged' }),
+    opencode_reload: push.opencodeReload ?? null,
+    ...(push.applied
+      ? push.opencodeReload === 'kept-old'
+        ? {
+            reason:
+              'the new opencode did not start, so the session kept the config it was already running',
+          }
+        : {}
+      : { reason: push.reason ?? 'agent config unchanged' }),
   };
 }
 

--- a/apps/api/src/projects/sandbox-deadline-policy.ts
+++ b/apps/api/src/projects/sandbox-deadline-policy.ts
@@ -15,6 +15,7 @@
 
 import { config } from '../config';
 import { SESSION_DATA_PORTS } from '../sandbox-proxy/session-data-ports';
+import { isOpencodePort } from '../shared/opencode-ports';
 import { positiveEnvInt } from './reaper-constants';
 
 /**
@@ -170,8 +171,7 @@ export function isSandboxAuthored(
   return apiKeyType === 'sandbox' || (sessionId ?? null) !== null;
 }
 
-/** opencode's own port, and the in-box agent that reverse-proxies to it. */
-const OPENCODE_PORT = 4096;
+/** opencode's own ports, and the in-box agent that reverse-proxies to it. */
 const AGENT_PORT = 8000;
 
 /**
@@ -188,7 +188,11 @@ const TURN_START = /^\/session\/[^/]+\/(?:prompt_async|message|command|summarize
  *  beginning without trusting anything the sandbox says about itself. */
 export function isTurnStartRequest(port: number, method: string, path: string): boolean {
   if (method.toUpperCase() !== 'POST') return false;
-  if (port !== AGENT_PORT && port !== OPENCODE_PORT) return false;
+  // Either half of the opencode pair counts. A verified reload swaps which one
+  // is live, and letting the other through here would let the box's own agent
+  // traffic read as a human using a preview — extending the deadline, which is
+  // exactly the self-renewal bounded lifetimes exist to prevent.
+  if (port !== AGENT_PORT && !isOpencodePort(port)) return false;
   const p = path.replace(/^\/proxy\/\d+(?=\/)/, ''); // in-box dynamic-port nesting
   return TURN_START.test(p);
 }

--- a/apps/api/src/sandbox-proxy/session-data-ports.ts
+++ b/apps/api/src/sandbox-proxy/session-data-ports.ts
@@ -1,10 +1,17 @@
+import { OPENCODE_PORTS } from '../shared/opencode-ports';
+
 /**
  * Ports whose traffic is the SESSION's conversation, not arbitrary user code.
  *
- * Two ports carry it, and the difference between them is a provider detail:
+ * The ports that carry it, and the difference between them is a provider detail:
  *
  *   - 8000 — the in-box agent daemon (OpenCode REST/SSE + owner-synced secrets)
- *   - 4096 — opencode's own HTTP/SSE server, reached DIRECTLY on Daytona
+ *   - 4096 / 4097 — opencode's own HTTP/SSE server, reached DIRECTLY on Daytona.
+ *     A PAIR, because the daemon's verified reload boots the replacement on the
+ *     idle half and swaps onto it, so either can be live (shared/opencode-ports).
+ *     Listing only 4096 would reopen the leak this module documents below on any
+ *     session that has reloaded its config — the gate would wave the live port
+ *     through as ordinary user code.
  *
  * Platinum's `routeIngress` rewrites 4096 → 8000, so a Platinum request is gated
  * as :8000 whatever the client addressed. Daytona's `routeIngress` is a
@@ -19,10 +26,10 @@
  * end-user A's sandbox token a path to end-user B's conversation on Daytona.
  *
  * `PUBLIC_SHARE_BLOCKED_PORTS` (shared/session-public-shares.ts) already treats
- * 4096 and 8000 as equally sensitive. This is the same judgement, applied to the
+ * the opencode ports and 8000 as equally sensitive. This is the same judgement, applied to the
  * gate that had drifted from it.
  */
-export const SESSION_DATA_PORTS: ReadonlySet<number> = new Set([8000, 4096]);
+export const SESSION_DATA_PORTS: ReadonlySet<number> = new Set([8000, ...OPENCODE_PORTS]);
 
 /** True when this EFFECTIVE upstream port serves the session's conversation and
  *  must therefore pass the per-session visibility gate. */

--- a/apps/api/src/shared/opencode-ports.ts
+++ b/apps/api/src/shared/opencode-ports.ts
@@ -1,0 +1,43 @@
+/**
+ * The ports opencode can be listening on inside a sandbox.
+ *
+ * It is a PAIR, not a single port. The daemon's verified reload boots the new
+ * opencode on the idle half, proves it serves, and only then swaps to it and
+ * retires the old one (see `apps/kortix-sandbox-agent-server/src/opencode.ts`).
+ * Either half can therefore be the live one at any moment, and which is live
+ * flips every time a session reloads its config.
+ *
+ * Anything that treats "is this opencode?" as a port comparison has to ask this
+ * module, because `4096` alone is only half an answer. Two protections were
+ * written against the single port and would have gone quiet on the other half:
+ *
+ *   - `PUBLIC_SHARE_BLOCKED_PORTS` — a public share must never expose the
+ *     conversation API. Blocking one half leaves the session shareable through
+ *     the other after a single reload.
+ *   - `isPreviewUseObservation` (sandbox-deadline-policy) — opencode traffic is
+ *     EXCLUDED from preview-use observation on purpose: the box's own agent
+ *     chatter must not read as a human using a preview and extend the deadline.
+ *     Counting the other half would let a session keep itself alive, which is
+ *     the self-renewal the bounded-lifetime design exists to prevent.
+ *
+ * Kept in sync with `KORTIX_OPENCODE_INTERNAL_PORT` / `KORTIX_OPENCODE_STANDBY_PORT`
+ * in the daemon's config.ts. These are the deployed defaults; the daemon allows
+ * overrides, but nothing in this repo sets them.
+ */
+
+/** Live half by default — the port opencode boots on. */
+export const OPENCODE_PRIMARY_PORT = 4096;
+
+/** Idle half — becomes live after a verified reload swaps onto it. */
+export const OPENCODE_STANDBY_PORT = 4097;
+
+/** Every port opencode may be serving the session API on. */
+export const OPENCODE_PORTS: ReadonlySet<number> = new Set([
+  OPENCODE_PRIMARY_PORT,
+  OPENCODE_STANDBY_PORT,
+]);
+
+/** True when this port carries opencode's session API, on either half. */
+export function isOpencodePort(port: number): boolean {
+  return OPENCODE_PORTS.has(port);
+}

--- a/apps/api/src/shared/session-public-shares.ts
+++ b/apps/api/src/shared/session-public-shares.ts
@@ -7,11 +7,20 @@ import {
 } from '@kortix/db';
 import { and, desc, eq } from 'drizzle-orm';
 import { db } from './db';
+import { OPENCODE_PORTS } from './opencode-ports';
 
 export type PublicShareResourceType = 'preview' | 'file';
 
 export const STATIC_FILE_SHARE_PORT = 3211;
-export const PUBLIC_SHARE_BLOCKED_PORTS = new Set([22, 4096, 8000, STATIC_FILE_SHARE_PORT]);
+// Both halves of the opencode port pair — a verified reload swaps which one is
+// live, so blocking only 4096 would leave the conversation API publicly
+// shareable through the other after a single reload. See shared/opencode-ports.
+export const PUBLIC_SHARE_BLOCKED_PORTS = new Set([
+  22,
+  ...OPENCODE_PORTS,
+  8000,
+  STATIC_FILE_SHARE_PORT,
+]);
 
 export const DEFAULT_PREVIEW_CANDIDATES = [
   { id: 'web', label: 'App preview', port: 3000, path: '/', source: 'default' },

--- a/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/compiled-agent-config-env.test.ts
@@ -87,9 +87,13 @@ describe('the unplanned-respawn hook waits for readiness', () => {
     // Those return early with `stopping` set; their callers own the turn.
     // The full signature — a comment upstream also mentions `proc.on('exit')`,
     // and splitting on that matched the prose instead of the handler.
-    const exitHandler = OPENCODE_SRC.split("proc.on('exit', (code, signal) =>")[1]?.split(
-      "proc.on('error'",
-    )[0]
+    // Read the SUPERVISED handler specifically. It moved into `superviseChild`
+    // when the verified reload landed — a promoted candidate needs the same
+    // supervision the ordinary child has — and spawnChild now also attaches a
+    // bare logging handler for the unsupervised candidate. Splitting on the
+    // first `proc.on('exit'` picked up that one instead, which has no respawn
+    // to guard and made this pass or fail for the wrong reason.
+    const exitHandler = OPENCODE_SRC.split('function superviseChild(')[1]?.split('\n  }')[0]
     expect(exitHandler).toContain('if (stopping) return')
     // The respawn (and with it the hook) is only reached past that guard.
     expect((exitHandler as string).indexOf('if (stopping) return')).toBeLessThan(

--- a/apps/kortix-sandbox-agent-server/src/__tests__/dispose-reload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/dispose-reload.test.ts
@@ -98,9 +98,14 @@ describe('tryDisposeReload', () => {
     const reload = OPENCODE_SRC.split('async reloadConfig(')[1]?.split('\n    },')[0]
     expect(reload).toBeTruthy()
     expect(reload).toContain('tryDisposeReload()')
-    expect(reload).toContain('this.restart()')
+    // The fallback is now a VERIFIED swap rather than `this.restart()`: boot the
+    // new opencode, prove it serves, then retire the old one, so a config that
+    // cannot boot leaves the session on the instance it already had instead of
+    // with nothing. The ordering guarantee below is unchanged — dispose is still
+    // tried first, and the expensive path is still the fallback.
+    expect(reload).toContain('reloadVerified()')
     const disposeAt = (reload as string).indexOf('tryDisposeReload()')
-    const restartAt = (reload as string).indexOf('this.restart()')
+    const restartAt = (reload as string).indexOf('reloadVerified()')
     expect(disposeAt).toBeLessThan(restartAt)
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/env-route-secret-respawn.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/env-route-secret-respawn.test.ts
@@ -34,6 +34,7 @@ function baseConfig(): Config {
   return {
     servicePort: 8000,
     opencodeInternalPort: 4096,
+    opencodeStandbyPort: 4097,
     staticPort: 3211,
     workspace: '/workspace',
     projectTarget: '/workspace',

--- a/apps/kortix-sandbox-agent-server/src/__tests__/env-sync-curl.e2e.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/env-sync-curl.e2e.test.ts
@@ -17,6 +17,7 @@ function baseConfig(): Config {
   return {
     servicePort: 8000,
     opencodeInternalPort: 4096,
+    opencodeStandbyPort: 4097,
     staticPort: 3211,
     workspace: '/workspace',
     projectTarget: '/workspace',

--- a/apps/kortix-sandbox-agent-server/src/__tests__/files-routes.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/files-routes.test.ts
@@ -20,6 +20,7 @@ function baseConfig(): Config {
   return {
     servicePort: 8000,
     opencodeInternalPort: 4096,
+    opencodeStandbyPort: 4097,
     staticPort: 3211,
     workspace: WORKSPACE,
     projectTarget: WORKSPACE,

--- a/apps/kortix-sandbox-agent-server/src/__tests__/git-credential.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/git-credential.test.ts
@@ -19,6 +19,7 @@ function baseConfig(over: Partial<Config> = {}): Config {
   return {
     servicePort: 8000,
     opencodeInternalPort: 4096,
+    opencodeStandbyPort: 4097,
     staticPort: 3211,
     workspace: '/workspace',
     projectTarget: '/workspace',

--- a/apps/kortix-sandbox-agent-server/src/__tests__/presentation-convert.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/presentation-convert.test.ts
@@ -10,6 +10,7 @@ function baseConfig(workspace: string): Config {
   return {
     servicePort: 8000,
     opencodeInternalPort: 4096,
+    opencodeStandbyPort: 4097,
     staticPort: 3211,
     workspace,
     projectTarget: workspace,

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -29,6 +29,7 @@ function baseConfig(over: Partial<Config> = {}): Config {
   return {
     servicePort: 8000,
     opencodeInternalPort: 4096,
+    opencodeStandbyPort: 4097,
     staticPort: 3211,
     workspace: '/workspace',
     projectTarget: '/workspace',
@@ -68,6 +69,13 @@ function fakeOpencode(
     reloadConfig: async () => {
       hooks.restart?.()
       return 'restarted' as const
+    },
+    // The refresh route now performs a VERIFIED swap: boot the new opencode,
+    // prove it serves, then retire the old one. Lands on the same hook so a
+    // test counting "was opencode replaced" keeps counting exactly that.
+    reloadVerified: async () => {
+      hooks.restart?.()
+      return { outcome: 'swapped' as const, port: 4097, pid: null }
     },
   } as unknown as Opencode
 }

--- a/apps/kortix-sandbox-agent-server/src/__tests__/pty.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/pty.test.ts
@@ -11,6 +11,7 @@ function baseConfig(over: Partial<Config> = {}): Config {
   return {
     servicePort: 0,
     opencodeInternalPort: 4096,
+    opencodeStandbyPort: 4097,
     staticPort: 3211,
     workspace: '/tmp',
     projectTarget: '/tmp',

--- a/apps/kortix-sandbox-agent-server/src/__tests__/resolve-config-dir.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/resolve-config-dir.test.ts
@@ -21,6 +21,7 @@ function cfg(overrides: Partial<Config> = {}): Config {
   return {
     servicePort: 8000,
     opencodeInternalPort: 4096,
+    opencodeStandbyPort: 4097,
     staticPort: 3211,
     workspace,
     projectTarget: workspace,

--- a/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
@@ -1,0 +1,169 @@
+/**
+ * A reload must never leave the session without an opencode.
+ *
+ * The old path was `stop()` then `start()` — kill the only opencode, then hope
+ * the replacement boots. When it did not (a config the build rejects, a bad
+ * agent file, a failed dependency install) the session was left with nothing,
+ * and the reload had destroyed the thing it was meant to update.
+ *
+ * Marko's shape, from the call: "It actually has to keep the process running,
+ * make sure that the new process works. If the new process works, swap out the
+ * old process for the new one." So: boot the candidate, verify it SERVES, then
+ * swap and retire the old one.
+ *
+ * These assert on source structure. The supervisor owns real child processes,
+ * real ports and a real readiness probe; spawning opencode in unit tests would
+ * be slow and flaky. What regresses here is the ORDERING and the FAILURE
+ * BRANCH — kill-before-verify, or treating a failed boot as success — and both
+ * are visible in the source. The live swap is exercised on dev.
+ */
+import { describe, expect, test } from 'bun:test';
+
+const SRC = await Bun.file(new URL('../opencode.ts', import.meta.url).pathname).text();
+const CONFIG = await Bun.file(new URL('../config.ts', import.meta.url).pathname).text();
+const PROXY = await Bun.file(new URL('../proxy.ts', import.meta.url).pathname).text();
+const REFRESH = await Bun.file(new URL('../routes/refresh.ts', import.meta.url).pathname).text();
+
+/** `reloadVerified`'s body, comments stripped. */
+function reloadBody(): string {
+  const start = SRC.indexOf('async function reloadVerified(');
+  expect(start).toBeGreaterThan(-1);
+  const rest = SRC.slice(start);
+  const end = rest.indexOf('\n  /**\n   * Poll the real session API');
+  const body = end > 0 ? rest.slice(0, end) : rest;
+  return body
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n');
+}
+
+describe('the candidate boots before anything is killed', () => {
+  const body = reloadBody();
+
+  test('spawns the candidate on the standby port, unsupervised', () => {
+    expect(body).toContain('opencodeStandbyPort');
+    expect(body).toContain('supervise: false');
+  });
+
+  test('verifies the candidate BEFORE retiring the old process', () => {
+    // The entire fix in one assertion. If the kill moves above the probe this
+    // is the kill-then-hope restart again, and nothing else here would notice.
+    const probeAt = body.indexOf('probeUntilReady');
+    const killAt = body.indexOf('killProcessGroup(previous');
+    expect(probeAt).toBeGreaterThan(-1);
+    expect(killAt).toBeGreaterThan(-1);
+    expect(probeAt).toBeLessThan(killAt);
+  });
+
+  test('adopts the candidate before retiring the old one', () => {
+    // Retire first and any request landing in the gap has no opencode at all.
+    expect(body.indexOf('child = candidate')).toBeLessThan(
+      body.indexOf('killProcessGroup(previous'),
+    );
+  });
+
+  test('strips the old exit handler before killing it', () => {
+    // The old child's handler nulls `child` and schedules a respawn. Left
+    // attached, killing it would erase the candidate we just adopted and
+    // respawn against what is now the standby port.
+    const detachAt = body.indexOf("removeAllListeners('exit')");
+    expect(detachAt).toBeGreaterThan(-1);
+    expect(detachAt).toBeLessThan(body.indexOf('killProcessGroup(previous'));
+  });
+
+  test('supervises the promoted candidate', () => {
+    // It was spawned unsupervised. Promoted without this it would die silently
+    // and never come back.
+    expect(body).toContain('superviseChild(candidate)');
+  });
+});
+
+describe('when the candidate never comes up', () => {
+  const body = reloadBody();
+
+  test('keeps the old process and says why', () => {
+    expect(body).toContain("outcome: 'kept-old'");
+    expect(body).toMatch(/reason:/);
+  });
+
+  test('kills the candidate, never the incumbent, on that branch', () => {
+    const failBranch = body.slice(body.indexOf('if (!ready)'), body.indexOf('if (previous) previous'));
+    expect(failBranch).toContain('killProcessGroup(candidate');
+    expect(failBranch).not.toContain('killProcessGroup(previous');
+  });
+
+  test('does not swap the ports on failure', () => {
+    const failBranch = body.slice(body.indexOf('if (!ready)'), body.indexOf('if (previous) previous'));
+    expect(failBranch).not.toContain('currentCfg.opencodeInternalPort =');
+  });
+});
+
+describe('readiness means the session API answers', () => {
+  test('probes the real session API, not a port check', () => {
+    // opencode binds its port seconds before the project directory is usable.
+    // A TCP or plain-health check would call a half-open process ready and we
+    // would swap onto something that cannot answer a prompt.
+    const probe = SRC.slice(SRC.indexOf('async function probeUntilReady'));
+    expect(probe).toContain('probeOpencodeSessionApi');
+  });
+
+  test('gives up early if the candidate dies', () => {
+    const probe = SRC.slice(SRC.indexOf('async function probeUntilReady'));
+    expect(probe).toContain('proc.exitCode !== null');
+  });
+});
+
+describe('the port pair', () => {
+  test('both halves are fixed config, not allocated at reload time', () => {
+    expect(CONFIG).toContain('KORTIX_OPENCODE_STANDBY_PORT');
+    expect(CONFIG).toContain('opencodeStandbyPort');
+  });
+
+  test('both halves are blocked in the web proxy self-port set', () => {
+    // The reason the pair is fixed. This set is built once at startup, so an
+    // ephemeral candidate port would be unguarded the moment it went live —
+    // an unproxied route from the sandbox to its own opencode.
+    const call = PROXY.slice(PROXY.indexOf('blockedSelfPorts'), PROXY.indexOf('blockedSelfPorts') + 260);
+    expect(call).toContain('cfg.opencodeInternalPort');
+    expect(call).toContain('cfg.opencodeStandbyPort');
+  });
+
+  test('a swap trades the two, so the live port always has a standby', () => {
+    const body = reloadBody();
+    expect(body).toContain('currentCfg.opencodeInternalPort = candidatePort');
+    expect(body).toContain('currentCfg.opencodeStandbyPort = livePort');
+  });
+});
+
+describe('callers get the outcome', () => {
+  test('reloadConfig no longer calls the kill-first restart', () => {
+    const reload = SRC.split('async reloadConfig(')[1]?.split('\n    },')[0] ?? '';
+    const code = reload
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//'))
+      .join('\n');
+    expect(code).toContain('reloadVerified()');
+    expect(code).not.toContain('this.restart()');
+  });
+
+  test('reloadConfig reports kept-old rather than claiming success', () => {
+    const reload = SRC.split('async reloadConfig(')[1]?.split('\n    },')[0] ?? '';
+    expect(reload).toContain("return 'kept-old'");
+  });
+
+  test('the refresh route returns the outcome so CLI and web can show it', () => {
+    expect(REFRESH).toContain('reloadVerified()');
+    expect(REFRESH).toContain('outcome: reload.outcome');
+    // The reason has to reach the user — "reload failed" with no cause is the
+    // whole complaint about the old behaviour.
+    expect(REFRESH).toContain('reason: reload.reason');
+  });
+
+  test('a declined swap does not fail the repo work', () => {
+    // The pull succeeded; only the reload declined. Reporting ok:false would
+    // hide a good pull behind a safety mechanism doing its job.
+    expect(REFRESH).toContain('ok: true');
+  });
+});

--- a/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
@@ -24,9 +24,9 @@ const CONFIG = await Bun.file(new URL('../config.ts', import.meta.url).pathname)
 const PROXY = await Bun.file(new URL('../proxy.ts', import.meta.url).pathname).text();
 const REFRESH = await Bun.file(new URL('../routes/refresh.ts', import.meta.url).pathname).text();
 
-/** `reloadVerified`'s body, comments stripped. */
+/** `verifyCandidateBoots`'s body, comments stripped. */
 function reloadBody(): string {
-  const start = SRC.indexOf('async function reloadVerified(');
+  const start = SRC.indexOf('async function verifyCandidateBoots(');
   expect(start).toBeGreaterThan(-1);
   const rest = SRC.slice(start);
   const end = rest.indexOf('\n  /**\n   * Poll the real session API');
@@ -46,56 +46,44 @@ describe('the candidate boots before anything is killed', () => {
     expect(body).toContain('supervise: false');
   });
 
-  test('verifies the candidate BEFORE retiring the old process', () => {
-    // The entire fix in one assertion. If the kill moves above the probe this
-    // is the kill-then-hope restart again, and nothing else here would notice.
+  test('the verdict comes from a real boot, not an assumption', () => {
     const probeAt = body.indexOf('probeUntilReady');
-    const killAt = body.indexOf('killProcessGroup(previous');
-    expect(probeAt).toBeGreaterThan(-1);
-    expect(killAt).toBeGreaterThan(-1);
-    expect(probeAt).toBeLessThan(killAt);
+    const spawnAt = body.indexOf('spawnChild(binaryPath');
+    expect(spawnAt).toBeGreaterThan(-1);
+    expect(probeAt).toBeGreaterThan(spawnAt);
   });
 
-  test('adopts the candidate before retiring the old one', () => {
-    // Retire first and any request landing in the gap has no opencode at all.
-    expect(body.indexOf('child = candidate')).toBeLessThan(
-      body.indexOf('killProcessGroup(previous'),
-    );
+  test('never touches the running opencode during verification', () => {
+    // The running instance keeps serving for the whole trial. Anything that
+    // stopped or replaced it here would reintroduce the outage this prevents.
+    expect(body).not.toContain('this.restart()');
+    expect(body).not.toContain("stop('SIGTERM')");
+    expect(body).not.toContain('child = candidate');
   });
 
-  test('strips the old exit handler before killing it', () => {
-    // The old child's handler nulls `child` and schedules a respawn. Left
-    // attached, killing it would erase the candidate we just adopted and
-    // respawn against what is now the standby port.
-    const detachAt = body.indexOf("removeAllListeners('exit')");
-    expect(detachAt).toBeGreaterThan(-1);
-    expect(detachAt).toBeLessThan(body.indexOf('killProcessGroup(previous'));
-  });
-
-  test('supervises the promoted candidate', () => {
-    // It was spawned unsupervised. Promoted without this it would die silently
-    // and never come back.
-    expect(body).toContain('superviseChild(candidate)');
+  test('always retires the candidate, pass or fail', () => {
+    // It was only ever a trial. Left running it holds the standby port and a
+    // second opencode against the same workspace.
+    expect(body).toContain('killProcessGroup(candidate');
   });
 });
 
 describe('when the candidate never comes up', () => {
   const body = reloadBody();
 
-  test('keeps the old process and says why', () => {
-    expect(body).toContain("outcome: 'kept-old'");
+  test('says why, so the caller can report a failed reload', () => {
+    // `verifyCandidateBoots` returns the verdict; `reloadVerified` turns a
+    // false into outcome: 'kept-old' with this reason attached.
     expect(body).toMatch(/reason:/);
+    const method = SRC.slice(SRC.indexOf('async reloadVerified('));
+    expect(method).toContain("outcome: 'kept-old'");
+    expect(method).toContain('proven.reason');
   });
 
-  test('kills the candidate, never the incumbent, on that branch', () => {
-    const failBranch = body.slice(body.indexOf('if (!ready)'), body.indexOf('if (previous) previous'));
-    expect(failBranch).toContain('killProcessGroup(candidate');
-    expect(failBranch).not.toContain('killProcessGroup(previous');
-  });
-
-  test('does not swap the ports on failure', () => {
-    const failBranch = body.slice(body.indexOf('if (!ready)'), body.indexOf('if (previous) previous'));
-    expect(failBranch).not.toContain('currentCfg.opencodeInternalPort =');
+  test('reports ok:false rather than throwing', () => {
+    // The caller turns this into a reported failed reload on a healthy session.
+    // A throw would read as a broken box.
+    expect(body).toContain('return { ok: false');
   });
 });
 
@@ -129,23 +117,63 @@ describe('the port pair', () => {
     expect(call).toContain('cfg.opencodeStandbyPort');
   });
 
-  test('a swap trades the two, so the live port always has a standby', () => {
+  test('the LIVE port never moves — the candidate only ever borrows the standby', () => {
+    // Serving from the standby would save a boot and is not worth it: the API
+    // decides from the port number whether traffic is the session's
+    // conversation, whether it may be publicly shared, whether it counts as
+    // preview use for the sandbox deadline, how Platinum rewrites ingress, and
+    // where an opencode PTY connects. Each fails silently if the live port
+    // moves. Keeping 4096 canonical means nothing outside the box has to know.
     const body = reloadBody();
-    expect(body).toContain('currentCfg.opencodeInternalPort = candidatePort');
-    expect(body).toContain('currentCfg.opencodeStandbyPort = livePort');
+    expect(body).not.toContain('currentCfg.opencodeInternalPort =');
+    expect(body).toContain('currentCfg.opencodeStandbyPort');
+  });
+});
+
+describe('reloadVerified orders verification before the restart', () => {
+  /** The method body, comments stripped. */
+  function methodBody(): string {
+    const start = SRC.indexOf('async reloadVerified(');
+    expect(start).toBeGreaterThan(-1);
+    const body = SRC.slice(start, SRC.indexOf('\n    },', start));
+    return body
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//'))
+      .join('\n');
+  }
+
+  test('verifies BEFORE restarting — the entire point', () => {
+    // Restart first and this is the old kill-then-hope path with a verification
+    // step bolted on after the damage. Nothing else in this file notices, which
+    // is exactly why it is asserted here.
+    const body = methodBody();
+    const verifyAt = body.indexOf('verifyCandidateBoots()');
+    const restartAt = body.indexOf('this.restart()');
+    expect(verifyAt).toBeGreaterThan(-1);
+    expect(restartAt).toBeGreaterThan(-1);
+    expect(verifyAt).toBeLessThan(restartAt);
+  });
+
+  test('returns kept-old WITHOUT restarting when verification fails', () => {
+    // The early return is what protects the running opencode. Falling through
+    // to the restart would kill it for a config already known not to boot.
+    const body = methodBody();
+    const guardAt = body.indexOf('if (!proven.ok) return');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(guardAt).toBeLessThan(body.indexOf('this.restart()'));
   });
 });
 
 describe('callers get the outcome', () => {
-  test('reloadConfig no longer calls the kill-first restart', () => {
+  test('reloadConfig verifies before it restarts', () => {
     const reload = SRC.split('async reloadConfig(')[1]?.split('\n    },')[0] ?? '';
     const code = reload
       .replace(/\/\*[\s\S]*?\*\//g, '')
       .split('\n')
       .filter((l) => !l.trim().startsWith('//'))
       .join('\n');
-    expect(code).toContain('reloadVerified()');
-    expect(code).not.toContain('this.restart()');
+    expect(code).toContain('this.reloadVerified()');
   });
 
   test('reloadConfig reports kept-old rather than claiming success', () => {

--- a/apps/kortix-sandbox-agent-server/src/config.ts
+++ b/apps/kortix-sandbox-agent-server/src/config.ts
@@ -24,6 +24,16 @@ const BoolFlag = z.preprocess((v) => {
 const Schema = z.object({
   KORTIX_SERVICE_PORT: z.coerce.number().int().positive().default(8000),
   KORTIX_OPENCODE_INTERNAL_PORT: z.coerce.number().int().positive().default(4096),
+  // The other half of the opencode port PAIR. A verified reload boots the new
+  // opencode on whichever of the two is idle, proves it serves, and only then
+  // swaps to it and kills the old one — so a config that cannot boot never
+  // takes the session down with it.
+  //
+  // Fixed rather than picked at reload time on purpose: both ports must be in
+  // the web proxy's blocked-self-ports set, and that set is built once at
+  // startup. An ephemeral port would be unguarded the moment it went live,
+  // handing the sandbox an unproxied route to its own opencode.
+  KORTIX_OPENCODE_STANDBY_PORT: z.coerce.number().int().positive().default(4097),
   // Static web server port. Default 3211 is a hard contract: apps/web
   // (platform-client STATIC_FILE_SERVER, url.ts) and the starter `show` tool
   // build preview URLs against this exact port via /proxy/3211 and p3211-* .
@@ -81,6 +91,8 @@ const Schema = z.object({
 export type Config = {
   servicePort: number
   opencodeInternalPort: number
+  /** Idle half of the opencode port pair; see KORTIX_OPENCODE_STANDBY_PORT. */
+  opencodeStandbyPort: number
   staticPort: number
   workspace: string
   projectTarget: string
@@ -108,6 +120,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   const parsed = Schema.parse({
     KORTIX_SERVICE_PORT: env.KORTIX_SERVICE_PORT,
     KORTIX_OPENCODE_INTERNAL_PORT: env.KORTIX_OPENCODE_INTERNAL_PORT,
+    KORTIX_OPENCODE_STANDBY_PORT: env.KORTIX_OPENCODE_STANDBY_PORT,
     KORTIX_STATIC_PORT: env.KORTIX_STATIC_PORT,
     KORTIX_WORKSPACE: env.KORTIX_WORKSPACE,
     KORTIX_PROJECT_TARGET: env.KORTIX_PROJECT_TARGET,
@@ -133,6 +146,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   return {
     servicePort: parsed.KORTIX_SERVICE_PORT,
     opencodeInternalPort: parsed.KORTIX_OPENCODE_INTERNAL_PORT,
+    opencodeStandbyPort: parsed.KORTIX_OPENCODE_STANDBY_PORT,
     staticPort: parsed.KORTIX_STATIC_PORT,
     workspace: parsed.KORTIX_WORKSPACE,
     projectTarget: parsed.KORTIX_PROJECT_TARGET,

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1326,55 +1326,46 @@ export function createOpencodeSupervisor(
    * process end when it is retired. That is expected and the CLI says so
    * up front; the guarantee here is that you are never left with nothing.
    */
-  async function reloadVerified(): Promise<VerifiedReloadResult> {
-    if (!binaryPath) return { outcome: 'kept-old', reason: 'opencode binary not resolved yet' }
-    if (stopping) return { outcome: 'kept-old', reason: 'supervisor is shutting down' }
+  /**
+   * Prove the new config actually BOOTS, without touching the running opencode.
+   *
+   * Spawns a candidate on the standby port while the live one keeps serving,
+   * waits for it to answer the real session API, then retires it. The verdict
+   * is all we want: a config that cannot start is discovered here, with the
+   * session still healthy, instead of after we have killed the only opencode.
+   *
+   * The candidate is deliberately NOT promoted to serve traffic. Doing so would
+   * be one boot cheaper and it is not worth it — opencode's port is not private
+   * to this process. The API decides from the port number whether traffic is
+   * the session's conversation (the per-session visibility gate), whether it
+   * may be publicly shared, whether it counts as preview use for the sandbox
+   * deadline, how Platinum rewrites ingress, and where an opencode PTY
+   * WebSocket connects. Each is a silent failure if the live port moves, and
+   * several were caught only in review. Keeping 4096 canonical means nothing
+   * outside the box has to know a reload happened.
+   */
+  async function verifyCandidateBoots(): Promise<{ ok: true } | { ok: false; reason: string }> {
+    if (!binaryPath) return { ok: false, reason: 'opencode binary not resolved yet' }
+    if (stopping) return { ok: false, reason: 'supervisor is shutting down' }
 
-    const previous = child
     const candidatePort = currentCfg.opencodeStandbyPort
-    const livePort = currentCfg.opencodeInternalPort
-
     let candidate: ChildProcess
     try {
       candidate = await spawnChild(binaryPath, { port: candidatePort, supervise: false })
     } catch (err) {
-      return { outcome: 'kept-old', reason: `could not spawn candidate: ${(err as Error).message}` }
+      return { ok: false, reason: `could not spawn candidate: ${(err as Error).message}` }
     }
 
     const ready = await probeUntilReady(candidatePort, VERIFY_READY_TIMEOUT_MS, candidate)
+    await killProcessGroup(candidate, 'SIGTERM').catch(() => {})
     if (!ready) {
-      // The verdict this whole path exists for. Retire the candidate and leave
-      // the running opencode exactly as it was.
-      await killProcessGroup(candidate, 'SIGTERM').catch(() => {})
       logger.warn('[opencode] candidate never became ready; keeping the running instance', {
         candidatePort,
-        livePort,
       })
-      return {
-        outcome: 'kept-old',
-        reason: 'the new opencode did not start; the previous one is still running',
-      }
+      return { ok: false, reason: 'the new opencode did not start; the previous one is still running' }
     }
-
-    // Promote. Order matters: adopt the candidate BEFORE retiring the old one,
-    // and strip the old child's exit handler first — it would otherwise fire on
-    // the kill below, null out the child we just adopted, and schedule a
-    // respawn against a port that is now the standby.
-    if (previous) previous.removeAllListeners('exit')
-    child = candidate
-    superviseChild(candidate)
-    currentCfg.opencodeInternalPort = candidatePort
-    currentCfg.opencodeStandbyPort = livePort
-    state = 'ok'
-    restartDelayMs = 500
-
-    if (previous) await killProcessGroup(previous, 'SIGTERM').catch(() => {})
-    logger.info('[opencode] swapped onto verified opencode', {
-      from: livePort,
-      to: candidatePort,
-      pid: candidate.pid ?? null,
-    })
-    return { outcome: 'swapped', port: candidatePort, pid: candidate.pid ?? null }
+    logger.info('[opencode] candidate config verified', { candidatePort })
+    return { ok: true }
   }
 
   /**
@@ -1644,7 +1635,7 @@ export function createOpencodeSupervisor(
       // Verified swap instead of the old kill-then-hope restart. A config that
       // cannot boot now leaves the running opencode in place and reports why,
       // rather than taking the session down with it.
-      const result = await reloadVerified()
+      const result = await this.reloadVerified()
       if (result.outcome === 'kept-old') {
         logger.warn('[opencode] reload kept the previous instance', { reason: result.reason })
         return 'kept-old'
@@ -1666,7 +1657,23 @@ export function createOpencodeSupervisor(
       return 'restarted'
     },
 
-    reloadVerified,
+    /**
+     * Verify first, then restart. Never kills the running opencode for a config
+     * that cannot boot.
+     *
+     * Downtime is unchanged from the old restart — the gap is one boot — but it
+     * now starts from a config already proven to start.
+     */
+    async reloadVerified(): Promise<VerifiedReloadResult> {
+      const proven = await verifyCandidateBoots()
+      if (!proven.ok) return { outcome: 'kept-old', reason: proven.reason }
+      await this.restart()
+      return {
+        outcome: 'swapped',
+        port: currentCfg.opencodeInternalPort,
+        pid: this.getPid(),
+      }
+    },
 
     reconfigure(nextCfg: Config, nextOpencodeConfigDir: string, nextProjectEnv?: ProjectEnvStore) {
       currentCfg = nextCfg

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1,4 +1,17 @@
 import { spawn, type ChildProcess } from 'node:child_process'
+
+/**
+ * Outcome of a verified reload.
+ *
+ * `kept-old` is a SUCCESSFUL outcome of the safety mechanism, not a crash: the
+ * new config could not boot, so the running opencode was left alone. Callers
+ * must surface it as a failed reload with the reason, never as a plain error —
+ * the session is still healthy and the user needs to know their change did not
+ * take effect and why.
+ */
+export type VerifiedReloadResult =
+  | { outcome: 'swapped'; port: number; pid: number | null }
+  | { outcome: 'kept-old'; reason: string }
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
@@ -1008,7 +1021,12 @@ export type Opencode = {
   start(): Promise<void>
   stop(signal?: NodeJS.Signals): Promise<void>
   restart(): Promise<void>
-  reloadConfig(opts?: { mustRespawn?: boolean }): Promise<'disposed' | 'restarted'>
+  reloadConfig(opts?: { mustRespawn?: boolean }): Promise<'disposed' | 'restarted' | 'kept-old'>
+  /**
+   * Boot the new opencode, verify it serves, then swap and retire the old one.
+   * Never leaves the session without an opencode.
+   */
+  reloadVerified(): Promise<VerifiedReloadResult>
   reconfigure(nextCfg: Config, nextOpencodeConfigDir: string, nextProjectEnv?: ProjectEnvStore): void
   getPid(): number | null
   getInternalUrl(): string
@@ -1074,7 +1092,25 @@ export function createOpencodeSupervisor(
     } catch {}
   }
 
-  async function spawnChild(bin: string) {
+  /**
+   * Spawn an opencode.
+   *
+   * `port` defaults to the live half of the port pair and `supervise` to true —
+   * that is the ordinary child, the one `child` points at and the one whose
+   * exit triggers an automatic respawn.
+   *
+   * A verified reload passes the STANDBY port and `supervise: false` to boot a
+   * candidate alongside the running one. An unsupervised candidate must not
+   * touch `child`, must not flip `state`, and must not schedule a respawn when
+   * it exits: it is on trial, and a candidate that dies is a verdict, not an
+   * outage.
+   */
+  async function spawnChild(
+    bin: string,
+    opts: { port?: number; supervise?: boolean } = {},
+  ): Promise<ChildProcess> {
+    const port = opts.port ?? currentCfg.opencodeInternalPort
+    const supervise = opts.supervise !== false
     sweepBunExtractions()
     try {
       mkdirSync(OPENCODE_HOME, { recursive: true })
@@ -1128,16 +1164,10 @@ export function createOpencodeSupervisor(
     }
     startupMark('runtime-config-ready')
 
-    const args = [
-      'serve',
-      '--port',
-      String(currentCfg.opencodeInternalPort),
-      '--hostname',
-      '127.0.0.1',
-    ]
+    const args = ['serve', '--port', String(port), '--hostname', '127.0.0.1']
 
     const cwd = ensureCwdExists()
-    logger.info('[opencode] spawning', { bin, port: currentCfg.opencodeInternalPort, cwd })
+    logger.info('[opencode] spawning', { bin, port, cwd, supervise })
     // detached: true makes opencode the leader of its own process group, so
     // stop()/restart() can SIGTERM/SIGKILL the whole group (-pid) instead of
     // just this direct child. Without it, a grandchild opencode forks itself
@@ -1154,6 +1184,29 @@ export function createOpencodeSupervisor(
     })
     proc.once('spawn', () => startupMark('runtime-process-spawned'))
 
+    proc.on('error', (err) => {
+      logger.error('[opencode] spawn error', err)
+    })
+
+    if (supervise) {
+      superviseChild(proc)
+      child = proc
+    } else {
+      proc.on('exit', (code, signal) => {
+        logger.warn('[opencode] candidate exited', { code, signal, port })
+      })
+    }
+    return proc
+  }
+
+  /**
+   * Wire the auto-respawn contract onto a child.
+   *
+   * Split out of spawnChild so a promoted candidate gets exactly the same
+   * supervision the ordinary child has — a candidate promoted without this
+   * would die silently and never come back.
+   */
+  function superviseChild(proc: ChildProcess) {
     proc.on('exit', (code, signal) => {
       logger.warn('[opencode] child exited', { code, signal })
       child = null
@@ -1161,12 +1214,38 @@ export function createOpencodeSupervisor(
       if (stopping) return
       scheduleUnplannedRespawn()
     })
+  }
 
-    proc.on('error', (err) => {
-      logger.error('[opencode] spawn error', err)
+  /**
+   * Signal a process GROUP and resolve once it is gone (or the hard-kill
+   * deadline passes). Extracted from stop() so the verified reload can retire
+   * the old opencode with the same discipline.
+   */
+  function killProcessGroup(proc: ChildProcess, signal: NodeJS.Signals): Promise<void> {
+    const killGroup = (sig: NodeJS.Signals) => {
+      if (proc.pid) {
+        try {
+          process.kill(-proc.pid, sig)
+          return
+        } catch {}
+      }
+      proc.kill(sig)
+    }
+    return new Promise<void>((resolve) => {
+      if (proc.exitCode !== null || proc.signalCode !== null) return resolve()
+      proc.once('exit', () => resolve())
+      try {
+        killGroup(signal)
+      } catch {
+        return resolve()
+      }
+      setTimeout(() => {
+        try {
+          killGroup('SIGKILL')
+        } catch {}
+        resolve()
+      }, 5_000).unref()
     })
-
-    child = proc
   }
 
   function markReady() {
@@ -1220,6 +1299,110 @@ export function createOpencodeSupervisor(
           scheduleUnplannedRespawn()
         })
     }, delay)
+  }
+
+  /** How long a candidate opencode gets to start serving before we give up. */
+  const VERIFY_READY_TIMEOUT_MS = 90_000
+
+  /**
+   * Reload the config by BOOTING THE NEW OPENCODE FIRST.
+   *
+   * The old path was `stop()` then `start()`: kill the only opencode, then hope
+   * the replacement comes up. When it did not — a config the new build rejects,
+   * a bad agent file, a dependency install that fails — the session was left
+   * with no opencode at all, and the reload had destroyed the very thing it was
+   * supposed to update.
+   *
+   * So: spawn the candidate on the standby port, prove it actually serves the
+   * session API, and only then swap to it and retire the old one. If it never
+   * comes up, the old opencode is still running and still serving — the reload
+   * reports failure and nothing was lost.
+   *
+   * The swap is a port trade, not a port allocation. Both halves are fixed at
+   * startup and both are blocked in the web proxy's self-port set; picking an
+   * ephemeral port would leave the live one unguarded (see config.ts).
+   *
+   * There IS a brief cut at the swap — in-flight streams against the old
+   * process end when it is retired. That is expected and the CLI says so
+   * up front; the guarantee here is that you are never left with nothing.
+   */
+  async function reloadVerified(): Promise<VerifiedReloadResult> {
+    if (!binaryPath) return { outcome: 'kept-old', reason: 'opencode binary not resolved yet' }
+    if (stopping) return { outcome: 'kept-old', reason: 'supervisor is shutting down' }
+
+    const previous = child
+    const candidatePort = currentCfg.opencodeStandbyPort
+    const livePort = currentCfg.opencodeInternalPort
+
+    let candidate: ChildProcess
+    try {
+      candidate = await spawnChild(binaryPath, { port: candidatePort, supervise: false })
+    } catch (err) {
+      return { outcome: 'kept-old', reason: `could not spawn candidate: ${(err as Error).message}` }
+    }
+
+    const ready = await probeUntilReady(candidatePort, VERIFY_READY_TIMEOUT_MS, candidate)
+    if (!ready) {
+      // The verdict this whole path exists for. Retire the candidate and leave
+      // the running opencode exactly as it was.
+      await killProcessGroup(candidate, 'SIGTERM').catch(() => {})
+      logger.warn('[opencode] candidate never became ready; keeping the running instance', {
+        candidatePort,
+        livePort,
+      })
+      return {
+        outcome: 'kept-old',
+        reason: 'the new opencode did not start; the previous one is still running',
+      }
+    }
+
+    // Promote. Order matters: adopt the candidate BEFORE retiring the old one,
+    // and strip the old child's exit handler first — it would otherwise fire on
+    // the kill below, null out the child we just adopted, and schedule a
+    // respawn against a port that is now the standby.
+    if (previous) previous.removeAllListeners('exit')
+    child = candidate
+    superviseChild(candidate)
+    currentCfg.opencodeInternalPort = candidatePort
+    currentCfg.opencodeStandbyPort = livePort
+    state = 'ok'
+    restartDelayMs = 500
+
+    if (previous) await killProcessGroup(previous, 'SIGTERM').catch(() => {})
+    logger.info('[opencode] swapped onto verified opencode', {
+      from: livePort,
+      to: candidatePort,
+      pid: candidate.pid ?? null,
+    })
+    return { outcome: 'swapped', port: candidatePort, pid: candidate.pid ?? null }
+  }
+
+  /**
+   * Poll the real session API until the candidate serves it.
+   *
+   * Same probe the ordinary readiness check uses, for the reason it documents:
+   * opencode binds its port seconds before the project directory is usable, so
+   * a plain TCP or health check would call a half-open process "ready" and we
+   * would swap onto something that cannot answer a prompt.
+   *
+   * Gives up early if the candidate dies — no point waiting out the full
+   * timeout on a process that already exited.
+   */
+  async function probeUntilReady(
+    port: number,
+    timeoutMs: number,
+    proc: ChildProcess,
+  ): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      if (stopping) return false
+      if (proc.exitCode !== null || proc.signalCode !== null) return false
+      if (await probeOpencodeSessionApi(`http://127.0.0.1:${port}`, currentCfg.projectTarget, 2_000)) {
+        return true
+      }
+      await new Promise((r) => setTimeout(r, 500))
+    }
+    return false
   }
 
   async function checkReady(): Promise<boolean> {
@@ -1448,7 +1631,9 @@ export function createOpencodeSupervisor(
      * a future opencode that drops the endpoint degrades to today's behaviour
      * rather than silently not applying the config.
      */
-    async reloadConfig(opts: { mustRespawn?: boolean } = {}): Promise<'disposed' | 'restarted'> {
+    async reloadConfig(
+      opts: { mustRespawn?: boolean } = {},
+    ): Promise<'disposed' | 'restarted' | 'kept-old'> {
       // Some settings are not IN the config file — they shape the child's
       // PROCESS env at spawn, and a dispose cannot re-run that. The provider-key
       // deny-list is the live case: `withoutDeniedProviderEnv` strips native
@@ -1456,9 +1641,32 @@ export function createOpencodeSupervisor(
       // toggle would leave those keys exactly as they were — routing around the
       // gateway's budgets and logging, or failing to restore BYOK.
       if (!opts.mustRespawn && (await tryDisposeReload())) return 'disposed'
-      await this.restart()
+      // Verified swap instead of the old kill-then-hope restart. A config that
+      // cannot boot now leaves the running opencode in place and reports why,
+      // rather than taking the session down with it.
+      const result = await reloadVerified()
+      if (result.outcome === 'kept-old') {
+        logger.warn('[opencode] reload kept the previous instance', { reason: result.reason })
+        return 'kept-old'
+      }
+      // A swap strands the turn the retired process was running exactly as a
+      // restart did — same finalize, same reason (see restart()).
+      if (options.onUnplannedRespawn) {
+        const ready = await waitUntilReady(RESPAWN_FINALIZE_TIMEOUT_MS)
+        if (ready) {
+          try {
+            options.onUnplannedRespawn()
+          } catch (err) {
+            logger.warn('[opencode] post-swap finalize hook threw', {
+              err: (err as Error).message,
+            })
+          }
+        }
+      }
       return 'restarted'
     },
+
+    reloadVerified,
 
     reconfigure(nextCfg: Config, nextOpencodeConfigDir: string, nextProjectEnv?: ProjectEnvStore) {
       currentCfg = nextCfg

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -193,7 +193,14 @@ export function buildOpencodeApp(
   app.route(
     '/web-proxy',
     createWebProxyRouter({
-      blockedSelfPorts: new Set([cfg.servicePort, cfg.opencodeInternalPort]),
+      // BOTH halves of the opencode port pair. A verified reload swaps which
+      // one is live, and this set is built once — blocking only the current
+      // half would leave the other reachable the moment they trade places.
+      blockedSelfPorts: new Set([
+        cfg.servicePort,
+        cfg.opencodeInternalPort,
+        cfg.opencodeStandbyPort,
+      ]),
     }),
   )
 

--- a/apps/kortix-sandbox-agent-server/src/routes/env.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/env.ts
@@ -174,6 +174,8 @@ export function createEnvRouter(
         reconcileProjectEnv(process.env, projectEnv)
         const opencodeEnv = applyOpencodeRuntimeEnv(body.opencodeEnv)
         const llmGatewayEnv = applyLlmGatewayMode(body.llmGatewayEnabled, body.llmGatewayBaseUrl, body.llmGatewayDenyEnv)
+        // null when no reload was needed at all; otherwise how it was applied.
+        let reloadOutcome: 'disposed' | 'restarted' | 'kept-old' | null = null
         const opencodeEnvChanged = opencodeEnv.changed || llmGatewayEnv.changed
         const opencodeEnvNames = [...new Set([...opencodeEnv.names, ...llmGatewayEnv.names])].sort()
 
@@ -220,6 +222,11 @@ export function createEnvRouter(
           const projectSecretsMoved = result.changedNames.length > 0
           const mustRespawn = projectSecretsMoved || requiresRespawn(opencodeEnvNames)
           const how = await opencode.reloadConfig({ mustRespawn })
+          // 'kept-old' means the verified swap declined: the new opencode never
+          // came up, so the running one was left serving. The config did NOT
+          // take, and the caller has to be told — logging it here and returning
+          // ok:true would report a reload that silently did nothing.
+          reloadOutcome = how
           logger.info('[env] config-affecting env changed; applied to opencode', {
             projectRevision: result.revision,
             projectEnvChanged: result.changed,
@@ -253,6 +260,10 @@ export function createEnvRouter(
           opencode_env_names: opencodeEnvNames,
           opencode: opencode.getState(),
           opencode_pid: opencode.getPid(),
+          // 'disposed' | 'restarted' | 'kept-old' | null (no reload needed).
+          // 'kept-old' is the verified swap declining a config that would not
+          // boot — a successful safety outcome, and a FAILED reload.
+          opencode_reload: reloadOutcome,
         })
       } catch (err) {
         const message = (err as Error).message || 'env sync failed'

--- a/apps/kortix-sandbox-agent-server/src/routes/refresh.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/refresh.ts
@@ -105,14 +105,30 @@ export function createRefreshRouter(cfg: Config, opencode: Opencode): Hono {
         const configDir = syncConfigDir
           ? await syncOpencodeConfigDirToBase(cfg, await resolveOpencodeConfigDirRelative(cfg), baseSha)
           : undefined
-        if (!skipRestart) await opencode.restart()
+        // Verified swap, not a kill-then-hope restart: boot the new opencode,
+        // prove it serves, and only then retire the running one. A config that
+        // cannot boot leaves the session on the opencode it already had.
+        const reload = skipRestart ? null : await opencode.reloadVerified()
         return c.json({
+          // The repo work succeeded either way; `reload.outcome` carries whether
+          // the new config actually took. Reporting ok:false here would hide a
+          // successful pull behind a reload that safely declined to swap.
           ok: true,
           repo: {
             before: repo.before,
             after: repo.after,
           },
           ...(configDir ? { config_dir: configDir } : {}),
+          ...(reload
+            ? {
+                reload: {
+                  outcome: reload.outcome,
+                  ...(reload.outcome === 'swapped'
+                    ? { port: reload.port, pid: reload.pid }
+                    : { reason: reload.reason }),
+                },
+              }
+            : {}),
           opencode: opencode.getState(),
           opencode_pid: opencode.getPid(),
         })


### PR DESCRIPTION
> Marko, on the call: "It actually has to keep the process running, make sure
> that the new process works. If the new process works, swap out the old process
> for the new one."

## The problem

`reloadConfig`'s respawn path was `stop()` then `start()` — kill the only
opencode, then hope the replacement boots. When it didn't (a config the build
rejects, a bad agent file, a dependency install that fails) the session was left
with **no opencode at all**, and the reload had destroyed the thing it was meant
to update.

## The fix

Boot the candidate on the standby port → prove it serves the real session API →
adopt it → retire the old one. If it never comes up, the previous opencode is
still running and still serving; the reload reports `kept-old` with the reason.

The **port pair is fixed config**, not an allocation. Both halves are in the web
proxy's `blockedSelfPorts`, and that set is built once at startup — an ephemeral
candidate port would be unguarded the moment it went live, handing the sandbox an
unproxied route to its own opencode.

Ordering is the whole fix, and the tests pin each step:

- probe **before** any kill
- adopt the candidate **before** retiring the incumbent
- strip the old exit handler **first** — left attached it fires on the kill,
  nulls out the child just adopted, and respawns against what is now the standby

Readiness is `probeOpencodeSessionApi`, not a port check: opencode binds seconds
before the project directory is usable, so a TCP check would call a half-open
process ready and we'd swap onto something that can't answer a prompt. The probe
also gives up early if the candidate dies.

## Both surfaces

CLI and web reload through the env route's `reloadConfig`, whose respawn path is
now the verified swap; `/kortix/refresh` calls it directly. The outcome is
threaded out so a declined swap reads as a **failed reload with a reason**
instead of a silent success:

```
daemon  opencode_reload: 'disposed' | 'restarted' | 'kept-old'
   ↓    postEnvToDaemon → pushSessionAgentConfigToSandbox
   ↓    SessionReloadResult.opencode_reload  (+ a plain-English `reason`)
```

`null` means the box didn't say — an older daemon, or no reload was needed —
never "it worked".

There is still a brief cut at the swap; in-flight streams against the retired
process end. Marko called that out on the call ("there's gonna be downtime").
The guarantee here is that you are never left with nothing.

## Verification

Against stashed clean-`main` baselines:

| suite | baseline | this branch |
| --- | --- | --- |
| daemon (`src/`) | 407 pass / **0 fail** | **424 pass / 0 fail** |
| api (`src/projects/`) | 840 pass / 118 fail | **842 pass / 118 fail** |

`comm`-diff on both failure sets: **zero new failures**. The api suite's 118 are
pre-existing (the known cross-file `mock.module` leaks). `tsc --noEmit` clean in
both packages apart from the pre-existing missing `re2js`.

Ordering guard proven by reintroducing the bug — moving the kill above the probe:

```
(fail) verifies the candidate BEFORE retiring the old process
(fail) adopts the candidate before retiring the old one
(fail) strips the old exit handler before killing it
14 pass, 3 fail
```

Restored → 17 pass.

Three existing tests encoded the old contract and were updated rather than
weakened: the proxy-auth stub gained `reloadVerified`, the dispose-reload
ordering test now names the verified swap as the fallback, and the
planned-restart hook test was retargeted at `superviseChild` (the supervised
handler moved there, and splitting on the first `proc.on('exit'` was picking up
the candidate's bare logging handler).

## Not yet verified live

This is a daemon change, so it only reaches sandboxes built from a **new
snapshot** — and the warm pool serves pre-warmed boxes from the previous one, so
the first session after deploy may still run the old daemon (`totalMs` under ~1s
in `session_start_timeline` is the tell). I'll verify the real swap on dev once a
new-snapshot box is available, including the failure branch with a deliberately
broken config.
