### PR TITLE
fix(audit): return complete session integrity chains

### DIFF
--- a/apps/api/src/__tests__/integration-approvals.test.ts
+++ b/apps/api/src/__tests__/integration-approvals.test.ts
@@ -11,6 +11,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
   accountMembers,
+  auditEvents,
   connectorCalls,
   projectMembers,
   projectSessions,
@@ -18,13 +19,10 @@ import {
   sessionLifecycleCommands,
 } from '@kortix/db';
 import { eq, sql } from 'drizzle-orm';
-import {
-  metadataClearSubtreeKey,
-  metadataMergeSubtree,
-} from '../projects/lib/metadata-merge';
 import { getCreditAccount, setDemoEnterprise } from '../billing/repositories/credit-accounts';
 import { config } from '../config';
 import { app } from '../index';
+import { metadataClearSubtreeKey, metadataMergeSubtree } from '../projects/lib/metadata-merge';
 import { createAccountToken } from '../repositories/account-tokens';
 import { mintSetupLink } from '../setup-links/token';
 import { db } from '../shared/db';
@@ -32,6 +30,8 @@ import { db } from '../shared/db';
 const minted: string[] = [];
 const execIds: string[] = [];
 const SESSION = crypto.randomUUID();
+const CHAIN_SESSION = crypto.randomUUID();
+const CHAIN_PROJECT = crypto.randomUUID();
 let ctx: { projectId: string; accountId: string; userId: string } | null = null;
 let secret = '';
 let humanToken = '';
