### PR TITLE
fix(ci): force gateway in full dev deploys

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -137,6 +137,7 @@ jobs:
             else
               api=true
               apps_router=true
+              gateway=true
               frontend=true
               terraform=true
             fi

--- a/tests/unit/app-runtime-workflow.test.ts
+++ b/tests/unit/app-runtime-workflow.test.ts
@@ -14,4 +14,20 @@ describe('app runtime workflow coverage', () => {
 
     expect(workflow).toContain('apps/kortix-app-runtime/**');
   });
+
+  it('forces every deployable service for a manual all-surface Dev recovery', () => {
+    const workflow = readFileSync(
+      resolve(import.meta.dirname, '../../.github/workflows/deploy-dev.yml'),
+      'utf8',
+    );
+    const normalize = workflow.slice(
+      workflow.indexOf('      - name: Normalize outputs'),
+      workflow.indexOf('      - name: Summary'),
+    );
+    const allSurface = normalize.slice(normalize.indexOf('            else'));
+
+    expect(allSurface).toContain('api=true');
+    expect(allSurface).toContain('gateway=true');
+    expect(allSurface).toContain('frontend=true');
+  });
 });


### PR DESCRIPTION
## Problem

A newer main push canceled Deploy Dev run `31436964461` before the gateway artifact built. Manual `surface=all` forced API and frontend, but it left the gateway value to path detection. A manual recovery from `main` could therefore skip the gateway again.

## Change

- Set `gateway=true` for manual all-surface Deploy Dev runs.
- Add a workflow contract test for API, gateway, and frontend.

## Verification

- Failing test before the change: expected the manual all-surface block to contain `gateway=true`.
- `pnpm --dir tests exec vitest run --config unit/vitest.config.ts unit/app-runtime-workflow.test.ts`: 4 passed, 0 failed.
- `git diff --check`: exit 0.