### PR TITLE
fix(manifest): refuse reserved App env names in validate, not only at deploy

### DIFF
--- a/apps/api/src/projects/lib/sandbox-env-names.ts
+++ b/apps/api/src/projects/lib/sandbox-env-names.ts
@@ -1,7 +1,11 @@
-const RESERVED_SANDBOX_ENV_NAMES = new Set([
-  'PORT', 'PATH', 'HOME', 'PWD', 'USER', 'LOGNAME', 'SHELL', 'HOSTNAME',
-  'TERM', 'TMPDIR', 'NODE_ENV', 'NODE_OPTIONS', 'LD_PRELOAD', 'LD_LIBRARY_PATH',
-]);
+// Imported, not restated. `kortix validate` has to refuse exactly what deploy
+// refuses — when the two lists drifted, a manifest setting `KORTIX_API_KEY`
+// validated clean and then failed at deploy, and the App that shipped without
+// those variables did not error at all: the feature that needed them simply
+// rendered nothing. One list, in the contract package both sides depend on.
+import { RESERVED_ENV_NAMES } from '@kortix/manifest-schema';
+
+const RESERVED_SANDBOX_ENV_NAMES = RESERVED_ENV_NAMES;
 
 // Secrets the sandbox must NEVER see, even though the platform holds them.
 // Boot (buildSessionSandboxEnvVars) deletes SLACK_BOT_TOKEN explicitly to keep

