### PR TITLE
fix(api): don't gate turn-stream lifecycle reports on connector.write

### DIFF
--- a/apps/api/src/projects/routes/r4-turn-stream-kind.test.ts
+++ b/apps/api/src/projects/routes/r4-turn-stream-kind.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { turnStreamKindField } from './r4-turn-stream-kind';
+import { turnStreamKindField, turnStreamKindNeedsConnectorWrite } from './r4-turn-stream-kind';
 
 describe('turnStreamKindField', () => {
   test('passes through every kind the route multiplexes', () => {
@@ -18,5 +18,31 @@ describe('turnStreamKindField', () => {
     expect(turnStreamKindField('')).toBe('unknown');
     expect(turnStreamKindField(null)).toBe('unknown');
     expect(turnStreamKindField(42)).toBe('unknown');
+  });
+});
+
+describe('turnStreamKindNeedsConnectorWrite', () => {
+  test('lifecycle kinds are EXEMPT (no connector.write) — a scoped agent reports these', () => {
+    // These reach a `return` before the send path; they carry no content and
+    // fan out to no connector, so the in-sandbox agent CLI (session token,
+    // no connector.write) must be allowed to report them.
+    expect(turnStreamKindNeedsConnectorWrite('end')).toBe(false);
+    expect(turnStreamKindNeedsConnectorWrite('turn_end')).toBe(false);
+    expect(turnStreamKindNeedsConnectorWrite('opencode_session')).toBe(false);
+  });
+
+  test('channel-send kinds REQUIRE connector.write', () => {
+    // step/answer post the agent's content to Slack/Teams.
+    expect(turnStreamKindNeedsConnectorWrite('step')).toBe(true);
+    expect(turnStreamKindNeedsConnectorWrite('answer')).toBe(true);
+  });
+
+  test('deny-by-default: any unknown / missing kind that could reach the send path is gated', () => {
+    expect(turnStreamKindNeedsConnectorWrite('something_new')).toBe(true);
+    expect(turnStreamKindNeedsConnectorWrite('execution_heartbeat')).toBe(true);
+    expect(turnStreamKindNeedsConnectorWrite(undefined)).toBe(true);
+    expect(turnStreamKindNeedsConnectorWrite('')).toBe(true);
+    expect(turnStreamKindNeedsConnectorWrite(null)).toBe(true);
+    expect(turnStreamKindNeedsConnectorWrite(42)).toBe(true);
   });
 });

--- a/apps/api/src/projects/routes/r4-turn-stream-kind.ts
+++ b/apps/api/src/projects/routes/r4-turn-stream-kind.ts
@@ -13,3 +13,25 @@
 export function turnStreamKindField(kind: unknown): string {
   return typeof kind === 'string' && kind ? kind : 'unknown';
 }
+
+// The SANDBOX-reported LIFECYCLE kinds. They carry no agent content and fan out
+// to no connector: `end`/`turn_end` only shorten this session's idle deadline
+// (LEAST-only — can never extend the box's life), and `opencode_session` only
+// persists the root-session pin. Everything NOT in this set reaches the
+// content-bearing send path in turn-stream (relayTurnStep/relayTurnAnswer, which
+// post to the project's Slack/Teams), including any unknown kind.
+export const TURN_STREAM_LIFECYCLE_KINDS: ReadonlySet<string> = new Set([
+  'end',
+  'turn_end',
+  'opencode_session',
+]);
+
+// Whether a turn-stream `kind` requires project.connector.write (a channel-send
+// primitive) vs is a lifecycle signal that only needs project membership.
+// Deny-by-default: only the explicit lifecycle kinds are exempt, so a new/unknown
+// kind that could reach the send path is gated. Gating the lifecycle kinds broke
+// turn-end reporting for scoped agents (their session token holds no
+// connector.write), stranding sandboxes alive for the full idle grace.
+export function turnStreamKindNeedsConnectorWrite(kind: unknown): boolean {
+  return !TURN_STREAM_LIFECYCLE_KINDS.has(typeof kind === 'string' ? kind : '');
+}

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -149,7 +149,7 @@ import { generateSessionTitleFromFirstPrompt } from '../session-title-generate';
 import { listProjectSecretNamesForConsumer } from '../secrets';
 import { reconcileProjectTriggerRuntime } from '../trigger-runtime-catalog';
 import { type ParsedManifest, extractTriggers, loadProjectTriggers } from '../triggers';
-import { turnStreamKindField } from './r4-turn-stream-kind';
+import { turnStreamKindField, turnStreamKindNeedsConnectorWrite } from './r4-turn-stream-kind';
 
 // Body keys that change the trigger's *repo manifest* (committed to git). A PATCH
 // whose body touches none of these has nothing to commit, so we skip git entirely
@@ -2295,13 +2295,31 @@ projectsApp.openapi(
     } else {
       const loaded = await loadProjectForUser(c, projectId, 'read');
       if (!loaded) return c.json({ error: 'Not found' }, 404);
-      await assertProjectCapability(
-        c,
-        loaded.userId,
-        loaded.row.accountId,
-        projectId,
-        PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
-      );
+      // Kind-aware capability floor. The connector.write gate protects the
+      // CHANNEL-SEND primitives: `step`/`answer` — and any unknown kind — fall
+      // through to relayTurnStep/relayTurnAnswer below, which post the agent's
+      // content to the project's Slack/Teams. The SANDBOX-reported LIFECYCLE
+      // signals carry no content and fan out to no connector: `end`/`turn_end`
+      // only shorten this session's idle deadline (LEAST-only — see the comment
+      // at the `end` branch below, it can never EXTEND the box's life), and
+      // `opencode_session` only persists the root-session pin. Those are exactly
+      // what the in-sandbox agent CLI reports over its session/CLI token, which a
+      // SCOPED agent grant has no reason to hold connector.write for — gating them
+      // 403'd every turn-end report on Essentia, stranding sandboxes alive for the
+      // full idle grace (wasted compute). So exempt the lifecycle kinds and keep
+      // the connector gate as the deny-by-default floor for anything that can
+      // reach the send path. The IDOR scope (session_id -> projectId) below still
+      // applies to every kind, and the `read` floor above still requires
+      // membership.
+      if (turnStreamKindNeedsConnectorWrite(body.kind)) {
+        await assertProjectCapability(
+          c,
+          loaded.userId,
+          loaded.row.accountId,
+          projectId,
+          PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+        );
+      }
     }
 
     if (authenticatedSandboxId) {


### PR DESCRIPTION
## Problem

`POST /:projectId/turn-stream`'s non-sandbox auth branch gated **every** `kind` on `project.connector.write`. But the in-sandbox agent CLI reports turn lifecycle over its **session/CLI token**, and a **scoped agent grant holds no `connector.write`** — so every `end` / `turn_end` / `opencode_session` report **403'd**.

Observed live on the Essentia self-host box: **222 turn-stream 403s in 24h** (`kind:"end"` in the completion log). Because the turn-end report is rejected, `shortenSandboxDeadlineOnTurnEnd` never runs, so the sandbox lives the **full idle grace** instead of dying ~15 min after the turn ends — **wasted compute / over-billing**. The route's own comment already states `end` "needs no auth gate of its own"; the blanket route-level gate overrode it before that code was reached.

## Fix

Make the capability floor **kind-aware, deny-by-default**:
- **Exempt** the sandbox-reported **lifecycle** kinds — `end`, `turn_end`, `opencode_session`. They carry no agent content and fan out to no connector (`end`/`turn_end` only shorten this session's idle deadline — LEAST-only, can never extend the box's life; `opencode_session` only persists the root pin).
- **Keep** `project.connector.write` for everything that can reach the send path — `step`/`answer` (which post the agent's content to the project's Slack/Teams) **and any unknown kind** — so the pentest gate protecting the channel-send primitives is preserved.
- The `read` membership floor and the `session_id → projectId` IDOR scope still apply to **every** kind.

Classification extracted to `turnStreamKindNeedsConnectorWrite` in `r4-turn-stream-kind.ts` (already the unit-testable turn-stream-kind module).

`turn-question` is **not** affected — its non-sandbox branch already uses the `'session'` floor (which a launched-agent grant holds), not `connector.write`.

## Verification

- `bun test apps/api/src/projects/routes/r4-turn-stream-kind.test.ts` — 5/5 pass (lifecycle exempt; step/answer gated; deny-by-default for unknown/missing/non-string).
- `apps/api` `tsc --noEmit` — no errors in the changed files.
