### PR TITLE
fix: network-boundary secrets fail loudly instead of silently

### DIFF
--- a/apps/api/src/__tests__/unit-project-secret-strategy-route.test.ts
+++ b/apps/api/src/__tests__/unit-project-secret-strategy-route.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { connectors, projectSecrets, projectSessionSecretHandles } from '@kortix/db';
+import type { SecretEgressPolicy } from '@kortix/db';
 import { Hono } from 'hono';
 import * as realAccess from '../projects/lib/access';
+import type {
+  ProjectSecretPropagationResult,
+  ProjectSecretPropagationTarget,
+} from '../projects/lib/sandbox-env-sync';
 
 const PROJECT_ID = '33333333-3333-4333-8333-333333333333';
 const ACCOUNT_ID = '44444444-4444-4444-8444-444444444444';
@@ -26,6 +31,53 @@ const handleUpdates: Array<Record<string, unknown>> = [];
 const audits: Array<Record<string, unknown>> = [];
 const propagations: Array<{ projectId: string; options: unknown }> = [];
 const boundConnectorSlugs: string[] = [];
+
+// The OTHER shared egress secrets in the project — what the save-time
+// destination-collision query reads.
+const boundarySecrets: Array<{ identifier: string; egressPolicy: SecretEgressPolicy | null }> = [];
+
+// What the mocked fan-out reports back, and an optional gate that never settles
+// so a test can prove a call site is fire-and-forget.
+let propagationResult: ProjectSecretPropagationResult = propagationReport();
+let propagationGate: Promise<void> | null = null;
+
+function propagationReport(
+  overrides: Partial<ProjectSecretPropagationResult> = {},
+): ProjectSecretPropagationResult {
+  return {
+    ok: true,
+    active_sandboxes: 0,
+    targeted: 0,
+    synced: 0,
+    failed: 0,
+    exported: 0,
+    results: [],
+    ...overrides,
+  };
+}
+
+function syncTarget(
+  overrides: Partial<ProjectSecretPropagationTarget> = {},
+): ProjectSecretPropagationTarget {
+  return {
+    session_id: 'session-1',
+    sandbox_id: 'sandbox-1',
+    status: 'synced',
+    scope: 'inherit',
+    revision: 'rev-1',
+    exported: 1,
+    managed: 0,
+    withheld: 0,
+    agent_env_written: true,
+    ...overrides,
+  };
+}
+
+function resetPropagation() {
+  propagations.length = 0;
+  propagationResult = propagationReport();
+  propagationGate = null;
+}
 
 function secretRow(overrides: Record<string, unknown> = {}) {
   const now = new Date('2026-08-03T10:00:00.000Z');
@@ -85,6 +137,12 @@ const databaseMock = {
         return { where: async () => boundConnectorSlugs.map((slug) => ({ slug })) };
       }
       if (table !== projectSecrets) throw new Error('unexpected table');
+      // The destination-collision query is the only projectSecrets select that
+      // asks for identifier + policy and no secretId, and the only one that
+      // resolves to a LIST rather than a single row.
+      if (fields && 'identifier' in fields && 'egressPolicy' in fields && !('secretId' in fields)) {
+        return { where: async () => boundarySecrets.map((secret) => ({ ...secret })) };
+      }
       return { where: () => queryResult(fields) };
     },
   }),
@@ -156,6 +214,8 @@ mock.module('../projects/lib/access', () => ({
 mock.module('../projects/lib/sandbox-env-sync', () => ({
   propagateProjectSecretsToActiveSandboxes: async (projectId: string, options: unknown) => {
     propagations.push({ projectId, options });
+    if (propagationGate) await propagationGate;
+    return propagationResult;
   },
 }));
 
@@ -208,8 +268,9 @@ describe('PUT /v1/projects/:projectId/secrets/:identifier/strategy', () => {
     updates.length = 0;
     handleUpdates.length = 0;
     audits.length = 0;
-    propagations.length = 0;
     boundConnectorSlugs.length = 0;
+    boundarySecrets.length = 0;
+    resetPropagation();
   });
 
   test('changes runtime to denied and records metadata-only audit data', async () => {
@@ -438,6 +499,186 @@ describe('PUT /v1/projects/:projectId/secrets/:identifier/strategy', () => {
     expect(audits).toHaveLength(1);
   });
 
+  test('rejects a boundary policy that claims another secret host and header', async () => {
+    boundarySecrets.push({
+      identifier: 'BOUNDARY_TEST',
+      egressPolicy: {
+        rules: [{ host: 'postman-echo.com' }],
+        inject: { kind: 'header', name: 'Authorization', template: 'Bearer {{secret}}' },
+      } as SecretEgressPolicy,
+    });
+
+    const response = await buildApp().request(
+      `/v1/projects/${PROJECT_ID}/secrets/SERVICE_API_KEY/strategy`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          strategy: 'egress',
+          egress_policy: {
+            // Different case on both axes — the provider edge matches neither
+            // case-sensitively, so neither may the save check.
+            rules: [{ host: 'Postman-Echo.com' }],
+            inject: { kind: 'header', name: 'AUTHORIZATION', template: 'Bearer {{secret}}' },
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      code: 'secret_boundary_destination_conflict',
+      conflict: {
+        identifier: 'BOUNDARY_TEST',
+        host: 'postman-echo.com',
+        header: 'authorization',
+      },
+    });
+    // The sentence has to name both secrets, or the author cannot tell which
+    // pair collided.
+    expect(body.error).toContain('BOUNDARY_TEST');
+    expect(body.error).toContain('SERVICE_API_KEY');
+    expect(body.error).toContain('postman-echo.com');
+    expect(body.error).toContain('authorization');
+    expect(updates).toHaveLength(0);
+    expect(audits).toHaveLength(0);
+    expect(propagations).toHaveLength(0);
+  });
+
+  test('accepts the same host under a different header', async () => {
+    boundarySecrets.push({
+      identifier: 'BOUNDARY_TEST',
+      egressPolicy: {
+        rules: [{ host: 'postman-echo.com' }],
+        inject: { kind: 'header', name: 'authorization' },
+      } as SecretEgressPolicy,
+    });
+
+    const response = await buildApp().request(
+      `/v1/projects/${PROJECT_ID}/secrets/SERVICE_API_KEY/strategy`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          strategy: 'egress',
+          egress_policy: {
+            rules: [{ host: 'postman-echo.com' }],
+            inject: { kind: 'header', name: 'x-api-key' },
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(updates).toHaveLength(1);
+  });
+
+  test('does not report a conflict against the secret being edited', async () => {
+    const stored = {
+      rules: [{ host: 'postman-echo.com' }],
+      inject: { kind: 'header', name: 'authorization', template: 'Bearer {{secret}}' },
+    } as SecretEgressPolicy;
+    row = secretRow({
+      strategy: 'egress',
+      consumer: 'network',
+      egressPolicy: stored,
+      rotatedAt: new Date('2026-08-03T10:00:00.000Z'),
+    });
+    boundarySecrets.push({ identifier: 'SERVICE_API_KEY', egressPolicy: stored });
+
+    const response = await buildApp().request(
+      `/v1/projects/${PROJECT_ID}/secrets/SERVICE_API_KEY/strategy`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          strategy: 'egress',
+          egress_policy: {
+            rules: [{ host: 'postman-echo.com' }],
+            inject: { kind: 'header', name: 'authorization', template: 'Token {{secret}}' },
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({ strategy: 'egress' });
+  });
+
+  test('reports every failed sandbox in the delivery sync', async () => {
+    propagationResult = propagationReport({
+      ok: false,
+      active_sandboxes: 2,
+      targeted: 2,
+      synced: 1,
+      failed: 1,
+      exported: 3,
+      results: [
+        syncTarget({ session_id: 'session-ok', sandbox_id: 'sandbox-ok' }),
+        syncTarget({
+          session_id: 'session-bad',
+          sandbox_id: 'sandbox-bad',
+          status: 'failed',
+          scope: null,
+          revision: null,
+          exported: 0,
+          managed: null,
+          withheld: null,
+          agent_env_written: false,
+          reason: 'Sandbox provider daytona does not support network-boundary secret delivery',
+        }),
+      ],
+    });
+
+    const response = await buildApp().request(
+      `/v1/projects/${PROJECT_ID}/secrets/SERVICE_API_KEY/strategy`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          strategy: 'egress',
+          egress_policy: {
+            rules: [{ host: 'api.example.com' }],
+            inject: { kind: 'header', name: 'authorization' },
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).delivery_sync).toEqual({
+      ok: false,
+      targeted: 2,
+      synced: 1,
+      failed: 1,
+      failures: [
+        {
+          session_id: 'session-bad',
+          sandbox_id: 'sandbox-bad',
+          reason: 'Sandbox provider daytona does not support network-boundary secret delivery',
+        },
+      ],
+    });
+  });
+
+  test('reports no delivery sync when the policy is unchanged', async () => {
+    const response = await buildApp().request(
+      `/v1/projects/${PROJECT_ID}/secrets/SERVICE_API_KEY/strategy`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ strategy: 'runtime' }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).delivery_sync).toBeNull();
+    expect(updates).toHaveLength(0);
+    expect(propagations).toHaveLength(0);
+  });
+
   test('rejects a network policy whose method restriction cannot be enforced', async () => {
     const response = await buildApp().request(
       `/v1/projects/${PROJECT_ID}/secrets/SERVICE_API_KEY/strategy`,
@@ -577,8 +818,9 @@ describe('POST /v1/projects/:projectId/secrets audit', () => {
     updates.length = 0;
     handleUpdates.length = 0;
     audits.length = 0;
-    propagations.length = 0;
     boundConnectorSlugs.length = 0;
+    boundarySecrets.length = 0;
+    resetPropagation();
   });
 
   test('records a metadata-only create event and marks the value rotated', async () => {
@@ -673,6 +915,127 @@ describe('POST /v1/projects/:projectId/secrets audit', () => {
       egress_policy: policy,
     });
     expect(row).toMatchObject({ strategy: 'egress', consumer: 'network', egressPolicy: policy });
+  });
+
+  test('rejects creating a boundary secret on a claimed host and header', async () => {
+    boundarySecrets.push({
+      identifier: 'BOUNDARY_TEST',
+      egressPolicy: {
+        rules: [{ host: 'postman-echo.com' }],
+        inject: { kind: 'header', name: 'authorization' },
+      } as SecretEgressPolicy,
+    });
+
+    const response = await buildApp().request(`/v1/projects/${PROJECT_ID}/secrets`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'SERVICE_API_KEY',
+        value: 'plaintext-test-value',
+        strategy: 'egress',
+        consumer: 'network',
+        egress_policy: {
+          rules: [{ host: 'postman-echo.com' }],
+          inject: { kind: 'header', name: 'Authorization' },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      code: 'secret_boundary_destination_conflict',
+      conflict: { identifier: 'BOUNDARY_TEST', host: 'postman-echo.com', header: 'authorization' },
+    });
+    expect(row).toBeNull();
+    expect(audits).toHaveLength(0);
+    expect(propagations).toHaveLength(0);
+  });
+
+  test('reports the delivery sync for a new boundary secret', async () => {
+    propagationResult = propagationReport({
+      ok: false,
+      active_sandboxes: 1,
+      targeted: 1,
+      synced: 0,
+      failed: 1,
+      results: [
+        syncTarget({
+          session_id: 'session-bad',
+          sandbox_id: 'sandbox-bad',
+          status: 'failed',
+          scope: null,
+          revision: null,
+          exported: 0,
+          managed: null,
+          withheld: null,
+          agent_env_written: false,
+          reason: 'Sandbox provider daytona does not support network-boundary secret delivery',
+        }),
+      ],
+    });
+
+    const response = await buildApp().request(`/v1/projects/${PROJECT_ID}/secrets`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'SERVICE_API_KEY',
+        value: 'plaintext-test-value',
+        strategy: 'egress',
+        consumer: 'network',
+        egress_policy: {
+          rules: [{ host: 'api.example.com' }],
+          inject: { kind: 'header', name: 'authorization' },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).delivery_sync).toEqual({
+      ok: false,
+      targeted: 1,
+      synced: 0,
+      failed: 1,
+      failures: [
+        {
+          session_id: 'session-bad',
+          sandbox_id: 'sandbox-bad',
+          reason: 'Sandbox provider daytona does not support network-boundary secret delivery',
+        },
+      ],
+    });
+  });
+
+  test('reports no delivery sync for an ordinary secret', async () => {
+    const response = await buildApp().request(`/v1/projects/${PROJECT_ID}/secrets`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'SERVICE_API_KEY', value: 'plaintext-test-value' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).delivery_sync).toBeNull();
+    expect(propagations).toHaveLength(1);
+  });
+
+  test('does not wait for the sandbox fan-out on an ordinary secret', async () => {
+    // The gate never settles. If the route awaited the fan-out here, an
+    // ordinary secret save would hang for the full push timeout per sandbox.
+    propagationGate = new Promise<void>(() => {});
+
+    const pending = Promise.resolve(
+      buildApp().request(`/v1/projects/${PROJECT_ID}/secrets`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'SERVICE_API_KEY', value: 'plaintext-test-value' }),
+      }),
+    );
+    const settled = await Promise.race([
+      pending.then((response) => `responded:${response.status}`),
+      new Promise<string>((resolve) => setTimeout(() => resolve('still-waiting'), 250)),
+    ]);
+
+    expect(settled).toBe('responded:200');
+    expect(propagations).toHaveLength(1);
   });
 
   test('rejects a creation consumer without a strategy', async () => {
@@ -845,7 +1208,8 @@ describe('DELETE /v1/projects/:projectId/secrets/:identifier audit', () => {
     authType = 'supabase';
     updates.length = 0;
     audits.length = 0;
-    propagations.length = 0;
+    boundarySecrets.length = 0;
+    resetPropagation();
   });
 
   test('records the deleted policy metadata without the encrypted value', async () => {
@@ -927,7 +1291,8 @@ describe('DELETE /v1/projects/:projectId/oauth/:provider audit', () => {
     agentGrant = null;
     authType = 'supabase';
     audits.length = 0;
-    propagations.length = 0;
+    boundarySecrets.length = 0;
+    resetPropagation();
   });
 
   test('deletes subscription credentials and records metadata only', async () => {

--- a/apps/api/src/platform/services/sandbox-provisioning-error.test.ts
+++ b/apps/api/src/platform/services/sandbox-provisioning-error.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 
+import { networkBoundaryPolicyError } from '../../secrets/network-boundary';
 import {
+  INVALID_SECRET_BOUNDARY_POLICY_MESSAGE,
   SANDBOX_PROVIDER_CAPACITY_MESSAGE,
   SANDBOX_PROVIDER_FAILURE_MESSAGE,
   classifySandboxProvisioningFailure,
@@ -57,5 +59,83 @@ describe('classifySandboxProvisioningFailure', () => {
       isCapacity: false,
       isGitAuth: false,
     });
+  });
+
+  // Two secrets claiming the same (host, header) used to land in 'sandbox-provider', whose copy
+  // blames the provider and says "Try again" — verified live on dev, where every new session in the
+  // project failed with exactly that. Retrying can never clear a config conflict.
+  test('classifies a host+header collision as an unretryable project config error', () => {
+    const result = classifySandboxProvisioningFailure(
+      new Error(
+        'Network-boundary secrets BOUNDARY_TEST and BOUNDARY_TEST2 both target postman-echo.com header authorization',
+      ),
+    );
+
+    expect(result.category).toBe('invalid-secret-boundary-policy');
+    expect(result.userMessage).toBe(INVALID_SECRET_BOUNDARY_POLICY_MESSAGE);
+    expect(result.isCapacity).toBe(false);
+    expect(result.isGitAuth).toBe(false);
+  });
+
+  test.each([
+    ['Network-boundary secret STRIPE has an invalid consumer'],
+    ['Network-boundary secret STRIPE has no outbound policy'],
+    ['STRIPE: Network-boundary delivery requires exact hosts'],
+    ['STRIPE: Network-boundary delivery cannot enforce path restrictions'],
+    ['STRIPE: invalid header injection'],
+  ])('classifies %s as an unretryable project config error', (message) => {
+    expect(classifySandboxProvisioningFailure(new Error(message)).category).toBe(
+      'invalid-secret-boundary-policy',
+    );
+  });
+
+  // The provider-capability gap and the project-config error are different problems with different
+  // fixes, so one must never absorb the other.
+  test('keeps the provider capability gap distinct from a bad project policy', () => {
+    expect(
+      classifySandboxProvisioningFailure(
+        new Error('Sandbox provider daytona does not support network-boundary secret delivery'),
+      ).category,
+    ).toBe('unsupported-secret-delivery');
+  });
+
+  test('leaves an ordinary provider failure unclassified', () => {
+    expect(
+      classifySandboxProvisioningFailure(new Error('upstream returned 500')).category,
+    ).toBe('sandbox-provider');
+  });
+
+  /**
+   * Drives the REAL validator rather than a copy of its strings, so a rule added to
+   * `networkBoundaryPolicyError` cannot quietly fall through to "Try again." A hardcoded list would
+   * still pass while the new message went unclassified — which is exactly how the collision shipped.
+   */
+  test('classifies every message the boundary validator can produce', () => {
+    const base = {
+      rules: [{ host: 'api.example.com' }],
+      inject: { kind: 'header' as const, name: 'authorization', template: 'Bearer {{secret}}' },
+    };
+    const invalidPolicies = [
+      { ...base, backend: 'kortix_fetch' },
+      { ...base, on_no_match: 'allow' },
+      { ...base, tls: 'passthrough' },
+      { ...base, inject: { kind: 'query' as const, name: 'token' } },
+      { ...base, rules: [{ host: '*.example.com' }] },
+      { ...base, rules: [{ host: 'api.example.com', methods: ['GET'] }] },
+      { ...base, rules: [{ host: 'api.example.com', path: '/v1' }] },
+    ];
+
+    const produced = invalidPolicies
+      .map((policy) => networkBoundaryPolicyError(policy as never))
+      .filter((message): message is string => message !== null);
+
+    // Every entry above must actually be rejected; otherwise this test proves nothing.
+    expect(produced).toHaveLength(invalidPolicies.length);
+
+    for (const message of produced) {
+      expect(classifySandboxProvisioningFailure(new Error(`STRIPE: ${message}`)).category).toBe(
+        'invalid-secret-boundary-policy',
+      );
+    }
   });
 });

--- a/apps/api/src/platform/services/sandbox-provisioning-error.ts
+++ b/apps/api/src/platform/services/sandbox-provisioning-error.ts
@@ -2,6 +2,7 @@ export type SandboxProvisioningFailureCategory =
   | 'provider-capacity'
   | 'git-auth'
   | 'unsupported-secret-delivery'
+  | 'invalid-secret-boundary-policy'
   | 'sandbox-provider';
 
 export interface SandboxProvisioningFailure {
@@ -20,6 +21,10 @@ export const SANDBOX_PROVIDER_FAILURE_MESSAGE =
 export const UNSUPPORTED_SECRET_DELIVERY_MESSAGE =
   'This sandbox provider cannot enforce network-boundary secret delivery. Select Platinum or change the secret delivery policy.';
 
+export const INVALID_SECRET_BOUNDARY_POLICY_MESSAGE =
+  "A network-boundary secret in this project has an invalid outbound policy, so no session can start. " +
+  'Two secrets cannot inject the same header for the same host. Fix the secret delivery settings — retrying will not help.';
+
 const CAPACITY_PATTERN =
   /no available runner|no runners available|no capacity|out of capacity|capacity exceeded|failed to place sandbox|rate ?limit|too many requests|maximum number of concurrent (?:e2b )?sandboxes|max(?:imum)? number of running sandboxes(?: on node)? reached|too many sandboxes starting on this node/i;
 
@@ -28,6 +33,20 @@ const GIT_AUTH_PATTERN =
 
 const UNSUPPORTED_SECRET_DELIVERY_PATTERN =
   /does not support network-boundary secret delivery/i;
+
+/**
+ * The project's own network-boundary config is unusable, so `resolveNetworkBoundaryBindings`
+ * refuses the whole set before any provider is contacted.
+ *
+ * Distinct from `unsupported-secret-delivery`, which is a PROVIDER capability gap. This is a
+ * Kortix-side configuration error, and it used to be indistinguishable from a provider fault:
+ * with no pattern here it fell through to `sandbox-provider`, whose copy blames the provider and
+ * says "Try again" — for a state where retrying can never succeed. Two secrets claiming the same
+ * (host, header) is now rejected at save time, so this classifies the configs that predate that
+ * check, plus the other policy throws (invalid consumer, missing policy, non-exact host).
+ */
+const INVALID_SECRET_BOUNDARY_POLICY_PATTERN =
+  /both target .+ header |Network-boundary secret |Network-boundary delivery |invalid header injection/i;
 
 /**
  * Convert a provider or initialization error into one stable user contract.
@@ -42,6 +61,15 @@ export function classifySandboxProvisioningFailure(error: unknown): SandboxProvi
     return {
       category: 'unsupported-secret-delivery',
       userMessage: UNSUPPORTED_SECRET_DELIVERY_MESSAGE,
+      isCapacity: false,
+      isGitAuth: false,
+    };
+  }
+
+  if (INVALID_SECRET_BOUNDARY_POLICY_PATTERN.test(rawMessage)) {
+    return {
+      category: 'invalid-secret-boundary-policy',
+      userMessage: INVALID_SECRET_BOUNDARY_POLICY_MESSAGE,
       isCapacity: false,
       isGitAuth: false,
     };

--- a/apps/api/src/projects/lib/serializers.test.ts
+++ b/apps/api/src/projects/lib/serializers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 
-import { serializeProject } from './serializers';
+import {
+  type SecretAgentGrantConfig,
+  buildSecretView,
+  secretDeliveryBlockedReason,
+  serializeProject,
+} from './serializers';
 
 // `metadata` is nullable: packages/db/src/schema/kortix.ts:330 declares
 // jsonb('metadata').default({}) with NO .notNull(), which is why
@@ -78,5 +83,262 @@ describe('serializeProject — icon_glyph', () => {
     const out = serializeProject(row);
     expect(out.icon).toBe('🚀');
     expect(out.icon_glyph).toEqual({ name: 'Star', color: 'red' });
+  });
+});
+
+// ─── delivery_blocked_reason: the agent-grant axis ──────────────────────────
+// An `egress`/`broker` secret reaches a session only when some agent's
+// `secrets:` list is an explicit array naming its IDENTIFIER
+// (apps/api/src/secrets/strategy.ts:475-507). `delivery_status` never looked at
+// that, so a project whose manifest grants nothing still reported 'available'
+// while every boot withheld the value as `agent_grant_unscoped`.
+
+function secretRow(overrides: Record<string, unknown> = {}): any {
+  return {
+    secretId: 's-1',
+    projectId: '33333333-3333-4333-8333-333333333333',
+    identifier: 'BOUNDARY_TEST',
+    name: 'BOUNDARY_TEST',
+    valueEnc: 'enc',
+    scope: 'runtime',
+    strategy: 'egress',
+    consumer: 'network',
+    egressPolicy: {
+      rules: [{ host: 'postman-echo.com' }],
+      inject: { kind: 'header', name: 'authorization' },
+    },
+    handlePrefix: null,
+    description: null,
+    rotatedAt: new Date('2026-01-02T00:00:00Z'),
+    strategyLocked: false,
+    ownerUserId: null,
+    active: true,
+    createdBy: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+/** A declarative config — the manifest parsed, so its `agents:` declarations
+ *  are the complete grant set and the answer is certain. */
+function declarative(env: Array<string[] | 'all' | undefined>): SecretAgentGrantConfig {
+  return {
+    agent_discovery: 'declarative',
+    agents: env.map((scopeEnv, i) => ({
+      name: `agent-${i}`,
+      path: `.opencode/agent/agent-${i}.md`,
+      description: null,
+      mode: null,
+      source: 'kortix.yaml' as const,
+      enabled: true,
+      ...(scopeEnv === undefined
+        ? {}
+        : { scope: { env: scopeEnv, connectors: 'all' as const, kortix_cli: 'all' as const } }),
+    })),
+  };
+}
+
+describe('secretDeliveryBlockedReason', () => {
+  test('an explicit identifier grant clears the block', () => {
+    expect(
+      secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', declarative([['BOUNDARY_TEST']])),
+    ).toBeNull();
+  });
+
+  test('matching is case-insensitive, like listAdmits', () => {
+    expect(
+      secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', declarative([['boundary_test']])),
+    ).toBeNull();
+  });
+
+  test('any one agent granting it is enough', () => {
+    const config = declarative([['OTHER_KEY'], 'all', ['BOUNDARY_TEST']]);
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', config)).toBeNull();
+  });
+
+  test('a grant that excludes the identifier blocks delivery', () => {
+    expect(
+      secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', declarative([['OTHER_KEY']])),
+    ).toBe('no_agent_grant');
+  });
+
+  test("'all' is not a grant for a non-runtime secret", () => {
+    // strategy.ts withholds it as `agent_grant_unscoped` — the same outcome as
+    // an absent list, which is exactly why 'all' cannot clear the block.
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', declarative(['all']))).toBe(
+      'no_agent_grant',
+    );
+  });
+
+  test('an agent with no scope at all blocks delivery', () => {
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', declarative([undefined]))).toBe(
+      'no_agent_grant',
+    );
+  });
+
+  test('a declarative config with zero agents is ambiguous, so it reports null', () => {
+    // `resolveConfigAgents` only reaches 'declarative' with an empty list when the
+    // manifest FAILED to parse (specs empty, errors present) or every agent is
+    // disabled. Neither proves the absence of a grant, and warning on a manifest
+    // we could not read is worse than not warning at all.
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', declarative([]))).toBeNull();
+  });
+
+  test('broker secrets take the same rule as egress', () => {
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'broker', declarative([['OTHER']]))).toBe(
+      'no_agent_grant',
+    );
+    expect(
+      secretDeliveryBlockedReason('BOUNDARY_TEST', 'broker', declarative([['BOUNDARY_TEST']])),
+    ).toBeNull();
+  });
+
+  test('runtime and denied secrets never carry the reason', () => {
+    // A null grant delivers a runtime secret, and `denied` is a policy
+    // statement about the secret, not about who may read it.
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'runtime', declarative([]))).toBeNull();
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'denied', declarative([]))).toBeNull();
+  });
+
+  // The commonest broken setup, and the one that sent a real user hunting for
+  // hours: an egress secret on a project whose manifest declares no `agents:`.
+  // `resolveConfigAgents` reports 'opencode' only when the manifest produced no
+  // specs AND no errors, so this state is certain, not unknown.
+  test('opencode discovery means no manifest grant exists, which is certain', () => {
+    const config: SecretAgentGrantConfig = { agent_discovery: 'opencode', agents: [] };
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', config)).toBe('no_agent_grant');
+  });
+
+  test('a native opencode agent does not rescue an egress secret', () => {
+    // Grants come only from manifest specs. A discovered `.opencode/agent/*.md`
+    // carries none, so it cannot make an egress secret deliverable.
+    const config: SecretAgentGrantConfig = {
+      agent_discovery: 'opencode',
+      agents: [
+        {
+          name: 'build',
+          description: null,
+          path: '.opencode/agent/build.md',
+          source: 'opencode',
+          enabled: true,
+          scope: { env: undefined, connectors: undefined },
+        } as SecretAgentGrantConfig['agents'][number],
+      ],
+    };
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', config)).toBe('no_agent_grant');
+  });
+
+  test('runtime secrets are unaffected by opencode discovery', () => {
+    const config: SecretAgentGrantConfig = { agent_discovery: 'opencode', agents: [] };
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'runtime', config)).toBeNull();
+  });
+
+  test('no config at all reports null', () => {
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', null)).toBeNull();
+    expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', undefined)).toBeNull();
+  });
+
+  test('authorization is by IDENTIFIER, never by the env-var name', () => {
+    // Two identifiers may share one name, so a grant naming the KEY authorizes
+    // nothing. GMAPS-primary and GMAPS-backup are both GOOGLE_MAPS_API_KEY.
+    expect(
+      secretDeliveryBlockedReason('GMAPS-primary', 'egress', declarative([['GMAPS-primary']])),
+    ).toBeNull();
+    expect(
+      secretDeliveryBlockedReason(
+        'GMAPS-primary',
+        'egress',
+        declarative([['GOOGLE_MAPS_API_KEY']]),
+      ),
+    ).toBe('no_agent_grant');
+  });
+});
+
+describe('buildSecretView — delivery_blocked_reason', () => {
+  test('an ungranted egress secret is flagged while delivery_status stays available', () => {
+    const view = buildSecretView({
+      identifier: 'BOUNDARY_TEST',
+      name: 'BOUNDARY_TEST',
+      shared: secretRow(),
+      canManageShared: true,
+      agentGrants: declarative([['OTHER_KEY']]),
+    });
+    expect(view.delivery_blocked_reason).toBe('no_agent_grant');
+    // The two axes are independent: 'available' still means "the deployment
+    // supports this mode", which the CLI and the web chip both key off.
+    expect(view.delivery_status).toBe(
+      view.network_boundary_available ? 'available' : 'unavailable',
+    );
+  });
+
+  test('a granted egress secret carries no reason', () => {
+    const view = buildSecretView({
+      identifier: 'BOUNDARY_TEST',
+      name: 'BOUNDARY_TEST',
+      shared: secretRow(),
+      canManageShared: true,
+      agentGrants: declarative([['BOUNDARY_TEST']]),
+    });
+    expect(view.delivery_blocked_reason).toBeNull();
+  });
+
+  test('the identifier decides, not the env-var key', () => {
+    const shared = secretRow({ identifier: 'GMAPS-primary', name: 'GOOGLE_MAPS_API_KEY' });
+    const byIdentifier = buildSecretView({
+      identifier: 'GMAPS-primary',
+      name: 'GOOGLE_MAPS_API_KEY',
+      shared,
+      canManageShared: true,
+      agentGrants: declarative([['GMAPS-primary']]),
+    });
+    const byName = buildSecretView({
+      identifier: 'GMAPS-primary',
+      name: 'GOOGLE_MAPS_API_KEY',
+      shared,
+      canManageShared: true,
+      agentGrants: declarative([['GOOGLE_MAPS_API_KEY']]),
+    });
+    expect(byIdentifier.delivery_blocked_reason).toBeNull();
+    expect(byName.delivery_blocked_reason).toBe('no_agent_grant');
+  });
+
+  test('omitting agentGrants leaves every pre-existing field unchanged', () => {
+    const shared = secretRow();
+    const before = buildSecretView({
+      identifier: 'BOUNDARY_TEST',
+      name: 'BOUNDARY_TEST',
+      shared,
+      canManageShared: true,
+    });
+    const after = buildSecretView({
+      identifier: 'BOUNDARY_TEST',
+      name: 'BOUNDARY_TEST',
+      shared,
+      canManageShared: true,
+      agentGrants: declarative([['OTHER_KEY']]),
+    });
+    expect(before.delivery_blocked_reason).toBeNull();
+    const { delivery_blocked_reason: _omitted, ...beforeRest } = before;
+    const { delivery_blocked_reason: _flagged, ...afterRest } = after;
+    expect(beforeRest).toEqual(afterRest);
+  });
+
+  test('a runtime secret is never flagged, whatever the manifest grants', () => {
+    const view = buildSecretView({
+      identifier: 'PLAIN_KEY',
+      name: 'PLAIN_KEY',
+      shared: secretRow({
+        identifier: 'PLAIN_KEY',
+        name: 'PLAIN_KEY',
+        strategy: 'runtime',
+        consumer: 'sandbox',
+        egressPolicy: null,
+      }),
+      canManageShared: true,
+      agentGrants: declarative([['OTHER_KEY']]),
+    });
+    expect(view.delivery_blocked_reason).toBeNull();
+    expect(view.delivery_status).toBe('available');
   });
 });

