### PR TITLE
fix(api): never warm into the last concurrent-session slot

### DIFF
--- a/apps/api/src/projects/lib/warm-session-capacity.test.ts
+++ b/apps/api/src/projects/lib/warm-session-capacity.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The warm-session concurrency guard.
+ *
+ * A warm session sits at `provisioning`, which `countActiveProjectSessions`
+ * counts, so speculative warming could consume the LAST concurrent-session slot
+ * and 429 the next genuine session start. The guard keeps one slot free — and
+ * governs CREATE only, never reuse.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  assertWarmSessionCapacity,
+  warmSessionCreateFitsCap,
+  WarmProjectSessionUnavailableError,
+} from './warm-session-capacity';
+
+const ACCOUNT = '00000000-0000-4000-a000-0000000000aa';
+
+describe('warmSessionCreateFitsCap', () => {
+  test('warms while a free slot would remain after the create', () => {
+    // Starter: concurrentSessionLimit 3 (billing/services/tiers.ts:263).
+    expect(warmSessionCreateFitsCap(0, 3)).toBe(true);
+    expect(warmSessionCreateFitsCap(1, 3)).toBe(true);
+  });
+
+  test('refuses the second-to-last slot — the boundary this guard exists for', () => {
+    expect(warmSessionCreateFitsCap(2, 3)).toBe(false);
+  });
+
+  test('refuses at and above the cap', () => {
+    expect(warmSessionCreateFitsCap(3, 3)).toBe(false);
+    expect(warmSessionCreateFitsCap(4, 3)).toBe(false);
+  });
+
+  test('a one-slot account never warms — its only slot belongs to real work', () => {
+    expect(warmSessionCreateFitsCap(0, 1)).toBe(false);
+  });
+
+  test('a zero or negative limit never warms', () => {
+    expect(warmSessionCreateFitsCap(0, 0)).toBe(false);
+    expect(warmSessionCreateFitsCap(0, -1)).toBe(false);
+  });
+
+  test('billing off resolves to MAX_SAFE_INTEGER and always warms', () => {
+    // resolveAccountSessionLimit returns this when
+    // KORTIX_BILLING_INTERNAL_ENABLED is off (shared/account-limits.ts:155).
+    expect(warmSessionCreateFitsCap(9, Number.MAX_SAFE_INTEGER)).toBe(true);
+  });
+});
+
+describe('assertWarmSessionCapacity', () => {
+  test('resolves when a free slot would remain', async () => {
+    expect(
+      await assertWarmSessionCapacity(ACCOUNT, {
+        resolveLimit: async () => ({ tier: 'starter', limit: 3, source: 'tier' }),
+        countActive: async () => 1,
+      }),
+    ).toBeUndefined();
+  });
+
+  test('throws WARM_SESSION_UNAVAILABLE at the boundary, with the reason', async () => {
+    const error = await assertWarmSessionCapacity(ACCOUNT, {
+      resolveLimit: async () => ({ tier: 'starter', limit: 3, source: 'tier' }),
+      countActive: async () => 2,
+    }).catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(WarmProjectSessionUnavailableError);
+    expect((error as WarmProjectSessionUnavailableError).reason).toBe(
+      'concurrent_session_headroom',
+    );
+  });
+
+  test('honours a per-account operator override, not only the tier', async () => {
+    const error = await assertWarmSessionCapacity(ACCOUNT, {
+      resolveLimit: async () => ({ tier: 'free', limit: 2, source: 'account_override' }),
+      countActive: async () => 1,
+    }).catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(WarmProjectSessionUnavailableError);
+  });
+
+  test('reads the limit and the count for the account it was asked about', async () => {
+    const seen: string[] = [];
+    await assertWarmSessionCapacity(ACCOUNT, {
+      resolveLimit: async (accountId) => {
+        seen.push(accountId);
+        return { tier: 'starter', limit: 3, source: 'tier' };
+      },
+      countActive: async (accountId) => {
+        seen.push(accountId);
+        return 0;
+      },
+    });
+    expect(seen).toEqual([ACCOUNT, ACCOUNT]);
+  });
+});

