### PR TITLE
Publish agent tunnel with platform releases

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -318,25 +318,28 @@ jobs:
             artifacts/kortix-linux-arm64
           if-no-files-found: error
 
-  # ── Publish the public SDKs to npm ──────────────────────────────────────────
-  # Three packages ship to npm on this version release, in lockstep with the
+  # ── Publish the public npm packages ─────────────────────────────────────────
+  # Three packages ship to npm on every version release, in lockstep with the
   # platform version:
   #   @kortix/llm-catalog   — the model catalog (models + managed-model defaults)
   #                           the frontend SDK consumes
   #   @kortix/sdk           — the frontend data-layer SDK; depends on
   #                           @kortix/llm-catalog@<version>, pinned in lockstep
-  #   @kortix/executor-sdk  — one final deprecated adapter over @kortix/sdk
+  #   @kortix/agent-tunnel  — the local-machine tunnel CLI and library
   #
-  # Each package declares its published (dist-pointing) layout in its own
+  # @kortix/executor-sdk had one final deprecated publication at 0.12.5.
+  #
+  # Each package declares its published layout in its own
   # publishConfig. scripts/publish-npm-package.sh builds it, stages that manifest
   # (scripts/stage-npm-publish.mjs: promote publishConfig, pin workspace deps to
-  # the release version, verify every entrypoint exists in dist/) and publishes
+  # the release version, verify every entrypoint and binary exists) and publishes
   # idempotently.
   #
   # Auth is Trusted Publishing (OIDC) when the job grants id-token, else the
   # NPM_TOKEN secret (an npm automation token with publish rights on the @kortix
-  # org). With neither, the publish step skips cleanly so a release is never
-  # blocked. Once Trusted Publishing is verified per package on npmjs.com (package
+  # org). Production sets REQUIRE_NPM_AUTH=1: missing auth fails the release
+  # instead of silently omitting a package. Once Trusted Publishing is verified
+  # per package on npmjs.com (package
   # → Settings → Trusted Publisher → this repo + this workflow), the NPM_TOKEN
   # secret and the NODE_AUTH_TOKEN env line below can be removed — OIDC needs no
   # stored secret.
@@ -374,6 +377,7 @@ jobs:
         working-directory: packages/llm-catalog
         env:
           VERSION: ${{ needs.version.outputs.version }}
+          REQUIRE_NPM_AUTH: '1'
           # Fallback only. Once Trusted Publishing is verified, delete the
           # NPM_TOKEN secret AND this line — OIDC needs no stored secret.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -409,8 +413,43 @@ jobs:
         working-directory: packages/sdk
         env:
           VERSION: ${{ needs.version.outputs.version }}
+          REQUIRE_NPM_AUTH: '1'
           # Fallback only. Once Trusted Publishing is verified, delete the
           # NPM_TOKEN secret AND this line — OIDC needs no stored secret.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bash ../../scripts/publish-npm-package.sh
+
+  publish-agent-tunnel:
+    name: Publish @kortix/agent-tunnel to npm
+    needs: version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install workspace deps (pnpm)
+        run: |
+          corepack enable && corepack prepare pnpm@latest --activate || true
+          pnpm install --frozen-lockfile
+        env:
+          npm_config_engine_strict: "false"
+
+      - name: Build + publish (Trusted Publishing via OIDC; token fallback)
+        working-directory: packages/agent-tunnel
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          REQUIRE_NPM_AUTH: '1'
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bash ../../scripts/publish-npm-package.sh
 
@@ -445,6 +484,7 @@ jobs:
         working-directory: packages/executor-sdk
         env:
           VERSION: ${{ needs.version.outputs.version }}
+          REQUIRE_NPM_AUTH: '1'
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           bash ../../scripts/publish-npm-package.sh
@@ -576,8 +616,9 @@ jobs:
           if-no-files-found: error
 
   # ── Cut a single GitHub Release vX.Y.Z (CLI + desktop) ──────────────────────
