### PR TITLE
fix(gateway): normalize message-only context overflow

### DIFF
--- a/apps/api/src/llm-gateway/README.md
+++ b/apps/api/src/llm-gateway/README.md
@@ -142,6 +142,10 @@ capped at 2,000 characters. The full chain is also stored in
 If any exhausted candidate reports `context_length_exceeded`, the top-level
 `code`, nested `error.code`, and nested `error.type` keep that canonical value.
 The HTTP status can remain `502` because the configured route was exhausted.
+The gateway also normalizes message-only overflow responses. For example,
+OpenRouter can return numeric `error.code: 400` with `maximum context length`
+only in `error.message`. This response becomes `context_length_exceeded` while
+the original HTTP status and complete message remain available.
 OpenCode 1.17.11 reads nested `error.code` and converts this response into a
 `ContextOverflowError`. Its session processor then creates an automatic
 compaction turn. A later fallback timeout must not replace this classification.

--- a/packages/llm-gateway/src/http/parse-upstream-error.test.ts
+++ b/packages/llm-gateway/src/http/parse-upstream-error.test.ts
@@ -45,6 +45,22 @@ describe('extractUpstreamErrorDetail', () => {
     ).toEqual({ message: 'nope', code: 400 });
   });
 
+  test('normalizes a numeric OpenRouter context overflow code from its message', () => {
+    expect(
+      extractUpstreamErrorDetail({
+        error: {
+          message:
+            "This endpoint's maximum context length is 1050000 tokens. However, you requested about 1550000 tokens.",
+          code: 400,
+        },
+      }),
+    ).toEqual({
+      message:
+        "This endpoint's maximum context length is 1050000 tokens. However, you requested about 1550000 tokens.",
+      code: 'context_length_exceeded',
+    });
+  });
+
   test('empty message inside error object → falls through', () => {
     expect(extractUpstreamErrorDetail({ error: { message: '' } })).toBeNull();
   });

--- a/packages/llm-gateway/src/http/parse-upstream-error.ts
+++ b/packages/llm-gateway/src/http/parse-upstream-error.ts
@@ -26,6 +26,31 @@ export interface UpstreamErrorDetail {
   code?: string | number;
 }
 
