### PR TITLE
fix(web): suppress Gecko/Firefox Paper Shaders null-WebGL-context crash wording (BS fd773de2)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -3412,7 +3412,53 @@ const PAPER_SHADER_NULL_CONTEXT_MESSAGES = [
   "null is not an object (evaluating 'this.gl.getAttribLocation')",
   "TypeError: null is not an object (evaluating 'this.gl.getAttribLocation')",
   "Unhandled promise rejection: TypeError: null is not an object (evaluating 'this.gl.getAttribLocation')",
+  // Gecko / Firefox DOM-binding wording — the FIFTH engine variant of this
+  // null-WebGL-context crash class, surfaced via a DIFFERENT code path from
+  // SpiderMonkey's engine TypeError (`can't access property "<m>"<…>`) above.
+  // When the WebGL2 context is null/invalid, Firefox's DOM bindings throw on
+  // the method call itself with the canonical Gecko DOM-API shape
+  // `<Interface>.<method>: Argument 1 is not an object.`. Better Stack pattern
+  // fd773de23b8dbee3551f1132df1dc048a80307133e1e513ca2422ca2bc4fd29a
+  // (Kortix Frontend prod, application_id 2346967): `TypeError`, message
+  // `WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.`,
+  // 1 occurrence / 0 identified users, first 2026-08-07 19:34:33 UTC
+  // (post-v0.12.5, release e2540c341c6f43536a7cf0e0b51599e9928f055c),
+  // call site `setupPositionAttribute` in chunk
+  // `app:///_next/static/immutable/chunks/24zv25pg_k-nz.js`, request URL
+  // `https://kortix.com/` (marketing homepage), browser Firefox 152.0 on
+  // Android 17 (Gecko engine), mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT,
+  // `handled:false`). The `getSupportedExtensions` sibling is pinned
+  // preemptively — same class, Firefox may emit it too. The
+  // `WebGL2RenderingContext.<method>:` prefix is Gecko's DOM-binding marker
+  // (never first-party app code), so the message-only contract (no chunk-frame
+  // anchor, no first-party negative guard) applies — same as the other engine
+  // variants. Note: `stripErrorWrappers`'s `[A-Za-z]+Error:` regex does NOT
+  // strip the `WebGL2RenderingContext.<method>:` prefix (it contains a `.`), so
+  // the `TypeError: ` / `Unhandled promise rejection: ` wrappers are stripped
+  // and the pattern is matched verbatim by `.includes()`.
+  'WebGL2RenderingContext.getSupportedExtensions: Argument 1 is not an object.',
+  'WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.',
+  // The wrapper forms a Sentry/runtime capture path may prefix the Gecko
+  // DOM-binding message with. `stripErrorWrappers` strips the `TypeError: `
+  // and `Unhandled promise rejection: ` / `Unhandled promise rejection:
+  // TypeError: ` prefixes; the `WebGL2RenderingContext.<method>:` prefix is NOT
+  // stripped (it is not a typed-error prefix), so the underlying pattern still
+  // matches verbatim.
+  'TypeError: WebGL2RenderingContext.getSupportedExtensions: Argument 1 is not an object.',
+  'TypeError: WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.',
+  'Unhandled promise rejection: TypeError: WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.',
 ]
