### PR TITLE
fix(ci): stop the dev deploy cancelling its own API build

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,22 @@ linked, not inlined.
 
 ## Register
 
+### A deploy workflow must not cancel a build it cannot outrun (2026-08-10)
+
+**When:** setting `concurrency.cancel-in-progress` on any
+`.github/workflows/deploy-*`. A workflow-wide group with `true` starves the
+SLOWEST surface, because every surface shares the group: a frontend-only push
+kills an in-flight multi-arch API build (~23 min) whenever `main` lands faster
+than that build takes (~10–20 min by day). Queue instead — GitHub holds one
+pending run and cancels the previous pending one, so a burst still collapses to a
+single deploy and the newest commit still wins. `true` also lets an unrelated
+push kill `migrate-db` mid-migration.
+*Incident:* 2026-08-10 — 19 of 30 Deploy Dev runs cancelled, `dev-api` pinned to
+`d1ed3589` for 3.5 h with 5 API commits stranded; it landed only once the trunk
+went quiet that evening.
+*Enforcer:* none — and `deploy-staging` is still `true`, where a cancelled
+`migrate-db` would hit `STAGING_DATABASE_URL`. Build the guard.
+
 ### One CREATE INDEX CONCURRENTLY per table at a time (2026-08-10)
 
 **When:** building indexes on a live table (runbooks, .concurrent.ts migrations).

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -38,9 +38,25 @@ on:
           - all
           - frontend
 
+# One group for every surface, and it must NOT cancel what is already running.
+#
+# `cancel-in-progress: true` starved the slowest surface out of existence. The
+# multi-arch API image takes ~23 min to build; main lands every ~10-20 min during
+# the day; and the group is workflow-wide, so a frontend-only push cancelled an
+# in-flight API build. Measured 2026-08-10: 19 of 30 runs cancelled, the API image
+# had not deployed in 3.5 h, and 5 API commits were stranded — the run that finally
+# landed only survived because the trunk went quiet in the evening.
+#
+# Queueing instead guarantees forward progress. GitHub keeps at most one pending
+# run per group and cancels the previous pending one, so a burst of pushes still
+# collapses into a single follow-up deploy — the newest commit wins, it just waits
+# its turn. This matches deploy-prod, rollback-prod and promote, which have always
+# used `false` for the same reason.
+#
+# It also stops `migrate-db` being killed mid-migration by an unrelated push.
 concurrency:
   group: deploy-dev
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # ── Detect what changed (so unrelated surfaces are skipped) ─────────────────


### PR DESCRIPTION
`deploy-dev` has one workflow-wide concurrency group with `cancel-in-progress:
true`. Every surface shares it, so **a frontend-only push cancels an in-flight API
build**. The multi-arch API image takes ~23 minutes and `main` lands every ~10–20
minutes, so during the working day the API job can effectively never reach the
end.

## Measured on 2026-08-10

| | |
|---|---|
| Deploy Dev runs that day | **19 cancelled**, 10 succeeded |
| `dev-api` stuck on | `d1ed3589`, for **3.5 hours** |
| Commits on main in that window | 25 |
| …touching `apps/api` | **5**, all stranded |
| Last successful API image build | 13:54:01 → 14:16:39 = **22m 38s** |

The successful runs are the fast ones — path-gated runs that skip the API
entirely. I watched seven consecutive attempts die at 19, 26 and 12 minutes; the
one that finally landed only survived because the trunk went quiet after 19:35.

## The change

```diff
-  cancel-in-progress: true
+  cancel-in-progress: false
```

Queueing guarantees forward progress. GitHub keeps at most one *pending* run per
group and cancels the previous pending one, so a burst of pushes still collapses
into a single follow-up deploy — the newest commit still wins, it just waits its
turn instead of killing the build in front of it.

This also stops `migrate-db` being killed mid-migration by an unrelated push,
which the current setting allows.

## Why not per-job concurrency groups

That was my first instinct — scope the group per surface so frontend can't touch
API. It has a trap: `migrate-db` and `build-api` both depend only on
`[detect-changes, dev-version]`, so they run **in parallel**. Putting the API
chain in one job-level group with `cancel-in-progress: true` would make those two
jobs cancel each other inside a single run. Getting that right means hand-splitting
groups per job and reasoning about every parallel pair — much more surface area
than the problem justifies.

## Consistency

Every other artifact-shipping deploy workflow already uses `false`:
`deploy-prod`, `rollback-prod`, `promote`, `cutover-prod-us-east-2`,
`deploy-preview`, `configure-apps-edge`. `deploy-dev` and `deploy-staging` are the
only two on `true`.

**Deliberately not touching `deploy-staging`.** It has the same shape, and the
mid-migration cancellation risk there is worse because it applies migrations
against `STAGING_DATABASE_URL`. But staging is on the release path and pushes are
rare enough that starvation hasn't happened, so that's a separate call to make
rather than something to slip into this PR.

## Trade-off

A dev deploy can now wait behind one in-flight build instead of pre-empting it —
up to ~23 minutes in the worst case. That is the cost of the API deploying at all.