### PR TITLE
fix(web): drop the Apps subtitle and stop Learn more pressing the edge

### DIFF
--- a/apps/web/src/features/apps/apps-feature-gate.test.ts
+++ b/apps/web/src/features/apps/apps-feature-gate.test.ts
@@ -85,7 +85,7 @@ test('Apps UI is operational only and has no creation action or modal', () => {
   expect(view).not.toContain('Create App');
   expect(view).toContain('kortix apps deploy .');
   expect(view).toContain('<iframe');
-  expect(view).toContain('className="max-w-5xl"');
+  expect(view).toContain('className="max-w-5xl px-4"');
 });
 
 test('the Apps row matches the row contract of the group it sits in', () => {

--- a/apps/web/src/features/apps/apps-view.tsx
+++ b/apps/web/src/features/apps/apps-view.tsx
@@ -287,9 +287,18 @@ export function AppsView({ projectId }: { projectId: string }) {
   return (
     <CustomizeSectionWrapper
       title="Apps"
-      description="Deploy apps to stable Kortix URLs. They wake on request and stop when idle."
       docs="/docs/feature-flags/apps"
-      className="max-w-5xl"
+      // `CustomizeSectionWrapper`'s content column carries no horizontal
+      // padding of its own — every other consumer stays inside `max-w-2xl`,
+      // narrow enough that the column's own margin (`mx-auto` against a much
+      // wider viewport) reads as a gutter. This page overrides to `max-w-5xl`
+      // for its card grid, and once viewport width gets close to that 1024px
+      // cap — an ordinary laptop window, not just a phone — the column fills
+      // the full width and "Learn more." presses flush against the browser
+      // edge. `px-4` matches `CapabilityPageShell`'s own gutter (the sibling
+      // shell the other capability routes use), so the header never touches
+      // the edge regardless of viewport width.
+      className="max-w-5xl px-4"
       showSidebarToggleButton
     >
       {appsGate.isLoading ? (


### PR DESCRIPTION
## The problems

**1. Redundant subtitle.** The Apps page header said "Deploy apps to stable Kortix URLs. They wake on request and stop when idle." right under the title — and when Apps is off for a project, the very next paragraph (`FeatureGateScreen`) repeats nearly the same sentence. The title plus the existing "Learn more." link (already pointing at `/docs/feature-flags/apps`) carry the same information with no redundant line. Dropped the subtitle.

**2. "Learn more." pressed against the browser edge at ordinary window widths.** Reported live on `essentia.kortix.cloud` at a normal laptop width — not a phone, not an edge case.

Root cause: `apps-view.tsx` overrides `CustomizeSectionWrapper`'s content column from `max-w-2xl` to `max-w-5xl` for its card grid, but that column carries no horizontal padding of its own. Every other `CustomizeSectionWrapper` consumer stays inside `max-w-2xl` (672px), narrow enough that `mx-auto` centering it against a much wider viewport reads as a gutter on its own — no explicit padding needed. Once viewport width closes in on `max-w-5xl`'s 1024px cap, the column fills edge to edge and the header's right-aligned action (`Learn more.`) presses flush against the browser edge.

## The fix

Added `px-4` to this page's `className` override, matching `CapabilityPageShell`'s own gutter — the sibling shell the other capability routes (Connectors/Agents/Skills) already use. Scoped to this page only; the shared `CustomizeSectionWrapper` primitive and its other ~10 consumers are untouched.

## Verification

Browser (chrome-devtools MCP), three widths:

| Width | Result |
|---|---|
| 1024px (the exact `max-w-5xl` breakpoint — worst case) | Clean gutter |
| 1183px (the reported width) | Clean gutter |
| 1440px (regression check) | Clean gutter, no shift |

`apps/web`:
```
bun test src/features/apps      → 19 pass, 0 fail (2 files)
tsc --noEmit                    → clean (bar the 3 pre-existing @types/bun files)
eslint apps-view.tsx apps-feature-gate.test.ts → clean
```

One source-assertion test (`apps-feature-gate.test.ts`) pinned the literal `className="max-w-5xl"` — updated to `className="max-w-5xl px-4"`.
