### PR TITLE
fix(sandbox): renew active turns on fast cadence

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,12 @@ linked, not inlined.
 
 ## Register
 
+### Active-turn renewal cadence must stay below the shortest provider backstop (2026-08-17)
+
+**When:** changing sandbox maintenance cadence, provider lifecycle timers, or active-turn renewal. Run exact-turn renewal in a separate leader-owned loop capped at 30 seconds. Do not couple it to the five-minute project-maintenance sweep. Scope the fast lane to durable `activeTurn` or `activeTurns` authority only.
+*Incident:* Dev Daytona renewed once, then stopped an exact active OpenCode turn 68 seconds later because the next project-maintenance pass was scheduled five minutes later than the one-minute deterministic provider timeout.
+*Enforcer:* `active-turn-renewal.test.ts` caps the loop at 30 seconds and requires `activeTurnsOnly`; `sandbox-reaper.test.ts` excludes idle rows from the fast lane; the live provider harness uses a one-minute native timer.
+
 ### Every sandbox stop must revoke all persisted turn authority (2026-08-17)
 
 **When:** changing provider webhooks, idle reaping, manual stop, or the shared stopped-state writer. Remove `activeTurn`, `activeTurns`, and `lifecycleStopClaim` in the same transaction that sets `status='stopped'`. Do not rely on the reaper to clear tokens first; a provider-native timer or webhook can win that race.

--- a/apps/api/src/__tests__/unit-leader-election.test.ts
+++ b/apps/api/src/__tests__/unit-leader-election.test.ts
@@ -45,13 +45,14 @@ describe('runsSingletonWorkers (dead-weight-leader guard)', () => {
     expect(runsSingletonWorkers({ KORTIX_WORKERS_ENABLED: 'false' })).toBe(false);
   });
 
