### PR TITLE
fix(release): gate prod frontend on live API; forbid blocking backfills in migrations

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1185,8 +1185,40 @@ jobs:
           echo "::error::Prod FE-ECS did not serve the expected release."
           exit 1
 
-  # The Vercel project remains git-connected during parallel validation. The
-  # prod branch continues to auto-deploy to kortix.com.
+  # Deploy kortix.com (Vercel) ONLY after the API provably serves the release.
+  # Vercel's git auto-deploy for `prod` is OFF (vercel.json deploymentEnabled +
+  # vercel-ignore.sh): during the 2026-08-10 v0.12.7 rollout the auto-deployed
+  # new frontend called routes the still-old API did not have, and every
+  # project load failed. Ordering the frontend after `verify-live-version`
+  # makes a mixed frontend/API pair impossible.
+  deploy-web-vercel:
+    name: Deploy prod web to Vercel (after API is live)
+    needs: [version, verify-live-version]
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Link and verify the Vercel project
+        run: |
+          set -euo pipefail
+          test -n "${VERCEL_TOKEN:-}" || { echo "::error::VERCEL_TOKEN is not configured."; exit 1; }
+          npx --yes vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
+          linked="$(jq -r '.projectId' .vercel/project.json)"
+          if [ "$linked" != "prj_SoUUSNJPvOTDneE0E7faWHFuWMAY" ]; then
+            echo "::error::VERCEL_PROJECT_ID resolves to '$linked', not the suna project — refusing to deploy the wrong project."
+            exit 1
+          fi
+      - name: Deploy the release frontend to production
+        run: |
+          set -euo pipefail
+          npx --yes vercel@latest deploy --prod --yes --token="$VERCEL_TOKEN"
+
   frontend-note:
     name: Prod frontend paths active
     needs: [version, publish-web-ecs-dns]
@@ -1202,7 +1234,7 @@ jobs:
 
   frontend-auth-proof:
     name: Prod frontend auth configuration
-    needs: [version, frontend-note, verify-web-ecs]
+    needs: [version, frontend-note, verify-web-ecs, deploy-web-vercel]
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:

--- a/apps/web/scripts/vercel-ignore.sh
+++ b/apps/web/scripts/vercel-ignore.sh
@@ -52,11 +52,22 @@ if ! printf '%s\n' "$changed" | grep -qvE "$SAFE"; then
 fi
 
 # ── Stage 2: deploy-target gate ──────────────────────────────────────────────
-# FE-relevant changes are present. The permanent environments always deploy;
-# per-PR previews are OPT-IN (previews on every PR were the bulk of build spend).
+# FE-relevant changes are present. Staging always deploys; per-PR previews are
+# OPT-IN (previews on every PR were the bulk of build spend).
+#
+# `prod` is NOT here: a push to prod must never auto-deploy the frontend.
+# The 2026-08-10 v0.12.7 outage shipped the new frontend to kortix.com while
+# the API was still on the old version (its prerequisite migration failed), so
+# every access check called a route that did not exist yet. The prod frontend
+# deploys ONLY from deploy-prod.yml's `deploy-web-vercel` job, which runs after
+# `verify-live-version` proves the API serves the release. Belt-and-braces with
+# `git.deploymentEnabled.prod: false` in vercel.json.
 REF="${VERCEL_GIT_COMMIT_REF:-}"
 case "${VERCEL_ENV:-}:$REF" in
-  production:*|*:staging|*:prod)
+  *:prod)
+    echo "vercel-ignore: prod deploys only via deploy-prod.yml after the API is live — skipping auto build."
+    exit 0 ;;
+  production:*|*:staging)
     echo "vercel-ignore: environment branch (${REF:-$VERCEL_ENV}) — building frontend."
     exit 1 ;;
 esac

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -13,7 +13,7 @@
     "deploymentEnabled": {
       "main": false,
       "staging": true,
-      "prod": true
+      "prod": false
     }
   }
 }

