### PR TITLE
fix(ci): raise tests-release timeout to 60m (measured ~47m real runtime)

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -15,13 +15,15 @@ jobs:
     name: full suite + quality gates
     runs-on: ubuntu-latest
     # `pnpm test -- --target-full` runs all 433 REST/CLI/browser flows against
-    # deployed staging serially; the real wall-clock is ~25 min of flows plus
-    # ~4 min setup (deps + playwright chromium). A 20-min cap killed the job
-    # mid-run at ~316/433 EVERY release (v0.12.7 and v0.12.8 both cancelled, not
-    # failed) — the gate was structurally un-passable. 45 gives headroom over
-    # the ~30-min real runtime without masking a genuine hang. Follow-up: shard
-    # the runner to bring this back under 20.
-    timeout-minutes: 45
+    # deployed staging serially. MEASURED on run 31535558700: setup + all 433
+    # flows finished at 44m36s (the tail browser journeys are far slower than
+    # the early REST flows), then the post-test secret-guard/upload steps push
+    # the job past 45m. The old 20-min cap killed it at ~316/433 EVERY release
+    # (v0.12.7 and v0.12.8 both cancelled, not failed) — the gate was
+    # structurally un-passable. 60 gives ~13 min headroom over the ~47-min real
+    # runtime without masking a genuine hang. Follow-up: shard the runner
+    # (matrix over flow domains + browser) to bring this back under 20.
+    timeout-minutes: 60
     env:
       KE2E_API_URL: ${{ vars.QA_API_BASE_URL || 'https://staging-api.kortix.com/v1' }}
       E2E_BASE_URL: ${{ vars.QA_WEB_BASE_URL || 'https://staging.kortix.com' }}


### PR DESCRIPTION
Follow-up to #6393. Run 31535558700 proved the full `--target-full` staging suite passes **433/433** — but the 45m cap killed the job during the post-test secret-guard/upload steps (all flows finished at 44m36s; tail browser journeys are far slower than early REST flows, so real wall-clock is ~47m, not the ~30m first extrapolated). Bump 45→60 for ~13m headroom. Already applied to `release/v0.12.8` to unblock the live release. Follow-up tracked in-comment: shard the runner (matrix over flow domains + browser) to bring wall-clock back under 20m.