### PR TITLE
fix(ci): make Rekor signing retries idempotent

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -59,6 +59,7 @@ jobs:
               - 'apps/sandbox/**'
               - 'apps/cli/**'          # baked into the API image (sandbox kortix CLI)
               - 'packages/**'
+              - 'scripts/ci/cosign-sign-attest.sh'
               - 'infra/k8s/charts/kortix-api/**'
               - 'infra/k8s/envs/dev/**'
               - '.github/workflows/deploy-dev.yml'
@@ -258,8 +259,7 @@ jobs:
           REF: ${{ steps.digest.outputs.ref }}
         run: |
           set -euo pipefail
-          cosign sign --yes "$REF"
-          cosign attest --yes --type spdxjson --predicate sbom.spdx.json "$REF"
+          bash scripts/ci/cosign-sign-attest.sh "$REF" sbom.spdx.json
       - name: SLSA build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:

--- a/scripts/ci/cosign-sign-attest.sh
+++ b/scripts/ci/cosign-sign-attest.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ref="${1:-}"
+predicate="${2:-}"
+max_attempts="${COSIGN_MAX_ATTEMPTS:-3}"
+retry_delay_seconds="${COSIGN_RETRY_DELAY_SECONDS:-10}"
+
+if [ -z "$ref" ] || [ -z "$predicate" ]; then
+  echo "usage: $0 <image-ref> <spdx-predicate>" >&2
+  exit 2
+fi
+if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "COSIGN_MAX_ATTEMPTS must be a positive integer" >&2
+  exit 2
+fi
+if ! [[ "$retry_delay_seconds" =~ ^[0-9]+$ ]]; then
+  echo "COSIGN_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+
+run_with_rekor_retry() {
+  local label="$1"
+  shift
+  local attempt output status
+
+  for attempt in $(seq 1 "$max_attempts"); do
+    set +e
+    output="$("$@" 2>&1)"
+    status=$?
+    set -e
+    [ -z "$output" ] || printf '%s\n' "$output" >&2
+
+    if [ "$status" -eq 0 ]; then
+      return 0
+    fi
+
+    # Rekor can persist an entry and lose the response. A retry then returns
+    # this exact conflict. The matching entry is the completed operation.
+    if grep -Fq 'createLogEntryConflict' <<<"$output" \
+      && grep -Fq 'equivalent entry already exists in the transparency log' <<<"$output"; then
+      echo "${label}: equivalent Rekor entry already exists; accepting idempotent success."
+      return 0
+    fi
+
+    if [ "$attempt" -lt "$max_attempts" ] \
+      && grep -Eq 'rekor\.sigstore\.dev|transparency log' <<<"$output" \
+      && grep -Eqi 'giving up|timed out|timeout|temporarily unavailable|connection reset|unexpected EOF|[^0-9]50[0234][^0-9]' <<<"$output"; then
+      echo "${label}: transient Rekor failure on attempt ${attempt}/${max_attempts}; retrying."
+      sleep "$retry_delay_seconds"
+      continue
+    fi
+
+    return "$status"
+  done
+}
+
+run_with_rekor_retry "image signature" cosign sign --yes "$ref"
+run_with_rekor_retry "SBOM attestation" \
+  cosign attest --yes --type spdxjson --predicate "$predicate" "$ref"

--- a/tests/unit/cosign-sign-attest.test.ts
+++ b/tests/unit/cosign-sign-attest.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+const signer = join(repoRoot, "scripts/ci/cosign-sign-attest.sh");
+const workflow = join(repoRoot, ".github/workflows/deploy-dev.yml");
+const tempDirs: string[] = [];
+
+function runSigner(mode: string) {
+  const dir = mkdtempSync(join(tmpdir(), "kortix-cosign-test-"));
+  tempDirs.push(dir);
+  const attempts = join(dir, "attempts");
+  writeFileSync(attempts, "0\n");
+  const cosign = join(dir, "cosign");
+  writeFileSync(
+    cosign,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "sign" ]; then
+  exit 0
+fi
+count="$(cat "$COSIGN_TEST_ATTEMPTS")"
+count="$((count + 1))"
+printf '%s\\n' "$count" > "$COSIGN_TEST_ATTEMPTS"
+case "$COSIGN_TEST_MODE:$count" in
+  transient-then-duplicate:1)
+    echo 'Post "https://rekor.sigstore.dev/api/v1/log/entries": giving up after 2 attempt(s)' >&2
+    exit 1
+    ;;
+  transient-then-duplicate:2)
+    echo '[409] createLogEntryConflict {"message":"an equivalent entry already exists in the transparency log"}' >&2
+    exit 1
+    ;;
+  fatal:*)
+    echo 'unauthorized: invalid identity' >&2
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+  );
+  chmodSync(cosign, 0o755);
+
+  const result = spawnSync(
+    "bash",
+    [signer, "kortix/example@sha256:abc", "sbom.json"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH ?? ""}`,
+        COSIGN_RETRY_DELAY_SECONDS: "0",
+        COSIGN_TEST_ATTEMPTS: attempts,
+        COSIGN_TEST_MODE: mode,
+      },
+    },
+  );
+
+  return {
+    ...result,
+    attempts: Number.parseInt(readFileSync(attempts, "utf8").trim(), 10),
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0))
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("keyless image signing", () => {
+  it("treats a duplicate Rekor entry after a transient failure as idempotent success", () => {
+    const result = runSigner("transient-then-duplicate");
+
+    expect(result.status).toBe(0);
+    expect(result.attempts).toBe(2);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      "equivalent Rekor entry already exists",
+    );
+  });
+
+  it("does not hide a non-Rekor signing failure", () => {
+    const result = runSigner("fatal");
+
+    expect(result.status).toBe(1);
+    expect(result.attempts).toBe(1);
+    expect(result.stderr).toContain("unauthorized: invalid identity");
+  });
+
+  it("routes the Dev supply-chain gate through the retry-safe signer", () => {
+    const yaml = readFileSync(workflow, "utf8");
+
+    expect(yaml).toContain(
+      'bash scripts/ci/cosign-sign-attest.sh "$REF" sbom.spdx.json',
+    );
+    expect(yaml).not.toContain("cosign attest --yes --type spdxjson");
+  });
+});


### PR DESCRIPTION
## Problem

Deploy Dev run `31172016392` signed the API image, then lost Rekor's attestation response. The rerun received `409 createLogEntryConflict` because the equivalent entry already existed. The workflow treated that completed idempotent operation as a failure.

## Change

- Retry transient Rekor failures up to three times.
- Accept only Rekor's exact equivalent-entry conflict as idempotent success.
- Preserve failures for authorization and other non-transient errors.
- Route the Dev supply-chain job through the tested script.

## Verification

- `bash -n scripts/ci/cosign-sign-attest.sh`
- `shellcheck scripts/ci/cosign-sign-attest.sh`
- `actionlint .github/workflows/deploy-dev.yml`
- `pnpm exec prettier --check .github/workflows/deploy-dev.yml tests/unit/cosign-sign-attest.test.ts`
- `cd tests && bun run test:unit` → `54 passed, 0 failed`

## Incident reproduction

The regression test simulates the observed sequence:

1. Rekor request fails after its internal retries.
2. Retry returns `409` with `equivalent entry already exists`.
3. The gate exits `0`.

A separate test proves an authorization failure still exits `1`.
