### PR TITLE
fix(web): select connector defaults for new sessions

### DIFF
--- a/apps/web/src/features/session/scope/session-scope-model.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.test.ts
@@ -1,9 +1,4 @@
-import type {
-  AdminConnector,
-  Connection,
-  ProjectSecret,
-  SessionScope,
-} from '@kortix/sdk';
+import type { AdminConnector, Connection, ProjectSecret, SessionScope } from '@kortix/sdk';
 import { describe, expect, test } from 'bun:test';
 
 import {
@@ -133,7 +128,7 @@ describe('createSessionScopeDraft', () => {
 });
 
 describe('createNewSessionScopeDraft', () => {
-  test('starts with unrestricted secrets (null) and no connections selected', () => {
+  test('starts with unrestricted secrets and every available default connection', () => {
     // `null` is the no-override state — "inherit everything the agent's grant
     // allows", identical to how a server-created session starts. `[]` would be an
     // explicit "inject zero project secrets", which silently denied every
@@ -154,7 +149,10 @@ describe('createNewSessionScopeDraft', () => {
 
     expect(createNewSessionScopeDraft(catalog)).toEqual({
       secrets: null,
-      connector_bindings: {},
+      connector_bindings: {
+        'mail-read': { connection_id: 'connection-mail-default' },
+        issues: { connection_id: 'connection-issues-only' },
+      },
       require_connectors: [],
     });
   });
@@ -328,7 +326,9 @@ describe('buildSessionScopeSelectionCatalog', () => {
 
     expect(ungoverned.secrets.status === 'ready' ? ungoverned.secrets.items : []).toHaveLength(1);
     expect(
-      ungoverned.connector_connections.status === 'ready' ? ungoverned.connector_connections.items : [],
+      ungoverned.connector_connections.status === 'ready'
+        ? ungoverned.connector_connections.items
+        : [],
     ).toHaveLength(1);
     expect(none.secrets).toEqual({ status: 'ready', items: [] });
     expect(none.connector_connections).toEqual({ status: 'ready', items: [] });

--- a/apps/web/src/features/session/scope/session-scope-model.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.ts
@@ -122,7 +122,18 @@ export function createNewSessionScopeDraft(
     draft.secrets = null;
   }
   if (catalog.connector_connections.status === 'ready') {
-    draft.connector_bindings = {};
+    // A browser-created session commits the visible connector selection before
+    // startup. Start from every strategy-compatible default that the agent grant
+    // exposes, not an empty fail-closed map. The create payload remains a complete
+    // explicit selection, so a later user deselection stays effective.
+    draft.connector_bindings = Object.fromEntries(
+      catalog.connector_connections.items.flatMap((connector) => {
+        const connection =
+          connector.connections.find((candidate) => candidate.is_default) ??
+          connector.connections[0];
+        return connection ? [[connector.slug, { connection_id: connection.connection_id }]] : [];
+      }),
+    );
     draft.require_connectors = [];
   }
   return draft;

--- a/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
@@ -69,18 +69,23 @@ describe('createNewSessionScopeInitialization', () => {
     // `null` is the no-override state — the session inherits the agent's grant,
     // exactly like a server-created session. `[]` would be an explicit "inject
     // zero project secrets", which silently denied every browser-created session
-    // its grant. The connector axes stay opt-in (empty defaults) per the scope
-    // opt-in design; only secrets default to unrestricted.
+    // its grant. Connector access starts from every visible default connection.
+    // The create payload remains a complete fail-closed selection, so later
+    // user changes remain effective.
     expect(createNewSessionScopeInitialization(catalog())).toEqual({
       draft: {
         secrets: null,
-        connector_bindings: {},
+        connector_bindings: {
+          mail: { connection_id: 'connection-mail' },
+        },
         require_connectors: [],
       },
       commit: {
         draft: {
           secrets: null,
-          connector_bindings: {},
+          connector_bindings: {
+            mail: { connection_id: 'connection-mail' },
+          },
           require_connectors: [],
         },
         availability: {
@@ -100,12 +105,16 @@ describe('createNewSessionScopeInitialization', () => {
       ),
     ).toEqual({
       draft: {
-        connector_bindings: {},
+        connector_bindings: {
+          mail: { connection_id: 'connection-mail' },
+        },
         require_connectors: [],
       },
       commit: {
         draft: {
-          connector_bindings: {},
+          connector_bindings: {
+            mail: { connection_id: 'connection-mail' },
+          },
           require_connectors: [],
         },
         availability: {

--- a/apps/web/src/features/workspace/project-layout/new-session-create.test.ts
+++ b/apps/web/src/features/workspace/project-layout/new-session-create.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
+import { createNewSessionScopeInitialization } from '@/features/session/scope/session-scope-toolbar';
+
 import { buildNewSessionCreateInput } from './new-session-create';
 
 describe('buildNewSessionCreateInput', () => {
@@ -13,15 +15,17 @@ describe('buildNewSessionCreateInput', () => {
   });
 
   it('carries the sandbox slug through alongside the agent', () => {
-    expect(
-      buildNewSessionCreateInput({ agent: 'builder', sandbox_slug: 'node22' }),
-    ).toEqual({ agent_name: 'builder', sandbox_slug: 'node22' });
+    expect(buildNewSessionCreateInput({ agent: 'builder', sandbox_slug: 'node22' })).toEqual({
+      agent_name: 'builder',
+      sandbox_slug: 'node22',
+    });
   });
 
   it('forces the fixed meta sandbox when the meta agent is selected', () => {
-    expect(
-      buildNewSessionCreateInput({ agent: 'meta', sandbox_slug: 'node22' }),
-    ).toEqual({ agent_name: 'meta', sandbox_slug: 'meta' });
+    expect(buildNewSessionCreateInput({ agent: 'meta', sandbox_slug: 'node22' })).toEqual({
+      agent_name: 'meta',
+      sandbox_slug: 'meta',
+    });
   });
 
   it('binds only the sandbox slug when no agent is picked', () => {
@@ -61,6 +65,73 @@ describe('buildNewSessionCreateInput', () => {
       connector_bindings: {
         mail: { connection_id: 'connection-mail-private' },
       },
+      inherit_unbound: false,
+    });
+  });
+
+  it('includes every available default connector for an untouched new session', () => {
+    const initialization = createNewSessionScopeInitialization({
+      secrets: { status: 'ready', items: [] },
+      connector_connections: {
+        status: 'ready',
+        items: [
+          {
+            slug: 'computer',
+            name: 'Computer',
+            authorization_strategy: 'project',
+            connections: [
+              {
+                connection_id: 'connection-computer-default',
+                label: 'Project computer',
+                is_default: true,
+              },
+            ],
+          },
+          {
+            slug: 'gmail',
+            name: 'Gmail',
+            authorization_strategy: 'user',
+            connections: [
+              {
+                connection_id: 'connection-gmail-default',
+                label: 'Personal Gmail',
+                is_default: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(
+      buildNewSessionCreateInput({
+        agent: 'kortix',
+        scope: initialization.commit,
+      }),
+    ).toEqual({
+      agent_name: 'kortix',
+      connector_bindings: {
+        computer: { connection_id: 'connection-computer-default' },
+        gmail: { connection_id: 'connection-gmail-default' },
+      },
+      inherit_unbound: false,
+    });
+  });
+
+  it('keeps an explicit empty connector selection fail-closed', () => {
+    expect(
+      buildNewSessionCreateInput({
+        agent: 'kortix',
+        scope: {
+          draft: {
+            connector_bindings: {},
+          },
+          availability: { secrets: true, connector_bindings: true },
+        },
+      }),
+    ).toEqual({
+      agent_name: 'kortix',
+      connector_bindings: {},
       inherit_unbound: false,
     });
   });


### PR DESCRIPTION
## Problem

Browser-created sessions submitted `connector_bindings: {}` with `inherit_unbound: false` before the first prompt.

The API correctly persisted that payload as an explicit empty, fail-closed connector scope. Calls then failed with `connector_not_found` even when the project had active default connections.

The affected Dev session `917205c5-c8e1-45d6-9e63-6291dbd491c5` had:

- `connector_bindings_configured = true`
- `connector_bindings_inherit_unbound = false`
- `0` session connector bindings
- `5` project connectors with active default connections
- `14` denied connector audit rows

## Fix

- Initialize each new-session connector binding from its visible default connection.
- Use the first visible connection when a connector has no default.
- Keep the creation payload explicit and fail-closed.
- Preserve explicit user deselection as an empty scope.
- Omit the connector axis when the catalog is unavailable.

## Verification

- `bun test src/features/session/scope/create-scoped-session.test.ts src/features/session/scope/session-scope-control.test.tsx src/features/session/scope/session-scope-model.test.ts src/features/session/scope/session-scope-toolbar.test.ts src/features/session/scope/use-session-scope.test.ts src/features/workspace/project-layout/new-session-create.test.ts`
  - `60 pass`
  - `0 fail`
- `bun test`
  - `4928 pass`
  - `0 fail`
  - `18955 expect() calls`
- `bunx eslint <4 changed files>`
  - exit `0`
- `bunx prettier --check <4 changed files>`
  - exit `0`
- `bunx tsc --noEmit`
  - only the documented `15` Bun `test.each` errors
  - `0` errors in changed files

## Security contract

Explicit empty and partial session scopes remain fail-closed. This change does not enable `inherit_unbound`.
