### PR TITLE
feat(models): add managed Grok 4.6

### DIFF
--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -46,6 +46,26 @@ describe('gatewayModelCatalog — served catalog', () => {
     expect(full['glm-5.2']?.temperature).toBe(true);
   });
 
+  test('serves Grok 4.6 capabilities and context-tier pricing from models.dev', () => {
+    expect(full['grok-4.6']).toMatchObject({
+      name: 'Grok 4.6',
+      provider: 'kortix',
+      reasoning: true,
+      reasoning_options: [{ type: 'effort', values: ['low', 'medium', 'high', 'xhigh'] }],
+      tool_call: true,
+      attachment: true,
+      structured_output: true,
+      temperature: true,
+      limit: { context: 500_000, output: 500_000 },
+      cost: {
+        input: 2,
+        output: 6,
+        cache_read: 0.5,
+        context_over_200k: { input: 4, output: 12, cache_read: 1 },
+      },
+    });
+  });
+
   test('every served model carries a positive context limit', () => {
     const missing = Object.entries(full)
       .filter(([, m]) => !(typeof m.limit?.context === 'number' && m.limit.context > 0))

--- a/apps/api/src/llm-gateway/models/catalog-models.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.ts
@@ -204,6 +204,20 @@ export function managedModels(): Record<string, GatewayModel> {
           ...(m.pricing.cacheWritePerMillion != null
             ? { cache_write: m.pricing.cacheWritePerMillion }
             : {}),
+          ...(m.pricing.contextOver200k
+            ? {
+                context_over_200k: {
+                  input: m.pricing.contextOver200k.inputPerMillion,
+                  output: m.pricing.contextOver200k.outputPerMillion,
+                  ...(m.pricing.contextOver200k.cachedInputPerMillion != null
+                    ? { cache_read: m.pricing.contextOver200k.cachedInputPerMillion }
+                    : {}),
+                  ...(m.pricing.contextOver200k.cacheWritePerMillion != null
+                    ? { cache_write: m.pricing.contextOver200k.cacheWritePerMillion }
+                    : {}),
+                },
+              }
+            : {}),
         }
       : undefined;
     const real = catalogModelForWireModel(m.id);

--- a/apps/api/src/llm-gateway/models/managed-models.ts
+++ b/apps/api/src/llm-gateway/models/managed-models.ts
@@ -14,6 +14,13 @@ const managedModelSchema = z.object({
     outputPerMillion: z.number().nonnegative(),
     cachedInputPerMillion: z.number().nonnegative().optional(),
     cacheWritePerMillion: z.number().nonnegative().optional(),
+    contextOver200k: z.object({
+      inputPerMillion: z.number().nonnegative(),
+      outputPerMillion: z.number().nonnegative(),
+      cachedInputPerMillion: z.number().nonnegative().optional(),
+      cacheWritePerMillion: z.number().nonnegative().optional(),
+      contextThreshold: z.number().int().positive(),
+    }).optional(),
   }).optional(),
   tier: z.enum(['flagship', 'balanced', 'fast']),
   vision: z.boolean(),

--- a/apps/api/src/llm-gateway/resolution/descriptors.test.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.test.ts
@@ -5,6 +5,8 @@ const config: Record<string, unknown> = {
   KORTIX_MANAGED_PROVIDER_ENABLED: true,
   ASTER_API_KEY: 'aster-test-key',
   ASTER_API_URL: 'https://api.asterlab.ai/v1',
+  OPENROUTER_API_KEY: 'openrouter-test-key',
+  OPENROUTER_API_URL: 'https://openrouter.ai/api/v1',
 };
 mock.module('../../config', () => ({ config }));
 // Spread the real module — see the note in resolve-candidates.test.ts. Listing
@@ -20,9 +22,20 @@ mock.module('../../billing/services/tiers', () => ({
 // with a tiny fixed catalog keyed by BASE (unprefixed) Bedrock model ids —
 // mirrors what models.dev actually publishes for Bedrock: it has never heard
 // of a cross-region inference-profile id like `us.anthropic.claude-...`.
-const CATALOG: Record<string, { inputPer1M: number; outputPer1M: number }> = {
+const CATALOG: Record<string, { inputPer1M: number; outputPer1M: number; cacheReadPer1M?: number; contextOver200k?: { inputPer1M: number; outputPer1M: number; cacheReadPer1M?: number; contextThreshold: number } }> = {
   'amazon-bedrock/anthropic.claude-opus-4-8': { inputPer1M: 15, outputPer1M: 75 },
   'amazon-bedrock/amazon.nova-micro-v1:0': { inputPer1M: 0.035, outputPer1M: 0.14 },
+  'openrouter/x-ai/grok-4.6': {
+    inputPer1M: 2,
+    outputPer1M: 6,
+    cacheReadPer1M: 0.5,
+    contextOver200k: {
+      inputPer1M: 4,
+      outputPer1M: 12,
+      cacheReadPer1M: 1,
+      contextThreshold: 200_000,
+    },
+  },
 };
 const getModelPricing = mock(
   (providerId: string, modelId: string) => CATALOG[`${providerId}/${modelId}`] ?? null,
@@ -211,5 +224,44 @@ describe('managed AsterLab descriptor', () => {
         },
       }),
     ]);
+  });
+});
+
+describe('managed Grok 4.6 descriptor', () => {
+  test('routes through OpenRouter xAI with context-tier pricing', () => {
+    expect(managedCandidates({
+      id: 'grok-4.6',
+      name: 'Grok 4.6',
+      upstreamModelId: 'x-ai/grok-4.6',
+      transport: 'openrouter',
+      pricingRef: 'openrouter/x-ai/grok-4.6',
+      tier: 'flagship',
+      vision: true,
+      limit: { context: 500_000, output: 500_000 },
+      openrouterProvider: { order: ['xai'], allow_fallbacks: true },
+    })).toEqual([expect.objectContaining({
+      provider: 'openrouter',
+      kind: 'openai-compat',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'openrouter-test-key',
+      resolvedModel: 'x-ai/grok-4.6',
+      billingMode: 'credits',
+      markup: 2,
+      pricing: {
+        inputPerMillion: 2,
+        outputPerMillion: 6,
+        cachedInputPerMillion: 0.5,
+        cacheWritePerMillion: undefined,
+        tiers: undefined,
+        contextOver200k: {
+          inputPerMillion: 4,
+          outputPerMillion: 12,
+          cachedInputPerMillion: 1,
+          cacheWritePerMillion: undefined,
+          contextThreshold: 200_000,
+        },
+      },
+      bodyExtras: { provider: { order: ['xai'], allow_fallbacks: true } },
+    })]);
   });
 });

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -905,6 +905,23 @@ export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
     temperature: false,
     limit: { context: 1_050_000, output: 128_000 },
   },
