### PR TITLE
fix(sandbox): the shim CA was unusable by python — missing key identifiers

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/egress-shim/ca.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/ca.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The certificate extensions, pinned because a missing one is invisible until a
+ * specific client rejects the chain in a real guest.
+ *
+ * Found the hard way: without the key-identifier pair, `curl` accepted the
+ * certificate and `python3 -m requests` refused it with
+ * `CERTIFICATE_VERIFY_FAILED ... Missing Authority Key Identifier`. Measured in
+ * a real Daytona sandbox — every local test passed while Python was broken for
+ * every agent that would have used it.
+ */
+import { describe, expect, test } from 'bun:test'
+import net from 'node:net'
+import tls from 'node:tls'
+import forge from 'node-forge'
+import { createEphemeralCa, LeafIssuer } from './ca'
+
+const ca = createEphemeralCa('test')
+const leaf = new LeafIssuer(ca).issue('api.example.com')
+const parse = (pem: string) => forge.pki.certificateFromPem(pem)
+
+describe('the chain carries the identifiers strict clients demand', () => {
+  test('the CA publishes a Subject Key Identifier', () => {
+    // An AKI can only reference a SKI that exists on the issuer, so this is the
+    // half that makes the leaf's reference resolvable.
+    expect(parse(ca.certPem).getExtension('subjectKeyIdentifier')).toBeTruthy()
+  })
+
+  test('the leaf carries BOTH its own SKI and an Authority Key Identifier', () => {
+    const cert = parse(leaf.certPem)
+    expect(cert.getExtension('subjectKeyIdentifier')).toBeTruthy()
+    expect(cert.getExtension('authorityKeyIdentifier')).toBeTruthy()
+  })
+
+  test("the leaf's AKI actually matches the CA's key id", () => {
+    // A present-but-wrong AKI is worse than none: it points the verifier at an
+    // issuer that does not exist. The first fix emitted exactly that and every
+    // TLS handshake failed with "unable to verify the first certificate".
+    const caKeyId = parse(ca.certPem).generateSubjectKeyIdentifier().getBytes()
+    const aki = parse(leaf.certPem).getExtension('authorityKeyIdentifier') as
+      | { value?: string }
+      | undefined
+    expect(aki?.value).toContain(caKeyId)
+  })
+})
+
+describe('a real TLS client verifies the chain', () => {
+  test('handshake succeeds and reports authorized', async () => {
+    // The end-to-end assertion the extension checks above only approximate.
+    const server = tls.createServer({ cert: leaf.certPem, key: leaf.keyPem }, (s) => s.end('ok'))
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()))
+    const port = (server.address() as net.AddressInfo).port
+    const authorized = await new Promise<boolean>((resolve) => {
+      const c = tls.connect(
+        { port, host: '127.0.0.1', servername: 'api.example.com', ca: ca.certPem },
+        () => {
+          const ok = c.authorized
+          c.destroy()
+          resolve(ok)
+        },
+      )
+      c.on('error', () => resolve(false))
+    })
+    server.close()
+    expect(authorized).toBe(true)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/ca.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/ca.ts
@@ -81,6 +81,13 @@ export function createEphemeralCa(label: string, ttlMs: number = DEFAULT_CA_TTL_
     // be used to mint another CA.
     { name: 'basicConstraints', cA: true, pathLenConstraint: 0, critical: true },
     { name: 'keyUsage', keyCertSign: true, cRLSign: true, critical: true },
+    // Required, not decorative. Python's OpenSSL refuses a chain whose leaf
+    // carries no Authority Key Identifier, and an AKI can only reference a
+    // Subject Key Identifier that exists on the issuer. Without this pair
+    // `requests` fails with `CERTIFICATE_VERIFY_FAILED ... Missing Authority
+    // Key Identifier` while curl accepts the same certificate — measured in a
+    // real Daytona guest, which is the only place it showed up.
+    { name: 'subjectKeyIdentifier' },
   ])
   cert.sign(keys.privateKey, forge.md.sha256.create())
 
@@ -104,11 +111,21 @@ export class LeafIssuer {
    */
   private readonly caKey: forge.pki.rsa.PrivateKey
   private readonly notAfter: Date
+  /** The CA's own key id, so each leaf's AKI can point back at it. */
+  private readonly caSubjectKeyId: string
 
   constructor(ca: EphemeralCa) {
     this.caCert = forge.pki.certificateFromPem(ca.certPem)
     this.caKey = forge.pki.privateKeyFromPem(ca.keyPem) as forge.pki.rsa.PrivateKey
     this.notAfter = ca.notAfter
+    // forge computes this from the public key when the extension is generated;
+    // read it back off the parsed cert so the leaf references the real bytes
+    // rather than a recomputation that could drift.
+    // forge's own derivation of the CA public key's identifier, as raw octets.
+    // Reading the parsed extension back gives a hex string that forge then
+    // re-encodes wrongly, producing a chain OpenSSL rejects with "unable to
+    // verify the first certificate" — measured.
+    this.caSubjectKeyId = this.caCert.generateSubjectKeyIdentifier().getBytes()
   }
 
   /**
@@ -134,6 +151,13 @@ export class LeafIssuer {
       { name: 'basicConstraints', cA: false, critical: true },
       { name: 'keyUsage', digitalSignature: true, keyEncipherment: true, critical: true },
       { name: 'extKeyUsage', serverAuth: true },
+      // See the CA's subjectKeyIdentifier above: this is the half Python
+      // actually looks for.
+      { name: 'subjectKeyIdentifier' },
+      // keyIdentifier ONLY. The issuer+serial form (`authorityCertIssuer` +
+      // `serialNumber`) is also legal ASN.1 but forge emits it in a shape
+      // OpenSSL would not chain; the bare key id is what Python asks for.
+      { name: 'authorityKeyIdentifier', keyIdentifier: this.caSubjectKeyId },
       {
         name: 'subjectAltName',
         // type 2 = dNSName, type 7 = iPAddress. A literal-IP destination needs


### PR DESCRIPTION
Found by running the in-guest shim inside a **real Daytona sandbox** (your personal account, since dev's billing gate blocks session creation). Every local test and every `curl` probe passed. Python did not:

```
requests.exceptions.SSLError: CERTIFICATE_VERIFY_FAILED
  ... Missing Authority Key Identifier
```

## The bug

The CA published no **Subject Key Identifier** and the leaves carried no **Authority Key Identifier**, so OpenSSL could not bind a leaf to its issuer. `curl` accepted the chain regardless — which is exactly why this was invisible: 27 passing tests, a working `curl`, and a shim that was broken for every agent reaching for `requests`.

## The first fix was worse, and that's worth recording

forge's *parsed* `subjectKeyIdentifier` is a hex **string**. Passing it back as `keyIdentifier` (with `authorityCertIssuer` + `serialNumber`) emitted an AKI pointing at an issuer that does not exist — every handshake then failed with `unable to verify the first certificate`. `generateSubjectKeyIdentifier().getBytes()` gives the raw octets, and the bare key-id form is what Python asks for.

## Re-measured in the same sandbox, after the fix

| probe | before | after |
| --- | --- | --- |
| `curl` → ruled host | relayed | relayed |
| `python3` requests → ruled host | **SSLError** | **200** |
| `curl` → unruled host | 200 (blind tunnel) | 200 (blind tunnel) |
| `accept-encoding` seen by the broker | `identity` | `identity` |

The relay payload confirms the whole in-guest path: `relayed_url: https://postman-echo.com/get`, `saw_x_probe: from-python`, `accept_encoding: identity`.

## Tests

Pin both extensions, that the leaf's AKI **matches the CA's actual key id**, and a real TLS handshake asserting `authorized`. The match assertion matters: a present-but-wrong AKI passes an existence check and fails every connection — which is precisely what my first fix shipped.

daemon **543 pass / 0 fail**, tsc clean.