### PR TITLE
Fix audit v2 migration timeout on hosted data

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -159,6 +159,7 @@ COPY --from=deps /app/packages/db/migrations ./packages/db/migrations
 COPY --from=deps /app/packages/db/scripts/migrate.ts ./packages/db/scripts/migrate.ts
 COPY --from=deps /app/packages/db/scripts/migration-ledger-repair.ts ./packages/db/scripts/migration-ledger-repair.ts
 COPY --from=deps /app/packages/db/scripts/migration-retry.ts ./packages/db/scripts/migration-retry.ts
+COPY --from=deps /app/packages/db/scripts/migration-runtime-overrides.ts ./packages/db/scripts/migration-runtime-overrides.ts
 # Non-kortix bootstrap (basejump + credit RPCs + signup triggers) for FRESH
 # self-host databases. `migrate.ts bootstrap` applies this before `up` when
 # basejump is absent (no-op on provisioned cloud/dev DBs).

--- a/apps/api/src/__tests__/unit-api-dockerfile-runtime-artifacts.test.ts
+++ b/apps/api/src/__tests__/unit-api-dockerfile-runtime-artifacts.test.ts
@@ -26,4 +26,12 @@ describe('API image sandbox runtime artifacts', () => {
     expect(sourceCopy).toBeGreaterThan(-1);
     expect(artifactRefresh).toBeGreaterThan(sourceCopy);
   });
+
+  test('copies every migration runner dependency into the self-host image', () => {
+    const dockerfile = readFileSync(resolve(repoRoot, 'apps/api/Dockerfile'), 'utf8');
+
+    expect(dockerfile).toContain(
+      'COPY --from=deps /app/packages/db/scripts/migration-runtime-overrides.ts ./packages/db/scripts/migration-runtime-overrides.ts',
+    );
+  });
 });

