### PR TITLE
fix(deploy-prod): gate the dead us-east-2 shadow lane behind ENABLE_US_SHADOW_DEPLOY

### DIFF
--- a/.github/workflows/activate-prod-us-east-2-writers.yml
+++ b/.github/workflows/activate-prod-us-east-2-writers.yml
@@ -28,6 +28,7 @@ jobs:
   writers:
     name: Apply guarded US writer state
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: prod-use2-shadow
     env:
       AWS_REGION: us-east-2

--- a/.github/workflows/cutover-prod-us-east-2.yml
+++ b/.github/workflows/cutover-prod-us-east-2.yml
@@ -31,6 +31,7 @@ jobs:
   cloudflare:
     name: Apply guarded Cloudflare production change
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: prod-use2-shadow
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -1,5 +1,83 @@
 name: Deploy Prod US East 2 Shadow
 
+# Rolls the DARK us-east-2 pre-cutover stack: shadow database schema, logical
+# replication refresh, avatar storage sync, ECS api + gateway, then smoke and
+# contract verification. It never changes production routing, DNS, desired
+# counts, or worker flags.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# STATUS: the release lane is OFF. deploy-prod.yml calls this workflow only
+# when the repository variable ENABLE_US_SHADOW_DEPLOY is `true`, which it is
+# not. `workflow_dispatch` still works, so an operator can drive every step by
+# hand. Three independent breakages, each proven in a release run:
+#
+#   1. Replication is gone. The source publication `kortix_us_east_2_20260725`
+#      and its replication slot were dropped from prod on 2026-08-08 with
+#      wal_status `lost`. Nothing can resume from a dropped slot; the target
+#      needs a rebuild plus a full resync.
+#   2. Source/target column drift. Prod still has
+#      `kortix.project_session_connector_bindings.profile_id`, which migration
+#      20260806150353417_connector_compat_removal.sql dropped and the shadow no
+#      longer has. `refresh-replication.sh` fails closed with "The target lacks
+#      selected source columns" — the sole failure of the v0.12.5 shadow lane
+#      (job 92927632339) and the v0.12.6 shadow lane (job 93130050196).
+#   3. Migration runtime. The shadow's pending `audit_events` work exceeds the
+#      Supabase statement timeout: v0.12.7 spent 24m20s on
+#      20260807221200000_centralized_audit_v2 and then failed
+#      20260807221205000 with 57014 "canceling statement due to statement
+#      timeout" (job 93576314456). The step now runs with
+#      `PGOPTIONS=-c statement_timeout=0` and a hard step timeout instead.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# REVIVAL CHECKLIST — turning the lane back on
+#
+# Every step needs an AWS session with MFA for `kortix-gha-prod-use2-terraform`
+# (or the equivalent break-glass role) plus psql against both databases. Full
+# detail, including the exact SQL and the verification queries, lives in
+# docs/runbooks/prod-us-east-2-supabase-migration.md, section "Reviving the
+# shadow deploy lane". Short form, in order:
+#
+#   1. Clear the source drift. Drop the leftover
+#      `kortix.project_session_connector_bindings.profile_id` column on prod so
+#      the source matches the migration ledger. Until this is true, step 5
+#      fails immediately.
+#   2. Clear invalid indexes on the shadow. A statement-timeout kill leaves an
+#      INVALID index behind, and `create index concurrently if not exists`
+#      silently accepts it on retry. Drop every `pg_index.indisvalid = false`
+#      entry in `kortix` on the target before re-running migrations.
+#   3. Bring the shadow schema current:
+#      `DATABASE_URL=<target> pnpm --filter @kortix/db migrate`, with
+#      `PGOPTIONS='-c statement_timeout=0'`. Expect tens of minutes.
+#   4. Rebuild replication from scratch — the slot is unrecoverable:
+#        a. `bash scripts/prod-us-east-2/db-sync.sh prepare-source`   (recreates
+#           the publication `kortix_us_east_2_20260725` on prod)
+#        b. drop the dead target subscription, then
+#           `bash scripts/prod-us-east-2/db-sync.sh start`            (creates
+#           the subscription + slot and starts `copy_data = true`)
+#        c. same pair for Auth via `scripts/prod-us-east-2/auth-sync.sh`
+#        d. `db-sync.sh status` / `auth-sync.sh status` until every relation
+#           reaches state `r` and both apply workers are live. A full initial
+#           copy of a ~286 GB source runs for hours.
+#   5. `bash scripts/prod-us-east-2/refresh-replication.sh` with
+#      ALLOW_REPLICATION_REFRESH=1 must exit 0.
+#   6. Run **Reconcile Prod US East 2 Shadow** (dispatch) to strip target-only
+#      shadow verification writes, then re-check `status`.
+#   7. Dispatch THIS workflow with `synchronize_database: true` and the current
+#      released version. It must go green end to end.
+#   8. Only then set the repository variable `ENABLE_US_SHADOW_DEPLOY=true`
+#      (`gh variable set ENABLE_US_SHADOW_DEPLOY --body true`).
+#
+# Cutover (a separate decision, not part of reviving the lane) runs in this
+# order once the lane is green and staying green:
+#   Finalize Prod US East 2 Database (`preflight-live`)
+#     → freeze the source
+#     → Finalize Prod US East 2 Database (`finalize-frozen`)
+#     → Activate Prod US East 2 Writers (`enable`)
+#     → Cutover Prod US East 2 (routing)
+#   Rollback path: Activate Prod US East 2 Writers (`disable`) then
+#   Finalize Prod US East 2 Database (`reenable-subscriptions`).
+# ─────────────────────────────────────────────────────────────────────────────
+
 on:
   workflow_call:
     inputs:
@@ -64,6 +142,9 @@ jobs:
   infrastructure:
     name: Apply US East 2 shadow Terraform
     runs-on: ubuntu-latest
+    # A healthy apply finishes in under a minute (v0.12.7: 40s, job
+    # 93576314738). Anything past 20 minutes is a stuck Terraform lock.
+    timeout-minutes: 20
     environment: prod-use2-shadow
     env:
       AWS_REGION: us-east-2
@@ -182,6 +263,11 @@ jobs:
     name: Deploy API and gateway to US shadow
     runs-on: ubuntu-latest
     needs: infrastructure
+    # Hard ceiling so a wedged shadow can never sit `in_progress` and block
+    # "re-run failed jobs" on the calling release run — the v0.12.7 failure
+    # mode, where the whole run had to be cancelled. Individual slow steps
+    # carry their own tighter timeouts below. A healthy run takes ~25 minutes.
+    timeout-minutes: 75
     env:
       AWS_REGION: us-east-2
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
@@ -307,8 +393,23 @@ jobs:
           printf 'SOURCE_DATABASE_URL=%s\n' "$source_database_url" >> "$GITHUB_ENV"
           printf 'TARGET_DATABASE_URL=%s\n' "$target_database_url" >> "$GITHUB_ENV"
 
+      # The shadow lags production by whole releases, so a catch-up run replays
+      # heavy migrations against a ~286 GB database. The Supabase role default
+      # `statement_timeout` of 120s killed `create index concurrently
+      # idx_audit_events_account_source_phase_time` on v0.12.7 (57014, job
+      # 93576314456), and the four indexes before it needed 1s, 99s, 39s, and
+      # 86s. Disable the per-statement cap here — the shadow serves no traffic —
+      # and bound the whole step with `timeout-minutes` instead. `pg` reads
+      # PGOPTIONS in ConnectionParameters when no explicit `options` is set.
+      #
+      # A killed `CREATE INDEX CONCURRENTLY` leaves an INVALID index that
+      # `if not exists` then accepts on retry. Drop invalid `kortix` indexes on
+      # the target before re-running this step. See the revival checklist above.
       - name: Apply migrations to the US shadow database
         if: inputs.synchronize_database
+        timeout-minutes: 40
+        env:
+          PGOPTIONS: -c statement_timeout=0
         run: |
           set -euo pipefail
           migration_database_url="$(
@@ -318,17 +419,21 @@ jobs:
           echo "::add-mask::$migration_database_url"
           DATABASE_URL="$migration_database_url" pnpm --filter @kortix/db migrate
 
+      # refresh-replication.sh self-caps its readiness poll at 20 minutes.
       - name: Refresh application replication
         if: inputs.synchronize_database
+        timeout-minutes: 25
         run: bash scripts/prod-us-east-2/refresh-replication.sh
         env:
           ALLOW_REPLICATION_REFRESH: "1"
 
       - name: Synchronize current avatar objects
         if: inputs.synchronize_database
+        timeout-minutes: 20
         run: TARGET_SECRET_ID="$TARGET_ENV_BLOB" bash scripts/prod-us-east-2/storage-sync.sh
 
       - name: Deploy released images
+        timeout-minutes: 20
         run: |
           set -euo pipefail
           bash infra/scripts/ecs-deploy.sh \
@@ -343,7 +448,9 @@ jobs:
             --version "$VERSION" \
             --database-migrated
 
+      # The loop below self-caps at 60 attempts x 10s = 10 minutes per service.
       - name: Verify ECS capacity and task images
