### PR TITLE
fix(web): the session header shows the session name, not opencode's title

### DIFF
--- a/apps/web/src/features/session/header/session-header-title.test.ts
+++ b/apps/web/src/features/session/header/session-header-title.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The header must show the SAME name as the sidebar row.
+ *
+ * They were two different names. The sidebar shows Kortix's session name, which
+ * is what a rename edits; the header was handed opencode's own `session.title`
+ * — the summary the agent writes for itself. So one session read as "Just A
+ * Simple Hey" on the left and "Greeting" on top, and renaming changed only the
+ * left one.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { ProjectSession } from '@kortix/sdk';
+import { getSessionDisplayTitle } from '@/features/workspace/project-sidebar/project-session-list-helpers';
+
+const SRC = await Bun.file(new URL('./session-site-header.tsx', import.meta.url).pathname).text();
+
+function code(): string {
+  return SRC.replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n');
+}
+
+function session(over: Partial<ProjectSession>): ProjectSession {
+  return {
+    session_id: '3f9a1c2b-0000-0000-0000-000000000000',
+    branch_name: 'feature/some-branch-name',
+    custom_name: null,
+    name: null,
+    metadata: {},
+    ...over,
+  } as unknown as ProjectSession;
+}
+
+describe('the header renders the sidebar name', () => {
+  test('uses the sidebar helper, not opencode\'s title', () => {
+    const src = code();
+    expect(src).toContain('getSessionDisplayTitle(projectSession)');
+    // The regression shape: the raw prop back in the label.
+    expect(src).not.toContain('truncate">{sessionTitle}<');
+  });
+
+  test('the delete confirmation names it the same way', () => {
+    // "Delete Greeting?" for a session the user knows as something else is the
+    // same bug with worse consequences.
+    expect(code()).toContain('sessionLabel={headerTitle}');
+  });
+
+  test('still falls back to the prop without a project session', () => {
+    // The share viewer and instant shell render this header with no project
+    // session; hardcoding the helper would blank the title there.
+    expect(code()).toContain('projectSession ? getSessionDisplayTitle(projectSession) : sessionTitle');
+  });
+});
+
+describe('the two surfaces cannot disagree', () => {
+  test('a rename wins in both', () => {
+    const s = session({ custom_name: 'My Rename', name: 'Greeting' });
+    expect(getSessionDisplayTitle(s)).toBe('My Rename');
+  });
+
+  test('the server name beats opencode auto-title drift', () => {
+    const s = session({ name: 'Just A Simple Hey' });
+    expect(getSessionDisplayTitle(s)).toBe('Just A Simple Hey');
+  });
+
+  test('an untitled session reads "New session", never a uuid slice', () => {
+    // This is why the sidebar helper is used rather than sessionDisplayLabel:
+    // that one ends at `session_id.slice(0, 8)`, so the header would have shown
+    // a raw hash where the sidebar shows words.
+    expect(getSessionDisplayTitle(session({}))).toBe('New session');
+  });
+});

--- a/apps/web/src/features/session/header/session-site-header.test.tsx
+++ b/apps/web/src/features/session/header/session-site-header.test.tsx
@@ -35,10 +35,15 @@ describe('SessionSiteHeader sidebar toggle', () => {
   });
 });
 
