### PR TITLE
fix(cli): suppress browser launches in CI

### DIFF
--- a/apps/cli/src/__tests__/browser.test.ts
+++ b/apps/cli/src/__tests__/browser.test.ts
@@ -3,11 +3,28 @@ import { describe, expect, test } from 'bun:test';
 import { openInBrowser } from '../browser.ts';
 
 describe('openInBrowser', () => {
+  test('does not spawn a browser in CI', () => {
+    let spawned = false;
+
+    const opened = openInBrowser('https://dev.kortix.com/cli/authorize', {
+      env: { CI: '1' },
+      platform: 'darwin',
+      spawn() {
+        spawned = true;
+        throw new Error('must not run');
+      },
+    });
+
+    expect(opened).toBe(false);
+    expect(spawned).toBe(false);
+  });
+
   test('swallows the asynchronous error emitted when a headless worker lacks xdg-open', () => {
     let errorListener: ((error: Error) => void) | undefined;
     let unrefCalled = false;
 
     const opened = openInBrowser('https://dev.kortix.com/cli/authorize', {
+      env: {},
       platform: 'linux',
       spawn(command, args) {
         expect(command).toBe('xdg-open');

--- a/apps/cli/src/browser.ts
+++ b/apps/cli/src/browser.ts
@@ -14,6 +14,7 @@ type BrowserSpawner = (
 interface BrowserOpenOptions {
   platform?: NodeJS.Platform;
   spawn?: BrowserSpawner;
+  env?: NodeJS.ProcessEnv;
 }
 
 function normalizeBrowserUrl(value: string): string | null {
@@ -27,6 +28,10 @@ function normalizeBrowserUrl(value: string): string | null {
 }
 
 export function openInBrowser(value: string, options: BrowserOpenOptions = {}): boolean {
+  // CI callers must handle the printed URL themselves. This also prevents
+  // black-box CLI tests from opening the host machine's default browser.
+  if ((options.env ?? process.env).CI) return false;
+
   const url = normalizeBrowserUrl(value);
   if (!url) return false;
 

--- a/tests/src/fixtures/cli.ts
+++ b/tests/src/fixtures/cli.ts
@@ -228,11 +228,11 @@ export async function runCliOnce(args: string[], opts?: CliRunOptions): Promise<
  *
  * `kortix login` (no --token) stands up a one-shot loopback callback server and
  * prints its URL — `…/cli/authorize?callback=http://127.0.0.1:<port>/callback&state=<hex>`
- * — to stdout, then tries to open a browser (harmless here). The dashboard's
- * only job is to POST `{state, token}` to that callback; we simulate the
- * dashboard by parsing the URL, then POSTing the (already-minted) PAT. The CLI
- * then verifies it via GET /accounts/me and saves the host. Returns the login
- * result once the process exits.
+ * — to stdout. The fixture's `CI=1` environment suppresses the browser process.
+ * The dashboard's only job is to POST `{state, token}` to that callback; we
+ * simulate the dashboard by parsing the URL, then POSTing the (already-minted)
+ * PAT. The CLI then verifies it via GET /accounts/me and saves the host. Returns
+ * the login result once the process exits.
  */
 export async function browserLogin(
   sb: CliSandbox,


### PR DESCRIPTION
## Problem

`LOGIN-2` runs `kortix login` twice. The CLI ignored the fixture's `CI=1` environment and spawned macOS `open` for each authorization URL. Root test runs therefore opened repeated browser tabs on developer machines.

## Change

- Make `openInBrowser()` return `false` without spawning when `CI` is set.
- Add deterministic environment injection for browser-helper tests.
- Document the CLI fixture's browser suppression contract.

## Verification

- `CI=1 bun test apps/cli/src/__tests__/browser.test.ts` — 3 passed, 0 failed.
- `pnpm test -- --id LOGIN-2` — 1 passed, 0 failed, 0 excluded.
- `pnpm --filter @kortix/cli typecheck` — exit 0.
- `pnpm --filter @kortix/cli test` — 796 passed, 0 failed.
- `pnpm test` — all 5 core lanes passed in 35.8s.
- `pnpm test -- --full` — all lanes passed in 414.7s; browser 11 passed and 7 documented local-profile skips; package-quality passed.