### PR TITLE
feat(models): add managed DeepSeek V4 Pro 0813

### DIFF
--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -66,6 +66,23 @@ describe('gatewayModelCatalog — served catalog', () => {
     });
   });
 
+  test('serves DeepSeek V4 Pro 0813 with its real capabilities and prices', () => {
+    expect(full['deepseek-v4-pro-0813']).toMatchObject({
+      name: 'DeepSeek V4 Pro 0813',
+      provider: 'kortix',
+      reasoning: true,
+      reasoning_options: [
+        { type: 'toggle' },
+        { type: 'effort', values: ['low', 'high', 'max'] },
+      ],
+      tool_call: true,
+      attachment: false,
+      temperature: true,
+      limit: { context: 1_048_575, output: 384_000 },
+      cost: { input: 1.74, output: 3.48, cache_read: 0.145 },
+    });
+  });
+
   test('every served model carries a positive context limit', () => {
     const missing = Object.entries(full)
       .filter(([, m]) => !(typeof m.limit?.context === 'number' && m.limit.context > 0))

--- a/apps/api/src/llm-gateway/resolution/descriptors.test.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.test.ts
@@ -265,3 +265,41 @@ describe('managed Grok 4.6 descriptor', () => {
     })]);
   });
 });
+
+describe('managed DeepSeek V4 Pro 0813 descriptor', () => {
+  test('routes DeepSeek V4 Pro 0813 through the reachable GMICloud endpoint', () => {
+    expect(managedCandidates({
+      id: 'deepseek-v4-pro-0813',
+      name: 'DeepSeek V4 Pro 0813',
+      upstreamModelId: 'deepseek/deepseek-v4-pro-0813',
+      transport: 'openrouter',
+      pricingRef: 'openrouter/deepseek/deepseek-v4-pro-0813',
+      pricing: {
+        inputPerMillion: 1.74,
+        cachedInputPerMillion: 0.145,
+        outputPerMillion: 3.48,
+      },
+      tier: 'balanced',
+      vision: false,
+      limit: { context: 1_048_575, output: 384_000 },
+      openrouterProvider: {
+        order: ['gmicloud'],
+        allow_fallbacks: true,
+      },
+    })).toEqual([expect.objectContaining({
+      provider: 'openrouter',
+      resolvedModel: 'deepseek/deepseek-v4-pro-0813',
+      pricing: expect.objectContaining({
+        inputPerMillion: 1.74,
+        cachedInputPerMillion: 0.145,
+        outputPerMillion: 3.48,
+      }),
+      bodyExtras: {
+        provider: {
+          order: ['gmicloud'],
+          allow_fallbacks: true,
+        },
+      },
+    })]);
+  });
+});

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -865,6 +865,21 @@ export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
     temperature: true,
     limit: { context: 1_048_576, output: 64_000 },
   },
