### PR TITLE
billing: plan catalog + pure resolver (PR2 — zero consumers switched)

### DIFF
--- a/apps/api/src/__tests__/unit-plan-catalog-parity.test.ts
+++ b/apps/api/src/__tests__/unit-plan-catalog-parity.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// Characterization test for the plan catalog (billing/services/plan-catalog.ts).
+//
+// The catalog is a SECOND SPELLING of facts that already live in `TIERS`
+// (billing/services/tiers.ts) and the legacy multiplier table
+// (shared/account-limits.ts). It exists so the billing refactor has one typed
+// record per plan instead of a dozen ad-hoc derivations — but it is only safe
+// while the two spellings agree exactly. This test is that guarantee: it walks
+// EVERY key in TIERS and asserts the catalog record reproduces what today's
+// helpers return. If someone edits one side, this goes red.
+//
+// No consumer is switched in this PR. The catalog and resolver land first,
+// proven equivalent, and callers move afterwards.
+
+// tiers.ts reads config.INTERNAL_KORTIX_ENV at module scope (per-environment
+// Stripe price catalogs) and account-limits.ts reads the rate-limit budgets and
+// the billing kill-switch. Stub both so the unit suite stays hermetic.
+// The two rate budgets are deliberately chosen so the multiplier is recoverable
+// from a policy limit with no ambiguity: 7 is not a multiple of 100, so
+// `limit === 7` means and only means "multiplier 0 → free budget".
+const FREE_REQS_PER_MIN = 7;
+const PAID_REQS_PER_MIN = 100;
+
+mock.module('../config', () => ({
+  config: {
+    INTERNAL_KORTIX_ENV: 'dev',
+    KORTIX_BILLING_INTERNAL_ENABLED: true,
+    ENTERPRISE_LICENSE_AVAILABLE: false,
+    KORTIX_LLM_ROUTER_REQS_PER_MIN_FREE: FREE_REQS_PER_MIN,
+    KORTIX_LLM_ROUTER_REQS_PER_MIN_PAID: PAID_REQS_PER_MIN,
+  },
+}));
+
+// account-limits.ts and entitlements.ts both reach the credit-account repo at
+// import time. Nothing under test calls these; the stub only keeps the DB out.
+mock.module('../billing/repositories/credit-accounts', () => ({
+  getCreditAccount: async () => null,
+  getSubscriptionInfo: async () => null,
+}));
+
+const {
+  getAllTiers,
+  getTier,
+  getTierEntitlements,
+  getTierOrder,
+  isValidTier,
+  tierGrantsAllModels,
+} = await import('../billing/services/tiers');
+const { maxConcurrentSessionsForTier, sessionLlmPolicyForTier } = await import(
+  '../shared/account-limits'
+);
+const { getPlanRecord, listPlanRecords, PLAN_CATALOG, PLAN_FAMILIES, resolvePlanRecord } =
+  await import('../billing/services/plan-catalog');
+
+/** The multiplier `tierMultiplier` applied, recovered from the emitted policy. */
+function observedLlmMultiplier(tier: string): number {
+  const { limit } = sessionLlmPolicyForTier(tier);
+  return limit === FREE_REQS_PER_MIN ? 0 : limit / PAID_REQS_PER_MIN;
+}
+
+const TIER_KEYS = getAllTiers().map((t) => t.name);
+
+describe('plan catalog covers exactly the tier vocabulary', () => {
+  test('every TIERS key has a record, and the catalog adds none of its own', () => {
+    expect([...TIER_KEYS].sort()).toEqual(Object.keys(PLAN_CATALOG).sort());
+    // 16 keys: none, free, pro, per_seat, starter, team, scale, enterprise, and
+    // the 8 legacy tier_N_M plans. Pinned so adding a tier without a plan record
+    // (or the reverse) fails here rather than silently resolving to `none`.
+    expect(TIER_KEYS).toHaveLength(16);
+  });
+
+  test('catalog membership is the same predicate as isValidTier', () => {
+    for (const key of Object.keys(PLAN_CATALOG)) expect(isValidTier(key)).toBe(true);
+    expect(getPlanRecord('not_a_tier')).toBeNull();
+    expect(isValidTier('not_a_tier')).toBe(false);
+  });
+
+  test('record.key matches its catalog slot and TierConfig.name', () => {
+    for (const key of TIER_KEYS) {
+      expect(PLAN_CATALOG[key]?.key).toBe(key);
+      expect(getTier(key).name).toBe(key);
+    }
+  });
+});
+
+// One describe block per tier key — a plain loop rather than describe.each so
+// the assertions stay fully typed.
+for (const key of TIER_KEYS) {
+  describe(`plan record parity — ${key}`, () => {
+    const record = PLAN_CATALOG[key] as NonNullable<(typeof PLAN_CATALOG)[string]>;
+    const tier = getTier(key);
+
+    test('displayName is exactly today’s displayName', () => {
+      expect(record.displayName).toBe(tier.displayName);
+    });
+
+    test('price matches TierConfig.monthlyPrice', () => {
+      expect(record.price.amountUsd).toBe(tier.monthlyPrice);
+    });
+
+    test('grant matches TierConfig.monthlyCredits', () => {
+      expect(record.grant.includedCreditsUsd).toBe(tier.monthlyCredits);
+    });
+
+    test('canPurchaseCredits matches TierConfig.canPurchaseCredits', () => {
+      expect(record.entitlements.canPurchaseCredits).toBe(tier.canPurchaseCredits);
+    });
+
+    test('enterprise entitlements match getTierEntitlements', () => {
+      const expected = getTierEntitlements(key);
+      expect({
+        sso: record.entitlements.sso,
+        scim: record.entitlements.scim,
+        rbac: record.entitlements.rbac,
+        auditAccess: record.entitlements.auditAccess,
+      }).toEqual(expected);
+    });
+
+    test('managedModels matches tierGrantsAllModels', () => {
+      expect(record.entitlements.managedModels).toBe(tierGrantsAllModels(key));
+    });
+
+    test('concurrentSessions matches TierConfig.concurrentSessionLimit', () => {
+      expect(record.limits.concurrentSessions).toBe(tier.concurrentSessionLimit);
+      // …and therefore the number the limit layer actually enforces.
+      expect(record.limits.concurrentSessions).toBe(maxConcurrentSessionsForTier(key));
+    });
+
+    test('llmRateMultiplier matches the multiplier sessionLlmPolicyForTier applies', () => {
+      expect(record.limits.llmRateMultiplier).toBe(observedLlmMultiplier(key));
+    });
+
+    test('metersCompute is true only for the seat shape', () => {
+      // accountMetersCompute() is billing_model-driven ('per_seat' | 'credit'),
+      // so on a RECORD the only structurally implied case is shape 'seat'.
+      expect(record.entitlements.metersCompute).toBe(record.shape === 'seat');
+    });
+
+    test('family is one of the three public families; compute multiplier is 1.0', () => {
+      expect(PLAN_FAMILIES).toContain(record.family);
+      expect(record.compute.rateMultiplier).toBe(1.0);
+    });
+  });
+}
+
+describe('rank is a strict ladder', () => {
+  test('ranks are unique and dense from 0', () => {
+    const ranks = listPlanRecords().map((r) => r.rank);
+    expect(ranks).toEqual(ranks.map((_, i) => i));
+  });
+
+  test('none is 0, free is 1, enterprise is last', () => {
+    expect(PLAN_CATALOG.none?.rank).toBe(0);
+    expect(PLAN_CATALOG.free?.rank).toBe(1);
+    const maxRank = Math.max(...Object.values(PLAN_CATALOG).map((r) => r.rank));
+    expect(PLAN_CATALOG.enterprise?.rank).toBe(maxRank);
+  });
+
+  test('rank strictly increases over getTierOrder’s known order', () => {
+    // The exact order array in tiers.ts getTierOrder().
+    const known = [
+      'none',
+      'free',
+      'pro',
+      'tier_2_20',
+      'tier_6_50',
+      'tier_12_100',
+      'tier_25_200',
+      'tier_50_400',
+      'tier_125_800',
+      'tier_200_1000',
+      'tier_150_1200',
+      'enterprise',
+    ];
+    // Guard the list itself against drift in getTierOrder.
+    expect(known.map((k) => getTierOrder(k))).toEqual(known.map((_, i) => i));
+
+    for (let i = 1; i < known.length; i++) {
+      const prev = PLAN_CATALOG[known[i - 1] as string] as { rank: number };
+      const curr = PLAN_CATALOG[known[i] as string] as { rank: number };
+      expect(curr.rank).toBeGreaterThan(prev.rank);
+    }
+  });
+
+  test('rank ascends with monthly price above free (enterprise excepted)', () => {
+    const ladder = listPlanRecords().filter((r) => r.key !== 'none' && r.key !== 'enterprise');
+    for (let i = 1; i < ladder.length; i++) {
+      const prev = ladder[i - 1] as { price: { amountUsd: number } };
+      const curr = ladder[i] as { price: { amountUsd: number } };
+      expect(curr.price.amountUsd).toBeGreaterThanOrEqual(prev.price.amountUsd);
+    }
+  });
+});
+
+describe('lookup helpers are total and fail-safe', () => {
+  test('getPlanRecord returns the record for a known key', () => {
+    expect(getPlanRecord('per_seat')?.key).toBe('per_seat');
+  });
+
+  test('getPlanRecord returns null for unknown / empty / null keys', () => {
+    expect(getPlanRecord('nope')).toBeNull();
+    expect(getPlanRecord('')).toBeNull();
+    expect(getPlanRecord(null)).toBeNull();
+    expect(getPlanRecord(undefined)).toBeNull();
+  });
+
+  test('resolvePlanRecord never throws and falls back to none — like getTier', () => {
+    for (const key of ['nope', '', null, undefined]) {
+      expect(resolvePlanRecord(key as string | null | undefined).key).toBe('none');
+      // getTier() has the same fallback, which is the behavior being preserved.
+      expect(getTier((key ?? '') as string).name).toBe('none');
+    }
+  });
+});

