### PR TITLE
fix(web): hide Apps discovery until the project enables the apps experiment

### DIFF
--- a/apps/web/src/features/apps/apps-feature-gate.test.ts
+++ b/apps/web/src/features/apps/apps-feature-gate.test.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 
 const root = resolve(import.meta.dir, '../..');
 
-test('Apps stays discoverable while execution remains behind the project experimental gate', () => {
+test('every Apps discovery surface hides until the project enables the apps experiment', () => {
   const nav = readFileSync(
     resolve(root, 'features/workspace/project-sidebar/footer/project-apps-nav.tsx'),
     'utf8',
@@ -12,9 +12,10 @@ test('Apps stays discoverable while execution remains behind the project experim
   const menu = readFileSync(resolve(root, 'lib/menu-registry.ts'), 'utf8');
   const view = readFileSync(resolve(root, 'features/apps/apps-view.tsx'), 'utf8');
 
-  expect(nav).not.toContain('useAppsFeatureEnabled');
+  expect(nav).toContain('useAppsFeatureEnabled');
+  expect(nav).toContain('if (!appsGate.enabled) return null;');
   expect(nav).toContain('Experimental');
-  expect(menu).not.toContain("requiresExperimental: 'apps'");
+  expect(menu).toContain("requiresExperimental: 'apps'");
   expect(view).toContain('useAppsFeatureEnabled');
   expect(view).toContain("updateExperimentalFeature(projectId, 'apps', true)");
   expect(view).toContain('Enable Apps');

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-apps-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-apps-nav.tsx
@@ -2,6 +2,7 @@
 
 import { SidebarMenuButton, SidebarMenuItem, useSidebar } from '@/components/ui/sidebar';
 import { Badge } from '@/components/ui/badge';
+import { useAppsFeatureEnabled } from '@/hooks/projects/use-apps-feature-enabled';
 import { useIsMobile } from '@/hooks/utils';
 import { GlobeIcon } from '@phosphor-icons/react';
 import Link from 'next/link';
@@ -14,11 +15,15 @@ export function ProjectAppsNavItem() {
   const projectId = params?.id;
   const isMobile = useIsMobile();
   const { setOpenMobile } = useSidebar();
+  const appsGate = useAppsFeatureEnabled(projectId);
   const handleClick = useCallback(() => {
     if (isMobile) setOpenMobile(false);
   }, [isMobile, setOpenMobile]);
 
   if (!projectId) return null;
+  /* Fail-closed: the entry exists only after the project opts into the `apps`
+     experiment in Settings → Experimental. Loading counts as disabled. */
+  if (!appsGate.enabled) return null;
   return (
     <SidebarMenuItem>
       <SidebarMenuButton

--- a/apps/web/src/lib/menu-registry.ts
+++ b/apps/web/src/lib/menu-registry.ts
@@ -406,6 +406,7 @@ export const menuRegistry: MenuItemDef[] = [
     kind: 'navigate',
     href: '/projects/{projectId}/apps',
     requiresProject: true,
+    requiresExperimental: 'apps',
     keywords: 'apps deploy deployments serverless docker static hosting urls',
   },
   {


### PR DESCRIPTION
## Problem

The `Apps` sidebar entry rendered for every project, permanently tagged `Experimental`, regardless of whether the project enabled the `apps` experimental feature. The command-palette `Apps` entry was also ungated. This was deliberate ("discoverable while execution stays gated") and locked in by `apps-feature-gate.test.ts` — reversed here per Marko's direction: Apps must be invisible until explicitly activated in Settings -> Experimental / WIP Features.

## Change

- `project-apps-nav.tsx`: the sidebar item now uses `useAppsFeatureEnabled(projectId)` and returns `null` unless `experimental.apps === true` (fail-closed; loading counts as disabled).
- `menu-registry.ts`: `proj-apps` gets `requiresExperimental: 'apps'` — the command palette already enforces this generically (`command-palette.tsx` `isExperimentalEnabled`).
- `apps-feature-gate.test.ts`: first test inverted to lock in the hidden-until-enabled contract.

Unchanged: `/projects/:id/apps` (direct URL) keeps its existing fail-closed gate screen with an "Enable Apps" button; API-side `apps` `platformDefault` stays `false`.

## Verification (local worktree, web 24200 / api 24208)

- `bun test src/lib src/features/apps src/features/workspace` — 1696 pass, 0 fail.
- `npx eslint` on the three touched files — clean. `tsc --noEmit` — only the known pre-existing `test.each` + generated `@/.source` errors.
- Real browser (chrome-devtools, fresh user + provisioned project):
  1. Flag off (API default `experimental.apps: false`): sidebar shows Files -> Settings, no Apps; palette query "apps" returns no Apps entry.
  2. Enabled the toggle in Settings -> Experimental / WIP Features -> Apps: sidebar entry appears immediately (no reload); palette shows Apps; `PATCH /projects/:id/experimental` persisted `apps: true`.
  3. Disabled via API + reload: both surfaces hide Apps again.
