### PR TITLE
fix(suna-migration): write migrated sessions as 'completed' so they list

### DIFF
--- a/apps/api/src/__tests__/unit-session-inventory-migrated.test.ts
+++ b/apps/api/src/__tests__/unit-session-inventory-migrated.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { selectSessionRowsForViewer } from '../projects/lib/session-inventory';
+
+const subject = { userId: 'viewer-1', groupIds: [] } as any;
+
+function row(overrides: Record<string, unknown>) {
+  return {
+    sessionId: crypto.randomUUID(),
+    createdBy: 'owner-1',
+    visibility: 'project',
+    origin: 'user',
+    metadata: {},
+    ...overrides,
+  } as any;
+}
+
+describe('selectSessionRowsForViewer — migrated sessions', () => {
+  test("a migrated session (status 'completed', no runtime row) is listed", () => {
+    const migrated = row({ status: 'completed' });
+    const selected = selectSessionRowsForViewer({
+      rows: [migrated],
+      scope: 'visible',
+      canManageProject: false,
+      subject,
+      callerSessionId: null,
+      grantsBySession: new Map(),
+      runtimeStatusBySession: new Map(),
+    });
+    expect(selected.authorized).toBe(true);
+    expect(selected.items.map((i) => i.row.sessionId)).toEqual([migrated.sessionId]);
+    expect(selected.items[0]!.canAccess).toBe(true);
+  });
+
+  test("a 'stopped' session without a runtime row stays hidden", () => {
+    const selected = selectSessionRowsForViewer({
+      rows: [row({ status: 'stopped' })],
+      scope: 'visible',
+      canManageProject: false,
+      subject,
+      callerSessionId: null,
+      grantsBySession: new Map(),
+      runtimeStatusBySession: new Map(),
+    });
+    expect(selected.items).toEqual([]);
+  });
+});

--- a/apps/api/src/projects/suna-migration/suna-migration-phases.ts
+++ b/apps/api/src/projects/suna-migration/suna-migration-phases.ts
@@ -206,7 +206,11 @@ export async function dbStep(ctx: SunaMigrationContext): Promise<void> {
         sessionId: crypto.randomUUID(), accountId: ctx.accountId, projectId,
         branchName: s.slug, baseRef: defaultBranch, sandboxProvider: 'daytona',
         sandboxId: null, sandboxUrl: null, opencodeSessionId: s.opencodeSessionId,
-        agentName: 'default', status: 'stopped', createdBy: ctx.accountId, visibility: 'project',
+        // 'completed', NOT 'stopped': the default session list
+        // (selectSessionRowsForViewer) hides stopped sessions that have no
+        // session_sandboxes row — which is every migrated session until its
+        // first open — so 'stopped' makes the whole migration invisible.
+        agentName: 'default', status: 'completed', createdBy: ctx.accountId, visibility: 'project',
         metadata: {
           // Carry the legacy thread's own title over; nothing ever re-titles a
           // migrated session (it serves no first prompt), so without this every


### PR DESCRIPTION
## Problem

A completed suna-account migration produced a project that looked **empty**. The default session list (`selectSessionRowsForViewer`, `visible` scope) hides sessions with `status='stopped'` and no `session_sandboxes` row — and every migrated session is exactly that shape until its first open.

Observed on prod project `79d76143` (247 migrated sessions): only the 2 sessions that had already been opened (and therefore had runtime rows) appeared in `GET /projects/:id/sessions`; the other 245 were invisible to every viewer, including the account owner.

## Fix

Write migrated sessions as `status='completed'` instead of `'stopped'`:

- `'completed'` passes the visible-scope filter (`row.status !== 'stopped'`).
- Every lifecycle path already treats `'completed'` identically to `'stopped'`: `openSession` returns stage `stopped` for both, `continueSession` flips both to `running` on first message, restart provisions the same way.

The 247 existing prod rows were flipped to `'completed'` in place (verified: list as a project member now returns 247/247 with `can_access: true`). This PR fixes the writer for future migrations.

## Verification

- `bun test unit-session-inventory-migrated` — 2 pass: a `'completed'` row with no runtime row survives the visible-scope filter; a `'stopped'` one without runtime stays hidden (pins the regression).
- `tsc --noEmit` reports only the 5 pre-existing `src/apps/artifacts.ts` errors from #6227 (missing `tar` types); nothing from this change.
- Prod behavior after the in-place data fix: `GET /v1/projects/79d76143…/sessions` as a member returns `{count: 247, all_accessible: true}` (was 2).

Follow-up to #6235 (legacy rehydrate re-land).
