### PR TITLE
fix(deploy-prod): pin the Vercel RUNTIME version env so the prod FE isn't stranded

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1328,13 +1328,25 @@ jobs:
             echo "::error::VERCEL_PROJECT_ID resolves to '$linked', not the suna project — refusing to deploy the wrong project."
             exit 1
           fi
+      - name: Pin the RUNTIME frontend version env
+        run: |
+          set -euo pipefail
+          VER="${{ needs.version.outputs.version }}"
+          # The frontend resolves its VERSION at RUNTIME:
+          # apps/web/src/lib/public-env-server.ts reads NEXT_PUBLIC_KORTIX_VERSION
+          # via Reflect.get(process.env, ...), which Next.js does NOT inline at
+          # build time. So `--build-env` below never overrides a STALE Production
+          # runtime var — v0.12.8 shipped an FE stuck on the prior 0.12.7 until
+          # this runtime var was corrected by hand. Overwrite the Production
+          # runtime var to the release version so the deploy binds it correctly.
+          npx --yes vercel@latest env rm NEXT_PUBLIC_KORTIX_VERSION production --yes --token="$VERCEL_TOKEN" 2>/dev/null || true
+          printf '%s' "$VER" | npx --yes vercel@latest env add NEXT_PUBLIC_KORTIX_VERSION production --token="$VERCEL_TOKEN"
       - name: Deploy the release frontend to production
         run: |
           set -euo pipefail
-          # Stamp the release version explicitly: the Vercel build cannot always
-          # read the repo-root VERSION file from the apps/web root directory
-          # (v0.12.7 shipped a frontend reporting VERSION "dev" and failed
-          # frontend-auth-proof until redeployed with the env set).
+          # Keep --build-env too (belt-and-braces for any build-time read); the
+          # RUNTIME var pinned in the step above is what actually drives
+          # /api/runtime-config and the frontend-auth-proof version guard.
           npx --yes vercel@latest deploy --prod --yes --token="$VERCEL_TOKEN" \
             --build-env "NEXT_PUBLIC_KORTIX_VERSION=${{ needs.version.outputs.version }}"
 


### PR DESCRIPTION
## Problem

During the v0.12.8 release, the prod frontend was stranded on **0.12.7** while the API was **0.12.8**. The `frontend-auth-proof` guard correctly caught the skew and failed, which cascaded a **skipped** rollout-banner-lower + **skipped GitHub Release** (both had to be recovered by hand).

Root cause: `/api/runtime-config` resolves the version at **runtime** — `apps/web/src/lib/public-env-server.ts` reads `NEXT_PUBLIC_KORTIX_VERSION` via `Reflect.get(process.env, ...)`, which Next.js does **not** inline at build time. So the deploy job's `--build-env NEXT_PUBLIC_KORTIX_VERSION=<version>` (build-time only) never overrode a **stale Vercel Production runtime env var** left at `0.12.7` from the previous release.

## Fix

Add a step to `deploy-web-vercel` that overwrites the Production **runtime** env var to the release version *before* `vercel deploy --prod` binds it. `--build-env` is kept as belt-and-braces.

```
vercel env rm NEXT_PUBLIC_KORTIX_VERSION production --yes
printf '%s' "$VERSION" | vercel env add NEXT_PUBLIC_KORTIX_VERSION production
vercel deploy --prod ...
```

## Verification

- `yaml.safe_load` parses clean.
- This exact remediation (update the runtime env var → redeploy) is what fixed the live v0.12.8 skew: after it, `kortix.com` and `www.kortix.com` `/api/runtime-config` both report `0.12.8`, matching the API, and the re-run auth-config guard passed.

## Follow-up (optional, larger)
Consider having the frontend read a build-stamped constant instead of a runtime `Reflect.get`, so version can never drift from the deployed build.
