### PR TITLE
feat(llm-catalog): add Muse Spark 1.2, MiniMax M3, GPT-5.6 Luna; DeepSeek V4 Flash default

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -370,10 +370,10 @@ const envSchema = z.object({
   LLM_GATEWAY_DEFAULT_MODEL: optStrDefault(PLATFORM_DEFAULT_MODEL_ID),
   // Target when a DEFAULT-model request carries image input and the default
   // model lacks vision. Empty = no reroute (the request goes to the default
-  // model as-is). Since the 2026-08-10 managed slim-down, no managed model has
-  // vision, so there is no in-house target — set this only to a BYOK-servable
-  // ref or a future vision-capable managed id.
-  LLM_GATEWAY_VISION_MODEL: optStr,
+  // model as-is). gpt-5.6-luna is the cheapest vision-capable managed model
+  // ($0.20/$1.20) — the default platform model (deepseek-v4-flash) is
+  // text-only.
+  LLM_GATEWAY_VISION_MODEL: optStrDefault('gpt-5.6-luna'),
   LLM_GATEWAY_FALLBACK_POLICIES: optFallbackPolicies,
   // Optional JSON array replacing the platform managed-model overlay (transport,
   // upstream id, pricing ref, capabilities). Empty uses the bundled last-known
@@ -385,7 +385,7 @@ const envSchema = z.object({
   // BYOK resilience: when a user's own provider key hits a rate-limit / quota /
   // billing error (429/402/403), fall over to THIS managed model (billed as
   // Kortix credits) so the turn survives instead of erroring. Empty disables.
-  LLM_GATEWAY_BYOK_FALLBACK_MODEL: optStrDefault('glm-5.2'),
+  LLM_GATEWAY_BYOK_FALLBACK_MODEL: optStrDefault('deepseek-v4-flash'),
   // Dev: reverse-proxy /v1/llm-gateway/* to a standalone gateway on this port,
   // so sandboxes reach it through the API's own tunnel (no separate tunnel).
   LLM_GATEWAY_PROXY_PORT: optInt(0),

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -825,7 +825,17 @@ export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
   //   temperature: true,
   //   limit: { context: 1_000_000, output: 64_000 },
   // },
-  // Managed default for fresh sessions. Bare id = Kortix-managed.
+  // Managed default for fresh sessions (PLATFORM_DEFAULT_MODEL_ID).
+  // Bare id = Kortix-managed.
+  'deepseek-v4-flash': {
+    name: 'DeepSeek V4 Flash',
+    provider: 'kortix',
+    reasoning: true,
+    tool_call: true,
+    attachment: false,
+    temperature: true,
+    limit: { context: 1_048_576, output: 64_000 },
+  },
   'glm-5.2': {
     name: 'GLM 5.2',
     provider: 'kortix',
@@ -834,6 +844,37 @@ export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
     attachment: false,
     temperature: true,
     limit: { context: 1_000_000, output: 131_072 },
+  },
+  'muse-spark-1.2': {
+    name: 'Muse Spark 1.2',
+    provider: 'kortix',
+    reasoning: true,
+    tool_call: true,
+    attachment: true,
+    temperature: true,
+    limit: { context: 1_048_576, output: 131_072 },
+  },
+  'minimax-m3': {
+    name: 'MiniMax M3',
+    provider: 'kortix',
+    reasoning: true,
+    tool_call: true,
+    attachment: true,
+    temperature: true,
+    limit: { context: 524_288, output: 131_072 },
+  },
+  // temperature:false — Luna rejects a client-sent temperature (models.dev
+  // openrouter/openai/gpt-5.6-luna), same regression class as the OpenAI
+  // reasoning-model guard below. Must NOT advertise temperature support or
+  // OpenCode sends one and 400s the turn.
+  'gpt-5.6-luna': {
+    name: 'GPT-5.6 Luna',
+    provider: 'kortix',
+    reasoning: true,
+    tool_call: true,
+    attachment: true,
+    temperature: false,
+    limit: { context: 1_050_000, output: 128_000 },
   },
   // Second Kortix-managed AsterLab model (Kimi K3). Same `kortix` provider
   // branding + `aster` transport (ASTER_API_KEY) as GLM 5.2.

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -507,15 +507,21 @@ export function pricingRefLookupCandidates(pricingRef: string): string[] {
 // markup, so the gateway enforces budgets/logging/spend on all of them. GLM
 // runs through AsterLab. DeepSeek V4 Flash runs on OpenRouter.
 //
-// 2026-08-10: the lineup is deliberately slimmed to GLM 5.2 + DeepSeek V4
-// Flash. Claude Opus 4.8 / Claude Sonnet 4.6 (Bedrock) and Kimi K3 (AsterLab)
-// are deactivated — their entries are kept below, commented out, so
+// 2026-08-10: Claude Opus 4.8 / Claude Sonnet 4.6 (Bedrock) and Kimi K3
+// (AsterLab) are deactivated — their entries are kept below, commented out, so
 // reactivation is a diff-review away. Consequences of a removed id:
 // stored account/project/agent defaults pointing at one degrade to the
 // platform default via `degradeUnservableDefault` (the servability probe
 // throws `model_not_found`), and an explicit request errors with
-// `model_not_found`. NOTE: neither remaining model has vision — the managed
-// lineup cannot accept image input; that needs a BYOK provider key.
+// `model_not_found`.
+//
+// Same day, three cheap near-frontier models were added (all OpenRouter
+// transport): Muse Spark 1.2, MiniMax M3, and GPT-5.6 Luna. All three carry
+// vision, which restores an image-input path after the Claude removal
+// (LLM_GATEWAY_VISION_MODEL defaults to gpt-5.6-luna, the cheapest vision
+// model), and DeepSeek V4 Flash became the platform default (cheapest
+// credible agentic coder; beats GLM 5.2 on every published agentic
+// benchmark while costing ~10x less per unit of work).
 export const MANAGED_MODELS: ManagedModel[] = [
   // {
   //   id: 'claude-opus-4.8',
@@ -646,6 +652,98 @@ export const MANAGED_MODELS: ManagedModel[] = [
       allow_fallbacks: true,
     },
   },
+  {
+    // Meta's Muse Spark 1.2 via OpenRouter. Exactly ONE endpoint serves the
+    // standard slug (Meta first-party: 1_048_576 ctx, tools, 100% 30m uptime
+    // measured 2026-08-10), so the pin is trivial. NEVER switch this to the
+    // `meta/muse-spark-1.2-contributor` slug — its 10x-cheaper tier grants
+    // Meta training rights over prompts and completions, which is
+    // disqualifying for customer sessions. `pricingRef` is the model's REAL
+    // models.dev id (live api.json has it as of 2026-08-10; the committed
+    // catalog.generated.json snapshot predates the 2026-08-05 release, so
+    // snapshot-only consumers fall back to the synthetic capability record
+    // until the next snapshot regen — the served runtime catalog fetches
+    // live models.dev and resolves it).
+    id: 'muse-spark-1.2',
+    name: 'Muse Spark 1.2',
+    upstreamModelId: 'meta/muse-spark-1.2',
+    transport: 'openrouter',
+    pricingRef: 'meta/muse-spark-1.2',
+    pricing: {
+      inputPerMillion: 1.25,
+      cachedInputPerMillion: 0.15,
+      outputPerMillion: 4.25,
+    },
+    tier: 'balanced',
+    vision: true,
+    limit: { context: 1_048_576, output: 131_072 },
+    openrouterProvider: {
+      order: ['meta'],
+      allow_fallbacks: true,
+    },
+  },
+  {
+    // MiniMax M3 via OpenRouter. 9 endpoints serve the slug (measured
+    // 2026-08-10) and they are NOT interchangeable:
+    //  - `gmicloud` (the cheapest, $0.24/$0.96) advertises NO tool support —
+    //    routing there breaks the agent harness outright, hence the explicit
+    //    `ignore`;
+    //  - `parasail` caps max_completion_tokens at 32_768 and `venice` at
+    //    65_536 against the 131_072 this entry advertises;
+    //  - context spans 256_000 (morph) to 1_048_576 (parasail).
+    // Order: `minimax` first (first-party, 524_288 ctx, 512_000 max out,
+    // 99.85% uptime), then `novita` (1_000_000 ctx, 131_072 max out, 99.88%).
+    // The advertised limit is the SAFE INTERSECTION of the two pinned hosts
+    // (ctx 524_288, output 131_072) so a session sized to this entry can land
+    // on either without truncation.
+    id: 'minimax-m3',
+    name: 'MiniMax M3',
+    upstreamModelId: 'minimax/minimax-m3',
+    transport: 'openrouter',
+    pricingRef: 'openrouter/minimax/minimax-m3',
+    pricing: {
+      inputPerMillion: 0.3,
+      cachedInputPerMillion: 0.06,
+      outputPerMillion: 1.2,
+    },
+    tier: 'balanced',
+    vision: true,
+    limit: { context: 524_288, output: 131_072 },
+    openrouterProvider: {
+      order: ['minimax', 'novita'],
+      ignore: ['gmicloud'],
+      allow_fallbacks: true,
+    },
+  },
+  {
+    // OpenAI's GPT-5.6 Luna via OpenRouter. First-party OpenAI endpoints plus
+    // Azure and Bedrock all advertise tools + 1_050_000 ctx / 128_000 max out
+    // (measured 2026-08-10); pin `openai` for cache locality. `pricingRef`
+    // resolves to the REAL models.dev openrouter entry — temperature:false
+    // (Luna rejects a client-sent temperature; advertising support would 400
+    // the turn) and the none→max effort ladder. `pricing` is OpenAI's
+    // published post-2026-07-30 rate ($0.20/$1.20, $0.02 cache read).
+    // KNOWN CAVEAT: measured TTFT at MAX reasoning effort is ~144s (median
+    // 1.87s at defaults) — fine for background agents, poor for interactive
+    // max-effort use.
+    id: 'gpt-5.6-luna',
+    name: 'GPT-5.6 Luna',
+    upstreamModelId: 'openai/gpt-5.6-luna',
+    transport: 'openrouter',
+    pricingRef: 'openrouter/openai/gpt-5.6-luna',
+    pricing: {
+      inputPerMillion: 0.2,
+      cachedInputPerMillion: 0.02,
+      outputPerMillion: 1.2,
+    },
+    tier: 'balanced',
+    vision: true,
+    limit: { context: 1_050_000, output: 128_000 },
+    openrouterProvider: {
+      order: ['openai'],
+      allow_fallbacks: true,
+    },
+  },
 ];
 
 const MANAGED_BY_ID = new Map(MANAGED_MODELS.map((m) => [m.id, m] as const));
@@ -665,7 +763,7 @@ export const MANAGED_FLAGSHIP_MODEL_ID = (
 ).id;
 
 /** Concrete Kortix-managed default used when no account or project default exists. */
-export const PLATFORM_DEFAULT_MODEL_ID = 'glm-5.2';
+export const PLATFORM_DEFAULT_MODEL_ID = 'deepseek-v4-flash';
 
 function modelsByWireId(catalog: Catalog): Map<string, CatalogModel> {
   const byId = new Map<string, CatalogModel>();

--- a/packages/llm-catalog/src/managed.test.ts
+++ b/packages/llm-catalog/src/managed.test.ts
@@ -10,10 +10,17 @@ import {
 } from './index';
 
 describe('managed catalog', () => {
-  // 2026-08-10 slim-down: claude-opus-4.8 / claude-sonnet-4.6 / kimi-k3 are
-  // deactivated (commented out in MANAGED_MODELS, reactivatable by diff).
+  // 2026-08-10: claude-opus-4.8 / claude-sonnet-4.6 / kimi-k3 deactivated
+  // (commented out in MANAGED_MODELS, reactivatable by diff); muse-spark-1.2,
+  // minimax-m3, and gpt-5.6-luna added the same day.
   test('exposes the managed lineup', () => {
-    expect(DEFAULT_MANAGED_MODEL_IDS).toEqual(['glm-5.2', 'deepseek-v4-flash']);
+    expect(DEFAULT_MANAGED_MODEL_IDS).toEqual([
+      'glm-5.2',
+      'deepseek-v4-flash',
+      'muse-spark-1.2',
+      'minimax-m3',
+      'gpt-5.6-luna',
+    ]);
   });
 
   test('the haiku/sonnet branded ids are gone from the served catalog', () => {

--- a/packages/llm-catalog/src/platform-default.test.ts
+++ b/packages/llm-catalog/src/platform-default.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe('PLATFORM_DEFAULT_MODEL_ID', () => {
   test('is a concrete managed model', () => {
-    expect(PLATFORM_DEFAULT_MODEL_ID).toBe('glm-5.2');
+    expect(PLATFORM_DEFAULT_MODEL_ID).toBe('deepseek-v4-flash');
     expect(getManagedModel(PLATFORM_DEFAULT_MODEL_ID)).toBeDefined();
   });
 


### PR DESCRIPTION
## What

Follow-up to #6348. The managed lineup grows from 2 to 5, and the platform default changes:

| Model | Transport | Price (in/out per M) | Vision | Role |
|---|---|---|---|---|
| GLM 5.2 | AsterLab | $1.00 / $4.00 | no | flagship tier |
| DeepSeek V4 Flash | OpenRouter | $0.094 / $0.188 | no | **new platform default** |
| Muse Spark 1.2 (new) | OpenRouter | $1.25 / $4.25 | yes | |
| MiniMax M3 (new) | OpenRouter | $0.30 / $1.20 | yes | |
| GPT-5.6 Luna (new) | OpenRouter | $0.20 / $1.20 | yes | vision reroute default |

## Decisions

- `PLATFORM_DEFAULT_MODEL_ID`: `glm-5.2` -> `deepseek-v4-flash`. Cheapest credible agentic coder (Terminal-Bench 2.1: 82.7 vs GLM's 81.0; beats GLM on all 9 published agentic benchmarks at ~10x lower cost per unit of work), and already battle-tested in this stack with tuned cache-locality pinning. `LLM_GATEWAY_BYOK_FALLBACK_MODEL` follows.
- `LLM_GATEWAY_VISION_MODEL` defaults to `gpt-5.6-luna` (cheapest vision-capable managed model) — image input on the managed lineup works again after #6348 removed it.
- Every OpenRouter entry pins provider routing (enforced by `managed.test.ts`), from endpoint data measured 2026-08-10:
  - `muse-spark-1.2`: single Meta first-party endpoint. The `-contributor` slug is deliberately NOT used — it grants Meta training rights over prompts/completions.
  - `minimax-m3`: pin `minimax` -> `novita`, `ignore: [gmicloud]` (GMICloud advertises no tool support — would break the agent harness). Advertised limit (524k ctx / 131k out) is the safe intersection of the pinned hosts.
  - `gpt-5.6-luna`: pin `openai`. `temperature: false` via its real models.dev entry (Luna rejects a client-sent temperature).
- `MINIMAL_FALLBACK_MODELS` (sandbox agent server) gains the three new entries plus the previously missing bare `deepseek-v4-flash` — now the fresh-session default, so the fallback catalog must carry it.

## Verification

Live upstream, real completions through our OpenRouter key with the exact pinned provider prefs:

- `minimax/minimax-m3` -> served by `Minimax` (first-party, per pin), content `OK`, cost $0.00005.
- `openai/gpt-5.6-luna` -> served by `OpenAI`, content `OK`.
- `meta/muse-spark-1.2` -> **403: account needs the 18+ age attestation** (dashboard-only setting at openrouter.ai/settings/preferences; Marko to confirm). Ships anyway per request; selecting it errors until the attestation is confirmed.

Local suites (all green):

- `packages/llm-catalog` 72 pass; `apps/api` `scripts/test.sh` 6187 pass / 0 fail; `apps/kortix-sandbox-agent-server` 465 pass; `packages/sdk` 1846 pass; `apps/web` 5492 pass.
- Repo root `pnpm test`: all lanes PASS (365/365 REST/CLI flows).
- `tsc --noEmit` clean on llm-catalog, api, sandbox-agent-server.

Muse Spark 1.2's `pricingRef` (`meta/muse-spark-1.2`) resolves on LIVE models.dev (released 2026-08-05) but not in the committed `catalog.generated.json` snapshot, which predates it — snapshot-only consumers use the synthetic capability record until the next snapshot regen; the served runtime catalog fetches live models.dev.
