### PR TITLE
test: run full-stack PR previews in warm sandboxes

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -42,6 +42,7 @@ pnpm test -- --id ACC-4        # One flow
 pnpm test -- --domain access   # One domain
 pnpm test -- --sdk-only        # SDK only
 pnpm test -- --browser-only    # Browser only; owns the deterministic local stack
+pnpm test -- --browser-only --browser-shard=1/2 # One browser shard
 pnpm test -- --packages-only   # Every app/package test and publish contract
 pnpm test -- --full            # Browser plus all app/package tests
 pnpm test -- --target-smoke    # Deployed staging API SHA and Playwright smoke
@@ -73,15 +74,18 @@ Each root run writes a benchmark to
 
 ## Run CI in a warm sandbox
 
-Keep the test commands unchanged. GitHub Actions starts three warm workers in
-parallel. They run `pnpm test`, `pnpm test -- --browser-only`, and
-`pnpm test -- --packages-only` at the exact requested SHA. PR QA selects
-Daytona to avoid Platinum restore latency. Manual runs can select `auto`,
-`platinum`, or `daytona` with `TEST_SANDBOX_PROVIDER`.
+Keep the test commands unchanged. GitHub Actions starts four warm workers in
+parallel. Core and package workers run `pnpm test` and
+`pnpm test -- --packages-only`. Two browser workers run shards `1/2` and `2/2`
+through `pnpm test -- --browser-only --browser-shard=CURRENT/TOTAL` at the exact
+requested SHA. PR QA selects Daytona to avoid Platinum restore latency. Manual
+runs can select `auto`, `platinum`, or `daytona` with
+`TEST_SANDBOX_PROVIDER`.
 
-Use one Playwright worker for the local-stack browser lane in CI. A Daytona
-worker has 12 GiB RAM, and concurrent cold Next.js route compilation can kill
-the web process. Keep two workers for deployed staging runs, which set
+Use one Playwright worker for each local-stack browser shard in CI. Two or more
+workers can exhaust the 12 GiB Daytona guest during cold Next.js compilation.
+Prestart Supabase in disposable browser workers so sandbox deletion replaces
+local Supabase teardown. Keep two workers for deployed staging runs, which set
 `E2E_BROWSER_WORKERS` explicitly.
 
 - Use Daytona for the required PR gate. Use `auto` for manual provider fallback.
@@ -147,3 +151,24 @@ For Daytona:
 
 Do not add CI-only test logic. Change `pnpm test` when local and CI behavior
 must change together.
+
+## Run a full-stack pull request preview
+
+- Add `preview` only after a writer reviews the exact same-repository PR SHA.
+- Build the API, gateway, and frontend without credentials in separate jobs.
+- Run the trusted preview controller from `main`.
+- Restore Platinum first. Use Daytona only for an infrastructure failure.
+- Generate the regular `kortix self-host` Compose distribution in the sandbox.
+- Give each preview a fresh PostgreSQL and Supabase data plane.
+- Run `pnpm test -- --target-full` against the sandbox HTTPS origin.
+- Post the preview URL and `/_tests/` report URL in one sticky PR comment.
+- Keep a failed product-test sandbox. Do not hide its failure with fallback.
+- Delete the sandbox on unlabel, close, or PR head change.
+- Remove the `preview` label after a PR head change.
+- Reconcile stale Platinum and Daytona previews each day.
+
+The preview warm image can contain dependencies and Docker layers. It must not
+contain a database or runtime secret. Keep the runtime secret allowlist in
+`tests/src/core/preview-stack.ts`. Use the dedicated preview GitHub App for the
+managed repository and CLI push flows. OAuth initiation remains an explicit
+preview exclusion until a stable callback broker exists.

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,55 +4,119 @@ on:
   pull_request_target:
     branches: [main]
     types: [labeled, unlabeled, synchronize, closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number with the preview label
+        required: true
+        type: number
+      provider:
+        description: Preview sandbox provider
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - platinum
+          - daytona
   schedule:
     - cron: "17 6 * * *"
 
 concurrency:
-  group: deploy-preview-${{ github.event.pull_request.number }}
+  group: deploy-preview-${{ github.event.pull_request.number || inputs.pr_number || 'reconcile' }}
   cancel-in-progress: false
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   authorize:
     name: Authorize exact preview SHA
     if: >-
-      github.event_name == 'pull_request_target' &&
+      (github.event_name == 'pull_request_target' &&
       github.event.action == 'labeled' &&
       github.event.label.name == 'preview' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
+    outputs:
+      pr_number: ${{ steps.preview.outputs.pr_number }}
+      sha: ${{ steps.preview.outputs.sha }}
+      ref: ${{ steps.preview.outputs.ref }}
+      lockfile_sha256: ${{ steps.preview.outputs.lockfile_sha256 }}
+      provider: ${{ steps.preview.outputs.provider }}
     env:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
-      NUM: ${{ github.event.pull_request.number }}
-      COMMIT: ${{ github.event.pull_request.head.sha }}
+      EVENT_NAME: ${{ github.event_name }}
+      EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      EVENT_SHA: ${{ github.event.pull_request.head.sha }}
+      INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+      INPUT_PROVIDER: ${{ inputs.provider }}
       APPROVER: ${{ github.actor }}
     steps:
       - name: Require writer approval for the current head SHA
+        id: preview
         run: |
           set -euo pipefail
           permission="$(gh api "repos/${REPO}/collaborators/${APPROVER}/permission" --jq .permission)"
           case "$permission" in
-            admin|write) ;;
-            *) echo "::error::${APPROVER} has ${permission} permission; preview approval requires write or admin."; exit 1 ;;
+            admin|maintain|write) ;;
+            *) echo "::error::${APPROVER} has ${permission} permission; preview approval requires write, maintain, or admin."; exit 1 ;;
           esac
-          current="$(gh api "repos/${REPO}/pulls/${NUM}" --jq .head.sha)"
-          [ "$current" = "$COMMIT" ] || {
-            echo "::error::Preview approval is stale. Expected ${COMMIT}; current head is ${current}."
+
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            num="$INPUT_PR_NUMBER"
+            sha="$(gh api "repos/${REPO}/pulls/${num}" --jq .head.sha)"
+            head_repo="$(gh api "repos/${REPO}/pulls/${num}" --jq .head.repo.full_name)"
+            provider="$INPUT_PROVIDER"
+          else
+            num="$EVENT_PR_NUMBER"
+            sha="$EVENT_SHA"
+            head_repo="$(gh api "repos/${REPO}/pulls/${num}" --jq .head.repo.full_name)"
+            provider=auto
+          fi
+
+          [ "$head_repo" = "$REPO" ] || {
+            echo "::error::Preview sandboxes accept same-repository pull requests only."
             exit 1
           }
-          labels="$(gh api "repos/${REPO}/issues/${NUM}/labels" --jq 'map(.name) | join(" ")')"
+          [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::Pull request head is not a full Git SHA."
+            exit 1
+          }
+          case "$provider" in auto|platinum|daytona) ;; *) exit 1 ;; esac
+
+          current="$(gh api "repos/${REPO}/pulls/${num}" --jq .head.sha)"
+          [ "$current" = "$sha" ] || {
+            echo "::error::Preview approval is stale. Expected ${sha}; current head is ${current}."
+            exit 1
+          }
+          labels="$(gh api "repos/${REPO}/issues/${num}/labels" --jq 'map(.name) | join(" ")')"
           [[ " $labels " == *" preview "* ]] || {
-            echo "::error::The preview label is no longer present."
+            echo "::error::The preview label is not present."
             exit 1
           }
-          echo "${APPROVER} approved exact preview SHA ${COMMIT}."
+
+          lockfile_sha256="$(gh api \
+            -H 'Accept: application/vnd.github.raw+json' \
+            "repos/${REPO}/contents/pnpm-lock.yaml?ref=${sha}" | sha256sum | awk '{print $1}')"
+          [[ "$lockfile_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "::error::Could not calculate the exact pull request lockfile hash."
+            exit 1
+          }
+
+          {
+            echo "pr_number=$num"
+            echo "sha=$sha"
+            echo "ref=refs/pull/${num}/head"
+            echo "lockfile_sha256=$lockfile_sha256"
+            echo "provider=$provider"
+          } >> "$GITHUB_OUTPUT"
+          echo "${APPROVER} approved preview PR ${num} at ${sha} with provider=${provider}."
 
   build-api:
     name: Build preview API image
@@ -63,7 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.authorize.outputs.sha }}
           submodules: false
           persist-credentials: false
       - uses: docker/setup-buildx-action@v4
@@ -76,12 +140,12 @@ jobs:
           outputs: type=docker,dest=/tmp/preview-api.tar
           build-args: |
             SERVICE=apps/api
-            KORTIX_VERSION=pr-${{ github.event.pull_request.number }}
-            KORTIX_COMMIT=${{ github.event.pull_request.head.sha }}
-          tags: kortix/kortix-api:pr-${{ github.event.pull_request.head.sha }}
+            KORTIX_VERSION=pr-${{ needs.authorize.outputs.pr_number }}
+            KORTIX_COMMIT=${{ needs.authorize.outputs.sha }}
+          tags: kortix/kortix-api:pr-${{ needs.authorize.outputs.sha }}
       - uses: actions/upload-artifact@v7
         with:
-          name: preview-api-${{ github.event.pull_request.head.sha }}
+          name: preview-api-${{ needs.authorize.outputs.sha }}
           path: /tmp/preview-api.tar
           if-no-files-found: error
           retention-days: 1
@@ -96,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.authorize.outputs.sha }}
           submodules: false
           persist-credentials: false
       - uses: docker/setup-buildx-action@v4
@@ -108,12 +172,12 @@ jobs:
           push: false
           outputs: type=docker,dest=/tmp/preview-gateway.tar
           build-args: |
-            KORTIX_VERSION=pr-${{ github.event.pull_request.number }}
-            KORTIX_COMMIT=${{ github.event.pull_request.head.sha }}
-          tags: kortix/kortix-gateway:pr-${{ github.event.pull_request.head.sha }}
+            KORTIX_VERSION=pr-${{ needs.authorize.outputs.pr_number }}
+            KORTIX_COMMIT=${{ needs.authorize.outputs.sha }}
+          tags: kortix/kortix-gateway:pr-${{ needs.authorize.outputs.sha }}
       - uses: actions/upload-artifact@v7
         with:
-          name: preview-gateway-${{ github.event.pull_request.head.sha }}
+          name: preview-gateway-${{ needs.authorize.outputs.sha }}
           path: /tmp/preview-gateway.tar
           if-no-files-found: error
           retention-days: 1
@@ -128,7 +192,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.authorize.outputs.sha }}
           submodules: false
           persist-credentials: false
       - uses: actions/setup-node@v7
@@ -147,8 +211,8 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: local-build-placeholder-anon-key
           NEXT_PUBLIC_BILLING_ENABLED: "false"
-          NEXT_PUBLIC_KORTIX_VERSION: pr-${{ github.event.pull_request.number }}
-          NEXT_PUBLIC_KORTIX_COMMIT: ${{ github.event.pull_request.head.sha }}
+          NEXT_PUBLIC_KORTIX_VERSION: pr-${{ needs.authorize.outputs.pr_number }}
+          NEXT_PUBLIC_KORTIX_COMMIT: ${{ needs.authorize.outputs.sha }}
           NEXT_OUTPUT: standalone
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
@@ -158,73 +222,88 @@ jobs:
           platforms: linux/amd64
           push: false
           outputs: type=docker,dest=/tmp/preview-web.tar
-          tags: kortix/kortix-frontend:pr-${{ github.event.pull_request.head.sha }}
+          tags: kortix/kortix-frontend:pr-${{ needs.authorize.outputs.sha }}
       - uses: actions/upload-artifact@v7
         with:
-          name: preview-web-${{ github.event.pull_request.head.sha }}
+          name: preview-web-${{ needs.authorize.outputs.sha }}
           path: /tmp/preview-web.tar
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
 
   deploy:
-    name: Publish and deploy preview API and frontend
+    name: Deploy full self-host preview and run end-to-end tests
     needs: [authorize, build-api, build-gateway, build-web]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 100
     permissions:
-      id-token: write
       contents: read
       pull-requests: write
+      deployments: write
     env:
-      AWS_REGION: us-west-2
-      PREVIEW_ROLE: arn:aws:iam::935064898258:role/kortix-gha-preview-deploy
-      NUM: ${{ github.event.pull_request.number }}
-      COMMIT: ${{ github.event.pull_request.head.sha }}
       GH_TOKEN: ${{ github.token }}
-      REPO: ${{ github.repository }}
-      WEB_PROTECTION_PASSWORD: ${{ secrets.WEB_PROTECTION_PASSWORD }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      APPROVER: ${{ github.actor }}
+      NUM: ${{ needs.authorize.outputs.pr_number }}
+      COMMIT: ${{ needs.authorize.outputs.sha }}
+      PREVIEW_PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+      PREVIEW_SHA: ${{ needs.authorize.outputs.sha }}
+      PREVIEW_REF: ${{ needs.authorize.outputs.ref }}
+      PREVIEW_LOCKFILE_SHA256: ${{ needs.authorize.outputs.lockfile_sha256 }}
+      PREVIEW_SANDBOX_PROVIDER: ${{ needs.authorize.outputs.provider }}
+      PLATINUM_API_URL: ${{ vars.PLATINUM_API_URL }}
+      PLATINUM_API_KEY: ${{ secrets.PLATINUM_API_KEY }}
+      DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
+      DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+      DAYTONA_CI_TARGET: ${{ vars.DAYTONA_CI_TARGET }}
+      KE2E_STRIPE_SECRET_KEY: ${{ secrets.STAGING_STRIPE_SECRET_KEY }}
+      KE2E_STRIPE_WEBHOOK_SECRET: ${{ secrets.STAGING_STRIPE_WEBHOOK_SECRET }}
+      KORTIX_GITHUB_APP_ID: ${{ secrets.PREVIEW_KORTIX_GITHUB_APP_ID }}
+      KORTIX_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PREVIEW_KORTIX_GITHUB_APP_PRIVATE_KEY }}
+      KORTIX_GITHUB_APP_SLUG: ${{ secrets.PREVIEW_KORTIX_GITHUB_APP_SLUG }}
+      MANAGED_GIT_GITHUB_INSTALL_ID: ${{ secrets.PREVIEW_MANAGED_GIT_GITHUB_INSTALL_ID }}
+      MANAGED_GIT_GITHUB_OWNER: ${{ secrets.PREVIEW_MANAGED_GIT_GITHUB_OWNER }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
       - name: Revalidate exact preview approval
-        env:
-          APPROVER: ${{ github.actor }}
         run: |
           set -euo pipefail
-          permission="$(gh api "repos/${REPO}/collaborators/${APPROVER}/permission" --jq .permission)"
+          permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${APPROVER}/permission" --jq .permission)"
           case "$permission" in
-            admin|write) ;;
-            *) echo "::error::Preview approver no longer has write or admin permission."; exit 1 ;;
+            admin|maintain|write) ;;
+            *) echo "::error::Preview approver no longer has write, maintain, or admin permission."; exit 1 ;;
           esac
-          current="$(gh api "repos/${REPO}/pulls/${NUM}" --jq .head.sha)"
+          current="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${NUM}" --jq .head.sha)"
           [ "$current" = "$COMMIT" ] || {
             echo "::error::Approved SHA ${COMMIT} is stale; current head is ${current}."
             exit 1
           }
-          labels="$(gh api "repos/${REPO}/issues/${NUM}/labels" --jq 'map(.name) | join(" ")')"
+          labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${NUM}/labels" --jq 'map(.name) | join(" ")')"
           [[ " $labels " == *" preview "* ]] || {
-            echo "::error::The preview label was removed before publication."
+            echo "::error::The preview label was removed before deployment."
             exit 1
           }
       - uses: actions/download-artifact@v8
         with:
-          name: preview-api-${{ github.event.pull_request.head.sha }}
+          name: preview-api-${{ needs.authorize.outputs.sha }}
           path: /tmp/preview-api
       - uses: actions/download-artifact@v8
         with:
-          name: preview-gateway-${{ github.event.pull_request.head.sha }}
+          name: preview-gateway-${{ needs.authorize.outputs.sha }}
           path: /tmp/preview-gateway
       - uses: actions/download-artifact@v8
         with:
-          name: preview-web-${{ github.event.pull_request.head.sha }}
+          name: preview-web-${{ needs.authorize.outputs.sha }}
           path: /tmp/preview-web
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Load and publish fixed preview image tags
+      - name: Publish exact linux/amd64 images
         run: |
           set -euo pipefail
           for archive in \
@@ -241,145 +320,168 @@ jobs:
             "kortix/kortix-api:pr-${COMMIT}" \
             "kortix/kortix-gateway:pr-${COMMIT}" \
             "kortix/kortix-frontend:pr-${COMMIT}"; do
-            docker image inspect "$image" >/dev/null
+            docker image inspect --format '{{.Os}}/{{.Architecture}}' "$image" | grep -qx 'linux/amd64'
             docker push "$image"
           done
