### PR TITLE
fix(projects): re-land legacy-migration chat rehydrate on session open

### DIFF
--- a/apps/api/src/__tests__/unit-legacy-rehydrate.test.ts
+++ b/apps/api/src/__tests__/unit-legacy-rehydrate.test.ts
@@ -1,0 +1,105 @@
+import { Database } from 'bun:sqlite';
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildRestoreScript,
+  legacyRehydrateSpec,
+  rekeyOpencodeDb,
+} from '../projects/legacy-migration-rehydrate';
+import {
+  seedOpencodeSchema,
+  writeConversations,
+} from '../projects/suna-migration/opencode-db-writer';
+
+describe('legacyRehydrateSpec', () => {
+  test('reads source + pin from session metadata', () => {
+    const spec = legacyRehydrateSpec(
+      {
+        legacy_migration: {
+          source_sandbox_id: 'proj-1',
+          rehydrate: { opencode_session_id: 'ses_abc' },
+        },
+      },
+      null,
+    );
+    expect(spec).toEqual({ sourceSandboxId: 'proj-1', opencodeSessionId: 'ses_abc' });
+  });
+
+  test('falls back to project metadata for the source id', () => {
+    const spec = legacyRehydrateSpec({}, { legacy_migration: { source_sandbox_id: 'proj-2' } });
+    expect(spec).toEqual({ sourceSandboxId: 'proj-2', opencodeSessionId: null });
+  });
+
+  test('returns null without legacy_migration metadata', () => {
+    expect(legacyRehydrateSpec({}, {})).toBeNull();
+    expect(legacyRehydrateSpec(null, null)).toBeNull();
+    expect(legacyRehydrateSpec({ legacy_migration: {} }, {})).toBeNull();
+  });
+});
+
+describe('rekeyOpencodeDb', () => {
+  test('re-keys project and session rows to the live projectID', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rekey-test-'));
+    const dbPath = join(dir, 'opencode.db');
+    try {
+      seedOpencodeSchema(dbPath);
+      writeConversations(dbPath, 'proj_original', [
+        {
+          title: 'One',
+          messages: [
+            {
+              role: 'user',
+              createdAt: new Date(0).toISOString(),
+              parts: [{ type: 'text', text: 'hi' }],
+            },
+          ],
+        },
+        {
+          title: 'Two',
+          messages: [
+            {
+              role: 'user',
+              createdAt: new Date(0).toISOString(),
+              parts: [{ type: 'text', text: 'yo' }],
+            },
+          ],
+        },
+      ] as any);
+
+      const { sessions } = rekeyOpencodeDb(dbPath, 'live-project-id');
+      expect(sessions).toBe(2);
+
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        expect(
+          (db.query('SELECT id FROM project').all() as Array<{ id: string }>).map((r) => r.id),
+        ).toEqual(['live-project-id']);
+        const rows = db.query('SELECT DISTINCT project_id FROM session').all() as Array<{
+          project_id: string;
+        }>;
+        expect(rows).toEqual([{ project_id: 'live-project-id' }]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildRestoreScript', () => {
+  test('kill pattern matches the real opencode.exe argv', () => {
+    const script = buildRestoreScript();
+    expect(script).toContain("pkill -9 -f 'opencode[^ ]* serve'");
+    expect(/opencode[^ ]* serve/.test('/path/opencode.exe serve --port 4096')).toBe(true);
+    expect('opencode serve'.includes('opencode.exe serve')).toBe(false);
+  });
+
+  test('resolves the store for both snapshot layouts', () => {
+    const script = buildRestoreScript();
+    expect(script).toContain('/home/kortix/.local/share/opencode');
+    expect(script).toContain('/opt/kortix/home/.local/share/opencode');
+  });
+});

--- a/apps/api/src/projects/legacy-migration-rehydrate.ts
+++ b/apps/api/src/projects/legacy-migration-rehydrate.ts
@@ -1,0 +1,226 @@
+/**
+ * Restore a migrated session's chat into its sandbox DURING provisioning, before
+ * the sandbox is marked active — re-land of the module removed in 0d8c2cbe97
+ * (#4592). Suna-account migrations (suna-migration-phases.ts) still write the
+ * `legacy_migration` metadata + upload the opencode archive this module ships;
+ * without it every migrated session opens with an empty chat.
+ *
+ * Why before-active: the frontend, once it sees `active`, calls `ensure-opencode`
+ * (opencode-mapping.ts) — the authoritative writer of opencode_session_id. It
+ * keeps the migrated pin only if that session already exists in the sandbox's
+ * opencode store; otherwise it re-pins to a fresh session. The hook therefore
+ * runs through `beforeActive` (session-sandbox.ts), and additionally restores
+ * the pin at the end so a lost race self-heals on the next open.
+ *
+ * Mechanics proven live on prod (project 79d76143, sandbox d265e212):
+ * download the archive captured at migration time, re-key its project ids to the
+ * workspace's opencode projectID (opencode scopes session lists by project),
+ * SIGKILL the server (pattern must match `opencode.exe serve`), swap the db in,
+ * and let the supervisor respawn onto it.
+ */
+import { Database } from 'bun:sqlite';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { projectSessions } from '@kortix/db';
+import { eq } from 'drizzle-orm';
+import { logger as appLogger } from '../lib/logger';
+import { getDaytona } from '../shared/daytona';
+import { db } from '../shared/db';
+import { downloadOpencodeArchive } from './legacy-migration-storage';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export interface LegacyRehydrateSpec {
+  sourceSandboxId: string;
+  opencodeSessionId: string | null;
+}
+
+/**
+ * Decide whether a session being provisioned needs a chat rehydrate.
+ * `source_sandbox_id` comes from the session's own `legacy_migration` metadata,
+ * falling back to the project's (both are written by the migration db phase).
+ */
+export function legacyRehydrateSpec(
+  sessionMetadata: Record<string, unknown> | null | undefined,
+  projectMetadata: Record<string, unknown> | null | undefined,
+): LegacyRehydrateSpec | null {
+  const fromSession = asObject(asObject(sessionMetadata).legacy_migration);
+  const fromProject = asObject(asObject(projectMetadata).legacy_migration);
+  const sourceSandboxId = firstString(fromSession.source_sandbox_id, fromProject.source_sandbox_id);
+  if (!sourceSandboxId) return null;
+  const opencodeSessionId = firstString(asObject(fromSession.rehydrate).opencode_session_id);
+  return { sourceSandboxId, opencodeSessionId: opencodeSessionId ?? null };
+}
+
+function asObject(v: unknown): Record<string, unknown> {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const v of values) if (typeof v === 'string' && v.length > 0) return v;
+  return null;
+}
+
+/** Re-key every project/session row to the live workspace's opencode projectID
+ *  and checkpoint the WAL so one self-contained file ships. */
+export function rekeyOpencodeDb(dbPath: string, newProjectId: string): { sessions: number } {
+  const local = new Database(dbPath);
+  try {
+    local.exec('PRAGMA foreign_keys=OFF');
+    local.prepare('UPDATE project SET id = ?').run(newProjectId);
+    local.prepare('UPDATE session SET project_id = ?').run(newProjectId);
+    local.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    const row = local.query('SELECT count(*) c FROM session').get() as { c: number };
+    return { sessions: row.c };
+  } finally {
+    local.close();
+  }
+}
+
+/** The current snapshot serves opencode as user `kortix` (HOME=/home/kortix);
+ *  older snapshots used /opt/kortix/home. Resolve at runtime inside the box. */
+const RESOLVE_STORE_SH =
+  'if [ -d /home/kortix ]; then DEST=/home/kortix/.local/share/opencode; OWNER=/home/kortix; ' +
+  'else DEST=/opt/kortix/home/.local/share/opencode; OWNER=/opt/kortix/home; fi';
+
+export function buildRestoreScript(): string {
+  return [
+    RESOLVE_STORE_SH,
+    'PORT=$(cat /var/run/kortix/opencode-port 2>/dev/null || echo 4096)',
+    'mkdir -p "$DEST"',
+    'cnt=0',
+    'for i in $(seq 1 8); do',
+    // The binary's argv[0] is `opencode.exe`, so the pattern must not assume a
+    // bare `opencode` token — 'opencode serve' silently matches nothing.
+    "  pkill -9 -f 'opencode[^ ]* serve' 2>/dev/null || true",
+    '  sleep 0.5',
+    '  rm -f "$DEST"/opencode.db-wal "$DEST"/opencode.db-shm "$DEST"/opencode.db',
+    '  cp /tmp/opencode.db "$DEST"/opencode.db',
+    '  chown -R --reference="$OWNER" "$DEST" 2>/dev/null || true',
+    '  sleep 2.5',
+    `  cnt=$(curl -s "http://127.0.0.1:$PORT/session?directory=/workspace" 2>/dev/null | grep -o '"id"' | wc -l)`,
+    '  if [ "$cnt" -ge 10 ]; then echo "REHYDRATE_OK cnt=$cnt iter=$i"; rm -f /tmp/opencode.db; exit 0; fi',
+    'done',
+    'echo "REHYDRATE_INCOMPLETE last_cnt=$cnt"',
+  ].join('\n');
+}
+
+export interface RehydrateInput {
+  sessionId: string;
+  externalId: string;
+  provider: string;
+  spec: LegacyRehydrateSpec;
+}
+
+export async function rehydrateSessionChat(input: RehydrateInput): Promise<void> {
+  const { sessionId, externalId, spec } = input;
+  if (input.provider !== 'daytona') {
+    appLogger.warn('[rehydrate] provider not supported; skipping', {
+      sessionId,
+      provider: input.provider,
+    });
+    return;
+  }
+  const sandbox = await getDaytona().get(externalId);
+
+  // 1. Wait for opencode to serve + learn this workspace's projectID. The
+  //    throwaway session is discarded when the db is overwritten below.
+  const newProjectId = await waitForOpencodeProjectId(sandbox, 180_000);
+  if (!newProjectId) {
+    appLogger.warn('[rehydrate] opencode never became ready; skipping', { sessionId, externalId });
+    return;
+  }
+
+  // 2. The archive captured at migration time (object storage, keyed by the
+  //    migration's source sandbox id — for suna migrations, the new projectId).
+  const tarball = await downloadOpencodeArchive(spec.sourceSandboxId);
+  if (!tarball) {
+    appLogger.warn('[rehydrate] no opencode archive in storage', {
+      sessionId,
+      sourceSandboxId: spec.sourceSandboxId,
+    });
+    return;
+  }
+
+  // 3. Re-key locally and ship one checkpointed file.
+  const workDir = mkdtempSync(join(tmpdir(), 'kortix-rehydrate-'));
+  let dbBuf: Buffer;
+  try {
+    writeFileSync(join(workDir, 'oc.tar.gz'), tarball);
+    const untar = Bun.spawnSync(['tar', 'xzf', join(workDir, 'oc.tar.gz'), '-C', workDir]);
+    if (untar.exitCode !== 0)
+      throw new Error(`unpack failed: ${new TextDecoder().decode(untar.stderr)}`);
+    const dbName = existsSync(join(workDir, 'opencode.db'))
+      ? 'opencode.db'
+      : readdirSync(workDir).find((f) => f.endsWith('opencode.db'));
+    if (!dbName)
+      throw new Error(`no opencode.db in archive (got: ${readdirSync(workDir).join(', ')})`);
+    const { sessions } = rekeyOpencodeDb(join(workDir, dbName), newProjectId);
+    appLogger.info('[rehydrate] re-keyed archive', { sessionId, sessions, newProjectId });
+    dbBuf = readFileSync(join(workDir, dbName));
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+
+  // 4. Replace opencode's db. Delicate: opencode holds the db open and flushes
+  //    its WAL on SIGTERM, clobbering the write — so SIGKILL, replace after it
+  //    is dead, let the supervisor respawn onto our file, and verify.
+  await sandbox.fs.uploadFile(dbBuf, '/tmp/opencode.db');
+  const restoreRes = await sandbox.process.executeCommand(
+    buildRestoreScript(),
+    undefined,
+    undefined,
+    120,
+  );
+  const restoreOut = ((restoreRes as { result?: string }).result ?? '').trim();
+  appLogger.info('[rehydrate] restore finished', {
+    sessionId,
+    externalId,
+    newProjectId,
+    bytes: dbBuf.length,
+    result: restoreOut.slice(-200),
+  });
+
+  // 5. Self-heal the pin. ensure-opencode may have re-pinned the row to a fresh
+  //    session while the store was still empty (earlier open, or the bounded
+  //    beforeActive wait elapsing); the migrated id in metadata is authoritative.
+  if (spec.opencodeSessionId) {
+    await db
+      .update(projectSessions)
+      .set({ opencodeSessionId: spec.opencodeSessionId, updatedAt: new Date() })
+      .where(eq(projectSessions.sessionId, sessionId));
+  }
+}
+
+type DaytonaSandbox = Awaited<ReturnType<ReturnType<typeof getDaytona>['get']>>;
+
+/** Create a throwaway session for the workspace and return its projectID —
+ *  doubles as an opencode-readiness probe. */
+async function waitForOpencodeProjectId(
+  sandbox: DaytonaSandbox,
+  timeoutMs: number,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await sandbox.process.executeCommand(
+        'P=$(cat /var/run/kortix/opencode-port 2>/dev/null || echo 4096); ' +
+          'curl -s -X POST "http://127.0.0.1:$P/session?directory=/workspace" 2>/dev/null',
+        undefined,
+        undefined,
+        30,
+      );
+      const out = (res as { result?: string }).result ?? '';
+      const start = out.indexOf('{');
+      if (start >= 0) {
+        const obj = JSON.parse(out.slice(start)) as { projectID?: string };
+        if (obj.projectID) return obj.projectID;
+      }
+    } catch {
+      /* opencode not up yet */
+    }
+    await sleep(3000);
+  }
+  return null;
+}

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -13,6 +13,7 @@ import { resolveBranchTip } from '../git';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, eq, sql } from 'drizzle-orm';
+import { legacyRehydrateSpec, rehydrateSessionChat } from '../legacy-migration-rehydrate';
 import { withProjectGitAuth } from '../lib/git';
 import { ProjectRow, serializeSessionSandboxConfig } from '../lib/serializers';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
