### PR TITLE
fix(audit): persist runtime state outside provider tmpfs

### DIFF
--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -211,9 +211,12 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // v39: bake the pinned Python package floor (runtime-versions.json
 // `pythonPackages`) into the managed interpreter — starter skills and bare
 // `python3` run with zero per-script resolution or runtime PyPI downloads.
-// v40: create a private, kortix-owned /var/run/kortix before daemon startup so
-// the durable OpenCode audit spool and session pins remain writable.
-const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v40';
+// v40: create a private, kortix-owned /var/run/kortix before daemon startup.
+// Platinum replaces /run and starts the image as `kortix`, so that directory
+// does not survive provider startup.
+// v41: store durable daemon state under /home/kortix/.local/state/kortix. This
+// path remains writable when a provider replaces /run or discards image USER.
+const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v41';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/apps/kortix-sandbox-agent-server/src/__tests__/runtime-state.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/runtime-state.test.ts
@@ -9,7 +9,8 @@ import {
   OPENCODE_SESSION_PIN_PATH,
   resolveKortixRuntimeStateDirectory,
   resolveOpenCodeAuditSpoolPath,
-  writePrivateRuntimeStateFile,
+  writeOpenCodeSeedBakedPin,
+  writeOpenCodeSessionPin,
 } from '../runtime-state'
 
 describe('sandbox runtime state paths', () => {
@@ -43,16 +44,32 @@ describe('sandbox runtime state paths', () => {
     ).toBe('/tmp/explicit-spool.json')
   })
 
-  test('writes state with a private directory and private file mode', () => {
+  test('writes validated session state with private directory and file modes', async () => {
     const root = mkdtempSync(join(tmpdir(), 'kortix-runtime-state-'))
-    const path = join(root, 'nested', 'pin')
+    const priorStateDirectory = process.env.KORTIX_RUNTIME_STATE_DIR
     try {
-      writePrivateRuntimeStateFile(path, 'ses_private')
-      expect(readFileSync(path, 'utf8')).toBe('ses_private')
-      expect(statSync(join(root, 'nested')).mode & 0o777).toBe(0o700)
-      expect(statSync(path).mode & 0o777).toBe(0o600)
+      process.env.KORTIX_RUNTIME_STATE_DIR = root
+      const fresh = await import(`../runtime-state.ts?test=${crypto.randomUUID()}`)
+      fresh.writeOpenCodeSessionPin('ses_private')
+      fresh.writeOpenCodeSeedBakedPin('ses_seed')
+      const sessionPath = join(root, 'opencode-session-id')
+      const seedPath = join(root, 'opencode-seed-baked-id')
+      expect(readFileSync(sessionPath, 'utf8')).toBe('ses_private')
+      expect(readFileSync(seedPath, 'utf8')).toBe('ses_seed')
+      expect(statSync(root).mode & 0o777).toBe(0o700)
+      expect(statSync(sessionPath).mode & 0o777).toBe(0o600)
+      expect(statSync(seedPath).mode & 0o777).toBe(0o600)
     } finally {
+      if (priorStateDirectory === undefined) delete process.env.KORTIX_RUNTIME_STATE_DIR
+      else process.env.KORTIX_RUNTIME_STATE_DIR = priorStateDirectory
       rmSync(root, { recursive: true, force: true })
     }
+  })
+
+  test('rejects malformed OpenCode session ids before any write', () => {
+    expect(() => writeOpenCodeSessionPin('../escape')).toThrow('malformed OpenCode session id')
+    expect(() => writeOpenCodeSeedBakedPin('ses_valid\ninjected')).toThrow(
+      'malformed OpenCode session id',
+    )
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/runtime-state.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/runtime-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  DEFAULT_KORTIX_RUNTIME_STATE_DIRECTORY,
+  OPENCODE_SEED_BAKED_PIN_PATH,
+  OPENCODE_SESSION_PIN_PATH,
+  resolveKortixRuntimeStateDirectory,
+  resolveOpenCodeAuditSpoolPath,
+  writePrivateRuntimeStateFile,
+} from '../runtime-state'
+
+describe('sandbox runtime state paths', () => {
+  test('keeps every default under the kortix-owned home directory', () => {
+    expect(DEFAULT_KORTIX_RUNTIME_STATE_DIRECTORY).toBe('/home/kortix/.local/state/kortix')
+    expect(OPENCODE_SESSION_PIN_PATH).toBe(
+      '/home/kortix/.local/state/kortix/opencode-session-id',
+    )
+    expect(OPENCODE_SEED_BAKED_PIN_PATH).toBe(
+      '/home/kortix/.local/state/kortix/opencode-seed-baked-id',
+    )
+    expect(resolveOpenCodeAuditSpoolPath({})).toBe(
+      '/home/kortix/.local/state/kortix/opencode-audit-spool.json',
+    )
+  })
+
+  test('supports one shared state-directory override', () => {
+    const env = { KORTIX_RUNTIME_STATE_DIR: '/tmp/kortix-runtime-test' }
+    expect(resolveKortixRuntimeStateDirectory(env)).toBe('/tmp/kortix-runtime-test')
+    expect(resolveOpenCodeAuditSpoolPath(env)).toBe(
+      '/tmp/kortix-runtime-test/opencode-audit-spool.json',
+    )
+  })
+
+  test('keeps the legacy spool-specific override authoritative', () => {
+    expect(
+      resolveOpenCodeAuditSpoolPath({
+        KORTIX_RUNTIME_STATE_DIR: '/tmp/ignored',
+        KORTIX_AUDIT_SPOOL_PATH: '/tmp/explicit-spool.json',
+      }),
+    ).toBe('/tmp/explicit-spool.json')
+  })
+
+  test('writes state with a private directory and private file mode', () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-runtime-state-'))
+    const path = join(root, 'nested', 'pin')
+    try {
+      writePrivateRuntimeStateFile(path, 'ses_private')
+      expect(readFileSync(path, 'utf8')).toBe('ses_private')
+      expect(statSync(join(root, 'nested')).mode & 0o777).toBe(0o700)
+      expect(statSync(path).mode & 0o777).toBe(0o600)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -31,6 +31,11 @@ import { ensureInjectedManagedSkills } from './injected-skills'
 import { isSharedSeedBakedRoot, OPENCODE_SEED_BAKED_PIN_PATH } from './opencode-fork-root'
 import { startOpencodeEventLoop, flattenOpencodeError, type QuestionRequest, type OpencodeTurnError } from './opencode-events'
 import { auditRelayToken, createAuditRelay } from './opencode-audit-relay'
+import {
+  OPENCODE_SESSION_PIN_PATH,
+  resolveOpenCodeAuditSpoolPath,
+  writePrivateRuntimeStateFile,
+} from './runtime-state'
 import { createProjectEnvStore } from './project-env'
 import { startProxy } from './proxy'
 import {
@@ -47,11 +52,6 @@ import type { SandboxBootState } from './routes/health'
 import { installShutdownHandlers } from './shutdown'
 import { startStaticWebServer } from './static-web'
 
-// Pin file for the opencode session created from KORTIX_INITIAL_PROMPT.
-// Webhook follow-ups (e.g. Slack thread replies) read this to deliver new
-// prompts into the same opencode conversation instead of opening a fresh
-// session with no context.
-export const OPENCODE_SESSION_PIN_PATH = '/var/run/kortix/opencode-session-id'
 const LEGACY_OPENCODE_ZEN_FREE_MODELS = new Set([
   'deepseek-v4-flash-free',
   'mimo-v2.5-free',
@@ -308,8 +308,7 @@ async function main() {
           // existing, so writing the marker first guarantees every fork that
           // inherits the pin also inherits the marker (else it can't rotate).
           markSeedBakedSession(session.id)
-          mkdirSync(dirname(OPENCODE_SESSION_PIN_PATH), { recursive: true })
-          writeFileSync(OPENCODE_SESSION_PIN_PATH, session.id, 'utf8')
+          writePrivateRuntimeStateFile(OPENCODE_SESSION_PIN_PATH, session.id)
           bootMark('seed-opencode-session')
           logger.info('[seed] pre-created root opencode session', { sessionId: session.id })
         }
@@ -406,10 +405,7 @@ async function startSessionRuntime(
         throw new Error(`audit batch rejected: ${response.status} ${body.slice(0, 200)}`)
       }
     },
-    {
-      spoolPath:
-        process.env.KORTIX_AUDIT_SPOOL_PATH || '/var/run/kortix/opencode-audit-spool.json',
-    },
+    { spoolPath: resolveOpenCodeAuditSpoolPath(process.env) },
   )
   const flushAuditRelay = () => {
     void auditRelay.stop().catch((error) =>
@@ -672,8 +668,7 @@ async function runWarmSeedMode(
           // existing, so writing the marker first guarantees every fork that
           // inherits the pin also inherits the marker (else it can't rotate).
           markSeedBakedSession(session.id)
-          mkdirSync(dirname(OPENCODE_SESSION_PIN_PATH), { recursive: true })
-          writeFileSync(OPENCODE_SESSION_PIN_PATH, session.id, 'utf8')
+          writePrivateRuntimeStateFile(OPENCODE_SESSION_PIN_PATH, session.id)
           bootMark('seed-opencode-session')
           logger.info('[seed] pre-created + pinned root opencode session', { sessionId: session.id })
         }
@@ -974,8 +969,7 @@ export async function finalizeOrphanedTurn(
  *  file (the in-sandbox source of truth read by abort/relay/turn-end). */
 function pinOpencodeSessionFile(sessionId: string): void {
   try {
-    mkdirSync(dirname(OPENCODE_SESSION_PIN_PATH), { recursive: true })
-    writeFileSync(OPENCODE_SESSION_PIN_PATH, sessionId, 'utf8')
+    writePrivateRuntimeStateFile(OPENCODE_SESSION_PIN_PATH, sessionId)
   } catch (err) {
     logger.warn('[boot] failed to pin opencode session id', err)
   }
@@ -986,8 +980,7 @@ function pinOpencodeSessionFile(sessionId: string): void {
  *  snapshot next to the pin, so every fork inherits it. See opencode-fork-root.ts. */
 function markSeedBakedSession(sessionId: string): void {
   try {
-    mkdirSync(dirname(OPENCODE_SEED_BAKED_PIN_PATH), { recursive: true })
-    writeFileSync(OPENCODE_SEED_BAKED_PIN_PATH, sessionId, 'utf8')
+    writePrivateRuntimeStateFile(OPENCODE_SEED_BAKED_PIN_PATH, sessionId)
   } catch (err) {
     logger.warn('[seed] failed to write seed-baked session marker', err)
   }

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -34,7 +34,8 @@ import { auditRelayToken, createAuditRelay } from './opencode-audit-relay'
 import {
   OPENCODE_SESSION_PIN_PATH,
   resolveOpenCodeAuditSpoolPath,
-  writePrivateRuntimeStateFile,
+  writeOpenCodeSeedBakedPin,
+  writeOpenCodeSessionPin,
 } from './runtime-state'
 import { createProjectEnvStore } from './project-env'
 import { startProxy } from './proxy'
@@ -308,7 +309,7 @@ async function main() {
           // existing, so writing the marker first guarantees every fork that
           // inherits the pin also inherits the marker (else it can't rotate).
           markSeedBakedSession(session.id)
-          writePrivateRuntimeStateFile(OPENCODE_SESSION_PIN_PATH, session.id)
+          writeOpenCodeSessionPin(session.id)
           bootMark('seed-opencode-session')
           logger.info('[seed] pre-created root opencode session', { sessionId: session.id })
         }
@@ -668,7 +669,7 @@ async function runWarmSeedMode(
           // existing, so writing the marker first guarantees every fork that
           // inherits the pin also inherits the marker (else it can't rotate).
           markSeedBakedSession(session.id)
-          writePrivateRuntimeStateFile(OPENCODE_SESSION_PIN_PATH, session.id)
+          writeOpenCodeSessionPin(session.id)
           bootMark('seed-opencode-session')
           logger.info('[seed] pre-created + pinned root opencode session', { sessionId: session.id })
         }
@@ -969,7 +970,7 @@ export async function finalizeOrphanedTurn(
  *  file (the in-sandbox source of truth read by abort/relay/turn-end). */
 function pinOpencodeSessionFile(sessionId: string): void {
   try {
-    writePrivateRuntimeStateFile(OPENCODE_SESSION_PIN_PATH, sessionId)
+    writeOpenCodeSessionPin(sessionId)
   } catch (err) {
     logger.warn('[boot] failed to pin opencode session id', err)
   }
@@ -980,7 +981,7 @@ function pinOpencodeSessionFile(sessionId: string): void {
  *  snapshot next to the pin, so every fork inherits it. See opencode-fork-root.ts. */
 function markSeedBakedSession(sessionId: string): void {
   try {
-    writePrivateRuntimeStateFile(OPENCODE_SEED_BAKED_PIN_PATH, sessionId)
+    writeOpenCodeSeedBakedPin(sessionId)
   } catch (err) {
     logger.warn('[seed] failed to write seed-baked session marker', err)
   }

--- a/apps/kortix-sandbox-agent-server/src/opencode-fork-root.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-fork-root.ts
@@ -18,11 +18,12 @@
  * daemon restarts reuse the fork's own root via the normal idempotent path.
  */
 
+import { OPENCODE_SEED_BAKED_PIN_PATH } from './runtime-state'
+export { OPENCODE_SEED_BAKED_PIN_PATH } from './runtime-state'
+
 /** Well-known marker recording the SEED's pre-baked root id. Lives next to
  *  OPENCODE_SESSION_PIN_PATH and is frozen into the warm snapshot, so every fork
  *  inherits it. Absent on cold sessions and after a fork has rotated. */
-export const OPENCODE_SEED_BAKED_PIN_PATH = '/var/run/kortix/opencode-seed-baked-id'
-
 /**
  * True when the fork's currently-resolved root is the shared seed-baked root and
  * must NOT be reused — the caller then mints a fresh per-session root instead.

--- a/apps/kortix-sandbox-agent-server/src/opencode-fork-root.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-fork-root.ts
@@ -18,7 +18,6 @@
  * daemon restarts reuse the fork's own root via the normal idempotent path.
  */
 
-import { OPENCODE_SEED_BAKED_PIN_PATH } from './runtime-state'
 export { OPENCODE_SEED_BAKED_PIN_PATH } from './runtime-state'
 
 /** Well-known marker recording the SEED's pre-baked root id. Lives next to

--- a/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs'
 
 import { logger } from './logger'
+import { OPENCODE_SESSION_PIN_PATH } from './runtime-state'
+export { OPENCODE_SESSION_PIN_PATH } from './runtime-state'
 
 /**
  * Is opencode mid-turn, and did a turn get orphaned?
@@ -16,8 +18,6 @@ import { logger } from './logger'
  * and for one whose writer died. Distinguishing them is the caller's job:
  * post-respawn, the writer is by definition gone.
  */
-export const OPENCODE_SESSION_PIN_PATH = '/var/run/kortix/opencode-session-id'
-
 /**
  * The canonical opencode root, or null when nothing is pinned yet.
  *

--- a/apps/kortix-sandbox-agent-server/src/runtime-state.ts
+++ b/apps/kortix-sandbox-agent-server/src/runtime-state.ts
@@ -1,0 +1,43 @@
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+/**
+ * Durable daemon state must live under the runtime user's home directory.
+ * Platinum replaces /run after image creation and starts the entrypoint as
+ * `kortix`, so image-time ownership and root-only entrypoint repairs cannot
+ * make /var/run/kortix reliable.
+ */
+export const DEFAULT_KORTIX_RUNTIME_STATE_DIRECTORY = '/home/kortix/.local/state/kortix'
+
+export function resolveKortixRuntimeStateDirectory(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  return env.KORTIX_RUNTIME_STATE_DIR?.trim() || DEFAULT_KORTIX_RUNTIME_STATE_DIRECTORY
+}
+
+export function resolveOpenCodeAuditSpoolPath(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  return (
+    env.KORTIX_AUDIT_SPOOL_PATH?.trim() ||
+    join(resolveKortixRuntimeStateDirectory(env), 'opencode-audit-spool.json')
+  )
+}
+
+export const OPENCODE_SESSION_PIN_PATH = join(
+  resolveKortixRuntimeStateDirectory(),
+  'opencode-session-id',
+)
+
+export const OPENCODE_SEED_BAKED_PIN_PATH = join(
+  resolveKortixRuntimeStateDirectory(),
+  'opencode-seed-baked-id',
+)
+
+export function writePrivateRuntimeStateFile(path: string, value: string): void {
+  const directory = dirname(path)
+  mkdirSync(directory, { recursive: true, mode: 0o700 })
+  chmodSync(directory, 0o700)
+  writeFileSync(path, value, { encoding: 'utf8', mode: 0o600 })
+  chmodSync(path, 0o600)
+}

--- a/apps/kortix-sandbox-agent-server/src/runtime-state.ts
+++ b/apps/kortix-sandbox-agent-server/src/runtime-state.ts
@@ -34,10 +34,37 @@ export const OPENCODE_SEED_BAKED_PIN_PATH = join(
   'opencode-seed-baked-id',
 )
 
-export function writePrivateRuntimeStateFile(path: string, value: string): void {
+const OPENCODE_SESSION_ID = /^[A-Za-z0-9_-]{1,128}$/
+
+function validatedOpenCodeSessionId(value: string): string {
+  if (!OPENCODE_SESSION_ID.test(value)) {
+    throw new Error('refusing to persist a malformed OpenCode session id')
+  }
+  return value
+}
+
+function ensurePrivateRuntimeStateDirectory(path: string): void {
   const directory = dirname(path)
   mkdirSync(directory, { recursive: true, mode: 0o700 })
   chmodSync(directory, 0o700)
-  writeFileSync(path, value, { encoding: 'utf8', mode: 0o600 })
-  chmodSync(path, 0o600)
+}
+
+export function writeOpenCodeSessionPin(sessionId: string): void {
+  const validatedSessionId = validatedOpenCodeSessionId(sessionId)
+  ensurePrivateRuntimeStateDirectory(OPENCODE_SESSION_PIN_PATH)
+  writeFileSync(OPENCODE_SESSION_PIN_PATH, validatedSessionId, {
+    encoding: 'utf8',
+    mode: 0o600,
+  })
+  chmodSync(OPENCODE_SESSION_PIN_PATH, 0o600)
+}
+
+export function writeOpenCodeSeedBakedPin(sessionId: string): void {
+  const validatedSessionId = validatedOpenCodeSessionId(sessionId)
+  ensurePrivateRuntimeStateDirectory(OPENCODE_SEED_BAKED_PIN_PATH)
+  writeFileSync(OPENCODE_SEED_BAKED_PIN_PATH, validatedSessionId, {
+    encoding: 'utf8',
+    mode: 0o600,
+  })
+  chmodSync(OPENCODE_SEED_BAKED_PIN_PATH, 0o600)
 }

--- a/apps/sandbox/entrypoint.sh
+++ b/apps/sandbox/entrypoint.sh
@@ -26,10 +26,6 @@ esac
 export PATH
 
 if [ "$(id -u)" -eq 0 ] && id kortix >/dev/null 2>&1; then
-  # The daemon persists OpenCode audit batches and session pins here. Images
-  # create this directory at build time. Repair it here because some providers
-  # replace /run or discard the image USER before starting the entrypoint.
-  install -d -o kortix -g kortix -m 0700 /var/run/kortix
   # TEMPORARY: Platinum starts with /dev/shm as a plain directory and low
   # nofile limits. Both settings must be repaired before the privilege drop.
   grep -q " /dev/shm " /proc/mounts \

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -27,7 +27,6 @@ RUN apt-get update \\
 RUN useradd --create-home --shell /bin/bash --user-group kortix \\
     && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\
     && chmod 0440 /etc/sudoers.d/kortix \\
-    && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\
     && chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral /home/kortix
@@ -205,7 +204,6 @@ RUN apt-get update \\
 RUN useradd --create-home --shell /bin/bash --user-group kortix \\
     && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\
     && chmod 0440 /etc/sudoers.d/kortix \\
-    && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\
     && chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral /home/kortix
@@ -384,7 +382,6 @@ RUN apt-get update \\
 RUN useradd --create-home --shell /bin/bash --user-group kortix \\
     && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\
     && chmod 0440 /etc/sudoers.d/kortix \\
-    && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\
     && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\
         /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\
     && chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral /home/kortix

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -334,14 +334,6 @@ describe('the entrypoint survives providers that discard image USER/ENV', () => 
     expect(entrypoint).toContain('sudo -u kortix --');
   });
 
-  test('creates the private runtime directory before dropping root privileges', () => {
-    const runtimeDirectory = 'install -d -o kortix -g kortix -m 0700 /var/run/kortix';
-    const dropAt = entrypoint.indexOf('setpriv --reuid kortix');
-    expect(rendered).toContain(runtimeDirectory);
-    expect(entrypoint).toContain(runtimeDirectory);
-    expect(entrypoint.indexOf(runtimeDirectory)).toBeLessThan(dropAt);
-  });
-
   test('entrypoint PATH dirs cannot drift from the toolchain ENV PATH', () => {
     expect(rendered).toContain(`PATH=${KORTIX_USER_PATH_DIRS}:$PATH`);
   });

--- a/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
@@ -49,9 +49,6 @@ describe('buildMetaSandboxDockerfile', () => {
     );
     expect(dockerfile).not.toContain('artifacts/AGENTS.md');
     expect(dockerfile).toContain('/ephemeral/kortix-master/opencode');
-    expect(dockerfile).toContain(
-      'install -d -o kortix -g kortix -m 0700 /var/run/kortix',
-    );
     expect(dockerfile).toContain('/opt/kortix/llm-catalog.json');
     expect(dockerfile).toContain(
       'COPY --chown=kortix:kortix artifacts/managed-skills /opt/kortix/managed-skills',

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -439,7 +439,6 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // Use echo so every provider writes the same valid sudoers line.
     "    && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \\",
     '    && chmod 0440 /etc/sudoers.d/kortix \\',
-    '    && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\',
     '    && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \\',
     '        /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \\',
     '    && chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral /home/kortix',

--- a/packages/shared/src/sandbox/meta-dockerfile.ts
+++ b/packages/shared/src/sandbox/meta-dockerfile.ts
@@ -68,7 +68,6 @@ RUN apt-get update \\
  && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash kortix \\
- && install -d -o kortix -g kortix -m 0700 /var/run/kortix \\
  && mkdir -p /workspace /opt/kortix /ephemeral/kortix-master/opencode \\
  && chown -R kortix:kortix /workspace /opt/kortix /ephemeral
 


### PR DESCRIPTION
## Problem

A fresh Platinum sandbox on dev used template `kortix-default-9a633091ce1f` and failed the natural OpenCode audit relay with:

`EACCES: permission denied, mkdir /var/run/kortix`

Platinum replaces `/run` after image creation and starts the entrypoint as `kortix`. The v40 image ownership repair therefore does not survive provider startup.

## Fix

- Centralize daemon state under `/home/kortix/.local/state/kortix`.
- Move the OpenCode audit spool and both session pin files to that directory.
- Enforce `0700` on the state directory and `0600` on pin files.
- Preserve `KORTIX_AUDIT_SPOOL_PATH` and add `KORTIX_RUNTIME_STATE_DIR` overrides.
- Remove the ineffective `/var/run/kortix` image and root-entrypoint workaround.
- Bump the runtime layer identity to v41.

## Verification

- `pnpm --filter @kortix/sandbox-agent-server test` — 453 passed, 0 failed.
- `pnpm --filter @kortix/sandbox-agent-server build` — Linux x64 agent compiled.
- `pnpm --filter @kortix/sandbox-agent-server typecheck` — passed.
- Focused sandbox rendering and artifact fingerprint suite — 42 passed, 0 failed.
- `git diff --check` — passed.

## Deployed acceptance

After merge and Deploy Dev, rerun `AUD-DEV-ACCEPT` against a fresh Platinum sandbox. The acceptance flow covers natural relay delivery, sandbox ingestion, duplicate rejection, privacy canaries, integrity chaining, authorization, real CLI queries and exports, reconciliation, webhook replay, and offline computer events.