### PR TITLE
docs: network-boundary secrets work on Daytona — measured, not argued

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -257,3 +257,48 @@ grep -E treats `\t` in single quotes as a literal `t` while macOS grep interpret
 it, so a locally-green pattern can be dead on ubuntu runners. Use ANSI-C
 quoting (`$'\t'`) and test the exact pattern in an ubuntu container.
 *Incident:* staging web verify failed twice on the same one-line assertion.
+
+### A TLS/proxy component is only as correct as the third-party clients that accept it (2026-08-14)
+
+**When:** shipping anything that terminates TLS, mints certificates, or sits in
+front of other people's HTTP clients (the in-guest egress shim, any MITM proxy).
+Unit tests and a `curl` probe are NOT evidence. Three separate bugs in this one
+component passed every in-process test and every curl check, and each was found
+only by running a real heterogeneous client in a real guest:
+
+- `git` sends CONNECT, gets a 407, and retries **on the same socket**. Without
+  `Content-Length: 0` + `Connection: close` on the challenge the retry vanishes
+  and every clone fails, while curl is unaffected because it reconnects.
+- Python's OpenSSL refuses a chain whose leaf carries no **Authority Key
+  Identifier** (`CERTIFICATE_VERIFY_FAILED ... Missing Authority Key
+  Identifier`); curl accepts the identical certificate. An AKI also needs a
+  **Subject Key Identifier** on the issuer to point at, and node-forge's PARSED
+  `subjectKeyIdentifier` is a hex string — feeding it back yields an AKI naming
+  an issuer that does not exist and breaks every handshake. Use
+  `caCert.generateSubjectKeyIdentifier().getBytes()`.
+- `curl` offers `Accept-Encoding: gzip` by default. Any redaction that scans
+  response BYTES is silently defeated by a compressed body, so a credential
+  echoed back returns intact. Force `identity` on the relayed request.
+
+Run the real clients — `curl`, `python3 -m requests`, `git`, `node fetch` — in a
+real sandbox before claiming a proxy works, and assert on what the UPSTREAM
+received, not on the absence of an error.
+*Incident:* the Daytona network-boundary shim shipped to dev broken for every
+Python client; caught by a live probe, not by 27 green tests.
+
+### Bun diverges from Node in three load-bearing ways around raw sockets and TLS (2026-08-14)
+
+**When:** writing socket/TLS code that runs under Bun (the API and the sandbox
+daemon both do). Measured, bun 1.3.14 vs node v22.22.0:
+
+- `http.Server.emit('connection', socket)` is a **no-op** — the request event
+  never fires and the connection hangs with nothing in any log. Use a real
+  loopback listener and pipe into it.
+- `SNICallback` **never fires** — the handshake completes against a default
+  certificate. Bind one static-cert listener per terminated host instead.
+- The `'upgrade'` event fires, but a write from that handler **never reaches the
+  client**; Node delivers the same bytes. Destroy the socket rather than trying
+  to answer.
+
+All three fail SILENTLY (a hang, or the wrong certificate), never an exception.
+*Incident:* each cost a debugging cycle in the egress proxy/shim.

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -633,21 +633,75 @@ caveat found the hard way — a required POSITIONAL parameter is not enough. The
 slot compiled while feeding the grants config in as the project metadata. The signature is
 named options for that reason.
 
-#### Blocked on infrastructure, not code
+### 7.7 PARITY, PROVEN ON DAYTONA
 
-- **Dev Daytona provisioning is failing** (`/start` succeeds, the sandbox never reaches
-  running), which blocks the Daytona re-run of §7.4.1.
-- **The Daytona snapshot quota is exhausted** — 225 of 200 — so every CI run that builds a
-  snapshot fails, on any PR. Deleting all 18 CI snapshots only reaches 207; the bulk is live
-  product data (`kortix-meta-*` 117, `kortix-app-*` 38). Needs a quota raise or a retention
-  policy.
+The whole point of this document, measured end to end on a real Daytona sandbox on dev
+(`ed82f4f969`), with every link real and nothing stubbed:
 
+```
+agent curl ──▶ in-guest shim ──▶ Kortix broker route ──▶ postman-echo.com
+```
 
