### PR TITLE
fix(api): stop App deploys failing on secret length

### DIFF
--- a/apps/api/src/apps/hosting.test.ts
+++ b/apps/api/src/apps/hosting.test.ts
@@ -11,7 +11,7 @@ import {
 
 const secret = 'test-secret-at-least-sixteen-characters';
 
-function dependencies() {
+function dependencies(controlSecret: string = secret) {
   const builds: any[] = [];
   const creates: any[] = [];
   const appRuntimeStarts: string[] = [];
@@ -51,12 +51,67 @@ function dependencies() {
   const hosting = new AppHostingProvider({
     snapshotProvider: () => snapshot,
     runtimeProvider: () => runtime,
-    controlSecret: secret,
+    controlSecret,
     fetch: fetch as typeof globalThis.fetch,
     sleep: async () => {},
   });
   return { hosting, builds, creates, appRuntimeStarts, ingressCalls, fetchCalls };
 }
+
+describe('appControlToken', () => {
+  // Prod ran a sub-16-character API_KEY_SECRET, so every App deployment died at
+  // provisioning with "App control secret must contain at least 16 characters"
+  // after a full image build. The secret is the scrypt salt for API-key hashes
+  // and the HKDF root for project secrets, so it cannot be rotated to satisfy a
+  // length floor. HKDF gives a fixed 32-byte key from any non-empty secret.
+  test('derives a token from a secret shorter than 16 characters', () => {
+    const token = appControlToken('runtime-1', 'short');
+    expect(token).toBe(appControlToken('runtime-1', 'short'));
+    expect(token).toHaveLength(43);
+  });
+
+  test('separates tokens by secret and by runtime id', () => {
+    expect(appControlToken('runtime-1', 'short')).not.toBe(appControlToken('runtime-1', 'other'));
+    expect(appControlToken('runtime-1', 'short')).not.toBe(appControlToken('runtime-2', 'short'));
+    expect(appControlToken('runtime-1', secret)).not.toBe(appControlToken('runtime-1', 'short'));
+  });
+
+  test('rejects a missing runtime id or an empty secret', () => {
+    expect(() => appControlToken('', secret)).toThrow('runtimeId is required');
+    expect(() => appControlToken('runtime-1', '')).toThrow('App control secret is required');
+  });
+
+  // The prod failure surfaced at provisioning, not in the helper: the image had
+  // already built and `createRuntime` threw while deriving the appd bearer.
+  test('provisions an App runtime on a server whose secret is 5 characters', async () => {
+    const { hosting, creates, appRuntimeStarts } = dependencies('short');
+    const result = await hosting.createRuntime({
+      provider: 'platinum',
+      runtimeId: 'runtime-1',
+      accountId: 'account-1',
+      userId: 'user-1',
+      name: 'app-bharat-ai-v1',
+      snapshotName: 'kortix-app-deployment-1',
+      machine: { cpuCores: 1, memoryGb: 2, diskGb: 10 },
+    });
+
+    expect(creates[0].envVars.KORTIX_APPD_TOKEN).toBe(appControlToken('runtime-1', 'short'));
+    expect(result.controlTokenHash).toBe(
+      appControlTokenHash(appControlToken('runtime-1', 'short')),
+    );
+    expect(appRuntimeStarts).toEqual(['box-1']);
+  });
+
+  // A control call must present the same bearer the runtime was created with,
+  // or every status/log request against a short-secret server returns 401.
+  test('signs control requests with the same short-secret bearer', async () => {
+    const { hosting, fetchCalls } = dependencies('short');
+    await hosting.status('platinum', 'box-1', 'runtime-1');
+    expect(fetchCalls[0].init.headers.Authorization).toBe(
+      `Bearer ${appControlToken('runtime-1', 'short')}`,
+    );
+  });
+});
 
 describe('AppHostingProvider', () => {
   test('derives a stable non-reversible control token hash', () => {

--- a/apps/api/src/apps/hosting.ts
+++ b/apps/api/src/apps/hosting.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac } from 'node:crypto';
+import { createHash, createHmac, hkdfSync } from 'node:crypto';
 import { config, type SandboxProviderName } from '../config';
 import {
   getProvider,
@@ -79,14 +79,47 @@ function defaultDependencies(): HostingDependencies {
 }
 
 /**
+ * HKDF-SHA256 turns any non-empty server secret into the fixed 32-byte key the
+ * control-token HMAC needs, so no deployment depends on how long the raw secret
+ * happens to be.
+ *
+ * The earlier `secret.length < 16` floor read API_KEY_SECRET directly, and that
+ * value cannot be lengthened to satisfy it: it is the scrypt salt for every
+ * stored API-key hash (shared/crypto.ts) and the HKDF input keying material for
+ * every encrypted project secret (projects/secrets.ts). Rotating it invalidates
+ * both. An environment whose secret was under 16 characters therefore failed
+ * every App deployment at provisioning, after a full image build.
+ *
+ * Stretching is a length fix, not an entropy fix. The derived key is only as
+ * strong as the secret behind it, and App runtimes receive their own token in
+ * `KORTIX_APPD_TOKEN`, so a low-entropy API_KEY_SECRET still deserves its own
+ * planned rotation with a re-hash and re-encrypt migration.
+ */
+function appControlKey(secret: string): Buffer {
+  return Buffer.from(
+    hkdfSync(
+      'sha256',
+      Buffer.from(secret, 'utf8'),
+      Buffer.from('kortix-appd-control', 'utf8'),
+      Buffer.from('kortix-appd-control-key:v1', 'utf8'),
+      32,
+    ),
+  );
+}
+
+/**
  * The database stores only this hash. The API reconstructs the bearer from the
  * stable runtime id and a server secret after process restarts.
+ *
+ * v2 derives the HMAC key through `appControlKey`. Any runtime provisioned
+ * under v1 holds a token this no longer reproduces, so its control requests
+ * fail until the App is redeployed.
  */
 export function appControlToken(runtimeId: string, secret: string): string {
   if (!runtimeId) throw new Error('runtimeId is required');
-  if (secret.length < 16) throw new Error('App control secret must contain at least 16 characters');
-  return createHmac('sha256', secret)
-    .update('kortix-appd-control:v1\0')
+  if (!secret) throw new Error('App control secret is required');
+  return createHmac('sha256', appControlKey(secret))
+    .update('kortix-appd-control:v2\0')
     .update(runtimeId)
     .digest('base64url');
 }


### PR DESCRIPTION
## Issue

Every App deployment on prod fails. `appControlToken` requires `API_KEY_SECRET` to
be at least 16 characters, and prod runs a shorter value, so provisioning throws
`App control secret must contain at least 16 characters` at
`deployment-worker.ts:435` — after the container image has already built. The
failure is not classified permanent, so each deploy burns three full image builds
before going terminal. No App has ever gone live on prod.

The floor cannot be satisfied by lengthening the secret. `API_KEY_SECRET` is the
scrypt salt for every stored API-key and PAT hash (`shared/crypto.ts:150`) and the
HKDF input keying material for every encrypted project secret
(`projects/secrets.ts:63`). Rotating it invalidates all existing API keys and makes
every stored project secret undecryptable.

## Solution

Derive the HMAC key with HKDF-SHA256 instead of using the raw secret, so any
non-empty secret yields the 32 bytes the token needs and no deployment depends on
how long the shared secret happens to be.

The constraint moves to where this module can enforce it. The old code validated a
borrowed value: `API_KEY_SECRET` belongs to API-key hashing and project-secret
encryption, and App hosting was a third consumer imposing a rule its owner could
not meet.

The context label moves `v1` → `v2` because the derivation changed. A runtime
provisioned under v1 holds a token this no longer reproduces, so its control
requests fail until the App is redeployed. Prod has no successful App deployment,
so prod is unaffected; a dev runtime may need one. The sandbox side only stores the
opaque `KORTIX_APPD_TOKEN` value and never re-derives it, so nothing outside
`hosting.ts` depends on the label.

## Testing

- `bun test --isolate --env-file=scripts/test.env src/apps/hosting.test.ts` —
  15 pass, 0 fail. Five new cases cover the helper plus the two call sites that
  actually failed in prod: `createRuntime` and `controlRequest` with a 5-character
  secret.
- All 5 new cases were confirmed RED against the unmodified implementation, each
  failing with the exact prod error.
- `src/apps` + `src/platform/providers` + `src/snapshots`, 56 files — 430 pass,
  11 skip, 0 fail.
- Full `apps/api` gate, `bun run test`, 600 files — 6331 pass / 31 fail, against a
  baseline at `main` of 6326 pass / 31 fail. `diff` of the named failure lists is
  identical, so this branch adds no failures. The 31 are pre-existing and unrelated
  (connector faces, postman catalog, project routes).
- `bun run typecheck` — 3 errors, 0 in `src/apps`. All three are `TS2307` for
  uninstalled AWS SDK packages in `src/lib/email/transport.ts`, verified missing via
  `require.resolve` and untouched here.

## Notes

- **This is a length fix, not an entropy fix.** HKDF normalizes key length; it does
  not add entropy. A short `API_KEY_SECRET` remains weak as a scrypt salt and as
  project-secret key material. App runtimes read their own token from
  `KORTIX_APPD_TOKEN`, so app code plus a known `runtimeId` is an offline
  brute-force target against that secret. Rotating it properly needs its own change
  with a re-hash and re-encrypt migration — worth tracking separately.
- `config.ts:131` still validates `API_KEY_SECRET` as `z.string().min(1)`. That is
  now the only length contract on the value, which is why the API boots fine on
  every environment while only App deployment used to fail.
- Not verified against a deployed environment. The proof here is unit-level.
