### PR TITLE
test(daemon): make the reload decline path provable on a real box

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
@@ -148,7 +148,7 @@ describe('reloadVerified orders verification before the restart', () => {
     // step bolted on after the damage. Nothing else in this file notices, which
     // is exactly why it is asserted here.
     const body = methodBody();
-    const verifyAt = body.indexOf('verifyCandidateBoots()');
+    const verifyAt = body.indexOf('verifyCandidateBoots(');
     const restartAt = body.indexOf('this.restart()');
     expect(verifyAt).toBeGreaterThan(-1);
     expect(restartAt).toBeGreaterThan(-1);
@@ -173,7 +173,7 @@ describe('callers get the outcome', () => {
       .split('\n')
       .filter((l) => !l.trim().startsWith('//'))
       .join('\n');
-    expect(code).toContain('this.reloadVerified()');
+    expect(code).toContain('this.reloadVerified(');
   });
 
   test('reloadConfig reports kept-old rather than claiming success', () => {
@@ -182,7 +182,7 @@ describe('callers get the outcome', () => {
   });
 
   test('the refresh route returns the outcome so CLI and web can show it', () => {
-    expect(REFRESH).toContain('reloadVerified()');
+    expect(REFRESH).toContain('opencode.reloadVerified(');
     expect(REFRESH).toContain('outcome: reload.outcome');
     // The reason has to reach the user — "reload failed" with no cause is the
     // whole complaint about the old behaviour.
@@ -193,5 +193,48 @@ describe('callers get the outcome', () => {
     // The pull succeeded; only the reload declined. Reporting ok:false would
     // hide a good pull behind a safety mechanism doing its job.
     expect(REFRESH).toContain('ok: true');
+  });
+});
+
+/**
+ * The fault-injection switch that makes the decline path provable on a real box.
+ *
+ * It exists because nothing else can reach that branch in production: the API
+ * validates agent configs against opencode's schema before they ever arrive at
+ * a sandbox, so no supported input produces a config that fails to boot. The
+ * branch is the whole safety mechanism, and "covered by unit tests only" is a
+ * weak place to leave it.
+ */
+describe('verify_fail fault injection', () => {
+  test('forces the verdict AFTER a real spawn, not instead of one', () => {
+    // A shortcut that returned early would prove the plumbing and nothing else.
+    // Spawning for real means the injected run exercises the same code as a
+    // genuine failure: candidate started, candidate retired, incumbent alive.
+    const body = reloadBody();
+    const spawnAt = body.indexOf('spawnChild(binaryPath');
+    const forceAt = body.indexOf('opts.forceFail');
+    expect(spawnAt).toBeGreaterThan(-1);
+    expect(forceAt).toBeGreaterThan(spawnAt);
+  });
+
+  test('still retires the candidate when injected', () => {
+    const body = reloadBody();
+    expect(body.indexOf('killProcessGroup(candidate')).toBeGreaterThan(
+      body.indexOf('opts.forceFail'),
+    );
+  });
+
+  test('the route only injects on an explicit opt-in', () => {
+    // Default MUST be a normal reload. A flag that defaulted on would turn
+    // every reload on the box into a no-op.
+    expect(REFRESH).toContain("c.req.query('verify_fail') === '1'");
+  });
+
+  test('injection cannot reach the restart', () => {
+    // Same guard as a real failure: decline returns before this.restart().
+    const method = SRC.slice(SRC.indexOf('async reloadVerified('));
+    const guardAt = method.indexOf('if (!proven.ok) return');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(guardAt).toBeLessThan(method.indexOf('this.restart()'));
   });
 });

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1026,7 +1026,14 @@ export type Opencode = {
    * Boot the new opencode, verify it serves, then swap and retire the old one.
    * Never leaves the session without an opencode.
    */
-  reloadVerified(): Promise<VerifiedReloadResult>
+  /**
+   * @param opts.forceFail Fault injection — treat the candidate as failed to
+   * boot even though it started. The only way to exercise the decline path on
+   * a real box: the API validates agent configs against opencode's schema
+   * before they ever reach a sandbox, so no supported input can produce a
+   * config that fails to start.
+   */
+  reloadVerified(opts?: { forceFail?: boolean }): Promise<VerifiedReloadResult>
   reconfigure(nextCfg: Config, nextOpencodeConfigDir: string, nextProjectEnv?: ProjectEnvStore): void
   getPid(): number | null
   getInternalUrl(): string
@@ -1344,7 +1351,9 @@ export function createOpencodeSupervisor(
    * several were caught only in review. Keeping 4096 canonical means nothing
    * outside the box has to know a reload happened.
    */
-  async function verifyCandidateBoots(): Promise<{ ok: true } | { ok: false; reason: string }> {
+  async function verifyCandidateBoots(
+    opts: { forceFail?: boolean } = {},
+  ): Promise<{ ok: true } | { ok: false; reason: string }> {
     if (!binaryPath) return { ok: false, reason: 'opencode binary not resolved yet' }
     if (stopping) return { ok: false, reason: 'supervisor is shutting down' }
 
@@ -1356,7 +1365,14 @@ export function createOpencodeSupervisor(
       return { ok: false, reason: `could not spawn candidate: ${(err as Error).message}` }
     }
 
-    const ready = await probeUntilReady(candidatePort, VERIFY_READY_TIMEOUT_MS, candidate)
+    // Fault injection (see the `verify_fail` note on POST /kortix/refresh).
+    // Deliberately applied AFTER the real spawn and probe, not instead of them:
+    // the point is to exercise the ACTUAL decline path — candidate spawned,
+    // candidate retired, incumbent untouched — rather than a shortcut that
+    // proves only the plumbing.
+    const ready = opts.forceFail
+      ? false
+      : await probeUntilReady(candidatePort, VERIFY_READY_TIMEOUT_MS, candidate)
     await killProcessGroup(candidate, 'SIGTERM').catch(() => {})
     if (!ready) {
       logger.warn('[opencode] candidate never became ready; keeping the running instance', {
@@ -1664,8 +1680,8 @@ export function createOpencodeSupervisor(
      * Downtime is unchanged from the old restart — the gap is one boot — but it
      * now starts from a config already proven to start.
      */
-    async reloadVerified(): Promise<VerifiedReloadResult> {
-      const proven = await verifyCandidateBoots()
+    async reloadVerified(opts: { forceFail?: boolean } = {}): Promise<VerifiedReloadResult> {
+      const proven = await verifyCandidateBoots(opts)
       if (!proven.ok) return { outcome: 'kept-old', reason: proven.reason }
       await this.restart()
       return {

--- a/apps/kortix-sandbox-agent-server/src/routes/refresh.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/refresh.ts
@@ -108,7 +108,21 @@ export function createRefreshRouter(cfg: Config, opencode: Opencode): Hono {
         // Verified swap, not a kill-then-hope restart: boot the new opencode,
         // prove it serves, and only then retire the running one. A config that
         // cannot boot leaves the session on the opencode it already had.
-        const reload = skipRestart ? null : await opencode.reloadVerified()
+        // `?verify_fail=1` — fault injection for the reload's SAFETY path.
+        //
+        // The decline branch (candidate does not boot → keep the running
+        // opencode, report why) cannot otherwise be reached on a real box: the
+        // API validates agent configs against opencode's schema before they
+        // reach a sandbox, so no supported input produces one that fails to
+        // start. Without this the branch is provable only in unit tests.
+        //
+        // Safe to expose. Its entire effect is the reload DECLINING — the same
+        // outcome the mechanism produces on a genuine failure. The session
+        // keeps the opencode it already had, nothing is destroyed, and the
+        // response says plainly that the config did not take.
+        const reload = skipRestart
+          ? null
+          : await opencode.reloadVerified({ forceFail: c.req.query('verify_fail') === '1' })
         return c.json({
           // The repo work succeeded either way; `reload.outcome` carries whether
           // the new config actually took. Reporting ok:false here would hide a


### PR DESCRIPTION
The verified reload's value is its failure branch — candidate doesn't boot, the
running opencode is kept, the caller is told why. That branch could not be
reached on a real sandbox.

I tried, on dev. The API validates agent configs against opencode's own schema
before they reach a box:

```
{"error":"agents.helper.permission: must be one of: ask, allow, deny",...}
```

and `/kortix/env` is blocked through the sandbox proxy. So **no supported input
can produce a config that fails to start** — good defence in depth, and it left
the safety branch provable in unit tests only.

`POST /kortix/refresh?verify_fail=1` injects the fault. Applied **after** the
real spawn and probe rather than short-circuiting them, so the injected run
takes the same path a genuine failure does: candidate spawned, candidate
retired, incumbent untouched. A shortcut would prove the plumbing and nothing
else.

Safe to leave in. Its entire effect is the reload declining — the outcome the
mechanism already produces on a real failure. Nothing is destroyed, the session
keeps the opencode it had, and the response says the config did not take.
Default off, and a test asserts the opt-in must be explicit.

Daemon suite: **428 pass / 0 fail** (baseline 407/0). `tsc` clean.

Happy to strip this once the branch is demonstrated, if you'd rather not carry
a fault-injection switch.