+        timeout-minutes: 25
         run: |
           set -euo pipefail
           verify_service() {
@@ -399,7 +506,9 @@ jobs:
               gateway \
               "kortix/kortix-gateway:${IMAGE_TAG}"
 
+      # The loop below self-caps at 40 attempts x 15s = 10 minutes.
       - name: Verify shadow endpoints
+        timeout-minutes: 12
         run: |
           set -euo pipefail
           for attempt in $(seq 1 40); do
@@ -433,6 +542,7 @@ jobs:
           exit 1
 
       - name: Verify target Auth, API, OAuth, MFA, and Storage
+        timeout-minutes: 15
         run: |
           set -euo pipefail
           TARGET_SECRET_ID="$TARGET_ENV_BLOB" \
@@ -445,6 +555,7 @@ jobs:
             bash scripts/prod-us-east-2/target-smoke.sh
 
       - name: Install frontend Auth smoke dependencies
+        timeout-minutes: 15
         run: |
           set -euo pipefail
           cd tests
@@ -452,6 +563,7 @@ jobs:
           bunx playwright install --with-deps chromium
 
       - name: Verify public API contracts
+        timeout-minutes: 20
         run: |
           set -euo pipefail
           cd tests
@@ -464,6 +576,7 @@ jobs:
               --workers 1
 
       - name: Verify frontend password login and authenticated shell
+        timeout-minutes: 15
         run: |
           set -euo pipefail
           TARGET_SECRET_ID="$TARGET_ENV_BLOB" \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,6 +17,10 @@ name: Deploy Prod
 #      - US East 2 ECS shadow: deploy-us-shadow applies the same database
 #        migrations, refreshes logical replication, and rolls the US API and
 #        gateway. It does not change production routing or enable writers.
+#        OFF by default — it runs only when the repository variable
+#        ENABLE_US_SHADOW_DEPLOY is `true`. Its data plane has been broken
+#        since 2026-08-07; see the job comment and
+#        docs/runbooks/prod-us-east-2-supabase-migration.md.
 #   3. verify-live-version curls the PUBLIC endpoints (router + each origin) and
 #      asserts the live reported version == X.Y.Z. Nothing that announces
 #      success — the GitHub Release, the Slack announce, the banner-lower — runs
@@ -875,17 +879,50 @@ jobs:
   # services. This job keeps its database schema, logical publication, API, and
   # gateway on the same release as production. It does not change Cloudflare
   # routing, production DNS, desired counts, or worker flags.
+  #
+  # DISABLED BY DEFAULT since v0.12.7. The shadow's data plane is broken in
+  # three independent places and no release needs it:
+  #   1. The source publication `kortix_us_east_2_20260725` and its replication
+  #      slot were DROPPED from prod on 2026-08-08 (wal_status was `lost`).
+  #      `scripts/prod-us-east-2/refresh-replication.sh` exits 1 with "The
+  #      enabled target subscription is missing" until both are rebuilt and the
+  #      target is fully resynced.
+  #   2. Prod still carries `kortix.project_session_connector_bindings.profile_id`,
+  #      which migration 20260806150353417_connector_compat_removal.sql dropped
+  #      and the shadow no longer has. The refresh script rejects that source
+  #      column with "The target lacks selected source columns" — the sole
+  #      failure of the v0.12.5 (job 92927632339) and v0.12.6 (job 93130050196)
+  #      shadow lanes.
+  #   3. The shadow's pending `audit_events` migrations exceed the server
+  #      statement timeout: v0.12.7 spent 24m20s on 20260807221200000 and then
+  #      failed 20260807221205000 with 57014 "canceling statement due to
+  #      statement timeout" (job 93576314456).
+  # Running that lane on every release costs 25-30 minutes, turns a green
+  # release red, and — because the job stays `in_progress` — blocks "re-run
+  # failed jobs" on the whole release run. v0.12.7 had to be cancelled outright
+  # to re-run anything else.
+  #
+  # Set the repository variable ENABLE_US_SHADOW_DEPLOY=true to turn the lane
+  # back on. Do that only after the revival checklist in
+  # docs/runbooks/prod-us-east-2-supabase-migration.md ("Reviving the shadow
+  # deploy lane") passes end to end. The reusable workflow keeps its
+  # `workflow_dispatch` trigger, so an operator can always drive the shadow by
+  # hand while the lane is off.
+  #
+  # The shadow is dark: Cloudflare routes no user traffic to it. A wedged
+  # shadow (e.g. logical replication stuck) must not block the release
+  # artifacts for the PRIMARY region — that skipped the tag, GitHub Release,
+  # and VERSION sync on v0.10.16 through v0.12.0. Nothing `needs:` this job
+  # (verify-live-version deliberately does not), so its failure shows red
+  # here but blocks nothing; verify-live-version reports shadow drift as a
+  # warning. NOTE: `continue-on-error` is NOT valid on a reusable-workflow
+  # call job — GitHub rejects the whole file (startup_failure, zero jobs).
+  # A job-level `if:` IS valid, and a skipped job leaves the run green — the
+  # same mechanism `verify-schema` uses with ENABLE_PROD_SCHEMA_GATE.
   deploy-us-shadow:
     name: Deploy API + gateway to US East 2 shadow
     needs: [version, retag-images, verify-image-commits, migrate-db]
-    # The shadow is dark: Cloudflare routes no user traffic to it. A wedged
-    # shadow (e.g. logical replication stuck) must not block the release
-    # artifacts for the PRIMARY region — that skipped the tag, GitHub Release,
-    # and VERSION sync on v0.10.16 through v0.12.0. Nothing `needs:` this job
-    # (verify-live-version deliberately does not), so its failure shows red
-    # here but blocks nothing; verify-live-version reports shadow drift as a
-    # warning. NOTE: `continue-on-error` is NOT valid on a reusable-workflow
-    # call job — GitHub rejects the whole file (startup_failure, zero jobs).
+    if: vars.ENABLE_US_SHADOW_DEPLOY == 'true'
     permissions:
       contents: read
       id-token: write
@@ -911,8 +948,10 @@ jobs:
   #     api-ecs-fargate.kortix.com
   #     gateway-ecs-fargate.kortix.com
   #
-  # The US East 2 shadow endpoints are also hard requirements. A release cannot
-  # leave the prepared cutover stack on an older version.
+  # The US East 2 shadow endpoints are checked only while
+  # ENABLE_US_SHADOW_DEPLOY is `true`, and they only ever warn. With the lane
+  # off, the shadow is not deployed at all, so asserting its version would log
+  # two guaranteed, meaningless warnings on every release.
   #
   # Everything that announces success (github-release, announce, banner-off)
   # needs this job. A release whose live version does not match cannot be
@@ -924,6 +963,7 @@ jobs:
     env:
       VERSION: ${{ needs.version.outputs.version }}
       SOURCE_SHA: ${{ needs.version.outputs.source_sha }}
+      SHADOW_ENABLED: ${{ vars.ENABLE_US_SHADOW_DEPLOY }}
     steps:
       - name: Assert public + origin endpoints report v${{ needs.version.outputs.version }}
         run: |
@@ -942,9 +982,16 @@ jobs:
             "router-gateway|https://gateway.kortix.com/health/live|required|0"
             "origin-api-ecs|https://api-ecs-fargate.kortix.com/v1/health|origin|1"
             "origin-gateway-ecs|https://gateway-ecs-fargate.kortix.com/health/live|origin|0"
-            "shadow-api-use2|https://api-use2-shadow.kortix.com/v1/health|shadow|1"
-            "shadow-gateway-use2|https://gateway-use2-shadow.kortix.com/health/live|shadow|1"
           )
