### PR TITLE
fix: mint the session handle row for network-boundary secrets

### DIFF
--- a/apps/api/src/projects/routes/secret-broker.ts
+++ b/apps/api/src/projects/routes/secret-broker.ts
@@ -210,10 +210,24 @@ projectsApp.openapi(
         )
         .orderBy(desc(projectSessionSecretHandles.revision))
         .limit(1);
+      // The snapshot must match the delivery mode this request is being served
+      // under. A broker secret's snapshot carries `kortix_fetch`; a boundary
+      // policy carries no backend at all — `networkBoundaryPolicyError` rejects
+      // one that does — so demanding `kortix_fetch` of both would make a
+      // boundary handle permanently invalid.
+      //
+      // Still checked, not skipped: the snapshot is what the request is
+      // executed against, so a row whose policy is neither shape must not be
+      // spent.
+      const handlePolicyValid = handle
+        ? isBoundarySecret
+          ? networkBoundaryPolicyError(handle.policySnapshot) === null
+          : handle.policySnapshot.backend === 'kortix_fetch'
+        : false;
       if (
         !handle ||
         (handle.expiresAt !== null && handle.expiresAt.getTime() <= Date.now()) ||
-        handle.policySnapshot.backend !== 'kortix_fetch'
+        !handlePolicyValid
       ) {
         await recordAuditEvent({
           ...auditBase,

--- a/apps/api/src/projects/secret-delivery-withholding.test.ts
+++ b/apps/api/src/projects/secret-delivery-withholding.test.ts
@@ -175,6 +175,71 @@ describe('materializeSecretDelivery', () => {
     expect(minted).toEqual(['secret-provider']);
   });
 
+  test('mints a handle ROW for a network-boundary secret but exports nothing', async () => {
+    // The broker route needs an active handle row (it looks the secret up by
+    // secretId and executes against the row's policy snapshot). Boundary
+    // secrets never got one, so a boundary relay died on
+    // `session_secret_handle_required` even once the strategy gate allowed it.
+    //
+    // The row is required; the export is forbidden. "The guest receives
+    // nothing — no value, no alias, no placeholder" is the property that makes
+    // a boundary secret a boundary secret, so the handle must NOT be assigned
+    // to env the way the broker branch does.
+    const boundary = row('gh', 'GITHUB_TEST', {
+      strategy: 'egress',
+      consumer: 'network',
+      egressPolicy: {
+        inject: { kind: 'header', name: 'authorization' },
+        rules: [{ host: 'api.github.com' }],
+      },
+    });
+    const env = envFor([boundary]);
+    const minted: string[] = [];
+
+    await materializeSecretDelivery([boundary], env, {
+      sessionId: 'session-1',
+      grantEnv: ['gh'],
+      mintHandleFor: async (selected) => {
+        minted.push(selected.secretId);
+        return 'kortix-handle';
+      },
+    });
+
+    // The row was minted...
+    expect(minted).toEqual(['secret-gh']);
+    // ...and the guest got nothing: not the value, not the handle, not the key.
+    expect(env).toEqual({});
+    expect(JSON.stringify(env)).not.toContain('kortix-handle');
+    expect(JSON.stringify(env)).not.toContain('value-of-gh');
+  });
+
+  test('mints no handle for a boundary secret the agent is not granted', async () => {
+    // No grant means no delivery at all — minting a row would create a
+    // spendable reference for a secret this session may not use.
+    const boundary = row('gh', 'GITHUB_TEST', {
+      strategy: 'egress',
+      consumer: 'network',
+      egressPolicy: {
+        inject: { kind: 'header', name: 'authorization' },
+        rules: [{ host: 'api.github.com' }],
+      },
+    });
+    const env = envFor([boundary]);
+    const minted: string[] = [];
+
+    await materializeSecretDelivery([boundary], env, {
+      sessionId: 'session-1',
+      grantEnv: ['something-else'],
+      mintHandleFor: async (selected) => {
+        minted.push(selected.secretId);
+        return 'kortix-handle';
+      },
+    });
+
+    expect(minted).toEqual([]);
+    expect(env).toEqual({});
+  });
+
   test.each([undefined, 'all'] as const)(
     'withholds a broker value from an unscoped %s grant',
     async (grantEnv) => {

--- a/apps/api/src/projects/secrets.ts
+++ b/apps/api/src/projects/secrets.ts
@@ -593,6 +593,23 @@ export async function materializeSecretDelivery(
       env[row.key] = await input.mintHandleFor(row);
       continue;
     }
+    // Network boundary: mint the handle ROW, put NOTHING in the guest env.
+    //
+    // The broker route requires an active handle row for the secret — it looks
+    // it up by secretId and reads its policy snapshot; it never validates a
+    // token the caller presents. Boundary secrets never got one (the branch
+    // above is broker-only), so a boundary relay died on
+    // `session_secret_handle_required` even after the strategy gate was
+    // relaxed. That was the second gate behind the first.
+    //
+    // The row is minted, the value is not exported. Assigning the handle to
+    // `env[row.key]` the way the broker branch does would put a credential
+    // reference in the sandbox, and "the guest receives nothing — no value, no
+    // alias, no placeholder" is the entire property that distinguishes a
+    // boundary secret. A test pins the env staying empty.
+    if (delivery.emit === 'handle' && delivery.strategy === 'egress' && consumer === 'network') {
+      await input.mintHandleFor(row);
+    }
     delete env[row.key];
   }
 }


### PR DESCRIPTION
Third gate behind the first two, found by testing the merged change on dev
rather than by reading the diff.

## What happened

After #6409 relaxed the strategy gate, a boundary relay on dev stopped
returning `409 secret_delivery_unavailable` and started returning:

```
✗ The active session does not have this brokered secret
```

Progress — but a second gate. The broker route requires an active
`project_session_secret_handles` row whose `policySnapshot.backend` is
`kortix_fetch`. `materializeSecretDelivery` mints handles only for
`broker` / `http_broker` / `kortix_fetch` rows, so a boundary secret never had
one, and a boundary policy carries no `backend` at all
(`networkBoundaryPolicyError` rejects one that does) — so even a minted row
would have failed the check.

## Why the obvious fix is wrong

"Mint handles for boundary secrets too" would break the feature. The broker
branch does `env[row.key] = await mintHandleFor(row)` — assigning the handle
into the sandbox environment. Doing that for a boundary secret puts a
credential reference in the guest, and **"the guest receives nothing — no
value, no alias, no placeholder"** is exactly what makes it a boundary secret.

So: mint the **row**, export **nothing**. The route looks the handle up by
`secretId` and executes against its policy snapshot; it never validates a token
the caller presents, so the row is what is actually needed.

The route's check now matches the snapshot to the delivery mode instead of
demanding `kortix_fetch` of both. Matched, not skipped — a snapshot of neither
shape is still refused.

## Verified

- 2 new tests, both confirmed to **fail with the fix reverted**; one pins that
  the guest env stays empty, the other that an ungranted boundary secret mints
  no row at all.
- 147 pass across the delivery + secrets suites; `tsc` 0 errors.

Live re-test on dev follows this merge — the flag is not involved in this path,
so it is directly observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)