### PR TITLE
fix(billing): ledger type honesty guard + 2026-07-30 backfill + overdraft-guard regression tests

### DIFF
--- a/apps/api/src/__tests__/billing/atomic-use-credits-overload.test.ts
+++ b/apps/api/src/__tests__/billing/atomic-use-credits-overload.test.ts
@@ -1,0 +1,192 @@
+// public.atomic_use_credits must have EXACTLY ONE signature, forever.
+//
+// The invariant broke twice:
+//
+//   1. The baseline shipped two overloads whose CALLABLE ARITIES overlapped at 4
+//      (a 4-param/0-default one and a 5-param/3-default one). A positional
+//      four-argument call is then ambiguous — SQLSTATE 42725 — in the money
+//      path. Production only escaped it because the busiest caller used named
+//      PostgREST parameters, which resolve by argument-name set instead.
+//   2. The extra overload was also the WEAKER function: SECURITY INVOKER, no
+//      metadata->>'ledger_type', and no balance guard. Anything that bound it
+//      silently skipped the overdraft check added by
+//      20260712160001000_atomic_use_credits_balance_guard.sql.
+//
+// 20260730012238065_credit_use_credits_single_overload.sql collapsed them, and
+// 20260805175409752_credit_use_credits_idempotency.sql deliberately REPLACED the
+// signature rather than overloading it. Nothing enforced either decision. This
+// test does: it replays every CREATE/DROP of the function across the migration
+// files in apply order and asserts the surviving set has one member.
+//
+// Signature identity here is the ordered list of INPUT ARGUMENT TYPES, which is
+// exactly how PostgreSQL identifies a function. Parameter names and DEFAULTs are
+// not part of it — that is why the 5-arg (…, p_thread_id, p_message_id) overload
+// and today's 5-arg (…, p_ledger_type, p_idempotency_key) one are the same
+// identity, and why the DROP in 20260805175409752 was required rather than
+// optional.
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const MIGRATIONS_DIR = resolve(import.meta.dir, '../../../../../packages/db/migrations');
+const FUNCTION = 'atomic_use_credits';
+
+function stripLineComments(sql: string): string {
+  return sql
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('--'))
+    .join('\n');
+}
+
+/** Text between the parenthesis that follows `from`, honouring nesting. */
+function argumentList(sql: string, openParen: number): string {
+  let depth = 0;
+  for (let i = openParen; i < sql.length; i += 1) {
+    if (sql[i] === '(') depth += 1;
+    else if (sql[i] === ')') {
+      depth -= 1;
+      if (depth === 0) return sql.slice(openParen + 1, i);
+    }
+  }
+  throw new Error('unbalanced parenthesis in migration SQL');
+}
+
+function splitTopLevel(args: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of args) {
+    if (char === '(') depth += 1;
+    if (char === ')') depth -= 1;
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current);
+  return parts.map((part) => part.trim()).filter((part) => part.length > 0);
+}
+
+/**
+ * `p_amount numeric` -> numeric, `p_description text DEFAULT 'x'::text` -> text,
+ * and for a DROP's bare list, `numeric` -> numeric.
+ */
+function argumentType(declaration: string): string {
+  const tokens = declaration.split(/\s+/);
+  const type = tokens.length === 1 ? tokens[0]! : tokens[1]!;
+  return type.toLowerCase().replace(/,$/, '');
+}
+
+function signaturesIn(sql: string, keyword: 'create' | 'drop'): string[] {
+  const pattern =
+    keyword === 'create'
+      ? new RegExp(`CREATE\\s+OR\\s+REPLACE\\s+FUNCTION\\s+public\\.${FUNCTION}\\s*\\(`, 'gi')
+      : new RegExp(`DROP\\s+FUNCTION(?:\\s+IF\\s+EXISTS)?\\s+public\\.${FUNCTION}\\s*\\(`, 'gi');
+
+  const found: string[] = [];
+  for (const match of sql.matchAll(pattern)) {
+    const openParen = match.index! + match[0].length - 1;
+    found.push(splitTopLevel(argumentList(sql, openParen)).map(argumentType).join(','));
+  }
+  return found;
+}
+
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((name) => name.endsWith('.sql'))
+    .sort();
+}
+
+function readSql(name: string): string {
+  return readFileSync(resolve(MIGRATIONS_DIR, name), 'utf8');
+}
+
+function replay(): { live: Set<string>; touched: string[]; lastCreatedBy: string } {
+  const live = new Set<string>();
+  const touched: string[] = [];
+  let lastCreatedBy = '';
+
+  for (const name of migrationFiles()) {
+    const sql = stripLineComments(readSql(name));
+    const drops = signaturesIn(sql, 'drop');
+    const creates = signaturesIn(sql, 'create');
+    if (drops.length === 0 && creates.length === 0) continue;
+    touched.push(name);
+    for (const signature of drops) live.delete(signature);
+    for (const signature of creates) live.add(signature);
+    if (creates.length > 0) lastCreatedBy = name;
+  }
+
+  return { live, touched, lastCreatedBy };
+}
+
+describe('atomic_use_credits migration source', () => {
+  test('the migrations actually define the function (the scan is not silently empty)', () => {
+    const { touched } = replay();
+    expect(touched.length).toBeGreaterThanOrEqual(4);
+    expect(touched).toContain('20260712160001000_atomic_use_credits_balance_guard.sql');
+    expect(touched).toContain('20260730012238065_credit_use_credits_single_overload.sql');
+    expect(touched).toContain('20260805175409752_credit_use_credits_idempotency.sql');
+  });
+
+  test('exactly ONE signature survives the full migration replay', () => {
+    const { live } = replay();
+    expect([...live].sort()).toEqual(['uuid,numeric,text,text,text']);
+  });
+
+  test('the baseline really did ship the two overlapping overloads this guards against', () => {
+    const baseline = stripLineComments(readSql('20260621094136410_baseline.sql'));
+    expect(signaturesIn(baseline, 'create').sort()).toEqual([
+      'uuid,numeric,text,text',
+      'uuid,numeric,text,text,text',
+    ]);
+  });
+
+  test('a new migration that adds a second overload would fail this test', () => {
+    const { live } = replay();
+    const hypothetical = new Set(live);
+    for (const signature of signaturesIn(
+      'CREATE OR REPLACE FUNCTION public.atomic_use_credits(p_account_id uuid, p_amount numeric)',
+      'create',
+    )) {
+      hypothetical.add(signature);
+    }
+    expect(hypothetical.size).toBe(2);
+  });
+
+  // Resolved from the replay, never hardcoded: a future migration that replaces
+  // the function becomes the subject of these assertions automatically, so
+  // dropping the guard on the way past fails here instead of shipping.
+  test('whichever migration defines the function LAST keeps the overdraft guard', () => {
+    const { lastCreatedBy } = replay();
+    const current = readSql(lastCreatedBy);
+    expect(current).toContain('IF v_total < p_amount THEN');
+    expect(current).toContain("'Insufficient credits'");
+  });
+
+  test('the last definition takes the row lock BEFORE the overdraft guard runs', () => {
+    const { lastCreatedBy } = replay();
+    const sql = readSql(lastCreatedBy);
+    const bodyStart = sql.indexOf('CREATE OR REPLACE FUNCTION');
+    const lockAt = sql.indexOf('FOR UPDATE', bodyStart);
+    const guardAt = sql.indexOf('IF v_total < p_amount THEN', bodyStart);
+    expect(lockAt).toBeGreaterThan(-1);
+    expect(guardAt).toBeGreaterThan(lockAt);
+  });
+
+  test('the last definition is SECURITY DEFINER with a pinned search_path', () => {
+    const { lastCreatedBy } = replay();
+    const sql = readSql(lastCreatedBy);
+    const body = sql.slice(sql.indexOf('CREATE OR REPLACE FUNCTION'));
+    expect(body).toContain('SECURITY DEFINER');
+    expect(body).toContain("SET search_path TO ''");
+    expect(body).not.toContain('SECURITY INVOKER');
+  });
+
+  test('the last definition stamps the granular kind into metadata', () => {
+    const { lastCreatedBy } = replay();
+    expect(readSql(lastCreatedBy)).toContain("'ledger_type', p_ledger_type");
+  });
+});