--- a/packages/db/backfill-grandfathered-migrations.json
+++ b/packages/db/backfill-grandfathered-migrations.json
@@ -1,0 +1,23 @@
+{
+  "_comment": [
+    "Snapshot of migrations/*.sql that existed BEFORE the backfill guard (backfill-safe annotation) was introduced after the 2026-08-10 centralized_audit_v2 prod outage.",
+    "Same contract as grandfathered-migrations.json: these files are immutable and already applied in every environment; only the backfill-DML check exempts them.",
+    "Do not add to this list."
+  ],
+  "generatedAt": "2026-08-10T18:00:00Z",
+  "files": [
+    "20260717014205629_retire_provider_secret_private_override.sql",
+    "20260725010940000_credit_rpc_numeric_precision.sql",
+    "20260725012141489_gateway_cost_precision_sync.sql",
+    "20260730000452547_sandbox_deadline.sql",
+    "20260805202913539_secret_consumer_boundary.sql",
+    "20260805205103000_migrate_legacy_git_secret_consumer.sql",
+    "20260805205104000_isolate_codex_subscription_credentials.sql",
+    "20260805205105000_isolate_existing_llm_credentials.sql",
+    "20260806140107656_connector_physical_cutover.sql",
+    "20260806150353417_connector_compat_removal.sql",
+    "20260807160000000_reconcile_app_deployment_provenance.sql",
+    "20260807221200000_centralized_audit_v2.sql",
+    "20260809201539095_preserve_tunnel_audit_history.sql"
+  ]
+}

--- a/packages/db/scripts/lint-migrations.test.ts
+++ b/packages/db/scripts/lint-migrations.test.ts
@@ -57,6 +57,57 @@ describe('lintMigration', () => {
   });
 });
 
