### PR TITLE
fix(sdk): stop pinning content-length when forwarding a request

### DIFF
--- a/packages/sdk/src/node/server.test.ts
+++ b/packages/sdk/src/node/server.test.ts
@@ -177,7 +177,11 @@ test('forwardKortixRequest owns wrapper authentication, body buffering, and resp
   expect(forwardedRequest!.headers.get('authorization')).toBe('Bearer kortix-operator-token');
   expect(forwardedRequest!.headers.get('cookie')).toBeNull();
   expect(forwardedRequest!.headers.get('accept-encoding')).toBe('identity');
-  expect(forwardedRequest!.headers.get('content-length')).toBe('17');
+  // Deliberately NOT set: undici derives it from the body, and pinning it made
+  // every bodied request a wrapper forwards throw `invalid content-length
+  // header`, which the helper swallowed into a bare 502. The body still arrives
+  // intact, which is the property that actually matters.
+  expect(forwardedRequest!.headers.get('content-length')).toBeNull();
   expect(await forwardedRequest!.text()).toBe('{"hello":"world"}');
 
   expect(response.status).toBe(202);

--- a/packages/sdk/src/node/server.ts
+++ b/packages/sdk/src/node/server.ts
@@ -58,7 +58,20 @@ export async function forwardKortixRequest(options: {
 
   const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
   const body = hasBody ? await request.arrayBuffer() : undefined;
-  if (body) headers.set('content-length', String(body.byteLength));
+  /*
+   * `content-length` is NOT set back on.
+   *
+   * undici derives it from the body, and setting it explicitly made every
+   * bodied request through a wrapper proxy fail with
+   * `InvalidArgumentError: invalid content-length header` (UND_ERR_INVALID_ARG)
+   * — the throw is swallowed below and returned as a bare
+   * `502 Upstream request failed`, with the real cause nowhere in the response.
+   *
+   * That is not a corner: it is every POST, PUT and PATCH a wrapper forwards.
+   * A chat panel could list sessions and read config over GET and then failed
+   * the moment it tried to CREATE a session, which reads as "the agent is
+   * broken" rather than "the proxy cannot send a body".
+   */
 
   let upstreamResponse: Response;
   try {


### PR DESCRIPTION
## The bug

`forwardKortixRequest` buffers the request body and then sets `content-length` from its byte length:

```ts
const body = hasBody ? await request.arrayBuffer() : undefined;
if (body) headers.set('content-length', String(body.byteLength));
```

undici derives `content-length` from the body itself and **rejects an explicitly supplied one**:

```
InvalidArgumentError: invalid content-length header   (UND_ERR_INVALID_ARG)
```

That throw lands in the helper's own `try/catch` and returns a bare `502 Upstream request failed`. The real cause appears nowhere in the response, so the wrapper looks like it cannot reach Kortix at all.

## Why it matters more than it looks

This is not a corner case — it is **every POST, PUT and PATCH any wrapper forwards**. GETs are unaffected, which makes the symptom actively misleading: a dashboard chat panel could list sessions and read config perfectly, then fail the instant it tried to *create* a session. That reads as "the agent is broken", not "the proxy cannot send a body", and it cost a long debugging session before the undici error was found underneath the 502.

## Verification

Proven both directions against a live upstream: with the header set, the request throws; with it removed, the same request returns `201`.

The test previously asserted `content-length` was `'17'`. It now asserts the header is absent **and** that the body still arrives intact — the second half is the property that actually matters, and it is what makes the removal safe rather than merely quiet.

`packages/sdk/src/node/server.test.ts` — 6 pass.

## Note

`headers.delete('content-length')` a few lines above (stripping the *inbound* header) is untouched and still correct. This only removes the explicit re-set.