### PR TITLE
fix(compliance): add MFA enforcement denial policy for IAM users (DCF-67)

### DIFF
--- a/docs/compliance/IAC-SCANNER-EXCEPTIONS.md
+++ b/docs/compliance/IAC-SCANNER-EXCEPTIONS.md
@@ -9,7 +9,7 @@ Owner: Security and Infrastructure
 Review cadence: quarterly and whenever the affected resource or trust boundary
 changes.
 
-Last reviewed: 2026-08-03
+Last reviewed: 2026-08-09
 
 Evidence run: `8a1f9479-23fd-4031-8411-babcb41aec28`
 
@@ -23,6 +23,18 @@ Evidence run: `8a1f9479-23fd-4031-8411-babcb41aec28`
 | 8011 Public Access Restricted              | High     | `module.ecs-api.aws_lb.this`                                                             |     1 | Intended public edge              | The ALB is the public HTTPS entry point. Security groups restrict origin ingress. TLS, WAF, access logs, and regional alarms protect and monitor the edge.                                                                                                                 |
 | 8028 Resource Tagging                      | Moderate | IAM, KMS, S3, SNS, subnet, instance, security-group, network-ACL, and DynamoDB resources |    24 | Parser false positive             | The Terraform resources use explicit tag maps, provider default tags, or module tag expressions. The scanner reports empty maps because it does not evaluate those expressions. Live inventory remains subject to the account tagging control.                             |
 | 8025 Access Policies Restrict Broad Access | Critical | `security-baseline.aws_iam_role_policy.gha_nacl_audit`                                   |     1 | Explicit Drata exclusion required | The policy grants only `ec2:DescribeRegions` and `ec2:DescribeNetworkAcls`. AWS does not support resource-level permissions for either action. GitHub OIDC trust is scoped to `kortix-ai/suna`. The policy grants no write action.                                         |
+
+## Not-flagged wildcard policies (recorded for review, not accepted findings)
+
+These policies use `Resource: "*"` but are **not** flagged by testId 8025 because
+the scanner evaluates the statement effect and does not raise a broad-access
+finding for `Effect: "Deny"` (a deny-all is the opposite of a broad allow). They
+are recorded here so a future change in scanner behaviour is caught against an
+explicit baseline, and so the wildcard use is justified for SOC 2 reviewers.
+
+| Resource                                                        | Why `Resource: "*"`                                                                                       | Scanner status                                                                                                              |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `security-baseline.aws_iam_policy.mfa_required`                 | DCF-67 MFA enforcement — deny-all-except-MFA-enrollment cannot be resource-scoped; grants no permission. | Not flagged (verified: scan `0c4a4878-9b23-4751-a7d0-84d68c6b0050`, PR #6289; critical count unchanged from main baseline). |
 
 ## Change rule
 

--- a/infra/terraform/security-baseline/iam-groups.tf
+++ b/infra/terraform/security-baseline/iam-groups.tf
@@ -61,6 +61,71 @@ resource "aws_iam_policy" "mfa_self_manage" {
   tags = local.tags
 }
 
+# MFA enforcement — the DENY side of the DCF-67 control. aws_iam_policy
+# .mfa_self_manage above lets a user ENROLL an MFA device; this policy DENIES
+# every action when the caller has NOT authenticated with MFA. Drata DCF-67
+# (testId 88 "MFA on Cloud Infrastructure") checks that MFA is actually
+# ENFORCED, not merely available — without a Deny, a user with no MFA device
+# (e.g. `ino` today) can still act on every permitted resource, which is what
+# the resource-level failure flagged.
+#
+# Standard AWS MFA-enforcement pattern: Effect = Deny, NotAction = the MFA +
+# password + GetSessionToken self-enrollment surface (so a user without MFA
+# can still enroll their first device and mint an MFA'd session), Condition
+# BoolIfExists { aws:MultiFactorAuthPresent = false }. BoolIfExists (not Bool)
+# is deliberate: an unauthenticated STS GetSessionToken call carries no MFA
+# context at all, and BoolIfExists treats a missing key the same as false, so
+# the deny fires for both "MFA present but false" and "MFA context absent".
+#
+# Resource MUST be "*" — this is a deny-all-except-enrollment, so it cannot be
+# scoped to a resource ARN. The Drata Compliance-as-Code scanner (testId 8025
+# "Access Policies Restrict Broad Access") only flags `Resource: "*"` on
+# `Effect: "Allow"` statements (a broad allow); this `Effect: "Deny"` is the
+# opposite and is NOT flagged — verified on PR #6289 (scan
+# 0c4a4878-9b23-4751-a7d0-84d68c6b0050: critical count unchanged from main).
+# The wildcard use is recorded in docs/compliance/IAC-SCANNER-EXCEPTIONS.md
+# under "Not-flagged wildcard policies" so a future scanner change is caught
+# against an explicit baseline. The checkov skip is defensive — checkov runs
+# soft_fail: true in CI so it does not gate, but the comment documents intent.
+resource "aws_iam_policy" "mfa_required" {
+  # checkov:skip=CKV_AWS_111: MFA enforcement requires a deny-all-except-
+  # enrollment statement; Resource must be "*" because the policy denies
+  # across every resource. See docs/compliance/IAC-SCANNER-EXCEPTIONS.md.
+  # checkov:skip=CKV_AWS_290: Deny-only policy; it grants no writes.
+  name = "kortix-mfa-required"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DenyAllWithoutMFA"
+        Effect = "Deny"
+        NotAction = [
+          "iam:CreateVirtualMFADevice",
+          "iam:DeleteVirtualMFADevice",
+          "iam:EnableMFADevice",
+          "iam:DeactivateMFADevice",
+          "iam:ResyncMFADevice",
+          "iam:ListMFADevices",
+          "iam:ListVirtualMFADevices",
+          "iam:ChangePassword",
+          "iam:GetLoginProfile",
+          "iam:UpdateLoginProfile",
+          "iam:CreateLoginProfile",
+          "iam:DeleteLoginProfile",
+          "sts:GetSessionToken"
+        ]
+        Resource = "*"
+        Condition = {
+          BoolIfExists = {
+            "aws:MultiFactorAuthPresent" = false
+          }
+        }
+      }
+    ]
+  })
+  tags = local.tags
+}
+
 # SES send-only — replaces the inline `ses-send-only` policy that used to hang
 # directly off the `kortix-ses-sender` user (Drata DCF-776 flags inline user
 # policies). Grants send on every SES identity in this account (the Kortix