--- a/apps/api/src/projects/lib/warm-session-capacity.ts
+++ b/apps/api/src/projects/lib/warm-session-capacity.ts
@@ -1,0 +1,85 @@
+import { resolveAccountSessionLimit } from '../../shared/account-limits';
+import { countActiveProjectSessions } from './sessions';
+
+/**
+ * Why a warm session could not be created right now.
+ *
+ * Carried in the 409 `WARM_SESSION_UNAVAILABLE` body as `reason`, so the skip
+ * is debuggable without a new status code or a new response schema.
+ */
+export type WarmSessionUnavailableReason = 'concurrent_session_headroom';
+
+/**
+ * A warm session that cannot be created. 409 `WARM_SESSION_UNAVAILABLE` — the
+ * same code the unreadable-repo skip already uses, for the same reason:
+ * warming is SPECULATIVE, the client ignores every warm failure and falls
+ * through to the normal create path, and `WarmProjectSessionResultSchema`
+ * requires a `session`, so a 200-with-null would be a public contract change.
+ */
+export class WarmProjectSessionUnavailableError extends Error {
+  constructor(
+    readonly reason: WarmSessionUnavailableReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'WarmProjectSessionUnavailableError';
+  }
+}
+
+/**
+ * May warming CREATE a new warm session at this account's occupancy?
+ *
+ * PURE — the whole policy in one predicate.
+ *
+ * A warm session sits at `provisioning`, which is in `ACTIVE_SESSION_STATUSES`
+ * (lib/session-status.ts:10), so `countActiveProjectSessions` counts it and it
+ * consumes a concurrent-session slot exactly like a working session. That is
+ * correct — a warm box is real, booted, billed compute and the cap exists to
+ * bound exactly that — but it means speculative warming could take the LAST
+ * slot and 429 the next genuine session start. On Starter
+ * (`concurrentSessionLimit: 3`, billing/services/tiers.ts:263) three project
+ * page views with zero real work were enough.
+ *
+ * So warming keeps one slot free: it may create only while a free slot would
+ * REMAIN afterwards. `limit - 1` rather than `limit`. A limit of 1 therefore
+ * never warms, which is right — that account's only slot belongs to real work.
+ *
+ * This governs CREATE only. Returning an existing `available` warm session
+ * costs nothing extra (that row is already counted), so reuse is never gated.
+ */
+export function warmSessionCreateFitsCap(activeSessions: number, limit: number): boolean {
+  return activeSessions < limit - 1;
+}
+
+export interface WarmSessionCapacityDependencies {
+  resolveLimit: typeof resolveAccountSessionLimit;
+  countActive: typeof countActiveProjectSessions;
+}
+
+const defaultDependencies: WarmSessionCapacityDependencies = {
+  resolveLimit: resolveAccountSessionLimit,
+  countActive: countActiveProjectSessions,
+};
+
+/**
+ * Throw `WarmProjectSessionUnavailableError` when creating a warm session would
+ * leave the account with no free concurrent-session slot.
+ *
+ * Call this on the CREATE path only. Reuses the same limit resolution and the
+ * same active-session count the real cap (`enforceConcurrentSessionCap`) uses,
+ * so the two can never disagree about an account.
+ */
+export async function assertWarmSessionCapacity(
+  accountId: string,
+  dependencies: WarmSessionCapacityDependencies = defaultDependencies,
+): Promise<void> {
+  const [{ limit }, activeSessions] = await Promise.all([
+    dependencies.resolveLimit(accountId),
+    dependencies.countActive(accountId),
+  ]);
+  if (warmSessionCreateFitsCap(activeSessions, limit)) return;
+  throw new WarmProjectSessionUnavailableError(
+    'concurrent_session_headroom',
+    'A warm session would consume the last concurrent-session slot.',
+  );
+}

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -106,6 +106,10 @@ import {
   withWarmProjectSessionLock,
 } from '../lib/warm-session-store';
 import { prepareReusedWarmSession } from '../lib/warm-session-refresh';
