### PR TITLE
fix(compliance): require MFA to replace IAM factors (DCF-67)

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -40,6 +40,8 @@ jobs:
         run: terraform fmt -check -recursive infra/terraform
       - name: nacl auditor unit tests
         run: python3 infra/terraform/scripts/test_audit_nacl_admin_ports.py
+      - name: MFA enforcement policy regression tests
+        run: python3 infra/terraform/scripts/test_mfa_enforcement_policy.py
       - name: terraform validate (every root)
         run: |
           set -euo pipefail

--- a/infra/terraform/scripts/test_mfa_enforcement_policy.py
+++ b/infra/terraform/scripts/test_mfa_enforcement_policy.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Regression checks for the DCF-67 IAM MFA enforcement policy."""
+
+from pathlib import Path
+import re
+import sys
+
+
+POLICY_FILE = Path(__file__).parents[1] / "security-baseline" / "iam-groups.tf"
+SOURCE = POLICY_FILE.read_text()
+
+
+def resource_body(resource_name: str) -> str:
+    marker = f'resource "aws_iam_policy" "{resource_name}"'
+    start = SOURCE.index(marker)
+    depth = 0
+    opened = False
+    for index in range(start, len(SOURCE)):
+        if SOURCE[index] == "{":
+            depth += 1
+            opened = True
+        elif SOURCE[index] == "}":
+            depth -= 1
+            if opened and depth == 0:
+                return SOURCE[start : index + 1]
+    raise AssertionError(f"unterminated resource: {resource_name}")
+
+
+def not_actions(body: str) -> set[str]:
+    match = re.search(r"NotAction\s*=\s*\[(.*?)\]", body, re.DOTALL)
+    assert match, "mfa_required must define NotAction"
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def test_password_only_sessions_cannot_remove_mfa():
+    actions = not_actions(resource_body("mfa_required"))
+    unsafe = {"iam:DeactivateMFADevice", "iam:DeleteVirtualMFADevice"}
+    assert actions.isdisjoint(unsafe), f"non-MFA exemptions permit factor removal: {actions & unsafe}"
+
+
+def test_first_enrollment_remains_available():
+    actions = not_actions(resource_body("mfa_required"))
+    required = {
+        "iam:CreateVirtualMFADevice",
+        "iam:EnableMFADevice",
+        "iam:ListMFADevices",
+        "iam:ListVirtualMFADevices",
+        "sts:GetSessionToken",
+    }
+    assert required <= actions, f"missing first-enrollment exemptions: {required - actions}"
+
+
+def test_deny_covers_absent_and_false_mfa_context():
+    body = resource_body("mfa_required")
+    assert 'Effect = "Deny"' in body
+    assert "BoolIfExists" in body
+    assert '"aws:MultiFactorAuthPresent" = false' in body
+    assert 'Resource = "*"' in body
+
+
+if __name__ == "__main__":
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"ok   {test.__name__}")
+        except (AssertionError, ValueError) as exc:
+            print(f"FAIL {test.__name__}: {exc}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/infra/terraform/scripts/test_mfa_enforcement_policy.py
+++ b/infra/terraform/scripts/test_mfa_enforcement_policy.py
@@ -32,17 +32,21 @@ def not_actions(body: str) -> set[str]:
     return set(re.findall(r'"([^"]+)"', match.group(1)))
 
 
-def test_password_only_sessions_cannot_remove_mfa():
+def test_password_only_sessions_cannot_manage_mfa_devices():
     actions = not_actions(resource_body("mfa_required"))
-    unsafe = {"iam:DeactivateMFADevice", "iam:DeleteVirtualMFADevice"}
-    assert actions.isdisjoint(unsafe), f"non-MFA exemptions permit factor removal: {actions & unsafe}"
+    unsafe = {
+        "iam:CreateVirtualMFADevice",
+        "iam:DeleteVirtualMFADevice",
+        "iam:EnableMFADevice",
+        "iam:DeactivateMFADevice",
+        "iam:ResyncMFADevice",
+    }
+    assert actions.isdisjoint(unsafe), f"non-MFA exemptions permit factor management: {actions & unsafe}"
 
 
-def test_first_enrollment_remains_available():
+def test_non_mfa_session_can_discover_devices_and_request_session_token():
     actions = not_actions(resource_body("mfa_required"))
     required = {
-        "iam:CreateVirtualMFADevice",
-        "iam:EnableMFADevice",
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "sts:GetSessionToken",

--- a/infra/terraform/security-baseline/iam-groups.tf
+++ b/infra/terraform/security-baseline/iam-groups.tf
@@ -69,9 +69,11 @@ resource "aws_iam_policy" "mfa_self_manage" {
 # (e.g. `ino` today) can still act on every permitted resource, which is what
 # the resource-level failure flagged.
 #
-# Standard AWS MFA-enforcement pattern: Effect = Deny, NotAction = the MFA +
-# password + GetSessionToken first-enrollment surface (so a user without MFA
-# can enroll their first device and mint an MFA-authenticated session), Condition
+# MFA enforcement uses Effect = Deny and limits NotAction to read-only MFA
+# discovery, password management, and GetSessionToken. MFA device lifecycle
+# actions require an MFA-authenticated session or administrator recovery.
+# This prevents a password-only session from adding a second attacker-controlled
+# factor to a user who already has MFA. The condition is
 # BoolIfExists { aws:MultiFactorAuthPresent = false }. BoolIfExists (not Bool)
 # is deliberate: an unauthenticated STS GetSessionToken call carries no MFA
 # context at all, and BoolIfExists treats a missing key the same as false, so
@@ -100,9 +102,6 @@ resource "aws_iam_policy" "mfa_required" {
         Sid    = "DenyAllWithoutMFA"
         Effect = "Deny"
         NotAction = [
-          "iam:CreateVirtualMFADevice",
-          "iam:EnableMFADevice",
-          "iam:ResyncMFADevice",
           "iam:ListMFADevices",
           "iam:ListVirtualMFADevices",
           "iam:ChangePassword",
@@ -198,11 +197,10 @@ locals {
     # self-scoped policy keeps DCF-776 satisfied with no member named in TF.
     # See aws_iam_policy.mfa_self_manage above.
     mfa-self-manage = {
-      # Self-service MFA enrollment (Allow side) + MFA enforcement (Deny side).
-      # mfa_self_manage lets a member enroll their own MFA device + manage their
-      # login profile; mfa_required DENIES every other action until they do
-      # (DCF-67). Device removal also requires an MFA-authenticated session, so
-      # password-only sessions cannot replace an enrolled factor.
+      # Self-service MFA management (Allow side) + MFA enforcement (Deny side).
+      # mfa_required gates every MFA device lifecycle action behind an
+      # MFA-authenticated session. First enrollment and lost-device recovery
+      # therefore require an administrator instead of trusting one password.
       policies = [
         aws_iam_policy.mfa_self_manage.arn,
         aws_iam_policy.mfa_required.arn

--- a/infra/terraform/security-baseline/iam-groups.tf
+++ b/infra/terraform/security-baseline/iam-groups.tf
@@ -70,8 +70,8 @@ resource "aws_iam_policy" "mfa_self_manage" {
 # the resource-level failure flagged.
 #
 # Standard AWS MFA-enforcement pattern: Effect = Deny, NotAction = the MFA +
-# password + GetSessionToken self-enrollment surface (so a user without MFA
-# can still enroll their first device and mint an MFA'd session), Condition
+# password + GetSessionToken first-enrollment surface (so a user without MFA
+# can enroll their first device and mint an MFA-authenticated session), Condition
 # BoolIfExists { aws:MultiFactorAuthPresent = false }. BoolIfExists (not Bool)
 # is deliberate: an unauthenticated STS GetSessionToken call carries no MFA
 # context at all, and BoolIfExists treats a missing key the same as false, so
@@ -101,9 +101,7 @@ resource "aws_iam_policy" "mfa_required" {
         Effect = "Deny"
         NotAction = [
           "iam:CreateVirtualMFADevice",
-          "iam:DeleteVirtualMFADevice",
           "iam:EnableMFADevice",
-          "iam:DeactivateMFADevice",
           "iam:ResyncMFADevice",
           "iam:ListMFADevices",
           "iam:ListVirtualMFADevices",
@@ -203,8 +201,8 @@ locals {
       # Self-service MFA enrollment (Allow side) + MFA enforcement (Deny side).
       # mfa_self_manage lets a member enroll their own MFA device + manage their
       # login profile; mfa_required DENIES every other action until they do
-      # (DCF-67). Together: a user with no MFA can do exactly one thing — enroll
-      # an MFA device — and once enrolled, the deny lifts for MFA'd sessions.
+      # (DCF-67). Device removal also requires an MFA-authenticated session, so
+      # password-only sessions cannot replace an enrolled factor.
       policies = [
         aws_iam_policy.mfa_self_manage.arn,
         aws_iam_policy.mfa_required.arn


### PR DESCRIPTION
## Demo
Non-visual change. `python3 infra/terraform/scripts/test_mfa_enforcement_policy.py` passes 3/3 checks and proves password-only sessions cannot create, enable, resync, deactivate, or delete MFA devices.

## Why
PR #6289 added the DCF-67 enforcement policy, but its non-MFA exemption included factor removal. A password-only session could replace an existing MFA device.

## What changed
- Remove all MFA device lifecycle actions from the non-MFA exemption.
- Add a dependency-free regression test to Terraform CI.

## Verification
- MFA enforcement regression: 3/3 passed.
- Existing NACL regression: 9/9 passed.
- Terraform 1.9.8 `fmt -check`: passed.
- Terraform 1.9.8 `validate`: configuration is valid.

## Risk / rollback
First enrollment and lost-device recovery require administrator assistance. This avoids trusting one password to establish or replace a factor. Revert this PR to restore the weaker self-enrollment path.