### PR TITLE
fix(billing): close compute windows atomically

### DIFF
--- a/apps/api/src/__tests__/billing/e2e-compute-metering.test.ts
+++ b/apps/api/src/__tests__/billing/e2e-compute-metering.test.ts
@@ -49,6 +49,10 @@ interface InMemorySession {
 let sessions: InMemorySession[] = [];
 let debitCalls: { accountId: string; amount: number; description: string; ledgerType: string }[] = [];
 let simulateUniqueViolationOnInsert = false;
+let holdFirstDebit = false;
+let releaseFirstDebit: (() => void) | null = null;
+let firstDebitStarted: Promise<void> = Promise.resolve();
+let signalFirstDebitStarted: (() => void) | null = null;
 
 mock.module('../../billing/repositories/compute-sessions', () => ({
   insertComputeSession: async (data: any) => {
@@ -100,6 +104,7 @@ mock.module('../../billing/repositories/compute-sessions', () => ({
     expectedLastBilledAt: string;
     nextLastBilledAt: string;
     addCostUsd: number;
+    terminalState?: 'stopped' | 'finalized';
   }) => {
     const row = sessions.find((r: any) => r.id === input.id);
     if (!row) return false;
@@ -107,6 +112,10 @@ mock.module('../../billing/repositories/compute-sessions', () => ({
     if (row.lastBilledAt !== input.expectedLastBilledAt) return false;
     row.lastBilledAt = input.nextLastBilledAt;
     row.costUsd = String(Number(row.costUsd ?? 0) + input.addCostUsd);
+    if (input.terminalState) {
+      row.state = input.terminalState;
+      row.endedAt = input.nextLastBilledAt;
+    }
     return true;
   },
   releaseComputeWindow: async (input: {
@@ -114,18 +123,18 @@ mock.module('../../billing/repositories/compute-sessions', () => ({
     claimedLastBilledAt: string;
     revertToLastBilledAt: string;
     subCostUsd: number;
+    terminalState?: 'stopped' | 'finalized';
   }) => {
     const row = sessions.find((r: any) => r.id === input.id);
     if (!row) return false;
     if (row.lastBilledAt !== input.claimedLastBilledAt) return false;
     row.lastBilledAt = input.revertToLastBilledAt;
     row.costUsd = String(Number(row.costUsd ?? 0) - input.subCostUsd);
+    if (input.terminalState) {
+      row.state = 'active';
+      row.endedAt = null;
+    }
     return true;
-  },
-  updateComputeSession: async (id: string, patch: any) => {
-    const row = sessions.find((s) => s.id === id);
-    if (!row) return;
-    Object.assign(row, patch, { updatedAt: new Date().toISOString() });
   },
   findStaleActiveSessions: async (cutoff: Date) =>
     sessions.filter(
@@ -141,6 +150,12 @@ mock.module('../../billing/services/credits', () => ({
   getCreditSummary: async () => ({ total: 0, daily: 0, monthly: 0, extra: 0, canRun: true }),
   deductCredits: async (accountId: string, amount: number, description: string, ledgerType = 'usage') => {
     debitCalls.push({ accountId, amount, description, ledgerType });
+    if (holdFirstDebit && debitCalls.length === 1) {
+      signalFirstDebitStarted?.();
+      await new Promise<void>((resolve) => {
+        releaseFirstDebit = resolve;
+      });
+    }
     return { success: true, cost: amount, newBalance: 0, transactionId: 'tx_test' };
   },
   deductForLlmUsage: async () => ({ success: true, cost: 0, newBalance: 0, transactionId: null }),
@@ -164,6 +179,11 @@ beforeEach(() => {
   sessions = [];
   debitCalls = [];
   simulateUniqueViolationOnInsert = false;
+  holdFirstDebit = false;
+  releaseFirstDebit = null;
+  firstDebitStarted = new Promise<void>((resolve) => {
+    signalFirstDebitStarted = resolve;
+  });
   resetMockRegistry();
   // Default to a per-seat account so metering engages.
   mockRegistry.getCreditAccount = async () =>
@@ -209,6 +229,35 @@ describe('compute metering — per-seat happy path', () => {
 
     expect(sessions[0].state).toBe('stopped');
     expect(sessions[0].endedAt).not.toBeNull();
+  });
+
+  test('concurrent closes use one terminal cutoff and cannot bill past ended_at', async () => {
+    await startComputeSession({
+      sandboxId: 'sb_close_race',
+      accountId: 'acc_test_123',
+      spec: SPEC,
+    });
+
+    const initialCursor = new Date(Date.now() - 5_000);
+    const firstCutoff = new Date(initialCursor.getTime() + 1_000);
+    const secondCutoff = new Date(initialCursor.getTime() + 2_000);
+    sessions[0].lastBilledAt = initialCursor.toISOString();
+    holdFirstDebit = true;
+
+    const firstClose = pauseComputeSession('sb_close_race', firstCutoff);
+    await firstDebitStarted;
+
+    // The first debit is deliberately held between the cursor claim and the
+    // old non-atomic ended_at write. A second closer can otherwise claim the
+    // next 1s window and close later before the first caller writes backwards.
+    await pauseComputeSession('sb_close_race', secondCutoff);
+    releaseFirstDebit?.();
+    await firstClose;
+
+    expect(debitCalls).toHaveLength(1);
+    expect(sessions[0].state).toBe('stopped');
+    expect(sessions[0].lastBilledAt).toBe(firstCutoff.toISOString());
+    expect(sessions[0].endedAt).toBe(firstCutoff.toISOString());
   });
 
   test('resume opens a brand new row, old row stays closed', async () => {

--- a/apps/api/src/billing/repositories/compute-sessions.ts
+++ b/apps/api/src/billing/repositories/compute-sessions.ts
@@ -1,5 +1,5 @@
-import { and, asc, desc, eq, isNull, lte, sql } from 'drizzle-orm';
 import { sandboxComputeSessions } from '@kortix/db';
+import { and, asc, desc, eq, isNull, lte, sql } from 'drizzle-orm';
 import { db } from '../../shared/db';
 
 export interface SandboxSpec {
@@ -44,16 +44,6 @@ export async function getLatestComputeSession(sandboxId: string) {
   return row ?? null;
 }
 
-export async function updateComputeSession(
-  id: string,
-  patch: Partial<typeof sandboxComputeSessions.$inferInsert>,
-) {
-  await db
-    .update(sandboxComputeSessions)
-    .set({ ...patch, updatedAt: new Date().toISOString() })
-    .where(eq(sandboxComputeSessions.id, id));
-}
-
 /**
  * Find active sessions whose `last_billed_at` is older than `cutoff`.
  * Used by the cron tick to partially bill long-running sandboxes so a missed
@@ -93,14 +83,15 @@ export async function findStaleActiveSessions(cutoff: Date, limit = 100) {
  * hooks on other replicas.
  *
  * So the cursor move IS the lock. `last_billed_at` must still equal the value
- * the caller read, and the row must still be open. `cost_usd` accumulates in
- * SQL rather than from an in-memory `Number(row.costUsd) + windowCost`, which
- * had the same lost-update flaw one column over.
+ * the caller read, and the row must still be open. A terminal claim also writes
+ * `state` and `ended_at` in this statement. `cost_usd` accumulates in SQL rather
+ * than from an in-memory `Number(row.costUsd) + windowCost`, which had the same
+ * lost-update flaw one column over.
  *
  * Returns true when this caller owns the window and may bill it. False means
  * somebody else already did — bill nothing.
  */
-export async function claimComputeWindow(input: {
+export interface ClaimComputeWindowInput {
   id: string;
   /** The `last_billed_at` the caller based its window on. */
   expectedLastBilledAt: string;
@@ -108,12 +99,20 @@ export async function claimComputeWindow(input: {
   nextLastBilledAt: string;
   /** Added to `cost_usd` in SQL. May be 0 for a zero-cost window. */
   addCostUsd: number;
-}): Promise<boolean> {
-  const rows = await db
+  /** Atomically closes the row at `nextLastBilledAt` when this is a terminal settle. */
+  terminalState?: 'stopped' | 'finalized';
+}
+
+/** Exported query builder so the terminal CAS predicate is tested as rendered SQL. */
+export function buildClaimComputeWindowQuery(input: ClaimComputeWindowInput) {
+  return db
     .update(sandboxComputeSessions)
     .set({
       lastBilledAt: input.nextLastBilledAt,
       costUsd: sql`${sandboxComputeSessions.costUsd} + ${String(input.addCostUsd)}::numeric`,
+      ...(input.terminalState
+        ? { state: input.terminalState, endedAt: input.nextLastBilledAt }
+        : {}),
       updatedAt: new Date().toISOString(),
     })
     .where(
@@ -124,6 +123,10 @@ export async function claimComputeWindow(input: {
       ),
     )
     .returning({ id: sandboxComputeSessions.id });
+}
+
+export async function claimComputeWindow(input: ClaimComputeWindowInput): Promise<boolean> {
+  const rows = await buildClaimComputeWindowQuery(input);
   return rows.length > 0;
 }
 
@@ -134,32 +137,48 @@ export async function claimComputeWindow(input: {
  * behaviour: an out-of-credits account must be able to retry the same seconds
  * once its wallet can pay, rather than silently forfeiting them.
  *
- * Also CAS'd. If another settler has since moved the cursor past our value we
- * do NOT force it back — that would re-open the window for double billing,
- * trading a revenue loss for a customer overcharge. Losing this race forfeits
- * the seconds, which is the safe direction.
+ * Also CAS'd. A partial release requires an open row. A terminal release
+ * requires the exact terminal state and timestamp it wrote, then reopens the
+ * row for the invariant sweep. If another settler moved the cursor, do NOT
+ * force it back. That would re-open the window for double billing.
  */
-export async function releaseComputeWindow(input: {
+export interface ReleaseComputeWindowInput {
   id: string;
   /** The cursor value this caller wrote when it claimed. */
   claimedLastBilledAt: string;
   /** Where to put the cursor back. */
   revertToLastBilledAt: string;
   subCostUsd: number;
-}): Promise<boolean> {
-  const rows = await db
+  /** Reopens a row whose terminal claim could not be debited. */
+  terminalState?: 'stopped' | 'finalized';
+}
+
+/** Exported query builder so release cannot silently reopen a closed unrelated row. */
+export function buildReleaseComputeWindowQuery(input: ReleaseComputeWindowInput) {
+  return db
     .update(sandboxComputeSessions)
     .set({
       lastBilledAt: input.revertToLastBilledAt,
       costUsd: sql`${sandboxComputeSessions.costUsd} - ${String(input.subCostUsd)}::numeric`,
+      ...(input.terminalState ? { state: 'active' as const, endedAt: null } : {}),
       updatedAt: new Date().toISOString(),
     })
     .where(
       and(
         eq(sandboxComputeSessions.id, input.id),
         eq(sandboxComputeSessions.lastBilledAt, input.claimedLastBilledAt),
+        input.terminalState
+          ? and(
+              eq(sandboxComputeSessions.state, input.terminalState),
+              eq(sandboxComputeSessions.endedAt, input.claimedLastBilledAt),
+            )
+          : isNull(sandboxComputeSessions.endedAt),
       ),
     )
     .returning({ id: sandboxComputeSessions.id });
+}
+
+export async function releaseComputeWindow(input: ReleaseComputeWindowInput): Promise<boolean> {
+  const rows = await buildReleaseComputeWindowQuery(input);
   return rows.length > 0;
 }

--- a/apps/api/src/billing/services/compute-metering-query.test.ts
+++ b/apps/api/src/billing/services/compute-metering-query.test.ts
@@ -23,6 +23,57 @@ mock.module('../../shared/db', () => ({ db: drizzle(client) }));
 
 const { selectMissingAppComputeCandidates, selectMissingComputeCandidates } = await import('./compute-metering');
 const { selectOpenComputeInvariantCandidates } = await import('./compute-invariant-sweep');
+const { buildClaimComputeWindowQuery, buildReleaseComputeWindowQuery } = await import(
+  '../repositories/compute-sessions'
+);
+
+const T0 = '2026-08-07T18:52:18.948Z';
+const T1 = '2026-08-07T18:52:41.710Z';
+
+describe('compute window compare-and-set SQL', () => {
+  test('terminal claim moves the cursor and closes the row in one update', () => {
+    const { sql, params } = buildClaimComputeWindowQuery({
+      id: 'meter-1',
+      expectedLastBilledAt: T0,
+      nextLastBilledAt: T1,
+      addCostUsd: 0.001,
+      terminalState: 'stopped',
+    }).toSQL();
+
+    expect(sql).toMatch(/set .*state.*ended_at.*last_billed_at.*cost_usd/);
+    expect(sql).toMatch(/ended_at.*is null/);
+    expect(sql).toMatch(/last_billed_at.*=/);
+    expect(params).toContain('stopped');
+    expect(params.filter((value) => value === T1)).toHaveLength(2);
+  });
+
+  test('terminal release only reopens the exact failed terminal claim', () => {
+    const { sql, params } = buildReleaseComputeWindowQuery({
+      id: 'meter-1',
+      claimedLastBilledAt: T1,
+      revertToLastBilledAt: T0,
+      subCostUsd: 0.001,
+      terminalState: 'stopped',
+    }).toSQL();
+
+    expect(sql).toMatch(/set .*last_billed_at.*cost_usd.*state.*ended_at/);
+    expect(sql).toMatch(/state.*=.*ended_at.*=/);
+    expect(params).toContain('active');
+    expect(params).toContain('stopped');
+    expect(params.filter((value) => value === T1)).toHaveLength(2);
+  });
+
+  test('partial release cannot move the cursor after a terminal close', () => {
+    const { sql } = buildReleaseComputeWindowQuery({
+      id: 'meter-1',
+      claimedLastBilledAt: T1,
+      revertToLastBilledAt: T0,
+      subCostUsd: 0.001,
+    }).toSQL();
+
+    expect(sql).toMatch(/ended_at.*is null/);
+  });
+});
 
 describe('reconcile candidate predicate', () => {
   const rendered = () => selectMissingComputeCandidates(100).toSQL();

--- a/apps/api/src/billing/services/compute-metering.test.ts
+++ b/apps/api/src/billing/services/compute-metering.test.ts
@@ -98,6 +98,7 @@ mock.module('../repositories/compute-sessions', () => ({
     expectedLastBilledAt: string;
     nextLastBilledAt: string;
     addCostUsd: number;
+    terminalState?: 'stopped' | 'finalized';
   }) => {
     const row = computeRows.find((r: any) => r.id === input.id);
     if (!row) return false;
@@ -105,6 +106,10 @@ mock.module('../repositories/compute-sessions', () => ({
     if (row.lastBilledAt !== input.expectedLastBilledAt) return false;
     row.lastBilledAt = input.nextLastBilledAt;
     row.costUsd = String(Number(row.costUsd ?? 0) + input.addCostUsd);
+    if (input.terminalState) {
+      row.state = input.terminalState;
+      row.endedAt = input.nextLastBilledAt;
+    }
     return true;
   },
   releaseComputeWindow: async (input: {
@@ -112,15 +117,19 @@ mock.module('../repositories/compute-sessions', () => ({
     claimedLastBilledAt: string;
     revertToLastBilledAt: string;
     subCostUsd: number;
+    terminalState?: 'stopped' | 'finalized';
   }) => {
     const row = computeRows.find((r: any) => r.id === input.id);
     if (!row) return false;
     if (row.lastBilledAt !== input.claimedLastBilledAt) return false;
     row.lastBilledAt = input.revertToLastBilledAt;
     row.costUsd = String(Number(row.costUsd ?? 0) - input.subCostUsd);
+    if (input.terminalState) {
+      row.state = 'active';
+      row.endedAt = null;
+    }
     return true;
   },
-  updateComputeSession: async () => {},
   findStaleActiveSessions: async () => [],
 }));
 

--- a/apps/api/src/billing/services/compute-metering.ts
+++ b/apps/api/src/billing/services/compute-metering.ts
@@ -19,7 +19,6 @@
 // bills any session whose last_billed_at is > 1 hour ago, so a missed close
 // hook can never silently accrue 24h+ of uncharged compute.
 
-import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import {
   appDeployments,
   appRuntimes,
@@ -28,19 +27,19 @@ import {
   sandboxComputeSessions,
   sessionSandboxes,
 } from '@kortix/db';
+import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { config } from '../../config';
-import { getProvider, type ProviderName } from '../../platform/providers';
+import { type ProviderName, getProvider } from '../../platform/providers';
 import { getProviderComputeRateCard } from '../../platform/providers/compute-rates';
 import { db } from '../../shared/db';
 import {
-  insertComputeSession,
-  getOpenComputeSession,
-  getLatestComputeSession,
-  updateComputeSession,
-  claimComputeWindow,
-  releaseComputeWindow,
-  findStaleActiveSessions,
   type SandboxSpec,
+  claimComputeWindow,
+  findStaleActiveSessions,
+  getLatestComputeSession,
+  getOpenComputeSession,
+  insertComputeSession,
+  releaseComputeWindow,
 } from '../repositories/compute-sessions';
 import { getCreditAccount } from '../repositories/credit-accounts';
 import {
@@ -133,13 +132,15 @@ export async function startComputeSession(opts: StartComputeOpts): Promise<strin
 
 /**
  * Bill a partial window without closing the row. Updates `cost_usd` and
- * `last_billed_at`, emits a `compute_debit` ledger entry, returns new cost.
+ * `last_billed_at`, emits a `compute_debit` ledger entry, and optionally closes
+ * the row in the same compare-and-set as the final cursor move.
  * Used by both `pauseComputeSession` (final) and the cron tick (partial).
  */
 async function settleComputeWindow(
   row: typeof sandboxComputeSessions.$inferSelect,
   windowEnd: Date,
-): Promise<number> {
+  terminalState?: 'stopped' | 'finalized',
+): Promise<'settled' | 'contended' | 'debit_failed' | 'no_window'> {
   const lastBilled = new Date(row.lastBilledAt);
   // THE CLAMP — never bill past the last control-plane observation that the box
   // was alive, plus the provider's own auto-stop ceiling. A sandbox physically
@@ -152,11 +153,16 @@ async function settleComputeWindow(
     lastAliveAt: lastAliveAtOf(row),
     graceMs: computeLivenessGraceMs(),
   });
-  const durationSeconds = Math.max(0, (billableEnd.getTime() - lastBilled.getTime()) / 1000);
-  if (durationSeconds <= 0) {
+  // A terminal row cannot end before its billing cursor. The cursor can already
+  // be later than an evidenced stop after an earlier partial settle. Preserve
+  // that historical debit, close at the cursor, and never move time backwards.
+  const claimedEnd =
+    terminalState && billableEnd.getTime() < lastBilled.getTime() ? lastBilled : billableEnd;
+  const durationSeconds = Math.max(0, (claimedEnd.getTime() - lastBilled.getTime()) / 1000);
+  if (durationSeconds <= 0 && !terminalState) {
     // Nothing more is billable, but advance nothing either: `last_billed_at`
     // stays put so a box that comes back alive resumes from where it stopped.
-    return 0;
+    return 'no_window';
   }
 
   const spec: SandboxSpec = {
@@ -166,18 +172,6 @@ async function settleComputeWindow(
     gpuCount: row.gpuCount,
   };
   const windowCost = calculateComputeCost(spec, durationSeconds, row.provider as ProviderName);
-  if (windowCost <= 0) {
-    // Still CAS'd: an unconditional write here would clobber a cursor another
-    // settler had legitimately advanced.
-    await claimComputeWindow({
-      id: row.id,
-      expectedLastBilledAt: row.lastBilledAt,
-      nextLastBilledAt: billableEnd.toISOString(),
-      addCostUsd: 0,
-    });
-    return 0;
-  }
-
   // CLAIM BEFORE DEBITING. The order is the whole fix.
   //
   // This used to debit first and move the cursor afterwards, with the update
@@ -188,14 +182,17 @@ async function settleComputeWindow(
   const claimed = await claimComputeWindow({
     id: row.id,
     expectedLastBilledAt: row.lastBilledAt,
-    nextLastBilledAt: billableEnd.toISOString(),
+    nextLastBilledAt: claimedEnd.toISOString(),
     addCostUsd: windowCost,
+    terminalState,
   });
   if (!claimed) {
     // Someone else settled this window. Not an error, and not worth a warning
     // on a path that runs every few minutes for every live box.
-    return 0;
+    return 'contended';
   }
+
+  if (windowCost <= 0) return 'settled';
 
   // Debit the wallet. deductCredits already triggers auto-topup as a
   // fire-and-forget after a deduction (services/credits.ts:79).
@@ -210,7 +207,7 @@ async function settleComputeWindow(
       // of charging again. The CAS claim above already stops two settlers from
       // both billing; this covers the single settler that never learned its own
       // debit succeeded.
-      `compute:${row.id}:${billableEnd.toISOString()}`,
+      `compute:${row.id}:${claimedEnd.toISOString()}`,
     );
   } catch (err) {
     // Out of credits + no auto-topup. Hand the window back so the next tick can
@@ -218,19 +215,20 @@ async function settleComputeWindow(
     // outrun the ledger.
     const released = await releaseComputeWindow({
       id: row.id,
-      claimedLastBilledAt: billableEnd.toISOString(),
+      claimedLastBilledAt: claimedEnd.toISOString(),
       revertToLastBilledAt: row.lastBilledAt,
       subCostUsd: windowCost,
+      terminalState,
     });
     console.warn(
       `[compute-metering] failed to debit ${row.accountId} for session ${row.id}` +
         `${released ? '' : ' (window NOT released — another settler moved the cursor; seconds forfeited)'}:`,
       err instanceof Error ? err.message : String(err),
     );
-    return 0;
+    return 'debit_failed';
   }
 
-  return windowCost;
+  return 'settled';
 }
 
 /**
@@ -262,23 +260,32 @@ export async function pauseComputeSession(sandboxId: string, windowEnd?: Date): 
 }
 
 /**
- * THE ONLY writer of `sandbox_compute_sessions.ended_at`.
+ * THE ONLY service entry point that closes `sandbox_compute_sessions`.
  *
  * `ended_at` is what every downstream reader treats as "this window is closed
  * and will never accrue again" — `getOpenComputeSession` keys off `IS NULL`, the
  * usage rollup in projects/routes/gateway.ts coalesces to it, and the reimburse
- * script bounds refunds by it. Two independent writers is how a window ends up
- * settled to one instant and stamped with another. Settling and stamping happen
- * here, in that order, or not at all; the two exported closers differ only in
- * the terminal state they record.
+ * script bounds refunds by it. The repository claim writes `last_billed_at`,
+ * `cost_usd`, `state`, and `ended_at` in one compare-and-set. The two exported
+ * closers differ only in the terminal state they record.
  */
 async function closeComputeWindow(
   row: typeof sandboxComputeSessions.$inferSelect,
   state: 'stopped' | 'finalized',
   billThrough: Date,
 ): Promise<void> {
-  await settleComputeWindow(row, billThrough);
-  await updateComputeSession(row.id, { state, endedAt: billThrough.toISOString() });
+  let current = row;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const result = await settleComputeWindow(current, billThrough, state);
+    if (result !== 'contended') return;
+
+    // A partial settler moved the cursor first. Reload and claim the remaining
+    // terminal window. A competing terminal settler leaves no open row.
+    const refreshed = await getOpenComputeSession(row.sandboxId);
+    if (!refreshed) return;
+    current = refreshed;
+  }
+  throw new Error(`compute close contention exceeded retry budget for ${row.id}`);
 }
 
 /**

--- a/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
+++ b/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
@@ -328,6 +328,6 @@ describe('the ended_at single-writer invariant', () => {
       }))
       .filter((entry) => entry.hits > 0);
 
-    expect(writers).toEqual([{ file: 'billing/services/compute-metering.ts', hits: 1 }]);
+    expect(writers).toEqual([{ file: 'billing/repositories/compute-sessions.ts', hits: 2 }]);
   });
 });


### PR DESCRIPTION
## Problem

A live Daytona stop produced two sequential debit windows for one short meter. The total debit matched the exact duration. The competing close calls then wrote ended_at backwards, leaving last_billed_at 323 ms after ended_at.

## Fix

- Claim the terminal billing cursor, cost, state, and ended_at in one PostgreSQL compare-and-set.
- Prevent partial release from moving a cursor after terminal close.
- Reopen only the exact terminal claim when its wallet debit fails.
- Keep one module as the only ended_at writer.
- Add a deterministic close-race test that failed with two debits before this fix.
- Add rendered-SQL tests for terminal claim and release predicates.

## Verification

- pnpm --filter kortix-api test: 5,722 pass, 60 skip, 0 fail.
- pnpm --filter kortix-api typecheck: pass.
- Focused billing, lifecycle, wake-fence, and stop tests: 126 pass, 0 fail.
- Live dev Platinum billing smoke before this follow-up: pass.
- Live dev Daytona smoke exposed the race with exact total debit and inconsistent terminal timestamps.

## Production reconciliation

- Kortix-core rows affected since 2026-08-06: 0.
- All accounts affected since 2026-08-06: 40 rows in one account.
- Maximum recent gap: 196 ms.
- Total recent upper-bound charge: $0.0000367673.
- No production balance or ledger row was modified.