### PR TITLE
test(deployed): 90m timeout + cap sandbox concurrency (final gate stabilization)

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -20,11 +20,13 @@ jobs:
     # the early REST flows), then the post-test secret-guard/upload steps push
     # the job past 45m. The old 20-min cap killed it at ~316/433 EVERY release
     # (v0.12.7 and v0.12.8 both cancelled, not failed) — the gate was
-    # structurally un-passable. Lanes run concurrently (~47m); every client now
-    # retries the transient laundered-503 so session-create contention self-heals
-    # rather than needing serialization. 65m gives headroom for retry overhead.
-    # Follow-up: shard the runner (matrix over flow domains + browser).
-    timeout-minutes: 65
+    # structurally un-passable. Lanes run concurrently; every client retries the
+    # transient laundered-503 (session-create self-heals). Once the Vercel-SSO
+    # bypass let the browser lane actually run, the full suite is ~65-75m real
+    # (the flow lane alone is ~60m), so the cap is 90m. Staging's JWT lifetime
+    # was raised to 2h (was 1h) so a >60m run no longer expires its tokens.
+    # Follow-up: shard the runner (flow + browser as parallel jobs) to cut this.
+    timeout-minutes: 90
     env:
       KE2E_API_URL: ${{ vars.QA_API_BASE_URL || 'https://staging-api.kortix.com/v1' }}
       E2E_BASE_URL: ${{ vars.QA_WEB_BASE_URL || 'https://staging.kortix.com' }}

--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -133,15 +133,18 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
   const targetApiFull: LocalTestLane = {
     name: 'target-api-full',
     command: ['bun', 'tests/bin/ke2e.ts', 'run', '--require-all'],
-    // This lane runs CONCURRENTLY with target-browser-full against the same
-    // staging origin. At the default 4 API + 4 sandbox workers the combined
-    // load pushes staging origin into 5xx, which the edge launders into
-    // MAINTENANCE_MODE. Dial the REST concurrency down (3+3) to cut that load;
-    // the per-request transient retry (runner.ts) absorbs what's left. Override
-    // via KE2E_API_WORKERS / KE2E_SANDBOX_WORKERS.
+    // This lane runs CONCURRENTLY with target-browser-full (2 workers), and
+    // BOTH boot real sandboxes on the shared staging Daytona provider. The
+    // provider handled ~3 concurrent boots fine when only this lane booted
+    // (browser lane was blocked at the SSO wall), but once the browser lane
+    // started booting too, the combined concurrency saturated the provider and
+    // RUN-*/SESS-* "session runtime ready" waits timed out at ~16 min. Cap this
+    // lane's sandbox boots at 1 so total concurrent boots (1 here + 2 browser)
+    // stay at the ~3 the provider tolerates. API (non-sandbox) workers stay
+    // higher — those flows are fast and don't provision. Override via env.
     env: {
       KE2E_API_WORKERS: process.env.KE2E_API_WORKERS ?? '3',
-      KE2E_SANDBOX_WORKERS: process.env.KE2E_SANDBOX_WORKERS ?? '3',
+      KE2E_SANDBOX_WORKERS: process.env.KE2E_SANDBOX_WORKERS ?? '1',
     },
   };
   const targetBrowserFull: LocalTestLane = {


### PR DESCRIPTION
Final stabilization of the deployed gate. Two changes + a staging-side JWT bump (applied out-of-band):

- **90m timeout** — once the Vercel-SSO bypass let the browser lane actually run, the real full-suite wall-clock is ~65-75m (flow lane alone ~60m). 65m cancelled it mid-run.
- **Cap flow-lane sandbox boots at 1** — the RUN-*/SESS-* 'session runtime ready' timeouts (~16m each) were the shared staging Daytona provider saturating: flow lane (3 sandbox workers) + browser lane (2 workers) both boot sandboxes. r3 proved ~3 concurrent is fine; cap to 1+2=3.
- **Staging JWT lifetime 1h→2h** (via Supabase mgmt API, verified 120m tokens) — the flow lane is ~60m, right at the old 1h token expiry, causing a mass 401 tail once the run crossed 60m. Not a repo change; noted here for the record.

r4c proved the JWT bump works (0 '401/Invalid or expired') and isolated the sandbox-saturation as the last flow-lane blocker (11 fails, ~9 of them RUN-*/SESS- runtime-ready timeouts). Verified by the r5 gate.