### PR TITLE
fix(llm-gateway): drop trailing assistant prefill so strict backends stop failing

### DIFF
--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -677,6 +677,82 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
   });
 });
 
+describe('trailing assistant prefill is stripped across the board (one normalization fixes both errors)', () => {
+  // Reproduces two real production errors, both from a trailing assistant message
+  // (a replayed partial from a cancelled turn):
+  //   • Bedrock `global.anthropic.claude-sonnet-5` → HTTP 400 "This model does not
+  //     support assistant message prefill. The conversation must end with a user
+  //     message."
+  //   • ChatGPT-Codex `gpt-5.6-sol` → empty 200 stream → empty_completion.
+  // A conversation must end on a user/tool turn, so toModelMessages drops the
+  // trailing assistant UNCONDITIONALLY (like repairToolPairing) — every family.
+  const withTrailingAssistant = {
+    messages: [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'partial reply the client replayed' },
+    ],
+  };
+
+  for (const family of ['bedrock', 'anthropic', 'openai', 'openai-compatible'] as const) {
+    it(`${family}: strips the trailing assistant so the request ends on a user message`, () => {
+      const args = buildAiSdkArgs({ ...withTrailingAssistant }, family);
+      expect(args.messages).toHaveLength(1);
+      expect(args.messages[args.messages.length - 1].role).toBe('user');
+    });
+  }
+
+  it('codex (openai + reasoning effort): strips the trailing assistant that makes the Responses backend return empty', () => {
+    const args = buildAiSdkArgs({ ...withTrailingAssistant, reasoning_effort: 'low' }, 'openai', {
+      providerName: 'openai-codex',
+    });
+    expect(args.messages).toHaveLength(1);
+    expect(args.messages[0].role).toBe('user');
+  });
+
+  it('strips multiple consecutive trailing assistant turns, keeps the last user/tool turn', () => {
+    const args = buildAiSdkArgs(
+      {
+        messages: [
+          { role: 'user', content: 'q' },
+          { role: 'assistant', content: 'a1' },
+          { role: 'assistant', content: 'a2' },
+        ],
+      },
+      'bedrock',
+    );
+    expect(args.messages).toHaveLength(1);
+    expect(args.messages[0].role).toBe('user');
+  });
+
+  it('a conversation already ending on a user turn is untouched', () => {
+    const args = buildAiSdkArgs(
+      { messages: [{ role: 'assistant', content: 'hi' }, { role: 'user', content: 'go' }] },
+      'openai',
+    );
+    expect(args.messages).toHaveLength(2);
+    expect(args.messages[args.messages.length - 1].role).toBe('user');
+  });
+
+  it('bedrock: the prompt-cache breakpoint lands on the surviving user turn, not a removed assistant', () => {
+    const args = buildAiSdkArgs({ ...withTrailingAssistant }, 'bedrock');
+    const last = args.messages[args.messages.length - 1] as {
+      role: string;
+      providerOptions?: { bedrock?: { cachePoint?: unknown } };
+    };
+    expect(last.role).toBe('user');
+    expect(last.providerOptions?.bedrock?.cachePoint).toEqual({ type: 'default' });
+  });
+
+  it('never strips down to an empty conversation (all-assistant history is left for the upstream)', () => {
+    const args = buildAiSdkArgs(
+      { messages: [{ role: 'assistant', content: 'only' }] },
+      'bedrock',
+    );
+    expect(args.messages).toHaveLength(1);
+    expect(args.messages[0].role).toBe('assistant');
+  });
+});
+
 describe('ai-sdk anthropic/bedrock prompt caching (ported from native)', () => {
   it('anthropic: attaches cacheControl to the system prompt, the last tool, and the last message', () => {
     const args = buildAiSdkArgs(

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -172,6 +172,26 @@ function repairToolPairing(messages: ModelMessage[]): ModelMessage[] {
   return out;
 }
 
+// A conversation must end on a user/tool turn. A TRAILING ASSISTANT message (a
+// "prefill") wedges strict backends across the board — Bedrock/Anthropic
+// reasoning Claude 400s ("This model does not support assistant message prefill.
+// The conversation must end with a user message.") and the ChatGPT-Codex
+// Responses backend returns an empty 200 stream (surfacing as empty_completion).
+// It reaches the gateway when a turn is cancelled mid-generation and the client
+// replays the half-finished assistant turn in history — the same replayed-partial
+// failure mode `repairToolPairing` and the empty-content backfill already repair.
+// Drop the trailing assistant turn(s) so the request ends on a user/tool message.
+// Applied UNCONDITIONALLY in toModelMessages, like repairToolPairing: it only ever
+// makes a request MORE valid (no provider requires a trailing assistant, and agent
+// flows never intend one). Pure + non-mutating. Never strips to empty (an
+// all-assistant history is degenerate — leave it for the upstream to reject).
+function stripTrailingAssistantPrefill(messages: ModelMessage[]): ModelMessage[] {
+  let end = messages.length;
+  while (end > 0 && messages[end - 1].role === 'assistant') end--;
+  if (end === messages.length || end === 0) return messages;
+  return messages.slice(0, end);
+}
+
 // OpenAI chat.completions messages → AI SDK ModelMessage[]. System messages are
 // hoisted into `system` (kept separate so provider prompt-caching works). The
 // role/tool-call/tool-result shape mirrors what the native transports build, but
@@ -245,7 +265,7 @@ export function toModelMessages(rawMessages: unknown): {
 
   return {
     system: systemParts.filter(Boolean).join('\n\n') || undefined,
-    messages: repairToolPairing(out),
+    messages: stripTrailingAssistantPrefill(repairToolPairing(out)),
   };
 }
 


### PR DESCRIPTION
## Problem

Two production gateway errors, both from the **same malformed history** — a conversation that ends with a trailing **assistant message** (a "prefill", i.e. a replayed partial from a cancelled turn):

1. `amazon-bedrock/global.anthropic.claude-sonnet-5` → **HTTP 400** · "This model does not support assistant message prefill. The conversation must end with a user message." (reasoning Claude on Bedrock/Anthropic rejects a trailing assistant).
2. `openai-codex/gpt-5.6-sol` → **empty_completion** · "Upstream stream closed before producing usable content" (×3) — the ChatGPT-Codex Responses backend returns an empty 200 stream on a trailing-assistant history; the single candidate is retried 3× and the route exhausts.

## Fix

One normalization at the single request-build point. `toModelMessages` (`transports/ai-sdk/request.ts`) now runs `stripTrailingAssistantPrefill` **unconditionally**, right after the existing `repairToolPairing` — dropping trailing assistant turn(s) so every provider's request ends on a user/tool turn.

- **Across the board**: no family/thinking/provider gating. Bedrock, Anthropic, OpenAI, codex, openai-compatible all get a well-formed tail.
- **Only ever more valid**: no provider requires a trailing assistant, and agent/opencode flows never intend one (a trailing assistant is always a replayed partial). Same philosophy as `repairToolPairing` and the empty-content backfill already applied here.
- **Never strips to empty**: an all-assistant history is left for the upstream to reject rather than sending an empty conversation.

Core change is a single line plus a small pure helper:
```
-    messages: repairToolPairing(out),
+    messages: stripTrailingAssistantPrefill(repairToolPairing(out)),
```

## Verification
- `bun test` (packages/llm-gateway): **406 pass, 0 fail** (9 new tests covering bedrock/anthropic/openai/openai-compatible/codex strip, multi-trailing, already-ends-on-user no-op, cache-breakpoint lands on the surviving user turn, and the never-strip-to-empty guard). No existing test regressed — nothing relied on preserving a trailing assistant.
- `tsc --noEmit`: clean.

Not in scope (per "simplest fix that just works"): the codex reasoning-summary/encrypted-content include and the slow-first-byte probe floor for `gpt-5.6-sol` are separate latent items, not the reported failures.