@@ -244,6 +245,7 @@ export async function allocateRuntimeOnOpen(
     typeof session.metadata?.opencode_model === 'string' ? session.metadata.opencode_model : null;
   const runtimeMetadata = { opened_at: new Date().toISOString() };
   const sessionMetadata = { ...(session.metadata ?? {}), ...runtimeMetadata };
+  const rehydrate = legacyRehydrateSpec(session.metadata, loaded.row.metadata);
 
   allocateSessionRuntime({
     sessionId,
@@ -272,6 +274,10 @@ export async function allocateRuntimeOnOpen(
         llmGatewayEnabled: projectLlmGatewayEnabled(loaded.row.metadata),
       }),
     resolveGitProject: async () => withProjectGitAuth(loaded.row),
+    beforeActive: rehydrate
+      ? (externalId) =>
+          rehydrateSessionChat({ sessionId, externalId, provider: providerName, spec: rehydrate })
+      : undefined,
   });
 }
 

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -7,6 +7,7 @@ import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { isMetaAgentName } from '@kortix/shared';
 import { and, eq } from 'drizzle-orm';
 import { revokeSessionConnectorTokens } from '../../repositories/account-tokens';
+import { legacyRehydrateSpec, rehydrateSessionChat } from '../legacy-migration-rehydrate';
 import { withProjectGitAuth } from '../lib/git';
 import { pushSessionAgentConfigToSandbox } from '../lib/sandbox-env-sync';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