+const CONTEXT_OVERFLOW_PATTERNS = [
+  /context length (?:is )?exceeded/i,
+  /exceeds? (?:the )?context window/i,
+  /maximum context length is \d+ tokens[\s\S]*\brequested\b/i,
+  /prompt is too long/i,
+  /input is too long/i,
+  /(?:input|prompt)[\s\S]*exceeds?[\s\S]*context (?:limit|window)/i,
+];
+
+/**
+ * Convert provider-specific context overflow responses into the one semantic
+ * code OpenAI-compatible clients use. Some providers return only HTTP 400 (or
+ * `invalid_request_error`) and put the actual classification in the message.
+ */
+export function normalizeUpstreamErrorCode(
+  code: string | number | undefined,
+  message: string,
+): string | number | undefined {
+  if (code === 'context_length_exceeded') return code;
+  if (CONTEXT_OVERFLOW_PATTERNS.some((pattern) => pattern.test(message))) {
+    return 'context_length_exceeded';
+  }
+  return code;
+}
+
 /**
  * Mine a PARSED upstream error object (the shape `{error:{message,code,type,
  * param}}` OpenAI-compatible upstreams use, the Anthropic shape
@@ -49,7 +74,8 @@ export function extractUpstreamErrorDetail(parsed: unknown): UpstreamErrorDetail
           : typeof err.type === 'string' && err.type.length > 0
             ? err.type
             : undefined;
-      return { message, ...(code !== undefined ? { code } : {}) };
+      const normalizedCode = normalizeUpstreamErrorCode(code, message);
+      return { message, ...(normalizedCode !== undefined ? { code: normalizedCode } : {}) };
     }
   }
 
@@ -62,7 +88,8 @@ export function extractUpstreamErrorDetail(parsed: unknown): UpstreamErrorDetail
         : typeof root.type === 'string' && root.type.length > 0
           ? root.type
           : undefined;
-    return { message, ...(code !== undefined ? { code } : {}) };
+    const normalizedCode = normalizeUpstreamErrorCode(code, message);
+    return { message, ...(normalizedCode !== undefined ? { code: normalizedCode } : {}) };
   }
 
   return null;

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -320,6 +320,10 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
           provider: descriptor.provider,
           status: err.status,
         });
+        const clientErrorCode =
+          upstreamError.code === 'context_length_exceeded'
+            ? 'context_length_exceeded'
+            : 'upstream_client_error';
         emit({
           ...trace,
           resolvedModel: descriptor.resolvedModel,
@@ -327,7 +331,7 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
           billingMode: descriptor.billingMode,
           status: err.status,
           ok: false,
-          errorCode: 'upstream_client_error',
+          errorCode: clientErrorCode,
           errorMessage: upstreamError.message,
           attempts,
           candidatesTried: tried,
@@ -339,14 +343,20 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
           response: json(
             gatewayErrorBody({
               message: upstreamError.message,
-              code: 'upstream_client_error',
-              upstreamCode: upstreamError.code,
+              code: clientErrorCode,
+              upstreamCode:
+                clientErrorCode === 'context_length_exceeded'
+                  ? clientErrorCode
+                  : upstreamError.code,
               upstreamStatus: err.status,
               provider: descriptor.provider,
               requestedModel: trace.requestedModel ?? '',
               resolvedModel: descriptor.resolvedModel ?? trace.requestedModel ?? '',
               requestId,
-              suggestion: suggestionFor(err.status),
+              suggestion:
+                clientErrorCode === 'context_length_exceeded'
+                  ? 'Compact the conversation or reduce the input, then retry.'
+                  : suggestionFor(err.status),
               attemptFailures,
             }),
             err.status,

--- a/packages/llm-gateway/src/pipeline/failure-chain.ts
+++ b/packages/llm-gateway/src/pipeline/failure-chain.ts
@@ -1,5 +1,9 @@
 import type { GatewayAttemptFailure, GatewayAttemptFailureStage } from '../domain';
-import { extractUpstreamErrorDetail, parseUpstreamErrorBody } from '../http/parse-upstream-error';
+import {
+  extractUpstreamErrorDetail,
+  normalizeUpstreamErrorCode,
+  parseUpstreamErrorBody,
+} from '../http/parse-upstream-error';
 import type { SseErrorFrame } from '../usage';
 
 const MAX_FAILURE_MESSAGE_CHARS = 500;
@@ -52,15 +56,24 @@ export function appendAttemptFailure(
 /** Prefer the provider's semantic code over its numeric transport status. */
 export function errorFrameCode(frame: SseErrorFrame): string | number {
   const upstreamCode = frame.detail?.upstream_code;
-  if (typeof upstreamCode === 'string' || typeof upstreamCode === 'number') return upstreamCode;
+  if (typeof upstreamCode === 'string' || typeof upstreamCode === 'number') {
+    return normalizeUpstreamErrorCode(upstreamCode, frame.message) ?? upstreamCode;
+  }
   const fromData = extractUpstreamErrorDetail(frame.detail?.data);
-  if (typeof fromData?.code === 'string') return fromData.code;
+  if (typeof fromData?.code === 'string' || typeof fromData?.code === 'number') {
+    return normalizeUpstreamErrorCode(fromData.code, fromData.message) ?? fromData.code;
+  }
   const responseBody = frame.detail?.responseBody;
   if (typeof responseBody === 'string') {
     const fromBody = parseUpstreamErrorBody(responseBody);
-    if (typeof fromBody.code === 'string') return fromBody.code;
+    if (typeof fromBody.code === 'string' || typeof fromBody.code === 'number') {
+      return normalizeUpstreamErrorCode(fromBody.code, fromBody.message) ?? fromBody.code;
+    }
   }
-  return frame.code ?? fromData?.code ?? 'upstream_stream_error';
+  return (
+    normalizeUpstreamErrorCode(frame.code ?? fromData?.code, frame.message) ??
+    'upstream_stream_error'
+  );
 }
 
 export function failureChainMessage(

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -398,6 +398,50 @@ describe("gateway.chatCompletions", () => {
     expect(bCalled).toBe(false);
   });
 
+  test("normalizes an OpenRouter numeric 400 context overflow for OpenCode compaction", async () => {
+    const message =
+      "This endpoint's maximum context length is 1050000 tokens. However, you requested about 1550000 tokens (1550000 of text input).";
+    const fetchImpl: FetchImpl = async () =>
+      new Response(JSON.stringify({ error: { message, code: 400 } }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    const { hooks, traces } = makeHooks();
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","messages":[{"role":"user","content":"oversized"}]}',
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      message,
+      code: "context_length_exceeded",
+      upstream_code: "context_length_exceeded",
+      upstream_status: 400,
+      error: {
+        message,
+        type: "context_length_exceeded",
+        code: "context_length_exceeded",
+      },
+      attempt_failures: [
+        expect.objectContaining({
+          status: 400,
+          code: "context_length_exceeded",
+          message,
+        }),
+      ],
+    });
+    await flush();
+    expect(traces[0]).toMatchObject({
+      status: 400,
+      errorCode: "context_length_exceeded",
+      attemptFailures: [
+        expect.objectContaining({ code: "context_length_exceeded", message }),
+      ],
+    });
+  });
+
   test("returns 502 when all candidates are down", async () => {
     const fetchImpl: FetchImpl = async () =>
       new Response("boom", { status: 500 });
@@ -1696,16 +1740,16 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     // 400, the upstream's real status — NOT a generic 502 "Bad Gateway".
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.code).toBe("upstream_error");
+    expect(body.code).toBe("context_length_exceeded");
     // The REAL upstream message reaches the caller, not a generic "Bad Request".
     expect(body.message).toContain("context length exceeded from messages");
     expect(body.error.message).toContain("context length exceeded from messages");
-    expect(body.upstream_code).toBe(400);
+    expect(body.upstream_code).toBe("context_length_exceeded");
     expect(body.suggestion).toContain("switch to another model");
     await flush();
     expect(traces[0].ok).toBe(false);
     expect(traces[0].status).toBe(400);
-    expect(traces[0].errorCode).toBe("upstream_error");
+    expect(traces[0].errorCode).toBe("context_length_exceeded");
     expect(traces[0].errorMessage).toContain("context length exceeded from messages");
   });
 


