### PR TITLE
fix(web): show real upstream provider, not "Kortix", in session usage + model switcher

### DIFF
--- a/apps/web/src/features/session/session-context-modal.tsx
+++ b/apps/web/src/features/session/session-context-modal.tsx
@@ -32,6 +32,7 @@ import { Close } from '@/features/icon/icons/close';
 import { useModelPricingLookup } from '@/lib/model-pricing';
 import { cn } from '@/lib/utils';
 import type { MessageWithParts } from '@/ui/types';
+import { PROVIDER_LABELS } from '@kortix/llm-catalog';
 import type { AssistantMessage, Message, Part, Session } from '@kortix/sdk';
 import type { ProviderListResponse } from '@kortix/sdk/react';
 import { useSessionStateStore } from '@kortix/sdk/react';
@@ -113,11 +114,21 @@ function getSessionContextMetrics(
   const limit = model?.limit?.context as number | undefined;
   const total = tokenTotal(last);
 
+  // The gateway registers every model under the single synthetic `kortix`
+  // opencode provider, so `provider.name` is always "Kortix" — even for a
+  // BYOK Anthropic/Bedrock/OpenAI model. The gateway separately serves the
+  // REAL upstream provider on the model itself (`model.provider`, e.g.
+  // "anthropic"); prefer that for display, same fallback order as
+  // `pickerGroupId`/`pickerGroupLabel` in ./model-grouping.ts.
+  const upstreamProviderId =
+    last.providerID === 'kortix' && model?.provider ? model.provider : last.providerID;
+
   return {
     totalCost,
     context: {
       message: last,
-      providerLabel: (provider as any)?.name ?? last.providerID,
+      providerLabel:
+        PROVIDER_LABELS[upstreamProviderId] ?? (provider as any)?.name ?? last.providerID,
       modelLabel: model?.name ?? last.modelID,
       limit,
       input: last.tokens?.input ?? 0,

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -99,6 +99,7 @@ import { useWorkspaceSearch } from '@/features/files';
 import { MODEL_SELECTOR_PROVIDER_IDS, ProviderLogo } from '@/features/providers/provider-branding';
 import { DiffDialog } from '@/features/session/diff-dialog';
 import { CompactModal } from '@/features/session/header/compact-modal';
+import { pickerGroupId, pickerGroupLabel } from '@/features/session/model-grouping';
 import { flattenModels } from '@/features/session/session-chat-input';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
 import { isBillingEnabled } from '@/lib/config';
@@ -803,13 +804,20 @@ export function CommandPalette() {
       { providerID: string; providerName: string; models: typeof visibleModels }
     >();
     for (const m of visibleModels) {
-      const existing = groups.get(m.providerID);
+      // Under the gateway every model is registered as opencode provider
+      // `kortix`, so `m.providerName` is always "Kortix" — even for a BYOK
+      // Anthropic/Bedrock model. Group/label by the resolved REAL upstream
+      // provider instead. Safe to call unconditionally: for a native
+      // (non-gateway) model `pickerGroupId` already returns `m.providerID`
+      // as-is. See model-grouping.ts's doc comment.
+      const groupID = pickerGroupId(m);
+      const existing = groups.get(groupID);
       if (existing) {
         existing.models.push(m);
       } else {
-        groups.set(m.providerID, {
-          providerID: m.providerID,
-          providerName: m.providerName,
+        groups.set(groupID, {
+          providerID: groupID,
+          providerName: pickerGroupLabel(groupID, m),
           models: [m],
         });
       }


### PR DESCRIPTION
## Problem

Every gateway model is registered under the single synthetic opencode
provider `kortix`, so `provider.name` on the wire is always `"Kortix"` —
even for a BYOK Anthropic/Bedrock/OpenAI model. Two surfaces read that
wrapper name directly instead of the model's own real upstream provider:

- **Session usage modal** (`session-context-modal.tsx`) — the "Model"
  stat's provider meta line always shows "Kortix", e.g. "Claude Opus 5 (EU)
  · Kortix" instead of "· Anthropic".
- **Cmd+K command palette model switcher** (`command-palette.tsx`) —
  `groupedModels` grouped/labeled strictly by raw `providerID`/`providerName`,
  so every model (Anthropic, OpenAI, ...) shows grouped under one "Kortix"
  heading instead of its real provider.

The gateway already serves the real upstream id on each model
(`GatewayModel.provider` / `FlatModel.provider`, e.g. `"anthropic"`) — this
same bug was already found and fixed for the model picker
(`model-selector.tsx`) and the "Manage models" tab, via
`pickerGroupId`/`pickerGroupLabel` in `model-grouping.ts`. It just wasn't
applied to these two spots.

## Fix

- `session-context-modal.tsx`: `getSessionContextMetrics` now resolves
  `providerLabel` from the model's own `.provider` field (via
  `PROVIDER_LABELS`) when the wrapper provider is `kortix`, falling back to
  the wrapper name only when the model doesn't carry the field.
- `command-palette.tsx`: `groupedModels` now groups/labels with the existing
  `pickerGroupId`/`pickerGroupLabel` helpers instead of raw `providerID`/
  `providerName`.

## Verification

- `npx eslint` on both changed files: clean (0 errors).
- `npx tsc --noEmit` on `apps/web`: same known baseline (15 pre-existing
  `test.each` errors in 3 documented test files + 2 `@/.source` errors from
  a fresh worktree missing the fumadocs build step) — nothing new from
  these files.
- Connected a real Anthropic BYOK key to a live local project via the
  "Manage models" panel, fetched the actual `/v1/projects/:id/model-picker`
  response from the running dev API, and ran the new `providerLabel`
  resolution logic (importing the real `PROVIDER_LABELS` from
  `@kortix/llm-catalog`) against that live data:
  - `anthropic/claude-sonnet-5` → `"Anthropic"` (was `"Kortix"`)
  - `deepseek-v4-flash` (genuinely Kortix-managed) → `"Kortix"` (unchanged,
    correct)

## Not verified

- A full send-a-message → Session usage modal screenshot on a BYOK model,
  because the local test account has no billing entitlement to run live
  inference. The fix is verified against the real catalog data shape
  instead (above). Anyone with a connected provider and an existing session
  can confirm visually once deployed to dev.
