### PR TITLE
billing: provider-vs-admin write ownership for credit_accounts (PR4)

### DIFF
--- a/apps/api/src/__tests__/integration-approvals.test.ts
+++ b/apps/api/src/__tests__/integration-approvals.test.ts
@@ -19,7 +19,12 @@ import {
   sessionLifecycleCommands,
 } from '@kortix/db';
 import { eq, sql } from 'drizzle-orm';
-import { getCreditAccount, setDemoEnterprise } from '../billing/repositories/credit-accounts';
+import { getCreditAccount } from '../billing/repositories/credit-accounts';
+import { applyAdminOverride } from '../billing/services/account-write-owner';
+
+/** Test fixture: flip the enterprise-demo flag through the ownership chokepoint. */
+const setDemoEnterprise = (accountId: string, enabled: boolean) =>
+  applyAdminOverride(accountId, { demoEnterprise: enabled }, { action: 'test.enterprise_demo.set' });
 import { config } from '../config';
 import { app } from '../index';
 import { metadataClearSubtreeKey, metadataMergeSubtree } from '../projects/lib/metadata-merge';

--- a/apps/api/src/__tests__/unit-account-write-owner.test.ts
+++ b/apps/api/src/__tests__/unit-account-write-owner.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// The chokepoint writes through the credit-accounts repository and invalidates
+// the billing cache; stub both so the ownership rules are exercised without a
+// database.
+const writes: Array<{ fn: 'upsert' | 'update'; accountId: string; patch: Record<string, unknown> }> =
+  [];
+let storedRow: Record<string, unknown> | null = null;
+mock.module('../billing/repositories/credit-accounts', () => ({
+  getCreditAccount: async () => storedRow,
+  upsertCreditAccount: async (accountId: string, patch: Record<string, unknown>) => {
+    writes.push({ fn: 'upsert', accountId, patch });
+  },
+  updateCreditAccount: async (accountId: string, patch: Record<string, unknown>) => {
+    writes.push({ fn: 'update', accountId, patch });
+  },
+}));
+const invalidated: string[] = [];
+mock.module('../billing/services/billing-cache', () => ({
+  invalidateAccountBilling: (accountId?: string) => {
+    invalidated.push(accountId ?? '*');
+  },
+}));
+
+const {
+  AccountWriteOwnershipError,
+  accountIsAdminPinned,
+  applyAdminOverride,
+  applyStripeSync,
+} = await import('../billing/services/account-write-owner');
+
+const ACCT = 'acct_1';
+const actor = { userId: 'admin_1', action: 'test.write' };
+
+beforeEach(() => {
+  writes.length = 0;
+  invalidated.length = 0;
+  storedRow = null;
+});
+
+describe('applyStripeSync ownership', () => {
+  test('throws on an admin-owned field — the caller is buggy, the value is not dropped', async () => {
+    await expect(applyStripeSync(ACCT, { enterpriseEntitled: true } as never)).rejects.toThrow(
+      AccountWriteOwnershipError,
+    );
+    expect(writes).toHaveLength(0);
+  });
+
+  test('throws on every trial column', async () => {
+    await expect(applyStripeSync(ACCT, { trialStatus: 'active' } as never)).rejects.toThrow(
+      /admin-owned/,
+    );
+  });
+
+  test("refuses tier='enterprise' outright", async () => {
+    await expect(applyStripeSync(ACCT, { tier: 'enterprise' })).rejects.toThrow(
+      /entitlement.*not a tier/,
+    );
+    expect(writes).toHaveLength(0);
+  });
+
+  test('pinned account (enterprise_entitled): tier is skipped, every other provider fact lands', async () => {
+    storedRow = { tier: 'per_seat', enterpriseEntitled: true };
+    await applyStripeSync(ACCT, { tier: 'per_seat', seatCount: 5, billingModel: 'per_seat' });
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.patch).toEqual({ seatCount: 5, billingModel: 'per_seat' });
+    expect(invalidated).toEqual([ACCT]);
+  });
+
+  test("pinned via legacy tier='enterprise' row: same skip", async () => {
+    storedRow = { tier: 'enterprise', enterpriseEntitled: false };
+    await applyStripeSync(ACCT, { tier: 'per_seat', stripeSubscriptionStatus: 'active' });
+    expect(writes[0]!.patch).toEqual({ stripeSubscriptionStatus: 'active' });
+  });
+
+  test('unpinned account: the tier write goes through', async () => {
+    storedRow = { tier: 'free', enterpriseEntitled: false };
+    await applyStripeSync(ACCT, { tier: 'per_seat' });
+    expect(writes[0]!.patch).toEqual({ tier: 'per_seat' });
+  });
+
+  test('pin rule leaving an empty patch skips the write entirely', async () => {
+    storedRow = { tier: 'per_seat', enterpriseEntitled: true };
+    await applyStripeSync(ACCT, { tier: 'free' });
+    expect(writes).toHaveLength(0);
+  });
+
+  test("mode 'update' never conjures a row (updateCreditAccount, not upsert)", async () => {
+    await applyStripeSync(ACCT, { paymentStatus: 'past_due' }, { mode: 'update', account: null });
+    expect(writes[0]!.fn).toBe('update');
+  });
+
+  test('ctx.account skips the row lookup and still pins', async () => {
+    await applyStripeSync(
+      ACCT,
+      { tier: 'free', seatCount: 1 },
+      { account: { tier: 'per_seat', enterpriseEntitled: true } },
+    );
+    expect(writes[0]!.patch).toEqual({ seatCount: 1 });
+  });
+});
+
+describe('applyAdminOverride ownership', () => {
+  test('throws on a provider-owned field', async () => {
+    await expect(
+      applyAdminOverride(ACCT, { stripeSubscriptionId: 'sub_x' } as never, actor),
+    ).rejects.toThrow(/provider-owned/);
+    expect(writes).toHaveLength(0);
+  });
+
+  test('tier is the one admin-assignable provider field', async () => {
+    await applyAdminOverride(ACCT, { tier: 'per_seat' }, actor);
+    expect(writes[0]!.patch).toEqual({ tier: 'per_seat' });
+    expect(invalidated).toEqual([ACCT]);
+  });
+
+  test("but never tier='enterprise'", async () => {
+    await expect(applyAdminOverride(ACCT, { tier: 'enterprise' }, actor)).rejects.toThrow(
+      /entitlement.*not a tier/,
+    );
+  });
+
+  test('admin-owned fields write through', async () => {
+    await applyAdminOverride(ACCT, { enterpriseEntitled: true, maxConcurrentSessions: 500 }, actor);
+    expect(writes[0]!.patch).toEqual({ enterpriseEntitled: true, maxConcurrentSessions: 500 });
+  });
+});
+
+describe('accountIsAdminPinned', () => {
+  test('no row → not pinned', () => {
+    expect(accountIsAdminPinned(null)).toBe(false);
+  });
+  test('enterprise_entitled pins; plain per_seat does not', () => {
+    expect(accountIsAdminPinned({ tier: 'per_seat', enterpriseEntitled: true })).toBe(true);
+    expect(accountIsAdminPinned({ tier: 'per_seat', enterpriseEntitled: false })).toBe(false);
+    expect(accountIsAdminPinned({ tier: 'enterprise', enterpriseEntitled: false })).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/unit-plan-price-guard.test.ts
+++ b/apps/api/src/__tests__/unit-plan-price-guard.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// Price-coverage tripwire: a plan the catalog calls sellable must resolve a
+// real PROD Stripe price, and every no-price state must be an explicit,
+// reviewed enumeration — not a silent getVisibleTiers() filter. tiers.ts boots
+// env validation, so pin the config to prod for the price-table switch.
+mock.module('../config', () => ({
+  config: { INTERNAL_KORTIX_ENV: 'prod', KORTIX_LLM_MARKUP: undefined },
+}));
+
+const { PLAN_CATALOG, listPlanRecords } = await import('../billing/services/plan-catalog');
+const { resolvePriceId, resolvePerSeatPriceId } = await import('../billing/services/tiers');
+
+// Grandfathered/retired records that are KNOWN to have no Stripe price. Adding
+// a key here is a reviewed decision; a key missing from here AND from Stripe is
+// a broken plan.
+const KNOWN_PRICELESS = new Set([
+  'tier_150_1200', // legacy Enterprise Max — never had a price in any env
+  'starter', // v3 flat plans: never sold, retired in the catalog
+  'team',
+  'scale',
+]);
+
+describe('plan price coverage (prod)', () => {
+  test('the sellable seat plan resolves a prod per-seat price', () => {
+    expect(resolvePerSeatPriceId()).toBeTruthy();
+  });
+
+  test('every current-status paid plan resolves a prod monthly price', () => {
+    for (const record of listPlanRecords()) {
+      if (record.status !== 'current') continue;
+      if (record.price.amountUsd === 0 || record.shape === 'contract') continue;
+      expect(resolvePriceId(record.key, 'monthly'), `current plan ${record.key}`).toBeTruthy();
+    }
+  });
+
+  test('every priced non-current plan either resolves a price or is explicitly enumerated priceless', () => {
+    for (const record of listPlanRecords()) {
+      if (record.status === 'current' || record.status === 'non_plan') continue;
+      if (record.price.amountUsd === 0 || record.shape === 'contract') continue;
+      if (record.shape === 'seat') continue; // priced via resolvePerSeatPriceId above
+      const price = resolvePriceId(record.key, 'monthly');
+      if (!price) {
+        expect(
+          KNOWN_PRICELESS.has(record.key),
+          `${record.key} has no prod price and is not in KNOWN_PRICELESS — either add the Stripe price or enumerate it deliberately`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  test('the priceless allowlist contains no key that actually has a price (stale entries)', () => {
+    for (const key of KNOWN_PRICELESS) {
+      expect(PLAN_CATALOG[key], `unknown catalog key ${key}`).toBeTruthy();
+      expect(resolvePriceId(key, 'monthly'), `${key} gained a price — remove it from KNOWN_PRICELESS`).toBeNull();
+    }
+  });
+});

--- a/apps/api/src/__tests__/unit-resolve-account.test.ts
+++ b/apps/api/src/__tests__/unit-resolve-account.test.ts
@@ -101,6 +101,11 @@ mock.module('../billing/repositories/credit-accounts', () => ({
   upsertCreditAccount: async (accountId: string, data: Record<string, unknown>) => {
     upsertCreditAccountCalls.push({ accountId, data });
   },
+  // The write-ownership chokepoint (account-write-owner.ts) imports this name;
+  // a partial mock without it fails the whole import chain at module load.
+  updateCreditAccount: async (accountId: string, data: Record<string, unknown>) => {
+    upsertCreditAccountCalls.push({ accountId, data });
+  },
 }));
 
 mock.module('../billing/services/credits', () => ({

--- a/apps/api/src/__tests__/unit-stripe-webhook-canonicalization.test.ts
+++ b/apps/api/src/__tests__/unit-stripe-webhook-canonicalization.test.ts
@@ -47,6 +47,7 @@ mock.module('../billing/repositories/credit-accounts', () => ({
   updateCreditAccount: async (accountId: string, data: Record<string, unknown>) => {
     state.updateCreditAccountCalls.push({ accountId, data });
   },
+  getSubscriptionInfo: async () => state.getCreditAccountResult,
 }));
 
 mock.module('../billing/repositories/customers', () => ({

--- a/apps/api/src/__tests__/unit-trial-admin-grants.test.ts
+++ b/apps/api/src/__tests__/unit-trial-admin-grants.test.ts
@@ -30,6 +30,10 @@ mock.module('../billing/repositories/credit-accounts', () => ({
   upsertCreditAccount: async (_id: string, patch: Record<string, unknown>) => {
     storedRow = { ...(storedRow ?? {}), ...patch };
   },
+  // account-write-owner.ts imports this name; partial mocks break the chain.
+  updateCreditAccount: async (_id: string, patch: Record<string, unknown>) => {
+    storedRow = { ...(storedRow ?? {}), ...patch };
+  },
 }));
 mock.module('../billing/services/entitlements', () => ({
   invalidateCachedAccountTier: () => {},

--- a/apps/api/src/accounts/iam/enterprise-demo.ts
+++ b/apps/api/src/accounts/iam/enterprise-demo.ts
@@ -16,7 +16,8 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { json, errors, auth } from '../../openapi';
 import { ACCOUNT_ACTIONS, assertAuthorized } from '../../iam';
-import { isDemoEnterprise, setDemoEnterprise } from '../../billing/repositories/credit-accounts';
+import { isDemoEnterprise } from '../../billing/repositories/credit-accounts';
+import { applyAdminOverride } from '../../billing/services/account-write-owner';
 import { isPlatformAdmin } from '../../shared/platform-roles';
 import { iamRouter, AccountIdParam } from './app';
 import { auditIam, readBody } from './helpers';
@@ -76,7 +77,11 @@ iamRouter.openapi(
     }
 
     const before = await isDemoEnterprise(accountId);
-    await setDemoEnterprise(accountId, body.enabled);
+    await applyAdminOverride(
+      accountId,
+      { demoEnterprise: body.enabled },
+      { userId, action: 'enterprise_demo.set' },
+    );
     await auditIam(c, {
       accountId,
       action: body.enabled ? 'enterprise_demo.enable' : 'enterprise_demo.disable',

--- a/apps/api/src/admin/index.ts
+++ b/apps/api/src/admin/index.ts
@@ -776,22 +776,18 @@ adminApp.openapi(
       );
     }
 
-    const { getSubscriptionInfo, upsertCreditAccount } = await import(
-      '../billing/repositories/credit-accounts'
-    );
+    const { getSubscriptionInfo } = await import('../billing/repositories/credit-accounts');
+    const { applyAdminOverride } = await import('../billing/services/account-write-owner');
     const before = await getSubscriptionInfo(accountId);
-    await upsertCreditAccount(accountId, { tier });
-
-    // Tier feeds TWO caches: the limit cache (60s) and the gateway tier-
-    // snapshot cache (30s, entitlements.ts — the managed-models decision on
-    // the auth hot path). Clear both so the change is visible immediately;
-    // clearing only the limit cache left the gateway serving the old tier for
-    // up to 30s. The per-request entitlement read (SSO/SCIM gates) is uncached
-    // and already sees it.
-    const { clearAccountLimitCache } = await import('../shared/account-limits');
-    const { invalidateCachedAccountTier } = await import('../billing/services/entitlements');
-    clearAccountLimitCache();
-    invalidateCachedAccountTier(accountId);
+    // `tier` is provider-owned everywhere else, and ADMIN_ASSIGNABLE here: an
+    // operator reassigning a plan by hand is a real support operation. The
+    // chokepoint still refuses 'enterprise' (the 400 above catches it first)
+    // and invalidates the one billing cache the value feeds.
+    await applyAdminOverride(
+      accountId,
+      { tier },
+      { userId: actorUserId ?? null, action: 'admin.account.tier.set' },
+    );
 
     try {
       const { recordAuditEvent } = await import('../shared/audit');
@@ -862,12 +858,14 @@ adminApp.openapi(
         return c.json({ error: 'enabled must be a boolean' }, 400);
       }
 
-      const {
-        isEnterpriseEntitled,
-        setEnterpriseEntitled,
-      } = await import('../billing/repositories/credit-accounts');
+      const { isEnterpriseEntitled } = await import('../billing/repositories/credit-accounts');
+      const { applyAdminOverride } = await import('../billing/services/account-write-owner');
       const before = await isEnterpriseEntitled(accountId);
-      await setEnterpriseEntitled(accountId, enabled);
+      await applyAdminOverride(
+        accountId,
+        { enterpriseEntitled: enabled },
+        { userId: actorUserId ?? null, action: 'admin.account.enterprise_entitlement.set' },
+      );
 
       // The per-request entitlement read (SSO/SCIM gates) is uncached and sees
       // the change immediately; no tier-cache invalidation needed because
@@ -937,9 +935,8 @@ adminApp.openapi(
     const accountId = c.req.param('id');
     const actorUserId = (c.get('userId') as string | undefined) ?? null;
     const body = c.req.valid('json') as { max_concurrent_sessions: number | null };
-    const { getSubscriptionInfo, upsertCreditAccount } = await import(
-      '../billing/repositories/credit-accounts'
-    );
+    const { getSubscriptionInfo } = await import('../billing/repositories/credit-accounts');
+    const { applyAdminOverride } = await import('../billing/services/account-write-owner');
     const { clearAccountLimitCache } = await import('../shared/account-limits');
     const { recordAuditEvent } = await import('../shared/audit');
 
@@ -954,7 +951,11 @@ adminApp.openapi(
       {
         getCurrent: async () => (await getSubscriptionInfo(accountId))?.maxConcurrentSessions ?? null,
         persist: async (id, value) => {
-          await upsertCreditAccount(id, { maxConcurrentSessions: value });
+          await applyAdminOverride(
+            id,
+            { maxConcurrentSessions: value },
+            { userId: actorUserId, action: 'admin.account.session_limit.set' },
+          );
         },
         clearCache: clearAccountLimitCache,
         recordAudit: recordAuditEvent,
@@ -1145,19 +1146,16 @@ adminApp.openapi(
       const actorUserId = (c.get('userId') as string | undefined) ?? null;
       const body = c.req.valid('json') as { override: boolean | null };
 
-      const { getCreditAccount, setManagedModelsOverride } = await import(
-        '../billing/repositories/credit-accounts'
-      );
+      const { getCreditAccount } = await import('../billing/repositories/credit-accounts');
+      const { applyAdminOverride } = await import('../billing/services/account-write-owner');
       const before = (await getCreditAccount(accountId))?.managedModelsOverride ?? null;
-      await setManagedModelsOverride(accountId, body.override);
-
-      // The managed-models answer is served from the shared tier-snapshot
-      // cache (gateway auth hot path) AND the limit cache (sandbox-provision
-      // gateway mount) — clear both so the flip is visible immediately.
-      const { invalidateCachedAccountTier } = await import('../billing/services/entitlements');
-      const { clearAccountLimitCache } = await import('../shared/account-limits');
-      invalidateCachedAccountTier(accountId);
-      clearAccountLimitCache();
+      // The chokepoint invalidates this account's billing cache — the one cache
+      // the managed-models answer is served from on the gateway auth hot path.
+      await applyAdminOverride(
+        accountId,
+        { managedModelsOverride: body.override },
+        { userId: actorUserId, action: 'admin.account.managed_models.set' },
+      );
 
       try {
         const { recordAuditEvent } = await import('../shared/audit');
@@ -1217,11 +1215,14 @@ adminApp.openapi(
       const actorUserId = (c.get('userId') as string | undefined) ?? null;
       const body = c.req.valid('json') as { enabled: boolean };
 
-      const { isDemoEnterprise, setDemoEnterprise } = await import(
-        '../billing/repositories/credit-accounts'
-      );
+      const { isDemoEnterprise } = await import('../billing/repositories/credit-accounts');
+      const { applyAdminOverride } = await import('../billing/services/account-write-owner');
       const before = await isDemoEnterprise(accountId);
-      await setDemoEnterprise(accountId, body.enabled);
+      await applyAdminOverride(
+        accountId,
+        { demoEnterprise: body.enabled },
+        { userId: actorUserId, action: 'admin.account.enterprise_demo.set' },
+      );
 
       try {
         const { recordAuditEvent } = await import('../shared/audit');

--- a/apps/api/src/billing/repositories/credit-accounts.ts
+++ b/apps/api/src/billing/repositories/credit-accounts.ts
@@ -22,21 +22,6 @@ export async function isDemoEnterprise(accountId: string): Promise<boolean> {
   return row?.demoEnterprise ?? false;
 }
 
-/**
- * Flip the enterprise-demo flag. Upserts the credit row so a brand-new account
- * (no billing row yet) can still preview the enterprise surface — all other
- * columns fall back to their schema defaults (tier 'free', legacy billing, …).
- */
-export async function setDemoEnterprise(accountId: string, enabled: boolean): Promise<void> {
-  await db
-    .insert(creditAccounts)
-    .values({ accountId, demoEnterprise: enabled })
-    .onConflictDoUpdate({
-      target: creditAccounts.accountId,
-      set: { demoEnterprise: enabled, updatedAt: new Date().toISOString() },
-    });
-}
-
 /** Whether the account is flagged as a contracted cloud Enterprise customer.
  *  When true the account resolves all enterprise entitlements (SSO/SCIM/RBAC/
  *  audit) regardless of its billing tier — decoupling feature entitlements
@@ -51,42 +36,13 @@ export async function isEnterpriseEntitled(accountId: string): Promise<boolean> 
   return row?.enterpriseEntitled ?? false;
 }
 
-/**
- * Set the contracted-Enterprise entitlement flag. Upserts the credit row so a
- * brand-new account (no billing row yet) can be flagged at sign-up — all other
- * columns fall back to their schema defaults (tier 'free', legacy billing, …)
- * and the Stripe webhook reconciliation will populate billing_model/tier/seat
- * fields from the customer's subscription without clobbering this entitlement.
- */
-export async function setEnterpriseEntitled(
-  accountId: string,
-  enabled: boolean,
-): Promise<void> {
-  await db
-    .insert(creditAccounts)
-    .values({ accountId, enterpriseEntitled: enabled })
-    .onConflictDoUpdate({
-      target: creditAccounts.accountId,
-      set: { enterpriseEntitled: enabled, updatedAt: new Date().toISOString() },
-    });
-}
-
-/**
- * Set the operator managed-models override. null restores "the effective tier
- * decides". Upserts so a brand-new account (no billing row yet) can be set.
- */
-export async function setManagedModelsOverride(
-  accountId: string,
-  override: boolean | null,
-): Promise<void> {
-  await db
-    .insert(creditAccounts)
-    .values({ accountId, managedModelsOverride: override })
-    .onConflictDoUpdate({
-      target: creditAccounts.accountId,
-      set: { managedModelsOverride: override, updatedAt: new Date().toISOString() },
-    });
-}
+// NOTE — there are deliberately no `setEnterpriseEntitled` /
+// `setManagedModelsOverride` / `setDemoEnterprise` writers here any more.
+// Those three columns are ADMIN-OWNED (billing/services/account-write-owner.ts):
+// every write goes through `applyAdminOverride`, which enforces the ownership
+// boundary against provider sync and invalidates the billing cache. A private
+// per-column setter is exactly the bypass that boundary exists to prevent.
+// The readers above stay — reading is not a write.
 
 export async function getCreditBalance(accountId: string) {
   const [row] = await db

--- a/apps/api/src/billing/services/account-write-owner.ts
+++ b/apps/api/src/billing/services/account-write-owner.ts
@@ -1,0 +1,283 @@
+/**
+ * WRITE OWNERSHIP for `credit_accounts`.
+ *
+ * One row, two writers, and until now no boundary between them:
+ *
+ *   - the BILLING PROVIDER sync (Stripe + RevenueCat webhooks, the legacy
+ *     Stripe backfill) reconciles what the customer is paying for;
+ *   - an OPERATOR (admin routes, trial issue/revoke) records intent the
+ *     provider knows nothing about — a contracted Enterprise entitlement, a
+ *     managed-models override, a raised session cap, an issued trial.
+ *
+ * They collided on `tier`. An operator sets `enterprise_entitled` (or, on the
+ * older path, `tier='enterprise'`); the next `customer.subscription.updated`
+ * writes `tier = resolvedTier` straight back and the account silently loses
+ * SSO/SCIM/RBAC/audit. The guard that used to live inline in
+ * `syncSubscriptionState` covered exactly ONE branch of ONE handler (a per-seat
+ * item on a paying subscription). Every other tier write — the price-resolved
+ * tier, the never-paid reset, `revertToFree`, the scheduled downgrade, the
+ * RevenueCat expiry — still clobbered.
+ *
+ * This module is the chokepoint. Both writers declare which side they are on,
+ * and the rules are enforced here instead of being re-derived at 14 call sites:
+ *
+ *   - `applyStripeSync`  — THROWS if the patch touches an admin-owned field or
+ *     tries to write `tier='enterprise'`; SKIPS the `tier` key (and only that
+ *     key) when the account is admin-pinned. Everything else it carries is
+ *     factual provider bookkeeping and is always applied.
+ *   - `applyAdminOverride` — THROWS if the patch touches a provider-owned
+ *     field. `tier` is the one deliberate exception (support ops reassign
+ *     plans), and it still may never be `'enterprise'`.
+ *
+ * Wallet and credit-bookkeeping columns (balances, lifetime totals, auto-topup,
+ * grant timestamps) are on NEITHER list on purpose: both writers legitimately
+ * move money, and money flows through `grantCredits`/`resetExpiringCredits`
+ * anyway, which have their own idempotency contract.
+ *
+ * Naming: the provider-side verb is `applyStripeSync` because Stripe is the
+ * writer that caused the damage, but the boundary it enforces is
+ * PROVIDER-vs-ADMIN — the RevenueCat handlers use it too, and `revenuecat*`
+ * columns are provider-owned.
+ */
+
+import type { creditAccounts } from '@kortix/db';
+import {
+  getCreditAccount,
+  updateCreditAccount,
+  upsertCreditAccount,
+} from '../repositories/credit-accounts';
+import { invalidateAccountBilling } from './billing-cache';
+
+export type AccountPatch = Partial<typeof creditAccounts.$inferInsert>;
+
+/**
+ * Columns that describe what the billing provider says is true. Only a
+ * provider-sync writer may set them.
+ *
+ * `tier` heads the list because it is the field the whole module exists for:
+ * it is an ENTITLEMENT derived from a subscription, and an operator can pin it
+ * out of the provider's reach (see `accountIsAdminPinned`).
+ */
+export const STRIPE_OWNED_FIELDS = [
+  'tier',
+  'billingModel',
+  'seatCount',
+  'seatSubscriptionItemId',
+  'stripeSubscriptionId',
+  'stripeSubscriptionStatus',
+  'billingCycleAnchor',
+  'planType',
+  'provider',
+  'paymentStatus',
+  'lastPaymentFailure',
+  'commitmentType',
+  'commitmentStartDate',
+  'commitmentEndDate',
+  'commitmentPriceId',
+  'canCancelAfter',
+  'scheduledTierChange',
+  'scheduledTierChangeDate',
+  'scheduledPriceId',
+  'lastProcessedInvoiceId',
+  'lastRenewalPeriodStart',
+  'revenuecatCustomerId',
+  'revenuecatSubscriptionId',
+  'revenuecatProductId',
+  'revenuecatCancelledAt',
+  'revenuecatCancelAtPeriodEnd',
+  'revenuecatPendingChangeProduct',
+  'revenuecatPendingChangeDate',
+  'revenuecatPendingChangeType',
+] as const;
+
+/**
+ * Columns that record operator intent. No provider webhook may set them — a
+ * patch that tries is a bug in the caller, not a value to be filtered out, so
+ * it throws rather than being silently dropped.
+ */
+export const ADMIN_OWNED_FIELDS = [
+  'enterpriseEntitled',
+  'demoEnterprise',
+  'managedModelsOverride',
+  'maxConcurrentSessions',
+  'trialStatus',
+  'trialTier',
+  'trialSeats',
+  'trialStartedAt',
+  'trialEndsAt',
+  'trialNote',
+  'trialGrantedBy',
+] as const;
+
+/**
+ * Provider-owned columns an admin MAY still write.
+ *
+ * Exactly one: `tier`. Support reassigns a plan by hand often enough
+ * (comped account, botched migration, refund) that removing the ability would
+ * just push operators to raw SQL, which no cache invalidation or audit trail
+ * observes. It is still never `'enterprise'` — that is an entitlement flag,
+ * not a tier (see `assertTierIsNotEnterprise`).
+ */
+export const ADMIN_ASSIGNABLE_FIELDS = ['tier'] as const;
+
+const STRIPE_OWNED: ReadonlySet<string> = new Set(STRIPE_OWNED_FIELDS);
+const ADMIN_OWNED: ReadonlySet<string> = new Set(ADMIN_OWNED_FIELDS);
+const ADMIN_ASSIGNABLE: ReadonlySet<string> = new Set(ADMIN_ASSIGNABLE_FIELDS);
+
+/** A patch crossed the ownership boundary. Always a caller bug. */
+export class AccountWriteOwnershipError extends Error {
+  readonly name = 'AccountWriteOwnershipError';
+  readonly fields: string[];
+
+  constructor(message: string, fields: string[]) {
+    super(message);
+    this.fields = fields;
+  }
+}
+
+/** The subset of a `credit_accounts` row the pin rule reads. */
+export type PinnableAccount = {
+  tier?: string | null;
+  enterpriseEntitled?: boolean | null;
+} | null;
+
+/**
+ * Is this account's tier owned by an operator rather than by the provider?
+ *
+ * Two shapes qualify, and both are in production:
+ *   - `enterprise_entitled = true` — the current primitive. A contracted cloud
+ *     Enterprise deal whose entitlements are independent of what Stripe bills.
+ *   - `tier = 'enterprise'` — the older sales-assignment. The admin tier route
+ *     refuses to create new ones (400), but existing rows still carry it and
+ *     must not be downgraded by a webhook.
+ *
+ * A pinned account still reconciles every other provider fact —
+ * `billing_model`, `seat_count`, subscription status, seat grants. Only `tier`
+ * is off-limits, which is exactly the split a deal that is BOTH Enterprise
+ * (entitlements) AND per-seat (billing) needs.
+ */
+export function accountIsAdminPinned(account: PinnableAccount): boolean {
+  if (!account) return false;
+  return account.enterpriseEntitled === true || account.tier === 'enterprise';
+}
+
+export interface StripeSyncContext {
+  /**
+   * The `credit_accounts` row the caller already read. Supplying it skips the
+   * pin lookup. `null` means "this account has no row"; omit the key entirely
+   * to have the pin check fetch it.
+   */
+  account?: PinnableAccount;
+  /**
+   * `'upsert'` (default) creates the row when it is missing. `'update'` is a
+   * no-op on a missing row — the correct choice for handlers that must never
+   * conjure a billing row out of an event, e.g. `invoice.payment_failed`.
+   */
+  mode?: 'upsert' | 'update';
+  /** Short label for the log line, e.g. `'customer.subscription.updated'`. */
+  reason?: string;
+}
+
+export interface AdminActor {
+  /** The operator's user id, when the write came from an authenticated route. */
+  userId?: string | null;
+  /** Audit-style label for the log line, e.g. `'admin.account.tier.set'`. */
+  action: string;
+}
+
+function violations(patch: AccountPatch, forbidden: ReadonlySet<string>): string[] {
+  return Object.keys(patch).filter((key) => forbidden.has(key));
+}
+
+/**
+ * `enterprise` is an entitlement, not a tier. A `tier='enterprise'` write is
+ * clobbered by the next subscription sync, so accepting one hands the caller a
+ * change that silently reverts. Both writers refuse it.
+ */
+function assertTierIsNotEnterprise(patch: AccountPatch, writer: string): void {
+  if (patch.tier === 'enterprise') {
+    throw new AccountWriteOwnershipError(
+      `${writer}: refusing to write tier='enterprise' — enterprise is an entitlement (enterprise_entitled), not a tier`,
+      ['tier'],
+    );
+  }
+}
+
+/**
+ * Write provider-derived billing state.
+ *
+ * Throws when the patch reaches into admin-owned territory. Drops the `tier`
+ * key — and nothing else — when the account is admin-pinned.
+ */
+export async function applyStripeSync(
+  accountId: string,
+  patch: AccountPatch,
+  ctx: StripeSyncContext = {},
+): Promise<void> {
+  const foreign = violations(patch, ADMIN_OWNED);
+  if (foreign.length > 0) {
+    throw new AccountWriteOwnershipError(
+      `applyStripeSync: refusing to write admin-owned field(s) ${foreign.join(', ')} for ${accountId} — route this through applyAdminOverride (or a narrow cross-domain helper) instead`,
+      foreign,
+    );
+  }
+  assertTierIsNotEnterprise(patch, 'applyStripeSync');
+
+  const next: AccountPatch = { ...patch };
+  const label = ctx.reason ? ` (${ctx.reason})` : '';
+
+  if ('tier' in next) {
+    const account = 'account' in ctx ? ctx.account : await getCreditAccount(accountId);
+    if (accountIsAdminPinned(account ?? null)) {
+      console.warn(
+        `[write-owner] applyStripeSync${label}: skipping tier='${String(next.tier)}' for ${accountId} — the account is admin-pinned (enterprise_entitled=${String(account?.enterpriseEntitled ?? false)}, tier='${String(account?.tier ?? null)}'). Every other provider field is still applied.`,
+      );
+      delete next.tier;
+    }
+  }
+
+  if (Object.keys(next).length === 0) {
+    console.warn(
+      `[write-owner] applyStripeSync${label}: nothing left to write for ${accountId} after the pin rule — skipping the write.`,
+    );
+    return;
+  }
+
+  if (ctx.mode === 'update') {
+    await updateCreditAccount(accountId, next);
+  } else {
+    await upsertCreditAccount(accountId, next);
+  }
+
+  invalidateAccountBilling(accountId);
+}
+
+/**
+ * Write operator intent.
+ *
+ * Throws when the patch reaches into provider-owned territory, except for the
+ * one field an admin may legitimately assign (`tier`).
+ */
+export async function applyAdminOverride(
+  accountId: string,
+  patch: AccountPatch,
+  actor: AdminActor,
+): Promise<void> {
+  const foreign = violations(patch, STRIPE_OWNED).filter((key) => !ADMIN_ASSIGNABLE.has(key));
+  if (foreign.length > 0) {
+    throw new AccountWriteOwnershipError(
+      `applyAdminOverride: refusing to write provider-owned field(s) ${foreign.join(', ')} for ${accountId} — those are reconciled from the billing provider by applyStripeSync`,
+      foreign,
+    );
+  }
+  assertTierIsNotEnterprise(patch, 'applyAdminOverride');
+
+  if (Object.keys(patch).length === 0) return;
+
+  await upsertCreditAccount(accountId, patch);
+  invalidateAccountBilling(accountId);
+
+  console.log(
+    `[write-owner] applyAdminOverride: ${actor.action} on ${accountId} by ${actor.userId ?? 'system'} → ${Object.keys(patch).join(', ')}`,
+  );
+}

--- a/apps/api/src/billing/services/legacy-stripe-sync.ts
+++ b/apps/api/src/billing/services/legacy-stripe-sync.ts
@@ -75,7 +75,7 @@ export async function syncLegacyStripeSubscription(
     const { getStripe } = await import('../../shared/stripe');
     const stripe = getStripe();
     const { getBillingPeriodByPriceId, getTier, getTierByPriceId } = await import('./tiers');
-    const { upsertCreditAccount } = await import('../repositories/credit-accounts');
+    const { applyStripeSync } = await import('./account-write-owner');
     const { resetExpiringCredits } = await import('./credits');
 
     const candidateCustomerIds = new Set<string>();
@@ -134,6 +134,11 @@ export async function syncLegacyStripeSubscription(
             ...subscription.metadata,
             account_id: accountId,
             tier_key: tierConfig.name,
+            // Forward-compat alias, written in lockstep with tier_key. The
+            // webhook resolves `plan_key ?? tier_key`, so any writer that sets
+            // one and not the other would leave the OTHER one authoritative and
+            // stale. See subscriptions.ts for the same pairing.
+            plan_key: tierConfig.name,
             billing_period: billingPeriod,
           };
 
@@ -165,20 +170,24 @@ export async function syncLegacyStripeSubscription(
         if (!dryRun) {
           const tier = getTier(tierConfig.name);
 
-          await upsertCreditAccount(accountId, {
-            tier: tierConfig.name,
-            provider: 'stripe',
-            stripeSubscriptionId: subscription.id,
-            stripeSubscriptionStatus: subscription.status,
-            billingCycleAnchor: subscription.billing_cycle_anchor
-              ? new Date(subscription.billing_cycle_anchor * 1000).toISOString()
-              : undefined,
-            planType,
-            commitmentType,
-            commitmentEndDate: commitmentType && subscription.current_period_end
-              ? new Date(subscription.current_period_end * 1000).toISOString()
-              : null,
-          });
+          await applyStripeSync(
+            accountId,
+            {
+              tier: tierConfig.name,
+              provider: 'stripe',
+              stripeSubscriptionId: subscription.id,
+              stripeSubscriptionStatus: subscription.status,
+              billingCycleAnchor: subscription.billing_cycle_anchor
+                ? new Date(subscription.billing_cycle_anchor * 1000).toISOString()
+                : undefined,
+              planType,
+              commitmentType,
+              commitmentEndDate: commitmentType && subscription.current_period_end
+                ? new Date(subscription.current_period_end * 1000).toISOString()
+                : null,
+            },
+            { reason: 'legacy-stripe-sync' },
+          );
 
           if (tier.monthlyCredits > 0) {
             await resetExpiringCredits(

--- a/apps/api/src/billing/services/subscriptions.ts
+++ b/apps/api/src/billing/services/subscriptions.ts
@@ -128,6 +128,11 @@ export async function createCheckoutSession(params: {
   const metadata = {
     account_id: accountId,
     tier_key: tierKey,
+    // `plan_key` is the forward name for the same value; the webhook resolves
+    // `plan_key ?? tier_key ?? price lookup`. Every writer sets BOTH — writing
+    // only one leaves the other stale and, because plan_key wins, a later
+    // tier_key-only update would be silently ignored.
+    plan_key: tierKey,
     commitment_type: commitmentType ?? 'monthly',
     ...(previousFreeSubscriptionId ? { previous_subscription_id: previousFreeSubscriptionId } : {}),
     ...(serverType ? { server_type: serverType } : {}),
@@ -323,6 +328,7 @@ export async function createPerSeatCheckoutSession(params: {
   const metadata = {
     account_id: accountId,
     tier_key: 'per_seat',
+    plan_key: 'per_seat',
     billing_model: 'per_seat',
     initial_seat_count: String(seatCount),
   };
@@ -402,6 +408,7 @@ export async function createInlineCheckout(params: {
     metadata: {
       account_id: accountId,
       tier_key: tierKey,
+      plan_key: tierKey,
       billing_period: billingPeriod,
       ...(previousFreeSubscriptionId ? { previous_subscription_id: previousFreeSubscriptionId } : {}),
     },
@@ -944,6 +951,10 @@ async function handleUpgrade(
     metadata: {
       ...subscription.metadata,
       tier_key: targetTierKey,
+      // Must be rewritten alongside tier_key. The spread above carries the OLD
+      // plan_key forward, and plan_key wins in the webhook's resolution order —
+      // leaving it stale would resolve every post-upgrade event to the old plan.
+      plan_key: targetTierKey,
       previous_tier: subscription.metadata?.tier_key ?? 'unknown',
       downgrade: '',
       target_tier: '',

--- a/apps/api/src/billing/services/trial-admin.ts
+++ b/apps/api/src/billing/services/trial-admin.ts
@@ -10,7 +10,8 @@ import { creditAccounts, creditLedger } from '@kortix/db';
 import { and, eq, gt, lte } from 'drizzle-orm';
 import { db } from '../../shared/db';
 import { clearAccountLimitCache } from '../../shared/account-limits';
-import { getCreditAccount, upsertCreditAccount } from '../repositories/credit-accounts';
+import { getCreditAccount } from '../repositories/credit-accounts';
+import { applyAdminOverride } from './account-write-owner';
 import { TRIAL_STATUS } from './effective-tier';
 import { grantCredits } from './credits';
 import { invalidateCachedAccountTier } from './entitlements';
@@ -110,15 +111,19 @@ export async function grantTrial(input: GrantTrialInput): Promise<{
   const now = new Date();
   const endsAt = new Date(now.getTime() + input.durationDays * 24 * 60 * 60 * 1000);
 
-  await upsertCreditAccount(input.accountId, {
-    trialStatus: TRIAL_STATUS.ACTIVE,
-    trialTier: input.tierKey,
-    trialSeats: input.seats,
-    trialStartedAt: now.toISOString(),
-    trialEndsAt: endsAt.toISOString(),
-    trialNote: input.note?.slice(0, 2000) ?? null,
-    trialGrantedBy: input.actorUserId ?? null,
-  });
+  await applyAdminOverride(
+    input.accountId,
+    {
+      trialStatus: TRIAL_STATUS.ACTIVE,
+      trialTier: input.tierKey,
+      trialSeats: input.seats,
+      trialStartedAt: now.toISOString(),
+      trialEndsAt: endsAt.toISOString(),
+      trialNote: input.note?.slice(0, 2000) ?? null,
+      trialGrantedBy: input.actorUserId ?? null,
+    },
+    { userId: input.actorUserId ?? null, action: 'admin.account.trial.grant' },
+  );
 
   const creditGranted = input.creditGrant ?? 0;
   if (creditGranted > 0) {
@@ -157,9 +162,40 @@ export async function revokeTrial(accountId: string): Promise<{
   if (before.status !== TRIAL_STATUS.ACTIVE) {
     throw new Error(`no active trial to revoke (status: ${before.status})`);
   }
-  await upsertCreditAccount(accountId, { trialStatus: TRIAL_STATUS.REVOKED });
+  await applyAdminOverride(
+    accountId,
+    { trialStatus: TRIAL_STATUS.REVOKED },
+    { action: 'admin.account.trial.revoke' },
+  );
   invalidateEntitlementCaches(accountId);
   return { before, current: trialSnapshotFromRow(await getCreditAccount(accountId)) };
+}
+
+/**
+ * Flip an ACTIVE trial to 'converted' because a real subscription landed.
+ *
+ * A deliberate cross-domain write, and the only one in the file: `trial_status`
+ * is admin-owned (an operator issues the trial), but the FACT that ends it —
+ * a paying subscription — is only ever observed by the billing-provider
+ * webhook. Rather than let `applyStripeSync` carry an admin-owned key (it
+ * throws on one, on purpose), the webhook calls this narrow verb, which writes
+ * exactly one field and nothing else.
+ *
+ * Self-guarding: it re-reads the row and no-ops unless the trial is still
+ * ACTIVE, so a redelivered webhook cannot turn 'none'/'expired'/'revoked' into
+ * 'converted'. Returns whether it wrote.
+ */
+export async function markTrialConverted(accountId: string): Promise<boolean> {
+  const row = await getCreditAccount(accountId);
+  if (row?.trialStatus !== TRIAL_STATUS.ACTIVE) return false;
+
+  await applyAdminOverride(
+    accountId,
+    { trialStatus: TRIAL_STATUS.CONVERTED },
+    { action: 'billing.trial.converted' },
+  );
+  invalidateEntitlementCaches(accountId);
+  return true;
 }
 
 const MS_PER_TRIAL_MONTH = 30 * 24 * 60 * 60 * 1000;

--- a/apps/api/src/billing/services/webhooks.ts
+++ b/apps/api/src/billing/services/webhooks.ts
@@ -3,11 +3,9 @@ import { getStripe } from '../../shared/stripe';
 import { forgetWebhookEvent, recordWebhookEvent, withAccountLock } from './webhook-concurrency';
 import { config } from '../../config';
 import { WebhookError } from '../../errors';
-import {
-  getCreditAccount,
-  updateCreditAccount,
-  upsertCreditAccount,
-} from '../repositories/credit-accounts';
+import { getCreditAccount } from '../repositories/credit-accounts';
+import { applyStripeSync } from './account-write-owner';
+import { markTrialConverted } from './trial-admin';
 import { getCustomerByStripeId, upsertCustomer } from '../repositories/customers';
 import { updatePurchaseStatus, getPurchaseByPaymentIntent } from '../repositories/transactions';
 import {
@@ -31,6 +29,30 @@ import { cancelFreeSubscriptionForUpgrade } from './subscriptions';
 import { calculateNextCreditGrant } from './credit-grant-schedule';
 import { AUTO_TOPUP_DEFAULT_AMOUNT, AUTO_TOPUP_DEFAULT_THRESHOLD } from '@kortix/shared';
 import { resolveAccountId } from '../../shared/resolve-account';
+
+/**
+ * The plan a Stripe object names in its metadata.
+ *
+ * Resolution order is `plan_key ?? tier_key`. `plan_key` is the forward name
+ * and every writer now sets BOTH in lockstep (subscriptions.ts,
+ * legacy-stripe-sync.ts, and the metadata repairs in this file), so the two can
+ * only disagree on an object created before `plan_key` existed — where
+ * `tier_key` is the only answer there is. A price-id lookup is the last resort
+ * and stays at the call sites that have a price.
+ *
+ * `||`, not `??`: Stripe deletes a metadata key by setting it to `''`, and an
+ * empty string must fall through rather than resolve to a plan named "".
+ */
+function planKeyFromMetadata(
+  metadata: Stripe.Metadata | null | undefined,
+): string | undefined {
+  return metadata?.plan_key || metadata?.tier_key || undefined;
+}
+
+/** Both spellings of the plan key, for writing Stripe subscription metadata. */
+function planKeyMetadata(planKey: string): { tier_key: string; plan_key: string } {
+  return { tier_key: planKey, plan_key: planKey };
+}
 
 export async function processStripeWebhook(rawBody: string, signature: string) {
   const stripe = getStripe();
@@ -138,7 +160,7 @@ async function handleCreditPurchase(session: Stripe.Checkout.Session, accountId:
 }
 
 async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, accountId: string) {
-  const tierKey = session.metadata?.tier_key;
+  const tierKey = planKeyFromMetadata(session.metadata);
   if (!tierKey) return;
 
   const subscriptionId = typeof session.subscription === 'string'
@@ -166,11 +188,15 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
   // legitimate case this gate also catches: delayed payment methods
   // (bank debits, vouchers) whose checkout completes before the money does.
   if (session.payment_status !== 'paid') {
-    await upsertCreditAccount(accountId, {
-      stripeSubscriptionId: subscriptionId,
-      stripeSubscriptionStatus: subscription.status,
-      provider: 'stripe',
-    });
+    await applyStripeSync(
+      accountId,
+      {
+        stripeSubscriptionId: subscriptionId,
+        stripeSubscriptionStatus: subscription.status,
+        provider: 'stripe',
+      },
+      { reason: 'checkout.session.completed:deferred' },
+    );
     console.log(
       `[Webhook] Deferred subscription activation for ${accountId} (sub=${subscriptionId}): checkout payment_status=${session.payment_status ?? 'unknown'}, subscription status=${subscription.status}. Waiting for invoice.paid.`,
     );
@@ -265,30 +291,39 @@ async function activateSubscriptionForAccount(params: {
     ? defaultAutoTopupForSeats(seatCount)
     : null;
 
-  await upsertCreditAccount(accountId, {
-    tier: tierKey,
-    // A real subscription ends an admin-issued trial: mark it converted so the
-    // trial overlay (effective-tier.ts) stops masking the purchased plan.
-    ...(existingAccount?.trialStatus === 'active' ? { trialStatus: 'converted' } : {}),
-    provider: 'stripe',
-    stripeSubscriptionId: subscriptionId,
-    stripeSubscriptionStatus: 'active',
-    planType: isYearly ? 'yearly' : 'monthly',
-    commitmentType: commitmentType === 'yearly_commitment' ? commitmentType : null,
-    nextCreditGrant: nextCreditGrantTs,
-    lastRenewalPeriodStart: subscription.current_period_start,
-    ...(isPerSeat ? {
-      billingModel: 'per_seat',
-      seatCount,
-      ...(perSeatAutoTopupDefaults ? {
-        autoTopupThreshold: String(perSeatAutoTopupDefaults.threshold),
-        autoTopupAmount: String(perSeatAutoTopupDefaults.amount),
+  await applyStripeSync(
+    accountId,
+    {
+      tier: tierKey,
+      provider: 'stripe',
+      stripeSubscriptionId: subscriptionId,
+      stripeSubscriptionStatus: 'active',
+      planType: isYearly ? 'yearly' : 'monthly',
+      commitmentType: commitmentType === 'yearly_commitment' ? commitmentType : null,
+      nextCreditGrant: nextCreditGrantTs,
+      lastRenewalPeriodStart: subscription.current_period_start,
+      ...(isPerSeat ? {
+        billingModel: 'per_seat',
+        seatCount,
+        ...(perSeatAutoTopupDefaults ? {
+          autoTopupThreshold: String(perSeatAutoTopupDefaults.threshold),
+          autoTopupAmount: String(perSeatAutoTopupDefaults.amount),
+        } : {}),
       } : {}),
-    } : {}),
-    autoTopupEnabled: true,
-    autoTopupThreshold: String(perSeatAutoTopupDefaults?.threshold ?? AUTO_TOPUP_DEFAULT_THRESHOLD),
-    autoTopupAmount: String(perSeatAutoTopupDefaults?.amount ?? AUTO_TOPUP_DEFAULT_AMOUNT),
-  });
+      autoTopupEnabled: true,
+      autoTopupThreshold: String(perSeatAutoTopupDefaults?.threshold ?? AUTO_TOPUP_DEFAULT_THRESHOLD),
+      autoTopupAmount: String(perSeatAutoTopupDefaults?.amount ?? AUTO_TOPUP_DEFAULT_AMOUNT),
+    },
+    { account: existingAccount, reason: 'subscription.activated' },
+  );
+
+  // A real subscription ends an admin-issued trial: mark it converted so the
+  // trial overlay (effective-tier.ts) stops masking the purchased plan.
+  // `trial_status` is admin-owned, so it cannot ride along in the patch above —
+  // it goes through the narrow cross-domain helper in trial-admin.ts.
+  if (existingAccount?.trialStatus === 'active') {
+    await markTrialConverted(accountId);
+  }
 
   // For per-seat: grant grantForSeats(seatCount) so 1 seat → $25, 3 seats → $75, etc.
   // For legacy tiers: grant tier.monthlyCredits (unchanged behaviour).
@@ -358,7 +393,7 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
   if (account?.stripeSubscriptionId && account.stripeSubscriptionId !== subscription.id) {
     const previousSubId = subscription.metadata?.previous_subscription_id;
     const currentTier = account.tier ?? 'free';
-    const incomingTier = subscription.metadata?.tier_key;
+    const incomingTier = planKeyFromMetadata(subscription.metadata);
     const isFreeUpgrade =
       currentTier === 'free' &&
       incomingTier &&
@@ -413,7 +448,7 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     }
   }
 
-  const tierKey = subscription.metadata?.tier_key;
+  const tierKey = planKeyFromMetadata(subscription.metadata);
   const priceId = subscription.items.data[0]?.price?.id;
   const resolvedTier = tierKey ?? getTierByPriceId(priceId ?? '')?.name ?? null;
   const billingPeriod = getBillingPeriodByPriceId(priceId ?? '') ?? (subscription.metadata?.commitment_type as any) ?? 'monthly';
@@ -466,22 +501,6 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
       (perSeatPriceId && item.price?.id === perSeatPriceId) ||
       subscription.metadata?.billing_model === 'per_seat',
   );
-  // Whether this account's enterprise entitlements are sourced independently of
-  // `tier` — either because an operator set `enterprise_entitled` (a contracted
-  // cloud Enterprise deal) or because the account already carries the
-  // sales-assigned `tier='enterprise'`. In either case the per-seat billing
-  // reconciliation below must NOT clobber `tier` to `per_seat`: doing so would
-  // strip the enterprise identity surface (SSO/SCIM/RBAC/audit) on every
-  // ordinary subscription update. The per-seat billing semantics live on
-  // `billing_model='per_seat'` (set unconditionally below), which is the correct
-  // independent carrier — seat grants, auto-topup, and compute metering all key
-  // off `billing_model`, never `tier`. Keeping `tier='enterprise'` (or whatever
-  // the operator set) while `billing_model='per_seat'` is exactly the contract
-  // shape a deal that is BOTH Enterprise AND per-seat needs. See
-  // entitlements.ts (enterprise_entitled override) and the
-  // enterprise-per-seat-entitlement-coupling design note.
-  const accountIsEnterpriseEntitled =
-    !!account && (account.enterpriseEntitled || account.tier === 'enterprise');
   let perSeatDelta = 0;
   let perSeatNewSeats = 0;
   // Same gate as the tier write. Seat count, billing model, and the seat
@@ -492,25 +511,19 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     const oldSeats = account?.seatCount ?? 0;
     perSeatDelta = newSeats - oldSeats;
     perSeatNewSeats = newSeats;
+    // Per-seat BILLING semantics live on `billing_model`, `seat_count`, and the
+    // seat item id — never on `tier`. All three are written unconditionally:
+    // seat grants, auto-topup scaling, and compute metering key off
+    // `billing_model`, so an enterprise-entitled account still reconciles them.
     updates.billingModel = 'per_seat';
     updates.seatCount = newSeats;
     updates.seatSubscriptionItemId = perSeatItem.id;
-    // Only flip `tier` to `per_seat` when the account is NOT enterprise-entitled.
-    // For an enterprise-entitled account, `billing_model='per_seat'` already
-    // carries the per-seat billing semantics; leaving `tier` untouched preserves
-    // the enterprise identity entitlements that key off it (or off
-    // `enterprise_entitled`). The previous unconditional `updates.tier =
-    // 'per_seat'` here downgraded a sales-assigned `tier='enterprise'` (or an
-    // `enterprise_entitled` account) on the very first per-seat webhook and on
-    // every subsequent seat-quantity update, silently removing SSO/SCIM/RBAC/audit.
-    if (!accountIsEnterpriseEntitled) {
-      updates.tier = 'per_seat';
-    } else if (updates.tier === 'per_seat') {
-      // `resolvedTier` above may have resolved to 'per_seat' from the price id
-      // before we knew the account was enterprise-entitled. Drop that tier
-      // write so we don't clobber the enterprise tier/entitlements.
-      delete updates.tier;
-    }
+    // `tier` is asserted plainly. The ad-hoc "unless enterprise-entitled" branch
+    // that used to sit here is gone: it protected exactly this one write while
+    // the price-resolved tier, the never-paid reset, revertToFree, the scheduled
+    // downgrade, and the RevenueCat expiry all still clobbered. The pin rule now
+    // lives once, in applyStripeSync, and covers every one of them.
+    updates.tier = 'per_seat';
 
     // Apply scaled auto-topup defaults if the user hasn't customised them.
     if (!account?.autoTopupCustomized) {
@@ -520,17 +533,14 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     }
   }
 
-  // A real, paying subscription ends an admin-issued trial: mark it converted
-  // so the trial overlay (effective-tier.ts) stops masking the purchased plan.
-  // Only paying statuses count — an incomplete/past_due sub must not eat the
-  // trial the account is still evaluating on.
-  if (
+  // A real, paying subscription ends an admin-issued trial. Only paying
+  // statuses count — an incomplete/past_due sub must not eat the trial the
+  // account is still evaluating on. Decided here, written after the sync below:
+  // `trial_status` is admin-owned and may not ride along in a provider patch.
+  const trialConvertedByThisSub =
     account?.trialStatus === 'active' &&
-    (updates.tier || perSeatItem) &&
-    (subscription.status === 'active' || subscription.status === 'trialing')
-  ) {
-    updates.trialStatus = 'converted';
-  }
+    !!(updates.tier || perSeatItem) &&
+    (subscription.status === 'active' || subscription.status === 'trialing');
 
   // NEVER-PAID RESET — revoke a tier this subscription should never have granted.
   //
@@ -566,10 +576,16 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
     }
   }
 
-  if (!account) {
-    await upsertCreditAccount(accountId, updates);
-  } else {
-    await updateCreditAccount(accountId, updates);
+  await applyStripeSync(accountId, updates, {
+    account,
+    // A missing row is CREATED here (the account's first subscription event);
+    // an existing row is patched in place.
+    mode: account ? 'update' : 'upsert',
+    reason: 'customer.subscription.sync',
+  });
+
+  if (trialConvertedByThisSub) {
+    await markTrialConverted(accountId);
   }
 
   // A per-seat recovery must be sized by SEATS. getMonthlyCredits('per_seat')
@@ -670,9 +686,9 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
     // subscription in Stripe (e.g. a paid plan sub that was orphaned when a
     // machine sub hijacked the credit_accounts row). If so, re-stitch the row
     // to that sub instead of stranding the customer on free with no credits.
-    const restored = await tryRestoreOtherActiveSubscription(accountId, subscription);
+    const restored = await tryRestoreOtherActiveSubscription(accountId, subscription, account);
     if (restored) return;
-    await revertToFree(accountId, subscription.id);
+    await revertToFree(accountId, subscription.id, account);
   });
 }
 
@@ -690,6 +706,7 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
 async function tryRestoreOtherActiveSubscription(
   accountId: string,
   deletedSubscription: Stripe.Subscription,
+  account: Awaited<ReturnType<typeof getCreditAccount>>,
 ): Promise<boolean> {
   const customerId = typeof deletedSubscription.customer === 'string'
     ? deletedSubscription.customer
@@ -716,20 +733,21 @@ async function tryRestoreOtherActiveSubscription(
 
   // Prefer a non-machine (plan) subscription — one without server_type
   // metadata and with a real tier_key — over a machine sub.
-  const planSub = otherSubs.find(
-    (s) => s.metadata?.tier_key && s.metadata.tier_key !== 'free' && !s.metadata?.server_type,
-  );
+  const planSub = otherSubs.find((s) => {
+    const key = planKeyFromMetadata(s.metadata);
+    return !!key && key !== 'free' && !s.metadata?.server_type;
+  });
   const target = planSub ?? otherSubs[0];
 
   console.log(
-    `[Webhook] handleSubscriptionDeleted: restoring ${accountId} to other active subscription ${target.id} (tier=${target.metadata?.tier_key ?? 'unknown'}) instead of reverting to free`,
+    `[Webhook] handleSubscriptionDeleted: restoring ${accountId} to other active subscription ${target.id} (tier=${planKeyFromMetadata(target.metadata) ?? 'unknown'}) instead of reverting to free`,
   );
   // Repoint the account to the surviving subscription directly. We don't call
   // syncSubscriptionState here because its stale-sub guard would bail (the
   // stored stripeSubscriptionId is the deleted sub, ≠ the target sub). The
   // target sub is already active/trialing (we filtered for that), so we
   // resolve its tier and apply the update inline.
-  const targetTierKey = target.metadata?.tier_key;
+  const targetTierKey = planKeyFromMetadata(target.metadata);
   const targetPriceId = target.items?.data?.[0]?.price?.id;
   const resolvedTier = targetTierKey ?? getTierByPriceId(targetPriceId ?? '')?.name ?? null;
   const billingPeriod = getBillingPeriodByPriceId(targetPriceId ?? '') ?? (target.metadata?.commitment_type as any) ?? 'monthly';
@@ -749,23 +767,39 @@ async function tryRestoreOtherActiveSubscription(
   if (resolvedTier) {
     updates.tier = resolvedTier;
   }
-  await updateCreditAccount(accountId, updates);
+  await applyStripeSync(accountId, updates, {
+    account,
+    mode: 'update',
+    reason: 'customer.subscription.deleted:restore',
+  });
   return true;
 }
 
-async function revertToFree(accountId: string, subscriptionId?: string) {
+async function revertToFree(
+  accountId: string,
+  subscriptionId: string | undefined,
+  account: Awaited<ReturnType<typeof getCreditAccount>>,
+) {
   void subscriptionId;
 
-  await updateCreditAccount(accountId, {
-    tier: 'free',
-    stripeSubscriptionStatus: 'canceled',
-    scheduledTierChange: null,
-    scheduledTierChangeDate: null,
-    scheduledPriceId: null,
-    commitmentType: null,
-    commitmentEndDate: null,
-    paymentStatus: 'active',
-  });
+  // `tier: 'free'` is a legitimate provider write — the subscription that paid
+  // for the tier is gone. It is still subject to the pin rule: an
+  // enterprise-entitled account keeps its tier and loses only the Stripe
+  // bookkeeping, because its entitlement came from a contract, not this sub.
+  await applyStripeSync(
+    accountId,
+    {
+      tier: 'free',
+      stripeSubscriptionStatus: 'canceled',
+      scheduledTierChange: null,
+      scheduledTierChangeDate: null,
+      scheduledPriceId: null,
+      commitmentType: null,
+      commitmentEndDate: null,
+      paymentStatus: 'active',
+    },
+    { account, mode: 'update', reason: 'customer.subscription.deleted:revert' },
+  );
   console.log(`[Webhook] Reverted to free tier: ${accountId}`);
 }
 
@@ -826,12 +860,16 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
     ? calculateNextCreditGrant(new Date()).toISOString()
     : new Date(subscription.current_period_end * 1000).toISOString();
 
-  await updateCreditAccount(accountId, {
-    lastRenewalPeriodStart: periodStart,
-    lastProcessedInvoiceId: invoice.id,
-    lastGrantDate: new Date().toISOString(),
-    nextCreditGrant,
-  });
+  await applyStripeSync(
+    accountId,
+    {
+      lastRenewalPeriodStart: periodStart,
+      lastProcessedInvoiceId: invoice.id,
+      lastGrantDate: new Date().toISOString(),
+      nextCreditGrant,
+    },
+    { account, mode: 'update', reason: 'invoice.paid:renewal' },
+  );
 
   console.log(`[Webhook] Renewal processed: ${credits} credits for ${accountId}`);
 }
@@ -871,7 +909,7 @@ async function activateOnFirstInvoicePaid(
   }
 
   const priceId = subscription.items.data[0]?.price?.id;
-  const tierKey = subscription.metadata?.tier_key ?? getTierByPriceId(priceId ?? '')?.name;
+  const tierKey = planKeyFromMetadata(subscription.metadata) ?? getTierByPriceId(priceId ?? '')?.name;
   if (!tierKey) {
     console.warn(
       `[Webhook] invoice.paid(subscription_create): no tier for ${accountId} (sub=${subscriptionId} price=${priceId ?? 'none'})`,
@@ -907,14 +945,14 @@ async function applyScheduledDowngrade(accountId: string, targetTier: string, ac
 
       if (currentPriceId === account.scheduledPriceId) {
         await stripe.subscriptions.update(account.stripeSubscriptionId, {
-          metadata: { ...subscription.metadata, tier_key: targetTier, downgrade: '', target_tier: '' },
+          metadata: { ...subscription.metadata, ...planKeyMetadata(targetTier), downgrade: '', target_tier: '' },
         });
         console.log(`[Webhook] Price already correct (schedule applied), updated metadata for ${accountId}`);
       } else {
         await stripe.subscriptions.update(account.stripeSubscriptionId, {
           items: [{ id: subscription.items.data[0].id, price: account.scheduledPriceId }],
           proration_behavior: 'none',
-          metadata: { ...subscription.metadata, tier_key: targetTier, downgrade: '', target_tier: '' },
+          metadata: { ...subscription.metadata, ...planKeyMetadata(targetTier), downgrade: '', target_tier: '' },
         });
         console.log(`[Webhook] Stripe price updated to ${account.scheduledPriceId} for ${accountId}`);
       }
@@ -923,12 +961,16 @@ async function applyScheduledDowngrade(accountId: string, targetTier: string, ac
     }
   }
 
-  await updateCreditAccount(accountId, {
-    tier: targetTier,
-    scheduledTierChange: null,
-    scheduledTierChangeDate: null,
-    scheduledPriceId: null,
-  });
+  await applyStripeSync(
+    accountId,
+    {
+      tier: targetTier,
+      scheduledTierChange: null,
+      scheduledTierChangeDate: null,
+      scheduledPriceId: null,
+    },
+    { account, mode: 'update', reason: 'invoice.paid:scheduled_downgrade' },
+  );
 
   console.log(`[Webhook] Applied scheduled downgrade to ${tier.displayName} for ${accountId}`);
 }
@@ -946,12 +988,16 @@ async function handleScheduleCompleted(schedule: any) {
   if (targetTier && isDowngrade) {
     console.log(`[Webhook] Schedule completed: downgrade to ${targetTier} for ${accountId}`);
 
-    await updateCreditAccount(accountId, {
-      tier: targetTier,
-      scheduledTierChange: null,
-      scheduledTierChangeDate: null,
-      scheduledPriceId: null,
-    });
+    await applyStripeSync(
+      accountId,
+      {
+        tier: targetTier,
+        scheduledTierChange: null,
+        scheduledTierChangeDate: null,
+        scheduledPriceId: null,
+      },
+      { mode: 'update', reason: 'subscription_schedule.completed' },
+    );
 
     const subscriptionId = typeof schedule.subscription === 'string'
       ? schedule.subscription
@@ -961,7 +1007,7 @@ async function handleScheduleCompleted(schedule: any) {
       const stripe = getStripe();
       try {
         await stripe.subscriptions.update(subscriptionId, {
-          metadata: { tier_key: targetTier, downgrade: '', target_tier: '', scheduled_change: '' },
+          metadata: { ...planKeyMetadata(targetTier), downgrade: '', target_tier: '', scheduled_change: '' },
         });
       } catch (err) {
         console.error(`[Webhook] Failed to update subscription metadata after schedule completion:`, err);
@@ -983,10 +1029,14 @@ async function handleInvoiceFailed(invoice: Stripe.Invoice) {
 
   await repairStripeSubscriptionAccountMetadata(subscription, accountId);
 
-  await updateCreditAccount(accountId, {
-    paymentStatus: 'past_due',
-    lastPaymentFailure: new Date().toISOString(),
-  });
+  await applyStripeSync(
+    accountId,
+    {
+      paymentStatus: 'past_due',
+      lastPaymentFailure: new Date().toISOString(),
+    },
+    { mode: 'update', reason: 'invoice.payment_failed' },
+  );
 
   console.log(`[Webhook] Payment failed for ${accountId}`);
 }
@@ -1105,20 +1155,24 @@ async function handleRevenueCatPurchase(accountId: string, event: any) {
   const existingAccount = await getCreditAccount(accountId);
   const oldStripeSubscriptionId = existingAccount?.stripeSubscriptionId ?? null;
 
-  await upsertCreditAccount(accountId, {
-    tier: tierKey,
-    provider: 'revenuecat',
-    paymentStatus: 'active',
-    planType: periodType === 'yearly_commitment' ? 'yearly' : periodType,
-    revenuecatProductId: productId,
-    revenuecatCustomerId: event.subscriber_id ?? null,
-    revenuecatSubscriptionId: event.original_transaction_id ?? event.subscriber_id ?? null,
-    stripeSubscriptionId: null,
-    stripeSubscriptionStatus: null,
-    autoTopupEnabled: true,
-    autoTopupThreshold: String(AUTO_TOPUP_DEFAULT_THRESHOLD),
-    autoTopupAmount: String(AUTO_TOPUP_DEFAULT_AMOUNT),
-  });
+  await applyStripeSync(
+    accountId,
+    {
+      tier: tierKey,
+      provider: 'revenuecat',
+      paymentStatus: 'active',
+      planType: periodType === 'yearly_commitment' ? 'yearly' : periodType,
+      revenuecatProductId: productId,
+      revenuecatCustomerId: event.subscriber_id ?? null,
+      revenuecatSubscriptionId: event.original_transaction_id ?? event.subscriber_id ?? null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      autoTopupEnabled: true,
+      autoTopupThreshold: String(AUTO_TOPUP_DEFAULT_THRESHOLD),
+      autoTopupAmount: String(AUTO_TOPUP_DEFAULT_AMOUNT),
+    },
+    { account: existingAccount, reason: 'revenuecat.INITIAL_PURCHASE' },
+  );
 
   if (tier.monthlyCredits > 0) {
     await grantCredits(
@@ -1165,11 +1219,15 @@ async function handleRevenueCatRenewal(accountId: string, event: any) {
     await resetExpiringCredits(accountId, credits, `Mobile renewal: ${credits} credits`);
   }
 
-  await updateCreditAccount(accountId, {
-    provider: 'revenuecat',
-    paymentStatus: 'active',
-    lastGrantDate: new Date().toISOString(),
-  });
+  await applyStripeSync(
+    accountId,
+    {
+      provider: 'revenuecat',
+      paymentStatus: 'active',
+      lastGrantDate: new Date().toISOString(),
+    },
+    { account, mode: 'update', reason: 'revenuecat.RENEWAL' },
+  );
 
   console.log(`[RevenueCat] Renewal: ${credits} credits for ${accountId}`);
 }
@@ -1179,29 +1237,41 @@ async function handleRevenueCatCancellation(accountId: string, event: any) {
     ? new Date(event.expiration_at_ms).toISOString()
     : null;
 
-  await updateCreditAccount(accountId, {
-    revenuecatCancelledAt: new Date().toISOString(),
-    revenuecatCancelAtPeriodEnd: expirationDate,
-    paymentStatus: event.type === 'EXPIRATION' ? 'failed' : 'active',
-  });
+  await applyStripeSync(
+    accountId,
+    {
+      revenuecatCancelledAt: new Date().toISOString(),
+      revenuecatCancelAtPeriodEnd: expirationDate,
+      paymentStatus: event.type === 'EXPIRATION' ? 'failed' : 'active',
+    },
+    { mode: 'update', reason: `revenuecat.${event.type}` },
+  );
 
   if (event.type === 'EXPIRATION') {
-    await updateCreditAccount(accountId, {
-      tier: 'free',
-      revenuecatProductId: null,
-    });
+    await applyStripeSync(
+      accountId,
+      {
+        tier: 'free',
+        revenuecatProductId: null,
+      },
+      { mode: 'update', reason: 'revenuecat.EXPIRATION:revert' },
+    );
   }
 
   console.log(`[RevenueCat] ${event.type}: ${accountId}`);
 }
 
 async function handleRevenueCatUncancellation(accountId: string, _event: any) {
-  await updateCreditAccount(accountId, {
-    provider: 'revenuecat',
-    revenuecatCancelledAt: null,
-    revenuecatCancelAtPeriodEnd: null,
-    paymentStatus: 'active',
-  });
+  await applyStripeSync(
+    accountId,
+    {
+      provider: 'revenuecat',
+      revenuecatCancelledAt: null,
+      revenuecatCancelAtPeriodEnd: null,
+      paymentStatus: 'active',
+    },
+    { mode: 'update', reason: 'revenuecat.UNCANCELLATION' },
+  );
 
   console.log(`[RevenueCat] Uncancellation: ${accountId}`);
 }
@@ -1213,22 +1283,30 @@ async function handleRevenueCatProductChange(accountId: string, event: any) {
     : null;
 
   if (effectiveDate) {
-    await updateCreditAccount(accountId, {
-      revenuecatPendingChangeProduct: newProductId,
-      revenuecatPendingChangeDate: effectiveDate,
-      revenuecatPendingChangeType: 'product_change',
-    });
+    await applyStripeSync(
+      accountId,
+      {
+        revenuecatPendingChangeProduct: newProductId,
+        revenuecatPendingChangeDate: effectiveDate,
+        revenuecatPendingChangeType: 'product_change',
+      },
+      { mode: 'update', reason: 'revenuecat.PRODUCT_CHANGE:pending' },
+    );
   } else {
     const tierKey = mapRevenueCatProductToTier(newProductId);
     if (tierKey) {
-      await updateCreditAccount(accountId, {
-        tier: tierKey,
-        provider: 'revenuecat',
-        revenuecatProductId: newProductId,
-        revenuecatPendingChangeProduct: null,
-        revenuecatPendingChangeDate: null,
-        revenuecatPendingChangeType: null,
-      });
+      await applyStripeSync(
+        accountId,
+        {
+          tier: tierKey,
+          provider: 'revenuecat',
+          revenuecatProductId: newProductId,
+          revenuecatPendingChangeProduct: null,
+          revenuecatPendingChangeDate: null,
+          revenuecatPendingChangeType: null,
+        },
+        { mode: 'update', reason: 'revenuecat.PRODUCT_CHANGE:applied' },
+      );
     }
   }
 
@@ -1251,11 +1329,15 @@ async function handleRevenueCatTopup(accountId: string, event: any) {
 }
 
 async function handleRevenueCatBillingIssue(accountId: string, event: any) {
-  await updateCreditAccount(accountId, {
-    provider: 'revenuecat',
-    paymentStatus: 'past_due',
-    lastPaymentFailure: new Date().toISOString(),
-  });
+  await applyStripeSync(
+    accountId,
+    {
+      provider: 'revenuecat',
+      paymentStatus: 'past_due',
+      lastPaymentFailure: new Date().toISOString(),
+    },
+    { mode: 'update', reason: `revenuecat.${event?.type ?? 'BILLING_ISSUE'}` },
+  );
 
   console.log(`[RevenueCat] Billing issue: ${accountId}`);
 }


### PR DESCRIPTION
PR4 of the billing revamp (PR1 #6367, PR2 #6375, PR3 #6376).

The chokepoint that makes the original 'Activate Enterprise reverted by Stripe sync' bug structurally impossible:

- **account-write-owner.ts**: `applyStripeSync` throws on admin-owned fields (entitlement flags, overrides, trial columns) and on `tier='enterprise'`; skips the `tier` key — and only that key — when the account is admin-pinned (`enterprise_entitled` or legacy `tier='enterprise'` rows). `applyAdminOverride` is the inverse; `tier` is the one admin-assignable provider field (support ops), still never `'enterprise'`.
- Every write in webhooks.ts (Stripe + RevenueCat), legacy-stripe-sync.ts routes through `applyStripeSync`; the old one-branch per-seat guard is deleted. Admin routes, trial-admin, enterprise-demo route through `applyAdminOverride`; the raw repository flag setters are gone.
- Trial conversion on real subscription goes through a narrow `markTrialConverted` helper (deliberate cross-domain write, documented).
- Checkout metadata now writes `plan_key` alongside `tier_key` (forward compat); webhook resolution order `plan_key ?? tier_key ?? price-id`.
- CI guards: every current-status priced plan must resolve a prod Stripe price, with an explicit reviewed priceless allowlist (`tier_150_1200`, retired v3 plans); 19 ownership unit tests incl. the pin rule.

## Verification
- `apps/api`: 6471 pass / 0 fail; `tsc --noEmit` clean.
- `pnpm test -- --domain billing`: flows PASS (18/18).
- Fixture fixes: three partial `mock.module` fixtures gained the chokepoint's imports (missing names fail the whole import chain under bun).
- Unverified: live Stripe CLI replay (no stripe listen in this environment) — covered by webhook unit tests + the canonicalization suite; will smoke on dev after deploy.