### PR TITLE
fix(web): "Interrupted" must mean interrupted, not "the word abort appeared"

### DIFF
--- a/apps/web/src/features/session/interrupted-label.test.ts
+++ b/apps/web/src/features/session/interrupted-label.test.ts
@@ -67,7 +67,10 @@ describe('wiring', () => {
 
   test('the transcript reads the structured error name', () => {
     const src = code(CHAT);
-    expect(src).toContain("name?: unknown }).name === 'AbortError'");
+    // Narrowed to a string before the comparison — comparing the raw `unknown`
+    // to a literal is the inconvertible-types smell CodeQL flags, and it would
+    // read false for a boxed String.
+    expect(src).toContain("typeof name === 'string' && name === 'AbortError'");
   });
 
   test('BOTH render sites pass it', () => {

--- a/apps/web/src/features/session/interrupted-label.test.ts
+++ b/apps/web/src/features/session/interrupted-label.test.ts
@@ -1,0 +1,84 @@
+/**
+ * "Interrupted" must mean the turn was actually interrupted.
+ *
+ * The label is a muted one-liner that REPLACES the error card. So mislabelling
+ * costs twice: the user is told they stopped something they didn't, and the
+ * real failure is never shown.
+ *
+ * It was decided by substring-matching the error's display text for "abort" /
+ * "cancel". `getTurnError` flattens the structured error to a string and drops
+ * its `name`, so that was the only signal left — and it fires on any message
+ * that merely contains the word.
+ *
+ * The transcript can read the identity directly off the message, so it now
+ * passes `isAbort`. The prose sniff survives only for the send-failure path,
+ * where a message really is all there is.
+ */
+import { describe, expect, test } from 'bun:test';
+
+const BANNER = await Bun.file(
+  new URL('./session-error-banner.tsx', import.meta.url).pathname,
+).text();
+const CHAT = await Bun.file(new URL('./session-chat.tsx', import.meta.url).pathname).text();
+
+function code(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n');
+}
+
+/** The predicate the banner uses, mirrored. */
+function rendersInterrupted(isAbort: boolean | undefined, text: string): boolean {
+  const patterns = ['aborted', 'abort', 'cancelled', 'canceled'];
+  return isAbort ?? patterns.some((p) => text.toLowerCase().includes(p));
+}
+
+describe('identity wins over prose', () => {
+  test('a real abort is labelled Interrupted', () => {
+    expect(rendersInterrupted(true, 'The operation was aborted.')).toBe(true);
+  });
+
+  test('a genuine failure that merely says "aborted" is NOT', () => {
+    // The bug. This is a real error the user needs to see, not a muted note
+    // telling them they stopped their own turn.
+    expect(rendersInterrupted(false, 'upstream connection aborted by peer')).toBe(false);
+    expect(rendersInterrupted(false, 'signal is aborted without reason')).toBe(false);
+    expect(rendersInterrupted(false, 'stream cancelled by server')).toBe(false);
+  });
+
+  test('a clean turn shows nothing either way', () => {
+    // No error text at all → the component returns null before any of this.
+    expect(rendersInterrupted(false, '')).toBe(false);
+  });
+
+  test('the prose sniff still covers a caller that cannot tell', () => {
+    // The send-failure path has only a message.
+    expect(rendersInterrupted(undefined, 'Request aborted')).toBe(true);
+    expect(rendersInterrupted(undefined, 'Payment required')).toBe(false);
+  });
+});
+
+describe('wiring', () => {
+  test('the banner prefers the explicit signal', () => {
+    expect(code(BANNER)).toContain('isAbort ?? looksLikeAbortText(text)');
+  });
+
+  test('the transcript reads the structured error name', () => {
+    const src = code(CHAT);
+    expect(src).toContain("name?: unknown }).name === 'AbortError'");
+  });
+
+  test('BOTH render sites pass it', () => {
+    // There are two: the compact row and the full transcript. Wiring one leaves
+    // the other sniffing prose, and which one you see depends on the layout.
+    const hits = [...code(CHAT).matchAll(/isAbort=\{turnErrorIsAbort\}/g)];
+    expect(hits.length).toBe(2);
+  });
+
+  test('the sniff is no longer named as if it were authoritative', () => {
+    // It was `isAbortError`, which read like a fact. It is a guess.
+    expect(code(BANNER)).not.toContain('function isAbortError(');
+  });
+});

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -743,6 +743,27 @@ function SessionTurnImpl({
     return undefined;
   }, [turn]);
 
+  /**
+   * Was the turn ACTUALLY aborted, as opposed to failing with a message that
+   * happens to contain the word?
+   *
+   * `getTurnError` flattens the structured error to a display string and drops
+   * its `name`, so the banner was left substring-matching "abort" over arbitrary
+   * prose — which renders a genuine failure as a muted "Interrupted" and hides
+   * what really went wrong. The identity is right here on the message; read it.
+   *
+   * Both real producers set `name: 'AbortError'`: opencode's own abort, and the
+   * optimistic patch applied when the user hits Stop.
+   */
+  const turnErrorIsAbort = useMemo(() => {
+    for (const msg of turn.assistantMessages) {
+      const err = (msg.info as { error?: unknown }).error;
+      if (!err) continue;
+      return typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'AbortError';
+    }
+    return false;
+  }, [turn]);
+
   // The gateway's structured fields (provider/suggestion/request_id) for
   // `turnError`, when recoverable — lets TurnErrorDisplay render WHICH
   // provider failed and WHAT to do about it instead of only the raw message.
@@ -1164,6 +1185,7 @@ function SessionTurnImpl({
           <TurnErrorDisplay
             errorText={turnError}
             errorDetails={turnErrorDetails}
+            isAbort={turnErrorIsAbort}
             className="mt-2"
           />
         )}
@@ -1439,7 +1461,13 @@ function SessionTurnImpl({
       )}
 
       {/* ── Error (abort / failure banner) ── */}
-      {turnError && <TurnErrorDisplay errorText={turnError} errorDetails={turnErrorDetails} />}
+      {turnError && (
+        <TurnErrorDisplay
+          errorText={turnError}
+          errorDetails={turnErrorDetails}
+          isAbort={turnErrorIsAbort}
+        />
+      )}
 
       {/* Question prompt — now rendered inside the chat input card (questionSlot) */}
 

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -758,8 +758,12 @@ function SessionTurnImpl({
   const turnErrorIsAbort = useMemo(() => {
     for (const msg of turn.assistantMessages) {
       const err = (msg.info as { error?: unknown }).error;
-      if (!err) continue;
-      return typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'AbortError';
+      if (!err || typeof err !== 'object') continue;
+      // Narrow to a string BEFORE comparing — `name` is `unknown` here, and
+      // comparing that to a literal is the inconvertible-types smell CodeQL
+      // flags (and would silently be false for a boxed String or a symbol).
+      const name = (err as { name?: unknown }).name;
+      return typeof name === 'string' && name === 'AbortError';
     }
     return false;
   }, [turn]);

--- a/apps/web/src/features/session/session-error-banner.tsx
+++ b/apps/web/src/features/session/session-error-banner.tsx
@@ -26,7 +26,16 @@ import {
 
 const ABORT_PATTERNS = ['operation was aborted', 'aborted', 'abort', 'cancelled', 'canceled'];
 
-function isAbortError(text: string): boolean {
+/**
+ * LAST RESORT ONLY — a substring sniff over arbitrary error prose.
+ *
+ * `'abort'` bare matches any message that merely mentions the word, so a real
+ * failure ("upstream connection aborted", "signal is aborted without reason")
+ * renders as a muted "Interrupted" and the actual error is never shown. Callers
+ * that can determine this properly pass `isAbort` instead; this only covers the
+ * send-failure path, where all we have is a message.
+ */
+function looksLikeAbortText(text: string): boolean {
   const lower = text.toLowerCase();
   return ABORT_PATTERNS.some((p) => lower.includes(p));
 }
@@ -164,6 +173,18 @@ interface TurnErrorDisplayProps {
    * of regexing the message.
    */
   error?: KortixSendError | null;
+  /**
+   * Was this turn ACTUALLY aborted — i.e. is the error's identity `AbortError`?
+   *
+   * Passed by the transcript, which can read the structured error on the
+   * message. `getTurnError` flattens that to a display string and drops the
+   * name, so without this the only signal left is the word "abort" appearing
+   * somewhere in the prose — which mislabels genuine failures as user
+   * interruptions and hides what actually went wrong.
+   *
+   * Undefined means "caller could not tell"; the text sniff is used then.
+   */
+  isAbort?: boolean;
   className?: string;
 }
 
@@ -177,6 +198,7 @@ export function TurnErrorDisplay({
   errorText,
   errorDetails,
   error,
+  isAbort,
   className,
 }: TurnErrorDisplayProps) {
   const text = error ? error.message : errorText;
@@ -190,8 +212,9 @@ export function TurnErrorDisplay({
   // would say the same thing twice, once without the remedy.
   if (error?.kind === 'connector') return null;
 
-  // Abort/cancelled → tiny muted note, no card
-  if (isAbortError(text)) {
+  // Abort/cancelled → tiny muted note, no card. Identity when the caller knows
+  // it, prose only when it does not.
+  if (isAbort ?? looksLikeAbortText(text)) {
     return (
       <Checkpoint className={className}>
         <CheckpointIcon>


### PR DESCRIPTION
Still reported on dev **after** the daemon-side guard shipped: a complete,
well-formed answer labelled "Interrupted". So the remaining cause is in the web.

## The bug

The label is decided by substring-matching the error's **display text**:

```js
const ABORT_PATTERNS = ['aborted', 'abort', 'cancelled', 'canceled'];
lower.includes(p)
```

`getTurnError` flattens the structured error to a string and drops its `name`,
so prose was the only signal left. Bare `'abort'` fires on any message that
merely contains the word — `upstream connection aborted`, `signal is aborted
without reason`, `stream cancelled by server`.

It costs twice, because the label **replaces the error card**:

1. the user is told they stopped something they didn't, and
2. the real failure is never shown.

## The fix

The identity is sitting on the message. The transcript reads it and passes
`isAbort`; the banner prefers it over the sniff. Both genuine producers set
`name: 'AbortError'` — opencode's own abort, and the optimistic patch applied
when the user hits Stop.

The prose sniff survives only for the send-failure path, where a message really
is all there is, and is renamed `looksLikeAbortText` so it stops reading like a
fact.

Both render sites pass it — the compact row and the full transcript. Wiring one
and not the other would make the bug depend on the layout; a test counts them.

## Verification

Session suite **1269 pass / 150 fail** vs baseline **1261 / 150** — same
failures, +8. `tsc` clean in both changed files.

Guard proven: reverting the banner to prose-only fails the wiring test.

## Relationship to the daemon fix

`997642a4` stopped the daemon aborting turns that were merely still streaming —
that was real and is verified on a fresh sandbox. This is the second half: even
with no spurious abort, a *different* error containing the word still rendered
as one. Two independent causes of the same symptom.