### PR TITLE
fix(tunnel): record signed heartbeat pongs

### DIFF
--- a/apps/api/src/__tests__/unit-tunnel-auth.test.ts
+++ b/apps/api/src/__tests__/unit-tunnel-auth.test.ts
@@ -15,6 +15,8 @@ import {
 } from '../tunnel/routes/auth';
 import { createConnectionsRouter } from '../tunnel/routes/connections';
 import { effectiveRegisteredCapabilities } from '../tunnel';
+import { tunnelRelay } from '../tunnel/core/relay';
+import { heartbeatManager } from '../tunnel/core/heartbeat';
 
 /** Minimal stand-in for a Hono context: only `c.get(key)` is used here. */
 function fakeCtx(values: Record<string, unknown>) {
@@ -169,5 +171,25 @@ describe('tunnel agent capability registration', () => {
       effectiveRegisteredCapabilities(['filesystem', 'filesystem'], ['filesystem']),
     ).toBeNull();
     expect(effectiveRegisteredCapabilities(['filesystem', 'camera'], ['filesystem'])).toBeNull();
+  });
+});
+
+describe('tunnel heartbeat wiring', () => {
+  test('records each signed agent pong in the heartbeat manager', () => {
+    const originalRecordPong = heartbeatManager.recordPong;
+    const recorded: string[] = [];
+    heartbeatManager.recordPong = (tunnelId: string) => {
+      recorded.push(tunnelId);
+    };
+
+    try {
+      tunnelRelay.emitEvent('message:pong', {
+        tunnelId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        params: {},
+      });
+      expect(recorded).toEqual(['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa']);
+    } finally {
+      heartbeatManager.recordPong = originalRecordPong;
+    }
   });
 });

--- a/apps/api/src/tunnel/index.ts
+++ b/apps/api/src/tunnel/index.ts
@@ -152,6 +152,14 @@ const wsHandlers = createWsHandlers(tunnelRelay, {
 
 // ─── Lifecycle ───────────────────────────────────────────────────────────────
 
+// Heartbeat liveness is transport state, not DB persistence state. Record the
+// signed pong synchronously before the async capability/heartbeat DB handler
+// runs below. Without this wiring, every healthy agent times out after three
+// intervals even though its pongs update the connection row successfully.
+tunnelRelay.on('message:pong', ({ tunnelId }) => {
+  heartbeatManager.recordPong(tunnelId);
+});
+
 let permissionCleanupInterval: ReturnType<typeof setInterval> | null = null;
 
 async function syncActiveTunnelPermissions(


### PR DESCRIPTION
## Problem

The API receives valid signed `tunnel.pong` messages and persists their machine metadata, but it does not call `heartbeatManager.recordPong`. The timeout counter therefore reaches three and closes every healthy Agent Tunnel WebSocket with code `4000` after about 90 seconds.

## Fix

- Wire each verified relay `message:pong` event into the API heartbeat manager.
- Keep transport liveness synchronous and independent from asynchronous database persistence.
- Add a regression test for the API-specific heartbeat wiring.

## Verification

- `KORTIX_URL=http://localhost:8008 pnpm exec dotenvx run --ignore=MISSING_ENV_FILE -f apps/api/.env.local -f apps/api/.env -- /tmp/kortix-bun.mZDcxR/node_modules/.bin/bun test apps/api/src/__tests__/unit-tunnel-auth.test.ts` -> 21 pass, 0 fail.
- `pnpm --filter kortix-api typecheck` -> exit 0.
- Real local WebSocket smoke -> online at 0/20/40/60/80/100 seconds; `lastHeartbeatAt` advanced every 30 seconds; cleanup returned HTTP 200.

## Live evidence before fix

The merged dev agent disconnected with code `4000` every 88-90 seconds. The service log grew at 00:09:48 and 00:11:16 during a 100-second monitor.