### PR TITLE
fix(api,sdk,web): converge session titles on the runtime title everywhere

### DIFF
--- a/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
+++ b/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
@@ -211,6 +211,107 @@ describe('serializeSession ⇄ ProjectSessionSchema', () => {
     expect(parsed.custom_name).toBe('Mine');
   });
 
+  test('runtime snapshot root title wins over the Kortix auto title', () => {
+    const out = serializeSession(
+      sessionRow({
+        metadata: {
+          name: 'Fix the login bug on the dashboard',
+          opencode_sessions: [
+            { id: 'ses_child', title: 'Sub-agent work', parent_id: 'ses_abc' },
+            { id: 'ses_abc', title: 'Dashboard Login Repair', parent_id: null },
+          ],
+        },
+      }),
+    );
+    const parsed = ProjectSessionSchema.strict().parse(out);
+    expect(parsed.name).toBe('Dashboard Login Repair');
+    expect(parsed.custom_name).toBeNull();
+  });
+
+  test('runtime root is matched by the pinned root id, not list order', () => {
+    const out = serializeSession(
+      sessionRow({
+        opencodeSessionId: 'ses_root',
+        metadata: {
+          name: 'Auto title',
+          opencode_sessions: [
+            { id: 'ses_other', title: 'Wrong Tree Root', parent_id: null },
+            { id: 'ses_root', title: 'Pinned Root Title', parent_id: null },
+          ],
+        },
+      }),
+    );
+    expect(ProjectSessionSchema.strict().parse(out).name).toBe('Pinned Root Title');
+  });
+
+  test('a parentless entry stands in when no snapshot entry matches the pin', () => {
+    const out = serializeSession(
+      sessionRow({
+        opencodeSessionId: null,
+        metadata: {
+          name: 'Auto title',
+          opencode_sessions: [
+            { id: 'ses_child', title: 'Child', parent_id: 'ses_root' },
+            { id: 'ses_root', title: 'Tree Root Title', parent_id: null },
+          ],
+        },
+      }),
+    );
+    expect(ProjectSessionSchema.strict().parse(out).name).toBe('Tree Root Title');
+  });
+
+  test('placeholder or blank runtime titles fall back to the Kortix auto title', () => {
+    const placeholder = serializeSession(
+      sessionRow({
+        metadata: {
+          name: 'Real Kortix Title',
+          opencode_sessions: [
+            { id: 'ses_abc', title: 'New session - 2026-08-09T10:00:00.000Z', parent_id: null },
+          ],
+        },
+      }),
+    );
+    expect(ProjectSessionSchema.strict().parse(placeholder).name).toBe('Real Kortix Title');
+
+    const blank = serializeSession(
+      sessionRow({
+        metadata: {
+          name: 'Real Kortix Title',
+          opencode_sessions: [{ id: 'ses_abc', title: '   ', parent_id: null }],
+        },
+      }),
+    );
+    expect(ProjectSessionSchema.strict().parse(blank).name).toBe('Real Kortix Title');
+  });
+
+  test('custom_name wins over the runtime snapshot title', () => {
+    const out = serializeSession(
+      sessionRow({
+        metadata: {
+          name: 'auto',
+          custom_name: 'Mine',
+          opencode_sessions: [{ id: 'ses_abc', title: 'Runtime Title', parent_id: null }],
+        },
+      }),
+    );
+    expect(ProjectSessionSchema.strict().parse(out).name).toBe('Mine');
+  });
+
+  test('a viewer without access never reads the runtime snapshot title', () => {
+    const out = serializeSession(
+      sessionRow({
+        metadata: {
+          name: 'auto',
+          opencode_sessions: [{ id: 'ses_abc', title: 'Runtime Title', parent_id: null }],
+        },
+      }),
+      { viewerId: 'someone-else', canAccess: false },
+    );
+    const parsed = ProjectSessionSchema.strict().parse(out);
+    expect(parsed.name).toBeNull();
+    expect(parsed.opencode_sessions).toEqual([]);
+  });
+
   test("opencode's frozen placeholder reads as untitled, a real title does not", () => {
     const placeholder = ProjectSessionSchema.strict().parse(
       serializeSession(sessionRow({ metadata: { name: 'New session - 2026-07-28' } })),

--- a/apps/api/src/projects/lib/opencode-title.ts
+++ b/apps/api/src/projects/lib/opencode-title.ts
@@ -19,3 +19,36 @@ export function isPlaceholderOpencodeTitle(title: string | null | undefined): bo
  * Kept in lockstep by unit test.
  */
 export const PLACEHOLDER_TITLE_SQL_PATTERN = '^new (session|agent)([^[:alnum:]_]|$)';
+
+/**
+ * The runtime's own title for a session's canonical ROOT conversation, read
+ * from the `metadata.opencode_sessions` snapshot (opencode-session-snapshot.ts).
+ *
+ * This is a READ-time preference, not a second title writer: `metadata.name`
+ * stays owned solely by session-title-generate.ts. The snapshot mirrors what
+ * OpenCode's in-sandbox summarizer produced — the string the session header
+ * already shows live — so session reads resolve the same title the header
+ * does instead of drifting to the first-prompt-derived generated name.
+ *
+ * The root entry is matched by the pinned root id first (`opencode_session_id`),
+ * then by the parentless entry of the scoped tree. Placeholder and blank titles
+ * read as absent so callers fall through to the generated name.
+ */
+export function runtimeRootTitleFromSnapshot(
+  snapshot: unknown,
+  pinnedRootId: string | null,
+): string | null {
+  if (!Array.isArray(snapshot)) return null;
+  const entries = snapshot.filter(
+    (entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object',
+  );
+  const root =
+    (pinnedRootId && entries.find((entry) => entry.id === pinnedRootId)) ||
+    entries.find((entry) => {
+      const parent = entry.parent_id;
+      return parent === null || parent === undefined || parent === '';
+    });
+  const title = typeof root?.title === 'string' ? root.title.trim() : '';
+  if (!title || isPlaceholderOpencodeTitle(title)) return null;
+  return title;
+}

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -24,7 +24,7 @@ import { templateSlugFromBuildSlug } from '../../snapshots/ppwarm-names';
 import type { ProjectRole } from '../access';
 import { type GitHubRepo, isGithubAppConfigured } from '../github';
 import { parseGitHubRepoUrl } from './git';
-import { isPlaceholderOpencodeTitle } from './opencode-title';
+import { isPlaceholderOpencodeTitle, runtimeRootTitleFromSnapshot } from './opencode-title';
 import { normalizeProjectGlyph } from './project-glyph';
 import { normalizeProjectIcon } from './project-icon';
 import { proxyGitUrl } from './sessions';
@@ -104,6 +104,11 @@ export function serializeSession(
   const rawAutoName =
     canAccess && typeof row.metadata?.name === 'string' ? row.metadata.name : null;
   const autoName = isPlaceholderOpencodeTitle(rawAutoName) ? null : rawAutoName;
+  // The runtime's own root-conversation title (already access-gated: the
+  // snapshot above is [] when canAccess is false). It outranks the generated
+  // auto title so list reads resolve the SAME string the session header shows
+  // live, but never a user rename.
+  const runtimeTitle = runtimeRootTitleFromSnapshot(opencodeSessions, row.opencodeSessionId);
   return {
     session_id: row.sessionId,
     account_id: row.accountId,
@@ -114,7 +119,7 @@ export function serializeSession(
     sandbox_id: row.sandboxId,
     sandbox_url: row.sandboxUrl,
     opencode_session_id: row.opencodeSessionId,
-    name: customName ?? autoName,
+    name: customName ?? runtimeTitle ?? autoName,
     custom_name: customName,
     agent_name: row.agentName,
     status: row.status,

--- a/apps/api/src/shared/public-session-share-view.ts
+++ b/apps/api/src/shared/public-session-share-view.ts
@@ -26,8 +26,15 @@
 import { eq } from 'drizzle-orm';
 import { projectSessions } from '@kortix/db';
 import { db } from './db';
-import { isPlaceholderOpencodeTitle } from '../projects/lib/opencode-title';
-import { sandboxOpencodeEndpoint, listSandboxOpencodeSessions, resolveRootSessionId } from '../projects/opencode-mapping';
+import {
+  isPlaceholderOpencodeTitle,
+  runtimeRootTitleFromSnapshot,
+} from '../projects/lib/opencode-title';
+import {
+  sandboxOpencodeEndpoint,
+  listSandboxOpencodeSessions,
+  resolveRootSessionId,
+} from '../projects/opencode-mapping';
 import type { PublicShareRow } from './session-public-shares';
 
 const WORKSPACE_DIRECTORY = '/workspace';
@@ -53,6 +60,7 @@ export async function getPublicSessionInfo(sessionId: string): Promise<PublicSes
     .select({
       sessionId: projectSessions.sessionId,
       status: projectSessions.status,
+      opencodeSessionId: projectSessions.opencodeSessionId,
       metadata: projectSessions.metadata,
       createdAt: projectSessions.createdAt,
       updatedAt: projectSessions.updatedAt,
@@ -68,12 +76,19 @@ export async function getPublicSessionInfo(sessionId: string): Promise<PublicSes
   // anonymous viewer a frozen "New session - …" as if it were a real title.
   const rawAutoName = typeof metadata.name === 'string' ? metadata.name : null;
   const autoName = isPlaceholderOpencodeTitle(rawAutoName) ? null : rawAutoName;
+  // Same read-time preference as the authenticated serializer: the runtime's
+  // root-conversation title (what the session header shows) over the generated
+  // auto title; a user rename still wins.
+  const runtimeTitle = runtimeRootTitleFromSnapshot(
+    metadata.opencode_sessions,
+    row.opencodeSessionId,
+  );
 
   return {
     ok: true,
     session: {
       session_id: row.sessionId,
-      title: customName ?? autoName,
+      title: customName ?? runtimeTitle ?? autoName,
       status: row.status,
       created_at: row.createdAt.toISOString(),
       updated_at: row.updatedAt.toISOString(),
@@ -128,7 +143,9 @@ type RawPart = {
 function normalizeMessageList(payload: unknown): RawMessage[] {
   const list = Array.isArray(payload)
     ? payload
-    : typeof payload === 'object' && payload && Array.isArray((payload as { messages?: unknown }).messages)
+    : typeof payload === 'object' &&
+        payload &&
+        Array.isArray((payload as { messages?: unknown }).messages)
       ? (payload as { messages: unknown[] }).messages
       : [];
   return list.filter((m): m is RawMessage => typeof m === 'object' && m !== null);
@@ -167,8 +184,17 @@ function compactMessage(msg: RawMessage): CompactPublicMessage {
   };
 }
 
-function unavailable(reason: string, opencodeSessionId: string | null = null): PublicSessionTranscript {
-  return { available: false, reason, opencode_session_id: opencodeSessionId, message_count: 0, messages: [] };
+function unavailable(
+  reason: string,
+  opencodeSessionId: string | null = null,
+): PublicSessionTranscript {
+  return {
+    available: false,
+    reason,
+    opencode_session_id: opencodeSessionId,
+    message_count: 0,
+    messages: [],
+  };
 }
 
 /**
@@ -232,7 +258,10 @@ export async function getPublicSessionMessages(
     };
   }
   if (!endpoint) {
-    return { ok: true, transcript: unavailable('Sandbox credentials unavailable', opencodeSessionId) };
+    return {
+      ok: true,
+      transcript: unavailable('Sandbox credentials unavailable', opencodeSessionId),
+    };
   }
 
   try {
@@ -245,10 +274,19 @@ export async function getPublicSessionMessages(
       signal: AbortSignal.timeout(8_000),
     });
     if (res.status === 503) {
-      return { ok: true, transcript: unavailable('OpenCode is not ready in the sandbox yet', opencodeSessionId) };
+      return {
+        ok: true,
+        transcript: unavailable('OpenCode is not ready in the sandbox yet', opencodeSessionId),
+      };
     }
     if (!res.ok) {
-      return { ok: true, transcript: unavailable(`OpenCode messages unavailable: HTTP ${res.status}`, opencodeSessionId) };
+      return {
+        ok: true,
+        transcript: unavailable(
+          `OpenCode messages unavailable: HTTP ${res.status}`,
+          opencodeSessionId,
+        ),
+      };
     }
     const payload = (await res.json().catch(() => null)) as unknown;
     const rawMessages = normalizeMessageList(payload).slice(-MAX_MESSAGES);

--- a/apps/web/src/features/session/session-tab-title-sync.tsx
+++ b/apps/web/src/features/session/session-tab-title-sync.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
 import { sessionTabTitleFromSession } from './session-tab-title';
-import type { ProjectSession } from '@kortix/sdk';
+import { listProjectSessions, type ProjectSession } from '@kortix/sdk';
 import { qk } from '@kortix/sdk/react';
 
 /**
@@ -36,8 +36,16 @@ export function SessionTabTitleSync({
   // mutation (`applySessionRename`) reaches the tab immediately. `select`
   // narrows 64 sessions down to one string, so structural sharing re-renders
   // this component only when the title actually changes.
+  //
+  // The `queryFn` is REQUIRED even though this observer never fetches: a
+  // query's options are last-writer-wins across its observers, so an observer
+  // without a queryFn poisons external fetches on the shared key —
+  // `refetchQueries`/`invalidateQueries` (the SDK's title mirror on
+  // `session.updated`, rename, restart, create) then reject with "No queryFn
+  // was passed" and the sidebar list silently stops syncing.
   const { data: title } = useQuery({
     queryKey: qk.project.sessions(projectId),
+    queryFn: () => listProjectSessions(projectId),
     enabled: false,
     notifyOnChangeProps: ['data'],
     select: (sessions: ProjectSession[]) => {

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,37 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-09 — session `session-title-sidebar-sync` claim
+
+No **Now** task claimed. User-directed fix: the sidebar/tab never converge to the
+runtime session title the header shows.
+
+Claimed SDK scope:
+
+- `react/use-opencode-events/helpers.ts`: new module-internal `realRuntimeTitle`
+  + `patchKortixSessionTitleMirrors` — on a `session.updated`/`session.created`
+  title change, patch the cached Kortix session reads (`name` on rows matching
+  `opencode_session_id`, `custom_name` untouched) before the existing
+  `refetchKortixSessionMirrors` reconciliation refetch.
+- `react/use-opencode-events/handle-event.ts`: wire both call sites.
+- Doc-only precedence update on `ProjectSession.name` (`core/rest/projects-client/sessions.ts`).
+- No published export name changed; no package.json change.
+
+RED: 4 new tests in `handle-event.test.ts` (`kortix session title mirroring`) —
+patch test failed against the unpatched handler (`Expected "Runtime Title",
+Received "Generated Title"`), guards passed.
+
+GREEN:
+
+- `bun test packages/sdk/src/react/use-opencode-events/`: `39 pass`, `0 fail`.
+- `pnpm --filter @kortix/sdk typecheck`: exit `0` (package + examples).
+- `pnpm --filter @kortix/sdk test`: `1829 pass`, `2 skip`, `0 fail`, `7044 expect()` calls, 141 files.
+- `pnpm --filter @kortix/sdk run smoke:install`: packed-install import passed.
+
+**Status:** COMPLETE.
+
+**SDK package shippable to production: YES.**
+
 ### 2026-08-09 — session `computers-connector-grouping` claim
 
 No **Now** task claimed. This is the user-directed Computers connector profile refactor.

--- a/packages/sdk/src/core/rest/projects-client/sessions.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.ts
@@ -31,8 +31,10 @@ export interface ProjectSession {
   sandbox_url: string | null;
   opencode_session_id: string | null;
   /**
-   * Resolved display name: the user-set `custom_name` if present, otherwise the
-   * auto title mirrored from OpenCode server-side during project session reads.
+   * Resolved display name. Precedence: the user-set `custom_name`, then the
+   * runtime's own root-conversation title (the `opencode_sessions` snapshot —
+   * the same string the session header shows), then the Kortix-generated
+   * first-prompt title (`metadata.name`).
    */
   name: string | null;
   /**
@@ -399,8 +401,7 @@ export async function getSessionAudit(
   const search = new URLSearchParams();
   if (limit) search.set('limit', String(limit));
   if (options?.cursor) search.set('cursor', options.cursor);
-  if (options?.includeEvents != null)
-    search.set('include_events', String(options.includeEvents));
+  if (options?.includeEvents != null) search.set('include_events', String(options.includeEvents));
   const qs = search.toString();
   return unwrap(
     await backendApi.get<SessionAudit>(

--- a/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
@@ -59,6 +59,7 @@ mock.module('../../platform/ui', () => ({
 }));
 
 const { createEventHandler } = await import('./handle-event');
+const { qk } = await import('../query-keys');
 const { useSyncStore } = await import('../../browser/stores/sync-store');
 const { useDiagnosticsStore } = await import('../../browser/stores/diagnostics-store');
 const { opencodeKeys } = await import('../use-opencode-sessions');
@@ -83,6 +84,7 @@ function buildHandler(
   overrides: {
     messagesImpl?: () => Promise<{ data?: unknown }>;
     getImpl?: () => Promise<{ data?: unknown }>;
+    projectId?: string;
   } = {},
 ) {
   const queryClient = new QueryClient();
@@ -122,6 +124,7 @@ function buildHandler(
     normalizeDiagnosticPaths: { current: (x) => x },
     markSessionAbortedLocally: { current: markSessionAbortedLocally.fn },
     fetchLspDiagnosticsDebounced: { current: fetchLspDiagnosticsDebounced.fn },
+    projectId: overrides.projectId,
   });
 
   return {
@@ -385,6 +388,103 @@ describe('session lifecycle cache mutations', () => {
       'ses_b',
     ]);
     expect(queryClient.getQueryData(opencodeKeys.runtimeSession('ses_a'))).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Kortix session-title mirroring — a runtime title change lands in the cached
+// Kortix session reads immediately, without waiting for the server-side
+// opencode_sessions snapshot (~20s) to make the next refetch carry it.
+// ============================================================================
+
+describe('kortix session title mirroring', () => {
+  const PROJECT_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+  const PROJECT_SESSION_ID = '11111111-2222-4333-8444-555555555555';
+
+  function kortixRow(overrides: Record<string, unknown> = {}) {
+    return {
+      session_id: PROJECT_SESSION_ID,
+      opencode_session_id: 'ses_a',
+      name: 'Generated Title',
+      custom_name: null,
+      ...overrides,
+    };
+  }
+
+  function titleEvent(title: string) {
+    return {
+      id: 'evt_1',
+      type: 'session.updated' as const,
+      properties: {
+        sessionID: 'ses_a',
+        info: session('ses_a', { title, time: { created: 1, updated: 9 } }),
+      },
+    };
+  }
+
+  test('session.updated with a new title patches every cached Kortix session read', () => {
+    const { handleEvent, queryClient } = buildHandler({ projectId: PROJECT_ID });
+    queryClient.setQueryData(qk.project.sessions(PROJECT_ID), [kortixRow()]);
+    queryClient.setQueryData(qk.project.sessions(PROJECT_ID, 'project'), [kortixRow()]);
+    queryClient.setQueryData(qk.project.session(PROJECT_ID, PROJECT_SESSION_ID), kortixRow());
+
+    handleEvent(titleEvent('Runtime Title'));
+
+    const visible = queryClient.getQueryData<Record<string, unknown>[]>(
+      qk.project.sessions(PROJECT_ID),
+    );
+    const project = queryClient.getQueryData<Record<string, unknown>[]>(
+      qk.project.sessions(PROJECT_ID, 'project'),
+    );
+    const detail = queryClient.getQueryData<Record<string, unknown>>(
+      qk.project.session(PROJECT_ID, PROJECT_SESSION_ID),
+    );
+    expect(visible?.[0]?.name).toBe('Runtime Title');
+    expect(project?.[0]?.name).toBe('Runtime Title');
+    expect(detail?.name).toBe('Runtime Title');
+  });
+
+  test('a user rename is never overwritten and other rows stay untouched', () => {
+    const { handleEvent, queryClient } = buildHandler({ projectId: PROJECT_ID });
+    const renamed = kortixRow({ custom_name: 'Mine', name: 'Mine' });
+    const other = kortixRow({
+      session_id: '99999999-8888-4777-8666-555555555555',
+      opencode_session_id: 'ses_other',
+      name: 'Other Session',
+    });
+    queryClient.setQueryData(qk.project.sessions(PROJECT_ID), [renamed, other]);
+
+    handleEvent(titleEvent('Runtime Title'));
+
+    const list = queryClient.getQueryData<Record<string, unknown>[]>(
+      qk.project.sessions(PROJECT_ID),
+    );
+    expect(list?.[0]?.name).toBe('Mine');
+    expect(list?.[1]?.name).toBe('Other Session');
+  });
+
+  test('placeholder runtime titles do not reach the Kortix caches', () => {
+    const { handleEvent, queryClient } = buildHandler({ projectId: PROJECT_ID });
+    queryClient.setQueryData(qk.project.sessions(PROJECT_ID), [kortixRow()]);
+
+    handleEvent(titleEvent('New session - 2026-08-09T10:00:00.000Z'));
+
+    const list = queryClient.getQueryData<Record<string, unknown>[]>(
+      qk.project.sessions(PROJECT_ID),
+    );
+    expect(list?.[0]?.name).toBe('Generated Title');
+  });
+
+  test('no projectId means no Kortix cache writes', () => {
+    const { handleEvent, queryClient } = buildHandler();
+    queryClient.setQueryData(qk.project.sessions(PROJECT_ID), [kortixRow()]);
+
+    handleEvent(titleEvent('Runtime Title'));
+
+    const list = queryClient.getQueryData<Record<string, unknown>[]>(
+      qk.project.sessions(PROJECT_ID),
+    );
+    expect(list?.[0]?.name).toBe('Generated Title');
   });
 });
 

--- a/packages/sdk/src/react/use-opencode-events/handle-event.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.ts
@@ -26,7 +26,9 @@ import { applyPartDiagnostics } from './diagnostics';
 import {
   asStringOrUndefined,
   looksLikeAbortError,
+  patchKortixSessionTitleMirrors,
   readSessionInfo,
+  realRuntimeTitle,
   refetchKortixSessionMirrors,
   scheduleProjectMetadataRefetch,
 } from './helpers';
@@ -136,6 +138,12 @@ export function createEventHandler(deps: {
             return [info, ...old].sort((a, b) => b.time.updated - a.time.updated);
           });
           queryClient.setQueryData(opencodeKeys.runtimeSession(info.id), info);
+          patchKortixSessionTitleMirrors(
+            queryClient,
+            projectId,
+            info.id,
+            realRuntimeTitle(info.title),
+          );
           refetchKortixSessionMirrors(queryClient, projectId);
         }
         break;
@@ -170,7 +178,18 @@ export function createEventHandler(deps: {
             next[idx] = info;
             return next.sort((a, b) => b.time.updated - a.time.updated);
           });
-          if (titleChanged) refetchKortixSessionMirrors(queryClient, projectId);
+          if (titleChanged) {
+            // Instant local mirror first (the refetch below can race the
+            // server-side snapshot write and return the pre-title name),
+            // then the authoritative server read.
+            patchKortixSessionTitleMirrors(
+              queryClient,
+              projectId,
+              info.id,
+              realRuntimeTitle(info.title),
+            );
+            refetchKortixSessionMirrors(queryClient, projectId);
+          }
         }
         break;
       }

--- a/packages/sdk/src/react/use-opencode-events/helpers.ts
+++ b/packages/sdk/src/react/use-opencode-events/helpers.ts
@@ -121,5 +121,63 @@ export function refetchKortixSessionMirrors(
   projectId: string | null,
 ): void {
   if (!projectId) return;
-  void queryClient.refetchQueries({ queryKey: qk.project.sessionsScope(projectId), type: 'active' });
+  void queryClient.refetchQueries({
+    queryKey: qk.project.sessionsScope(projectId),
+    type: 'active',
+  });
+}
+
+// Same placeholder predicate the API serializer applies (`lib/opencode-title.ts`)
+// and `session-title-sync.ts`'s `readRealTitle`: OpenCode stamps
+// "New session - <date>" before its summarizer runs, and that is not a title.
+const PLACEHOLDER_RUNTIME_TITLE_RE = /^new (?:session|agent)\b/i;
+
+export function realRuntimeTitle(value: unknown): string | null {
+  const title = typeof value === 'string' ? value.trim() : '';
+  if (!title || PLACEHOLDER_RUNTIME_TITLE_RE.test(title)) return null;
+  return title;
+}
+
+/**
+ * Mirror a runtime title change straight into the cached Kortix session reads
+ * (`name` on the row whose `opencode_session_id` matches), so the sidebar and
+ * tab converge with the header the moment the title event arrives.
+ *
+ * The durable owner is the API read (`serializeSession` prefers the
+ * `opencode_sessions` snapshot root title) — but that snapshot is written
+ * ~20s after the prompt, so the refetch `refetchKortixSessionMirrors` fires
+ * alongside this can beat it and come back with the pre-title name. This
+ * write closes that gap; the next server read reconciles.
+ *
+ * A user rename (`custom_name`) always wins and is never overwritten. Rows
+ * for other conversations, and cache entries that are not session rows
+ * (messages, sandbox slots under the same prefix), pass through untouched.
+ */
+export function patchKortixSessionTitleMirrors(
+  queryClient: QueryClient,
+  projectId: string | null,
+  nativeSessionId: string,
+  title: string | null,
+): void {
+  if (!projectId || !title) return;
+  const patchRow = (row: unknown): unknown => {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) return row;
+    const rec = row as Record<string, unknown>;
+    if (rec.opencode_session_id !== nativeSessionId) return row;
+    if (typeof rec.custom_name === 'string' && rec.custom_name.trim()) return row;
+    if (rec.name === title) return row;
+    return { ...rec, name: title };
+  };
+  queryClient.setQueriesData({ queryKey: qk.project.sessionsScope(projectId) }, (data: unknown) => {
+    if (Array.isArray(data)) {
+      let changed = false;
+      const next = data.map((row) => {
+        const patched = patchRow(row);
+        if (patched !== row) changed = true;
+        return patched;
+      });
+      return changed ? next : data;
+    }
+    return patchRow(data);
+  });
 }

--- a/tests/src/coverage/allowlist.ts
+++ b/tests/src/coverage/allowlist.ts
@@ -7,6 +7,12 @@ export interface AllowEntry {
 export const uncoveredAllow: AllowEntry[] = [
   {
     method: "POST",
+    path: "/v1/projects/provision-stream",
+    reason:
+      "SSE progress-stream sibling of the flow-covered POST /projects/provision (#6276 /new create page) — same provisioning engine and auth boundary; the JSON sibling carries the contract coverage, and its own source-level guards live in apps/api/src/projects/provision-stream.test.ts",
+  },
+  {
+    method: "POST",
     path: "/v1/platform/boot-timeline",
     reason:
       "sandbox-only telemetry sink called by the in-guest boot relay with a sandbox token; not an end-user API route",


### PR DESCRIPTION
## Problem

Two coupled bugs around session titles:

1. **Console error on session routes** (`SessionTabTitleSync`): `No queryFn was passed as an option, and no default queryFn was found` for key `["kx","project",<id>,"sessions","list","visible"]`.
2. **The left sidebar never converges to the session's actual title.** It renders the Kortix-generated first-prompt title (`metadata.name` — for short prompts, literally the prompt), while the session header renders the OpenCode runtime title (`useRuntimeSession(...).title`). Nothing has mirrored the runtime title back since #5739, so the two disagree forever.

The two bugs feed each other: the `enabled: false` observer in `session-tab-title-sync.tsx` has no `queryFn`. Query options are last-writer-wins across observers, so that observer poisons the shared `qk.project.sessions` query — every `refetchQueries`/`invalidateQueries` on it (the SDK's `refetchKortixSessionMirrors` on `session.updated` title events, rename, restart, create) rejects with exactly that console error, and the sidebar list silently stops refreshing. Even when the refetch worked, the refetched `name` never carried the runtime title.

## Fix

- **api** — `serializeSession` (and the public share view) resolve `name` as `custom_name` → `opencode_sessions` snapshot **root title** (new `runtimeRootTitleFromSnapshot`, root matched by the `opencode_session_id` pin, placeholder/blank filtered) → `metadata.name`. Read-time preference only: `session-title-generate.ts` remains the sole `metadata.name` writer (`unit-session-title-invariant.test.ts` untouched and green). Every client (web sidebar/tab, CLI, mobile, share) converges at rest.
- **sdk** — on a `session.created`/`session.updated` title change, `patchKortixSessionTitleMirrors` patches the cached Kortix session reads in place (rows matched by `opencode_session_id`; `custom_name` never overwritten; placeholder titles filtered) before the existing reconciliation refetch, which can beat the ~20s deferred snapshot write. Sidebar + tab now update the moment the header does.
- **web** — `SessionTabTitleSync`'s observer gets a real `queryFn` (`listProjectSessions`), keeping `enabled: false`. Kills the console error and un-poisons external refetches on the shared key.

## Verification (all run, real output)

- `apps/api` unit: `dotenvx run -- bun test unit-api-contract-serializers unit-session-title-invariant unit-session-title-generate` → **60 pass, 0 fail** (7 new serializer tests, written RED first).
- `@kortix/sdk` gates: `typecheck` exit 0; full suite **1829 pass, 2 skip, 0 fail** (141 files; 4 new `handle-event` tests written RED first); `smoke:install` passed. `PROGRESS.md` session log added.
- `apps/api` `tsc --noEmit` exit 0; `apps/web` `tsc --noEmit` clean apart from known `@types/bun`/`@/.source` pre-existing noise; `eslint session-tab-title-sync.tsx` clean; biome clean on changed files.
- **Live HTTP** (worktree stack, shared local DB): seeded a real row whose stored `metadata.name` is the prompt excerpt `"Write a file at out/greeting.txt containing exactly"` with snapshot root title `"Greeting File Delivery"` → `GET /v1/projects/:id/sessions` returns `name: "Greeting File Delivery"`; a no-snapshot row keeps its generated name.
- **Live browser** (chrome-devtools, logged-in): sidebar row and browser tab both render `Greeting File Delivery`; console shows **zero errors** on the session route.

Not exercised locally: the in-session SSE title event → sidebar patch on a freshly provisioned sandbox (needs a live prompt round-trip); covered by SDK unit tests, will be smoke-checked on dev after deploy.
