### PR TITLE
feat: turn the connectors MCP face on for every session

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,24 @@ linked, not inlined.
 
 ## Register
 
+### A deployed API is not a deployed daemon (2026-08-12)
+
+**When:** shipping any change to `apps/kortix-sandbox-agent-server`, or turning
+on something that depends on one. `/health` reporting your commit proves the API
+rolled; it says nothing about the sandbox. The daemon is gzipped into the
+snapshot build context (`apps/api/src/snapshots/build-context.ts:185`) and
+reaches a session only after that snapshot is rebuilt or agent-swapped
+(`snapshots/templates.ts:613`) AND the warm pool has cycled off the old one.
+Prove it in the guest, not from the API:
+`grep -aoE "<expected literal>" /usr/local/bin/kortix-agent` in a session
+created after the deploy — the Bun-compiled binary embeds its source strings.
+Sequence any dependent flag flip AFTER that probe passes.
+*Incident:* near-miss, same day as the MCP-argv fix below. Deploy Dev went green
+and `dev-api` reported `66b6148d`, but two sandboxes created ~15 min later both
+still had the pre-fix `"connector"` spelling. Merging the flag that enables the
+MCP face on that evidence would have given every session a server whose command
+exits 2 — a broken MCP entry where there had been none.
+
 ### A cross-process command string needs a test that RUNS it (2026-08-12)
 
 **When:** one component spawns another by a hardcoded argv — the daemon's

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -336,6 +336,24 @@ const envSchema = z.object({
   // Manager bundle. Self-host deployments leave it unset.
   ASTER_API_URL: optUrl('https://api.asterlab.ai/v1'),
   ASTER_API_KEY: optStr,
+  // Whether a session's sandbox gets the `kortix-connectors` OpenCode MCP
+  // server (KORTIX_CONNECTORS_MCP_ENABLED in the guest). It exposes the
+  // connector meta-tools plus `secret_call`, the only way to use an
+  // HTTPS-broker secret — those have no env var and no readable value, so
+  // without a tool the model has to find a shell command in a prompt file.
+  //
+  // ON by default: the tools are the discoverable surface for capabilities the
+  // agent already has. This is the operator kill switch — it takes the MCP
+  // server away fleet-wide without a code change.
+  //
+  // optBoolTrue disables on the literal string `false` ONLY: `0`, `no` and
+  // `off` all leave it ON. Write `CONNECTORS_MCP_ENABLED=false`.
+  //
+  // The email channel sets the guest variable itself from durable session
+  // metadata (session-channel-env.ts) and keeps the face either way — that
+  // channel was the only consumer before this flag, so turning this off
+  // restores the previous behaviour rather than regressing email sessions.
+  CONNECTORS_MCP_ENABLED: optBoolTrue,
   // Managed LLM gateway (/v1/llm) — the `kortix` OpenCode provider routes every
   // sandbox model call here. Off by default.
   LLM_GATEWAY_ENABLED: optBoolFalse,
@@ -990,6 +1008,7 @@ export const config = {
   OPENROUTER_API_KEY: env.OPENROUTER_API_KEY,
   ASTER_API_URL: env.ASTER_API_URL,
   ASTER_API_KEY: env.ASTER_API_KEY,
+  CONNECTORS_MCP_ENABLED: env.CONNECTORS_MCP_ENABLED,
   LLM_GATEWAY_ENABLED: env.LLM_GATEWAY_ENABLED,
   // Unset → follow billing (cloud keeps its revenue lineup even if the env
   // blob misses the var; self-host stays off). Explicit value always wins.

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -448,6 +448,17 @@ export async function buildSessionSandboxEnvVars(input: {
   const sessionContextEnv = await buildSessionRuntimeContextEnv(input.sessionId);
   return {
     ...runtimeSecrets.env,
+    // Fleet default for the `kortix-connectors` OpenCode MCP server. Set here
+    // rather than in the daemon so it is one operator switch
+    // (CONNECTORS_MCP_ENABLED) instead of a rebuilt sandbox image.
+    //
+    // Written BEFORE channelEnv on purpose: the email channel sets this same
+    // variable from durable session metadata (session-channel-env.ts), and it
+    // must stay authoritative. Spreading it after means switching the fleet
+    // default OFF cannot strip the MCP face from an email session that depends
+    // on it — the operator switch withdraws the default, never a channel's
+    // explicit contract.
+    ...(config.CONNECTORS_MCP_ENABLED ? { KORTIX_CONNECTORS_MCP_ENABLED: '1' } : {}),
     ...channelEnv,
     ...sessionContextEnv,
     KORTIX_PROJECT_SECRET_NAMES: runtimeSecrets.names.join(','),

--- a/apps/kortix-sandbox-agent-server/src/__tests__/env-route-secret-respawn.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/env-route-secret-respawn.test.ts
@@ -285,6 +285,69 @@ describe('env route — project-secret delta forces respawn, not dispose', () =>
     expect(calls[0]!.mustRespawn).toBe(true)
   })
 
+  it('enabling the connectors MCP face mid-session takes the dispose path', async () => {
+    // Pins CURRENT behaviour, which is not obviously the intended one.
+    // `KORTIX_CONNECTORS_MCP_ENABLED` shapes `out.mcp` inside the config file,
+    // so it follows the config-file rule and disposes rather than respawns —
+    // consistent with the invariant in dispose-reload.test.ts.
+    //
+    // But routes/env.ts:21 claims this variable "must restart OpenCode because
+    // MCP servers are registered only at spawn". If that claim is right, the
+    // email channel's mid-session enable (channels/email/session.ts:123, 208)
+    // silently does nothing and this expectation should flip to `true`. Nobody
+    // has measured which is true against the pinned opencode — see the note on
+    // RESPAWN_REQUIRED_ENV_NAMES in opencode.ts.
+    const { opencode, calls } = fakeOpencode()
+    const store = createProjectEnvStore({
+      KORTIX_PROJECT_SECRETS_REVISION: 'rev-1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY',
+      API_KEY: 'v1',
+    } as NodeJS.ProcessEnv)
+    const app = buildTestApp(opencode, store)
+
+    const { status } = await postEnv(app, {
+      revision: 'rev-1',
+      env: { API_KEY: 'v1' },
+      names: ['API_KEY'],
+      refreshModels: true,
+      opencodeEnv: { KORTIX_CONNECTORS_MCP_ENABLED: '1' },
+    })
+
+    expect(status).toBe(200)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.mustRespawn).toBe(false)
+  })
+
+  it('re-pushing the SAME connectors-MCP value does not reload at all', async () => {
+    // The fleet default now sets this at boot, so it is present on every box
+    // and gets re-sent by any caller that includes it. Respawning on an
+    // unchanged value would put an ~8s restart on a routine push — the route
+    // compares against process.env before marking the name changed, so an
+    // identical value produces no reload whatsoever, not merely a cheap one.
+    const { opencode, calls } = fakeOpencode()
+    const store = createProjectEnvStore({
+      KORTIX_PROJECT_SECRETS_REVISION: 'rev-1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY',
+      API_KEY: 'v1',
+    } as NodeJS.ProcessEnv)
+    const app = buildTestApp(opencode, store)
+    process.env.KORTIX_CONNECTORS_MCP_ENABLED = '1'
+    try {
+      const { status } = await postEnv(app, {
+        revision: 'rev-1',
+        env: { API_KEY: 'v1' },
+        names: ['API_KEY'],
+        refreshModels: true,
+        opencodeEnv: { KORTIX_CONNECTORS_MCP_ENABLED: '1' },
+      })
+
+      expect(status).toBe(200)
+      expect(calls).toHaveLength(0)
+    } finally {
+      delete process.env.KORTIX_CONNECTORS_MCP_ENABLED
+    }
+  })
+
   it('a byte-identical push (no change at all) does not reload opencode', async () => {
     // The boot-revision-matches guard is unchanged: nothing moved, nothing to
     // reload. This is the contract the proxy-auth "matches the boot revision"

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -98,6 +98,28 @@ export const RESPAWN_REQUIRED_ENV_NAMES = [
   SECRET_CAPABILITIES_ENV_NAME,
 ] as const
 
+/**
+ * NOT in the list above, deliberately: `KORTIX_CONNECTORS_MCP_ENABLED`.
+ *
+ * It shapes `out.mcp` INSIDE the config file, and `tryDisposeReload` rewrites
+ * that file and makes opencode re-read it — so it belongs to the dispose fast
+ * path by the same rule as every other config-file key.
+ *
+ * Flagged because two comments in this repo disagree and one of them is wrong:
+ * `routes/env.ts` says enabling the face "must restart OpenCode because MCP
+ * servers are registered only at spawn", which would make dispose insufficient
+ * for the email channel's mid-session enable (channels/email/session.ts:123,
+ * 208). Whether `POST /global/dispose` re-registers a server that was not
+ * previously in the set is UNVERIFIED against the pinned opencode.
+ *
+ * Left alone rather than guessed at: adding it here breaks the tested
+ * invariant in dispose-reload.test.ts ("every name spawnChild consumes outside
+ * the config file is listed") and would buy an ~8s respawn for a case nobody
+ * has measured. Resolve it with a live sandbox — enable the face mid-session,
+ * then ask opencode whether the server is registered — and update whichever
+ * comment turns out to be false.
+ */
+
 /** Does this env delta need a full respawn rather than a dispose? */
 export function requiresRespawn(changedNames: readonly string[]): boolean {
   return changedNames.some((name) =>


### PR DESCRIPTION
Turns `KORTIX_CONNECTORS_MCP_ENABLED` on fleet-wide, so every session gets the
`kortix-connectors` MCP server — including `secret_call`, which is the only way
to use an HTTPS-broker secret (no env var, no readable value).

## ⚠️ Do not merge before the daemon fix is in sandbox images

Depends on `66b6148d` (#6407), which corrected the registered MCP command from
`connector` to `connectors`. Merging this first would hand every session an MCP
entry whose command exits 2 — a broken server instead of no server.

The daemon binary is gzipped into the snapshot build context by the API
(`apps/api/src/snapshots/build-context.ts:185`), so the fix reaches sandboxes
via the API image. **Gate: confirm a freshly created dev sandbox registers
`['/usr/local/bin/kortix','connectors','mcp']` before merging.**

## Correction to #6407's description

That PR said blast radius was zero because the flag "appears only in tests".
**That was wrong** — I read a `head`-truncated grep and then confirmed it with a
second grep that excluded `.ts` files. The real producers:

- `apps/api/src/projects/lib/session-channel-env.ts:27` — every email-origin
  session, derived from durable metadata
- `apps/api/src/channels/email/session.ts:123,208,272` — boot and mid-session

So **email-channel sessions have had a dead MCP server since 2026-08-06**, losing
all eight connector meta-tools. Non-zero, and user-visible for that channel.

## Design

- `CONNECTORS_MCP_ENABLED` (config.ts) is the operator kill switch, default on.
  `optBoolTrue` disables on the literal `false` only — `0`/`no` leave it on, so
  the comment says so.
- Injected in `buildSessionSandboxEnvVars` **before** `...channelEnv`, so the
  email channel stays authoritative. Turning the fleet default off then
  withdraws a default; it cannot strip the face from a session that depends on it.

## An invariant I tripped over

I first added `KORTIX_CONNECTORS_MCP_ENABLED` to `RESPAWN_REQUIRED_ENV_NAMES`,
reasoning from the comment at `routes/env.ts:21` ("MCP servers are registered
only at spawn"). `dispose-reload.test.ts` failed and was right to: that list is
for env consumed *outside* the config file, which a dispose physically cannot
redo. This variable shapes `out.mcp` **inside** the config file, which
`tryDisposeReload` rewrites and re-reads.

Reverted. Two repo comments contradict each other and I could not settle it
without a live measurement, so instead of guessing I left behaviour unchanged,
documented the conflict on `RESPAWN_REQUIRED_ENV_NAMES`, and added a test that
pins current behaviour with the open question written into it.

## Verified

- `apps/kortix-sandbox-agent-server`: 489 pass / 0 fail (2 new)
- daemon `tsc --noEmit`: clean
- `apps/api` `tsc --noEmit`: my files clean; 12 remaining errors byte-identical
  with the change stashed (pre-existing worktree dep gaps)

## Not verified

Whether a mid-session enable actually registers the server via dispose. Affects
the email channel's `continueSession` path only, and is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)