### PR TITLE
Fix Platinum resume billing reconciliation race

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -42,6 +42,7 @@ const { config } = await import('../config');
 let branchCreateCalls = 0;
 let sandboxProvisionCalls = 0;
 let providerStartCalls = 0;
+let providerStopCalls = 0;
 let providerStatus = 'stopped';
 let providerStatusAfterStart: string | null = null;
 let providerStatusSessionMetadataUpdate: Record<string, unknown> | null = null;
@@ -110,6 +111,7 @@ function resetState() {
   branchCreateCalls = 0;
   sandboxProvisionCalls = 0;
   providerStartCalls = 0;
+  providerStopCalls = 0;
   providerStatus = 'stopped';
   providerStatusAfterStart = null;
   providerStatusSessionMetadataUpdate = null;
@@ -429,7 +431,9 @@ mock.module('../platform/providers', () => ({
       if (providerStatusAfterStart) providerStatus = providerStatusAfterStart;
       if (providerStartGate) await providerStartGate;
     },
-    stop: async () => undefined,
+    stop: async () => {
+      providerStopCalls += 1;
+    },
     remove: async () => undefined,
     ...(providerRecoveryEnabled
       ? {
@@ -713,7 +717,11 @@ mock.module('../shared/db', () => ({
           return [sessionRow];
         },
         onConflictDoNothing: async () => [],
-        onConflictDoUpdate: ({ set }: { set: Partial<typeof projectSecrets.$inferInsert> }) => {
+        onConflictDoUpdate: ({
+          set,
+        }: {
+          set: Partial<typeof projectSecrets.$inferInsert>;
+        }) => {
           const conflictResult = {
             returning: async () => {
               if (table === projectGitConnections) {
@@ -837,7 +845,7 @@ mock.module('../shared/db', () => ({
         updates: Partial<typeof projectSessions.$inferSelect> &
           Partial<typeof sessionSandboxes.$inferSelect>,
       ) => ({
-        where: () => ({
+        where: (predicate?: unknown) => ({
           returning: async () => {
             if (table === projectSessions) {
               if (!sessionRow) return [];
@@ -857,6 +865,13 @@ mock.module('../shared/db', () => ({
             if (table === sessionSandboxes) {
               const row = sessionSandboxRows[0];
               if (!row) return [];
+              if (predicate) {
+                const query = new PgDialect().sqlToQuery(predicate as SQL);
+                if (query.sql.includes('runtimeWakeId')) {
+                  const wakeId = (row.metadata as Record<string, unknown> | null)?.runtimeWakeId;
+                  if (typeof wakeId !== 'string' || !query.params.includes(wakeId)) return [];
+                }
+              }
               sessionSandboxRows[0] = {
                 ...row,
                 ...updates,
@@ -933,6 +948,9 @@ mock.module('../shared/db', () => ({
 const { projectsApp } = await import('../projects/index');
 const { encryptProjectSecret } = await import('../projects/secrets');
 const { resumeStoppedSandbox } = await import('../projects/routes/shared');
+const { applyStoppedState, reconcileSandboxStoppedByExternalId } = await import(
+  '../projects/reaping/sandbox-state-sync'
+);
 
 function createApp() {
   const app = new Hono();
@@ -1055,7 +1073,11 @@ describe('project session API contract', () => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${SESSION_BOUND_PAT}`,
       },
-      body: JSON.stringify({ provider: 'daytona', base_ref: 'main', agent_name: 'meta' }),
+      body: JSON.stringify({
+        provider: 'daytona',
+        base_ref: 'main',
+        agent_name: 'meta',
+      }),
     });
 
     expect(response.status).toBe(400);
@@ -1071,7 +1093,11 @@ describe('project session API contract', () => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${SESSION_BOUND_PAT}`,
       },
-      body: JSON.stringify({ provider: 'daytona', base_ref: 'main', agent_name: 'meta' }),
+      body: JSON.stringify({
+        provider: 'daytona',
+        base_ref: 'main',
+        agent_name: 'meta',
+      }),
     });
 
     expect(response.status).toBe(201);
@@ -1154,6 +1180,106 @@ describe('project session API contract', () => {
     releaseProviderStart?.();
   });
 
+  test('provider reconciliation cannot close billing while an in-place resume is starting', async () => {
+    sessionRow = {
+      ...sessionRow!,
+      status: 'stopped',
+      error: null,
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'platinum',
+        externalId: 'platinum-resume-race',
+        baseUrl: null,
+        status: 'stopped',
+        config: {},
+        metadata: { initStatus: 'ready' },
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+    providerStartGate = new Promise<void>((resolve) => {
+      releaseProviderStart = resolve;
+    });
+
+    const won = await resumeStoppedSandbox({
+      sandboxId: SESSION_ID,
+      sessionId: SESSION_ID,
+      accountId: ACCOUNT_ID,
+      provider: 'platinum',
+      externalId: 'platinum-resume-race',
+      metadata: sessionSandboxRows[0]!.metadata as Record<string, unknown>,
+    });
+    const reconciled = await reconcileSandboxStoppedByExternalId(
+      'platinum-resume-race',
+      new Date(),
+    );
+    releaseProviderStart?.();
+    await flushUntil(() => providerStartCalls === 1);
+
+    expect(won).toBe(true);
+    expect(reconciled).toBe(false);
+    expect(sessionSandboxRows[0]?.status).toBe('active');
+    expect(sessionRow?.status).toBe('running');
+    expect(computeReopenCalls).toBe(1);
+  });
+
+  test('a manual stop wins when provider start resolves after the stop', async () => {
+    sessionRow = {
+      ...sessionRow!,
+      status: 'stopped',
+      error: null,
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'platinum',
+        externalId: 'platinum-cancelled-wake',
+        baseUrl: null,
+        status: 'stopped',
+        config: {},
+        metadata: { initStatus: 'ready' },
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+    providerStartGate = new Promise<void>((resolve) => {
+      releaseProviderStart = resolve;
+    });
+
+    expect(
+      await resumeStoppedSandbox({
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        provider: 'platinum',
+        externalId: 'platinum-cancelled-wake',
+        metadata: sessionSandboxRows[0]!.metadata as Record<string, unknown>,
+      }),
+    ).toBe(true);
+    await applyStoppedState({
+      sandboxId: SESSION_ID,
+      sessionId: SESSION_ID,
+      externalId: 'platinum-cancelled-wake',
+      metadata: { stopReason: 'manual', stoppedBy: USER_ID },
+    });
+    releaseProviderStart?.();
+    await flushUntil(() => providerStopCalls === 1);
+
+    expect(providerStopCalls).toBe(1);
+    expect(sessionSandboxRows[0]?.status).toBe('stopped');
+    expect(sessionRow?.status).toBe('stopped');
+  });
+
   test('upserts and lists project secrets without exposing secret values', async () => {
     const app = createApp();
 
@@ -1213,7 +1339,9 @@ describe('project session API contract', () => {
       configured: true,
     });
 
-    const listRes = await app.request(`/v1/projects/${PROJECT_ID}/secrets`, { headers });
+    const listRes = await app.request(`/v1/projects/${PROJECT_ID}/secrets`, {
+      headers,
+    });
     expect(listRes.status).toBe(200);
     expect(await listRes.json()).toMatchObject({
       items: [
@@ -1403,19 +1531,17 @@ describe('project session API contract', () => {
       message: 'session workspace does not allow repository access',
     });
 
-    const patCloneRes = await app.request(
-      `/v1/projects/${PROJECT_ID}/git/clone-credential`,
-      { headers: { Authorization: `Bearer ${SESSION_AGENT_PAT}` } },
-    );
+    const patCloneRes = await app.request(`/v1/projects/${PROJECT_ID}/git/clone-credential`, {
+      headers: { Authorization: `Bearer ${SESSION_AGENT_PAT}` },
+    });
     expect(patCloneRes.status).toBe(403);
     expect(await patCloneRes.json()).toMatchObject({
       message: 'session workspace does not allow repository access',
     });
 
-    const sandboxCloneRes = await app.request(
-      `/v1/projects/${PROJECT_ID}/git/clone-credential`,
-      { headers: { Authorization: `Bearer ${PROJECT_SANDBOX_TOKEN}` } },
-    );
+    const sandboxCloneRes = await app.request(`/v1/projects/${PROJECT_ID}/git/clone-credential`, {
+      headers: { Authorization: `Bearer ${PROJECT_SANDBOX_TOKEN}` },
+    });
     expect(sandboxCloneRes.status).toBe(403);
     expect(await sandboxCloneRes.json()).toMatchObject({
       error: 'sandbox workspace does not allow repository access',
@@ -1437,7 +1563,11 @@ describe('project session API contract', () => {
     const app = createApp();
 
     for (const body of [
-      { provider: 'daytona', base_ref: 'main', end_user_ref: 'legacy-reference' },
+      {
+        provider: 'daytona',
+        base_ref: 'main',
+        end_user_ref: 'legacy-reference',
+      },
       { provider: 'daytona', base_ref: 'main', origin_ref: 'legacy-reference' },
     ]) {
       const response = await app.request(`/v1/projects/${PROJECT_ID}/sessions`, {
@@ -1468,10 +1598,16 @@ describe('project session API contract', () => {
     const forbidden = await app.request(`/v1/projects/${PROJECT_ID}/sessions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ provider: 'daytona', base_ref: 'main', secrets: ['GMAIL_TOKEN'] }),
+      body: JSON.stringify({
+        provider: 'daytona',
+        base_ref: 'main',
+        secrets: ['GMAIL_TOKEN'],
+      }),
     });
     expect(forbidden.status).toBe(403);
-    expect(await forbidden.json()).toMatchObject({ code: 'origin_override_forbidden' });
+    expect(await forbidden.json()).toMatchObject({
+      code: 'origin_override_forbidden',
+    });
 
     // A backend (PAT) caller naming an unknown identifier fails fast at create.
     const unknown = await app.request(`/v1/projects/${PROJECT_ID}/sessions`, {
@@ -1480,10 +1616,16 @@ describe('project session API contract', () => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${PROJECT_RUNTIME_PAT}`,
       },
-      body: JSON.stringify({ provider: 'daytona', base_ref: 'main', secrets: ['DOES_NOT_EXIST'] }),
+      body: JSON.stringify({
+        provider: 'daytona',
+        base_ref: 'main',
+        secrets: ['DOES_NOT_EXIST'],
+      }),
     });
     expect(unknown.status).toBe(404);
-    expect(await unknown.json()).toMatchObject({ code: 'SECRET_IDENTIFIER_NOT_FOUND' });
+    expect(await unknown.json()).toMatchObject({
+      code: 'SECRET_IDENTIFIER_NOT_FOUND',
+    });
 
     // A backend caller with a valid identifier → 201, allowlist persisted + echoed.
     const ok = await app.request(`/v1/projects/${PROJECT_ID}/sessions`, {
@@ -1492,7 +1634,11 @@ describe('project session API contract', () => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${PROJECT_RUNTIME_PAT}`,
       },
-      body: JSON.stringify({ provider: 'daytona', base_ref: 'main', secrets: ['GMAIL_TOKEN'] }),
+      body: JSON.stringify({
+        provider: 'daytona',
+        base_ref: 'main',
+        secrets: ['GMAIL_TOKEN'],
+      }),
     });
     expect(ok.status).toBe(201);
     expect((await ok.json()).secrets_allowlist).toEqual(['GMAIL_TOKEN']);
@@ -1504,7 +1650,11 @@ describe('project session API contract', () => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${PROJECT_RUNTIME_PAT}`,
       },
-      body: JSON.stringify({ provider: 'daytona', base_ref: 'main', secrets: [] }),
+      body: JSON.stringify({
+        provider: 'daytona',
+        base_ref: 'main',
+        secrets: [],
+      }),
     });
     expect(zero.status).toBe(201);
     expect((await zero.json()).secrets_allowlist).toEqual([]);
@@ -1547,7 +1697,9 @@ describe('project session API contract', () => {
       }),
     });
     expect(res.status).toBe(409);
-    expect(await res.json()).toMatchObject({ code: 'SECRET_IDENTIFIER_KEY_COLLISION' });
+    expect(await res.json()).toMatchObject({
+      code: 'SECRET_IDENTIFIER_KEY_COLLISION',
+    });
   });
 
   test('backend overrides for model, secrets, and agent apply at boot', async () => {
@@ -1560,7 +1712,12 @@ describe('project session API contract', () => {
       const w = await app.request(`/v1/projects/${PROJECT_ID}/secrets`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, value, strategy: 'runtime', consumer: 'sandbox' }),
+        body: JSON.stringify({
+          name,
+          value,
+          strategy: 'runtime',
+          consumer: 'sandbox',
+        }),
       });
       expect(w.status).toBe(200);
     }
@@ -1601,7 +1758,11 @@ describe('project session API contract', () => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${PROJECT_RUNTIME_PAT}`,
       },
-      body: JSON.stringify({ provider: 'daytona', base_ref: 'main', agent_name: 'reviewer' }),
+      body: JSON.stringify({
+        provider: 'daytona',
+        base_ref: 'main',
+        agent_name: 'reviewer',
+      }),
     });
     expect(res2.status).toBe(201);
     expect((await res2.json()).agent_name).toBe('reviewer');
@@ -2728,7 +2889,10 @@ describe('project session API contract', () => {
       ...sessionRow!,
       status: 'stopped',
       agentName: 'meta',
-      metadata: { ...((sessionRow!.metadata as Record<string, unknown>) ?? {}), sandbox_slug: 'meta' },
+      metadata: {
+        ...((sessionRow!.metadata as Record<string, unknown>) ?? {}),
+        sandbox_slug: 'meta',
+      },
     };
     sessionSandboxRows = [];
 
@@ -2975,7 +3139,10 @@ describe('project session API contract', () => {
     const response = await app.request(`/v1/projects/${PROJECT_ID}/sessions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ provider: 'daytona', pending_prompt: pendingPrompt }),
+      body: JSON.stringify({
+        provider: 'daytona',
+        pending_prompt: pendingPrompt,
+      }),
     });
 
     expect(response.status).toBe(201);
@@ -3050,7 +3217,11 @@ describe('project session API contract', () => {
     const createRes = await app.request(`/v1/projects/${PROJECT_ID}/sessions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ provider: 'daytona', base_ref: 'main', agent_name: 'default' }),
+      body: JSON.stringify({
+        provider: 'daytona',
+        base_ref: 'main',
+        agent_name: 'default',
+      }),
     });
     expect(createRes.status).toBe(201);
 

--- a/apps/api/src/billing/services/compute-close-policy.ts
+++ b/apps/api/src/billing/services/compute-close-policy.ts
@@ -74,6 +74,7 @@ export function decideComputeClose(input: {
   sandboxStatus: string | null;
   hasProviderTarget: boolean;
   runtimeStartFailed: boolean;
+  wakeInProgress: boolean;
   providerStatus: SandboxStatus | null;
   unresolvedForMs: number | null;
   openForMs: number;
@@ -101,6 +102,9 @@ export function decideComputeClose(input: {
   if (input.openForMs >= input.maxWindowMs) return db_('window-past-max');
 
   // ── Provider-informed rules ──
+  if (input.providerStatus === 'stopped' && input.wakeInProgress) {
+    return { reason: null, needsProviderStatus: true };
+  }
   if (
     input.providerStatus === 'stopped' ||
     input.providerStatus === 'removed' ||
@@ -126,9 +130,15 @@ export function decideComputeClose(input: {
  * box never came up — observed in prod with the meter still accruing behind it.
  */
 export function hasFailedRuntimeStart(metadata: Record<string, unknown> | null): boolean {
-  const failedAt = typeof metadata?.runtimeWakeFailedAt === 'string' ? Date.parse(metadata.runtimeWakeFailedAt) : Number.NaN;
+  const failedAt =
+    typeof metadata?.runtimeWakeFailedAt === 'string'
+      ? Date.parse(metadata.runtimeWakeFailedAt)
+      : Number.NaN;
   if (!Number.isFinite(failedAt)) return false;
-  const startedAt = typeof metadata?.runtimeWakeStartedAt === 'string' ? Date.parse(metadata.runtimeWakeStartedAt) : Number.NaN;
+  const startedAt =
+    typeof metadata?.runtimeWakeStartedAt === 'string'
+      ? Date.parse(metadata.runtimeWakeStartedAt)
+      : Number.NaN;
   return !Number.isFinite(startedAt) || failedAt >= startedAt;
 }
 

--- a/apps/api/src/billing/services/compute-invariant-sweep.ts
+++ b/apps/api/src/billing/services/compute-invariant-sweep.ts
@@ -4,30 +4,31 @@
  * the pass that applies them plus the DB-only counters `/health` alerts on.
  */
 
-import { and, eq, sql } from 'drizzle-orm';
 import { appRuntimes, sandboxComputeSessions, sessionSandboxes } from '@kortix/db';
+import { and, eq, sql } from 'drizzle-orm';
 import { logger } from '../../lib/logger';
-import { db } from '../../shared/db';
-import { getProvider, type ProviderName, type SandboxStatus } from '../../platform/providers';
+import { type ProviderName, type SandboxStatus, getProvider } from '../../platform/providers';
 import {
   REAP_BATCH_SIZE,
   REAP_CONCURRENCY,
   computeMaxWindowMs,
   computeUnresolvedCeilingMs,
 } from '../../projects/reaper-constants';
-import { pauseComputeSession } from './compute-metering';
-import {
-  computeLivenessGraceMs,
-  isBeyondLivenessCeiling,
-  lastAliveAtOf,
-  parseTimestamp,
-} from './compute-liveness';
+import { runtimeWakeInProgress } from '../../projects/session-lifecycle/runtime-wake-fence';
+import { db } from '../../shared/db';
 import {
   type ComputeCloseReason,
   computeCloseWindowEnd,
   decideComputeClose,
   hasFailedRuntimeStart,
 } from './compute-close-policy';
+import {
+  computeLivenessGraceMs,
+  isBeyondLivenessCeiling,
+  lastAliveAtOf,
+  parseTimestamp,
+} from './compute-liveness';
+import { pauseComputeSession } from './compute-metering';
 
 export interface OrphanComputeResult {
   checked: number;
@@ -101,7 +102,9 @@ export function selectOpenComputeInvariantCandidates(limit = REAP_BATCH_SIZE) {
  * `computeCloseWindowEnd`). Oldest-open first, so a saturated batch drains the
  * worst leaks first and can never starve them. Deterministic; idempotent.
  */
-export async function reconcileOrphanComputeSessions(now = new Date()): Promise<OrphanComputeResult> {
+export async function reconcileOrphanComputeSessions(
+  now = new Date(),
+): Promise<OrphanComputeResult> {
   const unresolvedCeilingMs = computeUnresolvedCeilingMs();
   const maxWindowMs = computeMaxWindowMs();
 
@@ -119,27 +122,34 @@ export async function reconcileOrphanComputeSessions(now = new Date()): Promise<
       const row = rows[cursor++];
       try {
         const isApp = row.workloadType === 'app';
-        const runtimeStatus = isApp
-          ? appRuntimeBillingStatus(row.appStatus)
-          : row.sbStatus;
+        const runtimeStatus = isApp ? appRuntimeBillingStatus(row.appStatus) : row.sbStatus;
         const runtimeUpdatedAt = isApp ? row.appUpdatedAt : row.sbUpdatedAt;
-        const runtimeMetadata = (isApp ? row.appMetadata : row.sbMetadata) as
-          | Record<string, unknown>
-          | null;
+        const runtimeMetadata = (isApp ? row.appMetadata : row.sbMetadata) as Record<
+          string,
+          unknown
+        > | null;
         const provider = isApp ? row.appProvider : row.sessionProvider;
         const externalId = isApp ? row.appExternalId : row.sessionExternalId;
         const startedAt = parseTimestamp(row.startedAt) ?? now;
         const openForMs = Math.max(0, now.getTime() - startedAt.getTime());
         const computeMetadata = (row.computeMetadata ?? {}) as Record<string, unknown>;
         const unresolvedSince = parseTimestamp(computeMetadata.unresolvedSince);
-        const lastAliveAt = lastAliveAtOf({ metadata: computeMetadata, startedAt: row.startedAt });
+        const lastAliveAt = lastAliveAtOf({
+          metadata: computeMetadata,
+          startedAt: row.startedAt,
+        });
         const livenessGraceMs = computeLivenessGraceMs();
 
         const base = {
           sandboxStatus: runtimeStatus ?? null,
           hasProviderTarget: !!externalId && !!provider,
           runtimeStartFailed: hasFailedRuntimeStart(runtimeMetadata),
-          beyondLivenessCeiling: isBeyondLivenessCeiling({ now, lastAliveAt, graceMs: livenessGraceMs }),
+          wakeInProgress: runtimeWakeInProgress(runtimeMetadata, now),
+          beyondLivenessCeiling: isBeyondLivenessCeiling({
+            now,
+            lastAliveAt,
+            graceMs: livenessGraceMs,
+          }),
           openForMs,
           unresolvedCeilingMs,
           maxWindowMs,
@@ -164,9 +174,16 @@ export async function reconcileOrphanComputeSessions(now = new Date()): Promise<
           // been continuously unresolvable rather than treating it as transient.
           if (providerStatus === 'running') {
             if (unresolvedSince) {
-              await updateComputeSessionMetadata(row.computeId, { ...computeMetadata, unresolvedSince: null });
+              await updateComputeSessionMetadata(row.computeId, {
+                ...computeMetadata,
+                unresolvedSince: null,
+              });
             }
-          } else if (providerStatus !== 'stopped' && providerStatus !== 'removed' && !unresolvedSince) {
+          } else if (
+            providerStatus !== 'stopped' &&
+            providerStatus !== 'removed' &&
+            !unresolvedSince
+          ) {
             await updateComputeSessionMetadata(row.computeId, {
               ...computeMetadata,
               unresolvedSince: now.toISOString(),
@@ -206,7 +223,10 @@ export async function reconcileOrphanComputeSessions(now = new Date()): Promise<
         });
       } catch (err) {
         result.errors += 1;
-        console.warn(`[reaper] orphan-compute reconcile failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err);
+        console.warn(
+          `[reaper] orphan-compute reconcile failed for ${row.sandboxId}:`,
+          err instanceof Error ? err.message : err,
+        );
       }
     }
   };
@@ -223,7 +243,10 @@ async function updateComputeSessionMetadata(
     .set({ metadata })
     .where(eq(sandboxComputeSessions.id, computeId))
     .catch((err) =>
-      console.warn('[reaper] compute metadata update failed:', err instanceof Error ? err.message : err),
+      console.warn(
+        '[reaper] compute metadata update failed:',
+        err instanceof Error ? err.message : err,
+      ),
     );
 }
 
@@ -238,9 +261,10 @@ export async function countBillingInvariantViolations(): Promise<number> {
     .from(sandboxComputeSessions)
     .leftJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
     .leftJoin(appRuntimes, eq(appRuntimes.runtimeId, sandboxComputeSessions.appRuntimeId))
-    .where(and(
-      eq(sandboxComputeSessions.state, 'active'),
-      sql`(
+    .where(
+      and(
+        eq(sandboxComputeSessions.state, 'active'),
+        sql`(
         (${sandboxComputeSessions.workloadType} = 'app' AND (
           ${appRuntimes.runtimeId} IS NULL OR
           ${appRuntimes.status} NOT IN ('provisioning', 'starting', 'running')
@@ -249,7 +273,8 @@ export async function countBillingInvariantViolations(): Promise<number> {
           ${sessionSandboxes.status} IS NULL OR ${sessionSandboxes.status} <> 'active'
         ))
       )`,
-    ));
+      ),
+    );
   return Number(row?.n ?? 0);
 }
 
@@ -274,13 +299,15 @@ export async function countStaleLivenessWindows(now = new Date()): Promise<numbe
     .from(sandboxComputeSessions)
     .leftJoin(sessionSandboxes, eq(sessionSandboxes.sandboxId, sandboxComputeSessions.sandboxId))
     .leftJoin(appRuntimes, eq(appRuntimes.runtimeId, sandboxComputeSessions.appRuntimeId))
-    .where(and(
-      eq(sandboxComputeSessions.state, 'active'),
-      sql`(
+    .where(
+      and(
+        eq(sandboxComputeSessions.state, 'active'),
+        sql`(
         (${sandboxComputeSessions.workloadType} = 'app' AND ${appRuntimes.status} = 'running') OR
         (${sandboxComputeSessions.workloadType} <> 'app' AND ${sessionSandboxes.status} = 'active')
       )`,
-      sql`coalesce(${sandboxComputeSessions.metadata}->>'lastAliveAt', ${sandboxComputeSessions.startedAt}::text) < ${cutoff}`,
-    ));
+        sql`coalesce(${sandboxComputeSessions.metadata}->>'lastAliveAt', ${sandboxComputeSessions.startedAt}::text) < ${cutoff}`,
+      ),
+    );
   return Number(row?.n ?? 0);
 }

--- a/apps/api/src/projects/reaping/box-reaper.ts
+++ b/apps/api/src/projects/reaping/box-reaper.ts
@@ -38,6 +38,7 @@ import { type SandboxStatus, getProvider } from '../../platform/providers';
 import { invalidateProviderCache } from '../../sandbox-proxy';
 import { REAP_CONCURRENCY } from '../reaper-constants';
 import { preserveEstablishedRuntime } from '../runtime-identity';
+import { runtimeWakeInProgress } from '../session-lifecycle/runtime-wake-fence';
 import {
   countReapCandidates,
   markReaperVisited,
@@ -136,6 +137,10 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
             result.skipped += 1;
             break;
           case 'reconcile-stopped':
+            if (providerStatus === 'stopped' && runtimeWakeInProgress(row.metadata, now)) {
+              result.skipped += 1;
+              break;
+            }
             await applyStoppedState({
               sandboxId: row.sandboxId,
               sessionId: row.sessionId,

--- a/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
+++ b/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 // applyStoppedState — the single writer for "this sandbox is parked".
 //
 // The procedure used to be copy-pasted three times (reaper idle stop, reaper
@@ -9,13 +10,16 @@
 //
 // Mocks are process-global (`mock.module`) — run this file in its own
 // `bun test <file>` invocation, same caveat as ../sandbox-reaper.test.ts.
-import { readdirSync, readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import * as realComputeMetering from '../../billing/services/compute-metering';
 
-type UpdateCall = { table: unknown; updates: Record<string, unknown>; inTransaction: boolean };
+type UpdateCall = {
+  table: unknown;
+  updates: Record<string, unknown>;
+  inTransaction: boolean;
+};
 
 let events: string[] = [];
 let updateCalls: UpdateCall[] = [];
@@ -25,7 +29,9 @@ let revokedTokens: Array<{ sessionId: string; accountId: string }> = [];
 let preserveCalls: Array<{ sandboxId: string; reason: string }> = [];
 let inTransaction = false;
 
-mock.module('../../config', () => ({ config: { KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15 } }));
+mock.module('../../config', () => ({
+  config: { KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15 },
+}));
 
 const updater = (table: unknown) => ({
   set: (updates: Record<string, unknown>) => ({
@@ -180,7 +186,9 @@ describe('applyStoppedState', () => {
   test('no caller patch writes no metadata at all', async () => {
     await applyStoppedState(write);
 
-    expect(sandboxUpdate()?.updates.metadata).toBeUndefined();
+    const rendered = describeSql(sandboxUpdate()?.updates.metadata);
+    expect(rendered).toContain('runtimeWakeId');
+    expect(rendered).toContain('runtimeWakeStartedAt');
   });
 
   // The lost update: a whole-object write assembled from a stale SELECT drops
@@ -235,6 +243,40 @@ describe('reconcileSandboxStoppedByExternalId', () => {
 
     expect(await reconcileSandboxStoppedByExternalId('ext-1', NOW)).toBe(false);
     expect(updateCalls).toEqual([]);
+  });
+
+  test('a fresh wake fence defers a transient provider-stopped observation', async () => {
+    selectedRows = [
+      {
+        sandboxId: 'sb-1',
+        sessionId: 'sess-1',
+        status: 'active',
+        metadata: {
+          runtimeWakeId: 'wake-1',
+          runtimeWakeStartedAt: new Date(NOW.getTime() - 5_000).toISOString(),
+        },
+      },
+    ];
+
+    expect(await reconcileSandboxStoppedByExternalId('ext-1', NOW)).toBe(false);
+    expect(events).toEqual([]);
+  });
+
+  test('an expired wake fence does not hide a provider-stopped sandbox', async () => {
+    selectedRows = [
+      {
+        sandboxId: 'sb-1',
+        sessionId: 'sess-1',
+        status: 'active',
+        metadata: {
+          runtimeWakeId: 'wake-1',
+          runtimeWakeStartedAt: new Date(NOW.getTime() - 120_000).toISOString(),
+        },
+      },
+    ];
+
+    expect(await reconcileSandboxStoppedByExternalId('ext-1', NOW)).toBe(true);
+    expect(events).toContain('pause:sb-1');
   });
 });
 

--- a/apps/api/src/projects/reaping/sandbox-state-sync.ts
+++ b/apps/api/src/projects/reaping/sandbox-state-sync.ts
@@ -8,13 +8,14 @@
  * no-op, so the two paths can race freely.
  */
 
-import { eq, sql } from 'drizzle-orm';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
-import { db } from '../../shared/db';
-import { invalidateProviderCache } from '../../sandbox-proxy';
+import { eq, sql } from 'drizzle-orm';
 import { pauseComputeSession } from '../../billing/services/compute-metering';
 import { revokeSessionConnectorTokens } from '../../repositories/account-tokens';
+import { invalidateProviderCache } from '../../sandbox-proxy';
+import { db } from '../../shared/db';
 import { preserveEstablishedRuntime } from '../runtime-identity';
+import { runtimeWakeInProgress } from '../session-lifecycle/runtime-wake-fence';
 
 /** Merge keys into a jsonb metadata column without clobbering siblings. */
 export function mergeMetadata(patch: Record<string, unknown>) {
@@ -57,7 +58,10 @@ export interface StoppedStateWrite {
 export async function applyStoppedState(write: StoppedStateWrite): Promise<void> {
   const now = write.now ?? new Date();
   await pauseComputeSession(write.sandboxId).catch((err) =>
-    console.warn(`[reaper] pauseComputeSession failed for ${write.sandboxId}:`, err instanceof Error ? err.message : err),
+    console.warn(
+      `[reaper] pauseComputeSession failed for ${write.sandboxId}:`,
+      err instanceof Error ? err.message : err,
+    ),
   );
   const patch = { ...(write.metadata ?? {}) };
   await db.transaction(async (tx) => {
@@ -66,7 +70,14 @@ export async function applyStoppedState(write: StoppedStateWrite): Promise<void>
       .set({
         status: 'stopped',
         updatedAt: now,
-        ...(Object.keys(patch).length ? { metadata: mergeMetadata(patch) } : {}),
+        // A committed stop cancels any in-flight wake. If provider.start()
+        // resolves after this transaction, its fenced completion write loses
+        // and the resume path stops the provider again. This makes an explicit
+        // user stop win both orderings of the start/stop race.
+        metadata: sql`(coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
+          - 'runtimeWakeStartedAt'
+          - 'runtimeWakeId'
+          - 'runtimeWakeProviderStatus') || ${JSON.stringify(patch)}::jsonb`,
       })
       .where(eq(sessionSandboxes.sandboxId, write.sandboxId));
     await tx
@@ -81,14 +92,23 @@ export async function applyStoppedState(write: StoppedStateWrite): Promise<void>
  * Close billing + reconcile a sandbox the PROVIDER reports stopped/archived,
  * keyed by external id. Returns true if it transitioned a live row.
  */
-export async function reconcileSandboxStoppedByExternalId(externalId: string, now = new Date()): Promise<boolean> {
+export async function reconcileSandboxStoppedByExternalId(
+  externalId: string,
+  now = new Date(),
+): Promise<boolean> {
   const [row] = await db
-    .select({ sandboxId: sessionSandboxes.sandboxId, sessionId: sessionSandboxes.sessionId, status: sessionSandboxes.status })
+    .select({
+      sandboxId: sessionSandboxes.sandboxId,
+      sessionId: sessionSandboxes.sessionId,
+      status: sessionSandboxes.status,
+      metadata: sessionSandboxes.metadata,
+    })
     .from(sessionSandboxes)
     .where(eq(sessionSandboxes.externalId, externalId))
     .limit(1);
   if (!row) return false;
   if (row.status === 'stopped' || row.status === 'archived') return false;
+  if (runtimeWakeInProgress(row.metadata, now)) return false;
   // A stopped box stays stopped: passive /v1/p traffic (markSandboxUsed heal /
   // wakeSandbox) must not resurrect it. That used to need an `idleQuiesced`
   // flag written here; the heal now refuses any row whose deadline has passed —
@@ -107,7 +127,10 @@ export async function reconcileSandboxStoppedByExternalId(externalId: string, no
  * preserve the original mapping. Keyed by external id; idempotent. Shared by
  * webhook ingress + reaper.
  */
-export async function reconcileSandboxRemovedByExternalId(externalId: string, now = new Date()): Promise<boolean> {
+export async function reconcileSandboxRemovedByExternalId(
+  externalId: string,
+  now = new Date(),
+): Promise<boolean> {
   const [row] = await db
     .select({
       sandboxId: sessionSandboxes.sandboxId,

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -1,21 +1,24 @@
-import { pauseComputeSession, reopenComputeForSandbox } from '../../billing/services/compute-metering';
-import { config, type SandboxProviderName } from '../../config';
 import type {
   ProjectSessionSandbox,
   SessionStartFailure,
   SessionStartResult,
 } from '@kortix/api-contract';
+import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
+import { and, eq, sql } from 'drizzle-orm';
+import {
+  pauseComputeSession,
+  reopenComputeForSandbox,
+} from '../../billing/services/compute-metering';
+import { type SandboxProviderName, config } from '../../config';
+import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { auth, json } from '../../openapi';
-import { getProvider, type SandboxStatus } from '../../platform/providers';
+import { type SandboxStatus, getProvider } from '../../platform/providers';
 import { classifySandboxProvisioningFailure } from '../../platform/services/sandbox-provisioning-error';
 import { db } from '../../shared/db';
 import { resolveBranchTip } from '../git';
-import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
-import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
-import { and, eq, sql } from 'drizzle-orm';
 import { legacyRehydrateSpec, rehydrateSessionChat } from '../legacy-migration-rehydrate';
 import { withProjectGitAuth } from '../lib/git';
-import { ProjectRow, serializeSessionSandboxConfig } from '../lib/serializers';
+import { type ProjectRow, serializeSessionSandboxConfig } from '../lib/serializers';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
 import {
   sandboxSlugFromSessionMetadata,
@@ -23,20 +26,21 @@ import {
 } from '../lib/session-sandbox-metadata';
 import { buildSessionSandboxEnvVars, sandboxCallbackUnreachableReason } from '../lib/sessions';
 import { ensureOpencodeSessionPin } from '../opencode-mapping';
-import { inspectSandboxRuntime } from '../runtime-inspection';
 import {
+  RUNTIME_IDENTITY_UNAVAILABLE,
   claimInPlaceRuntimeRecovery,
   finalizeRecoveredRuntimeIfRunning,
   markInPlaceRuntimeRecoveryAccepted,
   preserveEstablishedRuntime,
   retireUnmaterializedRuntime,
-  RUNTIME_IDENTITY_UNAVAILABLE,
 } from '../runtime-identity';
+import { inspectSandboxRuntime } from '../runtime-inspection';
 import {
-  hasRuntimeReadinessClock,
   RUNTIME_READINESS_CLOCK_KEYS,
+  hasRuntimeReadinessClock,
   staleOpencodeReadyReason,
 } from '../session-lifecycle/readiness-clocks';
+import { RUNTIME_WAKE_GRACE_MS } from '../session-lifecycle/runtime-wake-fence';
 
 /**
  * Resume a hibernated (status='stopped') session sandbox IN PLACE instead of
@@ -130,64 +134,83 @@ export async function resumeStoppedSandbox(row: {
   void provider
     .start(externalId)
     .then(async () => {
-    await db
-      .update(sessionSandboxes)
-      .set({
-        metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'runtimeWakeStartedAt' - 'runtimeWakeId' - 'runtimeWakeProviderStatus' - 'runtimeWakeError' - 'runtimeWakeFailedAt'`,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(sessionSandboxes.sandboxId, row.sandboxId),
-          eq(sessionSandboxes.externalId, externalId),
-          sql`${sessionSandboxes.metadata}->>'runtimeWakeId' = ${runtimeWakeId}`,
-        ),
-      )
-      .catch((err) =>
-          console.warn(`[runtime-identity] failed to clear wake fence for ${row.sessionId}:`, err),
-      );
+      const [completedWake] = await db
+        .update(sessionSandboxes)
+        .set({
+          metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'runtimeWakeStartedAt' - 'runtimeWakeId' - 'runtimeWakeProviderStatus' - 'runtimeWakeError' - 'runtimeWakeFailedAt'`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, row.sandboxId),
+            eq(sessionSandboxes.externalId, externalId),
+            eq(sessionSandboxes.status, 'active'),
+            sql`${sessionSandboxes.metadata}->>'runtimeWakeId' = ${runtimeWakeId}`,
+          ),
+        )
+        .returning({ sandboxId: sessionSandboxes.sandboxId })
+        .catch((err) => {
+          console.warn(`[runtime-identity] failed to clear wake fence for ${row.sessionId}:`, err);
+          return [] as Array<{ sandboxId: string }>;
+        });
+      if (!completedWake) {
+        // A real stop won while start() was in flight. The first provider.stop()
+        // can finish before this late start, so enforce the user's stopped state
+        // once more after start() resolves.
+        await provider
+          .stop(externalId)
+          .catch((err) =>
+            console.warn(
+              `[projects] failed to re-stop cancelled wake ${externalId} for session ${row.sessionId}:`,
+              err,
+            ),
+          );
+      }
     })
     .catch(async (err) => {
-    console.warn(
-      `[projects] failed to resume sandbox ${externalId} for session ${row.sessionId}:`,
-      err,
-    );
-    // Never retire or replace an established identity based on a provider
-    // start error. Revert this exact fenced wake so a later explicit open can
-    // retry the original sandbox in place.
-    await db
-      .update(sessionSandboxes)
-      .set({
-        status: 'stopped',
-        metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${JSON.stringify({ runtimeWakeError: isMissingRuntimeError(err) ? 'missing' : 'start_failed', runtimeWakeFailedAt: new Date().toISOString() })}::jsonb`,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(sessionSandboxes.sandboxId, row.sandboxId),
-          eq(sessionSandboxes.externalId, externalId),
-          sql`${sessionSandboxes.metadata}->>'runtimeWakeId' = ${runtimeWakeId}`,
-        ),
-      )
-      .catch(() => {});
-    await db
-      .update(projectSessions)
-      .set({ status: 'stopped', updatedAt: new Date() })
-      .where(eq(projectSessions.sessionId, row.sessionId))
-      .catch(() => {});
-    // The meter was opened optimistically above, BEFORE provider.start() had
-    // resolved. This branch is the proof it never came up, so the window must
-    // close here — reverting the two status rows and leaving the meter running
-    // is how a box that failed to start in 134ms went on accruing wall-clock
-    // (observed in prod 2026-07-29). The billing-invariant sweep would also
-    // catch it, but a leak this deterministic should not wait for a sweep.
-    await pauseComputeSession(row.sandboxId).catch((pauseErr) =>
       console.warn(
-        `[projects] compute pause after failed wake failed for ${row.sandboxId}:`,
-        pauseErr,
-      ),
-    );
-  });
+        `[projects] failed to resume sandbox ${externalId} for session ${row.sessionId}:`,
+        err,
+      );
+      // Never retire or replace an established identity based on a provider
+      // start error. Revert this exact fenced wake so a later explicit open can
+      // retry the original sandbox in place.
+      const [revertedWake] = await db
+        .update(sessionSandboxes)
+        .set({
+          status: 'stopped',
+          metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${JSON.stringify({ runtimeWakeError: isMissingRuntimeError(err) ? 'missing' : 'start_failed', runtimeWakeFailedAt: new Date().toISOString() })}::jsonb`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, row.sandboxId),
+            eq(sessionSandboxes.externalId, externalId),
+            eq(sessionSandboxes.status, 'active'),
+            sql`${sessionSandboxes.metadata}->>'runtimeWakeId' = ${runtimeWakeId}`,
+          ),
+        )
+        .returning({ sandboxId: sessionSandboxes.sandboxId })
+        .catch(() => []);
+      if (!revertedWake) return;
+      await db
+        .update(projectSessions)
+        .set({ status: 'stopped', updatedAt: new Date() })
+        .where(eq(projectSessions.sessionId, row.sessionId))
+        .catch(() => {});
+      // The meter was opened optimistically above, BEFORE provider.start() had
+      // resolved. This branch is the proof it never came up, so the window must
+      // close here — reverting the two status rows and leaving the meter running
+      // is how a box that failed to start in 134ms went on accruing wall-clock
+      // (observed in prod 2026-07-29). The billing-invariant sweep would also
+      // catch it, but a leak this deterministic should not wait for a sweep.
+      await pauseComputeSession(row.sandboxId).catch((pauseErr) =>
+        console.warn(
+          `[projects] compute pause after failed wake failed for ${row.sandboxId}:`,
+          pauseErr,
+        ),
+      );
+    });
   return true;
 }
 
@@ -307,7 +330,7 @@ export function sessionRuntimeUrlPath(externalId: string): string {
 
 const STALE_PENDING_PROVISIONING_MS = 10 * 60 * 1000;
 const STALE_STARTED_PROVISIONING_MS = 5 * 60 * 1000;
-const STALE_RUNTIME_WAKE_MS = 90 * 1000;
+const STALE_RUNTIME_WAKE_MS = RUNTIME_WAKE_GRACE_MS;
 const STALE_OPENCODE_READY_MS = 5 * 60 * 1000;
 
 function parseTimestampMs(value: unknown): number | null {
@@ -631,21 +654,21 @@ export async function openSession(args: {
       .getStatus(row.externalId)
       .catch(() => 'unknown' as const);
     if (stoppedProviderStatus !== 'removed' || !provider.recoverInPlace) {
-    await resumeStoppedSandbox({
-      sandboxId: row.sandboxId,
-      sessionId: row.sessionId,
-      accountId: row.accountId,
-      provider: row.provider,
-      externalId: row.externalId,
-      metadata: row.metadata as Record<string, unknown> | null,
-    });
-    const [resumed] = await db
-      .select()
-      .from(sessionSandboxes)
-      .where(eq(sessionSandboxes.sandboxId, row.sandboxId))
-      .limit(1);
-    if (resumed) row = resumed;
-  }
+      await resumeStoppedSandbox({
+        sandboxId: row.sandboxId,
+        sessionId: row.sessionId,
+        accountId: row.accountId,
+        provider: row.provider,
+        externalId: row.externalId,
+        metadata: row.metadata as Record<string, unknown> | null,
+      });
+      const [resumed] = await db
+        .select()
+        .from(sessionSandboxes)
+        .where(eq(sessionSandboxes.sandboxId, row.sandboxId))
+        .limit(1);
+      if (resumed) row = resumed;
+    }
   }
 
   // No usable box → provision on open (or report a terminal state).
@@ -866,8 +889,8 @@ export async function openSession(args: {
         sandbox: null,
         opencode_session_id: null,
         reason: 'runtime_recovery_cancelled',
-    };
-  }
+      };
+    }
     row = finalized;
   }
   const runningExternalId = row.externalId;

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { appRuntimes, projectSessions, sandboxComputeSessions, sessionSandboxes } from '@kortix/db';
-import * as realProviders from '../platform/providers';
 import * as realComputeMetering from '../billing/services/compute-metering';
+import * as realProviders from '../platform/providers';
 
 // ── mock state ──────────────────────────────────────────────────────────────
 let candidates: any[] = [];
@@ -18,7 +18,10 @@ let endedCompute: string[] = [];
 let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
 let stuckSessions: Array<{ sessionId: string }> = [];
 let computeRows: any[] = [];
-let pausedComputeWindows: Array<{ sandboxId: string; windowEnd: Date | undefined }> = [];
+let pausedComputeWindows: Array<{
+  sandboxId: string;
+  windowEnd: Date | undefined;
+}> = [];
 
 let orderByExpressions: string[] = [];
 let statusCalls: string[] = [];
@@ -43,9 +46,7 @@ function applyOrder(rows: any[], now: Date = NOW): any[] {
     'startedAt' in r ? String(r.startedAt ?? '') : String(r.metadata?.reaperVisitedAt ?? '');
   const expired = (r: any) =>
     r?.deadlineAt instanceof Date && r.deadlineAt.getTime() <= now.getTime() ? 0 : 1;
-  return [...rows].sort(
-    (a, b) => expired(a) - expired(b) || visited(a).localeCompare(visited(b)),
-  );
+  return [...rows].sort((a, b) => expired(a) - expired(b) || visited(a).localeCompare(visited(b)));
 }
 
 /** Flatten a drizzle SQL expression to its literal text so a test can assert
@@ -93,8 +94,7 @@ function sqlValues(expression: unknown): string[] {
  *  and `where().orderBy().limit()` resolve to the same rows. */
 function hybrid(rows: any[], throwOnGroupBy = false): any {
   const p: any = Promise.resolve(rows);
-  p.limit = (n?: number) =>
-    hybrid(typeof n === 'number' ? rows.slice(0, n) : rows, throwOnGroupBy);
+  p.limit = (n?: number) => hybrid(typeof n === 'number' ? rows.slice(0, n) : rows, throwOnGroupBy);
   p.orderBy = (...expressions: unknown[]) => {
     for (const expression of expressions) orderByExpressions.push(describeSql(expression));
     return hybrid(applyOrder(rows), throwOnGroupBy);
@@ -120,11 +120,13 @@ const visitStamps = () => updateCalls.filter(isVisitStamp);
 // test doesn't import the real config, which calls process.exit on incomplete
 // local env. Run this file in its own `bun test <file>` invocation (as CI does)
 // so the mock never leaks into a sibling file that uses the real config.
-mock.module('../config', () => ({ config: {
-  KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15,
-  KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES: 5,
-  ALLOWED_SANDBOX_PROVIDERS: ['daytona', 'e2b'],
-} }));
+mock.module('../config', () => ({
+  config: {
+    KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15,
+    KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES: 5,
+    ALLOWED_SANDBOX_PROVIDERS: ['daytona', 'e2b'],
+  },
+}));
 
 mock.module('../shared/db', () => ({
   db: {
@@ -160,11 +162,11 @@ mock.module('../shared/db', () => ({
                 ? candidates
                 : table === appRuntimes
                   ? appRuntimeKeepRows
-                : table === sandboxComputeSessions
-                  ? computeRows
-                  : table === projectSessions
-                    ? stuckSessions
-                    : [],
+                  : table === sandboxComputeSessions
+                    ? computeRows
+                    : table === projectSessions
+                      ? stuckSessions
+                      : [],
             );
           },
         };
@@ -212,7 +214,7 @@ mock.module('../platform/providers', () => ({
       const err = stopErrorByExternal[externalId];
       if (err) throw err;
     },
-    listManagedRunningSandboxes: async () => name === 'e2b' ? e2bManagedBoxes : managedBoxes,
+    listManagedRunningSandboxes: async () => (name === 'e2b' ? e2bManagedBoxes : managedBoxes),
   }),
 }));
 
@@ -346,8 +348,12 @@ describe('reapAndReconcileSandboxes — the one rule: deadline_at <= now', () =>
     // Billing is settled against the still-active row before the flip.
     expect(pausedCompute).toEqual(['sb-1']);
     expect(cacheInvalidations).toEqual(['ext-1']);
-    expect(updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped')).toBe(true);
-    expect(updateCalls.some((c) => c.table === projectSessions && c.updates.status === 'stopped')).toBe(true);
+    expect(
+      updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped'),
+    ).toBe(true);
+    expect(
+      updateCalls.some((c) => c.table === projectSessions && c.updates.status === 'stopped'),
+    ).toBe(true);
   });
 
   test('a box with an observed turn SURVIVES — its deadline is still ahead', async () => {
@@ -482,6 +488,26 @@ describe('reapAndReconcileSandboxes — the one rule: deadline_at <= now', () =>
     expect(r.billingClosed).toBe(1);
     expect(stops).toEqual([]);
     expect(pausedCompute).toEqual(['sb-1']);
+  });
+
+  test('a transient stopped observation cannot defeat an in-flight provider wake', async () => {
+    candidates = [
+      candidate({
+        provider: 'platinum',
+        metadata: {
+          runtimeWakeId: 'wake-1',
+          runtimeWakeStartedAt: new Date(NOW.getTime() - 5_000).toISOString(),
+        },
+      }),
+    ];
+    statusByExternal['ext-1'] = 'stopped';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(r.skipped).toBe(1);
+    expect(r.reconciled).toBe(0);
+    expect(r.billingClosed).toBe(0);
+    expect(pausedCompute).toEqual([]);
   });
 
   test('never acts on transient unknown provider state, expired or not', async () => {
@@ -684,13 +710,23 @@ describe('the batch cap rotates and cannot starve a row', () => {
     expect(orderByExpressions.some((e) => e.includes('nulls first'))).toBe(true);
     // Expired rows must win the batch, or a backlog of healthy rows could defer
     // the one row that is actually over its deadline, forever.
-    expect(orderByExpressions.some((e) => e.includes('deadline_at') && e.includes('desc'))).toBe(true);
+    expect(orderByExpressions.some((e) => e.includes('deadline_at') && e.includes('desc'))).toBe(
+      true,
+    );
   });
 
   test('every examined row is stamped, including ones the pass deliberately left alone', async () => {
     candidates = [
-      candidate({ sandboxId: 'sb-a', sessionId: 'sess-a', externalId: 'ext-a' }),
-      candidate({ sandboxId: 'sb-b', sessionId: 'sess-b', externalId: 'ext-b' }),
+      candidate({
+        sandboxId: 'sb-a',
+        sessionId: 'sess-a',
+        externalId: 'ext-a',
+      }),
+      candidate({
+        sandboxId: 'sb-b',
+        sessionId: 'sess-b',
+        externalId: 'ext-b',
+      }),
     ];
     statusByExternal['ext-a'] = 'running';
     statusByExternal['ext-b'] = 'running';
@@ -709,9 +745,21 @@ describe('the batch cap rotates and cannot starve a row', () => {
     process.env.KORTIX_REAP_BATCH_SIZE = '2';
     try {
       candidates = [
-        candidate({ sandboxId: 'sb-a', sessionId: 'sess-a', externalId: 'ext-a' }),
-        candidate({ sandboxId: 'sb-b', sessionId: 'sess-b', externalId: 'ext-b' }),
-        candidate({ sandboxId: 'sb-c', sessionId: 'sess-c', externalId: 'ext-c' }),
+        candidate({
+          sandboxId: 'sb-a',
+          sessionId: 'sess-a',
+          externalId: 'ext-a',
+        }),
+        candidate({
+          sandboxId: 'sb-b',
+          sessionId: 'sess-b',
+          externalId: 'ext-b',
+        }),
+        candidate({
+          sandboxId: 'sb-c',
+          sessionId: 'sess-c',
+          externalId: 'ext-c',
+        }),
       ];
 
       const r = await reapAndReconcileSandboxes(NOW);
@@ -801,6 +849,7 @@ describe('decideComputeClose', () => {
     sandboxStatus: 'active' as string | null,
     hasProviderTarget: true,
     runtimeStartFailed: false,
+    wakeInProgress: false,
     beyondLivenessCeiling: false,
     providerStatus: 'running' as any,
     unresolvedForMs: null as number | null,
@@ -820,10 +869,14 @@ describe('decideComputeClose', () => {
     expect(d.needsProviderStatus).toBe(false);
   });
   test('sandbox row in error → close', () => {
-    expect(decideComputeClose({ ...base, sandboxStatus: 'error' }).reason).toBe('sandbox-not-active');
+    expect(decideComputeClose({ ...base, sandboxStatus: 'error' }).reason).toBe(
+      'sandbox-not-active',
+    );
   });
   test('sandbox row archived → close', () => {
-    expect(decideComputeClose({ ...base, sandboxStatus: 'archived' }).reason).toBe('sandbox-not-active');
+    expect(decideComputeClose({ ...base, sandboxStatus: 'archived' }).reason).toBe(
+      'sandbox-not-active',
+    );
   });
   test('a provisioning box is NOT closed — the meter legitimately opens first', () => {
     expect(decideComputeClose({ ...base, sandboxStatus: 'provisioning' }).reason).toBeNull();
@@ -832,7 +885,9 @@ describe('decideComputeClose', () => {
     expect(decideComputeClose({ ...base, sandboxStatus: null }).reason).toBe('sandbox-row-missing');
   });
   test('no provider target → close', () => {
-    expect(decideComputeClose({ ...base, hasProviderTarget: false }).reason).toBe('sandbox-row-missing');
+    expect(decideComputeClose({ ...base, hasProviderTarget: false }).reason).toBe(
+      'sandbox-row-missing',
+    );
   });
   test('a wake that failed → close, without a provider call', () => {
     const d = decideComputeClose({ ...base, runtimeStartFailed: true });
@@ -847,37 +902,72 @@ describe('decideComputeClose', () => {
   });
 
   test('provider says stopped / removed / terminal → close', () => {
-    expect(decideComputeClose({ ...base, providerStatus: 'stopped' }).reason).toBe('provider-not-running');
-    expect(decideComputeClose({ ...base, providerStatus: 'removed' }).reason).toBe('provider-not-running');
-    expect(decideComputeClose({ ...base, providerStatus: 'terminal' }).reason).toBe('provider-not-running');
+    expect(decideComputeClose({ ...base, providerStatus: 'stopped' }).reason).toBe(
+      'provider-not-running',
+    );
+    expect(decideComputeClose({ ...base, providerStatus: 'removed' }).reason).toBe(
+      'provider-not-running',
+    );
+    expect(decideComputeClose({ ...base, providerStatus: 'terminal' }).reason).toBe(
+      'provider-not-running',
+    );
+  });
+
+  test('a fresh wake fence makes provider-stopped transitional, not billable-stop proof', () => {
+    const decision = decideComputeClose({
+      ...base,
+      providerStatus: 'stopped',
+      wakeInProgress: true,
+    });
+    expect(decision.reason).toBeNull();
   });
 
   // 44 of 66 open prod rows answered `unknown`: it is the steady state for a
   // box deleted out from under us, not a transient.
   test('REGRESSION: unknown is transient on first sight — do not close yet', () => {
     expect(
-      decideComputeClose({ ...base, providerStatus: 'unknown', unresolvedForMs: null }).reason,
+      decideComputeClose({
+        ...base,
+        providerStatus: 'unknown',
+        unresolvedForMs: null,
+      }).reason,
     ).toBeNull();
   });
   test('REGRESSION: unknown past the ceiling stops billing — uncertainty never justifies charging', () => {
     expect(
-      decideComputeClose({ ...base, providerStatus: 'unknown', unresolvedForMs: HOUR }).reason,
+      decideComputeClose({
+        ...base,
+        providerStatus: 'unknown',
+        unresolvedForMs: HOUR,
+      }).reason,
     ).toBe('unresolvable-past-ceiling');
   });
   test('unknown but only briefly → keep billing', () => {
     expect(
-      decideComputeClose({ ...base, providerStatus: 'unknown', unresolvedForMs: HOUR - 1 }).reason,
+      decideComputeClose({
+        ...base,
+        providerStatus: 'unknown',
+        unresolvedForMs: HOUR - 1,
+      }).reason,
     ).toBeNull();
   });
   test('an unresolvable lookup (provider threw, status null) is treated like unknown', () => {
     expect(
-      decideComputeClose({ ...base, providerStatus: null, unresolvedForMs: HOUR }).reason,
+      decideComputeClose({
+        ...base,
+        providerStatus: null,
+        unresolvedForMs: HOUR,
+      }).reason,
     ).toBe('unresolvable-past-ceiling');
   });
 
   // The rule that makes an 829-hour row impossible.
   test('REGRESSION: no window may exceed the max, even while the provider says running', () => {
-    const d = decideComputeClose({ ...base, openForMs: 24 * HOUR, providerStatus: 'running' });
+    const d = decideComputeClose({
+      ...base,
+      openForMs: 24 * HOUR,
+      providerStatus: 'running',
+    });
     expect(d.reason).toBe('window-past-max');
     expect(d.needsProviderStatus).toBe(false);
   });
@@ -905,19 +995,31 @@ describe('computeCloseWindowEnd', () => {
   test('a stopped sandbox bills through the moment we recorded the stop', () => {
     const stoppedAt = new Date(now.getTime() - 90 * HOUR);
     expect(
-      computeCloseWindowEnd({ ...base, reason: 'sandbox-not-active', sandboxUpdatedAt: stoppedAt }).getTime(),
+      computeCloseWindowEnd({
+        ...base,
+        reason: 'sandbox-not-active',
+        sandboxUpdatedAt: stoppedAt,
+      }).getTime(),
     ).toBe(stoppedAt.getTime());
   });
   test('a failed wake bills through the failure, not through today', () => {
     const failedAt = new Date(now.getTime() - 95 * HOUR);
     expect(
-      computeCloseWindowEnd({ ...base, reason: 'runtime-start-failed', runtimeWakeFailedAt: failedAt }).getTime(),
+      computeCloseWindowEnd({
+        ...base,
+        reason: 'runtime-start-failed',
+        runtimeWakeFailedAt: failedAt,
+      }).getTime(),
     ).toBe(failedAt.getTime());
   });
   test('an unresolvable box bills through the last moment it was resolvable', () => {
     const lastSeen = new Date(now.getTime() - 50 * HOUR);
     expect(
-      computeCloseWindowEnd({ ...base, reason: 'unresolvable-past-ceiling', unresolvedSince: lastSeen }).getTime(),
+      computeCloseWindowEnd({
+        ...base,
+        reason: 'unresolvable-past-ceiling',
+        unresolvedSince: lastSeen,
+      }).getTime(),
     ).toBe(lastSeen.getTime());
   });
   test('a max-length window bills exactly the max, never the 100h it actually ran', () => {
@@ -944,7 +1046,12 @@ describe('computeCloseWindowEnd', () => {
     ).toBe(now.getTime());
   });
   test('a missing evidence timestamp degrades to now rather than throwing', () => {
-    expect(computeCloseWindowEnd({ ...base, reason: 'sandbox-not-active' }).getTime()).toBe(now.getTime());
+    expect(
+      computeCloseWindowEnd({
+        ...base,
+        reason: 'sandbox-not-active',
+      }).getTime(),
+    ).toBe(now.getTime());
   });
 
   // Get the reason wrong and the bill is still capped — that is what makes the
@@ -995,18 +1102,38 @@ describe('reconcileOrphanComputeSessions', () => {
     expect(pausedCompute).toEqual([]);
   });
 
+  test('the compute invariant keeps the meter open during a fresh provider wake', async () => {
+    computeRows = [
+      openRow({
+        sessionProvider: 'platinum',
+        sbMetadata: {
+          runtimeWakeId: 'wake-1',
+          runtimeWakeStartedAt: new Date(NOW3.getTime() - 5_000).toISOString(),
+        },
+      }),
+    ];
+    statusByExternal['ext-1'] = 'stopped';
+
+    const r = await reconcileOrphanComputeSessions(NOW3);
+
+    expect(r.closed).toBe(0);
+    expect(pausedCompute).toEqual([]);
+  });
+
   test('a healthy running App runtime keeps billing through its App join', async () => {
-    computeRows = [openRow({
-      workloadType: 'app',
-      sbStatus: null,
-      sessionProvider: null,
-      sessionExternalId: null,
-      appStatus: 'running',
-      appUpdatedAt: new Date(NOW3.getTime() - HOUR).toISOString(),
-      appMetadata: {},
-      appProvider: 'daytona',
-      appExternalId: 'app-ext-1',
-    })];
+    computeRows = [
+      openRow({
+        workloadType: 'app',
+        sbStatus: null,
+        sessionProvider: null,
+        sessionExternalId: null,
+        appStatus: 'running',
+        appUpdatedAt: new Date(NOW3.getTime() - HOUR).toISOString(),
+        appMetadata: {},
+        appProvider: 'daytona',
+        appExternalId: 'app-ext-1',
+      }),
+    ];
     statusByExternal['app-ext-1'] = 'running';
 
     const r = await reconcileOrphanComputeSessions(NOW3);
@@ -1018,17 +1145,19 @@ describe('reconcileOrphanComputeSessions', () => {
 
   test('a stopped App runtime closes its compute window without a provider call', async () => {
     const stoppedAt = new Date(NOW3.getTime() - HOUR);
-    computeRows = [openRow({
-      workloadType: 'app',
-      sbStatus: null,
-      sessionProvider: null,
-      sessionExternalId: null,
-      appStatus: 'stopped',
-      appUpdatedAt: stoppedAt.toISOString(),
-      appMetadata: {},
-      appProvider: 'daytona',
-      appExternalId: 'app-ext-1',
-    })];
+    computeRows = [
+      openRow({
+        workloadType: 'app',
+        sbStatus: null,
+        sessionProvider: null,
+        sessionExternalId: null,
+        appStatus: 'stopped',
+        appUpdatedAt: stoppedAt.toISOString(),
+        appMetadata: {},
+        appProvider: 'daytona',
+        appExternalId: 'app-ext-1',
+      }),
+    ];
 
     const r = await reconcileOrphanComputeSessions(NOW3);
 
@@ -1097,7 +1226,13 @@ describe('reconcileOrphanComputeSessions', () => {
   });
 
   test('an open row with no sandbox row behind it is closed', async () => {
-    computeRows = [openRow({ sbStatus: null, sessionProvider: null, sessionExternalId: null })];
+    computeRows = [
+      openRow({
+        sbStatus: null,
+        sessionProvider: null,
+        sessionExternalId: null,
+      }),
+    ];
 
     const r = await reconcileOrphanComputeSessions(NOW3);
 
@@ -1143,7 +1278,10 @@ describe('reconcileOrphanComputeSessions', () => {
     computeRows = [
       openRow({
         startedAt: new Date(NOW3.getTime() - 20 * HOUR).toISOString(),
-        computeMetadata: { lastAliveAt: NOW3.toISOString(), unresolvedSince: lastSeen.toISOString() },
+        computeMetadata: {
+          lastAliveAt: NOW3.toISOString(),
+          unresolvedSince: lastSeen.toISOString(),
+        },
       }),
     ];
     statusByExternal['ext-1'] = 'unknown';
@@ -1157,7 +1295,12 @@ describe('reconcileOrphanComputeSessions', () => {
 
   test('a box that becomes resolvable again clears the unresolved clock', async () => {
     computeRows = [
-      openRow({ computeMetadata: { lastAliveAt: NOW3.toISOString(), unresolvedSince: new Date(NOW3.getTime() - 3 * HOUR).toISOString() } }),
+      openRow({
+        computeMetadata: {
+          lastAliveAt: NOW3.toISOString(),
+          unresolvedSince: new Date(NOW3.getTime() - 3 * HOUR).toISOString(),
+        },
+      }),
     ];
     statusByExternal['ext-1'] = 'running';
 
@@ -1183,19 +1326,36 @@ describe('reconcileOrphanComputeSessions', () => {
 
   test('oldest-open rows are drained first so a saturated batch cannot starve them', async () => {
     computeRows = [
-      openRow({ computeId: 'cs-new', sandboxId: 'sb-new', startedAt: new Date(NOW3.getTime() - HOUR).toISOString(), sbStatus: 'stopped' }),
-      openRow({ computeId: 'cs-old', sandboxId: 'sb-old', startedAt: new Date(NOW3.getTime() - 800 * HOUR).toISOString(), sbStatus: 'stopped' }),
+      openRow({
+        computeId: 'cs-new',
+        sandboxId: 'sb-new',
+        startedAt: new Date(NOW3.getTime() - HOUR).toISOString(),
+        sbStatus: 'stopped',
+      }),
+      openRow({
+        computeId: 'cs-old',
+        sandboxId: 'sb-old',
+        startedAt: new Date(NOW3.getTime() - 800 * HOUR).toISOString(),
+        sbStatus: 'stopped',
+      }),
     ];
 
     await reconcileOrphanComputeSessions(NOW3);
 
     expect(pausedCompute[0]).toBe('sb-old');
-    expect(orderByExpressions.some((e) => e.includes('started_at') || e.includes('startedAt'))).toBe(true);
+    expect(
+      orderByExpressions.some((e) => e.includes('started_at') || e.includes('startedAt')),
+    ).toBe(true);
   });
 
   test('one bad row never sinks the sweep', async () => {
     computeRows = [
-      openRow({ computeId: 'cs-a', sandboxId: 'sb-a', startedAt: 'not-a-date', sbStatus: 'stopped' }),
+      openRow({
+        computeId: 'cs-a',
+        sandboxId: 'sb-a',
+        startedAt: 'not-a-date',
+        sbStatus: 'stopped',
+      }),
       openRow({ computeId: 'cs-b', sandboxId: 'sb-b', sbStatus: 'stopped' }),
     ];
 

--- a/apps/api/src/projects/session-lifecycle/__tests__/stop.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/stop.test.ts
@@ -1,14 +1,18 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
-import * as realProviders from '../../../platform/providers';
 import * as realComputeMetering from '../../../billing/services/compute-metering';
+import * as realProviders from '../../../platform/providers';
 
 let sandboxRow: Record<string, unknown> | null = null;
 let stopCalls: string[] = [];
 let stopError: Error | null = null;
 let pausedCompute: string[] = [];
 let cacheInvalidations: string[] = [];
-let updateCalls: Array<{ table: unknown; updates: Record<string, unknown>; inTransaction: boolean }> = [];
+let updateCalls: Array<{
+  table: unknown;
+  updates: Record<string, unknown>;
+  inTransaction: boolean;
+}> = [];
 let inTransaction = false;
 
 /** Flatten a drizzle SQL expression (including its bound params) to text, so a
@@ -117,21 +121,39 @@ describe('stopSession', () => {
   });
 
   test('409s when the sandbox is not currently active', async () => {
-    sandboxRow = { sandboxId: 'sess-1', externalId: 'ext-1', provider: 'daytona', status: 'stopped', metadata: {} };
+    sandboxRow = {
+      sandboxId: 'sess-1',
+      externalId: 'ext-1',
+      provider: 'daytona',
+      status: 'stopped',
+      metadata: {},
+    };
     const result = await stopSession(baseInput);
     expect(result.status).toBe(409);
     expect(stopCalls).toEqual([]);
   });
 
   test('400s for an unsupported/unallowed provider', async () => {
-    sandboxRow = { sandboxId: 'sess-1', externalId: 'ext-1', provider: 'justavps', status: 'active', metadata: {} };
+    sandboxRow = {
+      sandboxId: 'sess-1',
+      externalId: 'ext-1',
+      provider: 'justavps',
+      status: 'active',
+      metadata: {},
+    };
     const result = await stopSession(baseInput);
     expect(result.status).toBe(400);
     expect(stopCalls).toEqual([]);
   });
 
   test('stops the provider sandbox, closes billing, and marks both rows stopped', async () => {
-    sandboxRow = { sandboxId: 'sess-1', externalId: 'ext-1', provider: 'daytona', status: 'active', metadata: { foo: 'bar' } };
+    sandboxRow = {
+      sandboxId: 'sess-1',
+      externalId: 'ext-1',
+      provider: 'daytona',
+      status: 'active',
+      metadata: { foo: 'bar' },
+    };
     const result = await stopSession(baseInput);
 
     expect(result.status).toBe(200);
@@ -182,23 +204,56 @@ describe('stopSession', () => {
     expect(rendered).toContain('coalesce');
     expect(rendered).toContain("'{}'::jsonb");
     expect(rendered).toContain('stopReason');
-    // The keys it read are left for the DB to keep — never re-sent, so a
-    // concurrent write to either of them survives this stop.
-    expect(rendered).not.toContain('runtimeWakeId');
+    // The wake fence is deleted in SQL so a late provider start cannot revive
+    // the stopped session. Unrelated concurrent metadata remains untouched.
+    expect(rendered).toContain('runtimeWakeId');
     expect(rendered).not.toContain('lastTurnAt');
   });
 
   test('reconciles the row as stopped even if the provider says it is already gone', async () => {
-    sandboxRow = { sandboxId: 'sess-1', externalId: 'ext-1', provider: 'daytona', status: 'active', metadata: {} };
+    sandboxRow = {
+      sandboxId: 'sess-1',
+      externalId: 'ext-1',
+      provider: 'daytona',
+      status: 'active',
+      metadata: {},
+    };
     stopError = new Error('sandbox already stopped');
     const result = await stopSession(baseInput);
 
     expect(result.status).toBe(200);
-    expect(updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped')).toBe(true);
+    expect(
+      updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped'),
+    ).toBe(true);
+  });
+
+  test('commits the stop when provider start is still transitioning', async () => {
+    sandboxRow = {
+      sandboxId: 'sess-1',
+      externalId: 'ext-1',
+      provider: 'platinum',
+      status: 'active',
+      metadata: { runtimeWakeId: 'wake-1' },
+    };
+    stopError = new Error('sandbox state change in progress');
+
+    const result = await stopSession(baseInput);
+
+    expect(result.status).toBe(200);
+    expect(pausedCompute).toEqual(['sess-1']);
+    expect(
+      updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped'),
+    ).toBe(true);
   });
 
   test('502s on a genuine provider failure and leaves the rows untouched', async () => {
-    sandboxRow = { sandboxId: 'sess-1', externalId: 'ext-1', provider: 'daytona', status: 'active', metadata: {} };
+    sandboxRow = {
+      sandboxId: 'sess-1',
+      externalId: 'ext-1',
+      provider: 'daytona',
+      status: 'active',
+      metadata: {},
+    };
     stopError = new Error('provider unreachable');
     stopError.message = 'internal provider error: connection refused';
     const result = await stopSession(baseInput);

--- a/apps/api/src/projects/session-lifecycle/runtime-wake-fence.ts
+++ b/apps/api/src/projects/session-lifecycle/runtime-wake-fence.ts
@@ -1,0 +1,19 @@
+/**
+ * A provider can continue to report `stopped` while start() is still changing
+ * the VM state. Reconciliation must not convert that transitional observation
+ * into a durable Kortix stop, because doing so closes the compute meter and
+ * leaves a later provider-running VM recorded as stopped.
+ */
+export const RUNTIME_WAKE_GRACE_MS = 90_000;
+
+export function runtimeWakeInProgress(
+  metadata: Record<string, unknown> | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!metadata || typeof metadata.runtimeWakeId !== 'string') return false;
+  if (typeof metadata.runtimeWakeStartedAt !== 'string') return false;
+  const startedAtMs = Date.parse(metadata.runtimeWakeStartedAt);
+  if (!Number.isFinite(startedAtMs)) return false;
+  const ageMs = now.getTime() - startedAtMs;
+  return ageMs >= 0 && ageMs <= RUNTIME_WAKE_GRACE_MS;
+}

--- a/apps/api/src/projects/session-lifecycle/stop.ts
+++ b/apps/api/src/projects/session-lifecycle/stop.ts
@@ -1,9 +1,9 @@
-import { config, type SandboxProviderName } from '../../config';
-import { getProvider } from '../../platform/providers';
-import { db } from '../../shared/db';
 import { sessionSandboxes } from '@kortix/db';
 import { and, eq } from 'drizzle-orm';
-import { isAlreadyNotRunning } from '../reaping/policy';
+import { type SandboxProviderName, config } from '../../config';
+import { getProvider } from '../../platform/providers';
+import { db } from '../../shared/db';
+import { isAlreadyNotRunning, isLifecycleTransitionInProgress } from '../reaping/policy';
 import { applyStoppedState } from '../reaping/sandbox-state-sync';
 
 /**
@@ -55,7 +55,7 @@ export async function stopSession(input: {
   try {
     await provider.stop(sandbox.externalId);
   } catch (err) {
-    if (!isAlreadyNotRunning(err)) {
+    if (!isAlreadyNotRunning(err) && !isLifecycleTransitionInProgress(err)) {
       return {
         status: 502,
         body: { error: err instanceof Error ? err.message : 'Failed to stop sandbox' },

--- a/tests/e2e/scripts/terminal-pty-smoke.ts
+++ b/tests/e2e/scripts/terminal-pty-smoke.ts
@@ -2,8 +2,9 @@
 
 /**
  * Real provider PTY smoke:
- * auth -> project -> provider-pinned session -> sandbox -> create PTY ->
- * WebSocket attach -> command I/O -> reconnect replay -> cleanup.
+ * auth -> project -> provider-pinned session -> sandbox -> stop -> resume the
+ * same sandbox -> create PTY -> WebSocket attach -> command I/O -> reconnect
+ * replay -> cleanup.
  *
  * Run with the isolated stack up:
  *   dotenvx run -f apps/api/.env -f apps/web/.env -- \
@@ -90,7 +91,23 @@ async function waitForRuntime(externalId: string): Promise<void> {
   throw new Error(`runtime did not become reachable: ${last}`);
 }
 
-async function attachAndCollect(wsUrl: string, input?: string): Promise<{ output: string; close?: { code: number; reason: string } }> {
+async function waitForStoredSessionStatus(expected: string): Promise<void> {
+  const end = deadline(60_000);
+  let last = '';
+  while (Date.now() < end) {
+    const response = await api(`/projects/${projectId}/sessions/${sessionId}`);
+    const status = response.body?.status ?? '';
+    last = `${response.status} ${status}`;
+    if (response.status === 200 && status === expected) return;
+    await sleep(500);
+  }
+  throw new Error(`stored session status did not become ${expected}: ${last}`);
+}
+
+async function attachAndCollect(
+  wsUrl: string,
+  input?: string,
+): Promise<{ output: string; close?: { code: number; reason: string } }> {
   return new Promise((resolve, reject) => {
     let output = '';
     let settled = false;
@@ -98,8 +115,14 @@ async function attachAndCollect(wsUrl: string, input?: string): Promise<{ output
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
-      try { ws.close(); } catch {}
-      reject(new Error(`timed out waiting for PTY output; received=${JSON.stringify(output.slice(-500))}`));
+      try {
+        ws.close();
+      } catch {}
+      reject(
+        new Error(
+          `timed out waiting for PTY output; received=${JSON.stringify(output.slice(-500))}`,
+        ),
+      );
     }, 20_000);
 
     ws.addEventListener('open', () => {
@@ -107,7 +130,10 @@ async function attachAndCollect(wsUrl: string, input?: string): Promise<{ output
       if (input) ws.send(input);
     });
     ws.addEventListener('message', (event) => {
-      output += typeof event.data === 'string' ? event.data : Buffer.from(event.data as ArrayBuffer).toString();
+      output +=
+        typeof event.data === 'string'
+          ? event.data
+          : Buffer.from(event.data as ArrayBuffer).toString();
       if (output.includes(marker) && !settled) {
         settled = true;
         clearTimeout(timer);
@@ -154,7 +180,7 @@ async function main(): Promise<void> {
 
   const accounts = await api('/accounts');
   const account = Array.isArray(accounts.body)
-    ? accounts.body.find((candidate: any) => candidate.personal_account) ?? accounts.body[0]
+    ? (accounts.body.find((candidate: any) => candidate.personal_account) ?? accounts.body[0])
     : null;
   if (!account?.account_id) throw new Error(`personal account missing: ${accounts.text}`);
 
@@ -201,6 +227,26 @@ async function main(): Promise<void> {
   const { externalId } = await waitForSandbox();
   await waitForRuntime(externalId);
 
+  const stopped = await api(`/projects/${projectId}/sessions/${sessionId}/stop`, {
+    method: 'POST',
+    body: '{}',
+  });
+  if (stopped.status !== 200 || stopped.body?.status !== 'stopped') {
+    throw new Error(`session stop failed: ${stopped.status} ${stopped.text}`);
+  }
+  await waitForStoredSessionStatus('stopped');
+  log('session stopped', { externalId });
+
+  const resumed = await waitForSandbox();
+  if (resumed.externalId !== externalId) {
+    throw new Error(
+      `resume replaced the sandbox identity: before=${externalId} after=${resumed.externalId}`,
+    );
+  }
+  await waitForStoredSessionStatus('running');
+  await waitForRuntime(externalId);
+  log('session resumed in place', { externalId });
+
   const createdPty = await api(`/p/${externalId}/8000/kortix/pty`, {
     method: 'POST',
     body: JSON.stringify({ env: { TERM: 'xterm-256color', COLORTERM: 'truecolor' } }),
@@ -215,27 +261,39 @@ async function main(): Promise<void> {
   const wsUrl = `${wsBase}/p/${externalId}/8000/kortix/pty/${encodeURIComponent(ptyId)}/connect?token=${encodeURIComponent(token)}`;
   const first = await attachAndCollect(wsUrl, `printf '${marker}\\n'\n`);
   if (!first.output.includes(marker)) {
-    throw new Error(`first attach failed: close=${JSON.stringify(first.close)} output=${JSON.stringify(first.output)}`);
+    throw new Error(
+      `first attach failed: close=${JSON.stringify(first.close)} output=${JSON.stringify(first.output)}`,
+    );
   }
 
   const second = await attachAndCollect(wsUrl);
   if (!second.output.includes(marker)) {
-    throw new Error(`reconnect replay failed: close=${JSON.stringify(second.close)} output=${JSON.stringify(second.output)}`);
+    throw new Error(
+      `reconnect replay failed: close=${JSON.stringify(second.close)} output=${JSON.stringify(second.output)}`,
+    );
   }
 
   const listed = await api(`/p/${externalId}/8000/kortix/pty`);
-  if (!Array.isArray(listed.body) || !listed.body.some((pty: any) => pty.id === ptyId && pty.status === 'running')) {
+  if (
+    !Array.isArray(listed.body) ||
+    !listed.body.some((pty: any) => pty.id === ptyId && pty.status === 'running')
+  ) {
     throw new Error(`PTY list lost running terminal: ${listed.status} ${listed.text}`);
   }
 
-  const removed = await api(`/p/${externalId}/8000/kortix/pty/${encodeURIComponent(ptyId)}`, { method: 'DELETE' });
-  if (removed.status !== 200) throw new Error(`PTY delete failed: ${removed.status} ${removed.text}`);
+  const removed = await api(`/p/${externalId}/8000/kortix/pty/${encodeURIComponent(ptyId)}`, {
+    method: 'DELETE',
+  });
+  if (removed.status !== 200)
+    throw new Error(`PTY delete failed: ${removed.status} ${removed.text}`);
   log('PASS', { provider, marker, ptyId });
 }
 
 async function cleanup(): Promise<void> {
   if (sessionId && projectId) {
-    await api(`/projects/${projectId}/sessions/${sessionId}`, { method: 'DELETE' }).catch(() => null);
+    await api(`/projects/${projectId}/sessions/${sessionId}`, { method: 'DELETE' }).catch(
+      () => null,
+    );
   }
   if (projectId) {
     await api(`/projects/${projectId}`, { method: 'DELETE' }).catch(() => null);


### PR DESCRIPTION
## Problem

A Platinum sandbox can still report `stopped` while `start()` is transitioning it to running. The webhook, box reaper, or compute invariant can treat that transient state as a committed stop. This closes billing and stores the session as stopped while the provider VM later becomes running.

## Fix

- Add a 90-second runtime wake fence.
- Defer provider-stopped reconciliation and compute closure during that fence.
- Clear wake metadata on every committed stop.
- Make a manual stop win against a late successful start.
- Guard failed-start state and billing writes with the exact wake CAS.
- Accept Platinum lifecycle-transition responses during manual stop.
- Extend the real PTY smoke with stop and same-identity resume.

## Verification

- `pnpm test`: 5,739 pass, 65 skip, 0 fail across 546 files.
- Focused lifecycle suite after final rebase: 156 pass, 0 fail, 649 assertions.
- `pnpm typecheck`: pass.
- Biome production-source check: 7 files checked, 0 errors.
- Real pre-PR Platinum lifecycle: same sandbox identity and live PTY I/O.
- Real pre-PR Daytona lifecycle: same sandbox identity and live PTY I/O.

## Production billing audit

No ledger row is modified by this PR. The audited account contains historical exact-second duplicate bursts. The existing lump admin refund has no source debit IDs, so an additional credit is not safe without an explicit reimbursement population or conservative policy.