### PR TITLE
fix(meta): stop the per-prompt re-mint from destroying the coordinator's grant

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,33 @@ linked, not inlined.
 
 ## Register
 
+### A platform-injected principal must never have its authority re-derived from user config (2026-08-13)
+
+**When:** touching code that RE-resolves an already-minted credential —
+`remintGrantForAgentSwitch` / `reconcileStoredSessionAgentGrant`
+(`apps/api/src/projects/lib/session-token-grant.ts`), which run on EVERY prompt
+and every connector call. The `meta` coordinator is injected by
+`addPlatformMetaAgent` and appears in no `kortix.yaml`, so resolving it through
+the manifest returns "unlisted agent": deny-all on a governed project,
+UNRESTRICTED on an ungoverned one. Both are destructive — the deny-all was
+WRITTEN over the coordinator's real grant on its first turn, and the null made
+the re-mint refuse the turn outright. Branch for the platform-owned principal in
+the ONE pure resolver every path shares (`grantFromLoadedAgents`); a special case
+at the mint alone is exactly what the re-mint then erases.
+Two traps cost hours here. A comment asserting a fast path is not evidence the
+fast path exists — `preview.ts:1144` says an ordinary turn "skips the manifest
+read entirely" while the callee has no early return at all; read the callee. And
+`authorizeV2` returns `super_admin` BEFORE the agent-grant fold, while a personal
+account's primary owner has `is_super_admin = true` — so this entire bug class is
+invisible on a laptop until you clear that flag.
+*Incident:* the meta coordinator could not list or spawn sessions for the account
+owner running it; `kortix sessions ls` / `new` 403'd from turn one onward, and
+the 403 blamed their role (that misdiagnosis fixed separately in #6443).
+*Enforcer:* `apps/api/src/__tests__/unit-meta-agent-grant-resolution.test.ts`
+pins resolution for governed / ungoverned / unreadable manifests, the `skip`
+re-mint decision, and the old destructive `write` as a regression guard. Nothing
+enforces the comment-vs-callee or super-admin traps — those are prose only.
+
 ### Anything created per-deploy needs a reaper, and the reaper needs a namespace (2026-08-12)
 
 **When:** adding or reviewing code that creates a named provider-side artifact

--- a/apps/api/src/__tests__/unit-meta-agent-grant-resolution.test.ts
+++ b/apps/api/src/__tests__/unit-meta-agent-grant-resolution.test.ts
@@ -1,0 +1,143 @@
+// The reserved coordinator's grant is PLATFORM-owned, and every path that
+// resolves a grant has to agree on that — not just the mint.
+//
+// `remintGrantForAgentSwitch` re-resolves the running agent's grant on every
+// prompt and writes the result onto the session's token row, and
+// `reconcileStoredSessionAgentGrant` does the same before a connector call.
+// Both go through `grantFromLoadedAgents`, which reads the PROJECT MANIFEST —
+// and `meta` is never declared in one. So the coordinator's token was minted
+// with `kortixCli: 'all'` and then rewritten on its first turn:
+//
+//   governed project (declares agents:)  -> unlisted -> default-DENY, and the
+//     re-mint WROTE `kortixCli: []` over the real grant. Every later `kortix`
+//     call 403'd with `agent_scope_insufficient`.
+//   ungoverned project (declares none)   -> UNRESTRICTED null, and the re-mint
+//     refuses rather than widen, failing the prompt outright.
+//
+// These tests pin the resolution for all three manifest shapes, pin that the
+// re-mint is now a no-op for meta, and pin that nothing else moved.
+import { describe, expect, test } from 'bun:test';
+
+import { grantFromLoadedAgents, type LoadedAgents } from '../projects/agents';
+import { platformMetaAgentGrant } from '../projects/lib/platform-meta-agent';
+import { remintDecisionFor } from '../projects/lib/session-token-grant';
+import { agentGrantDiffers } from '../projects/lib/secret-grant';
+
+const UNGOVERNED: LoadedAgents = { specs: [], errors: [], defaultAgent: null };
+
+const GOVERNED: LoadedAgents = {
+  specs: [
+    {
+      name: 'kortix',
+      enabled: true,
+      kortixCli: 'all',
+      connectors: 'all',
+      env: 'all',
+    },
+    {
+      name: 'worker',
+      enabled: true,
+      kortixCli: ['project.session.read'],
+      connectors: [],
+      env: [],
+    },
+  ] as unknown as LoadedAgents['specs'],
+  errors: [],
+  defaultAgent: 'kortix',
+};
+
+const UNREADABLE: LoadedAgents = {
+  specs: [],
+  errors: [{ name: '(manifest)', path: 'kortix.yaml', error: 'Failed to read manifest' }],
+  defaultAgent: null,
+};
+
+describe('grantFromLoadedAgents — the reserved meta coordinator', () => {
+  test('resolves to the platform grant on a GOVERNED project', () => {
+    // Was: { agent: 'meta', kortixCli: [], connectors: [], env: [] } — the
+    // unlisted-agent default-deny, which the per-prompt re-mint then wrote onto
+    // the session token.
+    expect(grantFromLoadedAgents('meta', GOVERNED)).toEqual(platformMetaAgentGrant());
+  });
+
+  test('resolves to the platform grant on an UNGOVERNED project', () => {
+    // Was: null (UNRESTRICTED), which made the re-mint refuse the prompt.
+    expect(grantFromLoadedAgents('meta', UNGOVERNED)).toEqual(platformMetaAgentGrant());
+  });
+
+  test('resolves to the platform grant even when the manifest is unreadable', () => {
+    // Fail-closed still holds: the platform grant is a fixed, known value that
+    // never depends on repository content, so an unreadable manifest cannot
+    // widen it.
+    expect(grantFromLoadedAgents('meta', UNREADABLE)).toEqual(platformMetaAgentGrant());
+  });
+
+  test('carries no connectors and no secrets, on every manifest shape', () => {
+    for (const loaded of [UNGOVERNED, GOVERNED, UNREADABLE]) {
+      const grant = grantFromLoadedAgents('meta', loaded);
+      expect(grant?.connectors).toEqual([]);
+      expect(grant?.env).toEqual([]);
+    }
+  });
+
+  test('the per-prompt re-mint is now a no-op for a meta session', () => {
+    // What the token holds at mint vs. what a prompt now resolves.
+    const stored = platformMetaAgentGrant();
+    const running = grantFromLoadedAgents('meta', GOVERNED);
+    expect(agentGrantDiffers(stored, running)).toBe(false);
+    expect(remintDecisionFor(stored, running)).toEqual({ action: 'skip' });
+  });
+
+  test('BEFORE the fix the same re-mint destroyed the grant (regression guard)', () => {
+    // The exact decision the old resolution produced. Kept as an explicit
+    // statement of what must never happen again.
+    const stored = platformMetaAgentGrant();
+    const oldResolution = { agent: 'meta', kortixCli: [], connectors: [], env: [] };
+    expect(remintDecisionFor(stored, oldResolution)).toEqual({
+      action: 'write',
+      grant: oldResolution,
+    });
+  });
+});
+
+describe('grantFromLoadedAgents — no other principal is widened', () => {
+  test('a declared narrow agent keeps exactly its declared kortix_cli', () => {
+    expect(grantFromLoadedAgents('worker', GOVERNED)).toEqual({
+      agent: 'worker',
+      kortixCli: ['project.session.read'],
+      connectors: [],
+      env: [],
+    });
+  });
+
+  test('an UNDECLARED non-meta agent still default-denies on a governed project', () => {
+    expect(grantFromLoadedAgents('not-declared', GOVERNED)).toEqual({
+      agent: 'not-declared',
+      kortixCli: [],
+      connectors: [],
+      env: [],
+    });
+  });
+
+  test('an agent named meta-something is NOT the reserved coordinator', () => {
+    // The reserved name is exact (`isMetaAgentName`). A near-miss must fall
+    // through to ordinary manifest resolution.
+    expect(grantFromLoadedAgents('meta-worker', GOVERNED)).toEqual({
+      agent: 'meta-worker',
+      kortixCli: [],
+      connectors: [],
+      env: [],
+    });
+    expect(grantFromLoadedAgents('Meta', GOVERNED)).toEqual({
+      agent: 'Meta',
+      kortixCli: [],
+      connectors: [],
+      env: [],
+    });
+  });
+
+  test('an ungoverned project still resolves every ordinary agent to unrestricted', () => {
+    expect(grantFromLoadedAgents('kortix', UNGOVERNED)).toBeNull();
+    expect(grantFromLoadedAgents('anything', UNGOVERNED)).toBeNull();
+  });
+});

--- a/apps/api/src/__tests__/unit-platform-meta-agent.test.ts
+++ b/apps/api/src/__tests__/unit-platform-meta-agent.test.ts
@@ -4,9 +4,9 @@ import {
   addPlatformMetaAgent,
   buildPlatformMetaOpenCodeConfig,
   platformMetaAgentGrant,
-  projectMetaAgentEnabled,
   resolvePlatformMetaSandbox,
 } from '../projects/lib/platform-meta-agent';
+import { resolveFeatureFlag } from '../feature-flags/registry';
 import { resolveManifestVerdict } from '../projects/lib/manifest-verdict';
 
 describe('platform meta agent', () => {
@@ -79,11 +79,13 @@ describe('platform meta agent', () => {
     });
   });
 
+  // Read through the canonical registry helper at every call site — the module
+  // above must stay free of runtime imports, see its header comment.
   test('is gated on the meta_agent feature flag, default off', () => {
-    expect(projectMetaAgentEnabled(null)).toBe(false);
-    expect(projectMetaAgentEnabled({})).toBe(false);
-    expect(projectMetaAgentEnabled({ experimental: {} })).toBe(false);
-    expect(projectMetaAgentEnabled({ experimental: { meta_agent: false } })).toBe(false);
-    expect(projectMetaAgentEnabled({ experimental: { meta_agent: true } })).toBe(true);
+    expect(resolveFeatureFlag(null, 'meta_agent')).toBe(false);
+    expect(resolveFeatureFlag({}, 'meta_agent')).toBe(false);
+    expect(resolveFeatureFlag({ experimental: {} }, 'meta_agent')).toBe(false);
+    expect(resolveFeatureFlag({ experimental: { meta_agent: false } }, 'meta_agent')).toBe(false);
+    expect(resolveFeatureFlag({ experimental: { meta_agent: true } }, 'meta_agent')).toBe(true);
   });
 });

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -43,6 +43,8 @@ import {
   type WorkspaceModeV2,
 } from '@kortix/manifest-schema';
 import { normalizeRequiredConnectorAliases } from './lib/agent-config-v2';
