### PR TITLE
fix(computers): allow personal machines in project profiles

### DIFF
--- a/apps/api/src/__tests__/e2e-connector.test.ts
+++ b/apps/api/src/__tests__/e2e-connector.test.ts
@@ -46,6 +46,7 @@ interface World {
   upstreamStatus: number;
   upstreamBody: string;
   connectorDrafts: Record<string, unknown>[];
+  connectorCreateActors: Array<string | undefined>;
   connectorCreateError: { error: string; status: number } | null;
   credentialInputs: unknown[];
   secretBindingInputs: Array<{ slug: string; secretIdentifier: string | null }>;
@@ -91,6 +92,7 @@ function freshWorld(): World {
     upstreamStatus: 200,
     upstreamBody: '{"id":"ch_1","paid":true}',
     connectorDrafts: [],
+    connectorCreateActors: [],
     connectorCreateError: null,
     credentialInputs: [],
     secretBindingInputs: [],
@@ -250,8 +252,9 @@ const deps: ConnectorRouterDeps = {
   getDiscoverConnector: async (id) => ({ item: { id }, variants: [] }),
   syncConnectors: async () => ({ synced: world.connectors.size, errors: [] }),
   discoverConnectorAuth: async () => detectedBearer,
-  createConnector: async (_projectId, _accountId, draft) => {
+  createConnector: async (_projectId, _accountId, draft, actorUserId) => {
     world.connectorDrafts.push(draft);
+    world.connectorCreateActors.push(actorUserId);
     if (world.connectorCreateError) {
       return { ok: false, ...world.connectorCreateError };
     }
@@ -560,6 +563,7 @@ describe('admin routes', () => {
     });
     expect(res.status).toBe(200);
     expect(world.connectorDrafts[0]).toMatchObject({ auth: detectedBearer.recommended });
+    expect(world.connectorCreateActors).toEqual([ALICE]);
     expect((await res.json()).authDiscovery).toEqual(detectedBearer);
   });
 

--- a/apps/api/src/__tests__/integration-computer-connector.test.ts
+++ b/apps/api/src/__tests__/integration-computer-connector.test.ts
@@ -33,6 +33,7 @@ let studioTunnelId = '';
 let travelTunnelId = '';
 let unassignedTunnelId = '';
 let crossAccountTunnelId = '';
+let personalTunnelId = '';
 const LEGACY_CONNECTOR_ID = crypto.randomUUID();
 const LEGACY_CONNECTION_ID = crypto.randomUUID();
 const LEGACY_SESSION_ID = crypto.randomUUID();
@@ -101,6 +102,13 @@ beforeAll(async () => {
         status: 'offline',
         lastHeartbeatAt: new Date(),
       },
+      {
+        accountId: LEGACY_USER_ID,
+        name: 'Personal Mac',
+        capabilities: ['filesystem', 'desktop'],
+        status: 'offline',
+        lastHeartbeatAt: new Date(),
+      },
     ])
     .returning({
       tunnelId: tunnelConnections.tunnelId,
@@ -110,6 +118,7 @@ beforeAll(async () => {
   travelTunnelId = inserted.find((row) => row.name === 'Travel Mac')!.tunnelId;
   unassignedTunnelId = inserted.find((row) => row.name === 'Unassigned Mac')!.tunnelId;
   crossAccountTunnelId = inserted.find((row) => row.name === 'Other Account Mac')!.tunnelId;
+  personalTunnelId = inserted.find((row) => row.name === 'Personal Mac')!.tunnelId;
 
   const created = await dbConnectorRouterDeps.createConnector!(projectId, accountId, {
     slug: GROUP_SLUG,
@@ -178,6 +187,7 @@ afterAll(async () => {
     travelTunnelId,
     unassignedTunnelId,
     crossAccountTunnelId,
+    personalTunnelId,
   ].filter(Boolean);
   if (tunnelIds.length) {
     await db.delete(tunnelConnections).where(inArray(tunnelConnections.tunnelId, tunnelIds));
@@ -187,6 +197,76 @@ afterAll(async () => {
 });
 
 describe('grouped Computers connector profiles — real DB', () => {
+  test('a project admin can explicitly grant their personal computer to an organization project', async () => {
+    const created = await dbConnectorRouterDeps.createConnector!(
+      projectId,
+      accountId,
+      {
+        slug: 'personal-computer',
+        name: 'Personal computer',
+        provider: 'computer',
+        tunnel_ids: [personalTunnelId],
+        create_only: true,
+      },
+      LEGACY_USER_ID,
+    );
+    expect(created.ok).toBe(true);
+
+    const [row] = await db
+      .select({ config: connectors.config })
+      .from(connectors)
+      .where(and(eq(connectors.projectId, projectId), eq(connectors.slug, 'personal-computer')));
+    expect(row?.config).toMatchObject({
+      tunnel_ids: [personalTunnelId],
+      tunnel_account_ids: [LEGACY_USER_ID],
+    });
+
+    const result = await executeComputerCall({
+      accountId,
+      projectId,
+      allowedTunnelIds: [personalTunnelId],
+      allowedTunnelAccountIds: [LEGACY_USER_ID],
+      selector: null,
+      method: 'list_computers',
+      args: {},
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        computers: [
+          expect.objectContaining({
+            id: personalTunnelId,
+            name: 'Personal Mac',
+          }),
+        ],
+      },
+    });
+
+    const deleted = await dbConnectorRouterDeps.deleteConnector!(projectId, 'personal-computer');
+    expect(deleted.ok).toBe(true);
+  });
+
+  test('a project admin cannot grant a computer owned by another account', async () => {
+    const created = await dbConnectorRouterDeps.createConnector!(
+      projectId,
+      accountId,
+      {
+        slug: 'forged-computer',
+        name: 'Forged computer',
+        provider: 'computer',
+        tunnel_ids: [crossAccountTunnelId],
+        create_only: true,
+      },
+      LEGACY_USER_ID,
+    );
+    expect(created).toEqual({
+      ok: false,
+      error:
+        'One or more selected computers are no longer available. Refresh the list or pair the computer again.',
+      status: 400,
+    });
+  });
+
   test('stores one regular connector with two assigned machine ids and the full catalog', async () => {
     const [row] = await db
       .select()

--- a/apps/api/src/__tests__/unit-connector-computers.test.ts
+++ b/apps/api/src/__tests__/unit-connector-computers.test.ts
@@ -96,6 +96,7 @@ const COMPUTER: GatewayConnector = {
   slug: 'studio-computers',
   provider: 'computer',
   tunnelIds: ['11111111-1111-4111-8111-111111111111', '22222222-2222-4222-8222-222222222222'],
+  tunnelAccountIds: ['acct-1', 'personal-account-1'],
   baseUrl: null,
   auth: { type: 'none', in: 'header', name: null, prefix: null },
   hasAuth: false, // no credential — the relay is the credential
@@ -170,6 +171,7 @@ describe('handleCall — computer (tunnel)', () => {
         '11111111-1111-4111-8111-111111111111',
         '22222222-2222-4222-8222-222222222222',
       ],
+      allowedTunnelAccountIds: ['acct-1', 'personal-account-1'],
       selector: '22222222-2222-4222-8222-222222222222',
       method: 'fs.read',
       args: { path: '/tmp/x' },

--- a/apps/api/src/connectors/computer-materialize.ts
+++ b/apps/api/src/connectors/computer-materialize.ts
@@ -26,6 +26,7 @@ export function computerProfileSpec(input: {
   slug: string;
   name: string;
   tunnelIds: string[];
+  tunnelAccountIds: string[];
   sensitive?: boolean;
 }): ConnectorSpec {
   return {
@@ -46,6 +47,7 @@ export function computerProfileSpec(input: {
     platform: null,
     spec: null,
     tunnelIds: [...new Set(input.tunnelIds)],
+    tunnelAccountIds: [...new Set(input.tunnelAccountIds)],
     auth: {
       type: 'none',
       in: 'header',
@@ -67,6 +69,20 @@ function storedTunnelIds(configValue: unknown): string[] | null {
   }
   if (typeof config.tunnel_id === 'string') return [config.tunnel_id];
   return null;
+}
+
+function storedTunnelAccountIds(configValue: unknown, fallbackAccountId: string): string[] {
+  const config = (configValue ?? {}) as Record<string, unknown>;
+  if (Array.isArray(config.tunnel_account_ids)) {
+    return [
+      ...new Set(
+        config.tunnel_account_ids.filter(
+          (value): value is string => typeof value === 'string' && value.length > 0,
+        ),
+      ),
+    ];
+  }
+  return [fallbackAccountId];
 }
 
 function isExplicitProfile(configValue: unknown): boolean {
@@ -108,6 +124,7 @@ export async function synthesizeComputerConnectors(
         slug: row.slug,
         name: row.name,
         tunnelIds: storedTunnelIds(row.config) ?? [],
+        tunnelAccountIds: storedTunnelAccountIds(row.config, proj.accountId),
         sensitive: (row.config as { sensitive?: unknown } | null)?.sensitive === true,
       }),
     )
@@ -135,6 +152,7 @@ export async function synthesizeComputerConnectors(
       slug: COMPUTER_SLUG,
       name: aggregate?.name || computerLabel(),
       tunnelIds,
+      tunnelAccountIds: [proj.accountId],
       sensitive: (aggregate?.config as { sensitive?: unknown } | null)?.sensitive === true,
     }),
   ];

--- a/apps/api/src/connectors/db-deps.ts
+++ b/apps/api/src/connectors/db-deps.ts
@@ -153,6 +153,24 @@ function computerTunnelIds(configValue: unknown, slug: string): string[] | null 
   return slug === COMPUTER_SLUG ? null : [];
 }
 
+function computerTunnelAccountIds(
+  configValue: unknown,
+  projectAccountId: string,
+  slug: string,
+): string[] | null {
+  const config = (configValue ?? {}) as Record<string, unknown>;
+  if (Array.isArray(config.tunnel_account_ids)) {
+    return [
+      ...new Set(
+        config.tunnel_account_ids.filter(
+          (value): value is string => typeof value === 'string' && value.length > 0,
+        ),
+      ),
+    ];
+  }
+  return slug === COMPUTER_SLUG && !Array.isArray(config.tunnel_ids) ? null : [projectAccountId];
+}
+
 function isLegacyComputerAggregate(row: {
   providerType: string;
   slug: string;
@@ -432,6 +450,10 @@ function toGatewayConnector(
     platform: channelPlatform(row.config),
     tunnelIds:
       row.providerType === 'computer' ? computerTunnelIds(row.config, row.slug) : undefined,
+    tunnelAccountIds:
+      row.providerType === 'computer'
+        ? computerTunnelAccountIds(row.config, row.accountId, row.slug)
+        : undefined,
     baseUrl: baseUrlOf(row),
     auth,
     headers: headersOf(row),
@@ -608,6 +630,7 @@ export function makeDbGatewayDeps(principal: ConnectorPrincipal): GatewayDeps {
       sessionId,
       actorUserId,
       allowedTunnelIds,
+      allowedTunnelAccountIds,
       selector,
       method,
       args,
@@ -618,6 +641,7 @@ export function makeDbGatewayDeps(principal: ConnectorPrincipal): GatewayDeps {
         sessionId,
         actorUserId,
         allowedTunnelIds,
+        allowedTunnelAccountIds,
         selector,
         method,
         args,
@@ -1519,6 +1543,7 @@ async function upsertComputerConnectorProfile(
   projectId: string,
   accountId: string,
   draft: Record<string, unknown>,
+  actorUserId?: string,
 ): Promise<ConnectorCrudResult | null> {
   if (draft.provider !== 'computer') return null;
   const slug = typeof draft.slug === 'string' ? draft.slug.trim() : '';
@@ -1549,12 +1574,16 @@ async function upsertComputerConnectorProfile(
       status: 400,
     };
   }
+  const eligibleAccountIds = [...new Set([accountId, actorUserId].filter(Boolean) as string[])];
   const owned = await db
-    .select({ tunnelId: tunnelConnections.tunnelId })
+    .select({
+      tunnelId: tunnelConnections.tunnelId,
+      accountId: tunnelConnections.accountId,
+    })
     .from(tunnelConnections)
     .where(
       and(
-        eq(tunnelConnections.accountId, accountId),
+        inArray(tunnelConnections.accountId, eligibleAccountIds),
         inArray(tunnelConnections.tunnelId, tunnelIds),
         isNotNull(tunnelConnections.lastHeartbeatAt),
       ),
@@ -1562,10 +1591,12 @@ async function upsertComputerConnectorProfile(
   if (owned.length !== tunnelIds.length) {
     return {
       ok: false,
-      error: 'every selected computer must belong to this account and have connected before',
+      error:
+        'One or more selected computers are no longer available. Refresh the list or pair the computer again.',
       status: 400,
     };
   }
+  const tunnelAccountIds = [...new Set(owned.map((row) => row.accountId))];
 
   const [existing] = await db
     .select({
@@ -1602,6 +1633,7 @@ async function upsertComputerConnectorProfile(
       slug,
       name,
       tunnelIds,
+      tunnelAccountIds,
       sensitive: (existing?.config as { sensitive?: unknown } | null)?.sensitive === true,
     }),
   });
@@ -1667,8 +1699,8 @@ export const dbConnectorRouterDeps: ConnectorRouterDeps = {
     invalidateProjectMirror(projectId);
     return syncProjectConnectors(projectId, accountId, { force: true });
   },
-  createConnector: async (projectId, accountId, draft) =>
-    (await upsertComputerConnectorProfile(projectId, accountId, draft)) ??
+  createConnector: async (projectId, accountId, draft, actorUserId) =>
+    (await upsertComputerConnectorProfile(projectId, accountId, draft, actorUserId)) ??
     upsertConnectorInManifest(projectId, accountId, draft as unknown as ConnectorDraft),
   deleteConnector: async (projectId, slug) =>
     (await deleteComputerConnectorProfile(projectId, slug)) ??

--- a/apps/api/src/connectors/gateway.ts
+++ b/apps/api/src/connectors/gateway.ts
@@ -50,6 +50,8 @@ export interface GatewayConnector {
   platform?: string | null;
   /** Server-side machine allowlist for a Computers connector profile. */
   tunnelIds?: string[] | null;
+  /** Verified machine-owner accounts paired with the Computers allowlist. */
+  tunnelAccountIds?: string[] | null;
   /** server / base_url / endpoint / url, per provider (null for some). */
   baseUrl: string | null;
   auth: ConnectorAuth;
@@ -192,8 +194,8 @@ export interface GatewayDeps {
   }): Promise<ExecResult>;
   /**
    * Computer (Agent Computer Tunnel) execution — required for `computer`
-   * connectors. Verifies the selected machine belongs to both `accountId` and
-   * the connector profile allowlist, then relays through the tunnel core.
+   * connectors. Verifies the selected machine belongs to the connector's
+   * stored id + owner-account grant, then relays through the tunnel core.
    */
   executeComputerCall?(input: {
     accountId: string;
@@ -201,6 +203,7 @@ export interface GatewayDeps {
     sessionId: string | null;
     actorUserId: string;
     allowedTunnelIds: string[] | null;
+    allowedTunnelAccountIds: string[] | null;
     selector: string | null;
     method: string;
     args: Record<string, unknown>;
@@ -649,6 +652,7 @@ export async function handleCall(deps: GatewayDeps, input: CallInput): Promise<C
         sessionId: input.sessionId ?? null,
         actorUserId: input.subject.userId,
         allowedTunnelIds: connector.tunnelIds ?? null,
+        allowedTunnelAccountIds: connector.tunnelAccountIds ?? null,
         selector,
         method: action.binding.method,
         args: callArgs,

--- a/apps/api/src/connectors/materialize.ts
+++ b/apps/api/src/connectors/materialize.ts
@@ -65,6 +65,7 @@ export function connectorConfig(
         // `none` auth so authOf() resolves hasAuth=false.
         return {
           tunnel_ids: spec.tunnelIds ?? (spec.tunnelId ? [spec.tunnelId] : []),
+          tunnel_account_ids: spec.tunnelAccountIds ?? [],
           computer_profile: true,
           auth: { type: 'none', in: 'header', name: null, prefix: null },
         };

--- a/apps/api/src/connectors/router.ts
+++ b/apps/api/src/connectors/router.ts
@@ -261,6 +261,7 @@ export interface ConnectorRouterDeps {
     projectId: string,
     accountId: string,
     draft: Record<string, unknown>,
+    actorUserId?: string,
   ): Promise<CrudOutcome>;
   discoverConnectorAuth?(
     projectId: string,
@@ -1116,7 +1117,7 @@ export function createConnectorRouter(deps: ConnectorRouterDeps): OpenAPIHono {
         }
       }
       try {
-        const result = await deps.createConnector(projectId, admin.accountId, body);
+        const result = await deps.createConnector(projectId, admin.accountId, body, admin.userId);
         return result.ok
           ? c.json({ ok: true, sync: result.sync, authDiscovery })
           : c.json(result.body ?? { error: result.error }, result.status as 400 | 403 | 409 | 502);

--- a/apps/api/src/projects/connectors.ts
+++ b/apps/api/src/projects/connectors.ts
@@ -198,8 +198,10 @@ export interface ConnectorSpec {
   platform: ChannelPlatform | null;
   /** computer: legacy single-machine binding. */
   tunnelId?: string | null;
-  /** computer: account-scoped machine allowlist for this profile. */
+  /** computer: profile-scoped machine allowlist. */
   tunnelIds?: string[] | null;
+  /** computer: verified owner accounts for the selected machine allowlist. */
+  tunnelAccountIds?: string[] | null;
   /** openapi/postman/graphql/http: a URL or repo-relative file path. Optional for graphql. */
   spec: string | null;
   // ── shared ──

--- a/apps/api/src/tunnel/core/rpc-core.ts
+++ b/apps/api/src/tunnel/core/rpc-core.ts
@@ -70,6 +70,8 @@ export function resolveCapability(method: string): TunnelCapability | null {
  */
 export async function executeTunnelRpc(input: {
   tunnelId: string;
+  /** Physical machine owner. Defaults to the audit/project account. */
+  tunnelOwnerAccountId?: string;
   accountId: string;
   projectId?: string | null;
   sessionId?: string | null;
@@ -164,7 +166,7 @@ export async function executeTunnelRpc(input: {
   try {
     result = await relayRpcToConnectedAgent({
       tunnelId,
-      accountId,
+      accountId: input.tunnelOwnerAccountId ?? accountId,
       method,
       params: {
         ...params,
@@ -239,26 +241,37 @@ export interface ComputerMachine {
   platform: string | null;
 }
 
+interface ResolvedComputerMachine extends ComputerMachine {
+  ownerAccountId: string;
+}
+
 /** List assigned account machines with DB-backed online status. Null is legacy all-account access. */
 export async function listAccountComputers(
   accountId: string,
   allowedTunnelIds: readonly string[] | null = null,
-): Promise<ComputerMachine[]> {
+  allowedTunnelAccountIds: readonly string[] | null = null,
+): Promise<ResolvedComputerMachine[]> {
   const allowed = allowedTunnelIds === null ? null : [...new Set(allowedTunnelIds)];
   if (allowed?.length === 0) return [];
+  const allowedAccounts =
+    allowed === null
+      ? [accountId]
+      : [...new Set(allowedTunnelAccountIds?.length ? allowedTunnelAccountIds : [accountId])];
+  if (allowedAccounts.length === 0) return [];
   const rows = await db
     .select()
     .from(tunnelConnections)
     .where(
       allowed
         ? and(
-            eq(tunnelConnections.accountId, accountId),
+            inArray(tunnelConnections.accountId, allowedAccounts),
             inArray(tunnelConnections.tunnelId, allowed),
           )
         : eq(tunnelConnections.accountId, accountId),
     );
   return rows.map((r) => ({
     id: r.tunnelId,
+    ownerAccountId: r.accountId,
     name: r.name,
     online: isTunnelConnectionLive(r),
     capabilities: Array.isArray(r.capabilities) ? (r.capabilities as string[]) : [],
@@ -267,11 +280,13 @@ export async function listAccountComputers(
   }));
 }
 
-type ResolveResult = { ok: true; tunnelId: string } | { ok: false; message: string };
+type ResolveResult =
+  | { ok: true; tunnelId: string; tunnelOwnerAccountId: string }
+  | { ok: false; message: string };
 
 /** Resolve a selector inside one connector profile's already-filtered machine set. */
 async function resolveComputerTunnel(
-  machines: ComputerMachine[],
+  machines: ResolvedComputerMachine[],
   selector: string | null,
 ): Promise<ResolveResult> {
   if (machines.length === 0) {
@@ -282,9 +297,22 @@ async function resolveComputerTunnel(
   }
   if (selector) {
     const byId = machines.find((m) => m.id === selector);
-    if (byId) return { ok: true, tunnelId: byId.id };
+    if (byId) {
+      return {
+        ok: true,
+        tunnelId: byId.id,
+        tunnelOwnerAccountId: byId.ownerAccountId,
+      };
+    }
     const byName = machines.filter((m) => m.name.toLowerCase() === selector.toLowerCase());
-    if (byName.length === 1) return { ok: true, tunnelId: byName[0]!.id };
+    const [byNameMachine] = byName;
+    if (byNameMachine && byName.length === 1) {
+      return {
+        ok: true,
+        tunnelId: byNameMachine.id,
+        tunnelOwnerAccountId: byNameMachine.ownerAccountId,
+      };
+    }
     if (byName.length > 1) {
       return {
         ok: false,
@@ -297,7 +325,14 @@ async function resolveComputerTunnel(
     };
   }
   const online = machines.filter((m) => m.online);
-  if (online.length === 1) return { ok: true, tunnelId: online[0]!.id };
+  const [onlineMachine] = online;
+  if (onlineMachine && online.length === 1) {
+    return {
+      ok: true,
+      tunnelId: onlineMachine.id,
+      tunnelOwnerAccountId: onlineMachine.ownerAccountId,
+    };
+  }
   if (online.length === 0) {
     return {
       ok: false,
@@ -334,19 +369,31 @@ export async function executeComputerCall(input: {
   actorUserId?: string | null;
   /** Null is accepted only for legacy aggregate rows and means all account machines. */
   allowedTunnelIds: string[] | null;
+  /** Verified owner accounts stored with an explicit profile. */
+  allowedTunnelAccountIds?: string[] | null;
   selector: string | null;
   method: string;
   args: Record<string, unknown>;
 }): Promise<ComputerCallOutcome> {
-  const machines = await listAccountComputers(input.accountId, input.allowedTunnelIds);
+  const machines = await listAccountComputers(
+    input.accountId,
+    input.allowedTunnelIds,
+    input.allowedTunnelAccountIds,
+  );
   if (input.method === 'list_computers') {
-    return { ok: true, data: { computers: machines } };
+    return {
+      ok: true,
+      data: {
+        computers: machines.map(({ ownerAccountId: _ownerAccountId, ...machine }) => machine),
+      },
+    };
   }
   const resolved = await resolveComputerTunnel(machines, input.selector);
   if (!resolved.ok) return { ok: false, kind: 'no_machine', message: resolved.message };
 
   const outcome = await executeTunnelRpc({
     tunnelId: resolved.tunnelId,
+    tunnelOwnerAccountId: resolved.tunnelOwnerAccountId,
     accountId: input.accountId,
     projectId: input.projectId,
     sessionId: input.sessionId,

--- a/apps/web/src/features/tunnel/tunnel-connect-panel.tsx
+++ b/apps/web/src/features/tunnel/tunnel-connect-panel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { CheckIcon, CopyIcon } from '@phosphor-icons/react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/components/ui/button';
+import { InlineMeta } from '@/components/ui/inline-meta';
+import { useCopy } from '@/hooks/use-copy';
+import { getEnv } from '@/lib/env-config';
+import { buildTunnelConnectCommand } from './tunnel-connect-command';
+
+function ConnectSteps() {
+  const tHardcodedUi = useTranslations('hardcodedUi');
+
+  return (
+    <InlineMeta className="justify-center text-pretty">
+      {tHardcodedUi.raw('componentsTunnelTunnelOverview.line203JsxTextText1RunTheCommand')}
+      {tHardcodedUi.raw('componentsTunnelTunnelOverview.line205JsxTextText2ApproveInBrowser')}
+      {tHardcodedUi.raw('componentsTunnelTunnelOverview.line207JsxTextText3Connected')}
+    </InlineMeta>
+  );
+}
+
+export function ConnectCommandPanel() {
+  const command = buildTunnelConnectCommand({
+    backendUrl: getEnv().BACKEND_URL || '',
+    origin: typeof window !== 'undefined' ? window.location.origin : '',
+  });
+  const { copied, copy } = useCopy({
+    successMessage: 'Command copied',
+    errorMessage: 'Copy failed',
+    duration: 2000,
+  });
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="bg-popover overflow-hidden rounded-md border">
+        <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+          <span className="text-muted-foreground text-xs">Install command</span>
+        </div>
+        <div className="bg-secondary relative rounded-t-md">
+          <Button
+            type="button"
+            variant="accent"
+            size="xs"
+            onClick={() => copy(command)}
+            aria-label={copied ? 'Copied' : 'Copy command'}
+            className="absolute top-2 right-2 shrink-0 transition-transform active:scale-[0.96]"
+          >
+            <span className="relative inline-flex size-3.5 items-center justify-center">
+              <AnimatePresence initial={false} mode="popLayout">
+                <motion.span
+                  key={copied ? 'check' : 'copy'}
+                  initial={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+                  animate={{ scale: 1, opacity: 1, filter: 'blur(0px)' }}
+                  exit={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+                  transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
+                  className="absolute inset-0 inline-flex items-center justify-center"
+                >
+                  {copied ? (
+                    <CheckIcon className="text-kortix-green size-3.5" />
+                  ) : (
+                    <CopyIcon className="text-muted-foreground size-3.5" />
+                  )}
+                </motion.span>
+              </AnimatePresence>
+            </span>
+          </Button>
+
+          <pre className="text-foreground/90 overflow-x-auto px-4 py-3 text-left font-mono text-xs leading-relaxed break-all whitespace-pre-wrap">
+            {command}
+          </pre>
+        </div>
+      </div>
+      <ConnectSteps />
+    </div>
+  );
+}

--- a/apps/web/src/features/tunnel/tunnel-overview.tsx
+++ b/apps/web/src/features/tunnel/tunnel-overview.tsx
@@ -3,8 +3,6 @@
 import { formatRelative } from '@kortix/shared';
 import {
   PlugsConnectedIcon as Cable,
-  CheckIcon as Check,
-  CopyIcon as Copy,
   MonitorIcon as Monitor,
   MagnifyingGlassIcon as Search,
 } from '@phosphor-icons/react';
@@ -21,7 +19,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { Button, buttonVariants } from '@/components/ui/button';
+import { buttonVariants } from '@/components/ui/button';
 import {
   Empty,
   EmptyContent,
@@ -54,63 +52,10 @@ import {
   type TunnelConnection,
 } from '@/hooks/tunnel/use-tunnel';
 import { useTunnelRealtimeSync } from '@/hooks/tunnel/use-tunnel-realtime';
-import { useCopy } from '@/hooks/use-copy';
-import { getEnv } from '@/lib/env-config';
 import { cn } from '@/lib/utils';
-import { buildTunnelConnectCommand } from './tunnel-connect-command';
+import { ConnectCommandPanel } from './tunnel-connect-panel';
 import { TunnelPermissionRequestDialog } from './tunnel-permission-request-dialog';
 import { TunnelSettingsDialog } from './tunnel-settings-dialog';
-
-function ConnectSteps() {
-  const tHardcodedUi = useTranslations('hardcodedUi');
-
-  return (
-    <InlineMeta className="justify-center text-pretty">
-      {tHardcodedUi.raw('componentsTunnelTunnelOverview.line203JsxTextText1RunTheCommand')}
-      {tHardcodedUi.raw('componentsTunnelTunnelOverview.line205JsxTextText2ApproveInBrowser')}
-      {tHardcodedUi.raw('componentsTunnelTunnelOverview.line207JsxTextText3Connected')}
-    </InlineMeta>
-  );
-}
-
-function ConnectCommandPanel() {
-  const command = getConnectCommand();
-  const { copied, copy } = useCopy({
-    successMessage: 'Command copied',
-    errorMessage: 'Copy failed',
-    duration: 2000,
-  });
-
-  return (
-    <div className="w-full space-y-4">
-      <div className="bg-popover overflow-hidden rounded-md border">
-        <div className="flex items-center justify-between gap-3 px-4 py-2.5">
-          <span className="text-muted-foreground text-xs">Install command</span>
-        </div>
-        <div className="bg-secondary relative rounded-t-md">
-          <Button
-            type="button"
-            variant="accent"
-            size="xs"
-            onClick={() => copy(command)}
-            className="absolute top-2 right-2 shrink-0"
-          >
-            {copied ? (
-              <Check className="text-muted-foreground size-3.5" />
-            ) : (
-              <Copy className="text-muted-foreground size-3.5" />
-            )}
-          </Button>
-
-          <pre className="text-foreground/90 overflow-x-auto px-4 py-3 text-left font-mono text-xs leading-relaxed break-all whitespace-pre-wrap">
-            {command}
-          </pre>
-        </div>
-      </div>
-      <ConnectSteps />
-    </div>
-  );
-}
 
 function LoadingSkeleton() {
   return (
@@ -168,7 +113,7 @@ export function TunnelOverview({ canWrite = false }: { canWrite?: boolean }) {
     <>
       <CustomizeSectionWrapper
         title="Computers"
-        description="Connect local machines and grant agents permissioned access over a reverse tunnel."
+        description="Connect Macs, Windows PCs, and Linux machines through the secure Kortix Agent Tunnel, then control agent permissions for each machine."
       >
         {hasConnections && canWrite && (
           <div className="flex items-center justify-between gap-3">
@@ -316,13 +261,6 @@ export function TunnelOverview({ canWrite = false }: { canWrite?: boolean }) {
       <TunnelPermissionRequestDialog />
     </>
   );
-}
-
-function getConnectCommand(): string {
-  return buildTunnelConnectCommand({
-    backendUrl: getEnv().BACKEND_URL || '',
-    origin: typeof window !== 'undefined' ? window.location.origin : '',
-  });
 }
 
 function DeleteConnectionDialog({

--- a/apps/web/src/features/workspace/capabilities/connectors/add/computers-add-flow.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/add/computers-add-flow.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(join(import.meta.dir, 'computers-add-flow.tsx'), 'utf8');
+const catalogSource = readFileSync(join(import.meta.dir, '../catalog/catalog-entry.ts'), 'utf8');
+
+describe('Computers add flow discovery and pairing', () => {
+  test('explains the Kortix Agent Tunnel before machine selection', () => {
+    expect(source).toMatch(/Kortix\s+Agent Tunnel/);
+    expect(catalogSource).toContain('Kortix Agent Tunnel');
+  });
+
+  test('can pair another computer without leaving profile setup', () => {
+    expect(source).toContain('Pair another computer');
+    expect(source).toContain('<ConnectCommandPanel');
+  });
+
+  test('links to fleet management for existing computer settings', () => {
+    expect(source).toContain('Manage computers');
+    expect(source).toContain('`/projects/${projectId}/customize/computers`');
+  });
+});

--- a/apps/web/src/features/workspace/capabilities/connectors/add/computers-add-flow.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/add/computers-add-flow.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { createConnector } from '@kortix/sdk';
-import { MonitorIcon } from '@phosphor-icons/react';
+import { CaretDownIcon, MonitorIcon } from '@phosphor-icons/react';
 import { useMutation } from '@tanstack/react-query';
+import Link from 'next/link';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import Loading from '@/components/ui/loading';
@@ -19,6 +21,7 @@ import {
   ModalTitle,
 } from '@/components/ui/modal';
 import { errorToast, successToast } from '@/components/ui/toast';
+import { ConnectCommandPanel } from '@/features/tunnel/tunnel-connect-panel';
 import { ComputerMachineSelector } from '@/features/workspace/capabilities/connectors/detail/computer-connector-account';
 import {
   isConnectorConnectionSlugAvailable,
@@ -67,6 +70,7 @@ function ComputersAddFlowContent({
   const [name, setName] = useState('Computers');
   const [slug, setSlug] = useState(initialSlug);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [pairingOpen, setPairingOpen] = useState(false);
 
   const add = useMutation({
     mutationFn: () =>
@@ -100,7 +104,8 @@ function ComputersAddFlowContent({
             <div className="min-w-0 space-y-1">
               <ModalTitle>Add Computers</ModalTitle>
               <ModalDescription>
-                Select the paired machines this connector profile can access.
+                Computers connects Macs, Windows PCs, and Linux machines through the secure Kortix
+                Agent Tunnel. Select which machines agents can access.
               </ModalDescription>
             </div>
           </div>
@@ -141,11 +146,16 @@ function ComputersAddFlowContent({
             </FieldGroup>
 
             <section className="space-y-2">
-              <div className="space-y-1">
-                <FieldLabel>Computers</FieldLabel>
-                <p className="text-muted-foreground text-xs text-pretty">
-                  You can select one machine or create a shared profile for several machines.
-                </p>
+              <div className="flex items-end justify-between gap-3">
+                <div className="space-y-1">
+                  <FieldLabel>Computers</FieldLabel>
+                  <p className="text-muted-foreground text-xs text-pretty">
+                    Select one machine or create a shared profile for several machines.
+                  </p>
+                </div>
+                <Button asChild variant="outline" size="sm" className="shrink-0">
+                  <Link href={`/projects/${projectId}/customize/computers`}>Manage computers</Link>
+                </Button>
               </div>
               <ComputerMachineSelector
                 selectedIds={selectedIds}
@@ -153,6 +163,29 @@ function ComputersAddFlowContent({
                 disabled={add.isPending}
               />
             </section>
+
+            <Disclosure
+              variant="outline"
+              className="overflow-hidden"
+              open={pairingOpen}
+              onOpenChange={setPairingOpen}
+            >
+              <DisclosureTrigger variant="outline">
+                <Button
+                  type="button"
+                  variant="popover"
+                  className="flex w-full items-center justify-between rounded-none px-4"
+                >
+                  <span className="text-sm font-medium">Pair another computer</span>
+                  <CaretDownIcon className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+                </Button>
+              </DisclosureTrigger>
+              <DisclosureContent variant="outline" contentClassName="border-border border-t">
+                <div className="px-4 py-5">
+                  <ConnectCommandPanel />
+                </div>
+              </DisclosureContent>
+            </Disclosure>
           </ModalBody>
           <ModalFooter>
             <Button

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.ts
@@ -47,7 +47,8 @@ export function computersCatalogEntry(): CatalogEntry {
     key: 'computer:computers',
     slug: 'computers',
     name: 'Computers',
-    description: 'Use selected local machines through the secure Kortix tunnel.',
+    description:
+      'Connect Macs, Windows PCs, and Linux machines through the secure Kortix Agent Tunnel, then choose which machines agents can access.',
     icon: null,
     categories: ['developer-tools'],
     popularity: null,

--- a/docs/specs/computer-connector.md
+++ b/docs/specs/computer-connector.md
@@ -7,8 +7,8 @@
 ## Goal
 
 Treat Computers as one regular connector provider. A connector profile selects
-one or more account-owned machines. Connector grants, tool policies, audit, and
-session exposure apply to the profile.
+one or more machines that the project account or profile creator owns. Connector
+grants, tool policies, audit, and session exposure apply to the profile.
 
 The Computers page remains the account fleet surface. It pairs machines, shows
 online state, and manages tunnel capability permissions. Pairing does not grant
@@ -21,6 +21,7 @@ any project access.
 - One machine can belong to multiple connector profiles.
 - A project can contain multiple profiles with different or overlapping sets.
 - The connector config stores selected machine ids in `tunnel_ids`.
+- The connector config stores verified machine owner ids in `tunnel_account_ids`.
 - Every profile exposes `list_computers`.
 - `list_computers` returns only machines assigned to that profile.
 - Every machine action accepts an optional `computer` name or id selector.
@@ -43,6 +44,7 @@ authorization_strategy project
 auth.type               none
 config.computer_profile true
 config.tunnel_ids       [<tunnel uuid>, ...]
+config.tunnel_account_ids [<owner account uuid>, ...]
 ```
 
 The user chooses the connector name and slug. The first suggested slug is
@@ -56,8 +58,13 @@ DB-backed profiles.
 The API validates every selected machine:
 
 1. The profile contains between 1 and 100 unique UUIDs.
-2. Every UUID belongs to the project's account.
+2. Every UUID belongs to the project account or the profile creator's personal account.
 3. Every selected machine completed at least one tunnel connection.
+
+The API resolves machine ownership during profile creation. It stores the
+verified owner account ids in `tunnel_account_ids`. Runtime calls use both
+`tunnel_ids` and `tunnel_account_ids`. A client cannot grant an arbitrary owner
+account by adding it to the request.
 
 An empty set fails closed. Pairing a machine creates only a fleet record. It
 does not create a connector profile or grant access to a project.
@@ -88,8 +95,9 @@ kortix connectors call studio-computers.fs.read \
 
 ## Execution
 
-The gateway loads `config.tunnel_ids` from the materialized connector. It passes
-that server-side allowlist and the optional selector to `executeComputerCall`.
+The gateway loads `config.tunnel_ids` and `config.tunnel_account_ids` from the
+materialized connector. It passes both server-side allowlists and the optional
+selector to `executeComputerCall`.
 
 ```text
 connector call
@@ -102,10 +110,11 @@ connector call
   -> tunnel audit and connector audit
 ```
 
-`listAccountComputers` applies the profile allowlist and `account_id` in the same
-database query. `list_computers` returns that filtered result. Other actions
+`listAccountComputers` applies the machine and verified owner allowlists in the
+same database query. `list_computers` returns that filtered result. Other actions
 resolve their selector only against that result. An unassigned, deleted, or
-cross-account machine returns `no_machine` before tunnel permission evaluation.
+unverified cross-account machine returns `no_machine` before tunnel permission
+evaluation.
 
 The direct `POST /v1/tunnel/rpc/:tunnelId` route and connector execution share
 `executeTunnelRpc`. Rate limits, tunnel permissions, relay errors, and tunnel
@@ -184,3 +193,5 @@ updated profiles always store `config.tunnel_ids`.
 10. Audit actions use `connector.computer.*` under the Connectors category.
 11. The Accounts tab can create and update one-machine and multi-machine sets.
 12. The deployed UI shows Computers in the normal connector catalog.
+13. A project admin can grant a computer from their personal account to an organization project.
+14. A machine owned by any other account fails closed.


### PR DESCRIPTION
## Summary

- allow a project admin to select computers paired to their personal account
- persist verified machine-owner account IDs with each Computers profile
- preserve fail-closed runtime filtering for unassigned and third-party machines
- add fleet management and inline pairing controls to the Computers setup modal
- explain the Kortix Agent Tunnel on the catalog, setup, and fleet surfaces

## Verification

- `pnpm --filter kortix-api test` — 6034 pass, 74 skip, 0 fail
- focused API unit and HTTP router tests — 61 pass, 0 fail
- real-DB Computers integration — 14 pass, 0 fail
- focused web tests — 20 pass, 0 fail
- API `tsc --noEmit` — pass
- focused web ESLint and Prettier — pass
- local authenticated HTTP proof — personal machine profile 200; third-party machine profile 400; scoped list returned only the selected personal machine

## UI proof

The local web and API servers started at ports 24200 and 24208. Browser discovery returned zero connected instances, so this PR does not claim a visual browser assertion.