+  'grok-4.6': {
+    name: 'Grok 4.6',
+    provider: 'kortix',
+    reasoning: true,
+    reasoning_options: [{ type: 'effort', values: ['low', 'medium', 'high', 'xhigh'] }],
+    tool_call: true,
+    attachment: true,
+    structured_output: true,
+    temperature: true,
+    limit: { context: 500_000, output: 500_000 },
+    cost: {
+      input: 2,
+      output: 6,
+      cache_read: 0.5,
+      context_over_200k: { input: 4, output: 12, cache_read: 1 },
+    },
+  },
   // Second Kortix-managed AsterLab model (Kimi K3). Same `kortix` provider
   // branding + `aster` transport (ASTER_API_KEY) as GLM 5.2.
   // `temperature:false` — models.dev advertises Kimi K3 as

--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -17,7 +17,7 @@ toggle it in Customize → Feature flags.
 
 A model id has one of three shapes:
 
-- **Managed** — a bare id, like `glm-5.2` or `deepseek-v4-flash`. Kortix
+- **Managed** — a bare id, like `grok-4.6` or `deepseek-v4-flash`. Kortix
   supplies the credentials. Cloud accounts pay with Kortix credits.
 - **BYOK** — a `provider/model` id, like `anthropic/claude-opus-4-8`. You
   supply the key. Your provider account pays.

