### PR TITLE
fix(infra): preserve canonical dev DNS metadata

### DIFF
--- a/infra/GITOPS.md
+++ b/infra/GITOPS.md
@@ -43,15 +43,16 @@ the label. A writer or administrator must review the new SHA and reapply it.
 1. Three unprivileged jobs build fixed-tag API, gateway, and frontend archives.
    They receive no Docker Hub, AWS, or application secrets.
 2. A trusted job publishes the archives without starting their containers.
-3. Terraform creates PR-specific listener rules, target groups, and DNS records.
-4. The workflow deploys one ECS Fargate service for the pull request.
+3. Terraform owns the shared preview ALB and wildcard DNS records.
+4. The workflow creates PR-specific listener rules and target groups, then
+   deploys one ECS Fargate service for the pull request.
 5. Verification checks the API commit, frontend commit, runtime URLs, password
-   gate, shared parent-domain cookie, and black-box API flows.
+   gate, and shared parent-domain cookie.
 6. One sticky pull-request comment publishes the API, health, and frontend URLs.
 
 Removing the label or closing the pull request destroys the ECS service, task
-definitions, listener rules, target groups, and DNS records. A daily
-reconciliation run removes leaked preview resources.
+definitions, listener rules, and target groups. The shared wildcard DNS records
+remain. A daily reconciliation run removes leaked preview resources.
 
 Preview compute is isolated per pull request. Preview database and Supabase
 state are shared with dev.

--- a/infra/terraform/environments/dev-web/README.md
+++ b/infra/terraform/environments/dev-web/README.md
@@ -16,9 +16,7 @@ The stack owns `https://dev.kortix.com`. The Deploy Dev workflow also updates
 this CNAME before it verifies the deployed frontend. Vercel is disabled for the
 `main` branch.
 
-The first cutover requires a state migration because the previous stack owned
-`dev-fe-ecs.kortix.com`. Import the existing `dev.kortix.com` Cloudflare record
-into `module.dns.cloudflare_record.records[\"dev\"]` before the next apply. Then
-remove the old `dev-fe-ecs` state entry after confirming the alias is no longer
-required. Do not apply a plan that attempts to create a duplicate canonical
-record.
+The remote state owns the existing `dev.kortix.com` Cloudflare record at
+`module.dns[0].cloudflare_record.this[\"dev\"]`. The cutover imported record
+`e6511a4819a0f05dca09e275329ae1cb` in place. Do not create a second canonical
+record or reintroduce the retired `dev-fe-ecs.kortix.com` alias.

--- a/infra/terraform/environments/dev-web/main.tf
+++ b/infra/terraform/environments/dev-web/main.tf
@@ -107,6 +107,7 @@ module "dns" {
       value   = module.web.alb_dns_name
       proxied = true
       ttl     = 1
+      comment = "Kortix dev frontend on ECS Fargate; canonical ECS endpoint"
     }
   }
 }

--- a/infra/terraform/modules/cloudflare-dns/main.tf
+++ b/infra/terraform/modules/cloudflare-dns/main.tf
@@ -28,4 +28,5 @@ resource "cloudflare_record" "this" {
   content = each.value.value
   proxied = each.value.proxied
   ttl     = each.value.ttl
+  comment = each.value.comment
 }

--- a/infra/terraform/modules/cloudflare-dns/variables.tf
+++ b/infra/terraform/modules/cloudflare-dns/variables.tf
@@ -11,6 +11,7 @@ variable "records" {
     value   = string
     proxied = bool
     ttl     = number
+    comment = optional(string)
   }))
   default = {}
 }


### PR DESCRIPTION
## Summary

- add optional Cloudflare record comments to the shared DNS module
- declare the existing `dev.kortix.com` operational comment
- document the completed canonical-record state import

## Verification

- `terraform fmt infra/terraform/modules/cloudflare-dns infra/terraform/environments/dev-web`
- Terraform 1.9.8 validation passed for `dev`, `staging`, `prod`, `dev-web`, `staging-web`, and `prod-web`
- live `dev-web` plan: `No changes. Your infrastructure matches the configuration.`
- remote state owns Cloudflare record `e6511a4819a0f05dca09e275329ae1cb` at `module.dns[0].cloudflare_record.this["dev"]`