### PR TITLE
fix(ci): checkout signing helper in supply-chain job

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -225,6 +225,7 @@ jobs:
     env:
       IMAGE: ${{ needs.tag-api.outputs.image }}
     steps:
+      - uses: actions/checkout@v7
       - name: Trivy image scan (fail on fixable CRITICAL)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:

--- a/tests/unit/cosign-sign-attest.test.ts
+++ b/tests/unit/cosign-sign-attest.test.ts
@@ -99,10 +99,18 @@ describe("keyless image signing", () => {
 
   it("routes the Dev supply-chain gate through the retry-safe signer", () => {
     const yaml = readFileSync(workflow, "utf8");
+    const supplyChain = yaml.slice(
+      yaml.indexOf("  supply-chain:"),
+      yaml.indexOf("  migrate-db:"),
+    );
 
     expect(yaml).toContain(
       'bash scripts/ci/cosign-sign-attest.sh "$REF" sbom.spdx.json',
     );
     expect(yaml).not.toContain("cosign attest --yes --type spdxjson");
+    expect(supplyChain).toContain("uses: actions/checkout@v7");
+    expect(supplyChain.indexOf("uses: actions/checkout@v7")).toBeLessThan(
+      supplyChain.indexOf("bash scripts/ci/cosign-sign-attest.sh"),
+    );
   });
 });


### PR DESCRIPTION
## Problem

Deploy Dev run `31174667793` reached the new retry-safe signing command, but the supply-chain job had no repository checkout. The runner returned `scripts/ci/cosign-sign-attest.sh: No such file or directory`.

## Change

- Check out the repository before the supply-chain steps.
- Assert the checkout exists and precedes the signing helper invocation.

## Verification

- Failing regression test reproduced the missing checkout.
- `actionlint .github/workflows/deploy-dev.yml`
- `shellcheck scripts/ci/cosign-sign-attest.sh`
- `cd tests && bun run test:unit` → `54 passed, 0 failed`
