### PR TITLE
fix(ci): resolve staging scanner findings

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,10 +24,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -buildvcs=false -trimpath -ldflags='-s -w' -o /out/kortix-appd .
 
 COPY apps/kortix-app-runtime/caddy/go.mod apps/kortix-app-runtime/caddy/go.sum ./caddy/
-RUN cd /runtime/caddy && go mod download
-COPY apps/kortix-app-runtime/caddy/main.go ./caddy/
-RUN cd /runtime/caddy && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+WORKDIR /runtime/caddy
+RUN go mod download
+COPY apps/kortix-app-runtime/caddy/main.go ./
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
       -trimpath -ldflags='-s -w' -o /out/caddy .
 
 # ---- Sandbox Agent Stage ----

--- a/apps/api/src/projects/lib/agent-config-push.test.ts
+++ b/apps/api/src/projects/lib/agent-config-push.test.ts
@@ -36,7 +36,7 @@ const SESSION_ROW = {
   accountId: 'acct-1',
 };
 let activeSandbox: { externalId: string; config: Record<string, unknown> } | null = SANDBOX_ROW;
-let daemonProof = true
+let daemonProof = true;
 let daemonReload: string | null = 'restarted';
 
 // Spread: the module also exports `agentConfigEtag`, which sandbox-env-sync now

--- a/apps/kortix-app-runtime/build_test.go
+++ b/apps/kortix-app-runtime/build_test.go
@@ -38,8 +38,8 @@ func TestBuildPinsPatchedCaddyRelease(t *testing.T) {
 	}
 	for _, required := range []string{
 		"COPY apps/kortix-app-runtime/caddy/go.mod apps/kortix-app-runtime/caddy/go.sum ./caddy/",
-		"COPY apps/kortix-app-runtime/caddy/main.go ./caddy/",
-		"cd /runtime/caddy",
+		"COPY apps/kortix-app-runtime/caddy/main.go ./",
+		"WORKDIR /runtime/caddy",
 		"CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build",
 		"-o /out/caddy .",
 	} {
@@ -49,5 +49,8 @@ func TestBuildPinsPatchedCaddyRelease(t *testing.T) {
 	}
 	if strings.Contains(string(dockerfile), "GOBIN=/out go install") {
 		t.Fatal("apps/api/Dockerfile must not set GOBIN while cross-compiling Caddy")
+	}
+	if strings.Contains(string(dockerfile), "RUN cd /runtime/caddy") {
+		t.Fatal("apps/api/Dockerfile must use WORKDIR instead of RUN cd")
 	}
 }


### PR DESCRIPTION
## Summary
- use `WORKDIR /runtime/caddy` instead of `RUN cd`
- keep the Caddy module copy path correct after changing the working directory
- enforce the Dockerfile invariant in the app-runtime test
- add the missing semicolon reported by CodeQL

## Verification
- `go test ./...` in `apps/kortix-app-runtime/caddy`
- `go mod verify` in `apps/kortix-app-runtime/caddy`
- static Linux `amd64` and `arm64` Caddy builds
- `go test ./...` in `apps/kortix-app-runtime`
- agent-config Bun test: 10 passed, 0 failed
- Docker BuildKit `app-runtime` stage for `linux/amd64,linux/arm64`: exit 0

## Scanner disposition
- `cel-go v0.29.0` is not compatible with Caddy v2.11.4. The attempted upgrade fails on `InterpretableV2`. No newer Caddy release exists.
- `golang.org/x/crypto/openpgp` is not in `go list -buildvcs=false -deps .`; the module-level finding does not enter the compiled binary.