### PR TITLE
fix(sandbox): revoke turn authority on stop

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,12 @@ linked, not inlined.
 
 ## Register
 
+### Every sandbox stop must revoke all persisted turn authority (2026-08-17)
+
+**When:** changing provider webhooks, idle reaping, manual stop, or the shared stopped-state writer. Remove `activeTurn`, `activeTurns`, and `lifecycleStopClaim` in the same transaction that sets `status='stopped'`. Do not rely on the reaper to clear tokens first; a provider-native timer or webhook can win that race.
+*Incident:* the one-minute Dev Platinum proof stopped after `deadline_at`, but the provider webhook committed `status='stopped'` with a synthetic unknown `activeTurns` token still present.
+*Enforcer:* `sandbox-state-sync.test.ts` requires `applyStoppedState()` to remove every turn-authority key atomically for all stop paths. The live provider harness verifies the stopped row has zero active turns.
+
 ### Presigned uploads must suppress runtime-inferred content types (2026-08-17)
 
 **When:** sending a body to a provider-generated signed upload URL. Send the exact signed headers. Set an explicit empty `Content-Type` when the signature omits it. Do not let Bun infer a MIME type from `Bun.file()`.

--- a/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
+++ b/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
@@ -23,7 +23,7 @@ type UpdateCall = {
 let events: string[] = [];
 let updateCalls: UpdateCall[] = [];
 let cacheInvalidations: string[] = [];
-let selectedRows: any[] = [];
+let selectedRows: Array<Record<string, unknown>> = [];
 let revokedTokens: Array<{ sessionId: string; accountId: string }> = [];
 let preserveCalls: Array<{ sandboxId: string; reason: string; stopReason: string }> = [];
 let inTransaction = false;
@@ -105,18 +105,21 @@ const {
 /** Flatten a drizzle SQL expression (including its bound params) to text, so a
  *  test can assert what the write actually asks Postgres to do. */
 function describeSql(expression: unknown): string {
-  const chunks: unknown[] = (expression as any)?.queryChunks ?? [];
+  const chunks = (expression as { queryChunks?: unknown[] } | null)?.queryChunks ?? [];
   return chunks
-    .map((chunk: any) => {
+    .map((chunk) => {
       if (typeof chunk === 'string') return chunk;
-      if (Array.isArray(chunk?.value)) return chunk.value.join('');
-      if (typeof chunk?.value === 'string') return chunk.value;
-      return chunk?.name ?? '';
+      if (!chunk || typeof chunk !== 'object') return '';
+      const value = (chunk as { value?: unknown }).value;
+      if (Array.isArray(value)) return value.join('');
+      if (typeof value === 'string') return value;
+      return (chunk as { name?: string }).name ?? '';
     })
     .join(' ');
 }
 
-const isSqlExpression = (value: unknown): boolean => Array.isArray((value as any)?.queryChunks);
+const isSqlExpression = (value: unknown): boolean =>
+  Array.isArray((value as { queryChunks?: unknown[] } | null)?.queryChunks);
 const sandboxUpdate = () => updateCalls.find((c) => c.table === sessionSandboxes);
 const sessionUpdate = () => updateCalls.find((c) => c.table === projectSessions);
 
@@ -198,6 +201,15 @@ describe('applyStoppedState', () => {
     // stop wins the start/stop race in both orderings.
     expect(rendered).toContain('runtimeWakeId');
     expect(rendered).toContain('runtimeWakeStartedAt');
+  });
+
+  test('atomically removes all turn authority when any stop path parks the sandbox', async () => {
+    await applyStoppedState(write);
+
+    const rendered = describeSql(sandboxUpdate()?.updates.metadata);
+    expect(rendered).toContain("- 'activeTurn'");
+    expect(rendered).toContain("- 'activeTurns'");
+    expect(rendered).toContain("- 'lifecycleStopClaim'");
   });
 
   // The lost update: a whole-object write assembled from a stale SELECT drops
@@ -335,11 +347,11 @@ describe('applyStoppedState — stopReason', () => {
     expect(update).toBeDefined();
     // The write must be a jsonb MERGE, never a whole-object assign — a concurrent
     // writer's runtimeWakeId / lastAliveAt live in the same column.
-    expect(update!.updates.metadata).toBeDefined();
+    expect(update?.updates.metadata).toBeDefined();
     // `updates.metadata` is a drizzle SQL AST (circular via its column/table
     // refs) — describeSql renders it to text the same way every other test in
     // this file asserts against it; a raw JSON.stringify throws on the cycle.
-    expect(describeSql(update!.updates.metadata)).toContain('deadline_expired');
+    expect(describeSql(update?.updates.metadata)).toContain('deadline_expired');
   });
 
   // The top-level field is the one source of truth for WHY a box parked. A

--- a/apps/api/src/projects/reaping/sandbox-state-sync.ts
+++ b/apps/api/src/projects/reaping/sandbox-state-sync.ts
@@ -66,7 +66,11 @@ export async function applyStoppedState(write: StoppedStateWrite): Promise<void>
       err instanceof Error ? err.message : err,
     ),
   );
-  const patch = { ...(write.metadata ?? {}), stopReason: write.stopReason, stoppedAt: now.toISOString() };
+  const patch = {
+    ...(write.metadata ?? {}),
+    stopReason: write.stopReason,
+    stoppedAt: now.toISOString(),
+  };
   await db.transaction(async (tx) => {
     await tx
       .update(sessionSandboxes)
@@ -79,9 +83,12 @@ export async function applyStoppedState(write: StoppedStateWrite): Promise<void>
         // user stop win both orderings of the start/stop race.
         //
         // `patch` always carries stopReason + stoppedAt, so this is never an
-        // empty merge: the wake keys are dropped AND the reason is recorded in
-        // one statement. Still a MERGE, never a whole-object assign — a
-        // concurrent writer's lastAliveAt lives in this column too.
+        // empty merge. The same statement drops wake fences and every turn
+        // authority record. A provider webhook can win the idle-stop race
+        // before the reaper clears an unknown turn. A stopped sandbox cannot
+        // retain authority that a later resume could misread. Still a MERGE,
+        // never a whole-object assign — a concurrent writer's lastAliveAt lives
+        // in this column too.
         metadata: sql`(coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
           - 'runtimeWakeStartedAt'
           - 'runtimeWakeId'
@@ -89,6 +96,8 @@ export async function applyStoppedState(write: StoppedStateWrite): Promise<void>
           - 'runtimeWakeProviderStatus'
           - 'runtimeWakeCleanupId'
           - 'runtimeWakeCleanupLeaseExpiresAt'
+          - 'activeTurn'
+          - 'activeTurns'
           - 'lifecycleStopClaim') || ${JSON.stringify(patch)}::jsonb`,
       })
       .where(eq(sessionSandboxes.sandboxId, write.sandboxId));


### PR DESCRIPTION
## Problem

The one-minute Dev Platinum lifecycle proof exposed a stop race. The provider native timer and webhook can set `status=stopped` before the reaper clears an unknown `activeTurns` token. The shared stopped-state writer preserved that stale authority metadata.

## Change

- Remove `activeTurn`, `activeTurns`, and `lifecycleStopClaim` in the same transaction that sets the sandbox row to `stopped`.
- Cover every stop path because provider webhooks, idle reaping, and manual stop share `applyStoppedState()`.
- Add the incident rule to the append-only learning register.

## Verification

- `bun test --env-file=apps/api/scripts/test.env apps/api/src/projects/reaping/sandbox-state-sync.test.ts` -> 16 pass, 0 fail.
- `bun test --env-file=apps/api/scripts/test.env apps/api/src/projects/session-lifecycle/__tests__/stop.test.ts` -> 14 pass, 0 fail.
- Reaper, stop-box, and turn lifecycle suites -> 121 pass, 0 fail.
- `pnpm --filter ./apps/api typecheck` -> exit 0.
- `pnpm test` -> all five lanes pass in 28.8s.
- Dev provider E2E will be rerun after deployment with a one-minute native timeout.