### PR TITLE
fix(secrets): give the boundary arm a budget the provider can meet

### DIFF
--- a/apps/api/src/secrets/platinum-network-boundary.ts
+++ b/apps/api/src/secrets/platinum-network-boundary.ts
@@ -26,6 +26,14 @@ const DESCRIPTION_PREFIX = 'kortix-network-v1';
  * name only: it also paid 40 sequential round-trips, so the real ceiling was
  * 10s PLUS provider latency, and it hammered the provider with 40 GETs.
  *
+ * 45s because the old 10s was simply below the provider's real latency, which is
+ * why arming a boundary secret failed provisioning outright. Measured against
+ * api.platinum.dev on a live dev sandbox: PUT returned `arming` in 1.9s and the
+ * edge reported `armed` after **17s**. 45s leaves room for a slower day without
+ * waiting forever. Session provisioning already takes ~40-60s and is fail-closed
+ * here on purpose, so it can afford the wait; the user's turn cannot, which is
+ * why the prompt path bounds its own patience instead of shortening this.
+ *
  * The budget stays generous because the caller that must NOT proceed without an
  * armed edge — session provision (platform/services/session-sandbox.ts) — has to
  * either arm or fail. Callers on a user's hot path must not adopt this as their
@@ -33,7 +41,7 @@ const DESCRIPTION_PREFIX = 'kortix-network-v1';
  * background (see PROMPT_BOUNDARY_ARM_WAIT_MS in
  * projects/lib/sandbox-env-sync.ts).
  */
-const ARM_TIMEOUT_MS = 10_000;
+const ARM_TIMEOUT_MS = 45_000;
 const ARM_POLL_MIN_MS = 150;
 const ARM_POLL_MAX_MS = 1_000;
 


### PR DESCRIPTION
Follow-up to [#6381](https://github.com/kortix-ai/suna/pull/6381). That PR fixed the 409 that made every
re-arm impossible; deploying it moved the failure one step along, to this:

```
Platinum network-boundary secrets did not arm for sbx_… within 10000ms
```

Session provisioning fails, so a project with a network-boundary secret still cannot start a session.

## The 10s budget was below the provider's real latency

Measured directly against `api.platinum.dev`, attaching a secret to a live dev sandbox:

| step | time |
|---|---|
| `PUT /v1/sandboxes/{id}/secrets` returns `arming` | 1.9s |
| edge reports `armed` | **17s** |

10s could never succeed. Raised to 45s, with the measurement recorded in the comment so the next person
doesn't have to re-derive it.

## Why 45s is safe here

Only **session provision** waits this long, and it is fail-closed on purpose — a session that cannot arm
its boundary must not start. Provisioning already takes ~40–60s, so the wait fits inside work the user is
already waiting on.

A user's **turn** never pays it: the prompt path bounds its own patience at 1.5s and lets the arm finish
in the background (#6381).

## Verified

- `apps/api`: **639 pass / 10 skip / 0 fail** across `secrets` and `projects/lib`.
- `tsc` clean in the touched file.
- Deployed-dev evidence for the failure this fixes: `lastProvisioningError` on the failed sandbox row read
  exactly the message above, and the same session provisioned fine with the egress secret disabled.