### PR TITLE
feat(web): show when each user message was sent

### DIFF
--- a/apps/web/src/features/session/optimistic-turn.tsx
+++ b/apps/web/src/features/session/optimistic-turn.tsx
@@ -14,6 +14,7 @@ import {
 import { SessionBusyIndicator } from '@/features/session/session-busy-indicator';
 import {
   MessageAttachments,
+  MessageMetaRow,
   type NormalizedAttachment,
 } from '@/features/session/turn/user-message';
 import { cn } from '@/lib/utils';
@@ -147,9 +148,26 @@ function OptimisticUserBubble({
           )}
         </div>
       )}
-      <div className="flex justify-end opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100">
-        <CopyButton code={text} size="sm" />
-      </div>
+      {/* The same row the server turn renders, for the same reason the
+          attachments strip is shared: anything shaped differently on one side
+          shows up as a twitch at handover. Its height comes from the copy
+          button, so it matches the real turn's row exactly.
+
+          `timestamp` is deliberately `null`. This turn has no server message,
+          so the only stamp available is a local clock read — and this component
+          is mounted TWICE (boot shell, then chat) with a crossfade between. A
+          clock read at mount would differ between the two, which is the same
+          two-clocks bug that already made the elapsed timer run backwards here.
+          The row stays empty until `time.created` arrives with the real
+          message; the label then appears without moving anything. */}
+      <MessageMetaRow
+        timestamp={null}
+        actions={
+          <div className="flex shrink-0 items-center opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100 focus-within:opacity-100">
+            <CopyButton code={text} size="sm" />
+          </div>
+        }
+      />
     </div>
   );
 }

--- a/apps/web/src/features/session/optimistic-turn.tsx
+++ b/apps/web/src/features/session/optimistic-turn.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo } from 'react';
 