@@ -199,6 +200,7 @@ export async function restartSession(input: {
       .where(eq(projectSessions.sessionId, sessionId));
 
     const runtimeMetadata = { restarted_at: new Date().toISOString() };
+    const rehydrate = legacyRehydrateSpec(session.metadata, loaded.row.metadata);
     allocateSessionRuntime({
       sessionId,
       accountId: loaded.row.accountId,
@@ -232,6 +234,10 @@ export async function restartSession(input: {
           platformMetaAgent: isMetaAgentName(session.agentName ?? ''),
         }),
       resolveGitProject: async () => withProjectGitAuth(loaded.row as any),
+      beforeActive: rehydrate
+        ? (externalId) =>
+            rehydrateSessionChat({ sessionId, externalId, provider: providerName, spec: rehydrate })
+        : undefined,
     });
   };
 


### PR DESCRIPTION
## Problem

Suna-account migrations (`suna-migration-phases.ts`) write `legacy_migration` metadata on the project + every session and upload the chat archive to storage — but the consumer that ships that archive into the sandbox on open, `legacy-migration-rehydrate.ts`, was deleted by the E2B provider refactor (0d8c2cbe97, #4592). Since Jul 13 every migrated session provisions an empty chat, and `ensure-opencode` then re-pins `opencode_session_id` to a fresh session, hiding the migrated conversation permanently.

Found while migrating a returning customer's 247-chat OG-Suna account (prod migration `03b4ef22`, project `79d76143`): all DB rows, repo content, and the 19.4 MB opencode archive were correct, but the opened session answered `Session not found` for the pinned migrated session.

## Fix

Re-land the module wired through the preserved `beforeActive` extension point in `session-sandbox.ts` (documented there as "no caller passes beforeActive today"). Hooked at both provisioning paths — `allocateRuntimeOnOpen` (open) and `restartSession` (replacement runtime) — gated on `legacy_migration` metadata via `legacyRehydrateSpec`; sessions without it are untouched.

Three fixes over the deleted version, each diagnosed live on prod:

1. **Store path** — current snapshots run opencode as user `kortix` reading `/home/kortix/.local/share/opencode/opencode.db`; the old module wrote `/opt/kortix/home/...`. Resolved at runtime inside the box, with fallback for old snapshots.
2. **Kill pattern** — the binary is `opencode.exe`, so the old `pkill -f 'opencode serve'` matched nothing; the server kept its open file descriptor and the swapped db was never read. Now `'opencode[^ ]* serve'`.
3. **Pin self-heal** — after the restore, the migrated `opencode_session_id` from metadata is written back to `project_sessions`, so a lost race against `ensure-opencode` (or the bounded 20s `beforeActive` wait) heals on the next open.

## Verification (real prod data)

- `bun test unit-legacy-rehydrate` — 6 pass (spec gating, sqlite re-key on a real writer-produced db, kill-pattern + store-path regressions pinned).
- `tsc --noEmit` — 0 errors. Neighbor suites (`unit-sandbox-backend`, `unit-opencode-mapping`) — 15 pass total.
- End-to-end with this branch's API running locally against the prod backend (`dotenvx -f .env.prod`, `KORTIX_URL=https://api.kortix.com`): `POST /restart` on migrated session `c9a2ca50` (project `79d76143`) → fresh Daytona sandbox `781b46ef` → hook logged `re-keyed archive {sessions: 247}` then `restore finished ... REHYDRATE_OK cnt=100 iter=1` → `GET /v1/p/781b46ef/8000/session/ses_019fdcb7b71c00714bfab10b72/message` returns the customer's real 3-message conversation, pin intact.

## Notes

- The 20s `BEFORE_ACTIVE_HOOK_TIMEOUT_MS` wait elapses on cold boots (opencode readiness + 19 MB archive download); the work continues detached and the pin self-heal covers the window. No timeout change needed.
- Prod does not have this code until the next release; migrated sessions opened on prod before then still need the fix deployed to rehydrate automatically.
