### PR TITLE
feat(web): expose session restart actions in command palette

### DIFF
--- a/apps/web/src/features/workspace/command-palette-visibility.test.ts
+++ b/apps/web/src/features/workspace/command-palette-visibility.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+
+import { LEGACY_PALETTE_HIDDEN } from '@/features/workspace/command-palette-visibility';
+import { menuRegistry } from '@/lib/menu-registry';
+
+describe('session restart command palette actions', () => {
+  test('exposes both restart actions only for active sessions', () => {
+    for (const id of ['restart-config', 'restart-full']) {
+      const item = menuRegistry.find((entry) => entry.id === id);
+
+      expect(item?.showIn).toContain('commandPalette');
+      expect(item?.requiresSession).toBe(true);
+      expect(LEGACY_PALETTE_HIDDEN.has(id)).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/features/workspace/command-palette-visibility.ts
+++ b/apps/web/src/features/workspace/command-palette-visibility.ts
@@ -1,0 +1,24 @@
+/**
+ * Legacy workspace commands that remain hidden from the session command palette.
+ *
+ * Session actions use the menu registry directly and must not be added here.
+ */
+export const LEGACY_PALETTE_HIDDEN = new Set([
+  'workspace',
+  'dashboard',
+  'scheduled-tasks',
+  'files',
+  'tunnel',
+  'running-services-cmd',
+  'agent-browser-cmd',
+  'internal-browser-cmd',
+  'desktop-cmd',
+  'templates',
+  'changelog',
+  'credits-explained',
+  'secrets-manager',
+  'api-keys',
+  'llm-providers',
+  'open-terminal',
+  'ssh-quick',
+]);

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -24,6 +24,7 @@ import Loading from '@/components/ui/loading';
 import { SidebarContext } from '@/components/ui/sidebar';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { openSessionQuickView } from '@/features/session/open-session-quick-view';
+import { LEGACY_PALETTE_HIDDEN } from '@/features/workspace/command-palette-visibility';
 import {
   consumePendingCommandPalette,
   OPEN_COMMAND_PALETTE_EVENT,
@@ -124,28 +125,6 @@ function sanitizeCmdkValue(value: string): string {
     .replace(/\s+/g, ' ')
     .trim();
 }
-
-const LEGACY_PALETTE_HIDDEN = new Set([
-  'workspace',
-  'dashboard',
-  'scheduled-tasks',
-  'files',
-  'tunnel',
-  'running-services-cmd',
-  'agent-browser-cmd',
-  'internal-browser-cmd',
-  'desktop-cmd',
-  'templates',
-  'changelog',
-  'credits-explained',
-  'secrets-manager',
-  'api-keys',
-  'llm-providers',
-  'open-terminal',
-  'restart-config',
-  'restart-full',
-  'ssh-quick',
-]);
 
 const SUBMENU_PAGE_BY_ID: Record<string, PalettePage> = {
   'nav-projects': 'projects',

--- a/apps/web/src/lib/menu-registry.ts
+++ b/apps/web/src/lib/menu-registry.ts
@@ -319,6 +319,7 @@ export const menuRegistry: MenuItemDef[] = [
     kind: 'action',
     actionId: 'restartConfig',
     keywords: 'reload restart config agents skills commands',
+    requiresSession: true,
   },
   {
     id: 'restart-full',
@@ -332,6 +333,7 @@ export const menuRegistry: MenuItemDef[] = [
     kind: 'action',
     actionId: 'restartFull',
     keywords: 'reload restart full services kill nuclear pull refresh workspace',
+    requiresSession: true,
   },
 
   // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- expose Config Only and Pull & Restart Runtime actions in the session command palette
- scope both commands to an active session
- keep legacy workspace commands hidden without hiding session restarts
- add focused visibility coverage

## Verification
- `bun test src/features/workspace/command-palette-visibility.test.ts`
- `bunx eslint src/features/workspace/command-palette.tsx src/features/workspace/command-palette-visibility.ts src/features/workspace/command-palette-visibility.test.ts src/lib/menu-registry.ts` (existing warnings only)
- local Next server compiled `/auth` and returned HTTP 200
- full `tsc --noEmit` reports existing unrelated baseline errors in test typings and generated `.source` modules