### PR TITLE
test(deployed): send Vercel SSO bypass header in the browser lane (+ weak-ETag tolerance)

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -43,6 +43,12 @@ jobs:
       E2E_AGENTMAIL_API_KEY: ${{ secrets.E2E_AGENTMAIL_API_KEY }}
       KE2E_CAP_MANAGED_GIT_PUSH: ${{ vars.KE2E_CAP_MANAGED_GIT_PUSH || '0' }}
       WEB_PROTECTION_PASSWORD: ${{ secrets.WEB_PROTECTION_PASSWORD }}
+      # Staging is behind Vercel SSO deployment protection; the browser lane must
+      # send x-vercel-protection-bypass (playwright.config) or every authenticated
+      # page 302s to vercel.com/sso-api. This env was missing when tests-release
+      # replaced the old qa-release gate, so the browser lane could never reach
+      # the app.
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
     steps:
       - uses: actions/checkout@v7
       - name: Require the deployed staging source SHA

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -3,6 +3,20 @@ import { defineConfig, devices } from '@playwright/test';
 const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3000';
 const apiURL = process.env.E2E_API_URL || 'http://localhost:8008/v1';
 const environmentProtectionPassword = process.env.WEB_PROTECTION_PASSWORD;
+// Staging/preview is behind Vercel SSO deployment protection (ssoProtection,
+// passwordProtection is null). Basic-auth httpCredentials does NOT satisfy it —
+// every navigation 302s to vercel.com/sso-api. The automation bypass is the
+// `x-vercel-protection-bypass` header; `x-vercel-set-bypass-cookie` makes Vercel
+// set a cookie so the bypass persists across the app's client-side navigations
+// and fetches. Verified against staging: without the header /auth 302s to SSO,
+// with it returns 200. Empty locally (no protection there) — headers are no-ops.
+const vercelBypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+const vercelBypassHeaders: Record<string, string> = vercelBypass
+  ? {
+      'x-vercel-protection-bypass': vercelBypass,
+      'x-vercel-set-bypass-cookie': 'samesitenone',
+    }
+  : {};
 export function resolveBrowserWorkers(value: string | undefined, ci: boolean): number {
   const configuredWorkers = Number.parseInt(value ?? '', 10);
   if (Number.isFinite(configuredWorkers) && configuredWorkers > 0) return configuredWorkers;
@@ -43,6 +57,7 @@ export default defineConfig({
     httpCredentials: environmentProtectionPassword
       ? { username: 'kortix', password: environmentProtectionPassword }
       : undefined,
+    extraHTTPHeaders: vercelBypassHeaders,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/tests/src/flows/runtime-assets.flow.ts
+++ b/tests/src/flows/runtime-assets.flow.ts
@@ -127,8 +127,13 @@ flow(
       if (body.hash !== hash) {
         throw new Error(`payload hash ${body.hash} must equal the manifest hash ${hash}`);
       }
-      if (r.header('etag') !== `"${hash}"`) {
-        throw new Error(`ETag must be the content hash, got ${r.header('etag')}`);
+      // The edge (Cloudflare) may weaken a strong ETag to `W/"<hash>"` when it
+      // compresses the response — a weak validator carrying the SAME content
+      // hash. Strip an optional `W/` prefix before comparing; the hash is what
+      // this asserts, not the validator strength.
+      const etag = (r.header('etag') ?? '').replace(/^W\//, '');
+      if (etag !== `"${hash}"`) {
+        throw new Error(`ETag must be the content hash "${hash}", got ${r.header('etag')}`);
       }
       // The overlay is what teaches every agent the platform. If kortix-system
       // is missing, a sandbox that reconciles is worse off than one that did not.


### PR DESCRIPTION
**The browser-lane root cause across 3 releases.** Staging is behind Vercel **SSO** deployment protection (`ssoProtection` set, `passwordProtection: null`), so the basic-auth `httpCredentials` the config used satisfies nothing — every authenticated page 302s to `vercel.com/sso-api`, and the specs time out on `Welcome to Kortix`. The `x-vercel-protection-bypass` env + header was lost when `tests-release` replaced the old `qa-release` gate, so the browser lane has never reached the app (I mis-read it as 'load').

**Fix:** playwright.config sends `x-vercel-protection-bypass` + `x-vercel-set-bypass-cookie` from `VERCEL_AUTOMATION_BYPASS_SECRET`, now passed into `tests-release.yml`. **Verified against staging:** `/auth` 302s to SSO without the header, **200 with it**.

Also **RTA-2**: the edge weakens the strong ETag to `W/"<hash>"` under compression — strip an optional `W/` prefix before comparing (the hash is the assertion).

Combined with the r3 retry fix (flow lane already 5/423), this should turn the browser lane green. Verified by the next gate.