### PR TITLE
fix(audit): make OpenCode relay spool writable

### DIFF
--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -211,7 +211,9 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // v39: bake the pinned Python package floor (runtime-versions.json
 // `pythonPackages`) into the managed interpreter — starter skills and bare
 // `python3` run with zero per-script resolution or runtime PyPI downloads.
-const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v39';
+// v40: create a private, kortix-owned /var/run/kortix before daemon startup so
+// the durable OpenCode audit spool and session pins remain writable.
+const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v40';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/apps/sandbox/entrypoint.sh
+++ b/apps/sandbox/entrypoint.sh
@@ -26,6 +26,10 @@ esac
 export PATH
 
 if [ "$(id -u)" -eq 0 ] && id kortix >/dev/null 2>&1; then
+  # The daemon persists OpenCode audit batches and session pins here. Images
+  # create this directory at build time. Repair it here because some providers
+  # replace /run or discard the image USER before starting the entrypoint.
+  install -d -o kortix -g kortix -m 0700 /var/run/kortix
   # TEMPORARY: Platinum starts with /dev/shm as a plain directory and low
   # nofile limits. Both settings must be repaired before the privilege drop.
   grep -q " /dev/shm " /proc/mounts \

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -27,6 +27,7 @@ RUN apt-get update \\
 RUN useradd --create-home --shell /bin/bash --user-group kortix \\
     && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\
     && chmod 0440 /etc/sudoers.d/kortix \\
+    && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\
     && chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral /home/kortix
@@ -204,6 +205,7 @@ RUN apt-get update \\
 RUN useradd --create-home --shell /bin/bash --user-group kortix \\
     && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\
     && chmod 0440 /etc/sudoers.d/kortix \\
+    && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\
     && chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral /home/kortix
@@ -382,6 +384,7 @@ RUN apt-get update \\
 RUN useradd --create-home --shell /bin/bash --user-group kortix \\
     && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\
     && chmod 0440 /etc/sudoers.d/kortix \\
+    && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\
     && chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral /home/kortix

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -334,6 +334,14 @@ describe('the entrypoint survives providers that discard image USER/ENV', () => 
     expect(entrypoint).toContain('sudo -u kortix --');
   });
 
+  test('creates the private runtime directory before dropping root privileges', () => {
+    const runtimeDirectory = 'install -d -o kortix -g kortix -m 0700 /var/run/kortix';
+    const dropAt = entrypoint.indexOf('setpriv --reuid kortix');
+    expect(rendered).toContain(runtimeDirectory);
+    expect(entrypoint).toContain(runtimeDirectory);
+    expect(entrypoint.indexOf(runtimeDirectory)).toBeLessThan(dropAt);
+  });
+
   test('entrypoint PATH dirs cannot drift from the toolchain ENV PATH', () => {
     expect(rendered).toContain(`PATH=${KORTIX_USER_PATH_DIRS}:$PATH`);
   });

--- a/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
@@ -49,6 +49,9 @@ describe('buildMetaSandboxDockerfile', () => {
     );
     expect(dockerfile).not.toContain('artifacts/AGENTS.md');
     expect(dockerfile).toContain('/ephemeral/kortix-master/opencode');
+    expect(dockerfile).toContain(
+      'install -d -o kortix -g kortix -m 0700 /var/run/kortix',
+    );
     expect(dockerfile).toContain('/opt/kortix/llm-catalog.json');
     expect(dockerfile).toContain(
       'COPY --chown=kortix:kortix artifacts/managed-skills /opt/kortix/managed-skills',

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -439,6 +439,7 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // Use echo so every provider writes the same valid sudoers line.
     "    && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\",
     '    && chmod 0440 /etc/sudoers.d/kortix \\',
+    '    && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\',
     '    && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\',
     '        /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\',
     '    && chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral /home/kortix',

--- a/packages/shared/src/sandbox/meta-dockerfile.ts
+++ b/packages/shared/src/sandbox/meta-dockerfile.ts
@@ -68,6 +68,7 @@ RUN apt-get update \\
  && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash kortix \\
+ && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\
  && mkdir -p /workspace /opt/kortix /ephemeral/kortix-master/opencode \\
  && chown -R kortix:kortix /workspace /opt/kortix /ephemeral
 


### PR DESCRIPTION
## Problem

A real dev OpenCode turn produced zero canonical `opencode` audit events. The sandbox health route reported `EACCES: permission denied, mkdir /var/run/kortix`.

## Fix

- Create `/var/run/kortix` with owner `kortix:kortix` and mode `0700` in standard and meta images.
- Repair that directory before the root entrypoint drops privileges.
- Bump `RUNTIME_LAYER_VERSION` to v40 so cached images cannot retain the broken ownership.
- Add renderer and entrypoint contract tests.

## Verification

- `pnpm --filter kortix-api test`: 5956 passed, 74 skipped, 0 failed.
- `pnpm --filter kortix-api test:integration`: 443 passed, 4 skipped, 0 failed.
- `bun test packages/shared/src/sandbox/__tests__ ...`: 84 passed, 0 failed.
- `pnpm --filter @kortix/sandbox-agent-server typecheck`: passed.
- `pnpm --filter kortix-api typecheck`: passed.
- Current `origin/main` shared typecheck has one unrelated `project-glyphs.test.ts:32` overload error.