### PR TITLE
fix(apps): frame self-host App previews from the operator frontend origin

### DIFF
--- a/apps/api/src/apps/public-proxy.test.ts
+++ b/apps/api/src/apps/public-proxy.test.ts
@@ -20,6 +20,7 @@ const {
   verifyAppEdgeRequest,
 } = await import('./public-proxy');
 const { createAppAccessToken } = await import('./access');
+const { config } = await import('../config');
 
 describe('Apps public edge', () => {
   test('public Apps bypass browser authentication', async () => {
@@ -429,6 +430,41 @@ describe('Apps public edge', () => {
       "default-src 'self'; script-src 'self'; frame-ancestors 'self' https://kortix.com https://*.kortix.com http://localhost:* http://127.0.0.1:*",
     );
     expect(result.get('content-security-policy-report-only')).toBe("img-src 'self'");
+  });
+
+  test('allows a self-host frontend origin to frame its own App previews', () => {
+    const original = config.FRONTEND_URL;
+    try {
+      config.FRONTEND_URL = 'https://essentia.kortix.cloud';
+      const result = appPublicResponseHeaders(
+        new Headers({ 'content-security-policy': "default-src 'self'; frame-ancestors 'none'" }),
+      );
+      const csp = result.get('content-security-policy') || '';
+      // The operator's own frontend origin — and a wildcard for its domain — must
+      // appear, or the dashboard preview iframe is blocked on self-host.
+      expect(csp).toContain('https://essentia.kortix.cloud');
+      expect(csp).toContain('https://*.kortix.cloud');
+      // Managed cloud + localhost stay allowed too.
+      expect(csp).toContain('https://kortix.com');
+      expect(csp).toContain('http://localhost:*');
+      // Upstream frame-ancestors is stripped, ours wins.
+      expect(csp).not.toContain("frame-ancestors 'none'");
+    } finally {
+      config.FRONTEND_URL = original;
+    }
+  });
+
+  test('does not duplicate localhost when FRONTEND_URL is a dev origin', () => {
+    const original = config.FRONTEND_URL;
+    try {
+      config.FRONTEND_URL = 'http://localhost:3000';
+      const result = appPublicResponseHeaders(new Headers());
+      expect(result.get('content-security-policy')).toBe(
+        "frame-ancestors 'self' https://kortix.com https://*.kortix.com http://localhost:* http://127.0.0.1:*",
+      );
+    } finally {
+      config.FRONTEND_URL = original;
+    }
   });
 
   test('renders a branded, auto-refreshing browser page while an App is building', async () => {

--- a/apps/api/src/apps/public-proxy.ts
+++ b/apps/api/src/apps/public-proxy.ts
@@ -31,8 +31,43 @@ const EDGE_SIGNATURE_HEADER = 'x-kortix-app-signature';
 const EDGE_MAX_SKEW_MS = 5 * 60_000;
 const WAKE_LEASE_MS = 2 * 60_000;
 const ACTIVITY_LEASE_MS = 60_000;
-const APP_FRAME_ANCESTORS =
-  "frame-ancestors 'self' https://kortix.com https://*.kortix.com http://localhost:* http://127.0.0.1:*";
+// The `frame-ancestors` directive for App responses. It decides which origins
+// may embed an App in an iframe — the dashboard's App preview does exactly this.
+// Managed cloud embeds from kortix.com; a SELF-HOST box embeds from the
+// operator's OWN frontend origin (e.g. https://essentia.kortix.cloud), which is
+// NOT kortix.com, so the browser would block the preview. Build the allowlist
+// dynamically to ALWAYS include the configured frontend origin (config.FRONTEND_URL)
+// plus a wildcard for its domain, so the preview frames reliably on any
+// self-host domain. Falls back to the managed base list if FRONTEND_URL is
+// unset/invalid.
+function appFrameAncestors(): string {
+  const parts = new Set<string>([
+    "'self'",
+    'https://kortix.com',
+    'https://*.kortix.com',
+    'http://localhost:*',
+    'http://127.0.0.1:*',
+  ]);
+  try {
+    const u = new URL(config.FRONTEND_URL);
+    const host = u.hostname.toLowerCase();
+    const isLocal = host === 'localhost' || host === '127.0.0.1' || host === '::1';
+    // localhost/127.0.0.1 are already covered by the wildcard entries above; only
+    // a real self-host domain needs adding.
+    if ((u.protocol === 'https:' || u.protocol === 'http:') && !isLocal) {
+      parts.add(u.origin);
+      // Also allow any sibling subdomain of the operator's registrable-ish
+      // domain (drop the leftmost label): essentia.kortix.cloud -> *.kortix.cloud.
+      const labels = host.split('.');
+      if (labels.length >= 3 && !/^\d+$/.test(labels[labels.length - 1])) {
+        parts.add(`${u.protocol}//*.${labels.slice(1).join('.')}`);
+      }
+    }
+  } catch {
+    // FRONTEND_URL missing/invalid — the managed base list above still applies.
+  }
+  return 'frame-ancestors ' + [...parts].join(' ');
+}
 
 function appWakeSupersededResponse(): Response {
   return Response.json({
@@ -191,7 +226,7 @@ export function appPublicStatusResponse(
   const headers = new Headers({
     'cache-control': 'no-store',
     'content-security-policy':
-      "default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'self' https://kortix.com https://*.kortix.com http://localhost:* http://127.0.0.1:*",
+      `default-src 'none'; style-src 'unsafe-inline'; ${appFrameAncestors()}`,
     'referrer-policy': 'no-referrer',
     'x-content-type-options': 'nosniff',
   });
@@ -329,7 +364,7 @@ function appAccessResponse(
     headers: {
       'content-type': 'text/html; charset=utf-8',
       'cache-control': 'no-store',
-      'content-security-policy': `default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; ${APP_FRAME_ANCESTORS}`,
+      'content-security-policy': `default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; ${appFrameAncestors()}`,
       'referrer-policy': 'no-referrer',
       'x-content-type-options': 'nosniff',
     },
@@ -725,7 +760,7 @@ export function appPublicResponseHeaders(upstreamHeaders: Headers): Headers {
   headers.delete('x-frame-options');
 
   const enforced = withoutFrameAncestors(headers.get('content-security-policy') || '');
-  headers.set('content-security-policy', [...enforced, APP_FRAME_ANCESTORS].join('; '));
+  headers.set('content-security-policy', [...enforced, appFrameAncestors()].join('; '));
 
   const reportOnlyKey = 'content-security-policy-report-only';
   const reportOnly = headers.get(reportOnlyKey);

--- a/apps/web/src/features/session/sandbox-loading-boundary.test.ts
+++ b/apps/web/src/features/session/sandbox-loading-boundary.test.ts
@@ -61,6 +61,9 @@ describe('session navigation loading boundaries', () => {
     expect(projectAccessSource).not.toContain('queryKey: qk.project.access(projectId)');
     expect(projectHomeSource).not.toContain('queryKey: qk.project.access(projectId)');
     expect(projectHomeSource).not.toContain('listProjectAccess(projectId');
-    expect(projectHomeSource).toContain('const PROJECT_SETUP_TILES');
+    // Project home renders its own starter content (StarterSuggestions replaced
+    // the old PROJECT_SETUP_TILES in #6467), so a members query is never the
+    // thing that gates the first paint.
+    expect(projectHomeSource).toContain('StarterSuggestions');
   });
 });


### PR DESCRIPTION
## Problem

On a self-host box, App preview thumbnails render as broken gray boxes even though the App itself serves HTTP 200. The dashboard embeds each App response in an iframe. The App response `Content-Security-Policy: frame-ancestors` listed only `'self' https://kortix.com https://*.kortix.com http://localhost:* http://127.0.0.1:*`. A self-host frontend origin (e.g. `https://essentia.kortix.cloud`) is none of those, so the browser blocks the iframe and the preview never paints.

## Fix

Replace the hardcoded `APP_FRAME_ANCESTORS` constant with `appFrameAncestors()`, which always appends the operator's own frontend origin from `config.FRONTEND_URL` — plus a wildcard for its parent domain (`essentia.kortix.cloud` -> `*.kortix.cloud`) — to the managed base list. Applied at all three response sites: the "building" status page, the unavailable/error page, and the proxied App response (`appPublicResponseHeaders`).

- `localhost`/`127.0.0.1`/`::1` frontends are already covered by the existing wildcards, so dev + managed cloud output is byte-for-byte unchanged.
- Malformed/unset `FRONTEND_URL` falls back to the managed base list (never throws).
- Robust "no matter what": the frontend origin is derived from box config at request time, so it works on any self-host domain without further configuration.

## Verification

- `bun test src/apps/public-proxy.test.ts` — 25 pass, 0 fail. Two new tests: self-host origin + domain wildcard present; dev-origin output unchanged (no localhost duplication).
- `tsc --noEmit` — no new errors in `public-proxy.ts`/`config.ts` (the 8 remaining are pre-existing `starter-suggestions` `@kortix/shared` drift on `main`).

## Also in this PR: unblock a pre-existing `main` CI break

`sandbox-loading-boundary.test.ts` asserted `const PROJECT_SETUP_TILES`, which #6467 removed from `project-home.tsx` (replaced by `StarterSuggestions`). That left the **packages test lane red on `main` for every PR**. Verified: the test fails on code byte-identical to `origin/main` (local + 2 CI runs, deterministic). Updated the assertion to `StarterSuggestions` — same guarantee, current source. This is orthogonal to the CSP fix (apps/api) but required to get a green gate.