-      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
-        with:
-          role-to-assume: ${{ env.PREVIEW_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Deploy isolated Fargate service
-        run: |
-          bash infra/scripts/ecs-preview.sh deploy "$NUM" \
-            "kortix/kortix-api:pr-${COMMIT}" \
-            "kortix/kortix-gateway:pr-${COMMIT}" \
-            "kortix/kortix-frontend:pr-${COMMIT}" \
-            "$COMMIT"
-      - name: Require isolated API and frontend health
+      - name: Create GitHub deployment
+        id: deployment
         run: |
           set -euo pipefail
-          test -n "${WEB_PROTECTION_PASSWORD:-}" || {
-            echo "::error::WEB_PROTECTION_PASSWORD is required for preview verification."
-            exit 1
-          }
-          api_host="pr-${NUM}.preview-api.kortix.com"
-          web_host="pr-${NUM}.preview.kortix.com"
-          for _ in $(seq 1 30); do
-            cookie_jar="$(mktemp)"
-            api_health="$(curl -fsS --max-time 8 "https://${api_host}/v1/health" 2>/dev/null || true)"
-            api_environment="$(printf '%s' "$api_health" | jq -r '.environment // empty' 2>/dev/null || true)"
-            api_commit="$(printf '%s' "$api_health" | jq -r '.commit // empty' 2>/dev/null || true)"
-            web_health="$(curl -fsS --max-time 8 "https://${web_host}/api/health" 2>/dev/null || true)"
-            web_commit="$(printf '%s' "$web_health" | jq -r '.commit // empty' 2>/dev/null || true)"
-            anonymous="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 "https://${web_host}/" || true)"
-            wrong="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 -u 'kortix:wrong-password' "https://${web_host}/" || true)"
-            protected="$(curl -sS -c "$cookie_jar" -o /dev/null -w '%{http_code}' --max-time 8 -u "kortix:${WEB_PROTECTION_PASSWORD}" "https://${web_host}/" || true)"
-            cookie_only="$(curl -sS -b "$cookie_jar" -o /dev/null -w '%{http_code}' --max-time 8 "https://${web_host}/" || true)"
-            runtime="$(curl -fsS -b "$cookie_jar" --max-time 8 "https://${web_host}/api/runtime-config" 2>/dev/null || true)"
-            rm -f "$cookie_jar"
-            echo "api_environment=${api_environment:-?} api_commit=${api_commit:-?} web_commit=${web_commit:-?} anonymous=${anonymous:-?} wrong=${wrong:-?} protected=${protected:-?} cookie_only=${cookie_only:-?}"
-            if [ "$api_environment" = "preview" ] \
-              && [ "$api_commit" = "$COMMIT" ] \
-              && [ "$web_commit" = "$COMMIT" ] \
-              && [ "$anonymous" = 401 ] \
-              && [ "$wrong" = 401 ] \
-              && { [ "$protected" = 200 ] || [ "$protected" = 307 ] || [ "$protected" = 308 ]; } \
-              && { [ "$cookie_only" = 200 ] || [ "$cookie_only" = 307 ] || [ "$cookie_only" = 308 ]; } \
-              && grep -q "https://${api_host}/v1" <<<"$runtime" \
-              && grep -q "https://${web_host}" <<<"$runtime"; then
-              printf '%s\n' "$api_health" > /tmp/preview-health.json
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "::error::Preview API or frontend did not report commit ${COMMIT} with isolated runtime configuration."
-          exit 1
-      - name: Update sticky status comment
+          id="$(jq -n \
+            --arg ref "$COMMIT" \
+            --arg environment "preview/pr-${NUM}" \
+            '{ref:$ref,environment:$environment,auto_merge:false,required_contexts:[],description:"Ephemeral full-stack sandbox preview"}' | \
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments" --input - --jq .id)"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+          jq -n '{state:"in_progress",description:"Building the self-host preview"}' | \
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${id}/statuses" --input - >/dev/null
+      - name: Deploy sandbox and run pnpm test -- --target-full
+        id: preview
+        continue-on-error: true
+        run: bun tests/bin/sandbox-preview.ts deploy
+      - name: Publish GitHub deployment result
+        if: always() && steps.deployment.outputs.id != ''
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
+          PREVIEW_URL: ${{ steps.preview.outputs.preview_url }}
+          PREVIEW_OUTCOME: ${{ steps.preview.outcome }}
+        run: |
+          set -euo pipefail
+          if [ "$PREVIEW_OUTCOME" = success ] && [ -n "$PREVIEW_URL" ]; then
+            state=success
+            description='Full self-host preview and target-full tests passed'
+          else
+            state=failure
+            description='Preview deployment or target-full tests failed'
+          fi
+          jq -n \
+            --arg state "$state" \
+            --arg description "$description" \
+            --arg environment_url "$PREVIEW_URL" \
+            --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{state:$state,description:$description,environment_url:$environment_url,log_url:$log_url}' | \
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" --input - >/dev/null
+      - name: Update sticky preview comment
+        if: always()
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.preview_url }}
+          REPORT_URL: ${{ steps.preview.outputs.report_url }}
+          PROVIDER: ${{ steps.preview.outputs.provider }}
+          SANDBOX_ID: ${{ steps.preview.outputs.sandbox_id }}
+          PREVIEW_OUTCOME: ${{ steps.preview.outcome }}
         run: |
           set -euo pipefail
           marker='<!-- preview-status -->'
