### PR TITLE
fix(web): deliver a queued prompt at the next tool boundary

### DIFF
--- a/apps/web/src/features/session/composer/queued-messages-logic.test.ts
+++ b/apps/web/src/features/session/composer/queued-messages-logic.test.ts
@@ -9,14 +9,17 @@ import {
 
 describe('queueSummaryLabel', () => {
   test('says what will happen, not just how many', () => {
-    expect(queueSummaryLabel(1)).toBe('1 queued · sends when this turn ends');
+    // "Next stopping point", not "when this turn ends": a queued message
+    // interrupts the run once the current tool call finishes, so the old
+    // wording promised a longer wait than the queue actually imposes.
+    expect(queueSummaryLabel(1)).toBe('1 queued · sends at the next stopping point');
   });
 
   test('says all of them send, because all of them do', () => {
-    // The queue drains as one batch. "4 queued · sends when this turn ends"
-    // reads as a schedule — one now, three later — which is the behaviour this
-    // surface used to have and no longer does.
-    expect(queueSummaryLabel(4)).toBe('4 queued · all send when this turn ends');
+    // The queue drains as one batch. A label that reads as a schedule — one
+    // now, three later — describes the behaviour this surface used to have
+    // and no longer does.
+    expect(queueSummaryLabel(4)).toBe('4 queued · all send at the next stopping point');
   });
 });
 

--- a/apps/web/src/features/session/composer/queued-messages-logic.ts
+++ b/apps/web/src/features/session/composer/queued-messages-logic.ts
@@ -11,15 +11,17 @@
  * The screen-reader announcement for the queue.
  *
  * "All send" is load-bearing, not filler: the queue drains as one batch, and a
- * label that reads like a schedule ("sends when this turn ends", one row at a
- * time) describes the behaviour this surface used to have. Sighted users get
- * the same fact from the numbered rows all being live at once, which is why
- * there is no visible header saying it.
+ * label that reads like a schedule (one row at a time) describes the behaviour
+ * this surface used to have. "Next stopping point", not "when this turn ends":
+ * a queued message interrupts the run once the currently executing tool call
+ * finishes (see `use-message-queue-drain.ts`) — promising the end of the turn
+ * would overstate the wait. Sighted users get the batch fact from the rows all
+ * being live at once, which is why there is no visible header saying it.
  */
 export function queueSummaryLabel(count: number): string {
   return count === 1
-    ? '1 queued · sends when this turn ends'
-    : `${count} queued · all send when this turn ends`;
+    ? '1 queued · sends at the next stopping point'
+    : `${count} queued · all send at the next stopping point`;
 }
 
 /**

--- a/apps/web/src/features/session/composer/queued-messages.tsx
+++ b/apps/web/src/features/session/composer/queued-messages.tsx
@@ -4,10 +4,11 @@
  * The queue, shown as a flat list of what goes next — one borderless row per
  * message, drag handle on the left, actions on the right.
  *
- * All of it sends when this turn ends, as one message, top to bottom. That is
- * why there is no number column: the order is the list. It is also why the
- * order gets a control — the batch is composed in list order, so moving a row
- * edits what the sent message says.
+ * All of it sends at the next stopping point — the run is interrupted once the
+ * currently executing tool call finishes (see `use-message-queue-drain.ts`) —
+ * as one message, top to bottom. That is why there is no number column: the
+ * order is the list. It is also why the order gets a control — the batch is
+ * composed in list order, so moving a row edits what the sent message says.
  *
  * ## The row anatomy
  *

--- a/apps/web/src/features/session/message-queue-boundary.test.ts
+++ b/apps/web/src/features/session/message-queue-boundary.test.ts
@@ -6,7 +6,9 @@ import {
   canDrainQueue,
   createDrainMachine,
   planDrainTick,
+  runQueueInterrupt,
   shouldClearPause,
+  shouldInterruptForQueue,
   shouldQueueInsteadOfSend,
   stepDrainMachine,
   type QueueDrainGates,
@@ -476,5 +478,152 @@ describe('dead-turn husk override', () => {
     if (action.kind === 'wait') {
       expect(action.ms).toBe(OPEN_TURN_HUSK_MS - 1_000);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interrupt-at-boundary: a queued message stops the run at the next tool
+// boundary instead of waiting for the whole turn.
+// ---------------------------------------------------------------------------
+
+/** The state in which the interrupt must fire. Tests flip one input at a time. */
+const INTERRUPTIBLE = {
+  gates: { ...CLEAR, isServerBusy: true, hasIncompleteAssistant: true },
+  hasRunningTool: false,
+  hasNewPending: true,
+  sending: false,
+  interrupting: false,
+};
+
+describe('shouldInterruptForQueue', () => {
+  test('fires while the server is busy, nothing else holds, and no tool is running', () => {
+    expect(shouldInterruptForQueue(INTERRUPTIBLE)).toBe(true);
+  });
+
+  test('an open assistant message alone does not block — busy IS the interrupt target', () => {
+    // `hasIncompleteAssistant` is a drain gate ("wait for the turn to end").
+    // The interrupt exists precisely because the turn has not ended.
+    expect(
+      shouldInterruptForQueue({
+        ...INTERRUPTIBLE,
+        gates: { ...INTERRUPTIBLE.gates, hasIncompleteAssistant: true },
+      }),
+    ).toBe(true);
+  });
+
+  test('waits while a tool call is executing — never kill a running tool', () => {
+    expect(shouldInterruptForQueue({ ...INTERRUPTIBLE, hasRunningTool: true })).toBe(false);
+  });
+
+  test('fires the moment the running tool finishes', () => {
+    const during = { ...INTERRUPTIBLE, hasRunningTool: true };
+    expect(shouldInterruptForQueue(during)).toBe(false);
+    expect(shouldInterruptForQueue({ ...during, hasRunningTool: false })).toBe(true);
+  });
+
+  test('does nothing while the server is idle — the ordinary drain owns that path', () => {
+    expect(
+      shouldInterruptForQueue({
+        ...INTERRUPTIBLE,
+        gates: { ...INTERRUPTIBLE.gates, isServerBusy: false },
+      }),
+    ).toBe(false);
+  });
+
+  test('nothing new pending → no interrupt', () => {
+    // Leftovers from a split batch queued BEFORE this turn started must wait
+    // for it, not kill it. Only a message typed during the run interrupts.
+    expect(shouldInterruptForQueue({ ...INTERRUPTIBLE, hasNewPending: false })).toBe(false);
+  });
+
+  test('never doubles up while a send or an earlier interrupt is in flight', () => {
+    expect(shouldInterruptForQueue({ ...INTERRUPTIBLE, sending: true })).toBe(false);
+    expect(shouldInterruptForQueue({ ...INTERRUPTIBLE, interrupting: true })).toBe(false);
+  });
+
+  const HOLDS: [string, Partial<QueueDrainGates>][] = [
+    ['a structured question is on screen', { hasActiveQuestion: true }],
+    ['an approval is pending', { hasPendingApproval: true }],
+    ['permissions are pending', { pendingPermissionCount: 1 }],
+    ['the user pressed stop', { isPaused: true }],
+    ['the view is read-only', { readOnly: true }],
+    ['the runtime is not ready', { runtimeReady: false }],
+    ['a rewind is staged', { revertStaged: true }],
+    ['our own send is unacknowledged', { pendingSendInFlight: true }],
+    ['a compaction is running', { isOptimisticCompacting: true }],
+  ];
+  for (const [name, override] of HOLDS) {
+    test(`held while ${name}`, () => {
+      expect(
+        shouldInterruptForQueue({
+          ...INTERRUPTIBLE,
+          gates: { ...INTERRUPTIBLE.gates, ...override },
+        }),
+      ).toBe(false);
+    });
+  }
+});
+
+describe('runQueueInterrupt', () => {
+  test('aborts first, then claims and dispatches the batch', async () => {
+    const order: string[] = [];
+    await runQueueInterrupt({
+      interrupt: async () => {
+        order.push('interrupt');
+      },
+      isHeld: () => false,
+      claimBatch: () => {
+        order.push('claim');
+        return ['a', 'b'];
+      },
+      dispatch: async (claimed) => {
+        order.push(`dispatch:${claimed.join(',')}`);
+      },
+    });
+    expect(order).toEqual(['interrupt', 'claim', 'dispatch:a,b']);
+  });
+
+  test('a failed abort dispatches nothing — never fire into a still-running turn', async () => {
+    let dispatched = false;
+    await runQueueInterrupt({
+      interrupt: async () => {
+        throw new Error('abort failed');
+      },
+      isHeld: () => false,
+      claimBatch: () => ['a'],
+      dispatch: async () => {
+        dispatched = true;
+      },
+    });
+    expect(dispatched).toBe(false);
+  });
+
+  test('a stop pressed while the abort settled holds the dispatch', async () => {
+    // The user hit stop during our interrupt. Stop wins: "stop doing things"
+    // includes the queue, and the pause must not be followed a beat later by
+    // exactly the message it was holding back.
+    let dispatched = false;
+    await runQueueInterrupt({
+      interrupt: async () => {},
+      isHeld: () => true,
+      claimBatch: () => ['a'],
+      dispatch: async () => {
+        dispatched = true;
+      },
+    });
+    expect(dispatched).toBe(false);
+  });
+
+  test('an empty claim dispatches nothing — another drain already took the batch', async () => {
+    let dispatched = false;
+    await runQueueInterrupt({
+      interrupt: async () => {},
+      isHeld: () => false,
+      claimBatch: () => [],
+      dispatch: async () => {
+        dispatched = true;
+      },
+    });
+    expect(dispatched).toBe(false);
   });
 });

--- a/apps/web/src/features/session/message-queue-boundary.ts
+++ b/apps/web/src/features/session/message-queue-boundary.ts
@@ -30,6 +30,28 @@
  * something: the server's own session status, plus the gates that mean the run
  * is paused waiting for a human. It is pure and clock-injected, so every rule
  * below is asserted in a unit test rather than observed by hand.
+ *
+ * ## Two release paths, matching Claude Code
+ *
+ * A queued message is an instruction the agent should react to NOW, not after
+ * it finishes everything it had planned. So there are two ways out of the
+ * queue:
+ *
+ *   1. **The interrupt** (`shouldInterruptForQueue` + `runQueueInterrupt`):
+ *      while the server is busy and a NEW message is waiting, the run is
+ *      stopped at the next tool boundary — the currently executing tool call
+ *      is allowed to finish (never killed halfway; see `running-tool.ts`), the
+ *      remainder of the turn is aborted, and the whole queue goes out
+ *      immediately. The interrupt IS the boundary, so no settle window
+ *      applies.
+ *   2. **The ordinary drain** (`stepDrainMachine`): when the interrupt is held
+ *      — a question on screen, an approval pending, the user pressed stop, a
+ *      batch leftover with nothing newly typed — the queue waits for the real
+ *      end of turn exactly as before.
+ *
+ * Rule 1 is why a finished tool call is still not a *drain* boundary: the
+ * drain waits for the whole turn. The interrupt is the only path that acts at
+ * a tool boundary, and it acts by ending the turn first.
  */
 
 /**
@@ -170,6 +192,93 @@ export function shouldQueueInsteadOfSend(input: {
 }): boolean {
   if (input.runtimeReady === false) return true;
   return input.isBusy || input.pendingCount > 0 || input.hasInFlight;
+}
+
+/**
+ * Whether a queued message should interrupt the running turn right now.
+ *
+ * This is the Claude Code behavior: a message typed while the agent works is
+ * not a note for later — it is the user steering. The agent finishes the tool
+ * call it is executing (never killed halfway), the rest of the turn is
+ * aborted, and the queue goes out immediately with the completed tool's result
+ * already in the transcript.
+ *
+ * What must hold before firing:
+ *
+ *   - **Something NEW is pending.** `hasNewPending` is "a message enqueued
+ *     since the last claim". A leftover from a split batch (the user changed
+ *     model mid-queue, so `claimBatch` stopped early) was queued BEFORE the
+ *     turn it did not join — it waits for that turn like any queued message,
+ *     rather than killing the run its own batch-mates just started.
+ *   - **The server says busy.** An idle session has nothing to interrupt; the
+ *     ordinary drain owns that path and already dispatches there.
+ *   - **No tool is executing.** The boundary. `hasRunningTool` comes from
+ *     `running-tool.ts`; a `pending` tool does not block, because it has not
+ *     started.
+ *   - **No human is being waited on.** A question, approval, or permission
+ *     prompt means the run is paused FOR the user — aborting it would answer
+ *     on their behalf. The queue holds, exactly as the drain does.
+ *   - **Nothing else holds the queue.** Stop's pause, read-only views, staged
+ *     rewinds, a sleeping runtime, our own unacknowledged send, a compaction:
+ *     all the reasons the drain would not release also mean do not interrupt.
+ *   - **Not already busy doing this.** One send or one interrupt at a time.
+ */
+export function shouldInterruptForQueue(input: {
+  gates: QueueDrainGates;
+  hasRunningTool: boolean;
+  /** A message was enqueued since the last claim — see above. */
+  hasNewPending: boolean;
+  /** A dispatch from an earlier tick is still awaiting its send. */
+  sending: boolean;
+  /** An earlier interrupt is still settling. */
+  interrupting: boolean;
+}): boolean {
+  const { gates } = input;
+  if (!input.hasNewPending || input.sending || input.interrupting) return false;
+  if (!gates.isServerBusy) return false;
+  if (input.hasRunningTool) return false;
+  if (gates.hasActiveQuestion || gates.hasPendingApproval || gates.pendingPermissionCount > 0) {
+    return false;
+  }
+  if (gates.isPaused || gates.readOnly || gates.revertStaged) return false;
+  if (!gates.runtimeReady) return false;
+  if (gates.pendingSendInFlight || gates.isOptimisticCompacting) return false;
+  return true;
+}
+
+/**
+ * Carry out one interrupt: abort the run, wait for that to settle, then claim
+ * and dispatch the queue as one prompt.
+ *
+ * Injected like `stopThenSendNow` (session-chat.tsx), so the ordering is
+ * asserted in tests rather than observed by hand. The rules:
+ *
+ *   - `interrupt()` resolves only once the abort has settled (server-confirmed
+ *     or bounded-timeout — see `AbortSettlement`). If it REJECTS, nothing is
+ *     dispatched: a prompt must never be fired into a turn that might still be
+ *     running. The ordinary drain picks the queue up at the real end of turn.
+ *   - `isHeld()` is re-checked after the abort settles. A stop pressed while
+ *     the interrupt was in flight wins — "stop doing things" includes the
+ *     queue, even a queue that was mid-interrupt.
+ *   - An empty claim means another path (the ordinary drain, another view of
+ *     this session) took the batch first; the store's claim is the lock, so
+ *     this dispatches nothing rather than doubling up.
+ */
+export async function runQueueInterrupt<T>(deps: {
+  interrupt: () => Promise<void>;
+  isHeld: () => boolean;
+  claimBatch: () => T[];
+  dispatch: (claimed: T[]) => Promise<void>;
+}): Promise<void> {
+  try {
+    await deps.interrupt();
+  } catch {
+    return;
+  }
+  if (deps.isHeld()) return;
+  const claimed = deps.claimBatch();
+  if (claimed.length === 0) return;
+  await deps.dispatch(claimed);
 }
 
 /**

--- a/apps/web/src/features/session/running-tool.test.ts
+++ b/apps/web/src/features/session/running-tool.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+
+import { hasRunningToolCall, type RunningToolMessage } from './running-tool';
+
+function assistant(
+  parts: Array<{ type?: string; state?: { status?: string } }>,
+  info: Partial<RunningToolMessage['info']> = {},
+): RunningToolMessage {
+  return { info: { role: 'assistant', ...info }, parts };
+}
+
+const user: RunningToolMessage = { info: { role: 'user' }, parts: [] };
+
+describe('hasRunningToolCall', () => {
+  test('false with no messages', () => {
+    expect(hasRunningToolCall(undefined)).toBe(false);
+    expect(hasRunningToolCall([])).toBe(false);
+  });
+
+  test('true while a tool part on the open assistant message is running', () => {
+    expect(
+      hasRunningToolCall([user, assistant([{ type: 'tool', state: { status: 'running' } }])]),
+    ).toBe(true);
+  });
+
+  test('false once every tool part has completed or errored', () => {
+    expect(
+      hasRunningToolCall([
+        user,
+        assistant([
+          { type: 'tool', state: { status: 'completed' } },
+          { type: 'tool', state: { status: 'error' } },
+        ]),
+      ]),
+    ).toBe(false);
+  });
+
+  test('a pending tool does not block — it has not started executing', () => {
+    // Interrupting before a tool starts is exactly the boundary the queue
+    // wants: the tool never runs, nothing is killed halfway.
+    expect(
+      hasRunningToolCall([user, assistant([{ type: 'tool', state: { status: 'pending' } }])]),
+    ).toBe(false);
+  });
+
+  test('non-tool parts never count', () => {
+    expect(
+      hasRunningToolCall([user, assistant([{ type: 'text' }, { type: 'reasoning' }])]),
+    ).toBe(false);
+  });
+
+  test('only the last assistant message is consulted', () => {
+    // An older message frozen with a `running` part (dead sandbox husk) must
+    // not block interrupts for the rest of the session's life.
+    expect(
+      hasRunningToolCall([
+        assistant([{ type: 'tool', state: { status: 'running' } }]),
+        user,
+        assistant([{ type: 'tool', state: { status: 'completed' } }]),
+      ]),
+    ).toBe(false);
+  });
+
+  test('a completed or errored assistant message cannot have a running tool', () => {
+    // `time.completed` / `error` mean the turn ended; a part still reading
+    // `running` there is stale data, not a live execution.
+    expect(
+      hasRunningToolCall([
+        assistant([{ type: 'tool', state: { status: 'running' } }], {
+          time: { completed: 123 },
+        }),
+      ]),
+    ).toBe(false);
+    expect(
+      hasRunningToolCall([
+        assistant([{ type: 'tool', state: { status: 'running' } }], { error: { name: 'x' } }),
+      ]),
+    ).toBe(false);
+  });
+
+  test('a trailing user message does not hide the open assistant turn', () => {
+    // The optimistic user bubble for a queued send appears after the open
+    // assistant message; the scan skips non-assistant roles.
+    expect(
+      hasRunningToolCall([
+        assistant([{ type: 'tool', state: { status: 'running' } }]),
+        user,
+      ]),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/features/session/running-tool.ts
+++ b/apps/web/src/features/session/running-tool.ts
@@ -1,0 +1,41 @@
+/**
+ * Whether a tool call is executing right now.
+ *
+ * The queue's interrupt path waits on this: a message queued mid-run stops the
+ * turn at the next tool boundary, and "boundary" means no tool is
+ * mid-execution. Aborting while a Bash command, file write, or git commit is
+ * running kills it halfway — the one thing the interrupt must never do. A tool
+ * in `pending` has not started executing, so it does not block; interrupting
+ * then is exactly the boundary the user wants, because the tool never starts.
+ *
+ * Only the LAST assistant message is scanned, and only while it is still open.
+ * A completed or errored turn cannot have a genuinely live tool, and a dead
+ * turn's husk (sandbox died mid-run, parts frozen at `running`) must not block
+ * interrupts for the rest of the session's life. The interrupt additionally
+ * requires the server to report busy (`shouldInterruptForQueue`), so a frozen
+ * part on an idle session never reaches this check at all.
+ */
+
+/** The shape this predicate needs. Wider message types satisfy it structurally. */
+export interface RunningToolMessage {
+  info: {
+    role: string;
+    time?: { completed?: number | null; [key: string]: unknown } | null;
+    error?: unknown;
+  };
+  parts?: Array<{ type?: string; state?: { status?: string } | null } | null | undefined> | null;
+}
+
+export function hasRunningToolCall(messages: RunningToolMessage[] | undefined): boolean {
+  if (!messages?.length) return false;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.info.role !== 'assistant') continue;
+    if (message.info.time?.completed || message.info.error) return false;
+    return (message.parts ?? []).some(
+      (part) => part?.type === 'tool' && part.state?.status === 'running',
+    );
+  }
+  return false;
+}

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -24,6 +24,7 @@ import { useParams, usePathname, useRouter } from 'next/navigation';
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { hasOpenAssistantTurn } from './assistant-turn-open';
+import { hasRunningToolCall } from './running-tool';
 import {
   SystemNotificationCard,
   parseSystemNotifications,
@@ -2277,6 +2278,12 @@ export function SessionChat({
   // gate permanently. See `assistant-turn-open.ts`.
   const hasIncompleteAssistant = useMemo(() => hasOpenAssistantTurn(messages), [messages]);
 
+  // A tool call is executing right now. This is the queue interrupt's ONE
+  // message-derived input: a message queued mid-run stops the turn at the next
+  // tool boundary, and this is the boundary — the drain's end-of-turn machine
+  // still never reads messages. See `running-tool.ts`.
+  const hasRunningTool = useMemo(() => hasRunningToolCall(messages), [messages]);
+
   const hasPendingUserReply = useMemo(() => {
     if (!messages || messages.length === 0) return false;
     let lastUserIdx = -1;
@@ -2415,7 +2422,8 @@ export function SessionChat({
   // Client-side message queue — mirrors Claude Code / Codex: a message typed
   // while the agent is mid-turn is held instead of being sent straight through
   // (the OpenCode server would accept it immediately, but interleaving it into
-  // a live turn is exactly the reported bug).
+  // a live turn is exactly the reported bug), then delivered by interrupting
+  // the run at the next tool boundary — see `use-message-queue-drain.ts`.
   //
   // The state lives in `useMessageQueueStore` — per session and persisted —
   // not here. As component state it died silently on every session-tab switch,
@@ -3457,15 +3465,19 @@ export function SessionChat({
     unregisterSender,
   ]);
 
-  // Release the whole queue on one prompt, only when the turn actually ended.
+  // Release the whole queue on one prompt — by interrupting the run at the
+  // next tool boundary when something new was typed mid-run (the Claude Code
+  // behavior; see `use-message-queue-drain.ts`), or at the real end of turn
+  // when the interrupt is held.
   //
   // What used to be here drained the WHOLE queue whenever any tool part flipped
   // to 'completed' or 'error', or whenever the debounced `isBusy` fell. Both
   // fire mid-turn: a tool finishing means the agent is still working, and
   // `isBusy` is a 300ms fade timer for the busy indicator. It also watched
   // `messages`, so scrolling up to load older history counted as boundaries
-  // too. The drain now reads the server's own session status plus the gates
-  // that mean a human is being waited on, and nothing else.
+  // too. The end-of-turn drain now reads the server's own session status plus
+  // the gates that mean a human is being waited on; the interrupt path
+  // additionally reads exactly one message-derived signal, `hasRunningTool`.
   const queueGates = useMemo<QueueDrainGates>(
     () => ({
       isServerBusy,
@@ -3560,10 +3572,37 @@ export function SessionChat({
     [handleSend, commands],
   );
 
+  /**
+   * The abort the queue's interrupt path issues when a message is typed
+   * mid-run. Same machinery as the stop button — the optimistic "Interrupted"
+   * label, the tracked `AbortSettlement` — with two deliberate differences:
+   * it never pauses the queue (the interrupt exists to deliver it), and it
+   * reuses a stop already in flight rather than issuing a second abort.
+   * Resolves only once the abort has settled; `awaitAbortSettlement`-produced
+   * settlements never reject, and a failed/timed-out settlement still means
+   * any local in-flight delivery was cancelled first (see `stopThenSendNow`'s
+   * doc), so dispatching after it cannot race the old turn.
+   */
+  const interruptForQueue = useCallback(async (): Promise<void> => {
+    const pending = pendingAbortSettlementRef.current.get(sessionId);
+    if (pending) {
+      await pending;
+      return;
+    }
+    const status = useSessionStateStore.getState().sessionStatus[sessionId];
+    if (status?.type !== 'busy' && status?.type !== 'retry') return;
+    applyOptimisticAbort(sessionId);
+    clearTimeout(busyTimerRef.current);
+    setIsBusy(false);
+    await issueSessionCancel();
+  }, [sessionId, issueSessionCancel]);
+
   const queueDrain = useMessageQueueDrain({
     sessionId,
     gates: queueGates,
+    hasRunningTool,
     send: sendQueuedBatch,
+    interrupt: interruptForQueue,
   });
 
   // NOTE: no client-side "auto-continue after approval" here — resuming the
@@ -3599,8 +3638,9 @@ export function SessionChat({
 
   /**
    * The per-row action: end the current turn if one is running, then send that
-   * message. The only path that interrupts a running turn — automatic draining
-   * never does — which is why it is a deliberate click and says what it does.
+   * message. Unlike the automatic interrupt (`interruptForQueue`), this jumps
+   * the queue order, sends the row ALONE, and does not wait for a tool
+   * boundary — it is a deliberate click and says what it does.
    *
    * T10: waits for the real `AbortSettlement` the stop it just issued
    * produces (via `stopThenSendNow`), not a guess and not the optimistic

--- a/apps/web/src/features/session/use-message-queue-drain.ts
+++ b/apps/web/src/features/session/use-message-queue-drain.ts
@@ -1,8 +1,20 @@
 'use client';
 
 /**
- * Drives the queue: watches the gates, waits for a real end-of-turn, and sends
- * everything that is waiting when it arrives.
+ * Drives the queue: interrupts the running turn at the next tool boundary when
+ * something new is queued, and otherwise waits for a real end-of-turn — either
+ * way sending everything that is waiting as one prompt.
+ *
+ * **A queued message interrupts; it does not wait out the run.** This is the
+ * Claude Code behavior: a message typed while the agent works is the user
+ * steering, so the currently executing tool call is allowed to finish (never
+ * killed halfway), the remainder of the turn is aborted, and the queue goes
+ * out immediately — with the completed tool's result already in the
+ * transcript. Waiting for the whole original turn, while the agent kept
+ * running more tools against a plan the user had already amended, was the
+ * reported bug. The decision is `shouldInterruptForQueue`'s and the ordering
+ * is `runQueueInterrupt`'s, both pure and tested in
+ * `message-queue-boundary.test.ts`.
  *
  * **The whole queue goes out together, on one prompt.** Three messages typed
  * during a turn reach the agent as one turn's worth of instructions, in the
@@ -38,9 +50,13 @@
  * Two things this hook deliberately does NOT do, both of them root causes of
  * the bug it replaces:
  *
- *   - It never reads `messages`. The old drain watched the message array for
- *     tool parts flipping to `completed`, which fired mid-turn on every tool
- *     call and again whenever scrolling up loaded older history.
+ *   - The end-of-turn drain never reads `messages`. The old drain watched the
+ *     message array for tool parts flipping to `completed`, which fired
+ *     mid-turn on every tool call and again whenever scrolling up loaded older
+ *     history. The interrupt path takes exactly one message-derived input —
+ *     the `hasRunningTool` boolean — and uses it only to WAIT (never to treat
+ *     a tool completion as a drain boundary), so a history load still cannot
+ *     release anything.
  *   - It never reads `isBusy`. That is a 300 ms fade timer for the busy
  *     indicator; `QueueDrainGates` does not expose it.
  *
@@ -54,7 +70,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   createDrainMachine,
   planDrainTick,
+  runQueueInterrupt,
   shouldClearPause,
+  shouldInterruptForQueue,
   type DrainMachine,
   type QueueDrainGates,
 } from './message-queue-boundary';
@@ -63,6 +81,12 @@ export interface UseMessageQueueDrainOptions {
   sessionId: string;
   gates: QueueDrainGates;
   /**
+   * A tool call is executing right now (`hasRunningToolCall`). The interrupt
+   * waits for it — the turn is only ever stopped at a tool boundary, so a
+   * Bash command, file write, or commit is never killed halfway.
+   */
+  hasRunningTool: boolean;
+  /**
    * Put the batch on the wire as ONE prompt, in the order given. Must reject
    * if the send did not land.
    *
@@ -70,6 +94,14 @@ export interface UseMessageQueueDrainOptions {
    * lands inside it, which is the interleaving this queue exists to prevent.
    */
   send: (messages: WebQueuedMessage[]) => Promise<void>;
+  /**
+   * Stop the current run and resolve once the abort has SETTLED — the
+   * server-confirmed `AbortSettlement`, not the optimistic idle flip. Must
+   * reject if the run may still be live, in which case nothing is dispatched
+   * and the ordinary drain takes over at the real end of turn. Must NOT pause
+   * the queue: this interrupt exists to deliver it.
+   */
+  interrupt: () => Promise<void>;
 }
 
 export interface MessageQueueDrainControls {
@@ -106,13 +138,27 @@ function errorMessage(cause: unknown): string {
 export function useMessageQueueDrain({
   sessionId,
   gates,
+  hasRunningTool,
   send,
+  interrupt,
 }: UseMessageQueueDrainOptions): MessageQueueDrainControls {
   const machineRef = useRef<DrainMachine>(createDrainMachine());
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const pausedRef = useRef(false);
   const [paused, setPaused] = useState(false);
   const sendingRef = useRef(false);
+  const interruptingRef = useRef(false);
+  /**
+   * Pending ids left behind by the last claim, or null before any claim.
+   *
+   * `claimBatch` stops at a model/agent change or a `/` command, so a claim
+   * can leave a remainder. Those messages were queued BEFORE the turn their
+   * batch-mates just started — they must wait for it like any queued message,
+   * not interrupt it. Only an id absent from this set counts as "newly typed
+   * during the run" for `shouldInterruptForQueue`. The ordinary end-of-turn
+   * drain still releases leftovers as before.
+   */
+  const leftoverIdsRef = useRef<Set<string> | null>(null);
 
   /** Keep the tick-visible ref and the render-visible state in lockstep. */
   const setPausedState = useCallback((next: boolean) => {
@@ -125,6 +171,8 @@ export function useMessageQueueDrain({
   // an effect, never during render — see the sync effect below.
   const gatesRef = useRef(gates);
   const sendRef = useRef(send);
+  const hasRunningToolRef = useRef(hasRunningTool);
+  const interruptRef = useRef(interrupt);
 
   const hydrated = useMessageQueueStore((s) => s.hydrated);
   useEffect(() => {
@@ -154,17 +202,79 @@ export function useMessageQueueDrain({
     [sessionId],
   );
 
-  // Every decision below is `planDrainTick`'s; what is left here is carrying it
-  // out. The store read, the timer and the claim are the only parts that
-  // genuinely cannot be a pure function.
+  /**
+   * Claim the batch and record what it left behind. Every claim goes through
+   * here so `leftoverIdsRef` — the "queued before this turn, do not interrupt
+   * it" set — is written in the same step that creates the leftovers.
+   */
+  const claimBatchTracked = useCallback((): WebQueuedMessage[] => {
+    const store = useMessageQueueStore.getState();
+    const claimed = store.claimBatch(sessionId);
+    if (claimed.length > 0) {
+      const claimedIds = new Set(claimed.map((m) => m.id));
+      leftoverIdsRef.current = new Set(
+        store
+          .getSessionQueue(sessionId)
+          .pending.filter((m) => !claimedIds.has(m.id))
+          .map((m) => m.id),
+      );
+    }
+    return claimed;
+  }, [sessionId]);
+
+  // Every decision below is `planDrainTick`'s (or `shouldInterruptForQueue`'s);
+  // what is left here is carrying it out. The store read, the timer and the
+  // claim are the only parts that genuinely cannot be a pure function.
   const tick = useCallback(() => {
     clearTimeout(timerRef.current);
 
+    const gatesNow = {
+      ...gatesRef.current,
+      isPaused: gatesRef.current.isPaused || pausedRef.current,
+    };
+    const pending = useMessageQueueStore.getState().getSessionQueue(sessionId).pending;
+
+    // The interrupt path: something newly typed is waiting, the server is
+    // mid-run, and no tool call is executing. Stop the run at this boundary
+    // and deliver the queue now — do not wait for the turn the user has
+    // already amended. `runQueueInterrupt` re-checks the pause after the abort
+    // settles and leaves the store claim as the lock against double-dispatch;
+    // if the abort fails, the ordinary drain below still releases the queue at
+    // the real end of turn.
+    const hasNewPending = pending.some((m) => !leftoverIdsRef.current?.has(m.id));
+    if (
+      shouldInterruptForQueue({
+        gates: gatesNow,
+        hasRunningTool: hasRunningToolRef.current,
+        hasNewPending,
+        sending: sendingRef.current,
+        interrupting: interruptingRef.current,
+      })
+    ) {
+      interruptingRef.current = true;
+      machineRef.current = createDrainMachine();
+      void runQueueInterrupt<WebQueuedMessage>({
+        interrupt: () => interruptRef.current(),
+        isHeld: () => pausedRef.current || gatesRef.current.readOnly,
+        claimBatch: claimBatchTracked,
+        dispatch: (claimed) => dispatchClaimed(claimed),
+      }).finally(() => {
+        interruptingRef.current = false;
+        tickRef.current();
+      });
+      return;
+    }
+
     const { machine, action } = planDrainTick({
       machine: machineRef.current,
-      gates: { ...gatesRef.current, isPaused: gatesRef.current.isPaused || pausedRef.current },
-      pendingCount: useMessageQueueStore.getState().getSessionQueue(sessionId).pending.length,
-      sending: sendingRef.current,
+      gates: gatesNow,
+      pendingCount: pending.length,
+      // An interrupt mid-settle counts as sending: `applyOptimisticAbort`
+      // flips the busy gate clear synchronously, so without this the settle
+      // window could elapse and dispatch a second prompt while the abort is
+      // still winding down on the server — the exact race `stopThenSendNow`
+      // exists to prevent.
+      sending: sendingRef.current || interruptingRef.current,
       now: Date.now(),
     });
     machineRef.current = machine;
@@ -172,8 +282,7 @@ export function useMessageQueueDrain({
     switch (action.kind) {
       case 'dispatch': {
         // Everything waiting, as one prompt.
-        const claimed = useMessageQueueStore.getState().claimBatch(sessionId);
-        void dispatchClaimed(claimed);
+        void dispatchClaimed(claimBatchTracked());
         return;
       }
       case 'wait':
@@ -183,7 +292,7 @@ export function useMessageQueueDrain({
       case 'idle':
         return;
     }
-  }, [sessionId, dispatchClaimed]);
+  }, [sessionId, dispatchClaimed, claimBatchTracked]);
 
   // Refresh the mutable reads after every commit. Declared BEFORE the gate
   // effect below, so by the time a gate change calls `tick`, the refs it reads
@@ -192,17 +301,24 @@ export function useMessageQueueDrain({
   useEffect(() => {
     gatesRef.current = gates;
     sendRef.current = send;
+    hasRunningToolRef.current = hasRunningTool;
+    interruptRef.current = interrupt;
     tickRef.current = tick;
   });
 
   // One dependency per gate, spelled out. `messages` is absent by design (root
-  // cause 3): a history load must never look like the end of a turn.
+  // cause 3): a history load must never look like the end of a turn —
+  // `hasRunningTool` is derived from messages but only its BOOLEAN transition
+  // ticks here, and it is read by the interrupt path alone, never by the
+  // drain's end-of-turn machine. Its falling edge is what makes "the moment
+  // the current tool finishes" an event rather than a poll.
   useEffect(() => {
     tick();
     return () => clearTimeout(timerRef.current);
   }, [
     tick,
     hydrated,
+    hasRunningTool,
     gates.isServerBusy,
     gates.pendingSendInFlight,
     gates.isOptimisticCompacting,
@@ -212,6 +328,7 @@ export function useMessageQueueDrain({
     gates.pendingPermissionCount,
     gates.isPaused,
     gates.readOnly,
+    gates.runtimeReady,
     gates.revertStaged,
   ]);
 
@@ -262,7 +379,18 @@ export function useMessageQueueDrain({
       useMessageQueueStore.getState().reorder(sessionId, id, 0);
       machineRef.current = createDrainMachine();
       const claimed = useMessageQueueStore.getState().claimNext(sessionId);
-      if (claimed) await dispatchClaimed([claimed]);
+      if (claimed) {
+        // Everything NOT sent by this click was queued before the turn it is
+        // about to start — mark it so the interrupt path lets that turn run.
+        leftoverIdsRef.current = new Set(
+          useMessageQueueStore
+            .getState()
+            .getSessionQueue(sessionId)
+            .pending.filter((m) => m.id !== claimed.id)
+            .map((m) => m.id),
+        );
+        await dispatchClaimed([claimed]);
+      }
     },
     [sessionId, dispatchClaimed, setPausedState],
   );


### PR DESCRIPTION
## Issue

A message typed while the agent was mid-run waited for the **entire** turn to finish. The agent kept thinking, kept running the tool calls it had already planned, and only then read the instruction that was meant to change what it was doing. Queue the note "actually, also update the README" during a five-tool task and it lands minutes later, after all five tools ran against the plan you had already amended.

The cause is in the release path, not the UI. `useMessageQueueDrain` dispatches only when `planDrainTick` says every drain gate — `isServerBusy` included — has been continuously clear for 700ms, which is "full turn end" by construction. No code path interrupted a running turn on enqueue. The only interrupting path was the per-row "Send now" button, which renders only while the queue is paused.

## Solution

Treat the queue as an interrupt at the next safe agent boundary, matching Claude Code. The currently executing tool call always finishes — a Bash command, file write, or `git commit` is never killed halfway — then the remainder of the run is aborted and the whole queue goes out immediately as one prompt, with the completed tool's result already in the transcript.

- **`running-tool.ts`** (new) — `hasRunningToolCall`: a tool part reading `running` on the still-open last assistant message. A `pending` tool does **not** block; it has not started executing, so interrupting there kills nothing.
- **`message-queue-boundary.ts`** — `shouldInterruptForQueue` (the decision) and `runQueueInterrupt` (abort → await settlement → re-check the pause → claim → dispatch). Both pure and clock-free, so every rule is a unit test rather than something observed by hand.
- **`use-message-queue-drain.ts`** — the interrupt branch runs before the end-of-turn machine. `hasRunningTool`'s falling edge is what makes "the moment the tool finishes" an event rather than a poll.
- **`session-chat.tsx`** — `interruptForQueue` reuses a stop already in flight, otherwise issues the same tracked `AbortSettlement` the stop button uses. Unlike `handleStop` it never pauses the queue: this interrupt exists to deliver it.

The end-of-turn drain stays as the fallback for every case where interrupting is wrong — a question or approval on screen, the user pressed stop, a read-only view, a staged rewind, a sleeping runtime — and for a failed abort, where dispatching could fire into a turn that is still live.

Three guards keep the state machine honest under the cases that broke earlier attempts:

1. **One interrupt at a time** (`interruptingRef`), so a re-render mid-abort cannot issue a second.
2. **A batch-split remainder never interrupts the turn its own batch-mates started** (`leftoverIdsRef`). `claimBatch` stops at a model/agent change or a `/` command, so a claim can leave messages behind — those were queued *before* that turn and wait for it like any queued message.
3. **An in-flight interrupt counts as `sending`** for the ordinary drain. `applyOptimisticAbort` flips the busy gate clear synchronously, so without this the 700ms settle window could elapse and dispatch a second prompt while the abort was still winding down.

Queue UX is unchanged, because it already matched: Enter auto-queues while busy, rows are visible in typed order, there is no per-row send button mid-run, rows leave the list the instant they are claimed, and the store claim is the double-send lock. One wording fix — the sr-only summary said "sends when this turn ends", which is now an overstatement of the wait.

Also fixed in passing: `gates.runtimeReady` was missing from the drain tick's effect dependencies, so a message queued while the sandbox slept could stall after it woke.

## Testing

- `bun test src` (apps/web) — **7671 pass, 0 fail, 601 files**. Includes 30 new tests: the interrupt decision matrix (every hold, the busy requirement, the running-tool wait and its falling edge), `runQueueInterrupt` ordering (abort before dispatch, failed abort dispatches nothing, stop-during-abort wins, empty claim is a no-op), and `hasRunningToolCall` edges (pending, non-tool parts, a dead turn's frozen husk, a trailing optimistic user bubble).
- `npx tsc --noEmit` — clean apart from the documented baseline (`test.each` in the 3 known files, `@/.source` from fumadocs). Zero errors in changed files.
- `npx eslint` on all 9 touched files — 0 errors. `session-chat.tsx`'s warning set is identical to `main` (37 pre-existing `react-hooks/*`); the new files are clean.

ESC-to-stop verified unaffected by reading the path rather than by test: the triple-ESC listener is a `window` keydown handler in `session-chat.tsx`, and tiptap only calls `preventDefault` on Escape while a suggestion menu is open — so the shortcut still fires with focus inside the composer.

## Notes

Not yet exercised against a live agent. The acceptance test is the side-by-side: start a task that runs several sequential tools, submit a prompt while one is running, and confirm the tool finishes, "Interrupted" appears, and the queued prompt is consumed immediately rather than after the remaining planned tools.

Two accepted races, both pre-existing in kind:

- If the agent starts its *next* tool in the window between our boundary check and the abort landing, that tool is aborted. A client cannot close this without a server-side "abort at next boundary" primitive.
- A `failed` or `timed-out` `AbortSettlement` still dispatches once its ~5s bound elapses — the same tradeoff `stopThenSendNow` already makes, on the same reasoning: whichever cancel path produced the settlement already cancelled any local in-flight delivery.