+import {
+  assertWarmSessionCapacity,
+  WarmProjectSessionUnavailableError,
+} from '../lib/warm-session-capacity';
 import { createWarmProjectSessionCoordinator, WarmProjectSessionError } from '../lib/warm-sessions';
 import {
   createSession,
@@ -348,6 +352,11 @@ projectsApp.openapi(
         discardAvailableWarmProjectSession(scope, sessionId, metadata),
       claim: (sessionId, metadata) => claimAvailableWarmProjectSession(scope, sessionId, metadata),
       create: async (metadata) => {
+        // CREATE only — the coordinator calls this after find-available has
+        // already failed, so a reusable warm session never reaches it. A warm
+        // box is billed compute holding a concurrent-session slot; it must
+        // never take the LAST one and 429 the next genuine session start.
+        await assertWarmSessionCapacity(loaded.row.accountId);
         const result = await createProjectSession({
           project: loaded.row,
           userId: loaded.userId,
@@ -433,6 +442,22 @@ projectsApp.openapi(
       }
       if (error instanceof WarmSessionCreateFailure) {
         return sendSessionCreateError(c, error.detail);
+      }
+      // Warming is possible in principle but not right now. Same 409
+      // WARM_SESSION_UNAVAILABLE as the unreadable-repo skip below: the client
+      // treats every warm failure identically (no warm session, fall through to
+      // the normal create path), so this is silent and correct at the UI.
+      // `reason` distinguishes the causes for debugging without changing the
+      // status, the code, or the response schema.
+      if (error instanceof WarmProjectSessionUnavailableError) {
+        return c.json(
+          {
+            error: 'This project cannot prepare a warm session right now.',
+            code: 'WARM_SESSION_UNAVAILABLE',
+            reason: error.reason,
+          },
+          409,
+        );
       }
       // A project whose repo cannot be read (no credentials, deleted remote,
       // bad ref) simply cannot be warmed. That is a fact about the project, not


### PR DESCRIPTION
Follow-up to #6437 (presence-driven warm sessions).

## Defect — a warm session can consume the last concurrent-session slot

Evidence on `main` @ `4a465bf89e`:

- `apps/api/src/projects/lib/session-status.ts:10` — `ACTIVE_SESSION_STATUSES = ['queued','branching','provisioning','running']`
- `apps/api/src/projects/lib/sessions.ts:137-149` — `countActiveProjectSessions(accountId)` counts exactly those statuses
- A warm session is created at `provisioning`, so it counts
- `apps/api/src/billing/services/tiers.ts:263` — Starter, $40/mo, `concurrentSessionLimit: 3`

`use-warm-project-session.ts` fires an ensure on project-route mount, on tab
visibility-regain, and after a claim. On Starter, three project page views with
zero real work exhausted the cap, and the next genuine session start returned
`429 concurrent_session_limit`.

## Fix

Warming may CREATE a warm session only while a free slot would REMAIN
afterwards: `activeSessions < limit - 1`.

- `apps/api/src/projects/lib/warm-session-capacity.ts` (new) — `warmSessionCreateFitsCap(activeSessions, limit)` is the whole policy as a pure predicate; `assertWarmSessionCapacity(accountId)` reads the limit and the count and throws.
- It reuses `resolveAccountSessionLimit` and `countActiveProjectSessions` — the same two reads the real cap (`enforceConcurrentSessionCap`) uses, so the guard and the cap can never disagree about an account. A per-account operator override (`credit_accounts.max_concurrent_sessions`) is honoured, not just the tier.
- `apps/api/src/projects/routes/r7.ts` — the guard is called inside the coordinator's `create` dependency, so it runs ONLY on the create path.

**Reuse is deliberately not gated.** `createWarmProjectSessionCoordinator`
separates find-available from create; a compatible `available` warm session is
returned before `create` is ever called. That row is already counted toward the
cap, so returning it costs nothing extra, and blocking it would be a straight
regression. Proven below at the boundary.

A limit of 1 therefore never warms. That is intended: the account's only slot
belongs to real work.

## Rejected: excluding warm rows from `countActiveProjectSessions`

A warm session is a real, booted, billed sandbox. Excluding it would make the
concurrency cap stop bounding the exact thing it exists to bound — an account
could hold N warm boxes plus N working sessions.

## Why 409 and not a schema change

`WarmProjectSessionResultSchema` requires a `session`, so a 200-with-null would
be a public API contract change with SDK type churn. #6437 already established
`409 WARM_SESSION_UNAVAILABLE` for "warming is not possible right now" (it
classifies an unreadable git repo that way), and the client treats every warm
failure identically — no warm session, fall through to the normal create path.
So the skip is silent and correct at the UI with no client change. A `reason`
field distinguishes the causes for debugging; status, code and schema are
unchanged.

## Verification

### Unit — the pure predicate and the guard

    cd apps/api && bun test --env-file=scripts/test.env \
      src/projects/lib/warm-session-capacity.test.ts src/projects/lib/warm-sessions.test.ts

    21 pass
    0 fail
    34 expect() calls
    Ran 21 tests across 2 files. [345.00ms]

### Real authenticated HTTP against the running API, with DB read-back

Worktree stack on `http://localhost:17508/v1` started with `pnpm worktree start
warm-guard --billing` (billing ON, so `resolveAccountSessionLimit` returns a
finite limit instead of `MAX_SAFE_INTEGER`). Real Supabase JWT, real
`POST /projects/provision`, real Platinum sandboxes. Every "no row was created"
claim is a direct `select ... from kortix.project_sessions` read-back, not the
status code.

    PASS  [3] below the boundary warms (limit 3, active 0) -> 200 + exactly one warm row
          {"status":200,"reused":false,"rows":1,"active":1}
    PASS  [5a] unclaimed warm session absent from scope=visible, present in scope=project
          {"visible":[],"project":["8dc9ec61-fc82-4bfe-8e4d-6b938f729258"],"warmSessionId":"8dc9ec61-fc82-4bfe-8e4d-6b938f729258"}
    PASS  [2] at the boundary an existing available warm session is still REUSED
          {"status":200,"reused":true,"sameId":true,"rows":1}
    PASS  [5b] claim flips warm_session.state available -> claimed
          {"status":200,"dbState":"claimed"}
    PASS  [1] create at the boundary -> 409 WARM_SESSION_UNAVAILABLE + ZERO new rows
          {"status":409,"body":{"error":"This project cannot prepare a warm session right now.","code":"WARM_SESSION_UNAVAILABLE","reason":"concurrent_session_headroom"},"rowsBefore":1,"rowsAfter":1,"active":1}
    PASS  [5c] warm_sessions flag OFF -> 403 feature_disabled + ZERO new rows
          {"status":403,"body":{"error":"Warm Sessions is not enabled for this project. Enable it in Settings -> Feature flags.","code":"feature_disabled","feature":"warm_sessions"},"rowsBefore":1,"rowsAfter":1}
    PASS  [3b] with headroom restored (limit 3, active 1) -> 200 reused:false + one NEW warm row
          {"status":200,"reused":false,"rows":2,"active":2}

    ALL CHECKS PASSED

Sequence: limit 3 -> warm creates (active 1); limit 2 -> the SAME request now
sits at the boundary and still reuses; claim the warm row so no `available` row
remains; the next ensure takes the create path and is refused with zero new
rows; flag off is still 403 with zero rows; limit 3 restores headroom and a new
row is created. All four sandboxes were stopped and both projects archived
afterwards (`session_sandboxes.status = stopped` verified).

### Gates

    pnpm test                                  EXIT=0
      api-cli-flows  370/370 passed, 0 failed, 0 skipped
      sdk            1901 pass, 2 skip, 0 fail
      route-coverage PASS   worktree-unit PASS   flow-runner-unit PASS

    apps/api  bash scripts/test.sh              6781 pass, 74 skip, 1 fail
      The single failure is `src/secrets/egress-proxy/proxy.test.ts` -> "Cannot
      find package 'node-forge'". Pre-existing and environment-level: the dep is
      declared (apps/api/package.json:45) and present in the pnpm store, but is
      not linked into apps/api/node_modules in EITHER this worktree or the
      primary checkout. Unrelated to this diff, which touches only
      apps/api/src/projects/**.

    apps/api  npx tsc --noEmit                  1 error, the same node-forge resolution
    apps/web  npx tsc --noEmit                  15 errors, exactly the known @types/bun
                                                `test.each` set in the 3 files named in CLAUDE.md

No eslint gate applies: eslint is configured only for `apps/web`
(`apps/web/eslint.config.mjs`); there is no root or `apps/api` config, and this
diff changes no `apps/web` file.

## Not done in this PR — the "no usable model" defect

The second reported defect was: warming boots a box for an account that has no
usable model, because the client gate `canRun` is billing-only. I did not ship a
guard for it, because there is no authoritative server-side "this account can
run a turn" signal to reuse, and every candidate I could build is a proxy that
fails closed on legitimate accounts.

What I checked:

- `createProjectSession` (`apps/api/src/projects/lib/sessions.ts`) validates
  only an EXPLICITLY requested model, via `isModelServableForAccount`. It has no
  check that any model is available, so there is nothing on the create path to
  copy.
- The only "usable model" predicate in the repo is `hasUsableModel`
  (`packages/sdk/src/react/use-model-store.ts:242`). It operates on the opencode
  `FlatModel` list, which exists only AFTER the sandbox boots. It cannot gate the
  boot.
- `accountMayUseManagedModels(accountId)` answers a narrower question. When it
  is false the sandbox still boots — `session-sandbox.ts:440-455` injects no
  `KORTIX_LLM_*`, and OpenCode "falls back to showing only its built-in Zen
  catalog". So "not entitled to managed models" does not imply "cannot run a
  turn".
- A pre-boot answer would have to be a new predicate composed from
  `listProjectSecretNamesForConsumer` + `SERVED_MANAGED_MODELS` +
  `accountMayUseManagedModels` + `projectLlmGatewayEnabled`, and it would have to
  decide product questions I cannot answer from the code: does the Zen fallback
  count, does a gateway-disabled project count, do Codex credentials count.

A false negative there is worse than the waste it saves: the client swallows
every warm failure, so warming would silently stay off forever for a legitimate
account with no signal anywhere. Blocked on a product decision. Once "an account
with only the Zen fallback cannot run a turn" (or the opposite) is settled, the
guard is a second `reason` value in the same 409 and about 15 lines in
`warm-session-capacity.ts`.

## Not covered by ke2e

The guard cannot be exercised by a `tests/src/flows` product flow. The local
test profile runs with billing disabled, where `resolveAccountSessionLimit`
returns `MAX_SAFE_INTEGER` (`shared/account-limits.ts:155`), so the boundary is
unreachable. SESS-18 also requires cloud sandboxes (`requires: ['daytona','funded']`)
and is excluded locally. The boundary is covered by the pure unit tests plus the
real-HTTP run above and on deployed dev.
