### PR TITLE
feat(cli): bare `kortix` attaches the OpenCode TUI to a session (managed binary + picker)

### DIFF
--- a/apps/cli/src/__tests__/home.test.ts
+++ b/apps/cli/src/__tests__/home.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runHome } from '../commands/home.ts';
+
+const savedEnv: Record<string, string | undefined> = {};
+let scratch: string;
+const ttyDescriptors: Array<{
+  stream: NodeJS.ReadStream | NodeJS.WriteStream;
+  descriptor: PropertyDescriptor | undefined;
+}> = [];
+
+function setTTY(stream: NodeJS.ReadStream | NodeJS.WriteStream, value: boolean | undefined) {
+  ttyDescriptors.push({ stream, descriptor: Object.getOwnPropertyDescriptor(stream, 'isTTY') });
+  Object.defineProperty(stream, 'isTTY', { value, configurable: true });
+}
+
+beforeEach(() => {
+  for (const key of ['KORTIX_AUTH_FILE', 'KORTIX_CONFIG_FILE', 'KORTIX_CLI_TOKEN', 'KORTIX_API_URL']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  scratch = mkdtempSync(join(tmpdir(), 'home-test-'));
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  while (ttyDescriptors.length > 0) {
+    const { stream, descriptor } = ttyDescriptors.pop()!;
+    if (descriptor) Object.defineProperty(stream, 'isTTY', descriptor);
+    else delete (stream as unknown as Record<string, unknown>).isTTY;
+  }
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+describe('runHome gating', () => {
+  test('falls back to the landing screen on a non-TTY stdin', async () => {
+    setTTY(process.stdin, false);
+    setTTY(process.stdout, true);
+
+    expect(await runHome()).toBe('landing');
+  });
+
+  test('falls back to the landing screen on a non-TTY stdout', async () => {
+    setTTY(process.stdin, true);
+    setTTY(process.stdout, false);
+
+    expect(await runHome()).toBe('landing');
+  });
+
+  test('falls back to the landing screen when not logged in', async () => {
+    setTTY(process.stdin, true);
+    setTTY(process.stdout, true);
+    process.env.KORTIX_AUTH_FILE = join(scratch, 'missing-auth.json');
+    process.env.KORTIX_CONFIG_FILE = join(scratch, 'missing-config.json');
+
+    expect(await runHome()).toBe('landing');
+  });
+});

--- a/apps/cli/src/__tests__/opencode-bin.test.ts
+++ b/apps/cli/src/__tests__/opencode-bin.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import * as tar from 'tar';
+
+import {
+  ensureOpencodeBin,
+  managedOpencodePath,
+  opencodePlatformPackage,
+  parseOpencodeVersion,
+} from '../opencode-bin.ts';
+
+const savedEnv: Record<string, string | undefined> = {};
+let scratch: string;
+
+beforeEach(() => {
+  for (const key of ['KORTIX_OPENCODE_BIN', 'KORTIX_OPENCODE_DIR']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  scratch = mkdtempSync(join(tmpdir(), 'opencode-bin-test-'));
+  process.env.KORTIX_OPENCODE_DIR = join(scratch, 'managed');
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+const neverFetch: typeof fetch = (() => {
+  throw new Error('unexpected network call');
+}) as unknown as typeof fetch;
+
+const noPathBinary = () => null;
+
+async function makeTarball(executableContent: string): Promise<string> {
+  const stage = join(scratch, 'tarball-stage');
+  mkdirSync(join(stage, 'package', 'bin'), { recursive: true });
+  writeFileSync(join(stage, 'package', 'bin', 'opencode'), executableContent);
+  const file = join(scratch, 'opencode.tgz');
+  await tar.c({ gzip: true, file, cwd: stage }, ['package']);
+  return file;
+}
+
+describe('parseOpencodeVersion', () => {
+  test('extracts a bare semver', () => {
+    expect(parseOpencodeVersion('1.17.11\n')).toBe('1.17.11');
+  });
+
+  test('extracts a prerelease semver from surrounding text', () => {
+    expect(parseOpencodeVersion('opencode 1.2.3-beta.1 (bun)')).toBe('1.2.3-beta.1');
+  });
+
+  test('returns null when no version is present', () => {
+    expect(parseOpencodeVersion('command not found')).toBeNull();
+  });
+});
+
+describe('opencodePlatformPackage', () => {
+  test('maps darwin/arm64', () => {
+    expect(opencodePlatformPackage('darwin', 'arm64')).toBe('opencode-darwin-arm64');
+  });
+
+  test('maps linux/x64 with musl suffix', () => {
+    expect(opencodePlatformPackage('linux', 'x64', true)).toBe('opencode-linux-x64-musl');
+  });
+
+  test('maps linux/arm64 glibc', () => {
+    expect(opencodePlatformPackage('linux', 'arm64', false)).toBe('opencode-linux-arm64');
+  });
+
+  test('throws for unsupported platforms', () => {
+    expect(() => opencodePlatformPackage('win32', 'x64')).toThrow(/KORTIX_OPENCODE_BIN/);
+    expect(() => opencodePlatformPackage('linux', 'ia32')).toThrow(/KORTIX_OPENCODE_BIN/);
+  });
+});
+
+describe('ensureOpencodeBin', () => {
+  test('KORTIX_OPENCODE_BIN overrides everything', async () => {
+    process.env.KORTIX_OPENCODE_BIN = '/custom/opencode';
+
+    const resolved = await ensureOpencodeBin({
+      version: '9.9.9',
+      fetchImpl: neverFetch,
+      probePathVersion: noPathBinary,
+    });
+
+    expect(resolved).toEqual({ bin: '/custom/opencode', source: 'env', version: null });
+  });
+
+  test('uses an already-managed binary without touching network or PATH', async () => {
+    const managed = managedOpencodePath('9.9.9');
+    mkdirSync(join(process.env.KORTIX_OPENCODE_DIR!, '9.9.9'), { recursive: true });
+    writeFileSync(managed, '#!/bin/sh\n');
+
+    const resolved = await ensureOpencodeBin({
+      version: '9.9.9',
+      fetchImpl: neverFetch,
+      probePathVersion: () => {
+        throw new Error('probe must not run on a cache hit');
+      },
+    });
+
+    expect(resolved).toEqual({ bin: managed, source: 'managed', version: '9.9.9' });
+  });
+
+  test('uses PATH opencode when its version matches exactly', async () => {
+    const resolved = await ensureOpencodeBin({
+      version: '9.9.9',
+      fetchImpl: neverFetch,
+      probePathVersion: () => '9.9.9',
+    });
+
+    expect(resolved).toEqual({ bin: 'opencode', source: 'path', version: '9.9.9' });
+  });
+
+  test('downloads, caches, and marks the binary executable', async () => {
+    const tarball = await makeTarball('#!/bin/sh\necho fake-opencode\n');
+    let requestedUrl = '';
+    const fetchImpl = (async (url: string | URL | Request) => {
+      requestedUrl = String(url);
+      return new Response(Bun.file(tarball));
+    }) as typeof fetch;
+
+    const resolved = await ensureOpencodeBin({
+      version: '9.9.9',
+      fetchImpl,
+      probePathVersion: noPathBinary,
+    });
+
+    const managed = managedOpencodePath('9.9.9');
+    expect(resolved).toEqual({ bin: managed, source: 'downloaded', version: '9.9.9' });
+    expect(requestedUrl).toContain('https://registry.npmjs.org/');
+    expect(requestedUrl).toContain('9.9.9.tgz');
+    expect(existsSync(managed)).toBe(true);
+    expect(statSync(managed).mode & 0o111).not.toBe(0);
+
+    const second = await ensureOpencodeBin({
+      version: '9.9.9',
+      fetchImpl: neverFetch,
+      probePathVersion: noPathBinary,
+    });
+    expect(second.source).toBe('managed');
+  });
+
+  test('falls back to a mismatched PATH binary when the download fails', async () => {
+    const fetchImpl = (async () =>
+      new Response('nope', { status: 404 })) as unknown as typeof fetch;
+
+    const resolved = await ensureOpencodeBin({
+      version: '9.9.9',
+      fetchImpl,
+      probePathVersion: () => '1.0.0',
+    });
+
+    expect(resolved).toEqual({ bin: 'opencode', source: 'path-fallback', version: '1.0.0' });
+  });
+
+  test('fails with install guidance when download fails and PATH has nothing', async () => {
+    const fetchImpl = (async () =>
+      new Response('nope', { status: 404 })) as unknown as typeof fetch;
+
+    await expect(
+      ensureOpencodeBin({ version: '9.9.9', fetchImpl, probePathVersion: noPathBinary }),
+    ).rejects.toThrow(/KORTIX_OPENCODE_BIN/);
+  });
+});

--- a/apps/cli/src/__tests__/opencode-bin.test.ts
+++ b/apps/cli/src/__tests__/opencode-bin.test.ts
@@ -7,6 +7,7 @@ import * as tar from 'tar';
 
 import {
   ensureOpencodeBin,
+  isValidOpencodeVersion,
   managedOpencodePath,
   opencodePlatformPackage,
   parseOpencodeVersion,
@@ -61,6 +62,23 @@ describe('parseOpencodeVersion', () => {
   });
 });
 
+describe('isValidOpencodeVersion', () => {
+  test('accepts exact semver with optional prerelease tag', () => {
+    expect(isValidOpencodeVersion('1.17.11')).toBe(true);
+    expect(isValidOpencodeVersion('1.2.3-beta.1')).toBe(true);
+  });
+
+  test('rejects anything that could steer a URL or path', () => {
+    expect(isValidOpencodeVersion('1.2.3/../../evil-pkg/-/evil-pkg-1.0.0')).toBe(false);
+    expect(isValidOpencodeVersion('1.2.3/evil')).toBe(false);
+    expect(isValidOpencodeVersion('1.2.3\nX')).toBe(false);
+    expect(isValidOpencodeVersion('1.2.3 ')).toBe(false);
+    expect(isValidOpencodeVersion('../1.2.3')).toBe(false);
+    expect(isValidOpencodeVersion('1.2')).toBe(false);
+    expect(isValidOpencodeVersion('')).toBe(false);
+  });
+});
+
 describe('opencodePlatformPackage', () => {
   test('maps darwin/arm64', () => {
     expect(opencodePlatformPackage('darwin', 'arm64')).toBe('opencode-darwin-arm64');
@@ -81,6 +99,16 @@ describe('opencodePlatformPackage', () => {
 });
 
 describe('ensureOpencodeBin', () => {
+  test('refuses a malformed version outright — no path build, no download', async () => {
+    await expect(
+      ensureOpencodeBin({
+        version: '1.2.3/../../evil-pkg/-/evil-pkg-1.0.0',
+        fetchImpl: neverFetch,
+        probePathVersion: noPathBinary,
+      }),
+    ).rejects.toThrow(/malformed OpenCode version/);
+  });
+
   test('KORTIX_OPENCODE_BIN overrides everything', async () => {
     process.env.KORTIX_OPENCODE_BIN = '/custom/opencode';
 

--- a/apps/cli/src/__tests__/opencode-proxy.test.ts
+++ b/apps/cli/src/__tests__/opencode-proxy.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { type RunningOpenCodeProxy, startOpenCodeProxy } from '../api/sdk.ts';
+
+type UpstreamCapture = {
+  method: string;
+  path: string;
+  search: string;
+  authorization: string | null;
+  body: string;
+};
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()?.();
+});
+
+function track(proxy: RunningOpenCodeProxy): RunningOpenCodeProxy {
+  cleanups.push(() => proxy.close());
+  return proxy;
+}
+
+describe('startOpenCodeProxy HTTP', () => {
+  test('injects the bearer token and forwards method, path, query, and body', async () => {
+    const captures: UpstreamCapture[] = [];
+    const upstream = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch: async (req) => {
+        const url = new URL(req.url);
+        captures.push({
+          method: req.method,
+          path: url.pathname,
+          search: url.search,
+          authorization: req.headers.get('authorization'),
+          body: await req.text(),
+        });
+        return Response.json({ ok: true });
+      },
+    });
+    cleanups.push(() => upstream.stop(true));
+
+    const proxy = track(
+      startOpenCodeProxy({ runtimeUrl: `http://127.0.0.1:${upstream.port}`, token: 'tok-123' }),
+    );
+
+    const get = await fetch(`${proxy.url}/session/abc?limit=2`);
+    expect(get.status).toBe(200);
+    expect(await get.json()).toEqual({ ok: true });
+
+    const post = await fetch(`${proxy.url}/session/abc/message`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'hi' }),
+    });
+    expect(post.status).toBe(200);
+
+    expect(captures).toHaveLength(2);
+    expect(captures[0]).toMatchObject({
+      method: 'GET',
+      path: '/session/abc',
+      search: '?limit=2',
+      authorization: 'Bearer tok-123',
+    });
+    expect(captures[1]).toMatchObject({
+      method: 'POST',
+      path: '/session/abc/message',
+      authorization: 'Bearer tok-123',
+      body: '{"text":"hi"}',
+    });
+  });
+
+  test('streams SSE bodies through without buffering the full response', async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const upstream = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch: () => {
+        const stream = new ReadableStream<Uint8Array>({
+          async start(controller) {
+            controller.enqueue(new TextEncoder().encode('data: {"type":"first"}\n\n'));
+            await gate;
+            controller.enqueue(new TextEncoder().encode('data: {"type":"second"}\n\n'));
+            controller.close();
+          },
+        });
+        return new Response(stream, { headers: { 'content-type': 'text/event-stream' } });
+      },
+    });
+    cleanups.push(() => upstream.stop(true));
+
+    const proxy = track(
+      startOpenCodeProxy({ runtimeUrl: `http://127.0.0.1:${upstream.port}`, token: 'tok-123' }),
+    );
+
+    const response = await fetch(`${proxy.url}/global/event`);
+    expect(response.headers.get('content-type')).toBe('text/event-stream');
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toContain('"first"');
+
+    release?.();
+    const second = await reader.read();
+    expect(decoder.decode(second.value)).toContain('"second"');
+    await reader.cancel();
+  });
+
+  test('keeps an idle SSE stream open past the 10s Bun.serve default idleTimeout', async () => {
+    let push: ((data: string) => void) | undefined;
+    const upstream = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      idleTimeout: 0,
+      fetch: () => {
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('data: {"type":"server.connected"}\n\n'));
+            push = (data) => {
+              controller.enqueue(new TextEncoder().encode(data));
+              controller.close();
+            };
+          },
+        });
+        return new Response(stream, { headers: { 'content-type': 'text/event-stream' } });
+      },
+    });
+    cleanups.push(() => upstream.stop(true));
+
+    const proxy = track(
+      startOpenCodeProxy({ runtimeUrl: `http://127.0.0.1:${upstream.port}`, token: 'tok-123' }),
+    );
+
+    const response = await fetch(`${proxy.url}/global/event`);
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toContain('server.connected');
+
+    await new Promise((resolve) => setTimeout(resolve, 11_000));
+    push?.('data: {"type":"after-idle"}\n\n');
+    const second = await reader.read();
+    expect(second.done).toBe(false);
+    expect(decoder.decode(second.value)).toContain('after-idle');
+  }, 20_000);
+
+  test('returns 502 when the upstream is unreachable', async () => {
+    const dead = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: () => new Response('') });
+    const deadUrl = `http://127.0.0.1:${dead.port}`;
+    dead.stop(true);
+
+    const proxy = track(startOpenCodeProxy({ runtimeUrl: deadUrl, token: 'tok-123' }));
+
+    const response = await fetch(`${proxy.url}/session/abc`);
+    expect(response.status).toBe(502);
+  });
+});
+
+describe('startOpenCodeProxy WebSocket', () => {
+  test('mirrors messages and appends the token as a query param upstream', async () => {
+    const seen: { token: string | null } = { token: null };
+    const upstream = Bun.serve<{ token: string | null }>({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch: (req, server) => {
+        const url = new URL(req.url);
+        seen.token = url.searchParams.get('token');
+        if (server.upgrade(req, { data: { token: seen.token } })) return undefined;
+        return new Response('no upgrade', { status: 400 });
+      },
+      websocket: {
+        message(ws, message) {
+          ws.send(`echo:${message}`);
+        },
+      },
+    });
+    cleanups.push(() => upstream.stop(true));
+
+    const proxy = track(
+      startOpenCodeProxy({ runtimeUrl: `http://127.0.0.1:${upstream.port}`, token: 'tok-123' }),
+    );
+
+    const ws = new WebSocket(`${proxy.url.replace('http:', 'ws:')}/pty/main`);
+    const echoed = await new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('ws echo timeout')), 5000);
+      ws.onmessage = (event) => {
+        clearTimeout(timer);
+        resolve(String(event.data));
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        reject(new Error('ws error'));
+      };
+      ws.onopen = () => ws.send('ping');
+    });
+    ws.close();
+
+    expect(echoed).toBe('echo:ping');
+    expect(seen.token).toBe('tok-123');
+  });
+});
+
+describe('startOpenCodeProxy lifecycle', () => {
+  test('close() tears the loopback listener down', async () => {
+    const upstream = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch: () => Response.json({ ok: true }),
+    });
+    cleanups.push(() => upstream.stop(true));
+
+    const proxy = startOpenCodeProxy({
+      runtimeUrl: `http://127.0.0.1:${upstream.port}`,
+      token: 'tok-123',
+    });
+    const before = await fetch(`${proxy.url}/session/abc`);
+    expect(before.status).toBe(200);
+
+    proxy.close();
+    await expect(fetch(`${proxy.url}/session/abc`)).rejects.toThrow();
+  });
+});

