### PR TITLE
fix(connectors): isolate legacy computer aggregate

### DIFF
--- a/apps/api/src/__tests__/integration-computer-connector.test.ts
+++ b/apps/api/src/__tests__/integration-computer-connector.test.ts
@@ -10,8 +10,11 @@ import {
   accounts,
   auditEvents,
   connectorActions,
+  connectorConnections,
   connectorPolicies,
   connectors,
+  projectSessionConnectorBindings,
+  projectSessions,
   projects,
   tunnelConnections,
   tunnelPermissions,
@@ -30,6 +33,10 @@ let studioTunnelId = '';
 let travelTunnelId = '';
 let unassignedTunnelId = '';
 let crossAccountTunnelId = '';
+const LEGACY_CONNECTOR_ID = crypto.randomUUID();
+const LEGACY_CONNECTION_ID = crypto.randomUUID();
+const LEGACY_SESSION_ID = crypto.randomUUID();
+const LEGACY_USER_ID = crypto.randomUUID();
 
 const GROUP_SLUG = 'team-computers';
 const TRAVEL_SLUG = 'travel-computer';
@@ -112,9 +119,59 @@ beforeAll(async () => {
     create_only: true,
   });
   expect(created.ok).toBe(true);
+
+  await db.insert(connectors).values({
+    connectorId: LEGACY_CONNECTOR_ID,
+    accountId,
+    projectId,
+    slug: 'computer',
+    name: 'Legacy Computers',
+    providerType: 'computer',
+    config: { auth: { type: 'none', in: 'header', name: null, prefix: null } },
+    authorizationStrategy: 'project',
+  });
+  await db.insert(connectorActions).values({
+    connectorId: LEGACY_CONNECTOR_ID,
+    path: 'list_computers',
+    name: 'List computers',
+    description: 'List connected computers.',
+    inputSchema: { type: 'object', properties: {} },
+    risk: 'read',
+    binding: { kind: 'tunnel', method: 'list_computers' },
+  });
+  await db.insert(connectorConnections).values({
+    connectionId: LEGACY_CONNECTION_ID,
+    accountId,
+    projectId,
+    connectorId: LEGACY_CONNECTOR_ID,
+    label: 'Legacy default',
+    isDefault: true,
+  });
+  await db.insert(projectSessions).values({
+    sessionId: LEGACY_SESSION_ID,
+    accountId,
+    projectId,
+    branchName: LEGACY_SESSION_ID,
+    createdBy: LEGACY_USER_ID,
+    connectorBindingsConfigured: true,
+  });
+  await db.insert(projectSessionConnectorBindings).values({
+    sessionId: LEGACY_SESSION_ID,
+    accountId,
+    projectId,
+    connectorAlias: 'computer',
+    connectorId: LEGACY_CONNECTOR_ID,
+    connectionId: LEGACY_CONNECTION_ID,
+    source: 'request',
+    createdBy: LEGACY_USER_ID,
+  });
 });
 
 afterAll(async () => {
+  await db
+    .delete(projectSessionConnectorBindings)
+    .where(eq(projectSessionConnectorBindings.sessionId, LEGACY_SESSION_ID));
+  await db.delete(projectSessions).where(eq(projectSessions.sessionId, LEGACY_SESSION_ID));
   if (projectId) await db.delete(projects).where(eq(projects.projectId, projectId));
   const tunnelIds = [
     studioTunnelId,
@@ -228,6 +285,42 @@ describe('grouped Computers connector profiles — real DB', () => {
     });
   });
 
+  test('legacy aggregate is hidden from admin and unbound project principals', async () => {
+    const admin = await dbConnectorRouterDeps.listConnectors(projectId);
+    expect(admin.map((connector) => connector.slug)).not.toContain('computer');
+
+    const principal = {
+      userId: LEGACY_USER_ID,
+      accountId,
+      projectId,
+      sessionId: null,
+      subject: { userId: LEGACY_USER_ID, groupIds: [] },
+      agentGrant: null,
+    };
+    const catalog = await dbConnectorRouterDeps.listCatalog(principal);
+    expect(catalog.map((connector) => connector.slug)).not.toContain('computer');
+    const deps = dbConnectorRouterDeps.makeGatewayDeps(principal);
+    expect(await deps.loadConnectorBySlug(projectId, 'computer')).toBeNull();
+  });
+
+  test('legacy aggregate remains callable only for its exact durable session binding', async () => {
+    const principal = {
+      userId: LEGACY_USER_ID,
+      accountId,
+      projectId,
+      sessionId: LEGACY_SESSION_ID,
+      subject: { userId: LEGACY_USER_ID, groupIds: [] },
+      agentGrant: null,
+    };
+    const catalog = await dbConnectorRouterDeps.listCatalog(principal);
+    expect(catalog.map((connector) => connector.slug)).toContain('computer');
+    const deps = dbConnectorRouterDeps.makeGatewayDeps(principal);
+    expect(await deps.loadConnectorBySlug(projectId, 'computer')).toMatchObject({
+      connectorId: LEGACY_CONNECTOR_ID,
+      tunnelIds: null,
+    });
+  });
+
   test('multiple profiles can overlap and keep independent policies', async () => {
     const created = await dbConnectorRouterDeps.createConnector!(projectId, accountId, {
       slug: TRAVEL_SLUG,
@@ -308,9 +401,15 @@ describe('grouped Computers connector profiles — real DB', () => {
     const deleted = await dbConnectorRouterDeps.deleteConnector!(projectId, TRAVEL_SLUG);
     expect(deleted.ok).toBe(true);
     const remaining = await db
-      .select({ slug: connectors.slug })
+      .select({ slug: connectors.slug, config: connectors.config })
       .from(connectors)
       .where(and(eq(connectors.projectId, projectId), eq(connectors.providerType, 'computer')));
-    expect(remaining.map((row) => row.slug)).toEqual([GROUP_SLUG]);
+    expect(
+      remaining
+        .filter(
+          (row) => (row.config as Record<string, unknown> | null)?.computer_profile === true,
+        )
+        .map((row) => row.slug),
+    ).toEqual([GROUP_SLUG]);
   });
 });

--- a/apps/api/src/connectors/db-deps.ts
+++ b/apps/api/src/connectors/db-deps.ts
@@ -153,6 +153,37 @@ function computerTunnelIds(configValue: unknown, slug: string): string[] | null 
   return slug === COMPUTER_SLUG ? null : [];
 }
 
+function isLegacyComputerAggregate(row: {
+  providerType: string;
+  slug: string;
+  config: unknown;
+}): boolean {
+  if (row.providerType !== 'computer' || row.slug !== COMPUTER_SLUG) return false;
+  const config = (row.config ?? {}) as Record<string, unknown>;
+  return !Array.isArray(config.tunnel_ids) && typeof config.tunnel_id !== 'string';
+}
+
+async function principalHasLegacyComputerBinding(
+  principal: ConnectorPrincipal,
+  connectorId: string,
+): Promise<boolean> {
+  if (!principal.sessionId) return false;
+  const [binding] = await db
+    .select({ connectorId: projectSessionConnectorBindings.connectorId })
+    .from(projectSessionConnectorBindings)
+    .where(
+      and(
+        eq(projectSessionConnectorBindings.accountId, principal.accountId),
+        eq(projectSessionConnectorBindings.projectId, principal.projectId),
+        eq(projectSessionConnectorBindings.sessionId, principal.sessionId),
+        eq(projectSessionConnectorBindings.connectorAlias, COMPUTER_SLUG),
+        eq(projectSessionConnectorBindings.connectorId, connectorId),
+      ),
+    )
+    .limit(1);
+  return binding !== undefined;
+}
+
 /** How long an unconsumed human approve stays claimable by a fresh call. Long
  *  enough for the "agent gave up → approve lands → nudge/`continue` retries"
  *  round-trip, short enough that a stale yes can't silently authorize a much
@@ -451,6 +482,12 @@ export function makeDbGatewayDeps(principal: ConnectorPrincipal): GatewayDeps {
         .where(and(eq(connectors.projectId, projectId), eq(connectors.slug, slug)))
         .limit(1);
       if (!row) return null;
+      if (
+        isLegacyComputerAggregate(row) &&
+        !(await principalHasLegacyComputerBinding(principal, row.connectorId))
+      ) {
+        return null;
+      }
       const connection = await resolveActiveConnectorConnection(principal, row);
       if (!connection) return null;
       return toGatewayConnector(row, connection);
@@ -959,6 +996,12 @@ async function listCatalog(p: ConnectorPrincipal): Promise<CatalogConnector[]> {
 
   const out: CatalogConnector[] = [];
   for (const row of conns) {
+    if (
+      isLegacyComputerAggregate(row) &&
+      !(await principalHasLegacyComputerBinding(p, row.connectorId))
+    ) {
+      continue;
+    }
     // Per-agent assignment: an agent only sees connectors its grant lists —
     // consistent with the call gate, so it never lists a tool it can't invoke.
     // This is the ONLY access gate — connectors are project-wide visible to
@@ -1090,7 +1133,7 @@ async function resolveSecretReader(
 async function listConnectors(projectId: string): Promise<AdminConnectorView[]> {
   const conns = hideSupersededSlack(
     await db.select().from(connectors).where(eq(connectors.projectId, projectId)),
-  );
+  ).filter((row) => !isLegacyComputerAggregate(row));
   if (conns.length === 0) return [];
 
   const credentialRows = conns.filter((row) => {

--- a/apps/api/src/connectors/sync.ts
+++ b/apps/api/src/connectors/sync.ts
@@ -492,8 +492,8 @@ export async function syncProjectConnectors(
       if (bound) {
         if (e.providerType === 'computer' && e.slug === COMPUTER_SLUG) {
           // Existing sessions can remain durably bound to the retired aggregate
-          // connector. Keep that row executable but hide it from new catalogs
-          // and admin lists when per-machine profiles exist.
+          // connector. DB-backed catalog and call resolution expose this row only
+          // to a session with an exact durable binding.
           await db
             .update(connectors)
             .set({ enabled: true, status: 'active', updatedAt: new Date() })

--- a/docs/specs/computer-connector.md
+++ b/docs/specs/computer-connector.md
@@ -156,8 +156,11 @@ included by the connector audit reconciliation path.
 ## Compatibility and migration
 
 The original aggregate `computer` row can omit `tunnel_ids`. A null allowlist is
-accepted only for that compatibility row and means all account machines. This
-keeps durable session bindings operational while profiles migrate.
+accepted only for that compatibility row and means all account machines. The API
+hides this row from connector administration and unbound principals. Only a
+session with an exact durable binding to the row can discover or call it. This
+keeps existing sessions operational without granting legacy aggregate access to
+new sessions or project-level callers.
 
 PR #6287 briefly created one `computer-<uuid>` profile per machine. The next
 connector sync folds those generated rows into one `computer` profile with a


### PR DESCRIPTION
## Problem

PR #6292 preserved the original aggregate `computer` row for durable sessions. That row has no machine allowlist. Project-default resolution could expose it to unbound callers while a durable binding kept the row alive.

## Fix

- Hide legacy aggregate rows from connector administration.
- Hide them from unbound connector catalogs.
- Reject direct gateway resolution unless the principal session has an exact durable binding to that connector row.
- Preserve the existing bound-session compatibility path.
- Document the compatibility boundary.

## Verification

- Failing regression test reproduced the admin exposure before the fix.
- Focused real-DB integration: 12 pass, 0 fail, 35 assertions.
- API unit suite: 5988 pass, 74 skip, 0 fail, 23031 assertions.
- API typecheck: exit 0.
- Full integration suite: 456 pass, 4 skip, 1 unrelated baseline failure in `integration-agent-scope-http.test.ts`; the isolated failure also reproduces on merged `main` behavior because the CR merge route returns 404 instead of the test's expected 403.