+          # The dark US East 2 shadow is only deployed when the lane is on.
+          if [ "${SHADOW_ENABLED:-}" = "true" ]; then
+            ENDPOINTS+=(
+              "shadow-api-use2|https://api-use2-shadow.kortix.com/v1/health|shadow|1"
+              "shadow-gateway-use2|https://gateway-use2-shadow.kortix.com/health/live|shadow|1"
+            )
+          else
+            echo "ENABLE_US_SHADOW_DEPLOY is not 'true' — skipping the US East 2 shadow endpoints."
+          fi
 
           declare -A live
           declare -A live_commit
@@ -976,7 +1023,7 @@ jobs:
               fi
             done
             if [ "$all_ok" = 1 ]; then
-              echo "✅ every production and US shadow endpoint reports v${VERSION} with the correct commit where available."
+              echo "✅ every checked endpoint reports v${VERSION} with the correct commit where available."
               exit 0
             fi
             sleep 15

--- a/.github/workflows/reconcile-prod-us-east-2-shadow.yml
+++ b/.github/workflows/reconcile-prod-us-east-2-shadow.yml
@@ -15,6 +15,8 @@ jobs:
   reconcile:
     name: Remove target-only shadow verification state
     runs-on: ubuntu-latest
+    # The repair steps run with statement_timeout=0, so bound the job instead.
+    timeout-minutes: 120
     environment: prod-use2-shadow
     env:
       AWS_REGION: us-east-2

--- a/docs/runbooks/prod-us-east-2-supabase-migration.md
+++ b/docs/runbooks/prod-us-east-2-supabase-migration.md
@@ -57,7 +57,13 @@
   - `api-use2-shadow.kortix.com`
   - `gateway-use2-shadow.kortix.com`
 - Target Auth email rate limit: 30,000 per hour, equal to the source.