--- a/packages/manifest-schema/src/__tests__/app-env-reserved.test.ts
+++ b/packages/manifest-schema/src/__tests__/app-env-reserved.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `kortix validate` must refuse exactly the App env names that deploy refuses.
+ *
+ * WHY THIS FILE EXISTS
+ *
+ * These two checks lived in different packages and drifted. The validator
+ * accepted any uppercase name; the API refused reserved ones when it built the
+ * deployment environment. So a `kortix.yaml` setting `KORTIX_API_KEY` passed
+ * `kortix validate` and failed at deploy — and the version that eventually
+ * shipped without those variables did not error at all, because the feature
+ * that read them just rendered nothing. The App looked fine and was missing a
+ * whole panel.
+ *
+ * The rule now lives in `constants.ts` and `apps/api` imports it. These tests
+ * are what stop someone adding a name to one side only.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  isReservedEnvName,
+  NEVER_DELIVERED_ENV_NAMES,
+  RESERVED_ENV_NAME_PREFIXES,
+  RESERVED_ENV_NAMES,
+  reservedEnvNameReason,
+  validateManifest,
+} from '../index.ts';
+
+/**
+ * A complete, otherwise-valid v2 manifest with one App — `apps:` is a v2
+ * section, and the App's fields are copied from `essentia-kortix/kortix.yaml`,
+ * the manifest whose `KORTIX_*` names validated clean and then failed to
+ * deploy.
+ */
+function appManifest(env: Record<string, string>, key: 'env' | 'secrets' = 'env'): string {
+  const block = Object.entries(env)
+    .map(([name, value]) => `      ${name}: ${JSON.stringify(value)}`)
+    .join('\n');
+
+  return `
+kortix_version: 2
+default_agent: support
+runtime: opencode
+
+project:
+  name: acme
+  description: Fixture
+
+agents:
+  support: {}
+
+apps:
+  dashboards:
+    type: dockerfile
+    dockerfile: Dockerfile
+    command:
+      - ./docker-entrypoint.sh
+    port: 3000
+    ${key}:
+${block}
+`;
+}
+
+function errors(input: string): string[] {
+  // 'yaml' explicitly: `validateManifest` defaults to TOML, and v2 manifests
+  // are YAML-only.
+  return validateManifest(input, 'yaml')
+    .issues.filter((issue) => issue.severity === 'error')
+    .map((issue) => `${issue.path}: ${issue.message}`);
+}
+
+describe('reserved App environment names', () => {
+  test('the platform prefixes are refused by validate, not only by deploy', () => {
+    for (const prefix of RESERVED_ENV_NAME_PREFIXES) {
+      const name = `${prefix}API_KEY`;
+      const found = errors(appManifest({ [name]: 'x' }));
+      expect(found.some((message) => message.includes(name)), name).toBe(true);
+    }
+  });
+
+  test('the message says what to do, not merely that it is wrong', () => {
+    // An author who reads "is reserved" and nothing else renames it to
+    // something else reserved. The one that bit us is worth naming exactly.
+    const [message] = errors(appManifest({ KORTIX_API_KEY: 'x' }));
+    expect(message).toContain('KORTIX_');
+    expect(message).toMatch(/rename/i);
+  });
+
+  test('names the runtime sets itself are refused', () => {
+    for (const name of ['PORT', 'PATH', 'NODE_ENV', 'LD_PRELOAD']) {
+      expect(RESERVED_ENV_NAMES.has(name), name).toBe(true);
+      expect(errors(appManifest({ [name]: '3000' })).length, name).toBeGreaterThan(0);
+    }
+  });
+
+  test('secrets are checked on the same rule as plain values', () => {
+    // `secrets:` maps an env name to a project-secret identifier. The
+    // DESTINATION is still an env name, so the same names are illegal — and
+    // this half was the one actually used in the manifest that failed.
+    expect(errors(appManifest({ KORTIX_API_KEY: 'SOME_SECRET' }, 'secrets')).length).toBeGreaterThan(0);
+  });
+
+  test('secrets the platform never delivers are refused up front', () => {
+    for (const name of NEVER_DELIVERED_ENV_NAMES) {
+      expect(errors(appManifest({ [name]: 'SOME_SECRET' }, 'secrets')).length, name).toBeGreaterThan(0);
+    }
+  });
+
+  test('an ordinary name is still accepted', () => {
+    // The prefixed name we actually shipped with, so the fix cannot have made
+    // the working configuration invalid.
+    const found = errors(appManifest({
+      DASHBOARDS_KORTIX_API_KEY: 'x',
+      DASHBOARDS_DATABASE_URL: 'postgres://…',
+      PORTAL_URL: 'https://example.com',
+    }));
+    expect(found).toEqual([]);
+  });
+
+  test('a reserved prefix is only reserved at the START of the name', () => {
+    // `PORTAL_URL` starts with the letters of `PORT` and must not be caught by
+    // the exact-name set; `MY_KORTIX_KEY` contains the prefix but does not
+    // start with it.
+    expect(isReservedEnvName('PORTAL_URL')).toBe(false);
+    expect(isReservedEnvName('MY_KORTIX_KEY')).toBe(false);
+    expect(isReservedEnvName('KORTIX_KEY')).toBe(true);
+  });
+
+  test('reservedEnvNameReason answers for exactly the names isReservedEnvName refuses', () => {
+    for (const name of ['KORTIX_A', 'OPENCODE_B', 'PORT', 'SLACK_BOT_TOKEN', 'FINE_NAME']) {
+      expect(reservedEnvNameReason(name) !== null, name).toBe(isReservedEnvName(name));
+    }
+  });
+});

