### PR TITLE
fix(audit): drop primitive structural summaries

### DIFF
--- a/apps/api/src/shared/opencode-audit-ingestion.test.ts
+++ b/apps/api/src/shared/opencode-audit-ingestion.test.ts
@@ -203,6 +203,31 @@ describe('parseOpenCodeAuditBatch', () => {
     ).toThrow('credential-shaped input_summary value');
   });
 
+  test('drops primitive wrapper values that can contain prompts or provider errors', () => {
+    const parsed = parseOpenCodeAuditBatch(
+      {
+        events: [
+          event({
+            input_summary: {
+              sessionID: 'ses_test',
+              message: 'private prompt body',
+              error: 'provider echoed raw output',
+              part: 'raw tool input',
+              info: 'private message metadata',
+            },
+          }),
+        ],
+      },
+      scope,
+    );
+    expect(parsed.values[0]?.inputSummary).toEqual({ sessionID: 'ses_test' });
+    const persisted = JSON.stringify(parsed.values[0]);
+    expect(persisted).not.toContain('private prompt body');
+    expect(persisted).not.toContain('provider echoed raw output');
+    expect(persisted).not.toContain('raw tool input');
+    expect(persisted).not.toContain('private message metadata');
+  });
+
   test('stores only the origin for URL-shaped summary values', () => {
     const parsed = parseOpenCodeAuditBatch(
       {

--- a/apps/api/src/shared/opencode-audit-ingestion.ts
+++ b/apps/api/src/shared/opencode-audit-ingestion.ts
@@ -68,6 +68,12 @@ const SUMMARY_KEYS = new Set([
   'delivery',
 ]);
 
+// These keys are structural wrappers in the OpenCode event contract. A
+// compromised sandbox can otherwise put a prompt or provider response in a
+// primitive `message`, `error`, or `part` value and pass the general string
+// allowlist. Keep only their recursively allowlisted object shape.
+const STRUCTURAL_WRAPPER_KEYS = new Set(['session', 'message', 'part', 'info', 'error', 'state']);
+
 type AuditInsert = typeof auditEvents.$inferInsert;
 
 export interface OpenCodeAuditScope {
@@ -144,6 +150,12 @@ function sanitizeSummary(
     const result: Record<string, unknown> = {};
     for (const [key, child] of Object.entries(candidate as Record<string, unknown>)) {
       if (!SUMMARY_KEYS.has(key)) fail(index, `has a disallowed ${field} key: ${key}`);
+      if (STRUCTURAL_WRAPPER_KEYS.has(key)) {
+        if (child && typeof child === 'object' && !Array.isArray(child)) {
+          result[key] = visit(child, depth + 1);
+        }
+        continue;
+      }
       result[key] = visit(child, depth + 1);
     }
     return result;

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-audit-relay.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-audit-relay.test.ts
@@ -81,6 +81,27 @@ describe('OpenCode canonical audit relay', () => {
     expect(JSON.stringify(event)).not.toContain('private-credential');
   });
 
+  test('drops primitive structural wrappers before writing or sending an event', () => {
+    const event = sanitizeOpenCodeEvent({
+      type: 'message.updated',
+      properties: {
+        sessionID: 'ses_wrappers',
+        message: 'private prompt body',
+        error: 'provider echoed raw output',
+        part: 'raw tool input',
+        info: 'private message metadata',
+      },
+    });
+    expect(event).not.toBeNull();
+    if (!event) throw new Error('expected sanitizable OpenCode event');
+    expect(event.input_summary).toEqual({ sessionID: 'ses_wrappers' });
+    const persisted = JSON.stringify(event);
+    expect(persisted).not.toContain('private prompt body');
+    expect(persisted).not.toContain('provider echoed raw output');
+    expect(persisted).not.toContain('raw tool input');
+    expect(persisted).not.toContain('private message metadata');
+  });
+
   test('classifies the real OpenCode message.part.updated tool lifecycle shape', () => {
     const event = sanitizeOpenCodeEvent({
       type: 'message.part.updated',

--- a/apps/kortix-sandbox-agent-server/src/opencode-audit-relay.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-audit-relay.ts
@@ -116,6 +116,7 @@ const SAFE_KEYS = new Set([
   'mode',
   'delivery',
 ]);
+const STRUCTURAL_WRAPPER_KEYS = new Set(['session', 'message', 'part', 'info', 'error', 'state']);
 
 const EVENT_FIELDS = new Set([
   'event_id',
@@ -148,6 +149,10 @@ function isSafePersistedSummary(value: unknown, depth = 0): boolean {
   if (!value || typeof value !== 'object' || Array.isArray(value) || depth > 4) return false;
   for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
     if (!SAFE_KEYS.has(key)) return false;
+    if (STRUCTURAL_WRAPPER_KEYS.has(key)) {
+      if (!isSafePersistedSummary(child, depth + 1)) return false;
+      continue;
+    }
     if (child === null || typeof child === 'boolean') continue;
     if (typeof child === 'number' && Number.isFinite(child)) continue;
     if (typeof child === 'string' && child.length <= 512 && !SECRET_VALUE.test(child)) continue;
@@ -238,6 +243,12 @@ function structuralSummary(value: unknown, depth = 0): Record<string, unknown> {
   if (!value || typeof value !== 'object' || depth > 3) return {};
   const result: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (STRUCTURAL_WRAPPER_KEYS.has(key)) {
+      if (child && typeof child === 'object' && !Array.isArray(child)) {
+        result[key] = structuralSummary(child, depth + 1);
+      }
+      continue;
+    }
     if (SAFE_KEYS.has(key)) {
       if (Array.isArray(child)) result[key] = { count: child.length };
       else if (child && typeof child === 'object')


### PR DESCRIPTION
## Summary

- require OpenCode structural wrapper fields to contain recursively allowlisted objects
- drop primitive `session`, `message`, `part`, `info`, `error`, and `state` values
- enforce the same rule in the sandbox relay and API ingestion boundary

## Security

A compromised sandbox could place prompt or provider-response text in primitive structural wrapper fields. The relay and API previously accepted those strings because the field names were allowlisted. This change drops those values before spooling and before persistence.

`time` and `delivery` remain scalar-capable because valid OpenCode events use scalar values there.

## Verification

- TDD red state: 24 pass, 2 fail
- focused relay and ingestion tests: 26 pass, 0 fail
- sandbox-agent full suite: 449 pass, 0 fail
- sandbox-agent typecheck: exit 0
- API typecheck: exit 0
- API unit suite: 5,955 pass, 74 skip; one external registry timeout passed in isolation (15 pass)
- API integration suite: 442 pass, 4 skip; one Git fixture timeout passed in isolation (3 pass)
- Biome check on all four files: clean
- git diff --check: clean