-  # HARD-GATED on the ECS backend deploy (deploy-ecs) AND on verify-live-version proving the public
-  # endpoints serve exactly X.Y.Z. The vX.Y.Z tag + Release are the public
+  # HARD-GATED on the required npm publications, ECS backend deploy (deploy-ecs),
+  # and verify-live-version proving the public endpoints serve exactly X.Y.Z.
+  # The vX.Y.Z tag + Release are the public
   # announcement — they must never exist for a version prod isn't running
   # (v0.10.0/v0.10.1 shipped Releases while deploy-ecs failed on IAM and
   # api.kortix.com kept serving the old build; that is now impossible).
@@ -587,7 +628,7 @@ jobs:
   # `attach-desktop` job, best-effort — a desktop problem can never block a release.
   github-release:
     name: GitHub Release v${{ needs.version.outputs.version }}
-    needs: [version, retag-images, build-cli, deploy-ecs, verify-live-version, frontend-auth-proof]
+    needs: [version, retag-images, build-cli, publish-sdk, publish-agent-tunnel, deploy-ecs, verify-live-version, frontend-auth-proof]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -81,14 +81,15 @@ jobs:
       - name: Build + dry-pack publishable npm packages (release gate)
         run: |
           set -euo pipefail
-          # @kortix/llm-catalog, @kortix/sdk, and the final deprecated
-          # @kortix/executor-sdk adapter publish to npm
+          # @kortix/llm-catalog, @kortix/sdk, @kortix/agent-tunnel, and the
+          # final deprecated @kortix/executor-sdk adapter publish to npm
           # on release (deploy-prod.yml). Build + stage + dry-pack them on every PR
           # so a broken dist/ or published manifest fails here, not at release time.
-          # The staging script asserts every publishConfig entrypoint exists in the
-          # emitted dist/ and that workspace deps pin cleanly.
+          # The staging script asserts every publishConfig entrypoint and binary
+          # exists and that workspace deps pin cleanly.
           node scripts/stage-npm-publish.test.mjs
-          for dir in llm-catalog sdk executor-sdk; do
+          node scripts/publish-npm-package.test.mjs
+          for dir in llm-catalog sdk agent-tunnel executor-sdk; do
             echo "::group::@kortix/$dir build + stage + dry-pack"
             # @kortix/sdk's build:bundles also emits the tsup browser bundles
             # (dist/kortix.esm.min.js, dist/kortix.global.js) that
@@ -106,6 +107,20 @@ jobs:
               && VERSION=0.0.0-ci node ../../scripts/stage-npm-publish.mjs \
               && npm pack --dry-run \
               && mv /tmp/pkg-bak.json package.json )
+            if [ "$dir" = "agent-tunnel" ]; then
+              help="$(node packages/agent-tunnel/dist/agent-cli.js help)"
+              for expected in 'connect' 'run' 'install-service' 'service-status' 'uninstall-service' '--daemon' '--keep-awake'; do
+                grep -F -- "$expected" <<<"$help" >/dev/null || {
+                  echo "::error::Packed agent-tunnel CLI help is missing '$expected'."
+                  exit 1
+                }
+              done
+              fallback_help="$(node --input-type=module -e "delete globalThis.WebSocket; process.argv[2] = 'help'; await import('./packages/agent-tunnel/dist/agent-cli.js')")"
+              grep -F -- 'install-service' <<<"$fallback_help" >/dev/null || {
+                echo "::error::Packed agent-tunnel CLI cannot load its WebSocket fallback."
+                exit 1
+              }
+            fi
             echo "::endgroup::"
           done
 