+import { isMetaAgentName } from '@kortix/shared';
+import { platformMetaAgentGrant } from './lib/platform-meta-agent';
 
 const MANIFEST_FILENAME = 'kortix.toml';
 
@@ -330,6 +332,17 @@ export async function resolveAgentGrant(
 
 /** Pure resolution rule (no I/O) — see `resolveAgentGrant`. Exported for tests. */
 export function grantFromLoadedAgents(agentName: string, loaded: LoadedAgents): AgentGrant | null {
+  // The reserved platform coordinator is injected by the platform and is NEVER
+  // declared in a project manifest, so manifest resolution cannot answer for it:
+  // a governed project falls through to the unlisted default-DENY below, and an
+  // ungoverned one returns the UNRESTRICTED null. Both are wrong, and the wrong
+  // answers were load-bearing — `remintGrantForAgentSwitch` re-resolves the
+  // running agent's grant on EVERY prompt and writes it onto the session's
+  // token, so the deny-all overwrote the coordinator's real grant on its first
+  // turn (every later `kortix` call then 403'd) and the null made the re-mint
+  // refuse the prompt outright. Its grant is platform-owned, at mint and here.
+  if (isMetaAgentName(agentName)) return platformMetaAgentGrant();
+
   // No [[agents]] section parsed and no errors → project hasn't adopted
   // per-agent governance → no restriction (today's behavior).
   if (loaded.specs.length === 0 && loaded.errors.length === 0) return null;

--- a/apps/api/src/projects/lib/platform-meta-agent.ts
+++ b/apps/api/src/projects/lib/platform-meta-agent.ts
@@ -1,15 +1,16 @@
+// No runtime imports beyond @kortix/shared: `projects/agents.ts` resolves the
+// coordinator's grant from here, and `projects/git/config.ts` imports that —
+// which `e2e-project-session-branch-git` loads in a `bun --eval` subprocess and
+// parses stdout from. Pulling `feature-flags/registry` (and through it the
+// config module, which banners on stdout) into that chain breaks it. The
+// per-project opt-in is read at its two call sites with the canonical
+// `resolveFeatureFlag(metadata, 'meta_agent')`.
 import {
   META_AGENT_NAME,
   META_SANDBOX_SLUG,
 } from '@kortix/shared';
 import type { AgentGrant } from '@kortix/db';
-import { resolveFeatureFlag } from '../../feature-flags/registry';
 import type { ProjectConfigSummary } from '../git/types';
-
-/** Per-project opt-in for the platform coordinator (Settings → Feature flags). */
-export function projectMetaAgentEnabled(metadata: unknown): boolean {
-  return resolveFeatureFlag(metadata, 'meta_agent');
-}
 
 export function addPlatformMetaAgent(config: ProjectConfigSummary): ProjectConfigSummary {
   return {

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -96,10 +96,10 @@ import {
   mergeSessionSandboxEnv,
   parseSessionRuntimeContext,
 } from './session-runtime-context';
+import { resolveFeatureFlag } from '../../feature-flags/registry';
 import { buildSessionRuntimeEnv } from './session-runtime-env';
 import {
   buildPlatformMetaOpenCodeConfig,
-  projectMetaAgentEnabled,
   resolvePlatformMetaSandbox,
 } from './platform-meta-agent';
 
@@ -737,7 +737,7 @@ export async function createProjectSession(input: {
   // (`meta_agent`). Flag off: agent resolution below is byte-for-byte the
   // pre-meta behavior, and an explicit "meta" request is an ordinary (unknown)
   // agent name.
-  const metaAgentEnabled = projectMetaAgentEnabled(project.metadata);
+  const metaAgentEnabled = resolveFeatureFlag(project.metadata, 'meta_agent');
   // Meta→meta recursion stop. Anyone — dashboard users included — may spawn
   // the meta coordinator, and an omitted agent still defaults to it. The one
   // exception is a caller that IS a meta session: its omitted agent resolves

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -38,7 +38,8 @@ import {
   serializeProject,
   serializeProjectGitConnection,
 } from '../lib/serializers';
-import { addPlatformMetaAgent, projectMetaAgentEnabled } from '../lib/platform-meta-agent';
+import { resolveFeatureFlag } from '../../feature-flags/registry';
+import { addPlatformMetaAgent } from '../lib/platform-meta-agent';
 
 function isMissingGitPathError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error || '');
@@ -136,7 +137,7 @@ projectsApp.openapi(
   // The platform coordinator appears in the agent list (and becomes the
   // default) only for projects that opted into the `meta_agent` experimental
   // feature. Flag off: the config is exactly the repo-declared surface.
-  const config = projectMetaAgentEnabled(loaded.row.metadata)
+  const config = resolveFeatureFlag(loaded.row.metadata, 'meta_agent')
     ? addPlatformMetaAgent(filteredConfig)
     : filteredConfig;
   // …and hide the raw FILES of those resources from the file list (visibility


### PR DESCRIPTION
## Symptom

The `meta` coordinator - whose entire purpose is spawning and coordinating
sub-sessions - could not do either. For the **account owner** who launched it:

- `kortix sessions ls` -> 403 (`project.session.read`)
- `kortix sessions new` -> 403
- `kortix doctor` -> "session create failed: ... higher role"

## Root cause (proved, not inferred)

**Step 1 - the mint is correct.** A real meta session on a live stack, read
straight off `account_tokens`:

```
token_id                             | session_id                           | service_account_id | agent_grant
ef9dfd04-175b-4979-8be0-55903647797f | 1d028b90-8be8-4d90-8bd9-fb11ffec90fa |                    | {"env": [], "agent": "meta", "kortixCli": "all", "connectors": []}
```

`service_account_id` is NULL and `kortixCli` is `"all"`. That eliminates both
candidate causes in the report: the token *was* minted on the meta branch, and
it carries no service-account identity.

**Step 2 - the per-prompt re-mint destroys it.**
`remintGrantForAgentSwitch` runs on **every** prompt (`preview.ts`, inside
`shouldSyncProjectEnvBeforeProxy` - not only on an actual agent switch, despite
the comment there). It re-resolves the running agent's grant via
`grantFromLoadedAgents`, which reads the **project manifest**. `meta` is
platform-injected and is never declared in a manifest, so it resolved as an
*unlisted* agent.

Real `grantFromLoadedAgents` against a real project's real manifest, before the
fix:

```
specs = [{"name":"kortix","cli":"all","enabled":true},{"name":"worker","cli":["project.session.read"],"enabled":true}]
errors = []
grantFromLoadedAgents('meta') = {"agent":"meta","kortixCli":[],"connectors":[],"env":[]}
```

And the real re-mint on that real session:

```
BEFORE agent_grant = {"env":[],"agent":"meta","kortixCli":"all","connectors":[]}
remint decision = {"action":"write","grant":{"agent":"meta","kortixCli":[],"connectors":[],"env":[]}}
AFTER  agent_grant = {"env":[],"agent":"meta","kortixCli":[],"connectors":[]}
```

From the coordinator's first turn onward the token held `kortixCli: []`, so
every `kortix` call failed the agent-grant fold with
`agent_scope_insufficient`. Reproduced over real HTTP with that exact token:

```
GET  /v1/projects/<id>/sessions -> 403 "You don't have permission to perform this action (project.session.read)."
POST /v1/projects/<id>/sessions -> 403 "Your role on this project doesn't let you change this project. Ask an account owner or admin to grant you a higher role."
```

The second message is the separate misdiagnosis fixed in #6443 - the account
owner was told to ask an account owner for a higher role.

There is a second broken shape on the same line: for an **ungoverned** project
(no `agents:` at all) the resolution returns `null` = UNRESTRICTED, and
`remintDecisionFor` correctly refuses to widen - so the prompt fails outright
with `SessionGrantRemintError`.

> Note for reviewers reproducing locally: a personal account's primary owner has
> `account_members.is_super_admin = true`, and `authorizeV2` short-circuits on
> super-admin **before** the agent-grant fold. The failure only appears for a
> non-super-admin owner (any team account), which is what the reporter had.

## Fix

`grantFromLoadedAgents` is the one pure resolver that mint
(`resolveAgentGrant`), the per-prompt re-mint and the connector-call reconcile
(`reconcileStoredSessionAgentGrant`) all share. The reserved coordinator's grant
is platform-owned, so it is answered there rather than looked for in a manifest
that structurally cannot contain it. All three paths now agree, the re-mint
decides `skip`, and the token is never rewritten.

`platform-meta-agent.ts` also drops the one-line `projectMetaAgentEnabled`
wrapper; its two call sites read the canonical
`resolveFeatureFlag(metadata, 'meta_agent')` directly. **This is load-bearing,
not cosmetic:** `projects/agents.ts` is imported by `projects/git/config.ts`,
which `e2e-project-session-branch-git` loads in a `bun --eval` subprocess and
JSON-parses stdout from. Reaching the config module (which banners on stdout)
from that chain breaks it - observed as a real test failure before this change.

## Verification

**Unit** - `unit-meta-agent-grant-resolution.test.ts`, 10 tests: resolution for
governed / ungoverned / unreadable-manifest, `remintDecisionFor` is now `skip`,
an explicit regression guard pinning the old `write` decision, and the negative
set below.

**Suite** - `bun test` (apps/api, 612 files): `6805 pass / 1 fail`. The single
failure is the pre-existing missing `node-forge` package in
`src/secrets/egress-proxy/proxy.test.ts`, identical on `main` (`6795 pass /
1 fail`). `tsc --noEmit`: only that same pre-existing TS2307.

**Real stack, after the fix.** New meta session created over HTTP, then the real
re-mint run against it:

```
create meta session HTTP 201 session_id a3a3a4ee-82f6-4b61-af0d-3fdbe55f327e
BEFORE agent_grant = {"env":[],"agent":"meta","kortixCli":"all","connectors":[]}
remint decision = {"action":"skip"}
AFTER  agent_grant = {"env":[],"agent":"meta","kortixCli":"all","connectors":[]}
```

Coordinator token against the live API - the two commands that were broken:

```
GET  /v1/projects/<id>/sessions -> 200
POST /v1/projects/<id>/sessions -> 201
```

**Negative test - no other principal is widened.** A scoped agent token whose
`kortix_cli` is `["project.session.read"]`, same project, same account:

```
GET   /v1/projects/<id>/sessions  -> 200   (granted)
POST  /v1/projects/<id>/sessions  -> 403   (not granted)
PATCH /v1/projects/<id>/features  -> 403   (not granted)
```

Unit-level negatives cover the rest: an undeclared non-meta agent still
default-denies, a declared narrow agent keeps exactly its declared list, an
ungoverned project still resolves ordinary agents to unrestricted, and near-miss
names (`meta-worker`, `Meta`) are **not** the reserved coordinator.

## Not changed

`platformMetaAgentGrant()` still returns `kortixCli: 'all'` with no connectors
and no secrets, still capped by the launching user's IAM role and the token's
project binding. The open Strix MEDIUM (CWE-863) on that grant is untouched -
see the PR discussion for why narrowing it is not part of this fix.
