### PR TITLE
fix(ci): install Bun for preview controller

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -269,6 +269,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
       - name: Revalidate exact preview approval
         run: |
           set -euo pipefail
@@ -439,6 +440,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
       - name: Delete the Platinum or Daytona preview sandbox
         run: bun tests/bin/sandbox-preview.ts teardown
       - name: Remove stale preview approval
@@ -484,4 +486,5 @@ jobs:
         with:
           ref: main
           persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
       - run: bun tests/bin/sandbox-preview.ts reconcile

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -155,6 +155,7 @@ describe('web ECS migration', () => {
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts deploy');
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts teardown');
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts reconcile');
+    expect(workflow.match(/uses: oven-sh\/setup-bun@v2/g)).toHaveLength(3);
     expect(workflow).toContain('pnpm test -- --target-full');
     expect(workflow).toContain('PREVIEW_LOCKFILE_SHA256');
     expect(workflow).toContain('Test report:');


### PR DESCRIPTION
## Cause

The preview controller job exited `127` before sandbox creation because Bun was absent. Teardown and reconciliation used the same missing runtime.

## Fix

Install Bun in the deploy, teardown, and reconciliation jobs. Add a workflow contract test for all three call sites.

## Verification

- Failing contract test reproduced the missing setup.
- Focused workflow test: 10 passed, 0 failed.
- `actionlint .github/workflows/deploy-preview.yml`: passed.
- `pnpm test`: passed in 30.3s.