--- a/apps/api/src/__tests__/billing/credit-overdraft-guard.test.ts
+++ b/apps/api/src/__tests__/billing/credit-overdraft-guard.test.ts
@@ -1,0 +1,169 @@
+// Service-layer half of the overdraft-guard regression lock.
+//
+// The guard itself lives in SQL (atomic_use_credits) and is exercised against a
+// real PostgreSQL in
+// packages/db/scripts/atomic-use-credits-balance-guard.integration.test.ts.
+// This unit suite is hermetic — scripts/test.env points DATABASE_URL at a dead
+// port on purpose — so what is asserted HERE is the other half: that
+// billing/services/credits.ts propagates the guard's refusal instead of
+// swallowing it, and that a caller cannot walk a wallet negative by looping.
+//
+// The fake RPC below is a stateful wallet that reproduces the shipped function's
+// decision rule (compare p_amount against the SUM of all three buckets under a
+// lock, refuse before moving anything). It is not a re-implementation used to
+// prove the SQL correct — the container test does that — it is the fixture that
+// lets the service path be driven through the refusal.
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { mockRegistry, registerGlobalMocks, resetMockRegistry } from './mocks';
+
+registerGlobalMocks();
+
+interface Wallet {
+  daily: number;
+  expiring: number;
+  nonExpiring: number;
+}
+
+let wallet: Wallet;
+let ledgerRows: { amount: number; ledgerType: string; description: string }[] = [];
+
+function total(): number {
+  return wallet.daily + wallet.expiring + wallet.nonExpiring;
+}
+
+function atomicUseCredits(params: Record<string, unknown>) {
+  const amount = Number(params.p_amount);
+  const ledgerType = String(params.p_ledger_type ?? 'usage');
+  const description = String(params.p_description ?? 'Credit usage');
+
+  if (amount <= 0) {
+    return { data: { success: false, error: 'Amount must be positive' }, error: null };
+  }
+  if (total() < amount) {
+    return {
+      data: { success: false, error: 'Insufficient credits', required: amount, available: total() },
+      error: null,
+    };
+  }
+
+  let remaining = amount;
+  for (const bucket of ['daily', 'expiring', 'nonExpiring'] as const) {
+    const take = Math.min(wallet[bucket], remaining);
+    wallet[bucket] -= take;
+    remaining -= take;
+  }
+  ledgerRows.push({ amount: -amount, ledgerType, description });
+
+  return {
+    data: {
+      success: true,
+      amount_deducted: amount,
+      new_total: total(),
+      transaction_id: `tx_${ledgerRows.length}`,
+    },
+    error: null,
+  };
+}
+
+beforeEach(() => {
+  resetMockRegistry();
+  wallet = { daily: 0, expiring: 10, nonExpiring: 0 };
+  ledgerRows = [];
+
+  mockRegistry.supabaseRpc = {
+    rpc: (name: string, params?: Record<string, unknown>) =>
+      Promise.resolve(
+        name === 'atomic_use_credits'
+          ? atomicUseCredits(params ?? {})
+          : { data: null, error: null },
+      ),
+  } as never;
+
+  mockRegistry.getCreditAccount = async () =>
+    ({
+      accountId: 'acc_test_123',
+      balance: String(total()),
+      expiringCredits: String(wallet.expiring),
+      nonExpiringCredits: String(wallet.nonExpiring),
+      dailyCreditsBalance: String(wallet.daily),
+    }) as never;
+});
+
+const { deductCredits } = await import('../../billing/services/credits');
+const { LedgerTypeMismatchError } = await import('../../billing/ledger-type-honesty');
+
+describe('overdraft guard — service layer (regression: 20260712160001000)', () => {
+  test('a debit larger than the balance throws InsufficientCreditsError', async () => {
+    await expect(deductCredits('acc_test_123', 25, 'Overdraft attempt', 'llm_debit')).rejects.toThrow(
+      /Insufficient credits/,
+    );
+  });
+
+  test('the thrown error reports the real balance and the amount required', async () => {
+    try {
+      await deductCredits('acc_test_123', 25, 'Overdraft attempt', 'llm_debit');
+      throw new Error('unreachable');
+    } catch (err) {
+      const insufficient = err as { name: string; balance: number; required: number };
+      expect(insufficient.name).toBe('InsufficientCreditsError');
+      expect(insufficient.balance).toBe(10);
+      expect(insufficient.required).toBe(25);
+    }
+  });
+
+  test('a refused debit moves no money and writes no ledger row', async () => {
+    await deductCredits('acc_test_123', 25, 'Overdraft attempt', 'llm_debit').catch(
+      () => undefined,
+    );
+
+    expect(total()).toBe(10);
+    expect(ledgerRows).toEqual([]);
+  });
+
+  test('a debit for exactly the balance succeeds and drains to zero', async () => {
+    const result = await deductCredits('acc_test_123', 10, 'Exact drain', 'compute_debit');
+
+    expect(result.success).toBe(true);
+    expect(result.newBalance).toBe(0);
+    expect(total()).toBe(0);
+  });
+
+  test('repeated metering ticks cannot walk the balance negative', async () => {
+    let refusals = 0;
+    for (let tick = 0; tick < 6; tick += 1) {
+      await deductCredits('acc_test_123', 3, `Tick ${tick}`, 'compute_debit').catch(() => {
+        refusals += 1;
+      });
+    }
+
+    expect(total()).toBe(1);
+    expect(ledgerRows.length).toBe(3);
+    expect(refusals).toBe(3);
+  });
+
+  test('the guard sums all three buckets rather than any single one', async () => {
+    wallet = { daily: 1, expiring: 2, nonExpiring: 3 };
+    const result = await deductCredits('acc_test_123', 6, 'Spans all buckets', 'compute_debit');
+
+    expect(result.success).toBe(true);
+    expect(total()).toBe(0);
+  });
+});
+
+describe('ledger-type honesty at the RPC boundary', () => {
+  test('a non-usage ledgerType is refused before the RPC is reached', async () => {
+    await expect(
+      deductCredits('acc_test_123', 1, 'Entitlement clawback', 'admin_debit' as never),
+    ).rejects.toThrow(LedgerTypeMismatchError);
+    expect(ledgerRows).toEqual([]);
+    expect(total()).toBe(10);
+  });
+
+  test.each([['usage'], ['llm_debit'], ['compute_debit'], ['token_deduction'], ['token_overage']])(
+    'the usage-family kind %s still reaches the RPC',
+    async (kind) => {
+      await deductCredits('acc_test_123', 1, 'Billed work', kind as never);
+      expect(ledgerRows[0]!.ledgerType).toBe(kind);
+    },
+  );
+});

