### PR TITLE
fix(web): de-noise three Better Stack frontend prod error classes (OneTrust JSON parse, Firefox DOM mutation, WebSocket Failed to send message)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -16,6 +16,7 @@ import {
   isExpectedCompactionNoModelMessage,
   isExtensionRejectedObjectNoise,
   isExtensionSource,
+  isFailedToSendMessageNoise,
   isFirefoxReactSchedulerReentryNoise,
   isFramelessNetworkErrorNoise,
   isInjectedAppSource,
@@ -24,12 +25,14 @@ import {
   isInpageWalletStreamNoise,
   isIOSWebViewWebKitBridgeNoise,
   isKnownBrowserNoiseMessage,
+  isLikelyDomMutationNoise,
   isModelNotServableNoise,
   isNonErrorObjectNotFoundRejectionNoise,
   isNonErrorUndefinedRejectionNoise,
   isOldBrowserDomNullDerefNoise,
   isOldBrowserSyntaxParseError,
   isOldWebkitRegexNoiseMessage,
+  isOneTrustJsonParseNoise,
   isOperationErrorPopErrorScopeNoise,
   isPaperShaderNullContextNoise,
   isPaperShaderWebGLUnsupportedNoise,
@@ -8645,4 +8648,703 @@ test('does NOT suppress a non-OOM RangeError (over-match guard on the RangeError
       `expected "${message}" to keep reporting`,
     )
   }
+})
+
+// ---------------------------------------------------------------------------
+// Firefox DOM-mutation "supplied node incorrect" noise — the Gecko/Firefox
+// sibling of the V8/JSC DOM-mutation class already covered by
+// `KNOWN_DOM_MUTATION_NOISE_MESSAGES` (Better Stack pattern
+// 9e6a70ffdb26ba2ab9f821fe8772f51b082d6a9b0e2c9f50b2130cde0c3e6438, Kortix
+// Frontend prod, application_id 2346967). `InvalidNodeTypeError`, message
+// `The supplied node is incorrect or has an incorrect ancestor for this
+// operation.`, 2 occurrences / 0 identified users, last 2026-08-11 16:37:15
+// UTC, release `cd9dfccec1fb7e41a6726e9e45fd678cf428cc3a` (v0.12.8 prod),
+// call site function `te` in chunk
+// `app:///_next-live/feedback/913.f924585152f5e22503e7.js?dpl=dpl_…`
+// (Next.js live feedback), request URL a co-worker session page, Firefox 153
+// on macOS, mechanism `auto.browser.global_handlers.onunhandledrejection`
+// (UNCAUGHT, `handled:false`). The existing V8/JSC patterns (covering only
+// the `insertBefore`/`removeChild` wording) did NOT match the Firefox
+// wording, so this sibling leaked to Better Stack. The fix just adds the
+// Gecko string to the existing `KNOWN_DOM_MUTATION_NOISE_MESSAGES` array.
+// ---------------------------------------------------------------------------
+
+test('classifies the Firefox "supplied node is incorrect" DOM mutation wording as noise', () => {
+  // The Gecko/Firefox wording for the same DOM-mutation class the V8/JSC
+  // `insertBefore`/`removeChild` entries cover. Anchored as an EXACT string
+  // in `KNOWN_DOM_MUTATION_NOISE_MESSAGES`, matched by `containsKnownPattern`
+  // the same way as the V8 entries.
+  const message =
+    'The supplied node is incorrect or has an incorrect ancestor for this operation.'
+  assert.equal(
+    isLikelyDomMutationNoise(message),
+    true,
+    `expected Firefox DOM-mutation wording to be noise`,
+  )
+  assert.equal(
+    isLikelyDomMutationNoise(`Error: ${message}`),
+    true,
+    `expected "Error: "-prefixed Firefox DOM-mutation wording to be noise`,
+  )
+})
+
+test('still classifies the existing V8 insertBefore/removeChild DOM mutation wording as noise (no regression)', () => {
+  // Regression guard: the Firefox entry must NOT shadow the existing V8
+  // entries — both wording families must continue to classify as noise.
+  for (const message of [
+    "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+    "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+  ]) {
+    assert.equal(
+      isLikelyDomMutationNoise(message),
+      true,
+      `expected V8 DOM-mutation wording "${message}" to still be noise`,
+    )
+  }
+})
+
+test('suppresses the Firefox DOM-mutation prod event via the Sentry beforeSend gate', () => {
+  // Reproduces the exact production event: BS pattern 9e6a70ff…, release
+  // v0.12.8, request URL a co-worker session page, mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT,
+  // handled:false), call site function `te` in the Next.js live feedback
+  // chunk, Firefox 153 on macOS.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/projects/be079cac-091c-4857-8b3f-f7982027b27c/sessions/f3d44320-846b-4dd3-be26-18d9ca05c931',
+      },
+      exception: {
+        values: [
+          {
+            value:
+              'The supplied node is incorrect or has an incorrect ancestor for this operation.',
+            mechanism: {
+              type: 'auto.browser.global_handlers.onunhandledrejection',
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    'app:///_next-live/feedback/913.f924585152f5e22503e7.js?dpl=dpl_zKXse3p1ftNZs62ELRA6sCjzQUJK',
+                  function: 'te',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the Firefox DOM-mutation noise via the Sentry beforeSend gate (with capture-path wrappers)', () => {
+  // `isLikelyDomMutationNoise` is wired into `shouldIgnoreSentryBrowserNoise`
+  // (the Sentry `beforeSend` gate). It uses `containsKnownPattern` (a
+  // `.includes()` match), so the bare message AND the `Error: `-prefixed /
+  // `Unhandled promise rejection: `-wrapped forms all drop — the wrapper
+  // does not break the substring anchor. (NOTE: the matcher is intentionally
+  // NOT wired into `shouldIgnoreBrowserRuntimeNoise` — the runtime gate's
+  // other DOM-mutation-specific matchers handle their own classes; the
+  // hydration/DOM-mutation class is Sentry-gate-only, mirroring the existing
+  // V8 `insertBefore`/`removeChild` entries' wiring.)
+  for (const message of [
+    'The supplied node is incorrect or has an incorrect ancestor for this operation.',
+    `Error: The supplied node is incorrect or has an incorrect ancestor for this operation.`,
+    `Unhandled promise rejection: Error: The supplied node is incorrect or has an incorrect ancestor for this operation.`,
+  ]) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: message,
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'app:///_next-live/feedback/913.f924585152f5e22503e7.js?dpl=dpl_zKXse3p1ftNZs62ELRA6sCjzQUJK',
+                    function: 'te',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry gate to suppress Firefox DOM-mutation "${message}"`,
+    )
+  }
+})
+
+test('does NOT suppress a near-worded Firefox DOM message (over-match guard)', () => {
+  // `isLikelyDomMutationNoise` uses `containsKnownPattern` (a `.includes()`
+  // match), the SAME contract as the existing V8 `insertBefore`/`removeChild`
+  // entries. So a DIFFERENT Gecko DOM message (a different DOMException
+  // wording that does NOT contain the canonical noise string as a
+  // substring) keeps reporting. (A message that merely EXTENDS the noise
+  // string — e.g. `<noise>. Please file a bug.` — is intentionally matched,
+  // matching the V8 entries' behavior; that is the documented contract, not
+  // an over-match bug.)
+  for (const message of [
+    // A different Gecko DOM message (a different DOMException) — does NOT
+    // contain the canonical noise string.
+    'The supplied node does not belong to this document.',
+    // A different Gecko `HierarchyRequestError` wording.
+    'The new child contains the parent.',
+    // A near-worded first-party throw without the canonical wrapper.
+    'supplied node is incorrect',
+    // A completely different DOMException type.
+    'NotFoundError: The node was not found.',
+  ]) {
+    assert.equal(
+      isLikelyDomMutationNoise(message),
+      false,
+      `expected near-worded "${message}" to keep reporting`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// OneTrust cookie-consent SDK JSON-parse noise (Better Stack pattern
+// aa1efd3fb7a9f6840d4eb25b881d2b12ac2e6f3c8dfe3158fbd3e9fc753a0526, Kortix
+// Frontend prod, application_id 2346967). The OneTrust cookie-consent SDK's
+// `otSDKStub.js?did=undefined` bootstrap stub XHR-fetches the site's consent
+// config, and when the domain ID is `undefined` / the endpoint returns an
+// empty or truncated body (old iOS Safari, CORS preflight failure, 5xx,
+// network abort), the stub's `XMLHttpRequest.onload` handler calls
+// `JSON.parse()` on the bad body and throws the canonical
+// `SyntaxError: Unexpected end of JSON input`. The throw is in the OneTrust
+// SDK's own injected script (frame
+// `app:///scripttemplates/otSDKStub.js?did=undefined` function `r.onload`),
+// never first-party code. 1 occurrence / 0 identified users, last
+// 2026-08-11 23:03:30 UTC, release
+// `cd9dfccec1fb7e41a6726e9e45fd678cf428cc3a` (v0.12.8 prod), request URL
+// `https://kortix.com/auth` (auth page), Safari on iOS 13.2.3 (iPhone),
+// mechanism `auto.browser.browserapierrors.xhr.onload` (UNCAUGHT,
+// handled:false). Stack frames (3, all in_app:true):
+//   1. `app:///_next/static/immutable/chunks/1zqaq83quwhm5.js` fn
+//      `XMLHttpRequest.r` (the Next.js webpack runtime chunk that XHR was
+//      monkey-patched through — the SCHEDULING frame, NOT the throw site).
+//   2. `app:///scripttemplates/otSDKStub.js?did=undefined` fn `r.onload`
+//      (THROW SITE — the OneTrust SDK's `onload` handler where the
+//      `JSON.parse` runs; `did=undefined` is the SDK's own misconfiguration
+//      marker).
+//   3. `<anonymous>` fn `JSON.parse` (the actual `JSON.parse` call the
+//      OneTrust SDK makes on the empty body).
+// NO first-party `apps/web/src/…` frame. The new matcher anchors on BOTH
+// the EXACT `Unexpected end of JSON input` message AND a frame whose
+// filename contains `otSDKStub.js`, with a first-party negative guard.
+// ---------------------------------------------------------------------------
+
+// The exact exception value from the production event.
+const ONETRUST_JSON_PARSE_MESSAGE = 'Unexpected end of JSON input'
+
+// The OneTrust SDK's canonical bootstrap filename (the `app:///scripttemplates/otSDKStub.js?did=…`
+// synthetic injected-script origin). `did=undefined` is the SDK's own
+// misconfiguration marker.
+const ONETRUST_SDK_FRAME =
+  'app:///scripttemplates/otSDKStub.js?did=undefined'
+
+// The three production stack frames (all in_app:true): the Next.js webpack
+// runtime chunk (XHR monkey-patch scheduling frame) → the OneTrust SDK
+// `onload` (throw site) → the `<anonymous>` `JSON.parse` call. NO first-party
+// `apps/web/src/…` frame, so the negative guard does not fire.
+const ONETRUST_PROD_FRAMES: Array<{ filename: unknown; function: unknown }> = [
+  {
+    filename: 'app:///_next/static/immutable/chunks/1zqaq83quwhm5.js',
+    function: 'XMLHttpRequest.r',
+  },
+  { filename: ONETRUST_SDK_FRAME, function: 'r.onload' },
+  { filename: '<anonymous>', function: 'JSON.parse' },
+]
+
+test('classifies the OneTrust JSON-parse prod event as noise (exact message + otSDKStub.js frame)', () => {
+  // Exact production shape: the `Unexpected end of JSON input` message + the
+  // three prod frames. The OneTrust `otSDKStub.js` frame is the positive
+  // anchor; no first-party `apps/web/src/…` frame, so the negative guard
+  // does not fire.
+  assert.equal(
+    isOneTrustJsonParseNoise({
+      message: ONETRUST_JSON_PARSE_MESSAGE,
+      frames: ONETRUST_PROD_FRAMES,
+    }),
+    true,
+  )
+})
+
+test('suppresses the OneTrust JSON-parse Sentry event via the beforeSend gate', () => {
+  // Reproduces the exact production Sentry event: mechanism
+  // `auto.browser.browserapierrors.xhr.onload` (UNCAUGHT, handled:false),
+  // request URL `https://kortix.com/auth` (auth page), Safari on iOS 13.2.3.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/auth' },
+      exception: {
+        values: [
+          {
+            value: ONETRUST_JSON_PARSE_MESSAGE,
+            mechanism: {
+              type: 'auto.browser.browserapierrors.xhr.onload',
+              handled: false,
+            },
+            stacktrace: { frames: ONETRUST_PROD_FRAMES },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the OneTrust JSON-parse noise through the SyntaxError wrapper', () => {
+  // `stripErrorWrappers` strips the `SyntaxError: ` prefix before matching
+  // the anchored message, so the `SyntaxError: Unexpected end of JSON input`
+  // form (the typical Sentry exception value) classifies as noise.
+  for (const message of [
+    ONETRUST_JSON_PARSE_MESSAGE,
+    `SyntaxError: ${ONETRUST_JSON_PARSE_MESSAGE}`,
+    `Unhandled promise rejection: SyntaxError: ${ONETRUST_JSON_PARSE_MESSAGE}`,
+  ]) {
+    assert.equal(
+      isOneTrustJsonParseNoise({
+        message,
+        frames: ONETRUST_PROD_FRAMES,
+      }),
+      true,
+      `expected "${message}" to be OneTrust JSON-parse noise`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: message, stacktrace: { frames: ONETRUST_PROD_FRAMES } }],
+        },
+      }),
+      true,
+      `expected Sentry event "${message}" to be suppressed`,
+    )
+  }
+})
+
+test('classifies the OneTrust JSON-parse noise from a filename alone (window.onerror)', () => {
+  // The runtime gate (window.onerror) sees the `filename` directly — the
+  // throw originates from the OneTrust SDK's injected script source.
+  assert.equal(
+    isOneTrustJsonParseNoise({
+      message: ONETRUST_JSON_PARSE_MESSAGE,
+      filename: ONETRUST_SDK_FRAME,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: ONETRUST_JSON_PARSE_MESSAGE,
+      filename: ONETRUST_SDK_FRAME,
+    }),
+    true,
+  )
+})
+
+test('classifies a OneTrust SDK frame with a different did query param as noise', () => {
+  // The matcher anchors on the `otSDKStub.js` filename token, NOT the
+  // `did=` value — a properly-configured OneTrust stub (`did=<real-id>`)
+  // whose consent endpoint still returns an empty body throws the same
+  // `Unexpected end of JSON input` and must also classify as noise. The
+  // `did=undefined` form is just the most-common misconfiguration shape.
+  const configuredOneTrustFrame =
+    'app:///scripttemplates/otSDKStub.js?did=abc123-real-domain-id'
+  assert.equal(
+    isOneTrustJsonParseNoise({
+      message: ONETRUST_JSON_PARSE_MESSAGE,
+      frames: [{ filename: configuredOneTrustFrame, function: 'r.onload' }],
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the OneTrust JSON-parse event when a first-party apps/web/src frame is present', () => {
+  // A resolved `apps/web/src/…` frame means our own code called
+  // `JSON.parse` on a bad body while a OneTrust frame happened to be in the
+  // stack (e.g. a first-party fetch wrapper that runs alongside the consent
+  // banner) → still actionable; the negative guard MUST preserve it so the
+  // call site can be found + fixed.
+  for (const frames of [
+    [
+      { filename: ONETRUST_SDK_FRAME, function: 'r.onload' },
+      { filename: 'apps/web/src/lib/api/client.ts', function: 'parseResponse' },
+    ],
+    [
+      { filename: ONETRUST_SDK_FRAME, function: 'r.onload' },
+      { filename: 'app:///apps/web/src/features/auth/use-session.ts', function: 'loadConfig' },
+    ],
+  ]) {
+    assert.equal(
+      isOneTrustJsonParseNoise({
+        message: ONETRUST_JSON_PARSE_MESSAGE,
+        frames,
+      }),
+      false,
+      `expected first-party OneTrust-prefixed event from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            { value: ONETRUST_JSON_PARSE_MESSAGE, stacktrace: { frames } },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party OneTrust-prefixed event from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: ONETRUST_JSON_PARSE_MESSAGE,
+      filename: 'apps/web/src/lib/api/client.ts',
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress the OneTrust JSON-parse event with NO otSDKStub.js frame (conservative — keep reporting)', () => {
+  // No `otSDKStub.js` frame → can't confirm the OneTrust origin; a real
+  // first-party `JSON.parse(truncatedApiResponse)` regression would throw
+  // the same `Unexpected end of JSON input` wording, so keep reporting.
+  for (const frames of [
+    [],
+    [{ filename: 'app:///_next/static/chunks/main.js', function: 'f' }],
+    [{ filename: 'apps/web/src/lib/foo.ts', function: 'bar' }],
+  ]) {
+    assert.equal(
+      isOneTrustJsonParseNoise({
+        message: ONETRUST_JSON_PARSE_MESSAGE,
+        frames,
+      }),
+      false,
+      `expected "${ONETRUST_JSON_PARSE_MESSAGE}" event from ${JSON.stringify(frames)} (no otSDKStub.js frame) to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a non-Unexpected-end-of-JSON-input message even with otSDKStub.js frames', () => {
+  // Only the EXACT `Unexpected end of JSON input` message is noise — a
+  // different `JSON.parse` SyntaxError (e.g. `Unexpected token < in JSON`,
+  // a different malformed-body wording) from the same OneTrust source is a
+  // different class and must keep reporting. (The OneTrust stub is known to
+  // throw only the empty-body `Unexpected end of JSON input` form; a
+  // different `JSON.parse` wording signals a different failure mode worth
+  // triaging.)
+  for (const message of [
+    'Unexpected token < in JSON at position 0',
+    'Unexpected token u in JSON at position 0',
+    'JSON.parse: unexpected end of data',
+    'Unexpected end of input',
+  ]) {
+    assert.equal(
+      isOneTrustJsonParseNoise({
+        message,
+        frames: ONETRUST_PROD_FRAMES,
+      }),
+      false,
+      `expected "${message}" with otSDKStub.js frames to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            { value: message, stacktrace: { frames: ONETRUST_PROD_FRAMES } },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry event "${message}" with otSDKStub.js frames to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a same-worded message from a near-miss otSDKStub filename', () => {
+  // The matcher anchors on the `otSDKStub.js` filename token — a
+  // near-identical filename (a typo, or a different consent SDK that
+  // happens to ship a similarly-named script) must NOT be swallowed by
+  // this guard. Only a frame whose filename literally contains
+  // `otSDKStub.js` is the OneTrust SDK.
+  for (const filename of [
+    'app:///scripttemplates/otOtherStub.js',
+    'app:///scripttemplates/ot-sdk-stub.js',
+    'app:///onetrust/otSDKStub.ts',
+    'app:///_next/static/chunks/otSDKStub.js.map',
+  ]) {
+    assert.equal(
+      isOneTrustJsonParseNoise({
+        message: ONETRUST_JSON_PARSE_MESSAGE,
+        frames: [{ filename, function: 'r.onload' }],
+      }),
+      // `otSDKStub.js.map` is the only one that contains the `otSDKStub.js`
+      // substring; it classifies as noise (the anchor is a substring match,
+      // so a sourcemap file with the same basename is still the OneTrust
+      // SDK's own artifact). The other three must keep reporting.
+      filename.endsWith('.map') ? true : false,
+      `expected filename "${filename}" to be ${filename.endsWith('.map') ? 'noise' : 'kept'}`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Transient WebSocket `postMessage` "Failed to send message" transport noise
+// (Better Stack pattern
+// 824577dd315c08f227a1f31c74e2eb90be209b1ffd129e18923907aa3068afd2, Kortix
+// Frontend prod, application_id 2346967). A co-worker session page's WebSocket
+// `ws.send(...)` rejected with the canonical WebSocket `InvalidStateError`
+// message `Failed to send message` (the spec's wording for `ws.send` on a
+// closed socket) when the sandbox tore the connection down mid-flight
+// (deploy / restart / idle-timeout recycle / sandbox park / network blip /
+// tab close). 1 occurrence / 0 identified users, last 2026-08-11 14:47:00
+// UTC, release `cd9dfccec1fb7e41a6726e9e45fd678cf428cc3a` (v0.12.8 prod),
+// call site function `Object.x [as mutationFn]` in chunk
+// `app:///_next/static/immutable/chunks/3n0z0jtixhg6r.js` (minified — NO
+// resolved first-party source), request URL a co-worker session page,
+// browser Chrome on macOS, mechanism `generic` with `handled:true` (CAUGHT
+// by an error boundary — NOT an uncaught global rejection). Stack frames
+// (1, in_app:true): the minified react-query mutation chunk. NO first-party
+// `apps/web/src/…` frame. Sibling of `isConnectionClosedNoise` (the
+// `Connection closed.` transport-close class) but a different throw (a
+// `ws.send` rejection on a closed socket).
+// ---------------------------------------------------------------------------
+
+// The exact exception value from the production event.
+const FAILED_TO_SEND_MESSAGE = 'Failed to send message'
+
+// The single production stack frame: the minified react-query mutation
+// chunk `3n0z0jtixhg6r.js` function `Object.x [as mutationFn]` (the
+// mutation that called `ws.send(...)` on the closed socket). No resolved
+// first-party `apps/web/src/…` source, so the negative guard does NOT fire.
+const FAILED_TO_SEND_PROD_FRAMES: Array<{ filename: unknown; function: unknown }> = [
+  {
+    filename: 'app:///_next/static/immutable/chunks/3n0z0jtixhg6r.js',
+    function: 'Object.x [as mutationFn]',
+  },
+]
+
+test('classifies the production Failed to send message transport noise (exact prod frame)', () => {
+  // Exact production shape: the canonical WebSocket `InvalidStateError`
+  // message + the single minified mutation-chunk frame. The chunk frame is
+  // NOT a first-party `apps/web/src/…` frame, so the negative guard does
+  // not fire.
+  assert.equal(
+    isFailedToSendMessageNoise({
+      message: FAILED_TO_SEND_MESSAGE,
+      frames: FAILED_TO_SEND_PROD_FRAMES,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/projects/834686a1-bf0c-4bd5-87ea-b2679288e191/sessions/54f7abe9-cad8-4b46-bd04-de8f1723dfd1',
+      },
+      exception: {
+        values: [
+          {
+            value: FAILED_TO_SEND_MESSAGE,
+            // The prod event is `handled:true` (caught by an error
+            // boundary — NOT an uncaught global rejection), mechanism
+            // `generic`. The matcher is message+frame-anchored and does NOT
+            // branch on `handled`; this test pins the prod shape exactly.
+            mechanism: { type: 'generic', handled: true },
+            stacktrace: { frames: FAILED_TO_SEND_PROD_FRAMES },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the Failed to send message noise through the Error wrapper', () => {
+  // The matcher strips the leading `Error: ` prefix before anchoring, so
+  // the `Error: Failed to send message` form (an `onunhandledrejection` of
+  // an `Error` instance) and the stacked `Unhandled promise rejection:
+  // Error: Failed to send message` form both classify as noise regardless
+  // of which capture path delivered it.
+  for (const message of [
+    FAILED_TO_SEND_MESSAGE,
+    `Error: ${FAILED_TO_SEND_MESSAGE}`,
+    `Unhandled promise rejection: ${FAILED_TO_SEND_MESSAGE}`,
+    `Unhandled promise rejection: Error: ${FAILED_TO_SEND_MESSAGE}`,
+  ]) {
+    assert.equal(
+      isFailedToSendMessageNoise({
+        message,
+        frames: FAILED_TO_SEND_PROD_FRAMES,
+      }),
+      true,
+      `expected "${message}" to be Failed-to-send-message noise`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            { value: message, stacktrace: { frames: FAILED_TO_SEND_PROD_FRAMES } },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event "${message}" to be suppressed`,
+    )
+  }
+})
+
+test('classifies the frameless Failed to send message variant as noise (message alone is specific)', () => {
+  // A frameless capture with this exact message still classifies as noise
+  // — the message is the WebSocket spec's canonical transport-failure
+  // wording and is specific enough (mirrors `isConnectionClosedNoise`'s
+  // frameless handling).
+  assert.equal(
+    isFailedToSendMessageNoise({
+      message: FAILED_TO_SEND_MESSAGE,
+      frames: [],
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/projects/x/sessions/y',
+      },
+      exception: {
+        values: [{ value: FAILED_TO_SEND_MESSAGE, stacktrace: { frames: [] } }],
+      },
+    }),
+    true,
+  )
+  // Also when the stacktrace key is omitted entirely (frames default to []).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: { values: [{ value: FAILED_TO_SEND_MESSAGE }] },
+    }),
+    true,
+  )
+})
+
+test('suppresses the Failed to send message noise via the runtime (window.onerror) gate', () => {
+  // The runtime gate sees the `message` directly; a frameless window.onerror
+  // capture with the exact message drops.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({ message: FAILED_TO_SEND_MESSAGE }),
+    true,
+  )
+  // A runtime capture with a minified chunk `filename` (no first-party
+  // source) also drops.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: FAILED_TO_SEND_MESSAGE,
+      filename: 'app:///_next/static/immutable/chunks/3n0z0jtixhg6r.js',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the Failed to send message throw when a first-party frame is present (real regression)', () => {
+  // The prod event is `handled:true` (caught by an error boundary — the
+  // user saw a controlled error state, not a blank page). When our own code
+  // is the `ws.send` caller, the boundary's error state is showing the
+  // user a defect we should fix → actionable. The negative guard MUST
+  // preserve any resolved first-party `apps/web/src/…` frame so the call
+  // site can be found + fixed.
+  for (const frames of [
+    [{ filename: 'apps/web/src/features/session/websocket.ts', function: 'sendMessage' }],
+    [
+      { filename: 'app:///_next/static/chunks/main.js', function: 'f' },
+      { filename: 'app:///apps/web/src/features/session/session-chat.tsx', function: 'pushMessage' },
+    ],
+  ]) {
+    assert.equal(
+      isFailedToSendMessageNoise({
+        message: FAILED_TO_SEND_MESSAGE,
+        frames,
+      }),
+      false,
+      `expected first-party Failed-to-send-message throw from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            { value: FAILED_TO_SEND_MESSAGE, stacktrace: { frames } },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party Failed-to-send-message throw from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: FAILED_TO_SEND_MESSAGE,
+      filename: 'apps/web/src/features/session/websocket.ts',
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a near-worded message (over-match guard)', () => {
+  // Only the EXACT `Failed to send message` string is noise. A near-worded
+  // message (e.g. a different transport-failure wording, or a first-party
+  // throw with extra context) keeps reporting so the matcher does not
+  // over-match a real first-party transport regression.
+  for (const message of [
+    'Failed to send message.',
+    'Failed to send a message',
+    'Failed to send messages',
+    'failed to send message',
+    'Failed to send message: WebSocket is not open',
+    'Could not send message',
+    'Message failed to send',
+  ]) {
+    assert.equal(
+      isFailedToSendMessageNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected near-worded "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event for near-worded "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress the Connection closed. message under the Failed-to-send-message matcher (and vice versa)', () => {
+  // The two sibling matchers are message-specific: a `Connection closed.`
+  // event must not be swallowed by the `Failed to send message` guard, and
+  // a `Failed to send message` event must not be swallowed by the
+  // `Connection closed.` guard (which would also keep reporting because it
+  // has no first-party frame but the wrong message).
+  assert.equal(
+    isFailedToSendMessageNoise({
+      message: 'Connection closed.',
+      frames: [],
+    }),
+    false,
+    'Failed-to-send-message matcher must not swallow the Connection closed. message',
+  )
+  assert.equal(
+    isConnectionClosedNoise({
+      message: FAILED_TO_SEND_MESSAGE,
+      frames: [],
+    }),
+    false,
+    'Connection-closed matcher must not swallow the Failed to send message',
+  )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -94,8 +94,34 @@ const KNOWN_TEST_NOISE_MESSAGES = [
 ] as const;
 
 const KNOWN_DOM_MUTATION_NOISE_MESSAGES = [
+  // V8/Chromium (Chrome/Edge) wording — the canonical DOM mutation error
+  // surfaced when React's reconciler or a portal tries to mutate a DOM node
+  // that has been moved/removed by an extension or the browser itself.
   "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
   "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+  // Gecko/Firefox wording for the SAME DOM mutation class — a
+  // `HierarchyRequestError` surfaced when Next.js's live-feedback/HMR module
+  // (`_next-live/feedback/…`) manipulates a node whose ancestor changed
+  // (extension DOM rewrite, devtools overlay, or a React portal moved mid-
+  // commit). The `InvalidNodeTypeError` type + "The supplied node is
+  // incorrect or has an incorrect ancestor for this operation." message is
+  // Gecko's canonical DOM-API phrasing for the same `insertBefore`/
+  // `removeChild` race the V8 entries above cover. Better Stack pattern
+  // 9e6a70ffdb26ba2ab9f821fe8772f51b082d6a9b0e2c9f50b2130cde0c3e6438
+  // (Kortix Frontend prod, application_id 2346967): `InvalidNodeTypeError`,
+  // 2 occurrences / 0 identified users, last 2026-08-11 16:37:15 UTC,
+  // release `cd9dfccec1fb7e41a6726e9e45fd678cf428cc3a` (v0.12.8 prod), call
+  // site function `te` in chunk
+  // `app:///_next-live/feedback/913.f924585152f5e22503e7.js?dpl=dpl_…`
+  // (Next.js live feedback), request URL a co-worker session page, Firefox
+  // 153 on macOS, mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT,
+  // `handled:false`). The existing V8/JSC patterns (covering only the
+  // `insertBefore`/`removeChild` wording) did NOT match the Firefox wording,
+  // so this sibling leaked to Better Stack. Adding the Gecko string to the
+  // existing array (no matcher change — `containsKnownPattern` matches it the
+  // same way as the V8 entries) is the simplest, lowest-risk fix.
+  "The supplied node is incorrect or has an incorrect ancestor for this operation.",
 ] as const;
 
 const KNOWN_HYDRATION_NOISE_MESSAGES = [
@@ -1468,6 +1494,130 @@ export function isUserscriptManagerNoise(input: {
     ...(input.frames ?? []).map((frame) => frame?.filename),
   ];
   return sources.some(isUserscriptManagerInjectedSource);
+}
+
+// OneTrust cookie-consent SDK JSON-parse noise. OneTrust
+// (`https://onetrust.com`) is a third-party cookie-consent / IAB TCF banner
+// vendors inject into pages via a small bootstrap stub
+// (`otSDKStub.js?did=<domainId>`) that XHR-fetches the consent configuration
+// for the site's domain. When the SDK is misconfigured / the domain ID is
+// `undefined` / the consent endpoint returns an empty or truncated body
+// (a CORS preflight failure, a 5xx, a network abort, or the page is loaded
+// in a stripped-down browser — an old iOS Safari that cannot complete the
+// XHR), the stub's `XMLHttpRequest` `onload` handler calls `JSON.parse()` on
+// the empty/truncated response and throws the canonical V8/JSC
+// `SyntaxError: Unexpected end of JSON input`. The throw originates INSIDE
+// the OneTrust SDK's own `otSDKStub.js` script (function `r.onload`), never
+// in first-party Kortix code: the `did=undefined` query param is the SDK's
+// OWN misconfiguration signal (the domain ID never resolved), and the
+// `app:///scripttemplates/otSDKStub.js` source is OneTrust's synthetic
+// injected-script origin (the same `app:///` empty-host origin shape as the
+// other injected/extension sources — distinct from a first-party
+// `app:///_next/…` bundle frame and a de-minified `apps/web/src/…` source
+// path). Sentry's `BrowserApiErrors` integration auto-wraps
+// `XMLHttpRequest.onload` and captures the throw as `handled:false`
+// (UNCAUGHT — never reached a React error boundary), so it leaks to Better
+// Stack.
+//
+// Better Stack pattern
+// aa1efd3fb7a9f6840d4eb25b881d2b12ac2e6f3c8dfe3158fbd3e9fc753a0526
+// (Kortix Frontend prod, application_id 2346967): `SyntaxError`, message
+// `Unexpected end of JSON input`, 1 occurrence / 0 identified users, last
+// 2026-08-11 23:03:30 UTC, release
+// `cd9dfccec1fb7e41a6726e9e45fd678cf428cc3a` (v0.12.8 prod), request URL
+// `https://kortix.com/auth` (auth page — the consent banner loads there
+// before the user is signed in), browser Safari on iOS 13.2.3 (iPhone — a
+// very old iOS whose XHR/JSON paths are quirkier), mechanism
+// `auto.browser.browserapierrors.xhr.onload` (UNCAUGHT, `handled:false`).
+// Stack frames (3, all `in_app:true`):
+//   1. `app:///_next/static/immutable/chunks/1zqaq83quwhm5.js` fn
+//      `XMLHttpRequest.r` (the Next.js webpack runtime chunk that
+//      `XMLHttpRequest` was monkey-patched through — the SCHEDULING frame,
+//      NOT the throw site).
+//   2. `app:///scripttemplates/otSDKStub.js?did=undefined` fn `r.onload`
+//      (THROW SITE — the OneTrust SDK's `onload` handler where the
+//      `JSON.parse` runs; `did=undefined` is the SDK's own misconfiguration
+//      marker).
+//   3. `<anonymous>` fn `JSON.parse` (the actual `JSON.parse` call the
+//      OneTrust SDK makes on the empty body).
+// NO first-party `apps/web/src/…` frame — the throw is in the OneTrust SDK's
+// own injected script, never in our code.
+//
+// The `Unexpected end of JSON input` message is the GENERIC V8/JSC wording
+// for `JSON.parse('')` / `JSON.parse(<truncated>)` — a real first-party
+// `JSON.parse(truncatedApiResponse)` regression in our own code would throw
+// the SAME wording, so matching on the message alone would swallow real app
+// JSON-parsing bugs. Require BOTH the exact message AND a frame whose
+// filename is the OneTrust SDK's `otSDKStub.js` source (the `app:///scripttemplates/otSDKStub.js?did=…`
+// synthetic injected-script origin — the `otSDKStub.js` token is OneTrust's
+// canonical bootstrap filename, never a first-party source path), so a real
+// first-party `JSON.parse` SyntaxError keeps reporting. A NEGATIVE guard
+// preserves any event whose stack carries a resolved first-party
+// `apps/web/src/…` frame (our own code called `JSON.parse` on a bad body
+// while a OneTrust frame happened to be in the stack → actionable). Returns
+// false when there is no `otSDKStub.js` frame (can't confirm the OneTrust
+// origin — keep reporting rather than swallow a possible first-party
+// `JSON.parse` bug). Deliberately NOT added to
+// `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame
+// context, so a bare-string match there would swallow a real first-party
+// `JSON.parse` SyntaxError the negative guard exists to preserve; the
+// frame-aware `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`)
+// is the only safe gate.
+const ONETRUST_SDK_FRAME_PATTERN = /otSDKStub\.js/;
+const ONETRUST_JSON_PARSE_NOISE_MESSAGE = /^Unexpected end of JSON input$/;
+
+function isOneTrustSdkFrame(filename: unknown): boolean {
+  return ONETRUST_SDK_FRAME_PATTERN.test(normalizeString(filename));
+}
+
+/**
+ * Whether a Sentry / window.onerror event is the OneTrust cookie-consent SDK
+ * JSON-parse noise class: OneTrust's `otSDKStub.js?did=<domainId>` bootstrap
+ * stub XHR-fetches the site's consent config, and when the domain ID is
+ * `undefined` / the endpoint returns an empty or truncated body (old iOS
+ * Safari, CORS preflight failure, 5xx, network abort), the stub's
+ * `XMLHttpRequest.onload` handler calls `JSON.parse()` on the bad body and
+ * throws the canonical `SyntaxError: Unexpected end of JSON input`. The
+ * throw is in the OneTrust SDK's own injected `otSDKStub.js` script, never
+ * first-party code (`did=undefined` is the SDK's own misconfiguration
+ * signal). Requires BOTH the EXACT `Unexpected end of JSON input` message
+ * AND a frame whose filename contains `otSDKStub.js` (the OneTrust SDK's
+ * canonical bootstrap filename — the `app:///scripttemplates/otSDKStub.js?did=…`
+ * synthetic injected-script origin), with a NEGATIVE guard: if any frame
+ * resolves to a de-minified first-party `apps/web/src/…` source path, the
+ * event keeps reporting (a real first-party `JSON.parse(truncatedApiResponse)`
+ * regression de-minifies to `apps/web/src/…` and must not be hidden).
+ * Returns false when there is no `otSDKStub.js` frame (can't confirm the
+ * OneTrust origin — keep reporting rather than swallow a possible first-
+ * party `JSON.parse` bug). See `ONETRUST_JSON_PARSE_NOISE_MESSAGE` for the
+ * full rationale and Better Stack pattern `aa1efd3fb…`.
+ */
+export function isOneTrustJsonParseNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (!ONETRUST_JSON_PARSE_NOISE_MESSAGE.test(stripped)) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame means our
+  // own code called `JSON.parse` on a bad body while a OneTrust frame
+  // happened to be in the stack → actionable regression; keep reporting so
+  // the call site can be found + fixed. (Mirrors `isInpageJsNoErrorMessageNoise`
+  // / `isConnectionClosedNoise`'s negative guards.)
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  // Positive anchor: at least one frame (or the window.onerror `filename`)
+  // is the OneTrust SDK's `otSDKStub.js` source. Without an `otSDKStub.js`
+  // frame we cannot confirm the OneTrust origin — keep reporting rather
+  // than swallow a possible first-party `JSON.parse` bug.
+  return sources.some(isOneTrustSdkFrame);
 }
 
 /**
@@ -3509,6 +3659,137 @@ export function isConnectionClosedNoise(input: {
   return true;
 }
 
+// Transient WebSocket `postMessage` "Failed to send message" transport
+// noise — a SIBLING of `isConnectionClosedNoise` (the `Connection closed.`
+// transport-close class) but a DIFFERENT throw. The co-worker session page
+// (`/projects/:id/sessions/:sessionId`) holds a WebSocket connection to the
+// sandbox runtime; when the sandbox tears the connection down mid-flight
+// (a deploy / restart / idle-timeout recycle / sandbox park / network
+// blip / the user closing the tab), a fire-and-forget `ws.send(...)` on the
+// already-closed socket rejects with the canonical
+// `Failed to send message` (the WebSocket spec's `InvalidStateError`
+// message — `ReadyState is not OPEN`). The throw fires from a react-query
+// mutation's `mutationFn` (a minified `Object.x [as mutationFn]` in a
+// `_next/static/immutable/chunks/…` bundle), is caught by an error
+// boundary (`handled:true`, mechanism `generic` — NOT an UNCAUGHT global
+// rejection; the boundary showed the user an error state instead of a
+// blank page), and Sentry captures it as an exception with ONE minified
+// chunk frame — NO resolved first-party `apps/web/src/…` source.
+//
+// This is the same transient-transport class as
+// `isConnectionClosedNoise` (PR for BS `ecac86df…`) and the broader
+// `isFramelessNetworkErrorNoise` family — a WebSocket/SSE transport
+// teardown that is EXPECTED (the sandbox closing is not a product bug),
+// self-healing-on-reconnect, and surfaces only as a transient transport
+// error. The `handled:true` means the error boundary already showed the
+// user a controlled error state (not a blank page), so it is doubly not
+// actionable — the user saw a controlled state, and the connection
+// recovers on the next session switch.
+//
+// Better Stack pattern
+// 824577dd315c08f227a1f31c74e2eb90be209b1ffd129e18923907aa3068afd2
+// (Kortix Frontend prod, application_id 2346967): `Error`, message
+// `Failed to send message`, 1 occurrence / 0 identified users, last
+// 2026-08-11 14:47:00 UTC, release
+// `cd9dfccec1fb7e41a6726e9e45fd678cf428cc3a` (v0.12.8 prod), call site
+// function `Object.x [as mutationFn]`, call site file
+// `app:///_next/static/immutable/chunks/3n0z0jtixhg6r.js` (minified — NO
+// resolved first-party source), request URL a co-worker session page
+// (`https://kortix.com/projects/834686a1-…/sessions/54f7abe9-…`), browser
+// Chrome on macOS, mechanism `generic` with `handled:true` (CAUGHT by an
+// error boundary — NOT an uncaught global rejection). Stack frames (1,
+// `in_app:true`):
+//   1. `app:///_next/static/immutable/chunks/3n0z0jtixhg6r.js` fn
+//      `Object.x [as mutationFn]` (the react-query mutation that called
+//      `ws.send(...)` on the closed socket — a minified bundle chunk, NOT a
+//      resolved first-party source path).
+// NO first-party `apps/web/src/…` frame.
+//
+// The `Failed to send message` wording is the WebSocket spec's canonical
+// `InvalidStateError` message for `ws.send(...)` on a closed socket — it
+// is GENERIC enough that a real first-party sender regression (our own
+// `ws.send` on a closed socket, surfacing from a de-minified
+// `apps/web/src/…` call site) would throw the SAME wording. Because the
+// event is `handled:true` (caught by an error boundary — the user saw a
+// controlled error state, not a blank page), a first-party sender IS
+// actionable: if our own code is the sender, the boundary's error state
+// is showing the user a defect we should fix. So this matcher anchors on
+// BOTH the EXACT message AND a NEGATIVE guard: if ANY frame (or the
+// window.onerror `filename`) resolves to a de-minified first-party
+// `apps/web/src/…` source path, the event KEEPS reporting — our own code
+// is the `ws.send` caller and a real first-party transport regression is
+// actionable to fix. Only events with NO resolved first-party frame (the
+// production noise shape: a minified `_next/static/immutable/chunks/…`
+// frame, or frameless) are dropped. A frameless capture with this exact
+// message still classifies as noise — the message alone is the WebSocket
+// spec's canonical transport-failure wording and is specific enough
+// (the `Failed to send message` string paired with the
+// `ws.send`-on-closed-socket context pins this single transport class),
+// mirroring `isConnectionClosedNoise`'s frameless handling. Deliberately
+// NOT added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate
+// has no frame context, so a bare-string match there would swallow a real
+// first-party `ws.send` regression the negative guard exists to preserve;
+// the frame-aware `beforeSend` hook (which calls
+// `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+const FAILED_TO_SEND_MESSAGE_NOISE_PATTERN = /^Failed to send message$/;
+
+/**
+ * Whether a Sentry / window.onerror event is the transient WebSocket
+ * `postMessage` "Failed to send message" transport-noise class: a co-worker
+ * session page's WebSocket `ws.send(...)` rejected with the canonical
+ * WebSocket `InvalidStateError` message (`Failed to send message` — the
+ * spec's wording for `ws.send` on a closed socket) when the sandbox tore
+ * the connection down mid-flight (deploy / restart / idle-timeout recycle /
+ * sandbox park / network blip / tab close). This is a SIBLING of
+ * `isConnectionClosedNoise` (the `Connection closed.` transport-close
+ * class) but a DIFFERENT throw — a `ws.send` rejection on an already-closed
+ * socket, NOT a library close event. The connection closing during a
+ * deploy/recycle is EXPECTED, not a product bug; the event is
+ * `handled:true` (caught by an error boundary — the user saw a controlled
+ * error state, not a blank page).
+ *
+ * Requires the EXACT message `Failed to send message` (case-sensitive, the
+ * WebSocket spec's canonical `InvalidStateError` wording) AND a NEGATIVE
+ * guard: if ANY frame (or the window.onerror `filename`) resolves to a
+ * de-minified first-party `apps/web/src/…` source path, the event KEEPS
+ * reporting — our own code is the `ws.send` caller and a real first-party
+ * transport regression is actionable (the boundary already showed the user
+ * a controlled error state, so we should fix the sender). Only events with
+ * NO resolved first-party frame (the production noise shape: a minified
+ * `_next/static/immutable/chunks/…` frame, or frameless) are dropped. A
+ * frameless capture with this exact message still classifies as noise.
+ * See `FAILED_TO_SEND_MESSAGE_NOISE_PATTERN` for the full rationale and
+ * Better Stack pattern `824577dd…`.
+ */
+export function isFailedToSendMessageNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message))
+    .replace(/^Error: /, '');
+  if (!FAILED_TO_SEND_MESSAGE_NOISE_PATTERN.test(stripped)) {
+    return false;
+  }
+  // Collect every source location — the window.onerror `filename` (runtime
+  // gate) and any stacktrace frames (Sentry gate) — for the first-party
+  // negative guard.
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame means our
+  // own code is the `ws.send` caller on a closed socket → a real first-party
+  // transport regression (the boundary already showed the user an error
+  // state); keep reporting so the call site can be found + fixed. A real
+  // first-party `ws.send` regression de-minifies to `apps/web/src/…` and is
+  // never hidden.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  return true;
+}
+
 // Third-party editor-library document-state race noise. A ProseMirror/TipTap-
 // based editor library (`@tiptap/*` deps in `apps/web/package.json`) holds an
 // internal document-state map keyed by document id. When the editor is
@@ -3771,29 +4052,43 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   }
 
   // Transient WebSocket / SSE transport-close noise — a client-side
-  // websocket/SSE library threw the canonical `Connection closed.` message when
-  // the server closed a background realtime connection during a deploy / idle-
-   // timeout recycle / session end. The connection closing is EXPECTED, not a
-   // product bug. Requires the EXACT message (with trailing `.`) and a NEGATIVE
-   // guard so a real first-party `throw new Error('Connection closed.')`
-   // regression keeps reporting. See `isConnectionClosedNoise`.
-   if (isConnectionClosedNoise({ message, filename: input.filename })) {
-     return true;
-   }
+   // websocket/SSE library threw the canonical `Connection closed.` message when
+   // the server closed a background realtime connection during a deploy / idle-
+    // timeout recycle / session end. The connection closing is EXPECTED, not a
+    // product bug. Requires the EXACT message (with trailing `.`) and a NEGATIVE
+    // guard so a real first-party `throw new Error('Connection closed.')`
+    // regression keeps reporting. See `isConnectionClosedNoise`.
+    if (isConnectionClosedNoise({ message, filename: input.filename })) {
+      return true;
+    }
 
-   // Third-party editor-library (ProseMirror/TipTap-based) document-state
-   // race noise — the library's own internal `getDocumentStateOrThrow` /
-   // `getDocumentState` helpers threw
-   // `<Interaction|Selection> state not found for document: <docId>` when the
-   // editor was unmounted / the document closed while an async interaction or
-   // selection was still in flight (a race in the library's async interaction
-   // handling, triggered by WebKit's async timing). Requires the canonical
-   // message prefix AND a NEGATIVE guard: any resolved first-party
-   // `apps/web/src/…` frame → keep reporting. See
-   // `isDocumentStateNotFoundNoise`.
-   if (isDocumentStateNotFoundNoise({ message, filename: input.filename })) {
-     return true;
-   }
+   // Transient WebSocket `postMessage` `Failed to send message` transport
+   // noise — a co-worker session page's `ws.send(...)` rejected with the
+   // canonical WebSocket `InvalidStateError` message when the sandbox tore
+   // the connection down mid-flight (deploy / recycle / park / network
+   // blip). Sibling of `isConnectionClosedNoise` but a different throw (a
+   // `ws.send` rejection on a closed socket, not a library close event).
+   // The event is `handled:true` (caught by an error boundary), so a
+   // first-party sender IS actionable — the negative guard preserves any
+   // resolved first-party `apps/web/src/…` frame. See
+   // `isFailedToSendMessageNoise`.
+    if (isFailedToSendMessageNoise({ message, filename: input.filename })) {
+      return true;
+    }
+
+    // Third-party editor-library (ProseMirror/TipTap-based) document-state
+    // race noise — the library's own internal `getDocumentStateOrThrow` /
+    // `getDocumentState` helpers threw
+    // `<Interaction|Selection> state not found for document: <docId>` when the
+    // editor was unmounted / the document closed while an async interaction or
+    // selection was still in flight (a race in the library's async interaction
+    // handling, triggered by WebKit's async timing). Requires the canonical
+    // message prefix AND a NEGATIVE guard: any resolved first-party
+    // `apps/web/src/…` frame → keep reporting. See
+    // `isDocumentStateNotFoundNoise`.
+    if (isDocumentStateNotFoundNoise({ message, filename: input.filename })) {
+      return true;
+    }
 
 
    // Browser-native <img> / next/image load failures can surface as this exact
@@ -3985,6 +4280,19 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   // captured as an unhandled rejection. Third-party user-script defect, never
   // first-party app code; drop it. See `isUserscriptManagerNoise`.
   if (isUserscriptManagerNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
+  // OneTrust cookie-consent SDK JSON-parse noise — the third-party
+  // `otSDKStub.js?did=undefined` bootstrap stub's `XMLHttpRequest.onload`
+  // handler calls `JSON.parse()` on an empty/truncated consent-config
+  // response (old iOS Safari, CORS preflight failure, 5xx, network abort)
+  // and throws the canonical `SyntaxError: Unexpected end of JSON input`.
+  // The throw is in the OneTrust SDK's own injected script, never first-
+  // party code. Requires BOTH the exact message AND an `otSDKStub.js`
+  // frame, with a negative guard preserving any resolved first-party
+  // `apps/web/src/…` frame. See `isOneTrustJsonParseNoise`.
+  if (isOneTrustJsonParseNoise({ message, filename: input.filename })) {
     return true;
   }
 
@@ -4378,6 +4686,21 @@ export function shouldIgnoreSentryBrowserNoise(event: {
     return true;
   }
 
+  // OneTrust cookie-consent SDK JSON-parse noise — the third-party
+  // `otSDKStub.js?did=undefined` bootstrap stub's `XMLHttpRequest.onload`
+  // handler calls `JSON.parse()` on an empty/truncated consent-config
+  // response (old iOS Safari, CORS preflight failure, 5xx, network abort)
+  // and throws the canonical `SyntaxError: Unexpected end of JSON input`.
+  // The throw is in the OneTrust SDK's own injected script (frame
+  // `app:///scripttemplates/otSDKStub.js?did=undefined` function `r.onload`),
+  // never first-party code. Requires BOTH the exact message AND an
+  // `otSDKStub.js` frame, with a negative guard preserving any resolved
+  // first-party `apps/web/src/…` frame. See `isOneTrustJsonParseNoise` and
+  // the production pattern `aa1efd3fb…`.
+  if (isOneTrustJsonParseNoise({ message, frames })) {
+    return true;
+  }
+
   // Browser-extension injectedScript.bundle.js `sendMessage` noise — a
   // browser extension (wallet / adblocker / privacy) injects
   // `app:///injectedScript.bundle.js` that calls `chrome.runtime.sendMessage`
@@ -4677,6 +5000,24 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // patterns into a real, tested matcher. NOT in `ignoreErrors` (no frame
   // context there). See `isConnectionClosedNoise`.
   if (isConnectionClosedNoise({ message, frames })) {
+    return true;
+  }
+
+  // Transient WebSocket `postMessage` `Failed to send message` transport
+  // noise — a co-worker session page's `ws.send(...)` rejected with the
+  // canonical WebSocket `InvalidStateError` message when the sandbox tore
+  // the connection down mid-flight (deploy / recycle / park / network
+  // blip). Sibling of `isConnectionClosedNoise` (the `Connection closed.`
+  // transport-close class) but a DIFFERENT throw (a `ws.send` rejection on
+  // an already-closed socket). The prod event is `handled:true`
+  // (mechanism `generic` — caught by an error boundary, NOT an uncaught
+  // global rejection), so a first-party sender IS actionable — the
+  // negative guard preserves any resolved first-party `apps/web/src/…`
+  // frame. The prod event carries only a minified `_next/static/immutable/
+  // chunks/…` frame, so the negative guard does not fire for it. NOT in
+  // `ignoreErrors` (no frame context there). See
+  // `isFailedToSendMessageNoise` and Better Stack pattern `824577dd…`.
+  if (isFailedToSendMessageNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. The proof is the noise-test suite: 310 → **331 passing** (`node --experimental-strip-types --test apps/web/src/lib/browser-error-noise.test.mts`), with 21 new tests pinning the three production noise shapes below so they stop paging Better Stack while real first-party regressions keep reporting.

## Why

Three sibling production-noise patterns in the Kortix Frontend prod Sentry (app_id `2346967`, v0.12.8 release `cd9dfcce…`) page Better Stack from third-party SDKs / transient transport teardown — none are first-party defects, and all three carry **no resolved first-party `apps/web/src/…` frame**. They were leaking because the existing noise matchers cover the V8/Chromium wording but not the Firefox/OneTrust/WebSocket-`InvalidStateError` variants. This PR adds three matchers (and one array extension) to `apps/web/src/lib/browser-error-noise.ts` so the Sentry `beforeSend` + runtime `window.onerror` gates drop them, while preserving the load-bearing first-party negative guard (any resolved `apps/web/src/…` frame → keep reporting).

## What changed

### 1. `isOneTrustJsonParseNoise` (Pattern 1 — Better Stack `aa1efd3fb7a9f6840d4eb25b881d2b12ac2e6f3c8dfe3158fbd3e9fc753a0526`)
OneTrust cookie-consent SDK JSON-parse noise. The third-party `otSDKStub.js?did=undefined` bootstrap stub's `XMLHttpRequest.onload` handler calls `JSON.parse()` on an empty/truncated consent-config response (old iOS Safari, CORS preflight failure, 5xx, network abort) and throws `SyntaxError: Unexpected end of JSON input`. The throw is in the OneTrust SDK's own injected script (frame `app:///scripttemplates/otSDKStub.js?did=undefined` fn `r.onload`), never first-party code. 1 occ / 0 users, request URL `https://kortix.com/auth`, Safari on iOS 13.2.3 (iPhone), mechanism `auto.browser.browserapierrors.xhr.onload` (UNCAUGHT, `handled:false`).

Anchored on **both** the exact message `/^Unexpected end of JSON input$/` (after `stripErrorWrappers`) AND a frame whose filename contains `otSDKStub.js` (the OneTrust SDK's canonical bootstrap filename), with a NEGATIVE guard: any resolved first-party `apps/web/src/…` frame → KEEP (a real first-party `JSON.parse(truncatedApiResponse)` regression de-minifies to `apps/web/src/…` and must not be hidden). Returns false when no `otSDKStub.js` frame is present (can't confirm the OneTrust origin). Wired into `shouldIgnoreSentryBrowserNoise` and `shouldIgnoreBrowserRuntimeNoise`.

### 2. Extend `KNOWN_DOM_MUTATION_NOISE_MESSAGES` (Pattern 2 — Better Stack `9e6a70ffdb26ba2ab9f821fe8772f51b082d6a9b0e2c9f50b2130cde0c3e6438`)
Firefox DOM-mutation "supplied node incorrect" noise — the Gecko/Firefox sibling of the existing V8 `insertBefore`/`removeChild` DOM-mutation class. `InvalidNodeTypeError: The supplied node is incorrect or has an incorrect ancestor for this operation.` from Next.js live feedback (`_next-live/feedback/913…js` fn `te`). 2 occ / 0 users, Firefox 153 on macOS, mechanism `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT, `handled:false`).

Fix: **just add the Gecko string to the existing `KNOWN_DOM_MUTATION_NOISE_MESSAGES` array** — `containsKnownPattern` (`.includes()`) matches it the same way as the V8 entries. No matcher change, no new function; lowest-risk fix.

### 3. `isFailedToSendMessageNoise` (Pattern 3 — Better Stack `824577dd315c08f227a1f31c74e2eb90be209b1ffd129e18923907aa3068afd2`)
Transient WebSocket `postMessage` `Failed to send message` transport noise — a co-worker session page's `ws.send(...)` rejected with the WebSocket spec's canonical `InvalidStateError` message (`Failed to send message` — `ws.send` on a closed socket) when the sandbox tore the connection down mid-flight (deploy / restart / idle-timeout recycle / sandbox park / network blip / tab close). Sibling of `isConnectionClosedNoise` but a **different** throw (a `ws.send` rejection on an already-closed socket, not a library close event). 1 occ / 0 users, Chrome on macOS, **mechanism `generic` with `handled:true`** (CAUGHT by an error boundary — the user saw a controlled error state, not a blank page, NOT an uncaught global rejection). Stack: 1 minified `_next/static/immutable/chunks/3n0z0jtixhg6r.js` frame (`Object.x [as mutationFn]`), NO resolved first-party source.

Because the event is `handled:true` (caught by an error boundary), a first-party sender IS actionable: if our own code is the sender, the boundary's error state is showing the user a defect we should fix. So the matcher anchors on the **exact** message `/^Failed to send message$/` (after `stripErrorWrappers` + leading `Error: ` strip) AND a NEGATIVE guard: any resolved first-party `apps/web/src/…` frame → KEEP. A frameless capture with this exact message still classifies as noise (the message is the WebSocket spec's canonical transport-failure wording and is specific enough — mirrors `isConnectionClosedNoise`'s frameless handling). Wired into `shouldIgnoreSentryBrowserNoise` and `shouldIgnoreBrowserRuntimeNoise`. Sibling-disjoint from `isConnectionClosedNoise` (a `Connection closed.` event is NOT matched by the `Failed to send message` matcher, and vice versa — pinned by a test).

## Verification

- **Noise tests**: `node --experimental-strip-types --test apps/web/src/lib/browser-error-noise.test.mts` → **331 pass / 0 fail** (was 310; +21 new tests covering prod-shape classification, capture-path wrappers, frameless variants, first-party negative guards, over-match guards, and sibling-disjointness).
- **Typecheck/build**: `bun build --no-bundle apps/web/src/lib/browser-error-noise.ts` exits 0 (clean compile).
- **Functional sanity**: `bun -e` import + smoke-test all three matchers against the exact prod frames (OneTrust 3-frame stack, Failed-to-send 1-frame stack) → all classify as noise; with a first-party `apps/web/src/…` frame → all keep reporting.
- **Production evidence**: All three Better Stack patterns confirmed via the Better Stack MCP `query` tool against `s3Cluster(primary, t502678_kortix_frontend_s3) WHERE _row_type = 4` — the `raw` JSON column carries the exact frames, mechanism, and `handled` flag cited above.

### Preview verification plan

This is a pure telemetry-noise-filter change (no user-facing behavior, no API change, no UI change). The preview E2E check is:
1. `preview` label added → wait for `deploy-preview.yml: success` + `bun unit tests (packages + apps): pass`.
2. Confirm the Vercel frontend loads (HTTP 200 on `/auth`) — the noise-filter is a `beforeSend` hook on the Sentry client, so a successful page load is the proof it doesn't break the client init.
3. (Optional) Trigger one of the three noise messages in the preview browser console and confirm it does NOT appear in the preview's Sentry (the `beforeSend` hook dropped it).

## Incident reference

- Better Stack error ids (Kortix Frontend prod, app_id `2346967`):
  - `aa1efd3fb7a9f6840d4eb25b881d2b12ac2e6f3c8dfe3158fbd3e9fc753a0526` (OneTrust JSON parse, 1 occ)
  - `9e6a70ffdb26ba2ab9f821fe8772f51b082d6a9b0e2c9f50b2130cde0c3e6438` (Firefox DOM mutation, 2 occ)
  - `824577dd315c08f227a1f31c74e2eb90be209b1ffd129e18923907aa3068afd2` (Failed to send message, 1 occ)
- Release: `cd9dfccec1fb7e41a6726e9e45fd678cf428cc3a` (v0.12.8 prod)
- All three last seen 2026-08-11 (within the current sweep window).

## Risk / rollback

- **Risk**: very low. The matchers are additive (`return false` unless ALL positive anchors match AND no negative guard fires), so they can only DROP events that match the exact prod noise shape; they cannot start dropping events that previously reported. The first-party `apps/web/src/…` negative guard preserves any attributable first-party regression. The DOM-mutation array extension is a pure string addition to an existing `.includes()` list (the existing V8 entries' contract).
- **Rollback**: revert the single commit. No migrations, no schema, no API contract, no dependency change. The matchers are local to `apps/web/src/lib/browser-error-noise.ts` (and its test file).

## Confirmation

After merge + promote, the three Better Stack error ids above should drop to **zero new occurrences** (Better Stack auto-resolves once no longer seen). The log/metric that should go quiet: the three named patterns in the `t502678_kortix_frontend_metrics` ClickHouse view.
