### PR TITLE
fix(preview): fail closed after EKS removal

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,29 +1,10 @@
 name: Deploy Preview (PR)
 
-# ONE workflow that runs a per-PR preview environment end to end — the preview
-# analogue of deploy-dev.yml / deploy-prod.yml. Gated on the `preview` label, so
-# only opted-in PRs build + deploy; every other PR is untouched.
-#
-#   build-api  → builds kortix/kortix-api:pr-<head-sha> (FULL head SHA — matches
-#                the Argo CD ApplicationSet PullRequest generator's {{.head_sha}},
-#                which deploys it into an ephemeral kortix-pr-<number> namespace).
-#                amd64-only. Internal-branch PRs only (needs Docker Hub secrets,
-#                unavailable to forks).
-#   wire        → points the PR's Vercel preview frontend at its OWN backend
-#                (KORTIX_PUBLIC_BACKEND_URL / NEXT_PUBLIC_BACKEND_URL =
-#                https://pr-<n>.preview-api.kortix.com/v1) via branch-scoped
-#                Vercel env + a fresh preview build.
-#   teardown    → on close/unlabel, deletes the Vercel branch env. The backend
-#                image + namespace are pruned automatically by the ApplicationSet.
-#
-# The preview runs API-only against the shared dev data plane (kortix-preview-env):
-# workers off, ensureSchema skipped (INTERNAL_KORTIX_ENV=preview), preview-aware CORS.
-#
-# Secrets/vars required:
-#   secrets DOCKERHUB_USERNAME / DOCKERHUB_TOKEN  — push the preview API image
-#   secret  VERCEL_TOKEN                          — Vercel API token (Kortix team)
-#   secret  VERCEL_PROJECT_ID                      — apps/web Vercel project id (prj_…)
-#   secret  VERCEL_TEAM_ID                         — Vercel team id (team_…)
+# Per-PR backend previews previously ran on the dev EKS cluster through an Argo CD
+# ApplicationSet. Commit 11c1d2dd4 decommissioned that cluster and deleted the
+# ApplicationSet, Helm charts, and ExternalDNS configuration. Keep this workflow
+# as a failing gate until a replacement runtime exists. A green image-build check
+# would otherwise imply a rollout that no control plane can perform.
 
 on:
   pull_request:
@@ -35,7 +16,7 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write # the `announce` job posts/updates a sticky status comment
+  pull-requests: write
 
 env:
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -45,230 +26,65 @@ env:
   BRANCH: ${{ github.event.pull_request.head.ref }}
 
 jobs:
-  # ── Build the preview API image (Argo CD deploys it) ────────────────────────
-  build-api:
-    name: Build preview API image
-    if: >-
-      contains(github.event.pull_request.labels.*.name, 'preview') &&
-      contains(fromJSON('["labeled","opened","synchronize","reopened"]'), github.event.action)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          submodules: false
-      - run: git submodule sync --recursive && git submodule update --init --recursive --remote
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push :pr-<head-sha> (amd64)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: apps/api/Dockerfile
-          platforms: linux/amd64
-          push: true
-          build-args: |
-            SERVICE=apps/api
-            KORTIX_VERSION=pr-${{ github.event.pull_request.number }}
-            KORTIX_COMMIT=${{ github.event.pull_request.head.sha }}
-          tags: |
-            kortix/kortix-api:pr-${{ github.event.pull_request.head.sha }}
-      - name: Summary
-        run: |
-          {
-            echo "### Preview API image built"
-            echo "Image: \`kortix/kortix-api:pr-${{ github.event.pull_request.head.sha }}\`"
-            echo "Argo CD deploys it to \`kortix-pr-${{ github.event.pull_request.number }}\` → \`pr-${{ github.event.pull_request.number }}.preview-api.kortix.com\`."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  # ── Build the preview gateway image (Argo CD co-deploys it with the API) ────
-  # Internal-only in preview (ClusterIP, no host) — the API reverse-proxies to it,
-  # so there's no per-PR gateway URL. Same pr-<head-sha> tag the ApplicationSet
-  # pins for the kortix-gateway source.
-  build-gateway:
-    name: Build preview gateway image
-    if: >-
-      contains(github.event.pull_request.labels.*.name, 'preview') &&
-      contains(fromJSON('["labeled","opened","synchronize","reopened"]'), github.event.action)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          submodules: false
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push :pr-<head-sha> (amd64)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: apps/llm-gateway/Dockerfile
-          platforms: linux/amd64
-          push: true
-          build-args: |
-            KORTIX_VERSION=pr-${{ github.event.pull_request.number }}
-            KORTIX_COMMIT=${{ github.event.pull_request.head.sha }}
-          tags: |
-            kortix/kortix-gateway:pr-${{ github.event.pull_request.head.sha }}
-      - name: Summary
-        run: |
-          {
-            echo "### Preview gateway image built"
-            echo "Image: \`kortix/kortix-gateway:pr-${{ github.event.pull_request.head.sha }}\`"
-            echo "Argo CD co-deploys it (internal, ClusterIP) into \`kortix-pr-${{ github.event.pull_request.number }}\`."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  # ── Post a sticky PR comment + poll until the backend is actually live ──────
-  # The k8s deploy is done by Argo CD (async, outside CI), so a green build does
-  # NOT mean the preview is serving. This job posts a status comment immediately,
-  # then polls the PUBLIC health URL (reachable from the runner) until it reports
-  # environment=preview, flips the comment to ✅, and adds the Vercel frontend URL.
-  announce:
-    name: Announce preview status
+  unavailable:
+    name: Preview backend unavailable
     if: >-
       contains(github.event.pull_request.labels.*.name, 'preview') &&
       contains(fromJSON('["labeled","opened","synchronize","reopened"]'), github.event.action)
     runs-on: ubuntu-latest
     env:
-      NUM: ${{ github.event.pull_request.number }}
       GH_TOKEN: ${{ github.token }}
+      NUM: ${{ github.event.pull_request.number }}
       REPO: ${{ github.repository }}
     steps:
-      - name: Sticky status comment (deploying → live)
+      - name: Remove stale Vercel backend overrides
         run: |
-          set -uo pipefail
-          MARKER="<!-- preview-status -->"
-          HOST="pr-${NUM}.preview-api.kortix.com"
-
-          upsert() {
-            local body="$1"
-            local id
-            id=$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
-                 --jq "map(select(.body | startswith(\"${MARKER}\"))) | .[0].id // empty" | head -1)
-            if [ -n "$id" ]; then
-              gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null
-            else
-              gh api -X POST "repos/${REPO}/issues/${NUM}/comments" -f body="$body" >/dev/null
-            fi
-          }
-
-          # printf -v (direct assignment) — NOT upsert "$(printf …)": nesting a
-          # command substitution with quoted args inside the outer quotes trips
-          # bash's parser. Plain URLs (GitHub auto-links); no backticks.
-          comment() { # $1=status  $2=backend detail  $3=frontend line
-            local body
-            printf -v body '%s\n' \
-              "$MARKER" \
-              "## 🔭 Preview environment — $1" \
-              "" \
-              "- **Backend:** https://${HOST} — $2" \
-              "- **Frontend:** $3" \
-              "- **Health:** https://${HOST}/v1/health" \
-              "" \
-              "_Ephemeral; torn down automatically when this PR closes._"
-            upsert "$body"
-          }
-
-          comment "⏳ deploying" "building image + Argo CD rollout…" "wiring to the preview backend…"
-
-          status="⚠️ still rolling out after ~12m — check Argo CD at ops.kortix.com"
-          detail="not serving yet"
-          for i in $(seq 1 36); do
-            j=$(curl -s --max-time 8 "https://${HOST}/v1/health" 2>/dev/null || true)
-            envv=$(printf '%s' "$j" | jq -r '.environment // empty' 2>/dev/null || true)
-            if [ "$envv" = "preview" ]; then
-              ver=$(printf '%s' "$j" | jq -r '.version // "?"')
-              status="✅ live"; detail="serving version ${ver}"; break
-            fi
-            sleep 20
-          done
-
-          # Best-effort: resolve this branch's Vercel preview URL.
-          fline="see Vercel's preview comment for the URL"
-          if [ -n "${VERCEL_TOKEN:-}" ] && [ -n "${PROJECT_ID:-}" ] && [ -n "${TEAM_ID:-}" ]; then
-            url=$(curl -s "https://api.vercel.com/v6/deployments?projectId=${PROJECT_ID}&teamId=${TEAM_ID}&target=preview&limit=50" \
-                  -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-                  | jq -r --arg b "$BRANCH" '[.deployments[]|select(.meta.githubCommitRef==$b)]|sort_by(.created)|last|.url // empty' 2>/dev/null || true)
-            [ -n "$url" ] && fline="https://${url}"
-          fi
-
-          comment "$status" "$detail" "$fline"
-
-  # ── Point the PR's preview frontend at its preview backend ──────────────────
-  wire:
-    name: Wire preview frontend → preview backend
-    if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview'))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Guard — Vercel creds present
-        run: |
+          set -euo pipefail
           if [ -z "${VERCEL_TOKEN:-}" ] || [ -z "${PROJECT_ID:-}" ] || [ -z "${TEAM_ID:-}" ]; then
-            echo "::warning::VERCEL_TOKEN / VERCEL_PROJECT_ID / VERCEL_TEAM_ID not set — skipping frontend wiring."
+            echo "::notice::Vercel credentials are not set; no branch override cleanup was attempted."
             exit 0
           fi
-          echo "ok=true" >> "$GITHUB_ENV"
-      - name: Upsert branch-scoped backend URL env + redeploy
-        if: env.ok == 'true'
-        env:
-          NUM: ${{ github.event.pull_request.number }}
-          ACTION: ${{ github.event.action }}
-        run: |
-          set -uo pipefail
+
           AUTH=(-H "Authorization: Bearer ${VERCEL_TOKEN}")
           API="https://api.vercel.com"
-          BACKEND="https://pr-${NUM}.preview-api.kortix.com/v1"
-          echo "Wiring branch '${BRANCH}' → ${BACKEND}"
-
-          # 1) Upsert the branch-scoped Preview env vars (overwrites if they exist).
-          # apps/web reads KORTIX_PUBLIC_BACKEND_URL first, while a few older paths
-          # still read NEXT_PUBLIC_BACKEND_URL directly. Set both so the preview is
-          # consistently wired to its own backend.
+          envs="$(curl --fail --silent --show-error \
+            "${API}/v9/projects/${PROJECT_ID}/env?teamId=${TEAM_ID}" "${AUTH[@]}")"
           for key in $ENV_KEYS; do
-            code=$(curl -sS -o "/tmp/env-${key}.json" -w '%{http_code}' -X POST \
-              "${API}/v10/projects/${PROJECT_ID}/env?teamId=${TEAM_ID}&upsert=true" \
-              "${AUTH[@]}" -H "Content-Type: application/json" \
-              -d "$(jq -n --arg v "$BACKEND" --arg b "$BRANCH" --arg k "$key" \
-                    '{key:$k,value:$v,type:"plain",target:["preview"],gitBranch:$b}')")
-            echo "${key} env upsert HTTP $code"
-            [ "$code" = "200" ] || [ "$code" = "201" ] || { cat "/tmp/env-${key}.json"; exit 1; }
+            id="$(printf '%s' "$envs" | jq -r --arg k "$key" --arg b "$BRANCH" \
+              '.envs[] | select(.key==$k and .gitBranch==$b) | .id' | head -1)"
+            if [ -n "$id" ]; then
+              curl --fail --silent --show-error -X DELETE \
+                "${API}/v9/projects/${PROJECT_ID}/env/${id}?teamId=${TEAM_ID}" \
+                "${AUTH[@]}" >/dev/null
+              echo "Deleted ${key} branch override for ${BRANCH}."
+            fi
           done
 
-          # 2) On the LABEL event only, trigger a fresh preview build so the env is
-          #    baked immediately. On `synchronize` the env is already set and
-          #    Vercel's own auto-build for the push inherits it — no extra build.
-          if [ "$ACTION" = "labeled" ]; then
-            PROJ="$(curl -sS "${API}/v9/projects/${PROJECT_ID}?teamId=${TEAM_ID}" "${AUTH[@]}")"
-            NAME="$(printf '%s' "$PROJ" | jq -r '.name')"
-            REPO_ID="$(printf '%s' "$PROJ" | jq -r '.link.repoId // empty')"
-            if [ -n "$REPO_ID" ] && [ "$NAME" != "null" ]; then
-              rc=$(curl -sS -o /tmp/dep.json -w '%{http_code}' -X POST \
-                "${API}/v13/deployments?teamId=${TEAM_ID}&forceNew=1&skipAutoDetectionConfirmation=1" \
-                "${AUTH[@]}" -H "Content-Type: application/json" \
-                -d "$(jq -n --arg n "$NAME" --argjson r "$REPO_ID" --arg b "$BRANCH" \
-                      '{name:$n,target:"preview",gitSource:{type:"github",repoId:$r,ref:$b}}')")
-              echo "redeploy HTTP $rc → $(jq -r '.url // .error.message // "?"' /tmp/dep.json 2>/dev/null)"
-            else
-              echo "::notice::Couldn't resolve project repoId — env is set; the next push rebuilds with it."
-            fi
-          else
-            echo "synchronize — env re-asserted; Vercel's auto-build for this push uses it."
-          fi
-          {
-            echo "### Preview frontend wired"
-            echo "Branch \`${BRANCH}\` preview backend envs → \`${BACKEND}\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Report unavailable preview backend
+        run: |
+          set -euo pipefail
+          marker="<!-- preview-status -->"
+          printf -v body '%s\n' \
+            "$marker" \
+            "## Preview environment - unavailable" \
+            "" \
+            "The per-PR backend runtime was removed when EKS was decommissioned." \
+            "No Argo CD ApplicationSet, Kubernetes cluster, ingress, or DNS controller exists to deploy this preview." \
+            "This check fails intentionally. Do not use a Vercel frontend wired to pr-${NUM}.preview-api.kortix.com." \
+            "" \
+            "Restore previews by provisioning a replacement runtime and updating this workflow to deploy and tear it down directly."
 
-  # ── Remove the branch override when the PR closes or loses the label ────────
+          id="$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
+            --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty" | head -1)"
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null
+          else
+            gh api -X POST "repos/${REPO}/issues/${NUM}/comments" -f body="$body" >/dev/null
+          fi
+
+          echo "::error::Per-PR backend previews have no deployment runtime after EKS decommission commit 11c1d2dd4."
+          exit 1
+
   teardown:
     name: Unwire preview frontend
     if: >-
@@ -276,35 +92,41 @@ jobs:
       (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
     runs-on: ubuntu-latest
     env:
-      NUM: ${{ github.event.pull_request.number }}
       GH_TOKEN: ${{ github.token }}
+      NUM: ${{ github.event.pull_request.number }}
       REPO: ${{ github.repository }}
     steps:
       - name: Mark the sticky comment torn down
         run: |
-          set -uo pipefail
-          MARKER="<!-- preview-status -->"
-          id=$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
-               --jq "map(select(.body | startswith(\"${MARKER}\"))) | .[0].id // empty" | head -1)
-          body="$(printf '%s\n' "$MARKER" "## 🔭 Preview environment — 🧹 torn down" "" \
-                  "The preview API + namespace were pruned and the Vercel branch override removed.")"
-          if [ -n "$id" ]; then gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null; fi
+          set -euo pipefail
+          marker="<!-- preview-status -->"
+          id="$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
+            --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty" | head -1)"
+          body="$(printf '%s\n' "$marker" "## Preview environment - torn down" "" \
+            "The Vercel branch override was removed. No per-PR backend runtime exists.")"
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null
+          fi
+
       - name: Delete branch-scoped backend URL env vars
         run: |
