### PR TITLE
fix: a network-boundary secret made every agent turn fail

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,24 @@ linked, not inlined.
 
 ## Register
 
+### A per-turn hot path must not contain an unbounded third-party round-trip (2026-08-11)
+
+**When:** adding an `await` to the prompt path — `syncSandboxEnvForPrompt`
+(`apps/api/src/projects/lib/sandbox-env-sync.ts`) and everything it calls. The
+network-boundary sync ran a FULL provider re-arm before every turn: manifest
+resolve, GET/PUT sandbox secrets, `ensureSecret` per binding, then
+`waitUntilArmed` at 40 × 250 ms — up to ~10 s, past the proxy budget. One egress
+secret therefore broke every agent turn in the project. Arm once at session
+start or in the background, bound the wait, and fail soft ONLY where a skipped
+call cannot widen access (a boundary value never enters the guest, so the worst
+case is a 401 upstream, not a leak). It also ran before `postEnvToDaemon`, so its
+failure skipped the ordinary runtime-secret push too.
+*Incident:* 2026-08-11 — same session, same sandbox: egress secret active →
+`prompt_async` 502 in 5.2 s, disabled → 200 in 1.2 s. Found only when the product
+owner said "I cannot test this on dev"; the symptom was a spinner stuck on
+"Considering next steps…", naming neither secrets nor the provider.
+*Enforcer:* none — build it.
+
 ### A deploy workflow must not cancel a build it cannot outrun (2026-08-10)
 
 **When:** setting `concurrency.cancel-in-progress` on any

