### PR TITLE
fix(llm-gateway): stop 413-ing large multimodal requests; raise body ceiling to 1 GiB

### DIFF
--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -382,18 +382,21 @@ describe('full self-host Docker distribution', () => {
     const vector = document.services['supabase-vector'];
     expect(analytics?.oom_score_adj).toBeGreaterThan(0);
     expect(vector?.oom_score_adj).toBeGreaterThan(0);
-    // The full worst-case (every STEADY-STATE service simultaneously at its
-    // own ceiling) must still fit comfortably on an 8GB box — these are
-    // circuit-breaker ceilings, not a steady-state budget, but they must not
-    // be so generous that the documented floor is fiction. kortix-migrate is
-    // excluded: it's a one-shot job that runs to completion and exits before
-    // the app tier is ever rolled, never concurrent with the rest at steady
-    // state (see kortix-compose.yml: `restart: "no"`).
+    // The full worst-case (every STEADY-STATE service simultaneously at its own
+    // ceiling) must still fit a modern self-host box — these are circuit-breaker
+    // ceilings, not a steady-state budget (reservations, which schedule the box,
+    // sum far lower), but they must not be so generous the documented floor is
+    // fiction. The floor is 12GB: the llm-gateway carries a deliberately large
+    // 2GB ceiling so an image-heavy multimodal turn (bodies of tens of MiB, see
+    // DEFAULT_MAX_REQUEST_BYTES) can never OOM it; a small-box operator dials that
+    // back with KORTIX_GATEWAY_MEMORY_LIMIT. kortix-migrate is excluded: it's a
+    // one-shot job that exits before the app tier is ever rolled, never concurrent
+    // with the rest at steady state (see kortix-compose.yml: `restart: "no"`).
     const totalCeilingMb = Object.entries(document.services)
       .filter(([name]) => name !== 'kortix-migrate')
       .map(([, service]) => (service.mem_limit ? toMb(service.mem_limit) : 0))
       .reduce((a, b) => a + b, 0);
-    expect(totalCeilingMb).toBeLessThan(8 * 1024);
+    expect(totalCeilingMb).toBeLessThan(12 * 1024);
   });
 
   test('kortix-updater image is pinned by digest, never :latest or a bare floating :cli tag', () => {

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -447,7 +447,12 @@ interface MemSpec {
 const MEM_LIMITS: Readonly<Record<string, MemSpec>> = {
   'supabase-db': { limit: '1280m', reservation: '512m', oomScoreAdj: -900 },
   'kortix-api': { limit: '${KORTIX_API_MEMORY_LIMIT:-640m}', reservation: '256m' },
-  'llm-gateway': { limit: '512m', reservation: '128m' },
+  // Headroom for large multimodal requests: the gateway buffers the raw request
+  // body (image-heavy agent turns run tens of MiB — see DEFAULT_MAX_REQUEST_BYTES),
+  // so 512m was far too tight once the body ceiling was raised. Give it a generous
+  // 2 GiB default so a big image-heavy turn never OOM-kills the gateway; small
+  // boxes can dial it back via KORTIX_GATEWAY_MEMORY_LIMIT.
+  'llm-gateway': { limit: '${KORTIX_GATEWAY_MEMORY_LIMIT:-2048m}', reservation: '256m' },
   frontend: { limit: '512m', reservation: '128m' },
   'kortix-migrate': { limit: '512m', reservation: '128m' },
   'kortix-updater': { limit: '256m', reservation: '64m' },

--- a/packages/llm-gateway/src/domain/config.test.ts
+++ b/packages/llm-gateway/src/domain/config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'bun:test';
+import { DEFAULT_MAX_REQUEST_BYTES } from './config';
+
+describe('DEFAULT_MAX_REQUEST_BYTES', () => {
+  it('is high enough that real multimodal (image-heavy) agent turns never 413', () => {
+    // Regression guard: the gateway must not be what rejects a large-but-legit
+    // request. Self-host measured 9-12 MiB turns 413'd at the old 8 MiB ceiling;
+    // image-heavy turns run larger still. Keep the default far above that so the
+    // upstream — not the gateway — enforces any real size limit.
+    expect(DEFAULT_MAX_REQUEST_BYTES).toBeGreaterThanOrEqual(1024 * 1024 * 1024);
+  });
+});

--- a/packages/llm-gateway/src/domain/config.ts
+++ b/packages/llm-gateway/src/domain/config.ts
@@ -1,7 +1,14 @@
 import type { CircuitBreakerOptions, RetryOptions } from '../resilience';
 
-/** Allows proven 2 MiB prompts while bounding accidental/untrusted payloads. */
-export const DEFAULT_MAX_REQUEST_BYTES = 8 * 1024 * 1024;
+// The gateway must NOT be the thing that rejects a real request for being large.
+// Multimodal agent turns carrying many base64 images plus long history routinely
+// run tens of MiB (measured: 9-12 MiB turns on self-host 413'd at the old 8 MiB
+// ceiling), and there is no reason to cap below what the upstream itself accepts —
+// let the upstream enforce its own real limit. This ceiling exists ONLY as a last
+// backstop against a truly runaway payload OOMing the gateway, so set it 1 GiB:
+// far above any legitimate request, so image-heavy turns just work. Hosts can
+// override with GATEWAY_MAX_REQUEST_BYTES (0 disables the check entirely).
+export const DEFAULT_MAX_REQUEST_BYTES = 1024 * 1024 * 1024;
 
 export interface GatewayConfig {
   retry?: RetryOptions;


### PR DESCRIPTION
## Problem

Self-host Essentia logged **~50 `413 request_too_large` in 3 hours** — real image-heavy agent turns of **9–12 MiB** rejected against the gateway's old **8 MiB** `DEFAULT_MAX_REQUEST_BYTES`. The 8 MiB default ("allows proven 2 MiB prompts") predates modern multimodal agent contexts.

## Fix

The gateway must not be the thing that rejects a large-but-legitimate request — the upstream enforces its own real size limit. Two changes:

1. **`DEFAULT_MAX_REQUEST_BYTES`: 8 MiB → 1 GiB** (`packages/llm-gateway/src/domain/config.ts`). Far above any legitimate request, so image-heavy turns just work; still a backstop against a truly runaway payload OOMing the gateway. Hosts override with `GATEWAY_MAX_REQUEST_BYTES` (0 disables the check).
2. **Self-host gateway memory: 512 m → configurable `${KORTIX_GATEWAY_MEMORY_LIMIT:-2048m}`** (`apps/cli/src/self-host/compose-assets.ts`) so buffering a big body can't OOM the gateway. The self-host worst-case *ceiling* floor rises 8 GB → 12 GB (these are burst ceilings, not steady-state reservations; small boxes dial the gateway back via the env var).

## Verification
- `packages/llm-gateway` `bun test`: **407 pass, 0 fail** (new `domain/config.test.ts` regression-guards the ceiling at ≥ 1 GiB).
- `apps/cli` compose-assets `bun test`: **51 pass, 0 fail** (mem-budget assertion updated to the 12 GB floor).
- `tsc --noEmit` clean in both packages.
- Applied live on Essentia as an interim env override; will be superseded by this default once the box resyncs from dev-latest.

## Other self-host log entries reviewed (no code change needed)
- `[slack-webhook] turn-end relay dropped — no open turn` — by design (diagnostic warn for a late error-idle after the turn already finalized).
- `502 port not ready` / caddy `502` — transient session/sandbox cold-boot and the brief api-recreate window; not persistent failures.