-          set -uo pipefail
+          set -euo pipefail
           if [ -z "${VERCEL_TOKEN:-}" ] || [ -z "${PROJECT_ID:-}" ] || [ -z "${TEAM_ID:-}" ]; then
-            echo "::notice::Vercel creds not set — nothing to unwire."; exit 0
+            echo "::notice::Vercel credentials are not set; no branch override cleanup was attempted."
+            exit 0
           fi
+
           AUTH=(-H "Authorization: Bearer ${VERCEL_TOKEN}")
           API="https://api.vercel.com"
-          envs="$(curl -sS "${API}/v9/projects/${PROJECT_ID}/env?teamId=${TEAM_ID}" "${AUTH[@]}")"
+          envs="$(curl --fail --silent --show-error \
+            "${API}/v9/projects/${PROJECT_ID}/env?teamId=${TEAM_ID}" "${AUTH[@]}")"
           for key in $ENV_KEYS; do
-            ID="$(printf '%s' "$envs" | jq -r --arg k "$key" --arg b "$BRANCH" \
+            id="$(printf '%s' "$envs" | jq -r --arg k "$key" --arg b "$BRANCH" \
               '.envs[] | select(.key==$k and .gitBranch==$b) | .id' | head -1)"
-            if [ -n "$ID" ]; then
-              curl -sS -X DELETE "${API}/v9/projects/${PROJECT_ID}/env/${ID}?teamId=${TEAM_ID}" "${AUTH[@]}" >/dev/null
-              echo "deleted ${key} branch env for ${BRANCH}"
-            else
-              echo "no ${key} branch env for ${BRANCH} — nothing to delete"
+            if [ -n "$id" ]; then
+              curl --fail --silent --show-error -X DELETE \
+                "${API}/v9/projects/${PROJECT_ID}/env/${id}?teamId=${TEAM_ID}" \
+                "${AUTH[@]}" >/dev/null
+              echo "Deleted ${key} branch override for ${BRANCH}."
             fi
           done

