### PR TITLE
infra: cut dev and previews over to ECS web

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,7 @@ name: Deploy Dev
 #                   (see infra/cloudflare/workers/api-router).
 #   - Frontend    → kortix/kortix-frontend:dev-<sha8> + :dev-latest, deployed to
 #                   the dedicated kortix-dev-web ECS Fargate service at
-#                   dev-fe-ecs.kortix.com. dev.kortix.com stays on Vercel.
+#                   dev.kortix.com. Vercel is disabled for main.
 #   - CLI         → 4 cross-compiled binaries published to the mutable
 #                   `dev-latest` GitHub prerelease (default API base dev-api).
 #
@@ -646,7 +646,7 @@ jobs:
             --version "${{ needs.dev-version.outputs.version }}"
 
   publish-web-ecs-dns:
-    name: Publish Dev FE-ECS DNS
+    name: Publish canonical Dev ECS DNS
     needs: [detect-changes, deploy-web-ecs]
     if: needs.detect-changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
@@ -664,7 +664,7 @@ jobs:
         with:
           role-to-assume: ${{ env.ROLE }}
           aws-region: ${{ env.AWS_REGION }}
-      - name: Point only the isolated FE-ECS hostname at the web ALB
+      - name: Point the canonical Dev hostname at the web ALB
         run: |
           set -euo pipefail
           alb="$(aws elbv2 describe-load-balancers \
@@ -674,7 +674,7 @@ jobs:
           node infra/scripts/sync-web-dns.mjs dev "$alb"
 
   verify-web-dev:
-    name: Verify Dev FE-ECS and Vercel isolation
+    name: Verify canonical Dev frontend on ECS
     needs: [detect-changes, dev-version, publish-web-ecs-dns]
     if: needs.detect-changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
@@ -683,39 +683,41 @@ jobs:
       EXPECTED_VERSION: ${{ needs.dev-version.outputs.version }}
       WEB_PROTECTION_PASSWORD: ${{ secrets.WEB_PROTECTION_PASSWORD }}
     steps:
-      - name: Verify ECS health, protection, runtime configuration, and Vercel isolation
+      - name: Verify ECS health, protection, runtime configuration, and edge headers
         run: |
           set -euo pipefail
           test -n "${WEB_PROTECTION_PASSWORD:-}" || {
             echo "::error::WEB_PROTECTION_PASSWORD is not configured."
             exit 1
           }
-          base=https://dev-fe-ecs.kortix.com
-          canonical=https://dev.kortix.com
+          base=https://dev.kortix.com
           consecutive_matches=0
           for attempt in $(seq 1 40); do
+            cookie_jar="$(mktemp)"
             body="$(curl -fsS --max-time 15 "$base/api/health" || true)"
             commit="$(jq -r '.commit // empty' <<<"$body" 2>/dev/null || true)"
             version="$(jq -r '.version // empty' <<<"$body" 2>/dev/null || true)"
             anonymous="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$base/" || true)"
-            protected="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 -u "kortix:${WEB_PROTECTION_PASSWORD}" "$base/" || true)"
-            runtime="$(curl -fsS --max-time 15 -u "kortix:${WEB_PROTECTION_PASSWORD}" "$base/api/runtime-config" || true)"
-            ecs_headers="$(curl -sS -D - -o /dev/null --max-time 15 "$base/" || true)"
-            canonical_headers="$(curl -sS -D - -o /dev/null --max-time 15 "$canonical/" || true)"
-            ecs_vercel_headers="$(awk 'BEGIN { IGNORECASE=1 } /^x-vercel-/ { count++ } END { print count + 0 }' <<<"$ecs_headers")"
-            canonical_vercel_headers="$(awk 'BEGIN { IGNORECASE=1 } /^x-vercel-/ { count++ } END { print count + 0 }' <<<"$canonical_headers")"
-            echo "(${attempt}/40) commit=${commit:-?} version=${version:-?} anonymous=${anonymous:-?} protected=${protected:-?} ecs_vercel_headers=${ecs_vercel_headers} canonical_vercel_headers=${canonical_vercel_headers}"
+            wrong="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 -u "kortix:${WEB_PROTECTION_PASSWORD}x" "$base/" || true)"
+            protected="$(curl -sS -c "$cookie_jar" -o /dev/null -w '%{http_code}' --max-time 15 -u "kortix:${WEB_PROTECTION_PASSWORD}" "$base/" || true)"
+            cookie_only="$(curl -sS -b "$cookie_jar" -o /dev/null -w '%{http_code}' --max-time 15 "$base/" || true)"
+            runtime="$(curl -fsS -b "$cookie_jar" --max-time 15 "$base/api/runtime-config" || true)"
+            headers="$(curl -sS -D - -o /dev/null --max-time 15 "$base/" || true)"
+            vercel_headers="$(awk 'BEGIN { IGNORECASE=1 } /^x-vercel-/ { count++ } END { print count + 0 }' <<<"$headers")"
+            rm -f "$cookie_jar"
+            echo "(${attempt}/40) commit=${commit:-?} version=${version:-?} anonymous=${anonymous:-?} wrong=${wrong:-?} protected=${protected:-?} cookie_only=${cookie_only:-?} vercel_headers=${vercel_headers}"
             if [ "$commit" = "$EXPECTED_COMMIT" ] \
               && [ "$version" = "$EXPECTED_VERSION" ] \
               && [ "$anonymous" = 401 ] \
+              && [ "$wrong" = 401 ] \
               && { [ "$protected" = 200 ] || [ "$protected" = 307 ] || [ "$protected" = 308 ]; } \
+              && { [ "$cookie_only" = 200 ] || [ "$cookie_only" = 307 ] || [ "$cookie_only" = 308 ]; } \
               && grep -q 'dev-api.kortix.com' <<<"$runtime" \
-              && grep -q 'dev-fe-ecs.kortix.com' <<<"$runtime" \
-              && [ "$ecs_vercel_headers" = 0 ] \
-              && [ "$canonical_vercel_headers" -gt 0 ]; then
+              && grep -q 'https://dev.kortix.com' <<<"$runtime" \
+              && [ "$vercel_headers" = 0 ]; then
               consecutive_matches=$((consecutive_matches + 1))
               if [ "$consecutive_matches" -ge 4 ]; then
-                echo "Dev FE-ECS served ${EXPECTED_COMMIT} for four consecutive checks. dev.kortix.com remained on Vercel."
+                echo "dev.kortix.com served ${EXPECTED_COMMIT} from ECS for four consecutive checks."
                 exit 0
               fi
             else
@@ -723,7 +725,7 @@ jobs:
             fi
             sleep 20
           done
