### PR TITLE
fix(self-host): hand out public Storage URLs, not the internal Docker host

### DIFF
--- a/apps/api/src/apps/artifacts.ts
+++ b/apps/api/src/apps/artifacts.ts
@@ -3,7 +3,7 @@ import { createReadStream } from 'node:fs';
 import { mkdir, rm, stat } from 'node:fs/promises';
 import { posix, resolve, sep } from 'node:path';
 import * as tar from 'tar';
-import { getSupabase } from '../shared/supabase';
+import { getSupabase, toPublicStorageUrl } from '../shared/supabase';
 
 export const APP_ARTIFACT_BUCKET = 'app-artifacts';
 // Managed Supabase Storage rejects bucket limits above the project's global
@@ -119,7 +119,7 @@ export async function createAppArtifactUploadUrl(
       if (error || !data?.signedUrl) {
         throw error ?? new Error('failed to create App artifact upload URL');
       }
-      return { uploadUrl: data.signedUrl, objectPath, maxBytes: MAX_ARCHIVE_BYTES };
+      return { uploadUrl: toPublicStorageUrl(data.signedUrl), objectPath, maxBytes: MAX_ARCHIVE_BYTES };
     });
   } catch (error) {
     throw new AppArtifactStorageUnavailableError(error);

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -125,6 +125,16 @@ const envSchema = z.object({
     .string()
     .min(1, 'SUPABASE_URL is required')
     .refine((v) => /^https?:\/\//.test(v), { message: 'SUPABASE_URL must be a valid HTTP(S) URL' }),
+  // Public origin for CLIENT-facing Supabase Storage URLs. On a self-host box
+  // SUPABASE_URL is an internal Docker hostname (http://supabase-kong:8000) that
+  // no browser/CLI/remote-sandbox can resolve; this is the box's public origin
+  // (e.g. https://essentia.kortix.cloud) used to rewrite signed URLs on the way
+  // out (see toPublicStorageUrl). Optional: unset on managed cloud, where
+  // SUPABASE_URL is already public and no rewrite is needed.
+  SUPABASE_PUBLIC_URL: z
+    .string()
+    .refine((v) => v === '' || /^https?:\/\//.test(v), { message: 'SUPABASE_PUBLIC_URL must be a valid HTTP(S) URL' })
+    .optional(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1, 'SUPABASE_SERVICE_ROLE_KEY is required'),
 
   // ── API Key Hashing (REQUIRED) ───────────────────────────────────────────
@@ -934,6 +944,7 @@ export const config = {
 
   // ─── Supabase ──────────────────────────────────────────────────────────────
   SUPABASE_URL: env.SUPABASE_URL,
+  SUPABASE_PUBLIC_URL: env.SUPABASE_PUBLIC_URL,
   SUPABASE_SERVICE_ROLE_KEY: env.SUPABASE_SERVICE_ROLE_KEY,
 
   // ─── API Key Hashing ──────────────────────────────────────────────────────

--- a/apps/api/src/connectors/attachments.ts
+++ b/apps/api/src/connectors/attachments.ts
@@ -1,7 +1,7 @@
 import { connectorAttachments } from '@kortix/db';
 import { and, asc, eq, inArray, lt, or } from 'drizzle-orm';
 import { db } from '../shared/db';
-import { getSupabase } from '../shared/supabase';
+import { getSupabase, toPublicStorageUrl } from '../shared/supabase';
 
 export const MAX_CONNECTOR_ATTACHMENT_FILES = 20;
 export const MAX_CONNECTOR_ATTACHMENT_BYTES = 25 * 1024 * 1024;
@@ -247,7 +247,7 @@ class DbConnectorAttachmentStore implements ConnectorAttachmentStore {
             content_type: row.contentType,
             content_disposition: row.contentDisposition as 'attachment' | 'inline',
             ...(row.contentId ? { content_id: row.contentId } : {}),
-            url: data.signedUrl,
+            url: toPublicStorageUrl(data.signedUrl),
           };
         }),
       );

--- a/apps/api/src/projects/legacy-migration-storage.ts
+++ b/apps/api/src/projects/legacy-migration-storage.ts
@@ -1,5 +1,5 @@
 import { config } from '../config';
-import { getSupabase } from '../shared/supabase';
+import { getSupabase, toPublicStorageUrl } from '../shared/supabase';
 
 const BUCKET = () => config.LEGACY_MIGRATION_BACKUP_BUCKET;
 const ARCHIVE_FILE_SIZE_LIMIT = 5 * 1024 * 1024 * 1024;
@@ -39,7 +39,7 @@ export async function createOpencodeArchiveUploadUrl(
   if (error || !data?.signedUrl) {
     throw error ?? new Error('failed to create opencode archive upload url');
   }
-  return { uploadUrl: data.signedUrl, path };
+  return { uploadUrl: toPublicStorageUrl(data.signedUrl), path };
 }
 
 export async function uploadOpencodeArchive(

--- a/apps/api/src/scripts/deliver-suna-files.ts
+++ b/apps/api/src/scripts/deliver-suna-files.ts
@@ -7,7 +7,7 @@
  */
 import { readFileSync, statSync } from 'node:fs';
 import { config } from '../config';
-import { getSupabase } from '../shared/supabase';
+import { getSupabase, toPublicStorageUrl } from '../shared/supabase';
 import { ensureBackupBucket } from '../projects/legacy-migration-storage';
 
 function arg(flag: string): string | undefined {
@@ -36,7 +36,7 @@ async function main() {
   if (signed.error || !signed.data?.signedUrl) throw signed.error ?? new Error('failed to sign url');
 
   console.log(`\n✓ uploaded to ${bucket}/${path}`);
-  console.log(`\nDownload link (valid ${days} days):\n${signed.data.signedUrl}\n`);
+  console.log(`\nDownload link (valid ${days} days):\n${toPublicStorageUrl(signed.data.signedUrl)}\n`);
 }
 
 await main();

--- a/apps/api/src/shared/storage-url.test.ts
+++ b/apps/api/src/shared/storage-url.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+
+import { rewriteStorageOrigin } from './storage-url';
+
+const INTERNAL = 'http://supabase-kong:8000';
+const PUBLIC = 'https://essentia.kortix.cloud';
+const SIGNED = `${INTERNAL}/storage/v1/object/upload/sign/app-artifacts/a/b/c?token=jwt.abc`;
+
+describe('rewriteStorageOrigin', () => {
+  test('rewrites the internal Docker host to the public origin for client-facing URLs', () => {
+    expect(rewriteStorageOrigin(SIGNED, INTERNAL, PUBLIC)).toBe(
+      `${PUBLIC}/storage/v1/object/upload/sign/app-artifacts/a/b/c?token=jwt.abc`,
+    );
+  });
+
+  test('no-op when the public base is unset (managed cloud: SUPABASE_URL already public)', () => {
+    expect(rewriteStorageOrigin(SIGNED, INTERNAL, undefined)).toBe(SIGNED);
+    expect(rewriteStorageOrigin(SIGNED, INTERNAL, '')).toBe(SIGNED);
+  });
+
+  test('no-op when public equals internal', () => {
+    const publicOnly = `${PUBLIC}/storage/v1/x`;
+    expect(rewriteStorageOrigin(publicOnly, PUBLIC, PUBLIC)).toBe(publicOnly);
+  });
+
+  test('tolerates a trailing slash on either base', () => {
+    expect(rewriteStorageOrigin(SIGNED, `${INTERNAL}/`, `${PUBLIC}/`)).toBe(
+      `${PUBLIC}/storage/v1/object/upload/sign/app-artifacts/a/b/c?token=jwt.abc`,
+    );
+  });
+
+  test('leaves a URL that is not on the internal host untouched', () => {
+    const already = `${PUBLIC}/storage/v1/object/y`;
+    expect(rewriteStorageOrigin(already, INTERNAL, PUBLIC)).toBe(already);
+  });
+
+  test('preserves a public base that carries a path prefix', () => {
+    expect(rewriteStorageOrigin(SIGNED, INTERNAL, 'https://host.example/sb')).toBe(
+      'https://host.example/sb/storage/v1/object/upload/sign/app-artifacts/a/b/c?token=jwt.abc',
+    );
+  });
+});

--- a/apps/api/src/shared/storage-url.ts
+++ b/apps/api/src/shared/storage-url.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure helper for rewriting Supabase Storage URLs. Kept dependency-free (no
+ * config/env import) so it is trivially unit-testable and safe to import from
+ * anywhere. The config-bound wrapper lives in `./supabase` as
+ * `toPublicStorageUrl`.
+ *
+ * Swap an `internal`-based URL prefix for `publicBase`. No-op when `publicBase`
+ * is empty/unset or equal to `internal`, or when `url` does not start with
+ * `internal` (already public).
+ */
+export function rewriteStorageOrigin(
+  url: string,
+  internal: string | undefined,
+  publicBase: string | undefined,
+): string {
+  const i = internal?.replace(/\/+$/, '');
+  const p = publicBase?.replace(/\/+$/, '');
+  if (!i || !p || p === i) return url;
+  return url.startsWith(i) ? p + url.slice(i.length) : url;
+}

--- a/apps/api/src/shared/supabase.ts
+++ b/apps/api/src/shared/supabase.ts
@@ -1,5 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { config } from '../config';
+import { rewriteStorageOrigin } from './storage-url';
 
 let client: SupabaseClient | null = null;
 
@@ -20,4 +21,26 @@ export function getSupabase(): SupabaseClient {
   }
 
   return client;
+}
+
+/**
+ * Rewrite a Supabase Storage signed/public URL so an EXTERNAL consumer (a
+ * browser, the App CLI/uploader, or a cloud sandbox fetching an attachment or
+ * image) can reach it.
+ *
+ * On a self-host box `SUPABASE_URL` is the INTERNAL Docker hostname
+ * (`http://supabase-kong:8000`) so server->Supabase calls stay on the fast
+ * internal network. But supabase-js bakes that same base URL into every signed
+ * URL it returns — and no external client (nor a remote E2B sandbox) can
+ * resolve `supabase-kong`, so uploads and attachment/image fetches silently
+ * fail. `SUPABASE_PUBLIC_URL` is the box's public origin
+ * (e.g. `https://essentia.kortix.cloud`, which Caddy proxies `/storage/v1*` ->
+ * Kong), so we swap the internal base for the public one on the way out.
+ *
+ * No-op (returns the URL unchanged) when `SUPABASE_PUBLIC_URL` is unset or equal
+ * to `SUPABASE_URL` — i.e. on managed cloud, where `SUPABASE_URL` is already
+ * public — so this only ever rewrites on a split internal/public self-host.
+ */
+export function toPublicStorageUrl(url: string): string {
+  return rewriteStorageOrigin(url, config.SUPABASE_URL, config.SUPABASE_PUBLIC_URL);
 }


### PR DESCRIPTION
## Problem

On a self-host box, `SUPABASE_URL` is the **internal** Docker hostname `http://supabase-kong:8000` so server→Supabase calls stay on the fast internal network. But `supabase-js` bakes that same base URL into every signed URL it returns — and the API handed those **straight to external consumers**, who cannot resolve `supabase-kong`:

- **App artifact upload URL** (`createAppArtifactUploadUrl`) — the App CLI/uploader PUTs the archive to `http://supabase-kong:8000/storage/v1/…`, unreachable from outside, so **every deploy's archive upload fails**. Observed live on the Essentia box: all Apps stuck at `active_deployment_id = null` — nobody had ever completed a deploy.
- **Connector attachment URLs** (`connectors/attachments.ts`) and the **legacy-migration upload URL** — same leak; a remote consumer (browser, App uploader, or a cloud E2B sandbox fetching an attachment) can't resolve the internal host.

## Fix

Rewrite the **host of client-facing signed URLs** from the internal `SUPABASE_URL` to the box's **public** origin, leaving server-side storage ops on the fast internal path untouched.

- New config `SUPABASE_PUBLIC_URL` — already set on self-host boxes (e.g. `https://essentia.kortix.cloud`, which Caddy proxies `/storage/v1*` → Kong). Optional.
- Pure helper `rewriteStorageOrigin` (dependency-free, unit-tested) + `toPublicStorageUrl` wrapper, applied at every client-facing signed-URL site (App artifact upload, connector attachments, legacy-migration upload, the deliver-suna-files script).
- **No-op on managed cloud**: `SUPABASE_PUBLIC_URL` is unset there and `SUPABASE_URL` is already public, so the rewrite never fires.

## Verification

- `bun test apps/api/src/shared/storage-url.test.ts` — 6/6 pass (rewrite, no-op-when-unset, no-op-when-equal, trailing-slash, already-public, path-prefixed public base).
- `apps/api` `tsc --noEmit` — clean.
- Empirically confirmed the target is reachable: `https://essentia.kortix.cloud/storage/v1/version` → `200` (`1.60.4`); box Caddy routes `/storage/v1*` → `supabase-kong:8000`.

## Rollout

Reaches self-host boxes via the next CLI/image release; the box already exports `SUPABASE_PUBLIC_URL`, so no box config change is needed once the fixed API image is live.
