### PR TITLE
fix(web): overrides trigger icon-only, save closes panel, agent-default labels, sandbox chooser in panel

### DIFF
--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { SessionOverridesComposer } from '@/features/session/overrides/session-overrides-composer';
+import type { SessionOverrideSlot } from '@/features/session/overrides/session-overrides-toolbar';
 import type { SessionScopeCommit } from '@/features/session/scope/session-scope-model';
 import {
   type AttachedFile,
@@ -66,6 +67,7 @@ export function ComposerChatInput({
   onReorderQueuedMessage,
   onRetryQueuedMessage,
   onAgentSelectionChange,
+  sandboxSlot,
 }: {
   onSend: (text: string, files: AttachedFile[] | undefined, options: ComposerOptions) => void;
   onCommand?: (command: Command, args: string | undefined, options: ComposerOptions) => void;
@@ -108,6 +110,8 @@ export function ComposerChatInput({
   onRetryQueuedMessage?: (id: string) => void;
   /** Reports the effective agent to parent controls such as the sandbox picker. */
   onAgentSelectionChange?: (agentName: string | null) => void;
+  /** Pre-create sandbox-template chooser, rendered inside the overrides panel. */
+  sandboxSlot?: SessionOverrideSlot;
 }) {
   const { data: agents } = useRuntimeAgents({ projectId });
   const { data: providers, isLoading: providersLoading } = useRuntimeProviders();
@@ -165,6 +169,7 @@ export function ComposerChatInput({
           onModelChange={(m) => local.model.set(m ?? undefined, { recent: true })}
           providers={providers}
           defaultModel={local.model.defaults.resolveDefaultFor(selectedAgentName ?? undefined)}
+          sandboxSlot={sandboxSlot}
         />
       ) : null,
     [
@@ -176,6 +181,7 @@ export function ComposerChatInput({
       projectId,
       providers,
       providersLoading,
+      sandboxSlot,
       selectedAgentName,
       sessionId,
     ],

--- a/apps/web/src/features/session/composer/composer-toolbar.tsx
+++ b/apps/web/src/features/session/composer/composer-toolbar.tsx
@@ -9,7 +9,6 @@ import { PaperclipIcon as Paperclip } from '@phosphor-icons/react';
 import type { FlatModel } from '../model-flatten';
 import type { ModelDefaultControls } from '../model-selector';
 import { ModelSelector } from '../model-selector';
-import { ReasoningEffortSelector } from '../reasoning-effort-selector';
 import { VoiceRecorder } from '../voice-recorder';
 import { AgentSelector } from './agent-selector';
 import { SendStopControl } from './send-stop-control';
@@ -58,8 +57,6 @@ export interface ComposerToolbarProps {
   selectedVariant: string | null;
   onVariantChange?: (variant: string | null) => void;
 
-  projectId: string | undefined;
-
   messages: MessageWithParts[] | undefined;
   onContextClick?: () => void;
 
@@ -100,7 +97,6 @@ export function ComposerToolbar({
   variants,
   selectedVariant,
   onVariantChange,
-  projectId,
   messages,
   onContextClick,
   toolbarSlot,
@@ -179,9 +175,8 @@ export function ComposerToolbar({
             onSelect={onVariantChange!}
           />
         )}
-        {/* Capability-gated internally: renders nothing unless the selected
-            model actually exposes a reasoning-effort knob. */}
-        <ReasoningEffortSelector model={selectedModel} projectId={projectId} />
+        {/* Reasoning effort deliberately does NOT render on the bar — it lives
+            inside the session-overrides panel. The bar keeps only agent + model. */}
       </div>
 
       {/* RIGHT: ambient token progress, any slot content, voice, send/stop. */}

--- a/apps/web/src/features/session/overrides/session-overrides-composer.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-composer.tsx
@@ -13,7 +13,10 @@ import type { SessionScopeCommit } from '@/features/session/scope/session-scope-
 import type { Agent, ProviderListResponse } from '@kortix/sdk/react';
 import { useProjectSession } from '@kortix/sdk/react';
 
-import { SessionOverridesToolbar } from './session-overrides-toolbar';
+import {
+  SessionOverridesToolbar,
+  type SessionOverrideSlot,
+} from './session-overrides-toolbar';
 
 export interface SessionOverridesComposerProps {
   projectId: string;
@@ -38,6 +41,12 @@ export interface SessionOverridesComposerProps {
    * this — so only a difference from it is an override worth badging.
    */
   defaultModel?: { providerID: string; modelID: string } | null;
+
+  /**
+   * Pre-create only: a live sandbox-template chooser for the session about to
+   * be created. Absent for existing sessions, whose environment is fixed.
+   */
+  sandboxSlot?: SessionOverrideSlot;
 }
 
 /**
@@ -64,6 +73,7 @@ export function SessionOverridesComposer({
   onModelChange,
   providers,
   defaultModel,
+  sandboxSlot,
 }: SessionOverridesComposerProps) {
   const sessionRow = useProjectSession(projectId, sessionId, { enabled: Boolean(sessionId) });
   const effort = useReasoningEffortControl(selectedModel, projectId);
@@ -166,6 +176,7 @@ export function SessionOverridesComposer({
       model={modelSlot}
       reasoningEffort={effortSlot}
       sandbox={sandbox}
+      sandboxSlot={sandboxSlot}
     />
   );
 }

--- a/apps/web/src/features/session/overrides/session-overrides-control.test.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-control.test.tsx
@@ -33,7 +33,7 @@ const rows = (overrides: Partial<SessionOverrideRow>[] = []): SessionOverrideRow
 
 function render(props: Partial<React.ComponentProps<typeof SessionOverridesControlContent>> = {}) {
   return renderToStaticMarkup(
-    <SessionOverridesControlContent rows={rows()} onSave={() => {}} {...props} />,
+    <SessionOverridesControlContent rows={rows()} onSave={() => true} {...props} />,
   );
 }
 
@@ -92,34 +92,30 @@ describe('SessionOverridesControlContent', () => {
 
   test('uses a non-submit toolbar trigger inside the composer', () => {
     const html = renderToStaticMarkup(
-      <SessionOverridesControl rows={rows()} onSave={() => {}} />,
+      <SessionOverridesControl rows={rows()} onSave={() => true} />,
     );
 
     expect(html).toContain('aria-label="Session overrides"');
     expect(html).toContain('type="button"');
   });
 
-  test('the trigger stays quiet until an override is in force', () => {
-    // Everything inherited: icon only, in the toolbar's muted tone.
+  test('the trigger is an icon and nothing else, overrides or not', () => {
+    // The composer bar says nothing about the axes — muted icon only, even
+    // while overrides are in force. The panel is where overrides live.
     const quiet = renderToStaticMarkup(
-      <SessionOverridesControl rows={rows()} onSave={() => {}} />,
+      <SessionOverridesControl rows={rows()} onSave={() => true} />,
     );
     expect(quiet).toContain('text-muted-foreground');
     expect(quiet).not.toContain('Session<');
 
-    // Exactly one override: the trigger names the overridden axis.
-    const one = renderToStaticMarkup(
-      <SessionOverridesControl rows={rows([{}, { overridden: true }])} onSave={() => {}} />,
-    );
-    expect(one).toContain('Secrets');
-
-    // Several: a count, not a list.
-    const two = renderToStaticMarkup(
+    const withOverrides = renderToStaticMarkup(
       <SessionOverridesControl
         rows={rows([{ overridden: true }, { overridden: true }])}
-        onSave={() => {}}
+        onSave={() => true}
       />,
     );
-    expect(two).toContain('2 overrides');
+    // Row names/counts never leak onto the closed trigger.
+    expect(withOverrides).not.toContain('2 overrides');
+    expect(withOverrides).not.toContain('>Agent<');
   });
 });

--- a/apps/web/src/features/session/overrides/session-overrides-control.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-control.tsx
@@ -14,10 +14,10 @@ import { type ReactNode, useState } from 'react';
  * One overridable axis of a session.
  *
  * `summary` is what the axis is set to RIGHT NOW, and for an axis nobody
- * touched that string names its real source — "Agent default" for secrets (the
- * agent's grant), "Project default" for connectors (the project's default
- * connections) — never "none". `overridden` is what earns the badge: a session
- * should look inherited until the user deliberately takes it off the default.
+ * touched that string names its real source (usually "Agent default" — the
+ * agent's grant defines the defaults) — never "none". `overridden` is what
+ * earns the badge: a session should look inherited until the user deliberately
+ * takes it off the default.
  */
 export interface SessionOverrideRow {
   id: string;
@@ -49,7 +49,13 @@ export interface SessionOverridesControlProps {
   saveDisabled?: boolean;
   /** Extra note above the footer — e.g. the non-retroactive secrets warning. */
   notice?: ReactNode;
-  onSave: () => void;
+  /**
+   * Commits the scope draft. Resolves `true` when the save succeeded (or there
+   * was nothing to write) — the popover closes on it, which is the visible
+   * result of the click. Agent/model/effort apply the moment they are picked;
+   * only secrets/connectors wait for Save.
+   */
+  onSave: () => boolean | Promise<boolean>;
 }
 
 /**
@@ -169,20 +175,21 @@ export function SessionOverridesControlContent({
   );
 }
 
-export function SessionOverridesControl({ ...contentProps }: SessionOverridesControlProps) {
-  // The trigger stays quiet: an icon like every other toolbar control, in the
-  // same muted tone as the agent/model selectors beside it. It only ever grows
-  // text when an override is actually in force — the one overridden axis's
-  // name, or a count — so the composer says nothing while everything inherits.
-  const overridden = contentProps.rows.filter((row) => row.overridden);
-  const triggerText =
-    overridden.length === 1
-      ? overridden[0].name
-      : overridden.length > 1
-        ? `${overridden.length} overrides`
-        : null;
+export function SessionOverridesControl({ onSave, ...contentProps }: SessionOverridesControlProps) {
+  const [open, setOpen] = useState(false);
+  // Closing the panel is the visible result of a successful Save. A failed
+  // save keeps it open — the error toast plus a still-open panel says
+  // "not saved" without losing the draft.
+  const saveAndClose = async () => {
+    const saved = await onSave();
+    if (saved) setOpen(false);
+    return saved;
+  };
+  // The trigger is an icon and nothing else, in the same muted tone as the
+  // agent/model selectors beside it — the axes and their overrides live inside
+  // the panel, never on the composer bar.
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
           type="button"
@@ -193,7 +200,6 @@ export function SessionOverridesControl({ ...contentProps }: SessionOverridesCon
           className="text-muted-foreground hover:text-foreground data-[state=open]:text-foreground"
         >
           <SlidersHorizontal className="size-3.5 shrink-0" />
-          {triggerText}
         </Button>
       </PopoverTrigger>
       <PopoverContent
@@ -210,7 +216,7 @@ export function SessionOverridesControl({ ...contentProps }: SessionOverridesCon
           if (target?.closest('[data-radix-popper-content-wrapper]')) event.preventDefault();
         }}
       >
-        <SessionOverridesControlContent {...contentProps} />
+        <SessionOverridesControlContent {...contentProps} onSave={saveAndClose} />
       </PopoverContent>
     </Popover>
   );

--- a/apps/web/src/features/session/overrides/session-overrides-toolbar.tsx
+++ b/apps/web/src/features/session/overrides/session-overrides-toolbar.tsx
@@ -69,6 +69,11 @@ export interface SessionOverridesToolbarProps {
   reasoningEffort?: SessionOverrideSlot;
   /** Create-time only. Shown so the session's environment is not a mystery. */
   sandbox?: { slug: string | null; provider: string | null };
+  /**
+   * Pre-create only: the sandbox template IS still choosable, so the row gets
+   * a real editor instead of the read-only summary.
+   */
+  sandboxSlot?: SessionOverrideSlot;
 }
 
 function activeScopeSignature(scope: SessionScope | undefined): string {
@@ -108,6 +113,7 @@ export function SessionOverridesToolbar({
   model,
   reasoningEffort,
   sandbox,
+  sandboxSlot,
 }: SessionOverridesToolbarProps) {
   const { scope, catalog, saveScope, isLoading, isScopeLoading } = useSessionScope({
     projectId,
@@ -152,8 +158,8 @@ export function SessionOverridesToolbar({
     !hasAvailableScopeAxis(activeCatalog) ||
     (Boolean(sessionId) && (!scope || isScopeLoading));
 
-  const handleSave = useCallback(async () => {
-    if (!catalog || !initialized) return;
+  const handleSave = useCallback(async (): Promise<boolean> => {
+    if (!catalog || !initialized) return false;
     try {
       const result = await commitSessionScopeDraft({
         sessionId,
@@ -170,8 +176,10 @@ export function SessionOverridesToolbar({
       } else if (!sessionId) {
         successToast('Session overrides configured');
       }
+      return true;
     } catch (error) {
       errorToast(error instanceof Error ? error.message : 'Session overrides could not be saved');
+      return false;
     }
   }, [
     catalog,
@@ -272,8 +280,8 @@ export function SessionOverridesToolbar({
           : 'Unavailable',
       overridden: sessionConnectorsAreOverridden(draft),
       description:
-        'Which connected accounts this session may use. By default every connector the agent grants resolves to the project’s default connection; pick here only to pin this session to something else.',
-      resetLabel: 'Reset to project default',
+        'Which connected accounts this session may use. The default is the agent’s grant — each granted connector uses the project’s default connection; pick here only to pin this session to something else.',
+      resetLabel: 'Reset to agent default',
       editor: (
         <SessionConnectorsEditor
           draft={draft}
@@ -284,28 +292,48 @@ export function SessionOverridesToolbar({
       ),
       onReset: () => onChange(resetSessionConnectorBindings(draft, activeCatalog)),
     });
-    list.push({
-      id: 'sandbox',
-      name: 'Sandbox',
-      icon: Cpu,
-      hint: 'Fixed at session start',
-      summary: sandbox?.slug ?? 'Default template',
-      description:
-        'The machine image this session runs on. It is chosen when the session is created and cannot be changed afterwards — start a new session to use a different one.',
-      readOnly: true,
-      editor: (
-        <dl className="text-sm">
-          <div className="border-border flex items-center justify-between gap-3 border-b py-2">
-            <dt className="text-muted-foreground text-xs">Template</dt>
-            <dd className="text-foreground truncate text-xs">{sandbox?.slug ?? 'Project default'}</dd>
-          </div>
-          <div className="flex items-center justify-between gap-3 py-2">
-            <dt className="text-muted-foreground text-xs">Provider</dt>
-            <dd className="text-foreground truncate text-xs">{sandbox?.provider ?? 'Automatic'}</dd>
-          </div>
-        </dl>
-      ),
-    });
+    if (sandboxSlot) {
+      // Pre-create: the template is still a real choice.
+      list.push({
+        id: 'sandbox',
+        name: 'Sandbox',
+        icon: Cpu,
+        hint: 'Where it runs',
+        summary: sandboxSlot.summary,
+        overridden: sandboxSlot.overridden,
+        description:
+          sandboxSlot.description ??
+          'The machine image this session will run on. It is fixed once the session starts — by default the agent’s environment, then the project or platform default.',
+        editor: sandboxSlot.control,
+        onReset: sandboxSlot.onReset,
+        resetLabel: sandboxSlot.resetLabel,
+      });
+    } else {
+      list.push({
+        id: 'sandbox',
+        name: 'Sandbox',
+        icon: Cpu,
+        hint: 'Fixed at session start',
+        summary: sandbox?.slug ?? 'Default template',
+        description:
+          'The machine image this session runs on. It is chosen when the session is created and cannot be changed afterwards — start a new session to use a different one.',
+        readOnly: true,
+        editor: (
+          <dl className="text-sm">
+            <div className="border-border flex items-center justify-between gap-3 border-b py-2">
+              <dt className="text-muted-foreground text-xs">Template</dt>
+              <dd className="text-foreground truncate text-xs">
+                {sandbox?.slug ?? 'Default template'}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between gap-3 py-2">
+              <dt className="text-muted-foreground text-xs">Provider</dt>
+              <dd className="text-foreground truncate text-xs">{sandbox?.provider ?? 'Automatic'}</dd>
+            </div>
+          </dl>
+        ),
+      });
+    }
     return list;
   }, [
     activeCatalog,
@@ -316,6 +344,7 @@ export function SessionOverridesToolbar({
     onChange,
     reasoningEffort,
     sandbox,
+    sandboxSlot,
     saveScope.isPending,
   ]);
 

--- a/apps/web/src/features/session/scope/session-scope-model.test.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.test.ts
@@ -154,15 +154,16 @@ describe('createSessionScopeDraft', () => {
 
 describe('session scope summaries', () => {
   test('names an inherited axis after its real source, never "none"', () => {
-    // Secrets inherit the AGENT's grant; connectors resolve to the PROJECT's
-    // default connections. Each axis names where its default actually lives.
+    // The agent's grant defines both defaults: which secrets flow, and which
+    // connectors are usable (each then resolving to the project's default
+    // connection — a detail the row description carries, not the label).
     expect(sessionSecretsSummary({ secrets: null })).toBe('Agent default');
     expect(
       sessionConnectorsSummary({
         connector_bindings: { mail: { connection_id: 'connection-mail-1' } },
         connector_bindings_inherited: true,
       }),
-    ).toBe('Project default');
+    ).toBe('Agent default');
   });
 
   test('names an explicit empty override honestly', () => {

--- a/apps/web/src/features/session/scope/session-scope-model.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.ts
@@ -189,14 +189,15 @@ export function resetSessionConnectorBindings(
 }
 
 /**
- * How an inherited axis reads in the UI — named for where the default really
- * comes from, per axis. Secrets: `intersectSecretGrants(grant, null)` returns
- * the AGENT's grant untouched, so the inherited state is the agent's. Connectors:
- * the agent's grant gates the set, but each granted alias resolves to the
- * PROJECT's default connection (`resolveProjectDefaultConnectorConnection`).
+ * How an inherited axis reads in the UI — the agent defines both defaults.
+ * Secrets: `intersectSecretGrants(grant, null)` returns the AGENT's grant
+ * untouched. Connectors: the agent's grant decides WHICH connectors the session
+ * may use; each granted alias then resolves to the project's default connection
+ * (`resolveProjectDefaultConnectorConnection`) — a resolution detail the row
+ * description carries, not the label.
  */
 export const SESSION_SCOPE_SECRETS_INHERITED_LABEL = 'Agent default';
-export const SESSION_SCOPE_CONNECTORS_INHERITED_LABEL = 'Project default';
+export const SESSION_SCOPE_CONNECTORS_INHERITED_LABEL = 'Agent default';
 
 export function sessionSecretsSummary(draft: SessionScopeDraft): string {
   if (draft.secrets === undefined) return 'Unchanged';

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -1356,7 +1356,6 @@ function SessionChatInputImpl({
             variants={variants}
             selectedVariant={selectedVariant}
             onVariantChange={onVariantChange}
-            projectId={projectId}
             messages={messages}
             onContextClick={onContextClick}
             toolbarSlot={toolbarSlot}

--- a/apps/web/src/features/workspace/project-layout/project-home.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-home.tsx
@@ -222,17 +222,28 @@ export function ProjectHome({
             )}
             prefill={prefill}
             onAgentSelectionChange={setSelectedAgent}
-            toolbarSlot={
-              metaSelected ? (
-                <MetaRuntimeIndicator />
-              ) : showSandboxPicker ? (
-                <SandboxPicker
-                  items={sandboxItems}
-                  activeSlug={activeSlug}
-                  selectedSlug={selectedSlug}
-                  onSelect={setSelectedSlug}
-                />
-              ) : null
+            toolbarSlot={metaSelected ? <MetaRuntimeIndicator /> : null}
+            // The template chooser lives inside the overrides panel, not on the
+            // bar — the bar keeps only agent + model.
+            sandboxSlot={
+              !metaSelected && showSandboxPicker
+                ? {
+                    summary: selectedSlug
+                      ? (sandboxItems.find((t) => t.slug === selectedSlug)?.name ?? selectedSlug)
+                      : 'Agent default',
+                    overridden: selectedSlug !== null,
+                    control: (
+                      <SandboxPicker
+                        items={sandboxItems}
+                        activeSlug={activeSlug}
+                        selectedSlug={selectedSlug}
+                        onSelect={setSelectedSlug}
+                      />
+                    ),
+                    onReset: () => setSelectedSlug(null),
+                    resetLabel: 'Reset to agent default',
+                  }
+                : undefined
             }
           />
         }


### PR DESCRIPTION
Direct product feedback on the session-overrides surface (follow-up to #6361/#6364):

1. **Trigger is an icon and nothing else.** No text on the composer bar, overridden or not — muted tone matching the agent/model selectors. Axes and their overrides live only inside the panel.
2. **Save has a visible result.** Clicking Save closes the panel (and toasts); a failed scope save keeps it open with the error toast so the draft is not lost. Previously agent/model picks applied instantly, so Save appeared to do nothing.
3. **The bar keeps only agent + model.** The reasoning-effort selector and the sandbox-template button are gone from the toolbar; both live in the overrides panel. On the pre-create composer the panel's Sandbox row hosts the real template chooser (`SandboxPicker`, with reset); on existing sessions it stays a read-only summary — the environment is fixed at start.
4. **Connectors read "Agent default"** — the agent's grant decides which connectors a session may use; each granted alias resolving to the project's default connection is a detail the row description carries, not the label. Reset reads "Reset to agent default". Sandbox pre-create default also reads "Agent default" (agent environment → project → platform).

Verification (worktree stack, real browser):
- Bar shows exactly: attach · Kortix · DeepSeek V4 Flash · [sliders icon] · mic · send.
- Panel rows: Agent kortix · Model · Reasoning effort "Model default" · Secrets "Agent default" · Connectors "Agent default" · Sandbox "Agent default" with the template dropdown rendered in the pane.
- Save → panel closes + "Session overrides configured" toast; focus returns to the trigger.
- Screenshot: `output/session-overrides/polish-05-sandbox-row-editable.png`.
- `bun test` overrides+scope 68/0 · eslint touched files 0 errors · `tsc --noEmit` clean vs known baseline.
