### PR TITLE
fix(web): end a workspace switch instead of stranding it

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 
 import { BillingReturnWatcher } from '@/features/billing/billing-return';
+import { ProjectSwitchWatcher } from '@/features/workspace/project-switch-watcher';
 
 /**
  * Shell for every authenticated app route.
@@ -9,7 +10,9 @@ import { BillingReturnWatcher } from '@/features/billing/billing-return';
  * user happens to be on. Returning from Stripe is the first such case: the
  * handling used to live in the projects list page, which forced every checkout
  * `success_url` to point at `/projects` — the one surface that is deliberately
- * never a destination.
+ * never a destination. Ending a workspace switch is the second: the picker that
+ * starts one closes immediately, and the route it navigates to is a different
+ * one on either side, so only a shell above both can watch it land.
  *
  * Keep this thin. Route-specific work belongs in the route.
  */
@@ -21,6 +24,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       <Suspense fallback={null}>
         <BillingReturnWatcher />
       </Suspense>
+      <ProjectSwitchWatcher />
       {children}
     </>
   );

--- a/apps/web/src/features/workspace/project-sidebar/workspace-menu-section.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/workspace-menu-section.tsx
@@ -33,7 +33,10 @@ import {
 } from '@/features/workspace/project-sidebar/workspace-grouping';
 import { cn } from '@/lib/utils';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
-import { useIsSwitchingProject, useProjectSwitchStore } from '@/stores/project-switch-store';
+import {
+  shouldShowProjectSwitchLoading,
+  useProjectSwitchStore,
+} from '@/stores/project-switch-store';
 import { listAccounts, listProjectsForAccount, type KortixProject } from '@kortix/sdk';
 import { contract, qk } from '@kortix/sdk/react';
 import { CheckCircleIcon as CheckCircleSolid } from '@phosphor-icons/react';
