### PR TITLE
fix(billing): pin compute meter start precision

### DIFF
--- a/apps/api/src/__tests__/billing/e2e-compute-metering.test.ts
+++ b/apps/api/src/__tests__/billing/e2e-compute-metering.test.ts
@@ -47,6 +47,7 @@ interface InMemorySession {
 }
 
 let sessions: InMemorySession[] = [];
+let insertedComputeSessionData: Record<string, unknown> | null = null;
 let debitCalls: { accountId: string; amount: number; description: string; ledgerType: string }[] = [];
 let simulateUniqueViolationOnInsert = false;
 let holdFirstDebit = false;
@@ -56,6 +57,7 @@ let signalFirstDebitStarted: (() => void) | null = null;
 
 mock.module('../../billing/repositories/compute-sessions', () => ({
   insertComputeSession: async (data: any) => {
+    insertedComputeSessionData = data;
     if (simulateUniqueViolationOnInsert) {
       simulateUniqueViolationOnInsert = false;
       const err = new Error('duplicate open compute session') as Error & { code?: string };
@@ -74,9 +76,9 @@ mock.module('../../billing/repositories/compute-sessions', () => ({
       diskGb: data.diskGb,
       gpuCount: data.gpuCount ?? 0,
       state: data.state ?? 'active',
-      startedAt: new Date().toISOString(),
+      startedAt: data.startedAt ?? new Date().toISOString(),
       endedAt: null,
-      lastBilledAt: new Date().toISOString(),
+      lastBilledAt: data.lastBilledAt ?? new Date().toISOString(),
       costUsd: '0',
       ledgerId: null,
       metadata: data.metadata ?? {},
@@ -177,6 +179,7 @@ const SPEC = { cpuCores: 2, memoryGb: 4, diskGb: 20, gpuCount: 0 };
 
 beforeEach(() => {
   sessions = [];
+  insertedComputeSessionData = null;
   debitCalls = [];
   simulateUniqueViolationOnInsert = false;
   holdFirstDebit = false;
@@ -205,6 +208,17 @@ describe('compute metering — per-seat happy path', () => {
     expect(sessions[0].state).toBe('active');
     expect(sessions[0].endedAt).toBeNull();
     expect(debitCalls.length).toBe(0);
+  });
+
+  test('start pins the initial billing cursor to the stored start timestamp', async () => {
+    await startComputeSession({
+      sandboxId: 'sb_timestamp_precision',
+      accountId: 'acc_test_123',
+      spec: SPEC,
+    });
+
+    expect(typeof insertedComputeSessionData?.startedAt).toBe('string');
+    expect(insertedComputeSessionData?.lastBilledAt).toBe(insertedComputeSessionData?.startedAt);
   });
 
   test('pause finalizes the row, debits with compute_debit type, and matches cost formula', async () => {

--- a/apps/api/src/billing/services/compute-metering.ts
+++ b/apps/api/src/billing/services/compute-metering.ts
@@ -109,6 +109,10 @@ export async function startComputeSession(opts: StartComputeOpts): Promise<strin
   const existing = await getOpenComputeSession(opts.sandboxId);
   if (existing) return existing.id;
 
+  // PostgreSQL defaults retain microseconds, but JavaScript Date reads only
+  // milliseconds. Pin both timestamps to one JavaScript instant so the first
+  // billing window cannot include a sub-millisecond interval before started_at.
+  const startedAt = new Date().toISOString();
   const row = await insertComputeSession({
     accountId: opts.accountId,
     sandboxId: opts.sandboxId,
@@ -120,6 +124,8 @@ export async function startComputeSession(opts: StartComputeOpts): Promise<strin
     diskGb: opts.spec.diskGb,
     gpuCount: opts.spec.gpuCount ?? 0,
     state: 'active',
+    startedAt,
+    lastBilledAt: startedAt,
     metadata: (opts.metadata ?? {}) as Record<string, unknown>,
     workloadType: opts.workloadType ?? 'session',
     appRuntimeId: opts.appRuntimeId ?? null,


### PR DESCRIPTION
## Problem

PostgreSQL defaults meter timestamps with microsecond precision. JavaScript `Date` truncates them to milliseconds when settling the first window. That precision mismatch can add less than 1 ms to a new meter debit. The observed maximum on the production Kortix account was $0.0000001666 per meter.

## Fix

- Set `started_at` and `last_billed_at` from the same JavaScript ISO timestamp.
- Keep the first billing cursor exactly equal to the stored meter start.
- Add a regression test that requires the insert payload to pin both values.

## Verification

- Regression test failed before the implementation and passed after it.
- Focused lifecycle suite: 50 pass, 0 fail.
- Full API suite: 5,764 pass, 60 skip, 0 fail.
- API typecheck passed.

## Production evidence

This PR is read/write code only. The production audit used read-only queries. No customer balance or billing row was changed.