### PR TITLE
fix(web): ground session-override labels in system truth + quiet trigger

### DIFF
--- a/apps/web/src/features/session/overrides/session-overrides-composer.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-composer.tsx
@@ -90,13 +90,18 @@ export function SessionOverridesComposer({
           disabled={agentLocked}
         />
       ),
+      onReset:
+        !agentLocked && onAgentChange && defaultAgentName
+          ? () => onAgentChange(defaultAgentName)
+          : undefined,
+      resetLabel: 'Reset to project default',
     }),
     [agentLocked, agents, defaultAgentName, onAgentChange, selectedAgent],
   );
 
   const modelSlot = useMemo(
     () => ({
-      summary: currentModel?.modelName ?? 'Project default',
+      summary: currentModel?.modelName ?? 'Default',
       overridden:
         Boolean(selectedModel) &&
         Boolean(defaultModel) &&
@@ -109,10 +114,16 @@ export function SessionOverridesComposer({
           selectedModel={selectedModel}
           onSelect={onModelChange ?? (() => {})}
           providers={providers}
-          unsetLabel="Project default"
+          unsetLabel="Default"
           disabled={!onModelChange}
         />
       ),
+      // Re-selecting the resolved default IS the reset: the store has no
+      // "unset" (set(undefined) re-persists its fallback), and selected ==
+      // default is what clears the override flag.
+      onReset:
+        onModelChange && defaultModel ? () => onModelChange(defaultModel) : undefined,
+      resetLabel: 'Reset to default',
     }),
     [
       currentModel?.modelName,

--- a/apps/web/src/features/session/overrides/session-overrides-control.test.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-control.test.tsx
@@ -72,12 +72,15 @@ describe('SessionOverridesControlContent', () => {
     // came back empty must not be able to hide the only way back to the
     // default.
     const overridden = render({
-      rows: rows([{ overridden: true, onReset: () => {} }, {}]),
+      rows: rows([{ overridden: true, onReset: () => {}, resetLabel: 'Reset to agent default' }, {}]),
     });
-    const inherited = render({ rows: rows([{ onReset: () => {} }, {}]) });
+    const inherited = render({
+      rows: rows([{ onReset: () => {}, resetLabel: 'Reset to agent default' }, {}]),
+    });
 
-    expect(overridden).toContain('Reset to project default');
-    expect(inherited).not.toContain('Reset to project default');
+    // The label names where the default actually comes from, per axis.
+    expect(overridden).toContain('Reset to agent default');
+    expect(inherited).not.toContain('Reset to agent default');
   });
 
   test('disables only the save action while a save is impossible', () => {
@@ -94,5 +97,29 @@ describe('SessionOverridesControlContent', () => {
 
     expect(html).toContain('aria-label="Session overrides"');
     expect(html).toContain('type="button"');
+  });
+
+  test('the trigger stays quiet until an override is in force', () => {
+    // Everything inherited: icon only, in the toolbar's muted tone.
+    const quiet = renderToStaticMarkup(
+      <SessionOverridesControl rows={rows()} onSave={() => {}} />,
+    );
+    expect(quiet).toContain('text-muted-foreground');
+    expect(quiet).not.toContain('Session<');
+
+    // Exactly one override: the trigger names the overridden axis.
+    const one = renderToStaticMarkup(
+      <SessionOverridesControl rows={rows([{}, { overridden: true }])} onSave={() => {}} />,
+    );
+    expect(one).toContain('Secrets');
+
+    // Several: a count, not a list.
+    const two = renderToStaticMarkup(
+      <SessionOverridesControl
+        rows={rows([{ overridden: true }, { overridden: true }])}
+        onSave={() => {}}
+      />,
+    );
+    expect(two).toContain('2 overrides');
   });
 });

--- a/apps/web/src/features/session/overrides/session-overrides-control.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-control.tsx
@@ -14,9 +14,10 @@ import { type ReactNode, useState } from 'react';
  * One overridable axis of a session.
  *
  * `summary` is what the axis is set to RIGHT NOW, and for an axis nobody
- * touched that string is "Project default" — never "none". `overridden` is what
- * earns the badge: a session should look inherited until the user deliberately
- * takes it off the default.
+ * touched that string names its real source — "Agent default" for secrets (the
+ * agent's grant), "Project default" for connectors (the project's default
+ * connections) — never "none". `overridden` is what earns the badge: a session
+ * should look inherited until the user deliberately takes it off the default.
  */
 export interface SessionOverrideRow {
   id: string;
@@ -35,6 +36,8 @@ export interface SessionOverrideRow {
    * catalog can never hide the only way back to the default.
    */
   onReset?: () => void;
+  /** Names where the default comes from — "Reset to agent default" etc. */
+  resetLabel?: string;
   /** Shown instead of the editor when the axis cannot be edited here. */
   readOnly?: boolean;
 }
@@ -47,7 +50,6 @@ export interface SessionOverridesControlProps {
   /** Extra note above the footer — e.g. the non-retroactive secrets warning. */
   notice?: ReactNode;
   onSave: () => void;
-  triggerLabel?: string;
 }
 
 /**
@@ -71,7 +73,7 @@ export function SessionOverridesControlContent({
   saveDisabled = false,
   notice,
   onSave,
-}: Omit<SessionOverridesControlProps, 'triggerLabel'>) {
+}: SessionOverridesControlProps) {
   const [focusedId, setFocusedId] = useState<string | null>(rows[0]?.id ?? null);
   const focused = rows.find((row) => row.id === focusedId) ?? rows[0];
   const controlsDisabled = disabled || saving;
@@ -137,7 +139,11 @@ export function SessionOverridesControlContent({
               </p>
               <div className="mt-3">{focused.editor}</div>
               {focused.overridden && focused.onReset ? (
-                <ResetAxisButton disabled={controlsDisabled} onReset={focused.onReset} />
+                <ResetAxisButton
+                  disabled={controlsDisabled}
+                  onReset={focused.onReset}
+                  label={focused.resetLabel}
+                />
               ) : null}
             </>
           ) : null}
@@ -163,10 +169,18 @@ export function SessionOverridesControlContent({
   );
 }
 
-export function SessionOverridesControl({
-  triggerLabel = 'Session',
-  ...contentProps
-}: SessionOverridesControlProps) {
+export function SessionOverridesControl({ ...contentProps }: SessionOverridesControlProps) {
+  // The trigger stays quiet: an icon like every other toolbar control, in the
+  // same muted tone as the agent/model selectors beside it. It only ever grows
+  // text when an override is actually in force — the one overridden axis's
+  // name, or a count — so the composer says nothing while everything inherits.
+  const overridden = contentProps.rows.filter((row) => row.overridden);
+  const triggerText =
+    overridden.length === 1
+      ? overridden[0].name
+      : overridden.length > 1
+        ? `${overridden.length} overrides`
+        : null;
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -176,9 +190,10 @@ export function SessionOverridesControl({
           size="toolbar"
           disabled={contentProps.disabled || contentProps.saving}
           aria-label="Session overrides"
+          className="text-muted-foreground hover:text-foreground data-[state=open]:text-foreground"
         >
           <SlidersHorizontal className="size-3.5 shrink-0" />
-          {triggerLabel}
+          {triggerText}
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/apps/web/src/features/session/overrides/session-overrides-toolbar.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-toolbar.tsx
@@ -46,11 +46,17 @@ const unavailableCatalog: SessionScopeSelectionCatalog = {
 
 /** An axis whose control the composer already owns, handed in as a slot. */
 export interface SessionOverrideSlot {
-  /** What it resolves to now. "Project default" when nothing is overriding it. */
+  /**
+   * What it resolves to now. When nothing overrides the axis this names its
+   * real source ("Agent default", "Project default") — never "none".
+   */
   summary: string;
   overridden?: boolean;
   control: ReactNode;
   description?: string;
+  /** Drops the override — hands the axis back to its default. */
+  onReset?: () => void;
+  resetLabel?: string;
 }
 
 export interface SessionOverridesToolbarProps {
@@ -198,6 +204,8 @@ export function SessionOverridesToolbar({
           agent.description ??
           'The agent that answers your next prompt. It also decides the ceiling for every other axis here — a session can never reach past what its agent is granted.',
         editor: agent.control,
+        onReset: agent.onReset,
+        resetLabel: agent.resetLabel,
       });
     }
     if (model) {
@@ -210,8 +218,10 @@ export function SessionOverridesToolbar({
         overridden: model.overridden,
         description:
           model.description ??
-          'The model this session sends to. Leave it on the project default unless this one session needs something else.',
+          'The model this session sends to. Unset, it follows the agent’s model, then the account default — set it here only when this one session needs something else.',
         editor: model.control,
+        onReset: model.onReset,
+        resetLabel: model.resetLabel,
       });
     }
     if (reasoningEffort) {
@@ -226,6 +236,8 @@ export function SessionOverridesToolbar({
           reasoningEffort.description ??
           'How much the model reasons before it answers. This one is stored per project and per model, so every session in this project using this model follows it.',
         editor: reasoningEffort.control,
+        onReset: reasoningEffort.onReset,
+        resetLabel: reasoningEffort.resetLabel,
       });
     }
     list.push({
@@ -237,7 +249,8 @@ export function SessionOverridesToolbar({
         activeCatalog.secrets.status === 'ready' ? sessionSecretsSummary(draft) : 'Unavailable',
       overridden: sessionSecretsAreOverridden(draft),
       description:
-        'Which project secrets reach this session. The default is everything this agent is granted; narrowing it here only ever takes access away.',
+        'Which secrets reach this session. The default is the agent’s grant — everything its kortix.yaml allows — and narrowing it here only ever takes access away.',
+      resetLabel: 'Reset to agent default',
       editor: (
         <SessionSecretsEditor
           draft={draft}
@@ -259,7 +272,8 @@ export function SessionOverridesToolbar({
           : 'Unavailable',
       overridden: sessionConnectorsAreOverridden(draft),
       description:
-        'Which connected accounts this session may use. On the project default each one resolves to the project’s active connection; pick here only to pin this session to something else.',
+        'Which connected accounts this session may use. By default every connector the agent grants resolves to the project’s default connection; pick here only to pin this session to something else.',
+      resetLabel: 'Reset to project default',
       editor: (
         <SessionConnectorsEditor
           draft={draft}
@@ -274,8 +288,8 @@ export function SessionOverridesToolbar({
       id: 'sandbox',
       name: 'Sandbox',
       icon: Cpu,
-      hint: 'Where it runs',
-      summary: sandbox?.slug ?? 'Project default',
+      hint: 'Fixed at session start',
+      summary: sandbox?.slug ?? 'Default template',
       description:
         'The machine image this session runs on. It is chosen when the session is created and cannot be changed afterwards — start a new session to use a different one.',
       readOnly: true,

--- a/apps/web/src/features/session/scope/session-scope-control.tsx
+++ b/apps/web/src/features/session/scope/session-scope-control.tsx
@@ -140,9 +140,12 @@ export function setSessionConnectorEnabled(
 export function ResetAxisButton({
   disabled = false,
   onReset,
+  label = 'Reset to default',
 }: {
   disabled?: boolean;
   onReset: () => void;
+  /** Names where the default comes from — "Reset to agent default" etc. */
+  label?: string;
 }) {
   return (
     <Button
@@ -154,7 +157,7 @@ export function ResetAxisButton({
       onClick={onReset}
     >
       <ArrowCounterClockwise className="size-3.5 shrink-0" />
-      Reset to project default
+      {label}
     </Button>
   );
 }

--- a/apps/web/src/features/session/scope/session-scope-model.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.test.ts
@@ -153,8 +153,10 @@ describe('createSessionScopeDraft', () => {
 });
 
 describe('session scope summaries', () => {
-  test('names an inherited axis the project default, never "none"', () => {
-    expect(sessionSecretsSummary({ secrets: null })).toBe('Project default');
+  test('names an inherited axis after its real source, never "none"', () => {
+    // Secrets inherit the AGENT's grant; connectors resolve to the PROJECT's
+    // default connections. Each axis names where its default actually lives.
+    expect(sessionSecretsSummary({ secrets: null })).toBe('Agent default');
     expect(
       sessionConnectorsSummary({
         connector_bindings: { mail: { connection_id: 'connection-mail-1' } },

--- a/apps/web/src/features/session/scope/session-scope-model.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.ts
@@ -188,21 +188,28 @@ export function resetSessionConnectorBindings(
   };
 }
 
-/** How an axis reads in the UI. "Project default" is the norm, never "none". */
-export const SESSION_SCOPE_INHERITED_LABEL = 'Project default';
+/**
+ * How an inherited axis reads in the UI — named for where the default really
+ * comes from, per axis. Secrets: `intersectSecretGrants(grant, null)` returns
+ * the AGENT's grant untouched, so the inherited state is the agent's. Connectors:
+ * the agent's grant gates the set, but each granted alias resolves to the
+ * PROJECT's default connection (`resolveProjectDefaultConnectorConnection`).
+ */
+export const SESSION_SCOPE_SECRETS_INHERITED_LABEL = 'Agent default';
+export const SESSION_SCOPE_CONNECTORS_INHERITED_LABEL = 'Project default';
 
 export function sessionSecretsSummary(draft: SessionScopeDraft): string {
   if (draft.secrets === undefined) return 'Unchanged';
   // `null` = inherit whatever the agent's grant allows. Calling this "All
   // allowed" overstated it, and calling it "None selected" inverted it.
-  if (draft.secrets === null) return SESSION_SCOPE_INHERITED_LABEL;
+  if (draft.secrets === null) return SESSION_SCOPE_SECRETS_INHERITED_LABEL;
   if (draft.secrets.length === 0) return 'None allowed';
   return `${draft.secrets.length} selected`;
 }
 
 export function sessionConnectorsSummary(draft: SessionScopeDraft): string {
   if (draft.connector_bindings === undefined) return 'Unchanged';
-  if (draft.connector_bindings_inherited === true) return SESSION_SCOPE_INHERITED_LABEL;
+  if (draft.connector_bindings_inherited === true) return SESSION_SCOPE_CONNECTORS_INHERITED_LABEL;
   const bound = Object.keys(draft.connector_bindings);
   // A required-but-unconnected alias is selected too — it has no connection to
   // bind, which is precisely why it is recorded separately.


### PR DESCRIPTION
Follow-up to #6361, from direct product feedback. Every label is now grounded in what the system actually resolves:

- **Secrets** inherited state reads **"Agent default"** — `intersectSecretGrants(grant, null)` returns the agent's grant untouched, so the default is the agent's, not the project's. Reset action reads "Reset to agent default".
- **Connectors** stays **"Project default"** — the agent's grant gates the set, but each granted alias resolves to the project's default connection. Reset reads "Reset to project default".
- **Model** description states the real chain (session → agent's model → account default); unset label is "Default".
- **Sandbox** row hint reads **"Fixed at session start"** so a row with no selection points cannot be mistaken for a broken selector; summary "Default template".
- **Trigger is quiet and toolbar-toned**: `text-muted-foreground` like the agent/model selectors beside it (it rendered foreground-white before), icon-only while everything inherits, and it names the overridden axis ("Model") or shows a count ("2 overrides") only when an override is actually in force.
- **Agent and model rows gained reset actions** — every overridable axis is now deactivatable. Model reset re-selects the resolved default explicitly (the model store has no unset: `set(undefined)` re-persists its fallback), which is what clears the override flag.

Verification (worktree stack, real browser):
- Popover on the project-home composer shows Agent kortix · Model DeepSeek V4 Flash · Reasoning effort "Model default" · Secrets "Agent default" · Connectors "Project default" · Sandbox "Default template"; trigger icon-only and muted.
- Picking GLM 5.2 in the popover's model pane: row flips to "GLM 5.2 · Override", the reasoning-effort row disappears (GLM exposes no effort knob), and the toolbar trigger reads "Model".
- "Reset to default" returns the row to DeepSeek V4 Flash, drops the badge, restores the effort row, and the trigger returns to icon-only.
- Screenshots: `output/session-overrides/polish-01..04`.
- `bun test` overrides+scope: 68 pass / 0 fail. `eslint` on touched dirs: 0 errors (3 pre-existing `react-hooks` warnings). `tsc --noEmit` clean vs known baseline.