--- a/packages/llm-catalog/src/catalog.generated.json
+++ b/packages/llm-catalog/src/catalog.generated.json
@@ -143121,6 +143121,67 @@
       "npm": "@openrouter/ai-sdk-provider",
       "models": [
         {
+          "id": "x-ai/grok-4.6",
+          "name": "Grok 4.6",
+          "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+          "released": "2026-08-12",
+          "attachment": true,
+          "reasoning": true,
+          "reasoning_options": [
+            {
+              "type": "effort",
+              "values": [
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": true,
+          "open_weights": false,
+          "temperature": true,
+          "knowledge": "2026-02-01",
+          "last_updated": "2026-08-12",
+          "family": "grok",
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 500000,
+            "output": 500000
+          },
+          "cost": {
+            "input": 2,
+            "output": 6,
+            "cache_read": 0.5,
+            "tiers": [
+              {
+                "input": 4,
+                "output": 12,
+                "cache_read": 1,
+                "tier": {
+                  "type": "context",
+                  "size": 200000
+                }
+              }
+            ],
+            "context_over_200k": {
+              "input": 4,
+              "output": 12,
+              "cache_read": 1
+            }
+          }
+        },
+        {
           "id": "moonshotai/kimi-k3",
           "name": "Kimi K3",
           "description": "Kimi multimodal agent model for visual understanding, coding, and planning",

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -457,6 +457,13 @@ export interface ManagedModel {
     outputPerMillion: number;
     cachedInputPerMillion?: number;
     cacheWritePerMillion?: number;
+    contextOver200k?: {
+      inputPerMillion: number;
+      outputPerMillion: number;
+      cachedInputPerMillion?: number;
+      cacheWritePerMillion?: number;
+      contextThreshold: number;
+    };
   };
   tier: 'flagship' | 'balanced' | 'fast';
   // Vision (image input). Curated explicitly: managed slugs don't all exist on
@@ -523,6 +530,35 @@ export function pricingRefLookupCandidates(pricingRef: string): string[] {
 // credible agentic coder; beats GLM 5.2 on every published agentic
 // benchmark while costing ~10x less per unit of work).
 export const MANAGED_MODELS: ManagedModel[] = [
+  {
+    // Grok 4.6 through OpenRouter's first-party xAI endpoint. The explicit
+    // xAI preference keeps routing on the model owner while fallbacks preserve
+    // availability. The pricingRef supplies its context tier: $2/$6 per
+    // million input/output tokens, doubled above a 200k-token prompt.
+    id: 'grok-4.6',
+    name: 'Grok 4.6',
+    upstreamModelId: 'x-ai/grok-4.6',
+    transport: 'openrouter',
+    pricingRef: 'openrouter/x-ai/grok-4.6',
+    pricing: {
+      inputPerMillion: 2,
+      cachedInputPerMillion: 0.5,
+      outputPerMillion: 6,
+      contextOver200k: {
+        inputPerMillion: 4,
+        cachedInputPerMillion: 1,
+        outputPerMillion: 12,
+        contextThreshold: 200_000,
+      },
+    },
+    tier: 'flagship',
+    vision: true,
+    limit: { context: 500_000, output: 500_000 },
+    openrouterProvider: {
+      order: ['xai'],
+      allow_fallbacks: true,
+    },
+  },
   // {
   //   id: 'claude-opus-4.8',
   //   name: 'Claude Opus 4.8',
@@ -567,9 +603,7 @@ export const MANAGED_MODELS: ManagedModel[] = [
       cacheWritePerMillion: 1,
       outputPerMillion: 4,
     },
-    // Flagship since the Bedrock Claude deactivation: MANAGED_FLAGSHIP_MODEL_ID
-    // and resolvePlatformDefaultModelId's degrade order both key off this tier.
-    tier: 'flagship',
+    tier: 'balanced',
     vision: false,
     limit: { context: 1_000_000, output: 131_072 },
   },

--- a/packages/llm-catalog/src/managed.test.ts
+++ b/packages/llm-catalog/src/managed.test.ts
@@ -15,6 +15,7 @@ describe('managed catalog', () => {
   // minimax-m3, and gpt-5.6-luna added the same day.
   test('exposes the managed lineup', () => {
     expect(DEFAULT_MANAGED_MODEL_IDS).toEqual([
+      'grok-4.6',
       'glm-5.2',
       'deepseek-v4-flash',
       'muse-spark-1.2',
@@ -28,8 +29,8 @@ describe('managed catalog', () => {
     expect(DEFAULT_MANAGED_MODEL_IDS).not.toContain('kortix-basic');
   });
 
-  test('GLM 5.2 is the single flagship', () => {
-    expect(MANAGED_FLAGSHIP_MODEL_ID).toBe('glm-5.2');
+  test('Grok 4.6 is the single flagship', () => {
+    expect(MANAGED_FLAGSHIP_MODEL_ID).toBe('grok-4.6');
     expect(MANAGED_MODELS.filter((m) => m.tier === 'flagship')).toHaveLength(1);
   });
 
@@ -139,6 +140,27 @@ describe('managed resolution + back-compat aliases', () => {
       cachedInputPerMillion: 0.01876,
       cacheWritePerMillion: 0.0938,
       outputPerMillion: 0.1876,
+    });
+    expect(getManagedModel('grok-4.6')).toMatchObject({
+      name: 'Grok 4.6',
+      upstreamModelId: 'x-ai/grok-4.6',
+      transport: 'openrouter',
+      pricingRef: 'openrouter/x-ai/grok-4.6',
+      tier: 'flagship',
+      vision: true,
+      limit: { context: 500_000, output: 500_000 },
+      openrouterProvider: { order: ['xai'], allow_fallbacks: true },
+    });
+    expect(getManagedModel('grok-4.6')?.pricing).toEqual({
+      inputPerMillion: 2,
+      cachedInputPerMillion: 0.5,
+      outputPerMillion: 6,
+      contextOver200k: {
+        inputPerMillion: 4,
+        cachedInputPerMillion: 1,
+        outputPerMillion: 12,
+        contextThreshold: 200_000,
+      },
     });
   });
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,17 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-13 — session `grok-4-6-managed`
+
+No public SDK API changes. The playground's compile-time `MODEL_IDS` union now
+matches `@kortix/llm-catalog` after adding `grok-4.6`. It also includes the
+three managed ids added on 2026-08-10. The package version is unchanged.
+
+Verification: SDK typecheck exits `0`; SDK tests report `1903 pass`, `0 fail`,
+and `7250` assertions across `145` files; packed-install smoke passes.
+
+**Status:** COMPLETE. SDK package shippable to production: YES.
+
 ### 2026-08-11 — session `billing-revamp-pr5-ui` claim
 
 No **Now** task claimed. User-directed work: the UI half of PR5 (the admin

--- a/packages/sdk/playground/chat/14-change-default-model.ts
+++ b/packages/sdk/playground/chat/14-change-default-model.ts
@@ -25,7 +25,14 @@ import { MANAGED_MODELS } from "@kortix/llm-catalog";
 
 import { createKortix } from "../../src/index";
 
-const MODEL_IDS = ["glm-5.2", "deepseek-v4-flash"] as const;
+const MODEL_IDS = [
+  "grok-4.6",
+  "glm-5.2",
+  "deepseek-v4-flash",
+  "muse-spark-1.2",
+  "minimax-m3",
+  "gpt-5.6-luna",
+] as const;
 
 type ManagedModelId = (typeof MODEL_IDS)[number];
 


### PR DESCRIPTION
## Problem

Kortix does not expose xAI Grok 4.6 through the managed gateway. Users cannot select `kortix/grok-4.6` or bill its usage through Kortix credits.

## Change

- Add managed `grok-4.6` routed to `x-ai/grok-4.6` through OpenRouter.
- Prefer the first-party `xai` provider and keep OpenRouter fallback enabled.
- Publish vision, tools, structured output, reasoning efforts, 500,000-token limits, and context-tier pricing.
- Make Grok 4.6 the managed flagship. Move GLM 5.2 to balanced.
- Add Grok 4.6 to the baked catalog and sandbox-agent fallback catalog.
- Update model documentation and the SDK playground model union.

## Verification

- `pnpm --filter @kortix/llm-catalog typecheck` — exit 0
- `pnpm --filter @kortix/llm-catalog test` — 72 pass, 0 fail
- `pnpm --filter @kortix/llm-catalog build` — exit 0
- `bun test --isolate --env-file=apps/api/scripts/test.env apps/api/src/llm-gateway/models/catalog-models.test.ts apps/api/src/llm-gateway/resolution/descriptors.test.ts` — 42 pass, 0 fail
- `pnpm --filter kortix-api typecheck` — exit 0
- `pnpm --filter @kortix/sandbox-agent-server build` — exit 0
- `pnpm --filter @kortix/sdk typecheck` — exit 0
- `pnpm --filter @kortix/sdk test` — 1903 pass, 0 fail, 7250 assertions
- `pnpm --filter @kortix/sdk run smoke:install` — pass

## Local black-box proof

Authenticated `GET /v1/llm/models` and project `GET /model-picker` return Grok 4.6 with the expected capabilities, 500,000-token limits, and `$2/$6/$0.50` pricing plus the above-200k `$4/$12/$1` tier.

Authenticated `POST /v1/llm/chat/completions` with `model: grok-4.6` returned `200` and `GROK46_METERED_OK`. The trace resolved `openrouter` → `x-ai/grok-4.6` in one attempt. It recorded 219 input, 87 output, and 128 cached tokens. Upstream cost was `$0.0007603200`. Final cost was `$0.0009123840`.

Billing-enabled local proof moved the precise wallet from `7.0000000000` to `6.9990876160`. The exact precise ledger sum equals `6.9990876160`.

## Verification boundary

The in-app browser runtime listed zero browsers. API catalog, picker payload, inference, generation, usage, wallet, and ledger contracts are verified. DOM and network UI verification remains blocked until a browser is available.
