### PR TITLE
fix(tests): scope preview idempotency to workflow run

### DIFF
--- a/tests/src/core/sandbox-preview-providers.ts
+++ b/tests/src/core/sandbox-preview-providers.ts
@@ -141,6 +141,14 @@ async function replaceExistingPlatinumPreview(
   for (const sandbox of existing) await deletePlatinum(api, sandbox.id);
 }
 
+export function platinumPreviewIdempotencyKey(input: {
+  prNumber: number;
+  sha: string;
+  runId: string;
+}): string {
+  return `kortix-preview-${input.prNumber}-${input.sha}-${input.runId}`;
+}
+
 export async function deployPlatinumPreview(
   input: SandboxPreviewDeploymentInput,
 ): Promise<SandboxPreviewResult> {
@@ -165,7 +173,7 @@ export async function deployPlatinumPreview(
       '/v1/sandboxes?wait_for_state=running&wait_timeout_ms=60000',
       {
         method: 'POST',
-        headers: { 'idempotency-key': `kortix-preview-${input.prNumber}-${input.sha}` },
+        headers: { 'idempotency-key': platinumPreviewIdempotencyKey(input) },
         body: JSON.stringify({
           name: previewSandboxName(input.prNumber),
           template: template.id,

--- a/tests/unit/sandbox-preview.test.ts
+++ b/tests/unit/sandbox-preview.test.ts
@@ -7,6 +7,7 @@ import {
   runSandboxPreview,
   selectStalePreviewSandboxIds,
 } from '../src/core/sandbox-preview';
+import { platinumPreviewIdempotencyKey } from '../src/core/sandbox-preview-providers';
 
 const input = {
   provider: 'auto' as const,
@@ -18,6 +19,29 @@ const input = {
 describe('provider-neutral preview lifecycle', () => {
   it('uses one stable sandbox name per pull request', () => {
     expect(previewSandboxName(6337)).toBe('kortix-preview-pr-6337');
+  });
+
+  it('uses a new Platinum idempotency key for each deployment run', () => {
+    expect(
+      platinumPreviewIdempotencyKey({
+        prNumber: 6337,
+        sha: 'a'.repeat(40),
+        runId: '31431634153',
+      }),
+    ).toBe(`kortix-preview-6337-${'a'.repeat(40)}-31431634153`);
+    expect(
+      platinumPreviewIdempotencyKey({
+        prNumber: 6337,
+        sha: 'a'.repeat(40),
+        runId: '31428940308',
+      }),
+    ).not.toBe(
+      platinumPreviewIdempotencyKey({
+        prNumber: 6337,
+        sha: 'a'.repeat(40),
+        runId: '31431634153',
+      }),
+    );
   });
 
   it('requires the exact SHA-256 of the pull request lockfile', () => {


### PR DESCRIPTION
## Problem

Platinum rejects a second preview deployment for the same PR SHA with HTTP 422 idempotency_key_reused. The request body contains a new GitHub Actions run ID, but the idempotency key did not.

## Change

- Include the workflow run ID in every Platinum preview creation idempotency key.
- Add a regression test for two deployment runs of the same PR SHA.

## Verification

- pnpm --dir tests test:unit -- sandbox-preview.test.ts: 168/168 passed.
- pnpm --dir tests typecheck: exit 0.
- pnpm test: 5/5 lanes passed; REST/CLI 365/365 passed.
- pnpm test -- --full: core passed. Local four-worker browser execution reported one transient auth timeout. Package-quality reported a transient workspace subprocess exit. Both affected browser and package commands passed on immediate isolated reruns. Required CI uses one browser per sandbox lane.