### PR TITLE
fix(web): keep connector defaults server-resolved

### DIFF
--- a/apps/web/src/features/session/scope/create-scoped-session.test.ts
+++ b/apps/web/src/features/session/scope/create-scoped-session.test.ts
@@ -123,6 +123,33 @@ describe('createScopedSession', () => {
     expect(replacement?.secrets).toBeNull();
   });
 
+  test('does not replace untouched inherited connector defaults', async () => {
+    let replacement: SessionScopeInput | undefined;
+
+    await createScopedSession({
+      create: async () => 'session-inherited',
+      draft: {
+        secrets: null,
+        connector_bindings: {
+          mail: { connection_id: 'stale-client-default' },
+        },
+        connector_bindings_inherited: true,
+        require_connectors: [],
+      },
+      availability: { secrets: true, connector_bindings: true },
+      readScope: async () => scope,
+      replaceScope: async (_id, input) => {
+        replacement = input;
+      },
+      onReady: () => {},
+    });
+
+    expect(replacement).toEqual({
+      secrets: null,
+      require_connectors: [],
+    });
+  });
+
   test('an explicit zero-secrets draft still PUTs [] (deliberate deselect is preserved)', async () => {
     // The flip side of the regression: a user who deliberately deselected every
     // secret MUST still get `[]` — that is a real, explicit "inject zero project

--- a/apps/web/src/features/session/scope/session-scope-control.test.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.test.tsx
@@ -175,18 +175,43 @@ describe('session scope control changes', () => {
       },
     };
 
-    expect(setSessionConnectorConnection(draft, 'calendar', 'connection-calendar-2')).toEqual(
-      {
-        connector_bindings: {
-          calendar: { connection_id: 'connection-calendar-2' },
-          crm: { connection_id: 'connection-crm' },
-        },
+    expect(setSessionConnectorConnection(draft, 'calendar', 'connection-calendar-2')).toEqual({
+      connector_bindings: {
+        calendar: { connection_id: 'connection-calendar-2' },
+        crm: { connection_id: 'connection-crm' },
       },
-    );
+      connector_bindings_inherited: false,
+    });
     expect(setSessionConnectorConnection(draft, 'calendar', null)).toEqual({
       connector_bindings: {
         crm: { connection_id: 'connection-crm' },
       },
+      connector_bindings_inherited: false,
+    });
+  });
+
+  test('changes inherited connector defaults into an explicit replacement', () => {
+    const connector =
+      catalog.connector_connections.status === 'ready'
+        ? catalog.connector_connections.items[0]
+        : undefined;
+    expect(connector).toBeDefined();
+    const draft: SessionScopeDraft = {
+      connector_bindings: {
+        calendar: { connection_id: 'connection-calendar' },
+      },
+      connector_bindings_inherited: true,
+    };
+
+    expect(setSessionConnectorConnection(draft, 'calendar', 'connection-calendar-2')).toEqual({
+      connector_bindings: {
+        calendar: { connection_id: 'connection-calendar-2' },
+      },
+      connector_bindings_inherited: false,
+    });
+    expect(setSessionConnectorEnabled(draft, connector!, false)).toEqual({
+      connector_bindings: {},
+      connector_bindings_inherited: false,
     });
   });
 
@@ -201,6 +226,7 @@ describe('session scope control changes', () => {
       connector_bindings: {
         calendar: { connection_id: 'connection-calendar' },
       },
+      connector_bindings_inherited: false,
     });
     expect(
       setSessionConnectorEnabled(
@@ -212,7 +238,7 @@ describe('session scope control changes', () => {
         connector!,
         false,
       ),
-    ).toEqual({ connector_bindings: {} });
+    ).toEqual({ connector_bindings: {}, connector_bindings_inherited: false });
   });
 
   test('a connector with NO authorization is selectable, as a requirement', () => {
@@ -232,6 +258,7 @@ describe('session scope control changes', () => {
 
     expect(next.require_connectors).toEqual([connector!.slug]);
     expect(next.connector_bindings).toEqual({});
+    expect(next.connector_bindings_inherited).toBeFalse();
   });
 
   test('unchecking it drops the requirement rather than leaving it behind', () => {

--- a/apps/web/src/features/session/scope/session-scope-control.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.tsx
@@ -99,6 +99,7 @@ export function setSessionConnectorConnection(
   return {
     ...draft,
     connector_bindings: connectorBindings,
+    connector_bindings_inherited: false,
   };
 }
 
@@ -140,7 +141,11 @@ export function setSessionConnectorEnabled(
   // agent discover it mid-answer.
   return draft.require_connectors?.includes(connector.slug)
     ? draft
-    : { ...draft, require_connectors: [...(draft.require_connectors ?? []), connector.slug] };
+    : {
+        ...draft,
+        connector_bindings_inherited: false,
+        require_connectors: [...(draft.require_connectors ?? []), connector.slug],
+      };
 }
 
 function secretSummary(draft: SessionScopeDraft): string {
@@ -362,8 +367,8 @@ export function SessionScopeControlContent({
                         // Select to offer — rendering it would show an empty
                         // dropdown that looks broken. Say what will happen instead.
                         <p className="text-muted-foreground pr-2 pb-2 pl-10 text-xs text-pretty">
-                          Nothing is connected to {connector.name} yet. This session will ask you
-                          to connect it before its next reply.
+                          Nothing is connected to {connector.name} yet. This session will ask you to
+                          connect it before its next reply.
                         </p>
                       ) : null}
                       {selected && !requiredUnconnected ? (
@@ -373,11 +378,7 @@ export function SessionScopeControlContent({
                             disabled={controlsDisabled}
                             onValueChange={(connectionId) =>
                               onChange(
-                                setSessionConnectorConnection(
-                                  draft,
-                                  connector.slug,
-                                  connectionId,
-                                ),
+                                setSessionConnectorConnection(draft, connector.slug, connectionId),
                               )
                             }
                           >

--- a/apps/web/src/features/session/scope/session-scope-model.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.test.ts
@@ -153,6 +153,7 @@ describe('createNewSessionScopeDraft', () => {
         'mail-read': { connection_id: 'connection-mail-default' },
         issues: { connection_id: 'connection-issues-only' },
       },
+      connector_bindings_inherited: true,
       require_connectors: [],
     });
   });
@@ -172,6 +173,7 @@ describe('createNewSessionScopeDraft', () => {
     expect(createNewSessionScopeDraft(catalog)).toEqual({
       secrets: null,
       connector_bindings: {},
+      connector_bindings_inherited: true,
       require_connectors: [],
     });
   });
@@ -245,6 +247,22 @@ describe('buildSessionScopeReplacement', () => {
     ).toEqual({
       secrets: null,
       connector_bindings: {},
+      require_connectors: [],
+    });
+  });
+
+  test('keeps untouched connector defaults on server-side inheritance', () => {
+    expect(
+      buildSessionScopeReplacement({
+        secrets: null,
+        connector_bindings: {
+          mail: { connection_id: 'stale-client-default' },
+        },
+        connector_bindings_inherited: true,
+        require_connectors: [],
+      }),
+    ).toEqual({
+      secrets: null,
       require_connectors: [],
     });
   });

--- a/apps/web/src/features/session/scope/session-scope-model.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.ts
@@ -10,6 +10,13 @@ export interface SessionScopeDraft {
   secrets?: string[] | null;
   connector_bindings?: Record<string, { connection_id: string }>;
   /**
+   * The connector bindings are a preview of server-resolved defaults, not a
+   * caller replacement. New sessions keep this marker until the user changes
+   * connector scope. Omitting the replacement lets the server discard stale or
+   * disconnected rows while preserving an explicit user deselection.
+   */
+  connector_bindings_inherited?: boolean;
+  /**
    * Connectors this session REQUIRES but has no connection for yet.
    *
    * A binding is "use THIS connection", so a connector with nothing connected
@@ -122,10 +129,10 @@ export function createNewSessionScopeDraft(
     draft.secrets = null;
   }
   if (catalog.connector_connections.status === 'ready') {
-    // A browser-created session commits the visible connector selection before
-    // startup. Start from every strategy-compatible default that the agent grant
-    // exposes, not an empty fail-closed map. The create payload remains a complete
-    // explicit selection, so a later user deselection stays effective.
+    // Preview every strategy-compatible default that the agent grant exposes.
+    // The inherited marker keeps an untouched session on server-side resolution,
+    // which filters stale or disconnected rows. A user change clears the marker
+    // and turns the draft into a complete fail-closed replacement.
     draft.connector_bindings = Object.fromEntries(
       catalog.connector_connections.items.flatMap((connector) => {
         const connection =
@@ -134,6 +141,7 @@ export function createNewSessionScopeDraft(
         return connection ? [[connector.slug, { connection_id: connection.connection_id }]] : [];
       }),
     );
+    draft.connector_bindings_inherited = true;
     draft.require_connectors = [];
   }
   return draft;
@@ -157,7 +165,11 @@ export function buildSessionScopeReplacement(
   const connectorBindings = Object.hasOwn(draft, 'connector_bindings')
     ? draft.connector_bindings
     : previousScope?.connector_bindings;
-  if (availability.connector_bindings && connectorBindings !== undefined) {
+  if (
+    availability.connector_bindings &&
+    connectorBindings !== undefined &&
+    draft.connector_bindings_inherited !== true
+  ) {
     replacement.connector_bindings = cloneBindings(connectorBindings);
   }
   const required = Object.hasOwn(draft, 'require_connectors')

--- a/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
@@ -69,15 +69,15 @@ describe('createNewSessionScopeInitialization', () => {
     // `null` is the no-override state — the session inherits the agent's grant,
     // exactly like a server-created session. `[]` would be an explicit "inject
     // zero project secrets", which silently denied every browser-created session
-    // its grant. Connector access starts from every visible default connection.
-    // The create payload remains a complete fail-closed selection, so later
-    // user changes remain effective.
+    // its grant. Connector access previews every visible default connection.
+    // Untouched defaults remain server-resolved until the user changes them.
     expect(createNewSessionScopeInitialization(catalog())).toEqual({
       draft: {
         secrets: null,
         connector_bindings: {
           mail: { connection_id: 'connection-mail' },
         },
+        connector_bindings_inherited: true,
         require_connectors: [],
       },
       commit: {
@@ -86,6 +86,7 @@ describe('createNewSessionScopeInitialization', () => {
           connector_bindings: {
             mail: { connection_id: 'connection-mail' },
           },
+          connector_bindings_inherited: true,
           require_connectors: [],
         },
         availability: {
@@ -108,6 +109,7 @@ describe('createNewSessionScopeInitialization', () => {
         connector_bindings: {
           mail: { connection_id: 'connection-mail' },
         },
+        connector_bindings_inherited: true,
         require_connectors: [],
       },
       commit: {
@@ -115,6 +117,7 @@ describe('createNewSessionScopeInitialization', () => {
           connector_bindings: {
             mail: { connection_id: 'connection-mail' },
           },
+          connector_bindings_inherited: true,
           require_connectors: [],
         },
         availability: {

--- a/apps/web/src/features/session/scope/session-scope-toolbar.tsx
+++ b/apps/web/src/features/session/scope/session-scope-toolbar.tsx
@@ -76,6 +76,23 @@ function canonicalDraftFromReplacement(replacement: SessionScopeInput): SessionS
   return draft;
 }
 
+function canonicalCommittedDraft(
+  replacement: SessionScopeInput,
+  source: SessionScopeDraft,
+): SessionScopeDraft {
+  const draft = canonicalDraftFromReplacement(replacement);
+  if (source.connector_bindings_inherited && source.connector_bindings !== undefined) {
+    draft.connector_bindings = Object.fromEntries(
+      Object.entries(source.connector_bindings).map(([alias, binding]) => [
+        alias,
+        { connection_id: binding.connection_id },
+      ]),
+    );
+    draft.connector_bindings_inherited = true;
+  }
+  return draft;
+}
+
 export function createNewSessionScopeInitialization(catalog: SessionScopeSelectionCatalog): {
   draft: SessionScopeDraft;
   commit: SessionScopeCommit | undefined;
@@ -89,7 +106,7 @@ export function createNewSessionScopeInitialization(catalog: SessionScopeSelecti
   return {
     draft,
     commit: {
-      draft: canonicalDraftFromReplacement(replacement),
+      draft: canonicalCommittedDraft(replacement, draft),
       availability,
     },
   };
@@ -109,7 +126,7 @@ export async function commitSessionScopeDraft({
   const replacement = buildSessionScopeReplacement(draft, previousScope, availability);
   if (!sessionId) {
     onCommittedDraft?.({
-      draft: canonicalDraftFromReplacement(replacement),
+      draft: canonicalCommittedDraft(replacement, draft),
       availability,
     });
     return undefined;

--- a/apps/web/src/features/workspace/project-layout/new-session-create.test.ts
+++ b/apps/web/src/features/workspace/project-layout/new-session-create.test.ts
@@ -69,7 +69,7 @@ describe('buildNewSessionCreateInput', () => {
     });
   });
 
-  it('includes every available default connector for an untouched new session', () => {
+  it('leaves untouched connector defaults to server-side resolution', () => {
     const initialization = createNewSessionScopeInitialization({
       secrets: { status: 'ready', items: [] },
       connector_connections: {
@@ -110,11 +110,6 @@ describe('buildNewSessionCreateInput', () => {
       }),
     ).toEqual({
       agent_name: 'kortix',
-      connector_bindings: {
-        computer: { connection_id: 'connection-computer-default' },
-        gmail: { connection_id: 'connection-gmail-default' },
-      },
-      inherit_unbound: false,
     });
   });
 

--- a/apps/web/src/features/workspace/project-layout/new-session-create.ts
+++ b/apps/web/src/features/workspace/project-layout/new-session-create.ts
@@ -35,7 +35,8 @@ export function buildNewSessionCreateInput(
   if (options.agent) input.agent_name = options.agent;
   if (
     options.scope?.availability.connector_bindings &&
-    options.scope.draft.connector_bindings !== undefined
+    options.scope.draft.connector_bindings !== undefined &&
+    options.scope.draft.connector_bindings_inherited !== true
   ) {
     input.connector_bindings = Object.fromEntries(
       Object.entries(options.scope.draft.connector_bindings).map(([alias, binding]) => [


### PR DESCRIPTION
## Problem

Browser-created sessions could commit stale connection rows as an explicit fail-closed connector scope. A row marked `active` without a usable credential then caused the complete scope replacement to fail with `CONNECTOR_CONNECTION_INACTIVE`.

## Fix

- Preview visible default connector bindings in the new-session scope UI.
- Keep untouched defaults on server-side resolution.
- Clear inheritance after any connector selection change.
- Preserve explicit empty and explicit partial connector scopes.
- Add regression coverage for create payloads, scope replacement, toolbar state, and inherited-to-explicit transitions.

## Verification

- `bun test` in `apps/web`: 4,931 pass, 0 fail, 18,961 assertions across 448 files.
- Focused scope tests: 60 pass, 0 fail, 104 assertions.
- ESLint: 0 errors; 2 existing React Compiler warnings in `session-scope-toolbar.tsx`.
- Prettier: all 9 modified files pass.
- `tsc --noEmit`: only the documented 15 Bun test-type errors in 3 unrelated test files.
