### PR TITLE
feat: tell the agent what the network boundary is doing

### DIFF
--- a/apps/api/src/projects/secret-capabilities.test.ts
+++ b/apps/api/src/projects/secret-capabilities.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { buildSecretCapabilities, serializeSecretCapabilities } from './secret-capabilities';
+import { resolveNetworkBoundaryBindings } from '../secrets/network-boundary';
+import {
+  NETWORK_BOUNDARY_NOTES,
+  buildSecretCapabilities,
+  serializeSecretCapabilities,
+} from './secret-capabilities';
 
 describe('buildSecretCapabilities', () => {
   test('describes each usable delivery without serializing secret material', () => {
@@ -83,6 +88,9 @@ describe('buildSecretCapabilities', () => {
           consumer: null,
         },
         {
+          // A network-boundary row with no policy claims no destination, so
+          // there is nothing to describe. `resolveNetworkBoundaryBindings`
+          // throws on this row, so the session never starts either.
           identifier: 'EGRESS',
           key: 'EGRESS',
           strategy: 'egress',
@@ -148,5 +156,162 @@ describe('buildSecretCapabilities', () => {
     expect(parsed.truncated).toBe(true);
     expect(parsed.total).toBe(1_000);
     expect(parsed.capabilities.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The boundary is invisible from inside the sandbox by design, and its one
+ * observable symptom — a cut connection — reads as a dead host. An agent told
+ * nothing invents an explanation for it (a real session concluded that an echo
+ * service had "legacy HTTP/1.1 ALPN negotiation" problems). The catalog is the
+ * only channel that can correct that before the guess happens.
+ */
+describe('buildSecretCapabilities describes the network boundary', () => {
+  const NEVER_LEAKS = 'sk_live_never_in_the_catalog';
+
+  const policy = {
+    rules: [
+      { host: 'Uploads.Stripe.test' },
+      { host: 'api.stripe.test' },
+      { host: 'api.stripe.test' },
+    ],
+    inject: { kind: 'header' as const, name: 'Authorization', template: 'Bearer {{secret}}' },
+    on_no_match: 'deny' as const,
+    tls: 'terminate' as const,
+  };
+
+  /** A full stored row, so the same object can drive the provider-edge check. */
+  const row = {
+    secretId: '00000000-0000-4000-8000-000000000001',
+    identifier: 'STRIPE_API_KEY',
+    key: 'STRIPE_API_KEY',
+    value: NEVER_LEAKS,
+    strategy: 'egress' as const,
+    consumer: 'network' as const,
+    egressPolicy: policy,
+  };
+
+  const sandboxRow = {
+    identifier: 'LOCAL_TOKEN',
+    key: 'LOCAL_TOKEN',
+    strategy: 'runtime' as const,
+    consumer: 'sandbox' as const,
+  };
+
+  type CapabilityRows = Parameters<typeof buildSecretCapabilities>[0];
+
+  const built = (rows: CapabilityRows = [row]) =>
+    buildSecretCapabilities(rows, {
+      grantEnv: ['STRIPE_API_KEY', 'LOCAL_TOKEN'],
+      sessionId: 'session-1',
+    });
+
+  test('names the allow-listed hosts and the injected header', () => {
+    expect(built().capabilities).toEqual([
+      {
+        identifier: 'STRIPE_API_KEY',
+        delivery: 'network',
+        hosts: ['api.stripe.test', 'uploads.stripe.test'],
+        header: 'authorization',
+        scheme: 'https',
+        readable_in_sandbox: false,
+        on_echo: 'block',
+      },
+    ]);
+  });
+
+  test('carries no value, no alias, and no header template', () => {
+    const json = JSON.stringify(built());
+    expect(json).not.toContain(NEVER_LEAKS);
+    expect(json).not.toContain('{{secret}}');
+    expect(json).not.toContain('Bearer');
+    // `bindingAlias` in ../secrets/network-boundary.ts derives the provider-side
+    // attachment name from the secret id. The guest must not see that either.
+    expect(json).not.toContain(row.secretId.replace(/-/g, ''));
+  });
+
+  test('states the echo cut, the HTTPS requirement, and what to probe instead', () => {
+    const notes = built().notes?.network ?? [];
+    const text = notes.join('\n');
+    expect(text).toContain('curl: (52) Empty reply from server');
+    expect(text).toContain('The host is not down.');
+    expect(text).toContain('HTTPS is required.');
+    expect(text).toContain('never one that reflects request headers');
+    expect(text).toContain('do not ask the user for it');
+    expect(text).toContain('do not build the header yourself');
+    expect(notes).toEqual([...NETWORK_BOUNDARY_NOTES]);
+  });
+
+  test('describes the same destination the provider edge arms', () => {
+    const [binding] = resolveNetworkBoundaryBindings([row], {
+      sessionId: 'session-1',
+      agentGrantEnv: ['STRIPE_API_KEY'],
+      sessionAllowlist: null,
+    });
+    const capability = built().capabilities[0];
+    if (capability?.delivery !== 'network') throw new Error('expected a network capability');
+    expect(capability.hosts).toEqual(binding!.hosts);
+    expect(capability.header).toBe(binding!.header);
+    expect(capability.on_echo).toBe(binding!.onEcho);
+    // The armed binding carries the rendered credential. The catalog must not.
+    expect(binding!.value).toBe(`Bearer ${NEVER_LEAKS}`);
+  });
+
+  test('leaves a sandbox secret unchanged and states the rules once', () => {
+    const catalog = built([row, sandboxRow]);
+
+    expect(catalog.capabilities[0]).toEqual({
+      identifier: 'LOCAL_TOKEN',
+      delivery: 'sandbox',
+      environment_variable: 'LOCAL_TOKEN',
+    });
+    expect(catalog.notes).toEqual({ network: NETWORK_BOUNDARY_NOTES });
+  });
+
+  test('omits the notes when no capability needs them', () => {
+    const catalog = built([sandboxRow]);
+    expect(catalog.notes).toBeUndefined();
+    expect(JSON.stringify(catalog)).not.toContain('Empty reply');
+  });
+
+  test('advertises nothing for a policy the boundary cannot enforce', () => {
+    const unenforceable = [
+      { ...policy, rules: [{ host: '*.stripe.test' }] },
+      { ...policy, rules: [{ host: 'api.stripe.test', path: '/v1/*' }] },
+      { ...policy, rules: [{ host: 'api.stripe.test', methods: ['GET'] }] },
+      { ...policy, inject: { kind: 'query' as const, name: 'api_key' } },
+      { ...policy, tls: 'tunnel' as const },
+      { ...policy, backend: 'kortix_fetch' as const },
+    ];
+    for (const egressPolicy of unenforceable) {
+      expect(built([{ ...row, egressPolicy }]).capabilities).toEqual([]);
+    }
+  });
+
+  test('keeps the rules inside the truncation budget', () => {
+    const identifiers = Array.from(
+      { length: 400 },
+      (_, index) => `BOUNDARY_${index.toString().padStart(4, '0')}_${'x'.repeat(100)}`,
+    );
+    const many = buildSecretCapabilities(
+      identifiers.map((identifier, index) => ({
+        identifier,
+        key: `BOUNDARY_${index}`,
+        strategy: 'egress' as const,
+        consumer: 'network' as const,
+        egressPolicy: policy,
+      })),
+      { grantEnv: identifiers, sessionId: 'session-1' },
+    );
+
+    const serialized = serializeSecretCapabilities(many);
+    const parsed = JSON.parse(serialized);
+    expect(many.capabilities.length).toBe(400);
+    expect(Buffer.byteLength(serialized, 'utf8')).toBeLessThanOrEqual(48 * 1024);
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.total).toBe(400);
+    expect(parsed.capabilities.length).toBeGreaterThan(0);
+    // A truncated catalog that still lists a network capability keeps its rules.
+    expect(parsed.notes.network).toEqual([...NETWORK_BOUNDARY_NOTES]);
   });
 });

--- a/apps/api/src/projects/secret-capabilities.ts
+++ b/apps/api/src/projects/secret-capabilities.ts
@@ -1,3 +1,4 @@
+import { networkBoundaryPolicyError } from '../secrets/network-boundary';
 import type { SecretConsumer, SecretEgressPolicy, SecretStrategy } from '../secrets/strategy';
 import { resolveSecretDelivery } from '../secrets/strategy';
 import { isSandboxSecretEnvNameAllowed } from './lib/sandbox-env-names';
@@ -27,13 +28,82 @@ export type SecretCapability =
       identifier: string;
       delivery: 'kortix_service';
       consumer: Exclude<SecretConsumer, 'sandbox' | 'network' | 'http_broker'>;
+    }
+  | {
+      identifier: string;
+      delivery: 'network';
+      /** The exact hosts whose requests get the header, lowercased and sorted.
+       *  Every other host leaves the sandbox untouched. */
+      hosts: string[];
+      /** The header the boundary sets on those hosts, lowercased. The VALUE is
+       *  never here — it is added outside the sandbox. */
+      header: string;
+      /** The boundary terminates TLS to rewrite the header, so a listed host
+       *  must be called over HTTPS. Plain HTTP is refused. */
+      scheme: 'https';
+      /** The value is not in the sandbox in any form. */
+      readable_in_sandbox: false;
+      /** A response that would echo the value back into the sandbox is cut. */
+      on_echo: 'block';
     };
+
+/**
+ * What an agent must know to USE a network-boundary secret, and — the reason
+ * this exists — how to read the boundary's one confusing symptom.
+ *
+ * A response that would carry the credential back into the guest is cut, so
+ * `curl` reports `curl: (52) Empty reply from server`. Against an echo endpoint
+ * a WORKING boundary is byte-identical to a dead host, and an agent with no
+ * other information will confabulate a network explanation for it. These lines
+ * are carried once per catalog rather than once per capability: they are the
+ * same for every network secret, and repeating them would spend the 48 KB
+ * budget that `serializeSecretCapabilities` divides between capabilities.
+ */
+export const NETWORK_BOUNDARY_NOTES: readonly string[] = [
+  'Kortix adds these credentials outside the sandbox, at the network boundary.',
+  'The value is not in this sandbox: no environment variable, no file, no alias, no placeholder.',
+  'Do not search for the value, do not ask the user for it, and do not build the header yourself.',
+  'Send an ordinary request with no credential. The boundary sets the header in flight.',
+  'Each capability lists its own `hosts` and `header`. Only those hosts get that header.',
+  'HTTPS is required. Plain HTTP to a listed host is refused before it leaves the sandbox.',
+  'A response that would echo the value back into the sandbox is cut mid-flight.',
+  'So `curl: (52) Empty reply from server` on a listed host means the boundary worked. The host is not down.',
+  'Verify with an endpoint that CONSUMES the credential and returns 200 or 401, never one that reflects request headers.',
+  'A listed host that answers 401 means the header did not arrive. Report that; do not invent a credential.',
+];
 
 export interface SecretCapabilityCatalog {
   version: 1;
   capabilities: SecretCapability[];
+  /** Usage rules for a whole delivery class, present only when the catalog
+   *  lists a capability of that class. */
+  notes?: { network: readonly string[] };
   truncated?: boolean;
   total?: number;
+}
+
+/**
+ * The (hosts, header) pair the provider edge will hold for this policy.
+ *
+ * An exact mirror of `boundaryDestinations` in ../secrets/network-boundary.ts,
+ * which is module-private and computes the same pair for the binding that is
+ * actually armed. Both lowercase, because the edge matches case-insensitively.
+ * A capability that spells the destination differently from the binding tells
+ * the agent to call a host the boundary is not watching — the test
+ * `describes the same destination the provider edge arms` pins them together.
+ */
+function networkDestination(
+  policy: SecretEgressPolicy,
+): { header: string; hosts: string[] } | null {
+  if (policy.inject.kind !== 'header') return null;
+  return {
+    header: policy.inject.name.toLowerCase(),
+    hosts: [...new Set(policy.rules.map((rule) => rule.host.toLowerCase()))].sort(),
+  };
+}
+
+function hasNetworkCapability(capabilities: readonly SecretCapability[]): boolean {
+  return capabilities.some((capability) => capability.delivery === 'network');
 }
 
 function isKortixServiceConsumer(
@@ -87,6 +157,36 @@ export function buildSecretCapabilities(
       continue;
     }
 
+    // Network boundary. The identifier, its hosts and its header are policy,
+    // not secret material, so they are safe to name; the value and the header
+    // TEMPLATE stay out, because an agent that can read the shape of the header
+    // starts trying to assemble one.
+    //
+    // Only a policy the boundary can actually enforce is advertised:
+    // `resolveNetworkBoundaryBindings` throws on anything else, so a session
+    // carrying one never reaches the agent at all.
+    if (
+      delivery.emit === 'handle' &&
+      delivery.strategy === 'egress' &&
+      consumer === 'network' &&
+      row.egressPolicy &&
+      !networkBoundaryPolicyError(row.egressPolicy)
+    ) {
+      const destination = networkDestination(row.egressPolicy);
+      if (destination) {
+        capabilities.push({
+          identifier: row.identifier,
+          delivery: 'network',
+          hosts: destination.hosts,
+          header: destination.header,
+          scheme: 'https',
+          readable_in_sandbox: false,
+          on_echo: 'block',
+        });
+      }
+      continue;
+    }
+
     if (
       delivery.emit === 'handle' &&
       delivery.strategy === 'broker' &&
@@ -111,7 +211,11 @@ export function buildSecretCapabilities(
   }
 
   capabilities.sort((a, b) => a.identifier.localeCompare(b.identifier));
-  return { version: 1, capabilities };
+  return {
+    version: 1,
+    capabilities,
+    ...(hasNetworkCapability(capabilities) ? { notes: { network: NETWORK_BOUNDARY_NOTES } } : {}),
+  };
 }
 
 export function serializeSecretCapabilities(catalog: SecretCapabilityCatalog): string {
@@ -119,21 +223,23 @@ export function serializeSecretCapabilities(catalog: SecretCapabilityCatalog): s
   const serialized = JSON.stringify(catalog);
   if (Buffer.byteLength(serialized, 'utf8') <= maxBytes) return serialized;
 
+  // The notes travel with the capabilities they explain: dropped when
+  // truncation leaves no network capability, and counted against the budget
+  // when it does, so the payload cannot exceed the cap by adding them last.
+  const notes = catalog.notes ?? { network: NETWORK_BOUNDARY_NOTES };
+  const build = (kept: SecretCapability[]): SecretCapabilityCatalog => ({
+    version: 1,
+    capabilities: kept,
+    ...(hasNetworkCapability(kept) ? { notes } : {}),
+    truncated: true,
+    total: catalog.capabilities.length,
+  });
+
   const capabilities: SecretCapability[] = [];
   for (const capability of catalog.capabilities) {
-    const candidate: SecretCapabilityCatalog = {
-      version: 1,
-      capabilities: [...capabilities, capability],
-      truncated: true,
-      total: catalog.capabilities.length,
-    };
+    const candidate = build([...capabilities, capability]);
     if (Buffer.byteLength(JSON.stringify(candidate), 'utf8') > maxBytes) break;
     capabilities.push(capability);
   }
-  return JSON.stringify({
-    version: 1,
-    capabilities,
-    truncated: true,
-    total: catalog.capabilities.length,
-  } satisfies SecretCapabilityCatalog);
+  return JSON.stringify(build(capabilities));
 }

--- a/apps/kortix-sandbox-agent-server/src/__tests__/secret-capabilities-network.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/secret-capabilities-network.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test'
+import { renderSecretCapabilitiesInstruction } from '../secret-capabilities'
+
+/**
+ * The rendered file is injected as an OpenCode `instructions` file, so it is the
+ * channel the model actually reads. A network-boundary capability used to be
+ * dropped here entirely — the renderer allow-listed three delivery values — and
+ * the result was an agent that hit the boundary's echo cut, concluded the host
+ * was broken, and invented a reason.
+ */
+const catalog = (extra: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    version: 1,
+    capabilities: [
+      {
+        identifier: 'STRIPE_KEY',
+        delivery: 'network',
+        hosts: ['api.stripe.com'],
+        header: 'authorization',
+        scheme: 'https',
+        readable_in_sandbox: false,
+        on_echo: 'block',
+      },
+    ],
+    notes: { network: ['Send an ordinary request.', 'curl: (52) Empty reply means it worked.'] },
+    ...extra,
+  })
+
+describe('network-boundary capabilities in the agent instructions', () => {
+  test('names the host and the header instead of dropping the entry', () => {
+    const md = renderSecretCapabilitiesInstruction(catalog())
+    expect(md).toContain('STRIPE_KEY')
+    expect(md).toContain('api.stripe.com')
+    expect(md).toContain('authorization')
+  })
+
+  test('renders the rules the API authored, so the wording lives in one place', () => {
+    const md = renderSecretCapabilitiesInstruction(catalog())
+    expect(md).toContain('## Network boundary')
+    expect(md).toContain('- Send an ordinary request.')
+    expect(md).toContain('curl: (52) Empty reply means it worked.')
+  })
+
+  test('accepts a string form too, so a shape change degrades to rendering', () => {
+    const md = renderSecretCapabilitiesInstruction(catalog({ notes: { network: 'one line rule' } }))
+    expect(md).toContain('- one line rule')
+  })
+
+  test('omits the rules block when no network capability is granted', () => {
+    const md = renderSecretCapabilitiesInstruction(
+      JSON.stringify({
+        version: 1,
+        capabilities: [{ identifier: 'LOCAL', delivery: 'sandbox', environment_variable: 'LOCAL' }],
+        notes: { network: ['should not appear'] },
+      }),
+    )
+    expect(md).not.toContain('## Network boundary')
+    expect(md).not.toContain('should not appear')
+    expect(md).toContain('`LOCAL`: sandbox environment variable `LOCAL`.')
+  })
+
+  test('drops a host or header that does not look like one', () => {
+    const md = renderSecretCapabilitiesInstruction(
+      JSON.stringify({
+        version: 1,
+        capabilities: [
+          {
+            identifier: 'BAD',
+            delivery: 'network',
+            hosts: ['api.ok.com', 'not a host', 'http://x.com'],
+            header: 'auth orization',
+          },
+        ],
+      }),
+    )
+    expect(md).toContain('api.ok.com')
+    expect(md).not.toContain('not a host')
+    expect(md).not.toContain('http://x.com')
+    // an unusable header name falls back rather than echoing junk into the prompt
+    expect(md).toContain('`authorization`')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/secret-capabilities.ts
+++ b/apps/kortix-sandbox-agent-server/src/secret-capabilities.ts
@@ -8,12 +8,45 @@ const IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/
 const ENV_NAME_RE = /^[A-Z_][A-Z0-9_]{0,63}$/
 const SERVICE_CONSUMERS = new Set(['llm_gateway', 'connector', 'git_proxy'])
 const MAX_CATALOG_BYTES = 64 * 1024
+const HOST_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/
+const HEADER_RE = /^[a-z0-9!#$%&'*+.^_`|~-]{1,128}$/
+const MAX_NOTES_CHARS = 4_000
 
 type CatalogEntry = {
   identifier: string
-  delivery: 'sandbox' | 'https_broker' | 'kortix_service'
+  delivery: 'sandbox' | 'https_broker' | 'kortix_service' | 'network'
   environment_variable?: string
   consumer?: string
+  /** Network-boundary only: the exact hosts the provider edge injects on. */
+  hosts?: string[]
+  /** Network-boundary only: the header name the edge writes. Never the value. */
+  header?: string
+}
+
+/** The API authors the network rules once, as `notes.network`. Rendering them
+ *  here rather than restating them keeps the guest-facing wording in a single
+ *  place — the agent reads this file as OpenCode `instructions`. */
+function parseNetworkNotes(raw: string | undefined): string[] {
+  if (!raw || Buffer.byteLength(raw, 'utf8') > MAX_CATALOG_BYTES) return []
+  try {
+    const value = JSON.parse(raw) as { notes?: unknown }
+    const notes = value.notes as Record<string, unknown> | undefined
+    const network = notes && typeof notes === 'object' ? notes.network : undefined
+    // The API emits an array of rules; a plain string is accepted so a future
+    // shape change degrades to "render it" instead of "drop it silently".
+    const list = Array.isArray(network) ? network : typeof network === 'string' ? [network] : []
+    let budget = MAX_NOTES_CHARS
+    const out: string[] = []
+    for (const line of list) {
+      if (typeof line !== 'string' || line.length === 0) continue
+      if (line.length > budget) break
+      budget -= line.length
+      out.push(line)
+    }
+    return out
+  } catch {
+    return []
+  }
 }
 
 function parseCatalog(raw: string | undefined): CatalogEntry[] {
@@ -28,7 +61,9 @@ function parseCatalog(raw: string | undefined): CatalogEntry[] {
       if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return []
       const item = entry as Record<string, unknown>
       if (typeof item.identifier !== 'string' || !IDENTIFIER_RE.test(item.identifier)) return []
-      if (!['sandbox', 'https_broker', 'kortix_service'].includes(String(item.delivery))) return []
+      if (!['sandbox', 'https_broker', 'kortix_service', 'network'].includes(String(item.delivery))) {
+        return []
+      }
       return [
         {
           identifier: item.identifier,
@@ -38,6 +73,16 @@ function parseCatalog(raw: string | undefined): CatalogEntry[] {
             : {}),
           ...(typeof item.consumer === 'string' && SERVICE_CONSUMERS.has(item.consumer)
             ? { consumer: item.consumer }
+            : {}),
+          ...(Array.isArray(item.hosts)
+            ? {
+                hosts: item.hosts.filter(
+                  (host): host is string => typeof host === 'string' && HOST_RE.test(host),
+                ),
+              }
+            : {}),
+          ...(typeof item.header === 'string' && HEADER_RE.test(item.header)
+            ? { header: item.header }
             : {}),
         },
       ]
@@ -49,6 +94,7 @@ function parseCatalog(raw: string | undefined): CatalogEntry[] {
 
 export function renderSecretCapabilitiesInstruction(raw: string | undefined): string {
   const entries = parseCatalog(raw)
+  const hasNetwork = entries.some((entry) => entry.delivery === 'network')
   const lines = [
     '# Session secret capabilities',
     '',
@@ -72,12 +118,24 @@ export function renderSecretCapabilitiesInstruction(raw: string | undefined): st
         lines.push(
           `- \`${entry.identifier}\`: HTTPS broker. Use \`kortix secrets call ${entry.identifier} <https-url> [options]\`.`,
         )
+      } else if (entry.delivery === 'network') {
+        const hosts = (entry.hosts ?? []).join(', ')
+        lines.push(
+          `- \`${entry.identifier}\`: network boundary. Kortix adds the \`${entry.header ?? 'authorization'}\`` +
+            ` header to your HTTPS requests to ${hosts || 'its allow-listed hosts'} — outside this sandbox.` +
+            ' Send the request normally and add no credential of your own.',
+        )
       } else {
         lines.push(
           `- \`${entry.identifier}\`: Kortix service \`${entry.consumer ?? 'managed'}\`; no sandbox plaintext.`,
         )
       }
     }
+  }
+  const networkNotes = hasNetwork ? parseNetworkNotes(raw) : []
+  if (networkNotes.length > 0) {
+    lines.push('', '## Network boundary', '')
+    for (const note of networkNotes) lines.push(`- ${note}`)
   }
   return `${lines.join('\n')}\n`
 }

--- a/apps/web/src/features/workspace/customize/sections/view/secret-delivery.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-delivery.test.ts
@@ -10,6 +10,8 @@ import {
   missingAgentGrantNotice,
   networkBoundaryAvailability,
   networkBoundaryBlockedReason,
+  networkBoundaryEchoNotice,
+  parseBoundaryHosts,
   readSecretDeliverySync,
   secretDeliveryBlockedReason,
   secretDeliveryOptions,
@@ -551,5 +553,56 @@ describe('buildNetworkBoundaryPolicy', () => {
     expect(buildNetworkBoundaryPolicy({ ...base, hosts: 'https://api.example.com' })).toBeNull();
     expect(buildNetworkBoundaryPolicy({ ...base, injectionTarget: 'bad header' })).toBeNull();
     expect(buildNetworkBoundaryPolicy({ ...base, template: 'Bearer token' })).toBeNull();
+  });
+});
+
+describe('parseBoundaryHosts', () => {
+  test('lowercases, splits on commas and newlines, and drops duplicates', () => {
+    expect(parseBoundaryHosts('API.Example.com, api.example.com\nuploads.example.com  ')).toEqual([
+      'api.example.com',
+      'uploads.example.com',
+    ]);
+  });
+
+  test('reads an empty field as no hosts', () => {
+    expect(parseBoundaryHosts('   \n , ')).toEqual([]);
+  });
+});
+
+/**
+ * The incident this text exists for: an agent probed an echo endpoint, read the
+ * cut connection as a dead host, and invented a TLS explanation. Nothing in the
+ * product said the boundary was there.
+ */
+describe('networkBoundaryEchoNotice', () => {
+  test('names the symptom and denies the wrong conclusion', () => {
+    const notice = networkBoundaryEchoNotice('api.stripe.com');
+    expect(notice.body).toContain('curl: (52) Empty reply from server');
+    expect(notice.body).toContain('the boundary working, not the host being down');
+  });
+
+  test('probes the first declared host with a credential-consuming request', () => {
+    const notice = networkBoundaryEchoNotice('API.Stripe.com\nuploads.stripe.com');
+    expect(notice.probe).toContain('https://api.stripe.com/');
+    expect(notice.probe).toContain('never one that echoes headers');
+    expect(notice.probe).toContain('200 = the header arrived. 401 = it did not.');
+  });
+
+  test('falls back to a placeholder host before anything is typed', () => {
+    expect(networkBoundaryEchoNotice('').probe).toContain('https://api.example.com/');
+  });
+
+  test('points at the two-probe procedure in the docs', () => {
+    const notice = networkBoundaryEchoNotice('api.stripe.com');
+    expect(notice.docsHref).toBe('/docs/project/secrets#verify-it-with-two-probes');
+    expect(notice.docsLabel).toBe('Verify it with two probes');
+  });
+
+  test('never suggests looking for the value in the sandbox', () => {
+    const notice = networkBoundaryEchoNotice('api.stripe.com');
+    const text = `${notice.title} ${notice.body} ${notice.probe}`;
+    expect(text).not.toContain('env ');
+    expect(text).not.toContain('{{secret}}');
+    expect(text.toLowerCase()).not.toContain('authorization:');
   });
 });

--- a/apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts
@@ -538,20 +538,31 @@ const HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 const EXACT_HOST =
   /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 
+/** The hosts the textarea declares: lowercased, deduplicated, first-seen order.
+ *  The policy and the verification probe both read the list from here, so the
+ *  host the user is told to probe is a host the boundary actually watches. */
+export function parseBoundaryHosts(hosts: string): string[] {
+  return [
+    ...new Set(
+      hosts
+        .split(/[\s,]+/)
+        .map((host) => host.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ];
+}
+
 export function buildNetworkBoundaryPolicy(
   form: NetworkBoundaryPolicyForm,
 ): SecretEgressPolicy | null {
-  const hosts = form.hosts
-    .split(/[\s,]+/)
-    .map((host) => host.trim().toLowerCase())
-    .filter(Boolean);
+  const hosts = parseBoundaryHosts(form.hosts);
   const target = form.injectionTarget.trim();
   const template = form.template.trim();
   if (hosts.length === 0 || hosts.some((host) => !EXACT_HOST.test(host))) return null;
   if (!HEADER_NAME.test(target)) return null;
   if (template && !template.includes('{{secret}}')) return null;
   return {
-    rules: [...new Set(hosts)].map((host) => ({ host })),
+    rules: hosts.map((host) => ({ host })),
     inject: {
       kind: 'header',
       name: target,
@@ -559,6 +570,43 @@ export function buildNetworkBoundaryPolicy(
     },
     on_no_match: 'deny',
     tls: 'terminate',
+  };
+}
+
+export type NetworkBoundaryEchoNotice = {
+  title: string;
+  /** The symptom, then what it actually means. */
+  body: string;
+  /** The shell probe that separates a working boundary from a missing header. */
+  probe: string;
+  docsHref: string;
+  docsLabel: string;
+};
+
+/**
+ * The one thing about this mode nobody can deduce from inside the sandbox.
+ *
+ * The boundary cuts any response that would carry the value back into the
+ * guest, so an echo endpoint answers `curl: (52) Empty reply from server` —
+ * byte-identical to a dead host. A product owner lost days to exactly that
+ * reading, and their agent invented a TLS explanation for it. The panel that
+ * configures the mode is the last place to say so before someone tests it.
+ *
+ * The probe names the first declared host so it can be pasted as-is; with no
+ * host typed yet it falls back to a placeholder rather than an empty URL.
+ */
+export function networkBoundaryEchoNotice(hosts: string): NetworkBoundaryEchoNotice {
+  const host = parseBoundaryHosts(hosts)[0] ?? 'api.example.com';
+  return {
+    title: 'A blocked echo looks exactly like a dead host',
+    body: 'A response that would carry this value back into the sandbox is cut, so curl reports "curl: (52) Empty reply from server". On an allowed host that is the boundary working, not the host being down.',
+    probe: [
+      '# Probe an endpoint that USES the credential, never one that echoes headers.',
+      `curl -s -o /dev/null -w '%{http_code}\\n' https://${host}/<authenticated-path>`,
+      '# 200 = the header arrived. 401 = it did not.',
+    ].join('\n'),
+    docsHref: '/docs/project/secrets#verify-it-with-two-probes',
+    docsLabel: 'Verify it with two probes',
   };
 }
 

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.delivery.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.delivery.test.ts
@@ -189,6 +189,31 @@ describe('SecretsView states the cost of an empty header template', () => {
   });
 });
 
+/**
+ * The panel is the last surface before someone tests the boundary by hand. The
+ * text has to come from the helper, because a hardcoded copy here drifts from
+ * the hosts the user typed and stops naming a host they can actually probe.
+ */
+describe('SecretsView states the echo caveat in the boundary panel', () => {
+  const panel = sliceBetween("{strategy === 'egress' && (", "{strategy === 'broker' && (");
+
+  test('the scan found the network-boundary panel', () => {
+    expect(panel.length).toBeGreaterThan(0);
+  });
+
+  test('the caveat is derived from the declared hosts, not hardcoded', () => {
+    expect(code).toContain('const echoNotice = networkBoundaryEchoNotice(brokerHosts);');
+    expect(panel).toContain('title={echoNotice.title}');
+    expect(panel).toContain('{echoNotice.body}');
+    expect(panel).toContain('{echoNotice.probe}');
+    expect(panel).toContain('href={echoNotice.docsHref}');
+  });
+
+  test('the old sentence that never said what the block looks like is gone', () => {
+    expect(code).not.toContain('Secret values echoed by an upstream response are blocked');
+  });
+});
+
 describe('agentGrantPlan', () => {
   const declarative = (
     agents: AgentGrantConfig['agents'],

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -9,6 +9,7 @@ import {
   PlusIcon as Plus,
 } from '@phosphor-icons/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import Link from 'next/link';
 import { type FormEvent, useCallback, useMemo, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
@@ -108,6 +109,7 @@ import {
   missingAgentGrantNotice,
   networkBoundaryAvailability,
   networkBoundaryBlockedReason,
+  networkBoundaryEchoNotice,
   secretDeliveryBlockedReason,
   secretDeliveryOptions,
   secretDeliveryPresentation,
@@ -930,6 +932,7 @@ function SecretDialog({
     networkBoundary,
   );
   const networkBoundaryNotice = networkBoundaryBlockedReason(networkBoundary);
+  const echoNotice = networkBoundaryEchoNotice(brokerHosts);
   // The dialog keeps the row it opened with, so a completed grant clears its own
   // warning — the refetch only reaches the table behind it.
   const grantNotice =
@@ -1175,8 +1178,23 @@ function SecretDialog({
                   )}
 
                   <InfoBanner tone="neutral" title="Not readable inside the sandbox">
-                    The sandbox receives no value, alias, or placeholder. Secret values echoed by an
-                    upstream response are blocked at the boundary.
+                    The sandbox receives no value, alias, or placeholder. The agent sends an
+                    ordinary request and the header appears in flight.
+                  </InfoBanner>
+
+                  <InfoBanner tone="neutral" title={echoNotice.title}>
+                    <span className="block text-pretty">{echoNotice.body}</span>
+                    <pre className="border-border bg-muted mt-2 overflow-x-auto rounded-sm border p-2 font-mono text-xs leading-relaxed">
+                      {echoNotice.probe}
+                    </pre>
+                    <Link
+                      href={echoNotice.docsHref}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-muted-foreground hover:text-foreground mt-2 inline-block text-xs underline underline-offset-2"
+                    >
+                      {echoNotice.docsLabel}
+                    </Link>
                   </InfoBanner>
 
                   <Field>

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -1,0 +1,270 @@
+# Network-boundary secrets on Daytona
+
+**Status:** proposal, awaiting one blocking experiment
+**Author:** drafted 2026-08-11
+**Problem owner:** production runs on Daytona; the feature exists only on Platinum
+
+---
+
+## 1. The problem in one paragraph
+
+A *network-boundary* secret (`strategy:'egress'`, `consumer:'network'`) is delivered by the
+**Platinum** sandbox provider: Kortix registers the credential with Platinum at session
+provision, and Platinum's egress proxy terminates TLS and injects a header on outbound
+requests to allow-listed hosts. The sandbox never receives the value — no env var, no alias,
+no placeholder. **Production runs on Daytona**, where
+`syncProviderNetworkBoundary` throws `Sandbox provider daytona does not support
+network-boundary secret delivery`. So no paying customer can use the feature.
+
+## 2. What we are actually protecting against
+
+Two different goals get conflated. Separating them decides the architecture.
+
+| Goal | Statement | Who it defends against |
+| --- | --- | --- |
+| **Confidentiality** | The agent never possesses the credential | a leaky or compromised agent, prompt injection, logs, `env` dumps |
+| **Transparency** | The agent uses an ordinary HTTP client and the credential appears in flight | developer effort; nothing security-related |
+
+Platinum's boundary delivers both. **Most of the value is confidentiality.** Transparency is
+ergonomics. This matters because we already ship a confidentiality-equivalent mechanism that
+works on Daytona today (§5).
+
+## 3. Measured facts
+
+Everything here was probed on live dev sandboxes on 2026-08-11, not read off a doc.
+
+### 3.1 Guest privilege — the same on both providers
+
+| | Platinum | Daytona |
+| --- | --- | --- |
+| PID 1 | `pt-init` as **root** | `daytona` as `kortix` (uid 1001) |
+| own kernel | yes (`kthreadd`, `kworker` visible) | no — Docker, bridge `172.20.0.0/16` |
+| agent uid | `kortix` (1001) | `kortix` (1001) |
+| `CapEff` / `CapPrm` | `0000000000000000` | `0000000000000000` |
+| **`sudo -n id`** | — | **`uid=0(root)`** |
+| `iptables` / `nft` in image | absent | absent |
+| direct egress | — | works (200 to `api.github.com`) |
+| CA store agent-writable | — | no (but sudo makes that moot) |
+
+**The agent has passwordless root** (`apps/sandbox/Dockerfile:94-96`, `NOPASSWD:ALL`). An
+earlier draft of this analysis claimed the agent was unprivileged and that a root-owned boot
+step could install egress rules it could not remove. That was wrong — a silent `sudo -n true`
+was misread as failure. Any in-guest rule is removable with `sudo iptables -F`.
+
+> **Conclusion:** in-guest enforcement is not viable on **either** provider. Enforcement must
+> live outside the guest.
+
+### 3.2 What Daytona offers outside the guest
+
+The pinned SDK (`@daytonaio/sdk@0.184.0`) exposes, at create **and** live via
+`sandbox.updateNetworkSettings()`:
+
+- `networkBlockAll` — default-deny egress
+- `networkAllowList` — CIDR allow-list
+- `outboundProxyUrl` — chain egress to a proxy **you** operate
+
+Documented as *"the runner applies iptables rules to the sandbox container"* — i.e. on the
+host, outside guest control. **We pass none of these today.**
+
+What Daytona does **not** have: a secret store, TLS termination, header injection, or any
+`on_echo` equivalent. Zero of the ten Platinum primitives the boundary depends on. So the
+feature cannot be ported provider-natively; it can only be **rebuilt** with Daytona supplying
+the funnel and Kortix supplying the injection.
+
+### 3.3 The claim the whole design rests on
+
+Daytona's docs state: *"Clients that do not respect `HTTP_PROXY` are blocked at egress."*
+
+If true, `outboundProxyUrl` is an **enforced** chaining point and a Kortix-operated proxy gets
+the same class of guarantee as Platinum. If false, it is **cooperative** and a determined agent
+walks around it. **This is unverified and is the first thing to test** (§7).
+
+## 4. Prior art
+
+The pattern is well-trodden; we should position against it rather than invent.
+
+- **Anthropic's Claude Code sandbox** — `credentials.envVars` with `mode:"mask"`, `injectHosts`,
+  `network.tlsTerminate`. Closest public analogue to what we want.
+- **Vercel Sandbox** — credential brokering + a documented firewall model.
+- **Cloudflare Sandbox** — outbound Workers.
+- **IETF draft "Credential Broker for Agents" (CB4A)**, Model A "Proxy Gateway" — names the
+  pattern.
+- **CyberArk Secretless Broker**, **Vault Agent/Proxy**, **Envoy ext_authz**, **Squid/mitmproxy
+  with a private CA** — the older generation.
+
+Convergent design across all of them:
+
+1. Terminate TLS **only** for hosts that have an injection rule; never blanket-MITM.
+2. Mint a **per-sandbox ephemeral CA**, push it into the system trust bundle *and* the ~11
+   per-runtime env vars (`NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, …).
+3. Enforce at the host/hypervisor, **never with `HTTP_PROXY` alone**.
+4. Give the guest a **placeholder**, not nothing, so tools that read the variable still work.
+
+Two places we are unusual:
+
+- **"Guest sees nothing at all"** is the strictest variant. Most vendors substitute a
+  placeholder. Ours breaks any tool that insists on reading the env var.
+- **`on_echo` response blocking appears to be genuinely rare.** No vendor found documents it.
+  One (iron-proxy) explains why: buffering responses end-to-end to scan them stalls the client.
+  Ours cuts the connection instead, which is cheaper but produces `curl: (52) Empty reply` —
+  the single biggest source of "this feature is broken" reports we have had.
+
+## 5. The option we already own
+
+`strategy:'broker'` + `consumer:'http_broker'` (backend `kortix_fetch`) is **provider-agnostic
+and works on Daytona today**. Route `POST /v1/projects/:projectId/secrets/:identifier/broker`,
+executed by `apps/api/src/secrets/http-broker.ts` from the API process. Verified on a live
+Daytona session: saves clean, `delivery_status: 'available'`, and the in-sandbox `kortix` CLI is
+session-authenticated.
+
+Compared with the network boundary:
+
+| | boundary (`egress`/`network`) | broker (`broker`/`http_broker`) |
+| --- | --- | --- |
+| credential in sandbox | never | never |
+| works on Daytona | **no** | **yes, today** |
+| host matching | exact only | wildcards, paths, methods |
+| injection slots | one header | header, query, JSON body |
+| per-request audit | no | **yes** |
+| transparent to the agent | **yes** | no — must call `kortix secrets call` |
+| TLS interception needed | yes (Platinum's) | **none** |
+
+On **confidentiality the broker is equal**, on **authorization and audit it is stronger**, and
+it needs no MITM. Its only deficit is transparency. An agent that ignores the broker does not
+get a weaker credential — it gets **no** credential.
+
+**Why customers do not have it: reach, not capability.** `kortix secrets call` is a string in a
+system-prompt file. There is no MCP tool for it
+(`apps/cli/src/connector-gateway/mcp.ts` has eight connector tools and no secret tool), and
+models reach for tools far more reliably than for documented shell commands.
+
+## 6. Recommendation — two tracks, in this order
+
+### Track A — make the broker the production answer (start now, low risk)
+
+The fastest path to a real capability for Daytona customers.
+
+1. **Add an MCP tool** for the broker so the model discovers it the way it discovers everything
+   else. Highest-leverage single change in this doc.
+2. **Stop offering `egress` on projects that cannot run it.** Already partly done — the UI now
+   gates on the project's active provider — but the *strategy picker* should present the broker
+   as the Daytona-native option rather than showing a disabled control.
+3. **Fix the dead limb**: `broker`/`git_proxy` advertises `delivery_status:'available'`
+   (`apps/api/src/projects/lib/serializers.ts:451`) while no execution path implements it.
+4. **Docs**: one page, "which delivery mode do I want", with the table from §5.
+
+### Track B — an enforced Kortix egress proxy (gated on the §7 experiment)
+
+Daytona supplies the non-bypassable funnel; Kortix supplies everything Platinum's edge does.
+
+```
+guest ──(runner iptables: block-all + allow only proxy)──▶ Kortix egress proxy ──▶ upstream
+                                                            │
+                                                            ├─ per-sandbox ephemeral CA
+                                                            ├─ inject header for policy hosts
+                                                            ├─ pass through everything else
+                                                            └─ on_echo response handling
+```
+
+Non-negotiables:
+
+- **Selective termination.** MITM only hosts with an injection rule. Everything else is
+  `CONNECT`-tunnelled untouched. This bounds the blast radius and avoids breaking pinned TLS.
+- **Ephemeral per-sandbox CA**, minted at provision, destroyed with the sandbox. Never a
+  long-lived Kortix root in a customer image.
+- **We become a credential-handling MITM.** That is a real compliance and blast-radius change
+  and must be an explicit decision, not a side effect. Document the threat model before code.
+- **Honest labelling.** If the §7 experiment fails, the UI must say *cooperative on Daytona,
+  enforced on Platinum* — in the product, not only in docs.
+
+## 6b. EXPERIMENT RESULT — the funnel is real and root-proof
+
+Run 2026-08-11 against `api.daytona.io` with a throwaway sandbox on
+`kortix-default-b539f1be09d3`, driving the SDK directly (no Kortix code in the path).
+
+**`networkBlockAll: true`**
+
+| probe | result |
+| --- | --- |
+| `curl https://api.github.com/rate_limit` | `000` |
+| `curl --noproxy '*'` | `000` |
+| raw Python socket to `140.82.121.6:443` | **Connection refused** |
+| DNS (`getent hosts`) | timeout |
+| **`sudo -n curl`** (as **root**) | **`000`** |
+| `sudo -n iptables -F` | `iptables: command not found` |
+| control: same sandbox, `networkBlockAll: false` | all **200 / CONNECTED** |
+
+**`networkAllowList: 140.82.112.0/20`** (GitHub's range; `networkBlockAll` must be OFF —
+the two are mutually exclusive, `400 DaytonaValidationError`)
+
+| probe | result |
+| --- | --- |
+| allowed CIDR, by IP | **200** |
+| allowed host **by DNS name** | `000` |
+| `1.1.1.1`, `example.com` | `000` |
+| **root**, not-allowed host | `000` |
+
+**Verdicts**
+
+1. **Daytona's egress control is enforced on the runner and root inside cannot bypass it.**
+   `iptables` is not even present in the guest because the rules do not live there. This is a
+   genuine non-bypassable funnel — the precondition for Track B. The `outboundProxyUrl`
+   enforcement claim no longer has to be taken on faith; the same mechanism demonstrably holds
+   against root.
+2. **`networkBlockAll` and the allow-lists are mutually exclusive.** Allow-list mode is
+   `networkAllowList` alone. The SDK error also reveals a `domainAllowList`, which is not in the
+   typings we read and should be investigated — a domain allow-list would solve DNS more cleanly
+   than a CIDR one.
+3. **DNS is the first real design constraint.** With a CIDR allow-list, name resolution fails —
+   the resolver is not in the list, so only literal IPs work. Track B must either allow the
+   resolver explicitly, resolve names at the proxy (guest sends `CONNECT host:443` to the proxy
+   and never resolves anything itself), or use `domainAllowList`. **Proxy-side resolution is the
+   right answer** and is what the prior art does.
+
+## 7. Remaining experiment — `outboundProxyUrl` specifically
+
+§6b removes the risk from this, but the proxy path itself is still unexercised.
+
+1. Create a Daytona sandbox with `outboundProxyUrl` pointed at a sink we control.
+2. From inside the guest, attempt egress that deliberately ignores the proxy:
+   - `curl --noproxy '*' https://api.github.com/rate_limit`
+   - a raw Python socket to a public IP on 443
+   - an outbound SSH connection
+   - the same three again after `sudo -i`
+3. **If all are dropped** → proceed. (§6b already shows the enforcement mechanism holds against
+   root, so the expected answer is yes; this confirms it for the proxy-chaining path specifically.)
+4. **If any succeeds** → belt-and-braces: pin egress with `networkAllowList` restricted to the
+   proxy's CIDR, which §6b proves is enforced. Either way Track B is viable.
+
+Secondary experiments, only if (3): `networkBlockAll` + `networkAllowList` restricted to the
+proxy CIDR, live `updateNetworkSettings()` on a running sandbox, and behaviour on
+resume/CoW-restore.
+
+## 8. What I would not build
+
+- **In-guest iptables enforcement.** Dead on both providers (§3.1). Even granting `NET_ADMIN`
+  is self-defeating while the agent holds `NOPASSWD:ALL`.
+- **Blanket TLS interception.** Breaks pinned clients and mTLS, and makes us MITM for traffic
+  that has nothing to do with any secret.
+- **`HTTP_PROXY` alone, sold as a boundary.** Every prior-art implementation warns against it,
+  and it would be a security claim we cannot support.
+
+## 9. Open questions
+
+1. Does `outboundProxyUrl` block non-conforming clients on its own? (§7 — no longer blocking:
+   `networkAllowList` is proven enforced and can pin egress to the proxy regardless.)
+1b. What is `domainAllowList`? It appears in a server-side validation error but not in the
+   typings we read. A domain allow-list may remove the DNS problem entirely.
+2. Are we willing to operate a credential-handling MITM for customer traffic, with the
+   compliance surface that implies?
+3. Should the guest get a **placeholder** instead of nothing, matching the rest of the industry?
+   It would fix tools that insist on reading the variable, at the cost of our strictest property.
+4. Can `on_echo` be preserved through a Kortix proxy without stalling responses, or do we accept
+   header-only protection off Platinum?
+
+## 10. Related
+
+- `docs/SECRET_DELIVERY_CONTROL_PLANE.md` — the shipped control plane
+- `apps/web/content/docs/project/secrets.mdx` — the user-facing explainer
+- `.claude/skills/learnings/SKILL.md` — "A per-turn hot path must not contain an unbounded
+  third-party round-trip", the incident that came out of this feature


### PR DESCRIPTION
A network-boundary secret was invisible to everything inside the sandbox. The agent made a request to a
policy host, hit the `on_echo` cut, saw `curl: (52) Empty reply from server`, concluded the host was down
and **invented an explanation** — "postman-echo is a legacy service, the proxy's HTTP/1.1 ALPN negotiation
triggers a connection reset". Three tool rounds, and days of debugging, for a feature that was working
correctly the whole time.

Nothing in the product told the agent — or the user — that the host was under a boundary policy.

## What the agent now reads

```
- `STRIPE_KEY`: network boundary. Kortix adds the `authorization` header to your HTTPS
  requests to api.stripe.com — outside this sandbox. Send the request normally and add
  no credential of your own.

## Network boundary
- The value is not in this sandbox: no environment variable, no file, no alias, no placeholder.
- Do not search for the value, do not ask the user for it, and do not build the header yourself.
- A response that would echo the value back into the sandbox is cut mid-flight.
- So `curl: (52) Empty reply from server` on a listed host means the boundary worked. The host is not down.
- Verify with an endpoint that CONSUMES the credential and returns 200 or 401, never one that
  reflects request headers.
- A listed host that answers 401 means the header did not arrive. Report that; do not invent a credential.
```

The catalog carries hosts, header, `scheme: https`, `readable_in_sandbox: false`, `on_echo: block` — and
**never** the value, the alias, or the header template, so the agent cannot assemble the header itself.
A test asserts the serialized catalog contains none of them.

## The half that was silently dropped

`apps/kortix-sandbox-agent-server/src/secret-capabilities.ts` allow-listed three delivery values, so a
`network` capability was **discarded before rendering**. That file is what OpenCode loads as an
`instructions` file — the channel the model actually reads. The env var had the data; the prompt didn't.

It now renders the entry, and renders the rules **the API authored** rather than restating them, so the two
cannot drift. A host or header that doesn't look like one is dropped rather than echoed into the prompt.

## Anti-drift

The API-side test runs the same secret row through `resolveNetworkBoundaryBindings` — the resolver the
provider edge actually arms from — and asserts the advertised hosts/header/on_echo equal the armed
binding's, while asserting the binding still carries the credential the catalog must not.

## Verified

- Real API builder → real daemon renderer, end to end: host named, header named, echo cut explained,
  value/alias/template absent.
- `apps/kortix-sandbox-agent-server`: **487 pass / 0 fail** (5 new).
- `apps/api`: 12 pass on the capabilities suite; **1254 pass / 0 fail** across `src/projects` + `src/secrets`.
- `apps/web`: 101 pass on the two changed suites; directory run +10 passing, +0 failing vs a stashed baseline.
- `tsc` clean in every touched file, all three packages.

⚠️ **The daemon is image-baked.** This reaches new sandboxes only after a snapshot rebuild, not on deploy.

## Also in this PR

`docs/NETWORK_BOUNDARY_ON_DAYTONA.md` — the design proposal for making this work on Daytona, where
production actually runs. Records the measured guest privilege on both providers (the agent has
`NOPASSWD:ALL` sudo, so in-guest enforcement is dead everywhere), what Daytona offers outside the guest
(`networkBlockAll` / `networkAllowList` / `outboundProxyUrl`, runner-enforced), the broker we already ship
that works there today, and the single unverified vendor claim the proxy design rests on.