### PR TITLE
fix(ci): raise tests-release timeout to 45m so the full suite can finish

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -14,7 +14,14 @@ jobs:
   deployed-staging:
     name: full suite + quality gates
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # `pnpm test -- --target-full` runs all 433 REST/CLI/browser flows against
+    # deployed staging serially; the real wall-clock is ~25 min of flows plus
+    # ~4 min setup (deps + playwright chromium). A 20-min cap killed the job
+    # mid-run at ~316/433 EVERY release (v0.12.7 and v0.12.8 both cancelled, not
+    # failed) — the gate was structurally un-passable. 45 gives headroom over
+    # the ~30-min real runtime without masking a genuine hang. Follow-up: shard
+    # the runner to bring this back under 20.
+    timeout-minutes: 45
     env:
       KE2E_API_URL: ${{ vars.QA_API_BASE_URL || 'https://staging-api.kortix.com/v1' }}
       E2E_BASE_URL: ${{ vars.QA_WEB_BASE_URL || 'https://staging.kortix.com' }}


### PR DESCRIPTION
## Problem

The `full suite + quality gates` job in `tests-release.yml` (the required check for `main → prod` release PRs) has `timeout-minutes: 20`. `pnpm test -- --target-full` runs **all 433** REST/CLI/browser flows against deployed staging **serially**; real wall-clock is ~25 min of flows + ~4 min setup ≈ 30 min.

**The 20-min cap killed the job mid-run at ~316/433 on every recent release.** Both v0.12.7 and v0.12.8 `tests-release` runs show `cancelled`, not `failure` — every flow that executed passed. The gate was structurally un-passable in 20 min, which is why releases have needed break-glass admin merges.

Evidence (v0.12.8 dispatch run 31533533815): started 20:33:31, reached `✓ [316/433] PASS PROJ-7` at 20:53:43, killed by timeout at 20:53:48. Zero failures.

## Change

`timeout-minutes: 20 → 45` on the one job. 45 gives headroom over the ~30-min real runtime while still catching a genuine hang.

## Follow-up (not in this PR)

Shard the runner (matrix over flow domains + browser) to bring the wall-clock back under 20 min. Tracked as a separate change; this PR unblocks the release gate first.