--- a/apps/web/scripts/validate-production-supabase-env.test.mjs
+++ b/apps/web/scripts/validate-production-supabase-env.test.mjs
@@ -218,7 +218,7 @@ describe('release wiring', () => {
     assert.match(workflow, /frontend-auth-proof:\n/);
     assert.match(
       workflow,
-      /needs: \[version, retag-images, build-cli, deploy-ecs, verify-live-version, frontend-auth-proof\]/,
+      /needs: \[version, retag-images, build-cli, publish-sdk, publish-agent-tunnel, deploy-ecs, verify-live-version, frontend-auth-proof\]/,
     );
     assert.match(
       workflow,

--- a/packages/agent-tunnel/README.md
+++ b/packages/agent-tunnel/README.md
@@ -1,0 +1,47 @@
+# `@kortix/agent-tunnel`
+
+`@kortix/agent-tunnel` connects a local computer to Kortix through an authenticated reverse tunnel.
+
+## Connect once
+
+Run the command shown in **Settings → Computers**, then approve the device code in your browser:
+
+```bash
+npx --yes @kortix/agent-tunnel@latest connect \
+  --api-url https://api.kortix.com/v1/tunnel
+```
+
+The interactive flow asks whether the computer should remain online after the terminal closes.
+
+## Keep the computer online
+
+Install the operating-system background service during connection:
+
+```bash
+npx --yes @kortix/agent-tunnel@latest connect \
+  --daemon \
+  --api-url https://api.kortix.com/v1/tunnel
+```
+
+Add `--keep-awake` to also prevent the computer from sleeping while the service runs:
+
+```bash
+npx --yes @kortix/agent-tunnel@latest connect \
+  --daemon \
+  --keep-awake \
+  --api-url https://api.kortix.com/v1/tunnel
+```
+
+The service uses LaunchAgent on macOS, a user systemd service on Linux, and Task Scheduler on Windows.
+
+## Manage the background service
+
+```bash
+npx --yes @kortix/agent-tunnel@latest service-status
+npx --yes @kortix/agent-tunnel@latest logs
+npx --yes @kortix/agent-tunnel@latest restart
+npx --yes @kortix/agent-tunnel@latest stop
+npx --yes @kortix/agent-tunnel@latest uninstall-service
+```
+
+Credentials are stored in `~/.agent-tunnel/config.json` with user-only file permissions.

--- a/packages/agent-tunnel/package.json
+++ b/packages/agent-tunnel/package.json
@@ -20,7 +20,8 @@
   },
   "files": [
     "src/",
-    "dist/"
+    "dist/",
+    "README.md"
   ],
   "scripts": {
     "build": "bun build src/agent/cli.ts --target=node --outfile=dist/agent-cli.js --banner='#!/usr/bin/env node' && bun build src/client/cli.ts --target=node --outfile=dist/client-cli.js --banner='#!/usr/bin/env node' && node -e \"const fs=require('node:fs'); fs.chmodSync('dist/agent-cli.js', 0o755); fs.chmodSync('dist/client-cli.js', 0o755);\"",
@@ -29,10 +30,12 @@
     "test": "bun test"
   },
   "dependencies": {
-    "hono": "^4.4.0"
+    "hono": "^4.4.0",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.9",
+    "@types/ws": "^8.5.13",
     "typescript": "^5.4.0"
   },
   "keywords": [
@@ -46,6 +49,15 @@
   ],
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "bin": {
+      "agent-tunnel": "dist/agent-cli.js",
+      "agent-tunnel-cli": "dist/client-cli.js"
+    },
+    "files": [
+      "src/",
+      "dist/",
+      "README.md"
+    ]
   }
 }

--- a/packages/agent-tunnel/src/node-ws-polyfill.test.ts
+++ b/packages/agent-tunnel/src/node-ws-polyfill.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { pathToFileURL } from 'node:url';
+
+describe('node WebSocket polyfill', () => {
+  test('loads ws when the runtime has no global WebSocket', () => {
+    const polyfillUrl = pathToFileURL(`${import.meta.dir}/node-ws-polyfill.ts`).href;
+    const script = `
+      delete globalThis.WebSocket;
+      await import(${JSON.stringify(polyfillUrl)});
+      if (typeof globalThis.WebSocket !== 'function') process.exit(1);
+    `;
+
+    const result = Bun.spawnSync([process.execPath, '--eval', script]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr.toString()).toBe('');
+  });
+});

