### PR TITLE
fix(web): building sandbox alert shows Details action instead of Retry build

### DIFF
--- a/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
@@ -170,7 +170,7 @@ function SandboxAlertContent({
         <p className="text-muted-foreground text-xs text-balance">
           {describeSandboxSeverity(severity, status)}
         </p>
-        {!failure && (
+        {!failure && severity !== 'building' && (
           <Button
             variant="transparent"
             size="sm"
@@ -212,39 +212,52 @@ function SandboxAlertContent({
       )}
 
       <div className="border-border flex flex-col gap-2 border-t p-3">
-        {canFixWithAgent && (
+        {severity === 'building' ? (
           <Button
             size="sm"
-            className="w-full"
-            disabled={fixWithAgent.isPending}
-            onClick={() => fixWithAgent.mutate()}
+            variant="secondary"
+            className="w-full border"
+            onClick={() => openCustomize('sandbox')}
           >
-            {fixWithAgent.isPending ? (
-              <Loading className="text-foreground! size-3.5" />
-            ) : (
-              <SparklesSolid weight="fill" className="size-3.5" />
-            )}
-            {tI18nHardcoded.raw(
-              'autoFeaturesCoWorkerProjectSidebarFooterProjectSandboxAlertJsxe7d8ac75',
-            )}
+            Details
           </Button>
+        ) : (
+          <>
+            {canFixWithAgent && (
+              <Button
+                size="sm"
+                className="w-full"
+                disabled={fixWithAgent.isPending}
+                onClick={() => fixWithAgent.mutate()}
+              >
+                {fixWithAgent.isPending ? (
+                  <Loading className="text-foreground! size-3.5" />
+                ) : (
+                  <SparklesSolid weight="fill" className="size-3.5" />
+                )}
+                {tI18nHardcoded.raw(
+                  'autoFeaturesCoWorkerProjectSidebarFooterProjectSandboxAlertJsxe7d8ac75',
+                )}
+              </Button>
+            )}
+            <Button
+              size="sm"
+              variant="secondary"
+              className="w-full border"
+              disabled={retry.isPending}
+              onClick={() => retry.mutate(failure?.template_slug)}
+            >
+              {retry.isPending ? (
+                <Loading className="text-foreground! size-3.5" />
+              ) : (
+                <RefreshCw className="size-3.5" />
+              )}
+              {tI18nHardcoded.raw(
+                'autoFeaturesCoWorkerProjectSidebarFooterProjectSandboxAlertJsx8794c0a3',
+              )}
+            </Button>
+          </>
         )}
-        <Button
-          size="sm"
-          variant="secondary"
-          className="w-full border"
-          disabled={retry.isPending}
-          onClick={() => retry.mutate(failure?.template_slug)}
-        >
-          {retry.isPending ? (
-            <Loading className="text-foreground! size-3.5" />
-          ) : (
-            <RefreshCw className="size-3.5" />
-          )}
-          {tI18nHardcoded.raw(
-            'autoFeaturesCoWorkerProjectSidebarFooterProjectSandboxAlertJsx8794c0a3',
-          )}
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

While a sandbox image build is running, the project-sidebar sandbox alert now shows a single full-width **Details** action instead of **Retry build**. Details opens Customize -> Sandbox templates (`openCustomize('sandbox')`), where the build status and Rebuild action live. Retrying mid-build was redundant; the templates page is the place with full context.

## Changes

- `apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx`
  - `severity === 'building'`: footer renders one Details button; Retry build and Fix with agent are hidden.
  - Inline "Details" text link under the description is removed for the building state (redundant with the button); it remains for a no-failure warning state.
  - Failure/warning states unchanged: Fix with agent + Retry build + Details link next to the error badge.
  - Both surfaces share `SandboxAlertContent`, so the expanded disclosure and the collapsed-rail popover both get the behavior.

## Verification

- `npx eslint src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx` — exit 0.
- `tsc --noEmit` — no errors in this file; remaining output is pre-existing stale `.next/dev/types` references and known `@types/bun` test noise.
- The click path is the identical `openCustomize('sandbox')` handler already shipping on the failure-state Details link.
