### PR TITLE
test(infra): align the preview runtime contract test with the sandbox-preview architecture

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -11,6 +11,15 @@ on:
     paths:
       - "infra/terraform/**"
       - ".github/workflows/terraform-ci.yml"
+      # The `preview runtime contract tests` step below asserts the security
+      # invariants of the pull request preview pipeline. Those invariants now
+      # live in the workflow and the sandbox preview runtime, not only in
+      # Terraform, so a change to either must run this gate.
+      - "infra/scripts/**"
+      - ".github/workflows/deploy-preview.yml"
+      - "tests/bin/sandbox-preview.ts"
+      - "tests/src/core/sandbox-preview*.ts"
+      - "tests/src/core/preview-stack.ts"
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:

--- a/infra/scripts/test-ecs-preview-runtime.py
+++ b/infra/scripts/test-ecs-preview-runtime.py
@@ -1,110 +1,448 @@
 #!/usr/bin/env python3
 
+"""Security contract for the pull request preview runtime.
+
+`deploy-preview.yml` runs on `pull_request_target`. It therefore holds write
+tokens and publish credentials while the pull request head is attacker
+controlled. This file pins the invariants that keep that safe. Every assertion
+below states one rule; a rule that stops being true must be deleted on purpose,
+not by accident.
+
+PR #6347 (7074ffd25e) replaced the per-PR ECS runtime with a warm Platinum or
+Daytona sandbox that boots the full self-host distribution:
+
+    old: build 3 images -> push -> infra/scripts/ecs-preview.sh deploy <pr>
+         -> Fargate service on pr-<n>.preview{-api}.kortix.com
+    new: build 3 images -> push -> bun tests/bin/sandbox-preview.ts deploy
+         -> one sandbox per PR, own PostgreSQL/Supabase/Mailpit behind a
+            provider-issued HTTPS origin, then `pnpm test -- --target-full`
+
+The gate structure is unchanged: an approval job resolves exactly one head SHA,
+three credential-free jobs build it, and one default-branch job holds the
+credentials and never executes pull request code. The assertions follow the new
+implementation files; each obsolete assertion is kept as a comment that records
+which rule replaced it.
+
+`infra/terraform/environments/preview` still exists and is still applied, so its
+guardrails are still asserted here. `infra/scripts/ecs-preview.sh` is no longer
+reachable from any workflow; this file asserts it stays disconnected.
+"""
+
 from pathlib import Path
+import re
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[2]
-WORKFLOW = (ROOT / ".github/workflows/deploy-preview.yml").read_text()
-SCRIPT = (ROOT / "infra/scripts/ecs-preview.sh").read_text()
-TERRAFORM = (ROOT / "infra/terraform/environments/preview/main.tf").read_text()
-VARIABLES = (ROOT / "infra/terraform/environments/preview/variables.tf").read_text()
-README = (ROOT / "infra/terraform/environments/preview/README.md").read_text()
 
 
-class PreviewRuntimeContract(unittest.TestCase):
-    def test_deploy_requires_exact_api_and_frontend_health(self):
-        self.assertIn("needs: [authorize, build-api, build-gateway, build-web]", WORKFLOW)
-        self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", WORKFLOW)
+def read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text()
+
+
+WORKFLOW = read(".github/workflows/deploy-preview.yml")
+# The preview runtime moved into the test package. These four files are the
+# whole implementation of "boot a preview and delete it again".
+PREVIEW_CLI = read("tests/bin/sandbox-preview.ts")
+PREVIEW_CORE = read("tests/src/core/sandbox-preview.ts")
+PREVIEW_PROVIDERS = read("tests/src/core/sandbox-preview-providers.ts")
+PREVIEW_STACK = read("tests/src/core/preview-stack.ts")
+PREVIEW_SOURCES = {
+    "tests/bin/sandbox-preview.ts": PREVIEW_CLI,
+    "tests/src/core/sandbox-preview.ts": PREVIEW_CORE,
+    "tests/src/core/sandbox-preview-providers.ts": PREVIEW_PROVIDERS,
+    "tests/src/core/preview-stack.ts": PREVIEW_STACK,
+}
+TERRAFORM = read("infra/terraform/environments/preview/main.tf")
+VARIABLES = read("infra/terraform/environments/preview/variables.tf")
+README = read("infra/terraform/environments/preview/README.md")
+
+JOB_HEADING = re.compile(r"^  [a-z][a-z0-9-]*:$", re.MULTILINE)
+
+
+def job(name: str) -> str:
+    """Return the YAML body of one top-level job in deploy-preview.yml."""
+    marker = f"\n  {name}:\n"
+    if marker not in WORKFLOW:
+        raise AssertionError(f"deploy-preview.yml has no job named {name}")
+    body = WORKFLOW.split(marker, 1)[1]
+    following = JOB_HEADING.search(body)
+    return body[: following.start()] if following else body
+
+
+def cli_action(name: str) -> str:
+    """Return the body of one `action === '<name>'` branch of the preview CLI."""
+    marker = f"action === '{name}'"
+    if marker not in PREVIEW_CLI:
+        raise AssertionError(f"tests/bin/sandbox-preview.ts has no {name} action")
+    return PREVIEW_CLI.split(marker, 1)[1].split("\n} else", 1)[0]
+
+
+def checkout_steps(text: str) -> list[str]:
+    """Return the body of every actions/checkout step in a workflow fragment."""
+    return [chunk.split("\n      - ", 1)[0] for chunk in text.split("- uses: actions/checkout@")[1:]]
+
+
+BUILD_JOBS = ("build-api", "build-gateway", "build-web")
+
+
+class PreviewApproval(unittest.TestCase):
+    """One writer approves one exact SHA, and every stage revalidates it."""
+
+    def test_preview_label_approves_one_exact_sha(self):
         self.assertIn("pull_request_target:", WORKFLOW)
         self.assertIn("branches: [main]", WORKFLOW)
