### PR TITLE
feat(secrets): boundary delivery is a project flag, not an operator env var

### DIFF
--- a/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
+++ b/apps/api/src/__tests__/unit-api-contract-serializers.test.ts
@@ -360,6 +360,7 @@ describe('buildSecretView ⇄ SecretSchema', () => {
       name: 'OPENAI_API_KEY',
       shared: secretRow(),
       canManageShared: true,
+      projectMetadata: undefined,
     });
     expect(SecretSchema.strict().parse(out)).toEqual(out);
     expect(out.effective_source).toBe('shared');
@@ -380,6 +381,7 @@ describe('buildSecretView ⇄ SecretSchema', () => {
       name: 'OPENAI_API_KEY',
       shared: secretRow({ strategy: 'denied', rotatedAt: null }),
       canManageShared: true,
+      projectMetadata: undefined,
     });
 
     expect(SecretSchema.strict().parse(out)).toEqual(out);
@@ -401,6 +403,7 @@ describe('buildSecretView ⇄ SecretSchema', () => {
         updatedAt: new Date('2026-08-03T10:00:00.000Z'),
       }),
       canManageShared: true,
+      projectMetadata: undefined,
     });
 
     expect(SecretSchema.strict().parse(out)).toEqual(out);
@@ -418,6 +421,7 @@ describe('buildSecretView ⇄ SecretSchema', () => {
       name: 'OPENAI_API_KEY',
       shared: secretRow({ strategy: 'broker', consumer: 'http_broker', egressPolicy }),
       canManageShared: true,
+      projectMetadata: undefined,
     });
 
     expect(SecretSchema.strict().parse(out)).toEqual(out);
@@ -435,6 +439,7 @@ describe('buildSecretView ⇄ SecretSchema', () => {
       name: 'OPENAI_API_KEY',
       shared: secretRow({ strategy: 'broker', consumer: 'llm_gateway' }),
       canManageShared: true,
+      projectMetadata: undefined,
     });
 
     expect(SecretSchema.strict().parse(out)).toEqual(out);
@@ -452,12 +457,14 @@ describe('buildSecretView ⇄ SecretSchema', () => {
       name: 'GOOGLE_MAPS_API_KEY',
       shared: secretRow({ identifier: 'GMAPS-primary', name: 'GOOGLE_MAPS_API_KEY' }),
       canManageShared: true,
+      projectMetadata: undefined,
     });
     const backup = buildSecretView({
       identifier: 'GMAPS-backup',
       name: 'GOOGLE_MAPS_API_KEY',
       shared: secretRow({ identifier: 'GMAPS-backup', name: 'GOOGLE_MAPS_API_KEY' }),
       canManageShared: true,
+      projectMetadata: undefined,
     });
     expect(SecretSchema.strict().parse(primary)).toEqual(primary);
     expect(SecretSchema.strict().parse(backup)).toEqual(backup);
@@ -471,6 +478,7 @@ describe('buildSecretView ⇄ SecretSchema', () => {
       name: 'OPENAI_API_KEY',
       personal: secretRow({ ownerUserId: USER_ID }),
       canManageShared: false,
+      projectMetadata: undefined,
     });
     const parsed = SecretSchema.strict().parse(out);
     expect(parsed.configured).toBe(false);
@@ -484,6 +492,7 @@ describe('buildSecretView ⇄ SecretSchema', () => {
       name: 'KORTIX_GIT_AUTH_TOKEN',
       shared: secretRow({ identifier: 'KORTIX_GIT_AUTH_TOKEN', name: 'KORTIX_GIT_AUTH_TOKEN' }),
       canManageShared: true,
+      projectMetadata: undefined,
     });
     const parsed = SecretSchema.strict().parse(out);
     expect(parsed.system).toBe(true);

--- a/apps/api/src/__tests__/unit-secret-view.test.ts
+++ b/apps/api/src/__tests__/unit-secret-view.test.ts
@@ -51,6 +51,7 @@ describe('buildSecretView — identifier model', () => {
       name: 'STRIPE_KEY',
       shared: sharedRow(),
       canManageShared: false,
+      projectMetadata: undefined,
     });
     expect(v.identifier).toBe('STRIPE_KEY');
     expect(v.name).toBe('STRIPE_KEY');
@@ -67,12 +68,14 @@ describe('buildSecretView — identifier model', () => {
       name: 'GOOGLE_MAPS_API_KEY',
       shared: sharedRow({ identifier: 'GMAPS-primary', name: 'GOOGLE_MAPS_API_KEY', secretId: 's-a' }),
       canManageShared: false,
+      projectMetadata: undefined,
     });
     const backup = buildSecretView({
       identifier: 'GMAPS-backup',
       name: 'GOOGLE_MAPS_API_KEY',
       shared: sharedRow({ identifier: 'GMAPS-backup', name: 'GOOGLE_MAPS_API_KEY', secretId: 's-b' }),
       canManageShared: false,
+      projectMetadata: undefined,
     });
     expect(primary.identifier).not.toBe(backup.identifier);
     expect(primary.name).toBe(backup.name);
@@ -85,6 +88,7 @@ describe('buildSecretView — identifier model', () => {
       name: 'CODEX_AUTH_JSON',
       personal: personalRow(),
       canManageShared: false,
+      projectMetadata: undefined,
     });
     expect(v.configured).toBe(false);
     expect(v.effective_source).toBe('mine');
@@ -97,6 +101,7 @@ describe('buildSecretView — identifier model', () => {
       shared: sharedRow({ identifier: 'CODEX_AUTH_JSON', name: 'CODEX_AUTH_JSON' }),
       personal: personalRow(),
       canManageShared: false,
+      projectMetadata: undefined,
     });
     expect(v.mine).toEqual({ active: true, updated_at: '2026-01-01T00:00:00.000Z' });
     expect(v.effective_source).toBe('mine');
@@ -109,6 +114,7 @@ describe('buildSecretView — identifier model', () => {
       shared: sharedRow({ identifier: 'CODEX_AUTH_JSON', name: 'CODEX_AUTH_JSON' }),
       personal: personalRow({ active: false }),
       canManageShared: false,
+      projectMetadata: undefined,
     });
     expect(v.effective_source).toBe('shared');
   });
