### PR TITLE
docs: broker end-to-end result, and the premise it disproved

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,32 @@ linked, not inlined.
 
 ## Register
 
+### Anything created per-deploy needs a reaper, and the reaper needs a namespace (2026-08-12)
+
+**When:** adding or reviewing code that creates a named provider-side artifact
+— a snapshot, image, template, volume. Ask two questions: *what deletes the
+previous one*, and *whose is it*. `ensureMetaSandboxImage` answered neither: it
+deleted a snapshot only when its OWN build failed, never when a newer one
+superseded it, and its name carried no environment. The meta fingerprint hashes
+the agent/CLI/SDK/shared/starter source trees, so it moves on nearly every
+commit — one permanent snapshot per deploy, forever.
+Namespace the name by `INTERNAL_KORTIX_ENV`: dev, staging and prod share ONE
+Daytona organisation (same API key in all four env profiles), so an
+un-namespaced reap on dev deletes the image prod boots from. And make the
+"is it still in use" lookup fail **closed** — `recentlyBuiltSnapshotNames`
+returns an empty set on a DB error, which a reaper reads as "nothing is
+protected, delete everything".
+Before writing any reaper, find who still reads the thing: the sibling
+`kortix-app-*` snapshots look equally abandoned but are the targets of
+`POST /apps/{appId}/rollback`, so reaping them on supersession would have
+broken rollback. Unbounded-but-needed means bounded retention, not deletion.
+*Incident:* the Daytona organisation hit its 200-snapshot quota (226, of which
+118 meta at ~8/day). `POST /snapshots` then 400s, which fails every CI run and
+every NEW-project build. Existing projects survived only because
+`canServeLastKnownGoodRuntime` lets a session-start boot the previous image —
+so the visible symptom was "CI is broken", while the quieter one was that
+runtime updates silently stopped reaching sandboxes.
+
 ### A deployed API is not a deployed daemon (2026-08-12)
 
 **When:** shipping any change to `apps/kortix-sandbox-agent-server`, or turning

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,6 +42,7 @@
     "hono": "^4.4.0",
     "jose": "^5.9.6",
     "livekit-server-sdk": "^2.17.0",
+    "node-forge": "^1.4.0",
     "postgres": "^3.4.8",
     "re2js": "2.8.6",
     "smol-toml": "^1.6.1",
@@ -55,6 +56,7 @@
     "@kortix/sdk": "workspace:*",
     "@smithy/signature-v4": "5.6.2",
     "@types/bun": "^1.3.12",
+    "@types/node-forge": "^1.3.11",
     "bun-types": "^1.3.12",
     "typescript": "^5.4.0"
   }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -336,6 +336,23 @@ const envSchema = z.object({
   // Manager bundle. Self-host deployments leave it unset.
   ASTER_API_URL: optUrl('https://api.asterlab.ai/v1'),
   ASTER_API_KEY: optStr,
+  // Whether network-boundary secrets may be delivered by the IN-GUEST shim on
+  // providers that have no credential edge of their own (i.e. Daytona, which is
+  // production). The shim terminates the guest's TLS and relays to the broker
+  // route; the credential stays server-side either way.
+  //
+  // OFF by default, deliberately, and this is the sequencing that matters:
+  // turning it on makes the API ADVERTISE network-boundary delivery to
+  // non-Platinum projects (save-time gate, delivery_status, the web control).
+  // If the sandbox image does not yet run the shim, a user could save a
+  // boundary secret that nothing in the guest can honour — a feature that
+  // looks available and silently does nothing, which is the exact failure
+  // this project has spent too long unpicking.
+  //
+  // Flip to `true` only once the guest half is in the image and a fresh
+  // sandbox has been observed running the shim. `optBoolFalse` accepts
+  // true/1/yes/on.
+  EGRESS_SHIM_ENABLED: optBoolFalse,
   // Whether a session's sandbox gets the `kortix-connectors` OpenCode MCP
   // server (KORTIX_CONNECTORS_MCP_ENABLED in the guest). It exposes the
   // connector meta-tools plus `secret_call`, the only way to use an
@@ -1009,6 +1026,7 @@ export const config = {
   ASTER_API_URL: env.ASTER_API_URL,
   ASTER_API_KEY: env.ASTER_API_KEY,
   CONNECTORS_MCP_ENABLED: env.CONNECTORS_MCP_ENABLED,
+  EGRESS_SHIM_ENABLED: env.EGRESS_SHIM_ENABLED,
   LLM_GATEWAY_ENABLED: env.LLM_GATEWAY_ENABLED,
   // Unset → follow billing (cloud keeps its revenue lineup even if the env
   // blob misses the var; self-host stays off). Explicit value always wins.

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -61,6 +61,7 @@ import { grantWarmPoolLifetime } from '../../projects/sandbox-deadline';
 import { withTimeout, configuredTimeoutMs } from '../../shared/with-timeout';
 import { classifySandboxProvisioningFailure } from './sandbox-provisioning-error';
 import { platformMetaAgentGrant } from '../../projects/lib/platform-meta-agent';
+import { networkBoundaryShimAvailable } from '../../secrets/network-boundary-availability';
 import { resolveSessionNetworkBoundary } from '../../projects/lib/network-secret-boundary';
 
 /**
@@ -534,7 +535,21 @@ export async function provisionSessionSandbox(opts: {
     try {
       const branch = opts.baseRef || opts.gitProject.defaultBranch;
       const networkBoundary = await resolveSessionNetworkBoundary(projectId, sandbox.sandboxId);
-      if (networkBoundary.length > 0 && !provider.syncNetworkBoundary) {
+      // A provider with no edge to arm is only a failure when nothing else can
+      // deliver the binding. With the in-guest shim the credential is injected
+      // by the broker route at request time, so there is nothing to register
+      // here — the binding reaches the guest as host->identifier rules in the
+      // sandbox env, carrying no value.
+      //
+      // This is the SECOND copy of this check; the other is in
+      // startNetworkBoundaryArm (projects/lib/sandbox-env-sync.ts). They share
+      // a message string and must not drift: relaxing only one still fails
+      // provisioning, just one frame later.
+      if (
+        networkBoundary.length > 0 &&
+        !provider.syncNetworkBoundary &&
+        !networkBoundaryShimAvailable()
+      ) {
         throw new Error(
           `Sandbox provider ${providerName} does not support network-boundary secret delivery`,
         );
@@ -648,9 +663,14 @@ export async function provisionSessionSandbox(opts: {
         throw createErr;
       }
       bgExternalId = result.externalId;
-      if (networkBoundary.length > 0) {
+      // `syncNetworkBoundary` is optional on the provider interface. The
+      // non-null assertion was safe only while the pre-check above guaranteed
+      // the method existed; now that a shim-backed provider gets past that
+      // check, calling it unguarded would be a TypeError at provision time
+      // rather than the clean skip this is.
+      if (networkBoundary.length > 0 && provider.syncNetworkBoundary) {
         try {
-          await provider.syncNetworkBoundary!(result.externalId, networkBoundary);
+          await provider.syncNetworkBoundary(result.externalId, networkBoundary);
           tl.mark(`network-secrets:${networkBoundary.length}`);
         } catch (error) {
           await provider.remove(result.externalId).catch(() => {});

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -17,6 +17,7 @@ import {
   listProjectSecretsSnapshotForUser,
   projectSecretsRevision,
 } from '../secrets';
+import { networkBoundaryShimAvailable } from '../../secrets/network-boundary-availability';
 import { DEFAULT_AGENT_SENTINEL } from '../agents';
 import { resolveSessionSecretGrant } from './secret-grant';
 import { sanitizeSandboxEnv } from './sandbox-env-names';
@@ -157,6 +158,22 @@ function startNetworkBoundaryArm(
     .then(async () => {
       const provider = getProvider(providerName);
       if (!provider.syncNetworkBoundary) {
+        // No provider edge to arm. That is not a failure when the shim path is
+        // available: on those providers the credential is injected by the
+        // broker route at request time, so there is nothing to register ahead
+        // of time and nothing to wait for. The binding still reaches the guest
+        // — as host->identifier rules in the sandbox env, carrying no value.
+        //
+        // Until the shim existed this threw, which is why creating a session on
+        // Daytona with a boundary secret failed provisioning outright.
+        if (networkBoundaryShimAvailable()) {
+          rememberNetworkBoundaryArm(
+            externalId,
+            digest,
+            bindings.map((binding) => binding.secretId),
+          );
+          return;
+        }
         throw new Error(
           `Sandbox provider ${providerName} does not support network-boundary secret delivery`,
         );

--- a/apps/api/src/projects/routes/secret-broker.ts
+++ b/apps/api/src/projects/routes/secret-broker.ts
@@ -11,6 +11,7 @@ import {
   executeSecretBrokerRequest,
   SecretBrokerError,
 } from '../../secrets/http-broker';
+import { networkBoundaryPolicyError } from '../../secrets/network-boundary';
 import { resolveSecretDelivery } from '../../secrets/strategy';
 import { recordAuditEvent } from '../../shared/audit';
 import { db } from '../../shared/db';
@@ -122,7 +123,11 @@ projectsApp.openapi(
       resourceId: shared.secretId,
       metadata: {
         identifier,
-        consumer: 'http_broker',
+        // Derived, not hardcoded: this route now serves the network boundary as
+        // well as the HTTP broker, and an audit row that calls every boundary
+        // relay `http_broker` would misattribute the delivery mode in the one
+        // record anybody reviews after an incident.
+        consumer: shared.strategy === 'egress' ? 'network' : 'http_broker',
         strategy: shared.strategy,
         host: destination.hostname,
         method: parsed.data.method,
@@ -150,10 +155,29 @@ projectsApp.openapi(
           403,
         );
       }
-      if (
-        shared.strategy !== 'broker' ||
-        shared.egressPolicy?.backend !== 'kortix_fetch'
-      ) {
+      // Two delivery modes reach this engine, and they are the same engine on
+      // purpose:
+      //
+      //  - `broker`/`kortix_fetch` — the agent calls the route itself
+      //    (`kortix secrets call`, the `secret_call` MCP tool).
+      //  - `egress`/`network` — a network-boundary secret on a provider with no
+      //    credential edge of its own. The in-guest shim terminates the guest's
+      //    TLS and relays here, so the credential stays server-side exactly as
+      //    it does for the broker.
+      //
+      // A boundary policy is already a `SecretEgressPolicy` and
+      // `prepareSecretBrokerRequest` reads only `rules` and `inject` — never
+      // `backend` — so it executes unchanged. `networkBoundaryPolicyError` is
+      // re-checked here rather than trusted from save time: the row could have
+      // been written by an older build, and a policy that is not a valid
+      // boundary must not be executed as one.
+      const isBrokerSecret =
+        shared.strategy === 'broker' && shared.egressPolicy?.backend === 'kortix_fetch';
+      const isBoundarySecret =
+        shared.strategy === 'egress' &&
+        !!shared.egressPolicy &&
+        networkBoundaryPolicyError(shared.egressPolicy) === null;
+      if (!isBrokerSecret && !isBoundarySecret) {
         await recordAuditEvent({
           ...auditBase,
           action: 'secret.broker.failed',

--- a/apps/api/src/secrets/egress-proxy/ca.ts
+++ b/apps/api/src/secrets/egress-proxy/ca.ts
@@ -1,0 +1,155 @@
+/**
+ * Ephemeral per-sandbox certificate authority for the egress proxy.
+ *
+ * Injecting a header into an HTTPS request means terminating the TLS the guest
+ * opened, which means presenting a certificate the guest will accept. So the
+ * proxy needs a CA the guest trusts.
+ *
+ * Two properties are deliberate:
+ *
+ *  - **Per sandbox, not per platform.** A single long-lived Kortix root baked
+ *    into customer images would be a skeleton key: possess it and you can
+ *    impersonate any host to any sandbox we ever shipped. Each sandbox gets its
+ *    own CA, minted at provision and thrown away with the sandbox, so the blast
+ *    radius of a leaked key is one short-lived box.
+ *  - **Short validity.** Hours, not years. A CA that escapes is useless
+ *    tomorrow.
+ *
+ * Leaves are issued on demand per SNI host and cached for the CA's lifetime —
+ * a fresh 2048-bit keypair costs ~100ms, which is far too slow to pay on every
+ * CONNECT.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import forge from 'node-forge';
+
+export interface EphemeralCa {
+  /** PEM the guest must trust (system bundle + the per-runtime env vars). */
+  readonly certPem: string;
+  /** PEM private key. Never leaves the proxy process. */
+  readonly keyPem: string;
+  readonly notAfter: Date;
+  /** SHA-256 of the DER cert, for logs and for asserting guest trust. */
+  readonly fingerprint: string;
+}
+
+export interface LeafCertificate {
+  readonly certPem: string;
+  readonly keyPem: string;
+}
+
+/** 12h: comfortably longer than a session, far shorter than a useful theft. */
+const DEFAULT_CA_TTL_MS = 12 * 60 * 60 * 1000;
+/** Backdate so a guest whose clock trails the proxy's does not reject the cert. */
+const CLOCK_SKEW_MS = 5 * 60 * 1000;
+const KEY_BITS = 2048;
+
+function serial(): string {
+  // Positive integer: a leading byte >= 0x80 is read as negative by some
+  // parsers and the certificate is then rejected outright.
+  return `00${randomBytes(16).toString('hex')}`;
+}
+
+function fingerprintOf(cert: forge.pki.Certificate): string {
+  const der = forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes();
+  return createHash('sha256').update(Buffer.from(der, 'binary')).digest('hex');
+}
+
+/**
+ * Mint a CA for one sandbox. `label` only shows up in the subject, so a human
+ * reading a cert chain in the guest can tell what issued it.
+ */
+export function createEphemeralCa(label: string, ttlMs: number = DEFAULT_CA_TTL_MS): EphemeralCa {
+  const keys = forge.pki.rsa.generateKeyPair(KEY_BITS);
+  const cert = forge.pki.createCertificate();
+  const now = Date.now();
+
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = serial();
+  cert.validity.notBefore = new Date(now - CLOCK_SKEW_MS);
+  cert.validity.notAfter = new Date(now + ttlMs);
+
+  const subject = [
+    { name: 'commonName', value: `Kortix Egress CA (${label})` },
+    { name: 'organizationName', value: 'Kortix' },
+  ];
+  cert.setSubject(subject);
+  cert.setIssuer(subject);
+  cert.setExtensions([
+    // pathLenConstraint 0: this CA may sign leaves and nothing else. It cannot
+    // be used to mint another CA.
+    { name: 'basicConstraints', cA: true, pathLenConstraint: 0, critical: true },
+    { name: 'keyUsage', keyCertSign: true, cRLSign: true, critical: true },
+  ]);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+
+  return {
+    certPem: forge.pki.certificateToPem(cert),
+    keyPem: forge.pki.privateKeyToPem(keys.privateKey),
+    notAfter: cert.validity.notAfter,
+    fingerprint: fingerprintOf(cert),
+  };
+}
+
+/** Issues and caches leaf certificates for the hosts the proxy terminates. */
+export class LeafIssuer {
+  private readonly cache = new Map<string, LeafCertificate>();
+  private readonly caCert: forge.pki.Certificate;
+  /**
+   * `privateKeyFromPem` is typed as the general `PrivateKey`, but `sign()`
+   * requires the RSA variant. Narrowed here rather than at the call site: the
+   * CA is minted by `createEphemeralCa` with `rsa.generateKeyPair`, so it is
+   * RSA by construction.
+   */
+  private readonly caKey: forge.pki.rsa.PrivateKey;
+  private readonly notAfter: Date;
+
+  constructor(ca: EphemeralCa) {
+    this.caCert = forge.pki.certificateFromPem(ca.certPem);
+    this.caKey = forge.pki.privateKeyFromPem(ca.keyPem) as forge.pki.rsa.PrivateKey;
+    this.notAfter = ca.notAfter;
+  }
+
+  /**
+   * A certificate for `host`, valid no longer than the CA that signed it.
+   *
+   * The SAN is what modern clients actually check — a matching commonName with
+   * no SAN is rejected by Node, Go, and every browser — so the host goes in
+   * both.
+   */
+  issue(host: string): LeafCertificate {
+    const cached = this.cache.get(host);
+    if (cached) return cached;
+
+    const keys = forge.pki.rsa.generateKeyPair(KEY_BITS);
+    const cert = forge.pki.createCertificate();
+    cert.publicKey = keys.publicKey;
+    cert.serialNumber = serial();
+    cert.validity.notBefore = new Date(Date.now() - CLOCK_SKEW_MS);
+    cert.validity.notAfter = this.notAfter;
+    cert.setSubject([{ name: 'commonName', value: host }]);
+    cert.setIssuer(this.caCert.subject.attributes);
+    cert.setExtensions([
+      { name: 'basicConstraints', cA: false, critical: true },
+      { name: 'keyUsage', digitalSignature: true, keyEncipherment: true, critical: true },
+      { name: 'extKeyUsage', serverAuth: true },
+      {
+        name: 'subjectAltName',
+        // type 2 = dNSName, type 7 = iPAddress. A literal-IP destination needs
+        // the iPAddress form; a dNSName of "1.2.3.4" does not match.
+        altNames: [
+          /^\d{1,3}(\.\d{1,3}){3}$/.test(host)
+            ? { type: 7, ip: host }
+            : { type: 2, value: host },
+        ],
+      },
+    ]);
+    cert.sign(this.caKey, forge.md.sha256.create());
+
+    const leaf: LeafCertificate = {
+      certPem: forge.pki.certificateToPem(cert),
+      keyPem: forge.pki.privateKeyToPem(keys.privateKey),
+    };
+    this.cache.set(host, leaf);
+    return leaf;
+  }
+}

--- a/apps/api/src/secrets/egress-proxy/proxy.test.ts
+++ b/apps/api/src/secrets/egress-proxy/proxy.test.ts
@@ -252,6 +252,33 @@ describe('egress proxy', () => {
     await expect(connect(POLICY_HOST, 443, null)).rejects.toThrow(/407/);
   });
 
+  test('the 407 announces its own close, so a client can retry with credentials', async () => {
+    // git sends `Proxy-Connection: Keep-Alive`, takes the challenge, and
+    // retries on the SAME socket. Node detaches that socket on `connect`, so
+    // nothing parses the retry — without these two headers git reported
+    // `Proxy CONNECT aborted` and every clone through the proxy failed
+    // (measured, git 2.43.0 in a Daytona guest). Announcing the close is what
+    // makes the client open a fresh connection instead.
+    const raw = await new Promise<string>((resolve, reject) => {
+      const socket = net.connect(proxyPort, '127.0.0.1', () => {
+        socket.write(
+          `CONNECT ${POLICY_HOST}:443 HTTP/1.1\r\nHost: ${POLICY_HOST}:443\r\nProxy-Connection: Keep-Alive\r\n\r\n`,
+        );
+      });
+      let buf = '';
+      socket.on('data', (c: Buffer) => {
+        buf += c.toString('utf8');
+      });
+      socket.on('close', () => resolve(buf));
+      socket.once('error', reject);
+    });
+
+    expect(raw).toContain('407 Proxy Authentication Required');
+    expect(raw).toContain('Proxy-Authenticate: Basic');
+    expect(raw.toLowerCase()).toContain('content-length: 0');
+    expect(raw.toLowerCase()).toContain('connection: close');
+  });
+
   test('rejects an unknown proxy credential', async () => {
     await expect(connect(POLICY_HOST, 443, 'not-a-real-token')).rejects.toThrow(/407/);
   });

--- a/apps/api/src/secrets/egress-proxy/proxy.test.ts
+++ b/apps/api/src/secrets/egress-proxy/proxy.test.ts
@@ -288,3 +288,144 @@ describe('ephemeral CA', () => {
     expect(createEphemeralCa('s1').fingerprint).not.toBe(createEphemeralCa('s2').fingerprint);
   });
 });