@@ -91,8 +156,17 @@ locals {
     # live-managed `lightsail` group (lightsail:* — kept out of TF so the service
     # wildcard isn't re-flagged by the IaC scanner).
     administrators = {
-      policies = ["arn:aws:iam::aws:policy/AdministratorAccess", "arn:aws:iam::aws:policy/IAMUserChangePassword"]
-      members  = []
+      # AdministratorAccess + IAMUserChangePassword for break-glass admins, plus
+      # mfa_required so every console action is denied unless the caller has
+      # authenticated with MFA (DCF-67). The AdministratorAccess Allow is still
+      # gated by the MFA Deny — IAM evaluates Deny before Allow, so an admin
+      # without MFA can do nothing except enroll an MFA device.
+      policies = [
+        "arn:aws:iam::aws:policy/AdministratorAccess",
+        "arn:aws:iam::aws:policy/IAMUserChangePassword",
+        aws_iam_policy.mfa_required.arn
+      ]
+      members = []
     }
     bedrock-limited = {
       policies = ["arn:aws:iam::aws:policy/AmazonBedrockLimitedAccess"]
@@ -126,8 +200,16 @@ locals {
     # self-scoped policy keeps DCF-776 satisfied with no member named in TF.
     # See aws_iam_policy.mfa_self_manage above.
     mfa-self-manage = {
-      policies = [aws_iam_policy.mfa_self_manage.arn]
-      members  = []
+      # Self-service MFA enrollment (Allow side) + MFA enforcement (Deny side).
+      # mfa_self_manage lets a member enroll their own MFA device + manage their
+      # login profile; mfa_required DENIES every other action until they do
+      # (DCF-67). Together: a user with no MFA can do exactly one thing — enroll
+      # an MFA device — and once enrolled, the deny lifts for MFA'd sessions.
+      policies = [
+        aws_iam_policy.mfa_self_manage.arn,
+        aws_iam_policy.mfa_required.arn
+      ]
+      members = []
     }
     # SES send-only for the `kortix-ses-sender` user (was an inline `ses-send-only`
     # policy — DCF-776 requires group-based permissions only). See aws_iam_policy


### PR DESCRIPTION
## What

Closes the **resource-level** failure of **Drata testId 88 / control DCF-67 "MFA on Cloud Infrastructure"** (failing since 2026-08-04) on IAM user `ino` (`arn:aws:iam::935064898258:user/ino`).

## Root cause

`infra/terraform/security-baseline/iam-groups.tf` already had:
- `aws_iam_policy.mfa_self_manage` — the **Allow** side: lets a user enroll their own MFA device + manage their login profile (self-scoped via `${aws:username}`).
- a `mfa-self-manage` group with `ino` as a member (added in PR #6255 for DCF-776).

But there was **no enforcement** — nothing **DENIED** actions when `aws:MultiFactorAuthPresent` is false. Drata DCF-67 checks that MFA is actually **enforced**, not merely available. So a user with no MFA device (`ino` today) could still act on every permitted resource.

## Fix

Add `aws_iam_policy.mfa_required` — the **Deny** side of MFA enforcement, following the standard AWS MFA-enforcement pattern:

```hcl
Effect    = "Deny"
NotAction = [ MFA + password + GetSessionToken self-enrollment surface ]
Resource  = "*"
Condition = { BoolIfExists = { "aws:MultiFactorAuthPresent" = false } }
```

- `NotAction` (not `Action`) so the deny exempts exactly the self-enrollment surface — a user with no MFA can still enroll their first device.
- `BoolIfExists` (not `Bool`) so the deny fires for both "MFA present but false" **and** "MFA context absent" (an unauthenticated `sts:GetSessionToken` call carries no MFA context).
- Attached to the two **human-user** groups: `administrators` and `mfa-self-manage`. IAM evaluates `Deny` before `Allow`, so an admin without MFA can do exactly one thing — enroll an MFA device — and once enrolled, the deny lifts for MFA'd sessions.
- **Not** attached to service/API groups (`bedrock-limited`, `bedrock-marketplace`, `bedrock-full`, `bedrock-count-tokens`, `cloudwatch-logs-writers`, `ses-senders`) — those are programmatic access (access keys), not console users who need MFA.

## `Resource: "*"` and the IaC scanner — verified baseline parity

This is a deny-all-except-enrollment, so `Resource` must be `*` (it cannot be resource-scoped). I verified against the live Drata Compliance-as-Code scanner rather than assuming:

- Dispatched the `sanitized-finding-details` job on this branch's scan (`0c4a4878-9b23-4751-a7d0-84d68c6b0050`).
- Result: **only ONE testId 8025 critical** — the pre-existing `gha_nacl_audit` (`iam-gha-nacl-audit.tf:54`). The new `mfa_required` policy is **NOT flagged**.
- The scanner evaluates the statement **effect**: testId 8025 ("Refine access policy scope") flags `Resource: "*"` on `Effect: "Allow"` statements (a broad allow); this `Effect: "Deny"` is the opposite and is correctly not flagged.
- Critical count on this branch: `Critical: 1 High: 1 Moderate: 33 Low: 0` — **identical** to the main-branch baseline (push run `31267430249`, scan `2e7717fc…`: `Critical: 1 High: 1 Moderate: 33 Low: 0`). **Zero new findings introduced.**
- The `compliance-as-code-action` check fails on this PR only because of the pre-existing `gha_nacl_audit` baseline critical — same as main, same as PR #6255.
- The wildcard use is recorded in `docs/compliance/IAC-SCANNER-EXCEPTIONS.md` under a new "Not-flagged wildcard policies" section (with the verifying scan id) so a future scanner change is caught against an explicit baseline. `# checkov:skip=CKV_AWS_111`/`CKV_AWS_290` comments are defensive documentation (checkov runs `soft_fail: true` so it does not gate).

## Validation

- `terraform fmt -check` on `infra/terraform/security-baseline/` — clean
- `terraform init -backend=false` + `terraform validate` — `Success! The configuration is valid.` (terraform v1.9.8, aws provider v6.58.0)
- CI (first push): `fmt + validate` pass, `tflint` pass, `checkov` pass, `Checkov (Terraform + K8s)` pass, `gitleaks` / `Gitleaks (full history)` pass, all unit tests + security scans pass. Only `compliance-as-code-action` fails — pre-existing `gha_nacl_audit` baseline (parity with main).

## Out of band (not this PR)

DCF-67 actually closes in Drata once:
1. this policy is `terraform apply`d to the live account, **and**
2. `ino` enrolls an MFA device (the `mfa-self-manage` Allow policy + this Deny policy together let `ino` do nothing until they enroll, then act normally with an MFA'd session).

The enforcement layer is what this PR provides; the user-side enrollment is the remaining human action (already tracked in the compliance-sweep ledger).

## Related

- PR #6255 — moved `ino` + `kortix-ses-sender` inline IAM policies to group-based (DCF-776), added `mfa_self_manage` Allow side. This PR adds the matching Deny side that PR #6255 intentionally left for DCF-67.
