### PR TITLE
test(deployed): serialize staging lanes + self-heal AgentMail quota (gate stabilization r2)

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -20,10 +20,11 @@ jobs:
     # the early REST flows), then the post-test secret-guard/upload steps push
     # the job past 45m. The old 20-min cap killed it at ~316/433 EVERY release
     # (v0.12.7 and v0.12.8 both cancelled, not failed) — the gate was
-    # structurally un-passable. 60 gives ~13 min headroom over the ~47-min real
-    # runtime without masking a genuine hang. Follow-up: shard the runner
-    # (matrix over flow domains + browser) to bring this back under 20.
-    timeout-minutes: 60
+    # structurally un-passable. The two lanes now run SERIALLY (not concurrently)
+    # so they stop overloading the staging origin into MAINTENANCE_MODE — that
+    # trades ~47m concurrent for ~60m sequential, so the cap is 75m. Follow-up:
+    # shard the runner (matrix over flow domains + browser) to bring this down.
+    timeout-minutes: 75
     env:
       KE2E_API_URL: ${{ vars.QA_API_BASE_URL || 'https://staging-api.kortix.com/v1' }}
       E2E_BASE_URL: ${{ vars.QA_WEB_BASE_URL || 'https://staging.kortix.com' }}

--- a/tests/e2e/helpers/inbox.ts
+++ b/tests/e2e/helpers/inbox.ts
@@ -126,6 +126,29 @@ function localMailpitInbox(mailpitUrl: string): DisposableInbox {
   };
 }
 
+/** Delete only THIS suite's leaked inboxes (kortix-e2e-*), never anyone else's. */
+async function purgeE2eInboxes(
+  baseUrl: string,
+  headers: Record<string, string>,
+): Promise<void> {
+  const res = await fetch(`${baseUrl}/inboxes?limit=100`, { headers });
+  if (!res.ok) return;
+  const body = (await res.json().catch(() => ({}))) as {
+    inboxes?: Array<{ inbox_id?: string }>;
+  };
+  const mine = (body.inboxes ?? [])
+    .map((entry) => entry.inbox_id)
+    .filter((id): id is string => typeof id === "string" && id.startsWith("kortix-e2e-"));
+  await Promise.all(
+    mine.map((id) =>
+      fetch(`${baseUrl}/inboxes/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+        headers,
+      }).catch(() => undefined),
+    ),
+  );
+}
+
 async function agentMailInbox(apiKey: string): Promise<DisposableInbox> {
   const baseUrl = (process.env.E2E_AGENTMAIL_API_URL || "https://api.agentmail.to/v0").replace(
     /\/+$/,
@@ -136,18 +159,30 @@ async function agentMailInbox(apiKey: string): Promise<DisposableInbox> {
     "Content-Type": "application/json",
   };
   const unique = `${Date.now()}-${randomUUID().slice(0, 8)}`;
-  const inbox = await json<AgentMailInboxResponse>(
-    await fetch(`${baseUrl}/inboxes`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        username: `kortix-e2e-${unique}`,
-        display_name: "Kortix E2E",
-        client_id: `kortix-browser-auth-${unique}`,
-      }),
-    }),
-    200,
-  );
+  const createBody = JSON.stringify({
+    username: `kortix-e2e-${unique}`,
+    display_name: "Kortix E2E",
+    client_id: `kortix-browser-auth-${unique}`,
+  });
+  const createOnce = () =>
+    fetch(`${baseUrl}/inboxes`, { method: "POST", headers, body: createBody });
+
+  // AgentMail caps inboxes per account (10 on the free plan). E2E inboxes are
+  // ephemeral but a crashed run can leak them and fill the quota, which 403s
+  // every later inbox create with limit_exceeded. On that specific error, sweep
+  // our OWN leaked inboxes (kortix-e2e-*, never anyone else's) and retry once.
+  let created = await createOnce();
+  if (created.status === 403) {
+    const detail = await created
+      .clone()
+      .json()
+      .catch(() => ({}) as { code?: string });
+    if (detail?.code === "limit_exceeded") {
+      await purgeE2eInboxes(baseUrl, headers);
+      created = await createOnce();
+    }
+  }
+  const inbox = await json<AgentMailInboxResponse>(created, 200);
 
   const readLatestMessage = async (after: Date): Promise<string | null> => {
     const listUrl = new URL(

--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -173,7 +173,14 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
   }
   if (targetFull) {
     const lanes = [targetApiFull, targetBrowserFull];
-    return { mode: 'target-full', lanes, stages: [lanes] };
+    // SERIALIZE the two deployed lanes (two stages, not one concurrent stage).
+    // Running the REST flow lane and the browser lane against the same staging
+    // origin at once drove sustained (multi-minute) origin overload that the
+    // edge laundered into MAINTENANCE_MODE — session-create (sandbox provision,
+    // the heaviest op) is the tipping point. A per-request retry can't outlast a
+    // minutes-long degradation; removing the concurrent peak is the real fix.
+    // Costs wall-clock (why tests-release.yml runs at 75m), buys a stable gate.
+    return { mode: 'target-full', lanes, stages: [[targetApiFull], [targetBrowserFull]] };
   }
   if (full) {
     const fullFlows: LocalTestLane = {


### PR DESCRIPTION
Round 2 of deployed-gate stabilization, from the v0.12.9 gate run 31552379517. All remaining failures were environmental, not product bugs:

- **Sustained MAINTENANCE_MODE** (session-create overload under the CONCURRENT API+browser lanes) → **serialize the two --target-full lanes** (two stages instead of one concurrent stage), removing the peak that tips staging over. Timeout 60→75m for the longer sequential run.
- **AgentMail 403 = limit_exceeded** (10-inbox cap filled by leaked ephemeral inboxes), not a dead key → on that error, sweep only our own `kortix-e2e-*` inboxes and retry once.

Also purged the currently-leaked inboxes out-of-band so the next gate starts at 0/10.

tsc clean, YAML valid. Verified by the next v0.12.9 gate run (this is test/CI-only).