-  test('API-only profile (ALL four worker flags "false") → NOT an owner', () => {
+  test('API-only profile (ALL five worker flags "false") → NOT an owner', () => {
     // This is the helm workers.enabled=false profile. Such a pod must never join
     // the election — otherwise it can win the lease and dead-weight-starve crons.
     expect(
       runsSingletonWorkers({
         KORTIX_TRIGGER_SCHEDULER_ENABLED: 'false',
         KORTIX_PROJECT_MAINTENANCE_ENABLED: 'false',
+        KORTIX_ACTIVE_TURN_RENEWAL_ENABLED: 'false',
         KORTIX_LEGACY_MIGRATION_WORKER_ENABLED: 'false',
         KORTIX_SUNA_MIGRATION_WORKER_ENABLED: 'false',
       }),
@@ -74,6 +75,19 @@ describe('runsSingletonWorkers (dead-weight-leader guard)', () => {
       runsSingletonWorkers({
         KORTIX_TRIGGER_SCHEDULER_ENABLED: 'true',
         KORTIX_PROJECT_MAINTENANCE_ENABLED: 'false',
+        KORTIX_ACTIVE_TURN_RENEWAL_ENABLED: 'false',
+        KORTIX_LEGACY_MIGRATION_WORKER_ENABLED: 'false',
+        KORTIX_SUNA_MIGRATION_WORKER_ENABLED: 'false',
+      }),
+    ).toBe(true);
+  });
+
+  test('only active-turn renewal enabled → owner', () => {
+    expect(
+      runsSingletonWorkers({
+        KORTIX_TRIGGER_SCHEDULER_ENABLED: 'false',
+        KORTIX_PROJECT_MAINTENANCE_ENABLED: 'false',
+        KORTIX_ACTIVE_TURN_RENEWAL_ENABLED: 'true',
         KORTIX_LEGACY_MIGRATION_WORKER_ENABLED: 'false',
         KORTIX_SUNA_MIGRATION_WORKER_ENABLED: 'false',
       }),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -96,6 +96,7 @@ import {
   getTriggerSchedulerHealth,
 } from './projects';
 import { startProjectMaintenance, stopProjectMaintenance } from './projects/maintenance';
+import { startActiveTurnRenewal, stopActiveTurnRenewal } from './projects/active-turn-renewal';
 import { kickStartupPreBuild } from './snapshots/builder';
 import { registerSunaMigrationRoutes } from './projects/suna-migration/suna-migration-routes';
 import { handleAppPublicRequest, resolveAppRequest } from './apps/public-proxy';
@@ -1361,6 +1362,7 @@ let singletonWorkersRunning = false;
 async function startSingletonWorkers() {
   if (singletonWorkersRunning) return;
   singletonWorkersRunning = true;
+  startActiveTurnRenewal();
   startProjectMaintenance();
   startProjectTriggerScheduler();
   // Mint the global platform-default sandbox image once per leadership term so
@@ -1385,6 +1387,7 @@ async function startSingletonWorkers() {
 async function stopSingletonWorkers() {
   if (!singletonWorkersRunning) return;
   singletonWorkersRunning = false;
+  stopActiveTurnRenewal();
   stopProjectTriggerScheduler();
   stopProjectMaintenance();
   stopSunaMigrationWorker();

--- a/apps/api/src/projects/active-turn-renewal.test.ts
+++ b/apps/api/src/projects/active-turn-renewal.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  activeTurnRenewalIntervalMs,
+  runActiveTurnRenewal,
+  startActiveTurnRenewal,
+  stopActiveTurnRenewal,
+} from './active-turn-renewal';
+import type { ReapResult } from './sandbox-reaper';
+
+function reapResult(overrides: Partial<ReapResult> = {}): ReapResult {
+  return {
+    candidates: 0,
+    matching: 0,
+    deferred: 0,
+    stopped: 0,
+    reconciled: 0,
+    billingClosed: 0,
+    skipped: 0,
+    lifecycleRenewed: 0,
+    errors: 0,
+    ...overrides,
+  };
+}
+
+async function flushAsync(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  stopActiveTurnRenewal();
+});
+
+describe('active-turn lifecycle renewal loop', () => {
+  test('runs faster than the one-minute provider lifecycle test timeout', () => {
+    expect(activeTurnRenewalIntervalMs({})).toBe(20_000);
+    expect(
+      activeTurnRenewalIntervalMs({
+        KORTIX_ACTIVE_TURN_RENEWAL_INTERVAL_MS: '60000',
+      }),
+    ).toBe(30_000);
+    expect(
+      activeTurnRenewalIntervalMs({
+        KORTIX_ACTIVE_TURN_RENEWAL_INTERVAL_MS: '1000',
+      }),
+    ).toBe(5_000);
+  });
+
+  test('reaps only rows with durable active-turn authority', async () => {
+    const calls: unknown[][] = [];
+    const result = await runActiveTurnRenewal({
+      reap: async (...args: unknown[]) => {
+        calls.push(args);
+        return reapResult({ candidates: 1, matching: 1, skipped: 1, lifecycleRenewed: 1 });
+      },
+      now: () => new Date('2026-08-17T06:00:00.000Z'),
+    });
+
+    expect(result.lifecycleRenewed).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toEqual(new Date('2026-08-17T06:00:00.000Z'));
+    expect(calls[0]?.[2]).toEqual({ activeTurnsOnly: true });
+  });
+
+  test('start schedules serial passes and stop cancels the pending pass', async () => {
+    let runs = 0;
+    const callbacks: Array<() => void> = [];
+    const delays: number[] = [];
+    const cancelled: Array<ReturnType<typeof setTimeout>> = [];
+    const timer = 101 as unknown as ReturnType<typeof setTimeout>;
+
+    const dependencies = {
+      reap: async () => {
+        runs += 1;
+        return reapResult();
+      },
+      schedule: (callback, delayMs) => {
+        callbacks.push(callback);
+        delays.push(delayMs);
+        return timer;
+      },
+      cancel: (pending) => cancelled.push(pending),
+      intervalMs: () => 20_000,
+      monotonicNowMs: () => 0,
+    };
+    startActiveTurnRenewal(dependencies);
+    startActiveTurnRenewal(dependencies);
+    await flushAsync();
+
+    expect(runs).toBe(1);
+    expect(callbacks).toHaveLength(1);
+    expect(delays).toEqual([20_000]);
+
+    stopActiveTurnRenewal();
+    expect(cancelled).toEqual([timer]);
+
+    callbacks[0]?.();
+    await flushAsync();
+    expect(runs).toBe(1);
+  });
+
+  test('a slow pass subtracts its runtime from the next delay', async () => {
+    const delays: number[] = [];
+    const clock = [1_000, 19_000];
+
+    startActiveTurnRenewal({
+      reap: async () => reapResult(),
+      schedule: (_callback, delayMs) => {
+        delays.push(delayMs);
+        return 301 as unknown as ReturnType<typeof setTimeout>;
+      },
+      intervalMs: () => 20_000,
+      monotonicNowMs: () => clock.shift() ?? 19_000,
+    });
+    await flushAsync();
+
+    expect(delays).toEqual([2_000]);
+  });
+
+  test('an in-flight pass cannot reschedule after stop and restart', async () => {
+    let finishOldPass: (() => void) | undefined;
+    const oldPass = new Promise<void>((resolve) => {
+      finishOldPass = resolve;
+    });
+    const oldCallbacks: Array<() => void> = [];
+    const newCallbacks: Array<() => void> = [];
+    let oldRuns = 0;
+    let newRuns = 0;
+
+    startActiveTurnRenewal({
+      reap: async () => {
+        oldRuns += 1;
+        await oldPass;
+        return reapResult();
+      },
+      schedule: (callback) => {
+        oldCallbacks.push(callback);
+        return 201 as unknown as ReturnType<typeof setTimeout>;
+      },
+    });
+    await flushAsync();
+    expect(oldRuns).toBe(1);
+
+    stopActiveTurnRenewal();
+    startActiveTurnRenewal({
+      reap: async () => {
+        newRuns += 1;
+        return reapResult();
+      },
+      schedule: (callback) => {
+        newCallbacks.push(callback);
+        return 202 as unknown as ReturnType<typeof setTimeout>;
+      },
+    });
+    await flushAsync();
+    expect(newRuns).toBe(1);
+    expect(newCallbacks).toHaveLength(1);
+
+    finishOldPass?.();
+    await flushAsync();
+    expect(oldCallbacks).toHaveLength(0);
+    expect(newCallbacks).toHaveLength(1);
+  });
+
+  test('the explicit disable flag starts no pass', async () => {
+    let runs = 0;
+    startActiveTurnRenewal(
+      {
+        reap: async () => {
+          runs += 1;
+          return reapResult();
+        },
+      },
+      { KORTIX_ACTIVE_TURN_RENEWAL_ENABLED: 'false' },
+    );
+    await flushAsync();
+    expect(runs).toBe(0);
+  });
+});

--- a/apps/api/src/projects/active-turn-renewal.test.ts
+++ b/apps/api/src/projects/active-turn-renewal.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import {
+  type ActiveTurnRenewalDependencies,
   activeTurnRenewalIntervalMs,
   runActiveTurnRenewal,
   startActiveTurnRenewal,
@@ -69,7 +70,7 @@ describe('active-turn lifecycle renewal loop', () => {
     const cancelled: Array<ReturnType<typeof setTimeout>> = [];
     const timer = 101 as unknown as ReturnType<typeof setTimeout>;
 
-    const dependencies = {
+    const dependencies: ActiveTurnRenewalDependencies = {
       reap: async () => {
         runs += 1;
         return reapResult();

--- a/apps/api/src/projects/active-turn-renewal.ts
+++ b/apps/api/src/projects/active-turn-renewal.ts
@@ -1,0 +1,125 @@
+import { logger } from '../lib/logger';
+import type { ReapResult } from './sandbox-reaper';
+
+const DEFAULT_ACTIVE_TURN_RENEWAL_INTERVAL_MS = 20_000;
+const MIN_ACTIVE_TURN_RENEWAL_INTERVAL_MS = 5_000;
+const MAX_ACTIVE_TURN_RENEWAL_INTERVAL_MS = 30_000;
+
+type Timer = ReturnType<typeof setTimeout>;
+type Reap = (
+  now?: Date,
+  dependencyOverrides?: Record<string, never>,
+  scope?: { sandboxIds?: readonly string[]; activeTurnsOnly?: boolean },
+) => Promise<ReapResult>;
+type Schedule = (callback: () => void, delayMs: number) => Timer;
+type Cancel = (timer: Timer) => void;
+
+export interface ActiveTurnRenewalDependencies {
+  reap?: Reap;
+  now?: () => Date;
+  schedule?: Schedule;
+  cancel?: Cancel;
+  intervalMs?: () => number;
+  monotonicNowMs?: () => number;
+}
+
+const state = globalThis as typeof globalThis & {
+  __kortixActiveTurnRenewalTimer?: Timer | null;
+  __kortixActiveTurnRenewalRunning?: boolean;
+  __kortixActiveTurnRenewalGeneration?: number;
+  __kortixActiveTurnRenewalCancel?: Cancel;
+};
+
+export function activeTurnRenewalIntervalMs(
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): number {
+  const parsed = Number.parseInt(env.KORTIX_ACTIVE_TURN_RENEWAL_INTERVAL_MS ?? '', 10);
+  const configured = Number.isFinite(parsed) ? parsed : DEFAULT_ACTIVE_TURN_RENEWAL_INTERVAL_MS;
+  return Math.min(
+    MAX_ACTIVE_TURN_RENEWAL_INTERVAL_MS,
+    Math.max(MIN_ACTIVE_TURN_RENEWAL_INTERVAL_MS, configured),
+  );
+}
+
+async function defaultReap(
+  now?: Date,
+  dependencyOverrides?: Record<string, never>,
+  scope?: { sandboxIds?: readonly string[]; activeTurnsOnly?: boolean },
+): Promise<ReapResult> {
+  const { reapAndReconcileSandboxes } = await import('./sandbox-reaper');
+  return reapAndReconcileSandboxes(now, dependencyOverrides, scope);
+}
+
+/** Run one provider-neutral pass over rows that currently hold turn authority. */
+export async function runActiveTurnRenewal(
+  dependencies: ActiveTurnRenewalDependencies = {},
+): Promise<ReapResult> {
+  const reap = dependencies.reap ?? defaultReap;
+  return reap((dependencies.now ?? (() => new Date()))(), {}, { activeTurnsOnly: true });
+}
+
+function isCurrentGeneration(generation: number): boolean {
+  return (
+    state.__kortixActiveTurnRenewalRunning === true &&
+    state.__kortixActiveTurnRenewalGeneration === generation
+  );
+}
+
+async function tick(
+  generation: number,
+  dependencies: ActiveTurnRenewalDependencies,
+): Promise<void> {
+  if (!isCurrentGeneration(generation)) return;
+  const monotonicNowMs = dependencies.monotonicNowMs ?? (() => performance.now());
+  const startedAtMs = monotonicNowMs();
+  try {
+    const result = await runActiveTurnRenewal(dependencies);
+    if (result.candidates > 0 || result.errors > 0) {
+      logger.info('[active-turn-renewal] pass', {
+        candidates: result.candidates,
+        matching: result.matching,
+        deferred: result.deferred,
+        lifecycleRenewed: result.lifecycleRenewed,
+        reconciled: result.reconciled,
+        errors: result.errors,
+      });
+    }
+  } catch (error) {
+    logger.error('[active-turn-renewal] pass failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    if (isCurrentGeneration(generation)) {
+      const schedule = dependencies.schedule ?? setTimeout;
+      const intervalMs = (dependencies.intervalMs ?? activeTurnRenewalIntervalMs)();
+      const delayMs = Math.max(0, intervalMs - (monotonicNowMs() - startedAtMs));
+      state.__kortixActiveTurnRenewalCancel = dependencies.cancel ?? clearTimeout;
+      state.__kortixActiveTurnRenewalTimer = schedule(
+        () => void tick(generation, dependencies),
+        delayMs,
+      );
+    }
+  }
+}
+
+export function startActiveTurnRenewal(
+  dependencies: ActiveTurnRenewalDependencies = {},
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): void {
+  if (env.KORTIX_ACTIVE_TURN_RENEWAL_ENABLED === 'false') return;
+  if (state.__kortixActiveTurnRenewalRunning) return;
+  state.__kortixActiveTurnRenewalRunning = true;
+  const generation = (state.__kortixActiveTurnRenewalGeneration ?? 0) + 1;
+  state.__kortixActiveTurnRenewalGeneration = generation;
+  void tick(generation, dependencies);
+}
+
+export function stopActiveTurnRenewal(): void {
+  state.__kortixActiveTurnRenewalRunning = false;
+  state.__kortixActiveTurnRenewalGeneration = (state.__kortixActiveTurnRenewalGeneration ?? 0) + 1;
+  if (state.__kortixActiveTurnRenewalTimer) {
+    (state.__kortixActiveTurnRenewalCancel ?? clearTimeout)(state.__kortixActiveTurnRenewalTimer);
+    state.__kortixActiveTurnRenewalTimer = null;
+  }
+  state.__kortixActiveTurnRenewalCancel = undefined;
+}

--- a/apps/api/src/projects/reaping/box-queries.ts
+++ b/apps/api/src/projects/reaping/box-queries.ts
@@ -32,7 +32,7 @@ export interface ReapCandidate {
 }
 
 /** Rows the sweep is allowed to examine: our own `active` rows with a box behind them. */
-export function reapCandidatePredicate(sandboxIds?: readonly string[]) {
+export function reapCandidatePredicate(sandboxIds?: readonly string[], activeTurnsOnly = false) {
   return and(
     eq(sessionSandboxes.status, 'active'),
     isNotNull(sessionSandboxes.externalId),
@@ -41,6 +41,7 @@ export function reapCandidatePredicate(sandboxIds?: readonly string[]) {
         ? inArray(sessionSandboxes.sandboxId, [...sandboxIds])
         : sql`false`
       : undefined,
+    activeTurnsOnly ? activeTurnAuthorityPredicate() : undefined,
   );
 }
 
@@ -77,6 +78,7 @@ export function activeTurnAuthorityPredicate() {
  */
 export async function selectReapCandidates(
   predicate: ReturnType<typeof reapCandidatePredicate>,
+  activeTurnsOnly = false,
 ): Promise<ReapCandidate[]> {
   const projection = {
     sandboxId: sessionSandboxes.sandboxId,
@@ -100,6 +102,8 @@ export async function selectReapCandidates(
       visitOrder,
     )
     .limit(batchSize)) as ReapCandidate[];
+
+  if (activeTurnsOnly) return turnRows;
 
   const regularRows = (await db
     .select(projection)

--- a/apps/api/src/projects/reaping/box-reaper.ts
+++ b/apps/api/src/projects/reaping/box-reaper.ts
@@ -97,7 +97,9 @@ const DEFAULT_REAPER_DEPENDENCIES: SandboxReaperDependencies = {
 
 export interface SandboxReaperScope {
   /** Optional operational/test scope. Production maintenance omits it. */
-  sandboxIds: readonly string[];
+  sandboxIds?: readonly string[];
+  /** Fast lifecycle lane. Excludes every row without durable turn authority. */
+  activeTurnsOnly?: boolean;
 }
 
 /**
@@ -113,8 +115,9 @@ export async function reapAndReconcileSandboxes(
   scope?: SandboxReaperScope,
 ): Promise<ReapResult> {
   const dependencies = { ...DEFAULT_REAPER_DEPENDENCIES, ...dependencyOverrides };
-  const candidatePredicate = reapCandidatePredicate(scope?.sandboxIds);
-  const rows = await selectReapCandidates(candidatePredicate);
+  const activeTurnsOnly = scope?.activeTurnsOnly === true;
+  const candidatePredicate = reapCandidatePredicate(scope?.sandboxIds, activeTurnsOnly);
+  const rows = await selectReapCandidates(candidatePredicate, activeTurnsOnly);
 
   const result: ReapResult = {
     ...EMPTY_REAP_RESULT,

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -324,7 +324,10 @@ const {
   observeSandboxTurn,
 } = sandboxReaper;
 
-const reapAndReconcileSandboxes = (now?: Date) =>
+const reapAndReconcileSandboxes = (
+  now?: Date,
+  scope?: { sandboxIds?: readonly string[]; activeTurnsOnly?: boolean },
+) =>
   sandboxReaper.reapAndReconcileSandboxes(now, {
     renewActiveSandboxTurn: async (sandboxId: string, token: string) => {
       activeTurnRenewalCalls.push({ sandboxId, token });
@@ -358,7 +361,7 @@ const reapAndReconcileSandboxes = (now?: Date) =>
       });
       return true;
     },
-  });
+  }, scope);
 
 const HOUR = 3_600_000;
 
@@ -563,6 +566,45 @@ describe('reapAndReconcileSandboxes — the one rule: deadline_at <= now', () =>
     expect(r.stopped).toBe(0);
     expect(r.lifecycleRenewed).toBe(1);
     expect(timeoutRenewals).toEqual([{ provider: 'daytona', externalId: 'ext-1' }]);
+  });
+
+  test('the fast renewal lane excludes every row without durable turn authority', async () => {
+    candidates = [
+      candidate({
+        sandboxId: 'sb-active',
+        externalId: 'ext-active',
+        deadlineAt: new Date(NOW.getTime() - 1),
+        metadata: {
+          activeTurns: {
+            'turn-token': {
+              token: 'turn-token',
+              state: 'active',
+              opencodeSessionId: 'ses_root',
+              messageId: 'msg_turn_1',
+            },
+          },
+        },
+      }),
+      candidate({
+        sandboxId: 'sb-idle',
+        externalId: 'ext-idle',
+        deadlineAt: new Date(NOW.getTime() - 1),
+        metadata: null,
+      }),
+    ];
+    statusByExternal['ext-active'] = 'running';
+    statusByExternal['ext-idle'] = 'running';
+    turnObservationByToken['turn-token'] = 'active';
+    activeTurnRenewalBySandbox['sb-active'] = 'renewed';
+
+    const result = await reapAndReconcileSandboxes(NOW, {
+      activeTurnsOnly: true,
+    });
+
+    expect(result.candidates).toBe(1);
+    expect(result.lifecycleRenewed).toBe(1);
+    expect(statusCalls).toEqual(['ext-active']);
+    expect(stops).toEqual([]);
   });
 
   test('recovers an accepted prompt whose post-delivery database promotion failed', async () => {

--- a/apps/api/src/shared/leader-election.ts
+++ b/apps/api/src/shared/leader-election.ts
@@ -80,7 +80,7 @@ export function shouldDemote(
  * DEAD-WEIGHT leader — holding it, renewing it, running nothing — silently
  * starving the cron scheduler fleet-wide with no error and no churn. That is what
  * left an EKS API-only pod able to freeze every cron in the 2026-06-21 outage. A
- * pod is an owner unless ALL four worker flags are explicitly "false"; default
+ * pod is an owner unless ALL five worker flags are explicitly "false"; default
  * (unset) = owner, so single-node / self-host is unaffected.
  */
 export function runsSingletonWorkers(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -89,6 +89,7 @@ export function runsSingletonWorkers(env: NodeJS.ProcessEnv = process.env): bool
   return (
     on(env.KORTIX_TRIGGER_SCHEDULER_ENABLED) ||
     on(env.KORTIX_PROJECT_MAINTENANCE_ENABLED) ||
+    on(env.KORTIX_ACTIVE_TURN_RENEWAL_ENABLED) ||
     on(env.KORTIX_LEGACY_MIGRATION_WORKER_ENABLED) ||
     on(env.KORTIX_SUNA_MIGRATION_WORKER_ENABLED)
   );


### PR DESCRIPTION
## Problem

The provider-neutral lifecycle renewal path ran only inside the five-minute project-maintenance sweep. A Daytona sandbox with a one-minute native timer renewed once and then stopped an exact active OpenCode turn before the next maintenance pass.

## Change

- Add a leader-owned active-turn renewal loop with a 20-second default cadence.
- Clamp the cadence to 5-30 seconds.
- Scope the fast lane to durable `activeTurn` and `activeTurns` authority.
- Keep passive and ordinary idle rows in the five-minute maintenance lane.
- Fence stop/restart generations so an old in-flight pass cannot create a duplicate loop.
- Subtract pass runtime from the next delay to preserve start-to-start cadence.
- Add the incident rule to the append-only learnings register.

## Contract

- Exact active turns renew `deadline_at` and the provider-native lifecycle.
- Unknown turn state does not extend `deadline_at`.
- Passive reads do not enter the fast lane.
- Stopped sandboxes remain excluded and provider adapters refuse renewal.
- Idle stop remains owned by the ordinary deadline reaper.

## Verification

- `bun test apps/api/src/projects/active-turn-renewal.test.ts`: 6 pass, 0 fail.
- `bun test --isolate --env-file=apps/api/scripts/test.env apps/api/src/projects/sandbox-reaper.test.ts`: 94 pass, 0 fail.
- `bun test --isolate --env-file=apps/api/scripts/test.env apps/api/src/__tests__/unit-leader-election.test.ts`: 12 pass, 0 fail.
- Provider adapter suites: 79 pass, 0 fail across E2B, Daytona, and Platinum.
- `pnpm --filter kortix-api typecheck`: exit 0.
- `pnpm test`: exit 0; all core lanes passed in 27.9s.

## Dev proof after merge

Run the live provider harness with one-minute native timers against Platinum and Daytona. Require active survival, exact deadline renewal, unchanged passive deadline, post-deadline idle stop, stopped-renewal refusal, and fixture cleanup.