### PR TITLE
Keep saved agent secret selection in sync

### DIFF
--- a/apps/web/src/hooks/projects/use-agent-config.test.ts
+++ b/apps/web/src/hooks/projects/use-agent-config.test.ts
@@ -1,0 +1,32 @@
+import type { AgentConfigResponse } from '@kortix/sdk';
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, test } from 'bun:test';
+
+import { agentConfigQueryKey, applyAgentConfigSaveResponse } from './use-agent-config';
+
+describe('applyAgentConfigSaveResponse', () => {
+  test('replaces a stale all-secrets grant with the explicit saved list', () => {
+    const queryClient = new QueryClient();
+    const key = agentConfigQueryKey('project-1', 'kortix');
+    const stale: AgentConfigResponse = {
+      agent: 'kortix',
+      schema_version: 2,
+      editable: true,
+      default_agent: 'kortix',
+      block: { secrets: 'all' },
+    };
+    queryClient.setQueryData(key, stale);
+
+    applyAgentConfigSaveResponse(queryClient, 'project-1', 'kortix', {
+      ok: true,
+      agent: 'kortix',
+      schema_version: 2,
+      block: { secrets: ['MAIL_TOKEN'] },
+    });
+
+    expect(queryClient.getQueryData<AgentConfigResponse>(key)).toEqual({
+      ...stale,
+      block: { secrets: ['MAIL_TOKEN'] },
+    });
+  });
+});

--- a/apps/web/src/hooks/projects/use-agent-config.ts
+++ b/apps/web/src/hooks/projects/use-agent-config.ts
@@ -8,10 +8,11 @@
  * agents list is drawn from, so every surface reflects the fresh manifest.
  */
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   type AgentConfigBlock,
+  type AgentConfigResponse,
   getAgentConfig,
   updateAgentConfig,
 } from '@kortix/sdk';
@@ -30,11 +31,32 @@ export function useAgentConfig(projectId: string | undefined, agentName: string 
   });
 }
 
+type AgentConfigSaveResponse = Awaited<ReturnType<typeof updateAgentConfig>>;
+
+export function applyAgentConfigSaveResponse(
+  queryClient: QueryClient,
+  projectId: string,
+  agentName: string,
+  response: AgentConfigSaveResponse,
+) {
+  queryClient.setQueryData<AgentConfigResponse>(
+    agentConfigQueryKey(projectId, agentName),
+    (current) => ({
+      agent: response.agent,
+      schema_version: response.schema_version,
+      editable: current?.editable ?? response.schema_version === 2,
+      default_agent: current?.default_agent ?? null,
+      block: response.block,
+    }),
+  );
+}
+
 export function useUpdateAgentConfig(projectId: string, agentName: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (block: AgentConfigBlock) => updateAgentConfig(projectId, agentName, block),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      applyAgentConfigSaveResponse(qc, projectId, agentName, response);
       qc.invalidateQueries({ queryKey: agentConfigQueryKey(projectId, agentName) });
       // The agents list + its per-agent badges come from project-detail.
       void invalidateProject(qc, projectId);


### PR DESCRIPTION
## Problem

Reopening an agent configuration immediately after saving could initialize the editor from stale cached data. The summary already reflected the saved explicit secret list, while the editor still selected **All**.

## Change

- Write the authoritative agent-config mutation response into the React Query cache before refetching.
- Preserve response metadata that the update endpoint does not return.
- Add a regression test for replacing a stale `secrets: all` grant with an explicit saved list.

## Verification

- `bun test src/hooks/projects/use-agent-config.test.ts` — 1 pass, 0 fail.
- ESLint on both changed files — clean.
- `git diff origin/main...HEAD --check` — clean.
- Local browser flow: save `Pick` for secrets, close, reopen — `Pick=true`, `All=false`. The test project was restored afterward.

## Existing baseline failures

- The full web test suite has one unrelated content-timestamp fixture failure.
- The full web typecheck has the existing generated `@/.source` and `test.each` typing failures. No changed file reports a TypeScript error.