### PR TITLE
fix: suppress request deadline toasts

### DIFF
--- a/apps/api/src/__tests__/unit-request-deadline.test.ts
+++ b/apps/api/src/__tests__/unit-request-deadline.test.ts
@@ -4,9 +4,12 @@ import { HTTPException } from 'hono/http-exception';
 // DEADLINE_MS is read from env at module load, and static imports are hoisted
 // above top-level code — so we must set the env var and then *dynamically*
 // import the middleware, otherwise it captures the default 28s budget.
-let requestDeadline: typeof import('../middleware/request-deadline').requestDeadline;
-let isRequestDeadlineHTTPException: typeof import('../middleware/request-deadline').isRequestDeadlineHTTPException;
-let RequestDeadlineHTTPException: typeof import('../middleware/request-deadline').RequestDeadlineHTTPException;
+type RequestDeadlineModule = typeof import('../middleware/request-deadline');
+
+let requestDeadline: RequestDeadlineModule['requestDeadline'];
+let isRequestDeadlineHTTPException: RequestDeadlineModule['isRequestDeadlineHTTPException'];
+let RequestDeadlineHTTPException: RequestDeadlineModule['RequestDeadlineHTTPException'];
+let REQUEST_DEADLINE_CODE: RequestDeadlineModule['REQUEST_DEADLINE_CODE'];
 
 beforeAll(async () => {
   process.env.REQUEST_DEADLINE_MS = '50';
@@ -14,13 +17,22 @@ beforeAll(async () => {
   requestDeadline = mod.requestDeadline;
   isRequestDeadlineHTTPException = mod.isRequestDeadlineHTTPException;
   RequestDeadlineHTTPException = mod.RequestDeadlineHTTPException;
+  REQUEST_DEADLINE_CODE = mod.REQUEST_DEADLINE_CODE;
 });
 
 function makeApp() {
   const app = new Hono();
   app.use('/v1/*', (c, next) => requestDeadline(c, next));
   app.onError((err, c) => {
-    if (err instanceof HTTPException) return c.json({ error: err.message }, err.status);
+    if (err instanceof HTTPException) {
+      return c.json(
+        {
+          error: err.message,
+          code: (err as HTTPException & { code?: string }).code,
+        },
+        err.status,
+      );
+    }
     return c.json({ error: String(err) }, 500);
   });
   const slow = async (c: any) => {
@@ -28,16 +40,16 @@ function makeApp() {
     return c.json({ ok: true });
   };
   app.get('/v1/projects/x/change-requests', slow); // bounded
-  app.get('/v1/p/sandbox/3000/index.html', slow);  // exempt prefix
-  app.get('/v1/projects/x/turn-stream', slow);      // JSON relay, bounded
-  app.get('/v1/router/chat/completions', slow);      // exempt prefix
-  app.get('/v1/llm/chat/completions', slow);          // exempt prefix (LLM streaming)
+  app.get('/v1/p/sandbox/3000/index.html', slow); // exempt prefix
+  app.get('/v1/projects/x/turn-stream', slow); // JSON relay, bounded
+  app.get('/v1/router/chat/completions', slow); // exempt prefix
+  app.get('/v1/llm/chat/completions', slow); // exempt prefix (LLM streaming)
   app.post('/v1/connectors/projects/x/connectors', slow); // exempt prefix (git + provider sync)
-  app.post('/v1/billing/webhooks/stripe', slow);      // exempt prefix (webhook)
-  app.post('/v1/projects/x/sessions/y/start', slow);  // exempt fragment (long sync op)
+  app.post('/v1/billing/webhooks/stripe', slow); // exempt prefix (webhook)
+  app.post('/v1/projects/x/sessions/y/start', slow); // exempt fragment (long sync op)
   app.post('/v1/projects/x/oauth/openai/start', slow); // exempt fragment (OAuth device flow — start can be slow on a cold replica)
-  app.post('/v1/projects', slow);                      // exempt method+path (provision)
-  app.get('/v1/projects', slow);                       // bounded — only POST is exempt
+  app.post('/v1/projects', slow); // exempt method+path (provision)
+  app.get('/v1/projects', slow); // bounded — only POST is exempt
   app.get('/v1/projects/x/fast', (c) => c.json({ ok: true })); // bounded, fast
   return app;
 }
@@ -46,7 +58,10 @@ describe('requestDeadline', () => {
   it('returns 503 when a non-streaming request exceeds the deadline', async () => {
     const res = await makeApp().request('/v1/projects/x/change-requests');
     expect(res.status).toBe(503);
-    expect((await res.json()).error).toContain('deadline');
+    expect(await res.json()).toMatchObject({
+      error: expect.stringContaining('deadline'),
+      code: 'request_deadline',
+    });
   });
 
   it('lets a fast non-streaming request through', async () => {
@@ -89,17 +104,23 @@ describe('requestDeadline', () => {
   });
 
   it('exempts billing webhooks from the deadline', async () => {
-    const res = await makeApp().request('/v1/billing/webhooks/stripe', { method: 'POST' });
+    const res = await makeApp().request('/v1/billing/webhooks/stripe', {
+      method: 'POST',
+    });
     expect(res.status).toBe(200);
   });
 
   it('exempts long sync sandbox ops (start) via fragment', async () => {
-    const res = await makeApp().request('/v1/projects/x/sessions/y/start', { method: 'POST' });
+    const res = await makeApp().request('/v1/projects/x/sessions/y/start', {
+      method: 'POST',
+    });
     expect(res.status).toBe(200);
   });
 
   it('exempts the provider OAuth device flow start (can be slow on a cold replica)', async () => {
-    const res = await makeApp().request('/v1/projects/x/oauth/openai/start', { method: 'POST' });
+    const res = await makeApp().request('/v1/projects/x/oauth/openai/start', {
+      method: 'POST',
+    });
     expect(res.status).toBe(200);
   });
 
@@ -157,5 +178,7 @@ describe('requestDeadline Sentry classification', () => {
     // REQUEST_DEADLINE_MS=50 → Math.round(50/1000) = 0s; just assert shape + 503.
     expect(err.status).toBe(503);
     expect(err.message).toContain('server processing deadline');
+    expect((err as { code?: string }).code).toBe(REQUEST_DEADLINE_CODE);
+    expect(REQUEST_DEADLINE_CODE).toBe('request_deadline');
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,7 +14,12 @@ import {
   renderMetrics,
   metricsEnabled,
 } from './lib/metrics';
-import { getDiagnosticFields, getRequestContext, runWithContext, setContextField } from './lib/request-context';
+import {
+  getDiagnosticFields,
+  getRequestContext,
+  runWithContext,
+  setContextField,
+} from './lib/request-context';
 import { getRequestUrl, ensureAbsoluteRequestUrl } from './lib/request-url';
 
 import { timingSafeEqual } from 'node:crypto';
@@ -40,7 +45,10 @@ import { createCorsMiddleware } from './middleware/cors';
 import { requestDeadline, isRequestDeadlineHTTPException } from './middleware/request-deadline';
 import { inspectDatabaseError } from './shared/database-errors';
 import { isPlatinumSandboxNotRunningError } from './shared/platinum';
-import { isDaytonaRateLimitError, primeDaytonaRateLimitClassifier } from './shared/daytona-rate-limit';
+import {
+  isDaytonaRateLimitError,
+  primeDaytonaRateLimitClassifier,
+} from './shared/daytona-rate-limit';
 import {
   isDaytonaTransientProviderError,
   primeDaytonaTransientClassifier,
@@ -95,10 +103,7 @@ import {
   startSunaMigrationWorker,
   stopSunaMigrationWorker,
 } from './projects/suna-migration/suna-migration-worker';
-import {
-  startAppDeploymentWorker,
-  stopAppDeploymentWorker,
-} from './apps/deployment-worker';
+import { startAppDeploymentWorker, stopAppDeploymentWorker } from './apps/deployment-worker';
 import { startAppIdleReaper, stopAppIdleReaper } from './apps/idle-reaper';
 import {
   startProviderTransitionWorker,
@@ -129,10 +134,15 @@ process.on('unhandledRejection', (reason: unknown) => {
     // which is exactly what took prod down on 2026-06-18. Record it locally and
     // drop it. See logger.ts isLoggingTransportError.
     if (isLoggingTransportError(`${err.message}\n${err.stack ?? ''}`)) {
-      appLogger.localError('Dropped logging-transport rejection', { error: err.message });
+      appLogger.localError('Dropped logging-transport rejection', {
+        error: err.message,
+      });
       return;
     }
-    appLogger.error('Unhandled promise rejection', { error: err.message, stack: err.stack });
+    appLogger.error('Unhandled promise rejection', {
+      error: err.message,
+      stack: err.stack,
+    });
     captureException(err, { handler: 'unhandledRejection' });
   } catch {
     // never let the crash guard itself crash the process
@@ -160,8 +170,7 @@ process.on('uncaughtException', (err: Error) => {
 // ─── App Setup ──────────────────────────────────────────────────────────────
 
 const app = new OpenAPIHono();
-const UUID_PATH_SEGMENT_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_PATH_SEGMENT_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 // Exported so tooling/tests can introspect the route table (app.routes) without
 // booting the server. See the import.meta.main guard around startup below.
 export { app };
@@ -303,7 +312,10 @@ app.use('*', async (c, next) => {
   // queue toward overflow. Suppress only SUCCESSFUL probes (a non-2xx still
   // logs, so a failing/degraded probe stays fully visible).
   const isHealthProbe =
-    path === '/health' || path === '/v1/health' || path.endsWith('/health/live') || path.endsWith('/health/ready');
+    path === '/health' ||
+    path === '/v1/health' ||
+    path.endsWith('/health/live') ||
+    path.endsWith('/health/ready');
   const suppressLog = isExpectedProxyNoise || (isHealthProbe && status < 400);
 
   if (!suppressLog) {
@@ -440,7 +452,11 @@ const livenessHandler = (c: any) => {
   if (eventLoopLagMs > MAX_EVENT_LOOP_LAG_MS) {
     // 503 → kubelet liveness fails → the pod is restarted (auto-recovery).
     return c.json(
-      { status: 'degraded', event_loop_lag_ms: lag, threshold_ms: MAX_EVENT_LOOP_LAG_MS },
+      {
+        status: 'degraded',
+        event_loop_lag_ms: lag,
+        threshold_ms: MAX_EVENT_LOOP_LAG_MS,
+      },
       503,
     );
   }
@@ -613,8 +629,13 @@ app.openapi(
     summary: 'Update the maintenance config (admin only)',
     ...auth,
     middleware: [supabaseAuth] as const,
-    request: { body: { content: { 'application/json': { schema: MaintenanceSchema } } } },
-    responses: { 200: json(MaintenanceSchema, 'Updated config'), ...errors(403, 503) },
+    request: {
+      body: { content: { 'application/json': { schema: MaintenanceSchema } } },
+    },
+    responses: {
+      200: json(MaintenanceSchema, 'Updated config'),
+      ...errors(403, 503),
+    },
   }),
   async (c: any) => {
     const userId = c.get('userId') as string;
@@ -631,7 +652,11 @@ app.openapi(
     };
     await db
       .insert(platformSettings)
-      .values({ key: MAINTENANCE_KEY, value: maintenanceConfig, updatedAt: new Date() })
+      .values({
+        key: MAINTENANCE_KEY,
+        value: maintenanceConfig,
+        updatedAt: new Date(),
+      })
       .onConflictDoUpdate({
         target: platformSettings.key,
         set: { value: maintenanceConfig, updatedAt: new Date() },
@@ -667,7 +692,9 @@ app.openapi(
     tags: ['system'],
     summary: 'Submit a public demo request (emails an internal notification)',
     middleware: [createDemoRequestRateLimitMiddleware()] as const,
-    request: { body: { content: { 'application/json': { schema: DemoRequestSchema } } } },
+    request: {
+      body: { content: { 'application/json': { schema: DemoRequestSchema } } },
+    },
     responses: {
       200: json(
         z.object({ ok: z.boolean(), emailed: z.boolean() }).openapi('DemoRequestResult'),
@@ -710,7 +737,9 @@ app.openapi(
     path: '/v1/prewarm',
     tags: ['system'],
     summary: 'No-op pre-warm (frontend fires this on login)',
-    responses: { 200: json(z.object({ success: z.boolean() }).openapi('Prewarm'), 'ok') },
+    responses: {
+      200: json(z.object({ success: z.boolean() }).openapi('Prewarm'), 'ok'),
+    },
   }),
   (c: any) => c.json({ success: true }),
 );
@@ -965,7 +994,11 @@ app.onError((err, c) => {
     });
     c.header('Retry-After', '10');
     return c.json(
-      { error: true, message: 'sandbox provider is temporarily rate-limited', status: 503 },
+      {
+        error: true,
+        message: 'sandbox provider is temporarily rate-limited',
+        status: 503,
+      },
       503,
     );
   }
@@ -993,7 +1026,11 @@ app.onError((err, c) => {
     });
     c.header('Retry-After', '10');
     return c.json(
-      { error: true, message: 'git mirror is temporarily unavailable', status: 503 },
+      {
+        error: true,
+        message: 'git mirror is temporarily unavailable',
+        status: 503,
+      },
       503,
     );
   }
@@ -1021,16 +1058,23 @@ app.onError((err, c) => {
   // error and fall through to the generic capture below, so unexpected
   // failures stay loud. See shared/daytona-transient.ts.
   if (isDaytonaTransientProviderError(err)) {
-    appLogger.warn(`${method} ${path} -> 503 [DaytonaError:transient] ${err.message.slice(0, 200)}`, {
-      method,
-      path,
-      errorType: 'DaytonaError',
-      errorName: err.name,
-      statusCode: (err as { statusCode?: unknown }).statusCode ?? null,
-    });
+    appLogger.warn(
+      `${method} ${path} -> 503 [DaytonaError:transient] ${err.message.slice(0, 200)}`,
+      {
+        method,
+        path,
+        errorType: 'DaytonaError',
+        errorName: err.name,
+        statusCode: (err as { statusCode?: unknown }).statusCode ?? null,
+      },
+    );
     c.header('Retry-After', '10');
     return c.json(
-      { error: true, message: 'sandbox provider is temporarily unavailable', status: 503 },
+      {
+        error: true,
+        message: 'sandbox provider is temporarily unavailable',
+        status: 503,
+      },
       503,
     );
   }
@@ -1069,6 +1113,10 @@ app.onError((err, c) => {
       status: err.status,
     };
 
+    if (isRequestDeadlineHTTPException(err)) {
+      response.code = err.code;
+    }
+
     // Add Retry-After header for 503s (sandbox waking up)
     if (err.status === 503) {
       c.header('Retry-After', '10');
@@ -1095,8 +1143,7 @@ app.onError((err, c) => {
     // follow-up (raise the shadow pooler's `pool_size` / move to transaction
     // mode) is a human-owned external action recorded in the sweep ledger.
     // Better Stack patterns 721b7efe… (API) + b38179c5… (frontend symptom).
-    const databaseMessage =
-      databaseError.causeMessage ?? databaseError.outerMessage;
+    const databaseMessage = databaseError.causeMessage ?? databaseError.outerMessage;
     const isPoolExhaustion = isSentryIgnoredError(
       databaseError.causeName ?? databaseError.outerName,
       databaseMessage,
@@ -1459,7 +1506,9 @@ export default {
       // gracefully instead of timing out.
       if (isWsUpgrade) {
         return new Response(
-          JSON.stringify({ error: 'WebSocket upgrade on preview subdomain not implemented' }),
+          JSON.stringify({
+            error: 'WebSocket upgrade on preview subdomain not implemented',
+          }),
           { status: 501, headers: { 'Content-Type': 'application/json' } },
         );
       }

--- a/apps/api/src/middleware/request-deadline.ts
+++ b/apps/api/src/middleware/request-deadline.ts
@@ -49,20 +49,23 @@ const DEADLINE_MS = (() => {
 
 const ENABLED = DEADLINE_MS > 0;
 
+/** Stable wire code for the API's total request-processing deadline. */
+export const REQUEST_DEADLINE_CODE = 'request_deadline' as const;
+
 // Route prefixes that stream, long-poll, proxy, or carry arbitrary upstream
 // latency and therefore must not be bounded by a fixed deadline.
 const EXEMPT_PREFIXES = [
-  '/v1/p',        // sandbox preview proxy (SSE event stream, long-poll, ws)
-  '/v1/tunnel',   // tunnel SSE (permission-requests) + ws
-  '/v1/git',      // git smart-HTTP (large packfile up/download)
-  '/v1/router',   // LLM gateway — streamed chat completions
-  '/v1/llm',      // LLM chat completions (streamed; p99 >10s is normal)
+  '/v1/p', // sandbox preview proxy (SSE event stream, long-poll, ws)
+  '/v1/tunnel', // tunnel SSE (permission-requests) + ws
+  '/v1/git', // git smart-HTTP (large packfile up/download)
+  '/v1/router', // LLM gateway — streamed chat completions
+  '/v1/llm', // LLM chat completions (streamed; p99 >10s is normal)
   '/v1/llm-gateway', // reverse proxy to the standalone gateway (streamed SSE)
   '/v1/connectors', // connector calls + git/provider sync — arbitrary upstream latency
   '/v1/webhooks', // inbound webhooks (Slack, …) — callers retry, don't truncate
-  '/v1/billing/webhooks',   // Stripe webhook processing (observed >60s, legit)
+  '/v1/billing/webhooks', // Stripe webhook processing (observed >60s, legit)
   '/v1/billing/revenuecat', // RevenueCat sync — batch reconcile, legit-long
-  '/v1/admin',    // operator maintenance endpoints — deliberate long ops
+  '/v1/admin', // operator maintenance endpoints — deliberate long ops
 ];
 
 // Path fragments for streaming or legitimately long *synchronous* endpoints
@@ -73,32 +76,32 @@ const EXEMPT_PREFIXES = [
 const EXEMPT_FRAGMENTS = [
   '/turn-question',
   '/provision-stream',
-  '/provision',               // managed repo create + sandbox boot
-  '/start',                   // unified session open: provision/resume + pin
-                              // resolve
-  '/commit-push',             // host-driven git commit+push
-  '/marketplace/install',     // marketplace item install — git-bound like
-                              // /commit-push (fetch + hash + commit + push)
-  '/registry/install',        // registry item install — same git-bound path
-  '/marketplace/update',      // marketplace item update(s) — also matches
-                              // /marketplace/update-all (path.includes), and
-                              // (intentionally) the GET .../updates
-                              // drift-listing routes, which are
-                              // GitHub-scan-heavy and legitimately long
-  '/registry/update',         // registry item update — same git-bound path,
-                              // plus its GET .../updates drift-listing route
-  '/snapshots',               // sandbox template builds
-  '/suna-migration',          // OG Suna → opencode migration runs
-  '/legacy-migration',        // legacy VM → project migration runs
-  '/oauth/',                  // provider OAuth device flow — `start` spawns
-                              // OpenCode + waits for the device challenge, which
-                              // can exceed the deadline on a cold replica
+  '/provision', // managed repo create + sandbox boot
+  '/start', // unified session open: provision/resume + pin
+  // resolve
+  '/commit-push', // host-driven git commit+push
+  '/marketplace/install', // marketplace item install — git-bound like
+  // /commit-push (fetch + hash + commit + push)
+  '/registry/install', // registry item install — same git-bound path
+  '/marketplace/update', // marketplace item update(s) — also matches
+  // /marketplace/update-all (path.includes), and
+  // (intentionally) the GET .../updates
+  // drift-listing routes, which are
+  // GitHub-scan-heavy and legitimately long
+  '/registry/update', // registry item update — same git-bound path,
+  // plus its GET .../updates drift-listing route
+  '/snapshots', // sandbox template builds
+  '/suna-migration', // OG Suna → opencode migration runs
+  '/legacy-migration', // legacy VM → project migration runs
+  '/oauth/', // provider OAuth device flow — `start` spawns
+  // OpenCode + waits for the device challenge, which
+  // can exceed the deadline on a cold replica
 ];
 
 // Long synchronous creates that can't be matched by fragment without
 // catching unrelated routes: method + exact path (or path prefix) pairs.
 const EXEMPT_METHOD_PATHS: Array<{ method: string; path: string }> = [
-  { method: 'POST', path: '/v1/projects' },          // create + seed + provision
+  { method: 'POST', path: '/v1/projects' }, // create + seed + provision
 ];
 
 const EXEMPT_METHOD_PATH_PATTERNS: Array<{ method: string; path: RegExp }> = [];
@@ -145,6 +148,8 @@ const bounded = timeout(Math.max(DEADLINE_MS, 1), () => new RequestDeadlineHTTPE
  * without brittle string-matching, while keeping the 503 response + log intact.
  */
 export class RequestDeadlineHTTPException extends HTTPException {
+  readonly code = REQUEST_DEADLINE_CODE;
+
   constructor() {
     super(503, {
       message: `Request exceeded the ${Math.round(DEADLINE_MS / 1000)}s server processing deadline`,
@@ -152,7 +157,7 @@ export class RequestDeadlineHTTPException extends HTTPException {
   }
 }
 
-export function isRequestDeadlineHTTPException(err: unknown): boolean {
+export function isRequestDeadlineHTTPException(err: unknown): err is RequestDeadlineHTTPException {
   return err instanceof RequestDeadlineHTTPException;
 }
 

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button';
 import Loading from '@/components/ui/loading';
 import { Close } from '@/features/icon/icons/close';
+import { isSilentTimeoutMessage } from '@/lib/timeout-toast-policy';
 import { cn } from '@/lib/utils';
 import {
   CheckCircleIcon as GoCheckCircleFill,
@@ -200,6 +201,8 @@ export const loadingToast = <T,>(
 };
 
 export const errorToast = (message: string, options?: ToastOptions) => {
+  if (isSilentTimeoutMessage(message)) return;
+
   const isMobile = window.innerWidth <= 768;
 
   toast.custom(

--- a/apps/web/src/hooks/projects/new-session-failure.test.ts
+++ b/apps/web/src/hooks/projects/new-session-failure.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import {
-  getRequiredConnectorConnections,
-  resolveCreateFailure,
-} from './new-session-failure';
+import { getRequiredConnectorConnections, resolveCreateFailure } from './new-session-failure';
 
 const connectorConnections = [
   {
@@ -30,6 +27,11 @@ describe('resolveCreateFailure', () => {
     expect(resolveCreateFailure('concurrent_session_limit')).toBe('silent');
   });
 
+  test('request deadlines stay silent because the server can complete after the client stops waiting', () => {
+    expect(resolveCreateFailure('TIMEOUT')).toBe('silent');
+    expect(resolveCreateFailure('request_deadline')).toBe('silent');
+  });
+
   test('a missing connection opens the connect-to-start gate', () => {
     expect(resolveCreateFailure('CONNECTOR_CONNECTION_REQUIRED')).toBe('connect');
   });
@@ -41,9 +43,8 @@ describe('resolveCreateFailure', () => {
     expect(resolveCreateFailure('REQUIRED_CONNECTOR_CONNECTION_UNAVAILABLE')).toBe('toast');
   });
 
-  test('everything else — including codeless network failures — surfaces a toast, never a redirect', () => {
+  test('other failures surface a toast, never a redirect', () => {
     expect(resolveCreateFailure(undefined)).toBe('toast');
-    expect(resolveCreateFailure('TIMEOUT')).toBe('toast');
     expect(resolveCreateFailure('internal_error')).toBe('toast');
   });
 });
@@ -86,7 +87,9 @@ describe('getRequiredConnectorConnections', () => {
       getRequiredConnectorConnections({
         code: 'CONNECTOR_CONNECTION_REQUIRED',
         data: {
-          connector_connections: [{ ...connectorConnections[0], authorization_strategy: 'workspace' }],
+          connector_connections: [
+            { ...connectorConnections[0], authorization_strategy: 'workspace' },
+          ],
         },
       }),
     ).toBeNull();

--- a/apps/web/src/hooks/projects/new-session-failure.ts
+++ b/apps/web/src/hooks/projects/new-session-failure.ts
@@ -21,6 +21,7 @@ export function resolveCreateFailure(
 ): 'upgrade' | 'silent' | 'connect' | 'toast' {
   if (code === 'subscription_required' || code === 'no_account') return 'upgrade';
   if (code === 'concurrent_session_limit') return 'silent';
+  if (code === 'TIMEOUT' || code === 'request_deadline') return 'silent';
   // One code, not two. `CONNECTOR_CONNECTION_REQUIRED` was also listed here and
   // the API has never emitted it — a dead branch that cost nothing only because
   // the live code sits beside it.
@@ -50,9 +51,7 @@ function isConnectorGateConnection(value: unknown): value is ConnectorGateConnec
   );
 }
 
-export function getRequiredConnectorConnections(
-  error: unknown,
-): ConnectorGateConnection[] | null {
+export function getRequiredConnectorConnections(error: unknown): ConnectorGateConnection[] | null {
   if (!isRecord(error)) return null;
 
   const rootCode = error.code;

--- a/apps/web/src/lib/error-handler.tsx
+++ b/apps/web/src/lib/error-handler.tsx
@@ -1,12 +1,13 @@
 import { Button } from '@/components/ui/button';
 import { errorToast, infoToast, successToast, warningToast } from '@/components/ui/toast';
-import { isBillingEnabled } from '@/lib/config';
 import { isServerDeadlineNoiseMessage } from '@/lib/browser-error-noise';
+import { isBillingEnabled } from '@/lib/config';
+import { isSilentTimeoutError } from '@/lib/timeout-toast-policy';
 import { useAccountSettingsModalStore } from '@/stores/account-settings-modal-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
-import * as Sentry from '@sentry/nextjs';
-import { BillingError, formatBillingErrorForUI, isBillingError } from '@kortix/sdk/react';
 import type { BillingState } from '@kortix/sdk';
+import { BillingError, formatBillingErrorForUI, isBillingError } from '@kortix/sdk/react';
+import * as Sentry from '@sentry/nextjs';
 
 const MANAGE_PLAN_LABEL = 'Manage plan';
 
@@ -162,6 +163,10 @@ export const handleApiError = (error: any, context?: ErrorContext): void => {
     console.error('API Error:', error, context);
   }
 
+  if (isSilentTimeoutError(error)) {
+    return;
+  }
+
   // Report server errors (5xx) and genuine network failures to Better Stack via
   // Sentry. 4xx errors are expected (auth, validation) and don't need alerting.
   //
@@ -204,12 +209,8 @@ export const handleApiError = (error: any, context?: ErrorContext): void => {
   // still reports — only the typed deadline message the API's
   // `RequestDeadlineHTTPException` emits is excluded.
   const errorMessage = typeof error?.message === 'string' ? error.message : '';
-  const isServerDeadline503 =
-    status === 503 && isServerDeadlineNoiseMessage(errorMessage);
-  if (
-    (status >= 500 && !isServerDeadline503) ||
-    error?.code === 'NETWORK_ERROR'
-  ) {
+  const isServerDeadline503 = status === 503 && isServerDeadlineNoiseMessage(errorMessage);
+  if ((status >= 500 && !isServerDeadline503) || error?.code === 'NETWORK_ERROR') {
     Sentry.captureException(
       error instanceof Error ? error : new Error(error?.message || String(error)),
       {
@@ -265,7 +266,8 @@ export const handleApiError = (error: any, context?: ErrorContext): void => {
       message: v2Message ?? '',
       balance: v2Balance,
       accountId: v2AccountId,
-      billingModel: typeof v2Detail?.billing_model === 'string' ? v2Detail.billing_model : undefined,
+      billingModel:
+        typeof v2Detail?.billing_model === 'string' ? v2Detail.billing_model : undefined,
       hasSubscription:
         typeof v2Detail?.has_subscription === 'boolean' ? v2Detail.has_subscription : undefined,
       // The unambiguous state (billing-state.ts). Preferred over `code`, which

--- a/apps/web/src/lib/timeout-toast-policy.test.ts
+++ b/apps/web/src/lib/timeout-toast-policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isSilentTimeoutError, isSilentTimeoutMessage } from './timeout-toast-policy';
+
+describe('timeout toast policy', () => {
+  test('suppresses typed client and API request deadlines', () => {
+    expect(
+      isSilentTimeoutError({
+        code: 'TIMEOUT',
+        message: 'Request timed out after 30s: /projects/p/sessions/s/audit',
+      }),
+    ).toBe(true);
+    expect(
+      isSilentTimeoutError({
+        status: 503,
+        code: 'request_deadline',
+        message: 'Request exceeded the 25s server processing deadline',
+      }),
+    ).toBe(true);
+  });
+
+  test('suppresses exact SDK and API deadline messages for direct errorToast calls', () => {
+    expect(
+      isSilentTimeoutMessage('Request timed out after 30s: /projects/p/sessions/s/audit'),
+    ).toBe(true);
+    expect(isSilentTimeoutMessage('Request exceeded the 25s server processing deadline')).toBe(
+      true,
+    );
+  });
+
+  test('does not suppress unrelated failures or generic third-party timeout text', () => {
+    expect(isSilentTimeoutError({ status: 503, code: '503', message: 'sandbox waking up' })).toBe(
+      false,
+    );
+    expect(isSilentTimeoutMessage('Network request timed out, please retry')).toBe(false);
+    expect(isSilentTimeoutMessage('Failed to save project')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/timeout-toast-policy.ts
+++ b/apps/web/src/lib/timeout-toast-policy.ts
@@ -1,0 +1,23 @@
+import {
+  isClientRequestTimeoutMessage,
+  isServerDeadlineNoiseMessage,
+} from '@/lib/browser-error-noise';
+
+interface TimeoutErrorLike {
+  code?: unknown;
+  message?: unknown;
+  status?: unknown;
+}
+
+/** Request deadlines are background transport state, not actionable toast content. */
+export function isSilentTimeoutError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const candidate = error as TimeoutErrorLike;
+  if (candidate.code === 'TIMEOUT' || candidate.code === 'request_deadline') return true;
+  return candidate.status === 503 && isServerDeadlineNoiseMessage(candidate.message);
+}
+
+/** Backstop for direct `errorToast(error.message)` call sites that lose the typed code. */
+export function isSilentTimeoutMessage(message: unknown): boolean {
+  return isClientRequestTimeoutMessage(message) || isServerDeadlineNoiseMessage(message);
+}

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -112,9 +112,35 @@ Claimed scope:
 The required `tdd` skill is unavailable in this session. This work will use the
 same RED, GREEN, and REFACTOR sequence directly.
 
-**Status:** IN PROGRESS.
+RED:
 
-**SDK package shippable to production: NOT YET.**
+- SDK deadline-policy coverage failed three assertions before the transport
+  classified client and API deadlines as silent.
+- Web coverage failed before `timeout-toast-policy.ts` existed and classified
+  `TIMEOUT` as `toast`.
+- API coverage failed before the response exposed `code: 'request_deadline'`.
+
+GREEN after rebasing onto `origin/main`:
+
+- `pnpm --filter @kortix/sdk typecheck`: exit `0`.
+- Full SDK suite: `1714 pass`, `0 fail`, and `6808 expect()` calls across `135`
+  files.
+- `pnpm --filter @kortix/sdk run smoke:install`: exit `0`; packed tarballs
+  imported and constructed `@kortix/sdk` and `@kortix/executor-sdk`.
+- Focused SDK transport suite: `29 pass`, `0 fail`.
+- Focused API deadline suite: `16 pass`, `0 fail`.
+- Focused web timeout-policy and session-create suite: `12 pass`, `0 fail`.
+- Complete web suite: `4814 pass`, `0 fail`.
+- API typecheck and focused web ESLint: exit `0`.
+- Authenticated HTTP proof against a local API with
+  `REQUEST_DEADLINE_MS=1`: HTTP `503`, `Retry-After: 10`, and
+  `code: 'request_deadline'` in the response body.
+
+No published SDK export changed. The package version was not edited.
+
+**Status:** COMPLETE in commit `9c5d9dc11d`.
+
+**SDK package shippable to production: YES.**
 
 ---
 
@@ -7444,3 +7470,30 @@ RED, GREEN, and REFACTOR sequence directly.
 **Status:** IN PROGRESS.
 
 **SDK package shippable to production: NOT YET.**
+
+### 2026-08-07 — session `no-timeout-toasts` completion
+
+Kept both request-safety deadlines. Added the stable API wire code
+`request_deadline`. The SDK normalizes typed and legacy API deadline responses,
+returns typed client `TIMEOUT` errors, and does not invoke the host global error
+handler for either class. The web host rejects these deadlines before telemetry
+or toast processing. The shared toast helper also rejects exact Kortix deadline
+messages when a direct caller has discarded the typed code. Unrelated `503`
+failures and third-party timeout messages remain visible.
+
+Verification after rebasing onto `origin/main`:
+
+- SDK typecheck: exit `0`.
+- SDK suite: `1714 pass`, `0 fail`, `6808 expect()` calls, `135` files.
+- SDK packed-install smoke: exit `0`.
+- API focused suite: `16 pass`, `0 fail`; API typecheck: exit `0`.
+- Web focused suite: `12 pass`, `0 fail`; complete suite: `4814 pass`, `0 fail`;
+  focused ESLint: exit `0`.
+- Authenticated local HTTP request with a 1 ms server deadline: HTTP `503`,
+  `Retry-After: 10`, and JSON `code: 'request_deadline'`.
+
+No SDK export or version changed.
+
+**Status:** COMPLETE in commit `9c5d9dc11d`.
+
+**SDK package shippable to production: YES.**

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -97,6 +97,27 @@ entries and two poll loops. The SDK hook also spreads no `contract(...)`, so it
 inherits the host's global defaults.
 
 **Status:** COMPLETE.
+### 2026-08-07 — session `no-timeout-toasts` claim
+
+No **Now** task claimed. This is a user-directed timeout error-UX correction.
+
+Claimed scope:
+
+- Keep the API and SDK request deadlines as resource-safety boundaries.
+- Prevent client request deadlines and typed API request-deadline responses from
+  invoking the host's global error handler.
+- Preserve typed errors for callers that own explicit, actionable error UI.
+- Verify the background session-audit path and the complete SDK package gates.
+
+The required `tdd` skill is unavailable in this session. This work will use the
+same RED, GREEN, and REFACTOR sequence directly.
+
+**Status:** IN PROGRESS.
+
+**SDK package shippable to production: NOT YET.**
+
+---
+
 ### 2026-08-06 — session `sdk-connectors-unified` claim
 
 No **Now** task claimed. This is the user-directed final SDK consolidation.

--- a/packages/sdk/src/core/http/api-client.test.ts
+++ b/packages/sdk/src/core/http/api-client.test.ts
@@ -47,7 +47,10 @@ describe('makeRequest admin-bypass header', () => {
   }
 
   test('attaches x-kortix-admin-bypass when enabled', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'test-token' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'test-token',
+    });
     const stub = stubFetch();
     try {
       setAdminBypass(true);
@@ -59,7 +62,10 @@ describe('makeRequest admin-bypass header', () => {
   });
 
   test('omits the header when disabled', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'test-token' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'test-token',
+    });
     const stub = stubFetch();
     try {
       setAdminBypass(false);
@@ -106,7 +112,10 @@ describe('makeRequest keeps ApiError.message a string for non-string body fields
   }
 
   test('a non-string top-level `message` (object) does not become ApiError.message', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
     const restore = stubErrorBody(403, { message: { code: 'FORBIDDEN' } });
     try {
       const res = await backendApi.get('/projects/abc/files');
@@ -121,7 +130,10 @@ describe('makeRequest keeps ApiError.message a string for non-string body fields
   });
 
   test('a non-string `detail.message` (number) does not become ApiError.message', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
     const restore = stubErrorBody(404, { detail: { message: 404 } });
     try {
       const res = await backendApi.get('/projects/abc/files');
@@ -134,8 +146,13 @@ describe('makeRequest keeps ApiError.message a string for non-string body fields
   });
 
   test('a real string `message` is still used verbatim', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
-    const restore = stubErrorBody(403, { message: 'Not allowed to read project files' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
+    const restore = stubErrorBody(403, {
+      message: 'Not allowed to read project files',
+    });
     try {
       const res = await backendApi.get('/projects/abc/files');
       expect(res.success).toBe(false);
@@ -177,7 +194,10 @@ describe('makeRequest retries transient gateway (502/503/504) on idempotent read
   }
 
   test('a single transient 502 on GET is retried and succeeds (no error surfaced)', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
     const stub = stubFetchSequence([
       { status: 502 }, // transient blip
       { status: 200, body: { ok: true } }, // retry succeeds
@@ -193,7 +213,10 @@ describe('makeRequest retries transient gateway (502/503/504) on idempotent read
   });
 
   test('503 and 504 are also retried on GET', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
     for (const status of [503, 504]) {
       const stub = stubFetchSequence([{ status }, { status: 200, body: { ok: true } }]);
       try {
@@ -207,7 +230,10 @@ describe('makeRequest retries transient gateway (502/503/504) on idempotent read
   });
 
   test('a persistent 502 on GET exhausts retries and surfaces the error', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
     const stub = stubFetchSequence([{ status: 502 }]); // always 502
     try {
       const res = await backendApi.get('/projects/abc/sessions/s1/audit');
@@ -221,7 +247,10 @@ describe('makeRequest retries transient gateway (502/503/504) on idempotent read
   });
 
   test('a 502 on a POST is NOT retried (non-idempotent)', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
     const stub = stubFetchSequence([{ status: 502 }, { status: 200, body: { ok: true } }]);
     try {
       const res = await backendApi.post('/projects/abc/sessions', { foo: 1 });
@@ -234,7 +263,10 @@ describe('makeRequest retries transient gateway (502/503/504) on idempotent read
   });
 
   test('a 500 on GET is NOT retried (deterministic server error)', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
     const stub = stubFetchSequence([{ status: 500 }, { status: 200, body: { ok: true } }]);
     try {
       const res = await backendApi.get('/projects/abc/sessions/s1/audit');
@@ -247,7 +279,10 @@ describe('makeRequest retries transient gateway (502/503/504) on idempotent read
   });
 
   test('a 4xx on GET is NOT retried', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
     const stub = stubFetchSequence([{ status: 404 }, { status: 200, body: { ok: true } }]);
     try {
       const res = await backendApi.get('/projects/abc/sessions/s1/audit');
@@ -314,7 +349,10 @@ describe('makeRequest retries transient transport failures on idempotent reads',
   });
 
   test('a POST transport failure is not retried', async () => {
-    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+    });
     const originalFetch = globalThis.fetch;
     let attempts = 0;
     globalThis.fetch = (async () => {
@@ -325,6 +363,131 @@ describe('makeRequest retries transient transport failures on idempotent reads',
       const response = await backendApi.post('/projects/p1/sessions', {});
       expect(response.success).toBe(false);
       expect(attempts).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('makeRequest keeps request deadlines silent to the global host error handler', () => {
+  test('a client request deadline returns TIMEOUT without invoking onError', async () => {
+    const errors: Error[] = [];
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+      onError: (error) => {
+        errors.push(error as Error);
+      },
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((_url: string, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          },
+          { once: true },
+        );
+      })) as unknown as typeof fetch;
+    try {
+      const response = await backendApi.get('/projects/p1/sessions/s1/audit', {
+        timeout: 5,
+      });
+      expect(response.success).toBe(false);
+      expect(response.error).toMatchObject({
+        code: 'TIMEOUT',
+        endpoint: '/projects/p1/sessions/s1/audit',
+        timeout: 5,
+      });
+      expect(errors).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('a typed API request deadline returns its error without invoking onError', async () => {
+    const errors: Error[] = [];
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+      onError: (error) => {
+        errors.push(error as Error);
+      },
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      Response.json(
+        {
+          error: true,
+          code: 'request_deadline',
+          message: 'Request exceeded the 25s server processing deadline',
+          status: 503,
+        },
+        { status: 503 },
+      )) as unknown as typeof fetch;
+    try {
+      const response = await backendApi.get('/projects/p1/sessions/s1/audit');
+      expect(response.success).toBe(false);
+      expect(response.error).toMatchObject({
+        status: 503,
+        code: 'request_deadline',
+        message: 'Request exceeded the 25s server processing deadline',
+      });
+      expect(errors).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('a legacy API request deadline is normalized and stays silent during rollout', async () => {
+    const errors: Error[] = [];
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+      onError: (error) => {
+        errors.push(error as Error);
+      },
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      Response.json(
+        {
+          error: true,
+          message: 'Request exceeded the 25s server processing deadline',
+          status: 503,
+        },
+        { status: 503 },
+      )) as unknown as typeof fetch;
+    try {
+      const response = await backendApi.get('/projects/p1/secrets');
+      expect(response.success).toBe(false);
+      expect(response.error?.code).toBe('request_deadline');
+      expect(errors).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('an unrelated 503 still invokes onError after read retries are exhausted', async () => {
+    const errors: Error[] = [];
+    configureKortix({
+      backendUrl: 'http://api.test/v1',
+      getToken: async () => 'tok',
+      onError: (error) => {
+        errors.push(error as Error);
+      },
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      Response.json({ message: 'sandbox waking up' }, { status: 503 })) as unknown as typeof fetch;
+    try {
+      const response = await backendApi.get('/projects/p1/sessions/s1');
+      expect(response.success).toBe(false);
+      expect(response.error).toMatchObject({ status: 503, code: '503' });
+      expect(errors).toHaveLength(1);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -365,7 +528,10 @@ describe('account_mfa_required 403 → kortix:mfa-required browser event', () =>
 
   test('the coded MFA denial dispatches the step-up event', async () => {
     configureKortix({ backendUrl: 'http://test', getToken: async () => 'tok' });
-    const restoreFetch = stubFetch403({ error: 'mfa needed', code: 'account_mfa_required' });
+    const restoreFetch = stubFetch403({
+      error: 'mfa needed',
+      code: 'account_mfa_required',
+    });
     const win = stubWindow();
     try {
       const res = await backendApi.get('/accounts/abc/iam/groups');
@@ -379,7 +545,9 @@ describe('account_mfa_required 403 → kortix:mfa-required browser event', () =>
 
   test('an ordinary 403 dispatches nothing', async () => {
     configureKortix({ backendUrl: 'http://test', getToken: async () => 'tok' });
-    const restoreFetch = stubFetch403({ error: "You don't have permission to create projects." });
+    const restoreFetch = stubFetch403({
+      error: "You don't have permission to create projects.",
+    });
     const win = stubWindow();
     try {
       const res = await backendApi.get('/accounts/abc/iam/groups');
@@ -462,7 +630,10 @@ describe('makeRequest classifies a typed feature_not_supported 501 as silent to 
         onErrorCalls++;
       },
     });
-    const restore = stubFetchOnce(501, { error: 'something broke', message: 'something broke' });
+    const restore = stubFetchOnce(501, {
+      error: 'something broke',
+      message: 'something broke',
+    });
     try {
       const res = await backendApi.post('/connectors/projects/p1/connectors/auth-discovery', {});
       expect(res.success).toBe(false);
@@ -550,7 +721,10 @@ describe('makeRequest classifies a typed model_not_servable 409 as silent to Sen
         onErrorCalls++;
       },
     });
-    const restore = stubFetchOnce(409, { error: 'Conflict', message: 'Conflict' });
+    const restore = stubFetchOnce(409, {
+      error: 'Conflict',
+      message: 'Conflict',
+    });
     try {
       const res = await backendApi.put('/projects/p1/model-defaults', {
         scope: 'project',
@@ -628,9 +802,14 @@ describe('makeRequest classifies a typed provision_in_flight 409 as silent to Se
         onErrorCalls++;
       },
     });
-    const restore = stubFetchOnce(409, { error: 'Conflict', message: 'Conflict' });
+    const restore = stubFetchOnce(409, {
+      error: 'Conflict',
+      message: 'Conflict',
+    });
     try {
-      const res = await backendApi.post('/projects/provision', { account_id: 'a1' });
+      const res = await backendApi.post('/projects/provision', {
+        account_id: 'a1',
+      });
       expect(res.success).toBe(false);
       expect(res.error?.status).toBe(409);
       expect(onErrorCalls).toBe(1);

--- a/packages/sdk/src/core/http/api-client.ts
+++ b/packages/sdk/src/core/http/api-client.ts
@@ -85,6 +85,22 @@ export const MODEL_NOT_SERVABLE_CODE = 'model_not_servable';
  */
 export const PROVISION_IN_FLIGHT_CODE = 'provision_in_flight';
 
+const REQUEST_DEADLINE_CODE = 'request_deadline';
+const LEGACY_REQUEST_DEADLINE_MESSAGE = /^Request exceeded the \d+s server processing deadline$/;
+
+const isRequestDeadlineResponse = (
+  status: number,
+  errorData: unknown,
+  message: string,
+): boolean => {
+  if (status !== 503) return false;
+  const code =
+    typeof errorData === 'object' && errorData !== null && 'code' in errorData
+      ? (errorData as { code?: unknown }).code
+      : undefined;
+  return code === REQUEST_DEADLINE_CODE || LEGACY_REQUEST_DEADLINE_MESSAGE.test(message);
+};
+
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
@@ -132,14 +148,9 @@ export function isAdminBypassEnabled(): boolean {
 
 async function makeRequest<T = any>(
   url: string,
-  options: RequestInit & ApiClientOptions = {}
+  options: RequestInit & ApiClientOptions = {},
 ): Promise<ApiResponse<T>> {
-  const {
-    showErrors = true,
-    errorContext,
-    timeout = 30000,
-    ...fetchOptions
-  } = options;
+  const { showErrors = true, errorContext, timeout = 30000, ...fetchOptions } = options;
 
   const controller = new AbortController();
   let timeoutId: NodeJS.Timeout | null = null;
@@ -248,8 +259,7 @@ async function makeRequest<T = any>(
 
       try {
         await response.arrayBuffer();
-      } catch {
-      }
+      } catch {}
     }
 
     if (!response.ok) {
@@ -270,16 +280,21 @@ async function makeRequest<T = any>(
         } else if (typeof errorData.detail?.message === 'string') {
           errorMessage = errorData.detail.message;
         }
-      } catch {
-      }
+      } catch {}
 
+      const isRequestDeadline = isRequestDeadlineResponse(response.status, errorData, errorMessage);
       let error: ApiError | Error = new ApiError(errorMessage, {
         status: response.status,
         response: response,
         details: errorData || undefined,
         data: errorData,
         detail: errorData?.detail,
-        code: errorData?.code || errorData?.error_code || errorData?.detail?.error_code || response.status.toString()
+        code: isRequestDeadline
+          ? REQUEST_DEADLINE_CODE
+          : errorData?.code ||
+            errorData?.error_code ||
+            errorData?.detail?.error_code ||
+            response.status.toString(),
       });
 
       if (response.status === 402) {
@@ -308,7 +323,8 @@ async function makeRequest<T = any>(
       if (response.status === 431) {
         error = new RequestTooLargeError(431, {
           message: 'Request is too large to process',
-          suggestion: 'Try uploading files one at a time, or reduce the number of files attached to your message.',
+          suggestion:
+            'Try uploading files one at a time, or reduce the number of files attached to your message.',
         });
       }
 
@@ -355,7 +371,13 @@ async function makeRequest<T = any>(
       const isProvisionInFlight =
         response.status === 409 && errorData?.code === PROVISION_IN_FLIGHT_CODE;
 
-      if (showErrors && !isFeatureNotSupported && !isModelNotServable && !isProvisionInFlight) {
+      if (
+        showErrors &&
+        !isFeatureNotSupported &&
+        !isModelNotServable &&
+        !isProvisionInFlight &&
+        !isRequestDeadline
+      ) {
         platformConfig().onError?.(error, errorContext);
       }
 
@@ -371,16 +393,15 @@ async function makeRequest<T = any>(
     if (contentType?.includes('application/json')) {
       data = await response.json();
     } else if (contentType?.includes('text/')) {
-      data = await response.text() as T;
+      data = (await response.text()) as T;
     } else {
-      data = await response.blob() as T;
+      data = (await response.blob()) as T;
     }
 
     return {
       data,
       success: true,
     };
-
   } catch (error: any) {
     // Always clear timeout on error
     if (timeoutId) {
@@ -405,7 +426,10 @@ async function makeRequest<T = any>(
       // "Request timeout" toasts/Sentry events. Swallow it silently.
       if (!didTimeout) {
         return {
-          error: new ApiError('Request aborted', { name: 'AbortError', code: 'ABORTED' }),
+          error: new ApiError('Request aborted', {
+            name: 'AbortError',
+            code: 'ABORTED',
+          }),
           success: false,
         };
       }
@@ -413,18 +437,19 @@ async function makeRequest<T = any>(
       // Genuine timeout — our timer fired. Attach the endpoint so it's clear
       // *what* timed out (the previous error carried no URL).
       const endpoint = url.replace(getApiUrl(), '') || url;
-      apiError = new ApiError(`Request timed out after ${Math.round(timeout / 1000)}s: ${endpoint}`, {
-        code: 'TIMEOUT',
-        url,
-        endpoint,
-        timeout,
-      });
+      apiError = new ApiError(
+        `Request timed out after ${Math.round(timeout / 1000)}s: ${endpoint}`,
+        {
+          code: 'TIMEOUT',
+          url,
+          endpoint,
+          timeout,
+        },
+      );
 
-      // Only show timeout errors if showErrors is true
-      // This prevents spam from multiple concurrent timeouts or React Query cancellations
-      if (showErrors) {
-        platformConfig().onError?.(apiError, errorContext);
-      }
+      // A request deadline is transport state, not an actionable user error.
+      // Return the typed error to the caller, but never invoke the host's global
+      // error handler. Explicit callers can still render local recovery UI.
     } else if (error instanceof Error) {
       apiError = new ApiError(error.message, {
         name: error.name || 'ApiError',
@@ -452,7 +477,7 @@ async function makeRequest<T = any>(
 export const supabaseClient = {
   async execute<T = any>(
     queryFn: () => Promise<{ data: T | null; error: any }>,
-    errorContext?: ErrorContext
+    errorContext?: ErrorContext,
   ): Promise<ApiResponse<T>> {
     try {
       const { data, error } = await queryFn();
@@ -476,9 +501,13 @@ export const supabaseClient = {
         success: true,
       };
     } catch (error: any) {
-      const apiError: ApiError = error instanceof Error
-        ? new ApiError(error.message, { name: error.name || 'ApiError', stack: error.stack })
-        : new ApiError(String(error));
+      const apiError: ApiError =
+        error instanceof Error
+          ? new ApiError(error.message, {
+              name: error.name || 'ApiError',
+              stack: error.stack,
+            })
+          : new ApiError(String(error));
 
       platformConfig().onError?.(apiError, errorContext);
 
@@ -491,36 +520,60 @@ export const supabaseClient = {
 };
 
 export const backendApi = {
-  get: <T = any>(endpoint: string, options?: Omit<RequestInit & ApiClientOptions, 'method' | 'body'>) =>
-    makeRequest<T>(`${getApiUrl()}${endpoint}`, { ...options, method: 'GET' }),
+  get: <T = any>(
+    endpoint: string,
+    options?: Omit<RequestInit & ApiClientOptions, 'method' | 'body'>,
+  ) => makeRequest<T>(`${getApiUrl()}${endpoint}`, { ...options, method: 'GET' }),
 
-  post: <T = any>(endpoint: string, data?: any, options?: Omit<RequestInit & ApiClientOptions, 'method'>) =>
+  post: <T = any>(
+    endpoint: string,
+    data?: any,
+    options?: Omit<RequestInit & ApiClientOptions, 'method'>,
+  ) =>
     makeRequest<T>(`${getApiUrl()}${endpoint}`, {
       ...options,
       method: 'POST',
       body: data ? JSON.stringify(data) : undefined,
     }),
 
-  put: <T = any>(endpoint: string, data?: any, options?: Omit<RequestInit & ApiClientOptions, 'method'>) =>
+  put: <T = any>(
+    endpoint: string,
+    data?: any,
+    options?: Omit<RequestInit & ApiClientOptions, 'method'>,
+  ) =>
     makeRequest<T>(`${getApiUrl()}${endpoint}`, {
       ...options,
       method: 'PUT',
       body: data ? JSON.stringify(data) : undefined,
     }),
 
-  patch: <T = any>(endpoint: string, data?: any, options?: Omit<RequestInit & ApiClientOptions, 'method'>) =>
+  patch: <T = any>(
+    endpoint: string,
+    data?: any,
+    options?: Omit<RequestInit & ApiClientOptions, 'method'>,
+  ) =>
     makeRequest<T>(`${getApiUrl()}${endpoint}`, {
       ...options,
       method: 'PATCH',
       body: data ? JSON.stringify(data) : undefined,
     }),
 
-  delete: <T = any>(endpoint: string, options?: Omit<RequestInit & ApiClientOptions, 'method' | 'body'>) =>
-    makeRequest<T>(`${getApiUrl()}${endpoint}`, { ...options, method: 'DELETE' }),
+  delete: <T = any>(
+    endpoint: string,
+    options?: Omit<RequestInit & ApiClientOptions, 'method' | 'body'>,
+  ) =>
+    makeRequest<T>(`${getApiUrl()}${endpoint}`, {
+      ...options,
+      method: 'DELETE',
+    }),
 
-  upload: <T = any>(endpoint: string, formData: FormData, options?: Omit<RequestInit & ApiClientOptions, 'method' | 'body'>) => {
+  upload: <T = any>(
+    endpoint: string,
+    formData: FormData,
+    options?: Omit<RequestInit & ApiClientOptions, 'method' | 'body'>,
+  ) => {
     const { headers, ...restOptions } = options || {};
-    const uploadHeaders = { ...headers as Record<string, string> };
+    const uploadHeaders = { ...(headers as Record<string, string>) };
     delete uploadHeaders['Content-Type'];
 
     return makeRequest<T>(`${getApiUrl()}${endpoint}`, {
@@ -531,9 +584,13 @@ export const backendApi = {
     });
   },
 
-  uploadPut: <T = any>(endpoint: string, formData: FormData, options?: Omit<RequestInit & ApiClientOptions, 'method' | 'body'>) => {
+  uploadPut: <T = any>(
+    endpoint: string,
+    formData: FormData,
+    options?: Omit<RequestInit & ApiClientOptions, 'method' | 'body'>,
+  ) => {
     const { headers, ...restOptions } = options || {};
-    const uploadHeaders = { ...headers as Record<string, string> };
+    const uploadHeaders = { ...(headers as Record<string, string>) };
     delete uploadHeaders['Content-Type'];
 
     return makeRequest<T>(`${getApiUrl()}${endpoint}`, {


### PR DESCRIPTION
## Problem

Background API work can exceed the 25-second server deadline or the 30-second SDK deadline. These transport deadlines currently reach the global error handler and display an unrelated red toast.

## Fix

- Keep both resource-safety deadlines.
- Return stable API code `request_deadline`.
- Normalize typed and legacy deadline responses in `@kortix/sdk`.
- Return typed timeout errors without invoking the host global error handler.
- Reject deadline errors before web telemetry and toast handling.
- Preserve unrelated 503 and third-party timeout errors.

## Verification

- SDK typecheck: exit 0.
- SDK suite: 1605 pass, 0 fail.
- SDK packed-install smoke: pass.
- API focused suite: 16 pass, 0 fail.
- API typecheck: exit 0.
- Web focused suite: 12 pass, 0 fail.
- Web full suite: 4814 pass, 0 fail.
- Focused web ESLint: exit 0.
- Authenticated local HTTP proof: 503, Retry-After 10, code request_deadline.