-          host="pr-${NUM}.preview-api.kortix.com"
-          web="pr-${NUM}.preview.kortix.com"
-          body="$(printf '%s\n' "$marker" '## Preview environment - live' '' \
-            "- **Backend:** https://${host}" \
-            "- **Health:** https://${host}/v1/health" \
-            "- **Frontend:** https://${web}" '' \
-            '_One isolated Fargate task with API, gateway, and frontend; automatic close/unlabel teardown._')"
-          id="$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
+          if [ "$PREVIEW_OUTCOME" = success ]; then
+            title='## Preview environment - live and tested'
+            # Markdown needs literal backticks.
+            # shellcheck disable=SC2016
+            result='`pnpm test -- --target-full` passed.'
+          elif [ -n "$PREVIEW_URL" ]; then
+            title='## Preview environment - live; tests failed'
+            result='The sandbox remains available for diagnosis. Open the report and workflow log.'
+          else
+            title='## Preview environment - deployment failed'
+            result='No preview URL was published. Open the workflow log.'
+          fi
+          body="$(printf '%s\n' "$marker" "$title" '' \
+            "- **Preview:** ${PREVIEW_URL:-unavailable}" \
+            "- **Test report:** ${REPORT_URL:-unavailable}" \
+            "- **Provider:** ${PROVIDER:-$PREVIEW_SANDBOX_PROVIDER}" \
+            "- **Sandbox:** ${SANDBOX_ID:-unavailable}" \
+            "- **Commit:** \`${COMMIT}\`" '' \
+            "$result" '' \
+            '_The preview owns PostgreSQL, Supabase, API, gateway, frontend, and Mailpit. OAuth initiation is the only explicit preview exclusion._')"
+          id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${NUM}/comments" --paginate \
             --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")"
           if [ -n "$id" ]; then
-            gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${id}" -f body="$body" >/dev/null
           else
-            gh api -X POST "repos/${REPO}/issues/${NUM}/comments" -f body="$body" >/dev/null
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${NUM}/comments" -f body="$body" >/dev/null
           fi
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: preview-results-pr-${{ needs.authorize.outputs.pr_number }}-${{ needs.authorize.outputs.sha }}
+          path: tests/test-results/**
+          if-no-files-found: warn
+          retention-days: 14
+      - name: Fail when deployment or tests failed
+        if: steps.preview.outcome != 'success'
+        run: exit 1
 
   teardown:
     name: Tear down preview and invalidate stale approval
     if: >-
+      github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.action == 'closed' ||
       (github.event.action == 'unlabeled' && github.event.label.name == 'preview') ||
       (github.event.action == 'synchronize' &&
       contains(github.event.pull_request.labels.*.name, 'preview')))
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
-      id-token: write
       contents: read
       pull-requests: write
+      deployments: write
     env:
-      AWS_REGION: us-west-2
-      PREVIEW_ROLE: arn:aws:iam::935064898258:role/kortix-gha-preview-deploy
-      NUM: ${{ github.event.pull_request.number }}
       GH_TOKEN: ${{ github.token }}
-      REPO: ${{ github.repository }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      PREVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
+      PLATINUM_API_URL: ${{ vars.PLATINUM_API_URL }}
+      PLATINUM_API_KEY: ${{ secrets.PLATINUM_API_KEY }}
+      DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
+      DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+      DAYTONA_CI_TARGET: ${{ vars.DAYTONA_CI_TARGET }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
-      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
-        with:
-          role-to-assume: ${{ env.PREVIEW_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Delete isolated Fargate resources
-        run: bash infra/scripts/ecs-preview.sh teardown "$NUM"
+          persist-credentials: false
+      - name: Delete the Platinum or Daytona preview sandbox
+        run: bun tests/bin/sandbox-preview.ts teardown
       - name: Remove stale preview approval
         if: github.event.action == 'synchronize'
         run: |
           set -euo pipefail
-          gh api -X DELETE "repos/${REPO}/issues/${NUM}/labels/preview" --silent
-          echo "Removed preview approval after the PR head changed."
-      - name: Mark sticky status comment torn down
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/${PREVIEW_PR_NUMBER}/labels/preview" --silent
+          echo "Removed preview approval after the pull request head changed."
+      - name: Mark GitHub deployment inactive
+        run: |
+          set -euo pipefail
+          id="$(gh api "repos/${GITHUB_REPOSITORY}/deployments?environment=preview/pr-${PREVIEW_PR_NUMBER}&per_page=1" --jq '.[0].id // empty')"
+          [ -z "$id" ] || jq -n '{state:"inactive",description:"Preview sandbox deleted"}' | \
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${id}/statuses" --input - >/dev/null
+      - name: Mark sticky preview comment torn down
         run: |
           set -euo pipefail
           marker='<!-- preview-status -->'
-          id="$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
+          id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PREVIEW_PR_NUMBER}/comments" --paginate \
             --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")"
           body="$(printf '%s\n' "$marker" '## Preview environment - torn down' '' \
-            'The ECS service, two listener rules, two target groups, and task definitions were deleted.')"
-          [ -z "$id" ] || gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null
+            'The Platinum or Daytona sandbox and its full self-host data plane were deleted.')"
+          [ -z "$id" ] || gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${id}" -f body="$body" >/dev/null
 
   reconcile:
-    name: Reconcile stale preview backends
+    name: Reconcile stale preview sandboxes
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
-      id-token: write
       contents: read
       pull-requests: read
     env:
-      AWS_REGION: us-west-2
-      PREVIEW_ROLE: arn:aws:iam::935064898258:role/kortix-gha-preview-deploy
-      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
       GITHUB_REPOSITORY: ${{ github.repository }}
-      PREVIEW_MAX_AGE_HOURS: "72"
+      PLATINUM_API_URL: ${{ vars.PLATINUM_API_URL }}
+      PLATINUM_API_KEY: ${{ secrets.PLATINUM_API_KEY }}
+      DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
+      DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+      DAYTONA_CI_TARGET: ${{ vars.DAYTONA_CI_TARGET }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
-      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
-        with:
-          role-to-assume: ${{ env.PREVIEW_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-      - run: bash infra/scripts/ecs-preview.sh reconcile 0
+          persist-credentials: false
+      - run: bun tests/bin/sandbox-preview.ts reconcile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lane: [core, browser, packages]
+        include:
+          - lane: core
+            mode: core
+          - lane: browser-1
+            mode: browser
+          - lane: browser-2
+            mode: browser
+          - lane: packages
+            mode: packages
     env:
       PLATINUM_API_URL: ${{ vars.PLATINUM_API_URL || 'https://api.platinum.dev' }}
       PLATINUM_API_KEY: ${{ secrets.PLATINUM_API_KEY }}
@@ -61,29 +69,30 @@ jobs:
             *) echo "::error::Invalid test mode: $TEST_MODE"; exit 2 ;;
           esac
       - uses: actions/checkout@v7
-        if: inputs.mode == 'full' || inputs.mode == matrix.lane
+        if: inputs.mode == 'full' || inputs.mode == matrix.mode
         with:
           ref: ${{ env.SANDBOX_TEST_SHA }}
           fetch-depth: 1
       - uses: oven-sh/setup-bun@v2
-        if: inputs.mode == 'full' || inputs.mode == matrix.lane
+        if: inputs.mode == 'full' || inputs.mode == matrix.mode
         with:
           bun-version: 1.3.14
       - name: Run the root test lane in a sandbox
-        if: inputs.mode == 'full' || inputs.mode == matrix.lane
+        if: inputs.mode == 'full' || inputs.mode == matrix.mode
         run: |
           set -euo pipefail
           case "$TEST_LANE" in
             core) bun tests/bin/sandbox-ci.ts ;;
-            browser) bun tests/bin/sandbox-ci.ts --browser-only ;;
+            browser-1) bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=1/2 ;;
+            browser-2) bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=2/2 ;;
             packages) bun tests/bin/sandbox-ci.ts --packages-only ;;
             *) echo "::error::Invalid test lane: $TEST_LANE"; exit 2 ;;
           esac
       - name: Delete the sandbox worker
-        if: always() && (inputs.mode == 'full' || inputs.mode == matrix.lane)
+        if: always() && (inputs.mode == 'full' || inputs.mode == matrix.mode)
         run: bun tests/bin/sandbox-ci-cleanup.ts
       - name: Guard test artifacts against secrets
-        if: always() && (inputs.mode == 'full' || inputs.mode == matrix.lane)
+        if: always() && (inputs.mode == 'full' || inputs.mode == matrix.mode)
         run: |
           set -euo pipefail
           if rg -l 'kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.' tests/test-results 2>/dev/null; then
@@ -92,7 +101,7 @@ jobs:
           fi
           echo "No secret-shaped values found."
       - uses: actions/upload-artifact@v7
-        if: always() && (inputs.mode == 'full' || inputs.mode == matrix.lane)
+        if: always() && (inputs.mode == 'full' || inputs.mode == matrix.mode)
         with:
           name: ${{ inputs.artifact-name }}-${{ matrix.lane }}
           path: tests/test-results/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,6 +369,19 @@ See `tests/e2e/helpers/auth.ts` for the exact calls.
   production when API or gateway health reports a SHA other than
   `RELEASE_SOURCE_SHA`, when any API flow is excluded, or when a configured
   Playwright journey fails.
+- The `preview` label creates one full self-host preview in a persistent warm
+  Platinum sandbox. `auto` uses Daytona only for a Platinum infrastructure
+  failure. The preview has its own PostgreSQL, Supabase, API, gateway, frontend,
+  Mailpit, and HTTPS origin.
+- Preview CI runs `pnpm test -- --target-full` against that origin. The sticky
+  pull request comment links the origin and its `/_tests/` HTML report.
+- A preview head change deletes the sandbox and removes the stale `preview`
+  label. Unlabel, close, and scheduled reconciliation also delete the sandbox.
+- Preview warm images contain dependencies and Docker layers only. They never
+  contain a database or runtime secret.
+- Preview Mailpit handles authentication and invite email. The dedicated
+  preview GitHub App runs the managed repository and CLI push flows. OAuth
+  initiation is the only allowed preview browser exclusion.
 
 ### Product flow source of truth
 

--- a/apps/api/src/__tests__/unit-ci-api-suite-runs.test.ts
+++ b/apps/api/src/__tests__/unit-ci-api-suite-runs.test.ts
@@ -18,9 +18,17 @@ const sandboxJob = workflow.slice(workflow.indexOf('\n  sandbox:'));
 describe('the kortix-api suite actually runs on pull requests', () => {
   test('the reusable workflow runs every root lane on exact-SHA sandbox workers', () => {
     expect(sandboxJob).toContain('matrix:');
-    expect(sandboxJob).toContain('lane: [core, browser, packages]');
+    expect(sandboxJob).toContain('- lane: core');
+    expect(sandboxJob).toContain('- lane: browser-1');
+    expect(sandboxJob).toContain('- lane: browser-2');
+    expect(sandboxJob).toContain('- lane: packages');
     expect(sandboxJob).toContain('core) bun tests/bin/sandbox-ci.ts ;;');
-    expect(sandboxJob).toContain('browser) bun tests/bin/sandbox-ci.ts --browser-only ;;');
+    expect(sandboxJob).toContain(
+      'browser-1) bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=1/2 ;;',
+    );
+    expect(sandboxJob).toContain(
+      'browser-2) bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=2/2 ;;',
+    );
     expect(sandboxJob).toContain('packages) bun tests/bin/sandbox-ci.ts --packages-only ;;');
     expect(sandboxJob).toContain('SANDBOX_TEST_SHA:');
     expect(sandboxJob).toContain('SANDBOX_TEST_REF:');

--- a/apps/web/scripts/vercel-ignore.sh
+++ b/apps/web/scripts/vercel-ignore.sh
@@ -7,11 +7,11 @@
 # Two stages run in order:
 #   1. FE-relevance — if a push changed NOTHING that feeds the apps/web build
 #      (only sibling apps / infra / tests / docs), skip it on every branch.
-#   2. Deploy-target — staging and prod deploy real frontend changes. Dev and
-#      per-PR previews run only on ECS and always skip Vercel builds.
+#   2. Deploy-target — staging auto-builds. Production deploys through the
+#      gated workflow. Dev uses ECS. PR previews use Platinum or Daytona.
 #
-# For staging and production, default to BUILD on ANY uncertainty. Dev and
-# per-PR previews default to SKIP because ECS owns those frontend deployments.
+# Staging defaults to BUILD on uncertainty. Dev and PR previews default to SKIP.
+# Production auto-builds always skip because deploy-prod.yml owns that release.
 #
 # WHY THIS EXISTS
 # A backend/infra-only push to `prod` (e.g. a rollback that only flips
@@ -72,5 +72,5 @@ case "${VERCEL_ENV:-}:$REF" in
     exit 1 ;;
 esac
 
-echo "vercel-ignore: dev and PR previews deploy on ECS only — skipping Vercel. ref=$REF"
+echo "vercel-ignore: dev deploys on ECS; PR previews deploy in sandboxes — skipping Vercel. ref=$REF"
 exit 0

--- a/apps/web/src/test-report-artifact.test.ts
+++ b/apps/web/src/test-report-artifact.test.ts
@@ -8,8 +8,14 @@ const playwrightConfig = readFileSync(join(repoRoot, 'tests/playwright.config.ts
 
 describe('frontend browser report artifact contract', () => {
   test('runs browser journeys through the canonical root test worker', () => {
-    expect(workflow).toContain('lane: [core, browser, packages]');
-    expect(workflow).toContain('bun tests/bin/sandbox-ci.ts --browser-only');
+    expect(workflow).toContain('- lane: browser-1');
+    expect(workflow).toContain('- lane: browser-2');
+    expect(workflow).toContain(
+      'bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=1/2',
+    );
+    expect(workflow).toContain(
+      'bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=2/2',
+    );
   });
 
   test('uploads every generated JSON and HTML report for inspection', () => {

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,6 +22,7 @@ pnpm test -- --id ACC-4        # One flow
 pnpm test -- --domain access   # One flow domain
 pnpm test -- --sdk-only        # SDK only
 pnpm test -- --browser-only    # Browser journeys with the deterministic local stack
+pnpm test -- --browser-only --browser-shard=1/2 # One deterministic browser shard
 pnpm test -- --packages-only   # Every app/package test and publish contract
 pnpm test -- --full            # Core, browser, and every app/package test
 pnpm test -- --target-smoke    # Deployed staging API SHA and browser smoke
@@ -48,18 +49,20 @@ code.
 
 GitHub Actions uses `.github/workflows/tests.yml` for local-profile PR tests.
 `tests-pr.yml` calls it once for pull requests into `main` or `staging`. Full
-mode starts three warm workers in parallel. The workers run
-`pnpm test`, `pnpm test -- --browser-only`, and
-`pnpm test -- --packages-only`. Set `provider` to `auto`, `platinum`, or
-`daytona`. Automatic PR tests use Daytona directly to avoid Platinum restore
-latency. Manual runs can select either provider or `auto`. Auto tries Platinum
-first. It falls back to Daytona only when Platinum infrastructure throws. A
-non-zero test exit returns directly and does not trigger fallback. Each lane
-has a unique sandbox run ID and artifact. The three lanes are the parallel
-equivalent of `pnpm test -- --full`.
-The local browser lane uses one Playwright worker in CI. This prevents two cold
-Next.js route compilations from exhausting a 12 GiB Daytona worker. Deployed
-staging browser runs set two workers explicitly.
+mode starts four warm workers in parallel. Core and package workers run
+`pnpm test` and `pnpm test -- --packages-only`. Two browser workers run shards
+`1/2` and `2/2` through `pnpm test -- --browser-only --browser-shard=CURRENT/TOTAL`.
+Set `provider` to `auto`, `platinum`, or `daytona`. Automatic PR tests use
+Daytona directly to avoid Platinum restore latency. Manual runs can select
+either provider or `auto`. Auto tries Platinum first. It falls back to Daytona
+only when Platinum infrastructure throws. A non-zero test exit returns directly
+and does not trigger fallback. Each worker has a unique sandbox run ID and
+artifact. The four workers are the parallel equivalent of `pnpm test -- --full`.
+Each local browser shard uses one Playwright worker in CI. Two or more workers
+can exhaust the 12 GiB Daytona guest while Next.js compiles cold routes. A
+disposable worker prestarts Supabase so the root runner reuses it and sandbox
+deletion replaces the local Supabase teardown.
+Deployed staging browser runs also set two workers explicitly.
 Platinum warm restore readiness is capped at 2 minutes. A missing marker or
 unreachable guest after that cap is an infrastructure error and triggers auto
 fallback. Cold template builds keep their separate 45-minute creation budget.
@@ -70,6 +73,43 @@ Chromium, linked `node_modules`, a warm checkout, and pre-pulled Supabase images
 Each worker fetches the requested ref, verifies the exact SHA, runs an offline
 lockfile install, starts nested Docker, and invokes the unchanged root command.
 Both runners stream logs, download `tests/test-results`, and delete the worker.
+
+## Pull request preview sandboxes
+
+Add the `preview` label to a same-repository pull request into `main`.
+`.github/workflows/deploy-preview.yml` then performs this sequence:
+
+1. A repository writer authorizes the exact pull request SHA.
+2. Three credential-free jobs build the API, gateway, and frontend images for
+   `linux/amd64`.
+3. The trusted controller from `main` publishes the three exact SHA tags.
+4. The controller restores one warm Platinum sandbox. `auto` uses Daytona only
+   when Platinum infrastructure fails.
+5. The sandbox generates the standard `kortix self-host` Compose distribution.
+6. One overlay adds Caddy, Mailpit, the report mount, and loopback PostgreSQL.
+7. The sandbox runs `pnpm test -- --target-full` against its public HTTPS origin.
+8. The workflow posts the preview URL and `/_tests/` report URL to the pull
+   request. It also creates a GitHub Deployment for `preview/pr-<number>`.
+
+The preview owns PostgreSQL, Supabase Auth, REST, Storage, API, gateway,
+frontend, and Mailpit. It does not use the Dev, staging, or production database.
+The warm image contains dependencies and Docker layers only. It contains no
+preview database and no runtime secret.
+
+The runtime secret allowlist contains `DAYTONA_API_KEY`,
+`KE2E_STRIPE_SECRET_KEY`, `KE2E_STRIPE_WEBHOOK_SECRET`, `OPENROUTER_API_KEY`, and the five fields required
+for the dedicated preview GitHub App installation. Mailpit handles preview
+email. The GitHub App runs the real managed repository and CLI push flows.
+OAuth initiation is the only allowed preview browser exclusion. All API flow
+exclusions and all other browser journey exclusions fail the preview test.
+
+Use **Run workflow** to select `platinum` or `daytona` explicitly for one
+provider proof. A new deployment deletes any existing provider sandbox for the
+same pull request. A test failure keeps the sandbox available for diagnosis.
+Removing the label, closing the pull request, or pushing a new commit deletes
+the sandbox. A new commit also removes the stale `preview` label. A scheduled
+reconciler deletes sandboxes whose pull request is closed, unlabeled, or at a
+different SHA.
 
 `tests-release.yml` runs `pnpm test -- --target-full` against deployed staging
 for pull requests into `prod`. It does not repeat the local-profile suite.

--- a/tests/bin/preview-stack.ts
+++ b/tests/bin/preview-stack.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+import {
+  applyPreviewEnvironment,
+  buildPreviewCaddyfile,
+  buildPreviewComposeOverlay,
+} from '../src/core/preview-stack';
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+const instanceDir = resolve(required('PREVIEW_INSTANCE_DIR'));
+const stateDir = resolve(required('PREVIEW_STATE_DIR'));
+const origin = required('PREVIEW_ORIGIN');
+const sha = required('PREVIEW_SHA');
+const secretsFile = resolve(required('PREVIEW_SECRETS_FILE'));
+const secrets = JSON.parse(await readFile(secretsFile, 'utf8')) as Record<string, string>;
+const envPath = join(instanceDir, '.env');
+const configured = applyPreviewEnvironment(
+  await readFile(envPath, 'utf8'),
+  {
+    origin,
+    sha,
+    apiImage: `kortix/kortix-api:pr-${sha}`,
+    gatewayImage: `kortix/kortix-gateway:pr-${sha}`,
+    frontendImage: `kortix/kortix-frontend:pr-${sha}`,
+  },
+  secrets,
+);
+
+await mkdir(stateDir, { recursive: true });
+await writeFile(envPath, configured.runtimeEnv, { mode: 0o600 });
+await chmod(envPath, 0o600);
+const testEnvPath = join(instanceDir, '.env.test');
+await writeFile(testEnvPath, configured.testEnv, { mode: 0o600 });
+await chmod(testEnvPath, 0o600);
+await writeFile(join(stateDir, 'Caddyfile.preview'), buildPreviewCaddyfile(), { mode: 0o644 });
+await writeFile(
+  join(stateDir, 'docker-compose.preview.yml'),
+  buildPreviewComposeOverlay(
+    '/workspace/suna/tests/test-results',
+    join(stateDir, 'Caddyfile.preview'),
+  ),
+  { mode: 0o644 },
+);
+
+console.log(`[preview-stack] configured origin=${origin} sha=${sha}`);

--- a/tests/bin/sandbox-preview.ts
+++ b/tests/bin/sandbox-preview.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env bun
+import { appendFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import {
+  type SandboxPreviewProvider,
+  runSandboxPreview,
+} from '../src/core/sandbox-preview';
+import {
+  type SandboxPreviewDeploymentInput,
+  deployDaytonaPreview,
+  deployPlatinumPreview,
+  reconcileDaytonaPreviews,
+  reconcilePlatinumPreviews,
+  teardownDaytonaPreview,
+  teardownPlatinumPreview,
+} from '../src/core/sandbox-preview-providers';
+import type { PreviewRuntimeSecrets } from '../src/core/preview-stack';
+
+function value(name: string, fallback = ''): string {
+  return process.env[name]?.trim() || fallback;
+}
+
+function required(name: string): string {
+  const result = value(name);
+  if (!result) throw new Error(`${name} is required`);
+  return result;
+}
+
+function positiveInteger(name: string): number {
+  const result = Number(required(name));
+  if (!Number.isSafeInteger(result) || result < 1) throw new Error(`${name} must be a positive integer`);
+  return result;
+}
+
+function provider(): SandboxPreviewProvider {
+  const selected = value('PREVIEW_SANDBOX_PROVIDER', 'auto').toLowerCase();
+  if (selected === 'auto' || selected === 'platinum' || selected === 'daytona') return selected;
+  throw new Error(`PREVIEW_SANDBOX_PROVIDER must be auto, platinum, or daytona; received ${selected}`);
+}
+
+function runtimeSecrets(): PreviewRuntimeSecrets {
+  return {
+    DAYTONA_API_KEY: value('DAYTONA_API_KEY'),
+    KE2E_STRIPE_SECRET_KEY: value('KE2E_STRIPE_SECRET_KEY'),
+    KE2E_STRIPE_WEBHOOK_SECRET: value('KE2E_STRIPE_WEBHOOK_SECRET'),
+    KORTIX_GITHUB_APP_ID: value('KORTIX_GITHUB_APP_ID'),
+    KORTIX_GITHUB_APP_PRIVATE_KEY: value('KORTIX_GITHUB_APP_PRIVATE_KEY'),
+    KORTIX_GITHUB_APP_SLUG: value('KORTIX_GITHUB_APP_SLUG'),
+    MANAGED_GIT_GITHUB_INSTALL_ID: value('MANAGED_GIT_GITHUB_INSTALL_ID'),
+    MANAGED_GIT_GITHUB_OWNER: value('MANAGED_GIT_GITHUB_OWNER'),
+    OPENROUTER_API_KEY: value('OPENROUTER_API_KEY'),
+  };
+}
+
+async function writeOutput(name: string, outputValue: string): Promise<void> {
+  const output = process.env.GITHUB_OUTPUT;
+  if (output) await appendFile(output, `${name}=${outputValue}\n`);
+  console.log(`[sandbox-preview] ${name}=${outputValue}`);
+}
+
+async function activePreviewPullRequests(
+  repository: string,
+  token: string,
+): Promise<Map<number, string>> {
+  const active = new Map<number, string>();
+  for (let page = 1; ; page += 1) {
+    const response = await fetch(
+      `https://api.github.com/repos/${repository}/pulls?state=open&per_page=100&page=${page}`,
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+        },
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+    if (!response.ok) throw new Error(`GitHub pull request list returned ${response.status}`);
+    const pulls = (await response.json()) as Array<{
+      number: number;
+      labels?: Array<{ name?: string }>;
+      head?: { sha?: string; repo?: { full_name?: string } };
+    }>;
+    for (const pull of pulls) {
+      const approved = pull.labels?.some((label) => label.name === 'preview');
+      const sameRepository = pull.head?.repo?.full_name === repository;
+      const sha = pull.head?.sha ?? '';
+      if (approved && sameRepository && /^[0-9a-f]{40}$/.test(sha)) active.set(pull.number, sha);
+    }
+    if (pulls.length < 100) return active;
+  }
+}
+
+const action = process.argv[2] ?? 'deploy';
+const repository = value('GITHUB_REPOSITORY', 'kortix-ai/suna');
+const platinum = {
+  apiUrl: value('PLATINUM_API_URL', 'https://api.platinum.dev'),
+  apiKey: value('PLATINUM_API_KEY'),
+};
+const daytona = {
+  apiUrl: value('DAYTONA_API_URL', value('DAYTONA_SERVER_URL', 'https://app.daytona.io/api')),
+  apiKey: value('DAYTONA_API_KEY'),
+  target: value('DAYTONA_CI_TARGET', value('DAYTONA_TARGET', 'us')),
+};
+
+if (action === 'deploy') {
+  const prNumber = positiveInteger('PREVIEW_PR_NUMBER');
+  const sha = required('PREVIEW_SHA');
+  const deployment: SandboxPreviewDeploymentInput = {
+    repository,
+    ref: value('PREVIEW_REF', sha),
+    sha,
+    prNumber,
+    runId: value('GITHUB_RUN_ID', `local-${Date.now()}`),
+    runAttempt: value('GITHUB_RUN_ATTEMPT', '1'),
+    root: resolve(value('PREVIEW_ROOT', resolve(import.meta.dir, '../..'))),
+    lockfileHash: required('PREVIEW_LOCKFILE_SHA256'),
+    secrets: runtimeSecrets(),
+    platinum,
+    daytona,
+  };
+  const result = await runSandboxPreview(
+    { provider: provider(), prNumber, repository, sha },
+    {
+      platinum: () => deployPlatinumPreview(deployment),
+      daytona: () => deployDaytonaPreview(deployment),
+    },
+  );
+  const staleProviderCleanup = result.provider === 'platinum'
+    ? teardownDaytonaPreview({ ...daytona, prNumber })
+    : teardownPlatinumPreview({ ...platinum, prNumber });
+  await staleProviderCleanup.catch((error) => {
+    console.warn(
+      `[sandbox-preview] stale provider cleanup failed; scheduled reconciliation will retry: ${String(error)}`,
+    );
+  });
+  await writeOutput('provider', result.provider);
+  await writeOutput('sandbox_id', result.sandboxId ?? '');
+  await writeOutput('preview_url', result.previewUrl ?? '');
+  await writeOutput('report_url', result.previewUrl ? `${result.previewUrl}/_tests/` : '');
+  process.exitCode = result.exitCode;
+} else if (action === 'teardown') {
+  const prNumber = positiveInteger('PREVIEW_PR_NUMBER');
+  const [platinumDeleted, daytonaDeleted] = await Promise.all([
+    teardownPlatinumPreview({ ...platinum, prNumber }),
+    teardownDaytonaPreview({ ...daytona, prNumber }),
+  ]);
+  console.log(`[sandbox-preview] teardown platinum=${platinumDeleted} daytona=${daytonaDeleted}`);
+} else if (action === 'reconcile') {
+  const active = await activePreviewPullRequests(repository, required('GITHUB_TOKEN'));
+  const [platinumDeleted, daytonaDeleted] = await Promise.all([
+    reconcilePlatinumPreviews({ ...platinum, activePullRequests: active }),
+    reconcileDaytonaPreviews({ ...daytona, activePullRequests: active }),
+  ]);
+  console.log(
+    `[sandbox-preview] reconcile active=${active.size} platinum_deleted=${platinumDeleted} daytona_deleted=${daytonaDeleted}`,
+  );
+} else {
+  throw new Error(`unknown sandbox preview action: ${action}`);
+}

--- a/tests/e2e/specs/01-account-auth.spec.ts
+++ b/tests/e2e/specs/01-account-auth.spec.ts
@@ -37,6 +37,7 @@ async function requestEmailAuthentication(page: Page, email: string) {
     name: "Continue",
     exact: true,
   });