--- a/apps/api/src/projects/lib/serializers.test.ts
+++ b/apps/api/src/projects/lib/serializers.test.ts
@@ -219,11 +219,11 @@ describe('secretDeliveryBlockedReason', () => {
         {
           name: 'build',
           description: null,
+          mode: null,
           path: '.opencode/agent/build.md',
           source: 'opencode',
           enabled: true,
-          scope: { env: undefined, connectors: undefined },
-        } as SecretAgentGrantConfig['agents'][number],
+        },
       ],
     };
     expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', config)).toBe('no_agent_grant');
@@ -232,6 +232,20 @@ describe('secretDeliveryBlockedReason', () => {
   test('runtime secrets are unaffected by opencode discovery', () => {
     const config: SecretAgentGrantConfig = { agent_discovery: 'opencode', agents: [] };
     expect(secretDeliveryBlockedReason('BOUNDARY_TEST', 'runtime', config)).toBeNull();
+  });
+
+  // A caller may hand over a config it only partly resolved. Reading `agents`
+  // off it threw a TypeError and turned GET /secrets into a 500, so the shape is
+  // checked rather than trusted.
+  test.each([
+    ['an empty object', {}],
+    ['a missing agents array', { agent_discovery: 'declarative' }],
+    ['a non-array agents field', { agent_discovery: 'declarative', agents: null }],
+    ['an unknown discovery mode', { agent_discovery: 'something-else', agents: [] }],
+  ])('survives %s and reports null', (_label, config) => {
+    expect(
+      secretDeliveryBlockedReason('BOUNDARY_TEST', 'egress', config as SecretAgentGrantConfig),
+    ).toBeNull();
   });
 
   test('no config at all reports null', () => {

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -353,8 +353,12 @@ export function secretDeliveryBlockedReason(
   if (strategy !== 'egress' && strategy !== 'broker') return null;
   if (!config) return null;
   if (config.agent_discovery === 'opencode') return 'no_agent_grant';
-  if (config.agents.length === 0) return null;
-  const granted = config.agents.some((agent) => {
+  // Anything other than the two known modes is a config we do not understand —
+  // including a partial object from a caller that resolved only part of it.
+  if (config.agent_discovery !== 'declarative') return null;
+  const agents = config.agents;
+  if (!Array.isArray(agents) || agents.length === 0) return null;
+  const granted = agents.some((agent) => {
     const env = agent.scope?.env;
     return Array.isArray(env) && grantAdmits(env, identifier);
   });

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -1,4 +1,10 @@
-import type { Project, ProjectSession, Secret } from '@kortix/api-contract';
+import type {
+  Project,
+  ProjectSession,
+  Secret,
+  SecretDeliveryBlockedReason,
+  SecretDeliveryStrategy,
+} from '@kortix/api-contract';
 import {
   type accountGithubInstallations,
   type projectGitConnections,
@@ -22,6 +28,7 @@ import {
 } from '../../snapshots/error-classify';
 import { templateSlugFromBuildSlug } from '../../snapshots/ppwarm-names';
 import type { ProjectRole } from '../access';
+import type { ProjectConfigSummary } from '../git/types';
 import { type GitHubRepo, isGithubAppConfigured } from '../github';
 import { parseGitHubRepoUrl } from './git';
 import { isPlaceholderOpencodeTitle, runtimeRootTitleFromSnapshot } from './opencode-title';
@@ -296,6 +303,65 @@ export function requestAuditContext(c: Context): RequestAuditContext {
 export type SecretRow = typeof projectSecrets.$inferSelect;
 
 /**
+ * The slice of a loaded `ProjectConfigSummary` the agent-grant axis needs. A
+ * `Pick`, so a route hands the whole loaded config straight through.
+ */
+export type SecretAgentGrantConfig = Pick<ProjectConfigSummary, 'agent_discovery' | 'agents'>;
+
+/** Grant membership. Case-insensitive, mirroring `listAdmits` in
+ *  ../../secrets/strategy.ts — a hand-written `secrets:` list in kortix.yaml may
+ *  use any case, and the two answers must agree. */
+function grantAdmits(list: string[], identifier: string): boolean {
+  const target = identifier.toUpperCase();
+  return list.some((entry) => entry.toUpperCase() === target);
+}
+
+/**
+ * Can any agent receive this secret? Returns the block reason, or null.
+ *
+ * `resolveSecretDelivery` (../../secrets/strategy.ts) hands an `egress`/`broker`
+ * secret to a session only when some agent's `secrets:` list is an explicit
+ * ARRAY naming this IDENTIFIER. `'all'` and an absent list both withhold it as
+ * `agent_grant_unscoped`, so neither counts as a grant here. Matching is by
+ * identifier, never by the env-var `name` — several identifiers may share one
+ * name.
+ *
+ * The tri-state forbids guessing, so read `agent_discovery` for what
+ * `resolveConfigAgents` (../git/config.ts) actually means by it:
+ *
+ *   `opencode`   — the manifest yielded NO agent specs AND NO parse errors, i.e.
+ *                  it declared no `agents:` at all (or there is no manifest).
+ *                  `grantFromLoadedAgents` then resolves to a null grant, which
+ *                  `resolveSecretDelivery` withholds. CERTAIN: no session can
+ *                  ever receive this secret. A native `.opencode` agent does not
+ *                  rescue it — grants come only from manifest specs.
+ *   `declarative`, agents non-empty — the manifest parsed and its declarations
+ *                  are the complete grant set. CERTAIN either way.
+ *   `declarative`, agents EMPTY — the only ambiguous state, and it is reached by
+ *                  a manifest that FAILED to parse (specs empty, errors present)
+ *                  or one whose agents are all disabled. Report null.
+ *
+ * Getting this backwards would be worse than useless in both directions: silent
+ * on the commonest broken setup (no `agents:` block), and crying wolf on a
+ * manifest we merely failed to read.
+ */
+export function secretDeliveryBlockedReason(
+  identifier: string,
+  strategy: SecretDeliveryStrategy,
+  config: SecretAgentGrantConfig | null | undefined,
+): SecretDeliveryBlockedReason | null {
+  if (strategy !== 'egress' && strategy !== 'broker') return null;
+  if (!config) return null;
+  if (config.agent_discovery === 'opencode') return 'no_agent_grant';
+  if (config.agents.length === 0) return null;
+  const granted = config.agents.some((agent) => {
+    const env = agent.scope?.env;
+    return Array.isArray(env) && grantAdmits(env, identifier);
+  });
+  return granted ? null : 'no_agent_grant';
+}
+
+/**
  * The view of one project secret (one IDENTIFIER): the shared/project row
  * merged with the requesting member's own private override (used today only by
  * the CODEX_AUTH_JSON per-user provider login), plus which one wins at runtime.
@@ -311,6 +377,9 @@ export function buildSecretView(input: {
   shared?: SecretRow;
   personal?: SecretRow;
   canManageShared: boolean;
+  /** The project's loaded config, for the agent-grant axis. Omit it and every
+   *  pre-existing field is unchanged; `delivery_blocked_reason` reports null. */
+  agentGrants?: SecretAgentGrantConfig | null;
 }): Secret {
   const { identifier, name, shared, personal, canManageShared } = input;
   const system = isSystemProjectSecretName(name);
@@ -383,6 +452,11 @@ export function buildSecretView(input: {
         : strategy === 'denied'
           ? 'disabled'
           : 'unavailable',
+    // Two axes, deliberately not folded together. `delivery_status` answers
+    // "does this deployment support the mode" and stays 'available' on a missing
+    // grant, because the CLI, the SDK and the web chip all key off that meaning.
+    // The grant axis is per-project and lives here.
+    delivery_blocked_reason: secretDeliveryBlockedReason(identifier, strategy, input.agentGrants),
     network_boundary_available: networkBoundaryDeliveryAvailable(),
     egress_policy: deliveryRow?.egressPolicy ?? null,
     strategy_locked: deliveryRow?.strategyLocked ?? false,
@@ -400,6 +474,9 @@ export async function loadSecretViewsForUser(
   projectId: string,
   userId: string,
   canManageShared: boolean,
+  /** The project's loaded config. Callers that have already read it pass it so
+   *  every row reports the agent-grant axis; omitting it reports null. */
+  agentGrants?: SecretAgentGrantConfig | null,
 ): Promise<ReturnType<typeof buildSecretView>[]> {
   const rows = await db
     .select()
@@ -427,6 +504,7 @@ export async function loadSecretViewsForUser(
       shared: slot.shared,
       personal: slot.personal,
       canManageShared,
+      agentGrants,
     }),
   );
 }

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -12,13 +12,24 @@ import { loadProjectConfig } from '../git';
 import { parseBasicAuthHeader } from '../git-backends';
 import { pollCodexDeviceAuth, startCodexDeviceAuth } from '../codex-device-auth';
 import { decryptProjectSecret, encryptProjectSecret, identifierKeyConflicts, isValidIdentifier, isValidSecretName, resolveProjectSecretForConsumer } from '../secrets';
-import { propagateProjectSecretsToActiveSandboxes } from '../lib/sandbox-env-sync';
+import {
+  propagateProjectSecretsToActiveSandboxes,
+  type ProjectSecretPropagationResult,
+} from '../lib/sandbox-env-sync';
 import { isGatewayManagedEnv } from '../../llm-gateway/sandbox-credentials';
 import { seedProjectDefaultModelOnConnect } from '../../llm-gateway/models/seed-default';
 import { createRoute, z } from '@hono/zod-openapi';
-import { SecretConsumerSchema, UpdateSecretStrategyInputSchema } from '@kortix/api-contract';
+import {
+  SecretConsumerSchema,
+  SecretSchema as ContractSecretSchema,
+  UpdateSecretStrategyInputSchema,
+} from '@kortix/api-contract';
 import { parseEgressPolicy } from '../../secrets/strategy';
-import { networkBoundaryPolicyError } from '../../secrets/network-boundary';
+import {
+  findBoundaryDestinationConflict,
+  networkBoundaryPolicyError,
+  type BoundaryDestinationConflict,
+} from '../../secrets/network-boundary';
 import { networkBoundaryDeliveryAvailable } from '../../secrets/network-boundary-availability';
 import {
   connectors,
@@ -26,6 +37,7 @@ import {
   projectSessionSecretHandles,
   projects,
   sessionSandboxes,
+  type SecretEgressPolicy,
 } from '@kortix/db';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import {
@@ -35,10 +47,99 @@ import {
 } from '../lib/access';
 import { AnyObject, SecretSchema, projectsApp } from '../lib/app';
 import { getProjectGitConnection, getProjectGitRemote, hasServerManagedGitAuth, loadGitProject, resolveProjectGitAuth, resolveProjectUpstream, upsertProjectGitConnection, upsertProjectGitCredential, withProjectGitAuth } from '../lib/git';
-import { CODEX_AUTH_JSON_SECRET_NAME, isSystemProjectSecretName, loadSecretViewsForUser, normalizeString, readBody, serializeProjectGitConnection } from '../lib/serializers';
+import { CODEX_AUTH_JSON_SECRET_NAME, isSystemProjectSecretName, loadSecretViewsForUser, normalizeString, readBody, serializeProjectGitConnection, type SecretAgentGrantConfig } from '../lib/serializers';
 import { sessionWorkspaceAllowsRepositoryAccess } from '../lib/session-workspace-access';
 
 type ProjectSecretConsumer = z.infer<typeof SecretConsumerSchema>;
+
+// ─── Secret write responses ─────────────────────────────────────────────────
+// A secret write may also have to reach every LIVE sandbox in the project. The
+// two write routes that can move a network-boundary credential report what that
+// fan-out actually did, because a save that stored fine and delivered nowhere
+// otherwise looks identical to a save that worked. `delivery_sync` is null when
+// no fan-out ran. It is NOT part of `SecretSchema` — a secret READ has no sync
+// to report.
+
+const SecretDeliverySyncSchema = z
+  .object({
+    ok: z.boolean(),
+    targeted: z.number(),
+    synced: z.number(),
+    failed: z.number(),
+    failures: z.array(
+      z.object({
+        session_id: z.string(),
+        sandbox_id: z.string().nullable(),
+        reason: z.string(),
+      }),
+    ),
+  })
+  .nullable()
+  .optional();
+
+type SecretDeliverySync = NonNullable<z.infer<typeof SecretDeliverySyncSchema>>;
+
+const SecretWriteResultSchema = ContractSecretSchema.extend({
+  delivery_sync: SecretDeliverySyncSchema,
+}).openapi('SecretWriteResult');
+
+/** Keep the per-sandbox reasons; drop the rows that succeeded. */
+function summarizeDeliverySync(result: ProjectSecretPropagationResult): SecretDeliverySync {
+  return {
+    ok: result.ok,
+    targeted: result.targeted,
+    synced: result.synced,
+    failed: result.failed,
+    failures: result.results
+      .filter((target) => target.status === 'failed')
+      .map((target) => ({
+        session_id: target.session_id,
+        sandbox_id: target.sandbox_id,
+        reason: target.reason ?? 'sandbox sync failed',
+      })),
+  };
+}
+
+/**
+ * The other network-boundary secret in this project that already claims one of
+ * the candidate's (host, header) destinations, or null.
+ *
+ * The provider edge maps one destination to one credential. A second claim is
+ * refused at session provision, so the stored pair takes down every NEW session
+ * in the project with an error the author cannot connect to their edit. Both
+ * write routes call this BEFORE the row lands.
+ */
+async function boundaryDestinationConflict(
+  projectId: string,
+  identifier: string,
+  policy: SecretEgressPolicy,
+): Promise<BoundaryDestinationConflict | null> {
+  const rows = await db
+    .select({ identifier: projectSecrets.identifier, egressPolicy: projectSecrets.egressPolicy })
+    .from(projectSecrets)
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        eq(projectSecrets.strategy, 'egress'),
+        isNull(projectSecrets.ownerUserId),
+      ),
+    );
+  return findBoundaryDestinationConflict(
+    { identifier, policy },
+    rows.map((other) => ({ identifier: other.identifier, policy: other.egressPolicy })),
+  );
+}
+
+function boundaryConflictBody(identifier: string, conflict: BoundaryDestinationConflict) {
+  return {
+    error:
+      `${conflict.identifier} already injects the "${conflict.header}" header for ${conflict.host}. ` +
+      `Two secrets cannot target the same host and header — give ${identifier} a different header, ` +
+      'or a different host.',
+    code: 'secret_boundary_destination_conflict',
+    conflict,
+  };
+}
 
 async function connectorSecretBindings(projectId: string, identifier: string): Promise<string[]> {
   const rows = await db
@@ -483,11 +584,16 @@ projectsApp.openapi(
   let optional: string[] = [];
   let manifestStatus: 'loaded' | 'missing' | 'error' = 'missing';
   let manifestError: string | null = null;
+  // The same load answers `delivery_blocked_reason` (which agents may receive an
+  // egress/broker secret). Threading the config costs no extra I/O; leaving it
+  // null on a failed load is what keeps the warning from firing on a guess.
+  let agentGrants: SecretAgentGrantConfig | null = null;
   try {
     const projectConfig = await loadProjectConfig(await withProjectGitAuth(loaded.row), []);
     required = projectConfig?.env?.required ?? [];
     optional = projectConfig?.env?.optional ?? [];
     manifestStatus = projectConfig?.manifest_raw ? 'loaded' : 'missing';
+    agentGrants = projectConfig ?? null;
   } catch (err) {
     manifestStatus = 'error';
     manifestError = err instanceof Error ? err.message : String(err);
@@ -509,7 +615,7 @@ projectsApp.openapi(
   // standing agent grant remains the enumeration ceiling for agent tokens.
   const agentGrant = getAgentGrant(c);
 
-  const items = (await loadSecretViewsForUser(projectId, loaded.userId, canManageShared))
+  const items = (await loadSecretViewsForUser(projectId, loaded.userId, canManageShared, agentGrants))
     .filter((item) => !item.system)
     .filter((item) => agentMayUseEnv(agentGrant, item.identifier));
 
@@ -542,8 +648,8 @@ projectsApp.openapi(
         body: { content: { 'application/json': { schema: AnyObject } } },
       },
     responses: {
-        200: json(SecretSchema, 'The created secret'),
-        ...errors(400, 404),
+        200: json(SecretWriteResultSchema, 'The created secret'),
+        ...errors(400, 404, 409),
     },
   }),
   async (c: any) => {
@@ -668,6 +774,8 @@ projectsApp.openapi(
           409,
         );
       }
+      const conflict = await boundaryDestinationConflict(projectId, identifier, policy.policy);
+      if (conflict) return c.json(boundaryConflictBody(identifier, conflict), 409);
     }
     explicitPolicy = policy.policy;
   } else if (body.egress_policy !== undefined) {
@@ -782,7 +890,22 @@ projectsApp.openapi(
     }),
   );
 
-  void propagateProjectSecretsToActiveSandboxes(projectId, { refreshModels: isGatewayManagedEnv(name) });
+  // Only a network-boundary secret waits for the fan-out. Its value never
+  // reaches the sandbox, so a failed push is the difference between "the agent
+  // can call that host" and "it cannot" — the author has to see it. Awaiting is
+  // up to 15s per live sandbox, which no ordinary secret save should pay, so
+  // every other strategy keeps the detached push.
+  const boundaryDelivery = explicitStrategy === 'egress' || existing?.strategy === 'egress';
+  let deliverySync: SecretDeliverySync | null = null;
+  if (boundaryDelivery) {
+    deliverySync = summarizeDeliverySync(
+      await propagateProjectSecretsToActiveSandboxes(projectId, {
+        refreshModels: isGatewayManagedEnv(name),
+      }),
+    );
+  } else {
+    void propagateProjectSecretsToActiveSandboxes(projectId, { refreshModels: isGatewayManagedEnv(name) });
+  }
 
   // First provider connect on a default-less project → seed a sensible project
   // default model (that provider's flagship). Detached + idempotent; never seeds
@@ -801,7 +924,7 @@ projectsApp.openapi(
   if (!view) {
     throw new Error(`Secret view not found after upsert: ${identifier}`);
   }
-  return c.json(view, 200);
+  return c.json({ ...view, delivery_sync: deliverySync }, 200);
 },
 );
 
@@ -817,7 +940,7 @@ projectsApp.openapi(
       body: { content: { 'application/json': { schema: UpdateSecretStrategyInputSchema } } },
     },
     responses: {
-      200: json(SecretSchema, 'Updated secret delivery strategy'),
+      200: json(SecretWriteResultSchema, 'Updated secret delivery strategy'),
       ...errors(400, 403, 404, 409),
     },
   }),
@@ -997,6 +1120,14 @@ projectsApp.openapi(
       }
     }
 
+    // Last gate before the write: the destination has to be free. Checked here,
+    // after the 404 and the lock checks, so an author sees the specific reason
+    // rather than a collision report for a secret they cannot edit anyway.
+    if (parsed.data.strategy === 'egress' && nextPolicy) {
+      const conflict = await boundaryDestinationConflict(projectId, identifier, nextPolicy);
+      if (conflict) return c.json(boundaryConflictBody(identifier, conflict), 409);
+    }
+
     const nextHandlePrefix =
       nextConsumer === 'http_broker' ? (parsed.data.handle_prefix ?? null) : null;
     const deliveryChanged =
@@ -1004,6 +1135,7 @@ projectsApp.openapi(
       existing.consumer !== nextConsumer ||
       JSON.stringify(existing.egressPolicy ?? null) !== JSON.stringify(nextPolicy) ||
       existing.handlePrefix !== nextHandlePrefix;
+    let deliverySync: SecretDeliverySync | null = null;
     if (deliveryChanged) {
       const changedAt = new Date();
       const actorType =
@@ -1055,16 +1187,21 @@ projectsApp.openapi(
           metadata: { identifier, name: existing.name },
         }),
       );
-      await propagateProjectSecretsToActiveSandboxes(projectId, {
-        refreshModels: isGatewayManagedEnv(existing.name),
-      });
+      // This route already paid for the fan-out and discarded the report. A
+      // network-boundary secret that stored fine and reached no live sandbox is
+      // otherwise indistinguishable from one that worked.
+      deliverySync = summarizeDeliverySync(
+        await propagateProjectSecretsToActiveSandboxes(projectId, {
+          refreshModels: isGatewayManagedEnv(existing.name),
+        }),
+      );
     }
 
     const views = await loadSecretViewsForUser(projectId, loaded.userId, true);
     const view = views.find((item) => item.identifier === identifier);
     if (!view) return c.json({ error: 'Not found' }, 404);
 
-    return c.json(view, 200);
+    return c.json({ ...view, delivery_sync: deliverySync }, 200);
   },
 );
 

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -625,6 +625,7 @@ export function sessionStartFailureFromSandbox(
     rawCategory === 'provider-capacity' ||
     rawCategory === 'git-auth' ||
     rawCategory === 'unsupported-secret-delivery' ||
+    rawCategory === 'invalid-secret-boundary-policy' ||
     rawCategory === 'sandbox-provider'
       ? rawCategory
       : 'sandbox-provider';
@@ -647,7 +648,14 @@ export function sessionStartFailureFromSandbox(
     (typeof metadata.errorMessage === 'string' && metadata.errorMessage.length > 0
       ? metadata.errorMessage
       : 'The sandbox provider could not start this session. Try again.');
-  return { category, message, retryable: category !== 'unsupported-secret-delivery' };
+  // Both secret-delivery categories are configuration states, not transient faults: the identical
+  // input produces the identical failure every time, so offering a retry only wastes the user's time.
+  return {
+    category,
+    message,
+    retryable:
+      category !== 'unsupported-secret-delivery' && category !== 'invalid-secret-boundary-policy',
+  };
 }
 
 async function preserveEstablishedRuntimeOnOpen(

--- a/apps/api/src/secrets/network-boundary.test.ts
+++ b/apps/api/src/secrets/network-boundary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  findBoundaryDestinationConflict,
   networkBoundaryPolicyError,
   resolveNetworkBoundaryBindings,
 } from './network-boundary';
@@ -132,5 +133,141 @@ describe('resolveNetworkBoundaryBindings', () => {
         },
       ),
     ).toThrow('api.example.com');
