### PR TITLE
Use a minimal icon for shared sessions

### DIFF
--- a/apps/web/src/components/projects/session-shared-icon.test.tsx
+++ b/apps/web/src/components/projects/session-shared-icon.test.tsx
@@ -1,26 +1,28 @@
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { SessionSharedBadge } from './session-shared-badge';
+import { SessionSharedIcon } from './session-shared-icon';
 
-describe('SessionSharedBadge', () => {
+describe('SessionSharedIcon', () => {
   test('renders no ownership decoration for the viewer own session', () => {
-    expect(renderToStaticMarkup(<SessionSharedBadge session={{ is_owner: true }} />)).toBe('');
+    expect(renderToStaticMarkup(<SessionSharedIcon session={{ is_owner: true }} />)).toBe('');
   });
 
-  test('renders a clear Shared label for a session owned by another principal', () => {
+  test('renders one minimal sharing icon for a session owned by another principal', () => {
     const html = renderToStaticMarkup(
-      <SessionSharedBadge
+      <SessionSharedIcon
         session={{ is_owner: false, owner_name: 'Nightly reviewer', owner_email: null }}
       />,
     );
 
-    expect(html).toContain('>Shared</span>');
+    expect(html).toContain('<svg');
+    expect(html).not.toContain('>Shared<');
+    expect(html).toContain('role="img"');
     expect(html).toContain('aria-label="Shared by Nightly reviewer"');
     expect(html).toContain('data-session-shared="true"');
   });
 
   test('does not guess that an older payload with unknown ownership is shared', () => {
-    expect(renderToStaticMarkup(<SessionSharedBadge session={{}} />)).toBe('');
+    expect(renderToStaticMarkup(<SessionSharedIcon session={{}} />)).toBe('');
   });
 });

--- a/apps/web/src/components/projects/session-shared-icon.tsx
+++ b/apps/web/src/components/projects/session-shared-icon.tsx
@@ -1,12 +1,13 @@
 import type { ProjectSession } from '@kortix/sdk';
+import { ShareNetworkIcon } from '@phosphor-icons/react';
 
 import { sessionIsShared } from '@/components/projects/session-label';
-import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 
 type SessionOwnership = Pick<ProjectSession, 'is_owner' | 'owner_name' | 'owner_email'>;
 
-/** Visible ownership marker for every accessible session the viewer does not own. */
-export function SessionSharedBadge({
+/** Minimal ownership marker for every accessible session the viewer does not own. */
+export function SessionSharedIcon({
   session,
   className,
 }: {
@@ -19,15 +20,17 @@ export function SessionSharedBadge({
   const label = owner ? `Shared by ${owner}` : 'Shared session';
 
   return (
-    <Badge
-      variant="kortix"
-      size="xs"
-      className={className}
+    <span
+      className={cn(
+        'text-muted-foreground/70 flex size-4 shrink-0 items-center justify-center',
+        className,
+      )}
+      role="img"
       aria-label={label}
       title={label}
       data-session-shared="true"
     >
-      Shared
-    </Badge>
+      <ShareNetworkIcon className="size-3" />
+    </span>
   );
 }

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SessionSharedBadge } from '@/components/projects/session-shared-badge';
+import { SessionSharedIcon } from '@/components/projects/session-shared-icon';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1750,7 +1750,7 @@ export function CommandPalette() {
                           >
                             <MessageCircle className="size-4 shrink-0" />
                             <span className="flex-1 truncate">{sessionName(session)}</span>
-                            <SessionSharedBadge session={session} />
+                            <SessionSharedIcon session={session} />
                             <span className="text-muted-foreground/30 shrink-0 text-xs tabular-nums">
                               {formatRelativeTime(
                                 new Date(sessionLastActivityAt(session)).getTime(),
@@ -1913,7 +1913,7 @@ export function CommandPalette() {
                           >
                             <MessageCircle className="size-4 shrink-0" />
                             <span className="flex-1 truncate">{sessionName(session)}</span>
-                            <SessionSharedBadge session={session} />
+                            <SessionSharedIcon session={session} />
                             {session.session_id === params?.sessionId && (
                               <Check className="text-primary h-3.5 w-3.5 shrink-0" />
                             )}
@@ -2296,7 +2296,7 @@ export function CommandPalette() {
                     >
                       <MessageCircle className="text-muted-foreground size-4 shrink-0" />
                       <span className="flex-1 truncate">{sessionName(session)}</span>
-                      <SessionSharedBadge session={session} />
+                      <SessionSharedIcon session={session} />
                       <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
                         {formatRelativeTime(new Date(sessionLastActivityAt(session)).getTime())}
                       </span>

--- a/apps/web/src/features/workspace/project-sessions/session-row.tsx
+++ b/apps/web/src/features/workspace/project-sessions/session-row.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { sessionSource, type SessionSourceKind } from '@/components/projects/session-label';
-import { SessionSharedBadge } from '@/components/projects/session-shared-badge';
+import { SessionSharedIcon } from '@/components/projects/session-shared-icon';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
@@ -184,7 +184,7 @@ function SessionRowImpl({
             <span className="text-muted-foreground"> · {source.triggerSlug}</span>
           ) : null}
         </span>
-        <SessionSharedBadge session={session} />
+        <SessionSharedIcon session={session} />
       </span>
     </>
   );

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -14,7 +14,7 @@ import {
   type SessionDisplayStatus,
   type SessionSourceKind,
 } from '@/components/projects/session-label';
-import { SessionSharedBadge } from '@/components/projects/session-shared-badge';
+import { SessionSharedIcon } from '@/components/projects/session-shared-icon';
 import { Button } from '@/components/ui/button';
 import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import {
@@ -733,8 +733,6 @@ function ProjectSessionRow({
 
           <SessionTitle title={displayTitle} className={cn(isActive && 'font-medium')} />
 
-          <SessionSharedBadge session={session} />
-
           {childCount > 0 && (
             <span className="bg-sidebar-accent/60 text-muted-foreground shrink-0 rounded-full px-1.5 py-0.5 text-xs tabular-nums">
               {childCount}
@@ -742,7 +740,7 @@ function ProjectSessionRow({
           )}
         </Link>
 
-        <div className="flex shrink-0 items-center gap-0">
+        <div className="flex shrink-0 items-center gap-0" data-session-indicators="true">
           {spawnedBy && !nested && (
             <Hint side="top" label={`Spawned by session ${spawnedBy.slice(0, 8)}`}>
               <span className="text-muted-foreground/70 flex size-4 shrink-0 items-center justify-center">
@@ -751,7 +749,10 @@ function ProjectSessionRow({
             </Hint>
           )}
           {SourceIcon && (
-            <span className="flex size-4 shrink-0 items-center justify-center">
+            <span
+              className="flex size-4 shrink-0 items-center justify-center"
+              data-session-source="true"
+            >
               <Hint
                 side="top"
                 label={
@@ -764,6 +765,7 @@ function ProjectSessionRow({
               </Hint>
             </span>
           )}
+          <SessionSharedIcon session={session} />
 
           <div className="relative w-10 min-w-10 shrink-0">
             {activity && (

--- a/tests/e2e/specs/21-trigger-session-access.spec.ts
+++ b/tests/e2e/specs/21-trigger-session-access.spec.ts
@@ -141,16 +141,22 @@ test.describe('21 — Trigger-created session access UI', () => {
       await page.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
       await dismissOnboarding(page);
 
-      const ownSidebarRow = page.locator(`a[href$="/sessions/${ownSessionId}"]`);
-      const sharedSidebarRow = page.locator(`a[href$="/sessions/${sharedTriggerSessionId}"]`);
-      await expect(ownSidebarRow).toBeVisible();
+      const ownSidebarLink = page.locator(`a[href$="/sessions/${ownSessionId}"]`);
+      const sharedSidebarLink = page.locator(`a[href$="/sessions/${sharedTriggerSessionId}"]`);
+      const ownSidebarRow = ownSidebarLink.locator('..');
+      const sharedSidebarRow = sharedSidebarLink.locator('..');
+      await expect(ownSidebarLink).toBeVisible();
       await expect(ownSidebarRow.locator('[data-session-shared="true"]')).toHaveCount(0);
-      await expect(sharedSidebarRow).toBeVisible();
-      await expect(sharedSidebarRow.getByText('Shared', { exact: true })).toBeVisible();
+      await expect(sharedSidebarLink).toBeVisible();
       await expect(sharedSidebarRow.locator('[data-session-shared="true"]')).toHaveAttribute(
         'aria-label',
         /^Shared by /,
       );
+      await expect(sharedSidebarRow.locator('[data-session-shared="true"] svg')).toHaveCount(1);
+      await expect(sharedSidebarRow.getByText('Shared', { exact: true })).toHaveCount(0);
+      const sidebarIndicators = sharedSidebarRow.locator('[data-session-indicators="true"]');
+      await expect(sidebarIndicators.locator('[data-session-shared="true"]')).toHaveCount(1);
+      await expect(sidebarIndicators.locator('[data-session-source="true"]')).toHaveCount(1);
 
       await page.goto(`/projects/${projectId}/sessions`, {
         waitUntil: 'domcontentloaded',
@@ -160,7 +166,8 @@ test.describe('21 — Trigger-created session access UI', () => {
       await expect(ownInventoryRow).toBeVisible();
       await expect(ownInventoryRow.locator('[data-session-shared="true"]')).toHaveCount(0);
       await expect(sharedInventoryRow).toBeVisible();
-      await expect(sharedInventoryRow.getByText('Shared', { exact: true })).toBeVisible();
+      await expect(sharedInventoryRow.locator('[data-session-shared="true"] svg')).toHaveCount(1);
+      await expect(sharedInventoryRow.getByText('Shared', { exact: true })).toHaveCount(0);
 
       await page.getByRole('button', { name: 'Search', exact: true }).click();
       const palette = page.getByRole('dialog');
@@ -168,7 +175,8 @@ test.describe('21 — Trigger-created session access UI', () => {
       const sharedPaletteRow = palette.locator('[cmdk-item]', {
         hasText: 'Shared scheduled session',
       });
-      await expect(sharedPaletteRow.getByText('Shared', { exact: true })).toBeVisible();
+      await expect(sharedPaletteRow.locator('[data-session-shared="true"] svg')).toHaveCount(1);
+      await expect(sharedPaletteRow.getByText('Shared', { exact: true })).toHaveCount(0);
       await page.keyboard.press('Escape');
 
       const { section } = await openTriggerAccess(page, projectId);


### PR DESCRIPTION
## Change

- Replace the visible `Shared` badge with one muted share-network icon.
- Place the sidebar icon beside the existing session source indicator.
- Keep own sessions unmarked.
- Preserve the owner label through `aria-label` and `title`.
- Use `role="img"` so assistive technology announces the label.

## Verification

- `pnpm --filter Kortix-Computer-Frontend exec bun test src/components/projects/session-shared-icon.test.tsx src/components/projects/session-label.test.ts`: 32 passed, 0 failed.
- Focused ESLint: 0 errors. Two existing command-palette hook warnings remain.
- `pnpm test`: all 5 core lanes passed in 30.4s.
- `pnpm test -- --browser-only`: 13 passed, 7 skipped, 0 failed in 57.0s.
- Trigger access browser journey: passed in 11.3s.
- Web `tsc --noEmit`: only the 15 documented Bun `test.each` baseline errors.