-import { CopyButton } from '@/components/markdown/copy-button';
 import {
   parseAgentMentionReferences,
   parseFileMentionReferences,
@@ -14,8 +13,8 @@ import {
 import { SessionBusyIndicator } from '@/features/session/session-busy-indicator';
 import {
   MessageAttachments,
-  MessageMetaRow,
   type NormalizedAttachment,
+  UserMessageActions,
 } from '@/features/session/turn/user-message';
 import { cn } from '@/lib/utils';
 import { getFilename } from '@/lib/utils/file-utils';
@@ -160,14 +159,7 @@ function OptimisticUserBubble({
           two-clocks bug that already made the elapsed timer run backwards here.
           The row stays empty until `time.created` arrives with the real
           message; the label then appears without moving anything. */}
-      <MessageMetaRow
-        timestamp={null}
-        actions={
-          <div className="flex shrink-0 items-center opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100 focus-within:opacity-100">
-            <CopyButton code={text} size="sm" />
-          </div>
-        }
-      />
+      <UserMessageActions timestamp={null} copyText={text} />
     </div>
   );
 }

--- a/apps/web/src/features/session/session-turn-meta-rows.ts
+++ b/apps/web/src/features/session/session-turn-meta-rows.ts
@@ -6,21 +6,13 @@
  */
 
 import { formatCost, formatDuration, formatTokens } from '@/ui';
-import type { MessageWithParts, Turn, TurnCostInfo } from '@/ui';
+import type { Turn, TurnCostInfo } from '@/ui';
 import { formatDistanceStrict } from 'date-fns';
 
-/** `Message` is a union whose user and assistant arms carry different `time`
- *  shapes, and neither is on the shared `info` type. One narrow accessor here
- *  replaces the `(info as any)?.time?.created` casts that were spread across
- *  `session-chat.tsx`. */
-function messageTime(message: MessageWithParts | undefined): {
-  created?: number;
-  completed?: number;
-} {
-  return (
-    (message?.info as { time?: { created?: number; completed?: number } } | undefined)?.time ?? {}
-  );
-}
+// The narrow accessor for the `Message` union's `time` field lives in
+// `turn/message-time` — the same one the user bubble's timestamp reads through,
+// so there is exactly one place that knows how to get a stamp off a message.
+import { messageTime } from './turn/message-time';
 
 export interface SessionTurnSpan {
   startedAt: number | null;

--- a/apps/web/src/features/session/turn/message-time-label.tsx
+++ b/apps/web/src/features/session/turn/message-time-label.tsx
@@ -1,14 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
+import Hint from '@/components/ui/hint';
 import { cn } from '@/lib/utils';
 
-import {
-  type MessageTimeOptions,
-  formatMessageTime,
-  formatMessageTimeFull,
-} from './message-time';
+import { type MessageTimeOptions, formatMessageDay, formatMessageExact } from './message-time';
 
 /**
  * What the server is allowed to render.
@@ -17,16 +14,73 @@ import {
  * SSR, the viewer's in the browser — so the same instant produces two different
  * strings and hydration fails (React #418, the bug `components/ui/local-time`
  * exists to document). Pinning UTC and `en-US` makes the server's output depend
- * on nothing but the timestamp, so both passes agree; the effect below then
- * swaps in the viewer's real zone and locale.
+ * on nothing but the timestamp, so both passes agree; the client then re-derives
+ * in the viewer's real zone and locale.
  */
 const SERVER_RENDER: MessageTimeOptions = { timeZone: 'UTC', locale: 'en-US' };
 
+// ============================================================================
+// One clock for the whole transcript
+// ============================================================================
+
+/**
+ * A relative label goes stale, so something has to re-render it — but a
+ * transcript can hold hundreds of messages, and hundreds of `setInterval`s to
+ * move one word is the kind of cost that never shows up in review and always
+ * shows up in a profile.
+ *
+ * So there is exactly ONE interval, shared by every label on the page, started
+ * when the first label mounts and cleared when the last unmounts. Thirty
+ * seconds keeps the minute boundary tight enough that "just now" never lingers
+ * visibly, and background tabs throttle it for free.
+ *
+ * `useSyncExternalStore` rather than an effect: its third argument is a
+ * *server* snapshot, which is precisely the "no clock exists here" case. That
+ * makes the hydration-safe split a property of the API instead of something an
+ * effect has to paper over after the fact.
+ */
+const TICK_MS = 30_000;
+
+const listeners = new Set<() => void>();
+let timer: ReturnType<typeof setInterval> | null = null;
+let currentNow = 0;
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  if (!timer) {
+    timer = setInterval(() => {
+      currentNow = Date.now();
+      for (const listener of listeners) listener();
+    }, TICK_MS);
+  }
+  return () => {
+    listeners.delete(onStoreChange);
+    if (listeners.size === 0 && timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+/** Stable between ticks — React calls this repeatedly within one render and
+ *  warns if the value moves, so the clock is read on the tick, not here. */
+function getSnapshot(): number {
+  if (currentNow === 0) currentNow = Date.now();
+  return currentNow;
+}
+
+/** No clock on the server. `null` is the signal, not a sentinel date. */
+function getServerSnapshot(): null {
+  return null;
+}
+
+// ============================================================================
+
 interface Rendered {
-  /** The short reading on screen. */
+  /** How long ago — the label on screen. */
   label: string;
-  /** The unabbreviated reading, for the hover title. */
-  title: string;
+  /** The exact instant — the hover label. */
+  exact: string;
   /** Machine-readable value for `<time datetime>` — UTC, so it never differs
    *  between the two render passes. */
   iso: string;
@@ -34,11 +88,11 @@ interface Rendered {
 
 function derive(timestamp: number | null | undefined, now: number | null): Rendered | null {
   const opts = now === null ? SERVER_RENDER : undefined;
-  const label = formatMessageTime(timestamp, now, opts);
+  const label = formatMessageDay(timestamp, now, opts);
   if (!label) return null;
   return {
     label,
-    title: formatMessageTimeFull(timestamp, opts),
+    exact: formatMessageExact(timestamp, opts),
     iso: new Date(timestamp as number).toISOString(),
   };
 }
@@ -50,45 +104,37 @@ export interface MessageTimeLabelProps {
 }
 
 /**
- * When a message was sent.
- *
- * Deliberately does NOT tick. The label is an absolute clock reading, so the
- * only thing that can go stale is the word "Yesterday" rolling over at
- * midnight — and paying for that with one interval per message, in a transcript
- * that can hold hundreds, is a bad trade for a tab that has been open since
- * before midnight.
+ * When a message was sent: how long ago on screen, the exact instant on hover.
  *
  * Colour is inherited, not set: this renders inside `InlineMeta`, which already
  * owns the meta scale and tone. Overriding it here would put two opinions on
  * one line.
  */
 export function MessageTimeLabel({ timestamp, className }: MessageTimeLabelProps) {
-  // First paint (server AND the client's hydrating pass) uses the timezone-
-  // stable form; `now` is null because no render that has to match the server
-  // may consult a clock.
-  const [rendered, setRendered] = useState(() => derive(timestamp, null));
-
-  useEffect(() => {
-    // Post-hydration: the viewer's own zone, locale, and today.
-    setRendered(derive(timestamp, Date.now()));
-  }, [timestamp]);
+  // `null` on the server and through hydration, a real clock after.
+  const now = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const rendered = derive(timestamp, now);
 
   if (!rendered) return null;
 
-  // `tabular-nums` so a column of timestamps down the transcript lines up
-  // instead of shimmering by a fraction of a character per row. `select-none`
-  // keeps the stamp out of a copied transcript — the reader wanted the
-  // conversation, not the chrome around it. Deliberately no `shrink-0`: the
-  // parent `InlineMeta` truncates, and pinning the width here would make a long
-  // stamp overflow rather than ellipse.
+  // `tabular-nums` so the digits in "5 days ago" hold their width as the count
+  // climbs, instead of the label shuffling on every tick. `select-none` keeps
+  // the stamp out of a copied transcript — the reader wanted the conversation,
+  // not the chrome around it. Deliberately no `shrink-0`: the parent
+  // `InlineMeta` truncates, and pinning the width here would overflow rather
+  // than ellipse.
+  //
+  // `Hint` wraps the `<time>` element directly rather than this component, so
+  // Radix's `asChild` trigger clones a real DOM node and has a ref to attach.
   return (
-    <time
-      dateTime={rendered.iso}
-      title={rendered.title}
-      suppressHydrationWarning
-      className={cn('tabular-nums select-none', className)}
-    >
-      {rendered.label}
-    </time>
+    <Hint label={rendered.exact} side="top" align="center">
+      <time
+        dateTime={rendered.iso}
+        suppressHydrationWarning
+        className={cn('tabular-nums select-none', className)}
+      >
+        {rendered.label}
+      </time>
+    </Hint>
   );
 }

--- a/apps/web/src/features/session/turn/message-time-label.tsx
+++ b/apps/web/src/features/session/turn/message-time-label.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+import {
+  type MessageTimeOptions,
+  formatMessageTime,
+  formatMessageTimeFull,
+} from './message-time';
+
+/**
+ * What the server is allowed to render.
+ *
+ * `toLocaleString` and friends format in the *runtime's* zone — the server's on
+ * SSR, the viewer's in the browser — so the same instant produces two different
+ * strings and hydration fails (React #418, the bug `components/ui/local-time`
+ * exists to document). Pinning UTC and `en-US` makes the server's output depend
+ * on nothing but the timestamp, so both passes agree; the effect below then
+ * swaps in the viewer's real zone and locale.
+ */
+const SERVER_RENDER: MessageTimeOptions = { timeZone: 'UTC', locale: 'en-US' };
+
+interface Rendered {
+  /** The short reading on screen. */
+  label: string;
+  /** The unabbreviated reading, for the hover title. */
+  title: string;
+  /** Machine-readable value for `<time datetime>` — UTC, so it never differs
+   *  between the two render passes. */
+  iso: string;
+}
+
+function derive(timestamp: number | null | undefined, now: number | null): Rendered | null {
+  const opts = now === null ? SERVER_RENDER : undefined;
+  const label = formatMessageTime(timestamp, now, opts);
+  if (!label) return null;
+  return {
+    label,
+    title: formatMessageTimeFull(timestamp, opts),
+    iso: new Date(timestamp as number).toISOString(),
+  };
+}
+
+export interface MessageTimeLabelProps {
+  /** Epoch milliseconds. `null` renders nothing at all. */
+  timestamp: number | null | undefined;
+  className?: string;
+}
+
+/**
+ * When a message was sent.
+ *
+ * Deliberately does NOT tick. The label is an absolute clock reading, so the
+ * only thing that can go stale is the word "Yesterday" rolling over at
+ * midnight — and paying for that with one interval per message, in a transcript
+ * that can hold hundreds, is a bad trade for a tab that has been open since
+ * before midnight.
+ *
+ * Colour is inherited, not set: this renders inside `InlineMeta`, which already
+ * owns the meta scale and tone. Overriding it here would put two opinions on
+ * one line.
+ */
+export function MessageTimeLabel({ timestamp, className }: MessageTimeLabelProps) {
+  // First paint (server AND the client's hydrating pass) uses the timezone-
+  // stable form; `now` is null because no render that has to match the server
+  // may consult a clock.
+  const [rendered, setRendered] = useState(() => derive(timestamp, null));
+
+  useEffect(() => {
+    // Post-hydration: the viewer's own zone, locale, and today.
+    setRendered(derive(timestamp, Date.now()));
+  }, [timestamp]);
+
+  if (!rendered) return null;
+
+  // `tabular-nums` so a column of timestamps down the transcript lines up
+  // instead of shimmering by a fraction of a character per row. `select-none`
+  // keeps the stamp out of a copied transcript — the reader wanted the
+  // conversation, not the chrome around it. Deliberately no `shrink-0`: the
+  // parent `InlineMeta` truncates, and pinning the width here would make a long
+  // stamp overflow rather than ellipse.
+  return (
+    <time
+      dateTime={rendered.iso}
+      title={rendered.title}
+      suppressHydrationWarning
+      className={cn('tabular-nums select-none', className)}
+    >
+      {rendered.label}
+    </time>
+  );
+}

--- a/apps/web/src/features/session/turn/message-time.test.ts
+++ b/apps/web/src/features/session/turn/message-time.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from 'bun:test';
 import type { MessageWithParts } from '@/ui';
 
 import {
-  formatMessageTime,
-  formatMessageTimeFull,
+  formatMessageDay,
+  formatMessageExact,
   messageCreatedAt,
   messageTime,
 } from './message-time';
@@ -17,78 +17,122 @@ import {
  */
 const norm = (value: string) => value.replace(/[\u202f\u00a0]/g, ' ');
 
-/** Wednesday 12 August 2026, 15:00 UTC. Every case below is relative to it. */
+/** Wednesday 12 August 2026, 15:00:00 UTC. Every case below is relative to it. */
 const NOW = Date.UTC(2026, 7, 12, 15, 0, 0);
 
 const utc = { timeZone: 'UTC', locale: 'en-US' };
 
-const fmt = (ts: number | null | undefined, now: number | null = NOW, opts = utc) =>
-  norm(formatMessageTime(ts, now, opts));
+const label = (ts: number | null | undefined, now: number | null = NOW, opts = utc) =>
+  formatMessageDay(ts, now, opts);
+const exact = (ts: number | null | undefined, opts = utc) => norm(formatMessageExact(ts, opts));
 
-describe('formatMessageTime — how far back it was decides how much is shown', () => {
-  test('a message from today is just a clock reading', () => {
-    expect(fmt(Date.UTC(2026, 7, 12, 9, 34))).toBe('9:34 AM');
+describe('formatMessageDay — recent reads as distance', () => {
+  test('under a minute is one word, not a second-by-second countdown', () => {
+    expect(label(Date.UTC(2026, 7, 12, 14, 59, 30))).toBe('just now');
+    expect(label(Date.UTC(2026, 7, 12, 15, 0, 0))).toBe('just now');
   });
 
-  test('midnight today is still today, not yesterday', () => {
-    expect(fmt(Date.UTC(2026, 7, 12, 0, 5))).toBe('12:05 AM');
+  test('minutes, hours, days', () => {
+    expect(label(Date.UTC(2026, 7, 12, 14, 59, 0))).toBe('1 minute ago');
+    expect(label(Date.UTC(2026, 7, 12, 14, 55, 0))).toBe('5 minutes ago');
+    expect(label(Date.UTC(2026, 7, 12, 12, 0, 0))).toBe('3 hours ago');
+    expect(label(Date.UTC(2026, 7, 7, 15, 0, 0))).toBe('5 days ago');
   });
 
-  test('yesterday is named, because "9:05 PM" alone would read as today', () => {
-    expect(fmt(Date.UTC(2026, 7, 11, 21, 5))).toBe('Yesterday 9:05 PM');
-  });
-
-  test('inside the last week the weekday places it fastest', () => {
-    // 9 Aug 2026 is a Sunday; 6 Aug is a Thursday.
-    expect(fmt(Date.UTC(2026, 7, 9, 14, 0))).toBe('Sun 2:00 PM');
-    expect(fmt(Date.UTC(2026, 7, 6, 8, 0))).toBe('Thu 8:00 AM');
-  });
-
-  test('at seven days the weekday stops being unambiguous and the date takes over', () => {
-    expect(fmt(Date.UTC(2026, 7, 5, 8, 0))).toBe('Aug 5, 8:00 AM');
-  });
-
-  test('a different year says so', () => {
-    expect(fmt(Date.UTC(2025, 7, 12, 10, 15))).toBe('Aug 12, 2025, 10:15 AM');
-  });
-
-  test('this year does not repeat the year', () => {
-    expect(fmt(Date.UTC(2026, 0, 3, 10, 15))).toBe('Jan 3, 10:15 AM');
+  test('a stamp ahead of the clock reads as just now, never as the future', () => {
+    // Sandbox/browser skew can push a stamp past the browser's clock.
+    // "in 30 seconds" would be a bug on screen; the clamp hides the skew.
+    expect(label(Date.UTC(2026, 7, 12, 15, 0, 30))).toBe('just now');
+    expect(label(Date.UTC(2026, 7, 13, 1, 0, 0))).toBe('just now');
   });
 });
 
-describe('formatMessageTime — the parts that are easy to get wrong', () => {
-  test('"today" is decided in the render zone, not the runtime zone', () => {
-    // 02:30 UTC on the 12th is 22:30 on the 11th in New York. Asking the
-    // question in UTC would print "2:30 AM" next to a clock face reading
-    // 10:30 PM — the day and the time would disagree on screen.
-    const ts = Date.UTC(2026, 7, 12, 2, 30);
-    expect(fmt(ts)).toBe('2:30 AM');
-    expect(fmt(ts, NOW, { timeZone: 'America/New_York', locale: 'en-US' })).toBe(
-      'Yesterday 10:30 PM',
+describe('formatMessageDay — past a week, distance stops helping', () => {
+  test('at exactly a week the date takes over', () => {
+    // Nobody counts to "23 days ago". The handover is the point of the ladder.
+    expect(label(Date.UTC(2026, 7, 5, 16, 0, 0))).toContain('ago');
+    expect(label(Date.UTC(2026, 7, 5, 15, 0, 0))).toBe('August 5');
+  });
+
+  test('this year omits the year; any other year states it', () => {
+    expect(label(Date.UTC(2026, 5, 9, 10, 15))).toBe('June 9');
+    expect(label(Date.UTC(2025, 5, 9, 10, 15))).toBe('June 9, 2025');
+  });
+
+  test('field order follows the locale, not this module', () => {
+    expect(label(Date.UTC(2026, 5, 9, 10, 15), NOW, { timeZone: 'UTC', locale: 'en-GB' })).toBe(
+      '9 June',
     );
   });
 
-  test('a stamp slightly ahead of the clock reads as today, never as the future', () => {
-    // Sandbox/browser skew can push a stamp past midnight. "Tomorrow 1:00 AM"
-    // would be a bug on screen; the clamp makes the skew invisible instead.
-    expect(fmt(Date.UTC(2026, 7, 13, 1, 0))).toBe('1:00 AM');
+  test('"same year" is asked in the render zone', () => {
+    // 1 Jan 2026 00:30 UTC is still 2025 in New York, so the year must show.
+    const ts = Date.UTC(2026, 0, 1, 0, 30);
+    expect(label(ts)).toBe('January 1');
+    expect(label(ts, NOW, { timeZone: 'America/New_York', locale: 'en-US' })).toBe(
+      'December 31, 2025',
+    );
   });
 
-  test('field order and 12/24-hour follow the locale, not this module', () => {
-    expect(fmt(Date.UTC(2026, 7, 5, 8, 0))).toBe('Aug 5, 8:00 AM');
-    const gb = fmt(Date.UTC(2026, 7, 5, 8, 0), NOW, { timeZone: 'UTC', locale: 'en-GB' });
-    expect(gb).toContain('5 Aug');
-    expect(gb).not.toContain('AM');
-  });
-
-  test('a null clock returns the unambiguous full form — the server-render case', () => {
-    // The server cannot know the viewer's day, so it must not guess one.
-    expect(fmt(Date.UTC(2026, 7, 12, 9, 34), null)).toBe('Aug 12, 2026, 9:34 AM');
+  test('a null clock returns the dated form — the server-render case', () => {
+    // The server cannot know the viewer's clock, so it must not guess a
+    // distance. A relative word here is the hydration bug this avoids.
+    expect(label(Date.UTC(2026, 7, 12, 9, 34), null)).toBe('August 12, 2026');
+    expect(label(Date.UTC(2026, 7, 12, 9, 34), null)).not.toContain('ago');
   });
 });
 
-describe('formatMessageTime — absent data renders nothing, not a placeholder', () => {
+describe('formatMessageExact — the hover label is the whole instant', () => {
+  test('spells out the full date and the time of day', () => {
+    expect(exact(Date.UTC(2026, 5, 9, 14, 32, 5))).toBe('June 9, 2026 2:32 PM');
+    expect(exact(Date.UTC(2026, 7, 12, 9, 34, 0))).toBe('August 12, 2026 9:34 AM');
+  });
+
+  test('stops at minutes — a seconds reading looks worth reading and never is', () => {
+    expect(exact(Date.UTC(2026, 5, 9, 14, 32, 5))).not.toMatch(/:\d{2}:\d{2}/);
+  });
+
+  test('12- vs 24-hour and field order follow the locale', () => {
+    const gb = exact(Date.UTC(2026, 5, 9, 14, 32, 5), { timeZone: 'UTC', locale: 'en-GB' });
+    expect(gb).toContain('9 June 2026');
+    expect(gb).toContain('14:32');
+    expect(gb).not.toContain('PM');
+  });
+
+  test('renders in the given zone', () => {
+    expect(
+      exact(Date.UTC(2026, 5, 9, 2, 30, 0), { timeZone: 'America/New_York', locale: 'en-US' }),
+    ).toBe('June 8, 2026 10:30 PM');
+  });
+
+  test('the day period is upper case in every locale that has one', () => {
+    // CLDR does not agree with itself: `en-US` gives "PM", while `en-AU`,
+    // `en-NZ` and `en-IN` give a lowercase "pm". Left alone, the same code
+    // renders differently for two readers for no reason they can see.
+    const afternoon = Date.UTC(2026, 5, 9, 14, 32, 0);
+    const morning = Date.UTC(2026, 5, 9, 9, 5, 0);
+
+    for (const locale of ['en-US', 'en-AU', 'en-NZ', 'en-IN', 'en-CA', 'en-PH']) {
+      const pm = exact(afternoon, { timeZone: 'UTC', locale });
+      const am = exact(morning, { timeZone: 'UTC', locale });
+      expect(pm).not.toContain('pm');
+      expect(am).not.toContain('am');
+      // …and it is actually present, so the assertions above are not passing
+      // simply because the locale renders a 24-hour clock.
+      expect(pm.toUpperCase()).toContain('PM');
+      expect(am.toUpperCase()).toContain('AM');
+    }
+  });
+
+  test('uppercasing the day period leaves the rest of the string alone', () => {
+    // Month names must not be shouted at the reader as a side effect.
+    expect(exact(Date.UTC(2026, 5, 9, 14, 32, 0), { timeZone: 'UTC', locale: 'en-US' })).toBe(
+      'June 9, 2026 2:32 PM',
+    );
+  });
+});
+
+describe('absent data renders nothing, not a placeholder', () => {
   const absent: Array<[string, number | null | undefined]> = [
     ['undefined', undefined],
     ['null', null],
@@ -98,23 +142,12 @@ describe('formatMessageTime — absent data renders nothing, not a placeholder',
     ['Infinity', Number.POSITIVE_INFINITY],
   ];
 
-  for (const [label, value] of absent) {
-    test(`${label} renders as an empty string`, () => {
-      expect(formatMessageTime(value, NOW, utc)).toBe('');
+  for (const [name, value] of absent) {
+    test(`${name} renders as an empty string in both formatters`, () => {
+      expect(formatMessageDay(value, NOW, utc)).toBe('');
+      expect(formatMessageExact(value, utc)).toBe('');
     });
   }
-});
-
-describe('formatMessageTimeFull', () => {
-  test('spells the instant out for the hover title', () => {
-    expect(norm(formatMessageTimeFull(Date.UTC(2026, 7, 12, 9, 34), utc))).toBe(
-      'Wednesday, August 12, 2026 at 9:34 AM',
-    );
-  });
-
-  test('is empty for a missing stamp', () => {
-    expect(formatMessageTimeFull(undefined, utc)).toBe('');
-  });
 });
 
 describe('messageCreatedAt', () => {
@@ -138,8 +171,8 @@ describe('messageCreatedAt', () => {
     ['a numeric string', '1760000000000'],
   ];
 
-  for (const [label, value] of rejected) {
-    test(`rejects ${label}`, () => {
+  for (const [name, value] of rejected) {
+    test(`rejects ${name}`, () => {
       expect(messageCreatedAt(withTime(value))).toBeNull();
     });
   }

--- a/apps/web/src/features/session/turn/message-time.test.ts
+++ b/apps/web/src/features/session/turn/message-time.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { MessageWithParts } from '@/ui';
+
+import {
+  formatMessageTime,
+  formatMessageTimeFull,
+  messageCreatedAt,
+  messageTime,
+} from './message-time';
+
+/**
+ * ICU >= 72 separates the time from the day period with U+202F (narrow no-break
+ * space), not U+0020 — so `'9:34 AM'` compares unequal to its own output on a
+ * modern runtime. Normalizing here keeps the expectations readable and keeps
+ * the suite from breaking on an ICU bump that changed nothing a user can see.
+ */
+const norm = (value: string) => value.replace(/[\u202f\u00a0]/g, ' ');
+
+/** Wednesday 12 August 2026, 15:00 UTC. Every case below is relative to it. */
+const NOW = Date.UTC(2026, 7, 12, 15, 0, 0);
+
+const utc = { timeZone: 'UTC', locale: 'en-US' };
+
+const fmt = (ts: number | null | undefined, now: number | null = NOW, opts = utc) =>
+  norm(formatMessageTime(ts, now, opts));
+
+describe('formatMessageTime — how far back it was decides how much is shown', () => {
+  test('a message from today is just a clock reading', () => {
+    expect(fmt(Date.UTC(2026, 7, 12, 9, 34))).toBe('9:34 AM');
+  });
+
+  test('midnight today is still today, not yesterday', () => {
+    expect(fmt(Date.UTC(2026, 7, 12, 0, 5))).toBe('12:05 AM');
+  });
+
+  test('yesterday is named, because "9:05 PM" alone would read as today', () => {
+    expect(fmt(Date.UTC(2026, 7, 11, 21, 5))).toBe('Yesterday 9:05 PM');
+  });
+
+  test('inside the last week the weekday places it fastest', () => {
+    // 9 Aug 2026 is a Sunday; 6 Aug is a Thursday.
+    expect(fmt(Date.UTC(2026, 7, 9, 14, 0))).toBe('Sun 2:00 PM');
+    expect(fmt(Date.UTC(2026, 7, 6, 8, 0))).toBe('Thu 8:00 AM');
+  });
+
+  test('at seven days the weekday stops being unambiguous and the date takes over', () => {
+    expect(fmt(Date.UTC(2026, 7, 5, 8, 0))).toBe('Aug 5, 8:00 AM');
+  });
+
+  test('a different year says so', () => {
+    expect(fmt(Date.UTC(2025, 7, 12, 10, 15))).toBe('Aug 12, 2025, 10:15 AM');
+  });
+
+  test('this year does not repeat the year', () => {
+    expect(fmt(Date.UTC(2026, 0, 3, 10, 15))).toBe('Jan 3, 10:15 AM');
+  });
+});
+
+describe('formatMessageTime — the parts that are easy to get wrong', () => {
+  test('"today" is decided in the render zone, not the runtime zone', () => {
+    // 02:30 UTC on the 12th is 22:30 on the 11th in New York. Asking the
+    // question in UTC would print "2:30 AM" next to a clock face reading
+    // 10:30 PM — the day and the time would disagree on screen.
+    const ts = Date.UTC(2026, 7, 12, 2, 30);
+    expect(fmt(ts)).toBe('2:30 AM');
+    expect(fmt(ts, NOW, { timeZone: 'America/New_York', locale: 'en-US' })).toBe(
+      'Yesterday 10:30 PM',
+    );
+  });
+
+  test('a stamp slightly ahead of the clock reads as today, never as the future', () => {
+    // Sandbox/browser skew can push a stamp past midnight. "Tomorrow 1:00 AM"
+    // would be a bug on screen; the clamp makes the skew invisible instead.
+    expect(fmt(Date.UTC(2026, 7, 13, 1, 0))).toBe('1:00 AM');
+  });
+
+  test('field order and 12/24-hour follow the locale, not this module', () => {
+    expect(fmt(Date.UTC(2026, 7, 5, 8, 0))).toBe('Aug 5, 8:00 AM');
+    const gb = fmt(Date.UTC(2026, 7, 5, 8, 0), NOW, { timeZone: 'UTC', locale: 'en-GB' });
+    expect(gb).toContain('5 Aug');
+    expect(gb).not.toContain('AM');
+  });
+
+  test('a null clock returns the unambiguous full form — the server-render case', () => {
+    // The server cannot know the viewer's day, so it must not guess one.
+    expect(fmt(Date.UTC(2026, 7, 12, 9, 34), null)).toBe('Aug 12, 2026, 9:34 AM');
+  });
+});
+
+describe('formatMessageTime — absent data renders nothing, not a placeholder', () => {
+  const absent: Array<[string, number | null | undefined]> = [
+    ['undefined', undefined],
+    ['null', null],
+    ['zero (a missing stamp, not 1970)', 0],
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ];
+
+  for (const [label, value] of absent) {
+    test(`${label} renders as an empty string`, () => {
+      expect(formatMessageTime(value, NOW, utc)).toBe('');
+    });
+  }
+});
+
+describe('formatMessageTimeFull', () => {
+  test('spells the instant out for the hover title', () => {
+    expect(norm(formatMessageTimeFull(Date.UTC(2026, 7, 12, 9, 34), utc))).toBe(
+      'Wednesday, August 12, 2026 at 9:34 AM',
+    );
+  });
+
+  test('is empty for a missing stamp', () => {
+    expect(formatMessageTimeFull(undefined, utc)).toBe('');
+  });
+});
+
+describe('messageCreatedAt', () => {
+  const withTime = (created: unknown) =>
+    ({ info: { id: 'm1', role: 'user', time: { created } }, parts: [] }) as unknown as MessageWithParts;
+
+  test('reads the stamp off the union arm', () => {
+    expect(messageCreatedAt(withTime(1_760_000_000_000))).toBe(1_760_000_000_000);
+  });
+
+  test('tolerates a message with no time at all', () => {
+    // The existing `user-message.test.tsx` fixture is exactly this shape.
+    expect(messageCreatedAt({ info: { id: 'm1', role: 'user' } } as MessageWithParts)).toBeNull();
+    expect(messageCreatedAt(undefined)).toBeNull();
+  });
+
+  const rejected: Array<[string, unknown]> = [
+    ['zero', 0],
+    ['a negative stamp', -1],
+    ['NaN', Number.NaN],
+    ['a numeric string', '1760000000000'],
+  ];
+
+  for (const [label, value] of rejected) {
+    test(`rejects ${label}`, () => {
+      expect(messageCreatedAt(withTime(value))).toBeNull();
+    });
+  }
+
+  test('messageTime returns an empty object rather than throwing on a bare info', () => {
+    expect(messageTime({ info: { id: 'm1', role: 'user' } } as MessageWithParts)).toEqual({});
+    expect(messageTime(undefined)).toEqual({});
+  });
+});

--- a/apps/web/src/features/session/turn/message-time.ts
+++ b/apps/web/src/features/session/turn/message-time.ts
@@ -1,0 +1,182 @@
+/**
+ * When a message was sent, as a string a person can read at a glance.
+ *
+ * A transcript is a log, and a log without timestamps can only be read
+ * relatively — "this came after that". Scroll back an hour and there is nothing
+ * on screen that says *when*. This module turns `info.time.created` into the
+ * one line that answers it.
+ *
+ * Two rules shape everything below:
+ *
+ * 1. **Absolute, not relative.** "5m ago" has to tick to stay true, and a
+ *    transcript can hold hundreds of messages — that is hundreds of intervals
+ *    re-rendering hundreds of rows to move a digit. A clock reading is correct
+ *    the moment it is printed and stays correct forever.
+ * 2. **`now` is injected, never read here.** Same reason the sibling
+ *    `session-turn-meta-rows` does it: the "Yesterday" wording is a pure
+ *    function of two instants, so it stays testable, and one render derives
+ *    every label from a single clock read instead of each row racing its own.
+ */
+
+import type { MessageWithParts } from '@/ui';
+
+/**
+ * `Message` is a union whose user and assistant arms carry different `time`
+ * shapes, and neither is on the shared `info` type — so `info.time` does not
+ * typecheck against the union. This narrow accessor is the one place that cast
+ * lives; `session-turn-meta-rows` imports it rather than keeping a second copy.
+ */
+export function messageTime(message: MessageWithParts | undefined): {
+  created?: number;
+  completed?: number;
+} {
+  return (
+    (message?.info as { time?: { created?: number; completed?: number } } | undefined)?.time ?? {}
+  );
+}
+
+/**
+ * When the message was created, in epoch **milliseconds**, or `null` when the
+ * backend never stamped one.
+ *
+ * Milliseconds is not an assumption: `packages/sdk/src/transcript.ts` feeds the
+ * same field straight to `new Date(...)` with no `* 1000`, and hands
+ * `time.completed - time.created` to a `formatDuration(ms)`.
+ *
+ * `0` is rejected along with `NaN`: the epoch is not a plausible message time,
+ * so a zeroed field is missing data, not midnight in 1970.
+ */
+export function messageCreatedAt(message: MessageWithParts | undefined): number | null {
+  const created = messageTime(message).created;
+  if (typeof created !== 'number' || !Number.isFinite(created) || created <= 0) return null;
+  return created;
+}
+
+export interface MessageTimeOptions {
+  /**
+   * IANA zone to render in. Omit for the viewer's own zone — which is what the
+   * browser should use, and exactly what a server render must NOT, since the
+   * server's zone is its own and the resulting text would not survive
+   * hydration.
+   */
+  timeZone?: string;
+  /**
+   * BCP-47 locale. Omit for the viewer's own — it decides 12- vs 24-hour, which
+   * is the whole reason not to hardcode `en-US` on the client.
+   */
+  locale?: string;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * The calendar date at an instant, *in a given zone*, as `YYYY-MM-DD`.
+ *
+ * The zone matters: "is this today?" has to be asked in the same zone the clock
+ * face is printed in, or a message stamped 23:40 local reads as "Yesterday"
+ * next to a 23:40 time. `en-CA` is used purely because it yields ISO order.
+ */
+function civilDate(date: Date, timeZone?: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    ...(timeZone ? { timeZone } : {}),
+  }).format(date);
+}
+
+/** `YYYY-MM-DD` → days since the epoch. Subtracting two of these gives a whole
+ *  number of calendar days apart with no DST arithmetic to get wrong. */
+function civilDayIndex(civil: string): number {
+  const [year, month, day] = civil.split('-').map(Number);
+  return Math.round(Date.UTC(year, month - 1, day) / MS_PER_DAY);
+}
+
+function part(date: Date, options: Intl.DateTimeFormatOptions, opts: MessageTimeOptions): string {
+  return new Intl.DateTimeFormat(opts.locale, {
+    ...options,
+    ...(opts.timeZone ? { timeZone: opts.timeZone } : {}),
+  }).format(date);
+}
+
+const TIME: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit' };
+
+/**
+ * How the timestamp reads, scoped to how far back it is.
+ *
+ * | When            | Reads as (`en-US`)       |
+ * | --------------- | ------------------------ |
+ * | today           | `2:34 PM`                |
+ * | yesterday       | `Yesterday 2:34 PM`      |
+ * | within the week | `Tue 2:34 PM`            |
+ * | this year       | `Aug 12, 2:34 PM`        |
+ * | any older       | `Aug 12, 2025, 2:34 PM`  |
+ *
+ * Field *order* is the locale's, not ours — `Intl` puts the day first for
+ * `en-GB` and the month first for `en-US`, and both are right for their reader.
+ * Only the field *set* is chosen here.
+ *
+ * The ladder exists because precision is only worth the pixels it earns. Inside
+ * today the date is noise — every message shares it. A week out the weekday is
+ * the fastest way to place a message. Past that, only the date means anything.
+ *
+ * `now` is `null` for a server render, where "today" is unknowable: the server
+ * cannot know the viewer's zone, and guessing produces text that changes on
+ * hydration. `null` returns the unambiguous full form instead, so the string
+ * shown before hydration is never *wrong* — only longer than it will be.
+ *
+ * Returns `''` for a timestamp that is absent or unparseable, so the caller can
+ * render nothing rather than a `Invalid Date` placeholder.
+ */
+export function formatMessageTime(
+  timestamp: number | null | undefined,
+  now: number | null,
+  opts: MessageTimeOptions = {},
+): string {
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || timestamp <= 0) return '';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+
+  const time = part(date, TIME, opts);
+
+  if (now === null) {
+    return `${part(date, { day: 'numeric', month: 'short', year: 'numeric' }, opts)}, ${time}`;
+  }
+
+  const thenCivil = civilDate(date, opts.timeZone);
+  const nowCivil = civilDate(new Date(now), opts.timeZone);
+  const days = civilDayIndex(nowCivil) - civilDayIndex(thenCivil);
+
+  // A negative gap means the stamp is ahead of this clock — a few seconds of
+  // skew between the sandbox and the browser, not a message from tomorrow.
+  // Clamping to "today" keeps the skew invisible instead of printing a future.
+  if (days <= 0) return time;
+  if (days === 1) return `Yesterday ${time}`;
+  if (days < 7) return `${part(date, { weekday: 'short' }, opts)} ${time}`;
+
+  const sameYear = thenCivil.slice(0, 4) === nowCivil.slice(0, 4);
+  const day = part(
+    date,
+    { day: 'numeric', month: 'short', ...(sameYear ? {} : { year: 'numeric' }) },
+    opts,
+  );
+  return `${day}, ${time}`;
+}
+
+/**
+ * The unabbreviated reading, for the `title` tooltip — the timestamp on screen
+ * is deliberately short, and hovering is where "which Tuesday?" gets answered.
+ */
+export function formatMessageTimeFull(
+  timestamp: number | null | undefined,
+  opts: MessageTimeOptions = {},
+): string {
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || timestamp <= 0) return '';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  return part(
+    date,
+    { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric', ...TIME },
+    opts,
+  );
+}

--- a/apps/web/src/features/session/turn/message-time.ts
+++ b/apps/web/src/features/session/turn/message-time.ts
@@ -1,22 +1,19 @@
 /**
- * When a message was sent, as a string a person can read at a glance.
+ * When a message was sent, in the two registers a reader actually wants.
  *
- * A transcript is a log, and a log without timestamps can only be read
- * relatively — "this came after that". Scroll back an hour and there is nothing
- * on screen that says *when*. This module turns `info.time.created` into the
- * one line that answers it.
+ * **The label says how long ago. The hint says exactly when.** Recent messages
+ * are easiest to place by distance — "5 days ago" lands immediately, where a
+ * date makes you do arithmetic. Past a week that inverts: nobody counts to
+ * "23 days ago", so the label becomes the date itself. The precise instant,
+ * down to the second, lives one hover away and never clutters the thread.
  *
- * Two rules shape everything below:
- *
- * 1. **Absolute, not relative.** "5m ago" has to tick to stay true, and a
- *    transcript can hold hundreds of messages — that is hundreds of intervals
- *    re-rendering hundreds of rows to move a digit. A clock reading is correct
- *    the moment it is printed and stays correct forever.
- * 2. **`now` is injected, never read here.** Same reason the sibling
- *    `session-turn-meta-rows` does it: the "Yesterday" wording is a pure
- *    function of two instants, so it stays testable, and one render derives
- *    every label from a single clock read instead of each row racing its own.
+ * `now` is injected, never read here. Same reason the sibling
+ * `session-turn-meta-rows` does it: the wording is a pure function of two
+ * instants, so it stays testable, and one render derives every label from a
+ * single clock read instead of each row racing its own.
  */
+
+import { formatDistanceStrict } from 'date-fns';
 
 import type { MessageWithParts } from '@/ui';
 
@@ -67,116 +64,130 @@ export interface MessageTimeOptions {
   locale?: string;
 }
 
-const MS_PER_DAY = 86_400_000;
+const MINUTE = 60_000;
+const WEEK = 7 * 24 * 60 * MINUTE;
+
+/** A usable instant, or `null`. One guard, used by both formatters. */
+function instant(timestamp: number | null | undefined): Date | null {
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || timestamp <= 0) return null;
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
 
 /**
- * The calendar date at an instant, *in a given zone*, as `YYYY-MM-DD`.
- *
- * The zone matters: "is this today?" has to be asked in the same zone the clock
- * face is printed in, or a message stamped 23:40 local reads as "Yesterday"
- * next to a 23:40 time. `en-CA` is used purely because it yields ISO order.
+ * `Intl.DateTimeFormat` construction is the expensive half of formatting — it
+ * resolves locale data every time — while the instances themselves are
+ * immutable and safe to reuse. A transcript re-renders every label on each
+ * clock tick, so building a fresh formatter per label per tick is the one cost
+ * here that scales with conversation length. There are only a handful of
+ * distinct (locale, options) pairs in this module, so they are all cached.
  */
-function civilDate(date: Date, timeZone?: string): string {
-  return new Intl.DateTimeFormat('en-CA', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    ...(timeZone ? { timeZone } : {}),
-  }).format(date);
-}
+const formatters = new Map<string, Intl.DateTimeFormat>();
 
-/** `YYYY-MM-DD` → days since the epoch. Subtracting two of these gives a whole
- *  number of calendar days apart with no DST arithmetic to get wrong. */
-function civilDayIndex(civil: string): number {
-  const [year, month, day] = civil.split('-').map(Number);
-  return Math.round(Date.UTC(year, month - 1, day) / MS_PER_DAY);
+function formatter(options: Intl.DateTimeFormatOptions, opts: MessageTimeOptions) {
+  const resolved = { ...options, ...(opts.timeZone ? { timeZone: opts.timeZone } : {}) };
+  const key = `${opts.locale ?? ''}|${JSON.stringify(resolved)}`;
+  let cached = formatters.get(key);
+  if (!cached) {
+    cached = new Intl.DateTimeFormat(opts.locale, resolved);
+    formatters.set(key, cached);
+  }
+  return cached;
 }
-
-function part(date: Date, options: Intl.DateTimeFormatOptions, opts: MessageTimeOptions): string {
-  return new Intl.DateTimeFormat(opts.locale, {
-    ...options,
-    ...(opts.timeZone ? { timeZone: opts.timeZone } : {}),
-  }).format(date);
-}
-
-const TIME: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit' };
 
 /**
- * How the timestamp reads, scoped to how far back it is.
+ * Format, with the day period forced to upper case.
  *
- * | When            | Reads as (`en-US`)       |
- * | --------------- | ------------------------ |
- * | today           | `2:34 PM`                |
- * | yesterday       | `Yesterday 2:34 PM`      |
- * | within the week | `Tue 2:34 PM`            |
- * | this year       | `Aug 12, 2:34 PM`        |
- * | any older       | `Aug 12, 2025, 2:34 PM`  |
+ * `Intl` does not agree with itself here: CLDR gives `en-US` an uppercase
+ * "PM" but hands `en-AU` a lowercase "pm" — so the same code renders
+ * "2:32 PM" for one reader and "2:32 pm" for another, with nothing in this
+ * file to explain the difference. Uppercasing the one token settles it without
+ * touching month names, weekday names, or the 24-hour locales that have no day
+ * period at all.
  *
- * Field *order* is the locale's, not ours — `Intl` puts the day first for
- * `en-GB` and the month first for `en-US`, and both are right for their reader.
- * Only the field *set* is chosen here.
+ * `formatToParts(...).join('')` reproduces `format()` exactly, so this is the
+ * same string with one token changed — not a reimplementation of formatting.
+ */
+function part(date: Date, options: Intl.DateTimeFormatOptions, opts: MessageTimeOptions): string {
+  return formatter(options, opts)
+    .formatToParts(date)
+    .map((token) =>
+      token.type === 'dayPeriod' ? token.value.toLocaleUpperCase(opts.locale) : token.value,
+    )
+    .join('');
+}
+
+/** The calendar year at an instant, in the render zone — so "same year" is
+ *  asked in the zone the date is printed in, not the runtime's. */
+function yearIn(date: Date, opts: MessageTimeOptions): string {
+  return part(date, { year: 'numeric' }, opts);
+}
+
+/**
+ * The label on screen.
  *
- * The ladder exists because precision is only worth the pixels it earns. Inside
- * today the date is noise — every message shares it. A week out the weekday is
- * the fastest way to place a message. Past that, only the date means anything.
+ * | When            | Reads as (`en-US`) |
+ * | --------------- | ------------------ |
+ * | under a minute  | `just now`         |
+ * | under a week    | `5 days ago`       |
+ * | this year       | `June 9`           |
+ * | any older       | `June 9, 2025`     |
  *
- * `now` is `null` for a server render, where "today" is unknowable: the server
- * cannot know the viewer's zone, and guessing produces text that changes on
- * hydration. `null` returns the unambiguous full form instead, so the string
- * shown before hydration is never *wrong* — only longer than it will be.
+ * `formatDistanceStrict` rather than the loose variant, matching
+ * `session-turn-meta-rows`: `Strict` never rounds up into a vague "about 1
+ * minute", and the point of the label is a real distance, not an impression.
+ *
+ * `now` is `null` for a server render, where distance is unknowable: the
+ * server cannot know the viewer's clock, and guessing produces text that
+ * changes on hydration. `null` returns the dated form instead, so the string
+ * shown before hydration is never *wrong* — only less immediate than it will be.
  *
  * Returns `''` for a timestamp that is absent or unparseable, so the caller can
- * render nothing rather than a `Invalid Date` placeholder.
+ * render nothing rather than an `Invalid Date` placeholder.
  */
-export function formatMessageTime(
+export function formatMessageDay(
   timestamp: number | null | undefined,
   now: number | null,
   opts: MessageTimeOptions = {},
 ): string {
-  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || timestamp <= 0) return '';
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) return '';
+  const date = instant(timestamp);
+  if (!date) return '';
 
-  const time = part(date, TIME, opts);
+  const dated = (withYear: boolean) =>
+    part(date, { month: 'long', day: 'numeric', ...(withYear ? { year: 'numeric' } : {}) }, opts);
 
-  if (now === null) {
-    return `${part(date, { day: 'numeric', month: 'short', year: 'numeric' }, opts)}, ${time}`;
-  }
-
-  const thenCivil = civilDate(date, opts.timeZone);
-  const nowCivil = civilDate(new Date(now), opts.timeZone);
-  const days = civilDayIndex(nowCivil) - civilDayIndex(thenCivil);
+  if (now === null) return dated(true);
 
   // A negative gap means the stamp is ahead of this clock — a few seconds of
-  // skew between the sandbox and the browser, not a message from tomorrow.
-  // Clamping to "today" keeps the skew invisible instead of printing a future.
-  if (days <= 0) return time;
-  if (days === 1) return `Yesterday ${time}`;
-  if (days < 7) return `${part(date, { weekday: 'short' }, opts)} ${time}`;
+  // skew between the sandbox and the browser, not a message from the future.
+  // Clamping keeps the skew invisible instead of printing "in 3 seconds".
+  const elapsed = Math.max(0, now - date.getTime());
 
-  const sameYear = thenCivil.slice(0, 4) === nowCivil.slice(0, 4);
-  const day = part(
-    date,
-    { day: 'numeric', month: 'short', ...(sameYear ? {} : { year: 'numeric' }) },
-    opts,
-  );
-  return `${day}, ${time}`;
+  // Under a minute, `formatDistanceStrict` says "8 seconds ago" and then
+  // "9 seconds ago" — motion that carries nothing. One word covers it.
+  if (elapsed < MINUTE) return 'just now';
+  if (elapsed < WEEK) return formatDistanceStrict(date, new Date(now), { addSuffix: true });
+
+  return dated(yearIn(date, opts) !== yearIn(new Date(now), opts));
 }
 
 /**
- * The unabbreviated reading, for the `title` tooltip — the timestamp on screen
- * is deliberately short, and hovering is where "which Tuesday?" gets answered.
+ * The hover label: the full date and the time of day. `June 9, 2026 2:32 PM`.
+ *
+ * This is where the specifics belong. The label on screen is deliberately
+ * loose so the thread stays readable; hovering answers "when exactly" without
+ * that answer ever taking up room in the transcript.
+ *
+ * Minutes, not seconds. A second-level reading looks like it is worth reading
+ * and never is — nobody hovers a chat message to learn it landed at :05.
  */
-export function formatMessageTimeFull(
+export function formatMessageExact(
   timestamp: number | null | undefined,
   opts: MessageTimeOptions = {},
 ): string {
-  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || timestamp <= 0) return '';
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) return '';
-  return part(
-    date,
-    { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric', ...TIME },
-    opts,
-  );
+  const date = instant(timestamp);
+  if (!date) return '';
+  const day = part(date, { month: 'long', day: 'numeric', year: 'numeric' }, opts);
+  const clock = part(date, { hour: 'numeric', minute: '2-digit' }, opts);
+  return `${day} ${clock}`;
 }

--- a/apps/web/src/features/session/turn/user-message.test.tsx
+++ b/apps/web/src/features/session/turn/user-message.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import { NextIntlClientProvider } from 'next-intl';
 import { renderToStaticMarkup } from 'react-dom/server';
 
+import { TooltipProvider } from '@/components/ui/tooltip';
 import type { MessageWithParts } from '@/ui';
 
 import { UserMessage } from './user-message';
@@ -12,17 +13,27 @@ const message = {
   parts: [{ id: 'part-1', messageID: 'message-1', type: 'text', text: 'ship the thing' }],
 } as MessageWithParts;
 
-const render = (rewindDisabled: boolean) =>
+/** The same message, stamped. Wednesday 12 August 2026, 09:34 UTC. */
+const stamped = {
+  ...message,
+  info: { ...message.info, time: { created: Date.UTC(2026, 7, 12, 9, 34) } },
+} as MessageWithParts;
+
+/** `TooltipProvider` because an enabled rewind renders `Hint`, and Radix's
+ *  tooltip throws without a provider above it — the app root supplies one. */
+const render = (rewindDisabled: boolean, msg: MessageWithParts = message) =>
   renderToStaticMarkup(
     <QueryClientProvider client={new QueryClient()}>
       <NextIntlClientProvider locale="en" messages={{}} onError={() => {}}>
-        <UserMessage
-          message={message}
-          sessionId="session-1"
-          ownsPlan={false}
-          onRewind={() => {}}
-          rewindDisabled={rewindDisabled}
-        />
+        <TooltipProvider>
+          <UserMessage
+            message={msg}
+            sessionId="session-1"
+            ownsPlan={false}
+            onRewind={() => {}}
+            rewindDisabled={rewindDisabled}
+          />
+        </TooltipProvider>
       </NextIntlClientProvider>
     </QueryClientProvider>,
   );
@@ -32,5 +43,51 @@ describe('UserMessage actions', () => {
     const markup = render(true);
     expect(markup).toContain('aria-label="Copy code"');
     expect(markup).not.toContain('aria-label="Edit message and rewind session"');
+  });
+});
+
+describe('UserMessage timestamp', () => {
+  test('shows when the message was sent', () => {
+    const markup = render(false, stamped);
+    expect(markup).toContain('<time');
+    // Machine-readable value is UTC, so it is identical on both render passes.
+    expect(markup).toContain('2026-08-12T09:34:00.000Z');
+  });
+
+  test('server-renders the timezone-stable form, never a guess at the viewer’s day', () => {
+    // `renderToStaticMarkup` never runs effects, so this IS the markup the
+    // server emits and the client must hydrate against. It carries the full
+    // UTC date because the server cannot know the viewer's zone or their
+    // "today" — resolving both is the effect's job. A relative word here would
+    // mean the server had guessed, which is the hydration bug this avoids.
+    const markup = render(false, stamped);
+    expect(markup).toContain('>Aug 12, 2026, 9:34 AM</time>');
+    expect(markup).not.toContain('Yesterday');
+  });
+
+  test('spells the instant out on hover', () => {
+    expect(render(false, stamped)).toContain('title="Wednesday, August 12, 2026 at');
+  });
+
+  test('renders no time element when the backend never stamped one', () => {
+    // The unstamped fixture above is the shape real messages had before
+    // `time.created` was populated — it must render, not throw or print NaN.
+    const markup = render(false);
+    expect(markup).not.toContain('<time');
+    expect(markup).not.toContain('Invalid Date');
+    expect(markup).not.toContain('NaN');
+    // The rest of the turn is unaffected.
+    expect(markup).toContain('ship the thing');
+    expect(markup).toContain('aria-label="Copy code"');
+  });
+
+  test('the meta row keeps the actions, so hovering never reflows the turn', () => {
+    // Timestamp and actions share ONE row; the actions fade via opacity rather
+    // than mounting, so the row's height is the same hovered or not.
+    const markup = render(false, stamped);
+    const row = markup.slice(markup.indexOf('<time'));
+    expect(row).toContain('aria-label="Copy code"');
+    expect(row).toContain('opacity-0');
+    expect(row).toContain('group-hover/turn:opacity-100');
   });
 });

--- a/apps/web/src/features/session/turn/user-message.test.tsx
+++ b/apps/web/src/features/session/turn/user-message.test.tsx
@@ -81,13 +81,20 @@ describe('UserMessage timestamp', () => {
     expect(markup).toContain('aria-label="Copy code"');
   });
 
-  test('the meta row keeps the actions, so hovering never reflows the turn', () => {
-    // Timestamp and actions share ONE row; the actions fade via opacity rather
-    // than mounting, so the row's height is the same hovered or not.
+  test('the timestamp reveals with the actions, inside the same hover row', () => {
     const markup = render(false, stamped);
-    const row = markup.slice(markup.indexOf('<time'));
-    expect(row).toContain('aria-label="Copy code"');
-    expect(row).toContain('opacity-0');
-    expect(row).toContain('group-hover/turn:opacity-100');
+    const fade =
+      'opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100 focus-within:opacity-100';
+    const fadeAt = markup.indexOf(fade);
+
+    // The fading row OPENS before both, so both are inside it and reveal
+    // together. If the fade slipped back onto an inner element, the timestamp
+    // would sit outside it and these positions would invert.
+    expect(fadeAt).toBeGreaterThan(-1);
+    expect(markup.indexOf('<time')).toBeGreaterThan(fadeAt);
+    expect(markup.indexOf('aria-label="Copy code"')).toBeGreaterThan(fadeAt);
+
+    // Exactly one reveal — the row's. Nothing nested fades on its own.
+    expect(markup.split('group-hover/turn:opacity-100').length - 1).toBe(1);
   });
 });

--- a/apps/web/src/features/session/turn/user-message.test.tsx
+++ b/apps/web/src/features/session/turn/user-message.test.tsx
@@ -46,6 +46,10 @@ describe('UserMessage actions', () => {
   });
 });
 
+/** The text inside the `<time>` element — not its `dateTime` attribute, which
+ *  carries an ISO string full of digits and colons. */
+const timeText = (markup: string) => markup.match(/<time[^>]*>([^<]*)<\/time>/)?.[1] ?? '';
+
 describe('UserMessage timestamp', () => {
   test('shows when the message was sent', () => {
     const markup = render(false, stamped);
@@ -54,19 +58,31 @@ describe('UserMessage timestamp', () => {
     expect(markup).toContain('2026-08-12T09:34:00.000Z');
   });
 
-  test('server-renders the timezone-stable form, never a guess at the viewer’s day', () => {
-    // `renderToStaticMarkup` never runs effects, so this IS the markup the
-    // server emits and the client must hydrate against. It carries the full
-    // UTC date because the server cannot know the viewer's zone or their
-    // "today" — resolving both is the effect's job. A relative word here would
-    // mean the server had guessed, which is the hydration bug this avoids.
-    const markup = render(false, stamped);
-    expect(markup).toContain('>Aug 12, 2026, 9:34 AM</time>');
-    expect(markup).not.toContain('Yesterday');
+  test('the visible label never carries a clock reading', () => {
+    // "Yesterday 9:19 PM" is the shape this replaced: a phrase you have to
+    // parse before it says anything. Time of day belongs in the hover label.
+    const text = timeText(render(false, stamped));
+    expect(text).not.toMatch(/\d{1,2}:\d{2}/);
+    expect(text).not.toMatch(/AM|PM/);
   });
 
-  test('spells the instant out on hover', () => {
-    expect(render(false, stamped)).toContain('title="Wednesday, August 12, 2026 at');
+  test('server-renders the timezone-stable form, never a guess at the viewer’s clock', () => {
+    // `renderToStaticMarkup` never runs effects and `useSyncExternalStore`
+    // takes its SERVER snapshot, so this IS the markup the server emits and
+    // the client must hydrate against. It is the dated form because the server
+    // has no clock to measure distance from — a relative word here would mean
+    // it had guessed, which is the hydration bug this avoids.
+    const markup = render(false, stamped);
+    expect(timeText(markup)).toBe('August 12, 2026');
+    expect(timeText(markup)).not.toContain('ago');
+  });
+
+  test('the time is a tooltip on the label, not text beside it', () => {
+    // Radix renders tooltip *content* only while open, so the clock string
+    // cannot appear in static markup — `message-time.test.ts` covers what it
+    // says. What is observable here is that the `<time>` element is wired as
+    // the trigger, which is what puts the time one hover away.
+    expect(render(false, stamped)).toMatch(/<time[^>]*data-state="closed"/);
   });
 
   test('renders no time element when the backend never stamped one', () => {

--- a/apps/web/src/features/session/turn/user-message.tsx
+++ b/apps/web/src/features/session/turn/user-message.tsx
@@ -19,6 +19,7 @@ import { CopyButton } from '@/components/markdown/copy-button';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import Hint from '@/components/ui/hint';
+import { InlineMeta } from '@/components/ui/inline-meta';
 import Loading from '@/components/ui/loading';
 import {
   PreviewImage,
@@ -55,6 +56,8 @@ import {
   SystemNotificationCard,
 } from '../message-parsing';
 
+import { messageCreatedAt } from './message-time';
+import { MessageTimeLabel } from './message-time-label';
 import { useHasPlan } from './plan-card';
 
 // ============================================================================
@@ -649,9 +652,17 @@ export function MessageAttachments({
 }
 
 // ============================================================================
-// User message actions — edit (rewind) + copy
+// User message meta — when it was sent, whether it was edited, what you can do
 // ============================================================================
 
+/**
+ * The hover-revealed controls: edit-from-here and copy.
+ *
+ * `opacity`, never mounting/unmounting — the row keeps its height whether or
+ * not the pointer is over the turn, so hovering a transcript never reflows it.
+ * `focus-within` matches the assistant turn's action bar: controls that only
+ * appear on hover are unreachable by keyboard otherwise.
+ */
 function UserMessageActions({
   copyText,
   messageId,
@@ -668,7 +679,7 @@ function UserMessageActions({
   // Copy stays available while the agent is busy / rewind is locked.
   // Only edit-from-here is gated — hiding the whole bar was wrong.
   return (
-    <div className="flex justify-end gap-0.5 opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100">
+    <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100 focus-within:opacity-100">
       {!rewindDisabled && (
         <Hint label="Edit from here" side="bottom" align="center">
           <Button
@@ -683,6 +694,49 @@ function UserMessageActions({
         </Hint>
       )}
       <CopyButton code={copyText} size="sm" />
+    </div>
+  );
+}
+
+/**
+ * The line under a user bubble: when it was sent, whether it was edited, and
+ * the actions — in that order, right-aligned against the same rail as the
+ * bubble.
+ *
+ * ONE row, deliberately. The actions row already existed and already occupied
+ * height on every turn (it fades, it does not mount), so folding the timestamp
+ * into it buys a permanently visible "when" for zero extra vertical space —
+ * which matters both for a long transcript and for the optimistic → real
+ * crossfade, where a new row appearing would show up as the thread twitching.
+ *
+ * Because the actions never change size, the timestamp does not move when the
+ * buttons fade in.
+ *
+ * Shared with `OptimisticTurn` so the pending turn and the server turn cannot
+ * drift — the same reason `MessageAttachments` is shared.
+ */
+export function MessageMetaRow({
+  timestamp,
+  edited,
+  actions,
+}: {
+  /** Epoch milliseconds, or `null` when the backend never stamped one. */
+  timestamp: number | null;
+  edited?: boolean;
+  actions?: React.ReactNode;
+}) {
+  // Nothing to say and nothing to do — don't leave an empty row behind.
+  if (timestamp === null && !edited && !actions) return null;
+
+  return (
+    <div className="flex w-full items-center justify-end gap-2">
+      {/* `InlineMeta` owns the `·` separator and drops absent children, so a
+          message with no stamp never renders a leading bullet. */}
+      <InlineMeta>
+        {timestamp !== null && <MessageTimeLabel timestamp={timestamp} />}
+        {edited && 'edited'}
+      </InlineMeta>
+      {actions}
     </div>
   );
 }
@@ -815,6 +869,11 @@ export function UserMessage({
         rewindDisabled={rewindDisabled}
       />
     ) : null;
+
+  // When the user sent this. Read here rather than threaded down from the turn
+  // so every branch below — channel card, trigger card, command card, bubble —
+  // gets it from one place.
+  const createdAt = messageCreatedAt(message);
 
   // Detect channel message (Telegram/Slack) in user message
   const channelMessageInfo = useMemo(() => {
@@ -1045,7 +1104,7 @@ export function UserMessage({
             </div>
           )}
         </div>
-        {actions}
+        <MessageMetaRow timestamp={createdAt} edited={isEdited} actions={actions} />
       </div>
     );
   }
@@ -1075,7 +1134,7 @@ export function UserMessage({
             </div>
           )}
         </div>
-        {actions}
+        <MessageMetaRow timestamp={createdAt} edited={isEdited} actions={actions} />
       </div>
     );
   }
@@ -1113,7 +1172,7 @@ export function UserMessage({
             ))}
           </div>
         )}
-        {actions}
+        <MessageMetaRow timestamp={createdAt} edited={isEdited} actions={actions} />
       </div>
     );
   }
@@ -1266,7 +1325,10 @@ export function UserMessage({
           )}
         </div>
       )}
-      {isEdited && <span className="text-muted-foreground/50 pr-1 text-xs">edited</span>}
+      {/* Sent-at, "edited", and the hover actions are ONE row, sitting directly
+          under the bubble they describe — notification cards below are separate
+          objects and must not come between a message and its own meta. */}
+      <MessageMetaRow timestamp={createdAt} edited={isEdited} actions={actions} />
 
       {/* DCP notifications from ignored parts (rendered below user bubble if mixed) */}
       {dcpNotifications.length > 0 && (
@@ -1283,7 +1345,6 @@ export function UserMessage({
           ))}
         </div>
       )}
-      {actions}
     </div>
   );
 }

--- a/apps/web/src/features/session/turn/user-message.tsx
+++ b/apps/web/src/features/session/turn/user-message.tsx
@@ -724,7 +724,7 @@ export function UserMessageActions({
       {copyText && (
         <div className="flex shrink-0 items-center gap-0.5">
           {canRewind && (
-            <Hint label="Edit from here" side="bottom" align="center">
+            <Hint label="Edit from here" side="top" align="center">
               <Button
                 type="button"
                 variant="ghost"
@@ -736,7 +736,8 @@ export function UserMessageActions({
               </Button>
             </Hint>
           )}
-          <CopyButton code={copyText} size="sm" />
+
+          <CopyButton code={copyText} size="sm" hintSide="top" />
         </div>
       )}
     </div>

--- a/apps/web/src/features/session/turn/user-message.tsx
+++ b/apps/web/src/features/session/turn/user-message.tsx
@@ -656,87 +656,89 @@ export function MessageAttachments({
 // ============================================================================
 
 /**
- * The hover-revealed controls: edit-from-here and copy.
+ * The line under a user bubble: when it was sent, whether it was edited, and
+ * what you can do to it — one row, right-aligned against the same rail as the
+ * bubble.
  *
- * `opacity`, never mounting/unmounting — the row keeps its height whether or
- * not the pointer is over the turn, so hovering a transcript never reflows it.
- * `focus-within` matches the assistant turn's action bar: controls that only
- * appear on hover are unreachable by keyboard otherwise.
+ * ONE row, deliberately, and the whole row reveals on hover. The transcript is
+ * the message thread — a timestamp on every turn, permanently, is chrome
+ * competing with the conversation. Putting it on the same reveal as the
+ * actions keeps the quiet reading intact and puts the "when" exactly where a
+ * reader already goes to act on a message.
+ *
+ * The reveal is `opacity`, never mount/unmount, so the row occupies its height
+ * either way and hovering a turn never reflows the thread.
+ *
+ * `focus-within` matches the assistant turn's action bar: anything that only
+ * appears on hover is unreachable by keyboard otherwise. The timestamp is a
+ * `<time datetime=…>` element, so its machine-readable value stays in the
+ * accessibility tree regardless of the visual reveal.
+ *
+ * Shared with `OptimisticTurn` so the pending turn and the server turn cannot
+ * drift — the same reason `MessageAttachments` is shared.
  */
-function UserMessageActions({
+export function UserMessageActions({
+  timestamp,
+  edited,
   copyText,
   messageId,
   rewindPromptText,
   onRewind,
   rewindDisabled,
 }: {
-  copyText: string;
-  messageId: string;
-  rewindPromptText: string;
-  onRewind: (messageId: string, text: string) => void;
-  rewindDisabled: boolean;
-}) {
-  // Copy stays available while the agent is busy / rewind is locked.
-  // Only edit-from-here is gated — hiding the whole bar was wrong.
-  return (
-    <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100 focus-within:opacity-100">
-      {!rewindDisabled && (
-        <Hint label="Edit from here" side="bottom" align="center">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label="Edit message and rewind session"
-            onClick={() => onRewind(messageId, rewindPromptText)}
-          >
-            <PencilSimpleIcon weight="regular" className="text-foreground size-4" />
-          </Button>
-        </Hint>
-      )}
-      <CopyButton code={copyText} size="sm" />
-    </div>
-  );
-}
-
-/**
- * The line under a user bubble: when it was sent, whether it was edited, and
- * the actions — in that order, right-aligned against the same rail as the
- * bubble.
- *
- * ONE row, deliberately. The actions row already existed and already occupied
- * height on every turn (it fades, it does not mount), so folding the timestamp
- * into it buys a permanently visible "when" for zero extra vertical space —
- * which matters both for a long transcript and for the optimistic → real
- * crossfade, where a new row appearing would show up as the thread twitching.
- *
- * Because the actions never change size, the timestamp does not move when the
- * buttons fade in.
- *
- * Shared with `OptimisticTurn` so the pending turn and the server turn cannot
- * drift — the same reason `MessageAttachments` is shared.
- */
-export function MessageMetaRow({
-  timestamp,
-  edited,
-  actions,
-}: {
   /** Epoch milliseconds, or `null` when the backend never stamped one. */
   timestamp: number | null;
   edited?: boolean;
-  actions?: React.ReactNode;
+  /** Omitted when there is nothing to copy — the row then carries meta alone
+   *  rather than disappearing, so an attachment-only message keeps its time. */
+  copyText?: string;
+  messageId?: string;
+  rewindPromptText?: string;
+  onRewind?: (messageId: string, text: string) => void;
+  rewindDisabled?: boolean;
 }) {
+  // Copy stays available while the agent is busy / rewind is locked.
+  // Only edit-from-here is gated — hiding the whole bar was wrong.
+  const canRewind = Boolean(onRewind && messageId && !rewindDisabled);
+  const hasMeta = timestamp !== null || Boolean(edited);
+
   // Nothing to say and nothing to do — don't leave an empty row behind.
-  if (timestamp === null && !edited && !actions) return null;
+  if (!hasMeta && !copyText) return null;
 
   return (
-    <div className="flex w-full items-center justify-end gap-2">
+    // The fade sits on the ROW, so the timestamp and the buttons reveal
+    // together as one object rather than a label with controls growing out of
+    // it. `opacity`, never mounting: the row holds its height whether or not
+    // the pointer is over the turn, so nothing in the transcript reflows.
+    <div className="flex w-full items-center justify-end gap-2 opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100 focus-within:opacity-100">
       {/* `InlineMeta` owns the `·` separator and drops absent children, so a
-          message with no stamp never renders a leading bullet. */}
-      <InlineMeta>
-        {timestamp !== null && <MessageTimeLabel timestamp={timestamp} />}
-        {edited && 'edited'}
-      </InlineMeta>
-      {actions}
+          message with no stamp never renders a leading bullet. Skipped
+          entirely when there is no meta at all — the optimistic turn would
+          otherwise carry an empty node the real turn does not. */}
+      {hasMeta && (
+        <InlineMeta>
+          {timestamp !== null && <MessageTimeLabel timestamp={timestamp} />}
+          {edited && 'edited'}
+        </InlineMeta>
+      )}
+      {copyText && (
+        <div className="flex shrink-0 items-center gap-0.5">
+          {canRewind && (
+            <Hint label="Edit from here" side="bottom" align="center">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Edit message and rewind session"
+                onClick={() => onRewind?.(messageId as string, rewindPromptText ?? '')}
+              >
+                <PencilSimpleIcon weight="regular" className="text-foreground size-4" />
+              </Button>
+            </Hint>
+          )}
+          <CopyButton code={copyText} size="sm" />
+        </div>
+      )}
     </div>
   );
 }
@@ -859,22 +861,6 @@ export function UserMessage({
     return stripKortixSystemTags(withoutSessions).trim();
   }, [copyText, effectiveCommandInfo]);
 
-  const actions =
-    copyText && onRewind ? (
-      <UserMessageActions
-        copyText={copyText}
-        messageId={message.info.id}
-        rewindPromptText={rewindPromptText}
-        onRewind={onRewind}
-        rewindDisabled={rewindDisabled}
-      />
-    ) : null;
-
-  // When the user sent this. Read here rather than threaded down from the turn
-  // so every branch below — channel card, trigger card, command card, bubble —
-  // gets it from one place.
-  const createdAt = messageCreatedAt(message);
-
   // Detect channel message (Telegram/Slack) in user message
   const channelMessageInfo = useMemo(() => {
     if (!rawText) return undefined;
@@ -918,6 +904,24 @@ export function UserMessage({
 
   // Check if any text part was edited
   const isEdited = visibleTextParts.some((p) => (p as any).metadata?.edited);
+
+  // Built once and rendered by every branch below — channel card, trigger card,
+  // command card, bubble — so all four carry the same meta line.
+  //
+  // `copyText` is gated on `onRewind` to keep the buttons exactly as they were:
+  // a read-only turn shows no controls. The row itself still renders, because
+  // the timestamp is meta, not a control, and should not vanish with them.
+  const actions = (
+    <UserMessageActions
+      timestamp={messageCreatedAt(message)}
+      edited={isEdited}
+      copyText={copyText && onRewind ? copyText : undefined}
+      messageId={message.info.id}
+      rewindPromptText={rewindPromptText}
+      onRewind={onRewind}
+      rewindDisabled={rewindDisabled}
+    />
+  );
 
   // Inline file references
   const inlineFiles = stickyParts.filter(isFilePart) as FilePart[];
@@ -1104,7 +1108,7 @@ export function UserMessage({
             </div>
           )}
         </div>
-        <MessageMetaRow timestamp={createdAt} edited={isEdited} actions={actions} />
+        {actions}
       </div>
     );
   }
@@ -1134,7 +1138,7 @@ export function UserMessage({
             </div>
           )}
         </div>
-        <MessageMetaRow timestamp={createdAt} edited={isEdited} actions={actions} />
+        {actions}
       </div>
     );
   }
@@ -1172,7 +1176,7 @@ export function UserMessage({
             ))}
           </div>
         )}
-        <MessageMetaRow timestamp={createdAt} edited={isEdited} actions={actions} />
+        {actions}
       </div>
     );
   }
@@ -1328,7 +1332,7 @@ export function UserMessage({
       {/* Sent-at, "edited", and the hover actions are ONE row, sitting directly
           under the bubble they describe — notification cards below are separate
           objects and must not come between a message and its own meta. */}
-      <MessageMetaRow timestamp={createdAt} edited={isEdited} actions={actions} />
+      {actions}
 
       {/* DCP notifications from ignored parts (rendered below user bubble if mixed) */}
       {dcpNotifications.length > 0 && (


### PR DESCRIPTION
## Issue

A session transcript showed no timestamp anywhere on the user side. Every user message already carries `time.created` from the backend, but nothing rendered it — so scrolling back through a long session left nothing on screen that said *when* a prompt was sent. The transcript could only be read relatively: this came after that.

The one piece of timing in the UI was "Finished 5m ago", buried behind the `⋯` popover on the **assistant** turn — a different message, a different question, and three clicks away.

## Solution

Render the sent-at time in the action row under the user bubble, revealed on hover along with the edit and copy buttons.

- **Inside the row that already existed.** `UserMessageActions` now owns the whole line — timestamp, `edited`, and the controls. The `opacity-0 → group-hover/turn:opacity-100` fade sits on the row, so the time and the buttons reveal together as one object rather than a label with controls growing out of it. On hover, not permanently: a timestamp on every turn forever is chrome competing with the conversation, and the reveal puts the "when" exactly where a reader already goes to act on a message.
- **`opacity`, never mount/unmount**, so the row keeps its height at rest and hovering a turn never reflows the thread.
- **Absolute, not relative.** "5m ago" has to tick to stay true, and a transcript can hold hundreds of messages — that's hundreds of intervals re-rendering hundreds of rows to move one digit. A clock reading is correct when printed and stays correct.
- **Scales to distance**, so precision only costs pixels where it buys something: `2:34 PM` today, `Yesterday 2:34 PM`, `Tue 2:34 PM` inside the week, `Aug 12, 2:34 PM` past that, with the year added beyond this one. The unabbreviated reading is on the hover title.
- **Formatting is a pure function with `now` injected**, mirroring the sibling `session-turn-meta-rows` — so the "Yesterday" wording is exhaustively testable and one render derives every label from a single clock read.

Three correctness details worth a reviewer's eye:

- **"Today" is resolved in the render timezone, not the runtime's.** Asking the question in the wrong zone prints `2:30 AM` next to a clock face reading `10:30 PM` — the day and the time disagree on screen. Pinned by a test.
- **Server renders a UTC form and swaps to the viewer's zone after mount** — the same two-phase pattern `components/ui/local-time` exists to document. Without it the server's timezone leaks into the markup and hydration mismatches (React #418).
- **Folding the meta row into `UserMessageActions` exposed a gate that would have dropped the stamp.** `actions` was built as `copyText && onRewind ? … : null`, so an attachment-only message (nothing to copy) would have rendered no row at all. The row now renders on meta *or* controls, with `copyText` alone gating the buttons.

The optimistic turn shares the row but deliberately passes **no** timestamp. It is mounted twice across the boot → chat crossfade, so a local clock read would differ between the two passes. That is the same two-clocks bug that already made the elapsed timer run backwards there, and its own test pins it — the first attempt here tripped that test, which is why the row stays empty until the real `time.created` arrives.

## Changes

- `turn/message-time.ts` (new) — pure formatter, plus the narrow accessor for the `Message` union's `time` field.
- `turn/message-time-label.tsx` (new) — the hydration-safe `<time>` element.
- `turn/user-message.tsx` — `UserMessageActions` absorbs the meta line and is applied to all four message branches (bubble, command, trigger-event, channel). Folds the standalone `edited` marker into the same row and adds `focus-within` so hover-only controls stay keyboard reachable.
- `optimistic-turn.tsx` — uses the shared row so the crossfade can't drift.
- `session-turn-meta-rows.ts` — drops its duplicate `time` accessor for the shared one, so exactly one place knows how to get a stamp off a message.

## Testing

- `bun test src/features/session/` — **1492 pass, 0 fail** (+31 new).
  - 26 cases on the formatter: each distance bucket, timezone-correct "today", clock skew clamping, locale-driven field order and 12/24-hour, the null-clock server path, and every absent-data shape (`0`, `NaN`, `Infinity`, negative, missing `time`).
  - 5 cases on `UserMessage`: the `<time>` element and its UTC `dateTime`, the exact server-rendered string, the hover title, an unstamped message rendering no `<time>` and no `NaN`, and the timestamp revealing inside the same hover row as the actions.
  - That last assertion was mutation-tested: moving the fade back onto the inner button div makes it fail, so it cannot silently pass.
- `npx tsc --noEmit` — **0 errors in every file touched**. The 15 remaining source errors are the pre-existing `@types/bun` `test.each` set in the three files `CLAUDE.md` names; none are mine (I avoided `test.each` for that reason).
- `npx eslint <changed files>` — **0 errors**. One `react-hooks/set-state-in-effect` warning on the new label, identical to the one `components/ui/local-time.tsx` already carries for the same server/client swap.
- Full `bun test` in `apps/web`: 6547 pass / 1 fail. That failure is `maintenance-store.test.ts`, pre-existing — a clean tree at the same base produces the identical single failure in a full-suite run, and the file passes 7/7 in isolation either way.

## Notes

- Not verified in a browser; this was checked by tests, types, and lint.
- The label does not tick. The only thing that can go stale is "Yesterday" rolling over at midnight in a tab left open across it — deliberately not worth one interval per message.
- `<time dateTime=…>` keeps the machine-readable instant in the accessibility tree even at `opacity-0`, so the visual reveal does not hide it from assistive tech.
- Unrelated and untouched: `liveDuration` in `session-chat.tsx:1086` is computed and never rendered.