+describe('backfill-DML guard (centralized_audit_v2 outage class)', () => {
+  test('rejects a top-level UPDATE without a backfill-safe sign-off', () => {
+    const { errors } = lintMigration(
+      GOOD_NAME,
+      'ALTER TABLE kortix.widgets ADD COLUMN kind text;\nUPDATE kortix.widgets SET kind = \'x\' WHERE kind IS NULL;\n',
+    );
+    expect(errors.some((e) => e.includes('top-level DML'))).toBe(true);
+  });
+
+  test('rejects a data-modifying WITH ... UPDATE CTE', () => {
+    const { errors } = lintMigration(
+      GOOD_NAME,
+      'WITH ranked AS (SELECT id FROM kortix.widgets)\nUPDATE kortix.widgets w SET n = 1 FROM ranked r WHERE w.id = r.id;\n',
+    );
+    expect(errors.some((e) => e.includes('top-level DML'))).toBe(true);
+  });
+
+  test('rejects DML that follows a drizzle statement-breakpoint on the same line', () => {
+    const { errors } = lintMigration(
+      GOOD_NAME,
+      "ALTER TABLE kortix.widgets ADD COLUMN kind text;--> statement-breakpoint\nUPDATE kortix.widgets SET kind = 'x' WHERE kind IS NULL;--> statement-breakpoint\n",
+    );
+    expect(errors.some((e) => e.includes('top-level DML'))).toBe(true);
+  });
+
+  test('accepts DML with a backfill-safe sign-off', () => {
+    const { errors } = lintMigration(
+      GOOD_NAME,
+      "-- backfill-safe: widgets has < 1000 rows in every env and no hot writers\nUPDATE kortix.widgets SET kind = 'x' WHERE kind IS NULL;\n",
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test('ignores DML inside a dollar-quoted trigger function body', () => {
+    const { errors } = lintMigration(
+      GOOD_NAME,
+      "CREATE OR REPLACE FUNCTION kortix.widget_audit() RETURNS trigger LANGUAGE plpgsql AS $$\nBEGIN\n  INSERT INTO kortix.audit_events(action) VALUES ('widget');\n  RETURN NEW;\nEND;\n$$;\n",
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test('exempts a backfill-grandfathered migration', () => {
+    const { errors } = lintMigration(
+      GOOD_NAME,
+      "UPDATE kortix.widgets SET kind = 'x' WHERE kind IS NULL;\n",
+      { backfillGrandfathered: true },
+    );
+    expect(errors).toEqual([]);
+  });
+});
+
 describe('lintMigrationSet', () => {
   test('unique timestamps produce no errors', () => {
     const errors = lintMigrationSet([

--- a/packages/db/scripts/lint-migrations.ts
+++ b/packages/db/scripts/lint-migrations.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 const DIR = join(import.meta.dir, '..', 'migrations');
 const GRANDFATHER_FILE = join(import.meta.dir, '..', 'grandfathered-migrations.json');
+const BACKFILL_GRANDFATHER_FILE = join(import.meta.dir, '..', 'backfill-grandfathered-migrations.json');
 // Two valid migration file shapes:
 //  - <ts>_<slug>.sql            hand-written or drizzle-generated, runs inside
 //                                the batch transaction (see MIGRATIONS.md).
@@ -186,6 +187,12 @@ export interface LintOptions {
    * new migration (anything not in the list) gets full enforcement.
    */
   grandfathered?: boolean;
+  /**
+   * Same contract, separate cutoff: migrations that existed before the
+   * backfill-DML guard landed (2026-08-10, centralized_audit_v2 outage) —
+   * see backfill-grandfathered-migrations.json.
+   */
+  backfillGrandfathered?: boolean;
 }
 
 export function lintMigration(filename: string, raw: string, options: LintOptions = {}): LintResult {
@@ -252,6 +259,31 @@ export function lintMigration(filename: string, raw: string, options: LintOption
     );
   }
 
+  // Backfill guard (2026-08-10 v0.12.7 prod outage). A plain .sql migration
+  // runs in ONE transaction, so its ALTER TABLE statements hold ACCESS
+  // EXCLUSIVE on the target table until COMMIT — and any top-level DML in the
+  // same file turns those milliseconds of lock into the full backfill
+  // duration. centralized_audit_v2 updated all 30.5M rows of the hottest
+  // table this way and every audit-writing request hung for ~15 minutes.
+  // Data moves belong in batched, incrementally-committed passes (a
+  // .concurrent.ts noTransaction migration or an out-of-band runbook), or
+  // must be explicitly signed off as bounded.
+  if (!(options.grandfathered ?? false) && !(options.backfillGrandfathered ?? false)) {
+    // Dollar-quoted function bodies may legitimately contain DML (triggers);
+    // drizzle appends `--> statement-breakpoint` on the statement line itself,
+    // so it survives the line-based comment strip and must go too.
+    const upNoBodies = upStripped
+      .replace(/\$[a-zA-Z_]*\$[\s\S]*?\$[a-zA-Z_]*\$/g, "'body'")
+      .replace(/-->\s*statement-breakpoint/g, '');
+    const dml = upNoBodies.match(/(?:^|;)\s*(UPDATE\s|DELETE\s+FROM\s|INSERT\s+INTO\s|MERGE\s+INTO\s|WITH\s)/i);
+    if (dml && !/(?:--|\/\/)\s*backfill-safe\s*:\s*\S/i.test(up)) {
+      errors.push(
+        `${filename}: top-level DML (${dml[1].trim().toUpperCase()}…) in a single-transaction .sql migration. The file's DDL holds ACCESS EXCLUSIVE until COMMIT, so this backfill blocks every writer on the table for its whole duration — this is exactly the 2026-08-10 centralized_audit_v2 prod outage. ` +
+          'Move the data pass into a batched .concurrent.ts migration or an out-of-band runbook, or add a `-- backfill-safe: <table + bounded row count + why writers cannot queue behind it>` sign-off.',
+      );
+    }
+  }
+
   // Mixed-version guard + enum-value guard (shared with .concurrent.ts — see
   // checkMixedVersionAndEnum). Exempt for pre-existing (grandfathered)
   // migrations — see grandfathered-migrations.json.
@@ -271,10 +303,20 @@ function loadGrandfatherSet(): Set<string> {
   }
 }
 
+function loadBackfillGrandfatherSet(): Set<string> {
+  try {
+    const data = JSON.parse(readFileSync(BACKFILL_GRANDFATHER_FILE, 'utf8')) as { files: string[] };
+    return new Set(data.files);
+  } catch {
+    return new Set();
+  }
+}
+
 function main(): void {
   const errors: string[] = [];
   const warnings: string[] = [];
   const grandfathered = loadGrandfatherSet();
+  const backfillGrandfathered = loadBackfillGrandfatherSet();
   const files = readdirSync(DIR)
     .filter((f) => f.endsWith('.sql') || f.endsWith('.concurrent.ts'))
     .sort();
@@ -283,6 +325,7 @@ function main(): void {
   for (const f of files) {
     const { errors: e, warnings: w } = lintMigration(f, readFileSync(join(DIR, f), 'utf8'), {
       grandfathered: grandfathered.has(f),
+      backfillGrandfathered: backfillGrandfathered.has(f),
     });
     errors.push(...e);
     warnings.push(...w);

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -156,16 +156,29 @@ describe('web ECS migration', () => {
     expect(workflow).toContain('"- **Frontend:** https://${web}"');
   });
 
-  it('disables Vercel for Dev and PR previews only', () => {
+  it('disables Vercel auto-deploys everywhere except staging', () => {
     const config = read('apps/web/vercel.json');
     const ignore = read('apps/web/scripts/vercel-ignore.sh');
 
     expect(config).toContain('"main": false');
     expect(config).toContain('"staging": true');
-    expect(config).toContain('"prod": true');
+    // prod must NOT auto-deploy on push: during the 2026-08-10 v0.12.7 rollout
+    // the auto-deployed new frontend called routes the still-old API lacked
+    // and every project load failed. kortix.com deploys only from
+    // deploy-prod.yml's deploy-web-vercel job, after verify-live-version.
+    expect(config).toContain('"prod": false');
+    expect(ignore).toContain('prod deploys only via deploy-prod.yml');
     expect(ignore).not.toContain('KORTIX_PREVIEW_APPROVED_SHA');
     expect(ignore).not.toContain('*:main');
     expect(ignore).toContain('dev and PR previews deploy on ECS only');
+  });
+
+  it('deploys the prod Vercel frontend only after the API serves the release', () => {
+    const workflow = read('.github/workflows/deploy-prod.yml');
+    expect(workflow).toContain('deploy-web-vercel:');
+    expect(workflow).toMatch(/deploy-web-vercel:\s*\n\s*name:[^\n]*\n\s*needs: \[version, verify-live-version\]/);
+    expect(workflow).toContain('prj_SoUUSNJPvOTDneE0E7faWHFuWMAY');
+    expect(workflow).toMatch(/frontend-auth-proof:\s*\n\s*name:[^\n]*\n\s*needs: \[[^\]]*deploy-web-vercel\]/);
   });
 
   it('uses Basic auth credentials in QA instead of Vercel bypass headers', () => {


### PR DESCRIPTION
Two guards derived from the 2026-08-10 v0.12.7 rollout outage (prod down ~30 min: migration lock storm + mixed frontend/API versions).

**1. kortix.com can no longer deploy before the API.**
- `apps/web/vercel.json`: `git.deploymentEnabled.prod: false` — a push to `prod` no longer auto-builds/promotes the frontend.
- `apps/web/scripts/vercel-ignore.sh`: `prod` branch → skip, with the incident rationale.
- `deploy-prod.yml`: new `deploy-web-vercel` job, `needs: verify-live-version` (API provably serves the release), asserts the linked Vercel project id (`prj_SoUUSNJPvOTDneE0E7faWHFuWMAY`) before deploying, then `vercel deploy --prod`. `frontend-auth-proof` (which polls kortix.com for the release version) now needs it.

**2. Migrations can no longer ship blocking backfills.**
- `lint-migrations.ts`: top-level DML (`UPDATE` / `INSERT INTO` / `DELETE FROM` / `MERGE` / data-modifying `WITH`) in a single-transaction `.sql` migration is an error unless annotated `-- backfill-safe: <table + bounded row count + why writers cannot queue behind it>`. Dollar-quoted trigger bodies and drizzle `--> statement-breakpoint` markers are handled.
- 13 pre-existing immutable migrations (including `centralized_audit_v2` itself, which the rule correctly catches) snapshotted in `backfill-grandfathered-migrations.json` — same contract as the existing grandfather list, separate cutoff.

**Verification**
- `bun test scripts/lint-migrations.test.ts`: 40 pass / 0 fail (6 new cases: bare UPDATE, WITH-CTE, statement-breakpoint same-line, sign-off accepted, trigger-body ignored, grandfathered exempt).
- `bun scripts/lint-migrations.ts`: 161 files pass, warnings only.
- Rule verified against the real `20260807221200000_centralized_audit_v2.sql`: flags without sign-off.

Not part of tonight's v0.12.7 completion (the rerun uses the prod branch's workflow snapshot); protects every release after this lands through the next promote.