-- **Provisioning wiring.** Mint the CA per session, push it into the guest trust store plus
-  the ~11 per-runtime env vars, set `HTTPS_PROXY`, and set `networkAllowList` to the proxy.
+An unmodified `curl` inside the guest:
+
+```json
+{"headers":{"host":"postman-echo.com","accept-encoding":"gzip, br","accept":"*/*",
+ "x-parity":"Bearer [REDACTED]","user-agent":"curl/8.5.0"},
+ "url":"https://postman-echo.com/get"}
+```
+
+One response proves three things at once, which is why an echo endpoint is the right probe
+HERE and the wrong one under Platinum's edge (§7.6):
+
+- `x-parity` is present → **the credential was injected**
+- the value reads `[REDACTED]` → **the echo was scrubbed server-side**
+- the real value appears nowhere → **it never entered the sandbox**
+
+`python-requests/2.34.2` returns the same, and `env` inside the guest contains neither the
+value nor the key. An unruled host (`example.com`) still answers 200 through a blind tunnel,
+so pinned-certificate and mTLS clients are untouched. **14 assertions, 0 failures.**
+
+This is the Platinum property on a provider with no credential edge of its own.
+
+#### What running it for real caught that nothing local did
+
+Both bugs passed every unit test and every `curl` probe:
+
+1. **The CA was unusable by Python.** No Subject Key Identifier on the CA, no Authority Key
+   Identifier on the leaves, so OpenSSL could not bind a leaf to its issuer.
+   `CERTIFICATE_VERIFY_FAILED ... Missing Authority Key Identifier`. curl accepted the same
+   chain, so only a real Python client in a real guest surfaced it. The first fix was worse:
+   forge's parsed `subjectKeyIdentifier` is a hex STRING, and feeding it back produced an AKI
+   pointing at an issuer that does not exist — every handshake then failed.
+   `generateSubjectKeyIdentifier().getBytes()` is the correct source.
+2. **gzip silently defeated echo redaction.** The broker redacts by scanning response BYTES; a
+   compressed body does not contain them, and `curl` offers gzip by default. Visible in the
+   run above as the shim forcing `accept-encoding: identity`.
+
+That is now three bugs in this feature that ONLY a real client in a real guest found — the
+`git` 407 framing bug of §7.6 was the first. The pattern is worth naming: this component's
+correctness is defined by what heterogeneous third-party clients accept, and no amount of
+in-process testing substitutes for running them.
+
+#### Getting a dev session at all
+
+Dev enforces billing (`billingStateAllowsRun` admits only `active`), so a fresh account 402s
+on session create and the feature cannot be reached. Funding one the way CI does —
+`tests/src/fixtures/billing.ts`, a real Stripe **test-mode** subscription — is the unblock.
+Note the account becomes runnable from the SUBSCRIPTION alone; the forged credit-purchase
+webhook returns 400 against dev because the deployed API validates the signature against AWS
+Secrets Manager rather than `.env.dev`.
+
+#### Still open
+
 - **Allow-list survival across resume / CoW-restore** — the funnel must not open on restore.
-- **Clients that ignore `HTTPS_PROXY`** (notably Node/Bun `fetch`) reach nothing once the
-  allow-list is on. Needs either an `LD_PRELOAD` shim or honest documentation.
+  Not required for the security property (an agent that bypasses the shim gets an
+  UNAUTHENTICATED request, never a credential), so this is egress restriction, a separate
+  feature.
+- **The relay's shape**, inherited from the broker: fully buffered, so no streaming, SSE or
+  websockets; 1 MiB request / 5 MiB response caps; redirects followed server-side.
+- **Daytona snapshot quota** — 225 of 200 at the time of writing; the bulk is live product
+  data (`kortix-meta-*` 117, `kortix-app-*` 38). Needs a retention policy, not a one-off purge.
 
 ## 8. What I would not build
 


### PR DESCRIPTION
Closes the loop on #6447 / #6448 / #6449.

## The result

Measured end to end on a **real Daytona sandbox** on dev (`ed82f4f969`) — every link real, nothing stubbed:

```
agent curl ──▶ in-guest shim ──▶ Kortix broker route ──▶ postman-echo.com
```

```json
{"headers":{"host":"postman-echo.com","x-parity":"Bearer [REDACTED]",
            "user-agent":"curl/8.5.0"},"url":"https://postman-echo.com/get"}
```

One response, three properties:

| | |
| --- | --- |
| `x-parity` present | the credential was **injected** |
| value reads `[REDACTED]` | the echo was **scrubbed server-side** |
| real value absent | it **never entered the sandbox** |

`python-requests/2.34.2` returns the same. `env` in the guest holds neither the value nor the key. An unruled host still answers 200 through a blind tunnel, so pinned-cert and mTLS clients are untouched. **14 assertions, 0 failures.**

## What running it for real caught

Two bugs that passed every unit test and every `curl` probe:

1. **The CA was unusable by Python** — no SKI on the CA, no AKI on the leaves. curl accepted the identical chain. The first fix was worse: forge's *parsed* `subjectKeyIdentifier` is a hex string, and feeding it back produced an AKI naming a non-existent issuer, breaking every handshake.
2. **gzip silently defeated echo redaction** — the broker redacts by scanning response bytes and curl offers gzip by default. Visible in the run as the shim forcing `accept-encoding: identity`.

That makes **three** bugs in this feature found only by a real client in a real guest — the `git` 407 framing bug was the first. That pattern is now a learning rather than folklore.

## Learnings appended

- **A TLS/proxy component is only as correct as the third-party clients that accept it.** Run curl, python, git and node fetch in a real sandbox; assert on what the *upstream* received.
- **Bun diverges from Node in three load-bearing ways** around raw sockets and TLS — `emit('connection')` is a no-op, `SNICallback` never fires, and a write from the `'upgrade'` handler never reaches the client. All three fail *silently*.

## Also documented

How to get a dev session at all: dev enforces billing, so a fresh account 402s. Funding one the way CI does (Stripe **test mode**) unblocks it — and the account becomes runnable from the subscription alone, since the forged credit-purchase webhook 400s against dev (the deployed API validates signatures against AWS Secrets Manager, not `.env.dev`).

Docs only — no code changes.