--- a/apps/api/src/billing/ledger-type-honesty.test.ts
+++ b/apps/api/src/billing/ledger-type-honesty.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  assertLedgerTypeHonesty,
+  assertRpcDebitLedgerType,
+  describesAdminCorrection,
+  isUsageFamilyLedgerType,
+  LedgerTypeMismatchError,
+  readDeclaredLedgerType,
+  USAGE_FAMILY_LEDGER_TYPES,
+} from './ledger-type-honesty';
+
+describe('readDeclaredLedgerType', () => {
+  test('reads metadata.ledger_type', () => {
+    expect(readDeclaredLedgerType({ ledger_type: 'admin_debit' })).toBe('admin_debit');
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(readDeclaredLedgerType({ ledger_type: '  admin_debit  ' })).toBe('admin_debit');
+  });
+
+  test.each([
+    ['null metadata', null],
+    ['undefined metadata', undefined],
+    ['array metadata', [{ ledger_type: 'admin_debit' }]],
+    ['no ledger_type key', { from_daily: 1 }],
+    ['empty string ledger_type', { ledger_type: '' }],
+    ['whitespace-only ledger_type', { ledger_type: '   ' }],
+    ['non-string ledger_type', { ledger_type: 7 }],
+  ])('returns null for %s', (_label, metadata) => {
+    expect(readDeclaredLedgerType(metadata)).toBeNull();
+  });
+});
+
+describe('isUsageFamilyLedgerType', () => {
+  test.each(USAGE_FAMILY_LEDGER_TYPES.map((kind) => [kind]))('%s is usage family', (kind) => {
+    expect(isUsageFamilyLedgerType(kind)).toBe(true);
+  });
+
+  test.each([['admin_debit'], ['admin_credit'], ['refund'], ['tier_grant'], ['forfeiture']])(
+    '%s is not usage family',
+    (kind) => {
+      expect(isUsageFamilyLedgerType(kind)).toBe(false);
+    },
+  );
+});
+
+describe('describesAdminCorrection', () => {
+  test.each([
+    ['Entitlement reconciliation clawback for 2026-07'],
+    ['Manual adjustment after support ticket'],
+    ['Admin correction (by admin 0000)'],
+    ['CLAWBACK of duplicated grant'],
+    ['Stripe chargeback'],
+  ])('flags %s', (description) => {
+    expect(describesAdminCorrection(description)).toBe(true);
+  });
+
+  test.each([
+    ['LLM · anthropic/claude-sonnet-4.6'],
+    ['Sandbox compute'],
+    ['Web search tool call'],
+    ['Credit usage'],
+    [null],
+    [undefined],
+  ])('does not flag %s', (description) => {
+    expect(describesAdminCorrection(description as string | null | undefined)).toBe(false);
+  });
+});
+
+describe('assertLedgerTypeHonesty', () => {
+  test('accepts a row with no metadata at all', () => {
+    expect(() =>
+      assertLedgerTypeHonesty({ type: 'tier_grant', description: 'Monthly grant' }),
+    ).not.toThrow();
+  });
+
+  test('accepts type matching metadata.ledger_type exactly', () => {
+    expect(() =>
+      assertLedgerTypeHonesty({
+        type: 'admin_debit',
+        description: 'Entitlement reconciliation clawback',
+        metadata: { ledger_type: 'admin_debit' },
+      }),
+    ).not.toThrow();
+  });
+
+  test.each([['llm_debit'], ['compute_debit'], ['token_deduction'], ['token_overage']])(
+    'accepts the RPC shape type=usage with granular sub-kind %s',
+    (kind) => {
+      expect(() =>
+        assertLedgerTypeHonesty({
+          type: 'usage',
+          description: 'LLM · anthropic/claude-sonnet-4.6',
+          metadata: { from_daily: 0, from_monthly: 1, from_extra: 0, ledger_type: kind },
+        }),
+      ).not.toThrow();
+    },
+  );
+
+  test('rejects the 2026-07-30 shape: type=usage with metadata.ledger_type=admin_debit', () => {
+    expect(() =>
+      assertLedgerTypeHonesty({
+        type: 'usage',
+        description: 'Entitlement clawback',
+        metadata: { ledger_type: 'admin_debit' },
+      }),
+    ).toThrow(LedgerTypeMismatchError);
+  });
+
+  test('the rejection names both sides and the honest type to write', () => {
+    try {
+      assertLedgerTypeHonesty({
+        type: 'usage',
+        description: 'x',
+        metadata: { ledger_type: 'admin_debit' },
+      });
+      throw new Error('unreachable');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LedgerTypeMismatchError);
+      const mismatch = err as LedgerTypeMismatchError;
+      expect(mismatch.rowType).toBe('usage');
+      expect(mismatch.declaredLedgerType).toBe('admin_debit');
+      expect(mismatch.statusCode).toBe(500);
+      expect(mismatch.message).toContain("type='admin_debit'");
+    }
+  });
+
+  test('rejects a non-usage type carrying a contradicting non-usage sub-kind', () => {
+    expect(() =>
+      assertLedgerTypeHonesty({
+        type: 'tier_grant',
+        description: 'Grant',
+        metadata: { ledger_type: 'refund' },
+      }),
+    ).toThrow(LedgerTypeMismatchError);
+  });
+
+  test('rejects a usage-typed row whose description reads as a reconciliation', () => {
+    expect(() =>
+      assertLedgerTypeHonesty({
+        type: 'usage',
+        description: 'Entitlement reconciliation clawback for account',
+      }),
+    ).toThrow(/operator correction/);
+  });
+
+  test('allows the same description once the type is honest', () => {
+    expect(() =>
+      assertLedgerTypeHonesty({
+        type: 'admin_debit',
+        description: 'Entitlement reconciliation clawback for account',
+      }),
+    ).not.toThrow();
+  });
+
+  test('a usage row with a machine-generated description is untouched', () => {
+    expect(() =>
+      assertLedgerTypeHonesty({
+        type: 'usage',
+        description: 'LLM · anthropic/claude-sonnet-4.6',
+        metadata: { ledger_type: 'llm_debit' },
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('assertRpcDebitLedgerType', () => {
+  test.each(USAGE_FAMILY_LEDGER_TYPES.map((kind) => [kind]))('accepts %s', (kind) => {
+    expect(() => assertRpcDebitLedgerType(kind)).not.toThrow();
+  });
+
+  test.each([['admin_debit'], ['refund'], ['adjustment']])(
+    'rejects %s because the RPC would stamp type=usage on it',
+    (kind) => {
+      expect(() => assertRpcDebitLedgerType(kind)).toThrow(LedgerTypeMismatchError);
+    },
+  );
+
+  test('the rejection explains the row shape it prevents', () => {
+    expect(() => assertRpcDebitLedgerType('admin_debit')).toThrow(
+      /atomic_use_credits writes type='usage' unconditionally/,
+    );
+  });
+});

--- a/apps/api/src/billing/ledger-type-honesty.ts
+++ b/apps/api/src/billing/ledger-type-honesty.ts
@@ -1,0 +1,168 @@
+// A credit_ledger row must not say two different things about the same money.
+//
+// THE INCIDENT (2026-07-30). A hand-run entitlement reconciliation wrote 1,609
+// clawback rows with `type = 'usage'` while stamping
+// `metadata->>'ledger_type' = 'admin_debit'`. The row therefore claimed to be
+// customer usage in one column and an operator correction in the other. A
+// -$5,239 admin correction on one account rendered as a $5.5k usage spike during
+// a fraud investigation, and every aggregation that groups on
+// credit_ledger.type counted an admin correction as revenue-bearing usage.
+// The repair is packages/db/migrations/20260807202629374_ledger_type_backfill_reconcile_20260730.sql;
+// this module is what stops it happening again.
+//
+// WHAT "HONEST" MEANS HERE. `type` and `metadata->>'ledger_type'` are NOT
+// duplicates — `ledger_type` is deliberately the finer grain. atomic_use_credits
+// writes `type = 'usage'` for every debit it makes and puts the granular kind
+// ('llm_debit', 'compute_debit', ...) in metadata. Those rows are honest: the
+// granular kind is a SUB-KIND of usage. What is dishonest is a granular kind
+// that is not usage at all — 'admin_debit', 'refund', 'adjustment' — carried on
+// a row typed 'usage'. So the invariant is not "the two fields must be equal",
+// it is "they must belong to the same family".
+//
+// THROW, NOT COERCE. The alternative was to silently rewrite `type` to
+// metadata.ledger_type. Rejected:
+//   1. No current caller of insertLedgerEntry sets metadata.ledger_type at all
+//      (billing/services/credits.ts x3, billing/services/account-deletion.ts x1),
+//      so a throw cannot break live traffic — it is a pure tripwire today.
+//   2. Coercion silently rewrites the type column of a MONEY row. Quietly
+//      resolving a contradiction in a financial ledger is the same class of
+//      behaviour that let the 2026-07-30 rows look plausible for a week. A
+//      ledger should refuse a write it cannot make honest, not guess at it.
+//   3. The honest shape is always available to the caller: admin/index.ts
+//      already passes 'admin_debit' as the row `type` directly.
+
+import { BillingError } from '../errors';
+
+/**
+ * Granular kinds that are legitimately carried on a row typed 'usage'.
+ *
+ * Kept in sync with `LedgerDebitType` (billing/services/credits.ts) and
+ * `RouterLedgerDebitType` (repositories/credits.ts) — the two unions of values
+ * that reach atomic_use_credits, which hardcodes `type = 'usage'`.
+ */
+export const USAGE_FAMILY_LEDGER_TYPES = [
+  'usage',
+  'llm_debit',
+  'compute_debit',
+  'token_deduction',
+  'token_overage',
+] as const;
+
+export type UsageFamilyLedgerType = (typeof USAGE_FAMILY_LEDGER_TYPES)[number];
+
+export function isUsageFamilyLedgerType(kind: string): boolean {
+  return (USAGE_FAMILY_LEDGER_TYPES as readonly string[]).includes(kind);
+}
+
+/**
+ * Vocabulary that marks a description as an operator correction rather than
+ * customer activity.
+ *
+ * Deliberately narrow. Every description written on a usage-family row is
+ * machine-generated from the thing being billed — 'LLM · anthropic/claude-…',
+ * 'Sandbox compute', a tool name — so none of these words can appear there by
+ * accident. Free-text descriptions only reach the ledger through admin and
+ * reconciliation paths, which is exactly the population this catches.
+ */
+const CORRECTION_DESCRIPTION_MARKERS = [
+  'admin correction',
+  'admin debit',
+  'admin credit',
+  'admin adjustment',
+  'manual adjustment',
+  'manual correction',
+  'reconciliation',
+  'reconcile',
+  'clawback',
+  'claw back',
+  'chargeback',
+  'write-off',
+  'writeoff',
+] as const;
+
+export function describesAdminCorrection(description: string | null | undefined): boolean {
+  if (!description) return false;
+  const text = description.toLowerCase();
+  return CORRECTION_DESCRIPTION_MARKERS.some((marker) => text.includes(marker));
+}
+
+export class LedgerTypeMismatchError extends BillingError {
+  constructor(
+    message: string,
+    public readonly rowType: string,
+    public readonly declaredLedgerType: string | null,
+  ) {
+    super(message, 500);
+    this.name = 'LedgerTypeMismatchError';
+  }
+}
+
+/** Reads metadata->>'ledger_type' from a value whose shape we do not control. */
+export function readDeclaredLedgerType(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return null;
+  const raw = (metadata as Record<string, unknown>).ledger_type;
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+export interface LedgerRowForHonestyCheck {
+  type: string;
+  description?: string | null;
+  metadata?: unknown;
+}
+
+/**
+ * Refuse a credit_ledger row whose `type` contradicts what the row otherwise
+ * says about itself. Called on the shared insert path before the row is written.
+ */
+export function assertLedgerTypeHonesty(row: LedgerRowForHonestyCheck): void {
+  const rowType = row.type;
+  const declared = readDeclaredLedgerType(row.metadata);
+
+  if (declared !== null && declared !== rowType) {
+    const bothUsageFamily = isUsageFamilyLedgerType(rowType) && isUsageFamilyLedgerType(declared);
+    if (!bothUsageFamily) {
+      throw new LedgerTypeMismatchError(
+        `credit_ledger row declares metadata.ledger_type='${declared}' but type='${rowType}'. ` +
+          `'${declared}' is not a sub-kind of '${rowType}', so the row would report itself as two ` +
+          `different things (the 2026-07-30 mislabelled-clawback incident). Write type='${declared}'.`,
+        rowType,
+        declared,
+      );
+    }
+  }
+
+  if (isUsageFamilyLedgerType(rowType) && describesAdminCorrection(row.description)) {
+    throw new LedgerTypeMismatchError(
+      `credit_ledger row has type='${rowType}' but its description reads as an operator ` +
+        `correction: ${JSON.stringify(row.description)}. An admin correction is not customer ` +
+        `usage — write the correction's own type (e.g. 'admin_debit') so usage aggregation ` +
+        `stays truthful (the 2026-07-30 mislabelled-clawback incident).`,
+      rowType,
+      declared,
+    );
+  }
+}
+
+/**
+ * Guard the RPC debit path.
+ *
+ * atomic_use_credits hardcodes `type = 'usage'` on the row it inserts and copies
+ * its `p_ledger_type` argument into metadata verbatim. Passing a non-usage kind
+ * through it therefore MANUFACTURES the 2026-07-30 row shape — the caller cannot
+ * make that row honest, because it does not control the type column. Reject at
+ * the boundary instead.
+ */
+export function assertRpcDebitLedgerType(ledgerType: string): void {
+  if (!isUsageFamilyLedgerType(ledgerType)) {
+    throw new LedgerTypeMismatchError(
+      `atomic_use_credits writes type='usage' unconditionally, so ledgerType='${ledgerType}' ` +
+        `would produce a row that calls itself usage in one column and '${ledgerType}' in ` +
+        `another (the 2026-07-30 mislabelled-clawback incident). Non-usage kinds must be ` +
+        `written through the ledger insert path with their own type.`,
+      'usage',
+      ledgerType,
+    );
+  }
+}

--- a/apps/api/src/billing/repositories/transactions.test.ts
+++ b/apps/api/src/billing/repositories/transactions.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let inserted: Record<string, unknown>[] = [];
+
+mock.module('../../shared/db', () => ({
+  db: {
+    insert: () => ({
+      values: (data: Record<string, unknown>) => ({
+        returning: async () => {
+          inserted.push(data);
+          return [{ id: 'ledger_row_1', ...data }];
+        },
+      }),
+    }),
+  },
+  hasDatabase: false,
+}));
+
+const { insertLedgerEntry } = await import('./transactions');
+const { LedgerTypeMismatchError } = await import('../ledger-type-honesty');
+
+beforeEach(() => {
+  inserted = [];
+});
+
+describe('insertLedgerEntry honesty guard', () => {
+  test('writes a row whose type nothing contradicts', async () => {
+    const row = await insertLedgerEntry({
+      accountId: 'acc_1',
+      amount: '50',
+      balanceAfter: '150',
+      type: 'tier_grant',
+      description: 'Monthly grant',
+      isExpiring: true,
+    } as never);
+
+    expect(inserted.length).toBe(1);
+    expect((row as { type: string }).type).toBe('tier_grant');
+  });
+
+  test('writes the forfeiture row account deletion depends on', async () => {
+    await insertLedgerEntry({
+      accountId: 'acc_1',
+      amount: '-12',
+      balanceAfter: '0',
+      type: 'forfeiture',
+      description: 'Account deletion: credit balance forfeited',
+      isExpiring: false,
+    } as never);
+
+    expect(inserted.length).toBe(1);
+  });
+
+  test('refuses the 2026-07-30 mislabelled-clawback shape', async () => {
+    await expect(
+      insertLedgerEntry({
+        accountId: 'acc_1',
+        amount: '-5239.44',
+        balanceAfter: '0',
+        type: 'usage',
+        description: 'Entitlement clawback',
+        metadata: { ledger_type: 'admin_debit' },
+      } as never),
+    ).rejects.toThrow(LedgerTypeMismatchError);
+  });
+
+  test('a refused row never reaches the database', async () => {
+    await insertLedgerEntry({
+      accountId: 'acc_1',
+      amount: '-5239.44',
+      balanceAfter: '0',
+      type: 'usage',
+      description: 'Entitlement clawback',
+      metadata: { ledger_type: 'admin_debit' },
+    } as never).catch(() => undefined);
+
+    expect(inserted).toEqual([]);
+  });
+
+  test('refuses a usage-typed row whose description reads as a reconciliation', async () => {
+    await expect(
+      insertLedgerEntry({
+        accountId: 'acc_1',
+        amount: '-5239.44',
+        balanceAfter: '0',
+        type: 'usage',
+        description: 'Entitlement reconciliation clawback 2026-07',
+      } as never),
+    ).rejects.toThrow(LedgerTypeMismatchError);
+    expect(inserted).toEqual([]);
+  });
+
+  test('accepts the same correction once it is typed honestly', async () => {
+    await insertLedgerEntry({
+      accountId: 'acc_1',
+      amount: '-5239.44',
+      balanceAfter: '0',
+      type: 'admin_debit',
+      description: 'Entitlement reconciliation clawback 2026-07',
+      metadata: { ledger_type: 'admin_debit' },
+    } as never);
+
+    expect(inserted.length).toBe(1);
+    expect(inserted[0]!.type).toBe('admin_debit');
+  });
+
+  test('still accepts the RPC-shaped usage row with a granular sub-kind', async () => {
+    await insertLedgerEntry({
+      accountId: 'acc_1',
+      amount: '-0.42',
+      balanceAfter: '99.58',
+      type: 'usage',
+      description: 'LLM · anthropic/claude-sonnet-4.6',
+      metadata: { from_daily: 0, from_monthly: 0.42, from_extra: 0, ledger_type: 'llm_debit' },
+    } as never);
+
+    expect(inserted.length).toBe(1);
+  });
+});

--- a/apps/api/src/billing/repositories/transactions.ts
+++ b/apps/api/src/billing/repositories/transactions.ts
@@ -1,8 +1,19 @@
 import { eq, desc, sql, and, gte, inArray } from 'drizzle-orm';
 import { creditLedger, creditUsage, creditPurchases } from '@kortix/db';
 import { db } from '../../shared/db';
+import { assertLedgerTypeHonesty } from '../ledger-type-honesty';
 
+/**
+ * The ONLY Drizzle write path into kortix.credit_ledger (the other writer is the
+ * atomic_use_credits / atomic_add_credits RPC pair, in SQL).
+ *
+ * Every row passes assertLedgerTypeHonesty first: a row may not claim one kind
+ * in `type` and a contradicting kind in `metadata.ledger_type` or its
+ * description. See billing/ledger-type-honesty.ts for the 2026-07-30
+ * mislabelled-clawback incident this closes.
+ */
 export async function insertLedgerEntry(data: typeof creditLedger.$inferInsert) {
+  assertLedgerTypeHonesty(data);
   const [row] = await db.insert(creditLedger).values(data).returning();
   return row;
 }

--- a/apps/api/src/billing/services/credits.ts
+++ b/apps/api/src/billing/services/credits.ts
@@ -7,6 +7,7 @@ import {
   updateCreditAccount,
 } from '../repositories/credit-accounts';
 import { insertLedgerEntry } from '../repositories/transactions';
+import { assertRpcDebitLedgerType } from '../ledger-type-honesty';
 import { MINIMUM_CREDIT_FOR_RUN, TOKEN_PRICE_MULTIPLIER } from './tiers';
 import { getManagedModel } from '@kortix/llm-catalog';
 import { calculateCost as calculateGatewayCost } from '@kortix/llm-gateway';
@@ -103,6 +104,11 @@ export async function deductCredits(
    */
   idempotencyKey?: string,
 ) {
+  // The RPC hardcodes `type = 'usage'` on the ledger row, so a non-usage kind
+  // here manufactures a row that contradicts itself. Reject before the money
+  // moves rather than after (2026-07-30 mislabelled-clawback incident).
+  assertRpcDebitLedgerType(ledgerType);
+
   const supabase = getSupabase();
 
   const { data, error } = await supabase.rpc('atomic_use_credits', {

--- a/apps/api/src/repositories/credits.ts
+++ b/apps/api/src/repositories/credits.ts
@@ -3,6 +3,7 @@ import { sql } from 'drizzle-orm';
 import { creditAccounts } from '@kortix/db';
 import { db } from '../shared/db';
 import { config } from '../config';
+import { assertRpcDebitLedgerType } from '../billing/ledger-type-honesty';
 
 interface CreditBalance {
   balance: number;
@@ -122,6 +123,13 @@ export async function deductCredits(
   description: string,
   ledgerType: RouterLedgerDebitType = 'usage',
 ): Promise<CreditDeductResult> {
+  // The RPC hardcodes `type = 'usage'` on the ledger row, so a non-usage kind
+  // here manufactures a row that contradicts itself. Checked BEFORE the
+  // billing-disabled short circuit so a self-hosted run rejects the same
+  // programming error a managed run does (2026-07-30 mislabelled-clawback
+  // incident; see billing/ledger-type-honesty.ts).
+  assertRpcDebitLedgerType(ledgerType);
+
   // Billing disabled: no deduction
   if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
     return { success: true, amountDeducted: 0, newBalance: 0 };

--- a/packages/db/migrations/20260807202629374_ledger_type_backfill_reconcile_20260730.sql
+++ b/packages/db/migrations/20260807202629374_ledger_type_backfill_reconcile_20260730.sql
@@ -1,0 +1,91 @@
+-- Migration: ledger_type_backfill_reconcile_20260730
+--
+-- SAFETY HEADER (house rules -- see packages/db/MIGRATIONS.md#zero-downtime-rules).
+set lock_timeout = '2s';
+-- Deliberately raised from the 30s template default. The predicate below reads
+-- metadata->>'ledger_type', which no index covers, so this is a sequential scan
+-- of kortix.credit_ledger. The scan itself blocks nothing: it takes ACCESS SHARE,
+-- and the UPDATE takes ROW EXCLUSIVE plus row locks on the ~1,609 matched rows
+-- only. Neither conflicts with ordinary INSERT/UPDATE traffic from the API, so a
+-- long statement here costs wall-clock, not availability. lock_timeout stays at
+-- 2s so the migration still fails fast if something is holding a table-level
+-- lock (a concurrent DDL/VACUUM FULL) rather than queueing behind it.
+set statement_timeout = '300s';
+
+-- WHY
+--
+-- On 2026-07-30 a hand-run entitlement reconciliation wrote clawback rows into
+-- kortix.credit_ledger with type = 'usage' while stamping
+-- metadata->>'ledger_type' = 'admin_debit'. The row therefore says two different
+-- things about the same money.
+--
+-- Consequences of leaving it:
+--   1. A -$5,239.xx operator correction on one account renders as a $5.5k usage
+--      spike. That is what it looked like during a fraud investigation.
+--   2. Any aggregation that groups on credit_ledger.type -- the
+--      /billing/transactions type filter (apps/api/src/billing/repositories/
+--      transactions.ts getTransactions) and every ad-hoc revenue query -- counts
+--      an admin correction as customer usage.
+--
+-- The usage breakdown (apps/api/src/billing/services/usage-breakdown.ts) already
+-- resolves the kind as COALESCE(NULLIF(metadata->>'ledger_type',''), type), so it
+-- classifies these rows correctly TODAY and will keep classifying them correctly
+-- AFTER this backfill -- metadata is not touched, and the fallback arm now agrees
+-- with the primary arm instead of contradicting it. This migration makes the two
+-- columns tell the same story; it does not change what the breakdown reports.
+--
+-- 'admin_debit' is an already-live value of this text column, not a new one:
+-- apps/api/src/admin/index.ts writes it directly via grantCredits(..., 'admin_debit',
+-- ...), and usage-breakdown.ts lists it in OTHER_DEBIT_KINDS. credit_ledger.type
+-- is `text`, not an enum, so there is no enum value to add and no
+-- enum-value-checked annotation to make.
+--
+-- mixed-version-safe: no schema object is dropped, renamed, or retyped -- this is
+-- a data-only relabel, so the mixed-version guard does not require an annotation.
+-- Recording the reasoning anyway: an API pod of ANY version reading these rows
+-- goes through usage-breakdown's COALESCE (metadata unchanged -> same answer) or
+-- through getTransactions' optional `type` filter. The only behaviour change for
+-- an old pod is that an explicit filter for type='usage' stops returning admin
+-- corrections, which is the defect being fixed, not a regression.
+--
+-- ROW-COUNT EXPECTATION
+--   prod, first run:  ~1,609 rows (the 2026-07-30 reconciliation batch)
+--   prod, re-run:     0 rows (the predicate no longer matches -- see IDEMPOTENCE)
+--   dev / staging / local / self-host: 0 rows (never took that reconciliation)
+--
+-- IDEMPOTENCE
+-- The predicate is self-extinguishing: it selects on type = 'usage', and the
+-- UPDATE sets type = 'admin_debit'. A second run matches nothing and is a no-op.
+-- 0 affected rows is therefore a SUCCESS, not a signal that the migration failed.
+--
+-- BLAST-RADIUS CEILING
+-- The predicate is intentionally unbounded in time -- a row whose type and
+-- metadata disagree in this exact way is mislabelled whenever it was written, and
+-- the 2026-07-30 batch is the only known population. The ceiling below exists so
+-- that if the predicate ever matches a population we did not reason about, the
+-- migration aborts the transaction instead of silently rewriting money rows.
+-- 10,000 is ~6x the known batch: loose enough to absorb an under-counted incident,
+-- tight enough to catch "this is matching normal traffic".
+
+DO $$
+DECLARE
+  v_updated bigint;
+BEGIN
+  UPDATE kortix.credit_ledger
+  SET type = 'admin_debit'
+  WHERE type = 'usage'
+    AND metadata ->> 'ledger_type' = 'admin_debit';
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  IF v_updated > 10000 THEN
+    RAISE EXCEPTION
+      'ledger_type backfill matched % credit_ledger rows; expected <= 10000 (~1609 on prod). Aborting so nothing is rewritten -- re-verify the predicate before re-running.',
+      v_updated;
+  END IF;
+
+  RAISE NOTICE
+    'ledger_type backfill: relabelled % credit_ledger rows usage -> admin_debit (prod expectation ~1609; 0 on a re-run or in an environment that never took the 2026-07-30 reconciliation).',
+    v_updated;
+END;
+$$;

--- a/packages/db/scripts/atomic-use-credits-balance-guard.integration.test.ts
+++ b/packages/db/scripts/atomic-use-credits-balance-guard.integration.test.ts
@@ -1,0 +1,281 @@
+// The overdraft guard inside atomic_use_credits, executed by a REAL PostgreSQL.
+//
+// This function is the only thing standing between a metering tick and a
+// negative wallet. It was hardened twice and tested zero times:
+//
+//   20260712160001000_atomic_use_credits_balance_guard.sql
+//     added `IF v_total < p_amount THEN RETURN ... 'Insufficient credits'`
+//     under the existing `FOR UPDATE` row lock.
+//   20260730012238065_credit_use_credits_single_overload.sql
+//     collapsed two overlapping overloads into one, because the WEAKER of the
+//     two (SECURITY INVOKER, no ledger_type, and NO BALANCE GUARD) could be
+//     bound by an ordinary four-argument positional call.
+//
+// So the guard has silently regressed once already, by being bypassed rather
+// than by being edited. Every case below runs the SHIPPED migration text — not a
+// TypeScript re-description of it — against a disposable server.
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { resolve } from 'node:path';
+
+const dockerAvailable =
+  Bun.spawnSync(['docker', 'version'], { stdout: 'ignore', stderr: 'ignore' }).exitCode === 0;
+
+const container = `kortix-credit-guard-${crypto.randomUUID().slice(0, 8)}`;
+
+function psql(sql: string, allowFailure = false, extraArgs: string[] = []) {
+  const result = Bun.spawnSync(
+    [
+      'docker',
+      'exec',
+      '-i',
+      container,
+      'psql',
+      '-U',
+      'postgres',
+      '-d',
+      'testdb',
+      '-v',
+      'ON_ERROR_STOP=1',
+      ...extraArgs,
+    ],
+    { stdin: Buffer.from(sql), stdout: 'pipe', stderr: 'pipe' },
+  );
+  const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+  if (!allowFailure && result.exitCode !== 0) throw new Error(output);
+  return { exitCode: result.exitCode, output };
+}
+
+function scalar(sql: string): string {
+  return psql(sql, false, ['-t', '-A']).output.trim();
+}
+
+function useCredits(args: string): Record<string, unknown> {
+  return JSON.parse(scalar(`SELECT public.atomic_use_credits(${args});`));
+}
+
+const ACCOUNT = '00000000-0000-4000-a000-000000000001';
+
+function reseed(daily: string, expiring: string, nonExpiring: string) {
+  psql(`
+    DELETE FROM kortix.credit_ledger WHERE account_id = '${ACCOUNT}';
+    DELETE FROM kortix.credit_accounts WHERE account_id = '${ACCOUNT}';
+    INSERT INTO kortix.credit_accounts(
+      account_id, daily_credits_balance_precise, expiring_credits_precise,
+      non_expiring_credits_precise, balance_precise
+    ) VALUES (
+      '${ACCOUNT}', ${daily}, ${expiring}, ${nonExpiring},
+      ${daily} + ${expiring} + ${nonExpiring}
+    );
+  `);
+}
+
+function balance(): number {
+  return Number(
+    scalar(
+      `SELECT balance_precise FROM kortix.credit_accounts WHERE account_id = '${ACCOUNT}';`,
+    ),
+  );
+}
+
+function ledgerRowCount(): number {
+  return Number(
+    scalar(`SELECT count(*) FROM kortix.credit_ledger WHERE account_id = '${ACCOUNT}';`),
+  );
+}
+
+describe.skipIf(!dockerAvailable)('atomic_use_credits overdraft guard — real PostgreSQL', () => {
+  beforeAll(async () => {
+    const started = Bun.spawnSync([
+      'docker',
+      'run',
+      '--rm',
+      '-d',
+      '--name',
+      container,
+      '-e',
+      'POSTGRES_PASSWORD=test',
+      '-e',
+      'POSTGRES_DB=testdb',
+      'postgres:16-alpine',
+    ]);
+    if (started.exitCode !== 0) throw new Error(started.stderr.toString());
+
+    let ready = false;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const probe = Bun.spawnSync(
+        ['docker', 'exec', container, 'psql', '-U', 'postgres', '-d', 'testdb', '-c', 'SELECT 1'],
+        { stdout: 'ignore', stderr: 'ignore' },
+      );
+      if (probe.exitCode === 0) {
+        ready = true;
+        break;
+      }
+      await Bun.sleep(250);
+    }
+    if (!ready) throw new Error('Disposable PostgreSQL did not become ready');
+
+    // Only the tables the function touches, with the columns it names. Every
+    // balance column is NULLABLE exactly as in production, because the function
+    // COALESCEs them and a NOT NULL here would hide a defect in that COALESCE.
+    psql(`
+      CREATE ROLE service_role;
+      CREATE ROLE authenticated;
+      CREATE SCHEMA kortix;
+      CREATE TABLE kortix.credit_accounts (
+        account_id uuid PRIMARY KEY,
+        daily_credits_balance_precise numeric(20,10),
+        expiring_credits_precise numeric(20,10),
+        non_expiring_credits_precise numeric(20,10),
+        balance_precise numeric(20,10),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      );
+      CREATE TABLE kortix.credit_ledger (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        account_id uuid NOT NULL,
+        amount numeric(12,4) NOT NULL DEFAULT 0,
+        amount_precise numeric(20,10) NOT NULL DEFAULT 0,
+        balance_after numeric(12,4) NOT NULL DEFAULT 0,
+        balance_after_precise numeric(20,10) NOT NULL DEFAULT 0,
+        type text NOT NULL,
+        description text,
+        metadata jsonb DEFAULT '{}'::jsonb,
+        idempotency_key text,
+        created_at timestamptz DEFAULT now()
+      );
+      CREATE INDEX idx_credit_ledger_idempotency ON kortix.credit_ledger(idempotency_key)
+        WHERE idempotency_key IS NOT NULL;
+    `);
+
+    // The CURRENT shipped definition, verbatim. Reading it from the migration
+    // file is the point: a future migration that replaces the function without
+    // carrying the guard forward fails these tests instead of passing them.
+    const migration = await Bun.file(
+      resolve(
+        import.meta.dir,
+        '..',
+        'migrations',
+        '20260805175409752_credit_use_credits_idempotency.sql',
+      ),
+    ).text();
+    const functionText = migration.slice(migration.indexOf('DROP FUNCTION IF EXISTS'));
+    if (!functionText.includes("IF v_total < p_amount THEN")) {
+      throw new Error(
+        'the shipped atomic_use_credits no longer contains the balance guard — this test is the alarm',
+      );
+    }
+    psql(functionText);
+  });
+
+  afterAll(() => {
+    Bun.spawnSync(['docker', 'rm', '-f', container], { stdout: 'ignore', stderr: 'ignore' });
+  });
+
+  test('refuses a debit larger than the balance and reports what was available', () => {
+    reseed('0', '10', '0');
+    const result = useCredits(`'${ACCOUNT}'::uuid, 25::numeric, 'Overdraft attempt', 'llm_debit'`);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Insufficient credits');
+    expect(Number(result.required)).toBe(25);
+    expect(Number(result.available)).toBe(10);
+  });
+
+  test('a refused debit moves no money and writes no ledger row', () => {
+    reseed('0', '10', '0');
+    useCredits(`'${ACCOUNT}'::uuid, 25::numeric, 'Overdraft attempt', 'llm_debit'`);
+
+    expect(balance()).toBe(10);
+    expect(ledgerRowCount()).toBe(0);
+  });
+
+  test('refuses a debit one cent over the balance', () => {
+    reseed('0', '10', '0');
+    const result = useCredits(`'${ACCOUNT}'::uuid, 10.01::numeric, 'One cent over', 'llm_debit'`);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Insufficient credits');
+    expect(balance()).toBe(10);
+  });
+
+  test('allows a debit for exactly the balance and drains the wallet to zero', () => {
+    reseed('0', '10', '0');
+    const result = useCredits(`'${ACCOUNT}'::uuid, 10::numeric, 'Exact drain', 'llm_debit'`);
+
+    expect(result.success).toBe(true);
+    expect(Number(result.amount_deducted)).toBe(10);
+    expect(Number(result.new_total)).toBe(0);
+    expect(balance()).toBe(0);
+    expect(ledgerRowCount()).toBe(1);
+  });
+
+  test('the guard sums all three buckets, not just the one being spent', () => {
+    reseed('1', '2', '3');
+    const ok = useCredits(`'${ACCOUNT}'::uuid, 6::numeric, 'Spans all buckets', 'compute_debit'`);
+    expect(ok.success).toBe(true);
+    expect(Number(ok.from_daily)).toBe(1);
+    expect(Number(ok.from_monthly)).toBe(2);
+    expect(Number(ok.from_extra)).toBe(3);
+
+    reseed('1', '2', '3');
+    const over = useCredits(`'${ACCOUNT}'::uuid, 6.5::numeric, 'One over', 'compute_debit'`);
+    expect(over.success).toBe(false);
+    expect(Number(over.available)).toBe(6);
+  });
+
+  test('refuses a non-positive amount before touching the wallet', () => {
+    reseed('0', '10', '0');
+    for (const amount of ['0', '-5']) {
+      const result = useCredits(`'${ACCOUNT}'::uuid, ${amount}::numeric, 'Bad amount', 'usage'`);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Amount must be positive');
+    }
+    expect(balance()).toBe(10);
+    expect(ledgerRowCount()).toBe(0);
+  });
+
+  test('refuses an account that has no credit account row', () => {
+    psql(`DELETE FROM kortix.credit_accounts WHERE account_id = '${ACCOUNT}';`);
+    const result = useCredits(`'${ACCOUNT}'::uuid, 1::numeric, 'No account', 'usage'`);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('No credit account found');
+  });
+
+  test('sequential debits cannot walk the balance negative', () => {
+    reseed('0', '10', '0');
+    for (let i = 0; i < 5; i += 1) {
+      useCredits(`'${ACCOUNT}'::uuid, 3::numeric, 'Tick ${i}', 'compute_debit'`);
+    }
+
+    expect(balance()).toBe(1);
+    expect(ledgerRowCount()).toBe(3);
+  });
+
+  test('a replayed idempotency key succeeds without debiting twice', () => {
+    reseed('0', '10', '0');
+    const first = useCredits(
+      `'${ACCOUNT}'::uuid, 4::numeric, 'Metered window', 'compute_debit', 'window-1'`,
+    );
+    const second = useCredits(
+      `'${ACCOUNT}'::uuid, 4::numeric, 'Metered window', 'compute_debit', 'window-1'`,
+    );
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    expect(second.replayed).toBe(true);
+    expect(second.transaction_id).toBe(first.transaction_id);
+    expect(balance()).toBe(6);
+    expect(ledgerRowCount()).toBe(1);
+  });
+
+  test('every written debit row stamps its granular kind into metadata', () => {
+    reseed('0', '10', '0');
+    useCredits(`'${ACCOUNT}'::uuid, 1::numeric, 'LLM call', 'llm_debit'`);
+
+    expect(
+      scalar(
+        `SELECT metadata ->> 'ledger_type' FROM kortix.credit_ledger WHERE account_id = '${ACCOUNT}';`,
+      ),
+    ).toBe('llm_debit');
+  });
+});


### PR DESCRIPTION
## Problem

The 2026-07-30 hand-run entitlement reconciliation wrote its clawback rows into `kortix.credit_ledger` with `type='usage'` (`metadata.ledger_type='admin_debit'`). A -$5,239.65 admin correction on one account therefore rendered as a $5.5k usage spike and derailed a fraud investigation today; the mislabel also corrupts every usage aggregation. Separately, the `atomic_use_credits` overdraft guard (migrations `20260712160001000`, `20260730012238065`) — the fix for June's -$6,818 compute overdraft month — had zero regression tests, and its single-overload invariant has broken twice.

## Changes

1. **Write-path honesty guard** (`billing/ledger-type-honesty.ts`, wired into `insertLedgerEntry` + both `deductCredits` paths): a usage-family row cannot carry a non-usage `metadata.ledger_type` (throws — no call site sets it today, verified, so pure tripwire), and usage rows with operator-correction descriptions (`reconciliation`, `clawback`, …) are refused. `assertRpcDebitLedgerType` blocks manufacturing the bad shape through the RPC's `p_ledger_type`.
2. **Backfill migration** `20260807202629374`: relabels the mislabeled rows `usage` → `admin_debit`. Idempotent; aborts if >10,000 rows match. Prod predicate count verified today: **1,422 rows** (read-only check).
3. **Regression tests**: dockerized integration suite executes the shipped `atomic_use_credits` migration text (refusal above balance, no partial writes, idempotency replay — 10 pass); a migration-replay test asserts exactly ONE function signature survives across all 146 migrations (the invariant that broke twice); service-layer overdraft tests (12 pass); guard tests (58 pass).

## Verification (agent-run, real output in commits)

- `apps/api` full hermetic suite: 5842 pass / 0 fail. `packages/db` script tests: 109 pass / 0 fail. `tsc --noEmit` clean. `pnpm --filter @kortix/db lint`: 146 files pass.
- Backfill rehearsed on a seeded Postgres container with the incident shape: run 1 relabels exactly the 1,609 seeded rows and matches the -$5,239 sum; run 2 relabels 0; honest `usage`+`llm_debit` rows untouched; ceiling test aborts and rolls back.

## Follow-up (not in this PR)

`atomic_use_credits` still hardcodes `type='usage'` internally; replacing the function to derive type from `p_ledger_type` family is deliberately decoupled from this data repair (single-overload risk).
