### PR TITLE
feat(web): first-class legacy-session UX — restore language, not 'Done'

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -8,7 +8,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 
 import { ClientErrorBoundary } from '@/components/common/error-boundary';
-import { sessionDisplayLabel } from '@/components/projects/session-label';
+import { isLegacyMigratedSession, sessionDisplayLabel } from '@/components/projects/session-label';
 import { Button } from '@/components/ui/button';
 import Loading from '@/components/ui/loading';
 import { errorToast, successToast } from '@/components/ui/toast';
@@ -523,6 +523,26 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
     // into the FAILURE card above and claim a session that merely stopped had
     // failed before it ever got a computer.
     if (dormantWithoutRuntime) {
+      // A migrated session's first open lands here by design: it has never had
+      // a computer. "Stopped" would be a lie — nothing ever ran. Say what it is
+      // and make the CTA the restore it actually performs.
+      if (currentProjectSession && isLegacyMigratedSession(currentProjectSession)) {
+        return (
+          <InlineSessionError
+            title="Legacy session"
+            message="This conversation was imported from Suna. Restore the session to load its chat history — its files are already in the project under legacy/."
+            detail={restart.errorMessage ?? undefined}
+            action={
+              <RestartSessionButton
+                restart={restart}
+                onRestart={handleRestart}
+                label="Restore session"
+                pendingLabel="Restoring…"
+              />
+            }
+          />
+        );
+      }
       return (
         <InlineSessionError
           title="This session is stopped"
@@ -644,9 +664,13 @@ function ProjectSessionRuntimeConnection({ children }: { children: ReactNode }) 
 function RestartSessionButton({
   restart,
   onRestart,
+  label = 'Restart session',
+  pendingLabel = 'Restarting…',
 }: {
   restart: { isPending: boolean };
   onRestart: () => void;
+  label?: string;
+  pendingLabel?: string;
 }) {
   return (
     <Button
@@ -662,7 +686,7 @@ function RestartSessionButton({
       ) : (
         <RotateCcw className="size-3.5 shrink-0" />
       )}
-      {restart.isPending ? 'Restarting…' : 'Restart session'}
+      {restart.isPending ? pendingLabel : label}
     </Button>
   );
 }

--- a/apps/web/src/components/projects/session-label.test.ts
+++ b/apps/web/src/components/projects/session-label.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type { ProjectSession, ProjectSessionStatus } from '@kortix/sdk';
 import {
+  isLegacyMigratedSession,
   matchesSourceFilters,
   matchesStatusFilters,
   SESSION_DISPLAY_STATUS_LABELS,
@@ -56,7 +57,7 @@ describe('sessionDisplayStatus', () => {
 
   test('every display status has a label', () => {
     const all: SessionDisplayStatus[] = [
-      'needs-you', 'starting', 'running', 'done', 'stopped', 'failed',
+      'needs-you', 'starting', 'running', 'done', 'stopped', 'failed', 'legacy',
     ];
     for (const value of all) {
       expect(SESSION_DISPLAY_STATUS_LABELS[value]).toBeTruthy();
@@ -79,6 +80,49 @@ describe('sessionDisplayStatus', () => {
 
   test('labels never say "Active" — the data cannot support it', () => {
     expect(Object.values(SESSION_DISPLAY_STATUS_LABELS)).not.toContain('Active');
+  });
+});
+
+describe('legacy migrated sessions', () => {
+  const legacyMeta = {
+    legacy_migration: { run_id: 'suna-a1', source_sandbox_id: 'proj-1' },
+  };
+
+  test('detected by legacy_migration metadata', () => {
+    expect(isLegacyMigratedSession(makeSession({ metadata: legacyMeta }))).toBe(true);
+    expect(isLegacyMigratedSession(makeSession({ metadata: {} }))).toBe(false);
+    expect(isLegacyMigratedSession(makeSession())).toBe(false);
+  });
+
+  test("dormant migrated sessions display as 'legacy', never 'done' or 'stopped'", () => {
+    expect(sessionDisplayStatus(makeSession({ status: 'completed', metadata: legacyMeta }))).toBe(
+      'legacy',
+    );
+    expect(sessionDisplayStatus(makeSession({ status: 'stopped', metadata: legacyMeta }))).toBe(
+      'legacy',
+    );
+  });
+
+  test('a restored (live) migrated session keeps its live paint', () => {
+    expect(sessionDisplayStatus(makeSession({ status: 'running', metadata: legacyMeta }))).toBe(
+      'running',
+    );
+    expect(sessionDisplayStatus(makeSession({ status: 'provisioning', metadata: legacyMeta }))).toBe(
+      'starting',
+    );
+  });
+
+  test('a pending review still outranks the legacy state', () => {
+    expect(sessionDisplayStatus(makeSession({ status: 'completed', metadata: legacyMeta }), 1)).toBe(
+      'needs-you',
+    );
+  });
+
+  test("the 'legacy' filter matches migrated sessions; 'done' does not", () => {
+    const dormant = makeSession({ status: 'completed', metadata: legacyMeta });
+    expect(matchesStatusFilters(dormant, ['legacy'])).toBe(true);
+    expect(matchesStatusFilters(dormant, ['done'])).toBe(false);
+    expect(matchesStatusFilters(makeSession({ status: 'completed' }), ['legacy'])).toBe(false);
   });
 });
 

--- a/apps/web/src/components/projects/session-label.ts
+++ b/apps/web/src/components/projects/session-label.ts
@@ -110,7 +110,8 @@ export type SessionDisplayStatus =
   | 'running'
   | 'done'
   | 'stopped'
-  | 'failed';
+  | 'failed'
+  | 'legacy';
 
 /** Tooltip + section copy. Never "Active": `running` means the sandbox is up,
  *  not that the agent is working, and the payload carries no signal for that. */
@@ -121,7 +122,19 @@ export const SESSION_DISPLAY_STATUS_LABELS: Record<SessionDisplayStatus, string>
   done: 'Done',
   stopped: 'Stopped',
   failed: 'Failed',
+  legacy: 'Legacy import — open to restore',
 };
+
+/**
+ * A session created by the Suna account migration. Its chat history lives in
+ * the migrated archive and is loaded into the sandbox when the session is
+ * restored; the workspace files are already in the repo under `legacy/`.
+ * Stamped by the migration's db phase as `metadata.legacy_migration`.
+ */
+export function isLegacyMigratedSession(session: ProjectSession): boolean {
+  const meta = (session.metadata ?? {}) as Record<string, unknown>;
+  return Boolean(meta.legacy_migration);
+}
 
 /**
  * Resolve a session to its display status.
@@ -150,9 +163,12 @@ export function sessionDisplayStatus(
     case 'running':
       return 'running';
     case 'completed':
-      return 'done';
     case 'stopped':
-      return 'stopped';
+      // A dormant migrated session is not "done" — nothing ran and nothing
+      // finished; its chat is waiting to be restored. Live states above keep
+      // their normal paint once the session has actually been restored.
+      if (isLegacyMigratedSession(session)) return 'legacy';
+      return session.status === 'completed' ? 'done' : 'stopped';
     case 'failed':
       return 'failed';
     default:
@@ -173,7 +189,7 @@ export type SessionSourceFilter =
   | 'email'
   | 'schedule'
   | 'webhook';
-export type SessionStatusFilter = 'running' | 'done' | 'stopped' | 'failed';
+export type SessionStatusFilter = 'running' | 'done' | 'stopped' | 'failed' | 'legacy';
 
 export const SESSION_SOURCE_FILTERS: Array<{ value: SessionSourceFilter; label: string }> = [
   { value: 'mine', label: 'My chats' },
@@ -190,6 +206,7 @@ export const SESSION_STATUS_FILTERS: Array<{ value: SessionStatusFilter; label: 
   { value: 'done', label: 'Done' },
   { value: 'stopped', label: 'Stopped' },
   { value: 'failed', label: 'Failed' },
+  { value: 'legacy', label: 'Legacy' },
 ];
 
 /** Selected values are ORed. Empty = everything. */

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -63,6 +63,7 @@ import { contract, qk } from '@kortix/sdk/react';
 import {
   CalendarDotsIcon as CalendarClock,
   CaretRightIcon,
+  ClockCounterClockwiseIcon,
   DotsThreeIcon,
   EnvelopeIcon as Mail,
   FolderSimpleIcon as MetaFolder,
@@ -908,6 +909,10 @@ const STATUS_DOT_STYLE: Record<
   done: { color: 'var(--muted-foreground)', glyph: 'check', fill: false },
   stopped: { color: 'var(--muted-foreground)', glyph: 'ring', fill: false },
   failed: { color: 'var(--kortix-red)', glyph: 'ring', fill: true },
+  // `legacy` renders <ClockCounterClockwiseIcon /> instead and never reads
+  // glyph/fill — a dormant migrated chat is neither done nor merely stopped;
+  // the history glyph says "restorable" without spending any color.
+  legacy: { color: 'var(--muted-foreground)', glyph: 'ring', fill: false },
 };
 
 function SessionStatusDot({
@@ -931,6 +936,12 @@ function SessionStatusDot({
           // Loading is the only spinner in this codebase. The previous
           // implementation spun an SVG with animate-spin, which the rule bans.
           <Loading className="text-kortix-yellow size-3.5" />
+        ) : display === 'legacy' ? (
+          <ClockCounterClockwiseIcon
+            className="size-3.5 shrink-0"
+            style={{ color: style.color }}
+            aria-hidden
+          />
         ) : (
           <svg
             height="16"


### PR DESCRIPTION
## Problem

Migrated Suna sessions (`metadata.legacy_migration`, written by the account migration) rendered as ordinary finished sessions:

- Sidebar: a muted **"Done ✓"** — an accounting artifact of the `completed` status (#6241), and a lie: nothing ever ran.
- Session page: **"This session is stopped — Its computer was released. Restart the session to bring it back."** — also wrong; a migrated session never had a computer.

## Change

One detector, three surfaces:

1. **`session-label.ts`** — `isLegacyMigratedSession()` + new display status `'legacy'` for dormant migrated sessions (`completed`/`stopped` + legacy metadata). Label: *"Legacy import — open to restore"*. Live states keep their normal paint once restored (green stays live-or-actionable only, per the governing rule). New **Legacy** entry in the status filter.
2. **Sidebar dot** (`project-session-list.tsx`) — renders a muted `ClockCounterClockwiseIcon` (restore glyph) for `'legacy'` instead of the check; spends no color.
3. **Session page** (`sessions/[sessionId]/page.tsx`) — the dormant card for a migrated session reads: *"**Legacy session** — This conversation was imported from Suna. Restore the session to load its chat history — its files are already in the project under `legacy/`."* with a **Restore session / Restoring…** CTA (`RestartSessionButton` gained `label`/`pendingLabel` props).

## Verification

- `bun test session-label.test.ts` — 27 pass (detection, `'legacy'` display mapping incl. review-override and live-state precedence, filter behavior: `legacy` matches, `done` doesn't).
- Browser, against the real migrated project `79d76143` (247 sessions) with the local web pointed at the prod API: sidebar shows the restore glyph on all dormant rows; the legacy card renders on open; clicking **Restore session** provisioned a sandbox and the restored chat rendered (session `05393c78` "Two Bluetooth Logos", real content).
- `tsc --noEmit` and `eslint` clean apart from pre-existing known errors (`@/.source` generated module, 3 known test files, `react-hooks` warning backlog).

Follow-up to #6235 (rehydrate re-land) and #6241 (migrated sessions listable).
