### PR TITLE
fix(gateway): stop killing slow reasoning turns at 90,000ms

### DIFF
--- a/apps/api/src/llm-gateway/README.md
+++ b/apps/api/src/llm-gateway/README.md
@@ -161,10 +161,39 @@ OpenTelemetry spans expose `kortix.failure_count`, `kortix.failure_codes`,
 gateway trace, provider attempt, and session retry.
 
 The standalone and in-process hosts reject request bodies above 8 MiB with
-`413 request_too_large`. A new streaming response gets a 30-second first-byte
-budget. Aster/GLM gets at least 45 seconds. Large requests add 15 seconds per
-MiB, capped at 120 seconds. `GATEWAY_STREAM_PROBE_TIMEOUT_MS` replaces this
-adaptive policy with an exact positive override; `0` keeps the adaptive policy.
+`413 request_too_large`.
+
+### Streaming timeouts
+
+A new streaming response gets a 30-second first-byte **commit deadline** — one
+value for every provider, model, and request size.
+
+Exceeding it does not fail the request. The stream is committed to the relay,
+which sends response headers downstream and emits a `: keep-alive` SSE comment
+every 10 seconds while the model works. The only thing the deadline decides is
+how long the gateway holds the response back so it can still fail over to
+another candidate; a slow candidate is not a broken one. Every other
+content-free probe outcome — a structured error frame, a transport read
+failure, a stream that closes without output — still fails over.
+
+Once committed, a stream may go silent for up to 90 minutes before it is
+declared dead. That is a **gap** budget measured from the last byte and reset by
+every chunk, so it never truncates a long response: a Claude Fable 5 turn
+emitting its full 128,000-token ceiling at 50 tok/s runs 42m40s end to end and
+is never at risk from it.
+
+`GATEWAY_STREAM_PROBE_TIMEOUT_MS` overrides the commit deadline with an exact
+positive value; `0` keeps the default. `GATEWAY_UPSTREAM_TIMEOUT_MS` (default 90
+minutes) bounds time-to-headers when streaming and the whole completion when
+not.
+
+> Do not reintroduce a request-size-scaled first-byte budget. The retired
+> version was `30_000 + ceil((bytes - 64KiB) / 1MiB) * 15_000` capped at
+> `120_000`, which handed every body between 3,211,776 and 4,259,840 bytes a
+> budget of exactly 90,000 ms and killed healthy large-context reasoning turns
+> with `upstream stream probe timeout exceeded (90000ms with no bytes)`. Scaling
+> the budget moves the cliff; it cannot remove it, because the same growth in
+> context that raises the budget raises the model's prefill time by more.
 
 ## Live e2e
 

--- a/apps/api/src/llm-gateway/README.md
+++ b/apps/api/src/llm-gateway/README.md
@@ -176,6 +176,13 @@ another candidate; a slow candidate is not a broken one. Every other
 content-free probe outcome — a structured error frame, a transport read
 failure, a stream that closes without output — still fails over.
 
+The 30 seconds is bounded from above by the edge, not by taste. The live
+`kortix.com` zone reports `proxy_read_timeout = 125` seconds with
+`editable: false` (Free plan), so an origin that produces nothing for longer
+than that gets a Cloudflare 524 regardless of what the gateway does. The same
+125 seconds applies to gaps between bytes after headers are sent, which is why
+the relay's 10-second heartbeat is load-bearing rather than cosmetic.
+
 Once committed, a stream may go silent for up to 90 minutes before it is
 declared dead. That is a **gap** budget measured from the last byte and reset by
 every chunk, so it never truncates a long response: a Claude Fable 5 turn

--- a/apps/api/src/llm-gateway/hooks.otel.test.ts
+++ b/apps/api/src/llm-gateway/hooks.otel.test.ts
@@ -167,9 +167,9 @@ describe('emitGatewayGenAiSpan', () => {
             provider: 'aster',
             routeModel: 'glm-5.2',
             resolvedModel: 'glm-5.2',
-            stage: 'stream_probe',
-            code: 'stream_probe_timeout',
-            message: 'probe timed out',
+            stage: 'completion_validation',
+            code: 'empty_completion',
+            message: 'Upstream stream closed before producing usable content',
           },
         ],
       }),
