### PR TITLE
refactor(connectors): group assigned computers in profiles

### DIFF
--- a/apps/api/src/__tests__/integration-computer-connector.test.ts
+++ b/apps/api/src/__tests__/integration-computer-connector.test.ts
@@ -1,111 +1,58 @@
 /**
- * Real-DB integration coverage for per-machine computer connectors.
+ * Real-DB integration coverage for grouped Computers connector profiles.
  *
- * The suite proves the full control-plane contract below HTTP: heartbeat-based
- * synthesis, one materialized connector per tunnel, immutable routing,
- * independent policies, lifecycle reconciliation, and legacy aggregate
- * compatibility for durable session bindings.
+ * This suite proves explicit profile creation, one-to-many tunnel assignment,
+ * profile-scoped discovery and routing, independent policies, account-boundary
+ * enforcement, and the connector audit namespace.
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
   accounts,
   auditEvents,
   connectorActions,
-  connectorConnections,
+  connectorPolicies,
   connectors,
-  projectSessionConnectorBindings,
-  projectSessions,
   projects,
-  tunnelAuditLogs,
   tunnelConnections,
   tunnelPermissions,
 } from '@kortix/db';
-import { execFileSync } from 'node:child_process';
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import { synthesizeComputerConnectors } from '../connectors/computer-materialize';
-import { computerConnectorSlug } from '../connectors/computers';
 import { dbConnectorRouterDeps } from '../connectors/db-deps';
-import { reconcileComputerConnectors, syncProjectConnectors } from '../connectors/sync';
 import { db } from '../shared/db';
-import { executeComputerCall, listAccountComputers } from '../tunnel/core/rpc-core';
+import { executeComputerCall } from '../tunnel/core/rpc-core';
 
 let projectId = '';
 let accountId = '';
 let otherAccountId = '';
-let firstTunnelId = '';
-let secondTunnelId = '';
-let neverConnectedTunnelId = '';
+let studioTunnelId = '';
+let travelTunnelId = '';
+let unassignedTunnelId = '';
 let crossAccountTunnelId = '';
-let fixtureRoot = '';
-let previousGitCacheDir: string | undefined;
 
-const firstSlug = () => computerConnectorSlug(firstTunnelId);
-const secondSlug = () => computerConnectorSlug(secondTunnelId);
-
-function git(args: string[], cwd: string): void {
-  execFileSync('git', args, {
-    cwd,
-    stdio: 'pipe',
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-  });
-}
-
-async function sync(): Promise<void> {
-  const result = await syncProjectConnectors(projectId, accountId);
-  expect(result.errors).toEqual([]);
-}
+const GROUP_SLUG = 'team-computers';
+const TRAVEL_SLUG = 'travel-computer';
 
 beforeAll(async () => {
   await db.execute(sql`alter type kortix.connector_provider add value if not exists 'computer'`);
-  await db.execute(sql`
-    alter table kortix.tunnel_connections
-      add column if not exists relay_owner_id varchar(255),
-      add column if not exists relay_owner_instance varchar(255),
-      add column if not exists relay_owner_started_at timestamp with time zone,
-      add column if not exists relay_owner_heartbeat_at timestamp with time zone
-  `);
-
-  fixtureRoot = await mkdtemp(join(tmpdir(), 'kortix-computer-profiles-'));
-  previousGitCacheDir = process.env.KORTIX_GIT_CACHE_DIR;
-  process.env.KORTIX_GIT_CACHE_DIR = join(fixtureRoot, 'git-cache');
-  const repository = join(fixtureRoot, 'repository');
-  mkdirSync(repository, { recursive: true });
-  git(['init', '-b', 'main'], repository);
-  git(['config', 'user.email', 'computer-connector@kortix.test'], repository);
-  git(['config', 'user.name', 'Computer Connector Test'], repository);
-  writeFileSync(
-    join(repository, 'kortix.yaml'),
-    ['kortix_version: 2', 'project:', '  name: Computer Connector Test', ''].join('\n'),
-    'utf8',
-  );
-  git(['add', 'kortix.yaml'], repository);
-  git(['commit', '-m', 'initial'], repository);
-
   projectId = crypto.randomUUID();
   accountId = crypto.randomUUID();
   otherAccountId = crypto.randomUUID();
   await db.insert(accounts).values([
-    { accountId, name: `computer-profiles-${accountId}` },
+    { accountId, name: `computer-groups-${accountId}` },
     {
       accountId: otherAccountId,
-      name: `computer-profiles-other-${otherAccountId}`,
+      name: `computer-groups-other-${otherAccountId}`,
     },
   ]);
   await db.insert(projects).values({
     projectId,
     accountId,
-    name: `computer-profiles-${projectId}`,
-    repoUrl: repository,
-    defaultBranch: 'main',
-    manifestPath: 'kortix.yaml',
+    name: `computer-groups-${projectId}`,
+    repoUrl: 'https://example.invalid/computer-groups.git',
     metadata: {},
   });
-
   const inserted = await db
     .insert(tunnelConnections)
     .values([
@@ -135,9 +82,10 @@ beforeAll(async () => {
       },
       {
         accountId,
-        name: 'Never Connected',
-        capabilities: [],
+        name: 'Unassigned Mac',
+        capabilities: ['filesystem'],
         status: 'offline',
+        lastHeartbeatAt: new Date(),
       },
       {
         accountId: otherAccountId,
@@ -151,25 +99,27 @@ beforeAll(async () => {
       tunnelId: tunnelConnections.tunnelId,
       name: tunnelConnections.name,
     });
-
-  firstTunnelId = inserted.find((row) => row.name === 'Studio Mac')!.tunnelId;
-  secondTunnelId = inserted.find((row) => row.name === 'Travel Mac')!.tunnelId;
-  neverConnectedTunnelId = inserted.find((row) => row.name === 'Never Connected')!.tunnelId;
+  studioTunnelId = inserted.find((row) => row.name === 'Studio Mac')!.tunnelId;
+  travelTunnelId = inserted.find((row) => row.name === 'Travel Mac')!.tunnelId;
+  unassignedTunnelId = inserted.find((row) => row.name === 'Unassigned Mac')!.tunnelId;
   crossAccountTunnelId = inserted.find((row) => row.name === 'Other Account Mac')!.tunnelId;
+
+  const created = await dbConnectorRouterDeps.createConnector!(projectId, accountId, {
+    slug: GROUP_SLUG,
+    name: 'Team computers',
+    provider: 'computer',
+    tunnel_ids: [studioTunnelId, travelTunnelId],
+    create_only: true,
+  });
+  expect(created.ok).toBe(true);
 });
 
 afterAll(async () => {
-  if (projectId) {
-    await db
-      .delete(projectSessionConnectorBindings)
-      .where(eq(projectSessionConnectorBindings.projectId, projectId));
-    await db.delete(projectSessions).where(eq(projectSessions.projectId, projectId));
-    await db.delete(projects).where(eq(projects.projectId, projectId));
-  }
+  if (projectId) await db.delete(projects).where(eq(projects.projectId, projectId));
   const tunnelIds = [
-    firstTunnelId,
-    secondTunnelId,
-    neverConnectedTunnelId,
+    studioTunnelId,
+    travelTunnelId,
+    unassignedTunnelId,
     crossAccountTunnelId,
   ].filter(Boolean);
   if (tunnelIds.length) {
@@ -177,304 +127,190 @@ afterAll(async () => {
   }
   const accountIds = [accountId, otherAccountId].filter(Boolean);
   if (accountIds.length) await db.delete(accounts).where(inArray(accounts.accountId, accountIds));
-  if (previousGitCacheDir === undefined) delete process.env.KORTIX_GIT_CACHE_DIR;
-  else process.env.KORTIX_GIT_CACHE_DIR = previousGitCacheDir;
-  if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true });
 });
 
-describe('per-machine computer connectors — real DB', () => {
-  test('synthesizes one stable connector profile per heartbeat-bearing tunnel', async () => {
-    const specs = await synthesizeComputerConnectors(projectId, []);
-    expect(specs).toHaveLength(2);
-    expect(specs.map((spec) => spec.slug).sort()).toEqual([firstSlug(), secondSlug()].sort());
-    expect(specs.map((spec) => spec.name).sort()).toEqual(['Studio Mac', 'Travel Mac']);
-    expect(specs.map((spec) => spec.tunnelId).sort()).toEqual(
-      [firstTunnelId, secondTunnelId].sort(),
-    );
-    expect(specs.every((spec) => spec.provider === 'computer' && spec.auth.type === 'none')).toBe(
-      true,
-    );
-    expect(specs.some((spec) => spec.tunnelId === neverConnectedTunnelId)).toBe(false);
-  });
-
-  test('materializes two regular connectors with independent bound configs and catalogs', async () => {
-    await sync();
-    const rows = await db
+describe('grouped Computers connector profiles — real DB', () => {
+  test('stores one regular connector with two assigned machine ids and the full catalog', async () => {
+    const [row] = await db
       .select()
       .from(connectors)
-      .where(and(eq(connectors.projectId, projectId), eq(connectors.providerType, 'computer')));
-    expect(rows).toHaveLength(2);
+      .where(and(eq(connectors.projectId, projectId), eq(connectors.slug, GROUP_SLUG)));
+    expect(row?.providerType).toBe('computer');
+    expect((row?.config as Record<string, unknown>).tunnel_ids).toEqual([
+      studioTunnelId,
+      travelTunnelId,
+    ]);
+    expect((row?.config as Record<string, unknown>).computer_profile).toBe(true);
 
-    for (const row of rows) {
-      const config = row.config as Record<string, unknown>;
-      const expectedTunnelId = row.slug === firstSlug() ? firstTunnelId : secondTunnelId;
-      expect(config.tunnel_id).toBe(expectedTunnelId);
+    const actions = await db
+      .select()
+      .from(connectorActions)
+      .where(eq(connectorActions.connectorId, row!.connectorId));
+    expect(actions.some((action) => action.path === 'list_computers')).toBe(true);
+    expect(actions.some((action) => action.path === 'fs.read')).toBe(true);
+    const read = actions.find((action) => action.path === 'fs.read')!;
+    expect(
+      (read.inputSchema as { properties?: Record<string, unknown> }).properties?.computer,
+    ).toBeDefined();
+  });
 
-      const actions = await db
-        .select()
-        .from(connectorActions)
-        .where(eq(connectorActions.connectorId, row.connectorId));
-      expect(actions.length).toBeGreaterThan(5);
-      expect(actions.some((action) => action.path === 'list_computers')).toBe(false);
-      expect(actions.some((action) => action.path === 'fs.read')).toBe(true);
-      for (const action of actions) {
-        expect((action.binding as { kind: string }).kind).toBe('tunnel');
-        const schema = action.inputSchema as {
-          properties?: Record<string, unknown>;
-        } | null;
-        expect(schema?.properties?.computer).toBeUndefined();
-      }
+  test('sync synthesis reads the stored profile instead of generating one connector per tunnel', async () => {
+    const specs = await synthesizeComputerConnectors(projectId, []);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]?.slug).toBe(GROUP_SLUG);
+    expect(specs[0]?.tunnelIds).toEqual([studioTunnelId, travelTunnelId]);
+  });
+
+  test('config returns the selected machines through the normal connector API model', async () => {
+    const config = await dbConnectorRouterDeps.getConnectorConfig!(projectId, GROUP_SLUG);
+    expect(config?.provider).toBe('computer');
+    expect(config?.tunnelIds).toEqual([studioTunnelId, travelTunnelId]);
+  });
+
+  test('list_computers returns only machines assigned to the profile', async () => {
+    const result = await executeComputerCall({
+      accountId,
+      projectId,
+      allowedTunnelIds: [studioTunnelId, travelTunnelId],
+      selector: null,
+      method: 'list_computers',
+      args: {},
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const ids = (result.data as { computers: Array<{ id: string }> }).computers.map(
+      (computer) => computer.id,
+    );
+    expect(ids.sort()).toEqual([studioTunnelId, travelTunnelId].sort());
+    expect(ids).not.toContain(unassignedTunnelId);
+  });
+
+  test('assigned selection reaches tunnel authorization while unassigned selection fails first', async () => {
+    const assigned = await executeComputerCall({
+      accountId,
+      projectId,
+      allowedTunnelIds: [studioTunnelId, travelTunnelId],
+      selector: studioTunnelId,
+      method: 'fs.read',
+      args: { path: '/etc/hosts' },
+    });
+    expect(assigned.ok).toBe(false);
+    if (!assigned.ok) expect(assigned.kind).toBe('permission_required');
+
+    const unassigned = await executeComputerCall({
+      accountId,
+      projectId,
+      allowedTunnelIds: [studioTunnelId, travelTunnelId],
+      selector: unassignedTunnelId,
+      method: 'fs.read',
+      args: { path: '/etc/hosts' },
+    });
+    expect(unassigned.ok).toBe(false);
+    if (!unassigned.ok) {
+      expect(unassigned.kind).toBe('no_machine');
+      expect(unassigned.message).toContain('not assigned');
     }
   });
 
-  test('settings resolve each synthetic profile as a regular connector', async () => {
-    const policies = await dbConnectorRouterDeps.getConnectorPolicies!(projectId, firstSlug());
-    expect(policies).not.toBeNull();
-    expect(Array.isArray(policies!.policies)).toBe(true);
-
-    const config = await dbConnectorRouterDeps.getConnectorConfig!(projectId, secondSlug());
-    expect(config).not.toBeNull();
-    expect(config!.provider).toBe('computer');
-    expect(config!.slug).toBe(secondSlug());
+  test('a cross-account id in a forged allowlist still fails closed', async () => {
+    const result = await executeComputerCall({
+      accountId,
+      projectId,
+      allowedTunnelIds: [crossAccountTunnelId],
+      selector: crossAccountTunnelId,
+      method: 'fs.read',
+      args: { path: '/x' },
+    });
+    expect(result).toEqual({
+      ok: false,
+      kind: 'no_machine',
+      message: 'No machines are assigned to this Computers connector profile.',
+    });
   });
 
-  test('stores policies and sensitive state independently per machine profile', async () => {
+  test('multiple profiles can overlap and keep independent policies', async () => {
+    const created = await dbConnectorRouterDeps.createConnector!(projectId, accountId, {
+      slug: TRAVEL_SLUG,
+      name: 'Travel computer',
+      provider: 'computer',
+      tunnel_ids: [travelTunnelId],
+      create_only: true,
+    });
+    expect(created.ok).toBe(true);
     const policyWrite = await dbConnectorRouterDeps.setConnectorPolicies!(
       projectId,
       accountId,
-      firstSlug(),
+      TRAVEL_SLUG,
       [{ match: 'fs.read', action: 'block' }],
     );
     expect(policyWrite.ok).toBe(true);
-    const sensitiveWrite = await dbConnectorRouterDeps.setSensitive!(
+
+    const groupPolicies = await dbConnectorRouterDeps.getConnectorPolicies!(projectId, GROUP_SLUG);
+    const travelPolicies = await dbConnectorRouterDeps.getConnectorPolicies!(
       projectId,
-      accountId,
-      firstSlug(),
-      true,
+      TRAVEL_SLUG,
     );
-    expect(sensitiveWrite.ok).toBe(true);
-
-    await sync();
-
-    const firstPolicies = await dbConnectorRouterDeps.getConnectorPolicies!(projectId, firstSlug());
-    const secondPolicies = await dbConnectorRouterDeps.getConnectorPolicies!(
-      projectId,
-      secondSlug(),
-    );
-    expect(firstPolicies?.policies).toEqual([{ match: 'fs.read', action: 'block' }]);
-    expect(secondPolicies?.policies).toEqual([]);
-
-    const listed = await dbConnectorRouterDeps.listConnectors(projectId);
-    expect(listed.find((connector) => connector.slug === firstSlug())?.sensitive).toBe(true);
-    expect(listed.find((connector) => connector.slug === secondSlug())?.sensitive).toBe(false);
+    expect(groupPolicies?.policies).toEqual([]);
+    expect(travelPolicies?.policies).toEqual([{ match: 'fs.read', action: 'block' }]);
   });
 
-  test('routes a call only through the connector-bound tunnel', async () => {
-    const first = await executeComputerCall({
-      accountId,
-      projectId,
-      tunnelId: firstTunnelId,
-      method: 'fs.read',
-      args: { path: '/etc/hosts' },
+  test('updating a profile replaces its allowlist without changing its policy rows', async () => {
+    const updated = await dbConnectorRouterDeps.createConnector!(projectId, accountId, {
+      slug: TRAVEL_SLUG,
+      name: 'Travel and studio',
+      provider: 'computer',
+      tunnel_ids: [travelTunnelId, studioTunnelId],
     });
-    expect(first.ok).toBe(false);
-    if (!first.ok) expect(first.kind).toBe('permission_required');
-
-    const second = await executeComputerCall({
-      accountId,
-      projectId,
-      tunnelId: secondTunnelId,
-      method: 'fs.read',
-      args: { path: '/etc/hosts' },
-    });
-    expect(second.ok).toBe(false);
-    if (!second.ok) expect(second.kind).toBe('permission_required');
+    expect(updated.ok).toBe(true);
+    const config = await dbConnectorRouterDeps.getConnectorConfig!(projectId, TRAVEL_SLUG);
+    expect(config?.tunnelIds).toEqual([travelTunnelId, studioTunnelId]);
+    const [policy] = await db
+      .select()
+      .from(connectorPolicies)
+      .innerJoin(connectors, eq(connectors.connectorId, connectorPolicies.connectorId))
+      .where(and(eq(connectors.projectId, projectId), eq(connectors.slug, TRAVEL_SLUG)));
+    expect(policy?.connector_policies.action).toBe('block');
   });
 
-  test('fails closed for a cross-account or deleted bound tunnel id', async () => {
-    const crossAccount = await executeComputerCall({
-      accountId,
-      tunnelId: crossAccountTunnelId,
-      method: 'fs.read',
-      args: { path: '/x' },
-    });
-    expect(crossAccount).toEqual({
-      ok: false,
-      kind: 'no_machine',
-      message: 'This computer is no longer connected',
-    });
-
-    const [temporary] = await db
-      .insert(tunnelConnections)
-      .values({
-        accountId,
-        name: 'Deleted Mac',
-        capabilities: ['filesystem'],
-        status: 'offline',
-        lastHeartbeatAt: new Date(),
-      })
-      .returning({ tunnelId: tunnelConnections.tunnelId });
-    await db.delete(tunnelConnections).where(eq(tunnelConnections.tunnelId, temporary!.tunnelId));
-    const deleted = await executeComputerCall({
-      accountId,
-      tunnelId: temporary!.tunnelId,
-      method: 'fs.read',
-      args: { path: '/x' },
-    });
-    expect(deleted.ok).toBe(false);
-    if (!deleted.ok) expect(deleted.kind).toBe('no_machine');
-  });
-
-  test('keeps permissions and audit isolated to the selected profile', async () => {
+  test('connector calls remain authoritative connector audit events', async () => {
     await db.insert(tunnelPermissions).values({
-      tunnelId: firstTunnelId,
+      tunnelId: studioTunnelId,
       accountId,
       capability: 'filesystem',
       scope: {},
       status: 'active',
     });
-    const first = await executeComputerCall({
+    await executeComputerCall({
       accountId,
       projectId,
-      tunnelId: firstTunnelId,
+      allowedTunnelIds: [studioTunnelId],
+      selector: studioTunnelId,
       method: 'fs.read',
       args: { path: '/etc/hosts' },
     });
-    expect(first.ok).toBe(false);
-    if (!first.ok) expect(first.kind).toBe('error');
-
-    const second = await executeComputerCall({
-      accountId,
-      projectId,
-      tunnelId: secondTunnelId,
-      method: 'fs.read',
-      args: { path: '/etc/hosts' },
-    });
-    expect(second.ok).toBe(false);
-    if (!second.ok) expect(second.kind).toBe('permission_required');
-
-    const audits = await db
+    const rows = await db
       .select({
-        tunnelId: tunnelAuditLogs.tunnelId,
-        phase: tunnelAuditLogs.phase,
-      })
-      .from(tunnelAuditLogs)
-      .where(eq(tunnelAuditLogs.operation, 'fs.read'));
-    expect(audits.some((row) => row.tunnelId === firstTunnelId && row.phase === 'failed')).toBe(
-      true,
-    );
-    expect(audits.some((row) => row.tunnelId === secondTunnelId)).toBe(false);
-
-    const centralized = await db
-      .select({
-        authoritativeSource: auditEvents.authoritativeSource,
         action: auditEvents.action,
-        resourceId: auditEvents.resourceId,
+        authoritativeSource: auditEvents.authoritativeSource,
       })
       .from(auditEvents)
       .where(
         and(
           eq(auditEvents.projectId, projectId),
-          eq(auditEvents.resourceId, firstTunnelId),
+          eq(auditEvents.resourceId, studioTunnelId),
           eq(auditEvents.action, 'connector.computer.fs.read'),
         ),
       );
-    expect(centralized.some((row) => row.authoritativeSource === 'connector')).toBe(true);
+    expect(rows.some((row) => row.authoritativeSource === 'connector')).toBe(true);
   });
 
-  test('rename updates profile names and delete removes only that profile', async () => {
-    await db
-      .update(tunnelConnections)
-      .set({ name: 'Renamed Studio Mac' })
-      .where(eq(tunnelConnections.tunnelId, firstTunnelId));
-    await reconcileComputerConnectors(accountId);
-
-    const [renamed] = await db
-      .select({ name: connectors.name })
-      .from(connectors)
-      .where(and(eq(connectors.projectId, projectId), eq(connectors.slug, firstSlug())));
-    expect(renamed?.name).toBe('Renamed Studio Mac');
-
-    await db.delete(tunnelConnections).where(eq(tunnelConnections.tunnelId, secondTunnelId));
-    await reconcileComputerConnectors(accountId);
+  test('deleting one profile leaves the other profile intact', async () => {
+    const deleted = await dbConnectorRouterDeps.deleteConnector!(projectId, TRAVEL_SLUG);
+    expect(deleted.ok).toBe(true);
     const remaining = await db
       .select({ slug: connectors.slug })
       .from(connectors)
       .where(and(eq(connectors.projectId, projectId), eq(connectors.providerType, 'computer')));
-    expect(remaining.map((row) => row.slug)).toEqual([firstSlug()]);
-    secondTunnelId = '';
-  });
-
-  test('retains the aggregate selector only for legacy durable bindings', async () => {
-    const sessionId = `legacy-computer-${crypto.randomUUID()}`;
-    const [aggregate] = await db
-      .insert(connectors)
-      .values({
-        accountId,
-        projectId,
-        slug: 'computer',
-        name: 'Computers',
-        providerType: 'computer',
-        enabled: false,
-        status: 'disabled',
-        config: {},
-      })
-      .returning({ connectorId: connectors.connectorId });
-    const [connection] = await db
-      .insert(connectorConnections)
-      .values({
-        accountId,
-        projectId,
-        connectorId: aggregate!.connectorId,
-        label: 'Computers',
-        isDefault: true,
-      })
-      .returning({ connectionId: connectorConnections.connectionId });
-    await db.insert(projectSessions).values({
-      sessionId,
-      accountId,
-      projectId,
-      branchName: `session/${sessionId}`,
-      connectorBindingsConfigured: true,
-    });
-    await db.insert(projectSessionConnectorBindings).values({
-      sessionId,
-      accountId,
-      projectId,
-      connectorAlias: 'computer',
-      connectorId: aggregate!.connectorId,
-      connectionId: connection!.connectionId,
-    });
-
-    await sync();
-
-    const [preserved] = await db
-      .select({ enabled: connectors.enabled, status: connectors.status })
-      .from(connectors)
-      .where(eq(connectors.connectorId, aggregate!.connectorId));
-    expect(preserved).toEqual({ enabled: true, status: 'active' });
-
-    const adminConnectors = await dbConnectorRouterDeps.listConnectors(projectId);
-    expect(adminConnectors.some((connector) => connector.slug === 'computer')).toBe(false);
-
-    const listed = await executeComputerCall({
-      accountId,
-      tunnelId: null,
-      method: 'list_computers',
-      args: {},
-    });
-    expect(listed.ok).toBe(true);
-    const machines = await listAccountComputers(accountId);
-    expect(machines.some((machine) => machine.id === firstTunnelId)).toBe(true);
-
-    const selected = await executeComputerCall({
-      accountId,
-      tunnelId: null,
-      selector: firstTunnelId,
-      method: 'fs.read',
-      args: { path: '/etc/hosts' },
-    });
-    expect(selected.ok).toBe(false);
-    if (!selected.ok) expect(selected.kind).toBe('error');
+    expect(remaining.map((row) => row.slug)).toEqual([GROUP_SLUG]);
   });
 });

--- a/apps/api/src/__tests__/unit-connector-computers.test.ts
+++ b/apps/api/src/__tests__/unit-connector-computers.test.ts
@@ -1,12 +1,12 @@
 /**
  * Computer connectors (the Agent Computer Tunnel as a first-class Connector
  * connector).
- *   • catalog — the tunnel RPC method set normalizes to `tunnel` bindings, with
- *     no machine selector because each connector is bound to one tunnel.
+ *   • catalog — the tunnel RPC method set normalizes to `tunnel` bindings. Each
+ *     relayed action accepts a selector from the profile's machine allowlist.
  *   • parse   — `provider="computer"` cannot be declared in kortix.yaml (it is
  *     synth-only; connecting a machine materializes it).
  *   • gateway — a computer call routes through executeComputerCall (NOT an HTTP
- *     call); the connector's bound tunnel id is used; a permission_required
+ *     call); the connector's machine allowlist is used; a permission_required
  *     outcome becomes pending_approval; missing-machine / relay errors become errors.
  */
 import { describe, expect, test } from 'bun:test';
