### PR TITLE
feat(llm-catalog): slim managed lineup to GLM 5.2 + DeepSeek V4 Flash

### DIFF
--- a/apps/api/src/__tests__/billing/credits.test.ts
+++ b/apps/api/src/__tests__/billing/credits.test.ts
@@ -67,9 +67,9 @@ const { TOKEN_PRICE_MULTIPLIER } = await import('../../billing/services/tiers');
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('calculateTokenCost', () => {
-  test('known model (claude-sonnet-4.6): correct cost with 1.2x multiplier', () => {
-    const cost = calculateTokenCost(1_000_000, 1_000_000, 'claude-sonnet-4.6');
-    const expected = (3 + 15) * TOKEN_PRICE_MULTIPLIER;
+  test('known model (glm-5.2): correct cost with 1.2x multiplier', () => {
+    const cost = calculateTokenCost(1_000_000, 1_000_000, 'glm-5.2');
+    const expected = (1 + 4) * TOKEN_PRICE_MULTIPLIER;
     expect(cost).toBeCloseTo(expected, 6);
   });
 
@@ -86,7 +86,7 @@ describe('calculateTokenCost', () => {
   });
 
   test('0 tokens returns 0 cost', () => {
-    const cost = calculateTokenCost(0, 0, 'claude-sonnet-4.6');
+    const cost = calculateTokenCost(0, 0, 'glm-5.2');
     expect(cost).toBe(0);
   });
 });

--- a/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
+++ b/apps/api/src/__tests__/unit-resolve-candidates-free-tier.test.ts
@@ -25,9 +25,11 @@ mock.module('../config', () => ({
         if (key === 'LLM_GATEWAY_ENABLED') return true;
         if (key === 'LLM_GATEWAY_DEFAULT_ENABLED') return false;
         if (key === 'TUNNEL_ENABLED') return false;
-        if (key === 'LLM_GATEWAY_BYOK_FALLBACK_MODEL') return 'claude-sonnet-4.6';
+        if (key === 'LLM_GATEWAY_BYOK_FALLBACK_MODEL') return 'glm-5.2';
         if (key === 'LLM_GATEWAY_DEFAULT_MODEL') return 'codex/gpt-5.6-sol';
-        if (key === 'LLM_GATEWAY_VISION_MODEL') return 'claude-sonnet-4.6';
+        if (key === 'LLM_GATEWAY_VISION_MODEL') return undefined;
+        if (key === 'ASTER_API_KEY') return 'aster-key';
+        if (key === 'ASTER_API_URL') return 'https://api.asterlab.ai/v1';
         if (key === 'LLM_GATEWAY_FALLBACK_POLICIES') {
           return [
             {
@@ -169,7 +171,7 @@ describe('resolveCandidates free-tier premium gate', () => {
   test('blocks managed premium candidates for free accounts', async () => {
     accountTier = 'free';
     await expect(
-      resolveCandidates(principal('free-managed'), 'claude-sonnet-4.6'),
+      resolveCandidates(principal('free-managed'), 'glm-5.2'),
     ).rejects.toMatchObject({
       name: 'GatewayResolutionError',
       code: 'plan_upgrade_required',
@@ -179,7 +181,7 @@ describe('resolveCandidates free-tier premium gate', () => {
 
   test('allows managed premium candidates for Team accounts', async () => {
     accountTier = 'per_seat';
-    const candidates = await resolveCandidates(principal('team-managed'), 'claude-sonnet-4.6');
+    const candidates = await resolveCandidates(principal('team-managed'), 'glm-5.2');
     expect(candidates).toHaveLength(1);
     expect(candidates[0]?.billingMode).toBe('credits');
     // 0, not 1: the pass path answers via the managed-models entitlement
@@ -240,7 +242,7 @@ describe('resolveCandidates free-tier premium gate', () => {
     billingEnabled = false;
     accountTier = 'free';
     managedProviderEnabled = true;
-    const candidates = await resolveCandidates(principal('self-host-managed'), 'claude-sonnet-4.6');
+    const candidates = await resolveCandidates(principal('self-host-managed'), 'glm-5.2');
     expect(candidates).toHaveLength(1);
     expect(accountTierCalls).toBe(0);
   });
@@ -249,7 +251,7 @@ describe('resolveCandidates free-tier premium gate', () => {
     managedProviderEnabled = false;
     accountTier = 'per_seat';
     await expect(
-      resolveCandidates(principal('self-host-flag-off'), 'claude-sonnet-4.6'),
+      resolveCandidates(principal('self-host-flag-off'), 'glm-5.2'),
     ).rejects.toMatchObject({
       name: 'GatewayResolutionError',
       code: 'model_disabled_on_deployment',

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -368,7 +368,12 @@ const envSchema = z.object({
   // constant baked into the gateway binary. Operators can replace the default
   // and define any number of exact-match fallback policies without code changes.
   LLM_GATEWAY_DEFAULT_MODEL: optStrDefault(PLATFORM_DEFAULT_MODEL_ID),
-  LLM_GATEWAY_VISION_MODEL: optStrDefault('claude-sonnet-4.6'),
+  // Target when a DEFAULT-model request carries image input and the default
+  // model lacks vision. Empty = no reroute (the request goes to the default
+  // model as-is). Since the 2026-08-10 managed slim-down, no managed model has
+  // vision, so there is no in-house target — set this only to a BYOK-servable
+  // ref or a future vision-capable managed id.
+  LLM_GATEWAY_VISION_MODEL: optStr,
   LLM_GATEWAY_FALLBACK_POLICIES: optFallbackPolicies,
   // Optional JSON array replacing the platform managed-model overlay (transport,
   // upstream id, pricing ref, capabilities). Empty uses the bundled last-known
@@ -380,7 +385,7 @@ const envSchema = z.object({
   // BYOK resilience: when a user's own provider key hits a rate-limit / quota /
   // billing error (429/402/403), fall over to THIS managed model (billed as
   // Kortix credits) so the turn survives instead of erroring. Empty disables.
-  LLM_GATEWAY_BYOK_FALLBACK_MODEL: optStrDefault('claude-sonnet-4.6'),
+  LLM_GATEWAY_BYOK_FALLBACK_MODEL: optStrDefault('glm-5.2'),
   // Dev: reverse-proxy /v1/llm-gateway/* to a standalone gateway on this port,
   // so sandboxes reach it through the API's own tunnel (no separate tunnel).
   LLM_GATEWAY_PROXY_PORT: optInt(0),

--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -31,7 +31,7 @@ describe('gatewayModelCatalog — served catalog', () => {
 
   test('synthetic auto is absent; anonymous callers get managed-only', () => {
     expect(full.auto).toBeUndefined();
-    expect(full['claude-opus-4.8']).toBeDefined();
+    expect(full['deepseek-v4-flash']).toBeDefined();
     expect(full['glm-5.2']).toBeDefined();
 
     const managedOnly = gatewayModelCatalog(undefined);
@@ -76,7 +76,7 @@ describe('gatewayModelCatalog — served catalog', () => {
     // BYOK catalog entries brand as their real upstream provider.
     expect(full['anthropic/claude-opus-4-8']?.provider).toBe('anthropic');
     // Managed models brand as `kortix`.
-    expect(full['claude-opus-4.8']?.provider).toBe('kortix');
+    expect(full['deepseek-v4-flash']?.provider).toBe('kortix');
     expect(full['glm-5.2']?.provider).toBe('kortix');
     // Codex (ChatGPT subscription) models brand as their own `codex` provider,
     // distinct from the raw `openai` BYOK provider.
@@ -181,21 +181,21 @@ describe('catalogModelForWireModel — generation-controls capability lookup', (
   // (temperature:false, reasoning_options up to 'xhigh'/'max'). Assert the
   // REAL entry, not just `reasoning:true` (which the synthetic fallback also
   // satisfied and so wouldn't have caught the regression).
+  // 2026-08-10 slim-down: the Claude managed ids this test used are
+  // deactivated. deepseek-v4-flash keeps the regression covered — its
+  // pricingRef ('openrouter/deepseek/deepseek-v4-flash') resolves to the REAL
+  // models.dev openrouter entry, whose reasoning_options ('high'/'xhigh') the
+  // synthetic fallback would not carry. (glm-5.2's 'z-ai/glm-5.2' is
+  // DELIBERATELY unresolvable — z-ai is not a models.dev provider id — so it
+  // cannot serve as the regression fixture.)
   test('resolves a managed bare id to its REAL catalog capabilities via pricingRef, not the synthetic fallback', () => {
-    const opus = catalogModelForWireModel('claude-opus-4.8');
-    expect(opus).toBeDefined();
-    expect(opus?.id).toBe('claude-opus-4-8');
-    expect(opus?.reasoning).toBe(true);
-    expect(opus?.temperature).toBe(false);
-    expect(opus?.reasoning_options?.[0]?.values).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
-    expect(opus?.limit?.output).toBe(128_000);
-
-    const sonnet = catalogModelForWireModel('claude-sonnet-4.6');
-    expect(sonnet).toBeDefined();
-    expect(sonnet?.id).toBe('claude-sonnet-4-6');
-    expect(sonnet?.reasoning).toBe(true);
-    expect(sonnet?.temperature).toBe(true);
-    expect(sonnet?.reasoning_options?.[0]?.values).toEqual(['low', 'medium', 'high', 'max']);
+    const flash = catalogModelForWireModel('deepseek-v4-flash');
+    expect(flash).toBeDefined();
+    expect(flash?.id).toBe('deepseek/deepseek-v4-flash');
+    expect(flash?.reasoning).toBe(true);
+    expect(flash?.temperature).toBe(true);
+    expect(flash?.reasoning_options?.[0]?.values).toEqual(['high', 'xhigh']);
+    expect(flash?.limit?.context).toBe(1_048_576);
   });
 
   test('does not resolve stale synthetic auto model ids', () => {

--- a/apps/api/src/llm-gateway/models/managed-provider-disabled.test.ts
+++ b/apps/api/src/llm-gateway/models/managed-provider-disabled.test.ts
@@ -141,7 +141,7 @@ describe('managed provider disabled (KORTIX_MANAGED_PROVIDER_ENABLED=false, the 
     await expect(
       resolveCandidates(
         { userId: 'u-managed', accountId: 'a-managed', projectId: 'p-managed' },
-        'claude-sonnet-4.6',
+        'glm-5.2',
       ),
     ).rejects.toMatchObject({
       name: 'GatewayResolutionError',
@@ -149,6 +149,7 @@ describe('managed provider disabled (KORTIX_MANAGED_PROVIDER_ENABLED=false, the 
     });
     expect(bedrockKeyReads).toBe(0);
     expect(openrouterKeyReads).toBe(0);
+    expect(asterKeyReads).toBe(0);
   });
 
   test('a BYOK request still works on its own key, but gets NO managed fallback appended', async () => {

--- a/apps/api/src/llm-gateway/models/managed-transport-credential-missing.test.ts
+++ b/apps/api/src/llm-gateway/models/managed-transport-credential-missing.test.ts
@@ -21,7 +21,7 @@ mock.module('../../config', () => ({
         if (key === 'TUNNEL_ENABLED') return false;
         if (key === 'LLM_GATEWAY_BYOK_FALLBACK_MODEL') return '';
         if (key === 'LLM_GATEWAY_DEFAULT_MODEL') return 'glm-5.2';
-        if (key === 'LLM_GATEWAY_VISION_MODEL') return 'claude-sonnet-4.6';
+        if (key === 'LLM_GATEWAY_VISION_MODEL') return undefined;
         if (key === 'LLM_GATEWAY_FALLBACK_POLICIES') return [];
         if (key === 'AWS_BEDROCK_REGION') return 'us-west-2';
         if (key === 'AWS_BEDROCK_API_KEY') return 'bedrock-key';
@@ -82,13 +82,12 @@ describe('a managed model whose transport credential is missing is never OFFERED
   test('the served lineup drops it and keeps every credentialed transport', () => {
     const served = SERVED_MANAGED_MODELS.map((m) => m.id);
     expect(served).not.toContain('glm-5.2');
-    expect(served).toContain('claude-opus-4.8');
     expect(served).toContain('deepseek-v4-flash');
   });
 
   test('the served model catalog does not advertise it', () => {
     expect(managedModels()['glm-5.2']).toBeUndefined();
-    expect(managedModels()['claude-opus-4.8']).toBeDefined();
+    expect(managedModels()['deepseek-v4-flash']).toBeDefined();
     expect(gatewayModelCatalog('proj')['glm-5.2']).toBeUndefined();
     expect(gatewayModelCatalog(undefined)['glm-5.2']).toBeUndefined();
   });
@@ -110,7 +109,9 @@ describe('the platform default model is always resolvable', () => {
       platformDefaultModelId(),
     );
     expect(candidates.length).toBeGreaterThan(0);
-    expect(candidates[0]?.apiKey).toBe('bedrock-key');
+    // 2026-08-10 slim-down: with aster uncredentialed the only served managed
+    // model is deepseek-v4-flash (openrouter transport).
+    expect(candidates[0]?.apiKey).toBe('openrouter-key');
   });
 
   test('naming the unreachable model explicitly still refuses, with an actionable reason', async () => {

--- a/apps/api/src/llm-gateway/models/picker.test.ts
+++ b/apps/api/src/llm-gateway/models/picker.test.ts
@@ -29,10 +29,10 @@ describe('providerFlagship', () => {
 
 describe('labelForModelRef', () => {
   test('managed ref (kortix/<id>) → the managed display name', () => {
-    const sonnet = RUNTIME_MANAGED_MODELS.find((m) => m.id === 'claude-sonnet-4.6');
-    expect(labelForModelRef('kortix/claude-sonnet-4.6')).toBe(sonnet!.name);
+    const glm = RUNTIME_MANAGED_MODELS.find((m) => m.id === 'glm-5.2');
+    expect(labelForModelRef('kortix/glm-5.2')).toBe(glm!.name);
     // bare managed id resolves too
-    expect(labelForModelRef('claude-sonnet-4.6')).toBe(sonnet!.name);
+    expect(labelForModelRef('glm-5.2')).toBe(glm!.name);
   });
 
   test('an unknown ref falls back to the raw id (never throws)', () => {

--- a/apps/api/src/llm-gateway/resolution/effective.test.ts
+++ b/apps/api/src/llm-gateway/resolution/effective.test.ts
@@ -69,7 +69,9 @@ describe('toWireModel / toOpencodeModelRef', () => {
 
   test('re-prefixes a bare managed id to the opencode ref; leaves BYOK/codex alone', () => {
     expect(toOpencodeModelRef('glm-5.2')).toBe('kortix/glm-5.2');
-    expect(toOpencodeModelRef('claude-opus-4.8')).toBe('kortix/claude-opus-4.8');
+    expect(toOpencodeModelRef('deepseek-v4-flash')).toBe('kortix/deepseek-v4-flash');
+    // 2026-08-10 slim-down: a deactivated managed id is no longer re-prefixed.
+    expect(toOpencodeModelRef('claude-opus-4.8')).toBe('claude-opus-4.8');
     expect(toOpencodeModelRef('kortix/glm-5.2')).toBe('kortix/glm-5.2');
     expect(toOpencodeModelRef('anthropic/claude-sonnet-4.6')).toBe('anthropic/claude-sonnet-4.6');
     expect(toOpencodeModelRef('codex/gpt-5.5')).toBe('codex/gpt-5.5');
@@ -115,8 +117,8 @@ describe('degradeUnservableDefault — stale default guard', () => {
       'glm-5.2',
     );
     expect(
-      await degradeUnservableDefault('kortix/claude-opus-4.8', { hasProject: true }, neverProbe),
-    ).toBe('kortix/claude-opus-4.8');
+      await degradeUnservableDefault('kortix/deepseek-v4-flash', { hasProject: true }, neverProbe),
+    ).toBe('kortix/deepseek-v4-flash');
   });
 
   test('BYOK default with no project context degrades to platform, no probe', async () => {

--- a/apps/api/src/llm-gateway/routing/resolve-route.ts
+++ b/apps/api/src/llm-gateway/routing/resolve-route.ts
@@ -18,7 +18,8 @@ export interface ResolvedProjectRoutingPolicy {
 
 export interface GatewayRouteResolverOptions {
   defaultModel: string;
-  visionModel: string;
+  /** Reroute target for image-bearing default requests; empty/undefined = no reroute. */
+  visionModel: string | undefined;
   policies: readonly ModelFallbackPolicy[];
   supportsImage: (model: string) => boolean;
   getProjectPolicy?: (projectId: string) => Promise<ResolvedProjectRoutingPolicy | null>;
@@ -73,7 +74,11 @@ export function createGatewayRouteResolver(
     let primaryModel = input.requestedModel;
 
     if (isDefaultRequest && input.requires.imageInput && !options.supportsImage(primaryModel)) {
-      primaryModel = projectPolicy?.visionModel || options.visionModel;
+      // No configured vision target (the managed lineup has no vision model
+      // since the 2026-08-10 slim-down) → keep the default model rather than
+      // rerouting to a dead ref that resolves as model_not_found.
+      const visionTarget = projectPolicy?.visionModel || options.visionModel;
+      if (visionTarget) primaryModel = visionTarget;
     }
 
     // Bound once per request (not per candidate) — cheap (a config lookup +

--- a/apps/api/src/projects/routes/gateway.ts
+++ b/apps/api/src/projects/routes/gateway.ts
@@ -1095,7 +1095,7 @@ async function routingPolicyDocument(ctx: RoutingContext, canWrite: boolean) {
     effective: {
       defaultModel: effectiveDefault,
       defaultModelSource,
-      visionModel: stored?.visionModel ?? config.LLM_GATEWAY_VISION_MODEL,
+      visionModel: stored?.visionModel ?? config.LLM_GATEWAY_VISION_MODEL ?? null,
       defaultFallback: {
         models: [...(route.fallbackModels ?? [])],
         fallbackOn: route.fallbackOn ?? 'transient',
@@ -1103,7 +1103,7 @@ async function routingPolicyDocument(ctx: RoutingContext, canWrite: boolean) {
     },
     platform: {
       defaultModel: platformDefaultModelId(),
-      visionModel: config.LLM_GATEWAY_VISION_MODEL,
+      visionModel: config.LLM_GATEWAY_VISION_MODEL ?? null,
       defaultFallback: operatorFallbackFor(platformDefaultModelId()),
     },
     capabilities: { write: canWrite },

--- a/apps/kortix-sandbox-agent-server/src/__tests__/connector-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/connector-mcp-config.test.ts
@@ -173,7 +173,7 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
     )
     const models = config.provider.kortix.models
     expect(Object.keys(models).length).toBeGreaterThan(0)
-    expect(models['claude-sonnet-4.6']).toBeDefined()
+    expect(models['glm-5.2']).toBeDefined()
     expect(Date.now() - started).toBeLessThan(1_000)
   })
 

--- a/apps/kortix-sandbox-agent-server/src/__tests__/fallback-catalog-capabilities.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/fallback-catalog-capabilities.test.ts
@@ -6,11 +6,11 @@ describe('MINIMAL_FALLBACK_MODELS capability metadata', () => {
     expect(MINIMAL_FALLBACK_MODELS['openai/gpt-5.5']?.temperature).toBe(false)
   })
 
-  // Kimi K3 (managed, aster transport) is temperature:false on models.dev —
-  // advertising support would make OpenCode send a `temperature` and 400 the
-  // turn, the same regression class as the OpenAI reasoning-model guard below.
-  test('kimi-k3 (managed aster) does not advertise temperature support', () => {
-    expect(MINIMAL_FALLBACK_MODELS['kimi-k3']?.temperature).toBe(false)
+  // 2026-08-10 managed slim-down: kimi-k3 is deactivated — the fallback
+  // catalog must not advertise it at all (a fallback entry for a model the
+  // gateway resolves as model_not_found would 400 every selection of it).
+  test('kimi-k3 (deactivated managed model) is absent from the fallback catalog', () => {
+    expect(MINIMAL_FALLBACK_MODELS['kimi-k3']).toBeUndefined()
   })
 
   test('no OpenAI reasoning model in the fallback catalog claims temperature support', () => {
@@ -25,9 +25,7 @@ describe('MINIMAL_FALLBACK_MODELS capability metadata', () => {
   // (managed models -> 'kortix', BYOK entries -> their real provider id), the
   // same field the served /v1/models catalog carries (catalog-models.ts).
   test('every fallback model carries an explicit `provider` field matching its wire id', () => {
-    expect(MINIMAL_FALLBACK_MODELS['claude-opus-4.8']?.provider).toBe('kortix')
     expect(MINIMAL_FALLBACK_MODELS['glm-5.2']?.provider).toBe('kortix')
-    expect(MINIMAL_FALLBACK_MODELS['kimi-k3']?.provider).toBe('kortix')
     expect(MINIMAL_FALLBACK_MODELS['openai/gpt-5.5']?.provider).toBe('openai')
     expect(MINIMAL_FALLBACK_MODELS['google/gemini-3.5-flash']?.provider).toBe('google')
     expect(MINIMAL_FALLBACK_MODELS['deepseek/deepseek-v4-flash']?.provider).toBe('deepseek')

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -803,24 +803,28 @@ type KortixGatewayModel = {
 }
 
 export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
-  'claude-opus-4.8': {
-    name: 'Claude Opus 4.8',
-    provider: 'kortix',
-    reasoning: true,
-    tool_call: true,
-    attachment: true,
-    temperature: true,
-    limit: { context: 1_000_000, output: 64_000 },
-  },
-  'claude-sonnet-4.6': {
-    name: 'Claude Sonnet 4.6',
-    provider: 'kortix',
-    reasoning: true,
-    tool_call: true,
-    attachment: true,
-    temperature: true,
-    limit: { context: 1_000_000, output: 64_000 },
-  },
+  // 2026-08-10 managed slim-down: Claude Opus 4.8 / Claude Sonnet 4.6 / Kimi K3
+  // deactivated in @kortix/llm-catalog MANAGED_MODELS — kept commented out here
+  // to match, so this fallback map never advertises a model the gateway
+  // resolves as model_not_found.
+  // 'claude-opus-4.8': {
+  //   name: 'Claude Opus 4.8',
+  //   provider: 'kortix',
+  //   reasoning: true,
+  //   tool_call: true,
+  //   attachment: true,
+  //   temperature: true,
+  //   limit: { context: 1_000_000, output: 64_000 },
+  // },
+  // 'claude-sonnet-4.6': {
+  //   name: 'Claude Sonnet 4.6',
+  //   provider: 'kortix',
+  //   reasoning: true,
+  //   tool_call: true,
+  //   attachment: true,
+  //   temperature: true,
+  //   limit: { context: 1_000_000, output: 64_000 },
+  // },
   // Managed default for fresh sessions. Bare id = Kortix-managed.
   'glm-5.2': {
     name: 'GLM 5.2',
@@ -837,15 +841,15 @@ export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
   // `temperature:false` (it rejects a client-sent temperature), matching
   // capabilitiesOf() in the served catalog. Must NOT advertise temperature
   // support or OpenCode sends one and 400s the turn.
-  'kimi-k3': {
-    name: 'Kimi K3',
-    provider: 'kortix',
-    reasoning: true,
-    tool_call: true,
-    attachment: true,
-    temperature: false,
-    limit: { context: 1_048_576, output: 131_072 },
-  },
+  // 'kimi-k3': {
+  //   name: 'Kimi K3',
+  //   provider: 'kortix',
+  //   reasoning: true,
+  //   tool_call: true,
+  //   attachment: true,
+  //   temperature: false,
+  //   limit: { context: 1_048_576, output: 131_072 },
+  // },
   'openai/gpt-5.5': {
     name: 'GPT-5.5',
     provider: 'openai',

--- a/apps/mobile/lib/utils/model-provider.ts
+++ b/apps/mobile/lib/utils/model-provider.ts
@@ -30,8 +30,8 @@ export function isKortixMode(modelId: string): boolean {
   const id = modelId.startsWith('kortix/') ? modelId.slice('kortix/'.length) : modelId;
   return (
     id === 'auto' ||
-    id === 'claude-opus-4.8' ||
-    id === 'claude-sonnet-4.6' ||
+    // 2026-08-10 managed slim-down: claude-opus-4.8 / claude-sonnet-4.6 /
+    // kimi-k3 are deactivated in @kortix/llm-catalog MANAGED_MODELS.
     id === 'glm-5.2' ||
     id === 'qwen3.7-max' ||
     id === 'deepseek-v4-pro' ||

--- a/apps/web/content/docs/backend.mdx
+++ b/apps/web/content/docs/backend.mdx
@@ -41,7 +41,7 @@ curl -X POST "$KORTIX_API_URL/projects/$KORTIX_PROJECT_ID/sessions" \
   -H "Idempotency-Key: $(uuidgen)" \
   -d '{
     "agent_name": "support",
-    "opencode_model": "kortix/claude-opus-4.8",
+    "opencode_model": "kortix/glm-5.2",
     "runtime_context": { "ticket_id": "ticket-123" },
     "connector_bindings": {
       "gmail": { "connection_id": "<connection-id>" }
@@ -64,7 +64,7 @@ const kortix = createScopedKortix({
 
 const session = await kortix.project(projectId).sessions.create({
   agent_name: 'support',
-  opencode_model: 'kortix/claude-opus-4.8',
+  opencode_model: 'kortix/glm-5.2',
   runtime_context: { ticket_id: 'ticket-123' },
   connector_bindings: {
     gmail: { connection_id: connectionId },

--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -17,7 +17,7 @@ toggle it in Customize → Feature flags.
 
 A model id has one of three shapes:
 
-- **Managed** — a bare id, like `claude-opus-4.8` or `glm-5.2`. Kortix
+- **Managed** — a bare id, like `glm-5.2` or `deepseek-v4-flash`. Kortix
   supplies the credentials. Cloud accounts pay with Kortix credits.
 - **BYOK** — a `provider/model` id, like `anthropic/claude-opus-4-8`. You
   supply the key. Your provider account pays.

--- a/apps/web/content/docs/sdk/example.mdx
+++ b/apps/web/content/docs/sdk/example.mdx
@@ -62,7 +62,7 @@ async function main() {
   //    prompt only (ids come from projects.modelPicker() and
   //    projects.detail().config.agents).
   await session.send('What files are in this repo?', {
-    model: { providerID: 'kortix', modelID: 'claude-sonnet-4.6' },
+    model: { providerID: 'kortix', modelID: 'glm-5.2' },
   });
 
   // 7. Wait for the turn to finish — the session.idle event, not a sleep.

--- a/apps/web/src/features/session/reasoning-effort-selector.test.ts
+++ b/apps/web/src/features/session/reasoning-effort-selector.test.ts
@@ -25,8 +25,8 @@ describe('reasoningEffortValuesFor — composer show/hide source of truth', () =
   });
 
   test('a managed model resolves through its pricingRef to real reasoning_options', () => {
-    const values = reasoningEffortValuesFor('claude-opus-4.8');
-    expect(values).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+    const values = reasoningEffortValuesFor('deepseek-v4-flash');
+    expect(values).toEqual(['high', 'xhigh']);
   });
 });
 

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/generation-controls.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/generation-controls.test.ts
@@ -16,29 +16,25 @@ describe('catalogModelForGateway — client-side capability lookup', () => {
     expect(model?.temperature).toBe(false);
   });
 
-  // MUST-FIX regression (adversarial review of PR #4995): `claude-opus-4.8`'s
-  // `pricingRef` used to be the DOTTED display id ('anthropic/claude-opus-4.8'),
-  // which never matches models.dev's DASHED catalog id ('claude-opus-4-8') —
-  // so this lookup silently missed and fell back to the permissive synthetic
-  // record below (temperature:true, no reasoning_options). It must now hit
-  // the model's REAL catalog entry: temperature:false, and reasoning_options
-  // including the newer 'xhigh'/'max' tiers.
-  test('resolves claude-opus-4.8 to its REAL catalog entry, not the synthetic fallback', () => {
-    const model = catalogModelForGateway('claude-opus-4.8');
+  // MUST-FIX regression (adversarial review of PR #4995): a managed model's
+  // `pricingRef` mismatching its models.dev catalog id makes this lookup
+  // silently miss and fall back to the permissive synthetic record
+  // (temperature:true, no reasoning_options). 2026-08-10 slim-down: the Claude
+  // ids this test used are deactivated; deepseek-v4-flash keeps the regression
+  // covered — its pricingRef ('openrouter/deepseek/deepseek-v4-flash') must hit
+  // the REAL openrouter entry, whose 'high'/'xhigh' effort ladder the synthetic
+  // fallback would never carry.
+  test('resolves deepseek-v4-flash to its REAL catalog entry, not the synthetic fallback', () => {
+    const model = catalogModelForGateway('deepseek-v4-flash');
     expect(model).toBeDefined();
-    expect(model?.id).toBe('claude-opus-4-8');
-    expect(model?.reasoning).toBe(true);
-    expect(model?.temperature).toBe(false);
-    expect(model?.reasoning_options?.[0]?.values).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
-  });
-
-  test('resolves claude-sonnet-4.6 to its REAL catalog entry, not the synthetic fallback', () => {
-    const model = catalogModelForGateway('claude-sonnet-4.6');
-    expect(model).toBeDefined();
-    expect(model?.id).toBe('claude-sonnet-4-6');
+    expect(model?.id).toBe('deepseek/deepseek-v4-flash');
     expect(model?.reasoning).toBe(true);
     expect(model?.temperature).toBe(true);
-    expect(model?.reasoning_options?.[0]?.values).toEqual(['low', 'medium', 'high', 'max']);
+    expect(model?.reasoning_options?.[0]?.values).toEqual(['high', 'xhigh']);
+  });
+
+  test('a deactivated managed id (claude-opus-4.8) no longer resolves', () => {
+    expect(catalogModelForGateway('claude-opus-4.8')).toBeUndefined();
   });
 
   test('does not resolve the removed synthetic auto model', () => {

--- a/docs/KORTIX_AS_A_BACKEND_GUIDE.md
+++ b/docs/KORTIX_AS_A_BACKEND_GUIDE.md
@@ -43,7 +43,7 @@ curl -sS -X POST \
   -H "Idempotency-Key: $(uuidgen)" \
   -d '{
     "agent_name": "support",
-    "opencode_model": "kortix/claude-opus-4.8",
+    "opencode_model": "kortix/glm-5.2",
     "runtime_context": {
       "ticket_id": "ticket-123"
     },
@@ -77,7 +77,7 @@ const kortix = createScopedKortix({
 
 const session = await kortix.project(projectId).sessions.create({
   agent_name: "support",
-  opencode_model: "kortix/claude-opus-4.8",
+  opencode_model: "kortix/glm-5.2",
   runtime_context: { ticket_id: "ticket-123" },
   connector_bindings: {
     "gmail-read": { connection_id: connectionId },

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -504,42 +504,51 @@ export function pricingRefLookupCandidates(pricingRef: string): string[] {
 // (`anthropic/claude-...` → the user's own key) without the two ever colliding.
 //
 // Every managed model runs through OUR keys and is billed as Kortix credits with
-// markup, so the gateway enforces budgets/logging/spend on all of them. Claude
-// runs on Bedrock (the proven Anthropic-payload InvokeModel transport). GLM
-// runs through AsterLab. DeepSeek V4 Flash remains on OpenRouter.
+// markup, so the gateway enforces budgets/logging/spend on all of them. GLM
+// runs through AsterLab. DeepSeek V4 Flash runs on OpenRouter.
+//
+// 2026-08-10: the lineup is deliberately slimmed to GLM 5.2 + DeepSeek V4
+// Flash. Claude Opus 4.8 / Claude Sonnet 4.6 (Bedrock) and Kimi K3 (AsterLab)
+// are deactivated — their entries are kept below, commented out, so
+// reactivation is a diff-review away. Consequences of a removed id:
+// stored account/project/agent defaults pointing at one degrade to the
+// platform default via `degradeUnservableDefault` (the servability probe
+// throws `model_not_found`), and an explicit request errors with
+// `model_not_found`. NOTE: neither remaining model has vision — the managed
+// lineup cannot accept image input; that needs a BYOK provider key.
 export const MANAGED_MODELS: ManagedModel[] = [
-  {
-    id: 'claude-opus-4.8',
-    name: 'Claude Opus 4.8',
-    upstreamModelId: 'us.anthropic.claude-opus-4-8',
-    transport: 'bedrock',
-    pricingRef: 'anthropic/claude-opus-4-8',
-    pricing: {
-      inputPerMillion: 5,
-      cachedInputPerMillion: 0.5,
-      cacheWritePerMillion: 6.25,
-      outputPerMillion: 25,
-    },
-    tier: 'flagship',
-    vision: true,
-    limit: { context: 1_000_000, output: 64_000 },
-  },
-  {
-    id: 'claude-sonnet-4.6',
-    name: 'Claude Sonnet 4.6',
-    upstreamModelId: 'us.anthropic.claude-sonnet-4-6',
-    transport: 'bedrock',
-    pricingRef: 'anthropic/claude-sonnet-4-6',
-    pricing: {
-      inputPerMillion: 3,
-      cachedInputPerMillion: 0.3,
-      cacheWritePerMillion: 3.75,
-      outputPerMillion: 15,
-    },
-    tier: 'balanced',
-    vision: true,
-    limit: { context: 1_000_000, output: 64_000 },
-  },
+  // {
+  //   id: 'claude-opus-4.8',
+  //   name: 'Claude Opus 4.8',
+  //   upstreamModelId: 'us.anthropic.claude-opus-4-8',
+  //   transport: 'bedrock',
+  //   pricingRef: 'anthropic/claude-opus-4-8',
+  //   pricing: {
+  //     inputPerMillion: 5,
+  //     cachedInputPerMillion: 0.5,
+  //     cacheWritePerMillion: 6.25,
+  //     outputPerMillion: 25,
+  //   },
+  //   tier: 'flagship',
+  //   vision: true,
+  //   limit: { context: 1_000_000, output: 64_000 },
+  // },
+  // {
+  //   id: 'claude-sonnet-4.6',
+  //   name: 'Claude Sonnet 4.6',
+  //   upstreamModelId: 'us.anthropic.claude-sonnet-4-6',
+  //   transport: 'bedrock',
+  //   pricingRef: 'anthropic/claude-sonnet-4-6',
+  //   pricing: {
+  //     inputPerMillion: 3,
+  //     cachedInputPerMillion: 0.3,
+  //     cacheWritePerMillion: 3.75,
+  //     outputPerMillion: 15,
+  //   },
+  //   tier: 'balanced',
+  //   vision: true,
+  //   limit: { context: 1_000_000, output: 64_000 },
+  // },
   {
     id: 'glm-5.2',
     name: 'GLM 5.2',
@@ -552,36 +561,38 @@ export const MANAGED_MODELS: ManagedModel[] = [
       cacheWritePerMillion: 1,
       outputPerMillion: 4,
     },
-    tier: 'balanced',
+    // Flagship since the Bedrock Claude deactivation: MANAGED_FLAGSHIP_MODEL_ID
+    // and resolvePlatformDefaultModelId's degrade order both key off this tier.
+    tier: 'flagship',
     vision: false,
     limit: { context: 1_000_000, output: 131_072 },
   },
-  {
-    // Kimi K3 (Moonshot AI) served through AsterLab's OpenAI-compatible
-    // endpoint — same `aster` transport + ASTER_API_KEY as GLM 5.2, so no new
-    // credential is needed. AsterLab accepts the bare `kimi-k3` slug on
-    // https://api.asterlab.ai/v1/chat/completions. `pricingRef` resolves to a
-    // REAL models.dev entry (moonshotai/kimi-k3), so capability lookups borrow
-    // the real reasoning_options (toggle + effort low/high/max) and
-    // temperature:false (K3 rejects a client-sent temperature) instead of the
-    // permissive synthetic fallback. `pricing` is the published Moonshot
-    // upstream rate ($3/$15, $0.30 cache read); Aster is an OpenAI-compatible
-    // proxy — verify against Aster's own price list and adjust via the
-    // LLM_GATEWAY_MANAGED_MODELS overlay if Aster's rate differs.
-    id: 'kimi-k3',
-    name: 'Kimi K3',
-    upstreamModelId: 'kimi-k3',
-    transport: 'aster',
-    pricingRef: 'moonshotai/kimi-k3',
-    pricing: {
-      inputPerMillion: 3,
-      cachedInputPerMillion: 0.3,
-      outputPerMillion: 15,
-    },
-    tier: 'balanced',
-    vision: true,
-    limit: { context: 1_048_576, output: 131_072 },
-  },
+  // {
+  //   // Kimi K3 (Moonshot AI) served through AsterLab's OpenAI-compatible
+  //   // endpoint — same `aster` transport + ASTER_API_KEY as GLM 5.2, so no new
+  //   // credential is needed. AsterLab accepts the bare `kimi-k3` slug on
+  //   // https://api.asterlab.ai/v1/chat/completions. `pricingRef` resolves to a
+  //   // REAL models.dev entry (moonshotai/kimi-k3), so capability lookups borrow
+  //   // the real reasoning_options (toggle + effort low/high/max) and
+  //   // temperature:false (K3 rejects a client-sent temperature) instead of the
+  //   // permissive synthetic fallback. `pricing` is the published Moonshot
+  //   // upstream rate ($3/$15, $0.30 cache read); Aster is an OpenAI-compatible
+  //   // proxy — verify against Aster's own price list and adjust via the
+  //   // LLM_GATEWAY_MANAGED_MODELS overlay if Aster's rate differs.
+  //   id: 'kimi-k3',
+  //   name: 'Kimi K3',
+  //   upstreamModelId: 'kimi-k3',
+  //   transport: 'aster',
+  //   pricingRef: 'moonshotai/kimi-k3',
+  //   pricing: {
+  //     inputPerMillion: 3,
+  //     cachedInputPerMillion: 0.3,
+  //     outputPerMillion: 15,
+  //   },
+  //   tier: 'balanced',
+  //   vision: true,
+  //   limit: { context: 1_048_576, output: 131_072 },
+  // },
   {
     id: 'deepseek-v4-flash',
     name: 'DeepSeek V4 Flash',

--- a/packages/llm-catalog/src/managed.test.ts
+++ b/packages/llm-catalog/src/managed.test.ts
@@ -10,14 +10,10 @@ import {
 } from './index';
 
 describe('managed catalog', () => {
+  // 2026-08-10 slim-down: claude-opus-4.8 / claude-sonnet-4.6 / kimi-k3 are
+  // deactivated (commented out in MANAGED_MODELS, reactivatable by diff).
   test('exposes the managed lineup', () => {
-    expect(DEFAULT_MANAGED_MODEL_IDS).toEqual([
-      'claude-opus-4.8',
-      'claude-sonnet-4.6',
-      'glm-5.2',
-      'kimi-k3',
-      'deepseek-v4-flash',
-    ]);
+    expect(DEFAULT_MANAGED_MODEL_IDS).toEqual(['glm-5.2', 'deepseek-v4-flash']);
   });
 
   test('the haiku/sonnet branded ids are gone from the served catalog', () => {
@@ -25,8 +21,8 @@ describe('managed catalog', () => {
     expect(DEFAULT_MANAGED_MODEL_IDS).not.toContain('kortix-basic');
   });
 
-  test('Opus is the single flagship', () => {
-    expect(MANAGED_FLAGSHIP_MODEL_ID).toBe('claude-opus-4.8');
+  test('GLM 5.2 is the single flagship', () => {
+    expect(MANAGED_FLAGSHIP_MODEL_ID).toBe('glm-5.2');
     expect(MANAGED_MODELS.filter((m) => m.tier === 'flagship')).toHaveLength(1);
   });
 
@@ -121,8 +117,6 @@ describe('managed catalog', () => {
 
 describe('managed resolution + back-compat aliases', () => {
   test('resolves current ids', () => {
-    expect(getManagedModel('claude-opus-4.8')?.name).toBe('Claude Opus 4.8');
-    expect(getManagedModel('claude-opus-4.8')?.transport).toBe('bedrock');
     expect(getManagedModel('glm-5.2')?.name).toBe('GLM 5.2');
     expect(getManagedModel('glm-5.2')?.transport).toBe('aster');
     expect(getManagedModel('glm-5.2')?.upstreamModelId).toBe('glm-5.2');
@@ -131,16 +125,6 @@ describe('managed resolution + back-compat aliases', () => {
       cachedInputPerMillion: 0.2,
       cacheWritePerMillion: 1,
       outputPerMillion: 4,
-    });
-    expect(getManagedModel('kimi-k3')?.name).toBe('Kimi K3');
-    expect(getManagedModel('kimi-k3')?.transport).toBe('aster');
-    expect(getManagedModel('kimi-k3')?.upstreamModelId).toBe('kimi-k3');
-    expect(getManagedModel('kimi-k3')?.vision).toBe(true);
-    expect(getManagedModel('kimi-k3')?.limit).toEqual({ context: 1_048_576, output: 131_072 });
-    expect(getManagedModel('kimi-k3')?.pricing).toEqual({
-      inputPerMillion: 3,
-      cachedInputPerMillion: 0.3,
-      outputPerMillion: 15,
     });
     expect(getManagedModel('deepseek-v4-flash')?.providerBrand).toBeUndefined();
     expect(getManagedModel('deepseek-v4-flash')?.pricing).toEqual({
@@ -161,6 +145,10 @@ describe('managed resolution + back-compat aliases', () => {
       'qwen3-max',
       'minimax-m2.5',
       'kimi-k2',
+      // 2026-08-10 slim-down (commented out, not aliased):
+      'claude-opus-4.8',
+      'claude-sonnet-4.6',
+      'kimi-k3',
     ]) {
       expect(getManagedModel(old), `${old} should be gone`).toBeUndefined();
       expect(isManagedModelId(old), `${old} should be gone`).toBe(false);

--- a/packages/sdk/playground/_shared.ts
+++ b/packages/sdk/playground/_shared.ts
@@ -11,7 +11,7 @@
  *
  * Optional:
  *   KORTIX_PROJECT_ID / KORTIX_SESSION_ID  — pin a project/session
- *   KORTIX_MODEL=claude-sonnet-4.6         — per-send model override (the local
+ *   KORTIX_MODEL=glm-5.2         — per-send model override (the local
  *     stack's default model currently 400s on `max_tokens`, so set this)
  */
 import {

--- a/packages/sdk/playground/agents/07-use-agent.ts
+++ b/packages/sdk/playground/agents/07-use-agent.ts
@@ -6,7 +6,7 @@
  * `projects.detail().config.agents` — script 05 lists them.
  *
  * Run (from packages/sdk):
- *   KORTIX_MODEL=claude-sonnet-4.6 bun run playground/agents/07-use-agent.ts [agentName]
+ *   KORTIX_MODEL=glm-5.2 bun run playground/agents/07-use-agent.ts [agentName]
  */
 import {
   makeKortix,

--- a/packages/sdk/playground/chat/04-send-and-stream.ts
+++ b/packages/sdk/playground/chat/04-send-and-stream.ts
@@ -6,7 +6,7 @@
  * Uses KORTIX_SESSION_ID if set, otherwise creates a fresh session.
  *
  * Run (from packages/sdk):
- *   KORTIX_MODEL=claude-sonnet-4.6 bun run playground/chat/04-send-and-stream.ts "Say hello"
+ *   KORTIX_MODEL=glm-5.2 bun run playground/chat/04-send-and-stream.ts "Say hello"
  */
 import {
   makeKortix,

--- a/packages/sdk/playground/chat/14-change-default-model.ts
+++ b/packages/sdk/playground/chat/14-change-default-model.ts
@@ -15,7 +15,7 @@
  *
  * Run:
  *   KORTIX_API_URL=http://localhost:8008/v1 KORTIX_API_KEY=kortix_pat_... \
- *     bun run playground/chat/14-change-default-model.ts claude-opus-4.8 [projectId]
+ *     bun run playground/chat/14-change-default-model.ts glm-5.2 [projectId]
  *
  * As an npm consumer, the import lines change to:
  *   import { createKortix } from '@kortix/sdk';
@@ -25,13 +25,7 @@ import { MANAGED_MODELS } from "@kortix/llm-catalog";
 
 import { createKortix } from "../../src/index";
 
-const MODEL_IDS = [
-  "claude-opus-4.8",
-  "claude-sonnet-4.6",
-  "glm-5.2",
-  "kimi-k3",
-  "deepseek-v4-flash",
-] as const;
+const MODEL_IDS = ["glm-5.2", "deepseek-v4-flash"] as const;
 
 type ManagedModelId = (typeof MODEL_IDS)[number];
 

--- a/packages/sdk/playground/run-all.ts
+++ b/packages/sdk/playground/run-all.ts
@@ -3,7 +3,7 @@
  *
  * - Creates ONE session up front and pins it via KORTIX_SESSION_ID, so the
  *   five sandbox scripts (04, 06, 07, 09, 11) share a single boot.
- * - Defaults KORTIX_MODEL to claude-sonnet-4.6 when unset (the local stack's
+ * - Defaults KORTIX_MODEL to glm-5.2 when unset (the local stack's
  *   default model currently 400s on `max_tokens`).
  * - Keeps going after a failure; exits 1 if anything failed.
  * - Skipped on purpose: 14-change-default-model (mutates the project's
@@ -54,7 +54,7 @@ run("run-all", async () => {
   const kortix = makeKortix();
   const projectId = await pickProjectId(kortix);
 
-  const model = process.env.KORTIX_MODEL ?? "claude-sonnet-4.6";
+  const model = process.env.KORTIX_MODEL ?? "glm-5.2";
   if (!process.env.KORTIX_MODEL) {
     console.log(
       `KORTIX_MODEL not set — defaulting to ${model} (local gateway bug workaround)`,

--- a/packages/sdk/src/react/use-model-store.test.ts
+++ b/packages/sdk/src/react/use-model-store.test.ts
@@ -52,7 +52,7 @@ describe('hasUsableModel — gateway connection gating prefers the explicit `pro
   });
 
   test('a managed model is usable iff the caller is not free-tier, regardless of `provider`', () => {
-    const models = [gatewayModel({ modelID: 'claude-opus-4.8', provider: 'kortix' })];
+    const models = [gatewayModel({ modelID: 'glm-5.2', provider: 'kortix' })];
     expect(hasUsableModel(models, { freeTier: true })).toBe(false);
     expect(hasUsableModel(models, { freeTier: false })).toBe(true);
   });

--- a/tests/src/flows/billing-reads.flow.ts
+++ b/tests/src/flows/billing-reads.flow.ts
@@ -173,7 +173,7 @@ flow(
         .post("/v1/billing/deduct", {
           prompt_tokens: 0,
           completion_tokens: 0,
-          model: "claude-sonnet-4.6",
+          model: "glm-5.2",
         });
       r.status(401);
     });
@@ -183,7 +183,7 @@ flow(
         .post("/v1/billing/deduct", {
           prompt_tokens: 0,
           completion_tokens: 0,
-          model: "claude-sonnet-4.6",
+          model: "glm-5.2",
         });
       r.status([200, 404]);
       if (r.statusCode === 200) {


### PR DESCRIPTION
## What

Slim the Kortix-managed model lineup from 5 models to 2:

| Model | Status |
|---|---|
| GLM 5.2 (AsterLab) | kept, promoted to `tier: 'flagship'` |
| DeepSeek V4 Flash (OpenRouter) | kept |
| Claude Opus 4.8 (Bedrock) | deactivated (commented out) |
| Claude Sonnet 4.6 (Bedrock) | deactivated (commented out) |
| Kimi K3 (AsterLab) | deactivated (commented out) |

Entries are commented out in `MANAGED_MODELS` (`packages/llm-catalog/src/index.ts`) and mirrored in `MINIMAL_FALLBACK_MODELS` (`apps/kortix-sandbox-agent-server/src/opencode.ts`), so reactivation is a diff-review away. BYOK providers are untouched — `anthropic/...` with a user key still works.

## Behavior changes

- `LLM_GATEWAY_VISION_MODEL` loses its `claude-sonnet-4.6` default (now unset). The vision reroute in `resolve-route.ts` now skips when no target is configured instead of rerouting a default-model image request to a dead ref that resolves as `model_not_found`. **After this PR no managed model has vision** — image input needs a BYOK vision model (per-project `visionModel` policy still works).
- `LLM_GATEWAY_BYOK_FALLBACK_MODEL` default: `claude-sonnet-4.6` -> `glm-5.2`.
- Stored account/project/agent defaults pointing at a removed id degrade to the platform default (`glm-5.2`): `isManagedRef` reads the runtime set, so the servability probe throws `model_not_found` and `degradeUnservableDefault` falls back. No dead turns.
- Explicit requests naming a removed id get `model_not_found`.
- Billing: `calculateTokenCost` no longer prices the removed ids (fail-closed, as for any retired id).

## Verification (all local, real inputs/outputs)

- `packages/llm-catalog`: `bun test` — 72 pass / 0 fail.
- `apps/api`: `bash scripts/test.sh` — 6185 pass / 0 fail (585 files).
- `apps/kortix-sandbox-agent-server`: `bun test` — 465 pass / 0 fail.
- `packages/sdk`: `bun test --isolate src` — 1846 pass / 0 fail.
- `packages/llm-gateway`: `bun test` — 379 pass / 0 fail.
- `apps/web`: `bun test` — 5489 pass / 0 fail.
- `apps/cli`: `bun test` — 792 pass / 0 fail; `packages/starter`: 70 pass.
- Repo root: `pnpm test` — 365/365 REST/CLI flows passed, all lanes PASS.
- `tsc --noEmit` clean on `packages/llm-catalog`, `apps/api`, `packages/sdk`, `apps/kortix-sandbox-agent-server`.

Regression fixtures that needed a managed id whose `pricingRef` resolves on models.dev (the PR #4995 dotted/dashed guard) now use `deepseek-v4-flash` (`openrouter/deepseek/deepseek-v4-flash`, effort ladder `high`/`xhigh`).
