### PR TITLE
fix(apps): return 409 (not 500) on duplicate App slug

### DIFF
--- a/apps/api/src/apps/routes.ts
+++ b/apps/api/src/apps/routes.ts
@@ -14,6 +14,7 @@ import { pauseComputeSession } from '../billing/services/compute-metering';
 import { config, type SandboxProviderName } from '../config';
 import { getProvider } from '../platform/providers';
 import { db } from '../shared/db';
+import { inspectDatabaseError } from '../shared/database-errors';
 import {
   AppArtifactStorageUnavailableError,
   createAppArtifactUploadUrl,
@@ -447,7 +448,12 @@ projectsApp.openapi(
       }).returning();
       return c.json(serializeApp(row!), 201);
     } catch (error) {
-      if ((error as { code?: string }).code === '23505') return c.json({ error: 'An App with this slug already exists' }, 409);
+      // Drizzle wraps the postgres.js error, so the SQLSTATE lives on
+      // error.cause.code, NOT error.code — reading error.code left this branch
+      // dead and a duplicate-slug create returned 500 instead of 409.
+      // inspectDatabaseError walks the .cause chain for the real pgCode.
+      if (inspectDatabaseError(error)?.pgCode === '23505')
+        return c.json({ error: 'An App with this slug already exists' }, 409);
       throw error;
     }
   },

--- a/apps/api/src/shared/database-errors.test.ts
+++ b/apps/api/src/shared/database-errors.test.ts
@@ -39,6 +39,15 @@ describe('inspectDatabaseError', () => {
     });
   });
 
+  test('reads a unique_violation (23505) off the wrapped cause — the App-create 409 path', () => {
+    // Drizzle wraps postgres.js, so the SQLSTATE is on error.cause.code, never
+    // error.code. The old `(error as {code?}).code === '23505'` check was dead
+    // (undefined) and duplicate-slug App creates returned 500 instead of 409.
+    const error = wrappedDatabaseError('23505', 'duplicate key value violates unique constraint');
+    expect((error as { code?: string }).code).toBeUndefined(); // why the old check never fired
+    expect(inspectDatabaseError(error)?.pgCode).toBe('23505');
+  });
+
   test('rejects an application error with no database signal', () => {
     expect(inspectDatabaseError(new Error('invalid project state'))).toBeNull();
   });


### PR DESCRIPTION
## Problem

`POST /:projectId/apps` returns **500 instead of 409** when the slug already exists. The handler tries to catch the unique-violation:

```ts
if ((error as { code?: string }).code === '23505') return c.json(..., 409);
```

but Drizzle wraps the postgres.js error — the SQLSTATE is on **`error.cause.code`**, not `error.code`. So `error.code` is `undefined`, the branch is **dead**, and the error rethrows to the central handler as a 500.

Observed live on the Essentia self-host box: `POST /apps -> 500 [DB ERROR 23505]` (`Key (project_id, slug)=(…, essentia-dashboards) already exists`) after the user re-submitted an existing App slug.

## Fix

Use the existing `inspectDatabaseError()` (already used at `index.ts` for the same reason), which walks the `.cause` chain and returns the real `pgCode`.

## Verification

- `bun test apps/api/src/shared/database-errors.test.ts` — 12/12 pass, incl. a new case proving `error.code` is `undefined` on a wrapped error while `inspectDatabaseError(...).pgCode` is `'23505'`.
- `apps/api` `tsc --noEmit` — no errors in the changed files.
