### PR TITLE
fix(api): deny agent-scope and secret-grant writes during impersonation

### DIFF
--- a/apps/api/src/__tests__/unit-impersonation.test.ts
+++ b/apps/api/src/__tests__/unit-impersonation.test.ts
@@ -185,6 +185,10 @@ describe('decideImpersonation', () => {
       '/v1/projects/p1/sessions/s1/public-shares',
       '/v1/tunnel/connections',
       '/v1/tunnel/connections/t1/rotate-token',
+      // Agent governance: both routes commit `kortix.yaml` changes that widen
+      // what an agent may read in every future session, outliving the grant.
+      '/v1/projects/p1/agents/researcher/scope',
+      '/v1/projects/p1/secrets/OPENAI_API_KEY/grant',
     ]) {
       expect(decide({ path })).toEqual({ ok: false, reason: 'route_forbidden' });
     }
@@ -228,6 +232,10 @@ describe('decideImpersonation', () => {
       '/v1/p/sandbox/8000/session',
       // Near-misses for the new patterns — these must stay reachable.
       '/v1/projects/p1/sessions/s1/messages',
+      // Secret CRUD and the agents list are ordinary project surfaces; only
+      // the /grant and /scope leaves mint durable agent governance.
+      '/v1/projects/p1/secrets',
+      '/v1/projects/p1/agents',
       // Audit READ (not the webhooks sub-route) stays open for support.
       '/v1/accounts/33333333-3333-4333-8333-333333333333/audit',
     ]) {
@@ -265,6 +273,9 @@ describe('decideImpersonation', () => {
       '/v1/tunnel/permissions/x',
       // Public shares without expiry = permanent unauthenticated link.
       '/v1/projects/p1/sessions/s1/public-shares',
+      // Agent governance written into kortix.yaml.
+      '/v1/projects/p1/agents/researcher/scope',
+      '/v1/projects/p1/secrets/OPENAI_API_KEY/grant',
     ]) {
       expect(isImpersonationForbiddenPath(path, 'POST'), `POST ${path}`).toBe(true);
     }

--- a/apps/api/src/shared/impersonation.ts
+++ b/apps/api/src/shared/impersonation.ts
@@ -158,6 +158,14 @@ const IMPERSONATION_FORBIDDEN_ROUTES: ForbiddenRoute[] = [
   // Same permanent-access outcome as the account-scoped member route above.
   { re: /^\/v1\/projects\/[^/]+\/access(\/|$)/ },
   { re: /^\/v1\/account-invites(\/|$)/ },
+  // Agent governance. PUT /agents/:name/scope and POST /secrets/:id/grant
+  // commit durable state into `kortix.yaml`: widening what an agent may read
+  // changes every future session of the project and survives the grant with
+  // no banner and no marker — the same persistence-not-debugging outcome as a
+  // membership row. An operator who needs a scope change lands it through the
+  // customer or an attributable admin route, not from inside the hour.
+  { re: /^\/v1\/projects\/[^/]+\/agents\/[^/]+\/scope(\/|$)/ },
+  { re: /^\/v1\/projects\/[^/]+\/secrets\/[^/]+\/grant(\/|$)/ },
   // Audit webhooks. Pointing the customer's audit stream at an operator URL
   // exfiltrates their events and survives the grant.
   { re: /^\/v1\/accounts\/[^/]+\/audit\/webhooks(\/|$)/ },

--- a/apps/web/src/app/admin/accounts/page.tsx
+++ b/apps/web/src/app/admin/accounts/page.tsx
@@ -93,7 +93,6 @@ import { cn } from '@/lib/utils';
 
 import { adminLedgerRows } from './ledger-rows';
 import {
-  BOOLEAN_OVERRIDE_KEYS,
   MAX_COMPUTE_RATE_MULTIPLIER,
   MAX_CONCURRENT_SESSIONS_OVERRIDE,
   describeOverridePatch,


### PR DESCRIPTION
## Problem

Strix HIGH (CWE-862) on #6387: the impersonation deny-list blocks tokens, memberships, invites, SSO, shares, and tunnels, but left two durable-write routes reachable during act-as:

- `PUT /v1/projects/:projectId/agents/:agentName/scope`
- `POST /v1/projects/:projectId/secrets/:identifier/grant`

Both commit agent governance into `kortix.yaml`. A widened secret grant changes what every future session of the project can read and survives the 1-hour grant with no banner and no marker — the exact durable-access shape `IMPERSONATION_FORBIDDEN_ROUTES` exists to refuse.

## Change

1. `apps/api/src/shared/impersonation.ts` — two new deny-list entries for the routes above (state-changing methods only, reads unaffected).
2. `apps/api/src/__tests__/unit-impersonation.test.ts` — both paths added to the durable-access refusal tests and the PR6 regression-guard list; near-miss coverage that `/v1/projects/:id/secrets` and `/v1/projects/:id/agents` stay reachable.
3. `apps/web/src/app/admin/accounts/page.tsx` — removes the unused `BOOLEAN_OVERRIDE_KEYS` import CodeQL flagged.

## Verification

- `bun test src/__tests__/unit-impersonation.test.ts`: 36 pass, 0 fail, 167 assertions.
- `apps/api` `bunx tsc --noEmit`: exit 0.
- `npx eslint src/app/admin/accounts/page.tsx`: 0 errors (2 pre-existing `react-hooks` warnings, expected per repo baseline).