+  'deepseek-v4-pro-0813': {
+    name: 'DeepSeek V4 Pro 0813',
+    provider: 'kortix',
+    reasoning: true,
+    reasoning_options: [
+      { type: 'toggle' },
+      { type: 'effort', values: ['low', 'high', 'max'] },
+    ],
+    tool_call: true,
+    attachment: false,
+    structured_output: false,
+    temperature: true,
+    limit: { context: 1_048_575, output: 384_000 },
+    cost: { input: 1.74, output: 3.48, cache_read: 0.145 },
+  },
   'glm-5.2': {
     name: 'GLM 5.2',
     provider: 'kortix',

--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -17,7 +17,7 @@ toggle it in Customize → Feature flags.
 
 A model id has one of three shapes:
 
-- **Managed** — a bare id, like `grok-4.6` or `deepseek-v4-flash`. Kortix
+- **Managed** — a bare id, like `grok-4.6` or `deepseek-v4-pro-0813`. Kortix
   supplies the credentials. Cloud accounts pay with Kortix credits.
 - **BYOK** — a `provider/model` id, like `anthropic/claude-opus-4-8`. You
   supply the key. Your provider account pays.

--- a/packages/llm-catalog/src/catalog.generated.json
+++ b/packages/llm-catalog/src/catalog.generated.json
@@ -145681,6 +145681,50 @@
           }
         },
         {
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "name": "DeepSeek V4 Pro 0813",
+          "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
+          "released": "2026-08-12",
+          "attachment": false,
+          "reasoning": true,
+          "reasoning_options": [
+            {
+              "type": "toggle"
+            },
+            {
+              "type": "effort",
+              "values": [
+                "low",
+                "high",
+                "max"
+              ]
+            }
+          ],
+          "tool_call": true,
+          "structured_output": false,
+          "open_weights": false,
+          "temperature": true,
+          "last_updated": "2026-08-12",
+          "family": "deepseek-thinking",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 384000
+          },
+          "cost": {
+            "input": 0.435,
+            "output": 0.87,
+            "cache_read": 0.003625
+          }
+        },
+        {
           "id": "inclusionai/ling-2.6-1t",
           "name": "Ling-2.6-1T",
           "description": "Tool-capable chat model for instruction following and agentic application workflows",

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -687,6 +687,34 @@ export const MANAGED_MODELS: ManagedModel[] = [
     },
   },
   {
+    // DeepSeek V4 Pro's 2026-08-13 GA snapshot through OpenRouter. The
+    // immutable upstream slug prevents a future `latest` alias from changing
+    // behavior without a catalog review. OpenRouter currently exposes two
+    // endpoints: first-party DeepSeek at $0.435/$0.87 per million tokens, and
+    // GMICloud at exactly 4x that price. The Kortix OpenRouter account cannot
+    // use the first-party endpoint under its current data policy (live canary:
+    // HTTP 404 `No endpoints available matching your guardrail restrictions
+    // and data policy`). Pin GMICloud and bill its actual price. Do not add the
+    // first-party endpoint without changing both the account policy and price.
+    id: 'deepseek-v4-pro-0813',
+    name: 'DeepSeek V4 Pro 0813',
+    upstreamModelId: 'deepseek/deepseek-v4-pro-0813',
+    transport: 'openrouter',
+    pricingRef: 'openrouter/deepseek/deepseek-v4-pro-0813',
+    pricing: {
+      inputPerMillion: 1.74,
+      cachedInputPerMillion: 0.145,
+      outputPerMillion: 3.48,
+    },
+    tier: 'balanced',
+    vision: false,
+    limit: { context: 1_048_575, output: 384_000 },
+    openrouterProvider: {
+      order: ['gmicloud'],
+      allow_fallbacks: true,
+    },
+  },
+  {
     // Meta's Muse Spark 1.2 via OpenRouter. Exactly ONE endpoint serves the
     // standard slug (Meta first-party: 1_048_576 ctx, tools, 100% 30m uptime
     // measured 2026-08-10), so the pin is trivial. NEVER switch this to the

--- a/packages/llm-catalog/src/managed.test.ts
+++ b/packages/llm-catalog/src/managed.test.ts
@@ -18,6 +18,7 @@ describe('managed catalog', () => {
       'grok-4.6',
       'glm-5.2',
       'deepseek-v4-flash',
+      'deepseek-v4-pro-0813',
       'muse-spark-1.2',
       'minimax-m3',
       'gpt-5.6-luna',
@@ -160,6 +161,24 @@ describe('managed resolution + back-compat aliases', () => {
         cachedInputPerMillion: 1,
         outputPerMillion: 12,
         contextThreshold: 200_000,
+      },
+    });
+    expect(getManagedModel('deepseek-v4-pro-0813')).toMatchObject({
+      name: 'DeepSeek V4 Pro 0813',
+      upstreamModelId: 'deepseek/deepseek-v4-pro-0813',
+      transport: 'openrouter',
+      pricingRef: 'openrouter/deepseek/deepseek-v4-pro-0813',
+      pricing: {
+        inputPerMillion: 1.74,
+        cachedInputPerMillion: 0.145,
+        outputPerMillion: 3.48,
+      },
+      tier: 'balanced',
+      vision: false,
+      limit: { context: 1_048_575, output: 384_000 },
+      openrouterProvider: {
+        order: ['gmicloud'],
+        allow_fallbacks: true,
       },
     });
   });

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,19 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-13 — session `latest-managed-models`
+
+No public SDK API changes. The playground's compile-time `MODEL_IDS` union now
+matches `@kortix/llm-catalog` after adding managed `deepseek-v4-pro-0813`. The
+package version is unchanged.
+
+Verification: SDK typecheck exits `0`; SDK tests report `1901 pass`, `2 skip`,
+`0 fail`, and `7244` assertions across `145` files; packed-install smoke passes.
+The managed model also passed the local catalog, inference, usage-log, and
+generation-record canary through the API.
+
+**Status:** COMPLETE. SDK package shippable to production: YES.
+
 ### 2026-08-13 — session `grok-4-6-managed`
 
 No public SDK API changes. The playground's compile-time `MODEL_IDS` union now

--- a/packages/sdk/playground/chat/14-change-default-model.ts
+++ b/packages/sdk/playground/chat/14-change-default-model.ts
@@ -29,6 +29,7 @@ const MODEL_IDS = [
   "grok-4.6",
   "glm-5.2",
   "deepseek-v4-flash",
+  "deepseek-v4-pro-0813",
   "muse-spark-1.2",
   "minimax-m3",
   "gpt-5.6-luna",


### PR DESCRIPTION
## Summary

- add `deepseek-v4-pro-0813` as a Kortix-managed reasoning model
- route the immutable `deepseek/deepseek-v4-pro-0813` upstream through OpenRouter and GMICloud
- expose the model in the catalog, docs, sandbox defaults, and SDK playground
- add catalog and gateway descriptor coverage

## Provider decision

OpenRouter advertises a lower-cost DeepSeek first-party endpoint. The Kortix OpenRouter account rejects it with HTTP 404: `No endpoints available matching your guardrail restrictions and data policy.` Request-level `provider.data_collection` values cannot loosen the account-wide privacy policy. The OpenRouter Privacy dashboard setting must change before this route can pass a live canary.

This PR pins GMICloud because it passes live inference today. Managed prices are `$1.74/M` input, `$3.48/M` output, and `$0.145/M` cache read.

## Verification

- `@kortix/llm-catalog`: 72 pass, 0 fail, 196 assertions
- API catalog and descriptor tests: 44 pass, 0 fail, 100 assertions
- `@kortix/sandbox-agent-server` build: exit 0
- `@kortix/sdk` typecheck: exit 0
- full SDK suite: 1901 pass, 2 skip, 0 fail, 7244 assertions
- packed SDK install smoke: passed
- local managed catalog: HTTP 200
- local managed inference: HTTP 200, `DEEPSEEK_V4_PRO_MANAGED_OK`
- persisted gateway log: resolved `deepseek/deepseek-v4-pro-0813`, provider `openrouter`, status 200