@@ -56,6 +56,7 @@ beforeAll(async () => {
     select p.project_id, p.account_id, m.user_id
     from kortix.projects p
     join kortix.account_members m on m.account_id = p.account_id and m.account_role = 'owner'
+    where p.status = 'active'
     limit 1`)) as unknown as Array<{ project_id: string; account_id: string; user_id: string }>;
   const r = rows[0];
   if (!r) return;
@@ -170,7 +171,7 @@ beforeAll(async () => {
     .update(projects)
     .set({ metadata: metadataMergeSubtree('experimental', { review_center: true }) })
     .where(eq(projects.projectId, ctx.projectId));
-});
+}, 30_000);
 
 afterAll(async () => {
   if (ctx) {
@@ -187,7 +188,15 @@ afterAll(async () => {
   for (const id of execIds)
     await db.delete(connectorCalls).where(eq(connectorCalls.executionId, id));
   await db.delete(sessionLifecycleCommands).where(eq(sessionLifecycleCommands.sessionId, SESSION));
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`set local kortix.audit_maintenance = 'on'`);
+    await tx
+      .delete(auditEvents)
+      .where(sql`${auditEvents.sessionId} in (${SESSION}, ${CHAIN_SESSION})`);
+  });
   await db.delete(projectSessions).where(eq(projectSessions.sessionId, SESSION));
+  await db.delete(projectSessions).where(eq(projectSessions.sessionId, CHAIN_SESSION));
+  await db.delete(projects).where(eq(projects.projectId, CHAIN_PROJECT));
   for (const id of minted)
     await db.execute(sql`delete from kortix.account_tokens where token_id = ${id}`);
   if (ctx && humanUserId) {
@@ -224,7 +233,7 @@ afterAll(async () => {
     });
   }
   if (ctx) await setDemoEnterprise(ctx.accountId, priorDemoEnterprise);
-});
+}, 30_000);
 
 async function seedPending(argsPreviewComplete = true): Promise<string> {
   if (!ctx) throw new Error('approval integration test has no project context');
@@ -269,6 +278,92 @@ const patPost = (path: string, body: unknown) =>
   });
 
 describe('approvals inbox + resolution', () => {
+  test('session reconstruction includes integrity-linked events with partial request context', async () => {
+    if (!ctx) return;
+    await db.insert(projects).values({
+      projectId: CHAIN_PROJECT,
+      accountId: ctx.accountId,
+      name: 'audit-chain-test',
+      repoUrl: 'https://example.test/audit-chain-test.git',
+    });
+    await db.insert(projectSessions).values({
+      sessionId: CHAIN_SESSION,
+      accountId: ctx.accountId,
+      projectId: CHAIN_PROJECT,
+      branchName: 'audit-chain-test',
+      createdBy: ctx.userId,
+      visibility: 'private',
+    });
+    const chainId = crypto.randomUUID();
+    const sourceRecordIds = ['first', 'auth', 'skills', 'last'].map(
+      (suffix) => `${chainId}:${suffix}`,
+    );
+    const inserted = await db
+      .insert(auditEvents)
+      .values([
+        {
+          accountId: ctx.accountId,
+          projectId: CHAIN_PROJECT,
+          sessionId: CHAIN_SESSION,
+          action: 'test.session_chain.first',
+          resourceType: 'test',
+          sourceLedger: 'integration_test',
+          sourceRecordId: sourceRecordIds[0],
+        },
+        {
+          accountId: null,
+          projectId: CHAIN_PROJECT,
+          sessionId: CHAIN_SESSION,
+          action: 'auth.login.success',
+          resourceType: 'session',
+          sourceLedger: 'integration_test',
+          sourceRecordId: sourceRecordIds[1],
+        },
+        {
+          accountId: ctx.accountId,
+          projectId: null,
+          sessionId: CHAIN_SESSION,
+          action: 'GET /v1/skills',
+          resourceType: 'skill',
+          sourceLedger: 'integration_test',
+          sourceRecordId: sourceRecordIds[2],
+        },
+        {
+          accountId: ctx.accountId,
+          projectId: CHAIN_PROJECT,
+          sessionId: CHAIN_SESSION,
+          action: 'test.session_chain.last',
+          resourceType: 'test',
+          sourceLedger: 'integration_test',
+          sourceRecordId: sourceRecordIds[3],
+        },
+      ])
+      .returning({ eventId: auditEvents.eventId });
+
+    const response = await patGet(
+      `/v1/projects/${CHAIN_PROJECT}/sessions/${CHAIN_SESSION}/audit?limit=1000`,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      events: Array<{
+        event_id: string;
+        source_record_id: string | null;
+        integrity_previous_hash: string | null;
+        integrity_hash: string | null;
+      }>;
+    };
+    const projected = body.events.filter((event) =>
+      sourceRecordIds.includes(event.source_record_id ?? ''),
+    );
+
+    expect(projected.map((event) => event.event_id)).toEqual(
+      inserted.map((event) => event.eventId),
+    );
+    expect(projected[1]?.integrity_previous_hash).toBe(projected[0]?.integrity_hash);
+    expect(projected[2]?.integrity_previous_hash).toBe(projected[1]?.integrity_hash);
+    expect(projected[3]?.integrity_previous_hash).toBe(projected[2]?.integrity_hash);
+  });
+
   test('pending → inbox → approve → resolved (leaves inbox) → re-approve 409 → audit shows approver', async () => {
     if (!ctx) {
       console.warn('[integration] no project/owner in local DB — skipping');

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -1363,11 +1363,14 @@ projectsApp.openapi(
     const audited = await accountHasEntitlement(loaded.row.accountId, 'auditAccess');
     const includeEvents = c.req.query('include_events') !== 'false';
 
-    const eventConditions = [
-      eq(auditEvents.accountId, loaded.row.accountId),
-      eq(auditEvents.projectId, projectId),
-      eq(auditEvents.sessionId, sessionId),
-    ];
+    // `session_id` is the integrity-chain scope and is globally unique. The
+    // visibility gate above already proves that the caller may read this
+    // project session. Some request-level events are written before account
+    // resolution (`auth.login.success`) or from a project-neutral endpoint
+    // (`GET /v1/skills`). Those rows still belong to this session's chain. An
+    // account/project predicate would remove the middle row while returning its
+    // successor, which makes a valid persisted chain impossible to verify.
+    const eventConditions = [eq(auditEvents.sessionId, sessionId)];
     if (cursor) {
       const cursorCondition = or(
         gt(auditEvents.sessionSequence, cursor.sequence),


### PR DESCRIPTION
## Problem

The session audit route filters by `account_id`, `project_id`, and `session_id`. Request middleware writes valid session-chain events before account resolution or from project-neutral routes. Those events have a null account or project dimension. The route omits them while returning their successors, so the persisted hash chain cannot be reconstructed.

## Fix

- Keep the existing project/session visibility authorization.
- Query the canonical reconstruction by globally unique `session_id`, which is also the integrity-chain scope.
- Add an HTTP + PostgreSQL regression containing four consecutive events.
- Cover `auth.login.success` with `account_id = NULL` and `GET /v1/skills` with `project_id = NULL`.
- Make the borrowed integration fixture select an active project and use explicit hook timeouts.

## Verification

- `KORTIX_URL=http://localhost:8008 dotenvx run -- bun test --isolate src/__tests__/integration-approvals.test.ts` — 12 passed, 0 failed.
- `pnpm --filter kortix-api test` — 5,956 passed, 0 failed, 74 skipped.
- `pnpm --filter kortix-api typecheck` — exit 0.
- `pnpm exec biome check apps/api/src/__tests__/integration-approvals.test.ts` — exit 0.
- `git diff origin/main --check` — exit 0.