### PR TITLE
fix(sdk): eliminate connector URL regex denial of service

### DIFF
--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -26,7 +26,21 @@ Claimed SDK scope:
 The required `tdd` skill is unavailable in this session. This work uses the
 required RED, GREEN, and REFACTOR sequence directly.
 
-**Status:** IN PROGRESS.
+RED:
+
+- The slash-heavy URL regression took `492.09 ms` and failed its `< 200 ms` bound.
+
+GREEN:
+
+- Focused connector gateway suite: `12 pass`, `0 fail`; regression case `0.19 ms`.
+- `pnpm --filter @kortix/sdk typecheck`: exit `0`.
+- `pnpm --filter @kortix/sdk test`: `1807 pass`, `0 fail`, `7004 expect()` calls.
+- `pnpm --filter @kortix/sdk run smoke:install`: packed-install import and construction passed.
+- No published export name or package version changed.
+
+**Status:** COMPLETE.
+
+**SDK package shippable to production: YES.**
 
 ### 2026-08-08 — session `sandbox-agent-lifecycle` claim
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,22 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-09 — session `release-codeql-connector-url` claim
+
+No **Now** task claimed. This is a narrow production-release security gate fix.
+
+Claimed SDK scope:
+
+- Replace the polynomial trailing-slash regular expression in connector attachment uploads.
+- Preserve the existing URL contract and every published export name.
+- Add a failing regression test before implementation.
+- Run SDK typecheck, the complete SDK suite, and packed-install smoke.
+
+The required `tdd` skill is unavailable in this session. This work uses the
+required RED, GREEN, and REFACTOR sequence directly.
+
+**Status:** IN PROGRESS.
+
 ### 2026-08-08 — session `sandbox-agent-lifecycle` claim
 
 No **Now** task claimed. This is the user-directed sandbox lifecycle and billing

--- a/packages/sdk/src/core/rest/projects-client/connector-gateway.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/connector-gateway.test.ts
@@ -225,6 +225,31 @@ test('attachment upload sends raw bytes through the shared token seam', async ()
   expect(calls[0]?.body).toBe(bytes);
 });
 
+test('attachment upload handles an uncontrolled slash-heavy backend URL in linear time', async () => {
+  responseBody = {
+    attachment_id: 'attachment-one',
+    filename: 'chart.png',
+    content_type: 'image/png',
+    content_disposition: 'attachment',
+    content_id: null,
+    size: 1,
+    expires_at: '2026-08-09T00:00:00.000Z',
+  };
+  configureKortix({
+    backendUrl: `http://test.local/${'/'.repeat(40_000)}x/v1`,
+    getToken: async () => 'agent-token',
+  });
+
+  const startedAt = performance.now();
+  await uploadConnectorAttachment(undefined, new Uint8Array([1]), {
+    filename: 'chart.png',
+    contentType: 'image/png',
+  });
+
+  expect(performance.now() - startedAt).toBeLessThan(200);
+  expect(calls[0]?.url.endsWith('/v1/connectors/attachments')).toBe(true);
+});
+
 test('gateway failures use the SDK ApiError with the server reason', async () => {
   responseStatus = 403;
   responseBody = { ok: false, status: 'denied', reason: 'not_shared' };

--- a/packages/sdk/src/core/rest/projects-client/connectors.ts
+++ b/packages/sdk/src/core/rest/projects-client/connectors.ts
@@ -157,6 +157,12 @@ function connectorResponseMessage(body: unknown, status: number): string {
   return `HTTP ${status}`;
 }
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+  return end === value.length ? value : value.slice(0, end);
+}
+
 export async function uploadConnectorAttachment(
   projectId: string | undefined,
   content: Uint8Array | ArrayBuffer | Blob,
@@ -176,7 +182,7 @@ export async function uploadConnectorAttachment(
     headers['X-Kortix-Attachment-Content-Id'] = encodeURIComponent(input.contentId.trim());
   }
 
-  const backendUrl = platformConfig().backendUrl.replace(/\/+$/, '');
+  const backendUrl = trimTrailingSlashes(platformConfig().backendUrl);
   const endpoint = connectorGatewayPath(projectId, 'attachments');
   const response = await authenticatedFetch(
     `${backendUrl}${endpoint}`,


### PR DESCRIPTION
Unblocks production promotion after CodeQL found a polynomial trailing-slash regex in the `main` -> `staging` comparison.

RED:
- Slash-heavy uncontrolled `backendUrl`: `492.09 ms`, failed the `< 200 ms` regression bound.

GREEN:
- Index-based trim: `0.19 ms`.
- Focused suite: `12 pass`, `0 fail`.
- Full SDK suite: `1807 pass`, `0 fail`.
- SDK typecheck: exit `0`.
- Packed-install smoke: passed.

No SDK export or package version changed.