+
+/**
+ * Shim mode: the proxy runs INSIDE the guest and must never hold a credential.
+ * It terminates TLS and relays to the Kortix broker, which injects.
+ */
+describe('egress proxy — broker (in-guest shim) mode', () => {
+  let kortix: http.Server;
+  let kortixPort = 0;
+  let shim: http.Server;
+  let shimPort = 0;
+  const brokerCalls: Array<{ path: string; auth: string | undefined; body: Record<string, unknown> }> = [];
+  let brokerReply: () => { status: number; payload: unknown } = () => ({ status: 200, payload: null });
+
+  const shimCa = createEphemeralCa('shim-fixture');
+
+  beforeAll(async () => {
+    // Stands in for the Kortix API's broker route. Plain HTTP on loopback: the
+    // relay leg's TLS belongs to the runtime's fetch, not to code under test,
+    // and using https here would only be testing whether the fixture's CA is
+    // installed. Production points `apiUrl` at the real https API.
+    kortix = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        brokerCalls.push({
+          path: req.url ?? '',
+          auth: req.headers.authorization,
+          body: JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}'),
+        });
+        const { status, payload } = brokerReply();
+        res.writeHead(status, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      });
+    });
+    await new Promise<void>((r) => kortix.listen(0, '127.0.0.1', r));
+    kortixPort = (kortix.address() as AddressInfo).port;
+
+    shim = await createEgressProxy({
+      ca: shimCa,
+      resolveRules: () => [
+        {
+          mode: 'broker',
+          hosts: [POLICY_HOST],
+          identifier: 'BROKER_PROOF',
+          apiUrl: `http://127.0.0.1:${kortixPort}/v1`,
+          token: 'session-token',
+          projectId: 'proj-1',
+        },
+      ],
+    });
+    await new Promise<void>((r) => shim.listen(0, '127.0.0.1', r));
+    shimPort = (shim.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((r) => shim.close(() => r()));
+    await new Promise<void>((r) => kortix.close(() => r()));
+  });
+
+  function throughShim(path: string): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const socket = net.connect(shimPort, '127.0.0.1', () => {
+        socket.write(
+          `CONNECT ${POLICY_HOST}:443 HTTP/1.1\r\nHost: ${POLICY_HOST}:443\r\nProxy-Authorization: Bearer t\r\n\r\n`,
+        );
+      });
+      let buf = '';
+      const onData = (chunk: Buffer) => {
+        buf += chunk.toString('utf8');
+        if (!buf.includes('\r\n\r\n')) return;
+        socket.removeListener('data', onData);
+        if (Number(buf.split(' ')[1]) !== 200) {
+          socket.destroy();
+          reject(new Error(buf.split('\r\n')[0]));
+          return;
+        }
+        speakHttps(socket, POLICY_HOST, path, shimCa.certPem).then(resolve, reject);
+      };
+      socket.on('data', onData);
+      socket.once('error', reject);
+    });
+  }
+
+  test('relays to the broker route and returns its response', async () => {
+    brokerCalls.length = 0;
+    brokerReply = () => ({
+      status: 200,
+      payload: {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+        body_base64: Buffer.from('{"created":true}').toString('base64'),
+      },
+    });
+
+    const res = await throughShim('/things?x=1');
+
+    expect(brokerCalls).toHaveLength(1);
+    expect(brokerCalls[0].path).toBe('/v1/projects/proj-1/secrets/BROKER_PROOF/broker');
+    expect(brokerCalls[0].auth).toBe('Bearer session-token');
+    // The shim reconstructs the guest's intended URL for Kortix to perform.
+    expect(brokerCalls[0].body.url).toBe(`https://${POLICY_HOST}/things?x=1`);
+    expect(brokerCalls[0].body.method).toBe('GET');
+    // Upstream status and body are passed through untouched.
+    expect(res.status).toBe(201);
+    expect(res.body).toBe('{"created":true}');
+  });
+
+  test('holds no credential — nothing secret is sent to Kortix or configured locally', async () => {
+    brokerCalls.length = 0;
+    brokerReply = () => ({
+      status: 200,
+      payload: { status: 200, headers: {}, body_base64: Buffer.from('ok').toString('base64') },
+    });
+
+    await throughShim('/x');
+
+    // The whole request the shim made, serialised: it names an identifier and
+    // carries the session's own token, and contains no secret value. This is
+    // the property that lets this component run inside an untrusted guest.
+    const sent = JSON.stringify(brokerCalls[0]);
+    expect(sent).toContain('BROKER_PROOF');
+    expect(sent).not.toContain(SECRET);
+    // And the rule the shim was configured with has no value field at all.
+    expect(JSON.stringify(shim.listeners('connect'))).not.toContain(SECRET);
+  });
+
+  test("surfaces the broker's refusal verbatim instead of a generic proxy error", async () => {
+    brokerCalls.length = 0;
+    brokerReply = () => ({
+      status: 403,
+      payload: { error: 'secret delivery denied', code: 'agent_grant_excludes' },
+    });
+
+    const res = await throughShim('/x');
+
+    // An agent that sees "agent_grant_excludes" can act on it; a bare 502
+    // costs it a turn of guessing.
+    expect(res.status).toBe(403);
+    expect(res.body).toContain('agent_grant_excludes');
+  });
+});