-- Production release workflow: deploys and verifies the US shadow.
+- Production release workflow: does NOT deploy the US shadow. The lane is
+  gated behind the repository variable `ENABLE_US_SHADOW_DEPLOY`, which is
+  unset. See "Reviving the shadow deploy lane" below.
+- Application logical replication: BROKEN since 2026-08-08. The publication
+  `kortix_us_east_2_20260725` and its replication slot were dropped from the
+  source; `wal_status` was `lost`. The `101/101` figure above is the last
+  healthy reading, not the current state.
 - Runtime database endpoint: regional session pooler
   `aws-0-us-east-2.pooler.supabase.com:5432`.
 - Logical replication endpoint: direct target database host
@@ -81,6 +87,164 @@
   window until 2026-08-01.
 
 Do not print or copy secret values into this document, shell output, or Git.
+
+## Reviving the shadow deploy lane
+
+The release lane is OFF. `deploy-prod.yml` calls
+`deploy-prod-us-east-2-shadow.yml` only when the repository variable
+`ENABLE_US_SHADOW_DEPLOY` equals `true`. The variable is unset, so the job is
+skipped and the release run stays green.
+
+### Why it is off
+
+Three independent breakages, each proven by a release run:
+
+| # | Breakage | Evidence |
+| - | -------- | -------- |
+| 1 | Source publication `kortix_us_east_2_20260725` and its replication slot were dropped from prod on 2026-08-08 with `wal_status = lost`. A dropped slot cannot resume; the target needs a rebuild and a full resync. | `refresh-replication.sh` exits 1 with `The enabled target subscription is missing.` |
+| 2 | Prod still has `kortix.project_session_connector_bindings.profile_id`. Migration `20260806150353417_connector_compat_removal.sql:70` drops it, and the shadow no longer has it. `refresh-replication.sh` fails closed on any source column the target lacks. | v0.12.5 job `92927632339` and v0.12.6 job `93130050196`, both: `The target lacks selected source columns: kortix.project_session_connector_bindings profile_id` |
+| 3 | The shadow lags whole releases, so a catch-up run replays heavy `audit_events` migrations. `create index concurrently` exceeds the Supabase role default `statement_timeout` of 120s. | v0.12.7 job `93576314456`: `error: canceling statement due to statement timeout` (`57014`) on `idx_audit_events_account_source_phase_time`. The prior four indexes needed 1s, 99s, 39s, and 86s. Attempt 2 (job `93568793041`) spent 24m20s on `20260807221200000_centralized_audit_v2` before an operator cancelled it. |
+
+Breakage 3 is addressed in the workflow: the migration step now runs with
+`PGOPTIONS=-c statement_timeout=0` and a 40-minute step timeout. Breakages 1
+and 2 need the manual work below.
+
+### Cost of leaving it on
+
+Each release paid 25-30 minutes on a lane that can never pass, turned a green
+release red, and — because the job stayed `in_progress` — blocked "re-run
+failed jobs" for the whole release run. v0.12.7 had to be cancelled outright to
+re-run anything else.
+
+### Checklist
+
+Every step needs an AWS session with MFA plus `psql` against both databases.
+Do the steps in order. Do not set the variable before step 8 passes.
+
+1. **Clear the source drift.** On the source (prod, `eu-west-2`), drop the
+   leftover column so the source matches the migration ledger:
+
+   ```sql
+   ALTER TABLE kortix.project_session_connector_bindings
+     DROP COLUMN IF EXISTS profile_id;
+   ```
+
+   Confirm no running production build reads it first — the compat removal
+   migration's header records that contract. Until this is true, step 6 fails
+   in under two seconds.
+
+2. **Drop invalid indexes on the target.** A statement-timeout kill leaves an
+   `INVALID` index, and `create index concurrently if not exists` silently
+   accepts it on retry, recording the migration as applied with a permanently
+   unusable index. List and drop them on the target:
+
+   ```sql
+   SELECT indexrelid::regclass AS index_name
+   FROM pg_index
+   JOIN pg_class ON pg_class.oid = pg_index.indexrelid
+   JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+   WHERE pg_namespace.nspname = 'kortix'
+     AND NOT pg_index.indisvalid;
+   -- then, per row:
+   DROP INDEX CONCURRENTLY kortix.<index_name>;
+   ```
+
+3. **Bring the shadow schema current.**
+
+   ```bash
+   PGOPTIONS='-c statement_timeout=0' \
+   DATABASE_URL='<target session-pooler URL>?uselibpqcompat=true' \
+     pnpm --filter @kortix/db migrate
+   ```
+
+   Expect tens of minutes. `20260807221200000_centralized_audit_v2` alone took
+   24m20s on this database.
+
+4. **Rebuild replication from scratch.** The slot is unrecoverable, so
+   `db-sync.sh start` alone is not enough — it only re-`ENABLE`s an existing
+   subscription. Drop the dead subscription first; detach its slot, because the
+   slot no longer exists on the source:
+
+   ```sql
+   -- on the target
+   ALTER SUBSCRIPTION kortix_us_east_2_20260725 DISABLE;
+   ALTER SUBSCRIPTION kortix_us_east_2_20260725 SET (slot_name = NONE);
+   DROP SUBSCRIPTION kortix_us_east_2_20260725;
+   ```
+
+   Then, in order:
+
+   ```bash
+   bash scripts/prod-us-east-2/db-sync.sh   prepare-source   # recreates the publication
+   bash scripts/prod-us-east-2/db-sync.sh   start            # creates subscription + slot, copy_data = true
+   bash scripts/prod-us-east-2/auth-sync.sh prepare-source
+   bash scripts/prod-us-east-2/auth-sync.sh start
+   ```
+
+   Repeat the same drop for the Auth subscription if it is also dead.
+   `prepare-source` is idempotent: it creates the publication only when it is
+   absent.
+
+5. **Wait for the initial copy.** Poll until every relation reaches
+   `srsubstate = 'r'` and both subscriptions have a live apply worker:
+
+   ```bash
+   bash scripts/prod-us-east-2/db-sync.sh   status
+   bash scripts/prod-us-east-2/auth-sync.sh status
+   ```
+
+   A full copy of a ~286 GB source runs for hours. Watch source WAL retention
+   (`max_slot_wal_keep_size` is 32 GB) for the whole copy.
+
+6. **Prove the refresh passes.**
+
+   ```bash
+   ALLOW_REPLICATION_REFRESH=1 bash scripts/prod-us-east-2/refresh-replication.sh
+   ```
+
+   It must exit 0. Application replication is `101/101` relations when healthy.
+
+7. **Reconcile shadow-only writes.** Dispatch **Reconcile Prod US East 2
+   Shadow** (`reconcile-prod-us-east-2-shadow.yml`), then re-run the two
+   `status` commands.
+
+8. **Dry-run the lane by hand.** Dispatch **Deploy Prod US East 2 Shadow**
+   (`deploy-prod-us-east-2-shadow.yml`) from `prod` with the current released
+   version and `synchronize_database: true`. It must go green end to end.
+
+9. **Turn the lane on.**
+
+   ```bash
+   gh variable set ENABLE_US_SHADOW_DEPLOY --body true
+   ```
+
+   Confirm the next `deploy-prod` run shows
+   `Deploy API + gateway to US East 2 shadow` as executed, not skipped.
+
+To turn it back off, delete the variable
+(`gh variable delete ENABLE_US_SHADOW_DEPLOY`) or set it to any value other
+than `true`.
+
+### Cutover dispatch order
+
+Cutover is a separate decision. Start it only when the lane is green and stays
+green.
+
+1. **Finalize Prod US East 2 Database** — `preflight-live`
+   (confirm: `preflight-live:prod-us-east-2`).
+2. Freeze the source and set the freeze marker
+   (`/kortix/prod-use2/source-freeze`).
+3. **Finalize Prod US East 2 Database** — `finalize-frozen`. This catches up
+   both subscriptions, reconciles counts, key hashes, critical hashes, and
+   sequences, syncs avatars, then disables the finalized subscriptions.
+4. **Activate Prod US East 2 Writers** — `enable`
+   (confirm: `enable:prod-us-east-2`).
+5. **Cutover Prod US East 2** — the guarded Cloudflare change.
+
+Rollback order:
+
+1. **Activate Prod US East 2 Writers** — `disable`.
+2. **Finalize Prod US East 2 Database** — `reenable-subscriptions`.
 
 ## Verified source inventory
 


