### PR TITLE
fix(web,api): session scope defaults to Project default + unified overrides popover

### DIFF
--- a/apps/api/src/__tests__/integration-connection-authorization-http.test.ts
+++ b/apps/api/src/__tests__/integration-connection-authorization-http.test.ts
@@ -878,6 +878,85 @@ describe('connection owner authorization over HTTP', () => {
     });
   });
 
+  test('scope reports whether the session holds a connector override, and null clears it', async () => {
+    // The resolved `connector_bindings` map looks the same whether a session
+    // overrode its connectors or merely inherited the project defaults. A
+    // client that cannot tell the two apart renders an inherited session as
+    // "none" and writes an explicit zero-connector override on the next save.
+    // So: the flag says which state the row is in, and `null` is the verb that
+    // gets back out of an override.
+    const token = await mint(ALICE);
+    const connected = await request(
+      'PUT',
+      `/v1/projects/${PROJECT}/connections/${ALICE_CONNECTION}/credential`,
+      token,
+      { value: 'scope-clear-capability' },
+    );
+    expect(connected.status).toBe(200);
+
+    await db
+      .update(projectSessions)
+      .set({ connectorBindingsConfigured: false, connectorBindingsInheritUnbound: true })
+      .where(eq(projectSessions.sessionId, DEFAULT_SCOPE_SESSION));
+
+    const inherited = await request(
+      'GET',
+      `/v1/projects/${PROJECT}/sessions/${DEFAULT_SCOPE_SESSION}/scope`,
+      token,
+    );
+    expect(inherited.status).toBe(200);
+    expect(await inherited.json()).toMatchObject({
+      connector_bindings_configured: false,
+      connector_bindings_inherit_unbound: true,
+    });
+
+    // A save that names no connector axis must not create an override.
+    const secretsOnly = await request(
+      'PUT',
+      `/v1/projects/${PROJECT}/sessions/${DEFAULT_SCOPE_SESSION}/scope`,
+      token,
+      { secrets: null },
+    );
+    expect(secretsOnly.status).toBe(200);
+    expect(await secretsOnly.json()).toMatchObject({ connector_bindings_configured: false });
+
+    const explicit = await request(
+      'PUT',
+      `/v1/projects/${PROJECT}/sessions/${DEFAULT_SCOPE_SESSION}/scope`,
+      token,
+      { connector_bindings: {} },
+    );
+    expect(explicit.status).toBe(200);
+    expect(await explicit.json()).toMatchObject({ connector_bindings_configured: true });
+
+    const cleared = await request(
+      'PUT',
+      `/v1/projects/${PROJECT}/sessions/${DEFAULT_SCOPE_SESSION}/scope`,
+      token,
+      { connector_bindings: null },
+    );
+    expect(cleared.status).toBe(200);
+    expect(await cleared.json()).toMatchObject({
+      connector_bindings_configured: false,
+      // Back to resolving the project default, which is the whole point.
+      connector_bindings: {
+        personal_data: { connection_id: ALICE_CONNECTION },
+      },
+    });
+
+    const [row] = await db
+      .select({ configured: projectSessions.connectorBindingsConfigured })
+      .from(projectSessions)
+      .where(eq(projectSessions.sessionId, DEFAULT_SCOPE_SESSION));
+    expect(row).toEqual({ configured: false });
+    expect(
+      await db
+        .select({ alias: projectSessionConnectorBindings.connectorAlias })
+        .from(projectSessionConnectorBindings)
+        .where(eq(projectSessionConnectorBindings.sessionId, DEFAULT_SCOPE_SESSION)),
+    ).toEqual([]);
+  });
+
   test('scope replacement uses the session owner and rejects shared user authorization', async () => {
     const ownerToken = await mint(ALICE);
     const connected = await request(

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -2644,6 +2644,13 @@ projectsApp.openapi(
       added_secrets: [],
       dropped_bindings: [],
       retroactive: true,
+      // `connector_bindings` above is the RESOLVED map, so an inherited session
+      // and an overridden one look identical in it. Clients read this flag to
+      // tell them apart — without it the browser rendered "None selected" for a
+      // session that was simply inheriting, then wrote an explicit
+      // zero-connector override on the next untouched save.
+      connector_bindings_configured: visible.row.connectorBindingsConfigured === true,
+      connector_bindings_inherit_unbound: visible.row.connectorBindingsInheritUnbound === true,
       detail: 'Current session scope.',
     });
   },
@@ -2965,6 +2972,11 @@ projectsApp.openapi(
     const body = parsedBody.data;
     const wantsSecrets = Object.hasOwn(body, 'secrets');
     const wantsBindings = Object.hasOwn(body, 'connector_bindings');
+    // `null` CLEARS the override: drop the stored rows AND the configured flag,
+    // so every granted alias resolves to the project default again. `{}` is the
+    // opposite — an explicit "no connectors at all". Before this existed an
+    // override was one-way: nothing in the API could undo one.
+    const clearsBindings = wantsBindings && body.connector_bindings === null;
     const wantsRequired = Object.hasOwn(body, 'require_connectors');
 
     // The agent grant is the ceiling for both axes. Resolved from the agent this
@@ -3097,7 +3109,12 @@ projectsApp.openapi(
 
     let nextBindings = currentDurableBindings;
     let droppedBindings: string[] = [];
-    if (wantsBindings) {
+    if (clearsBindings) {
+      // No grant check and no binding validation: removing every stored binding
+      // cannot widen what this session may reach beyond the project default,
+      // which is what an un-overridden session already resolves to.
+      nextBindings = {};
+    } else if (wantsBindings) {
       const requested = Object.fromEntries(
         Object.entries(body.connector_bindings ?? {}).map(([alias, value]) => [
           alias,
@@ -3152,7 +3169,7 @@ projectsApp.openapi(
       source: 'request';
       createdBy: string;
     }> = [];
-    if (wantsBindings) {
+    if (wantsBindings && !clearsBindings) {
       const [ownerServiceAccount] = visible.row.createdBy
         ? await db
             .select({ id: serviceAccounts.serviceAccountId })
@@ -3216,7 +3233,9 @@ projectsApp.openapi(
       if (wantsSecrets) sessionUpdates.secretsAllowlist = nextAllowlist;
       if (wantsRequired) sessionUpdates.requiredConnectors = nextRequired;
       if (wantsBindings) {
-        sessionUpdates.connectorBindingsConfigured = true;
+        // `null` reverts the session to inheriting project defaults; anything
+        // else is an explicit override.
+        sessionUpdates.connectorBindingsConfigured = !clearsBindings;
         // Deliberately NOT touching connectorBindingsInheritUnbound. Forcing it
         // false here meant a single scope save silently cut off project-default
         // fallback for every alias the caller did not re-bind — a session that had
@@ -3311,6 +3330,12 @@ projectsApp.openapi(
       dropped_secrets: canReadSecretNames ? droppedSecrets : [],
       added_secrets: addedSecrets,
       dropped_bindings: droppedBindings,
+      // Echoed so the caller can re-render from THIS response instead of
+      // re-fetching the scope to learn whether an override now exists.
+      connector_bindings_configured: wantsBindings
+        ? !clearsBindings
+        : visible.row.connectorBindingsConfigured === true,
+      connector_bindings_inherit_unbound: visible.row.connectorBindingsInheritUnbound === true,
       // Connector bindings ARE retroactive (resolved at call time). Secrets are
       // not: a dropped one stops being delivered from the next prompt, but the
       // agent's context and any shell it already spawned still hold what it read.
@@ -3331,7 +3356,9 @@ projectsApp.openapi(
           : scopeAppliedLive
             ? 'Applied to the running sandbox now — the OpenCode process and new shells see the new scope.'
             : 'Applies from the next prompt.'
-        : 'No change to the secrets scope.',
+        : clearsBindings
+          ? 'Connector access is back to the project defaults.'
+          : 'No change to the secrets scope.',
     });
   },
 );

--- a/apps/web/content/docs/sdk/sessions.mdx
+++ b/apps/web/content/docs/sdk/sessions.mdx
@@ -143,7 +143,13 @@ Read the stored secret narrowing and materialized connection bindings.
 
 ```ts
 const scope = await s.scope();
+scope.connector_bindings_configured; // false = inherits the project defaults
 ```
+
+`connector_bindings` is the RESOLVED map, so it looks the same for a session
+that overrode its connectors and one that inherits the project defaults. Read
+`connector_bindings_configured` to tell them apart before rendering the scope or
+sending it back.
 
 Replace one or both scope fields:
 
@@ -160,6 +166,21 @@ Each supplied field replaces its complete previous value. Omit a field to leave
 it unchanged. Connection changes apply to the next tool call.
 Secret removal stops future delivery but cannot remove an already disclosed
 value from model context or an existing process.
+
+Both axes have an explicit way back to the default. They are not the same as an
+empty value:
+
+```ts
+await s.rescope({
+  secrets: null, // inherit the agent's secret grant
+  connector_bindings: null, // drop the override; inherit the project defaults
+});
+```
+
+`secrets: []` and `connector_bindings: {}` are the opposite instruction: an
+explicit "no project secrets" and "no connectors at all", project defaults
+included. A session that sends `{}` where it meant `null` fails closed on every
+alias it did not name.
 
 Read the unified cost record:
 

--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -160,6 +160,7 @@ export function ComposerChatInput({
           selectedModel={local.model.currentKey ?? null}
           onModelChange={(m) => local.model.set(m ?? undefined, { recent: true })}
           providers={providers}
+          defaultModel={local.model.defaults.resolveDefaultFor(selectedAgentName ?? undefined)}
         />
       ) : null,
     [

--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -2,8 +2,8 @@
 
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { SessionOverridesComposer } from '@/features/session/overrides/session-overrides-composer';
 import type { SessionScopeCommit } from '@/features/session/scope/session-scope-model';
-import { SessionScopeToolbar } from '@/features/session/scope/session-scope-toolbar';
 import {
   type AttachedFile,
   SessionChatInput,
@@ -141,18 +141,41 @@ export function ComposerChatInput({
     },
     [selectedAgentName],
   );
+  // Every axis a session can override, in one popover — built from the SAME
+  // agent/model/effort controls this toolbar already renders.
   const sessionScopeToolbar = useMemo(
     () =>
       projectId ? (
-        <SessionScopeToolbar
+        <SessionOverridesComposer
           projectId={projectId}
           sessionId={sessionId}
-          agentName={selectedAgentName ?? undefined}
           onCommittedDraft={sessionId ? undefined : handleCommittedScope}
+          agents={local.agent.list}
+          selectedAgent={selectedAgentName}
+          onAgentChange={lockedAgentName ? undefined : (name) => local.agent.set(name ?? undefined)}
+          agentLocked={!!lockedAgentName}
+          defaultAgentName={projectConfig?.open_code_default_agent}
+          models={local.model.list}
+          modelsLoading={providersLoading}
+          selectedModel={local.model.currentKey ?? null}
+          onModelChange={(m) => local.model.set(m ?? undefined, { recent: true })}
+          providers={providers}
         />
       ) : null,
-    [handleCommittedScope, projectId, selectedAgentName, sessionId],
+    [
+      handleCommittedScope,
+      local.agent,
+      local.model,
+      lockedAgentName,
+      projectConfig?.open_code_default_agent,
+      projectId,
+      providers,
+      providersLoading,
+      selectedAgentName,
+      sessionId,
+    ],
   );
+
   const combinedToolbarSlot = useMemo(
     () =>
       toolbarSlot || sessionScopeToolbar ? (

--- a/apps/web/src/features/session/overrides/session-overrides-composer.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-composer.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { AgentSelector } from '@/features/session/composer/agent-selector';
+import type { FlatModel } from '@/features/session/model-flatten';
+import { ModelSelector } from '@/features/session/model-selector';
+import {
+  ReasoningEffortSelector,
+  useReasoningEffortControl,
+} from '@/features/session/reasoning-effort-selector';
+import type { SessionScopeCommit } from '@/features/session/scope/session-scope-model';
+import type { Agent, ProviderListResponse } from '@kortix/sdk/react';
+import { useProjectSession } from '@kortix/sdk/react';
+
+import { SessionOverridesToolbar } from './session-overrides-toolbar';
+
+export interface SessionOverridesComposerProps {
+  projectId: string;
+  sessionId?: string;
+  onCommittedDraft?: (commit: SessionScopeCommit | undefined) => void;
+
+  agents: Agent[];
+  selectedAgent: string | null;
+  onAgentChange?: (agentName: string | null) => void;
+  agentLocked?: boolean;
+  /** The project's configured default agent — what "no override" resolves to. */
+  defaultAgentName?: string | null;
+
+  models: FlatModel[];
+  modelsLoading?: boolean;
+  selectedModel: { providerID: string; modelID: string } | null;
+  onModelChange?: (model: { providerID: string; modelID: string } | null) => void;
+  providers?: ProviderListResponse;
+}
+
+/**
+ * The composer's overrides control, wired to the SAME agent/model/effort
+ * controls the toolbar row renders.
+ *
+ * It exists so the two composers (the project-home one in
+ * `composer-chat-input.tsx` and the in-session one in `session-chat.tsx`) build
+ * the panel from one place. Each already owns this state for its toolbar; this
+ * only re-uses it.
+ */
+export function SessionOverridesComposer({
+  projectId,
+  sessionId,
+  onCommittedDraft,
+  agents,
+  selectedAgent,
+  onAgentChange,
+  agentLocked = false,
+  defaultAgentName,
+  models,
+  modelsLoading,
+  selectedModel,
+  onModelChange,
+  providers,
+}: SessionOverridesComposerProps) {
+  const sessionRow = useProjectSession(projectId, sessionId, { enabled: Boolean(sessionId) });
+  const effort = useReasoningEffortControl(selectedModel, projectId);
+  const currentModel = models.find(
+    (candidate) =>
+      candidate.providerID === selectedModel?.providerID &&
+      candidate.modelID === selectedModel?.modelID,
+  );
+
+  const agentSlot = useMemo(
+    () => ({
+      summary: selectedAgent ?? 'Project default',
+      // The project's own default agent is not an override, even though it is
+      // the selected one.
+      overridden: Boolean(selectedAgent) && selectedAgent !== defaultAgentName,
+      description: agentLocked
+        ? 'This session is bound to its agent, so it cannot be changed here. The agent also sets the ceiling for every other axis: a session never reaches past what its agent is granted.'
+        : 'The agent that answers your next prompt. It also sets the ceiling for every other axis — a session never reaches past what its agent is granted.',
+      control: (
+        <AgentSelector
+          agents={agents}
+          selectedAgent={selectedAgent}
+          onSelect={onAgentChange ?? (() => {})}
+          disabled={agentLocked}
+        />
+      ),
+    }),
+    [agentLocked, agents, defaultAgentName, onAgentChange, selectedAgent],
+  );
+
+  const modelSlot = useMemo(
+    () => ({
+      summary: currentModel?.modelName ?? 'Project default',
+      overridden: Boolean(selectedModel),
+      control: (
+        <ModelSelector
+          models={models}
+          modelsLoading={modelsLoading}
+          selectedModel={selectedModel}
+          onSelect={onModelChange ?? (() => {})}
+          providers={providers}
+          unsetLabel="Project default"
+          disabled={!onModelChange}
+        />
+      ),
+    }),
+    [currentModel?.modelName, models, modelsLoading, onModelChange, providers, selectedModel],
+  );
+
+  const effortSlot = useMemo(
+    () =>
+      effort.visible
+        ? {
+            summary: effort.current ?? 'Model default',
+            overridden: Boolean(effort.current),
+            control: <ReasoningEffortSelector model={selectedModel} projectId={projectId} />,
+          }
+        : undefined,
+    [effort.current, effort.visible, projectId, selectedModel],
+  );
+
+  const sandbox = useMemo(
+    () => ({
+      slug: (sessionRow.data?.metadata?.sandbox_slug as string | undefined) ?? null,
+      provider: sessionRow.data?.sandbox_provider ?? null,
+    }),
+    [sessionRow.data?.metadata, sessionRow.data?.sandbox_provider],
+  );
+
+  return (
+    <SessionOverridesToolbar
+      projectId={projectId}
+      sessionId={sessionId}
+      agentName={selectedAgent ?? undefined}
+      onCommittedDraft={onCommittedDraft}
+      agent={agentSlot}
+      model={modelSlot}
+      reasoningEffort={effortSlot}
+      sandbox={sandbox}
+    />
+  );
+}

--- a/apps/web/src/features/session/overrides/session-overrides-composer.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-composer.tsx
@@ -32,6 +32,12 @@ export interface SessionOverridesComposerProps {
   selectedModel: { providerID: string; modelID: string } | null;
   onModelChange?: (model: { providerID: string; modelID: string } | null) => void;
   providers?: ProviderListResponse;
+  /**
+   * What the model resolves to with no session pick (agent → project → account
+   * → platform). The composer always HAS a selected model — it is seeded from
+   * this — so only a difference from it is an override worth badging.
+   */
+  defaultModel?: { providerID: string; modelID: string } | null;
 }
 
 /**
@@ -57,6 +63,7 @@ export function SessionOverridesComposer({
   selectedModel,
   onModelChange,
   providers,
+  defaultModel,
 }: SessionOverridesComposerProps) {
   const sessionRow = useProjectSession(projectId, sessionId, { enabled: Boolean(sessionId) });
   const effort = useReasoningEffortControl(selectedModel, projectId);
@@ -90,7 +97,11 @@ export function SessionOverridesComposer({
   const modelSlot = useMemo(
     () => ({
       summary: currentModel?.modelName ?? 'Project default',
-      overridden: Boolean(selectedModel),
+      overridden:
+        Boolean(selectedModel) &&
+        Boolean(defaultModel) &&
+        (selectedModel?.providerID !== defaultModel?.providerID ||
+          selectedModel?.modelID !== defaultModel?.modelID),
       control: (
         <ModelSelector
           models={models}
@@ -103,7 +114,15 @@ export function SessionOverridesComposer({
         />
       ),
     }),
-    [currentModel?.modelName, models, modelsLoading, onModelChange, providers, selectedModel],
+    [
+      currentModel?.modelName,
+      defaultModel,
+      models,
+      modelsLoading,
+      onModelChange,
+      providers,
+      selectedModel,
+    ],
   );
 
   const effortSlot = useMemo(

--- a/apps/web/src/features/session/overrides/session-overrides-control.test.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-control.test.tsx
@@ -1,0 +1,85 @@
+import { KeyIcon, RobotIcon } from '@phosphor-icons/react';
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  SessionOverridesControl,
+  SessionOverridesControlContent,
+  type SessionOverrideRow,
+} from './session-overrides-control';
+
+const rows = (overrides: Partial<SessionOverrideRow>[] = []): SessionOverrideRow[] => [
+  {
+    id: 'agent',
+    name: 'Agent',
+    icon: RobotIcon,
+    hint: 'Who answers',
+    summary: 'Project default',
+    description: 'The agent that answers your next prompt.',
+    editor: <div>agent editor</div>,
+    ...overrides[0],
+  },
+  {
+    id: 'secrets',
+    name: 'Secrets',
+    icon: KeyIcon,
+    hint: 'Environment values',
+    summary: 'Project default',
+    description: 'Which project secrets reach this session.',
+    editor: <div>secrets editor</div>,
+    ...overrides[1],
+  },
+];
+
+function render(props: Partial<React.ComponentProps<typeof SessionOverridesControlContent>> = {}) {
+  return renderToStaticMarkup(
+    <SessionOverridesControlContent rows={rows()} onSave={() => {}} {...props} />,
+  );
+}
+
+describe('SessionOverridesControlContent', () => {
+  test('lists every axis and opens on the first one', () => {
+    const html = render();
+
+    expect(html).toContain('Agent');
+    expect(html).toContain('Secrets');
+    // Left pane lists all axes; the right pane shows only the focused one.
+    expect(html).toContain('agent editor');
+    expect(html).not.toContain('secrets editor');
+    expect(html).toContain('The agent that answers your next prompt.');
+    expect(html).toContain('Changes apply to the next prompt.');
+  });
+
+  test('every untouched axis reads as the project default, never "none"', () => {
+    const html = render();
+
+    expect(html.match(/Project default/g)).toHaveLength(2);
+    expect(html).not.toContain('None selected');
+    expect(html).not.toContain('>Override<');
+  });
+
+  test('badges only the axes that actually hold an override', () => {
+    const html = render({
+      rows: rows([{}, { summary: '2 selected', overridden: true }]),
+    });
+
+    expect(html.match(/>Override</g)).toHaveLength(1);
+    expect(html).toContain('2 selected');
+  });
+
+  test('disables only the save action while a save is impossible', () => {
+    const html = render({ saveDisabled: true });
+
+    expect(html).toContain('disabled=""');
+    expect(html).toContain('Save');
+  });
+
+  test('uses a non-submit toolbar trigger inside the composer', () => {
+    const html = renderToStaticMarkup(
+      <SessionOverridesControl rows={rows()} onSave={() => {}} />,
+    );
+
+    expect(html).toContain('aria-label="Session overrides"');
+    expect(html).toContain('type="button"');
+  });
+});

--- a/apps/web/src/features/session/overrides/session-overrides-control.test.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-control.test.tsx
@@ -67,6 +67,19 @@ describe('SessionOverridesControlContent', () => {
     expect(html).toContain('2 selected');
   });
 
+  test('offers the way out of an override, and only when one exists', () => {
+    // The reset lives in the PANEL, beside the editor — an axis whose catalog
+    // came back empty must not be able to hide the only way back to the
+    // default.
+    const overridden = render({
+      rows: rows([{ overridden: true, onReset: () => {} }, {}]),
+    });
+    const inherited = render({ rows: rows([{ onReset: () => {} }, {}]) });
+
+    expect(overridden).toContain('Reset to project default');
+    expect(inherited).not.toContain('Reset to project default');
+  });
+
   test('disables only the save action while a save is impossible', () => {
     const html = render({ saveDisabled: true });
 

--- a/apps/web/src/features/session/overrides/session-overrides-control.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-control.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import Loading from '@/components/ui/loading';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
+import { ResetAxisButton } from '@/features/session/scope/session-scope-control';
 import { SlidersHorizontalIcon as SlidersHorizontal } from '@phosphor-icons/react';
 import type { Icon } from '@phosphor-icons/react';
 import { type ReactNode, useState } from 'react';
@@ -27,8 +28,13 @@ export interface SessionOverrideRow {
   overridden?: boolean;
   /** Sentence explaining what an override on this axis does, in the detail pane. */
   description: string;
-  /** The axis editor. `null` renders the unavailable note instead. */
+  /** The axis editor. */
   editor: ReactNode;
+  /**
+   * Drops the override on this axis. Rendered BESIDE the editor, so an empty
+   * catalog can never hide the only way back to the default.
+   */
+  onReset?: () => void;
   /** Shown instead of the editor when the axis cannot be edited here. */
   readOnly?: boolean;
 }
@@ -71,10 +77,15 @@ export function SessionOverridesControlContent({
   const controlsDisabled = disabled || saving;
 
   return (
-    <div className="flex max-h-[min(520px,calc(100vh-2rem))] flex-col">
+    <div
+      // Radix reports how much room it actually has; without this the panel is
+      // taller than the gap above the composer on a short or narrow viewport and
+      // its first row slides off the top of the screen.
+      className="flex max-h-[min(520px,var(--radix-popover-content-available-height))] flex-col"
+    >
       <div className="border-border flex min-h-0 flex-1 flex-col sm:flex-row">
         <ul
-          className="border-border flex shrink-0 flex-col gap-0.5 overflow-y-auto border-b p-1.5 sm:w-[212px] sm:border-r sm:border-b-0"
+          className="border-border flex max-h-[45%] shrink-0 flex-col gap-0.5 overflow-y-auto border-b p-1.5 sm:max-h-none sm:w-[212px] sm:border-r sm:border-b-0"
           aria-label="Session overrides"
         >
           {rows.map((row) => {
@@ -125,6 +136,9 @@ export function SessionOverridesControlContent({
                 {focused.description}
               </p>
               <div className="mt-3">{focused.editor}</div>
+              {focused.overridden && focused.onReset ? (
+                <ResetAxisButton disabled={controlsDisabled} onReset={focused.onReset} />
+              ) : null}
             </>
           ) : null}
           {notice ? <div className="mt-3">{notice}</div> : null}
@@ -171,6 +185,7 @@ export function SessionOverridesControl({
         side="top"
         align="end"
         sideOffset={8}
+        collisionPadding={12}
         className="w-[min(620px,calc(100vw-2rem))] overflow-hidden p-0 shadow-md"
         // The model, agent and effort editors are themselves popovers rendered
         // into their own portal. Radix sees that portal as "outside", so an

--- a/apps/web/src/features/session/overrides/session-overrides-control.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-control.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import { SlidersHorizontalIcon as SlidersHorizontal } from '@phosphor-icons/react';
+import type { Icon } from '@phosphor-icons/react';
+import { type ReactNode, useState } from 'react';
+
+/**
+ * One overridable axis of a session.
+ *
+ * `summary` is what the axis is set to RIGHT NOW, and for an axis nobody
+ * touched that string is "Project default" — never "none". `overridden` is what
+ * earns the badge: a session should look inherited until the user deliberately
+ * takes it off the default.
+ */
+export interface SessionOverrideRow {
+  id: string;
+  name: string;
+  icon: Icon;
+  /** One line under the axis name in the list. */
+  hint: string;
+  summary: string;
+  overridden?: boolean;
+  /** Sentence explaining what an override on this axis does, in the detail pane. */
+  description: string;
+  /** The axis editor. `null` renders the unavailable note instead. */
+  editor: ReactNode;
+  /** Shown instead of the editor when the axis cannot be edited here. */
+  readOnly?: boolean;
+}
+
+export interface SessionOverridesControlProps {
+  rows: SessionOverrideRow[];
+  disabled?: boolean;
+  saving?: boolean;
+  saveDisabled?: boolean;
+  /** Extra note above the footer — e.g. the non-retroactive secrets warning. */
+  notice?: ReactNode;
+  onSave: () => void;
+  triggerLabel?: string;
+}
+
+/**
+ * The session's overrides, in one place: a list of axes on the left and the
+ * focused axis's editor on the right.
+ *
+ * The old surface was a "Scope" popover holding two collapsed accordions. It
+ * hid the two axes it did cover, said nothing about the four other things a
+ * session can override (agent, model, reasoning effort, sandbox), and — worst —
+ * reported an inherited connector axis as "None selected", which invited the
+ * user to Save an override that had never existed.
+ *
+ * Everything here is inherited until it is not. A row shows what it resolves to
+ * today; only a deliberate change writes an override, and every writable axis
+ * carries the way back to the default.
+ */
+export function SessionOverridesControlContent({
+  rows,
+  disabled = false,
+  saving = false,
+  saveDisabled = false,
+  notice,
+  onSave,
+}: Omit<SessionOverridesControlProps, 'triggerLabel'>) {
+  const [focusedId, setFocusedId] = useState<string | null>(rows[0]?.id ?? null);
+  const focused = rows.find((row) => row.id === focusedId) ?? rows[0];
+  const controlsDisabled = disabled || saving;
+
+  return (
+    <div className="flex max-h-[min(520px,calc(100vh-2rem))] flex-col">
+      <div className="border-border flex min-h-0 flex-1 flex-col sm:flex-row">
+        <ul
+          className="border-border flex shrink-0 flex-col gap-0.5 overflow-y-auto border-b p-1.5 sm:w-[212px] sm:border-r sm:border-b-0"
+          aria-label="Session overrides"
+        >
+          {rows.map((row) => {
+            const RowIcon = row.icon;
+            const active = row.id === focused?.id;
+            return (
+              <li key={row.id}>
+                <button
+                  type="button"
+                  aria-current={active}
+                  onClick={() => setFocusedId(row.id)}
+                  className={cn(
+                    'flex w-full min-w-0 items-center gap-2.5 rounded-md px-2 py-2 text-left',
+                    'transition-colors active:scale-[0.99]',
+                    active ? 'bg-primary/[0.06]' : 'hover:bg-foreground/[0.04]',
+                  )}
+                >
+                  <RowIcon
+                    className={cn(
+                      'size-4 shrink-0',
+                      active ? 'text-foreground' : 'text-muted-foreground',
+                    )}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="text-foreground block truncate text-sm font-medium">
+                      {row.name}
+                    </span>
+                    <span className="text-muted-foreground block truncate text-xs">
+                      {row.summary}
+                    </span>
+                  </span>
+                  {row.overridden ? (
+                    <Badge variant="outline" size="xs" className="shrink-0">
+                      Override
+                    </Badge>
+                  ) : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        <div className="min-h-0 min-w-0 flex-1 overflow-y-auto px-4 py-3.5">
+          {focused ? (
+            <>
+              <h3 className="text-foreground text-sm font-medium text-balance">{focused.name}</h3>
+              <p className="text-muted-foreground mt-1 text-xs leading-relaxed text-pretty">
+                {focused.description}
+              </p>
+              <div className="mt-3">{focused.editor}</div>
+            </>
+          ) : null}
+          {notice ? <div className="mt-3">{notice}</div> : null}
+        </div>
+      </div>
+
+      <div className="border-border flex items-center justify-between gap-3 border-t px-4 py-3">
+        <p className="text-muted-foreground text-xs leading-relaxed text-pretty">
+          Changes apply to the next prompt.
+        </p>
+        <Button
+          type="button"
+          className="h-9 px-4"
+          disabled={controlsDisabled || saveDisabled}
+          onClick={onSave}
+        >
+          {saving ? <Loading className="size-3.5 shrink-0" /> : null}
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function SessionOverridesControl({
+  triggerLabel = 'Session',
+  ...contentProps
+}: SessionOverridesControlProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="toolbar"
+          disabled={contentProps.disabled || contentProps.saving}
+          aria-label="Session overrides"
+        >
+          <SlidersHorizontal className="size-3.5 shrink-0" />
+          {triggerLabel}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="end"
+        sideOffset={8}
+        className="w-[min(620px,calc(100vw-2rem))] overflow-hidden p-0 shadow-md"
+        // The model, agent and effort editors are themselves popovers rendered
+        // into their own portal. Radix sees that portal as "outside", so an
+        // unguarded interaction there closes THIS panel under the user's cursor.
+        onInteractOutside={(event) => {
+          const target = event.target as HTMLElement | null;
+          if (target?.closest('[data-radix-popper-content-wrapper]')) event.preventDefault();
+        }}
+      >
+        <SessionOverridesControlContent {...contentProps} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/session/overrides/session-overrides-toolbar.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-toolbar.tsx
@@ -20,6 +20,8 @@ import {
 } from '@/features/session/scope/session-scope-control';
 import {
   createSessionScopeDraft,
+  resetSessionConnectorBindings,
+  resetSessionSecrets,
   sessionConnectorsAreOverridden,
   sessionConnectorsSummary,
   sessionSecretsAreOverridden,
@@ -244,6 +246,7 @@ export function SessionOverridesToolbar({
           onChange={onChange}
         />
       ),
+      onReset: () => onChange(resetSessionSecrets(draft)),
     });
     list.push({
       id: 'connectors',
@@ -265,6 +268,7 @@ export function SessionOverridesToolbar({
           onChange={onChange}
         />
       ),
+      onReset: () => onChange(resetSessionConnectorBindings(draft, activeCatalog)),
     });
     list.push({
       id: 'sandbox',

--- a/apps/web/src/features/session/overrides/session-overrides-toolbar.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-toolbar.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { InfoBanner } from '@/components/ui/info-banner';
+import { errorToast, successToast } from '@/components/ui/toast';
+import {
+  CpuIcon as Cpu,
+  BrainIcon as Brain,
+  KeyIcon as KeyRound,
+  PlugIcon as PlugZap,
+  RobotIcon as Robot,
+  SparkleIcon as Sparkle,
+  WarningIcon as TriangleAlert,
+} from '@phosphor-icons/react';
+import type { SessionScope } from '@kortix/sdk';
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  SessionConnectorsEditor,
+  SessionSecretsEditor,
+} from '@/features/session/scope/session-scope-control';
+import {
+  createSessionScopeDraft,
+  sessionConnectorsAreOverridden,
+  sessionConnectorsSummary,
+  sessionSecretsAreOverridden,
+  sessionSecretsSummary,
+  type SessionScopeCommit,
+  type SessionScopeDraft,
+  type SessionScopeSelectionCatalog,
+} from '@/features/session/scope/session-scope-model';
+import {
+  commitSessionScopeDraft,
+  createNewSessionScopeInitialization,
+  getSessionScopeAvailability,
+} from '@/features/session/scope/session-scope-toolbar';
+import { useSessionScope } from '@/features/session/scope/use-session-scope';
+
+import { SessionOverridesControl, type SessionOverrideRow } from './session-overrides-control';
+
+const unavailableCatalog: SessionScopeSelectionCatalog = {
+  secrets: { status: 'unavailable' },
+  connector_connections: { status: 'unavailable' },
+};
+
+/** An axis whose control the composer already owns, handed in as a slot. */
+export interface SessionOverrideSlot {
+  /** What it resolves to now. "Project default" when nothing is overriding it. */
+  summary: string;
+  overridden?: boolean;
+  control: ReactNode;
+  description?: string;
+}
+
+export interface SessionOverridesToolbarProps {
+  projectId: string;
+  sessionId?: string;
+  agentName?: string;
+  onCommittedDraft?: (commit: SessionScopeCommit | undefined) => void;
+  agent?: SessionOverrideSlot;
+  model?: SessionOverrideSlot;
+  reasoningEffort?: SessionOverrideSlot;
+  /** Create-time only. Shown so the session's environment is not a mystery. */
+  sandbox?: { slug: string | null; provider: string | null };
+}
+
+function activeScopeSignature(scope: SessionScope | undefined): string {
+  if (!scope) return 'pending';
+  return JSON.stringify({
+    secrets_allowlist: scope.secrets_allowlist,
+    connector_bindings: scope.connector_bindings,
+    connector_bindings_configured: scope.connector_bindings_configured,
+    retroactive: scope.retroactive,
+  });
+}
+
+function newScopeCatalogSignature(catalog: SessionScopeSelectionCatalog): string {
+  return JSON.stringify(catalog);
+}
+
+function hasAvailableScopeAxis(catalog: SessionScopeSelectionCatalog): boolean {
+  const availability = getSessionScopeAvailability(catalog);
+  return availability.secrets || availability.connector_bindings;
+}
+
+/**
+ * Every per-session override, behind one composer control.
+ *
+ * It owns the scope draft (secrets + connectors) and borrows the agent, model
+ * and reasoning-effort controls the composer already renders, so each axis
+ * keeps exactly one implementation. The sandbox row is read-only on purpose:
+ * a session's environment is fixed at create, and a control that looked
+ * editable would be a lie.
+ */
+export function SessionOverridesToolbar({
+  projectId,
+  sessionId,
+  agentName,
+  onCommittedDraft,
+  agent,
+  model,
+  reasoningEffort,
+  sandbox,
+}: SessionOverridesToolbarProps) {
+  const { scope, catalog, saveScope, isLoading, isScopeLoading } = useSessionScope({
+    projectId,
+    sessionId,
+    agentName,
+  });
+  const committedDraftRef = useRef(onCommittedDraft);
+  committedDraftRef.current = onCommittedDraft;
+
+  const initializationKey = useMemo(() => {
+    if (!catalog) return null;
+    const identity = `${projectId}:${sessionId ?? 'new'}:${agentName ?? ''}`;
+    if (sessionId) {
+      if (!scope) return null;
+      return `${identity}:${catalog.secrets.status}:${catalog.connector_connections.status}:${activeScopeSignature(scope)}`;
+    }
+    return `${identity}:${newScopeCatalogSignature(catalog)}`;
+  }, [agentName, catalog, projectId, scope, sessionId]);
+
+  const [draftState, setDraftState] = useState<{ key: string | null; draft: SessionScopeDraft }>({
+    key: null,
+    draft: {},
+  });
+  const [retroactive, setRetroactive] = useState<boolean | undefined>();
+
+  useEffect(() => {
+    if (!catalog || !initializationKey) return;
+    if (draftState.key === initializationKey) return;
+    const initialization =
+      sessionId && scope
+        ? { draft: createSessionScopeDraft(scope, catalog), commit: undefined }
+        : createNewSessionScopeInitialization(catalog);
+    setDraftState({ key: initializationKey, draft: initialization.draft });
+    setRetroactive(sessionId ? scope?.retroactive : undefined);
+    if (!sessionId) committedDraftRef.current?.(initialization.commit);
+  }, [catalog, draftState.key, initializationKey, scope, sessionId]);
+
+  const activeCatalog = catalog ?? unavailableCatalog;
+  const initialized = draftState.key === initializationKey && initializationKey !== null;
+  const saveDisabled =
+    !initialized ||
+    !hasAvailableScopeAxis(activeCatalog) ||
+    (Boolean(sessionId) && (!scope || isScopeLoading));
+
+  const handleSave = useCallback(async () => {
+    if (!catalog || !initialized) return;
+    try {
+      const result = await commitSessionScopeDraft({
+        sessionId,
+        draft: draftState.draft,
+        catalog,
+        previousScope: scope,
+        replaceScope: saveScope.mutateAsync,
+        onCommittedDraft: committedDraftRef.current,
+      });
+      if (sessionId && result) {
+        setRetroactive(result.retroactive);
+        setDraftState({ key: initializationKey, draft: createSessionScopeDraft(result, catalog) });
+        successToast('Session overrides saved');
+      } else if (!sessionId) {
+        successToast('Session overrides configured');
+      }
+    } catch (error) {
+      errorToast(error instanceof Error ? error.message : 'Session overrides could not be saved');
+    }
+  }, [
+    catalog,
+    draftState.draft,
+    initializationKey,
+    initialized,
+    saveScope.mutateAsync,
+    scope,
+    sessionId,
+  ]);
+
+  const draft = draftState.draft;
+  const onChange = useCallback(
+    (next: SessionScopeDraft) => setDraftState((current) => ({ ...current, draft: next })),
+    [],
+  );
+  const controlsDisabled = isLoading || (Boolean(sessionId) && !scope);
+
+  const rows = useMemo(() => {
+    const list: SessionOverrideRow[] = [];
+    if (agent) {
+      list.push({
+        id: 'agent',
+        name: 'Agent',
+        icon: Robot,
+        hint: 'Who answers',
+        summary: agent.summary,
+        overridden: agent.overridden,
+        description:
+          agent.description ??
+          'The agent that answers your next prompt. It also decides the ceiling for every other axis here — a session can never reach past what its agent is granted.',
+        editor: agent.control,
+      });
+    }
+    if (model) {
+      list.push({
+        id: 'model',
+        name: 'Model',
+        icon: Sparkle,
+        hint: 'Which model',
+        summary: model.summary,
+        overridden: model.overridden,
+        description:
+          model.description ??
+          'The model this session sends to. Leave it on the project default unless this one session needs something else.',
+        editor: model.control,
+      });
+    }
+    if (reasoningEffort) {
+      list.push({
+        id: 'reasoning-effort',
+        name: 'Reasoning effort',
+        icon: Brain,
+        hint: 'How hard it thinks',
+        summary: reasoningEffort.summary,
+        overridden: reasoningEffort.overridden,
+        description:
+          reasoningEffort.description ??
+          'How much the model reasons before it answers. This one is stored per project and per model, so every session in this project using this model follows it.',
+        editor: reasoningEffort.control,
+      });
+    }
+    list.push({
+      id: 'secrets',
+      name: 'Secrets',
+      icon: KeyRound,
+      hint: 'Environment values',
+      summary:
+        activeCatalog.secrets.status === 'ready' ? sessionSecretsSummary(draft) : 'Unavailable',
+      overridden: sessionSecretsAreOverridden(draft),
+      description:
+        'Which project secrets reach this session. The default is everything this agent is granted; narrowing it here only ever takes access away.',
+      editor: (
+        <SessionSecretsEditor
+          draft={draft}
+          catalog={activeCatalog}
+          disabled={controlsDisabled || saveScope.isPending}
+          onChange={onChange}
+        />
+      ),
+    });
+    list.push({
+      id: 'connectors',
+      name: 'Connectors',
+      icon: PlugZap,
+      hint: 'Authorized accounts',
+      summary:
+        activeCatalog.connector_connections.status === 'ready'
+          ? sessionConnectorsSummary(draft)
+          : 'Unavailable',
+      overridden: sessionConnectorsAreOverridden(draft),
+      description:
+        'Which connected accounts this session may use. On the project default each one resolves to the project’s active connection; pick here only to pin this session to something else.',
+      editor: (
+        <SessionConnectorsEditor
+          draft={draft}
+          catalog={activeCatalog}
+          disabled={controlsDisabled || saveScope.isPending}
+          onChange={onChange}
+        />
+      ),
+    });
+    list.push({
+      id: 'sandbox',
+      name: 'Sandbox',
+      icon: Cpu,
+      hint: 'Where it runs',
+      summary: sandbox?.slug ?? 'Project default',
+      description:
+        'The machine image this session runs on. It is chosen when the session is created and cannot be changed afterwards — start a new session to use a different one.',
+      readOnly: true,
+      editor: (
+        <dl className="text-sm">
+          <div className="border-border flex items-center justify-between gap-3 border-b py-2">
+            <dt className="text-muted-foreground text-xs">Template</dt>
+            <dd className="text-foreground truncate text-xs">{sandbox?.slug ?? 'Project default'}</dd>
+          </div>
+          <div className="flex items-center justify-between gap-3 py-2">
+            <dt className="text-muted-foreground text-xs">Provider</dt>
+            <dd className="text-foreground truncate text-xs">{sandbox?.provider ?? 'Automatic'}</dd>
+          </div>
+        </dl>
+      ),
+    });
+    return list;
+  }, [
+    activeCatalog,
+    agent,
+    controlsDisabled,
+    draft,
+    model,
+    onChange,
+    reasoningEffort,
+    sandbox,
+    saveScope.isPending,
+  ]);
+
+  return (
+    <SessionOverridesControl
+      rows={rows}
+      disabled={controlsDisabled}
+      saving={saveScope.isPending}
+      saveDisabled={saveDisabled}
+      notice={
+        retroactive === false ? (
+          <InfoBanner tone="warning" icon={TriangleAlert} title="Existing context is unchanged">
+            Removed secret values can remain in the current conversation or existing shells.
+          </InfoBanner>
+        ) : null
+      }
+      onSave={handleSave}
+    />
+  );
+}

--- a/apps/web/src/features/session/scope/create-scoped-session.test.ts
+++ b/apps/web/src/features/session/scope/create-scoped-session.test.ts
@@ -13,6 +13,8 @@ const scope: SessionScope = {
   added_secrets: [],
   dropped_bindings: [],
   retroactive: true,
+  connector_bindings_configured: false,
+  connector_bindings_inherit_unbound: true,
   detail: 'Current session scope.',
 };
 

--- a/apps/web/src/features/session/scope/session-scope-control.test.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.test.tsx
@@ -80,24 +80,6 @@ describe('session scope editors', () => {
     expect(html).not.toContain('Reset to project default');
   });
 
-  test('offers the way out of an override, and only when one exists', () => {
-    // An override that cannot be switched off is a trap: the session keeps a
-    // frozen selection while the project's defaults move on.
-    expect(renderSecrets({ secrets: ['CALENDAR_TOKEN'] })).toContain('Reset to project default');
-    expect(
-      renderConnectors({
-        connector_bindings: { calendar: { connection_id: 'connection-calendar' } },
-        connector_bindings_inherited: false,
-      }),
-    ).toContain('Reset to project default');
-    expect(
-      renderConnectors({
-        connector_bindings: { calendar: { connection_id: 'connection-calendar' } },
-        connector_bindings_inherited: true,
-      }),
-    ).not.toContain('Reset to project default');
-  });
-
   test('shows the connection picker only for a selected connector', () => {
     const html = renderConnectors({
       connector_bindings: { calendar: { connection_id: 'connection-calendar' } },

--- a/apps/web/src/features/session/scope/session-scope-control.test.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.test.tsx
@@ -99,14 +99,29 @@ describe('SessionScopeControlContent', () => {
     expect(html).toContain('Changes apply to the next prompt.');
   });
 
-  test('distinguishes unrestricted secret access from an explicit empty allowlist', () => {
-    const allHtml = renderControl({ secrets: null, connector_bindings: {} });
+  test('distinguishes an inherited default from an explicit empty allowlist', () => {
+    // "None selected" for an inheriting session was a lie in both directions:
+    // it under-reported what the session can read, and it invited a Save that
+    // wrote the zero-access override the label claimed already existed.
+    const inheritedHtml = renderControl({ secrets: null, connector_bindings: {} });
     const noneHtml = renderControl({ secrets: [], connector_bindings: {} });
 
-    expect(allHtml).toContain('All allowed');
-    expect(noneHtml).toContain('None selected');
-    expect(allHtml).not.toContain('aria-checked="true"');
+    expect(inheritedHtml).toContain('Project default');
+    expect(inheritedHtml).not.toContain('None selected');
+    expect(noneHtml).toContain('None allowed');
+    expect(inheritedHtml).not.toContain('aria-checked="true"');
     expect(noneHtml).not.toContain('aria-checked="true"');
+  });
+
+  test('reports inherited connector access as the project default', () => {
+    const html = renderControl({
+      secrets: null,
+      connector_bindings: { calendar: { connection_id: 'connection-calendar' } },
+      connector_bindings_inherited: true,
+    });
+
+    expect(html).not.toContain('None selected');
+    expect(html.match(/>Project default</g)).toHaveLength(2);
   });
 
   test('distinguishes an omitted secret axis from an explicit empty allowlist', () => {
@@ -114,7 +129,7 @@ describe('SessionScopeControlContent', () => {
     const noneHtml = renderControl({ secrets: [], connector_bindings: {} });
 
     expect(unchangedHtml).toContain('Unchanged');
-    expect(noneHtml).toContain('None selected');
+    expect(noneHtml).toContain('None allowed');
   });
 
   test('shows catalog failures without converting them into empty selections', () => {
@@ -131,7 +146,7 @@ describe('SessionScopeControlContent', () => {
     );
 
     expect(html.match(/>Unavailable</g)).toHaveLength(2);
-    expect(html).not.toContain('None selected');
+    expect(html).not.toContain('None allowed');
   });
 
   test('shows saving state and the non-retroactive warning', () => {

--- a/apps/web/src/features/session/scope/session-scope-control.test.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.test.tsx
@@ -2,8 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import {
-  SessionScopeControl,
-  SessionScopeControlContent,
+  SessionConnectorsEditor,
+  SessionSecretsEditor,
   setAllSessionSecrets,
   setSessionConnectorConnection,
   setSessionConnectorEnabled,
@@ -50,123 +50,93 @@ const catalog: SessionScopeSelectionCatalog = {
   },
 };
 
-function renderControl(
-  draft: SessionScopeDraft,
-  props: Partial<React.ComponentProps<typeof SessionScopeControlContent>> = {},
-) {
+const unavailable: SessionScopeSelectionCatalog = {
+  secrets: { status: 'unavailable' },
+  connector_connections: { status: 'unavailable' },
+};
+
+function renderSecrets(draft: SessionScopeDraft, scopeCatalog = catalog) {
   return renderToStaticMarkup(
-    <SessionScopeControlContent
-      draft={draft}
-      catalog={catalog}
-      onChange={() => {}}
-      onSave={() => {}}
-      {...props}
-    />,
+    <SessionSecretsEditor draft={draft} catalog={scopeCatalog} onChange={() => {}} />,
   );
 }
 
-describe('SessionScopeControlContent', () => {
-  test('uses a non-submit toolbar trigger inside the session composer', () => {
-    const html = renderToStaticMarkup(
-      <SessionScopeControl
-        draft={{ secrets: [], connector_bindings: {} }}
-        catalog={catalog}
-        onChange={() => {}}
-        onSave={() => {}}
-      />,
-    );
+function renderConnectors(draft: SessionScopeDraft, scopeCatalog = catalog) {
+  return renderToStaticMarkup(
+    <SessionConnectorsEditor draft={draft} catalog={scopeCatalog} onChange={() => {}} />,
+  );
+}
 
-    expect(html).toContain('aria-label="Configure session scope"');
-    expect(html).toContain('type="button"');
+describe('session scope editors', () => {
+  test('an inherited secrets axis keeps the project default checked', () => {
+    // `null` is the INHERITED state, so the box that says "use the project
+    // default" is the one that is on. Unchecking a secret is what converts the
+    // axis into an explicit allowlist — an override is never created by
+    // opening the panel.
+    const html = renderSecrets({ secrets: null });
+
+    expect(html).toContain('Use the project default');
+    expect(html).toContain('Calendar token');
+    expect(html).not.toContain('Reset to project default');
   });
 
-  test('renders compact collapsed summaries for the selected scope', () => {
-    const html = renderControl({
-      secrets: ['CALENDAR_TOKEN'],
-      connector_bindings: {
-        calendar: { connection_id: 'connection-calendar' },
-        crm: { connection_id: 'connection-crm' },
-      },
-    });
-
-    expect(html).toContain('Session access');
-    expect(html).toContain('Share only the secrets and connectors this session needs.');
-    expect(html).toContain('1 selected');
-    expect(html).toContain('2 selected');
-    expect(html.match(/aria-expanded="false"/g)).toHaveLength(2);
-    expect(html).not.toContain('aria-label="Authorization for Calendar"');
-    expect(html).not.toContain('aria-label="Authorization for CRM"');
-    expect(html).toContain('Changes apply to the next prompt.');
+  test('offers the way out of an override, and only when one exists', () => {
+    // An override that cannot be switched off is a trap: the session keeps a
+    // frozen selection while the project's defaults move on.
+    expect(renderSecrets({ secrets: ['CALENDAR_TOKEN'] })).toContain('Reset to project default');
+    expect(
+      renderConnectors({
+        connector_bindings: { calendar: { connection_id: 'connection-calendar' } },
+        connector_bindings_inherited: false,
+      }),
+    ).toContain('Reset to project default');
+    expect(
+      renderConnectors({
+        connector_bindings: { calendar: { connection_id: 'connection-calendar' } },
+        connector_bindings_inherited: true,
+      }),
+    ).not.toContain('Reset to project default');
   });
 
-  test('distinguishes an inherited default from an explicit empty allowlist', () => {
-    // "None selected" for an inheriting session was a lie in both directions:
-    // it under-reported what the session can read, and it invited a Save that
-    // wrote the zero-access override the label claimed already existed.
-    const inheritedHtml = renderControl({ secrets: null, connector_bindings: {} });
-    const noneHtml = renderControl({ secrets: [], connector_bindings: {} });
-
-    expect(inheritedHtml).toContain('Project default');
-    expect(inheritedHtml).not.toContain('None selected');
-    expect(noneHtml).toContain('None allowed');
-    expect(inheritedHtml).not.toContain('aria-checked="true"');
-    expect(noneHtml).not.toContain('aria-checked="true"');
-  });
-
-  test('reports inherited connector access as the project default', () => {
-    const html = renderControl({
-      secrets: null,
+  test('shows the connection picker only for a selected connector', () => {
+    const html = renderConnectors({
       connector_bindings: { calendar: { connection_id: 'connection-calendar' } },
-      connector_bindings_inherited: true,
+      connector_bindings_inherited: false,
     });
 
-    expect(html).not.toContain('None selected');
-    expect(html.match(/>Project default</g)).toHaveLength(2);
+    expect(html).toContain('aria-label="Connection for Calendar"');
+    expect(html).not.toContain('aria-label="Connection for CRM"');
   });
 
-  test('distinguishes an omitted secret axis from an explicit empty allowlist', () => {
-    const unchangedHtml = renderControl({ connector_bindings: {} });
-    const noneHtml = renderControl({ secrets: [], connector_bindings: {} });
-
-    expect(unchangedHtml).toContain('Unchanged');
-    expect(noneHtml).toContain('None allowed');
-  });
-
-  test('shows catalog failures without converting them into empty selections', () => {
-    const html = renderToStaticMarkup(
-      <SessionScopeControlContent
-        draft={{}}
-        catalog={{
-          secrets: { status: 'unavailable' },
-          connector_connections: { status: 'unavailable' },
-        }}
-        onChange={() => {}}
-        onSave={() => {}}
-      />,
+  test('names a connector that has nothing connected as a requirement', () => {
+    // A binding carries a connection id, so it cannot express "this session
+    // needs Calendar and nothing is connected". The requirement can, and the
+    // next turn stops at a connect prompt instead of failing mid-answer.
+    const disconnected: SessionScopeSelectionCatalog = {
+      ...catalog,
+      connector_connections: {
+        status: 'ready',
+        items: [
+          { slug: 'calendar', name: 'Calendar', authorization_strategy: 'user', connections: [] },
+        ],
+      },
+    };
+    const html = renderConnectors(
+      {
+        connector_bindings: {},
+        require_connectors: ['calendar'],
+        connector_bindings_inherited: false,
+      },
+      disconnected,
     );
 
-    expect(html.match(/>Unavailable</g)).toHaveLength(2);
-    expect(html).not.toContain('None allowed');
+    expect(html).toContain('Required — connect to continue');
+    expect(html).not.toContain('aria-label="Connection for Calendar"');
   });
 
-  test('shows saving state and the non-retroactive warning', () => {
-    const html = renderControl(
-      { secrets: [], connector_bindings: {} },
-      { saving: true, retroactive: false },
-    );
-
-    expect(html).toContain(
-      'Removed secret values can remain in the current conversation or existing shells.',
-    );
-    expect(html).toContain('animate-spinner-orbit');
-    expect(html).toContain('disabled=""');
-  });
-
-  test('disables only the save action when the current draft is unsafe to commit', () => {
-    const html = renderControl({ secrets: [], connector_bindings: {} }, { saveDisabled: true });
-
-    expect(html).toContain('type="button" disabled="">Save');
-    expect(html.match(/disabled=""/g)).toHaveLength(1);
+  test('reports catalog failures instead of rendering an empty selection', () => {
+    expect(renderSecrets({}, unavailable)).toContain('Secret access is unavailable');
+    expect(renderConnectors({}, unavailable)).toContain('Connector access is unavailable');
   });
 });
 

--- a/apps/web/src/features/session/scope/session-scope-control.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.tsx
@@ -3,10 +3,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { InfoBanner } from '@/components/ui/info-banner';
-import Loading from '@/components/ui/loading';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
   SelectContent,
@@ -14,41 +11,23 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  ArrowCounterClockwiseIcon as ArrowCounterClockwise,
-  CaretDownIcon as ChevronDown,
-  KeyIcon as KeyRound,
-  PlugIcon as PlugZap,
-  SlidersHorizontalIcon as SlidersHorizontal,
-  WarningIcon as TriangleAlert,
-} from '@phosphor-icons/react';
-import { useState } from 'react';
+import { ArrowCounterClockwiseIcon as ArrowCounterClockwise } from '@phosphor-icons/react';
 
 import {
   resetSessionConnectorBindings,
   resetSessionSecrets,
   sessionConnectorsAreOverridden,
-  sessionConnectorsSummary,
   sessionSecretsAreOverridden,
-  sessionSecretsSummary,
   type SessionScopeConnectorOption,
   type SessionScopeDraft,
   type SessionScopeSelectionCatalog,
 } from './session-scope-model';
 
-export interface SessionScopeControlContentProps {
+export interface SessionScopeEditorProps {
   draft: SessionScopeDraft;
   catalog: SessionScopeSelectionCatalog;
   disabled?: boolean;
-  saveDisabled?: boolean;
-  saving?: boolean;
-  retroactive?: boolean;
   onChange: (draft: SessionScopeDraft) => void;
-  onSave: () => void;
-}
-
-export interface SessionScopeControlProps extends SessionScopeControlContentProps {
-  triggerLabel?: string;
 }
 
 export function setAllSessionSecrets(
@@ -159,14 +138,20 @@ export function setSessionConnectorEnabled(
  * The way OUT of an override. An override you cannot switch off is a trap: the
  * session keeps a frozen selection while the project's own defaults move on.
  */
-function ResetAxisButton({ disabled, onReset }: { disabled: boolean; onReset: () => void }) {
+export function ResetAxisButton({
+  disabled = false,
+  onReset,
+}: {
+  disabled?: boolean;
+  onReset: () => void;
+}) {
   return (
     <Button
       type="button"
       variant="ghost"
       size="sm"
       disabled={disabled}
-      className="text-muted-foreground h-8 w-full justify-start px-3"
+      className="text-muted-foreground -ml-1 h-8"
       onClick={onReset}
     >
       <ArrowCounterClockwise className="size-3.5 shrink-0" />
@@ -175,327 +160,195 @@ function ResetAxisButton({ disabled, onReset }: { disabled: boolean; onReset: ()
   );
 }
 
-export function SessionScopeControlContent({
+/**
+ * The secrets checklist. `null` (every box checked) is the INHERITED state, not
+ * "all selected by hand" — unchecking one converts the axis into an explicit
+ * allowlist, which is the only way an override is ever created here.
+ */
+export function SessionSecretsEditor({
   draft,
   catalog,
   disabled = false,
-  saveDisabled = false,
-  saving = false,
-  retroactive,
   onChange,
-  onSave,
-}: SessionScopeControlContentProps) {
-  const controlsDisabled = disabled || saving;
-  const [openSection, setOpenSection] = useState<'secrets' | 'connectors' | null>(null);
+}: SessionScopeEditorProps) {
+  if (catalog.secrets.status === 'unavailable') {
+    return (
+      <InfoBanner tone="neutral" title="Secret access is unavailable">
+        The current secret selection stays unchanged.
+      </InfoBanner>
+    );
+  }
 
   return (
-    <div className="flex max-h-[min(500px,calc(100vh-2rem))] flex-col">
-      <div className="border-border border-b px-4 py-3.5">
-        <h3 className="text-foreground text-sm font-medium text-balance">Session access</h3>
-        <p className="text-muted-foreground mt-1 text-xs leading-relaxed text-pretty">
-          Share only the secrets and connectors this session needs.
+    <div className="space-y-1">
+      <Checkbox
+        checked={draft.secrets === null}
+        disabled={disabled}
+        className="min-h-10"
+        label="Use the project default"
+        onCheckedChange={(checked) => onChange(setAllSessionSecrets(draft, checked === true))}
+      />
+      {catalog.secrets.items.length > 0 ? (
+        <div className="border-border border-t pt-1">
+          {catalog.secrets.items.map((secret) => {
+            const checked =
+              draft.secrets === null || draft.secrets?.includes(secret.identifier) === true;
+            return (
+              <Checkbox
+                key={secret.identifier}
+                checked={checked}
+                disabled={disabled}
+                className="min-h-10"
+                label={
+                  <span className="flex min-w-0 flex-col gap-0.5">
+                    <span className="text-foreground truncate">{secret.name}</span>
+                    {secret.name !== secret.identifier ? (
+                      <code className="text-muted-foreground truncate text-xs">
+                        {secret.identifier}
+                      </code>
+                    ) : null}
+                  </span>
+                }
+                onCheckedChange={(nextChecked) =>
+                  onChange(toggleSessionSecret(draft, catalog, secret.identifier, nextChecked === true))
+                }
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-muted-foreground border-border border-t px-1 py-3 text-xs text-pretty">
+          No secrets are available for this agent.
         </p>
-      </div>
-
-      <div className="min-h-0 flex-1 space-y-2 overflow-y-auto px-3 py-3">
-        <Disclosure
-          open={openSection === 'secrets'}
-          onOpenChange={(open) => setOpenSection(open ? 'secrets' : null)}
-          variant="outline"
-          className="overflow-hidden"
-        >
-          <DisclosureTrigger variant="outline">
-            <Button
-              type="button"
-              variant="popover"
-              className="min-h-12 w-full justify-start rounded-none px-3 py-2 text-left"
-            >
-              <span className="bg-foreground/5 flex size-8 shrink-0 items-center justify-center rounded-sm">
-                <KeyRound className="text-muted-foreground size-4" />
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="text-foreground block truncate text-sm font-medium">Secrets</span>
-                <span className="text-muted-foreground mt-0.5 block truncate text-xs font-normal">
-                  Environment values
-                </span>
-              </span>
-              <Badge variant="secondary" size="xs" className="tabular-nums">
-                {catalog.secrets.status === 'ready' ? sessionSecretsSummary(draft) : 'Unavailable'}
-              </Badge>
-              <ChevronDown className="text-muted-foreground size-3.5 transition-transform group-data-[state=open]:rotate-180" />
-            </Button>
-          </DisclosureTrigger>
-          <DisclosureContent variant="outline" contentClassName="border-border border-t">
-            {catalog.secrets.status === 'unavailable' ? (
-              <div className="p-2">
-                <InfoBanner tone="neutral" title="Secret access is unavailable">
-                  The current secret selection stays unchanged.
-                </InfoBanner>
-              </div>
-            ) : (
-              <div className="p-1">
-                {sessionSecretsAreOverridden(draft) ? (
-                  <ResetAxisButton
-                    disabled={controlsDisabled}
-                    onReset={() => onChange(resetSessionSecrets(draft))}
-                  />
-                ) : null}
-                <Checkbox
-                  checked={draft.secrets === null}
-                  disabled={controlsDisabled}
-                  className="min-h-10"
-                  label="Use the project default"
-                  onCheckedChange={(checked) =>
-                    onChange(setAllSessionSecrets(draft, checked === true))
-                  }
-                />
-                {catalog.secrets.items.length > 0 ? (
-                  <div className="border-border mt-1 border-t pt-1">
-                    {catalog.secrets.items.map((secret) => {
-                      const checked =
-                        draft.secrets === null ||
-                        draft.secrets?.includes(secret.identifier) === true;
-                      return (
-                        <Checkbox
-                          key={secret.identifier}
-                          checked={checked}
-                          disabled={controlsDisabled}
-                          className="min-h-10"
-                          label={
-                            <span className="flex min-w-0 flex-col gap-0.5">
-                              <span className="text-foreground truncate">{secret.name}</span>
-                              {secret.name !== secret.identifier ? (
-                                <code className="text-muted-foreground truncate text-xs">
-                                  {secret.identifier}
-                                </code>
-                              ) : null}
-                            </span>
-                          }
-                          onCheckedChange={(nextChecked) =>
-                            onChange(
-                              toggleSessionSecret(
-                                draft,
-                                catalog,
-                                secret.identifier,
-                                nextChecked === true,
-                              ),
-                            )
-                          }
-                        />
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <p className="text-muted-foreground border-border mt-1 border-t px-3 py-3 text-xs text-pretty">
-                    No secrets are available for this agent.
-                  </p>
-                )}
-              </div>
-            )}
-          </DisclosureContent>
-        </Disclosure>
-
-        <Disclosure
-          open={openSection === 'connectors'}
-          onOpenChange={(open) => setOpenSection(open ? 'connectors' : null)}
-          variant="outline"
-          className="overflow-hidden"
-        >
-          <DisclosureTrigger variant="outline">
-            <Button
-              type="button"
-              variant="popover"
-              className="min-h-12 w-full justify-start rounded-none px-3 py-2 text-left"
-            >
-              <span className="bg-foreground/5 flex size-8 shrink-0 items-center justify-center rounded-sm">
-                <PlugZap className="text-muted-foreground size-4" />
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="text-foreground block truncate text-sm font-medium">
-                  Connectors
-                </span>
-                <span className="text-muted-foreground mt-0.5 block truncate text-xs font-normal">
-                  Authorized accounts
-                </span>
-              </span>
-              <Badge variant="secondary" size="xs" className="tabular-nums">
-                {catalog.connector_connections.status === 'ready'
-                  ? sessionConnectorsSummary(draft)
-                  : 'Unavailable'}
-              </Badge>
-              <ChevronDown className="text-muted-foreground size-3.5 transition-transform group-data-[state=open]:rotate-180" />
-            </Button>
-          </DisclosureTrigger>
-          <DisclosureContent variant="outline" contentClassName="border-border border-t">
-            {catalog.connector_connections.status === 'unavailable' ? (
-              <div className="p-2">
-                <InfoBanner tone="neutral" title="Connector access is unavailable">
-                  The current connector selection stays unchanged.
-                </InfoBanner>
-              </div>
-            ) : catalog.connector_connections.items.length === 0 ? (
-              <p className="text-muted-foreground px-3 py-3 text-xs text-pretty">
-                No connectors are available for this agent.
-              </p>
-            ) : (
-              <ul className="space-y-1 p-1">
-                {sessionConnectorsAreOverridden(draft) ? (
-                  <li>
-                    <ResetAxisButton
-                      disabled={controlsDisabled}
-                      onReset={() => onChange(resetSessionConnectorBindings(draft, catalog))}
-                    />
-                  </li>
-                ) : null}
-                {catalog.connector_connections.items.map((connector) => {
-                  const currentConnection =
-                    draft.connector_bindings?.[connector.slug]?.connection_id;
-                  const currentConnectionIsAvailable = connector.connections.some(
-                    (connection) => connection.connection_id === currentConnection,
-                  );
-                  const bound = currentConnection !== undefined;
-                  // Required but not connected: the session declares it and the
-                  // next turn will stop for a connect prompt.
-                  const requiredUnconnected =
-                    !bound && (draft.require_connectors?.includes(connector.slug) ?? false);
-                  const selected = bound || requiredUnconnected;
-                  const hasConnection = connector.connections.length > 0;
-
-                  return (
-                    <li key={connector.slug}>
-                      <Checkbox
-                        checked={selected}
-                        // Selectable with nothing connected. Greying it out meant
-                        // you could only require a connector that already worked,
-                        // which is precisely backwards — needing one you have not
-                        // connected yet is the case worth expressing.
-                        disabled={controlsDisabled}
-                        className="min-h-10"
-                        label={
-                          <span className="flex min-w-0 items-center gap-1.5">
-                            <span className="text-foreground truncate">{connector.name}</span>
-                            <Badge variant="outline" size="xs">
-                              {connector.authorization_strategy === 'user' ? 'Private' : 'Project'}
-                            </Badge>
-                            {!hasConnection ? (
-                              <span className="text-muted-foreground truncate text-xs font-normal">
-                                {requiredUnconnected
-                                  ? 'Required — connect to continue'
-                                  : 'Not connected'}
-                              </span>
-                            ) : null}
-                          </span>
-                        }
-                        onCheckedChange={(checked) =>
-                          onChange(setSessionConnectorEnabled(draft, connector, checked === true))
-                        }
-                      />
-                      {requiredUnconnected ? (
-                        // No connection exists, so there is nothing for the
-                        // Select to offer — rendering it would show an empty
-                        // dropdown that looks broken. Say what will happen instead.
-                        <p className="text-muted-foreground pr-2 pb-2 pl-10 text-xs text-pretty">
-                          Nothing is connected to {connector.name} yet. This session will ask you to
-                          connect it before its next reply.
-                        </p>
-                      ) : null}
-                      {selected && !requiredUnconnected ? (
-                        <div className="pr-2 pb-2 pl-10">
-                          <Select
-                            value={currentConnection}
-                            disabled={controlsDisabled}
-                            onValueChange={(connectionId) =>
-                              onChange(
-                                setSessionConnectorConnection(draft, connector.slug, connectionId),
-                              )
-                            }
-                          >
-                            <SelectTrigger
-                              size="md"
-                              variant="outline"
-                              className="w-full"
-                              aria-label={`Connection for ${connector.name}`}
-                            >
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent align="end">
-                              {currentConnection && !currentConnectionIsAvailable ? (
-                                <SelectItem value={currentConnection}>
-                                  Current connection
-                                </SelectItem>
-                              ) : null}
-                              {connector.connections.map((connection) => (
-                                <SelectItem
-                                  key={connection.connection_id}
-                                  value={connection.connection_id}
-                                >
-                                  {connection.label}
-                                  {connection.is_default ? ' · Default' : ''}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      ) : null}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </DisclosureContent>
-        </Disclosure>
-
-        {retroactive === false ? (
-          <InfoBanner tone="warning" icon={TriangleAlert} title="Existing context is unchanged">
-            Removed secret values can remain in the current conversation or existing shells.
-          </InfoBanner>
-        ) : null}
-      </div>
-
-      <div className="border-border flex items-center justify-between gap-3 border-t px-4 py-3">
-        <p className="text-muted-foreground text-xs leading-relaxed text-pretty">
-          Changes apply to the next prompt.
-        </p>
-        <Button
-          type="button"
-          className="h-10 px-4"
-          disabled={controlsDisabled || saveDisabled}
-          onClick={onSave}
-        >
-          {saving ? <Loading className="size-3.5 shrink-0" /> : null}
-          Save
-        </Button>
-      </div>
+      )}
+      {sessionSecretsAreOverridden(draft) ? (
+        <ResetAxisButton disabled={disabled} onReset={() => onChange(resetSessionSecrets(draft))} />
+      ) : null}
     </div>
   );
 }
 
-export function SessionScopeControl({
-  triggerLabel = 'Scope',
-  ...contentProps
-}: SessionScopeControlProps) {
+/**
+ * The connector checklist, plus a connection picker per selected connector.
+ * Untouched, it PREVIEWS what the project resolves today — see
+ * `connector_bindings_inherited`. Touching any row turns the preview into an
+ * explicit, fail-closed override.
+ */
+export function SessionConnectorsEditor({
+  draft,
+  catalog,
+  disabled = false,
+  onChange,
+}: SessionScopeEditorProps) {
+  if (catalog.connector_connections.status === 'unavailable') {
+    return (
+      <InfoBanner tone="neutral" title="Connector access is unavailable">
+        The current connector selection stays unchanged.
+      </InfoBanner>
+    );
+  }
+
+  if (catalog.connector_connections.items.length === 0) {
+    return (
+      <p className="text-muted-foreground px-1 py-3 text-xs text-pretty">
+        No connectors are available for this agent.
+      </p>
+    );
+  }
+
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="toolbar"
-          disabled={contentProps.disabled || contentProps.saving}
-          aria-label="Configure session scope"
-        >
-          <SlidersHorizontal className="size-3.5 shrink-0" />
-          {triggerLabel}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        side="top"
-        align="start"
-        sideOffset={8}
-        className="w-[352px] max-w-[calc(100vw-2rem)] overflow-hidden p-0 shadow-md"
-      >
-        <SessionScopeControlContent {...contentProps} />
-      </PopoverContent>
-    </Popover>
+    <div className="space-y-1">
+      <ul className="space-y-1">
+        {catalog.connector_connections.items.map((connector) => {
+          const currentConnection = draft.connector_bindings?.[connector.slug]?.connection_id;
+          const currentConnectionIsAvailable = connector.connections.some(
+            (connection) => connection.connection_id === currentConnection,
+          );
+          const bound = currentConnection !== undefined;
+          // Required but not connected: the session declares it and the
+          // next turn will stop for a connect prompt.
+          const requiredUnconnected =
+            !bound && (draft.require_connectors?.includes(connector.slug) ?? false);
+          const selected = bound || requiredUnconnected;
+          const hasConnection = connector.connections.length > 0;
+
+          return (
+            <li key={connector.slug}>
+              <Checkbox
+                checked={selected}
+                // Selectable with nothing connected. Greying it out meant
+                // you could only require a connector that already worked,
+                // which is precisely backwards — needing one you have not
+                // connected yet is the case worth expressing.
+                disabled={disabled}
+                className="min-h-10"
+                label={
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <span className="text-foreground truncate">{connector.name}</span>
+                    <Badge variant="outline" size="xs">
+                      {connector.authorization_strategy === 'user' ? 'Private' : 'Project'}
+                    </Badge>
+                    {!hasConnection ? (
+                      <span className="text-muted-foreground truncate text-xs font-normal">
+                        {requiredUnconnected ? 'Required — connect to continue' : 'Not connected'}
+                      </span>
+                    ) : null}
+                  </span>
+                }
+                onCheckedChange={(checked) =>
+                  onChange(setSessionConnectorEnabled(draft, connector, checked === true))
+                }
+              />
+              {requiredUnconnected ? (
+                // No connection exists, so there is nothing for the
+                // Select to offer — rendering it would show an empty
+                // dropdown that looks broken. Say what will happen instead.
+                <p className="text-muted-foreground pr-2 pb-2 pl-10 text-xs text-pretty">
+                  Nothing is connected to {connector.name} yet. This session will ask you to connect
+                  it before its next reply.
+                </p>
+              ) : null}
+              {selected && !requiredUnconnected ? (
+                <div className="pr-2 pb-2 pl-10">
+                  <Select
+                    value={currentConnection}
+                    disabled={disabled}
+                    onValueChange={(connectionId) =>
+                      onChange(setSessionConnectorConnection(draft, connector.slug, connectionId))
+                    }
+                  >
+                    <SelectTrigger
+                      size="md"
+                      variant="outline"
+                      className="w-full"
+                      aria-label={`Connection for ${connector.name}`}
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent align="end">
+                      {currentConnection && !currentConnectionIsAvailable ? (
+                        <SelectItem value={currentConnection}>Current connection</SelectItem>
+                      ) : null}
+                      {connector.connections.map((connection) => (
+                        <SelectItem key={connection.connection_id} value={connection.connection_id}>
+                          {connection.label}
+                          {connection.is_default ? ' · Default' : ''}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+      {sessionConnectorsAreOverridden(draft) ? (
+        <ResetAxisButton
+          disabled={disabled}
+          onReset={() => onChange(resetSessionConnectorBindings(draft, catalog))}
+        />
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/features/session/scope/session-scope-control.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import {
+  ArrowCounterClockwiseIcon as ArrowCounterClockwise,
   CaretDownIcon as ChevronDown,
   KeyIcon as KeyRound,
   PlugIcon as PlugZap,
@@ -23,10 +24,16 @@ import {
 } from '@phosphor-icons/react';
 import { useState } from 'react';
 
-import type {
-  SessionScopeConnectorOption,
-  SessionScopeDraft,
-  SessionScopeSelectionCatalog,
+import {
+  resetSessionConnectorBindings,
+  resetSessionSecrets,
+  sessionConnectorsAreOverridden,
+  sessionConnectorsSummary,
+  sessionSecretsAreOverridden,
+  sessionSecretsSummary,
+  type SessionScopeConnectorOption,
+  type SessionScopeDraft,
+  type SessionScopeSelectionCatalog,
 } from './session-scope-model';
 
 export interface SessionScopeControlContentProps {
@@ -148,17 +155,24 @@ export function setSessionConnectorEnabled(
       };
 }
 
-function secretSummary(draft: SessionScopeDraft): string {
-  if (draft.secrets === null) return 'All allowed';
-  if (draft.secrets === undefined) return 'Unchanged';
-  if (draft.secrets.length === 0) return 'None selected';
-  return `${draft.secrets.length} selected`;
-}
-
-function connectorSummary(draft: SessionScopeDraft): string {
-  if (draft.connector_bindings === undefined) return 'Unchanged';
-  const count = Object.keys(draft.connector_bindings).length;
-  return count === 0 ? 'None selected' : `${count} selected`;
+/**
+ * The way OUT of an override. An override you cannot switch off is a trap: the
+ * session keeps a frozen selection while the project's own defaults move on.
+ */
+function ResetAxisButton({ disabled, onReset }: { disabled: boolean; onReset: () => void }) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      disabled={disabled}
+      className="text-muted-foreground h-8 w-full justify-start px-3"
+      onClick={onReset}
+    >
+      <ArrowCounterClockwise className="size-3.5 shrink-0" />
+      Reset to project default
+    </Button>
+  );
 }
 
 export function SessionScopeControlContent({
@@ -206,7 +220,7 @@ export function SessionScopeControlContent({
                 </span>
               </span>
               <Badge variant="secondary" size="xs" className="tabular-nums">
-                {catalog.secrets.status === 'ready' ? secretSummary(draft) : 'Unavailable'}
+                {catalog.secrets.status === 'ready' ? sessionSecretsSummary(draft) : 'Unavailable'}
               </Badge>
               <ChevronDown className="text-muted-foreground size-3.5 transition-transform group-data-[state=open]:rotate-180" />
             </Button>
@@ -220,11 +234,17 @@ export function SessionScopeControlContent({
               </div>
             ) : (
               <div className="p-1">
+                {sessionSecretsAreOverridden(draft) ? (
+                  <ResetAxisButton
+                    disabled={controlsDisabled}
+                    onReset={() => onChange(resetSessionSecrets(draft))}
+                  />
+                ) : null}
                 <Checkbox
                   checked={draft.secrets === null}
                   disabled={controlsDisabled}
                   className="min-h-10"
-                  label="Allow every available secret"
+                  label="Use the project default"
                   onCheckedChange={(checked) =>
                     onChange(setAllSessionSecrets(draft, checked === true))
                   }
@@ -300,7 +320,7 @@ export function SessionScopeControlContent({
               </span>
               <Badge variant="secondary" size="xs" className="tabular-nums">
                 {catalog.connector_connections.status === 'ready'
-                  ? connectorSummary(draft)
+                  ? sessionConnectorsSummary(draft)
                   : 'Unavailable'}
               </Badge>
               <ChevronDown className="text-muted-foreground size-3.5 transition-transform group-data-[state=open]:rotate-180" />
@@ -319,6 +339,14 @@ export function SessionScopeControlContent({
               </p>
             ) : (
               <ul className="space-y-1 p-1">
+                {sessionConnectorsAreOverridden(draft) ? (
+                  <li>
+                    <ResetAxisButton
+                      disabled={controlsDisabled}
+                      onReset={() => onChange(resetSessionConnectorBindings(draft, catalog))}
+                    />
+                  </li>
+                ) : null}
                 {catalog.connector_connections.items.map((connector) => {
                   const currentConnection =
                     draft.connector_bindings?.[connector.slug]?.connection_id;

--- a/apps/web/src/features/session/scope/session-scope-control.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.tsx
@@ -14,10 +14,6 @@ import {
 import { ArrowCounterClockwiseIcon as ArrowCounterClockwise } from '@phosphor-icons/react';
 
 import {
-  resetSessionConnectorBindings,
-  resetSessionSecrets,
-  sessionConnectorsAreOverridden,
-  sessionSecretsAreOverridden,
   type SessionScopeConnectorOption,
   type SessionScopeDraft,
   type SessionScopeSelectionCatalog,
@@ -137,6 +133,9 @@ export function setSessionConnectorEnabled(
 /**
  * The way OUT of an override. An override you cannot switch off is a trap: the
  * session keeps a frozen selection while the project's own defaults move on.
+ *
+ * Rendered by the overrides panel BESIDE an axis editor, never inside it: an
+ * empty catalog must not be able to hide the only way back to the default.
  */
 export function ResetAxisButton({
   disabled = false,
@@ -221,9 +220,6 @@ export function SessionSecretsEditor({
           No secrets are available for this agent.
         </p>
       )}
-      {sessionSecretsAreOverridden(draft) ? (
-        <ResetAxisButton disabled={disabled} onReset={() => onChange(resetSessionSecrets(draft))} />
-      ) : null}
     </div>
   );
 }
@@ -343,12 +339,6 @@ export function SessionConnectorsEditor({
           );
         })}
       </ul>
-      {sessionConnectorsAreOverridden(draft) ? (
-        <ResetAxisButton
-          disabled={disabled}
-          onReset={() => onChange(resetSessionConnectorBindings(draft, catalog))}
-        />
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/session/scope/session-scope-model.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.test.ts
@@ -6,6 +6,10 @@ import {
   buildSessionScopeSelectionCatalog,
   createNewSessionScopeDraft,
   createSessionScopeDraft,
+  resetSessionConnectorBindings,
+  resetSessionSecrets,
+  sessionConnectorsSummary,
+  sessionSecretsSummary,
   type SessionScopeCatalogState,
 } from './session-scope-model';
 
@@ -20,6 +24,8 @@ const scope = (overrides: Partial<SessionScope> = {}): SessionScope => ({
   added_secrets: [],
   dropped_bindings: [],
   retroactive: true,
+  connector_bindings_configured: false,
+  connector_bindings_inherit_unbound: true,
   detail: 'Current session scope.',
   ...overrides,
 });
@@ -122,6 +128,104 @@ describe('createSessionScopeDraft', () => {
         'mail-read': { connection_id: 'connection-mail-1' },
         issues: { connection_id: 'connection-issues-1' },
       },
+      connector_bindings_inherited: true,
+      require_connectors: [],
+    });
+  });
+
+  test('marks connectors inherited when the session holds no override', () => {
+    // The scope read-back returns SERVER-RESOLVED bindings, which look the same
+    // for an inherited session and an overridden one. Without this marker the
+    // draft treated the preview as a user selection and posted it back, so an
+    // untouched Save wrote an override nobody asked for.
+    expect(
+      createSessionScopeDraft(scope({ connector_bindings_configured: false }))
+        .connector_bindings_inherited,
+    ).toBe(true);
+  });
+
+  test('leaves a configured override as an explicit selection', () => {
+    expect(
+      createSessionScopeDraft(scope({ connector_bindings_configured: true }))
+        .connector_bindings_inherited,
+    ).toBe(false);
+  });
+});
+
+describe('session scope summaries', () => {
+  test('names an inherited axis the project default, never "none"', () => {
+    expect(sessionSecretsSummary({ secrets: null })).toBe('Project default');
+    expect(
+      sessionConnectorsSummary({
+        connector_bindings: { mail: { connection_id: 'connection-mail-1' } },
+        connector_bindings_inherited: true,
+      }),
+    ).toBe('Project default');
+  });
+
+  test('names an explicit empty override honestly', () => {
+    // Opposite of the line above: the user deliberately deselected everything.
+    expect(sessionSecretsSummary({ secrets: [] })).toBe('None allowed');
+    expect(
+      sessionConnectorsSummary({ connector_bindings: {}, connector_bindings_inherited: false }),
+    ).toBe('None allowed');
+  });
+
+  test('counts explicit selections, including a required unconnected alias', () => {
+    expect(sessionSecretsSummary({ secrets: ['MAIL_TOKEN', 'ISSUE_TOKEN'] })).toBe('2 selected');
+    expect(
+      sessionConnectorsSummary({
+        connector_bindings: { mail: { connection_id: 'connection-mail-1' } },
+        connector_bindings_inherited: false,
+        require_connectors: ['issues'],
+      }),
+    ).toBe('2 selected');
+  });
+});
+
+describe('resetting an axis to the project default', () => {
+  const catalog = () =>
+    buildSessionScopeSelectionCatalog({
+      secrets: ready([secret('MAIL_TOKEN')]),
+      connectors: ready([connector('mail-read', 'project')]),
+      connections: ready([
+        connection('connection-mail-default', 'mail-read', 'project', { is_default: true }),
+      ]),
+      grants: { secrets: 'all', connectors: 'all' },
+    });
+
+  test('secrets go back to inheriting the agent grant', () => {
+    expect(resetSessionSecrets({ secrets: ['MAIL_TOKEN'] })).toEqual({ secrets: null });
+  });
+
+  test('connectors go back to inherited, previewing the project defaults', () => {
+    expect(
+      resetSessionConnectorBindings(
+        {
+          connector_bindings: { 'mail-read': { connection_id: 'hand-picked' } },
+          connector_bindings_inherited: false,
+          require_connectors: ['issues'],
+        },
+        catalog(),
+      ),
+    ).toEqual({
+      connector_bindings: { 'mail-read': { connection_id: 'connection-mail-default' } },
+      connector_bindings_inherited: true,
+      require_connectors: [],
+    });
+  });
+
+  test('a reset on a configured session sends the null clear verb', () => {
+    // An override the user cannot switch off is a trap. `null` is the only
+    // request that removes one; omitting the key would leave it in place.
+    expect(
+      buildSessionScopeReplacement(
+        resetSessionConnectorBindings({ connector_bindings: {} }, catalog()),
+        scope({ connector_bindings_configured: true }),
+      ),
+    ).toEqual({
+      secrets: ['MAIL_TOKEN', 'ISSUE_TOKEN'],
+      connector_bindings: null,
       require_connectors: [],
     });
   });
@@ -281,6 +385,18 @@ describe('buildSessionScopeReplacement', () => {
       },
       require_connectors: [],
     });
+  });
+
+  test('an untouched save on an unconfigured session sends no connector key', () => {
+    // THE regression. An existing session that never overrode its connectors
+    // read back server-resolved bindings, and Save posted them as an explicit
+    // replacement — turning "inherit the project defaults" into a frozen
+    // override, and an empty resolve into an explicit zero-connector session.
+    const previous = scope({ connector_bindings_configured: false });
+
+    const replacement = buildSessionScopeReplacement(createSessionScopeDraft(previous), previous);
+
+    expect(Object.hasOwn(replacement, 'connector_bindings')).toBe(false);
   });
 
   test('omits an authoritative axis when its catalog is unavailable', () => {

--- a/apps/web/src/features/session/scope/session-scope-model.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.ts
@@ -128,9 +128,96 @@ export function createSessionScopeDraft(
   }
   if (!catalog || catalog.connector_connections.status === 'ready') {
     draft.connector_bindings = cloneBindings(scope.connector_bindings);
+    // `scope.connector_bindings` is the SERVER-RESOLVED map, which is identical
+    // for a session that overrode its connectors and one that just inherits the
+    // project defaults. `connector_bindings_configured` is the only thing that
+    // separates them. Without this marker the draft treated the preview as a
+    // user selection, so an untouched Save posted it back as a full
+    // replacement — freezing project defaults into an override, and turning an
+    // empty resolve into an explicit zero-connector session.
+    draft.connector_bindings_inherited = scope.connector_bindings_configured !== true;
     draft.require_connectors = [...(scope.required_connectors ?? [])];
   }
   return draft;
+}
+
+/**
+ * The connections a session inherits today: each granted connector's default
+ * (or only) connection. A PREVIEW of what the server resolves, never a
+ * selection — it is always paired with `connector_bindings_inherited`.
+ */
+function defaultConnectorBindingsPreview(
+  catalog: SessionScopeSelectionCatalog,
+): Record<string, { connection_id: string }> {
+  if (catalog.connector_connections.status !== 'ready') return {};
+  return Object.fromEntries(
+    catalog.connector_connections.items.flatMap((connector) => {
+      const connection =
+        connector.connections.find((candidate) => candidate.is_default) ?? connector.connections[0];
+      return connection ? [[connector.slug, { connection_id: connection.connection_id }]] : [];
+    }),
+  );
+}
+
+/**
+ * Drop a session's secret override. `null` is "inherit the agent's grant" —
+ * the state a session starts in — and is the opposite of `[]`.
+ */
+export function resetSessionSecrets(draft: SessionScopeDraft): SessionScopeDraft {
+  return { ...draft, secrets: null };
+}
+
+/**
+ * Drop a session's connector override and preview the project defaults again.
+ *
+ * The marker is what makes `buildSessionScopeReplacement` send
+ * `connector_bindings: null` — the API's clear verb — when the session actually
+ * holds an override. An override the user cannot switch off is a trap.
+ */
+export function resetSessionConnectorBindings(
+  draft: SessionScopeDraft,
+  catalog: SessionScopeSelectionCatalog,
+): SessionScopeDraft {
+  return {
+    ...draft,
+    connector_bindings: defaultConnectorBindingsPreview(catalog),
+    connector_bindings_inherited: true,
+    // A requirement is an override too: it stops the next turn until the alias
+    // is connected. Resetting the axis clears it with the bindings.
+    require_connectors: [],
+  };
+}
+
+/** How an axis reads in the UI. "Project default" is the norm, never "none". */
+export const SESSION_SCOPE_INHERITED_LABEL = 'Project default';
+
+export function sessionSecretsSummary(draft: SessionScopeDraft): string {
+  if (draft.secrets === undefined) return 'Unchanged';
+  // `null` = inherit whatever the agent's grant allows. Calling this "All
+  // allowed" overstated it, and calling it "None selected" inverted it.
+  if (draft.secrets === null) return SESSION_SCOPE_INHERITED_LABEL;
+  if (draft.secrets.length === 0) return 'None allowed';
+  return `${draft.secrets.length} selected`;
+}
+
+export function sessionConnectorsSummary(draft: SessionScopeDraft): string {
+  if (draft.connector_bindings === undefined) return 'Unchanged';
+  if (draft.connector_bindings_inherited === true) return SESSION_SCOPE_INHERITED_LABEL;
+  const bound = Object.keys(draft.connector_bindings);
+  // A required-but-unconnected alias is selected too — it has no connection to
+  // bind, which is precisely why it is recorded separately.
+  const required = (draft.require_connectors ?? []).filter((alias) => !bound.includes(alias));
+  const count = bound.length + required.length;
+  return count === 0 ? 'None allowed' : `${count} selected`;
+}
+
+/** True when this axis holds an explicit override rather than inheriting. */
+export function sessionSecretsAreOverridden(draft: SessionScopeDraft): boolean {
+  return draft.secrets !== undefined && draft.secrets !== null;
+}
+
+export function sessionConnectorsAreOverridden(draft: SessionScopeDraft): boolean {
+  return draft.connector_bindings !== undefined && draft.connector_bindings_inherited !== true;
 }
 
 export function createNewSessionScopeDraft(
@@ -151,14 +238,7 @@ export function createNewSessionScopeDraft(
     // The inherited marker keeps an untouched session on server-side resolution,
     // which filters stale or disconnected rows. A user change clears the marker
     // and turns the draft into a complete fail-closed replacement.
-    draft.connector_bindings = Object.fromEntries(
-      catalog.connector_connections.items.flatMap((connector) => {
-        const connection =
-          connector.connections.find((candidate) => candidate.is_default) ??
-          connector.connections[0];
-        return connection ? [[connector.slug, { connection_id: connection.connection_id }]] : [];
-      }),
-    );
+    draft.connector_bindings = defaultConnectorBindingsPreview(catalog);
     draft.connector_bindings_inherited = true;
     draft.require_connectors = [];
   }
@@ -183,12 +263,18 @@ export function buildSessionScopeReplacement(
   const connectorBindings = Object.hasOwn(draft, 'connector_bindings')
     ? draft.connector_bindings
     : previousScope?.connector_bindings;
-  if (
-    availability.connector_bindings &&
-    connectorBindings !== undefined &&
-    draft.connector_bindings_inherited !== true
-  ) {
-    replacement.connector_bindings = cloneBindings(connectorBindings);
+  if (availability.connector_bindings) {
+    if (draft.connector_bindings_inherited === true) {
+      // Inheriting. Send the API's clear verb ONLY when the session actually
+      // holds an override — that is the one case with something to undo. With
+      // nothing to undo the key stays out entirely, so an untouched Save cannot
+      // create the override it is trying to avoid.
+      if (previousScope?.connector_bindings_configured === true) {
+        replacement.connector_bindings = null;
+      }
+    } else if (connectorBindings !== undefined) {
+      replacement.connector_bindings = cloneBindings(connectorBindings);
+    }
   }
   const required = Object.hasOwn(draft, 'require_connectors')
     ? draft.require_connectors

--- a/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-toolbar.test.ts
@@ -1,7 +1,11 @@
 import type { SessionScope, SessionScopeInput } from '@kortix/sdk';
 import { describe, expect, test } from 'bun:test';
 
-import type { SessionScopeSelectionCatalog } from './session-scope-model';
+import {
+  createSessionScopeDraft,
+  resetSessionConnectorBindings,
+  type SessionScopeSelectionCatalog,
+} from './session-scope-model';
 import {
   commitSessionScopeDraft,
   createNewSessionScopeInitialization,
@@ -18,6 +22,8 @@ const scope = (overrides: Partial<SessionScope> = {}): SessionScope => ({
   added_secrets: [],
   dropped_bindings: [],
   retroactive: true,
+  connector_bindings_configured: false,
+  connector_bindings_inherit_unbound: true,
   detail: 'Current session scope.',
   ...overrides,
 });
@@ -131,9 +137,14 @@ describe('createNewSessionScopeInitialization', () => {
 
 describe('commitSessionScopeDraft', () => {
   test('saves a complete active-session replacement from authoritative read-back', async () => {
+    // The session already HOLDS a connector override, so its bindings are a
+    // user selection and the save must resend them in full — a partial map
+    // would silently drop whatever it left out.
     let replacement: SessionScopeInput | undefined;
+    const previous = scope({ connector_bindings_configured: true });
     const response = scope({
       secrets_allowlist: ['ISSUE_TOKEN'],
+      connector_bindings_configured: true,
       retroactive: false,
     });
 
@@ -141,7 +152,7 @@ describe('commitSessionScopeDraft', () => {
       sessionId: 'session-1',
       draft: { secrets: ['ISSUE_TOKEN'] },
       catalog: catalog(),
-      previousScope: scope(),
+      previousScope: previous,
       replaceScope: async (input) => {
         replacement = input;
         return response;
@@ -156,6 +167,51 @@ describe('commitSessionScopeDraft', () => {
       require_connectors: [],
     });
     expect(result?.retroactive).toBeFalse();
+  });
+
+  test('an untouched save on an inheriting session writes no connector override', async () => {
+    // The bug this replaced: opening the panel on an existing session and
+    // pressing Save posted the server-resolved bindings back as an explicit
+    // override, so `connector_bindings_configured` flipped to true and every
+    // unbound alias started failing closed — with nothing in the UI asking for
+    // it.
+    let replacement: SessionScopeInput | undefined;
+    const previous = scope({ connector_bindings_configured: false });
+
+    await commitSessionScopeDraft({
+      sessionId: 'session-1',
+      draft: createSessionScopeDraft(previous, catalog()),
+      catalog: catalog(),
+      previousScope: previous,
+      replaceScope: async (input) => {
+        replacement = input;
+        return previous;
+      },
+    });
+
+    expect(replacement).toBeDefined();
+    expect(Object.hasOwn(replacement as SessionScopeInput, 'connector_bindings')).toBe(false);
+  });
+
+  test('a reset on an overridden session sends the null clear verb', async () => {
+    let replacement: SessionScopeInput | undefined;
+    const previous = scope({ connector_bindings_configured: true });
+
+    await commitSessionScopeDraft({
+      sessionId: 'session-1',
+      draft: resetSessionConnectorBindings(
+        createSessionScopeDraft(previous, catalog()),
+        catalog(),
+      ),
+      catalog: catalog(),
+      previousScope: previous,
+      replaceScope: async (input) => {
+        replacement = input;
+        return scope({ connector_bindings_configured: false });
+      },
+    });
+
+    expect(replacement?.connector_bindings).toBeNull();
   });
 
   test('omits an unavailable catalog axis from active-session replacement', async () => {

--- a/apps/web/src/features/session/scope/session-scope-toolbar.tsx
+++ b/apps/web/src/features/session/scope/session-scope-toolbar.tsx
@@ -1,32 +1,20 @@
 'use client';
 
-import { errorToast, successToast } from '@/components/ui/toast';
+/**
+ * The session-scope draft state machine: what a save actually sends, and what a
+ * pre-create session commits for its first prompt. The composer surface that
+ * renders it lives in `features/session/overrides`.
+ */
 import type { SessionScope, SessionScopeInput } from '@kortix/sdk';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { SessionScopeControl } from './session-scope-control';
 import {
   buildSessionScopeReplacement,
   createNewSessionScopeDraft,
-  createSessionScopeDraft,
   type SessionScopeAvailability,
   type SessionScopeCommit,
   type SessionScopeDraft,
   type SessionScopeSelectionCatalog,
 } from './session-scope-model';
-import { useSessionScope } from './use-session-scope';
-
-const unavailableCatalog: SessionScopeSelectionCatalog = {
-  secrets: { status: 'unavailable' },
-  connector_connections: { status: 'unavailable' },
-};
-
-export interface SessionScopeToolbarProps {
-  projectId: string;
-  sessionId?: string;
-  agentName?: string;
-  onCommittedDraft?: (commit: SessionScopeCommit | undefined) => void;
-}
 
 interface CommitSessionScopeDraftInput {
   sessionId?: string;
@@ -135,124 +123,4 @@ export async function commitSessionScopeDraft({
     throw new Error('The current session scope is required before replacement.');
   }
   return replaceScope(replacement);
-}
-
-function activeScopeSignature(scope: SessionScope | undefined): string {
-  if (!scope) return 'pending';
-  return JSON.stringify({
-    secrets_allowlist: scope.secrets_allowlist,
-    connector_bindings: scope.connector_bindings,
-    retroactive: scope.retroactive,
-  });
-}
-
-function newScopeCatalogSignature(catalog: SessionScopeSelectionCatalog): string {
-  return JSON.stringify(catalog);
-}
-
-export function SessionScopeToolbar({
-  projectId,
-  sessionId,
-  agentName,
-  onCommittedDraft,
-}: SessionScopeToolbarProps) {
-  const { scope, catalog, saveScope, isLoading, isScopeLoading } = useSessionScope({
-    projectId,
-    sessionId,
-    agentName,
-  });
-  const committedDraftRef = useRef(onCommittedDraft);
-  committedDraftRef.current = onCommittedDraft;
-
-  const initializationKey = useMemo(() => {
-    if (!catalog) return null;
-    const identity = `${projectId}:${sessionId ?? 'new'}:${agentName ?? ''}`;
-    if (sessionId) {
-      if (!scope) return null;
-      return `${identity}:${catalog.secrets.status}:${catalog.connector_connections.status}:${activeScopeSignature(scope)}`;
-    }
-    return `${identity}:${newScopeCatalogSignature(catalog)}`;
-  }, [agentName, catalog, projectId, scope, sessionId]);
-
-  const [draftState, setDraftState] = useState<{
-    key: string | null;
-    draft: SessionScopeDraft;
-  }>({
-    key: null,
-    draft: {},
-  });
-  const [retroactive, setRetroactive] = useState<boolean | undefined>();
-
-  useEffect(() => {
-    if (!catalog || !initializationKey) return;
-    if (draftState.key === initializationKey) return;
-    const initialization =
-      sessionId && scope
-        ? {
-            draft: createSessionScopeDraft(scope, catalog),
-            commit: undefined,
-          }
-        : createNewSessionScopeInitialization(catalog);
-    setDraftState({
-      key: initializationKey,
-      draft: initialization.draft,
-    });
-    setRetroactive(sessionId ? scope?.retroactive : undefined);
-    if (!sessionId) committedDraftRef.current?.(initialization.commit);
-  }, [catalog, draftState.key, initializationKey, scope, sessionId]);
-
-  const activeCatalog = catalog ?? unavailableCatalog;
-  const availability = getSessionScopeAvailability(activeCatalog);
-  const initialized = draftState.key === initializationKey && initializationKey !== null;
-  const saveDisabled =
-    !initialized ||
-    !hasAvailableScopeAxis(availability) ||
-    (Boolean(sessionId) && (!scope || isScopeLoading));
-
-  const handleSave = useCallback(async () => {
-    if (!catalog || !initialized) return;
-    try {
-      const result = await commitSessionScopeDraft({
-        sessionId,
-        draft: draftState.draft,
-        catalog,
-        previousScope: scope,
-        replaceScope: saveScope.mutateAsync,
-        onCommittedDraft: committedDraftRef.current,
-      });
-      if (sessionId && result) {
-        setRetroactive(result.retroactive);
-        setDraftState({
-          key: initializationKey,
-          draft: createSessionScopeDraft(result, catalog),
-        });
-        successToast('Session scope saved');
-      } else if (!sessionId) {
-        successToast('Session scope configured');
-      }
-    } catch (error) {
-      errorToast(error instanceof Error ? error.message : 'Session scope could not be saved');
-    }
-  }, [
-    catalog,
-    draftState.draft,
-    initializationKey,
-    initialized,
-    saveScope.mutateAsync,
-    scope,
-    sessionId,
-  ]);
-
-  return (
-    <SessionScopeControl
-      draft={draftState.draft}
-      catalog={activeCatalog}
-      disabled={isLoading || (Boolean(sessionId) && !scope)}
-      saveDisabled={saveDisabled}
-      saving={saveScope.isPending}
-      retroactive={retroactive}
-      onChange={(draft) => setDraftState((current) => ({ ...current, draft }))}
-      onSave={handleSave}
-    />
-  );
 }

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -3607,6 +3607,7 @@ export function SessionChat({
           selectedModel={local.model.currentKey ?? null}
           onModelChange={handleModelChange}
           providers={providers}
+          defaultModel={local.model.defaults.resolveDefaultFor(sessionScopeAgentName)}
         />
       ) : undefined,
     [
@@ -3614,6 +3615,7 @@ export function SessionChat({
       handleModelChange,
       local.agent.list,
       local.model.currentKey,
+      local.model.defaults,
       local.model.list,
       lockedAgentName,
       projectConfig?.open_code_default_agent,

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -49,7 +49,7 @@ import {
   QuestionPrompt,
   type QuestionPromptHandle,
 } from '@/features/session/question-prompt';
-import { SessionScopeToolbar } from '@/features/session/scope/session-scope-toolbar';
+import { SessionOverridesComposer } from '@/features/session/overrides/session-overrides-composer';
 import { SessionActionPanelColumn } from '@/features/session/session-action-panel-column';
 import {
   type AttachedFile,
@@ -3594,13 +3594,35 @@ export function SessionChat({
   const chatToolbarSlot = useMemo(
     () =>
       projectId && projectSessionId ? (
-        <SessionScopeToolbar
+        <SessionOverridesComposer
           projectId={projectId}
           sessionId={projectSessionId}
-          agentName={sessionScopeAgentName}
+          agents={local.agent.list}
+          selectedAgent={sessionScopeAgentName ?? null}
+          onAgentChange={lockedAgentName ? undefined : handleAgentChange}
+          agentLocked={!!lockedAgentName}
+          defaultAgentName={projectConfig?.open_code_default_agent}
+          models={local.model.list}
+          modelsLoading={providersLoading}
+          selectedModel={local.model.currentKey ?? null}
+          onModelChange={handleModelChange}
+          providers={providers}
         />
       ) : undefined,
-    [projectId, projectSessionId, sessionScopeAgentName],
+    [
+      handleAgentChange,
+      handleModelChange,
+      local.agent.list,
+      local.model.currentKey,
+      local.model.list,
+      lockedAgentName,
+      projectConfig?.open_code_default_agent,
+      projectId,
+      projectSessionId,
+      providers,
+      providersLoading,
+      sessionScopeAgentName,
+    ],
   );
 
   const chatInputSlot = useMemo(

--- a/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
@@ -107,6 +107,8 @@ describe('authoritative session scope', () => {
     secrets_allowlist: ['PRIMARY_TOKEN'],
     required_connectors: null,
     connector_bindings: { gmail: { connection_id: 'auth-primary' } },
+    connector_bindings_configured: true,
+    connector_bindings_inherit_unbound: true,
     dropped_secrets: [],
     added_secrets: [],
     dropped_bindings: [],

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -862,6 +862,17 @@ describe('session scope contracts', () => {
     expect(SessionScopeInputSchema.safeParse({ secret_values: [] }).success).toBe(false);
   });
 
+  test('accepts a null connector_bindings clear', () => {
+    // `null` is the REVERT verb: drop the stored override and go back to the
+    // project defaults. `{}` is its opposite — an explicit "zero connectors".
+    expect(SessionScopeInputSchema.parse({ connector_bindings: null })).toEqual({
+      connector_bindings: null,
+    });
+    expect(SessionScopeInputSchema.parse({ connector_bindings: {} })).toEqual({
+      connector_bindings: {},
+    });
+  });
+
   test('emits only connection_id in authoritative scope output', () => {
     const value = {
       secrets_allowlist: ['GMAIL_TOKEN'],
@@ -873,6 +884,11 @@ describe('session scope contracts', () => {
       added_secrets: ['GMAIL_TOKEN'],
       dropped_bindings: [],
       retroactive: true,
+      // Whether the session HOLDS a connector override at all. Without it a
+      // client cannot tell an inherited project default from a saved
+      // zero-connector override, and every save writes one by accident.
+      connector_bindings_configured: true,
+      connector_bindings_inherit_unbound: false,
       detail: 'Applies from the next prompt.',
     };
     expect(SessionScopeSchema.parse(value)).toEqual(value);
@@ -896,6 +912,8 @@ describe('session scope contracts', () => {
       added_secrets: ['STRIPE_KEY'],
       dropped_bindings: [],
       retroactive: true,
+      connector_bindings_configured: false,
+      connector_bindings_inherit_unbound: true,
       applied_live: true,
       detail: 'Applied to the running sandbox now — the OpenCode process and new shells see the new scope.',
     };
@@ -916,6 +934,8 @@ describe('session scope contracts', () => {
       added_secrets: ['STRIPE_KEY'],
       dropped_bindings: [],
       retroactive: true,
+      connector_bindings_configured: false,
+      connector_bindings_inherit_unbound: true,
       applied_live: false,
       push_failed: true as const,
       push_reason: 'daemon unreachable',
@@ -935,6 +955,8 @@ describe('session scope contracts', () => {
       added_secrets: [],
       dropped_bindings: [],
       retroactive: true,
+      connector_bindings_configured: false,
+      connector_bindings_inherit_unbound: true,
       applied_live: false,
       detail: 'No change to the secrets scope.',
       surprise: true,

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -325,7 +325,18 @@ export type SessionRequiredConnectors = z.infer<typeof SessionRequiredConnectors
 export const SessionScopeInputSchema = z
   .object({
     secrets: SessionSecretsAllowlistSchema.nullable().optional(),
-    connector_bindings: SessionConnectorBindingsInputSchema.optional(),
+    /**
+     * FULL new binding map — REPLACES the previous one. Three distinct states,
+     * and conflating any two of them is a bug:
+     *
+     * - **omitted** — leave the session's connector scope exactly as it is.
+     * - **`null`** — CLEAR the override. The session goes back to inheriting the
+     *   project default for every alias its agent grants. This is the only way
+     *   to undo an override; without it an override was permanent.
+     * - **`{}`** — an EXPLICIT zero-connector override: this session gets no
+     *   connector at all, project defaults included. The opposite of `null`.
+     */
+    connector_bindings: SessionConnectorBindingsInputSchema.nullable().optional(),
     require_connectors: SessionRequiredConnectorsSchema.nullable().optional(),
   })
   .strict()
@@ -347,6 +358,26 @@ export const SessionScopeSchema = z
     added_secrets: z.array(z.string()),
     dropped_bindings: z.array(z.string()),
     retroactive: z.boolean(),
+    /**
+     * Whether this session HOLDS its own connector override.
+     *
+     * `connector_bindings` above is the server-RESOLVED effective map, so it
+     * looks identical whether the session overrode its connectors or simply
+     * inherited the project defaults. A client could not tell the two apart, so
+     * it rendered an inherited session as "None selected" and wrote an explicit
+     * zero-connector override on the next untouched save. This flag is the
+     * difference: `false` means every alias still resolves to the project
+     * default; `true` means the stored bindings are authoritative.
+     *
+     * Send `connector_bindings: null` to put it back to `false`.
+     */
+    connector_bindings_configured: z.boolean(),
+    /**
+     * Whether an alias with NO stored binding still falls back to the project
+     * default while an override is configured. Create-time only, and false for
+     * a session that supplied bindings at create — those fail closed.
+     */
+    connector_bindings_inherit_unbound: z.boolean(),
     /**
      * True when the new secrets scope was pushed to the live sandbox and
      * OpenCode was restarted to pick it up — the change is in effect NOW.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,42 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-10 — session `session-overrides-ux` claim
+
+No **Now** task claimed. This is user-directed session-scope correctness work.
+
+Claimed SDK scope:
+
+- `SessionScope` gains `connector_bindings_configured` and
+  `connector_bindings_inherit_unbound`. Both are always emitted by the API.
+- `SessionScopeInput.connector_bindings` widens to accept `null`, the verb that
+  CLEARS a connector override.
+- Additive only. No published name changes. The `version` field is untouched.
+
+The `tdd` skill is unavailable in this session. The required RED → GREEN →
+REFACTOR sequence was followed directly.
+
+RED — `pnpm --filter @kortix/sdk typecheck`:
+
+```
+src/core/rest/projects-client/sessions.test.ts(577,17): error TS2339: Property 'connector_bindings_configured' does not exist on type 'SessionScope'.
+src/core/rest/projects-client/sessions.test.ts(578,17): error TS2339: Property 'connector_bindings_inherit_unbound' does not exist on type 'SessionScope'.
+src/core/rest/projects-client/sessions.test.ts(597,61): error TS2322: Type 'null' is not assignable to type 'SessionConnectorBindingsInput | undefined'.
+src/core/rest/projects-client/sessions.test.ts(602,17): error TS2339: Property 'connector_bindings_configured' does not exist on type 'SessionScope'.
+```
+
+GREEN:
+
+- `pnpm --filter @kortix/sdk typecheck`: exit `0` for the package and examples.
+- `pnpm --filter @kortix/sdk test`: `1847 pass`, `2 skip`, `0 fail`, 141 files.
+- `pnpm --filter @kortix/sdk smoke:install`: packed-install import + construction passed.
+- Public-surface snapshot unchanged — the change adds fields to existing types,
+  not new export names.
+
+**Status:** COMPLETE.
+
+**SDK package shippable to production: YES.**
+
 ### 2026-08-10 — session `reload-live-status` claim
 
 No **Now** task claimed. This is the user-directed live session-config reload status work.

--- a/packages/sdk/src/core/rest/projects-client/sessions.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.test.ts
@@ -562,6 +562,8 @@ test('getProjectSessionScope reads canonical session scope', async () => {
     added_secrets: [],
     dropped_bindings: [],
     retroactive: true,
+    connector_bindings_configured: false,
+    connector_bindings_inherit_unbound: true,
     detail: 'Current session scope.',
   };
   nextResponse = { status: 200, body: scope };
@@ -569,6 +571,35 @@ test('getProjectSessionScope reads canonical session scope', async () => {
   expect(last().url).toBe('http://test.local/projects/P1/sessions/S1/scope');
   expect(last().method).toBe('GET');
   expect(result.connector_bindings.gmail).toEqual({ connection_id: 'AUTH-1' });
+  // `connector_bindings` is the RESOLVED map, identical for an inherited and an
+  // overridden session. This flag is the only thing that separates them, so a
+  // client can stop calling an inherited default "nothing selected".
+  expect(result.connector_bindings_configured).toBe(false);
+  expect(result.connector_bindings_inherit_unbound).toBe(true);
+});
+
+test('setProjectSessionScope clears a connector override with null', async () => {
+  nextResponse = {
+    status: 200,
+    body: {
+      secrets_allowlist: null,
+      required_connectors: null,
+      connector_bindings: { gmail: { connection_id: 'AUTH-DEFAULT' } },
+      dropped_secrets: [],
+      added_secrets: [],
+      dropped_bindings: [],
+      retroactive: true,
+      connector_bindings_configured: false,
+      connector_bindings_inherit_unbound: false,
+      detail: 'Connector access is back to the project defaults.',
+    },
+  };
+  const result = await setProjectSessionScope('P1', 'S1', { connector_bindings: null });
+  expect(last().method).toBe('PUT');
+  // `null` is the REVERT verb. `{}` is its opposite — an explicit "no
+  // connectors at all" — so the two must reach the wire unchanged.
+  expect(last().body).toEqual({ connector_bindings: null });
+  expect(result.connector_bindings_configured).toBe(false);
 });
 
 test('setProjectSessionScope replaces connections with canonical input', async () => {

--- a/packages/sdk/src/core/rest/projects-client/sessions.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.ts
@@ -797,8 +797,17 @@ export interface SessionScopeInput {
    * secrets untouched.
    */
   secrets?: string[] | null;
-  /** FULL new binding map — REPLACES the previous one. Omit to leave untouched. */
-  connector_bindings?: SessionConnectorBindingsInput;
+  /**
+   * FULL new binding map — REPLACES the previous one. Three distinct states:
+   *
+   * - **omitted** — leave the session's connector scope untouched.
+   * - **`null`** — CLEAR the override. Every alias the agent grants goes back to
+   *   resolving the project default. This is the only way to undo an override.
+   * - **`{}`** — an EXPLICIT zero-connector override: no connector at all, not
+   *   even a project default. The opposite of `null`, so never send one for the
+   *   other.
+   */
+  connector_bindings?: SessionConnectorBindingsInput | null;
   /**
    * FULL new list of connector aliases this session REQUIRES — REPLACES the
    * previous one. Omit to leave untouched.
@@ -818,6 +827,22 @@ export interface SessionScope {
   /** Aliases this session requires, connected or not. See `require_connectors`. */
   required_connectors: string[] | null;
   connector_bindings: SessionConnectorBindings;
+  /**
+   * Whether this session HOLDS its own connector override.
+   *
+   * `connector_bindings` is the server-RESOLVED map, so it looks the same for a
+   * session that overrode its connectors and one that simply inherits the
+   * project defaults. Read this to tell them apart: `false` means every alias
+   * still resolves to the project default, and the UI must say "project
+   * default" rather than "none selected". Send `connector_bindings: null` to
+   * return a session to `false`.
+   */
+  connector_bindings_configured: boolean;
+  /**
+   * Whether an alias with no stored binding still falls back to the project
+   * default while an override is configured. Create-time only.
+   */
+  connector_bindings_inherit_unbound: boolean;
   dropped_secrets: string[];
   added_secrets: string[];
   dropped_bindings: string[];


### PR DESCRIPTION
## Problem

The composer's "Scope" popover shows "None selected" for connectors when NO override exists, and an untouched Save silently writes one. PR #6133 fixed this null-vs-[] pattern for secrets and PR #6288 for the connector axis on the *pre-create* path — but the *existing-session* path (every real popover open) was never patched:

- `createSessionScopeDraft` never set `connector_bindings_inherited`, so every Save included `connector_bindings` in the PUT.
- The PUT handler sets `connectorBindingsConfigured = true` whenever the key is present — including `{}` — permanently converting "inherit project defaults, resolved live" into "explicitly configured to zero". Once set, unbound aliases fail closed.
- `GET /scope` never exposed the configured flag, so the client could not distinguish "inherited default" from "saved override", and there was no way to undo an override — the API had no clear verb.

## Fix

**Correctness**

- API: `GET`/`PUT /projects/:pid/sessions/:sid/scope` now emit `connector_bindings_configured` + `connector_bindings_inherit_unbound`. `SessionScopeInput.connector_bindings` accepts `null` = clear the override (drops stored rows, `configured=false`); `{}` keeps its explicit "no connectors" meaning. Clearing skips grant/binding validation deliberately — removing bindings cannot widen access past the project default.
- SDK: additive fields on `SessionScope`, widened input type, per packages/sdk rules (no renamed exports, version untouched, PROGRESS.md entry).
- Web: `createSessionScopeDraft` sets `connector_bindings_inherited = !scope.connector_bindings_configured`; `buildSessionScopeReplacement` omits the key when inherited. An untouched Save now sends no `connector_bindings` at all. Labels: inherited axis reads **"Project default"**; explicit empty reads **"None allowed"** with an Override badge. Per-axis **"Reset to project default"** sends the null clear verb.
- Existing `configured=true` rows are deliberately not mass-repaired (some are intentional); the reset verb is the user-facing repair path.

**UX — unified session overrides popover** (`apps/web/src/features/session/overrides/`)

One two-pane popover (axis list left, focused editor right) replaces the old Scope panel: Agent, Model, Reasoning effort (capability-gated), Secrets, Connectors, Sandbox (read-only, create-time). Every axis defaults to "Project default"; overrides are opt-in, badged, and resettable. Both composers build it through one shared module; agent/model/effort reuse the existing toolbar controls; secrets/connectors reuse the extracted checklist editors. Footer keeps the "Changes apply to the next prompt." truth + Save; Save is PUT-noop for untouched axes. Stacks below `sm`.

## Verification (local, worktree stack)

- Wire proof via real JWT + real session: GET shows `configured:false`; untouched-Save PUT carries no `connector_bindings` key and leaves it false; `PUT {"connector_bindings":{}}` → true; `PUT {"connector_bindings":null}` → false, "Connector access is back to the project defaults."
- Browser: untouched Save on an existing session asserted on the network request (no connector key); seeded `configured=true` renders "None allowed · Override"; Reset → null PUT → 200 → back to "Project default". Screenshots in `output/session-overrides/`.
- Suites: api-contract 69/0 · apps/api 6185/0 · SDK 1847 pass, typecheck + smoke:install clean · apps/web 5503/0 · web tsc clean vs known baseline · eslint touched files 0 errors.

## Not exercised in a browser

Connector checklist toggling (test project has zero connectors in grant — covered by unit + API integration tests); reasoning-effort row rendering (GLM 5.2 exposes no effort knob).
