### PR TITLE
fix(cli): show the minted agent token's identity, not "not logged in"

### DIFF
--- a/apps/cli/src/__tests__/agent-token-identity.blackbox.test.ts
+++ b/apps/cli/src/__tests__/agent-token-identity.blackbox.test.ts
@@ -1,0 +1,177 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+
+// Black-box reproduction of the in-sandbox agent case: the real `kortix`
+// process, a real HTTP API, a real `.kortix/link.json`, and a real minted
+// agent token in the environment.
+//
+// The original report — `kortix sessions restart "$KORTIX_SESSION_ID"` from
+// inside a session — printed:
+//
+//   host cloud (https://api.kortix.com, not logged in) · account … · session …
+//     ✗  You don't have permission to perform this action (project.session.read).
+//
+// Both halves were unusable: the CLI was authenticated (it just made an
+// authenticated request), and the denial never said WHICH identity was refused.
+
+const CLI_ENTRY = join(resolve(import.meta.dir, '..', '..'), 'src', 'index.ts');
+
+const PROJECT_ID = '508bccdd-1edb-4c61-877b-164aceac20e2';
+const SESSION_ID = 'ea985b87-d12c-4ba4-aa12-ee0711dab6f6';
+const ACCOUNT_ID = '3b1fc472-a90e-404f-823f-ca42f6b32e4d';
+const AGENT_TOKEN = 'kortix_pat_minted_for_osp_vision_route_agent';
+
+let tmp: string;
+let server: ReturnType<typeof Bun.serve> | null = null;
+let requests: string[] = [];
+
+/** Stand-in for the Kortix API: it knows the token's identity, and it refuses
+ *  the session read exactly as production does for an agent without the
+ *  `project.session.read` grant. */
+function startApi() {
+  requests = [];
+  return Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      requests.push(`${req.method} ${url.pathname}`);
+      if (req.headers.get('authorization') !== `Bearer ${AGENT_TOKEN}`) {
+        return Response.json({ error: 'unauthenticated' }, { status: 401 });
+      }
+      if (url.pathname === '/v1/accounts/me') {
+        return Response.json({
+          user_id: 'user_123',
+          email: 'owner@example.test',
+          token_context: {
+            auth_type: 'pat',
+            project_id: PROJECT_ID,
+            session_id: SESSION_ID,
+            agent: 'osp-vision-route-agent',
+            connectors: [],
+            kortix_cli: ['project.secret.read', 'project.secret.write'],
+          },
+          accounts: [
+            { account_id: ACCOUNT_ID, slug: '3b1fc472', name: 'Essentia', role: 'owner' },
+          ],
+        });
+      }
+      if (url.pathname.startsWith(`/v1/projects/${PROJECT_ID}/sessions`)) {
+        return Response.json(
+          { error: "You don't have permission to perform this action (project.session.read)." },
+          { status: 403 },
+        );
+      }
+      return Response.json({ error: 'not found' }, { status: 404 });
+    },
+  });
+}
+
+/** A sandbox workspace: linked directory, plus a `cloud` host that was never
+ *  logged in — the credential arrives through the environment instead. */
+function seedWorkspace(apiBase: string): void {
+  mkdirSync(join(tmp, '.kortix'), { recursive: true });
+  writeFileSync(
+    join(tmp, '.kortix', 'link.json'),
+    JSON.stringify({
+      project_id: PROJECT_ID,
+      account_id: ACCOUNT_ID,
+      host: 'cloud',
+      host_url: apiBase,
+      linked_at: '2026-07-13T17:06:24.828Z',
+    }),
+  );
+  writeFileSync(
+    join(tmp, 'config.json'),
+    JSON.stringify({
+      active: 'cloud',
+      hosts: {
+        cloud: {
+          url: apiBase,
+          token: '',
+          user_id: '',
+          user_email: '',
+          account_id: '',
+          logged_in_at: '',
+        },
+      },
+    }),
+  );
+}
+
+async function runCli(args: string[]) {
+  const proc = Bun.spawn({
+    cmd: [process.execPath, CLI_ENTRY, ...args],
+    cwd: tmp,
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      FORCE_COLOR: '0',
+      KORTIX_NO_UPDATE_CHECK: '1',
+      KORTIX_DISABLE_SANDBOX_ENV_FILE: '1',
+      KORTIX_CONFIG_FILE: join(tmp, 'config.json'),
+      // What the platform injects into a running session.
+      KORTIX_API_URL: `http://127.0.0.1:${server!.port}`,
+      KORTIX_CLI_TOKEN: AGENT_TOKEN,
+      KORTIX_PROJECT_ID: PROJECT_ID,
+      KORTIX_SESSION_ID: SESSION_ID,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const timeout = setTimeout(() => proc.kill(), 30_000);
+  const [code, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]).finally(() => clearTimeout(timeout));
+  return { code, stdout, stderr };
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'kortix-agent-identity-'));
+  server = startApi();
+  seedWorkspace(`http://127.0.0.1:${server.port}`);
+});
+
+afterEach(() => {
+  server?.stop(true);
+  server = null;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('a refused session read reports the CLI as authenticated and names the agent', async () => {
+  const first = await runCli(['sessions', 'restart', SESSION_ID]);
+
+  // 1. The standing context line no longer contradicts the request it just made.
+  expect(first.stderr).not.toContain('not logged in');
+  expect(first.stderr).toContain('authenticated (session token)');
+  // The cwd link still supplies account + project.
+  expect(first.stderr).toContain(`account ${ACCOUNT_ID.slice(0, 8)}`);
+  expect(first.stderr).toContain(`project ${PROJECT_ID.slice(0, 8)}`);
+
+  // 2. The denial still names the action…
+  expect(first.stderr).toContain('project.session.read');
+  // …and now also names the identity that was refused, its grant, and the fix.
+  expect(first.stderr).toContain('session token · agent osp-vision-route-agent');
+  expect(first.stderr).toContain('project.secret.read, project.secret.write');
+  expect(first.stderr).toContain('agents.osp-vision-route-agent.kortix_cli');
+  expect(first.code).toBe(1);
+
+  // 3. The identity was resolved once and cached, so the NEXT command names the
+  //    agent in its standing line without any further /accounts/me call.
+  const meCallsAfterFirst = requests.filter((r) => r.endsWith('/v1/accounts/me')).length;
+  const second = await runCli(['sessions', 'restart', SESSION_ID]);
+  expect(second.stderr).toContain('agent osp-vision-route-agent');
+  expect(requests.filter((r) => r.endsWith('/v1/accounts/me')).length).toBe(meCallsAfterFirst);
+});
+
+test('the bare landing screen shows the agent row instead of a logged-out host', async () => {
+  await runCli(['sessions', 'restart', SESSION_ID]); // warms the identity cache
+  const landing = await runCli([]);
+
+  expect(landing.stdout).toContain('osp-vision-route-agent');
+  expect(landing.stdout).not.toContain('not logged in');
+  expect(landing.stdout).toContain('kortix whoami --token-only');
+});

--- a/apps/cli/src/__tests__/host-notice.test.ts
+++ b/apps/cli/src/__tests__/host-notice.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { renderHostNotice } from '../host-notice.ts';
+import { renderContext, renderHostNotice } from '../host-notice.ts';
+import { clearTokenIdentityCache } from '../api/token-identity.ts';
 
 const ENV_KEYS = [
   'KORTIX_CLI_TOKEN',
@@ -18,21 +20,26 @@ const ENV_KEYS = [
 ] as const;
 
 let saved: Record<string, string | undefined>;
+let savedCwd: string;
 
 beforeEach(() => {
   saved = {};
+  savedCwd = process.cwd();
   for (const key of ENV_KEYS) {
     saved[key] = process.env[key];
     delete process.env[key];
   }
   process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
+  clearTokenIdentityCache();
 });
 
 afterEach(() => {
+  process.chdir(savedCwd);
   for (const key of ENV_KEYS) {
     if (saved[key] === undefined) delete process.env[key];
     else process.env[key] = saved[key];
   }
+  clearTokenIdentityCache();
 });
 
 function writeConfig(hosts: Record<string, unknown>, active = 'cloud'): string {
@@ -41,6 +48,65 @@ function writeConfig(hosts: Record<string, unknown>, active = 'cloud'): string {
   writeFileSync(file, JSON.stringify({ active, hosts }, null, 2));
   process.env.KORTIX_CONFIG_FILE = file;
   return dir;
+}
+
+/** A logged-out `cloud` host — exactly what a sandbox sees, since the sandbox
+ *  never runs `kortix login` and gets its credential from the environment. */
+const LOGGED_OUT_CLOUD = {
+  cloud: {
+    url: 'https://api.kortix.com',
+    token: '',
+    user_id: '',
+    user_email: '',
+    account_id: '',
+    logged_in_at: '',
+  },
+};
+
+/** Create a linked project directory and chdir into it, as every sandbox
+ *  workspace is (`.kortix/link.json` is committed by `kortix init`). */
+function enterLinkedProject(host: string, accountId: string, projectId: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kortix-cli-linked-'));
+  mkdirSync(join(dir, '.kortix'), { recursive: true });
+  writeFileSync(
+    join(dir, '.kortix', 'link.json'),
+    JSON.stringify({
+      project_id: projectId,
+      account_id: accountId,
+      host,
+      host_url: 'https://api.kortix.com',
+      linked_at: '2026-07-13T17:06:24.828Z',
+    }),
+  );
+  process.chdir(dir);
+  return dir;
+}
+
+/** Seed the token-identity cache the way a real `/accounts/me` response would
+ *  (see api/client.ts captureIdentity), without a network call. */
+function seedTokenIdentity(token: string, agent: string): void {
+  const configFile = process.env.KORTIX_CONFIG_FILE!;
+  const key = createHash('sha256').update(token).digest('hex').slice(0, 16);
+  writeFileSync(
+    join(configFile, '..', 'token-identity.json'),
+    JSON.stringify({
+      entries: {
+        [key]: {
+          identity: {
+            authType: 'pat',
+            agent,
+            projectId: 'proj_123',
+            sessionId: 'sess_123',
+            kortixCli: ['project.secret.read', 'project.secret.write'],
+            userId: 'user_123',
+            userEmail: 'agent@example.com',
+          },
+          fetchedAt: Date.now(),
+        },
+      },
+    }),
+  );
+  clearTokenIdentityCache();
 }
 
 describe('host notice', () => {
@@ -147,6 +213,69 @@ describe('host notice', () => {
       expect(notice).not.toContain('project token');
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: a sandbox workspace ALWAYS carries `.kortix/link.json`, whose
+  // named host has no stored credentials there. Reading it for the auth state
+  // reported a fully-authenticated agent CLI as "not logged in" on every
+  // command, which is what sent an agent hunting for a login problem instead of
+  // a missing grant.
+  test('linked directory does not override sandbox env auth', () => {
+    const configDir = writeConfig(LOGGED_OUT_CLOUD);
+    const projectDir = enterLinkedProject('cloud', 'acct_3b1fc472', 'proj_508bccdd');
+    try {
+      process.env.KORTIX_API_URL = 'https://api.kortix.com';
+      process.env.KORTIX_CLI_TOKEN = 'kortix_pat_session';
+      process.env.KORTIX_SESSION_ID = 'sess_ea985b87';
+
+      const notice = renderHostNotice(['sessions', 'restart', 'sess_ea985b87']);
+      expect(notice).toContain('authenticated (session token)');
+      expect(notice).not.toContain('not logged in');
+      // The link still supplies account + project; only the auth state moved.
+      expect(notice).toContain('account acct_3b1');
+      expect(notice).toContain('project proj_508');
+      expect(notice).toContain('session sess_ea9');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  test('names the agent a minted session token belongs to', () => {
+    const configDir = writeConfig(LOGGED_OUT_CLOUD);
+    const projectDir = enterLinkedProject('cloud', 'acct_3b1fc472', 'proj_508bccdd');
+    try {
+      process.env.KORTIX_API_URL = 'https://api.kortix.com';
+      process.env.KORTIX_CLI_TOKEN = 'kortix_pat_session';
+      process.env.KORTIX_SESSION_ID = 'sess_ea985b87';
+      seedTokenIdentity('kortix_pat_session', 'osp-vision-route-agent');
+
+      expect(renderHostNotice(['sessions', 'restart', 'x'])).toContain(
+        'agent osp-vision-route-agent',
+      );
+      // The bare-`kortix` hierarchy names it too, on its own row.
+      const context = renderContext();
+      expect(context).toContain('agent');
+      expect(context).toContain('osp-vision-route-agent');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  test('omits the agent row when the token identity is not cached', () => {
+    const configDir = writeConfig(LOGGED_OUT_CLOUD);
+    try {
+      process.env.KORTIX_API_URL = 'https://api.kortix.com';
+      process.env.KORTIX_CLI_TOKEN = 'kortix_pat_session';
+      process.env.KORTIX_SESSION_ID = 'sess_ea985b87';
+
+      const notice = renderHostNotice(['sessions', 'ls']);
+      expect(notice).toContain('authenticated (session token)');
+      expect(notice).not.toContain('agent ');
+    } finally {
+      rmSync(configDir, { recursive: true, force: true });
     }
   });
 });

--- a/apps/cli/src/__tests__/token-identity.test.ts
+++ b/apps/cli/src/__tests__/token-identity.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  cachedTokenIdentity,
+  clearTokenIdentityCache,
+  formatGrantList,
+  identityFromMe,
+  rememberTokenIdentity,
+  tokenKindLabel,
+} from '../api/token-identity.ts';
+import {
+  printPermissionDenialIdentity,
+  recordPermissionDenial,
+  resetPermissionDenial,
+} from '../token-denial.ts';
+import type { MeResponse } from '../api/types.ts';
+
+const ENV_KEYS = [
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_TOKEN',
+  'KORTIX_API_URL',
+  'KORTIX_PROJECT_ID',
+  'KORTIX_SESSION_ID',
+  'BASH_ENV',
+  'KORTIX_DISABLE_SANDBOX_ENV_FILE',
+  'KORTIX_CONFIG_FILE',
+  'KORTIX_AUTH_FILE',
+] as const;
+
+let saved: Record<string, string | undefined>;
+let dir: string;
+
+/** An `/accounts/me` body for a minted agent session token — the exact shape
+ *  the API returns for the Essentia `osp-vision-route-agent` case. */
+function agentMe(): MeResponse {
+  return {
+    user_id: 'user_123',
+    email: 'owner@example.com',
+    token_context: {
+      auth_type: 'pat',
+      project_id: '508bccdd-1edb-4c61-877b-164aceac20e2',
+      session_id: 'ea985b87-d12c-4ba4-aa12-ee0711dab6f6',
+      agent: 'osp-vision-route-agent',
+      connectors: [],
+      kortix_cli: ['project.secret.read', 'project.secret.write'],
+    },
+    accounts: [],
+  };
+}
+
+beforeEach(() => {
+  saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
+  dir = mkdtempSync(join(tmpdir(), 'kortix-token-identity-'));
+  process.env.KORTIX_CONFIG_FILE = join(dir, 'config.json');
+  clearTokenIdentityCache();
+  resetPermissionDenial();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+  clearTokenIdentityCache();
+  resetPermissionDenial();
+});
+
+describe('token identity cache', () => {
+  test('remembers what a token resolves to and reads it back', () => {
+    rememberTokenIdentity('kortix_pat_session', agentMe());
+    clearTokenIdentityCache(); // force a disk read, not the in-process memo
+
+    const identity = cachedTokenIdentity('kortix_pat_session');
+    expect(identity?.agent).toBe('osp-vision-route-agent');
+    expect(identity?.sessionId).toBe('ea985b87-d12c-4ba4-aa12-ee0711dab6f6');
+    expect(identity?.kortixCli).toEqual(['project.secret.read', 'project.secret.write']);
+  });
+
+  test('never writes the token itself to disk, and keeps the file 0600', () => {
+    rememberTokenIdentity('kortix_pat_supersecret', agentMe());
+    const path = join(dir, 'token-identity.json');
+    const raw = readFileSync(path, 'utf8');
+
+    expect(raw).not.toContain('kortix_pat_supersecret');
+    expect(raw).toContain('osp-vision-route-agent');
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  test('a re-minted token misses the cache instead of showing a stale agent', () => {
+    rememberTokenIdentity('kortix_pat_old', agentMe());
+    clearTokenIdentityCache();
+
+    expect(cachedTokenIdentity('kortix_pat_old')?.agent).toBe('osp-vision-route-agent');
+    expect(cachedTokenIdentity('kortix_pat_new')).toBeNull();
+  });
+
+  test('an expired entry is a miss, but the error path can still read it', () => {
+    rememberTokenIdentity('kortix_pat_session', agentMe());
+    const path = join(dir, 'token-identity.json');
+    const file = JSON.parse(readFileSync(path, 'utf8')) as {
+      entries: Record<string, { fetchedAt: number }>;
+    };
+    for (const entry of Object.values(file.entries)) {
+      entry.fetchedAt = Date.now() - 60 * 60 * 1000; // 1h — past the 15m TTL
+    }
+    writeFileSync(path, JSON.stringify(file));
+    clearTokenIdentityCache();
+
+    expect(cachedTokenIdentity('kortix_pat_session')).toBeNull();
+    expect(cachedTokenIdentity('kortix_pat_session', { allowStale: true })?.agent).toBe(
+      'osp-vision-route-agent',
+    );
+  });
+
+  test('a corrupt cache file is an empty cache, not a crash', () => {
+    writeFileSync(join(dir, 'token-identity.json'), '{ not json');
+    expect(cachedTokenIdentity('kortix_pat_session')).toBeNull();
+  });
+
+  test('labels a token by what it is', () => {
+    expect(tokenKindLabel(identityFromMe(agentMe()))).toBe(
+      'session token · agent osp-vision-route-agent',
+    );
+    expect(
+      tokenKindLabel({
+        authType: 'supabase',
+        agent: null,
+        projectId: null,
+        sessionId: null,
+        kortixCli: null,
+        userId: 'u',
+        userEmail: 'a@b.c',
+      }),
+    ).toBe('supabase');
+    expect(formatGrantList('all')).toBe('all');
+    expect(formatGrantList([])).toBe('none');
+    expect(formatGrantList(null)).toBe('ungated');
+    expect(formatGrantList(['project.secret.read'])).toBe('project.secret.read');
+  });
+});
+
+describe('permission-denial identity footer', () => {
+  function captureStderr(): { output: () => string; restore: () => void } {
+    const original = process.stderr.write.bind(process.stderr);
+    let buffer = '';
+    (process.stderr as unknown as { write: (chunk: string) => boolean }).write = (chunk) => {
+      buffer += chunk;
+      return true;
+    };
+    return {
+      output: () => buffer,
+      restore: () => {
+        (process.stderr as unknown as { write: typeof original }).write = original;
+      },
+    };
+  }
+
+  test('names the agent, its grant, and where to change it', async () => {
+    process.env.KORTIX_API_URL = 'https://api.kortix.com';
+    process.env.KORTIX_CLI_TOKEN = 'kortix_pat_session';
+    rememberTokenIdentity('kortix_pat_session', agentMe());
+    recordPermissionDenial(403);
+
+    const cap = captureStderr();
+    try {
+      await printPermissionDenialIdentity();
+    } finally {
+      cap.restore();
+    }
+    const out = cap.output();
+
+    expect(out).toContain('session token · agent osp-vision-route-agent');
+    expect(out).toContain('project.secret.read, project.secret.write');
+    expect(out).toContain('agents.osp-vision-route-agent.kortix_cli');
+  });
+
+  test('prints nothing when no call was refused', async () => {
+    process.env.KORTIX_API_URL = 'https://api.kortix.com';
+    process.env.KORTIX_CLI_TOKEN = 'kortix_pat_session';
+    rememberTokenIdentity('kortix_pat_session', agentMe());
+
+    const cap = captureStderr();
+    try {
+      await printPermissionDenialIdentity();
+    } finally {
+      cap.restore();
+    }
+    expect(cap.output()).toBe('');
+  });
+
+  test('a non-identity status is not recorded', async () => {
+    process.env.KORTIX_API_URL = 'https://api.kortix.com';
+    process.env.KORTIX_CLI_TOKEN = 'kortix_pat_session';
+    rememberTokenIdentity('kortix_pat_session', agentMe());
+    recordPermissionDenial(404);
+    recordPermissionDenial(500);
+
+    const cap = captureStderr();
+    try {
+      await printPermissionDenialIdentity();
+    } finally {
+      cap.restore();
+    }
+    expect(cap.output()).toBe('');
+  });
+
+  test('the footer is emitted once per command', async () => {
+    process.env.KORTIX_API_URL = 'https://api.kortix.com';
+    process.env.KORTIX_CLI_TOKEN = 'kortix_pat_session';
+    rememberTokenIdentity('kortix_pat_session', agentMe());
+    recordPermissionDenial(403);
+    recordPermissionDenial(403);
+
+    const first = captureStderr();
+    try {
+      await printPermissionDenialIdentity();
+    } finally {
+      first.restore();
+    }
+    const second = captureStderr();
+    try {
+      await printPermissionDenialIdentity();
+    } finally {
+      second.restore();
+    }
+
+    expect(first.output()).toContain('osp-vision-route-agent');
+    expect(second.output()).toBe('');
+  });
+});

--- a/apps/cli/src/api/client.ts
+++ b/apps/cli/src/api/client.ts
@@ -3,8 +3,7 @@ import { backendApi } from '@kortix/sdk';
 import type { Auth } from './auth.ts';
 import { secureRemoteBase } from './config.ts';
 import { withKortixScope } from './sdk.ts';
-import { rememberTokenIdentity } from './token-identity.ts';
-import type { MeResponse } from './types.ts';
+import { rememberTokenIdentity, type AccountsMeBody } from './token-identity.ts';
 
 // Re-exported for callers/tests that reach it via the client module.
 export { secureRemoteBase };
@@ -99,7 +98,7 @@ function isMeEndpoint(endpoint: string): boolean {
 function captureIdentity(endpoint: string, token: string, data: unknown): void {
   if (!isMeEndpoint(endpoint) || !token || !data || typeof data !== 'object') return;
   try {
-    rememberTokenIdentity(token, data as MeResponse);
+    rememberTokenIdentity(token, data as AccountsMeBody);
   } catch {
     /* best effort */
   }

--- a/apps/cli/src/api/client.ts
+++ b/apps/cli/src/api/client.ts
@@ -3,6 +3,8 @@ import { backendApi } from '@kortix/sdk';
 import type { Auth } from './auth.ts';
 import { secureRemoteBase } from './config.ts';
 import { withKortixScope } from './sdk.ts';
+import { rememberTokenIdentity } from './token-identity.ts';
+import type { MeResponse } from './types.ts';
 
 // Re-exported for callers/tests that reach it via the client module.
 export { secureRemoteBase };
@@ -80,6 +82,29 @@ function unwrap<T>(res: { data?: T; error?: unknown; success: boolean }): T {
   throw new ApiError(0, String(err ?? 'request failed'));
 }
 
+/** Is this the identity endpoint, with or without a query string? */
+function isMeEndpoint(endpoint: string): boolean {
+  return endpoint === '/accounts/me' || endpoint.startsWith('/accounts/me?');
+}
+
+/**
+ * Capture WHO the acting token is from any `/accounts/me` response.
+ *
+ * Every command that already fetches identity (whoami, projects, accounts,
+ * login, doctor, ship, the cross-host session scan) warms the token-identity
+ * cache here, so the host line can name the agent a sandbox token was minted
+ * for without ever adding a request of its own. Never throws: a cache write is
+ * never a reason to fail the call that produced the data.
+ */
+function captureIdentity(endpoint: string, token: string, data: unknown): void {
+  if (!isMeEndpoint(endpoint) || !token || !data || typeof data !== 'object') return;
+  try {
+    rememberTokenIdentity(token, data as MeResponse);
+  } catch {
+    /* best effort */
+  }
+}
+
 async function request<T>(
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
   path: string,
@@ -90,8 +115,11 @@ async function request<T>(
   const options = { showErrors: false as const, timeout: CLI_REQUEST_TIMEOUT_MS };
   return withKortixScope(opts.auth, async () => {
     switch (method) {
-      case 'GET':
-        return unwrap<T>(await backendApi.get<T>(endpoint, options));
+      case 'GET': {
+        const data = unwrap<T>(await backendApi.get<T>(endpoint, options));
+        captureIdentity(endpoint, opts.auth.token, data);
+        return data;
+      }
       case 'POST':
         return unwrap<T>(await backendApi.post<T>(endpoint, body, options));
       case 'PUT':

--- a/apps/cli/src/api/token-identity.ts
+++ b/apps/cli/src/api/token-identity.ts
@@ -1,0 +1,181 @@
+import { createHash } from 'node:crypto';
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import { configFilePath } from './config.ts';
+import type { MeResponse } from './types.ts';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Who is this token?
+//
+// A sandbox CLI authenticates with a MINTED AGENT TOKEN — project- and
+// session-scoped, carrying that agent's `kortix_cli` grant from kortix.yaml.
+// Nothing in the sandbox names the agent: `agent-env.sh` ships the token, the
+// API URL, and the project/session ids, never the agent it was minted for
+// (apps/kortix-sandbox-agent-server/src/agent-env-file.ts). So a 403 like
+// "You don't have permission (project.session.read)" gave the agent no way to
+// see WHICH identity was refused, and the standing host line could not say it
+// either.
+//
+// The only authority is `GET /v1/accounts/me` → `token_context`. This module
+// caches that answer so the host line stays a zero-network render (same
+// contract as update-check.ts) and so a denial can name the identity without a
+// second round trip.
+//
+// The cache stores NO token — entries are keyed by a SHA-256 prefix of it, so
+// a re-minted token misses the cache instead of showing a stale agent. That
+// matters: the platform re-resolves the grant on every prompt, and an agent
+// switch mid-session changes the answer.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** What a minted token resolves to. Mirrors `MeResponse.token_context`. */
+export interface TokenIdentity {
+  /** 'pat' | 'supabase' | … — the API's own classification. */
+  authType: string | null;
+  /** Agent the session token was minted for, or null for a user/project token. */
+  agent: string | null;
+  projectId: string | null;
+  sessionId: string | null;
+  /** The agent's `kortix_cli` grant: 'all', an explicit list, or null (ungated). */
+  kortixCli: string[] | 'all' | null;
+  userId: string;
+  userEmail: string;
+}
+
+interface CacheEntry {
+  identity: TokenIdentity;
+  fetchedAt: number;
+}
+
+interface CacheFile {
+  entries: Record<string, CacheEntry>;
+}
+
+/** A grant can change under a running session (a CR-merged kortix.yaml, an
+ *  agent switch that re-mints). Short enough that a fixed grant is re-read
+ *  within a working session; long enough that the header never costs a call. */
+const TTL_MS = 15 * 60 * 1000;
+
+/** Bound the file. Entries are ~200 bytes; the cap only matters on a dev box
+ *  that cycles through many tokens. */
+const MAX_ENTRIES = 8;
+
+/** Same directory as the config + update-check cache (~/.config/kortix), so a
+ *  test that redirects KORTIX_CONFIG_FILE redirects this too. */
+function cachePath(): string {
+  return resolve(dirname(configFilePath()), 'token-identity.json');
+}
+
+/** Key a cache entry WITHOUT storing the credential. */
+function tokenKey(token: string): string {
+  return createHash('sha256').update(token).digest('hex').slice(0, 16);
+}
+
+/** Within one process the disk cache is read once — a command that renders the
+ *  header and then 403s must not re-read the file for the same answer. */
+const memo = new Map<string, CacheEntry>();
+
+function readCacheFile(): CacheFile {
+  try {
+    const parsed = JSON.parse(readFileSync(cachePath(), 'utf8')) as Partial<CacheFile>;
+    if (parsed && typeof parsed === 'object' && parsed.entries && typeof parsed.entries === 'object') {
+      return { entries: parsed.entries };
+    }
+  } catch {
+    /* absent or corrupt — an empty cache is always a valid answer */
+  }
+  return { entries: {} };
+}
+
+function writeCacheFile(file: CacheFile): void {
+  try {
+    const path = cachePath();
+    mkdirSync(dirname(path), { recursive: true });
+    // Newest first, then truncate — an eviction must never drop the entry we
+    // just wrote.
+    const kept = Object.entries(file.entries)
+      .sort((a, b) => b[1].fetchedAt - a[1].fetchedAt)
+      .slice(0, MAX_ENTRIES);
+    writeFileSync(path, JSON.stringify({ entries: Object.fromEntries(kept) }, null, 2) + '\n', {
+      mode: 0o600,
+    });
+    try {
+      // `mode` only applies on create; a pre-existing file keeps its old mode.
+      chmodSync(path, 0o600);
+    } catch {
+      /* Windows */
+    }
+  } catch {
+    /* a read-only HOME must not break the command that triggered the write */
+  }
+}
+
+/** Translate an `/accounts/me` body into the cached shape. */
+export function identityFromMe(me: MeResponse): TokenIdentity {
+  const ctx = me.token_context;
+  return {
+    authType: ctx?.auth_type ?? null,
+    agent: ctx?.agent ?? null,
+    projectId: ctx?.project_id ?? null,
+    sessionId: ctx?.session_id ?? null,
+    kortixCli: ctx?.kortix_cli ?? null,
+    userId: me.user_id,
+    userEmail: me.email ?? '',
+  };
+}
+
+/**
+ * Record what a token resolves to. Called from the API client for EVERY
+ * `/accounts/me` response, so the many commands that already fetch it
+ * (whoami, projects, accounts, login, doctor, ship, the session scan) warm the
+ * cache without a single extra request.
+ */
+export function rememberTokenIdentity(token: string, me: MeResponse): void {
+  if (!token) return;
+  const key = tokenKey(token);
+  const entry: CacheEntry = { identity: identityFromMe(me), fetchedAt: Date.now() };
+  memo.set(key, entry);
+  const file = readCacheFile();
+  file.entries[key] = entry;
+  writeCacheFile(file);
+}
+
+/**
+ * The token's identity if we already know it — never touches the network.
+ * `allowStale` returns an expired entry, for the error path where a slightly
+ * old agent name still beats printing nothing.
+ */
+export function cachedTokenIdentity(
+  token: string,
+  opts: { allowStale?: boolean } = {},
+): TokenIdentity | null {
+  if (!token) return null;
+  const key = tokenKey(token);
+  const entry = memo.get(key) ?? readCacheFile().entries[key];
+  if (!entry || typeof entry.fetchedAt !== 'number' || !entry.identity) return null;
+  memo.set(key, entry);
+  if (!opts.allowStale && Date.now() - entry.fetchedAt > TTL_MS) return null;
+  return entry.identity;
+}
+
+/** Drop every cached entry. Test seam. */
+export function clearTokenIdentityCache(): void {
+  memo.clear();
+}
+
+/** Render a grant list for display. */
+export function formatGrantList(value: string[] | 'all' | null): string {
+  if (value === 'all') return 'all';
+  if (value == null) return 'ungated';
+  return value.length ? value.join(', ') : 'none';
+}
+
+/** One-line label for the token itself: what kind it is, and whose it is. */
+export function tokenKindLabel(identity: TokenIdentity): string {
+  const kind = identity.sessionId
+    ? 'session token'
+    : identity.projectId
+      ? 'project token'
+      : identity.authType || 'token';
+  return identity.agent ? `${kind} · agent ${identity.agent}` : kind;
+}

--- a/apps/cli/src/api/token-identity.ts
+++ b/apps/cli/src/api/token-identity.ts
@@ -3,7 +3,6 @@ import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 import { configFilePath } from './config.ts';
-import type { MeResponse } from './types.ts';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Who is this token?
@@ -27,6 +26,30 @@ import type { MeResponse } from './types.ts';
 // matters: the platform re-resolves the grant on every prompt, and an agent
 // switch mid-session changes the answer.
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The `/accounts/me` fields this module reads.
+ *
+ * Declared structurally instead of importing `MeResponse` on purpose. This
+ * file is reachable from `api/client.ts`, which puts it in the in-sandbox
+ * `kortix connectors` import closure — every file in that closure is hashed
+ * into the snapshot runtime fingerprint (see cli-connector-closure.test.ts).
+ * `api/types.ts` changes with every API type addition (23 commits in 6
+ * months), so pulling it into the fingerprint would re-mint every project's
+ * runtime identity on edits that cannot affect the connector binary.
+ * `MeResponse` satisfies this shape, so callers pass it unchanged.
+ */
+export interface AccountsMeBody {
+  user_id: string;
+  email?: string;
+  token_context?: {
+    auth_type?: string | null;
+    project_id?: string | null;
+    session_id?: string | null;
+    agent?: string | null;
+    kortix_cli?: string[] | 'all' | null;
+  };
+}
 
 /** What a minted token resolves to. Mirrors `MeResponse.token_context`. */
 export interface TokenIdentity {
@@ -111,7 +134,7 @@ function writeCacheFile(file: CacheFile): void {
 }
 
 /** Translate an `/accounts/me` body into the cached shape. */
-export function identityFromMe(me: MeResponse): TokenIdentity {
+export function identityFromMe(me: AccountsMeBody): TokenIdentity {
   const ctx = me.token_context;
   return {
     authType: ctx?.auth_type ?? null,
@@ -130,7 +153,7 @@ export function identityFromMe(me: MeResponse): TokenIdentity {
  * (whoami, projects, accounts, login, doctor, ship, the session scan) warm the
  * cache without a single extra request.
  */
-export function rememberTokenIdentity(token: string, me: MeResponse): void {
+export function rememberTokenIdentity(token: string, me: AccountsMeBody): void {
   if (!token) return;
   const key = tokenKey(token);
   const entry: CacheEntry = { identity: identityFromMe(me), fetchedAt: Date.now() };

--- a/apps/cli/src/api/token-identity.ts
+++ b/apps/cli/src/api/token-identity.ts
@@ -89,7 +89,26 @@ function cachePath(): string {
   return resolve(dirname(configFilePath()), 'token-identity.json');
 }
 
-/** Key a cache entry WITHOUT storing the credential. */
+/**
+ * Key a cache entry WITHOUT storing the credential.
+ *
+ * This is a cache partition key, NOT a password hash. CodeQL's
+ * `js/insufficient-password-hash` flags it because the input is tainted as a
+ * credential; the rule's threat model does not apply here:
+ *
+ *   - The input is a machine-generated bearer token (`kortix_pat_…`), never a
+ *     user-chosen password, so there is no dictionary to attack.
+ *   - The digest is truncated to 64 bits and used only to decide which cache
+ *     entry belongs to the acting token. It is never compared for
+ *     authentication, never transmitted, and grants nothing.
+ *   - The PLAINTEXT token already sits in `config.json` (mode 0600) in this
+ *     same directory, so anyone who can read this file already holds the token
+ *     — a slow KDF here would cost every CLI invocation and protect nothing.
+ *
+ * Keying on the token (rather than the session id) is what makes a re-minted
+ * token miss instead of showing a stale agent, which is the whole point: the
+ * platform re-resolves the grant every prompt and an agent switch re-mints.
+ */
 function tokenKey(token: string): string {
   return createHash('sha256').update(token).digest('hex').slice(0, 16);
 }

--- a/apps/cli/src/command-helpers.ts
+++ b/apps/cli/src/command-helpers.ts
@@ -5,6 +5,7 @@ import { activeHostName, hasEnvTokenHost, listHosts } from './api/config.ts';
 import { ApiError, clientFromAuth, type ApiClient } from './api/client.ts';
 import { loadLink, resolveProjectId } from './project-link.ts';
 import { ensureDefaultProjectBinding } from './project-bind.ts';
+import { recordPermissionDenial } from './token-denial.ts';
 import { C, status } from './style.ts';
 import type { MeResponse, ProjectSession, ProjectSummary } from './api/types.ts';
 
@@ -458,6 +459,10 @@ export function surfaceApiError(err: unknown): number {
     return 1;
   }
   if (err instanceof ApiError) {
+    // Both codes are identity verdicts. Note it so the CLI's tail can name the
+    // token that was refused (see token-denial.ts) — the message itself only
+    // ever names the action.
+    recordPermissionDenial(err.status);
     if (err.status === 401) {
       process.stderr.write(
         `${status.err('Token rejected. Run `kortix login` to re-authenticate.')}\n`,

--- a/apps/cli/src/host-notice.ts
+++ b/apps/cli/src/host-notice.ts
@@ -6,6 +6,7 @@ import {
   hasEnvTokenHost,
   type Host,
 } from './api/config.ts';
+import { cachedTokenIdentity } from './api/token-identity.ts';
 import { loadLink } from './project-link.ts';
 import { C, pad, visibleWidth } from './style.ts';
 
@@ -13,6 +14,8 @@ export interface HostNotice {
   name: string;
   url: string;
   authState: string;
+  /** Agent the acting token was minted for, when already known locally. */
+  agent?: string;
 }
 
 function hostAuthState(host: Host, mode: 'env' | 'stored'): string {
@@ -24,6 +27,17 @@ function hostAuthState(host: Host, mode: 'env' | 'stored'): string {
   }
   if (host.user_email || host.user_id) return `${host.user_email || host.user_id} (user)`;
   return 'authenticated';
+}
+
+/**
+ * The agent a token was minted for, from cache only — the host line is a
+ * zero-network render and stays one. The cache is filled by any `/accounts/me`
+ * the CLI already makes (see api/client.ts), and by the denial footer.
+ * Undefined simply means "not known yet", never "no agent".
+ */
+function tokenAgent(host: Host): string | undefined {
+  if (!host.token) return undefined;
+  return cachedTokenIdentity(host.token)?.agent ?? undefined;
 }
 
 export function findHostArg(argv: readonly string[]): string | undefined {
@@ -42,6 +56,7 @@ export function resolveHostNotice(hostArg?: string): HostNotice {
       name: hostArg,
       url: host?.url ?? 'unconfigured',
       authState: host ? hostAuthState(host, 'stored') : 'not logged in',
+      ...(host ? { agent: tokenAgent(host) } : {}),
     };
   }
 
@@ -50,6 +65,7 @@ export function resolveHostNotice(hostArg?: string): HostNotice {
     name,
     url: host.url,
     authState: hostAuthState(host, hasEnvTokenHost() ? 'env' : 'stored'),
+    ...(tokenAgent(host) ? { agent: tokenAgent(host) } : {}),
   };
 }
 
@@ -59,8 +75,19 @@ export function renderHostNotice(commandArgv: readonly string[]): string | null 
   const hostArg = findHostArg(commandArgv.slice(1));
   const directoryLink = loadLink();
   const linkedHost = !hostArg ? directoryLink?.host : undefined;
-  const notice = resolveHostNotice(hostArg ?? linkedHost);
+  // Host resolution mirrors resolveProjectContext: --host wins, then the
+  // platform-injected sandbox token, then the cwd link. Reading the LINK host
+  // while a KORTIX_CLI_TOKEN is present resolves a named host that carries no
+  // stored credentials inside a sandbox — which reported a fully-authenticated
+  // agent CLI as "not logged in" on every command (the exact trap called out in
+  // api/config.ts). The link still supplies the account/project below; only the
+  // auth state comes from the env host.
+  const notice = resolveHostNotice(hasEnvTokenHost() ? hostArg : (hostArg ?? linkedHost));
   let line = `${C.dim}host ${C.reset}${C.bold}${notice.name}${C.reset}${C.dim} (${notice.url}, ${notice.authState})${C.reset}`;
+  // The token's own identity: WHICH agent this session's minted token belongs
+  // to. Printed next to the host because it is a property of the credential,
+  // not of the account/project it happens to address.
+  if (notice.agent) line += `${C.dim} · agent ${C.reset}${notice.agent}`;
   // Append account + project for the active host only. With an explicit
   // `--host`, the active-config account/project may belong to a different
   // host, so we don't claim them.
@@ -133,12 +160,16 @@ export function renderContext(): string {
   // A cwd directory link (`loadLink`) can pin the host — and, with it, the
   // account — for this directory, overriding the globally-active host.
   const directoryLink = loadLink();
-  const linkedHost = directoryLink?.host ? getHost(directoryLink.host) : null;
+  // Same precedence as renderHostNotice: a platform-injected sandbox token
+  // outranks the cwd link, whose named host has no credentials in a sandbox.
+  const linkedHost =
+    !hasEnvTokenHost() && directoryLink?.host ? getHost(directoryLink.host) : null;
   const active = activeHostEntry();
   const name = linkedHost ? directoryLink!.host! : active.name;
   const host = linkedHost ?? active.host;
   const signedIn = Boolean(host.token);
   const authState = hostAuthState(host, hasEnvTokenHost() ? 'env' : 'stored');
+  const agent = tokenAgent(host);
   const labelW = 7; // "account".length / "project".length / "session".length
 
   const rows: ContextRow[] = [];
@@ -150,6 +181,17 @@ export function renderContext(): string {
     value: `${C.bold}${name}${C.reset}  ${C.faded}(${host.url}, ${authState})${C.reset}`,
     hint: signedIn ? navHint('kortix hosts use') : gapHint('kortix hosts login'),
   });
+
+  // 1b. Agent — WHO the acting token is, when it was minted for one. Rendered
+  // only for an agent token, so a human login keeps the four-level hierarchy.
+  if (signedIn && agent) {
+    rows.push({
+      glyph: ' ',
+      label: 'agent',
+      value: `${C.bold}${agent}${C.reset}  ${C.faded}(token)${C.reset}`,
+      hint: `${C.faded}grants: ${C.reset}${C.cyan}kortix whoami --token-only${C.reset}`,
+    });
+  }
 
   // You can't have an account/project/session without a signed-in host.
   if (!signedIn) return renderRows(rows, labelW);
@@ -168,7 +210,10 @@ export function renderContext(): string {
             : `${C.bold}${acct.slug}${C.reset}`,
           hint: navHint('kortix accounts use'),
         }
-      : linkedHost && directoryLink?.account_id
+      : // No globally-active account: fall back to the one the cwd link pins.
+        // This is the ONLY account a sandbox has — its env host carries none —
+        // so without it a linked session renders "account — none".
+        directoryLink?.account_id
         ? {
             glyph: ' ',
             label: 'account',

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -38,6 +38,7 @@ import { runValidate } from './commands/validate.ts';
 import { runWhoami } from './commands/whoami.ts';
 import { runDoctor } from './commands/doctor.ts';
 import { renderContext, renderHostNotice } from './host-notice.ts';
+import { printPermissionDenialIdentity } from './token-denial.ts';
 import { C, header, pad, rule, visibleWidth } from './style.ts';
 import { confirm } from './prompts.ts';
 import {
@@ -696,6 +697,12 @@ function finish(code: number): void {
 }
 
 main(process.argv.slice(2))
+  // A refused call names the action, never the identity. Answer that here —
+  // once, after the command's own output, and only when something was refused.
+  .then(async (code) => {
+    await printPermissionDenialIdentity();
+    return code;
+  })
   .then((code) => finish(code))
   .catch((err: unknown) => {
     const msg = err instanceof Error ? err.message : String(err);

--- a/apps/cli/src/token-denial.ts
+++ b/apps/cli/src/token-denial.ts
@@ -1,0 +1,99 @@
+import { loadAuth, loadAuthForHost, type Auth } from './api/auth.ts';
+import { clientFromAuth } from './api/client.ts';
+import {
+  cachedTokenIdentity,
+  formatGrantList,
+  tokenKindLabel,
+  type TokenIdentity,
+} from './api/token-identity.ts';
+import type { MeResponse } from './api/types.ts';
+import { C } from './style.ts';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// "Who was refused?"
+//
+// A permission denial names the ACTION ("project.session.read") but never the
+// IDENTITY it was evaluated against. Inside a sandbox that identity is a minted
+// agent token, and nothing local names the agent — so the only way to answer
+// "which agent am I, and what am I granted?" was to already know to run
+// `kortix whoami --token-only`.
+//
+// So after a 401/403 the CLI answers it unprompted: the token kind, the agent,
+// and that agent's `kortix_cli` grant — which is exactly the list a manifest
+// author has to change. One `/accounts/me` at most, and only on the error path.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RecordedDenial {
+  status: number;
+  hostArg?: string;
+}
+
+let denial: RecordedDenial | null = null;
+
+/**
+ * Note that a call was refused. Recorded rather than printed inline because
+ * `surfaceApiError` is synchronous and resolving the identity may need a
+ * request; the footer is emitted once, from the CLI's async tail.
+ */
+export function recordPermissionDenial(status: number, hostArg?: string): void {
+  if (status !== 401 && status !== 403) return;
+  // Keep the FIRST denial: a command that probes several projects reports the
+  // one that actually stopped it, not the last probe to fail.
+  if (denial) return;
+  denial = { status, ...(hostArg ? { hostArg } : {}) };
+}
+
+/** Test seam — clears state between cases. */
+export function resetPermissionDenial(): void {
+  denial = null;
+}
+
+async function resolveIdentity(auth: Auth): Promise<TokenIdentity | null> {
+  const cached = cachedTokenIdentity(auth.token);
+  if (cached) return cached;
+  try {
+    // The client records the identity for us (api/client.ts captureIdentity),
+    // so this both answers now and warms the host line for the next command.
+    await clientFromAuth(auth).get<MeResponse>('/accounts/me');
+  } catch {
+    // The token may be dead (401) or the network down. A stale entry still
+    // names the agent, which is the point.
+    return cachedTokenIdentity(auth.token, { allowStale: true });
+  }
+  return cachedTokenIdentity(auth.token, { allowStale: true });
+}
+
+/**
+ * Print the acting token's identity after a denial. No-op when nothing was
+ * refused, when there is no token, or when the identity cannot be resolved —
+ * a diagnostic must never turn into a second error.
+ *
+ * Writes to stderr so `--json` stdout stays machine-readable.
+ */
+export async function printPermissionDenialIdentity(): Promise<void> {
+  const pending = denial;
+  denial = null;
+  if (!pending) return;
+  const auth = pending.hostArg ? loadAuthForHost(pending.hostArg) : loadAuth();
+  if (!auth?.token) return;
+
+  let identity: TokenIdentity | null;
+  try {
+    identity = await resolveIdentity(auth);
+  } catch {
+    return;
+  }
+  if (!identity) return;
+
+  const lines = [`  ${C.dim}acting as ${C.reset}${C.bold}${tokenKindLabel(identity)}${C.reset}`];
+  if (identity.agent) {
+    lines.push(`  ${C.dim}granted   ${C.reset}${formatGrantList(identity.kortixCli)}`);
+    lines.push(
+      `  ${C.dim}fix       ${C.reset}add the action to ` +
+        `${C.cyan}agents.${identity.agent}.kortix_cli${C.reset}${C.dim} in kortix.yaml, then merge${C.reset}`,
+    );
+  } else if (identity.userEmail) {
+    lines.push(`  ${C.dim}user      ${C.reset}${identity.userEmail}`);
+  }
+  process.stderr.write(`${lines.join('\n')}\n`);
+}

--- a/packages/shared/src/sandbox-runtime-artifact.ts
+++ b/packages/shared/src/sandbox-runtime-artifact.ts
@@ -39,6 +39,13 @@ export const CLI_CONNECTOR_RUNTIME_FILES = [
   // is the guard that catches it).
   'src/api/sdk.ts',
   'src/api/sandbox-env.ts',
+  // `src/api/client.ts` records what the acting token resolves to from every
+  // `/accounts/me` response, so this file is compiled into the connector
+  // binary. It deliberately declares its own `AccountsMeBody` instead of
+  // importing `src/api/types.ts` — that file changes with every API type
+  // addition, and hashing it would re-mint every project's runtime identity on
+  // edits that cannot affect the connector.
+  'src/api/token-identity.ts',
   'src/project-link.ts',
 ] as const;
 


### PR DESCRIPTION
## Problem

An agent inside a sandbox ran `kortix sessions restart "$KORTIX_SESSION_ID"` and got:

```
host cloud (https://api.kortix.com, not logged in) · account 3b1fc472 · project 508bccdd (linked) · session ea985b87
  ✗  You don't have permission to perform this action (project.session.read).
```

Both halves are unusable:

1. **`not logged in` is false.** The CLI had just made an authenticated request — the API answered with a permission verdict, not a 401.
2. **The denial names the action, never the identity.** Nothing in a sandbox names the agent a token was minted for, so there was no way to see which agent was refused or what it is granted.

The real cause was a missing grant: that project's `osp-vision-route-agent` has `kortix_cli: [project.secret.read, project.secret.write]`, and only `essentia-agi` carries `kortix_cli: all`. Neither line said so.

## Root causes

**1. The cwd link overrode the sandbox token for the auth state.**

`renderHostNotice` and `renderContext` resolved the auth state from the host named in `.kortix/link.json`. That host carries no stored credentials inside a sandbox — the exact trap documented in `api/config.ts`:

> inside a sandbox the named host has no stored credentials, so honoring the link would strand a fully-authenticated CLI on "not logged in".

`resolveProjectContext` already guards this with `!hasEnvTokenHost()` (`command-helpers.ts:52`); the two renderers did not. Every sandbox workspace has a committed `.kortix/link.json`, so the line was wrong on **every** command. Existing tests only covered the unlinked case, which is why it survived.

**2. Nothing local names the agent.**

`agent-env.sh` ships the token, the API URL, and the project/session ids — never the agent (`apps/kortix-sandbox-agent-server/src/agent-env-file.ts:40-49`). The only authority is `GET /v1/accounts/me` → `token_context`.

## Change

- **`api/token-identity.ts`** (new) — cache of `token_context`, keyed by a SHA-256 prefix of the token. The token itself is never written to disk; the file is `0600` next to `config.json`, TTL 15 min. A re-minted token misses the cache rather than showing a stale agent, which matters because the platform re-resolves the grant every prompt.
- **`api/client.ts`** — captures the identity from every `/accounts/me` response the CLI already makes (whoami, projects, accounts, login, doctor, ship, the cross-host session scan). The host line stays a zero-network render, same contract as `update-check.ts`.
- **`host-notice.ts`** — env-token precedence fix, plus an `· agent <name>` segment on the one-liner and an `agent` row in the bare-`kortix` hierarchy. The link still supplies account and project; only the auth state moved. The hierarchy's account row now also falls back to the link's `account_id`, which is the only account a sandbox has.
- **`token-denial.ts`** (new) — a 401/403 is recorded in `surfaceApiError` and the footer is emitted once from the CLI's async tail. At most one `/accounts/me`, only on the error path, only when the cache is cold. Writes to stderr, so `--json` stdout stays machine-readable.

## Result

```
$ kortix sessions restart ea985b87-…                                   (exit 1)
host sandbox (…, authenticated (session token)) · agent osp-vision-route-agent · account 3b1fc472 · project 508bccdd (linked) · session ea985b87
  ✗  You don't have permission to perform this action (project.session.read).
  acting as session token · agent osp-vision-route-agent
  granted   project.secret.read, project.secret.write
  fix       add the action to agents.osp-vision-route-agent.kortix_cli in kortix.yaml, then merge
```

Bare `kortix`:

```
  ● host     sandbox  (…, authenticated (session token))   ▸ kortix hosts use
    agent    osp-vision-route-agent  (token)               grants: kortix whoami --token-only
    account  3b1fc472  (linked)                            ▸ kortix accounts use
    project  508bccdd  (linked)
    session  ea985b87
```

## Not in this PR

The generic 403 wording is already fixed on `main` by #6443 (`78b646e1ed`, 2026-08-13): `agent_scope_insufficient` renders *"This agent session is not granted …"*. Production runs `0.12.8 / dfa19604f1` (2026-08-11), so `git merge-base --is-ancestor 78b646e1ed dfa19604f1` exits 1 — the fix ships with the next promote. Nothing to do here.

## Verification

- `tsc --noEmit -p apps/cli` — clean, exit 0.
- `bun test` in `apps/cli` — **838 pass / 0 fail**, 79 files.
- `src/__tests__/agent-token-identity.blackbox.test.ts` spawns the **real CLI as a process** against a real Bun HTTP API, with a real `.kortix/link.json` and a real `KORTIX_CLI_TOKEN`. It asserts the absence of `not logged in`, the agent name and grant list in the denial footer, and that a second invocation adds **no** further `/accounts/me` call.
- The output blocks above are that process's actual stdout/stderr, not a mock-up.

Sandbox CLIs pull from the deployed API's `/v1/runtime-assets`, so dev verification follows the Deploy Dev run after merge.
