### PR TITLE
fix(llm-gateway): serve real managed-model capabilities via pricingRef

### DIFF
--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -22,6 +22,30 @@ describe('gatewayModelCatalog — served catalog', () => {
     });
   });
 
+  // Regression: managedModels() used to hardcode `temperature: true` for the
+  // whole managed lineup. gpt-5.6-luna REJECTS a client-sent temperature —
+  // OpenCode reads this served record, so advertising support 400s every
+  // Luna turn. Capabilities must come from the real catalog record via
+  // pricingRef; curated vision/limit still win.
+  test('managed gpt-5.6-luna serves its REAL capabilities (temperature:false, effort ladder)', () => {
+    const luna = full['gpt-5.6-luna'];
+    expect(luna).toBeDefined();
+    expect(luna?.temperature).toBe(false);
+    expect(luna?.reasoning_options?.[0]?.values).toEqual([
+      'none',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+    ]);
+    // Curated fields win over the models.dev record.
+    expect(luna?.attachment).toBe(true);
+    expect(luna?.limit?.context).toBe(1_050_000);
+    // Unresolvable pricingRef (glm-5.2) keeps the permissive defaults.
+    expect(full['glm-5.2']?.temperature).toBe(true);
+  });
+
   test('every served model carries a positive context limit', () => {
     const missing = Object.entries(full)
       .filter(([, m]) => !(typeof m.limit?.context === 'number' && m.limit.context > 0))

--- a/apps/api/src/llm-gateway/models/catalog-models.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.ts
@@ -185,8 +185,14 @@ export function managedModels(): Record<string, GatewayModel> {
   // catalog must never advertise a model that request-time resolution refuses.
   if (SERVED_MANAGED_MODELS.length === 0) return out;
   // The managed lineup is curated and its slugs don't all exist on models.dev
-  // (z-ai≠zhipuai, dotted vs dashed Claude ids), so vision + limit are explicit
-  // on each model. All current managed models support reasoning/tools/temperature.
+  // (z-ai≠zhipuai), so vision + limit are explicit on each model and always
+  // win. Everything else (temperature, reasoning_options, structured_output,
+  // ...) comes from the model's REAL catalog record via its pricingRef when
+  // that resolves — hardcoding `temperature: true` here is exactly the bug
+  // class the sandbox fallback catalog documents: gpt-5.6-luna REJECTS a
+  // client-sent temperature, so advertising support makes OpenCode send one
+  // and 400 every turn. Unresolvable refs (glm-5.2) keep the permissive
+  // defaults.
   for (const m of SERVED_MANAGED_MODELS) {
     const cost = m.pricing
       ? {
@@ -200,13 +206,17 @@ export function managedModels(): Record<string, GatewayModel> {
             : {}),
         }
       : undefined;
+    const real = catalogModelForWireModel(m.id);
+    const caps = real && real.attachment !== undefined ? capabilitiesOf(real) : undefined;
     out[m.id] = {
       name: m.name,
       provider: m.providerBrand ?? KORTIX_PROVIDER_ID,
       reasoning: true,
       tool_call: true,
-      attachment: m.vision,
       temperature: true,
+      ...(caps ?? {}),
+      // Curated fields always win over the models.dev record.
+      attachment: m.vision,
       limit: m.limit,
       ...(cost ? { cost } : {}),
     };


### PR DESCRIPTION
Follow-up to #6352. `managedModels()` hardcoded `temperature: true` for every managed model. GPT-5.6 Luna rejects a client-sent temperature (models.dev `openrouter/openai/gpt-5.6-luna` says `temperature: false`), so OpenCode reading the served record would send one and 400 every Luna turn — found while behavior-verifying #6352 on dev (`GET /model-picker` showed `gpt-5.6-luna.temperature: true`).

Fix: resolve each managed model's capability record via its `pricingRef` (`catalogModelForWireModel`); curated `vision`/`limit` still win; unresolvable refs (glm-5.2) keep permissive defaults. Also surfaces real `reasoning_options` for luna + deepseek-v4-flash (effort selector).

Verification: new regression test in `catalog-models.test.ts` (luna temperature:false + none→max effort ladder + curated attachment/limit; glm stays permissive). `apps/api` full suite 6188 pass / 0 fail; `tsc --noEmit` clean.