### PR TITLE
Stabilize preview and full local test gates

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -54,6 +54,7 @@ Do not replace this package contract with a separate CI workflow.
 
 Browser and full modes start local Supabase, migrations, API, gateway, and web.
 They reuse a running API only when it proves the deterministic test profile.
+Local browser runs use two Playwright workers. CI browser shards use one worker.
 
 Run the narrowest relevant command first. Run `pnpm test` before handoff. Run
 `pnpm test -- --full` for testing infrastructure, broad refactors, and release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,12 @@ jobs:
             core) bun tests/bin/sandbox-ci.ts ;;
             browser-1) bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=1/2 ;;
             browser-2) bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=2/2 ;;
-            packages) bun tests/bin/sandbox-ci.ts --packages-only ;;
+            packages)
+              if [[ "$TEST_MODE" == "full" ]]; then
+                export KORTIX_PACKAGE_SKIP_SDK_TESTS=1
+              fi
+              bun tests/bin/sandbox-ci.ts --packages-only
+              ;;
             *) echo "::error::Invalid test lane: $TEST_LANE"; exit 2 ;;
           esac
       - name: Delete the sandbox worker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,7 @@ See `tests/e2e/helpers/auth.ts` for the exact calls.
 - `pnpm test -- --sdk-only` runs only `packages/sdk` tests.
 - `pnpm test -- --browser-only` runs Playwright browser journeys. It starts the
   deterministic local stack.
+- Local browser runs use two Playwright workers. CI browser shards use one.
 - `pnpm test -- --packages-only` runs every app/package test and publish check.
 - `pnpm test -- --full` adds browser journeys and every app/package test. It
   starts the deterministic local stack.

