### PR TITLE
fix(api): never render a boot failure as a provider-side loss

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -2542,7 +2542,11 @@ describe('project session API contract', () => {
     expect(sandboxProvisionCalls).toBe(0);
   });
 
-  test('dashboard start preserves a sandbox that stayed stopped after wake grace', async () => {
+  // Incident 2026-08-14: a wake that ran out of time is NOT evidence the
+  // provider lost the box — the provider just answered `stopped`, which proves
+  // the box exists. The row parks retriable instead of being preserved as
+  // "computer was lost" (docs/incidents/2026-08-14-computer-lost-false-alarm-and-boot-failures.md).
+  test('dashboard start parks (not preserves) a sandbox that stayed stopped after wake grace', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -2578,8 +2582,8 @@ describe('project session API contract', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
       stage: 'failed',
-      retriable: false,
-      reason: 'runtime_identity_unavailable',
+      retriable: true,
+      reason: 'runtime_wake_timeout',
       sandbox: { external_id: 'box-stuck-stopped', status: 'stopped' },
     });
 
@@ -2587,6 +2591,11 @@ describe('project session API contract', () => {
     expect(sandboxProvisionCalls).toBe(0);
     expect(sessionSandboxRows).toHaveLength(1);
     expect(sessionSandboxRows[0]?.externalId).toBe('box-stuck-stopped');
+    // A park must never carry the loss flag the web renders as "computer was
+    // lost", and must record which failure parked it.
+    const parkedMetadata = sessionSandboxRows[0]?.metadata as Record<string, unknown>;
+    expect(parkedMetadata.runtimeIdentityState).toBeUndefined();
+    expect(parkedMetadata.stopReason).toBe('runtime_wake_failed');
   });
 
   test('dashboard start trusts live runtime health when the provider status stays unknown', async () => {
@@ -3038,7 +3047,13 @@ describe('project session API contract', () => {
     expect(sandboxProvisionCalls).toBe(0);
   });
 
-  test('dashboard start preserves a running sandbox whose OpenCode runtime never becomes reachable', async () => {
+  // Incident 2026-08-14: this exact population — a RUNNING box whose runtime
+  // never became ready (a dead local tunnel blocked the guest's git clone) —
+  // was preserved as "computer was lost" while both provider control planes
+  // showed the box alive. A failed boot on a present box parks retriable and
+  // stops the provider box, so a DB-stopped row cannot keep burning unmetered
+  // compute.
+  test('dashboard start parks (not preserves) a running sandbox whose OpenCode runtime never becomes reachable', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -3077,8 +3092,8 @@ describe('project session API contract', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
       stage: 'failed',
-      retriable: false,
-      reason: 'runtime_identity_unavailable',
+      retriable: true,
+      reason: 'runtime_unreachable_timeout',
       sandbox: { external_id: 'box-opencode-dead', status: 'stopped' },
     });
 
@@ -3086,6 +3101,11 @@ describe('project session API contract', () => {
     expect(sandboxProvisionCalls).toBe(0);
     expect(sessionSandboxRows).toHaveLength(1);
     expect(sessionSandboxRows[0]?.externalId).toBe('box-opencode-dead');
+    // The box was RUNNING when the boot failed: the park must stop it.
+    expect(providerStopCalls).toBe(1);
+    const parkedMetadata = sessionSandboxRows[0]?.metadata as Record<string, unknown>;
+    expect(parkedMetadata.runtimeIdentityState).toBeUndefined();
+    expect(parkedMetadata.stopReason).toBe('runtime_boot_failed');
   });
 
   test('restart of a provider-removed sandbox refuses replacement and preserves identity', async () => {

--- a/apps/api/src/projects/lib/dead-tunnel-probe.test.ts
+++ b/apps/api/src/projects/lib/dead-tunnel-probe.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { resetTunnelProbeCache, sandboxCallbackDeadTunnelReason } from './sessions';
+
+/**
+ * Incident 2026-08-14: the trycloudflare quick tunnel died server-side while
+ * the local cloudflared process stayed up. Every sandbox created afterwards
+ * booted into a callback URL that could never answer, never became ready, and
+ * surfaced as a false "computer was lost". The static loopback check could not
+ * catch it — the URL was public and well-formed, just dead. This probe fails
+ * session create/restart fast, with a reason that names the tunnel.
+ */
+describe('sandboxCallbackDeadTunnelReason', () => {
+  const DEAD = 'https://scheduling-tampa-development-patents.trycloudflare.com/v1';
+  const failingFetch = (async () => {
+    throw new Error('unreachable');
+  }) as unknown as typeof fetch;
+  const okFetch = (async () => new Response('ok', { status: 200 })) as unknown as typeof fetch;
+
+  beforeEach(() => resetTunnelProbeCache());
+
+  test('a stable (non-quick-tunnel) URL is never probed', async () => {
+    const explodingFetch = (async () => {
+      throw new Error('must not be called');
+    }) as unknown as typeof fetch;
+    expect(
+      await sandboxCallbackDeadTunnelReason(Date.now(), 'https://api.kortix.com/v1', explodingFetch),
+    ).toBeNull();
+  });
+
+  test('a dead quick tunnel returns an actionable reason', async () => {
+    const reason = await sandboxCallbackDeadTunnelReason(Date.now(), DEAD, failingFetch);
+    expect(reason).toContain('not answering');
+    expect(reason).toContain('pnpm dev');
+  });
+
+  test('a healthy quick tunnel returns null', async () => {
+    expect(await sandboxCallbackDeadTunnelReason(Date.now(), DEAD, okFetch)).toBeNull();
+  });
+
+  test('a non-2xx health answer is reported with its status', async () => {
+    const gatewayFetch = (async () =>
+      new Response('offline', { status: 530 })) as unknown as typeof fetch;
+    const reason = await sandboxCallbackDeadTunnelReason(Date.now(), DEAD, gatewayFetch);
+    expect(reason).toContain('530');
+  });
+
+  test('the verdict is cached inside the TTL so hot paths pay one probe', async () => {
+    const t0 = Date.now();
+    expect(await sandboxCallbackDeadTunnelReason(t0, DEAD, failingFetch)).toContain('not answering');
+    // Within the TTL a healthy fetch is not even consulted — the cache answers.
+    expect(await sandboxCallbackDeadTunnelReason(t0 + 1_000, DEAD, okFetch)).toContain(
+      'not answering',
+    );
+    // Past the TTL the probe runs again and observes recovery.
+    expect(await sandboxCallbackDeadTunnelReason(t0 + 31_000, DEAD, okFetch)).toBeNull();
+  });
+});

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -577,6 +577,63 @@ export function sandboxCallbackUnreachableReason(): string | null {
   );
 }
 
+// One probe verdict is cached briefly: session create and restart are
+// user-facing paths and must not pay a fresh network round-trip on every call.
+const TUNNEL_PROBE_TTL_MS = 30_000;
+const TUNNEL_PROBE_TIMEOUT_MS = 3_000;
+let tunnelProbe: { base: string; reason: string | null; at: number } | null = null;
+
+/** Test seam: drop the cached verdict so a test can force a fresh probe. */
+export function resetTunnelProbeCache(): void {
+  tunnelProbe = null;
+}
+
+/**
+ * Liveness check for a quick-tunnel KORTIX_URL. The static loopback check
+ * above catches a MISSING tunnel; this catches a DEAD one. trycloudflare quick
+ * tunnels die server-side while the local `cloudflared` process stays up, and
+ * every sandbox created after that boots into a callback URL that can never
+ * answer — the runtime never becomes ready and the failure used to surface as
+ * a false "computer was lost" (incident 2026-08-14). Scoped to
+ * *.trycloudflare.com on purpose: deployed environments use a stable public
+ * URL and must not pay a self-probe on the session-create path.
+ */
+export async function sandboxCallbackDeadTunnelReason(
+  now = Date.now(),
+  base = deriveKortixApiBase(),
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | null> {
+  let host: string;
+  try {
+    host = new URL(base).hostname.toLowerCase();
+  } catch {
+    return null; // sandboxCallbackUnreachableReason() already reports an invalid URL
+  }
+  if (!host.endsWith('.trycloudflare.com')) return null;
+  if (tunnelProbe && tunnelProbe.base === base && now - tunnelProbe.at < TUNNEL_PROBE_TTL_MS) {
+    return tunnelProbe.reason;
+  }
+  let reason: string | null = null;
+  try {
+    const res = await fetchImpl(`${base}/health`, {
+      signal: AbortSignal.timeout(TUNNEL_PROBE_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      reason =
+        `The dev tunnel at ${config.KORTIX_URL} answered ${res.status} to a health probe. ` +
+        `Cloud sandboxes cannot call back to this API through it, so a new sandbox would ` +
+        `boot but never become ready. Restart the dev stack (\`pnpm dev\`) to mint a fresh tunnel.`;
+    }
+  } catch {
+    reason =
+      `The dev tunnel at ${config.KORTIX_URL} is not answering. Cloud sandboxes cannot ` +
+      `call back to this API through it, so a new sandbox would boot but never become ` +
+      `ready. Restart the dev stack (\`pnpm dev\`) to mint a fresh tunnel.`;
+  }
+  tunnelProbe = { base, reason, at: now };
+  return reason;
+}
+
 export async function createProjectSession(input: {
   project: ProjectRow;
   userId: string;
@@ -1066,7 +1123,8 @@ export async function createProjectSession(input: {
   const providerName: SandboxProviderName =
     'provider' in picked ? (picked.provider as SandboxProviderName) : await selectProvider();
 
-  const callbackUnreachable = sandboxCallbackUnreachableReason();
+  const callbackUnreachable =
+    sandboxCallbackUnreachableReason() ?? (await sandboxCallbackDeadTunnelReason());
   if (callbackUnreachable) {
     return {
       error: { status: 503, body: { error: callbackUnreachable, code: 'KORTIX_URL_UNREACHABLE' } },

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -32,8 +32,10 @@ import {
   claimInPlaceRuntimeRecovery,
   finalizeRecoveredRuntimeIfRunning,
   markInPlaceRuntimeRecoveryAccepted,
+  parkEstablishedRuntime,
   preserveEstablishedRuntime,
   retireUnmaterializedRuntime,
+  runtimeLossVerdict,
 } from '../runtime-identity';
 import { inspectSandboxRuntime } from '../runtime-inspection';
 import type { StopReason } from '../stop-reason';
@@ -692,6 +694,9 @@ async function preserveEstablishedRuntimeOnOpen(
    *  failed wake, a failed boot, a real provider removal) and cannot tell them
    *  apart from the inside. */
   stopReason: StopReason,
+  /** A provider status the CALLER just observed, so the loss gate below does
+   *  not re-probe. Pass only a fresh answer; omit to let the gate ask. */
+  knownProviderStatus?: SandboxStatus,
 ): Promise<SessionStartResult> {
   if (!row.externalId) {
     await retireUnmaterializedRuntime(row, reason);
@@ -702,6 +707,28 @@ async function preserveEstablishedRuntimeOnOpen(
       retriable: true,
       sandbox: null,
       opencode_session_id: null,
+      reason,
+    };
+  }
+  // Incident 2026-08-14: only a definitive provider `removed` may become the
+  // terminal "computer was lost" state. Two healthy boxes were preserved as
+  // lost because a dead local tunnel kept them from booting and nothing asked
+  // the provider first. Anything short of `removed` — including `unknown`,
+  // which is a probe failure, not evidence — parks the row retriable instead.
+  const providerStatus =
+    knownProviderStatus ??
+    (await getProvider(row.provider as SandboxProviderName)
+      .getStatus(row.externalId)
+      .catch(() => 'unknown' as const));
+  if (runtimeLossVerdict(providerStatus) === 'park') {
+    const parked = await parkEstablishedRuntime(row, reason, stopReason);
+    return {
+      stage: 'failed',
+      agent_name: visible.row.agentName ?? 'default',
+      retriable: true,
+      sandbox: serializeSandboxRow(parked ?? row),
+      opencode_session_id: null,
+      runtime_url: sessionRuntimeUrlPath(row.externalId),
       reason,
     };
   }
@@ -963,6 +990,7 @@ export async function openSession(args: {
       // The provider itself answered `removed` and in-place recovery came back
       // unavailable — a real Path D2 removal, not a wake that ran out of time.
       'provider_removed',
+      'removed',
     );
   }
 
@@ -988,6 +1016,7 @@ export async function openSession(args: {
         row,
         staleWake,
         'runtime_wake_failed',
+        providerStatus,
       );
     }
     if (providerStatus === 'stopped') {

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -715,11 +715,19 @@ async function preserveEstablishedRuntimeOnOpen(
   // lost because a dead local tunnel kept them from booting and nothing asked
   // the provider first. Anything short of `removed` — including `unknown`,
   // which is a probe failure, not evidence — parks the row retriable instead.
-  const providerStatus =
-    knownProviderStatus ??
-    (await getProvider(row.provider as SandboxProviderName)
-      .getStatus(row.externalId)
-      .catch(() => 'unknown' as const));
+  // try/catch, not .catch(): getProvider() itself throws SYNCHRONOUSLY for a
+  // disabled provider (missing API key), and that must read as "cannot ask" —
+  // park — never as a 500 out of /start.
+  let providerStatus: SandboxStatus = knownProviderStatus ?? 'unknown';
+  if (!knownProviderStatus) {
+    try {
+      providerStatus = await getProvider(row.provider as SandboxProviderName).getStatus(
+        row.externalId,
+      );
+    } catch {
+      providerStatus = 'unknown';
+    }
+  }
   if (runtimeLossVerdict(providerStatus) === 'park') {
     const parked = await parkEstablishedRuntime(row, reason, stopReason);
     return {

--- a/apps/api/src/projects/runtime-identity.test.ts
+++ b/apps/api/src/projects/runtime-identity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { parkMetadataPatch, runtimeLossVerdict } from './runtime-identity';
+
+/**
+ * Incident 2026-08-14 (docs/incidents/2026-08-14-computer-lost-false-alarm-and-boot-failures.md).
+ *
+ * Two healthy sandboxes were shown as "This session's computer was lost": a
+ * dead local tunnel kept them from booting, the on-open path preserved both as
+ * unavailable, and NOTHING asked the provider first. Both provider control
+ * planes reported the boxes running the whole time.
+ *
+ * The rule these tests pin: only a fresh, definitive provider `removed` may
+ * classify an identity as lost. Everything else — present states, transitional
+ * states, and probes the provider could not answer — parks the runtime as an
+ * ordinary stopped row that a later /start can wake.
+ */
+describe('runtimeLossVerdict', () => {
+  test('a definitive provider `removed` is the ONLY loss verdict', () => {
+    expect(runtimeLossVerdict('removed')).toBe('preserve');
+  });
+
+  test.each(['running', 'stopped', 'starting', 'restoring', 'error'])(
+    'a present or transitional provider state (%s) parks instead of preserving',
+    (status) => {
+      expect(runtimeLossVerdict(status)).toBe('park');
+    },
+  );
+
+  test('`unknown` is a probe failure, not evidence of loss — it parks', () => {
+    // Declaring a permanent, unrecoverable loss requires positive evidence.
+    // A timeout or 5xx from the provider control plane is not that.
+    expect(runtimeLossVerdict('unknown')).toBe('park');
+  });
+});
+
+describe('parkMetadataPatch', () => {
+  const now = new Date('2026-08-14T18:24:51.624Z');
+  const patch = parkMetadataPatch('opencode_ready_wait_stale', 'runtime_boot_failed', now);
+
+  test('a park never carries the loss flags the web renders as "computer was lost"', () => {
+    // apps/web isRuntimeIdentityUnavailable() keys on runtimeIdentityState ===
+    // 'unavailable'; preservedExternalId / runtimeUnavailable* are its
+    // companions. None of them may appear on a park.
+    expect(patch).not.toHaveProperty('runtimeIdentityState');
+    expect(patch).not.toHaveProperty('runtimeUnavailableReason');
+    expect(patch).not.toHaveProperty('runtimeUnavailableAt');
+    expect(patch).not.toHaveProperty('preservedExternalId');
+  });
+
+  test('a park still records WHICH failure parked it, for the stop-reason query', () => {
+    expect(patch.stopReason).toBe('runtime_boot_failed');
+    expect(patch.stoppedAt).toBe('2026-08-14T18:24:51.624Z');
+    expect(patch.runtimeParkReason).toBe('opencode_ready_wait_stale');
+  });
+});

--- a/apps/api/src/projects/runtime-identity.ts
+++ b/apps/api/src/projects/runtime-identity.ts
@@ -321,14 +321,16 @@ export async function parkEstablishedRuntime(
       err,
     ),
   );
-  await getProvider(row.provider as ProviderName)
-    .stop(externalId)
-    .catch((err) =>
-      console.warn(
-        `[runtime-identity] provider stop failed while parking ${externalId}:`,
-        err instanceof Error ? err.message : err,
-      ),
+  // try/catch, not .catch(): getProvider() throws synchronously for a
+  // disabled provider, and a park must survive that too.
+  try {
+    await getProvider(row.provider as ProviderName).stop(externalId);
+  } catch (err) {
+    console.warn(
+      `[runtime-identity] provider stop failed while parking ${externalId}:`,
+      err instanceof Error ? err.message : err,
     );
+  }
 
   const metadata = {
     ...((row.metadata as Record<string, unknown> | null) ?? {}),

--- a/apps/api/src/projects/runtime-identity.ts
+++ b/apps/api/src/projects/runtime-identity.ts
@@ -4,7 +4,7 @@ import { and, eq, isNull, sql } from 'drizzle-orm';
 import { endComputeSession, reopenComputeForSandbox } from '../billing/services/compute-metering';
 import { logger } from '../lib/logger';
 import { captureException } from '../lib/sentry';
-import type { ProviderName } from '../platform/providers';
+import { getProvider, type ProviderName } from '../platform/providers';
 import { db } from '../shared/db';
 import type { StopReason } from './stop-reason';
 
@@ -254,6 +254,116 @@ export async function preserveEstablishedRuntime(
 
   reportLostRuntime(preserved, reason, stopReason, now);
   return preserved;
+}
+
+/**
+ * The gate between "the computer failed" and "the computer was LOST".
+ *
+ * Only a fresh, definitive provider `removed` may classify an identity as
+ * lost. Every other answer — a present state, a transitional state, or a probe
+ * the provider could not answer — parks the runtime as an ordinary stopped row
+ * that a later `/start` can wake. Incident 2026-08-14: a dead local tunnel kept
+ * two healthy sandboxes from booting, the on-open path preserved both as lost
+ * without asking the provider, and both control planes showed the boxes running
+ * the whole time (docs/incidents/2026-08-14-computer-lost-false-alarm-and-boot-failures.md).
+ */
+export type RuntimeLossVerdict = 'preserve' | 'park';
+
+export function runtimeLossVerdict(providerStatus: string): RuntimeLossVerdict {
+  return providerStatus === 'removed' ? 'preserve' : 'park';
+}
+
+/**
+ * Metadata patch for a parked (NOT lost) runtime. Pure so a test can pin that
+ * a park never carries `runtimeIdentityState: 'unavailable'` — the one flag the
+ * web renders as "This session's computer was lost".
+ */
+export function parkMetadataPatch(
+  reason: string,
+  stopReason: StopReason,
+  now: Date,
+): Record<string, unknown> {
+  return {
+    stopReason,
+    stoppedAt: now.toISOString(),
+    runtimeParkReason: reason,
+  };
+}
+
+type ParkableRuntimeRow = Pick<
+  typeof sessionSandboxes.$inferSelect,
+  'sandboxId' | 'sessionId' | 'externalId' | 'metadata' | 'provider'
+>;
+
+/**
+ * Park an established runtime that FAILED without being lost: close its
+ * compute window, stop the provider box, and record an ordinary stopped row.
+ * Unlike {@link preserveEstablishedRuntime} it writes no loss flags, so the
+ * session stays wakeable and the UI shows the honest "restart it" card. The
+ * provider stop is load-bearing, not defensive: the incident's boot-failed
+ * boxes stayed RUNNING on both providers after their rows were marked stopped
+ * and their metering closed — unmetered compute until a backstop fired.
+ */
+export async function parkEstablishedRuntime(
+  row: ParkableRuntimeRow,
+  reason: string,
+  stopReason: StopReason,
+  now = new Date(),
+): Promise<typeof sessionSandboxes.$inferSelect | null> {
+  if (!row.externalId) {
+    throw new Error(`Cannot park sandbox ${row.sandboxId} as established without an external_id`);
+  }
+  const externalId = row.externalId;
+
+  await endComputeSession(row.sandboxId).catch((err) =>
+    console.warn(
+      `[runtime-identity] failed to close compute for ${row.sandboxId} while parking ${externalId}:`,
+      err,
+    ),
+  );
+  await getProvider(row.provider as ProviderName)
+    .stop(externalId)
+    .catch((err) =>
+      console.warn(
+        `[runtime-identity] provider stop failed while parking ${externalId}:`,
+        err instanceof Error ? err.message : err,
+      ),
+    );
+
+  const metadata = {
+    ...((row.metadata as Record<string, unknown> | null) ?? {}),
+  };
+  delete metadata.needsReprovision;
+  delete metadata.runtimeRecoveryLeaseId;
+  delete metadata.runtimeRecoveryLeaseAt;
+  delete metadata.runtimeRecoveryLeaseExpiresAtMs;
+  Object.assign(metadata, parkMetadataPatch(reason, stopReason, now));
+
+  try {
+    return await db.transaction(async (tx) => {
+      const [liveSession] = await tx
+        .update(projectSessions)
+        .set({ status: 'stopped', error: null, updatedAt: now })
+        .where(and(eq(projectSessions.sessionId, row.sessionId), sessionIsNotDeleted()))
+        .returning({ sessionId: projectSessions.sessionId });
+      if (!liveSession) return null;
+      const [parkedRow] = await tx
+        .update(sessionSandboxes)
+        .set({ status: 'stopped', metadata, updatedAt: now })
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, row.sandboxId),
+            eq(sessionSandboxes.externalId, externalId),
+          ),
+        )
+        .returning();
+      if (!parkedRow) throw new RuntimeIdentityCasLostError();
+      return parkedRow;
+    });
+  } catch (err) {
+    if (err instanceof RuntimeIdentityCasLostError) return null;
+    throw err;
+  }
 }
 
 /**

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -16,7 +16,11 @@ import {
   sandboxSlugFromSessionMetadata,
   workspaceModeFromSessionMetadata,
 } from '../lib/session-sandbox-metadata';
-import { buildSessionSandboxEnvVars, sandboxCallbackUnreachableReason } from '../lib/sessions';
+import {
+  buildSessionSandboxEnvVars,
+  sandboxCallbackDeadTunnelReason,
+  sandboxCallbackUnreachableReason,
+} from '../lib/sessions';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { isMissingRuntimeError } from '../routes/shared';
 import { invalidateProviderCache } from '../../sandbox-proxy';
@@ -168,7 +172,8 @@ export async function restartSession(input: {
     };
   }
 
-  const restartUnreachable = sandboxCallbackUnreachableReason();
+  const restartUnreachable =
+    sandboxCallbackUnreachableReason() ?? (await sandboxCallbackDeadTunnelReason());
   if (restartUnreachable) {
     return {
       status: 503,

--- a/docs/incidents/2026-08-14-computer-lost-false-alarm-and-boot-failures.md
+++ b/docs/incidents/2026-08-14-computer-lost-false-alarm-and-boot-failures.md
@@ -1,0 +1,228 @@
+# "Computer was lost" false alarm and nightly new-sandbox boot failures
+
+Date: 2026-08-14 (window 18:14–18:36 UTC = 23:44–00:06 IST)
+
+Environment: local dev stack (`pnpm dev`) against the shared provider org
+
+Status: root-caused; fixes not yet shipped
+
+Severity: local-dev outage window; plus one product defect (misleading loss
+classification) and one cross-environment defect (orphan-reaper label
+collision) that affect the shared dev fleet
+
+## TL;DR
+
+**Neither computer was lost on the provider side. Both sandboxes are alive.**
+The "This session's computer was lost" screen fired for two sandboxes whose
+provider control planes report them running at the time of writing:
+
+| Provider | External id | Provider state (verified 2026-08-14 ~18:40Z) |
+| --- | --- | --- |
+| daytona | `168119c9-e984-4025-aadb-e6aad5f32ee2` | `state: "started"`, `errorReason: null` |
+| platinum | `sbx_01M00QP8ZD8BV4DHJACYMR5EH4` | `state: "running"`, agent heartbeating, `deletedAt: null` |
+
+The real failure: the local stack's cloudflared quick tunnel
+(`scheduling-tampa-development-patents.trycloudflare.com`) was dead. Every
+sandbox is born with `KORTIX_REPO_URL` / `KORTIX_API_URL` pointing at that
+tunnel, so the guest could not clone the project repo and never became ready.
+After 5 minutes of `not_ready`, the session-open path files this as
+`runtime_boot_failed` **and preserves the runtime identity as unavailable** —
+which the web UI renders with copy that blames the provider: "Its cloud sandbox
+disappeared on the provider side." That copy was false in both cases.
+
+This is distinct from Domagoj's 2026-08-13 prod incident (session `ad4b63ac`,
+`sbx_01KZP370WDB8DGYNAQM1B875VR`), where Platinum's reconciler really did
+delete a sandbox. That one is a genuine provider-side loss, handled by
+PR #6438 and the report in the platinum repo. Tonight's events are not that.
+
+## Observed symptoms
+
+1. ~23:50 IST: a new session's sandbox "never starts" — recurring "every day
+   this same time at night ... since 2-3 days".
+2. ~23:56–23:58 IST: "This session's computer was lost" for a daytona box and
+   a platinum box, from the same project
+   (`d4914405-5405-451e-b5a4-208b4ad2d854`).
+
+## Verified chain of events (all times UTC; IST = UTC+5:30)
+
+| Time | Event | Evidence |
+| --- | --- | --- |
+| 18:14:01 | Platinum box `sbx_01M00QP...` created for session `3b2e5540` | local DB `session_sandboxes.created_at`; Platinum `createdAt: 18:14:02.280Z` |
+| 18:19:32 | Daytona box `168119c9` created for session `7f438fca` (warm-pool, provider-create 1.28 s) | DB row + Daytona `createdAt: 18:19:32.397Z` |
+| 18:19:51 | Daytona box runtime readiness wait starts, reason `not_ready` — the guest cannot clone through the dead tunnel | DB `metadata.opencodeReadyWaitStartedAt` |
+| 18:24:51 | 5-minute stale-boot threshold hit on session open → identity preserved, `stopReason: runtime_boot_failed` → **"computer was lost" screen** (daytona) | DB `metadata.stoppedAt`, `preservedExternalId` |
+| ~18:26 | Same for the platinum session (first preserve at 18:27:15) → second "computer was lost" screen | DB metadata (later overwritten by the 18:35:39 re-preserve) |
+| 18:26:57–58 | Parked-runtime sweep asks Daytona, gets a settled present state, **heals the daytona row** — clears the "unavailable" flag it had set ~2 min earlier | DB `parkedVerifiedAt: 18:26:57.646`, `runtimeRestoredAt: 18:26:58.421` |
+| 18:29:58 | The local stack is restarted (`pnpm dev`); new cloudflared tunnel minted at 18:30:01 | `ps -o lstart` on `dev-local.sh` and `cloudflared` |
+| 18:30:36 | Restarted stack re-opens the platinum session; the box still carries the OLD tunnel URL baked into its env, so it still cannot become ready | DB `opencodeReadyWaitStartedAt: 18:30:36.433Z` |
+| 18:35:39 | Platinum session preserved again, `runtimeIdentityState: unavailable` — stuck on the "lost" screen while its box runs | DB row |
+| ~18:36 | Platinum agent telemetry still heartbeating from the "lost" box: `runtimeReason: "git clone failed after 4 attempt(s): ... fatal: unable to access 'https://scheduling-tampa-development-patents.trycloudflare.com/v1/git/d491440...'"` | `GET https://api.platinum.dev/v1/sandboxes/sbx_01M00QP8ZD8BV4DHJACYMR5EH4` |
+
+The Platinum telemetry line is the provider-side proof Marko asked for — it
+records the exact failing operation (git clone) and the exact failing URL (the
+dead local tunnel), from inside the supposedly "lost" box, 9 minutes after the
+UI declared it gone.
+
+Direct probe of the tunnel: `curl https://scheduling-tampa-development-patents.trycloudflare.com/v1/health`
+→ curl exit with HTTP code `000` (unreachable).
+
+## Root causes
+
+### 1. Dead local tunnel → every new sandbox is born broken (trigger)
+
+`scripts/dev-local.sh` mints a trycloudflare quick tunnel once at stack start
+and bakes its URL into every sandbox's env (`KORTIX_REPO_URL`,
+`KORTIX_API_URL`, `KORTIX_LLM_BASE_URL`). Quick tunnels die server-side while
+the local `cloudflared` process stays up. After the tunnel dies:
+
+- every NEW sandbox boots, fails `git clone`, and never reaches ready;
+- every EXISTING sandbox keeps the dead URL forever — even after the stack
+  restarts with a fresh tunnel, old boxes can never wake into a working state
+  (observed: the platinum session re-failed at 18:30–18:35 against the new
+  stack).
+
+Nothing monitors the tunnel, nothing restarts it, and provisioning is not
+blocked while it is down.
+
+### 2. `runtime_boot_failed` is rendered as a provider-side loss (product defect)
+
+- `apps/api/src/projects/routes/shared.ts:393` — `STALE_OPENCODE_READY_MS = 5 * 60 * 1000`.
+- `shared.ts:1074–1082` — a stale `not_ready` boot calls
+  `preserveEstablishedRuntimeOnOpen(..., 'runtime_boot_failed')`, which answers
+  `reason: runtime_identity_unavailable`, `retriable: false`.
+- `apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx:596–603`
+  — that reason renders: "Its cloud sandbox disappeared on the provider side,
+  so this session cannot be restarted or recovered."
+
+The helper's own comment says it "serves four unrelated populations (a stalled
+provision, a failed wake, a failed boot, a real provider removal) and cannot
+tell them apart from the inside." No provider status check is made before
+showing the "lost" copy. A local tunnel outage is therefore reported to the
+user — and to Better Stack/Sentry via the `runtime.lost` event — as a provider
+losing a sandbox.
+
+### 3. Preserve closes billing but leaves the box running (compute leak)
+
+`preserveEstablishedRuntime` (`apps/api/src/projects/runtime-identity.ts`)
+calls `endComputeSession` and marks the row `stopped`, but never calls
+`provider.stop()`. Both "lost" boxes were still running on their providers
+~25 minutes later (Daytona `state: started` with `updatedAt` unchanged since
+18:19:33 — no stop ever reached it). Backstops that eventually stop them:
+Daytona `autoStopInterval` 720 min; the orphan sweep. Until then the box burns
+unmetered compute.
+
+### 4. Cross-environment orphan-reaper label collision (secondary, all-day)
+
+`apps/api/.env` sets `INTERNAL_KORTIX_ENV=dev`, so laptop-created boxes carry
+the SAME `kortix.env=dev` label as the deployed dev fleet (verified on the live
+Daytona box). The orphan sweep (`projects/reaping/orphan-boxes.ts`) stops any
+running `kortix.env=dev` box older than 60 min that has no row in ITS OWN
+database. Consequences, both directions:
+
+- the deployed dev API stops laptop-created boxes (no rows in the dev DB). Local
+  DB fingerprint: boxes reconciled `provider_reconcile` at ages 70, 70, 70, 78
+  min — 60-min grace + hourly sweep — some only 2–13 min after last use
+  (mid-work);
+- the laptop stops deployed-dev users' boxes (no rows in the local DB) on the
+  same schedule, whenever `pnpm dev` is running with the shared org keys.
+
+This matches the 2026-08-12 learning "anything created per-deploy needs a
+reaper, and the reaper needs a namespace" — the box labels have the namespace,
+but local dev squats the `dev` namespace.
+
+## The nightly pattern
+
+Local DB, stop reasons by hour, last 6 days: failures cluster in the 18:00Z
+hour (23:30–00:30 IST) on Aug 9 (`runtime_wake_failed`), Aug 12
+(`runtime_wake_failed` + 2× `deadline_expired`), and Aug 14 (2×
+`runtime_boot_failed`, 4× `provider_reconcile`). This is consistent with the
+reported "same time every night since 2-3 days".
+
+**Unverified:** why the tunnel dies in that window. Most plausible: the quick
+tunnel's server-side lifetime expiring at a fixed offset from the morning stack
+start. No local API/cloudflared logs are persisted, so the exact death time of
+the tunnel cannot be recovered. Corrective action 6 closes this gap.
+
+## Impact
+
+- Local dev, 18:14–18:36Z: 2 sessions unrecoverable-by-UI on a healthy provider fleet;
+  every new session in the window failed to boot.
+- One session (`3b2e5540`, platinum) is still stuck on the "lost" screen while
+  its box runs.
+- 2 false `runtime.lost` alerts (the event created to catch REAL provider
+  losses after #6438) — alert noise that will desensitize us to the genuine
+  class.
+- Dev-fleet users: hourly risk of mid-session provider stops from any laptop
+  running `pnpm dev` (root cause 4). Wake usually recovers these, so the
+  symptom is "my sandbox randomly stopped", not data loss.
+- No data loss anywhere: repos live in the project git remote; both boxes are
+  intact.
+
+## Corrective actions
+
+1. **Truthful classification.** Show the "computer was lost" copy only when a
+   fresh `provider.getStatus()` returns `removed` at preserve time. A failed
+   boot gets its own screen ("The computer could not start", retriable) and its
+   own stop reason surface. Files: `shared.ts` (preserve call sites),
+   `page.tsx:596`.
+2. **Surface the guest's own reason.** Platinum already reports
+   `runtimeReason: "git clone failed ... <url>"` in sandbox metadata; pipe it
+   into the boot-failure screen so a dead tunnel names itself.
+3. **Stop the box when preserving.** `preserveEstablishedRuntime` must call
+   `provider.stop()` (best-effort) after closing metering, or enqueue the box
+   for the reaper explicitly.
+4. **Tunnel liveness.** `scripts/dev-local.sh`: probe `KORTIX_URL/v1/health`
+   through the tunnel every 60 s; on failure restart cloudflared, update
+   `KORTIX_URL`, and block new provisions with an explicit "local tunnel down"
+   error until it passes. Consider a named tunnel for stability.
+5. **Own env namespace for laptops.** Set `INTERNAL_KORTIX_ENV=local` (or
+   `local-<user>`) in `apps/api/.env` so laptop boxes never share the deployed
+   dev label namespace; audit `orphan-boxes.ts` against the remaining shared
+   labels. Kill switch exists today: `KORTIX_ORPHAN_BOX_REAP_ENABLED=false`.
+6. **Persist local stack logs.** `dev-local.sh` should tee API + cloudflared
+   output to a dated file so the next nightly incident is diagnosable.
+7. **Alert hygiene.** `runtime.lost` must carry a `providerVerified` flag;
+   alerts route only on verified losses.
+
+After these ship, append the learning to `.claude/skills/learnings/SKILL.md`.
+Candidate rule: *"Never render or alert a provider-side loss that the provider
+was not asked about — a loss verdict requires a fresh `getStatus() ===
+'removed'` at classification time."*
+
+## Verification appendix (exact commands)
+
+```sh
+# 1. Daytona control plane — box alive (key from apps/api/.env via dotenvx)
+curl -H "Authorization: Bearer $DAYTONA_API_KEY" \
+  https://app.daytona.io/api/sandbox/168119c9-e984-4025-aadb-e6aad5f32ee2 \
+  | jq '{state, desiredState, errorReason, createdAt, updatedAt, labels}'
+# → state "started", desiredState "started", errorReason null,
+#   labels {"kortix.env":"dev","kortix.managed":"true", ...}
+
+# 2. Platinum control plane — box alive, telemetry names the real failure
+curl -H "Authorization: Bearer $PLATINUM_API_KEY" \
+  https://api.platinum.dev/v1/sandboxes/sbx_01M00QP8ZD8BV4DHJACYMR5EH4 \
+  | jq '{state, deletedAt, agent: .metadata.agent}'
+# → state "running", deletedAt null,
+#   agent.runtimeReason "git clone failed after 4 attempt(s): ...
+#   unable to access 'https://scheduling-tampa-development-patents.trycloudflare.com/...'"
+
+# 3. The tunnel those boxes were given is dead
+curl -s -o /dev/null -w '%{http_code}' \
+  https://scheduling-tampa-development-patents.trycloudflare.com/v1/health   # → 000
+
+# 4. Local DB — both rows are runtime_boot_failed, not provider_removed
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -c "
+SELECT provider, external_id, status, metadata->>'stopReason',
+       metadata->>'runtimeIdentityState'
+FROM kortix.session_sandboxes
+WHERE external_id IN ('sbx_01M00QP8ZD8BV4DHJACYMR5EH4',
+                      '168119c9-e984-4025-aadb-e6aad5f32ee2');"
+
+# 5. Reaper-collision fingerprint — provider_reconcile at 70/70/70/78 min ages
+psql ... -c "SELECT provider, created_at, metadata->>'stoppedAt',
+  round(extract(epoch FROM ((metadata->>'stoppedAt')::timestamptz - created_at))/60) AS age_min
+  FROM kortix.session_sandboxes
+  WHERE metadata->>'stopReason'='provider_reconcile'
+  ORDER BY 3 DESC;"
+```


### PR DESCRIPTION
## Issue

Two healthy sandboxes were shown as "This session's computer was lost — its cloud sandbox disappeared on the provider side" while both provider control planes reported them running (incident 2026-08-14, report included in this PR). The real failure was a dead local quick tunnel that kept the guests from booting; the on-open path preserved the runtime identity as unavailable without ever asking the provider, fired false `runtime.lost` alerts, and left both boxes running with their metering already closed. Session create kept minting new sandboxes born with the dead callback URL, so "new sandbox never starts" recurred all evening.

## Solution

Declaring a permanent loss now requires positive evidence, and a plain failure stays recoverable:

- `preserveEstablishedRuntimeOnOpen` gates on a fresh `provider.getStatus()`. Only a definitive `removed` preserves the identity as lost; every other answer — present, transitional, or an unanswerable probe — parks the row via the new `parkEstablishedRuntime`: ordinary `stopped` state, no loss flags, retriable `/start`. The two call sites that already hold a fresh provider answer pass it through instead of re-probing. The web needs no change: the lost screen keys on `runtimeIdentityState === 'unavailable'`, so parked sessions land on the honest "restart it" card.
- `parkEstablishedRuntime` stops the provider box after closing metering. The old preserve path never called `provider.stop()`, so a boot-failed box kept burning unmetered compute until a backstop fired.
- Session create and restart probe a `*.trycloudflare.com` `KORTIX_URL` (`/health`, 3s timeout, 30s cache) and answer `503 KORTIX_URL_UNREACHABLE` with an actionable message while the tunnel is dead. Stable public URLs are never probed.

## Testing

- `apps/api` suite: 6842 pass / 0 fail (613 files) via `bash scripts/test.sh`; `tsc --noEmit` clean.
- `runtime-identity.test.ts` pins the loss verdict (red-checked: flipping the verdict fails 2 tests) and that a park never carries the flag the web renders as "computer was lost".
- `dead-tunnel-probe.test.ts` covers scope (stable URLs never probed), dead tunnel, healthy tunnel, non-2xx, and TTL caching.
- The two e2e contract tests that pinned the old preserve-on-boot-failure behavior now pin the park, including `providerStopCalls === 1`.

## Notes

Follow-ups from the incident report, not in this PR: laptop env namespace (`INTERNAL_KORTIX_ENV=local` so local reapers stop colliding with the deployed dev fleet), persisted dev-stack logs, and a `providerVerified` flag on the `runtime.lost` alert.
