### PR TITLE
fix(secrets): the boundary echo guidance was lying to shim-backed agents

### DIFF
--- a/apps/api/src/projects/secret-capabilities.test.ts
+++ b/apps/api/src/projects/secret-capabilities.test.ts
@@ -315,3 +315,75 @@ describe('buildSecretCapabilities describes the network boundary', () => {
     expect(parsed.notes.network).toEqual([...NETWORK_BOUNDARY_NOTES]);
   });
 });
+
+/**
+ * The echo wording is mode-specific because the two mechanisms produce
+ * OPPOSITE symptoms for the same working request.
+ *
+ * Platinum's edge CUTS an echoing response, so `curl` reports an empty reply
+ * and that means success. The in-guest shim relays through the broker, which
+ * REDACTS instead, so success is a 200 containing `[REDACTED]` and an empty
+ * reply is a genuine failure. Telling a shim-backed agent the edge's story
+ * makes it read a dead host as a working boundary — which is why the catalog
+ * cannot keep hardcoding one of them.
+ */
+describe('network-boundary echo guidance follows the mechanism', () => {
+  const boundaryRow = {
+    secretId: '00000000-0000-4000-8000-0000000000ff',
+    identifier: 'BOUNDARY_ONE',
+    key: 'BOUNDARY_ONE',
+    value: 'sk_never_in_the_catalog',
+    strategy: 'egress' as const,
+    consumer: 'network' as const,
+    egressPolicy: {
+      rules: [{ host: 'api.example.com' }],
+      inject: { kind: 'header' as const, name: 'x-demo', template: 'Bearer {{secret}}' },
+      on_no_match: 'deny' as const,
+      tls: 'terminate' as const,
+    },
+  };
+  const build = (boundaryMode: 'provider-edge' | 'in-guest-shim' | null) =>
+    buildSecretCapabilities([boundaryRow], {
+      grantEnv: ['BOUNDARY_ONE'],
+      // Network delivery is handle-based, so it is withheld entirely without a
+      // session — without this the catalog is empty and every assertion below
+      // would vacuously pass on `undefined`.
+      sessionId: 'session-1',
+      boundaryMode,
+    });
+
+  test('the provider edge says an empty reply is success', () => {
+    const catalog = build('provider-edge');
+    expect(catalog.capabilities[0]).toMatchObject({ delivery: 'network', on_echo: 'block' });
+    const notes = (catalog.notes?.network ?? []).join(' ');
+    expect(notes).toContain('cut mid-flight');
+    expect(notes).toContain('Empty reply from server');
+    expect(notes).not.toContain('[REDACTED]');
+  });
+
+  test('the in-guest shim says [REDACTED] is success and an empty reply is NOT', () => {
+    const catalog = build('in-guest-shim');
+    expect(catalog.capabilities[0]).toMatchObject({ delivery: 'network', on_echo: 'redact' });
+    const notes = (catalog.notes?.network ?? []).join(' ');
+    expect(notes).toContain('[REDACTED]');
+    // The exact inversion that would mislead an agent.
+    expect(notes).toContain('is a REAL failure here');
+    expect(notes).not.toContain('Empty reply from server');
+  });
+
+  test('both modes still forbid inventing a credential', () => {
+    for (const mode of ['provider-edge', 'in-guest-shim'] as const) {
+      const notes = (build(mode).notes?.network ?? []).join(' ');
+      expect(notes).toContain('do not invent a credential');
+      expect(notes).toContain('The value is not in this sandbox');
+    }
+  });
+
+  test('an unknown mechanism keeps the pre-shim wording rather than guessing', () => {
+    // Conservative: `block` is what every deployment did before the shim, so a
+    // caller that cannot name the mechanism gets the historical answer instead
+    // of a claim about a mechanism it never chose.
+    const catalog = build(null);
+    expect(catalog.capabilities[0]).toMatchObject({ on_echo: 'block' });
+  });
+});

--- a/apps/api/src/projects/secret-capabilities.ts
+++ b/apps/api/src/projects/secret-capabilities.ts
@@ -43,8 +43,19 @@ export type SecretCapability =
       scheme: 'https';
       /** The value is not in the sandbox in any form. */
       readable_in_sandbox: false;