-        self.assertIn("ref: ${{ github.event.repository.default_branch }}", WORKFLOW)
-        self.assertIn('[ "$api_environment" = "preview" ]', WORKFLOW)
-        self.assertIn('[ "$api_commit" = "$COMMIT" ]', WORKFLOW)
-        self.assertIn('[ "$web_commit" = "$COMMIT" ]', WORKFLOW)
-        self.assertIn("kortix/kortix-frontend:pr-${{ github.event.pull_request.head.sha }}", WORKFLOW)
-        self.assertIn('web_host="pr-${NUM}.preview.kortix.com"', WORKFLOW)
-        self.assertIn("WEB_PROTECTION_PASSWORD", WORKFLOW)
-        self.assertIn("cookie_only", WORKFLOW)
+        self.assertIn("github.event.action == 'labeled'", WORKFLOW)
+        self.assertIn("github.event.label.name == 'preview'", WORKFLOW)
+        # Automatic previews on open/synchronize would deploy unreviewed code.
+        self.assertNotIn("['labeled','opened','synchronize','reopened']", WORKFLOW)
+        # The approval is the label plus the live head SHA, never a stored variable.
+        self.assertNotIn("KORTIX_PREVIEW_APPROVED_SHA", WORKFLOW)
+
+        authorize = job("authorize")
+        self.assertIn('case "$permission" in', authorize)
+        # Widened from admin|write by #6347; still excludes read and triage.
+        self.assertIn("admin|maintain|write) ;;", authorize)
+        self.assertIn("*) echo \"::error::${APPROVER} has ${permission} permission;", authorize)
+        # Forks never reach the sandbox, on either trigger.
+        self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", WORKFLOW)
+        self.assertIn('[ "$head_repo" = "$REPO" ] || {', authorize)
+        self.assertIn('[[ "$sha" =~ ^[0-9a-f]{40}$ ]] || {', authorize)
+        self.assertIn('[ "$current" = "$sha" ] || {', authorize)
+        self.assertIn('[[ " $labels " == *" preview "* ]] || {', authorize)
+        # workflow_dispatch is a second entry point; it reads the head SHA from
+        # the API and runs through the same permission, label, and SHA checks.
+        self.assertIn("github.event_name == 'workflow_dispatch'", WORKFLOW)
+        self.assertIn("case \"$provider\" in auto|platinum|daytona) ;; *) exit 1 ;; esac", authorize)
+        self.assertIn('echo "ref=refs/pull/${num}/head"', authorize)
+        # The dependency graph is pinned to the approved SHA as well.
+        self.assertIn("contents/pnpm-lock.yaml?ref=${sha}", authorize)
+        self.assertIn('[[ "$lockfile_sha256" =~ ^[0-9a-f]{64}$ ]] || {', authorize)
+
+    def test_every_later_job_consumes_the_approved_sha_not_the_event_sha(self):
+        # OLD: build jobs read ${{ github.event.pull_request.head.sha }} directly.
+        # NEW: only the authorize job may touch the raw event SHA. Every other
+        # job reads needs.authorize.outputs.sha, so a head change between the
+        # label and the build cannot slip a different commit through.
+        self.assertEqual(WORKFLOW.count("github.event.pull_request.head.sha"), 1)
+        self.assertIn("EVENT_SHA: ${{ github.event.pull_request.head.sha }}", job("authorize"))
+        for build in BUILD_JOBS:
+            self.assertIn("ref: ${{ needs.authorize.outputs.sha }}", job(build))
+        self.assertIn("kortix/kortix-api:pr-${{ needs.authorize.outputs.sha }}", WORKFLOW)
+        self.assertIn("kortix/kortix-gateway:pr-${{ needs.authorize.outputs.sha }}", WORKFLOW)
+        self.assertIn("kortix/kortix-frontend:pr-${{ needs.authorize.outputs.sha }}", WORKFLOW)
+
+    def test_deploy_revalidates_permission_label_and_sha_before_publishing(self):
+        deploy = job("deploy")
+        self.assertIn("needs: [authorize, build-api, build-gateway, build-web]", deploy)
+        self.assertIn("Revalidate exact preview approval", deploy)
+        self.assertIn("admin|maintain|write) ;;", deploy)
+        self.assertIn('[ "$current" = "$COMMIT" ] || {', deploy)
+        self.assertIn('[[ " $labels " == *" preview "* ]] || {', deploy)
+
+    def test_the_sandbox_refuses_to_run_any_other_sha(self):
+        # OLD: `[ "$api_commit" = "$COMMIT" ]` polled the deployed ALB.
+        # NEW: the bootstrap script verifies the checkout itself and then the
+        # in-sandbox health endpoint, so an unapproved SHA cannot serve traffic.
+        self.assertIn('git -C "$ROOT" checkout --detach --force FETCH_HEAD', PREVIEW_CORE)
+        self.assertIn('test "$actual_sha" = "${input.sha}"', PREVIEW_CORE)
+        self.assertIn("pnpm install --offline --frozen-lockfile", PREVIEW_CORE)
+        self.assertIn("if (!/^[a-f0-9]{40}$/i.test(input.sha)) throw new Error", PREVIEW_CORE)
+        self.assertIn("preview lockfile hash must contain 64 hex characters", PREVIEW_CORE)
+        self.assertIn("PREVIEW_LOCKFILE_SHA256: ${{ needs.authorize.outputs.lockfile_sha256 }}", WORKFLOW)
+
+
+class PreviewBuildIsolation(unittest.TestCase):
+    """Pull request code compiles without credentials and never executes on the runner."""
+
+    def test_no_checkout_persists_credentials(self):
+        # OLD: assertEqual(count("persist-credentials: false"), 3) — the count
+        # broke as soon as #6347 added checkouts. The rule was never "three";
+        # it is "every checkout in this workflow".
+        steps = checkout_steps(WORKFLOW)
+        self.assertEqual(len(steps), WORKFLOW.count("- uses: actions/checkout@"))
+        self.assertGreaterEqual(len(steps), 6)
+        for step in steps:
+            self.assertIn("persist-credentials: false", step)
+
+    def test_build_jobs_have_no_secret_no_registry_and_no_push(self):
+        self.assertEqual(WORKFLOW.count("push: false"), 3)
+        self.assertEqual(WORKFLOW.count("type=docker,dest=/tmp/preview-"), 3)
+        self.assertEqual(WORKFLOW.count("actions/download-artifact@v8"), 3)
+        for name in BUILD_JOBS:
+            section = job(name)
+            self.assertIn("permissions:\n      contents: read", section)
+            self.assertIn("submodules: false", section)
+            self.assertEqual(section.count("actions/upload-artifact@v7"), 1)
+            self.assertIn("if-no-files-found: error", section)
+            self.assertNotIn("${{ secrets.", section)
+            self.assertNotIn("DOCKERHUB_", section)
+            self.assertNotIn("docker/login-action", section)
+            self.assertNotIn("push: true", section)
+            self.assertNotIn("aws-actions/configure-aws-credentials", section)
+
+    def test_the_credentialed_job_loads_images_and_never_runs_them(self):
+        deploy = job("deploy")
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", deploy)
+        # The privileged runner must not check out pull request code at all.
+        self.assertNotIn("ref: ${{ needs.authorize.outputs.sha }}", deploy)
+        self.assertIn("docker/login-action@v3", deploy)
+        self.assertIn("docker load --input", deploy)
+        self.assertIn("docker push", deploy)
+        self.assertIn(
+            "docker image inspect --format '{{.Os}}/{{.Architecture}}' \"$image\" | grep -qx 'linux/amd64'",
+            deploy,
+        )
+        self.assertNotIn("docker run", deploy)
+        self.assertNotIn("docker compose", deploy)
+        # Pull request code executes only inside the disposable sandbox.
+        self.assertIn("bun tests/bin/sandbox-preview.ts deploy", deploy)
+
+    def test_a_failed_preview_cannot_report_success(self):
+        deploy = job("deploy")
+        self.assertIn("continue-on-error: true", deploy)
+        self.assertIn("if: steps.preview.outcome != 'success'", deploy)
+        self.assertIn("run: exit 1", deploy)
+
+    def test_the_preview_pipeline_holds_no_cloud_or_delivery_identity(self):
+        # OLD: the deploy and teardown jobs assumed
+        # arn:aws:iam::…:role/kortix-gha-preview-deploy through OIDC. The
+        # sandbox runtime needs no AWS identity, so the workflow must not
+        # request one, and the disconnected ECS path must stay disconnected.
+        self.assertNotIn("aws-actions/configure-aws-credentials", WORKFLOW)
+        self.assertNotIn("id-token: write", WORKFLOW)
+        self.assertNotIn("ecs-preview.sh", WORKFLOW)
         self.assertNotIn("Vercel", WORKFLOW)
         self.assertNotIn("VERCEL_", WORKFLOW)
         self.assertNotIn("Argo CD", WORKFLOW)
         self.assertNotIn("submodule update --init --recursive --remote", WORKFLOW)
 
