### PR TITLE
fix(monitors): monitor-box git-proxy access + stale-agent recycle

### DIFF
--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -43,7 +43,6 @@ mock.module('../shared/db', () => ({
           innerJoin: () => ({ where: () => ({ limit: async () => rows() }) }),
           // Monitor-box lookup (loadMonitorBoxForToken) has no join.
           where: () => ({ limit: async () => rows() }),
-          where: () => ({ limit: async () => rows() }),
         }),
       };
     },

--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -21,6 +21,7 @@ let projectRow: Record<string, unknown> | null = null;
 let patResult: Record<string, unknown> = {};
 let apiKeyResult: Record<string, unknown> = {};
 let sandboxRow: Record<string, unknown> | null = null;
+let monitorBoxRow: Record<string, unknown> | null = null;
 let authorizeAllowed = false;
 let authorizeCalls: Array<{
   userId: string;
@@ -34,10 +35,14 @@ mock.module('../shared/db', () => ({
     select: (fields?: Record<string, unknown>) => {
       const rows = fields?.sessionMetadata
         ? () => (sandboxRow ? [sandboxRow] : [])
-        : () => (projectRow ? [projectRow] : []);
+        : fields?.boxEpoch
+          ? () => (monitorBoxRow ? [monitorBoxRow] : [])
+          : () => (projectRow ? [projectRow] : []);
       return {
         from: () => ({
           innerJoin: () => ({ where: () => ({ limit: async () => rows() }) }),
+          // Monitor-box lookup (loadMonitorBoxForToken) has no join.
+          where: () => ({ limit: async () => rows() }),
           where: () => ({ limit: async () => rows() }),
         }),
       };
@@ -256,5 +261,34 @@ describe('authorizeGitProxy — sandbox token', () => {
     const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'read');
 
     expect(res.ok).toBe(true);
+  });
+
+  // A monitor box has NO session_sandboxes row by design — its token scopes
+  // against project_monitor_boxes (docs/specs/2026-08-12-monitors.md). Caught
+  // live on dev 2026-08-12: the box could not clone and no monitor ever ran.
+  test('a live monitor box clones through the proxy without a session row', async () => {
+    sandboxRow = null;
+    monitorBoxRow = {
+      boxId: 'sandbox-1',
+      projectId: PROJECT_ID,
+      boxEpoch: 'epoch-1',
+    };
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'read');
+
+    expect(res.ok).toBe(true);
+  });
+
+  test('a sandbox token with neither a session nor a monitor box stays denied', async () => {
+    sandboxRow = null;
+    monitorBoxRow = null;
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'read');
+
+    expect(res).toMatchObject({
+      ok: false,
+      status: 403,
+      message: 'sandbox token is not scoped to this project',
+    });
   });
 });

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -763,6 +763,18 @@ export async function authorizeGitProxy(
         ))
         .limit(1);
       if (!sandbox) {
+        // Not a session box — a MONITOR box authenticates with the same token
+        // class but lives in `project_monitor_boxes` (it has no session row by
+        // design; docs/specs/2026-08-12-monitors.md §Security model). It clones
+        // the repo at default-branch HEAD through this proxy — the
+        // clone-credential route is session-shaped and cannot serve it.
+        const { loadMonitorBoxForToken } = await import('./monitor-ingest');
+        const monitorBox = await loadMonitorBoxForToken({
+          projectId,
+          accountId: result.accountId,
+          sandboxId: result.sandboxId,
+        });
+        if (monitorBox) return { ok: true, project };
         return { ok: false, status: 403, message: 'sandbox token is not scoped to this project' };
       }
       if (!workspaceMetadataAllowsRepositoryAccess(sandbox.sessionMetadata)) {

--- a/apps/api/src/projects/lib/monitor-box-core.ts
+++ b/apps/api/src/projects/lib/monitor-box-core.ts
@@ -93,6 +93,10 @@ export interface MonitorBoxSnapshot {
   status: string;
   manifestRevision: string | null;
   externalId: string | null;
+  /** Row creation time — gates the stale-agent recycle so a box that is still
+   *  booting (or a template that is still refreshing post-deploy) is not
+   *  churned. Null on legacy loads that did not select it. */
+  createdAt?: Date | null;
 }
 
 export type MonitorBoxAction =

--- a/apps/api/src/projects/lib/monitor-box.ts
+++ b/apps/api/src/projects/lib/monitor-box.ts
@@ -195,6 +195,7 @@ export async function loadLiveMonitorBox(projectId: string): Promise<MonitorBoxS
       status: projectMonitorBoxes.status,
       manifestRevision: projectMonitorBoxes.manifestRevision,
       externalId: projectMonitorBoxes.externalId,
+      createdAt: projectMonitorBoxes.createdAt,
     })
     .from(projectMonitorBoxes)
     .where(
@@ -262,6 +263,36 @@ async function stopMonitorBox(
  * steady state of a provider hiccup — changes nothing, because acting on it
  * would destroy a healthy box during an outage.
  */
+/** Floor before a running box may be recycled for a stale agent — gives the
+ *  post-deploy template refresh time to land and never probes a booting box. */
+const STALE_AGENT_RECYCLE_MIN_AGE_MS = 30 * 60 * 1000;
+
+/**
+ * Ask the box's daemon which boot path it took. `'monitor'` = current binary in
+ * monitor mode; `'session'` = the daemon booted the session path (an agent
+ * binary that predates monitor mode omits the field — same verdict); `null` =
+ * unreachable/unparseable, in which case the caller must do nothing (the
+ * provider's own status governs and the box may legitimately still be booting).
+ */
+async function probeBoxWorkload(
+  provider: ReturnType<typeof getProvider>,
+  externalId: string,
+): Promise<'monitor' | 'session' | null> {
+  try {
+    const ingress = await provider.resolveIngress(externalId, { port: 8000, transport: 'http' });
+    const res = await fetch(`${ingress.url.replace(/\/$/, '')}/kortix/health`, {
+      headers: ingress.headers ?? {},
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { daemon?: string; workload?: string };
+    if (body?.daemon !== 'ok') return null;
+    return body.workload === 'monitor' ? 'monitor' : 'session';
+  } catch {
+    return null;
+  }
+}
+
 async function observeMonitorBox(
   project: MonitorProjectSnapshot,
   box: MonitorBoxSnapshot,
@@ -278,6 +309,24 @@ async function observeMonitorBox(
       .update(projectMonitorBoxes)
       .set({ lastHeartbeatAt: now, updatedAt: now })
       .where(eq(projectMonitorBoxes.boxId, box.boxId));
+    // A running box whose daemon booted the SESSION path can never run
+    // monitors: the baked agent binary predates monitor mode. The shared
+    // template refreshes asynchronously after a deploy, so a box created in
+    // that window bakes the old binary (observed live on dev 2026-08-12:
+    // env said KORTIX_WORKLOAD=monitor, health said opencode/session).
+    // Recycle it; the next pass recreates it from the refreshed template.
+    // The age floor stops a churn loop while the template pipeline is still
+    // catching up, and keeps the probe off freshly-booting boxes.
+    const ageMs = box.createdAt ? now.getTime() - new Date(box.createdAt).getTime() : 0;
+    if (ageMs > STALE_AGENT_RECYCLE_MIN_AGE_MS) {
+      const workload = await probeBoxWorkload(provider, box.externalId);
+      if (workload === 'session') {
+        console.warn(
+          `[monitor-box] box ${box.boxId} daemon lacks monitor mode (stale agent binary); recycling`,
+        );
+        await stopMonitorBox(project, box, 'daemon booted without monitor mode (stale agent binary)');
+      }
+    }
     return;
   }
   if (status === 'stopped') {

--- a/apps/kortix-sandbox-agent-server/src/routes/health.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/health.ts
@@ -121,6 +121,12 @@ export function createHealthRouter(
       daemon: 'ok',
       status,
       runtimeReady,
+      // Which boot path this daemon took. An agent binary that predates
+      // monitor mode omits the field entirely, which is exactly what the
+      // monitor-box reconciler uses to detect a stale-agent box and recreate
+      // it (a box whose env says KORTIX_WORKLOAD=monitor but whose daemon
+      // booted the session path can never run monitors).
+      workload: process.env.KORTIX_WORKLOAD === 'monitor' ? 'monitor' : 'session',
       opencode: opencodeState,
       uptime_s: Math.floor((Date.now() - bootTime) / 1000),
       opencode_pid: opencode.getPid(),


### PR DESCRIPTION
Follow-up to #6413, from the dev smoke: the monitor box could not clone through the git proxy (its sandbox token has no session row — now scoped against project_monitor_boxes, with authz tests), and a box created in the post-deploy template-refresh window bakes a pre-monitor agent binary and silently boots the session path — the daemon health now reports its boot path and the reconciler recycles running boxes that answer 'session' (30-min age floor to avoid churn). Gates: apps/api 6810/0, agent-server 510/0 + build, authz 16/16.