### PR TITLE
fix(test): separate Platinum cold and restore budgets

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -65,7 +65,8 @@ deletion replaces the local Supabase teardown.
 Deployed staging browser runs also set two workers explicitly.
 Platinum warm restore readiness is capped at 2 minutes. A missing marker or
 unreachable guest after that cap is an infrastructure error and triggers auto
-fallback. Cold template builds keep their separate 45-minute creation budget.
+fallback. A sandbox reported as `via=cold-boot` gets 45 minutes to prepare the
+warm image. This cold preparation budget does not weaken the restore cap.
 
 Both providers use a content-addressed warm image. The image name includes the
 `pnpm-lock.yaml` hash. Both images contain pinned Node, Bun, pnpm, Docker,
@@ -149,6 +150,8 @@ The base template requests Platinum's `kernel_modules: container` profile.
 The capture and worker load those modules before they start dockerd. This
 infrastructure does not change test logic.
 
+The capture retries Supabase startup for up to 40 minutes. This absorbs bounded
+registry rate limits while preserving the 45-minute cold preparation budget.
 The capture and fresh local stack use Supabase's `--ignore-health-check` only
 before migrations. This prevents PostgREST from rejecting a new database before
 the `kortix` schema exists. The runner still requires migrations and service

--- a/tests/src/core/platinum-ci.ts
+++ b/tests/src/core/platinum-ci.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 
-export const PLATINUM_CI_TEMPLATE_VERSION = 'v12';
+export const PLATINUM_CI_TEMPLATE_VERSION = 'v13';
 const PLATINUM_CI_BASE_TEMPLATE_VERSION = 'v10';
 export const PLATINUM_CI_NODE_IMAGE =
   'node:22.22.0-bookworm@sha256:2e3d655fd1e3ffaa6b5f23ee9f3905a0fd9e8c0a65df94c8ae6e4d18a0f48870';
