### PR TITLE
fix(ci): scope Apps edge certificate token

### DIFF
--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -186,7 +186,9 @@ jobs:
       - name: Verify public DNS and TLS routing
         run: |
           set -euo pipefail
-          host="dev-edge-probe-invalid.apps.kortix.com"
+          # Keep the probe syntactically valid so the API host parser reaches
+          # the signed Apps route before returning the expected missing App.
+          host="dev-edge-probe-invalid-0000000000000000.apps.kortix.com"
           for attempt in $(seq 1 30); do
             answer="$({
               curl --silent --show-error --get \

--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -216,6 +216,9 @@ jobs:
               --write-out '%{http_code}' \
               "https://$host/"
           })"
+          echo "HTTP status: $status"
+          grep -Ei '^x-kortix-app-environment:' "$headers" || true
+          jq -c . "$body" || true
           test "$status" = 404
           grep -Eiq '^x-kortix-app-environment: dev\r?$' "$headers"
           jq -e '.error == "App not found"' "$body"

--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -220,5 +220,5 @@ jobs:
           grep -Ei '^x-kortix-app-environment:' "$headers" || true
           jq -c . "$body" || true
           test "$status" = 404
-          grep -Eiq '^x-kortix-app-environment: dev\r?$' "$headers"
+          tr -d '\r' < "$headers" | grep -Eiq '^x-kortix-app-environment: dev$'
           jq -e '.error == "App not found"' "$body"

--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
+      # Account: Workers Scripts Write. kortix.com zone: DNS Write,
+      # Workers Routes Write, SSL and Certificates Write, and Zone Read.
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}
       CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
       APPS_DNS_NAME: '*.apps.kortix.com'

--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}
       CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
       APPS_DNS_NAME: '*.apps.kortix.com'
       APPS_DNS_TARGET: '192.0.2.1'

--- a/infra/cloudflare/workers/apps-router/README.md
+++ b/infra/cloudflare/workers/apps-router/README.md
@@ -17,13 +17,6 @@ The workflow creates the proxied wildcard DNS record when it is absent. It
 refuses to replace a conflicting record. It also verifies the Worker route,
 secret bindings, public DNS, TLS, and the signed Dev routing path.
 
-Store its scoped token in the `CLOUDFLARE_APPS_EDGE_API_TOKEN` GitHub secret.
-Scope the token to the `kortix.com` zone. Grant `DNS Write`, `Workers Routes
-Write`, `SSL and Certificates Write`, and `Zone Read`. Grant `Workers Scripts
-Write` on the owning Cloudflare account so the workflow can verify Worker
-secret bindings. Do not reuse the broader deployment token for certificate
-management.
-
 Each API environment must receive the corresponding value as
 `KORTIX_APPS_EDGE_SECRET`. The API falls back to its existing `API_KEY_SECRET`
 when the dedicated value is absent. Do not store secret values in

--- a/infra/cloudflare/workers/apps-router/README.md
+++ b/infra/cloudflare/workers/apps-router/README.md
@@ -17,6 +17,13 @@ The workflow creates the proxied wildcard DNS record when it is absent. It
 refuses to replace a conflicting record. It also verifies the Worker route,
 secret bindings, public DNS, TLS, and the signed Dev routing path.
 
+Store its scoped token in the `CLOUDFLARE_APPS_EDGE_API_TOKEN` GitHub secret.
+Scope the token to the `kortix.com` zone. Grant `DNS Write`, `Workers Routes
+Write`, `SSL and Certificates Write`, and `Zone Read`. Grant `Workers Scripts
+Write` on the owning Cloudflare account so the workflow can verify Worker
+secret bindings. Do not reuse the broader deployment token for certificate
+management.
+
 Each API environment must receive the corresponding value as
 `KORTIX_APPS_EDGE_SECRET`. The API falls back to its existing `API_KEY_SECRET`
 when the dedicated value is absent. Do not store secret values in


### PR DESCRIPTION
## Problem

The Apps edge workflow used the general Cloudflare deployment token. That token can manage Workers and DNS, but Cloudflare returned 403 for certificate-pack access.

## Changes

- use the dedicated `CLOUDFLARE_APPS_EDGE_API_TOKEN` secret;
- document the exact account and zone permissions in workflow comments;
- use a syntactically valid missing-App probe;
- normalize CRLF response headers;
- print safe probe diagnostics.

## Live proof

- created the least-privilege token for the `kortix.com` zone;
- stored it as the dedicated GitHub secret;
- verified certificate-pack and Worker-route access;
- activated the nested wildcard certificate;
- normal TLS returns HTTP 200 with `ssl_verify_result=0`;
- branch workflow run 31175488293 completed successfully.

## Verification

- `actionlint .github/workflows/configure-apps-edge.yml`
- `git diff --check`