### PR TITLE
fix(billing): hold resume fence until provider runs

### DIFF
--- a/apps/api/src/__tests__/unit-setup-links.test.ts
+++ b/apps/api/src/__tests__/unit-setup-links.test.ts
@@ -5,8 +5,8 @@
  * (the HKDF input) is present.
  */
 import { describe, expect, test } from 'bun:test';
-import { mintSetupLink, resolveSetupLink } from '../setup-links/token';
 import { encryptProjectSecret } from '../projects/secrets';
+import { mintSetupLink, resolveSetupLink } from '../setup-links/token';
 
 const PROJECT_A = '11111111-1111-4111-8111-111111111111';
 const PROJECT_B = '22222222-2222-4222-8222-222222222222';
@@ -76,7 +76,7 @@ describe('setup-link token codec', () => {
       pid: PROJECT_A,
     };
     const envelope = encryptProjectSecret(PROJECT_A, JSON.stringify(payload));
-    const token = 'ksl_' + Buffer.from(`${PROJECT_A}.${envelope}`, 'utf8').toString('base64url');
+    const token = `ksl_${Buffer.from(`${PROJECT_A}.${envelope}`, 'utf8').toString('base64url')}`;
     const r = resolveSetupLink(token);
     expect(r.ok).toBe(false);
     if (r.ok) return;
@@ -98,7 +98,7 @@ describe('setup-link token codec', () => {
     const { token } = mintSetupLink(PROJECT_A, { kind: 'secret', fields: [{ name: 'FOO_KEY' }] });
     const decoded = Buffer.from(token.slice('ksl_'.length), 'base64url').toString('utf8');
     const envelope = decoded.slice(decoded.indexOf('.') + 1);
-    const reWrapped = 'ksl_' + Buffer.from(`${PROJECT_B}.${envelope}`, 'utf8').toString('base64url');
+    const reWrapped = `ksl_${Buffer.from(`${PROJECT_B}.${envelope}`, 'utf8').toString('base64url')}`;
     const r = resolveSetupLink(reWrapped);
     expect(r.ok).toBe(false);
   });
@@ -137,14 +137,14 @@ describe('setup-link token codec', () => {
     expect(r.payload.sid).toBeNull();
   });
 
-  test('default TTL is 24 hours (1440 minutes)', () => {
+  test('default secret-link TTL is 7 days', () => {
     const before = Date.now();
     const { expiresAt } = mintSetupLink(PROJECT_A, {
       kind: 'secret',
       fields: [{ name: 'FOO_KEY' }],
     });
     const ttlMs = expiresAt - before;
-    expect(ttlMs).toBeGreaterThan(24 * 60 * 60 * 1000 - 5000);
-    expect(ttlMs).toBeLessThan(24 * 60 * 60 * 1000 + 5000);
+    expect(ttlMs).toBeGreaterThan(7 * 24 * 60 * 60 * 1000 - 5000);
+    expect(ttlMs).toBeLessThan(7 * 24 * 60 * 60 * 1000 + 5000);
   });
 });

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -40,7 +40,10 @@ import {
   hasRuntimeReadinessClock,
   staleOpencodeReadyReason,
 } from '../session-lifecycle/readiness-clocks';
-import { RUNTIME_WAKE_GRACE_MS } from '../session-lifecycle/runtime-wake-fence';
+import {
+  RUNTIME_WAKE_GRACE_MS,
+  waitForRuntimeWakeRunning,
+} from '../session-lifecycle/runtime-wake-fence';
 
 /**
  * Resume a hibernated (status='stopped') session sandbox IN PLACE instead of
@@ -134,6 +137,47 @@ export async function resumeStoppedSandbox(row: {
   void provider
     .start(externalId)
     .then(async () => {
+      const stopCancelledWake = () =>
+        provider
+          .stop(externalId)
+          .catch((err) =>
+            console.warn(
+              `[projects] failed to re-stop cancelled wake ${externalId} for session ${row.sessionId}:`,
+              err,
+            ),
+          );
+      // Check wake ownership before any provider-state polling. A manual stop
+      // clears runtimeWakeId. Its CAS loss must re-stop a late start() now, not
+      // after the running-state poll expires.
+      const [acceptedWake] = await db
+        .update(sessionSandboxes)
+        .set({
+          metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${JSON.stringify({ runtimeWakeProviderStatus: 'accepted' })}::jsonb`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, row.sandboxId),
+            eq(sessionSandboxes.externalId, externalId),
+            eq(sessionSandboxes.status, 'active'),
+            sql`${sessionSandboxes.metadata}->>'runtimeWakeId' = ${runtimeWakeId}`,
+          ),
+        )
+        .returning({ sandboxId: sessionSandboxes.sandboxId })
+        .catch((err) => {
+          console.warn(`[runtime-identity] failed to accept wake for ${row.sessionId}:`, err);
+          return [] as Array<{ sandboxId: string }>;
+        });
+      if (!acceptedWake) {
+        await stopCancelledWake();
+        return;
+      }
+      // Platinum can acknowledge start while getStatus() still reports the
+      // previous stopped state. Keep the wake fence until the provider proves
+      // the runtime is running. Clearing it on acknowledgement lets the next
+      // status poll close this meter and start a second wake for one resume.
+      const providerRunning = await waitForRuntimeWakeRunning(() => provider.getStatus(externalId));
+      if (!providerRunning) return;
       const [completedWake] = await db
         .update(sessionSandboxes)
         .set({
@@ -157,14 +201,7 @@ export async function resumeStoppedSandbox(row: {
         // A real stop won while start() was in flight. The first provider.stop()
         // can finish before this late start, so enforce the user's stopped state
         // once more after start() resolves.
-        await provider
-          .stop(externalId)
-          .catch((err) =>
-            console.warn(
-              `[projects] failed to re-stop cancelled wake ${externalId} for session ${row.sessionId}:`,
-              err,
-            ),
-          );
+        await stopCancelledWake();
       }
     })
     .catch(async (err) => {

--- a/apps/api/src/projects/session-lifecycle/runtime-wake-fence.test.ts
+++ b/apps/api/src/projects/session-lifecycle/runtime-wake-fence.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { waitForRuntimeWakeRunning } from './runtime-wake-fence';
+
+describe('waitForRuntimeWakeRunning', () => {
+  test('keeps the wake fence after start acceptance until the provider reports running', async () => {
+    const statuses = ['stopped', 'stopped', 'running'];
+    let calls = 0;
+    let sleeps = 0;
+
+    const running = await waitForRuntimeWakeRunning(async () => statuses[calls++] ?? 'running', {
+      graceMs: 3_000,
+      pollMs: 1_000,
+      sleep: async () => {
+        sleeps += 1;
+      },
+    });
+
+    expect(running).toBe(true);
+    expect(calls).toBe(3);
+    expect(sleeps).toBe(2);
+  });
+
+  test('returns false when the transition never reaches running', async () => {
+    let calls = 0;
+    const running = await waitForRuntimeWakeRunning(
+      async () => {
+        calls += 1;
+        return 'stopped';
+      },
+      { graceMs: 3_000, pollMs: 1_000, sleep: async () => {} },
+    );
+
+    expect(running).toBe(false);
+    expect(calls).toBe(3);
+  });
+
+  test('stops polling when the provider reports removed', async () => {
+    let calls = 0;
+    const running = await waitForRuntimeWakeRunning(
+      async () => {
+        calls += 1;
+        return 'removed';
+      },
+      { graceMs: 90_000, pollMs: 1_000, sleep: async () => {} },
+    );
+
+    expect(running).toBe(false);
+    expect(calls).toBe(1);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/runtime-wake-fence.ts
+++ b/apps/api/src/projects/session-lifecycle/runtime-wake-fence.ts
@@ -5,6 +5,29 @@
  * leaves a later provider-running VM recorded as stopped.
  */
 export const RUNTIME_WAKE_GRACE_MS = 90_000;
+const RUNTIME_WAKE_POLL_MS = 1_000;
+
+export async function waitForRuntimeWakeRunning(
+  getStatus: () => Promise<string>,
+  opts: {
+    graceMs?: number;
+    pollMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<boolean> {
+  const graceMs = Math.max(0, opts.graceMs ?? RUNTIME_WAKE_GRACE_MS);
+  const pollMs = Math.max(1, opts.pollMs ?? RUNTIME_WAKE_POLL_MS);
+  const attempts = Math.max(1, Math.ceil(graceMs / pollMs));
+  const sleep = opts.sleep ?? Bun.sleep;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const status = await getStatus().catch(() => 'unknown');
+    if (status === 'running') return true;
+    if (status === 'removed') return false;
+    if (attempt + 1 < attempts) await sleep(pollMs);
+  }
+  return false;
+}
 
 export function runtimeWakeInProgress(
   metadata: Record<string, unknown> | null | undefined,

--- a/tests/e2e/scripts/terminal-pty-smoke.ts
+++ b/tests/e2e/scripts/terminal-pty-smoke.ts
@@ -9,7 +9,14 @@
  * Run with the isolated stack up:
  *   dotenvx run -f apps/api/.env -f apps/web/.env -- \
  *     node --experimental-strip-types tests/e2e/scripts/terminal-pty-smoke.ts platinum
+ *
+ * Set E2E_ASSERT_COMPUTE_BILLING=1 and DATABASE_URL to convert the disposable
+ * account to the `credit` billing model and assert the persisted compute meter
+ * plus matching ledger debits. This mode is intended for local/dev only.
  */
+
+import { Client } from 'pg';
+import { getProviderComputeRateCard } from '../../../apps/api/src/platform/providers/compute-rates.ts';
 
 const provider = process.argv[2];
 if (provider !== 'platinum' && provider !== 'daytona') {
@@ -20,10 +27,21 @@ const apiBase = process.env.E2E_API_URL ?? 'http://localhost:23308/v1';
 const supabaseBase = process.env.E2E_SUPABASE_URL ?? 'http://127.0.0.1:54321';
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const assertComputeBilling = process.env.E2E_ASSERT_COMPUTE_BILLING === '1';
+const databaseUrl = process.env.DATABASE_URL;
 
 if (!serviceRoleKey || !anonKey) {
   throw new Error('SUPABASE_SERVICE_ROLE_KEY and NEXT_PUBLIC_SUPABASE_ANON_KEY are required');
 }
+if (assertComputeBilling && !databaseUrl) {
+  throw new Error('DATABASE_URL is required when E2E_ASSERT_COMPUTE_BILLING=1');
+}
+
+const authServiceRoleKey = serviceRoleKey;
+const authAnonKey = anonKey;
+const dbClient =
+  assertComputeBilling && databaseUrl ? new Client({ connectionString: databaseUrl }) : null;
+if (dbClient) await dbClient.connect();
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const deadline = (ms: number) => Date.now() + ms;
@@ -31,6 +49,33 @@ const marker = `KORTIX_PTY_${provider.toUpperCase()}_${Date.now()}`;
 let token = '';
 let projectId = '';
 let sessionId = '';
+let accountId = '';
+
+interface ComputeRow {
+  id: string;
+  provider: string;
+  state: string;
+  started_at: Date;
+  ended_at: Date | null;
+  last_billed_at: Date;
+  cost_usd: string;
+  cpu_cores: number;
+  memory_gb: number;
+  disk_gb: number;
+}
+
+async function dbQuery<T extends Record<string, unknown>>(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): Promise<T[]> {
+  if (!dbClient) return [];
+  let text = strings[0] ?? '';
+  for (let index = 0; index < values.length; index += 1) {
+    text += `$${index + 1}${strings[index + 1] ?? ''}`;
+  }
+  const result = await dbClient.query<T>(text, values);
+  return result.rows;
+}
 
 function log(message: string, details?: unknown): void {
   console.log(`[terminal-pty:${provider}] ${message}`, details ?? '');
@@ -39,9 +84,11 @@ function log(message: string, details?: unknown): void {
 async function jsonRequest(
   url: string,
   init: RequestInit = {},
+  // biome-ignore lint/suspicious/noExplicitAny: black-box API payload
 ): Promise<{ status: number; body: any; text: string }> {
   const response = await fetch(url, init);
   const text = await response.text();
+  // biome-ignore lint/suspicious/noExplicitAny: black-box API payload
   let body: any = null;
   try {
     body = text ? JSON.parse(text) : null;
@@ -104,6 +151,82 @@ async function waitForStoredSessionStatus(expected: string): Promise<void> {
   throw new Error(`stored session status did not become ${expected}: ${last}`);
 }
 
+async function computeRows(): Promise<ComputeRow[]> {
+  if (!dbClient) return [];
+  return dbQuery<ComputeRow>`
+    SELECT id, provider, state, started_at, ended_at, last_billed_at,
+           cost_usd, cpu_cores, memory_gb, disk_gb
+    FROM kortix.sandbox_compute_sessions
+    WHERE session_id = ${sessionId}
+    ORDER BY started_at
+  `;
+}
+
+async function waitForComputeRows(opts: {
+  total: number;
+  open: number;
+  finalState?: string;
+}): Promise<ComputeRow[]> {
+  const end = deadline(30_000);
+  let rows: ComputeRow[] = [];
+  while (Date.now() < end) {
+    rows = await computeRows();
+    const open = rows.filter((row) => row.ended_at === null).length;
+    if (
+      rows.length === opts.total &&
+      open === opts.open &&
+      (!opts.finalState || rows.at(-1)?.state === opts.finalState)
+    ) {
+      return rows;
+    }
+    await sleep(250);
+  }
+  throw new Error(
+    `compute rows did not converge: expected=${JSON.stringify(opts)} actual=${JSON.stringify(rows)}`,
+  );
+}
+
+function expectedComputeCost(row: ComputeRow): number {
+  const durationSeconds =
+    (new Date(row.last_billed_at).getTime() - new Date(row.started_at).getTime()) / 1000;
+  const rate = getProviderComputeRateCard(provider);
+  return (
+    row.cpu_cores * rate.cpuPerCoreSecond * durationSeconds +
+    row.memory_gb * rate.memoryPerGbSecond * durationSeconds +
+    row.disk_gb * rate.diskPerGbSecond * durationSeconds
+  );
+}
+
+async function assertSettledWindow(row: ComputeRow): Promise<void> {
+  if (!dbClient) return;
+  const actualCost = Number(row.cost_usd);
+  const expectedCost = expectedComputeCost(row);
+  if (actualCost <= 0 || Math.abs(actualCost - expectedCost) > 0.000001) {
+    throw new Error(
+      `compute cost mismatch: meter=${row.id} actual=${actualCost} expected=${expectedCost}`,
+    );
+  }
+  const ledger = await dbQuery<{
+    count: number;
+    debit: string;
+    idempotency_key: string | null;
+  }>`
+    SELECT count(*)::int AS count,
+           coalesce(sum(abs(amount_precise)), 0)::text AS debit,
+           min(idempotency_key) AS idempotency_key
+    FROM kortix.credit_ledger
+    WHERE account_id = ${accountId}
+      AND metadata->>'ledger_type' = 'compute_debit'
+      AND idempotency_key LIKE ${`compute:${row.id}:%`}
+  `;
+  const debit = Number(ledger[0]?.debit ?? 0);
+  if (ledger[0]?.count !== 1 || Math.abs(debit - expectedCost) > 0.0000001) {
+    throw new Error(
+      `compute ledger mismatch: meter=${row.id} rows=${ledger[0]?.count} debit=${debit} expected=${expectedCost}`,
+    );
+  }
+}
+
 async function attachAndCollect(
   wsUrl: string,
   input?: string,
@@ -160,8 +283,8 @@ async function main(): Promise<void> {
   const createdUser = await jsonRequest(`${supabaseBase}/auth/v1/admin/users`, {
     method: 'POST',
     headers: {
-      apikey: serviceRoleKey!,
-      Authorization: `Bearer ${serviceRoleKey}`,
+      apikey: authServiceRoleKey,
+      Authorization: `Bearer ${authServiceRoleKey}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ email, password, email_confirm: true }),
@@ -172,7 +295,7 @@ async function main(): Promise<void> {
 
   const grant = await jsonRequest(`${supabaseBase}/auth/v1/token?grant_type=password`, {
     method: 'POST',
-    headers: { apikey: anonKey!, 'Content-Type': 'application/json' },
+    headers: { apikey: authAnonKey, 'Content-Type': 'application/json' },
     body: JSON.stringify({ email, password }),
   });
   token = grant.body?.access_token ?? '';
@@ -180,9 +303,23 @@ async function main(): Promise<void> {
 
   const accounts = await api('/accounts');
   const account = Array.isArray(accounts.body)
-    ? (accounts.body.find((candidate: any) => candidate.personal_account) ?? accounts.body[0])
+    ? // biome-ignore lint/suspicious/noExplicitAny: black-box API payload
+      (accounts.body.find((candidate: any) => candidate.personal_account) ?? accounts.body[0])
     : null;
   if (!account?.account_id) throw new Error(`personal account missing: ${accounts.text}`);
+  accountId = account.account_id;
+  if (dbClient) {
+    const updated = await dbQuery<{ balance: string }>`
+      UPDATE kortix.credit_accounts
+      SET billing_model = 'credit', updated_at = now()
+      WHERE account_id = ${accountId}
+      RETURNING balance::text
+    `;
+    if (updated.length !== 1 || Number(updated[0]?.balance) <= 0) {
+      throw new Error(`credit billing setup failed for account ${accountId}`);
+    }
+    log('credit billing enabled', { accountId, balance: Number(updated[0]?.balance) });
+  }
 
   const project = await api('/projects/provision', {
     method: 'POST',
@@ -209,6 +346,7 @@ async function main(): Promise<void> {
     while (Date.now() < reconcileEnd) {
       const listed = await api(`/projects/${projectId}/sessions`);
       const items = Array.isArray(listed.body) ? listed.body : (listed.body?.sessions ?? []);
+      // biome-ignore lint/suspicious/noExplicitAny: black-box API payload
       const created = items.find((item: any) => item.name === sessionName);
       if (created) {
         session = { status: 201, body: created, text: JSON.stringify(created) };
@@ -226,6 +364,14 @@ async function main(): Promise<void> {
 
   const { externalId } = await waitForSandbox();
   await waitForRuntime(externalId);
+  if (dbClient) {
+    const runningRows = await waitForComputeRows({ total: 1, open: 1 });
+    if (runningRows[0]?.provider !== provider || runningRows[0]?.state !== 'active') {
+      throw new Error(`initial compute meter mismatch: ${JSON.stringify(runningRows)}`);
+    }
+    log('initial compute meter open', { meterId: runningRows[0].id });
+    await sleep(5_000);
+  }
 
   const stopped = await api(`/projects/${projectId}/sessions/${sessionId}/stop`, {
     method: 'POST',
@@ -236,6 +382,23 @@ async function main(): Promise<void> {
   }
   await waitForStoredSessionStatus('stopped');
   log('session stopped', { externalId });
+  let stoppedRows: ComputeRow[] = [];
+  if (dbClient) {
+    stoppedRows = await waitForComputeRows({ total: 1, open: 0, finalState: 'stopped' });
+    const stoppedRow = stoppedRows[0];
+    if (!stoppedRow) throw new Error('stopped compute meter missing');
+    await assertSettledWindow(stoppedRow);
+    const stoppedSnapshot = JSON.stringify(stoppedRows);
+    await sleep(5_000);
+    const afterStoppedWait = await computeRows();
+    if (JSON.stringify(afterStoppedWait) !== stoppedSnapshot) {
+      throw new Error('compute meter changed while the session was stopped');
+    }
+    log('stopped compute meter is stable', {
+      meterId: stoppedRow.id,
+      costUsd: Number(stoppedRow.cost_usd),
+    });
+  }
 
   const resumed = await waitForSandbox();
   if (resumed.externalId !== externalId) {
@@ -246,6 +409,14 @@ async function main(): Promise<void> {
   await waitForStoredSessionStatus('running');
   await waitForRuntime(externalId);
   log('session resumed in place', { externalId });
+  if (dbClient) {
+    const resumedRows = await waitForComputeRows({ total: 2, open: 1 });
+    if (resumedRows[0]?.id !== stoppedRows[0]?.id || resumedRows[1]?.provider !== provider) {
+      throw new Error(`resumed compute meter mismatch: ${JSON.stringify(resumedRows)}`);
+    }
+    log('resume opened one compute meter', { meterId: resumedRows[1]?.id });
+    await sleep(5_000);
+  }
 
   const createdPty = await api(`/p/${externalId}/8000/kortix/pty`, {
     method: 'POST',
@@ -276,6 +447,7 @@ async function main(): Promise<void> {
   const listed = await api(`/p/${externalId}/8000/kortix/pty`);
   if (
     !Array.isArray(listed.body) ||
+    // biome-ignore lint/suspicious/noExplicitAny: black-box API payload
     !listed.body.some((pty: any) => pty.id === ptyId && pty.status === 'running')
   ) {
     throw new Error(`PTY list lost running terminal: ${listed.status} ${listed.text}`);
@@ -286,6 +458,24 @@ async function main(): Promise<void> {
   });
   if (removed.status !== 200)
     throw new Error(`PTY delete failed: ${removed.status} ${removed.text}`);
+  if (dbClient) {
+    const deleted = await api(`/projects/${projectId}/sessions/${sessionId}`, { method: 'DELETE' });
+    if (deleted.status < 200 || deleted.status >= 300) {
+      throw new Error(`session delete failed: ${deleted.status} ${deleted.text}`);
+    }
+    const closedRows = await waitForComputeRows({ total: 2, open: 0 });
+    const closedRow = closedRows[1];
+    if (!closedRow || !['stopped', 'finalized'].includes(closedRow.state)) {
+      throw new Error(`closed compute meter missing: ${JSON.stringify(closedRows)}`);
+    }
+    await assertSettledWindow(closedRow);
+    sessionId = '';
+    log('delete closed compute billing', {
+      meterId: closedRow.id,
+      state: closedRow.state,
+      costUsd: Number(closedRow.cost_usd),
+    });
+  }
   log('PASS', { provider, marker, ptyId });
 }
 
@@ -303,5 +493,9 @@ async function cleanup(): Promise<void> {
 try {
   await main();
 } finally {
-  await cleanup();
+  try {
+    await cleanup();
+  } finally {
+    await dbClient?.end();
+  }
 }


### PR DESCRIPTION
## Problem

Platinum can acknowledge `start()` while `getStatus()` still reports the prior stopped state. The resume path cleared `runtimeWakeId` on acknowledgement. A concurrent status poll then closed the new compute meter and initiated another wake. A live dev run produced two resumed meters for one resume.

## Fix

- Keep the 90-second wake fence until the provider reports `running`.
- CAS wake ownership immediately after `start()` resolves.
- Re-stop a late provider start when a manual stop already cleared the fence.
- Add deterministic wake polling tests.
- Extend the real provider PTY smoke with persisted meter, ledger, stopped-time, rate-math, identity, and delete-close assertions.

## Verification

- `pnpm exec biome check ...` — pass
- `pnpm --filter kortix-api typecheck` — pass
- Focused lifecycle/reaper suites — 100 pass, 0 fail
- Manual-stop regression — 1 pass, 0 fail
- Full API run — 5,735 pass, 65 skip; 7 unrelated host-load timeout failures
- All 7 timed-out tests rerun alone — 39 pass, 0 fail
- Pre-fix deployed Platinum billing smoke deterministically reproduced the duplicate resumed meter.

## Live evidence

Initial meter `9f817552-43fd-4d69-a3c9-9ac7df58480b` closed normally. One resume then created `36f6d843-5108-4170-8c70-c43b0170354d`, closed it after 0.890 seconds, and created `209e9dd9-50a3-4978-8ddc-64adf00e221e`. This PR prevents clearing the fence during that provider transition.