### PR TITLE
fix(apps): cross-compile Caddy without GOBIN

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,8 +22,10 @@ WORKDIR /runtime
 COPY apps/kortix-app-runtime/go.mod apps/kortix-app-runtime/main.go ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -buildvcs=false -trimpath -ldflags='-s -w' -o /out/kortix-appd . && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOBIN=/out go install \
-      -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOPATH=/tmp/caddy-go go install \
+      -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4 && \
+    find /tmp/caddy-go/bin -type f -name caddy -exec cp {} /out/caddy \; && \
+    test -x /out/caddy
 
 # ---- Sandbox Agent Stage ----
 # The API builds Daytona layered snapshots at runtime. Those snapshots bake the

--- a/apps/kortix-app-runtime/build_test.go
+++ b/apps/kortix-app-runtime/build_test.go
@@ -19,16 +19,29 @@ func TestBuildPinsPatchedCaddyRelease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(dockerfile), "github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4") {
+	normalizedDockerfile := strings.Join(
+		strings.Fields(strings.ReplaceAll(string(dockerfile), "\\\n", " ")),
+		" ",
+	)
+	if !strings.Contains(normalizedDockerfile, "github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4") {
 		t.Fatal("apps/api/Dockerfile must pin Caddy v2.11.4")
 	}
-	if strings.Contains(string(dockerfile), "github.com/caddyserver/caddy/v2/cmd/caddy@v2.10.2") {
+	if strings.Contains(normalizedDockerfile, "github.com/caddyserver/caddy/v2/cmd/caddy@v2.10.2") {
 		t.Fatal("apps/api/Dockerfile must not build the vulnerable Caddy v2.10.2 release")
 	}
 	if !strings.Contains(
-		string(dockerfile),
-		"CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOBIN=/out go install",
+		normalizedDockerfile,
+		"CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOPATH=/tmp/caddy-go go install -ldflags='-s -w' github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4",
 	) {
-		t.Fatal("apps/api/Dockerfile must build a static Linux amd64 Caddy binary for Alpine App snapshots")
+		t.Fatal("apps/api/Dockerfile must cross-compile Caddy without setting GOBIN")
+	}
+	if !strings.Contains(
+		normalizedDockerfile,
+		"find /tmp/caddy-go/bin -type f -name caddy -exec cp {} /out/caddy \\; && test -x /out/caddy",
+	) {
+		t.Fatal("apps/api/Dockerfile must copy and verify the cross-compiled Caddy binary")
+	}
+	if strings.Contains(normalizedDockerfile, "GOBIN=/out go install") {
+		t.Fatal("apps/api/Dockerfile must not use GOBIN with a cross-compiled go install")
 	}
 }


### PR DESCRIPTION
## Summary
- cross-compile the pinned Caddy v2.11.4 binary without setting `GOBIN`
- copy the architecture-specific Go install output into the App runtime layer
- fail the image build if the Caddy binary is absent
- guard the Docker contract with a focused Go test

## Verification
- `go test ./...`
- `cd tests && bun run test:unit -- unit/app-runtime-workflow.test.ts`
- `docker buildx build --platform linux/amd64,linux/arm64 --target app-runtime --output type=cacheonly --progress=plain -f apps/api/Dockerfile .`