### PR TITLE
Connectors: no Pipedream on this deployment, no Discovery tab

### DIFF
--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/use-catalog.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/use-catalog.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  getConnectStatus,
   listDiscoverConnectors,
   listPipedreamApps,
   listPipedreamSections,
@@ -14,8 +15,8 @@ import { useDebounce } from '@/hooks/use-debounce';
 import {
   catalogEntryFromDiscover,
   catalogEntryFromEasyConnect,
-  computersCatalogEntry,
   catalogSections,
+  computersCatalogEntry,
   type CatalogEntry,
   type CatalogSource,
 } from './catalog-entry';
@@ -84,6 +85,50 @@ export interface CatalogState {
 }
 
 /**
+ * What this DEPLOYMENT knows about Easy Connect (Pipedream).
+ *
+ * `absent` is the only actionable answer: it means the surface must not be
+ * offered at all. `unknown` and `asking` both mean "carry on as before" — one
+ * because the probe has not answered yet, the other because it never will.
+ */
+export type PipedreamStatus = 'asking' | 'configured' | 'absent' | 'unknown';
+
+/**
+ * Is Easy Connect (Pipedream) configured on this deployment?
+ *
+ * `listPipedreamApps` / `listPipedreamSections` are wired into the API router
+ * only when `pipedreamConfigured()` is true — three env vars, checked in
+ * `apps/api/src/connectors/pipedream.ts`. Without them every call answers
+ * `501 FEATURE_NOT_SUPPORTED`, and a self-host that never set them is the
+ * entire population of that branch. The page used to spend a request per load
+ * discovering that, then paint the generic "Server error … (501)" card over a
+ * catalogue it could never have had.
+ *
+ * **Deployment-wide, so it is keyed without the project** — `['connect-status']`
+ * is the same entry `customize/sections/connectors-view.tsx` reads, so the two
+ * surfaces share one request — and it never goes stale: the answer is an
+ * environment variable on the server and cannot change while the tab is open.
+ *
+ * **Not retried.** A probe that cannot run is not evidence that the provider is
+ * missing, so a failure resolves to `unknown` and the catalogue proceeds. Three
+ * backed-off retries would only hold the grid on skeletons for seconds before
+ * reaching the same conclusion.
+ */
+export function usePipedreamStatus(enabled: boolean): PipedreamStatus {
+  const query = useQuery({
+    queryKey: ['connect-status'],
+    queryFn: getConnectStatus,
+    staleTime: Infinity,
+    retry: false,
+    enabled,
+  });
+  if (!enabled) return 'unknown';
+  if (query.isSuccess) return query.data.configured ? 'configured' : 'absent';
+  if (query.isError) return 'unknown';
+  return 'asking';
+}
+
+/**
  * The catalogue behind the Discovery and All tabs, from whichever of the two
  * sources this project actually has.
  *
@@ -107,6 +152,14 @@ export interface CatalogState {
  * `category` are query keys, so changing either starts a new list rather than
  * re-slicing an accumulated one. Pipedream's own API cannot filter by category
  * at all — see `apps/api/src/connectors/pipedream-index.ts`.
+ *
+ * **Easy Connect waits for the deployment probe.** No Pipedream request is sent
+ * until `usePipedreamStatus` has ruled out `absent`, because on a deployment
+ * without Pipedream credentials every one of them is a `501` — and one landing
+ * before the probe would paint the error card the probe exists to prevent. The
+ * cost is one round trip on the first load of the session, spent on a route that
+ * only reads env vars, and the wait is reported as `isLoading` so the grid holds
+ * its skeletons instead of flashing an empty result.
  */
 export function useCatalog(
   projectId: string,
@@ -122,6 +175,19 @@ export function useCatalog(
   const source: CatalogSource = opts.discoverEnabled ? 'discover' : 'easy-connect';
   const category = opts.focusCategory ?? null;
   const searching = activeQuery.length > 0;
+
+  // Probed whenever Easy Connect is the source, whether or not the catalogue is
+  // `enabled`. `ConnectorsPage` turns Discovery and All OFF when this answers
+  // `absent`, which turns `enabled` off with them — a probe gated on `enabled`
+  // would then have nothing left to keep it answered, and the tabs would
+  // oscillate. It is one cached request either way.
+  const pipedreamStatus = usePipedreamStatus(source === 'easy-connect');
+
+  // `unknown` proceeds: the probe failed, and refusing to load a catalogue that
+  // may well exist is the worse of the two mistakes.
+  const easyConnectRunnable =
+    source === 'easy-connect' &&
+    (pipedreamStatus === 'configured' || pipedreamStatus === 'unknown');
 
   const discoverQuery = useInfiniteQuery({
     queryKey: ['discover-connectors', projectId, activeQuery],
@@ -146,7 +212,7 @@ export function useCatalog(
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (last) => (last.hasMore ? last.nextCursor : undefined),
     staleTime: 60_000,
-    enabled: opts.enabled && source === 'easy-connect',
+    enabled: opts.enabled && easyConnectRunnable,
     placeholderData: keepPreviousData,
   });
 
@@ -161,7 +227,7 @@ export function useCatalog(
         maxCategories: SECTION_COUNT,
       }),
     staleTime: 5 * 60_000,
-    enabled: opts.enabled && source === 'easy-connect' && !searching && category === null,
+    enabled: opts.enabled && easyConnectRunnable && !searching && category === null,
   });
 
   const active = source === 'discover' ? discoverQuery : easyConnectQuery;
