### PR TITLE
fix(tests): bake Docker Compose into preview workers

### DIFF
--- a/tests/src/core/daytona-ci.ts
+++ b/tests/src/core/daytona-ci.ts
@@ -6,12 +6,13 @@ import {
   PLATINUM_CI_NODE_IMAGE,
   PLATINUM_CI_PNPM_VERSION,
   buildWorkerScript,
+  dockerComposeInstallCommand,
   observePlatinumWorker,
   providerMetadataIdentifier,
 } from './platinum-ci';
 
-export const DAYTONA_CI_SNAPSHOT_VERSION = 'v3';
-const DAYTONA_CI_BASE_SNAPSHOT_VERSION = 'v2';
+export const DAYTONA_CI_SNAPSHOT_VERSION = 'v4';
+const DAYTONA_CI_BASE_SNAPSHOT_VERSION = 'v3';
 
 const POLL_MS = 3_000;
 const SNAPSHOT_TIMEOUT_MS = 45 * 60_000;
@@ -125,6 +126,7 @@ export function buildDaytonaBaseDockerfile(input: {
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PLAYWRIGHT_BROWSERS_PATH=/root/.cache/ms-playwright
 RUN set -eux; apt-get update; apt-get install -y --no-install-recommends ca-certificates curl docker.io git iptables jq kmod postgresql-client procps ripgrep unzip xz-utils; rm -rf /var/lib/apt/lists/*
+RUN set -eux; ${dockerComposeInstallCommand()}
 RUN npm install --global bun@${PLATINUM_CI_BUN_VERSION} && corepack prepare pnpm@${PLATINUM_CI_PNPM_VERSION} --activate
 RUN set -eux; mkdir -p /workspace /root/.cache/ms-playwright; git init /workspace/suna; git -C /workspace/suna remote add origin https://github.com/${input.repository}.git; git -C /workspace/suna fetch --depth=1 origin ${input.cacheSha}; git -C /workspace/suna checkout --detach FETCH_HEAD; test "$(git -C /workspace/suna rev-parse HEAD)" = "${input.cacheSha}"
 RUN set -eux; cd /workspace/suna; corepack enable; pnpm install --frozen-lockfile; pnpm --dir tests exec playwright install --with-deps chromium; rm -rf /workspace/suna/tests/test-results

--- a/tests/src/core/platinum-ci.ts
+++ b/tests/src/core/platinum-ci.ts
@@ -2,12 +2,15 @@ import { createHash } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 
-export const PLATINUM_CI_TEMPLATE_VERSION = 'v13';
-const PLATINUM_CI_BASE_TEMPLATE_VERSION = 'v10';
+export const PLATINUM_CI_TEMPLATE_VERSION = 'v14';
+const PLATINUM_CI_BASE_TEMPLATE_VERSION = 'v11';
 export const PLATINUM_CI_NODE_IMAGE =
   'node:22.22.0-bookworm@sha256:2e3d655fd1e3ffaa6b5f23ee9f3905a0fd9e8c0a65df94c8ae6e4d18a0f48870';
 export const PLATINUM_CI_BUN_VERSION = '1.3.14';
 export const PLATINUM_CI_PNPM_VERSION = '8.11.0';
+export const CI_DOCKER_COMPOSE_VERSION = 'v2.40.3';
+export const CI_DOCKER_COMPOSE_AMD64_SHA256 =
+  'dba9d98e1ba5bfe11d88c99b9bd32fc4a0624a30fafe68eea34d61a3e42fd372';
 
 const POLL_MS = 3_000;
 const TEMPLATE_TIMEOUT_MS = 45 * 60_000;
@@ -215,6 +218,18 @@ export function platinumBaseTemplateName(lockHash: string): string {
   return `kortix-ci-${PLATINUM_CI_BASE_TEMPLATE_VERSION}-${lockHash.slice(0, 16)}-base`;
 }
 
+export function dockerComposeInstallCommand(): string {
+  const plugin = '/usr/local/lib/docker/cli-plugins/docker-compose';
+  const url = `https://github.com/docker/compose/releases/download/${CI_DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64`;
+  return [
+    'install -d /usr/local/lib/docker/cli-plugins',
+    `curl -fsSL ${url} -o ${plugin}`,
+    `echo '${CI_DOCKER_COMPOSE_AMD64_SHA256}  ${plugin}' | sha256sum -c -`,
+    `chmod 0755 ${plugin}`,
+    'docker compose version',
+  ].join(' && ');
+}
+
 function platinumWarmEntrypoint(): string {
   return [
     'set -eux',
@@ -278,6 +293,7 @@ export function buildPlatinumTemplateSpec(input: {
           'export DEBIAN_FRONTEND=noninteractive',
           'apt-get update',
           'apt-get install -y --no-install-recommends ca-certificates curl docker.io git jq procps ripgrep unzip xz-utils',
+          dockerComposeInstallCommand(),
           'rm -rf /var/lib/apt/lists/*',
           `npm install --global bun@${PLATINUM_CI_BUN_VERSION}`,
           `corepack prepare pnpm@${PLATINUM_CI_PNPM_VERSION} --activate`,

--- a/tests/unit/daytona-ci.test.ts
+++ b/tests/unit/daytona-ci.test.ts
@@ -38,9 +38,9 @@ describe('Daytona CI worker plan', () => {
   });
 
   test('uses one content-addressed warm snapshot for one lockfile', () => {
-    expect(DAYTONA_CI_SNAPSHOT_VERSION).toBe('v3');
-    expect(daytonaSnapshotName(lockHash)).toBe('kortix-ci-daytona-v3-bbbbbbbbbbbbbbbb');
-    expect(daytonaBaseSnapshotName(lockHash)).toBe('kortix-ci-daytona-v2-bbbbbbbbbbbbbbbb-base');
+    expect(DAYTONA_CI_SNAPSHOT_VERSION).toBe('v4');
+    expect(daytonaSnapshotName(lockHash)).toBe('kortix-ci-daytona-v4-bbbbbbbbbbbbbbbb');
+    expect(daytonaBaseSnapshotName(lockHash)).toBe('kortix-ci-daytona-v3-bbbbbbbbbbbbbbbb-base');
   });
 
   test('builds the same pinned toolchain and repository cache as Platinum', () => {
@@ -51,6 +51,9 @@ describe('Daytona CI worker plan', () => {
 
     expect(dockerfile).toContain('node:22.22.0-bookworm@sha256:');
     expect(dockerfile).toContain('docker.io');
+    expect(dockerfile).toContain('docker-compose-linux-x86_64');
+    expect(dockerfile).toContain('sha256sum -c -');
+    expect(dockerfile).toContain('docker compose version');
     expect(dockerfile).toContain('kmod');
     expect(dockerfile).toContain('postgresql-client');
     expect(dockerfile).toContain('bun@1.3.14');

--- a/tests/unit/platinum-ci.test.ts
+++ b/tests/unit/platinum-ci.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
+  CI_DOCKER_COMPOSE_AMD64_SHA256,
+  CI_DOCKER_COMPOSE_VERSION,
   PLATINUM_CI_BUN_VERSION,
   PLATINUM_CI_NODE_IMAGE,
   PLATINUM_CI_PNPM_VERSION,
@@ -11,6 +13,7 @@ import {
   buildPlatinumWarmTemplateRequest,
   buildWorkerScript,
   cleanupPlatinumCiSandboxes,
+  dockerComposeInstallCommand,
   selectOutstandingPlatinumSandboxIds,
   isRetryablePlatinumError,
   observePlatinumSandboxStart,
@@ -40,9 +43,9 @@ describe('Platinum CI worker plan', () => {
   });
 
   test('uses one content-addressed template for one lockfile', () => {
-    expect(PLATINUM_CI_TEMPLATE_VERSION).toBe('v13');
-    expect(platinumTemplateName(lockHash)).toBe('kortix-ci-v13-bbbbbbbbbbbbbbbb');
-    expect(platinumBaseTemplateName(lockHash)).toBe('kortix-ci-v10-bbbbbbbbbbbbbbbb-base');
+    expect(PLATINUM_CI_TEMPLATE_VERSION).toBe('v14');
+    expect(platinumTemplateName(lockHash)).toBe('kortix-ci-v14-bbbbbbbbbbbbbbbb');
+    expect(platinumBaseTemplateName(lockHash)).toBe('kortix-ci-v11-bbbbbbbbbbbbbbbb-base');
     const spec = buildPlatinumTemplateSpec({
       lockHash,
       repository: 'kortix-ai/suna',
@@ -57,6 +60,8 @@ describe('Platinum CI worker plan', () => {
     expect(spec.steps[0]).toEqual({ op: 'kernel_modules', profile: 'container' });
     expect(JSON.stringify(spec.steps)).toContain(`bun@${PLATINUM_CI_BUN_VERSION}`);
     expect(JSON.stringify(spec.steps)).toContain(`pnpm@${PLATINUM_CI_PNPM_VERSION}`);
+    expect(JSON.stringify(spec.steps)).toContain('docker-compose-linux-x86_64');
+    expect(JSON.stringify(spec.steps)).toContain(CI_DOCKER_COMPOSE_AMD64_SHA256);
     expect(JSON.stringify(spec.steps)).not.toContain('postgresql-client');
     expect(JSON.stringify(spec.steps)).toContain(`fetch --depth=1 origin ${sha}`);
     expect(JSON.stringify(spec.steps)).toContain('playwright install --with-deps chromium');
@@ -85,6 +90,16 @@ describe('Platinum CI worker plan', () => {
     for (const step of spec.steps) {
       if (step.op === 'run') expect(step.cmd).not.toContain('\n');
     }
+  });
+
+  test('installs a pinned Docker Compose plugin in every base template', () => {
+    const command = dockerComposeInstallCommand();
+    expect(CI_DOCKER_COMPOSE_VERSION).toBe('v2.40.3');
+    expect(CI_DOCKER_COMPOSE_AMD64_SHA256).toHaveLength(64);
+    expect(command).toContain(`/download/${CI_DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64`);
+    expect(command).toContain(CI_DOCKER_COMPOSE_AMD64_SHA256);
+    expect(command).toContain('sha256sum -c -');
+    expect(command).toContain('docker compose version');
   });
 
   test('post cleanup selects only the exact CI run sandbox', () => {


### PR DESCRIPTION
## Problem

The first live Daytona preview reached the standard self-host bootstrap and failed before stack startup. The warm image contained Docker 20.10.24 but no Compose plugin. `docker compose version` returned `docker: compose is not a docker command`.

## Change

- Install Docker Compose v2.40.3 in both provider base images.
- Verify the published amd64 SHA-256 before execution.
- Rebuild Platinum as base v11 / warm v14.
- Rebuild Daytona as base v3 / warm v4.

## Verification

- `pnpm --dir tests test:unit`: 169 passed, 0 failed.
- `pnpm --dir tests typecheck`: exit 0.
- `pnpm test`: five lanes passed in 32.1s.
- Exact `node:22.22.0-bookworm` container smoke: `/usr/local/lib/docker/cli-plugins/docker-compose: OK`; `Docker Compose version v2.40.3`.

## Live evidence

Daytona sandbox `2bebdde3-e050-4562-8df7-2f8a5e98ba43` matched PR #6353 and SHA `60205e3a141af02f67047035e5128185995ec8ff`. The sandbox log proved the missing Compose plugin before this patch.