### PR TITLE
fix(sandbox): harden provider lifecycle renewal

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,24 @@ linked, not inlined.
 
 ## Register
 
+### Presigned uploads must suppress runtime-inferred content types (2026-08-17)
+
+**When:** sending a body to a provider-generated signed upload URL. Send the exact signed headers. Set an explicit empty `Content-Type` when the signature omits it. Do not let Bun infer a MIME type from `Bun.file()`.
+*Incident:* E2B template uploads returned GCS `403 SignatureDoesNotMatch` because Bun added `application/gzip` to a URL signed with an empty content type. Template creation succeeded, but every new immutable image remained unbuildable.
+*Enforcer:* `unit-e2b-bun-upload-patch.test.ts` requires the E2B dependency patch to use `Bun.file()` and an explicit empty `Content-Type` in both bundles. A real E2B template build verifies the signed upload.
+
+### Provider lifecycle renewal must use the provider activity primitive (2026-08-17)
+
+**When:** implementing provider-neutral lifecycle renewal. Use the provider's native activity or deadline API. Do not assume a guest command updates the provider lifecycle clock. Reject renewal unless the provider reports the sandbox as running.
+*Incident:* Daytona accepted repeated `true` guest commands while its one-minute native autostop clock continued unchanged. The sandbox stopped 21 seconds before Kortix `deadline_at` during deterministic lifecycle testing.
+*Enforcer:* `daytona.test.ts` requires `refreshActivity()`, rejects stopped sandboxes, propagates failures, and bounds a hung refresh. The live provider harness forces a one-minute native timer.
+
+### A persisted user message is not proof that its OpenCode turn is active (2026-08-17)
+
+**When:** changing exact-turn lifecycle probes. Treat a user-only or incomplete assistant message as active only when `/session/status` reports that exact session as `busy` or `retry`. Treat an idle session as terminal. Treat an unreadable or unknown status as unknown and non-renewing.
+*Incident:* a native OpenCode prompt persisted its user message but created no assistant message; the exact-message probe returned active for 198 seconds and would have renewed an idle Platinum sandbox indefinitely.
+*Enforcer:* `orphaned-turn-finalize.test.ts` covers busy, retry, idle, and unreadable session status.
+
 ### A sandbox lifecycle grant requires exact active-turn evidence (2026-08-17)
 
 **When:** changing session prompt delivery, sandbox reaping, or any sandbox provider lifecycle adapter. Persist token-bound `delivering` authority before upstream delivery. Promote only after OpenCode exposes the exact user `messageID`. Renew both `deadline_at` and the provider-native timer only from a fresh exact-turn probe. Treat unknown evidence as non-renewing. Linearize idle stop against prompt delivery with one database claim, and never let renewal wake a stopped sandbox.