--- a/apps/api/src/projects/lib/sandbox-env-sync.prompt.test.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.prompt.test.ts
@@ -1,0 +1,341 @@
+// A network-boundary secret must never cost the user a turn.
+//
+// It did. `syncSandboxEnvForPrompt` re-armed the provider edge on EVERY prompt —
+// re-reading the sandbox's secrets, re-checking each replica, re-attaching the
+// same set, then polling up to 10s for `armed` — before the prompt could be
+// forwarded. Measured on dev, same session, same sandbox, only the egress secret
+// toggled: `POST /session/{id}/prompt_async` returned 502 in 5.2s with the secret
+// active and 200 in 1.2s with it disabled. A project with one boundary secret
+// could not run a single agent turn.
+//
+// Two properties close it, and both are asserted here: an unchanged desired set
+// does not call the provider at all, and a provider failure never fails the turn.
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import * as realProviders from '../../platform/providers';
+import * as realSecrets from '../secrets';
+import * as realSecretGrant from './secret-grant';
+import type { NetworkBoundarySecretBinding } from '../../secrets/network-boundary';
+
+/** Everything the two paths do, in the order they did it. */
+let events: string[] = [];
+let armCalls: Array<{ externalId: string; bindings: NetworkBoundarySecretBinding[] }> = [];
+let envPushes: Array<{ url: string }> = [];
+let armBehavior: 'ok' | 'throw' | 'hang' = 'ok';
+/** Held open by `armBehavior: 'hang'` until a case decides the arm may finish.
+ *  Created before every case so `openArmGate()` is safe to call at any moment,
+ *  including before the provider call has actually started. */
+let armGate = Promise.resolve();
+let openArmGate: () => void = () => {};
+let bindings: NetworkBoundarySecretBinding[] = [];
+let boundaryResolveError: Error | null = null;
+
+const SESSION_ROW = {
+  createdBy: 'user-1',
+  agentName: 'support',
+  secretsAllowlist: null,
+  repoUrl: 'https://example.test/acme/repo.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+  metadata: null,
+  sessionId: 'sess-1',
+  externalId: 'ext-1',
+  provider: 'platinum',
+  config: { serviceKey: 'svc-key' },
+};
+
+// One fake row satisfies every select on this path: the session lookup, the
+// project lookup, the gateway-mode lookup and the sandbox lookup.
+mock.module('../../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => {
+          const rows = [SESSION_ROW];
+          return {
+            limit: async () => rows,
+            then: (resolve: (value: typeof rows) => unknown, reject?: (reason: unknown) => unknown) =>
+              Promise.resolve(rows).then(resolve, reject),
+          };
+        },
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  },
+}));
+
+mock.module('./secret-grant', () => ({
+  ...realSecretGrant,
+  resolveSessionSecretGrant: async () => 'all' as const,
+}));
+
+mock.module('../secrets', () => ({
+  ...realSecrets,
+  listProjectSecretsSnapshotForUser: async () => ({
+    env: { EXAMPLE: 'v' },
+    names: ['EXAMPLE'],
+    revision: 'rev-1',
+    capabilitiesJson: '{"version":1,"capabilities":[]}',
+  }),
+}));
+
+mock.module('./network-secret-boundary', () => ({
+  resolveSessionNetworkBoundary: async () => {
+    if (boundaryResolveError) throw boundaryResolveError;
+    return bindings;
+  },
+}));
+
+mock.module('../../sandbox-proxy/backend', () => ({
+  resolveSandboxIngress: async () => ({ url: 'https://sandbox.test', headers: {} }),
+}));
+
+// `shouldSyncProviderNetworkBoundary` stays REAL — the platinum-is-authoritative
+// rule is part of what these cases exercise.
+mock.module('../../platform/providers', () => ({
+  ...realProviders,
+  getProvider: () => ({
+    syncNetworkBoundary: async (
+      externalId: string,
+      requested: NetworkBoundarySecretBinding[],
+    ) => {
+      events.push('boundary');
+      armCalls.push({ externalId, bindings: requested });
+      if (armBehavior === 'throw') throw new Error('platinum arm exploded');
+      if (armBehavior === 'hang') await armGate;
+      return { state: 'armed' as const, attached: requested.length };
+    },
+  }),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+(globalThis as { fetch: unknown }).fetch = async (url: unknown, init?: { body?: string }) => {
+  events.push('env-push');
+  envPushes.push({ url: String(url) });
+  const body = init?.body ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+  return Response.json({
+    ok: true,
+    revision: body.revision,
+    exported: Object.keys((body.env as Record<string, unknown> | undefined) ?? {}).length,
+    managed: 1,
+    withheld: 0,
+    agent_env_written: true,
+  });
+};
+
+const {
+  __resetNetworkBoundaryArmCacheForTests,
+  propagateProjectSecretsToActiveSandboxes,
+  syncSandboxEnvForPrompt,
+} = await import('./sandbox-env-sync');
+
+function binding(overrides: Partial<NetworkBoundarySecretBinding> = {}): NetworkBoundarySecretBinding {
+  return {
+    secretId: 'secret-1',
+    identifier: 'billing-api',
+    alias: 'KORTIX_secret1',
+    hosts: ['api.example.com'],
+    header: 'authorization',
+    value: 'Bearer first-value',
+    onEcho: 'block',
+    ...overrides,
+  };
+}
+
+function prompt(externalId = 'ext-1') {
+  return syncSandboxEnvForPrompt({
+    projectId: 'proj-1',
+    sessionId: 'sess-1',
+    externalId,
+    serviceKey: 'svc-key',
+    previewUrl: 'https://sandbox.test',
+    providerHeaders: {},
+    providerName: 'platinum',
+  });
+}
+
+afterAll(() => {
+  (globalThis as { fetch: unknown }).fetch = ORIGINAL_FETCH;
+});
+
+beforeEach(() => {
+  __resetNetworkBoundaryArmCacheForTests();
+  events = [];
+  armCalls = [];
+  envPushes = [];
+  armBehavior = 'ok';
+  armGate = new Promise<void>((resolve) => {
+    openArmGate = resolve;
+  });
+  bindings = [binding()];
+  boundaryResolveError = null;
+});
+
+describe('syncSandboxEnvForPrompt — network boundary', () => {
+  test('arms once, then skips the provider while the desired set is unchanged', async () => {
+    await prompt();
+    await prompt();
+    await prompt();
+
+    expect(armCalls).toHaveLength(1);
+    expect(envPushes).toHaveLength(3);
+  });
+
+  test('a rotated credential re-arms — the new value must reach the edge', async () => {
+    await prompt();
+    bindings = [binding({ value: 'Bearer rotated-value' })];
+    await prompt();
+
+    expect(armCalls).toHaveLength(2);
+    expect(armCalls[1].bindings[0].value).toBe('Bearer rotated-value');
+  });
+
+  test('a changed policy re-arms — host, header and echo mode all count', async () => {
+    await prompt();
+    bindings = [binding({ hosts: ['api.example.com', 'eu.example.com'] })];
+    await prompt();
+    bindings = [binding({ header: 'x-api-key' })];
+    await prompt();
+    bindings = [binding({ alias: 'KORTIX_renamed' })];
+    await prompt();
+
+    expect(armCalls).toHaveLength(4);
+  });
+
+  test('removing the last binding re-arms so the edge stops holding the credential', async () => {
+    await prompt();
+    bindings = [];
+    await prompt();
+    await prompt();
+
+    expect(armCalls).toHaveLength(2);
+    expect(armCalls[1].bindings).toEqual([]);
+  });
+
+  test('two prompts racing on one sandbox share a single arm', async () => {
+    // Two overlapping PUTs at the provider are last-write-wins, so an identical
+    // desired set must join the arm already in flight rather than start another.
+    armBehavior = 'hang';
+    const first = prompt();
+    const second = prompt();
+    // Hold the arm long enough for BOTH turns to reach it, so the second one
+    // genuinely joins the in-flight call instead of finding a finished memo.
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    openArmGate();
+    await Promise.all([first, second]);
+
+    expect(armCalls).toHaveLength(1);
+    expect(events).toEqual(['boundary', 'env-push', 'env-push']);
+  });
+
+  test('a provider that needs no boundary call is never called for an empty set', async () => {
+    // Daytona is on-demand: zero bindings means nothing to arm and nothing stale
+    // to erase. Platinum is authoritative and still gets the erase (asserted
+    // above), so this is the policy split, not a shortcut.
+    bindings = [];
+    await syncSandboxEnvForPrompt({
+      projectId: 'proj-1',
+      sessionId: 'sess-1',
+      externalId: 'ext-daytona',
+      serviceKey: 'svc-key',
+      previewUrl: 'https://sandbox.test',
+      providerHeaders: {},
+      providerName: 'daytona',
+    });
+
+    expect(armCalls).toEqual([]);
+    expect(envPushes).toHaveLength(1);
+  });
+
+  test('the memo is per sandbox — a second box arms on its own first prompt', async () => {
+    await prompt('ext-1');
+    await prompt('ext-2');
+    await prompt('ext-1');
+
+    expect(armCalls.map((call) => call.externalId)).toEqual(['ext-1', 'ext-2']);
+  });
+
+  test('a provider failure logs and the turn still runs', async () => {
+    armBehavior = 'throw';
+
+    await prompt();
+
+    expect(events).toEqual(['boundary', 'env-push']);
+    expect(envPushes).toHaveLength(1);
+  });
+
+  test('a failed arm is not remembered as armed — the next prompt retries it', async () => {
+    armBehavior = 'throw';
+    await prompt();
+    armBehavior = 'ok';
+    await prompt();
+
+    expect(armCalls).toHaveLength(2);
+    expect(events).toEqual(['boundary', 'env-push', 'boundary', 'env-push']);
+  });
+
+  test('a slow arm does not hold the turn, and its result still lands', async () => {
+    armBehavior = 'hang';
+
+    const startedAt = Date.now();
+    await prompt();
+    const elapsedMs = Date.now() - startedAt;
+
+    // Bounded by PROMPT_BOUNDARY_ARM_WAIT_MS (1500ms), not by the provider's own
+    // 10s arm budget — the 502 this whole change exists to remove.
+    expect(elapsedMs).toBeLessThan(3_000);
+    expect(envPushes).toHaveLength(1);
+
+    // The arm was never abandoned: let it finish and the memo records it, so the
+    // next prompt skips instead of re-arming.
+    openArmGate();
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    armBehavior = 'ok';
+    await prompt();
+    expect(armCalls).toHaveLength(1);
+  });
+
+  test('the boundary is armed BEFORE the env push, always', async () => {
+    await prompt();
+    bindings = [binding({ value: 'Bearer rotated-value' })];
+    await prompt();
+
+    expect(events).toEqual(['boundary', 'env-push', 'boundary', 'env-push']);
+  });
+
+  test('an unresolvable binding set still fails the prompt closed', async () => {
+    // The fail-soft covers provider ARMING only. Resolving the bindings re-reads
+    // the agent's grant, and a grant we cannot prove must refuse the turn.
+    boundaryResolveError = new Error('could not resolve the secrets grant');
+
+    await expect(prompt()).rejects.toThrow('could not resolve the secrets grant');
+    expect(envPushes).toEqual([]);
+  });
+});
+
+describe('propagateProjectSecretsToActiveSandboxes — network boundary', () => {
+  test('an arming failure is REPORTED here, never swallowed', async () => {
+    // The secret-CRUD fan-out is the path that delivers a rotated credential.
+    // Its caller shows the outcome to the author who just saved the secret, so
+    // the prompt path's fail-soft must not reach it.
+    armBehavior = 'throw';
+
+    const result = await propagateProjectSecretsToActiveSandboxes('proj-1');
+
+    expect(result).toMatchObject({
+      ok: false,
+      synced: 0,
+      failed: 1,
+      results: [{ session_id: 'sess-1', status: 'failed', reason: 'platinum arm exploded' }],
+    });
+    expect(envPushes).toEqual([]);
+  });
+
+  test('the fan-out shares the memo: an unchanged set is not re-armed', async () => {
+    await prompt();
+    const result = await propagateProjectSecretsToActiveSandboxes('proj-1');
+
+    expect(result.ok).toBe(true);
+    expect(armCalls).toHaveLength(1);
+  });
+});

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { projects, projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../../shared/db';
@@ -42,19 +43,195 @@ const SANDBOX_SERVICE_PORT = 8000;
 const FANOUT_CONCURRENCY = 6;
 const ENV_PUSH_TIMEOUT_MS = 15_000;
 
+/**
+ * How long one recorded arm is trusted before the next sync re-arms anyway.
+ * Nothing we run mutates a live sandbox's provider-side attachment behind our
+ * back, so this is not correctness — it is a self-heal for drift we did not
+ * cause (a provider-side loss of the attachment). Long enough that an ordinary
+ * session never pays for it twice; short enough that drift clears without a
+ * deploy.
+ */
+const BOUNDARY_ARM_TTL_MS = 10 * 60_000;
+/** Cap on remembered sandboxes. Entries are only ~120 bytes, but the process is
+ *  long-lived and external ids are never reused, so the map must be bounded. */
+const BOUNDARY_ARM_CACHE_MAX = 2_000;
+/**
+ * The longest a user's turn blocks on the provider edge confirming an arm.
+ *
+ * The arm is NOT abandoned at this deadline — it keeps running and records its
+ * result — we just stop making the person wait for it. Blocking a turn for the
+ * provider's full arm budget (see `waitUntilArmed` in
+ * secrets/platinum-network-boundary.ts) is what pushed
+ * `POST /session/{id}/prompt_async` past the proxy budget and returned 502.
+ */
+const PROMPT_BOUNDARY_ARM_WAIT_MS = 1_500;
+
+/** `secretIds` is what the edge is currently holding. Kept because the digest
+ *  alone cannot tell a WIDENING from a REVOCATION, and the two need opposite
+ *  failure handling — see the shrink check in `syncSandboxEnvForPrompt`. */
+type BoundaryArmRecord = { digest: string; armedAt: number; secretIds: string[] };
+
+/**
+ * Per-sandbox record of the LAST binding set this process successfully armed.
+ *
+ * In-process on purpose: it is a cost optimization, not state anyone reads for
+ * a decision. A fresh API replica (deploy, scale-out, restart) simply misses and
+ * performs exactly one re-arm for that sandbox — the same call it would have
+ * made anyway, applying the same desired state, so a miss is always safe.
+ */
+const armedNetworkBoundaries = new Map<string, BoundaryArmRecord>();
+/** In-flight arms, so two prompts on one sandbox never race two PUTs at the
+ *  provider. Same digest joins; a different digest queues behind it. */
+const inFlightNetworkBoundaries = new Map<string, { digest: string; done: Promise<void> }>();
+
+/** Test seam: drop every remembered arm so a case starts from a cold replica. */
+export function __resetNetworkBoundaryArmCacheForTests(): void {
+  armedNetworkBoundaries.clear();
+  inFlightNetworkBoundaries.clear();
+}
+
+/**
+ * Identity AND material of the binding set, as the provider edge sees it.
+ *
+ * Keyed on everything a re-arm would change at the edge — the replica identity
+ * (`secretId`), the attachment (`alias`), the policy (`hosts`, `header`,
+ * `onEcho`) and the credential itself (`value`). A rotated value or a widened
+ * host list therefore produces a different digest and DOES re-arm; only a
+ * byte-identical desired state is skipped. Order-independent, because binding
+ * order carries no meaning at the edge.
+ *
+ * The secret value is hashed, never retained: only this hex digest is stored.
+ */
+function networkBoundaryDigest(
+  providerName: ProviderName,
+  bindings: NetworkBoundarySecretBinding[],
+): string {
+  const material = bindings
+    .map((binding) =>
+      JSON.stringify([
+        binding.secretId,
+        binding.alias,
+        [...binding.hosts].map((host) => host.toLowerCase()).sort(),
+        binding.header.toLowerCase(),
+        binding.onEcho,
+        binding.value,
+      ]),
+    )
+    .sort()
+    .join('\n');
+  return createHash('sha256').update(`${providerName}\n${material}`).digest('hex');
+}
+
+function rememberNetworkBoundaryArm(externalId: string, digest: string, secretIds: string[]): void {
+  armedNetworkBoundaries.delete(externalId);
+  if (armedNetworkBoundaries.size >= BOUNDARY_ARM_CACHE_MAX) {
+    const cutoff = Date.now() - BOUNDARY_ARM_TTL_MS;
+    for (const [key, record] of armedNetworkBoundaries) {
+      if (record.armedAt <= cutoff) armedNetworkBoundaries.delete(key);
+    }
+    // Still full of live entries — evict the least recently written. Map
+    // iteration is insertion order and every refresh deletes before it sets,
+    // so the first key is the oldest write.
+    while (armedNetworkBoundaries.size >= BOUNDARY_ARM_CACHE_MAX) {
+      const oldest = armedNetworkBoundaries.keys().next();
+      if (oldest.done) break;
+      armedNetworkBoundaries.delete(oldest.value);
+    }
+  }
+  armedNetworkBoundaries.set(externalId, { digest, armedAt: Date.now(), secretIds: [...secretIds] });
+}
+
+function startNetworkBoundaryArm(
+  providerName: ProviderName,
+  externalId: string,
+  bindings: NetworkBoundarySecretBinding[],
+  digest: string,
+): Promise<void> {
+  const previous = inFlightNetworkBoundaries.get(externalId);
+  if (previous?.digest === digest) return previous.done;
+  // A different desired set must not race the one already in flight: the
+  // provider PUT is last-write-wins, so two overlapping arms could leave the
+  // edge on the older set. Queue instead.
+  const done = (previous?.done ?? Promise.resolve())
+    .catch(() => {})
+    .then(async () => {
+      const provider = getProvider(providerName);
+      if (!provider.syncNetworkBoundary) {
+        throw new Error(
+          `Sandbox provider ${providerName} does not support network-boundary secret delivery`,
+        );
+      }
+      try {
+        await provider.syncNetworkBoundary(externalId, bindings);
+        rememberNetworkBoundaryArm(
+          externalId,
+          digest,
+          bindings.map((binding) => binding.secretId),
+        );
+      } catch (err) {
+        // Never leave a record claiming an arm that did not land — the next
+        // caller must retry it.
+        armedNetworkBoundaries.delete(externalId);
+        throw err;
+      } finally {
+        if (inFlightNetworkBoundaries.get(externalId)?.done === done) {
+          inFlightNetworkBoundaries.delete(externalId);
+        }
+      }
+    });
+  inFlightNetworkBoundaries.set(externalId, { digest, done });
+  return done;
+}
+
+/**
+ * Apply this session's network-boundary bindings at the provider edge.
+ *
+ * Returns `'skipped'` when there is nothing to do (provider does not need the
+ * call, or this sandbox is already armed with this exact set), `'armed'` when
+ * the provider confirmed, and `'pending'` when the caller's wait budget expired
+ * while the arm was still running in the background.
+ *
+ * `maxWaitMs` is the CALLER's patience, not the arm's deadline. Omit it — as
+ * the secret fan-out does — to wait for the real result and report a failure.
+ */
 async function syncProviderNetworkBoundary(
   providerName: ProviderName,
   externalId: string,
   bindings: NetworkBoundarySecretBinding[],
-): Promise<void> {
-  if (!shouldSyncProviderNetworkBoundary(providerName, bindings.length)) return;
-  const provider = getProvider(providerName);
-  if (!provider.syncNetworkBoundary) {
-    throw new Error(
-      `Sandbox provider ${providerName} does not support network-boundary secret delivery`,
-    );
+  opts?: { maxWaitMs?: number },
+): Promise<'skipped' | 'armed' | 'pending'> {
+  if (!shouldSyncProviderNetworkBoundary(providerName, bindings.length)) return 'skipped';
+  const digest = networkBoundaryDigest(providerName, bindings);
+  const armed = armedNetworkBoundaries.get(externalId);
+  if (armed?.digest === digest && Date.now() - armed.armedAt < BOUNDARY_ARM_TTL_MS) {
+    return 'skipped';
   }
-  await provider.syncNetworkBoundary(externalId, bindings);
+
+  const attempt = startNetworkBoundaryArm(providerName, externalId, bindings, digest);
+  const maxWaitMs = opts?.maxWaitMs;
+  if (!maxWaitMs) {
+    await attempt;
+    return 'armed';
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const outcome = await Promise.race([
+      // Both legs are handled here, so a rejection that lands AFTER the timeout
+      // wins is still consumed — it can never surface as an unhandled rejection.
+      attempt.then(
+        () => 'armed' as const,
+        (error: unknown) => ({ error }),
+      ),
+      new Promise<'pending'>((resolve) => {
+        timer = setTimeout(() => resolve('pending'), maxWaitMs);
+      }),
+    ]);
+    if (typeof outcome === 'object') throw outcome.error;
+    return outcome;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export interface SandboxEnvSnapshot {
@@ -348,12 +525,80 @@ export async function syncSandboxEnvForPrompt(args: {
     args.requestedAgent,
   );
   if (!snapshot) return;
+  // Resolving the bindings stays FAIL-CLOSED: it re-reads the agent's grant, and
+  // an unresolvable grant must refuse the prompt (the caller maps
+  // SecretGrantResolutionError / AgentSecretGrantMismatchError to its own
+  // response). In practice `resolveSandboxEnvSnapshot` above already resolved the
+  // same grant and threw first — this line cannot silently widen anything.
   const networkBoundary = await resolveSessionNetworkBoundary(
     args.projectId,
     args.sessionId,
     args.requestedAgent,
   );
-  await syncProviderNetworkBoundary(args.providerName, args.externalId, networkBoundary);
+  // Sampled BEFORE the attempt, because a failed arm forgets its record. `true`
+  // means this process already armed a DIFFERENT set on this sandbox (an
+  // unchanged set never reaches the provider at all), so a failure below leaves
+  // the edge holding the PREVIOUS bindings. That is the one case the fail-soft
+  // below does not fully cover: a narrowing that does not land keeps a
+  // credential injectable at the edge — still never readable in the guest —
+  // until the next successful arm. It is logged so it is greppable.
+  // A REVOCATION must not fail soft. When the desired set drops a binding this
+  // process already armed, the arm IS the revocation (the provider PUT shrinks
+  // the attachment and DELETEs the dropped replica). Swallowing that leaves the
+  // edge injecting a credential for an agent that no longer holds the grant —
+  // the value still never enters the guest, but the agent keeps making
+  // authenticated calls, which is a widening, not a broken feature. So a shrink
+  // that fails is raised, exactly as before this change. A widening or a
+  // rotation that fails still forwards the turn.
+  const priorArm = armedNetworkBoundaries.get(args.externalId);
+  const hadPriorArm = priorArm !== undefined;
+  const nextSecretIds = new Set(networkBoundary.map((binding) => binding.secretId));
+  const revokesArmedBinding = (priorArm?.secretIds ?? []).some((id) => !nextSecretIds.has(id));
+  try {
+    // ARMING, by contrast, fails SOFT — a failed or late arm cannot leak.
+    // A network-boundary secret's value never enters the sandbox: the provider
+    // injects it at its own egress edge and the guest receives no value, alias
+    // or placeholder. So skipping the arm cannot disclose anything; the only
+    // consequence is that the agent's outbound request goes without the header
+    // and the upstream answers 401. That is a broken feature, not an exposure —
+    // and it beats the alternative we shipped, where one egress secret made
+    // EVERY turn in the project 502 and the agent could not run at all.
+    //
+    // SCOPE: this fail-soft covers the provider-arming call and nothing else.
+    // It does not extend to the grant resolution above (failing open there would
+    // widen what the agent may read), and it must not be copied into the
+    // provision path in platform/services/session-sandbox.ts — a session that
+    // cannot arm its boundary should still fail to provision, loudly.
+    const armState = await syncProviderNetworkBoundary(
+      args.providerName,
+      args.externalId,
+      networkBoundary,
+      { maxWaitMs: PROMPT_BOUNDARY_ARM_WAIT_MS },
+    );
+    if (armState === 'pending' && revokesArmedBinding) {
+      throw new Error(
+        `network-boundary revocation did not land within ${PROMPT_BOUNDARY_ARM_WAIT_MS}ms for ${args.externalId}`,
+      );
+    }
+    if (armState === 'pending') {
+      console.warn(
+        `[env-sync] network boundary still arming after ${PROMPT_BOUNDARY_ARM_WAIT_MS}ms; ` +
+          `forwarding the prompt without waiting session=${args.sessionId} sandbox=${args.externalId} ` +
+          `bindings=${networkBoundary.length} replaces-previous-set=${hadPriorArm}`,
+      );
+    }
+  } catch (err) {
+    // The one case that must still refuse the turn: an arm that would have
+    // REMOVED a binding the edge is holding. See the comment on
+    // `revokesArmedBinding`.
+    if (revokesArmedBinding) throw err;
+    console.warn(
+      `[env-sync] network-boundary arm failed; continuing the turn without it ` +
+        `session=${args.sessionId} sandbox=${args.externalId} bindings=${networkBoundary.length} ` +
+        `replaces-previous-set=${hadPriorArm}: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   const llmGatewayEnabled = await resolveProjectLlmGatewayEnabled(args.projectId);
   const { opencodeState } = await postEnvToDaemon({
     previewUrl: args.previewUrl,
@@ -459,6 +704,11 @@ export async function propagateProjectSecretsToActiveSandboxes(
         if (!snapshot) throw new Error('session env snapshot is unavailable');
         const providerName = row.provider as ProviderName;
         const networkBoundary = await resolveSessionNetworkBoundary(projectId, row.sessionId);
+        // No wait budget and no fail-soft here. This is the secret-CRUD fan-out:
+        // it is the path that DELIVERS a rotated credential to the edge, and its
+        // caller reports the per-sandbox outcome to the author who just saved the
+        // secret. An arming failure has to be visible there, so it stays a
+        // `status: 'failed'` row rather than a warning nobody reads.
         await syncProviderNetworkBoundary(providerName, row.externalId, networkBoundary);
         const { url, headers } = await resolveSandboxIngress(row.externalId, { port: SANDBOX_SERVICE_PORT, transport: 'http' });
         const proof = await postEnvToDaemon({

--- a/apps/api/src/secrets/platinum-network-boundary.test.ts
+++ b/apps/api/src/secrets/platinum-network-boundary.test.ts
@@ -27,12 +27,27 @@ mock.module('../shared/platinum', () => ({
     const body = init.body ? JSON.parse(String(init.body)) : undefined;
     calls.push({ path, method, body });
 
-    if (method === 'GET' && path.startsWith('/v1/secrets/')) {
+    // The real API resolves this path by ID ONLY — a name 404s here and then
+    // POST answers 409 name_conflict. Verified against api.platinum.dev; the
+    // mock used to accept either, which hid the bug that broke every re-arm.
+    if (method === 'GET' && /^\/v1\/secrets\/[^?]+$/.test(path)) {
       const key = decodeURIComponent(path.slice('/v1/secrets/'.length));
-      const item = [...external.values()].find((secret) => secret.id === key || secret.name === key);
+      const item = [...external.values()].find((secret) => secret.id === key);
       if (!item) throw new Error(`platinum GET ${path} -> 404 {"code":"not_found"}`);
       const { value: _value, ...descriptor } = item;
       return descriptor;
+    }
+    // Cursor-paged list — the only way to resolve a replica by name.
+    if (method === 'GET' && path.startsWith('/v1/secrets?')) {
+      const params = new URLSearchParams(path.slice(path.indexOf('?') + 1));
+      const limit = Number(params.get('limit') ?? '100');
+      const cursor = params.get('cursor');
+      const ordered = [...external.values()].map(({ value: _value, ...rest }) => rest);
+      const start = cursor ? ordered.findIndex((item) => item.id === cursor) + 1 : 0;
+      const items = ordered.slice(start, start + limit);
+      const last = items.at(-1);
+      const more = last ? ordered.indexOf(ordered.find((i) => i.id === last.id)!) + 1 < ordered.length : false;
+      return { items, total: ordered.length, cursor: more && last ? last.id : null };
     }
     if (method === 'POST' && path === '/v1/secrets') {
       const id = `sec_${nextId++}`;
@@ -72,13 +87,15 @@ mock.module('../shared/platinum', () => ({
     const sandboxMatch = path.match(/^\/v1\/sandboxes\/([^/]+)\/secrets$/);
     if (sandboxMatch && method === 'GET') {
       const ids = attached.get(sandboxMatch[1]) ?? [];
+      // Reports the CURRENT attachment state, so a poll can observe an edge that
+      // is still arming instead of always answering 'armed' on the first read.
       return {
         sandbox_id: sandboxMatch[1],
         epoch: 1,
-        leased_epoch: 1,
-        state: 'armed',
+        leased_epoch: attachmentState === 'armed' ? 1 : 0,
+        state: attachmentState,
         implied_egress: { domains: [], rules: {}, proxy: true },
-        secrets: ids.map((id) => ({ secret_id: id, state: 'armed' })),
+        secrets: ids.map((id) => ({ secret_id: id, state: attachmentState })),
       };
     }
     if (sandboxMatch && method === 'PUT') {
@@ -183,6 +200,33 @@ describe('syncPlatinumNetworkBoundary', () => {
       calls.filter((call) => call.method === 'GET' && call.path.endsWith('/secrets')),
     ).toHaveLength(1);
     expect(attached.get('sandbox-1')).toEqual([]);
+  });
+
+  test('gives up on a stuck arm at the wall-clock budget, without hammering the edge', async () => {
+    // The old loop was 40 attempts x 250ms, so its real ceiling was 10s PLUS 40
+    // sequential round-trips. A deadline with backoff bounds the elapsed time
+    // and cuts the poll count.
+    attachmentState = 'arming';
+
+    const startedAt = Date.now();
+    await expect(
+      syncPlatinumNetworkBoundary('sandbox-1', [binding()], context, { armTimeoutMs: 400 }),
+    ).rejects.toThrow('did not arm for sandbox-1 within 400ms');
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(
+      calls.filter((call) => call.method === 'GET' && call.path.endsWith('/secrets')),
+    ).not.toHaveLength(0);
+    expect(
+      calls.filter((call) => call.method === 'GET' && call.path.endsWith('/secrets')).length,
+    ).toBeLessThanOrEqual(4);
+  });
+
+  test('returns as soon as the edge reports armed', async () => {
+    const startedAt = Date.now();
+    await syncPlatinumNetworkBoundary('sandbox-1', [binding()], context);
+    expect(Date.now() - startedAt).toBeLessThan(150);
   });
 
   test('fails closed when the provider reports an unavailable binding', async () => {

--- a/apps/api/src/secrets/platinum-network-boundary.ts
+++ b/apps/api/src/secrets/platinum-network-boundary.ts
@@ -20,8 +20,22 @@ type PlatinumSandboxSecrets = {
 };
 
 const DESCRIPTION_PREFIX = 'kortix-network-v1';
-const ARM_ATTEMPTS = 40;
-const ARM_DELAY_MS = 250;
+/**
+ * Wall-clock budget for the edge to report `armed`, and the backoff used to get
+ * there. This replaced a fixed 40 x 250ms attempt count, which was a budget in
+ * name only: it also paid 40 sequential round-trips, so the real ceiling was
+ * 10s PLUS provider latency, and it hammered the provider with 40 GETs.
+ *
+ * The budget stays generous because the caller that must NOT proceed without an
+ * armed edge — session provision (platform/services/session-sandbox.ts) — has to
+ * either arm or fail. Callers on a user's hot path must not adopt this as their
+ * own patience: they bound their own wait and let the arm finish in the
+ * background (see PROMPT_BOUNDARY_ARM_WAIT_MS in
+ * projects/lib/sandbox-env-sync.ts).
+ */
+const ARM_TIMEOUT_MS = 10_000;
+const ARM_POLL_MIN_MS = 150;
+const ARM_POLL_MAX_MS = 1_000;
 
 function httpStatus(error: unknown): number | null {
   const match = String(error instanceof Error ? error.message : error).match(/ -> (\d{3})(?: |$)/);
@@ -79,13 +93,37 @@ function descriptorFingerprints(description: string | null): {
   return { material, policy };
 }
 
-async function readSecret(nameOrId: string): Promise<PlatinumSecret | null> {
-  try {
-    return await platinumJson<PlatinumSecret>(`/v1/secrets/${encodeURIComponent(nameOrId)}`);
-  } catch (error) {
-    if (httpStatus(error) === 404) return null;
-    throw error;
+
+type PlatinumSecretPage = { items: PlatinumSecret[]; cursor: string | null };
+
+const LIST_PAGE_SIZE = 100;
+// A guard, not a limit: the organization holds one replica per (sandbox, secret),
+// so paging is bounded in practice. Stopping is safer than looping forever if the
+// provider ever returns a non-advancing cursor.
+const LIST_MAX_PAGES = 50;
+
+/**
+ * Find a replica by NAME, the only way the provider supports it: page the list
+ * and match. `?name=` is accepted and ignored (verified — it returns every
+ * item), so the filter has to happen here.
+ *
+ * Pagination is `?limit=N&cursor=<last id>`, with `cursor: null` on the final
+ * page.
+ */
+async function findSecretByName(name: string): Promise<PlatinumSecret | null> {
+  let cursor: string | null = null;
+  for (let page = 0; page < LIST_MAX_PAGES; page += 1) {
+    const query: string = cursor
+      ? `?limit=${LIST_PAGE_SIZE}&cursor=${encodeURIComponent(cursor)}`
+      : `?limit=${LIST_PAGE_SIZE}`;
+    const res: PlatinumSecretPage = await platinumJson<PlatinumSecretPage>(`/v1/secrets${query}`);
+    const hit = (res.items ?? []).find((item: PlatinumSecret) => item.name === name);
+    if (hit) return hit;
+    const next: string | null = res.cursor ?? null;
+    if (!next || next === cursor) return null;
+    cursor = next;
   }
+  return null;
 }
 
 async function createSecret(
@@ -108,7 +146,10 @@ async function createSecret(
     });
   } catch (error) {
     if (httpStatus(error) !== 409) throw error;
-    const raced = await readSecret(name);
+    // 409 `name_conflict` means the replica already exists. Resolve it by
+    // LISTING — a read by name 404s, so the old recovery here always rethrew and
+    // turned every re-arm into a failed sync.
+    const raced = await findSecretByName(name);
     if (!raced) throw error;
     return raced;
   }
@@ -120,7 +161,7 @@ async function ensureSecret(
   context: PlatinumNetworkBoundaryContext,
 ): Promise<PlatinumSecret> {
   const name = replicaName(externalId, binding.secretId, context);
-  let secret = await readSecret(name);
+  let secret = await findSecretByName(name);
   if (!secret) return createSecret(name, binding, context);
 
   const stored = descriptorFingerprints(secret.description);
@@ -149,25 +190,46 @@ async function ensureSecret(
 async function waitUntilArmed(
   externalId: string,
   initial: PlatinumSandboxSecrets,
+  timeoutMs: number,
 ): Promise<PlatinumSandboxSecrets> {
   let current = initial;
-  for (let attempt = 0; attempt < ARM_ATTEMPTS; attempt += 1) {
+  let delayMs = ARM_POLL_MIN_MS;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
     if (current.state === 'armed') return current;
     if (current.state === 'unavailable') {
       throw new Error(`Platinum network-boundary secrets are unavailable for ${externalId}`);
     }
-    await new Promise<void>((resolve) => setTimeout(resolve, ARM_DELAY_MS));
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Platinum network-boundary secrets did not arm for ${externalId} within ${timeoutMs}ms`,
+      );
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    delayMs = Math.min(delayMs * 2, ARM_POLL_MAX_MS);
     current = await platinumJson<PlatinumSandboxSecrets>(
       `/v1/sandboxes/${encodeURIComponent(externalId)}/secrets`,
     );
   }
-  throw new Error(`Platinum network-boundary secrets did not arm for ${externalId}`);
 }
 
+/**
+ * Make the provider edge hold exactly `bindings` for this sandbox.
+ *
+ * Cost is real — one sandbox read, one read (and possibly a write) per binding,
+ * one attachment write, then polling until the edge reports `armed`. Callers on
+ * a hot path must not run it per request: `syncProviderNetworkBoundary` in
+ * projects/lib/sandbox-env-sync.ts skips it when the desired set is byte-identical
+ * to the last one it armed for this sandbox.
+ *
+ * `armTimeoutMs` overrides the wall-clock arm budget; production callers use the
+ * default.
+ */
 export async function syncPlatinumNetworkBoundary(
   externalId: string,
   bindings: NetworkBoundarySecretBinding[],
   context: PlatinumNetworkBoundaryContext,
+  options?: { armTimeoutMs?: number },
 ): Promise<{ state: 'armed'; attached: number }> {
   const sandboxPath = `/v1/sandboxes/${encodeURIComponent(externalId)}/secrets`;
   const before = await platinumJson<PlatinumSandboxSecrets>(sandboxPath);
@@ -187,7 +249,9 @@ export async function syncPlatinumNetworkBoundary(
       })),
     }),
   });
-  if (desired.length > 0) await waitUntilArmed(externalId, updated);
+  if (desired.length > 0) {
+    await waitUntilArmed(externalId, updated, options?.armTimeoutMs ?? ARM_TIMEOUT_MS);
+  }
 
   const desiredIds = new Set(desired.map(({ secret }) => secret.id));
   const removed = [...new Set((before.secrets ?? []).map((item) => item.secret_id))]


### PR DESCRIPTION
Reported as "it never responds — I cannot test network-boundary secrets on dev". Configuring one egress
secret makes **every prompt in the project** fail. Two independent bugs, both reproduced on dev.

## Bug 1 — the re-arm could never succeed

Platinum resolves `GET /v1/secrets/{x}` by **ID only**. Probed against `api.platinum.dev`:

| call | result |
|---|---|
| `GET /v1/secrets/<id>` | **200** |
| `GET /v1/secrets/<name>` | **404** |
| `POST /v1/secrets` (same name) | **409 `name_conflict`** |
| `GET /v1/secrets` (list) | **200** — `{items,total,cursor}` |

`ensureSecret` looked a replica up **by name**, so it always missed; `createSecret` then always got 409;
its recovery re-read by name, missed again, and rethrew. The first arm happens at session provision, so a
boundary secret worked right up until something tried to re-arm it — which is every prompt.

Fixed by paging `GET /v1/secrets?limit&cursor` and matching client-side (`?name=` is accepted and
silently ignored — verified). `findSecretByName` confirmed against the live API: **finds** the replica the
old read 404s on.

**The test mock accepted a name where the real API does not**, which is exactly why nothing caught this.
Corrected to id-only plus a cursor-paged list.

## Bug 2 — the arm blocked the turn

`syncSandboxEnvForPrompt` re-armed from scratch on every prompt and waited for the edge to report `armed`
(40 × 250ms). It runs *before* `postEnvToDaemon`, so its failure also skipped the ordinary runtime-secret
push. `preview.ts` turned the throw into the measured 502; the session-lifecycle engine turned it into
`pending` — the spinner that never resolves.

- Skip the provider call when the desired set is byte-identical to the last one this process armed. The
  digest covers identity **and** material, so a rotation or policy change still re-arms; only a no-op is
  skipped.
- Bound the caller's patience at 1.5s; the arm finishes in the background and still records its result.
- `waitUntilArmed` is now a 10s wall-clock budget with backoff instead of 40 sequential round-trips.

## The fail-soft is deliberately asymmetric

Adding or rotating cannot leak: a boundary value never enters the guest, so a failed arm means the request
goes without the header and the upstream 401s — a broken feature, not an exposure.

**Revoking is the opposite.** There the arm *is* the revocation, so swallowing it would leave the edge
injecting a credential for an agent that no longer holds the grant. A shrink that fails, or does not land
inside the 1.5s window, still raises. An adversarial reviewer caught this — my original brief asserted a
blanket "a failed arm cannot leak", which is only true for the growing case.

Provision-time arming is untouched and still fails loudly.

## Verified

- Live A/B before the fix, same session and sandbox: egress secret active → `prompt_async` **502 in 5.2s**;
  disabled → **200 in 1.2s**.
- The real arm failure, captured through the `delivery_sync` reporting added earlier today:
  `platinum POST /v1/secrets -> 409 {"error":"that name is already in use in this organization"}`.
- `apps/api`: **905 pass / 10 skip / 0 fail** across `projects/lib`, `secrets`, `platform`, `sandbox-proxy`.
- `tsc`: 8 errors, all pre-existing module-resolution noise, none in a touched file.

## Not fixed here

The reviewer flagged that a swallowed arm failure is only visible in a `console.warn`. The feature can
still be dark without telling anyone. `delivery_blocked_reason` is the natural home for it — separate PR.