-    def test_pr_code_builds_without_credentials_and_publish_never_runs_it(self):
-        self.assertEqual(WORKFLOW.count("persist-credentials: false"), 3)
-        self.assertEqual(WORKFLOW.count("push: false"), 3)
-        self.assertEqual(WORKFLOW.count("type=docker,dest=/tmp/preview-"), 3)
-        self.assertEqual(WORKFLOW.count("actions/upload-artifact@v7"), 3)
-        self.assertEqual(WORKFLOW.count("actions/download-artifact@v8"), 3)
-        for build, next_job in (
-            ("build-api:", "build-gateway:"),
-            ("build-gateway:", "build-web:"),
-            ("build-web:", "deploy:"),
+
+class PreviewRuntimeIsolation(unittest.TestCase):
+    """One sandbox per pull request, its own data plane, no production reach."""
+
+    def test_each_pull_request_gets_one_named_sandbox(self):
+        # OLD: SERVICE="kortix-pr-${PR}" plus pr-<n>.preview{-api}.kortix.com.
+        # NEW: one stable sandbox name per PR; the origin is provider-issued.
+        self.assertIn("return `kortix-preview-pr-${prNumber}`;", PREVIEW_CORE)
+        self.assertIn("invalid preview PR number", PREVIEW_CORE)
+        self.assertEqual(PREVIEW_PROVIDERS.count("name: previewSandboxName(input.prNumber),"), 2)
+        # OLD: rollback_deploy / PREVIOUS_TASK_DEFINITION rolled a live service
+        # back. A sandbox is disposable, so a redeploy deletes and recreates it.
+        self.assertIn("async function replaceExistingPlatinumPreview(", PREVIEW_PROVIDERS)
+        self.assertIn("async function replaceExistingDaytonaPreview(", PREVIEW_PROVIDERS)
+        self.assertIn("refused to replace unowned Daytona sandbox", PREVIEW_PROVIDERS)
+        self.assertIn("owner: 'kortix-preview',", PREVIEW_PROVIDERS)
+        self.assertIn("'kortix-preview': 'true',", PREVIEW_PROVIDERS)
+        # A provider switch must not leave the other provider's sandbox running.
+        self.assertIn(
+            "const staleProviderCleanup = result.provider === 'platinum'",
+            cli_action("deploy"),
+        )
+
+    def test_the_preview_origin_is_credential_free_https(self):
+        # OLD: WEB_PROTECTION_PASSWORD plus the anonymous/wrong/cookie_only
+        # probes guarded pr-<n>.preview.kortix.com, a guessable public hostname.
+        # NEW: there is no Kortix hostname and no HTTP password. The origin is a
+        # per-sandbox provider URL, and both the URL and the compose overlay are
+        # validated. The blast radius is bounded by the data-plane isolation
+        # asserted below, not by a shared password.
+        self.assertIn("sandbox preview URL must use credential-free HTTPS", PREVIEW_PROVIDERS)
+        self.assertIn("if (url.protocol !== 'https:' || url.username || url.password)", PREVIEW_PROVIDERS)
+        self.assertIn("preview origin must be an HTTPS origin", PREVIEW_CORE)
+        self.assertIn("preview origin must be an HTTPS origin without a path", PREVIEW_STACK)
+        for path, source in PREVIEW_SOURCES.items():
+            self.assertNotIn("kortix.com", source, f"{path} must not pin a Kortix hostname")
+
+    def test_only_the_edge_port_is_published_and_the_gateway_stays_internal(self):
+        # OLD: LLM_GATEWAY_PROXY_TARGET http://127.0.0.1:8090, an API container
+        # port 3000 for web, and two ALB target groups.
+        # NEW: one Caddy edge on 8080 fronts everything; the gateway, API,
+        # frontend, and Supabase are reachable only inside the compose network.
+        self.assertIn("reverse_proxy kortix-api:8008", PREVIEW_STACK)
+        self.assertIn("reverse_proxy llm-gateway:8090", PREVIEW_STACK)
+        self.assertIn("reverse_proxy frontend:3000", PREVIEW_STACK)
+        self.assertIn("handle_path /_gateway/*", PREVIEW_STACK)
+        self.assertIn('- "0.0.0.0:8080:8080"', PREVIEW_STACK)
+        # The database port is bound to loopback inside the sandbox only.
+        self.assertIn('- "127.0.0.1:15432:5432"', PREVIEW_STACK)
+        self.assertIn("expose: [{ port: 8080, public: true }]", PREVIEW_PROVIDERS)
+
+    def test_the_preview_runs_its_own_data_plane_in_preview_mode(self):
+        # OLD: INTERNAL_KORTIX_ENV=preview, KORTIX_WORKERS_ENABLED=false, and
+        # KORTIX_SKIP_ENSURE_SCHEMA=1 on a shared preview database.
+        # NEW: the same environment marker and worker switch, and the schema
+        # flag is obsolete because each preview creates its own PostgreSQL.
+        self.assertIn("INTERNAL_KORTIX_ENV: 'preview',", PREVIEW_STACK)
+        self.assertIn("KORTIX_WORKERS_ENABLED: 'false',", PREVIEW_STACK)
+        self.assertIn("SCHEDULER_ENABLED: 'false',", PREVIEW_STACK)
+        self.assertIn("KORTIX_TRIGGER_SCHEDULER_ENABLED: 'false',", PREVIEW_STACK)
+        self.assertIn(
+            "DATABASE_URL: `postgresql://postgres:${postgresPassword}@supabase-db:5432/postgres`,",
+            PREVIEW_STACK,
+        )
+        self.assertIn(
+            "KE2E_DATABASE_URL: `postgresql://postgres:${postgresPassword}@127.0.0.1:15432/postgres`,",
+            PREVIEW_STACK,
+        )
+        # A preview must never deliver real email.
+        self.assertIn("EMAIL_PROVIDER_ORDER: 'mailpit',", PREVIEW_STACK)
+        self.assertIn("SMTP_HOST: 'mailpit',", PREVIEW_STACK)
+        # OLD: NEXT_PUBLIC_APP_URL / NEXT_PUBLIC_BACKEND_URL were set to the two
+        # per-PR hostnames. NEW: every public URL is the one validated origin.
+        for key in (
+            "PUBLIC_URL: origin,",
+            "API_PUBLIC_URL: origin,",
+            "SUPABASE_PUBLIC_URL: origin,",
+            "CORS_ALLOWED_ORIGINS: origin,",
+            "KORTIX_PUBLIC_APP_URL: origin,",
         ):
-            section = WORKFLOW.split(f"  {build}", 1)[1].split(f"\n  {next_job}", 1)[0]
-            self.assertIn("permissions:\n      contents: read", section)
-            self.assertNotIn("DOCKERHUB_", section)
-            self.assertNotIn("docker/login-action", section)
-            self.assertNotIn("push: true", section)
-        deploy = WORKFLOW.split("  deploy:", 1)[1].split("\n  teardown:", 1)[0]
-        self.assertIn("docker/login-action@v3", deploy)
-        self.assertIn("docker load --input", deploy)
-        self.assertIn("docker push", deploy)
-        self.assertNotIn("docker run", deploy)
+            self.assertIn(key, PREVIEW_STACK)
+        # OLD: KORTIX_PUBLIC_VERSION carried the commit into the UI.
+        self.assertIn("KORTIX_VERSION: `pr-${input.sha}`,", PREVIEW_STACK)
+        self.assertIn("KORTIX_COMMIT: input.sha,", PREVIEW_STACK)
+        self.assertIn("KE2E_EXPECT_SHA: input.sha,", PREVIEW_STACK)
 
-    def test_preview_label_approves_one_exact_sha(self):
-        self.assertIn("github.event.action == 'labeled'", WORKFLOW)
-        self.assertIn("github.event.label.name == 'preview'", WORKFLOW)
-        self.assertIn('case "$permission" in', WORKFLOW)
-        self.assertIn("admin|write)", WORKFLOW)
-        self.assertNotIn("['labeled','opened','synchronize','reopened']", WORKFLOW)
-        self.assertIn("github.event.action == 'synchronize'", WORKFLOW)
-        self.assertIn("gh api -X DELETE", WORKFLOW)
-        self.assertIn("labels/preview", WORKFLOW)
-        self.assertNotIn("KORTIX_PREVIEW_APPROVED_SHA", WORKFLOW)
+    def test_runtime_secrets_are_allowlisted_and_delivered_per_sandbox(self):
+        # OLD: SECRET_NAME="kortix-preview-env" / "kortix-preview-web-env" in
+        # Secrets Manager, with `assertNotIn("kortix-prod-env")` as the guard.
+        # NEW: an explicit allowlist decides what may enter a preview, and the
+        # values land in one 0600 file inside the sandbox.
+        self.assertIn("export const PREVIEW_RUNTIME_SECRET_ALLOWLIST = [", PREVIEW_STACK)
+        for name in (
+            "'DAYTONA_API_KEY',",
+            "'KE2E_STRIPE_SECRET_KEY',",
+            "'KE2E_STRIPE_WEBHOOK_SECRET',",
+            "'KORTIX_GITHUB_APP_ID',",
+            "'KORTIX_GITHUB_APP_PRIVATE_KEY',",
+            "'KORTIX_GITHUB_APP_SLUG',",
+            "'MANAGED_GIT_GITHUB_INSTALL_ID',",
+            "'MANAGED_GIT_GITHUB_OWNER',",
+            "'OPENROUTER_API_KEY',",
+        ):
+            self.assertIn(name, PREVIEW_STACK)
+        self.assertIn("preview runtime secret is not allowlisted", PREVIEW_STACK)
+        self.assertIn("validatePreviewRuntimeSecrets(rawSecrets);", PREVIEW_STACK)
+        self.assertIn("/workspace/kortix-preview/runtime-secrets.json", PREVIEW_PROVIDERS)
+        # Platinum passes the mode explicitly; Daytona uses the 0600 default of
+        # encodedFileCommand. Both secret writes must stay owner-only.
+        platinum_write = PREVIEW_PROVIDERS.split(
+            "`${sandboxId}:/workspace/kortix-preview/runtime-secrets.json`", 1
+        )[1].split(");", 1)[0]
+        self.assertIn("'0600'", platinum_write)
+        self.assertIn("mode = '0600'", PREVIEW_PROVIDERS)
+        daytona_write = PREVIEW_PROVIDERS.split(
+            "'/workspace/kortix-preview/runtime-secrets.json',", 1
+        )[1].split("),", 1)[0]
+        self.assertNotIn("'07", daytona_write)
+        # No production identity may reach a preview, on any surface.
+        for path, source in list(PREVIEW_SOURCES.items()) + [("deploy-preview.yml", WORKFLOW)]:
+            self.assertNotIn("kortix-prod-env", source, path)
+            self.assertNotIn("PROD_", source, path)
+            self.assertNotIn("STAGING_DATABASE_URL", source, path)
 
-    def test_close_and_unlabel_run_complete_base_branch_teardown(self):
+
+class PreviewTeardown(unittest.TestCase):
+    """Close, unlabel, new head, and the nightly sweep all delete the sandbox."""
+
+    def test_close_and_unlabel_run_complete_default_branch_teardown(self):
+        teardown = job("teardown")
         self.assertIn("github.event.action == 'closed'", WORKFLOW)
-        self.assertIn("github.event.label.name == 'preview'", WORKFLOW)
-        privileged = WORKFLOW.split("deploy:", 1)[1]
-        for section in privileged.split("- uses: aws-actions/configure-aws-credentials")[1:]:
-            before_script = section.split("ecs-preview.sh", 1)[0]
-            self.assertNotIn("github.event.pull_request.head.sha", before_script)
-        self.assertIn("ecs-preview.sh teardown", WORKFLOW)
+        self.assertIn("github.event.action == 'unlabeled' && github.event.label.name == 'preview'", WORKFLOW)
+        self.assertIn("github.event.action == 'synchronize'", WORKFLOW)
+        # Teardown runs default-branch code, never the pull request head.
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", teardown)
+        # OLD: bash infra/scripts/ecs-preview.sh teardown "$NUM".
+        self.assertIn("bun tests/bin/sandbox-preview.ts teardown", teardown)
+        # OLD: aws ecs delete-service / elbv2 delete-rule / delete-target-group
+        # / ecs deregister-task-definition removed the four ECS resources.
+        # NEW: one sandbox holds the whole stack, so teardown deletes it on both
+        # providers and refuses to touch a sandbox it does not own.
+        teardown_action = cli_action("teardown")
+        self.assertIn("teardownPlatinumPreview({ ...platinum, prNumber })", teardown_action)
+        self.assertIn("teardownDaytonaPreview({ ...daytona, prNumber })", teardown_action)
+        self.assertIn("refused to delete unowned Daytona sandbox", PREVIEW_PROVIDERS)
+        self.assertIn("sandbox.metadata?.owner === 'kortix-preview' &&", PREVIEW_PROVIDERS)
+        self.assertIn("Mark GitHub deployment inactive", teardown)
         self.assertNotIn("branch-scoped Vercel", WORKFLOW)
-        for command in (
-            "aws ecs delete-service",
-            "aws elbv2 delete-rule",
-            "aws elbv2 delete-target-group",
-            "aws ecs deregister-task-definition",
-        ):
-            self.assertIn(command, SCRIPT)
 
-    def test_each_pr_has_isolated_routing_and_preview_secret_delivery(self):
-        self.assertIn('SERVICE="kortix-pr-${PR}"', SCRIPT)
-        self.assertIn('HOST="pr-${PR}.preview-api.kortix.com"', SCRIPT)
-        self.assertIn('WEB_HOST="pr-${PR}.preview.kortix.com"', SCRIPT)
-        self.assertIn('SECRET_NAME="kortix-preview-env"', SCRIPT)
-        self.assertIn('WEB_SECRET_NAME="kortix-preview-web-env"', SCRIPT)
-        self.assertIn('{"name": "INTERNAL_KORTIX_ENV", "value": "preview"}', SCRIPT)
-        self.assertIn('{"name": "KORTIX_WORKERS_ENABLED", "value": "false"}', SCRIPT)
-        self.assertIn('{"name": "KORTIX_SKIP_ENSURE_SCHEMA", "value": "1"}', SCRIPT)
-        self.assertIn('"LLM_GATEWAY_PROXY_TARGET", "value": "http://127.0.0.1:8090"', SCRIPT)
-        self.assertIn('"name": "web"', SCRIPT)
-        self.assertIn('"containerPort": 3000', SCRIPT)
-        self.assertIn('"name": "NEXT_PUBLIC_APP_URL", "value": web_url', SCRIPT)
-        self.assertIn('"name": "NEXT_PUBLIC_BACKEND_URL", "value": backend_url', SCRIPT)
-        self.assertIn('"name": "KORTIX_PUBLIC_VERSION"', SCRIPT)
-        self.assertIn("f\"pr-{family.removeprefix('kortix-pr-')}\"", SCRIPT)
-        self.assertNotIn("kortix-prod-env", SCRIPT)
-        self.assertIn("rollback_deploy", SCRIPT)
-        self.assertIn("PREVIOUS_TASK_DEFINITION", SCRIPT)
-        self.assertIn('MAX_ACTIVE_PREVIEWS="${MAX_ACTIVE_PREVIEWS:-20}"', SCRIPT)
-        self.assertIn('PREVIEW_MAX_AGE_HOURS:-72', SCRIPT)
-        self.assertIn("ecs-preview.sh reconcile 0", WORKFLOW)
-        self.assertIn("preserving its preview", SCRIPT)
-        self.assertNotIn("|| printf closed", SCRIPT)
+    def test_a_new_head_sha_invalidates_the_approval(self):
+        teardown = job("teardown")
+        self.assertIn("gh api -X DELETE", teardown)
+        self.assertIn("labels/preview", teardown)
+        self.assertIn("if: github.event.action == 'synchronize'", teardown)
+
+    def test_the_nightly_sweep_deletes_only_unapproved_sandboxes(self):
+        # OLD: MAX_ACTIVE_PREVIEWS=20 and PREVIEW_MAX_AGE_HOURS=72 bounded a
+        # shared cluster; "preserving its preview" kept the live PR's service.
+        # NEW: the bound is one sandbox per open, labeled PR at its current head
+        # SHA, plus provider-side archive and delete after seven days.
+        self.assertIn("bun tests/bin/sandbox-preview.ts reconcile", job("reconcile"))
+        self.assertIn('cron: "17 6 * * *"', WORKFLOW)
+        reconcile_action = cli_action("reconcile")
+        self.assertIn(
+            "reconcilePlatinumPreviews({ ...platinum, activePullRequests: active })", reconcile_action
+        )
+        self.assertIn(
+            "reconcileDaytonaPreviews({ ...daytona, activePullRequests: active })", reconcile_action
+        )
+        self.assertIn("selectStalePreviewSandboxIds", PREVIEW_CORE)
+        self.assertIn("return !activeSha || activeSha !== sandbox.metadata?.git_sha;", PREVIEW_CORE)
+        self.assertIn(".filter((sandbox) => sandbox.metadata?.owner === 'kortix-preview')", PREVIEW_CORE)
+        self.assertIn("const approved = pull.labels?.some((label) => label.name === 'preview');", PREVIEW_CLI)
+        self.assertIn("const sameRepository = pull.head?.repo?.full_name === repository;", PREVIEW_CLI)
+        self.assertIn("auto_archive_days: 7,", PREVIEW_PROVIDERS)
+        self.assertIn("auto_delete_days: 7,", PREVIEW_PROVIDERS)
+        self.assertIn("autoArchiveInterval: 10_080,", PREVIEW_PROVIDERS)
+        self.assertIn("autoDeleteInterval: 10_080,", PREVIEW_PROVIDERS)
+
+    def test_a_failed_pull_request_query_never_reads_as_no_active_previews(self):
+        # OLD: assertNotIn("|| printf closed") — a shell fallback that turned a
+        # GitHub API error into "the PR is closed" and deleted a live preview.
+        # NEW: the reconciler throws instead of returning an empty active set.
+        self.assertIn(
+            "if (!response.ok) throw new Error(`GitHub pull request list returned ${response.status}`);",
+            PREVIEW_CLI,
+        )
+        self.assertIn("if (pulls.length < 100) return active;", PREVIEW_CLI)
+
+
+class PreviewHealthGate(unittest.TestCase):
+    """The preview proves it is the approved build before it is published."""
+
+    def test_deploy_requires_exact_api_health_and_the_full_deployed_suite(self):
+        # OLD: the workflow polled https://pr-<n>.preview-api.kortix.com/v1/health
+        # for `.environment == "preview"` and `.commit == $COMMIT`, and the
+        # frontend for `.commit`. NEW: the bootstrap script runs the same
+        # assertion against the sandbox origin, then runs the deployed suite.
+        self.assertIn(
+            '\'.status == "ok" and .environment == "preview" and .commit == $sha\'',
+            PREVIEW_CORE,
+        )
+        self.assertIn("docker compose --project-name kortix-${instance}", PREVIEW_CORE)
+        self.assertIn("up -d --wait --wait-timeout 300", PREVIEW_CORE)
+        self.assertIn("condition: service_healthy", PREVIEW_STACK)
+        self.assertIn("pnpm test -- --target-full", PREVIEW_CORE)
+        self.assertIn("Deploy sandbox and run pnpm test -- --target-full", WORKFLOW)
+
+    def test_provider_fallback_hides_no_product_failure(self):
+        # New rule with #6347: `auto` may retry on Daytona only when Platinum
+        # infrastructure fails. A failing test run or a controller bug must
+        # surface, not trigger a second, greener attempt.
+        self.assertIn("if (!(error instanceof PreviewInfrastructureError)) throw error;", PREVIEW_CORE)
+        self.assertIn("if (input.provider === 'platinum') return runners.platinum(input);", PREVIEW_CORE)
+        self.assertIn("if (input.provider === 'daytona') return runners.daytona(input);", PREVIEW_CORE)
+        self.assertIn("PREVIEW_SANDBOX_PROVIDER must be auto, platinum, or daytona", PREVIEW_CLI)
+
+
+class SharedPreviewEdge(unittest.TestCase):
+    """The ECS preview root no longer serves previews but is still applied."""
+
+    # `infra/terraform/environments/preview` provisions a real ALB, WAF, DNS
+    # records, and a GitHub OIDC role in account 935064898258. #6347 stopped
+    # using them; it did not destroy them. Until the root is removed, its
+    # guardrails stay gated here. Retiring it must delete this class and the
+    # root together.
 
     def test_shared_edge_has_tls_waf_logs_and_preview_only_oidc_role(self):
         for fragment in (
@@ -133,7 +471,7 @@ class PreviewRuntimeContract(unittest.TestCase):
             self.assertIn(fragment, TERRAFORM)
 
     def test_database_egress_and_bootstrap_are_bounded(self):
-        self.assertIn('cidr_blocks = var.postgres_egress_cidrs', TERRAFORM)
+        self.assertIn("cidr_blocks = var.postgres_egress_cidrs", TERRAFORM)
         self.assertIn('!contains(var.postgres_egress_cidrs, "0.0.0.0/0")', VARIABLES)
         for heading in ("## Existing-resource import", "## Cutover", "## Reconciliation and rollback"):
             self.assertIn(heading, README)


### PR DESCRIPTION
## Problem

`infra/scripts/test-ecs-preview-runtime.py` fails 5 of 7 tests on `main`.

PR #6347 (`7074ffd25e`) moved pull request previews from
`infra/scripts/ecs-preview.sh` (per-PR ECS Fargate service behind
`pr-<n>.preview.kortix.com`) to `tests/bin/sandbox-preview.ts` (one warm
Platinum or Daytona sandbox per PR running the full self-host distribution).
The contract test was not updated. It still asserts `ecs-preview.sh teardown`,
per-PR ALB hostnames, and `count("persist-credentials: false") == 3` — that
count is 6 now, because #6347 added three more checkouts.

That test is the `preview runtime contract tests` step of the `fmt + validate`
job in `terraform-ci.yml`, so **every PR touching `infra/terraform/**` fails**,
including #6358.

Baseline on `main`:

```
$ python3 infra/scripts/test-ecs-preview-runtime.py
F.FFFF.
Ran 7 tests — FAILED (failures=5)
AssertionError: 'ecs-preview.sh teardown' not found in ...
AssertionError: 6 != 3
```

## What changed

1. **`infra/scripts/test-ecs-preview-runtime.py` — rewritten** against the
   current architecture. It now reads `.github/workflows/deploy-preview.yml`
   plus the four files that are the whole preview runtime
   (`tests/bin/sandbox-preview.ts`,
   `tests/src/core/{sandbox-preview,sandbox-preview-providers,preview-stack}.ts`)
   and the still-applied `infra/terraform/environments/preview` root.
   22 tests in 6 classes. Every old assertion is either re-expressed or kept as
   a comment stating which rule replaced it.
2. **`.github/workflows/terraform-ci.yml`** — added `infra/scripts/**`,
   `.github/workflows/deploy-preview.yml`, and the three preview runtime source
   paths to the `pull_request` `paths` filter. The gate asserted files it never
   ran against; a preview-workflow change could break these invariants without
   this job ever starting.

Filename kept as `test-ecs-preview-runtime.py`: the ECS preview Terraform root
still exists and is still asserted here, and `terraform-ci.yml` invokes the
test by path.

## Assertion mapping — old to new

### `test_deploy_requires_exact_api_and_frontend_health`

| Old assertion | New assertion / rationale |
| --- | --- |
| `needs: [authorize, build-api, build-gateway, build-web]` | Kept, scoped to the `deploy` job body. |
| `head.repo.full_name == github.repository` | Kept, plus the script-level `[ "$head_repo" = "$REPO" ]` check that also covers the new `workflow_dispatch` entry point. |
| `pull_request_target:` / `branches: [main]` | Kept. |
| `ref: ${{ github.event.repository.default_branch }}` | Kept, asserted inside both the `deploy` and `teardown` job bodies. |
| `[ "$api_environment" = "preview" ]` | The bootstrap script's health gate `'.status == "ok" and .environment == "preview" and .commit == $sha'`, plus `INTERNAL_KORTIX_ENV: 'preview'` in `preview-stack.ts`. |
| `[ "$api_commit" = "$COMMIT" ]` | Same jq gate, plus `test "$actual_sha" = "${input.sha}"` after the in-sandbox checkout. |
| `[ "$web_commit" = "$COMMIT" ]` | `KORTIX_COMMIT: input.sha` + `KE2E_EXPECT_SHA: input.sha`, `docker compose … up -d --wait`, and `condition: service_healthy` on the frontend. There is no separate frontend host to poll. |
| `kortix/kortix-frontend:pr-${{ github.event.pull_request.head.sha }}` | All three image tags asserted with `needs.authorize.outputs.sha`, plus a new rule: `github.event.pull_request.head.sha` may appear exactly **once**, in the `authorize` job env. |
| `web_host="pr-${NUM}.preview.kortix.com"` | **Obsolete** — no per-PR DNS. Replaced by `previewSandboxName` → `kortix-preview-pr-<n>` and a provider-issued origin. |
| `WEB_PROTECTION_PASSWORD`, `cookie_only` | **Obsolete** — the HTTP basic-auth gate existed because the preview sat on a guessable public wildcard hostname. Replaced by `sandbox preview URL must use credential-free HTTPS` validation plus the data-plane isolation rules below. See "Posture change" — this is a real delta, not an equivalence. |
| `not in: Vercel`, `VERCEL_`, `Argo CD`, `submodule … --remote` | Kept. |

### `test_pr_code_builds_without_credentials_and_publish_never_runs_it`

| Old assertion | New assertion / rationale |
| --- | --- |
| `count("persist-credentials: false") == 3` | Replaced by a per-step check: every `actions/checkout` step body in the workflow must contain it (6 today, and adding a job cannot silently regress it). |
| `count("push: false") == 3`, `count("type=docker,dest=/tmp/preview-") == 3`, `count("actions/download-artifact@v8") == 3` | Kept. |
| `count("actions/upload-artifact@v7") == 3` | Now 4 (the deploy job uploads test results). Replaced by a per-build-job check: exactly one upload with `if-no-files-found: error`. |
| build jobs: `contents: read`, no `DOCKERHUB_`, no `docker/login-action`, no `push: true` | Kept, and tightened: no `${{ secrets.` at all, no `aws-actions/configure-aws-credentials`, `submodules: false`. |
| deploy: `docker/login-action@v3`, `docker load --input`, `docker push`, not `docker run` | Kept, plus `docker image inspect --format '{{.Os}}/{{.Architecture}}' … linux/amd64`, no `docker compose`, and **no checkout of the PR SHA** on the credentialed runner. |
| — | **New:** `continue-on-error: true` on the preview step must be paired with `if: steps.preview.outcome != 'success'` + `exit 1`, so a failed preview cannot report green. |

### `test_preview_label_approves_one_exact_sha`

| Old assertion | New assertion / rationale |
| --- | --- |
| `action == 'labeled'`, `label.name == 'preview'` | Kept. |
| `case "$permission" in` | Kept in both the `authorize` and `deploy` bodies. |
| `admin\|write)` | Updated to `admin\|maintain\|write) ;;` (#6347 widened it), plus the explicit reject arm. |
| `not in: ['labeled','opened','synchronize','reopened']` | Kept. |
| `action == 'synchronize'`, `gh api -X DELETE`, `labels/preview` | Kept, scoped to the `teardown` job with `if: github.event.action == 'synchronize'`. |
| `not in: KORTIX_PREVIEW_APPROVED_SHA` | Kept. |
| — | **New, for the added `workflow_dispatch` entry point:** same-repo check, `^[0-9a-f]{40}$` SHA shape, live-head staleness check, label presence, provider allowlist, `refs/pull/<n>/head`, and the `pnpm-lock.yaml@sha` → `^[0-9a-f]{64}$` lockfile pin. |
| — | **New:** the sandbox itself verifies what it ran — `checkout --detach --force FETCH_HEAD`, `test "$actual_sha" = "${input.sha}"`, `pnpm install --offline --frozen-lockfile`. |

### `test_close_and_unlabel_run_complete_base_branch_teardown`

| Old assertion | New assertion / rationale |
| --- | --- |
| `action == 'closed'`, label name | Kept, including the `unlabeled` arm. |
| loop: no `head.sha` before `ecs-preview.sh` in any AWS-credentialed section | **Obsolete mechanism** (no AWS credentials exist now). Replaced by two stronger global rules: the workflow contains **no** `aws-actions/configure-aws-credentials` and **no** `id-token: write`, and `github.event.pull_request.head.sha` appears exactly once, in `authorize`. |
| `ecs-preview.sh teardown` | `bun tests/bin/sandbox-preview.ts teardown`. |
| `aws ecs delete-service`, `elbv2 delete-rule`, `elbv2 delete-target-group`, `ecs deregister-task-definition` | One sandbox holds the whole stack: teardown calls **both** `teardownPlatinumPreview` and `teardownDaytonaPreview` (asserted inside the `teardown` branch of the CLI, not anywhere in the file), each refusing unowned sandboxes, plus `Mark GitHub deployment inactive`. |
| `not in: branch-scoped Vercel` | Kept. |

### `test_each_pr_has_isolated_routing_and_preview_secret_delivery`

| Old assertion | New assertion / rationale |
| --- | --- |
| `SERVICE="kortix-pr-${PR}"` | `` return `kortix-preview-pr-${prNumber}`; `` + `invalid preview PR number` guard. |
| `HOST=`/`WEB_HOST=` per PR | `name: previewSandboxName(input.prNumber)` in both providers; origin validated as credential-free HTTPS; no `kortix.com` string in any preview source. |
| `SECRET_NAME="kortix-preview-env"`, `WEB_SECRET_NAME=…` | `PREVIEW_RUNTIME_SECRET_ALLOWLIST` (all 9 names asserted), `validatePreviewRuntimeSecrets`, `preview runtime secret is not allowlisted`, and delivery as a `0600` `runtime-secrets.json` inside the sandbox (both providers). |
| `INTERNAL_KORTIX_ENV = preview` | `INTERNAL_KORTIX_ENV: 'preview'`. |
| `KORTIX_WORKERS_ENABLED = false` | `KORTIX_WORKERS_ENABLED: 'false'` + `SCHEDULER_ENABLED` + `KORTIX_TRIGGER_SCHEDULER_ENABLED`. |
| `KORTIX_SKIP_ENSURE_SCHEMA = 1` | **Obsolete** — that flag existed because previews shared a database. Replaced by proof the database is in-sandbox: `@supabase-db:5432` runtime URL and `127.0.0.1:15432` test URL. |
| `LLM_GATEWAY_PROXY_TARGET http://127.0.0.1:8090` | The Caddy edge: `reverse_proxy llm-gateway:8090` behind `handle_path /_gateway/*`, only `0.0.0.0:8080:8080` published, DB bound to `127.0.0.1:15432`. |
| `"name": "web"`, `"containerPort": 3000` | `reverse_proxy frontend:3000` (+ `reverse_proxy kortix-api:8008`). |
| `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_BACKEND_URL` | `PUBLIC_URL`, `API_PUBLIC_URL`, `SUPABASE_PUBLIC_URL`, `CORS_ALLOWED_ORIGINS`, `KORTIX_PUBLIC_APP_URL` all bound to the one validated origin. |
| `KORTIX_PUBLIC_VERSION` | `` KORTIX_VERSION: `pr-${input.sha}` `` + `KORTIX_COMMIT: input.sha`. |
| `f"pr-{family.removeprefix('kortix-pr-')}"` | **Obsolete** — ECS task-definition family parsing. Covered by `previewSandboxName`. |
| `not in: kortix-prod-env` | Widened: no `kortix-prod-env`, no `PROD_`, no `STAGING_DATABASE_URL` in the workflow **or** any of the four preview sources. |
| `rollback_deploy`, `PREVIOUS_TASK_DEFINITION` | **Obsolete** — a sandbox is disposable, so there is nothing to roll back in place. Replaced by `replaceExistingPlatinumPreview` / `replaceExistingDaytonaPreview` (delete-before-create) + `refused to replace unowned Daytona sandbox`. |
| `MAX_ACTIVE_PREVIEWS="${MAX_ACTIVE_PREVIEWS:-20}"` | The bound is now structural: one stable sandbox name per PR, replace-before-create, cross-provider `staleProviderCleanup` after a fallback, and reconcile deletes everything not backed by an open labeled PR. |
| `PREVIEW_MAX_AGE_HOURS:-72` | Provider-side TTL: `auto_archive_days: 7` / `auto_delete_days: 7` (Platinum), `autoArchiveInterval` / `autoDeleteInterval: 10_080` (Daytona), plus the daily `cron: "17 6 * * *"`. |
| `ecs-preview.sh reconcile 0` | `bun tests/bin/sandbox-preview.ts reconcile`, with `reconcilePlatinum…` and `reconcileDaytona…` asserted inside the `reconcile` branch. |
| `"preserving its preview"` | `selectStalePreviewSandboxIds`: keep only `owner === 'kortix-preview'` sandboxes whose PR is open, labeled `preview`, same-repo, and whose `git_sha` matches the current head. |
| `not in: "\|\| printf closed"` | The same bug class, expressed in the new code: `if (!response.ok) throw new Error('GitHub pull request list returned …')` — an API error must never read as "no active previews" and delete live sandboxes. |

### Kept unchanged

`test_shared_edge_has_tls_waf_logs_and_preview_only_oidc_role` and
`test_database_egress_and_bootstrap_are_bounded` are unchanged, moved into a
`SharedPreviewEdge` class with a comment: #6347 stopped using
`infra/terraform/environments/preview`, it did not destroy it. The ALB, WAF,
DNS records, and the `kortix-gha-preview-deploy` OIDC role still exist in
account `935064898258`, so their guardrails still gate. Retiring the root must
delete the class and the root together.

### New rules with no old counterpart

- Provider fallback may not mask a product failure: `auto` retries on Daytona
  only for `PreviewInfrastructureError`; a non-zero test exit or a controller
  bug propagates.
- `infra/scripts/ecs-preview.sh` must stay disconnected from every workflow.

## Verification

```
$ python3 infra/scripts/test-ecs-preview-runtime.py
Ran 22 tests in 0.002s
OK

$ python3 infra/terraform/scripts/test_audit_nacl_admin_ports.py
9/9 passed

$ python3 infra/terraform/scripts/test_web_waf_associations.py
Ran 3 tests — OK

$ terraform fmt -check -recursive infra/terraform
FMT_OK
```

Green is not proof a contract test works, so 14 regressions were injected one
at a time; the suite must fail on each. All 14 were detected, and the tree was
restored green afterwards:

```
baseline: PASS
DETECTED: re-add credential persistence
DETECTED: remove the label approval gate
DETECTED: build an unapproved SHA
DETECTED: build job gets a registry secret
DETECTED: weaken the writer permission check
DETECTED: give the pipeline an AWS identity back
DETECTED: re-wire the disconnected ECS path
DETECTED: drop the sandbox SHA verification
DETECTED: serve a non-preview environment
DETECTED: allow an arbitrary runtime secret
DETECTED: let an API error read as no active previews
DETECTED: keep a stale-SHA sandbox alive
DETECTED: accept a credentialed preview origin
DETECTED: teardown only one provider
restored: PASS
missed: none
```

The first pass missed "teardown only one provider" because
`teardownDaytonaPreview({ ...daytona, prNumber })` also appears in the deploy
path; the assertion is now scoped to the `teardown` branch of the CLI.

## Posture change this test now records (not introduced here)

#6347 removed the preview HTTP password. Old previews sat on a guessable
`pr-<n>.preview.kortix.com` and required `WEB_PROTECTION_PASSWORD`. New
previews sit on an unguessable provider origin that the workflow posts in a
public PR comment, with `KORTIX_RESTRICT_ACCOUNT_CREATION: 'false'`. Anyone
with the link can sign up on a running preview. The blast radius is bounded by
the isolation this test now pins: own PostgreSQL and Supabase, Mailpit-only
email, an allowlisted secret set, no production identity. Flagging it, not
changing it — reverting the tradeoff is a separate decision.

## Follow-up, not in this PR

`infra/scripts/ecs-preview.sh` (429 lines) and
`infra/terraform/environments/preview` are now unreachable from any workflow,
but the AWS resources and the `kortix-gha-preview-deploy` OIDC role — which
trusts `repo:kortix-ai/suna:pull_request` — remain live. Decide whether to
retire them or keep them warm.