--- a/apps/api/src/__tests__/unit-resolve-billing.test.ts
+++ b/apps/api/src/__tests__/unit-resolve-billing.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, test } from 'bun:test';
+
+// resolveBillingFromRow (billing/services/resolve-billing.ts) states an
+// account's whole billing situation from one credit_accounts row: which plan it
+// behaves as, where that came from, its effective entitlements after the
+// account-level overrides, and its concurrent-session cap.
+//
+// It replaces nothing yet. These tests pin the semantics it is required to
+// reproduce — the trial overlay and per-seat self-heal from
+// effective-tier.ts:93-100, the enterprise/demo/managed-models overrides from
+// entitlements.ts:107-140, and the session-limit override from
+// shared/account-limits.ts:151-160 — so the consumer flip in the next PR is a
+// mechanical swap and not a behavior change.
+//
+// No mocks: the module is pure by construction. If it ever needs one, it has
+// stopped being pure and that is the bug.
+
+import { PLAN_CATALOG } from '../billing/services/plan-catalog';
+import { type BillingRow, resolveBillingFromRow } from '../billing/services/resolve-billing';
+
+const NOW = Date.UTC(2026, 0, 15, 12, 0, 0);
+const HOUR = 3_600_000;
+const iso = (offsetMs: number) => new Date(NOW + offsetMs).toISOString();
+
+/** A live seat subscription — the precondition for the per-seat self-heal. */
+const LIVE_SEAT_SUB = {
+  billingModel: 'per_seat',
+  stripeSubscriptionId: 'sub_live',
+  stripeSubscriptionStatus: 'active',
+} satisfies Partial<BillingRow>;
+
+const ALL_KEYS = Object.keys(PLAN_CATALOG);
+
+describe('no row', () => {
+  test('null row → none / no_account, fail-closed', () => {
+    for (const row of [null, undefined]) {
+      const r = resolveBillingFromRow(row, NOW);
+      expect(r.plan.key).toBe('none');
+      expect(r.source).toBe('no_account');
+      expect(r.entitlements).toEqual(PLAN_CATALOG.none?.entitlements as never);
+      expect(r.limits.concurrentSessions).toEqual({ value: 50, source: 'plan' });
+    }
+  });
+});
+
+describe('stored tier', () => {
+  for (const key of ALL_KEYS) {
+    test(`tier='${key}' resolves to its own record, source 'stored'`, () => {
+      const record = PLAN_CATALOG[key] as NonNullable<(typeof PLAN_CATALOG)[string]>;
+      const r = resolveBillingFromRow({ tier: key }, NOW);
+      expect(r.plan.key).toBe(key);
+      expect(r.source).toBe('stored');
+      expect(r.entitlements).toEqual(record.entitlements);
+      expect(r.limits.concurrentSessions).toEqual({
+        value: record.limits.concurrentSessions,
+        source: 'plan',
+      });
+    });
+  }
+
+  test('null tier reads as none, not free (matches resolveEffectiveTier)', () => {
+    const r = resolveBillingFromRow({ tier: null }, NOW);
+    expect(r.plan.key).toBe('none');
+    expect(r.source).toBe('stored');
+  });
+
+  test('unknown tier string falls back to the none record without throwing', () => {
+    const r = resolveBillingFromRow({ tier: 'tier_from_the_future' }, NOW);
+    expect(r.plan.key).toBe('none');
+    expect(r.source).toBe('stored');
+  });
+});
+
+describe('trial overlay', () => {
+  test('active trial behaves as the trial tier, not the stored tier', () => {
+    const r = resolveBillingFromRow(
+      {
+        tier: 'free',
+        trialStatus: 'active',
+        trialTier: 'enterprise',
+        trialEndsAt: iso(24 * HOUR),
+      },
+      NOW,
+    );
+    expect(r.plan.key).toBe('enterprise');
+    expect(r.source).toBe('trial');
+    expect(r.entitlements.sso).toBe(true);
+    expect(r.entitlements.managedModels).toBe(true);
+    expect(r.limits.concurrentSessions.value).toBe(5000);
+  });
+
+  test('expired trial falls back to the stored tier', () => {
+    const r = resolveBillingFromRow(
+      {
+        tier: 'free',
+        trialStatus: 'active',
+        trialTier: 'enterprise',
+        trialEndsAt: iso(-1),
+      },
+      NOW,
+    );
+    expect(r.plan.key).toBe('free');
+    expect(r.source).toBe('stored');
+    expect(r.entitlements.sso).toBe(false);
+  });
+
+  test('non-active trial_status never grants, whatever the end date says', () => {
+    for (const status of ['none', 'expired', 'revoked', 'converted']) {
+      const r = resolveBillingFromRow(
+        { tier: 'free', trialStatus: status, trialTier: 'pro', trialEndsAt: iso(24 * HOUR) },
+        NOW,
+      );
+      expect(r.plan.key).toBe('free');
+      expect(r.source).toBe('stored');
+    }
+  });
+
+  test('trial with an unknown or missing tier does not grant', () => {
+    const unknown = resolveBillingFromRow(
+      { tier: 'free', trialStatus: 'active', trialTier: 'nope', trialEndsAt: iso(24 * HOUR) },
+      NOW,
+    );
+    expect(unknown.plan.key).toBe('free');
+    const missing = resolveBillingFromRow(
+      { tier: 'free', trialStatus: 'active', trialTier: 'pro', trialEndsAt: null },
+      NOW,
+    );
+    expect(missing.plan.key).toBe('free');
+  });
+
+  test('trial outranks the per-seat self-heal', () => {
+    const r = resolveBillingFromRow(
+      {
+        tier: 'free',
+        ...LIVE_SEAT_SUB,
+        trialStatus: 'active',
+        trialTier: 'enterprise',
+        trialEndsAt: iso(HOUR),
+      },
+      NOW,
+    );
+    expect(r.plan.key).toBe('enterprise');
+    expect(r.source).toBe('trial');
+  });
+});
+
+describe('per-seat self-heal', () => {
+  test('non-paid stored tier + live seat subscription → per_seat', () => {
+    for (const tier of ['free', 'none', null]) {
+      const r = resolveBillingFromRow({ tier, ...LIVE_SEAT_SUB }, NOW);
+      expect(r.plan.key).toBe('per_seat');
+      expect(r.source).toBe('per_seat_selfheal');
+      expect(r.entitlements.managedModels).toBe(true);
+      expect(r.entitlements.metersCompute).toBe(true);
+      expect(r.limits.concurrentSessions).toEqual({ value: 200, source: 'plan' });
+    }
+  });
+
+  test('canceled / unpaid subscription does not self-heal', () => {
+    for (const status of ['canceled', 'unpaid']) {
+      const r = resolveBillingFromRow(
+        { tier: 'free', ...LIVE_SEAT_SUB, stripeSubscriptionStatus: status },
+        NOW,
+      );
+      expect(r.plan.key).toBe('free');
+      expect(r.source).toBe('stored');
+    }
+  });
+
+  test('no subscription id does not self-heal', () => {
+    const r = resolveBillingFromRow(
+      { tier: 'free', billingModel: 'per_seat', stripeSubscriptionStatus: 'active' },
+      NOW,
+    );
+    expect(r.plan.key).toBe('free');
+    expect(r.source).toBe('stored');
+  });
+
+  test('an already-paid stored tier is left alone (no self-heal, source stored)', () => {
+    const r = resolveBillingFromRow({ tier: 'tier_25_200', ...LIVE_SEAT_SUB }, NOW);
+    expect(r.plan.key).toBe('tier_25_200');
+    expect(r.source).toBe('stored');
+  });
+});
+
+describe('enterprise entitlement overlays', () => {
+  test('enterpriseEntitled on per_seat → all entitlements true, plan stays per_seat', () => {
+    const r = resolveBillingFromRow({ tier: 'per_seat', enterpriseEntitled: true }, NOW);
+    expect(r.plan.key).toBe('per_seat');
+    expect(r.source).toBe('stored');
+    expect(r.entitlements.sso).toBe(true);
+    expect(r.entitlements.scim).toBe(true);
+    expect(r.entitlements.rbac).toBe(true);
+    expect(r.entitlements.auditAccess).toBe(true);
+    // The overlay grants the enterprise IDENTITY surface only. Plan-shaped
+    // facts stay the plan's.
+    expect(r.limits.concurrentSessions).toEqual({ value: 200, source: 'plan' });
+    expect(r.entitlements.metersCompute).toBe(true);
+  });
+
+  test('demoEnterprise on free → all entitlements true, plan stays free', () => {
+    const r = resolveBillingFromRow({ tier: 'free', demoEnterprise: true }, NOW);
+    expect(r.plan.key).toBe('free');
+    expect(r.entitlements.sso).toBe(true);
+    expect(r.entitlements.auditAccess).toBe(true);
+    // Demo is an identity preview, not a plan upgrade: no managed models.
+    expect(r.entitlements.managedModels).toBe(false);
+    expect(r.limits.concurrentSessions.value).toBe(50);
+  });
+
+  test('both flags false → plan gating stands', () => {
+    const r = resolveBillingFromRow(
+      { tier: 'per_seat', enterpriseEntitled: false, demoEnterprise: false },
+      NOW,
+    );
+    expect(r.entitlements.sso).toBe(false);
+    expect(r.entitlements.scim).toBe(false);
+  });
+
+  test('a genuine enterprise plan needs no flag', () => {
+    const r = resolveBillingFromRow({ tier: 'enterprise' }, NOW);
+    expect(r.entitlements.rbac).toBe(true);
+  });
+});
+
+describe('managedModelsOverride is tri-state', () => {
+  test('true grants managed models to a plan that does not include them', () => {
+    const r = resolveBillingFromRow({ tier: 'free', managedModelsOverride: true }, NOW);
+    expect(r.plan.key).toBe('free');
+    expect(r.entitlements.managedModels).toBe(true);
+  });
+
+  test('false withdraws managed models from a plan that does include them', () => {
+    const r = resolveBillingFromRow({ tier: 'pro', managedModelsOverride: false }, NOW);
+    expect(r.plan.key).toBe('pro');
+    expect(r.entitlements.managedModels).toBe(false);
+  });
+
+  test('null / undefined defers to the plan', () => {
+    expect(
+      resolveBillingFromRow({ tier: 'pro', managedModelsOverride: null }, NOW).entitlements
+        .managedModels,
+    ).toBe(true);
+    expect(resolveBillingFromRow({ tier: 'free' }, NOW).entitlements.managedModels).toBe(false);
+  });
+});
+
+describe('maxConcurrentSessions override', () => {
+  test('a positive override wins over the plan cap, in both directions', () => {
+    const up = resolveBillingFromRow({ tier: 'free', maxConcurrentSessions: 900 }, NOW);
+    expect(up.limits.concurrentSessions).toEqual({ value: 900, source: 'account_override' });
+    const down = resolveBillingFromRow({ tier: 'enterprise', maxConcurrentSessions: 5 }, NOW);
+    expect(down.limits.concurrentSessions).toEqual({ value: 5, source: 'account_override' });
+  });
+
+  test('non-positive / null / non-finite overrides fall back to the plan cap', () => {
+    for (const value of [0, -1, null, Number.NaN]) {
+      const r = resolveBillingFromRow({ tier: 'free', maxConcurrentSessions: value }, NOW);
+      expect(r.limits.concurrentSessions).toEqual({ value: 50, source: 'plan' });
+    }
+  });
+
+  test('a fractional override floors, like resolveAccountLimitInfo', () => {
+    const r = resolveBillingFromRow({ tier: 'free', maxConcurrentSessions: 7.9 }, NOW);
+    expect(r.limits.concurrentSessions.value).toBe(7);
+  });
+});
+
+describe('display naming', () => {
+  test('family label, with a grandfathered sublabel where one applies', () => {
+    expect(resolveBillingFromRow({ tier: 'free' }, NOW).display).toEqual({
+      label: 'Free',
+      sublabel: null,
+    });
+    expect(resolveBillingFromRow({ tier: 'enterprise' }, NOW).display).toEqual({
+      label: 'Enterprise',
+      sublabel: null,
+    });
+    expect(resolveBillingFromRow({ tier: 'per_seat' }, NOW).display).toEqual({
+      label: 'Team',
+      sublabel: '$40/seat/mo · grandfathered',
+    });
+    expect(resolveBillingFromRow({ tier: 'tier_25_200' }, NOW).display).toEqual({
+      label: 'Team',
+      sublabel: '$200/mo · grandfathered',
+    });
+  });
+});
+
+describe('purity', () => {
+  test('the same row and clock always resolve identically', () => {
+    const row: BillingRow = { tier: 'free', ...LIVE_SEAT_SUB, maxConcurrentSessions: 12 };
+    expect(resolveBillingFromRow(row, NOW)).toEqual(resolveBillingFromRow(row, NOW));
+  });
+
+  test('mutating the returned entitlements cannot corrupt the catalog', () => {
+    const r = resolveBillingFromRow({ tier: 'free' }, NOW);
+    r.entitlements.managedModels = true;
+    expect(PLAN_CATALOG.free?.entitlements.managedModels).toBe(false);
+    expect(resolveBillingFromRow({ tier: 'free' }, NOW).entitlements.managedModels).toBe(false);
+  });
+});

