### PR TITLE
test(deployed): make the staging release gate resilient to origin load + dead email key

### DIFF
--- a/tests/e2e/helpers/inbox.ts
+++ b/tests/e2e/helpers/inbox.ts
@@ -214,3 +214,54 @@ export async function createDisposableInbox(): Promise<DisposableInbox> {
     "browser authentication requires E2E_MAILPIT_URL locally or E2E_AGENTMAIL_API_KEY on a deployed target",
   );
 }
+
+export interface EmailProviderStatus {
+  available: boolean;
+  reason: string;
+}
+
+let emailProviderStatusPromise: Promise<EmailProviderStatus> | null = null;
+
+/**
+ * Whether an email inbox provider is actually usable — probed once per process.
+ * Mailpit (local) is authoritative by presence. For AgentMail on a deployed
+ * target the key can be present but rejected (expired/suspended → 403), so we
+ * make one live call. Email-dependent specs use this to `test.skip` with a
+ * clear reason instead of hard-failing inbox creation.
+ *
+ * NOTE: on the strict deployed lane (`E2E_REQUIRE_ALL_BROWSER=1`) a skip is
+ * still converted to a failure by strict-skip-reporter.ts — by design, a
+ * release gate must surface broken email delivery. This graceful skip therefore
+ * only degrades cleanly on local / non-strict runs.
+ */
+export function emailProviderStatus(): Promise<EmailProviderStatus> {
+  if (emailProviderStatusPromise) return emailProviderStatusPromise;
+  emailProviderStatusPromise = (async () => {
+    const mailpitUrl = process.env.E2E_MAILPIT_URL?.trim();
+    if (mailpitUrl) return { available: true, reason: "mailpit" };
+
+    const agentMailApiKey = process.env.E2E_AGENTMAIL_API_KEY?.trim();
+    if (agentMailApiKey) {
+      const baseUrl = (process.env.E2E_AGENTMAIL_API_URL || "https://api.agentmail.to/v0").replace(
+        /\/+$/,
+        "",
+      );
+      try {
+        const res = await fetch(`${baseUrl}/inboxes?limit=1`, {
+          headers: { Authorization: `Bearer ${agentMailApiKey}` },
+        });
+        return res.ok
+          ? { available: true, reason: "agentmail" }
+          : { available: false, reason: `AgentMail key rejected (HTTP ${res.status})` };
+      } catch (error) {
+        return { available: false, reason: `AgentMail unreachable: ${String(error)}` };
+      }
+    }
+
+    return {
+      available: false,
+      reason: "no email provider (set E2E_MAILPIT_URL or a valid E2E_AGENTMAIL_API_KEY)",
+    };
+  })();
+  return emailProviderStatusPromise;
+}

--- a/tests/e2e/helpers/session-auth.ts
+++ b/tests/e2e/helpers/session-auth.ts
@@ -187,8 +187,18 @@ export async function installBrowserSessionDirect(
       sameSite: "Lax" as const,
     })),
   );
-  await page.goto(returnUrl, {
-    waitUntil: "domcontentloaded",
-    timeout: 180_000,
-  });
+  // Retry the authenticated landing navigation on a transient origin 5xx. Under
+  // the concurrent deployed load the edge launders an overloaded origin into a
+  // 503 MAINTENANCE_MODE page; a fresh goto a moment later renders the real app.
+  // A 4xx (e.g. a genuine 404) is NOT retried — only origin overload is.
+  const maxNav = 4;
+  for (let attempt = 1; attempt <= maxNav; attempt += 1) {
+    const response = await page.goto(returnUrl, {
+      waitUntil: "domcontentloaded",
+      timeout: 180_000,
+    });
+    const status = response?.status() ?? 0;
+    if (status < 500 || attempt === maxNav) return;
+    await page.waitForTimeout(Math.min(2_000 * attempt, 8_000));
+  }
 }

--- a/tests/e2e/specs/01-account-auth.spec.ts
+++ b/tests/e2e/specs/01-account-auth.spec.ts
@@ -4,6 +4,7 @@ import { queryDatabaseRows, runDatabaseSql } from "../helpers/database";
 import {
   type AuthEmailAction,
   createDisposableInbox,
+  emailProviderStatus,
 } from "../helpers/inbox";
 import { deleteAuthUser } from "../helpers/session-auth";
 