@@ -178,10 +178,12 @@ describe('emitGatewayGenAiSpan', () => {
     const span = lastSpan();
     expect(attrScalar(span, 'kortix.failure_count')).toBe('2');
     expect(attrScalar(span, 'kortix.failure_codes')).toBe(
-      'context_length_exceeded,stream_probe_timeout',
+      'context_length_exceeded,empty_completion',
     );
     expect(attrScalar(span, 'kortix.context_rejected')).toBe(true);
-    expect(attrScalar(span, 'kortix.probe_timeout')).toBe(true);
+    // `kortix.probe_timeout` is gone — a probe timeout commits the stream
+    // rather than failing it, so the attribute could only ever report false.
+    expect(attrScalar(span, 'kortix.probe_timeout')).toBeUndefined();
     expect(attrScalar(span, 'kortix.fallback_recovered')).toBe(false);
 
     await emitAndFlush(

--- a/apps/api/src/llm-gateway/hooks.ts
+++ b/apps/api/src/llm-gateway/hooks.ts
@@ -361,7 +361,10 @@ export function emitGatewayGenAiSpan(trace: GatewayTrace): void {
         'kortix.failure_count': attemptFailures.length,
         'kortix.failure_codes': failureCodes.join(','),
         'kortix.context_rejected': failureCodes.includes('context_length_exceeded'),
-        'kortix.probe_timeout': failureCodes.includes('stream_probe_timeout'),
+        // `kortix.probe_timeout` removed: the gateway's first-byte deadline
+        // commits the stream instead of failing it, so `stream_probe_timeout`
+        // can no longer reach a failure chain and the attribute was pinned to
+        // false on every span.
         'kortix.fallback_recovered': trace.ok && attemptFailures.length > 0,
         ...(trace.errorCode ? { 'kortix.error_code': trace.errorCode } : {}),
       },

--- a/apps/llm-gateway/src/config.ts
+++ b/apps/llm-gateway/src/config.ts
@@ -42,14 +42,18 @@ export const config = {
   // Default: 8 MiB. This accepts the measured 2,023,225-byte Aster request and
   // rejects accidental/untrusted oversized payloads before upstream dispatch.
   maxRequestBytes: optionalInt('GATEWAY_MAX_REQUEST_BYTES', DEFAULT_MAX_REQUEST_BYTES),
-  // 0/unset uses the adaptive 30-120 second first-byte policy. A positive value
-  // is an exact operator override.
+  // 0/unset uses the default first-byte COMMIT deadline (30s). Exceeding it no
+  // longer fails a request — it hands the stream to the relay, which heartbeats
+  // downstream while the model works. A positive value is an exact operator
+  // override. See PROBE_COMMIT_DEADLINE_MS in @kortix/llm-gateway.
   streamProbeTimeoutMs: optionalInt('GATEWAY_STREAM_PROBE_TIMEOUT_MS', 0),
   retry: {
     maxAttempts: optionalInt('GATEWAY_RETRY_MAX_ATTEMPTS', 3),
     baseDelayMs: optionalInt('GATEWAY_RETRY_BASE_MS', 300),
     maxDelayMs: optionalInt('GATEWAY_RETRY_MAX_MS', 8_000),
-    timeoutMs: optionalInt('GATEWAY_UPSTREAM_TIMEOUT_MS', 120_000),
+    // 90 minutes. Bounds time-to-headers when streaming, and the full
+    // completion when not — see DEFAULTS in resilience/retry.ts.
+    timeoutMs: optionalInt('GATEWAY_UPSTREAM_TIMEOUT_MS', 90 * 60_000),
   },
   breaker: {
     failureThreshold: optionalInt('GATEWAY_BREAKER_THRESHOLD', 5),

--- a/packages/llm-gateway/src/pipeline/failure-chain.ts
+++ b/packages/llm-gateway/src/pipeline/failure-chain.ts
@@ -126,7 +126,12 @@ export function failureChainMetadata(
     codes: chain.map((failure) => String(failure.code)),
     providers: chain.map((failure) => failure.provider),
     contextRejected: chain.some((failure) => failure.code === 'context_length_exceeded'),
-    probeTimedOut: chain.some((failure) => failure.code === 'stream_probe_timeout'),
+    // NOTE: there is deliberately no `probeTimedOut` here any more. A probe
+    // timeout stopped being a failure when the deadline became a commit point
+    // (see handler.ts), so it can never appear in a failure chain — the field
+    // was permanently false and reported "no probe timeouts happened" whether
+    // or not any had. Reintroduce it only alongside a failure mode that can
+    // actually produce the code.
   };
 }
 

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -876,7 +876,15 @@ describe("gateway.chatCompletions — combined authorize hook", () => {
     });
   });
 
-  test("streaming model fallback bypasses a primary that opens but produces no bytes", async () => {
+  // Reversed deliberately. This used to assert that a primary which stays
+  // silent past the probe deadline is bypassed in favour of the fallback. That
+  // is precisely the behaviour that killed healthy large-context turns: a model
+  // still prefilling a multi-megabyte prompt is indistinguishable from a stalled
+  // one, and cancelling it silently downgraded the user to a different model —
+  // or, with no fallback configured, failed the turn outright with
+  // `upstream stream probe timeout exceeded (90000ms with no bytes)`.
+  // A slow candidate is now COMMITTED and relayed, not replaced.
+  test("streaming commits a primary that is slow to first byte instead of failing over", async () => {
     const calls: string[] = [];
     const { hooks, traces } = makeHooks({
       resolveRoute: async (_principal, input) => ({
@@ -895,10 +903,26 @@ describe("gateway.chatCompletions — combined authorize hook", () => {
     const fetchImpl: FetchImpl = async (url) => {
       calls.push(String(url));
       if (String(url).includes("primary.test")) {
-        return new Response(new ReadableStream<Uint8Array>(), {
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-        });
+        // Silent well past the 20ms probe deadline, then real output — the
+        // shape of a long prefill / thinking phase.
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              setTimeout(() => {
+                const enc = new TextEncoder();
+                controller.enqueue(
+                  enc.encode('data: {"choices":[{"delta":{"content":"primary ok"}}]}\n\n'),
+                );
+                controller.enqueue(
+                  enc.encode('data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'),
+                );
+                controller.enqueue(enc.encode("data: [DONE]\n\n"));
+                controller.close();
+              }, 120);
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
       }
       return new Response(
         'data: {"choices":[{"delta":{"content":"fallback ok"}}]}\n\n' +
@@ -917,13 +941,18 @@ describe("gateway.chatCompletions — combined authorize hook", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(await res.text()).toContain("fallback ok");
-    expect(calls).toHaveLength(2);
+    const body = await res.text();
+    // The slow primary's own output is delivered — including the chunk that
+    // arrived on the read left in flight when the deadline expired.
+    expect(body).toContain("primary ok");
+    expect(body).not.toContain("fallback ok");
+    // The fallback was never dialled at all.
+    expect(calls).toHaveLength(1);
     await flush();
     expect(traces.at(-1)?.metadata.gatewayRouting).toEqual({
       policy: "test-stalled-stream",
       models: ["primary", "fallback"],
-      selected: "fallback",
+      selected: "primary",
     });
   });
 
@@ -1793,7 +1822,11 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     });
   });
 
-  test('streaming: preserves the Codex context rejection and fallback probe timeout as one failure chain', async () => {
+  // The fallback's failure mode here used to be a probe timeout. A probe
+  // timeout is no longer a failure at all (it commits the stream), so the
+  // second link in the chain is now the nearest still-terminal outcome: a
+  // stream that closes cleanly without producing anything.
+  test('streaming: preserves the Codex context rejection and fallback empty completion as one failure chain', async () => {
     const codex: UpstreamDescriptor = {
       ...managed,
       provider: 'openai-codex',
@@ -1834,10 +1867,14 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
           { status: 400, headers: { 'content-type': 'application/json' } },
         );
       }
-      return new Response(new ReadableStream<Uint8Array>({ start() {} }), {
-        status: 200,
-        headers: { 'content-type': 'text/event-stream' },
-      });
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'text/event-stream' } },
+      );
     };
 
     const res = await createGateway(
@@ -1850,7 +1887,11 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
         '{"model":"codex/gpt-5.6-sol","stream":true,"messages":[{"role":"user","content":"large prompt"}]}',
     });
 
-    expect(res.status).toBe(502);
+    // 400, not 502: a cleanly-closed empty fallback stream contributes no error
+    // frame of its own, so the Codex context rejection remains the last frame
+    // seen and its status is the one surfaced. That is the more accurate answer
+    // for this chain — the request really was rejected for its size.
+    expect(res.status).toBe(400);
     const body = await res.json();
     // OpenCode 1.17.11 parseAPICallError() recognizes this exact nested code
     // and converts the failed turn into ContextOverflowError. The processor
@@ -1866,52 +1907,63 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     expect(body.message).toContain('HTTP 400');
     expect(body.message).toContain('context_length_exceeded');
     expect(body.message).toContain('aster');
-    expect(body.message).toContain('stream_probe_timeout');
-    expect(body.attempt_failures).toEqual([
-      {
-        attempt: 1,
-        provider: 'openai-codex',
-        route_model: 'codex/gpt-5.6-sol',
-        resolved_model: 'gpt-5.6-sol',
-        stage: 'stream_error',
-        status: 400,
-        code: 'context_length_exceeded',
-        message: 'Your input exceeds the context window of this model.',
-      },
-      {
-        attempt: 2,
+    expect(body.message).toContain('empty_completion');
+    expect(body.attempt_failures[0]).toEqual({
+      attempt: 1,
+      provider: 'openai-codex',
+      route_model: 'codex/gpt-5.6-sol',
+      resolved_model: 'gpt-5.6-sol',
+      stage: 'stream_error',
+      status: 400,
+      code: 'context_length_exceeded',
+      message: 'Your input exceeds the context window of this model.',
+    });
+    // An empty completion is same-candidate retryable (unlike the terminal
+    // rejection above), so the fallback contributes one entry per retry. What
+    // matters for this test is that every one of them is the fallback's empty
+    // completion and that none of them displaces the code in `body.code`.
+    expect(body.attempt_failures.length).toBeGreaterThan(1);
+    for (const failure of body.attempt_failures.slice(1)) {
+      expect(failure).toMatchObject({
         provider: 'aster',
         route_model: 'glm-5.2',
         resolved_model: 'glm-5.2',
-        stage: 'stream_probe',
-        code: 'stream_probe_timeout',
-        message: 'upstream stream probe timeout exceeded (10ms with no bytes)',
-      },
-    ]);
+        stage: 'completion_validation',
+        code: 'empty_completion',
+        message: 'Upstream stream closed before producing usable content',
+      });
+    }
     expect(body.error.attempt_failures).toEqual(body.attempt_failures);
 
     await flush();
     expect(traces).toHaveLength(1);
     expect(traces[0]).toMatchObject({
       ok: false,
-      status: 502,
-      attempts: 2,
+      status: 400,
       provider: 'aster',
       resolvedModel: 'glm-5.2',
-      candidatesTried: ['openai-codex', 'aster'],
-      attemptFailures: [
-        { provider: 'openai-codex', code: 'context_length_exceeded', status: 400 },
-        { provider: 'aster', code: 'stream_probe_timeout' },
-      ],
       errorCode: 'context_length_exceeded',
     });
+    // Codex first, then the fallback — repeated once per same-candidate
+    // empty-completion retry.
+    expect(traces[0].candidatesTried?.[0]).toBe('openai-codex');
+    expect(new Set(traces[0].candidatesTried)).toEqual(new Set(['openai-codex', 'aster']));
+    expect(traces[0].attemptFailures?.[0]).toMatchObject({
+      provider: 'openai-codex',
+      code: 'context_length_exceeded',
+      status: 400,
+    });
+    // The overflow code must survive every later attempt in the trace too —
+    // that is what drives opencode's automatic compaction.
     expect(traces[0].metadata).toMatchObject({
       gatewayFailure: {
-        attemptCount: 2,
         fallbackRecovered: false,
-        codes: ['context_length_exceeded', 'stream_probe_timeout'],
+        contextRejected: true,
       },
     });
+    expect((traces[0].metadata.gatewayFailure as { codes: string[] }).codes[0]).toBe(
+      'context_length_exceeded',
+    );
   });
 });
 

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -856,7 +856,30 @@ export async function handleChatCompletions(
     const probe = await probeStream(candidateUpstream.body, {
       inactivityTimeoutMs: streamProbeTimeoutMs,
     });
-    if (probe.hasContent) {
+    // A slow candidate is not a broken one. The probe holds the response back
+    // only so a DEAD candidate can be swapped out before headers are committed;
+    // once it has merely run out of patience, the correct move is to commit the
+    // stream and let relayStream heartbeat downstream while the model works —
+    // not to cancel a healthy upstream mid-prefill and fail the turn. Failing
+    // over here is what produced the deterministic
+    // `upstream stream probe timeout exceeded (90000ms with no bytes)` on large
+    // Fable contexts (see PROBE_COMMIT_DEADLINE_MS in streaming.ts).
+    //
+    // Only a TIMEOUT commits. Every other content-free probe outcome below
+    // (structured error frame, transport read failure, cleanly-closed empty
+    // stream) is a real failure and still fails over.
+    const probeTimedOut = probe.readError?.code === 'stream_probe_timeout';
+    if (probe.hasContent || probeTimedOut) {
+      if (probeTimedOut) {
+        logger.info(
+          `[llm-gateway] committing slow-but-live upstream from ${chosenDescriptor.provider} ${requestId} after ${streamProbeTimeoutMs}ms with no bytes — relaying with heartbeats instead of failing over`,
+        );
+        step('upstream_slow_commit', {
+          provider: chosenDescriptor.provider,
+          routeModel: chosenRouteModel,
+          probeTimeoutMs: streamProbeTimeoutMs,
+        });
+      }
       upstream = candidateUpstream;
       descriptor = chosenDescriptor;
       selectedRouteModel = chosenRouteModel;
@@ -1119,7 +1142,13 @@ export async function handleChatCompletions(
     throw new Error(`unreachable: streaming dispatch exited without a probe result (${requestId})`);
   }
   const readable = relayStream({
-    primed: { reader: streamProbe.reader, chunks: streamProbe.chunks },
+    primed: {
+      reader: streamProbe.reader,
+      chunks: streamProbe.chunks,
+      // Present only when the probe committed on its deadline rather than on
+      // content; adopting it keeps the first post-commit chunk from being lost.
+      ...(streamProbe.pendingRead ? { pendingRead: streamProbe.pendingRead } : {}),
+    },
     captureBodies,
     requestId,
     logger,

--- a/packages/llm-gateway/src/pipeline/streaming.test.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.test.ts
@@ -161,7 +161,7 @@ describe('probeStream', () => {
     expect(result.hasContent).toBe(false);
   });
 
-  test('times out and cancels a stream that opens but produces no bytes', async () => {
+  test('leaves a slow stream OPEN on timeout so the caller can commit it', async () => {
     const up = controllableUpstream();
     const result = await probeStream(up.stream, { inactivityTimeoutMs: 20 });
 
@@ -170,7 +170,24 @@ describe('probeStream', () => {
       message: 'upstream stream probe timeout exceeded (20ms with no bytes)',
       code: 'stream_probe_timeout',
     });
-    expect(up.cancelled).toBe(true);
+    // The whole point of the commit path: a still-prefilling upstream must not
+    // be cancelled. Cancelling here is what killed healthy large-context turns.
+    expect(up.cancelled).toBe(false);
+    expect(result.pendingRead).toBeDefined();
+  });
+
+  test('hands the in-flight read to the caller so no post-timeout chunk is lost', async () => {
+    const up = controllableUpstream();
+    const result = await probeStream(up.stream, { inactivityTimeoutMs: 20 });
+    expect(result.pendingRead).toBeDefined();
+
+    // The chunk the model finally produces resolves the read that was already
+    // in flight when the deadline expired. A caller that issued a fresh
+    // reader.read() instead would queue behind this promise and never see it.
+    up.push('data: {"choices":[{"delta":{"content":"late but real"}}]}\n\n');
+    const first = await result.pendingRead!;
+    expect(first.done).toBe(false);
+    expect(new TextDecoder().decode(first.value)).toContain('late but real');
   });
 
   test('holds and classifies the production soft rate-limit completion before relaying bytes', async () => {
@@ -243,24 +260,40 @@ describe('resolveStreamProbeTimeoutMs', () => {
     ).toBe(30_000);
   });
 
-  test('gives a two-megabyte prompt 60 seconds to produce its first byte', () => {
+  test('does not scale with request size — a 2MiB prompt gets the same deadline', () => {
     expect(
       resolveStreamProbeTimeoutMs({
         requestBytes: 2_023_225,
         provider: 'aster',
         model: 'glm-5.2',
       }),
-    ).toBe(60_000);
+    ).toBe(30_000);
   });
 
-  test('gives slow-first-byte GLM requests at least 45 seconds even when small', () => {
+  test('does not special-case a provider or model', () => {
     expect(
       resolveStreamProbeTimeoutMs({
         requestBytes: 64_000,
         provider: 'aster',
         model: 'glm-5.2',
       }),
-    ).toBe(45_000);
+    ).toBe(30_000);
+  });
+
+  // Regression lock. The retired ladder was
+  // `30_000 + ceil((bytes - 64KiB) / 1MiB) * 15_000`, capped at 120_000, so
+  // every request body between 3,211,776 and 4,259,840 bytes resolved to
+  // exactly 90_000 — the deadline that deterministically killed healthy
+  // large-context Fable turns. No request size may ever produce it again.
+  test('no request size can resolve to the 90-second cliff again', () => {
+    for (let bytes = 0; bytes <= 16 * 1024 * 1024; bytes += 64 * 1024) {
+      const resolved = resolveStreamProbeTimeoutMs({
+        requestBytes: bytes,
+        provider: 'anthropic',
+        model: 'claude-fable-5',
+      });
+      expect(resolved).toBe(30_000);
+    }
   });
 
   test('an explicit operator timeout remains an exact override', () => {
@@ -274,7 +307,7 @@ describe('resolveStreamProbeTimeoutMs', () => {
     ).toBe(12_345);
   });
 
-  test('zero keeps the adaptive policy', () => {
+  test('zero keeps the default deadline', () => {
     expect(
       resolveStreamProbeTimeoutMs({
         requestBytes: 64_000,
@@ -282,17 +315,17 @@ describe('resolveStreamProbeTimeoutMs', () => {
         model: 'glm-5.2',
         configuredTimeoutMs: 0,
       }),
-    ).toBe(45_000);
+    ).toBe(30_000);
   });
 
-  test('caps an extreme request at two minutes', () => {
+  test('an extreme request is not given a longer deadline', () => {
     expect(
       resolveStreamProbeTimeoutMs({
         requestBytes: 50 * 1024 * 1024,
         provider: 'openrouter',
         model: 'x',
       }),
-    ).toBe(120_000);
+    ).toBe(30_000);
   });
 });
 

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -212,10 +212,6 @@ export async function probeStream(
   const inactivityTimeoutMs = options.inactivityTimeoutMs ?? PROBE_COMMIT_DEADLINE_MS;
   let buffer = '';
   let bytes = 0;
-  // Exactly one read is kept in flight across loop turns. Hoisted out of the
-  // race so a timeout can hand the still-pending read to the relay instead of
-  // orphaning it — see StreamProbeResult.pendingRead.
-  let pending: PendingRead | null = null;
 
   for (;;) {
     const mayContainSoftFailure =
@@ -236,8 +232,12 @@ export async function probeStream(
     ) {
       return { hasContent: true, reader, chunks };
     }
-    const inFlight: PendingRead = pending ?? reader.read();
-    pending = inFlight;
+    // Bound to a local rather than inlined into the race: the timeout branch
+    // below returns this exact promise to the caller (`pendingRead`) so the
+    // relay can adopt the read that is still in flight. Every other branch is
+    // reached only after it has settled, so no loop turn ever carries one over
+    // — the read is always fresh here.
+    const inFlight: PendingRead = reader.read();
     let timeout: ReturnType<typeof setTimeout> | undefined;
     const outcome = await Promise.race([
       inFlight.then(
@@ -266,8 +266,6 @@ export async function probeStream(
         pendingRead: inFlight,
       };
     }
-    // The awaited read settled — the next loop turn must issue a fresh one.
-    pending = null;
     if (outcome.kind === 'error') {
       const err = outcome.error;
       const message = boundedErrorMessage(err);

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -13,7 +13,16 @@ export interface StreamRelayOptions {
   /** Fresh upstream body — mutually exclusive with `primed`. */
   upstreamBody?: ReadableStream<Uint8Array>;
   /** A reader already advanced by `probeStream`, plus the chunks it consumed (must be replayed first). */
-  primed?: { reader: ReadableStreamDefaultReader<Uint8Array>; chunks: Uint8Array[] };
+  primed?: {
+    reader: ReadableStreamDefaultReader<Uint8Array>;
+    chunks: Uint8Array[];
+    /**
+     * A read the probe left in flight (commit-on-timeout path). Adopted as the
+     * relay's first pending read — issuing a fresh one instead would queue
+     * behind it and drop the chunk it resolves with.
+     */
+    pendingRead?: ReturnType<ReadableStreamDefaultReader<Uint8Array>['read']>;
+  };
   captureBodies: boolean;
   requestId: string;
   logger: { warn: (...args: unknown[]) => void; debug?: (...args: unknown[]) => void };
@@ -67,8 +76,19 @@ const HEARTBEAT_FRAME = new TextEncoder().encode(': keep-alive\n\n');
 // Total silence budget before a stalled-but-never-closed upstream connection
 // (accepted the request, sent a 200, then never sent another byte and never
 // closed) is treated as dead rather than propped up by heartbeats forever.
-// Generous — well beyond any legitimate single-turn reasoning pause.
-const INACTIVITY_TIMEOUT_MS = 15 * 60 * 1000;
+//
+// This is a GAP budget, not a duration budget: it measures time since the last
+// byte and resets on every chunk, so it never truncates a long-but-productive
+// stream. Sizing therefore only has to clear the largest legitimate SILENCE,
+// not the largest legitimate response — a Claude Fable 5 turn emitting its full
+// 128,000-token ceiling at 50 tok/s runs 2,560s (42m40s) end to end and is
+// never at risk from a gap budget, because every token resets the clock.
+//
+// 90 minutes is deliberately far beyond any gap a working upstream produces.
+// The only thing it delays is declaring a wedged-but-open socket dead, and that
+// case is already bounded from both ends: the client can abort at any time, and
+// heartbeats keep every intermediate hop's socket alive meanwhile.
+const INACTIVITY_TIMEOUT_MS = 90 * 60 * 1000;
 // Default cap on the retained response preview when `captureBodies` is on —
 // matches the gateway's default `maxCapturedBodyBytes`.
 const DEFAULT_PREVIEW_CAP_BYTES = 256 * 1024;
@@ -83,54 +103,73 @@ class StreamInactivityTimeoutError extends Error {
 // A candidate that opens a stream, sends nothing usable, and closes cleanly (the
 // empty-completion bug) fails fast — real models produce their first token well
 // within this budget. The chunk/byte budget bounds valid but content-free
-// frames. The inactivity budget cancels a pending read before failover, so a
-// late chunk cannot reach the rejected candidate's relay.
+// frames.
 const PROBE_MAX_CHUNKS = 64;
 const PROBE_MAX_BYTES = 64 * 1024;
-const PROBE_INACTIVITY_TIMEOUT_MS = 30_000;
-const SLOW_FIRST_BYTE_FLOOR_MS = 45_000;
-const PROBE_SIZE_STEP_BYTES = 1024 * 1024;
-const PROBE_SIZE_STEP_MS = 15_000;
-const MAX_ADAPTIVE_PROBE_TIMEOUT_MS = 120_000;
+
+/**
+ * How long the probe waits for a byte before it stops holding the response back
+ * and COMMITS the candidate to the relay (see handler.ts).
+ *
+ * This is a commit deadline, NOT a failure deadline. Exceeding it no longer
+ * fails the turn: the stream is handed to relayStream, which starts heart-
+ * beating downstream immediately and waits out the real work under the (much
+ * larger) INACTIVITY_TIMEOUT_MS gap budget. The only thing this bound costs is
+ * the ability to fail over to another candidate, which is the correct trade —
+ * a slow candidate is not a broken one.
+ *
+ * WHY THIS IS NOT SIZE-SCALED ANY MORE. It used to be
+ * `30_000 + ceil((requestBytes - 64KiB) / 1MiB) * 15_000`, capped at 120_000.
+ * Any request body between 3,211,776 and 4,259,840 bytes therefore resolved to
+ * exactly 90,000 — and a Claude Fable 5 turn on a ~3.5MiB context routinely
+ * spends longer than that in prefill + thinking before its first reasoning
+ * delta, because the transport emits no bytes for the AI SDK's `start` /
+ * `start-step` parts. The result was a deterministic, repeating
+ * `upstream stream probe timeout exceeded (90000ms with no bytes)` on a
+ * perfectly healthy upstream: the bigger the context, the longer the model
+ * needs, and the ladder handed it a bigger budget while the model needed a
+ * bigger one still. Scaling the budget could only ever move the cliff; it
+ * could not remove it. Committing instead of failing removes it.
+ *
+ * It must also stay well under the downstream first-byte deadline: nothing has
+ * been written to the client yet while the probe runs, and Cloudflare gives an
+ * origin 100s to produce a response before it serves a 524.
+ */
+const PROBE_COMMIT_DEADLINE_MS = 30_000;
 
 export interface StreamProbeTimeoutInput {
   requestBytes: number;
   provider: string;
   model: string;
-  /** Exact operator override. Omit it to use the adaptive policy. */
+  /** Exact operator override. Omit it to use the default commit deadline. */
   configuredTimeoutMs?: number;
 }
 
 /**
- * Resolve the first-byte budget for a newly opened upstream stream.
+ * Resolve the first-byte commit deadline for a newly opened upstream stream.
  *
- * Large prompts need more prefill time. GLM through Aster also has a measured
- * slow-first-byte floor. The cap prevents one silent candidate from holding a
- * turn for more than two minutes before failover.
+ * One value for every provider, model, and request size. See
+ * PROBE_COMMIT_DEADLINE_MS for why this is deliberately not adaptive.
  */
 export function resolveStreamProbeTimeoutMs(input: StreamProbeTimeoutInput): number {
   if (input.configuredTimeoutMs !== undefined && input.configuredTimeoutMs > 0) {
     return input.configuredTimeoutMs;
   }
-
-  const requestBytes = Math.max(0, input.requestBytes);
-  const sizeSteps = Math.max(0, Math.ceil((requestBytes - 64 * 1024) / PROBE_SIZE_STEP_BYTES));
-  const sizeBasedTimeout = PROBE_INACTIVITY_TIMEOUT_MS + sizeSteps * PROBE_SIZE_STEP_MS;
-  const slowFirstByte =
-    input.provider.toLowerCase() === 'aster' || input.model.toLowerCase().includes('glm-5.2');
-  return Math.min(
-    MAX_ADAPTIVE_PROBE_TIMEOUT_MS,
-    Math.max(sizeBasedTimeout, slowFirstByte ? SLOW_FIRST_BYTE_FLOOR_MS : 0),
-  );
+  return PROBE_COMMIT_DEADLINE_MS;
 }
 
 export interface StreamProbeOptions {
   /**
-   * Maximum time between upstream chunks while no usable output exists.
-   * The reader is cancelled when the timeout expires.
+   * Maximum time to wait for a chunk while no usable output exists. On expiry
+   * the probe returns `stream_probe_timeout` with the reader STILL OPEN and its
+   * in-flight read handed back as `pendingRead`, so the caller can commit the
+   * stream to the relay. Every other content-free outcome cancels the reader.
    */
   inactivityTimeoutMs?: number;
 }
+
+/** Exactly what `reader.read()` returns, so no structural mismatch can creep in. */
+type PendingRead = ReturnType<ReadableStreamDefaultReader<Uint8Array>['read']>;
 
 export interface StreamProbeResult {
   hasContent: boolean;
@@ -144,6 +183,14 @@ export interface StreamProbeResult {
   readError?: SseErrorFrame | null;
   reader: ReadableStreamDefaultReader<Uint8Array>;
   chunks: Uint8Array[];
+  /**
+   * The read that was still in flight when the commit deadline expired. Set
+   * ONLY on the `stream_probe_timeout` outcome. The relay must adopt it as its
+   * first pending read rather than issuing a fresh `reader.read()`: a second
+   * read queues BEHIND this one, so the chunk this promise eventually resolves
+   * with would be delivered to an orphaned promise and silently dropped.
+   */
+  pendingRead?: PendingRead;
 }
 
 // Reads from the upstream body until real content/tool-call/reasoning output is
@@ -158,9 +205,13 @@ export async function probeStream(
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   const decoder = new TextDecoder();
-  const inactivityTimeoutMs = options.inactivityTimeoutMs ?? PROBE_INACTIVITY_TIMEOUT_MS;
+  const inactivityTimeoutMs = options.inactivityTimeoutMs ?? PROBE_COMMIT_DEADLINE_MS;
   let buffer = '';
   let bytes = 0;
+  // Exactly one read is kept in flight across loop turns. Hoisted out of the
+  // race so a timeout can hand the still-pending read to the relay instead of
+  // orphaning it — see StreamProbeResult.pendingRead.
+  let pending: PendingRead | null = null;
 
   for (;;) {
     const mayContainSoftFailure =
@@ -181,9 +232,11 @@ export async function probeStream(
     ) {
       return { hasContent: true, reader, chunks };
     }
+    const inFlight: PendingRead = pending ?? reader.read();
+    pending = inFlight;
     let timeout: ReturnType<typeof setTimeout> | undefined;
     const outcome = await Promise.race([
-      reader.read().then(
+      inFlight.then(
         (result) => ({ kind: 'read' as const, result }),
         (error: unknown) => ({ kind: 'error' as const, error }),
       ),
@@ -196,15 +249,21 @@ export async function probeStream(
     if (outcome.kind === 'timeout') {
       const message =
         `upstream stream probe timeout exceeded (${inactivityTimeoutMs}ms with no bytes)`;
-      await reader.cancel(message).catch(() => undefined);
+      // Deliberately NOT cancelled: the caller commits this stream to the relay
+      // (handler.ts), which resumes reading from `pendingRead`. Cancelling a
+      // healthy, still-prefilling upstream here is exactly the bug this path
+      // used to have.
       return {
         hasContent: sseHasContent(buffer),
         errorFrame: sseErrorFrame(buffer),
         readError: { message, code: 'stream_probe_timeout' },
         reader,
         chunks,
+        pendingRead: inFlight,
       };
     }
+    // The awaited read settled — the next loop turn must issue a fresh one.
+    pending = null;
     if (outcome.kind === 'error') {
       const err = outcome.error;
       const message = boundedErrorMessage(err);
@@ -355,7 +414,7 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
         // long token gap emits a keep-alive without ever issuing a second read,
         // and against the client-abort signal so a disconnect is noticed even
         // while a read is still pending.
-        let pending = reader.read();
+        let pending = opts.primed?.pendingRead ?? reader.read();
         while (true) {
           let timer: ReturnType<typeof setTimeout> | undefined;
           const beat = new Promise<'beat'>((resolve) => {

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -132,8 +132,12 @@ const PROBE_MAX_BYTES = 64 * 1024;
  * could not remove it. Committing instead of failing removes it.
  *
  * It must also stay well under the downstream first-byte deadline: nothing has
- * been written to the client yet while the probe runs, and Cloudflare gives an
- * origin 100s to produce a response before it serves a 524.
+ * been written to the client yet while the probe runs, and the edge will serve
+ * a 524 if the origin takes too long to respond. Measured on the live
+ * kortix.com zone (2026-08-16): `proxy_read_timeout = 125` seconds, and
+ * `editable: false` on the Free plan, so it cannot be raised. 30s leaves ~95s
+ * of headroom. Raising this budget past ~125s cannot work — the client would
+ * get a Cloudflare 524 before the gateway ever reached its own deadline.
  */
 const PROBE_COMMIT_DEADLINE_MS = 30_000;
 

--- a/packages/llm-gateway/src/resilience/retry.ts
+++ b/packages/llm-gateway/src/resilience/retry.ts
@@ -30,10 +30,20 @@ const DEFAULTS = {
   baseDelayMs: 250,
   maxDelayMs: 8_000,
   jitter: true,
-  timeoutMs: 120_000,
-  // ~2 attempts' worth — bounds total server time well under the old
-  // 3 × 120s = 6-minute worst case while leaving slow single attempts alone.
-  deadlineMs: 240_000,
+  // Per-attempt budget. On the STREAMING path this only bounds time-to-headers
+  // (the transport returns as soon as the Response exists, so the race below
+  // settles and the timer is cleared long before the body finishes). On the
+  // NON-STREAMING path it bounds the whole completion — and 120s was far too
+  // small for that: a Claude Fable 5 request emitting its 128,000-token ceiling
+  // at 50 tok/s needs 2,560s (42m40s) before the single JSON body comes back.
+  // 90 minutes clears that with room to spare and is never reached by a
+  // healthy request, because a healthy request finishes when it finishes.
+  timeoutMs: 90 * 60_000,
+  // Total wall clock across all attempts. Kept above the per-attempt budget so
+  // one full-length attempt can still be followed by a retry after a FAST
+  // failure (a 500/timeout that returns in milliseconds), which is the only
+  // case where retrying a request this long is useful.
+  deadlineMs: 120 * 60_000,
 };
 
 export function backoffDelay(

--- a/packages/llm-gateway/src/transports/ai-sdk/sse.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/sse.ts
@@ -102,6 +102,18 @@ function sse(obj: unknown): Uint8Array {
   return enc.encode(`data: ${JSON.stringify(obj)}\n\n`);
 }
 
+// SSE comment line — ignored by every SSE/OpenAI client (and by the gateway's
+// own probe, which only parses `data:` lines), so it is invisible payload.
+//
+// Emitted the moment the AI SDK reports the upstream stream has started. Before
+// this, the bridge produced its first byte only on the first `text-delta` /
+// `reasoning-delta`: `start` and `start-step` fell through the switch silently,
+// so the entire prefill window looked byte-identical to a dead upstream. On a
+// large context that window routinely outran the probe's deadline and a healthy
+// turn was cancelled. One byte at stream-open is all it takes to tell the two
+// apart.
+const STREAM_OPEN_FRAME = enc.encode(': keep-alive\n\n');
+
 interface StreamCtx {
   model: string;
   provider: string;
@@ -162,6 +174,14 @@ export function openAiSseFromFullStream(
           if (next.done) break;
           const part = next.value;
           switch (part.type) {
+            case 'start':
+            case 'start-step': {
+              // Liveness only — carries no model output, so it must not open a
+              // `data:` frame (that would make the probe treat a prefilling
+              // stream as having produced content).
+              emit(STREAM_OPEN_FRAME);
+              break;
+            }
             case 'text-delta': {
               if (!roleSent) {
                 emit(delta({ role: 'assistant', content: '' }));


### PR DESCRIPTION
## The bug

A streaming request whose body landed between **3,211,776 and 4,259,840 bytes** got a first-byte budget of exactly **90,000 ms**, then failed on a completely healthy upstream with:

```
upstream stream probe timeout exceeded (90000ms with no bytes)
```

Reported against Claude Fable 5: an analysis step pushes the context past ~3 MiB, the next turn spends longer than 90 s in prefill + thinking, and the turn then fails deterministically on every retry. Not quota, not OpenCode.

## Why exactly 90,000

`resolveStreamProbeTimeoutMs` scaled the budget by request size:

```
30_000 + ceil((requestBytes - 64KiB) / 1MiB) * 15_000     cap 120_000
```

| request body | budget |
|---|---|
| 1 MiB | 45,000 ms |
| 2 MiB | 60,000 ms |
| 3 MiB | 75,000 ms |
| **3.06 – 4.06 MiB** | **90,000 ms** |
| 4.5 MiB | 105,000 ms |

Four size steps land on 90,000 exactly.

Compounding it, `transports/ai-sdk/sse.ts` emitted bytes only for `text-delta` / `reasoning-delta` / tool parts. The AI SDK's `start` and `start-step` parts fell through the switch emitting **nothing**, so the entire prefill window was byte-identical to a dead upstream.

Scaling the budget could only move the cliff, never remove it: the context growth that raises the budget raises the model's prefill time by more.

## The fix

1. **Flat 30 s, no size scaling.** A regression test sweeps 0–16 MiB and asserts no request size can ever resolve to 90,000 again.
2. **The deadline commits instead of killing.** A slow candidate is not a broken one, so on expiry the stream is handed to `relayStream`, which sends headers downstream and emits a keep-alive every 10 s while the model works. Structured error frames, transport read failures, and cleanly-closed empty streams still fail over exactly as before.
3. **No dropped chunk.** `probeStream` no longer cancels on timeout and returns its still-in-flight read as `pendingRead`; `relayStream` adopts it rather than issuing a fresh `read()` that would queue behind it and lose that chunk.
4. **Keep-alive on stream open** for the AI SDK `start` / `start-step` parts. This also removes the Cloudflare 100 s first-byte (524) exposure that raising the budget alone would have walked straight into — the client now gets bytes at 30 s instead of nothing until first content.
5. **Limits raised.** Relay silence 15 min → **90 min**; `GATEWAY_UPSTREAM_TIMEOUT_MS` 120 s → 90 min; retry deadline 240 s → 120 min. The relay budget is a *gap* budget reset by every chunk, so it never truncates a long response — a Fable 5 turn emitting its full 128,000-token ceiling at 50 tok/s runs 42 m 40 s end to end and is unaffected. The 120 s upstream timeout, however, genuinely could not fit a full 128k-token completion on the non-streaming path.
6. **Dropped `kortix.probe_timeout`** (and the `probeTimedOut` field behind it). With the deadline no longer producing failures, both were pinned to false on every span — worse than absent, since a dashboard built on them would look healthy by construction.

## Trade-off

A provider that returns 200, then sends nothing and never closes, is no longer failed over at 30 s — it is committed and held until the client aborts or 90 min elapses. There is no local signal that distinguishes "prefilling" from "wedged", and a wrongly-killed real turn is worse than a rare wedged one. The client can always abort, and the circuit breaker still trips on real errors. The test that encoded the old failover-on-silence behaviour is deliberately reversed in this PR.

## Verification

Real pipeline, no stubs, default config, 3.44 MiB body, upstream silent for 100 s:

- `resolveStreamProbeTimeoutMs` returned **30000** (was 90000)
- status 200 committed downstream at **30,015 ms** instead of failing at 90,000 ms
- **8 keep-alive frames** spanned the silence
- full upstream content delivered at **100,021 ms**
- neither `90000ms` nor `stream_probe_timeout` appeared in the response

Suites:

- `packages/llm-gateway` — **397 pass / 0 fail**
- `apps/api src/llm-gateway/hooks.otel.test.ts` — 7 pass / 0 fail
- `apps/api src/llm-gateway` — 198 pass / 67 fail, byte-identical to the same suite on this branch with these changes stashed (pre-existing local env failures)
- `tsc --noEmit` clean for `packages/llm-gateway`, `apps/llm-gateway`, and `apps/api`
