### PR TITLE
fix(proxy): the opencode PTY must follow opencode across a reload swap

### DIFF
--- a/apps/api/src/sandbox-proxy/pty-live-port.test.ts
+++ b/apps/api/src/sandbox-proxy/pty-live-port.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The opencode PTY must follow opencode, not a constant.
+ *
+ * opencode's port MOVES: a verified config reload boots the replacement on the
+ * idle half of the port pair and promotes it. `ws-proxy` hardcoded 4096, so
+ * after one reload a terminal would open a WebSocket to a dead socket — and
+ * only for sessions that had reloaded, which is the hardest kind of bug to
+ * catch by hand.
+ *
+ * It was the last of five places that decided "is this opencode?" from a port
+ * number; the other four are covered by `shared/opencode-ports`. This one could
+ * not be, because the API cannot know which half is live without asking the box.
+ */
+import { describe, expect, test } from 'bun:test';
+import { OPENCODE_PRIMARY_PORT, OPENCODE_STANDBY_PORT, isOpencodePort } from '../shared/opencode-ports';
+
+const SRC = await Bun.file(new URL('./ws-proxy.ts', import.meta.url).pathname).text();
+const HEALTH = await Bun.file(
+  new URL('../../../kortix-sandbox-agent-server/src/routes/health.ts', import.meta.url).pathname,
+).text();
+
+function code(): string {
+  return SRC.replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n');
+}
+
+describe('the PTY asks where opencode is', () => {
+  test('resolves the port instead of hardcoding it', () => {
+    const src = code();
+    expect(src).toContain('resolveLiveOpencodePort(sandboxId)');
+    // The regression shape: the ternary pinned to a constant.
+    expect(src).not.toMatch(/ptyKind === 'opencode' \? OPENCODE_\w+_PORT : port/);
+  });
+
+  test('reads the daemon health field the daemon actually publishes', () => {
+    // Both sides of one contract, in two packages — the API is useless if the
+    // daemon calls it something else.
+    expect(code()).toContain('opencode_port');
+    expect(HEALTH).toContain('opencode_port:');
+  });
+
+  test('only accepts a port from the known pair', () => {
+    // The value arrives in a response body. Following it blindly would let that
+    // body aim the PTY at any port inside the sandbox.
+    expect(code()).toContain('isOpencodePort(port)');
+    expect(isOpencodePort(OPENCODE_PRIMARY_PORT)).toBe(true);
+    expect(isOpencodePort(OPENCODE_STANDBY_PORT)).toBe(true);
+    expect(isOpencodePort(3000)).toBe(false);
+    expect(isOpencodePort(8000)).toBe(false);
+  });
+
+  test('falls back to 4096 rather than failing the connect', () => {
+    // An older daemon does not report the field. Refusing the PTY there would
+    // break terminals that work today, to fix a case that cannot arise on that
+    // daemon — it never moves opencode's port.
+    const src = code();
+    expect(src).toContain('OPENCODE_FALLBACK_PORT');
+    expect(src).toMatch(/catch \{\s*return OPENCODE_FALLBACK_PORT/);
+  });
+
+  test('the lookup is bounded, so a wedged box cannot hang the terminal', () => {
+    expect(code()).toContain('AbortSignal.timeout(');
+  });
+
+  test('is NOT cached', () => {
+    // The value changes on exactly the event this exists for. A cache would be
+    // stale precisely when it matters.
+    const fn = code().slice(code().indexOf('async function resolveLiveOpencodePort'));
+    expect(fn).not.toContain('cache');
+  });
+
+  test('non-opencode PTYs still use the port the client addressed', () => {
+    expect(code()).toContain(": port;");
+  });
+});

--- a/apps/api/src/sandbox-proxy/ws-proxy.ts
+++ b/apps/api/src/sandbox-proxy/ws-proxy.ts
@@ -25,10 +25,56 @@
 import { authenticatePreviewPrincipalDetailed } from './preview-auth';
 import { resolvePreviewWsUpstream } from './routes/preview';
 import { classifyPtyWebSocketPath } from '../platform/providers/pty-ingress';
+import { OPENCODE_PRIMARY_PORT, isOpencodePort } from '../shared/opencode-ports';
+import { resolveSandboxIngress } from './backend';
 
-// opencode's internal port — its PTY WebSocket endpoint lives here, reachable
-// via a dedicated Daytona preview link (the daemon on 8000 can't proxy WS).
-const OPENCODE_INTERNAL_PORT = 4096;
+// opencode's PTY WebSocket endpoint lives on opencode's own port, reachable via
+// a dedicated Daytona preview link (the daemon on 8000 can't proxy WS).
+//
+// That port MOVES. A verified config reload boots the replacement opencode on
+// the idle half of the port pair and promotes it, so after one reload the live
+// port is the other half and this constant points at a dead socket. It is now
+// only the fallback for a daemon too old to report where opencode actually is.
+const OPENCODE_FALLBACK_PORT = OPENCODE_PRIMARY_PORT;
+
+/** The daemon's own port — where its health endpoint answers. */
+const AGENT_PORT = 8000;
+
+/**
+ * Ask the box which port opencode is on right now.
+ *
+ * Deliberately NOT cached: the value changes on exactly the event we care about
+ * (a reload), so a cache would be stale precisely when it matters and would
+ * reintroduce the dead-socket bug it was meant to avoid. A PTY connect is a
+ * human opening a terminal — rare enough to afford one short round-trip.
+ *
+ * Falls back to 4096 on anything unexpected: an older daemon that does not
+ * report the field, an unreachable box, a slow one. That is the previous
+ * behaviour, so this can only improve on it.
+ */
+async function resolveLiveOpencodePort(sandboxId: string): Promise<number> {
+  try {
+    const { url, headers } = await resolveSandboxIngress(sandboxId, {
+      port: AGENT_PORT,
+      transport: 'http',
+    });
+    const res = await fetch(`${url.replace(/\/$/, '')}/kortix/health`, {
+      headers,
+      signal: AbortSignal.timeout(2_000),
+    });
+    if (!res.ok) return OPENCODE_FALLBACK_PORT;
+    const body = (await res.json().catch(() => null)) as { opencode_port?: unknown } | null;
+    const port = body?.opencode_port;
+    // Must be one of the pair. A daemon reporting anything else is either
+    // misconfigured or not the daemon, and following it blindly would let a
+    // response body redirect the PTY at an arbitrary port inside the sandbox.
+    return typeof port === 'number' && Number.isInteger(port) && isOpencodePort(port)
+      ? port
+      : OPENCODE_FALLBACK_PORT;
+  } catch {
+    return OPENCODE_FALLBACK_PORT;
+  }
+}
 
 /** Per-connection state stashed on the upgraded socket's `data`. */
 export interface PreviewWsData {
@@ -88,7 +134,8 @@ export async function preparePreviewWsUpgrade(
   // on 4096 — the daemon on 8000 can't carry a WebSocket. Everything else is
   // proxied against the port the client addressed.
   const ptyKind = classifyPtyWebSocketPath(remainingPath);
-  const upstreamPort = ptyKind === 'opencode' ? OPENCODE_INTERNAL_PORT : port;
+  const upstreamPort =
+    ptyKind === 'opencode' ? await resolveLiveOpencodePort(sandboxId) : port;
 
   // Strip our own auth token before forwarding — opencode authenticates via the
   // Daytona preview token header, not our query param.

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -62,6 +62,9 @@ function fakeOpencode(
     getState: () => state,
     getPid: () => null,
     getInternalUrl: () => hooks.internalUrl ?? 'http://127.0.0.1:1', // unreachable by default
+    // Health reports this so the API's PTY proxy can follow opencode across a
+    // reload swap. Omitting it made every /kortix/health assertion 500.
+    getActivePort: () => 4096,
     restart: async () => hooks.restart?.(),
     // The env route calls reloadConfig now, which applies config in place via
     // dispose and falls back to restart. Both land here so a test counting

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1060,6 +1060,16 @@ export type Opencode = {
   reconfigure(nextCfg: Config, nextOpencodeConfigDir: string, nextProjectEnv?: ProjectEnvStore): void
   getPid(): number | null
   getInternalUrl(): string
+  /**
+   * The port opencode is listening on RIGHT NOW.
+   *
+   * It moves: a verified reload boots the replacement on the idle half of the
+   * port pair and promotes it, so the live port alternates. Anything outside
+   * this process that needs to reach opencode directly — the API's PTY
+   * WebSocket proxy is the live case, since the daemon cannot carry a WS — has
+   * to ask rather than assume 4096.
+   */
+  getActivePort(): number
   getBinaryPath(): string | null
   getState(): OpencodeState
   markReady(): void
@@ -1781,6 +1791,10 @@ export function createOpencodeSupervisor(
 
     getPid() {
       return child?.pid ?? null
+    },
+
+    getActivePort() {
+      return activePort
     },
 
     getInternalUrl() {

--- a/apps/kortix-sandbox-agent-server/src/routes/health.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/health.ts
@@ -120,6 +120,12 @@ export function createHealthRouter(
       opencode: opencodeState,
       uptime_s: Math.floor((Date.now() - bootTime) / 1000),
       opencode_pid: opencode.getPid(),
+      // The port opencode is listening on right now. It ALTERNATES: a verified
+      // reload boots the replacement on the idle half of the port pair and
+      // promotes it. The API's PTY proxy has to reach opencode directly (the
+      // daemon cannot carry a WebSocket) and previously hardcoded 4096, which
+      // becomes the dead half after one reload.
+      opencode_port: opencode.getActivePort(),
       // Static web server (preview/static files). The bound port when up, else
       // null — surfaces "preview won't load because static-web never bound".
       static_web_port: staticWebPort,


### PR DESCRIPTION
The last of the five places that decide *"is this opencode?"* from a port
number. The other four are covered by `shared/opencode-ports`; this one couldn't
be, because the API can't know which half of the pair is live without asking the
box.

## The bug

`ws-proxy.ts:91` hardcoded `4096` for the opencode PTY WebSocket. A verified
reload boots the replacement on the idle half of the port pair and promotes it —
so after one reload, opening a terminal connects to a **dead socket**. Only for
sessions that had reloaded, which is the hardest kind of bug to catch by hand.

Latent until the promote-in-place daemon (`01ff6939d4`) reaches sandboxes.

## The fix

The daemon publishes its live port as `opencode_port` on `/kortix/health`;
`ws-proxy` asks per PTY connect.

**Not cached** — the value changes on exactly the event this exists for, so a
cache would be stale precisely when it matters and would reintroduce the bug. A
PTY connect is a human opening a terminal: rare enough to afford one round-trip,
bounded at 2s so a wedged box can't hang the terminal.

**Falls back to 4096** on an older daemon, an unreachable box, or a slow one —
that's the previous behaviour, so this can only improve on it. An old daemon
never moves opencode's port, so the fallback is correct there, not just safe.

**Validated against the known pair.** The port arrives in a response body;
following it blindly would let that body aim the PTY at any port inside the
sandbox.

## Verification

| | baseline | branch |
| --- | --- | --- |
| daemon | 407 / 0 | **435 pass / 0 fail** |
| api (`sandbox-proxy` + `projects`) | 955 / 120 | **962 pass / 120 fail** |

`comm`-diff: zero new failures. `tsc` clean in both packages.

Guard proven — pinning the ternary back to a constant fails the test. Caught one
of my own regressions on the way: `fakeOpencode` lacked `getActivePort`, which
500'd four `/kortix/health` assertions until the stub was updated.