--- a/tests/unit/preview-workflow.test.ts
+++ b/tests/unit/preview-workflow.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/deploy-preview.yml'),
+  'utf8',
+);
+
+describe('preview workflow after EKS decommission', () => {
+  it('does not claim that the removed Argo and Kubernetes runtime will deploy images', () => {
+    expect(workflow).not.toContain('docker/build-push-action');
+    expect(workflow).not.toContain('Argo CD deploys it');
+    expect(workflow).not.toContain('still rolling out');
+    expect(workflow).not.toContain('BACKEND="https://pr-${NUM}.preview-api.kortix.com/v1"');
+  });
+
+  it('fails labeled preview requests with the decommissioned dependency named', () => {
+    expect(workflow).toContain('name: Preview backend unavailable');
+    expect(workflow).toContain('EKS was decommissioned');
+    expect(workflow).toContain('exit 1');
+  });
+
+  it('removes stale Vercel branch overrides on rollout attempts and teardown', () => {
+    expect(workflow.match(/Delete branch-scoped backend URL env vars/g)).toHaveLength(1);
+    expect(workflow).toContain('name: Remove stale Vercel backend overrides');
+    expect(workflow.match(/-X DELETE/g)).toHaveLength(2);
+    expect(workflow).toContain('gitBranch==$b');
+  });
+});


