### PR TITLE
fix(compliance): remove hardcoded `ino` user from IAM groups Terraform (DCF-776)

### DIFF
--- a/infra/terraform/security-baseline/iam-groups.tf
+++ b/infra/terraform/security-baseline/iam-groups.tf
@@ -113,12 +113,18 @@ locals {
       policies = [aws_iam_policy.cloudwatch_logs.arn]
       members  = ["kortix-cloudwatch-logs"]
     }
-    # Self-service MFA for the `ino` user (was an inline `EnforceMFA` policy —
-    # DCF-776 requires group-based permissions only). See aws_iam_policy
-    # .mfa_self_manage above.
+    # Self-service MFA group (replaces the inline `EnforceMFA` policy that used
+    # to hang directly off one user — DCF-776 requires group-based permissions
+    # only). The policy is self-scoped via the ${aws:username} IAM variable, so
+    # it is safe for any member. Person memberships are managed OUT-OF-BAND
+    # (AWS console / `aws iam add-user-to-group --group-name mfa-self-manage`),
+    # NOT committed to this repo: individual people must not live in
+    # version-controlled IaC (churn + audit noise on every join/leave), and the
+    # self-scoped policy keeps DCF-776 satisfied with no member named in TF.
+    # See aws_iam_policy.mfa_self_manage above.
     mfa-self-manage = {
       policies = [aws_iam_policy.mfa_self_manage.arn]
-      members  = ["ino"]
+      members  = []
     }
     # SES send-only for the `kortix-ses-sender` user (was an inline `ses-send-only`
     # policy — DCF-776 requires group-based permissions only). See aws_iam_policy


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. Terraform IaC-only edit.

Proof of validity:
- `tofu fmt -check -diff infra/terraform/security-baseline/iam-groups.tf` → no diff (already formatted)
- `tofu init -backend=false` → OpenTofu initialized, hashicorp/aws v6.58.0 installed
- `tofu validate` → `Success! The configuration is valid.`

The diff (one block in `iam-groups.tf`):
```diff
-    # Self-service MFA for the `ino` user (was an inline `EnforceMFA` policy —
-    # DCF-776 requires group-based permissions only). See aws_iam_policy
-    # .mfa_self_manage above.
+    # Self-service MFA group (replaces the inline `EnforceMFA` policy that used
+    # to hang directly off one user — DCF-776 requires group-based permissions
+    # only). The policy is self-scoped via the ${aws:username} IAM variable, so
+    # it is safe for any member. Person memberships are managed OUT-OF-BAND
+    # (AWS console / `aws iam add-user-to-group --group-name mfa-self-manage`),
+    # NOT committed to this repo: individual people must not live in
+    # version-controlled IaC (churn + audit noise on every join/leave), and the
+    # self-scoped policy keeps DCF-776 satisfied with no member named in TF.
+    # See aws_iam_policy.mfa_self_manage above.
     mfa-self-manage = {
       policies = [aws_iam_policy.mfa_self_manage.arn]
-      members  = ["ino"]
+      members  = []
     }
```

## Why
PR #6255 (merged) built the correct *generic* `mfa-self-manage` group — the policy is self-scoped via the `${aws:username}` IAM policy variable, so it is safe for any member. But it then hardcoded `members = ["ino"]` directly below it, committing a person's name to version-controlled IaC. That defeats the point of DCF-776 (group-based permissions): every join/leave/rotation would require a Terraform edit → PR → merge → apply, and individual people must not live in IaC (the file's own header, `iam-groups.tf:3-5`, says users are created out-of-band).

This removes `ino` from the Terraform. It is the right fix regardless of whether `ino` stays in the group out-of-band — the repo should not name people.

## What changed
- `infra/terraform/security-baseline/iam-groups.tf`: `mfa-self-manage.members` `["ino"]` → `[]`. Comment rewritten to state the membership is out-of-band and why (self-scoped policy keeps DCF-776 satisfied with no member named in TF). One block, +10/-4.
- No other files touched. The `mfa_self_manage` policy resource itself is unchanged (still created, still attached to the group). The `ses-senders` group / `kortix-ses-sender` user is left as-is — that is a functional service user (analogous to `kortix-cloudwatch-logs`), not a person.

Mirrors the established `bedrock-full` empty-members pattern (`iam-groups.tf:102-107`), which already uses `members = []` with a comment.

## Verification
- `tofu fmt -check -diff iam-groups.tf` → clean (no formatting diff).
- `tofu init -backend=false` → OpenTofu initialized, `hashicorp/aws v6.58.0` installed (lock file written to `.terraform.lock.hcl`, gitignored).
- `tofu validate` → `Success! The configuration is valid.`
- `git status --short` → only `iam-groups.tf` modified (no stray init artifacts committed; `.terraform/` and `.terraform.lock.hcl` are gitignored).

**Note on `terraform plan`:** a real plan/apply requires AWS provider auth + the S3 backend (credentials in the Kortix secret store, not in this sandbox). The expected plan effect is one `aws_iam_user_group_membership` resource destroyed (the `ino → mfa-self-manage` membership), with the group + policy attachment unchanged. The out-of-band `aws iam add-user-to-group --group-name mfa-self-manage --user-name ino` re-adds the membership outside Terraform state if `ino` should remain in the group.

## Risk / rollback
- **Low.** The group and policy are unchanged; only one out-of-band membership is removed from Terraform state. DCF-776 stays satisfied (group-based, no inline policy).
- **One out-of-band follow-up:** whoever manages `ino`'s access should run `aws iam add-user-to-group --group-name mfa-self-manage --user-name ino` (console or CLI) after apply if `ino` is to keep self-service MFA — otherwise `ino` loses the MFA self-service permission until re-added. This is by design: person memberships are now out-of-band, like the users themselves.
- Rollback: revert the commit; re-add `members = ["ino"]`.
