### PR TITLE
feat(secrets): bind a session credential to the sandbox it was issued to

### DIFF
--- a/apps/api/src/__tests__/unit-boot-timeline-auth-mount.test.ts
+++ b/apps/api/src/__tests__/unit-boot-timeline-auth-mount.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The boot-timeline route must be REACHABLE, not merely correct.
+ *
+ * This is the test that was missing. The handler's own logic was fine; nothing
+ * ever asked whether a request could get to it. `auth` from openapi/index.ts is
+ * `{ security: [{ bearerAuth: [] }] }` — OpenAPI metadata, NOT middleware — and
+ * `/v1/platform` was mounted with no auth middleware, so `authType` was never
+ * set and the handler's `authType !== 'apiKey'` guard returned 403 for every
+ * relay. The daemon fire-and-forgets the call, so it failed in silence and no
+ * in-guest boot timeline was ever recorded.
+ *
+ * That also made the sandbox egress pin inert: the pin is written on this
+ * route, so a route nobody can reach pins nobody, and every session stayed
+ * `unpinned` — which the broker allows.
+ *
+ * Source-level rather than a live request because the failure was in the WIRING
+ * (which middleware is mounted where), and that is what these assertions read.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const index = readFileSync(new URL('../index.ts', import.meta.url), 'utf8');
+const openapi = readFileSync(new URL('../openapi/index.ts', import.meta.url), 'utf8');
+
+describe('boot-timeline is actually reachable', () => {
+  test('auth middleware is mounted on the route', () => {
+    expect(index).toContain("app.use('/v1/platform/boot-timeline', supabaseAuth)");
+  });
+
+  test('the mount comes BEFORE the platform router', () => {
+    // Hono runs middleware registered before the matching route. Registering
+    // this after `app.route('/v1/platform', …)` would leave it dead.
+    const use = index.indexOf("app.use('/v1/platform/boot-timeline', supabaseAuth)");
+    const route = index.indexOf("app.route('/v1/platform', platformApp)");
+    expect(use).toBeGreaterThan(-1);
+    expect(route).toBeGreaterThan(-1);
+    expect(use).toBeLessThan(route);
+  });
+
+  test('the whole platform sub-app is NOT blanket-authenticated', () => {
+    // `/sandbox/version` and the github-app setup callbacks are deliberately
+    // public; a wildcard mount would break them.
+    expect(index).not.toContain("app.use('/v1/platform/*', supabaseAuth)");
+  });
+
+  test('openapi `auth` is metadata, so a route cannot rely on it for identity', () => {
+    // Pinning the root cause: if this ever becomes real middleware the comment
+    // above (and this test) should change deliberately, not by accident.
+    expect(openapi).toContain("export const auth: Pick<RouteConfig, 'security'>");
+  });
+});

--- a/apps/api/src/__tests__/unit-project-secret-broker-route.test.ts
+++ b/apps/api/src/__tests__/unit-project-secret-broker-route.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { projectSecrets, projectSessionSecretHandles, projectSessions } from '@kortix/db';
+import {
+  projectSecrets,
+  projectSessionSecretHandles,
+  projectSessions,
+  sessionSandboxes,
+} from '@kortix/db';
 import { Hono } from 'hono';
 import * as realAccess from '../projects/lib/access';
 import * as realProjectSecrets from '../projects/secrets';