### PR DESCRIPTION
## Problem

`Deploy API + gateway to US East 2 shadow` is the only failing job in the last
three production releases. It is also the reason tonight's v0.12.7 release run
(`31413673528`) had to be **cancelled outright**: the shadow job was still
`in_progress` after 28 minutes, and GitHub refuses "re-run failed jobs" while
any job in the run is still running.

| Release | Run | Shadow job | Failing step | Error |
| --- | --- | --- | --- | --- |
| v0.12.5 | `31195627839` | `92927632339` | Refresh application replication | `The target lacks selected source columns: kortix.project_session_connector_bindings profile_id` |
| v0.12.6 | `31267782633` | `93130050196` | Refresh application replication | same |
| v0.12.7 attempt 2 | `31413673528` | `93568793041` | Apply migrations to the US shadow database | ran 19:17:07 -> 19:44:08 (26m59s), cancelled by an operator |
| v0.12.7 attempt 3 | `31413673528` | `93576314456` | Apply migrations to the US shadow database | `57014 canceling statement due to statement timeout` |

## Root cause — three independent breakages

**1. Replication is unrecoverable.** The source publication
`kortix_us_east_2_20260725` and its replication slot were dropped from prod on
2026-08-08 with `wal_status = lost`. `scripts/prod-us-east-2/refresh-replication.sh`
exits 1 (`The enabled target subscription is missing.`) until both are rebuilt
and the target is fully resynced.