@@ -231,7 +231,7 @@ function platinumWarmEntrypoint(): string {
     'dockerd --host=unix:///var/run/docker.sock >/workspace/kortix-template-dockerd.log 2>&1 &',
     "timeout 180 sh -c 'until docker info >/dev/null 2>&1; do sleep 1; done'",
     'docker info >/dev/null',
-    'pnpm exec supabase start --ignore-health-check',
+    "timeout 2400 sh -c 'until pnpm exec supabase start --ignore-health-check; do sleep 30; done'",
     'docker image ls -q | sort -u | wc -l > /workspace/.kortix-ci-warm-ready',
     "grep -Eq '^[1-9][0-9]*$' /workspace/.kortix-ci-warm-ready",
     'docker image ls --digests',
@@ -746,8 +746,18 @@ export async function observePlatinumSandboxStart(input: {
   );
 }
 
-export async function waitForWarmSandbox(api: PlatinumApi, sandboxId: string): Promise<void> {
-  const deadline = Date.now() + PLATINUM_CI_WARM_TIMEOUT_MS;
+export function platinumWarmReadinessTimeoutMs(
+  via: PlatinumSandbox['via'],
+): number {
+  return via === 'cold-boot' ? WARM_PREPARE_TIMEOUT_MS : PLATINUM_CI_WARM_TIMEOUT_MS;
+}
+
+export async function waitForWarmSandbox(
+  api: PlatinumApi,
+  sandboxId: string,
+  timeoutMs = PLATINUM_CI_WARM_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   let observationFailures = 0;
   while (Date.now() < deadline) {
     try {
@@ -784,7 +794,7 @@ export async function waitForWarmSandbox(api: PlatinumApi, sandboxId: string): P
     // The log is optional. The missing marker is the authoritative failure.
   }
   throw new Error(
-    `Platinum sandbox ${sandboxId} did not become warm within ${PLATINUM_CI_WARM_TIMEOUT_MS}ms\n${warmLog.slice(-20_000)}`,
+    `Platinum sandbox ${sandboxId} did not become warm within ${timeoutMs}ms\n${warmLog.slice(-20_000)}`,
   );
 }
 
@@ -1036,7 +1046,7 @@ export async function runPlatinumCi(input: PlatinumCiInput): Promise<number> {
     sandboxCreateDurationMs = Date.now() - createStartedAt;
 
     const warmStartedAt = Date.now();
-    await waitForWarmSandbox(api, sandboxId);
+    await waitForWarmSandbox(api, sandboxId, platinumWarmReadinessTimeoutMs(sandbox.via));
     warmPrepareDurationMs = Date.now() - warmStartedAt;
 
     const workerScript = buildWorkerScript(input);

--- a/tests/src/core/sandbox-preview-providers.ts
+++ b/tests/src/core/sandbox-preview-providers.ts
@@ -26,6 +26,7 @@ import {
   exec as execPlatinum,
   observePlatinumSandboxStart,
   observePlatinumWorker,
+  platinumWarmReadinessTimeoutMs,
   stat as statPlatinum,
   waitForWarmSandbox,
 } from './platinum-ci';
@@ -192,7 +193,7 @@ export async function deployPlatinumPreview(
       startedAt,
       readSandbox: () => api.json<PlatinumSandbox>(`/v1/sandboxes/${created.id}`),
     });
-    await waitForWarmSandbox(api, sandboxId);
+    await waitForWarmSandbox(api, sandboxId, platinumWarmReadinessTimeoutMs(sandbox.via));
     let previewUrl = sandbox.exposed?.find((item) => item.port === 8080)?.url;
     if (!previewUrl) {
       const exposed = await api.json<{ url: string }>(`/v1/sandboxes/${sandboxId}/expose`, {

--- a/tests/unit/platinum-ci.test.ts
+++ b/tests/unit/platinum-ci.test.ts
@@ -3,6 +3,7 @@ import {
   PLATINUM_CI_BUN_VERSION,
   PLATINUM_CI_NODE_IMAGE,
   PLATINUM_CI_PNPM_VERSION,
+  PLATINUM_CI_TEMPLATE_VERSION,
   PLATINUM_CI_WARM_TIMEOUT_MS,
   PlatinumHttpError,
   buildPlatinumTemplateSpec,
@@ -19,6 +20,7 @@ import {
   retryPlatinumOperation,
   selectReusablePlatinumTemplate,
   platinumTemplateName,
+  platinumWarmReadinessTimeoutMs,
   validatePlatinumCiInput,
 } from '../src/core/platinum-ci';
 
@@ -32,10 +34,14 @@ afterEach(() => {
 describe('Platinum CI worker plan', () => {
   test('bounds warm restore readiness so auto mode can fail over quickly', () => {
     expect(PLATINUM_CI_WARM_TIMEOUT_MS).toBe(120_000);
+    expect(platinumWarmReadinessTimeoutMs('restore')).toBe(120_000);
+    expect(platinumWarmReadinessTimeoutMs('cold-boot')).toBe(2_700_000);
+    expect(platinumWarmReadinessTimeoutMs(undefined)).toBe(120_000);
   });
 
   test('uses one content-addressed template for one lockfile', () => {
-    expect(platinumTemplateName(lockHash)).toBe('kortix-ci-v12-bbbbbbbbbbbbbbbb');
+    expect(PLATINUM_CI_TEMPLATE_VERSION).toBe('v13');
+    expect(platinumTemplateName(lockHash)).toBe('kortix-ci-v13-bbbbbbbbbbbbbbbb');
     expect(platinumBaseTemplateName(lockHash)).toBe('kortix-ci-v10-bbbbbbbbbbbbbbbb-base');
     const spec = buildPlatinumTemplateSpec({
       lockHash,
@@ -55,7 +61,9 @@ describe('Platinum CI worker plan', () => {
     expect(JSON.stringify(spec.steps)).toContain(`fetch --depth=1 origin ${sha}`);
     expect(JSON.stringify(spec.steps)).toContain('playwright install --with-deps chromium');
     expect(JSON.stringify(spec.steps)).toContain('git init /workspace/suna');
-    expect(spec.entrypoint).toContain('supabase start --ignore-health-check');
+    expect(spec.entrypoint).toContain(
+      "timeout 2400 sh -c 'until pnpm exec supabase start --ignore-health-check; do sleep 30; done'",
+    );
     expect(spec.entrypoint).not.toContain('docker pull postgres:16-alpine');
     expect(spec.entrypoint).toContain('supabase stop --no-backup');
     expect(spec.entrypoint).toContain('.kortix-ci-warm-ready');


### PR DESCRIPTION
## Problem

Platinum warm-image preparation failed when Docker Hub returned `toomanyrequests`. The controller then applied the 120-second restore deadline to a sandbox reported as `via=cold-boot`.

## Change

- create the repaired derived image as `kortix-ci-v13-*`
- retry `supabase start --ignore-health-check` for up to 40 minutes during capture
- allow `via=cold-boot` 45 minutes for warm preparation
- keep `via=restore` and unknown paths capped at 120 seconds
- apply the same timeout policy to CI workers and preview sandboxes
- document the cold and restore budgets

## Verification

- `pnpm --dir tests test -- unit/platinum-ci.test.ts`: 15 passed, 0 failed
- `pnpm --dir tests typecheck`: exit 0
- `pnpm test`: 5 lanes passed, 0 failed, 32.160 s
- `pnpm test -- --full`: 6 lanes passed, 0 failed, 184.3 s
- full REST/CLI lane: 365 passed, 0 failed, 0 skipped
- full browser lane: 11 passed, 0 failed, 7 configured local-profile exclusions
- package quality lane: passed