@@ -119,6 +125,7 @@ describe('buildSecretView — identifier model', () => {
       name: 'KORTIX_INTERNAL',
       shared: sharedRow({ identifier: 'KORTIX_INTERNAL', name: 'KORTIX_INTERNAL' }),
       canManageShared: true,
+      projectMetadata: undefined,
     });
     expect(v.system).toBe(true);
     expect(v.can_manage_shared).toBe(false);

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -341,18 +341,6 @@ const envSchema = z.object({
   // production). The shim terminates the guest's TLS and relays to the broker
   // route; the credential stays server-side either way.
   //
-  // OFF by default, deliberately, and this is the sequencing that matters:
-  // turning it on makes the API ADVERTISE network-boundary delivery to
-  // non-Platinum projects (save-time gate, delivery_status, the web control).
-  // If the sandbox image does not yet run the shim, a user could save a
-  // boundary secret that nothing in the guest can honour — a feature that
-  // looks available and silently does nothing, which is the exact failure
-  // this project has spent too long unpicking.
-  //
-  // Flip to `true` only once the guest half is in the image and a fresh
-  // sandbox has been observed running the shim. `optBoolFalse` accepts
-  // true/1/yes/on.
-  EGRESS_SHIM_ENABLED: optBoolFalse,
   // Whether a session's sandbox gets the `kortix-connectors` OpenCode MCP
   // server (KORTIX_CONNECTORS_MCP_ENABLED in the guest). It exposes the
   // connector meta-tools plus `secret_call`, the only way to use an
@@ -1026,7 +1014,6 @@ export const config = {
   ASTER_API_URL: env.ASTER_API_URL,
   ASTER_API_KEY: env.ASTER_API_KEY,
   CONNECTORS_MCP_ENABLED: env.CONNECTORS_MCP_ENABLED,
-  EGRESS_SHIM_ENABLED: env.EGRESS_SHIM_ENABLED,
   LLM_GATEWAY_ENABLED: env.LLM_GATEWAY_ENABLED,
   // Unset → follow billing (cloud keeps its revenue lineup even if the env
   // blob misses the var; self-host stays off). Explicit value always wins.

--- a/apps/api/src/feature-flags/registry.ts
+++ b/apps/api/src/feature-flags/registry.ts
@@ -232,6 +232,30 @@ const FLAGS: readonly FeatureFlagDef[] = [
     platformDefault: () => false,
     enforcement: 'routes',
   },
+  {
+    key: 'network_boundary_shim',
+    name: 'Network boundary without Platinum',
+    description:
+      'Use network-boundary secrets on a project that does not run on Platinum. The credential is injected by Kortix at request time instead of by a provider edge, so the sandbox still never receives the value. Requires a sandbox image that runs the in-guest shim; without it a boundary secret saves but nothing in the sandbox can spend it.',
+    stability: 'experimental',
+    // No operator env gates it — the delivery path is ordinary API code that
+    // ships with the app. What it needs is a sandbox image new enough to run
+    // the shim, which is a per-deployment fact the API cannot introspect, so
+    // the decision is left to whoever turns it on for a project.
+    available: () => true,
+    // Explicit opt-in. Defaulting this on would advertise boundary delivery to
+    // every non-Platinum project, and on an older sandbox image the secret
+    // would save and then silently never reach anything — the failure mode this
+    // whole feature exists to remove.
+    platformDefault: () => false,
+    enforcement: 'behavioral',
+    enforcementNote:
+      'On ⇒ networkBoundaryDeliveryAvailable() accepts this project without ' +
+      'Platinum, provisioning stops treating a missing provider edge as fatal, ' +
+      'and the broker route serves egress/network secrets (secrets/' +
+      'network-boundary-availability.ts, projects/lib/sandbox-env-sync.ts, ' +
+      'platform/services/session-sandbox.ts).',
+  },
 ];
 
 const FLAG_BY_KEY: Record<FeatureFlagKey, FeatureFlagDef> = Object.fromEntries(

--- a/apps/api/src/feature-flags/registry.ts
+++ b/apps/api/src/feature-flags/registry.ts
@@ -17,12 +17,31 @@
  * Per-project state is DB-only (projects.metadata) — never in kortix.yaml.
  * The `experimental` metadata key is a stable storage detail; do not rename it.
  *
- * To add a flag:
- *   1. Add the key to FeatureFlagMapSchema in @kortix/api-contract (typecheck
- *      forces this) and to the SDK's runtime key list.
- *   2. Append an entry below, DECLARING its enforcement mode.
- *   3. Gate its routes with `requireFeatureFlag` (enforcement: 'routes'), or
- *      its runtime behavior on `resolveFeatureFlag` (enforcement: 'behavioral').
+ * To add a flag, the key goes in SIX places. Typecheck forces only one of them
+ * (the SDK union), so do not rely on a clean build:
+ *
+ *   1. `FeatureFlagMapSchema` — packages/api-contract/src/index.ts
+ *   2. TWO sites in packages/api-contract/src/__tests__/schemas.test.ts: a
+ *      project fixture, and a hand-written copy of the key list
+ *   3. The `FeatureFlagKey` union AND the `FEATURE_FLAG_KEYS` array —
+ *      packages/sdk/.../projects-client/projects.ts. Only the union is
+ *      typechecked; a missing array entry compiles fine.
+ *   4. Another hand-written copy in that package's projects.test.ts
+ *   5. An entry below, DECLARING its enforcement mode
+ *   6. One `useFeatureFlag` call + one map entry in
+ *      apps/web/src/lib/use-project-feature-flags.ts (and move the trailing
+ *      `isLoading:` to the newly-last hook)
+ *
+ * Then gate its routes with `requireFeatureFlag` (enforcement: 'routes'), or
+ * its runtime behavior on `resolveFeatureFlag` (enforcement: 'behavioral').
+ *
+ * FOUR separate tests guard those six sites, each in its own package, so each
+ * one fails only when that package's suite runs — they surface one CI round at
+ * a time. `unit-feature-flag-drift.test.ts` compares contract <-> SDK <->
+ * registry and catches 1/3/5 only. List every holder before you start:
+ *
+ *   rg -l "meta_agent" --glob '!node_modules' . | xargs rg -l "review_center"
+ *
  * The UI renders straight from {@link buildFeatureFlagCatalog}, so a new entry
  * lights up in Settings automatically. `unit-feature-flags.test.ts` pins the
  * catalog to the contract key list and requires every entry to declare its

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -61,7 +61,7 @@ import { grantWarmPoolLifetime } from '../../projects/sandbox-deadline';
 import { withTimeout, configuredTimeoutMs } from '../../shared/with-timeout';
 import { classifySandboxProvisioningFailure } from './sandbox-provisioning-error';
 import { platformMetaAgentGrant } from '../../projects/lib/platform-meta-agent';
-import { networkBoundaryShimAvailable } from '../../secrets/network-boundary-availability';
+import { projectFeatureFlagEnabled } from '../../feature-flags/for-project';
 import { resolveSessionNetworkBoundary } from '../../projects/lib/network-secret-boundary';
 
 /**
@@ -548,7 +548,7 @@ export async function provisionSessionSandbox(opts: {
       if (
         networkBoundary.length > 0 &&
         !provider.syncNetworkBoundary &&
-        !networkBoundaryShimAvailable()
+        !(await projectFeatureFlagEnabled(projectId, 'network_boundary_shim'))
       ) {
         throw new Error(
           `Sandbox provider ${providerName} does not support network-boundary secret delivery`,

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -17,7 +17,7 @@ import {
   listProjectSecretsSnapshotForUser,
   projectSecretsRevision,
 } from '../secrets';
-import { networkBoundaryShimAvailable } from '../../secrets/network-boundary-availability';
+import { projectFeatureFlagEnabled } from '../../feature-flags/for-project';
 import { DEFAULT_AGENT_SENTINEL } from '../agents';
 import { resolveSessionSecretGrant } from './secret-grant';
 import { sanitizeSandboxEnv } from './sandbox-env-names';
@@ -143,6 +143,7 @@ function rememberNetworkBoundaryArm(externalId: string, digest: string, secretId
 }
 
 function startNetworkBoundaryArm(
+  projectId: string,
   providerName: ProviderName,
   externalId: string,
   bindings: NetworkBoundarySecretBinding[],
@@ -166,7 +167,7 @@ function startNetworkBoundaryArm(
         //
         // Until the shim existed this threw, which is why creating a session on
         // Daytona with a boundary secret failed provisioning outright.
-        if (networkBoundaryShimAvailable()) {
+        if (await projectFeatureFlagEnabled(projectId, 'network_boundary_shim')) {
           rememberNetworkBoundaryArm(
             externalId,
             digest,
@@ -212,6 +213,7 @@ function startNetworkBoundaryArm(
  * the secret fan-out does — to wait for the real result and report a failure.
  */
 async function syncProviderNetworkBoundary(
+  projectId: string,
   providerName: ProviderName,
   externalId: string,
   bindings: NetworkBoundarySecretBinding[],
@@ -224,7 +226,7 @@ async function syncProviderNetworkBoundary(
     return 'skipped';
   }
 
-  const attempt = startNetworkBoundaryArm(providerName, externalId, bindings, digest);
+  const attempt = startNetworkBoundaryArm(projectId, providerName, externalId, bindings, digest);
   const maxWaitMs = opts?.maxWaitMs;
   if (!maxWaitMs) {
     await attempt;
@@ -587,6 +589,7 @@ export async function syncSandboxEnvForPrompt(args: {
     // provision path in platform/services/session-sandbox.ts — a session that
     // cannot arm its boundary should still fail to provision, loudly.
     const armState = await syncProviderNetworkBoundary(
+      args.projectId,
       args.providerName,
       args.externalId,
       networkBoundary,
@@ -726,7 +729,7 @@ export async function propagateProjectSecretsToActiveSandboxes(
         // caller reports the per-sandbox outcome to the author who just saved the
         // secret. An arming failure has to be visible there, so it stays a
         // `status: 'failed'` row rather than a warning nobody reads.
-        await syncProviderNetworkBoundary(providerName, row.externalId, networkBoundary);
+        await syncProviderNetworkBoundary(projectId, providerName, row.externalId, networkBoundary);
         const { url, headers } = await resolveSandboxIngress(row.externalId, { port: SANDBOX_SERVICE_PORT, transport: 'http' });
         const proof = await postEnvToDaemon({
           previewUrl: url,

--- a/apps/api/src/projects/lib/serializers.test.ts
+++ b/apps/api/src/projects/lib/serializers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
+import { config } from '../../config';
 import {
   type SecretAgentGrantConfig,
   buildSecretView,
@@ -266,6 +267,43 @@ describe('secretDeliveryBlockedReason', () => {
         declarative([['GOOGLE_MAPS_API_KEY']]),
       ),
     ).toBe('no_agent_grant');
+  });
+});
+
+/**
+ * `network_boundary_available` and `delivery_status` are what the web control
+ * and the CLI read to decide whether this mode can be offered at all. Both are
+ * computed from an OPTIONAL `projectMetadata` argument, so a caller that simply
+ * forgot to pass the project still typechecks and silently reports the old
+ * Platinum-only answer. That is exactly the regression these tests catch.
+ */
+describe('buildSecretView — the per-project boundary flag reaches the view', () => {
+  const boundaryView = (projectMetadata?: unknown) =>
+    buildSecretView({
+      identifier: 'BOUNDARY_TEST',
+      name: 'BOUNDARY_TEST',
+      shared: secretRow(),
+      canManageShared: true,
+      agentGrants: declarative([['BOUNDARY_TEST']]),
+      projectMetadata,
+    });
+
+  test('a project with the flag on reports boundary delivery available', () => {
+    const view = boundaryView({ experimental: { network_boundary_shim: true } });
+    expect(view.network_boundary_available).toBe(true);
+    expect(view.delivery_status).toBe('available');
+  });
+
+  test('an omitted project cannot widen the gate', () => {
+    // Without Platinum the answer must be the closed one — never a default-open
+    // guess made on a caller's behalf.
+    const view = boundaryView(undefined);
+    expect(view.network_boundary_available).toBe(config.isPlatinumEnabled());
+  });
+
+  test('an explicit off is not read as "unset"', () => {
+    const view = boundaryView({ experimental: { network_boundary_shim: false } });
+    expect(view.network_boundary_available).toBe(config.isPlatinumEnabled());
   });
 });
 

--- a/apps/api/src/projects/lib/serializers.test.ts
+++ b/apps/api/src/projects/lib/serializers.test.ts
@@ -278,7 +278,7 @@ describe('secretDeliveryBlockedReason', () => {
  * Platinum-only answer. That is exactly the regression these tests catch.
  */
 describe('buildSecretView — the per-project boundary flag reaches the view', () => {
-  const boundaryView = (projectMetadata?: unknown) =>
+  const boundaryView = (projectMetadata: unknown) =>
     buildSecretView({
       identifier: 'BOUNDARY_TEST',
       name: 'BOUNDARY_TEST',
@@ -294,9 +294,10 @@ describe('buildSecretView — the per-project boundary flag reaches the view', (
     expect(view.delivery_status).toBe('available');
   });
 
-  test('an omitted project cannot widen the gate', () => {
-    // Without Platinum the answer must be the closed one — never a default-open
-    // guess made on a caller's behalf.
+  test('an explicitly absent project cannot widen the gate', () => {
+    // The argument is REQUIRED, so a caller with no project has to write
+    // `undefined` and say so. Without Platinum that reads as the closed answer,
+    // never as a default-open guess made on the caller's behalf.
     const view = boundaryView(undefined);
     expect(view.network_boundary_available).toBe(config.isPlatinumEnabled());
   });
@@ -314,6 +315,7 @@ describe('buildSecretView — delivery_blocked_reason', () => {
       name: 'BOUNDARY_TEST',
       shared: secretRow(),
       canManageShared: true,
+      projectMetadata: undefined,
       agentGrants: declarative([['OTHER_KEY']]),
     });
     expect(view.delivery_blocked_reason).toBe('no_agent_grant');
@@ -330,6 +332,7 @@ describe('buildSecretView — delivery_blocked_reason', () => {
       name: 'BOUNDARY_TEST',
       shared: secretRow(),
       canManageShared: true,
+      projectMetadata: undefined,
       agentGrants: declarative([['BOUNDARY_TEST']]),
     });
     expect(view.delivery_blocked_reason).toBeNull();
@@ -342,6 +345,7 @@ describe('buildSecretView — delivery_blocked_reason', () => {
       name: 'GOOGLE_MAPS_API_KEY',
       shared,
       canManageShared: true,
+      projectMetadata: undefined,
       agentGrants: declarative([['GMAPS-primary']]),
     });
     const byName = buildSecretView({
@@ -349,6 +353,7 @@ describe('buildSecretView — delivery_blocked_reason', () => {
       name: 'GOOGLE_MAPS_API_KEY',
       shared,
       canManageShared: true,
+      projectMetadata: undefined,
       agentGrants: declarative([['GOOGLE_MAPS_API_KEY']]),
     });
     expect(byIdentifier.delivery_blocked_reason).toBeNull();
@@ -362,12 +367,14 @@ describe('buildSecretView — delivery_blocked_reason', () => {
       name: 'BOUNDARY_TEST',
       shared,
       canManageShared: true,
+      projectMetadata: undefined,
     });
     const after = buildSecretView({
       identifier: 'BOUNDARY_TEST',
       name: 'BOUNDARY_TEST',
       shared,
       canManageShared: true,
+      projectMetadata: undefined,
       agentGrants: declarative([['OTHER_KEY']]),
     });
     expect(before.delivery_blocked_reason).toBeNull();
@@ -388,6 +395,7 @@ describe('buildSecretView — delivery_blocked_reason', () => {
         egressPolicy: null,
       }),
       canManageShared: true,
+      projectMetadata: undefined,
       agentGrants: declarative([['OTHER_KEY']]),
     });
     expect(view.delivery_blocked_reason).toBeNull();

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -11,7 +11,7 @@ import {
   type projectGitCredentials,
   projectSecrets,
   type projectSessions,
-  type projects,
+  projects,
 } from '@kortix/db';
 import { and, desc, eq, isNull, or } from 'drizzle-orm';
 import type { Context } from 'hono';
@@ -384,6 +384,10 @@ export function buildSecretView(input: {
   /** The project's loaded config, for the agent-grant axis. Omit it and every
    *  pre-existing field is unchanged; `delivery_blocked_reason` reports null. */
   agentGrants?: SecretAgentGrantConfig | null;
+  /** The project's metadata row, for the per-project boundary flag. Omit it and
+   *  boundary delivery reports available only where Platinum covers it — the
+   *  pre-flag behaviour, so an un-updated caller cannot over-advertise. */
+  projectMetadata?: unknown;
 }): Secret {
   const { identifier, name, shared, personal, canManageShared } = input;
   const system = isSystemProjectSecretName(name);
@@ -450,7 +454,9 @@ export function buildSecretView(input: {
       (strategy === 'broker' && consumer === 'llm_gateway') ||
       (strategy === 'broker' && consumer === 'git_proxy') ||
       (strategy === 'broker' && consumer === 'http_broker' && backend === 'kortix_fetch') ||
-      (strategy === 'egress' && consumer === 'network' && networkBoundaryDeliveryAvailable()) ||
+      (strategy === 'egress' &&
+        consumer === 'network' &&
+        networkBoundaryDeliveryAvailable(input.projectMetadata)) ||
       consumer === 'connector'
         ? 'available'
         : strategy === 'denied'
@@ -461,7 +467,7 @@ export function buildSecretView(input: {
     // grant, because the CLI, the SDK and the web chip all key off that meaning.
     // The grant axis is per-project and lives here.
     delivery_blocked_reason: secretDeliveryBlockedReason(identifier, strategy, input.agentGrants),
-    network_boundary_available: networkBoundaryDeliveryAvailable(),
+    network_boundary_available: networkBoundaryDeliveryAvailable(input.projectMetadata),
     egress_policy: deliveryRow?.egressPolicy ?? null,
     strategy_locked: deliveryRow?.strategyLocked ?? false,
     last_rotated_at: deliveryRow?.rotatedAt?.toISOString() ?? null,
@@ -481,7 +487,27 @@ export async function loadSecretViewsForUser(
   /** The project's loaded config. Callers that have already read it pass it so
    *  every row reports the agent-grant axis; omitting it reports null. */
   agentGrants?: SecretAgentGrantConfig | null,
+  /**
+   * Project metadata, for the per-project network-boundary flag. Resolved here
+   * when the caller does not supply it.
+   *
+   * Looked up rather than threaded through every call site on purpose: five
+   * routes call this, only two have the project row in scope, and a caller that
+   * silently omitted it would under-report `network_boundary_available` — the
+   * web control would then hide an option the project actually has. One extra
+   * row read on a list endpoint is cheaper than that class of bug.
+   */
+  projectMetadata?: unknown,
 ): Promise<ReturnType<typeof buildSecretView>[]> {
+  const metadata =
+    projectMetadata ??
+    (
+      await db
+        .select({ metadata: projects.metadata })
+        .from(projects)
+        .where(eq(projects.projectId, projectId))
+        .limit(1)
+    )[0]?.metadata;
   const rows = await db
     .select()
     .from(projectSecrets)
@@ -509,6 +535,7 @@ export async function loadSecretViewsForUser(
       personal: slot.personal,
       canManageShared,
       agentGrants,
+      projectMetadata: metadata,
     }),
   );
 }

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -11,7 +11,7 @@ import {
   type projectGitCredentials,
   projectSecrets,
   type projectSessions,
-  projects,
+  type projects,
 } from '@kortix/db';
 import { and, desc, eq, isNull, or } from 'drizzle-orm';
 import type { Context } from 'hono';
@@ -384,10 +384,19 @@ export function buildSecretView(input: {
   /** The project's loaded config, for the agent-grant axis. Omit it and every
    *  pre-existing field is unchanged; `delivery_blocked_reason` reports null. */
   agentGrants?: SecretAgentGrantConfig | null;
-  /** The project's metadata row, for the per-project boundary flag. Omit it and
-   *  boundary delivery reports available only where Platinum covers it — the
-   *  pre-flag behaviour, so an un-updated caller cannot over-advertise. */
-  projectMetadata?: unknown;
+  /**
+   * The project's `metadata` column, for the per-project boundary flag.
+   *
+   * REQUIRED, and deliberately so. It feeds `network_boundary_available` and
+   * `delivery_status`, which the web control and the CLI read to decide whether
+   * this delivery mode can be offered at all. As an optional parameter a caller
+   * that simply forgot it still typechecked and silently reported the old
+   * Platinum-only answer — a wrong feature verdict, invisible to tsc and to
+   * every test that did not happen to look. Required turns that into a compile
+   * error. Pass `undefined` explicitly for a caller that genuinely has no
+   * project; that reads as closed, never as "unset".
+   */
+  projectMetadata: unknown;
 }): Secret {
   const { identifier, name, shared, personal, canManageShared } = input;
   const system = isSystemProjectSecretName(name);
@@ -480,34 +489,22 @@ export function buildSecretView(input: {
  * own override merged). Used by the secrets list + returned after a write.
  */
 
-export async function loadSecretViewsForUser(
-  projectId: string,
-  userId: string,
-  canManageShared: boolean,
+export async function loadSecretViewsForUser(input: {
+  projectId: string;
+  userId: string;
+  canManageShared: boolean;
+  /** The loaded project's `metadata` column — see `buildSecretView`. */
+  projectMetadata: unknown;
   /** The project's loaded config. Callers that have already read it pass it so
    *  every row reports the agent-grant axis; omitting it reports null. */
-  agentGrants?: SecretAgentGrantConfig | null,
-  /**
-   * Project metadata, for the per-project network-boundary flag. Resolved here
-   * when the caller does not supply it.
-   *
-   * Looked up rather than threaded through every call site on purpose: five
-   * routes call this, only two have the project row in scope, and a caller that
-   * silently omitted it would under-report `network_boundary_available` — the
-   * web control would then hide an option the project actually has. One extra
-   * row read on a list endpoint is cheaper than that class of bug.
-   */
-  projectMetadata?: unknown,
-): Promise<ReturnType<typeof buildSecretView>[]> {
-  const metadata =
-    projectMetadata ??
-    (
-      await db
-        .select({ metadata: projects.metadata })
-        .from(projects)
-        .where(eq(projects.projectId, projectId))
-        .limit(1)
-    )[0]?.metadata;
+  agentGrants?: SecretAgentGrantConfig | null;
+}): Promise<ReturnType<typeof buildSecretView>[]> {
+  // NAMED, not positional. `projectMetadata` is `unknown`, so it accepts any
+  // argument — as a positional parameter it silently swallowed the `agentGrants`
+  // that a call site passed in that slot, and typechecked while doing it. That
+  // is the same class of invisible failure the required flag exists to prevent,
+  // so the whole signature is by name.
+  const { projectId, userId, canManageShared, projectMetadata, agentGrants } = input;
   const rows = await db
     .select()
     .from(projectSecrets)
@@ -535,7 +532,7 @@ export async function loadSecretViewsForUser(
       personal: slot.personal,
       canManageShared,
       agentGrants,
-      projectMetadata: metadata,
+      projectMetadata,
     }),
   );
 }

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -765,10 +765,11 @@ projectsApp.openapi(
           400,
         );
       }
-      if (!networkBoundaryDeliveryAvailable()) {
+      if (!networkBoundaryDeliveryAvailable(loaded.row.metadata)) {
         return c.json(
           {
-            error: 'Network-boundary delivery requires the Platinum sandbox provider',
+            error:
+              'Network-boundary delivery needs Platinum, or the "Network boundary without Platinum" project feature flag',
             code: 'secret_delivery_unavailable',
           },
           409,
@@ -1040,10 +1041,11 @@ projectsApp.openapi(
       return c.json({ error: 'This consumer does not accept an outbound policy' }, 400);
     }
     if (parsed.data.strategy === 'egress') {
-      if (!networkBoundaryDeliveryAvailable()) {
+      if (!networkBoundaryDeliveryAvailable(loaded.row.metadata)) {
         return c.json(
           {
-            error: 'Network-boundary delivery requires the Platinum sandbox provider',
+            error:
+              'Network-boundary delivery needs Platinum, or the "Network boundary without Platinum" project feature flag',
             code: 'secret_delivery_unavailable',
           },
           409,

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -615,7 +615,13 @@ projectsApp.openapi(
   // standing agent grant remains the enumeration ceiling for agent tokens.
   const agentGrant = getAgentGrant(c);
 
-  const items = (await loadSecretViewsForUser(projectId, loaded.userId, canManageShared, agentGrants))
+  const items = (await loadSecretViewsForUser({
+    projectId,
+    userId: loaded.userId,
+    canManageShared,
+    projectMetadata: loaded.row.metadata,
+    agentGrants,
+  }))
     .filter((item) => !item.system)
     .filter((item) => agentMayUseEnv(agentGrant, item.identifier));
 
@@ -920,7 +926,12 @@ projectsApp.openapi(
     });
   }
 
-  const views = await loadSecretViewsForUser(projectId, loaded.userId, true);
+  const views = await loadSecretViewsForUser({
+    projectId,
+    userId: loaded.userId,
+    canManageShared: true,
+    projectMetadata: loaded.row.metadata,
+  });
   const view = views.find((v) => v.identifier === identifier);
   if (!view) {
     throw new Error(`Secret view not found after upsert: ${identifier}`);
@@ -1199,7 +1210,12 @@ projectsApp.openapi(
       );
     }
 
-    const views = await loadSecretViewsForUser(projectId, loaded.userId, true);
+    const views = await loadSecretViewsForUser({
+    projectId,
+    userId: loaded.userId,
+    canManageShared: true,
+    projectMetadata: loaded.row.metadata,
+  });
     const view = views.find((item) => item.identifier === identifier);
     if (!view) return c.json({ error: 'Not found' }, 404);
 
@@ -1248,8 +1264,11 @@ async function writeCodexAuthSecret(input: {
   userId: string;
   value: string;
   sharing?: ReturnType<typeof parseSharingIntent>;
+  /** The loaded project's `metadata` column. This helper has no project row of
+   *  its own, so its caller supplies it — see `buildSecretView`. */
+  projectMetadata: unknown;
 }) {
-  const { projectId, accountId, userId, value, sharing } = input;
+  const { projectId, accountId, userId, value, sharing, projectMetadata } = input;
   const now = new Date();
   let secretId: string;
 
@@ -1340,7 +1359,12 @@ async function writeCodexAuthSecret(input: {
 
   void propagateProjectSecretsToActiveSandboxes(projectId, { refreshModels: true });
 
-  const views = await loadSecretViewsForUser(projectId, userId, true);
+  const views = await loadSecretViewsForUser({
+    projectId,
+    userId,
+    canManageShared: true,
+    projectMetadata,
+  });
   return views.find((v) => v.identifier === CODEX_AUTH_JSON_SECRET_NAME)
     ?? { identifier: CODEX_AUTH_JSON_SECRET_NAME, name: CODEX_AUTH_JSON_SECRET_NAME };
 }
@@ -1506,6 +1530,7 @@ projectsApp.openapi(
     userId: loaded.userId,
     value: result.authJson,
     sharing,
+    projectMetadata: loaded.row.metadata,
   });
 
   return c.json({
@@ -1825,7 +1850,12 @@ projectsApp.openapi(
 
   void propagateProjectSecretsToActiveSandboxes(projectId, { refreshModels: isGatewayManagedEnv(name) });
 
-  const views = await loadSecretViewsForUser(projectId, loaded.userId, roleAllows(loaded.effectiveRole, 'manage'));
+  const views = await loadSecretViewsForUser({
+    projectId,
+    userId: loaded.userId,
+    canManageShared: roleAllows(loaded.effectiveRole, 'manage'),
+    projectMetadata: loaded.row.metadata,
+  });
   return c.json(views.find((v) => v.name === name) ?? { name }, 200);
 },
 );

--- a/apps/api/src/secrets/network-boundary-availability.test.ts
+++ b/apps/api/src/secrets/network-boundary-availability.test.ts
@@ -1,8 +1,14 @@
 /**
  * The availability gate decides whether the API ADVERTISES network-boundary
- * delivery — save-time validation, delivery_status, and the web control all
+ * delivery — save-time validation, `delivery_status`, and the web control all
  * read it. Getting it wrong in the permissive direction ships a feature that
  * looks available and silently does nothing, so the default is pinned here.
+ *
+ * The shim half is a PER-PROJECT experimental flag rather than an operator env
+ * var. What it really depends on is a sandbox image new enough to run the shim,
+ * which the API cannot introspect — so it is a human decision, and scoping it
+ * per project lets one project opt in and be verified before anything else is
+ * exposed to it.
  */
 import { describe, expect, test } from 'bun:test';
 import { config } from '../config';
@@ -12,58 +18,70 @@ import {
   networkBoundaryShimAvailable,
 } from './network-boundary-availability';
 
-function withConfig<T>(patch: { platinum?: boolean; shim?: boolean }, run: () => T): T {
-  const originalShim = config.EGRESS_SHIM_ENABLED;
-  const originalIsPlatinum = config.isPlatinumEnabled;
+/** Project metadata with the flag explicitly on/off. The override map lives at
+ *  `projects.metadata.experimental` — a stable storage detail. */
+const withShim = (on: boolean) => ({ experimental: { network_boundary_shim: on } });
+const noOverrides = {};
+
+function withPlatinum<T>(enabled: boolean, run: () => T): T {
+  const original = config.isPlatinumEnabled;
   try {
-    if (patch.shim !== undefined) {
-      (config as { EGRESS_SHIM_ENABLED: boolean }).EGRESS_SHIM_ENABLED = patch.shim;
-    }
-    if (patch.platinum !== undefined) {
-      (config as { isPlatinumEnabled: () => boolean }).isPlatinumEnabled = () => patch.platinum!;
-    }
+    (config as { isPlatinumEnabled: () => boolean }).isPlatinumEnabled = () => enabled;
     return run();
   } finally {
-    (config as { EGRESS_SHIM_ENABLED: boolean }).EGRESS_SHIM_ENABLED = originalShim;
-    (config as { isPlatinumEnabled: () => boolean }).isPlatinumEnabled = originalIsPlatinum;
+    (config as { isPlatinumEnabled: () => boolean }).isPlatinumEnabled = original;
   }
 }
 
 describe('network boundary availability', () => {
-  test('the shim is OFF unless an operator turns it on', () => {
-    // Pins the sequencing decision: the API must not advertise boundary
-    // delivery to non-Platinum projects before the guest can perform it.
-    expect(config.EGRESS_SHIM_ENABLED).toBe(false);
+  test('a project that has not opted in gets nothing without Platinum', () => {
+    // The default has to be off: turning it on for a project whose sandbox
+    // image predates the shim means the secret saves and nothing can spend it.
+    withPlatinum(false, () => {
+      expect(networkBoundaryShimAvailable(noOverrides)).toBe(false);
+      expect(networkBoundaryDeliveryAvailable(noOverrides)).toBe(false);
+      expect(networkBoundaryMode('daytona', noOverrides)).toBeNull();
+    });
+  });
+
+  test('absent metadata is treated as not opted in', () => {
+    // Callers that cannot supply the project must not accidentally widen the
+    // gate; an unknown project is a closed one.
+    withPlatinum(false, () => {
+      expect(networkBoundaryShimAvailable(undefined)).toBe(false);
+      expect(networkBoundaryDeliveryAvailable(undefined)).toBe(false);
+    });
   });
 
   test('Platinum alone still satisfies availability, as before', () => {
-    withConfig({ platinum: true, shim: false }, () => {
-      expect(networkBoundaryDeliveryAvailable()).toBe(true);
-      expect(networkBoundaryMode('platinum')).toBe('provider-edge');
+    withPlatinum(true, () => {
+      expect(networkBoundaryDeliveryAvailable(noOverrides)).toBe(true);
+      expect(networkBoundaryMode('platinum', noOverrides)).toBe('provider-edge');
     });
   });
 
-  test('with the shim off and no Platinum, the feature stays unavailable', () => {
-    withConfig({ platinum: false, shim: false }, () => {
-      expect(networkBoundaryDeliveryAvailable()).toBe(false);
-      expect(networkBoundaryShimAvailable()).toBe(false);
-      expect(networkBoundaryMode('daytona')).toBeNull();
+  test('the flag makes it available on a provider with no credential edge', () => {
+    withPlatinum(false, () => {
+      expect(networkBoundaryShimAvailable(withShim(true))).toBe(true);
+      expect(networkBoundaryDeliveryAvailable(withShim(true))).toBe(true);
+      expect(networkBoundaryMode('daytona', withShim(true))).toBe('in-guest-shim');
     });
   });
 
-  test('the shim makes it available on a provider with no credential edge', () => {
-    withConfig({ platinum: false, shim: true }, () => {
-      expect(networkBoundaryDeliveryAvailable()).toBe(true);
-      expect(networkBoundaryMode('daytona')).toBe('in-guest-shim');
+  test('an explicit off is respected even where Platinum exists', () => {
+    withPlatinum(true, () => {
+      expect(networkBoundaryShimAvailable(withShim(false))).toBe(false);
+      // Platinum still covers the project — the flag only governs the shim.
+      expect(networkBoundaryDeliveryAvailable(withShim(false))).toBe(true);
     });
   });
 
-  test('Platinum keeps the provider edge even when the shim is available', () => {
+  test('Platinum keeps the provider edge even when the project has the flag', () => {
     // The edge injects for ANY client; the shim only for requests routed
     // through it. Where both exist the edge is strictly better, so it wins.
-    withConfig({ platinum: true, shim: true }, () => {
-      expect(networkBoundaryMode('platinum')).toBe('provider-edge');
-      expect(networkBoundaryMode('daytona')).toBe('in-guest-shim');
+    withPlatinum(true, () => {
+      expect(networkBoundaryMode('platinum', withShim(true))).toBe('provider-edge');
+      expect(networkBoundaryMode('daytona', withShim(true))).toBe('in-guest-shim');
     });
   });
 });

--- a/apps/api/src/secrets/network-boundary-availability.ts
+++ b/apps/api/src/secrets/network-boundary-availability.ts
@@ -1,46 +1,50 @@
 import { config } from '../config';
+import { resolveFeatureFlag } from '../feature-flags/registry';
 
 /**
- * Can this deployment deliver a network-boundary secret at all?
+ * Can a given project deliver a network-boundary secret?
  *
- * Two independent mechanisms can satisfy it, and a project needs only one:
+ * Two independent mechanisms satisfy it, and a project needs only one:
  *
  *  - **Provider edge (Platinum).** Kortix registers the credential with the
  *    provider and its egress proxy injects on allow-listed hosts. Nothing runs
- *    in the guest.
- *  - **In-guest shim (everything else, notably Daytona).** The shim terminates
- *    the guest's TLS and relays to the broker route, which injects server-side.
- *    The guest still never holds the credential — see
+ *    in the guest, and it applies to every client in the sandbox.
+ *  - **In-guest shim (any other provider, notably Daytona).** The shim
+ *    terminates the guest's TLS and relays to the broker route, which injects
+ *    server-side. The guest still never holds the credential — see
  *    docs/NETWORK_BOUNDARY_ON_DAYTONA.md §7.4.
  *
  * This used to be `config.isPlatinumEnabled()` alone, which is why the feature
  * was unavailable to every production project: production runs on Daytona.
+ *
+ * The shim half is a **per-project experimental flag**, not an operator env
+ * var. Deliberate: the thing it actually depends on is a sandbox image new
+ * enough to run the shim, which the API cannot introspect, so it has to be a
+ * human decision — and a per-project one lets a single project opt in and be
+ * verified before anything else is exposed to it.
  */
-export function networkBoundaryDeliveryAvailable(): boolean {
-  return config.isPlatinumEnabled() || networkBoundaryShimAvailable();
+export function networkBoundaryDeliveryAvailable(projectMetadata?: unknown): boolean {
+  return config.isPlatinumEnabled() || networkBoundaryShimAvailable(projectMetadata);
+}
+
+/** Has this project opted into the in-guest shim path? */
+export function networkBoundaryShimAvailable(projectMetadata?: unknown): boolean {
+  if (projectMetadata === undefined) return false;
+  return resolveFeatureFlag(projectMetadata, 'network_boundary_shim');
 }
 
 /**
- * Is the in-guest shim path available?
+ * Which mechanism a project uses, or null when it has none.
  *
- * Gated so an operator can withdraw it without a code change, and so a
- * deployment whose sandbox image predates the shim does not advertise a
- * delivery mode its guests cannot perform. `optBoolTrue` disables on the
- * literal string `false` only.
+ * The provider edge wins where it exists: it needs nothing in the guest and
+ * injects for any client, whereas the shim only serves requests routed through
+ * it.
  */
-export function networkBoundaryShimAvailable(): boolean {
-  return config.EGRESS_SHIM_ENABLED;
-}
-
-/**
- * Which mechanism a given provider uses.
- *
- * The provider edge is preferred where it exists: it needs nothing in the guest
- * and injects for any client, whereas the shim only serves requests routed
- * through it.
- */
-export function networkBoundaryMode(providerName: string): 'provider-edge' | 'in-guest-shim' | null {
+export function networkBoundaryMode(
+  providerName: string,
+  projectMetadata?: unknown,
+): 'provider-edge' | 'in-guest-shim' | null {
   if (providerName === 'platinum' && config.isPlatinumEnabled()) return 'provider-edge';
-  if (networkBoundaryShimAvailable()) return 'in-guest-shim';
+  if (networkBoundaryShimAvailable(projectMetadata)) return 'in-guest-shim';
   return null;
 }

--- a/apps/web/src/features/workspace/customize/sections/view/secret-delivery.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-delivery.test.ts
@@ -79,6 +79,13 @@ describe('secretDeliveryPresentation', () => {
   });
 });
 
+/** The two fix sentences, pinned once. They are user-facing copy, so the exact
+ *  wording is the assertion — a helper that stopped naming the flag would still
+ *  return a non-empty string. */
+const SHIM_FIX = 'Turn on "Network boundary without Platinum" in Feature flags → Experimental.';
+const PIN_FIX =
+  'This project does not run on Platinum — pin it in Feature flags → Runtime → Sandbox provider, or turn on "Network boundary without Platinum" in Feature flags → Experimental.';
+
 describe('networkBoundaryAvailability', () => {
   test('requires the project itself to run on Platinum', () => {
     expect(
@@ -116,17 +123,55 @@ describe('networkBoundaryAvailability', () => {
     expect(networkBoundaryAvailability(undefined)).toBe('unsupported');
     expect(networkBoundaryAvailability(null)).toBe('unsupported');
   });
+
+  test('the shim flag makes it available on a project with no Platinum at all', () => {
+    // The second mechanism does not run at a provider edge, so the provider the
+    // project is pinned to stops mattering.
+    expect(
+      networkBoundaryAvailability({
+        available_sandbox_providers: ['daytona'],
+        default_sandbox_provider: 'daytona',
+        experimental: { network_boundary_shim: true },
+      }),
+    ).toBe('available');
+    expect(
+      networkBoundaryAvailability({
+        available_sandbox_providers: ['daytona', 'platinum'],
+        default_sandbox_provider: 'daytona',
+        experimental: { network_boundary_shim: true },
+      }),
+    ).toBe('available');
+  });
+
+  test('an off or absent flag leaves the provider verdict untouched', () => {
+    // The flag is opt-in only: it can grant availability, never remove it.
+    expect(
+      networkBoundaryAvailability({
+        available_sandbox_providers: ['daytona'],
+        default_sandbox_provider: 'daytona',
+        experimental: { network_boundary_shim: false },
+      }),
+    ).toBe('unsupported');
+    expect(
+      networkBoundaryAvailability({
+        available_sandbox_providers: ['daytona', 'platinum'],
+        default_sandbox_provider: 'platinum',
+        experimental: { network_boundary_shim: false },
+      }),
+    ).toBe('available');
+  });
 });
 
 describe('networkBoundaryBlockedReason', () => {
-  test('names the exact fix for an unpinned project', () => {
-    expect(networkBoundaryBlockedReason('project_not_pinned')).toBe(
-      'This project does not run on Platinum — pin it in Feature flags → Runtime → Sandbox provider.',
-    );
+  test('names both fixes for an unpinned project', () => {
+    expect(networkBoundaryBlockedReason('project_not_pinned')).toBe(PIN_FIX);
   });
 
-  test('keeps the deployment wording, and says nothing when delivery works', () => {
-    expect(networkBoundaryBlockedReason('unsupported')).toBe('Not available in this deployment.');
+  test('a deployment without Platinum is now fixable, so it says how', () => {
+    // It used to read "Not available in this deployment.", which is no longer
+    // true — the shim needs no Platinum, so the state is an opt-in away.
+    expect(networkBoundaryBlockedReason('unsupported')).toBe(SHIM_FIX);
+    expect(networkBoundaryBlockedReason('unsupported')).not.toContain('Not available');
     expect(networkBoundaryBlockedReason('available')).toBeNull();
   });
 });
@@ -147,15 +192,14 @@ describe('secretDeliveryOptions', () => {
     expect(secretDeliveryOptions('broker', 'available', 'unsupported')[1]?.disabled).toBe(false);
     expect(secretDeliveryOptions('egress', 'available', 'unsupported')[2]).toMatchObject({
       disabled: true,
-      disabledReason: 'Not available in this deployment.',
+      disabledReason: SHIM_FIX,
     });
   });
 
   test('disables network delivery on an unpinned project and states the fix', () => {
     expect(secretDeliveryOptions('runtime', 'available', 'project_not_pinned')[2]).toMatchObject({
       disabled: true,
-      disabledReason:
-        'This project does not run on Platinum — pin it in Feature flags → Runtime → Sandbox provider.',
+      disabledReason: PIN_FIX,
     });
   });
 

--- a/apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts
@@ -135,28 +135,46 @@ export function secretDeliveryPresentation(
 export type NetworkBoundaryAvailability = 'available' | 'project_not_pinned' | 'unsupported';
 
 /**
- * Network-boundary delivery is injected by the Platinum provider itself, so the
- * PROJECT has to run on Platinum. A deployment that merely offers Platinum is
- * not enough: on any other provider nothing injects the header and the secret
- * is silently dead.
+ * Two independent mechanisms deliver a network-boundary secret, and a project
+ * needs only one.
+ *
+ * The original one is the **Platinum provider edge**, which is why this used to
+ * be a Platinum check. A deployment that merely offers Platinum was never
+ * enough: on any other provider nothing injects the header and the secret is
+ * silently dead.
+ *
+ * The second is the **in-guest shim**, a per-project experimental flag. It works
+ * on any provider, so it short-circuits the provider question entirely. It is a
+ * deliberate opt-in — it also needs a sandbox image new enough to run the shim,
+ * which nothing here can verify.
  */
 export function networkBoundaryAvailability(
   project?: {
     available_sandbox_providers?: readonly string[] | null;
     default_sandbox_provider?: string | null;
+    experimental?: Partial<Record<string, boolean>> | null;
   } | null,
 ): NetworkBoundaryAvailability {
+  if (project?.experimental?.network_boundary_shim) return 'available';
   if (!project?.available_sandbox_providers?.includes('platinum')) return 'unsupported';
   return project.default_sandbox_provider === 'platinum' ? 'available' : 'project_not_pinned';
 }
 
-/** Why network-boundary delivery cannot run here, and how to fix it. */
+/** The flag's name in Feature flags → Experimental, quoted so the sentence below
+ *  points at something the user can actually find. */
+const SHIM_FLAG = 'Network boundary without Platinum';
+
+/** Why network-boundary delivery cannot run here, and how to fix it. Both
+ *  states are now fixable, so neither says "not available" — the shim flag is
+ *  an escape hatch from either one. */
 export function networkBoundaryBlockedReason(
   availability: NetworkBoundaryAvailability,
 ): string | null {
   if (availability === 'available') return null;
-  if (availability === 'unsupported') return 'Not available in this deployment.';
-  return 'This project does not run on Platinum — pin it in Feature flags → Runtime → Sandbox provider.';
+  if (availability === 'unsupported') {
+    return `Turn on "${SHIM_FLAG}" in Feature flags → Experimental.`;
+  }
+  return `This project does not run on Platinum — pin it in Feature flags → Runtime → Sandbox provider, or turn on "${SHIM_FLAG}" in Feature flags → Experimental.`;
 }
 
 export type SecretDeliveryOption = SecretDeliveryPresentation & {

--- a/apps/web/src/lib/use-project-feature-flags.ts
+++ b/apps/web/src/lib/use-project-feature-flags.ts
@@ -34,6 +34,7 @@ export function useProjectFeatureFlags(projectId: string | null | undefined): {
   const metaAgent = useFeatureFlag(projectId, 'meta_agent');
   const apps = useFeatureFlag(projectId, 'apps');
   const monitors = useFeatureFlag(projectId, 'monitors');
+  const networkBoundaryShim = useFeatureFlag(projectId, 'network_boundary_shim');
 
   return {
     flags: {
@@ -48,7 +49,8 @@ export function useProjectFeatureFlags(projectId: string | null | undefined): {
       meta_agent: metaAgent.enabled,
       apps: apps.enabled,
       monitors: monitors.enabled,
+      network_boundary_shim: networkBoundaryShim.enabled,
     },
-    isLoading: monitors.isLoading,
+    isLoading: networkBoundaryShim.isLoading,
   };
 }

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -521,7 +521,7 @@ Caveats, stated rather than implied:
 
 ### 7.5 Wiring — what is done, what is left
 
-#### Done: the server half (behind `EGRESS_SHIM_ENABLED`, default OFF)
+#### Done: the server half (behind the `network_boundary_shim` project flag, default OFF)
 
 Three gates stood between a non-Platinum project and this feature.
 
@@ -541,11 +541,20 @@ Three gates stood between a non-Platinum project and this feature.
    the pre-check guaranteed the method existed — with a shim-backed provider reaching it, that
    would have been a TypeError at provision time instead of a clean skip.
 
-**The flag defaults OFF deliberately.** Turning it on makes the API *advertise* boundary
-delivery to non-Platinum projects — the save gate, `delivery_status`, and the web control all
-read it. Until the guest actually runs the shim, that is a feature that looks available and
-silently does nothing, which is the failure this whole document exists to unpick. Flip it once
-a fresh sandbox has been *observed* running the shim, not merely once the code is merged.
+**It is a per-project experimental flag, not an operator env var.** The first version was
+`EGRESS_SHIM_ENABLED`, an env var, which was wrong twice over. It made the smallest testable
+unit the whole deployment, and it put the switch in the infrastructure repo — so verifying the
+feature on dev required a GitOps change before anyone could see whether it worked at all. The
+registry entry (`feature-flags/registry.ts`, `stability: 'experimental'`) is toggled through
+the existing Feature flags UI and `PATCH /projects/:id/experimental`, so one project can opt in
+and be proven before anything else is exposed to it.
+
+**It still defaults OFF deliberately.** Turning it on makes the API *advertise* boundary
+delivery — the save gate, `delivery_status`, and the web control all read it. Until the guest
+actually runs the shim, that is a feature that looks available and silently does nothing, which
+is the failure this whole document exists to unpick. What the flag really asserts is "this
+project's sandbox image runs the shim", a fact the API cannot introspect. Turn it on once a
+fresh sandbox has been *observed* running the shim, not merely once the code is merged.
 
 #### Left: the guest half
 
@@ -555,15 +564,21 @@ a fresh sandbox has been *observed* running the shim, not merely once the code i
 2. **Trust the CA.** Install the ephemeral CA into the system store *and* the per-runtime env
    vars. §7.6 measured which ones actually matter.
 3. **Point the clients.** `HTTPS_PROXY` plus `NODE_USE_ENV_PROXY=1` and `REQUESTS_CA_BUNDLE`.
-4. **The web gate.** `apps/web/.../secret-delivery.ts` requires the project to run Platinum and
-   does **not** read `network_boundary_available`. That is correct while the flag is off, and
-   wrong the moment it flips — the API has to expose which mode applies
-   (`provider-edge` vs `in-guest-shim`) and the web has to read it. Belongs with this half,
-   not before it.
-5. **Optional: the allow-list.** Not required for the security property — an agent that
+4. **Optional: the allow-list.** Not required for the security property — an agent that
    bypasses the shim gets an *unauthenticated* request, not a credential — so it is egress
    restriction, a separate feature. It also needs a stable Kortix egress address, which
    `dev-api` (Cloudflare-fronted) does not provide.
+
+The web gate moved into the *done* half along with the flag. `networkBoundaryAvailability`
+(`apps/web/.../secret-delivery.ts`) reads `project.experimental.network_boundary_shim` and
+short-circuits the provider question when it is on, because the shim runs nowhere near a
+provider edge. Both blocked-state messages now name the flag: neither state says "not available
+in this deployment" any more, because neither is true — both are one opt-in away.
+
+`buildSecretView` takes the project metadata through an OPTIONAL argument, which is a trap
+worth naming: a caller that omits it still typechecks and silently reports the pre-flag
+Platinum-only answer. `loadSecretViewsForUser` therefore looks the metadata up itself rather
+than making five routes remember to pass it — only two of them have the project row in scope.
 
 #### Blocked on infrastructure, not code
 

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -116,6 +116,7 @@ function projectFixture(overrides: Record<string, unknown> = {}) {
       meta_agent: false,
       apps: false,
       monitors: false,
+      network_boundary_shim: false,
     },
     experimental_features: [],
     default_sandbox_provider: null,
@@ -662,6 +663,7 @@ describe('envelopes', () => {
       'meta_agent',
       'apps',
       'monitors',
+      'network_boundary_shim',
     ]);
   });
 

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -61,6 +61,7 @@ export const FeatureFlagMapSchema = z.object({
   meta_agent: z.boolean(),
   apps: z.boolean(),
   monitors: z.boolean(),
+  network_boundary_shim: z.boolean(),
 });
 export type FeatureFlagMap = z.infer<typeof FeatureFlagMapSchema>;
 

--- a/packages/sdk/src/core/rest/projects-client/projects.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/projects.test.ts
@@ -935,6 +935,7 @@ test('FEATURE_FLAG_KEYS lists every flag key exactly once', () => {
     'marketplace',
     'meta_agent',
     'monitors',
+    'network_boundary_shim',
     'review_center',
     'teams',
     'voice',

--- a/packages/sdk/src/core/rest/projects-client/projects.ts
+++ b/packages/sdk/src/core/rest/projects-client/projects.ts
@@ -33,7 +33,8 @@ export type FeatureFlagKey =
   | 'review_center'
   | 'meta_agent'
   | 'apps'
-  | 'monitors';
+  | 'monitors'
+  | 'network_boundary_shim';
 
 /**
  * Every {@link FeatureFlagKey}, at runtime. Kept in the same order as the
@@ -52,6 +53,7 @@ export const FEATURE_FLAG_KEYS: readonly FeatureFlagKey[] = [
   'meta_agent',
   'apps',
   'monitors',
+  'network_boundary_shim',
 ] as const;
 
 /**


### PR DESCRIPTION
## What

Replaces the operator env var `EGRESS_SHIM_ENABLED` with `network_boundary_shim`, an **experimental per-project feature flag**.

`EGRESS_SHIM_ENABLED` was wrong twice over. It made the smallest testable unit the whole deployment, and it put the switch in the infrastructure repo — so proving the feature on dev needed a GitOps change before anyone could see whether it worked at all. The new flag rides the existing registry, the Feature flags UI, and `PATCH /projects/:id/experimental`, so one project opts in and gets verified before anything else is exposed to it.

## Two silent gaps closed, neither of which tsc can see

1. **`serializers.ts` called `networkBoundaryDeliveryAvailable()` with no argument.** The parameter is optional, so it typechecked and quietly kept the old Platinum-only answer for `delivery_status` and `network_boundary_available` — the two fields the web control and the CLI read. `loadSecretViewsForUser` now resolves the metadata itself rather than asking five routes to remember it; only two of them have the project row in scope.
2. **The web gate still required the project to run Platinum.** The shim runs nowhere near a provider edge, so the flag short-circuits the provider question entirely. Neither blocked state says "not available in this deployment" any more, because neither is true — both are one opt-in away.

## Still OFF by default

What the flag really asserts is "this project's sandbox image runs the shim", which the API cannot introspect. The guest half is not built yet; turning it on before that ships a mode that looks available and does nothing — the exact failure this feature exists to remove. The registry description says so.

## Verification

| Suite | Result |
| --- | --- |
| `apps/api` `tsc --noEmit` | clean |
| `packages/sdk` `tsc --noEmit` | clean |
| api: feature-flag drift + `src/feature-flags/` + `src/secrets/` + serializers | **168 pass, 0 fail** |
| web: `customize/sections/view/` | **136 pass, 5 fail** — baseline on `origin/main` is 134/5, so +2 (the new tests), no new failures |
| `packages/sdk` (full) | **1485 pass, 418 fail** — byte-identical to the `origin/main` baseline |

The SDK's 418 failures are the pre-existing cross-file `mock.module` leak, measured on unmodified `origin/main` in the same worktree, not introduced here.

One real regression was caught this way and fixed: `projects.test.ts` keeps its own hand-written copy of the key list (a third drift guard, separate from `unit-feature-flag-drift.test.ts`). It went 1485/418 → 1484/419 until the key was added there too.

### New tests

- `network-boundary-availability.test.ts` — rewritten, 6 tests: default-closed, absent metadata treated as opted-out, Platinum still sufficient, the flag working with no Platinum, explicit-off respected, and the provider edge winning where both exist.
- `serializers.test.ts` — 3 tests pinning that the metadata actually reaches `network_boundary_available`/`delivery_status`, and that an omitted or explicitly-off project cannot widen the gate. These exist specifically because the optional argument makes the regression invisible to tsc.
- `secret-delivery.test.ts` — 2 tests for the web gate, plus the two fix sentences pinned as exact user-facing copy.