### PR TITLE
fix(compliance): associate ECS web ALBs with WAF (DCF-88)

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -40,6 +40,8 @@ jobs:
         run: terraform fmt -check -recursive infra/terraform
       - name: nacl auditor unit tests
         run: python3 infra/terraform/scripts/test_audit_nacl_admin_ports.py
+      - name: web ALB WAF association tests
+        run: python3 infra/terraform/scripts/test_web_waf_associations.py
       - name: preview runtime contract tests
         run: python3 infra/scripts/test-ecs-preview-runtime.py
       - name: terraform validate (every root)

--- a/infra/terraform/compliance-monitoring/monitoring.tf
+++ b/infra/terraform/compliance-monitoring/monitoring.tf
@@ -55,6 +55,14 @@ locals {
       dimension = replace(arn, "/^.*:loadbalancer\\//", "")
     }
   }
+  usw2_compliance_waf_albs = {
+    for arn, alb in local.usw2_albs : arn => alb
+    if !contains(["kortix-dev-web-alb", "kortix-staging-web-alb"], alb.name)
+  }
+  euw2_compliance_waf_albs = {
+    for arn, alb in local.euw2_albs : arn => alb
+    if alb.name != "kortix-prod-web-alb"
+  }
   alarm_tags = {
     ManagedBy = "kortix-compliance"
     Control   = "DCF-86"
@@ -95,14 +103,14 @@ resource "aws_iam_role_policy" "drata_sns_inspection" {
 }
 
 resource "aws_wafv2_web_acl_association" "usw2" {
-  for_each     = local.usw2_albs
+  for_each     = local.usw2_compliance_waf_albs
   resource_arn = each.key
   web_acl_arn  = data.aws_wafv2_web_acl.usw2.arn
 }
 
 resource "aws_wafv2_web_acl_association" "euw2" {
   provider     = aws.euw2
-  for_each     = local.euw2_albs
+  for_each     = local.euw2_compliance_waf_albs
   resource_arn = each.key
   web_acl_arn  = data.aws_wafv2_web_acl.euw2.arn
 }

--- a/infra/terraform/environments/dev-web/main.tf
+++ b/infra/terraform/environments/dev-web/main.tf
@@ -68,6 +68,11 @@ data "aws_secretsmanager_secret" "web_env" {
   name = "kortix-dev-web-env"
 }
 
+data "aws_wafv2_web_acl" "regional" {
+  name  = "kortix-alb-waf"
+  scope = "REGIONAL"
+}
+
 module "web" {
   source     = "../../modules/ecs-api"
   name       = local.name
@@ -93,6 +98,11 @@ module "web" {
   max_capacity     = 4
   use_fargate_spot = true
   tags             = local.tags
+}
+
+resource "aws_wafv2_web_acl_association" "web" {
+  resource_arn = module.web.alb_arn
+  web_acl_arn  = data.aws_wafv2_web_acl.regional.arn
 }
 
 module "dns" {

--- a/infra/terraform/environments/prod-web/main.tf
+++ b/infra/terraform/environments/prod-web/main.tf
@@ -68,6 +68,11 @@ data "aws_secretsmanager_secret" "web_env" {
   name = "kortix-prod-web-env"
 }
 
+data "aws_wafv2_web_acl" "regional" {
+  name  = "kortix-alb-waf"
+  scope = "REGIONAL"
+}
+
 module "certificate" {
   source      = "../../modules/acm-cloudflare"
   domain_name = "prod-fe-ecs.kortix.com"
@@ -100,6 +105,11 @@ module "web" {
   max_capacity     = 12
   use_fargate_spot = false
   tags             = local.tags
+}
+
+resource "aws_wafv2_web_acl_association" "web" {
+  resource_arn = module.web.alb_arn
+  web_acl_arn  = data.aws_wafv2_web_acl.regional.arn
 }
 
 module "dns" {

--- a/infra/terraform/environments/staging-web/main.tf
+++ b/infra/terraform/environments/staging-web/main.tf
@@ -68,6 +68,11 @@ data "aws_secretsmanager_secret" "web_env" {
   name = "kortix-staging-web-env"
 }
 
+data "aws_wafv2_web_acl" "regional" {
+  name  = "kortix-alb-waf"
+  scope = "REGIONAL"
+}
+
 module "web" {
   source     = "../../modules/ecs-api"
   name       = local.name
@@ -93,6 +98,11 @@ module "web" {
   max_capacity     = 4
   use_fargate_spot = false
   tags             = local.tags
+}
+
+resource "aws_wafv2_web_acl_association" "web" {
+  resource_arn = module.web.alb_arn
+  web_acl_arn  = data.aws_wafv2_web_acl.regional.arn
 }
 
 module "dns" {

--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -338,7 +338,7 @@ resource "aws_s3_bucket_policy" "alb_logs" {
 
 #trivy:ignore:AVD-AWS-0053 This public API origin must accept Cloudflare traffic; the ALB security group restricts ingress to var.alb_ingress_cidrs.
 resource "aws_lb" "this" {
-  #checkov:skip=CKV2_AWS_28:The compliance-monitoring stack associates every account ALB with the regional kortix-alb-waf ACL.
+  #checkov:skip=CKV2_AWS_28:Environment roots associate this output ALB with a regional WAF; legacy API roots use the compliance-monitoring association.
   name               = "${local.name}-alb"
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb.id]

--- a/infra/terraform/modules/ecs-api/outputs.tf
+++ b/infra/terraform/modules/ecs-api/outputs.tf
@@ -3,6 +3,11 @@ output "alb_dns_name" {
   value       = aws_lb.this.dns_name
 }
 
+output "alb_arn" {
+  description = "ALB ARN for regional WAF associations and other environment-level integrations."
+  value       = aws_lb.this.arn
+}
+
 output "alb_zone_id" {
   value = aws_lb.this.zone_id
 }

--- a/infra/terraform/scripts/test_web_waf_associations.py
+++ b/infra/terraform/scripts/test_web_waf_associations.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WEB_ENVIRONMENTS = ("dev-web", "staging-web", "prod-web")
+
+
+class WebWafAssociationTests(unittest.TestCase):
+    def test_ecs_module_exposes_alb_arn(self):
+        outputs = (ROOT / "terraform/modules/ecs-api/outputs.tf").read_text()
+        self.assertIn('output "alb_arn"', outputs)
+        self.assertIn("value       = aws_lb.this.arn", outputs)
+
+    def test_each_web_environment_owns_a_regional_waf_association(self):
+        for environment in WEB_ENVIRONMENTS:
+            with self.subTest(environment=environment):
+                config = (
+                    ROOT / f"terraform/environments/{environment}/main.tf"
+                ).read_text()
+                self.assertIn('data "aws_wafv2_web_acl" "regional"', config)
+                self.assertIn('name  = "kortix-alb-waf"', config)
+                self.assertIn('scope = "REGIONAL"', config)
+                self.assertIn(
+                    'resource "aws_wafv2_web_acl_association" "web"', config
+                )
+                self.assertIn("resource_arn = module.web.alb_arn", config)
+                self.assertIn(
+                    "web_acl_arn  = data.aws_wafv2_web_acl.regional.arn", config
+                )
+
+    def test_compliance_stack_does_not_compete_for_web_albs(self):
+        config = (ROOT / "terraform/compliance-monitoring/monitoring.tf").read_text()
+        self.assertIn("for_each     = local.usw2_compliance_waf_albs", config)
+        self.assertIn("for_each     = local.euw2_compliance_waf_albs", config)
+        self.assertIn(
+            '["kortix-dev-web-alb", "kortix-staging-web-alb"]', config
+        )
+        self.assertIn('alb.name != "kortix-prod-web-alb"', config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Demo

Non-visual infrastructure change. The regression test proves that each ECS web environment owns a regional `kortix-alb-waf` association:

```text
Ran 3 tests in 0.001s
OK
```

## Why

Drata DCF-88 testId 122 found that the dev, staging, and production ECS web ALBs created by #6319 have no WAF association.

## What changed

- Expose the ECS module ALB ARN for environment-level integrations.
- Associate `dev-web`, `staging-web`, and `prod-web` with the existing regional `kortix-alb-waf` ACL.
- Exclude those three ALBs from the older compliance-monitoring association owner to prevent two Terraform states from competing.
- Add a deterministic regression test to Terraform CI.

## Verification

- `python3 infra/terraform/scripts/test_web_waf_associations.py`
- `terraform fmt -check -recursive infra/terraform`
- `terraform init -backend=false && terraform validate` for `modules/ecs-api`, all three web roots, and `compliance-monitoring`

## Risk / rollback

The change reuses the existing regional ACL in each ALB region. Roll back by reverting this PR and applying the affected Terraform roots. No AWS resource was changed directly during development.
