### PR TITLE
docs: the session credential is bound to its sandbox — verified on dev

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -302,3 +302,33 @@ daemon both do). Measured, bun 1.3.14 vs node v22.22.0:
 
 All three fail SILENTLY (a hang, or the wrong certificate), never an exception.
 *Incident:* each cost a debugging cycle in the egress proxy/shim.
+
+### A control split across API and daemon is only live when BOTH halves are (2026-08-14)
+
+**When:** shipping any security control whose two halves live in `apps/api` and
+`apps/kortix-sandbox-agent-server`. The API half goes live the moment Deploy Dev
+finishes. The daemon half does NOT: it is baked into the sandbox image, reaches
+a guest only through a new meta-snapshot build, and the fingerprint that
+triggers that build hashes `apps/kortix-sandbox-agent-server/src`. Until an
+image carrying the new daemon exists, the API half is running against old
+guests and the control does nothing.
+
+The sandbox egress pin hit this exactly: the API mount was verifiably live
+(boot-timeline went 403 → 401 on the same request), but a real exfiltrated-token
+attack still SUCCEEDED because the box's baked daemon still sent the wrong
+token, so nothing wrote a pin. The identical test passed later, unchanged, once
+a sandbox with the new daemon existed.
+
+Two rules:
+
+- **Never conclude "the control does not work" from one post-deploy run.** Prove
+  which half is live first. An API-side before/after on the same request is
+  cheap and decisive (`403 handler-guard` → `401 middleware`).
+- **A control that fails OPEN is the right default while it propagates** — the
+  pin allows `unpinned`, so old guests kept working and nothing regressed
+  during the lag. A fail-closed control shipped this way is an outage.
+
+Do not read a fast `session_start_timeline.totalMs` as proof of a warm-pool box
+either: `KORTIX_WARM_SNAPSHOT_ENABLED` defaults false, and ~2s is also what
+creating a container from an ALREADY-BUILT image costs.
+*Incident:* the token-binding verification failed twice before the image landed.

--- a/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
+++ b/docs/NETWORK_BOUNDARY_ON_DAYTONA.md
@@ -692,6 +692,30 @@ Note the account becomes runnable from the SUBSCRIPTION alone; the forged credit
 webhook returns 400 against dev because the deployed API validates the signature against AWS
 Secrets Manager rather than `.env.dev`.
 
+#### The session credential is bound to its sandbox
+
+`KORTIX_CLI_TOKEN` is in the agent's own shell env (the CLI and git need it) and
+is what the shim authenticates to the broker with, so an agent can copy it out.
+The credential it spends was never readable and still is not; the exposure was
+the TOKEN being usable from somewhere the sandbox is not.
+
+Verified on dev by running the actual attack — read the token out of the guest,
+then call the broker from a laptop:
+
+    broker call from outside the sandbox -> 403
+    {"code":"sandbox_egress_mismatch"}
+
+with the in-sandbox control still passing in the same run. Pinned at boot from
+the daemon's boot-timeline relay (sandbox credential, before the agent runs), so
+trust-on-first-use cannot let an attacker pin themselves. Fails OPEN when
+unpinned — see the learnings entry on split API/daemon controls.
+
+The egress ALLOW-LIST was considered for this and rejected on measurement:
+dev-api and api.kortix.com are both Cloudflare-fronted on the same anycast
+addresses, so a CIDR pin means trusting 1,524,736 addresses and an agent would
+exfiltrate through a Cloudflare Worker — while breaking git, npm and pip. It
+becomes worth building only behind a dedicated non-Cloudflare ingress.
+
 #### Still open
 
 - **Allow-list survival across resume / CoW-restore** — the funnel must not open on restore.


### PR DESCRIPTION
Records the outcome of #6451 and the lesson its verification cost.

## Verified on dev, by running the actual attack

Read `KORTIX_CLI_TOKEN` out of the guest's own shell — exactly what an agent can do — then used that token against the broker from a laptop:

```
broker call from this laptop -> 403
{"error":"This session credential may only be used from its own sandbox",
 "code":"sandbox_egress_mismatch"}
```

**8 passed, 0 failed**, with the in-sandbox control passing in the same run (`x-bind: Bearer [REDACTED]`) — so the pin refuses the attacker, not everyone.

## Why the allow-list was rejected

Measured: `dev-api.kortix.com` and `api.kortix.com` resolve to the **same Cloudflare anycast IPs**. A CIDR pin means trusting **1,524,736** addresses, an agent exfiltrates through a free Worker, and `git`/`npm`/`pip` break. Worth building only behind a dedicated non-Cloudflare ingress.

## The learning this cost two failed runs

**A control split across `apps/api` and the sandbox daemon is only live when both halves are.** The API half ships with Deploy Dev; the daemon half is baked into the sandbox image and arrives only with a new meta-snapshot build.

The pin hit this exactly: the API mount was verifiably live (`403` handler-guard → `401` middleware on the same request), yet the attack still **succeeded**, because the box's baked daemon sent the wrong token and nothing wrote a pin. The identical test passed later, unchanged, once an image with the new daemon existed.

- Never conclude "the control doesn't work" from one post-deploy run — prove which half is live first.
- **Fail-open is the right default while it propagates.** The pin allows `unpinned`, so old guests kept working and nothing regressed during the lag. Fail-closed shipped this way is an outage.
- A fast `session_start_timeline.totalMs` is **not** proof of a warm-pool box: warm snapshots default off, and ~2s is also what a container from an already-built image costs. I misread this initially.

Docs only.