+  });
+});
+
+function policy(
+  hosts: string[],
+  header: string,
+): NonNullable<ResolvedProjectSecret['egressPolicy']> {
+  return {
+    rules: hosts.map((host) => ({ host })),
+    inject: { kind: 'header', name: header, template: 'Bearer {{secret}}' },
+    on_no_match: 'deny',
+  };
+}
+
+describe('findBoundaryDestinationConflict', () => {
+  test('reports the secret that already claims the same host and header', () => {
+    expect(
+      findBoundaryDestinationConflict(
+        { identifier: 'billing-backup', policy: policy(['api.example.com'], 'authorization') },
+        [{ identifier: 'billing-api', policy: policy(['api.example.com'], 'authorization') }],
+      ),
+    ).toEqual({
+      identifier: 'billing-api',
+      host: 'api.example.com',
+      header: 'authorization',
+    });
+  });
+
+  test('allows one host to carry two secrets under different headers', () => {
+    expect(
+      findBoundaryDestinationConflict(
+        { identifier: 'billing-backup', policy: policy(['api.example.com'], 'x-api-key') },
+        [{ identifier: 'billing-api', policy: policy(['api.example.com'], 'authorization') }],
+      ),
+    ).toBeNull();
+  });
+
+  test('does not collide a secret with its own stored row', () => {
+    expect(
+      findBoundaryDestinationConflict(
+        { identifier: 'billing-api', policy: policy(['api.example.com'], 'authorization') },
+        [{ identifier: 'billing-api', policy: policy(['api.example.com'], 'authorization') }],
+      ),
+    ).toBeNull();
+  });
+
+  test('compares host and header case-insensitively', () => {
+    expect(
+      findBoundaryDestinationConflict(
+        { identifier: 'billing-backup', policy: policy(['API.Example.COM'], 'Authorization') },
+        [{ identifier: 'billing-api', policy: policy(['api.example.com'], 'authorization') }],
+      ),
+    ).toEqual({
+      identifier: 'billing-api',
+      host: 'api.example.com',
+      header: 'authorization',
+    });
+  });
+
+  test('skips a secret that has no outbound policy', () => {
+    expect(
+      findBoundaryDestinationConflict(
+        { identifier: 'billing-backup', policy: policy(['api.example.com'], 'authorization') },
+        [
+          { identifier: 'plain-runtime', policy: null },
+          { identifier: 'billing-api', policy: policy(['other.example.com'], 'authorization') },
+        ],
+      ),
+    ).toBeNull();
+  });
+
+  test('skips a secret injected somewhere other than a header', () => {
+    expect(
+      findBoundaryDestinationConflict(
+        { identifier: 'billing-backup', policy: policy(['api.example.com'], 'authorization') },
+        [
+          {
+            identifier: 'billing-api',
+            policy: {
+              rules: [{ host: 'api.example.com' }],
+              inject: { kind: 'query', name: 'authorization' },
+            },
+          },
+        ],
+      ),
+    ).toBeNull();
+  });
+
+  test('reports a conflict on any overlapping host of a multi-host policy', () => {
+    expect(
+      findBoundaryDestinationConflict(
+        {
+          identifier: 'billing-backup',
+          policy: policy(['a.example.com', 'b.example.com'], 'authorization'),
+        },
+        [
+          {
+            identifier: 'billing-api',
+            policy: policy(['c.example.com', 'b.example.com'], 'authorization'),
+          },
+        ],
+      ),
+    ).toEqual({
+      identifier: 'billing-api',
+      host: 'b.example.com',
+      header: 'authorization',
+    });
+  });
+
+  test('agrees with the provision-time throw on the same pair of policies', () => {
+    const first = secret({ egressPolicy: policy(['API.Example.com'], 'Authorization') });
+    const second = secret({
+      secretId: 'backup',
+      identifier: 'billing-backup',
+      key: 'BILLING_BACKUP_KEY',
+      egressPolicy: policy(['api.example.COM'], 'authorization'),
+    });
+
+    expect(
+      findBoundaryDestinationConflict(
+        { identifier: second.identifier, policy: second.egressPolicy! },
+        [{ identifier: first.identifier, policy: first.egressPolicy! }],
+      ),
+    ).toEqual({
+      identifier: 'billing-api',
+      host: 'api.example.com',
+      header: 'authorization',
+    });
+
+    expect(() =>
+      resolveNetworkBoundaryBindings([first, second], {
+        sessionId: 'session-1',
+        agentGrantEnv: ['billing-api', 'billing-backup'],
+        sessionAllowlist: null,
+      }),
+    ).toThrow('billing-api and billing-backup both target api.example.com header authorization');
   });
 });

