### PR TITLE
fix(iam): report the constraint that actually denied a project request

### DIFF
--- a/apps/api/src/__tests__/unit-iam-denial-reason-message.test.ts
+++ b/apps/api/src/__tests__/unit-iam-denial-reason-message.test.ts
@@ -1,0 +1,107 @@
+// A 403's message must name the constraint that ACTUALLY fired.
+//
+// `authorizeV2` folds three independent limits into one boolean — the human's
+// project role, the agent session's `kortix_cli` grant, and an activated service
+// account's assigned role. Only `verdict.reason` separates them. The project
+// loader used to discard the reason and re-derive the cause by probing
+// `project.read`, which is exempt from the agent-grant fold — so the probe
+// passed for EVERY agent-session token and every agent/service-account denial
+// rendered as "your role is too low". An account owner running the meta
+// coordinator was told to ask an account owner for a higher role.
+//
+// These tests pin the reason → message mapping as a pure function, and pin the
+// two properties that keep it honest: a remedy that matches the constraint, and
+// no disclosure of the account's wider permission model.
+import { describe, expect, test } from 'bun:test';
+import { buildDenialError, denialReasonMessage } from '../iam/denial-message';
+
+describe('denialReasonMessage', () => {
+  test('agent_scope_insufficient names the agent grant, not the role', () => {
+    const message = denialReasonMessage('project.session.start', 'agent_scope_insufficient');
+    expect(message).toBe(
+      'This agent session is not granted "project.session.start". Add it to the agent\'s kortix_cli in kortix.yaml and merge the change.',
+    );
+    // The bug being fixed: this must NEVER read as a role problem.
+    expect(message).not.toContain('role');
+  });
+
+  test('service_account_scope_insufficient names the service account role', () => {
+    const message = denialReasonMessage(
+      'project.session.start',
+      'service_account_scope_insufficient',
+    );
+    expect(message).toBe(
+      'This agent runs as its own service account, and the role assigned to it does not allow "project.session.start". Ask an account admin to update that role.',
+    );
+    // The launching user's own role is irrelevant once the SA is activated, so
+    // the remedy must point at the SA's role, not the caller's.
+    expect(message).not.toContain('higher role');
+  });
+
+  test('token_out_of_scope names the token binding', () => {
+    expect(denialReasonMessage('project.write', 'token_out_of_scope')).toBe(
+      'This token is scoped to a single project and cannot be used for this request.',
+    );
+  });
+
+  test('resource_scope_insufficient names the per-resource grant', () => {
+    expect(denialReasonMessage('project.agent.read', 'resource_scope_insufficient')).toBe(
+      'You are not granted access to this resource.',
+    );
+  });
+
+  test('account_mfa_required keeps the step-up wording', () => {
+    expect(denialReasonMessage('project.write', 'account_mfa_required')).toContain(
+      'multi-factor authentication',
+    );
+  });
+
+  test('role-shaped and unknown reasons return null so the caller keeps its own wording', () => {
+    for (const reason of [
+      'project_role_insufficient',
+      'no_project_membership',
+      'account_role_insufficient',
+      'project_target_required',
+      'not_a_member',
+      'impersonation_scope',
+      undefined,
+      'a_reason_that_does_not_exist_yet',
+    ]) {
+      expect(denialReasonMessage('project.session.start', reason)).toBeNull();
+    }
+  });
+
+  test('no message discloses the permission model beyond the caller\'s own request', () => {
+    for (const reason of [
+      'agent_scope_insufficient',
+      'service_account_scope_insufficient',
+      'token_out_of_scope',
+      'resource_scope_insufficient',
+      'account_mfa_required',
+    ]) {
+      const message = denialReasonMessage('project.session.start', reason);
+      expect(message).not.toBeNull();
+      // No engine internals, and no enumeration of what WOULD be allowed.
+      expect(message).not.toContain(reason);
+      expect(message).not.toContain('iam_policies');
+      expect(message).not.toContain('super_admin');
+      expect(message).not.toContain('project_members');
+    }
+  });
+});
+
+describe('buildDenialError uses the reason message', () => {
+  test('agent_scope_insufficient 403 body carries the agent-grant remedy', async () => {
+    const err = buildDenialError('project.session.read', 'agent_scope_insufficient');
+    expect(err.status).toBe(403);
+    const text = await err.getResponse().text();
+    expect(text).toContain('kortix_cli');
+    expect(text).toContain('project.session.read');
+  });
+
+  test('a role denial still falls back to the humanized action phrase', async () => {
+    const err = buildDenialError('project.write', 'project_role_insufficient');
+    const text = await err.getResponse().text();
+    expect(text).toContain("don't have permission to change this project");
+  });
+});