@@ -44,7 +47,7 @@ export function WorkspaceMenuSection() {
   const params = useParams<{ id?: string }>();
   const { selectedAccountId, setSelectedAccountId } = useCurrentAccountStore();
   const beginSwitch = useProjectSwitchStore((s) => s.beginSwitch);
-  const switching = useIsSwitchingProject();
+  const switchingToProjectId = useProjectSwitchStore((s) => s.targetProjectId);
   const [query, setQuery] = useState('');
 
   const activeProjectId = pathname?.startsWith('/projects/') ? params?.id : undefined;
@@ -165,7 +168,13 @@ export function WorkspaceMenuSection() {
                 </DropdownMenuLabel>
                 {group.workspaces.map((workspace) => {
                   const active = workspace.project_id === activeProjectId;
-                  const loading = switching && workspace.project_id !== activeProjectId;
+                  // Only the row you clicked, and only until the URL is on it.
+                  // Never the whole list — see `shouldShowProjectSwitchLoading`.
+                  const loading = shouldShowProjectSwitchLoading(
+                    switchingToProjectId,
+                    workspace.project_id,
+                    activeProjectId ?? null,
+                  );
                   return (
                     <DropdownMenuItem
                       key={workspace.project_id}

--- a/apps/web/src/features/workspace/project-switch-watcher.test.ts
+++ b/apps/web/src/features/workspace/project-switch-watcher.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveProjectSwitchOutcome } from './project-switch-watcher';
+
+const outcome = (targetProjectId: string | null, pathname: string, pathnameAtBegin: string) =>
+  resolveProjectSwitchOutcome({ targetProjectId, pathname, pathnameAtBegin });
+
+describe('resolveProjectSwitchOutcome', () => {
+  test('is pending while the URL has not moved off the page the switch started on', () => {
+    expect(outcome('proj-b', '/projects/proj-a', '/projects/proj-a')).toBe('pending');
+    expect(outcome('proj-b', '/projects/proj-a/sessions/s1', '/projects/proj-a/sessions/s1')).toBe(
+      'pending',
+    );
+  });
+
+  test('arrives on any route inside the target workspace', () => {
+    expect(outcome('proj-b', '/projects/proj-b', '/projects/proj-a')).toBe('arrived');
+    expect(outcome('proj-b', '/projects/proj-b/sessions/s2', '/projects/proj-a')).toBe('arrived');
+  });
+
+  test('diverts when the URL lands anywhere else', () => {
+    expect(outcome('proj-b', '/projects/proj-c', '/projects/proj-a')).toBe('diverted');
+    expect(outcome('proj-b', '/accounts/acct-a', '/projects/proj-a')).toBe('diverted');
+    expect(outcome('proj-b', '/auth', '/projects/proj-a')).toBe('diverted');
+  });
+
+  test('is idle with no switch pending', () => {
+    expect(outcome(null, '/projects/proj-a', '/projects/proj-a')).toBe('idle');
+  });
+});

--- a/apps/web/src/features/workspace/project-switch-watcher.tsx
+++ b/apps/web/src/features/workspace/project-switch-watcher.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+import { projectIdFromPathname, useProjectSwitchStore } from '@/stores/project-switch-store';
+
+/**
+ * Ends a workspace switch. One instance, in the authenticated app shell.
+ *
+ * The workspace picker starts a switch and then closes — Radix unmounts the menu
+ * on select — so the picker itself cannot be what ends one. That is exactly how
+ * the switch used to get stranded: nothing outside the menu owned the end of it,
+ * so `targetProjectId` stayed set and every re-open of the picker painted a
+ * field of spinners you could not switch out of. This watcher sits above every
+ * route, so it is still mounted while the navigation it watches happens.
+ *
+ * It ends a switch three ways, in order of how good the news is:
+ * - `arrived`: the URL is inside the target workspace. Compare-and-clear, so a
+ *   slow older switch never clears a newer rapid click's target.
+ * - `diverted`: the URL moved somewhere else entirely — a different workspace, a
+ *   settings page, `/auth` after an access bounce. The switch is over; it just
+ *   did not go where it was aimed.
+ * - timed out: the URL never moved at all — a `router.push` that never resolves.
+ *   A backstop, not a normal path.
+ */
+const SWITCH_TIMEOUT_MS = 20_000;
+
+export type ProjectSwitchOutcome = 'idle' | 'pending' | 'arrived' | 'diverted';
+
+export function resolveProjectSwitchOutcome(args: {
+  targetProjectId: string | null;
+  pathname: string | null;
+  pathnameAtBegin: string | null;
+}): ProjectSwitchOutcome {
+  const { targetProjectId, pathname, pathnameAtBegin } = args;
+  if (!targetProjectId) return 'idle';
+  if (projectIdFromPathname(pathname) === targetProjectId) return 'arrived';
+  // Still on the page the switch started from: the navigation is in flight.
+  if (pathname === pathnameAtBegin) return 'pending';
+  return 'diverted';
+}
+
+export function ProjectSwitchWatcher() {
+  const pathname = usePathname();
+  const targetProjectId = useProjectSwitchStore((s) => s.targetProjectId);
+  const completeSwitch = useProjectSwitchStore((s) => s.completeSwitch);
+  const cancelSwitch = useProjectSwitchStore((s) => s.cancelSwitch);
+
+  // The pathname the switch started from. Without it, the first render after
+  // `beginSwitch` — still on the old workspace, because `router.push` has not
+  // resolved yet — is indistinguishable from "the user ended up somewhere else",
+  // and the switch would cancel itself before it ever left the page.
+  const pathnameAtBegin = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!targetProjectId) {
+      pathnameAtBegin.current = null;
+      return;
+    }
+    if (pathnameAtBegin.current === null) pathnameAtBegin.current = pathname;
+
+    const outcome = resolveProjectSwitchOutcome({
+      targetProjectId,
+      pathname,
+      pathnameAtBegin: pathnameAtBegin.current,
+    });
+    if (outcome === 'arrived') {
+      completeSwitch(targetProjectId);
+      return;
+    }
+    if (outcome === 'diverted') {
+      cancelSwitch();
+      return;
+    }
+    const timer = setTimeout(cancelSwitch, SWITCH_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [targetProjectId, pathname, completeSwitch, cancelSwitch]);
+
+  return null;
+}

--- a/apps/web/src/stores/project-switch-store.test.ts
+++ b/apps/web/src/stores/project-switch-store.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import {
+  projectIdFromPathname,
+  shouldShowProjectSwitchLoading,
+  useProjectSwitchStore,
+} from './project-switch-store';
+
+describe('shouldShowProjectSwitchLoading', () => {
+  test('spins only the row that was clicked', () => {
+    expect(shouldShowProjectSwitchLoading('proj-b', 'proj-b', 'proj-a')).toBe(true);
+    expect(shouldShowProjectSwitchLoading('proj-b', 'proj-c', 'proj-a')).toBe(false);
+    expect(shouldShowProjectSwitchLoading('proj-b', 'proj-a', 'proj-a')).toBe(false);
+  });
+
+  test('stops as soon as the URL is on the target, even if nothing cleared the store', () => {
+    // The regression this file exists for: a stranded target used to paint every
+    // non-active row as a permanently disabled spinner.
+    expect(shouldShowProjectSwitchLoading('proj-b', 'proj-b', 'proj-b')).toBe(false);
+    expect(shouldShowProjectSwitchLoading('proj-b', 'proj-c', 'proj-b')).toBe(false);
+  });
+
+  test('shows nothing when no switch is pending', () => {
+    expect(shouldShowProjectSwitchLoading(null, 'proj-a', 'proj-a')).toBe(false);
+    expect(shouldShowProjectSwitchLoading(null, 'proj-b', 'proj-a')).toBe(false);
+  });
+});
+
+describe('projectIdFromPathname', () => {
+  test('reads the workspace out of every route inside it', () => {
+    expect(projectIdFromPathname('/projects/proj-a')).toBe('proj-a');
+    expect(projectIdFromPathname('/projects/proj-a/sessions/sess-1')).toBe('proj-a');
+    expect(projectIdFromPathname('/projects/proj-a/files')).toBe('proj-a');
+  });
+
+  test('returns null off a workspace route', () => {
+    expect(projectIdFromPathname('/accounts/acct-a')).toBeNull();
+    expect(projectIdFromPathname('/projects')).toBeNull();
+    expect(projectIdFromPathname('/projects/start')).toBeNull();
+    expect(projectIdFromPathname('/projects/new')).toBeNull();
+    expect(projectIdFromPathname(null)).toBeNull();
+    expect(projectIdFromPathname('')).toBeNull();
+  });
+});
+
+describe('project switch state', () => {
+  beforeEach(() => useProjectSwitchStore.setState({ targetProjectId: null }));
+
+  test('keeps the newest target when an older rapid switch finishes later', () => {
+    useProjectSwitchStore.getState().beginSwitch('proj-b');
+    useProjectSwitchStore.getState().beginSwitch('proj-c');
+
+    useProjectSwitchStore.getState().completeSwitch('proj-b');
+    expect(useProjectSwitchStore.getState().targetProjectId).toBe('proj-c');
+
+    useProjectSwitchStore.getState().completeSwitch('proj-c');
+    expect(useProjectSwitchStore.getState().targetProjectId).toBeNull();
+  });
+
+  test('cancel clears whatever is pending', () => {
+    useProjectSwitchStore.getState().beginSwitch('proj-b');
+    useProjectSwitchStore.getState().cancelSwitch();
+    expect(useProjectSwitchStore.getState().targetProjectId).toBeNull();
+  });
+});

--- a/apps/web/src/stores/project-switch-store.ts
+++ b/apps/web/src/stores/project-switch-store.ts
@@ -3,26 +3,73 @@
 import { create } from 'zustand';
 
 /**
- * Tracks an in-flight switch between projects so the chrome can render a
- * progress bar / pulse while navigation + data fetch settle.
+ * Tracks an in-flight switch between workspaces so the workspace picker can show
+ * which row you committed to while the route is still loading.
  *
- * `targetProjectId` is what we're switching TO. The project shell clears it
- * the moment the URL's projectId equals the target — i.e., the new page is
- * rendering. Any data-fetch is gated separately by React Query.
+ * Three rules, all of them earned from the bug this file used to have — the
+ * store had a `beginSwitch` and an `endSwitch`, and NOTHING in the app ever
+ * called `endSwitch`. One switch left `targetProjectId` set forever, which the
+ * picker read as "a switch is in flight" and painted as a spinner on every row
+ * that was not the active one, each of them `disabled`. The menu became a
+ * permanent spinner field you could not switch out of.
+ *
+ * 1. The pending state is per-row, never global. Loading is `target === row`
+ *    (see {@link shouldShowProjectSwitchLoading}), so a stale target can only
+ *    ever mark the ONE row it names — never the whole list.
+ * 2. The pending state is derived against the active workspace, so it self-heals:
+ *    once the URL is on the target, that row is the active row and stops
+ *    loading, whether or not anything cleared the store.
+ * 3. Something always clears it anyway — {@link ProjectSwitchWatcher}, mounted
+ *    once in the authenticated app shell, completes on arrival and cancels a
+ *    switch that never lands.
+ *
+ * Clearing is compare-and-clear so a slow older switch cannot clear the target
+ * of a newer rapid click — the same shape `session-switch-store` uses.
  */
-interface State {
+interface ProjectSwitchState {
   targetProjectId: string | null;
   beginSwitch: (projectId: string) => void;
-  endSwitch: () => void;
+  completeSwitch: (projectId: string) => void;
+  cancelSwitch: () => void;
 }
 
-export const useProjectSwitchStore = create<State>((set) => ({
+export const useProjectSwitchStore = create<ProjectSwitchState>((set) => ({
   targetProjectId: null,
   beginSwitch: (projectId) => set({ targetProjectId: projectId }),
-  endSwitch: () => set({ targetProjectId: null }),
+  completeSwitch: (projectId) =>
+    set((state) => (state.targetProjectId === projectId ? { targetProjectId: null } : state)),
+  cancelSwitch: () => set({ targetProjectId: null }),
 }));
 
-/** Convenience boolean — true while a project switch is in flight. */
-export function useIsSwitchingProject(): boolean {
-  return useProjectSwitchStore((s) => s.targetProjectId !== null);
+/**
+ * The workspace id a pathname is inside, or `null`. `/projects/<id>` and every
+ * route below it (`/projects/<id>/sessions/<sid>`, `/files`, …) all count as
+ * being in that workspace — arriving anywhere inside the target completes the
+ * switch.
+ */
+export function projectIdFromPathname(pathname: string | null | undefined): string | null {
+  if (!pathname) return null;
+  const match = /^\/projects\/([^/?#]+)/.exec(pathname);
+  const id = match?.[1];
+  if (!id) return null;
+  // `/projects/start` and `/projects/new` are pages, not workspaces.
+  return id === 'start' || id === 'new' ? null : id;
+}
+
+/**
+ * Whether one workspace row in the picker shows its pending spinner.
+ *
+ * Only the row you actually clicked, and only until the URL is on it. The old
+ * condition was `switching && row !== active` — a global "something is
+ * switching" AND-ed with "this is not where I am", which spins every other row
+ * in the list and, because nothing ever cleared `switching`, spins them forever.
+ */
+export function shouldShowProjectSwitchLoading(
+  targetProjectId: string | null,
+  rowProjectId: string,
+  activeProjectId: string | null,
+): boolean {
+  if (targetProjectId === null) return false;
+  if (targetProjectId !== rowProjectId) return false;
+  return targetProjectId !== activeProjectId;
 }


### PR DESCRIPTION
## The bug

Switch workspace once, and every other row in the picker becomes a disabled spinner — forever. You cannot switch again without a hard reload.

## Root cause

`apps/web/src/stores/project-switch-store.ts` exposed `beginSwitch` and `endSwitch`. Nothing in the app ever called `endSwitch`:

```
$ rg 'endSwitch' apps packages --type ts --type tsx
apps/web/src/stores/project-switch-store.ts:16,22   # declaration + implementation only
```

So `targetProjectId` stayed set for the rest of the tab's life. The picker read it as a global flag:

```ts
const switching = useIsSwitchingProject();
const loading = switching && workspace.project_id !== activeProjectId;   // every OTHER row
```

One switch therefore spun and `disabled`-ed every non-active row, permanently. The picker also cannot be what ends its own switch: Radix unmounts the menu on select, so it is gone before the navigation lands.

## The fix

1. **Store** — compare-and-clear `completeSwitch(projectId)` + `cancelSwitch()`, the shape `session-switch-store` already uses, so a slow older switch never clears a newer rapid click's target.
2. **Per-row, derived pending state** — `shouldShowProjectSwitchLoading(target, row, active)`: only the row you clicked, and only until the URL is on it. A stranded target can no longer mark more than the one row it names, and it self-heals on arrival even if nothing clears the store.
3. **`ProjectSwitchWatcher`** — one instance in the `(app)` shell, above every route, ends the switch: `arrived` (URL inside the target workspace) completes, `diverted` (URL lands anywhere else — another workspace, settings, `/auth` bounce) cancels, and a 20s backstop cancels a `router.push` that never moves.

## Verification — local stack, 3 workspaces in one account

Real Chrome against `localhost:3000`, real login, real clicks on the picker.

**Before** (fix stashed), after switching Gamma -> Beta and reopening the picker:

```json
[{"text":"BBeta Workspace","disabled":false,"spinner":false,"check":true},
 {"text":"GGamma Workspace","disabled":true,"spinner":true,"check":false},
 {"text":"AAlpha Workspace","disabled":true,"spinner":true,"check":false}]
```

**After**, same flow:

```json
[{"text":"GGamma Workspace","disabled":false,"spinner":false,"check":false},
 {"text":"BBeta Workspace","disabled":false,"spinner":false,"check":true},
 {"text":"AAlpha Workspace","disabled":false,"spinner":false,"check":false}]
```

Then Beta -> Alpha (the switch that was impossible before) is equally clean, and the console reports no errors or warnings across the whole run.

## Checks

- `apps/web` `npx tsc --noEmit` — clean.
- `npx eslint` on all changed files — clean.
- `bun test src/stores src/features/workspace` — 1394 pass, 0 fail (11 of them new, covering the predicate, the pathname parser, compare-and-clear, and every watcher outcome).