--- a/packages/manifest-schema/src/__tests__/validator.test.ts
+++ b/packages/manifest-schema/src/__tests__/validator.test.ts
@@ -717,6 +717,12 @@ base_url = "https://example.com"
 });
 
 describe('validateManifest — Kortix Apps', () => {
+  // This fixture used to set `NODE_ENV` here. It was never deployable: the API
+  // refuses reserved env names when it builds a deployment's environment, and
+  // `NODE_ENV` is on that list. The validator simply did not know, so the
+  // fixture encoded a manifest that passed `validate` and failed `deploy` —
+  // the exact drift `app-env-reserved.test.ts` now prevents. Renamed rather
+  // than deleted, because what this test is actually about is the v2 App map.
   test('rejects the retired v1 section and accepts the provider-neutral v2 map', () => {
     expect(summarize('kortix_version = 1\n[[apps]]\nslug = "site"').errorPaths).toContain('apps');
     const v2 = validateManifest(
@@ -738,7 +744,7 @@ apps:
       memory_gb: 2
       disk_gb: 10
     env:
-      NODE_ENV: production
+      APP_MODE: production
     secrets:
       DATABASE_URL: DATABASE_URL`,
       'yaml',

--- a/packages/manifest-schema/src/constants.ts
+++ b/packages/manifest-schema/src/constants.ts
@@ -17,6 +17,66 @@ export const SLUG_RE = /^[a-z0-9][a-z0-9_-]{0,127}$/;
 /** Regex matching every legal env-var name. */
 export const ENV_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
 
+/**
+ * Env-var names the runtime owns, which a manifest may therefore not set.
+ *
+ * WHY THIS LIVES IN THE MANIFEST SCHEMA
+ *
+ * The API refuses these when it builds a deployment's environment
+ * (`resolveAppRuntimeEnvironment` → `assertDestination`). For a long time the
+ * manifest validator did not, so `kortix validate` passed on a manifest that
+ * could never deploy, and the author found out from a failed deploy instead of
+ * from the tool whose entire job is to tell them first.
+ *
+ * That is not a hypothetical: a `kortix.yaml` setting `KORTIX_API_KEY`
+ * validated clean and failed at deploy, and the App that eventually shipped
+ * without those variables did not error at all — the feature depending on them
+ * simply rendered nothing.
+ *
+ * So the rule lives here, in the contract package both sides already depend
+ * on, and `apps/api` imports it rather than restating it.
+ */
+export const RESERVED_ENV_NAME_PREFIXES = ['KORTIX_', 'OPENCODE_'] as const;
+
+/** Process-level names the sandbox sets itself; overriding them breaks boot. */
+export const RESERVED_ENV_NAMES: ReadonlySet<string> = new Set([
+  'PORT', 'PATH', 'HOME', 'PWD', 'USER', 'LOGNAME', 'SHELL', 'HOSTNAME',
+  'TERM', 'TMPDIR', 'NODE_ENV', 'NODE_OPTIONS', 'LD_PRELOAD', 'LD_LIBRARY_PATH',
+]);
+
+/**
+ * Secrets the platform holds but must never hand to a runtime, because an
+ * agent reachable by prompt injection would then be holding them too.
+ */
+export const NEVER_DELIVERED_ENV_NAMES: ReadonlySet<string> = new Set([
+  'SLACK_SIGNING_SECRET',
+  'SLACK_BOT_TOKEN',
+]);
+
+/** Is this name one the runtime owns? Used by both `validate` and deploy. */
+export function isReservedEnvName(name: string): boolean {
+  return (
+    RESERVED_ENV_NAMES.has(name) ||
+    NEVER_DELIVERED_ENV_NAMES.has(name) ||
+    RESERVED_ENV_NAME_PREFIXES.some((prefix) => name.startsWith(prefix))
+  );
+}
+
+/** Why a name is refused, phrased for the person who wrote the manifest. */
+export function reservedEnvNameReason(name: string): string | null {
+  const prefix = RESERVED_ENV_NAME_PREFIXES.find((candidate) => name.startsWith(candidate));
+  if (prefix) {
+    return `is reserved: the \`${prefix}\` prefix belongs to the platform. Rename it (for example \`MYAPP_${name.slice(prefix.length)}\`) and read it under the new name.`;
+  }
+  if (NEVER_DELIVERED_ENV_NAMES.has(name)) {
+    return 'is reserved: the platform never delivers this secret to a runtime.';
+  }
+  if (RESERVED_ENV_NAMES.has(name)) {
+    return 'is reserved: the runtime sets this itself, and overriding it breaks the sandbox.';
+  }
+  return null;
+}
+
 export const TRIGGER_TYPES = ['cron', 'webhook', 'monitor'] as const;
 
 /**

--- a/packages/manifest-schema/src/index.ts
+++ b/packages/manifest-schema/src/index.ts
@@ -29,6 +29,7 @@ import {
   GRANTABLE_KORTIX_CLI_ACTIONS,
   LEGACY_SANDBOX_KEYS,
   LEGACY_TOLERATED_KORTIX_CLI_ACTIONS,
+  reservedEnvNameReason,
   MONITOR_MIN_EXPECT_EVENT_WITHIN_SECONDS,
   MONITOR_MIN_INTERVAL_SECONDS,
   MONITOR_MODES,
@@ -97,8 +98,13 @@ export {
   HEX_COLOR_RE_V2,
   LEGACY_SANDBOX_KEYS,
   LEGACY_TOLERATED_KORTIX_CLI_ACTIONS,
+  isReservedEnvName,
+  NEVER_DELIVERED_ENV_NAMES,
   PERMISSION_ACTION_ONLY_KEYS_V2,
   PERMISSION_ACTIONS_V2,
+  RESERVED_ENV_NAME_PREFIXES,
+  RESERVED_ENV_NAMES,
+  reservedEnvNameReason,
   RESERVED_SANDBOX_SLUG,
   RESERVED_SLUG_PROVIDERS,
   MONITOR_MIN_EXPECT_EVENT_WITHIN_SECONDS,
@@ -771,6 +777,15 @@ function validateAppStringMap(
     const where = `${path}.${key}`;
     if (validateKey && !ENV_NAME_RE.test(key)) {
       issues.push({ path: where, message: 'key must be an uppercase environment variable name.', severity: 'error' });
+    }
+    // The deploy path refuses these (`resolveAppRuntimeEnvironment` →
+    // `assertDestination`). Without the same check here, `validate` passes on a
+    // manifest that cannot deploy — which is the one job this command has.
+    if (validateKey) {
+      const reason = reservedEnvNameReason(key);
+      if (reason) {
+        issues.push({ path: where, message: `key "${key}" ${reason}`, severity: 'error' });
+      }
     }
     if (typeof value !== 'string' || value.trim() === '') {
       issues.push({ path: where, message: 'must be a non-empty string.', severity: 'error' });


### PR DESCRIPTION
## The drift

Two checks lived in different packages and disagreed.

`kortix validate` (`manifest-schema`) checked only that an App env key matched `ENV_NAME_RE` — any uppercase name passed. The API separately refuses reserved names when it builds a deployment's environment (`resolveAppRuntimeEnvironment` → `assertDestination`, which rejects the `KORTIX_`/`OPENCODE_` prefixes, the process-level names the sandbox sets itself, and the secrets the platform never delivers).

So a `kortix.yaml` setting `KORTIX_API_KEY` **validated clean and failed at deploy** — from the one command whose entire job is to tell you first.

## The follow-on was worse than the failed deploy

The App that eventually shipped *without* those variables did not error at all. The code reading them returned `null`, and the chat panel simply rendered nothing. A misconfiguration `validate` had already been shown became an App that looked healthy in the control plane and was missing a whole feature — much harder to find than a build failure.

## The fix

The rule moves into `@kortix/manifest-schema` — the contract package **both sides already depend on** — and `apps/api/src/projects/lib/sandbox-env-names.ts` imports it rather than restating it. One list, so they cannot drift again.

Errors now say what to do:

```
apps.dashboards.env.KORTIX_API_KEY: key "KORTIX_API_KEY" is reserved: the
`KORTIX_` prefix belongs to the platform. Rename it (for example
`MYAPP_API_KEY`) and read it under the new name.
```

`secrets:` is validated on the same rule — the *destination* of a secret mapping is still an env name, and that was the half the manifest that failed actually used.

## One fixture had to change

`validator.test.ts` set `NODE_ENV` in an App's `env`. **That was never deployable** — `NODE_ENV` is on the reserved list and the API would have refused it; the validator just didn't know. Renamed to `APP_MODE` with a comment explaining why, since what that test is actually about is the v2 App map.

Worth a separate decision, not made here: that reserved list was designed for *agent sandboxes*, where overriding `NODE_ENV` breaks the runtime. For a containerised App, `NODE_ENV` is arguably the app's own business. I did not relax the API's rule unilaterally — this PR only makes `validate` agree with what deploy already does.

## Verification

- `packages/manifest-schema` — **372 pass**, 0 fail (8 new tests in `app-env-reserved.test.ts`, including that `PORTAL_URL` and `MY_KORTIX_KEY` are *not* caught — the prefix is only reserved at the start).
- `apps/api` `src/apps` + `src/projects` — **1354 pass**, 0 fail.
- Both packages typecheck.
- The real `essentia-kortix/kortix.yaml` validates with **0 errors**; inserting `KORTIX_API_KEY` into it produces exactly the message above.