--- a/packages/agent-tunnel/src/node-ws-polyfill.ts
+++ b/packages/agent-tunnel/src/node-ws-polyfill.ts
@@ -5,9 +5,9 @@
  */
 if (typeof globalThis.WebSocket === 'undefined') {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const ws = require('ws');
-    globalThis.WebSocket = ws.default || ws;
+    const ws = await import('ws');
+    const WebSocketImpl = ws.WebSocket ?? ws.default;
+    globalThis.WebSocket = WebSocketImpl as unknown as typeof WebSocket;
   } catch {
     console.error(
       '[agent-tunnel] WebSocket is not available. Install the "ws" package or use Node.js 22+.',
@@ -15,3 +15,5 @@ if (typeof globalThis.WebSocket === 'undefined') {
     process.exit(1);
   }
 }
+
+export {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1403,10 +1403,16 @@ importers:
       hono:
         specifier: 4.12.27
         version: 4.12.27
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
     devDependencies:
       '@types/bun':
         specifier: ^1.3.9
         version: 1.3.14
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -14074,6 +14080,12 @@ packages:
   /@types/webxr@0.5.24:
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
     dev: false
+
+  /@types/ws@8.18.1:
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+    dependencies:
+      '@types/node': 20.19.43
+    dev: true
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}

--- a/scripts/publish-npm-package.sh
+++ b/scripts/publish-npm-package.sh
@@ -5,9 +5,10 @@
 # dry-packs it, and publishes idempotently.
 #
 # Auth is Trusted Publishing (OIDC) when the job grants id-token, else the
-# NPM_TOKEN automation token (NODE_AUTH_TOKEN). With neither, it skips cleanly so
-# a release is never blocked. Re-running the same release is a no-op (it skips a
-# version already on npm rather than hard-failing on E409).
+# NPM_TOKEN automation token (NODE_AUTH_TOKEN). Production release jobs set
+# REQUIRE_NPM_AUTH=1 and fail closed when neither credential is available.
+# Local/manual runs keep the no-auth skip behavior. Re-running the same release
+# is a no-op (it skips a version already on npm rather than hard-failing on E409).
 #
 # Run from the package directory with VERSION (and optionally NODE_AUTH_TOKEN) in
 # the environment:
@@ -18,16 +19,21 @@ set -euo pipefail
 
 : "${VERSION:?VERSION env is required}"
 
-# Trusted Publishing (OIDC) requires npm >= 11.5.1; node 22 ships npm 10.
-npm install -g npm@latest
-echo "npm $(npm --version)"
-
 # Publish only if SOME auth path is available: OIDC (id-token granted →
 # ACTIONS_ID_TOKEN_REQUEST_URL set) or a fallback automation token.
 if [ -z "${NODE_AUTH_TOKEN:-}" ] && [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+  if [ "${REQUIRE_NPM_AUTH:-0}" = "1" ]; then
+    echo "::error::No npm auth (no OIDC and no NPM_TOKEN); required publication cannot continue."
+    exit 1
+  fi
   echo "::warning::No npm auth (no OIDC, no NPM_TOKEN) — skipping publish."
   exit 0
 fi
+
+# Trusted Publishing (OIDC) requires npm >= 11.5.1; node 22 ships npm 10. Do
+# not mutate the runner's npm installation until the auth preflight passes.
+npm install -g npm@latest
+echo "npm $(npm --version)"
 
 name="$(node -p "require('./package.json').name")"
 

--- a/scripts/publish-npm-package.test.mjs
+++ b/scripts/publish-npm-package.test.mjs
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(
+  new URL("./publish-npm-package.sh", import.meta.url),
+);
+
+function run(requireAuth) {
+  const env = {
+    ...process.env,
+    VERSION: "0.0.0-test",
+    REQUIRE_NPM_AUTH: requireAuth ? "1" : "0",
+  };
+  delete env.NODE_AUTH_TOKEN;
+  delete env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  return spawnSync("bash", [script], { env, encoding: "utf8" });
+}
+
+const required = run(true);
+if (
+  required.status !== 1 ||
+  !required.stdout.includes("required publication cannot continue")
+) {
+  console.error(required.stdout);
+  console.error(required.stderr);
+  throw new Error(
+    "Required npm publication must fail closed when auth is unavailable",
+  );
+}
+
+const optional = run(false);
+if (optional.status !== 0 || !optional.stdout.includes("skipping publish")) {
+  console.error(optional.stdout);
+  console.error(optional.stderr);
+  throw new Error(
+    "Optional local npm publication must retain the no-auth skip behavior",
+  );
+}
+
+console.log("publish-npm-package.test: 2 assertions passed");

--- a/scripts/stage-npm-publish.mjs
+++ b/scripts/stage-npm-publish.mjs
@@ -10,8 +10,9 @@
 // `publishConfig` (main/types/exports/files/type). This script promotes that
 // onto the top-level manifest npm reads from the tarball — so the published
 // package is correct regardless of whether the npm client honours publishConfig
-// overrides — then validates that every published entrypoint actually exists in
-// the build output (catches drift between publishConfig and the emitted dist/).
+// overrides — then validates that every published entrypoint and executable
+// actually exists in the build output (catches drift between publishConfig and
+// the emitted dist/).
 //
 // Run from the package directory AFTER `bun run build`:
 //
@@ -63,9 +64,9 @@ for (const field of ['dependencies', 'peerDependencies', 'optionalDependencies']
   }
 }
 
-// 4) Validate that every published entrypoint exists in dist/ — a missing target
-//    means the build did not emit what publishConfig advertises, which would
-//    publish a broken package. Fail loudly instead.
+// 4) Validate that every published entrypoint and executable exists — a missing
+//    target means the build did not emit or include what the manifest advertises,
+//    which would publish a broken package. Fail loudly instead.
 const targets = new Set();
 const add = (v) => {
   if (typeof v === 'string' && v.startsWith('./')) targets.add(v);
@@ -80,6 +81,14 @@ const walkExports = (entry) => {
   else if (entry && typeof entry === 'object') for (const v of Object.values(entry)) walkExports(v);
 };
 walkExports(pkg.exports);
+const addBin = (target) => {
+  if (typeof target !== 'string' || target.length === 0) return;
+  targets.add(target.startsWith('./') ? target : `./${target}`);
+};
+if (typeof pkg.bin === 'string') addBin(pkg.bin);
+else if (pkg.bin && typeof pkg.bin === 'object') {
+  for (const target of Object.values(pkg.bin)) addBin(target);
+}
 const missing = [...targets].filter((t) => !existsSync(t));
 if (missing.length) {
   console.error(`stage-npm-publish: ${pkg.name} declares entrypoints missing from the build output:`);
@@ -96,5 +105,5 @@ if (pkg.browser || pkg.unpkg || pkg.jsdelivr) {
   console.log(`  browser:${pkg.browser ?? '(none)'}  unpkg:${pkg.unpkg ?? '(none)'}  jsdelivr:${pkg.jsdelivr ?? '(none)'}`);
 }
 console.log(`  files:  ${JSON.stringify(pkg.files ?? [])}`);
-console.log(`  exports:${Object.keys(pkg.exports ?? {}).length} entrypoint(s), all present in dist/`);
+console.log(`  exports:${Object.keys(pkg.exports ?? {}).length} entrypoint(s), all targets present`);
 if (pinned.length) console.log(`  pinned: ${pinned.join(', ')}`);

--- a/scripts/stage-npm-publish.test.mjs
+++ b/scripts/stage-npm-publish.test.mjs
@@ -25,6 +25,7 @@ const run = (dir, version) =>
   mkdirSync(join(dir, 'dist'));
   writeFileSync(join(dir, 'dist', 'index.js'), '');
   writeFileSync(join(dir, 'dist', 'index.d.ts'), '');
+  writeFileSync(join(dir, 'dist', 'cli.js'), '');
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify(
@@ -34,6 +35,7 @@ const run = (dir, version) =>
         main: './src/index.ts',
         types: './src/index.ts',
         exports: { '.': './src/index.ts' },
+        bin: { 'kortix-x': './src/cli.ts' },
         dependencies: { '@kortix/shared': 'workspace:*', zustand: '^5.0.3' },
         files: ['dist', 'src', 'README.md'],
         publishConfig: {
@@ -42,6 +44,7 @@ const run = (dir, version) =>
           main: './dist/index.js',
           types: './dist/index.d.ts',
           exports: { '.': { types: './dist/index.d.ts', import: './dist/index.js' } },
+          bin: { 'kortix-x': './dist/cli.js' },
           files: ['dist', 'README.md'],
         },
       },
@@ -56,6 +59,7 @@ const run = (dir, version) =>
   assert(out.main === './dist/index.js', 'main promoted to dist');
   assert(out.types === './dist/index.d.ts', 'types promoted to dist');
   assert(out.exports['.'].import === './dist/index.js', 'exports promoted to dist');
+  assert(out.bin['kortix-x'] === './dist/cli.js', 'bin promoted to dist');
   assert(JSON.stringify(out.files) === JSON.stringify(['dist', 'README.md']), 'files promoted from publishConfig');
   assert(out.dependencies['@kortix/shared'] === '2.3.4', 'workspace dep pinned to the release version');
   assert(out.dependencies.zustand === '^5.0.3', 'registry dep range left untouched');
@@ -179,7 +183,38 @@ const run = (dir, version) =>
   rmSync(dir, { recursive: true, force: true });
 }
 
-// 5) Missing VERSION must fail.
+// 5) A declared binary missing from the build output must fail loudly. A
+// package can otherwise publish successfully while every `npx` invocation is
+// broken.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'stage-bin-miss-'));
+  mkdirSync(join(dir, 'dist'));
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify(
+      {
+        name: '@kortix/bin-miss',
+        version: '1.0.0',
+        publishConfig: {
+          access: 'public',
+          bin: { 'kortix-bin-miss': 'dist/cli.js' },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  let threw = false;
+  try {
+    run(dir, '1.0.0');
+  } catch {
+    threw = true;
+  }
+  assert(threw, 'missing bin target must fail');
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// 6) Missing VERSION must fail.
 {
   const dir = mkdtempSync(join(tmpdir(), 'stage-nov-'));
   writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: '@kortix/z', version: '1.0.0' }, null, 2));


### PR DESCRIPTION
## Problem

`@kortix/agent-tunnel@latest` is still `0.1.4`, published on April 1. The package is absent from the production release workflow and package release gate. Persistent service commands added in June are therefore unavailable from npm.

## Changes

- Publish `@kortix/agent-tunnel` with the platform `VERSION` during every production release.
- Require npm authentication for all required production package publications.
- Block the GitHub Release until the SDK and agent-tunnel publications finish.
- Build, stage, and dry-pack agent-tunnel in the package CI gate.
- Validate published binary targets, including standard bare `dist/...` npm bin paths.
- Package the `ws` fallback and verify it without Node global WebSocket support.
- Publish package documentation for foreground and persistent service operation.

## Verification

- `pnpm --filter @kortix/agent-tunnel test` — 36 pass, 0 fail.
- `pnpm --filter @kortix/agent-tunnel typecheck` — pass.
- `node scripts/stage-npm-publish.test.mjs` — 26 assertions passed.
- `node scripts/publish-npm-package.test.mjs` — 2 assertions passed.
- Four-package build, stage, and dry-pack gate — pass.
- Packed and installed `@kortix/agent-tunnel@0.0.0-e2e`; both binaries were executable.
- Forced `globalThis.WebSocket` removal against the installed tarball — CLI help loaded through `ws` and exposed all persistent-service commands.
- `actionlint` reports only the five warnings already present on `origin/main`.

## Release behavior

This PR does not publish manually. The next production release publishes agent-tunnel with the same platform version as the SDK and GitHub Release.