-      /** A response that would echo the value back into the sandbox is cut. */
-      on_echo: 'block';
+      /**
+       * What happens when an upstream echoes the credential back.
+       *
+       *  - `block`   the provider edge CUTS the response mid-flight (Platinum)
+       *  - `redact`  Kortix replaces the value with `[REDACTED]` and returns
+       *              the rest (the in-guest shim, which relays through the
+       *              broker)
+       *
+       * This is not cosmetic. The two produce OPPOSITE symptoms for the same
+       * working request — an empty reply versus a 200 — so an agent told the
+       * wrong one misreads success as failure, or the reverse.
+       */
+      on_echo: 'block' | 'redact';
     };
 
 /**
@@ -59,18 +70,44 @@ export type SecretCapability =
  * same for every network secret, and repeating them would spend the 48 KB
  * budget that `serializeSecretCapabilities` divides between capabilities.
  */
-export const NETWORK_BOUNDARY_NOTES: readonly string[] = [
+const SHARED_BOUNDARY_NOTES: readonly string[] = [
   'Kortix adds these credentials outside the sandbox, at the network boundary.',
   'The value is not in this sandbox: no environment variable, no file, no alias, no placeholder.',
   'Do not search for the value, do not ask the user for it, and do not build the header yourself.',
   'Send an ordinary request with no credential. The boundary sets the header in flight.',
   'Each capability lists its own `hosts` and `header`. Only those hosts get that header.',
   'HTTPS is required. Plain HTTP to a listed host is refused before it leaves the sandbox.',
+]
+
+/** Provider edge (Platinum): the echoing response is CUT. */
+export const NETWORK_BOUNDARY_NOTES_BLOCK: readonly string[] = [
+  ...SHARED_BOUNDARY_NOTES,
   'A response that would echo the value back into the sandbox is cut mid-flight.',
   'So `curl: (52) Empty reply from server` on a listed host means the boundary worked. The host is not down.',
   'Verify with an endpoint that CONSUMES the credential and returns 200 or 401, never one that reflects request headers.',
   'A listed host that answers 401 means the header did not arrive. Report that; do not invent a credential.',
-];
+]
+
+/**
+ * In-guest shim: the echoing response comes back REDACTED, not cut.
+ *
+ * The opposite symptom from the edge, which is the whole reason these are two
+ * lists. Telling a shim-backed agent that an empty reply means success would
+ * have it read a genuinely dead host as a working boundary — and read the real
+ * success (a 200 containing `[REDACTED]`) as a failure.
+ */
+export const NETWORK_BOUNDARY_NOTES_REDACT: readonly string[] = [
+  ...SHARED_BOUNDARY_NOTES,
+  'A response that would echo the value back into the sandbox comes back with `[REDACTED]` in its place.',
+  'So seeing `[REDACTED]` on a listed host means the boundary worked — that is the credential, removed on the way in.',
+  'An empty reply or a connection error on a listed host is a REAL failure here. Do not read it as the boundary working.',
+  'Requests are relayed through Kortix, so responses are not streamed: no SSE, no websockets, and large bodies are capped.',
+  'A listed host that answers 401 means the header did not arrive. Report that; do not invent a credential.',
+]
+
+/** @deprecated Ambiguous now that two mechanisms exist. Use the mode-specific
+ *  lists above; kept so an out-of-tree importer keeps compiling. */
+export const NETWORK_BOUNDARY_NOTES = NETWORK_BOUNDARY_NOTES_BLOCK
 
 export interface SecretCapabilityCatalog {
   version: 1;
@@ -122,8 +159,18 @@ export function buildSecretCapabilities(
     grantEnv?: string[] | 'all';
     sessionAllowlist?: string[] | null;
     sessionId?: string | null;
+    /**
+     * Which mechanism actually serves this session's boundary secrets.
+     *
+     * Defaults to the provider edge. That is the conservative default for a
+     * caller that has not been updated: `block` is what Platinum has always
+     * done, so an un-passed mode keeps the pre-shim wording rather than
+     * inventing a claim about a mechanism the caller never named.
+     */
+    boundaryMode?: 'provider-edge' | 'in-guest-shim' | null;
   },
 ): SecretCapabilityCatalog {
+  const echo = input.boundaryMode === 'in-guest-shim' ? 'redact' : 'block';
   const capabilities: SecretCapability[] = [];
 
   for (const row of rows) {
@@ -181,7 +228,7 @@ export function buildSecretCapabilities(
           header: destination.header,
           scheme: 'https',
           readable_in_sandbox: false,
-          on_echo: 'block',
+          on_echo: echo,
         });
       }
       continue;
@@ -214,7 +261,13 @@ export function buildSecretCapabilities(
   return {
     version: 1,
     capabilities,
-    ...(hasNetworkCapability(capabilities) ? { notes: { network: NETWORK_BOUNDARY_NOTES } } : {}),
+    ...(hasNetworkCapability(capabilities)
+      ? {
+          notes: {
+            network: echo === 'redact' ? NETWORK_BOUNDARY_NOTES_REDACT : NETWORK_BOUNDARY_NOTES_BLOCK,
+          },
+        }
+      : {}),
   };
 }
 
