### PR TITLE
fix(web): suppress bot/automation `webdriver` redefine + transient `signal timed out` noise (BS ee14e84d…, 73e683c3…)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -36,9 +36,11 @@ import {
   isOperationErrorPopErrorScopeNoise,
   isPaperShaderNullContextNoise,
   isPaperShaderWebGLUnsupportedNoise,
+  isRedefineWebdriverNoise,
   isRuntimeNotReadyNoiseMessage,
   isSafariGenericSecurityErrorNoise,
   isServerDeadlineNoiseMessage,
+  isSignalTimeoutNoise,
   isStaleWebpackRuntimeCallNoise,
   isStorageDisabledWebViewNoiseMessage,
   isStorageSecurityErrorNoise,
@@ -9449,5 +9451,696 @@ test('does NOT suppress the Connection closed. message under the Failed-to-send-
     }),
     false,
     'Connection-closed matcher must not swallow the Failed to send message',
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Bot / automation-framework `Cannot redefine property: webdriver` noise
+// (BS ee14e84d…)
+// ---------------------------------------------------------------------------
+
+// The exact raw exception value from the production event.
+const REDEFINE_WEBDRIVER_MESSAGE = 'Cannot redefine property: webdriver'
+
+// The three production stack frames — ALL `<anonymous>` (functions `?`, `?`,
+// `Object.defineProperty`), with NO resolved first-party `apps/web/src/…`
+// source. The call_site_file Better Stack surfaces is `<anonymous>` and the
+// call_site_function is `Object.defineProperty`.
+const REDEFINE_WEBDRIVER_PROD_FRAMES: Array<{ filename: unknown; function: unknown }> = [
+  { filename: '<anonymous>', function: 'Object.defineProperty' },
+  { filename: '<anonymous>', function: '?' },
+  { filename: '<anonymous>', function: '?' },
+]
+
+// The canonical capture-path forms: raw, `TypeError:` prefix, and stacked
+// `Unhandled promise rejection: TypeError:` prefix. All strip to the same
+// underlying message via `stripErrorWrappers`.
+const REDEFINE_WEBDRIVER_CAPTURE_FORMS = [
+  REDEFINE_WEBDRIVER_MESSAGE,
+  `TypeError: ${REDEFINE_WEBDRIVER_MESSAGE}`,
+  `Unhandled promise rejection: ${REDEFINE_WEBDRIVER_MESSAGE}`,
+  `Unhandled promise rejection: TypeError: ${REDEFINE_WEBDRIVER_MESSAGE}`,
+]
+
+test('classifies the production Cannot redefine property: webdriver noise (exact prod frames, all <anonymous>)', () => {
+  // Exact production shape: the canonical message + the three `<anonymous>`
+  // frames (all unresolved — NO first-party `apps/web/src/…` source), so the
+  // negative guard does NOT fire.
+  assert.equal(
+    isRedefineWebdriverNoise({
+      message: REDEFINE_WEBDRIVER_MESSAGE,
+      frames: REDEFINE_WEBDRIVER_PROD_FRAMES,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/projects/61df2bc0-2a20-43cf-b666-0b636fb82904' },
+      exception: {
+        values: [
+          {
+            value: REDEFINE_WEBDRIVER_MESSAGE,
+            mechanism: {
+              type: 'auto.browser.global_handlers.onerror',
+              handled: false,
+            },
+            stacktrace: { frames: REDEFINE_WEBDRIVER_PROD_FRAMES },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the Cannot redefine property: webdriver noise through all capture-path wrappers', () => {
+  // The matcher strips the canonical `TypeError: ` / `Unhandled promise
+  // rejection: ` (and stacked) wrappers before anchoring, so the SAME
+  // underlying message classifies as noise regardless of which capture path
+  // delivered it (window.onerror, onunhandledrejection, Sentry exception).
+  for (const message of REDEFINE_WEBDRIVER_CAPTURE_FORMS) {
+    assert.equal(
+      isRedefineWebdriverNoise({
+        message,
+        frames: REDEFINE_WEBDRIVER_PROD_FRAMES,
+      }),
+      true,
+      `expected "${message}" to be noise`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: message,
+              stacktrace: { frames: REDEFINE_WEBDRIVER_PROD_FRAMES },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event "${message}" to be noise`,
+    )
+  }
+})
+
+test('classifies the frameless Cannot redefine property: webdriver variant as noise (webdriver property name is the specific anchor)', () => {
+  // A frameless capture with this exact message still classifies as noise —
+  // the `webdriver` property name pins it to `navigator.webdriver` (never a
+  // first-party Kortix API surface), so a frameless capture is safe to drop.
+  assert.equal(
+    isRedefineWebdriverNoise({
+      message: REDEFINE_WEBDRIVER_MESSAGE,
+      frames: [],
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/projects/61df2bc0-2a20-43cf-b666-0b636fb82904' },
+      exception: {
+        values: [{ value: REDEFINE_WEBDRIVER_MESSAGE, stacktrace: { frames: [] } }],
+      },
+    }),
+    true,
+  )
+  // Also when the stacktrace key is omitted entirely (frames default to []).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/projects/61df2bc0-2a20-43cf-b666-0b636fb82904' },
+      exception: {
+        values: [{ value: REDEFINE_WEBDRIVER_MESSAGE }],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the Cannot redefine property: webdriver noise via the runtime (window.onerror) gate', () => {
+  // The runtime gate (window.onerror) sees the message + the `<anonymous>`
+  // filename; both classify as noise because no first-party `apps/web/src/…`
+  // source is present.
+  for (const message of REDEFINE_WEBDRIVER_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message }),
+      true,
+      `expected runtime gate to suppress "${message}"`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message,
+        filename: '<anonymous>',
+      }),
+      true,
+      `expected runtime gate to suppress "${message}" from an <anonymous> filename`,
+    )
+  }
+})
+
+test('does NOT suppress the Cannot redefine property: webdriver throw when a first-party frame is present (real regression)', () => {
+  // A resolved `apps/web/src/…` frame means our own code called
+  // `Object.defineProperty` on a non-configurable property → a real first-party
+  // regression; the negative guard MUST preserve it so the call site can be
+  // found + fixed.
+  for (const frames of [
+    [{ filename: 'apps/web/src/lib/bot-detection.ts', function: 'hideWebdriver' }],
+    [
+      { filename: 'app:///_next/static/chunks/main.js', function: 'f' },
+      { filename: 'app:///apps/web/src/lib/navigator-guard.ts', function: 'patchNavigator' },
+    ],
+  ]) {
+    assert.equal(
+      isRedefineWebdriverNoise({
+        message: REDEFINE_WEBDRIVER_MESSAGE,
+        frames,
+      }),
+      false,
+      `expected first-party defineProperty throw from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            { value: REDEFINE_WEBDRIVER_MESSAGE, stacktrace: { frames } },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party defineProperty throw from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  for (const message of REDEFINE_WEBDRIVER_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message,
+        filename: 'apps/web/src/lib/bot-detection.ts',
+      }),
+      false,
+      `expected runtime gate to keep reporting first-party "${message}"`,
+    )
+  }
+})
+
+test('does NOT suppress a near-worded message without the webdriver property name (over-match guard)', () => {
+  // The `webdriver` property name is part of the anchor — a different
+  // `Cannot redefine property: <X>` (a real first-party `defineProperty` on a
+  // different non-configurable property) must keep reporting so the matcher
+  // does not over-match a real app regression.
+  for (const message of [
+    'Cannot redefine property: foo',
+    'Cannot redefine property: __proto__',
+    'Cannot redefine property: constructor',
+    'Cannot redefine property: webdriver (configurable)',
+    'Cannot redefine webdriver',
+    'Cannot set property: webdriver',
+  ]) {
+    assert.equal(
+      isRedefineWebdriverNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a non-webdriver TypeError (over-match guard on the TypeError type)', () => {
+  // The matcher anchors on the EXACT `Cannot redefine property: webdriver`
+  // message, NOT on the `TypeError` type. A generic `TypeError` keeps
+  // reporting unless it matches the exact webdriver wording.
+  for (const message of [
+    'Cannot read properties of null (reading "webdriver")',
+    "TypeError: 'defineProperty' on proxy: trap returned falsish for property 'webdriver'",
+    'Cannot redefine property: webdriver_extra',
+  ]) {
+    assert.equal(
+      isRedefineWebdriverNoise({ message, frames: [] }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress Cannot redefine property: webdriver when a first-party frame is mixed with <anonymous> frames (negative guard is any-frame)', () => {
+  // The negative guard fires if ANY frame resolves to a first-party
+  // `apps/web/src/…` source — even when mixed with the production
+  // `<anonymous>` frames. A real first-party `defineProperty` regression
+  // surfaces with at least one resolved first-party frame in the stack, so the
+  // any-frame negative guard preserves it.
+  const mixedFrames: Array<{ filename: unknown; function?: unknown }> = [
+    { filename: '<anonymous>', function: 'Object.defineProperty' },
+    { filename: '<anonymous>', function: '?' },
+    { filename: 'app:///apps/web/src/lib/bot-detection.ts', function: 'hideWebdriver' },
+  ]
+  assert.equal(
+    isRedefineWebdriverNoise({
+      message: REDEFINE_WEBDRIVER_MESSAGE,
+      frames: mixedFrames,
+    }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          { value: REDEFINE_WEBDRIVER_MESSAGE, stacktrace: { frames: mixedFrames } },
+        ],
+      },
+    }),
+    false,
+  )
+})
+
+test('classifies the Cannot redefine property: webdriver noise via the runtime gate with an empty <anonymous> filename', () => {
+  // The runtime gate (window.onerror) can deliver an empty-string filename
+  // (the `<anonymous>` call site has no resolvable source). An empty filename
+  // is never a first-party `apps/web/src/…` source, so the noise classifies.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: REDEFINE_WEBDRIVER_MESSAGE,
+      filename: '',
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: REDEFINE_WEBDRIVER_MESSAGE,
+      filename: '<anonymous>',
+    }),
+    true,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Transient fetch-abort `signal timed out` noise (BS 73e683c3…)
+// ---------------------------------------------------------------------------
+
+// The exact raw exception value from the production event.
+const SIGNAL_TIMEOUT_MESSAGE = 'signal timed out'
+
+// The canonical capture-path forms: raw, `TimeoutError:` prefix, and stacked
+// `Unhandled promise rejection: TimeoutError:` prefix. All strip to the same
+// underlying message via `stripErrorWrappers`.
+const SIGNAL_TIMEOUT_CAPTURE_FORMS = [
+  SIGNAL_TIMEOUT_MESSAGE,
+  `TimeoutError: ${SIGNAL_TIMEOUT_MESSAGE}`,
+  `Unhandled promise rejection: ${SIGNAL_TIMEOUT_MESSAGE}`,
+  `Unhandled promise rejection: TimeoutError: ${SIGNAL_TIMEOUT_MESSAGE}`,
+]
+
+test('classifies the production signal timed out noise (frameless, exact prod shape)', () => {
+  // Exact production shape: the canonical message with NO stacktrace frames
+  // (the production event's exception value has no `stacktrace` key at all —
+  // a frameless `TimeoutError` from `AbortSignal.timeout()`). The negative
+  // guard does NOT fire because there are no frames.
+  assert.equal(
+    isSignalTimeoutNoise({
+      message: SIGNAL_TIMEOUT_MESSAGE,
+      frames: [],
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/projects/6c60bc35-4371-46a0-bf49-6f82ea9fd878/sessions/c0111ad4-06bc-428b-a27a-df5ecdc0e0fa',
+      },
+      exception: {
+        values: [
+          {
+            type: 'TimeoutError',
+            value: SIGNAL_TIMEOUT_MESSAGE,
+            mechanism: {
+              type: 'auto.browser.global_handlers.onunhandledrejection',
+              handled: false,
+            },
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+  // Also when the stacktrace key is omitted entirely (frames default to []).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/projects/6c60bc35-4371-46a0-bf49-6f82ea9fd878/sessions/c0111ad4-06bc-428b-a27a-df5ecdc0e0fa',
+      },
+      exception: {
+        values: [
+          {
+            type: 'TimeoutError',
+            value: SIGNAL_TIMEOUT_MESSAGE,
+            mechanism: {
+              type: 'auto.browser.global_handlers.onunhandledrejection',
+              handled: false,
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the signal timed out noise through all capture-path wrappers', () => {
+  // The matcher strips the canonical `TimeoutError: ` / `Unhandled promise
+  // rejection: ` (and stacked) wrappers before anchoring, so the SAME
+  // underlying message classifies as noise regardless of which capture path
+  // delivered it (window.onerror, onunhandledrejection, Sentry exception).
+  for (const message of SIGNAL_TIMEOUT_CAPTURE_FORMS) {
+    assert.equal(
+      isSignalTimeoutNoise({
+        message,
+        frames: [],
+      }),
+      true,
+      `expected "${message}" to be noise`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: message, stacktrace: { frames: [] } }],
+        },
+      }),
+      true,
+      `expected Sentry event "${message}" to be noise`,
+    )
+  }
+})
+
+test('classifies the signal timed out noise even when a minified SDK chunk frame is present (no first-party source)', () => {
+  // A minified SDK chunk frame (NOT a resolved first-party `apps/web/src/…`
+  // source) does NOT trip the negative guard — the production `signal timed
+  // out` throw originates from the SDK's `makeRequest` abort path, which
+  // de-minifies to a chunk frame, never to first-party `apps/web/src/…`.
+  const chunkFrames = [
+    {
+      filename:
+        'app:///_next/static/chunks/66499-652b83425f671b38.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno',
+      function: 't',
+    },
+  ]
+  for (const message of SIGNAL_TIMEOUT_CAPTURE_FORMS) {
+    assert.equal(
+      isSignalTimeoutNoise({ message, frames: chunkFrames }),
+      true,
+      `expected "${message}" from a chunk frame to be noise`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: message, stacktrace: { frames: chunkFrames } }],
+        },
+      }),
+      true,
+      `expected Sentry event "${message}" from a chunk frame to be noise`,
+    )
+  }
+})
+
+test('suppresses the signal timed out noise via the runtime (window.onerror) gate', () => {
+  // The runtime gate (window.onerror) sees the message; it classifies as
+  // noise because no first-party `apps/web/src/…` source is present.
+  for (const message of SIGNAL_TIMEOUT_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message }),
+      true,
+      `expected runtime gate to suppress "${message}"`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message,
+        filename: 'app:///_next/static/chunks/66499-652b83425f671b38.js',
+      }),
+      true,
+      `expected runtime gate to suppress "${message}" from a chunk filename`,
+    )
+  }
+})
+
+test('does NOT suppress the signal timed out throw when a first-party frame is present (real regression)', () => {
+  // A resolved `apps/web/src/…` frame means our own code threw
+  // `signal timed out` → a real first-party regression; the negative guard
+  // MUST preserve it so the call site can be found + fixed.
+  for (const frames of [
+    [{ filename: 'apps/web/src/lib/api-client.ts', function: 'fetchWithTimeout' }],
+    [
+      { filename: 'app:///_next/static/chunks/main.js', function: 'f' },
+      { filename: 'app:///apps/web/src/lib/request.ts', function: 'abortOnTimeout' },
+    ],
+  ]) {
+    assert.equal(
+      isSignalTimeoutNoise({
+        message: SIGNAL_TIMEOUT_MESSAGE,
+        frames,
+      }),
+      false,
+      `expected first-party signal timed out throw from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            { value: SIGNAL_TIMEOUT_MESSAGE, stacktrace: { frames } },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party signal timed out throw from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  for (const message of SIGNAL_TIMEOUT_CAPTURE_FORMS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message,
+        filename: 'apps/web/src/lib/api-client.ts',
+      }),
+      false,
+      `expected runtime gate to keep reporting first-party "${message}"`,
+    )
+  }
+})
+
+test('does NOT suppress a near-worded message (over-match guard on the exact signal timed out message)', () => {
+  // Only the EXACT `signal timed out` message is matched by `isSignalTimeoutNoise`;
+  // a near-worded message (the SDK's typed `Request timed out after <N>s:` —
+  // handled by the separate `isClientRequestTimeoutMessage` matcher — or a
+  // different timeout wording) is NOT matched by THIS matcher. The matcher-level
+  // check is the over-match guard; the Sentry-gate check is only asserted for
+  // messages no OTHER matcher handles (so we don't conflate this matcher's
+  // selectivity with the SDK typed-timeout matcher's coverage).
+  for (const message of [
+    'signal timed out: fetch failed',
+    'Upload failed: signal timed out',
+    'AbortError: signal aborted',
+    'signal timeout',
+    'Signal timed out',
+    'signal timed out.',
+    'The operation timed out.',
+  ]) {
+    assert.equal(
+      isSignalTimeoutNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event "${message}" to keep reporting`,
+    )
+  }
+  // The SDK's typed `Request timed out after <N>s:` wording is matched by the
+  // SEPARATE `isClientRequestTimeoutMessage` matcher (wired earlier in the
+  // gate), so the Sentry gate DOES suppress it — but `isSignalTimeoutNoise`
+  // itself must NOT match it (it's a different wording/surface). This is the
+  // disjointness assertion at the matcher level.
+  assert.equal(
+    isSignalTimeoutNoise(
+      { message: 'Request timed out after 30s: /v1/projects', frames: [] },
+    ),
+    false,
+  )
+})
+
+test('does NOT suppress signal timed out when a first-party frame is mixed with chunk frames (negative guard is any-frame)', () => {
+  // The negative guard fires if ANY frame resolves to a first-party
+  // `apps/web/src/…` source — even when mixed with minified SDK chunk frames.
+  // A real first-party `signal timed out` throw surfaces with at least one
+  // resolved first-party frame, so the any-frame negative guard preserves it.
+  const mixedFrames: Array<{ filename: unknown; function?: unknown }> = [
+    {
+      filename:
+        'app:///_next/static/chunks/66499-652b83425f671b38.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno',
+      function: 't',
+    },
+    { filename: 'apps/web/src/lib/api-client.ts', function: 'fetchWithTimeout' },
+  ]
+  assert.equal(
+    isSignalTimeoutNoise({
+      message: SIGNAL_TIMEOUT_MESSAGE,
+      frames: mixedFrames,
+    }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          { value: SIGNAL_TIMEOUT_MESSAGE, stacktrace: { frames: mixedFrames } },
+        ],
+      },
+    }),
+    false,
+  )
+})
+
+test('classifies the signal timed out noise via the runtime gate with an empty filename', () => {
+  // The runtime gate (window.onerror) can deliver an empty-string filename
+  // (the frameless `TimeoutError` has no resolvable source). An empty filename
+  // is never a first-party `apps/web/src/…` source, so the noise classifies.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: SIGNAL_TIMEOUT_MESSAGE,
+      filename: '',
+    }),
+    true,
+  )
+})
+
+test('the two new noise matchers do not shadow each other (disjoint message anchors)', () => {
+  // `isRedefineWebdriverNoise` (`Cannot redefine property: webdriver`) and
+  // `isSignalTimeoutNoise` (`signal timed out`) anchor on disjoint exact
+  // messages, so neither matcher matches the other's message.
+  assert.equal(
+    isRedefineWebdriverNoise({ message: 'signal timed out', frames: [] }),
+    false,
+  )
+  assert.equal(
+    isSignalTimeoutNoise({
+      message: 'Cannot redefine property: webdriver',
+      frames: [],
+    }),
+    false,
+  )
+})
+
+test('the new noise matchers handle non-string message values gracefully (no crash, no match)', () => {
+  // A non-string `message` (undefined / null / number / object) must not crash
+  // either matcher; `normalizeString` coerces to `''`, which never matches the
+  // anchored regex.
+  for (const message of [undefined, null, 42, {}, [], true]) {
+    assert.equal(
+      isRedefineWebdriverNoise({ message, frames: [] }),
+      false,
+    )
+    assert.equal(
+      isSignalTimeoutNoise({ message, frames: [] }),
+      false,
+    )
+  }
+})
+
+test('the new noise matchers handle non-string frame filenames gracefully (no crash, negative guard still works)', () => {
+  // A non-string `filename` (undefined / null / number / object) must not
+  // crash either matcher; `normalizeString` coerces to `''`, which is never a
+  // first-party `apps/web/src/…` source, so the negative guard does NOT fire
+  // and the message-only anchor classifies the noise.
+  for (const filename of [undefined, null, 42, {}, true]) {
+    assert.equal(
+      isRedefineWebdriverNoise({
+        message: REDEFINE_WEBDRIVER_MESSAGE,
+        filename,
+      }),
+      true,
+    )
+    assert.equal(
+      isSignalTimeoutNoise({ message: SIGNAL_TIMEOUT_MESSAGE, filename }),
+      true,
+    )
+  }
+})
+
+test('the two new noise matchers are disjoint from the SDK typed-timeout matcher', () => {
+  // `isSignalTimeoutNoise` (bare `signal timed out`) and
+  // `isClientRequestTimeoutMessage` (`Request timed out after <N>s:`) cover
+  // DIFFERENT surfaces and must not shadow each other. The bare native
+  // `TimeoutError` wording is distinct from the SDK's wrapped `ApiError`
+  // message.
+  assert.equal(
+    isSignalTimeoutNoise({ message: 'signal timed out', frames: [] }),
+    true,
+  )
+  assert.equal(
+    isClientRequestTimeoutMessage('signal timed out'),
+    false,
+  )
+  assert.equal(
+    isSignalTimeoutNoise(
+      { message: 'Request timed out after 30s: /v1/projects', frames: [] },
+    ),
+    false,
+  )
+  assert.equal(
+    isClientRequestTimeoutMessage('Request timed out after 30s: /v1/projects'),
+    true,
+  )
+})
+
+test('both new matchers classify the production wrappers with a non-default mechanism (onunhandledrejection) as noise', () => {
+  // The production events both use `auto.browser.global_handlers.onerror` /
+  // `auto.browser.global_handlers.onunhandledrejection` mechanisms. Neither
+  // matcher gates on the mechanism — both are message + frame anchored — so
+  // the SAME noise classifies regardless of the capture mechanism.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: REDEFINE_WEBDRIVER_MESSAGE,
+            mechanism: {
+              type: 'auto.browser.global_handlers.onunhandledrejection',
+              handled: false,
+            },
+            stacktrace: { frames: REDEFINE_WEBDRIVER_PROD_FRAMES },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            type: 'TimeoutError',
+            value: SIGNAL_TIMEOUT_MESSAGE,
+            mechanism: {
+              type: 'auto.browser.global_handlers.onerror',
+              handled: false,
+            },
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    }),
+    true,
   )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -4062,6 +4062,183 @@ export function isFramelessNetworkErrorNoise(input: {
   return true;
 }
 
+// Bot / automation-framework / scraper `Cannot redefine property: webdriver`
+// noise. A headless-browser or automation tool (Selenium, Puppeteer, Playwright,
+// or a scraper) injects a script that attempts
+// `Object.defineProperty(navigator, 'webdriver', { get: () => undefined })` to
+// hide its automation footprint from bot-detection on the page it is crawling.
+// In some Chrome builds `navigator.webdriver` is a NON-configurable property,
+// so the `defineProperty` trap throws `TypeError: Cannot redefine property:
+// webdriver`. The throw originates in the injected automation/anti-detection
+// script — NEVER in first-party Kortix code — and surfaces as an UNCAUGHT global
+// `onerror` (mechanism `auto.browser.global_handlers.onerror`, `handled:false`
+// — never reaches a React error boundary). Better Stack pattern
+// ee14e84d1a150ae094e20722e619083499d8b29206445a2ef349ff42db6d0f7f
+// (Kortix Frontend prod, application_id 2346967): `TypeError`, message
+// `Cannot redefine property: webdriver`, call site function
+// `Object.defineProperty`, call site file `<anonymous>`, 1 occurrence / 0
+// identified users, first 2026-08-12 07:49:16 UTC, request URL
+// `https://kortix.com/projects/61df2bc0-…` (project page), browser Chrome on
+// Windows 10. Stack: 3 frames, ALL `<anonymous>` (functions `?`, `?`,
+// `Object.defineProperty`) — NO resolved first-party `apps/web/src/…` frame
+// and NO chunk frame at all. This is bot/scanner noise, NOT a product bug: a
+// real first-party `Object.defineProperty` call that redefined a non-
+// configurable property would de-minify to `apps/web/src/…` frames (Sentry
+// uploads sourcemaps), and `navigator.webdriver` is never touched by
+// first-party app code.
+//
+// The EXACT message `Cannot redefine property: webdriver` is the V8/Chrome
+// canonical `TypeError` for a `defineProperty` on a non-configurable property
+// (the property name `webdriver` pins it to `navigator.webdriver` specifically,
+// never a coincidental app-logic `defineProperty` regression). BUT the matcher
+// carries a NEGATIVE guard: if ANY frame (or the window.onerror `filename`)
+// resolves to a de-minified first-party `apps/web/src/…` source path, the event
+// keeps reporting — a real first-party `defineProperty` regression
+// de-minifies to `apps/web/src/…` and must not be hidden. The production event
+// carries only `<anonymous>` frames, so the negative guard does NOT fire for
+// it. A frameless capture with this exact message still classifies as noise
+// — the `webdriver` property name is the specific anchor (it is never a
+// first-party Kortix API surface). Deliberately NOT added to
+// `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame
+// context, so a bare-string match there could swallow a real first-party
+// `defineProperty` regression the negative guard exists to preserve; the
+// frame-aware `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`)
+// is the only safe gate.
+const REDEFINE_WEBDRIVER_NOISE_MESSAGE = /^Cannot redefine property: webdriver$/;
+
+/**
+ * Whether a Sentry / window.onerror event is the bot / automation-framework /
+ * scraper `Cannot redefine property: webdriver` noise class: an injected
+ * anti-detection script attempts
+ * `Object.defineProperty(navigator, 'webdriver', …)` to hide its automation
+ * footprint, and Chrome throws a `TypeError` because `navigator.webdriver` is
+ * non-configurable in that build. The throw originates in the injected
+ * automation script, never first-party Kortix code. Requires the EXACT message
+ * (case-sensitive; the `webdriver` property name pins it to
+ * `navigator.webdriver` specifically) AND a NEGATIVE guard: if any frame (or
+ * the window.onerror `filename`) resolves to a de-minified first-party
+ * `apps/web/src/…` source path, the event keeps reporting (a real first-party
+ * `defineProperty` regression de-minifies to `apps/web/src/…` and must not be
+ * hidden). The production event carries only `<anonymous>` frames, so the
+ * negative guard does NOT fire for it. A frameless capture with this exact
+ * message still classifies as noise — the `webdriver` property name is the
+ * specific anchor. See `REDEFINE_WEBDRIVER_NOISE_MESSAGE` for the full
+ * rationale and Better Stack pattern `ee14e84d…`.
+ */
+export function isRedefineWebdriverNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (!REDEFINE_WEBDRIVER_NOISE_MESSAGE.test(stripped)) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame (or
+  // window.onerror `filename`) means our own code called `defineProperty` on a
+  // non-configurable property → a real first-party regression; keep reporting
+  // so the call site can be found + fixed. A real first-party `defineProperty`
+  // regression de-minifies to `apps/web/src/…` and is never hidden.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  return true;
+}
+
+// Transient fetch-abort `signal timed out` noise — the Bun / native
+// `TimeoutError` raised by `AbortSignal.timeout()` when a client-side fetch
+// exceeds its 30s deadline. This is the SAME transient-timeout class as the
+// prior API pattern `c672fb5e…` which was fixed by PR #4709 (API-side
+// `SENTRY_IGNORE_ERRORS` filter for `'The operation timed out.'`). The existing
+// API-side filter covers `'The operation timed out.'` but NOT the frontend's
+// `'signal timed out'` wording. The SDK's `makeRequest` aborts on its 30s
+// deadline and the abort surfaces as `TimeoutError: signal timed out` in the
+// frontend's `onunhandledrejection` handler (the rejection reaches Sentry
+// through a fire-and-forget path that bypasses `handleApiError`'s timeout
+// guard). The SDK already has a bounded retry for transient gateway statuses
+// (#4609) and the API already filters its own timeout (#4709), but the
+// frontend rejection still reaches Sentry.
+//
+// Better Stack pattern
+// 73e683c3aad440ccf4cc817f0484366cc66ba26b9435517fc8c86d4f7d258d60
+// (Kortix Frontend prod, application_id 2346967): `TimeoutError`, message
+// `signal timed out`, 24 occurrences / 0 identified users, first 2026-05-16
+// (recurring), last 2026-08-12 04:08:45 UTC, mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT,
+// `handled:false`), request URL
+// `https://kortix.com/projects/…/sessions/…` (session pages), browser Chrome
+// on macOS, tags `DOMException.code: 23` (InvalidStateError — the network
+// abort). Stack: NONE — the exception value has NO `stacktrace` key at all
+// (frameless capture). A transient network/timeout error, not a code bug.
+//
+// The EXACT message `signal timed out` is the canonical `TimeoutError` message
+// from `AbortSignal.timeout()` — it is specific enough to anchor on without a
+// frame guard (a real first-party `throw new Error('signal timed out')` would
+// be unusual). For conservativism, the matcher carries an OPTIONAL negative
+// guard: if ANY frame (or the window.onerror `filename`) resolves to a
+// de-minified first-party `apps/web/src/…` source path, the event keeps
+// reporting (a real first-party `signal timed out` throw de-minifies to
+// `apps/web/src/…` and must not be hidden). The production event has NO frames
+// at all, so the negative guard does NOT fire for it. A frameless capture
+// with this exact message classifies as noise — the message is the canonical
+// `AbortSignal.timeout()` wording. Sibling to `isClientRequestTimeoutMessage`
+// (the SDK's typed `Request timed out after <N>s:` wording, #4531) — this is
+// the NATIVE `TimeoutError` wording the bare `AbortSignal.timeout()` promise
+// rejection surfaces with, distinct from the SDK's wrapped `ApiError`
+// message. Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors`
+// list — that gate has no frame context; the frame-aware `beforeSend` hook
+// (which calls `shouldIgnoreSentryBrowserNoise`) is the safe gate.
+const SIGNAL_TIMEOUT_NOISE_MESSAGE = /^signal timed out$/;
+
+/**
+ * Whether a Sentry / window.onerror event is the transient fetch-abort
+ * `signal timed out` noise class: the native `TimeoutError` raised by
+ * `AbortSignal.timeout()` when a client-side fetch exceeds its 30s deadline.
+ * The SDK's `makeRequest` aborts on its 30s deadline and the abort surfaces as
+ * `TimeoutError: signal timed out` in the frontend's `onunhandledrejection`
+ * handler; it reaches Sentry through a fire-and-forget path that bypasses
+ * `handleApiError`'s timeout guard. A transient network/timeout error, not a
+ * code bug. Requires the EXACT message (case-sensitive; the canonical
+ * `AbortSignal.timeout()` `TimeoutError` wording) AND a NEGATIVE guard: if
+ * any frame (or the window.onerror `filename`) resolves to a de-minified
+ * first-party `apps/web/src/…` source path, the event keeps reporting (a real
+ * first-party `signal timed out` throw de-minifies to `apps/web/src/…` and
+ * must not be hidden). The production event has NO frames at all, so the
+ * negative guard does NOT fire for it. A frameless capture with this exact
+ * message classifies as noise. Sibling of `isClientRequestTimeoutMessage` (the
+ * SDK's typed `Request timed out after <N>s:` wording). See
+ * `SIGNAL_TIMEOUT_NOISE_MESSAGE` for the full rationale and Better Stack
+ * pattern `73e683c3…`.
+ */
+export function isSignalTimeoutNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (!SIGNAL_TIMEOUT_NOISE_MESSAGE.test(stripped)) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame (or
+  // window.onerror `filename`) means our own code threw `signal timed out` →
+  // a real first-party regression; keep reporting so the call site can be
+  // found + fixed. A real first-party `signal timed out` throw de-minifies to
+  // `apps/web/src/…` and is never hidden. The production event has NO frames,
+  // so this guard does NOT fire for it.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  return true;
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -4415,6 +4592,42 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   // carries a chunk/source frame keeps reporting. See
   // `isUnresolvableStackOverflowNoise`.
   if (isUnresolvableStackOverflowNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
+  // Bot / automation-framework / scraper `Cannot redefine property: webdriver`
+  // noise — an injected anti-detection script attempts
+  // `Object.defineProperty(navigator, 'webdriver', …)` to hide its automation
+  // footprint, and Chrome throws a `TypeError` because `navigator.webdriver`
+  // is non-configurable in that build. The throw is in the injected
+  // automation script, never first-party code. Requires the EXACT message AND
+  // a NEGATIVE guard: a resolved first-party `apps/web/src/…` filename means
+  // our own code called `defineProperty` on a non-configurable property → a
+  // real first-party regression; keep reporting. The production event has
+  // only `<anonymous>` frames, so the negative guard does NOT fire for it. A
+  // frameless window.onerror capture with the exact message + no first-party
+  // filename drops. See `isRedefineWebdriverNoise` and Better Stack pattern
+  // `ee14e84d…`.
+  if (isRedefineWebdriverNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
+  // Transient fetch-abort `signal timed out` noise — the native `TimeoutError`
+  // raised by `AbortSignal.timeout()` when a client-side fetch exceeds its 30s
+  // deadline. The SDK's `makeRequest` aborts on its 30s deadline and the abort
+  // surfaces as `TimeoutError: signal timed out` in the frontend's
+  // `onunhandledrejection`; it reaches the runtime gate through a fire-and-
+  // forget path. The API already filters its OWN timeout wording
+  // (`The operation timed out.`, #4709), but the frontend's `signal timed out`
+  // wording is NOT covered. A transient network/timeout error, not a code
+  // bug. Requires the EXACT message AND a NEGATIVE guard: a resolved
+  // first-party `apps/web/src/…` filename means our own code threw
+  // `signal timed out` → a real first-party regression; keep reporting. The
+  // production event has NO frames, so the negative guard does NOT fire for
+  // it. A frameless window.onerror capture with the exact message + no
+  // first-party filename drops. See `isSignalTimeoutNoise` and Better Stack
+  // pattern `73e683c3…`.
+  if (isSignalTimeoutNoise({ message, filename: input.filename })) {
     return true;
   }
 
@@ -5091,6 +5304,45 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // negative guard does not fire for them. NOT in `ignoreErrors` (no frame
   // context there). See `isDocumentStateNotFoundNoise`.
   if (isDocumentStateNotFoundNoise({ message, frames })) {
+    return true;
+  }
+
+  // Bot / automation-framework / scraper `Cannot redefine property: webdriver`
+  // noise — an injected anti-detection script attempts
+  // `Object.defineProperty(navigator, 'webdriver', …)` to hide its automation
+  // footprint, and Chrome throws a `TypeError` because `navigator.webdriver`
+  // is non-configurable in that build. The throw is in the injected
+  // automation script, never first-party code. Requires the EXACT message AND
+  // a NEGATIVE guard: a resolved first-party `apps/web/src/…` frame means our
+  // own code called `defineProperty` on a non-configurable property → a real
+  // first-party regression; keep reporting. The production event carries only
+  // `<anonymous>` frames, so the negative guard does NOT fire for it. A
+  // frameless capture with this exact message still classifies as noise (the
+  // `webdriver` property name is the specific anchor). NOT in `ignoreErrors`
+  // (no frame context there). See `isRedefineWebdriverNoise` and Better Stack
+  // pattern `ee14e84d…`.
+  if (isRedefineWebdriverNoise({ message, frames })) {
+    return true;
+  }
+
+  // Transient fetch-abort `signal timed out` noise — the native `TimeoutError`
+  // raised by `AbortSignal.timeout()` when a client-side fetch exceeds its 30s
+  // deadline. The SDK's `makeRequest` aborts on its 30s deadline and the abort
+  // surfaces as `TimeoutError: signal timed out` in the frontend's
+  // `onunhandledrejection`; it reaches Sentry through a fire-and-forget path
+  // that bypasses `handleApiError`'s timeout guard. The API already filters
+  // its OWN timeout wording (`The operation timed out.`, #4709), but the
+  // frontend's `signal timed out` wording is NOT covered. A transient
+  // network/timeout error, not a code bug. Requires the EXACT message AND a
+  // NEGATIVE guard: a resolved first-party `apps/web/src/…` frame means our
+  // own code threw `signal timed out` → a real first-party regression; keep
+  // reporting. The production event has NO frames at all, so the negative
+  // guard does NOT fire for it. A frameless capture with this exact message
+  // classifies as noise. Sibling of `isClientRequestTimeoutMessage` (the SDK's
+  // typed `Request timed out after <N>s:` wording). NOT in `ignoreErrors` (no
+  // frame context there). See `isSignalTimeoutNoise` and Better Stack pattern
+  // `73e683c3…`.
+  if (isSignalTimeoutNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. Two new browser-error-noise matchers + 22 tests; `bun test apps/web/src/lib/browser-error-noise.test.mts` → **354 pass / 0 fail** (was 332 on main; +22 new).

## Why
Two production noise patterns in Better Stack (Kortix Frontend prod, app_id 2346967) are paging as uncaught browser errors but are NOT product bugs:

1. **`Cannot redefine property: webdriver`** (BS `ee14e84d…`, 1 occ / 0 users, 2026-08-12 07:49 UTC) — a bot/automation framework (Selenium/Puppeteer/Playwright/scraper) injects an anti-detection script that calls `Object.defineProperty(navigator, 'webdriver', …)` to hide its automation footprint; Chrome throws because `navigator.webdriver` is non-configurable in that build. All 3 frames are `<anonymous>` — no first-party code.

2. **`signal timed out`** (BS `73e683c3…`, 24 occ / 0 users, recurring since 2026-05-16, last 2026-08-12) — the native `TimeoutError` from `AbortSignal.timeout()` when a client-side fetch exceeds its 30s deadline. The same transient-timeout class as the API-side `The operation timed out.` filter (PR #4709), but the frontend's `signal timed out` wording is NOT covered. The SDK's `makeRequest` aborts on its 30s deadline and the abort surfaces as an unhandled rejection bypassing `handleApiError`'s timeout guard. Frameless capture (no stacktrace).

## What changed
Two new matchers in `apps/web/src/lib/browser-error-noise.ts`, each wired into BOTH `shouldIgnoreSentryBrowserNoise` (Sentry `beforeSend`) and `shouldIgnoreBrowserRuntimeNoise` (runtime `window.onerror`/`onunhandledrejection`):

- **`isRedefineWebdriverNoise`** — anchored on exact message `/^Cannot redefine property: webdriver$/` (the `webdriver` property name pins it to `navigator.webdriver` specifically). Negative guard: any resolved first-party `apps/web/src/…` frame → KEEP (a real first-party `defineProperty` regression de-minifies to `apps/web/src/…`).
- **`isSignalTimeoutNoise`** — anchored on exact message `/^signal timed out$/` (the canonical `AbortSignal.timeout()` `TimeoutError` wording). Negative guard: any resolved first-party `apps/web/src/…` frame → KEEP. Sibling of `isClientRequestTimeoutMessage` (the SDK's typed `Request timed out after <N>s:` wording, #4531) — disjoint message anchors, so they don't shadow each other.

Both matchers deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there could swallow a real first-party regression the negative guard exists to preserve; the frame-aware `beforeSend` hook is the only safe gate.

## Verification
- **Evidence**: Queried the Better Stack MCP for both patterns. Pattern 1 (`ee14e84d…`): `TypeError`, message `Cannot redefine property: webdriver`, call_site_file `<anonymous>`, call_site_function `Object.defineProperty`, 3 frames all `<anonymous>` (functions `?`, `?`, `Object.defineProperty`), mechanism `auto.browser.global_handlers.onerror`. Pattern 2 (`73e683c3…`): `TimeoutError`, message `signal timed out`, 24 occ, `has_stacktrace = 0` across all sampled occurrences (frameless), mechanism `auto.browser.global_handlers.onunhandledrejection`, tag `DOMException.code: 23` (InvalidStateError/network abort).
- **Tests**: 22 new tests covering (a) exact prod-shape classification for both matchers, (b) all capture-path wrappers (`TypeError:`/`TimeoutError:`/`Unhandled promise rejection:`/stacked), (c) frameless variants, (d) runtime-gate suppression, (e) first-party negative guards (mixed frames + first-party filename), (f) over-match guards (near-worded messages keep reporting), (g) disjointness from `isClientRequestTimeoutMessage`, (h) graceful handling of non-string messages/filenames.
- **Result**: `bun test apps/web/src/lib/browser-error-noise.test.mts` → **354 pass / 0 fail** (332 on main + 22 new). `node --experimental-strip-types --test` → same. TS transpiles cleanly via `bun build`. CI `Frontend build` + `all local tests` workers all PASS.

```
1..354
# tests 354
# pass 354
# fail 0
```

## Risk / rollback
Telemetry-filter only — no user-facing behavior change. Both matchers are message + frame anchored with first-party negative guards, so a real first-party regression with the same wording still reports. Rollback = revert the single commit.

## Confirmation
After merge + promote, the two Better Stack patterns (`ee14e84d…` and `73e683c3…`) should drop to zero new occurrences and auto-resolve once no longer seen.

## CI status (rebased onto latest main — commit `21a4538601`)
- ✅ `Frontend build` — production Next.js build PASS (the `browser-error-noise.ts` change compiles + bundles)
- ✅ `all local tests / warm packages worker` — PASS (runs the 354 noise tests in CI, including the 22 new)
- ✅ `all local tests / warm core worker` / `warm browser-1 worker` / `warm browser-2 worker` — PASS
- ✅ `Analyze (javascript-typescript)` / `(go)` / `(python)` — CodeQL security analysis PASS
- ✅ `CodeQL` / `Dependency + secret scan` / `gitleaks` — PASS
- ✅ `Build preview API image` / `Build preview frontend image` / `Build preview gateway image` — PASS
- ✅ `Vercel` — PASS
- ❌ `Deploy full self-host preview and run end-to-end tests` — FAILS on **transient preview-sandbox infra** (NOT a code issue): `[sandbox-preview] Platinum infrastructure failed; fallback=daytona` (Platinum preview provider down) + `GitHub /orgs/***/repos failed (403): Resource not accessible by integration` (Kortix GitHub App in the preview sandbox lacks org-repo access). These are sandbox-infra/credentials issues affecting the E2E project-provision tests; a pure-frontend telemetry filter cannot affect GitHub App permissions or sandbox provisioning. Reproduced across 4+ runs on two commits — same transient infra failure (Platinum provider outage + GitHub App 403), no code failure. The E2E failure is in project-provision (`KAAB-*`/`RUN-*` tests), which calls the GitHub API with the preview sandbox's GitHub App credentials — unrelated to `browser-error-noise.ts`.

---
- BS error 1: pattern `ee14e84d1a150ae094e20722e619083499d8b29206445a2ef349ff42db6d0f7f` (Kortix Frontend prod, app_id 2346967) — `Cannot redefine property: webdriver`
- BS error 2: pattern `73e683c3aad440ccf4cc817f0484366cc66ba26b9435517fc8c86d4f7d258d60` (Kortix Frontend prod, app_id 2346967) — `signal timed out`


