### PR TITLE
Apps: show the App's desktop layout on a card, not its mobile one

### DIFF
--- a/apps/web/src/features/apps/app-preview.test.tsx
+++ b/apps/web/src/features/apps/app-preview.test.tsx
@@ -8,6 +8,9 @@ import {
   AppPreview,
   AppPreviewOverlay,
   PREVIEW_SPINNER_DELAY_MS,
+  PREVIEW_VIEWPORT_HEIGHT,
+  PREVIEW_VIEWPORT_WIDTH,
+  previewScale,
   scheduleSlowPreview,
 } from './apps-view';
 
@@ -151,5 +154,75 @@ describe('scheduleSlowPreview', () => {
   test('the threshold is short enough to stay under a perceived stall', () => {
     expect(PREVIEW_SPINNER_DELAY_MS).toBeGreaterThanOrEqual(200);
     expect(PREVIEW_SPINNER_DELAY_MS).toBeLessThanOrEqual(400);
+  });
+});
+
+/**
+ * The second defect: a card thumbnail showed the App's MOBILE layout.
+ *
+ * A tile is ~300-450px wide, and an iframe that wide is a 300-450px viewport,
+ * so every App answered the card with its hamburger-and-one-column view — the
+ * one layout nobody deploys an App for. The card now renders the App at a
+ * desktop viewport and scales the result down, so the tile shows the layout
+ * opening the App would show.
+ */
+describe('previewScale', () => {
+  test('shrinks a desktop viewport into the tile it has to fit', () => {
+    expect(previewScale(640, 1280)).toBe(0.5);
+    expect(previewScale(320, 1280)).toBe(0.25);
+  });
+
+  test('defaults to the desktop viewport the card renders at', () => {
+    expect(previewScale(PREVIEW_VIEWPORT_WIDTH)).toBe(1);
+  });
+
+  test('refuses a width nothing can be concluded from', () => {
+    // A detached node, a display:none ancestor, and a server render all measure
+    // 0. Scaling by 0 — or by NaN — is how a thumbnail silently disappears.
+    for (const width of [0, -10, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(previewScale(width)).toBeNull();
+    }
+    expect(previewScale(640, 0)).toBeNull();
+  });
+
+  test('the viewport is 16:9, matching the tile, so nothing is cropped', () => {
+    expect(PREVIEW_VIEWPORT_WIDTH / PREVIEW_VIEWPORT_HEIGHT).toBeCloseTo(16 / 9, 5);
+  });
+
+  test('the viewport is a desktop width — a phone width would defeat the point', () => {
+    expect(PREVIEW_VIEWPORT_WIDTH).toBeGreaterThanOrEqual(1024);
+  });
+});
+
+describe('AppPreview — the card renders a desktop viewport', () => {
+  test('the card frame is sized to the desktop viewport, not to the tile', () => {
+    const html = renderToStaticMarkup(
+      <AppPreview app={APP} url={URL} accessError={false} interactive={false} />,
+    );
+
+    expect(html).toContain(`width:${PREVIEW_VIEWPORT_WIDTH}px`);
+    expect(html).toContain(`height:${PREVIEW_VIEWPORT_HEIGHT}px`);
+    expect(html).toContain('origin-top-left');
+  });
+
+  test('it stays hidden until measured, rather than flashing an unscaled corner', () => {
+    // `renderToStaticMarkup` skips effects, which is exactly the pre-measure
+    // state: no layout has happened, so there is no honest scale to apply yet.
+    const html = renderToStaticMarkup(
+      <AppPreview app={APP} url={URL} accessError={false} interactive={false} />,
+    );
+
+    expect(html).toContain('visibility:hidden');
+    expect(html).not.toContain('transform:scale');
+  });
+
+  test('the modal frame is untouched — it fills the dialog at its real size', () => {
+    const html = renderToStaticMarkup(
+      <AppPreview app={APP} url={URL} accessError={false} interactive />,
+    );
+
+    expect(html).not.toContain(`width:${PREVIEW_VIEWPORT_WIDTH}px`);
+    expect(html).not.toContain('visibility:hidden');
+    expect(html).toContain('size-full');
   });
 });

--- a/apps/web/src/features/apps/apps-view.tsx
+++ b/apps/web/src/features/apps/apps-view.tsx
@@ -59,7 +59,7 @@ import {
 } from '@phosphor-icons/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 function deploymentTone(
   status: AppDeployment['status'],
@@ -152,6 +152,86 @@ export function AppPreviewOverlay({
   );
 }
 
+/**
+ * The logical viewport a CARD thumbnail renders the App into.
+ *
+ * A card tile is 300-450px wide, and an iframe that wide is a 300-450px
+ * viewport — so the App answers with its mobile layout. Every thumbnail on the
+ * page was a hamburger over a single stacked column: the one view of the App
+ * nobody deploys an App for, and nothing like what opening it actually shows.
+ *
+ * Render at a desktop width instead and scale the result down. The App lays
+ * out at 1280px, the tile shows that layout in miniature, and the thumbnail
+ * finally looks like the App — the same thing a screenshot would give you.
+ *
+ * 1280x720 is 16:9 exactly, which is the tile's own `aspect-video`, so the
+ * scaled frame fills it edge to edge with no letterboxing and no cropping.
+ *
+ * This is the house pattern, not a new one: `presentations/engine/deck.tsx`
+ * renders its slide thumbnails into the same fixed 1280x720 box scaled from
+ * `origin-top-left`, and `FullScreenPresentationViewer` does it at 1920x1080.
+ * Note what does NOT solve this — `showAspectRatioToCSS` in
+ * `show-content-renderer.tsx` reshapes the BOX and leaves the guest laying out
+ * at the host's width, which is the thing that produced the mobile layout here.
+ */
+export const PREVIEW_VIEWPORT_WIDTH = 1280;
+export const PREVIEW_VIEWPORT_HEIGHT = 720;
+
+/**
+ * How far to shrink the desktop frame so it fits the tile. `null` for a width
+ * nothing can be concluded from — a detached node, a display:none ancestor, a
+ * server render with no layout at all — which the caller paints as "not yet
+ * measured" rather than scaling by a garbage factor.
+ */
+export function previewScale(
+  containerWidth: number,
+  viewportWidth: number = PREVIEW_VIEWPORT_WIDTH,
+): number | null {
+  if (!Number.isFinite(containerWidth) || containerWidth <= 0) return null;
+  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return null;
+  return containerWidth / viewportWidth;
+}
+
+/**
+ * Measures the tile and keeps the scale honest as it changes.
+ *
+ * A layout effect, not an effect: it runs after DOM mutation and BEFORE paint,
+ * so the browser never shows the unscaled 1280px frame cropped to the tile's
+ * top-left corner. The `ResizeObserver` then covers every later change — the
+ * responsive grid going one-column, a sidebar opening, a window drag — none of
+ * which fire anything else this component would hear.
+ */
+function useDesktopViewportScale(enabled: boolean) {
+  // A callback ref held in state, not a `useRef`: the node is an INPUT to the
+  // measurement, so the effect has to re-run when it arrives. A ref object
+  // would also have to be read during render to be handed to `<div ref>`,
+  // which is the thing `react-hooks/refs` correctly refuses.
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
+  const [scale, setScale] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (!enabled || !node) return;
+
+    const measure = () => setScale(previewScale(node.getBoundingClientRect().width));
+    measure();
+
+    // Guarded for a runtime without it (jsdom-less unit renders, older Safari):
+    // the one synchronous measurement above still lands, so the frame is scaled
+    // correctly at its mounted size and simply stops tracking resizes.
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [enabled, node]);
+
+  // A tuple, not an object. `react-hooks/refs` treats every property read on an
+  // object whose member lands in a `ref=` prop as a ref access during render —
+  // true for a `useRef` container, wrong for a callback ref. Destructuring to
+  // plain locals says what this is and keeps the rule meaningful where it does
+  // apply.
+  return [setNode, scale] as const;
+}
+
 export function AppPreview({
   app,
   url,
@@ -175,6 +255,9 @@ export function AppPreview({
   const [loaded, setLoaded] = useState(false);
   const [failed, setFailed] = useState(false);
   const slow = useSlowPreview(!loaded && !failed);
+  // Cards only. In the modal the frame IS the App at the size you are using it,
+  // so a fixed desktop viewport there would scale the thing you came to click.
+  const [attachViewport, viewportScale] = useDesktopViewportScale(!interactive);
   const frame = cn(
     'bg-muted/20 relative overflow-hidden',
     !interactive && 'aspect-video',
@@ -217,11 +300,26 @@ export function AppPreview({
   }
 
   return (
-    <div className={frame}>
+    <div className={frame} ref={attachViewport}>
       <iframe
         key={app.active_deployment_id}
         src={url}
         title={`${app.name} live preview`}
+        style={
+          interactive
+            ? undefined
+            : {
+                width: PREVIEW_VIEWPORT_WIDTH,
+                height: PREVIEW_VIEWPORT_HEIGHT,
+                // Hidden, not unmounted, until the tile has been measured: an
+                // unmounted frame would restart the document load on every
+                // resize, and a visible unscaled one would flash the App's
+                // top-left 1280px corner. It still loads while hidden.
+                ...(viewportScale === null
+                  ? { visibility: 'hidden' as const }
+                  : { transform: `scale(${viewportScale})` }),
+              }
+        }
         // The card thumbnail is one of many below the fold, so defer it. In the
         // modal the frame IS the content and it is already on screen — `lazy`
         // there makes the browser wait for layout before it even starts the
@@ -231,8 +329,13 @@ export function AppPreview({
         allow={CLIPBOARD_IFRAME_ALLOW}
         sandbox={INTERACTIVE_PREVIEW_IFRAME_SANDBOX}
         className={cn(
-          'bg-background absolute inset-0 size-full border-0',
-          !interactive && 'pointer-events-none',
+          'bg-background absolute border-0',
+          interactive
+            ? 'inset-0 size-full'
+            : // Anchored top-left because that is the scale's origin: the frame
+              // shrinks toward the corner it starts in, so the miniature lands
+              // flush in the tile instead of drifting toward the middle.
+              'top-0 left-0 origin-top-left pointer-events-none',
         )}
         {...(interactive ? {} : { tabIndex: -1, 'aria-hidden': true })}
         data-testid="app-live-preview"


### PR DESCRIPTION
## The problem

A card tile on the Apps page is ~500px wide, and an iframe that wide **is** a
500px viewport. So every thumbnail showed the App's mobile breakpoint — a
hamburger over one stacked column. That is the one layout nobody deploys an App
for, and nothing like what clicking the card then shows you.

## What does NOT fix it

Worth naming, because it looks like it should. The `aspect_ratio` handling in
`show-content-renderer.tsx:779-781` (values `auto/1:1/16:9/9:16/4:3/3:2/21:9`,
authored by the agent in the starter's `show.ts`) reshapes the **box** and leaves
the guest laying out at the host's width. That mechanism *produces* a mobile
layout; it does not cure one. Same for `fitSplitPercent` and `isWideDeliverable`
— both size a panel column, and no iframe surface ever feeds them.

## The fix

Render the card frame at a fixed **1280x720** desktop viewport and scale it down
to the tile. The App lays out at 1280, the tile shows that layout in miniature,
and the thumbnail finally looks like the App the way a screenshot would.
1280x720 is 16:9 — the tile's own `aspect-video` — so it fills edge to edge with
nothing cropped or letterboxed.

This is the **house pattern**, not a new one: `presentations/engine/deck.tsx:482-500`
renders slide thumbnails into the same fixed 1280x720 box scaled from
`origin-top-left`, and `FullScreenPresentationViewer` does it at 1920x1080.
Those are the only places in `apps/web` that decouple a guest's viewport from its
container.

Details worth reviewing:

- The scale is measured with a callback ref + `ResizeObserver` in a **layout**
  effect, so the unscaled 1280px corner never reaches a painted frame. The frame
  stays `visibility:hidden` until a real measurement exists rather than scaling by
  a garbage factor.
- The hook returns a **tuple**. `react-hooks/refs` treats any property read on an
  object whose member lands in a `ref=` prop as a ref access during render —
  correct for a `useRef` container, wrong for a callback ref. Fixing the cause
  rather than suppressing the rule.
- **The detail modal is deliberately untouched.** There the frame IS the App at
  the size you are using it, so a fixed viewport would scale the thing you came
  to click.

## Verification — a really-deployed App that reports its own viewport

Static App with `@media (max-width:700px)` that flips to a red `MOBILE LAYOUT`,
hides its 5-item nav, and writes `window.innerWidth` into the page and title.
Deployed with `bun apps/cli/src/index.ts apps deploy <dir> --type static`.

Guest viewport read from **inside** each frame via `frame.evaluate()`:

| | card frame | modal frame |
|---|---|---|
| guest `innerWidth` | **1280** | **1409** |
| renders | `DESKTOP LAYOUT`, 5-item nav, 3 columns | unscaled, fills dialog |
| inline style | `width:1280px; height:720px; transform:scale(0.392688)` | none |
| interaction | `pointer-events:none` → opens the modal | host click reached the guest |

Same App, same URL, both frames alive at once — that pair is the proof in one line.

- Tile 502.640625px → `matrix(0.392688)` = 502.640625/1280 **exactly**; width delta
  **0.000px**, height delta 0.00098px. No crop, no letterbox.
- Resize 1440 → 900 → 1440: scale tracks 0.392688 → 0.24386 → 0.392688 and the
  guest stays 1280 throughout (ResizeObserver).
- 811 rAF samples across load: **0 frames** at scale≈1, **0 frames**
  `visibility:hidden`. The same sampler did catch the resize transitions, so it is
  not blind. (Limit: a sub-frame state is invisible to a per-frame sampler — this
  proves nothing unscaled survived to a *painted* frame.)

Screenshots light + dark: card grid, close crop, narrowed window, modal.

## Tests

```
apps/web: bun test        → 7678 pass, 0 fail (605 files)
apps/web: tsc --noEmit    → 0 errors outside the 3 known @types/bun test.each files
eslint apps-view.tsx app-preview.test.tsx → 0 errors, 0 warnings
```

8 new tests: `previewScale` maths and its refusals (0, negative, NaN, Infinity),
the 16:9 invariant, the desktop-width floor, and render assertions that the card
carries 1280x720 + `origin-top-left`, stays hidden pre-measure, and that the modal
has none of it.

## Not verified

Local-only against the worktree stack; no dev-deployed evidence yet.
