### PR TITLE
fix(compliance): resolve Drata IaC critical/high findings

### DIFF
--- a/docs/compliance/IAC-SCANNER-EXCEPTIONS.md
+++ b/docs/compliance/IAC-SCANNER-EXCEPTIONS.md
@@ -9,9 +9,17 @@ Owner: Security and Infrastructure
 Review cadence: quarterly and whenever the affected resource or trust boundary
 changes.
 
-Last reviewed: 2026-08-10
+Last reviewed: 2026-08-11
 
-Evidence run: `c8397bf7-3e20-4347-8dec-0a6f6fcd90a7`
+Evidence run: `5d9d7d52-adc0-4565-98c3-9ede258b9fa0` (3 critical, 2 high, 39
+moderate; `excludedFindings: 0`).
+
+Local verification: `checkov` 3.3.8 passes every crit/high control on the exact
+code below — `CKV_AWS_21` (S3 versioning), `CKV2_AWS_6` + `CKV_AWS_53..56` (S3
+public-access-block), `CKV_AWS_355`/`CKV_AWS_356` (IAM wildcard, honored via
+`#checkov:skip`), and `CKV_AWS_150` (ALB). The code is correct; the residual
+crit/high findings are Drata-engine limitations (see root cause below), not code
+defects.
 
 ## Accepted findings
 
@@ -22,7 +30,7 @@ Evidence run: `c8397bf7-3e20-4347-8dec-0a6f6fcd90a7`
 | 8010 Broad Network Egress                  | Moderate | ECS service and self-host security groups                                                |     2 | Required service egress           | The workloads call registries, model providers, package mirrors, identity services, and user-selected targets without stable destination CIDRs. Ingress is independently restricted. NAT, VPC flow logs, GuardDuty, and application monitoring provide detective controls. |
 | 8011 Public Access Restricted              | High     | `module.ecs-api.aws_lb.this`                                                             |     1 | Intended public edge              | The ALB is the public HTTPS entry point. Security groups restrict origin ingress. TLS, WAF, access logs, and regional alarms protect and monitor the edge.                                                                                                                 |
 | 8011 Public Access Restricted              | Critical | `module.ecs-api.aws_s3_bucket.alb_logs`                                                  |     1 | Parser false positive             | The bucket has all four S3 public-access-block settings enabled. `BucketOwnerEnforced` disables ACLs. Its bucket policy denies insecure transport and grants writes only to the Elastic Load Balancing log-delivery principal on the account-specific prefix.                |
-| 8028 Resource Tagging                      | Moderate | IAM, KMS, S3, SNS, subnet, instance, security-group, network-ACL, and DynamoDB resources |    24 | Parser false positive             | The Terraform resources use explicit tag maps, provider default tags, or module tag expressions. The scanner reports empty maps because it does not evaluate those expressions. Live inventory remains subject to the account tagging control.                             |
+| 8028 Resource Tagging                      | Moderate | IAM, KMS, S3, SNS, subnet, instance, security-group, network-ACL, and DynamoDB resources |    31 | Parser false positive             | The Terraform resources carry tags through `local.tags`, `merge(local.tags, …)`, literal maps, or provider default tags. Drata reports `{}` because its engine does not resolve `local`/`var`/`merge` references (verified: `module.ecs-api.aws_lb.this` has a literal tag block yet is still reported `{}`). Live inventory remains subject to the account tagging control. Fixed in code: the three imported legacy IAM roles in `security-baseline/legacy-roles.tf` (`whatsapp_gateway_github_deploy`, `bedrock_logs`, `whatsapp_gateway_instance`) had literal `tags = {}` and now use `tags = local.tags`; Drata may still report them `{}` until it resolves the `local` reference. |
 | 8025 Access Policies Restrict Broad Access | Critical | `security-baseline.aws_iam_role_policy.gha_nacl_audit`                                   |     1 | Explicit Drata exclusion required | The policy grants only `ec2:DescribeRegions` and `ec2:DescribeNetworkAcls`. AWS does not support resource-level permissions for either action. GitHub OIDC trust is scoped to `kortix-ai/suna`. The policy grants no write action.                                         |
 | 8025 Access Policies Restrict Broad Access | Critical | `preview.aws_iam_role_policy.github_preview_deploy`                                      |     1 | Explicit Drata exclusion required | Wildcard resources apply only to ECS task-definition registration and deregistration, ECS/EC2/ELB read APIs, and target-group creation. AWS does not support resource scoping for these calls. Mutations use preview name patterns, request or resource tags, one listener, and two preview roles. The OIDC trust also requires `deploy-preview.yml` from `main`. |
 
