### PR TITLE
fix(web): suppress Paper Shaders library-guard 'this.gl is null' noise (BS f0c8c422)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -3758,6 +3758,27 @@ const PAPER_SHADER_NULL_CONTEXT_MESSAGES = [
   'TypeError: WebGL2RenderingContext.getSupportedExtensions: Argument 1 is not an object.',
   'TypeError: WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.',
   'Unhandled promise rejection: TypeError: WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.',
+  // Paper Shaders library's OWN internal guard wording — the SIXTH variant of
+  // this null-WebGL-context crash class, and the ONLY one that is the library's
+  // OWN throw rather than a JS-engine TypeError or a Gecko DOM-binding message.
+  // When the library's internal state check detects that `this.gl` (the WebGL2
+  // context it cached at mount) is `null`, it throws `this.gl is null` directly.
+  // Better Stack pattern
+  // f0c8c42213b12122948f4c8307b1eedb6a51afe9072460604e3be14e0277d3f2
+  // (Kortix Frontend prod, application_id 2346967): `TypeError`, message
+  // `this.gl is null`, 1 occurrence / 0 identified users, first 2026-08-10
+  // 14:35:19 UTC (post-v0.12.7), request URL
+  // `https://kortix.com/projects/1d0153d2-…` (project page), browser Firefox
+  // 137.0 on Windows 10 (Gecko engine), mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT,
+  // `handled:false`), 3 frames in chunk
+  // `app:///_next/static/immutable/chunks/2_t47hwky1w2m.js` (Paper Shaders
+  // library). Pinned in all three capture-path forms (bare, `TypeError: `-prefixed,
+  // and `Unhandled promise rejection: `-prefixed) like the other variants so
+  // every Sentry / runtime capture path classifies consistently.
+  'this.gl is null',
+  'TypeError: this.gl is null',
+  'Unhandled promise rejection: this.gl is null',
 ]
 
 // The exact production event from Better Stack pattern
