### PR TITLE
feat(cli,tests,docs): feature_disabled everywhere — CLI message, drift pin, flags UI spec

### DIFF
--- a/apps/api/src/__tests__/unit-feature-flag-drift.test.ts
+++ b/apps/api/src/__tests__/unit-feature-flag-drift.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Cross-package drift gate for the per-project feature-flag list.
+ *
+ * The same list is declared THREE times, on purpose:
+ *   1. `@kortix/api-contract` — `FEATURE_FLAG_KEYS` (zod, the wire contract).
+ *   2. `@kortix/sdk` — `FEATURE_FLAG_KEYS` (hand-written; the SDK is
+ *      framework-free and dependency-light, so it must not pull zod into every
+ *      consumer's bundle to re-derive the contract's list).
+ *   3. `apps/api/src/feature-flags/registry.ts` — the registry that owns each
+ *      flag's name, description, stability, availability, and enforcement.
+ *
+ * Nothing at the type level can force those three to agree: (2) is a hand-typed
+ * union in a separate published package. This test is the structural guarantee
+ * — add a flag to one list and not the others and it fails here.
+ *
+ * It lives in apps/api because apps/api is the only package that already
+ * depends on BOTH `@kortix/api-contract` (runtime dep) and `@kortix/sdk`
+ * (devDependency, test-only — see e2e-connector-faces.test.ts) AND owns the
+ * registry. Putting it in packages/sdk is not an option: `packages/sdk/AGENTS.md`
+ * keeps the core framework-free and import-graph-checked, and it has no
+ * dependency on the API's registry at all.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  FEATURE_FLAG_KEYS as CONTRACT_FEATURE_FLAG_KEYS,
+  FeatureFlagStabilitySchema,
+} from '@kortix/api-contract';
+import { FEATURE_FLAG_KEYS as SDK_FEATURE_FLAG_KEYS } from '@kortix/sdk';
+
+import { REGISTERED_FEATURE_FLAGS, buildFeatureFlagCatalog } from '../feature-flags/registry';
+
+const contractKeys = [...CONTRACT_FEATURE_FLAG_KEYS].sort();
+const sdkKeys = [...SDK_FEATURE_FLAG_KEYS].sort();
+const registryKeys = REGISTERED_FEATURE_FLAGS.map((flag) => flag.key).sort();
+const catalogKeys = buildFeatureFlagCatalog({})
+  .map((flag) => flag.key)
+  .sort();
+
+describe('feature-flag key lists — contract ↔ SDK ↔ API registry', () => {
+  test('the SDK key list matches the contract key list exactly', () => {
+    expect(sdkKeys).toEqual(contractKeys);
+  });
+
+  test('the API registry matches the contract key list exactly', () => {
+    expect(registryKeys).toEqual(contractKeys);
+  });
+
+  test('the catalog the clients render matches the SDK key list exactly', () => {
+    // The catalog is what Settings → Feature flags actually draws, and the SDK
+    // list is what a host uses to name and gate a flag. A flag present in one
+    // and not the other is a row nobody can act on, or a gate with no row.
+    expect(catalogKeys).toEqual(sdkKeys);
+  });
+
+  test('no list carries a duplicate key', () => {
+    expect(new Set(contractKeys).size).toBe(contractKeys.length);
+    expect(new Set(sdkKeys).size).toBe(sdkKeys.length);
+    expect(new Set(registryKeys).size).toBe(registryKeys.length);
+  });
+
+  test('all three lists are non-empty', () => {
+    // Guards the assertions above against the degenerate case where an import
+    // resolves to an empty array and every equality passes vacuously.
+    expect(contractKeys.length).toBeGreaterThan(0);
+    expect(sdkKeys.length).toBe(contractKeys.length);
+    expect(registryKeys.length).toBe(contractKeys.length);
+  });
+});
+
+describe('feature-flag stability — registry ↔ contract enum', () => {
+  test('every registered flag declares a stability the contract accepts', () => {
+    for (const flag of REGISTERED_FEATURE_FLAGS) {
+      expect(FeatureFlagStabilitySchema.options).toContain(flag.stability);
+      expect(FeatureFlagStabilitySchema.safeParse(flag.stability).success).toBe(true);
+    }
+  });
+
+  test('every catalog entry serializes a stability the contract accepts', () => {
+    // The catalog is the serialized wire shape, so this is the value a client
+    // actually receives and renders as a badge.
+    for (const flag of buildFeatureFlagCatalog({})) {
+      expect(FeatureFlagStabilitySchema.options).toContain(flag.stability);
+    }
+  });
+});