@@ -37,6 +45,44 @@ explicit baseline, and so the wildcard use is justified for SOC 2 reviewers.
 | Resource                                                        | Why `Resource: "*"`                                                                                       | Scanner status                                                                                                              |
 | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `security-baseline.aws_iam_policy.mfa_required`                 | DCF-67 MFA enforcement — deny-all-except-MFA-enrollment cannot be resource-scoped; grants no permission. | Not flagged (verified: scan `0c4a4878-9b23-4751-a7d0-84d68c6b0050`, PR #6289; critical count unchanged from main baseline). |
+
+## Recurring failure root cause and re-exclusion IDs
+
+The CI gate fails on the 3 critical findings **even though the code is correct and
+every prior finding is documented here**. Root cause: Drata renamed its
+finding-ID scheme. Each finding's `idHistory` shows the `configId` moving from
+Terraform resource names to a cloud-model path — for example
+`aws_lb.internal` → `elastic_load_balancing_v2.load_balancer.scheme`,
+`aws_s3_bucket_public_access_block` → `s3.bucket.public_access_block_configuration`,
+and `aws_iam_role.inline_policy.policy` → `iam.role[0].policies[0].policy_document`.
+A dashboard exclusion is keyed to the exact finding ID, so the rename orphaned the
+earlier exclusions. Evidence run `5d9d7d52` reports `excludedFindings: 0` — no
+exclusion currently matches. The fix is to **re-create the exclusions in the Drata
+dashboard against the current finding IDs below** (Compliance-as-Code → this run →
+each finding → Exclude). There is no public Drata API to exclude findings; this is
+dashboard-only.
+
+Drata does **not** honor in-code `#checkov:skip` comments and does **not**
+graph-link the split `aws_s3_bucket_versioning` / `aws_s3_bucket_public_access_block`
+resources to their bucket. Both behaviors are confirmed against the scanned branch
+`release/v0.12.8`, which already contained the split resources (status `Enabled`,
+all four blocks `true`) and the skip comments, yet was still flagged. No code change
+clears these; the exclusions are required.
+
+Current finding IDs to exclude (critical gate) — copy the whole `id` string:
+
+| Sev | Test | Resource | Finding `id` |
+| --- | ---- | -------- | ------------ |
+| Critical | 8011 | `module.ecs-api.aws_s3_bucket.alb_logs` | `8011|s3.bucket.public_access_block_configuration|e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|kortix-ai/suna|terraform/infra/terraform/modules/ecs-api/main.tf|alb_logs|AWS::S3|2` |
+| Critical | 8025 | `preview.aws_iam_role_policy.github_preview_deploy` (Drata labels it `ecs-api…execution`) | `8025|iam.role[0].policies[0].policy_document|1c978eaa194a87f0871f01555dcd1ed4eabbf1d01994ab999a59a7f3dac76ba4|kortix-ai/suna|terraform/infra/terraform/modules/ecs-api/main.tf|execution|AWS::IAM|2` |
+| Critical | 8025 | `security-baseline.aws_iam_role_policy.gha_nacl_audit` | `8025|iam.role[0].policies[0].policy_document|631c0a9268d669fd46048a6c74529b06c412d7f7d12c252466668360b31f9d1f|kortix-ai/suna|terraform/infra/terraform/security-baseline/iam-gha-nacl-audit.tf|gha_nacl_audit|AWS::IAM|2` |
+| High | 8011 | `module.ecs-api.aws_lb.this` | `8011|elastic_load_balancing_v2.load_balancer.scheme|e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|kortix-ai/suna|terraform/infra/terraform/modules/ecs-api/main.tf|https|AWS::ElasticLoadBalancingV2|2` |
+| High | 8003 | `module.ecs-api.aws_s3_bucket.alb_logs` | `8003|s3.bucket.versioning_configuration.status|e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|kortix-ai/suna|terraform/infra/terraform/modules/ecs-api/main.tf|alb_logs|AWS::S3|2` |
+
+Only the two critical `8025` IAM findings and the critical `8011` S3 finding must be
+excluded to make the gate pass at `minimumSeverity: CRITICAL`. The two high findings
+do not fail the gate but should be excluded to keep the run clean; their rationale is
+in the Accepted findings table above.
 
 ## Change rule
 

--- a/infra/terraform/security-baseline/iam-gha-nacl-audit.tf
+++ b/infra/terraform/security-baseline/iam-gha-nacl-audit.tf
@@ -46,9 +46,8 @@ resource "aws_iam_role" "gha_nacl_audit" {
 }
 
 resource "aws_iam_role_policy" "gha_nacl_audit" {
-  # checkov:skip=CKV_AWS_355: DescribeRegions and DescribeNetworkAcls are
-  # account-wide describes; neither API supports resource-level permissions.
-  # checkov:skip=CKV_AWS_290: Read-only describes; the policy grants no writes.
+  #checkov:skip=CKV_AWS_355:ec2:DescribeRegions and ec2:DescribeNetworkAcls are account-wide describe APIs; neither supports resource-level permissions, so Resource must be "*".
+  #checkov:skip=CKV_AWS_290:Read-only describe policy; it grants no write action.
   name = "nacl-admin-port-audit"
   role = aws_iam_role.gha_nacl_audit.id
   policy = jsonencode({

--- a/infra/terraform/security-baseline/legacy-roles.tf
+++ b/infra/terraform/security-baseline/legacy-roles.tf
@@ -11,8 +11,7 @@ resource "aws_iam_role" "whatsapp_gateway_github_deploy" {
   name_prefix           = null
   path                  = "/"
   permissions_boundary  = null
-  tags                  = {}
-  tags_all              = {}
+  tags                  = local.tags
 }
 
 # __generated__ by Terraform from "bedrock-logs"
@@ -25,8 +24,7 @@ resource "aws_iam_role" "bedrock_logs" {
   name_prefix           = null
   path                  = "/service-role/"
   permissions_boundary  = null
-  tags                  = {}
-  tags_all              = {}
+  tags                  = local.tags
 }
 
 # __generated__ by Terraform from "whatsapp-gateway-instance"
@@ -39,6 +37,5 @@ resource "aws_iam_role" "whatsapp_gateway_instance" {
   name_prefix           = null
   path                  = "/"
   permissions_boundary  = null
-  tags                  = {}
-  tags_all              = {}
+  tags                  = local.tags
 }


### PR DESCRIPTION
## Summary

The Drata Compliance-as-Code IaC scan (`drata-compliance.yml`, `minimumSeverity: CRITICAL`) fails the CI step on 3 CRITICAL findings. Scan run `5d9d7d52-adc0-4565-98c3-9ede258b9fa0`: 3 critical, 2 high, 39 moderate, `excludedFindings: 0`.

I verified every crit/high finding against the actual code on `origin/main` and against the exact scanned branch `release/v0.12.8`. **All 5 crit/high findings are already correct or architecturally necessary in code** — `checkov` 3.3.8 (the engine Drata derives from) passes every one. Drata's fork cannot see the fixes. This PR makes the genuinely-fixable moderate cleanups, and documents the precise re-exclusion path for the criticals, which is dashboard-only.

Honest bottom line: **merging this PR alone does NOT make the check pass at CRITICAL.** The 3 critical findings require Drata dashboard exclusions (details below).

Local verification (worktree, `terraform` + `checkov` 3.3.8):
- `terraform fmt -check -recursive infra/terraform` -> clean (exit 0).
- `terraform validate` (security-baseline root, where the code change lives) -> `Success! The configuration is valid.`
- `checkov -d infra/terraform/modules/ecs-api -c CKV_AWS_21,CKV2_AWS_6,CKV_AWS_53,CKV_AWS_54,CKV_AWS_55,CKV_AWS_56,CKV_AWS_355,CKV_AWS_356` -> `Passed 8, Failed 0`.
- `checkov -d infra/terraform/environments/preview` (same checks) -> `Passed 10, Failed 0`.
- `checkov` on `iam-gha-nacl-audit.tf` + `legacy-roles.tf` (`CKV_AWS_355/356/290`) -> `Failed 0, Skipped 2` (skips honored).

---

## Fixed in code

| Finding | Change | Proof |
| ------- | ------ | ----- |
| **8028** Resource Tagging (Moderate) — 3 of the 31 findings: `whatsapp_gateway_github_deploy`, `bedrock_logs`, `whatsapp_gateway_instance` in `security-baseline/legacy-roles.tf` | These imported roles had literal `tags = {}` (the only genuinely untagged resources in the whole finding set). Set `tags = local.tags` (`{ManagedBy, Stack, Compliance}`) and removed the hardcoded computed `tags_all = {}` from the generated imports. | `checkov` on the file: `Failed 0`. `terraform validate` -> valid. Caveat: Drata may still report these `{}` because its engine does not resolve `local`/`var`/`merge` tag references — but the roles are now genuinely tagged at apply time. |
| **CKV_AWS_355/290 skip hygiene** on `aws_iam_role_policy.gha_nacl_audit` | Normalized the two `# checkov:skip` comments (space form, reason split across lines) to the repo's canonical single-`#` one-line form, matching `preview/main.tf` and `iam-gha-ecs-deploy.tf`. No behavior change. | `checkov` reports `Skipped 2` (both skips honored). |

The remaining 36 moderates are **not** code-fixed because doing so is not correct:
- **8004** ALB zone redundancy (2): `aws_lb.this` already receives two AZ subnets; AWS rejects fewer. Drata cannot resolve the `var.public_subnet_ids` list. Blind spot on correct code.
- **8007** Lambda VPC config (5): the alarm/CPU reconcilers call public AWS control-plane APIs; VPC attachment adds NAT dependency and reduces repair reliability. Intentional — exclude, do not change.
- **8010** broad egress (1): self-host / ECS service SGs need egress to registries, model providers, and user-selected targets with no stable CIDR. Ingress is independently restricted. Intentional.
- **8028** the other 28: resources already carry tags via `local.tags` / `merge(local.tags, …)` / literal blocks / provider default tags; Drata does not resolve those references (proven: `aws_lb.this` has a literal tag block yet is reported `{}`). Adding duplicated literal maps would violate the repo tag convention and likely still not clear.

---

## Legitimate — needs dashboard exclusion

There is no public Drata API to exclude findings; this is dashboard-only. **Root cause of the recurring failure:** Drata renamed its finding-ID scheme (each finding's `idHistory` shows `aws_lb.internal` -> `elastic_load_balancing_v2.load_balancer.scheme`, `aws_s3_bucket_public_access_block` -> `s3.bucket.public_access_block_configuration`, `aws_iam_role.inline_policy.policy` -> `iam.role[0].policies[0].policy_document`). Exclusions are keyed to the exact finding ID, so the rename orphaned the prior exclusions — hence `excludedFindings: 0` in the current run. Re-create them against the current IDs (listed in `docs/compliance/IAC-SCANNER-EXCEPTIONS.md`).

| Sev | Test | Resource | Business rationale to paste into Drata |
| --- | ---- | -------- | -------------------------------------- |
| **Critical** | 8025 | `security-baseline.aws_iam_role_policy.gha_nacl_audit` | Grants only `ec2:DescribeRegions` and `ec2:DescribeNetworkAcls`. AWS supports no resource-level permission for either action, so `Resource` must be `*`. Read-only; no write action. GitHub OIDC trust is pinned to `repo:kortix-ai/suna:ref:refs/heads/main`. |
| **Critical** | 8025 | `preview.aws_iam_role_policy.github_preview_deploy` (Drata mislabels the file as `ecs-api…execution`; content = `ecs:DeleteService`/`RegisterTaskDefinition` identifies `github_preview_deploy`) | Wildcard resources apply only to `ecs:RegisterTaskDefinition`/`DeregisterTaskDefinition` and ECS/EC2/ELB read APIs, none of which support resource-level permissions in AWS. Mutating actions are scoped to `kortix-pr-*` names, request/resource tags, one listener, and two preview roles. OIDC trust requires `deploy-preview.yml` from `main`. |
| **Critical** | 8011 | `module.ecs-api.aws_s3_bucket.alb_logs` (public access) | All four `aws_s3_bucket_public_access_block` settings are `true` (separate resource, required by AWS provider v5). `BucketOwnerEnforced` disables ACLs. Bucket policy denies insecure transport and grants writes only to the ELB log-delivery principal on the account prefix. `checkov` CKV2_AWS_6 passes; Drata does not graph-link the split resource. |
| **High** | 8011 | `module.ecs-api.aws_lb.this` (internal=true) | This is the public `api.kortix.com` HTTPS origin; it MUST stay public. Making it internal breaks production. Ingress is restricted to Cloudflare CIDRs at the ALB security group; TLS 1.3, WAF, access logs, and regional alarms protect the edge. |
| **High** | 8003 | `module.ecs-api.aws_s3_bucket.alb_logs` (versioning) | `aws_s3_bucket_versioning.alb_logs` is `Enabled` (separate resource, required by AWS provider v5). `checkov` CKV_AWS_21 passes; Drata does not graph-link the split resource. |

Only the two critical `8025` and the critical `8011` S3 finding must be excluded to make the gate pass at CRITICAL. The two highs do not fail the gate but should be excluded to keep the run clean.

---

## Scanner false-positive

The controls already exist in code; Drata's engine cannot see them. Confirmed against the exact scanned branch `release/v0.12.8`, which already contained the split S3 resources (versioning `Enabled`, all four public-access blocks `true`) and the `#checkov:skip=CKV_AWS_355` comments — yet was still flagged.

- **8011 S3 public access (CRIT)** and **8003 S3 versioning (HIGH)**: fixed as separate `aws_s3_bucket_public_access_block` / `aws_s3_bucket_versioning` resources (the only form AWS provider v5 allows). Drata does not merge split resources into the bucket. My restructuring cannot make this visible — inline bucket versioning/ACL no longer exists in the provider. -> exclusion.
- **8025 IAM wildcards (both CRIT)**: `#checkov:skip=CKV_AWS_355` is present and honored by checkov; Drata ignores checkov skips. -> exclusion.
- **8004 ALB multi-AZ (2 MODERATE)** and most **8028 tagging (MODERATE)**: correct code with `var`/`local` references Drata does not resolve. No code change clears them.

---

## Verification the code is correct (not weakened)

No security posture was weakened: no ALB made internal, no IAM policy broadened, no encryption disabled. The IAM wildcards are on un-scopable AWS actions only; the public ALB is a required public edge with SG-level ingress restriction; the S3 bucket is fully locked down via separate resources. `checkov` 3.3.8 passes all crit/high controls.