--- a/apps/api/src/secrets/network-boundary.ts
+++ b/apps/api/src/secrets/network-boundary.ts
@@ -64,6 +64,70 @@ export function networkBoundaryPolicyError(policy: BoundaryPolicy): string | nul
   return null;
 }
 
+/**
+ * The (host, header) pairs a policy claims at the provider edge, lowercased —
+ * the provider matches both case-insensitively. Null when the policy injects
+ * somewhere other than a header, which claims no boundary destination at all.
+ *
+ * Save-time validation and provision-time assembly both read the pair from
+ * here. A destination the save check spells differently from the provision
+ * check is a destination the save check cannot protect.
+ */
+function boundaryDestinations(
+  policy: Pick<SecretEgressPolicy, 'rules' | 'inject'>,
+): { header: string; hosts: string[] } | null {
+  if (policy.inject.kind !== 'header') return null;
+  return {
+    header: policy.inject.name.toLowerCase(),
+    hosts: [...new Set(policy.rules.map((rule) => rule.host.toLowerCase()))].sort(),
+  };
+}
+
+function destinationKey(host: string, header: string): string {
+  return `${host.toLowerCase()}\n${header.toLowerCase()}`;
+}
+
+export interface BoundaryDestinationConflict {
+  /** The OTHER secret that already claims the destination. */
+  identifier: string;
+  host: string;
+  header: string;
+}
+
+/**
+ * The first destination the candidate shares with another secret in the project.
+ *
+ * The provider edge maps one (host, header) pair to one credential, so a second
+ * claim has no defined winner. `resolveNetworkBoundaryBindings` refuses it, but
+ * that happens at session provision: the project keeps its stored secrets and
+ * every NEW session dies with a generic provider error that no retry can clear.
+ * Callers run this at SAVE time so the author sees the collision while they can
+ * still pick another header or host.
+ *
+ * Identifiers are compared exactly, matching the provision-time check — two rows
+ * that differ only in case are two secrets to both paths, not one.
+ */
+export function findBoundaryDestinationConflict(
+  candidate: { identifier: string; policy: Pick<SecretEgressPolicy, 'rules' | 'inject'> },
+  others: Array<{ identifier: string; policy: Pick<SecretEgressPolicy, 'rules' | 'inject'> | null }>,
+): BoundaryDestinationConflict | null {
+  const target = boundaryDestinations(candidate.policy);
+  if (!target) return null;
+  const claimed = new Set(target.hosts.map((host) => destinationKey(host, target.header)));
+
+  for (const other of others) {
+    if (!other.policy || other.identifier === candidate.identifier) continue;
+    const destination = boundaryDestinations(other.policy);
+    if (!destination) continue;
+    for (const host of destination.hosts) {
+      if (claimed.has(destinationKey(host, destination.header))) {
+        return { identifier: other.identifier, host, header: destination.header };
+      }
+    }
+  }
+  return null;
+}
+
 function bindingAlias(secretId: string): string {
   const compact = secretId.replace(/[^A-Za-z0-9]/g, '').slice(0, 56);
   if (!compact) throw new Error('Network-boundary secret has no stable id');
@@ -103,27 +167,28 @@ export function resolveNetworkBoundaryBindings(
     const policyError = networkBoundaryPolicyError(row.egressPolicy);
     if (policyError) throw new Error(`${row.identifier}: ${policyError}`);
 
+    const destination = boundaryDestinations(row.egressPolicy);
     const inject = row.egressPolicy.inject;
-    if (inject.kind !== 'header') throw new Error(`${row.identifier}: invalid header injection`);
-    const header = inject.name.toLowerCase();
-    const hosts = [...new Set(row.egressPolicy.rules.map((rule) => rule.host.toLowerCase()))].sort();
-    for (const host of hosts) {
-      const destination = `${host}\n${header}`;
-      const existing = destinations.get(destination);
+    if (!destination || inject.kind !== 'header') {
+      throw new Error(`${row.identifier}: invalid header injection`);
+    }
+    for (const host of destination.hosts) {
+      const key = destinationKey(host, destination.header);
+      const existing = destinations.get(key);
       if (existing && existing !== row.identifier) {
         throw new Error(
-          `Network-boundary secrets ${existing} and ${row.identifier} both target ${host} header ${header}`,
+          `Network-boundary secrets ${existing} and ${row.identifier} both target ${host} header ${destination.header}`,
         );
       }
-      destinations.set(destination, row.identifier);
+      destinations.set(key, row.identifier);
     }
 
     bindings.push({
       secretId: row.secretId,
       identifier: row.identifier,
       alias: bindingAlias(row.secretId),
-      hosts,
-      header,
+      hosts: destination.hosts,
+      header: destination.header,
       value: renderSecret(inject.template, row.value),
       onEcho: 'block',
     });

--- a/apps/web/content/docs/project/secrets.mdx
+++ b/apps/web/content/docs/project/secrets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Secrets
-description: How Kortix stores, injects, and rotates encrypted project credentials.
+description: How Kortix stores project credentials and controls where each value is allowed to go.
 ---
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
@@ -21,6 +21,8 @@ differ only when a project holds several candidate values for one name —
 for example, a primary and a backup Google Maps key can both resolve to
 `GOOGLE_MAPS_API_KEY`.
 
+Every access rule uses the identifier. None of them uses the name.
+
 ## Shared and personal scope
 
 A secret is either shared or a personal override:
@@ -39,9 +41,33 @@ An agent only receives the secrets its manifest grants. In `kortix.yaml`,
 the agent's `secrets` field lists identifiers, or is empty to deny all —
 the default when you omit it. See [Agents](/docs/project/agents).
 
-A secret with scope `connector` is different: it authenticates a
-[connector](/docs/connect/connectors), not a session. Kortix resolves it
-server-side and never injects it into a sandbox.
+## Delivery
+
+Delivery decides where the value is allowed to go. Every secret has one
+delivery mode. The default is **Sandbox**.
+
+| Delivery | The sandbox receives | Use it for |
+|---|---|---|
+| **Sandbox** | The plaintext value, as an environment variable | A local process or script that must read the value |
+| **Kortix service** | Nothing | The LLM gateway, a connector, Git, or one policy-bound HTTPS request Kortix makes for you |
+| **Network boundary** | Nothing | An ordinary HTTP client in the sandbox that calls one known host over HTTPS |
+| **Disabled** | Nothing | Keeping a value on file without letting anything use it |
+
+**Sandbox** is the only mode that puts plaintext in the sandbox. Agent code
+can read, print, and forward it. Every other mode keeps the value outside.
+
+Change the mode in the project's Secrets page, or from the CLI:
+
+```bash
+kortix secrets delivery STRIPE_API_KEY denied
+```
+
+<Callout type="warn" title="Session-scoped delivery needs a named agent grant">
+Network boundary and the HTTPS broker attach a credential to one running
+session. For those two modes an agent's `secrets` list must name the identifier
+explicitly. `secrets: all` does not count, and a project with no `agents:` block
+in `kortix.yaml` never receives one.
+</Callout>
 
 ## Add a secret
 
@@ -62,8 +88,8 @@ value under the same name, add `--identifier <id>`. Names can't start with
 <Step>
 ### Or use the dashboard
 
-Open the project's Environment variables page, enter the key and value,
-and save. Kortix encrypts the value immediately.
+Open the project's Secrets page, enter the key and value, and save. Kortix
+encrypts the value immediately.
 </Step>
 
 <Step>
@@ -93,7 +119,7 @@ configuration metadata that the agent grant permits.
 ### Set a new value
 
 Run the same command with the new value, or set it again on the project's
-Environment variables page:
+Secrets page:
 
 ```bash
 kortix secrets set STRIPE_API_KEY=sk_live_new...
@@ -113,7 +139,7 @@ restarts the OpenCode compatibility process.
 ## Remove a secret
 
 Run `kortix secrets unset STRIPE_API_KEY` (or `unset <identifier>`), or
-delete it from the project's Environment variables page.
+delete it from the project's Secrets page.
 
 <Callout type="warn" title="Removal is immediate, propagation is not">
 Kortix deletes a shared secret right away. Push to already-running
@@ -127,6 +153,207 @@ link can enter the value. You never see it. Links stay valid for 7 days by
 default; adjust with `--expires <minutes>` (max 30 days). An expired link shows
 a clear "expired" page — mint a fresh one with the same command.
 
+## Network boundary
+
+Network boundary is the strictest delivery mode. Kortix registers the value
+with the Platinum sandbox provider. Platinum adds the value to matching
+outbound requests at its own egress edge, after the request has left the
+sandbox.
+
+The sandbox never receives the value. It is not an environment variable, it is
+not a file, and no alias or placeholder stands in for it. Grepping the sandbox
+environment for the identifier returns nothing. The agent writes an ordinary
+request with no credential in it, and the header appears in flight.
+
+### Set it up
+
+<Callout type="warn" title="Three things must be true, or the header is silently missing">
+Nothing inside the sandbox can detect a wrong setup. The request leaves without
+the header, and the upstream API answers `401`.
+</Callout>
+
+<Steps>
+
+<Step>
+### Pin the project to Platinum
+
+Only Platinum injects at the boundary. Open **Customize → Feature flags →
+Sandbox provider** and set it to **Platinum**. "Automatic" is not enough: it
+follows the platform default, which can place a session on another provider
+where nothing injects the header.
+
+New sessions use the pinned provider. A session that is already running keeps
+the provider it started on.
+</Step>
+
+<Step>
+### Name the secret in an agent's `secrets` list
+
+```yaml
+kortix_version: 2
+agents:
+  my-agent:
+    secrets: [STRIPE_API_KEY]
+```
+
+The list holds identifiers, and matching ignores case.
+
+`secrets: all` does **not** work here. It grants Sandbox delivery only, and a
+network-boundary secret behaves exactly as if no grant existed. A project with
+no `agents:` block in `kortix.yaml` can never deliver one. Start the session
+with an agent whose list names the secret.
+</Step>
+
+<Step>
+### Write the header value template
+
+The template is what Platinum puts in the header. `{{secret}}` is where the
+value goes.
+
+| Template | Header sent |
+|---|---|
+| `Bearer {{secret}}` | `authorization: Bearer sk_live_...` |
+| `{{secret}}` | `x-api-key: sk_live_...` |
+| *(blank)* | `authorization: sk_live_...` |
+
+A blank template sends the bare value with no scheme. That is correct for
+`x-api-key`. It is wrong for a bearer token, and the API answers `401`. Write
+`Bearer {{secret}}` when the API expects one.
+</Step>
+
+</Steps>
+
+From the CLI, the same configuration is one command:
+
+```bash
+kortix secrets delivery STRIPE_API_KEY egress \
+  --allow-host api.stripe.com \
+  --inject-header authorization \
+  --template 'Bearer {{secret}}'
+```
+
+### Hosts match exactly
+
+List every host you call, one exact hostname per line. There is no pattern
+matching, and the boundary accepts nothing narrower than a host.
+
+| Rejected | Reason |
+|---|---|
+| A wildcard host, `*.example.com` | The boundary needs exact hosts |
+| A path, `api.example.com/v1` | Platinum cannot enforce path restrictions |
+| A method filter, `POST` only | Platinum cannot enforce method restrictions |
+
+`api.example.com` does not cover `uploads.api.example.com`. Add the second host
+to the same secret, or use a second secret. Kortix rejects an unenforceable
+policy with `400` when you save it — it never stores a rule it cannot apply.
+
+Use Kortix service delivery with the HTTPS broker consumer when you need
+wildcards, paths, or method filters. Kortix makes that request itself, so it can
+enforce controls Platinum cannot.
+
+### One header per host
+
+A host and a header can be claimed by one secret only. Saving a second secret
+that targets the same pair fails with `409` and
+`secret_boundary_destination_conflict`, naming the secret that already holds it.
+
+Two secrets on the same host with **different** headers are fine. Platinum
+injects both.
+
+### HTTPS only
+
+Platinum has to terminate TLS to rewrite a header, so a policy host must be
+called over HTTPS. Plain HTTP is refused before the request leaves:
+
+```text
+egress to "api.stripe.com" is blocked: this sandbox's policy puts a secret in a
+request header for this host, and that requires HTTPS
+```
+
+That message is a policy refusal, not a network fault.
+
+### Verify it with two probes
+
+<Callout type="warn" title="An echo service is the worst possible test target">
+If a response would send the secret back into the sandbox, Platinum kills the
+connection. `curl` reports `curl: (52) Empty reply from server`. A correct setup
+therefore looks exactly like a broken one when you test against an endpoint that
+echoes request headers.
+</Callout>
+
+Run both probes from inside the sandbox, against a host that is in the policy.
+The example below uses `postman-echo.com`, which serves one endpoint of each
+kind. Add it as an allowed host for the duration of the test.
+
+```bash
+# 1. Reachability — an endpoint that does NOT echo request headers.
+curl -s -o /dev/null -w '%{http_code}\n' https://postman-echo.com/status/200
+# expected: 200
+
+# 2. Injection — an endpoint that DOES echo request headers.
+curl -sS https://postman-echo.com/get
+# expected: curl: (52) Empty reply from server
+```
+
+Read the pair together. Probe 1 first — it is the only one that tells you the
+host is reachable.
+
+| Probe 1 | Probe 2 | Meaning |
+|---|---|---|
+| `200` | `curl: (52)` | Working. The header was injected and the echo guard blocked the reply. |
+| `200` | `200`, and the echoed headers show no credential | The header was not injected. Re-check the three prerequisites. |
+| anything else | — | The host is not reachable. Probe 2 proves nothing until this passes. |
+
+Also confirm the value never reached the guest:
+
+```bash
+env | grep -c STRIPE_API_KEY
+# expected: 0
+```
+
+A policy host presents Platinum's per-sandbox certificate, which the sandbox
+already trusts:
+
+```bash
+curl -sv https://postman-echo.com/status/200 2>&1 | grep 'issuer:'
+# issuer: O=Platinum; CN=Platinum egress proxy (sandbox sbx_...)
+```
+
+A host that is not in the policy passes through untouched and presents its own
+origin certificate.
+
+### End-to-end example
+
+`kortix.yaml`:
+
+```yaml
+kortix_version: 2
+default_agent: my-agent
+agents:
+  my-agent:
+    secrets: [STRIPE_API_KEY]
+```
+
+Secret configuration:
+
+```bash
+kortix secrets set STRIPE_API_KEY=sk_live_...
+kortix secrets delivery STRIPE_API_KEY egress \
+  --allow-host api.stripe.com \
+  --inject-header authorization \
+  --template 'Bearer {{secret}}'
+```
+
+The agent then calls Stripe with no credential of its own:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' https://api.stripe.com/v1/customers
+# expected: 200
+```
+
+The same request from a session on another provider, or from an agent whose
+`secrets` list omits `STRIPE_API_KEY`, returns `401`. Nothing else changes.
+
 ## CLI commands
 
 | Command | What it does |
@@ -134,18 +361,16 @@ a clear "expired" page — mint a fresh one with the same command.
 | `kortix secrets ls` | List secrets declared and set for the project |
 | `kortix secrets set KEY=VALUE [--identifier <id>]` | Create or update a secret. `KEY=-` reads the value from stdin |
 | `kortix secrets unset IDENTIFIER` | Remove a secret |
+| `kortix secrets delivery IDENTIFIER runtime\|broker\|egress\|denied` | Set the delivery mode and its policy |
+| `kortix secrets call IDENTIFIER URL` | Send one HTTPS broker request |
+| `kortix secrets sync` | Re-push project secrets to this session's sandbox |
 | `kortix secrets request NAME [--scope runtime\|connector] [--expires <min>]` | Create a link so someone else can enter a value |
 | `kortix env push --from <path>` | Upload a `.env` file as secrets |
 | `kortix env pull [--out <path>] [--force]` | Export secret names, not values, to a `.env` file |
 
-## Scopes reference
+Run `kortix secrets --help` for every delivery flag.
 
-Every secret has a `scope`. Default: `runtime`.
-
-| Scope | Injected into the sandbox? | Notes |
-|---|---|---|
-| `runtime` | Yes, as an environment variable | Supports both shared and personal-override values. |
-| `connector` | No | Resolved server-side, inside the connector. `GET /secrets` does not list connector-scope secrets. |
+## Names and permissions
 
 Format rules for the two names:
 
@@ -165,7 +390,8 @@ All routes sit under `/v1/projects/{projectId}`.
 | Method | Path | Description |
 |---|---|---|
 | GET | `/secrets` | List secrets. Scoped to the caller's grant if the caller is a scoped agent token. |
-| POST | `/secrets` | Create or update the shared value. Body: `{name, identifier?, value}`. |
+| POST | `/secrets` | Create or update the shared value. Body: `{name, identifier?, value}`, plus an optional delivery policy. |
+| PUT | `/secrets/{identifier}/strategy` | Change the delivery mode and its policy. |
 | DELETE | `/secrets/{name}` | Delete the shared value. Personal overrides stay in place. |
 | PUT | `/secrets/{name}/personal` | Set or turn on the caller's personal override. |
 | DELETE | `/secrets/{name}/personal` | Remove the caller's personal override. |
@@ -174,6 +400,14 @@ All routes sit under `/v1/projects/{projectId}`.
 if the `identifier` already exists with a different `name`. It rejects the
 exact name `CODEX_AUTH_JSON` with `400` — Kortix manages that secret
 through ChatGPT subscription onboarding.
+
+Both write routes return a `delivery_sync` object when the change had to reach
+running sandboxes. `ok: false` means the value is saved but at least one live
+session still uses the previous one; the listed sessions pick it up on restart.
+
+A secret in the list carries `delivery_blocked_reason`. The value
+`no_agent_grant` means no agent can receive this secret. `null` means it is
+granted, the mode needs no grant, or Kortix could not read the manifest.
 
 ## Rotation and propagation
 
@@ -191,6 +425,9 @@ This push is best-effort. The API call that changes the secret returns
 before the push finishes. A failed push is only logged, not retried. A
 sandbox with a failed push keeps the old value until the next successful
 push, or until the session restarts.
+
+Rotating a network-boundary secret updates the Platinum replica in place. The
+sandbox does not restart, because it never held the value.
 
 ## Model credentials
 

--- a/apps/web/src/features/session/scope/session-scope-model.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.ts
@@ -94,10 +94,28 @@ function cloneBindings(
   );
 }
 
-function grantIncludes(grant: SessionScopeGrant, value: string): boolean {
+/**
+ * Connector grant membership. Exact match, on purpose: the server compares
+ * canonical slugs with a plain `includes` (`agentMayUseConnector`), so a looser
+ * match here would offer a connector the call gate then rejects.
+ */
+function connectorGrantIncludes(grant: SessionScopeGrant, slug: string): boolean {
   if (grant === 'none') return false;
   if (grant === 'all' || grant == null) return true;
-  return grant.includes(value);
+  return grant.includes(slug);
+}
+
+/**
+ * Secret grant membership. Case-INSENSITIVE, matching the server
+ * (`agentMayUseEnv`, and `listAdmits` in the delivery rule). The grant is the
+ * hand-written `secrets:` list from kortix.yaml, so its case need not match the
+ * stored identifier. An exact match here hid secrets the server does deliver.
+ */
+function secretGrantIncludes(grant: SessionScopeGrant, identifier: string): boolean {
+  if (grant === 'none') return false;
+  if (grant === 'all' || grant == null) return true;
+  const target = identifier.toUpperCase();
+  return grant.some((entry) => entry.toUpperCase() === target);
 }
 
 export function createSessionScopeDraft(
@@ -197,7 +215,7 @@ export function buildSessionScopeSelectionCatalog(
             .filter(
               (secret) =>
                 secret.effective_source !== 'none' &&
-                grantIncludes(input.grants?.secrets, secret.identifier),
+                secretGrantIncludes(input.grants?.secrets, secret.identifier),
             )
             .map((secret) => ({
               identifier: secret.identifier,
@@ -222,7 +240,7 @@ export function buildSessionScopeSelectionCatalog(
         .filter(
           (connector) =>
             connector.status !== 'disabled' &&
-            grantIncludes(input.grants?.connectors, connector.slug),
+            connectorGrantIncludes(input.grants?.connectors, connector.slug),
         )
         .map((connector) => {
           const ownerType = connector.authorizationStrategy === 'user' ? 'member' : 'project';

--- a/apps/web/src/features/workspace/capabilities/agents/agent-detail-aside.test.tsx
+++ b/apps/web/src/features/workspace/capabilities/agents/agent-detail-aside.test.tsx
@@ -1,0 +1,170 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  buildScopeChecklist,
+  buildSecretScopeOptions,
+  toggleScopeSelection,
+} from './agent-detail-aside';
+
+const secret = (identifier: string, name: string) => ({ identifier, name });
+
+describe('buildSecretScopeOptions', () => {
+  test('keys the checklist on IDENTIFIER, not on the env var name', () => {
+    // `id` is what `setAgentScope` writes into the manifest grant, and every
+    // consumer matches by identifier (`listAdmits` in the delivery rule,
+    // `agentMayUseEnv` in the agent-scope gate). Writing the env var KEY
+    // produced a grant nothing ever matched, so the secret was never delivered
+    // and nothing said so.
+    const options = buildSecretScopeOptions([secret('gmaps-primary', 'GOOGLE_MAPS_API_KEY')]);
+    expect(options).toEqual([
+      { id: 'gmaps-primary', label: 'gmaps-primary', hint: 'GOOGLE_MAPS_API_KEY' },
+    ]);
+  });
+
+  test('two secrets sharing one env var name stay separately grantable', () => {
+    // `name` is not unique. De-duplicating on it collapsed these into one row,
+    // so the primary key could not be granted without the backup.
+    const options = buildSecretScopeOptions([
+      secret('gmaps-primary', 'GOOGLE_MAPS_API_KEY'),
+      secret('gmaps-backup', 'GOOGLE_MAPS_API_KEY'),
+    ]);
+    expect(options.map((o) => o.id)).toEqual(['gmaps-backup', 'gmaps-primary']);
+  });
+
+  test('omits the hint when the name adds nothing', () => {
+    const [option] = buildSecretScopeOptions([secret('OPENAI_API_KEY', 'OPENAI_API_KEY')]);
+    expect(option.hint).toBeUndefined();
+  });
+
+  test('sorts by identifier', () => {
+    const options = buildSecretScopeOptions([
+      secret('zulu', 'Z'),
+      secret('alpha', 'A'),
+      secret('mike', 'M'),
+    ]);
+    expect(options.map((o) => o.id)).toEqual(['alpha', 'mike', 'zulu']);
+  });
+
+  test('the ids it emits round-trip through the read-only mirror', () => {
+    // The mirror below the editor prints `scope.env` verbatim. When the editor
+    // wrote names and the mirror printed identifiers, the two halves of one card
+    // disagreed about the same secret.
+    const options = buildSecretScopeOptions([secret('gmaps-primary', 'GOOGLE_MAPS_API_KEY')]);
+    const committedGrant = options.map((o) => o.id);
+    expect(committedGrant).toEqual(['gmaps-primary']);
+  });
+});
+
+describe('buildScopeChecklist', () => {
+  const secrets = buildSecretScopeOptions([secret('GMAPS-primary', 'GOOGLE_MAPS_API_KEY')]);
+
+  test('ticks the row a lowercase kortix.yaml entry actually grants', () => {
+    // `agentMayUseEnv` uppercases both sides, so the server DOES deliver this
+    // secret. Matching exactly here showed the row unticked AND added a second
+    // row flagged "missing" — the editor calling a working grant broken.
+    const rows = buildScopeChecklist(['gmaps-primary'], secrets, 'case-insensitive');
+    expect(rows).toEqual([
+      {
+        id: 'GMAPS-primary',
+        label: 'GMAPS-primary',
+        hint: 'GOOGLE_MAPS_API_KEY',
+        selected: true,
+        orphan: false,
+      },
+    ]);
+  });
+
+  test('connector slugs stay exact, matching agentMayUseConnector', () => {
+    const rows = buildScopeChecklist(['GMAIL'], [{ id: 'gmail', label: 'Gmail' }]);
+    expect(rows.map((r) => [r.id, r.selected, r.orphan])).toEqual([
+      ['gmail', false, false],
+      ['GMAIL', true, true],
+    ]);
+  });
+
+  test('a genuinely deleted entry is still listed and flagged', () => {
+    const rows = buildScopeChecklist(['deleted-secret'], secrets, 'case-insensitive');
+    expect(rows.find((r) => r.id === 'deleted-secret')).toMatchObject({
+      selected: true,
+      orphan: true,
+    });
+  });
+
+  test("'all' ticks nothing — the checklist is only for a specific grant", () => {
+    expect(buildScopeChecklist('all', secrets, 'case-insensitive')).toEqual([
+      {
+        id: 'GMAPS-primary',
+        label: 'GMAPS-primary',
+        hint: 'GOOGLE_MAPS_API_KEY',
+        selected: false,
+        orphan: false,
+      },
+    ]);
+  });
+});
+
+describe('toggleScopeSelection', () => {
+  test('unticking removes the entry whatever case the manifest used', () => {
+    // Removing only the byte-identical id left `gmaps-primary` in the manifest,
+    // so the grant stayed live under a checkbox that now read as off.
+    expect(toggleScopeSelection(['gmaps-primary'], 'GMAPS-primary', 'case-insensitive')).toEqual(
+      [],
+    );
+  });
+
+  test('unticking clears every case variant of the same grant', () => {
+    expect(
+      toggleScopeSelection(['gmaps-primary', 'GMAPS-PRIMARY'], 'GMAPS-primary', 'case-insensitive'),
+    ).toEqual([]);
+  });
+
+  test('ticking appends the option id and keeps the rest', () => {
+    expect(toggleScopeSelection(['other'], 'GMAPS-primary', 'case-insensitive')).toEqual([
+      'other',
+      'GMAPS-primary',
+    ]);
+  });
+
+  test('exact mode treats a case variant as a different connector', () => {
+    expect(toggleScopeSelection(['gmail'], 'GMAIL')).toEqual(['gmail', 'GMAIL']);
+  });
+
+  test("ticking from 'all' starts a fresh specific list", () => {
+    expect(toggleScopeSelection('all', 'gmail')).toEqual(['gmail']);
+  });
+});
+
+/**
+ * `ScopeEditor` holds `useState`, and `renderToStaticMarkup` cannot run a
+ * hook-bearing component in this workspace (the sibling
+ * `session-scope-control.test.tsx` fails the same way on an unmodified tree).
+ * So the wiring the pure builder cannot cover is asserted against the source.
+ */
+describe('AgentScopeCard wiring', () => {
+  const source = readFileSync(join(import.meta.dir, 'agent-detail-aside.tsx'), 'utf8');
+
+  test('the Secrets checklist comes from the identifier-keyed builder', () => {
+    expect(source).toContain('buildSecretScopeOptions(secretsQuery.data?.items ?? [])');
+  });
+
+  test('no option list keys a secret grant on `s.name`', () => {
+    expect(source).not.toMatch(/secretsQuery\.data[^\n]*\.name/);
+    expect(source).not.toContain('map((s) => s.name)');
+  });
+
+  test('the checklist row renders the hint', () => {
+    expect(source).toContain('{o.hint}');
+  });
+
+  test('the Secrets editor asks for the server-matching case rule', () => {
+    // Without this prop the Secrets checklist falls back to `match='exact'`,
+    // which is the connector rule, not `agentMayUseEnv`.
+    expect(source).toMatch(/label="Secrets"[\s\S]{0,320}?match="case-insensitive"/);
+  });
+
+  test('the Connectors editor stays on the exact default', () => {
+    expect(source).not.toMatch(/label="Connectors"[\s\S]{0,320}?match=/);
+  });
+});

--- a/apps/web/src/features/workspace/capabilities/agents/agent-detail-aside.tsx
+++ b/apps/web/src/features/workspace/capabilities/agents/agent-detail-aside.tsx
@@ -293,10 +293,10 @@ function AgentScopeCard({
     ...contract('config'),
   });
 
-  const secretOptions = useMemo(() => {
-    const names = new Set((secretsQuery.data?.items ?? []).map((s) => s.name));
-    return [...names].sort().map((name) => ({ id: name, label: name }));
-  }, [secretsQuery.data]);
+  const secretOptions = useMemo(
+    () => buildSecretScopeOptions(secretsQuery.data?.items ?? []),
+    [secretsQuery.data],
+  );
   const connectorOptions = useMemo(
     () =>
       (connectorsQuery.data?.connectors ?? [])
@@ -343,6 +343,7 @@ function AgentScopeCard({
         emptyLabel="No secrets in this project yet."
         value={env}
         options={secretOptions}
+        match="case-insensitive"
         onChange={setEnv}
       />
       <ScopeEditor
@@ -383,6 +384,103 @@ function AgentScopeCard({
   );
 }
 
+/** One row of a `ScopeEditor` checklist. `id` is the exact string written into
+ *  the manifest grant; `hint` is context that helps a human recognise the row
+ *  and is never part of the grant. */
+export interface ScopeOption {
+  id: string;
+  label: string;
+  hint?: string;
+}
+
+/**
+ * The Secrets checklist, built from the project's secrets.
+ *
+ * Keyed on IDENTIFIER, never on `name`. Every consumer of the grant matches by
+ * identifier — `listAdmits` in the delivery rule and `agentMayUseEnv` in the
+ * agent-scope gate — and `name` is the env var KEY, which is NOT unique. Keying
+ * on the key wrote a grant nothing matched, and collapsed two secrets that share
+ * one key into a single row that could not be granted separately. The key is
+ * still what the user reads on the sandbox side, so it stays visible as a hint
+ * whenever it differs from the identifier.
+ */
+export function buildSecretScopeOptions(
+  items: readonly { identifier: string; name: string }[],
+): ScopeOption[] {
+  return items
+    .map((s) => ({
+      id: s.identifier,
+      label: s.identifier,
+      hint: s.name === s.identifier ? undefined : s.name,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/**
+ * How a manifest grant entry is paired with a checklist option. It must mirror
+ * the server gate for that resource: secrets are case-insensitive
+ * (`agentMayUseEnv`, and `listAdmits` in the delivery rule), connector slugs are
+ * exact (`agentMayUseConnector`).
+ */
+export type ScopeMatch = 'exact' | 'case-insensitive';
+
+export interface ScopeChecklistRow extends ScopeOption {
+  selected: boolean;
+  /** Declared in the manifest but not a resource in this project — a deleted
+   *  secret, or a typo. Shown so it can be removed. */
+  orphan: boolean;
+}
+
+const scopeMatchKey = (id: string, match: ScopeMatch) =>
+  match === 'exact' ? id : id.toUpperCase();
+
+/**
+ * The checklist rows for one grant: every project resource, plus any declared
+ * entry that no longer maps to one.
+ *
+ * With one exact rule for both resource kinds, a hand-written lowercase
+ * `secrets:` entry that the server DOES honour rendered as an unticked row plus
+ * a second row flagged "missing" — the editor calling a working grant broken.
+ */
+export function buildScopeChecklist(
+  value: AgentGrantSet,
+  options: ScopeOption[],
+  match: ScopeMatch = 'exact',
+): ScopeChecklistRow[] {
+  const declared = value === 'all' ? [] : value;
+  const declaredKeys = new Set(declared.map((id) => scopeMatchKey(id, match)));
+  const optionKeys = new Set(options.map((o) => scopeMatchKey(o.id, match)));
+  const orphans = declared.filter((id) => !optionKeys.has(scopeMatchKey(id, match)));
+  return [
+    ...options.map((o) => ({
+      ...o,
+      selected: declaredKeys.has(scopeMatchKey(o.id, match)),
+      orphan: false,
+    })),
+    ...orphans.map((id) => ({ id, label: id, selected: true, orphan: true })),
+  ];
+}
+
+/**
+ * The grant after ticking or unticking one row.
+ *
+ * Unticking drops every entry that MATCHES, not just the byte-identical one: the
+ * row shows the option's id while the manifest may spell the same grant in
+ * another case, and leaving that spelling behind keeps the grant live under a
+ * checkbox that now reads as off.
+ */
+export function toggleScopeSelection(
+  value: AgentGrantSet,
+  id: string,
+  match: ScopeMatch = 'exact',
+): string[] {
+  const declared = value === 'all' ? [] : value;
+  const key = scopeMatchKey(id, match);
+  const next = declared.filter((entry) => scopeMatchKey(entry, match) !== key);
+  if (next.length === declared.length) next.push(id);
+  return next;
+}
+
 /** True when two grant sets mean the same thing (order-insensitive). */
 function grantSetEqual(a: AgentGrantSet, b: AgentGrantSet): boolean {
   if (a === 'all' || b === 'all') return a === b;
@@ -393,8 +491,10 @@ function grantSetEqual(a: AgentGrantSet, b: AgentGrantSet): boolean {
 
 /**
  * Three-way scope control: All · Specific · None. In "Specific" mode it shows a
- * checklist of the project's secrets/connectors; a declared name that no longer
- * exists as a resource still shows (flagged) so it can be removed.
+ * checklist of the project's secrets/connectors; a declared id that no longer
+ * exists as a resource still shows (flagged) so it can be removed. Rows and
+ * toggles come from `buildScopeChecklist` / `toggleScopeSelection`, which own
+ * the per-resource `ScopeMatch` rule.
  */
 function ScopeEditor({
   label,
@@ -402,13 +502,15 @@ function ScopeEditor({
   emptyLabel,
   value,
   options,
+  match = 'exact',
   onChange,
 }: {
   label: string;
   allLabel: string;
   emptyLabel: string;
   value: AgentGrantSet;
-  options: { id: string; label: string }[];
+  options: ScopeOption[];
+  match?: ScopeMatch;
   onChange: (v: AgentGrantSet) => void;
 }) {
   // "Specific" with nothing selected yet is a real UI state the value type can't
@@ -420,14 +522,7 @@ function ScopeEditor({
   const [wantSpecific, setWantSpecific] = useState(value !== 'all' && value.length > 0);
   const mode: 'all' | 'specific' | 'none' =
     value === 'all' ? 'all' : value.length > 0 || wantSpecific ? 'specific' : 'none';
-  const selected = value === 'all' ? new Set<string>() : new Set(value);
-  const optionIds = new Set(options.map((o) => o.id));
-  // Selected names that aren't in the current option list (deleted resource, or
-  // typed via kortix.yaml) — keep them visible so they can be unchecked.
-  const orphanRows = [...selected]
-    .filter((id) => !optionIds.has(id))
-    .map((id) => ({ id, label: id }));
-  const rows = [...options, ...orphanRows];
+  const rows = buildScopeChecklist(value, options, match);
 
   const pick = (m: 'all' | 'specific' | 'none') => {
     setWantSpecific(m === 'specific');
@@ -437,12 +532,7 @@ function ScopeEditor({
     // above keeps us in specific mode even while the list is empty.
     onChange(value === 'all' ? [] : value);
   };
-  const toggle = (id: string) => {
-    const next = new Set(selected);
-    if (next.has(id)) next.delete(id);
-    else next.add(id);
-    onChange([...next]);
-  };
+  const toggle = (id: string) => onChange(toggleScopeSelection(value, id, match));
 
   return (
     <div className="space-y-2">
@@ -476,35 +566,38 @@ function ScopeEditor({
           <p className="text-muted-foreground text-xs">{emptyLabel}</p>
         ) : (
           <div className="border-border/60 max-h-44 overflow-y-auto rounded-md border p-1">
-            {rows.map((o) => {
-              const isSel = selected.has(o.id);
-              const isOrphan = !optionIds.has(o.id);
-              return (
-                <button
-                  key={o.id}
-                  type="button"
-                  aria-pressed={isSel}
-                  onClick={() => toggle(o.id)}
+            {rows.map((o) => (
+              <button
+                key={o.id}
+                type="button"
+                aria-pressed={o.selected}
+                onClick={() => toggle(o.id)}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs transition-colors',
+                  o.selected ? 'bg-secondary' : 'hover:bg-muted/50',
+                )}
+              >
+                <span
                   className={cn(
-                    'flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs transition-colors',
-                    isSel ? 'bg-secondary' : 'hover:bg-muted/50',
+                    'flex size-4 shrink-0 items-center justify-center rounded border',
+                    o.selected
+                      ? 'border-foreground bg-foreground text-background'
+                      : 'border-border/70',
                   )}
                 >
-                  <span
-                    className={cn(
-                      'flex size-4 shrink-0 items-center justify-center rounded border',
-                      isSel
-                        ? 'border-foreground bg-foreground text-background'
-                        : 'border-border/70',
-                    )}
-                  >
-                    {isSel && <Check className="size-3" />}
+                  {o.selected && <Check className="size-3" />}
+                </span>
+                <span className="min-w-0 flex-1 truncate font-mono">{o.label}</span>
+                {/* The env var KEY, shown only when it differs from the id the
+                    grant is written with — the sandbox side of the same secret. */}
+                {o.hint ? (
+                  <span className="text-muted-foreground max-w-[40%] shrink-0 truncate font-mono">
+                    {o.hint}
                   </span>
-                  <span className="min-w-0 flex-1 truncate font-mono">{o.label}</span>
-                  {isOrphan && <span className="text-kortix-orange">missing</span>}
-                </button>
-              );
-            })}
+                ) : null}
+                {o.orphan && <span className="text-kortix-orange">missing</span>}
+              </button>
+            ))}
           </div>
         ))}
     </div>

--- a/apps/web/src/features/workspace/customize/sections/view/secret-delivery.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-delivery.test.ts
@@ -7,8 +7,15 @@ import {
   canSaveSecretDelivery,
   connectorBindingChanges,
   connectorBindingOptions,
+  missingAgentGrantNotice,
+  networkBoundaryAvailability,
+  networkBoundaryBlockedReason,
+  readSecretDeliverySync,
+  secretDeliveryBlockedReason,
   secretDeliveryOptions,
   secretDeliveryPresentation,
+  secretDeliverySyncWarning,
+  shouldWarnMissingAgentGrant,
 } from './secret-delivery';
 
 describe('brokerConsumerForSecret', () => {
@@ -70,24 +77,214 @@ describe('secretDeliveryPresentation', () => {
   });
 });
 
+describe('networkBoundaryAvailability', () => {
+  test('requires the project itself to run on Platinum', () => {
+    expect(
+      networkBoundaryAvailability({
+        available_sandbox_providers: ['daytona', 'platinum'],
+        default_sandbox_provider: 'platinum',
+      }),
+    ).toBe('available');
+  });
+
+  test('reports a platform-capable but unpinned project separately', () => {
+    // The live dev state: Platinum is offered, the project runs on Daytona, so
+    // no header is injected.
+    expect(
+      networkBoundaryAvailability({
+        available_sandbox_providers: ['daytona', 'platinum'],
+        default_sandbox_provider: null,
+      }),
+    ).toBe('project_not_pinned');
+    expect(
+      networkBoundaryAvailability({
+        available_sandbox_providers: ['daytona', 'platinum'],
+        default_sandbox_provider: 'daytona',
+      }),
+    ).toBe('project_not_pinned');
+  });
+
+  test('reports a deployment without Platinum as unsupported', () => {
+    expect(
+      networkBoundaryAvailability({
+        available_sandbox_providers: ['daytona'],
+        default_sandbox_provider: 'daytona',
+      }),
+    ).toBe('unsupported');
+    expect(networkBoundaryAvailability(undefined)).toBe('unsupported');
+    expect(networkBoundaryAvailability(null)).toBe('unsupported');
+  });
+});
+
+describe('networkBoundaryBlockedReason', () => {
+  test('names the exact fix for an unpinned project', () => {
+    expect(networkBoundaryBlockedReason('project_not_pinned')).toBe(
+      'This project does not run on Platinum — pin it in Feature flags → Runtime → Sandbox provider.',
+    );
+  });
+
+  test('keeps the deployment wording, and says nothing when delivery works', () => {
+    expect(networkBoundaryBlockedReason('unsupported')).toBe('Not available in this deployment.');
+    expect(networkBoundaryBlockedReason('available')).toBeNull();
+  });
+});
+
 describe('secretDeliveryOptions', () => {
-  test('offers the HTTPS broker and enables network delivery when the deployment supports it', () => {
-    const options = secretDeliveryOptions('runtime', 'available', true);
+  test('offers the HTTPS broker and enables network delivery when the project runs on Platinum', () => {
+    const options = secretDeliveryOptions('runtime', 'available', 'available');
     expect(options.map(({ strategy, disabled }) => ({ strategy, disabled }))).toEqual([
       { strategy: 'runtime', disabled: false },
       { strategy: 'broker', disabled: false },
       { strategy: 'egress', disabled: false },
       { strategy: 'denied', disabled: false },
     ]);
+    expect(options[2]?.disabledReason).toBeNull();
   });
 
   test('keeps network delivery disabled when Platinum is unavailable', () => {
-    expect(secretDeliveryOptions('broker', 'available', false)[1]?.disabled).toBe(false);
-    expect(secretDeliveryOptions('egress', 'available', false)[2]?.disabled).toBe(true);
+    expect(secretDeliveryOptions('broker', 'available', 'unsupported')[1]?.disabled).toBe(false);
+    expect(secretDeliveryOptions('egress', 'available', 'unsupported')[2]).toMatchObject({
+      disabled: true,
+      disabledReason: 'Not available in this deployment.',
+    });
+  });
+
+  test('disables network delivery on an unpinned project and states the fix', () => {
+    expect(secretDeliveryOptions('runtime', 'available', 'project_not_pinned')[2]).toMatchObject({
+      disabled: true,
+      disabledReason:
+        'This project does not run on Platinum — pin it in Feature flags → Runtime → Sandbox provider.',
+    });
   });
 
   test('disables a selected non-runtime policy when the server marks it unavailable', () => {
-    expect(secretDeliveryOptions('broker', 'unavailable', true)[1]?.disabled).toBe(true);
+    expect(secretDeliveryOptions('broker', 'unavailable', 'available')[1]).toMatchObject({
+      disabled: true,
+      disabledReason: 'Not available in this deployment.',
+    });
+  });
+});
+
+describe('secretDeliveryBlockedReason', () => {
+  test('reports the blocked verdict only on the exact reason', () => {
+    expect(
+      secretDeliveryBlockedReason({
+        identifier: 'BOUNDARY_TEST',
+        delivery_blocked_reason: 'no_agent_grant',
+      }),
+    ).toBe('no_agent_grant');
+  });
+
+  test('stays silent on null, absent, and unrecognized values', () => {
+    // Tri-state: null covers "granted", "not applicable" AND "we could not
+    // tell" — warning on uncertainty is worse than not warning.
+    expect(
+      secretDeliveryBlockedReason({ identifier: 'BOUNDARY_TEST', delivery_blocked_reason: null }),
+    ).toBeNull();
+    expect(secretDeliveryBlockedReason({ identifier: 'BOUNDARY_TEST' })).toBeNull();
+    expect(
+      secretDeliveryBlockedReason({
+        identifier: 'BOUNDARY_TEST',
+        delivery_blocked_reason: 'manifest_unreadable',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('shouldWarnMissingAgentGrant', () => {
+  test('warns for the delivery modes that need a named agent grant', () => {
+    expect(shouldWarnMissingAgentGrant('no_agent_grant', 'egress')).toBe(true);
+    expect(shouldWarnMissingAgentGrant('no_agent_grant', 'broker')).toBe(true);
+  });
+
+  test('stays silent for runtime, disabled, and an unblocked secret', () => {
+    expect(shouldWarnMissingAgentGrant('no_agent_grant', 'runtime')).toBe(false);
+    expect(shouldWarnMissingAgentGrant('no_agent_grant', 'denied')).toBe(false);
+    expect(shouldWarnMissingAgentGrant(null, 'egress')).toBe(false);
+  });
+});
+
+describe('missingAgentGrantNotice', () => {
+  test('names the identifier, the manifest fix, and rejects the "all" shorthand', () => {
+    const notice = missingAgentGrantNotice('BOUNDARY_TEST');
+    expect(notice.title).toBe('No agent can receive this secret');
+    expect(notice.body).toContain('BOUNDARY_TEST');
+    expect(notice.body).toContain('kortix.yaml');
+    expect(notice.body).toContain('"secrets: all" does not grant this delivery mode');
+    expect(notice.manifest).toBe(
+      'kortix_version: 2\nagents:\n  my-agent:\n    secrets: [BOUNDARY_TEST]',
+    );
+  });
+});
+
+describe('secret delivery sync', () => {
+  const sync = (overrides: Record<string, unknown> = {}) => ({
+    delivery_sync: {
+      ok: false,
+      targeted: 2,
+      synced: 1,
+      failed: 1,
+      failures: [{ session_id: 'ses_1', sandbox_id: 'sbx_1', reason: 'sandbox unreachable: 502' }],
+      ...overrides,
+    },
+  });
+
+  test('reads the block a secret write returns', () => {
+    expect(readSecretDeliverySync(sync())).toEqual({
+      ok: false,
+      targeted: 2,
+      synced: 1,
+      failed: 1,
+      failures: [{ session_id: 'ses_1', sandbox_id: 'sbx_1', reason: 'sandbox unreachable: 502' }],
+    });
+  });
+
+  test('reports nothing for an absent, null, or unrecognized block', () => {
+    expect(readSecretDeliverySync({ identifier: 'BOUNDARY_TEST' })).toBeNull();
+    expect(readSecretDeliverySync({ delivery_sync: null })).toBeNull();
+    expect(readSecretDeliverySync({ delivery_sync: { targeted: 2 } })).toBeNull();
+    expect(readSecretDeliverySync(null)).toBeNull();
+  });
+
+  test('warns with the session count and the first failure reason verbatim', () => {
+    expect(secretDeliverySyncWarning('BOUNDARY_TEST', sync())).toEqual({
+      message: 'Saved BOUNDARY_TEST, but it is not applied to 1 running session',
+      description: 'sandbox unreachable: 502',
+    });
+    expect(
+      secretDeliverySyncWarning(
+        'BOUNDARY_TEST',
+        sync({
+          failed: 2,
+          failures: [
+            { session_id: 'ses_1', sandbox_id: null, reason: 'first reason' },
+            { session_id: 'ses_2', sandbox_id: 'sbx_2', reason: 'second reason' },
+          ],
+        }),
+      ),
+    ).toEqual({
+      message: 'Saved BOUNDARY_TEST, but it is not applied to 2 running sessions',
+      description: 'first reason',
+    });
+  });
+
+  test('falls back to the targeted count and a plain reason when the block is thin', () => {
+    expect(secretDeliverySyncWarning('BOUNDARY_TEST', sync({ failed: 0, failures: [] }))).toEqual({
+      message: 'Saved BOUNDARY_TEST, but it is not applied to 2 running sessions',
+      description: 'No failure reason was reported.',
+    });
+    expect(
+      secretDeliverySyncWarning('BOUNDARY_TEST', sync({ targeted: 0, failed: 0, failures: [] })),
+    ).toEqual({
+      message: 'Saved BOUNDARY_TEST, but it is not applied to the running sessions',
+      description: 'No failure reason was reported.',
+    });
+  });
+
+  test('stays silent on a successful sync and on a response without the block', () => {
+    expect(secretDeliverySyncWarning('BOUNDARY_TEST', sync({ ok: true, failed: 0 }))).toBeNull();
+    expect(secretDeliverySyncWarning('BOUNDARY_TEST', { delivery_sync: null })).toBeNull();
+    expect(secretDeliverySyncWarning('BOUNDARY_TEST', { identifier: 'BOUNDARY_TEST' })).toBeNull();
   });
 });
 

--- a/apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts
@@ -128,23 +128,167 @@ export function secretDeliveryPresentation(
   return PRESENTATIONS[strategy];
 }
 
+export type NetworkBoundaryAvailability = 'available' | 'project_not_pinned' | 'unsupported';
+
+/**
+ * Network-boundary delivery is injected by the Platinum provider itself, so the
+ * PROJECT has to run on Platinum. A deployment that merely offers Platinum is
+ * not enough: on any other provider nothing injects the header and the secret
+ * is silently dead.
+ */
+export function networkBoundaryAvailability(
+  project?: {
+    available_sandbox_providers?: readonly string[] | null;
+    default_sandbox_provider?: string | null;
+  } | null,
+): NetworkBoundaryAvailability {
+  if (!project?.available_sandbox_providers?.includes('platinum')) return 'unsupported';
+  return project.default_sandbox_provider === 'platinum' ? 'available' : 'project_not_pinned';
+}
+
+/** Why network-boundary delivery cannot run here, and how to fix it. */
+export function networkBoundaryBlockedReason(
+  availability: NetworkBoundaryAvailability,
+): string | null {
+  if (availability === 'available') return null;
+  if (availability === 'unsupported') return 'Not available in this deployment.';
+  return 'This project does not run on Platinum — pin it in Feature flags → Runtime → Sandbox provider.';
+}
+
 export type SecretDeliveryOption = SecretDeliveryPresentation & {
   strategy: SecretDeliveryStrategy;
   disabled: boolean;
+  /** Why the option cannot be selected. Null when it can. */
+  disabledReason: string | null;
 };
 
 export function secretDeliveryOptions(
   selected: SecretDeliveryStrategy,
   status: SecretDeliveryStatus,
-  networkBoundaryAvailable: boolean,
+  networkBoundary: NetworkBoundaryAvailability,
 ): SecretDeliveryOption[] {
-  return (Object.keys(PRESENTATIONS) as SecretDeliveryStrategy[]).map((strategy) => ({
-    strategy,
-    ...PRESENTATIONS[strategy],
-    disabled:
-      (strategy === 'egress' && !networkBoundaryAvailable) ||
-      (strategy === 'broker' && strategy === selected && status !== 'available'),
-  }));
+  return (Object.keys(PRESENTATIONS) as SecretDeliveryStrategy[]).map((strategy) => {
+    const disabledReason =
+      strategy === 'egress'
+        ? networkBoundaryBlockedReason(networkBoundary)
+        : strategy === 'broker' && strategy === selected && status !== 'available'
+          ? 'Not available in this deployment.'
+          : null;
+    return {
+      strategy,
+      ...PRESENTATIONS[strategy],
+      disabled: disabledReason !== null,
+      disabledReason,
+    };
+  });
+}
+
+export type SecretDeliveryBlockedReason = 'no_agent_grant';
+
+/**
+ * Read the API's per-secret delivery verdict. The field is tri-state: absent or
+ * null means granted, not applicable, OR undetermined — so anything other than
+ * an exact `no_agent_grant` stays silent.
+ */
+export function secretDeliveryBlockedReason(secret: {
+  identifier: string;
+  delivery_blocked_reason?: string | null;
+}): SecretDeliveryBlockedReason | null {
+  return secret.delivery_blocked_reason === 'no_agent_grant' ? 'no_agent_grant' : null;
+}
+
+/**
+ * A runtime secret reaches the sandbox without a grant, and a disabled one goes
+ * nowhere by design. Only broker and egress delivery need a named agent grant.
+ */
+export function shouldWarnMissingAgentGrant(
+  blockedReason: SecretDeliveryBlockedReason | null,
+  strategy: SecretDeliveryStrategy,
+): boolean {
+  if (blockedReason !== 'no_agent_grant') return false;
+  return strategy === 'broker' || strategy === 'egress';
+}
+
+export type MissingAgentGrantNotice = {
+  title: string;
+  body: string;
+  /** kortix.yaml snippet that grants the secret to one agent. */
+  manifest: string;
+};
+
+export function missingAgentGrantNotice(identifier: string): MissingAgentGrantNotice {
+  return {
+    title: 'No agent can receive this secret',
+    body: `List ${identifier} under an agent's secrets in kortix.yaml, then run the session with that agent. "secrets: all" does not grant this delivery mode — only an explicit list does.`,
+    manifest: `kortix_version: 2\nagents:\n  my-agent:\n    secrets: [${identifier}]`,
+  };
+}
+
+export type SecretDeliverySyncFailure = {
+  session_id: string;
+  sandbox_id: string | null;
+  reason: string;
+};
+
+export type SecretDeliverySync = {
+  ok: boolean;
+  targeted: number;
+  synced: number;
+  failed: number;
+  failures: SecretDeliverySyncFailure[];
+};
+
+/**
+ * Read the `delivery_sync` block a secret write returns. The field is additive
+ * and null when no sync ran, so an unrecognized shape reports nothing rather
+ * than guessing at a failure.
+ */
+export function readSecretDeliverySync(result: unknown): SecretDeliverySync | null {
+  if (typeof result !== 'object' || result === null) return null;
+  const sync = (result as { delivery_sync?: unknown }).delivery_sync;
+  if (typeof sync !== 'object' || sync === null) return null;
+  const record = sync as Record<string, unknown>;
+  if (typeof record.ok !== 'boolean') return null;
+  const count = (value: unknown) => (typeof value === 'number' ? value : 0);
+  const rawFailures = Array.isArray(record.failures) ? record.failures : [];
+  return {
+    ok: record.ok,
+    targeted: count(record.targeted),
+    synced: count(record.synced),
+    failed: count(record.failed),
+    failures: rawFailures.flatMap((entry) => {
+      if (typeof entry !== 'object' || entry === null) return [];
+      const failure = entry as Record<string, unknown>;
+      if (typeof failure.reason !== 'string') return [];
+      return [
+        {
+          session_id: typeof failure.session_id === 'string' ? failure.session_id : '',
+          sandbox_id: typeof failure.sandbox_id === 'string' ? failure.sandbox_id : null,
+          reason: failure.reason,
+        },
+      ];
+    }),
+  };
+}
+
+/**
+ * The save succeeded; the running sandboxes did not take the new policy. The
+ * user has to know the difference — the secret looks configured but the live
+ * sessions still use the previous one.
+ */
+export function secretDeliverySyncWarning(
+  identifier: string,
+  result: unknown,
+): { message: string; description: string } | null {
+  const sync = readSecretDeliverySync(result);
+  if (!sync || sync.ok) return null;
+  const count = sync.failed > 0 ? sync.failed : sync.targeted;
+  const scope =
+    count > 0 ? `${count} running session${count === 1 ? '' : 's'}` : 'the running sessions';
+  return {
+    message: `Saved ${identifier}, but it is not applied to ${scope}`,
+    description: sync.failures[0]?.reason ?? 'No failure reason was reported.',
+  };
 }
 
 const HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']);

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.delivery.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.delivery.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * `SecretsView` cannot be rendered here: `apps/web` has no jsdom and no
+ * `@testing-library/react`, and its `bun test` runs WITHOUT `--isolate`, so
+ * mocking `@tanstack/react-query` process-wide would corrupt every other file
+ * in the run.
+ *
+ * So the coverage is split in two, and neither half alone proves the fix:
+ * `secret-delivery.test.ts` proves what the decision functions DECIDE, and
+ * this file pins that the view actually CALLS them — the gap a
+ * helpers-in-isolation test cannot see, because a silent return to the old
+ * platform-wide `available_sandbox_providers` check, or to an unconditional
+ * success toast, still passes it.
+ */
+const source = readFileSync(join(import.meta.dir, 'secrets-view.tsx'), 'utf8');
+const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const sliceBetween = (start: string, end: string) => {
+  const from = code.indexOf(start);
+  const to = code.indexOf(end, from);
+  return from < 0 || to < 0 ? '' : code.slice(from, to);
+};
+
+describe('SecretsView gates network-boundary delivery on the ACTIVE provider', () => {
+  test('the availability comes from the helper, not from the platform provider list', () => {
+    expect(code).toContain(
+      'const networkBoundary = networkBoundaryAvailability(projectDetailQuery.data?.project);',
+    );
+    // The old gate read what the DEPLOYMENT offers. A project on Daytona
+    // injects nothing, so that check offered an impossible mode.
+    expect(code).not.toContain('available_sandbox_providers');
+  });
+
+  test('the dialog receives the availability and forwards it to the option builder', () => {
+    expect(code).toContain('networkBoundary={networkBoundary}');
+    expect(code).toContain('networkBoundary: NetworkBoundaryAvailability;');
+    expect(sliceBetween('secretDeliveryOptions(', ');')).toContain('networkBoundary,');
+  });
+
+  test('the disabled option states its own reason instead of one fixed sentence', () => {
+    expect(code).toMatch(
+      /description=\{\s*option\.disabledReason\s*\?\s*`\$\{option\.description\} \$\{option\.disabledReason\}`/,
+    );
+    expect(code).not.toContain('Not available in this deployment.');
+  });
+
+  test('an already-egress secret on a non-Platinum project says so in the panel', () => {
+    expect(code).toContain(
+      'const networkBoundaryNotice = networkBoundaryBlockedReason(networkBoundary);',
+    );
+    expect(code).toContain('{networkBoundaryNotice && (');
+  });
+});
+
+describe('SecretsView warns when no agent can receive the secret', () => {
+  test('the row carries the API verdict through the reader, never a raw field read', () => {
+    expect(code).toContain('deliveryBlockedReason: secretDeliveryBlockedReason(item),');
+    expect(code).toContain('deliveryBlockedReason: SecretDeliveryBlockedReason | null;');
+    // Placeholder rows for manifest keys with no stored secret know nothing.
+    expect(code).toContain('deliveryBlockedReason: null,');
+  });
+
+  test('the table row shows the warning only for the modes that need a grant', () => {
+    expect(code).toContain(
+      'shouldWarnMissingAgentGrant(row.deliveryBlockedReason, row.strategy) && (',
+    );
+    expect(code).toContain('>No agent grant</span>');
+  });
+
+  test('the dialog renders the notice and the kortix.yaml fix', () => {
+    expect(code).toMatch(
+      /const grantNotice =\s*row && shouldWarnMissingAgentGrant\(row\.deliveryBlockedReason, strategy\)\s*\?\s*missingAgentGrantNotice\(row\.identifier\)\s*:\s*null;/,
+    );
+    expect(code).toContain('{grantNotice.body}');
+    expect(code).toContain('{grantNotice.manifest}');
+  });
+});
+
+describe('SecretsView reports a save that did not reach the running sessions', () => {
+  const onSuccess = sliceBetween('onSuccess: (result, plan) => {', 'onError:');
+
+  test('the scan found the save mutation success handler', () => {
+    // Guard the guards: an empty string passes `.not.toContain` silently.
+    expect(onSuccess.length).toBeGreaterThan(0);
+  });
+
+  test('a failed delivery sync warns instead of reporting a plain success', () => {
+    expect(onSuccess).toContain(
+      'const syncWarning = secretDeliverySyncWarning(plan.finalIdentifier, result);',
+    );
+    expect(onSuccess).toMatch(
+      /if \(syncWarning\) \{\s*warningToast\(syncWarning\.message, \{ description: syncWarning\.description \}\);\s*\} else \{\s*successToast\(`Saved \$\{plan\.finalIdentifier\}`\);\s*\}/,
+    );
+  });
+
+  test('the success toast fires only in the else branch', () => {
+    expect(onSuccess.match(/successToast\(/g)).toHaveLength(1);
+    expect(code).toContain('import { errorToast, successToast, warningToast } from');
+  });
+});
+
+describe('SecretsView states the cost of an empty header template', () => {
+  test('both template fields name the 401 consequence', () => {
+    expect(code.match(/reject with 401\./g)).toHaveLength(2);
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -57,7 +57,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Textarea } from '@/components/ui/textarea';
-import { errorToast, successToast } from '@/components/ui/toast';
+import { errorToast, successToast, warningToast } from '@/components/ui/toast';
 import { Plus as PlusIcon } from '@/features/icon/icons/plus';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
@@ -89,14 +89,22 @@ import {
   TrashIcon,
 } from '@phosphor-icons/react';
 import {
+  type NetworkBoundaryAvailability,
+  type SecretDeliveryBlockedReason,
   brokerConsumerForSecret,
   buildBrokerPolicy,
   buildNetworkBoundaryPolicy,
   canSaveSecretDelivery,
   connectorBindingChanges,
   connectorBindingOptions,
+  missingAgentGrantNotice,
+  networkBoundaryAvailability,
+  networkBoundaryBlockedReason,
+  secretDeliveryBlockedReason,
   secretDeliveryOptions,
   secretDeliveryPresentation,
+  secretDeliverySyncWarning,
+  shouldWarnMissingAgentGrant,
 } from './secret-delivery';
 import {
   type OptimisticProjectSecretInput,
@@ -132,6 +140,8 @@ interface SecretRow {
   deliveryStatus: SecretDeliveryStatus;
   egressPolicy: SecretEgressPolicy | null;
   requiresRotation: boolean;
+  /** 'no_agent_grant' only when the API is certain. Null covers "unknown" too. */
+  deliveryBlockedReason: SecretDeliveryBlockedReason | null;
 }
 
 type SecretSavePlan = {
@@ -159,9 +169,7 @@ export function SecretsView({ projectId }: { projectId: string }) {
     ...contract('config'),
   });
   const llmGatewayEnabled = isLlmGatewayEnabled(projectDetailQuery.data?.project);
-  const networkBoundaryAvailable = Boolean(
-    projectDetailQuery.data?.project.available_sandbox_providers?.includes('platinum'),
-  );
+  const networkBoundary = networkBoundaryAvailability(projectDetailQuery.data?.project);
 
   const secretsQuery = useQuery({
     queryKey,
@@ -348,7 +356,7 @@ export function SecretsView({ projectId }: { projectId: string }) {
                 row={dialogRow}
                 connectors={connectorsQuery.data?.connectors ?? []}
                 connectorsLoading={connectorsQuery.isLoading}
-                networkBoundaryAvailable={networkBoundaryAvailable}
+                networkBoundary={networkBoundary}
                 onSaved={refreshSecretsAndProviders}
               />
             </>
@@ -433,6 +441,7 @@ function buildRows(raw: ProjectSecretsResponse | ProjectSecret[] | null | undefi
     deliveryStatus: item.delivery_status ?? (item.strategy === 'denied' ? 'disabled' : 'available'),
     egressPolicy: item.egress_policy ?? null,
     requiresRotation: Boolean(item.requires_rotation),
+    deliveryBlockedReason: secretDeliveryBlockedReason(item),
   });
 
   const rows: SecretRow[] = [];
@@ -461,6 +470,7 @@ function buildRows(raw: ProjectSecretsResponse | ProjectSecret[] | null | undefi
       deliveryStatus: 'available',
       egressPolicy: null,
       requiresRotation: false,
+      deliveryBlockedReason: null,
     });
   }
 
@@ -536,6 +546,9 @@ function SecretTableRow({
           {row.requiresRotation && (
             <span className="text-kortix-orange text-[11px] font-medium">Rotation required</span>
           )}
+          {shouldWarnMissingAgentGrant(row.deliveryBlockedReason, row.strategy) && (
+            <span className="text-kortix-orange text-[11px] font-medium">No agent grant</span>
+          )}
         </div>
       </TableCell>
       <TableCell>
@@ -584,7 +597,7 @@ function SecretDialog({
   row,
   connectors,
   connectorsLoading,
-  networkBoundaryAvailable,
+  networkBoundary,
   onSaved,
 }: {
   open: boolean;
@@ -593,7 +606,7 @@ function SecretDialog({
   row: SecretRow | null;
   connectors: Awaited<ReturnType<typeof listConnectors>>['connectors'];
   connectorsLoading: boolean;
-  networkBoundaryAvailable: boolean;
+  networkBoundary: NetworkBoundaryAvailability;
   onSaved: () => void;
 }) {
   const queryClient = useQueryClient();
@@ -821,7 +834,14 @@ function SecretDialog({
           cache ? applyProjectSecretResponse(cache, result) : cache,
         );
       }
-      successToast(`Saved ${plan.finalIdentifier}`);
+      // The write can land while the running sandboxes refuse the new policy.
+      // A plain success toast would hide that split outcome.
+      const syncWarning = secretDeliverySyncWarning(plan.finalIdentifier, result);
+      if (syncWarning) {
+        warningToast(syncWarning.message, { description: syncWarning.description });
+      } else {
+        successToast(`Saved ${plan.finalIdentifier}`);
+      }
       resetForm();
       onSaved();
       queryClient.invalidateQueries({ queryKey: qk.project.connectors(projectId) });
@@ -866,8 +886,13 @@ function SecretDialog({
   const deliveryOptions = secretDeliveryOptions(
     strategy,
     row?.deliveryStatus ?? 'available',
-    networkBoundaryAvailable,
+    networkBoundary,
   );
+  const networkBoundaryNotice = networkBoundaryBlockedReason(networkBoundary);
+  const grantNotice =
+    row && shouldWarnMissingAgentGrant(row.deliveryBlockedReason, strategy)
+      ? missingAgentGrantNotice(row.identifier)
+      : null;
   const canSave = canSaveSecretDelivery({
     isEdit,
     key,
@@ -991,8 +1016,8 @@ function SecretDialog({
                       value={option.strategy}
                       disabled={option.disabled}
                       description={
-                        option.disabled
-                          ? `${option.description} Not available in this deployment.`
+                        option.disabledReason
+                          ? `${option.description} ${option.disabledReason}`
                           : option.description
                       }
                     >
@@ -1011,6 +1036,19 @@ function SecretDialog({
               </InfoBanner>
             )}
 
+            {grantNotice && (
+              <InfoBanner
+                tone="warning"
+                icon={<DangerTriangleSolid weight="fill" />}
+                title={grantNotice.title}
+              >
+                <span className="block text-pretty">{grantNotice.body}</span>
+                <pre className="border-border bg-muted mt-2 overflow-x-auto rounded-sm border p-2 font-mono text-xs leading-relaxed">
+                  {grantNotice.manifest}
+                </pre>
+              </InfoBanner>
+            )}
+
             {strategy === 'egress' && (
               <div className="border-border bg-sidebar space-y-4 rounded-md border p-3">
                 <div className="space-y-1">
@@ -1019,6 +1057,16 @@ function SecretDialog({
                     Platinum adds this value to matching HTTPS requests outside the sandbox.
                   </p>
                 </div>
+
+                {networkBoundaryNotice && (
+                  <InfoBanner
+                    tone="warning"
+                    icon={<DangerTriangleSolid weight="fill" />}
+                    title="Nothing injects this header today"
+                  >
+                    {networkBoundaryNotice}
+                  </InfoBanner>
+                )}
 
                 <InfoBanner tone="neutral" title="Not readable inside the sandbox">
                   The sandbox receives no value, alias, or placeholder. Secret values echoed by an
@@ -1071,7 +1119,9 @@ function SecretDialog({
                     disabled={save.isPending}
                   />
                   <FieldDescription>
-                    Optional. Include {'{{secret}}'} where Platinum inserts the value.
+                    Optional. Include {'{{secret}}'} where Platinum inserts the value. Leave it
+                    blank and the header carries the bare value with no scheme, which most APIs
+                    reject with 401.
                   </FieldDescription>
                 </Field>
               </div>
@@ -1296,7 +1346,9 @@ function SecretDialog({
                           disabled={save.isPending}
                         />
                         <FieldDescription>
-                          Optional. Include {'{{secret}}'} where Kortix inserts the value.
+                          Optional. Include {'{{secret}}'} where Kortix inserts the value. Leave it
+                          blank and the header carries the bare value with no scheme, which most
+                          APIs reject with 401.
                         </FieldDescription>
                       </Field>
                     )}

--- a/docs/SECRET_DELIVERY_CONTROL_PLANE.md
+++ b/docs/SECRET_DELIVERY_CONTROL_PLANE.md
@@ -165,10 +165,27 @@ and rebinding targets. It reevaluates redirects. It bounds request and response
 sizes. It strips sensitive response headers and never records request bodies,
 response bodies, query values, injected headers, handles, or secret values.
 
+The CLI configures the policy, then sends the request:
+
+```bash
+kortix secrets delivery API_KEY broker \
+  --consumer http-broker \
+  --allow-host api.example.com \
+  --allow-method POST \
+  --allow-path '/v1/*' \
+  --inject-header Authorization \
+  --template 'Bearer {{secret}}'
+
+kortix secrets call API_KEY https://api.example.com/v1/resource \
+  --method POST \
+  --data '{"input":"value"}'
+```
+
 ## Network boundary
 
-Network-boundary delivery is for ordinary sandbox HTTP clients that cannot use
-the explicit broker API. It is narrower than the HTTPS broker:
+Network-boundary delivery serves ordinary sandbox HTTP clients that cannot call
+the explicit broker API. Kortix registers the value with Platinum. Platinum
+injects one header at its own egress edge. It is narrower than the HTTPS broker:
 
 - the project must run the session on Platinum;
 - the agent grant and session allowlist must name the secret explicitly;
@@ -189,21 +206,183 @@ kortix secrets delivery ANTHROPIC_API_KEY egress \
   --template '{{secret}}'
 ```
 
-The CLI exposes this path through:
+### What the guest holds
 
-```bash
-kortix secrets delivery API_KEY broker \
-  --consumer http-broker \
-  --allow-host api.example.com \
-  --allow-method POST \
-  --allow-path '/v1/*' \
-  --inject-header Authorization \
-  --template 'Bearer {{secret}}'
+Nothing. The value, the rendered header, and the binding alias all stay outside
+the sandbox:
 
-kortix secrets call API_KEY https://api.example.com/v1/resource \
-  --method POST \
-  --data '{"input":"value"}'
+- `resolveNetworkBoundaryBindings` (`apps/api/src/secrets/network-boundary.ts`)
+  renders the header value on the API and returns it to the provider adapter.
+- `syncPlatinumNetworkBoundary`
+  (`apps/api/src/secrets/platinum-network-boundary.ts`) writes the write-only
+  replica and attaches it to the sandbox by id. The `alias` field is provider
+  bookkeeping and is sent only to Platinum.
+- The env builder emits no name for an `egress` row, so
+  `KORTIX_PROJECT_SECRET_NAMES` never lists it.
+
+Verified on dev 2026-08-10. Inside a live Platinum session,
+`env | grep -c <IDENTIFIER>` returns `0` while injection works. A policy host
+presents the per-sandbox MITM certificate
+`issuer: O=Platinum; CN=Platinum egress proxy (sandbox sbx_...)`, which the box
+already trusts. A host outside the policy passes through untouched with its own
+origin certificate.
+
+### The three prerequisites
+
+All three must hold. Each one used to fail silently.
+
+| # | Requirement | Where it is set | Result when wrong |
+| --- | --- | --- | --- |
+| 1 | The session runs on Platinum | Customize -> Feature flags -> Sandbox provider | No binding is attached. The request leaves without the header. |
+| 2 | An agent `secrets:` list NAMES the identifier | `kortix.yaml` | `resolveSecretDelivery` withholds the row. No binding. |
+| 3 | The header value template renders what the API expects | Secret editor -> Header value template | The header carries the bare value with no scheme. Upstream returns `401`. |
+
+Requirement 1 is project scope, not deployment scope.
+`networkBoundaryDeliveryAvailable()` reports only that the deployment enables
+Platinum. The web editor therefore gates the option on
+`networkBoundaryAvailability(project)`
+(`apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts`),
+which requires `default_sandbox_provider === 'platinum'`.
+
+Requirement 2 is stricter than every other strategy. `resolveSecretDelivery`
+(`apps/api/src/secrets/strategy.ts`) delivers a non-`runtime` row only when
+`agentGrantEnv` is a `string[]` that contains the identifier:
+
+```ts
+const grant = input.agentGrantEnv ?? null;
+if (Array.isArray(grant)) {
+  if (!listAdmits(grant, input.identifier)) return withheld('agent_grant_excludes');
+} else if (strategy !== 'runtime') {
+  return withheld('agent_grant_unscoped');
+}
 ```
+
+`secrets: all` resolves to the string `'all'`, not an array. It therefore fails
+exactly like an absent grant, with reason `agent_grant_unscoped`. A project with
+no `agents:` block resolves to a null grant and can never deliver an egress
+secret. Membership is by IDENTIFIER, case-insensitive. It is never by env-var
+key: one key can carry several identifiers.
+
+`SecretSchema.delivery_blocked_reason` reports only the certain case. It is
+`'no_agent_grant'` when the manifest loaded and no agent's explicit list names
+the identifier. It is `null` when the row is granted, when the strategy needs no
+grant, or when the manifest could not be read. A warning that fires on an
+unreadable manifest is worse than no warning, so uncertainty always renders as
+`null`.
+
+### Policy shape
+
+`networkBoundaryPolicyError` (`apps/api/src/secrets/network-boundary.ts`)
+accepts only the controls Platinum can enforce. A stored policy must never look
+narrower than the data path that applies it.
+
+| Rejected input | Message |
+| --- | --- |
+| A broker `backend` | `Network-boundary delivery does not accept a broker backend` |
+| `on_no_match` other than `deny` | `Network-boundary delivery must deny unmatched requests` |
+| `tls` other than `terminate` | `Network-boundary delivery requires TLS termination` |
+| A query or JSON-body injection | `Network-boundary delivery supports header injection only` |
+| A wildcard host such as `*.example.com` | `Network-boundary delivery requires exact hosts` |
+| Any `methods` entry | `Network-boundary delivery cannot enforce HTTP method restrictions` |
+| Any `path` | `Network-boundary delivery cannot enforce path restrictions` |
+| A per-rule header or template that differs from the policy default | `Every network-boundary rule must use the same header and template` |
+
+Host matching is exact. `api.example.com` never covers
+`uploads.api.example.com`. List every host explicitly. The API returns `400`
+with `code: 'secret_delivery_policy_invalid'`.
+
+### Destination uniqueness
+
+One `(host, header)` pair per project. `findBoundaryDestinationConflict`
+(`apps/api/src/secrets/network-boundary.ts`) compares a candidate against every
+other egress row. Host and header compare lowercased. The same identifier never
+conflicts with itself. A row with a null policy, or a non-header injection, is
+skipped.
+
+The check runs at save time on `POST /:projectId/secrets` and on
+`PUT /:projectId/secrets/:identifier/strategy`. A collision returns `409`:
+
+```json
+{
+  "error": "BOUNDARY_TEST already injects the \"authorization\" header for postman-echo.com. Two secrets cannot target the same host and header — give STRIPE_API_KEY a different header, or a different host.",
+  "code": "secret_boundary_destination_conflict",
+  "conflict": { "identifier": "BOUNDARY_TEST", "host": "postman-echo.com", "header": "authorization" }
+}
+```
+
+`conflict.identifier` is the secret that already holds the destination. The
+sentence names both: the incumbent first, then the secret being saved.
+
+Two secrets on the same host with DIFFERENT headers are legal. Platinum injects
+both. `resolveNetworkBoundaryBindings` keeps its start-time throw as the last
+line of defense. The save-time check exists so the failure reaches the person
+who caused it, not a session that starts hours later.
+
+### HTTPS only
+
+The proxy needs to terminate TLS to rewrite a header. Plain HTTP to a policy
+host is refused:
+
+```text
+egress to "<host>" is blocked: this sandbox's policy puts a secret in a request
+header for this host, and that requires HTTPS
+```
+
+A test that uses `http://` reads as a network fault. It is a policy refusal.
+
+### Echo blocking is the verification trap
+
+`onEcho` is hardcoded `'block'` in `NetworkBoundarySecretBinding`. When an
+upstream response would return the secret to the guest, the proxy kills the
+connection. The guest sees `curl: (52) Empty reply from server`.
+
+An echo service is therefore the worst possible test target. Success there is a
+dead connection, which is exactly what a broken boundary also produces. One
+probe cannot separate the two. Use two.
+
+| Probe | Target | Correct result | Meaning |
+| --- | --- | --- | --- |
+| Reachability | A policy host endpoint that does NOT echo request headers | `200` | The host is reachable and the proxy passes traffic. |
+| Injection | An endpoint on the same host that DOES echo request headers | `curl: (52) Empty reply from server` | The header was present and the echo guard killed the response. |
+
+A `200` with the secret visible in the body would mean the guard failed. A
+`curl: (52)` on the non-echoing probe means the policy host is unreachable, not
+that injection worked.
+
+### Save-time sync
+
+`POST /:projectId/secrets` and `PUT /:projectId/secrets/:identifier/strategy`
+push the binding to every active sandbox and report the outcome in
+`delivery_sync`:
+
+```ts
+delivery_sync: {
+  ok: boolean;
+  targeted: number;
+  synced: number;
+  failed: number;
+  failures: Array<{ session_id: string; sandbox_id: string | null; reason: string }>;
+} | null
+```
+
+`null` means no sync ran: the row is not an egress secret, or the project has no
+active session. A partial failure returns `ok: false` with one entry per session
+that did not take the binding. The save itself still succeeds; the stored policy
+is the source of truth and the next session start reapplies it.
+
+### File map
+
+| Concern | File |
+| --- | --- |
+| Delivery decision for one row | `apps/api/src/secrets/strategy.ts` |
+| Policy validation, bindings, destination conflicts | `apps/api/src/secrets/network-boundary.ts` |
+| Provider replica, attach, arm, erase | `apps/api/src/secrets/platinum-network-boundary.ts` |
+| Deployment capability flag | `apps/api/src/secrets/network-boundary-availability.ts` |
+| Session grant + allowlist resolution | `apps/api/src/projects/lib/network-secret-boundary.ts` |
+| Provider adapter and teardown | `apps/api/src/platform/providers/platinum.ts` |
+| Save routes | `apps/api/src/projects/routes/r3.ts` |
+| Web editor | `apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx` |
+| CLI | `apps/cli/src/commands/secrets.ts` |
 
 ## Connector credentials
 
@@ -232,7 +411,15 @@ authentication scheme.
 ## Product surfaces
 
 The API, SDK, CLI, and web UI expose `strategy`, `consumer`,
-`delivery_status`, and `requires_rotation`. Values remain write-only.
+`delivery_status`, `delivery_blocked_reason`, and `requires_rotation`. Values
+remain write-only.
+
+`delivery_blocked_reason` is optional and nullable. Its only value today is
+`'no_agent_grant'`. Treat `null` as "granted, not applicable, or unknown", never
+as "blocked".
+
+`POST /:projectId/secrets` and `PUT /:projectId/secrets/:identifier/strategy`
+additionally return `delivery_sync`. No other route returns it.
 
 The web editor provides these choices:
 
@@ -318,7 +505,15 @@ without returning the new value to a client.
 - A generic unsupported broker backend returns `409`.
 - Transparent `egress` returns `409` when Platinum is unavailable.
 - An unenforceable transparent policy returns `400`.
+- Two egress secrets that claim one `(host, header)` pair return `409` with
+  `code: 'secret_boundary_destination_conflict'`.
+- Two egress secrets on one host with different headers are accepted. Both are
+  injected.
 - A granted transparent secret blocks session startup on unsupported providers.
+- Plain HTTP to a policy host is refused by the proxy, not by Kortix.
+- A response that would echo an egress secret is killed by the proxy.
+- A failed push to a running sandbox returns `delivery_sync.ok === false`. The
+  save still succeeds.
 - A stale, expired, or revoked session handle returns `409`.
 - A host, method, or path mismatch returns `403`.
 - A connector binding blocks secret deletion and incompatible strategy changes
@@ -345,7 +540,8 @@ Every change to this control plane must prove these paths:
 
 Platinum network substitution also requires a live provider test. That test
 must prove injection, sandbox non-disclosure, rotation, revocation, and echo
-blocking.
+blocking. Prove injection with the two-probe recipe above. A single probe
+against an echo endpoint cannot distinguish a working boundary from a dead one.
 
 ## Related specifications
 

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -857,7 +857,11 @@ export const SessionStartFailureSchema = z
     category: z.enum([
       'provider-capacity',
       'git-auth',
+      // The PROVIDER cannot do network-boundary delivery (e.g. a Daytona box).
       'unsupported-secret-delivery',
+      // The PROJECT's own boundary policy is unusable — two secrets claiming the same
+      // (host, header), or a policy the boundary cannot enforce. Never retryable.
+      'invalid-secret-boundary-policy',
       'sandbox-provider',
     ]),
     message: z.string(),
@@ -979,6 +983,19 @@ export type SecretConsumer = z.infer<typeof SecretConsumerSchema>;
 export const SecretDeliveryStatusSchema = z.enum(['available', 'unavailable', 'disabled']);
 export type SecretDeliveryStatus = z.infer<typeof SecretDeliveryStatusSchema>;
 
+/**
+ * Why a secret reaches no agent, even though the platform supports its delivery
+ * mode. Tri-state, and the distinction is load-bearing:
+ *
+ *   'no_agent_grant' — CERTAIN: no agent in the manifest can receive this secret.
+ *   null / absent    — granted, not applicable, or the server could not tell.
+ *
+ * Never a guess. A warning raised because the manifest failed to load is worse
+ * than no warning, so an unreadable manifest reports null.
+ */
+export const SecretDeliveryBlockedReasonSchema = z.enum(['no_agent_grant']);
+export type SecretDeliveryBlockedReason = z.infer<typeof SecretDeliveryBlockedReasonSchema>;
+
 export const SecretInjectionSlotSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('header'), name: z.string(), template: z.string().optional() }),
   z.object({ kind: z.literal('query'), name: z.string() }),
@@ -1059,6 +1076,11 @@ export const SecretSchema = z.object({
   strategy: SecretDeliveryStrategySchema,
   consumer: SecretConsumerSchema.nullable(),
   delivery_status: SecretDeliveryStatusSchema,
+  /** The agent-grant axis of delivery, orthogonal to `delivery_status`.
+   *  `delivery_status` says the deployment supports the mode; this says whether
+   *  any agent may actually receive the secret. See
+   *  `SecretDeliveryBlockedReasonSchema` for the tri-state rule. */
+  delivery_blocked_reason: SecretDeliveryBlockedReasonSchema.nullable().optional(),
   network_boundary_available: z.boolean().optional(),
   egress_policy: SecretEgressPolicySchema.nullable(),
   strategy_locked: z.boolean(),


### PR DESCRIPTION
A network-boundary secret (`strategy: egress`) has three prerequisites. Every one
of them failed **silently** when wrong, so the feature looked broken while
reporting success at every step. Found while debugging a real report of "I set
this up and get 401"; all five defects are reproduced live on dev.

## What was wrong

1. **Two secrets on one destination bricked the project.** Same `(host, header)`
   pair → accepted with `200`, then `resolveNetworkBoundaryBindings` throws at
   provision and **every new session fails**. The classifier had no pattern for it,
   so it read `The sandbox provider could not start this session. Try again.` —
   blames the provider, and `retryable: true` for a state retrying cannot clear.
   The throw also runs *before* the env push, so it stops ordinary `runtime`
   secrets reaching every active sandbox too.
2. **`delivery_status` said `available` for undeliverable secrets.** It reads
   strategy and consumer only. `resolveSecretDelivery` hands out an egress secret
   only when some agent names its identifier in an explicit `secrets:` list —
   `'all'` does not count, and a project with no `agents:` block can never deliver
   one. Nothing said so.
3. **The sync report was thrown away.** The strategy route already awaited the
   fan-out and discarded the result, so `Sandbox provider daytona does not support
   network-boundary secret delivery` never reached anyone.
4. **The UI offered the mode to projects that cannot run it** — gated on
   `available_sandbox_providers` (what the platform offers) rather than the
   project's pinned provider.
5. **The agent scope editor wrote the wrong key.** It built its Secrets checklist
   from `name` and PUT those as the grant, while `listAdmits` and `agentMayUseEnv`
   match on `identifier`. Where the two differ the grant never matched; where two
   identifiers shared a name the `Set` collapsed them.

## What changed

- `findBoundaryDestinationConflict` runs at save time on both write routes →
  `409 secret_boundary_destination_conflict` naming both secrets, the host and the
  header. It shares one destination-key helper with the provision-time guard so
  the two cannot drift, with a test asserting they agree.
- New unretryable `invalid-secret-boundary-policy` category. Its test drives the
  **real** validator rather than a copy of its strings, so a rule added later
  cannot fall through to "Try again" — which is exactly how this one shipped.
- `delivery_blocked_reason: 'no_agent_grant' | null` on `SecretSchema`, computed
  from config the secrets route already loads (no extra I/O). Strictly tri-state:
  emitted only when certain. `'opencode'` discovery means the manifest produced no
  specs *and* no errors, i.e. certainly no grant; `'declarative'` with an empty
  list is the ambiguous one (unparseable manifest) and stays null.
- `delivery_sync` on both write routes. Only a boundary secret waits for the
  fan-out — awaiting unconditionally would add up to 15s per live sandbox to every
  ordinary secret save.
- Web: gates on the active provider and names the fix; warns on the missing grant
  with the `kortix.yaml` block that repairs it; warns when a save reaches no live
  sandbox; says what a blank header template actually produces.
- Docs: the public secrets page never mentioned the feature and still described
  the retired `scope` model. Both docs now cover the three prerequisites, exact
  host matching, destination uniqueness, HTTPS-only, and `on_echo=block`.

## Verified live on dev before writing any code

| Probe | Result |
| --- | --- |
| Collision saved | `200`, no warning |
| Session after collision | `failed` — "could not start this session. Try again." |
| Same host, different headers | boots clean, both armed |
| HTTPS to a non-echoing endpoint | `200`, real upstream response |
| HTTPS to an echoing endpoint | connection killed — `on_echo` working |
| Plain HTTP | blocked: "...requires HTTPS" |
| `env \| grep -c <IDENTIFIER>` in sandbox | `0` |

TLS showed the interception directly:
`issuer: O=Platinum; CN=Platinum egress proxy (sandbox sbx_…)`, `verify ok`.

`on_echo` is why this was so hard to diagnose: an echo service is the one target
where a **correct** setup looks exactly like a broken one (`curl: (52) Empty reply
from server`). That dead response is the proof injection happened.

## Checks

- `apps/api`: 612 pass / 1 fail / 1 error. Baseline on clean `main` is
  576 pass / **1 fail / 1 error** — same two, both pre-existing (`re2js` module
  resolution). +36 tests, all passing.
- `apps/web`: 68 pass / 0 fail across the three changed test files.
- `apps/web` `tsc --noEmit`: 50 errors, **identical count to baseline**, none in
  any touched file.
- `tests/spec/routes.generated.json` regenerates unchanged — paths and methods are
  untouched; only response schemas grew.
- `eslint` could not run in this worktree (`eslint-config-next` resolution fails at
  config load, for any file). Left to CI.