### PR TITLE
fix(api): deny connector, channel-connect and setup-link writes during impersonation

### DIFF
--- a/apps/api/src/__tests__/unit-impersonation.test.ts
+++ b/apps/api/src/__tests__/unit-impersonation.test.ts
@@ -189,6 +189,26 @@ describe('decideImpersonation', () => {
       // what an agent may read in every future session, outliving the grant.
       '/v1/projects/p1/agents/researcher/scope',
       '/v1/projects/p1/secrets/OPENAI_API_KEY/grant',
+      // Connector management, BOTH mounts: connection rows, credentials and
+      // OAuth state outlive the grant like any other minted credential.
+      '/v1/projects/p1/connections',
+      '/v1/projects/p1/connections/me',
+      '/v1/projects/p1/connections/c1/credential',
+      '/v1/projects/p1/connections/c1/connect/finalize',
+      '/v1/projects/p1/connections/c1/oauth2/authorize',
+      '/v1/projects/p1/connectors/slack/oauth2/connection',
+      '/v1/connectors/projects/p1/connectors',
+      '/v1/connectors/projects/p1/connectors/slack/connect',
+      '/v1/connectors/projects/p1/connectors/slack/credential',
+      '/v1/connectors/projects/p1/connectors/slack/secret-binding',
+      '/v1/connectors/projects/p1/policies',
+      // Channel connects bind an external workspace that keeps reaching the
+      // account after the hour.
+      '/v1/projects/p1/channels/slack/connect',
+      '/v1/projects/p1/channels/email/connect',
+      // Setup links: 7-day public-token intake doors minted inside the hour.
+      '/v1/projects/p1/connect-requests',
+      '/v1/projects/p1/secret-requests',
     ]) {
       expect(decide({ path })).toEqual({ ok: false, reason: 'route_forbidden' });
     }
@@ -236,6 +256,13 @@ describe('decideImpersonation', () => {
       // the /grant and /scope leaves mint durable agent governance.
       '/v1/projects/p1/secrets',
       '/v1/projects/p1/agents',
+      // Live connector invocation acts now, inside the audited hour, and
+      // creates nothing durable — support uses it to reproduce issues.
+      '/v1/connectors/projects/p1/call',
+      '/v1/connectors/call',
+      // Trigger writes stay open pending a team decision: they are visible
+      // customer product state, not minted operator access.
+      '/v1/projects/p1/triggers',
       // Audit READ (not the webhooks sub-route) stays open for support.
       '/v1/accounts/33333333-3333-4333-8333-333333333333/audit',
     ]) {
@@ -276,6 +303,13 @@ describe('decideImpersonation', () => {
       // Agent governance written into kortix.yaml.
       '/v1/projects/p1/agents/researcher/scope',
       '/v1/projects/p1/secrets/OPENAI_API_KEY/grant',
+      // Connector credentials + OAuth state, both mounts; channel binds; and
+      // the 7-day public setup-link mints.
+      '/v1/projects/p1/connections/me',
+      '/v1/connectors/projects/p1/connectors/slack/connect/finalize',
+      '/v1/projects/p1/channels/teams/connect',
+      '/v1/projects/p1/connect-requests',
+      '/v1/projects/p1/secret-requests',
     ]) {
       expect(isImpersonationForbiddenPath(path, 'POST'), `POST ${path}`).toBe(true);
     }

--- a/apps/api/src/shared/impersonation.ts
+++ b/apps/api/src/shared/impersonation.ts
@@ -175,6 +175,26 @@ const IMPERSONATION_FORBIDDEN_ROUTES: ForbiddenRoute[] = [
   // sso, scim (directory sync), and the token routes above.
   { re: /^\/v1\/accounts\/[^/]+\/iam\/sso(\/|$)/ },
   { re: /^\/v1\/accounts\/[^/]+\/iam\/scim(\/|$)/ },
+  // Connectors. A connection row carries a stored credential or OAuth state
+  // for an external service; connecting a workspace or app the OPERATOR
+  // controls is a durable exfiltration channel that outlives the grant, the
+  // same shape as an audit webhook. Both mounts of the management surface are
+  // blocked for writes: the project-scoped one and the /v1/connectors one.
+  // Reads (inventory, status, catalog) stay open — they are what support
+  // needs. Live invocation (`/call`) stays open too: it acts now, inside the
+  // audited hour, and creates nothing durable.
+  { re: /^\/v1\/projects\/[^/]+\/connections(\/|$)/ },
+  { re: /^\/v1\/projects\/[^/]+\/connectors\/[^/]+\/oauth2\/connection(\/|$)/ },
+  { re: /^\/v1\/connectors\/projects\/[^/]+\/connectors(\/|$)/ },
+  { re: /^\/v1\/connectors\/projects\/[^/]+\/policies(\/|$)/ },
+  // Channels are connections too: email/slack/teams connect binds an external
+  // workspace or address that keeps reaching the account after the hour.
+  { re: /^\/v1\/projects\/[^/]+\/channels\/[^/]+\/connect(\/|$)/ },
+  // Setup links. connect-requests and secret-requests mint 7-day tokens whose
+  // consuming routes are public (`/v1/setup-links/*`) — a link minted inside
+  // the hour is a credential-intake door that works for days after it.
+  { re: /^\/v1\/projects\/[^/]+\/connect-requests(\/|$)/ },
+  { re: /^\/v1\/projects\/[^/]+\/secret-requests(\/|$)/ },
   // Public shares. `expires_at` is optional, and the consuming route
   // (`/v1/public/session-shares/:shareId`) is mounted before auth — an
   // omitted expiry is a permanent unauthenticated link to a customer session.


### PR DESCRIPTION
## Problem

Strix HIGH (CWE-863) on release PR #6389: the act-as deny-list did not cover connector management. A connection row carries a stored credential or OAuth state for an external service — connecting a workspace the operator controls is a durable exfiltration channel that outlives the 1-hour grant, same shape as an audit webhook.

The review suggestion covered only `/v1/projects/:id/connections*`. The route manifest (`tests/spec/routes.generated.json`) shows more of the same class, all included here:

- `/v1/connectors/projects/:id/connectors*` + `.../policies` — a second mount of the same management surface (connect, finalize, credential, secret-binding, policies)
- `/v1/projects/:id/channels/{email,slack,teams}/connect` — binds an external workspace
- `/v1/projects/:id/connect-requests` and `.../secret-requests` — mint 7-day public setup-link tokens (`/v1/setup-links/*` is unauthenticated by design)

## Left open, on purpose

- Reads (inventory, status, catalog) and live `/call` invocation — what support actually needs; `/call` acts inside the audited hour and creates nothing durable.
- **Trigger writes** — visible customer product state, not minted operator access, and support legitimately fixes trigger activation. Flagged for a team decision; easy to add later.

## Verification

- `bun test src/__tests__/unit-impersonation.test.ts`: 36 pass, 0 fail, 190 assertions (each new family covered in both refusal lists + near-misses proving `/call`, `/triggers`, `/secrets`, `/agents` stay reachable).
- `apps/api` `bunx tsc --noEmit`: exit 0.