-          echo "::error::Dev FE-ECS verification or Vercel isolation failed for ${EXPECTED_COMMIT}."
+          echo "::error::Canonical Dev ECS verification failed for ${EXPECTED_COMMIT}."
           exit 1
 
   # ── Move the self-host `:dev` channel tag onto the image that just built ────

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -265,6 +265,7 @@ jobs:
           api_host="pr-${NUM}.preview-api.kortix.com"
           web_host="pr-${NUM}.preview.kortix.com"
           for _ in $(seq 1 30); do
+            cookie_jar="$(mktemp)"
             api_health="$(curl -fsS --max-time 8 "https://${api_host}/v1/health" 2>/dev/null || true)"
             api_environment="$(printf '%s' "$api_health" | jq -r '.environment // empty' 2>/dev/null || true)"
             api_commit="$(printf '%s' "$api_health" | jq -r '.commit // empty' 2>/dev/null || true)"
@@ -272,15 +273,18 @@ jobs:
             web_commit="$(printf '%s' "$web_health" | jq -r '.commit // empty' 2>/dev/null || true)"
             anonymous="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 "https://${web_host}/" || true)"
             wrong="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 -u 'kortix:wrong-password' "https://${web_host}/" || true)"
-            protected="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 -u "kortix:${WEB_PROTECTION_PASSWORD}" "https://${web_host}/" || true)"
-            runtime="$(curl -fsS --max-time 8 -u "kortix:${WEB_PROTECTION_PASSWORD}" "https://${web_host}/api/runtime-config" 2>/dev/null || true)"
-            echo "api_environment=${api_environment:-?} api_commit=${api_commit:-?} web_commit=${web_commit:-?} anonymous=${anonymous:-?} wrong=${wrong:-?} protected=${protected:-?}"
+            protected="$(curl -sS -c "$cookie_jar" -o /dev/null -w '%{http_code}' --max-time 8 -u "kortix:${WEB_PROTECTION_PASSWORD}" "https://${web_host}/" || true)"
+            cookie_only="$(curl -sS -b "$cookie_jar" -o /dev/null -w '%{http_code}' --max-time 8 "https://${web_host}/" || true)"
+            runtime="$(curl -fsS -b "$cookie_jar" --max-time 8 "https://${web_host}/api/runtime-config" 2>/dev/null || true)"
+            rm -f "$cookie_jar"
+            echo "api_environment=${api_environment:-?} api_commit=${api_commit:-?} web_commit=${web_commit:-?} anonymous=${anonymous:-?} wrong=${wrong:-?} protected=${protected:-?} cookie_only=${cookie_only:-?}"
             if [ "$api_environment" = "preview" ] \
               && [ "$api_commit" = "$COMMIT" ] \
               && [ "$web_commit" = "$COMMIT" ] \
               && [ "$anonymous" = 401 ] \
               && [ "$wrong" = 401 ] \
               && { [ "$protected" = 200 ] || [ "$protected" = 307 ] || [ "$protected" = 308 ]; } \
+              && { [ "$cookie_only" = 200 ] || [ "$cookie_only" = 307 ] || [ "$cookie_only" = 308 ]; } \
               && grep -q "https://${api_host}/v1" <<<"$runtime" \
               && grep -q "https://${web_host}" <<<"$runtime"; then
               printf '%s\n' "$api_health" > /tmp/preview-health.json
@@ -299,8 +303,7 @@ jobs:
           body="$(printf '%s\n' "$marker" '## Preview environment - live' '' \
             "- **Backend:** https://${host}" \
             "- **Health:** https://${host}/v1/health" \
-            "- **ECS frontend:** https://${web}" \
-            '- **Vercel frontend:** deployment is building' '' \
+            "- **Frontend:** https://${web}" '' \
             '_One isolated Fargate task with API, gateway, and frontend; automatic close/unlabel teardown._')"
           id="$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
             --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")"
@@ -309,130 +312,6 @@ jobs:
           else
             gh api -X POST "repos/${REPO}/issues/${NUM}/comments" -f body="$body" >/dev/null
           fi