+  await expect(continueButton).toBeEnabled();
   let submitted = false;
   for (let attempt = 1; attempt <= 3 && !submitted; attempt += 1) {
     const formRequest = page
@@ -47,7 +48,7 @@ async function requestEmailAuthentication(page: Page, email: string) {
       )
       .then(() => true)
       .catch(() => false);
-    await continueButton.click();
+    await page.getByLabel("Email").press("Enter");
     submitted = await formRequest;
     if (!submitted) {
       await expect(continueButton).toBeEnabled();

--- a/tests/e2e/strict-skip-reporter.ts
+++ b/tests/e2e/strict-skip-reporter.ts
@@ -1,11 +1,34 @@
 import type { FullResult, Reporter, TestCase, TestResult } from '@playwright/test/reporter';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+type ExclusionWriter = (excluded: string[]) => Promise<void>;
 
 export class StrictSkipReporter implements Reporter {
   private readonly requireAll: boolean;
+  private readonly allowPreviewOAuthExclusion: boolean;
+  private readonly writeExclusions: ExclusionWriter;
   private readonly skipped: string[] = [];
 
-  constructor(options: { requireAll?: boolean } = {}) {
+  constructor(
+    options: {
+      requireAll?: boolean;
+      allowPreviewOAuthExclusion?: boolean;
+      writeExclusions?: ExclusionWriter;
+    } = {},
+  ) {
     this.requireAll = options.requireAll ?? process.env.E2E_REQUIRE_ALL_BROWSER === '1';
+    this.allowPreviewOAuthExclusion =
+      options.allowPreviewOAuthExclusion ??
+      process.env.E2E_ALLOW_PREVIEW_OAUTH_EXCLUSION === '1';
+    this.writeExclusions = options.writeExclusions ?? (async (excluded) => {
+      const output = resolve(process.cwd(), 'test-results/browser-exclusions.json');
+      await mkdir(resolve(output, '..'), { recursive: true });
+      await writeFile(
+        output,
+        `${JSON.stringify({ excluded, count: excluded.length }, null, 2)}\n`,
+      );
+    });
   }
 
   onTestEnd(test: TestCase, result: TestResult): void {
@@ -13,10 +36,19 @@ export class StrictSkipReporter implements Reporter {
   }
 
   async onEnd(_result: FullResult): Promise<{ status: 'failed' } | undefined> {
-    if (!this.requireAll || this.skipped.length === 0) return undefined;
+    if (this.skipped.length === 0) return undefined;
+    await this.writeExclusions(this.skipped);
+    const unauthorized = this.skipped.filter(
+      (title) =>
+        !(
+          this.allowPreviewOAuthExclusion &&
+          title.includes('17 — OAuth provider initiation')
+        ),
+    );
+    if (!this.requireAll || unauthorized.length === 0) return undefined;
     process.stderr.write(
-      `[browser] strict target excluded ${this.skipped.length} journey(s):\n` +
-        `${this.skipped.map((title) => `- ${title}`).join('\n')}\n`,
+      `[browser] strict target excluded ${unauthorized.length} unauthorized journey(s):\n` +
+        `${unauthorized.map((title) => `- ${title}`).join('\n')}\n`,
     );
     return { status: 'failed' };
   }

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -6,10 +6,9 @@ const environmentProtectionPassword = process.env.WEB_PROTECTION_PASSWORD;
 export function resolveBrowserWorkers(value: string | undefined, ci: boolean): number {
   const configuredWorkers = Number.parseInt(value ?? '', 10);
   if (Number.isFinite(configuredWorkers) && configuredWorkers > 0) return configuredWorkers;
-  // Daytona provides the organization maximum of 12 GiB. Two browsers can
-  // make Next dev compile separate project routes concurrently and kill the
-  // web process. One worker keeps the local black-box stack stable. Deployed
-  // target runs set E2E_BROWSER_WORKERS explicitly.
+  // The warm Daytona lane has 6 vCPU and 12 GiB RAM. One worker keeps cold
+  // Next.js route compilation below the guest memory limit. Deployed target
+  // runs can override this independently.
   if (ci) return 1;
   return 4;
 }

--- a/tests/src/core/daytona-ci.ts
+++ b/tests/src/core/daytona-ci.ts
@@ -368,7 +368,7 @@ async function ensureBaseSnapshot(
   return waitForSnapshot(api, created);
 }
 
-async function waitForSandbox(api: DaytonaApi, sandbox: DaytonaSandbox): Promise<DaytonaSandbox> {
+export async function waitForSandbox(api: DaytonaApi, sandbox: DaytonaSandbox): Promise<DaytonaSandbox> {
   const deadline = Date.now() + SANDBOX_TIMEOUT_MS;
   let current = sandbox;
   let lastState = '';
@@ -392,7 +392,7 @@ async function waitForSandbox(api: DaytonaApi, sandbox: DaytonaSandbox): Promise
   );
 }
 
-async function getSandboxByName(api: DaytonaApi, name: string): Promise<DaytonaSandbox | null> {
+export async function getSandboxByName(api: DaytonaApi, name: string): Promise<DaytonaSandbox | null> {
   try {
     return await api.json<DaytonaSandbox>(
       `/sandbox/${encodeURIComponent(name)}`,
@@ -452,7 +452,7 @@ function toolboxBase(sandbox: DaytonaSandbox): string {
   return `${sandbox.toolboxProxyUrl.replace(/\/+$/, '')}/${encodeURIComponent(sandbox.id)}`;
 }
 
-async function execute(
+export async function execute(
   api: DaytonaApi,
   sandbox: DaytonaSandbox,
   command: string,
@@ -506,7 +506,7 @@ rm -rf /var/lib/docker/tmp /var/lib/docker/runtimes
 `;
 }
 
-async function deleteSandbox(api: DaytonaApi, idOrName: string): Promise<void> {
+export async function deleteSandbox(api: DaytonaApi, idOrName: string): Promise<void> {
   try {
     await api.json(`/sandbox/${encodeURIComponent(idOrName)}`, { method: 'DELETE' });
   } catch (error) {
@@ -549,7 +549,7 @@ async function waitForWarmSnapshotOwner(
   );
 }
 
-async function ensureWarmSnapshot(
+export async function ensureWarmSnapshot(
   api: DaytonaApi,
   input: DaytonaCiInput,
   lockHash: string,
@@ -682,7 +682,7 @@ async function ensureWarmSnapshot(
   }
 }
 
-async function readRemoteExitCode(
+export async function readRemoteExitCode(
   api: DaytonaApi,
   sandbox: DaytonaSandbox,
   path: string,
@@ -702,7 +702,7 @@ async function readRemoteExitCode(
   return exitCode;
 }
 
-async function statRemoteLog(
+export async function statRemoteLog(
   api: DaytonaApi,
   sandbox: DaytonaSandbox,
   path: string,
@@ -722,7 +722,7 @@ async function statRemoteLog(
   return { size };
 }
 
-async function readRemoteLog(
+export async function readRemoteLog(
   api: DaytonaApi,
   sandbox: DaytonaSandbox,
   path: string,
@@ -740,7 +740,7 @@ async function readRemoteLog(
   return Uint8Array.from(Buffer.from(result.result.trim(), 'base64'));
 }
 
-async function downloadArtifacts(
+export async function downloadArtifacts(
   api: DaytonaApi,
   sandbox: DaytonaSandbox,
   root: string,

--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -44,6 +44,7 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
   const packagesOnly = args.includes('--packages-only');
   const targetSmoke = args.includes('--target-smoke');
   const targetFull = args.includes('--target-full');
+  const browserShardArgs = args.filter((arg) => arg.startsWith('--browser-shard='));
   const modes = [
     full,
     flowsOnly,
@@ -58,6 +59,21 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
       'choose only one of --full, --flows-only, --sdk-only, --browser-only, --packages-only, --target-smoke, or --target-full',
     );
   }
+  if (browserShardArgs.length > 1) {
+    throw new Error('choose only one --browser-shard value');
+  }
+  const browserShard = browserShardArgs[0]?.slice('--browser-shard='.length);
+  if (browserShardArgs.length === 1) {
+    const match = browserShard.match(/^(\d+)\/(\d+)$/);
+    const current = Number(match?.[1]);
+    const total = Number(match?.[2]);
+    if (!match || current < 1 || total < 2 || current > total) {
+      throw new Error('--browser-shard must use CURRENT/TOTAL with 1 <= CURRENT <= TOTAL');
+    }
+    if (!browserOnly) {
+      throw new Error('--browser-shard requires --browser-only');
+    }
+  }
 
   const flowArgs = args.filter(
     (arg) =>
@@ -67,7 +83,8 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
       arg !== '--browser-only' &&
       arg !== '--packages-only' &&
       arg !== '--target-smoke' &&
-      arg !== '--target-full',
+      arg !== '--target-full' &&
+      !arg.startsWith('--browser-shard='),
   );
   const flows: LocalTestLane = {
     name: 'api-cli-flows',
@@ -91,7 +108,12 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
   };
   const browser: LocalTestLane = {
     name: 'browser',
-    command: ['bun', 'run', 'test:browser'],
+    command: [
+      'bun',
+      'run',
+      'test:browser',
+      ...(browserShard ? ['--', `--shard=${browserShard}`] : []),
+    ],
     cwd: 'tests',
   };
   const packageQuality: LocalTestLane = {
@@ -120,9 +142,12 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
       E2E_BROWSER_WORKERS: '2',
       E2E_ENABLE_SDK_ONLY_SESSION: '1',
       E2E_ENABLE_SANDBOX_TEMPLATE_BUILD: '1',
-      E2E_OAUTH_PROVIDER_INITIATION: '1',
+      E2E_OAUTH_PROVIDER_INITIATION: process.env.KE2E_TARGET === 'preview' ? '0' : '1',
       E2E_ENABLE_BILLING_JOURNEY: '1',
       E2E_REQUIRE_ALL_BROWSER: '1',
+      ...(process.env.KE2E_TARGET === 'preview'
+        ? { E2E_ALLOW_PREVIEW_OAUTH_EXCLUSION: '1' }
+        : {}),
     },
   };
 
@@ -241,9 +266,14 @@ async function runLane(root: string, lane: LocalTestLane): Promise<LaneResult> {
         'KE2E_DATABASE_URL',
         'KE2E_STRIPE_SECRET_KEY',
         'KE2E_STRIPE_WEBHOOK_SECRET',
-        'E2E_AGENTMAIL_API_KEY',
       ] as const;
       const missing = required.filter((name) => !process.env[name]?.trim());
+      if (
+        !process.env.E2E_AGENTMAIL_API_KEY?.trim() &&
+        !process.env.E2E_MAILPIT_URL?.trim()
+      ) {
+        missing.push('E2E_AGENTMAIL_API_KEY or E2E_MAILPIT_URL' as never);
+      }
       if (missing.length > 0) {
         throw new Error(`deployed browser suite requires ${missing.join(', ')}`);
       }

--- a/tests/src/core/platinum-ci.ts
+++ b/tests/src/core/platinum-ci.ts
@@ -124,6 +124,7 @@ export interface PlatinumSandbox {
   via?: 'restore' | 'cold-boot';
   metadata?: Record<string, unknown>;
   errorMessage?: string | null;
+  exposed?: Array<{ port: number; url: string; token?: string; public?: boolean }>;
 }
 
 interface PlatinumSandboxPage {
@@ -356,6 +357,10 @@ export function buildWorkerScript(input: {
   const provider = input.provider ?? 'platinum';
   const command = ['pnpm', 'test', ...(input.testArgs.length ? ['--', ...input.testArgs] : [])];
   const testCommand = command.map(shellQuote).join(' ');
+  const prestartSupabase = input.testArgs.includes('--browser-only')
+    ? `pnpm exec supabase start --ignore-health-check
+echo "[${provider}-ci] supabase_prestarted=1"`
+    : '';
   const providerLogs =
     provider === 'daytona'
       ? '/workspace/daytona-bootstrap.log /workspace/daytona-warm.log /workspace/daytona-dockerd.log'
@@ -431,6 +436,7 @@ echo "[${provider}-ci] docker_ready=1"
 docker network inspect bridge --format '{{.Driver}}' | grep -qx bridge
 echo "[${provider}-ci] docker_bridge_ready=1"
 
+${prestartSupabase}
 ${testCommand}
 `;
 }
@@ -439,7 +445,7 @@ export function platinumWorkerLaunchCommand(): string {
   return 'setsid -f /workspace/run-kortix-tests.sh >/workspace/kortix-bootstrap.log 2>&1 </dev/null';
 }
 
-class PlatinumApi {
+export class PlatinumApi {
   readonly base: string;
   readonly headers: Record<string, string>;
 
@@ -629,7 +635,7 @@ async function waitForTemplate(api: PlatinumApi, template: PlatinumTemplate): Pr
   throw new Error(`Platinum template ${template.id} did not become ready within ${TEMPLATE_TIMEOUT_MS}ms`);
 }
 
-async function ensureTemplate(
+export async function ensureTemplate(
   api: PlatinumApi,
   spec: PlatinumTemplateSpec,
 ): Promise<PlatinumTemplate> {
@@ -654,7 +660,7 @@ async function ensureTemplate(
   return waitForTemplate(api, queued);
 }
 
-async function ensureWarmTemplate(
+export async function ensureWarmTemplate(
   api: PlatinumApi,
   base: PlatinumTemplate,
   lockHash: string,
@@ -740,7 +746,7 @@ export async function observePlatinumSandboxStart(input: {
   );
 }
 
-async function waitForWarmSandbox(api: PlatinumApi, sandboxId: string): Promise<void> {
+export async function waitForWarmSandbox(api: PlatinumApi, sandboxId: string): Promise<void> {
   const deadline = Date.now() + PLATINUM_CI_WARM_TIMEOUT_MS;
   let observationFailures = 0;
   while (Date.now() < deadline) {
@@ -782,7 +788,7 @@ async function waitForWarmSandbox(api: PlatinumApi, sandboxId: string): Promise<
   );
 }
 
-async function exec(
+export async function exec(
   api: PlatinumApi,
   sandboxId: string,
   command: string[],
@@ -798,7 +804,7 @@ async function exec(
   return response.result;
 }
 
-async function stat(
+export async function stat(
   api: PlatinumApi,
   sandboxId: string,
   path: string,
@@ -935,7 +941,7 @@ async function streamWorker(
   });
 }
 
-async function downloadArtifacts(
+export async function downloadArtifacts(
   api: PlatinumApi,
   sandboxId: string,
   root: string,

--- a/tests/src/core/preview-stack.ts
+++ b/tests/src/core/preview-stack.ts
@@ -1,0 +1,253 @@
+export const PREVIEW_RUNTIME_SECRET_ALLOWLIST = [
+  'DAYTONA_API_KEY',
+  'KE2E_STRIPE_SECRET_KEY',
+  'KE2E_STRIPE_WEBHOOK_SECRET',
+  'KORTIX_GITHUB_APP_ID',
+  'KORTIX_GITHUB_APP_PRIVATE_KEY',
+  'KORTIX_GITHUB_APP_SLUG',
+  'MANAGED_GIT_GITHUB_INSTALL_ID',
+  'MANAGED_GIT_GITHUB_OWNER',
+  'OPENROUTER_API_KEY',
+] as const;
+
+export type PreviewRuntimeSecretName = (typeof PREVIEW_RUNTIME_SECRET_ALLOWLIST)[number];
+export type PreviewRuntimeSecrets = Partial<Record<PreviewRuntimeSecretName, string>>;
+
+export interface PreviewStackInput {
+  origin: string;
+  sha: string;
+  apiImage: string;
+  gatewayImage: string;
+  frontendImage: string;
+}
+
+function validatedOrigin(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' || url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('preview origin must be an HTTPS origin without a path');
+  }
+  return url.origin;
+}
+
+function validatedValue(value: string, key: string): string {
+  if (/[\r\n\0]/.test(value)) throw new Error(`${key} contains an invalid control character`);
+  return value;
+}
+
+function parseEnvironment(text: string): Record<string, string> {
+  const environment: Record<string, string> = {};
+  for (const raw of text.split(/\r?\n/)) {
+    if (!raw || raw.startsWith('#') || !raw.includes('=')) continue;
+    const separator = raw.indexOf('=');
+    environment[raw.slice(0, separator)] = raw.slice(separator + 1);
+  }
+  return environment;
+}
+
+function renderEnvironment(environment: Record<string, string>): string {
+  return `${Object.entries(environment)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${validatedValue(value, key)}`)
+    .join('\n')}\n`;
+}
+
+export function validatePreviewRuntimeSecrets(
+  secrets: Record<string, string>,
+): asserts secrets is PreviewRuntimeSecrets {
+  const allowed = new Set<string>(PREVIEW_RUNTIME_SECRET_ALLOWLIST);
+  const unexpected = Object.keys(secrets).filter((key) => !allowed.has(key));
+  if (unexpected.length > 0) {
+    throw new Error(`preview runtime secret is not allowlisted: ${unexpected.sort().join(', ')}`);
+  }
+  for (const [key, value] of Object.entries(secrets)) {
+    if (key === 'KORTIX_GITHUB_APP_PRIVATE_KEY') {
+      if (value.includes('\0')) throw new Error(`${key} contains an invalid control character`);
+    } else {
+      validatedValue(value, key);
+    }
+  }
+}
+
+export function buildPreviewCaddyfile(): string {
+  return `:8080 {
+  encode zstd gzip
+
+  @api path /v1*
+  handle @api {
+    reverse_proxy kortix-api:8008
+  }
+
+  @supabase path /auth/v1* /rest/v1* /storage/v1* /realtime/v1* /functions/v1* /graphql/v1*
+  handle @supabase {
+    reverse_proxy supabase-kong:8000
+  }
+
+  handle_path /_gateway/* {
+    reverse_proxy llm-gateway:8090
+  }
+
+  handle_path /_tests/* {
+    root * /reports
+    file_server browse
+  }
+
+  handle_path /_mailpit/* {
+    reverse_proxy mailpit:8025
+  }
+
+  handle {
+    reverse_proxy frontend:3000
+  }
+}
+`;
+}
+
+export function buildPreviewComposeOverlay(
+  reportPath: string,
+  caddyfilePath = '/workspace/kortix-preview/Caddyfile.preview',
+): string {
+  if (!reportPath.startsWith('/') || !caddyfilePath.startsWith('/')) {
+    throw new Error('preview bind mounts require absolute paths');
+  }
+  validatedValue(reportPath, 'reportPath');
+  validatedValue(caddyfilePath, 'caddyfilePath');
+  return `services:
+  preview-edge:
+    image: caddy:2.10.2-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
+    ports:
+      - "0.0.0.0:8080:8080"
+    volumes:
+      - "${caddyfilePath}:/etc/caddy/Caddyfile:ro"
+      - "${reportPath}:/reports:ro"
+    depends_on:
+      frontend:
+        condition: service_healthy
+      kortix-api:
+        condition: service_healthy
+      supabase-kong:
+        condition: service_healthy
+      mailpit:
+        condition: service_started
+    restart: unless-stopped
+  mailpit:
+    image: axllent/mailpit:v1.27.8@sha256:6abc8e633df15eaf785cfcf38bae48e66f64beecdc03121e249d0f9ec15f0707
+    restart: unless-stopped
+  supabase-db:
+    ports:
+      - "127.0.0.1:15432:5432"
+`;
+}
+
+export function applyPreviewEnvironment(
+  baseEnvironmentText: string,
+  input: PreviewStackInput,
+  rawSecrets: Record<string, string>,
+): { runtimeEnv: string; testEnv: string } {
+  validatePreviewRuntimeSecrets(rawSecrets);
+  if (!/^[0-9a-f]{40}$/.test(input.sha)) throw new Error('preview SHA must contain 40 hex characters');
+  const origin = validatedOrigin(input.origin);
+  const runtime = parseEnvironment(baseEnvironmentText);
+  const postgresPassword = runtime.POSTGRES_PASSWORD;
+  const anonKey = runtime.SUPABASE_ANON_KEY;
+  const serviceRoleKey = runtime.SUPABASE_SERVICE_ROLE_KEY;
+  const internalServiceKey = runtime.INTERNAL_SERVICE_KEY;
+  if (!postgresPassword || !anonKey || !serviceRoleKey || !internalServiceKey) {
+    throw new Error('self-host environment is missing generated preview credentials');
+  }
+  const managedGitValues = [
+    rawSecrets.KORTIX_GITHUB_APP_ID,
+    rawSecrets.KORTIX_GITHUB_APP_PRIVATE_KEY,
+    rawSecrets.KORTIX_GITHUB_APP_SLUG,
+    rawSecrets.MANAGED_GIT_GITHUB_INSTALL_ID,
+    rawSecrets.MANAGED_GIT_GITHUB_OWNER,
+  ];
+  const managedGitEnabled = managedGitValues.every((value) => Boolean(value?.trim()));
+  if (!managedGitEnabled) {
+    throw new Error('preview target-full requires the complete managed GitHub App configuration');
+  }
+
+  Object.assign(runtime, {
+    API_IMAGE: input.apiImage,
+    GATEWAY_IMAGE: input.gatewayImage,
+    FRONTEND_IMAGE: input.frontendImage,
+    KORTIX_VERSION: `pr-${input.sha}`,
+    KORTIX_COMMIT: input.sha,
+    INTERNAL_KORTIX_ENV: 'preview',
+    ENV_MODE: 'local',
+    PUBLIC_URL: origin,
+    API_PUBLIC_URL: origin,
+    SUPABASE_PUBLIC_URL: origin,
+    KORTIX_URL: origin,
+    FRONTEND_URL: origin,
+    SITE_URL: origin,
+    API_EXTERNAL_URL: `${origin}/auth/v1`,
+    ADDITIONAL_REDIRECT_URLS: `${origin}/auth/callback`,
+    CORS_ALLOWED_ORIGINS: origin,
+    KORTIX_PUBLIC_APP_URL: origin,
+    KORTIX_PUBLIC_AUTH_METHODS: 'magic,password',
+    KORTIX_PUBLIC_DISABLE_LANDING_PAGE: 'true',
+    KORTIX_RESTRICT_ACCOUNT_CREATION: 'false',
+    KORTIX_PUBLIC_RESTRICT_ACCOUNT_CREATION: 'false',
+    KORTIX_BILLING_INTERNAL_ENABLED: 'true',
+    KORTIX_PUBLIC_BILLING_ENABLED: 'true',
+    KORTIX_WORKERS_ENABLED: 'false',
+    SCHEDULER_ENABLED: 'false',
+    KORTIX_TRIGGER_SCHEDULER_ENABLED: 'false',
+    EMAIL_PROVIDER_ORDER: 'mailpit',
+    MAILPIT_API_URL: 'http://mailpit:8025',
+    SMTP_HOST: 'mailpit',
+    SMTP_PORT: '1025',
+    SMTP_USER: 'unused',
+    SMTP_PASS: 'unused',
+    ENABLE_EMAIL_AUTOCONFIRM: 'false',
+    ALLOWED_SANDBOX_PROVIDERS: 'daytona',
+    DATABASE_URL: `postgresql://postgres:${postgresPassword}@supabase-db:5432/postgres`,
+    DAYTONA_API_KEY: rawSecrets.DAYTONA_API_KEY ?? '',
+    MANAGED_GIT_PROVIDER: 'github',
+    MANAGED_GIT_GITHUB_OWNER: rawSecrets.MANAGED_GIT_GITHUB_OWNER ?? '',
+    MANAGED_GIT_GITHUB_INSTALL_ID: rawSecrets.MANAGED_GIT_GITHUB_INSTALL_ID ?? '',
+    KORTIX_GITHUB_APP_ID: rawSecrets.KORTIX_GITHUB_APP_ID ?? '',
+    KORTIX_GITHUB_APP_PRIVATE_KEY:
+      rawSecrets.KORTIX_GITHUB_APP_PRIVATE_KEY?.replace(/\r?\n/g, '\\n') ?? '',
+    KORTIX_GITHUB_APP_SLUG: rawSecrets.KORTIX_GITHUB_APP_SLUG ?? '',
+    OPENROUTER_API_KEY: rawSecrets.OPENROUTER_API_KEY ?? '',
+    STRIPE_SECRET_KEY: rawSecrets.KE2E_STRIPE_SECRET_KEY ?? '',
+    STRIPE_WEBHOOK_SECRET: rawSecrets.KE2E_STRIPE_WEBHOOK_SECRET ?? '',
+  });
+
+  const testEnvironment: Record<string, string> = {
+    CI: '1',
+    KE2E_TARGET: 'preview',
+    KE2E_LIVE_CONFIRM: 'preview',
+    KE2E_PREVIEW_ORIGIN: origin,
+    KE2E_PREVIEW_AUTHORIZATION: `approved:${input.sha}`,
+    KE2E_EXPECT_SHA: input.sha,
+    KE2E_API_URL: `${origin}/v1`,
+    E2E_API_URL: `${origin}/v1`,
+    KE2E_BASE_URL: origin,
+    E2E_BASE_URL: origin,
+    KE2E_GATEWAY_URL: `${origin}/_gateway`,
+    KE2E_SUPABASE_URL: origin,
+    E2E_SUPABASE_URL: origin,
+    E2E_MAILPIT_URL: `${origin}/_mailpit`,
+    KE2E_DATABASE_URL: `postgresql://postgres:${postgresPassword}@127.0.0.1:15432/postgres`,
+    E2E_DATABASE_URL: `postgresql://postgres:${postgresPassword}@127.0.0.1:15432/postgres`,
+    KE2E_SUPABASE_ANON_KEY: anonKey,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: anonKey,
+    KE2E_SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+    SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+    KE2E_INTERNAL_SERVICE_KEY: internalServiceKey,
+    KE2E_STRIPE_SECRET_KEY: rawSecrets.KE2E_STRIPE_SECRET_KEY ?? '',
+    KE2E_STRIPE_WEBHOOK_SECRET: rawSecrets.KE2E_STRIPE_WEBHOOK_SECRET ?? '',
+    E2E_AGENTMAIL_API_KEY: '',
+    KE2E_CAP_DAYTONA: rawSecrets.DAYTONA_API_KEY ? '1' : '0',
+    KE2E_CAP_MANAGED_GIT: managedGitEnabled ? '1' : '0',
+    KE2E_CAP_MANAGED_GIT_PUSH: managedGitEnabled ? '1' : '0',
+    KE2E_DEFAULT_FLOW_ATTEMPTS: '1',
+  };
+
+  return {
+    runtimeEnv: renderEnvironment(runtime),
+    testEnv: renderEnvironment(testEnvironment),
+  };
+}

--- a/tests/src/core/sandbox-preview-providers.ts
+++ b/tests/src/core/sandbox-preview-providers.ts
@@ -1,0 +1,494 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import {
+  DaytonaApi,
+  type DaytonaCiInput,
+  type DaytonaSandbox,
+  createDaytonaSandbox,
+  deleteSandbox as deleteDaytonaSandbox,
+  downloadArtifacts as downloadDaytonaArtifacts,
+  ensureWarmSnapshot,
+  execute as executeDaytona,
+  getSandboxByName,
+  readRemoteExitCode,
+  readRemoteLog,
+  statRemoteLog,
+  waitForSandbox as waitForDaytonaSandbox,
+} from './daytona-ci';
+import {
+  PlatinumApi,
+  type PlatinumSandbox,
+  buildPlatinumTemplateSpec,
+  downloadArtifacts as downloadPlatinumArtifacts,
+  ensureTemplate,
+  ensureWarmTemplate,
+  exec as execPlatinum,
+  observePlatinumSandboxStart,
+  observePlatinumWorker,
+  stat as statPlatinum,
+  waitForWarmSandbox,
+} from './platinum-ci';
+import {
+  PreviewInfrastructureError,
+  type SandboxPreviewResult,
+  buildPreviewBootstrapScript,
+  previewLockfileHash,
+  previewSandboxName,
+  selectStalePreviewSandboxIds,
+} from './sandbox-preview';
+import type { PreviewRuntimeSecrets } from './preview-stack';
+
+const PREVIEW_TIMEOUT_MS = 90 * 60_000;
+const LOG_CHUNK_BYTES = 1024 * 1024;
+
+export interface SandboxPreviewDeploymentInput {
+  repository: string;
+  ref: string;
+  sha: string;
+  prNumber: number;
+  runId: string;
+  runAttempt: string;
+  root: string;
+  lockfileHash: string;
+  secrets: PreviewRuntimeSecrets;
+  platinum: { apiUrl: string; apiKey: string };
+  daytona: { apiUrl: string; apiKey: string; target: string };
+}
+
+interface PlatinumSandboxPage {
+  rows?: PlatinumSandbox[];
+  has_more?: boolean;
+}
+
+interface PreviewLink {
+  url?: string;
+  token?: string;
+}
+
+function encodedFileCommand(path: string, content: string, mode = '0600'): string {
+  if (!/^\/[a-z0-9_./-]+$/i.test(path)) throw new Error(`invalid remote path: ${path}`);
+  return `mkdir -p "$(dirname ${path})" && printf %s ${Buffer.from(content).toString('base64')} | base64 -d > ${path} && chmod ${mode} ${path}`;
+}
+
+function validatedPreviewUrl(value: string | undefined): string {
+  if (!value) throw new Error('sandbox provider did not return a preview URL');
+  const url = new URL(value);
+  if (url.protocol !== 'https:' || url.username || url.password) {
+    throw new Error(`sandbox preview URL must use credential-free HTTPS: ${url.origin}`);
+  }
+  url.pathname = '/';
+  url.search = '';
+  url.hash = '';
+  return url.origin;
+}
+
+async function writeDeploymentResult(
+  root: string,
+  result: SandboxPreviewResult,
+  input: SandboxPreviewDeploymentInput,
+): Promise<void> {
+  const directory = resolve(root, 'tests/test-results/preview');
+  await mkdir(directory, { recursive: true });
+  await writeFile(
+    resolve(directory, 'deployment.json'),
+    `${JSON.stringify(
+      {
+        ...result,
+        repository: input.repository,
+        prNumber: input.prNumber,
+        gitSha: input.sha,
+        reportUrl: result.previewUrl ? `${result.previewUrl}/_tests/` : null,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function allPlatinumPreviewSandboxes(api: PlatinumApi): Promise<PlatinumSandbox[]> {
+  const sandboxes: PlatinumSandbox[] = [];
+  const limit = 100;
+  for (let offset = 0; ; offset += limit) {
+    const page = await api.json<PlatinumSandboxPage>(
+      `/v1/sandboxes?paginated=true&limit=${limit}&offset=${offset}`,
+    );
+    sandboxes.push(...(page.rows ?? []));
+    if (!page.has_more || (page.rows ?? []).length === 0) return sandboxes;
+  }
+}
+
+async function deletePlatinum(api: PlatinumApi, sandboxId: string): Promise<void> {
+  try {
+    await api.json(`/v1/sandboxes/${sandboxId}`, { method: 'DELETE' });
+  } catch (error) {
+    if (!String(error).includes('-> 404:')) throw error;
+  }
+}
+
+async function replaceExistingPlatinumPreview(
+  api: PlatinumApi,
+  prNumber: number,
+): Promise<void> {
+  const name = previewSandboxName(prNumber);
+  const existing = (await allPlatinumPreviewSandboxes(api)).filter(
+    (sandbox) =>
+      sandbox.name === name &&
+      sandbox.metadata?.owner === 'kortix-preview' &&
+      Number(sandbox.metadata?.pr_number) === prNumber,
+  );
+  for (const sandbox of existing) await deletePlatinum(api, sandbox.id);
+}
+
+export async function deployPlatinumPreview(
+  input: SandboxPreviewDeploymentInput,
+): Promise<SandboxPreviewResult> {
+  if (!input.platinum.apiKey) throw new PreviewInfrastructureError('PLATINUM_API_KEY is required');
+  const api = new PlatinumApi(input.platinum.apiUrl, input.platinum.apiKey);
+  let sandboxId = '';
+  let launched = false;
+  try {
+    await replaceExistingPlatinumPreview(api, input.prNumber);
+    const hash = previewLockfileHash(input.lockfileHash);
+    const base = await ensureTemplate(
+      api,
+      buildPlatinumTemplateSpec({
+        lockHash: hash,
+        repository: input.repository,
+        cacheSha: input.sha,
+      }),
+    );
+    const template = await ensureWarmTemplate(api, base, hash);
+    const startedAt = Date.now();
+    const created = await api.json<PlatinumSandbox>(
+      '/v1/sandboxes?wait_for_state=running&wait_timeout_ms=60000',
+      {
+        method: 'POST',
+        headers: { 'idempotency-key': `kortix-preview-${input.prNumber}-${input.sha}` },
+        body: JSON.stringify({
+          name: previewSandboxName(input.prNumber),
+          template: template.id,
+          type: 'persistent',
+          auto_stop_minutes: 0,
+          auto_archive_days: 7,
+          auto_delete_days: 7,
+          cpu: 8,
+          ram_mb: 16_384,
+          disk_gb: 50,
+          expose: [{ port: 8080, public: true }],
+          metadata: {
+            owner: 'kortix-preview',
+            repository: input.repository,
+            pr_number: String(input.prNumber),
+            git_sha: input.sha,
+            run_id: input.runId,
+          },
+        }),
+      },
+    );
+    sandboxId = created.id;
+    const sandbox = await observePlatinumSandboxStart({
+      sandbox: created,
+      startedAt,
+      readSandbox: () => api.json<PlatinumSandbox>(`/v1/sandboxes/${created.id}`),
+    });
+    await waitForWarmSandbox(api, sandboxId);
+    let previewUrl = sandbox.exposed?.find((item) => item.port === 8080)?.url;
+    if (!previewUrl) {
+      const exposed = await api.json<{ url: string }>(`/v1/sandboxes/${sandboxId}/expose`, {
+        method: 'POST',
+        body: JSON.stringify({ port: 8080, public: true }),
+      });
+      previewUrl = exposed.url;
+    }
+    const origin = validatedPreviewUrl(previewUrl);
+    await execPlatinum(api, sandboxId, ['bash', '-lc', 'mkdir -p /workspace/kortix-preview']);
+    await api.write(
+      `${sandboxId}:/workspace/kortix-preview/runtime-secrets.json`,
+      `${JSON.stringify(input.secrets)}\n`,
+      '0600',
+    );
+    await api.write(
+      `${sandboxId}:/workspace/run-kortix-preview.sh`,
+      buildPreviewBootstrapScript({ ...input, origin }),
+      '0755',
+    );
+    const launch = await execPlatinum(api, sandboxId, [
+      'bash',
+      '-lc',
+      'setsid -f /workspace/run-kortix-preview.sh >/workspace/kortix-preview/bootstrap.log 2>&1 </dev/null',
+    ]);
+    if ((launch.exit_code ?? 0) !== 0) {
+      throw new Error(`Platinum preview launch failed: ${launch.stderr ?? ''}`);
+    }
+    launched = true;
+    const exitCode = await observePlatinumWorker({
+      startedAt: Date.now(),
+      timeoutMs: PREVIEW_TIMEOUT_MS,
+      checkExitCode: async () => {
+        const status = await statPlatinum(api, sandboxId, '/workspace/kortix-preview/kortix-preview.exit', 1);
+        if (!status) return null;
+        const bytes = await api.read(
+          sandboxId,
+          '/workspace/kortix-preview/kortix-preview.exit',
+          undefined,
+          undefined,
+          1,
+        );
+        const value = Number(new TextDecoder().decode(bytes).trim());
+        if (!Number.isInteger(value)) throw new Error('Platinum preview wrote an invalid exit code');
+        return value;
+      },
+      statLog: () => statPlatinum(api, sandboxId, '/workspace/kortix-preview/kortix-preview.log', 1),
+      readLog: (offset, limit) =>
+        api.read(
+          sandboxId,
+          '/workspace/kortix-preview/kortix-preview.log',
+          offset,
+          Math.min(limit, LOG_CHUNK_BYTES),
+          1,
+        ),
+    });
+    const result: SandboxPreviewResult = {
+      provider: 'platinum',
+      exitCode,
+      sandboxId,
+      previewUrl: origin,
+    };
+    await downloadPlatinumArtifacts(api, sandboxId, input.root).catch((error) => {
+      console.warn(`[sandbox-preview] Platinum result download failed: ${String(error)}`);
+    });
+    await writeDeploymentResult(input.root, result, input);
+    return result;
+  } catch (error) {
+    if (launched) throw error;
+    if (sandboxId) await deletePlatinum(api, sandboxId).catch(() => {});
+    throw new PreviewInfrastructureError('Platinum preview infrastructure failed', error);
+  }
+}
+
+async function replaceExistingDaytonaPreview(
+  api: DaytonaApi,
+  prNumber: number,
+): Promise<void> {
+  const existing = await getSandboxByName(api, previewSandboxName(prNumber));
+  if (!existing) return;
+  if (
+    existing.labels?.['kortix-preview'] !== 'true' ||
+    existing.labels?.['kortix-preview-pr'] !== String(prNumber)
+  ) {
+    throw new Error(`refused to replace unowned Daytona sandbox ${existing.id}`);
+  }
+  await deleteDaytonaSandbox(api, existing.id);
+}
+
+export async function deployDaytonaPreview(
+  input: SandboxPreviewDeploymentInput,
+): Promise<SandboxPreviewResult> {
+  if (!input.daytona.apiKey) throw new PreviewInfrastructureError('DAYTONA_API_KEY is required');
+  const api = new DaytonaApi(input.daytona.apiUrl, input.daytona.apiKey);
+  let sandbox: DaytonaSandbox | null = null;
+  let launched = false;
+  try {
+    await replaceExistingDaytonaPreview(api, input.prNumber);
+    const hash = previewLockfileHash(input.lockfileHash);
+    const ciInput: DaytonaCiInput = {
+      apiUrl: input.daytona.apiUrl,
+      apiKey: input.daytona.apiKey,
+      target: input.daytona.target,
+      repository: input.repository,
+      sha: input.sha,
+      ref: input.ref,
+      runId: input.runId,
+      runAttempt: input.runAttempt,
+      testArgs: [],
+      root: input.root,
+    };
+    const snapshot = await ensureWarmSnapshot(api, ciInput, hash);
+    sandbox = await waitForDaytonaSandbox(
+      api,
+      await createDaytonaSandbox(api, {
+        name: previewSandboxName(input.prNumber),
+        snapshot: snapshot.name,
+        target: input.daytona.target,
+        public: true,
+        autoStopInterval: 0,
+        autoArchiveInterval: 10_080,
+        autoDeleteInterval: 10_080,
+        labels: {
+          'kortix-preview': 'true',
+          'kortix-preview-pr': String(input.prNumber),
+          'kortix-preview-repository': input.repository,
+          'kortix-preview-git-sha': input.sha,
+          'kortix-preview-run-id': input.runId,
+        },
+      }),
+    );
+    const marker = await executeDaytona(
+      api,
+      sandbox,
+      'test -s /workspace/.kortix-ci-warm-ready && ! pgrep -x dockerd >/dev/null && ! pgrep -x containerd >/dev/null',
+      30,
+    );
+    if (marker.exitCode !== 0) throw new Error('Daytona preview did not restore the warm marker');
+    const link = await api.json<PreviewLink>(
+      `/sandbox/${encodeURIComponent(sandbox.id)}/ports/8080/preview-url`,
+    );
+    const origin = validatedPreviewUrl(link.url);
+    const secretsUpload = await executeDaytona(
+      api,
+      sandbox,
+      encodedFileCommand(
+        '/workspace/kortix-preview/runtime-secrets.json',
+        `${JSON.stringify(input.secrets)}\n`,
+      ),
+      60,
+    );
+    if (secretsUpload.exitCode !== 0) throw new Error(`Daytona secret upload failed: ${secretsUpload.result}`);
+    const scriptUpload = await executeDaytona(
+      api,
+      sandbox,
+      encodedFileCommand(
+        '/workspace/run-kortix-preview.sh',
+        buildPreviewBootstrapScript({ ...input, origin }),
+        '0755',
+      ),
+      60,
+    );
+    if (scriptUpload.exitCode !== 0) throw new Error(`Daytona script upload failed: ${scriptUpload.result}`);
+    const launch = await executeDaytona(
+      api,
+      sandbox,
+      'setsid -f /workspace/run-kortix-preview.sh >/workspace/kortix-preview/bootstrap.log 2>&1 </dev/null',
+      30,
+    );
+    if (launch.exitCode !== 0) throw new Error(`Daytona preview launch failed: ${launch.result}`);
+    launched = true;
+    const exitCode = await observePlatinumWorker({
+      startedAt: Date.now(),
+      timeoutMs: PREVIEW_TIMEOUT_MS,
+      checkExitCode: () =>
+        readRemoteExitCode(
+          api,
+          sandbox!,
+          '/workspace/kortix-preview/kortix-preview.exit',
+          'preview',
+        ),
+      statLog: () =>
+        statRemoteLog(api, sandbox!, '/workspace/kortix-preview/kortix-preview.log', 'preview'),
+      readLog: (offset, limit) =>
+        readRemoteLog(
+          api,
+          sandbox!,
+          '/workspace/kortix-preview/kortix-preview.log',
+          offset,
+          Math.min(limit, LOG_CHUNK_BYTES),
+          'preview',
+        ),
+    });
+    const result: SandboxPreviewResult = {
+      provider: 'daytona',
+      exitCode,
+      sandboxId: sandbox.id,
+      previewUrl: origin,
+    };
+    await downloadDaytonaArtifacts(api, sandbox, input.root).catch((error) => {
+      console.warn(`[sandbox-preview] Daytona result download failed: ${String(error)}`);
+    });
+    await writeDeploymentResult(input.root, result, input);
+    return result;
+  } catch (error) {
+    if (launched) throw error;
+    if (sandbox) await deleteDaytonaSandbox(api, sandbox.id).catch(() => {});
+    throw new PreviewInfrastructureError('Daytona preview infrastructure failed', error);
+  }
+}
+
+export async function teardownPlatinumPreview(input: {
+  apiUrl: string;
+  apiKey: string;
+  prNumber: number;
+}): Promise<number> {
+  if (!input.apiKey) return 0;
+  const api = new PlatinumApi(input.apiUrl, input.apiKey);
+  const name = previewSandboxName(input.prNumber);
+  const owned = (await allPlatinumPreviewSandboxes(api)).filter(
+    (sandbox) =>
+      sandbox.name === name &&
+      sandbox.metadata?.owner === 'kortix-preview' &&
+      Number(sandbox.metadata?.pr_number) === input.prNumber,
+  );
+  for (const sandbox of owned) await deletePlatinum(api, sandbox.id);
+  return owned.length;
+}
+
+export async function teardownDaytonaPreview(input: {
+  apiUrl: string;
+  apiKey: string;
+  prNumber: number;
+}): Promise<number> {
+  if (!input.apiKey) return 0;
+  const api = new DaytonaApi(input.apiUrl, input.apiKey);
+  const sandbox = await getSandboxByName(api, previewSandboxName(input.prNumber));
+  if (!sandbox) return 0;
+  if (
+    sandbox.labels?.['kortix-preview'] !== 'true' ||
+    sandbox.labels?.['kortix-preview-pr'] !== String(input.prNumber)
+  ) {
+    throw new Error(`refused to delete unowned Daytona sandbox ${sandbox.id}`);
+  }
+  await deleteDaytonaSandbox(api, sandbox.id);
+  return 1;
+}
+
+export async function reconcilePlatinumPreviews(input: {
+  apiUrl: string;
+  apiKey: string;
+  activePullRequests: ReadonlyMap<number, string>;
+}): Promise<number> {
+  if (!input.apiKey) return 0;
+  const api = new PlatinumApi(input.apiUrl, input.apiKey);
+  const sandboxes = await allPlatinumPreviewSandboxes(api);
+  const stale = selectStalePreviewSandboxIds(sandboxes, input.activePullRequests);
+  for (const sandboxId of stale) await deletePlatinum(api, sandboxId);
+  return stale.length;
+}
+
+interface DaytonaSandboxPage {
+  items?: DaytonaSandbox[];
+  nextCursor?: string | null;
+}
+
+async function allDaytonaPreviewSandboxes(api: DaytonaApi): Promise<DaytonaSandbox[]> {
+  const sandboxes: DaytonaSandbox[] = [];
+  let cursor = '';
+  do {
+    const query = new URLSearchParams({ limit: '100', labels: 'kortix-preview=true' });
+    if (cursor) query.set('cursor', cursor);
+    const page = await api.json<DaytonaSandboxPage>(`/sandbox?${query}`);
+    sandboxes.push(...(page.items ?? []));
+    cursor = page.nextCursor ?? '';
+  } while (cursor);
+  return sandboxes;
+}
+
+export async function reconcileDaytonaPreviews(input: {
+  apiUrl: string;
+  apiKey: string;
+  activePullRequests: ReadonlyMap<number, string>;
+}): Promise<number> {
+  if (!input.apiKey) return 0;
+  const api = new DaytonaApi(input.apiUrl, input.apiKey);
+  const sandboxes = await allDaytonaPreviewSandboxes(api);
+  const records = sandboxes.map((sandbox) => ({
+    id: sandbox.id,
+    metadata: {
+      owner: sandbox.labels?.['kortix-preview'] === 'true' ? 'kortix-preview' : '',
+      pr_number: sandbox.labels?.['kortix-preview-pr'],
+      git_sha: sandbox.labels?.['kortix-preview-git-sha'],
+    },
+  }));
+  const stale = selectStalePreviewSandboxIds(records, input.activePullRequests);
+  for (const sandboxId of stale) await deleteDaytonaSandbox(api, sandboxId);
+  return stale.length;
+}

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -1,0 +1,180 @@
+export type SandboxPreviewProvider = 'auto' | 'platinum' | 'daytona';
+
+export interface SandboxPreviewInput {
+  provider: SandboxPreviewProvider;
+  prNumber: number;
+  repository: string;
+  sha: string;
+}
+
+export interface SandboxPreviewResult {
+  provider: 'platinum' | 'daytona';
+  exitCode: number;
+  sandboxId?: string;
+  previewUrl?: string;
+}
+
+export function previewLockfileHash(value: string): string {
+  const hash = value.trim().toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(hash)) {
+    throw new Error('preview lockfile hash must contain 64 hex characters');
+  }
+  return hash;
+}
+
+export interface PreviewSandboxRecord {
+  id: string;
+  metadata?: Record<string, unknown>;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+export function buildPreviewBootstrapScript(input: {
+  repository: string;
+  ref: string;
+  sha: string;
+  prNumber: number;
+  origin: string;
+}): string {
+  if (!/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/i.test(input.repository)) {
+    throw new Error(`invalid GitHub repository: ${input.repository}`);
+  }
+  if (!/^[a-z0-9_./-]+$/i.test(input.ref)) throw new Error(`invalid Git ref: ${input.ref}`);
+  if (!/^[a-f0-9]{40}$/i.test(input.sha)) throw new Error(`invalid Git SHA: ${input.sha}`);
+  previewSandboxName(input.prNumber);
+  const origin = new URL(input.origin);
+  if (origin.protocol !== 'https:' || origin.pathname !== '/') {
+    throw new Error('preview origin must be an HTTPS origin');
+  }
+  const instance = `pr-${input.prNumber}`;
+  const state = '/workspace/kortix-preview';
+  const instanceDir = `${state}/self-host/${instance}`;
+  const compose = `docker compose --project-name kortix-${instance} --env-file ${instanceDir}/.env -f ${instanceDir}/docker-compose.yml -f ${state}/docker-compose.preview.yml`;
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=/workspace/suna
+STATE=${state}
+LOG="$STATE/kortix-preview.log"
+STATUS="$STATE/kortix-preview.exit"
+PHASE="$STATE/kortix-preview.phase"
+SECRETS="$STATE/runtime-secrets.json"
+export HOME=/root
+export CI=1
+export KORTIX_SELF_HOST_CONFIG_DIR="$STATE/self-host"
+
+mkdir -p "$STATE" "$ROOT/tests/test-results"
+rm -f "$STATUS" "$PHASE"
+exec > >(tee -a "$LOG") 2>&1
+
+finish() {
+  local code="$1"
+  set +e
+  tar -czf /workspace/kortix-test-results.tar.gz -C "$ROOT" tests/test-results
+  printf '%s\n' "$code" > "$STATUS"
+}
+trap 'code=$?; finish "$code"' EXIT
+
+printf 'checkout\n' > "$PHASE"
+test -d "$ROOT/.git"
+git -C "$ROOT" remote set-url origin ${shellQuote(`https://github.com/${input.repository}.git`)}
+git -C "$ROOT" fetch --depth=1 origin ${shellQuote(input.ref)}
+git -C "$ROOT" checkout --detach --force FETCH_HEAD
+git -C "$ROOT" clean -ffd
+actual_sha="$(git -C "$ROOT" rev-parse HEAD)"
+test "$actual_sha" = "${input.sha}"
+
+cd "$ROOT"
+corepack enable
+pnpm install --offline --frozen-lockfile
+
+printf 'docker\n' > "$PHASE"
+for module in overlay bridge br_netfilter veth nf_tables ip_tables iptable_nat; do
+  modprobe "$module" || true
+done
+if ! docker info >/dev/null 2>&1; then
+  rm -f /var/run/docker.pid /var/run/docker.sock
+  nohup dockerd --host=unix:///var/run/docker.sock > "$STATE/dockerd.log" 2>&1 &
+  timeout 180 sh -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
+fi
+docker info >/dev/null
+
+printf 'configure\n' > "$PHASE"
+bun apps/cli/src/index.ts self-host init --yes --local-images --no-restrict-account-creation --instance ${instance}
+PREVIEW_INSTANCE_DIR=${shellQuote(instanceDir)} \
+PREVIEW_STATE_DIR=${shellQuote(state)} \
+PREVIEW_ORIGIN=${shellQuote(origin.origin)} \
+PREVIEW_SHA=${shellQuote(input.sha)} \
+PREVIEW_SECRETS_FILE="$SECRETS" \
+bun tests/bin/preview-stack.ts
+
+printf 'stack\n' > "$PHASE"
+${compose} pull --policy always frontend kortix-api llm-gateway preview-edge mailpit
+${compose} up -d --wait --wait-timeout 300
+
+for _ in $(seq 1 60); do
+  health="$(curl -fsS --max-time 5 ${shellQuote(`${origin.origin}/v1/health`)} 2>/dev/null || true)"
+  if printf '%s' "$health" | jq -e --arg sha ${shellQuote(input.sha)} '.status == "ok" and .environment == "preview" and .commit == $sha' >/dev/null; then
+    break
+  fi
+  sleep 2
+done
+curl -fsS --max-time 10 ${shellQuote(`${origin.origin}/v1/health`)} | jq -e --arg sha ${shellQuote(input.sha)} '.status == "ok" and .environment == "preview" and .commit == $sha' >/dev/null
+
+printf 'tests\n' > "$PHASE"
+set -a
+source ${shellQuote(`${instanceDir}/.env.test`)}
+set +a
+pnpm test -- --target-full
+
+printf 'ready\n' > "$PHASE"
+`;
+}
+
+export class PreviewInfrastructureError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = 'PreviewInfrastructureError';
+  }
+}
+
+export function previewSandboxName(prNumber: number): string {
+  if (!Number.isSafeInteger(prNumber) || prNumber < 1) {
+    throw new Error(`invalid preview PR number: ${prNumber}`);
+  }
+  return `kortix-preview-pr-${prNumber}`;
+}
+
+export function selectStalePreviewSandboxIds(
+  sandboxes: PreviewSandboxRecord[],
+  activePullRequests: ReadonlyMap<number, string>,
+): string[] {
+  return sandboxes
+    .filter((sandbox) => sandbox.metadata?.owner === 'kortix-preview')
+    .filter((sandbox) => {
+      const prNumber = Number(sandbox.metadata?.pr_number);
+      const activeSha = activePullRequests.get(prNumber);
+      return !activeSha || activeSha !== sandbox.metadata?.git_sha;
+    })
+    .map((sandbox) => sandbox.id);
+}
+
+export async function runSandboxPreview(
+  input: SandboxPreviewInput,
+  runners: {
+    platinum: (input: SandboxPreviewInput) => Promise<SandboxPreviewResult>;
+    daytona: (input: SandboxPreviewInput) => Promise<SandboxPreviewResult>;
+  },
+): Promise<SandboxPreviewResult> {
+  if (input.provider === 'platinum') return runners.platinum(input);
+  if (input.provider === 'daytona') return runners.daytona(input);
+  try {
+    return await runners.platinum(input);
+  } catch (error) {
+    if (!(error instanceof PreviewInfrastructureError)) throw error;
+    console.warn(`[sandbox-preview] Platinum infrastructure failed; fallback=daytona error=${error.message}`);
+    return runners.daytona(input);
+  }
+}

--- a/tests/src/core/target-smoke.ts
+++ b/tests/src/core/target-smoke.ts
@@ -3,6 +3,7 @@ export interface TargetSmokeConfig {
   webUrl: string;
   gatewayUrl: string;
   expectedSha: string;
+  environment: 'staging' | 'preview';
 }
 
 interface ApiHealth {
@@ -33,6 +34,7 @@ function normalizedUrl(value: string, name: string): URL {
 export function resolveTargetSmokeConfig(
   environment: NodeJS.ProcessEnv = process.env,
 ): TargetSmokeConfig {
+  const target = environment.KE2E_TARGET === 'preview' ? 'preview' : 'staging';
   const api = normalizedUrl(
     environment.KE2E_API_URL ?? 'https://staging-api.kortix.com/v1',
     'KE2E_API_URL',
@@ -46,21 +48,47 @@ export function resolveTargetSmokeConfig(
     'KE2E_GATEWAY_URL',
   );
 
-  if (api.hostname !== 'staging-api.kortix.com' || api.pathname !== '/v1') {
-    throw new Error(`target smoke requires https://staging-api.kortix.com/v1; received ${api}`);
-  }
-  if (web.hostname !== 'staging.kortix.com' || web.pathname !== '/') {
-    throw new Error(`target smoke requires https://staging.kortix.com; received ${web}`);
-  }
-  if (gateway.hostname !== 'gateway-staging.kortix.com' || gateway.pathname !== '/') {
-    throw new Error(
-      `target smoke requires https://gateway-staging.kortix.com; received ${gateway}`,
-    );
-  }
-
   const expectedSha = environment.KE2E_EXPECT_SHA?.trim() ?? '';
   if (!/^[0-9a-f]{40}$/.test(expectedSha)) {
-    throw new Error('KE2E_EXPECT_SHA must contain the 40-character staging source SHA');
+    throw new Error('KE2E_EXPECT_SHA must contain the 40-character target source SHA');
+  }
+
+  if (target === 'preview') {
+    const origin = normalizedUrl(environment.KE2E_PREVIEW_ORIGIN ?? '', 'KE2E_PREVIEW_ORIGIN');
+    if (origin.pathname !== '/') {
+      throw new Error('preview origin must not contain a path');
+    }
+    if (environment.KE2E_PREVIEW_AUTHORIZATION !== `approved:${expectedSha}`) {
+      throw new Error('preview target requires approval for the exact expected SHA');
+    }
+    const supabase = normalizedUrl(
+      environment.KE2E_SUPABASE_URL ?? '',
+      'KE2E_SUPABASE_URL',
+    );
+    const sameOrigin = [api, web, gateway, supabase].every(
+      (candidate) => candidate.origin === origin.origin,
+    );
+    if (!sameOrigin) throw new Error('preview API, web, gateway, and Supabase must use one origin');
+    if (
+      api.pathname !== '/v1' ||
+      web.pathname !== '/' ||
+      gateway.pathname !== '/_gateway' ||
+      supabase.pathname !== '/'
+    ) {
+      throw new Error('preview target uses invalid single-origin paths');
+    }
+  } else {
+    if (api.hostname !== 'staging-api.kortix.com' || api.pathname !== '/v1') {
+      throw new Error(`target smoke requires https://staging-api.kortix.com/v1; received ${api}`);
+    }
+    if (web.hostname !== 'staging.kortix.com' || web.pathname !== '/') {
+      throw new Error(`target smoke requires https://staging.kortix.com; received ${web}`);
+    }
+    if (gateway.hostname !== 'gateway-staging.kortix.com' || gateway.pathname !== '/') {
+      throw new Error(
+        `target smoke requires https://gateway-staging.kortix.com; received ${gateway}`,
+      );
+    }
   }
 
   return {
@@ -68,6 +96,7 @@ export function resolveTargetSmokeConfig(
     webUrl: web.toString().replace(/\/$/, ''),
     gatewayUrl: gateway.toString().replace(/\/$/, ''),
     expectedSha,
+    environment: target,
   };
 }
 
@@ -85,15 +114,15 @@ export async function assertTargetSmokeHealth(
     healthJson<ApiHealth>(`${config.apiUrl}/health`, fetchImpl),
     healthJson<GatewayHealth>(`${config.gatewayUrl}/health`, fetchImpl),
   ]);
-  if (api.status !== 'ok' || api.environment !== 'staging') {
-    throw new Error(`staging API health contract failed: ${JSON.stringify(api)}`);
+  if (api.status !== 'ok' || api.environment !== config.environment) {
+    throw new Error(`${config.environment} API health contract failed: ${JSON.stringify(api)}`);
   }
   if (gateway.status !== 'healthy') {
     throw new Error(`staging gateway health contract failed: ${JSON.stringify(gateway)}`);
   }
   if (api.commit !== config.expectedSha || gateway.commit !== config.expectedSha) {
     throw new Error(
-      `staging SHA mismatch: expected=${config.expectedSha} api=${api.commit ?? 'missing'} gateway=${gateway.commit ?? 'missing'}`,
+      `${config.environment} SHA mismatch: expected=${config.expectedSha} api=${api.commit ?? 'missing'} gateway=${gateway.commit ?? 'missing'}`,
     );
   }
 }

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -59,7 +59,35 @@ describe('local test runner', () => {
     });
   });
 
-  it('serializes the local CI browser lane and preserves explicit target concurrency', () => {
+  it('runs one browser shard through the same root command', () => {
+    const plan = buildLocalTestPlan(['--browser-only', '--browser-shard=1/2']);
+
+    expect(plan.mode).toBe('browser');
+    expect(plan.lanes[0]?.command).toEqual([
+      'bun',
+      'run',
+      'test:browser',
+      '--',
+      '--shard=1/2',
+    ]);
+  });
+
+  it('rejects invalid browser shards', () => {
+    expect(() => buildLocalTestPlan(['--browser-only', '--browser-shard='])).toThrow(
+      'CURRENT/TOTAL',
+    );
+    expect(() => buildLocalTestPlan(['--browser-only', '--browser-shard=0/2'])).toThrow(
+      'CURRENT/TOTAL',
+    );
+    expect(() => buildLocalTestPlan(['--browser-only', '--browser-shard=3/2'])).toThrow(
+      'CURRENT/TOTAL',
+    );
+    expect(() => buildLocalTestPlan(['--browser-shard=1/2'])).toThrow(
+      'requires --browser-only',
+    );
+  });
+
+  it('uses one CI browser worker and preserves explicit concurrency', () => {
     expect(resolveBrowserWorkers(undefined, true)).toBe(1);
     expect(resolveBrowserWorkers(undefined, false)).toBe(4);
     expect(resolveBrowserWorkers('2', true)).toBe(2);
@@ -115,6 +143,26 @@ describe('local test runner', () => {
         E2E_REQUIRE_ALL_BROWSER: '1',
       },
     });
+  });
+
+  it('keeps strict browser coverage but records the authorized preview OAuth exclusion', () => {
+    const previous = process.env.KE2E_TARGET;
+    process.env.KE2E_TARGET = 'preview';
+    try {
+      const plan = buildLocalTestPlan(['--target-full']);
+      expect(plan.lanes[1]?.env).toEqual({
+        E2E_BROWSER_WORKERS: '2',
+        E2E_ENABLE_SDK_ONLY_SESSION: '1',
+        E2E_ENABLE_SANDBOX_TEMPLATE_BUILD: '1',
+        E2E_OAUTH_PROVIDER_INITIATION: '0',
+        E2E_ENABLE_BILLING_JOURNEY: '1',
+        E2E_REQUIRE_ALL_BROWSER: '1',
+        E2E_ALLOW_PREVIEW_OAUTH_EXCLUSION: '1',
+      });
+    } finally {
+      if (previous === undefined) delete process.env.KE2E_TARGET;
+      else process.env.KE2E_TARGET = previous;
+    }
   });
 
   it('rejects conflicting modes', () => {

--- a/tests/unit/platinum-ci.test.ts
+++ b/tests/unit/platinum-ci.test.ts
@@ -203,16 +203,26 @@ describe('Platinum CI worker plan', () => {
     expect(script).toContain('tests/test-results/platinum');
   });
 
-  test('lets the root runner own the local stack for every mode', () => {
+  test('prestarts only the disposable browser database and leaves product processes to the root runner', () => {
     const script = buildWorkerScript({
+      repository: 'kortix-ai/suna',
+      ref: sha,
+      sha,
+      testArgs: ['--browser-only'],
+    });
+
+    expect(script).toContain('pnpm exec supabase start --ignore-health-check');
+    expect(script).toContain('supabase_prestarted=1');
+    expect(script).toContain("'pnpm' 'test' '--' '--browser-only'");
+    expect(script).not.toContain('nohup pnpm dev');
+
+    const coreScript = buildWorkerScript({
       repository: 'kortix-ai/suna',
       ref: sha,
       sha,
       testArgs: [],
     });
-
-    expect(script).toContain("'pnpm' 'test'");
-    expect(script).not.toContain('nohup pnpm dev');
+    expect(coreScript).not.toContain('supabase_prestarted=1');
   });
 
   test('detaches the worker with the Platinum-supported setsid contract', () => {

--- a/tests/unit/preview-stack.test.ts
+++ b/tests/unit/preview-stack.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PREVIEW_RUNTIME_SECRET_ALLOWLIST,
+  applyPreviewEnvironment,
+  buildPreviewCaddyfile,
+  buildPreviewComposeOverlay,
+  validatePreviewRuntimeSecrets,
+} from '../src/core/preview-stack';
+
+const SHA = 'a'.repeat(40);
+
+describe('ephemeral self-host preview stack', () => {
+  it('routes every public surface through one origin', () => {
+    const caddy = buildPreviewCaddyfile();
+    expect(caddy).toContain(':8080');
+    expect(caddy).toContain('@api path /v1*');
+    expect(caddy).toContain('reverse_proxy kortix-api:8008');
+    expect(caddy).toContain('@supabase path /auth/v1* /rest/v1* /storage/v1*');
+    expect(caddy).toContain('reverse_proxy supabase-kong:8000');
+    expect(caddy).toContain('handle_path /_gateway/*');
+    expect(caddy).toContain('reverse_proxy llm-gateway:8090');
+    expect(caddy).toContain('handle_path /_tests/*');
+    expect(caddy).toContain('root * /reports');
+    expect(caddy).toContain('handle_path /_mailpit/*');
+    expect(caddy).toContain('reverse_proxy mailpit:8025');
+    expect(caddy).toContain('reverse_proxy frontend:3000');
+  });
+
+  it('adds only the preview edge, Mailpit, and direct loopback database port', () => {
+    const overlay = buildPreviewComposeOverlay('/workspace/suna/tests/test-results');
+    expect(overlay).toContain('preview-edge:');
+    expect(overlay).toContain('mailpit:');
+    expect(overlay).toContain('127.0.0.1:15432:5432');
+    expect(overlay).toContain('/workspace/suna/tests/test-results:/reports:ro');
+    expect(overlay).not.toContain('volumes/db/data');
+  });
+
+  it('rejects every runtime secret outside the explicit allowlist', () => {
+    expect(PREVIEW_RUNTIME_SECRET_ALLOWLIST).toEqual([
+      'DAYTONA_API_KEY',
+      'KE2E_STRIPE_SECRET_KEY',
+      'KE2E_STRIPE_WEBHOOK_SECRET',
+      'KORTIX_GITHUB_APP_ID',
+      'KORTIX_GITHUB_APP_PRIVATE_KEY',
+      'KORTIX_GITHUB_APP_SLUG',
+      'MANAGED_GIT_GITHUB_INSTALL_ID',
+      'MANAGED_GIT_GITHUB_OWNER',
+      'OPENROUTER_API_KEY',
+    ]);
+    expect(() =>
+      validatePreviewRuntimeSecrets({
+        DAYTONA_API_KEY: 'allowed',
+        DEV_DATABASE_URL: 'forbidden',
+      }),
+    ).toThrow('DEV_DATABASE_URL');
+  });
+
+  it('pins exact images and configures the preview data plane', () => {
+    const configured = applyPreviewEnvironment(
+      'POSTGRES_PASSWORD=generated\nSUPABASE_ANON_KEY=anon\nSUPABASE_SERVICE_ROLE_KEY=service\nINTERNAL_SERVICE_KEY=internal\n',
+      {
+        origin: 'https://preview.example',
+        sha: SHA,
+        apiImage: `kortix/kortix-api:pr-${SHA}`,
+        gatewayImage: `kortix/kortix-gateway:pr-${SHA}`,
+        frontendImage: `kortix/kortix-frontend:pr-${SHA}`,
+      },
+      {
+        DAYTONA_API_KEY: 'daytona',
+        KE2E_STRIPE_SECRET_KEY: 'stripe',
+        KE2E_STRIPE_WEBHOOK_SECRET: 'webhook',
+        KORTIX_GITHUB_APP_ID: '12345',
+        KORTIX_GITHUB_APP_PRIVATE_KEY: 'line-one\nline-two',
+        KORTIX_GITHUB_APP_SLUG: 'kortix-preview-test',
+        MANAGED_GIT_GITHUB_INSTALL_ID: '67890',
+        MANAGED_GIT_GITHUB_OWNER: 'kortix-preview',
+        OPENROUTER_API_KEY: 'openrouter',
+      },
+    );
+
+    expect(configured.runtimeEnv).toContain(`API_IMAGE=kortix/kortix-api:pr-${SHA}`);
+    expect(configured.runtimeEnv).toContain('DATABASE_URL=postgresql://postgres:generated@supabase-db:5432/postgres');
+    expect(configured.runtimeEnv).toContain('SUPABASE_PUBLIC_URL=https://preview.example');
+    expect(configured.runtimeEnv).toContain('INTERNAL_KORTIX_ENV=preview');
+    expect(configured.runtimeEnv).toContain('EMAIL_PROVIDER_ORDER=mailpit');
+    expect(configured.runtimeEnv).toContain('MANAGED_GIT_PROVIDER=github');
+    expect(configured.runtimeEnv).toContain('KORTIX_GITHUB_APP_PRIVATE_KEY=line-one\\nline-two');
+    expect(configured.runtimeEnv).not.toContain('E2E_AGENTMAIL_API_KEY');
+    expect(configured.testEnv).toContain('KE2E_TARGET=preview');
+    expect(configured.testEnv).toContain(`KE2E_PREVIEW_AUTHORIZATION=approved:${SHA}`);
+    expect(configured.testEnv).toContain('E2E_MAILPIT_URL=https://preview.example/_mailpit');
+    expect(configured.testEnv).toContain('KE2E_DATABASE_URL=postgresql://postgres:generated@127.0.0.1:15432/postgres');
+    expect(configured.testEnv).toContain('KE2E_CAP_MANAGED_GIT_PUSH=1');
+    expect(configured.testEnv).toContain('E2E_AGENTMAIL_API_KEY=');
+  });
+
+  it('fails before boot when managed GitHub cannot run every target flow', () => {
+    expect(() =>
+      applyPreviewEnvironment(
+        'POSTGRES_PASSWORD=generated\nSUPABASE_ANON_KEY=anon\nSUPABASE_SERVICE_ROLE_KEY=service\nINTERNAL_SERVICE_KEY=internal\n',
+        {
+          origin: 'https://preview.example',
+          sha: SHA,
+          apiImage: 'api',
+          gatewayImage: 'gateway',
+          frontendImage: 'frontend',
+        },
+        {},
+      ),
+    ).toThrow('complete managed GitHub App configuration');
+  });
+});

--- a/tests/unit/sandbox-preview.test.ts
+++ b/tests/unit/sandbox-preview.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  PreviewInfrastructureError,
+  buildPreviewBootstrapScript,
+  previewLockfileHash,
+  previewSandboxName,
+  runSandboxPreview,
+  selectStalePreviewSandboxIds,
+} from '../src/core/sandbox-preview';
+
+const input = {
+  provider: 'auto' as const,
+  prNumber: 6337,
+  repository: 'kortix-ai/suna',
+  sha: 'a'.repeat(40),
+};
+
+describe('provider-neutral preview lifecycle', () => {
+  it('uses one stable sandbox name per pull request', () => {
+    expect(previewSandboxName(6337)).toBe('kortix-preview-pr-6337');
+  });
+
+  it('requires the exact SHA-256 of the pull request lockfile', () => {
+    expect(previewLockfileHash('A'.repeat(64))).toBe('a'.repeat(64));
+    expect(() => previewLockfileHash('a'.repeat(40))).toThrow('64 hex characters');
+  });
+
+  it('boots the exact self-host distribution and runs the canonical deployed suite', () => {
+    const script = buildPreviewBootstrapScript({
+      repository: 'kortix-ai/suna',
+      ref: 'refs/pull/6337/head',
+      sha: 'a'.repeat(40),
+      prNumber: 6337,
+      origin: 'https://preview.example',
+    });
+    expect(script).toContain('git -C "$ROOT" checkout --detach --force FETCH_HEAD');
+    expect(script).toContain('test "$actual_sha" = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"');
+    expect(script).toContain('apps/cli/src/index.ts self-host init');
+    expect(script).toContain('tests/bin/preview-stack.ts');
+    expect(script).toContain('docker compose');
+    expect(script).toContain('pnpm test -- --target-full');
+    expect(script).toContain('/workspace/kortix-test-results.tar.gz');
+    expect(script).toContain('kortix-preview.exit');
+    expect(script).not.toContain('ecs-preview');
+  });
+
+  it('falls back only after a Platinum infrastructure failure', async () => {
+    const platinum = vi.fn().mockRejectedValue(new PreviewInfrastructureError('restore timeout'));
+    const daytona = vi.fn().mockResolvedValue({ exitCode: 0, provider: 'daytona' });
+    await expect(runSandboxPreview(input, { platinum, daytona })).resolves.toEqual({
+      exitCode: 0,
+      provider: 'daytona',
+    });
+    expect(daytona).toHaveBeenCalledOnce();
+  });
+
+  it('does not fall back after a product test failure', async () => {
+    const platinum = vi.fn().mockResolvedValue({ exitCode: 9, provider: 'platinum' });
+    const daytona = vi.fn();
+    await expect(runSandboxPreview(input, { platinum, daytona })).resolves.toEqual({
+      exitCode: 9,
+      provider: 'platinum',
+    });
+    expect(daytona).not.toHaveBeenCalled();
+  });
+
+  it('does not hide an arbitrary controller bug behind fallback', async () => {
+    const platinum = vi.fn().mockRejectedValue(new Error('invalid preview config'));
+    const daytona = vi.fn();
+    await expect(runSandboxPreview(input, { platinum, daytona })).rejects.toThrow(
+      'invalid preview config',
+    );
+    expect(daytona).not.toHaveBeenCalled();
+  });
+
+  it('selects only stale or unlabeled preview sandboxes for teardown', () => {
+    const sandboxes = [
+      { id: 'keep', metadata: { owner: 'kortix-preview', pr_number: '10', git_sha: 'a' } },
+      { id: 'stale', metadata: { owner: 'kortix-preview', pr_number: '10', git_sha: 'b' } },
+      { id: 'closed', metadata: { owner: 'kortix-preview', pr_number: '11', git_sha: 'c' } },
+      { id: 'ci', metadata: { owner: 'kortix-ci', pr_number: '11', git_sha: 'c' } },
+    ];
+    const active = new Map([[10, 'a']]);
+    expect(selectStalePreviewSandboxIds(sandboxes, active)).toEqual(['stale', 'closed']);
+  });
+});

--- a/tests/unit/sandbox-workflow.test.ts
+++ b/tests/unit/sandbox-workflow.test.ts
@@ -6,13 +6,21 @@ const root = resolve(import.meta.dirname, '../..');
 const testWorkflow = readFileSync(resolve(root, '.github/workflows/tests.yml'), 'utf8');
 
 describe('sandbox test workflow', () => {
-  test('runs three root lanes at the pull request head SHA', () => {
+  test('runs four root workers at the pull request head SHA', () => {
     expect(testWorkflow).toContain(
       'SANDBOX_TEST_SHA: ${{ github.event.pull_request.head.sha || github.sha }}',
     );
-    expect(testWorkflow).toContain('lane: [core, browser, packages]');
+    expect(testWorkflow).toContain('- lane: core');
+    expect(testWorkflow).toContain('- lane: browser-1');
+    expect(testWorkflow).toContain('- lane: browser-2');
+    expect(testWorkflow).toContain('- lane: packages');
     expect(testWorkflow).toContain('bun tests/bin/sandbox-ci.ts ;;');
-    expect(testWorkflow).toContain('bun tests/bin/sandbox-ci.ts --browser-only');
+    expect(testWorkflow).toContain(
+      'bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=1/2',
+    );
+    expect(testWorkflow).toContain(
+      'bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=2/2',
+    );
     expect(testWorkflow).toContain('bun tests/bin/sandbox-ci.ts --packages-only');
     expect(testWorkflow).toContain('timeout-minutes: 90');
     expect(testWorkflow).toContain('SANDBOX_TEST_RUN_ID: ${{ github.run_id }}-${{ matrix.lane }}');
@@ -92,19 +100,23 @@ describe('sandbox test workflow', () => {
     expect(release).not.toContain('mode: full');
   });
 
-  test('has one automatic local-suite caller and one deployed release caller', () => {
+  test('has one automatic local-suite caller and two intentional deployed targets', () => {
     const workflowRoot = resolve(root, '.github/workflows');
     const workflows = readdirSync(workflowRoot)
       .filter((name) => /\.ya?ml$/.test(name))
-      .map((name) => readFileSync(resolve(workflowRoot, name), 'utf8'));
+      .map((name) => ({ name, source: readFileSync(resolve(workflowRoot, name), 'utf8') }));
 
     expect(
-      workflows.filter((workflow) =>
-        workflow.includes('uses: ./.github/workflows/tests.yml'),
+      workflows.filter(({ source }) =>
+        source.includes('uses: ./.github/workflows/tests.yml'),
       ),
     ).toHaveLength(1);
-    expect(
-      workflows.filter((workflow) => workflow.includes('pnpm test -- --target-full')),
-    ).toHaveLength(1);
+    const targetFullCallers = workflows.filter(({ source }) =>
+      source.includes('pnpm test -- --target-full'),
+    );
+    expect(targetFullCallers.map(({ name }) => name).sort()).toEqual([
+      'deploy-preview.yml',
+      'tests-release.yml',
+    ]);
   });
 });

--- a/tests/unit/strict-skip-reporter.test.ts
+++ b/tests/unit/strict-skip-reporter.test.ts
@@ -1,20 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import { StrictSkipReporter } from '../e2e/strict-skip-reporter';
 
-describe('strict Playwright skip reporter', () => {
-  it('fails a strict browser lane when one journey is skipped', async () => {
-    const reporter = new StrictSkipReporter({ requireAll: true });
-    reporter.onTestEnd({ titlePath: () => ['journey'] } as never, { status: 'skipped' } as never);
+function skipped(title: string[]) {
+  return {
+    titlePath: () => title,
+  } as never;
+}
 
-    await expect(reporter.onEnd({ status: 'passed' } as never)).resolves.toEqual({
-      status: 'failed',
-    });
+describe('strict browser skip reporter', () => {
+  it('fails an unapproved skip', async () => {
+    const reporter = new StrictSkipReporter({ requireAll: true, writeExclusions: async () => {} });
+    reporter.onTestEnd(skipped(['chromium', 'journey']), { status: 'skipped' } as never);
+    await expect(reporter.onEnd({} as never)).resolves.toEqual({ status: 'failed' });
   });
 
-  it('keeps ordinary browser lanes compatible with explicit skips', async () => {
-    const reporter = new StrictSkipReporter({ requireAll: false });
-    reporter.onTestEnd({ titlePath: () => ['journey'] } as never, { status: 'skipped' } as never);
-
-    await expect(reporter.onEnd({ status: 'passed' } as never)).resolves.toBeUndefined();
+  it('records only the preview OAuth exclusion without failing the run', async () => {
+    const reporter = new StrictSkipReporter({
+      requireAll: true,
+      allowPreviewOAuthExclusion: true,
+      writeExclusions: async () => {},
+    });
+    reporter.onTestEnd(
+      skipped(['chromium', '17 — OAuth provider initiation', 'Google accepts callback']),
+      { status: 'skipped' } as never,
+    );
+    await expect(reporter.onEnd({} as never)).resolves.toBeUndefined();
   });
 });

--- a/tests/unit/target-smoke.test.ts
+++ b/tests/unit/target-smoke.test.ts
@@ -17,6 +17,7 @@ describe('deployed staging smoke', () => {
       webUrl: 'https://staging.kortix.com',
       gatewayUrl: 'https://gateway-staging.kortix.com',
       expectedSha: SHA,
+      environment: 'staging',
     });
   });
 
@@ -47,6 +48,51 @@ describe('deployed staging smoke', () => {
     ).toThrow('KE2E_EXPECT_SHA');
   });
 
+  it('accepts one explicitly authorized preview origin', () => {
+    const origin = 'https://preview-6337.sbx.platinum.dev';
+    expect(
+      resolveTargetSmokeConfig({
+        KE2E_TARGET: 'preview',
+        KE2E_PREVIEW_ORIGIN: origin,
+        KE2E_PREVIEW_AUTHORIZATION: `approved:${SHA}`,
+        KE2E_API_URL: `${origin}/v1`,
+        E2E_BASE_URL: origin,
+        KE2E_GATEWAY_URL: `${origin}/_gateway`,
+        KE2E_SUPABASE_URL: origin,
+        KE2E_EXPECT_SHA: SHA,
+      }),
+    ).toEqual({
+      apiUrl: `${origin}/v1`,
+      webUrl: origin,
+      gatewayUrl: `${origin}/_gateway`,
+      expectedSha: SHA,
+      environment: 'preview',
+    });
+  });
+
+  it.each([
+    ['missing approval', { KE2E_PREVIEW_AUTHORIZATION: '' }],
+    ['wrong approval SHA', { KE2E_PREVIEW_AUTHORIZATION: `approved:${'b'.repeat(40)}` }],
+    ['different API origin', { KE2E_API_URL: 'https://other.example/v1' }],
+    ['different Supabase origin', { KE2E_SUPABASE_URL: 'https://other.example' }],
+    ['wrong gateway path', { KE2E_GATEWAY_URL: 'https://preview.example/gateway' }],
+  ])('rejects an unauthorized preview target: %s', (_name, override) => {
+    const origin = 'https://preview.example';
+    expect(() =>
+      resolveTargetSmokeConfig({
+        KE2E_TARGET: 'preview',
+        KE2E_PREVIEW_ORIGIN: origin,
+        KE2E_PREVIEW_AUTHORIZATION: `approved:${SHA}`,
+        KE2E_API_URL: `${origin}/v1`,
+        E2E_BASE_URL: origin,
+        KE2E_GATEWAY_URL: `${origin}/_gateway`,
+        KE2E_SUPABASE_URL: origin,
+        KE2E_EXPECT_SHA: SHA,
+        ...override,
+      }),
+    ).toThrow('preview');
+  });
+
   it('requires both deployed services to report the exact release SHA', async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
@@ -68,6 +114,7 @@ describe('deployed staging smoke', () => {
           webUrl: 'https://staging.kortix.com',
           gatewayUrl: 'https://gateway-staging.kortix.com',
           expectedSha: SHA,
+          environment: 'staging',
         },
         fetchImpl,
       ),
@@ -96,9 +143,36 @@ describe('deployed staging smoke', () => {
           webUrl: 'https://staging.kortix.com',
           gatewayUrl: 'https://gateway-staging.kortix.com',
           expectedSha: SHA,
+          environment: 'staging',
         },
         fetchImpl,
       ),
     ).rejects.toThrow('staging SHA mismatch');
+  });
+
+  it('requires preview health to report preview and the exact SHA', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: 'ok', environment: 'preview', commit: SHA }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: 'healthy', commit: SHA }), { status: 200 }),
+      );
+
+    await expect(
+      assertTargetSmokeHealth(
+        {
+          apiUrl: 'https://preview.example/v1',
+          webUrl: 'https://preview.example',
+          gatewayUrl: 'https://preview.example/_gateway',
+          expectedSha: SHA,
+          environment: 'preview',
+        },
+        fetchImpl,
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -139,21 +139,34 @@ describe('web ECS migration', () => {
     }
   });
 
-  it('builds preview images without credentials and invalidates approval on new commits', () => {
+  it('builds preview images without credentials and deploys one full self-host sandbox', () => {
     const workflow = read('.github/workflows/deploy-preview.yml');
-    const previewScript = read('infra/scripts/ecs-preview.sh');
-    const previewTerraform = read('infra/terraform/environments/preview/main.tf');
+    const buildJobs = workflow.slice(
+      workflow.indexOf('  build-api:'),
+      workflow.indexOf('  deploy:'),
+    );
 
-    expect(workflow.match(/persist-credentials: false/g)).toHaveLength(3);
-    expect(workflow.match(/push: false/g)).toHaveLength(3);
+    expect(buildJobs.match(/persist-credentials: false/g)).toHaveLength(3);
+    expect(buildJobs.match(/push: false/g)).toHaveLength(3);
+    expect(buildJobs.match(/platforms: linux\/amd64/g)).toHaveLength(3);
     expect(workflow).toContain("github.event.action == 'labeled'");
     expect(workflow).toContain("github.event.action == 'synchronize'");
     expect(workflow).toContain('labels/preview');
-    expect(previewScript).toContain('WEB_SECRET_NAME="kortix-preview-web-env"');
-    expect(previewTerraform).toContain('name = "kortix-preview-web-env"');
+    expect(workflow).toContain('bun tests/bin/sandbox-preview.ts deploy');
+    expect(workflow).toContain('bun tests/bin/sandbox-preview.ts teardown');
+    expect(workflow).toContain('bun tests/bin/sandbox-preview.ts reconcile');
+    expect(workflow).toContain('pnpm test -- --target-full');
+    expect(workflow).toContain('PREVIEW_LOCKFILE_SHA256');
+    expect(workflow).toContain('Test report:');
+    expect(workflow).toContain('deployments: write');
+    expect(workflow).toContain('type: choice');
+    expect(workflow).toContain('- platinum');
+    expect(workflow).toContain('- daytona');
+    expect(workflow).not.toContain('infra/scripts/ecs-preview.sh');
+    expect(workflow).not.toContain('configure-aws-credentials');
     expect(workflow).not.toMatch(/vercel/i);
     expect(workflow).not.toContain('KORTIX_PREVIEW_APPROVED_SHA');
-    expect(workflow).toContain('"- **Frontend:** https://${web}"');
+    expect(workflow).toContain('**Preview:**');
   });
 
   it('disables Vercel auto-deploys everywhere except staging', () => {
@@ -170,7 +183,7 @@ describe('web ECS migration', () => {
     expect(ignore).toContain('prod deploys only via deploy-prod.yml');
     expect(ignore).not.toContain('KORTIX_PREVIEW_APPROVED_SHA');
     expect(ignore).not.toContain('*:main');
-    expect(ignore).toContain('dev and PR previews deploy on ECS only');
+    expect(ignore).toContain('dev deploys on ECS; PR previews deploy in sandboxes');
   });
 
   it('deploys the prod Vercel frontend only after the API serves the release', () => {


### PR DESCRIPTION
## Outcome

The `preview` label now creates one persistent full-stack preview in a warm Platinum or Daytona sandbox.

The preview runs the exact PR API, gateway, frontend, PostgreSQL, Supabase, Mailpit, and Caddy. It uses one public HTTPS origin. It does not use the Dev, staging, or production database.

## Lifecycle

- A writer authorizes the exact same-repository PR SHA.
- Three credential-free jobs build `linux/amd64` API, gateway, and frontend images.
- The trusted controller from `main` restores Platinum first.
- `auto` falls back to Daytona only for a Platinum infrastructure failure.
- Product-test failures preserve the sandbox and never trigger fallback.
- The sandbox generates the regular `kortix self-host` Compose distribution.
- `pnpm test -- --target-full` runs against the public preview origin.
- The sticky PR comment publishes the preview and `/_tests/` report URLs.
- GitHub Deployment tracks `preview/pr-<number>`.
- Unlabel, close, head change, and daily reconciliation delete stale sandboxes.
- A head change also removes the stale `preview` label.

OAuth initiation is the only explicit preview browser exclusion. Mailpit covers authentication and invitation email. A dedicated preview GitHub App covers managed Git and CLI push flows.

## Verification

- `pnpm test -- --full`: exit `0`; 6 lanes passed; 0 failed; `181.7s`
- REST/CLI lane: 365 passed; 0 failed
- Browser lane: exit `0`; `53.8s`
- Package quality: exit `0`; `100.6s`
- `pnpm test` after rebase: exit `0`; 5 lanes passed; 0 failed; `28.7s`
- SDK: 1,848 passed; 0 failed
- Runner: 164 passed; 0 failed
- `pnpm --dir tests exec tsc --noEmit`: exit `0`
- `actionlint .github/workflows/deploy-preview.yml`: exit `0`
- `docker compose config --quiet` on the generated 20-service profile: exit `0`
- `git diff --check`: exit `0`
