### PR TITLE
feat(infra): CI-applied Terraform — reusable guarded apply, per-env OIDC roles, drift coverage

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -180,6 +180,7 @@ jobs:
       aws_region: us-west-2
       role_arn: ${{ vars.TF_APPLY_ROLE_ARN_DEV }}
       github_environment: dev
+      trusted_branch: main
       cloudflare: true
     secrets: inherit
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -167,10 +167,16 @@ jobs:
   # TF_APPLY_ROLE_ARN_DEV is set — so merging this before the IAM role exists
   # cannot break the dev pipeline. The image jobs below treat a SKIPPED
   # terraform job as a pass and a FAILED one as a blocker.
+  #
+  # The `github.ref` condition keeps the documented "manual branch run" of this
+  # workflow working: terraform-apply.yml refuses any commit that is not on
+  # `main`, so on a branch dispatch this job would fail and block the image
+  # deploys. Skipping is the correct outcome there — a branch run deploys
+  # images, never infrastructure.
   terraform-dev:
     name: Apply dev Terraform
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.terraform == 'true' && vars.TF_APPLY_ROLE_ARN_DEV != '' }}
+    if: ${{ needs.detect-changes.outputs.terraform == 'true' && vars.TF_APPLY_ROLE_ARN_DEV != '' && github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -53,6 +53,7 @@ jobs:
       frontend: ${{ steps.outputs.outputs.frontend }}
       cli: ${{ steps.outputs.outputs.cli }}
       apps_router: ${{ steps.outputs.outputs.apps_router }}
+      terraform: ${{ steps.outputs.outputs.terraform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -108,6 +109,14 @@ jobs:
             apps_router:
               - 'infra/cloudflare/workers/apps-router/**'
               - '.github/workflows/deploy-dev.yml'
+            # Only the roots this pipeline actually applies. environments/dev is
+            # deliberately absent: it reads an operator-local terraform.tfvars
+            # and is still applied by hand (see terraform-apply.yml).
+            terraform:
+              - 'infra/terraform/environments/dev-web/**'
+              - 'infra/terraform/modules/**'
+              - '.github/workflows/terraform-apply.yml'
+              - '.github/workflows/deploy-dev.yml'
       - name: Normalize outputs
         id: outputs
         run: |
@@ -116,6 +125,7 @@ jobs:
           gateway="${{ steps.filter.outputs.gateway }}"
           frontend="${{ steps.filter.outputs.frontend }}"
           cli="${{ steps.filter.outputs.cli }}"
+          terraform="${{ steps.filter.outputs.terraform }}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "${{ inputs.surface }}" = "frontend" ]; then
               api=false
@@ -123,10 +133,12 @@ jobs:
               gateway=false
               frontend=true
               cli=false
+              terraform=false
             else
               api=true
               apps_router=true
               frontend=true
+              terraform=true
             fi
           fi
           {
@@ -135,6 +147,7 @@ jobs:
             echo "gateway=$gateway"
             echo "frontend=$frontend"
             echo "cli=$cli"
+            echo "terraform=$terraform"
           } >> "$GITHUB_OUTPUT"
       - name: Summary
         run: |
@@ -145,7 +158,30 @@ jobs:
             echo "- Frontend: ${{ steps.outputs.outputs.frontend }}"
             echo "- CLI: ${{ steps.outputs.outputs.cli }}"
             echo "- Apps router: ${{ steps.outputs.outputs.apps_router }}"
+            echo "- Terraform (dev-web): ${{ steps.outputs.outputs.terraform }}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Apply dev Terraform before any image rolls ──────────────────────────────
+  # Infrastructure first, then the image that runs on it. Skipped when nothing
+  # under the dev roots changed, and skipped entirely until the repo variable
+  # TF_APPLY_ROLE_ARN_DEV is set — so merging this before the IAM role exists
+  # cannot break the dev pipeline. The image jobs below treat a SKIPPED
+  # terraform job as a pass and a FAILED one as a blocker.
+  terraform-dev:
+    name: Apply dev Terraform
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.terraform == 'true' && vars.TF_APPLY_ROLE_ARN_DEV != '' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/terraform-apply.yml
+    with:
+      tf_root: infra/terraform/environments/dev-web
+      aws_region: us-west-2
+      role_arn: ${{ vars.TF_APPLY_ROLE_ARN_DEV }}
+      github_environment: dev
+      cloudflare: true
+    secrets: inherit
 
   # ── Compute the dev version (single source of truth) ────────────────────────
   # Dev builds are a pre-release of the UPCOMING version, derived from the latest
@@ -329,8 +365,16 @@ jobs:
   # ── Roll the freshly-built image onto the dev ECS Fargate service ───────────
   deploy-api-ecs:
     name: Deploy API to dev (ECS Fargate)
-    needs: [detect-changes, dev-version, tag-api, migrate-db]
-    if: needs.detect-changes.outputs.api == 'true'
+    needs: [detect-changes, dev-version, tag-api, migrate-db, terraform-dev]
+    # `always()` is required because terraform-dev is SKIPPED whenever no dev
+    # Terraform changed — without it GitHub would skip this job too. Every other
+    # upstream is still required to have succeeded.
+    if: >-
+      ${{ always()
+        && needs.detect-changes.outputs.api == 'true'
+        && needs.tag-api.result == 'success'
+        && needs.migrate-db.result == 'success'
+        && (needs.terraform-dev.result == 'success' || needs.terraform-dev.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # OIDC → ECS deploy role
@@ -609,8 +653,14 @@ jobs:
 
   deploy-web-ecs:
     name: Deploy frontend to dev (ECS Fargate)
-    needs: [detect-changes, dev-version, build-frontend]
-    if: needs.detect-changes.outputs.frontend == 'true'
+    needs: [detect-changes, dev-version, build-frontend, terraform-dev]
+    # Same soft dependency as deploy-api-ecs: environments/dev-web owns the web
+    # ALB, WAF association, and task roles this image runs behind.
+    if: >-
+      ${{ always()
+        && needs.detect-changes.outputs.frontend == 'true'
+        && needs.build-frontend.result == 'success'
+        && (needs.terraform-dev.result == 'success' || needs.terraform-dev.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -126,6 +126,7 @@ jobs:
       aws_region: eu-west-2
       role_arn: ${{ vars.TF_APPLY_ROLE_ARN_PROD }}
       github_environment: prod
+      trusted_branch: prod
       cloudflare: true
     secrets: inherit
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -102,6 +102,33 @@ jobs:
             echo "No RELEASE_SOURCE_SHA (legacy release) — will use legacy dev fallback images"
           fi
 
+  # ── Apply production Terraform before any image rolls ───────────────────────
+  # Scope: environments/prod-web only. environments/prod reads an
+  # operator-local, gitignored terraform.tfvars (it pins api_image to the
+  # release tag and sets api_environment), so CI would plan against inputs no
+  # operator ever used. That root stays manual until those inputs move into
+  # variables this workflow supplies — see terraform-apply.yml.
+  #
+  # Skipped while TF_APPLY_ROLE_ARN_PROD is unset, so merging this before the
+  # IAM role exists cannot break a release. Once set, a failed apply blocks the
+  # release: shipping an image onto infrastructure that failed to converge is
+  # exactly the state this pipeline exists to prevent.
+  terraform-prod:
+    name: Apply prod Terraform
+    needs: version
+    if: vars.TF_APPLY_ROLE_ARN_PROD != ''
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/terraform-apply.yml
+    with:
+      tf_root: infra/terraform/environments/prod-web
+      aws_region: eu-west-2
+      role_arn: ${{ vars.TF_APPLY_ROLE_ARN_PROD }}
+      github_environment: prod
+      cloudflare: true
+    secrets: inherit
+
   # ── Raise the "release in progress" banner ──────────────────────────────────
   # Show users a CRITICAL banner for the duration of the rollout (non-dismissible
   # for members; admins can still dismiss). Best-effort and non-blocking: it never
@@ -812,7 +839,16 @@ jobs:
   # active backend serves old code.
   deploy-ecs:
     name: Deploy API + gateway to prod (ECS Fargate)
-    needs: [version, retag-images, verify-image-commits, migrate-db]
+    needs: [version, retag-images, verify-image-commits, migrate-db, terraform-prod]
+    # `always()` is required because terraform-prod is SKIPPED while
+    # TF_APPLY_ROLE_ARN_PROD is unset. Every other upstream stays required, so
+    # this remains the hard gate described above.
+    if: >-
+      ${{ always()
+        && needs.retag-images.result == 'success'
+        && needs.verify-image-commits.result == 'success'
+        && needs.migrate-db.result == 'success'
+        && (needs.terraform-prod.result == 'success' || needs.terraform-prod.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # OIDC → ECS deploy role

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -90,6 +90,47 @@ jobs:
             echo "found ${image}:staging-${SHA8}"
           done
 
+  # ── Apply staging Terraform before any image rolls ──────────────────────────
+  # Both staging roots are safe to apply unattended: every variable has a
+  # default and the committed terraform.tfvars.example is identical to those
+  # defaults (api_environment = {}, manage_dns = false), so CI plans exactly
+  # what an operator plans. Skipped while TF_APPLY_ROLE_ARN_STAGING is unset.
+  terraform-staging:
+    name: Apply staging Terraform
+    needs: preflight
+    if: vars.TF_APPLY_ROLE_ARN_STAGING != ''
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/terraform-apply.yml
+    with:
+      tf_root: infra/terraform/environments/staging
+      aws_region: us-west-2
+      role_arn: ${{ vars.TF_APPLY_ROLE_ARN_STAGING }}
+      github_environment: staging
+      cloudflare: true
+      ref: ${{ needs.preflight.outputs.sha }}
+    secrets: inherit
+
+  # staging-web shares modules/ecs-api with staging; apply it after so a shared
+  # module change lands in one order, not two racing ones.
+  terraform-staging-web:
+    name: Apply staging web Terraform
+    needs: [preflight, terraform-staging]
+    if: vars.TF_APPLY_ROLE_ARN_STAGING != ''
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/terraform-apply.yml
+    with:
+      tf_root: infra/terraform/environments/staging-web
+      aws_region: us-west-2
+      role_arn: ${{ vars.TF_APPLY_ROLE_ARN_STAGING }}
+      github_environment: staging
+      cloudflare: true
+      ref: ${{ needs.preflight.outputs.sha }}
+    secrets: inherit
+
   sync-secret:
     name: Sync staging secret bundle
     needs: preflight
@@ -240,7 +281,15 @@ jobs:
   # so a broken ECS staging deploy fails the staging rollout loudly.
   deploy-ecs:
     name: Deploy API + gateway to staging (ECS Fargate)
-    needs: [preflight, sync-secret, migrate-db]
+    needs: [preflight, sync-secret, migrate-db, terraform-staging]
+    # `always()` is required because terraform-staging is SKIPPED while
+    # TF_APPLY_ROLE_ARN_STAGING is unset. Every other upstream stays required.
+    if: >-
+      ${{ always()
+        && needs.preflight.result == 'success'
+        && needs.sync-secret.result == 'success'
+        && needs.migrate-db.result == 'success'
+        && (needs.terraform-staging.result == 'success' || needs.terraform-staging.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # OIDC → ECS deploy role
@@ -351,7 +400,12 @@ jobs:
 
   deploy-web-ecs:
     name: Deploy staging web to ECS Fargate
-    needs: [preflight, deploy-ecs]
+    needs: [preflight, deploy-ecs, terraform-staging-web]
+    if: >-
+      ${{ always()
+        && needs.preflight.result == 'success'
+        && needs.deploy-ecs.result == 'success'
+        && (needs.terraform-staging-web.result == 'success' || needs.terraform-staging-web.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -108,6 +108,7 @@ jobs:
       aws_region: us-west-2
       role_arn: ${{ vars.TF_APPLY_ROLE_ARN_STAGING }}
       github_environment: staging
+      trusted_branch: staging
       cloudflare: true
       ref: ${{ needs.preflight.outputs.sha }}
     secrets: inherit
@@ -127,6 +128,7 @@ jobs:
       aws_region: us-west-2
       role_arn: ${{ vars.TF_APPLY_ROLE_ARN_STAGING }}
       github_environment: staging
+      trusted_branch: staging
       cloudflare: true
       ref: ${{ needs.preflight.outputs.sha }}
     secrets: inherit

--- a/.github/workflows/terraform-apply-global.yml
+++ b/.github/workflows/terraform-apply-global.yml
@@ -1,0 +1,65 @@
+name: Terraform Apply Global
+
+# Applies the two ACCOUNT-GLOBAL Terraform roots on every push to `main` that
+# touches them. These are not environment infrastructure — they are the SOC 2
+# controls themselves (CloudTrail, GuardDuty, IAM baseline, WAF, the compliance
+# Lambdas), and a merged-but-unapplied change here is a compliance finding, not
+# a deploy delay.
+#
+# ORDER IS LOAD-BEARING: compliance-monitoring runs FIRST. It owns the WAF web
+# ACL and the monitoring KMS keys and SNS topics that the baseline alerting
+# resources point at, so applying the baseline against a stale monitoring stack
+# can reference a web ACL or topic that does not exist yet.
+#
+# The job is skipped while TF_APPLY_ROLE_ARN_GLOBAL is unset, so this workflow
+# is safe to merge before the role exists. terraform-ci.yml's
+# `apply-pipeline-health` job fails loudly if the variable stays unset — a
+# control that silently never runs is worse than no control.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infra/terraform/security-baseline/**"
+      - "infra/terraform/compliance-monitoring/**"
+      - ".github/workflows/terraform-apply-global.yml"
+      - ".github/workflows/terraform-apply.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: terraform-apply-global
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  compliance-monitoring:
+    name: compliance-monitoring
+    if: vars.TF_APPLY_ROLE_ARN_GLOBAL != ''
+    uses: ./.github/workflows/terraform-apply.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      tf_root: infra/terraform/compliance-monitoring
+      aws_region: us-west-2
+      role_arn: ${{ vars.TF_APPLY_ROLE_ARN_GLOBAL }}
+      github_environment: infra-global
+    secrets: inherit
+
+  security-baseline:
+    name: security-baseline
+    needs: compliance-monitoring
+    if: vars.TF_APPLY_ROLE_ARN_GLOBAL != ''
+    uses: ./.github/workflows/terraform-apply.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      tf_root: infra/terraform/security-baseline
+      aws_region: us-west-2
+      role_arn: ${{ vars.TF_APPLY_ROLE_ARN_GLOBAL }}
+      github_environment: infra-global
+    secrets: inherit

--- a/.github/workflows/terraform-apply-global.yml
+++ b/.github/workflows/terraform-apply-global.yml
@@ -47,6 +47,7 @@ jobs:
       aws_region: us-west-2
       role_arn: ${{ vars.TF_APPLY_ROLE_ARN_GLOBAL }}
       github_environment: infra-global
+      trusted_branch: main
     secrets: inherit
 
   security-baseline:
@@ -62,4 +63,5 @@ jobs:
       aws_region: us-west-2
       role_arn: ${{ vars.TF_APPLY_ROLE_ARN_GLOBAL }}
       github_environment: infra-global
+      trusted_branch: main
     secrets: inherit

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,213 @@
+name: Terraform Apply
+
+# Reusable, guarded `terraform apply` for exactly ONE Terraform root.
+#
+# WHY THIS EXISTS: until now the only workflow that ran `terraform apply` was
+# deploy-prod-us-east-2-shadow.yml. Every other root — dev, staging, prod, the
+# three *-web roots, compliance-monitoring, security-baseline — was applied by
+# hand from an operator laptop. On 2026-08-10 two merged compliance PRs (#6295,
+# #6344) sat unapplied for hours because nobody ran the apply. Merged Terraform
+# that never reaches AWS is not a change, it is a lie in the repository.
+#
+# CONTRACT
+#   - The caller pins the root, the region, the OIDC role, and the GitHub
+#     environment. The environment is part of the OIDC subject
+#     (repo:kortix-ai/suna:environment:<name>), so it must match the trust
+#     policy of `role_arn` — see security-baseline/iam-gha-tf-apply.tf.
+#   - Plan first, guard the plan, then apply THE SAME plan file. Never
+#     `apply -auto-approve` without a plan: that would re-resolve the diff after
+#     the guard ran.
+#   - The guard blocks every destroy. The single exception is an immutable
+#     `aws_ecs_task_definition` replacement, which Terraform always renders as
+#     a delete+create pair and which destroys nothing that serves traffic.
+#     Logic copied from deploy-prod-us-east-2-shadow.yml, generalized from two
+#     hardcoded module addresses to the resource type.
+#   - Terraform is pinned to the same TF_VERSION as terraform-ci.yml. State is
+#     forward-incompatible: applying with a newer Terraform than the drift job
+#     runs would break drift detection with "state snapshot was created by a
+#     newer Terraform". Bump both files together or neither.
+#
+# NOT AUTO-APPLIED (still manual): environments/dev and environments/prod. Both
+# roots read an operator-local, gitignored terraform.tfvars whose committed
+# .example diverges from the variable defaults (dev/prod set api_environment
+# and prod pins api_image to a release tag). Applying them from CI with plain
+# defaults would plan against inputs no operator ever used.
+# infra/terraform/README.md carries the full root-by-root table and the TODO
+# that unblocks those two.
+
+on:
+  workflow_call:
+    inputs:
+      tf_root:
+        description: Terraform root directory, relative to the repository root.
+        required: true
+        type: string
+      aws_region:
+        description: Region for the OIDC session and the state backend.
+        required: false
+        default: us-west-2
+        type: string
+      role_arn:
+        description: OIDC role to assume. Must trust the github_environment subject.
+        required: true
+        type: string
+      github_environment:
+        description: GitHub environment. Part of the OIDC subject, so it is required.
+        required: true
+        type: string
+      cloudflare:
+        description: Pass CLOUDFLARE_API_TOKEN as TF_VAR_cloudflare_api_token.
+        required: false
+        default: false
+        type: boolean
+      ref:
+        description: Ref or SHA to check out. Defaults to the caller's ref.
+        required: false
+        default: ""
+        type: string
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        description: Cloudflare token for roots that manage DNS or ACM validation.
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  TF_VERSION: 1.15.8
+
+jobs:
+  apply:
+    name: apply ${{ inputs.tf_root }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: ${{ inputs.github_environment }}
+    env:
+      TF_ROOT: ${{ inputs.tf_root }}
+      TF_IN_AUTOMATION: "true"
+      TF_INPUT: "false"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Require the root to exist
+        run: |
+          set -euo pipefail
+          if [ ! -f "$TF_ROOT/backend.tf" ]; then
+            echo "::error::$TF_ROOT is not a Terraform root (no backend.tf)."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ inputs.role_arn }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Export Cloudflare credentials
+        if: inputs.cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "::error::$TF_ROOT manages Cloudflare, but CLOUDFLARE_API_TOKEN is unset."
+            exit 1
+          fi
+          printf 'TF_VAR_cloudflare_api_token=%s\n' "$CLOUDFLARE_API_TOKEN" >> "$GITHUB_ENV"
+
+      - name: terraform init
+        run: terraform -chdir="$TF_ROOT" init -input=false -no-color
+
+      - name: terraform plan
+        run: |
+          set -euo pipefail
+          terraform -chdir="$TF_ROOT" plan \
+            -input=false \
+            -no-color \
+            -lock-timeout=5m \
+            -out=tf.plan
+
+      # Copied from deploy-prod-us-east-2-shadow.yml and generalized: block every
+      # planned delete except an immutable ECS task-definition replacement, which
+      # Terraform always renders as a delete+create pair.
+      - name: Guard against destructive changes
+        run: |
+          set -euo pipefail
+          terraform -chdir="$TF_ROOT" show -json tf.plan > "$RUNNER_TEMP/plan.json"
+
+          blocked_destructive_changes="$(
+            jq '[
+              .resource_changes[]?
+              | select(.change.actions | index("delete"))
+              | select(
+                  (.type != "aws_ecs_task_definition")
+                  or (
+                    .change.actions != ["delete", "create"]
+                    and .change.actions != ["create", "delete"]
+                  )
+                )
+            ] | length' "$RUNNER_TEMP/plan.json"
+          )"
+          task_definition_replacements="$(
+            jq '[
+              .resource_changes[]?
+              | select(.type == "aws_ecs_task_definition")
+              | select(
+                  .change.actions == ["delete", "create"]
+                  or .change.actions == ["create", "delete"]
+                )
+            ] | length' "$RUNNER_TEMP/plan.json"
+          )"
+
+          echo "Planned actions:"
+          jq -r '
+            [.resource_changes[]?.change.actions | join(",")]
+            | group_by(.)
+            | map({action: .[0], count: length})
+          ' "$RUNNER_TEMP/plan.json"
+
+          if [ "$blocked_destructive_changes" != "0" ]; then
+            echo "::error::$TF_ROOT plans $blocked_destructive_changes blocked destructive change(s). Apply it by hand after review."
+            jq -r '
+              .resource_changes[]?
+              | select(.change.actions | index("delete"))
+              | select(
+                  (.type != "aws_ecs_task_definition")
+                  or (
+                    .change.actions != ["delete", "create"]
+                    and .change.actions != ["create", "delete"]
+                  )
+                )
+              | "  \(.address): \(.change.actions | join(","))"
+            ' "$RUNNER_TEMP/plan.json"
+            exit 1
+          fi
+          echo "Allowed immutable ECS task-definition replacements: $task_definition_replacements."
+
+      - name: terraform apply
+        run: |
+          set -euo pipefail
+          terraform -chdir="$TF_ROOT" apply \
+            -input=false \
+            -no-color \
+            -lock-timeout=5m \
+            -auto-approve \
+            tf.plan
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Terraform apply — \`${TF_ROOT}\`"
+            echo "- Region: \`${{ inputs.aws_region }}\`"
+            echo "- Environment: \`${{ inputs.github_environment }}\`"
+            echo "- Terraform: \`${TF_VERSION}\`"
+            echo "- Result: \`${{ job.status }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -55,6 +55,12 @@ on:
         description: GitHub environment. Part of the OIDC subject, so it is required.
         required: true
         type: string
+      trusted_branch:
+        description: >-
+          Branch the applied commit must be reachable from (main, staging, prod).
+          Enforced in-workflow before any credential is minted.
+        required: true
+        type: string
       cloudflare:
         description: Pass CLOUDFLARE_API_TOKEN as TF_VAR_cloudflare_api_token.
         required: false
@@ -91,6 +97,32 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
+          # Full history: the trusted-branch guard below needs a merge base.
+          fetch-depth: 0
+
+      # Runs BEFORE configure-aws-credentials, so untrusted code never reaches a
+      # credential. The GitHub environment alone is not a sufficient gate: it is
+      # part of the OIDC subject, but the deployment-branch restriction that
+      # backs it is out-of-band repository configuration, and three of the four
+      # callers are workflow_dispatch-able from an arbitrary branch. Without
+      # this step, anyone who can dispatch deploy-prod.yml from a branch could
+      # apply arbitrary Terraform with the production role.
+      #
+      # Reachability, not `github.ref`: it is correct for push, dispatch, and
+      # workflow_run alike, and it proves the applied commit is merged rather
+      # than merely running under a trusted-looking ref.
+      - name: Enforce a trusted branch
+        env:
+          TRUSTED_BRANCH: ${{ inputs.trusted_branch }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "$TRUSTED_BRANCH"
+          head="$(git rev-parse HEAD)"
+          if ! git merge-base --is-ancestor "$head" "origin/${TRUSTED_BRANCH}"; then
+            echo "::error::${head} is not reachable from origin/${TRUSTED_BRANCH}. Refusing to apply ${TF_ROOT}."
+            exit 1
+          fi
+          echo "${head} is reachable from origin/${TRUSTED_BRANCH}."
 
       - name: Require the root to exist
         run: |

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -116,7 +116,10 @@ jobs:
           TRUSTED_BRANCH: ${{ inputs.trusted_branch }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --quiet origin "$TRUSTED_BRANCH"
+          # Explicit refspec: this must update refs/remotes/origin/<branch> to the
+          # live tip, not just FETCH_HEAD, and it must fail if the branch is gone.
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/${TRUSTED_BRANCH}:refs/remotes/origin/${TRUSTED_BRANCH}"
           head="$(git rev-parse HEAD)"
           if ! git merge-base --is-ancestor "$head" "origin/${TRUSTED_BRANCH}"; then
             echo "::error::${head} is not reachable from origin/${TRUSTED_BRANCH}. Refusing to apply ${TF_ROOT}."

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -23,7 +23,11 @@ permissions:
   contents: read
 
 env:
-  TF_VERSION: 1.9.8
+  # Must equal terraform-apply.yml's TF_VERSION. Terraform state is
+  # forward-incompatible: once terraform-apply.yml writes state with 1.15.x, a
+  # 1.9.x plan here fails with "state snapshot was created by a newer
+  # Terraform". Bump both files in the same commit or neither.
+  TF_VERSION: 1.15.8
 
 jobs:
   validate:
@@ -150,10 +154,30 @@ jobs:
           - infra/terraform/environments/staging
           - infra/terraform/environments/dev
           - infra/terraform/environments/preview
-          # Not under environments/ — the stack lives at the terraform root.
+          # The *-web roots own the frontend ALBs, their WAF associations, and
+          # the web task roles. They were missing here, so #6344's WAF change
+          # could drift unseen.
+          - infra/terraform/environments/dev-web
+          - infra/terraform/environments/staging-web
+          - infra/terraform/environments/prod-web
+          # Not under environments/ — these stacks live at the terraform root.
           - infra/terraform/security-baseline
+          - infra/terraform/compliance-monitoring
+    env:
+      # Every environments/* root declares a `cloudflare` provider. Without a
+      # token the provider fails to authenticate and the plan errors out before
+      # it can report drift — which is how this job has been failing since
+      # 2026-08-03. The token is read-only for planning purposes: plan never
+      # writes a DNS record.
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: require Cloudflare token
+        run: |
+          if [ -z "${TF_VAR_cloudflare_api_token:-}" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN is unset - every environments/* plan will fail to authenticate."
+            exit 1
+          fi
       - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ vars.TF_PLAN_ROLE_ARN }}
@@ -174,3 +198,95 @@ jobs:
             exit 1
           fi
           exit 0
+
+  apply-pipeline-health:
+    name: apply pipeline health
+    # The alarm for the alarms. Two failure modes this repository has already
+    # hit, both of which render GREEN in the checks list:
+    #
+    #   1. A gated job whose gate is never satisfied. TF_PLAN_ROLE_ARN did not
+    #      exist for the entire life of the drift job, so `drift detection`
+    #      resolved to "skipped" and nobody noticed (see
+    #      security-baseline/iam-gha-tf-plan.tf). The apply jobs added in
+    #      deploy-{dev,staging,prod}.yml and terraform-apply-global.yml carry
+    #      the same `vars.* != ''` gate, so they can fail the same way.
+    #   2. A scheduled job that starts failing and stays failing. Drift
+    #      detection has been erroring on Cloudflare authentication since
+    #      2026-08-03; a stale-but-once-green control is indistinguishable from
+    #      a healthy one unless something measures its age.
+    #
+    # This job fails loudly on both. It runs on the same schedule as drift, one
+    # cycle behind it.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: require every Terraform CI/CD role variable
+        env:
+          TF_PLAN_ROLE_ARN: ${{ vars.TF_PLAN_ROLE_ARN }}
+          TF_APPLY_ROLE_ARN_DEV: ${{ vars.TF_APPLY_ROLE_ARN_DEV }}
+          TF_APPLY_ROLE_ARN_STAGING: ${{ vars.TF_APPLY_ROLE_ARN_STAGING }}
+          TF_APPLY_ROLE_ARN_PROD: ${{ vars.TF_APPLY_ROLE_ARN_PROD }}
+          TF_APPLY_ROLE_ARN_GLOBAL: ${{ vars.TF_APPLY_ROLE_ARN_GLOBAL }}
+        run: |
+          set -uo pipefail
+          missing=0
+          for name in \
+            TF_PLAN_ROLE_ARN \
+            TF_APPLY_ROLE_ARN_DEV \
+            TF_APPLY_ROLE_ARN_STAGING \
+            TF_APPLY_ROLE_ARN_PROD \
+            TF_APPLY_ROLE_ARN_GLOBAL
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Repository variable ${name} is unset, so its Terraform job silently skips. Apply security-baseline once and set it to the matching output ARN."
+              missing=1
+            else
+              echo "ok: ${name}"
+            fi
+          done
+          exit "$missing"
+
+      - name: require a successful drift run in the last 48h
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAX_AGE_HOURS: "48"
+        run: |
+          set -euo pipefail
+          newest=0
+          run_ids="$(
+            gh api -X GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/terraform-ci.yml/runs" \
+              -f branch=main -f per_page=15 \
+              --jq '.workflow_runs[] | select(.status == "completed") | .id'
+          )"
+          for id in $run_ids; do
+            completed_at="$(
+              gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${id}/jobs?per_page=100" \
+                --jq '[.jobs[]
+                       | select(.name | startswith("drift detection"))
+                       | select(.conclusion == "success")
+                       | .completed_at] | sort | last // empty'
+            )"
+            if [ -n "$completed_at" ]; then
+              newest="$(date -u -d "$completed_at" +%s)"
+              echo "Newest successful drift job: ${completed_at} (run ${id})."
+              break
+            fi
+          done
+
+          if [ "$newest" = "0" ]; then
+            echo "::error::No successful \`drift detection\` job in the last 15 terraform-ci runs on main. Drift detection is not running."
+            exit 1
+          fi
+
+          age_hours=$(( ( $(date -u +%s) - newest ) / 3600 ))
+          echo "Last successful drift run: ${age_hours}h ago (limit ${MAX_AGE_HOURS}h)."
+          if [ "$age_hours" -gt "$MAX_AGE_HOURS" ]; then
+            echo "::error::Drift detection last succeeded ${age_hours}h ago, over the ${MAX_AGE_HOURS}h limit."
+            exit 1
+          fi

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,102 @@
+# Terraform roots — what CI applies, and what it does not
+
+Every directory with a `backend.tf` is a Terraform root. Until 2026-08-10 CI
+applied exactly one of them (`environments/prod-us-east-2-shadow`, from
+`deploy-prod-us-east-2-shadow.yml`); the rest were applied by hand. Merged
+infrastructure could therefore sit unapplied indefinitely, and on 2026-08-10 two
+merged compliance PRs (#6295, #6344) did exactly that for several hours.
+
+`.github/workflows/terraform-apply.yml` is the reusable, guarded apply. This
+table is the source of truth for which root it drives.
+
+| Root | Applied by | Trigger | Region | OIDC role |
+| --- | --- | --- | --- | --- |
+| `environments/dev-web` | `deploy-dev.yml` -> `terraform-dev` | push to `main` touching `environments/dev-web/**` or `modules/**` | `us-west-2` | `kortix-gha-tf-apply-dev` |
+| `environments/staging` | `deploy-staging.yml` -> `terraform-staging` | every staging deploy | `us-west-2` | `kortix-gha-tf-apply-staging` |
+| `environments/staging-web` | `deploy-staging.yml` -> `terraform-staging-web` | every staging deploy | `us-west-2` | `kortix-gha-tf-apply-staging` |
+| `environments/prod-web` | `deploy-prod.yml` -> `terraform-prod` | every production release | `eu-west-2` | `kortix-gha-tf-apply-prod` |
+| `compliance-monitoring` | `terraform-apply-global.yml` | push to `main` touching the root | `us-west-2` | `kortix-gha-tf-apply-global` |
+| `security-baseline` | `terraform-apply-global.yml` | push to `main` touching the root | `us-west-2` | `kortix-gha-tf-apply-global` |
+| `environments/prod-us-east-2-shadow` | `deploy-prod-us-east-2-shadow.yml` | release | `us-east-2` | `kortix-gha-prod-use2-terraform` |
+| **`environments/dev`** | **nobody — apply by hand** | — | `us-west-2` | — |
+| **`environments/prod`** | **nobody — apply by hand** | — | `us-west-2` | — |
+| **`environments/preview`** | **nobody — apply by hand** | — | `us-west-2` | — |
+
+Every root above, applied or not, is planned nightly by the `drift detection`
+matrix in `terraform-ci.yml`, so an unapplied change still shows up as drift.
+
+## TODO: make `environments/dev` and `environments/prod` auto-appliable
+
+Both roots read a `terraform.tfvars` that is gitignored
+(`.gitignore:133`, `infra/terraform/**/*.tfvars`) and lives only on an operator
+laptop. Their committed `terraform.tfvars.example` files diverge from the
+variable defaults:
+
+- `environments/dev/terraform.tfvars.example` sets a non-empty `api_environment`
+  (`KORTIX_URL`, `ALLOWED_SANDBOX_PROVIDERS`).
+- `environments/prod/terraform.tfvars.example` sets `api_environment` and pins
+  `api_image` to an immutable release tag rather than the `:latest` default.
+
+`environments/staging` is auto-applied precisely because its example file is
+identical to the defaults (`api_environment = {}`, `manage_dns = false`), so CI
+plans exactly what an operator plans.
+
+The unblock is small and worth doing:
+
+1. `api_image`, `gateway_image`, `api_environment`, `api_secrets`, and
+   `gateway_environment` only reach `aws_ecs_task_definition.container_definitions`,
+   which `modules/ecs-api/main.tf:473` marks `ignore_changes`. `ecs-deploy.sh`
+   has owned every revision after the first since that lifecycle block landed,
+   so these five variables are inert for an existing environment. Confirm that
+   against a real `terraform plan -detailed-exitcode` with no tfvars file
+   present, on both roots.
+2. If the plan is empty, delete the five variables from the two
+   `terraform.tfvars.example` files and add both roots to the apply pipeline —
+   `environments/dev` to `deploy-dev.yml`, `environments/prod` to
+   `deploy-prod.yml`, mirroring the existing `*-web` jobs.
+3. If the plan is not empty, move the differing inputs into workflow-supplied
+   `-var` arguments or into the environment's Secrets Manager blob, then repeat
+   step 1.
+
+Do not shortcut this by committing a `terraform.tfvars`: the prod file
+references Secrets Manager ARNs and is intentionally out of git.
+
+## Bootstrap
+
+The four `kortix-gha-tf-apply-*` roles live in
+`security-baseline/iam-gha-tf-apply.tf`, which is itself applied by one of those
+roles. Break the cycle once, by hand:
+
+```bash
+cd infra/terraform/security-baseline
+terraform init
+terraform apply
+terraform output -json | jq -r 'to_entries[] | select(.key | startswith("gha_tf_apply_role_arn")) | "\(.key)\t\(.value.value)"'
+```
+
+Then set the repository variables (`gh variable set`):
+
+| Variable | Output |
+| --- | --- |
+| `TF_APPLY_ROLE_ARN_DEV` | `gha_tf_apply_role_arn_dev` |
+| `TF_APPLY_ROLE_ARN_STAGING` | `gha_tf_apply_role_arn_staging` |
+| `TF_APPLY_ROLE_ARN_PROD` | `gha_tf_apply_role_arn_prod` |
+| `TF_APPLY_ROLE_ARN_GLOBAL` | `gha_tf_apply_role_arn_global` |
+
+Each role's trust policy pins the OIDC subject to a GitHub **environment**, so
+the environments must exist with a matching deployment-branch restriction:
+
+| Environment | Deployment branch | Used by |
+| --- | --- | --- |
+| `dev` | `main` | `deploy-dev.yml` |
+| `staging` | `staging` | `deploy-staging.yml` |
+| `prod` | `prod` | `deploy-prod.yml` |
+| `infra-global` | `main` | `terraform-apply-global.yml` |
+
+Do **not** add required reviewers to `prod`. `deploy-prod.yml` runs unattended
+after a reviewed release PR merges; a reviewer gate there pauses every release
+at the Terraform step. The branch restriction is the control that costs nothing.
+
+Until those variables are set, every apply job skips and the image deploys still
+run. `terraform-ci.yml`'s `apply-pipeline-health` job fails on the daily
+schedule while any of them is unset, so the skip cannot go unnoticed.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -84,7 +84,7 @@ Then set the repository variables (`gh variable set`):
 | `TF_APPLY_ROLE_ARN_GLOBAL` | `gha_tf_apply_role_arn_global` |
 
 Each role's trust policy pins the OIDC subject to a GitHub **environment**, so
-the environments must exist with a matching deployment-branch restriction:
+the environments must exist. Give each one a deployment-branch restriction too:
 
 | Environment | Deployment branch | Used by |
 | --- | --- | --- |
@@ -93,9 +93,17 @@ the environments must exist with a matching deployment-branch restriction:
 | `prod` | `prod` | `deploy-prod.yml` |
 | `infra-global` | `main` | `terraform-apply-global.yml` |
 
+The branch restriction is defence in depth, not the primary control.
+`terraform-apply.yml` takes a required `trusted_branch` input and refuses to
+mint AWS credentials unless the checked-out commit is reachable from
+`origin/<trusted_branch>`. That guard runs in-workflow, before
+`configure-aws-credentials`, and therefore holds even if the environment is
+misconfigured. It is what stops a `workflow_dispatch` from an arbitrary branch
+applying attacker-authored Terraform with the production role.
+
 Do **not** add required reviewers to `prod`. `deploy-prod.yml` runs unattended
 after a reviewed release PR merges; a reviewer gate there pauses every release
-at the Terraform step. The branch restriction is the control that costs nothing.
+at the Terraform step.
 
 Until those variables are set, every apply job skips and the image deploys still
 run. `terraform-ci.yml`'s `apply-pipeline-health` job fails on the daily

--- a/infra/terraform/security-baseline/iam-gha-tf-apply.tf
+++ b/infra/terraform/security-baseline/iam-gha-tf-apply.tf
@@ -1,0 +1,230 @@
+# ════════════════════════════════════════════════════════════════════════════
+# kortix-gha-tf-apply-{dev,staging,prod,global} — the OIDC roles that
+# .github/workflows/terraform-apply.yml assumes to run `terraform apply` in CI.
+#
+# WHY: before these existed, deploy-prod-us-east-2-shadow.yml was the only
+# workflow in the repository that applied Terraform. Every other root was
+# applied by hand, so merged infrastructure could sit unapplied indefinitely —
+# on 2026-08-10 two merged compliance PRs (#6295, #6344) did exactly that.
+#
+# TRUST: the GitHub environment is part of the OIDC subject, so a workflow that
+# does not declare `environment: <name>` cannot assume the matching role. This
+# is the same containment the prod-use2 bootstrap role uses
+# (iam-gha-prod-use2-terraform.tf). Pair each environment with a deployment
+# branch restriction (dev -> main, staging -> staging, prod -> prod,
+# infra-global -> main) so the subject cannot be minted from a stray branch.
+#
+# PERMISSIONS: PowerUserAccess plus a narrow inline IAM grant, matching the
+# prod-use2 role. PowerUserAccess covers everything a root builds (VPC, ECS,
+# ALB, KMS, S3, ACM, WAF, Lambda, CloudWatch, autoscaling, DynamoDB state lock)
+# and excludes IAM, Organizations, and Account. The env roles get IAM write on
+# their own `kortix-<env>-*` task and execution roles only.
+# ════════════════════════════════════════════════════════════════════════════
+
+locals {
+  # environment name => IAM role-name prefix the root is allowed to manage.
+  # environments/dev + dev-web create kortix-dev-*, kortix-dev-web-*,
+  # kortix-dev-gateway-*; staging and prod follow the same shape.
+  gha_tf_apply_envs = {
+    dev     = "kortix-dev-"
+    staging = "kortix-staging-"
+    prod    = "kortix-prod-"
+  }
+}
+
+resource "aws_iam_role" "gha_tf_apply" {
+  for_each = local.gha_tf_apply_envs
+
+  name = "kortix-gha-tf-apply-${each.key}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = data.aws_iam_openid_connect_provider.github_actions.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:sub" = "repo:kortix-ai/suna:environment:${each.key}"
+        }
+      }
+    }]
+  })
+
+  tags = {
+    ManagedBy  = "terraform"
+    Name       = "kortix-gha-tf-apply-${each.key}"
+    Stack      = "security-baseline"
+    Compliance = "soc2"
+  }
+}
+
+# checkov:skip=CKV_AWS_274: The environment-scoped OIDC trust plus the inline IAM
+# policy below constrain this role. PowerUserAccess is what a full environment
+# root needs (VPC, ECS, ALB, KMS, S3, ACM, WAF, autoscaling) and it excludes IAM.
+resource "aws_iam_role_policy_attachment" "gha_tf_apply_power_user" {
+  for_each = local.gha_tf_apply_envs
+
+  role       = aws_iam_role.gha_tf_apply[each.key].name
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+# The ecs-api module creates the task role, the execution role, and (since
+# #6295) the SES sender policy on the task role. PowerUserAccess denies IAM, so
+# grant exactly those actions, only on this environment's own role prefix.
+resource "aws_iam_role_policy" "gha_tf_apply_iam" {
+  for_each = local.gha_tf_apply_envs
+
+  name = "tf-apply-${each.key}-iam"
+  role = aws_iam_role.gha_tf_apply[each.key].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ManageOnlyThisEnvironmentTaskRoles"
+        Effect = "Allow"
+        Action = [
+          "iam:AttachRolePolicy",
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:DeleteRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:GetRole",
+          "iam:GetRolePolicy",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListRolePolicies",
+          "iam:PassRole",
+          "iam:PutRolePolicy",
+          "iam:TagRole",
+          "iam:UntagRole",
+          "iam:UpdateAssumeRolePolicy",
+          "iam:UpdateRole",
+          "iam:UpdateRoleDescription",
+        ]
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/${each.value}*",
+        ]
+      },
+    ]
+  })
+}
+
+# ── Account-global roots: compliance-monitoring + security-baseline ──────────
+#
+# These two roots are not environment infrastructure. They manage the account
+# security baseline itself: IAM roles that are NOT kortix-<env>-* prefixed
+# (whatsapp-gateway-*, bedrock-logs), IAM groups and their memberships, the
+# account password policy, CloudTrail, GuardDuty in 17 regions, the S3 account
+# public-access block, WAF, and the compliance Lambdas.
+#
+# There is no useful resource-level scope for that: the role must be able to
+# manage arbitrarily named IAM roles, including its own. So this grant is
+# IAM-wide, which is admin-equivalent in the limit — a caller that can attach a
+# policy to a role it controls can grant itself anything.
+#
+# What actually contains it:
+#   1. the OIDC subject is pinned to `environment:infra-global`, and that
+#      environment is restricted to the `main` deployment branch;
+#   2. terraform-apply-global.yml runs only on push to main, i.e. only after a
+#      reviewed PR merged;
+#   3. the Deny below removes the one escalation that survives a merge review —
+#      minting a long-lived human credential (IAM user, access key, console
+#      password) that outlives the workflow run.
+resource "aws_iam_role" "gha_tf_apply_global" {
+  name = "kortix-gha-tf-apply-global"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = data.aws_iam_openid_connect_provider.github_actions.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:sub" = "repo:kortix-ai/suna:environment:infra-global"
+        }
+      }
+    }]
+  })
+
+  tags = {
+    ManagedBy  = "terraform"
+    Name       = "kortix-gha-tf-apply-global"
+    Stack      = "security-baseline"
+    Compliance = "soc2"
+  }
+}
+
+# checkov:skip=CKV_AWS_274: see the comment above — security-baseline manages the
+# account IAM surface, so PowerUserAccess plus IAM write is the minimum that can
+# apply it. Containment is the environment-scoped OIDC subject, the main-branch
+# restriction, and the credential-minting Deny below.
+resource "aws_iam_role_policy_attachment" "gha_tf_apply_global_power_user" {
+  role       = aws_iam_role.gha_tf_apply_global.name
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+resource "aws_iam_role_policy" "gha_tf_apply_global_iam" {
+  name = "tf-apply-global-iam"
+  role = aws_iam_role.gha_tf_apply_global.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ManageAccountIamBaseline"
+        Effect   = "Allow"
+        Action   = ["iam:*"]
+        Resource = "*"
+      },
+      {
+        # Everything above is reviewable in a Terraform plan. Creating a human
+        # credential is not something any root here does, and it is the one
+        # escalation that keeps working after the workflow run ends.
+        Sid    = "DenyLongLivedCredentialMinting"
+        Effect = "Deny"
+        Action = [
+          "iam:CreateUser",
+          "iam:DeleteUser",
+          "iam:CreateAccessKey",
+          "iam:UpdateAccessKey",
+          "iam:CreateLoginProfile",
+          "iam:UpdateLoginProfile",
+          "iam:CreateServiceSpecificCredential",
+          "iam:ResetServiceSpecificCredential",
+          "iam:UploadSigningCertificate",
+          "iam:UploadSSHPublicKey",
+          "iam:DeleteVirtualMFADevice",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+output "gha_tf_apply_role_arn_dev" {
+  description = "Set as the repo variable TF_APPLY_ROLE_ARN_DEV (deploy-dev.yml)."
+  value       = aws_iam_role.gha_tf_apply["dev"].arn
+}
+
+output "gha_tf_apply_role_arn_staging" {
+  description = "Set as the repo variable TF_APPLY_ROLE_ARN_STAGING (deploy-staging.yml)."
+  value       = aws_iam_role.gha_tf_apply["staging"].arn
+}
+
+output "gha_tf_apply_role_arn_prod" {
+  description = "Set as the repo variable TF_APPLY_ROLE_ARN_PROD (deploy-prod.yml)."
+  value       = aws_iam_role.gha_tf_apply["prod"].arn
+}
+
+output "gha_tf_apply_role_arn_global" {
+  description = "Set as the repo variable TF_APPLY_ROLE_ARN_GLOBAL (terraform-apply-global.yml)."
+  value       = aws_iam_role.gha_tf_apply_global.arn
+}

--- a/infra/terraform/security-baseline/iam-gha-tf-apply.tf
+++ b/infra/terraform/security-baseline/iam-gha-tf-apply.tf
@@ -117,23 +117,23 @@ resource "aws_iam_role_policy" "gha_tf_apply_iam" {
 #
 # These two roots are not environment infrastructure. They manage the account
 # security baseline itself: IAM roles that are NOT kortix-<env>-* prefixed
-# (whatsapp-gateway-*, bedrock-logs), IAM groups and their memberships, the
-# account password policy, CloudTrail, GuardDuty in 17 regions, the S3 account
-# public-access block, WAF, and the compliance Lambdas.
+# (whatsapp-gateway-*, bedrock-logs, vpc-flow-logs-role), IAM groups and their
+# memberships, the account password policy, CloudTrail, GuardDuty in 17 regions,
+# the S3 account public-access block, WAF, and the compliance Lambdas.
 #
-# There is no useful resource-level scope for that: the role must be able to
-# manage arbitrarily named IAM roles, including its own. So this grant is
-# IAM-wide, which is admin-equivalent in the limit — a caller that can attach a
-# policy to a role it controls can grant itself anything.
+# `iam:*` on `*` would be the easy grant and the wrong one: it is
+# admin-equivalent, because a caller that can attach a policy to a role it
+# controls can grant itself anything. Instead every IAM principal these two
+# roots manage is enumerated below. A newly named role fails the apply with an
+# explicit AccessDenied rather than silently widening the grant — which is the
+# correct failure mode for the stack that defines the account's security
+# controls.
 #
-# What actually contains it:
-#   1. the OIDC subject is pinned to `environment:infra-global`, and that
-#      environment is restricted to the `main` deployment branch;
-#   2. terraform-apply-global.yml runs only on push to main, i.e. only after a
-#      reviewed PR merged;
-#   3. the Deny below removes the one escalation that survives a merge review —
-#      minting a long-lived human credential (IAM user, access key, console
-#      password) that outlives the workflow run.
+# Containment on top of that: the OIDC subject is pinned to
+# `environment:infra-global` (restrict that environment to the `main` deployment
+# branch), terraform-apply-global.yml runs only on push to main, and the Deny at
+# the end blocks minting a long-lived human credential that would outlive the
+# workflow run.
 resource "aws_iam_role" "gha_tf_apply_global" {
   name = "kortix-gha-tf-apply-global"
 
@@ -162,13 +162,42 @@ resource "aws_iam_role" "gha_tf_apply_global" {
   }
 }
 
-# checkov:skip=CKV_AWS_274: see the comment above — security-baseline manages the
-# account IAM surface, so PowerUserAccess plus IAM write is the minimum that can
-# apply it. Containment is the environment-scoped OIDC subject, the main-branch
-# restriction, and the credential-minting Deny below.
+# checkov:skip=CKV_AWS_274: PowerUserAccess is what compliance-monitoring and
+# security-baseline need outside IAM (CloudTrail, GuardDuty, KMS, S3, WAF,
+# Lambda, EventBridge, Backup) and it explicitly excludes IAM. The IAM half is
+# the enumerated, resource-scoped inline policy below.
 resource "aws_iam_role_policy_attachment" "gha_tf_apply_global_power_user" {
   role       = aws_iam_role.gha_tf_apply_global.name
   policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+locals {
+  # Every IAM role the two account-global roots declare, by ARN pattern.
+  # Cross-check when adding an aws_iam_role to either root: an unlisted name
+  # makes `terraform apply` fail with AccessDenied.
+  gha_tf_apply_global_roles = [
+    # kortix-gha-*, kortix-guardduty-event-forwarder
+    "arn:aws:iam::${local.account_id}:role/kortix-*",
+    # compliance-monitoring: KortixEc2CpuAlarmReconciler
+    "arn:aws:iam::${local.account_id}:role/Kortix*",
+    # legacy-roles.tf
+    "arn:aws:iam::${local.account_id}:role/whatsapp-gateway-*",
+    "arn:aws:iam::${local.account_id}:role/bedrock-logs",
+    # main.tf service-delivery roles
+    "arn:aws:iam::${local.account_id}:role/cloudtrail-cloudwatch-logs-role",
+    "arn:aws:iam::${local.account_id}:role/vpc-flow-logs-role",
+    "arn:aws:iam::${local.account_id}:role/AWSBackupDefaultServiceRole",
+  ]
+
+  # Derived from iam-groups.tf so the two never drift apart.
+  gha_tf_apply_global_groups = [
+    for group in keys(local.groups) :
+    "arn:aws:iam::${local.account_id}:group/${group}"
+  ]
+  gha_tf_apply_global_users = [
+    for user in keys(local.user_groups) :
+    "arn:aws:iam::${local.account_id}:user/${user}"
+  ]
 }
 
 resource "aws_iam_role_policy" "gha_tf_apply_global_iam" {
@@ -177,35 +206,138 @@ resource "aws_iam_role_policy" "gha_tf_apply_global_iam" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
+    Statement = concat([
       {
-        Sid      = "ManageAccountIamBaseline"
-        Effect   = "Allow"
-        Action   = ["iam:*"]
-        Resource = "*"
+        Sid    = "ManageBaselineRoles"
+        Effect = "Allow"
+        Action = [
+          "iam:AttachRolePolicy",
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:DeleteRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:GetRole",
+          "iam:GetRolePolicy",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListRolePolicies",
+          "iam:ListRoleTags",
+          "iam:PassRole",
+          "iam:PutRolePolicy",
+          "iam:TagRole",
+          "iam:UntagRole",
+          "iam:UpdateAssumeRolePolicy",
+          "iam:UpdateRole",
+          "iam:UpdateRoleDescription",
+        ]
+        Resource = local.gha_tf_apply_global_roles
       },
       {
-        # Everything above is reviewable in a Terraform plan. Creating a human
-        # credential is not something any root here does, and it is the one
-        # escalation that keeps working after the workflow run ends.
-        Sid    = "DenyLongLivedCredentialMinting"
-        Effect = "Deny"
+        # GuardDuty, WAF, Backup, and Config create their own service-linked
+        # roles on first use in a region.
+        Sid      = "CreateServiceLinkedRoles"
+        Effect   = "Allow"
+        Action   = ["iam:CreateServiceLinkedRole"]
+        Resource = "arn:aws:iam::${local.account_id}:role/aws-service-role/*"
+      },
+      {
+        Sid    = "ManageBaselineCustomerPolicies"
+        Effect = "Allow"
         Action = [
-          "iam:CreateUser",
-          "iam:DeleteUser",
-          "iam:CreateAccessKey",
-          "iam:UpdateAccessKey",
-          "iam:CreateLoginProfile",
-          "iam:UpdateLoginProfile",
-          "iam:CreateServiceSpecificCredential",
-          "iam:ResetServiceSpecificCredential",
-          "iam:UploadSigningCertificate",
-          "iam:UploadSSHPublicKey",
-          "iam:DeleteVirtualMFADevice",
+          "iam:CreatePolicy",
+          "iam:CreatePolicyVersion",
+          "iam:DeletePolicy",
+          "iam:DeletePolicyVersion",
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+          "iam:ListEntitiesForPolicy",
+          "iam:ListPolicyVersions",
+          "iam:TagPolicy",
+          "iam:UntagPolicy",
+        ]
+        Resource = "arn:aws:iam::${local.account_id}:policy/kortix-*"
+      },
+      {
+        Sid    = "ManageBaselineGroups"
+        Effect = "Allow"
+        Action = [
+          "iam:AddUserToGroup",
+          "iam:AttachGroupPolicy",
+          "iam:CreateGroup",
+          "iam:DeleteGroup",
+          "iam:DeleteGroupPolicy",
+          "iam:DetachGroupPolicy",
+          "iam:GetGroup",
+          "iam:GetGroupPolicy",
+          "iam:ListAttachedGroupPolicies",
+          "iam:ListGroupPolicies",
+          "iam:PutGroupPolicy",
+          "iam:RemoveUserFromGroup",
+        ]
+        Resource = local.gha_tf_apply_global_groups
+      },
+      {
+        Sid      = "ReadGitHubOidcProvider"
+        Effect   = "Allow"
+        Action   = ["iam:GetOpenIDConnectProvider"]
+        Resource = data.aws_iam_openid_connect_provider.github_actions.arn
+      },
+      {
+        # checkov:skip=CKV_AWS_355: IAM account-level actions have no
+        # resource-level permission — AWS requires "*" for the password policy
+        # and the account-wide List/Get calls Terraform makes while refreshing.
+        # The action list is closed and grants no write outside the password
+        # policy.
+        Sid    = "AccountLevelIamControls"
+        Effect = "Allow"
+        Action = [
+          "iam:DeleteAccountPasswordPolicy",
+          "iam:GetAccountPasswordPolicy",
+          "iam:GetAccountSummary",
+          "iam:ListAccountAliases",
+          "iam:ListGroups",
+          "iam:ListOpenIDConnectProviders",
+          "iam:ListPolicies",
+          "iam:ListRoles",
+          "iam:ListUsers",
+          "iam:UpdateAccountPasswordPolicy",
         ]
         Resource = "*"
       },
-    ]
+      {
+        # Belt and braces over the closed action lists above: no root here mints
+        # a human credential, and that is the one escalation that keeps working
+        # after the workflow run ends.
+        Sid    = "DenyLongLivedCredentialMinting"
+        Effect = "Deny"
+        Action = [
+          "iam:CreateAccessKey",
+          "iam:CreateLoginProfile",
+          "iam:CreateServiceSpecificCredential",
+          "iam:CreateUser",
+          "iam:DeleteUser",
+          "iam:DeleteVirtualMFADevice",
+          "iam:ResetServiceSpecificCredential",
+          "iam:UpdateAccessKey",
+          "iam:UpdateLoginProfile",
+          "iam:UploadSSHPublicKey",
+          "iam:UploadSigningCertificate",
+        ]
+        Resource = "*"
+      },
+      ],
+      # aws_iam_user_group_membership reads a user's current groups before it
+      # reconciles them. It never creates or modifies the user. Emitted
+      # conditionally: an IAM statement with an empty Resource list is a
+      # MalformedPolicyDocument, and iam-groups.tf's member lists can legitimately
+      # empty out (memberships are managed out-of-band).
+      length(local.gha_tf_apply_global_users) == 0 ? [] : [
+        {
+          Sid      = "ReadBaselineGroupMembers"
+          Effect   = "Allow"
+          Action   = ["iam:GetUser", "iam:ListGroupsForUser"]
+          Resource = local.gha_tf_apply_global_users
+        },
+    ])
   })
 }
 

--- a/infra/terraform/security-baseline/iam-gha-tf-apply.tf
+++ b/infra/terraform/security-baseline/iam-gha-tf-apply.tf
@@ -10,9 +10,12 @@
 # TRUST: the GitHub environment is part of the OIDC subject, so a workflow that
 # does not declare `environment: <name>` cannot assume the matching role. This
 # is the same containment the prod-use2 bootstrap role uses
-# (iam-gha-prod-use2-terraform.tf). Pair each environment with a deployment
-# branch restriction (dev -> main, staging -> staging, prod -> prod,
-# infra-global -> main) so the subject cannot be minted from a stray branch.
+# (iam-gha-prod-use2-terraform.tf). The environment name alone is not enough,
+# because it says nothing about which branch ran: terraform-apply.yml therefore
+# refuses to mint credentials unless the checked-out commit is reachable from
+# its required `trusted_branch` (dev -> main, staging -> staging, prod -> prod,
+# infra-global -> main). Set the matching deployment-branch restriction on each
+# environment as well.
 #
 # PERMISSIONS: PowerUserAccess plus a narrow inline IAM grant, matching the
 # prod-use2 role. PowerUserAccess covers everything a root builds (VPC, ECS,


### PR DESCRIPTION
## Problem

`deploy-prod-us-east-2-shadow.yml` was the only workflow in the repository that
ran `terraform apply`. Every other root — `environments/{dev,dev-web,staging,staging-web,prod,prod-web,preview}`,
`compliance-monitoring`, `security-baseline` — was applied by hand from an
operator laptop.

Consequence, today (2026-08-10): two merged compliance PRs, #6295 (SES IAM user
→ ECS task role, DCF-71) and #6344 (WAF association on the ECS web ALBs), sat
merged and unapplied for hours. Both have since been applied by hand. Nothing in
CI would have caught it:

- No apply job existed for those roots.
- The nightly `drift detection` matrix in `terraform-ci.yml` did not include
  `dev-web`, `staging-web`, `prod-web`, or `compliance-monitoring` — exactly the
  roots #6344 touched.
- The drift job that does exist has been erroring on Cloudflare authentication
  since 2026-08-03, because it never passed a `cloudflare` provider credential.

## What ships

**1. `.github/workflows/terraform-apply.yml`** — a reusable (`workflow_call`)
guarded apply for one root. Inputs: `tf_root`, `aws_region`, `role_arn`,
`github_environment`, `trusted_branch`, `cloudflare`, `ref`. Flow: checkout →
**trusted-branch guard** → OIDC `configure-aws-credentials` → `init` →
`plan -out=tf.plan` → **destructive-change guard** → `apply tf.plan`. It applies
the same plan file it inspected, so the guard cannot be raced by a diff that
re-resolves at apply time.

*Destructive-change guard*: the shadow workflow's JSON guard
(`deploy-prod-us-east-2-shadow.yml:138-178`), generalized from two hardcoded
module addresses to the resource type. Any planned `delete` fails the job,
except an `aws_ecs_task_definition` rendered as a `["delete","create"]` /
`["create","delete"]` replacement.

*Trusted-branch guard*: fails unless the checked-out commit is reachable from
`origin/<trusted_branch>`, and runs **before** any credential is minted. The
GitHub environment alone is not a sufficient gate — it is part of the OIDC
subject, but the deployment-branch restriction behind it is out-of-band
repository configuration, and three callers are `workflow_dispatch`-able from an
arbitrary branch. Reachability rather than `github.ref`, so it is correct for
`push`, `workflow_dispatch`, and `workflow_run` alike.

**2. `infra/terraform/security-baseline/iam-gha-tf-apply.tf`** — four OIDC roles
built on the shape of `iam-gha-prod-use2-terraform.tf` (PowerUserAccess plus a
narrow inline IAM grant, trust subject pinned to a GitHub *environment*):

| Role | Trust subject | IAM scope |
| --- | --- | --- |
| `kortix-gha-tf-apply-dev` | `repo:kortix-ai/suna:environment:dev` | `role/kortix-dev-*` |
| `kortix-gha-tf-apply-staging` | `…:environment:staging` | `role/kortix-staging-*` |
| `kortix-gha-tf-apply-prod` | `…:environment:prod` | `role/kortix-prod-*` |
| `kortix-gha-tf-apply-global` | `…:environment:infra-global` | enumerated baseline roles, policies, groups (below) |

The global role does **not** get `iam:*`. Its inline policy enumerates every IAM
principal `compliance-monitoring` and `security-baseline` manage — roles by ARN
pattern (`kortix-*`, `Kortix*`, `whatsapp-gateway-*`, `bedrock-logs`,
`cloudtrail-cloudwatch-logs-role`, `vpc-flow-logs-role`,
`AWSBackupDefaultServiceRole`), customer policies under `policy/kortix-*`, and
group/user ARNs derived from `keys(local.groups)` in `iam-groups.tf` so the two
cannot drift. An unlisted role name fails the apply with `AccessDenied` rather
than silently widening the grant. A `Deny` on IAM-user, access-key, and
login-profile creation is the backstop.

**3. Wiring.** `deploy-dev.yml` gains a `terraform` paths filter and a
`terraform-dev` job; `deploy-staging.yml` gains `terraform-staging` +
`terraform-staging-web` after `preflight`; `deploy-prod.yml` gains
`terraform-prod` after `version`. New `terraform-apply-global.yml` applies
`compliance-monitoring` then `security-baseline` on push to `main`.

**4. `terraform-ci.yml` fixes.** Drift matrix gains `dev-web`, `staging-web`,
`prod-web`, `compliance-monitoring`. The drift job now exports
`TF_VAR_cloudflare_api_token` and fails loudly if the secret is unset. New
`apply-pipeline-health` job fails on the daily schedule when any
`TF_APPLY_ROLE_ARN_*` / `TF_PLAN_ROLE_ARN` variable is unset, or when the last
successful `drift detection` job is older than 48h.

## Which roots are auto-applied, and which are not

| Root | Applied by | Region |
| --- | --- | --- |
| `environments/dev-web` | `deploy-dev.yml` → `terraform-dev` | us-west-2 |
| `environments/staging` | `deploy-staging.yml` → `terraform-staging` | us-west-2 |
| `environments/staging-web` | `deploy-staging.yml` → `terraform-staging-web` | us-west-2 |
| `environments/prod-web` | `deploy-prod.yml` → `terraform-prod` | eu-west-2 |
| `compliance-monitoring` | `terraform-apply-global.yml` | us-west-2 |
| `security-baseline` | `terraform-apply-global.yml` | us-west-2 |
| `environments/prod-us-east-2-shadow` | unchanged, already automated | us-east-2 |
| **`environments/dev`** | **still manual** | — |
| **`environments/prod`** | **still manual** | — |
| **`environments/preview`** | **still manual** | — |

Every root, applied or not, is now planned nightly by the drift matrix, so an
unapplied change still surfaces.

### Why `environments/dev` and `environments/prod` stay manual

Both read a gitignored `terraform.tfvars` (`.gitignore:133`) whose committed
`.example` diverges from the variable defaults: dev sets a non-empty
`api_environment`, prod additionally pins `api_image` to a release tag instead
of `:latest`. CI applying with plain defaults would plan against inputs no
operator ever used.

`environments/staging` is auto-applied precisely because its example file *is*
the defaults (`api_environment = {}`, `manage_dns = false`).

`infra/terraform/README.md` carries the root table plus a concrete three-step
TODO to unblock dev/prod. The likely answer is that the blocking variables are
already inert — `api_image`, `gateway_image`, `api_environment`, `api_secrets`,
`gateway_environment` reach only `aws_ecs_task_definition.container_definitions`,
which `modules/ecs-api/main.tf:473` marks `ignore_changes` — but that must be
confirmed with a real credentialed `plan -detailed-exitcode` before those two
roots go into CI. This PR does not guess at production.

## Deviations from the brief, and why

1. **A fourth role, `kortix-gha-tf-apply-global`.** The brief routes
   `terraform-apply-global.yml` through `TF_APPLY_ROLE_ARN_PROD`. That role
   cannot apply `security-baseline`: PowerUserAccess excludes IAM, and the
   root's inline grant is scoped to `role/kortix-prod-*`, while the stack
   manages `whatsapp-gateway-github-deploy`, `bedrock-logs`, IAM groups, and the
   account password policy. Widening the prod role would put IAM write in the
   release pipeline. A separate, enumerated role keeps that blast radius in one
   place.
2. **`github_environment` is required, not optional.** All three trust policies
   pin the OIDC subject to `environment:<name>`. A call without an environment
   mints subject `ref:refs/heads/<branch>` and the AssumeRole fails. Making it
   optional would ship a pipeline that cannot authenticate.
3. **`terraform_version` is `1.15.8`, and `terraform-ci.yml`'s `TF_VERSION` is
   bumped from `1.9.8` to match.** State is forward-incompatible. The two roots
   applied by hand this morning were applied with local Terraform 1.15.8, so a
   1.9.8 plan against that state now fails with "state snapshot was created by a
   newer Terraform". One pinned version, bumped in lock-step, in both files.
4. **`deploy-dev.yml`'s paths filter excludes `infra/terraform/environments/dev/**`.**
   Listing a path the job does not apply produces a green check for work that
   did not happen — the failure mode this PR exists to remove.
5. **Do not add required reviewers to the `prod` environment.** `deploy-prod.yml`
   runs unattended after a reviewed release PR merges; a reviewer gate would
   pause every release at the Terraform step. The in-workflow `trusted_branch`
   guard plus a deployment-branch restriction give the containment without the
   stall.

## Review findings fixed in this PR

Two automated reviewers caught real problems in the first commit
(`7823ff05aa`). Both are fixed; both fixes are verified below.

- **Checkov / Drata, 4 errors + 1 new CRITICAL** — the global role's inline
  policy was `iam:*` on `*` (CKV_AWS_286 privilege escalation, CKV_AWS_289
  unconstrained permissions management, CKV_AWS_355 wildcard resource,
  CKV2_AWS_40 full IAM privileges). Drata went from 3 CRITICAL on `main` to 4 on
  the branch. Fixed in `b047036aa2` by enumerating the managed IAM resources.
  `checkov -d infra/terraform/security-baseline` is now 362 passed / **0
  failed** / 25 skipped.
- **Strix, HIGH — "Privileged Terraform apply trusts GitHub environment name
  without enforcing a trusted branch."** Correct: anyone able to
  `workflow_dispatch` `deploy-prod.yml` from a branch could have applied
  attacker-authored Terraform with the production role. Fixed in `93a117bd75`
  by the `trusted_branch` guard described above, hardened in `e2232ce99e`
  (explicit fetch refspec).

  The fix is deliberately stronger than the suggested patch. A `GITHUB_REF ==
  refs/heads/prod` comparison would still pass while `inputs.ref` pointed at an
  arbitrary SHA; checking that the **checked-out HEAD** is reachable from the
  trusted branch closes that hole too.

  Follow-on in `def9e523d6`: `deploy-dev.yml` documents `workflow_dispatch` as a
  "manual branch run", so `terraform-dev` is additionally gated on
  `github.ref == 'refs/heads/main'`. A branch dispatch skips the apply instead
  of failing it, which keeps the image deploys green — a branch run deploys
  images, never infrastructure. `deploy-prod.yml` keeps the loud failure.

## Required manual steps after merge

The four roles are defined in `security-baseline`, which is applied by one of
them. Break the cycle once, by hand:

```bash
cd infra/terraform/security-baseline
terraform init
terraform apply
terraform output -json | jq -r 'to_entries[]
  | select(.key | startswith("gha_tf_apply_role_arn"))
  | "\(.key)\t\(.value.value)"'
```

Then set four repository variables:

| Variable | Terraform output |
| --- | --- |
| `TF_APPLY_ROLE_ARN_DEV` | `gha_tf_apply_role_arn_dev` |
| `TF_APPLY_ROLE_ARN_STAGING` | `gha_tf_apply_role_arn_staging` |
| `TF_APPLY_ROLE_ARN_PROD` | `gha_tf_apply_role_arn_prod` |
| `TF_APPLY_ROLE_ARN_GLOBAL` | `gha_tf_apply_role_arn_global` |

And create four GitHub environments with deployment-branch restrictions:

| Environment | Deployment branch |
| --- | --- |
| `dev` | `main` |
| `staging` | `staging` |
| `prod` | `prod` |
| `infra-global` | `main` |

Also confirm `TF_PLAN_ROLE_ARN` (already output by `iam-gha-tf-plan.tf`) and the
`CLOUDFLARE_API_TOKEN` secret are set, or the drift job stays red.

**Until those variables are set, every apply job skips and every image deploy
still runs.** This PR is safe to merge before the bootstrap. `apply-pipeline-health`
fails on the daily schedule while any variable is missing, so the skip cannot
become permanent silently.

## Verification

Run locally on this branch (Terraform v1.15.8, TFLint v0.63.1, actionlint):

```
$ actionlint .github/workflows/terraform-apply.yml \
    .github/workflows/terraform-apply-global.yml \
    .github/workflows/terraform-ci.yml \
    .github/workflows/deploy-dev.yml \
    .github/workflows/deploy-staging.yml \
    .github/workflows/deploy-prod.yml
EXIT=0

$ terraform fmt -check -recursive infra/terraform
FMT CLEAN

$ cd infra/terraform && tflint --recursive --format compact
TFLINT_EXIT=0

$ python3 infra/terraform/scripts/test_web_waf_associations.py   # 3/3 OK
$ python3 infra/terraform/scripts/test_audit_nacl_admin_ports.py # 9/9 passed

$ checkov -d infra/terraform/security-baseline --framework terraform --compact --quiet
Passed checks: 362, Failed checks: 0, Skipped checks: 25
```

`terraform init -backend=false && terraform validate` on every root, i.e. the
same loop `terraform-ci.yml`'s `validate` job runs:

```
ok: infra/terraform/environments/prod
ok: infra/terraform/environments/staging-web
ok: infra/terraform/environments/staging
ok: infra/terraform/environments/prod-web
ok: infra/terraform/environments/prod-us-east-2-shadow
ok: infra/terraform/environments/dev-web
ok: infra/terraform/environments/dev
ok: infra/terraform/environments/preview
ok: infra/terraform/compliance-monitoring
ok: infra/terraform/security-baseline
ok: infra/terraform/examples/selfhost-ec2
```

The destructive-change guard was exercised against synthetic
`terraform show -json` payloads using the exact jq expressions from the
workflow:

```
1-noop.json               blocked=0 allowed_taskdef_replacements=0 => APPLY
2-create-update.json      blocked=0 allowed_taskdef_replacements=0 => APPLY
3-taskdef-replace.json    blocked=0 allowed_taskdef_replacements=2 => APPLY
4-real-delete.json        blocked=1 allowed_taskdef_replacements=0 => FAIL (as designed)
5-alb-replace.json        blocked=1 allowed_taskdef_replacements=0 => FAIL (as designed)
6-taskdef-pure-delete.json blocked=1 allowed_taskdef_replacements=0 => FAIL (as designed)
7-empty.json              blocked=0 allowed_taskdef_replacements=0 => APPLY
```

Case 5 is the one that matters: an ALB replacement is a delete+create pair, and
the guard blocks it because the type is not `aws_ecs_task_definition`. Case 7
proves the empty-plan payload does not trip the `jq` iterator.

The trusted-branch guard was exercised against this repository's real git
history, using the same `git merge-base --is-ancestor` call the workflow makes:

```
commit already on main, trusted_branch=main  => APPLY
unmerged PR head,       trusted_branch=main  => REFUSE (as designed)
unmerged PR head,       trusted_branch=prod  => REFUSE (as designed)
prod tip,               trusted_branch=prod  => APPLY
```

The `apply-pipeline-health` freshness query was checked against a fixture jobs
payload — it selects the newest **successful** `drift detection (…)` job and
ignores a later failed one:

```
$ jq -r '[.jobs[] | select(.name | startswith("drift detection"))
         | select(.conclusion == "success") | .completed_at] | sort | last // empty' jobs-fixture.json
2026-08-09T07:15:44Z
```

The two derived IAM locals were evaluated in a scratch Terraform root (no AWS
credentials needed) to confirm they render well-formed ARNs: 8 group ARNs
(`administrators`, `bedrock-*`, `cloudwatch-logs-writers`, `mfa-self-manage`,
`ses-senders`) and 13 user ARNs.

## Pre-existing red check, not caused by this PR

`terraform-ci.yml`'s `fmt + validate` job fails on its
`preview runtime contract tests` step. 5 of 7 tests in
`infra/scripts/test-ecs-preview-runtime.py` fail. It is stale relative to
`main`, not broken by this branch:

- Neither `deploy-preview.yml` nor `test-ecs-preview-runtime.py` appears in
  `git diff --name-only origin/main...HEAD`.
- #6347 (`7074ffd25e`, "run full-stack PR previews in warm sandboxes") moved
  previews from `infra/scripts/ecs-preview.sh` to
  `bun tests/bin/sandbox-preview.ts` and changed the checkout count.
  `git show 7074ffd25e^:.github/workflows/deploy-preview.yml | grep -c "persist-credentials: false"`
  returns `3`; the same command on `origin/main` returns `6`. The test asserts
  `== 3`.
- `terraform-ci.yml` only runs on PRs touching `infra/terraform/**` or itself.
  No PR since #6347 did, so this PR is the first to surface the breakage. The
  last green `terraform-ci` run was `31407625141` at 16:11 UTC today, before
  #6347 and #6354 merged.

The contract test encodes real security assertions (approval permission gating,
credential non-persistence, build/publish separation) against an architecture
that no longer exists. Rewriting it belongs with the author of #6347, not with
this PR — a blind "make it green" edit would drop those assertions. `main` has
no required status checks, so this does not block the merge, but it should be
fixed next.

`Drata compliance-as-code` is also already failing on `main` (runs
`31409454524`, `31404058506`), at 3 CRITICAL / 2 HIGH / 39 MODERATE. This branch
now matches that baseline again after `b047036aa2`.

## Not verified here

- No `terraform plan` was run against real AWS state: this branch has no
  credentials for the OIDC roles, which do not exist yet. The first real proof
  is the bootstrap apply plus the first `terraform-apply-global.yml` run after
  merge.
- The `always()` gates on `deploy-{dev,staging,prod}` are reviewed statically and
  actionlint-clean; the first push to `main` after merge is the live proof that a
  SKIPPED terraform job keeps the image deploys green.