--- a/apps/api/src/__tests__/unit-iam-mfa-denial.test.ts
+++ b/apps/api/src/__tests__/unit-iam-mfa-denial.test.ts
@@ -3,7 +3,7 @@
 // `code` (the web's step-up dialog keys on it); every other reason stays a
 // plain humanized message with no code leak.
 import { describe, expect, test } from 'bun:test';
-import { buildDenialError } from '../iam/dispatcher';
+import { buildDenialError } from '../iam/denial-message';
 
 describe('buildDenialError', () => {
   test('account_mfa_required → 403 with machine-readable code in the body', async () => {

--- a/apps/api/src/iam/denial-message.ts
+++ b/apps/api/src/iam/denial-message.ts
@@ -1,0 +1,122 @@
+// What a 403 SAYS. Pure — no DB, no request, no Hono context beyond the
+// HTTPException it builds — and deliberately its own module rather than part of
+// `dispatcher.ts`: several route tests replace the dispatcher wholesale with
+// `mock.module`, so every name a non-test module imports from it is a name those
+// stubs must also declare. The wording policy has no reason to live behind that.
+
+import { HTTPException } from 'hono/http-exception';
+
+const MFA_DENIAL_MESSAGE =
+  'This account requires multi-factor authentication. Verify your second factor and retry.';
+
+/**
+ * The message for a denial whose REASON — not the action — names what the
+ * caller has to change. Returns null when the reason carries no
+ * caller-actionable meaning, so the caller keeps its own action-shaped wording.
+ *
+ * This exists because a denial's reason is the only thing that can distinguish
+ * WHICH constraint fired. `authorizeV2` folds three independent limits into one
+ * boolean — the human's project role, the agent session's `kortix_cli` grant,
+ * and an activated service account's assigned role — and a caller that
+ * re-derives the cause from a second `authorize()` probe cannot separate them.
+ * Guessing "your role is too low" at an account owner whose AGENT grant denied
+ * the call sends them to a remedy that can never work.
+ *
+ * Naming the constraint class is not a policy oracle. The caller already holds
+ * the credential whose own scope produced the denial, and the action is the one
+ * it just requested — neither discloses anything about the account's wider
+ * permission model, who else holds what, or which other actions would succeed.
+ */
+export function denialReasonMessage(action: string, reason?: string): string | null {
+  switch (reason) {
+    case 'account_mfa_required':
+      return MFA_DENIAL_MESSAGE;
+    case 'agent_scope_insufficient':
+      // The agent-session token's own grant denied it, at any role. Mirrors the
+      // wording assertAgentScope already uses for the same constraint.
+      return `This agent session is not granted "${action}". Add it to the agent's kortix_cli in kortix.yaml and merge the change.`;
+    case 'service_account_scope_insufficient':
+      // The session authorizes AS the agent's service account (an admin gave it
+      // a standing role), so the launching user's role is irrelevant here.
+      return `This agent runs as its own service account, and the role assigned to it does not allow "${action}". Ask an account admin to update that role.`;
+    case 'token_out_of_scope':
+      return 'This token is scoped to a single project and cannot be used for this request.';
+    case 'resource_scope_insufficient':
+      return 'You are not granted access to this resource.';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Turn a denial into the HTTPException the route layer surfaces. Exported for
+ * unit tests.
+ *
+ * Reason-specific wording comes from `denialReasonMessage`; everything else
+ * falls back to a plain humanized message for the action. `account_mfa_required`
+ * additionally carries a machine-readable `code` because the web client keys
+ * its step-up dialog on it (the SDK's ApiError already lifts `code` from error
+ * bodies).
+ */
+export function buildDenialError(action: string, reason?: string): HTTPException {
+  if (reason === 'account_mfa_required') {
+    return new HTTPException(403, {
+      message: MFA_DENIAL_MESSAGE,
+      res: new Response(
+        JSON.stringify({ error: MFA_DENIAL_MESSAGE, code: 'account_mfa_required' }),
+        { status: 403, headers: { 'content-type': 'application/json' } },
+      ),
+    });
+  }
+  return new HTTPException(403, {
+    message: denialReasonMessage(action, reason) ?? humanizePermissionDenial(action),
+  });
+}
+
+/**
+ * Map action codes (`project.create`, `member.invite`, …) to a sentence
+ * the user can act on. Unknown codes get a generic phrase with the code
+ * suffixed for support visibility. Keep this list short — only the
+ * actions that actually show up in user-visible 403s.
+ */
+function humanizePermissionDenial(action: string): string {
+  const verb = ACTION_VERBS[action];
+  if (verb) return `You don't have permission to ${verb}.`;
+  // Generic fallback. Suffix the code so support can still identify
+  // which gate fired without needing server logs.
+  return `You don't have permission to perform this action (${action}).`;
+}
+
+const ACTION_VERBS: Record<string, string> = {
+  // Projects
+  'project.create': 'create projects',
+  'project.write': 'change this project',
+  'project.delete': 'delete projects',
+  // Project members
+  'project.members.manage': 'manage project members',
+  // Account
+  'account.write': 'change account settings',
+  'account.delete': 'delete this account',
+  // Members
+  'member.invite': 'invite members',
+  'member.remove': 'remove members',
+  'member.update': 'change member roles',
+  'member.read': 'view members',
+  'member.super_admin.grant': 'grant super-admin',
+  'member.super_admin.revoke': 'revoke super-admin',
+  // Groups
+  'group.create': 'create groups',
+  'group.update': 'change groups',
+  'group.delete': 'delete groups',
+  'group.read': 'view groups',
+  'group.members.manage': 'manage group members',
+  // Audit
+  'audit.read': 'view the audit log',
+  'audit.export': 'export audit events',
+  // Tokens
+  'token.read': 'view personal access tokens',
+  'token.revoke': 'revoke personal access tokens',
+  // Billing
+  'billing.read': 'view billing',
+  'billing.write': 'change billing',
+};

--- a/apps/api/src/iam/dispatcher.ts
+++ b/apps/api/src/iam/dispatcher.ts
@@ -9,7 +9,6 @@
 //   - The route layer + cache helper + iam/index.ts all pin their
 //     imports here; consolidating preserves that import path.
 
-import { HTTPException } from 'hono/http-exception';
 import type {
   AccessibleResources,
   AuthorizeResult,
@@ -18,6 +17,7 @@ import type {
 } from './engine';
 import type { ResourceType } from './actions';
 import { authorizeV2, filterAccessibleProjectResources, listAccessibleProjectsV2 } from './engine-v2';
+import { buildDenialError } from './denial-message';
 
 // Per-resource (agent/skill) list filter — see engine-v2. Re-exported here so the
 // route layer keeps a single iam import surface (the dispatcher), like authorize.
@@ -47,82 +47,6 @@ export async function assertAuthorized(
     throw buildDenialError(action, result.reason);
   }
 }
-
-/**
- * Turn a denial into the HTTPException the route layer surfaces. Exported for
- * unit tests.
- *
- * Most reason codes (account_role_insufficient, …) are diagnostic, not
- * actionable, so the body stays a plain humanized message. The ONE actionable
- * reason is `account_mfa_required` — the caller can fix it by completing an
- * MFA challenge and retrying — so that denial carries a machine-readable
- * `code` the web client keys its step-up dialog on (the SDK's ApiError
- * already lifts `code` from error bodies).
- */
-export function buildDenialError(action: string, reason?: string): HTTPException {
-  if (reason === 'account_mfa_required') {
-    const message =
-      'This account requires multi-factor authentication. Verify your second factor and retry.';
-    return new HTTPException(403, {
-      message,
-      res: new Response(JSON.stringify({ error: message, code: 'account_mfa_required' }), {
-        status: 403,
-        headers: { 'content-type': 'application/json' },
-      }),
-    });
-  }
-  return new HTTPException(403, {
-    message: humanizePermissionDenial(action),
-  });
-}
-
-/**
- * Map action codes (`project.create`, `member.invite`, …) to a sentence
- * the user can act on. Unknown codes get a generic phrase with the code
- * suffixed for support visibility. Keep this list short — only the
- * actions that actually show up in user-visible 403s.
- */
-function humanizePermissionDenial(action: string): string {
-  const verb = ACTION_VERBS[action];
-  if (verb) return `You don't have permission to ${verb}.`;
-  // Generic fallback. Suffix the code so support can still identify
-  // which gate fired without needing server logs.
-  return `You don't have permission to perform this action (${action}).`;
-}
-
-const ACTION_VERBS: Record<string, string> = {
-  // Projects
-  'project.create': 'create projects',
-  'project.write': 'change this project',
-  'project.delete': 'delete projects',
-  // Project members
-  'project.members.manage': 'manage project members',
-  // Account
-  'account.write': 'change account settings',
-  'account.delete': 'delete this account',
-  // Members
-  'member.invite': 'invite members',
-  'member.remove': 'remove members',
-  'member.update': 'change member roles',
-  'member.read': 'view members',
-  'member.super_admin.grant': 'grant super-admin',
-  'member.super_admin.revoke': 'revoke super-admin',
-  // Groups
-  'group.create': 'create groups',
-  'group.update': 'change groups',
-  'group.delete': 'delete groups',
-  'group.read': 'view groups',
-  'group.members.manage': 'manage group members',
-  // Audit
-  'audit.read': 'view the audit log',
-  'audit.export': 'export audit events',
-  // Tokens
-  'token.read': 'view personal access tokens',
-  'token.revoke': 'revoke personal access tokens',
-  // Billing
-  'billing.read': 'view billing',
-  'billing.write': 'change billing',
-};
 
 export async function listAccessibleResources(
   userId: string,

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -8,6 +8,12 @@ import {
 } from '../../connectors/share';
 import { authorize, assertAuthorized } from '../../iam';
 import { deriveRequestContext } from '../../iam/cache';
+// Straight from `iam/denial-message`, not the `iam` barrel or the dispatcher:
+// both of those are replaced wholesale by `mock.module` in several route tests,
+// so every name imported from them is a name those stubs must also declare.
+// These two are pure wording policy. Same reason `deriveRequestContext` above
+// comes from `iam/cache` directly.
+import { buildDenialError, denialReasonMessage } from '../../iam/denial-message';
 import { invalidateIamCacheForUser, registerPrincipalScopedMemo } from '../../iam/cache-invalidation';
 import { setContextField } from '../../lib/request-context';
 import { auth } from '../../openapi';
@@ -669,12 +675,27 @@ export async function loadProjectForUser(c: Context, projectId: string, action: 
 
   const accountRole = membership?.accountRole as AccountRole | undefined;
   if (!verdict.allowed && !adminBypass) {
-    // Distinguish "no access at all" from "has access but not for this
-    // action" so the UI can show a meaningful message. A Viewer can see
-    // the project but can't create a session — telling them "no access"
-    // is misleading and they spend time wondering why they can see the
-    // page at all. Only do the second probe when the failed action was
-    // NOT already 'read' — otherwise it's the same answer.
+    const iamAction = iamActionForProjectAccess(action);
+    // The engine already computed WHY. When the reason names a constraint other
+    // than the caller's project role — an agent-session grant, a service
+    // account's assigned role, MFA, token scope — report THAT.
+    //
+    // The role-probe below cannot: `project.read` is one of the two actions the
+    // agent-grant fold never gates (AGENT_GRANT_EXEMPT_ACTIONS in engine-v2),
+    // so for an agent-session token the probe passes no matter what actually
+    // denied the request. Every agent-scope and service-account-scope denial
+    // therefore rendered as "your role is too low" — advice that told an
+    // account owner running the meta coordinator to ask an account owner for a
+    // higher role.
+    if (denialReasonMessage(iamAction, verdict.reason) !== null) {
+      throw buildDenialError(iamAction, verdict.reason);
+    }
+    // Genuine role denial. Distinguish "no access at all" from "has access but
+    // not for this action" so the UI can show a meaningful message. A Viewer can
+    // see the project but can't create a session — telling them "no access" is
+    // misleading and they spend time wondering why they can see the page at
+    // all. Only do the second probe when the failed action was NOT already
+    // 'read' — otherwise it's the same answer.
     if (action !== 'read') {
       const readVerdict = await authorize(
         userId,


### PR DESCRIPTION
## The bug

`loadProjectForUser` (`apps/api/src/projects/lib/access.ts`) threw away the
`reason` that `authorizeV2` had already computed and re-derived the cause of a
denial by probing a second action:

```
if (action !== 'read') {
  const readVerdict = await authorize(userId, accountId, 'project.read', ...);
  if (readVerdict.allowed) throw new HTTPException(403, {
    message: `Your role on this project doesn't let you ${verb}. Ask an account owner or admin to grant you a higher role.`,
  });
}
```

That probe is structurally incapable of being right for an agent-session token.
`project.read` is one of exactly two actions in `AGENT_GRANT_EXEMPT_ACTIONS`
(`apps/api/src/iam/engine-v2.ts`), the set the agent-grant fold never gates. So
the read probe passes for *every* agent-session token regardless of what
actually denied the request, and an `agent_scope_insufficient` or
`service_account_scope_insufficient` denial always rendered as "your role is
too low".

This is not hypothetical. An **account owner** hit it and was told to ask an
account owner for a higher role.

## The fix

- New `apps/api/src/iam/denial-message.ts` owns the pure `reason -> message`
  policy plus `buildDenialError` (moved out of `dispatcher.ts` unchanged in
  behaviour).
- Reason-specific messages for `agent_scope_insufficient`,
  `service_account_scope_insufficient`, `token_out_of_scope` and
  `resource_scope_insufficient`. `account_mfa_required` keeps its
  machine-readable `code` body.
- Role-shaped reasons (`project_role_insufficient`, `no_project_membership`,
  ...) return `null`, so `loadProjectForUser` keeps the existing role wording
  and the "can read but not act" probe **unchanged**. On the reason-specific
  denials it now skips that extra `authorize()` round-trip entirely.

### Why its own module, not `dispatcher.ts`

Three route tests (`e2e-accounts-contract`, `e2e-projects-contract`,
`unit-git-proxy-authz`) replace `iam/dispatcher` wholesale with `mock.module`.
Importing a new name from the dispatcher (or from the `iam` barrel) into
`access.ts` turns each of those stubs into a missing-export `SyntaxError` and
takes ~130 tests down with it - measured, not theorised. The wording policy is
pure and has no reason to sit behind that surface.

### Disclosure

Every message names only the caller's own credential scope and the action it
just requested. Nothing enumerates what *would* be allowed, who holds what, or
any engine internals. A unit test asserts that property.

## Verification

`bun test` (apps/api, 612 files): `6804 pass / 1 fail`. The single failure is
the pre-existing missing `node-forge` package in
`src/secrets/egress-proxy/proxy.test.ts`, identical on `main`.

`tsc --noEmit` (apps/api): only the same pre-existing `node-forge` TS2307.

Real HTTP against a live API on `:17508`, one denial constructed per class:

**1. agent-scope denial** - session token whose `agent_grant.kortixCli` is `[]`

```
POST /v1/projects/<id>/sessions
{"error":true,"message":"This agent session is not granted \"project.session.start\". Add it to the agent's kortix_cli in kortix.yaml and merge the change.","status":403}

GET /v1/projects/<id>/sessions
{"error":true,"message":"This agent session is not granted \"project.session.read\". Add it to the agent's kortix_cli in kortix.yaml and merge the change.","status":403}
```

Before this change both returned the role message above.

**2. service-account-scope denial** - token bound to an activated service
account whose assigned IAM role holds only `project.read`

```
POST /v1/projects/<id>/sessions
{"error":true,"message":"This agent runs as its own service account, and the role assigned to it does not allow \"project.session.start\". Ask an account admin to update that role.","status":403}
```

**3. genuine role denial** - a real project member (floor `member` role) on a
manage-tier route; wording must be unchanged

```
PATCH /v1/projects/<id>
{"error":true,"message":"Your role on this project doesn't let you manage this project. Ask an account owner or admin to grant you a higher role.","status":403}
GET   /v1/projects/<id>  -> 200
```

## Scope

Message accuracy only. No authorization decision changes - `authorizeV2`
returns exactly the same verdicts.
