### PR TITLE
fix(secrets): close the audit findings against the boundary-shim flag

### DIFF
--- a/apps/api/src/feature-flags/registry.ts
+++ b/apps/api/src/feature-flags/registry.ts
@@ -268,12 +268,18 @@ const FLAGS: readonly FeatureFlagDef[] = [
     // whole feature exists to remove.
     platformDefault: () => false,
     enforcement: 'behavioral',
+    // Exactly two effects. An earlier version of this note also claimed the
+    // flag governs whether the broker route serves egress/network secrets — it
+    // does not. That route accepts them unconditionally and holds no reference
+    // to any flag; it was widened separately. Overstating what a flag governs
+    // is how someone later flips it expecting the wrong thing to change.
     enforcementNote:
       'On ⇒ networkBoundaryDeliveryAvailable() accepts this project without ' +
-      'Platinum, provisioning stops treating a missing provider edge as fatal, ' +
-      'and the broker route serves egress/network secrets (secrets/' +
-      'network-boundary-availability.ts, projects/lib/sandbox-env-sync.ts, ' +
-      'platform/services/session-sandbox.ts).',
+      'Platinum, and provisioning stops treating a missing provider edge as ' +
+      'fatal (secrets/network-boundary-availability.ts, projects/lib/' +
+      'sandbox-env-sync.ts, platform/services/session-sandbox.ts). ' +
+      'OFF again with a boundary secret still saved ⇒ new sessions fail to ' +
+      'provision until the secret changes delivery.',
   },
 ];
 

--- a/apps/api/src/platform/services/sandbox-provisioning-error.remedy.test.ts
+++ b/apps/api/src/platform/services/sandbox-provisioning-error.remedy.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The remedy sentence a user sees when a session cannot provision because the
+ * provider has no credential edge.
+ *
+ * It is pinned because it went stale silently once. It read "Select Platinum or
+ * change the secret delivery policy" — written when Platinum was the only
+ * mechanism. On a deployment that ships no Platinum that left the reader one
+ * impossible option and one destructive one, and it never learned about the
+ * `network_boundary_shim` flag that is now the cheapest fix. Nothing failed;
+ * the sentence was simply wrong for anyone who read it.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  UNSUPPORTED_SECRET_DELIVERY_MESSAGE,
+  classifySandboxProvisioningFailure,
+} from './sandbox-provisioning-error';
+
+describe('the unsupported-delivery remedy names every way out', () => {
+  test('it offers the flag, Platinum, and changing the policy', () => {
+    expect(UNSUPPORTED_SECRET_DELIVERY_MESSAGE).toContain('Network boundary without Platinum');
+    expect(UNSUPPORTED_SECRET_DELIVERY_MESSAGE).toContain('Platinum');
+    expect(UNSUPPORTED_SECRET_DELIVERY_MESSAGE).toContain('delivery policy');
+  });
+
+  test('it does not present Platinum as the only option', () => {
+    // The exact old sentence. A deployment without Platinum cannot act on it.
+    expect(UNSUPPORTED_SECRET_DELIVERY_MESSAGE).not.toContain(
+      'Select Platinum or change the secret delivery policy',
+    );
+  });
+
+  test('the raw provisioning throw is what maps to it', () => {
+    // The classifier is the ONLY reason the raw string never reaches a client,
+    // which is what makes the message above the thing users actually read — a
+    // dev-verification script grepping for the raw throw found nothing.
+    const failure = classifySandboxProvisioningFailure(
+      new Error('Sandbox provider daytona does not support network-boundary secret delivery'),
+    );
+    expect(failure.category).toBe('unsupported-secret-delivery');
+    expect(failure.userMessage).toBe(UNSUPPORTED_SECRET_DELIVERY_MESSAGE);
+  });
+});