--- a/apps/api/src/billing/services/plan-catalog.ts
+++ b/apps/api/src/billing/services/plan-catalog.ts
@@ -1,0 +1,455 @@
+/**
+ * The plan catalog — one record per billable plan key, describing the plan the
+ * way the product talks about it (family, status, billing shape, price, grant,
+ * entitlements, limits) rather than the way `TierConfig` happens to store it.
+ *
+ * PURE. Like `tier-facts.ts`, this module must never import `../../config` (or
+ * anything that reaches it — `tiers.ts` builds per-environment Stripe price
+ * catalogs at module scope, so importing ANY symbol from it boots env
+ * validation). Everything here is static data plus total functions over it.
+ *
+ * PARITY CONTRACT. Every number below is transcribed from `TIERS` in `tiers.ts`
+ * and the legacy multiplier table in `shared/account-limits.ts`. It is a second
+ * spelling of today's behavior, NOT a redefinition of it.
+ * `src/__tests__/unit-plan-catalog-parity.test.ts` asserts the two agree for all
+ * 16 keys and fails the build if they ever drift.
+ *
+ * NOTHING CONSUMES THIS YET. The catalog and `resolve-billing.ts` land first so
+ * the parity test can prove them equivalent before any consumer is switched.
+ */
+
+/**
+ * Public plan family — the identity a customer sees. There are exactly three
+ * rungs on the public ladder: Free, Team, Enterprise. Grandfathered and retired
+ * plans still belong to a family (that is how they are LABELLED); they keep
+ * their own prices, grants, and limits.
+ */
+export type PlanFamily = 'free' | 'team' | 'enterprise';
+
+/**
+ * Lifecycle of a plan key.
+ *   current       — sellable today.
+ *   grandfathered — sold once, still honored exactly as sold, not offered.
+ *   retired       — defined but never sold (no Stripe price ever existed).
+ *   non_plan      — the absence of a plan (`none`).
+ */
+export type PlanStatus = 'current' | 'grandfathered' | 'retired' | 'non_plan';
+
+/** How the recurring charge is computed. */
+export type BillingShape = 'none' | 'flat' | 'seat' | 'contract';
+
+export interface PlanRecord {
+  key: string;
+  family: PlanFamily;
+  status: PlanStatus;
+  shape: BillingShape;
+  /** Strictly ordered ladder position. See RANKING below. */
+  rank: number;
+  price: { amountUsd: number; unit: 'month' | 'seat_month' | 'contract' };
+  grant: { includedCreditsUsd: number; per: 'account' | 'seat' };
+  entitlements: {
+    sso: boolean;
+    scim: boolean;
+    rbac: boolean;
+    auditAccess: boolean;
+    /** True iff the tier's `models` list includes 'all' (tierGrantsAllModels). */
+    managedModels: boolean;
+    canPurchaseCredits: boolean;
+    /**
+     * Does an account on this plan pay for sandbox compute?
+     *
+     * Today this is NOT a property of the plan — `accountMetersCompute` in
+     * `tier-facts.ts` reads `credit_accounts.billing_model` ('per_seat' |
+     * 'credit'), a column, not the tier. The only plan key whose billing_model
+     * is structurally implied is `per_seat`, so on a RECORD this is true iff
+     * `shape === 'seat'`. A flat v3 credit plan meters compute because its ROW
+     * carries billing_model='credit', which the record cannot know — the
+     * resolver takes the row, so that mapping belongs there when a consumer
+     * needs it, not here.
+     */
+    metersCompute: boolean;
+  };
+  limits: {
+    concurrentSessions: number;
+    /**
+     * LLM router rate multiplier, transcribed from `tierMultiplier` in
+     * `shared/account-limits.ts`. NOTE: free/none are 0, not 1 — a 0 multiplier
+     * selects the FREE requests-per-minute budget instead of paid × multiplier.
+     */
+    llmRateMultiplier: number;
+  };
+  /** Reserved for per-plan compute pricing. 1.0 everywhere today. */
+  compute: { rateMultiplier: number };
+  /** EXACTLY `TierConfig.displayName` — parity, not a new label. */
+  displayName: string;
+}
+
+/** Public ladder, low to high. */
+export const PLAN_FAMILIES: readonly PlanFamily[] = ['free', 'team', 'enterprise'] as const;
+
+/** Customer-facing name of each family. */
+export const PLAN_FAMILY_LABELS: Record<PlanFamily, string> = {
+  free: 'Free',
+  team: 'Team',
+  enterprise: 'Enterprise',
+};
+
+const NO_ENTERPRISE = { sso: false, scim: false, rbac: false, auditAccess: false } as const;
+const ALL_ENTERPRISE = { sso: true, scim: true, rbac: true, auditAccess: true } as const;
+
+// ─── RANKING ────────────────────────────────────────────────────────────────
+// rank 0 = none, rank 1 = free, then ascending monthly price, enterprise last.
+// Ties at equal price break so that (a) non-legacy plan keys precede legacy
+// `tier_*` keys and (b) otherwise alphabetically. That rule reproduces
+// `getTierOrder()`'s relative order for every key that appears in it, which the
+// parity test asserts:
+//   none < free < pro < tier_2_20 < tier_6_50 < tier_12_100 < tier_25_200
+//        < tier_50_400 < tier_125_800 < tier_200_1000 < tier_150_1200 < enterprise
+// $20: pro, tier_2_20 · $40: per_seat, starter · $200: team, tier_25_200
+// $800: scale, tier_125_800
+
+export const PLAN_CATALOG: Record<string, PlanRecord> = {
+  // ─── Free family ──────────────────────────────────────────────────────────
+  none: {
+    key: 'none',
+    family: 'free',
+    status: 'non_plan',
+    shape: 'none',
+    rank: 0,
+    price: { amountUsd: 0, unit: 'month' },
+    grant: { includedCreditsUsd: 0, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: false,
+      canPurchaseCredits: false,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 50, llmRateMultiplier: 0 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'No Plan',
+  },
+
+  free: {
+    key: 'free',
+    family: 'free',
+    status: 'current',
+    shape: 'none',
+    rank: 1,
+    price: { amountUsd: 0, unit: 'month' },
+    // $2 of expiring sandbox-only credits — sandbox-only because
+    // managedModels is false, not because the wallet is partitioned.
+    grant: { includedCreditsUsd: 2, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: false,
+      canPurchaseCredits: false,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 50, llmRateMultiplier: 0 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Free',
+  },
+
+  // ─── Team family ──────────────────────────────────────────────────────────
+  // Grandfathered individual/small plans. There is no separate "starter"
+  // family: the public ladder is free / team / enterprise, and a grandfathered
+  // key keeps its own numbers while displaying under its family's name.
+  pro: {
+    key: 'pro',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'flat',
+    rank: 2,
+    price: { amountUsd: 20, unit: 'month' },
+    // No monthly credits — $5 one-time per machine provisioned.
+    grant: { includedCreditsUsd: 0, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 200, llmRateMultiplier: 1 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Pro',
+  },
+
+  tier_2_20: {
+    key: 'tier_2_20',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'flat',
+    rank: 3,
+    price: { amountUsd: 20, unit: 'month' },
+    grant: { includedCreditsUsd: 20, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 200, llmRateMultiplier: 1 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Plus (Legacy)',
+  },
+
+  // Billing v2 seat plan. The record models ONE seat: price is per seat-month
+  // and the grant is per seat (multi-seat math is grantForSeats() in tiers.ts).
+  // The only shape that structurally meters compute.
+  per_seat: {
+    key: 'per_seat',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'seat',
+    rank: 4,
+    price: { amountUsd: 40, unit: 'seat_month' },
+    grant: { includedCreditsUsd: 25, per: 'seat' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: true,
+    },
+    limits: { concurrentSessions: 200, llmRateMultiplier: 1 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Team (legacy seats)',
+  },
+
+  // Billing v3 flat credit plans. Defined, never sold — no Stripe price exists
+  // for any of them, so getVisibleTiers() has always filtered them out and no
+  // account can carry one. Retired, not current.
+  starter: {
+    key: 'starter',
+    family: 'team',
+    status: 'retired',
+    shape: 'flat',
+    rank: 5,
+    price: { amountUsd: 40, unit: 'month' },
+    grant: { includedCreditsUsd: 25, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: false,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 3, llmRateMultiplier: 1 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Starter',
+  },
+
+  tier_6_50: {
+    key: 'tier_6_50',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'flat',
+    rank: 6,
+    price: { amountUsd: 50, unit: 'month' },
+    grant: { includedCreditsUsd: 50, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 300, llmRateMultiplier: 2 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Pro (Legacy)',
+  },
+
+  tier_12_100: {
+    key: 'tier_12_100',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'flat',
+    rank: 7,
+    price: { amountUsd: 100, unit: 'month' },
+    grant: { includedCreditsUsd: 100, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 400, llmRateMultiplier: 3 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Business (Legacy)',
+  },
+
+  team: {
+    key: 'team',
+    family: 'team',
+    status: 'retired',
+    shape: 'flat',
+    rank: 8,
+    price: { amountUsd: 200, unit: 'month' },
+    grant: { includedCreditsUsd: 125, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: false,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 10, llmRateMultiplier: 1 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Team',
+  },
+
+  tier_25_200: {
+    key: 'tier_25_200',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'flat',
+    rank: 9,
+    price: { amountUsd: 200, unit: 'month' },
+    grant: { includedCreditsUsd: 200, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 500, llmRateMultiplier: 4 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Ultra (Legacy)',
+  },
+
+  tier_50_400: {
+    key: 'tier_50_400',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'flat',
+    rank: 10,
+    price: { amountUsd: 400, unit: 'month' },
+    grant: { includedCreditsUsd: 400, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 750, llmRateMultiplier: 6 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Enterprise (Legacy)',
+  },
+
+  scale: {
+    key: 'scale',
+    family: 'team',
+    status: 'retired',
+    shape: 'flat',
+    rank: 11,
+    price: { amountUsd: 800, unit: 'month' },
+    grant: { includedCreditsUsd: 500, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: false,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 30, llmRateMultiplier: 1 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Scale',
+  },
+
+  tier_125_800: {
+    key: 'tier_125_800',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'flat',
+    rank: 12,
+    price: { amountUsd: 800, unit: 'month' },
+    grant: { includedCreditsUsd: 800, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 1000, llmRateMultiplier: 8 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Scale (Legacy)',
+  },
+
+  tier_200_1000: {
+    key: 'tier_200_1000',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'flat',
+    rank: 13,
+    price: { amountUsd: 1000, unit: 'month' },
+    grant: { includedCreditsUsd: 1000, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 1500, llmRateMultiplier: 10 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Max (Legacy)',
+  },
+
+  tier_150_1200: {
+    key: 'tier_150_1200',
+    family: 'team',
+    status: 'grandfathered',
+    shape: 'flat',
+    rank: 14,
+    price: { amountUsd: 1200, unit: 'month' },
+    grant: { includedCreditsUsd: 1200, per: 'account' },
+    entitlements: {
+      ...NO_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 2000, llmRateMultiplier: 12 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Enterprise Max (Legacy)',
+  },
+
+  // ─── Enterprise family ────────────────────────────────────────────────────
+  // Sales-assigned. Price and credits are negotiated out-of-band, which is why
+  // both are 0 in the tier config — the contract, not the catalog, carries them.
+  enterprise: {
+    key: 'enterprise',
+    family: 'enterprise',
+    status: 'current',
+    shape: 'contract',
+    rank: 15,
+    price: { amountUsd: 0, unit: 'contract' },
+    grant: { includedCreditsUsd: 0, per: 'account' },
+    entitlements: {
+      ...ALL_ENTERPRISE,
+      managedModels: true,
+      canPurchaseCredits: true,
+      metersCompute: false,
+    },
+    limits: { concurrentSessions: 5000, llmRateMultiplier: 1 },
+    compute: { rateMultiplier: 1.0 },
+    displayName: 'Enterprise',
+  },
+};
+
+/** The record used whenever a key cannot be resolved. */
+export const NO_PLAN: PlanRecord = PLAN_CATALOG.none as PlanRecord;
+
+/** Exact lookup. Returns null for an unknown key — use this to TEST a key. */
+export function getPlanRecord(key: string | null | undefined): PlanRecord | null {
+  if (!key) return null;
+  return PLAN_CATALOG[key] ?? null;
+}
+
+/**
+ * Total lookup. An unknown, empty, or null key resolves to the `none` record.
+ * Fail-safe by construction: never throws, and the fallback grants nothing —
+ * same convention as `getTier()`.
+ */
+export function resolvePlanRecord(key: string | null | undefined): PlanRecord {
+  return getPlanRecord(key) ?? NO_PLAN;
+}
+
+/** Every key in the catalog, in rank order. */
+export function listPlanRecords(): PlanRecord[] {
+  return Object.values(PLAN_CATALOG).sort((a, b) => a.rank - b.rank);
+}

--- a/apps/api/src/billing/services/resolve-billing.ts
+++ b/apps/api/src/billing/services/resolve-billing.ts
@@ -1,0 +1,197 @@
+/**
+ * One pure function that answers "what is this account's billing situation?"
+ * from a single credit_accounts row.
+ *
+ * Today that answer is assembled by three separate layers that each re-derive
+ * part of it: `resolveEffectiveTier` (trial overlay + per-seat self-heal),
+ * `getAccountEntitlements` (enterprise_entitled / demo_enterprise /
+ * managed_models_override), and `resolveAccountSessionLimit`
+ * (max_concurrent_sessions override). Every surface picks a different subset,
+ * which is how they skew. This module states the whole thing once.
+ *
+ * PURE, and deliberately so — it takes the row, not an accountId, and returns a
+ * value with no I/O, no clock of its own, and no cache. NOTHING CONSUMES IT
+ * YET: it lands with the parity tests first so the equivalence is proven before
+ * any caller is switched. The cache wrapper lands with that flip.
+ *
+ * ZERO BEHAVIOR CHANGE is the whole contract. Every branch below reproduces a
+ * cited branch of today's code.
+ */
+
+import {
+  PLAN_FAMILY_LABELS,
+  type PlanRecord,
+  getPlanRecord,
+  resolvePlanRecord,
+} from './plan-catalog';
+import { isPaidTier, isPerSeatAccount } from './tier-facts';
+
+/**
+ * Trial/subscription/override columns this resolver reads. A structural subset
+ * of `getSubscriptionInfo`'s row plus the two enterprise flags from
+ * `getCreditAccount`, so either row shape can be passed directly.
+ */
+export interface BillingRow {
+  tier?: string | null;
+  trialStatus?: string | null;
+  trialTier?: string | null;
+  trialEndsAt?: string | null;
+  billingModel?: string | null;
+  stripeSubscriptionId?: string | null;
+  stripeSubscriptionStatus?: string | null;
+  enterpriseEntitled?: boolean | null;
+  demoEnterprise?: boolean | null;
+  managedModelsOverride?: boolean | null;
+  maxConcurrentSessions?: number | null;
+}
+
+/** Where the resolved plan came from. */
+export type BillingPlanSource = 'no_account' | 'trial' | 'per_seat_selfheal' | 'stored';
+
+/** Where a resolved limit came from. */
+export type BillingLimitSource = 'plan' | 'account_override';
+
+export interface ResolvedBilling {
+  plan: PlanRecord;
+  source: BillingPlanSource;
+  /** Plan entitlements with the account-level overrides applied. */
+  entitlements: PlanRecord['entitlements'];
+  limits: { concurrentSessions: { value: number; source: BillingLimitSource } };
+  /** Customer-facing naming. Not wired to any surface yet. */
+  display: { label: string; sublabel: string | null };
+}
+
+const TRIAL_STATUS_ACTIVE = 'active';
+
+/**
+ * `trialIsActive` from `effective-tier.ts`, replicated rather than imported:
+ * that module imports `isValidTier` from `tiers.ts`, which boots env validation
+ * at module scope, and this module must stay pure. Membership in the catalog is
+ * the same predicate as `isValidTier` — both cover exactly the same 16 tier
+ * keys, which the parity test asserts.
+ */
+function trialIsActive(row: BillingRow, nowMs: number): boolean {
+  if (row.trialStatus !== TRIAL_STATUS_ACTIVE) return false;
+  if (!row.trialTier || !getPlanRecord(row.trialTier)) return false;
+  if (!row.trialEndsAt) return false;
+  const endsAt = new Date(row.trialEndsAt).getTime();
+  return Number.isFinite(endsAt) && endsAt > nowMs;
+}
+
+/**
+ * `coercePerSeatTier` from `effective-tier.ts`, replicated for the same reason.
+ * A paying seat subscription overrides a stored non-paid tier so stale rows
+ * cannot gate a paying team as free.
+ */
+function coercePerSeatTier(rawTier: string, row: BillingRow): string {
+  if (
+    !isPaidTier(rawTier) &&
+    isPerSeatAccount(row.billingModel) &&
+    !!row.stripeSubscriptionId &&
+    row.stripeSubscriptionStatus !== 'canceled' &&
+    row.stripeSubscriptionStatus !== 'unpaid'
+  ) {
+    return 'per_seat';
+  }
+  return rawTier;
+}
+
+/** Positive-integer override, or null. Mirrors `resolveAccountLimitInfo`. */
+function positiveOverride(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : null;
+}
+
+function displayFor(plan: PlanRecord): { label: string; sublabel: string | null } {
+  const label = PLAN_FAMILY_LABELS[plan.family];
+  if (plan.status !== 'grandfathered') return { label, sublabel: null };
+  const per = plan.price.unit === 'seat_month' ? '/seat/mo' : '/mo';
+  return { label, sublabel: `$${plan.price.amountUsd}${per} · grandfathered` };
+}
+
+/**
+ * Resolve the plan an account BEHAVES as, plus its effective entitlements and
+ * limits, from one row.
+ *
+ * Plan precedence (`resolveEffectiveTier`, effective-tier.ts:93-100):
+ *   1. no row                 → `none`     (fail-closed)
+ *   2. active admin trial     → trial tier (overlay, never a tier write)
+ *   3. per-seat self-heal     → `per_seat`
+ *   4. stored tier
+ *
+ * Override precedence (`getAccountEntitlements`, entitlements.ts:107-140):
+ *   enterprise_entitled → demo_enterprise → plan. `ENTERPRISE_LICENSE_AVAILABLE`
+ *   sits above both in that function but is an ENV fact, not a row fact, so it
+ *   stays with the (impure) caller.
+ *
+ * `managed_models_override` is tri-state (`loadTierSnapshot`,
+ * entitlements.ts:31-42): a boolean wins in both directions, NULL defers to the
+ * plan. `max_concurrent_sessions` overrides the plan cap in both directions
+ * (`resolveAccountSessionLimit`, shared/account-limits.ts:151-160).
+ */
+export function resolveBillingFromRow(
+  row: BillingRow | null | undefined,
+  nowMs: number = Date.now(),
+): ResolvedBilling {
+  if (!row) {
+    const plan = resolvePlanRecord('none');
+    return {
+      plan,
+      source: 'no_account',
+      entitlements: { ...plan.entitlements },
+      limits: {
+        concurrentSessions: { value: plan.limits.concurrentSessions, source: 'plan' },
+      },
+      display: displayFor(plan),
+    };
+  }
+
+  let source: BillingPlanSource;
+  let key: string;
+  if (trialIsActive(row, nowMs)) {
+    source = 'trial';
+    key = row.trialTier as string;
+  } else {
+    // resolveEffectiveTier passes `acct.tier ?? 'none'` — a row with no tier
+    // reads as 'none', not 'free'.
+    const stored = row.tier ?? 'none';
+    key = coercePerSeatTier(stored, row);
+    source = key === stored ? 'stored' : 'per_seat_selfheal';
+  }
+
+  const plan = resolvePlanRecord(key);
+
+  const enterpriseOverlay = row.enterpriseEntitled === true || row.demoEnterprise === true;
+  const enterprisePlan = resolvePlanRecord('enterprise');
+  const entitlements: PlanRecord['entitlements'] = {
+    ...plan.entitlements,
+    ...(enterpriseOverlay
+      ? {
+          sso: enterprisePlan.entitlements.sso,
+          scim: enterprisePlan.entitlements.scim,
+          rbac: enterprisePlan.entitlements.rbac,
+          auditAccess: enterprisePlan.entitlements.auditAccess,
+        }
+      : {}),
+    managedModels:
+      typeof row.managedModelsOverride === 'boolean'
+        ? row.managedModelsOverride
+        : plan.entitlements.managedModels,
+  };
+
+  const sessionOverride = positiveOverride(row.maxConcurrentSessions);
+
+  return {
+    plan,
+    source,
+    entitlements,
+    limits: {
+      concurrentSessions:
+        sessionOverride !== null
+          ? { value: sessionOverride, source: 'account_override' }
+          : { value: plan.limits.concurrentSessions, source: 'plan' },
+    },
+    display: displayFor(plan),
+  };
+}


### PR DESCRIPTION
PR2 of the billing revamp (one plan + entitlements; PR1 was #6367). Introduces the plan catalog and pure resolver with **zero behavior change** — 4 new files, no existing file touched, no consumer switched.

## What this adds

1. **`plan-catalog.ts`** — one `PlanRecord` per stored tier key (16 keys, set-equality-tested against `getAllTiers()`). Each record: `family` (`free|team|enterprise` — the only identity surfaces will ever render), `status` (`current|grandfathered|retired|non_plan`), `shape` (`none|flat|seat|contract`), strict `rank`, price, credit grant, entitlements (incl. `managedModels`, `canPurchaseCredits`, `metersCompute`), limits (incl. the legacy `llmRateMultiplier` table lifted out of `account-limits.ts`), `compute.rateMultiplier` (1.0 everywhere, the future per-plan compute-pricing knob), and today's exact `displayName`. Pure module — imports no config; import-without-env verified.
2. **`resolve-billing.ts`** — pure `resolveBillingFromRow(row, nowMs)`: no-row → `none`; active-trial overlay; per-seat self-heal; stored key; then the override layer in today's exact precedence (`enterprise_entitled` → `demo_enterprise` → `managed_models_override` tri-state → `max_concurrent_sessions`). Emits `display.label`/`sublabel` ("Team", "$40/seat/mo · grandfathered") — consumed by nothing yet.
3. **Characterization tests** (the safety net for the PR3 consumer flip):
   - `unit-plan-catalog-parity.test.ts` — for every key, catalog fields equal today's `getTier`/`getTierEntitlements`/`tierGrantsAllModels`/rate-multiplier behavior; rank strictly increases over `getTierOrder()`'s order (which today mis-sorts 4 keys as 0 — the catalog fixes that without touching the old function).
   - `unit-resolve-billing.test.ts` — table test: all 16 stored keys, trial active/expired, per-seat self-heal, every override.

## Notable parity findings (preserved, not "fixed")

- `llmRateMultiplier` is **0** for `free`/`none` — load-bearing: 0 selects the free requests-per-minute budget in `sessionLlmPolicyForTier`. Writing 1 would have silently given free accounts the paid rate budget; the parity test pins this.
- `metersCompute` is structural only for `shape='seat'`: compute metering is actually driven by the `billing_model` column, which a plan record cannot know. Documented on the type.
- `starter`/`team`/`scale` are `retired`: no Stripe price in any environment, `getVisibleTiers()` has always hidden them, no account can hold one.

## Verification

- `apps/api` `bun run test`: **6396 pass, 0 fail** (211 of those from the 2 new test files); `tsc --noEmit` clean.
- Purity: `bun --env-file=/dev/null -e "import('./src/billing/services/resolve-billing.ts')"` imports cleanly; the same against `tiers.ts` fails env validation (the precedent this module escapes).
- No runtime surface changed, so no dev-behavior delta to verify; the consumer flip in PR3 carries the runtime verification.