-
-  wire:
-    name: Wire preview frontend to preview backend
-    needs: deploy
-    runs-on: ubuntu-latest
-    env:
-      NUM: ${{ github.event.pull_request.number }}
-      COMMIT: ${{ github.event.pull_request.head.sha }}
-      GH_TOKEN: ${{ github.token }}
-      REPO: ${{ github.repository }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-      ENV_KEYS: NEXT_PUBLIC_BACKEND_URL KORTIX_PUBLIC_BACKEND_URL
-      PREVIEW_FLAG_KEY: KORTIX_PREVIEW_APPROVED_SHA
-      BRANCH: ${{ github.event.pull_request.head.ref }}
-    steps:
-      - name: Revalidate exact SHA before Vercel mutation
-        run: |
-          set -euo pipefail
-          current="$(gh api "repos/${REPO}/pulls/${NUM}" --jq .head.sha)"
-          [ "$current" = "$COMMIT" ] || {
-            echo "::error::Approved SHA ${COMMIT} is stale; current head is ${current}."
-            exit 1
-          }
-          labels="$(gh api "repos/${REPO}/issues/${NUM}/labels" --jq 'map(.name) | join(" ")')"
-          [[ " $labels " == *" preview "* ]] || {
-            echo "::error::The preview label was removed before Vercel wiring."
-            exit 1
-          }
-      - name: Require Vercel credentials
-        run: |
-          set -euo pipefail
-          for name in VERCEL_TOKEN PROJECT_ID TEAM_ID; do
-            [ -n "${!name:-}" ] || { echo "::error::$name is required for preview wiring."; exit 1; }
-          done
-      - name: Upsert branch-scoped backend URLs and redeploy
-        env:
-          NUM: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          auth=(-H "Authorization: Bearer ${VERCEL_TOKEN}")
-          api="https://api.vercel.com"
-          backend="https://pr-${NUM}.preview-api.kortix.com/v1"
-          for key_value in \
-            "NEXT_PUBLIC_BACKEND_URL|${backend}" \
-            "KORTIX_PUBLIC_BACKEND_URL|${backend}" \
-            "${PREVIEW_FLAG_KEY}|${COMMIT}"; do
-            key="${key_value%%|*}"
-            value="${key_value#*|}"
-            code="$(curl -sS -o "/tmp/env-${key}.json" -w '%{http_code}' -X POST \
-              "${api}/v10/projects/${PROJECT_ID}/env?teamId=${TEAM_ID}&upsert=true" \
-              "${auth[@]}" -H 'Content-Type: application/json' \
-              -d "$(jq -n --arg v "$value" --arg b "$BRANCH" --arg k "$key" \
-                '{key:$k,value:$v,type:"plain",target:["preview"],gitBranch:$b}')")"
-            [ "$code" = 200 ] || [ "$code" = 201 ] || { jq . "/tmp/env-${key}.json"; exit 1; }
-          done
-          project_code="$(curl -sS -o /tmp/vercel-project.json -w '%{http_code}' \
-            "${api}/v9/projects/${PROJECT_ID}?teamId=${TEAM_ID}" "${auth[@]}")"
-          if [ "$project_code" != 200 ]; then
-            jq '{error}' /tmp/vercel-project.json
-            echo "::error::Vercel project lookup returned HTTP ${project_code}."
-            exit 1
-          fi
-          project="$(</tmp/vercel-project.json)"
-          name="$(printf '%s' "$project" | jq -r .name)"
-          repo_id="$(printf '%s' "$project" | jq -r '.link.repoId')"
-          [ -n "$name" ] && [ "$name" != null ] || { echo "::error::Vercel project response has no name."; exit 1; }
-          [ -n "$repo_id" ] && [ "$repo_id" != null ] || { echo "::error::Vercel project response has no GitHub repoId."; exit 1; }
-          deployment_code="$(curl -sS -o /tmp/vercel-deployment.json -w '%{http_code}' -X POST \
-            "${api}/v13/deployments?teamId=${TEAM_ID}&forceNew=1&skipAutoDetectionConfirmation=1" \
-            "${auth[@]}" -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg n "$name" --argjson r "$repo_id" --arg b "$BRANCH" --arg s "$COMMIT" \
-              '{name:$n,gitSource:{type:"github",repoId:$r,ref:$b,sha:$s}}')")"
-          if [ "$deployment_code" != 200 ] && [ "$deployment_code" != 201 ]; then
-            jq '{error}' /tmp/vercel-deployment.json
-            echo "::error::Vercel deployment creation returned HTTP ${deployment_code}."
-            exit 1
-          fi
-          deployment="$(</tmp/vercel-deployment.json)"
-          deployment_id="$(printf '%s' "$deployment" | jq -r '.id // error("Vercel deployment response has no id")')"
-          frontend="https://$(printf '%s' "$deployment" | jq -r '.url // error("Vercel deployment response has no URL")')"
-          ready=false
-          for _ in $(seq 1 60); do
-            current="$(curl -fsS "${api}/v13/deployments/${deployment_id}?teamId=${TEAM_ID}" "${auth[@]}")"
-            state="$(printf '%s' "$current" | jq -r '.readyState // .state // empty')"
-            deployed_sha="$(printf '%s' "$current" | jq -r '.meta.githubCommitSha // empty')"
-            deployed_branch="$(printf '%s' "$current" | jq -r '.meta.githubCommitRef // empty')"
-            if [ "$state" = "ERROR" ] || [ "$state" = "CANCELED" ]; then
-              echo "::error::Vercel deployment ${deployment_id} entered ${state}."
-              exit 1
-            fi
-            if [ "$state" = "READY" ] && [ "$deployed_sha" = "$COMMIT" ] && [ "$deployed_branch" = "$BRANCH" ]; then
-              ready=true
-              break
-            fi
-            sleep 10
-          done
-          [ "$ready" = true ] || { echo "::error::Vercel deployment was not READY for exact SHA ${COMMIT}."; exit 1; }
-          deployed_envs="$(curl -fsS "${api}/v9/projects/${PROJECT_ID}/env?teamId=${TEAM_ID}" "${auth[@]}")"
-          for key_value in \
-            "NEXT_PUBLIC_BACKEND_URL|${backend}" \
-            "KORTIX_PUBLIC_BACKEND_URL|${backend}" \
-            "${PREVIEW_FLAG_KEY}|${COMMIT}"; do
-            key="${key_value%%|*}"
-            value="${key_value#*|}"
-            count="$(printf '%s' "$deployed_envs" | jq --arg k "$key" --arg b "$BRANCH" --arg v "$value" \
-              '[.envs[] | select(.key==$k and .gitBranch==$b and .value==$v)] | length')"
-            [ "$count" = 1 ] || {
-              echo "::error::${key} does not have the expected branch-scoped value for ${BRANCH}."
-              exit 1
-            }
-          done
-          curl -fsS --max-time 20 "$frontend" >/dev/null
-          marker='<!-- preview-status -->'
-          body="$(printf '%s\n' "$marker" '## Preview environment - live' '' \
-            "- **Backend:** https://pr-${NUM}.preview-api.kortix.com" \
-            "- **Health:** https://pr-${NUM}.preview-api.kortix.com/v1/health" \
-            "- **ECS frontend:** https://pr-${NUM}.preview.kortix.com" \
-            "- **Vercel frontend:** ${frontend}" '' \
-            '_One isolated Fargate task plus a parallel Vercel frontend; automatic close, unlabel, or new-commit teardown._')"
-          id="$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
-            --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")"
-          [ -z "$id" ] || gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null
 
   teardown:
     name: Tear down preview and invalidate stale approval
@@ -454,12 +333,6 @@ jobs:
       NUM: ${{ github.event.pull_request.number }}
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-      ENV_KEYS: NEXT_PUBLIC_BACKEND_URL KORTIX_PUBLIC_BACKEND_URL
-      PREVIEW_FLAG_KEY: KORTIX_PREVIEW_APPROVED_SHA
-      BRANCH: ${{ github.event.pull_request.head.ref }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -470,36 +343,6 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - name: Delete isolated Fargate resources
         run: bash infra/scripts/ecs-preview.sh teardown "$NUM"
-      - name: Delete branch-scoped Vercel environment
-        run: |
-          set -euo pipefail
-          for name in VERCEL_TOKEN PROJECT_ID TEAM_ID; do
-            [ -n "${!name:-}" ] || { echo "::error::$name is required for deterministic teardown."; exit 1; }
-          done
-          auth=(-H "Authorization: Bearer ${VERCEL_TOKEN}")
-          api="https://api.vercel.com"
-          envs="$(curl -fsS "${api}/v9/projects/${PROJECT_ID}/env?teamId=${TEAM_ID}" "${auth[@]}")"
-          backend="https://pr-${NUM}.preview-api.kortix.com/v1"
-          deleted=0
-          conflicts=0
-          for key in $ENV_KEYS; do
-            expected="$backend"
-            ids="$(printf '%s' "$envs" | jq -r --arg k "$key" --arg b "$BRANCH" \
-              --arg v "$expected" '.envs[] | select(.key==$k and .gitBranch==$b and .value==$v) | .id')"
-            conflicts="$((conflicts + $(printf '%s' "$envs" | jq --arg k "$key" --arg b "$BRANCH" --arg v "$expected" \
-              '[.envs[] | select(.key==$k and .gitBranch==$b and .value!=$v)] | length')))"
-            for id in $ids; do
-              curl -fsS -X DELETE "${api}/v9/projects/${PROJECT_ID}/env/${id}?teamId=${TEAM_ID}" "${auth[@]}" >/dev/null
-              deleted=$((deleted + 1))
-            done
-          done
-          approval_ids="$(printf '%s' "$envs" | jq -r --arg k "$PREVIEW_FLAG_KEY" --arg b "$BRANCH" \
-            '.envs[] | select(.key==$k and .gitBranch==$b) | .id')"
-          for id in $approval_ids; do
-            curl -fsS -X DELETE "${api}/v9/projects/${PROJECT_ID}/env/${id}?teamId=${TEAM_ID}" "${auth[@]}" >/dev/null
-            deleted=$((deleted + 1))
-          done
-          echo "Deleted ${deleted} Vercel variables owned by PR ${NUM}; preserved ${conflicts} variables with a different backend value."
       - name: Remove stale preview approval
         if: github.event.action == 'synchronize'
         run: |
@@ -513,8 +356,7 @@ jobs:
           id="$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
             --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")"
           body="$(printf '%s\n' "$marker" '## Preview environment - torn down' '' \
-            'The ECS service, two listener rules, two target groups, and task definitions were deleted.' \
-            'Vercel cleanup deleted only branch variables whose value still targeted this PR backend.')"
+            'The ECS service, two listener rules, two target groups, and task definitions were deleted.')"
           [ -z "$id" ] || gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null
 
   reconcile:

--- a/apps/web/scripts/vercel-ignore.sh
+++ b/apps/web/scripts/vercel-ignore.sh
@@ -7,12 +7,11 @@
 # Two stages run in order:
 #   1. FE-relevance — if a push changed NOTHING that feeds the apps/web build
 #      (only sibling apps / infra / tests / docs), skip it on every branch.
-#   2. Deploy-target — the permanent environments (main/staging/prod) always
-#      deploy real FE changes; per-PR previews are OPT-IN to save build spend.
+#   2. Deploy-target — staging and prod deploy real frontend changes. Dev and
+#      per-PR previews run only on ECS and always skip Vercel builds.
 #
-# For the permanent environments, default to BUILD on ANY uncertainty — never
-# silently skip a real FE deploy. Per-PR previews invert that: default SKIP.
-# The preview workflow must approve the exact commit SHA.
+# For staging and production, default to BUILD on ANY uncertainty. Dev and
+# per-PR previews default to SKIP because ECS owns those frontend deployments.
 #
 # WHY THIS EXISTS
 # A backend/infra-only push to `prod` (e.g. a rollback that only flips
@@ -57,19 +56,10 @@ fi
 # per-PR previews are OPT-IN (previews on every PR were the bulk of build spend).
 REF="${VERCEL_GIT_COMMIT_REF:-}"
 case "${VERCEL_ENV:-}:$REF" in
-  production:*|*:main|*:staging|*:prod)
+  production:*|*:staging|*:prod)
     echo "vercel-ignore: environment branch (${REF:-$VERCEL_ENV}) — building frontend."
     exit 1 ;;
 esac
 