--- a/apps/api/src/secrets/egress-proxy/proxy.test.ts
+++ b/apps/api/src/secrets/egress-proxy/proxy.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Egress-proxy tests. No mocks: a real HTTPS upstream, a real CONNECT through
+ * the real proxy, real TLS termination with a real ephemeral CA.
+ *
+ * The upstream echoes the headers it received, so "did the credential arrive at
+ * the destination" is answered by the destination itself rather than by
+ * inspecting our own outgoing object.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { AddressInfo } from 'node:net';
+import https from 'node:https';
+import http from 'node:http';
+import net from 'node:net';
+import tls from 'node:tls';
+
+import { createEphemeralCa, LeafIssuer } from './ca';
+import { createEgressProxy, type EgressInjectionRule } from './proxy';
+
+const SECRET = 'sk-live-never-in-the-guest';
+const POLICY_HOST = 'api.example.test';
+
+/** Upstream TLS needs its own CA; the proxy verifies it via upstreamOptions. */
+const upstreamCa = createEphemeralCa('upstream-fixture');
+const upstreamLeaf = new LeafIssuer(upstreamCa);
+
+let upstream: https.Server;
+let upstreamPort = 0;
+let proxy: http.Server;
+let proxyPort = 0;
+let plainTunnelTarget: net.Server;
+let plainTunnelPort = 0;
+
+const proxyCa = createEphemeralCa('sandbox-fixture');
+
+const RULES: EgressInjectionRule[] = [
+  { hosts: [POLICY_HOST], header: 'x-proof-token', value: SECRET },
+];
+
+beforeAll(async () => {
+  // Upstream: echoes what it received, and can be asked to echo the secret back
+  // so the redaction path is exercised against a real response body.
+  upstream = https.createServer(
+    { cert: upstreamLeaf.issue(POLICY_HOST).certPem, key: upstreamLeaf.issue(POLICY_HOST).keyPem },
+    (req, res) => {
+      res.setHeader('content-type', 'application/json');
+      if (req.url === '/echo-secret') {
+        // Deliberately leaks the credential back, to exercise redaction.
+        res.end(JSON.stringify({ leaked: req.headers['x-proof-token'] ?? null }));
+        return;
+      }
+      // Reports a DERIVED fact rather than echoing the value. Echoing it would
+      // trip the proxy's own redaction and the assertion could never see it —
+      // the test would then be measuring redaction while claiming to measure
+      // injection.
+      const token = req.headers['x-proof-token'];
+      res.end(
+        JSON.stringify({
+          tokenMatched: token === SECRET,
+          tokenCount: Array.isArray(token) ? token.length : token === undefined ? 0 : 1,
+          sawAttackerValue: JSON.stringify(req.headers).includes('attacker-supplied'),
+          url: req.url,
+        }),
+      );
+    },
+  );
+  await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', r));
+  upstreamPort = (upstream.address() as AddressInfo).port;
+
+  // A plain TCP server standing in for a non-policy destination, so the blind
+  // tunnel can be proven to carry bytes the proxy never parses.
+  plainTunnelTarget = net.createServer((socket) => {
+    socket.on('data', (d) => socket.write(Buffer.concat([Buffer.from('echo:'), d])));
+  });
+  await new Promise<void>((r) => plainTunnelTarget.listen(0, '127.0.0.1', r));
+  plainTunnelPort = (plainTunnelTarget.address() as AddressInfo).port;
+
+  proxy = await createEgressProxy({
+    ca: proxyCa,
+    resolveRules: (token) => (token === 'sandbox-token' ? RULES : null),
+    upstreamOptions: () => ({ host: '127.0.0.1', port: upstreamPort, ca: upstreamCa.certPem }),
+  });
+  await new Promise<void>((r) => proxy.listen(0, '127.0.0.1', r));
+  proxyPort = (proxy.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((r) => proxy.close(() => r()));
+  await new Promise<void>((r) => upstream.close(() => r()));
+  await new Promise<void>((r) => plainTunnelTarget.close(() => r()));
+});
+
+/** Open a CONNECT tunnel; resolves with the raw socket on 200. */
+function connect(host: string, port: number, token: string | null): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(proxyPort, '127.0.0.1', () => {
+      const auth = token ? `Proxy-Authorization: Bearer ${token}\r\n` : '';
+      socket.write(`CONNECT ${host}:${port} HTTP/1.1\r\nHost: ${host}:${port}\r\n${auth}\r\n`);
+    });
+    let buf = '';
+    const onData = (chunk: Buffer) => {
+      buf += chunk.toString('utf8');
+      if (!buf.includes('\r\n\r\n')) return;
+      socket.removeListener('data', onData);
+      const status = Number(buf.split(' ')[1]);
+      if (status === 200) resolve(socket);
+      else {
+        socket.destroy();
+        reject(new Error(`CONNECT ${status}: ${buf.split('\r\n')[0]}`));
+      }
+    };
+    socket.on('data', onData);
+    socket.once('error', reject);
+  });
+}
+
+/**
+ * Speak HTTP/1.1 by hand over the tunnel.
+ *
+ * Not using `https.request({ socket })`: Bun's HTTP client ignores a
+ * pre-opened socket and dials the hostname itself, which made these tests
+ * reach for the real internet. Writing the request line directly also means the
+ * test asserts against the bytes on the wire rather than a client library's
+ * interpretation of them.
+ */
+function speakHttps(
+  socket: net.Socket,
+  host: string,
+  path: string,
+  ca: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const tlsSocket = tls.connect({ socket, servername: host, ca }, () => {
+      const extra = Object.entries(extraHeaders)
+        .map(([k, v]) => `${k}: ${v}\r\n`)
+        .join('');
+      tlsSocket.write(`GET ${path} HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n${extra}\r\n`);
+    });
+    const chunks: Buffer[] = [];
+    let settled = false;
+    /**
+     * Complete on content-length rather than on socket close. The proxy sets an
+     * accurate length and may legitimately keep the connection alive, so
+     * waiting for a FIN would hang on a perfectly good response.
+     */
+    const tryResolve = () => {
+      if (settled) return;
+      const raw = Buffer.concat(chunks).toString('utf8');
+      const split = raw.indexOf('\r\n\r\n');
+      if (split === -1) return;
+      const head = raw.slice(0, split);
+      const body = raw.slice(split + 4);
+      const declared = /content-length:\s*(\d+)/i.exec(head);
+      if (declared && Buffer.byteLength(body) < Number(declared[1])) return;
+      settled = true;
+      tlsSocket.destroy();
+      resolve({ status: Number(head.split(' ')[1] ?? 0), body });
+    };
+    tlsSocket.on('data', (c: Buffer) => {
+      chunks.push(c);
+      tryResolve();
+    });
+    tlsSocket.on('error', (err: Error) => {
+      if (!settled) reject(err);
+    });
+    tlsSocket.on('close', tryResolve);
+  });
+}
+
+/** A GET through the tunnel, with the guest trusting the proxy's CA. */
+async function getThroughProxy(
+  host: string,
+  path: string,
+  extraHeaders: Record<string, string> = {},
+  token: string | null = 'sandbox-token',
+) {
+  const socket = await connect(host, 443, token);
+  return speakHttps(socket, host, path, proxyCa.certPem, extraHeaders);
+}
+
+describe('egress proxy', () => {
+  test('injects the credential into a policy host, and the guest never sends it', async () => {
+    const res = await getThroughProxy(POLICY_HOST, '/whoami');
+    expect(res.status).toBe(200);
+
+    const seen = JSON.parse(res.body) as { tokenMatched: boolean; url: string };
+    // The destination confirms it received the exact credential — injection
+    // happened outside the guest. The client above never sent that header.
+    expect(seen.tokenMatched).toBe(true);
+    expect(seen.url).toBe('/whoami');
+  });
+
+  test('a client-supplied copy of the managed header cannot shadow the real one', async () => {
+    // An agent guessing at the header must not be able to override it, or it
+    // could probe whether its guess matched.
+    const res = await getThroughProxy(POLICY_HOST, '/whoami', {
+      'x-proof-token': 'attacker-supplied',
+    });
+    const seen = JSON.parse(res.body) as {
+      tokenMatched: boolean;
+      tokenCount: number;
+      sawAttackerValue: boolean;
+    };
+    expect(seen.tokenMatched).toBe(true);
+    // Exactly one value on the wire: the client's copy was dropped, not
+    // appended alongside ours as a second header value.
+    expect(seen.tokenCount).toBe(1);
+    expect(seen.sawAttackerValue).toBe(false);
+  });
+
+  test('redacts the credential when the upstream echoes it back', async () => {
+    const res = await getThroughProxy(POLICY_HOST, '/echo-secret');
+    expect(res.status).toBe(200);
+    // The upstream really did echo it, so this is the redaction working, not
+    // an upstream that happened to omit it.
+    expect(res.body).not.toContain(SECRET);
+    expect(res.body).toContain('[REDACTED]');
+  });
+
+  test('a host with no rule is tunnelled blind, not intercepted', async () => {
+    // Target the real upstream by address, which has no injection rule. If the
+    // proxy terminated it, the handshake would present OUR leaf and verify
+    // against proxyCa; instead it must present the UPSTREAM's own certificate.
+    const handshake = (ca: string) =>
+      connect('127.0.0.1', upstreamPort, 'sandbox-token').then(
+        (socket) =>
+          new Promise<boolean>((resolve) => {
+            const s = tls.connect({ socket, servername: POLICY_HOST, ca }, () => {
+              s.destroy();
+              resolve(true);
+            });
+            s.on('error', () => resolve(false));
+          }),
+      );
+
+    expect(await handshake(proxyCa.certPem)).toBe(false); // not our cert
+    expect(await handshake(upstreamCa.certPem)).toBe(true); // the origin's own
+  });
+
+  test('the blind tunnel actually carries bytes', async () => {
+    const socket = await connect('127.0.0.1', plainTunnelPort, 'sandbox-token');
+    const reply = await new Promise<string>((resolve, reject) => {
+      socket.once('data', (d: Buffer) => resolve(d.toString('utf8')));
+      socket.once('error', reject);
+      socket.write('ping');
+    });
+    socket.destroy();
+    expect(reply).toBe('echo:ping');
+  });
+
+  test('rejects a sandbox that does not identify itself', async () => {
+    await expect(connect(POLICY_HOST, 443, null)).rejects.toThrow(/407/);
+  });
+
+  test('rejects an unknown proxy credential', async () => {
+    await expect(connect(POLICY_HOST, 443, 'not-a-real-token')).rejects.toThrow(/407/);
+  });
+
+  test('refuses plain HTTP so a credential is never put on the wire in clear', async () => {
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        { host: '127.0.0.1', port: proxyPort, method: 'GET', path: `http://${POLICY_HOST}/x` },
+        (res) => resolve(res.statusCode ?? 0),
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(status).toBe(405);
+  });
+});
+
+describe('ephemeral CA', () => {
+  test('is constrained to signing leaves, and expires', () => {
+    const ca = createEphemeralCa('scope-test', 60_000);
+    expect(ca.certPem).toContain('BEGIN CERTIFICATE');
+    expect(ca.fingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(ca.notAfter.getTime()).toBeGreaterThan(Date.now());
+    expect(ca.notAfter.getTime()).toBeLessThanOrEqual(Date.now() + 60_000);
+  });
+
+  test('caches leaves per host, so a CONNECT does not pay a keygen', () => {
+    const issuer = new LeafIssuer(createEphemeralCa('cache-test'));
+    expect(issuer.issue('a.example.test')).toBe(issuer.issue('a.example.test'));
+    expect(issuer.issue('b.example.test')).not.toBe(issuer.issue('a.example.test'));
+  });
+
+  test('two sandboxes never share a CA', () => {
+    expect(createEphemeralCa('s1').fingerprint).not.toBe(createEphemeralCa('s2').fingerprint);
+  });
+});

--- a/apps/api/src/secrets/egress-proxy/proxy.ts
+++ b/apps/api/src/secrets/egress-proxy/proxy.ts
@@ -1,0 +1,346 @@
+/**
+ * Kortix egress proxy — the Daytona half of network-boundary secrets.
+ *
+ * Platinum injects credentials at its own edge. Daytona has no equivalent and
+ * no way to redirect traffic into one (`outboundProxyUrl` is accepted and
+ * ignored — measured, see docs/NETWORK_BOUNDARY_ON_DAYTONA.md §7). What Daytona
+ * does give us is a runner-enforced egress allow-list that root inside the
+ * guest cannot escape. So:
+ *
+ *   guest ──(allow-list: ONLY this proxy)──▶ Kortix egress proxy ──▶ upstream
+ *
+ * Enforcement is the allow-list's job and lives outside the guest. This file is
+ * only the injection half: it may assume every packet already has to come
+ * through it.
+ *
+ * ## What it does
+ *
+ * `CONNECT host:443` arrives. If `host` has an injection rule, the proxy
+ * terminates TLS with a per-sandbox ephemeral CA, adds the configured header,
+ * re-originates the request over real TLS, and redacts the credential from the
+ * response on the way back. If it has no rule, the bytes are tunnelled blind —
+ * the proxy never sees them.
+ *
+ * ## Why selective termination is not an optimisation
+ *
+ * Blanket MITM would break every pinned-certificate client and mTLS handshake
+ * in the sandbox, and would put Kortix in the middle of traffic that has
+ * nothing to do with any secret. Terminating only the hosts that carry an
+ * injection rule bounds both the breakage and the liability.
+ */
+import { Buffer } from 'node:buffer';
+import type { Duplex } from 'node:stream';
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import tls from 'node:tls';
+
+import { redactSecretFromResponse } from '../http-broker';
+import { LeafIssuer, type EphemeralCa } from './ca';
+
+/** One host→header rule. `hosts` match exactly: no wildcards, no suffixes. */
+export interface EgressInjectionRule {
+  readonly hosts: readonly string[];
+  readonly header: string;
+  readonly value: string;
+  /**
+   * What to do when the upstream echoes the credential back.
+   *  - `redact`  replace it in the body and return the rest (default)
+   *  - `block`   cut the connection, matching Platinum's on_echo
+   *
+   * `redact` is the better default and this is a considered disagreement with
+   * Platinum: cutting the connection surfaces as `curl: (52) Empty reply from
+   * server`, which reads as "the feature is broken" and has cost this project
+   * days of confusion. Redaction leaves a usable response with `[REDACTED]`
+   * where the credential would have been.
+   */
+  readonly onEcho?: 'redact' | 'block';
+}
+
+export interface EgressProxyOptions {
+  readonly ca: EphemeralCa;
+  /**
+   * Map a proxy credential to that sandbox's rules. Returning null rejects the
+   * connection with 407 — a sandbox must identify itself before the proxy will
+   * carry a byte for it, so one sandbox can never borrow another's injection.
+   */
+  readonly resolveRules: (token: string | null) => readonly EgressInjectionRule[] | null;
+  /**
+   * Test seam: extra `https.request` options for the upstream leg, so a test
+   * can redirect `api.example.com` to a local HTTPS server and hand over its
+   * CA. Shaped as request options rather than a "trust this CA" config value,
+   * because a production knob that relaxes upstream verification is exactly the
+   * knob that gets set by accident. Unset in production, where the upstream is
+   * verified against the system trust store.
+   */
+  readonly upstreamOptions?: (host: string) => https.RequestOptions;
+  readonly onError?: (where: string, err: Error) => void;
+}
+
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
+function proxyToken(req: http.IncomingMessage): string | null {
+  const header = req.headers['proxy-authorization'];
+  if (typeof header !== 'string') return null;
+  const [scheme, ...rest] = header.trim().split(/\s+/);
+  const value = rest.join(' ');
+  if (!value) return null;
+  if (scheme?.toLowerCase() === 'bearer') return value;
+  if (scheme?.toLowerCase() === 'basic') {
+    // curl and most clients only speak Basic to a proxy. The token rides as the
+    // password so it never has to be URL-safe.
+    const decoded = Buffer.from(value, 'base64').toString('utf8');
+    const sep = decoded.indexOf(':');
+    return sep === -1 ? decoded : decoded.slice(sep + 1);
+  }
+  return null;
+}
+
+function ruleFor(
+  rules: readonly EgressInjectionRule[],
+  host: string,
+): EgressInjectionRule | null {
+  const needle = host.toLowerCase();
+  return rules.find((rule) => rule.hosts.some((h) => h.toLowerCase() === needle)) ?? null;
+}
+
+function parseTarget(target: string): { host: string; port: number } | null {
+  // CONNECT targets are `host:port`; an IPv6 literal is bracketed.
+  const match = /^(\[[^\]]+\]|[^:]+):(\d{1,5})$/.exec(target.trim());
+  if (!match) return null;
+  const host = match[1].replace(/^\[|\]$/g, '');
+  const port = Number(match[2]);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+  return { host, port };
+}
+
+/**
+ * Async because the proxy owns a loopback TLS listener that must be bound
+ * before the first CONNECT can be served.
+ */
+export async function createEgressProxy(options: EgressProxyOptions): Promise<http.Server> {
+  const issuer = new LeafIssuer(options.ca);
+  const fail = options.onError ?? (() => {});
+
+  /**
+   * Serves the guest's decrypted requests.
+   *
+   * This is a REAL listener on loopback that the guest's tunnel is piped into,
+   * rather than an `http.Server` handed a socket via `emit('connection')`. That
+   * trick is Node-only — measured: under Bun the request event never fires and
+   * the connection just hangs, while the identical script works under Node. The
+   * API runs on Bun, so the socket has to reach a genuine listening port.
+   *
+   * The per-connection rule is keyed by the loopback source port, which is
+   * unique per connection and is what the inner server sees as
+   * `req.socket.remotePort`.
+   */
+  const bindings = new Map<number, { rule: EgressInjectionRule; host: string }>();
+  const onTerminatedRequest: http.RequestListener = (req, res) => {
+    const binding = bindings.get(req.socket.remotePort ?? -1);
+    const rule = binding?.rule;
+    const host = binding?.host ?? '';
+    if (!rule) {
+      res.writeHead(500).end('kortix egress proxy: no rule bound to connection');
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      // Strip hop-by-hop and any client-supplied copy of the managed header:
+      // the injected value must be the ONLY one on the wire, or an agent could
+      // shadow it and learn whether its guess matched.
+      const headers: Record<string, string | string[]> = {};
+      for (const [name, value] of Object.entries(req.headers)) {
+        const lower = name.toLowerCase();
+        if (lower === 'proxy-authorization' || lower === 'connection') continue;
+        if (lower === rule.header.toLowerCase()) continue;
+        if (value !== undefined) headers[name] = value;
+      }
+      headers[rule.header] = rule.value;
+      headers.host = host;
+      // Ask for an uncompressed body. Echo redaction is a byte scan, and a
+      // gzipped response would sail through it — the credential would be
+      // present but unrecognisable, so the protection would silently not
+      // apply. Costs bandwidth on the Kortix→upstream leg only.
+      headers['accept-encoding'] = 'identity';
+
+      const upstream = https.request(
+        {
+          host,
+          port: 443,
+          method: req.method,
+          path: req.url,
+          headers,
+          servername: host,
+          timeout: UPSTREAM_TIMEOUT_MS,
+          ...(options.upstreamOptions?.(host) ?? {}),
+        },
+        (upstreamRes) => {
+          const body: Buffer[] = [];
+          let total = 0;
+          let truncated = false;
+          upstreamRes.on('data', (chunk: Buffer) => {
+            total += chunk.length;
+            if (total > MAX_RESPONSE_BYTES) {
+              truncated = true;
+              upstreamRes.destroy();
+              return;
+            }
+            body.push(chunk);
+          });
+          upstreamRes.on('end', () => {
+            const raw = Buffer.concat(body);
+            const echoed = raw.includes(rule.value);
+            if (echoed && (rule.onEcho ?? 'redact') === 'block') {
+              // Platinum's behaviour: kill it rather than return anything.
+              res.socket?.destroy();
+              return;
+            }
+            const redacted = echoed ? redactSecretFromResponse(raw, rule.value) : raw;
+            const out = truncated
+              ? Buffer.concat([redacted, Buffer.from('\n[truncated by kortix egress proxy]')])
+              : redacted;
+
+            const safeHeaders = { ...upstreamRes.headers };
+            // The body has been fully buffered, so the upstream's framing no
+            // longer describes it: redaction changes the length, and its
+            // chunked encoding was already undone by reading to the end. State
+            // the real length explicitly rather than deleting it and letting
+            // the server pick — dropping both headers leaves Bun's HTTP server
+            // holding the response instead of flushing it, which reads as a
+            // hang with no error anywhere (measured: the handler ran to
+            // completion and the client received nothing).
+            delete safeHeaders['transfer-encoding'];
+            safeHeaders['content-length'] = String(out.length);
+            // Mirror the client's connection intent. Without this a client that
+            // sent `Connection: close` is left holding an open socket, because
+            // the upstream's own keep-alive header gets forwarded in its place.
+            if (/close/i.test(String(req.headers.connection ?? ''))) {
+              safeHeaders.connection = 'close';
+            } else {
+              delete safeHeaders.connection;
+            }
+            res.writeHead(upstreamRes.statusCode ?? 502, safeHeaders);
+            res.end(out);
+          });
+        },
+      );
+      upstream.on('error', (err) => {
+        fail('upstream', err);
+        if (!res.headersSent) res.writeHead(502);
+        res.end('kortix egress proxy: upstream error');
+      });
+      if (chunks.length > 0) upstream.write(Buffer.concat(chunks));
+      upstream.end();
+    });
+  };
+
+  /**
+   * One loopback TLS listener per terminated host, each holding that host's
+   * leaf as a STATIC cert.
+   *
+   * The obvious design is a single listener with `SNICallback` picking the leaf
+   * per connection. Bun never invokes SNICallback — measured: the handshake
+   * completes against a default certificate and the callback does not fire,
+   * while the same script works under Node — so the certificate has to be fixed
+   * at listen() time. Listeners are bounded by the number of distinct hosts
+   * carrying an injection rule, which is small, and are created once.
+   *
+   * Loopback only: the decrypted leg must never be reachable from outside this
+   * process.
+   */
+  const listeners = new Map<string, Promise<number>>();
+  const innerServers: https.Server[] = [];
+  function listenerFor(host: string): Promise<number> {
+    const existing = listeners.get(host);
+    if (existing) return existing;
+    const started = (async () => {
+      const leaf = issuer.issue(host);
+      const inner = https.createServer({ cert: leaf.certPem, key: leaf.keyPem });
+      inner.on('request', onTerminatedRequest);
+      inner.on('clientError', (err) => fail('terminated-client', err));
+      await new Promise<void>((resolve) => inner.listen(0, '127.0.0.1', resolve));
+      innerServers.push(inner);
+      return (inner.address() as net.AddressInfo).port;
+    })();
+    listeners.set(host, started);
+    return started;
+  }
+
+  const server = http.createServer((_req, res) => {
+    // Plain HTTP through the proxy is refused outright. Injecting a credential
+    // into a cleartext request would put it on the wire unencrypted, which is
+    // strictly worse than not having the feature.
+    res.writeHead(405).end('kortix egress proxy: HTTPS CONNECT only');
+  });
+
+  server.on('connect', (req: http.IncomingMessage, socket: Duplex, head: Buffer) => {
+    const rules = options.resolveRules(proxyToken(req));
+    if (!rules) {
+      socket.end('HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm="kortix"\r\n\r\n');
+      return;
+    }
+    const target = parseTarget(req.url ?? '');
+    if (!target) {
+      socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+      return;
+    }
+
+    const rule = target.port === 443 ? ruleFor(rules, target.host) : null;
+    socket.on('error', (err) => fail('client', err as Error));
+
+    if (!rule) {
+      // No injection rule: blind tunnel. The proxy carries the bytes and never
+      // looks at them, so a pinned or mTLS client is unaffected.
+      const upstream = net.connect(target.port, target.host, () => {
+        socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        if (head?.length) upstream.write(head);
+        upstream.pipe(socket);
+        socket.pipe(upstream);
+      });
+      upstream.on('error', (err) => {
+        fail('tunnel', err);
+        socket.destroy();
+      });
+      return;
+    }
+
+    // Injection rule: hand the tunnel to our own TLS listener for this host,
+    // which terminates it, parses the request, and adds the header.
+    void listenerFor(target.host)
+      .then((terminatedPort) => {
+        const inner = net.connect(terminatedPort, '127.0.0.1', () => {
+          // Bind BEFORE any byte flows, so the request handler can never look
+          // up a port that has not been registered yet.
+          bindings.set(inner.localPort ?? -1, { rule, host: target.host });
+          socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+          if (head?.length) inner.write(head);
+          inner.pipe(socket);
+          socket.pipe(inner);
+        });
+        const release = () => {
+          if (inner.localPort) bindings.delete(inner.localPort);
+        };
+        inner.on('close', release);
+        inner.on('error', (err) => {
+          fail('terminate', err);
+          release();
+          socket.destroy();
+        });
+      })
+      .catch((err) => {
+        fail('listener', err as Error);
+        socket.destroy();
+      });
+  });
+
+  // Closing the proxy must also close every per-host listener, or the process
+  // hangs on open handles after server.close().
+  server.on('close', () => {
+    for (const inner of innerServers) inner.close();
+  });
+  return server;
+}

