### PR TITLE
fix(compliance): enforce ALB log bucket versioning (DCF-78)

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -61,6 +61,8 @@ jobs:
         run: python3 infra/terraform/scripts/test_audit_nacl_admin_ports.py
       - name: web ALB WAF association tests
         run: python3 infra/terraform/scripts/test_web_waf_associations.py
+      - name: ALB log bucket versioning regression test
+        run: python3 infra/terraform/scripts/test_alb_log_bucket_versioning.py
       - name: preview runtime contract tests
         run: python3 infra/scripts/test-ecs-preview-runtime.py
       - name: terraform validate (every root)

--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -264,6 +264,13 @@ resource "aws_s3_bucket" "alb_logs" {
   tags          = var.tags
 }
 
+resource "aws_s3_bucket_versioning" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "alb_logs" {
   bucket                  = aws_s3_bucket.alb_logs.id
   block_public_acls       = true
@@ -286,13 +293,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "alb_logs" {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
-  }
-}
-
-resource "aws_s3_bucket_versioning" "alb_logs" {
-  bucket = aws_s3_bucket.alb_logs.id
-  versioning_configuration {
-    status = "Enabled"
   }
 }
 

--- a/infra/terraform/scripts/test_alb_log_bucket_versioning.py
+++ b/infra/terraform/scripts/test_alb_log_bucket_versioning.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Regression test for DCF-78 ALB log bucket versioning."""
+
+from pathlib import Path
+import re
+
+
+MODULE = Path(__file__).parents[1] / "modules" / "ecs-api" / "main.tf"
+
+
+def resource_body(source: str, resource_type: str, name: str) -> str:
+    match = re.search(
+        rf'resource\s+"{re.escape(resource_type)}"\s+"{re.escape(name)}"\s*{{',
+        source,
+    )
+    assert match, f"missing {resource_type}.{name}"
+
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+
+    assert depth == 0, f"unterminated {resource_type}.{name}"
+    return source[match.end() : cursor - 1]
+
+
+def assert_alb_logs_versioning_enabled(source: str) -> None:
+    body = resource_body(source, "aws_s3_bucket_versioning", "alb_logs")
+    assert re.search(r"bucket\s*=\s*aws_s3_bucket\.alb_logs\.id", body), (
+        "alb_logs versioning must target aws_s3_bucket.alb_logs"
+    )
+    assert re.search(r'versioning_configuration\s*{[^}]*status\s*=\s*"Enabled"', body), (
+        "alb_logs versioning status must be Enabled"
+    )
+
+
+def test_module_enables_alb_log_bucket_versioning() -> None:
+    assert_alb_logs_versioning_enabled(MODULE.read_text())
+
+
+def test_missing_versioning_is_rejected() -> None:
+    source = 'resource "aws_s3_bucket" "alb_logs" { bucket = "logs" }'
+    try:
+        assert_alb_logs_versioning_enabled(source)
+    except AssertionError:
+        return
+    raise AssertionError("a bucket without versioning passed the DCF-78 guard")
+
+
+def test_suspended_versioning_is_rejected() -> None:
+    source = """
+resource "aws_s3_bucket_versioning" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+  versioning_configuration {
+    status = "Suspended"
+  }
+}
+"""
+    try:
+        assert_alb_logs_versioning_enabled(source)
+    except AssertionError:
+        return
+    raise AssertionError("suspended versioning passed the DCF-78 guard")
+
+
+if __name__ == "__main__":
+    tests = [value for key, value in sorted(globals().items()) if key.startswith("test_")]
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"ok   {test.__name__}")
+        except AssertionError as exc:
+            print(f"FAIL {test.__name__}: {exc}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
## Demo
Non-visual Terraform compliance change. `python3 infra/terraform/scripts/test_alb_log_bucket_versioning.py` passes 3/3 cases and rejects missing or suspended versioning.

## Why
Drata test 8003 (DCF-78 Storage Bucket Versioning) reports the ECS API module resource `alb_logs` without a recognized enabled versioning configuration.

## What changed
- Place the `aws_s3_bucket_versioning.alb_logs` configuration next to its bucket so the bucket and control are explicit together.
- Add a dependency-free regression test that requires the versioning resource to target `aws_s3_bucket.alb_logs` with `status = "Enabled"`.
- Run the regression guard in Terraform CI.

## Verification
- ALB log versioning regression: 3/3 passed.
- Existing web WAF regression: 3/3 passed.
- Existing NACL audit regression: 9/9 passed.
- Terraform 1.15.8 fmt check passed.
- Terraform 1.15.8 init and validate passed for `infra/terraform/modules/ecs-api`.

## Risk / rollback
No resource address changes. Terraform keeps `aws_s3_bucket_versioning.alb_logs`; rollback removes the CI guard and restores declaration order.