-# A per-PR / feature-branch preview builds only when the trusted preview
-# workflow stores this exact commit SHA in the branch-scoped Vercel profile.
-# A later commit cannot reuse an earlier approval.
-if [ -n "${KORTIX_PREVIEW_APPROVED_SHA:-}" ] \
-  && [ "${KORTIX_PREVIEW_APPROVED_SHA}" = "${VERCEL_GIT_COMMIT_SHA:-}" ]; then
-  echo "vercel-ignore: exact preview SHA is approved — building opt-in preview."
-  exit 1
-fi
-
-echo "vercel-ignore: exact preview SHA is not approved — skipping. ref=$REF"
+echo "vercel-ignore: dev and PR previews deploy on ECS only — skipping Vercel. ref=$REF"
 exit 0

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -11,7 +11,7 @@
   ],
   "git": {
     "deploymentEnabled": {
-      "main": true,
+      "main": false,
       "staging": true,
       "prod": true
     }

--- a/infra/GITOPS.md
+++ b/infra/GITOPS.md
@@ -10,22 +10,22 @@ Helm, and Kubernetes are not part of the current deployment path. Commit
 
 ## Environments
 
-| Environment | Source | API | ECS frontend | Vercel frontend |
+| Environment | Source | API | Frontend | Vercel status |
 | --- | --- | --- | --- | --- |
-| Preview | PR with `preview` label | `pr-<number>.preview-api.kortix.com` | `pr-<number>.preview.kortix.com` | PR-specific Vercel URL |
-| Dev | `main` | `dev-api.kortix.com` | `dev-fe-ecs.kortix.com` | `dev.kortix.com` |
-| Staging | `staging` | `staging-api.kortix.com` | `staging-fe-ecs.kortix.com` | `staging.kortix.com` |
-| Production | `prod` | `api.kortix.com` | `prod-fe-ecs.kortix.com` | `kortix.com` |
+| Preview | PR with `preview` label | `pr-<number>.preview-api.kortix.com` | `pr-<number>.preview.kortix.com` on ECS | Disabled |
+| Dev | `main` | `dev-api.kortix.com` | `dev.kortix.com` on ECS | Disabled |
+| Staging | `staging` | `staging-api.kortix.com` | `staging-fe-ecs.kortix.com` on ECS | `staging.kortix.com` |
+| Production | `prod` | `api.kortix.com` | `prod-fe-ecs.kortix.com` on ECS | `kortix.com` |
 
-The permanent Vercel hostnames remain active during the ECS frontend migration.
-The `*-fe-ecs.kortix.com` hostnames provide parallel ECS validation.
+Dev and previews are ECS-only. Staging and production retain their parallel
+Vercel and `*-fe-ecs.kortix.com` paths.
 
 ## Deployment workflows
 
 | Workflow | Role |
 | --- | --- |
-| `deploy-preview.yml` | Builds PR-specific API, gateway, and frontend images. It deploys an isolated ECS service and a parallel Vercel preview. It verifies both paths and removes resources after unlabel or close. |
-| `deploy-dev.yml` | Builds changed dev images, applies dev migrations, rolls the changed ECS services, and verifies the ECS and Vercel frontend paths. |
+| `deploy-preview.yml` | Builds PR-specific API, gateway, and frontend images. It deploys and verifies one isolated ECS service. It removes resources after unlabel or close. |
+| `deploy-dev.yml` | Builds changed dev images, applies dev migrations, rolls the changed ECS services, publishes canonical frontend DNS, and verifies ECS. |
 | `build-staging.yml` | Builds immutable staging release-candidate images. |
 | `deploy-staging.yml` | Applies staging migrations, rolls staging ECS services, and verifies the staging targets. |
 | `promote.yml` | Opens a reviewed release PR from staging into `prod`. It does not deploy. |
@@ -41,19 +41,17 @@ approves the exact head SHA. A new commit tears down the old preview and removes
 the label. A writer or administrator must review the new SHA and reapply it.
 
 1. Three unprivileged jobs build fixed-tag API, gateway, and frontend archives.
-   They receive no Docker Hub, AWS, Vercel, or application secrets.
+   They receive no Docker Hub, AWS, or application secrets.
 2. A trusted job publishes the archives without starting their containers.
 3. Terraform creates PR-specific listener rules, target groups, and DNS records.
 4. The workflow deploys one ECS Fargate service for the pull request.
-5. The workflow creates the parallel Vercel preview.
-6. Verification checks the API commit, frontend commit, runtime URLs, password
+5. Verification checks the API commit, frontend commit, runtime URLs, password
    gate, shared parent-domain cookie, and black-box API flows.
-7. One sticky pull-request comment publishes the API, health, ECS frontend, and
-   Vercel frontend URLs.
+6. One sticky pull-request comment publishes the API, health, and frontend URLs.
 
 Removing the label or closing the pull request destroys the ECS service, task
-definitions, listener rules, target groups, DNS records, and Vercel branch
-configuration. A daily reconciliation run removes leaked preview resources.
+definitions, listener rules, target groups, and DNS records. A daily
+reconciliation run removes leaked preview resources.
 
 Preview compute is isolated per pull request. Preview database and Supabase
 state are shared with dev.

--- a/infra/scripts/render-web-env.mjs
+++ b/infra/scripts/render-web-env.mjs
@@ -9,7 +9,7 @@ const ENVIRONMENTS = {
   },
   dev: {
     canonicalHost: 'dev.kortix.com',
-    ecsHost: 'dev-fe-ecs.kortix.com',
+    ecsHost: 'dev.kortix.com',
     apiHost: 'dev-api.kortix.com',
     protected: true,
   },
@@ -106,7 +106,9 @@ export function renderWebEnvironment(name, environment = process.env) {
   }
 
   const optionalKeys =
-    name === 'preview' ? OPTIONAL_KEYS.filter((key) => !PREVIEW_DENIED_KEYS.has(key)) : OPTIONAL_KEYS;
+    name === 'preview'
+      ? OPTIONAL_KEYS.filter((key) => !PREVIEW_DENIED_KEYS.has(key))
+      : OPTIONAL_KEYS;
   for (const key of optionalKeys) {
     const value = environment[key];
     if (value && value !== '-') payload[key] = value;

--- a/infra/scripts/render-web-env.test.mjs
+++ b/infra/scripts/render-web-env.test.mjs
@@ -25,9 +25,9 @@ function profile(name) {
 }
 
 describe('renderWebEnvironment', () => {
-  test('rewrites canonical profile URLs to isolated ECS frontend URLs', () => {
+  test('uses the canonical Dev host and isolated staging and production ECS hosts', () => {
     expect(renderWebEnvironment('dev', profile('dev')).NEXT_PUBLIC_APP_URL).toBe(
-      'https://dev-fe-ecs.kortix.com',
+      'https://dev.kortix.com',
     );
     expect(renderWebEnvironment('staging', profile('staging')).NEXT_PUBLIC_APP_URL).toBe(
       'https://staging-fe-ecs.kortix.com',

--- a/infra/scripts/sync-web-dns.mjs
+++ b/infra/scripts/sync-web-dns.mjs
@@ -3,7 +3,7 @@ import { pathToFileURL } from 'node:url';
 const ZONE_ID = process.env.CLOUDFLARE_ZONE_ID || 'af378d3df4e4dd5052a1fcbf263b685d';
 
 const ECS_WEB_HOSTS = {
-  dev: 'dev-fe-ecs.kortix.com',
+  dev: 'dev.kortix.com',
   staging: 'staging-fe-ecs.kortix.com',
   prod: 'prod-fe-ecs.kortix.com',
 };
@@ -14,13 +14,16 @@ export function webDnsRecord(environment, target) {
   if (!/^[a-z0-9.-]+\.elb\.amazonaws\.com$/.test(target)) {
     throw new Error('target must be an AWS ELB hostname');
   }
+  const canonical = environment === 'dev';
   return {
     type: 'CNAME',
     name: host,
     content: target,
     proxied: true,
     ttl: 1,
-    comment: `Kortix ${environment} frontend on ECS Fargate; canonical remains on Vercel`,
+    comment: canonical
+      ? 'Kortix dev frontend on ECS Fargate; canonical ECS endpoint'
+      : `Kortix ${environment} frontend on ECS Fargate; canonical remains on Vercel`,
   };
 }
 
@@ -44,7 +47,10 @@ async function cloudflare(path, options = {}) {
 
 export async function syncWebDns(environment, target) {
   const record = webDnsRecord(environment, target);
-  const query = new URLSearchParams({ type: record.type, name: record.name });
+  // Query by name, not type. The Dev cutover converts the existing Vercel A
+  // record to an ECS CNAME in place. A type-filtered query would miss it and
+  // attempt to create a conflicting record.
+  const query = new URLSearchParams({ name: record.name });
   const existing = await cloudflare(`/zones/${ZONE_ID}/dns_records?${query}`);
   if (existing.length > 1) throw new Error(`multiple DNS records exist for ${record.name}`);
   const current = existing[0];

--- a/infra/scripts/sync-web-dns.test.mjs
+++ b/infra/scripts/sync-web-dns.test.mjs
@@ -1,15 +1,15 @@
 import { describe, expect, test } from 'bun:test';
-import { webDnsRecord } from './sync-web-dns.mjs';
+import { syncWebDns, webDnsRecord } from './sync-web-dns.mjs';
 
 describe('webDnsRecord', () => {
-  test('renders only the isolated ECS hostname for each environment', () => {
+  test('renders the canonical Dev host and isolated ECS hosts elsewhere', () => {
     const targets = {
       dev: 'kortix-dev-web-alb-123.us-west-2.elb.amazonaws.com',
       staging: 'kortix-staging-web-alb-123.us-west-2.elb.amazonaws.com',
       prod: 'kortix-prod-web-alb-123.eu-west-2.elb.amazonaws.com',
     };
     const expectedHosts = {
-      dev: 'dev-fe-ecs.kortix.com',
+      dev: 'dev.kortix.com',
       staging: 'staging-fe-ecs.kortix.com',
       prod: 'prod-fe-ecs.kortix.com',
     };
@@ -30,10 +30,62 @@ describe('webDnsRecord', () => {
     expect(() => webDnsRecord('dev', 'example.com')).toThrow('target must be an AWS ELB hostname');
   });
 
-  test('can never select a canonical Vercel hostname', () => {
+  test('selects canonical Dev only and preserves isolated staging and prod hosts', () => {
     const target = 'kortix-dev-web-alb-123.us-west-2.elb.amazonaws.com';
-    for (const environment of ['dev', 'staging', 'prod']) {
-      expect(webDnsRecord(environment, target).name).toContain('-fe-ecs.kortix.com');
+    expect(webDnsRecord('dev', target).name).toBe('dev.kortix.com');
+    expect(webDnsRecord('staging', target).name).toBe('staging-fe-ecs.kortix.com');
+    expect(webDnsRecord('prod', target).name).toBe('prod-fe-ecs.kortix.com');
+  });
+
+  test('converts the existing canonical Vercel A record to the ECS CNAME in place', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.CLOUDFLARE_API_TOKEN;
+    const requests = [];
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    globalThis.fetch = async (url, options = {}) => {
+      requests.push({ url: String(url), options });
+      if (!options.method) {
+        return Response.json({
+          success: true,
+          result: [
+            {
+              id: 'canonical-record',
+              type: 'A',
+              name: 'dev.kortix.com',
+              content: '76.76.21.21',
+              proxied: true,
+            },
+          ],
+        });
+      }
+      return Response.json({
+        success: true,
+        result: {
+          id: 'canonical-record',
+          type: 'CNAME',
+          name: 'dev.kortix.com',
+          content: 'kortix-dev-web-alb-123.us-west-2.elb.amazonaws.com',
+          proxied: true,
+        },
+      });
+    };
+
+    try {
+      const result = await syncWebDns('dev', 'kortix-dev-web-alb-123.us-west-2.elb.amazonaws.com');
+      expect(result.action).toBe('updated');
+      expect(requests).toHaveLength(2);
+      expect(requests[0].url).toContain('name=dev.kortix.com');
+      expect(requests[0].url).not.toContain('type=');
+      expect(requests[1].url).toContain('/dns_records/canonical-record');
+      expect(requests[1].options.method).toBe('PUT');
+      expect(JSON.parse(requests[1].options.body)).toMatchObject({
+        type: 'CNAME',
+        name: 'dev.kortix.com',
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalToken === undefined) Reflect.deleteProperty(process.env, 'CLOUDFLARE_API_TOKEN');
+      else process.env.CLOUDFLARE_API_TOKEN = originalToken;
     }
   });
 });

--- a/infra/scripts/test-ecs-preview-runtime.py
+++ b/infra/scripts/test-ecs-preview-runtime.py
@@ -10,13 +10,11 @@ SCRIPT = (ROOT / "infra/scripts/ecs-preview.sh").read_text()
 TERRAFORM = (ROOT / "infra/terraform/environments/preview/main.tf").read_text()
 VARIABLES = (ROOT / "infra/terraform/environments/preview/variables.tf").read_text()
 README = (ROOT / "infra/terraform/environments/preview/README.md").read_text()
-VERCEL_IGNORE = (ROOT / "apps/web/scripts/vercel-ignore.sh").read_text()
 
 
 class PreviewRuntimeContract(unittest.TestCase):
-    def test_deploy_precedes_vercel_wiring_and_requires_exact_health(self):
+    def test_deploy_requires_exact_api_and_frontend_health(self):
         self.assertIn("needs: [authorize, build-api, build-gateway, build-web]", WORKFLOW)
-        self.assertIn("needs: deploy", WORKFLOW)
         self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", WORKFLOW)
         self.assertIn("pull_request_target:", WORKFLOW)
         self.assertIn("branches: [main]", WORKFLOW)
@@ -24,15 +22,12 @@ class PreviewRuntimeContract(unittest.TestCase):
         self.assertIn('[ "$api_environment" = "preview" ]', WORKFLOW)
         self.assertIn('[ "$api_commit" = "$COMMIT" ]', WORKFLOW)
         self.assertIn('[ "$web_commit" = "$COMMIT" ]', WORKFLOW)
-        self.assertIn("KORTIX_PUBLIC_BACKEND_URL", WORKFLOW)
-        self.assertIn("NEXT_PUBLIC_BACKEND_URL", WORKFLOW)
         self.assertIn("kortix/kortix-frontend:pr-${{ github.event.pull_request.head.sha }}", WORKFLOW)
-        self.assertIn("https://pr-${NUM}.preview.kortix.com", WORKFLOW)
+        self.assertIn('web_host="pr-${NUM}.preview.kortix.com"', WORKFLOW)
         self.assertIn("WEB_PROTECTION_PASSWORD", WORKFLOW)
-        self.assertIn('deployed_sha="$(printf', WORKFLOW)
-        self.assertIn('[ "$state" = "READY" ]', WORKFLOW)
-        self.assertIn('[ "$deployed_sha" = "$COMMIT" ]', WORKFLOW)
-        self.assertIn('.value==$v', WORKFLOW)
+        self.assertIn("cookie_only", WORKFLOW)
+        self.assertNotIn("Vercel", WORKFLOW)
+        self.assertNotIn("VERCEL_", WORKFLOW)
         self.assertNotIn("Argo CD", WORKFLOW)
         self.assertNotIn("submodule update --init --recursive --remote", WORKFLOW)
 
@@ -52,7 +47,7 @@ class PreviewRuntimeContract(unittest.TestCase):
             self.assertNotIn("DOCKERHUB_", section)
             self.assertNotIn("docker/login-action", section)
             self.assertNotIn("push: true", section)
-        deploy = WORKFLOW.split("  deploy:", 1)[1].split("\n  wire:", 1)[0]
+        deploy = WORKFLOW.split("  deploy:", 1)[1].split("\n  teardown:", 1)[0]
         self.assertIn("docker/login-action@v3", deploy)
         self.assertIn("docker load --input", deploy)
         self.assertIn("docker push", deploy)
@@ -67,10 +62,7 @@ class PreviewRuntimeContract(unittest.TestCase):
         self.assertIn("github.event.action == 'synchronize'", WORKFLOW)
         self.assertIn("gh api -X DELETE", WORKFLOW)
         self.assertIn("labels/preview", WORKFLOW)
-        self.assertIn("KORTIX_PREVIEW_APPROVED_SHA", WORKFLOW)
-        self.assertIn("sha:$s", WORKFLOW)
-        self.assertIn('KORTIX_PREVIEW_APPROVED_SHA}" = "${VERCEL_GIT_COMMIT_SHA', VERCEL_IGNORE)
-        self.assertNotIn("GITHUB_TOKEN", VERCEL_IGNORE)
+        self.assertNotIn("KORTIX_PREVIEW_APPROVED_SHA", WORKFLOW)
 
     def test_close_and_unlabel_run_complete_base_branch_teardown(self):
         self.assertIn("github.event.action == 'closed'", WORKFLOW)
@@ -80,7 +72,7 @@ class PreviewRuntimeContract(unittest.TestCase):
             before_script = section.split("ecs-preview.sh", 1)[0]
             self.assertNotIn("github.event.pull_request.head.sha", before_script)
         self.assertIn("ecs-preview.sh teardown", WORKFLOW)
-        self.assertIn('--arg v "$expected"', WORKFLOW)
+        self.assertNotIn("branch-scoped Vercel", WORKFLOW)
         for command in (
             "aws ecs delete-service",
             "aws elbv2 delete-rule",

--- a/infra/terraform/environments/dev-web/README.md
+++ b/infra/terraform/environments/dev-web/README.md
@@ -5,12 +5,20 @@ records. It reads the existing Dev VPC and subnets. It uses a separate remote
 state at `dev/ecs-web.tfstate`, so frontend changes cannot modify the Dev API or
 gateway resources.
 
-Apply the parallel ECS frontend:
+Apply the canonical ECS frontend:
 
 ```bash
 terraform init
 terraform apply
 ```
 
-The stack creates `https://dev-fe-ecs.kortix.com`. It never reads, changes, or
-deletes `dev.kortix.com`. The canonical Dev frontend remains on Vercel.
+The stack owns `https://dev.kortix.com`. The Deploy Dev workflow also updates
+this CNAME before it verifies the deployed frontend. Vercel is disabled for the
+`main` branch.
+
+The first cutover requires a state migration because the previous stack owned
+`dev-fe-ecs.kortix.com`. Import the existing `dev.kortix.com` Cloudflare record
+into `module.dns.cloudflare_record.records[\"dev\"]` before the next apply. Then
+remove the old `dev-fe-ecs` state entry after confirming the alias is no longer
+required. Do not apply a plan that attempts to create a duplicate canonical
+record.

--- a/infra/terraform/environments/dev-web/main.tf
+++ b/infra/terraform/environments/dev-web/main.tf
@@ -101,8 +101,8 @@ module "dns" {
   zone_id = var.cloudflare_zone_id
 
   records = {
-    dev-fe-ecs = {
-      name    = "dev-fe-ecs"
+    dev = {
+      name    = "dev"
       type    = "CNAME"
       value   = module.web.alb_dns_name
       proxied = true

--- a/infra/terraform/environments/dev-web/variables.tf
+++ b/infra/terraform/environments/dev-web/variables.tf
@@ -10,7 +10,7 @@ variable "web_image" {
 }
 
 variable "web_certificate_arn" {
-  description = "ACM wildcard certificate covering dev-fe-ecs.kortix.com."
+  description = "ACM wildcard certificate covering dev.kortix.com."
   type        = string
   default     = "arn:aws:acm:us-west-2:935064898258:certificate/d70f1f49-d981-4add-abb6-971bad1f3755"
 }
@@ -27,7 +27,7 @@ variable "cloudflare_api_token" {
 }
 
 variable "manage_dns" {
-  description = "Create only dev-fe-ecs.kortix.com. This stack never manages dev.kortix.com."
+  description = "Manage the canonical dev.kortix.com CNAME for the ECS frontend."
   type        = bool
   default     = true
 }

--- a/infra/terraform/environments/dev/README.md
+++ b/infra/terraform/environments/dev/README.md
@@ -3,8 +3,7 @@
 | Surface | Where it runs | Managed by |
 |---|---|---|
 | `dev-api.kortix.com` | Cloudflare (proxied) → ALB → **ECS Fargate** (autoscaled, private subnets, NAT egress) | **this Terraform** |
-| `dev.kortix.com` (frontend) | Vercel | Vercel Git integration |
-| `dev-fe-ecs.kortix.com` (parallel frontend) | Cloudflare (proxied) → ALB → **ECS Fargate** | `../dev-web` Terraform |
+| `dev.kortix.com` (frontend) | Cloudflare (proxied) → ALB → **ECS Fargate** | `../dev-web` Terraform |
 
 The **same module set prod uses** (`../prod`) — dev just runs smaller numbers
 and Fargate Spot. App code still ships via CI (`deploy-dev.yml`); Terraform owns

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -2,8 +2,8 @@
 #
 #   dev-api-ecs-fargate.kortix.com → Cloudflare (proxied, Full strict) → ALB →
 #   ECS Fargate service (autoscaled) in private subnets, egress via NAT.
-#   dev-fe-ecs.kortix.com → Cloudflare → a separate ECS Fargate frontend service.
-#   dev.kortix.com remains on Vercel.
+#   dev.kortix.com → Cloudflare → a separate ECS Fargate frontend service.
+#   Vercel is disabled for the main branch.
 #
 # This ECS service is the always-warm FALLBACK behind dev-api.kortix.com: that
 # hostname is a Cloudflare Worker (infra/cloudflare/workers/api-router, env=dev)

--- a/infra/terraform/environments/preview/README.md
+++ b/infra/terraform/environments/preview/README.md
@@ -43,7 +43,7 @@ endpoint before planning. Pass only its operator-verified CIDR values through
 
 Set `TF_VAR_cloudflare_api_token` only for this apply. Do not commit the token.
 The workflow uses `pull_request_target`. It builds the approved PR SHA in three
-jobs with read-only repository access and no Docker Hub, AWS, Vercel, or
+jobs with read-only repository access and no Docker Hub, AWS, or
 application secrets. Those jobs upload fixed-tag Docker archives. A default-branch
 job loads and publishes the archives without starting their containers. Only that
 job receives deployment credentials. The deployed containers receive preview
@@ -62,11 +62,10 @@ following evidence:
    `environment=preview` and this PR's full commit SHA.
 2. `https://pr-<PR>.preview.kortix.com/api/health` reports the same SHA.
 3. The ECS frontend uses Basic auth and targets only its per-PR API.
-4. The sticky PR comment contains both ECS and Vercel frontend URLs.
-5. The Vercel deployment calls the per-PR backend successfully.
-6. Closing or removing the label deletes the ECS service, two listener rules,
-   two target groups, active task definitions, and owned Vercel variables.
-7. Pushing a new commit tears down the old preview and removes `preview`.
+4. The sticky PR comment contains the ECS frontend URL.
+5. Closing or removing the label deletes the ECS service, two listener rules,
+   two target groups, and active task definitions.
+6. Pushing a new commit tears down the old preview and removes `preview`.
 
 The shared Terraform root remains after per-PR teardown.
 
@@ -94,10 +93,10 @@ DNS record, role, secret, VPC, or certificate.
 2. Apply the reviewed shared-root plan from an operator session.
 3. Have a repository writer or administrator label one disposable internal PR
    with `preview` after reviewing its exact head SHA.
-4. Require exact API SHA, `environment=preview`, Vercel `READY`, exact Vercel
-   commit/branch metadata, and both branch variables targeting its PR backend.
-5. Remove the label. Confirm per-PR ECS, ALB, task-definition, and owned Vercel
-   resources are absent. The workflow rejects a 21st active preview by default.
+4. Require the exact API SHA, `environment=preview`, exact frontend SHA, and
+   per-PR runtime URLs.
+5. Remove the label. Confirm per-PR ECS, ALB, and task-definition resources are
+   absent. The workflow rejects a 21st active preview by default.
 
 The backend containers receive `kortix-preview-env`. That secret contains
 provider and application credentials required by the full preview API. Applying
@@ -115,7 +114,6 @@ PR is closed or no longer has `preview`. It derives the PR number from the stric
 and name.
 
 Before shared-root rollback, remove `preview` from every PR and verify zero
-`kortix-pr-*` services. Restore Vercel branch variables only if their value still
-targets that PR's backend. Then run and review `terraform plan -destroy`. Destroy
+`kortix-pr-*` services. Then run and review `terraform plan -destroy`. Destroy
 only this root; do not remove the shared dev VPC, preview secret, ACM certificate,
 GitHub OIDC provider, state bucket, or lock table.

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -42,24 +42,25 @@ describe('web ECS migration', () => {
     expect(webDeploy).toContain('bash infra/scripts/sync-web-env.sh dev');
     expect(webDeploy).toContain('--service web');
     expect(webDeploy).toContain('${{ needs.build-frontend.outputs.image }}');
-    expect(workflow).toContain('https://dev-fe-ecs.kortix.com');
+    expect(workflow).toContain('base=https://dev.kortix.com');
     expect(workflow).toContain('  publish-web-ecs-dns:');
     expect(workflow).toContain('node infra/scripts/sync-web-dns.mjs dev "$alb"');
     expect(workflow).not.toContain('detach-web-dev-vercel-domain');
-    expect(workflow).not.toContain('cutover-web-dev-dns');
     expect(workflow).not.toContain('detach-vercel-web-domain.mjs');
-    expect(workflow).not.toContain('sync-web-dns.mjs dev canonical');
     expect(workflow).toContain('consecutive_matches=0');
     expect(workflow).toContain('/^x-vercel-/');
-    expect(workflow).toContain('dev.kortix.com remained on Vercel');
+    expect(workflow).toContain('kortix:${WEB_PROTECTION_PASSWORD}x');
+    expect(workflow).toContain('cookie_only=');
+    expect(workflow).toContain('[ "$vercel_headers" = 0 ]');
+    expect(workflow).not.toContain('dev-fe-ecs.kortix.com');
     expect(workflow).toContain('gateway: ${{ steps.outputs.outputs.gateway }}');
     expect(workflow).toContain('cli: ${{ steps.outputs.outputs.cli }}');
     expect(workflow).toContain('gateway=false');
     expect(workflow).toContain('cli=false');
-    expect(workflow).toContain('dev.kortix.com stays on Vercel');
+    expect(workflow).toContain('Vercel is disabled for main');
   });
 
-  it('defines an isolated Dev web service that cannot manage canonical DNS', () => {
+  it('defines the Dev web service and canonical DNS record', () => {
     const terraform = read('infra/terraform/environments/dev-web/main.tf');
     const variables = read('infra/terraform/environments/dev-web/variables.tf');
 
@@ -68,9 +69,9 @@ describe('web ECS migration', () => {
     expect(terraform).toContain('container_name         = "web"');
     expect(terraform).toContain('health_check_path      = "/api/health"');
     expect(terraform).toContain('enable_postgres_egress = false');
-    expect(terraform).toContain('dev-fe-ecs');
-    expect(terraform).not.toContain('name    = "dev"');
-    expect(variables).toContain('This stack never manages dev.kortix.com');
+    expect(terraform).toContain('name    = "dev"');
+    expect(terraform).not.toContain('dev-fe-ecs');
+    expect(variables).toContain('Manage the canonical dev.kortix.com CNAME');
     expect(variables).not.toContain('manage_canonical_dns');
   });
 
@@ -150,6 +151,21 @@ describe('web ECS migration', () => {
     expect(workflow).toContain('labels/preview');
     expect(previewScript).toContain('WEB_SECRET_NAME="kortix-preview-web-env"');
     expect(previewTerraform).toContain('name = "kortix-preview-web-env"');
+    expect(workflow).not.toMatch(/vercel/i);
+    expect(workflow).not.toContain('KORTIX_PREVIEW_APPROVED_SHA');
+    expect(workflow).toContain('"- **Frontend:** https://${web}"');
+  });
+
+  it('disables Vercel for Dev and PR previews only', () => {
+    const config = read('apps/web/vercel.json');
+    const ignore = read('apps/web/scripts/vercel-ignore.sh');
+
+    expect(config).toContain('"main": false');
+    expect(config).toContain('"staging": true');
+    expect(config).toContain('"prod": true');
+    expect(ignore).not.toContain('KORTIX_PREVIEW_APPROVED_SHA');
+    expect(ignore).not.toContain('*:main');
+    expect(ignore).toContain('dev and PR previews deploy on ECS only');
   });
 
   it('uses Basic auth credentials in QA instead of Vercel bypass headers', () => {


### PR DESCRIPTION
## Problem

`dev.kortix.com` still resolves to Vercel while the Dev ECS frontend runs only on `dev-fe-ecs.kortix.com`. Preview deployments also build a second Vercel frontend and keep branch-scoped backend variables.

## Changes

- point `dev.kortix.com` at the Dev web ALB and use it in the ECS runtime profile
- convert the existing Cloudflare Vercel A record to the ECS CNAME by record name
- disable Vercel Git deployments for `main` and all PR branches
- keep Vercel enabled for `staging` and `prod`
- remove the Vercel preview wiring job, credentials, variables, status URL, and teardown path
- preserve exact-SHA preview approval, unprivileged image builds, ECS teardown, password protection, shared cookie access, and stale-preview reconciliation
- update Terraform ownership and migration documentation

## Verification

- `bun test tests/unit/sandbox-workflow.test.ts apps/web/src/lib/environment-protection.test.ts infra/scripts/render-web-env.test.mjs infra/scripts/sync-web-dns.test.mjs tests/unit/web-ecs-workflow.test.ts` — 38 pass, 0 fail
- `python3 infra/scripts/test-ecs-preview-runtime.py` — 7 pass
- `actionlint .github/workflows/deploy-dev.yml .github/workflows/deploy-preview.yml` — pass
- `shellcheck apps/web/scripts/vercel-ignore.sh` — pass
- `pnpm exec biome check ...` for changed JS, JSON, and TypeScript files — pass
- Terraform `1.9.8` `fmt`, `init -backend=false`, and `validate` — every configured root passes
- `tflint --chdir=infra/terraform --recursive --format compact` — pass

## Live preflight

- Dev ALB: `kortix-dev-web-alb-1003755586.us-west-2.elb.amazonaws.com`, active
- TLS: issued `*.kortix.com` ACM certificate covers `dev.kortix.com`
- ECS: service active, 1 desired, 1 running, 0 pending
- autoscaling: min 1, max 4; scale-in and scale-out are enabled
- current canonical DNS: proxied A `dev.kortix.com -> 76.76.21.21` (Vercel)
- current ECS alias: proxied CNAME `dev-fe-ecs.kortix.com ->` Dev web ALB

## Post-merge proof

The Deploy Dev workflow will perform the DNS cutover and exact-SHA frontend verification. A disposable PR will then verify the full ECS-only preview deploy, new-commit invalidation, redeploy, unlabel teardown, and close teardown.