@@ -261,7 +327,16 @@ export function useCatalog(
     // `isLoading` is the COLD state only — no cards on screen at all. A search
     // over a populated catalogue keeps its results and reports `isRefreshing`,
     // so the grid dims instead of blanking to skeletons.
-    isLoading: opts.enabled && (active.isLoading || (showingSections && sectionsQuery.isLoading)),
+    //
+    // `asking` counts as loading: the Easy Connect queries are held disabled
+    // until the deployment probe answers, and a disabled query reports neither
+    // loading nor data — without this the grid would render "no results" for a
+    // round trip before the real request had started.
+    isLoading:
+      opts.enabled &&
+      (pipedreamStatus === 'asking' ||
+        active.isLoading ||
+        (showingSections && sectionsQuery.isLoading)),
     isRefreshing: opts.enabled && isPlaceholderData,
     isError: active.isError,
     error: active.error,

--- a/apps/web/src/features/workspace/capabilities/connectors/connector-filter.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/connector-filter.test.ts
@@ -53,9 +53,19 @@ describe('the landing tab is Discovery, unconditionally', () => {
   // connector, and the ones they have are one click away. It also made the
   // landing tab depend on a query, so the page could settle onto a different
   // tab than it first rendered.
+  //
+  // `catalogueAvailable` is not a return of that: it is not derived from the
+  // project's connectors but from the DEPLOYMENT, and it does not pick between
+  // tabs — it decides whether Discovery and All exist at all. On a self-host
+  // with no Pipedream credentials the catalogue they show answers `501`, so
+  // both are removed and Connected is the only tab left to land on. See
+  // `connectors-page.pipedream-unconfigured.test.ts`.
   test('the default scope is a constant, not derived from the project', () => {
-    expect(page).toContain("const scope: ConnectorScope = scopeChoice ?? 'discover';");
+    expect(page).toContain(
+      "const scope: ConnectorScope = catalogueAvailable ? (scopeChoice ?? 'discover') : 'connected';",
+    );
     expect(page).not.toContain('defaultConnectorScope');
+    expect(page).not.toContain('connectors.length ?');
   });
 
   test('the helper is gone rather than left unused', () => {

--- a/apps/web/src/features/workspace/capabilities/connectors/connectors-page.pipedream-unconfigured.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/connectors-page.pipedream-unconfigured.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const page = readFileSync(join(import.meta.dir, 'connectors-page.tsx'), 'utf8');
+const catalog = readFileSync(join(import.meta.dir, 'catalog', 'use-catalog.ts'), 'utf8');
+
+/**
+ * A source-assertion tripwire, in the shape of
+ * `connectors-page.error-path.test.ts`.
+ *
+ * **The bug.** `listPipedreamApps` and `listPipedreamSections` are wired into
+ * the API router only when `pipedreamConfigured()` is true — three env vars,
+ * checked in `apps/api/src/connectors/pipedream.ts`. A self-host that never set
+ * them gets `501 FEATURE_NOT_SUPPORTED` from both. This page fired them anyway
+ * on every load, and `catalogErrorCopy()` has no 501 branch, so the Discovery
+ * tab answered with the generic "Server error … The server failed to answer
+ * (501). Retrying may work" card — over a catalogue that could never load, with
+ * a Retry button that could never succeed.
+ *
+ * **The fix is a deployment probe, not error copy.** `GET
+ * /connectors/connect-status` already existed for exactly this, and its own doc
+ * comment says so. Softening the 501 copy would have kept two tabs that cannot
+ * work; the tabs are removed instead, and the request is never sent.
+ *
+ * Three couplings hold that up, and none of them is visible from either file
+ * alone — which is why they are pinned here rather than trusted:
+ *
+ *   1. the Easy Connect queries wait on the probe,
+ *   2. the tab strip disappears only when the probe has CONFIRMED `absent`,
+ *   3. `scope` is forced past whatever `scopeChoice` still holds.
+ *
+ * Drop any one and the 501 card comes back — silently, and only on the
+ * deployments that cannot report it.
+ */
+describe('connectors page without Pipedream', () => {
+  test('the Easy Connect queries are gated on the deployment probe', () => {
+    // Both Pipedream-backed queries run off ONE derived flag, so neither can be
+    // gated while the other is forgotten. `source === 'easy-connect'` reaching
+    // an `enabled:` line again is the regression: it is true on exactly the
+    // deployments that answer 501.
+    expect(catalog).toContain('const pipedreamStatus = usePipedreamStatus(');
+    expect(catalog).toContain('const easyConnectRunnable =');
+    expect(catalog).toContain('enabled: opts.enabled && easyConnectRunnable,');
+    expect(catalog).toContain(
+      'enabled: opts.enabled && easyConnectRunnable && !searching && category === null,',
+    );
+    expect(catalog).not.toContain("enabled: opts.enabled && source === 'easy-connect'");
+  });
+
+  test('a probe that failed does not stand in for a provider that is missing', () => {
+    // `unknown` is not `absent`. A probe that could not run says nothing about
+    // whether Pipedream is configured, and refusing to load a catalogue that
+    // probably exists is the worse of the two mistakes — the real failure is
+    // then reported by the catalogue query, in the one place that can retry it.
+    expect(catalog).toContain(
+      "(pipedreamStatus === 'configured' || pipedreamStatus === 'unknown')",
+    );
+    expect(catalog).toContain('retry: false,');
+  });
+
+  test('the wait for the probe reads as loading, not as an empty catalogue', () => {
+    // A disabled react-query reports neither loading nor data. Without this the
+    // grid would paint "no results" for a round trip, before the request it is
+    // waiting on had even started.
+    expect(catalog).toContain("pipedreamStatus === 'asking' ||");
+  });
+
+  test('the probe outlives the tabs it closes', () => {
+    // The probe must NOT be gated on `opts.enabled`. The page turns Discovery
+    // and All off when it answers `absent`, which turns `enabled` off with
+    // them; a probe that then stopped answering would reopen the tabs, which
+    // would re-enable the probe — a strip that flickers forever.
+    expect(catalog).toContain("usePipedreamStatus(source === 'easy-connect')");
+    expect(catalog).not.toContain('usePipedreamStatus(opts.enabled');
+  });
+
+  test('the tab strip goes only when the catalogue is CONFIRMED absent', () => {
+    // `discoverEnabled ||` is load-bearing twice over. `connectors_api_discover`
+    // is a different catalogue backend entirely, so a project with that flag on
+    // keeps Discovery and All whatever Pipedream's status is — and with the flag
+    // off, Pipedream is the only catalogue left, so its absence removes both.
+    expect(page).toContain('const pipedreamStatus = usePipedreamStatus(!discoverEnabled);');
+    expect(page).toContain(
+      "const catalogueAvailable = discoverEnabled || pipedreamStatus !== 'absent';",
+    );
+    // `!== 'absent'`, never `=== 'configured'`: `asking` must render the page
+    // exactly as it always has. Almost every deployment does have Pipedream,
+    // and dropping two tabs for a beat on every load to spare a minority one
+    // failed request is the wrong trade.
+    expect(page).not.toContain("pipedreamStatus === 'configured'");
+  });
+
+  test('the strip is removed, not disabled, and leaves no empty row behind', () => {
+    // `CapabilityPageShell` drops the whole filter row when `filters` is
+    // undefined and keeps it for anything truthy — so a fragment here would
+    // leave a 28px gap where the tabs used to be. A single remaining tab is
+    // not a choice either; the page keeps its title and its `+` button.
+    expect(page).toContain('filters={');
+    expect(page).toContain('catalogueAvailable ? (');
+    expect(page).toContain(') : undefined');
+    expect(page).not.toContain('disabled={!catalogueAvailable}');
+  });
+
+  test('scope is forced to Connected, not defaulted to it', () => {
+    // `scopeChoice` outlives the answer it was made under: the user can click
+    // Discovery in the beat before the probe lands, and an OAuth return brings
+    // them back to this page with that state intact. `scopeChoice ?? 'discover'`
+    // alone would strand them on a tab the strip no longer renders — the
+    // catalogue would mount, fire, and 501 with nothing to switch away to.
+    expect(page).toContain(
+      "const scope: ConnectorScope = catalogueAvailable ? (scopeChoice ?? 'discover') : 'connected';",
+    );
+    expect(page).not.toContain("const scope: ConnectorScope = scopeChoice ?? 'discover';");
+    // `catalogActive` is what mounts `ConnectorBrowse`, and it is derived from
+    // the forced `scope` — so the forcing above is also what keeps the
+    // catalogue unmounted.
+    expect(page).toContain("const catalogActive = scope !== 'connected';");
+  });
+
+  test('the Connected empty state offers no tab that is not there', () => {
+    // "Browse the catalogue" sets `scopeChoice` to `discover`. With no
+    // catalogue that is a button to a hidden tab, and the forced `scope` would
+    // swallow the click — a control that visibly does nothing.
+    const start = page.indexOf('title="No connectors yet"');
+    const end = page.indexOf('</CatalogGrid>');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const emptyState = page.slice(start, end);
+    expect(emptyState).toContain('catalogueAvailable ? (');
+    expect(emptyState).toContain('Browse the catalogue');
+  });
+});

--- a/apps/web/src/features/workspace/capabilities/connectors/connectors-page.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/connectors-page.tsx
@@ -49,7 +49,10 @@ import {
 } from '@/features/workspace/capabilities/connectors/catalog/catalog-entry';
 import { ConnectorBrowse } from '@/features/workspace/capabilities/connectors/catalog/connector-browse';
 import { ALL_CATEGORIES } from '@/features/workspace/capabilities/connectors/catalog/connector-categories';
-import { useCatalog } from '@/features/workspace/capabilities/connectors/catalog/use-catalog';
+import {
+  useCatalog,
+  usePipedreamStatus,
+} from '@/features/workspace/capabilities/connectors/catalog/use-catalog';
 import { CapabilityPageShell } from '@/features/workspace/capabilities/shared/capability-page-shell';
 import { CatalogCard } from '@/features/workspace/capabilities/shared/catalog/catalog-card';
 import { catalogEmptyKind } from '@/features/workspace/capabilities/shared/catalog/catalog-empty';
@@ -120,6 +123,16 @@ function ModalFormFallback() {
  * on the other two tabs. Removing a card the user can already see is connected
  * is not a filter worth a tab; it just made "where did Slack go?" a question
  * the page could provoke.
+ *
+ * Two of the three are dropped entirely on a deployment with no catalogue —
+ * see `catalogueAvailable`. Discovery and All are two views of ONE catalogue,
+ * and without `connectors_api_discover` that catalogue is Pipedream's, which
+ * answers `501` on every request unless three env vars are set. They are
+ * removed rather than disabled: a disabled tab still asserts that the feature
+ * exists and is merely out of reach for now, which is not what "this
+ * deployment does not have Pipedream" means. What is left is the project's own
+ * connectors, which every deployment has, and `+`, which never needed a
+ * catalogue.
  */
 const SCOPES: readonly ConnectorScope[] = ['discover', 'all', 'connected'];
 
@@ -226,6 +239,22 @@ export function ConnectorsPage({ projectId }: { projectId: string }) {
   const discoverEnabled = useFeatureFlag(projectId, 'connectors_api_discover').enabled;
   const emailChannelEnabled = useFeatureFlag(projectId, 'agentmail_email').enabled;
 
+  // Whether this deployment has a catalogue to browse at all.
+  //
+  // `useCatalog` falls back to Easy Connect (Pipedream) whenever
+  // `connectors_api_discover` is off, which is the default — so with the flag
+  // off and Pipedream unconfigured, Discovery and All have no backend and every
+  // request they make answers `501`. The probe is read HERE rather than off
+  // `catalog`, because it decides `enabled` for the very hook that would
+  // otherwise report it.
+  //
+  // Only a confirmed `absent` closes the tabs. While the probe is in flight the
+  // page renders exactly as it always has: the overwhelming majority of
+  // deployments do have Pipedream, and removing two tabs for a beat on every
+  // load to spare a minority one is the wrong trade.
+  const pipedreamStatus = usePipedreamStatus(!discoverEnabled);
+  const catalogueAvailable = discoverEnabled || pipedreamStatus !== 'absent';
+
   const authorizationQueryKeys = useMemo(
     () => connectorConnectionQueryKeys(projectId),
     [projectId],
@@ -284,7 +313,14 @@ export function ConnectorsPage({ projectId }: { projectId: string }) {
   // connector than reading the ones already there, and the ones already there
   // are one click away. It also made the landing tab depend on a query, so the
   // page could settle onto a different tab than it first rendered.
-  const scope: ConnectorScope = scopeChoice ?? 'discover';
+  //
+  // Unless there is no catalogue at all, in which case the choice is forced
+  // rather than defaulted: `scopeChoice` outlives the answer it was made
+  // under — the user can click Discovery in the beat before the probe lands,
+  // and `?c=` returns them to this page after an OAuth round trip with that
+  // choice still in state. Reading it here would strand them on a tab the
+  // strip no longer renders.
+  const scope: ConnectorScope = catalogueAvailable ? (scopeChoice ?? 'discover') : 'connected';
   const catalogActive = scope !== 'connected';
 
   // The category the catalogue should FILTER by, server-side. `null` while
@@ -417,27 +453,33 @@ export function ConnectorsPage({ projectId }: { projectId: string }) {
         ) : undefined
       }
       filters={
-        <>
-          {/* Rendered immediately, not behind `settled`. The strip used to
-              wait for both queries because the landing tab was derived from
-              one of them and Connected carried a count off the other; neither
-              is true now, so waiting only meant an empty 28px slot on every
-              load followed by the tabs popping in. Three static labels over a
-              constant `scope` have nothing to wait for. */}
-          <Tabs value={scope} onValueChange={(value) => setScopeChoice(value as ConnectorScope)}>
-            <TabsList>
-              {SCOPES.map((value) => (
-                <TabsTrigger key={value} value={value}>
-                  {SCOPE_LABEL[value]}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </Tabs>
-          {/* The category filter is NOT here. It is a rail of chips rendered by
-              `ConnectorBrowse` directly above the grid it filters — this row is
-              too narrow for it, and the rail has to sit next to its content for
-              the lit chip to read as "this is why you are seeing these". */}
-        </>
+        // A strip of one tab is not a choice, so a deployment with no catalogue
+        // gets no strip — `CapabilityPageShell` drops the whole row when this
+        // is `undefined`, which is why it must not be a fragment.
+        catalogueAvailable ? (
+          <>
+            {/* Rendered immediately, not behind `settled`. The strip used to
+                wait for both queries because the landing tab was derived from
+                one of them and Connected carried a count off the other; neither
+                is true now, so waiting only meant an empty 28px slot on every
+                load followed by the tabs popping in. Three static labels over a
+                constant `scope` have nothing to wait for. */}
+            <Tabs value={scope} onValueChange={(value) => setScopeChoice(value as ConnectorScope)}>
+              <TabsList>
+                {SCOPES.map((value) => (
+                  <TabsTrigger key={value} value={value}>
+                    {SCOPE_LABEL[value]}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+            {/* The category filter is NOT here. It is a rail of chips rendered
+                by `ConnectorBrowse` directly above the grid it filters — this
+                row is too narrow for it, and the rail has to sit next to its
+                content for the lit chip to read as "this is why you are seeing
+                these". */}
+          </>
+        ) : undefined
       }
     >
       {catalogActive ? (
@@ -469,10 +511,19 @@ export function ConnectorsPage({ projectId }: { projectId: string }) {
                 size="sm"
                 title="No connectors yet"
                 description="Connect an outside tool and your agents can use it in a session."
+                // The CTA goes with the tab it opens. With no catalogue on this
+                // deployment it would be a button to a tab that is not there;
+                // `+` is the remaining way in, and it is already in the header.
                 action={
-                  <Button size="sm" variant="secondary" onClick={() => setScopeChoice('discover')}>
-                    Browse the catalogue
-                  </Button>
+                  catalogueAvailable ? (
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => setScopeChoice('discover')}
+                    >
+                      Browse the catalogue
+                    </Button>
+                  ) : undefined
                 }
               />
             )


### PR DESCRIPTION
## The report

On a self-host without Pipedream credentials (`essentia.kortix.cloud`), the Connectors page opens on **Discovery** and paints:

> **Server error**
> The server failed to answer (501). Retrying may work; the details are in the server log. **[Retry]**

Over a tab that can never work, with a Retry that can never succeed.

## Root cause

`listPipedreamApps` / `listPipedreamSections` are wired into the API router **only** when `pipedreamConfigured()` is true — three env vars, checked in `apps/api/src/connectors/pipedream.ts:38`. Without them both routes answer `501 FEATURE_NOT_SUPPORTED` (`apps/api/src/connectors/router.ts:481-491`).

`useCatalog` fired both unconditionally whenever `source === 'easy-connect'`, which is the fallback for every project without the separate `connectors_api_discover` flag. `catalogErrorCopy()` has no 501 branch, so the answer surfaced as the generic 5xx card.

`GET /connectors/connect-status` already existed for exactly this — its doc comment literally says *"so the UI can hide or disable the 'Easy Connect' surface up front instead of letting the user open it and hit a 501"*. This page just never called it.

## The fix

`usePipedreamStatus()` (new, in `use-catalog.ts`) reads that route under the shared `['connect-status']` key — the same entry the legacy `connectors-view.tsx` already uses, so it is one request for both surfaces.

- **The Easy Connect queries wait for it.** Nothing is sent to Pipedream until the probe has ruled out `absent`. The wait reports as `isLoading` so the grid holds skeletons rather than flashing an empty result, and it is **not retried**: a probe that could not run is not evidence the provider is missing, so a failure resolves to `unknown` and the catalogue proceeds exactly as before.
- **The tab strip goes when — and only when — the probe confirms `absent` and `connectors_api_discover` is off.** That flag is a different catalogue backend entirely; a project that has it keeps Discovery and All whatever Pipedream's status is. One remaining tab is not a choice, so the whole filter row goes; the page keeps its title, its search and its `+`.
- **`scope` is forced to `'connected'`, not defaulted to it.** `scopeChoice` outlives the answer it was made under — the user can click Discovery in the beat before the probe lands, and an OAuth return brings them back with that state intact. Reading it would strand them on a tab the strip no longer renders.
- **The Connected empty state drops "Browse the catalogue"**, which would otherwise be a button to a hidden tab.

Error copy is deliberately untouched. Softening the 501 card would have kept two tabs that cannot work.

## Verified in the browser, both directions

Chromium against the local stack, driving the real page and reading the network panel.

**Pipedream configured** (today's normal case) — `connect-status` → `{"configured":true,"provider":"pipedream"}`:

```
tabs: ["Connectors","Agents","Skills","Discovery","All","Connected"]
requests: /connectors            200
          /connect-status        200
          /pipedream/apps        200
          /pipedream/sections    200
failed connector responses: []
body contains "Server error": false
```

Discovery renders the sectioned catalogue (Marketing · 207, AI · 200, Productivity · 188). No regression.

**Pipedream unconfigured** (three vars blanked in a gitignored `apps/api/.env.local`) — `connect-status` → `{"configured":false,"provider":null}`:

```
tabs: ["Connectors","Agents","Skills"]      <- no Discovery / All / Connected strip
requests: /connectors            200
          /connect-status        200
                                            <- ZERO Pipedream requests
failed connector responses: []
body contains "Server error": false
body contains "501": false
```

Only the project's own connectors show, under the page title, with `+` still available.

**Same run with this commit stashed** reproduces the report exactly:

```
failed connector responses: [
  "501 …/pipedream/apps?limit=48",
  "501 …/pipedream/sections?perCategory=6&maxCategories=12"
]
body contains "Server error": true
body contains "501": true
```

Light and dark both checked in both states.

## Gates

- `bun test src/features/workspace/capabilities/connectors/` → **256 pass / 0 fail**
- `tsc --noEmit` → clean for these files (only the two pre-existing `@/.source` codegen errors in this fresh worktree)
- `eslint` on the changed files → **0 errors** (1 pre-existing `react-hooks/set-state-in-effect` warning on untouched code)

New source-assertion tests in `connectors-page.pipedream-unconfigured.test.ts` pin the three couplings that are invisible from either file alone: the queries wait on the probe, the strip goes only on a confirmed `absent`, and `scope` is forced past `scopeChoice`. `connector-filter.test.ts` was updated for the new `scope` expression, keeping its "landing tab is not derived from the project" intent.

## Not touched

`customize/sections/connectors-view.tsx` — the legacy surface already has its own correct `connectStatus` query for its own Easy Connect section.