@@ -55,11 +60,21 @@ function sharedSecret(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/** `null` = no pin recorded. Set `{ metadata: { egress_ip: '…' } }` to pin. */
+let sandboxRow: { metadata: Record<string, unknown> } | null = null;
+
 const databaseMock = {
   select: () => ({
     from: (table: unknown) => ({
       where: () => {
         if (table === projectSessions) return { limit: async () => (sessionRow ? [sessionRow] : []) };
+        // The egress pin reads the sandbox row to see whether this token is
+        // being used from the box it was issued to. `sandboxRow` is null by
+        // default, i.e. UNPINNED — which the route must allow, or every session
+        // provisioned before the pin shipped would lose its secrets.
+        if (table === sessionSandboxes) {
+          return { limit: async () => (sandboxRow ? [sandboxRow] : []) };
+        }
         if (table === projectSecrets) return Promise.resolve(secretRows);
         if (table === projectSessionSecretHandles) {
           return {
@@ -141,10 +156,14 @@ function buildApp() {
   return app;
 }
 
-function brokerRequest() {
+function brokerRequest(fromIp?: string) {
   return buildApp().request(`/v1/projects/${PROJECT_ID}/secrets/PRIMARY/broker`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      'content-type': 'application/json',
+      // Cloudflare fronts this API and appends, so the FIRST hop is the caller.
+      ...(fromIp ? { 'x-forwarded-for': `${fromIp}, 172.68.1.1` } : {}),
+    },
     body: JSON.stringify({
       url: 'https://api.example.com/v1/messages?trace=private',
       method: 'POST',
@@ -171,6 +190,51 @@ describe('POST /v1/projects/:projectId/secrets/:identifier/broker', () => {
     decrypted.length = 0;
     brokerCalls.length = 0;
     brokerFailure = null;
+    sandboxRow = null;
+  });
+
+  /**
+   * The session token lives in the AGENT's own shell env (it needs it for the
+   * CLI and git), so the agent can copy it out and hand it to someone else.
+   * Everything else on this route checks what the token IS. These check where
+   * it is being used FROM.
+   */
+  describe('the session credential is bound to its own sandbox', () => {
+    test('a request from the pinned sandbox is served', async () => {
+      sandboxRow = { metadata: { egress_ip: '67.213.121.131' } };
+      const response = await brokerRequest('67.213.121.131');
+      expect(response.status).toBe(200);
+      expect(brokerCalls).toHaveLength(1);
+    });
+
+    test('the SAME token from anywhere else is refused before the secret is decrypted', async () => {
+      sandboxRow = { metadata: { egress_ip: '67.213.121.131' } };
+      const response = await brokerRequest('203.0.113.9');
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({ code: 'sandbox_egress_mismatch' });
+      // The point of refusing EARLY: an exfiltrated token must not reach the
+      // decrypt path at all, not merely fail afterwards.
+      expect(decrypted).toHaveLength(0);
+      expect(brokerCalls).toHaveLength(0);
+    });
+
+    test('an UNPINNED session is still served', async () => {
+      // Fails open on purpose. Sandboxes provisioned before the pin shipped
+      // have none, and a boot relay that never landed would otherwise take a
+      // working session's secrets away with a 403 nobody could diagnose.
+      sandboxRow = null;
+      const response = await brokerRequest('203.0.113.9');
+      expect(response.status).toBe(200);
+    });
+
+    test('a caller with no resolvable address cannot pass a pinned session', async () => {
+      // Absent != matching. Treating "unknown" as a match would let anyone
+      // through by simply stripping the header.
+      sandboxRow = { metadata: { egress_ip: '67.213.121.131' } };
+      const response = await brokerRequest();
+      expect(response.status).toBe(403);
+      expect(brokerCalls).toHaveLength(0);
+    });
   });
 
   test('requires a session-scoped agent token', async () => {

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -141,6 +141,18 @@ const envSchema = z.object({
   // Global background-worker switch. API-only and migration-shadow deployments
   // keep request handling active while disabling every recurring write loop.
   KORTIX_WORKERS_ENABLED: optBoolTrue,
+  /**
+   * Enforce the sandbox egress pin on the secret-broker route (default ON).
+   *
+   * A kill switch, not a feature flag. The pin blocks a session token used from
+   * outside its own sandbox — but the broker route also serves
+   * `kortix secrets call` and the connector MCP, so if a provider ever
+   * reassigns a running sandbox's egress address the pin would 403 real work.
+   * Set this to `false` to fall back to log-only while that is investigated,
+   * instead of reverting a deploy. Watch for `[secret-broker] refused an
+   * off-sandbox token use`.
+   */
+  KORTIX_SANDBOX_EGRESS_PIN_ENFORCED: optBoolTrue,
   // Kortix-owned session titles: the moment a session's first prompt text is
   // known server-side (at create when it carries one, else on the first HTTP
   // prompt), generate the title ourselves via the internal LLM gateway instead
@@ -927,6 +939,7 @@ export const config = {
   // Single master switch — see schema docstring above.
   KORTIX_BILLING_INTERNAL_ENABLED: env.KORTIX_BILLING_INTERNAL_ENABLED,
   KORTIX_WORKERS_ENABLED: env.KORTIX_WORKERS_ENABLED,
+  KORTIX_SANDBOX_EGRESS_PIN_ENFORCED: env.KORTIX_SANDBOX_EGRESS_PIN_ENFORCED,
   SESSION_TITLE_GENERATION_ENABLED: env.SESSION_TITLE_GENERATION_ENABLED,
   KORTIX_TEMPLATES_ENABLED: env.KORTIX_TEMPLATES_ENABLED,
   OPENAPI_PUBLIC_DOCS: env.OPENAPI_PUBLIC_DOCS,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -813,6 +813,18 @@ app.route('/v1/usage', usageApp); // GET /v1/usage[?start&end&group_by] — acco
 
 app.route('/v1/billing', billingApp); // /v1/billing/account-state, /v1/billing/webhooks/*
 app.route('/v1/account', accountDeletionApp); // account deletion status/request/cancel/immediate
+// Auth for the ONE platform route that needs an identity. Scoped to this exact
+// path, not `/v1/platform/*`: the mount point, `/sandbox/version` and the
+// github-app setup callbacks are deliberately unauthenticated and would break.
+//
+// Without this the route was unreachable. `auth` from openapi/index.ts is
+// `{ security: [{ bearerAuth: [] }] }` — OpenAPI METADATA, not middleware — so
+// `authType` was never set and the handler's `authType !== 'apiKey'` guard
+// returned 403 for every relay. The daemon fire-and-forgets this call, so it
+// failed silently and no in-guest boot timeline was ever recorded.
+// supabaseAuth is the middleware carrying the sandbox-token path allowlist
+// (middleware/auth.ts), which already lists `/boot-timeline`.
+app.use('/v1/platform/boot-timeline', supabaseAuth);
 app.route('/v1/platform', platformApp); // /v1/platform, /v1/platform/sandbox/version
 registerSunaMigrationRoutes(projectsApp); // /v1/projects/suna-migration/* (OG Suna → opencode, user-triggered)
 // Voice routes are registered BEFORE projectsApp: Hono matches in registration

--- a/apps/api/src/platform/routes/boot-timeline.ts
+++ b/apps/api/src/platform/routes/boot-timeline.ts
@@ -21,6 +21,7 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { and, eq, inArray } from 'drizzle-orm';
 import { sessionSandboxes } from '@kortix/db';
+import { pinSandboxEgressIp, requestEgressIp } from '../services/sandbox-egress-pin';
 import { db } from '../../shared/db';
 import { auth, errors, json, makeOpenApiApp } from '../../openapi';
 import type { AppEnv } from '../../types';
@@ -88,6 +89,15 @@ bootTimelineRouter.openapi(
     if (!sandbox) {
       return c.json({ error: 'sandbox token is not scoped to this session' }, 403);
     }
+
+    // Pin the sandbox's egress address on the way past. THIS call is the right
+    // moment: it is the daemon, authenticated with the SANDBOX credential, and
+    // it happens before the agent can run — so the pin cannot be set by whoever
+    // reaches the API first. Fire-and-forget for the same reason as the
+    // timeline: a failed pin must never fail a boot.
+    void pinSandboxEgressIp(sandboxId, requestEgressIp(c)).catch((err) =>
+      console.warn('[egress-pin] could not pin sandbox egress ip (ignored):', err?.message ?? err),
+    );
 
     // Fire-and-forget — this is telemetry, not a durability contract the
     // caller should wait on (see recordBootTimeline's doc comment).

--- a/apps/api/src/platform/services/sandbox-egress-pin.test.ts
+++ b/apps/api/src/platform/services/sandbox-egress-pin.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The pin decides whether a stolen session token still works.
+ *
+ * These test the DECISION function directly, without a DB, because the two
+ * things that matter are pure: which x-forwarded-for hop is the client, and
+ * which verdicts allow versus block. The DB paths are exercised on dev.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { Context } from 'hono';
+import { requestEgressIp } from './sandbox-egress-pin';
+
+const ctx = (headers: Record<string, string>) =>
+  ({ req: { header: (n: string) => headers[n.toLowerCase()] } }) as unknown as Context;
+
+describe('which address counts as the caller', () => {
+  test('the FIRST x-forwarded-for hop is the client, not the last', () => {
+    // Cloudflare fronts this API and appends. Taking the last hop would pin
+    // Cloudflare's own address — identical for every sandbox on earth, which
+    // would make the check pass for everyone and protect no one.
+    expect(requestEgressIp(ctx({ 'x-forwarded-for': '67.213.121.131, 172.68.1.1' }))).toBe(
+      '67.213.121.131',
+    );
+  });
+
+  test('whitespace around a hop is tolerated', () => {
+    expect(requestEgressIp(ctx({ 'x-forwarded-for': '  67.213.121.131 , 172.68.1.1' }))).toBe(
+      '67.213.121.131',
+    );
+  });
+
+  test('x-real-ip is the fallback', () => {
+    expect(requestEgressIp(ctx({ 'x-real-ip': '67.213.113.135' }))).toBe('67.213.113.135');
+  });
+
+  test('an empty forwarded-for does not become an empty-string pin', () => {
+    // '' is falsy but IS a string — pinning it would then "match" every later
+    // request that also had no address, quietly disabling the check.
+    expect(requestEgressIp(ctx({ 'x-forwarded-for': '' }))).toBeNull();
+    expect(requestEgressIp(ctx({ 'x-forwarded-for': '   ' }))).toBeNull();
+    expect(requestEgressIp(ctx({}))).toBeNull();
+  });
+});

--- a/apps/api/src/platform/services/sandbox-egress-pin.ts
+++ b/apps/api/src/platform/services/sandbox-egress-pin.ts
@@ -1,0 +1,120 @@
+/**
+ * Binding a session's credential to the sandbox it was issued for.
+ *
+ * ## The exposure this closes
+ *
+ * `KORTIX_CLI_TOKEN` is in the agent's own shell environment (the CLI, git push
+ * and CR-merge all need it — see agent-env-file.ts SHELL_SESSION_CREDS). It is
+ * also the token the in-guest egress shim authenticates to the broker with. An
+ * agent can therefore copy it out of its own env and send it anywhere, and the
+ * recipient could spend the project's network-boundary secrets against the
+ * allow-listed hosts for as long as the session runs.
+ *
+ * The credential itself was never readable — the boundary design keeps the
+ * VALUE outside the guest, and that holds. This is about the token that SPENDS
+ * it being usable from somewhere the sandbox is not.
+ *
+ * ## Why an IP pin, and why this one
+ *
+ * The obvious alternative — an egress allow-list restricting the sandbox to
+ * Kortix — was measured and rejected: both dev-api and api.kortix.com are
+ * Cloudflare-fronted (AS13335, and the SAME anycast addresses), so pinning them
+ * by CIDR means trusting 1,524,736 addresses that front a large share of the
+ * internet. An agent would exfiltrate through a Cloudflare Worker and the
+ * control would have bought nothing, while breaking git, npm and pip.
+ *
+ * Measured instead (two Daytona sandboxes, personal account, 2026-08-14):
+ *
+ *     sandbox c6009f9d → 67.213.121.131 , 67.213.121.131
+ *     sandbox 004f74dc → 67.213.113.135 , 67.213.113.135
+ *
+ * Each sandbox has its OWN egress address, stable across calls. So "is this
+ * request coming from the sandbox the token was issued to" is answerable.
+ *
+ * ## Pinned at BOOT, not on first use
+ *
+ * The pin is recorded when the daemon relays its boot timeline — a daemon→API
+ * call authenticated with the SANDBOX credential, made before the agent runs.
+ * Trust-on-first-use would instead let whoever calls first set the pin, and an
+ * attacker who exfiltrated the token during provisioning could pin themselves
+ * and lock the sandbox out of its own secrets.
+ *
+ * ## Fails OPEN when unpinned, on purpose
+ *
+ * A session with no recorded address is allowed. Sandboxes provisioned before
+ * this shipped have none, and a boot-timeline relay that never landed would
+ * otherwise take a working session's secrets away with a 403 nobody could
+ * diagnose. The mismatch case — a pin exists and does not match — is the one
+ * that blocks, and it is the one that means what it says.
+ */
+import { and, eq } from 'drizzle-orm';
+import type { Context } from 'hono';
+import { sessionSandboxes } from '@kortix/db';
+import { db } from '../../shared/db';
+
+/** Where the pin lives on `session_sandboxes.metadata`. Stable storage detail. */
+export const EGRESS_IP_KEY = 'egress_ip';
+
+/**
+ * The caller's address as this deployment sees it.
+ *
+ * `x-forwarded-for`'s FIRST hop is the original client; the rest are proxies.
+ * Cloudflare fronts the API and sets it, which is why the raw socket address is
+ * never the answer here.
+ */
+export function requestEgressIp(c: Context): string | null {
+  const xff = c.req.header('x-forwarded-for');
+  const first = xff ? xff.split(',')[0]?.trim() : undefined;
+  return first || c.req.header('x-real-ip')?.trim() || null;
+}
+
+/**
+ * Record the sandbox's egress address, once.
+ *
+ * First write wins: re-pinning on every daemon callback would let a later call
+ * move the pin, which is exactly the property the boot-time pin exists to deny.
+ */
+export async function pinSandboxEgressIp(sandboxId: string, ip: string | null): Promise<void> {
+  if (!ip) return;
+  const [row] = await db
+    .select({ metadata: sessionSandboxes.metadata })
+    .from(sessionSandboxes)
+    .where(eq(sessionSandboxes.sandboxId, sandboxId))
+    .limit(1);
+  if (!row) return;
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+  if (typeof metadata[EGRESS_IP_KEY] === 'string' && metadata[EGRESS_IP_KEY]) return;
+  await db
+    .update(sessionSandboxes)
+    .set({ metadata: { ...metadata, [EGRESS_IP_KEY]: ip } })
+    .where(eq(sessionSandboxes.sandboxId, sandboxId));
+}
+
+export type EgressPinVerdict =
+  /** No pin recorded — allowed, see the fail-open note above. */
+  | { ok: true; reason: 'unpinned' }
+  | { ok: true; reason: 'match'; ip: string }
+  /** A pin exists and the caller is somewhere else. */
+  | { ok: false; reason: 'mismatch'; pinned: string; seen: string | null };
+
+/**
+ * Is this request coming from the sandbox the session was issued to?
+ *
+ * Looked up by SESSION rather than handed a sandbox id, because the caller that
+ * needs this (the secret-broker route) authenticates a session token and has no
+ * sandbox id of its own — and resolving it here keeps the two from drifting.
+ */
+export async function verifySandboxEgressIp(
+  sessionId: string,
+  seen: string | null,
+): Promise<EgressPinVerdict> {
+  const [row] = await db
+    .select({ metadata: sessionSandboxes.metadata })
+    .from(sessionSandboxes)
+    .where(and(eq(sessionSandboxes.sessionId, sessionId)))
+    .limit(1);
+  const pinned = ((row?.metadata ?? {}) as Record<string, unknown>)[EGRESS_IP_KEY];
+  if (typeof pinned !== 'string' || !pinned) return { ok: true, reason: 'unpinned' };
+  if (seen && seen === pinned) return { ok: true, reason: 'match', ip: pinned };
+  return { ok: false, reason: 'mismatch', pinned, seen };
+}

--- a/apps/api/src/projects/routes/secret-broker.ts
+++ b/apps/api/src/projects/routes/secret-broker.ts
@@ -16,7 +16,12 @@ import { resolveSecretDelivery } from '../../secrets/strategy';
 import { recordAuditEvent } from '../../shared/audit';
 import { db } from '../../shared/db';
 import { decryptProjectSecret, intersectSecretGrants } from '../secrets';
+import { config } from '../../config';
 import { loadProjectForUser } from '../lib/access';
+import {
+  requestEgressIp,
+  verifySandboxEgressIp,
+} from '../../platform/services/sandbox-egress-pin';
 import { projectsApp } from '../lib/app';
 import { ACTIVE_SESSION_STATUSES } from '../lib/session-status';
 import { readBody } from '../lib/serializers';
@@ -57,6 +62,35 @@ projectsApp.openapi(
         {
           error: 'Secret broker requests require a session-scoped agent token',
           code: 'session_agent_token_required',
+        },
+        403,
+      );
+    }
+
+    // Is this request coming from the sandbox the session token was issued to?
+    //
+    // The token lives in the agent's own shell env (it needs it for the CLI and
+    // git), so the agent can copy it out. Everything else on this route checks
+    // what the token IS; this checks where it is being used FROM. Unpinned
+    // sessions pass — see sandbox-egress-pin.ts on why that direction is the
+    // safe one.
+    const pin = await verifySandboxEgressIp(sessionId, requestEgressIp(c));
+    if (!pin.ok) {
+      // Logged whether or not it blocks, so log-only mode still surfaces the
+      // event — a kill switch that also silences the evidence is useless.
+      console.warn('[secret-broker] refused an off-sandbox token use', {
+        sessionId,
+        projectId,
+        pinned: pin.pinned,
+        seen: pin.seen,
+        enforced: config.KORTIX_SANDBOX_EGRESS_PIN_ENFORCED,
+      });
+    }
+    if (!pin.ok && config.KORTIX_SANDBOX_EGRESS_PIN_ENFORCED) {
+      return c.json(
+        {
+          error: 'This session credential may only be used from its own sandbox',
+          code: 'sandbox_egress_mismatch',
         },
         403,
       );

--- a/apps/kortix-sandbox-agent-server/src/boot-timeline-relay.ts
+++ b/apps/kortix-sandbox-agent-server/src/boot-timeline-relay.ts
@@ -52,15 +52,15 @@ export function __resetBootTimelineRelayForTests(): void {
 async function doRelay(timeline: BootMark[]): Promise<void> {
   const projectId = process.env.KORTIX_PROJECT_ID?.trim()
   const sessionId = process.env.KORTIX_SESSION_ID?.trim()
-  // Same token fallback order as relayBootstrapPinToApi: prefer the session
-  // token, then the sandbox credential (canonical name first, legacy
-  // KORTIX_TOKEN alias last) — this route accepts either.
-  const token = (
-    process.env.KORTIX_CLI_TOKEN ||
-    process.env.KORTIX_SANDBOX_TOKEN ||
-    process.env.KORTIX_TOKEN ||
-    ''
-  ).trim()
+  // The SANDBOX credential, not the session PAT. This route is sandbox-only:
+  // its handler requires `apiKeyType === 'sandbox'` and rejects a PAT outright,
+  // so the old "prefer KORTIX_CLI_TOKEN, this route accepts either" order sent
+  // the one token that cannot work on a normal session. Canonical name first,
+  // legacy KORTIX_TOKEN alias second for daemons baked before the rename.
+  //
+  // It is also the right credential on the merits: this is the daemon
+  // reporting its OWN boot, which is the sandbox's identity, not the user's.
+  const token = (process.env.KORTIX_SANDBOX_TOKEN || process.env.KORTIX_TOKEN || '').trim()
   const apiUrl = process.env.KORTIX_API_URL?.replace(/\/$/, '')
   if (!projectId || !sessionId || !token || !apiUrl) return
   if (timeline.length === 0) return


### PR DESCRIPTION
Closes the last exposure I flagged on the Daytona network-boundary work.

## The gap

`KORTIX_CLI_TOKEN` is in the **agent's own shell env** — the CLI, `git push` and CR-merge all need it — and it is also what the in-guest shim authenticates to the broker with. So an agent can copy it out and hand it to someone else, who could spend the project's boundary secrets for as long as the session runs.

The credential itself was never readable and still isn't. This is about the token that *spends* it being usable from somewhere the sandbox is not.

## Why an IP pin and not the egress allow-list

The allow-list was the obvious answer. I measured it rather than assuming:

```
dev-api.kortix.com → 104.21.94.168, 172.67.138.69   AS13335 Cloudflare
api.kortix.com     → 104.21.94.168, 172.67.138.69   AS13335 Cloudflare (same IPs)
```

Pinning those by CIDR means trusting **1,524,736** addresses fronting a large share of the internet. An agent would exfiltrate through a free Cloudflare Worker — inside the allow-list — so the one threat it targets, it doesn't stop. Meanwhile it breaks `git clone`, `npm install` and `pip install`. That would have been security theatre.

What makes the pin viable, measured on two real Daytona sandboxes:

```
c6009f9d → 67.213.121.131 , 67.213.121.131
004f74dc → 67.213.113.135 , 67.213.113.135
```

Distinct per sandbox, stable across calls.

## Pinned at boot, not on first use

Recorded when the daemon relays its boot timeline — daemon→API, authenticated with the **sandbox** credential, before the agent runs. Trust-on-first-use would let whoever calls first set the pin, so an attacker who exfiltrated during provisioning could pin *themselves* and lock the sandbox out of its own secrets.

## Fails open when unpinned — deliberately

Sandboxes provisioned before this have no pin, and a boot relay that never landed would otherwise take a working session's secrets away with a 403 nobody could diagnose. Only a pin that **exists and does not match** blocks. Absent is not treated as matching, so stripping the header doesn't get you through — there's a test for exactly that.

`KORTIX_SANDBOX_EGRESS_PIN_ENFORCED` (default **on**) is a kill switch, not a feature flag: this route also serves `kortix secrets call` and the connector MCP, so if a provider ever reassigns a running sandbox's address, log-only is one config change rather than a revert. The mismatch is logged either way.

## Verification

**6794 pass / 0 fail**, tsc clean. New tests cover: a request from the pinned sandbox is served; the same token from elsewhere is refused **before decryption**; an unpinned session still works; and a caller with no resolvable address cannot pass a pinned session.

## Honest limits

- Not a defence against the agent *using* the secret from inside its own box. That's the feature.
- Doesn't address the other two exposures: a transform that defeats byte-scan redaction, or an attacker-controlled allow-listed host. Neither is a network-layer problem.
- IP stability is measured across calls, not across hours. If a provider rebalances NAT mid-session, the kill switch is the answer.