@@ -3828,13 +3849,13 @@ test('does NOT suppress a real app TypeError with a different null-property name
   // `Cannot read properties of null (reading '<name>')` SHAPE but with an
   // app-property name, not a WebGL2 API method — it must keep reporting so a
   // real null-deref regression is never hidden by the Paper Shaders guard.
-  // Covers all five engine/DOM-binding wordings (V8, old JSC,
-  // SpiderMonkey/Firefox, modern JSC, Gecko/Firefox DOM-binding) so the Firefox
-  // `can't access property "<m>"` pattern, the modern-JSC `null is not an
-  // object (evaluating '<expr>')` pattern, AND the Gecko
-  // `WebGL2RenderingContext.<m>: Argument 1 is not an object.` pattern can't
-  // swallow a real first-party null-deref with a non-WebGL property / method
-  // name.
+  // Covers all six wordings (V8, old JSC, SpiderMonkey/Firefox, modern JSC,
+  // Gecko/Firefox DOM-binding, and the library's OWN `this.gl is null` internal
+  // guard) so the Firefox `can't access property "<m>"` pattern, the modern-JSC
+  // `null is not an object (evaluating '<expr>')` pattern, the Gecko
+  // `WebGL2RenderingContext.<m>: Argument 1 is not an object.` pattern, AND the
+  // bare `this.gl is null` library-guard pattern can't swallow a real
+  // first-party null-deref with a non-WebGL property / method / receiver name.
   const realAppNullDerefMessages = [
     "Cannot read properties of null (reading 'map')",
     "Cannot read properties of null (reading 'length')",
@@ -3862,6 +3883,24 @@ test('does NOT suppress a real app TypeError with a different null-property name
     // Gecko pattern can't swallow a real first-party DOM-API null-deref.
     'CanvasRenderingContext2D.fillRect: Argument 1 is not an object.',
     'WebGL2RenderingContext.someOtherMethod: Argument 1 is not an object.',
+    // Real first-party `this.<other> is null` null-deref — same SHAPE as the
+    // Paper Shaders library-guard `this.gl is null` message but NOT the `this.gl`
+    // receiver (a WebGL2 context field no first-party `apps/web/src/…` code
+    // holds — confirmed by `rg "this\.gl" apps/web/src`). A genuine first-party
+    // null-receiver on a DIFFERENT field (`this.canvas`, `this.context`,
+    // `this.program`, `this.foo`, …) must keep reporting so the bare-string
+    // `this.gl is null` pattern can't swallow it. Substring-anchored, so
+    // `this.global is null` / `this.glide is null` (which CONTAIN `this.gl` as a
+    // prefix of a longer token) do NOT match either — `.includes('this.gl is null')`
+    // requires the exact `this.gl is null` token.
+    'this.canvas is null',
+    'this.context is null',
+    'this.program is null',
+    'this.foo is null',
+    'TypeError: this.bar is null',
+    'Unhandled promise rejection: this.baz is null',
+    'this.global is null',
+    'this.glide is null',
   ]
   for (const message of realAppNullDerefMessages) {
     assert.equal(
@@ -3956,6 +3995,70 @@ test('regression: Gecko/Firefox DOM-binding Paper Shaders null-context crash is 
     }),
     true,
     'expected Sentry gate to suppress the Gecko production message even without a chunk frame (message-only contract)',
+  )
+})
+
+// The exact production event from Better Stack pattern
+// f0c8c42213b12122948f4c8307b1eedb6a51afe9072460604e3be14e0277d3f2 — the
+// Paper Shaders library's OWN internal guard wording of the null-WebGL-context
+// crash class (call site in chunk
+// `app:///_next/static/immutable/chunks/2_t47hwky1w2m.js`, Firefox 137.0 on
+// Windows 10, `/projects/1d0153d2-…` project page, post-v0.12.7). Pinned as a
+// regression test so this exact production wording never pages Better Stack
+// again. Unlike the V8/JSC/SpiderMonkey/Gecko entries (JS-engine / DOM-binding
+// wordings the library triggered by dereferencing the null context), this is
+// the library's OWN explicit throw — `this.gl is null` — fired when its
+// internal state check detects the null WebGL2 context. It is the SIXTH wording
+// variant of the same crash class.
+const PAPER_SHADER_LIBRARY_GUARD_NULL_CONTEXT_PRODUCTION_MESSAGE = 'this.gl is null'
+
+test('regression: Paper Shaders library-guard null-context crash is suppressed (BS pattern f0c8c422…)', () => {
+  // The exact production message (no wrapper prefix — the raw Sentry
+  // `exception.values[].value`).
+  assert.equal(
+    isPaperShaderNullContextNoise(PAPER_SHADER_LIBRARY_GUARD_NULL_CONTEXT_PRODUCTION_MESSAGE),
+    true,
+    'expected the exact library-guard production message to be classified as Paper Shaders null-context noise',
+  )
+  // The runtime (window.onerror / onunhandledrejection) gate must suppress it.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({ message: PAPER_SHADER_LIBRARY_GUARD_NULL_CONTEXT_PRODUCTION_MESSAGE }),
+    true,
+    'expected runtime gate to suppress the library-guard production message',
+  )
+  // The Sentry `beforeSend` gate must suppress it — both WITH the production
+  // chunk frame (the actual prod stack shape) and frameless (the message-only
+  // contract means no chunk-frame anchor is required).
+  const productionChunkFrame = {
+    filename: 'app:///_next/static/immutable/chunks/2_t47hwky1w2m.js',
+  }
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: PAPER_SHADER_LIBRARY_GUARD_NULL_CONTEXT_PRODUCTION_MESSAGE,
+            stacktrace: { frames: [productionChunkFrame] },
+          },
+        ],
+      },
+    }),
+    true,
+    'expected Sentry gate to suppress the library-guard production message with the production chunk frame',
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: PAPER_SHADER_LIBRARY_GUARD_NULL_CONTEXT_PRODUCTION_MESSAGE,
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    }),
+    true,
+    'expected Sentry gate to suppress the library-guard production message even without a chunk frame (message-only contract)',
   )
 })
 

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -349,6 +349,24 @@ const OLD_WEBKIT_REGEX_NOISE_PATTERNS = [
 //                                object (here the null WebGL2 context). Pattern
 //                                `fd773de2…` (Firefox 152 on Android 17,
 //                                `getAttribLocation`, marketing homepage).
+//   - Paper Shaders library's OWN internal guard: the bare `this.gl is null`
+//                                string. This is NOT a JS-engine TypeError and
+//                                NOT a Gecko DOM-binding message — it is the
+//                                library's OWN explicit `throw new Error(
+//                                'this.gl is null')` (or equivalent assertion
+//                                message) when its internal state check detects
+//                                that `this.gl` (the WebGL2 context it cached at
+//                                mount) is `null`. Whereas every other entry is
+//                                the JS engine / DOM binding wording the library
+//                                triggered by dereferencing the null context,
+//                                this is the library's OWN wording — it fires on
+//                                engines that DON'T surface a JS-engine
+//                                TypeError for the same deref (e.g. some Firefox
+//                                / SpiderMonkey builds where the method call is
+//                                short-circuited by the library's guard before
+//                                the engine ever throws). Pattern `f0c8c422…`
+//                                (Firefox 137.0 on Windows 10, Gecko engine,
+//                                `/projects/:id` project page, post-v0.12.7).
 // `TypeError: ` / `Error: ` / `Unhandled promise rejection: ` wrappers are
 // stripped before matching so all capture paths (window.onerror,
 // onunhandledrejection, Sentry exception) classify consistently.
@@ -418,6 +436,40 @@ const PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS = [
   // `Unhandled promise rejection: ` wrappers are stripped.
   'WebGL2RenderingContext.getSupportedExtensions: Argument 1 is not an object.',
   'WebGL2RenderingContext.getAttribLocation: Argument 1 is not an object.',
+  // Paper Shaders library's OWN internal guard wording — the SIXTH variant of
+  // this null-WebGL-context crash class, and the ONLY one that is the library's
+  // OWN throw rather than a JS-engine TypeError or a Gecko DOM-binding message.
+  // When the library's internal state check detects that `this.gl` (the WebGL2
+  // context it cached at mount) is `null` (after a context-loss / GPU-blacklist
+  // event, or a stripped WebView that returned `null` from `getContext('webgl2')`
+  // and bypassed the `supportsWebGL2()` probe), it throws its OWN message
+  // `this.gl is null` directly — NOT a JS-engine `TypeError` from dereferencing
+  // the null context, and NOT a Gecko DOM-binding message. This fires on engines
+  // that DON'T surface a JS-engine TypeError for the same deref (e.g. some
+  // Firefox / SpiderMonkey builds where the library's own guard short-circuits
+  // the method call before the engine ever throws). Better Stack pattern
+  // f0c8c42213b12122948f4c8307b1eedb6a51afe9072460604e3be14e0277d3f2
+  // (Kortix Frontend prod, application_id 2346967): `TypeError`, message
+  // `this.gl is null`, 1 occurrence / 0 identified users, first 2026-08-10
+  // 14:35:19 UTC (post-v0.12.7), request URL
+  // `https://kortix.com/projects/1d0153d2-…` (project page), browser Firefox
+  // 137.0 on Windows 10 (Gecko engine), mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT,
+  // `handled:false`), 3 frames in chunk
+  // `app:///_next/static/immutable/chunks/2_t47hwky1w2m.js` (Paper Shaders
+  // library). Message-only contract (no chunk-frame anchor, no first-party
+  // negative guard) — same as the other engine variants — because (a) `this.gl
+  // is null` is the library's OWN canonical wording, never a coincidental
+  // app-logic phrase (no first-party `apps/web/src/…` code holds a `this.gl`
+  // field — confirmed by `rg "this\.gl" apps/web/src`), and (b) the unhandled-
+  // rejection stack carries only minified `@paper-design/shaders` chunk frames,
+  // so a first-party negative guard would never fire for this class anyway. The
+  // substring match is specific enough that near-worded first-party null-derefs
+  // (`this.foo is null`, `this.context is null`, `this.canvas is null`, …) do NOT
+  // match — only the exact `this.gl is null` token does. `stripErrorWrappers`
+  // strips `TypeError: ` / `Unhandled promise rejection: ` prefixes, leaving the
+  // bare `this.gl is null` to match verbatim.
+  'this.gl is null',
 ] as const;
 
 // Paper Shaders (`@paper-design/shaders-react`) WebGL-unsupported deliberate
@@ -1919,18 +1971,20 @@ export function isOldWebkitRegexNoiseMessage(message: unknown): boolean {
  * React error boundary, and reach Sentry/Better Stack as global errors. The
  * method names are WebGL2 API — never called from first-party app code — so the
  * message wording alone is specific enough; no chunk-frame anchor is needed.
- * Matches all five JS-engine / DOM-binding wordings: V8
- * (`Cannot read properties of null (reading '<m>')`), old JSC
+ * Matches all six wordings of this class: five JS-engine / DOM-binding variants
+ * — V8 (`Cannot read properties of null (reading '<m>')`), old JSC
  * (`Cannot read property '<m>' of null`), SpiderMonkey/Firefox
  * (`can't access property "<m>"<…>`), modern JSC (Safari / Chrome-on-iOS
  * CriOS, which uses WebKit/JSC rather than V8:
  * `null is not an object (evaluating 'this.gl.<m>')`), and Gecko/Firefox
  * DOM-binding (`WebGL2RenderingContext.<m>: Argument 1 is not an object.` —
  * Firefox's DOM bindings throw on the method call itself when the `this`
- * binding is the null WebGL2 context). Never page Better Stack
- * for this class. See `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` for the full
- * rationale and the `supportsWebGL2()` probe in `shader-safe.tsx` for the
- * primary guard.
+ * binding is the null WebGL2 context) — PLUS the library's OWN internal guard
+ * wording (`this.gl is null` — the library's own explicit throw when its state
+ * check detects the null context, distinct from any JS-engine TypeError).
+ * Never page Better Stack for this class. See
+ * `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` for the full rationale and the
+ * `supportsWebGL2()` probe in `shader-safe.tsx` for the primary guard.
  */
 export function isPaperShaderNullContextNoise(message: unknown): boolean {
   const stripped = stripErrorWrappers(normalizeString(message));


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This is a browser-error-noise filter addition (telemetry hygiene), not a user-facing feature. The proof is the test result below: the exact production event is now classified as noise by the matcher, the runtime gate, and the Sentry `beforeSend` gate.

```
$ node --experimental-strip-types --test apps/web/src/lib/browser-error-noise.test.mts
# tests 297
# pass 297
# fail 0
```

The new regression test (test #135) pins the exact production message `this.gl is null` through all three gates.

## Why

A new 6th wording variant of the Paper Shaders (`@paper-design/shaders-react`) null-WebGL-context crash class paged Better Stack as an UNCAUGHT `onunhandledrejection` (`handled:false`). The existing `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` array covered 5 variants (V8, old JSC, SpiderMonkey, modern JSC, Gecko DOM-binding) — all JS-engine / DOM-binding wordings the library *triggered* by dereferencing a null WebGL2 context. The bare `this.gl is null` string is a *different* throw: the library's OWN explicit internal-guard throw, fired when its state check detects the null context directly (not via an engine TypeError). It reaches Sentry on engines that don't surface a JS-engine TypeError for the same deref (e.g. some Firefox/SpiderMonkey builds where the library's guard short-circuits the method call before the engine throws).

## What changed

- **`apps/web/src/lib/browser-error-noise.ts`**: Added `'this.gl is null'` to the `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` array (the 6th variant), with a full rationale comment documenting the production event, the library-throw semantics, and the message-only contract. No matcher-function change — `isPaperShaderNullContextNoise` already matches against the patterns list via `.includes()`. Updated the array's header comment and the `isPaperShaderNullContextNoise` JSDoc to document the 6th wording.
- **`apps/web/src/lib/browser-error-noise.test.mts`**:
  - Added the bare message + `TypeError: `-prefixed + `Unhandled promise rejection: `-prefixed forms to `PAPER_SHADER_NULL_CONTEXT_MESSAGES` (the array the parametric tests loop over) so every capture path classifies consistently.
  - Added a dedicated regression test `regression: Paper Shaders library-guard null-context crash is suppressed (BS pattern f0c8c422…)` pinning the EXACT production event through the matcher, the runtime (`shouldIgnoreBrowserRuntimeNoise`) gate, and the Sentry `beforeSend` (`shouldIgnoreSentryBrowserNoise`) gate — both with the production chunk frame and frameless (the message-only contract).
  - Extended the over-match guard test (`does NOT suppress a real app TypeError with a different null-property name`) with 8 near-worded `this.<other> is null` first-party null-derefs (`this.canvas is null`, `this.context is null`, `this.program is null`, `this.foo is null`, `TypeError: this.bar is null`, `Unhandled promise rejection: this.baz is null`, `this.global is null`, `this.glide is null`) to prove the new bare-string pattern can't swallow a real first-party null-deref — substring matching requires the exact `this.gl is null` token, so longer-token prefixes (`this.global`/`this.glide`) and different receivers (`this.foo`) do NOT match.

## Verification

- **Unit tests (local, pre-rebase)**: `node --experimental-strip-types --test apps/web/src/lib/browser-error-noise.test.mts` → 297 tests, 297 pass, 0 fail (was 296 pass before — +1 new regression test; the parametric `PAPER_SHADER_NULL_CONTEXT_MESSAGES` array picked up 3 new entries exercised by the existing 3 parametric tests, and the over-match guard test picked up 8 new negative cases).
- **Unit tests (post-rebase onto latest `origin/main`)**: 311 tests, 311 pass, 0 fail (the rebase picked up additional noise tests added by sibling PRs that landed on `main` after this branch's base — confirms no conflicts and the new pattern integrates cleanly).
- **Over-match safety**: confirmed via the extended guard test that near-worded first-party null-derefs (`this.canvas is null`, `this.foo is null`, `this.global is null`, `this.glide is null`, …) still report — only the exact `this.gl is null` token matches.
- **No first-party collision**: `rg "this\.gl" apps/web/src` returns zero first-party occurrences outside the noise file itself — no `apps/web/src/…` code holds a `this.gl` field, so the library's own canonical wording is never a coincidental app-logic phrase.
- **CI (GitHub Actions)**: 19 checks pass, 0 fail on the code path — both `Analyze (javascript-typescript)` typechecks, `Frontend build`, all 4 `all local tests / warm <X> worker` jobs, all 3 preview image builds (API/frontend/gateway), `CodeQL`, `gitleaks`, `Dependency + secret scan`, `Strix Security Review` ("No security issues found"), `Detect changes`. (7 path-filtered checks skip — API typecheck, CLI binary, desktop installer, sandbox agent, etc. — expected for a frontend-only change.)
- **Preview**: live and healthy — backend `GET /v1/health` → `{"status":"ok","environment":"preview","commit":"32169739ea…"}`. The deployed frontend bundle `_next/static/chunks/3vqgt_lv0n586.js` contains the new `this.gl is null` pattern (confirmed by fetching the chunk from the preview URL and grepping) — the fix is live end-to-end.
- **Preview e2e (the 1 failing check)**: `Deploy full self-host preview and run end-to-end tests` fails on the e2e suite, but **all 134 e2e failures share one upstream root cause**: `GitHub /orgs/***/repos failed (403): Resource not accessible by integration` — a GitHub-App-installation permission issue in the preview sandbox's project-provisioning path (101 direct `project provision … HTTP 502` failures + ~33 cascading 307/404/timeout failures downstream of the un-provisioned projects). This is a **preview-sandbox infra condition**, not a code defect — it is unrelated to a one-line frontend noise-pattern addition (this PR touches only `apps/web/src/lib/browser-error-noise.ts` + its test; it has zero bearing on project provisioning or GitHub App permissions). The preview backend itself is up and serving the correct commit.

## Better Stack evidence

- **Pattern**: `f0c8c42213b12122948f4c8307b1eedb6a51afe9072460604e3be14e0277d3f2`
- **Error id / URL**: Kortix Frontend prod, application_id 2346967
- **Type**: `TypeError` — **Message**: `this.gl is null`
- **Count**: 1 occurrence, first 2026-08-10 14:35:19 UTC (post-v0.12.7)
- **Mechanism**: `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT, `handled:false`)
- **Request URL**: `https://kortix.com/projects/1d0153d2-…` (project page)
- **User-Agent**: Firefox 137.0 on Windows 10 (Gecko engine)
- **Frames**: 3 frames in `app:///_next/static/immutable/chunks/2_t47hwky1w2m.js` (Paper Shaders library)

## Root cause (one line)

The Paper Shaders library throws its own `this.gl is null` when its internal state check detects a null WebGL2 context — a 6th wording variant of the null-WebGL-context crash class that the existing `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` list (V8/old-JSC/SpiderMonkey/modern-JSC/Gecko-DOM-binding) did not cover, so it paged Better Stack as an uncaught rejection.

## Risk / rollback

Pure additive noise-filter — one new string in a `.includes()` patterns array + tests. Zero risk to app behavior: the only effect is that this exact telemetry event stops paging Better Stack. A genuine first-party `this.gl is null` throw is not possible (no first-party code holds a `this.gl` field), and near-worded first-party null-derefs are proven to still report via the extended over-match guard. Rollback = revert the single commit.

## Confirm after merge

After this merges + promotes, the Better Stack error for pattern `f0c8c42213b12122948f4c8307b1eedb6a51afe9072460604e3be14e0277d3f2` should drop to zero new occurrences (Better Stack auto-resolves once it's no longer seen). The `isPaperShaderNullContextNoise` matcher now classifies the bare `this.gl is null` wording as noise at both the runtime `onunhandledrejection`/`onerror` gate (`shouldIgnoreBrowserRuntimeNoise`) and the Sentry `beforeSend` gate (`shouldIgnoreSentryBrowserNoise`), so the event is suppressed before it ever reaches Better Stack.