--- a/packages/db/MIGRATIONS.md
+++ b/packages/db/MIGRATIONS.md
@@ -51,6 +51,7 @@ aren't a schema-shape diff.
 
 - **Schema shape** is defined in `kortix.ts`. You edit the schema and *generate* the SQL — you don't hand-write schema DDL. (Data migrations, RLS, custom functions, and CONCURRENTLY operations are the exception — hand-written; see below.)
 - **Migration files** in `packages/db/migrations/` are **immutable, timestamp-named** `YYYYMMDDHHMMSSmmm_slug.sql` (17-digit UTC — node-pg-migrate's native format; collision-safe across parallel branches). The one exception is the `.concurrent.ts` escape hatch, same timestamp prefix, different suffix — see [Roll-forward safety](#roll-forward-safety-transactions-per-file-and-the-concurrently-escape-hatch).
+- A merged migration that fails its first hosted deployment remains immutable. A runtime correction must live in `scripts/migration-runtime-overrides.ts`, match the exact committed SHA-256, change the minimum required statement, fail closed on drift, and have an integration test. The migration runner prints each applied override.
 - **Applied state** lives in `kortix_migrations.pgmigrations` (node-pg-migrate's table; one row per migration, by name — **not** the `public` schema, and not the same table CI/local dev might assume by default).
 
 ### Tracking is by NAME, not checksum (known tradeoff)

--- a/packages/db/scripts/centralized-audit-v2-upgrade.integration.test.ts
+++ b/packages/db/scripts/centralized-audit-v2-upgrade.integration.test.ts
@@ -4,6 +4,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { runner } from 'node-pg-migrate';
 import pg from 'pg';
+import { materializeMigrationRuntimeDirectory } from './migration-runtime-overrides';
 
 const databaseUrl = process.env.AUDIT_V2_DATABASE_URL;
 const migrationsDir = join(import.meta.dir, '..', 'migrations');
@@ -63,10 +64,10 @@ async function applyBootstrap(client: pg.Client): Promise<void> {
   }
 }
 
-function migrationOptions(url: string) {
+function migrationOptions(url: string, directory: string) {
   return {
     databaseUrl: url,
-    dir: migrationsDir,
+    dir: directory,
     migrationsTable: 'pgmigrations',
     migrationsSchema: 'kortix_migrations',
     createMigrationsSchema: true,
@@ -87,6 +88,7 @@ describe.skipIf(!databaseUrl)('centralized audit v2 — upgrade from the v1 ledg
     'backfills legacy session cursors and begins the integrity chain after legacy history',
     async () => {
       const databaseName = `audit_v2_upgrade_${randomUUID().replaceAll('-', '')}`;
+      const runtimeMigrations = materializeMigrationRuntimeDirectory(migrationsDir);
       const admin = new pg.Client({ connectionString: databaseUrl });
       await admin.connect();
       try {
@@ -105,7 +107,13 @@ describe.skipIf(!databaseUrl)('centralized audit v2 — upgrade from the v1 ledg
           await client.end();
         }
 
-        const migrationFiles = readdirSync(migrationsDir)
+        expect(
+          readFileSync(
+            join(runtimeMigrations.path, '20260807221200000_centralized_audit_v2.sql'),
+            'utf8',
+          ),
+        ).toContain("SET statement_timeout = '30min';");
+        const migrationFiles = readdirSync(runtimeMigrations.path)
           .filter((name) => name.endsWith('.sql') || name.endsWith('.ts'))
           .sort();
         const auditV2Index = migrationFiles.findIndex((name) =>
@@ -113,7 +121,7 @@ describe.skipIf(!databaseUrl)('centralized audit v2 — upgrade from the v1 ledg
         );
         expect(auditV2Index).toBeGreaterThan(0);
         await runner({
-          ...migrationOptions(upgradeUrl),
+          ...migrationOptions(upgradeUrl, runtimeMigrations.path),
           direction: 'up',
           count: auditV2Index,
         });
@@ -144,7 +152,7 @@ describe.skipIf(!databaseUrl)('centralized audit v2 — upgrade from the v1 ledg
         }
 
         await runner({
-          ...migrationOptions(upgradeUrl),
+          ...migrationOptions(upgradeUrl, runtimeMigrations.path),
           direction: 'up',
           count: Number.POSITIVE_INFINITY,
         });
@@ -208,6 +216,7 @@ describe.skipIf(!databaseUrl)('centralized audit v2 — upgrade from the v1 ledg
           await verified.end();
         }
       } finally {
+        runtimeMigrations.cleanup();
         const cleanup = new pg.Client({ connectionString: databaseUrl });
         await cleanup.connect();
         try {

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -27,6 +27,7 @@ import {
   repairMigrationLedger,
 } from './migration-ledger-repair';
 import { withMigrationDeadlockRetry } from './migration-retry';
+import { materializeMigrationRuntimeDirectory } from './migration-runtime-overrides';
 
 const MIGRATIONS_DIR = join(import.meta.dir, '..', 'migrations');
 const BOOTSTRAP_SQL = join(import.meta.dir, '..', 'drizzle', '0000_bootstrap.sql');
@@ -195,10 +196,11 @@ async function main() {
   const [cmd = 'up', ...rest] = process.argv.slice(2);
   const databaseUrl = resolveUrl(rest);
   const countArg = rest.find((a) => a.startsWith('--count='))?.slice('--count='.length);
+  const runtimeMigrations = materializeMigrationRuntimeDirectory(MIGRATIONS_DIR);
 
   const base = {
     databaseUrl,
-    dir: MIGRATIONS_DIR,
+    dir: runtimeMigrations.path,
     migrationsTable: 'pgmigrations',
     migrationsSchema: 'kortix_migrations',
     createMigrationsSchema: true,
@@ -209,11 +211,14 @@ async function main() {
   } as const;
 
   console.log(`node-pg-migrate ${cmd}  DB: ${fmtUrl(databaseUrl)}`);
+  for (const override of runtimeMigrations.appliedOverrides) {
+    console.warn(`[migrate] checksum-guarded runtime override: ${override}`);
+  }
 
   const repairAppliedMigrationRenames = async () => {
     const repaired = await repairMigrationLedger({
       databaseUrl,
-      migrationsDir: MIGRATIONS_DIR,
+      migrationsDir: runtimeMigrations.path,
       applyConnectorMigration: async () => {
         await runner({
           ...base,
@@ -238,47 +243,51 @@ async function main() {
     },
   );
 
-  switch (cmd) {
-    case 'up':
-      await autoBaselineIfNeeded(base, databaseUrl);
-      await repairAppliedMigrationRenames();
-      await applyPendingMigrations();
-      return;
-    case 'bootstrap':
-      // Fresh-DB convenience for self-host: prereqs → then `up`.
-      await selfHostBootstrapIfFresh(databaseUrl);
-      await autoBaselineIfNeeded(base, databaseUrl);
-      await repairAppliedMigrationRenames();
-      await applyPendingMigrations();
-      return;
-    case 'fake':
-      await runner({ ...base, direction: 'up', count: Number.POSITIVE_INFINITY, fake: true });
-      return;
-    case 'down':
-      await runner({
-        ...base,
-        direction: 'down',
-        count: countArg ? Number.parseInt(countArg, 10) : 1,
-      });
-      return;
-    case 'status': {
-      const pending = await runner({
-        ...base,
-        direction: 'up',
-        count: Number.POSITIVE_INFINITY,
-        dryRun: true,
-      });
-      if (pending.length === 0) console.log('Up to date — no pending migrations.');
-      else {
-        console.log(`${pending.length} pending migration(s):`);
-        for (const m of pending) console.log(`  pending  ${m.name}`);
+  try {
+    switch (cmd) {
+      case 'up':
+        await autoBaselineIfNeeded(base, databaseUrl);
+        await repairAppliedMigrationRenames();
+        await applyPendingMigrations();
+        return;
+      case 'bootstrap':
+        // Fresh-DB convenience for self-host: prereqs → then `up`.
+        await selfHostBootstrapIfFresh(databaseUrl);
+        await autoBaselineIfNeeded(base, databaseUrl);
+        await repairAppliedMigrationRenames();
+        await applyPendingMigrations();
+        return;
+      case 'fake':
+        await runner({ ...base, direction: 'up', count: Number.POSITIVE_INFINITY, fake: true });
+        return;
+      case 'down':
+        await runner({
+          ...base,
+          direction: 'down',
+          count: countArg ? Number.parseInt(countArg, 10) : 1,
+        });
+        return;
+      case 'status': {
+        const pending = await runner({
+          ...base,
+          direction: 'up',
+          count: Number.POSITIVE_INFINITY,
+          dryRun: true,
+        });
+        if (pending.length === 0) console.log('Up to date — no pending migrations.');
+        else {
+          console.log(`${pending.length} pending migration(s):`);
+          for (const m of pending) console.log(`  pending  ${m.name}`);
+        }
+        if (pending.length > 0) process.exitCode = 1;
+        return;
       }
-      if (pending.length > 0) process.exitCode = 1;
-      return;
+      default:
+        console.error(`Unknown command: ${cmd}. Use: up | status | down | fake | bootstrap`);
+        process.exit(1);
     }
-    default:
-      console.error(`Unknown command: ${cmd}. Use: up | status | down | fake | bootstrap`);
-      process.exit(1);
+  } finally {
+    runtimeMigrations.cleanup();
   }
 }
 

--- a/packages/db/scripts/migration-runtime-overrides.test.ts
+++ b/packages/db/scripts/migration-runtime-overrides.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { materializeMigrationRuntimeDirectory } from './migration-runtime-overrides';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { force: true, recursive: true });
+});
+
+function fixture(sql: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'kortix-migration-runtime-'));
+  const migrations = join(root, 'migrations');
+  mkdirSync(migrations, { recursive: true });
+  writeFileSync(join(migrations, '20260807221200000_centralized_audit_v2.sql'), sql);
+  writeFileSync(join(migrations, '20260807221201000_after.sql'), 'select 1;\n');
+  roots.push(root);
+  return migrations;
+}
+
+describe('materializeMigrationRuntimeDirectory', () => {
+  test('changes only the known audit-v2 timeout and keeps the immutable source untouched', () => {
+    const sql = "SET lock_timeout = '5s';\nSET statement_timeout = '120s';\nSELECT 1;\n";
+    const source = fixture(sql);
+    const runtime = materializeMigrationRuntimeDirectory(source, {
+      expectedSha256: '622840481c9538d777b09fb0bdf542143f95c119646ecbb18c260510b6158838',
+    });
+
+    expect(runtime.path).not.toBe(source);
+    expect(runtime.appliedOverrides).toEqual([
+      '20260807221200000_centralized_audit_v2.sql: statement_timeout 120s -> 30min (769b863ef0b62c4693e232cf102757ce3c3ee904f0f44c9aea450901a56e07f9)',
+    ]);
+    expect(readFileSync(join(source, '20260807221200000_centralized_audit_v2.sql'), 'utf8')).toBe(sql);
+    expect(
+      readFileSync(
+        join(runtime.path, '20260807221200000_centralized_audit_v2.sql'),
+        'utf8',
+      ),
+    ).toBe("SET lock_timeout = '5s';\nSET statement_timeout = '30min';\nSELECT 1;\n");
+    expect(readFileSync(join(runtime.path, '20260807221201000_after.sql'), 'utf8')).toBe(
+      'select 1;\n',
+    );
+
+    runtime.cleanup();
+  });
+
+  test('fails closed when the immutable migration content does not match the approved checksum', () => {
+    const source = fixture("SET statement_timeout = '120s';\nSELECT 2;\n");
+
+    expect(() =>
+      materializeMigrationRuntimeDirectory(source, { expectedSha256: '0'.repeat(64) }),
+    ).toThrow('checksum mismatch');
+  });
+
+  test('fails closed when the approved timeout statement is missing or duplicated', () => {
+    const missing = fixture('SELECT 1;\n');
+    expect(() =>
+      materializeMigrationRuntimeDirectory(missing, {
+        expectedSha256: 'b4e0497804e46e0a0b0b8c31975b062152d551bac49c3c2e80932567b4085dcd',
+      }),
+    ).toThrow('expected exactly one');
+
+    const duplicatedSql = "SET statement_timeout = '120s';\nSET statement_timeout = '120s';\n";
+    const duplicated = fixture(duplicatedSql);
+    expect(() =>
+      materializeMigrationRuntimeDirectory(duplicated, {
+        expectedSha256: 'b99a7e9f6659464429b1494a03212c5cccdc185191e802ae911203046a8b86e7',
+      }),
+    ).toThrow('expected exactly one');
+  });
+});

--- a/packages/db/scripts/migration-runtime-overrides.ts
+++ b/packages/db/scripts/migration-runtime-overrides.ts
@@ -1,0 +1,93 @@
+import { createHash } from 'node:crypto';
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const AUDIT_V2_MIGRATION = '20260807221200000_centralized_audit_v2.sql';
+const AUDIT_V2_SHA256 = '769b863ef0b62c4693e232cf102757ce3c3ee904f0f44c9aea450901a56e07f9';
+const AUDIT_V2_TIMEOUT = "SET statement_timeout = '120s';";
+const AUDIT_V2_RUNTIME_TIMEOUT = "SET statement_timeout = '30min';";
+
+interface RuntimeOverrideOptions {
+  /** Test seam. Production always uses the committed migration checksum above. */
+  expectedSha256?: string;
+}
+
+export interface MigrationRuntimeDirectory {
+  path: string;
+  appliedOverrides: string[];
+  cleanup: () => void;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * Materialize the immutable migration set used by node-pg-migrate.
+ *
+ * The first audit-v2 deploy proved that its 120-second statement timeout is
+ * lower than the real legacy audit backfill duration. The migration rolled
+ * back before any hosted environment recorded it. Migration files are
+ * immutable after merge, so the runner applies one checksum-guarded runtime
+ * override instead of editing the committed SQL. Only the timeout changes,
+ * and the replacement remains bounded at 30 minutes.
+ */
+export function materializeMigrationRuntimeDirectory(
+  sourceDirectory: string,
+  options: RuntimeOverrideOptions = {},
+): MigrationRuntimeDirectory {
+  const sourceMigration = join(sourceDirectory, AUDIT_V2_MIGRATION);
+  if (!existsSync(sourceMigration)) {
+    return { path: sourceDirectory, appliedOverrides: [], cleanup: () => {} };
+  }
+
+  const source = readFileSync(sourceMigration, 'utf8');
+  const expectedSha256 = options.expectedSha256 ?? AUDIT_V2_SHA256;
+  const actualSha256 = sha256(source);
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(
+      `${AUDIT_V2_MIGRATION} checksum mismatch: expected ${expectedSha256}, received ${actualSha256}`,
+    );
+  }
+
+  const occurrenceCount = source.split(AUDIT_V2_TIMEOUT).length - 1;
+  if (occurrenceCount !== 1) {
+    throw new Error(
+      `${AUDIT_V2_MIGRATION} expected exactly one ${JSON.stringify(AUDIT_V2_TIMEOUT)} statement; found ${occurrenceCount}`,
+    );
+  }
+
+  const runtimeRoot = mkdtempSync(join(tmpdir(), 'kortix-migrations-'));
+  const runtimeDirectory = join(runtimeRoot, 'migrations');
+  try {
+    cpSync(sourceDirectory, runtimeDirectory, { recursive: true });
+    writeFileSync(
+      join(runtimeDirectory, AUDIT_V2_MIGRATION),
+      source.replace(AUDIT_V2_TIMEOUT, AUDIT_V2_RUNTIME_TIMEOUT),
+    );
+  } catch (error) {
+    rmSync(runtimeRoot, { force: true, recursive: true });
+    throw error;
+  }
+
+  let cleaned = false;
+  return {
+    path: runtimeDirectory,
+    appliedOverrides: [
+      `${AUDIT_V2_MIGRATION}: statement_timeout 120s -> 30min (${AUDIT_V2_SHA256})`,
+    ],
+    cleanup: () => {
+      if (cleaned) return;
+      cleaned = true;
+      rmSync(runtimeRoot, { force: true, recursive: true });
+    },
+  };
+}


### PR DESCRIPTION
## Problem

Deploy Dev run `31263842638` rolled back `20260807221200000_centralized_audit_v2.sql` with PostgreSQL `57014`.

The migration's `SET statement_timeout = '120s'` canceled the legacy `audit_events` sequence backfill on real dev data. No hosted environment recorded the migration.

## Fix

- Keep the merged migration SQL immutable.
- Materialize a temporary migration directory at runtime.
- Verify the audit-v2 migration's exact SHA-256 before changing anything.
- Replace its one `statement_timeout` statement from `120s` to a bounded `30min` in the temporary copy only.
- Fail closed if the checksum or expected statement changes.
- Print the exact applied override in every migration run.
- Exercise the runtime copy through the real PostgreSQL v1-to-v2 upgrade test.

## Verification

```text
AUDIT_V2_DATABASE_URL=... bun test centralized-audit-v2-upgrade.integration.test.ts migration-runtime-overrides.test.ts
4 pass
0 fail
15 expect() calls
```

```text
pnpm --filter @kortix/db typecheck
exit 0
```

```text
pnpm --filter @kortix/db lint
157 migration files pass lint
0 Squawk issues
```

```text
pnpm --filter @kortix/db test
exit 0
```

The immutable SQL remains at SHA-256 `769b863ef0b62c4693e232cf102757ce3c3ee904f0f44c9aea450901a56e07f9`.
