### PR TITLE
fix(web): de-noise Canvas getImageData OOM on marketing homepage (BS b4b43847)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   isAndroidWebViewNativeBridgePostEventNoise,
   isAndroidWebViewNativeBridgePostMessageNoise,
+  isCanvasImageDataOOMNoise,
   isClientRequestTimeoutMessage,
   isConnectionClosedNoise,
   isDocumentStateNotFoundNoise,
@@ -7725,6 +7726,212 @@ test('does NOT suppress the "Connection closed by server." wording (over-match g
       }),
       false,
       `expected Sentry event "${message}" to keep reporting`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Canvas `getImageData` out-of-memory noise (BS b4b43847…)
+// ---------------------------------------------------------------------------
+
+// The exact raw exception value from the production event (V8/Chrome wording).
+const CANVAS_GETIMAGEDATA_OOM_MESSAGE =
+  "Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Out of memory at ImageData creation"
+
+// A minified third-party canvas library chunk frame — the call site file from
+// the production event (`app:///_next/static/chunks/0fl4m2af7bsiq.js`). No
+// resolved first-party `apps/web/src/…` source, so the negative guard does NOT
+// fire. Represents the production event's frame shape.
+const CANVAS_OOM_PROD_CHUNK_FRAME = 'app:///_next/static/chunks/0fl4m2af7bsiq.js'
+
+// The two production stack frames (both minified third-party canvas library
+// chunk frames — NO resolved first-party `apps/web/src/…` source). The call
+// site function is `Image.<anonymous>` (the `addEventListener` callback the
+// third-party library registered).
+const CANVAS_OOM_PROD_FRAMES: Array<{ filename: unknown; function: unknown }> = [
+  { filename: CANVAS_OOM_PROD_CHUNK_FRAME, function: 'Image.<anonymous>' },
+  { filename: 'app:///_next/static/chunks/0fl4m2af7bsiq.js', function: '?' },
+]
+
+// The canonical capture-path forms: raw, `RangeError:` prefix, and stacked
+// `Unhandled promise rejection: RangeError:` prefix. All strip to the same
+// underlying message via `stripErrorWrappers`.
+const CANVAS_OOM_CAPTURE_FORMS = [
+  CANVAS_GETIMAGEDATA_OOM_MESSAGE,
+  `RangeError: ${CANVAS_GETIMAGEDATA_OOM_MESSAGE}`,
+  `Unhandled promise rejection: RangeError: ${CANVAS_GETIMAGEDATA_OOM_MESSAGE}`,
+]
+
+test('classifies every Canvas getImageData OOM capture form as noise (no first-party frame)', () => {
+  for (const message of CANVAS_OOM_CAPTURE_FORMS) {
+    // Matcher-level: message alone (frameless — still noise because the message
+    // is the browser's canonical OOM wording and is specific enough).
+    assert.equal(
+      isCanvasImageDataOOMNoise({ message }),
+      true,
+      `expected "${message}" to be classified as Canvas getImageData OOM noise`,
+    )
+    // Matcher-level: with a minified chunk frame (no first-party source).
+    assert.equal(
+      isCanvasImageDataOOMNoise({
+        message,
+        frames: [{ filename: CANVAS_OOM_PROD_CHUNK_FRAME }],
+      }),
+      true,
+      `expected "${message}" from a chunk frame to be noise`,
+    )
+    // Matcher-level: with a window.onerror filename (no first-party source).
+    assert.equal(
+      isCanvasImageDataOOMNoise({ message, filename: CANVAS_OOM_PROD_CHUNK_FRAME }),
+      true,
+      `expected "${message}" from a chunk filename to be noise`,
+    )
+  }
+})
+
+test('suppresses the production Canvas getImageData OOM Sentry event via the beforeSend gate', () => {
+  // Reproduces the exact production event: BS pattern b4b43847…, release
+  // v0.12.4, request URL https://kortix.com/ (marketing homepage), mechanism
+  // auto.browser.browserapierrors.addEventListener (UNCAUGHT, handled:false),
+  // call site function Image.<anonymous>, call site file
+  // app:///_next/static/chunks/0fl4m2af7bsiq.js, 2 minified chunk frames.
+  for (const value of CANVAS_OOM_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/' },
+        exception: {
+          values: [
+            {
+              value,
+              mechanism: {
+                type: 'auto.browser.browserapierrors.addEventListener',
+                handled: false,
+              },
+              stacktrace: { frames: CANVAS_OOM_PROD_FRAMES },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses a frameless Canvas getImageData OOM Sentry event (no first-party frame to preserve)', () => {
+  for (const value of CANVAS_OOM_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      true,
+      `expected frameless Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses the Canvas getImageData OOM via the runtime (window.onerror) gate', () => {
+  for (const message of CANVAS_OOM_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message }),
+      true,
+      `expected runtime gate to suppress "${message}"`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message, filename: CANVAS_OOM_PROD_CHUNK_FRAME }),
+      true,
+      `expected runtime gate to suppress "${message}" from a chunk filename`,
+    )
+  }
+})
+
+test('does NOT suppress a Canvas getImageData OOM whose stack resolves to a first-party app frame', () => {
+  // A de-minified `apps/web/src/…` frame means our own code called
+  // `getImageData()` and the browser ran out of memory — a real first-party
+  // OOM regression, actionable to fix (e.g. shrink the canvas, guard the
+  // allocation, or drop the call on low-memory devices). This is the negative
+  // guard that distinguishes actionable first-party code regressions from the
+  // third-party-library noise class.
+  const realAppFrames: Array<Array<{ filename: unknown; function?: unknown }>> = [
+    [{ filename: 'app:///apps/web/src/features/marketing/hyper-logo.ts', function: 'samplePixels' }],
+    [{ filename: 'apps/web/src/lib/canvas/pixel-reader.ts', function: 'readRegion' }],
+  ]
+  for (const frames of realAppFrames) {
+    for (const message of CANVAS_OOM_CAPTURE_FORMS) {
+      assert.equal(
+        isCanvasImageDataOOMNoise({ message, frames }),
+        false,
+        `expected first-party event "${message}" from ${JSON.stringify(frames)} to keep reporting`,
+      )
+      assert.equal(
+        shouldIgnoreSentryBrowserNoise({
+          exception: {
+            values: [{ value: message, stacktrace: { frames } }],
+          },
+        }),
+        false,
+        `expected Sentry gate to keep reporting first-party "${message}" from ${JSON.stringify(frames)}`,
+      )
+    }
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  for (const message of CANVAS_OOM_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message,
+        filename: 'apps/web/src/lib/canvas/pixel-reader.ts',
+      }),
+      false,
+      `expected runtime gate to keep reporting first-party "${message}"`,
+    )
+  }
+})
+
+test('does NOT suppress a near-worded message without the exact OOM suffix (over-match guard)', () => {
+  // The `Out of memory at ImageData creation` suffix is part of the anchor —
+  // a different `getImageData` failure (e.g. a different DOM exception, or a
+  // different allocation reason) must keep reporting so the matcher does not
+  // over-match a real first-party canvas bug.
+  for (const message of [
+    // A different `getImageData` DOM exception (e.g. index out of range).
+    "Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Index is not in the allowed range.",
+    // A different OOM wording without the `ImageData creation` suffix.
+    "Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Out of memory.",
+    // A different Canvas 2D method entirely.
+    "Failed to execute 'putImageData' on 'CanvasRenderingContext2D': Out of memory at ImageData creation",
+    // A near-worded first-party throw (no `Failed to execute` DOM prefix).
+    'Out of memory at ImageData creation',
+  ]) {
+    assert.equal(
+      isCanvasImageDataOOMNoise({ message, frames: [] }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a non-OOM RangeError (over-match guard on the RangeError type)', () => {
+  // The matcher anchors on the EXACT `getImageData` OOM message, NOT on the
+  // `RangeError` type. A generic `RangeError: Maximum call stack size
+  // exceeded.` (the iOS-WebKit stack-overflow class, handled by
+  // `isUnresolvableStackOverflowNoise`) or a first-party `RangeError` keeps
+  // reporting unless it matches the exact canvas OOM wording.
+  for (const message of [
+    'Maximum call stack size exceeded.',
+    'RangeError: Maximum call stack size exceeded.',
+    'Array length must be finite.',
+  ]) {
+    assert.equal(
+      isCanvasImageDataOOMNoise({ message, frames: [] }),
+      false,
+      `expected "${message}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -451,6 +451,72 @@ const PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS = [
 const PAPER_SHADER_WEBGL_UNSUPPORTED_NOISE_MESSAGE =
   'Paper Shaders: WebGL is not supported in this browser';
 
+// Canvas `getImageData` out-of-memory noise — a third-party canvas library
+// (e.g. a decorative background / hyper-logo animation effect on the marketing
+// homepage) called `CanvasRenderingContext2D.getImageData()` and the browser ran
+// out of memory allocating the `ImageData` buffer, surfacing as
+//   `Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Out of
+//    memory at ImageData creation`
+// (V8/Chrome wording — a `RangeError`, NOT a `TypeError`). This is TRANSIENT
+// browser resource exhaustion: the canvas was too large / the tab was under
+// memory pressure / the device is low-RAM, so the engine failed the buffer
+// allocation. It is NOT a deterministic code bug — the same canvas renders fine
+// on the next visit once memory frees up. The throw fires from a
+// third-party library's `addEventListener` callback (Sentry's `BrowserApiErrors`
+// integration auto-wraps `addEventListener` on `EventTarget` and captures the
+// throw as `handled:false`, UNCAUGHT — it never reached a React error
+// boundary), and the stack frames are all minified `_next/static/chunks/…`
+// library frames with NO resolved first-party `apps/web/src/…` source.
+//
+// Better Stack pattern
+// b4b4384734b09b411e476591e3f9ac3ad88f110e0be91aae390913038f6844f0
+// (Kortix Frontend prod, application_id 2346967): `RangeError`, message
+// `Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Out of
+// memory at ImageData creation`, 1 occurrence / 0 identified users, last
+// 2026-08-07 10:09:13 UTC, release
+// `160f0b286f0ad5c53debc343d5e055241694e24d` (v0.12.4 prod), call site
+// function `Image.<anonymous>`, call site file
+// `app:///_next/static/chunks/0fl4m2af7bsiq.js` (minified), request URL
+// `https://kortix.com/` (marketing homepage), browser Chrome 130 on Linux,
+// mechanism `auto.browser.browserapierrors.addEventListener` (UNCAUGHT,
+// `handled:false`). Stack: 2 frames, both minified third-party canvas library
+// chunk frames — NO first-party `apps/web/src/…` frame.
+//
+// The message is the browser's OWN canonical out-of-memory wording for a
+// `CanvasRenderingContext2D.getImageData()` allocation failure (the
+// `Failed to execute 'getImageData' on 'CanvasRenderingContext2D':` prefix is
+// V8's DOM-bindings exception format; the `Out of memory at ImageData
+// creation` suffix is the specific allocation-failure reason). This exact
+// string is the browser's, never an app-logic phrase — a real first-party
+// `throw new RangeError('…Out of memory at ImageData creation…')` regression
+// is vanishingly unlikely AND would de-minify to `apps/web/src/…` frames.
+// BUT `getImageData` IS a Canvas 2D API method that first-party code CAN call
+// (e.g. an image-processing helper, a screenshot/export path, a pixel-reader),
+// so — mirroring `isSafariGenericSecurityErrorNoise` /
+// `isOldBrowserDomNullDerefNoise` — the matcher carries a NEGATIVE guard: if
+// ANY frame (or the window.onerror `filename`) resolves to a de-minified
+// first-party `apps/web/src/…` source path, the event KEEPS reporting (our
+// own code is the `getImageData` caller → a real first-party OOM regression
+// we want to fix). Only events with NO resolved first-party frame (the prod
+// noise shape: all minified third-party canvas library chunk frames, or
+// frameless) are dropped. A frameless capture with this exact message still
+// classifies as noise — the message alone is the browser's canonical OOM
+// wording and is specific enough (the `CanvasRenderingContext2D` +
+// `getImageData` + `ImageData creation` tokens together pin this single DOM
+// API call site). Deliberately NOT added to
+// `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame
+// context, so a bare-string match there could swallow a real first-party
+// `getImageData` OOM regression the negative guard exists to preserve; the
+// frame-aware `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`)
+// is the only safe gate. The runtime `window.onerror` gate
+// (`shouldIgnoreBrowserRuntimeNoise`) is also wired so a runtime capture with
+// the exact message + no first-party `filename` drops.
+const CANVAS_GETIMAGE_DATA_OOM_NOISE_PATTERNS: ReadonlyArray<RegExp> = [
+  // The exact V8/Chrome message. Anchored as a full-match (the trailing
+  // `Out of memory at ImageData creation` is the specific OOM reason).
+  /^Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Out of memory at ImageData creation$/,
+];
+
 // Old-browser / stripped-down-WebView minified-chunk parse failures. When a
 // browser that cannot parse modern minified JS (old Safari/iOS, legacy Android
 // WebView, in-app browsers, mail-client preview WebViews) tries to evaluate a
@@ -1781,6 +1847,59 @@ export function isPaperShaderWebGLUnsupportedNoise(input: {
   // (the library's canonical string) that a frameless capture is safe to
   // drop, unlike the generic `undefined` / `OperationError` matchers.
   if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Whether a Sentry / window.onerror event is the Canvas `getImageData`
+ * out-of-memory noise class: a `RangeError` from
+ * `CanvasRenderingContext2D.getImageData()` running out of memory allocating
+ * the `ImageData` buffer — the browser's canonical
+ * `Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Out of
+ * memory at ImageData creation` message. This is TRANSIENT browser resource
+ * exhaustion (the canvas was too large / the tab was under memory pressure /
+ * the device is low-RAM), fired from a third-party canvas library's
+ * `addEventListener` callback (Sentry's `BrowserApiErrors` auto-wrapper captures
+ * it as UNCAUGHT, `handled:false` — never reached a React error boundary).
+ * NOT a deterministic code bug — the same canvas renders fine on the next
+ * visit once memory frees up. See `CANVAS_GETIMAGE_DATA_OOM_NOISE_PATTERNS`
+ * for the full rationale and Better Stack pattern `b4b43847…`.
+ *
+ * Requires the EXACT V8/Chrome message AND a NEGATIVE guard: if any frame (or
+ * the window.onerror `filename`) resolves to a de-minified first-party
+ * `apps/web/src/…` source path, the event keeps reporting — our own code is
+ * the `getImageData` caller and a real first-party OOM regression is
+ * actionable. Only events with NO resolved first-party frame (the prod noise
+ * shape: all minified third-party canvas library chunk frames, or frameless)
+ * are dropped. A frameless capture with this exact message still classifies
+ * as noise (the message alone is the browser's canonical OOM wording and is
+ * specific enough — the `CanvasRenderingContext2D` + `getImageData` +
+ * `ImageData creation` tokens together pin this single DOM API call site).
+ * `RangeError: ` / `Unhandled promise rejection: ` wrappers are stripped
+ * before matching so all capture paths (window.onerror, onunhandledrejection,
+ * Sentry exception) classify consistently.
+ */
+export function isCanvasImageDataOOMNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (!CANVAS_GETIMAGE_DATA_OOM_NOISE_PATTERNS.some((re) => re.test(stripped))) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame (or
+  // window.onerror `filename`) means our own code is the `getImageData` caller
+  // → a real first-party OOM regression; keep reporting so the call site can
+  // be found + fixed. A real first-party `getImageData` OOM de-minifies to
+  // `apps/web/src/…` and is never hidden.
+  if (sources.some(isFirstPartyResolvedSource)) {
     return false;
   }
   return true;
@@ -3477,6 +3596,26 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Canvas `getImageData` out-of-memory noise — a third-party canvas library
+  // (e.g. a decorative background / hyper-logo animation on the marketing
+  // homepage) called `CanvasRenderingContext2D.getImageData()` and the browser
+  // ran out of memory allocating the `ImageData` buffer, surfacing as the
+  // canonical `Failed to execute 'getImageData' on 'CanvasRenderingContext2D':
+  // Out of memory at ImageData creation` `RangeError`. TRANSIENT browser
+  // resource exhaustion (canvas too large / tab under memory pressure / low-
+  // RAM device), not a deterministic code bug. The throw fires from a
+  // third-party library's `addEventListener` callback (Sentry's
+  // `BrowserApiErrors` auto-wrapper captures it as UNCAUGHT, `handled:false`
+  // — never reached a React error boundary). Requires the exact message AND a
+  // NEGATIVE guard: a resolved first-party `apps/web/src/…` filename means our
+  // own code is the `getImageData` caller → a real first-party OOM regression;
+  // keep reporting. A frameless window.onerror capture with the exact message
+  // + no first-party filename drops. See `isCanvasImageDataOOMNoise` and
+  // Better Stack pattern `b4b43847…`.
+  if (isCanvasImageDataOOMNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
   // Old-browser / stripped-down-WebView minified-chunk parse failures
   // (`Unexpected token …`, `Invalid or unexpected token`, `Cannot use import
   // statement outside a module`) from `window.onerror`. The browser cannot
@@ -3797,6 +3936,28 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // `@paper-design/shaders` chunk frames. NOT in `ignoreErrors` (no frame
   // context there). See `isPaperShaderWebGLUnsupportedNoise`.
   if (isPaperShaderWebGLUnsupportedNoise({ message, frames })) {
+    return true;
+  }
+
+  // Canvas `getImageData` out-of-memory noise — a third-party canvas library
+  // (e.g. a decorative background / hyper-logo animation on the marketing
+  // homepage) called `CanvasRenderingContext2D.getImageData()` and the browser
+  // ran out of memory allocating the `ImageData` buffer, surfacing as the
+  // canonical `Failed to execute 'getImageData' on 'CanvasRenderingContext2D':
+  // Out of memory at ImageData creation` `RangeError`. This is TRANSIENT
+  // browser resource exhaustion (canvas too large / tab under memory pressure
+  // / low-RAM device), NOT a deterministic code bug — the same canvas renders
+  // fine on the next visit. The throw fires from a third-party library's
+  // `addEventListener` callback (Sentry's `BrowserApiErrors` auto-wrapper
+  // captures it as UNCAUGHT, `handled:false` — never reached a React error
+  // boundary). Requires the exact message AND a NEGATIVE guard: a resolved
+  // first-party `apps/web/src/…` frame means our own code is the
+  // `getImageData` caller → a real first-party OOM regression; keep reporting.
+  // The prod event carries only minified third-party canvas library chunk
+  // frames (no first-party source). NOT in `ignoreErrors` (no frame context
+  // there). See `isCanvasImageDataOOMNoise` and Better Stack pattern
+  // `b4b43847…`.
+  if (isCanvasImageDataOOMNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This is a telemetry-noise filter (a new matcher in `browser-error-noise.ts`); the proof is the test result below.

```
$ bun test apps/web/src/lib/browser-error-noise.test.mts
285 pass
0 fail
```

The production event (`Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Out of memory at ImageData creation`) is now classified as noise and dropped at both the Sentry `beforeSend` gate and the runtime `window.onerror` gate, while a first-party `getImageData` OOM keeps reporting (negative guard).

## Why

A third-party canvas library (a decorative background / hyper-logo animation effect on the marketing homepage) called `CanvasRenderingContext2D.getImageData()` and the browser ran out of memory allocating the `ImageData` buffer, surfacing as a `RangeError`:

```
Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Out of memory at ImageData creation
```

This is **transient browser resource exhaustion** (canvas too large / tab under memory pressure / low-RAM device), **not a deterministic code bug** — the same canvas renders fine on the next visit once memory frees up. It paged Better Stack as an UNCAUGHT global error, but it is browser noise:

1. **UNCAUGHT** — fired from a third-party library's `addEventListener` callback (Sentry `BrowserApiErrors` auto-wrapper, `handled:false`); never reached a React error boundary.
2. **Marketing page only** — `https://kortix.com/`, not a product flow.
3. **Third-party library** — both stack frames are minified `_next/static/chunks/0fl4m2af7bsiq.js` frames (call site `Image.<anonymous>`); NO resolved first-party `apps/web/src/…` source.
4. **1 occurrence / 0 identified users** — low volume, transient.

Better Stack pattern `b4b4384734b09b411e476591e3f9ac3ad88f110e0be91aae390913038f6844f0` (Kortix Frontend prod, app_id `2346967`): 1 occurrence / 0 identified users, last 2026-08-07 10:09:13 UTC, release `160f0b286f0ad5c53debc343d5e055241694e24d` (v0.12.4 prod), Chrome 130 on Linux.

## What changed

- **`apps/web/src/lib/browser-error-noise.ts`**
  - Added `CANVAS_GETIMAGE_DATA_OOM_NOISE_PATTERNS` — a regex anchored on the exact V8/Chrome message `/^Failed to execute 'getImageData' on 'CanvasRenderingContext2D': Out of memory at ImageData creation$/`.
  - Added exported `isCanvasImageDataOOMNoise(input)` — exact-message match + a **first-party-frame negative guard**: if any frame (or the `window.onerror` `filename`) resolves to a de-minified first-party `apps/web/src/…` source path, the event **keeps reporting** (our own code is the `getImageData` caller → a real first-party OOM regression we want to fix). Only events with NO resolved first-party frame (the prod noise shape: all minified third-party canvas library chunk frames, or frameless) are dropped. A frameless capture with this exact message still classifies as noise (the message alone is the browser's canonical OOM wording; the `CanvasRenderingContext2D` + `getImageData` + `ImageData creation` tokens together pin this single DOM API call site).
  - Wired `isCanvasImageDataOOMNoise` into **both** gates:
    - `shouldIgnoreSentryBrowserNoise` (the frame-aware Sentry `beforeSend` gate).
    - `shouldIgnoreBrowserRuntimeNoise` (the runtime `window.onerror` gate).
  - Deliberately **NOT** added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there could swallow a real first-party `getImageData` OOM regression the negative guard exists to preserve. The frame-aware `beforeSend` hook is the only safe gate. (Mirrors `isSafariGenericSecurityErrorNoise` / `isOldBrowserDomNullDerefNoise`.)

- **`apps/web/src/lib/browser-error-noise.test.mts`** — 7 new tests pinning the production event:
  - Classifies every capture-path form (raw, `RangeError:`, `Unhandled promise rejection: RangeError:`) as noise with no first-party frame (matcher-level: frameless, chunk frame, chunk filename).
  - Suppresses the **exact production event** via the `beforeSend` gate (BS pattern `b4b43847…`, release v0.12.4, `https://kortix.com/`, `auto.browser.browserapierrors.addEventListener`, `handled:false`, call site `Image.<anonymous>`, 2 minified chunk frames).
  - Suppresses a frameless Sentry event.
  - Suppresses via the runtime `window.onerror` gate (frameless + chunk filename).
  - **Negative guard**: does NOT suppress when a stack frame resolves to a first-party `apps/web/src/…` source (real first-party `getImageData` OOM regression) — verified at both the matcher, Sentry, and runtime gates.
  - **Over-match guards**: does NOT suppress a different `getImageData` DOM exception, OOM without the `ImageData creation` suffix, `putImageData`, a bare `Out of memory at ImageData creation` (no DOM prefix), or a non-OOM `RangeError` (stack overflow / array length).

## Verification

```
$ cd apps/web && bun test src/lib/browser-error-noise.test.mts
285 pass
0 fail
```

(278 pre-existing + 7 new = 285; the new tests reproduce the production event and confirm it is suppressed, while the first-party negative guard and over-match guards keep real regressions reporting.)

## Risk / rollback

Low. The matcher is additive (a new noise class); it only drops events that match the exact browser-canonical `getImageData` OOM message AND have no resolved first-party frame. A real first-party `getImageData` OOM regression (de-minified to `apps/web/src/…`) is preserved by the negative guard. Revert the commit to restore reporting.

## Confirmation

After this merges + promotes, the Better Stack error `b4b43847…` should drop to zero new occurrences (the `beforeSend` gate returns `null` for the noise class before it reaches Better Stack).
