### PR TITLE
Remove agent tunnel keep-awake mode

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -109,12 +109,16 @@ jobs:
               && mv /tmp/pkg-bak.json package.json )
             if [ "$dir" = "agent-tunnel" ]; then
               help="$(node packages/agent-tunnel/dist/agent-cli.js help)"
-              for expected in 'connect' 'run' 'install-service' 'service-status' 'uninstall-service' '--daemon' '--keep-awake'; do
+              for expected in 'connect' 'run' 'install-service' 'service-status' 'uninstall-service' '--daemon' '--foreground'; do
                 grep -F -- "$expected" <<<"$help" >/dev/null || {
                   echo "::error::Packed agent-tunnel CLI help is missing '$expected'."
                   exit 1
                 }
               done
+              if grep -F -- '--keep-awake' <<<"$help" >/dev/null; then
+                echo "::error::Packed agent-tunnel CLI still exposes the removed keep-awake flag."
+                exit 1
+              fi
               fallback_help="$(node --input-type=module -e "delete globalThis.WebSocket; process.argv[2] = 'help'; await import('./packages/agent-tunnel/dist/agent-cli.js')")"
               grep -F -- 'install-service' <<<"$fallback_help" >/dev/null || {
                 echo "::error::Packed agent-tunnel CLI cannot load its WebSocket fallback."

--- a/packages/agent-tunnel/README.md
+++ b/packages/agent-tunnel/README.md
@@ -11,9 +11,9 @@ npx --yes @kortix/agent-tunnel@latest connect \
   --api-url https://api.kortix.com/v1/tunnel
 ```
 
-The interactive flow asks whether the computer should remain online after the terminal closes.
+After approval, the interactive flow asks whether it should install a persistent background service. The default answer is yes.
 
-## Keep the computer online
+## Run in the background
 
 Install the operating-system background service during connection:
 
@@ -23,16 +23,8 @@ npx --yes @kortix/agent-tunnel@latest connect \
   --api-url https://api.kortix.com/v1/tunnel
 ```
 
-Add `--keep-awake` to also prevent the computer from sleeping while the service runs:
-
-```bash
-npx --yes @kortix/agent-tunnel@latest connect \
-  --daemon \
-  --keep-awake \
-  --api-url https://api.kortix.com/v1/tunnel
-```
-
 The service uses LaunchAgent on macOS, a user systemd service on Linux, and Task Scheduler on Windows.
+It starts at login and restarts after failures. It does not change the computer's sleep settings.
 
 ## Manage the background service
 

--- a/packages/agent-tunnel/src/agent/cli-help.test.ts
+++ b/packages/agent-tunnel/src/agent/cli-help.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'child_process';
+import { resolve } from 'path';
+
+const CLI_PATH = resolve(import.meta.dir, 'cli.ts');
+
+describe('agent tunnel service UX', () => {
+  test('offers persistent daemon mode without an unsupported keep-awake flag', () => {
+    const result = spawnSync('bun', ['run', CLI_PATH, 'help'], { encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--daemon');
+    expect(result.stdout).toContain('--foreground');
+    expect(result.stdout).not.toContain('--keep-awake');
+  });
+
+  test('rejects the removed keep-awake flag instead of silently ignoring it', () => {
+    const result = spawnSync('bun', ['run', CLI_PATH, 'connect', '--keep-awake'], {
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('--keep-awake is not supported');
+  });
+});

--- a/packages/agent-tunnel/src/agent/cli.ts
+++ b/packages/agent-tunnel/src/agent/cli.ts
@@ -5,7 +5,16 @@ import { CapabilityRegistry } from './capabilities/index';
 import { createFilesystemCapability } from './capabilities/filesystem';
 import { createShellCapability } from './capabilities/shell';
 import { createDesktopCapability } from './capabilities/desktop';
-import { getServicePaths, getServiceStatus, installService, restartService, startService, stopService, uninstallService } from './service';
+import {
+  DEFAULT_INSTALL_BACKGROUND_SERVICE,
+  getServicePaths,
+  getServiceStatus,
+  installService,
+  restartService,
+  startService,
+  stopService,
+  uninstallService,
+} from './service';
 import { hostname, platform, arch, release } from 'os';
 import { chmodSync, existsSync, mkdirSync, writeFileSync, readFileSync, renameSync } from 'fs';
 import { join } from 'path';
@@ -54,7 +63,6 @@ const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 
 type ConnectMode = {
   background: boolean;
-  keepAwake: boolean;
 };
 
 async function printStartup(config: { tunnelId: string; apiUrl: string }, capabilities: string[], version: string): Promise<void> {
@@ -193,10 +201,6 @@ function isTruthyFlag(value: string | undefined): boolean {
   return value === 'true' || value === '1' || value === 'yes';
 }
 
-function isFalseyFlag(value: string | undefined): boolean {
-  return value === 'false' || value === '0' || value === 'no';
-}
-
 function isInteractiveTerminal(): boolean {
   return process.stdin.isTTY === true && process.stdout.isTTY === true;
 }
@@ -212,6 +216,12 @@ async function promptYesNo(question: string, defaultValue: boolean): Promise<boo
       if (['n', 'no'].includes(answer)) return false;
       console.log(`  ${c.yellow}!${c.reset} Please answer yes or no.`);
     }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      process.stdout.write('\n');
+      process.exit(130);
+    }
+    throw error;
   } finally {
     rl.close();
   }
@@ -230,38 +240,34 @@ async function chooseConnectMode(flags: Record<string, string>): Promise<Connect
     isTruthyFlag(flags['no-background']);
 
   if (explicitBackground) {
-    return { background: true, keepAwake: isTruthyFlag(flags['keep-awake']) };
+    return { background: true };
   }
   if (explicitForeground) {
-    return { background: false, keepAwake: false };
+    return { background: false };
   }
   if (!isInteractiveTerminal()) {
-    return { background: false, keepAwake: false };
+    return { background: false };
   }
 
   console.log('');
   console.log(`  ${c.yellow}!${c.reset} ${c.bold}Security note${c.reset}`);
-  console.log(`  ${c.dim}Always-online keeps this computer reachable by approved Kortix agents after this terminal closes.${c.reset}`);
-  console.log(`  ${c.dim}Keep-awake is separate: it also asks the OS to avoid sleep while the tunnel service runs.${c.reset}`);
+  console.log(`  ${c.dim}Background mode starts at login, continues after this terminal closes, and restarts after failures.${c.reset}`);
+  console.log(`  ${c.dim}The computer must remain powered on, awake, and connected to the internet.${c.reset}`);
   console.log('');
 
-  const background = await promptYesNo('  Keep this computer always online in the background?', true);
-  if (!background) return { background: false, keepAwake: false };
-
-  let keepAwake = isTruthyFlag(flags['keep-awake']);
-  if (!keepAwake && !isFalseyFlag(flags['keep-awake'])) {
-    keepAwake = await promptYesNo('  Also keep this computer awake while the tunnel is running?', false);
-  }
-  return { background, keepAwake };
+  const background = await promptYesNo(
+    '  Install the background service now?',
+    DEFAULT_INSTALL_BACKGROUND_SERVICE,
+  );
+  return { background };
 }
 
-function installBackgroundService(mode: ConnectMode): void {
-  const status = installService({ keepAwake: mode.keepAwake });
+function installBackgroundService(): void {
+  const status = installService();
   console.log('');
   console.log(`  ${c.green}●${c.reset} ${c.bold}Background service installed${c.reset}`);
   if (status.path) console.log(`  ${c.dim}${status.path}${c.reset}`);
-  console.log(`  ${c.dim}Always-online: enabled${c.reset}`);
-  console.log(`  ${c.dim}Keep-awake: ${mode.keepAwake ? 'enabled' : 'disabled'}${c.reset}`);
+  console.log(`  ${c.dim}Starts at login and restarts after failures.${c.reset}`);
   if (status.detail) console.log(`  ${c.gray}${status.detail}${c.reset}`);
   console.log('');
 }
@@ -357,7 +363,7 @@ async function commandConnectDeviceAuth(config: TunnelConfig, flags: Record<stri
 
           const mode = await chooseConnectMode(flags);
           if (mode.background) {
-            installBackgroundService(mode);
+            installBackgroundService();
             return;
           }
 
@@ -408,7 +414,7 @@ async function commandConnect(flags: Record<string, string>): Promise<void> {
     const mode = await chooseConnectMode(flags);
     if (mode.background) {
       saveCredentials(config.tunnelId, config.token, config.apiUrl);
-      installBackgroundService(mode);
+      installBackgroundService();
       return;
     }
     startAgent(config);
@@ -498,7 +504,7 @@ function commandInstallService(flags: Record<string, string>): void {
     saveCredentials(config.tunnelId, config.token, config.apiUrl);
   }
 
-  const status = installService({ keepAwake: isTruthyFlag(flags['keep-awake']) });
+  const status = installService();
   console.log(JSON.stringify(status, null, 2));
 }
 
@@ -566,9 +572,8 @@ function showHelp(): void {
   console.log(`  ${c.white}--token${c.reset} ${c.dim}<token>${c.reset}       Skip device auth, connect directly`);
   console.log(`  ${c.white}--tunnel-id${c.reset} ${c.dim}<id>${c.reset}     Tunnel ID ${c.dim}(required with --token)${c.reset}`);
   console.log(`  ${c.white}--api-url${c.reset} ${c.dim}<url>${c.reset}       API URL ${c.dim}(default: http://localhost:8080)${c.reset}`);
-  console.log(`  ${c.white}--daemon${c.reset}             With connect: save credentials and install the 24/7 service`);
+  console.log(`  ${c.white}--daemon${c.reset}             With connect: skip the prompt and install the background service`);
   console.log(`  ${c.white}--foreground${c.reset}         With connect: skip prompts and run only in this terminal`);
-  console.log(`  ${c.white}--keep-awake${c.reset}         With service: also ask OS to avoid sleep while tunnel runs`);
   console.log('');
   console.log(`  ${c.dim}Config: ~/.agent-tunnel/config.json${c.reset}`);
   console.log(`  ${c.dim}powered by ${c.cyan}kortix${c.reset}`);
@@ -576,6 +581,11 @@ function showHelp(): void {
 }
 
 const { command, flags } = parseArgs(process.argv);
+
+if (Object.prototype.hasOwnProperty.call(flags, 'keep-awake')) {
+  console.error(`${c.red}${c.bold} error${c.reset} --keep-awake is not supported. Configure sleep behavior in the operating system.`);
+  process.exit(2);
+}
 
 switch (command) {
   case 'connect':

--- a/packages/agent-tunnel/src/agent/service.test.ts
+++ b/packages/agent-tunnel/src/agent/service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { platform } from 'os';
 import {
+  DEFAULT_INSTALL_BACKGROUND_SERVICE,
   SERVICE_LABEL,
   buildServiceShellCommand,
   getServicePaths,
@@ -10,23 +10,15 @@ import {
 } from './service';
 
 describe('agent tunnel service definitions', () => {
+  test('defaults the interactive connection flow to the background service', () => {
+    expect(DEFAULT_INSTALL_BACKGROUND_SERVICE).toBe(true);
+  });
+
   test('builds a command that runs the supervised tunnel agent', () => {
     const command = buildServiceShellCommand();
     expect(command).toContain("'run'");
     expect(command).toContain("'--service'");
     expect(command).toStartWith('exec ');
-  });
-
-  test('keep-awake command wraps the service on supported platforms', () => {
-    const command = buildServiceShellCommand({ keepAwake: true });
-    expect(command).toContain("'run'");
-    expect(command).toContain("'--service'");
-    if (platform() === 'darwin') {
-      expect(command).toContain('/usr/bin/caffeinate -dimsu');
-    }
-    if (platform() === 'linux') {
-      expect(command).toContain('systemd-inhibit');
-    }
   });
 
   test('launchd plist restarts and runs at login', () => {
@@ -47,12 +39,12 @@ describe('agent tunnel service definitions', () => {
     expect(unit).toContain('agent-tunnel.err.log');
   });
 
-  test('windows scheduled-task script restarts forever and can keep awake', () => {
-    const script = renderWindowsPowerShellScript(
-      { keepAwake: true },
-      { command: 'node', args: ['agent-tunnel.js', 'run', '--service'] },
-    );
-    expect(script).toContain('SetThreadExecutionState');
+  test('windows scheduled-task script restarts forever', () => {
+    const script = renderWindowsPowerShellScript({
+      command: 'node',
+      args: ['agent-tunnel.js', 'run', '--service'],
+    });
+    expect(script).not.toContain('SetThreadExecutionState');
     expect(script).toContain('while ($true)');
     expect(script).toContain("& 'node' 'agent-tunnel.js' 'run' '--service'");
     expect(script).toContain('Start-Sleep -Seconds 5');

--- a/packages/agent-tunnel/src/agent/service.ts
+++ b/packages/agent-tunnel/src/agent/service.ts
@@ -4,10 +4,7 @@ import { dirname, join } from 'path';
 import { spawnSync } from 'child_process';
 
 export const SERVICE_LABEL = 'ai.kortix.agent-tunnel';
-
-export interface ServiceInstallOptions {
-  keepAwake?: boolean;
-}
+export const DEFAULT_INSTALL_BACKGROUND_SERVICE = true;
 
 export interface ServicePaths {
   configDir: string;
@@ -68,40 +65,18 @@ function currentRunnerCommand(): string {
   return [runner.command, ...runner.args].map(shellQuote).join(' ');
 }
 
-export function buildServiceShellCommand(options: ServiceInstallOptions = {}): string {
-  const runner = currentRunnerCommand();
-  if (!options.keepAwake) return `exec ${runner}`;
-
-  if (platform() === 'darwin') {
-    return `exec /usr/bin/caffeinate -dimsu ${runner}`;
-  }
-
-  if (platform() === 'linux') {
-    return `if command -v systemd-inhibit >/dev/null 2>&1; then exec systemd-inhibit --what=sleep:idle --why='Kortix Agent Tunnel' ${runner}; else exec ${runner}; fi`;
-  }
-
-  return `exec ${runner}`;
+export function buildServiceShellCommand(): string {
+  return `exec ${currentRunnerCommand()}`;
 }
 
 export function renderWindowsPowerShellScript(
-  options: ServiceInstallOptions = {},
   runner = currentRunnerParts(),
 ): string {
-  const keepAwake = options.keepAwake === true;
   const command = powershellQuote(runner.command);
   const args = runner.args.map(powershellQuote).join(' ');
 
   return `$ErrorActionPreference = 'Continue'
-${keepAwake ? `Add-Type -TypeDefinition @'
-using System;
-using System.Runtime.InteropServices;
-public static class KortixPower {
-  [DllImport("kernel32.dll", SetLastError = true)]
-  public static extern UInt32 SetThreadExecutionState(UInt32 esFlags);
-}
-'@
-[KortixPower]::SetThreadExecutionState(0x80000000 -bor 0x00000001 -bor 0x00000040) | Out-Null
-` : ''}while ($true) {
+while ($true) {
   & ${command}${args ? ` ${args}` : ''}
   Start-Sleep -Seconds 5
 }
@@ -181,12 +156,12 @@ function launchdTarget(): string {
   return `gui/${uid}`;
 }
 
-export function installService(options: ServiceInstallOptions = {}): ServiceStatus {
+export function installService(): ServiceStatus {
   const paths = getServicePaths();
   mkdirSync(paths.configDir, { recursive: true, mode: 0o700 });
   mkdirSync(paths.logDir, { recursive: true, mode: 0o700 });
 
-  const command = buildServiceShellCommand(options);
+  const command = buildServiceShellCommand();
 
   if (platform() === 'darwin') {
     mkdirSync(dirname(paths.launchdPlist), { recursive: true });
@@ -218,7 +193,7 @@ export function installService(options: ServiceInstallOptions = {}): ServiceStat
   }
 
   if (platform() === 'win32') {
-    writeFileSync(paths.windowsScript, renderWindowsPowerShellScript(options), { mode: 0o600 });
+    writeFileSync(paths.windowsScript, renderWindowsPowerShellScript(), { mode: 0o600 });
     const create = run('schtasks.exe', [
       '/Create',
       '/TN',


### PR DESCRIPTION
## Problem

The agent tunnel exposed one `--keep-awake` promise through three different operating-system mechanisms. macOS used `caffeinate`, Linux used `systemd-inhibit`, and Windows used `SetThreadExecutionState`. These mechanisms do not provide one cross-platform contract. The macOS implementation also does not provide the lid-close behavior of `mac-awake`, which requires privileged `pmset` configuration.

## Changes

- Remove the keep-awake prompt, flag, and platform-specific service wrappers.
- Reject `--keep-awake` with exit code 2 instead of silently ignoring it.
- Keep the cross-platform background service and make it the default interactive choice.
- State that the machine must remain powered on, awake, and connected.
- Exit cleanly with code 130 when the user presses Ctrl+C at the prompt.
- Gate packed CLI help against reintroducing the removed flag.
- Update package documentation.

## Verification

- `npx --yes bun test` — 38 pass, 0 fail.
- `npx --yes bun run typecheck` — pass.
- `npx --yes bun run build` — both binaries built.
- `npm pack --dry-run` — 38 files, both binaries included.
- `node scripts/stage-npm-publish.test.mjs` — 26 assertions passed.
- `node scripts/publish-npm-package.test.mjs` — 2 assertions passed.
- Packed-help check contains `--daemon` and `--foreground`, with no `--keep-awake`.
- Node WebSocket fallback loads the same help successfully.
- Interactive PTY smoke shows `Install the background service now? [Y/n]`.
- Prompt cancellation exits 130 without a stack trace.
- `actionlint .github/workflows/package-tests.yml` reports only the existing SC2001 warning on line 30, identical to `origin/main`.
