### PR TITLE
fix(apps): preserve runtime billing through idle lifecycle

### DIFF
--- a/apps/api/src/apps/deployment-worker.ts
+++ b/apps/api/src/apps/deployment-worker.ts
@@ -393,7 +393,6 @@ export async function driveAppDeployment(
           memoryGb: context.app.memoryGb,
           diskGb: context.app.diskGb,
         },
-        autoStopMinutes: Math.max(2, Math.ceil(context.app.idleTimeoutSeconds / 60)),
         envVars: runtimeEnvironment.env,
       });
       runtimeExternalId = handle.externalId;

--- a/apps/api/src/apps/hosting.test.ts
+++ b/apps/api/src/apps/hosting.test.ts
@@ -100,8 +100,10 @@ describe('AppHostingProvider', () => {
       name: 'app-hello-v1',
       snapshotName: 'kortix-app-deployment-1',
       machine: { cpuCores: 1, memoryGb: 2, diskGb: 10 },
+      // An obsolete caller must not be able to shrink the provider safety
+      // backstop below the control-plane idle deadline.
       autoStopMinutes: 5,
-    });
+    } as any);
 
     expect(creates[0]).toMatchObject({
       workloadType: 'app',
@@ -109,6 +111,7 @@ describe('AppHostingProvider', () => {
       publishedPorts: [APP_CONTROL_PORT, APP_INGRESS_PORT],
       envVars: { KORTIX_APPD_TOKEN: appControlToken('runtime-1', secret) },
     });
+    expect(creates[0].autoStopInterval).toBeUndefined();
     expect(creates[0].envVars.KORTIX_SANDBOX_TOKEN).toBeUndefined();
     expect(result.controlTokenHash).toBe(
       appControlTokenHash(appControlToken('runtime-1', secret)),

--- a/apps/api/src/apps/hosting.ts
+++ b/apps/api/src/apps/hosting.ts
@@ -40,7 +40,6 @@ export interface StartAppRuntimeInput {
   name: string;
   snapshotName: string;
   machine: AppMachineSpec;
-  autoStopMinutes: number;
   envVars?: Record<string, string>;
 }
 
@@ -129,7 +128,6 @@ export class AppHostingProvider {
       userId: input.userId,
       name: input.name,
       snapshot: input.snapshotName,
-      autoStopInterval: input.autoStopMinutes,
       workloadType: 'app',
       resourceSpec: input.machine,
       publishedPorts: [APP_CONTROL_PORT, APP_INGRESS_PORT],

--- a/apps/api/src/apps/public-proxy.test.ts
+++ b/apps/api/src/apps/public-proxy.test.ts
@@ -6,6 +6,7 @@ process.env.KORTIX_APPS_ALLOW_LOCAL_EDGE = 'true';
 
 const {
   appPublicUnavailableResponse,
+  appRuntimeNeedsWake,
   appEdgeSignature,
   appUpstreamHeaders,
   resolveAppHost,
@@ -14,6 +15,19 @@ const {
 } = await import('./public-proxy');
 
 describe('Apps public edge', () => {
+  test('revalidates a running row after its Kortix idle deadline passes', () => {
+    const now = new Date('2026-08-07T10:30:00.000Z');
+    expect(appRuntimeNeedsWake({
+      status: 'running',
+      idleDeadlineAt: new Date('2026-08-07T10:29:59.000Z'),
+    }, now)).toBe(true);
+    expect(appRuntimeNeedsWake({
+      status: 'running',
+      idleDeadlineAt: new Date('2026-08-07T10:30:01.000Z'),
+    }, now)).toBe(false);
+    expect(appRuntimeNeedsWake({ status: 'stopped', idleDeadlineAt: null }, now)).toBe(true);
+  });
+
   test('resolves local and environment-scoped production hostnames', () => {
     expect(resolveAppHost('aaaaaaaaaaaaaaaa.apps.localhost')).toEqual({
       routeKey: 'aaaaaaaaaaaaaaaa', local: true,

--- a/apps/api/src/apps/public-proxy.ts
+++ b/apps/api/src/apps/public-proxy.ts
@@ -155,6 +155,14 @@ async function waitForWake(runtimeId: string, deadline: number) {
   throw new Error('App cold start timed out');
 }
 
+export function appRuntimeNeedsWake(
+  runtime: Pick<typeof appRuntimes.$inferSelect, 'status' | 'idleDeadlineAt'>,
+  now = new Date(),
+): boolean {
+  if (runtime.status !== 'running') return true;
+  return Boolean(runtime.idleDeadlineAt && runtime.idleDeadlineAt.getTime() <= now.getTime());
+}
+
 export async function ensureAppRuntimeRunning(
   loaded: NonNullable<Awaited<ReturnType<typeof loadPublicApp>>>,
   hosting: AppHostingProvider,
@@ -162,7 +170,7 @@ export async function ensureAppRuntimeRunning(
   if (loaded.app.desiredState !== 'running') {
     throw appStoppedResponse();
   }
-  if (loaded.runtime.status === 'running') return loaded.runtime;
+  if (!appRuntimeNeedsWake(loaded.runtime)) return loaded.runtime;
   if (loaded.runtime.status === 'deleted') {
     throw new Error('App runtime cannot wake from deleted');
   }

--- a/apps/api/src/billing/services/compute-invariant-sweep.ts
+++ b/apps/api/src/billing/services/compute-invariant-sweep.ts
@@ -5,7 +5,7 @@
  */
 
 import { and, eq, sql } from 'drizzle-orm';
-import { sandboxComputeSessions, sessionSandboxes } from '@kortix/db';
+import { appRuntimes, sandboxComputeSessions, sessionSandboxes } from '@kortix/db';
 import { logger } from '../../lib/logger';
 import { db } from '../../shared/db';
 import { getProvider, type ProviderName, type SandboxStatus } from '../../platform/providers';
@@ -46,6 +46,44 @@ const EMPTY_REASON_COUNTS = (): Record<ComputeCloseReason, number> => ({
   'window-past-max': 0,
 });
 
+function appRuntimeBillingStatus(status: string | null): string | null {
+  if (status === 'running') return 'active';
+  if (status === 'provisioning' || status === 'starting') return 'provisioning';
+  return status;
+}
+
+/**
+ * Every compute window belongs to exactly one runtime model. Session windows
+ * join through `session_sandboxes`; App windows join through `app_runtime_id`.
+ * Keeping both joins in one bounded query preserves oldest-first sweep order.
+ */
+export function selectOpenComputeInvariantCandidates(limit = REAP_BATCH_SIZE) {
+  return db
+    .select({
+      computeId: sandboxComputeSessions.id,
+      sandboxId: sandboxComputeSessions.sandboxId,
+      workloadType: sandboxComputeSessions.workloadType,
+      startedAt: sandboxComputeSessions.startedAt,
+      computeMetadata: sandboxComputeSessions.metadata,
+      sbStatus: sessionSandboxes.status,
+      sbUpdatedAt: sessionSandboxes.updatedAt,
+      sbMetadata: sessionSandboxes.metadata,
+      sessionProvider: sessionSandboxes.provider,
+      sessionExternalId: sessionSandboxes.externalId,
+      appStatus: appRuntimes.status,
+      appUpdatedAt: appRuntimes.updatedAt,
+      appMetadata: appRuntimes.metadata,
+      appProvider: appRuntimes.provider,
+      appExternalId: appRuntimes.externalId,
+    })
+    .from(sandboxComputeSessions)
+    .leftJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
+    .leftJoin(appRuntimes, eq(appRuntimes.runtimeId, sandboxComputeSessions.appRuntimeId))
+    .where(eq(sandboxComputeSessions.state, 'active'))
+    .orderBy(sql`${sandboxComputeSessions.startedAt} asc`)
+    .limit(limit);
+}
+
 /**
  * The single authority that guarantees "no compute row stays open unless its
  * sandbox is provably alive".
@@ -67,26 +105,7 @@ export async function reconcileOrphanComputeSessions(now = new Date()): Promise<
   const unresolvedCeilingMs = computeUnresolvedCeilingMs();
   const maxWindowMs = computeMaxWindowMs();
 
-  // Join the metering row to its sandbox to recover provider + externalId.
-  const rows = await db
-    .select({
-      computeId: sandboxComputeSessions.id,
-      sandboxId: sandboxComputeSessions.sandboxId,
-      startedAt: sandboxComputeSessions.startedAt,
-      computeMetadata: sandboxComputeSessions.metadata,
-      sbStatus: sessionSandboxes.status,
-      sbUpdatedAt: sessionSandboxes.updatedAt,
-      sbMetadata: sessionSandboxes.metadata,
-      provider: sessionSandboxes.provider,
-      externalId: sessionSandboxes.externalId,
-    })
-    .from(sandboxComputeSessions)
-    .leftJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
-    .where(eq(sandboxComputeSessions.state, 'active'))
-    // Oldest-open first: the longest-running leak is the most expensive one, and
-    // an unordered LIMIT is how a 34-day-old row stayed invisible for 34 days.
-    .orderBy(sql`${sandboxComputeSessions.startedAt} asc`)
-    .limit(REAP_BATCH_SIZE);
+  const rows = await selectOpenComputeInvariantCandidates();
 
   const result: OrphanComputeResult = {
     checked: rows.length,
@@ -99,18 +118,27 @@ export async function reconcileOrphanComputeSessions(now = new Date()): Promise<
     while (cursor < rows.length) {
       const row = rows[cursor++];
       try {
+        const isApp = row.workloadType === 'app';
+        const runtimeStatus = isApp
+          ? appRuntimeBillingStatus(row.appStatus)
+          : row.sbStatus;
+        const runtimeUpdatedAt = isApp ? row.appUpdatedAt : row.sbUpdatedAt;
+        const runtimeMetadata = (isApp ? row.appMetadata : row.sbMetadata) as
+          | Record<string, unknown>
+          | null;
+        const provider = isApp ? row.appProvider : row.sessionProvider;
+        const externalId = isApp ? row.appExternalId : row.sessionExternalId;
         const startedAt = parseTimestamp(row.startedAt) ?? now;
         const openForMs = Math.max(0, now.getTime() - startedAt.getTime());
-        const sbMetadata = (row.sbMetadata ?? null) as Record<string, unknown> | null;
         const computeMetadata = (row.computeMetadata ?? {}) as Record<string, unknown>;
         const unresolvedSince = parseTimestamp(computeMetadata.unresolvedSince);
         const lastAliveAt = lastAliveAtOf({ metadata: computeMetadata, startedAt: row.startedAt });
         const livenessGraceMs = computeLivenessGraceMs();
 
         const base = {
-          sandboxStatus: (row.sbStatus as string | null) ?? null,
-          hasProviderTarget: !!row.externalId && !!row.provider,
-          runtimeStartFailed: hasFailedRuntimeStart(sbMetadata),
+          sandboxStatus: runtimeStatus ?? null,
+          hasProviderTarget: !!externalId && !!provider,
+          runtimeStartFailed: hasFailedRuntimeStart(runtimeMetadata),
           beyondLivenessCeiling: isBeyondLivenessCeiling({ now, lastAliveAt, graceMs: livenessGraceMs }),
           openForMs,
           unresolvedCeilingMs,
@@ -128,8 +156,8 @@ export async function reconcileOrphanComputeSessions(now = new Date()): Promise<
 
         let providerStatus: SandboxStatus | null = null;
         if (!decision.reason && decision.needsProviderStatus) {
-          providerStatus = await getProvider(row.provider as ProviderName)
-            .getStatus(row.externalId as string)
+          providerStatus = await getProvider(provider as ProviderName)
+            .getStatus(externalId as string)
             .catch(() => null);
           // 'unknown' is the STEADY state for a box deleted out from under us
           // (44 of 66 open prod rows answered unknown), so track how long it has
@@ -157,9 +185,9 @@ export async function reconcileOrphanComputeSessions(now = new Date()): Promise<
           reason: decision.reason,
           now,
           startedAt,
-          sandboxUpdatedAt: parseTimestamp(row.sbUpdatedAt),
+          sandboxUpdatedAt: parseTimestamp(runtimeUpdatedAt),
           unresolvedSince,
-          runtimeWakeFailedAt: parseTimestamp(sbMetadata?.runtimeWakeFailedAt),
+          runtimeWakeFailedAt: parseTimestamp(runtimeMetadata?.runtimeWakeFailedAt),
           lastAliveAt,
           livenessGraceMs,
           maxWindowMs,
@@ -172,7 +200,8 @@ export async function reconcileOrphanComputeSessions(now = new Date()): Promise<
           reason: decision.reason,
           open_for_hours: Number((openForMs / 3_600_000).toFixed(2)),
           billed_through: windowEnd.toISOString(),
-          sandbox_status: row.sbStatus ?? null,
+          workload_type: row.workloadType,
+          sandbox_status: runtimeStatus ?? null,
           provider_status: providerStatus,
         });
       } catch (err) {
@@ -208,9 +237,18 @@ export async function countBillingInvariantViolations(): Promise<number> {
     .select({ n: sql<number>`count(*)::int` })
     .from(sandboxComputeSessions)
     .leftJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
+    .leftJoin(appRuntimes, eq(appRuntimes.runtimeId, sandboxComputeSessions.appRuntimeId))
     .where(and(
       eq(sandboxComputeSessions.state, 'active'),
-      sql`(${sessionSandboxes.status} IS NULL OR ${sessionSandboxes.status} <> 'active')`,
+      sql`(
+        (${sandboxComputeSessions.workloadType} = 'app' AND (
+          ${appRuntimes.runtimeId} IS NULL OR
+          ${appRuntimes.status} NOT IN ('provisioning', 'starting', 'running')
+        )) OR
+        (${sandboxComputeSessions.workloadType} <> 'app' AND (
+          ${sessionSandboxes.status} IS NULL OR ${sessionSandboxes.status} <> 'active'
+        ))
+      )`,
     ));
   return Number(row?.n ?? 0);
 }
@@ -234,10 +272,14 @@ export async function countStaleLivenessWindows(now = new Date()): Promise<numbe
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(sandboxComputeSessions)
-    .innerJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
+    .leftJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
+    .leftJoin(appRuntimes, eq(appRuntimes.runtimeId, sandboxComputeSessions.appRuntimeId))
     .where(and(
       eq(sandboxComputeSessions.state, 'active'),
-      eq(sessionSandboxes.status, 'active'),
+      sql`(
+        (${sandboxComputeSessions.workloadType} = 'app' AND ${appRuntimes.status} = 'running') OR
+        (${sandboxComputeSessions.workloadType} <> 'app' AND ${sessionSandboxes.status} = 'active')
+      )`,
       sql`coalesce(${sandboxComputeSessions.metadata}->>'lastAliveAt', ${sandboxComputeSessions.startedAt}::text) < ${cutoff}`,
     ));
   return Number(row?.n ?? 0);

--- a/apps/api/src/billing/services/compute-metering-query.test.ts
+++ b/apps/api/src/billing/services/compute-metering-query.test.ts
@@ -22,6 +22,7 @@ mock.module('../../config', () => ({
 mock.module('../../shared/db', () => ({ db: drizzle(client) }));
 
 const { selectMissingAppComputeCandidates, selectMissingComputeCandidates } = await import('./compute-metering');
+const { selectOpenComputeInvariantCandidates } = await import('./compute-invariant-sweep');
 
 describe('reconcile candidate predicate', () => {
   const rendered = () => selectMissingComputeCandidates(100).toSQL();
@@ -74,5 +75,23 @@ describe('App reconcile candidate predicate', () => {
     expect(params).toContain('credit');
     expect(sql).toMatch(/sandbox_compute_sessions"?\."?ended_at"? is null/);
     expect(sql).toMatch(/sandbox_compute_sessions"?\."?id"? is null/);
+  });
+});
+
+describe('compute invariant candidate predicate', () => {
+  const rendered = () => selectOpenComputeInvariantCandidates(100).toSQL();
+
+  test('joins both session sandboxes and App runtimes', () => {
+    const { sql } = rendered();
+    expect(sql).toContain('session_sandboxes');
+    expect(sql).toContain('app_runtimes');
+    expect(sql).toMatch(/app_runtime_id/);
+  });
+
+  test('selects workload_type so the sweep uses the matching runtime state', () => {
+    const { sql } = rendered();
+    expect(sql).toMatch(/workload_type/);
+    expect(sql).toMatch(/app_runtimes"?\."?status/);
+    expect(sql).toMatch(/app_runtimes"?\."?external_id/);
   });
 });

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -969,13 +969,19 @@ describe('reconcileOrphanComputeSessions', () => {
   const openRow = (over: Partial<any> = {}) => ({
     computeId: 'cs-1',
     sandboxId: 'sb-1',
+    workloadType: 'session',
     startedAt: new Date(NOW3.getTime() - 2 * HOUR).toISOString(),
     computeMetadata: { lastAliveAt: NOW3.toISOString() },
     sbStatus: 'active',
     sbUpdatedAt: new Date(NOW3.getTime() - HOUR).toISOString(),
     sbMetadata: {},
-    provider: 'daytona',
-    externalId: 'ext-1',
+    sessionProvider: 'daytona',
+    sessionExternalId: 'ext-1',
+    appStatus: null,
+    appUpdatedAt: null,
+    appMetadata: null,
+    appProvider: null,
+    appExternalId: null,
     ...over,
   });
 
@@ -987,6 +993,49 @@ describe('reconcileOrphanComputeSessions', () => {
 
     expect(r.closed).toBe(0);
     expect(pausedCompute).toEqual([]);
+  });
+
+  test('a healthy running App runtime keeps billing through its App join', async () => {
+    computeRows = [openRow({
+      workloadType: 'app',
+      sbStatus: null,
+      sessionProvider: null,
+      sessionExternalId: null,
+      appStatus: 'running',
+      appUpdatedAt: new Date(NOW3.getTime() - HOUR).toISOString(),
+      appMetadata: {},
+      appProvider: 'daytona',
+      appExternalId: 'app-ext-1',
+    })];
+    statusByExternal['app-ext-1'] = 'running';
+
+    const r = await reconcileOrphanComputeSessions(NOW3);
+
+    expect(r.closed).toBe(0);
+    expect(statusCalls).toEqual(['app-ext-1']);
+    expect(pausedCompute).toEqual([]);
+  });
+
+  test('a stopped App runtime closes its compute window without a provider call', async () => {
+    const stoppedAt = new Date(NOW3.getTime() - HOUR);
+    computeRows = [openRow({
+      workloadType: 'app',
+      sbStatus: null,
+      sessionProvider: null,
+      sessionExternalId: null,
+      appStatus: 'stopped',
+      appUpdatedAt: stoppedAt.toISOString(),
+      appMetadata: {},
+      appProvider: 'daytona',
+      appExternalId: 'app-ext-1',
+    })];
+
+    const r = await reconcileOrphanComputeSessions(NOW3);
+
+    expect(r.closed).toBe(1);
+    expect(r.byReason['sandbox-not-active']).toBe(1);
+    expect(statusCalls).toEqual([]);
+    expect(pausedComputeWindows[0].windowEnd?.getTime()).toBe(stoppedAt.getTime());
   });
 
   // The 17 prod rows: 5,587 sandbox-hours billed on boxes our own DB said were
@@ -1048,7 +1097,7 @@ describe('reconcileOrphanComputeSessions', () => {
   });
 
   test('an open row with no sandbox row behind it is closed', async () => {
-    computeRows = [openRow({ sbStatus: null, provider: null, externalId: null })];
+    computeRows = [openRow({ sbStatus: null, sessionProvider: null, sessionExternalId: null })];
 
     const r = await reconcileOrphanComputeSessions(NOW3);
 


### PR DESCRIPTION
## Problem

Live Daytona acceptance exposed three lifecycle defects:

- the provider auto-stop timer started during provisioning and stopped the sandbox seconds after readiness;
- the compute invariant sweep joined only session_sandboxes and closed every App compute row as sandbox-row-missing;
- a stale running runtime row bypassed cold-wake revalidation after its Kortix idle deadline.

## Changes

- use the provider default safety backstop for App sandboxes;
- reconcile App compute rows through app_runtimes;
- map App runtime states to billing states;
- revalidate running rows whose idle deadline expired;
- cover session and App sweep behavior with focused tests.

## Verification

- pnpm --filter kortix-api typecheck
- pnpm --filter kortix-api test: 5681 pass, 64 skip, 0 fail
- focused Apps tests: 20 pass, 0 fail
- sandbox-reaper tests: 73 pass, 0 fail
- git diff --check