### PR DESCRIPTION
## Problem

A live dev request below the gateway's 8 MiB body limit exceeded the model's 1,050,000-token context window. OpenRouter returned HTTP 400 with the concrete overflow message, but its JSON carried numeric `error.code: 400`.

The gateway preserved the message but returned top-level `code: upstream_client_error`. OpenCode therefore could not classify the failure as `ContextOverflowError` or start automatic compaction.

Live request ID: `req_msnt5gskeo1tyf02`.

## Change

- Normalize strong provider overflow messages to `context_length_exceeded`.
- Preserve the original HTTP status and complete provider message.
- Apply the canonical code to direct 4xx responses, streaming error frames, attempt chains, traces, and nested OpenAI-compatible errors.
- Return a compaction-specific recovery suggestion.
- Document message-only provider overflow behavior.

## Verification

- Failing tests first: 2 failed (`OpenRouter numeric 400` parser and end-to-end gateway response).
- `bun test packages/llm-gateway/src/http/parse-upstream-error.test.ts packages/llm-gateway/src/pipeline/failure-chain.test.ts packages/llm-gateway/src/pipeline/handler.test.ts`: 96 passed, 0 failed.
- `pnpm --filter @kortix/llm-gateway typecheck`: exit 0.
- `pnpm --filter @kortix/llm-gateway test`: 395 passed, 0 failed.
- `pnpm --filter @kortix/llm-gateway-server typecheck`: exit 0.
- `pnpm --filter @kortix/llm-gateway-server test`: 29 passed, 0 failed.
- `bun test packages/sdk/src/core/turns/errors.test.ts packages/sdk/src/core/turns/state.test.ts packages/sdk/src/core/turns/classify.test.ts`: 55 passed, 0 failed.
- `git diff --check`: exit 0.
