### PR TITLE
billing: kill the duplicate frontend tier catalogs (PR7)

### DIFF
--- a/apps/web/src/app/(public)/(marketing)/pricing/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/pricing/page.tsx
@@ -13,9 +13,11 @@ import Link from 'next/link';
 const START_URL = '/auth';
 const DEMO_URL = '/enterprise';
 
+// Keyed by MARKETING plan id (display-only — see pricing-plans.ts). Never an
+// API tier key.
 const PLAN_CTAS: Record<(typeof PRICING_PLANS)[number]['id'], { cta: string; href: string }> = {
   free: { cta: 'Get started', href: START_URL },
-  team: { cta: 'Get started', href: START_URL },
+  team_seat: { cta: 'Get started', href: START_URL },
   enterprise: { cta: 'Request demo', href: DEMO_URL },
 };
 

--- a/apps/web/src/features/billing/global-upgrade-modal.tsx
+++ b/apps/web/src/features/billing/global-upgrade-modal.tsx
@@ -121,6 +121,9 @@ export function UpgradePlansModal({
     });
   };
 
+  // Keyed by MARKETING plan id (display-only — see pricing-plans.ts). The
+  // account's real plan is `isPerSeat` / `resolvedPlan(accountState)`, never
+  // one of these ids.
   const planActions: Record<UpgradeModalPlanId, React.ReactNode> = {
     free: (
       <Button
@@ -132,7 +135,7 @@ export function UpgradePlansModal({
         Continue on Free
       </Button>
     ),
-    team: canManageBilling ? (
+    team_seat: canManageBilling ? (
       <div className="space-y-2">
         {hasSeatMath && (
           <p className="text-muted-foreground text-center text-xs tabular-nums">
@@ -180,7 +183,7 @@ export function UpgradePlansModal({
   // core bug here). The top-up view already handles per-seat/subscribed
   // accounts, so this plans view is only reached for free/no-plan accounts.
   const planBadges: Partial<Record<UpgradeModalPlanId, string>> = isPerSeat
-    ? { team: 'Current plan' }
+    ? { team_seat: 'Current plan' }
     : { free: 'Current plan' };
 
   return (
@@ -207,7 +210,7 @@ export function UpgradePlansModal({
                 compact
                 action={planActions[plan.id]}
                 badgeOverride={planBadges[plan.id]}
-                priceOverride={plan.id === 'team' ? `$${pricePerSeat}` : undefined}
+                priceOverride={plan.id === 'team_seat' ? `$${pricePerSeat}` : undefined}
               />
             ))}
           </div>

--- a/apps/web/src/features/billing/pricing-plans.ts
+++ b/apps/web/src/features/billing/pricing-plans.ts
@@ -1,4 +1,19 @@
-export type PricingPlanId = 'free' | 'team' | 'enterprise';
+/**
+ * Ids for the MARKETING plan cards. DISPLAY-ONLY.
+ *
+ * These are React keys and copy lookups for the three cards on /pricing and the
+ * two in the upgrade modal. They are NOT billing identifiers and must never be
+ * compared against an API tier key, `subscription.tier_key`, `billing_model`, a
+ * Stripe price/product id, or an entitlement key.
+ *
+ * `'team_seat'` is spelled out for exactly that reason: the card it names is the
+ * live $40/seat per-seat offer (`billing_model === 'per_seat'`), while the API
+ * key `team` is the RETIRED $200 flat plan. The id used to be `'team'`, so the
+ * same six letters meant two different products depending on which file you
+ * were reading. To branch on what an account is actually on, use
+ * `resolvedPlan(accountState)` from `@kortix/sdk` — not one of these ids.
+ */
+export type PricingPlanId = 'free' | 'team_seat' | 'enterprise';
 
 export type UpgradeModalPlanId = Exclude<PricingPlanId, 'enterprise'>;
 
@@ -28,7 +43,7 @@ export const PRICING_PLANS: PricingPlan[] = [
     ],
   },
   {
-    id: 'team',
+    id: 'team_seat',
     name: 'Team',
     price: '$40',
     unit: '/ seat / mo',

--- a/apps/web/src/features/marketing/faq/content.ts
+++ b/apps/web/src/features/marketing/faq/content.ts
@@ -41,10 +41,12 @@
  * 2026-07-31. Do not soften, inflate, or "restore" any of it.
  * ==========================================================================
  *  - PRICE. Managed cloud is $40 / seat / mo — `apps/web/src/features/billing/
- *    pricing-plans.ts:33` (`price: '$40'`, `unit: '/ seat / mo'`). Free is $0
- *    with "200 credits / month for sandbox compute" and "1 project" (:22-27).
- *    Team carries "2,500 credits / month per seat, pooled" (:40). Quote no other
- *    figure, and never invent a discount, a trial length or a usage rate.
+ *    pricing-plans.ts`, the `team_seat` entry of `PRICING_PLANS` (`price: '$40'`,
+ *    `unit: '/ seat / mo'`). Its `free` entry is $0 with "200 credits / month for
+ *    sandbox compute" and "1 project". `team_seat` carries "2,500 credits /
+ *    month per seat, pooled". (Cited by plan id, not line number — the ids are
+ *    stable, the line numbers were not.) Quote no other figure, and never invent
+ *    a discount, a trial length or a usage rate.
  *  - MODELS. The ChatGPT subscription path is REAL — Codex device-grant OAuth,
  *    `apps/api/src/projects/codex-device-auth.ts`. There is NO Cursor auth path
  *    and no Claude-subscription auth path anywhere in the codebase, however

--- a/apps/web/src/hooks/billing/use-account-state.ts
+++ b/apps/web/src/hooks/billing/use-account-state.ts
@@ -567,15 +567,11 @@ export const accountStateSelectors = {
   tierDisplayName: (state: AccountState | undefined) =>
     state?.subscription?.tier_display_name ?? 'No Plan',
 
-  /** Get plan name for TierBadge (e.g., 'Plus', 'Pro', 'Ultra', 'Basic') */
-  planName: (state: AccountState | undefined) => {
-    if (!state?.subscription) return 'Basic';
-    const tierKey = state.subscription.tier_key || state.tier?.name;
-    if (!tierKey || tierKey === 'none' || tierKey === 'free') return 'Basic';
-
-    if (tierKey === 'pro') return 'Pro';
-    return 'Basic';
-  },
+  // REMOVED: `planName`. It was a third frontend tier catalog — a hand-written
+  // tier_key -> display-name map that only knew 'pro' and called every other
+  // paid plan 'Basic', so a per-seat Team account read as Basic. It had no
+  // callers. Use `resolvedPlan(state).label` (@kortix/sdk), which reads the
+  // server's plan block.
 
   /** Check if subscription is cancelled */
   isCancelled: (state: AccountState | undefined) => state?.subscription?.is_cancelled ?? false,

--- a/apps/web/src/lib/analytics/gtm.ts
+++ b/apps/web/src/lib/analytics/gtm.ts
@@ -457,8 +457,8 @@ export function trackSendAuthLink() {
 // =============================================================================
 
 export interface PurchaseItem {
-  item_id: string;          // e.g., "tier_2_20", "tier_6_50", "free"
-  item_name: string;        // e.g., "Plus", "Pro", "Basic"
+  item_id: string;          // API tier key, e.g. "free", "per_seat"
+  item_name: string;        // Plan label, e.g. "Free", "Team"
   coupon?: string;
   discount?: number;
   item_brand: string;       // "Kortix AI"
@@ -558,7 +558,7 @@ export function storeCheckoutData(data: {
   billing_period: string;
   coupon?: string;
   discount?: number;
-  previous_tier?: string; // User's tier before checkout (e.g., "free", "tier_2_20")
+  previous_tier?: string; // User's API tier key before checkout (e.g. "free")
 }) {
   if (typeof window === 'undefined') return;
   safeSessionSetItem('gtm_checkout_data', JSON.stringify({

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -1,72 +1,16 @@
-// Subscription tier structure - tier keys only, no price IDs
-export interface SubscriptionTierData {
-  tierKey: string;  // Backend tier key like 'free', 'pro', etc.
-  name: string;     // Display name like 'Free', 'Pro'
-}
+import { getEnv } from '@/lib/env-config';
 
-// Subscription tiers structure - ONLY tier keys, price IDs come from backend
-export interface SubscriptionTiers {
-  FREE_TIER: SubscriptionTierData;
-  PRO: SubscriptionTierData;
-  // Legacy tiers kept for backward compat (existing users)
-  TIER_2_20: SubscriptionTierData;
-  TIER_6_50: SubscriptionTierData;
-  TIER_12_100: SubscriptionTierData;
-  TIER_25_200: SubscriptionTierData;
-  TIER_50_400: SubscriptionTierData;
-  TIER_125_800: SubscriptionTierData;
-  TIER_200_1000: SubscriptionTierData;
-}
-
-// Configuration object
-interface Config {
-  SUBSCRIPTION_TIERS: SubscriptionTiers;
-}
-
-// Tier keys - single source, no environment-specific price IDs
-const TIERS: SubscriptionTiers = {
-  FREE_TIER: {
-    tierKey: 'free',
-    name: 'Free/$0',
-  },
-  PRO: {
-    tierKey: 'pro',
-    name: 'Pro/$20',
-  },
-  // Legacy tiers
-  TIER_2_20: {
-    tierKey: 'tier_2_20',
-    name: 'Plus/$20',
-  },
-  TIER_6_50: {
-    tierKey: 'tier_6_50',
-    name: 'Pro/$50',
-  },
-  TIER_12_100: {
-    tierKey: 'tier_12_100',
-    name: 'Business/$100',
-  },
-  TIER_25_200: {
-    tierKey: 'tier_25_200',
-    name: 'Ultra/$200',
-  },
-  TIER_50_400: {
-    tierKey: 'tier_50_400',
-    name: 'Enterprise/$400',
-  },
-  TIER_125_800: {
-    tierKey: 'tier_125_800',
-    name: 'Scale/$800',
-  },
-  TIER_200_1000: {
-    tierKey: 'tier_200_1000',
-    name: 'Max/$1000',
-  },
-} as const;
-
-export const config: Config = {
-  SUBSCRIPTION_TIERS: TIERS,
-};
+/**
+ * Deployment feature switches for `apps/web`.
+ *
+ * NO TIER / PLAN DATA LIVES HERE. This file used to carry a hand-maintained
+ * `SUBSCRIPTION_TIERS` catalog (FREE_TIER, PRO, TIER_2_20 … TIER_200_1000 with
+ * prices baked into display names). Every one of those tiers is retired, the
+ * catalog had zero importers, and the API is the only source of truth for what
+ * an account is on. Read plan identity from `resolvedPlan(accountState)` and
+ * plan numbers from `accountState.tier` / `accountState.plan` — never from a
+ * frontend constant.
+ */
 
 /**
  * Whether billing (Stripe, credit tracking, paywall, plan picker) is enabled on
@@ -124,5 +68,3 @@ export const isConnectorsEnabled = (): boolean => {
 export const isAccountCreationRestricted = (): boolean => {
   return getEnv().RESTRICT_ACCOUNT_CREATION;
 };
-
-import { getEnv } from '@/lib/env-config';


### PR DESCRIPTION
PR7, the final cleanup of the billing revamp (PR1 #6367 → PR5 #6383).

- **`lib/config.ts` tier catalog deleted** (−54 lines). Headline finding: it had ZERO importers — all 28 `@/lib/config` importers take only feature flags. Header comment now bans tier data in the file.
- **Marketing plan-id collision resolved**: `PricingPlanId` `'team'` → `'team_seat'` (the $40/seat offer) so it can never be confused with the API's retired `team` key; doc comment pins marketing ids as DISPLAY-ONLY. Consumers updated (pricing page CTAs, upgrade modal — compile-enforced exhaustive records).
- Third mini-catalog removed: dead `accountStateSelectors.planName`; stale tier examples in gtm.ts comments refreshed; FAQ accuracy-gate citations updated.
- `/pricing` rendered output proven **byte-identical** (SSR render old vs new: 11,694 bytes equal; `PricingPlanCard` never reads `plan.id`).

## Verification
- web touched suites: 3890/0 + 841/0 + 381/0; post-main-merge rerun 1153/0. tsc clean except the 3 known @types/bun files; eslint 0 problems on touched files.
- Left for a later dead-code sweep (zero callers, not duplicated data): `useTierConfigurations`/`getTierByKey`, `UserMenuUser.planName`.