### PR TITLE
fix(web): bring the permission-approval card onto the design system

### DIFF
--- a/apps/web/src/app/(system)/debug/permissions/page.tsx
+++ b/apps/web/src/app/(system)/debug/permissions/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { SessionPermissionPrompt } from '@/features/session/session-permission-prompt';
+import type { PermissionRequest } from '@/ui/types';
+import { useState } from 'react';
+
+/**
+ * /debug/permissions
+ *
+ * Visual harness for `SessionPermissionPrompt` outside a live session — lets
+ * you stare at the chrome (short command, long/multiline command needing
+ * expand, mixed permission types feeding the project-config footer) without
+ * driving an agent through an actual `ask`-mode tool call.
+ *
+ * Mirrors the chat column width so spacing reads true. Not linked from
+ * anywhere — just hit /debug/permissions.
+ */
+
+const SHORT: PermissionRequest = {
+  id: 'perm_short',
+  sessionID: 'ses_dbg',
+  permission: 'bash',
+  patterns: ['git status'],
+  metadata: {},
+  always: [],
+};
+
+const LONG: PermissionRequest = {
+  id: 'perm_long',
+  sessionID: 'ses_dbg',
+  permission: 'bash',
+  patterns: [
+    "kortix sessions digest --since 24h --json 2>&1 echo 'KORTIX_EXIT:' $?; kortix cr ls --state merged --limit 20 2>&1 echo 'KORTIX_EXIT:' $?; git log -- .kortix/ -15 --oneline 2>&1",
+  ],
+  metadata: {},
+  always: [],
+};
+
+const EDIT: PermissionRequest = {
+  id: 'perm_edit',
+  sessionID: 'ses_dbg',
+  permission: 'edit',
+  patterns: ['apps/web/src/features/session/session-chat.tsx'],
+  metadata: {},
+  always: [],
+};
+
+const WEBFETCH: PermissionRequest = {
+  id: 'perm_webfetch',
+  sessionID: 'ses_dbg',
+  permission: 'webfetch',
+  patterns: ['https://api.github.com/repos/kortix-ai/suna/commits'],
+  metadata: {},
+  always: [],
+};
+
+const SCENARIOS: Record<string, PermissionRequest[]> = {
+  'Single short command': [SHORT],
+  'Long / multiline command (expand-to-review)': [LONG],
+  'Four mixed actions (matches the reported screenshot)': [SHORT, LONG, EDIT, WEBFETCH],
+};
+
+export default function DebugPermissionsPage() {
+  const [scenario, setScenario] = useState<keyof typeof SCENARIOS>(
+    'Four mixed actions (matches the reported screenshot)',
+  );
+  const [answered, setAnswered] = useState<Set<string>>(new Set());
+
+  const permissions = SCENARIOS[scenario].filter((p) => !answered.has(p.id));
+
+  return (
+    <div className="bg-background min-h-screen px-6 py-10">
+      <div className="mx-auto max-w-xl space-y-4">
+        <div className="flex flex-wrap gap-2">
+          {Object.keys(SCENARIOS).map((key) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => {
+                setScenario(key);
+                setAnswered(new Set());
+              }}
+              className={`rounded-md border px-2.5 py-1 text-xs ${
+                scenario === key
+                  ? 'border-foreground bg-foreground text-background'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {key}
+            </button>
+          ))}
+        </div>
+
+        <SessionPermissionPrompt
+          sessionId="ses_dbg"
+          permissions={permissions}
+          onReply={async (requestId) => {
+            await new Promise((r) => setTimeout(r, 300));
+            setAnswered((current) => new Set(current).add(requestId));
+          }}
+        />
+
+        <div className="border-border bg-popover rounded-md border px-3 py-2">
+          <span className="text-muted-foreground text-xs">Ask anything...</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/session/session-permission-prompt.tsx
+++ b/apps/web/src/features/session/session-permission-prompt.tsx
@@ -30,9 +30,17 @@ import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import { useRuntimePendingStore } from '@kortix/sdk/react';
 import { PERMISSION_LABELS, type PermissionRequest } from '@/ui/types';
-import { ShieldCheckIcon as ShieldCheck } from '@phosphor-icons/react';
+import {
+  CaretDownIcon,
+  ShieldCheckIcon as ShieldCheck,
+  ShieldWarningIcon as ShieldAlert,
+} from '@phosphor-icons/react';
 import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/** Full-text review is only worth an extra click for a detail that won't fit
+ * on one line — short commands stay flat, no chevron. */
+const EXPANDABLE_DETAIL_LENGTH = 64;
 
 interface SessionPermissionPromptProps {
   /** The OPENCODE session id (what `PermissionRequest.sessionID` carries). */
@@ -74,6 +82,16 @@ export function SessionPermissionPrompt({
   // Which button is loading: `${requestId}:once|always|reject`, 'session-all',
   // or `config:${type}` / 'config:*'.
   const [busy, setBusy] = useState<string | null>(null);
+  // Request ids currently showing their full (untruncated) detail text.
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+  const toggleExpanded = useCallback((requestId: string) => {
+    setExpandedRows((current) => {
+      const next = new Set(current);
+      if (next.has(requestId)) next.delete(requestId);
+      else next.add(requestId);
+      return next;
+    });
+  }, []);
 
   const reply = useCallback(
     async (requestId: string, kind: 'once' | 'always' | 'reject') => {
@@ -181,9 +199,9 @@ export function SessionPermissionPrompt({
 
   if (autoApprove) {
     return (
-      <div className="border-border/60 bg-muted/40 mb-2 flex items-center gap-2 rounded-xl border px-3 py-1.5">
-        <ShieldCheck className="text-muted-foreground size-3.5" />
-        <span className="text-muted-foreground flex-1 text-[11px]">
+      <div className="border-border bg-popover mb-2 flex items-center gap-2 rounded-md border px-3 py-2">
+        <ShieldCheck className="text-kortix-green size-4" />
+        <span className="text-muted-foreground flex-1 text-xs">
           Auto-allowing all permission requests for this session
         </span>
         <Button size="xs" variant="ghost" onClick={() => void turnOffAutoApprove()}>
@@ -196,39 +214,60 @@ export function SessionPermissionPrompt({
   if (permissions.length === 0) return null;
 
   return (
-    <div className="mb-2 overflow-hidden rounded-xl border border-amber-500/40 bg-amber-50/60 dark:bg-amber-950/20">
-      <div className="flex items-center gap-2 border-b border-amber-500/20 px-3 py-1.5">
-        <ShieldCheck className="size-3.5 text-amber-600 dark:text-amber-400" />
-        <span className="text-foreground text-xs font-semibold tracking-tight">
+    <div className="bg-popover border-kortix-orange/25 mb-2 overflow-hidden rounded-md border">
+      <div className="border-kortix-orange/20 flex items-center gap-2 border-b px-3 py-2">
+        <ShieldAlert className="text-kortix-orange size-4" />
+        <span className="text-foreground text-xs font-medium">
           {permissions.length === 1
             ? 'The agent needs your permission'
             : `${permissions.length} actions need your permission`}
         </span>
-        <span className="text-muted-foreground text-[11px]">— it's paused until you decide</span>
+        <span className="text-muted-foreground text-xs">— it's paused until you decide</span>
       </div>
-      <ul className="divide-y divide-amber-500/15">
+      <ul className="divide-border divide-y">
         {permissions.map((p) => {
           const detail = permissionDetail(p);
+          const expandable = !!detail && detail.length > EXPANDABLE_DETAIL_LENGTH;
+          const expanded = expandedRows.has(p.id);
           return (
-            <li key={p.id} className="flex items-center gap-2 px-3 py-2">
+            <li key={p.id} className="flex items-start gap-2 px-3 py-2">
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-1.5">
                   <span className="text-foreground text-xs font-medium">{permissionLabel(p)}</span>
                 </div>
                 {detail ? (
-                  <code
-                    title={detail}
-                    className="text-muted-foreground mt-0.5 block truncate font-mono text-[11px]"
+                  <button
+                    type="button"
+                    onClick={expandable ? () => toggleExpanded(p.id) : undefined}
+                    className={cn(
+                      'mt-0.5 flex w-full items-start gap-1 text-left',
+                      expandable ? 'cursor-pointer' : 'cursor-default',
+                    )}
                   >
-                    {detail}
-                  </code>
+                    <code
+                      title={expandable ? undefined : detail}
+                      className={cn(
+                        'text-muted-foreground font-mono text-xs',
+                        expanded ? 'wrap-break-word whitespace-pre-wrap' : 'truncate',
+                      )}
+                    >
+                      {detail}
+                    </code>
+                    {expandable ? (
+                      <CaretDownIcon
+                        className={cn(
+                          'text-muted-foreground mt-0.5 size-3 shrink-0 transition-transform duration-150',
+                          expanded && 'rotate-180',
+                        )}
+                      />
+                    ) : null}
+                  </button>
                 ) : null}
               </div>
               <div className="flex shrink-0 items-center gap-1.5">
                 <Button
                   size="xs"
-                  variant="muted"
-                  className={cn('hover:bg-destructive/10 hover:text-destructive')}
+                  variant="outline"
                   disabled={!!busy}
                   onClick={() => void reply(p.id, 'reject')}
                 >
@@ -237,7 +276,7 @@ export function SessionPermissionPrompt({
                 </Button>
                 <Button
                   size="xs"
-                  variant="outline"
+                  variant="muted"
                   title="Allow this action for the rest of this session — the agent won't ask again for it"
                   disabled={!!busy}
                   onClick={() => void reply(p.id, 'always')}
@@ -259,11 +298,12 @@ export function SessionPermissionPrompt({
           );
         })}
       </ul>
-      <div className="flex items-center gap-2 border-t border-amber-500/15 px-3 py-1.5">
-        <span className="text-muted-foreground text-[11px]">This session:</span>
+      <div className="border-border flex items-center gap-2 border-t px-3 py-2">
+        <span className="text-muted-foreground text-xs">This session:</span>
         <Button
           size="xs"
           variant="ghost"
+          className="text-muted-foreground hover:text-foreground"
           title="Allow every permission request for the rest of this session"
           disabled={!!busy}
           onClick={() => void allowAllForSession()}
@@ -275,8 +315,8 @@ export function SessionPermissionPrompt({
       {canWriteConfig.allowed ? (
         // Deliberately set apart from the one-off buttons above: these WRITE the
         // project's permission config — every future session stops asking.
-        <div className="bg-muted/40 border-border/40 flex flex-wrap items-center gap-2 border-t px-3 py-1.5">
-          <span className="text-muted-foreground text-[11px]">
+        <div className="bg-muted/40 border-border flex flex-wrap items-center gap-2 border-t px-3 py-2">
+          <span className="text-muted-foreground text-xs">
             Project config <span className="opacity-70">(applies to future sessions)</span>:
           </span>
           {uniqueTypes.map((type) => (


### PR DESCRIPTION
## Problem

`SessionPermissionPrompt` (the "N actions need your permission" card pinned
above the composer for opencode `bash`/`edit`/`write`/... tool-permission
requests) used a visual language nothing else in the app uses: raw
`amber-500`/`amber-50`/`amber-950` Tailwind colors instead of a design
token, `rounded-xl` instead of the system's `rounded-md`, no `bg-popover`
surface, arbitrary `text-[11px]` sizes, and a hand-rolled Deny button
(`variant="muted"` + a manual `hover:bg-destructive/10` override) instead of
the system's `outline` variant.

Its sibling `SessionApprovalPrompt` (connector approvals) renders directly
above it in the exact same composer slot, and already does all of this
correctly with `kortix-orange`, `rounded-md`, `bg-popover`, `text-xs`. The
two cards stacked together read as two different products.

Also: the header icon was `ShieldCheckIcon` ("already allowed") on a card
that is asking for permission — should be `ShieldWarningIcon`, same as the
sibling. And long/multiline bash commands were truncated to one line with
only a `title` tooltip as the sole way to review them — unreadable, and no
way to actually see what you're approving before deciding.

## Fix

- `border-amber-*` → `border-kortix-orange/*` (token-driven, adapts
  correctly in light/dark instead of needing separate `dark:` overrides)
- `rounded-xl` → `rounded-md`, add `bg-popover` surface
- `text-[11px]` → `text-xs` (the app's actual type scale)
- `ShieldCheckIcon` → `ShieldWarningIcon` (matches the sibling's pending-state icon)
- Deny: `variant="muted"` + hover hack → `variant="outline"` (the system's real Deny styling)
- Added an expand/collapse chevron for any command detail over 64 chars, so
  a multi-line or long bash command can be fully reviewed in place before
  you decide — previously cut off with only a tooltip.

No behavior change to the three decision scopes (per-request / per-session /
per-project) — same props, same hooks, same handlers.

## New: `/debug/permissions`

This component has no test file and can only normally be seen by hitting a
live `ask`-mode tool call mid-session. Added a visual harness following the
existing `/debug/tools` convention (unlinked, `robots: noindex`) with three
scenarios, including the exact 4-action case from the reported screenshot.

## Verification

- `npx eslint` on both changed files: clean, 0 warnings
  (`--max-warnings=0`).
- `npx tsc --noEmit` on `apps/web`: no new errors — output is exactly the
  ~15 pre-existing `@types/bun` `test.each` errors already documented as
  expected in `CLAUDE.md`.
- Drove `/debug/permissions` in Chromium (isolated worktree, `pnpm worktree
  start approval-ux-refactor`): confirmed the collapsed 4-action layout
  matches the reported screenshot's density, confirmed the long-command
  expand toggle works (click → full multi-line command renders,
  `whitespace-pre-wrap`, chevron rotates), confirmed light + dark mode both
  render correctly with the token-driven colors, confirmed a full
  Deny/Allow decision resolves the row and the header count decrements
  (4 → 3 actions).

## Test plan

- [ ] `pnpm test -- --browser-only` (or hit `/debug/permissions` directly) to eyeball all three scenarios in light + dark
- [ ] Trigger a real `ask`-mode bash permission request in a session and confirm Deny / Allow for session / Allow once / Allow everything / project-config-writes all still work end to end