### PR TITLE
fix(billing): activate subscriptions only after the first invoice is paid

### DIFF
--- a/apps/api/src/__tests__/billing/mocks.ts
+++ b/apps/api/src/__tests__/billing/mocks.ts
@@ -337,6 +337,12 @@ export function createMockStripeCheckoutSession(overrides: Record<string, any> =
   return {
     id: 'cs_test_123',
     mode: 'subscription',
+    // Real Stripe always sets these two on a completed session. `payment_status`
+    // is the fraud gate in handleSubscriptionCheckout: only 'paid' activates.
+    // Defaulting it to 'paid' keeps this factory a HAPPY-PATH factory; tests for
+    // the unpaid path override it explicitly.
+    status: 'complete',
+    payment_status: 'paid',
     subscription: 'sub_test_123',
     customer: 'cus_test_123',
     customer_email: 'test@example.com',

--- a/apps/api/src/__tests__/billing/subscriptions.test.ts
+++ b/apps/api/src/__tests__/billing/subscriptions.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, mock } from 'bun:test';
 import {
   createMockCreditAccount,
   createMockStripeSubscription,
+  createMockStripeCheckoutSession,
   createMockStripeClient,
   mockRegistry,
   registerGlobalMocks,
@@ -643,5 +644,45 @@ describe('createCheckoutSession: machine sub does not clobber live plan sub', ()
     // Should overwrite since the existing sub is dead
     expect(upsertCreditAccountCalls.length).toBe(1);
     expect(upsertCreditAccountCalls[0].data.stripeSubscriptionId).toBe('sub_machine_new');
+  });
+});
+
+describe('confirmCheckoutSession: payment gate (client-callable fraud path)', () => {
+  test('a COMPLETE session with an UNPAID first invoice does not activate or grant', async () => {
+    // The old guard accepted session.status === 'complete' as proof of payment.
+    // A delayed/failed payment method completes checkout with
+    // payment_status 'unpaid' and subscription 'incomplete' — the same
+    // never-paid shape the webhook fraud gate closes, but reachable by any
+    // signed-in client via POST checkout/confirm.
+    mockRegistry.stripeClient.checkout.sessions.retrieve = async () =>
+      createMockStripeCheckoutSession({ status: 'complete', payment_status: 'unpaid' });
+
+    let granted = false;
+    mockRegistry.grantCredits = async () => {
+      granted = true;
+    };
+
+    const { confirmCheckoutSession } = await import('../../billing/services/subscriptions');
+    const result = await confirmCheckoutSession({
+      accountId: 'acc_test_123',
+      sessionId: 'cs_test_123',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe('pending');
+    expect(granted).toBe(false);
+  });
+
+  test('no_payment_required (100% coupon) still activates', async () => {
+    mockRegistry.stripeClient.checkout.sessions.retrieve = async () =>
+      createMockStripeCheckoutSession({ status: 'complete', payment_status: 'no_payment_required' });
+
+    const { confirmCheckoutSession } = await import('../../billing/services/subscriptions');
+    const result = await confirmCheckoutSession({
+      accountId: 'acc_test_123',
+      sessionId: 'cs_test_123',
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/api/src/__tests__/billing/webhooks.test.ts
+++ b/apps/api/src/__tests__/billing/webhooks.test.ts
@@ -261,6 +261,234 @@ describe('checkout.session.completed', () => {
   });
 });
 
+// ─── Payment-gated activation ────────────────────────────────────────────────
+// Regression suite for the never-paid-subscription hole: the webhook layer used
+// to activate on subscription EVENTS, so a checkout whose first invoice was
+// never paid still received the paid-tier write AND the activation credit
+// grant. Measured on production: 85 accounts on incomplete/incomplete_expired
+// subscriptions burned $840 of granted credit without paying anything.
+
+describe('activation is gated on payment', () => {
+  test('checkout.session.completed with payment_status=unpaid records the sub pointer ONLY', async () => {
+    mockRegistry.stripeClient.subscriptions.retrieve = async () =>
+      createMockStripeSubscription({ status: 'incomplete' });
+
+    const session = createMockStripeCheckoutSession({ payment_status: 'unpaid' });
+    const event = createMockStripeEvent('checkout.session.completed', session);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    // The pointer is factual bookkeeping and IS written.
+    expect(upsertCreditAccountCalls.length).toBe(1);
+    expect(upsertCreditAccountCalls[0].data.stripeSubscriptionId).toBe('sub_test_123');
+    expect(upsertCreditAccountCalls[0].data.stripeSubscriptionStatus).toBe('incomplete');
+    expect(upsertCreditAccountCalls[0].data.provider).toBe('stripe');
+
+    // Entitlements and money are NOT.
+    expect(upsertCreditAccountCalls[0].data.tier).toBeUndefined();
+    expect(grantCreditsCalls.length).toBe(0);
+    expect(upsertCustomerCalls.length).toBe(0);
+  });
+
+  test('invoice.paid(subscription_create) on an active sub performs the full activation', async () => {
+    const invoice = createMockStripeInvoice({ billing_reason: 'subscription_create' });
+    const event = createMockStripeEvent('invoice.paid', invoice);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    expect(upsertCreditAccountCalls.length).toBe(1);
+    expect(upsertCreditAccountCalls[0].accountId).toBe('acc_test_123');
+    expect(upsertCreditAccountCalls[0].data.tier).toBe('tier_6_50');
+    expect(upsertCreditAccountCalls[0].data.stripeSubscriptionId).toBe('sub_test_123');
+
+    const tierGrant = grantCreditsCalls.find((c: any) => c[2] === 'tier_grant');
+    expect(tierGrant).toBeDefined();
+    expect(tierGrant[1]).toBe(50);
+    expect(tierGrant[5]).toBe('subscription_activation:sub_test_123');
+
+    // Customer is stitched from the subscription's customer, with no email.
+    expect(upsertCustomerCalls.length).toBe(1);
+    expect(upsertCustomerCalls[0].id).toBe('cus_test_123');
+  });
+
+  test('invoice.paid(subscription_create) is skipped when the sub is not in a paying status', async () => {
+    mockRegistry.stripeClient.subscriptions.retrieve = async () =>
+      createMockStripeSubscription({ status: 'incomplete' });
+
+    const invoice = createMockStripeInvoice({ billing_reason: 'subscription_create' });
+    const event = createMockStripeEvent('invoice.paid', invoice);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    expect(upsertCreditAccountCalls.length).toBe(0);
+    expect(grantCreditsCalls.length).toBe(0);
+  });
+
+  test('invoice.paid(subscription_create) after a paid checkout does NOT grant twice', async () => {
+    // Both paths call grantCredits with the SAME idempotency key, so the credits
+    // ledger collapses them. Model that here: the stub grants once per key and
+    // records the effective grants.
+    const grantedKeys = new Set<string>();
+    const effectiveGrants: any[] = [];
+    mockRegistry.grantCredits = async (...args: any[]) => {
+      grantCreditsCalls.push(args);
+      const key = args[5];
+      if (key && grantedKeys.has(key)) return;
+      if (key) grantedKeys.add(key);
+      effectiveGrants.push(args);
+    };
+
+    const checkout = createMockStripeCheckoutSession();
+    const checkoutEvent = createMockStripeEvent('checkout.session.completed', checkout);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => checkoutEvent;
+    await processStripeWebhook(JSON.stringify(checkoutEvent), 'sig');
+
+    const invoice = createMockStripeInvoice({ billing_reason: 'subscription_create' });
+    const invoiceEvent = createMockStripeEvent('invoice.paid', invoice);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => invoiceEvent;
+    await processStripeWebhook(JSON.stringify(invoiceEvent), 'sig');
+
+    expect(grantCreditsCalls.length).toBe(2);
+    expect(grantCreditsCalls[0][5]).toBe('subscription_activation:sub_test_123');
+    expect(grantCreditsCalls[1][5]).toBe(grantCreditsCalls[0][5]);
+    expect(effectiveGrants.length).toBe(1);
+    expect(effectiveGrants[0][1]).toBe(50);
+  });
+
+  test('customer.subscription.created with status=incomplete writes no tier and no recovery credits', async () => {
+    // An account with no sub pointer on a free tier is exactly the shape that
+    // used to earn recovery credits from a subscription that never paid.
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({ tier: 'free', stripeSubscriptionId: null, balance: '0' });
+
+    const sub = createMockStripeSubscription({ status: 'incomplete' });
+    const event = createMockStripeEvent('customer.subscription.created', sub);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    expect(updateCreditAccountCalls.length).toBe(1);
+    expect(updateCreditAccountCalls[0].data.stripeSubscriptionStatus).toBe('incomplete');
+    expect(updateCreditAccountCalls[0].data.tier).toBeUndefined();
+    expect(resetExpiringCreditsCalls.length).toBe(0);
+    expect(grantCreditsCalls.length).toBe(0);
+  });
+
+  test('a per-seat sub with status=incomplete writes no seat entitlements', async () => {
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({ tier: 'free', billingModel: null, seatCount: 0, stripeSubscriptionId: null });
+
+    const sub = createMockStripeSubscription({
+      id: 'sub_seat_incomplete',
+      status: 'incomplete',
+      metadata: { account_id: 'acc_test_123', tier_key: 'per_seat', billing_model: 'per_seat' },
+      items: { data: [{ id: 'si_seat_1', quantity: 5, price: { id: 'price_seat' } }] },
+    });
+    const event = createMockStripeEvent('customer.subscription.created', sub);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    expect(updateCreditAccountCalls.length).toBe(1);
+    expect(updateCreditAccountCalls[0].data.tier).toBeUndefined();
+    expect(updateCreditAccountCalls[0].data.billingModel).toBeUndefined();
+    expect(updateCreditAccountCalls[0].data.seatCount).toBeUndefined();
+    expect(grantCreditsCalls.filter((c: any) => c[2] === 'seat_grant').length).toBe(0);
+    expect(resetExpiringCreditsCalls.length).toBe(0);
+  });
+});
+
+describe('incomplete_expired revokes a never-paid tier', () => {
+  test('resets the account to free when it still holds the tier this sub granted', async () => {
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({ stripeSubscriptionId: 'sub_test_123', tier: 'tier_6_50' });
+
+    const sub = createMockStripeSubscription({ id: 'sub_test_123', status: 'incomplete_expired' });
+    const event = createMockStripeEvent('customer.subscription.updated', sub);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    expect(updateCreditAccountCalls.length).toBe(1);
+    expect(updateCreditAccountCalls[0].data.tier).toBe('free');
+    expect(updateCreditAccountCalls[0].data.stripeSubscriptionStatus).toBe('incomplete_expired');
+  });
+
+  test('a per-seat account is reset to free and off the per-seat billing model', async () => {
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({
+        stripeSubscriptionId: 'sub_seat_expired',
+        tier: 'per_seat',
+        billingModel: 'per_seat',
+        seatCount: 5,
+      });
+
+    const sub = createMockStripeSubscription({
+      id: 'sub_seat_expired',
+      status: 'incomplete_expired',
+      metadata: { account_id: 'acc_test_123', billing_model: 'per_seat' },
+      items: { data: [{ id: 'si_seat_1', quantity: 5, price: { id: 'price_seat' } }] },
+    });
+    const event = createMockStripeEvent('customer.subscription.updated', sub);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    expect(updateCreditAccountCalls[0].data.tier).toBe('free');
+    expect(updateCreditAccountCalls[0].data.billingModel).toBe('legacy');
+  });
+
+  test('an enterprise-entitled account is NEVER reset', async () => {
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({
+        stripeSubscriptionId: 'sub_test_123',
+        tier: 'tier_6_50',
+        enterpriseEntitled: true,
+      });
+
+    const sub = createMockStripeSubscription({ id: 'sub_test_123', status: 'incomplete_expired' });
+    const event = createMockStripeEvent('customer.subscription.updated', sub);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    expect(updateCreditAccountCalls.length).toBe(1);
+    expect(updateCreditAccountCalls[0].data.tier).toBeUndefined();
+  });
+
+  test('does not touch a tier this subscription did not grant', async () => {
+    // The account moved on to another plan; an old sub expiring unpaid must not
+    // strip the tier some other subscription paid for.
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({ stripeSubscriptionId: 'sub_test_123', tier: 'tier_2_20' });
+
+    const sub = createMockStripeSubscription({ id: 'sub_test_123', status: 'incomplete_expired' });
+    const event = createMockStripeEvent('customer.subscription.updated', sub);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    expect(updateCreditAccountCalls[0].data.tier).toBeUndefined();
+  });
+
+  test('does not touch an account that points at a different subscription', async () => {
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({ stripeSubscriptionId: 'sub_live_other', tier: 'tier_6_50' });
+
+    const sub = createMockStripeSubscription({ id: 'sub_expired', status: 'incomplete_expired' });
+    const event = createMockStripeEvent('customer.subscription.updated', sub);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => event;
+
+    await processStripeWebhook(JSON.stringify(event), 'sig');
+
+    // Stale-sub guard bails before any write.
+    expect(updateCreditAccountCalls.length).toBe(0);
+  });
+});
+
 describe('subscription changes', () => {
   test('updates tier, status, billing cycle anchor', async () => {
     const sub = createMockStripeSubscription();

--- a/apps/api/src/billing/services/billing-state.test.ts
+++ b/apps/api/src/billing/services/billing-state.test.ts
@@ -7,6 +7,7 @@ import {
   hasLiveSubscription,
   hasPayingSubscription,
   hasPlan,
+  isPayingSubscriptionStatus,
   resolveBillingState,
   subscriptionBypassesWalletFloor,
 } from './billing-state';
@@ -283,6 +284,40 @@ describe('only a PAYING subscription bypasses the wallet floor', () => {
   test('hasLiveSubscription stays a REPORTING predicate and still counts past_due as live', () => {
     expect(hasLiveSubscription(perSeat('past_due', 0))).toBe(true);
     expect(hasPayingSubscription(perSeat('past_due', 0))).toBe(false);
+  });
+});
+
+describe('isPayingSubscriptionStatus — the webhook layer activation gate', () => {
+  test('only active and trialing are paying', () => {
+    expect(isPayingSubscriptionStatus('active')).toBe(true);
+    expect(isPayingSubscriptionStatus('trialing')).toBe(true);
+  });
+
+  test('a never-paid subscription is not paying — the 85-account/$840 signup farm', () => {
+    expect(isPayingSubscriptionStatus('incomplete')).toBe(false);
+    expect(isPayingSubscriptionStatus('incomplete_expired')).toBe(false);
+  });
+
+  test('a lapsed or terminated subscription is not paying', () => {
+    expect(isPayingSubscriptionStatus('past_due')).toBe(false);
+    expect(isPayingSubscriptionStatus('unpaid')).toBe(false);
+    expect(isPayingSubscriptionStatus('canceled')).toBe(false);
+    expect(isPayingSubscriptionStatus('paused')).toBe(false);
+  });
+
+  test('an absent or unknown status fails CLOSED', () => {
+    expect(isPayingSubscriptionStatus(null)).toBe(false);
+    expect(isPayingSubscriptionStatus(undefined)).toBe(false);
+    expect(isPayingSubscriptionStatus('')).toBe(false);
+    expect(isPayingSubscriptionStatus('some_future_stripe_status')).toBe(false);
+  });
+
+  test('agrees with hasPayingSubscription for every status', () => {
+    for (const status of ['active', 'trialing', 'incomplete', 'incomplete_expired', 'past_due', 'unpaid', 'canceled']) {
+      expect(isPayingSubscriptionStatus(status)).toBe(
+        hasPayingSubscription(snapshot({ subscriptionId: 'sub_1', subscriptionStatus: status })),
+      );
+    }
   });
 });
 

--- a/apps/api/src/billing/services/billing-state.ts
+++ b/apps/api/src/billing/services/billing-state.ts
@@ -108,6 +108,33 @@ export function isDeadSubscriptionStatus(status: string | null | undefined): boo
   return DEAD_SUBSCRIPTION_STATUSES.has(status ?? '');
 }
 
+/**
+ * Whether a RAW Stripe subscription status means Stripe is collecting money.
+ *
+ * Same allow-list as `hasPayingSubscription`, but takes the status string
+ * directly so the webhook layer can ask the question about a `Stripe.
+ * Subscription` object it has just retrieved, before any `credit_accounts` row
+ * exists to build a snapshot from.
+ *
+ * THE WEBHOOK LAYER MUST GATE EVERY TIER WRITE AND EVERY ACTIVATION/RECOVERY
+ * CREDIT GRANT ON THIS PREDICATE. It previously activated on subscription
+ * EVENTS alone — `checkout.session.completed` and `customer.subscription.
+ * created` fire the moment Stripe attaches a subscription, whether or not the
+ * first invoice is ever paid. A subscription that never collects sits at
+ * `incomplete` for 23 hours and then becomes `incomplete_expired`; no money
+ * moves at any point. A signup farm exploited exactly that: 85 production
+ * accounts held `incomplete`/`incomplete_expired` subscriptions, received the
+ * full paid-tier write plus the activation credit grant, and burned $840 of
+ * granted credit without paying a cent.
+ *
+ * Gating on this predicate means money must settle first. The paid path is
+ * driven by `invoice.paid` (billing_reason `subscription_create`), which Stripe
+ * only sends once the first invoice is actually paid.
+ */
+export function isPayingSubscriptionStatus(status: string | null | undefined): boolean {
+  return PAYING_SUBSCRIPTION_STATUSES.has(status ?? '');
+}
+
 /** Whether a subscription row exists at all, live or lapsed. */
 export function hasSubscriptionRecord(snapshot: BillingSnapshot): boolean {
   return !!snapshot.subscriptionId;

--- a/apps/api/src/billing/services/subscriptions.ts
+++ b/apps/api/src/billing/services/subscriptions.ts
@@ -830,7 +830,14 @@ export async function confirmCheckoutSession(params: {
     return { success: false, status: 'pending', message: 'Subscription not attached yet' };
   }
 
-  if (session.status !== 'complete' && session.payment_status !== 'paid' && session.payment_status !== 'no_payment_required') {
+  // Payment_status is the ONLY signal that money settled. The old guard also
+  // accepted session.status === 'complete', but a checkout completes with an
+  // UNPAID first invoice for delayed/failed payment methods (subscription
+  // status 'incomplete') — and this endpoint is client-callable, so that
+  // loophole reproduced the exact never-paid activation hole the webhook
+  // layer closes (see handleSubscriptionCheckout's fraud gate). Fail closed:
+  // no settled payment, no activation, no grant.
+  if (session.payment_status !== 'paid' && session.payment_status !== 'no_payment_required') {
     return { success: false, status: 'pending', message: 'Checkout payment is not completed yet' };
   }
 

--- a/apps/api/src/billing/services/webhooks.ts
+++ b/apps/api/src/billing/services/webhooks.ts
@@ -25,6 +25,7 @@ import {
   defaultAutoTopupForSeats,
 } from './tiers';
 import { grantCredits, resetExpiringCredits } from './credits';
+import { isPayingSubscriptionStatus } from './billing-state';
 import { grantMachineBonusOnce, getStripeMachineBonusKey } from './machine-bonus';
 import { cancelFreeSubscriptionForUpgrade } from './subscriptions';
 import { calculateNextCreditGrant } from './credit-grant-schedule';
@@ -148,11 +149,92 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
   const stripe = getStripe();
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
 
+  // FRAUD GATE — money first, entitlements second.
+  //
+  // `checkout.session.completed` fires as soon as Stripe finishes the session,
+  // INCLUDING when the first invoice was never paid. Such a session carries
+  // `payment_status='unpaid'` and leaves the subscription at `incomplete`,
+  // which expires to `incomplete_expired` after 23 hours with no money moved.
+  // Activating here handed those sessions the full tier write AND the
+  // activation credit grant: on production, 85 accounts holding
+  // incomplete/incomplete_expired subscriptions burned $840 of granted credit
+  // without ever paying (a signup farm).
+  //
+  // Record the subscription pointer only — no tier, no credits. Activation is
+  // deferred to `invoice.paid` (billing_reason `subscription_create`), which
+  // Stripe sends once the first invoice actually settles. That covers the
+  // legitimate case this gate also catches: delayed payment methods
+  // (bank debits, vouchers) whose checkout completes before the money does.
+  if (session.payment_status !== 'paid') {
+    await upsertCreditAccount(accountId, {
+      stripeSubscriptionId: subscriptionId,
+      stripeSubscriptionStatus: subscription.status,
+      provider: 'stripe',
+    });
+    console.log(
+      `[Webhook] Deferred subscription activation for ${accountId} (sub=${subscriptionId}): checkout payment_status=${session.payment_status ?? 'unknown'}, subscription status=${subscription.status}. Waiting for invoice.paid.`,
+    );
+    return;
+  }
+
+  await activateSubscriptionForAccount({
+    accountId,
+    subscription,
+    subscriptionId,
+    tierKey,
+    commitmentType: session.metadata?.commitment_type ?? null,
+    previousSubscriptionIdHint: session.metadata?.previous_subscription_id ?? null,
+    customerId: typeof session.customer === 'string'
+      ? session.customer
+      : session.customer?.id ?? null,
+    customerEmail: session.customer_email ?? null,
+    serverType: session.metadata?.server_type ?? null,
+    location: session.metadata?.location ?? null,
+  });
+}
+
+/**
+ * Write the tier, grant the activation credit, and stitch up the customer /
+ * previous-subscription / machine-bonus side effects for a subscription whose
+ * first payment has SETTLED.
+ *
+ * Two callers reach it, and both must have proven payment first:
+ * - `handleSubscriptionCheckout`, when `session.payment_status === 'paid'`.
+ * - `handleInvoicePaid` on billing_reason `subscription_create`, when the
+ *   subscription status is a paying one.
+ *
+ * Nothing in here re-checks payment. The gate belongs to the callers, so this
+ * function stays a single place that describes what activation IS.
+ */
+async function activateSubscriptionForAccount(params: {
+  accountId: string;
+  subscription: Stripe.Subscription;
+  subscriptionId: string;
+  tierKey: string;
+  commitmentType: string | null;
+  previousSubscriptionIdHint: string | null;
+  customerId: string | null;
+  customerEmail: string | null;
+  serverType: string | null;
+  location: string | null;
+}) {
+  const {
+    accountId,
+    subscription,
+    subscriptionId,
+    tierKey,
+    commitmentType,
+    previousSubscriptionIdHint,
+    customerId,
+    customerEmail,
+    serverType,
+    location,
+  } = params;
+
   const tier = getTier(tierKey);
-  const commitmentType = session.metadata?.commitment_type;
   const isYearly = commitmentType === 'yearly' || commitmentType === 'yearly_commitment';
   const existingAccount = await getCreditAccount(accountId);
-  const previousSubscriptionId = session.metadata?.previous_subscription_id
+  const previousSubscriptionId = previousSubscriptionIdHint
     ?? (
       existingAccount?.tier === 'free' &&
       existingAccount.stripeSubscriptionId &&
@@ -227,12 +309,11 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
   }
 
   // Upsert Stripe customer record
-  if (session.customer) {
-    const customerId = typeof session.customer === 'string' ? session.customer : session.customer.id;
+  if (customerId) {
     await upsertCustomer({
       accountId,
       id: customerId,
-      email: session.customer_email ?? null,
+      email: customerEmail,
       provider: 'stripe',
       active: true,
     });
@@ -241,9 +322,6 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
   if (previousSubscriptionId && previousSubscriptionId !== subscriptionId) {
     await cancelFreeSubscriptionForUpgrade(previousSubscriptionId, accountId);
   }
-
-  const serverType = session.metadata?.server_type;
-  const location = session.metadata?.location;
 
   if (serverType) {
     try {
@@ -261,7 +339,7 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
     void tierKey;
   }
 
-  console.log(`[Webhook] Subscription checkout: ${tierKey} for ${accountId} (sub=${subscriptionId})`);
+  console.log(`[Webhook] Subscription activated: ${tierKey} for ${accountId} (sub=${subscriptionId})`);
 }
 
 async function handleSubscriptionChange(subscription: Stripe.Subscription) {
@@ -344,11 +422,17 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
   // (the stored pointer pointed at a dead sub while a live plan sub was being
   // adopted above). In all these cases the balance is likely $0 and the
   // customer was paywalled through no fault of their own.
+  //
+  // Gated on `subIsPaying` for the same reason the checkout path is: a
+  // `customer.subscription.created` for an `incomplete` subscription is not a
+  // customer, it is an unpaid attempt. Recovery credit for one is a pure gift.
+  const subIsPaying = isPayingSubscriptionStatus(subscription.status);
   const shouldGrantRecoveryCredits =
     !!resolvedTier &&
+    subIsPaying &&
     (!account || (!account.stripeSubscriptionId && (!account.tier || account.tier === 'free' || account.tier === 'none')));
 
-  console.log(`[Webhook] syncSubscriptionState: account=${accountId} tier_meta=${tierKey} price=${priceId} resolved=${resolvedTier} status=${subscription.status}`);
+  console.log(`[Webhook] syncSubscriptionState: account=${accountId} tier_meta=${tierKey} price=${priceId} resolved=${resolvedTier} status=${subscription.status} paying=${subIsPaying}`);
 
   const updates: Record<string, any> = {
     stripeSubscriptionId: subscription.id,
@@ -362,7 +446,11 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
       : null,
   };
 
-  if (resolvedTier) {
+  // Tier is an ENTITLEMENT, and entitlements follow money. A subscription that
+  // is `incomplete` (first invoice never paid) or `incomplete_expired` (first
+  // invoice never paid, and now it never will be) must not write a paid tier.
+  // Every other field above is factual bookkeeping and is written regardless.
+  if (resolvedTier && subIsPaying) {
     updates.tier = resolvedTier;
   }
 
@@ -396,7 +484,10 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     !!account && (account.enterpriseEntitled || account.tier === 'enterprise');
   let perSeatDelta = 0;
   let perSeatNewSeats = 0;
-  if (perSeatItem) {
+  // Same gate as the tier write. Seat count, billing model, and the seat
+  // allowance grant are all entitlements bought with the first invoice; an
+  // `incomplete` per-seat subscription has bought none of them yet.
+  if (perSeatItem && subIsPaying) {
     const newSeats = Math.max(1, Math.floor(perSeatItem.quantity ?? 1));
     const oldSeats = account?.seatCount ?? 0;
     perSeatDelta = newSeats - oldSeats;
@@ -441,6 +532,40 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     updates.trialStatus = 'converted';
   }
 
+  // NEVER-PAID RESET — revoke a tier this subscription should never have granted.
+  //
+  // `incomplete_expired` has exactly one meaning in Stripe: the first invoice
+  // was never paid, and Stripe has given up collecting it. No money EVER moved
+  // on this subscription. Rows written before the payment gate above landed
+  // (85 production accounts, $840 of granted credit) still carry the paid tier
+  // that this subscription handed out, and nothing else would ever take it
+  // back — `customer.subscription.deleted` does not fire for a subscription
+  // that expired without activating.
+  //
+  // Deliberately narrow. It only fires when the account still points at THIS
+  // subscription and still holds the exact tier THIS subscription granted, so
+  // it can never strip a tier that some other subscription, a migration, or an
+  // operator granted. `enterprise_entitled` accounts are never touched: their
+  // entitlement is contracted, not Stripe-derived.
+  const neverPaidTierGrantedByThisSub =
+    subscription.status === 'incomplete_expired' &&
+    account &&
+    account.stripeSubscriptionId === subscription.id &&
+    !account.enterpriseEntitled &&
+    account.tier &&
+    !['free', 'none'].includes(account.tier) &&
+    (account.tier === resolvedTier || (!!perSeatItem && account.tier === 'per_seat'));
+
+  if (neverPaidTierGrantedByThisSub) {
+    console.log(
+      `[Webhook] syncSubscriptionState: revoking never-paid tier '${account!.tier}' for ${accountId} (sub=${subscription.id} is incomplete_expired — first invoice was never paid)`,
+    );
+    updates.tier = 'free';
+    if (account!.billingModel === 'per_seat') {
+      updates.billingModel = 'legacy';
+    }
+  }
+
   if (!account) {
     await upsertCreditAccount(accountId, updates);
   } else {
@@ -475,7 +600,7 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     }
   }
 
-  if (perSeatItem && perSeatDelta > 0 && !recoveryCoveredEverySeat) {
+  if (perSeatItem && subIsPaying && perSeatDelta > 0 && !recoveryCoveredEverySeat) {
     // INCLUDED_CREDITS_PER_SEAT_USD ($25 of wallet allowance), never
     // PER_SEAT_PRICE_USD ($40, the price the customer pays). tiers.ts documents
     // that the two are decoupled on purpose — the other $15 is platform margin.
@@ -650,8 +775,11 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
     : invoice.subscription?.id;
   if (!subscriptionId) return;
 
+  // `subscription_cycle` is a renewal. `subscription_create` is the FIRST
+  // invoice of a new subscription actually settling — the event that proves
+  // money moved, and therefore the only trustworthy activation trigger.
   const billingReason = invoice.billing_reason;
-  if (billingReason !== 'subscription_cycle') return;
+  if (billingReason !== 'subscription_cycle' && billingReason !== 'subscription_create') return;
 
   const stripe = getStripe();
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
@@ -659,6 +787,11 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
   if (!accountId) return;
 
   await repairStripeSubscriptionAccountMetadata(subscription, accountId);
+
+  if (billingReason === 'subscription_create') {
+    await activateOnFirstInvoicePaid(accountId, subscription, subscriptionId);
+    return;
+  }
 
   const account = await getCreditAccount(accountId);
   if (!account) return;
@@ -701,6 +834,67 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
   });
 
   console.log(`[Webhook] Renewal processed: ${credits} credits for ${accountId}`);
+}
+
+/**
+ * Activate a subscription whose FIRST invoice has just been paid
+ * (`invoice.paid`, billing_reason `subscription_create`).
+ *
+ * This is the money-first counterpart to the checkout path. It is what
+ * activates a delayed-payment-method checkout — bank debit, voucher, 3DS
+ * finished late — where `checkout.session.completed` arrived with
+ * `payment_status='unpaid'` and was deferred on purpose.
+ *
+ * IDEMPOTENT WITH THE CHECKOUT PATH. Running both for the same subscription
+ * grants once and converges on the same row:
+ * - the activation credit grant shares the
+ *   `subscription_activation:${subscriptionId}` idempotency key with
+ *   `handleSubscriptionCheckout` (and with syncSubscriptionState's recovery
+ *   reset), so the second caller is deduped by the credits ledger;
+ * - the machine bonus is guarded by `grantMachineBonusOnce`;
+ * - every other write (`upsertCreditAccount`, `upsertCustomer`) is an upsert
+ *   with identical values, and `cancelFreeSubscriptionForUpgrade` is a no-op
+ *   for an already-cancelled subscription.
+ */
+async function activateOnFirstInvoicePaid(
+  accountId: string,
+  subscription: Stripe.Subscription,
+  subscriptionId: string,
+) {
+  // Stripe can send `invoice.paid` for an invoice that was paid out-of-band on
+  // a subscription that is still not collecting. Require a paying status.
+  if (!isPayingSubscriptionStatus(subscription.status)) {
+    console.log(
+      `[Webhook] invoice.paid(subscription_create): skipping activation for ${accountId} (sub=${subscriptionId} status=${subscription.status} is not a paying status)`,
+    );
+    return;
+  }
+
+  const priceId = subscription.items.data[0]?.price?.id;
+  const tierKey = subscription.metadata?.tier_key ?? getTierByPriceId(priceId ?? '')?.name;
+  if (!tierKey) {
+    console.warn(
+      `[Webhook] invoice.paid(subscription_create): no tier for ${accountId} (sub=${subscriptionId} price=${priceId ?? 'none'})`,
+    );
+    return;
+  }
+
+  await withAccountLock(accountId, () =>
+    activateSubscriptionForAccount({
+      accountId,
+      subscription,
+      subscriptionId,
+      tierKey,
+      commitmentType: subscription.metadata?.commitment_type ?? null,
+      previousSubscriptionIdHint: null,
+      customerId: typeof subscription.customer === 'string'
+        ? subscription.customer
+        : subscription.customer?.id ?? null,
+      customerEmail: null,
+      serverType: null,
+      location: null,
+    }),
+  );
 }
 
 async function applyScheduledDowngrade(accountId: string, targetTier: string, account: any) {


### PR DESCRIPTION
## Problem — verified on prod

85 accounts hold Stripe subscriptions whose first invoice was **never paid** (`incomplete` / `incomplete_expired`), yet they received the full tier write plus **$840** of activation credit grants and burned them. A signup farm (32 accounts on `web-library.net`, plus `qware.me`, `disiok.com`) exploits this daily: checkout with a payment method that never settles → tier + ~$25 credits land anyway → burn → new account.

Two doors, same hole:
1. **Webhook path**: `handleSubscriptionCheckout` / `syncSubscriptionState` activate on subscription *events* without checking payment ever succeeded.
2. **Client-callable path**: `POST checkout/confirm` → `confirmCheckoutSession` — its guard accepted `session.status === 'complete'` as proof of payment, but checkouts complete with `payment_status: 'unpaid'` for delayed/failed payment methods.

## Fix — fail closed on actual payment

- `billing-state.ts`: new `isPayingSubscriptionStatus()` over the existing allow-list.
- `handleSubscriptionCheckout`: `session.payment_status !== 'paid'` → record the subscription pointer only; no tier, no grant. Paid path byte-for-byte unchanged (extracted to `activateSubscriptionForAccount`).
- `handleInvoicePaid`: now also handles `billing_reason='subscription_create'` — the deferred activation once money settles (delayed payment methods, $0-coupon checkouts). Idempotent with the checkout path via the shared `subscription_activation:<subId>` grant key.
- `syncSubscriptionState`: tier writes, per-seat reconciliation, seat-delta grants, and recovery credits all gated on paying status. New: `incomplete_expired` (first invoice never paid, by Stripe definition) **resets** a tier that sub granted; `enterprise_entitled` accounts never touched.
- `confirmCheckoutSession`: requires `payment_status` `'paid'` / `'no_payment_required'`.

## Verification

- Red-first: with `webhooks.ts` reverted, 9 of the 11 new webhook tests fail; with the old confirm guard, the new confirm test fails.
- `apps/api` full hermetic suite: **5780 pass / 0 fail** (549 files). Billing directory: 268 pass / 0 fail. `tsc --noEmit` clean.
- New tests cover: unpaid checkout (no tier/grant, pointer recorded), deferred activation on `invoice.paid`, no double-grant after paid checkout, `incomplete` sub gets no tier/recovery credits, `incomplete_expired` resets granted tier (and not for `enterprise_entitled`), coupon `no_payment_required` still activates.

## Notes / follow-ups

- Existing 85 never-paid rows keep their stale tier until Stripe re-emits an event or a one-off remediation runs; their spend is already blocked by the wallet floor (balances ~$0, `incomplete_expired` fails the per-seat bypass). Remediation script deliberately not in this PR (operator decision).
- YOLO seat-token minting stays ungated (auth material, not money, idempotent).
- Real-Stripe rehearsal (test-mode `4000000000000341` fail card → pay → `invoice.paid` activates) not run locally; unit harness covers the event shapes.