--- a/apps/cli/src/__tests__/channels.test.ts
+++ b/apps/cli/src/__tests__/channels.test.ts
@@ -324,24 +324,29 @@ describe('kortix channels --platform teams', () => {
     expect(parsed.orgInstalled).toBe(false);
   });
 
-  test('connect with the `teams` experiment off → points at Settings, not at server env vars', async () => {
+  test('connect with the `teams` feature flag off → points at Settings on stderr, not at server env vars', async () => {
     state.teamsEnabled = false;
     const code = await runChannels(['connect', '--platform', 'teams']);
     expect(code).toBe(1);
-    const out = stripAnsi(stdout);
-    expect(out).toContain('Customize → Settings → Experimental');
-    expect(out).not.toContain(TEAMS_CONSENT_URL);
-    expect(out).not.toContain('MICROSOFT_APP_ID');
+    // A rejection is an error: it belongs on stderr, worded exactly like the
+    // server's feature-flag gate so both sides read identically.
+    const err = stripAnsi(stderr);
+    expect(err).toContain(
+      'Microsoft Teams is not enabled for this project. Enable it in Settings → Feature flags.',
+    );
+    expect(stripAnsi(stdout)).toBe('');
+    expect(err).not.toContain(TEAMS_CONSENT_URL);
+    expect(err).not.toContain('MICROSOFT_APP_ID');
   });
 
-  test('connect with the experiment on but no bot credentials → points at the credentials', async () => {
+  test('connect with the feature flag on but no bot credentials → points at the credentials', async () => {
     state.oauthAvailable = false;
     const code = await runChannels(['connect', '--platform', 'teams']);
     expect(code).toBe(1);
     const out = stripAnsi(stdout);
     expect(out).toContain('MICROSOFT_APP_ID');
     expect(out).toContain('bring your own bot');
-    expect(out).not.toContain('Settings → Experimental');
+    expect(out).not.toContain('Settings → Feature flags');
   });
 
   test('invalid --platform value → exit 2', async () => {

--- a/apps/cli/src/__tests__/cli-blackbox.test.ts
+++ b/apps/cli/src/__tests__/cli-blackbox.test.ts
@@ -162,7 +162,19 @@ function startSystemSkillsServer() {
   return `http://127.0.0.1:${server.port}`;
 }
 
-function startAppsServer(appsEnabled = true) {
+/** The API's one feature-flag gate body — 403 `{ error, code, feature }` from
+ *  `featureDisabledBody('apps')` in apps/api/src/feature-flags/gate.ts. Copied
+ *  verbatim so the test asserts the real wire shape, not a paraphrase. */
+const APPS_FEATURE_DISABLED_BODY = {
+  error: 'Apps is not enabled for this project. Enable it in Settings → Feature flags.',
+  code: 'feature_disabled',
+  feature: 'apps',
+};
+
+/** `serverGate: true` keeps the project row reporting the flag ON while every
+ *  `/apps` route rejects with the server's gate — the case a client-side
+ *  pre-check cannot catch (flag turned off between the two calls). */
+function startAppsServer(appsEnabled = true, serverGate = false) {
   let appAccessMode = 'private';
   let appAccessRevision = 1;
   const app = {
@@ -203,6 +215,9 @@ function startAppsServer(appsEnabled = true) {
           name: 'Apps Test',
           experimental: { apps: appsEnabled },
         });
+      }
+      if (serverGate && url.pathname.startsWith('/v1/projects/proj_e2e/apps')) {
+        return Response.json(APPS_FEATURE_DISABLED_BODY, { status: 403 });
       }
       if (url.pathname === '/v1/projects/proj_e2e/apps' && req.method === 'GET') {
         return Response.json({ apps: [{ ...app, access_mode: appAccessMode, access_revision: appAccessRevision }] });
@@ -766,8 +781,34 @@ describe('kortix CLI black-box behavior', () => {
     const listed = await runCli(['apps', 'list', '--project', 'proj_e2e'], tmp, env);
     expect(listed.code).toBe(1);
     expect(listed.stdout).not.toContain('No Apps deployed');
-    expect(listed.stderr).toContain('Apps is not enabled for this project');
+    // The pre-check says exactly what the server's gate says, so the user reads
+    // one sentence whichever side rejects.
+    expect(listed.stderr).toContain(
+      'Apps is not enabled for this project. Enable it in Settings → Feature flags.',
+    );
+    expect(listed.stderr).not.toContain('Experimental');
     expect(requests.every((request) => request.path === '/v1/projects/proj_e2e')).toBe(true);
+  }, 20_000);
+
+  test("a raw 403 feature_disabled from the API surfaces the server's message verbatim", async () => {
+    // The project row still reports the flag ON — only the server gate rejects,
+    // so this exercises `surfaceApiError`, not the client-side pre-check.
+    const apiBase = startAppsServer(true, true);
+    const configFile = writeConfig(apiBase, true);
+    const env = { KORTIX_CONFIG_FILE: configFile };
+
+    const listed = await runCli(['apps', 'list', '--project', 'proj_e2e'], tmp, env);
+
+    expect(listed.code).toBe(1);
+    expect(listed.stderr).toContain(APPS_FEATURE_DISABLED_BODY.error);
+    // Never the generic 403 prose — a role problem the user does not have.
+    expect(listed.stderr).not.toContain('you may not have permission');
+    expect(listed.stderr).not.toContain('HTTP 403');
+    expect(listed.stdout).not.toContain('No Apps deployed');
+    expect(requests.map((request) => [request.method, request.path])).toEqual([
+      ['GET', '/v1/projects/proj_e2e'],
+      ['GET', '/v1/projects/proj_e2e/apps'],
+    ]);
   }, 20_000);
 
   test('tunnel is no longer a top-level command', async () => {

--- a/apps/cli/src/command-helpers.ts
+++ b/apps/cli/src/command-helpers.ts
@@ -1,3 +1,5 @@
+import { FEATURE_DISABLED_CODE } from '@kortix/sdk';
+
 import { loadAuth, loadAuthForHost, type Auth } from './api/auth.ts';
 import { activeHostName, hasEnvTokenHost, listHosts } from './api/config.ts';
 import { ApiError, clientFromAuth, type ApiClient } from './api/client.ts';
@@ -409,8 +411,52 @@ async function probeConcurrently<Item, Result>(
   return found;
 }
 
+/**
+ * Pull the server's feature-flag gate message off an error, or null when the
+ * error is not that gate.
+ *
+ * The gate is one shape on the wire — 403 `{ error, code: 'feature_disabled',
+ * feature }` (apps/api/src/feature-flags/gate.ts) — but reaches the CLI as two
+ * error classes: the CLI's own `ApiError` keeps the parsed body in `.body`,
+ * while an SDK `ApiError` thrown by a `kortix.*` handle keeps it in
+ * `.details`/`.data` and lifts `code` onto the error. Both are read
+ * structurally here, and the status is deliberately NOT checked, so a future
+ * status carrying the same code still surfaces the same message.
+ */
+function featureDisabledMessage(err: unknown): string | null {
+  if (!err || typeof err !== 'object') return null;
+  const carrier = err as {
+    code?: unknown;
+    message?: unknown;
+    body?: unknown;
+    details?: unknown;
+    data?: unknown;
+  };
+  const body = [carrier.body, carrier.details, carrier.data].find(
+    (candidate): candidate is Record<string, unknown> =>
+      !!candidate && typeof candidate === 'object' && !Array.isArray(candidate),
+  );
+  const code = typeof carrier.code === 'string' ? carrier.code : body?.code;
+  if (code !== FEATURE_DISABLED_CODE) return null;
+  // The server's prose already names the feature and points at
+  // Settings → Feature flags — print it verbatim rather than paraphrasing.
+  const fromBody = body?.error;
+  if (typeof fromBody === 'string' && fromBody.length > 0) return fromBody;
+  return typeof carrier.message === 'string' && carrier.message.length > 0
+    ? carrier.message
+    : null;
+}
+
 /** Print an HTTP error in a consistent style + return exit code 1. */
 export function surfaceApiError(err: unknown): number {
+  // The feature-flag gate is actionable on its own — never let it fall through
+  // to the generic 403 "you may not have permission" prose, which sends the
+  // user hunting for a role problem that does not exist.
+  const featureDisabled = featureDisabledMessage(err);
+  if (featureDisabled) {
+    process.stderr.write(`${status.err(featureDisabled)}\n`);
+    return 1;
+  }
   if (err instanceof ApiError) {
     if (err.status === 401) {
       process.stderr.write(

--- a/apps/cli/src/commands/apps.ts
+++ b/apps/cli/src/commands/apps.ts
@@ -160,9 +160,12 @@ async function context(options: ContextOptions): Promise<{
   const project = await withKortixScope(resolved.auth, () =>
     kortix.project(resolved.projectId).get(),
   );
+  // Client-side pre-check: saves a wasted round trip when the flag is off. The
+  // wording matches the server's gate verbatim (feature-flags/gate.ts), so the
+  // user reads the same sentence whichever side rejects.
   if (project.experimental?.apps !== true) {
     process.stderr.write(
-      `${status.err('Apps is not enabled for this project.')} Enable Apps in Project Settings → Experimental.\n`,
+      `${status.err('Apps is not enabled for this project. Enable it in Settings → Feature flags.')}\n`,
     );
     return null;
   }

--- a/apps/cli/src/commands/channels.ts
+++ b/apps/cli/src/commands/channels.ts
@@ -493,9 +493,12 @@ async function teamsConnect(
     const mode = await ctx.client.get<TeamsMode>(
       `/projects/${ctx.projectId}/channels/teams/mode`,
     );
+    // Client-side pre-check, worded exactly like the server's feature-flag gate
+    // (feature-flags/gate.ts). It is a failure, so it goes to stderr like every
+    // other CLI error — stdout stays reserved for the command's own output.
     if (!mode.enabled) {
-      process.stdout.write(
-        `${C.dim}Microsoft Teams is off for this project. Turn it on under Customize → Settings → Experimental, then retry.${C.reset}\n`,
+      process.stderr.write(
+        `${status.err('Microsoft Teams is not enabled for this project. Enable it in Settings → Feature flags.')}\n`,
       );
       return 1;
     }

--- a/apps/web/content/docs/connect/computers.mdx
+++ b/apps/web/content/docs/connect/computers.mdx
@@ -10,7 +10,7 @@ sandbox is a disposable cloud machine that Kortix creates for a
 it stays connected across sessions.
 
 This feature is experimental. Before you connect a machine, enable **Agent
-Computer Tunnel** in Customize → Experimental.
+Computer Tunnel** in Customize → Feature flags.
 
 ## Connect a machine
 

--- a/apps/web/content/docs/connect/slack.mdx
+++ b/apps/web/content/docs/connect/slack.mdx
@@ -16,12 +16,11 @@ Kortix supports four channel platforms today:
 - **Slack** — connect with one click through the Kortix-managed app, or bring
   your own bot token.
 - **Microsoft Teams** — connect through org admin-consent OAuth, or bring your
-  own Azure Bot (experimental; enable it under Customize → Settings →
-  Experimental).
+  own Azure Bot (experimental; enable it under Customize → Feature flags).
 - **Email** — an AgentMail-backed channel (experimental; enable it under
-  Customize → Settings → Experimental).
+  Customize → Feature flags).
 - **Voice** — a realtime voice channel on LiveKit (experimental; enable it under
-  Customize → Settings → Experimental). A connected call is a LiveKit room;
+  Customize → Feature flags). A connected call is a LiveKit room;
   the agent speaks through the live media session.
 
 Only Slack and Microsoft Teams connect through the CLI and dashboard. Email

--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -10,8 +10,8 @@ explains managed models vs. your own provider key (BYOK), how Kortix picks a
 model automatically, and two billing gotchas to know.
 
 This page applies to projects with the LLM Gateway on. LLM Gateway is an
-experimental setting, and it is on by default for cloud projects. Check or
-toggle it in Customize → Experimental.
+experimental feature flag, and it is on by default for cloud projects. Check or
+toggle it in Customize → Feature flags.
 
 ## Managed models and BYOK
 

--- a/apps/web/content/docs/sdk/apps.mdx
+++ b/apps/web/content/docs/sdk/apps.mdx
@@ -5,7 +5,7 @@ description: Deploy static sites, bundles, Dockerfiles, and OCI images to stable
 
 Kortix Apps are provider-neutral serverless deployments. An App owns one stable URL. Each deployment is immutable. Failed deployments do not replace active traffic.
 
-Apps is experimental and off by default. The Apps navigation remains visible for a selected project and opens an enablement screen. API and CLI execution return `404` until a project manager enables **Apps** for that project.
+Apps is an experimental feature flag and off by default. The Apps navigation remains visible for a selected project and opens an enablement screen. Until a project manager enables **Apps** under Customize → Feature flags, every Apps route answers `403` with `{ error, code: "feature_disabled", feature: "apps" }`, and `kortix apps <subcommand>` prints that message and exits `1`.
 
 All current source kinds run through the same Kortix sandbox hosting backend. Kortix selects Daytona, Platinum, or E2B. Static Apps, bundles, Dockerfiles, and OCI images therefore share one deployment and cold-wake contract. Cloudflare, Deno Deploy, Vercel, and other managed hosting backends are not part of the current API or SDK contract.
 

--- a/apps/web/content/docs/sdk/reference.mdx
+++ b/apps/web/content/docs/sdk/reference.mdx
@@ -259,7 +259,7 @@ agent, a skill, a secret) instead of the whole project.
 | `connections.updateCredential(connectionId, input)` | rotate a connection credential |
 | `connections.revoke(connectionId)` · `connections.activate(connectionId)` | deny · restore a connection |
 
-`p.connectors.discover` browses the direct-connector catalog. It is **experimental** and off by default — enable it per project under Customize → Settings → Experimental → "Connectors API Discover". Easy Connect (Pipedream) remains the default connector marketplace.
+`p.connectors.discover` browses the direct-connector catalog. It is **experimental** and off by default — enable it per project under Customize → Feature flags → "Connectors API Discover". Easy Connect (Pipedream) remains the default connector marketplace.
 
 | method | what |
 | --- | --- |
@@ -423,10 +423,25 @@ Account, agent, and project-scoped model defaults, resolved by the gateway.
 then sets it as `default_agent` in the project's `kortix.yaml`. New sessions
 prefer this agent unless a user picks another one.
 
-#### `p.updateExperimentalFeature` — feature flags
+#### `p.updateFeatureFlag` — feature flags
 
-`p.updateExperimentalFeature(feature, enabled)` toggles an experimental
-feature for the project. Pass `enabled: null` to clear the override.
+`p.updateFeatureFlag(feature, enabled)` turns one feature flag on or off for the
+project. Pass `enabled: null` to clear the override and fall back to the
+platform default. It calls the canonical `PATCH /v1/projects/:id/features`.
+
+`feature` is one of `FEATURE_FLAG_KEYS` (exported from `@kortix/sdk`, typed as
+`FeatureFlagKey`). The caller needs the project's `project.customize.write`
+permission; the route answers `403` otherwise.
+
+Every flag-gated route rejects the same way while the flag is off: HTTP `403`
+with `{ error, code: "feature_disabled", feature }`. Use `isFeatureDisabledError(error)`
+to branch on it and `featureDisabledKey(error)` to read the flag key — never
+match on the message text.
+
+`p.updateExperimentalFeature(feature, enabled)` is the **deprecated** alias. It
+keeps calling the deprecated route alias `PATCH /v1/projects/:id/experimental`
+so consumers pinned to an older deployed API keep working. Use
+`p.updateFeatureFlag` in new code.
 
 #### `p.sandbox` — templates and snapshot builds
 

--- a/apps/web/src/features/marketing/channels/content.ts
+++ b/apps/web/src/features/marketing/channels/content.ts
@@ -101,7 +101,7 @@ export const surfaces = {
       icon: 'Gmail',
       name: 'Email',
       state: 'Experimental',
-      body: 'A project inbox, so a message to an address starts a session and a reply continues it. Opt in per project under Customize → Settings → Experimental. Real, and not finished.',
+      body: 'A project inbox, so a message to an address starts a session and a reply continues it. Opt in per project under Customize → Feature flags. Real, and not finished.',
     },
     {
       id: 'voice',

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-apps-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-apps-nav.tsx
@@ -21,8 +21,8 @@ export function ProjectAppsNavItem() {
   }, [isMobile, setOpenMobile]);
 
   if (!projectId) return null;
-  /* Fail-closed: the entry exists only after the project opts into the `apps`
-     experiment in Settings → Experimental. Loading counts as disabled. */
+  /* Fail-closed: the entry exists only after the project turns the `apps`
+     feature flag on in Customize → Feature flags. Loading counts as disabled. */
   if (!appsGate.enabled) return null;
   return (
     <SidebarMenuItem>

--- a/tests/e2e/specs/18-apps-ui.spec.ts
+++ b/tests/e2e/specs/18-apps-ui.spec.ts
@@ -165,26 +165,37 @@ test.describe("18 — Kortix Apps UI", () => {
       await expect(
         page.getByRole("main").getByText("Experimental", { exact: true }),
       ).toBeVisible();
-      await expect(page.getByRole("button", { name: "Enable Apps" })).toBeVisible();
+      // The gate screen never self-enables: it points at Customize → Feature
+      // flags and there is no Enable button on the feature's own page.
+      await expect(page.getByText("is off for this project")).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Enable Apps" }),
+      ).toHaveCount(0);
       expect(disabledAppRequests).toEqual([]);
       page.off("request", recordDisabledRequest);
 
+      // Enable through the Feature flags section — the only activation path.
+      await page.getByRole("button", { name: "Feature flags" }).click();
       const enabledRequest = page.waitForRequest(
         (request) =>
           request.method() === "PATCH" &&
-          request.url().endsWith(`/v1/projects/${project.id}/experimental`),
+          request.url().endsWith(`/v1/projects/${project.id}/features`),
       );
       const enabledResponse = page.waitForResponse(
         (response) =>
           response.request().method() === "PATCH" &&
-          response.url().endsWith(`/v1/projects/${project.id}/experimental`),
+          response.url().endsWith(`/v1/projects/${project.id}/features`),
       );
-      await page.getByRole("button", { name: "Enable Apps" }).click();
+      await page.getByRole("switch", { name: "Apps" }).click();
       expect((await enabledRequest).postDataJSON()).toEqual({
         feature: "apps",
         enabled: true,
       });
       expect((await enabledResponse).status()).toBe(200);
+      await page.getByRole("button", { name: "Back to workspace" }).click();
+      await page.goto(`/projects/${project.id}/apps`, {
+        waitUntil: "domcontentloaded",
+      });
       await expect(page.getByText("No Apps deployed", { exact: true })).toBeVisible();
 
       const seeded = await api<AppResponse>(

--- a/tests/e2e/specs/19-feature-flags-ui.spec.ts
+++ b/tests/e2e/specs/19-feature-flags-ui.spec.ts
@@ -1,0 +1,277 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+import { loadEnv } from "../../src/core/env";
+import {
+  createDatabaseProject,
+  deleteDatabaseProject,
+} from "../../src/fixtures/database-project";
+import { createApiJsonClient } from "../helpers/http";
+import {
+  createAuthUser,
+  deleteAuthUser,
+  installBrowserSessionDirect,
+  signIn,
+} from "../helpers/session-auth";
+import { selectAccountForUi } from "../helpers/ui";
+
+const apiBase = process.env.E2E_API_URL || "http://localhost:13738/v1";
+const supabaseUrl = process.env.E2E_SUPABASE_URL || "http://localhost:13740";
+const databaseUrl =
+  process.env.KE2E_DATABASE_URL || process.env.E2E_DATABASE_URL;
+const password = "E2eFeatureFlagsUi123!";
+const authOptions = { supabaseUrl, password };
+const api = createApiJsonClient(apiBase);
+
+/** The badge each stability renders as (feature-flags-view.tsx STABILITY_BADGE). */
+const STABILITY_BADGE: Record<string, string> = {
+  experimental: "Experimental",
+  beta: "Beta",
+  stable: "Stable",
+};
+
+interface AccountSummary {
+  account_id: string;
+  personal_account?: boolean;
+  is_primary_owner?: boolean;
+  account_role: string;
+}
+
+/** One entry of the server's self-describing catalog — `buildFeatureFlagCatalog`
+ *  in apps/api/src/feature-flags/registry.ts, serialized as
+ *  `project.experimental_features`. The UI renders straight from it, so the
+ *  spec reads its expectations from the same source instead of hard-coding a
+ *  flag list that would rot the moment a flag is added. */
+interface FeatureFlagView {
+  key: string;
+  name: string;
+  description: string;
+  stability: string;
+  available: boolean;
+  enabled: boolean;
+  overridden: boolean;
+}
+
+interface ProjectResponse {
+  project_id: string;
+  experimental_features: FeatureFlagView[];
+}
+
+async function dismissOnboarding(page: Page): Promise<void> {
+  await page.waitForTimeout(2_000);
+  for (let step = 0; step < 12; step += 1) {
+    const onboarding = page.getByRole("dialog").last();
+    if (!(await onboarding.isVisible().catch(() => false))) break;
+    const skip = onboarding
+      .getByRole("button", { name: /^(Skip|Not now|Maybe later)/i })
+      .last();
+    if (await skip.isVisible().catch(() => false)) {
+      await skip.click();
+    } else {
+      const primary = onboarding
+        .getByRole("button", {
+          name: /^(Continue|Done|Open project|Start building|Get started)$/i,
+        })
+        .last();
+      if (!(await primary.isVisible().catch(() => false))) break;
+      await primary.click();
+    }
+    await page.waitForTimeout(250);
+  }
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+}
+
+/**
+ * Customize → Manage → Feature flags, driven exactly as a user does it: the
+ * sidebar's Settings row opens the Customize overlay (a full-screen modal),
+ * then the rail's "Feature flags" item selects the section.
+ */
+async function openFeatureFlags(page: Page): Promise<Locator> {
+  await page
+    .locator('[data-slot="sidebar"]')
+    .getByRole("button", { name: "Settings" })
+    .click();
+  const panel = page.getByRole("dialog");
+  await expect(panel).toBeVisible();
+  await panel.getByRole("button", { name: "Feature flags" }).click();
+  await expect(
+    panel.getByRole("heading", { name: "Feature flags", exact: true }),
+  ).toBeVisible();
+  return panel;
+}
+
+/** The `<li>` that owns one flag, identified by its switch's accessible name
+ *  (`aria-label={flag.name}`) — never by DOM order, which is registry order and
+ *  changes when a flag is added. */
+function flagRow(panel: Locator, page: Page, name: string): Locator {
+  return panel
+    .getByRole("listitem")
+    .filter({ has: page.getByRole("switch", { name, exact: true }) });
+}
+
+/** The origin line under a flag (`originLabel` in feature-flags-view.tsx). */
+function originLabel(flag: FeatureFlagView): string {
+  if (flag.overridden) return "Overridden for this project";
+  return flag.enabled ? "Default on" : "Default off";
+}
+
+test.describe("19 — Feature flags UI", () => {
+  // Coverage note: the viewer/read-only case (a member WITHOUT
+  // project.customize.write sees the switches disabled) is NOT covered here.
+  // It needs a second auth user, an account invite, and a custom project role
+  // seeded per run — heavier than the rest of this spec put together. The
+  // capability gate itself is unit-covered by the `canWrite` fail-closed logic
+  // in feature-flags-view.tsx and enforced server-side by
+  // `assertProjectCapability(PROJECT_CUSTOMIZE_WRITE)` on
+  // `PATCH /projects/:id/features` (apps/api/src/projects/routes/r6.ts).
+  test("lists every available flag, toggles one through PATCH /features, and persists it", async ({
+    page,
+  }) => {
+    test.skip(!databaseUrl, "KE2E_DATABASE_URL is required");
+    test.setTimeout(180_000);
+
+    const runId = Date.now().toString(36);
+    const email = `e2e-feature-flags-ui-${runId}@example.test`;
+    const user = await createAuthUser(email, authOptions);
+    const session = await signIn(email, authOptions);
+    const env = loadEnv();
+    let projectId: string | null = null;
+    const pageErrors: string[] = [];
+    // The deprecated alias must stay unused by the web app: the canonical route
+    // is `/features` and a silent fallback to `/experimental` would hide a
+    // regression in the SDK's `updateFeatureFlag`.
+    const deprecatedAliasCalls: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    page.on("request", (request) => {
+      if (
+        request.method() === "PATCH" &&
+        request.url().endsWith(`/v1/projects/${projectId}/experimental`)
+      ) {
+        deprecatedAliasCalls.push(request.url());
+      }
+    });
+
+    try {
+      const accounts = await api<AccountSummary[]>(
+        session.access_token,
+        "GET",
+        "/accounts",
+      );
+      const account = accounts.find(
+        (item) =>
+          item.personal_account ||
+          item.is_primary_owner ||
+          item.account_role === "owner",
+      );
+      if (!account) throw new Error("the seeded user owns no account");
+
+      const project = await createDatabaseProject(env, {
+        accountId: account.account_id,
+        userId: user.id,
+        name: `Feature flags UI ${runId}`,
+      });
+      projectId = project.id;
+
+      // The server's catalog IS the expectation for what the section renders.
+      const before = await api<ProjectResponse>(
+        session.access_token,
+        "GET",
+        `/projects/${project.id}`,
+      );
+      const flags = before.experimental_features.filter((f) => f.available);
+      expect(flags.length).toBeGreaterThan(0);
+
+      // Toggle target: prefer `review_center` — it is always available, defaults
+      // OFF, and its toggle effects are pure web/DB (no connector
+      // materialization, no sandbox env fan-out). Fall back to any available
+      // flag that is currently off, so the spec survives a registry change.
+      const target =
+        flags.find((f) => f.key === "review_center" && !f.enabled) ??
+        flags.find((f) => !f.enabled);
+      if (!target) throw new Error("no available feature flag is currently off");
+
+      await installBrowserSessionDirect(
+        page,
+        session,
+        `/projects/${project.id}`,
+        authOptions,
+      );
+      await selectAccountForUi(page, account.account_id);
+      await page.goto(`/projects/${project.id}`, {
+        waitUntil: "domcontentloaded",
+      });
+      await dismissOnboarding(page);
+
+      // (b) every available flag renders a row with a stability badge and an
+      //     origin line.
+      const panel = await openFeatureFlags(page);
+      await expect(panel.getByRole("switch")).toHaveCount(flags.length);
+      for (const flag of flags) {
+        const row = flagRow(panel, page, flag.name);
+        await expect(row).toHaveCount(1);
+        await expect(row.getByText(flag.name, { exact: true })).toBeVisible();
+        const badge = STABILITY_BADGE[flag.stability];
+        if (!badge) throw new Error(`unknown stability: ${flag.stability}`);
+        await expect(row.getByText(badge, { exact: true })).toBeVisible();
+        await expect(
+          row.getByText(originLabel(flag), { exact: true }),
+        ).toBeVisible();
+        await expect(
+          panel.getByRole("switch", { name: flag.name, exact: true }),
+        ).toHaveAttribute("aria-checked", String(flag.enabled));
+      }
+
+      // (c) toggling one flag issues the canonical PATCH and persists.
+      const patchRequest = page.waitForRequest(
+        (request) =>
+          request.method() === "PATCH" &&
+          request.url().endsWith(`/v1/projects/${project.id}/features`),
+      );
+      const patchResponse = page.waitForResponse(
+        (response) =>
+          response.request().method() === "PATCH" &&
+          response.url().endsWith(`/v1/projects/${project.id}/features`),
+      );
+      await panel
+        .getByRole("switch", { name: target.name, exact: true })
+        .click();
+      expect((await patchRequest).postDataJSON()).toEqual({
+        feature: target.key,
+        enabled: true,
+      });
+      expect((await patchResponse).status()).toBe(200);
+      await expect(
+        panel.getByRole("switch", { name: target.name, exact: true }),
+      ).toHaveAttribute("aria-checked", "true");
+
+      // The API is the source of truth for persistence, not the optimistic
+      // cache write — read it back before trusting the reloaded UI.
+      const after = await api<ProjectResponse>(
+        session.access_token,
+        "GET",
+        `/projects/${project.id}`,
+      );
+      const persisted = after.experimental_features.find(
+        (f) => f.key === target.key,
+      );
+      expect(persisted).toMatchObject({ enabled: true, overridden: true });
+
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await dismissOnboarding(page);
+      const reopened = await openFeatureFlags(page);
+      const targetRow = flagRow(reopened, page, target.name);
+      await expect(
+        reopened.getByRole("switch", { name: target.name, exact: true }),
+      ).toHaveAttribute("aria-checked", "true");
+      await expect(
+        targetRow.getByText("Overridden for this project", { exact: true }),
+      ).toBeVisible();
+
+      expect(deprecatedAliasCalls).toEqual([]);
+      expect(pageErrors).toEqual([]);
+    } finally {
+      if (projectId)
+        await deleteDatabaseProject(env, projectId).catch(() => {});
+      await deleteAuthUser(user.id, authOptions).catch(() => {});
+    }
+  });
+});


### PR DESCRIPTION
## Change

Final part of the feature-flag hardening (#6275 → #6277 → #6279).

**CLI speaks `feature_disabled`.** `surfaceApiError` gains a first branch keyed on `code === 'feature_disabled'` (structural read covering both the CLI's own ApiError and SDK-thrown errors; status-agnostic) that prints the server's message verbatim — "X is not enabled for this project. Enable it in Settings → Feature flags." — to stderr, exit 1. The `apps` and `teams` pre-check messages align with the server wording; the teams one moves from stdout to stderr for consistency. Uses the SDK's exported `FEATURE_DISABLED_CODE` (boundary check: 0 violations).

**Drift is structurally impossible.** New `apps/api/src/__tests__/unit-feature-flag-drift.test.ts` pins contract ⇄ SDK ⇄ API registry ⇄ served catalog key sets equal (sorted, deduped, non-empty) and every stability value inside `FeatureFlagStabilitySchema`. Lives in apps/api because it already depends on both packages (SDK devDep precedent: `e2e-connector-faces.test.ts`). Mutation-proven: deleting a key from the SDK list turns 3 tests red.

**Playwright.** New `19-feature-flags-ui.spec.ts` — Customize → Feature flags renders every available flag with stability badge + default/override line; toggling issues `PATCH /v1/projects/:id/features` with the exact body and persists across reload; asserts no fallback to `/experimental`. Also fixed `18-apps-ui.spec.ts`, which still asserted the pre-#6279 "Enable Apps" self-enable button and the `/experimental` PATCH — it now asserts the gate screen (no Enable button), enables via the Feature flags section, and expects the canonical route. Viewer-permission case deliberately skipped (needs a second seeded user; noted in-spec where that gate IS covered).

**Docs are the spec.** `content/docs` updated: `Customize → Settings → Experimental` → `Customize → Feature flags` (5 pages), `sdk/reference.mdx` documents `updateFeatureFlag`, the canonical route, the 403 `feature_disabled` contract with `isFeatureDisabledError`, and marks `updateExperimentalFeature` deprecated; fixed `sdk/apps.mdx` claiming 404 for disabled apps (it is 403 since #6277).

## Verification

- `apps/cli`: tsc clean; `bun test src` **759 pass / 0 fail**; sdk-boundary 0 violations; new blackbox test proves a raw API `403 feature_disabled` surfaces the server message verbatim (never the generic 403 prose).
- `apps/api`: tsc clean; full suite **5964 pass / 0 fail**; drift test 7 pass (re-verified independently).
- Playwright spec typechecked for real (the `tests/` tsconfig excludes `e2e/` — checked with a scoped tsconfig); not executed here (needs `KE2E_DATABASE_URL` + live stack; it follows `18-apps-ui`'s harness exactly).

## Known follow-up (out of scope)

`packages/starter` baked skills still say "Settings → Experimental" in 4 files (and one claims 404) — changing those requires a snapshot rebuild/pin cycle, tracked separately.