--- a/apps/cli/src/api/sdk.ts
+++ b/apps/cli/src/api/sdk.ts
@@ -138,6 +138,9 @@ export function startOpenCodeProxy(opts: StartOpenCodeProxyOpts): RunningOpenCod
   const server = Bun.serve<ProxyWsData>({
     hostname: '127.0.0.1',
     port: opts.port ?? 0,
+    // Bun's default 10s idleTimeout severs exactly the connections the TUI
+    // depends on: the idle global SSE event stream and long-blocking sends.
+    idleTimeout: 0,
     fetch: async (req, bunServer) => {
       const incoming = new URL(req.url);
       if (req.headers.get('upgrade')?.toLowerCase() === 'websocket') {

--- a/apps/cli/src/commands/home.ts
+++ b/apps/cli/src/commands/home.ts
@@ -1,0 +1,163 @@
+import { loadAuth } from '../api/auth.ts';
+import type { ProjectSession } from '../api/types.ts';
+import { resolveProjectContext, surfaceApiError } from '../command-helpers.ts';
+import { confirm } from '../prompts.ts';
+import { C, status } from '../style.ts';
+import { selectFromList } from '../tui-select.ts';
+import { runSessionsConnect } from './sessions-connect.ts';
+import { prepareClientCreatedBranch } from './sessions.ts';
+
+type Ctx = NonNullable<Awaited<ReturnType<typeof resolveProjectContext>>>;
+
+/** Session states a picked row has to traverse before `connect` can attach. */
+const DORMANT: ReadonlySet<ProjectSession['status']> = new Set(['stopped', 'completed', 'failed']);
+
+/**
+ * Bare `kortix` on an interactive terminal: pick a session in the bound
+ * project — running ones attach immediately, dormant ones are booted first,
+ * or start a fresh one — then hand the terminal to the full OpenCode TUI via
+ * `sessions connect`.
+ *
+ * Returns the sentinel `'landing'` when this flow does not apply (non-TTY, or
+ * not logged in) so `main` can fall back to the classic landing screen —
+ * scripts that run bare `kortix` for the command list keep working, and a
+ * logged-out human still gets the "run `kortix login`" landing instead of an
+ * error.
+ */
+export async function runHome(): Promise<number | 'landing'> {
+  if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) return 'landing';
+  if (!loadAuth()?.token) return 'landing';
+
+  // From here on this IS the connect command: resolveProjectContext prints its
+  // own guidance (and interactively binds a default project when none is
+  // linked), so a failure is a real error, not a landing fallback.
+  const ctx = await resolveProjectContext({});
+  if (!ctx) return 1;
+
+  let sessions: ProjectSession[];
+  try {
+    sessions = await ctx.client.get<ProjectSession[]>(`/projects/${ctx.projectId}/sessions`);
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+
+  const chosen = await pickSession(sessions);
+  if (chosen === null) {
+    process.stderr.write(
+      `${C.dim}Nothing selected. Run ${C.reset}${C.cyan}kortix help${C.reset}${C.dim} for all commands.${C.reset}\n`,
+    );
+    return 0;
+  }
+
+  let sessionId: string;
+  if (chosen === 'new') {
+    const created = await createSession(ctx);
+    if (!created) return 1;
+    sessionId = created;
+    if (!(await waitUntilReady(ctx, sessionId))) return 1;
+  } else {
+    sessionId = chosen.session_id;
+    if (chosen.status !== 'running') {
+      if (DORMANT.has(chosen.status)) {
+        try {
+          await ctx.client.post(`/projects/${ctx.projectId}/sessions/${sessionId}/restart`, {});
+        } catch (err) {
+          return surfaceApiError(err);
+        }
+      }
+      if (!(await waitUntilReady(ctx, sessionId))) return 1;
+    }
+  }
+
+  return runSessionsConnect([sessionId, '--project', ctx.projectId]);
+}
+
+async function pickSession(sessions: ProjectSession[]): Promise<ProjectSession | 'new' | null> {
+  if (sessions.length === 0) {
+    const start = await confirm('No sessions in this project yet — start one now?', true, {
+      onEndOfInput: false,
+    });
+    return start ? 'new' : null;
+  }
+
+  const byRecency = (a: ProjectSession, b: ProjectSession) =>
+    Date.parse(b.updated_at) - Date.parse(a.updated_at);
+  const running = sessions.filter((s) => s.status === 'running').sort(byRecency);
+  const booting = sessions
+    .filter((s) => !DORMANT.has(s.status) && s.status !== 'running')
+    .sort(byRecency);
+  const dormant = sessions
+    .filter((s) => DORMANT.has(s.status))
+    .sort(byRecency)
+    .slice(0, 15);
+
+  const row = (s: ProjectSession, hint: string) => ({
+    value: s as ProjectSession | 'new',
+    label: s.name ?? s.session_id.split('-')[0] ?? s.session_id,
+    sublabel: `${s.status} · ${s.session_id.split('-')[0]} · ${s.branch_name}${hint}`,
+  });
+
+  return selectFromList<ProjectSession | 'new'>({
+    title: 'Connect to a session',
+    items: [
+      ...running.map((s) => row(s, '')),
+      ...booting.map((s) => row(s, ' · waits for boot')),
+      ...dormant.map((s) => row(s, ' · starts it first')),
+      { value: 'new', label: '+ New session', sublabel: 'fresh sandbox on this project' },
+    ],
+  });
+}
+
+async function createSession(ctx: Ctx): Promise<string | null> {
+  const body: Record<string, unknown> = {};
+  if ((await prepareClientCreatedBranch(ctx, body)) === 'error') return null;
+  try {
+    const created = await ctx.client.post<ProjectSession>(
+      `/projects/${ctx.projectId}/sessions`,
+      body,
+    );
+    return created.session_id;
+  } catch (err) {
+    surfaceApiError(err);
+    return null;
+  }
+}
+
+/**
+ * Drive the canonical `/start` lifecycle endpoint until the runtime is ready —
+ * the same loop `sessions new --wait` runs (row status alone can say "running"
+ * before OpenCode actually answers). Sandbox boots take minutes, not seconds:
+ * up to 75 × 4s ≈ 5 min, matching the API's own provisioning ceiling.
+ */
+async function waitUntilReady(ctx: Ctx, sessionId: string): Promise<boolean> {
+  process.stderr.write(`${C.dim}  waiting for the sandbox to come up…${C.reset}\n`);
+  for (let i = 0; i < 75; i += 1) {
+    if (i > 0) await new Promise((r) => setTimeout(r, 4000));
+    let stage: string;
+    let reason: string | undefined;
+    try {
+      const start = await ctx.client.post<{
+        stage: 'provisioning' | 'starting' | 'ready' | 'stopped' | 'failed';
+        reason?: string;
+      }>(`/projects/${ctx.projectId}/sessions/${sessionId}/start`, {});
+      stage = start.stage;
+      reason = start.reason;
+    } catch (err) {
+      return surfaceApiError(err) === 0;
+    }
+    if (stage === 'ready') return true;
+    // A just-restarted session can report `stopped` for a few polls before the
+    // provisioner picks it up — only treat it as terminal once that grace is
+    // clearly over.
+    if (stage === 'stopped' && i < 5) continue;
+    if (stage === 'failed' || stage === 'stopped') {
+      process.stderr.write(
+        `${status.err(`Session did not start (${stage}${reason ? `: ${reason}` : ''}).`)}\n` +
+          `  ${C.dim}Try ${C.reset}${C.cyan}kortix sessions restart ${sessionId}${C.reset}${C.dim}, then ${C.reset}${C.cyan}kortix${C.reset}${C.dim} again.${C.reset}\n`,
+      );
+      return false;
+    }
+  }
+  process.stderr.write(`${status.err('Timed out waiting for the sandbox to start.')}\n`);
+  return false;
+}

--- a/apps/cli/src/commands/sessions-connect.ts
+++ b/apps/cli/src/commands/sessions-connect.ts
@@ -7,7 +7,7 @@ import {
   withKortixScope,
 } from '../api/sdk.ts';
 import { takeFlagValue } from '../command-helpers.ts';
-import { ensureOpencodeBin } from '../opencode-bin.ts';
+import { ensureOpencodeBin, isValidOpencodeVersion } from '../opencode-bin.ts';
 import { C, help, status } from '../style.ts';
 import {
   ensureOpencodeSession,
@@ -131,6 +131,10 @@ export async function runSessionsConnect(argv: string[]): Promise<number> {
  * `/global/health` — the sandbox image may be newer or older than this CLI's
  * baked pin, and the TUI must match the server, not the pin. Falls back to
  * undefined (→ the runtime-versions pin) when the probe fails.
+ *
+ * The value crosses a trust boundary: it comes from inside the sandbox and
+ * ends up in a download URL and an executable path, so anything that is not
+ * strictly `X.Y.Z(-tag)` is discarded, not truncated.
  */
 async function runtimeOpencodeVersion(resolved: ResolvedSession): Promise<string | undefined> {
   try {
@@ -138,7 +142,7 @@ async function runtimeOpencodeVersion(resolved: ResolvedSession): Promise<string
       await withKortixScope(resolved.auth, () => resolved.runtime.global.health()),
     );
     const version = (health as { version?: unknown }).version;
-    return typeof version === 'string' && /^\d+\.\d+\.\d+/.test(version) ? version : undefined;
+    return typeof version === 'string' && isValidOpencodeVersion(version) ? version : undefined;
   } catch {
     return undefined;
   }

--- a/apps/cli/src/commands/sessions-connect.ts
+++ b/apps/cli/src/commands/sessions-connect.ts
@@ -1,11 +1,18 @@
 import { spawn } from 'node:child_process';
 
-import { type RunningOpenCodeProxy, startOpenCodeProxy } from '../api/sdk.ts';
+import {
+  type RunningOpenCodeProxy,
+  startOpenCodeProxy,
+  unwrapRuntime,
+  withKortixScope,
+} from '../api/sdk.ts';
 import { takeFlagValue } from '../command-helpers.ts';
+import { ensureOpencodeBin } from '../opencode-bin.ts';
 import { C, help, status } from '../style.ts';
 import {
   ensureOpencodeSession,
   loadSessionForChat,
+  type ResolvedSession,
   resolveRunningSessionId,
 } from './sessions-chat.ts';
 
@@ -16,6 +23,10 @@ const CONNECT_HELP = help`Usage: kortix sessions connect [<session-id>] [options
 Attach your local OpenCode TUI to the OpenCode server already running inside a
 Kortix session sandbox. The CLI opens a local loopback proxy, injects your
 Kortix auth token, then runs \`opencode attach\` against it.
+
+The \`opencode\` binary is managed for you: the CLI downloads the exact version
+the session's server runs (cached under ~/.kortix/opencode/<version>/) so the
+TUI and server never skew. Set KORTIX_OPENCODE_BIN to force your own binary.
 
 Given a session id, resolves the right host/project on its own: tries the
 active/linked project first, then — unless you pin --host/--project — scans
@@ -79,6 +90,16 @@ export async function runSessionsConnect(argv: string[]): Promise<number> {
   const ocSessionId = await ensureOpencodeSession(resolved);
   if (!ocSessionId) return 1;
 
+  // Resolve (and, first time, download) the version-matched binary BEFORE the
+  // proxy exists — a multi-minute download must not sit on an open proxy.
+  let bin: string;
+  try {
+    bin = (await ensureOpencodeBin({ version: await runtimeOpencodeVersion(resolved) })).bin;
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n`);
+    return 1;
+  }
+
   let proxy: RunningOpenCodeProxy;
   try {
     proxy = startOpenCodeProxy({
@@ -99,9 +120,27 @@ export async function runSessionsConnect(argv: string[]): Promise<number> {
   );
 
   try {
-    return await spawnOpenCodeAttach(attachCommand);
+    return await spawnOpenCodeAttach(bin, attachCommand);
   } finally {
     proxy.close();
+  }
+}
+
+/**
+ * The version the session's OpenCode server actually runs, from its own
+ * `/global/health` — the sandbox image may be newer or older than this CLI's
+ * baked pin, and the TUI must match the server, not the pin. Falls back to
+ * undefined (→ the runtime-versions pin) when the probe fails.
+ */
+async function runtimeOpencodeVersion(resolved: ResolvedSession): Promise<string | undefined> {
+  try {
+    const health = unwrapRuntime(
+      await withKortixScope(resolved.auth, () => resolved.runtime.global.health()),
+    );
+    const version = (health as { version?: unknown }).version;
+    return typeof version === 'string' && /^\d+\.\d+\.\d+/.test(version) ? version : undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -132,8 +171,7 @@ function buildAttachArgs(url: string, opencodeSessionId: string, extraArgs: stri
   ];
 }
 
-function spawnOpenCodeAttach(args: string[]): Promise<number> {
-  const bin = process.env.KORTIX_OPENCODE_BIN || 'opencode';
+function spawnOpenCodeAttach(bin: string, args: string[]): Promise<number> {
   const child = spawn(bin, args, { stdio: 'inherit' });
   return new Promise((resolve) => {
     child.on('error', (err) => {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -552,7 +552,7 @@ async function sendPromptToSession(
   }
 }
 
-async function prepareClientCreatedBranch(
+export async function prepareClientCreatedBranch(
   ctx: { client: { get<T>(path: string): Promise<T> }; projectId: string },
   body: Record<string, unknown>,
 ): Promise<'ok' | 'error'> {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -26,7 +26,9 @@ import { runSandboxes } from './commands/sandboxes.ts';
 import { runSchema } from './commands/schema.ts';
 import { runSecrets } from './commands/secrets.ts';
 import { runSelfHost } from './commands/self-host.ts';
+import { runHome } from './commands/home.ts';
 import { runSessionsChat } from './commands/sessions-chat.ts';
+import { runSessionsConnect } from './commands/sessions-connect.ts';
 import { runSessions } from './commands/sessions.ts';
 import { runShip } from './commands/ship.ts';
 import { SYSTEM_SKILLS_COMMAND, runSystemSkills } from './commands/system-skills.ts';
@@ -149,6 +151,11 @@ const TIERS: readonly CommandTier[] = [
             name: 'sessions',
             args: '<subcommand>',
             blurb: 'List, create, restart project sessions',
+          },
+          {
+            name: 'connect',
+            args: '[session-id]',
+            blurb: 'Attach the full OpenCode TUI to a session (bare `kortix` does this too)',
           },
           {
             name: 'chat',
@@ -410,11 +417,21 @@ async function main(argv: string[]): Promise<number> {
     printVersion();
     return 0;
   }
-  // Bare `kortix` and explicit help are the same landing screen. Only the bare
-  // form offers to update: `kortix --help` is what people (and scripts) reach
-  // for to READ something, and it must never block on a question.
-  if (argv.length === 0 || argv[0] === 'help' || argv[0] === '--help' || argv[0] === '-h') {
-    await printLanding({ offerUpdate: argv.length === 0 });
+  // Bare `kortix` on an interactive, logged-in terminal connects you to a
+  // session (pick → boot if needed → full OpenCode TUI). Everywhere else —
+  // non-TTY, logged out — it stays the landing screen, so scripts that shell
+  // out to bare `kortix` for the command list keep working.
+  if (argv.length === 0) {
+    const home = await runHome();
+    if (home !== 'landing') return home;
+    await printLanding({ offerUpdate: true });
+    return 0;
+  }
+  // Explicit help is a landing screen that never blocks: `kortix --help` is
+  // what people (and scripts) reach for to READ something, so no update
+  // question and no interactive picker here.
+  if (argv[0] === 'help' || argv[0] === '--help' || argv[0] === '-h') {
+    await printLanding({ offerUpdate: false });
     return 0;
   }
   if (argv[0] === 'version') {
@@ -501,6 +518,11 @@ async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'chat') {
     return runSessionsChat(argv.slice(1));
   }
+  // Top-level aliases for `sessions connect` — the flagship "land me in the
+  // TUI" verb deserves a first-class name (bare `kortix` is its no-args form).
+  if (argv[0] === 'connect' || argv[0] === 'attach') {
+    return runSessionsConnect(argv.slice(1));
+  }
   if (argv[0] === 'files') {
     return runFiles(argv.slice(1));
   }
@@ -584,6 +606,8 @@ const KNOWN_COMMANDS = [
   'projects',
   'sessions',
   'chat',
+  'connect',
+  'attach',
   'files',
   'cr',
   'triggers',

--- a/apps/cli/src/opencode-bin.ts
+++ b/apps/cli/src/opencode-bin.ts
@@ -1,0 +1,165 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, renameSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { OPENCODE_VERSION } from '@kortix/shared';
+import * as tar from 'tar';
+
+import { C, status } from './style.ts';
+
+/**
+ * Resolves the `opencode` binary that `kortix connect` hands the terminal to.
+ *
+ * The TUI is a client of the OpenCode server running inside the session
+ * sandbox, and the two are only guaranteed compatible at the same version —
+ * the sandbox pin lives in @kortix/shared runtime-versions.json. So instead of
+ * requiring users to install and version-manage OpenCode themselves, the CLI
+ * keeps per-version managed binaries under ~/.kortix/opencode/<version>/ and
+ * downloads the missing one from the npm registry on first use (the same
+ * platform packages the official installer uses).
+ */
+
+export interface OpencodeBinResolution {
+  /** Executable to spawn — an absolute managed path, or a PATH lookup name. */
+  bin: string;
+  source: 'env' | 'managed' | 'path' | 'downloaded' | 'path-fallback';
+  /** Version the binary is known to be; null when unverifiable (env override). */
+  version: string | null;
+}
+
+export interface EnsureOpencodeBinOpts {
+  /** Exact server version to match; defaults to the runtime-versions pin. */
+  version?: string;
+  /** Test seam for the registry download. */
+  fetchImpl?: typeof fetch;
+  /** Test seam for the `opencode --version` PATH probe. */
+  probePathVersion?: () => string | null;
+}
+
+function managedRoot(): string {
+  return process.env.KORTIX_OPENCODE_DIR || join(homedir(), '.kortix', 'opencode');
+}
+
+export function managedOpencodePath(version: string): string {
+  return join(managedRoot(), version, 'opencode');
+}
+
+/** Pull an X.Y.Z(-tag) out of whatever `opencode --version` prints. */
+export function parseOpencodeVersion(output: string): string | null {
+  const match = output.match(/\b(\d+\.\d+\.\d+(?:-[\w.]+)?)\b/);
+  return match ? match[1] : null;
+}
+
+/**
+ * npm platform package holding the prebuilt binary, e.g. `opencode-darwin-arm64`.
+ * Throws on platforms OpenCode does not publish for.
+ */
+export function opencodePlatformPackage(
+  platform: string = process.platform,
+  arch: string = process.arch,
+  musl: boolean = isMuslLinux(platform),
+): string {
+  const os = platform === 'darwin' ? 'darwin' : platform === 'linux' ? 'linux' : null;
+  if (!os || (arch !== 'arm64' && arch !== 'x64')) {
+    throw new Error(
+      `No prebuilt OpenCode binary for ${platform}/${arch}. ` +
+        'Install OpenCode yourself and set KORTIX_OPENCODE_BIN.',
+    );
+  }
+  return `opencode-${os}-${arch}${os === 'linux' && musl ? '-musl' : ''}`;
+}
+
+function isMuslLinux(platform: string): boolean {
+  return platform === 'linux' && existsSync('/etc/alpine-release');
+}
+
+function probeOpencodeOnPath(): string | null {
+  try {
+    const probe = spawnSync('opencode', ['--version'], { encoding: 'utf8', timeout: 5000 });
+    if (probe.error || probe.status !== 0) return null;
+    return parseOpencodeVersion(`${probe.stdout ?? ''}\n${probe.stderr ?? ''}`);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolution order:
+ *   1. `KORTIX_OPENCODE_BIN` — explicit user override, used as-is.
+ *   2. Managed binary already cached for the wanted version.
+ *   3. `opencode` on PATH when its `--version` matches exactly.
+ *   4. Download the exact version from the npm registry into the cache.
+ * A failed download degrades to any PATH binary (with a version-skew warning)
+ * before giving up, so an offline machine that has OpenCode still connects.
+ */
+export async function ensureOpencodeBin(
+  opts: EnsureOpencodeBinOpts = {},
+): Promise<OpencodeBinResolution> {
+  const envBin = process.env.KORTIX_OPENCODE_BIN;
+  if (envBin) return { bin: envBin, source: 'env', version: null };
+
+  const version = opts.version ?? OPENCODE_VERSION;
+  const managed = managedOpencodePath(version);
+  if (existsSync(managed)) return { bin: managed, source: 'managed', version };
+
+  const probe = opts.probePathVersion ?? probeOpencodeOnPath;
+  const pathVersion = probe();
+  if (pathVersion === version) return { bin: 'opencode', source: 'path', version };
+
+  try {
+    await downloadOpencode(version, managed, opts.fetchImpl);
+    return { bin: managed, source: 'downloaded', version };
+  } catch (err) {
+    const reason = (err as Error).message;
+    if (pathVersion) {
+      process.stderr.write(
+        `${status.warn(`Could not download OpenCode v${version} (${reason}).`)}\n` +
+          `  ${C.dim}Falling back to \`opencode\` v${pathVersion} from PATH — the session server runs v${version}, so the TUI may misbehave.${C.reset}\n`,
+      );
+      return { bin: 'opencode', source: 'path-fallback', version: pathVersion };
+    }
+    throw new Error(
+      `Could not download OpenCode v${version}: ${reason}. ` +
+        'Install OpenCode (https://opencode.ai) or set KORTIX_OPENCODE_BIN.',
+    );
+  }
+}
+
+async function downloadOpencode(
+  version: string,
+  dest: string,
+  fetchImpl?: typeof fetch,
+): Promise<void> {
+  const pkg = opencodePlatformPackage();
+  const url = `https://registry.npmjs.org/${pkg}/-/${pkg}-${version}.tgz`;
+  process.stderr.write(
+    `${C.dim}Downloading OpenCode v${version} (~40 MB, one-time per version)…${C.reset}\n`,
+  );
+
+  const doFetch = fetchImpl ?? fetch;
+  const response = await doFetch(url);
+  if (!response.ok) throw new Error(`${url} → HTTP ${response.status}`);
+
+  const scratch = mkdtempSync(join(tmpdir(), 'kortix-opencode-'));
+  try {
+    const tgz = join(scratch, 'opencode.tgz');
+    // Buffer before writing: `Bun.write(path, response)` can hang forever on a
+    // streamed 40 MB body, while arrayBuffer() drains it in seconds.
+    await Bun.write(tgz, await response.arrayBuffer());
+    await tar.x({ file: tgz, cwd: scratch });
+    const extracted = join(scratch, 'package', 'bin', 'opencode');
+    if (!existsSync(extracted)) {
+      throw new Error(`${pkg}@${version} tarball did not contain package/bin/opencode`);
+    }
+    mkdirSync(dirname(dest), { recursive: true });
+    // Stage in the destination directory, then rename: a concurrent `kortix`
+    // downloading the same version must never see a half-written executable.
+    const staging = `${dest}.${process.pid}.staging`;
+    copyFileSync(extracted, staging);
+    chmodSync(staging, 0o755);
+    renameSync(staging, dest);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}

--- a/apps/cli/src/opencode-bin.ts
+++ b/apps/cli/src/opencode-bin.ts
@@ -45,9 +45,21 @@ export function managedOpencodePath(version: string): string {
   return join(managedRoot(), version, 'opencode');
 }
 
+/**
+ * Strict full-string semver check. The version reaches us from the session
+ * runtime's health endpoint — attacker-influenceable if the sandbox is
+ * compromised — and is spliced into both the registry download URL and the
+ * managed cache path, where anything beyond `X.Y.Z(-tag)` (a `/`, `..`, a
+ * newline) would redirect the download or escape the cache dir. Reject
+ * everything that is not exactly a version.
+ */
+export function isValidOpencodeVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$/.test(version);
+}
+
 /** Pull an X.Y.Z(-tag) out of whatever `opencode --version` prints. */
 export function parseOpencodeVersion(output: string): string | null {
-  const match = output.match(/\b(\d+\.\d+\.\d+(?:-[\w.]+)?)\b/);
+  const match = output.match(/\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)\b/);
   return match ? match[1] : null;
 }
 
@@ -100,6 +112,9 @@ export async function ensureOpencodeBin(
   if (envBin) return { bin: envBin, source: 'env', version: null };
 
   const version = opts.version ?? OPENCODE_VERSION;
+  if (!isValidOpencodeVersion(version)) {
+    throw new Error(`Refusing malformed OpenCode version "${version}".`);
+  }
   const managed = managedOpencodePath(version);
   if (existsSync(managed)) return { bin: managed, source: 'managed', version };
 

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -85,18 +85,27 @@ Each session runs in its own sandbox, on its own branch. `--wait` blocks until t
 Attach to a session from your terminal:
 
 ```sh
+kortix
+```
+
+Bare `kortix` on an interactive, logged-in terminal opens a session picker for
+the bound project — running sessions attach immediately, stopped ones boot
+first, and `+ New session` starts a fresh sandbox — then lands you in the full
+OpenCode TUI attached to that session. The same flow is available explicitly as
+`kortix connect [<session-id>]` (alias: `attach`).
+
+The CLI manages the `opencode` binary for you: on first connect it downloads
+the exact version the session's server runs and caches it under
+`~/.kortix/opencode/<version>/`, so the TUI and server never skew. Set
+`KORTIX_OPENCODE_BIN` to force your own binary.
+
+For a lighter-weight line-based chat instead of the full TUI, run:
+
+```sh
 kortix sessions chat
 ```
 
 This opens an interactive chat with your most recent session. Add an id to target a specific session: `kortix sessions chat <id>`.
-
-To attach your local OpenCode client to the sandbox instead, run:
-
-```sh
-kortix sessions connect
-```
-
-This command attaches to the OpenCode REST process.
 
 To open a raw shell in the sandbox, with no agent involved, run:
 
@@ -243,7 +252,7 @@ Each session runs in one sandbox on its own branch.
 | `kortix sessions info <id> [--json]` | Detail view: status, branch, agent, sandbox URL. |
 | `kortix sessions new [--prompt "<text>"] [--agent <name>] [--model <id>] [--wait] [--json]` | Start a session. `--model <id>` overrides the project's default model. `--wait` blocks until it is running (up to ~5 minutes). Use `--secret <id>` or `--no-secrets` to narrow Secret access. These Secret flags require a backend token. Use `--connector <alias>=<authorization-id>` or `--no-connectors` to set Connector access. Use `--require-connector <alias>` to require an authorization before provisioning. Scope flags are repeatable. Use `--context <key>=<value>` for non-secret runtime context. |
 | `kortix sessions chat [<id>] [--prompt "<text>"] [--new] [--agent <name>] [--json]` | Talk to a session's agent. Interactive by default. Alias: `talk`. Top-level `kortix chat` also works. |
-| `kortix sessions connect [<id>] [-- <opencode args>]` | Attach your local OpenCode TUI to the OpenCode REST compatibility process in the sandbox. Alias: `attach`. |
+| `kortix sessions connect [<id>] [-- <opencode args>]` | Attach the OpenCode TUI to the session's OpenCode server. Also available top-level: `kortix connect` / `kortix attach`, and bare `kortix` opens a session picker first. The CLI auto-downloads the version-matched `opencode` binary (cache: `~/.kortix/opencode/<version>/`; override: `KORTIX_OPENCODE_BIN`). |
 | `kortix sessions shell [<id>] [--new]` | Open a raw interactive terminal in the sandbox, with no agent. Aliases: `terminal`, `ssh`. |
 | `kortix sessions log [<id>] [--limit <n>] [--json]` | Print recent messages, read-only. Aliases: `messages`, `history`. |
 | `kortix sessions pending <id> [--json]` | List open tool-permission or question prompts. Alias: `prompts`. |


### PR DESCRIPTION
## What

Type `kortix` and you land in the full OpenCode TUI attached to a session.

- **Bare `kortix`** (interactive TTY + logged in): session picker for the bound project — running sessions attach immediately, stopped/completed/failed ones are restarted and awaited via the canonical `/start` loop, `+ New session` provisions a fresh sandbox. Non-TTY and logged-out invocations keep the existing landing screen, so scripts and first-run UX are unchanged. Esc exits with a `kortix help` hint.
- **Top-level `kortix connect` / `kortix attach`** aliases for `sessions connect`.
- **Managed `opencode` binary.** `connect` asks the session's OpenCode server for its version (`global.health` via the SDK runtime client) and downloads that exact version from the npm registry into `~/.kortix/opencode/<version>/` (one-time per version, ~40 MB). Resolution order: `KORTIX_OPENCODE_BIN` → cached managed binary → PATH `opencode` iff exact version match → download. Offline degrades to the PATH binary with a version-skew warning. Fallback pin when the health probe fails: `OPENCODE_VERSION` from `@kortix/shared` runtime-versions (1.17.11), the same pin the sandbox image bakes.
- **Reliability fix:** `startOpenCodeProxy` ran on `Bun.serve`'s default 10s `idleTimeout`, which severed the TUI's idle SSE event stream (`[Bun.serve]: request timed out after 10 seconds` observed live). Now `idleTimeout: 0`.

## Why

`kortix sessions connect` already proxied auth into `opencode attach`, but it required a user-installed, version-unmanaged `opencode` on PATH, had zero test coverage, silently killed the event stream after 10s idle, and was buried three words deep. The TUI/server pair is only guaranteed compatible at the same version; managing the binary per-session-version removes the skew class entirely.

## Verification (all against real surfaces)

Local gates:
- `pnpm --filter @kortix/cli test` → sdk-boundary 0 violations, **783 pass / 0 fail** (includes new suites: proxy auth-injection, SSE passthrough incl. an 11s-idle regression test, WS token mirror, 502, close; opencode-bin resolution matrix; runHome TTY/auth gating).
- `tsc --noEmit` clean.

Live E2E against `dev-api.kortix.com` (project `05b9519d`, session `da2c04ee` on a real Daytona sandbox), driven under a real pty:
1. `kortix connect da2c04ee…` with empty cache → downloaded `opencode-darwin-arm64@1.17.11` from the registry (matches the server's health version), cached at `<dir>/1.17.11/opencode` (`--version` → `1.17.11`), TUI entered alt-screen and rendered the session (`Build · Grok 4.5 Kortix`), attached to `ses_01740e93bffeydSCa0HYIWOisc`, exit 0.
2. Re-run → no download (cache hit), no `request timed out` in the capture after the idleTimeout fix.
3. Bare `kortix` (temp config bound to the dev project) → picker listed 1 running + dormant sessions + `+ New session`; Enter attached the TUI to the same OpenCode session; Esc path exits 0 with the help hint.

## Notes

- Pre-existing, unrelated: `projects ls --host <dev>` fails with `HTTP 0` on this machine at the base commit too (direct authenticated curl of `/v1/projects` returns 200) — not touched here, needs its own investigation.
- `prepareClientCreatedBranch` is now exported from `sessions.ts` (reused by the home flow's `+ New session` path).