@@ -226,7 +279,7 @@ export function serializeSecretCapabilities(catalog: SecretCapabilityCatalog): s
   // The notes travel with the capabilities they explain: dropped when
   // truncation leaves no network capability, and counted against the budget
   // when it does, so the payload cannot exceed the cap by adding them last.
-  const notes = catalog.notes ?? { network: NETWORK_BOUNDARY_NOTES };
+  const notes = catalog.notes ?? { network: NETWORK_BOUNDARY_NOTES_BLOCK };
   const build = (kept: SecretCapability[]): SecretCapabilityCatalog => ({
     version: 1,
     capabilities: kept,

--- a/apps/api/src/projects/secrets.ts
+++ b/apps/api/src/projects/secrets.ts
@@ -2,6 +2,7 @@ import { createHash, createCipheriv, createDecipheriv, hkdfSync, randomBytes } f
 import { SESSION_SECRETS_ALLOWLIST_MAX_KEYS } from '@kortix/api-contract';
 import { and, desc, eq, isNull, or, sql } from 'drizzle-orm';
 import { projectSecrets, projectSessionSecretHandles, projectSessions, projects } from '@kortix/db';
+import { networkBoundaryMode } from '../secrets/network-boundary-availability';
 import { config } from '../config';
 import { recordAuditEvent } from '../shared/audit';
 import { db } from '../shared/db';
@@ -721,6 +722,38 @@ async function mintSessionSecretHandle(
   return result.handle;
 }
 
+
+/**
+ * Which mechanism will serve this session's network-boundary secrets.
+ *
+ * Reads the session's own provider and the project's flag, because the answer
+ * is per-SESSION: the same project can run one session on Platinum (edge) and
+ * the next on Daytona (shim), and `provider` is chosen per session create.
+ *
+ * Returns null when there is no session (a monitor box, or a snapshot built
+ * outside any session). Null withholds the echo guidance rather than guessing —
+ * the guidance is only useful if it is right, and each mechanism's symptom is
+ * the other's failure signal.
+ */
+async function resolveSessionBoundaryMode(
+  projectId: string,
+  sessionId: string | null,
+): Promise<'provider-edge' | 'in-guest-shim' | null> {
+  if (!sessionId) return null;
+  const [session] = await db
+    .select({ provider: projectSessions.sandboxProvider })
+    .from(projectSessions)
+    .where(and(eq(projectSessions.sessionId, sessionId), eq(projectSessions.projectId, projectId)))
+    .limit(1);
+  if (!session?.provider) return null;
+  const [project] = await db
+    .select({ metadata: projects.metadata })
+    .from(projects)
+    .where(eq(projects.projectId, projectId))
+    .limit(1);
+  return networkBoundaryMode(session.provider, project?.metadata);
+}
+
 export async function listProjectSecretsSnapshotForUser(
   projectId: string,
   userId: string | null,
@@ -745,9 +778,25 @@ export async function listProjectSecretsSnapshotForUser(
   });
 
   const names = Object.keys(env).sort();
+  // Which mechanism will serve this session's boundary secrets — resolved
+  // HERE rather than threaded in.
+  //
+  // It decides the guest-facing echo wording, and the two mechanisms produce
+  // OPPOSITE symptoms for the same working request: the provider edge CUTS an
+  // echoing response (an empty reply means it worked) while the in-guest shim
+  // REDACTS it (a 200 containing `[REDACTED]` means it worked). Tell an agent
+  // the wrong one and it reads a dead host as success, or success as failure.
+  //
+  // Threading it from the callers was the first attempt and it was worse: four
+  // layers, and the two that build the catalog (session boot and the mid-session
+  // hot push) sit behind different call chains, so one of them would have kept
+  // today's edge-only wording while the other got the truth. One lookup, in the
+  // one function that builds the catalog, cannot disagree with itself.
+  const boundaryMode = await resolveSessionBoundaryMode(projectId, sessionId ?? null);
   const capabilities = buildSecretCapabilities(selected, {
     grantEnv,
     sessionId: sessionId ?? null,
+    boundaryMode,
   });
   return {
     env,

--- a/apps/kortix-sandbox-agent-server/src/__tests__/secret-capabilities-network.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/secret-capabilities-network.test.ts
@@ -80,3 +80,60 @@ describe('network-boundary capabilities in the agent instructions', () => {
     expect(md).toContain('`authorization`')
   })
 })
+
+/**
+ * The echo guidance is authored by the API (mode-aware since the in-guest shim
+ * shipped) and rendered here verbatim. This asserts the passthrough, because
+ * the two mechanisms give OPPOSITE advice for the same symptom: the provider
+ * edge cuts an echoing response (empty reply = success) while the shim redacts
+ * it (200 with `[REDACTED]` = success). A renderer that dropped or rewrote
+ * these lines would leave the agent reading a dead host as a working boundary.
+ */
+describe('boundary echo notes reach the agent unchanged', () => {
+  const catalog = (network: string[]) =>
+    JSON.stringify({
+      version: 1,
+      capabilities: [
+        {
+          identifier: 'BOUNDARY_ONE',
+          delivery: 'network',
+          hosts: ['api.example.com'],
+          header: 'x-demo',
+        },
+      ],
+      notes: { network },
+    })
+
+  test('the shim wording survives rendering', () => {
+    const out = renderSecretCapabilitiesInstruction(
+      catalog([
+        'A response that would echo the value back into the sandbox comes back with `[REDACTED]` in its place.',
+        'An empty reply or a connection error on a listed host is a REAL failure here. Do not read it as the boundary working.',
+      ]),
+    )
+    expect(out).toContain('[REDACTED]')
+    expect(out).toContain('is a REAL failure here')
+  })
+
+  test('the provider-edge wording survives rendering', () => {
+    const out = renderSecretCapabilitiesInstruction(
+      catalog(['So `curl: (52) Empty reply from server` on a listed host means the boundary worked.']),
+    )
+    expect(out).toContain('Empty reply from server')
+  })
+
+  test('the renderer does not invent echo guidance when the API sent none', () => {
+    // The API withholds the notes when it cannot tell which mechanism serves
+    // the session. The guest must not fill that in.
+    const out = renderSecretCapabilitiesInstruction(
+      JSON.stringify({
+        version: 1,
+        capabilities: [
+          { identifier: 'B', delivery: 'network', hosts: ['api.example.com'], header: 'x' },
+        ],
+      }),
+    )
+    expect(out).not.toContain('[REDACTED]')
+    expect(out).not.toContain('Empty reply from server')
+  })
+})


### PR DESCRIPTION
Follow-up to #6447. When the in-guest shim shipped, it made a code path reachable that the guest-facing capability catalog describes **incorrectly** — and I'm the one who made it reachable.

## The bug

The catalog hardcoded `on_echo: 'block'` and told every agent:

> "A response that would echo the value back into the sandbox is cut."
> "So `curl: (52) Empty reply from server` on a listed host means the boundary worked. The host is not down."

That is true of **Platinum's edge**, which cuts the response. It is false of the **in-guest shim**, which relays through the broker and gets **redaction**.

The two mechanisms produce **opposite symptoms for the same working request**:

| | working request looks like | empty reply means |
| --- | --- | --- |
| provider edge | `curl: (52) Empty reply` | success |
| in-guest shim | `200` containing `[REDACTED]` | **a real failure** |

So a shim-backed agent was being taught to read a dead host as a working boundary, and to read real success as failure. This is the exact confusion the notes were written to prevent — a product owner previously lost days to it — now pointing the wrong way.

## The fix

The catalog picks its wording from the mechanism that will actually serve the session, and the shim wording also states the relay's limits (no streaming/SSE/websockets, capped bodies).

**Resolved in one place** — `listProjectSecretsSnapshotForUser`, the only function that builds the catalog — rather than threaded from callers. Threading was my first attempt and it was worse: four layers, and the two catalog-building paths (session boot, and the mid-session hot push) sit behind different call chains, so one would have kept the edge-only wording while the other got the truth. One lookup cannot disagree with itself.

**The mode is per-session, not per-project.** `provider` is chosen at session create, so the same project can run a Platinum session and a Daytona session served by different mechanisms.

**Unknown stays conservative.** No session ⇒ no mode ⇒ the pre-shim wording, rather than a claim about a mechanism nobody chose. A test pins that, and another pins that the guest renderer invents no guidance when the API sends none.

## Verification

| | |
| --- | --- |
| `kortix-api` | **6786 pass / 0 fail** |
| sandbox daemon | **539 pass / 0 fail** |
| tsc (both) | clean |

New tests cover both mechanisms' wording, the shared rules that must survive in both, the unknown case, and — across the package boundary — that the notes reach the agent's instruction file unchanged.

One note on running these locally: `bun test src/projects/` directly reports ~165 failures from the known cross-file `mock.module` leak. `bash scripts/test.sh` (what `pnpm --filter kortix-api test` runs) is the real gate and is what the numbers above come from.