### PR TITLE
fix(connectors): refresh session grants from manifest

### DIFF
--- a/apps/api/scripts/e2e-cli-agent-token.ts
+++ b/apps/api/scripts/e2e-cli-agent-token.ts
@@ -341,6 +341,39 @@ async function driveConnectorSdk(): Promise<void> {
   );
 }
 
+async function driveExistingSessionGrantRefresh(): Promise<void> {
+  const stale = await createAccountToken({
+    accountId,
+    userId,
+    projectId,
+    sessionId,
+    name: `Connector Session stale grant ${sessionId.slice(0, 8)}`,
+    agentGrant: {
+      agent: 'kortix',
+      kortixCli: 'all',
+      connectors: [],
+      env: 'all',
+    },
+  });
+  const originalToken = agentToken;
+  agentToken = stale.secretKey;
+  try {
+    await expectCli(
+      'existing session catalog reconciles a stale same-agent grant without a new session',
+      ['connectors', 'ls', '--session', sessionId],
+      { stdout: new RegExp(FIXTURE_SLUG) },
+    );
+    await expectCli(
+      'existing session calls the newly granted connector with the unchanged token',
+      ['connectors', 'call', `${FIXTURE_SLUG}.get`, '{"q":"hot-grant-agent-token"}'],
+      { stdout: /hot-grant-agent-token/ },
+    );
+  } finally {
+    agentToken = originalToken;
+    await db.delete(accountTokens).where(eq(accountTokens.tokenId, stale.tokenId));
+  }
+}
+
 async function driveExecutorCompatibilityAdapter(): Promise<void> {
   const client = createExecutorClient({
     apiUrl: API,
@@ -493,6 +526,7 @@ async function commandMatrix(): Promise<void> {
   );
 
   await seedCallableAction();
+  await driveExistingSessionGrantRefresh();
   await driveConnectorSdk();
   await driveExecutorCompatibilityAdapter();
   const inheritedCatalog = await expectCli(

--- a/apps/api/src/connectors/db-deps.ts
+++ b/apps/api/src/connectors/db-deps.ts
@@ -45,6 +45,7 @@ import type { ChannelPlatform } from '../projects/connectors';
 import { invalidateProjectMirror } from '../projects/git';
 import { loadProjectForUser } from '../projects/lib/access';
 import { connectorAuthorizationMatchesStrategy } from '../projects/lib/connector-authorization-strategy';
+import { reconcileStoredSessionAgentGrant } from '../projects/lib/session-token-grant';
 import { getProjectSecretValueForConsumer } from '../projects/secrets';
 import {
   canonicalConnectorAlias,
@@ -776,13 +777,19 @@ async function resolvePrincipal(c: Context): Promise<ConnectorPrincipal | null> 
     c.req.header('X-Kortix-Session-Id') ?? null,
   );
   if (!sessionIdentity.ok) return null;
+  const agentGrant = sessionIdentity.sessionId
+    ? await reconcileStoredSessionAgentGrant({
+        projectId: result.projectId,
+        sessionId: sessionIdentity.sessionId,
+      })
+    : (result.agentGrant ?? null);
   return {
     userId: result.userId,
     accountId: result.accountId,
     projectId: result.projectId,
     sessionId: sessionIdentity.sessionId,
     subject: await resolveShareSubject(result.userId),
-    agentGrant: result.agentGrant ?? null,
+    agentGrant,
   };
 }
 
@@ -837,13 +844,21 @@ async function resolveProjectPrincipal(
   );
   if (!sessionIdentity.ok) return null;
 
+  const storedAgentGrant = (c.get('agentGrant') as ConnectorPrincipal['agentGrant']) ?? null;
+  const agentGrant = sessionIdentity.sessionId
+    ? await reconcileStoredSessionAgentGrant({
+        projectId,
+        sessionId: sessionIdentity.sessionId,
+      })
+    : storedAgentGrant;
+
   return {
     userId,
     accountId,
     projectId,
     sessionId: sessionIdentity.sessionId,
     subject: await resolveShareSubject(userId),
-    agentGrant: (c.get('agentGrant') as ConnectorPrincipal['agentGrant']) ?? null,
+    agentGrant,
   };
 }
 

--- a/apps/api/src/projects/lib/secret-grant.ts
+++ b/apps/api/src/projects/lib/secret-grant.ts
@@ -216,6 +216,10 @@ export interface SessionSecretGrantInput {
   /** Operational kill switch for the grant-change refusal — see
    *  `secretGrantEnvForRunningAgent`. Defaults to enforced. */
   enforceGrantLock?: boolean;
+  /** Bypass the process-local Git mirror TTL. Authorization paths set this so
+   *  a manifest commit handled by another API replica applies on the next
+   *  request, not up to 60 seconds later. */
+  forceRefresh?: boolean;
 }
 
 /**
@@ -271,7 +275,7 @@ async function loadGrantForRunningAgent(
         manifestPath: input.manifestPath ?? 'kortix.yaml',
         gitAuthToken: null,
       },
-      { rethrowReadErrors: true },
+      { rethrowReadErrors: true, forceRefresh: input.forceRefresh },
     );
   } catch (err) {
     throw new SecretGrantResolutionError(runningAgent, err);

--- a/apps/api/src/projects/lib/session-token-grant-reconcile.test.ts
+++ b/apps/api/src/projects/lib/session-token-grant-reconcile.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import type { AgentGrant } from '@kortix/db';
+import * as realSecretGrant from './secret-grant';
+
+const storedGrant: AgentGrant = {
+  agent: 'kortix',
+  connectors: ['slack'],
+  kortixCli: 'all',
+  env: 'all',
+};
+const currentGrant: AgentGrant = {
+  agent: 'kortix',
+  connectors: ['slack', 'google_workspace'],
+  kortixCli: 'all',
+  env: 'all',
+};
+
+let selectCount = 0;
+let writtenGrant: AgentGrant | null | undefined;
+let resolvedAgent: string | undefined;
+let forceRefresh: boolean | undefined;
+
+mock.module('../../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            selectCount += 1;
+            if (selectCount === 1) return [{ agentGrant: storedGrant }];
+            return [
+              {
+                repoUrl: 'https://example.test/acme/repo.git',
+                defaultBranch: 'main',
+                manifestPath: 'kortix.yaml',
+              },
+            ];
+          },
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (values: { agentGrant: AgentGrant | null }) => {
+        writtenGrant = values.agentGrant;
+        return {
+          where: () => ({
+            returning: async () => [{ tokenId: 'token-1' }],
+          }),
+        };
+      },
+    }),
+  },
+}));
+
+mock.module('./secret-grant', () => ({
+  ...realSecretGrant,
+  resolveSessionAgentGrant: async (input: { sessionAgent: string; forceRefresh?: boolean }) => {
+    resolvedAgent = input.sessionAgent;
+    forceRefresh = input.forceRefresh;
+    return currentGrant;
+  },
+}));
+
+const { reconcileStoredSessionAgentGrant, remintGrantForAgentSwitch } = await import(
+  './session-token-grant'
+);
+
+beforeEach(() => {
+  selectCount = 0;
+  writtenGrant = undefined;
+  resolvedAgent = undefined;
+  forceRefresh = undefined;
+});
+
+test('reconciles a same-agent connector change for an existing session token', async () => {
+  const grant = await reconcileStoredSessionAgentGrant({
+    projectId: 'project-1',
+    sessionId: 'session-1',
+  });
+
+  expect(resolvedAgent).toBe('kortix');
+  expect(forceRefresh).toBe(true);
+  expect(writtenGrant).toEqual(currentGrant);
+  expect(grant).toEqual(currentGrant);
+});
+
+test('reconciles manifest grant changes on the next prompt without an agent switch', async () => {
+  const decision = await remintGrantForAgentSwitch({
+    projectId: 'project-1',
+    sessionId: 'session-1',
+    sessionAgent: 'kortix',
+    requestedAgent: null,
+  });
+
+  expect(resolvedAgent).toBe('kortix');
+  expect(forceRefresh).toBe(true);
+  expect(writtenGrant).toEqual(currentGrant);
+  expect(decision).toEqual({ action: 'write', grant: currentGrant });
+});

--- a/apps/api/src/projects/lib/session-token-grant.ts
+++ b/apps/api/src/projects/lib/session-token-grant.ts
@@ -1,19 +1,15 @@
 /**
- * Re-mint a live session token's agent grant when a prompt switches agents.
+ * Reconcile a live session token's agent grant with the current manifest.
  *
- * `account_tokens.agent_grant` is written ONCE, at session mint, from the agent
- * the session was created with. Nothing ever rewrote it, and nothing updates
- * `project_sessions.agent_name` either — but in-session agent switching is
- * allowed and the proxy forwards a prompt's concrete `agent` field untouched.
- * So the connector and Kortix-CLI gates (`agentMayUseConnector`,
- * `agentMayPerform`) read the BOOT agent's grant no matter which agent is
- * actually running:
+ * `account_tokens.agent_grant` starts from the session's create-time agent.
+ * The connector and Kortix-CLI gates (`agentMayUseConnector`,
+ * `agentMayPerform`) read that row at call time. The row must therefore follow
+ * both in-session agent switches and same-agent manifest edits:
  *
- *     create session with agent A (connectors: all)
- *     prompt {"agent": "B"}  where B declares connectors: [calendar]
- *       -> opencode runs B
- *       -> the token still carries A's grant
- *       -> B calls A's connectors, including ones its own manifest denies it
+ *     create session with agent A (connectors: [slack])
+ *     update A to connectors: [slack, google_workspace]
+ *       -> the token still carries the old list unless it is reconciled
+ *       -> the existing session receives connector_not_assigned
  *
  * Secrets are replaced through the pre-prompt env sync (see `secret-grant.ts`).
  * An operator can enable the strict secret-grant lock to refuse a boundary
@@ -23,10 +19,10 @@
  * every subsequent call.
  */
 
+import { type AgentGrant, accountTokens, projectSessions, projects } from '@kortix/db';
 import { and, eq, isNull } from 'drizzle-orm';
-import { accountTokens, projects, type AgentGrant } from '@kortix/db';
-import { db } from '../../shared/db';
 import { config } from '../../config';
+import { db } from '../../shared/db';
 import { DEFAULT_AGENT_SENTINEL } from '../agents';
 import {
   AgentSecretGrantMismatchError,
@@ -119,12 +115,83 @@ export function remintDecisionFor(
   return { action: 'write', grant: running };
 }
 
+async function loadStoredSessionGrant(sessionId: string): Promise<AgentGrant | null> {
+  try {
+    const [token] = await db
+      .select({ agentGrant: accountTokens.agentGrant })
+      .from(accountTokens)
+      .where(
+        and(
+          eq(accountTokens.sessionId, sessionId),
+          eq(accountTokens.status, 'active'),
+          isNull(accountTokens.revokedAt),
+        ),
+      )
+      .limit(1);
+    return token?.agentGrant ?? null;
+  } catch (err) {
+    throw new SessionGrantRemintError(sessionId, err);
+  }
+}
+
+async function resolveCurrentGrant(input: {
+  projectId: string;
+  sessionId: string;
+  sessionAgent: string;
+  runningAgent: string;
+  enforceGrantLock: boolean;
+  forceRefresh: boolean;
+}): Promise<AgentGrant | null> {
+  try {
+    const [project] = await db
+      .select({
+        repoUrl: projects.repoUrl,
+        defaultBranch: projects.defaultBranch,
+        manifestPath: projects.manifestPath,
+      })
+      .from(projects)
+      .where(eq(projects.projectId, input.projectId))
+      .limit(1);
+
+    return await resolveSessionAgentGrant({
+      projectId: input.projectId,
+      repoUrl: project?.repoUrl ?? '',
+      defaultBranch: project?.defaultBranch,
+      manifestPath: project?.manifestPath,
+      sessionAgent: input.sessionAgent,
+      requestedAgent: input.runningAgent,
+      enforceGrantLock: input.enforceGrantLock,
+      forceRefresh: input.forceRefresh,
+    });
+  } catch (err) {
+    // A secret-boundary refusal is the env sync's error to report, not ours.
+    if (err instanceof AgentSecretGrantMismatchError) throw err;
+    throw new SessionGrantRemintError(input.sessionId, err);
+  }
+}
+
+async function applyResolvedGrant(
+  sessionId: string,
+  stored: AgentGrant | null,
+  running: AgentGrant | null,
+): Promise<RemintDecision> {
+  const decision = remintDecisionFor(stored, running);
+  if (decision.action === 'refuse') {
+    throw new SessionGrantRemintError(sessionId, new Error(decision.reason));
+  }
+  if (decision.action === 'write') {
+    await remintSessionAgentGrant(sessionId, decision.grant);
+  }
+  return decision;
+}
+
 /**
  * Re-point a session token's grant at the agent a prompt actually runs.
  *
- * A no-op — and, importantly, no manifest read — unless the prompt names a
- * concrete agent that differs from the session's. Ordinary turns are the
- * overwhelming majority and must not pay for this.
+ * Resolve on every prompt. The manifest can change while the session remains
+ * active, including through `kortix connectors add --apply`. Comparing only
+ * agent names leaves the token frozen at its create-time connector and CLI
+ * lists.
  *
  * Throws `SessionGrantRemintError` if the grant cannot be resolved or written;
  * the caller must fail the prompt rather than run the new agent under the old
@@ -153,72 +220,64 @@ export async function remintGrantForAgentSwitch(input: {
   const runningAgent =
     requested && requested !== DEFAULT_AGENT_SENTINEL ? requested : input.sessionAgent;
 
-  let stored: AgentGrant | null;
-  try {
-    const [token] = await db
-      .select({ agentGrant: accountTokens.agentGrant })
-      .from(accountTokens)
-      .where(
-        and(
-          eq(accountTokens.sessionId, input.sessionId),
-          eq(accountTokens.status, 'active'),
-          isNull(accountTokens.revokedAt),
-        ),
-      )
-      .limit(1);
-    stored = token?.agentGrant ?? null;
-  } catch (err) {
-    throw new SessionGrantRemintError(input.sessionId, err);
+  const stored = await loadStoredSessionGrant(input.sessionId);
+  const running = await resolveCurrentGrant({
+    ...input,
+    runningAgent,
+    enforceGrantLock: config.KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK,
+    forceRefresh: true,
+  });
+  return applyResolvedGrant(input.sessionId, stored, running);
+}
+
+/**
+ * Resolve the grant represented by an existing session token from the current
+ * project manifest.
+ *
+ * Connector and Kortix CLI requests can occur after the session changes
+ * `kortix.yaml` in the same turn. The prompt hook cannot observe that later
+ * mutation. Gateway authorization therefore calls this function before it
+ * evaluates the stored grant.
+ *
+ * The stored grant identifies the agent that currently owns the token after an
+ * in-session agent switch. A null legacy or unrestricted grant falls back to
+ * `project_sessions.agent_name`.
+ */
+export async function reconcileStoredSessionAgentGrant(input: {
+  projectId: string;
+  sessionId: string;
+}): Promise<AgentGrant | null> {
+  const stored = await loadStoredSessionGrant(input.sessionId);
+
+  let runningAgent = stored?.agent?.trim() ?? '';
+  if (!runningAgent) {
+    try {
+      const [session] = await db
+        .select({ agentName: projectSessions.agentName })
+        .from(projectSessions)
+        .where(
+          and(
+            eq(projectSessions.sessionId, input.sessionId),
+            eq(projectSessions.projectId, input.projectId),
+          ),
+        )
+        .limit(1);
+      runningAgent = session?.agentName?.trim() || DEFAULT_AGENT_SENTINEL;
+    } catch (err) {
+      throw new SessionGrantRemintError(input.sessionId, err);
+    }
   }
 
-  // Skip — and pay NO manifest read — only when the token already represents the
-  // agent about to run.
-  //
-  // The earlier version skipped whenever `requested === sessionAgent`, which was
-  // wrong the moment a re-mint had happened: switch to a broader agent once, then
-  // switch back (or simply omit `agent`), and the token kept the BROADER grant
-  // while the narrower agent ran. `agent_name` never changes, so it could not
-  // detect that the token had moved. The grant's own `agent` field can.
-  if (stored?.agent === runningAgent) return { action: 'skip' };
-  // A null stored grant means the project declares no per-agent governance, so
-  // boot minted null too. Nothing to revert unless a concrete DIFFERENT agent is
-  // named — which is the only case worth a manifest read.
-  if (stored === null && runningAgent === input.sessionAgent) return { action: 'skip' };
-
-  let running: AgentGrant | null;
-  try {
-    const [project] = await db
-      .select({
-        repoUrl: projects.repoUrl,
-        defaultBranch: projects.defaultBranch,
-        manifestPath: projects.manifestPath,
-      })
-      .from(projects)
-      .where(eq(projects.projectId, input.projectId))
-      .limit(1);
-
-    running = await resolveSessionAgentGrant({
-      projectId: input.projectId,
-      repoUrl: project?.repoUrl ?? '',
-      defaultBranch: project?.defaultBranch,
-      manifestPath: project?.manifestPath,
-      sessionAgent: input.sessionAgent,
-      requestedAgent: runningAgent,
-      enforceGrantLock: config.KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK,
-    });
-  } catch (err) {
-    // A secret-boundary refusal is the env sync's error to report, not ours —
-    // rethrow it unchanged so the proxy still answers 409, not 503.
-    if (err instanceof AgentSecretGrantMismatchError) throw err;
-    throw new SessionGrantRemintError(input.sessionId, err);
-  }
-
-  const decision = remintDecisionFor(stored, running);
-  if (decision.action === 'refuse') {
-    throw new SessionGrantRemintError(input.sessionId, new Error(decision.reason));
-  }
-  if (decision.action === 'write') {
-    await remintSessionAgentGrant(input.sessionId, decision.grant);
-  }
-  return decision;
+  // This path refreshes connector and CLI authorization only. Secret delivery
+  // already ran at prompt time. Resolve this agent against itself so a connector
+  // call does not re-run the secret-boundary switch policy.
+  const running = await resolveCurrentGrant({
+    ...input,
+    sessionAgent: runningAgent,
+    runningAgent,
+    enforceGrantLock: false,
+    forceRefresh: true,
+  });
+  await applyResolvedGrant(input.sessionId, stored, running);
+  return running;
 }

--- a/docs/specs/2026-07-12-session-context-and-connector-connections.md
+++ b/docs/specs/2026-07-12-session-context-and-connector-connections.md
@@ -42,8 +42,10 @@ The implementation MUST preserve these invariants:
    binding may only narrow that set; it cannot add a connector the agent was not
    granted.
 5. Omitted session bindings preserve existing manifest/project defaults.
-6. Binding and connection revocation take effect on the next Connector request,
-   without sandbox restart or token remint.
+6. Binding, connection and manifest grant changes take effect on the next
+   Connector request, without sandbox restart or a replacement token.
+   Authorization reads bypass the process-local Git mirror TTL so this remains
+   true when the manifest write and Connector request reach different replicas.
 7. Runtime context contains only bounded JSON scalars and is never security
    significant.
 8. A session bound to a member connection remains private and cannot create public

--- a/docs/specs/2026-07-26-secret-delivery-policy.md
+++ b/docs/specs/2026-07-26-secret-delivery-policy.md
@@ -159,13 +159,16 @@ Agent identity has two halves: secret delivery and the connector token grant.
 `mintConnectorToken` (`apps/api/src/platform/services/session-sandbox.ts:129`) has
 exactly **one** call site — at sandbox provision. It stamps the token with
 `agentGrant` from the session's create-time agent. The proxy rewrites the
-persisted grant when a later prompt switches agents.
+persisted grant before every prompt. It compares the resolved grant, not only
+the agent name. A same-agent change to `connectors` or `kortix_cli` therefore
+takes effect in the existing session.
 
-Re-scoping *env* per prompt is not sufficient on its own. The proxy now also
-re-mints every active session token's `agent_grant` before it forwards a switched
-prompt. Connector and Kortix CLI authorization therefore follow the running
-agent. `KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` defaults off; operators can set
-it to true when they require immutable secret grants per sandbox.
+Re-scoping *env* per prompt is not sufficient on its own. The proxy also
+reconciles every active session token's `agent_grant` before it forwards each
+prompt. Connector and Kortix CLI authorization therefore follow the current
+manifest and running agent. `KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` defaults
+off; operators can set it to true when they require immutable secret grants per
+sandbox.
 
 There is also a live fail-open on that path: `session-sandbox.ts:143` does
 `resolveAgentGrant(...).catch(() => null)`, and `null` means unrestricted. It
@@ -174,8 +177,13 @@ failure synthesizes a manifest granting `connectors: 'all'` + `kortix_cli: 'all'
 This is the same bug class #5514 fixed for env, still open for the token — and
 the plumbing to fix it (`rethrowReadErrors`) is already on main.
 
-The implementation keeps the token value stable and rewrites its server-side
-grant row. The sandbox does not receive a replacement credential.
+The Connector gateway also reconciles the persisted grant before catalog and
+call authorization. This covers a manifest change followed by a Connector call
+inside one turn. These authorization reads bypass the process-local Git mirror
+TTL, so a different API replica cannot serve the prior grant for up to 60
+seconds. The implementation keeps the token value stable and rewrites
+its server-side grant row. The sandbox does not receive a replacement
+credential, restart, or new session.
 
 ## Delivery-policy sequencing
 


### PR DESCRIPTION
## Problem

Session tokens persist the agent connector grant from session creation. A same-agent change in kortix.yaml does not update that grant. A new session appears to fix authorization because it mints a new token.

## Fix

- Reconcile the current manifest grant before every prompt.
- Reconcile the current manifest grant before Connector catalog and call authorization.
- Force authorization reads past the process-local Git mirror TTL.
- Keep the session ID and token value unchanged.
- Keep OAuth connection state separate from manifest grant state.

## Verification

- pnpm --filter kortix-api test: 5,954 pass, 0 fail, 74 skip.
- pnpm --filter kortix-api typecheck: pass.
- Focused grant tests: 54 pass, 0 fail.
- Real local API and CLI matrix: 107 pass, 0 fail.
- Existing session catalog reconciles a stale same-agent grant without a new session.
- Existing session calls the newly granted connector with the unchanged token.