### PR TITLE
fix(runtime): parse CRLF OpenCode event frames

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/event-loop-boot-race.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/event-loop-boot-race.test.ts
@@ -47,6 +47,27 @@ function flakyEventServer(failures: number) {
   return { server, port: server.port as number, attemptCount: () => attempts }
 }
 
+function eventServerWithChunks(chunks: string[]) {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (!new URL(req.url).pathname.startsWith('/event')) return new Response('ok')
+      const stream = new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(new TextEncoder().encode(chunk))
+        },
+      })
+      return new Response(stream, { headers: { 'content-type': 'text/event-stream' } })
+    },
+  })
+  servers.push(server)
+  return { server, port: server.port as number }
+}
+
+function eventServerWithFrame(frame: string) {
+  return eventServerWithChunks([frame])
+}
+
 const cfg = { workspace: '/workspace' } as never
 
 describe('event-loop boot race — the SSE subscribe must not sleep through opencode becoming ready', () => {
@@ -87,6 +108,49 @@ describe('event-loop boot race — the SSE subscribe must not sleep through open
 
     await loop.connected
     expect(connectedCalls).toBeGreaterThanOrEqual(1)
+  }, 20_000)
+
+  test('dispatches an event framed with CRLF line endings', async () => {
+    const event = {
+      type: 'session.updated',
+      properties: { info: { id: 'ses_crlf' } },
+    }
+    const { port } = eventServerWithFrame(`data: ${JSON.stringify(event)}\r\n\r\n`)
+    const observed: string[] = []
+    const loop = startOpencodeEventLoop(fakeOpencode(port), cfg, {
+      onEvent: (candidate) => {
+        if (candidate.type) observed.push(candidate.type)
+      },
+    })
+    loops.push(loop)
+
+    await loop.connected
+    await Bun.sleep(50)
+    expect(observed).toEqual(['session.updated'])
+  }, 20_000)
+
+  test('dispatches a CRLF frame whose delimiter spans reader chunks', async () => {
+    const event = {
+      type: 'session.idle',
+      properties: { sessionID: 'ses_split' },
+    }
+    const encoded = `data: ${JSON.stringify(event)}\r\n\r\n`
+    const { port } = eventServerWithChunks([
+      encoded.slice(0, -3),
+      encoded.slice(-3, -1),
+      encoded.slice(-1),
+    ])
+    const observed: string[] = []
+    const loop = startOpencodeEventLoop(fakeOpencode(port), cfg, {
+      onEvent: (candidate) => {
+        if (candidate.type) observed.push(candidate.type)
+      },
+    })
+    loops.push(loop)
+
+    await loop.connected
+    await Bun.sleep(50)
+    expect(observed).toEqual(['session.idle'])
   }, 20_000)
 
   test('keeps retrying rather than giving up while opencode is still unavailable', async () => {

--- a/apps/kortix-sandbox-agent-server/src/opencode-events.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-events.ts
@@ -101,14 +101,16 @@ export function startOpencodeEventLoop(
       const { value, done } = await reader.read()
       if (done) return
       buf += decoder.decode(value, { stream: true })
-      // SSE frames are separated by a blank line.
-      let idx = buf.indexOf('\n\n')
-      while (idx !== -1) {
-        const frame = buf.slice(0, idx)
-        buf = buf.slice(idx + 2)
-        idx = buf.indexOf('\n\n')
+      // SSE permits LF and CRLF line endings. OpenCode can emit CRLF frames,
+      // including when the delimiter spans reader chunks, so retain the raw
+      // buffer and consume the complete delimiter returned by the match.
+      let boundary = /\r?\n\r?\n/.exec(buf)
+      while (boundary?.index !== undefined) {
+        const frame = buf.slice(0, boundary.index)
+        buf = buf.slice(boundary.index + boundary[0].length)
+        boundary = /\r?\n\r?\n/.exec(buf)
         const dataLines = frame
-          .split('\n')
+          .split(/\r?\n/)
           .filter((l) => l.startsWith('data:'))
           .map((l) => l.slice(5).trim())
           .filter(Boolean)


### PR DESCRIPTION
## Problem

Deploy Dev run `31273800684` shipped merge `d92aeb0d7e56dfbf455b42ec088a9db3d48a5a73` and the new Platinum template `kortix-default-7c5629e13e28`.

The deployed `AUD-DEV-ACCEPT` flow still failed. The daemon connected to OpenCode, but its canonical audit relay recorded zero events and created no spool file. A second subscriber observed 39 OpenCode events from the same turn.

`startOpencodeEventLoop` recognized only LF (`\n\n`) SSE delimiters. The deployed OpenCode stream uses CRLF (`\r\n\r\n`). The daemon therefore connected without dispatching any frames. This also prevented question and turn-end handlers from receiving those frames.

Failed deployed report:

`tests/test-results/20260808193920-ntjoew/report.html`

## Change

- Accept LF and CRLF SSE frame delimiters.
- Consume the matched delimiter length.
- Split frame fields with LF or CRLF.
- Cover a CRLF frame.
- Cover a CRLF delimiter split across reader chunks.

## Verification

- Failing test before the fix: `0 observed` instead of `['session.updated']`.
- Focused regression: `6 passed, 0 failed, 6 assertions`.
- Complete sandbox-agent suite: exit `0`.
- Sandbox-agent typecheck: pass.
- Linux x64 sandbox-agent build: pass; `dist/kortix-agent` is `95,025,280` bytes.
- `git diff --check`: pass.

## Deployed acceptance

After merge and Deploy Dev, rerun:

- `bun bin/ke2e.ts run --domain audit`
- `bun bin/ke2e.ts run --id AUD-DEV-ACCEPT`