### PR DESCRIPTION
## Demo
Non-visual workflow guardrail. Contract proof: the workflow no longer builds images for a deleted Argo/EKS runtime, no longer wires Vercel to unresolvable per-PR hosts, and fails immediately with the missing runtime named.

## Why
Commit `11c1d2dd4` decommissioned every EKS cluster and deleted the preview ApplicationSet, Helm charts, ingress, and ExternalDNS. `deploy-preview.yml` still claimed Argo would deploy each image, wired Vercel to an unresolvable hostname, and returned success after 36 failed probes. This affected PRs #6294 and #6295 independently of their compliance changes.

## What changed
- Replace the orphaned image-build and rollout poll with an explicit failing `Preview backend unavailable` gate.
- Remove stale Vercel branch overrides before reporting failure and during teardown.
- Update the sticky PR status with the exact missing dependencies and replacement-runtime remediation.
- Add a workflow contract test that prevents the stale Argo rollout path from returning.

## Verification
- `git diff --check` passed.
- Biome passed for `.github/workflows/deploy-preview.yml` and `tests/unit/preview-workflow.test.ts`.
- A direct contract assertion passed for removed build/wire strings, explicit failure, and both override-deletion paths.
- Full Vitest execution was blocked locally by sandbox disk exhaustion while installing optional cross-platform packages; CI runs the committed test.
- Read-only AWS evidence: no EKS clusters in checked regions; no load balancer in the former dev-EKS VPC; only fixed dev/staging ECS services.
- DNS-over-HTTPS: both affected preview hosts return `NOERROR` with no answers.

## Risk / rollback
This intentionally makes preview requests fail fast instead of reporting a false-green rollout. Revert after a replacement per-PR runtime is provisioned and this workflow deploys and tears it down directly.