@@ -36,18 +36,20 @@ describe('computerCatalog()', () => {
     }
   });
 
-  test('does not expose account-wide machine discovery', () => {
-    expect(byPath.has('list_computers')).toBe(false);
+  test('exposes profile-scoped machine discovery', () => {
+    const action = byPath.get('list_computers');
+    expect(action).toBeDefined();
+    expect(action?.inputSchema).toBeNull();
   });
 
-  test('fs.read → tunnel fs.read, read, path required, no machine selector', () => {
+  test('fs.read → tunnel fs.read, read, path required, optional machine selector', () => {
     const a = byPath.get('fs.read')!;
     expect(a.binding).toEqual({ kind: 'tunnel', method: 'fs.read' });
     expect(a.risk).toBe('read');
     const props = Object.keys((a.inputSchema as any).properties);
-    expect(props).not.toContain('computer');
+    expect(props).toContain('computer');
     expect(props).toContain('path');
-    expect((a.inputSchema as any).required).toEqual(['path']); // selector NOT required
+    expect((a.inputSchema as any).required).toEqual(['path']);
   });
 
   test('fs.delete is destructive; shell.exec is write', () => {
@@ -60,11 +62,11 @@ describe('computerCatalog()', () => {
     expect(a.binding).toEqual({ kind: 'tunnel', method: 'desktop.cua.call' });
     const props = Object.keys((a.inputSchema as any).properties);
     expect(props).toContain('tool');
-    expect(props).not.toContain('computer');
+    expect(props).toContain('computer');
   });
 
   test('label', () => {
-    expect(computerLabel()).toBe('Computer');
+    expect(computerLabel()).toBe('Computers');
   });
 });
 
@@ -76,14 +78,14 @@ function parse(body: string) {
 }
 
 describe('connectors: provider="computer"', () => {
-  test('cannot be declared in kortix.yaml (synth-only)', () => {
+  test('cannot be declared in kortix.yaml because profiles are API-managed', () => {
     const { specs, errors } = parse(`
 connectors:
   - slug: computer
     provider: computer
 `);
     expect(specs).toEqual([]);
-    expect(errors[0]!.error).toMatch(/managed automatically|cannot be declared/);
+    expect(errors[0]!.error).toMatch(/managed through the connector API|cannot be declared/);
   });
 });
 
@@ -91,9 +93,9 @@ connectors:
 
 const COMPUTER: GatewayConnector = {
   connectorId: 'conn-computer',
-  slug: 'computer-11111111-1111-4111-8111-111111111111',
+  slug: 'studio-computers',
   provider: 'computer',
-  tunnelId: '11111111-1111-4111-8111-111111111111',
+  tunnelIds: ['11111111-1111-4111-8111-111111111111', '22222222-2222-4222-8222-222222222222'],
   baseUrl: null,
   auth: { type: 'none', in: 'header', name: null, prefix: null },
   hasAuth: false, // no credential — the relay is the credential
@@ -102,9 +104,13 @@ const COMPUTER: GatewayConnector = {
 };
 
 const FS_READ: GatewayAction = {
-  path: 'computer-11111111-1111-4111-8111-111111111111.fs.read',
+  path: 'studio-computers.fs.read',
   relPath: 'fs.read',
-  inputSchema: { type: 'object', properties: { path: {} }, required: ['path'] },
+  inputSchema: {
+    type: 'object',
+    properties: { computer: {}, path: {} },
+    required: ['path'],
+  },
   risk: 'read',
   binding: { kind: 'tunnel', method: 'fs.read' },
 };
@@ -143,9 +149,15 @@ function input(args: Record<string, unknown>, actionPath = 'fs.read'): CallInput
 }
 
 describe('handleCall — computer (tunnel)', () => {
-  test('relays through the connector-bound tunnel without a selector argument', async () => {
+  test('passes the profile allowlist and strips the selector from relay arguments', async () => {
     const { deps, calls } = makeDeps({ ok: true, data: { content: 'hello' } });
-    const res = await handleCall(deps, input({ path: '/tmp/x' }));
+    const res = await handleCall(
+      deps,
+      input({
+        computer: '22222222-2222-4222-8222-222222222222',
+        path: '/tmp/x',
+      }),
+    );
     expect(res.status).toBe('ok');
     if (res.status === 'ok') expect(res.data).toEqual({ content: 'hello' });
     expect(calls).toHaveLength(1);
@@ -154,10 +166,29 @@ describe('handleCall — computer (tunnel)', () => {
       actorUserId: 'u1',
       projectId: 'proj-1',
       sessionId: 'sess-1',
-      tunnelId: '11111111-1111-4111-8111-111111111111',
+      allowedTunnelIds: [
+        '11111111-1111-4111-8111-111111111111',
+        '22222222-2222-4222-8222-222222222222',
+      ],
+      selector: '22222222-2222-4222-8222-222222222222',
       method: 'fs.read',
       args: { path: '/tmp/x' },
     });
+  });
+
+  test('list_computers uses the same profile allowlist', async () => {
+    const action: GatewayAction = {
+      path: 'studio-computers.list_computers',
+      relPath: 'list_computers',
+      inputSchema: null,
+      risk: 'read',
+      binding: { kind: 'tunnel', method: 'list_computers' },
+    };
+    const { deps, calls } = makeDeps({ ok: true, data: { computers: [] } }, action);
+    const res = await handleCall(deps, input({}, 'list_computers'));
+    expect(res.status).toBe('ok');
+    expect(calls[0]?.allowedTunnelIds).toEqual(COMPUTER.tunnelIds!);
+    expect(calls[0]?.selector).toBeNull();
   });
 
   test('permission_required → pending_approval, requestId surfaced', async () => {
@@ -183,13 +214,13 @@ describe('handleCall — computer (tunnel)', () => {
     if (res.status === 'error') expect(res.reason).toMatch(/online/);
   });
 
-  test('a connector without a bound tunnel fails closed', async () => {
+  test('a connector without assigned machines fails closed', async () => {
     const { deps } = makeDeps({ ok: true, data: {} });
-    deps.loadConnectorBySlug = async () => ({ ...COMPUTER, tunnelId: null });
+    deps.loadConnectorBySlug = async () => ({ ...COMPUTER, tunnelIds: [] });
     const res = await handleCall(deps, input({ path: '/tmp/x' }));
     expect(res).toEqual({
       status: 'error',
-      reason: 'computer connector has no bound machine',
+      reason: 'computer connector has no assigned machines',
     });
   });
 });

--- a/apps/api/src/connectors/computer-materialize.ts
+++ b/apps/api/src/connectors/computer-materialize.ts
@@ -1,58 +1,42 @@
 /**
- * Auto-materialize the `computer` connector from connected machines.
+ * Materialize platform-managed Computers connector profiles.
  *
- * Exactly like the Slack `channel` connector, `computer` is a REGULAR connector
- * with no `[[connectors]]` entry and no experimental opt-in — connecting a
- * machine over the Agent Computer Tunnel IS the registration. When a project's
- * account has connected machines, we synthesize one ConnectorSpec PER MACHINE
- * so the materializer treats each profile like any other connector (DB rows,
- * the fixed action catalog, policies, and the connector surface). The connector
- * config binds its immutable tunnel id. There is no credential: the live WS
- * relay is the credential, and per-machine auth/scope is the tunnel permission
- * layer.
+ * Pairing a tunnel only adds it to the account fleet. It does not grant a
+ * project access. A Computers connector profile is created explicitly through
+ * the connector API and stores one or more selected tunnel ids in its DB config.
+ * The normal connector row owns grants, policies, audit, and session exposure.
  *
- * NOT gated by the per-project `agent_tunnel` feature flag: a machine can
- * only exist when the platform tunnel service is on (the tunnel routes are
- * `config.TUNNEL_ENABLED`-gated), so machine-presence already implies platform
- * support. The `agent_tunnel` flag now only gates the dedicated Computers
- * management UI (device-auth / per-machine permissions), not the connector.
- * See docs/specs/computer-connector.md.
+ * Profiles never live in kortix.yaml because tunnel ids are account control-
+ * plane identities, not repository configuration. This synthesizer reads the
+ * stored profiles back into the normal materializer during connector sync.
  *
- * "Connected machine" means the tunnel has completed a real WS handshake at
- * least once (`last_heartbeat_at IS NOT NULL`) — NOT merely that a
- * `tunnel_connections` row exists. Approving a device-auth request creates the
- * row up front with `status: 'offline'` and no heartbeat, and the CLI then
- * dials in and flips it live within seconds; requiring a heartbeat costs that
- * flow nothing. What it excludes is a pairing that was approved (or seeded —
- * e.g. by a test) and then never actually connected: without this check that
- * row sits forever and silently materializes an "active" `computer` connector
- * across every project in the account, looking exactly like a real,
- * intentionally-added connector even though nothing is or ever was connected.
- * Once a machine has connected at least once, its connector correctly stays
- * materialized through later offline periods (closed laptop, etc.) — only a
- * connection that never came online even once is excluded.
+ * Compatibility: PR #6287 briefly created one `computer-<uuid>` row per
+ * machine. The next sync folds those generated rows into one `computer`
+ * profile. Explicit profiles carry `computer_profile=true` and are preserved.
  */
-import { and, eq, isNotNull } from 'drizzle-orm';
-import { projects, tunnelConnections } from '@kortix/db';
-import { db } from '../shared/db';
-import { computerConnectorSlug } from './computers';
+import { connectors, projects, tunnelConnections } from '@kortix/db';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
+
 import type { ConnectorSpec } from '../projects/connectors';
 import { MANIFEST_FILENAME } from '../projects/triggers';
+import { db } from '../shared/db';
+import { COMPUTER_SLUG, computerLabel } from './computers';
 
-function computerSpec(tunnel: {
-  tunnelId: string;
+export function computerProfileSpec(input: {
+  slug: string;
   name: string;
+  tunnelIds: string[];
+  sensitive?: boolean;
 }): ConnectorSpec {
-  const slug = computerConnectorSlug(tunnel.tunnelId);
   return {
-    slug,
-    path: `${MANIFEST_FILENAME}#connectors.${slug} (auto: tunnel)`,
-    name: tunnel.name || `Computer ${tunnel.tunnelId.slice(0, 8)}`,
+    slug: input.slug,
+    path: `${MANIFEST_FILENAME}#connectors.${input.slug} (platform: computers)`,
+    name: input.name,
     enabled: true,
     provider: 'computer',
     credentialMode: 'shared',
     authorizationStrategy: 'project',
-    sensitive: false,
+    sensitive: input.sensitive === true,
     app: null,
     account: null,
     url: null,
@@ -61,7 +45,7 @@ function computerSpec(tunnel: {
     baseUrl: null,
     platform: null,
     spec: null,
-    tunnelId: tunnel.tunnelId,
+    tunnelIds: [...new Set(input.tunnelIds)],
     auth: {
       type: 'none',
       in: 'header',
@@ -69,17 +53,31 @@ function computerSpec(tunnel: {
       prefix: null,
       secret: null,
     },
-    // Platform-called connector — the request isn't built by executeCall's
-    // HTTP builders, so a static header table would be inert. Always empty.
     headers: {},
     policies: [],
   };
 }
 
+function storedTunnelIds(configValue: unknown): string[] | null {
+  const config = (configValue ?? {}) as Record<string, unknown>;
+  if (Array.isArray(config.tunnel_ids)) {
+    return [
+      ...new Set(config.tunnel_ids.filter((value): value is string => typeof value === 'string')),
+    ];
+  }
+  if (typeof config.tunnel_id === 'string') return [config.tunnel_id];
+  return null;
+}
+
+function isExplicitProfile(configValue: unknown): boolean {
+  const config = (configValue ?? {}) as Record<string, unknown>;
+  return config.computer_profile === true && Array.isArray(config.tunnel_ids);
+}
+
 /**
- * One synthetic ConnectorSpec per machine that completed a handshake. Specs are
- * never written to git. A declared slug wins defensively, although the UUID-
- * based platform slug makes a collision impractical.
+ * Return every explicit DB-backed Computers profile for normal materialization.
+ * No tunnel row means no implicit connector. Project access begins only after a
+ * connector profile is created.
  */
 export async function synthesizeComputerConnectors(
   projectId: string,
@@ -92,18 +90,52 @@ export async function synthesizeComputerConnectors(
     .limit(1);
   if (!proj) return [];
 
-  const tunnels = await db
+  const rows = await db
     .select({
-      tunnelId: tunnelConnections.tunnelId,
-      name: tunnelConnections.name,
+      slug: connectors.slug,
+      name: connectors.name,
+      config: connectors.config,
     })
+    .from(connectors)
+    .where(and(eq(connectors.projectId, projectId), eq(connectors.providerType, 'computer')));
+  if (rows.length === 0) return [];
+
+  const declaredSlugs = new Set(declared.map((spec) => spec.slug));
+  const explicit = rows
+    .filter((row) => isExplicitProfile(row.config))
+    .map((row) =>
+      computerProfileSpec({
+        slug: row.slug,
+        name: row.name,
+        tunnelIds: storedTunnelIds(row.config) ?? [],
+        sensitive: (row.config as { sensitive?: unknown } | null)?.sensitive === true,
+      }),
+    )
+    .filter((spec) => !declaredSlugs.has(spec.slug));
+  if (explicit.length > 0) return explicit;
+
+  // Fold the short-lived per-machine model into one regular profile. Only
+  // account-owned machines that completed a handshake can enter the migration.
+  const legacyIds = [...new Set(rows.flatMap((row) => storedTunnelIds(row.config) ?? []))];
+  const accountTunnels = await db
+    .select({ tunnelId: tunnelConnections.tunnelId })
     .from(tunnelConnections)
     .where(
       and(
         eq(tunnelConnections.accountId, proj.accountId),
         isNotNull(tunnelConnections.lastHeartbeatAt),
+        ...(legacyIds.length > 0 ? [inArray(tunnelConnections.tunnelId, legacyIds)] : []),
       ),
     );
-  const declaredSlugs = new Set(declared.map((spec) => spec.slug));
-  return tunnels.map(computerSpec).filter((spec) => !declaredSlugs.has(spec.slug));
+  const tunnelIds = accountTunnels.map((row) => row.tunnelId);
+  if (tunnelIds.length === 0 || declaredSlugs.has(COMPUTER_SLUG)) return [];
+  const aggregate = rows.find((row) => row.slug === COMPUTER_SLUG);
+  return [
+    computerProfileSpec({
+      slug: COMPUTER_SLUG,
+      name: aggregate?.name || computerLabel(),
+      tunnelIds,
+      sensitive: (aggregate?.config as { sensitive?: unknown } | null)?.sensitive === true,
+    }),
+  ];
 }

--- a/apps/api/src/connectors/computers.ts
+++ b/apps/api/src/connectors/computers.ts
@@ -6,9 +6,9 @@
  * live WS relay IS the credential, and per-machine auth/scope is enforced by the
  * tunnel permission layer at call time.
  *
- * Each connected machine is one connector profile bound to one immutable
- * tunnel id. Tool schemas therefore describe only the operation inputs. The
- * connector identity selects the machine. The gateway routes `tunnel` bindings
+ * One connector profile contains one or more selected machines. Tool schemas
+ * include a machine selector, and the gateway restricts it to the profile's
+ * server-side allowlist. The gateway routes `tunnel` bindings
  * through the shared tunnel RPC core
  * (`tunnel/core/rpc-core.ts`), NOT executeCall. See
  * docs/specs/computer-connector.md.
@@ -17,13 +17,13 @@ import type { ActionBinding, NormalizedAction, Risk } from './types';
 
 /** Human label for the computer connector (UI default name). */
 export function computerLabel(): string {
-  return 'Computer';
+  return 'Computers';
 }
 
 /** Legacy aggregate slug. Kept for existing session bindings during migration. */
 export const COMPUTER_SLUG = 'computer';
 
-/** Stable project connector slug for one tunnel. The full UUID avoids collisions. */
+/** Legacy per-machine slug. Kept only for compatibility and migration. */
 export function computerConnectorSlug(tunnelId: string): string {
   return `computer-${tunnelId.toLowerCase()}`;
 }
@@ -40,7 +40,17 @@ interface ComputerActionDef {
   /** JSON-schema properties for the operation itself. */
   properties: Record<string, { type: string; description: string }>;
   required: string[];
+  /** Meta actions run server-side and do not accept a machine selector. */
+  meta?: boolean;
 }
+
+const COMPUTER_SELECTOR = {
+  computer: {
+    type: 'string',
+    description:
+      'Target machine name or id from list_computers. Optional when exactly one assigned machine is online.',
+  },
+} as const;
 
 /**
  * The computer catalog. `fs.*` + `shell.exec` are fully typed; the high-value
@@ -49,6 +59,17 @@ interface ComputerActionDef {
  * the long tail is reachable without hand-maintaining every schema.
  */
 const COMPUTER_ACTIONS: ComputerActionDef[] = [
+  {
+    path: 'list_computers',
+    method: 'list_computers',
+    name: 'List computers',
+    description:
+      'List the machines assigned to this connector profile — id, name, online status, declared capabilities, and platform. Use this to choose a `computer` for the other actions.',
+    risk: 'read',
+    properties: {},
+    required: [],
+    meta: true,
+  },
   // ── filesystem ──────────────────────────────────────────────────────────
   {
     path: 'fs.read',
@@ -277,7 +298,7 @@ const COMPUTER_ACTIONS: ComputerActionDef[] = [
 
 function toAction(def: ComputerActionDef): NormalizedAction {
   const binding: ActionBinding = { kind: 'tunnel', method: def.method };
-  const properties = def.properties;
+  const properties = def.meta ? def.properties : { ...COMPUTER_SELECTOR, ...def.properties };
   const inputSchema = Object.keys(properties).length
     ? {
         type: 'object',
@@ -296,7 +317,7 @@ function toAction(def: ComputerActionDef): NormalizedAction {
   };
 }
 
-/** The fixed catalog for every machine-bound computer connector. */
+/** The fixed catalog for every Computers connector profile. */
 export function computerCatalog(): NormalizedAction[] {
   return COMPUTER_ACTIONS.map(toAction);
 }

--- a/apps/api/src/connectors/db-deps.ts
+++ b/apps/api/src/connectors/db-deps.ts
@@ -7,10 +7,12 @@ import {
   connectorProjectPolicies,
   connectorProjectSettings,
   projectSecrets,
+  projectSessionConnectorBindings,
   projectSessions,
   projects,
+  tunnelConnections,
 } from '@kortix/db';
-import { sanitizeConnectorHeaders } from '@kortix/manifest-schema';
+import { sanitizeConnectorHeaders, SLUG_RE } from '@kortix/manifest-schema';
 import { and, desc, eq, gt, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 /**
  * Production wiring for the connector router — DB-backed ConnectorRouterDeps +
@@ -57,7 +59,8 @@ import { validateAccountToken } from '../repositories/account-tokens';
 import { db } from '../shared/db';
 import { executeComputerCall } from '../tunnel/core/rpc-core';
 import { connectorAttachmentStore } from './attachments';
-import { COMPUTER_SLUG } from './computers';
+import { computerProfileSpec } from './computer-materialize';
+import { COMPUTER_SLUG, computerLabel } from './computers';
 import { hideSupersededSlack } from './channel-rules';
 import { buildAdminConnectorViews } from './connector-list';
 import { validateConnectorSecretBinding } from './connector-secret-binding';
@@ -117,6 +120,7 @@ import { resolveShareSubject } from './share';
 import { getConnectorCatalogDetail, listConnectorCatalog } from './connector-catalog';
 import {
   discoverDraftConnectorAuth,
+  materializeComputerConnectorProfile,
   setMaterializedComputerConnectorPolicies,
   syncProjectConnectors,
 } from './sync';
@@ -137,17 +141,16 @@ function isUuid(value: string): boolean {
   return UUID_REGEX.test(value);
 }
 
-function hideLegacyComputerAggregate<
-  T extends { providerType: string; slug: string; config: unknown },
->(rows: T[]): T[] {
-  const hasPerMachineProfile = rows.some(
-    (row) =>
-      row.providerType === 'computer' &&
-      typeof (row.config as Record<string, unknown> | null)?.tunnel_id === 'string',
-  );
-  return hasPerMachineProfile
-    ? rows.filter((row) => !(row.providerType === 'computer' && row.slug === COMPUTER_SLUG))
-    : rows;
+function computerTunnelIds(configValue: unknown, slug: string): string[] | null {
+  const config = (configValue ?? {}) as Record<string, unknown>;
+  if (Array.isArray(config.tunnel_ids)) {
+    return [
+      ...new Set(config.tunnel_ids.filter((value): value is string => typeof value === 'string')),
+    ];
+  }
+  if (typeof config.tunnel_id === 'string') return [config.tunnel_id];
+  // Compatibility for durable sessions bound to the original aggregate row.
+  return slug === COMPUTER_SLUG ? null : [];
 }
 
 /** How long an unconsumed human approve stays claimable by a fresh call. Long
@@ -396,10 +399,8 @@ function toGatewayConnector(
     slug: row.slug,
     provider: row.providerType,
     platform: channelPlatform(row.config),
-    tunnelId:
-      row.providerType === 'computer' && typeof config.tunnel_id === 'string'
-        ? config.tunnel_id
-        : null,
+    tunnelIds:
+      row.providerType === 'computer' ? computerTunnelIds(row.config, row.slug) : undefined,
     baseUrl: baseUrlOf(row),
     auth,
     headers: headersOf(row),
@@ -562,15 +563,14 @@ export function makeDbGatewayDeps(principal: ConnectorPrincipal): GatewayDeps {
       runPipedreamAction(projectId, connectorSlug, app, actionKey, args, accountId, userId),
     executePipedreamProxy: ({ projectId, connectorSlug, args, accountId, userId }) =>
       runPipedreamProxy(projectId, connectorSlug, args, accountId, userId),
-    // Computer connectors relay through the shared tunnel RPC core (permission
-    // check → relay → audit). The machine is resolved from the `computer`
-    // immutable tunnel id, scoped to this account.
+    // Computers connectors relay through the shared tunnel RPC core (profile
+    // allowlist → account ownership → permission check → relay → audit).
     executeComputerCall: ({
       accountId,
       projectId,
       sessionId,
       actorUserId,
-      tunnelId,
+      allowedTunnelIds,
       selector,
       method,
       args,
@@ -580,7 +580,7 @@ export function makeDbGatewayDeps(principal: ConnectorPrincipal): GatewayDeps {
         projectId,
         sessionId,
         actorUserId,
-        tunnelId,
+        allowedTunnelIds,
         selector,
         method,
         args,
@@ -944,13 +944,11 @@ async function resolveProjectPrincipal(
 
 /** The catalog a principal can actually use (agent grant + credential present + not blocked). */
 async function listCatalog(p: ConnectorPrincipal): Promise<CatalogConnector[]> {
-  const conns = hideLegacyComputerAggregate(
-    hideSupersededSlack(
-      await db
-        .select()
-        .from(connectors)
-        .where(and(eq(connectors.projectId, p.projectId), eq(connectors.enabled, true))),
-    ),
+  const conns = hideSupersededSlack(
+    await db
+      .select()
+      .from(connectors)
+      .where(and(eq(connectors.projectId, p.projectId), eq(connectors.enabled, true))),
   );
 
   // Project-scoped layer is the same for every connector in this list — load once.
@@ -1090,10 +1088,8 @@ async function resolveSecretReader(
 
 /** Admin list — sharing + credential mode + whether the shared credential is set. */
 async function listConnectors(projectId: string): Promise<AdminConnectorView[]> {
-  const conns = hideLegacyComputerAggregate(
-    hideSupersededSlack(
-      await db.select().from(connectors).where(eq(connectors.projectId, projectId)),
-    ),
+  const conns = hideSupersededSlack(
+    await db.select().from(connectors).where(eq(connectors.projectId, projectId)),
   );
   if (conns.length === 0) return [];
 
@@ -1378,6 +1374,8 @@ async function getConnectorConfig(
     endpoint: cfg.endpoint ?? null,
     baseUrl: baseUrlOf(row),
     spec: cfg.spec ?? null,
+    tunnelIds:
+      row.providerType === 'computer' ? (computerTunnelIds(row.config, row.slug) ?? []) : undefined,
     auth: {
       type: auth.type,
       in: auth.in,
@@ -1422,10 +1420,18 @@ async function setComputerConnectorPolicies(
   const allowedActions = new Set<PolicyAction>(['always_run', 'require_approval', 'block']);
   for (const [index, policy] of policies.entries()) {
     if (typeof policy?.match !== 'string' || !policy.match.trim()) {
-      return { ok: false, error: `rule #${index + 1}: \`match\` is required`, status: 400 };
+      return {
+        ok: false,
+        error: `rule #${index + 1}: \`match\` is required`,
+        status: 400,
+      };
     }
     if (!isValidMatcher(policy.match.trim())) {
-      return { ok: false, error: `rule #${index + 1}: invalid regex pattern`, status: 400 };
+      return {
+        ok: false,
+        error: `rule #${index + 1}: invalid regex pattern`,
+        status: 400,
+      };
     }
     if (!allowedActions.has(policy.action as PolicyAction)) {
       return {
@@ -1464,6 +1470,143 @@ async function setComputerConnectorSensitive(
   return { ok: true };
 }
 
+const MAX_COMPUTERS_PER_PROFILE = 100;
+
+async function upsertComputerConnectorProfile(
+  projectId: string,
+  accountId: string,
+  draft: Record<string, unknown>,
+): Promise<ConnectorCrudResult | null> {
+  if (draft.provider !== 'computer') return null;
+  const slug = typeof draft.slug === 'string' ? draft.slug.trim() : '';
+  if (!SLUG_RE.test(slug)) {
+    return { ok: false, error: 'invalid connector slug', status: 400 };
+  }
+  const rawTunnelIds = draft.tunnel_ids;
+  if (!Array.isArray(rawTunnelIds)) {
+    return { ok: false, error: 'tunnel_ids must be an array', status: 400 };
+  }
+  const tunnelIds = [
+    ...new Set(rawTunnelIds.filter((value): value is string => typeof value === 'string')),
+  ];
+  if (tunnelIds.length === 0) {
+    return { ok: false, error: 'select at least one computer', status: 400 };
+  }
+  if (tunnelIds.length !== rawTunnelIds.length || tunnelIds.some((value) => !isUuid(value))) {
+    return {
+      ok: false,
+      error: 'tunnel_ids must contain unique UUIDs',
+      status: 400,
+    };
+  }
+  if (tunnelIds.length > MAX_COMPUTERS_PER_PROFILE) {
+    return {
+      ok: false,
+      error: `a Computers profile can contain at most ${MAX_COMPUTERS_PER_PROFILE} machines`,
+      status: 400,
+    };
+  }
+  const owned = await db
+    .select({ tunnelId: tunnelConnections.tunnelId })
+    .from(tunnelConnections)
+    .where(
+      and(
+        eq(tunnelConnections.accountId, accountId),
+        inArray(tunnelConnections.tunnelId, tunnelIds),
+        isNotNull(tunnelConnections.lastHeartbeatAt),
+      ),
+    );
+  if (owned.length !== tunnelIds.length) {
+    return {
+      ok: false,
+      error: 'every selected computer must belong to this account and have connected before',
+      status: 400,
+    };
+  }
+
+  const [existing] = await db
+    .select({
+      connectorId: connectors.connectorId,
+      providerType: connectors.providerType,
+      name: connectors.name,
+      config: connectors.config,
+    })
+    .from(connectors)
+    .where(and(eq(connectors.projectId, projectId), eq(connectors.slug, slug)))
+    .limit(1);
+  if (existing && existing.providerType !== 'computer') {
+    return {
+      ok: false,
+      error: `Connector slug "${slug}" already exists`,
+      status: 409,
+    };
+  }
+  if (existing && draft.create_only === true) {
+    return {
+      ok: false,
+      error: `Connector slug "${slug}" already exists`,
+      status: 409,
+    };
+  }
+  const requestedName = typeof draft.name === 'string' ? draft.name.trim() : '';
+  const name = requestedName || existing?.name || computerLabel();
+  if (name.length > 255) return { ok: false, error: 'name is too long (max 255)', status: 400 };
+  await materializeComputerConnectorProfile({
+    projectId,
+    accountId,
+    existingId: existing?.connectorId ?? null,
+    spec: computerProfileSpec({
+      slug,
+      name,
+      tunnelIds,
+      sensitive: (existing?.config as { sensitive?: unknown } | null)?.sensitive === true,
+    }),
+  });
+  return { ok: true, sync: { synced: 1, errors: [] } };
+}
+
+async function deleteComputerConnectorProfile(
+  projectId: string,
+  slug: string,
+): Promise<ConnectorCrudResult | null> {
+  const [row] = await db
+    .select({
+      connectorId: connectors.connectorId,
+      providerType: connectors.providerType,
+    })
+    .from(connectors)
+    .where(and(eq(connectors.projectId, projectId), eq(connectors.slug, slug)))
+    .limit(1);
+  if (!row || row.providerType !== 'computer') return null;
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(projectSessionConnectorBindings)
+      .where(eq(projectSessionConnectorBindings.connectorId, row.connectorId));
+    await tx.delete(connectors).where(eq(connectors.connectorId, row.connectorId));
+  });
+  return { ok: true };
+}
+
+async function setComputerConnectorName(
+  projectId: string,
+  accountId: string,
+  slug: string,
+  name: string,
+): Promise<ConnectorCrudResult | null> {
+  const connectorId = await computerConnectorId(projectId, accountId, slug);
+  if (!connectorId) return null;
+  const trimmed = name.trim();
+  if (!trimmed) return { ok: false, error: 'name is required', status: 400 };
+  if (trimmed.length > 255) {
+    return { ok: false, error: 'name is too long (max 255)', status: 400 };
+  }
+  await db
+    .update(connectors)
+    .set({ name: trimmed, updatedAt: new Date() })
+    .where(eq(connectors.connectorId, connectorId));
+  return { ok: true };
+}
+
 export const dbConnectorRouterDeps: ConnectorRouterDeps = {
   attachmentStore: connectorAttachmentStore,
   resolvePrincipal,
@@ -1481,9 +1624,12 @@ export const dbConnectorRouterDeps: ConnectorRouterDeps = {
     invalidateProjectMirror(projectId);
     return syncProjectConnectors(projectId, accountId, { force: true });
   },
-  createConnector: (projectId, accountId, draft) =>
+  createConnector: async (projectId, accountId, draft) =>
+    (await upsertComputerConnectorProfile(projectId, accountId, draft)) ??
     upsertConnectorInManifest(projectId, accountId, draft as unknown as ConnectorDraft),
-  deleteConnector: (projectId, slug) => deleteConnectorFromManifest(projectId, slug),
+  deleteConnector: async (projectId, slug) =>
+    (await deleteComputerConnectorProfile(projectId, slug)) ??
+    deleteConnectorFromManifest(projectId, slug),
   setConnectorCredential: (projectId, slug, input) =>
     setConnectorCredentialShared(projectId, slug, input),
   setConnectorSecretBinding,
@@ -1515,7 +1661,8 @@ export const dbConnectorRouterDeps: ConnectorRouterDeps = {
   setSensitive: async (projectId, accountId, slug, sensitive) =>
     (await setComputerConnectorSensitive(projectId, accountId, slug, sensitive)) ??
     setConnectorSensitiveInManifest(projectId, accountId, slug, sensitive),
-  setConnectorName: (projectId, accountId, slug, name) =>
+  setConnectorName: async (projectId, accountId, slug, name) =>
+    (await setComputerConnectorName(projectId, accountId, slug, name)) ??
     setConnectorNameInManifest(projectId, accountId, slug, name),
   getConnectorPolicies,
   getConnectorConfig,

--- a/apps/api/src/connectors/gateway.ts
+++ b/apps/api/src/connectors/gateway.ts
@@ -46,17 +46,10 @@ export interface GatewayConnector {
   connectionMetadata?: Record<string, unknown>;
   slug: string;
   provider:
-    | 'pipedream'
-    | 'mcp'
-    | 'openapi'
-    | 'postman'
-    | 'graphql'
-    | 'http'
-    | 'channel'
-    | 'computer';
+    'pipedream' | 'mcp' | 'openapi' | 'postman' | 'graphql' | 'http' | 'channel' | 'computer';
   platform?: string | null;
-  /** Machine identity for a per-computer connector. Null only on legacy aggregate rows. */
-  tunnelId?: string | null;
+  /** Server-side machine allowlist for a Computers connector profile. */
+  tunnelIds?: string[] | null;
   /** server / base_url / endpoint / url, per provider (null for some). */
   baseUrl: string | null;
   auth: ConnectorAuth;
@@ -199,17 +192,16 @@ export interface GatewayDeps {
   }): Promise<ExecResult>;
   /**
    * Computer (Agent Computer Tunnel) execution — required for `computer`
-   * connectors. Verifies the bound `tunnelId` belongs to `accountId`, then
-   * relays `method` through the tunnel permission/relay/audit core.
+   * connectors. Verifies the selected machine belongs to both `accountId` and
+   * the connector profile allowlist, then relays through the tunnel core.
    */
   executeComputerCall?(input: {
     accountId: string;
     projectId: string;
     sessionId: string | null;
     actorUserId: string;
-    tunnelId: string | null;
-    /** Compatibility only for the retired aggregate `computer` connector. */
-    selector?: string | null;
+    allowedTunnelIds: string[] | null;
+    selector: string | null;
     method: string;
     args: Record<string, unknown>;
   }): Promise<ComputerCallOutcome>;
@@ -633,34 +625,31 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
   }
 
   try {
-    // Computer (Agent Computer Tunnel): relay through the shared tunnel RPC core
-    // instead of an HTTP call. The connector itself binds the machine.
+    // Computers (Agent Computer Tunnel): relay through the shared tunnel RPC
+    // core. The connector profile owns the machine allowlist.
     if (connector.provider === 'computer') {
       if (action.binding.kind !== 'tunnel') {
         throw new Error(`computer connector has unexpected binding kind "${action.binding.kind}"`);
       }
       if (!deps.executeComputerCall) throw new Error('computer runner not wired');
-      if (!connector.tunnelId && connector.slug !== 'computer') {
+      if (connector.tunnelIds && connector.tunnelIds.length === 0) {
         return {
           status: 'error',
-          reason: 'computer connector has no bound machine',
+          reason: 'computer connector has no assigned machines',
         };
       }
-      const legacySelector =
-        connector.slug === 'computer' && typeof executionArgs.computer === 'string'
-          ? executionArgs.computer.trim() || null
-          : null;
-      const callArgs =
-        connector.slug === 'computer'
-          ? Object.fromEntries(Object.entries(executionArgs).filter(([key]) => key !== 'computer'))
-          : executionArgs;
+      const selector =
+        typeof executionArgs.computer === 'string' ? executionArgs.computer.trim() || null : null;
+      const callArgs = Object.fromEntries(
+        Object.entries(executionArgs).filter(([key]) => key !== 'computer'),
+      );
       const outcome = await deps.executeComputerCall({
         accountId: input.accountId,
         projectId: input.projectId,
         sessionId: input.sessionId ?? null,
         actorUserId: input.subject.userId,
-        tunnelId: connector.tunnelId ?? null,
-        ...(connector.slug === 'computer' ? { selector: legacySelector } : {}),
+        allowedTunnelIds: connector.tunnelIds ?? null,
+        selector,
         method: action.binding.method,
         args: callArgs,
       });

--- a/apps/api/src/connectors/manifest-crud.ts
+++ b/apps/api/src/connectors/manifest-crud.ts
@@ -509,6 +509,8 @@ export interface ConnectorConfigView {
   endpoint: string | null;
   baseUrl: string | null;
   spec: string | null;
+  /** Platform-managed Computers profiles only. Manifest connectors omit it. */
+  tunnelIds?: string[];
   auth: {
     type:
       | 'none'

--- a/apps/api/src/connectors/materialize.ts
+++ b/apps/api/src/connectors/materialize.ts
@@ -64,7 +64,8 @@ export function connectorConfig(
         // through the shared tunnel RPC core, not executeCall. Carry explicit
         // `none` auth so authOf() resolves hasAuth=false.
         return {
-          tunnel_id: spec.tunnelId ?? null,
+          tunnel_ids: spec.tunnelIds ?? (spec.tunnelId ? [spec.tunnelId] : []),
+          computer_profile: true,
           auth: { type: 'none', in: 'header', name: null, prefix: null },
         };
       default:

--- a/apps/api/src/connectors/router.ts
+++ b/apps/api/src/connectors/router.ts
@@ -341,6 +341,7 @@ export interface ConnectorRouterDeps {
     endpoint: string | null;
     baseUrl: string | null;
     spec: string | null;
+    tunnelIds?: string[];
     auth: {
       type:
         | 'none'

--- a/apps/api/src/connectors/sync.ts
+++ b/apps/api/src/connectors/sync.ts
@@ -729,6 +729,25 @@ async function upsertConnector(
   }
 }
 
+/** Materialize one platform-managed Computers profile without writing kortix.yaml. */
+export async function materializeComputerConnectorProfile(input: {
+  projectId: string;
+  accountId: string;
+  spec: ConnectorSpec;
+  existingId: string | null;
+}): Promise<void> {
+  if (input.spec.provider !== 'computer') {
+    throw new Error('computer profile materialization requires provider="computer"');
+  }
+  await upsertConnector(
+    input.projectId,
+    input.accountId,
+    input.spec,
+    { actions: computerCatalog(), server: null },
+    input.existingId,
+  );
+}
+
 /** Fetch + normalize a connector's catalog. Best-effort; never throws. */
 export async function resolveCatalog(
   project: GitBackedProject,

--- a/apps/api/src/feature-flags/registry.ts
+++ b/apps/api/src/feature-flags/registry.ts
@@ -68,14 +68,13 @@ export interface FeatureFlagDef {
 /**
  * The registry. Order here is the order shown in Settings → Feature flags.
  *
- * agent_tunnel → connector: connected machines flow through the Connector as a
- * regular `computer` connector (one connector fronts all the account's machines;
- * `connectors`/`discover`/`describe`/`call`, one audit + policy path). That
- * connector is NOT gated by this flag — it auto-materializes whenever the
- * account has a connected machine, exactly like the Slack channel connector
- * (see connectors/computer-materialize.ts). This flag only gates the dedicated
- * tunnel surface (Customize → Computers, the device-auth / permissions UI).
- * See docs/specs/computer-connector.md.
+ * agent_tunnel → connector: paired machines are selectable accounts inside a
+ * regular `computer` connector profile. A profile can contain one or more
+ * machines and uses the normal connector grant, policy, call, and audit paths.
+ * Pairing does not auto-create project access. This flag gates the dedicated
+ * fleet surface (Customize → Computers, device auth, and tunnel permissions).
+ * Connector profiles remain API-managed because tunnel ids do not belong in
+ * repository configuration. See docs/specs/computer-connector.md.
  */
 const FLAGS: readonly FeatureFlagDef[] = [
   {

--- a/apps/api/src/projects/connectors.ts
+++ b/apps/api/src/projects/connectors.ts
@@ -83,9 +83,10 @@ export type ConnectorAuthorizationStrategy = (typeof CONNECTOR_AUTHORIZATION_STR
  *
  *  - `kortix_slack` → channel only (the Slack channel materializes under it; see
  *    connector/channels.ts SLACK_CHANNEL_CONNECTOR_SLUG).
- *  - `computer`     → computer only (retired aggregate compatibility slug).
- * Per-machine connector slugs are synthetic `computer-<tunnel-uuid>` values
- * and never pass through manifest parsing.
+ *  - `computer`     → computer only (default Computers profile slug).
+ * Additional Computers profile slugs are created through the connector API.
+ * They never pass through manifest parsing because machine ids are account
+ * control-plane identities, not repository configuration.
  * See KORTIX-206 + docs/specs/computer-connector.md. The pairs themselves are
  * canonically defined in `@kortix/manifest-schema` (imported above) — this
  * `export` just preserves this module's existing public surface, since
@@ -195,8 +196,10 @@ export interface ConnectorSpec {
   baseUrl: string | null;
   /** channel: chat platform (slack | …) — selects the fixed action catalog + API base. */
   platform: ChannelPlatform | null;
-  /** computer: immutable account-scoped tunnel bound to this synthetic profile. */
+  /** computer: legacy single-machine binding. */
   tunnelId?: string | null;
+  /** computer: account-scoped machine allowlist for this profile. */
+  tunnelIds?: string[] | null;
   /** openapi/postman/graphql/http: a URL or repo-relative file path. Optional for graphql. */
   spec: string | null;
   // ── shared ──
@@ -379,7 +382,7 @@ export function manifestHashForConnector(spec: ConnectorSpec): string {
     endpoint: spec.endpoint,
     baseUrl: spec.baseUrl,
     platform: spec.platform,
-    tunnelId: spec.tunnelId ?? null,
+    tunnelIds: spec.tunnelIds ?? (spec.tunnelId ? [spec.tunnelId] : null),
     spec: spec.spec,
     auth: spec.auth,
     authAuto: spec.authAuto ?? false,
@@ -594,11 +597,11 @@ function parseProviderFields(
   }
 
   if (provider === 'computer') {
-    // Synth-only: connecting a machine over the Agent Computer Tunnel auto-
-    // materializes a single `computer` connector. It can't be declared by hand.
+    // API-only: profiles select account-owned machines through the connector
+    // API. Tunnel ids must not enter repository configuration.
     return err(
       slug,
-      'provider="computer" is managed automatically when you connect a machine (Computers) — it cannot be declared in kortix.yaml',
+      'provider="computer" is managed through the connector API (Computers) — it cannot be declared in kortix.yaml',
       filename,
     );
   }

--- a/apps/api/src/tunnel/core/rpc-core.ts
+++ b/apps/api/src/tunnel/core/rpc-core.ts
@@ -9,8 +9,7 @@
  * Connector maps it onto a CallResult.
  *
  * The computer helpers (`listAccountComputers`, `executeComputerCall`) sit here
- * too. New connectors bind one tunnel id. The selector path remains only for
- * durable sessions bound to the retired aggregate connector.
+ * too. A connector profile supplies an allowlist of account-owned tunnel ids.
  */
 import { tunnelConnections, tunnelPermissionRequests } from '@kortix/db';
 import {
@@ -19,7 +18,7 @@ import {
   TunnelMethods,
   TunnelRelayError,
 } from 'agent-tunnel';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { db } from '../../shared/db';
 import { notifyPermissionRequest } from '../routes/permission-requests';
 import { buildRequestSummary, finishAuditLog, startAuditLog } from './audit-logger';
@@ -231,7 +230,7 @@ function estimateBytes(result: unknown): number {
 
 // ─── Computer connector helpers ───────────────────────────────────────────────
 
-/** Legacy aggregate machine-list shape. New connector profiles do not expose it. */
+/** Profile-scoped machine-list shape exposed by `list_computers`. */
 export interface ComputerMachine {
   id: string;
   name: string;
@@ -240,12 +239,24 @@ export interface ComputerMachine {
   platform: string | null;
 }
 
-/** Legacy aggregate helper: list account machines with DB-backed online status. */
-export async function listAccountComputers(accountId: string): Promise<ComputerMachine[]> {
+/** List assigned account machines with DB-backed online status. Null is legacy all-account access. */
+export async function listAccountComputers(
+  accountId: string,
+  allowedTunnelIds: readonly string[] | null = null,
+): Promise<ComputerMachine[]> {
+  const allowed = allowedTunnelIds === null ? null : [...new Set(allowedTunnelIds)];
+  if (allowed?.length === 0) return [];
   const rows = await db
     .select()
     .from(tunnelConnections)
-    .where(eq(tunnelConnections.accountId, accountId));
+    .where(
+      allowed
+        ? and(
+            eq(tunnelConnections.accountId, accountId),
+            inArray(tunnelConnections.tunnelId, allowed),
+          )
+        : eq(tunnelConnections.accountId, accountId),
+    );
   return rows.map((r) => ({
     id: r.tunnelId,
     name: r.name,
@@ -258,17 +269,15 @@ export async function listAccountComputers(accountId: string): Promise<ComputerM
 
 type ResolveResult = { ok: true; tunnelId: string } | { ok: false; message: string };
 
-/** Legacy aggregate helper: resolve a selector to an account-owned tunnel id. */
+/** Resolve a selector inside one connector profile's already-filtered machine set. */
 async function resolveComputerTunnel(
-  accountId: string,
+  machines: ComputerMachine[],
   selector: string | null,
 ): Promise<ResolveResult> {
-  const machines = await listAccountComputers(accountId);
   if (machines.length === 0) {
     return {
       ok: false,
-      message:
-        'No machines are connected to this account. Connect one in Computers (or run `kortix tunnel`).',
+      message: 'No machines are assigned to this Computers connector profile.',
     };
   }
   if (selector) {
@@ -284,7 +293,7 @@ async function resolveComputerTunnel(
     }
     return {
       ok: false,
-      message: `No machine matches "${selector}". Available: ${machines.map((m) => m.name).join(', ')}.`,
+      message: `Machine "${selector}" is not assigned to this connector profile. Available: ${machines.map((m) => m.name).join(', ')}.`,
     };
   }
   const online = machines.filter((m) => m.online);
@@ -314,57 +323,30 @@ export type ComputerCallOutcome =
   | { ok: false; kind: 'error'; message: string };
 
 /**
- * Execute one machine-bound `computer` connector action. The account lookup
- * verifies the materialized tunnel id before relay. A deleted or cross-account
- * tunnel fails closed.
+ * Execute one Computers connector action. Listing and selection use the same
+ * server-side allowlist. The DB query also verifies account ownership, so a
+ * stale, deleted, unassigned, or cross-account tunnel fails closed.
  */
 export async function executeComputerCall(input: {
   accountId: string;
   projectId?: string | null;
   sessionId?: string | null;
   actorUserId?: string | null;
-  tunnelId: string | null;
-  /** Compatibility only for the retired aggregate connector. */
-  selector?: string | null;
+  /** Null is accepted only for legacy aggregate rows and means all account machines. */
+  allowedTunnelIds: string[] | null;
+  selector: string | null;
   method: string;
   args: Record<string, unknown>;
 }): Promise<ComputerCallOutcome> {
-  let tunnelId = input.tunnelId;
-  if (tunnelId) {
-    const [bound] = await db
-      .select({ tunnelId: tunnelConnections.tunnelId })
-      .from(tunnelConnections)
-      .where(
-        and(
-          eq(tunnelConnections.accountId, input.accountId),
-          eq(tunnelConnections.tunnelId, tunnelId),
-        ),
-      )
-      .limit(1);
-    if (!bound) {
-      return {
-        ok: false,
-        kind: 'no_machine',
-        message: 'This computer is no longer connected',
-      };
-    }
-    tunnelId = bound.tunnelId;
-  } else {
-    // Existing sessions can remain bound to the retired aggregate connector.
-    // Keep its selector path until those durable bindings age out.
-    if (input.method === 'list_computers') {
-      return {
-        ok: true,
-        data: { computers: await listAccountComputers(input.accountId) },
-      };
-    }
-    const resolved = await resolveComputerTunnel(input.accountId, input.selector ?? null);
-    if (!resolved.ok) return { ok: false, kind: 'no_machine', message: resolved.message };
-    tunnelId = resolved.tunnelId;
+  const machines = await listAccountComputers(input.accountId, input.allowedTunnelIds);
+  if (input.method === 'list_computers') {
+    return { ok: true, data: { computers: machines } };
   }
+  const resolved = await resolveComputerTunnel(machines, input.selector);
+  if (!resolved.ok) return { ok: false, kind: 'no_machine', message: resolved.message };
 
   const outcome = await executeTunnelRpc({
-    tunnelId,
+    tunnelId: resolved.tunnelId,
     accountId: input.accountId,
     projectId: input.projectId,
     sessionId: input.sessionId,

--- a/apps/web/content/docs/connect/computers.mdx
+++ b/apps/web/content/docs/connect/computers.mdx
@@ -28,20 +28,23 @@ permission request. You approve or deny each request on the Computers page.
 
 ## How the agent reaches a computer
 
-Connecting a machine creates one standalone
-[connector](/docs/connect/connectors) profile for that machine. Connecting two
-machines creates two profiles. Each profile has its own agent grants and tool
-policies, so a project can allow one machine without allowing the other.
+Pairing adds a machine to your account fleet. It does not grant a project access.
+Add **Computers** from the project's [connector](/docs/connect/connectors)
+catalog, then select one or more paired machines for that profile.
 
-The connector profile selects the machine. Tool inputs contain only the
-operation arguments, such as `{ "path": "/etc/hosts" }`. They do not accept a
-machine name or id. The connector slug includes the immutable tunnel id, for
-example `computer-11111111-1111-4111-8111-111111111111`.
+One profile can contain one machine or a group. You can create multiple profiles
+with different or overlapping groups. Each profile has independent agent grants
+and tool policies.
+
+The `list_computers` tool returns only machines assigned to the active profile.
+Other tools accept an optional `computer` name or id from that result. The
+selector is optional when exactly one assigned machine is online.
 
 ```bash
-kortix connectors call \
-  computer-11111111-1111-4111-8111-111111111111.fs.read \
-  '{"path":"/etc/hosts"}'
+kortix connectors call studio-computers.list_computers '{}'
+
+kortix connectors call studio-computers.fs.read \
+  '{"computer":"MacBook-Pro-9.local","path":"/etc/hosts"}'
 ```
 
 A computer has no credential. The live tunnel connection is the credential.
@@ -49,7 +52,6 @@ Per-machine filesystem, shell, and desktop access also lives in the tunnel
 permission layer. The connector policy and tunnel permission must both allow a
 call.
 
-You configure computers from the dashboard, not from `kortix.yaml`. Connecting
-a machine creates its connector profile automatically — you never add it by
-hand. Use the Computers page to pair, rename, and remove machines. Use each
-profile's Tools tab to configure its Connector policy.
+You configure Computers profiles from the dashboard, not from `kortix.yaml`.
+Use the Computers page to pair, rename, and remove machines. Use a profile's
+Accounts tab to select machines. Use its Tools tab to configure connector policy.

--- a/apps/web/content/docs/project/manifest.mdx
+++ b/apps/web/content/docs/project/manifest.mdx
@@ -86,7 +86,7 @@ triggers:
   - slug: daily-digest
     type: cron
     agent: kortix
-    cron: "0 0 9 * * 1-5"
+    cron: '0 0 9 * * 1-5'
     timezone: America/Los_Angeles
     prompt: |
       Summarize yesterday's commits. Open a CR against main.
@@ -94,19 +94,19 @@ triggers:
 
 ## Top-level keys
 
-| Key | Required | Notes |
-|---|---|---|
-| `kortix_version` | yes | must be `2` |
-| `default_agent` | yes | must name a declared, enabled agent |
-| `runtime` | no | only legal value is `"opencode"` (the default) |
-| `project.name` / `project.description` | no | display metadata; the platform does not read `project.name` for the project's display name |
-| `env.required` / `env.optional` | no | env var names; `required` is advisory only, never enforced at session start |
-| `sandbox` / `sandbox.templates` / `sandbox.default` | no | sandbox image(s) and hardware |
-| `opencode.config_dir` | no | default `.kortix/opencode` |
-| `triggers` | no | list of cron and webhook triggers |
-| `connectors` | no | list of connector definitions |
-| `policy.default_mode` | no | `allow_all` (default) or `risk`; project-wide connector approval mode |
-| `agents` | yes | name-to-block governance map; must not be empty |
+| Key                                                 | Required | Notes                                                                                      |
+| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `kortix_version`                                    | yes      | must be `2`                                                                                |
+| `default_agent`                                     | yes      | must name a declared, enabled agent                                                        |
+| `runtime`                                           | no       | only legal value is `"opencode"` (the default)                                             |
+| `project.name` / `project.description`              | no       | display metadata; the platform does not read `project.name` for the project's display name |
+| `env.required` / `env.optional`                     | no       | env var names; `required` is advisory only, never enforced at session start                |
+| `sandbox` / `sandbox.templates` / `sandbox.default` | no       | sandbox image(s) and hardware                                                              |
+| `opencode.config_dir`                               | no       | default `.kortix/opencode`                                                                 |
+| `triggers`                                          | no       | list of cron and webhook triggers                                                          |
+| `connectors`                                        | no       | list of connector definitions                                                              |
+| `policy.default_mode`                               | no       | `allow_all` (default) or `risk`; project-wide connector approval mode                      |
+| `agents`                                            | yes      | name-to-block governance map; must not be empty                                            |
 
 ## `project:`
 
@@ -122,10 +122,10 @@ env:
   optional: [STRIPE_API_KEY]
 ```
 
-| Field | Type | Notes |
-|---|---|---|
+| Field      | Type       | Notes                                                                                                    |
+| ---------- | ---------- | -------------------------------------------------------------------------------------------------------- |
 | `required` | `string[]` | Advisory. The dashboard prompts the user for these, but session start does not block on a missing value. |
-| `optional` | `string[]` | Available to sessions if set. Absence is fine. |
+| `optional` | `string[]` | Available to sessions if set. Absence is fine.                                                           |
 
 Env var names match `^[A-Z_][A-Z0-9_]*$`. The Secrets Manager caps a name at 64 characters — a longer name parses here but can never get a value. Names starting with `KORTIX_` can never get a value either. Keep names at 64 characters or fewer, and avoid the `KORTIX_` prefix. Full contract: [Secrets](/docs/project/secrets).
 
@@ -144,16 +144,16 @@ sandbox:
       disk: 50
 ```
 
-| Field | Type | Default | Notes |
-|---|---|---|---|
-| `slug` | string | — | Required. Unique per project. `default` is reserved. |
-| `name` | string | slug | Display label in the dashboard picker. |
-| `dockerfile` | string | — | Repo-relative path. Mutually exclusive with `image`. |
-| `image` | string | — | Public Docker image, tag- or digest-pinned. Mutually exclusive with `dockerfile`. |
-| `entrypoint` | string | runtime layer's own | Overrides the container entrypoint. |
-| `cpu` | int | provider default | vCPU cores. Bound: 1–32. |
-| `memory` | int | provider default | RAM in GiB. Bound: 1–128. |
-| `disk` | int | provider default | Disk in GiB. Bound: 1–500. |
+| Field        | Type   | Default             | Notes                                                                             |
+| ------------ | ------ | ------------------- | --------------------------------------------------------------------------------- |
+| `slug`       | string | —                   | Required. Unique per project. `default` is reserved.                              |
+| `name`       | string | slug                | Display label in the dashboard picker.                                            |
+| `dockerfile` | string | —                   | Repo-relative path. Mutually exclusive with `image`.                              |
+| `image`      | string | —                   | Public Docker image, tag- or digest-pinned. Mutually exclusive with `dockerfile`. |
+| `entrypoint` | string | runtime layer's own | Overrides the container entrypoint.                                               |
+| `cpu`        | int    | provider default    | vCPU cores. Bound: 1–32.                                                          |
+| `memory`     | int    | provider default    | RAM in GiB. Bound: 1–128.                                                         |
+| `disk`       | int    | provider default    | Disk in GiB. Bound: 1–500.                                                        |
 
 Each value must be a positive integer. A value below the minimum fails validation with an error. A value above the maximum passes with a warning, then clamps at runtime. GPUs are not supported — declaring `gpu` produces a warning, not an error. See [Runtime](/docs/work/runtime) for what the runtime layer injects on top of your image.
 
@@ -199,8 +199,8 @@ opencode:
   config_dir: .kortix/opencode
 ```
 
-| Field | Type | Default | Notes |
-|---|---|---|---|
+| Field        | Type   | Default            | Notes                    |
+| ------------ | ------ | ------------------ | ------------------------ |
 | `config_dir` | string | `.kortix/opencode` | Repo-relative directory. |
 
 That directory holds agents, skills, commands, tools, plugins, and `opencode.jsonc`. `opencode.jsonc` stays the OpenCode-native registry for plugins, MCP servers, providers, and permissions — do not duplicate those settings in the manifest. See [Agents](/docs/project/agents).
@@ -213,21 +213,21 @@ A list of cron and webhook definitions. Each entry fires a session that runs `pr
 triggers:
   - slug: daily-digest
     type: cron
-    cron: "0 0 9 * * 1-5"
+    cron: '0 0 9 * * 1-5'
     prompt: Summarize yesterday's commits.
 ```
 
-| Field | Required | Default | Notes |
-|---|---|---|---|
-| `slug` | yes | — | `[a-z0-9][a-z0-9_-]{0,127}`, unique among triggers. |
-| `type` | yes | — | `cron` or `webhook`. |
-| `prompt` | yes | — | Non-empty. Supports templating. |
-| `name` | no | slug | Human label. |
-| `agent` | no | `default` | Must name a key in `agents:`, or fall back to `default_agent`. |
-| `enabled` | no | `true` | `false` skips the entry. |
-| `model` | no | resolves at fire time | Wire form `provider/model`. Pins the fired session to that model. See [Models](/docs/project/models). |
-| `session_mode` | no | `fresh` | `fresh`, `reuse`, `pinned`, or `keyed`. |
-| `session_id` | required for `pinned` | — | Exact session to re-prompt. |
+| Field          | Required              | Default               | Notes                                                                                                 |
+| -------------- | --------------------- | --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `slug`         | yes                   | —                     | `[a-z0-9][a-z0-9_-]{0,127}`, unique among triggers.                                                   |
+| `type`         | yes                   | —                     | `cron` or `webhook`.                                                                                  |
+| `prompt`       | yes                   | —                     | Non-empty. Supports templating.                                                                       |
+| `name`         | no                    | slug                  | Human label.                                                                                          |
+| `agent`        | no                    | `default`             | Must name a key in `agents:`, or fall back to `default_agent`.                                        |
+| `enabled`      | no                    | `true`                | `false` skips the entry.                                                                              |
+| `model`        | no                    | resolves at fire time | Wire form `provider/model`. Pins the fired session to that model. See [Models](/docs/project/models). |
+| `session_mode` | no                    | `fresh`               | `fresh`, `reuse`, `pinned`, or `keyed`.                                                               |
+| `session_id`   | required for `pinned` | —                     | Exact session to re-prompt.                                                                           |
 
 Cron triggers need exactly one of `cron` (a 6-field expression) or `run_at` (a one-off ISO-8601 timestamp), plus `timezone` as an IANA name. Webhook triggers need `secret_env`, the name of a secret holding the HMAC signing key. Full field reference, payload templating, endpoints, and session strategy: see [Triggers](/docs/connect/triggers).
 
@@ -247,30 +247,30 @@ connectors:
         action: always_run
 ```
 
-| Field | Required | Notes |
-|---|---|---|
-| `slug` | yes | `[a-z0-9][a-z0-9_-]{0,127}`, unique among connectors. |
-| `provider` | yes | `pipedream`, `mcp`, `openapi`, `postman`, `graphql`, `http`, or `channel`. |
-| `name` | no | Display name. Defaults to slug. |
-| `authorization_strategy` | no | `project` or `user`. Defaults to `project` when omitted. A project strategy uses active project connections. A user strategy uses only the acting member's connection. |
-| `enabled` | no | Defaults to `true`. |
-| `credential` | no | Only `shared` is supported. The retired `per_user` mode is a hard error. |
-| `sensitive` | no | Defaults to `false`. `true` makes `require_approval` the unmatched-action default, including reads. Explicit project and connector rules still resolve first. |
+| Field                    | Required | Notes                                                                                                                                                                  |
+| ------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slug`                   | yes      | `[a-z0-9][a-z0-9_-]{0,127}`, unique among connectors.                                                                                                                  |
+| `provider`               | yes      | `pipedream`, `mcp`, `openapi`, `postman`, `graphql`, `http`, or `channel`.                                                                                             |
+| `name`                   | no       | Display name. Defaults to slug.                                                                                                                                        |
+| `authorization_strategy` | no       | `project` or `user`. Defaults to `project` when omitted. A project strategy uses active project connections. A user strategy uses only the acting member's connection. |
+| `enabled`                | no       | Defaults to `true`.                                                                                                                                                    |
+| `credential`             | no       | Only `shared` is supported. The retired `per_user` mode is a hard error.                                                                                               |
+| `sensitive`              | no       | Defaults to `false`. `true` makes `require_approval` the unmatched-action default, including reads. Explicit project and connector rules still resolve first.          |
 
 Provider-specific fields:
 
-| Provider | Required field | Notes |
-|---|---|---|
-| `pipedream` | `app` | `account` optional, defaults to slug. |
-| `mcp` | `url` | `transport`: `http` (default) or `sse`. |
-| `openapi` | `spec` | A URL or repo-relative path. |
-| `postman` | `spec` | A Collection JSON URL or path, a `.postman/api` manifest, or a Postman workspace URL. |
-| `graphql` | `endpoint` | `spec` optional (SDL). |
-| `http` | `base_url` | `spec` optional. |
-| `channel` | `platform` | `slack`, `teams`, `email`, or `voice`. |
-| `computer` | — | Synth-only. You cannot declare it by hand. Each connected machine creates its own profile. See [Computers](/docs/connect/computers). |
+| Provider    | Required field | Notes                                                                                                                                |
+| ----------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `pipedream` | `app`          | `account` optional, defaults to slug.                                                                                                |
+| `mcp`       | `url`          | `transport`: `http` (default) or `sse`.                                                                                              |
+| `openapi`   | `spec`         | A URL or repo-relative path.                                                                                                         |
+| `postman`   | `spec`         | A Collection JSON URL or path, a `.postman/api` manifest, or a Postman workspace URL.                                                |
+| `graphql`   | `endpoint`     | `spec` optional (SDL).                                                                                                               |
+| `http`      | `base_url`     | `spec` optional.                                                                                                                     |
+| `channel`   | `platform`     | `slack`, `teams`, `email`, or `voice`.                                                                                               |
+| `computer`  | —              | API-managed. You cannot declare it by hand. A profile selects one or more paired machines. See [Computers](/docs/connect/computers). |
 
-`channel` connectors rarely need a hand-written entry — connecting a channel from the dashboard creates one for you. See [Slack & channels](/docs/connect/slack). The slugs `kortix_slack`, `kortix_teams`, `kortix_email`, `kortix_voice`, and `computer` are platform-owned; using one with a different provider is a validation error. Per-machine `computer-<tunnel-uuid>` slugs are also generated by Kortix and must not be declared in the manifest.
+`channel` connectors rarely need a hand-written entry — connecting a channel from the dashboard creates one for you. See [Slack & channels](/docs/connect/slack). The slugs `kortix_slack`, `kortix_teams`, `kortix_email`, `kortix_voice`, and `computer` are platform-owned; using one with a different provider is a validation error. Computers profiles are created through the connector API because tunnel ids are account control-plane identities and must not enter the manifest.
 
 `connectors.auth`: optional, for providers other than `pipedream`. `type` is `bearer`, `basic`, `custom`, `api_key`, `oauth1`, `hmac`, `aws_sigv4`, `mtls`, or `none` (default). `oauth1` is restricted to `openapi`, `postman`, and `http` providers. `in` is `header` (default), `query`, or `cookie`. `name` is required when `type` is `custom` or `api_key`.
 
@@ -306,16 +306,16 @@ agents:
     secrets: [GITHUB_AGENT_TOKEN]
 ```
 
-| Field | Default | Notes |
-|---|---|---|
-| *(map key)* | — | `[a-z0-9][a-z0-9_-]{0,127}`, unique per project. Matches the `.md` filename it governs. |
-| `enabled` | `true` | `false` treats the agent as undeclared — the platform will not launch it. |
-| `connectors` | `none` | Which connector slugs this agent may call. `all` means every connector. |
-| `connectors_required` | `none` | Connector slugs that must resolve an active, strategy-compatible authorization before sandbox startup. Must be a subset of `connectors`. A missing authorization returns `CONNECTOR_CONNECTION_REQUIRED`. |
-| `secrets` | `none` | Which project secrets this agent receives as sandbox env vars. Renamed from v1's `env`. |
-| `kortix_cli` | `none` | Which Kortix CLI and API actions this agent may perform. `all` means everything the launching user can do — an agent can never exceed its launcher. |
-| `skills` | `none` | Which skills this agent may load. |
-| `workspace` | — | Git-boundary mode: `runtime`, `read`, or `branch`. Validated against the enum; any other value is rejected. |
+| Field                 | Default | Notes                                                                                                                                                                                                     |
+| --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _(map key)_           | —       | `[a-z0-9][a-z0-9_-]{0,127}`, unique per project. Matches the `.md` filename it governs.                                                                                                                   |
+| `enabled`             | `true`  | `false` treats the agent as undeclared — the platform will not launch it.                                                                                                                                 |
+| `connectors`          | `none`  | Which connector slugs this agent may call. `all` means every connector.                                                                                                                                   |
+| `connectors_required` | `none`  | Connector slugs that must resolve an active, strategy-compatible authorization before sandbox startup. Must be a subset of `connectors`. A missing authorization returns `CONNECTOR_CONNECTION_REQUIRED`. |
+| `secrets`             | `none`  | Which project secrets this agent receives as sandbox env vars. Renamed from v1's `env`.                                                                                                                   |
+| `kortix_cli`          | `none`  | Which Kortix CLI and API actions this agent may perform. `all` means everything the launching user can do — an agent can never exceed its launcher.                                                       |
+| `skills`              | `none`  | Which skills this agent may load.                                                                                                                                                                         |
+| `workspace`           | —       | Git-boundary mode: `runtime`, `read`, or `branch`. Validated against the enum; any other value is rejected.                                                                                               |
 
 v2 is deny-by-default: an omitted `connectors`, `secrets`, `kortix_cli`, or `skills` on a declared agent resolves to `none`. Grant every permission an agent needs explicitly, as the starter's `kortix` agent does above. A project migrating from v1 must re-grant everything by hand — v1 defaults `env` (secrets) to `all` when omitted, the opposite of v2.
 

--- a/apps/web/src/features/workspace/capabilities/connectors/add/computers-add-flow.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/add/computers-add-flow.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { createConnector } from '@kortix/sdk';
+import { MonitorIcon } from '@phosphor-icons/react';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from '@/components/ui/modal';
+import { errorToast, successToast } from '@/components/ui/toast';
+import { ComputerMachineSelector } from '@/features/workspace/capabilities/connectors/detail/computer-connector-account';
+import {
+  isConnectorConnectionSlugAvailable,
+  normalizeConnectorConnectionSlug,
+  proposeConnectorConnectionSlug,
+} from '@/features/workspace/customize/sections/connector-connection-form';
+
+export function ComputersAddFlow({
+  projectId,
+  open,
+  existingSlugs,
+  canWrite,
+  onClose,
+  onAdded,
+}: {
+  projectId: string;
+  open: boolean;
+  existingSlugs: readonly string[];
+  canWrite: boolean;
+  onClose: () => void;
+  onAdded: (slug?: string) => void;
+}) {
+  if (!canWrite || !open) return null;
+  return (
+    <ComputersAddFlowContent
+      projectId={projectId}
+      existingSlugs={existingSlugs}
+      onClose={onClose}
+      onAdded={onAdded}
+    />
+  );
+}
+
+function ComputersAddFlowContent({
+  projectId,
+  existingSlugs,
+  onClose,
+  onAdded,
+}: {
+  projectId: string;
+  existingSlugs: readonly string[];
+  onClose: () => void;
+  onAdded: (slug?: string) => void;
+}) {
+  const initialSlug = proposeConnectorConnectionSlug('Computers', existingSlugs);
+  const [name, setName] = useState('Computers');
+  const [slug, setSlug] = useState(initialSlug);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const add = useMutation({
+    mutationFn: () =>
+      createConnector(projectId, {
+        slug,
+        name: name.trim(),
+        provider: 'computer',
+        tunnel_ids: selectedIds,
+        authorization_strategy: 'project',
+        create_only: true,
+      }),
+    onSuccess: () => {
+      successToast(`Added ${name.trim()}`);
+      onAdded(slug);
+      onClose();
+    },
+    onError: (error: Error) => errorToast(error.message || 'Failed to add Computers'),
+  });
+
+  const slugAvailable = isConnectorConnectionSlugAvailable(slug, existingSlugs);
+  const valid = name.trim().length > 0 && slugAvailable && selectedIds.length > 0;
+
+  return (
+    <Modal open onOpenChange={(next) => !next && !add.isPending && onClose()}>
+      <ModalContent className="lg:max-w-xl">
+        <ModalHeader>
+          <div className="flex items-start gap-3">
+            <span className="bg-kortix-blue/15 text-kortix-blue flex size-10 shrink-0 items-center justify-center rounded-sm">
+              <MonitorIcon className="size-5" />
+            </span>
+            <div className="min-w-0 space-y-1">
+              <ModalTitle>Add Computers</ModalTitle>
+              <ModalDescription>
+                Select the paired machines this connector profile can access.
+              </ModalDescription>
+            </div>
+          </div>
+        </ModalHeader>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (valid && !add.isPending) add.mutate();
+          }}
+        >
+          <ModalBody className="max-h-[65vh] space-y-5 overflow-y-auto">
+            <FieldGroup className="grid gap-3 sm:grid-cols-2">
+              <Field>
+                <FieldLabel htmlFor="computers-profile-name">Profile name</FieldLabel>
+                <Input
+                  id="computers-profile-name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  variant="popover"
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="computers-profile-slug">Slug</FieldLabel>
+                <Input
+                  id="computers-profile-slug"
+                  value={slug}
+                  onChange={(event) =>
+                    setSlug(normalizeConnectorConnectionSlug(event.target.value))
+                  }
+                  variant="popover"
+                  className="font-mono text-xs"
+                  aria-invalid={slug.length > 0 && !slugAvailable}
+                />
+                {!slugAvailable ? (
+                  <p className="text-destructive text-xs">This slug is already in use.</p>
+                ) : null}
+              </Field>
+            </FieldGroup>
+
+            <section className="space-y-2">
+              <div className="space-y-1">
+                <FieldLabel>Computers</FieldLabel>
+                <p className="text-muted-foreground text-xs text-pretty">
+                  You can select one machine or create a shared profile for several machines.
+                </p>
+              </div>
+              <ComputerMachineSelector
+                selectedIds={selectedIds}
+                onSelectedIdsChange={setSelectedIds}
+                disabled={add.isPending}
+              />
+            </section>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              type="button"
+              variant="outline-ghost"
+              disabled={add.isPending}
+              onClick={onClose}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!valid || add.isPending}>
+              {add.isPending ? <Loading className="size-4 shrink-0" /> : null}
+              Add connector
+            </Button>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.test.ts
@@ -5,6 +5,7 @@ import {
   catalogEntryFromDiscover,
   catalogEntryFromEasyConnect,
   catalogSections,
+  computersCatalogEntry,
   connectedCatalogKeys,
   isCatalogEntryConnected,
   POPULAR_SECTION,
@@ -53,6 +54,16 @@ const conn = (over: Partial<AdminConnector> = {}): AdminConnector =>
   }) as AdminConnector;
 
 describe('normalising the two catalogues', () => {
+  test('Computers is a native connector catalogue entry', () => {
+    const entry = computersCatalogEntry();
+    expect(entry).toMatchObject({
+      source: 'computer',
+      slug: 'computers',
+      name: 'Computers',
+      categories: ['developer-tools'],
+    });
+  });
+
   test('a Discover entry keeps its rank and its raw connector', () => {
     const entry = catalogEntryFromDiscover(connector({ popularity: 42 }));
     expect(entry.source).toBe('discover');
@@ -103,6 +114,13 @@ describe('connected join', () => {
   test('a fully renamed connector falls back to + rather than matching wrongly', () => {
     const keys = connectedCatalogKeys([conn({ slug: 'tracker', name: 'Tracker' })]);
     expect(isCatalogEntryConnected(catalogEntryFromDiscover(connector()), keys)).toBe(false);
+  });
+
+  test('Computers stays connected when every profile has a custom name and slug', () => {
+    const keys = connectedCatalogKeys([
+      conn({ provider: 'computer', slug: 'studio-machines', name: 'Studio' }),
+    ]);
+    expect(isCatalogEntryConnected(computersCatalogEntry(), keys)).toBe(true);
   });
 
   // A connector with a blank name must not index the empty string, or every

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.ts
@@ -37,7 +37,22 @@ interface CatalogEntryFields {
  */
 export type CatalogEntry =
   | (CatalogEntryFields & { source: 'discover'; connector: DiscoverConnector })
-  | (CatalogEntryFields & { source: 'easy-connect'; app: PipedreamApp });
+  | (CatalogEntryFields & { source: 'easy-connect'; app: PipedreamApp })
+  | (CatalogEntryFields & { source: 'computer' });
+
+/** Native platform provider. The tunnel fleet is its account directory. */
+export function computersCatalogEntry(): CatalogEntry {
+  return {
+    source: 'computer',
+    key: 'computer:computers',
+    slug: 'computers',
+    name: 'Computers',
+    description: 'Use selected local machines through the secure Kortix tunnel.',
+    icon: null,
+    categories: ['developer-tools'],
+    popularity: null,
+  };
+}
 
 export function catalogEntryFromDiscover(connector: DiscoverConnector): CatalogEntry {
   return {
@@ -103,6 +118,7 @@ export function foldKey(value: string): string {
 export function connectedCatalogKeys(connectors: readonly AdminConnector[]): ReadonlySet<string> {
   const keys = new Set<string>();
   for (const connector of connectors) {
+    keys.add(`provider:${connector.provider}`);
     keys.add(foldKey(connector.slug));
     if (connector.name?.trim()) keys.add(foldKey(connector.name));
   }
@@ -114,6 +130,7 @@ export function isCatalogEntryConnected(
   entry: CatalogEntry,
   connectedKeys: ReadonlySet<string>,
 ): boolean {
+  if (entry.source === 'computer') return connectedKeys.has('provider:computer');
   return connectedKeys.has(foldKey(entry.slug)) || connectedKeys.has(foldKey(entry.name));
 }
 

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/connector-browse.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/connector-browse.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeftIcon, GlobeIcon, PlusIcon } from '@phosphor-icons/react';
+import { ArrowLeftIcon, GlobeIcon, MonitorIcon, PlusIcon } from '@phosphor-icons/react';
 import Image from 'next/image';
 import { useCallback, useMemo, useState, type CSSProperties } from 'react';
 
@@ -20,11 +20,7 @@ import { GRID_CLASSNAME } from '@/features/workspace/capabilities/shared/catalog
 import { cn } from '@/lib/utils';
 import { catalogSections, isCatalogEntryConnected, type CatalogEntry } from './catalog-entry';
 import { catalogFootSummary } from './catalog-foot';
-import {
-  CATALOG_INITIAL_REVEAL,
-  canRevealMore,
-  nextRevealCount,
-} from './catalog-paging';
+import { CATALOG_INITIAL_REVEAL, canRevealMore, nextRevealCount } from './catalog-paging';
 import { CategoryIcon } from './category-icon';
 import {
   ALL_CATEGORIES,
@@ -67,11 +63,11 @@ function CatalogAffordance({ connected }: { connected: boolean }) {
  * 10% in light, pure white at 10% in dark. A tinted neutral would pick up the
  * surface colour behind it and read as dirt on the logo's edge.
  */
-function ConnectorIcon({ icon }: { icon: string | null }) {
+function ConnectorIcon({ icon, computer = false }: { icon: string | null; computer?: boolean }) {
   if (!icon) {
     return (
       <span className="bg-card flex size-9 shrink-0 items-center justify-center rounded-sm">
-        <GlobeIcon className="size-5" />
+        {computer ? <MonitorIcon className="size-5" /> : <GlobeIcon className="size-5" />}
       </span>
     );
   }
@@ -111,7 +107,7 @@ function CatalogEntryCard({
 }) {
   return (
     <CatalogCard
-      leading={<ConnectorIcon icon={entry.icon} />}
+      leading={<ConnectorIcon icon={entry.icon} computer={entry.source === 'computer'} />}
       title={entry.name}
       description={entry.description}
       trailing={<CatalogAffordance connected={isCatalogEntryConnected(entry, connectedKeys)} />}
@@ -555,10 +551,7 @@ export function ConnectorBrowse({
           above the catalogue — the page is the catalogue, and a category is a
           place you go rather than a switch you leave flipped. */}
       {!searching && activeCategory !== ALL_CATEGORIES ? (
-        <CategoryViewHeader
-          category={activeCategory}
-          onBack={() => openCategory(ALL_CATEGORIES)}
-        />
+        <CategoryViewHeader category={activeCategory} onBack={() => openCategory(ALL_CATEGORIES)} />
       ) : null}
 
       {showSections ? (

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/use-catalog.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/use-catalog.ts
@@ -9,6 +9,7 @@ import { useDebounce } from '@/hooks/use-debounce';
 import {
   catalogEntryFromDiscover,
   catalogEntryFromEasyConnect,
+  computersCatalogEntry,
   type CatalogEntry,
   type CatalogSource,
 } from './catalog-entry';
@@ -134,15 +135,26 @@ export function useCatalog(
   const active = source === 'discover' ? discoverQuery : easyConnectQuery;
 
   const entries = useMemo(() => {
+    const native = computersCatalogEntry();
+    const includeComputers =
+      !activeQuery ||
+      `${native.name} ${native.description ?? ''}`
+        .toLowerCase()
+        .includes(activeQuery.toLowerCase());
+    const nativeEntries = includeComputers ? [native] : [];
     if (source === 'discover') {
-      return (discoverQuery.data?.pages ?? [])
-        .flatMap((page) => page.items)
-        .map(catalogEntryFromDiscover);
+      return nativeEntries.concat(
+        (discoverQuery.data?.pages ?? [])
+          .flatMap((page) => page.items)
+          .map(catalogEntryFromDiscover),
+      );
     }
-    return (easyConnectQuery.data?.pages ?? [])
-      .flatMap((page) => page.apps)
-      .map(catalogEntryFromEasyConnect);
-  }, [source, discoverQuery.data, easyConnectQuery.data]);
+    return nativeEntries.concat(
+      (easyConnectQuery.data?.pages ?? [])
+        .flatMap((page) => page.apps)
+        .map(catalogEntryFromEasyConnect),
+    );
+  }, [activeQuery, source, discoverQuery.data, easyConnectQuery.data]);
 
   const {
     fetchNextPage,
@@ -173,7 +185,8 @@ export function useCatalog(
         hasNextPage,
         isFetchingNextPage,
         isPlaceholderData,
-        focus: focusCategory === null ? null : { loaded: focusLoaded, target: CATALOG_FOCUS_TARGET },
+        focus:
+          focusCategory === null ? null : { loaded: focusLoaded, target: CATALOG_FOCUS_TARGET },
         initialPages: CATALOG_INITIAL_PAGES,
         maxPages: CATALOG_AUTOLOAD_MAX_PAGES,
       })
@@ -210,7 +223,8 @@ export function useCatalog(
     source === 'discover'
       ? discoverQuery.data?.pages[0]?.total
       : easyConnectQuery.data?.pages[0]?.total;
-  const total = typeof reportedTotal === 'number' ? reportedTotal : entries.length;
+  const nativeCount = entries.some((entry) => entry.source === 'computer') ? 1 : 0;
+  const total = typeof reportedTotal === 'number' ? reportedTotal + nativeCount : entries.length;
 
   return {
     entries,

--- a/apps/web/src/features/workspace/capabilities/connectors/connectors-page.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/connectors-page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type AdminConnector, getProjectDetail, listConnectors } from '@kortix/sdk';
+import { getProjectDetail, listConnectors, type AdminConnector } from '@kortix/sdk';
 import { contract, qk, useFeatureFlag, useProjectAccountId } from '@kortix/sdk/react';
 import { MagnifyingGlassIcon, PlugIcon, PlusIcon } from '@phosphor-icons/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -40,6 +40,7 @@ import {
 } from './connector-identity';
 import { providerLabel } from './provider-label';
 
+import { ComputersAddFlow } from '@/features/workspace/capabilities/connectors/add/computers-add-flow';
 import { DiscoverAddFlow } from '@/features/workspace/capabilities/connectors/add/discover-add-flow';
 import { EasyConnectAddFlow } from '@/features/workspace/capabilities/connectors/add/easy-connect-add-flow';
 import {
@@ -523,6 +524,14 @@ export function ConnectorsPage({ projectId }: { projectId: string }) {
       <EasyConnectAddFlow
         projectId={projectId}
         app={catalogTarget?.source === 'easy-connect' ? catalogTarget.app : null}
+        existingSlugs={existingSlugs}
+        canWrite={canWrite}
+        onClose={() => setCatalogTarget(null)}
+        onAdded={onCatalogAdded}
+      />
+      <ComputersAddFlow
+        projectId={projectId}
+        open={catalogTarget?.source === 'computer'}
         existingSlugs={existingSlugs}
         canWrite={canWrite}
         onClose={() => setCatalogTarget(null)}

--- a/apps/web/src/features/workspace/capabilities/connectors/detail/computer-connector-account.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/detail/computer-connector-account.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 
-import { computerTunnelId } from './computer-connector-account';
+import { machineSelectionChanged, normalizeMachineSelection } from './computer-connector-account';
 
-describe('computerTunnelId', () => {
-  test('reads the immutable tunnel UUID from a per-machine connector slug', () => {
-    expect(computerTunnelId('computer-11111111-1111-4111-8111-111111111111')).toBe(
-      '11111111-1111-4111-8111-111111111111',
-    );
+describe('Computers profile machine selection', () => {
+  test('normalizes duplicates and ignores non-string values', () => {
+    expect(normalizeMachineSelection(['b', 'a', 'b', null])).toEqual(['a', 'b']);
   });
 
-  test('rejects the retired aggregate slug and malformed profile slugs', () => {
-    expect(computerTunnelId('computer')).toBeNull();
-    expect(computerTunnelId('computer-not-a-uuid')).toBeNull();
+  test('compares selections independent of display order', () => {
+    expect(machineSelectionChanged(['b', 'a'], ['a', 'b'])).toBe(false);
+    expect(machineSelectionChanged(['a'], ['a', 'b'])).toBe(true);
   });
 });

--- a/apps/web/src/features/workspace/capabilities/connectors/detail/computer-connector-account.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/detail/computer-connector-account.tsx
@@ -1,64 +1,82 @@
 'use client';
 
-import type { AdminConnector } from '@kortix/sdk';
+import { createConnector, getConnectorConfig, type AdminConnector } from '@kortix/sdk';
 import { formatRelative } from '@kortix/shared';
 import { ArrowRightIcon, MonitorIcon } from '@phosphor-icons/react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import Link from 'next/link';
+import { useMemo, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { InlineMeta } from '@/components/ui/inline-meta';
+import { Checkbox } from '@/components/ui/checkbox';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { Label } from '@/components/ui/label';
+import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
+import { errorToast, successToast } from '@/components/ui/toast';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { useTunnelConnections } from '@/hooks/tunnel/use-tunnel';
 import { useTunnelRealtimeSync } from '@/hooks/tunnel/use-tunnel-realtime';
 import { cn } from '@/lib/utils';
 
-const COMPUTER_PROFILE_PREFIX = 'computer-';
+export function normalizeMachineSelection(values: readonly unknown[]): string[] {
+  return [
+    ...new Set(
+      values.filter((value): value is string => typeof value === 'string' && value.length > 0),
+    ),
+  ].sort();
+}
 
-/** The per-machine connector slug contains the immutable tunnel UUID. */
-export function computerTunnelId(slug: string): string | null {
-  if (!slug.startsWith(COMPUTER_PROFILE_PREFIX)) return null;
-  const tunnelId = slug.slice(COMPUTER_PROFILE_PREFIX.length);
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(tunnelId)
-    ? tunnelId.toLowerCase()
-    : null;
+export function machineSelectionChanged(
+  current: readonly unknown[],
+  saved: readonly unknown[],
+): boolean {
+  return (
+    JSON.stringify(normalizeMachineSelection(current)) !==
+    JSON.stringify(normalizeMachineSelection(saved))
+  );
 }
 
 function machineValue(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
-export function ComputerConnectorAccount({
-  projectId,
-  connector,
+export function ComputerMachineSelector({
+  selectedIds,
+  onSelectedIdsChange,
+  disabled = false,
+  visibleIds,
 }: {
-  projectId: string;
-  connector: AdminConnector;
+  selectedIds: readonly string[];
+  onSelectedIdsChange: (ids: string[]) => void;
+  disabled?: boolean;
+  /** Restrict read-only views to the profile's assigned set. */
+  visibleIds?: readonly string[];
 }) {
-  const tunnelId = computerTunnelId(connector.slug);
   const connectionsQuery = useTunnelConnections();
   useTunnelRealtimeSync();
+  const selected = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const visible = useMemo(() => (visibleIds ? new Set(visibleIds) : null), [visibleIds]);
 
   if (connectionsQuery.isLoading) {
     return (
       <div className="space-y-2">
-        <Skeleton className="h-4 w-20 rounded-sm" />
-        <Skeleton className="h-32 rounded-md" />
+        {[0, 1, 2].map((index) => (
+          <Skeleton key={index} className="h-16 rounded-md" />
+        ))}
       </div>
     );
   }
-
   if (connectionsQuery.isError) {
     return (
       <ErrorState
         size="sm"
-        title="Couldn’t load this computer"
+        title="Couldn’t load computers"
         description={
           connectionsQuery.error instanceof Error
             ? connectionsQuery.error.message
-            : 'The computer connection could not be read.'
+            : 'The paired computer fleet could not be read.'
         }
         action={
           <Button variant="outline" size="sm" onClick={() => void connectionsQuery.refetch()}>
@@ -68,64 +86,182 @@ export function ComputerConnectorAccount({
       />
     );
   }
+  const machines = (connectionsQuery.data ?? []).filter(
+    (connection) => visible === null || visible.has(connection.tunnelId),
+  );
+  if (machines.length === 0) {
+    return (
+      <InfoBanner
+        tone="neutral"
+        title={visible ? 'No assigned computers are available' : 'No paired computers'}
+      >
+        {visible
+          ? 'The assigned computers are no longer present in this account fleet.'
+          : 'Pair a computer from the Computers page before creating a connector profile.'}
+      </InfoBanner>
+    );
+  }
 
-  const connection = connectionsQuery.data?.find((item) => item.tunnelId === tunnelId);
-  if (!tunnelId || !connection) {
+  return (
+    <ul className="space-y-2">
+      {machines.map((connection) => {
+        const platform = machineValue(connection.machineInfo.platform);
+        const arch = machineValue(connection.machineInfo.arch);
+        const lastSeen = connection.lastHeartbeatAt
+          ? (formatRelative(connection.lastHeartbeatAt, { maxRelativeDays: null }) ?? 'Unknown')
+          : 'Never';
+        return (
+          <li key={connection.tunnelId} className="bg-popover rounded-md border px-1 py-1">
+            <Checkbox
+              checked={selected.has(connection.tunnelId)}
+              disabled={disabled}
+              onCheckedChange={(checked) => {
+                const next = new Set(selected);
+                if (checked === true) next.add(connection.tunnelId);
+                else next.delete(connection.tunnelId);
+                onSelectedIdsChange([...next]);
+              }}
+              className="min-h-14 py-2"
+              label={
+                <span className="flex min-w-0 items-center gap-3">
+                  <span
+                    className={cn(
+                      'flex size-9 shrink-0 items-center justify-center rounded-sm',
+                      connection.isLive
+                        ? 'bg-kortix-green/15 text-kortix-green'
+                        : 'bg-primary/5 text-muted-foreground',
+                    )}
+                  >
+                    <MonitorIcon className="size-5" weight="fill" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex flex-wrap items-center gap-2">
+                      <span className="text-foreground truncate text-sm font-medium">
+                        {connection.name}
+                      </span>
+                      <Badge variant={connection.isLive ? 'success' : 'outline'} size="xs">
+                        {connection.isLive ? 'Online' : 'Offline'}
+                      </Badge>
+                    </span>
+                    <span className="text-muted-foreground mt-0.5 block text-xs">
+                      {[platform, arch].filter(Boolean).join(' ') || 'Unknown platform'} &bull; Last
+                      seen {lastSeen}
+                    </span>
+                  </span>
+                </span>
+              }
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function ComputerConnectorAccount({
+  projectId,
+  connector,
+  canWrite,
+  onChanged,
+}: {
+  projectId: string;
+  connector: AdminConnector;
+  canWrite: boolean;
+  onChanged: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const configQuery = useQuery({
+    queryKey: ['connector-config', projectId, connector.slug],
+    queryFn: () => getConnectorConfig(projectId, connector.slug),
+  });
+  const savedIds = configQuery.data?.tunnelIds ?? [];
+  const [selection, setSelection] = useState<string[] | null>(null);
+  const selectedIds = selection ?? savedIds;
+
+  const save = useMutation({
+    mutationFn: () =>
+      createConnector(projectId, {
+        slug: connector.slug,
+        name: connector.name,
+        provider: 'computer',
+        tunnel_ids: normalizeMachineSelection(selectedIds),
+      }),
+    onSuccess: () => {
+      successToast('Computer assignments saved');
+      setSelection(null);
+      void queryClient.invalidateQueries({
+        queryKey: ['connector-config', projectId, connector.slug],
+      });
+      onChanged();
+    },
+    onError: (error: Error) => errorToast(error.message || 'Failed to save computer assignments'),
+  });
+
+  if (configQuery.isLoading) {
+    return <Skeleton className="h-40 rounded-md" />;
+  }
+  if (configQuery.isError) {
     return (
       <ErrorState
         size="sm"
-        title="Computer disconnected"
-        description="This connector profile no longer has a connected computer. Refresh the connector list to remove it."
+        title="Couldn’t load computer assignments"
+        description={(configQuery.error as Error).message}
+        action={
+          <Button variant="outline" size="sm" onClick={() => void configQuery.refetch()}>
+            Retry
+          </Button>
+        }
       />
     );
   }
 
-  const hostname = machineValue(connection.machineInfo.hostname);
-  const platform = machineValue(connection.machineInfo.platform);
-  const arch = machineValue(connection.machineInfo.arch);
-  const lastSeen = connection.lastHeartbeatAt
-    ? (formatRelative(connection.lastHeartbeatAt, { maxRelativeDays: null }) ?? 'Unknown')
-    : 'Never';
-
+  const dirty = machineSelectionChanged(selectedIds, savedIds);
   return (
-    <section className="space-y-2">
-      <Label>Computer</Label>
-      <div className="bg-popover overflow-hidden rounded-md border">
-        <div className="flex flex-col gap-4 px-4 py-5 sm:flex-row sm:items-start">
-          <span
-            className={cn(
-              'flex size-9 shrink-0 items-center justify-center rounded-sm',
-              connection.isLive
-                ? 'bg-kortix-green/15 text-kortix-green'
-                : 'bg-primary/5 text-muted-foreground',
-            )}
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="space-y-1">
+          <Label>Assigned computers</Label>
+          <p className="text-muted-foreground text-xs text-pretty">
+            Agents using this connector can list and target only these computers.
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm" className="shrink-0 gap-1.5">
+          <Link href={`/projects/${projectId}/customize/computers`}>
+            Manage fleet
+            <ArrowRightIcon className="size-3.5 shrink-0" />
+          </Link>
+        </Button>
+      </div>
+
+      <ComputerMachineSelector
+        selectedIds={selectedIds}
+        onSelectedIdsChange={setSelection}
+        disabled={!canWrite || save.isPending}
+        visibleIds={canWrite ? undefined : savedIds}
+      />
+
+      {canWrite ? (
+        <div className="border-border/60 flex justify-end gap-2 border-t pt-4">
+          {dirty ? (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={save.isPending}
+              onClick={() => setSelection(null)}
+            >
+              Reset
+            </Button>
+          ) : null}
+          <Button
+            size="sm"
+            disabled={!dirty || selectedIds.length === 0 || save.isPending}
+            onClick={() => save.mutate()}
           >
-            <MonitorIcon className="size-5" weight="fill" />
-          </span>
-          <div className="min-w-0 flex-1 space-y-1.5">
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="text-foreground truncate text-sm font-medium">{connection.name}</p>
-              <Badge variant={connection.isLive ? 'success' : 'outline'} size="sm">
-                {connection.isLive ? 'Online' : 'Offline'}
-              </Badge>
-            </div>
-            <InlineMeta className="flex-wrap">
-              {hostname}
-              {[platform, arch].filter(Boolean).join(' ') || null}
-              {`Last seen ${lastSeen}`}
-            </InlineMeta>
-            <p className="text-muted-foreground font-mono text-xs break-all">
-              {connection.tunnelId}
-            </p>
-          </div>
-          <Button asChild variant="outline" size="sm" className="shrink-0 gap-1.5">
-            <Link href={`/projects/${projectId}/customize/computers`}>
-              Manage computer
-              <ArrowRightIcon className="size-3.5 shrink-0" />
-            </Link>
+            {save.isPending ? <Loading className="size-4 shrink-0" /> : null}
+            Save assignments
           </Button>
         </div>
-      </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/features/workspace/capabilities/connectors/detail/connector-accounts.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/detail/connector-accounts.tsx
@@ -57,7 +57,14 @@ export function ConnectorAccounts({
     isPipedream && canManageConnections && connector.authorizationStrategy === 'user';
 
   if (isComputer) {
-    return <ComputerConnectorAccount projectId={projectId} connector={connector} />;
+    return (
+      <ComputerConnectorAccount
+        projectId={projectId}
+        connector={connector}
+        canWrite={canWrite}
+        onChanged={onChanged}
+      />
+    );
   }
 
   if (isPipedream) {

--- a/apps/web/src/features/workspace/capabilities/connectors/detail/connector-modal.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/detail/connector-modal.tsx
@@ -286,7 +286,7 @@ function ConnectorModalBody({
               projectId={projectId}
               slug={connector.slug}
               displayName={displayName}
-              canWrite={canWrite && !isComputer}
+              canWrite={canWrite}
               disabled={strategyUpdating}
               onChanged={onChanged}
             />

--- a/apps/web/src/features/workspace/capabilities/connectors/detail/connector-settings.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/detail/connector-settings.tsx
@@ -30,14 +30,12 @@ export interface ConnectorSettingsProps {
 /**
  * Settings — who the connector runs as, and removing it.
  *
- * `connectorTabs` already restricts this tab to writers and drops it for
- * `computer` connectors, so neither is re-checked here.
+ * `connectorTabs` already restricts this tab to writers.
  *
  * Two rows, one shape: label, statement, trailing control. Every row is a
  * `bg-popover rounded-md border px-4 py-3` box, so they line up as one wall.
  *
- * Renaming is not here — it lives in the modal header (`HeaderName`), so
- * `computer` connectors keep it without having a Settings tab.
+ * Renaming is not here — it lives in the modal header (`HeaderName`).
  */
 export function ConnectorSettings({
   projectId,
@@ -96,7 +94,7 @@ export function ConnectorSettings({
             <div className="min-w-0">
               <p className="text-foreground text-sm font-medium">Remove connector</p>
               <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
-                Its saved connections and tool rules are deleted too.
+                Its assignments, saved connections, and tool rules are deleted too.
               </p>
             </div>
             <Button
@@ -119,8 +117,8 @@ export function ConnectorSettings({
         title={`Remove ${displayName}?`}
         description={
           <>
-            This deletes <code className="font-mono">{connector.slug}</code>, its saved connections
-            and its tool rules. This can’t be undone.
+            This deletes <code className="font-mono">{connector.slug}</code>, its assignments, saved
+            connections, and tool rules. This can’t be undone.
           </>
         }
         confirmLabel="Remove connector"

--- a/apps/web/src/features/workspace/capabilities/connectors/detail/connector-tabs.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/detail/connector-tabs.test.ts
@@ -47,7 +47,7 @@ describe('connectorTabs', () => {
     ]);
   });
 
-  test('a computer connector with no write access still identifies its bound machine', () => {
+  test('a computer connector with no write access still shows its assigned machines', () => {
     expect(connectorTabs(conn({ provider: 'computer' }), { canWrite: false })).toEqual([
       'accounts',
     ]);
@@ -59,10 +59,8 @@ describe('connectorTabs', () => {
     expect(tabs).not.toContain('settings');
   });
 
-  test('a computer profile omits generic credential settings', () => {
-    expect(connectorTabs(conn({ provider: 'computer' }), { canWrite: true })).not.toContain(
-      'settings',
-    );
+  test('a computer profile keeps regular profile settings', () => {
+    expect(connectorTabs(conn({ provider: 'computer' }), { canWrite: true })).toContain('settings');
   });
 
   test('channel connectors keep settings for their channel connection form', () => {
@@ -73,10 +71,11 @@ describe('connectorTabs', () => {
     expect(connectorTabs(conn({ provider: 'mcp' }), { canWrite: true })).toContain('accounts');
   });
 
-  test('a writer on a computer connector gets accounts and tools', () => {
+  test('a writer on a computer connector gets all regular connector tabs', () => {
     expect(connectorTabs(conn({ provider: 'computer' }), { canWrite: true })).toEqual([
       'accounts',
       'tools',
+      'settings',
     ]);
   });
 

--- a/apps/web/src/features/workspace/capabilities/connectors/detail/connector-tabs.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/detail/connector-tabs.ts
@@ -19,10 +19,8 @@ export const CONNECTOR_TAB_LABEL: Record<ConnectorTab, string> = {
  *
  * - The name, icon, status and connect action live in the modal header, above
  *   every tab — so there is no separate Overview tab.
- * - Every connector has Accounts. For a computer profile, Accounts identifies
- *   its one bound machine and links to the fleet-management surface.
- * - `computer` connectors omit Settings because pairing and machine lifecycle
- *   are account-scoped, not connector credential settings.
+ * - Every connector has Accounts. For a Computers profile, Accounts edits its
+ *   assigned machine set and links to the fleet-management surface.
  * - Tools and Settings mutate project state, so they are writer-only. Accounts
  *   stays for readers: it is how they see whether the connector works, and how
  *   they connect their own account.
@@ -31,10 +29,9 @@ export function connectorTabs(
   connector: AdminConnector,
   caps: { canWrite: boolean },
 ): ConnectorTab[] {
-  const isComputer = connector.provider === 'computer';
   const present = new Set<ConnectorTab>();
   present.add('accounts');
   if (caps.canWrite) present.add('tools');
-  if (caps.canWrite && !isComputer) present.add('settings');
+  if (caps.canWrite) present.add('settings');
   return CONNECTOR_TABS.filter((tab) => present.has(tab));
 }

--- a/apps/web/src/features/workspace/capabilities/connectors/provider-label.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/provider-label.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+
+import { providerLabel } from './provider-label';
+
+describe('providerLabel', () => {
+  test('uses the regular plural Computers provider name', () => {
+    expect(providerLabel('computer')).toBe('Computers');
+  });
+});

--- a/apps/web/src/features/workspace/capabilities/connectors/provider-label.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/provider-label.ts
@@ -17,7 +17,7 @@ import type { AdminConnector } from '@kortix/sdk';
 export function providerLabel(p: AdminConnector['provider']): string {
   if (p === 'pipedream') return 'App';
   if (p === 'channel') return 'Channel';
-  if (p === 'computer') return 'Computer';
+  if (p === 'computer') return 'Computers';
   if (p === 'postman') return 'Postman';
   return p.toUpperCase();
 }

--- a/docs/specs/computer-connector.md
+++ b/docs/specs/computer-connector.md
@@ -1,4 +1,4 @@
-# Computer connector profiles
+# Computers connector profiles
 
 **Status:** Implemented specification
 
@@ -6,130 +6,127 @@
 
 ## Goal
 
-Represent each connected machine as one standalone Connector profile.
+Treat Computers as one regular connector provider. A connector profile selects
+one or more account-owned machines. Connector grants, tool policies, audit, and
+session exposure apply to the profile.
 
-The profile is the machine selector. Connector grants and tool policies can
-therefore allow one machine and block another. Tool calls never receive an
-account-wide machine selector.
-
-The dedicated Computers page remains the account-level lifecycle surface. It
-pairs machines, shows online state, and manages tunnel capability grants.
+The Computers page remains the account fleet surface. It pairs machines, shows
+online state, and manages tunnel capability permissions. Pairing does not grant
+any project access.
 
 ## Product contract
 
-- One heartbeat-bearing tunnel creates one `computer` connector in each project
-  owned by the same account.
-- The connector name is the tunnel connection name.
-- The connector slug is `computer-<full-tunnel-uuid>`.
-- The connector config stores the immutable `tunnel_id`.
-- The connector catalog contains the machine operations only.
-- The catalog does not contain `list_computers`.
-- Tool input schemas do not contain a `computer` field.
-- The Connectors page shows each machine as a normal connector card.
-- Each machine profile has an Accounts tab that identifies its bound machine.
-- Each machine profile has an independent Tools policy tab.
-- The Computers page remains the fleet-management page.
+- Computers appears in the normal connector catalog.
+- A user creates a connector profile and selects one or more paired machines.
+- One machine can belong to multiple connector profiles.
+- A project can contain multiple profiles with different or overlapping sets.
+- The connector config stores selected machine ids in `tunnel_ids`.
+- Every profile exposes `list_computers`.
+- `list_computers` returns only machines assigned to that profile.
+- Every machine action accepts an optional `computer` name or id selector.
+- The selector can resolve only inside the profile's assigned set.
+- A selector is optional when exactly one assigned machine is online.
+- Each profile has normal Accounts, Tools, and Settings tabs.
+- The Accounts tab edits the profile's assigned machine set.
+- The Tools tab edits the profile's independent tool policy.
+- The Settings tab edits normal connector grants and settings.
 - Computer operations appear under Connectors in the account audit log.
 
-## Why the connector is per machine
+## Identity and storage
 
-The old aggregate design created one `computer` connector that fronted every
-machine in the account. Each tool accepted a machine name or id. That design
-created three security problems:
-
-1. A connector grant implicitly granted discovery of every machine.
-2. One connector policy applied to every machine.
-3. A mutable name or caller-supplied id selected the execution target.
-
-The per-machine design makes the connector identity the authorization target.
-The gateway reads the tunnel id from server-side connector config. The caller
-cannot redirect a call to a different machine.
-
-## Identity and materialization
-
-`synthesizeComputerConnectors(projectId, declared)` queries the project's
-account for `tunnel_connections` rows with `last_heartbeat_at IS NOT NULL`.
-It emits one synthetic `ConnectorSpec` per row.
-
-The synthetic spec has these fixed values:
+Computers profiles are project-scoped connector rows with these fixed values:
 
 ```text
-slug                   computer-<full-tunnel-uuid>
-name                   <tunnel connection name>
 provider               computer
 credential_mode        shared
 authorization_strategy project
 auth.type               none
-tunnel_id               <full-tunnel-uuid>
+config.computer_profile true
+config.tunnel_ids       [<tunnel uuid>, ...]
 ```
 
-The full UUID prevents collisions. The tunnel id does not change when the user
-renames the machine. The rename updates only the connector display name.
+The user chooses the connector name and slug. The first suggested slug is
+`computers`. Additional profiles use another available slug. Machine ids are
+stable tunnel UUIDs. Renaming a paired machine does not change a profile.
 
-A pairing row without a heartbeat does not create a connector. A machine that
-connected once remains materialized while offline. Deleting the tunnel removes
-its connector unless a durable session binding still references the row. A
-referenced row becomes disabled until that binding ages out.
+Profiles do not live in `kortix.yaml`. Tunnel ids are account control-plane
+identities. The normal connector API creates, updates, renames, and deletes the
+DB-backed profiles.
+
+The API validates every selected machine:
+
+1. The profile contains between 1 and 100 unique UUIDs.
+2. Every UUID belongs to the project's account.
+3. Every selected machine completed at least one tunnel connection.
+
+An empty set fails closed. Pairing a machine creates only a fleet record. It
+does not create a connector profile or grant access to a project.
 
 ## Catalog
 
-Every machine profile receives the same native catalog from
+Every Computers profile receives the native catalog from
 `apps/api/src/connectors/computers.ts`:
 
+- `list_computers`
 - `fs.read`, `fs.write`, `fs.list`, `fs.stat`, `fs.delete`
 - `shell.exec`
 - curated `desktop.cua.*` operations
 - `desktop.cua.call` for the computer-use long tail
 
-Each action uses `{ kind: 'tunnel', method }`. Its input schema contains only
-the operation inputs. The connector slug selects the machine.
+Each machine action uses `{ kind: 'tunnel', method }`. The action schema includes
+the optional `computer` selector plus the operation inputs. `list_computers` has
+no selector because it lists the profile's complete allowed set.
 
-Example:
+Examples:
 
 ```bash
-kortix connectors call computer-11111111-1111-4111-8111-111111111111 \
-  fs.read '{"path":"/etc/hosts"}'
+kortix connectors call studio-computers.list_computers '{}'
+
+kortix connectors call studio-computers.fs.read \
+  '{"computer":"MacBook-Pro-9.local","path":"/etc/hosts"}'
 ```
 
 ## Execution
 
-The gateway resolves the materialized connector and passes its `tunnel_id` to
-`executeComputerCall`.
+The gateway loads `config.tunnel_ids` from the materialized connector. It passes
+that server-side allowlist and the optional selector to `executeComputerCall`.
 
 ```text
 connector call
   -> connector grant
   -> connector tool policy
-  -> bound tunnel ownership check
+  -> profile machine allowlist
+  -> account ownership check
   -> tunnel capability and scope check
   -> WebSocket relay
   -> tunnel audit and connector audit
 ```
 
-`executeComputerCall` verifies both `account_id` and `tunnel_id` against
-`tunnel_connections` before relay. A deleted tunnel or a tunnel owned by a
-different account returns `no_machine`. The gateway never accepts a selector
-for a per-machine connector.
+`listAccountComputers` applies the profile allowlist and `account_id` in the same
+database query. `list_computers` returns that filtered result. Other actions
+resolve their selector only against that result. An unassigned, deleted, or
+cross-account machine returns `no_machine` before tunnel permission evaluation.
 
-The direct `POST /v1/tunnel/rpc/:tunnelId` route and Connector execution share
-`executeTunnelRpc`. This keeps rate limits, tunnel permissions, relay errors,
-and tunnel audit behavior identical.
+The direct `POST /v1/tunnel/rpc/:tunnelId` route and connector execution share
+`executeTunnelRpc`. Rate limits, tunnel permissions, relay errors, and tunnel
+audit behavior stay identical.
 
 ## Permission model
 
 Two permission layers remain intentional:
 
-1. Connector grants and connector tool policies decide which project members,
-   agents, and sessions can use this machine profile and which tools can run.
+1. Connector grants and connector tool policies decide who can use the profile
+   and which tools can run.
 2. Tunnel permissions decide which filesystem paths, shell commands, and
-   desktop features the machine exposes.
+   desktop features each selected machine exposes.
 
-Both layers are per machine because both resolve through the bound tunnel id.
+The connector profile authorizes membership in a machine set. Tunnel
+permissions remain specific to each machine.
 
-## Lifecycle reconciliation
+## Fleet lifecycle
 
-`reconcileComputerConnectors(accountId)` synchronizes all projects for the
-account. These lifecycle events call it:
+The Computers page manages account-level tunnel records. These events reconcile
+the connector materializer without changing profile membership:
 
 - the first authenticated WebSocket connection;
 - tunnel rename or capability update;
@@ -137,12 +134,13 @@ account. These lifecycle events call it:
 - device approval as a repair path;
 - normal project connector synchronization.
 
-The first WebSocket connection writes `last_heartbeat_at` before reconciliation.
-The machine profile therefore appears only after a real agent connects.
+Deleting a paired machine removes it from the fleet. A stale profile reference
+then fails closed because account ownership resolution cannot find the machine.
+The user can update or delete that profile through the connector API.
 
 ## Audit model
 
-New central audit events use:
+Central audit events use:
 
 ```text
 source        connector
@@ -151,40 +149,35 @@ resource_type computer_tunnel
 resource_id   <tunnel-id>
 ```
 
-The account Audit page has one Connectors quick filter. The API includes legacy
-`computer.*` events when that filter is active. The UI does not expose a second
-Computer quick-filter category.
-
-The tunnel audit log remains the machine-level technical record. Connector
-calls also write the standard Connector call record.
+The account Audit page uses the regular Connectors filter. The UI does not
+expose a separate COMPUTER category. Historical `computer.*` events remain
+included by the connector audit reconciliation path.
 
 ## Compatibility and migration
 
-The retired aggregate connector used slug `computer`, exposed
-`list_computers`, and accepted `args.computer`.
+The original aggregate `computer` row can omit `tunnel_ids`. A null allowlist is
+accepted only for that compatibility row and means all account machines. This
+keeps durable session bindings operational while profiles migrate.
 
-Compatibility is limited to durable bindings that already reference that
-aggregate row:
+PR #6287 briefly created one `computer-<uuid>` profile per machine. The next
+connector sync folds those generated rows into one `computer` profile with a
+`tunnel_ids` array. Profiles marked `computer_profile: true` are explicit and
+remain independent.
 
-- gateway execution recognizes only the exact legacy slug `computer`;
-- legacy calls can still use `list_computers` and `args.computer`;
-- new per-machine catalogs never expose those inputs;
-- user-facing connector lists hide the aggregate row after at least one
-  per-machine profile exists;
-- historical `computer.*` audit events remain visible under Connectors.
-
-No database migration rewrites session bindings. Reconciliation creates the new
-profiles. The legacy row can age out without breaking an active durable session.
+Legacy `config.tunnel_id` values normalize to a one-element allowlist. New and
+updated profiles always store `config.tunnel_ids`.
 
 ## Verification requirements
 
-1. Two tunnels create two connector rows with different `tunnel_id` values.
-2. Neither catalog contains `list_computers` or a `computer` input field.
-3. A policy change on one profile does not change the other profile.
-4. A call through one profile reaches only its bound tunnel.
-5. A cross-account or deleted `tunnel_id` fails closed.
-6. A rename updates the connector name without changing its slug.
-7. A delete removes or disables only the deleted machine profile.
-8. A never-connected pairing row creates no profile.
-9. The Audit page groups new and legacy computer events under Connectors.
-10. The deployed web UI shows each machine as its own connector profile.
+1. One profile can contain two assigned machines.
+2. `list_computers` returns exactly those two machines.
+3. A call can target either assigned machine.
+4. An unassigned machine id fails closed.
+5. A cross-account machine id fails closed.
+6. Two profiles can contain overlapping machine sets.
+7. Policies and grants remain independent per profile.
+8. Updating assignments preserves the profile's policies and sensitive state.
+9. Pairing a machine does not create a connector profile.
+10. Audit actions use `connector.computer.*` under the Connectors category.
+11. The Accounts tab can create and update one-machine and multi-machine sets.
+12. The deployed UI shows Computers in the normal connector catalog.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,36 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-09 — session `computers-connector-grouping` claim
+
+No **Now** task claimed. This is the user-directed Computers connector profile refactor.
+
+Claimed SDK scope:
+
+- Add an optional machine-id allowlist to the existing connector draft and config types.
+- Preserve every existing published name and wire route.
+- Add failing REST client coverage before implementation.
+- Run SDK typecheck, the complete SDK suite, and packed-install smoke.
+
+The required `tdd` skill is unavailable in this session. This work uses the
+required RED, GREEN, and REFACTOR sequence directly.
+
+RED:
+
+- Connector draft and config types rejected `tunnel_ids` / `tunnelIds` before implementation.
+
+GREEN:
+
+- Focused connector REST client suite: `38 pass`, `0 fail`.
+- `pnpm --filter @kortix/sdk test`: `1807 pass`, `2 skip`, `0 fail`, `7001 expect()` calls.
+- `pnpm --filter @kortix/sdk typecheck`: exit `0` for the package and examples.
+- `pnpm --filter @kortix/sdk run smoke:install`: packed-install import and construction passed.
+- No published export name or package version changed.
+
+**Status:** COMPLETE.
+
+**SDK package shippable to production: YES.**
+
 ### 2026-08-09 — session `release-codeql-connector-url` claim
 
 No **Now** task claimed. This is a narrow production-release security gate fix.

--- a/packages/sdk/src/core/rest/projects-client/connectors.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/connectors.test.ts
@@ -423,6 +423,36 @@ test('getConnectorConfig GETs the config, url-encoding a slug with special chara
   expect(result.slug).toBe('my app/v1');
 });
 
+test('computer connector config exposes its assigned machine ids', async () => {
+  const tunnelIds = [
+    '11111111-1111-4111-8111-111111111111',
+    '22222222-2222-4222-8222-222222222222',
+  ];
+  nextResponse = {
+    status: 200,
+    body: {
+      slug: 'studio-computers',
+      name: 'Studio computers',
+      provider: 'computer',
+      platform: null,
+      credentialMode: 'shared',
+      authorizationStrategy: 'project',
+      app: null,
+      account: null,
+      url: null,
+      transport: null,
+      endpoint: null,
+      baseUrl: null,
+      spec: null,
+      tunnelIds,
+      auth: { type: 'none', in: 'header', name: null, prefix: null },
+      headers: {},
+    },
+  };
+  const result = await getConnectorConfig('P1', 'studio-computers');
+  expect(result.tunnelIds).toEqual(tunnelIds);
+});
+
 test('setConnectorName PUTs { name }', async () => {
   nextResponse = { status: 200, body: { ok: true } };
   await setConnectorName('P1', 'slack', 'Team Slack');
@@ -454,6 +484,20 @@ test('createConnector POSTs the draft as the raw body', async () => {
   await createConnector('P1', draft);
   expect(last().url).toContain('/connectors/projects/P1/connectors');
   expect(last().url).not.toContain('/executor/');
+  expect(last().method).toBe('POST');
+  expect(last().body).toEqual(draft);
+});
+
+test('createConnector sends a Computers profile machine allowlist', async () => {
+  nextResponse = { status: 200, body: { ok: true } };
+  const draft: import('./connectors').ConnectorDraftInput = {
+    slug: 'studio-computers',
+    name: 'Studio computers',
+    provider: 'computer',
+    tunnel_ids: ['11111111-1111-4111-8111-111111111111', '22222222-2222-4222-8222-222222222222'],
+    create_only: true,
+  };
+  await createConnector('P1', draft);
   expect(last().method).toBe('POST');
   expect(last().body).toEqual(draft);
 });

--- a/packages/sdk/src/core/rest/projects-client/connectors.ts
+++ b/packages/sdk/src/core/rest/projects-client/connectors.ts
@@ -820,6 +820,8 @@ export interface ConnectorConfig {
   endpoint: string | null;
   baseUrl: string | null;
   spec: string | null;
+  /** Machine ids assigned to a Computers connector profile. */
+  tunnelIds?: string[];
   auth: {
     type: ConnectorRequestAuthType;
     in: 'header' | 'query' | 'cookie';
@@ -875,6 +877,8 @@ export interface ConnectorDraftInput {
   endpoint?: string;
   baseUrl?: string;
   spec?: string;
+  /** Account-owned machine ids assigned to a Computers connector profile. */
+  tunnel_ids?: string[];
   /** Credential storage mode. `shared` is the only mode (`per_user` was
    *  removed 2026-07-05). */
   credential?: 'shared';


### PR DESCRIPTION
## Problem

PR #6287 modeled every paired machine as a separate connector profile. That prevents one profile from authorizing a selected machine group and makes Computers look like a special category.

## Solution

- Treat Computers as one regular API-managed connector provider.
- Create profiles with one or more account-owned tunnel_ids.
- Keep list_computers and filter it to the profile assignment set.
- Restrict every machine selector to the same server-side assignment set.
- Support multiple overlapping profiles with independent policies and grants.
- Keep pairing and tunnel permissions on the Computers fleet page.
- Keep audit actions under connector.computer.* and the Connectors filter.
- Preserve legacy aggregate and per-machine compatibility during sync.

## Before / after

| Before | After |
| --- | --- |
| One connector profile per machine | One profile selects one or more machines |
| Pairing implicitly created project profiles | Pairing only adds a machine to the account fleet |
| No grouped authorization set | Profile assignments form the server-side allowlist |
| Computer-specific presentation | Native Computers catalog entry and regular connector tabs |

## Verification

- API focused unit: 12 pass, 0 fail, 64 assertions.
- API real-DB integration: 10 pass, 0 fail, 30 assertions.
- API full package: 5988 pass, 74 skip, 0 fail, 23031 assertions.
- API typecheck: exit 0.
- SDK focused connector tests: 38 pass, 0 fail.
- SDK full suite: 1807 pass, 2 skip, 0 fail, 7001 assertions.
- SDK typecheck and examples: exit 0.
- SDK packed-install smoke: pass.
- Frontend focused tests: 29 pass, 0 fail, 140 assertions.
- Frontend typecheck: only the documented 15 test.each baseline errors.
- Modified web files: Prettier pass.
- New frontend files: ESLint zero warnings.
- Real local HTTP: two-machine and overlapping profiles created; filtered list_computers returned exactly assigned ids; unassigned and cross-account ids failed closed; assigned id reached tunnel relay; independent policies persisted; connector.computer.fs.read audit rows recorded with authoritative source connector.

## Browser proof

The in-app browser runtime had zero connected browser instances. The source-level UI contracts and HTTP payloads are verified. Deployed browser proof will be retried after merge.