### PR TITLE
feat(reload): say the turn was stopped, and ask before stopping it

### DIFF
--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -224,6 +224,11 @@ async function postEnvToDaemon(args: {
    * serves — the push landed, the config did not.
    */
   opencodeReload: 'disposed' | 'restarted' | 'kept-old' | null;
+  /**
+   * Did applying the config interrupt a turn someone was waiting on?
+   * `null` = the box did not say (older daemon, or no reload happened).
+   */
+  opencodeTurnEnded: boolean | null;
 }> {
   if (!isSecureOrPrivateTarget(args.previewUrl)) {
     throw new Error('refusing to push secrets over insecure transport (non-TLS public host)');
@@ -273,6 +278,7 @@ async function postEnvToDaemon(args: {
     agent_env_written?: unknown;
     opencode?: unknown;
     opencode_reload?: unknown;
+    opencode_turn_ended?: unknown;
   } | null;
   const expectedExported = Object.keys(args.snapshot.env).length;
   if (args.requireAgentEnvProof) {
@@ -297,6 +303,8 @@ async function postEnvToDaemon(args: {
       typeof body?.opencode_reload === 'string'
         ? (body.opencode_reload as 'disposed' | 'restarted' | 'kept-old')
         : null,
+    opencodeTurnEnded:
+      typeof body?.opencode_turn_ended === 'boolean' ? body.opencode_turn_ended : null,
     revision: typeof body?.revision === 'string' ? body.revision : args.snapshot.revision,
     exported: typeof body?.exported === 'number' ? body.exported : expectedExported,
     managed: typeof body?.managed === 'number' ? body.managed : null,
@@ -658,7 +666,12 @@ export async function pushSessionAgentConfigToSandbox(input: {
   defaultBranch: string;
   manifestPath?: string | null;
   baseRef?: string | null;
-}): Promise<{ applied: boolean; reason?: string; opencodeReload?: 'disposed' | 'restarted' | 'kept-old' | null }> {
+}): Promise<{
+  applied: boolean;
+  reason?: string;
+  opencodeReload?: 'disposed' | 'restarted' | 'kept-old' | null;
+  opencodeTurnEnded?: boolean | null;
+}> {
   try {
     const [session] = await db
       .select({
@@ -727,7 +740,11 @@ export async function pushSessionAgentConfigToSandbox(input: {
     // `applied` means WE pushed it. Whether opencode actually took it is
     // `opencodeReload` — a declined swap leaves the old config running, and
     // reporting a bare `applied: true` for that is the lie this field prevents.
-    return { applied: true, opencodeReload: pushed.opencodeReload };
+    return {
+      applied: true,
+      opencodeReload: pushed.opencodeReload,
+      opencodeTurnEnded: pushed.opencodeTurnEnded,
+    };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     console.warn(`[env-sync] agent-config push failed for session ${input.sessionId}:`, reason);

--- a/apps/api/src/projects/lib/session-reload.test.ts
+++ b/apps/api/src/projects/lib/session-reload.test.ts
@@ -185,6 +185,7 @@ describe('reloadDetail', () => {
     repo_refreshed: true,
     commit_sha: null,
     opencode_reload: null,
+    turn_ended: null,
   } as const;
 
   test('claims the agent changed ONLY for "updated"', () => {
@@ -235,6 +236,7 @@ describe('reloadNeedsAttention', () => {
     repo_refreshed: true,
     commit_sha: null,
     opencode_reload: null,
+    turn_ended: null,
   } as const;
 
   test('the three success outcomes are NOT warnings', () => {
@@ -255,5 +257,68 @@ describe('reloadNeedsAttention', () => {
     expect(
       reloadNeedsAttention({ ...base, applied: false, agent_files: 'updated' }),
     ).toBe(true);
+  });
+});
+
+/**
+ * Telling the user their turn was stopped.
+ *
+ * Marko, on the call: the reload restarts the runtime and "the whole opencode
+ * session is going to stop", so the command has to say so — and Ino: "so he has
+ * to continue, right." The turn already ended cleanly; what was missing was
+ * anyone saying it had, which made the agent look like it gave up.
+ */
+describe('turn-ended notice', () => {
+  const applied = {
+    applied: true as const,
+    previous_etag: 'aaaa',
+    etag: 'bbbb',
+    repo_refreshed: true,
+    commit_sha: null,
+    opencode_reload: 'restarted' as const,
+    agent_files: 'updated' as const,
+  };
+
+  test('says the turn stopped AND what to do about it', () => {
+    const out = reloadDetail({ ...applied, turn_ended: true });
+    expect(out).toContain('was stopped');
+    // The actionable half. "Your turn was stopped" alone leaves the user
+    // staring at a session wondering whether to retry.
+    expect(out).toContain('send a message to continue');
+  });
+
+  test('keeps the outcome sentence in front of it', () => {
+    // The reload result is still the primary fact; the interruption is context.
+    const out = reloadDetail({ ...applied, turn_ended: true });
+    expect(out.indexOf('Reloaded.')).toBeLessThan(out.indexOf('was stopped'));
+  });
+
+  test('says NOTHING when no turn was interrupted', () => {
+    expect(reloadDetail({ ...applied, turn_ended: false })).not.toContain('was stopped');
+  });
+
+  test('says nothing when the box could not tell', () => {
+    // null is "unknown", not "nothing happened". Claiming a turn was stopped
+    // when one finished normally sends the user chasing work that completed.
+    expect(reloadDetail({ ...applied, turn_ended: null })).not.toContain('was stopped');
+  });
+
+  test('appends to every applied outcome, not just the happy one', () => {
+    for (const agent_files of ['updated', 'already-current', 'not-applicable', 'kept-yours'] as const) {
+      expect(reloadDetail({ ...applied, agent_files, turn_ended: true })).toContain(
+        'send a message to continue',
+      );
+    }
+  });
+
+  test('a refusal never claims a turn was stopped', () => {
+    // Nothing was applied, so nothing was interrupted — even if the flag lied.
+    const out = reloadDetail({
+      ...applied,
+      applied: false,
+      reason: 'session is mid-turn',
+      turn_ended: true,
+    } as never);
+    expect(out).not.toContain('was stopped');
   });
 });

--- a/apps/api/src/projects/lib/session-reload.ts
+++ b/apps/api/src/projects/lib/session-reload.ts
@@ -132,6 +132,18 @@ export interface SessionReloadResult {
    * no reload was needed) — never "it worked".
    */
   opencode_reload: 'disposed' | 'restarted' | 'kept-old' | null;
+  /**
+   * Did the reload stop a turn the user was waiting on?
+   *
+   * Reported by the box AFTER the fact — it is true only when the finalize
+   * actually aborted an incomplete turn. A pre-flight "is a turn running?"
+   * check would race the turn finishing and tell people their work was
+   * interrupted when it completed normally.
+   *
+   * `null` = the box did not say. Never render that as "nothing was
+   * interrupted"; say nothing instead.
+   */
+  turn_ended: boolean | null;
   /** Present when nothing was applied. */
   reason?: string;
 }
@@ -145,8 +157,31 @@ export interface SessionReloadResult {
  * brought forward: the etag moved, opencode kept reading the working tree, and
  * the user was told the opposite.
  */
+/**
+ * The sentence appended when the reload STOPPED work someone was waiting on.
+ *
+ * Marko asked for this on the call: the reload restarts the runtime and "the
+ * whole opencode session is going to stop", so the command has to say so and
+ * the user has to know they must continue. Until now the turn simply ended —
+ * cleanly, so nothing spun, but silently, so it looked like the agent gave up.
+ *
+ * Only appended on a definite `true`. `null` means the box could not tell, and
+ * inventing "your turn was stopped" for a turn that finished normally is worse
+ * than saying nothing.
+ */
+const TURN_ENDED_SENTENCE =
+  'The turn that was running was stopped — send a message to continue.';
+
+function withTurnNotice(sentence: string, result: SessionReloadResult): string {
+  return result.turn_ended === true ? `${sentence} ${TURN_ENDED_SENTENCE}` : sentence;
+}
+
 export function reloadDetail(result: SessionReloadResult): string {
   if (!result.applied) return `Nothing to apply: ${result.reason ?? 'unchanged'}.`;
+  return withTurnNotice(reloadOutcomeSentence(result), result);
+}
+
+function reloadOutcomeSentence(result: SessionReloadResult): string {
   switch (result.agent_files) {
     case 'updated':
       return 'Reloaded. The next prompt runs the new config.';
@@ -342,6 +377,7 @@ export async function reloadSessionConfig(input: {
       commit_sha: null,
       agent_files: 'unknown',
       opencode_reload: null,
+      turn_ended: null,
       reason: 'no reachable sandbox',
     };
   }
@@ -360,6 +396,7 @@ export async function reloadSessionConfig(input: {
       commit_sha: before.commitSha,
       agent_files: 'unknown',
       opencode_reload: null,
+      turn_ended: null,
       reason:
         before.turnInFlight === true
           ? 'session is mid-turn'
@@ -412,6 +449,7 @@ export async function reloadSessionConfig(input: {
       reason: configDirReason,
     }),
     opencode_reload: push.opencodeReload ?? null,
+    turn_ended: push.opencodeTurnEnded ?? null,
     ...(push.applied
       ? push.opencodeReload === 'kept-old'
         ? {

--- a/apps/cli/src/__tests__/reload-force-confirm.test.ts
+++ b/apps/cli/src/__tests__/reload-force-confirm.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `sessions reload --force` must ask before it kills a running turn.
+ *
+ * `--force` exists precisely to reload DURING a turn, so it destroys work the
+ * user is waiting on. The web already confirms before doing that; the CLI did
+ * not, and its only warning lived in `--help` — read once, months before the
+ * command that actually ends the turn.
+ *
+ * Marko asked for exactly this on the call: the reload command "should also
+ * include this instruction to ensure the user that he will have to, you know,
+ * it will stop."
+ *
+ * Asserted on source: the handler needs auth, a located session and a live API
+ * before it reaches the prompt, so driving it end-to-end would test the network
+ * stack rather than the guard.
+ */
+import { describe, expect, test } from 'bun:test';
+
+const SRC = await Bun.file(new URL('../commands/sessions.ts', import.meta.url).pathname).text();
+
+/** `sessionsReload`'s body, comments stripped. */
+function reloadHandler(): string {
+  const start = SRC.indexOf('async function sessionsReload(');
+  expect(start).toBeGreaterThan(-1);
+  const body = SRC.slice(start, SRC.indexOf('\nasync function ', start + 10));
+  return body
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n');
+}
+
+describe('reload --force confirmation', () => {
+  const body = reloadHandler();
+
+  test('asks before forcing', () => {
+    expect(body).toContain('confirm(');
+    expect(body).toContain("args.includes('--force')");
+  });
+
+  test('the warning says what is lost and what to do next', () => {
+    // "Are you sure?" tells the user nothing. Both halves matter: the turn dies,
+    // and they have to send a message afterwards.
+    expect(body).toContain("ends the turn that's running right now");
+    expect(body).toContain('send a message to continue');
+  });
+
+  test('declining changes nothing', () => {
+    // A confirm that falls through to the request is decoration.
+    const declineAt = body.indexOf('Left the session alone');
+    expect(declineAt).toBeGreaterThan(-1);
+    expect(declineAt).toBeLessThan(body.indexOf('/reload`'));
+  });
+
+  test('-y / --yes skips it, for scripts', () => {
+    expect(body).toContain("args.includes('--yes')");
+    expect(body).toContain("args.includes('-y')");
+  });
+
+  test('--json skips it too', () => {
+    // A prompt in a machine-readable run hangs forever instead of failing,
+    // which is worse than not asking.
+    expect(body).toMatch(/!json/);
+  });
+
+  test('a NON-forced reload is never prompted', () => {
+    // Without --force the server refuses mid-turn on its own, so there is
+    // nothing to warn about and a prompt would just be friction.
+    const guard = body.slice(body.indexOf('if (force'), body.indexOf('confirm('));
+    expect(guard).toContain('force');
+  });
+
+  test('the prompt happens BEFORE the request', () => {
+    expect(body.indexOf('confirm(')).toBeLessThan(body.indexOf('/reload`'));
+  });
+
+  test('--help mentions the prompt and the escape hatch', () => {
+    expect(SRC).toContain('asks first, because it ends the running');
+    expect(SRC).toContain('-y/--yes skips the prompt');
+  });
+});

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -14,6 +14,7 @@ import { runSessionsAnswer, runSessionsApprove, runSessionsPending } from './ses
 import { runSessionsChat, runSessionsLog, runSessionsStatus } from './sessions-chat.ts';
 import { runSessionsConnect } from './sessions-connect.ts';
 import type { Auth } from '../api/auth.ts';
+import { confirm } from '../prompts.ts';
 import { hasEnvTokenHost } from '../api/config.ts';
 import { kortixFromAuth } from '../api/sdk.ts';
 import type { ProjectSession, ProjectSummary } from '../api/types.ts';
@@ -123,7 +124,9 @@ Subcommands:
                                     sandbox — the way to pick up a merged
                                     agent change without starting over.
                                     Restarts the agent runtime, so it refuses
-                                    mid-turn unless you pass --force.
+                                    mid-turn unless you pass --force — which
+                                    asks first, because it ends the running
+                                    turn. -y/--yes skips the prompt.
                                     --no-repo skips the git pull.
                                     --status only reports whether the session
                                     is behind, changing nothing. --json.
@@ -737,6 +740,25 @@ async function sessionsReload(
   }
   const json = args.includes('--json');
   const statusOnly = args.includes('--status');
+  const force = args.includes('--force');
+  const assumeYes = args.includes('--yes') || args.includes('-y');
+  // `--force` exists to reload DURING a turn, so it ends work the user is
+  // waiting on. The web asks before doing that; the CLI did not, and the only
+  // warning lived in `--help` — read once, months before the command that
+  // actually kills the turn. Same wording as the web confirm on purpose.
+  //
+  // Skipped for --json and --yes: both mean "no human here". A prompt in a
+  // script hangs forever instead of failing, which is worse than not asking.
+  if (force && !assumeYes && !json) {
+    process.stdout.write(
+      `${status.warn("Reloading restarts the runtime, which ends the turn that's running right now.")}\n` +
+        `  Whatever the agent is part-way through will be lost, and you will have to send a message to continue.\n`,
+    );
+    if (!(await confirm('Reload anyway?', false))) {
+      process.stdout.write(`${status.info('Left the session alone.')}\n`);
+      return 0;
+    }
+  }
   const located = await locateSessionAnywhere(
     sessionId,
     opts,
@@ -790,7 +812,7 @@ async function sessionsReload(
       detail: string;
     }>(`/projects/${projectId}/sessions/${canonicalSessionId}/reload`, {
       refresh_repo: !args.includes('--no-repo'),
-      force: args.includes('--force'),
+      force,
     });
     if (json) {
       process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);

--- a/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
@@ -192,7 +192,7 @@ describe('callers get the outcome', () => {
 
   test('reloadConfig reports kept-old rather than claiming success', () => {
     const reload = SRC.split('async reloadConfig(')[1]?.split('\n    },')[0] ?? '';
-    expect(reload).toContain("return 'kept-old'");
+    expect(reload).toContain("how: 'kept-old'");
   });
 
   test('the refresh route returns the outcome so CLI and web can show it', () => {

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -155,7 +155,10 @@ async function main() {
       // writing, or the client streams a part that will never complete.
       const pinned = readPinnedOpencodeSessionId()
       if (!pinned) return
-      void finalizeOrphanedTurn(
+      // RETURNED, not fire-and-forget. The boolean is whether a turn was really
+      // interrupted, and the reload surfaces it so the user can be told to
+      // continue instead of watching a turn stop for no stated reason.
+      return finalizeOrphanedTurn(
         opencode.getInternalUrl(),
         process.env.KORTIX_WORKSPACE || '/workspace',
         pinned,
@@ -165,6 +168,7 @@ async function main() {
             sessionId: pinned,
           })
         }
+        return finalized
       })
     },
   })
@@ -580,7 +584,10 @@ async function runWarmSeedMode(
       // writing, or the client streams a part that will never complete.
       const pinned = readPinnedOpencodeSessionId()
       if (!pinned) return
-      void finalizeOrphanedTurn(
+      // RETURNED, not fire-and-forget. The boolean is whether a turn was really
+      // interrupted, and the reload surfaces it so the user can be told to
+      // continue instead of watching a turn stop for no stated reason.
+      return finalizeOrphanedTurn(
         opencode.getInternalUrl(),
         process.env.KORTIX_WORKSPACE || '/workspace',
         pinned,
@@ -590,6 +597,7 @@ async function runWarmSeedMode(
             sessionId: pinned,
           })
         }
+        return finalized
       })
     },
   })

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -9,8 +9,31 @@ import { spawn, type ChildProcess } from 'node:child_process'
  * the session is still healthy and the user needs to know their change did not
  * take effect and why.
  */
+/**
+ * How a config reload was applied, and what it cost.
+ *
+ * `turnEnded` is only ever true for the respawn path — a dispose re-reads the
+ * config in place and interrupts nothing.
+ */
+export interface ReloadConfigResult {
+  how: 'disposed' | 'restarted' | 'kept-old'
+  turnEnded: boolean | null
+}
+
 export type VerifiedReloadResult =
-  | { outcome: 'swapped'; port: number; pid: number | null }
+  | {
+      outcome: 'swapped'
+      port: number
+      pid: number | null
+      /**
+       * Did the swap stop a turn someone was waiting on?
+       *
+       * `null` = could not tell (no finalize hook, or opencode never came back
+       * in time to ask). Never collapse null to false — "we don't know" and
+       * "nothing was interrupted" produce different things said to the user.
+       */
+      turnEnded: boolean | null
+    }
   | { outcome: 'kept-old'; reason: string }
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
@@ -1021,7 +1044,7 @@ export type Opencode = {
   start(): Promise<void>
   stop(signal?: NodeJS.Signals): Promise<void>
   restart(): Promise<void>
-  reloadConfig(opts?: { mustRespawn?: boolean }): Promise<'disposed' | 'restarted' | 'kept-old'>
+  reloadConfig(opts?: { mustRespawn?: boolean }): Promise<ReloadConfigResult>
   /**
    * Boot the new opencode, verify it serves, then swap and retire the old one.
    * Never leaves the session without an opencode.
@@ -1059,7 +1082,16 @@ export interface OpencodeSupervisorOptions {
    * It reports the fact and main.ts finalizes the orphaned turn, the same way
    * boot already does when it adopts a root whose last turn never completed.
    */
-  onUnplannedRespawn?: () => void
+  /**
+   * Runs once opencode is serving again after it was replaced.
+   *
+   * Resolves TRUE when it actually aborted an incomplete turn — i.e. the
+   * replacement really did stop work someone was waiting on. That is the only
+   * honest basis for telling a user "your turn was stopped, continue": a
+   * pre-flight "is a turn running?" check races the turn finishing on its own,
+   * and would say it to people whose work completed normally.
+   */
+  onUnplannedRespawn?: () => void | Promise<boolean | void>
 }
 
 export function createOpencodeSupervisor(
@@ -1407,6 +1439,26 @@ export function createOpencodeSupervisor(
     return false
   }
 
+  /**
+   * Close the turn the retired opencode took with it, and report whether there
+   * was one. Returns null when it could not be determined.
+   */
+  async function finalizeAfterReplacement(): Promise<boolean | null> {
+    if (!options.onUnplannedRespawn) return null
+    const ready = await waitUntilReady(RESPAWN_FINALIZE_TIMEOUT_MS)
+    if (!ready) {
+      logger.warn('[opencode] replaced but never became ready; orphaned turn left as-is')
+      return null
+    }
+    try {
+      const ended = await options.onUnplannedRespawn()
+      return ended === true
+    } catch (err) {
+      logger.warn('[opencode] post-swap finalize hook threw', { err: (err as Error).message })
+      return null
+    }
+  }
+
   async function checkReady(port = activePort): Promise<boolean> {
     return probeOpencodeSessionApi(`http://127.0.0.1:${port}`, currentCfg.projectTarget, 2_000)
   }
@@ -1640,39 +1692,29 @@ export function createOpencodeSupervisor(
      * a future opencode that drops the endpoint degrades to today's behaviour
      * rather than silently not applying the config.
      */
-    async reloadConfig(
-      opts: { mustRespawn?: boolean } = {},
-    ): Promise<'disposed' | 'restarted' | 'kept-old'> {
+    async reloadConfig(opts: { mustRespawn?: boolean } = {}): Promise<ReloadConfigResult> {
       // Some settings are not IN the config file — they shape the child's
       // PROCESS env at spawn, and a dispose cannot re-run that. The provider-key
       // deny-list is the live case: `withoutDeniedProviderEnv` strips native
       // keys when the child is spawned, so disposing after a gateway-mode
       // toggle would leave those keys exactly as they were — routing around the
       // gateway's budgets and logging, or failing to restore BYOK.
-      if (!opts.mustRespawn && (await tryDisposeReload())) return 'disposed'
+      // A dispose re-reads the config in place — same process, no turn lost.
+      if (!opts.mustRespawn && (await tryDisposeReload())) {
+        return { how: 'disposed', turnEnded: false }
+      }
       // Verified swap instead of the old kill-then-hope restart. A config that
       // cannot boot now leaves the running opencode in place and reports why,
       // rather than taking the session down with it.
       const result = await this.reloadVerified()
       if (result.outcome === 'kept-old') {
         logger.warn('[opencode] reload kept the previous instance', { reason: result.reason })
-        return 'kept-old'
+        // Nothing was replaced, so nothing was interrupted.
+        return { how: 'kept-old', turnEnded: false }
       }
-      // A swap strands the turn the retired process was running exactly as a
-      // restart did — same finalize, same reason (see restart()).
-      if (options.onUnplannedRespawn) {
-        const ready = await waitUntilReady(RESPAWN_FINALIZE_TIMEOUT_MS)
-        if (ready) {
-          try {
-            options.onUnplannedRespawn()
-          } catch (err) {
-            logger.warn('[opencode] post-swap finalize hook threw', {
-              err: (err as Error).message,
-            })
-          }
-        }
-      }
-      return 'restarted'
+      // No finalize here: reloadVerified() owns it now, so /kortix/refresh —
+      // which calls it directly — stops stranding the turn it interrupts.
+      return { how: 'restarted', turnEnded: result.turnEnded }
     },
 
     /** Promote the verified process before retiring the previous process. */
@@ -1701,10 +1743,22 @@ export function createOpencodeSupervisor(
         previousPort,
         previousPid: previous?.pid ?? null,
       })
+
+      // Finalize HERE, not in reloadConfig.
+      //
+      // A turn ends only when opencode emits session.idle/session.error over
+      // SSE. The process we just retired emits neither, so its last assistant
+      // message stays incomplete and every client streaming it spins forever.
+      // reloadConfig used to own this, which left `/kortix/refresh` — the one
+      // route that calls reloadVerified directly — stranding the turn it
+      // interrupted. Retiring the process and closing its turn belong together.
+      const turnEnded = await finalizeAfterReplacement()
+
       return {
         outcome: 'swapped',
         port: activePort,
         pid: this.getPid(),
+        turnEnded,
       }
     },
 

--- a/apps/kortix-sandbox-agent-server/src/routes/env.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/env.ts
@@ -176,6 +176,9 @@ export function createEnvRouter(
         const llmGatewayEnv = applyLlmGatewayMode(body.llmGatewayEnabled, body.llmGatewayBaseUrl, body.llmGatewayDenyEnv)
         // null when no reload was needed at all; otherwise how it was applied.
         let reloadOutcome: 'disposed' | 'restarted' | 'kept-old' | null = null
+        // Whether applying the config interrupted work someone was waiting on.
+        // null = no reload happened, or the box could not tell.
+        let reloadTurnEnded: boolean | null = null
         const opencodeEnvChanged = opencodeEnv.changed || llmGatewayEnv.changed
         const opencodeEnvNames = [...new Set([...opencodeEnv.names, ...llmGatewayEnv.names])].sort()
 
@@ -221,7 +224,9 @@ export function createEnvRouter(
           // store, so a respawn clears a dropped secret via `mergeProjectEnv`.
           const projectSecretsMoved = result.changedNames.length > 0
           const mustRespawn = projectSecretsMoved || requiresRespawn(opencodeEnvNames)
-          const how = await opencode.reloadConfig({ mustRespawn })
+          const applied = await opencode.reloadConfig({ mustRespawn })
+          const how = applied.how
+          reloadTurnEnded = applied.turnEnded
           // 'kept-old' means the verified swap declined: the new opencode never
           // came up, so the running one was left serving. The config did NOT
           // take, and the caller has to be told — logging it here and returning
@@ -264,6 +269,7 @@ export function createEnvRouter(
           // 'kept-old' is the verified swap declining a config that would not
           // boot — a successful safety outcome, and a FAILED reload.
           opencode_reload: reloadOutcome,
+          opencode_turn_ended: reloadTurnEnded,
         })
       } catch (err) {
         const message = (err as Error).message || 'env sync failed'

--- a/apps/kortix-sandbox-agent-server/src/routes/refresh.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/refresh.ts
@@ -138,7 +138,13 @@ export function createRefreshRouter(cfg: Config, opencode: Opencode): Hono {
                 reload: {
                   outcome: reload.outcome,
                   ...(reload.outcome === 'swapped'
-                    ? { port: reload.port, pid: reload.pid }
+                    ? {
+                        port: reload.port,
+                        pid: reload.pid,
+                        // Whether the swap interrupted work someone was waiting
+                        // on. null = could not tell; never report that as false.
+                        turn_ended: reload.turnEnded,
+                      }
                     : { reason: reload.reason }),
                 },
               }


### PR DESCRIPTION
Both halves of what Marko asked for on the call:

> it's going to switch it out and the whole opencode session is going to stop …
> part of the cortex CLI … should also include this instruction to ensure the
> user that he will have to, you know, it will stop

— and Ino: *"so he has to continue, right."*

## 1. Telling the user the turn stopped

The turn already ended **cleanly** (nothing spun), but **silently** — so it
looked like the agent gave up mid-thought.

The daemon's finalize hook already returns whether it actually aborted an
incomplete turn. It was called fire-and-forget and the answer discarded. It is
now awaited and threaded out:

```
daemon  turnEnded → opencode_turn_ended
   ↓    postEnvToDaemon → pushSessionAgentConfigToSandbox
   ↓    SessionReloadResult.turn_ended
   ↓    reloadDetail(): "… The turn that was running was stopped —
                          send a message to continue."
```

Reported **after the fact**, deliberately not from a pre-flight "is a turn
running?" check — that races the turn finishing on its own and would tell people
their work was interrupted when it completed normally. `null` stays `null` and
says nothing; "we couldn't tell" is not "nothing happened".

## 2. Asking before stopping it

`sessions reload --force` exists to reload **during** a turn. The web confirms
before that; the CLI didn't, and its only warning lived in `--help` — read once,
months before the command that actually kills the turn. It now prints the same
wording the web uses:

```
▲  Reloading restarts the runtime, which ends the turn that's running right now.
   Whatever the agent is part-way through will be lost, and you will have to
   send a message to continue.
Reload anyway? [y/N]:
```

`-y`/`--yes` and `--json` skip it — a prompt with no human hangs forever instead
of failing, which is worse than not asking.

## Fixed on the way

`/kortix/refresh` calls `reloadVerified` **directly**, bypassing `reloadConfig`,
which owned the orphaned-turn finalize. So that route retired opencode and left
the turn it interrupted spinning — the exact bug the finalize exists to prevent,
on the one path that skipped it. The finalize now lives in `reloadVerified`,
next to the kill that causes it, so every caller gets it. That also removed a
double-fire on the `reloadConfig` path.

## Verification

Against clean-`main` baselines taken just now (main moved during this work, so
the earlier ones were stale):

| | baseline | branch |
| --- | --- | --- |
| daemon | 407 / 0 | **435 pass / 0 fail** |
| api `src/projects/` | 855 / 120 | **861 pass / 120 fail** |
| cli | 435 / 73 | **443 pass / 73 fail** |
| cli `tsc` errors | 44 | **44** |

`comm`-diff on every failure set: **zero new failures**. The api/cli failures are
pre-existing (`mock.module` leaks, missing `re2js`/`tar`, a `clientSource` SDK
type gap).

Both new guards proven to guard:

- Removing the CLI confirm (`if (force && …)` → `if (false)`) fails 2 tests.
- The turn-notice tests cover `true`, `false`, `null`, every applied outcome,
  and that a refusal never claims a turn was stopped.

## Separate finding — not in this PR

`01ff6939d4` re-introduced the promote-in-place port swap after I'd removed it
for canonical-4096. Four of the five API-side port assumptions are covered by
`shared/opencode-ports.ts`, but the fifth is not: **`ws-proxy.ts:91` still
hardcodes `4096` for the opencode PTY WebSocket.** Once that daemon reaches
sandboxes, a reload moves opencode to 4097 and terminal sessions connect to a
dead port. The daemon doesn't advertise its live port over HTTP, so the fix is
`opencode_port` in health + a lookup in `ws-proxy` with a 4096 fallback for older
daemons. Not folded in here to keep this PR to what was asked.
