### PR TITLE
fix(daemon): never abort a turn that is still being written

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/never-abort-live-turn.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/never-abort-live-turn.test.ts
@@ -1,0 +1,123 @@
+/**
+ * A turn that is still being written must never be aborted.
+ *
+ * The daemon closes turns that a dying opencode left unfinished, so a client
+ * streaming one stops spinning. It decided "unfinished" as
+ * `role === 'assistant' && !time.completed` — which is equally true of a turn
+ * that is STREAMING RIGHT NOW.
+ *
+ * Aborting that one ends a healthy answer and stamps it with an AbortError,
+ * which the web renders as "Interrupted" (session-error-banner.tsx) underneath
+ * a reply that finished perfectly well. Reported from dev: a first "hey" got a
+ * complete greeting, labelled Interrupted.
+ *
+ * The two cases separate by WAITING. Nothing is writing an orphaned turn, so it
+ * stays unfinished forever; a live one completes in moments. So: look twice.
+ *
+ * Asserted on source — the real path needs a live opencode, its message API and
+ * a genuine race. What regresses is the ORDER and the CONDITION, both visible.
+ */
+import { describe, expect, test } from 'bun:test';
+
+const SRC = await Bun.file(new URL('../main.ts', import.meta.url).pathname).text();
+
+function code(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n');
+}
+
+function fn(name: string): string {
+  const start = SRC.indexOf(`async function ${name}(`);
+  expect(start).toBeGreaterThan(-1);
+  return code(SRC.slice(start, SRC.indexOf('\n}\n', start)));
+}
+
+describe('confirmTurnOrphaned', () => {
+  const body = fn('confirmTurnOrphaned');
+
+  test('waits before deciding', () => {
+    // The wait IS the discriminator. Without it there is nothing to distinguish
+    // "nobody is writing this" from "not written YET".
+    expect(body).toContain('ORPHAN_SETTLE_MS');
+    expect(body).toMatch(/setTimeout/);
+  });
+
+  test('re-reads the turn rather than trusting the first look', () => {
+    expect(body).toContain('await inspectRoot(');
+  });
+
+  test('refuses when the turn finished during the wait', () => {
+    // The exact case that produced "Interrupted" on a complete answer.
+    const guardAt = body.indexOf('if (!second.lastTurnIncomplete)');
+    expect(guardAt).toBeGreaterThan(-1);
+    // The refusal must come out of that branch, before the function can ever
+    // reach its `return true`.
+    const refuseAt = body.indexOf('return false', guardAt);
+    expect(refuseAt).toBeGreaterThan(guardAt);
+    expect(refuseAt).toBeLessThan(body.indexOf('return true'));
+  });
+
+  test('refuses when a DIFFERENT turn started meanwhile', () => {
+    // Identity, not just state: a new turn is certainly alive, and aborting it
+    // would interrupt work that started after we decided to clean up.
+    expect(body).toContain('second.lastMessageId !== first.lastMessageId');
+  });
+
+  test('only returns true for a turn that is still unfinished AND unchanged', () => {
+    const returns = body.split('\n').filter((l) => l.includes('return '));
+    expect(returns.filter((l) => l.includes('true'))).toHaveLength(1);
+    expect(returns.filter((l) => l.includes('false')).length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('every abort site goes through the guard', () => {
+  test('finalizeOrphanedTurn confirms before aborting', () => {
+    const body = fn('finalizeOrphanedTurn');
+    const confirmAt = body.indexOf('confirmTurnOrphaned(');
+    const abortAt = body.indexOf('abortOpencodeTurn(');
+    expect(confirmAt).toBeGreaterThan(-1);
+    expect(abortAt).toBeGreaterThan(confirmAt);
+  });
+
+  test('the reused-root boot path confirms too', () => {
+    // Two independent call sites reached the same abort. Fixing only the
+    // respawn one would leave a session re-adopting a warm root still able to
+    // kill a live turn.
+    const src = code(SRC);
+    const reuse = src.slice(src.indexOf('existing.lastTurnIncomplete'));
+    expect(reuse.slice(0, 220)).toContain('confirmTurnOrphaned(');
+  });
+
+  test('no abort call bypasses the guard', () => {
+    const src = code(SRC);
+    // Every abortOpencodeTurn call except the definition must be preceded by a
+    // confirm in the same function. Counted rather than parsed: two call sites,
+    // two confirms.
+    const aborts = [...src.matchAll(/await abortOpencodeTurn\(/g)].length;
+    const confirms = [...src.matchAll(/confirmTurnOrphaned\(/g)].length;
+    // one definition + two uses
+    expect(confirms).toBe(aborts + 1);
+  });
+});
+
+describe('inspectRoot carries turn identity', () => {
+  test('reports the last message id', () => {
+    // Without it the re-check cannot tell a new turn from the old one.
+    const body = fn('inspectRoot');
+    expect(body).toContain('lastMessageId');
+    expect(body).toContain('last?.info?.id');
+  });
+
+  test('every early return still supplies the field', () => {
+    // A missing id silently disables the "different turn" half of the guard.
+    const body = fn('inspectRoot');
+    // Split on the returns themselves — several are multi-line, so a per-line
+    // scan would miss the field sitting two lines below `return {`.
+    const blocks = body.split('return {').slice(1);
+    expect(blocks.length).toBeGreaterThan(1);
+    for (const b of blocks) expect(b.slice(0, 220)).toContain('lastMessageId');
+  });
+});

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -878,7 +878,12 @@ async function maybeCreateInitialOpencodeSession(
     })
     // A turn interrupted by the restart left a part stuck "running"; finalize it
     // so a client streaming this root sees the turn end instead of spinning.
-    if (existing.lastTurnIncomplete) await abortOpencodeTurn(baseUrl, workspace, sessionId)
+    if (
+      existing.lastTurnIncomplete &&
+      (await confirmTurnOrphaned(baseUrl, workspace, sessionId, existing))
+    ) {
+      await abortOpencodeTurn(baseUrl, workspace, sessionId)
+    }
     bootMark('runtime-session-resume-requested')
   } else {
     logger.info('[boot] creating initial opencode session', {
@@ -962,6 +967,10 @@ export async function finalizeOrphanedTurn(
 ): Promise<boolean> {
   const inspection = await inspectRoot(baseUrl, workspace, sessionId)
   if (!inspection.lastTurnIncomplete) return false
+  // Never abort a turn that is merely still being written — see
+  // confirmTurnOrphaned. This is the difference between closing a turn its
+  // opencode took to the grave and interrupting one that was about to finish.
+  if (!(await confirmTurnOrphaned(baseUrl, workspace, sessionId, inspection))) return false
   await abortOpencodeTurn(baseUrl, workspace, sessionId)
   return true
 }
@@ -1021,7 +1030,14 @@ async function deleteOpencodeSession(baseUrl: string, workspace: string, session
   }
 }
 
-interface ExistingRoot { id: string; hasMessages: boolean; lastTurnIncomplete: boolean }
+interface ExistingRoot {
+  id: string
+  hasMessages: boolean
+  lastTurnIncomplete: boolean
+  /** Carried through so the orphan re-check can tell the same unfinished turn
+   *  from a different one that started since. */
+  lastMessageId: string | null
+}
 
 /**
  * Resolve a usable existing canonical root for this workspace so a restart
@@ -1040,7 +1056,12 @@ async function resolveExistingRoot(baseUrl: string, workspace: string): Promise<
   const chosen = (pinned && roots.find((r) => r.id === pinned)) || pickMostRecentRoot(roots)
   if (!chosen) return null
   const inspection = await inspectRoot(baseUrl, workspace, chosen.id)
-  return { id: chosen.id, hasMessages: inspection.hasMessages, lastTurnIncomplete: inspection.lastTurnIncomplete }
+  return {
+    id: chosen.id,
+    hasMessages: inspection.hasMessages,
+    lastTurnIncomplete: inspection.lastTurnIncomplete,
+    lastMessageId: inspection.lastMessageId,
+  }
 }
 
 interface RootLite { id: string; created: number; updated: number }
@@ -1097,7 +1118,30 @@ function pickMostRecentRoot(roots: RootLite[]): RootLite | null {
   return best
 }
 
-interface RootInspection { hasMessages: boolean; lastTurnIncomplete: boolean }
+interface RootInspection {
+  hasMessages: boolean
+  lastTurnIncomplete: boolean
+  /** Identity of the last message, so a re-check can tell "same turn, still
+   *  unfinished" from "a different turn has since started". */
+  lastMessageId: string | null
+}
+
+/**
+ * How long to let an "incomplete" turn prove itself alive before aborting it.
+ *
+ * `lastTurnIncomplete` is `role === 'assistant' && !time.completed`, which is
+ * equally true of a turn nobody is writing (orphaned by a dead opencode) and
+ * one that is streaming right now. Aborting the second kind ends a healthy turn
+ * and stamps it with an AbortError, which the UI renders as "Interrupted" under
+ * an answer that finished perfectly well.
+ *
+ * The two are separable by waiting: nothing is writing an orphaned turn, so it
+ * stays incomplete forever, while a live one completes in moments. Two seconds
+ * is far longer than the gap between opencode finishing a turn and stamping
+ * `time.completed`, and it costs nothing on the path that matters — a genuinely
+ * orphaned turn is already broken and two seconds later still is.
+ */
+const ORPHAN_SETTLE_MS = 2_000
 
 /** Does the root already have messages (prompt delivered), and is its last turn
  *  an assistant message left incomplete by a crash (no completion time)? */
@@ -1107,15 +1151,52 @@ async function inspectRoot(baseUrl: string, workspace: string, sessionId: string
       `${baseUrl}/session/${encodeURIComponent(sessionId)}/message?directory=${encodeURIComponent(workspace)}`,
       { signal: AbortSignal.timeout(5_000) },
     )
-    if (!res.ok) return { hasMessages: false, lastTurnIncomplete: false }
-    const msgs = (await res.json()) as Array<{ info?: { role?: string; time?: { completed?: number } } }>
-    if (!Array.isArray(msgs) || msgs.length === 0) return { hasMessages: false, lastTurnIncomplete: false }
+    if (!res.ok) return { hasMessages: false, lastTurnIncomplete: false, lastMessageId: null }
+    const msgs = (await res.json()) as Array<{
+      info?: { id?: string; role?: string; time?: { completed?: number } }
+    }>
+    if (!Array.isArray(msgs) || msgs.length === 0) {
+      return { hasMessages: false, lastTurnIncomplete: false, lastMessageId: null }
+    }
     const last = msgs[msgs.length - 1]
     const incomplete = last?.info?.role === 'assistant' && !last?.info?.time?.completed
-    return { hasMessages: true, lastTurnIncomplete: Boolean(incomplete) }
+    return {
+      hasMessages: true,
+      lastTurnIncomplete: Boolean(incomplete),
+      lastMessageId: last?.info?.id ?? null,
+    }
   } catch {
-    return { hasMessages: false, lastTurnIncomplete: false }
+    return { hasMessages: false, lastTurnIncomplete: false, lastMessageId: null }
   }
+}
+
+/**
+ * Is the turn actually ORPHANED, or just still being written?
+ *
+ * Look again after a settle window. Nothing is writing an orphaned turn, so it
+ * is still incomplete; a live one has finished, and aborting it would have
+ * ended a healthy answer and labelled it "Interrupted".
+ *
+ * Also refuses when the last message CHANGED — a different turn started in the
+ * meantime, and that one is certainly alive.
+ */
+async function confirmTurnOrphaned(
+  baseUrl: string,
+  workspace: string,
+  sessionId: string,
+  first: RootInspection,
+): Promise<boolean> {
+  await new Promise((r) => setTimeout(r, ORPHAN_SETTLE_MS))
+  const second = await inspectRoot(baseUrl, workspace, sessionId)
+  if (!second.lastTurnIncomplete) {
+    logger.info('[boot] turn completed on its own; not aborting', { sessionId })
+    return false
+  }
+  if (first.lastMessageId && second.lastMessageId !== first.lastMessageId) {
+    logger.info('[boot] a newer turn started; not aborting', { sessionId })
+    return false
+  }
+  return true
 }
 
 /** Finalize an interrupted turn so a streaming client stops spinning. */


### PR DESCRIPTION
## The bug

A first "hey" on dev got a complete, well-formed greeting — and **"Interrupted"**
underneath it.

The daemon closes turns that a dying opencode left unfinished, so a client
streaming one stops spinning. It judged "unfinished" as:

```ts
role === 'assistant' && !time.completed
```

which is equally true of a turn that is **streaming right now**. Aborting that
one ends a healthy answer and stamps it with an `AbortError`, which
`session-error-banner.tsx` renders as "Interrupted". The text still shows,
because it had already streamed — hence a reply that looks finished *and*
interrupted.

## The fix

The two cases separate by **waiting**. Nothing is writing an orphaned turn, so
it stays unfinished forever; a live one completes in moments.

`confirmTurnOrphaned` looks again after a 2s settle and aborts only when the
turn is **still unfinished** *and* **still the same message**. A different last
message means a newer turn started — and that one is certainly alive.

Both abort sites go through it:

- the post-respawn finalize (`finalizeOrphanedTurn`)
- the reused-root boot path

Fixing only the first would leave a session adopting a warm root still able to
kill a live turn — two independent call sites reached the same abort.

The settle costs nothing where it matters: a genuinely orphaned turn is already
broken, and two seconds later it still is.

## Verification

Daemon **465 pass / 0 fail**, `tsc` clean.

Guard proven against the exact pre-fix code — removing both confirms fails 3
tests:

```
(fail) finalizeOrphanedTurn confirms before aborting
(fail) the reused-root boot path confirms too
(fail) no abort call bypasses the guard
```

The last one counts call sites rather than trusting a spot check, so a third
abort added later without a confirm fails too.

## Still open

`isAbortError` in the web matches the **bare substring** `'abort'`:

```js
const ABORT_PATTERNS = ['aborted', 'abort', 'cancelled', 'canceled'];
lower.includes(p)
```

So any error text merely mentioning the word renders as a user interruption.
That's a separate mislabel risk — left alone here because tightening it could
hide genuine aborts, and the root cause is fixed above.

## Note on verifying this live

Daemon change, so it only reaches sandboxes built from a new image, and a
session boots from its **project's pinned image** — creating another session in
the same project keeps the old daemon. A freshly provisioned project is the way
to get it.