--- a/apps/api/src/secrets/egress-proxy/proxy.ts
+++ b/apps/api/src/secrets/egress-proxy/proxy.ts
@@ -389,12 +389,26 @@ export async function createEgressProxy(options: EgressProxyOptions): Promise<ht
   server.on('connect', (req: http.IncomingMessage, socket: Duplex, head: Buffer) => {
     const rules = options.resolveRules(proxyToken(req));
     if (!rules) {
-      socket.end('HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm="kortix"\r\n\r\n');
+      // `Content-Length: 0` + `Connection: close` are load-bearing, not
+      // decoration. Node hands us the raw socket on `connect`, so once this
+      // request is answered nothing is parsing that socket any more — a client
+      // that retries with credentials on the SAME connection is talking to
+      // nobody. git does exactly that: it sends `Proxy-Connection: Keep-Alive`,
+      // gets the challenge, and retries in place. Without these headers its
+      // retry vanished and it reported `Proxy CONNECT aborted` (measured
+      // against git 2.43.0 in a real sandbox). Announcing the close makes the
+      // client open a fresh connection for the authenticated attempt.
+      socket.end(
+        'HTTP/1.1 407 Proxy Authentication Required\r\n' +
+          'Proxy-Authenticate: Basic realm="kortix"\r\n' +
+          'Content-Length: 0\r\n' +
+          'Connection: close\r\n\r\n',
+      );
       return;
     }
     const target = parseTarget(req.url ?? '');
     if (!target) {
-      socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+      socket.end('HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n');
       return;
     }
 

--- a/apps/api/src/secrets/egress-proxy/proxy.ts
+++ b/apps/api/src/secrets/egress-proxy/proxy.ts
@@ -33,7 +33,6 @@ import type { Duplex } from 'node:stream';
 import http from 'node:http';
 import https from 'node:https';
 import net from 'node:net';
-import tls from 'node:tls';
 
 import { redactSecretFromResponse } from '../http-broker';
 import { LeafIssuer, type EphemeralCa } from './ca';

--- a/apps/api/src/secrets/egress-proxy/proxy.ts
+++ b/apps/api/src/secrets/egress-proxy/proxy.ts
@@ -38,8 +38,14 @@ import tls from 'node:tls';
 import { redactSecretFromResponse } from '../http-broker';
 import { LeafIssuer, type EphemeralCa } from './ca';
 
-/** One host→header rule. `hosts` match exactly: no wildcards, no suffixes. */
-export interface EgressInjectionRule {
+/**
+ * Inject the credential here, in this process. Used when the proxy runs
+ * OUTSIDE the guest and is trusted to hold the secret.
+ *
+ * `hosts` match exactly: no wildcards, no suffixes.
+ */
+export interface EgressInjectRule {
+  readonly mode?: 'inject';
   readonly hosts: readonly string[];
   readonly header: string;
   readonly value: string;
@@ -57,6 +63,37 @@ export interface EgressInjectionRule {
   readonly onEcho?: 'redact' | 'block';
 }
 
+/**
+ * Relay the request to Kortix and let IT inject. Used when the proxy runs
+ * INSIDE the guest, where holding the credential would defeat the point.
+ *
+ * This is the shim of docs §7.4: it terminates the guest's TLS (which can only
+ * be done in the guest) but never possesses a secret (which must not be). The
+ * far end is the existing broker route, already shipped and verified live, so
+ * the credential, the host/method policy, and echo redaction all stay
+ * server-side exactly as they are today.
+ *
+ * An agent that reads, patches, or kills this component learns nothing. Under
+ * the runner allow-list it also loses its own networking, so tampering is
+ * fail-closed.
+ */
+export interface EgressBrokerRule {
+  readonly mode: 'broker';
+  readonly hosts: readonly string[];
+  /** Secret identifier, NOT a value. The guest may see this. */
+  readonly identifier: string;
+  /** Kortix API base, e.g. `https://dev-api.kortix.com/v1`. */
+  readonly apiUrl: string;
+  /** The session's own token — already in the guest; grants no new authority. */
+  readonly token: string;
+  readonly projectId: string;
+}
+
+export type EgressRule = EgressInjectRule | EgressBrokerRule;
+
+/** @deprecated Use {@link EgressInjectRule}. Kept so callers keep compiling. */
+export type EgressInjectionRule = EgressInjectRule;
+
 export interface EgressProxyOptions {
   readonly ca: EphemeralCa;
   /**
@@ -64,7 +101,7 @@ export interface EgressProxyOptions {
    * connection with 407 — a sandbox must identify itself before the proxy will
    * carry a byte for it, so one sandbox can never borrow another's injection.
    */
-  readonly resolveRules: (token: string | null) => readonly EgressInjectionRule[] | null;
+  readonly resolveRules: (token: string | null) => readonly EgressRule[] | null;
   /**
    * Test seam: extra `https.request` options for the upstream leg, so a test
    * can redirect `api.example.com` to a local HTTPS server and hand over its
@@ -98,11 +135,74 @@ function proxyToken(req: http.IncomingMessage): string | null {
 }
 
 function ruleFor(
-  rules: readonly EgressInjectionRule[],
+  rules: readonly EgressRule[],
   host: string,
-): EgressInjectionRule | null {
+): EgressRule | null {
   const needle = host.toLowerCase();
   return rules.find((rule) => rule.hosts.some((h) => h.toLowerCase() === needle)) ?? null;
+}
+
+/**
+ * Hand the guest's request to Kortix, which holds the credential.
+ *
+ * Deliberately the SAME broker route `kortix secrets call` and the `secret_call`
+ * MCP tool already use — so the shim inherits a path that is shipped, tested,
+ * and verified live rather than opening a second way to spend a secret. The
+ * host/method policy, the injection, and the echo redaction all happen there.
+ */
+async function relayToBroker(
+  rule: EgressBrokerRule,
+  host: string,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  body: Buffer,
+): Promise<void> {
+  // Forward only the request's own headers. Nothing secret is added here —
+  // that is the entire point of this mode.
+  const forwarded: Record<string, string> = {};
+  for (const [name, value] of Object.entries(req.headers)) {
+    const lower = name.toLowerCase();
+    if (['proxy-authorization', 'connection', 'host', 'content-length'].includes(lower)) continue;
+    if (typeof value === 'string') forwarded[lower] = value;
+  }
+
+  const response = await fetch(
+    `${rule.apiUrl.replace(/\/$/, '')}/projects/${rule.projectId}/secrets/${encodeURIComponent(rule.identifier)}/broker`,
+    {
+      method: 'POST',
+      headers: { authorization: `Bearer ${rule.token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        url: `https://${host}${req.url ?? '/'}`,
+        method: (req.method ?? 'GET').toUpperCase(),
+        ...(Object.keys(forwarded).length > 0 ? { headers: forwarded } : {}),
+        ...(body.length > 0 ? { body_base64: body.toString('base64') } : {}),
+      }),
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    },
+  );
+
+  if (!response.ok) {
+    // Surface Kortix's own refusal verbatim: a denied grant or an out-of-policy
+    // host must reach the agent as that, not as a generic proxy error it will
+    // waste a turn guessing about.
+    const detail = await response.text().catch(() => '');
+    res.writeHead(response.status, { 'content-type': 'application/json' });
+    res.end(detail || JSON.stringify({ error: 'broker refused the request' }));
+    return;
+  }
+
+  const result = (await response.json()) as {
+    status: number;
+    headers: Record<string, string>;
+    body_base64: string;
+  };
+  const out = Buffer.from(result.body_base64 ?? '', 'base64');
+  const headers: Record<string, string> = { ...(result.headers ?? {}) };
+  delete headers['transfer-encoding'];
+  headers['content-length'] = String(out.length);
+  if (/close/i.test(String(req.headers.connection ?? ''))) headers.connection = 'close';
+  res.writeHead(result.status ?? 502, headers);
+  res.end(out);
 }
 
 function parseTarget(target: string): { host: string; port: number } | null {
@@ -136,7 +236,7 @@ export async function createEgressProxy(options: EgressProxyOptions): Promise<ht
    * unique per connection and is what the inner server sees as
    * `req.socket.remotePort`.
    */
-  const bindings = new Map<number, { rule: EgressInjectionRule; host: string }>();
+  const bindings = new Map<number, { rule: EgressRule; host: string }>();
   const onTerminatedRequest: http.RequestListener = (req, res) => {
     const binding = bindings.get(req.socket.remotePort ?? -1);
     const rule = binding?.rule;
@@ -149,6 +249,15 @@ export async function createEgressProxy(options: EgressProxyOptions): Promise<ht
     const chunks: Buffer[] = [];
     req.on('data', (chunk: Buffer) => chunks.push(chunk));
     req.on('end', () => {
+      if (rule.mode === 'broker') {
+        void relayToBroker(rule, host, req, res, Buffer.concat(chunks)).catch((err: Error) => {
+          fail('broker', err);
+          if (!res.headersSent) res.writeHead(502);
+          res.end('kortix egress shim: broker relay failed');
+        });
+        return;
+      }
+
       // Strip hop-by-hop and any client-supplied copy of the managed header:
       // the injected value must be the ONLY one on the wire, or an agent could
       // shadow it and learn whether its guess matched.

--- a/apps/api/src/secrets/network-boundary-availability.test.ts
+++ b/apps/api/src/secrets/network-boundary-availability.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The availability gate decides whether the API ADVERTISES network-boundary
+ * delivery — save-time validation, delivery_status, and the web control all
+ * read it. Getting it wrong in the permissive direction ships a feature that
+ * looks available and silently does nothing, so the default is pinned here.
+ */
+import { describe, expect, test } from 'bun:test';
+import { config } from '../config';
+import {
+  networkBoundaryDeliveryAvailable,
+  networkBoundaryMode,
+  networkBoundaryShimAvailable,
+} from './network-boundary-availability';
+
+function withConfig<T>(patch: { platinum?: boolean; shim?: boolean }, run: () => T): T {
+  const originalShim = config.EGRESS_SHIM_ENABLED;
+  const originalIsPlatinum = config.isPlatinumEnabled;
+  try {
+    if (patch.shim !== undefined) {
+      (config as { EGRESS_SHIM_ENABLED: boolean }).EGRESS_SHIM_ENABLED = patch.shim;
+    }
+    if (patch.platinum !== undefined) {
+      (config as { isPlatinumEnabled: () => boolean }).isPlatinumEnabled = () => patch.platinum!;
+    }
+    return run();
+  } finally {
+    (config as { EGRESS_SHIM_ENABLED: boolean }).EGRESS_SHIM_ENABLED = originalShim;
+    (config as { isPlatinumEnabled: () => boolean }).isPlatinumEnabled = originalIsPlatinum;
+  }
+}
+
+describe('network boundary availability', () => {
+  test('the shim is OFF unless an operator turns it on', () => {
+    // Pins the sequencing decision: the API must not advertise boundary
+    // delivery to non-Platinum projects before the guest can perform it.
+    expect(config.EGRESS_SHIM_ENABLED).toBe(false);
+  });
+
+  test('Platinum alone still satisfies availability, as before', () => {
+    withConfig({ platinum: true, shim: false }, () => {
+      expect(networkBoundaryDeliveryAvailable()).toBe(true);
+      expect(networkBoundaryMode('platinum')).toBe('provider-edge');
+    });
+  });
+
+  test('with the shim off and no Platinum, the feature stays unavailable', () => {
+    withConfig({ platinum: false, shim: false }, () => {
+      expect(networkBoundaryDeliveryAvailable()).toBe(false);
+      expect(networkBoundaryShimAvailable()).toBe(false);
+      expect(networkBoundaryMode('daytona')).toBeNull();
+    });
+  });
+
+  test('the shim makes it available on a provider with no credential edge', () => {
+    withConfig({ platinum: false, shim: true }, () => {
+      expect(networkBoundaryDeliveryAvailable()).toBe(true);
+      expect(networkBoundaryMode('daytona')).toBe('in-guest-shim');
+    });
+  });
+
+  test('Platinum keeps the provider edge even when the shim is available', () => {
+    // The edge injects for ANY client; the shim only for requests routed
+    // through it. Where both exist the edge is strictly better, so it wins.
+    withConfig({ platinum: true, shim: true }, () => {
+      expect(networkBoundaryMode('platinum')).toBe('provider-edge');
+      expect(networkBoundaryMode('daytona')).toBe('in-guest-shim');
+    });
+  });
+});

--- a/apps/api/src/secrets/network-boundary-availability.ts
+++ b/apps/api/src/secrets/network-boundary-availability.ts
@@ -1,5 +1,46 @@
 import { config } from '../config';
 
+/**
+ * Can this deployment deliver a network-boundary secret at all?
+ *
+ * Two independent mechanisms can satisfy it, and a project needs only one:
+ *
+ *  - **Provider edge (Platinum).** Kortix registers the credential with the
+ *    provider and its egress proxy injects on allow-listed hosts. Nothing runs
+ *    in the guest.
+ *  - **In-guest shim (everything else, notably Daytona).** The shim terminates
+ *    the guest's TLS and relays to the broker route, which injects server-side.
+ *    The guest still never holds the credential — see
+ *    docs/NETWORK_BOUNDARY_ON_DAYTONA.md §7.4.
+ *
+ * This used to be `config.isPlatinumEnabled()` alone, which is why the feature
+ * was unavailable to every production project: production runs on Daytona.
+ */
 export function networkBoundaryDeliveryAvailable(): boolean {
-  return config.isPlatinumEnabled();
+  return config.isPlatinumEnabled() || networkBoundaryShimAvailable();
+}
+
+/**
+ * Is the in-guest shim path available?
+ *
+ * Gated so an operator can withdraw it without a code change, and so a
+ * deployment whose sandbox image predates the shim does not advertise a
+ * delivery mode its guests cannot perform. `optBoolTrue` disables on the
+ * literal string `false` only.
+ */
+export function networkBoundaryShimAvailable(): boolean {
+  return config.EGRESS_SHIM_ENABLED;
+}
+
+/**
+ * Which mechanism a given provider uses.
+ *
+ * The provider edge is preferred where it exists: it needs nothing in the guest
+ * and injects for any client, whereas the shim only serves requests routed
+ * through it.
+ */
+export function networkBoundaryMode(providerName: string): 'provider-edge' | 'in-guest-shim' | null {
+  if (providerName === 'platinum' && config.isPlatinumEnabled()) return 'provider-edge';
+  if (networkBoundaryShimAvailable()) return 'in-guest-shim';
+  return null;
 }

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -1320,6 +1320,116 @@ function currentMetaRuntimeFingerprint(): Promise<string> {
   return metaRuntimeFingerprint;
 }
 
+/**
+ * How long a superseded meta image is protected from the reap.
+ *
+ * A deploy rolls replicas one at a time, so for a few minutes the previous
+ * image is still the current one for whoever has not restarted yet. Deleting it
+ * underneath them would break meta sandbox creation mid-rollout.
+ */
+const META_REAP_PROTECT_MS = 60 * 60 * 1000;
+
+/** Names are `kortix-meta-<env>-<hash16>`; see `metaSnapshotName`. */
+const META_SNAPSHOT_PREFIX = 'kortix-meta';
+
+/**
+ * Which of `names` were built recently — same query as
+ * `recentlyBuiltSnapshotNames`, but it lets a failure propagate.
+ *
+ * The difference is the whole point: that function returns an empty set when
+ * the lookup fails, which a caller cannot distinguish from "none were recent".
+ * For a reaper those two mean opposite things.
+ *
+ * Exported for the reap test, which needs to inject a failing lookup.
+ */
+export async function recentlyBuiltStrict(
+  snapshotNames: string[],
+  withinMs: number,
+): Promise<Set<string>> {
+  if (snapshotNames.length === 0) return new Set();
+  const cutoff = new Date(Date.now() - withinMs);
+  const rows = await db
+    .select({ snapshotName: projectSnapshotBuilds.snapshotName })
+    .from(projectSnapshotBuilds)
+    .where(
+      and(
+        inArray(projectSnapshotBuilds.snapshotName, snapshotNames),
+        or(
+          and(eq(projectSnapshotBuilds.status, 'ready'), gt(projectSnapshotBuilds.finishedAt, cutoff)),
+          and(eq(projectSnapshotBuilds.status, 'building'), gt(projectSnapshotBuilds.startedAt, cutoff)),
+        ),
+      ),
+    );
+  return new Set(rows.map((row) => row.snapshotName));
+}
+
+/**
+ * The meta image name, namespaced by environment.
+ *
+ * The namespace is not cosmetic — it is what makes the reap safe. dev,
+ * staging and prod share one Daytona organisation (same API key), so an
+ * un-namespaced reap running on dev would happily delete the image prod is
+ * booting meta sandboxes from. Each environment can only ever see, and
+ * therefore only ever delete, its own.
+ *
+ * Older builds used `kortix-meta-<hash16>` with no namespace. Those names do
+ * not match this prefix pattern and are left alone by the reap; they need one
+ * deliberate cleanup.
+ */
+export function metaSnapshotName(contentHash: string): string {
+  return `${META_SNAPSHOT_PREFIX}-${config.INTERNAL_KORTIX_ENV}-${contentHash.slice(0, 16)}`;
+}
+
+/**
+ * Delete this environment's superseded meta images.
+ *
+ * The meta fingerprint hashes the source trees of the agent, CLI, SDK, shared,
+ * starter and friends, so it changes on essentially every commit that touches
+ * them — roughly every deploy. Nothing reaped the old ones: `ensureMetaSandboxImage`
+ * deleted a snapshot only when its own build had FAILED, never when a newer one
+ * superseded it. Measured 2026-08-12: 118 `kortix-meta-*` snapshots, all under
+ * 14 days old, ~8 per day, against a 200-snapshot organisation quota that was
+ * already exceeded (226) — which fails every CI run and every new-project
+ * build, because those cannot fall back to a last-known-good image.
+ *
+ * Best-effort by construction: a reap failure must never fail the build that
+ * triggered it. The image is already there; tidying is not on the critical path.
+ */
+export async function reapSupersededMetaSnapshots(
+  provider: Pick<SandboxProviderAdapter, 'listSnapshots' | 'deleteSnapshot'>,
+  keepName: string,
+  /** Test seam for the protection lookup; production uses the strict query. */
+  recentLookup: (names: string[], withinMs: number) => Promise<Set<string>> = recentlyBuiltStrict,
+): Promise<void> {
+  try {
+    const mine = `${META_SNAPSHOT_PREFIX}-${config.INTERNAL_KORTIX_ENV}-`;
+    const candidates = (await provider.listSnapshots())
+      .map((snapshot: { name: string }) => snapshot.name)
+      .filter((name: string) => name.startsWith(mine) && name !== keepName);
+    if (candidates.length === 0) return;
+    // Fail CLOSED on the protection lookup. `recentlyBuiltSnapshotNames`
+    // swallows a DB error and returns an empty set — "nothing is protected" —
+    // which for a reap means "delete everything". During a rolling deploy that
+    // would take out the image the not-yet-restarted replicas are booting. A
+    // throw here lands in the outer catch and skips the reap entirely, which is
+    // the right trade: an extra stale image costs one snapshot slot, deleting a
+    // live one breaks meta sandbox creation for the whole environment.
+    const recent = await recentLookup(candidates, META_REAP_PROTECT_MS);
+    for (const name of candidates) {
+      if (recent.has(name)) {
+        console.log(`[snapshots] meta: keeping ${name} (built recently — a replica may still boot it)`);
+        continue;
+      }
+      await provider.deleteSnapshot(name);
+      console.log(`[snapshots] meta: reaped superseded ${name}`);
+    }
+  } catch (err) {
+    console.warn(
+      `[snapshots] meta: reap skipped: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 export async function ensureMetaSandboxImage(opts: {
   source?: SnapshotBuildSource;
   provider: string;
@@ -1330,7 +1440,7 @@ export async function ensureMetaSandboxImage(opts: {
   }
   const fingerprint = await currentMetaRuntimeFingerprint();
   const contentHash = createHash('sha256').update(`meta-runtime-v1\0${fingerprint}`).digest('hex');
-  const snapshotName = `kortix-meta-${contentHash.slice(0, 16)}`;
+  const snapshotName = metaSnapshotName(contentHash);
   const buildKey = `${opts.provider}:${snapshotName}`;
   const existing = metaImageBuilds.get(buildKey);
   if (existing) return existing;
@@ -1350,6 +1460,9 @@ export async function ensureMetaSandboxImage(opts: {
       isShared: true,
       runtimeProfile: 'meta',
     });
+    // Tidy only after the replacement is actually active, so a failed build
+    // can never leave the environment with nothing to boot.
+    await reapSupersededMetaSnapshots(provider, snapshotName);
     return { snapshotName, slug: 'meta', contentHash, built: true, isDefault: false };
   })().finally(() => metaImageBuilds.delete(buildKey));
   metaImageBuilds.set(buildKey, build);

--- a/apps/api/src/snapshots/meta-snapshot-reap.test.ts
+++ b/apps/api/src/snapshots/meta-snapshot-reap.test.ts
@@ -19,6 +19,16 @@ import { describe, expect, test } from 'bun:test';
 import { config } from '../config';
 import { metaSnapshotName, reapSupersededMetaSnapshots } from './builder';
 
+/**
+ * No-op protection lookup: "nothing was built recently".
+ *
+ * Injected in every test that asserts WHICH names are deleted. Without it the
+ * reap uses the real DB-backed query, and the result then depends on whether a
+ * database is reachable — these tests passed locally and failed in CI for
+ * exactly that reason. The DB-backed path has its own test below.
+ */
+const NOTHING_RECENT = async () => new Set<string>();
+
 function fakeProvider(names: string[]) {
   const deleted: string[] = [];
   return {
@@ -53,7 +63,7 @@ describe('meta snapshot reap', () => {
     const foreign = others.map((e) => `kortix-meta-${e}-${'f'.repeat(16)}`);
     const provider = fakeProvider([metaSnapshotName(HASH_A), ...foreign]);
 
-    await reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B));
+    await reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B), NOTHING_RECENT);
 
     // Only our own superseded image goes.
     expect(provider.deleted).toEqual([metaSnapshotName(HASH_A)]);
@@ -64,7 +74,7 @@ describe('meta snapshot reap', () => {
     const keep = metaSnapshotName(HASH_B);
     const provider = fakeProvider([keep, metaSnapshotName(HASH_A)]);
 
-    await reapSupersededMetaSnapshots(provider, keep);
+    await reapSupersededMetaSnapshots(provider, keep, NOTHING_RECENT);
 
     expect(provider.deleted).not.toContain(keep);
     expect(provider.deleted).toContain(metaSnapshotName(HASH_A));
@@ -77,7 +87,7 @@ describe('meta snapshot reap', () => {
     const legacy = `kortix-meta-${'c'.repeat(16)}`;
     const provider = fakeProvider([legacy, metaSnapshotName(HASH_A)]);
 
-    await reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B));
+    await reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B), NOTHING_RECENT);
 
     expect(provider.deleted).not.toContain(legacy);
   });
@@ -92,14 +102,14 @@ describe('meta snapshot reap', () => {
       deleteSnapshot: async () => {},
     };
     await expect(
-      reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B)),
+      reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B), NOTHING_RECENT),
     ).resolves.toBeUndefined();
   });
 
   test('nothing to reap is not an error', async () => {
     const keep = metaSnapshotName(HASH_B);
     const provider = fakeProvider([keep]);
-    await reapSupersededMetaSnapshots(provider, keep);
+    await reapSupersededMetaSnapshots(provider, keep, NOTHING_RECENT);
     expect(provider.deleted).toEqual([]);
   });
 });

--- a/apps/api/src/snapshots/meta-snapshot-reap.test.ts
+++ b/apps/api/src/snapshots/meta-snapshot-reap.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The meta-image reap, and the property that makes it safe to run at all.
+ *
+ * Incident it comes from: `ensureMetaSandboxImage` deleted a snapshot only when
+ * its OWN build had failed, never when a newer one superseded it. The meta
+ * fingerprint hashes the agent/CLI/SDK/shared/starter source trees, so it moves
+ * on roughly every deploy. Measured 2026-08-12 on the live organisation: 118
+ * `kortix-meta-*` snapshots, all under 14 days old, ~8/day, against a
+ * 200-snapshot quota already at 226. Over quota, `POST /snapshots` returns 400,
+ * which fails every CI run and every new-project build — those cannot fall back
+ * to a last-known-good image the way an existing project's session can.
+ *
+ * The dangerous part is that dev, staging and prod share ONE Daytona
+ * organisation (verified: identical API key across all four env profiles). A
+ * reap that is not namespaced would let a dev deploy delete the image prod
+ * boots meta sandboxes from. That is the first test below.
+ */
+import { describe, expect, test } from 'bun:test';
+import { config } from '../config';
+import { metaSnapshotName, reapSupersededMetaSnapshots } from './builder';
+
+function fakeProvider(names: string[]) {
+  const deleted: string[] = [];
+  return {
+    deleted,
+    listSnapshots: async () => names.map((name) => ({ name })),
+    deleteSnapshot: async (name: string) => {
+      deleted.push(name);
+    },
+  };
+}
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+
+describe('meta snapshot naming', () => {
+  test('is namespaced by environment', () => {
+    const name = metaSnapshotName(HASH_A);
+    expect(name).toBe(`kortix-meta-${config.INTERNAL_KORTIX_ENV}-${'a'.repeat(16)}`);
+  });
+
+  test('two different fingerprints get different names', () => {
+    expect(metaSnapshotName(HASH_A)).not.toBe(metaSnapshotName(HASH_B));
+  });
+});
+
+describe('meta snapshot reap', () => {
+  test("never touches another environment's images", async () => {
+    // The whole reason for the namespace. If this regresses, a dev deploy can
+    // delete the image production is booting from.
+    const env = config.INTERNAL_KORTIX_ENV;
+    const others = ['dev', 'staging', 'prod', 'preview'].filter((e) => e !== env);
+    const foreign = others.map((e) => `kortix-meta-${e}-${'f'.repeat(16)}`);
+    const provider = fakeProvider([metaSnapshotName(HASH_A), ...foreign]);
+
+    await reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B));
+
+    // Only our own superseded image goes.
+    expect(provider.deleted).toEqual([metaSnapshotName(HASH_A)]);
+    for (const name of foreign) expect(provider.deleted).not.toContain(name);
+  });
+
+  test('keeps the image just built', async () => {
+    const keep = metaSnapshotName(HASH_B);
+    const provider = fakeProvider([keep, metaSnapshotName(HASH_A)]);
+
+    await reapSupersededMetaSnapshots(provider, keep);
+
+    expect(provider.deleted).not.toContain(keep);
+    expect(provider.deleted).toContain(metaSnapshotName(HASH_A));
+  });
+
+  test('leaves un-namespaced legacy names alone', async () => {
+    // `kortix-meta-<hash>` with no environment segment predates this scheme.
+    // They cannot be attributed to an environment, so the reap must not guess —
+    // they need one deliberate cleanup instead.
+    const legacy = `kortix-meta-${'c'.repeat(16)}`;
+    const provider = fakeProvider([legacy, metaSnapshotName(HASH_A)]);
+
+    await reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B));
+
+    expect(provider.deleted).not.toContain(legacy);
+  });
+
+  test('a listing failure never propagates into the build', async () => {
+    // The image is already active by the time the reap runs. Tidying must not
+    // be able to fail the thing that produced it.
+    const provider = {
+      listSnapshots: async () => {
+        throw new Error('provider unreachable');
+      },
+      deleteSnapshot: async () => {},
+    };
+    await expect(
+      reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B)),
+    ).resolves.toBeUndefined();
+  });
+
+  test('nothing to reap is not an error', async () => {
+    const keep = metaSnapshotName(HASH_B);
+    const provider = fakeProvider([keep]);
+    await reapSupersededMetaSnapshots(provider, keep);
+    expect(provider.deleted).toEqual([]);
+  });
+});
+
+describe('meta snapshot reap — fail-closed protection', () => {
+  test('a failing protection lookup skips the reap entirely', async () => {
+    // The shared `recentlyBuiltSnapshotNames` returns an empty set when its DB
+    // query fails, which a reaper reads as "nothing is protected — delete it
+    // all". Mid-rollout that deletes the image the not-yet-restarted replicas
+    // are booting. This reap must do the opposite and delete nothing.
+    const provider = fakeProvider([metaSnapshotName(HASH_A), metaSnapshotName(HASH_B)]);
+    await reapSupersededMetaSnapshots(provider, metaSnapshotName(HASH_B), async () => {
+      throw new Error('database unreachable');
+    });
+    expect(provider.deleted).toEqual([]);
+  });
+
+  test('a protected name survives while its siblings are reaped', async () => {
+    const keep = metaSnapshotName(HASH_B);
+    const protectedName = metaSnapshotName(HASH_A);
+    const stale = metaSnapshotName('d'.repeat(64));
+    const provider = fakeProvider([keep, protectedName, stale]);
+
+    await reapSupersededMetaSnapshots(provider, keep, async () => new Set([protectedName]));
+
+    expect(provider.deleted).toEqual([stale]);
+  });
+});

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -473,6 +473,55 @@ general egress alongside injection. Stricter is defensible — arguably it is th
 "network boundary" should have had all along — but it is a behaviour difference, not parity,
 and the UI has to say so.
 
+#### 7.4.1 The shim, proven end to end
+
+Built as a second rule mode on the same proxy (`mode: 'broker'`), so the CONNECT and
+TLS-termination machinery is the code already tested in §7.3 rather than a parallel
+implementation. Run inside a **real Kortix session** against the **real dev broker**, with an
+unmodified `curl` and `https_proxy` pointed at the local shim:
+
+```
+SHIM_READY
+--- ca: done.
+--- curl through the shim:
+{"args":{},"headers":{"host":"postman-echo.com","accept":"*/*",
+ "x-proof-token":"[REDACTED]","user-agent":"curl/8.5.0", …},
+ "url":"https://postman-echo.com/get"}
+```
+
+The chain: unmodified client → in-guest shim (terminates TLS, holds nothing) → Kortix broker
+(holds the credential, injects, redacts) → real upstream. **The credential reached the
+destination and was never in the guest.** That is the Platinum property, on a provider with
+no credential edge of its own.
+
+`[REDACTED]` is the broker's server-side scrub of the echoed value, so injection and
+echo-protection are both visible in the one response.
+
+Caveats, stated rather than implied:
+
+- This session was Platinum-backed (`kaab-demo` follows the dev default). The shim is
+  provider-agnostic by construction — it is in-guest code plus HTTPS to the Kortix API, and
+  touches no provider surface — but "provider-agnostic by construction" is an argument, and
+  the Daytona re-run is pending only because dev Daytona provisioning is currently failing
+  (`/start` succeeds, the sandbox never reaches running).
+- No allow-list was applied in this run. Enforcement was measured separately (§7.2); this run
+  measured injection.
+
+### 7.5 What is left
+
+Ordered by what blocks a customer using it:
+
+1. **Provisioning wiring.** Ship the shim in the sandbox image, start it at boot with the
+   session's own token, install the ephemeral CA into the guest trust store and the
+   per-runtime env vars, set `HTTPS_PROXY`, and set `networkAllowList` to the Kortix API.
+2. **Allow-list survival across resume / CoW-restore.** The funnel must not open on restore.
+3. **Clients that ignore `HTTPS_PROXY`** — Node/Bun `fetch` (undici) is the common one.
+   Either an `LD_PRELOAD` shim or documentation; silently losing network is not acceptable.
+4. **Dev Daytona provisioning is broken**, which blocks the Daytona re-run of §7.4.1.
+5. **The Daytona snapshot quota is exhausted** (225 of 200), which fails every CI run that
+   builds a snapshot. Needs a quota raise or a retention policy; the bulk is live product
+   data (`kortix-meta-*`, `kortix-app-*`), not garbage.
+
 
 - **Provisioning wiring.** Mint the CA per session, push it into the guest trust store plus
   the ~11 per-runtime env vars, set `HTTPS_PROXY`, and set `networkAllowList` to the proxy.

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -430,10 +430,50 @@ refactors it — both measured, both silent failures rather than errors:
 
 Hence: a real loopback TLS listener per terminated host, each with a static leaf.
 
-### 7.4 Remaining before this is a product
+### 7.4 Where the proxy runs — split it, and the answer falls out
 
-- **Where the proxy runs.** It needs an address the sandbox can reach and the allow-list can
-  pin. This is the main open infrastructure question.
+The obvious reading of §7.3 is "stand up a public Kortix proxy service": new deployment, new
+TLS surface, a stable address to pin, and Kortix terminating customer traffic at a brand-new
+internet-facing box. That is a lot of new exposure for a credential-handling MITM.
+
+There is a better shape, and it comes from noticing that the proxy does two separable jobs:
+
+1. **Terminate the guest's TLS** so an ordinary client can be intercepted. Must happen
+   *inside* the guest — it is the guest's own connection.
+2. **Hold the credential and call the upstream.** Must happen *outside* the guest.
+
+Nothing requires those to be the same process. Split them:
+
+```
+guest client ──HTTPS──▶ in-guest shim ──HTTPS──▶ Kortix API ──▶ upstream
+                        (ephemeral CA;            (holds the credential,
+                         holds NO secret)          injects, redacts)
+```
+
+The in-guest shim is the proxy in this directory with its injection step replaced by a call
+to the existing broker route — the one already proven end to end in §5.1. It terminates TLS,
+reads the request, and relays it to Kortix, which does what it already does today: resolve
+the secret, apply the host/method policy, inject, perform the request, redact the echo.
+
+Why this is the better answer here:
+
+- **No new public infrastructure.** Sandboxes already reach the Kortix API — it is how every
+  session works. The allow-list pins that address, which we already own and which is stable.
+- **The in-guest component holds no secret.** It is fully untrusted. An agent that reads it,
+  patches it, or kills it learns nothing; under the allow-list, killing it costs the agent
+  its own networking. Fail-closed, and security never rests on guest-side code.
+- **Kortix does not MITM arbitrary traffic.** Only requests the shim relays reach us, and only
+  policy hosts have rules. We are not terminating the whole internet on a shared box.
+- **It reuses a proven path.** The broker is shipped, tested, and verified live; this makes it
+  transparent rather than replacing it.
+
+The consequence to state plainly: with the allow-list pinned to Kortix, a session in boundary
+mode can reach **only its approved hosts**. That is stricter than Platinum, which permits
+general egress alongside injection. Stricter is defensible — arguably it is the posture a
+"network boundary" should have had all along — but it is a behaviour difference, not parity,
+and the UI has to say so.
+
+
 - **Provisioning wiring.** Mint the CA per session, push it into the guest trust store plus
   the ~11 per-runtime env vars, set `HTTPS_PROXY`, and set `networkAllowList` to the proxy.
 - **Allow-list survival across resume / CoW-restore** — the funnel must not open on restore.

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -351,13 +351,49 @@ So the honest positioning of Track B on Daytona is **enforced, selectively trans
 strictly weaker on ergonomics than Platinum, identical on confidentiality. Any UI copy must
 say which one a project is getting.
 
-### 7.2 Still worth measuring before building
+### 7.2 Phase-1 measurements — RUN 2026-08-12
 
-- `domainAllowList` (surfaced in a validation error, absent from the SDK typings): if it
-  accepts DNS names it removes the CIDR-only constraint and the DNS breakage in §6b.
-- Live `updateNetworkSettings()` on a running sandbox, and behaviour across resume /
-  CoW-restore — the allow-list must survive both or the funnel has a hole.
-- Whether the proxy can be reached over Daytona's own network without a public address.
+Control-vs-treatment on throwaway sandboxes from `kortix-default-b539f1be09d3`.
+
+**`domainAllowList` does nothing.** With `domainAllowList: 'api.github.com'`, the listed
+host, an unlisted host, and a raw IP all returned 200 for both the user and root —
+byte-identical to a sandbox created with no options at all. Like `outboundProxyUrl`, the
+API accepts it and drops it. Only `networkBlockAll` and `networkAllowList` are real.
+
+> A first pass at this looked like an *inverted* allow-list (listed host `000`, unlisted
+> host `200`, root reaching what the user could not) and would have gone into this doc as a
+> security finding. It was a transient `curl 000`. Every probe here is now three
+> repetitions; single-shot `curl` exit codes are not evidence.
+
+**A CIDR allow-list needs the DNS resolvers in it.** This is the load-bearing result:
+
+| create option | github | example.com | DNS | root → github |
+| --- | --- | --- | --- | --- |
+| `networkAllowList: 140.82.112.0/20` | 000 | 000 | **timeout** | 000 |
+| `…/20` + `1.1.1.1/32,8.8.8.8/32,169.254.0.0/16` | **200** | **000** | RESOLVED | 200 (listed host) |
+
+With the resolver ranges added, the funnel behaves exactly as Track B needs: the listed
+destination is reachable, everything else is refused, and root is refused too.
+
+**The funnel can be closed on a RUNNING sandbox.** `sandbox.updateNetworkSettings({
+networkBlockAll: true })` on a live, previously-open sandbox took effect immediately — all
+egress, DNS, and root egress went to 000 without a restart.
+
+**Upstream IPs are not stable.** `api.github.com` resolved to `172.182.252.137` in one
+sandbox and `140.82.112.6` in another, and the resolver set itself varied
+(`1.1.1.1 / 1.0.0.1 / 100.65.160.1` vs `1.1.1.1 / 1.0.0.1 / 8.8.8.8`). Allow-listing an
+*upstream* by CIDR is therefore unreliable by construction. Allow-listing **our own proxy**
+is not — we own that address. This is another reason the design must funnel through a proxy
+rather than try to express policy as vendor allow-list entries.
+
+**Consequence for the guest's DNS:** none needed. The allow-list pins the proxy by IP and
+`HTTPS_PROXY` names that IP, so the guest never resolves anything; the proxy resolves
+upstream names on its behalf. That sidesteps the resolver variability entirely.
+
+### 7.3 Still unmeasured
+
+- Allow-list survival across resume / CoW-restore — the funnel must not open on restore.
+- Where the proxy runs so a sandbox can reach it (public address vs Daytona-internal).
 
 ## 8. What I would not build
 

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -390,10 +390,55 @@ rather than try to express policy as vendor allow-list entries.
 `HTTPS_PROXY` names that IP, so the guest never resolves anything; the proxy resolves
 upstream names on its behalf. That sidesteps the resolver variability entirely.
 
-### 7.3 Still unmeasured
+### 7.3 The proxy — built, and proven in a real Daytona guest
 
-- Allow-list survival across resume / CoW-restore — the funnel must not open on restore.
-- Where the proxy runs so a sandbox can reach it (public address vs Daytona-internal).
+`apps/api/src/secrets/egress-proxy/` (`ca.ts`, `proxy.ts`). CONNECT to a host carrying an
+injection rule is terminated with a per-sandbox ephemeral CA, the header is added, and the
+credential is redacted from the response. A host with no rule is tunnelled blind.
+
+11 tests, no mocks: real HTTPS upstream, real CONNECT, real interception. Live run on a
+throwaway Daytona sandbox (`kortix-default-b539f1be09d3`), proxy bundled and executed inside
+the guest, CA installed into the system store with `update-ca-certificates`:
+
+```
+curl/8.5.0            {"headers":{…,"x-proof-token":"[REDACTED]",…},"url":"https://postman-echo.com/get"}
+python-requests/2.34.2 {"headers":{…,"x-proof-token":"[REDACTED]",…}}
+api.github.com (no rule) -> 200      # tunnelled untouched
+credential in guest env  -> 0 occurrences
+```
+
+Two independent TLS stacks (curl/OpenSSL and python-requests) both accepted the ephemeral CA
+and both reached the upstream **with the credential attached, having never held it**. The
+`[REDACTED]` in the echo is the response-scrubbing working on the same request — injection
+and echo-protection demonstrated in one call.
+
+> **What this run does and does not show.** The proxy ran *inside* the sandbox, which is not
+> where it runs in production. Its location is not what was under test: enforcement is the
+> allow-list's job and was measured separately (§7.2). What this shows is that the injection
+> mechanism survives contact with a real Linux guest — cert trust, ordinary HTTP clients, a
+> real upstream. Note also that the credential was present in the guest in this run, inside
+> the proxy bundle itself; in production that bundle is not in the guest.
+
+Two runtime divergences shaped the implementation and are worth knowing before anyone
+refactors it — both measured, both silent failures rather than errors:
+
+- **`http.Server.emit('connection', socket)` is a no-op under Bun.** The canonical way to run
+  an HTTP parser over a socket you already own does nothing; the request event never fires
+  and the connection hangs. The same script works under Node.
+- **`SNICallback` never fires under Bun.** The handshake completes against a default
+  certificate instead, so a single listener choosing certs per SNI cannot work.
+
+Hence: a real loopback TLS listener per terminated host, each with a static leaf.
+
+### 7.4 Remaining before this is a product
+
+- **Where the proxy runs.** It needs an address the sandbox can reach and the allow-list can
+  pin. This is the main open infrastructure question.
+- **Provisioning wiring.** Mint the CA per session, push it into the guest trust store plus
+  the ~11 per-runtime env vars, set `HTTPS_PROXY`, and set `networkAllowList` to the proxy.
+- **Allow-list survival across resume / CoW-restore** — the funnel must not open on restore.
+- **Clients that ignore `HTTPS_PROXY`** (notably Node/Bun `fetch`) reach nothing once the
+  allow-list is on. Needs either an `LD_PRELOAD` shim or honest documentation.
 
 ## 8. What I would not build
 

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -126,6 +126,7 @@ Compared with the network boundary:
 | host matching | exact only | wildcards, paths, methods |
 | injection slots | one header | header, query, JSON body |
 | per-request audit | no | **yes** |
+| **credential echoed by upstream** | connection cut (`on_echo`) | **redacted, response still returned** |
 | transparent to the agent | **yes** | no — must call `kortix secrets call` |
 | TLS interception needed | yes (Platinum's) | **none** |
 
@@ -133,10 +134,100 @@ On **confidentiality the broker is equal**, on **authorization and audit it is s
 it needs no MITM. Its only deficit is transparency. An agent that ignores the broker does not
 get a weaker credential — it gets **no** credential.
 
+**Correction to an earlier draft of this doc.** It claimed `on_echo` had no broker equivalent.
+It does: `redactSecretFromResponse` (`apps/api/src/secrets/http-broker.ts:350`) scrubs the
+value from the response body in four representations — raw, URL-encoded, base64, and
+JSON-escaped — and returns the rest of the response normally. That is *better* than the
+boundary's behaviour, not worse: Platinum kills the connection, which surfaces as
+`curl: (52) Empty reply from server` and is the single largest source of "this feature is
+broken" reports we have had (§4). The broker gives the agent a usable response with
+`[REDACTED]` where the credential would have been. Verified live — see §5.1.
+
 **Why customers do not have it: reach, not capability.** `kortix secrets call` is a string in a
-system-prompt file. There is no MCP tool for it
-(`apps/cli/src/connector-gateway/mcp.ts` has eight connector tools and no secret tool), and
-models reach for tools far more reliably than for documented shell commands.
+system-prompt file, and models reach for tools far more reliably than for documented shell
+commands.
+
+### 5.1 Verified live on dev, 2026-08-12
+
+Project `kaab-demo`, secret `BROKER_PROOF`, policy `broker`/`http_broker` with
+`--allow-host postman-echo.com --allow-method GET --inject-header x-proof-token`. A real
+session agent ran `kortix secrets call BROKER_PROOF https://postman-echo.com/get`:
+
+```
+Upstream status: 200
+{"args":{},"headers":{"host":"postman-echo.com",…,"x-proof-token":"[REDACTED]",…}}
+```
+
+Three facts in one response: the header **arrived at the upstream** (so Kortix injected it
+outside the sandbox), the call **succeeded** (200), and the echoed value came back
+**redacted** rather than killing the connection.
+
+The authorization gate was also observed working: before the agent's `secrets:` grant named
+`BROKER_PROOF`, the identical call returned
+`✗ secret delivery denied: agent_grant_excludes`.
+
+**Caveat — this ran on Platinum.** `kaab-demo` inherits the dev platform default, which is
+Platinum, so this proves the broker works but not yet that it works on Daytona. The broker
+executes entirely in the API process (`http-broker.ts`) and touches no provider API, so
+there is no mechanism by which the provider could matter — but that is an argument, not a
+measurement, and this doc does not accept arguments where a measurement is available.
+Daytona confirmation is tracked in §5.2.
+
+### 5.2 The MCP tool, end to end — and the premise it disproved
+
+`secret_call` verified live on dev (2026-08-12, commit `3d03cc68`), invoked as a real MCP
+`tools/call` inside a sandbox:
+
+```json
+{"ok": true, "status": 200,
+ "body": "{\"headers\":{\"x-proof-token\":\"[REDACTED]\", …},\"url\":\"https://postman-echo.com/get\"}"}
+```
+
+The tool works. **But the reason given for building it does not hold.** §6 argued that
+`kortix secrets call` was unreachable in practice because "models reach for tools far more
+reliably than for documented shell commands". Tested with a prompt that named neither the
+tool nor the command — *"Fetch https://postman-echo.com/get with our BROKER_PROOF credential
+attached"* — the agent went straight to the CLI on its first move:
+
+> `BROKER_PROOF`: HTTPS broker. Use `kortix secrets call BROKER_PROOF <https-url> [options]`.
+> So I need to use `kortix secrets call BROKER_PROOF https://postman-echo.com/get`.
+
+One turn, `200`, header injected. It never considered the MCP tool — reasonably, because the
+capabilities instruction it reads (`secret-capabilities.ts`) names the CLI command and says
+nothing about a tool.
+
+So the honest scoring of Track A step 1: the broker was **already discoverable** through the
+instruction file, and the tool is a second door onto the same room rather than the first door
+onto a locked one. It is still worth having (a host that only speaks MCP now has a path, and
+tool calls are structured where shell output is not), but it was not the highest-leverage
+change in this doc and this section should be read before anyone repeats that claim.
+
+If the tool is meant to be the preferred path, the instruction renderer has to say so —
+that is a one-line change in `secret-capabilities.ts`, not a new capability.
+
+### 5.3 Where the broker is NOT equivalent to Platinum
+
+Worth stating plainly, because a passing end-to-end test makes them look identical and they
+are not:
+
+| | Platinum boundary | broker (today, any provider) |
+| --- | --- | --- |
+| agent calls the API itself | works | works |
+| a Python script the agent writes | **works** | **no credential** |
+| a third-party SDK / CLI in the sandbox | **works** | **no credential** |
+| `curl` in a Makefile, a test suite, a build step | **works** | **no credential** |
+
+Platinum injects for *any* process making an allow-listed HTTPS request; the broker injects
+only for requests routed through `secret_call` / `kortix secrets call`. Everything else in
+the sandbox gets an unauthenticated request, not a failed one — which fails at the upstream
+rather than locally, and is the more confusing failure.
+
+Closing that gap is exactly Track B, and §6b establishes its precondition holds: Daytona's
+egress control is enforced on the runner and root inside the guest cannot bypass it.
+
+Note also that the agent, unprompted, described the broker's injection as happening "at the
+network boundary". The two mechanisms are already being conflated in transcripts; the naming
+in the product should separate them.
 
 ## 6. Recommendation — two tracks, in this order
 
@@ -145,12 +236,38 @@ models reach for tools far more reliably than for documented shell commands.
 The fastest path to a real capability for Daytona customers.
 
 1. **Add an MCP tool** for the broker so the model discovers it the way it discovers everything
-   else. Highest-leverage single change in this doc.
+   else. **Done** — `secret_call` in `apps/cli/src/connector-gateway/mcp.ts`.
+
+   This step was written on a false premise and the premise had to be fixed first. The doc
+   assumed the `kortix-connectors` MCP server was a live surface with eight tools on it. It is
+   not, for two independent reasons found while implementing:
+
+   - **It was broken.** The daemon registered `kortix connector mcp` (singular) while the CLI
+     only routes `connectors`. OpenCode's launcher got `unknown command` and exit 2, so the
+     server never started. Introduced by e868be1d6c on 2026-08-06 — the same commit that
+     renamed `executor` → `connectors` — and invisible because the daemon's unit tests were
+     updated to assert the typo'd literal. Fixed, with a CLI-side guard that now runs the argv
+     the daemon registers and requires a clean JSON-RPC handshake.
+   - **It is disabled.** `KORTIX_CONNECTORS_MCP_ENABLED` appears in tests and nowhere else —
+     no values.yaml, no env profile. The CLI is the deliberate agent-facing default
+     (87ad9a3665, "refactor executor to prefer cli surface").
+
+   So `secret_call` is correct and tested but reaches no production agent until that flag is
+   turned on. **That flag flip is a product decision, not a bug fix** — it adds nine tools to
+   every agent's context — and is deliberately left to the owner rather than taken here.
+   Until then the live channel for broker discovery remains the capabilities instruction file
+   (`/tmp/kortix/secret-capabilities.md`), which already names `kortix secrets call`.
 2. **Stop offering `egress` on projects that cannot run it.** Already partly done — the UI now
    gates on the project's active provider — but the *strategy picker* should present the broker
    as the Daytona-native option rather than showing a disabled control.
-3. **Fix the dead limb**: `broker`/`git_proxy` advertises `delivery_status:'available'`
-   (`apps/api/src/projects/lib/serializers.ts:451`) while no execution path implements it.
+3. ~~**Fix the dead limb**: `broker`/`git_proxy` advertises `delivery_status:'available'`
+   while no execution path implements it.~~ **Withdrawn — the claim was false.** `git_proxy`
+   is consumed at `apps/api/src/projects/lib/git.ts:569`, which resolves the git credential
+   server-side for push/pull. It is narrow (one call site, one fixed key
+   `KORTIX_GIT_AUTH_TOKEN`) but it is live. And `delivery_status` documents itself, in a
+   comment directly above the branch, as "does this *deployment* support the mode" — not
+   "will this particular secret be consumed" — so `available` is the correct value under the
+   field's own semantics. Nothing to fix.
 4. **Docs**: one page, "which delivery mode do I want", with the table from §5.
 
 ### Track B — an enforced Kortix egress proxy (gated on the §7 experiment)
@@ -177,53 +294,9 @@ Non-negotiables:
 - **Honest labelling.** If the §7 experiment fails, the UI must say *cooperative on Daytona,
   enforced on Platinum* — in the product, not only in docs.
 
-## 6b. EXPERIMENT RESULT — the funnel is real and root-proof
+## 7. The blocking experiment — run before writing any Track B code
 
-Run 2026-08-11 against `api.daytona.io` with a throwaway sandbox on
-`kortix-default-b539f1be09d3`, driving the SDK directly (no Kortix code in the path).
-
-**`networkBlockAll: true`**
-
-| probe | result |
-| --- | --- |
-| `curl https://api.github.com/rate_limit` | `000` |
-| `curl --noproxy '*'` | `000` |
-| raw Python socket to `140.82.121.6:443` | **Connection refused** |
-| DNS (`getent hosts`) | timeout |
-| **`sudo -n curl`** (as **root**) | **`000`** |
-| `sudo -n iptables -F` | `iptables: command not found` |
-| control: same sandbox, `networkBlockAll: false` | all **200 / CONNECTED** |
-
-**`networkAllowList: 140.82.112.0/20`** (GitHub's range; `networkBlockAll` must be OFF —
-the two are mutually exclusive, `400 DaytonaValidationError`)
-
-| probe | result |
-| --- | --- |
-| allowed CIDR, by IP | **200** |
-| allowed host **by DNS name** | `000` |
-| `1.1.1.1`, `example.com` | `000` |
-| **root**, not-allowed host | `000` |
-
-**Verdicts**
-
-1. **Daytona's egress control is enforced on the runner and root inside cannot bypass it.**
-   `iptables` is not even present in the guest because the rules do not live there. This is a
-   genuine non-bypassable funnel — the precondition for Track B. The `outboundProxyUrl`
-   enforcement claim no longer has to be taken on faith; the same mechanism demonstrably holds
-   against root.
-2. **`networkBlockAll` and the allow-lists are mutually exclusive.** Allow-list mode is
-   `networkAllowList` alone. The SDK error also reveals a `domainAllowList`, which is not in the
-   typings we read and should be investigated — a domain allow-list would solve DNS more cleanly
-   than a CIDR one.
-3. **DNS is the first real design constraint.** With a CIDR allow-list, name resolution fails —
-   the resolver is not in the list, so only literal IPs work. Track B must either allow the
-   resolver explicitly, resolve names at the proxy (guest sends `CONNECT host:443` to the proxy
-   and never resolves anything itself), or use `domainAllowList`. **Proxy-side resolution is the
-   right answer** and is what the prior art does.
-
-## 7. Remaining experiment — `outboundProxyUrl` specifically
-
-§6b removes the risk from this, but the proxy path itself is still unexercised.
+Cheap, and it can kill the plan.
 
 1. Create a Daytona sandbox with `outboundProxyUrl` pointed at a sink we control.
 2. From inside the guest, attempt egress that deliberately ignores the proxy:
@@ -231,10 +304,10 @@ the two are mutually exclusive, `400 DaytonaValidationError`)
    - a raw Python socket to a public IP on 443
    - an outbound SSH connection
    - the same three again after `sudo -i`
-3. **If all are dropped** → proceed. (§6b already shows the enforcement mechanism holds against
-   root, so the expected answer is yes; this confirms it for the proxy-chaining path specifically.)
-4. **If any succeeds** → belt-and-braces: pin egress with `networkAllowList` restricted to the
-   proxy's CIDR, which §6b proves is enforced. Either way Track B is viable.
+3. **If all are dropped** → `outboundProxyUrl` is enforced. Track B delivers a Platinum-class
+   guarantee on Daytona; proceed.
+4. **If any succeeds** → it is cooperative. Track B becomes leak-prevention only, and the
+   product must say so. Track A becomes the security story.
 
 Secondary experiments, only if (3): `networkBlockAll` + `networkAllowList` restricted to the
 proxy CIDR, live `updateNetworkSettings()` on a running sandbox, and behaviour on
@@ -251,10 +324,7 @@ resume/CoW-restore.
 
 ## 9. Open questions
 
-1. Does `outboundProxyUrl` block non-conforming clients on its own? (§7 — no longer blocking:
-   `networkAllowList` is proven enforced and can pin egress to the proxy regardless.)
-1b. What is `domainAllowList`? It appears in a server-side validation error but not in the
-   typings we read. A domain allow-list may remove the DNS problem entirely.
+1. Does `outboundProxyUrl` actually block non-conforming clients? (§7 — blocking)
 2. Are we willing to operate a credential-handling MITM for customer traffic, with the
    compliance surface that implies?
 3. Should the guest get a **placeholder** instead of nothing, matching the rest of the industry?

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -515,8 +515,7 @@ Ordered by what blocks a customer using it:
    session's own token, install the ephemeral CA into the guest trust store and the
    per-runtime env vars, set `HTTPS_PROXY`, and set `networkAllowList` to the Kortix API.
 2. **Allow-list survival across resume / CoW-restore.** The funnel must not open on restore.
-3. **Clients that ignore `HTTPS_PROXY`** — Node/Bun `fetch` (undici) is the common one.
-   Either an `LD_PRELOAD` shim or documentation; silently losing network is not acceptable.
+3. **Clients that ignore `HTTPS_PROXY`** — measured, and less bad than assumed (§7.6).
 4. **Dev Daytona provisioning is broken**, which blocks the Daytona re-run of §7.4.1.
 5. **The Daytona snapshot quota is exhausted** (225 of 200), which fails every CI run that
    builds a snapshot. Needs a quota raise or a retention policy; the bulk is live product
@@ -554,3 +553,34 @@ Ordered by what blocks a customer using it:
 - `apps/web/content/docs/project/secrets.mdx` — the user-facing explainer
 - `.claude/skills/learnings/SKILL.md` — "A per-turn hot path must not contain an unbounded
   third-party round-trip", the incident that came out of this feature
+
+### 7.6 Which in-guest clients actually honour the proxy — measured
+
+Once the allow-list permits only the proxy, a client that ignores `https_proxy` reaches
+**nothing**. §7.1 asserted from general knowledge that Node/Bun `fetch` was the problem case.
+Measured in a real guest, that was half wrong:
+
+| client | routed through the proxy? |
+| --- | --- |
+| `curl` 8.5.0 | yes |
+| `bun` `fetch` | **yes** — the earlier claim that it would not was wrong |
+| `node` `fetch` (undici) | **no**, goes direct |
+| `node` with `NODE_USE_ENV_PROXY=1` | **yes** |
+| `python3` `requests` | yes, but needs `REQUESTS_CA_BUNDLE` or it fails cert verification |
+| `git` 2.43.0 | yes — **after fixing a bug in this proxy**, below |
+
+So the mitigation is a handful of environment variables set at provision — `NODE_USE_ENV_PROXY`,
+`REQUESTS_CA_BUNDLE`, and the rest of the per-runtime CA vars — not an `LD_PRELOAD` shim. That
+is a much smaller and much less fragile piece of work than §7.1 assumed.
+
+**The git bug, because it is the kind that only real clients find.** `git` sends
+`CONNECT`, receives the 407 challenge, and retries with credentials **on the same
+connection** (`Proxy-Connection: Keep-Alive`). Node hands the raw socket to the `connect`
+handler, so after the 407 nothing is parsing that socket and the retry went into the void:
+`fatal: unable to access …: Proxy CONNECT aborted`. Every clone, fetch, and push through the
+proxy failed, while `curl` was unaffected because it opened a new connection.
+
+The fix is two headers on the 407 — `Content-Length: 0` and `Connection: close` — telling the
+client to reconnect rather than reuse. Verified after the change: `git ls-remote` returns the
+real SHA and `git clone` completes, with injection and blind tunnelling both still correct.
+Pinned by a regression test that asserts the framing.

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -1,8 +1,14 @@
 # Network-boundary secrets on Daytona
 
-**Status:** proposal, awaiting one blocking experiment
-**Author:** drafted 2026-08-11
+**Status:** mechanism built and proven end to end (§7.3, §7.4.1); not yet wired into
+provisioning (§7.5)
+**Author:** drafted 2026-08-11, substantially revised 2026-08-12 after measurement
 **Problem owner:** production runs on Daytona; the feature exists only on Platinum
+
+> **Read §7 before §3.** Several claims in the early sections were written from vendor docs
+> and general knowledge, then disproved by measurement. Where they conflict, the measured
+> result in §7 wins. The wrong claims are left in place with corrections attached rather than
+> quietly edited, because the pattern of *how* they were wrong is the useful part.
 
 ---
 
@@ -76,13 +82,19 @@ What Daytona does **not** have: a secret store, TLS termination, header injectio
 feature cannot be ported provider-natively; it can only be **rebuilt** with Daytona supplying
 the funnel and Kortix supplying the injection.
 
-### 3.3 The claim the whole design rests on
+### 3.3 ~~The claim the whole design rests on~~ — settled, and it was moot
 
 Daytona's docs state: *"Clients that do not respect `HTTP_PROXY` are blocked at egress."*
 
-If true, `outboundProxyUrl` is an **enforced** chaining point and a Kortix-operated proxy gets
-the same class of guarantee as Platinum. If false, it is **cooperative** and a determined agent
-walks around it. **This is unverified and is the first thing to test** (§7).
+The original plan hung on whether that made `outboundProxyUrl` **enforced** or merely
+**cooperative**. The question turned out not to matter: **`outboundProxyUrl` is not
+implemented at all** (§7). The sentence in the vendor docs describes a feature this API does
+not have.
+
+Worth keeping as a marker: a whole architecture was designed around one sentence of vendor
+documentation, and the field it referred to did not exist. The lesson generalises past this
+doc — before building on a provider capability, send it a request that must fail if the
+capability is real.
 
 ## 4. Prior art
 

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -519,19 +519,60 @@ Caveats, stated rather than implied:
 - No allow-list was applied in this run. Enforcement was measured separately (§7.2); this run
   measured injection.
 
-### 7.5 What is left
+### 7.5 Wiring — what is done, what is left
 
-Ordered by what blocks a customer using it:
+#### Done: the server half (behind `EGRESS_SHIM_ENABLED`, default OFF)
 
-1. **Provisioning wiring.** Ship the shim in the sandbox image, start it at boot with the
-   session's own token, install the ephemeral CA into the guest trust store and the
-   per-runtime env vars, set `HTTPS_PROXY`, and set `networkAllowList` to the Kortix API.
-2. **Allow-list survival across resume / CoW-restore.** The funnel must not open on restore.
-3. **Clients that ignore `HTTPS_PROXY`** — measured, and less bad than assumed (§7.6).
-4. **Dev Daytona provisioning is broken**, which blocks the Daytona re-run of §7.4.1.
-5. **The Daytona snapshot quota is exhausted** (225 of 200), which fails every CI run that
-   builds a snapshot. Needs a quota raise or a retention policy; the bulk is live product
-   data (`kortix-meta-*`, `kortix-app-*`), not garbage.
+Three gates stood between a non-Platinum project and this feature.
+
+1. **The relay route.** `POST /projects/:id/secrets/:identifier/broker` rejected anything that
+   was not `strategy:'broker'`. It now also accepts `egress`/`network`. This cost almost
+   nothing: a boundary policy *is* a `SecretEgressPolicy`, and `prepareSecretBrokerRequest`
+   reads only `rules` and `inject` — never `backend` — so the existing engine executes it
+   unchanged. The policy is re-validated at request time rather than trusted from the row.
+   Audit metadata now derives the consumer instead of hardcoding `http_broker`.
+2. **`networkBoundaryDeliveryAvailable()`** was `config.isPlatinumEnabled()` alone. That one
+   expression is why no production project could ever use this feature.
+3. **The provider gate — in TWO places.** `startNetworkBoundaryArm`
+   (`projects/lib/sandbox-env-sync.ts`) and a duplicated pre-check in
+   `platform/services/session-sandbox.ts`, sharing a message string. Relaxing only the first
+   still fails provisioning, one frame later. Both now consult the shim. The post-create call
+   also dropped a `provider.syncNetworkBoundary!` non-null assertion that was safe only while
+   the pre-check guaranteed the method existed — with a shim-backed provider reaching it, that
+   would have been a TypeError at provision time instead of a clean skip.
+
+**The flag defaults OFF deliberately.** Turning it on makes the API *advertise* boundary
+delivery to non-Platinum projects — the save gate, `delivery_status`, and the web control all
+read it. Until the guest actually runs the shim, that is a feature that looks available and
+silently does nothing, which is the failure this whole document exists to unpick. Flip it once
+a fresh sandbox has been *observed* running the shim, not merely once the code is merged.
+
+#### Left: the guest half
+
+1. **Ship the shim and start it.** No new image artifact is needed — the daemon already ships
+   in the image and already starts child processes, so it can host the shim. It needs the
+   session token, project id, and the host->identifier rules (no values).
+2. **Trust the CA.** Install the ephemeral CA into the system store *and* the per-runtime env
+   vars. §7.6 measured which ones actually matter.
+3. **Point the clients.** `HTTPS_PROXY` plus `NODE_USE_ENV_PROXY=1` and `REQUESTS_CA_BUNDLE`.
+4. **The web gate.** `apps/web/.../secret-delivery.ts` requires the project to run Platinum and
+   does **not** read `network_boundary_available`. That is correct while the flag is off, and
+   wrong the moment it flips — the API has to expose which mode applies
+   (`provider-edge` vs `in-guest-shim`) and the web has to read it. Belongs with this half,
+   not before it.
+5. **Optional: the allow-list.** Not required for the security property — an agent that
+   bypasses the shim gets an *unauthenticated* request, not a credential — so it is egress
+   restriction, a separate feature. It also needs a stable Kortix egress address, which
+   `dev-api` (Cloudflare-fronted) does not provide.
+
+#### Blocked on infrastructure, not code
+
+- **Dev Daytona provisioning is failing** (`/start` succeeds, the sandbox never reaches
+  running), which blocks the Daytona re-run of §7.4.1.
+- **The Daytona snapshot quota is exhausted** — 225 of 200 — so every CI run that builds a
+  snapshot fails, on any PR. Deleting all 18 CI snapshots only reaches 207; the bulk is live
+  product data (`kortix-meta-*` 117, `kortix-app-*` 38). Needs a quota raise or a retention
+  policy.
 
 
 - **Provisioning wiring.** Mint the CA per session, push it into the guest trust store plus

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -61,10 +61,15 @@ The pinned SDK (`@daytonaio/sdk@0.184.0`) exposes, at create **and** live via
 
 - `networkBlockAll` — default-deny egress
 - `networkAllowList` — CIDR allow-list
-- `outboundProxyUrl` — chain egress to a proxy **you** operate
 
 Documented as *"the runner applies iptables rules to the sandbox container"* — i.e. on the
-host, outside guest control. **We pass none of these today.**
+host, outside guest control. **We pass neither today.**
+
+> **`outboundProxyUrl` does not exist.** An earlier draft listed it here as a third option
+> and built all of Track B on it. It is absent from the pinned SDK's typings, and the API
+> silently ignores it — see §7, which is now a settled negative result, not a pending
+> experiment. Treat any vendor-proxy-chaining design as unavailable until Daytona ships the
+> feature.
 
 What Daytona does **not** have: a secret store, TLS termination, header injection, or any
 `on_echo` equivalent. Zero of the ten Platinum primitives the boundary depends on. So the
@@ -294,24 +299,65 @@ Non-negotiables:
 - **Honest labelling.** If the §7 experiment fails, the UI must say *cooperative on Daytona,
   enforced on Platinum* — in the product, not only in docs.
 
-## 7. The blocking experiment — run before writing any Track B code
+## 7. The blocking experiment — RUN. Result: `outboundProxyUrl` is ignored
 
-Cheap, and it can kill the plan.
+Run 2026-08-12 against `app.daytona.io/api` on throwaway sandboxes from
+`kortix-default-b539f1be09d3`, control vs treatment, deleted after.
 
-1. Create a Daytona sandbox with `outboundProxyUrl` pointed at a sink we control.
-2. From inside the guest, attempt egress that deliberately ignores the proxy:
-   - `curl --noproxy '*' https://api.github.com/rate_limit`
-   - a raw Python socket to a public IP on 443
-   - an outbound SSH connection
-   - the same three again after `sudo -i`
-3. **If all are dropped** → `outboundProxyUrl` is enforced. Track B delivers a Platinum-class
-   guarantee on Daytona; proceed.
-4. **If any succeeds** → it is cooperative. Track B becomes leak-prevention only, and the
-   product must say so. Track A becomes the security story.
+Treatment set `outboundProxyUrl` to `http://198.51.100.7:3128` — RFC 5737 TEST-NET-2, which
+cannot route anywhere. If the runner forced egress through it, every request would die.
 
-Secondary experiments, only if (3): `networkBlockAll` + `networkAllowList` restricted to the
-proxy CIDR, live `updateNetworkSettings()` on a running sandbox, and behaviour on
-resume/CoW-restore.
+| probe | control (no options) | `outboundProxyUrl` set |
+| --- | --- | --- |
+| `curl https://api.github.com/rate_limit` | 200 | **200** |
+| `curl --noproxy '*'` | 200 | 200 |
+| `$HTTPS_PROXY` / `$https_proxy` in guest | unset | **unset** |
+| raw Python socket to `140.82.121.6:443` | CONNECTED | CONNECTED |
+| DNS | RESOLVED | RESOLVED |
+| `sudo -n curl` (root) | 200 | 200 |
+
+Identical in every cell. The field is not enforced and not even **applied** — the runner
+does not so much as set the proxy env var. Consistent with the API validator, which is
+lenient about unknown properties: a deliberately invented `zzTotallyMadeUpField` produced
+no complaint either, so a clean 200 on create says nothing about a field being real.
+
+**Consequence: the transparent-redirect architecture in §6 Track B is unbuildable as
+written.** Daytona gives us a funnel we can close (§6b) but no vendor mechanism to redirect
+traffic into a proxy.
+
+### 7.1 What Track B has to look like instead
+
+Split the two properties, because on Daytona they now come from different places:
+
+- **Enforcement** comes from `networkAllowList` restricted to the Kortix proxy's address.
+  Runner-applied, root-proof, already measured (§6b). Nothing escapes the guest, ever.
+- **Transparency** cannot come from the runner. The guest has to be *pointed* at the proxy:
+  `HTTPS_PROXY`/`HTTP_PROXY` in the sandbox env, and for clients that ignore those, an
+  `LD_PRELOAD` socket shim (proxychains-style).
+
+The pleasant property of that split: the transparency layer is removable and its removal is
+**fail-closed**. An agent that unsets `HTTPS_PROXY` does not gain a bypass — the allow-list
+still permits only the proxy, so it simply loses network. Security does not depend on the
+part the guest can touch.
+
+The unpleasant one: **in-guest transparent redirect is impossible**, so any client that
+honours neither the env var nor the shim gets no network at all. That is not hypothetical —
+Node/Bun `fetch` (undici) ignores `HTTP_PROXY` by default, and agents write `fetch` code
+constantly. Note also that in-guest `iptables` is doubly out: it is absent from the image
+*and* the container holds no capabilities (`CapEff: 0000000000000000`, §3.1), so even root
+cannot install a redirect rule.
+
+So the honest positioning of Track B on Daytona is **enforced, selectively transparent** —
+strictly weaker on ergonomics than Platinum, identical on confidentiality. Any UI copy must
+say which one a project is getting.
+
+### 7.2 Still worth measuring before building
+
+- `domainAllowList` (surfaced in a validation error, absent from the SDK typings): if it
+  accepts DNS names it removes the CIDR-only constraint and the DNS breakage in §6b.
+- Live `updateNetworkSettings()` on a running sandbox, and behaviour across resume /
+  CoW-restore — the allow-list must survive both or the funnel has a hole.
+- Whether the proxy can be reached over Daytona's own network without a public address.
 
 ## 8. What I would not build
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       livekit-server-sdk:
         specifier: ^2.17.0
         version: 2.17.0
+      node-forge:
+        specifier: ^1.4.0
+        version: 1.4.0
       postgres:
         specifier: ^3.4.8
         version: 3.4.9
@@ -251,6 +254,9 @@ importers:
         version: 5.6.2
       '@types/bun':
         specifier: ^1.3.12
+        version: 1.3.14
+      '@types/node-forge':
+        specifier: ^1.3.11
         version: 1.3.14
       bun-types:
         specifier: ^1.3.12
@@ -14009,6 +14015,12 @@ packages:
 
   /@types/ms@2.1.0:
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  /@types/node-forge@1.3.14:
+    resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
+    dependencies:
+      '@types/node': 20.19.43
+    dev: true
 
   /@types/node@20.19.43:
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}


### PR DESCRIPTION
Records the live verification of `secret_call` and two things it changed my mind about.

## Verified (dev, `3d03cc68`)

Real MCP `tools/call` inside a sandbox:

```json
{"ok": true, "status": 200,
 "body": "{\"headers\":{\"x-proof-token\":\"[REDACTED]\", …}}"}
```

Plus the full chain: `FLAG=1` in the guest, `CFGHIT=1` from opencode's live
`:4096/config`, and `secret_call` present in `tools/list` alongside the eight
connector tools.

## The premise behind Track A step 1 was wrong

The doc argued the broker was unreachable because "models reach for tools far
more reliably than for documented shell commands". Tested with a prompt naming
neither the tool nor the command, the agent went straight to the CLI:

> `BROKER_PROOF`: HTTPS broker. Use `kortix secrets call BROKER_PROOF <https-url>`.

One turn, 200, header injected. It never considered the MCP tool — the
capabilities instruction names the command and says nothing about a tool.

The tool is still worth having (MCP-only hosts, structured results), but it was
a second door onto the same room, not the first door onto a locked one. Making
it the *preferred* path is a one-line change to `secret-capabilities.ts`, not a
new capability — deliberately not bundled here.

## Where the broker is NOT Platinum

A passing end-to-end test makes them look equivalent. They are not:

| | Platinum boundary | broker |
| --- | --- | --- |
| agent calls the API itself | works | works |
| a Python script the agent writes | **works** | **no credential** |
| a third-party SDK/CLI in the sandbox | **works** | **no credential** |
| curl in a Makefile / test / build step | **works** | **no credential** |

Platinum injects for any process making an allow-listed request; the broker only
for requests routed through it. Others get an unauthenticated request that fails
at the upstream — the more confusing failure. Closing that is Track B, whose
precondition §6b already establishes.

Also noted: the agent spontaneously called the broker's injection "the network
boundary". The two are being conflated in transcripts; the product naming should
separate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)