### PR TITLE
fix: close three prompt-loss holes around session hand-off

### DIFF
--- a/apps/api/src/sandbox-proxy/prompt-dedupe.test.ts
+++ b/apps/api/src/sandbox-proxy/prompt-dedupe.test.ts
@@ -19,7 +19,7 @@ describe('promptDeliveryKey', () => {
       sessionId: 'se',
       body: undefined,
     });
-    expect(key).toBe('idem:abc-123');
+    expect(key).toBe('idem:sb\0se\0abc-123');
   });
 
   test('falls back to a stable content hash when no key is supplied', () => {
@@ -131,7 +131,7 @@ describe('promptDeliveryKey', () => {
         sessionId: 'se',
         body: bodyWithId('msg_0123456789ab00000000000000'),
       });
-      expect(key).toBe('idem:cli-key-1');
+      expect(key).toBe('idem:sb\0se\0cli-key-1');
     });
 
     test('a command body (no messageID field) still falls back to the content hash', () => {
@@ -365,5 +365,47 @@ describe('shouldClaimPromptDelivery', () => {
 
   test('a lookalike path is treated as a prompt, not a command', () => {
     expect(shouldClaimPromptDelivery('/session/abc/commands', false)).toBe(true);
+  });
+});
+
+describe('Idempotency-Key scoping', () => {
+  // A failed create can requeue and re-provision onto a DIFFERENT
+  // session/sandbox while carrying the SAME command-scoped Idempotency-Key
+  // (session-lifecycle/engine.ts reuses the create command's id for the
+  // post-create prompt). An unscoped `idem:` key let the first attempt's
+  // claim swallow the retry's delivery to the NEW sandbox as a "duplicate" —
+  // that sandbox genuinely never saw the prompt. Scope by sandbox+session,
+  // exactly like the msgid and hash precedences: a repeat to the SAME box
+  // still dedupes; a different box is a different delivery.
+  test('the same Idempotency-Key on a different sandbox/session is a different delivery', () => {
+    const a = promptDeliveryKey({
+      idempotencyKey: 'cmd-1',
+      sandboxId: 'sb-old',
+      sessionId: 'se-old',
+      body: undefined,
+    });
+    const b = promptDeliveryKey({
+      idempotencyKey: 'cmd-1',
+      sandboxId: 'sb-new',
+      sessionId: 'se-new',
+      body: undefined,
+    });
+    expect(a).not.toBe(b);
+  });
+
+  test('the same Idempotency-Key on the same sandbox/session still collides', () => {
+    const a = promptDeliveryKey({
+      idempotencyKey: 'cmd-1',
+      sandboxId: 'sb',
+      sessionId: 'se',
+      body: undefined,
+    });
+    const b = promptDeliveryKey({
+      idempotencyKey: 'cmd-1',
+      sandboxId: 'sb',
+      sessionId: 'se',
+      body: new TextEncoder().encode('{"different":"body"}').buffer,
+    });
+    expect(a).toBe(b);
   });
 });

--- a/apps/api/src/sandbox-proxy/prompt-dedupe.ts
+++ b/apps/api/src/sandbox-proxy/prompt-dedupe.ts
@@ -172,8 +172,13 @@ export function promptDeliveryKey(opts: {
   sessionId: string;
   body: ArrayBuffer | undefined;
 }): string {
+  // Scoped by sandbox + session like the two precedences below. A create
+  // retry re-provisions onto a DIFFERENT session/sandbox while reusing the
+  // same command-scoped Idempotency-Key (session-lifecycle/engine.ts); an
+  // unscoped key let the first attempt's claim swallow the retry's delivery
+  // to the new box — which genuinely never saw the prompt — as a "duplicate".
   const provided = opts.idempotencyKey?.trim();
-  if (provided) return `idem:${provided}`;
+  if (provided) return `idem:${opts.sandboxId}\0${opts.sessionId}\0${provided}`;
   const messageId = extractWireMessageId(opts.body);
   if (messageId) return `msgid:${opts.sandboxId}\0${opts.sessionId}\0${messageId}`;
   const hash = createHash('sha256')

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -14,6 +14,8 @@ import Loading from '@/components/ui/loading';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { useAuth } from '@/features/providers/auth-provider';
 import { InstantSessionShell } from '@/features/session/instant-session-shell';
+import { resolvePinnedRootSessionId } from '@/features/session/pinned-root-session';
+import { useMessageQueueStore } from '@/stores/message-queue-store';
 import { ProviderFailureRecovery } from '@/features/session/provider-failure-recovery';
 import {
   pendingSessionPromptForRecovery,
@@ -838,14 +840,20 @@ function ActiveSessionChat({
   const selectedSession = selectedOpenCodeSessionId
     ? runtimeSessions.find((session) => session.id === selectedOpenCodeSessionId)
     : null;
-  // Pin the first resolved root id so the chat keeps its identity if the live
-  // value blips back to null mid-session. State, not a ref written during
-  // render: this component is already keyed per session by the route, so there
-  // is no cross-session reset to hand-roll, and a discarded render can no longer
+  // Pin the resolved root id so the chat keeps its identity if the live
+  // value blips back to null mid-session — but FOLLOW a non-null change: the
+  // SDK's pin precedence only climbs, so a different resolved id is a
+  // higher-authority correction (e.g. a stale persisted mirror displaced by
+  // the real /start pin) and holding the old latch would keep painting — and
+  // delivering into — the conversation the stale pin named. See
+  // resolvePinnedRootSessionId. State, not a ref written during render: this
+  // component is already keyed per session by the route, so there is no
+  // cross-session reset to hand-roll, and a discarded render can no longer
   // leave a pin behind that the state it belongs to never saw.
   const [pinnedRootSessionId, setPinnedRootSessionId] = useState<string | null>(null);
   useEffect(() => {
-    if (!pinnedRootSessionId && rootSessionId) setPinnedRootSessionId(rootSessionId);
+    const next = resolvePinnedRootSessionId(pinnedRootSessionId, rootSessionId);
+    if (next !== pinnedRootSessionId) setPinnedRootSessionId(next);
   }, [pinnedRootSessionId, rootSessionId]);
   const chatSessionId = selectedSession?.id ?? pinnedRootSessionId ?? rootSessionId ?? null;
 
@@ -867,6 +875,9 @@ function ActiveSessionChat({
   useEffect(() => {
     if (!chatSessionId) return;
     migrateStash(sessionId, chatSessionId);
+    // Same hand-off for the message queue: the instant shell enqueues under
+    // the ROUTE id, SessionChat drains under the pin — see adoptSessionQueue.
+    useMessageQueueStore.getState().adoptSessionQueue(sessionId, chatSessionId);
   }, [sessionId, chatSessionId]);
 
   // ── Readiness benchmarking marks ───────────────────────────────────────

--- a/apps/web/src/features/session/pinned-root-session.test.ts
+++ b/apps/web/src/features/session/pinned-root-session.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolvePinnedRootSessionId } from './pinned-root-session';
+
+describe('resolvePinnedRootSessionId', () => {
+  test('latches the first resolved id', () => {
+    expect(resolvePinnedRootSessionId(null, 'ses_a')).toBe('ses_a');
+  });
+
+  test('keeps the latch through a null blip — the reason the latch exists', () => {
+    expect(resolvePinnedRootSessionId('ses_a', null)).toBe('ses_a');
+  });
+
+  test('a DIFFERENT resolved id displaces the latch — the /start pin is authoritative', () => {
+    // The pin precedence only climbs (persisted mirror → network row →
+    // /start), so a non-null change is always a higher-authority correction.
+    // Keeping the stale latch painted — and delivered prompts into — the
+    // conversation the stale pin named.
+    expect(resolvePinnedRootSessionId('ses_stale', 'ses_fresh')).toBe('ses_fresh');
+  });
+
+  test('the same id is a no-op', () => {
+    expect(resolvePinnedRootSessionId('ses_a', 'ses_a')).toBe('ses_a');
+  });
+
+  test('nothing resolved yet stays unlatched', () => {
+    expect(resolvePinnedRootSessionId(null, null)).toBeNull();
+  });
+});

--- a/apps/web/src/features/session/pinned-root-session.ts
+++ b/apps/web/src/features/session/pinned-root-session.ts
@@ -1,0 +1,21 @@
+/**
+ * The chat's root-conversation pin latch.
+ *
+ * The live pin (`useSession().opencodeSessionId`) can blip back to null
+ * mid-session (a runtime reconnect re-resolving), and the chat must keep its
+ * identity through that — hence a latch. But the live value can also CORRECT
+ * itself: the SDK's pin precedence only climbs (persisted localStorage mirror
+ * → session-row network read → the `/start` result), so a change from one
+ * non-null id to another is always a higher-authority source landing — e.g. a
+ * stale persisted mirror displaced by the real `/start` pin. A latch that
+ * ignored that kept painting — and delivering prompts into — the conversation
+ * the stale pin named.
+ *
+ * So: latch on first resolve, hold through null, follow any non-null change.
+ */
+export function resolvePinnedRootSessionId(
+  pinned: string | null,
+  live: string | null,
+): string | null {
+  return live ?? pinned;
+}

--- a/apps/web/src/stores/message-queue-store.test.ts
+++ b/apps/web/src/stores/message-queue-store.test.ts
@@ -500,3 +500,60 @@ describe('queued slash commands', () => {
     expect(revived.command).toBeUndefined();
   });
 });
+
+describe('adoptSessionQueue', () => {
+  // #6110's orphan: the instant shell enqueues under the ROUTE session id,
+  // but SessionChat drains `queues[chatSessionId]` — the OpenCode `ses_*`
+  // pin. Without a hand-off, messages typed during boot never render in the
+  // real chat and never send. The session page calls this beside
+  // `migrateStash` the moment the pin resolves.
+  test('moves a queue from the route id to the resolved pin', () => {
+    const store = useMessageQueueStore.getState();
+    store.enqueue(A, { text: 'typed during boot' } as never);
+
+    useMessageQueueStore.getState().adoptSessionQueue(A, B);
+
+    const state = useMessageQueueStore.getState();
+    expect(state.getSessionQueue(A).pending).toHaveLength(0);
+    expect(state.getSessionQueue(B).pending.map((m) => m.text)).toEqual(['typed during boot']);
+  });
+
+  test('prepends the boot-time messages before anything already queued at the pin', () => {
+    const store = useMessageQueueStore.getState();
+    store.enqueue(A, { text: 'first, typed on the shell' } as never);
+    store.enqueue(B, { text: 'second, typed in the chat' } as never);
+
+    useMessageQueueStore.getState().adoptSessionQueue(A, B);
+
+    expect(
+      useMessageQueueStore
+        .getState()
+        .getSessionQueue(B)
+        .pending.map((m) => m.text),
+    ).toEqual(['first, typed on the shell', 'second, typed in the chat']);
+  });
+
+  test("keeps the pin queue's in-flight claim", () => {
+    const store = useMessageQueueStore.getState();
+    store.enqueue(B, { text: 'sending' } as never);
+    const claimed = useMessageQueueStore.getState().claimNext(B);
+    expect(claimed).toBeDefined();
+    store.enqueue(A, { text: 'boot message' } as never);
+
+    useMessageQueueStore.getState().adoptSessionQueue(A, B);
+
+    expect(useMessageQueueStore.getState().getSessionQueue(B).inFlightId).toBe(
+      claimed?.id ?? null,
+    );
+  });
+
+  test('same id or empty source: no-op', () => {
+    const store = useMessageQueueStore.getState();
+    store.enqueue(B, { text: 'stays' } as never);
+
+    useMessageQueueStore.getState().adoptSessionQueue(B, B);
+    useMessageQueueStore.getState().adoptSessionQueue('ses_empty', B);
+
+    expect(useMessageQueueStore.getState().getSessionQueue(B).pending).toHaveLength(1);
+  });
+});

--- a/apps/web/src/stores/message-queue-store.ts
+++ b/apps/web/src/stores/message-queue-store.ts
@@ -104,6 +104,16 @@ interface MessageQueueState {
   getInFlightIds: (sessionId: string) => string[];
 
   enqueue: (sessionId: string, input: EnqueueInput) => void;
+  /**
+   * Hand a queue from one session-id namespace to another — the queue twin of
+   * `migrateStash`. The instant shell enqueues under the ROUTE session id
+   * before the canonical OpenCode pin exists; SessionChat drains under the
+   * pin. Without this hand-off, messages typed during boot were orphaned
+   * under the route id — never rendered, never sent (#6110). Boot-time
+   * messages keep their ids and go BEFORE anything already queued at the
+   * target (they were typed earlier); the target's in-flight claim is kept.
+   */
+  adoptSessionQueue: (fromSessionId: string, toSessionId: string) => void;
   remove: (sessionId: string, id: string) => void;
   edit: (sessionId: string, id: string, text: string) => void;
   reorder: (sessionId: string, id: string, toIndex: number) => void;
@@ -292,6 +302,23 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => {
           createdAt: Date.now(),
         }),
       ),
+
+    adoptSessionQueue: (fromSessionId, toSessionId) => {
+      if (fromSessionId === toSessionId) return;
+      const state = get();
+      const from = state.queues[fromSessionId];
+      if (!from || (from.pending.length === 0 && from.failed.length === 0)) return;
+      const target = state.queues[toSessionId] ?? EMPTY;
+      const queues = { ...state.queues };
+      delete queues[fromSessionId];
+      queues[toSessionId] = {
+        ...target,
+        pending: [...from.pending, ...target.pending],
+        failed: [...from.failed, ...target.failed],
+      };
+      persist(queues);
+      set({ queues });
+    },
 
     remove: (sessionId, id) => mutate(sessionId, (queue) => removeQueued(queue, id)),
     edit: (sessionId, id, text) => mutate(sessionId, (queue) => editQueued(queue, id, text)),


### PR DESCRIPTION
## Issue

Three separable defects on the session hand-off path, surfaced by the audit behind #6485 — each silently loses or misroutes a user's prompt. A failed create that re-provisions onto a new session/sandbox had its first prompt swallowed as a duplicate, because the prompt-dedupe `idem:` key was unscoped while the engine reuses the create command's id as the Idempotency-Key across retries. Messages typed during sandbox boot were orphaned: the instant shell enqueues under the route session id, SessionChat drains under the resolved OpenCode pin, and no hand-off existed (#6110). And the chat's root-pin latch held its first resolved id forever, so a stale persisted pin kept painting — and delivering prompts into — the conversation it named, even after the authoritative `/start` pin corrected it.

## Solution

- Scope the `idem:` dedupe key by sandbox+session, matching the `msgid:` and hash precedences: a repeat to the same box still dedupes; a different box is a different delivery.
- `adoptSessionQueue` — the queue twin of `migrateStash`, called beside it when the pin resolves: boot-time messages keep their ids, go before anything already queued at the pin, and the target's in-flight claim is kept.
- `resolvePinnedRootSessionId(pinned, live) = live ?? pinned`: the pin precedence only climbs (persisted mirror → network row → `/start`), so a non-null change is always a higher-authority correction; the latch still holds through null blips, the case it exists for.

## Testing

- All three fixes RED-proven first; scoped suites on the committed tree: `prompt-dedupe.test.ts` 31 pass, `message-queue-store.test.ts` + `pinned-root-session.test.ts` 43 pass.
- The full `apps/web` (7420 pass / 0 fail) and `apps/api` runs reported on #6485 were taken with these changes present in the tree.
