### PR TITLE
test(deployed): retry transient gateway errors in ALL clients (fixture clients too)

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -20,11 +20,11 @@ jobs:
     # the early REST flows), then the post-test secret-guard/upload steps push
     # the job past 45m. The old 20-min cap killed it at ~316/433 EVERY release
     # (v0.12.7 and v0.12.8 both cancelled, not failed) — the gate was
-    # structurally un-passable. The two lanes now run SERIALLY (not concurrently)
-    # so they stop overloading the staging origin into MAINTENANCE_MODE — that
-    # trades ~47m concurrent for ~60m sequential, so the cap is 75m. Follow-up:
-    # shard the runner (matrix over flow domains + browser) to bring this down.
-    timeout-minutes: 75
+    # structurally un-passable. Lanes run concurrently (~47m); every client now
+    # retries the transient laundered-503 so session-create contention self-heals
+    # rather than needing serialization. 65m gives headroom for retry overhead.
+    # Follow-up: shard the runner (matrix over flow domains + browser).
+    timeout-minutes: 65
     env:
       KE2E_API_URL: ${{ vars.QA_API_BASE_URL || 'https://staging-api.kortix.com/v1' }}
       E2E_BASE_URL: ${{ vars.QA_WEB_BASE_URL || 'https://staging.kortix.com' }}

--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -229,7 +229,18 @@ export class Client {
     apiUrl: string,
     private readonly identity: Identity = ANON,
     private readonly defaultTimeoutMs = 60_000,
-    private readonly transientGatewayRetries = 0,
+    // Retry gateway-generated transient 502/503/504 by DEFAULT, for every client
+    // — including the fixture clients (world.ts, provision.ts) that create
+    // sessions/sandboxes. Under concurrent deployed load a session-create can
+    // briefly exceed the edge timeout and come back as a laundered 503
+    // MAINTENANCE_MODE (Retry-After set, NO x-request-id); retrying lets it
+    // self-heal when the momentary contention clears. SAFE: the classifier
+    // (isKe2eTransientGatewayResponse) only matches responses WITHOUT
+    // x-request-id, so a genuine app 5xx still fails. Overridable per env
+    // (KE2E_GATEWAY_RETRIES) via runner.ts.
+    private readonly transientGatewayRetries = Number(
+      process.env.KE2E_GATEWAY_RETRIES ?? 3,
+    ),
   ) {
     this.origin = new URL(apiUrl).origin;
   }

--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -172,15 +172,14 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
     return { mode: 'target', lanes, stages: [lanes] };
   }
   if (targetFull) {
+    // Lanes run CONCURRENTLY (one stage). An earlier serialize experiment did
+    // NOT fix the session-create MAINTENANCE_MODE (the real cause was fixture
+    // clients not retrying the laundered 503 — fixed in client.ts) and it
+    // doubled wall-clock past the JWT lifetime, adding a 401 tail. With every
+    // client now retrying transient gateway errors, concurrent contention
+    // self-heals and the run fits the 60m budget.
     const lanes = [targetApiFull, targetBrowserFull];
-    // SERIALIZE the two deployed lanes (two stages, not one concurrent stage).
-    // Running the REST flow lane and the browser lane against the same staging
-    // origin at once drove sustained (multi-minute) origin overload that the
-    // edge laundered into MAINTENANCE_MODE — session-create (sandbox provision,
-    // the heaviest op) is the tipping point. A per-request retry can't outlast a
-    // minutes-long degradation; removing the concurrent peak is the real fix.
-    // Costs wall-clock (why tests-release.yml runs at 75m), buys a stable gate.
-    return { mode: 'target-full', lanes, stages: [[targetApiFull], [targetBrowserFull]] };
+    return { mode: 'target-full', lanes, stages: [lanes] };
   }
   if (full) {
     const fullFlows: LocalTestLane = {


### PR DESCRIPTION
**The real root cause of the deployed-gate flakiness.** A live probe proved staging session-create is healthy — **HTTP 201 in 5.6s idle**, not a capacity wall. Under concurrent load a create briefly exceeds the edge timeout → laundered 503 MAINTENANCE_MODE (Retry-After, no x-request-id).

Round 1 added retries only to `ctx.client` (runner.ts). But session-create runs through **fixture** clients — `world.ts:109 new Client(...)`, `provision.ts` — which had retries **OFF**, so those 503s failed hard and never self-healed.

**Fix:** default `transientGatewayRetries` ON in the `Client` constructor → every client (fixtures included) retries the transient laundered 503. Safe via the existing `x-request-id` guard (genuine app 5xx still fail).

**Also reverts the round-2 serialize** — it didn't fix the root cause, doubled wall-clock to 64m (API lane alone), and that expiry caused the 401 tail. Concurrent lanes + working retries fit the 65m budget.

Verified by the next v0.12.9 gate.