### PR TITLE
fix: promote verified agent config replacements

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/config-dir-sync.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/config-dir-sync.test.ts
@@ -20,7 +20,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Config } from '../config'
@@ -139,6 +139,25 @@ describe('syncOpencodeConfigDirToBase', () => {
 
     expect(result).toEqual({ synced: false, skipped: 'local commits' })
     expect(agentText()).toBe('MY COMMITTED PROMPT\n')
+  })
+
+  test('preserves a conflicting config commit and unrelated dirty work together', async () => {
+    write(work, AGENT, 'SESSION PROMPT\n')
+    git(work, 'add', AGENT)
+    git(work, 'commit', '-qm', 'session config')
+    const head = git(work, 'rev-parse', 'HEAD')
+    write(work, 'app.ts', 'export const x = 999\n')
+    write(work, 'notes/untracked.txt', 'keep me\n')
+
+    const result = await syncOpencodeConfigDirToBase(cfg(), CONFIG_DIR)
+
+    expect(result).toEqual({ synced: false, skipped: 'local commits' })
+    expect(git(work, 'rev-parse', 'HEAD')).toBe(head)
+    expect(git(work, 'branch', '--show-current')).toBe('ses-1111-2222')
+    expect(existsSync(join(work, '.git', 'MERGE_HEAD'))).toBe(false)
+    expect(agentText()).toBe('SESSION PROMPT\n')
+    expect(readFileSync(join(work, 'app.ts'), 'utf8')).toBe('export const x = 999\n')
+    expect(readFileSync(join(work, 'notes/untracked.txt'), 'utf8')).toBe('keep me\n')
   })
 
   test('an untracked file under the config dir also blocks it', async () => {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload-process.e2e.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload-process.e2e.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Config } from '../config'
+import { createOpencodeSupervisor, waitForOpencodeReady } from '../opencode'
+
+let root: string
+let supervisor: ReturnType<typeof createOpencodeSupervisor> | null
+
+function reservePort(): number {
+  const server = Bun.serve({ port: 0, fetch: () => new Response('reserved') })
+  const port = server.port
+  server.stop(true)
+  if (typeof port !== 'number') throw new Error('Bun did not assign a port')
+  return port
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (check()) return
+    await Bun.sleep(20)
+  }
+  throw new Error('condition did not become true')
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'kortix-reload-process-'))
+  supervisor = null
+})
+
+afterEach(async () => {
+  await supervisor?.stop()
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('verified reload process promotion', () => {
+  test('promotes each verified candidate and preserves the active process on failure', async () => {
+    const workspace = join(root, 'workspace')
+    const configDir = join(root, 'config')
+    const binary = join(root, 'opencode')
+    mkdirSync(workspace)
+    mkdirSync(configDir)
+    writeFileSync(
+      binary,
+      '#!/usr/bin/env bun\nconst port = Number(Bun.argv[Bun.argv.indexOf("--port") + 1])\nBun.serve({ port, hostname: "127.0.0.1", fetch: () => Response.json([]) })\n',
+    )
+    chmodSync(binary, 0o755)
+
+    const primary = reservePort()
+    const standby = reservePort()
+    const cfg = {
+      workspace,
+      projectTarget: workspace,
+      opencodeInternalPort: primary,
+      opencodeStandbyPort: standby,
+      gitUserName: 'Kortix Agent',
+      gitUserEmail: 'agent@kortix.ai',
+    } as Config
+    supervisor = createOpencodeSupervisor(cfg, configDir, undefined, {
+      binaryPathOverride: binary,
+      configPathOverride: join(root, 'runtime-config.json'),
+    })
+
+    await supervisor.start()
+    expect(await waitForOpencodeReady(supervisor, workspace)).toBe(true)
+    const initialPid = supervisor.getPid()
+    expect(initialPid).not.toBeNull()
+    expect(supervisor.getInternalUrl()).toBe(`http://127.0.0.1:${primary}`)
+
+    const first = await supervisor.reloadVerified()
+    expect(first.outcome).toBe('swapped')
+    if (first.outcome !== 'swapped') throw new Error(first.reason)
+    expect(first.port).toBe(standby)
+    expect(first.pid).not.toBe(initialPid)
+    expect(supervisor.getInternalUrl()).toBe(`http://127.0.0.1:${standby}`)
+    await waitFor(() => !processExists(initialPid as number))
+    expect((await fetch(`${supervisor.getInternalUrl()}/session`)).status).toBe(200)
+    await Bun.sleep(650)
+    expect(supervisor.getPid()).toBe(first.pid)
+
+    const second = await supervisor.reloadVerified()
+    expect(second.outcome).toBe('swapped')
+    if (second.outcome !== 'swapped') throw new Error(second.reason)
+    expect(second.port).toBe(primary)
+    expect(second.pid).not.toBe(first.pid)
+    expect(supervisor.getInternalUrl()).toBe(`http://127.0.0.1:${primary}`)
+    await waitFor(() => !processExists(first.pid as number))
+    await Bun.sleep(650)
+    expect(supervisor.getPid()).toBe(second.pid)
+
+    const activePid = supervisor.getPid()
+    const failed = await supervisor.reloadVerified({ forceFail: true })
+    expect(failed.outcome).toBe('kept-old')
+    expect(supervisor.getPid()).toBe(activePid)
+    expect(supervisor.getInternalUrl()).toBe(`http://127.0.0.1:${primary}`)
+    expect((await fetch(`${supervisor.getInternalUrl()}/session`)).status).toBe(200)
+  }, 20_000)
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
@@ -6,10 +6,8 @@
  * agent file, a failed dependency install) the session was left with nothing,
  * and the reload had destroyed the thing it was meant to update.
  *
- * Marko's shape, from the call: "It actually has to keep the process running,
- * make sure that the new process works. If the new process works, swap out the
- * old process for the new one." So: boot the candidate, verify it SERVES, then
- * swap and retire the old one.
+ * The required shape is: boot the candidate, verify it serves, then promote it
+ * and retire the old process.
  *
  * These assert on source structure. The supervisor owns real child processes,
  * real ports and a real readiness probe; spawning opencode in unit tests would
@@ -25,7 +23,7 @@ const PROXY = await Bun.file(new URL('../proxy.ts', import.meta.url).pathname).t
 const REFRESH = await Bun.file(new URL('../routes/refresh.ts', import.meta.url).pathname).text();
 
 /** `verifyCandidateBoots`'s body, comments stripped. */
-function reloadBody(): string {
+function candidateBody(): string {
   const start = SRC.indexOf('async function verifyCandidateBoots(');
   expect(start).toBeGreaterThan(-1);
   const rest = SRC.slice(start);
@@ -39,7 +37,7 @@ function reloadBody(): string {
 }
 
 describe('the candidate boots before anything is killed', () => {
-  const body = reloadBody();
+  const body = candidateBody();
 
   test('spawns the candidate on the standby port, unsupervised', () => {
     expect(body).toContain('opencodeStandbyPort');
@@ -53,27 +51,21 @@ describe('the candidate boots before anything is killed', () => {
     expect(probeAt).toBeGreaterThan(spawnAt);
   });
 
-  test('never touches the running opencode during verification', () => {
-    // The running instance keeps serving for the whole trial. Anything that
-    // stopped or replaced it here would reintroduce the outage this prevents.
+  test('does not touch the running opencode before the verdict', () => {
     expect(body).not.toContain('this.restart()');
     expect(body).not.toContain("stop('SIGTERM')");
     expect(body).not.toContain('child = candidate');
   });
 
-  test('always retires the candidate, pass or fail', () => {
-    // It was only ever a trial. Left running it holds the standby port and a
-    // second opencode against the same workspace.
-    expect(body).toContain('killProcessGroup(candidate');
+  test('returns the live candidate after a successful probe', () => {
+    expect(body).toContain('return { ok: true, candidate, port: candidatePort }');
   });
 });
 
 describe('when the candidate never comes up', () => {
-  const body = reloadBody();
+  const body = candidateBody();
 
   test('says why, so the caller can report a failed reload', () => {
-    // `verifyCandidateBoots` returns the verdict; `reloadVerified` turns a
-    // false into outcome: 'kept-old' with this reason attached.
     expect(body).toMatch(/reason:/);
     const method = SRC.slice(SRC.indexOf('async reloadVerified('));
     expect(method).toContain("outcome: 'kept-old'");
@@ -81,9 +73,15 @@ describe('when the candidate never comes up', () => {
   });
 
   test('reports ok:false rather than throwing', () => {
-    // The caller turns this into a reported failed reload on a healthy session.
-    // A throw would read as a broken box.
     expect(body).toContain('return { ok: false');
+  });
+
+  test('retires only the failed candidate', () => {
+    const failureAt = body.indexOf('if (!ready)');
+    const retireAt = body.indexOf("await killProcessGroup(candidate, 'SIGTERM')", failureAt);
+    const returnAt = body.indexOf("return { ok: false, reason: 'the new opencode", failureAt);
+    expect(retireAt).toBeGreaterThan(failureAt);
+    expect(retireAt).toBeLessThan(returnAt);
   });
 });
 
@@ -117,20 +115,14 @@ describe('the port pair', () => {
     expect(call).toContain('cfg.opencodeStandbyPort');
   });
 
-  test('the LIVE port never moves — the candidate only ever borrows the standby', () => {
-    // Serving from the standby would save a boot and is not worth it: the API
-    // decides from the port number whether traffic is the session's
-    // conversation, whether it may be publicly shared, whether it counts as
-    // preview use for the sandbox deadline, how Platinum rewrites ingress, and
-    // where an opencode PTY connects. Each fails silently if the live port
-    // moves. Keeping 4096 canonical means nothing outside the box has to know.
-    const body = reloadBody();
-    expect(body).not.toContain('currentCfg.opencodeInternalPort =');
+  test('chooses the idle half relative to the current active port', () => {
+    const body = candidateBody();
+    expect(body).toContain('activePort === currentCfg.opencodeInternalPort');
     expect(body).toContain('currentCfg.opencodeStandbyPort');
   });
 });
 
-describe('reloadVerified orders verification before the restart', () => {
+describe('reloadVerified promotes the verified process', () => {
   /** The method body, comments stripped. */
   function methodBody(): string {
     const start = SRC.indexOf('async reloadVerified(');
@@ -143,25 +135,38 @@ describe('reloadVerified orders verification before the restart', () => {
       .join('\n');
   }
 
-  test('verifies BEFORE restarting — the entire point', () => {
-    // Restart first and this is the old kill-then-hope path with a verification
-    // step bolted on after the damage. Nothing else in this file notices, which
-    // is exactly why it is asserted here.
+  test('verifies before changing the active process', () => {
     const body = methodBody();
     const verifyAt = body.indexOf('verifyCandidateBoots(');
-    const restartAt = body.indexOf('this.restart()');
+    const promoteAt = body.indexOf('child = proven.candidate');
     expect(verifyAt).toBeGreaterThan(-1);
-    expect(restartAt).toBeGreaterThan(-1);
-    expect(verifyAt).toBeLessThan(restartAt);
+    expect(promoteAt).toBeGreaterThan(verifyAt);
   });
 
-  test('returns kept-old WITHOUT restarting when verification fails', () => {
-    // The early return is what protects the running opencode. Falling through
-    // to the restart would kill it for a config already known not to boot.
+  test('returns kept-old without promotion when verification fails', () => {
     const body = methodBody();
     const guardAt = body.indexOf('if (!proven.ok) return');
     expect(guardAt).toBeGreaterThan(-1);
-    expect(guardAt).toBeLessThan(body.indexOf('this.restart()'));
+    expect(guardAt).toBeLessThan(body.indexOf('child = proven.candidate'));
+  });
+
+  test('does not boot a second replacement after verification', () => {
+    expect(methodBody()).not.toContain('this.restart()');
+  });
+
+  test('switches routing before retiring the previous process', () => {
+    const body = methodBody();
+    const routeAt = body.indexOf('activePort = proven.port');
+    const childAt = body.indexOf('child = proven.candidate');
+    const retireAt = body.indexOf("killProcessGroup(previous, 'SIGTERM')");
+    expect(routeAt).toBeGreaterThan(-1);
+    expect(childAt).toBeGreaterThan(routeAt);
+    expect(retireAt).toBeGreaterThan(childAt);
+  });
+
+  test('supervises the promoted process', () => {
+    const body = methodBody();
+    expect(body).toContain('superviseChild(proven.candidate)');
   });
 });
 
@@ -210,7 +215,7 @@ describe('verify_fail fault injection', () => {
     // A shortcut that returned early would prove the plumbing and nothing else.
     // Spawning for real means the injected run exercises the same code as a
     // genuine failure: candidate started, candidate retired, incumbent alive.
-    const body = reloadBody();
+    const body = candidateBody();
     const spawnAt = body.indexOf('spawnChild(binaryPath');
     const forceAt = body.indexOf('opts.forceFail');
     expect(spawnAt).toBeGreaterThan(-1);
@@ -218,7 +223,7 @@ describe('verify_fail fault injection', () => {
   });
 
   test('still retires the candidate when injected', () => {
-    const body = reloadBody();
+    const body = candidateBody();
     expect(body.indexOf('killProcessGroup(candidate')).toBeGreaterThan(
       body.indexOf('opts.forceFail'),
     );
@@ -230,11 +235,10 @@ describe('verify_fail fault injection', () => {
     expect(REFRESH).toContain("c.req.query('verify_fail') === '1'");
   });
 
-  test('injection cannot reach the restart', () => {
-    // Same guard as a real failure: decline returns before this.restart().
+  test('injection cannot reach promotion', () => {
     const method = SRC.slice(SRC.indexOf('async reloadVerified('));
     const guardAt = method.indexOf('if (!proven.ok) return');
     expect(guardAt).toBeGreaterThan(-1);
-    expect(guardAt).toBeLessThan(method.indexOf('this.restart()'));
+    expect(guardAt).toBeLessThan(method.indexOf('child = proven.candidate'));
   });
 });

--- a/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
@@ -98,6 +98,15 @@ describe('readiness means the session API answers', () => {
     const probe = SRC.slice(SRC.indexOf('async function probeUntilReady'));
     expect(probe).toContain('proc.exitCode !== null');
   });
+
+  test('a stale probe cannot downgrade a newly promoted process', () => {
+    const probe = SRC.slice(
+      SRC.indexOf('function scheduleReadinessProbe()'),
+      SRC.indexOf('\n  return {', SRC.indexOf('function scheduleReadinessProbe()')),
+    );
+    expect(probe).toContain('const probedPort = activePort');
+    expect(probe).toContain('if (probedPort !== activePort)');
+  });
 });
 
 describe('the port pair', () => {

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -384,7 +384,7 @@ async function startSessionRuntime(
   bootMark: (label: string) => void,
 ): Promise<void> {
   const onQuestionAsked = (req: QuestionRequest) => {
-    void relayQuestionToApi(req, cfg).catch((err) =>
+    void relayQuestionToApi(req, cfg, opencode).catch((err) =>
       logger.warn('[opencode-events] question relay failed', { err: (err as Error).message }),
     )
   }
@@ -1276,7 +1276,11 @@ function slackRelayContext(): SandboxRelayContext | null {
 // answers `question.asked` interactively over opencode's own SSE, and
 // auto-answering it here is the "every question is auto-answered even outside
 // Slack" bug. No round-trip, no status codes — the env is the source of truth.
-async function relayQuestionToApi(req: QuestionRequest, cfg: Config): Promise<void> {
+async function relayQuestionToApi(
+  req: QuestionRequest,
+  cfg: Config,
+  opencode: ReturnType<typeof createOpencodeSupervisor>,
+): Promise<void> {
   // EVERY session, not just Slack ones.
   //
   // This used to take `slackRelayContext()`, which returns null without
@@ -1348,7 +1352,7 @@ async function relayQuestionToApi(req: QuestionRequest, cfg: Config): Promise<vo
     'wait for an answer here; finish this turn now. Next time, just ask with ' +
     '`slack send` rather than the question tool.)'
   const answers: string[][] = req.questions.map(() => [sentinel])
-  const replyUrl = `http://127.0.0.1:${cfg.opencodeInternalPort}/question/${encodeURIComponent(req.id)}/reply?directory=${encodeURIComponent(cfg.workspace)}`
+  const replyUrl = `${opencode.getInternalUrl()}/question/${encodeURIComponent(req.id)}/reply?directory=${encodeURIComponent(cfg.workspace)}`
   try {
     const r = await fetch(replyUrl, {
       method: 'POST',

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1044,6 +1044,8 @@ export type Opencode = {
 
 export interface OpencodeSupervisorOptions {
   onStartupMark?: (label: string) => void
+  binaryPathOverride?: string
+  configPathOverride?: string
   /**
    * opencode died without anyone asking it to, and has just been respawned.
    *
@@ -1070,6 +1072,7 @@ export function createOpencodeSupervisor(
   let currentOpencodeConfigDir = opencodeConfigDir
   let currentProjectEnv = projectEnv
   let child: ChildProcess | null = null
+  let activePort = cfg.opencodeInternalPort
   let binaryPath: string | null = null
   let stopping = false
   let restartDelayMs = 500
@@ -1116,7 +1119,7 @@ export function createOpencodeSupervisor(
     bin: string,
     opts: { port?: number; supervise?: boolean } = {},
   ): Promise<ChildProcess> {
-    const port = opts.port ?? currentCfg.opencodeInternalPort
+    const port = opts.port ?? activePort
     const supervise = opts.supervise !== false
     sweepBunExtractions()
     try {
@@ -1162,6 +1165,7 @@ export function createOpencodeSupervisor(
       })
     }
     const configPath = await writeKortixOpencodeConfig(baseEnv, {
+      configPath: options.configPathOverride,
       injectedSkillsDir: join(currentOpencodeConfigDir, 'skills'),
       secretCapabilitiesInstructionPath,
     })
@@ -1196,12 +1200,8 @@ export function createOpencodeSupervisor(
     })
 
     if (supervise) {
-      superviseChild(proc)
       child = proc
-    } else {
-      proc.on('exit', (code, signal) => {
-        logger.warn('[opencode] candidate exited', { code, signal, port })
-      })
+      superviseChild(proc)
     }
     return proc
   }
@@ -1216,6 +1216,10 @@ export function createOpencodeSupervisor(
   function superviseChild(proc: ChildProcess) {
     proc.on('exit', (code, signal) => {
       logger.warn('[opencode] child exited', { code, signal })
+      if (child !== proc) {
+        logger.info('[opencode] retired child exit ignored', { pid: proc.pid })
+        return
+      }
       child = null
       state = stopping ? 'down' : 'starting'
       if (stopping) return
@@ -1320,44 +1324,36 @@ export function createOpencodeSupervisor(
    * with no opencode at all, and the reload had destroyed the very thing it was
    * supposed to update.
    *
-   * So: spawn the candidate on the standby port, prove it actually serves the
-   * session API, and only then swap to it and retire the old one. If it never
-   * comes up, the old opencode is still running and still serving — the reload
-   * reports failure and nothing was lost.
+   * So: spawn the candidate on the idle port, prove it actually serves the
+   * session API, promote that exact process, and only then retire the old one.
+   * If it never comes up, the old opencode remains active.
    *
    * The swap is a port trade, not a port allocation. Both halves are fixed at
    * startup and both are blocked in the web proxy's self-port set; picking an
    * ephemeral port would leave the live one unguarded (see config.ts).
    *
-   * There IS a brief cut at the swap — in-flight streams against the old
-   * process end when it is retired. That is expected and the CLI says so
-   * up front; the guarantee here is that you are never left with nothing.
+   * Existing streams end when the old process retires. New requests route to
+   * the promoted process before retirement starts.
    */
   /**
    * Prove the new config actually BOOTS, without touching the running opencode.
    *
-   * Spawns a candidate on the standby port while the live one keeps serving,
-   * waits for it to answer the real session API, then retires it. The verdict
-   * is all we want: a config that cannot start is discovered here, with the
-   * session still healthy, instead of after we have killed the only opencode.
-   *
-   * The candidate is deliberately NOT promoted to serve traffic. Doing so would
-   * be one boot cheaper and it is not worth it — opencode's port is not private
-   * to this process. The API decides from the port number whether traffic is
-   * the session's conversation (the per-session visibility gate), whether it
-   * may be publicly shared, whether it counts as preview use for the sandbox
-   * deadline, how Platinum rewrites ingress, and where an opencode PTY
-   * WebSocket connects. Each is a silent failure if the live port moves, and
-   * several were caught only in review. Keeping 4096 canonical means nothing
-   * outside the box has to know a reload happened.
+   * Spawns a candidate on the idle port while the live one keeps serving and
+   * waits for the real session API. A successful result owns a live process;
+   * the caller must either promote it or retire it.
    */
   async function verifyCandidateBoots(
     opts: { forceFail?: boolean } = {},
-  ): Promise<{ ok: true } | { ok: false; reason: string }> {
+  ): Promise<
+    | { ok: true; candidate: ChildProcess; port: number }
+    | { ok: false; reason: string }
+  > {
     if (!binaryPath) return { ok: false, reason: 'opencode binary not resolved yet' }
     if (stopping) return { ok: false, reason: 'supervisor is shutting down' }
 
-    const candidatePort = currentCfg.opencodeStandbyPort
+    const candidatePort = activePort === currentCfg.opencodeInternalPort
+      ? currentCfg.opencodeStandbyPort
+      : currentCfg.opencodeInternalPort
     let candidate: ChildProcess
     try {
       candidate = await spawnChild(binaryPath, { port: candidatePort, supervise: false })
@@ -1370,18 +1366,17 @@ export function createOpencodeSupervisor(
     // the point is to exercise the ACTUAL decline path — candidate spawned,
     // candidate retired, incumbent untouched — rather than a shortcut that
     // proves only the plumbing.
-    const ready = opts.forceFail
-      ? false
-      : await probeUntilReady(candidatePort, VERIFY_READY_TIMEOUT_MS, candidate)
-    await killProcessGroup(candidate, 'SIGTERM').catch(() => {})
+    const candidateReady = await probeUntilReady(candidatePort, VERIFY_READY_TIMEOUT_MS, candidate)
+    const ready = candidateReady && !opts.forceFail
     if (!ready) {
+      await killProcessGroup(candidate, 'SIGTERM').catch(() => {})
       logger.warn('[opencode] candidate never became ready; keeping the running instance', {
         candidatePort,
       })
       return { ok: false, reason: 'the new opencode did not start; the previous one is still running' }
     }
     logger.info('[opencode] candidate config verified', { candidatePort })
-    return { ok: true }
+    return { ok: true, candidate, port: candidatePort }
   }
 
   /**
@@ -1413,7 +1408,7 @@ export function createOpencodeSupervisor(
   }
 
   async function checkReady(): Promise<boolean> {
-    return probeOpencodeSessionApi(`http://127.0.0.1:${currentCfg.opencodeInternalPort}`, currentCfg.projectTarget, 2_000)
+    return probeOpencodeSessionApi(`http://127.0.0.1:${activePort}`, currentCfg.projectTarget, 2_000)
   }
 
   /**
@@ -1436,7 +1431,9 @@ export function createOpencodeSupervisor(
     const baseEnv = currentProjectEnv
       ? mergeProjectEnv(process.env, currentProjectEnv)
       : process.env
-    const written = await writeKortixOpencodeConfig(baseEnv).catch((err) => {
+    const written = await writeKortixOpencodeConfig(baseEnv, {
+      configPath: options.configPathOverride,
+    }).catch((err) => {
       logger.warn('[opencode] could not rewrite config for reload', {
         err: (err as Error).message,
       })
@@ -1445,7 +1442,7 @@ export function createOpencodeSupervisor(
     if (!written) return false
     try {
       const res = await fetch(
-        `http://127.0.0.1:${currentCfg.opencodeInternalPort}/global/dispose`,
+        `http://127.0.0.1:${activePort}/global/dispose`,
         { method: 'POST', signal: AbortSignal.timeout(15_000) },
       )
       // Content-type matters: the SPA catch-all also answers 200, so a status
@@ -1515,7 +1512,7 @@ export function createOpencodeSupervisor(
     async start() {
       stopping = false
       state = 'starting'
-      const bin = await detectOpencodeBinary()
+      const bin = options.binaryPathOverride ?? await detectOpencodeBinary()
       if (!bin) {
         logger.warn('[opencode] binary not found on PATH (and /usr/local/bin/opencode-kortix missing); daemon will continue, opencode reports as starting')
         state = 'starting'
@@ -1673,26 +1670,47 @@ export function createOpencodeSupervisor(
       return 'restarted'
     },
 
-    /**
-     * Verify first, then restart. Never kills the running opencode for a config
-     * that cannot boot.
-     *
-     * Downtime is unchanged from the old restart — the gap is one boot — but it
-     * now starts from a config already proven to start.
-     */
+    /** Promote the verified process before retiring the previous process. */
     async reloadVerified(opts: { forceFail?: boolean } = {}): Promise<VerifiedReloadResult> {
       const proven = await verifyCandidateBoots(opts)
       if (!proven.ok) return { outcome: 'kept-old', reason: proven.reason }
-      await this.restart()
+
+      const previous = child
+      const previousPort = activePort
+      activePort = proven.port
+      child = proven.candidate
+      superviseChild(proven.candidate)
+      if (proven.candidate.exitCode !== null || proven.candidate.signalCode !== null) {
+        child = previous
+        activePort = previousPort
+        return {
+          outcome: 'kept-old',
+          reason: 'the verified opencode exited before promotion; the previous one is still running',
+        }
+      }
+      markReady()
+      if (previous) await killProcessGroup(previous, 'SIGTERM').catch(() => {})
+      logger.info('[opencode] candidate promoted', {
+        port: activePort,
+        pid: proven.candidate.pid,
+        previousPort,
+        previousPid: previous?.pid ?? null,
+      })
       return {
         outcome: 'swapped',
-        port: currentCfg.opencodeInternalPort,
+        port: activePort,
         pid: this.getPid(),
       }
     },
 
     reconfigure(nextCfg: Config, nextOpencodeConfigDir: string, nextProjectEnv?: ProjectEnvStore) {
       currentCfg = nextCfg
+      if (
+        activePort !== nextCfg.opencodeInternalPort &&
+        activePort !== nextCfg.opencodeStandbyPort
+      ) {
+        activePort = nextCfg.opencodeInternalPort
+      }
       currentOpencodeConfigDir = nextOpencodeConfigDir
       if (nextProjectEnv) currentProjectEnv = nextProjectEnv
       state = 'starting'
@@ -1707,7 +1725,7 @@ export function createOpencodeSupervisor(
     },
 
     getInternalUrl() {
-      return `http://127.0.0.1:${currentCfg.opencodeInternalPort}`
+      return `http://127.0.0.1:${activePort}`
     },
 
     getBinaryPath() {

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1407,8 +1407,8 @@ export function createOpencodeSupervisor(
     return false
   }
 
-  async function checkReady(): Promise<boolean> {
-    return probeOpencodeSessionApi(`http://127.0.0.1:${activePort}`, currentCfg.projectTarget, 2_000)
+  async function checkReady(port = activePort): Promise<boolean> {
+    return probeOpencodeSessionApi(`http://127.0.0.1:${port}`, currentCfg.projectTarget, 2_000)
   }
 
   /**
@@ -1498,7 +1498,12 @@ export function createOpencodeSupervisor(
     const interval = state === 'ok' ? READY_LIVENESS_MS : READY_POLL_MS
     readinessTimer = setTimeout(async () => {
       if (stopping) return
-      const ready = await checkReady()
+      const probedPort = activePort
+      const ready = await checkReady(probedPort)
+      if (probedPort !== activePort) {
+        scheduleReadinessProbe()
+        return
+      }
       if (ready) {
         markReady()
       } else if (state !== 'starting') {

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -120,7 +120,7 @@ export function buildOpencodeApp(
   const kortixRouter = new Hono()
   const healthRouter = createHealthRouter(cfg, opencode, bootTime, bootState, staticWebPort)
   const refreshRouter = createRefreshRouter(cfg, opencode)
-  const abortRouter = createAbortRouter(cfg)
+  const abortRouter = createAbortRouter(cfg, opencode)
   const envRouter = projectEnv
     ? createEnvRouter(cfg, opencode, projectEnv, { agentEnvFile })
     : null

--- a/apps/kortix-sandbox-agent-server/src/routes/abort.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/abort.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { logger } from '../logger'
 import { readPinnedOpencodeSessionId } from '../main'
 import type { Config } from '../config'
+import type { Opencode } from '../opencode'
 import {
   KORTIX_USER_CONTEXT_HEADER,
   verifyKortixUserContext,
@@ -11,7 +12,7 @@ import {
 // session. apps/api calls this when the user clicks "Stop" on the Slack
 // stream. opencode's /session/{id}/abort cancels the running model call and
 // any in-flight tools; the next prompt to the same session resumes cleanly.
-export function createAbortRouter(cfg: Config): Hono {
+export function createAbortRouter(cfg: Config, opencode: Opencode): Hono {
   const app = new Hono()
 
   app.post('/', async (c) => {
@@ -31,7 +32,7 @@ export function createAbortRouter(cfg: Config): Hono {
     }
 
     const workspace = process.env.KORTIX_WORKSPACE || '/workspace'
-    const url = `http://127.0.0.1:${cfg.opencodeInternalPort}/session/${encodeURIComponent(sessionId)}/abort?directory=${encodeURIComponent(workspace)}`
+    const url = `${opencode.getInternalUrl()}/session/${encodeURIComponent(sessionId)}/abort?directory=${encodeURIComponent(workspace)}`
     try {
       const res = await fetch(url, {
         method: 'POST',

--- a/docs/SESSION_CONFIG_RELOAD.md
+++ b/docs/SESSION_CONFIG_RELOAD.md
@@ -144,3 +144,7 @@ after the edit. The clean run above is the one to trust.
    `/kortix/refresh` (the only client-reachable path that restarts the runtime —
    it pulls the workspace too, and the palette label says so). Both check
    `content-type` before trusting a 200, for the reason above.
+4. A required respawn is a verified process swap. The daemon boots the candidate
+   on the idle OpenCode port and probes its session API. It then routes new
+   requests to that same process before retiring the previous process. A failed
+   candidate is retired while the previous PID and port remain active.

--- a/docs/SESSION_RELOAD_CONFIG_DIR.md
+++ b/docs/SESSION_RELOAD_CONFIG_DIR.md
@@ -150,8 +150,8 @@ which is a different and wrong statement.
    `git branch --show-current` are identical before and after.
 2. A session with committed work keeps it, and keeps its files.
 3. A session that edited its own agent config keeps that, and is **told** so.
-4. After a real merge, the marker appears in `localhost:4096/config` — not just in
-   `~/.config/kortix-opencode.json`. The second proves the push; only the first
-   proves the agent changed.
+4. After a real merge, the marker appears in `localhost:<reload.port>/config` —
+   not only in `~/.config/kortix-opencode.json`. The refresh response reports
+   the active port. The runtime port alternates after verified process swaps.
 
 Point 4 is the one that was never checked, and it is why this shipped broken.


### PR DESCRIPTION
## Summary

- Promote the exact OpenCode candidate that passed the session API probe.
- Switch daemon routing before retiring the previous process.
- Keep the previous PID and port active when candidate verification fails.
- Route abort and channel-question replies through the active runtime port.
- Verify conflicting config commits with unrelated dirty and untracked session work.

## Verification

- `bun test apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts apps/kortix-sandbox-agent-server/src/__tests__/verified-reload-process.e2e.test.ts apps/kortix-sandbox-agent-server/src/__tests__/config-dir-sync.test.ts` — 47 pass, 0 fail.
- `node apps/kortix-sandbox-agent-server/node_modules/typescript/bin/tsc --noEmit -p apps/kortix-sandbox-agent-server/tsconfig.json` — pass.
- `bun run --cwd apps/kortix-sandbox-agent-server build` — pass.