**2. Source/target column drift.** Prod still carries
`kortix.project_session_connector_bindings.profile_id`, which
`packages/db/migrations/20260806150353417_connector_compat_removal.sql:70`
drops and the shadow no longer has. `refresh-replication.sh` fails closed on
any source column the target lacks — the sole failure of v0.12.5 and v0.12.6.

**3. Migration runtime exceeds the statement timeout.** The shadow lags whole
releases, so a catch-up run replays heavy `audit_events` work against a
~286 GB database through the `us-east-2` session pooler. From job
`93576314456`:

```
### MIGRATION 20260807221201000_audit_account_project_sequence_index.concurrent (UP) ###   1.3s
### MIGRATION 20260807221202000_audit_account_session_sequence_index.concurrent (UP) ###    99s
### MIGRATION 20260807221203000_audit_source_phase_index.concurrent (UP) ###                39s
### MIGRATION 20260807221204000_audit_action_pattern_index.concurrent (UP) ###              86s
### MIGRATION 20260807221205000_audit_account_source_phase_time_index.concurrent (UP) ###
Error executing:
    create index concurrently if not exists idx_audit_events_account_source_phase_time
      on kortix.audit_events (account_id, authoritative_source, phase, occurred_at)
error: canceling statement due to statement timeout
   code: "57014"
```

The 120s cap is the Supabase role default; the concurrent index migrations set
only `lock_timeout`. Attempt 2's 27 minutes were
`20260807221200000_centralized_audit_v2` (19:17:08 -> 19:41:28 = 24m20s), which
already has an approved 30-minute runtime override.

The lane produces nothing today: `gateway-use2-shadow.kortix.com/health/live`
reports `0.12.2` and `api-use2-shadow.kortix.com/v1/health` returns `503`.

## Fix

Nothing `needs: deploy-us-shadow`, and `verify-live-version` already treats the
shadow as warn-only — so the lane blocked no artifact. It only burned 25-30
minutes, turned every release red, and froze reruns. Since its data plane
cannot pass until a multi-hour manual resync happens, gate it off.

- **`deploy-prod.yml`** — `deploy-us-shadow` gets
  `if: vars.ENABLE_US_SHADOW_DEPLOY == 'true'`. The variable is unset, so the
  job is *skipped*, and a skipped job leaves the run green. This is the exact
  mechanism `verify-schema` already uses with `ENABLE_PROD_SCHEMA_GATE`.
  `continue-on-error` remains invalid on a reusable-workflow call job, so a
  job-level `if:` is the only option.
- **`deploy-prod.yml`** — `verify-live-version` polls the two shadow endpoints
  only when the same variable is `true`. With the lane off they would be two
  guaranteed, meaningless warnings per release.
- **`deploy-prod-us-east-2-shadow.yml`** — `timeout-minutes` on both jobs
  (`infrastructure: 20`, `deploy: 75`) plus per-step caps on every long step
  (migrations 40, replication refresh 25, storage sync 20, ECS deploy 20, ECS
  verify 25, endpoint verify 12, smokes 15/20/15). A wedged lane can no longer
  sit `in_progress` and freeze the release run's reruns.
- **`deploy-prod-us-east-2-shadow.yml`** — the migration step runs with
  `PGOPTIONS=-c statement_timeout=0`, bounded by the 40-minute step timeout, so
  a catch-up run can actually finish a concurrent index build on the shadow.
  `pg@8.22.0` reads `PGOPTIONS` in `ConnectionParameters` when no explicit
  `options` is set (`lib/connection-parameters.js:83`).
- **`reconcile-`/`activate-`/`cutover-prod-us-east-2*.yml`** — `timeout-minutes`
  added (none had one; only `finalize-` did).
- **Runbook** — a revival checklist in the shadow workflow header, and the full
  procedure in `docs/runbooks/prod-us-east-2-supabase-migration.md` under
  "Reviving the shadow deploy lane": clear the source drift, drop invalid
  indexes, migrate, rebuild publication + subscription + slot, resync, verify,
  reconcile, dry-run the dispatch, then flip the variable. The cutover dispatch
  order (`preflight-live` -> freeze -> `finalize-frozen` -> writers `enable` ->
  cutover) and the rollback order are documented alongside it.

The reusable workflow keeps its `workflow_dispatch` trigger, so an operator can
still drive the shadow by hand while the lane is off.

