### PR TITLE
fix(web): restore preview for inline content artifacts

### DIFF
--- a/apps/web/src/features/session/tool/tools/show-tool.test.tsx
+++ b/apps/web/src/features/session/tool/tools/show-tool.test.tsx
@@ -7,6 +7,8 @@ import type { ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import {
+  BoundActivateContext,
+  ToolNavigationContext,
   ToolRunningContext,
   ToolSurfaceContext,
 } from '@/features/session/tool/shared/infrastructure';
@@ -100,6 +102,50 @@ describe('ShowTool drives its inline surface with a scalloped panel; panel stays
     // Always open: the payload lives in the content plane, not behind a disclosure.
     expect(html).toContain('Hello from the payload.');
     expect(html).not.toContain('aria-expanded');
+  });
+
+  test('content-only inline show exposes Preview when the panel activation is available', () => {
+    const html = renderToStaticMarkup(
+      withProviders(
+        <BoundActivateContext.Provider value={() => {}}>
+          <ShowTool part={PART} />
+        </BoundActivateContext.Provider>,
+      ),
+    );
+
+    expect(html).toContain('Preview</button>');
+    // The Preview action adds the right toolbar tab.
+    expect(html.match(/viewBox="0 0 38 64"/g)?.length).toBe(2);
+    expect(html).not.toContain('rounded-tr-lg');
+  });
+
+  test('content-only inline show omits Preview when panel navigation is unavailable', () => {
+    const html = renderToStaticMarkup(
+      withProviders(
+        <ToolNavigationContext.Provider value={false}>
+          <BoundActivateContext.Provider value={() => {}}>
+            <ShowTool part={PART} />
+          </BoundActivateContext.Provider>
+        </ToolNavigationContext.Provider>,
+      ),
+    );
+
+    expect(html).not.toContain('Preview</button>');
+    expect(html.match(/viewBox="0 0 38 64"/g)?.length).toBe(1);
+  });
+
+  test('panel surface omits content Preview because the artifact is already open', () => {
+    const html = renderToStaticMarkup(
+      withProviders(
+        <ToolSurfaceContext.Provider value="panel">
+          <BoundActivateContext.Provider value={() => {}}>
+            <ShowTool part={PART} />
+          </BoundActivateContext.Provider>
+        </ToolSurfaceContext.Provider>,
+      ),
+    );
+
+    expect(html).not.toContain('Preview</button>');
   });
 
   test('panel surface fills the pane exactly as before — no shell wrapper', () => {

--- a/apps/web/src/features/session/tool/tools/show-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/show-tool.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import Loading from '@/components/ui/loading';
+import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
 import { TextShimmer } from '@/components/ui/text-shimmer';
 import { prefersPreviewLink } from '@/features/session/preview-url-fallback';
 import {
@@ -9,11 +11,13 @@ import {
 } from '@/features/session/show-availability';
 import {
   InlineServicePreview,
+  BoundActivateContext,
   partInput,
   ServicePreviewActions,
   type ServicePreviewState,
   ToolRunningContext,
   ToolSurfaceContext,
+  useToolNavigation,
 } from '@/features/session/tool/shared/infrastructure';
 import { ToolRegistry } from '@/features/session/tool/shared/registry';
 import {
@@ -72,6 +76,8 @@ export function ShowTool({ part, sessionId }: ToolProps) {
   const running = useContext(ToolRunningContext);
 
   const fill = useContext(ToolSurfaceContext) === 'panel';
+  const activate = useContext(BoundActivateContext);
+  const { enabled: navigationEnabled } = useToolNavigation();
 
   const title = (input.title as string) || '';
   const description = (input.description as string) || '';
@@ -131,6 +137,14 @@ export function ShowTool({ part, sessionId }: ToolProps) {
     !isWebsitePreview && activePath ? (
       <ShowFileActions path={activePath} inPanel={fill} />
     ) : undefined;
+  const contentActions =
+    !isCarousel && !isWebsitePreview && !activePath && content && activate && navigationEnabled ? (
+      <Hint label="Open in the panel" side="top">
+        <Button type="button" onClick={activate} size="xs" className="active:scale-[0.96]">
+          Preview
+        </Button>
+      </Hint>
+    ) : undefined;
   const preview = useServicePreview(
     resolvedPreviewUrl,
     activeTitle || title || description || undefined,
@@ -162,7 +176,7 @@ export function ShowTool({ part, sessionId }: ToolProps) {
   const inlineToolbar = isWebsitePreview ? (
     <ServicePreviewActions preview={preview} />
   ) : (
-    fileActions
+    fileActions || contentActions
   );
   const hasInlineToolbar = !!inlineToolbar;
 


### PR DESCRIPTION
## Demo

Preview environment and final visual evidence will be added after deployment.

## Why

Content-only `show` artifacts render inline without a file path or URL. The toolbar only handled file-backed and website previews, so these artifacts had no Preview action.

## What changed

- Add a Preview action for content-only inline artifacts.
- Route the action through the existing tool activation path.
- Respect disabled-navigation and panel contexts.
- Add regression coverage for enabled, disabled, and already-open panel states.

## Verification

- `pnpm --filter Kortix-Computer-Frontend test -- src/features/session/tool/tools/show-tool.test.tsx src/features/session/tool/shared/infrastructure.test.tsx src/features/session/action-panel/shared/derive-panels.test.ts` — 85 passed.
- `pnpm --filter Kortix-Computer-Frontend exec eslint src/features/session/tool/tools/show-tool.tsx src/features/session/tool/tools/show-tool.test.tsx` — passed.
- `git diff --check` — passed.
- Full web typecheck reaches 17 documented baseline errors: 15 Bun `test.each` typing errors and 2 missing generated `@/.source` imports. No changed file reports an error.

## Risk / rollback

Low. The new action appears only for content-only inline artifacts with active panel navigation. Revert this commit to restore the prior toolbar gate.