### PR TITLE
fix(monitors): stale-agent probe uses resolveEndpoint (authed edge)

### DIFF
--- a/apps/api/src/projects/lib/monitor-box.ts
+++ b/apps/api/src/projects/lib/monitor-box.ts
@@ -279,9 +279,12 @@ async function probeBoxWorkload(
   externalId: string,
 ): Promise<'monitor' | 'session' | null> {
   try {
-    const ingress = await provider.resolveIngress(externalId, { port: 8000, transport: 'http' });
-    const res = await fetch(`${ingress.url.replace(/\/$/, '')}/kortix/health`, {
-      headers: ingress.headers ?? {},
+    // resolveEndpoint, not resolveIngress: the exposed edge is gated by the
+    // per-box serviceKey bearer, and only resolveEndpoint attaches it — a bare
+    // ingress URL answers 401 and the probe would silently no-op forever.
+    const endpoint = await provider.resolveEndpoint(externalId);
+    const res = await fetch(`${endpoint.url.replace(/\/$/, '')}/kortix/health`, {
+      headers: endpoint.headers ?? {},
       signal: AbortSignal.timeout(5_000),
     });
     if (!res.ok) return null;


### PR DESCRIPTION
Follow-up to #6417: the stale-agent health probe called resolveIngress, whose URL is gated by the per-box serviceKey bearer only resolveEndpoint attaches — so it 401'd and never recycled the wedged dev box. One-line switch to resolveEndpoint (the ensureAppRuntimeStarted pattern). apps/api suite 6810/0, tsc clean.