--- a/apps/api/src/__tests__/unit-ci-api-suite-runs.test.ts
+++ b/apps/api/src/__tests__/unit-ci-api-suite-runs.test.ts
@@ -29,7 +29,9 @@ describe('the kortix-api suite actually runs on pull requests', () => {
     expect(sandboxJob).toContain(
       'browser-2) bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=2/2 ;;',
     );
-    expect(sandboxJob).toContain('packages) bun tests/bin/sandbox-ci.ts --packages-only ;;');
+    expect(sandboxJob).toContain('packages)');
+    expect(sandboxJob).toContain('export KORTIX_PACKAGE_SKIP_SDK_TESTS=1');
+    expect(sandboxJob).toContain('bun tests/bin/sandbox-ci.ts --packages-only');
     expect(sandboxJob).toContain('SANDBOX_TEST_SHA:');
     expect(sandboxJob).toContain('SANDBOX_TEST_REF:');
     expect(sandboxJob).toContain('TEST_SANDBOX_PROVIDER:');
@@ -47,7 +49,7 @@ describe('the kortix-api suite actually runs on pull requests', () => {
   test('full mode reaches every package and app test through package-quality', () => {
     expect(packageQuality).toContain("'./packages/**'");
     expect(packageQuality).toContain("'./apps/**'");
-    expect(packageQuality).toContain("KORTIX_TEST_TIMEOUT_MS: '15000'");
+    expect(packageQuality).toContain("KORTIX_TEST_TIMEOUT_MS: '30000'");
   });
 
   test('the unit suite runs off the committed fake env, not dotenvx', () => {
@@ -65,7 +67,7 @@ describe('the kortix-api suite actually runs on pull requests', () => {
     expect(testScript).toContain('exit 1');
   });
 
-  test('the package timeout preserves declared 15-second load budgets', () => {
+  test('the package timeout preserves each package default outside the loaded package lane', () => {
     expect(testScript).toContain('KORTIX_TEST_TIMEOUT_MS:-15000');
   });
 

--- a/apps/cli/src/__tests__/sessions.e2e.test.ts
+++ b/apps/cli/src/__tests__/sessions.e2e.test.ts
@@ -66,9 +66,10 @@ describe('sessions new CLI flow', () => {
     writeFileSync(join(repo, 'README.md'), '# test repo\n', 'utf8');
     git(['add', 'README.md'], repo);
     git(['commit', '-m', 'initial'], repo);
-    git(['-c', 'init.defaultBranch=main', 'init', '--bare', origin]);
+    // Copy the initial repository directly. Repeating a setup push in every
+    // test can wait on Git maintenance locks during the loaded package lane.
+    git(['clone', '--quiet', '--bare', repo, origin]);
     git(['remote', 'add', 'origin', origin], repo);
-    git(['push', '--quiet', 'origin', 'main'], repo);
 
     mkdirSync(join(repo, '.kortix'), { recursive: true });
     writeFileSync(

--- a/tests/README.md
+++ b/tests/README.md
@@ -237,6 +237,9 @@ CLI contracts. The browser suite does not claim complete customer-journey
 coverage. A browser journey is incomplete when it skips for a missing provider,
 OAuth, or mutation capability; report that skip explicitly.
 
+Local browser runs use two Playwright workers. Four workers make cold Next.js
+route compilation slower and can exceed the five-minute journey timeout.
+
 The browser lane uses the current worktree web, API, and Supabase ports. It
 starts and owns the deterministic local stack. Run it directly:
 

--- a/tests/bin/package-quality.ts
+++ b/tests/bin/package-quality.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 const root = resolve(import.meta.dir, '../..');
+const skipSdkTests = process.env.KORTIX_PACKAGE_SKIP_SDK_TESTS === '1';
 
 async function run(
   command: string[],
@@ -129,7 +130,9 @@ async function runWorkspaceTests(
     {
       env: {
         ...process.env,
-        KORTIX_TEST_TIMEOUT_MS: '15000',
+        // The CLI includes an intentional 11-second idle-stream contract.
+        // Concurrent API and agent workers can push it past 15 seconds.
+        KORTIX_TEST_TIMEOUT_MS: '30000',
         ...env,
       },
     },
@@ -176,6 +179,7 @@ await runAll([
       '!@kortix/cli',
       '!@kortix/sandbox-agent-server',
       '!@kortix/db',
+      ...(skipSdkTests ? ['!@kortix/sdk'] : []),
     ],
     2,
   ),

--- a/tests/bin/sandbox-ci.ts
+++ b/tests/bin/sandbox-ci.ts
@@ -9,6 +9,7 @@ const repository = process.env.GITHUB_REPOSITORY || 'kortix-ai/suna';
 const runId = process.env.SANDBOX_TEST_RUN_ID || process.env.GITHUB_RUN_ID || `local-${Date.now()}`;
 const runAttempt = process.env.GITHUB_RUN_ATTEMPT || '1';
 const testArgs = process.argv.slice(2);
+const skipSdkPackageTests = process.env.KORTIX_PACKAGE_SKIP_SDK_TESTS === '1';
 
 process.exitCode = await runSandboxCi({
   provider: parseSandboxCiProvider(process.env.TEST_SANDBOX_PROVIDER),
@@ -21,6 +22,7 @@ process.exitCode = await runSandboxCi({
     runId,
     runAttempt,
     testArgs,
+    skipSdkPackageTests,
     root,
   },
   daytona: {
@@ -34,6 +36,7 @@ process.exitCode = await runSandboxCi({
     runId,
     runAttempt,
     testArgs,
+    skipSdkPackageTests,
     root,
   },
 });

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -7,10 +7,10 @@ export function resolveBrowserWorkers(value: string | undefined, ci: boolean): n
   const configuredWorkers = Number.parseInt(value ?? '', 10);
   if (Number.isFinite(configuredWorkers) && configuredWorkers > 0) return configuredWorkers;
   // The warm Daytona lane has 6 vCPU and 12 GiB RAM. One worker keeps cold
-  // Next.js route compilation below the guest memory limit. Deployed target
-  // runs can override this independently.
+  // Next.js route compilation below the guest memory limit. Two local workers
+  // keep cold compilation below the full-suite deadline on development Macs.
   if (ci) return 1;
-  return 4;
+  return 2;
 }
 
 const workers = resolveBrowserWorkers(process.env.E2E_BROWSER_WORKERS, Boolean(process.env.CI));

--- a/tests/src/core/daytona-ci.ts
+++ b/tests/src/core/daytona-ci.ts
@@ -36,6 +36,7 @@ export interface DaytonaCiInput {
   runId: string;
   runAttempt: string;
   testArgs: string[];
+  skipSdkPackageTests?: boolean;
   root: string;
 }
 

--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -171,7 +171,21 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
       command: [...flows.command, '--api-workers', '4'],
     };
     const fullBrowser: LocalTestLane = { ...browser };
-    const lanes = [fullFlows, runnerUnit, routeCoverage, worktreeUnit, fullBrowser, packageQuality];
+    const fullPackageQuality: LocalTestLane = {
+      ...packageQuality,
+      // Full mode runs the SDK as a named lane. Keep package-only mode complete,
+      // but do not execute the same SDK tests twice inside one full run.
+      env: { KORTIX_PACKAGE_SKIP_SDK_TESTS: '1' },
+    };
+    const lanes = [
+      fullFlows,
+      sdk,
+      runnerUnit,
+      routeCoverage,
+      worktreeUnit,
+      fullBrowser,
+      fullPackageQuality,
+    ];
     return {
       mode: 'full',
       lanes,
@@ -179,9 +193,9 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
       // database. Keep browser verification after REST. Package quality stays
       // exclusive because concurrent package workers double both lane times.
       stages: [
-        [fullFlows, runnerUnit, routeCoverage, worktreeUnit],
+        [fullFlows, sdk, runnerUnit, routeCoverage, worktreeUnit],
         [fullBrowser],
-        [packageQuality],
+        [fullPackageQuality],
       ],
     };
   }

--- a/tests/src/core/platinum-ci.ts
+++ b/tests/src/core/platinum-ci.ts
@@ -34,6 +34,7 @@ export interface PlatinumCiInput {
   runId: string;
   runAttempt: string;
   testArgs: string[];
+  skipSdkPackageTests?: boolean;
   root: string;
 }
 
@@ -368,6 +369,7 @@ export function buildWorkerScript(input: {
   ref: string;
   sha: string;
   testArgs: string[];
+  skipSdkPackageTests?: boolean;
   provider?: 'platinum' | 'daytona';
 }): string {
   const provider = input.provider ?? 'platinum';
@@ -390,6 +392,7 @@ STATUS=/workspace/kortix-test.exit
 ARTIFACT=/workspace/kortix-test-results.tar.gz
 export HOME=/root
 export CI=1
+${input.skipSdkPackageTests ? 'export KORTIX_PACKAGE_SKIP_SDK_TESTS=1' : ''}
 
 exec > >(tee -a "$LOG") 2>&1
 rm -f "$STATUS" "$ARTIFACT"

--- a/tests/src/core/preview-stack.ts
+++ b/tests/src/core/preview-stack.ts
@@ -132,6 +132,14 @@ export function buildPreviewComposeOverlay(
   mailpit:
     image: axllent/mailpit:v1.27.8@sha256:6abc8e633df15eaf785cfcf38bae48e66f64beecdc03121e249d0f9ec15f0707
     restart: unless-stopped
+  supabase-auth:
+    environment:
+      GOTRUE_RATE_LIMIT_EMAIL_SENT: "10000"
+      GOTRUE_RATE_LIMIT_SMS_SENT: "10000"
+      GOTRUE_RATE_LIMIT_VERIFY: "10000"
+      GOTRUE_RATE_LIMIT_TOKEN_REFRESH: "10000"
+      GOTRUE_RATE_LIMIT_OTP: "10000"
+      GOTRUE_RATE_LIMIT_ANONYMOUS_USERS: "10000"
   supabase-db:
     ports:
       - "127.0.0.1:15432:5432"

--- a/tests/src/core/sandbox-preview-providers.ts
+++ b/tests/src/core/sandbox-preview-providers.ts
@@ -468,11 +468,18 @@ interface DaytonaSandboxPage {
   nextCursor?: string | null;
 }
 
+export function daytonaPreviewLabelsFilter(): string {
+  return JSON.stringify({ 'kortix-preview': 'true' });
+}
+
 async function allDaytonaPreviewSandboxes(api: DaytonaApi): Promise<DaytonaSandbox[]> {
   const sandboxes: DaytonaSandbox[] = [];
   let cursor = '';
   do {
-    const query = new URLSearchParams({ limit: '100', labels: 'kortix-preview=true' });
+    const query = new URLSearchParams({
+      limit: '100',
+      labels: daytonaPreviewLabelsFilter(),
+    });
     if (cursor) query.set('cursor', cursor);
     const page = await api.json<DaytonaSandboxPage>(`/sandbox?${query}`);
     sandboxes.push(...(page.items ?? []));

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -112,7 +112,14 @@ bun tests/bin/preview-stack.ts
 
 printf 'stack\n' > "$PHASE"
 ${compose} pull --policy always frontend kortix-api llm-gateway preview-edge mailpit
-${compose} up -d --wait --wait-timeout 300
+for stack_attempt in 1 2; do
+  if ${compose} up -d --wait --wait-timeout 300; then
+    break
+  fi
+  test "$stack_attempt" -lt 2
+  printf 'stack readiness failed on attempt %s; retrying once after container restarts\n' "$stack_attempt"
+  sleep 10
+done
 
 for _ in $(seq 1 60); do
   health="$(curl -fsS --max-time 5 ${shellQuote(`${origin.origin}/v1/health`)} 2>/dev/null || true)"

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -24,21 +24,26 @@ describe('local test runner', () => {
     expect(plan.lanes[0]?.command.slice(-2)).toEqual(['--id', 'ACC-4']);
   });
 
-  it('adds every app and package test plus publish checks without running SDK twice', () => {
+  it('runs the SDK explicitly and suppresses its duplicate package invocation in full mode', () => {
     const plan = buildLocalTestPlan(['--full']);
 
     expect(plan.mode).toBe('full');
     expect(plan.lanes.map((lane) => lane.name)).toEqual([
       'api-cli-flows',
+      'sdk',
       'flow-runner-unit',
       'route-coverage',
       'worktree-unit',
       'browser',
       'package-quality',
     ]);
-    expect(plan.lanes.at(-1)?.command).toEqual(['bun', 'tests/bin/package-quality.ts']);
+    expect(plan.lanes.at(-1)).toEqual({
+      name: 'package-quality',
+      command: ['bun', 'tests/bin/package-quality.ts'],
+      env: { KORTIX_PACKAGE_SKIP_SDK_TESTS: '1' },
+    });
     expect(plan.stages.map((stage) => stage.map((lane) => lane.name))).toEqual([
-      ['api-cli-flows', 'flow-runner-unit', 'route-coverage', 'worktree-unit'],
+      ['api-cli-flows', 'sdk', 'flow-runner-unit', 'route-coverage', 'worktree-unit'],
       ['browser'],
       ['package-quality'],
     ]);

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -94,7 +94,7 @@ describe('local test runner', () => {
 
   it('uses one CI browser worker and preserves explicit concurrency', () => {
     expect(resolveBrowserWorkers(undefined, true)).toBe(1);
-    expect(resolveBrowserWorkers(undefined, false)).toBe(4);
+    expect(resolveBrowserWorkers(undefined, false)).toBe(2);
     expect(resolveBrowserWorkers('2', true)).toBe(2);
   });
 

--- a/tests/unit/platinum-ci.test.ts
+++ b/tests/unit/platinum-ci.test.ts
@@ -248,6 +248,25 @@ describe('Platinum CI worker plan', () => {
     expect(coreScript).not.toContain('supabase_prestarted=1');
   });
 
+  test('propagates the full-run SDK de-duplication flag into the package worker', () => {
+    const fullPackageScript = buildWorkerScript({
+      repository: 'kortix-ai/suna',
+      ref: sha,
+      sha,
+      testArgs: ['--packages-only'],
+      skipSdkPackageTests: true,
+    });
+    expect(fullPackageScript).toContain('export KORTIX_PACKAGE_SKIP_SDK_TESTS=1');
+
+    const standalonePackageScript = buildWorkerScript({
+      repository: 'kortix-ai/suna',
+      ref: sha,
+      sha,
+      testArgs: ['--packages-only'],
+    });
+    expect(standalonePackageScript).not.toContain('export KORTIX_PACKAGE_SKIP_SDK_TESTS=1');
+  });
+
   test('detaches the worker with the Platinum-supported setsid contract', () => {
     const command = platinumWorkerLaunchCommand();
     expect(command).toContain('setsid -f /workspace/run-kortix-tests.sh');

--- a/tests/unit/preview-stack.test.ts
+++ b/tests/unit/preview-stack.test.ts
@@ -26,12 +26,14 @@ describe('ephemeral self-host preview stack', () => {
     expect(caddy).toContain('reverse_proxy frontend:3000');
   });
 
-  it('adds only the preview edge, Mailpit, and direct loopback database port', () => {
+  it('adds preview ingress, Mailpit, direct database access, and preview-only Auth capacity', () => {
     const overlay = buildPreviewComposeOverlay('/workspace/suna/tests/test-results');
     expect(overlay).toContain('preview-edge:');
     expect(overlay).toContain('mailpit:');
     expect(overlay).toContain('127.0.0.1:15432:5432');
     expect(overlay).toContain('/workspace/suna/tests/test-results:/reports:ro');
+    expect(overlay).toContain('GOTRUE_RATE_LIMIT_TOKEN_REFRESH: "10000"');
+    expect(overlay).toContain('GOTRUE_RATE_LIMIT_EMAIL_SENT: "10000"');
     expect(overlay).not.toContain('volumes/db/data');
   });
 

--- a/tests/unit/sandbox-preview.test.ts
+++ b/tests/unit/sandbox-preview.test.ts
@@ -7,7 +7,10 @@ import {
   runSandboxPreview,
   selectStalePreviewSandboxIds,
 } from '../src/core/sandbox-preview';
-import { platinumPreviewIdempotencyKey } from '../src/core/sandbox-preview-providers';
+import {
+  daytonaPreviewLabelsFilter,
+  platinumPreviewIdempotencyKey,
+} from '../src/core/sandbox-preview-providers';
 
 const input = {
   provider: 'auto' as const,
@@ -44,6 +47,10 @@ describe('provider-neutral preview lifecycle', () => {
     );
   });
 
+  it('encodes the Daytona preview ownership filter as JSON', () => {
+    expect(daytonaPreviewLabelsFilter()).toBe('{"kortix-preview":"true"}');
+  });
+
   it('requires the exact SHA-256 of the pull request lockfile', () => {
     expect(previewLockfileHash('A'.repeat(64))).toBe('a'.repeat(64));
     expect(() => previewLockfileHash('a'.repeat(40))).toThrow('64 hex characters');
@@ -62,6 +69,9 @@ describe('provider-neutral preview lifecycle', () => {
     expect(script).toContain('apps/cli/src/index.ts self-host init');
     expect(script).toContain('tests/bin/preview-stack.ts');
     expect(script).toContain('docker compose');
+    expect(script).toContain('for stack_attempt in 1 2; do');
+    expect(script).toMatch(/if docker compose .* up -d --wait --wait-timeout 300; then/);
+    expect(script).toContain('test "$stack_attempt" -lt 2');
     expect(script).toContain('pnpm test -- --target-full');
     expect(script).toContain('/workspace/kortix-test-results.tar.gz');
     expect(script).toContain('kortix-preview.exit');

--- a/tests/unit/sandbox-workflow.test.ts
+++ b/tests/unit/sandbox-workflow.test.ts
@@ -22,6 +22,7 @@ describe('sandbox test workflow', () => {
       'bun tests/bin/sandbox-ci.ts --browser-only --browser-shard=2/2',
     );
     expect(testWorkflow).toContain('bun tests/bin/sandbox-ci.ts --packages-only');
+    expect(testWorkflow).toContain('export KORTIX_PACKAGE_SKIP_SDK_TESTS=1');
     expect(testWorkflow).toContain('timeout-minutes: 90');
     expect(testWorkflow).toContain('SANDBOX_TEST_RUN_ID: ${{ github.run_id }}-${{ matrix.lane }}');
   });

--- a/tests/unit/test-runner-contract.test.ts
+++ b/tests/unit/test-runner-contract.test.ts
@@ -67,12 +67,14 @@ describe('local test runner contract', () => {
     expect(source).toContain('packed agent-tunnel CLI cannot load its WebSocket fallback');
     expect(source).toContain("'--no-sort'");
     expect(source).toContain("KORTIX_API_TEST_WORKERS: '3'");
+    expect(source).toContain("KORTIX_TEST_TIMEOUT_MS: '30000'");
     expect(source).toContain("['@kortix/cli', '@kortix/sandbox-agent-server']");
     expect(source).toContain("await runWorkspaceTests(['@kortix/db'], 1)");
     expect(source).toContain('Promise.allSettled(tasks)');
     expect(source.match(/await runAll\(\[/g)).toHaveLength(5);
     expect(source).toContain("'!kortix-api'");
     expect(source).toContain("'!@kortix/db'");
+    expect(source).toContain("skipSdkTests ? ['!@kortix/sdk'] : []");
   });
 
   it('runs isolated API test files through a bounded parallel worker pool', () => {


### PR DESCRIPTION
## Problem

The full local gate did not report SDK as its own lane. Four local Playwright workers exceeded the browser deadline. Preview Auth returned 429 under target-full load. Preview Compose could fail on one transient analytics restart. Daytona reconciliation used an invalid label-filter encoding.

## Changes

- Run SDK as an explicit full-mode lane and suppress the duplicate package invocation.
- Use two Playwright workers locally and one per CI shard.
- Raise only the loaded package-lane timeout to 30 seconds.
- Replace repeated CLI fixture setup pushes with local bare clones.
- Retry preview Compose readiness once after 10 seconds.
- Raise preview-only GoTrue limits to 10000.
- Encode Daytona preview labels as JSON.

## Verification

- Command: pnpm test -- --full
- Exit: 0
- Total: 242.1s
- REST/CLI: 368/368 passed, 0 skipped, 19.5s
- SDK: 1,855 passed, 0 failed, 24.9s
- Browser: 11 passed, 7 declared local-profile skips, 99.5s
- Package quality: passed, 104.3s
- Benchmark: tests/test-results/local/benchmark-1786403034773.json

## Prior preview proof

- Daytona PR preview: https://8080-58411222-1793-4e14-9518-f2fa045cd882.daytonaproxy01.net
- Report: https://8080-58411222-1793-4e14-9518-f2fa045cd882.daytonaproxy01.net/_tests/
- API reported the exact prior PR SHA before these stabilization changes.