--- a/apps/api/src/platform/services/sandbox-provisioning-error.test.ts
+++ b/apps/api/src/platform/services/sandbox-provisioning-error.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import { networkBoundaryPolicyError } from '../../secrets/network-boundary';
 import {
+  UNSUPPORTED_SECRET_DELIVERY_MESSAGE,
   INVALID_SECRET_BOUNDARY_POLICY_MESSAGE,
   SANDBOX_PROVIDER_CAPACITY_MESSAGE,
   SANDBOX_PROVIDER_FAILURE_MESSAGE,
@@ -52,10 +53,14 @@ describe('classifySandboxProvisioningFailure', () => {
       new Error('Sandbox provider daytona does not support network-boundary secret delivery'),
     );
 
+    // Compared against the CONSTANT, not a second copy of the sentence. The
+    // literal used to be duplicated here, so editing the user-facing copy broke
+    // this test for no reason a reader could see — and a grep for the constant's
+    // name did not find this file. The wording itself is asserted in
+    // sandbox-provisioning-error.remedy.test.ts, which is where it belongs.
     expect(result).toEqual({
       category: 'unsupported-secret-delivery',
-      userMessage:
-        'This sandbox provider cannot enforce network-boundary secret delivery. Select Platinum or change the secret delivery policy.',
+      userMessage: UNSUPPORTED_SECRET_DELIVERY_MESSAGE,
       isCapacity: false,
       isGitAuth: false,
     });

--- a/apps/api/src/platform/services/sandbox-provisioning-error.ts
+++ b/apps/api/src/platform/services/sandbox-provisioning-error.ts
@@ -18,8 +18,14 @@ export const SANDBOX_PROVIDER_CAPACITY_MESSAGE =
 export const SANDBOX_PROVIDER_FAILURE_MESSAGE =
   'The sandbox provider could not start this session. Try again.';
 
+// Names all THREE remedies. It used to say "Select Platinum or change the
+// secret delivery policy", which on a deployment that ships no Platinum left
+// the reader with one impossible option and one destructive one — and it
+// predates the flag that is now the cheapest fix.
 export const UNSUPPORTED_SECRET_DELIVERY_MESSAGE =
-  'This sandbox provider cannot enforce network-boundary secret delivery. Select Platinum or change the secret delivery policy.';
+  'This sandbox provider cannot enforce network-boundary secret delivery. ' +
+  'Turn on "Network boundary without Platinum" in Feature flags → Experimental, ' +
+  'or run the project on Platinum, or change the secret delivery policy.';
 
 export const INVALID_SECRET_BOUNDARY_POLICY_MESSAGE =
   "A network-boundary secret in this project has an invalid outbound policy, so no session can start. " +

--- a/apps/api/src/secrets/network-boundary-availability.ts
+++ b/apps/api/src/secrets/network-boundary-availability.ts
@@ -23,12 +23,21 @@ import { resolveFeatureFlag } from '../feature-flags/registry';
  * human decision — and a per-project one lets a single project opt in and be
  * verified before anything else is exposed to it.
  */
-export function networkBoundaryDeliveryAvailable(projectMetadata?: unknown): boolean {
+export function networkBoundaryDeliveryAvailable(projectMetadata: unknown): boolean {
   return config.isPlatinumEnabled() || networkBoundaryShimAvailable(projectMetadata);
 }
 
-/** Has this project opted into the in-guest shim path? */
-export function networkBoundaryShimAvailable(projectMetadata?: unknown): boolean {
+/**
+ * Has this project opted into the in-guest shim path?
+ *
+ * The parameter is REQUIRED on all three functions here. It was optional, which
+ * made `networkBoundaryDeliveryAvailable()` — no argument — compile and quietly
+ * return the pre-flag Platinum-only verdict. `buildSecretView` was hardened
+ * against exactly that and this gate was not, so the compile-time guarantee
+ * stopped one call short of the thing it guards. A caller with no project must
+ * now write `undefined` and mean it.
+ */
+export function networkBoundaryShimAvailable(projectMetadata: unknown): boolean {
   if (projectMetadata === undefined) return false;
   return resolveFeatureFlag(projectMetadata, 'network_boundary_shim');
 }
@@ -42,7 +51,7 @@ export function networkBoundaryShimAvailable(projectMetadata?: unknown): boolean
  */
 export function networkBoundaryMode(
   providerName: string,
-  projectMetadata?: unknown,
+  projectMetadata: unknown,
 ): 'provider-edge' | 'in-guest-shim' | null {
   if (providerName === 'platinum' && config.isPlatinumEnabled()) return 'provider-edge';
   if (networkBoundaryShimAvailable(projectMetadata)) return 'in-guest-shim';

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -1193,7 +1193,7 @@ function SecretDialog({
                   <div className="space-y-1">
                     <p className="text-sm font-medium">Network boundary</p>
                     <p className="text-muted-foreground text-xs text-pretty">
-                      Platinum adds this value to matching HTTPS requests outside the sandbox.
+                      Kortix adds this value to matching HTTPS requests outside the sandbox.
                     </p>
                   </div>
 
@@ -1256,7 +1256,7 @@ function SecretDialog({
                       disabled={save.isPending}
                     />
                     <FieldDescription>
-                      Platinum replaces this header only for the allowed hosts.
+                      Kortix replaces this header only for the allowed hosts.
                     </FieldDescription>
                   </Field>
 
@@ -1273,7 +1273,7 @@ function SecretDialog({
                       disabled={save.isPending}
                     />
                     <FieldDescription>
-                      Optional. Include {'{{secret}}'} where Platinum inserts the value. Leave it
+                      Optional. Include {'{{secret}}'} where Kortix inserts the value. Leave it
                       blank and the header carries the bare value with no scheme, which most APIs
                       reject with 401.
                     </FieldDescription>

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -575,10 +575,21 @@ short-circuits the provider question when it is on, because the shim runs nowher
 provider edge. Both blocked-state messages now name the flag: neither state says "not available
 in this deployment" any more, because neither is true — both are one opt-in away.
 
-`buildSecretView` takes the project metadata through an OPTIONAL argument, which is a trap
-worth naming: a caller that omits it still typechecks and silently reports the pre-flag
-Platinum-only answer. `loadSecretViewsForUser` therefore looks the metadata up itself rather
-than making five routes remember to pass it — only two of them have the project row in scope.
+`buildSecretView` takes the project metadata through a REQUIRED argument, and so do the three
+functions in `network-boundary-availability.ts`. That is the second answer to this problem; the
+first two were both wrong and are worth recording, because the failure mode is invisible.
+
+An OPTIONAL argument was the original. It let a caller omit the project and still typecheck,
+silently reporting the pre-flag Platinum-only answer — a wrong feature verdict that no test
+happened to look at. The second attempt had `loadSecretViewsForUser` read
+`projects.metadata` itself so no route had to remember. That hid a DB read inside a serializer
+and broke 22 route tests whose mock whitelists the tables it will serve; the mock was right.
+
+Required is the answer: tsc names every caller, and all five have the project row in scope. One
+caveat found the hard way — a required POSITIONAL parameter is not enough. The type is
+`unknown`, so it accepts anything, and a call site that had been passing `agentGrants` in that
+slot compiled while feeding the grants config in as the project metadata. The signature is
+named options for that reason.
 
 #### Blocked on infrastructure, not code
 

--- a/docs/SECRET_DELIVERY_CONTROL_PLANE.md
+++ b/docs/SECRET_DELIVERY_CONTROL_PLANE.md
@@ -233,16 +233,24 @@ All three must hold. Each one used to fail silently.
 
 | # | Requirement | Where it is set | Result when wrong |
 | --- | --- | --- | --- |
-| 1 | The session runs on Platinum | Customize -> Feature flags -> Sandbox provider | No binding is attached. The request leaves without the header. |
+| 1 | The session runs on Platinum, OR the project has the `network_boundary_shim` flag | Customize -> Feature flags (Sandbox provider, or Experimental -> "Network boundary without Platinum") | No binding is attached. The request leaves without the header. |
 | 2 | An agent `secrets:` list NAMES the identifier | `kortix.yaml`, by hand or through the grant route below | `resolveSecretDelivery` withholds the row. No binding. |
 | 3 | The header value template renders what the API expects | Secret editor -> Header value template | The header carries the bare value with no scheme. Upstream returns `401`. |
 
-Requirement 1 is project scope, not deployment scope.
-`networkBoundaryDeliveryAvailable()` reports only that the deployment enables
-Platinum. The web editor therefore gates the option on
+Requirement 1 is project scope, not deployment scope, and it is satisfied two
+independent ways. `networkBoundaryDeliveryAvailable(projectMetadata)` returns
+true when the DEPLOYMENT enables Platinum, or when the PROJECT has the
+`network_boundary_shim` experimental flag — the in-guest shim path, which needs
+no provider edge and so no particular provider. The web editor mirrors that in
 `networkBoundaryAvailability(project)`
-(`apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts`),
-which requires `default_sandbox_provider === 'platinum'`.
+(`apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts`):
+the flag short-circuits the provider question, and without it the old rule still
+applies (`default_sandbox_provider === 'platinum'`).
+
+This paragraph previously said the availability check "reports only that the
+deployment enables Platinum" and that the web editor "requires
+`default_sandbox_provider === 'platinum'`". Both were true before the flag
+existed. See docs/NETWORK_BOUNDARY_ON_DAYTONA.md §7.5.
 
 Requirement 2 is stricter than every other strategy. `resolveSecretDelivery`
 (`apps/api/src/secrets/strategy.ts`) delivers a non-`runtime` row only when


### PR DESCRIPTION
Follow-up to #6428. An adversarial multi-lens audit of that PR raised 23 findings; 6 survived refutation, and I verified each against the code before acting. Five are fixed here.

**Every one is a place where something *says* the wrong thing rather than *does*** — which is exactly why CI was green through all of it.

| # | Where | What was wrong |
| --- | --- | --- |
| 1 | `sandbox-provisioning-error.ts` | The message users actually read on a failed provision said *"Select Platinum or change the secret delivery policy"* — on a deployment shipping no Platinum, one impossible option and one destructive one. It predates the flag that is now the cheapest fix. |
| 2 | `registry.ts` | My own `enforcementNote` claimed the flag governs the broker route. It does not — that route holds no flag reference and was widened separately. |
| 3 | `network-boundary-availability.ts` | All three gate functions kept `projectMetadata` **optional**, so a no-argument call compiled and silently returned the pre-flag Platinum-only verdict. `buildSecretView` was hardened against exactly this; the gate it calls was not. |
| 4 | `secrets-view.tsx` | The panel said *"Platinum adds this value…"*. This flag makes that panel reachable where Platinum is not involved at all. |
| 5 | two docs | `NETWORK_BOUNDARY_ON_DAYTONA.md` §7.5 described the design a **later commit in the same PR** replaced — it stated the opposite of the code it shipped beside. Four independent audit lenses flagged it. `SECRET_DELIVERY_CONTROL_PLANE.md` still said availability "reports only that the deployment enables Platinum". |

### Deliberately not fixed here

Turning the flag back **off** on a project that still holds a boundary secret makes every new session fail to provision, with no warning at toggle time. Two lenses confirmed it. It is real, but the remedy is a design decision — validate at toggle time, or degrade the secret's delivery — and I would rather it be chosen than rushed. The `enforcementNote` now states the consequence out loud so it is not invisible.

### Verification

- `apps/api` — **128 pass / 0 fail** across `src/secrets/` + `src/feature-flags/` + the new remedy test
- `apps/api` `tsc --noEmit` — clean
- Making the gate parameters required changed **no** call site; tsc confirms they all already passed it

### New test

`sandbox-provisioning-error.remedy.test.ts` pins the remedy sentence, including that it no longer presents Platinum as the only way out. It also pins that the raw provisioning throw maps to that message — the fact that the raw string never reaches a client is what made a dev-verification script grepping for it find nothing.