## Verification

`actionlint` on all five changed workflows:

```
$ actionlint .github/workflows/deploy-prod.yml .github/workflows/deploy-prod-us-east-2-shadow.yml \
    .github/workflows/reconcile-prod-us-east-2-shadow.yml \
    .github/workflows/activate-prod-us-east-2-writers.yml \
    .github/workflows/cutover-prod-us-east-2.yml
actionlint exit=0
```

The `verify-live-version` script extracted from the workflow and run against
the live production endpoints, both branches:

```
$ VERSION=0.12.7 SOURCE_SHA=5b8833923d... bash verify.sh
ENABLE_US_SHADOW_DEPLOY is not 'true' — skipping the US East 2 shadow endpoints.
(1/20) OK router-api  version=0.12.7 commit=5b8833923d...
(1/20) OK router-gateway  version=0.12.7 commit=5b8833923d...
(1/20) OK origin-api-ecs  version=0.12.7 commit=5b8833923d...
(1/20) OK origin-gateway-ecs  version=0.12.7 commit=5b8833923d...
every checked endpoint reports v0.12.7 with the correct commit where available.

$ SHADOW_ENABLED=true VERSION=0.12.7 SOURCE_SHA=5b8833923d... bash verify.sh
... four production endpoints OK ...
(1/20) .. shadow-api-use2  version=<unreachable> commit=n/a
(1/20) .. shadow-gateway-use2  version=0.12.2 commit=c135400766...
every checked endpoint reports v0.12.7 with the correct commit where available.
```

Both exit `0`. The second run also confirms the shadow is five releases behind.

Job graph after the change (`yaml.safe_load`):

```
deploy-us-shadow if: vars.ENABLE_US_SHADOW_DEPLOY == 'true'
infrastructure timeout-minutes= 20
deploy         timeout-minutes= 75
```

`grep -n "deploy-us-shadow" .github/workflows/*.yml` confirms no job depends on
it, so skipping it changes no other job's gating.

## Not verified / follow-ups

- **The gate takes effect only once this reaches `prod`.** `deploy-prod.yml`
  runs from the pushed `prod` ref, so the next release still runs the shadow
  lane unless this rides a promote first (`main` -> `staging` -> `prod`) or goes
  in as a targeted release-candidate branch. Setting the repository variable
  before then is a no-op either way (the variable is unset, which is the
  desired state).
- AWS API access from the authoring machine is MFA-locked, so nothing was
  queried against the shadow database, the prod source database, or ECS. Every
  database claim above is read from GitHub Actions logs and repo source, not
  from a live query.
- **`PGOPTIONS` through Supavisor is untested.** `pg` sends `options` as a
  startup parameter; the `us-east-2` session pooler is expected to forward it,
  but that is unconfirmed. If a future revival run still hits `57014`, run the
  catch-up migration against the direct database host
  (`db.uhrwvisbqjfxhxjvoofd.supabase.co:5432`) instead of the pooler.
- **Latent, repo-wide:** a killed `CREATE INDEX CONCURRENTLY` leaves an
  `INVALID` index, and `create index concurrently if not exists` accepts it on
  retry — the migration then records as applied with a permanently unusable
  index. `dropLocalInvalidIndexes` covers local only. The runbook now requires
  a manual invalid-index sweep on the shadow before re-running migrations; a
  deployed-environment guard is deliberately out of scope here.

## Manual AWS steps (need an MFA session)

None are required for this PR to be correct — the lane is off. These are the
steps to *revive* it, and they are the checklist in the runbook:

1. Drop `kortix.project_session_connector_bindings.profile_id` on the prod
   source so it matches the migration ledger.
2. Drop every `pg_index.indisvalid = false` index in schema `kortix` on the
   shadow target.
3. Run `pnpm --filter @kortix/db migrate` against the shadow with
   `PGOPTIONS='-c statement_timeout=0'`.
4. Drop the dead target subscription
   (`ALTER SUBSCRIPTION ... SET (slot_name = NONE); DROP SUBSCRIPTION ...`),
   then `db-sync.sh prepare-source` + `db-sync.sh start`, and the same pair for
   `auth-sync.sh`. `db-sync.sh start` only re-`ENABLE`s an existing
   subscription, so the drop is mandatory.
5. Wait for the full initial copy (hours; watch the 32 GB
   `max_slot_wal_keep_size` on the source).
6. `ALLOW_REPLICATION_REFRESH=1 refresh-replication.sh` must exit 0.
7. Dispatch **Reconcile Prod US East 2 Shadow**, then **Deploy Prod US East 2
   Shadow** by hand; both must go green.
8. `gh variable set ENABLE_US_SHADOW_DEPLOY --body true`.