+/**
+ * The rendered name is `headerTitle`, not the `sessionTitle` prop: the prop
+ * carries OPENCODE's own session.title, and the header must show the same name
+ * as the sidebar row (see session-header-title.test.ts).
+ */
 describe('SessionSiteHeader session title', () => {
-  test('renders sessionTitle in the leading cluster, after the home button and before leadingAction', () => {
+  test('renders the session name in the leading cluster, after the home button and before leadingAction', () => {
     const homeButtonIndex = source.indexOf('<HouseIcon');
-    const titleIndex = source.indexOf('{sessionTitle}');
+    const titleIndex = source.indexOf('{headerTitle}');
     const leadingActionIndex = source.lastIndexOf('{leadingAction}');
     expect(titleIndex).toBeGreaterThan(-1);
     expect(titleIndex).toBeGreaterThan(homeButtonIndex);
@@ -48,7 +53,7 @@ describe('SessionSiteHeader session title', () => {
   // Without these, a long title just grows the leading cluster and pushes
   // the trailing cluster (config/dev-tools/⋯) off-screen instead of eliding.
   test('the title element carries min-w-0 and truncate, so a long value shrinks instead of expanding the row', () => {
-    const titleIndex = source.indexOf('{sessionTitle}');
+    const titleIndex = source.indexOf('{headerTitle}');
     const titleTagStart = source.lastIndexOf('<span', titleIndex);
     const titleTag = source.slice(titleTagStart, titleIndex);
     expect(titleTag).toContain('min-w-0');
@@ -65,7 +70,7 @@ describe('SessionSiteHeader session title', () => {
   });
 
   test('renders the title and down caret as a padded dropdown trigger', () => {
-    const titleIndex = source.indexOf('{sessionTitle}');
+    const titleIndex = source.indexOf('{headerTitle}');
     const triggerStart = source.lastIndexOf('<DropdownMenuTrigger', titleIndex);
     const trigger = source.slice(
       triggerStart,

--- a/apps/web/src/features/session/header/session-site-header.tsx
+++ b/apps/web/src/features/session/header/session-site-header.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 
 import { sessionDisplayLabel } from '@/components/projects/session-label';
+import { getSessionDisplayTitle } from '@/features/workspace/project-sidebar/project-session-list-helpers';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -136,6 +137,24 @@ export function SessionSiteHeader({
   });
   const projectSession = projectSessions?.find((s) => s.session_id === projectSessionId) ?? null;
   const canShare = !!projectSession && projectSession.can_manage_sharing !== false;
+
+  /**
+   * The name shown in the header, matched to the sidebar row.
+   *
+   * `sessionTitle` is OPENCODE's `session.title` — the summary it writes for
+   * itself ("Greeting"). The sidebar shows Kortix's session name ("Just A
+   * Simple Hey"), and a rename only ever touches that one, so the two drifted
+   * apart the moment opencode auto-titled: the same session read as two
+   * different things depending on where you looked.
+   *
+   * Uses the SIDEBAR's helper, not `sessionDisplayLabel`, so the two strings
+   * cannot diverge on the fallback either — they differ for an untitled session
+   * ("New session" vs a branch/id slice).
+   *
+   * Falls back to the prop when there is no project session: the share viewer
+   * and the instant shell render this header without one.
+   */
+  const headerTitle = projectSession ? getSessionDisplayTitle(projectSession) : sessionTitle;
 
   const restartMutation = useMutation({
     mutationFn: () => restartProjectSession(projectId!, projectSessionId!),
@@ -318,7 +337,7 @@ export function SessionSiteHeader({
                   variant="ghost"
                   className="text-foreground/80 hover:text-foreground data-[state=open]:bg-card group h-auto min-w-0 shrink justify-start gap-3 rounded-md px-2.5 py-1 transition-[color,background-color,transform] duration-150 ease-out active:scale-[0.96] has-[>svg]:px-2.5"
                 >
-                  <span className="min-w-0 truncate">{sessionTitle}</span>
+                  <span className="min-w-0 truncate">{headerTitle}</span>
                   <CaretDownIcon className="text-muted-foreground size-3.5 shrink-0 transition-transform duration-150 ease-out group-data-[state=open]:rotate-180" />
                 </Button>
               </DropdownMenuTrigger>
@@ -477,7 +496,7 @@ export function SessionSiteHeader({
           <SessionDeleteModal
             projectId={projectId!}
             sessionId={projectSessionId!}
-            sessionLabel={sessionTitle}
+            sessionLabel={headerTitle}
             open={deleteOpen}
             onOpenChange={setDeleteOpen}
             onDeleted={() => router.push(`/projects/${projectId}`)}


### PR DESCRIPTION
The header above a session showed `session.title` — the summary **opencode**
writes for itself ("Greeting") — while the sidebar row showed Kortix's session
name ("Just A Simple Hey"). Rename only ever touches the Kortix one, so the two
drifted apart the moment opencode auto-titled, and the same session read as two
different things depending on where you looked.

The header now uses the sidebar's own helper, so the two strings cannot diverge
on the fallback path either (they differ for an untitled session: "New session"
vs a branch/id slice). Falls back to the prop when there is no project session —
the share viewer and the instant shell render this header without one.

## Verification

- `session-header-title.test.ts` — new, covers the drift case, the rename case,
  the untitled fallback, and the no-project-session fallback.
- `session-site-header.test.tsx` — updated for the new source of truth.

Reported from the running dev UI: sidebar title correct, header title stale.