--- a/apps/api/src/__tests__/unit-e2b-bun-upload-patch.test.ts
+++ b/apps/api/src/__tests__/unit-e2b-bun-upload-patch.test.ts
@@ -9,7 +9,7 @@ function readRepoFile(path: string): string {
 }
 
 describe('E2B template uploads on Bun', () => {
-  test('uses Bun.file for the presigned S3 request body', () => {
+  test('uses Bun.file without a runtime-inferred content type', () => {
     const packageJson = JSON.parse(readRepoFile('package.json')) as {
       pnpm?: { patchedDependencies?: Record<string, string> };
     };
@@ -22,6 +22,7 @@ describe('E2B template uploads on Bun', () => {
 
     const patch = readRepoFile(patchPath as string);
     expect(patch.match(/globalThis\.Bun \? globalThis\.Bun\.file\(filePath\)/g)).toHaveLength(2);
+    expect(patch.match(/"Content-Type": ""/g)).toHaveLength(2);
     expect(patch).toContain('Readable.toWeb');
   });
 });

--- a/apps/api/src/platform/providers/daytona.test.ts
+++ b/apps/api/src/platform/providers/daytona.test.ts
@@ -23,7 +23,7 @@ mock.module('../../config', () => ({
 mock.module('../../shared/db', () => ({ db: {} }));
 
 let getDaytonaSandbox: (_externalId: string) => Promise<unknown>;
-let lifecycleCommands: Array<{ command: string; timeout: number | undefined }>;
+let activityRefreshes: string[];
 
 mock.module('../../shared/daytona', () => ({
   getDaytona: () => ({
@@ -54,45 +54,31 @@ beforeEach(() => {
   // Below the code's own 1000ms floor (Math.max(1000, …)) would just get
   // clamped up — use a value comfortably above it.
   process.env.KORTIX_DAYTONA_CALL_TIMEOUT_MS = '1200';
-  lifecycleCommands = [];
+  activityRefreshes = [];
   getDaytonaSandbox = () => new Promise<never>(() => {});
 });
 
-test('renewLifecycle performs one bounded no-op inside the running sandbox', async () => {
+test('renewLifecycle refreshes provider activity for a running sandbox', async () => {
   getDaytonaSandbox = async () => ({
+    id: 'sbx_active',
     state: 'started',
-    process: {
-      executeCommand: async (
-        command: string,
-        _cwd?: string,
-        _env?: Record<string, string>,
-        timeout?: number,
-      ) => {
-        lifecycleCommands.push({ command, timeout });
-        return { exitCode: 0, result: '' };
-      },
+    refreshActivity: async () => {
+      activityRefreshes.push('sbx_active');
     },
   });
   const { DaytonaProvider } = await import('./daytona');
 
   await new DaytonaProvider().renewLifecycle('sbx_active');
 
-  expect(lifecycleCommands).toEqual([{ command: 'true', timeout: 10 }]);
+  expect(activityRefreshes).toEqual(['sbx_active']);
 });
 
-test('renewLifecycle never executes inside a stopped sandbox', async () => {
+test('renewLifecycle never refreshes a stopped sandbox', async () => {
   getDaytonaSandbox = async () => ({
+    id: 'sbx_stopped',
     state: 'stopped',
-    process: {
-      executeCommand: async (
-        command: string,
-        _cwd?: string,
-        _env?: Record<string, string>,
-        timeout?: number,
-      ) => {
-        lifecycleCommands.push({ command, timeout });
-        return { exitCode: 0, result: '' };
-      },
+    refreshActivity: async () => {
+      activityRefreshes.push('sbx_stopped');
     },
   });
   const { DaytonaProvider } = await import('./daytona');
@@ -100,21 +86,37 @@ test('renewLifecycle never executes inside a stopped sandbox', async () => {
   await expect(new DaytonaProvider().renewLifecycle('sbx_stopped')).rejects.toThrow(
     'non-running sandbox',
   );
-  expect(lifecycleCommands).toEqual([]);
+  expect(activityRefreshes).toEqual([]);
 });
 
-test('renewLifecycle rejects a failed no-op instead of reporting renewal', async () => {
+test('renewLifecycle rejects a failed activity refresh instead of reporting renewal', async () => {
   getDaytonaSandbox = async () => ({
+    id: 'sbx_failed',
     state: 'started',
-    process: {
-      executeCommand: async () => ({ exitCode: 17, result: 'guest unavailable' }),
+    refreshActivity: async () => {
+      throw new Error('activity refresh unavailable');
     },
   });
   const { DaytonaProvider } = await import('./daytona');
 
   await expect(new DaytonaProvider().renewLifecycle('sbx_failed')).rejects.toThrow(
-    'exit 17: guest unavailable',
+    'activity refresh unavailable',
   );
+});
+
+test('renewLifecycle bounds a hung activity refresh', async () => {
+  getDaytonaSandbox = async () => ({
+    id: 'sbx_hung',
+    state: 'started',
+    refreshActivity: () => new Promise<never>(() => {}),
+  });
+  const { DaytonaProvider } = await import('./daytona');
+
+  const startedAt = Date.now();
+  await expect(new DaytonaProvider().renewLifecycle('sbx_hung')).rejects.toThrow(
+    'Daytona lifecycle renewal(sbx_hung) timed out after 1200ms',
+  );
+  expect(Date.now() - startedAt).toBeLessThan(5_000);
 });
 
 test('getStatus() gives up on a hung Daytona call instead of hanging forever', async () => {

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -341,16 +341,14 @@ export class DaytonaProvider implements SandboxProvider {
     if (classifyDaytonaState(sandbox.state) !== 'running') {
       throw new Error(`Daytona lifecycle renewal refused for non-running sandbox ${externalId}`);
     }
-    const result = await withTimeout(
-      sandbox.process.executeCommand('true', undefined, undefined, 10),
+    // Guest commands do not reset Daytona's lifecycle clock. Use the provider's
+    // dedicated activity endpoint. The state gate above prevents this call from
+    // granting activity to a stopped sandbox.
+    await withTimeout(
+      sandbox.refreshActivity(),
       PROVIDER_CALL_TIMEOUT_MS,
       `Daytona lifecycle renewal(${externalId})`,
     );
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Daytona lifecycle renewal failed for ${externalId}: exit ${result.exitCode}: ${result.result.slice(0, 500)}`,
-      );
-    }
   }
 
   async stop(externalId: string): Promise<void> {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/initial-turn-lifecycle.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/initial-turn-lifecycle.test.ts
@@ -157,6 +157,9 @@ describe('daemon-delivered initial turn lifecycle', () => {
       port: 0,
       async fetch(request) {
         if (request.method === 'GET') {
+          if (new URL(request.url).pathname === '/session/status') {
+            return Response.json({ ses_root: { type: 'busy' } });
+          }
           return Response.json([{ info: { id: 'msg_initial', role: 'user' } }]);
         }
         acceptanceRelays += 1;

--- a/apps/kortix-sandbox-agent-server/src/__tests__/orphaned-turn-finalize.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/orphaned-turn-finalize.test.ts
@@ -28,7 +28,15 @@ const SESSION = 'ses_abc';
 const ORIGINAL_FETCH = globalThis.fetch;
 let calls: string[] = [];
 
-function stubFetch(messages: unknown, opts: { messagesOk?: boolean; abortThrows?: boolean } = {}) {
+function stubFetch(
+  messages: unknown,
+  opts: {
+    messagesOk?: boolean;
+    abortThrows?: boolean;
+    sessionStatus?: unknown;
+    sessionStatusOk?: boolean;
+  } = {},
+) {
   calls = []
   ;(globalThis as { fetch: unknown }).fetch = async (input: unknown, init?: { method?: string }) => {
     const url = String(input);
@@ -36,6 +44,10 @@ function stubFetch(messages: unknown, opts: { messagesOk?: boolean; abortThrows?
     if (url.includes('/abort')) {
       if (opts.abortThrows) throw new Error('connection refused');
       return new Response('{}', { status: 200 });
+    }
+    if (url.includes('/session/status')) {
+      if (opts.sessionStatusOk === false) return new Response('nope', { status: 503 });
+      return new Response(JSON.stringify(opts.sessionStatus ?? {}), { status: 200 });
     }
     if (opts.messagesOk === false) return new Response('nope', { status: 503 });
     return new Response(JSON.stringify(messages), { status: 200 });
@@ -159,16 +171,61 @@ describe('opencodeTurnInFlight — the reload gate reads this', () => {
 });
 
 describe('opencodeDeliveryInFlight — lifecycle acceptance recovery', () => {
-  test('a delivered user message without an assistant is active, not terminal', async () => {
-    stubFetch([{ info: { id: 'msg_turn_1', role: 'user' } }]);
+  test('a delivered user message without an assistant is active only while OpenCode reports busy', async () => {
+    stubFetch([{ info: { id: 'msg_turn_1', role: 'user' } }], {
+      sessionStatus: { [SESSION]: { type: 'busy' } },
+    });
     expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(true);
+  });
+
+  test('a user-only message in an idle OpenCode session is terminal', async () => {
+    stubFetch([{ info: { id: 'msg_turn_1', role: 'user' } }], {
+      sessionStatus: { [SESSION]: { type: 'idle' } },
+    });
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(false);
+  });
+
+  test('an absent OpenCode session status is terminal', async () => {
+    stubFetch([{ info: { id: 'msg_turn_1', role: 'user' } }], { sessionStatus: {} });
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(false);
+  });
+
+  test('a retrying OpenCode session keeps a user-only message active', async () => {
+    stubFetch([{ info: { id: 'msg_turn_1', role: 'user' } }], {
+      sessionStatus: { [SESSION]: { type: 'retry' } },
+    });
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(true);
+  });
+
+  test('an unreadable OpenCode session status makes user-only evidence unknown', async () => {
+    stubFetch([{ info: { id: 'msg_turn_1', role: 'user' } }], { sessionStatusOk: false });
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBeNull();
+  });
+
+  test('an unrecognized OpenCode session status makes user-only evidence unknown', async () => {
+    stubFetch([{ info: { id: 'msg_turn_1', role: 'user' } }], {
+      sessionStatus: { [SESSION]: { type: 'paused' } },
+    });
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBeNull();
+  });
+
+  test('a later user message makes the exact older turn terminal even while the session is busy', async () => {
+    stubFetch(
+      [
+        { info: { id: 'msg_turn_1', role: 'user' } },
+        { info: { id: 'msg_turn_2', role: 'user' } },
+      ],
+      { sessionStatus: { [SESSION]: { type: 'busy' } } },
+    );
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(false);
+    expect(calls.some((url) => url.includes('/session/status'))).toBe(false);
   });
 
   test('an incomplete assistant for the exact user message remains active', async () => {
     stubFetch([
       { info: { id: 'msg_turn_1', role: 'user' } },
       { info: { role: 'assistant', parentID: 'msg_turn_1', time: {} } },
-    ]);
+    ], { sessionStatus: { [SESSION]: { type: 'busy' } } });
     expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(true);
   });
 
@@ -199,7 +256,7 @@ describe('opencodeDeliveryInFlight — lifecycle acceptance recovery', () => {
           error: { name: 'APIError', data: { isRetryable: true } },
         },
       },
-    ]);
+    ], { sessionStatus: { [SESSION]: { type: 'retry' } } });
     expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(true);
     expect(await opencodeTurnInFlight(BASE, WORKSPACE, SESSION)).toBe(true);
   });

--- a/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
@@ -131,13 +131,39 @@ export async function opencodeTurnInFlight(
   }
 }
 
+async function opencodeSessionInFlight(
+  baseUrl: string,
+  workspace: string,
+  sessionId: string,
+): Promise<boolean | null> {
+  try {
+    const response = await fetch(
+      `${baseUrl}/session/status?directory=${encodeURIComponent(workspace)}`,
+      { signal: AbortSignal.timeout(5_000) },
+    )
+    if (!response.ok) return null
+    const statuses = (await response.json()) as unknown
+    if (!statuses || typeof statuses !== 'object' || Array.isArray(statuses)) return null
+    const status = (statuses as Record<string, unknown>)[sessionId]
+    if (status === undefined) return false
+    if (!status || typeof status !== 'object' || Array.isArray(status)) return null
+    const type = (status as { type?: unknown }).type
+    if (type === 'busy' || type === 'retry') return true
+    if (type === 'idle') return false
+    return null
+  } catch {
+    return null
+  }
+}
+
 /**
  * Observe one client-minted OpenCode user message for lifecycle recovery.
  *
- * A matching user message with no assistant reply is queued and therefore
- * active. A matching assistant reply is terminal only when it has a completed
- * timestamp. A successful list that lacks the exact message is terminal: the
- * reaper calls this only after the full delivery grace has elapsed.
+ * A matching user message is active only when it is the newest user message and
+ * OpenCode reports the exact root session as busy or retrying. Message
+ * persistence alone is not execution evidence. A successful list that lacks
+ * the exact message is terminal: the reaper calls this only after the full
+ * delivery grace has elapsed.
  */
 export async function opencodeDeliveryInFlight(
   baseUrl: string,
@@ -165,15 +191,21 @@ export async function opencodeDeliveryInFlight(
       (message) => message.info?.role === 'user' && message.info.id === messageId,
     )
     if (userIndex < 0) return false
+    if (messages.slice(userIndex + 1).some((message) => message.info?.role === 'user')) {
+      return false
+    }
     const assistants = messages
       .slice(userIndex + 1)
       .filter(
         (message) => message.info?.role === 'assistant' && message.info.parentID === messageId,
       )
-    if (assistants.length === 0) return true
+    if (assistants.length === 0) {
+      return opencodeSessionInFlight(baseUrl, workspace, rootSessionId)
+    }
     const latest = assistants[assistants.length - 1]?.info
     if (latest?.error && latest.error.data?.isRetryable !== true) return false
-    return latest?.time?.completed == null
+    if (latest?.time?.completed != null) return false
+    return opencodeSessionInFlight(baseUrl, workspace, rootSessionId)
   } catch {
     return null
   }

--- a/patches/e2b@2.37.0.patch
+++ b/patches/e2b@2.37.0.patch
@@ -8,7 +8,8 @@ index 32f120cb13590a20c411262974dd656857eff8bc..1053e6e7b4b21e0855581c28f53595cc
  		method: "PUT",
 -		body: node_stream.default.Readable.toWeb(node_fs.default.createReadStream(filePath)),
 +		body: globalThis.Bun ? globalThis.Bun.file(filePath) : node_stream.default.Readable.toWeb(node_fs.default.createReadStream(filePath)),
- 		headers: { "Content-Length": size.toString() },
+-		headers: { "Content-Length": size.toString() },
++		headers: { "Content-Length": size.toString(), "Content-Type": "" },
  		duplex: "half",
  		signal
 diff --git a/dist/index.mjs b/dist/index.mjs
@@ -21,6 +22,7 @@ index 89ad39bc2bc81d1a104457a6edc5230bc10ccd3e..c8d698b8c201d9144cac1dbd1f9df0d0
  		method: "PUT",
 -		body: stream.Readable.toWeb(fs.createReadStream(filePath)),
 +		body: globalThis.Bun ? globalThis.Bun.file(filePath) : stream.Readable.toWeb(fs.createReadStream(filePath)),
- 		headers: { "Content-Length": size.toString() },
+-		headers: { "Content-Length": size.toString() },
++		headers: { "Content-Length": size.toString(), "Content-Type": "" },
  		duplex: "half",
  		signal

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ overrides:
 
 patchedDependencies:
   e2b@2.37.0:
-    hash: zu6vef42e2qi55rbxctjdoogau
+    hash: yvfhnsbredtxqzv5fhmwxaetam
     path: patches/e2b@2.37.0.patch
 
 importers:
@@ -208,7 +208,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(@types/pg@8.20.4)(bun-types@1.3.14)(pg@8.22.0)(postgres@3.4.9)
       e2b:
         specifier: 2.37.0
-        version: 2.37.0(patch_hash=zu6vef42e2qi55rbxctjdoogau)
+        version: 2.37.0(patch_hash=yvfhnsbredtxqzv5fhmwxaetam)
       hono:
         specifier: 4.12.34
         version: 4.12.34
@@ -17602,7 +17602,7 @@ packages:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  /e2b@2.37.0(patch_hash=zu6vef42e2qi55rbxctjdoogau):
+  /e2b@2.37.0(patch_hash=yvfhnsbredtxqzv5fhmwxaetam):
     resolution: {integrity: sha512-OWmTHwgQlPmTyCMUrcFReq9zhqsuwJn14p2AcCgYIcJifFnl1sJOrm/vZBCXe82SU7ZCgbzB3sIj7iFsZwewXw==}
     engines: {node: '>=20.18.1 <21 || >=22'}
     dependencies:


### PR DESCRIPTION
## Problem

Live provider tests found two defects after #6480:

- OpenCode can persist a user message without starting an assistant turn. Message persistence alone kept the sandbox alive forever.
- Daytona guest commands do not refresh the native lifecycle clock. Daytona stopped an active sandbox before the Kortix deadline.

A fresh E2B image build also exposed a signed-upload incompatibility. Bun inferred application/gzip for an upload URL signed with an empty content type.

## Change

- Require OpenCode session status busy or retry for exact active-turn evidence.
- Treat idle or missing session status as terminal.
- Treat unreadable or unknown status as unknown and non-renewing.
- Use Daytona refreshActivity for native lifecycle renewal.
- Reject Daytona renewal unless the sandbox is running.
- Suppress Bun content-type inference for E2B signed uploads.
- Add incident learnings and regression coverage.

## Verification

- Sandbox daemon: 611 pass, 0 fail.
- Sandbox daemon typecheck and Linux binary build: pass.
- Daytona provider: 7 pass, 0 fail.
- E2B provider: 26 pass, 0 fail.
- Platinum provider: 2 pass, 0 fail.
- Reaper and lifecycle units: 115 pass, 0 fail.
- PostgreSQL lifecycle integration: 17 pass, 0 fail.
- E2B upload patch guard: 1 pass, 0 fail.
- Platinum live provider lifecycle harness: ALL_PASS.
- Daytona live provider lifecycle harness: ALL_PASS.
- E2B live provider lifecycle harness: ALL_PASS.

Each live harness forced a one-minute provider timeout. Each active turn survived more than three timeout periods. Each provider stopped only after the idle deadline. Passive polling did not extend the deadline. Renewal did not wake a stopped sandbox.