+
+// The exact production event from Better Stack pattern
+// fd773de23b8dbee3551f1132df1dc048a80307133e1e513ca2422ca2bc4fd29a — the
+// Gecko/Firefox DOM-binding wording of the Paper Shaders null-WebGL-context
+// crash class (call site `setupPositionAttribute`, chunk
+// `app:///_next/static/immutable/chunks/24zv25pg_k-nz.js`, Firefox 152 on
+// Android 17, marketing homepage). Pinned as a regression test so this exact
+// production wording never pages Better Stack again.
+const PAPER_SHADER_GECKO_NULL_CONTEXT_PRODUCTION_MESSAGE =
+  'WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.'
 
 test('classifies every Paper Shaders null-context WebGL message as noise', () => {
   for (const message of PAPER_SHADER_NULL_CONTEXT_MESSAGES) {
@@ -3472,10 +3518,13 @@ test('does NOT suppress a real app TypeError with a different null-property name
   // `Cannot read properties of null (reading '<name>')` SHAPE but with an
   // app-property name, not a WebGL2 API method — it must keep reporting so a
   // real null-deref regression is never hidden by the Paper Shaders guard.
-  // Covers all four engine wordings (V8, old JSC, SpiderMonkey/Firefox,
-  // modern JSC) so the Firefox `can't access property "<m>"` pattern and the
-  // modern-JSC `null is not an object (evaluating '<expr>')` pattern can't
-  // swallow a real first-party null-deref with a non-WebGL property name.
+  // Covers all five engine/DOM-binding wordings (V8, old JSC,
+  // SpiderMonkey/Firefox, modern JSC, Gecko/Firefox DOM-binding) so the Firefox
+  // `can't access property "<m>"` pattern, the modern-JSC `null is not an
+  // object (evaluating '<expr>')` pattern, AND the Gecko
+  // `WebGL2RenderingContext.<m>: Argument 1 is not an object.` pattern can't
+  // swallow a real first-party null-deref with a non-WebGL property / method
+  // name.
   const realAppNullDerefMessages = [
     "Cannot read properties of null (reading 'map')",
     "Cannot read properties of null (reading 'length')",
@@ -3497,6 +3546,12 @@ test('does NOT suppress a real app TypeError with a different null-property name
     "null is not an object (evaluating 'this.gl.someOtherMethod')",
     "null is not an object (evaluating 'foo.bar')",
     "TypeError: null is not an object (evaluating 'this.gl.unsupportedMethod')",
+    // A Gecko-style DOM-binding message with a NON-WebGL2 interface / method —
+    // same `Argument 1 is not an object.` SHAPE but NOT the
+    // `WebGL2RenderingContext.<method>` anchor — must keep reporting so the
+    // Gecko pattern can't swallow a real first-party DOM-API null-deref.
+    'CanvasRenderingContext2D.fillRect: Argument 1 is not an object.',
+    'WebGL2RenderingContext.someOtherMethod: Argument 1 is not an object.',
   ]
   for (const message of realAppNullDerefMessages) {
     assert.equal(
@@ -3528,6 +3583,70 @@ test('does NOT suppress a real app TypeError with a different null-property name
       `expected Sentry gate to keep reporting real app TypeError "${message}" even from a chunk frame`,
     )
   }
+})
+
+// Regression test pinning the EXACT production event from Better Stack pattern
+// fd773de23b8dbee3551f1132df1dc048a80307133e1e513ca2422ca2bc4fd29a — the
+// Gecko/Firefox DOM-binding wording of the Paper Shaders null-WebGL-context
+// crash class. The event reached Sentry as an UNCAUGHT `onunhandledrejection`
+// (`handled:false`) from Firefox 152 on Android 17 on the marketing homepage
+// (`https://kortix.com/`), post-v0.12.5, with call site `setupPositionAttribute`
+// in chunk `app:///_next/static/immutable/chunks/24zv25pg_k-nz.js`. Before this
+// fix, the `WebGL2RenderingContext.getAttribLocation: Argument 1 is not an
+// object.` wording was NOT in `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS`
+// (which covered V8, old JSC, SpiderMonkey, and modern JSC only), so the
+// event paged Better Stack. This test pins the exact message + the production
+// chunk frame so the Gecko DOM-binding wording is classified as noise by the
+// matcher, the runtime gate, AND the Sentry `beforeSend` gate — and a future
+// recurrence of this exact production event never pages Better Stack again.
+test('regression: Gecko/Firefox DOM-binding Paper Shaders null-context crash is suppressed (BS pattern fd773de2…)', () => {
+  // The exact production message (no wrapper prefix — the raw Sentry
+  // `exception.values[].value`).
+  assert.equal(
+    isPaperShaderNullContextNoise(PAPER_SHADER_GECKO_NULL_CONTEXT_PRODUCTION_MESSAGE),
+    true,
+    'expected the exact Gecko production message to be classified as Paper Shaders null-context noise',
+  )
+  // The runtime (window.onerror / onunhandledrejection) gate must suppress it.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({ message: PAPER_SHADER_GECKO_NULL_CONTEXT_PRODUCTION_MESSAGE }),
+    true,
+    'expected runtime gate to suppress the Gecko production message',
+  )
+  // The Sentry `beforeSend` gate must suppress it — both WITH the production
+  // chunk frame (the actual prod stack shape) and frameless (the message-only
+  // contract means no chunk-frame anchor is required).
+  const productionChunkFrame = {
+    filename: 'app:///_next/static/immutable/chunks/24zv25pg_k-nz.js',
+  }
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: PAPER_SHADER_GECKO_NULL_CONTEXT_PRODUCTION_MESSAGE,
+            stacktrace: { frames: [productionChunkFrame] },
+          },
+        ],
+      },
+    }),
+    true,
+    'expected Sentry gate to suppress the Gecko production message with the production chunk frame',
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: PAPER_SHADER_GECKO_NULL_CONTEXT_PRODUCTION_MESSAGE,
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    }),
+    true,
+    'expected Sentry gate to suppress the Gecko production message even without a chunk frame (message-only contract)',
+  )
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -321,7 +321,8 @@ const OLD_WEBKIT_REGEX_NOISE_PATTERNS = [
 // first-party app code (only from Paper Shaders' library internals), so the
 // message wording alone is specific enough to safely classify as noise without
 // a chunk-frame anchor (unlike the generic old-browser SyntaxError class). The
-// matching covers all four JS engine wordings for the same null-context bug:
+// matching covers all five JS-engine / DOM-binding wordings for the same
+// null-context bug:
 //   - V8 (Chrome/Edge):          `Cannot read properties of null (reading '<m>')`
 //   - old JSC (old Safari/iOS):  `Cannot read property '<m>' of null`
 //   - SpiderMonkey (Firefox):    `can't access property "<m>"<…>` (the variable
@@ -340,6 +341,14 @@ const OLD_WEBKIT_REGEX_NOISE_PATTERNS = [
 //                                method so a generic JSC `null is not an object
 //                                (evaluating '<other expr>')` throw does NOT
 //                                match (pattern `a8754de5…`).
+//   - Gecko (Firefox) DOM-binding: `WebGL2RenderingContext.<m>: Argument 1 is
+//                                not an object.` — Firefox's DOM bindings throw
+//                                on the method call itself (a DIFFERENT code
+//                                path from SpiderMonkey's engine TypeError
+//                                above) when the `this` binding is not a valid
+//                                object (here the null WebGL2 context). Pattern
+//                                `fd773de2…` (Firefox 152 on Android 17,
+//                                `getAttribLocation`, marketing homepage).
 // `TypeError: ` / `Error: ` / `Unhandled promise rejection: ` wrappers are
 // stripped before matching so all capture paths (window.onerror,
 // onunhandledrejection, Sentry exception) classify consistently.
@@ -377,6 +386,38 @@ const PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS = [
   // class after V8 (#4544), old JSC, and SpiderMonkey (#5172).
   "null is not an object (evaluating 'this.gl.getSupportedExtensions')",
   "null is not an object (evaluating 'this.gl.getAttribLocation')",
+  // Gecko / Firefox DOM-binding wording. When the WebGL2 context is `null` /
+  // invalid (context loss, blacklisted GPU, stripped WebView), Firefox's DOM
+  // bindings throw on the method call itself with the canonical Gecko DOM-API
+  // shape `<Interface>.<method>: Argument 1 is not an object.` — the
+  // `Argument 1 is not an object.` is Gecko's standard message for a `this`
+  // binding that is not a valid object (here the null WebGL2 context). This is
+  // the SAME null-WebGL-context crash class as the V8/JSC/SpiderMonkey entries
+  // above, just with Firefox's DOM-API error wording instead of an engine
+  // TypeError. Better Stack pattern
+  // fd773de23b8dbee3551f1132df1dc048a80307133e1e513ca2422ca2bc4fd29a
+  // (Kortix Frontend prod, application_id 2346967): `TypeError`, message
+  // `WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.`,
+  // 1 occurrence / 0 identified users, first 2026-08-07 19:34:33 UTC
+  // (post-v0.12.5, release `e2540c341c6f43536a7cf0e0b51599e9928f055c`),
+  // call site `setupPositionAttribute` in chunk
+  // `app:///_next/static/immutable/chunks/24zv25pg_k-nz.js`, request URL
+  // `https://kortix.com/` (marketing homepage), browser Firefox 152.0 on
+  // Android 17 (Gecko engine), mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT,
+  // `handled:false`). The `getSupportedExtensions` sibling is added
+  // preemptively — same class, Firefox may emit it too. The
+  // `WebGL2RenderingContext.<method>:` prefix is the Gecko DOM-binding's own
+  // canonical marker (the interface + method name), never emitted by
+  // first-party app code, so the message wording alone is specific enough —
+  // same message-only contract as the other engine variants (no chunk-frame
+  // anchor, no first-party negative guard). Note: `stripErrorWrappers`'s
+  // `[A-Za-z]+Error:` regex does NOT strip the
+  // `WebGL2RenderingContext.<method>:` prefix (it contains a `.`), so the
+  // pattern is matched verbatim by `.includes()` after the `TypeError: ` /
+  // `Unhandled promise rejection: ` wrappers are stripped.
+  'WebGL2RenderingContext.getSupportedExtensions: Argument 1 is not an object.',
+  'WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.',
 ] as const;
 
 // Paper Shaders (`@paper-design/shaders-react`) WebGL-unsupported deliberate
@@ -1704,12 +1745,15 @@ export function isOldWebkitRegexNoiseMessage(message: unknown): boolean {
  * React error boundary, and reach Sentry/Better Stack as global errors. The
  * method names are WebGL2 API — never called from first-party app code — so the
  * message wording alone is specific enough; no chunk-frame anchor is needed.
- * Matches all four JS engine wordings: V8
+ * Matches all five JS-engine / DOM-binding wordings: V8
  * (`Cannot read properties of null (reading '<m>')`), old JSC
  * (`Cannot read property '<m>' of null`), SpiderMonkey/Firefox
- * (`can't access property "<m>"<…>`), and modern JSC (Safari / Chrome-on-iOS
+ * (`can't access property "<m>"<…>`), modern JSC (Safari / Chrome-on-iOS
  * CriOS, which uses WebKit/JSC rather than V8:
- * `null is not an object (evaluating 'this.gl.<m>')`). Never page Better Stack
+ * `null is not an object (evaluating 'this.gl.<m>')`), and Gecko/Firefox
+ * DOM-binding (`WebGL2RenderingContext.<m>: Argument 1 is not an object.` —
+ * Firefox's DOM bindings throw on the method call itself when the `this`
+ * binding is the null WebGL2 context). Never page Better Stack
  * for this class. See `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` for the full
  * rationale and the `supportsWebGL2()` probe in `shader-safe.tsx` for the
  * primary guard.


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This is a telemetry-noise filter addition (two new message-pattern strings in `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS`); there is no user-visible surface to record. Proof below is the test run pinning the exact production event.

## Why

A Firefox-Gecko-worded variant of the Paper Shaders null-WebGL-context crash class paged Better Stack as an UNCAUGHT `onunhandledrejection`. The existing `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` array covered V8, old JSC, SpiderMonkey, and modern JSC engine wordings but NOT Firefox's DOM-binding wording, which throws on the WebGL2 method call itself instead of as an engine `TypeError`.

## What changed

`apps/web/src/lib/browser-error-noise.ts` — added the Gecko (Firefox) DOM-binding wording to `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` (the fifth engine/DOM-binding variant of this crash class):

- `WebGL2RenderingContext.getSupportedExtensions: Argument 1 is not an object.`
- `WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.`

No change to the `isPaperShaderNullContextNoise` matcher function — it already matches the patterns list via `.includes()` after `stripErrorWrappers` strips `TypeError: ` / `Unhandled promise rejection: ` prefixes (the `WebGL2RenderingContext.<method>:` prefix contains a `.` so it is NOT stripped by the `[A-Za-z]+Error:` regex — the pattern matches verbatim). Kept the existing message-only contract (no chunk-frame anchor, no first-party negative guard) — WebGL2 method names are never called from first-party app code, so the message wording alone is specific enough, identical to the other four engine variants. Block-comment header + the matcher's JSDoc updated to document the fifth variant.

`apps/web/src/lib/browser-error-noise.test.mts`:
- Added the Gecko wording (both methods + the `TypeError: ` / `Unhandled promise rejection: TypeError: ` wrapper forms) to `PAPER_SHADER_NULL_CONTEXT_MESSAGES` so all three existing gate tests (matcher, runtime `window.onerror`, Sentry `beforeSend`) cover it.
- Added a dedicated regression test pinning the EXACT production event (BS pattern `fd773de2…`): asserts the matcher, the runtime gate, and the Sentry `beforeSend` gate all suppress it — both with the production chunk frame (`app:///_next/static/immutable/chunks/24zv25pg_k-nz.js`) and frameless (message-only contract).
- Extended the negative-guard test with non-WebGL2 Gecko DOM-binding shapes (`CanvasRenderingContext2D.fillRect: Argument 1 is not an object.`, `WebGL2RenderingContext.someOtherMethod: Argument 1 is not an object.`) so the new pattern cannot swallow a real first-party DOM-API null-deref.

## Root cause

The Paper Shaders (`@paper-design/shaders-react`) shader-mount `useEffect`/rAF callback reaches a WebGL2 context that has become `null` (context loss, blacklisted GPU, stripped WebView, headless renderer) and calls a WebGL2 API method on it. The throw happens INSIDE an async callback, so it ESCAPES the `<ShaderSafe>` React error boundary → global `onunhandledrejection` → Sentry → Better Stack. The `supportsWebGL2()` probe in `shader-safe.tsx` is the primary guard (degrades to the fallback BEFORE the throw); this matcher is the leak-path backstop for the residual async-context-loss throws that bypass the one-shot probe. Firefox's DOM bindings throw on the method call itself with the canonical Gecko DOM-API shape `<Interface>.<method>: Argument 1 is not an object.` — a DIFFERENT code path from SpiderMonkey's engine `TypeError` (`can't access property "<m>"<…>`), which is why the existing SpiderMonkey pattern did not match it.

## Evidence

Better Stack error (Kortix Frontend prod, application_id `2346967`):
- **Pattern:** `fd773de23b8dbee3551f1132df1dc048a80307133e1e513ca2422ca2bc4fd29a`
- **Type:** TypeError — **Message:** `WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.`
- **Call site function:** `setupPositionAttribute`
- **Call site file:** `app:///_next/static/immutable/chunks/24zv25pg_k-nz.js`
- **Count:** 1 occurrence / 0 identified users, first 2026-08-07 19:34:33 UTC (post-v0.12.5)
- **Release:** `e2540c341c6f43536a7cf0e0b51599e9928f055c` (v0.12.5 prod)
- **Request URL:** `https://kortix.com/` (marketing homepage)
- **Browser:** Firefox 152.0 on Android 17 (Gecko engine)
- **Mechanism:** `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT, `handled:false`)
- **Frames:** 3 frames in `app:///_next/static/immutable/chunks/24zv25pg_k-nz.js` (Paper Shaders library)

This is the fifth engine/DOM-binding wording of the same null-WebGL-context crash class already de-noised for V8 (`Cannot read properties of null (reading '<m>')`, PR #4544), old JSC (`Cannot read property '<m>' of null`), SpiderMonkey (`can't access property "<m>"<…>`, PR #5172), and modern JSC (`null is not an object (evaluating 'this.gl.<m>')`, pattern `a8754de5…`).

## Verification

```
$ node --experimental-strip-types --test apps/web/src/lib/browser-error-noise.test.mts
# tests 279
# pass 279
# fail 0
```

All 279 noise tests pass (was 278 before this change; +1 dedicated Gecko regression test). Key tests:
- `ok 130 - classifies every Paper Shaders null-context WebGL message as noise` (now includes the Gecko wording)
- `ok 131 - suppresses every Paper Shaders null-context message via the runtime (window.onerror) gate`
- `ok 132 - suppresses every Paper Shaders null-context message via the Sentry beforeSend gate`
- `ok 133 - does NOT suppress a real app TypeError with a different null-property name` (extended with non-WebGL2 Gecko DOM-binding shapes — confirms no over-match)
- `ok 134 - regression: Gecko/Firefox DOM-binding Paper Shaders null-context crash is suppressed (BS pattern fd773de2…)` (NEW — pins the exact production event through matcher + runtime + Sentry gates, with and without the production chunk frame)

## Confirmation

After this merges + promotes, the Better Stack error for pattern `fd773de2…` should drop to zero new occurrences (Better Stack auto-resolves once the noise is no longer seen). The residual async-context-loss throws that bypass the `supportsWebGL2()` probe will now be dropped by the telemetry gate instead of paging.

## Risk / rollback

Very low. Two new exact-string entries in a noise-patterns array; no behavioral change to the matcher function, no new guards, no change to first-party error reporting (the negative-guard test confirms non-WebGL2 Gecko DOM-binding shapes still report). Revert is a single-commit `git revert`.
