### PR TITLE
fix(web): align the Apps sidebar row with the group it moved into

### DIFF
--- a/apps/web/src/features/apps/apps-feature-gate.test.ts
+++ b/apps/web/src/features/apps/apps-feature-gate.test.ts
@@ -88,6 +88,30 @@ test('Apps UI is operational only and has no creation action or modal', () => {
   expect(view).toContain('className="max-w-5xl"');
 });
 
+test('the Apps row matches the row contract of the group it sits in', () => {
+  // The sidebar has TWO row conventions. The top group (New session, Customize)
+  // pads with px-3 and rests muted; the bottom group (Files, Settings) does
+  // neither. Apps moved from the bottom group to the top one and kept the old
+  // class list, so its icon and label sat ~8px left of its neighbours and read a
+  // shade darker — visibly out of line.
+  const apps = readFileSync(
+    resolve(root, 'features/workspace/project-sidebar/footer/project-apps-nav.tsx'),
+    'utf8',
+  );
+  const customize = readFileSync(
+    resolve(root, 'features/workspace/project-sidebar/project-settings-nav.tsx'),
+    'utf8',
+  );
+
+  const ROW = 'group/menu-button text-muted-foreground hover:text-sidebar-foreground flex items-center gap-2 px-3 text-sm! font-medium [&_svg]:size-4!';
+  // The same string the sibling rows in this group use — if that contract is
+  // ever restyled, this fails rather than letting Apps silently drift out.
+  expect(customize).toContain(ROW);
+  expect(apps).toContain(ROW);
+  // The glyph keeps its box on a narrow sidebar, like its neighbours.
+  expect(apps).toContain('<span className="shrink-0">');
+});
+
 test('an App with no deployment never claims to be Running', () => {
   // `desired_state` defaults to 'running' when the App row is created, so
   // reading the badge off it alone painted a green "Running" pill on an App

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-apps-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-apps-nav.tsx
@@ -31,10 +31,19 @@ export function ProjectAppsNavItem() {
         asChild
         isActive={pathname?.startsWith(`/projects/${projectId}/apps`) === true}
         tooltip="Apps"
-        className="flex items-center gap-2 text-sm! font-medium [&_svg]:size-4!"
+        /* Must match the row contract of THIS group — New session and Customize
+           (project-settings-nav `ProjectCustomizeNavItem`). The bottom group
+           (Files, Settings) uses a different one with no px-3 and no muted
+           resting colour; Apps kept that after moving up here, which left its
+           icon and label ~8px left of its neighbours and a shade darker. */
+        className="group/menu-button text-muted-foreground hover:text-sidebar-foreground flex items-center gap-2 px-3 text-sm! font-medium [&_svg]:size-4!"
       >
         <Link href={`/projects/${projectId}/apps`} prefetch onClick={handleClick}>
-          <GlobeIcon />
+          {/* shrink-0 so the glyph keeps its box when the label is long or the
+              sidebar is narrow — the sibling rows wrap their icons the same way. */}
+          <span className="shrink-0">
+            <GlobeIcon />
+          </span>
           Apps
         </Link>
       </SidebarMenuButton>


### PR DESCRIPTION
## The bug

Moving the Apps row from the bottom of the sidebar up next to **Customize**
(#6453) left it on the wrong row convention, so it rendered visibly out of line
with its new neighbours.

The sidebar has two:

| Group | Convention |
|---|---|
| **Top** — New session, Customize | `group/menu-button text-muted-foreground hover:text-sidebar-foreground … **px-3** …`, glyph wrapped in `<span className="shrink-0">` |
| **Bottom** — Files, Settings | `flex items-center gap-2 …` — no `px-3`, no muted resting colour |

Apps kept the bottom-group class list while sitting in the top group: **7.36px**
of padding against its neighbours' **11.04px**, so its icon and label sat 3px
left of the column, and it rested a shade darker.

## The fix

Apps now uses the same row contract as `ProjectCustomizeNavItem`, glyph wrapper
included.

## Verified in the browser

Computed styles, sidebar expanded:

| Row | padding-left | icon x |
|---|---|---|
| New session | 11.04px | 18 |
| Customize | 11.04px | 18 |
| **Apps** | **11.04px** | **18** |
| Files *(bottom group, unchanged)* | 7.36px | 15 |

- Identical at **1600px** and **1100px**.
- `document.documentElement.scrollWidth > innerWidth` → **false** at every width.
- At 500px the sidebar goes offcanvas as designed.

`apps/web` tests: **182 pass / 0 fail** across the apps + sidebar + menu-registry
suites. `tsc --noEmit` clean, `eslint` clean on the touched file.

The contract test asserts Apps carries the *same class string* the sibling row
uses, read out of `project-settings-nav.tsx` — so restyling that group fails the
test rather than letting Apps silently drift out of line again.