@@ -72,6 +73,11 @@ async function completeEmailAuthentication(page: Page, action: AuthEmailAction) 
 
 test.describe("01 - Account authentication", () => {
   test.setTimeout(180_000);
+
+  test.beforeEach(async () => {
+    const { available, reason } = await emailProviderStatus();
+    test.skip(!available, `email provider unavailable: ${reason}`);
+  });
 
   test("a new user creates an account from the delivered email, clears the session, and logs in again", async ({
     page,

--- a/tests/e2e/specs/08-accounts-project-access.spec.ts
+++ b/tests/e2e/specs/08-accounts-project-access.spec.ts
@@ -9,6 +9,7 @@ import {
 import {
   type DisposableInbox,
   createDisposableInbox,
+  emailProviderStatus,
 } from "../helpers/inbox";
 import {
   type AuthSession,
@@ -171,6 +172,11 @@ function toGitHubWebUrl(repoUrl: string): string {
 
 test.describe("08 — Accounts, invites, and project access", () => {
   test.setTimeout(300_000);
+
+  test.beforeEach(async () => {
+    const { available, reason } = await emailProviderStatus();
+    test.skip(!available, `email provider unavailable: ${reason}`);
+  });
 
   test.afterEach(async () => {
     for (const accountId of createdAccountIds) {

--- a/tests/e2e/specs/10-billing-journey.spec.ts
+++ b/tests/e2e/specs/10-billing-journey.spec.ts
@@ -114,7 +114,10 @@ test.describe
       });
 
       await test.step('The owner starts a one-time credit purchase', async () => {
-        await page.getByRole('button', { name: '$10', exact: true }).click();
+        // The topup button's accessible name is "$10 1,000 credits" (two spans:
+        // amount + credits), so an exact "$10" never matches. Anchor on the
+        // leading amount instead of pinning the whole composite label.
+        await page.getByRole('button', { name: /^\$10\b/ }).click();
         const purchaseResponsePromise = page.waitForResponse(
           (response) =>
             response.request().method() === 'POST' &&

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -15,14 +15,22 @@ export function resolveBrowserWorkers(value: string | undefined, ci: boolean): n
 
 const workers = resolveBrowserWorkers(process.env.E2E_BROWSER_WORKERS, Boolean(process.env.CI));
 
+// A deployed target (staging/preview) shares one origin with the concurrent
+// REST lane, so transient overload (5xx laundered into MAINTENANCE_MODE by the
+// edge) shows up as slow/empty page loads. Give deployed runs more retries and
+// longer element/action timeouts so a transient blip self-heals; local stays
+// tight and fast. Signalled by KE2E_TARGET, which local-runner sets only for
+// deployed lanes.
+const deployedTarget = Boolean(process.env.KE2E_TARGET);
+
 export default defineConfig({
   testDir: './e2e/specs',
   timeout: 300_000,
   expect: {
-    timeout: 30_000,
+    timeout: deployedTarget ? 45_000 : 30_000,
   },
   fullyParallel: true,
-  retries: process.env.CI ? 2 : 0,
+  retries: deployedTarget ? 3 : process.env.CI ? 2 : 0,
   workers,
   reporter: [
     ['list'],
@@ -38,7 +46,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
-    actionTimeout: 20_000,
+    actionTimeout: deployedTarget ? 30_000 : 20_000,
     navigationTimeout: 60_000,
   },
   projects: [

--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -133,6 +133,16 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
   const targetApiFull: LocalTestLane = {
     name: 'target-api-full',
     command: ['bun', 'tests/bin/ke2e.ts', 'run', '--require-all'],
+    // This lane runs CONCURRENTLY with target-browser-full against the same
+    // staging origin. At the default 4 API + 4 sandbox workers the combined
+    // load pushes staging origin into 5xx, which the edge launders into
+    // MAINTENANCE_MODE. Dial the REST concurrency down (3+3) to cut that load;
+    // the per-request transient retry (runner.ts) absorbs what's left. Override
+    // via KE2E_API_WORKERS / KE2E_SANDBOX_WORKERS.
+    env: {
+      KE2E_API_WORKERS: process.env.KE2E_API_WORKERS ?? '3',
+      KE2E_SANDBOX_WORKERS: process.env.KE2E_SANDBOX_WORKERS ?? '3',
+    },
   };
   const targetBrowserFull: LocalTestLane = {
     name: 'target-browser-full',

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -125,7 +125,17 @@ async function runOneFlow(
     steps.length = 0;
     const stack = world.newStack();
     const ctx: FlowContext = {
-      client: new Client(env.apiUrl),
+      // Every flow's client retries gateway-generated transient 502/503/504
+      // (incl. the Cloudflare worker's MAINTENANCE_MODE laundering of an
+      // overloaded staging origin — see accounts.flow.ts and
+      // isKe2eTransientGatewayResponse). This is SAFE because that classifier
+      // requires the response to carry NO x-request-id; a genuine app 5xx does
+      // carry one and is never retried. Retrying at the request layer (not just
+      // on .status() gates) also self-heals body-only assertions that would
+      // otherwise surface the laundered 503 as a hard AssertionError.
+      client: new Client(env.apiUrl).withTransientGatewayRetries(
+        Number(process.env.KE2E_GATEWAY_RETRIES ?? 3),
+      ),
       P: world.principals,
       env,
       track: (kind, id, meta) => stack.push(kind, id, meta),

--- a/tests/src/flows/billing.flow.ts
+++ b/tests/src/flows/billing.flow.ts
@@ -36,11 +36,21 @@ flow(
         .exists('$.plan.label')
         .exists('$.plan.status')
         .exists('$.plan.shape')
-        .has('$.plan.is_grandfathered', false)
+        .exists('$.plan.is_grandfathered')
         .has('$.plan.key', state.subscription.tier_key)
         .has('$.tier.name', state.subscription.tier_key);
       if (typeof state.plan?.rank !== 'number') {
         throw new Error(`plan.rank must be a number, got ${JSON.stringify(state.plan?.rank)}`);
+      }
+      // `is_grandfathered` is resolved from the account's stored
+      // is_grandfathered_free column, so on a shared long-lived fixture account
+      // it is legitimately data-dependent — pin the TYPE, not a fixed value.
+      // (A fixed `false` here flaked the release gate once the shared OWNER
+      // account was grandfathered upstream.)
+      if (typeof state.plan?.is_grandfathered !== 'boolean') {
+        throw new Error(
+          `plan.is_grandfathered must be a boolean, got ${JSON.stringify(state.plan?.is_grandfathered)}`,
+        );
       }
       if (!['free', 'team', 'enterprise'].includes(String(state.plan?.family))) {
         throw new Error(`plan.family must be a public family, got ${String(state.plan?.family)}`);


### PR DESCRIPTION
## Problem

The deployed `--target-full` release gate (`tests-release.yml`) was **structurally flaky, not catching real bugs**. Two releases (v0.12.7, v0.12.8) had the gate cancel or fail on environment noise, forcing break-glass merges. Root causes, all environmental:

1. **MAINTENANCE_MODE/503 storm** — the `target-api-full` and `target-browser-full` lanes run concurrently against one staging origin; under that load the origin returns 5xx which the Cloudflare edge worker launders into `503 {"error":"MAINTENANCE_MODE"}`. ~20-40 flows failed per run.
2. **Dead AgentMail key** — the external email provider 403'd, hard-failing the 2 email-dependent browser specs at inbox creation.
3. **BILL-1** asserted `is_grandfathered === false` on the shared long-lived OWNER account, which legitimately drifted to `true` (the field resolves from a stored per-account column).
4. **`$10` topup button** matched by exact accessible name, but the button renders `"$10 1,000 credits"` (two spans; structure landed 2026-07-21 in #5141).

The product itself is sound (manually verified E2E); these are test-harness defects.

## Changes (test-only; no product code)

- **Central transient retry** (`tests/src/core/runner.ts`): every flow's client opts into gateway-transient retries at the single construction chokepoint. **Safe** — the classifier only retries responses with **no `x-request-id`** (a genuine app 5xx carries one and still fails). Fixes body-only assertions that previously surfaced the laundered 503 as a hard AssertionError.
- **Reduce origin load** (`tests/src/core/local-runner.ts`): `target-api-full` runs at 3+3 workers (was 4+4), overridable via `KE2E_API_WORKERS`/`KE2E_SANDBOX_WORKERS`.
- **Browser load-resilience** (`tests/playwright.config.ts`, `tests/e2e/helpers/session-auth.ts`): deployed-target-only `retries=3` + `expect.timeout=45s`/`actionTimeout=30s`, plus retry-on-5xx on the authenticated landing navigation. Local stays tight.
- **Graceful email skip** (`tests/e2e/helpers/inbox.ts` + specs 01, 08): `emailProviderStatus()` probes the provider once; the email specs `test.skip` with a clear reason when none is usable. With a valid key they run and pass; the strict deployed lane still surfaces a dead key by design.
- **BILL-1** (`tests/src/flows/billing.flow.ts`): assert `is_grandfathered` is a boolean, not a fixed `false`.
- **10-billing-journey**: match the topup button by `/^\$10\b/`.

## Verification

- `tests` `bunx tsc --noEmit`: exit 0.
- Two independent read-only agents mapped the harness (retry chokepoint + browser lane) and confirmed the pricing/connector specs are LOAD-ONLY (zero string regressions), with only the `$10` matcher genuinely stale.
- End-to-end verification is the `tests-release` gate itself under real concurrent load — exercised by the next release (v0.12.9), with the now-valid `E2E_AGENTMAIL_API_KEY` repo secret.

## Follow-up (not in this PR)
Shard the deployed browser lane to cut wall-clock (the 60m timeout — #6393/#6394 — currently holds).
