### PR TITLE
fix(apps): don't 500 App teardown when a runtime's provider is disabled/retired

### DIFF
--- a/apps/api/src/apps/hosting.test.ts
+++ b/apps/api/src/apps/hosting.test.ts
@@ -204,6 +204,34 @@ describe('AppHostingProvider', () => {
     expect(hosting.stop('platinum', 'box-1')).rejects.toThrow('provider stop failed');
   });
 
+  test('stop is a no-op when the runtime provider can no longer be constructed', async () => {
+    // A legacy runtime on a provider this box has since disabled: resolving it
+    // throws. Teardown must not surface that as an error — the remote sandbox is
+    // unreachable and effectively gone.
+    let resolveCalls = 0;
+    const hosting = new AppHostingProvider({
+      runtimeProvider: () => {
+        resolveCalls += 1;
+        throw new Error('Platinum provider requires PLATINUM_API_KEY to be set.');
+      },
+    });
+
+    await hosting.stop('platinum', 'box-1');
+
+    expect(resolveCalls).toBe(1);
+  });
+
+  test('remove is a no-op when the runtime provider can no longer be constructed', async () => {
+    const hosting = new AppHostingProvider({
+      runtimeProvider: () => {
+        throw new Error('Daytona provider requires DAYTONA_API_KEY to be set.');
+      },
+    });
+
+    // Resolves rather than rejecting; nothing to assert beyond no throw.
+    await hosting.remove('daytona', 'box-1');
+  });
+
   test('polls authenticated appd status until the runtime is ready', async () => {
     const { hosting, ingressCalls, fetchCalls } = dependencies();
     const status = await hosting.waitUntilReady('e2b', 'box-1', 'runtime-1', 1_000);

--- a/apps/api/src/apps/hosting.ts
+++ b/apps/api/src/apps/hosting.ts
@@ -1,5 +1,6 @@
 import { createHash, createHmac } from 'node:crypto';
 import { config, type SandboxProviderName } from '../config';
+import { logger } from '../lib/logger';
 import {
   effectiveAppMachine,
   getProvider,
@@ -196,8 +197,29 @@ export class AppHostingProvider {
     throw new Error(`App provider runtime ${externalId} did not become running within ${APP_PROVIDER_WAKE_TIMEOUT_MS}ms`);
   }
 
+  /**
+   * Resolve the runtime provider for a teardown operation, tolerating a
+   * provider this deployment can no longer construct. A legacy runtime can name
+   * a provider that has since been disabled (its API key is unset) or retired;
+   * the remote sandbox is then unreachable regardless. Returning null lets stop
+   * and remove complete as a no-op success instead of throwing a 500/502 that
+   * blocks App delete, idle-reap, and deploy supersede.
+   */
+  private resolveRuntimeProvider(provider: SandboxProviderName): SandboxProvider | null {
+    try {
+      return this.dependencies.runtimeProvider(provider);
+    } catch (error) {
+      logger.warn('[apps] teardown skipped: sandbox provider is not resolvable', {
+        provider,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
   async stop(provider: SandboxProviderName, externalId: string): Promise<void> {
-    const runtimeProvider = this.dependencies.runtimeProvider(provider);
+    const runtimeProvider = this.resolveRuntimeProvider(provider);
+    if (!runtimeProvider) return;
     try {
       await runtimeProvider.stop(externalId);
     } catch (error) {
@@ -212,7 +234,9 @@ export class AppHostingProvider {
   }
 
   async remove(provider: SandboxProviderName, externalId: string): Promise<void> {
-    await this.dependencies.runtimeProvider(provider).remove(externalId);
+    const runtimeProvider = this.resolveRuntimeProvider(provider);
+    if (!runtimeProvider) return;
+    await runtimeProvider.remove(externalId);
   }
 
   async ingress(

--- a/apps/api/src/apps/routes.ts
+++ b/apps/api/src/apps/routes.ts
@@ -12,7 +12,7 @@ import { PROJECT_ACTIONS } from '../iam';
 import { auth, errors, json } from '../openapi';
 import { pauseComputeSession } from '../billing/services/compute-metering';
 import { config, type SandboxProviderName } from '../config';
-import { getProvider } from '../platform/providers';
+import { tryGetProvider } from '../platform/providers';
 import { db } from '../shared/db';
 import { inspectDatabaseError } from '../shared/database-errors';
 import {
@@ -602,7 +602,14 @@ projectsApp.openapi(
       .where(eq(appDeployments.appId, appId));
     for (const item of runtimes) {
       const runtime = item.app_runtimes;
-      await getProvider(runtime.provider as SandboxProviderName).remove(runtime.externalId).catch(() => {});
+      // Best-effort remote teardown. A legacy runtime can name a provider this
+      // box has since disabled or retired (e.g. platinum after switching to
+      // e2b-only); tryGetProvider returns null there instead of throwing, so a
+      // dead provider never blocks the delete. pauseComputeSession runs
+      // unconditionally — it stops billing and must not depend on the provider
+      // being reachable.
+      const provider = tryGetProvider(runtime.provider);
+      if (provider) await provider.remove(runtime.externalId).catch(() => {});
       await pauseComputeSession(runtime.runtimeId).catch(() => {});
     }
     await db.update(apps).set({ deletedAt: new Date(), desiredState: 'stopped', activeDeploymentId: null, updatedAt: new Date() })

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -378,3 +378,24 @@ export function getProvider(name: ProviderName): SandboxProvider {
   providers.set(name, provider);
   return provider;
 }
+
+/**
+ * Best-effort provider resolution for teardown paths. Returns null instead of
+ * throwing when the provider cannot be constructed — its API key is unset
+ * (the provider is disabled on this deployment) or the name is not a known
+ * provider (a legacy runtime deployed on a provider this box has since retired).
+ *
+ * Teardown code (App delete, stop, idle-reap, deploy supersede) must never fail
+ * because a long-gone sandbox lived on a provider we can no longer reach: the
+ * remote box is unreachable regardless, so the caller skips the remote call and
+ * still completes the local state change (soft-delete, mark stopped, pause the
+ * compute session). A live request path that genuinely needs the provider keeps
+ * calling getProvider() and still gets the hard error.
+ */
+export function tryGetProvider(name: string): SandboxProvider | null {
+  try {
+    return getProvider(name as ProviderName);
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/platform/providers/try-get-provider.test.ts
+++ b/apps/api/src/platform/providers/try-get-provider.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { tryGetProvider } from './index';
+
+describe('tryGetProvider', () => {
+  test('returns null for an unknown/retired provider name instead of throwing', () => {
+    // A legacy runtime can name a provider this build no longer knows. getProvider
+    // throws for it; tryGetProvider must swallow that so teardown can proceed.
+    expect(tryGetProvider('some-retired-provider')).toBeNull();
+  });
+
+  test('never throws, whatever the provider string', () => {
+    // Disabled providers (API key unset) throw inside getProvider; tryGetProvider
+    // converts every such failure to null.
+    for (const name of ['platinum', 'daytona', 'e2b', '', 'garbage']) {
+      expect(() => tryGetProvider(name)).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Deleting an App on a self-host box returned **HTTP 500** for every App whose deployment history includes a runtime on a sandbox provider the box has since disabled (e.g. platinum/daytona after switching to e2b-only). On the Essentia box, two legacy Apps (`essentia-dashboards`, `test-deploy-check`) failed every delete; e2b-only Apps deleted fine.

**Live stack trace from the box:**
```
Error: Platinum provider requires PLATINUM_API_KEY to be set.
    at getProvider (.../platform/providers/index.ts:362:19)
    at <anonymous> (.../apps/routes.ts:605:13)   ← the DELETE handler
```

## Root cause

Three teardown paths resolved the sandbox provider **outside** their error guard:

1. `DELETE /{projectId}/apps/{appId}` — `getProvider(runtime.provider).remove(...).catch(() => {})`. The `.catch()` only guarded the `.remove()` promise, not the synchronous `getProvider()` throw. So one legacy runtime 500'd the whole delete. It also meant `pauseComputeSession` (next line) never ran for that runtime → **billing leak**.
2. `AppHostingProvider.stop()` / `.remove()` — resolved the provider on the line **before** the `try`. This is the path used by idle-reap, deploy-supersede (`deployment-worker`), and the public-proxy idle stop, so those threw/502'd on a legacy runtime too (explains the transient 502 on stop).

## Fix

- New `tryGetProvider(name)`: returns `null` instead of throwing when the provider is disabled (API key unset) or unknown/retired. The remote box is unreachable regardless, so teardown skips the remote call and still completes local state.
- DELETE loop: `tryGetProvider` → skip remote `remove` when null; **`pauseComputeSession` always runs**.
- `hosting.stop`/`remove`: resolve via a guarded helper; no-op with a warning log when the provider is unresolvable. A live request path still calls `getProvider` and keeps the hard error.

## Verification

- `bun test` hosting + tryGetProvider suites: 14 pass, 0 fail (2 new hosting tests for the no-op path; 2 new `tryGetProvider` tests). Warn log confirms the guard fires.
- Full `apps/` + `platform/providers/` suites: **zero new failures** vs base (identical fail set — pre-existing provider-lifecycle tests that need real keys).
- `tsc --noEmit`: no new errors (8 pre-existing `starter-suggestions` only).
- Dev-box e2e (self-host): reproduced the 500 with the stack above; will confirm both legacy Apps delete 200 after the image lands.
