### PR TITLE
fix(members): repair Groups/Roles links + multi-select grant dialogs

### DIFF
--- a/apps/web/src/features/workspace/capabilities/members/members-page.tsx
+++ b/apps/web/src/features/workspace/capabilities/members/members-page.tsx
@@ -31,7 +31,7 @@ export function MembersPage({ projectId }: { projectId: string }) {
     ...contract('config'),
   });
 
-  const settingsNav = useStandaloneCapabilityNav(projectId, 'members');
+  const settingsNav = useStandaloneCapabilityNav(projectId, 'members', detail.data?.project.account_id);
 
   return (
     <SettingsNavProvider value={settingsNav}>

--- a/apps/web/src/features/workspace/capabilities/project-settings/project-settings-page.test.ts
+++ b/apps/web/src/features/workspace/capabilities/project-settings/project-settings-page.test.ts
@@ -23,12 +23,16 @@ import {
  * `stores/settings-panel-store.test.ts`, so these reset it between tests
  * rather than mocking it.
  */
-function navFor(section: Parameters<typeof buildProjectSettingsNav>[0]['section'] = 'general') {
+function navFor(
+  section: Parameters<typeof buildProjectSettingsNav>[0]['section'] = 'general',
+  accountId?: string,
+) {
   const pushed: string[] = [];
   const nav = buildProjectSettingsNav({
     projectId: 'p1',
     section,
     membersTab: useSettingsPanelStore.getState().membersTab,
+    accountId,
     navigateTo: (href) => pushed.push(href),
   });
   return { nav, pushed };
@@ -177,6 +181,24 @@ describe('buildProjectSettingsNav', () => {
   test('navigate() to an id nobody owns does nothing at all', () => {
     const { nav, pushed } = navFor('sandbox');
     nav.navigate('marketplace');
+    expect(pushed).toEqual([]);
+    expect(useSettingsPanelStore.getState().open).toBe(false);
+  });
+
+  test('navigate() to an ACCOUNT_GRADUATED id (groups, roles) routes to the account page', () => {
+    // Regression: Members' Access tab links "Create one in Groups" / "Create
+    // one in Roles" through this same navigate() vocabulary. Before this
+    // branch existed, `groups`/`roles` matched none of the three checks and
+    // the click did nothing — reported live as "when I click the groups
+    // link, it doesn't work either."
+    const { nav, pushed } = navFor('sandbox', 'acct-1');
+    nav.navigate('groups');
+    expect(pushed).toEqual(['/accounts/acct-1?tab=groups']);
+  });
+
+  test('an ACCOUNT_GRADUATED id with no accountId yet does nothing, not a broken URL', () => {
+    const { nav, pushed } = navFor('sandbox');
+    nav.navigate('roles');
     expect(pushed).toEqual([]);
     expect(useSettingsPanelStore.getState().open).toBe(false);
   });

--- a/apps/web/src/features/workspace/capabilities/project-settings/project-settings-page.tsx
+++ b/apps/web/src/features/workspace/capabilities/project-settings/project-settings-page.tsx
@@ -36,7 +36,11 @@ import {
 } from '@/lib/project-actions';
 import { useProjectCans } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
-import { parseSettingsTab } from '@/features/workspace/settings/settings-tabs';
+import {
+  ACCOUNT_GRADUATED,
+  isAccountGraduatedSection,
+  parseSettingsTab,
+} from '@/features/workspace/settings/settings-tabs';
 import { useSettingsPanelStore, type MembersTab } from '@/stores/settings-panel-store';
 
 import {
@@ -152,8 +156,15 @@ export function ProjectSettingsPage({ projectId }: { projectId: string }) {
   const membersTab = useSettingsPanelStore((s) => s.membersTab);
   const navigateTo = useCallback((href: string) => router.push(href), [router]);
   const settingsNav = useMemo(
-    () => buildProjectSettingsNav({ projectId, section: active, membersTab, navigateTo }),
-    [projectId, active, membersTab, navigateTo],
+    () =>
+      buildProjectSettingsNav({
+        projectId,
+        section: active,
+        membersTab,
+        accountId: project?.account_id,
+        navigateTo,
+      }),
+    [projectId, active, membersTab, project?.account_id, navigateTo],
   );
 
   const activeSection = sections.find((s) => s.key === active);
@@ -393,6 +404,9 @@ export function buildProjectSettingsNav(state: {
   projectId: string;
   section: ProjectSettingsSectionKey;
   membersTab: MembersTab;
+  /** See the identical field on `buildStandaloneCapabilityNav` — resolves
+   *  `ACCOUNT_GRADUATED` ids (`groups`, `roles`, ...) to `/accounts/<id>`. */
+  accountId?: string;
   navigateTo: (href: string) => void;
 }): SettingsNav {
   return {
@@ -414,6 +428,14 @@ export function buildProjectSettingsNav(state: {
       const capabilityTarget = projectCapabilityNavTarget(tab);
       if (capabilityTarget) {
         state.navigateTo(projectCapabilityNavHref(state.projectId, tab, capabilityTarget));
+        return;
+      }
+      // See `standalone-settings-nav.ts`'s identical branch (and its comment
+      // on why this is NOT `legacySectionRedirect`): without this,
+      // `navigate('groups')` / `navigate('roles')` matched nothing and did
+      // nothing at all.
+      if (state.accountId && isAccountGraduatedSection(tab)) {
+        state.navigateTo(`/accounts/${state.accountId}?tab=${ACCOUNT_GRADUATED[tab]}`);
         return;
       }
       const overlayTab = parseSettingsTab(tab);

--- a/apps/web/src/features/workspace/capabilities/shared/standalone-settings-nav.test.ts
+++ b/apps/web/src/features/workspace/capabilities/shared/standalone-settings-nav.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { useSettingsPanelStore } from '@/stores/settings-panel-store';
+
+import { buildStandaloneCapabilityNav } from './standalone-settings-nav';
+
+/**
+ * `useStandaloneCapabilityNav`'s pure half — the adapter behind Models,
+ * Secrets, and Members (`members-page.tsx`). Mirrors
+ * `project-settings-page.test.ts`'s `navFor` harness for its sibling adapter;
+ * see that file's header for why `navigate` writes through the real store
+ * instead of a mock.
+ */
+function navFor(activeTab = 'members', accountId?: string) {
+  const pushed: string[] = [];
+  const nav = buildStandaloneCapabilityNav({
+    projectId: 'p1',
+    activeTab,
+    membersTab: useSettingsPanelStore.getState().membersTab,
+    accountId,
+    navigateTo: (href) => pushed.push(href),
+  });
+  return { nav, pushed };
+}
+
+beforeEach(() => {
+  useSettingsPanelStore.setState({ open: false, membersTab: 'people' });
+});
+
+describe('buildStandaloneCapabilityNav', () => {
+  test('navigate() to a sibling top-level Customize tab routes there', () => {
+    const { nav, pushed } = navFor('members');
+    nav.navigate('secrets');
+    expect(pushed).toEqual(['/projects/p1/secrets']);
+  });
+
+  test('navigate() to the page it is already on is a no-op, not a self-route', () => {
+    const { nav, pushed } = navFor('members');
+    nav.navigate('members');
+    expect(pushed).toEqual([]);
+  });
+
+  test('navigate() to an ACCOUNT_GRADUATED id (groups, roles) routes to the account page', () => {
+    // Regression: Members' Access tab's "Create one in Groups" / "Create one
+    // in Roles" links call exactly this — before this branch existed,
+    // `groups`/`roles` matched none of the checks and the click did nothing.
+    const { nav, pushed } = navFor('members', 'acct-1');
+    nav.navigate('groups');
+    expect(pushed).toEqual(['/accounts/acct-1?tab=groups']);
+  });
+
+  test('roles resolves the same way', () => {
+    const { nav, pushed } = navFor('members', 'acct-1');
+    nav.navigate('roles');
+    expect(pushed).toEqual(['/accounts/acct-1?tab=roles']);
+  });
+
+  test('an ACCOUNT_GRADUATED id with no accountId yet does nothing, not a broken URL', () => {
+    const { nav, pushed } = navFor('members');
+    nav.navigate('groups');
+    expect(pushed).toEqual([]);
+    expect(useSettingsPanelStore.getState().open).toBe(false);
+  });
+
+  test('navigate() to a tab that stayed in the overlay opens the overlay, not a route', () => {
+    const { nav, pushed } = navFor('members', 'acct-1');
+    nav.navigate('preferences');
+    expect(pushed).toEqual([]);
+    expect(useSettingsPanelStore.getState().open).toBe(true);
+    expect(useSettingsPanelStore.getState().tab).toBe('preferences');
+  });
+
+  test('an explicit membersTab opt writes the intent to the live store', () => {
+    const { nav } = navFor('sandbox');
+    nav.navigate('members', { membersTab: 'invite' });
+    expect(useSettingsPanelStore.getState().membersTab).toBe('invite');
+  });
+});

--- a/apps/web/src/features/workspace/capabilities/shared/standalone-settings-nav.ts
+++ b/apps/web/src/features/workspace/capabilities/shared/standalone-settings-nav.ts
@@ -29,7 +29,11 @@ import {
   projectSettingsNavTarget,
 } from '@/features/workspace/capabilities/project-settings/project-settings-page';
 import { projectSettingsSectionHref } from '@/features/workspace/capabilities/project-settings/project-settings-sections';
-import { parseSettingsTab } from '@/features/workspace/settings/settings-tabs';
+import {
+  ACCOUNT_GRADUATED,
+  isAccountGraduatedSection,
+  parseSettingsTab,
+} from '@/features/workspace/settings/settings-tabs';
 import type { SettingsNav } from '@/features/workspace/shared/settings-nav-context';
 import { useSettingsPanelStore, type MembersTab } from '@/stores/settings-panel-store';
 
@@ -45,6 +49,11 @@ export function buildStandaloneCapabilityNav(state: {
   projectId: string;
   activeTab: string;
   membersTab: MembersTab;
+  /** Resolves `ACCOUNT_GRADUATED` ids (`groups`, `roles`, ...) to
+   *  `/accounts/<id>?tab=<...>`. Undefined while the project detail that
+   *  yields it is still loading — those ids no-op rather than mis-navigate,
+   *  same fail-open rule the capability-tab probes use. */
+  accountId?: string;
   navigateTo: (href: string) => void;
 }): SettingsNav {
   return {
@@ -68,19 +77,37 @@ export function buildStandaloneCapabilityNav(state: {
         }
         return;
       }
+      // Groups / Roles / Organization / ... — graduated OFF every project
+      // surface entirely, onto the account page. Members' Access tab links to
+      // both ("Create one in Groups", "Create one in Roles") and, without
+      // this branch, `tab` matched none of the checks above or below and the
+      // click did nothing at all. Deliberately NOT `legacySectionRedirect` —
+      // that helper's own fallback also resolves overlay-still ids
+      // (`preferences` -> `/projects/<id>/settings/preferences`, a route),
+      // which would bypass the store-based `openSettings()` call below and
+      // break `project-settings-page.test.ts`'s "opens the overlay, not a
+      // route" contract for this adapter.
+      if (state.accountId && isAccountGraduatedSection(tab)) {
+        state.navigateTo(`/accounts/${state.accountId}?tab=${ACCOUNT_GRADUATED[tab]}`);
+        return;
+      }
       const overlayTab = parseSettingsTab(tab);
       if (overlayTab) useSettingsPanelStore.getState().openSettings(overlayTab);
     },
   };
 }
 
-export function useStandaloneCapabilityNav(projectId: string, activeTab: string): SettingsNav {
+export function useStandaloneCapabilityNav(
+  projectId: string,
+  activeTab: string,
+  accountId?: string,
+): SettingsNav {
   const router = useRouter();
   const membersTab = useSettingsPanelStore((s) => s.membersTab);
   const navigateTo = useCallback((href: string) => router.push(href), [router]);
 
   return useMemo(
-    () => buildStandaloneCapabilityNav({ projectId, activeTab, membersTab, navigateTo }),
-    [projectId, activeTab, membersTab, navigateTo],
+    () => buildStandaloneCapabilityNav({ projectId, activeTab, membersTab, accountId, navigateTo }),
+    [projectId, activeTab, membersTab, accountId, navigateTo],
   );
 }

--- a/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
@@ -3006,12 +3006,12 @@ function ResourceAccessCard({
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [pickerType] = useState<ResourceGrantType>('agent'); // agent-only grant flow
-  const [pickerResourceId, setPickerResourceId] = useState<string>(''); // the agent
-  // Multi-select: grant the same agent to several members and/or groups in
-  // one action, instead of one grant per dialog open. Fires one
-  // createProjectResourceGrant call per selected principal — the API is one
-  // row per (resource, principal), there is no batch endpoint — but the
-  // person only ever picks a set and hits one button.
+  // Multi-select on BOTH sides: grant several agents to several members/groups
+  // in one action. Fires one createProjectResourceGrant call per (agent,
+  // principal) pair — the API is one row per resource×principal, there is no
+  // batch endpoint — but the person only ever picks two sets and hits one
+  // button, instead of re-opening the dialog per agent per person.
+  const [selectedAgentIds, setSelectedAgentIds] = useState<string[]>([]);
   const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
   const [pendingIds, setPendingIds] = useState<Set<string>>(() => new Set());
@@ -3022,6 +3022,8 @@ function ResourceAccessCard({
       next.delete(id);
       return next;
     });
+  const toggleAgent = (id: string) =>
+    setSelectedAgentIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
 
   // The grant flow is AGENT-ONLY: the pyramid routes ALL resources — secrets,
   // connectors, AND skills — to people through the AGENTS they're assigned to,
@@ -3030,16 +3032,23 @@ function ResourceAccessCard({
   // grants still render in the list below so they can be revoked.)
   const activeItems = resources.agents;
 
-  // Blast-radius preview: when an AGENT is picked, what the assignee inherits
-  // (the agent's declared secrets + connectors). Null for skills/secrets or until
-  // an agent is chosen. Reads the `declares` the resource-grants API attaches.
+  // Blast-radius preview: the UNION of every selected agent's declared
+  // secrets/connectors — what the assignees inherit across all of them, not
+  // just the first pick. 'all' on any one agent makes the union 'all' for
+  // that dimension (it can't be narrowed by adding more agents).
   const selectedAgentDeclares = useMemo(() => {
-    if (pickerType !== 'agent' || !pickerResourceId) return null;
-    return resources.agents.find((a) => a.id === pickerResourceId)?.declares ?? null;
-  }, [pickerType, pickerResourceId, resources.agents]);
+    if (pickerType !== 'agent' || selectedAgentIds.length === 0) return null;
+    const picked = resources.agents.filter((a) => selectedAgentIds.includes(a.id));
+    if (picked.length === 0) return null;
+    const union = (key: 'secrets' | 'connectors'): string[] | 'all' => {
+      if (picked.some((a) => a.declares?.[key] === 'all')) return 'all';
+      return [...new Set(picked.flatMap((a) => (a.declares?.[key] as string[] | undefined) ?? []))];
+    };
+    return { secrets: union('secrets'), connectors: union('connectors') };
+  }, [pickerType, selectedAgentIds, resources.agents]);
 
   function resetGrantForm() {
-    setPickerResourceId('');
+    setSelectedAgentIds([]);
     setSelectedMemberIds([]);
     setSelectedGroupIds([]);
   }
@@ -3055,6 +3064,9 @@ function ResourceAccessCard({
   }
 
   const selectedPrincipalCount = selectedMemberIds.length + selectedGroupIds.length;
+  // Total grants this submit will create: every selected agent crossed with
+  // every selected principal, not just one dimension.
+  const selectedGrantCount = selectedAgentIds.length * selectedPrincipalCount;
 
   const createMutation = useMutation({
     mutationFn: async () => {
@@ -3062,18 +3074,21 @@ function ResourceAccessCard({
         ...selectedMemberIds.map((principalId) => ({ principalType: 'member' as const, principalId })),
         ...selectedGroupIds.map((principalId) => ({ principalType: 'group' as const, principalId })),
       ];
+      const pairs = selectedAgentIds.flatMap((resourceId) =>
+        principals.map((p) => ({ resourceId, ...p })),
+      );
       const results = await Promise.allSettled(
-        principals.map((p) =>
+        pairs.map((pair) =>
           createProjectResourceGrant(projectId, {
             resourceType: pickerType as ResourceGrantType,
-            resourceId: pickerResourceId,
-            principalType: p.principalType,
-            principalId: p.principalId,
+            resourceId: pair.resourceId,
+            principalType: pair.principalType,
+            principalId: pair.principalId,
           }),
         ),
       );
       const failed = results.filter((r) => r.status === 'rejected') as PromiseRejectedResult[];
-      return { total: principals.length, failed };
+      return { total: pairs.length, failed };
     },
     onSuccess: ({ total, failed }) => {
       const ok = total - failed.length;
@@ -3139,7 +3154,10 @@ function ResourceAccessCard({
   );
 
   const canSubmit =
-    !!pickerType && !!pickerResourceId && selectedPrincipalCount > 0 && !createMutation.isPending;
+    !!pickerType &&
+    selectedAgentIds.length > 0 &&
+    selectedPrincipalCount > 0 &&
+    !createMutation.isPending;
 
   return (
     <>
@@ -3280,23 +3298,26 @@ function ResourceAccessCard({
           >
             <ModalBody className="space-y-4">
               <div className="space-y-1.5">
-                <span className="text-muted-foreground text-xs font-medium">1. Agent</span>
-                <Select
-                  value={pickerResourceId}
-                  onValueChange={setPickerResourceId}
-                  disabled={createMutation.isPending}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select an agent" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {activeItems.map((r) => (
-                      <SelectItem key={r.id} value={r.id}>
-                        {r.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <span className="text-muted-foreground text-xs font-medium">
+                  1. Agent
+                  {selectedAgentIds.length > 0 ? (
+                    <span className="ml-1 tabular-nums">({selectedAgentIds.length})</span>
+                  ) : null}
+                </span>
+                {/* Multi-select: grant several agents to the same set of
+                    people in one submit, instead of re-opening this dialog
+                    per agent. */}
+                <div className="border-border max-h-40 overflow-y-auto rounded-md border p-1">
+                  {activeItems.map((r) => (
+                    <Checkbox
+                      key={r.id}
+                      label={r.name}
+                      checked={selectedAgentIds.includes(r.id)}
+                      onCheckedChange={() => toggleAgent(r.id)}
+                      disabled={createMutation.isPending}
+                    />
+                  ))}
+                </div>
               </div>
 
               {selectedAgentDeclares && <BlastRadiusPreview declares={selectedAgentDeclares} />}
@@ -3335,9 +3356,7 @@ function ResourceAccessCard({
               </Button>
               <Button type="submit" size="sm" disabled={!canSubmit}>
                 {createMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
-                {selectedPrincipalCount > 1
-                  ? `Grant access to ${selectedPrincipalCount}`
-                  : 'Grant access'}
+                {selectedGrantCount > 1 ? `Grant access (${selectedGrantCount})` : 'Grant access'}
               </Button>
             </ModalFooter>
           </form>

--- a/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
@@ -399,6 +399,7 @@ import {
 } from 'react';
 
 import { useAuth } from '@/features/providers/auth-provider';
+import { SubjectPicker } from '@/features/workspace/shared/sharing-picker';
 import { useSettingsNav } from '@/features/workspace/shared/settings-nav-context';
 import { cn } from '@/lib/utils';
 // Moved here from `members-view.tsx` when that file was deleted — it was the
@@ -415,6 +416,7 @@ import { ACCOUNT_ROLE_DESCRIPTORS } from '@/components/iam/project-role-descript
 import { ProjectRoleSelectItem } from '@/components/iam/role-select-item';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { InlineMeta } from '@/components/ui/inline-meta';
@@ -2064,12 +2066,7 @@ function MembersTabInner({
       }
       resourceAccessSlot={
         project?.account_id && canManage ? (
-          <ResourceAccessCard
-            projectId={projectId}
-            accountId={project.account_id}
-            canManage={!!canManage}
-            members={accessQuery.data?.members ?? []}
-          />
+          <ResourceAccessCard projectId={projectId} canManage={!!canManage} />
         ) : undefined
       }
       roleAssignmentsSlot={
@@ -2966,14 +2963,10 @@ function BlastRadiusPreview({
 
 function ResourceAccessCard({
   projectId,
-  accountId,
   canManage,
-  members,
 }: {
   projectId: string;
-  accountId: string;
   canManage: boolean;
-  members: ProjectAccessMember[];
 }) {
   const queryClient = useQueryClient();
   const grantsKey = qk.project.resourceGrants(projectId);
@@ -2984,12 +2977,6 @@ function ResourceAccessCard({
     // Manager-only endpoint (403s otherwise) — don't fire it for non-managers.
     enabled: canManage,
     ...contract('inventory'),
-  });
-  const groupsQuery = useQuery({
-    queryKey: ['account-groups', accountId],
-    queryFn: () => listGroups(accountId),
-    enabled: canManage,
-    staleTime: 60_000,
   });
 
   const resources = grantsQuery.data?.resources ?? { agents: [], skills: [], secrets: [] };
@@ -3002,7 +2989,6 @@ function ResourceAccessCard({
       return r !== 0 ? r : a.principal_label.localeCompare(b.principal_label);
     });
   }, [grantsQuery.data]);
-  const groups: AccountGroup[] = useMemo(() => toArray(groupsQuery.data), [groupsQuery.data]);
 
   // Display name for a resource id (falls back to the id itself).
   const resourceName = useMemo(() => {
@@ -3021,7 +3007,13 @@ function ResourceAccessCard({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [pickerType] = useState<ResourceGrantType>('agent'); // agent-only grant flow
   const [pickerResourceId, setPickerResourceId] = useState<string>(''); // the agent
-  const [principalValue, setPrincipalValue] = useState<string>(''); // "member:id" | "group:id"
+  // Multi-select: grant the same agent to several members and/or groups in
+  // one action, instead of one grant per dialog open. Fires one
+  // createProjectResourceGrant call per selected principal — the API is one
+  // row per (resource, principal), there is no batch endpoint — but the
+  // person only ever picks a set and hits one button.
+  const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
   const [pendingIds, setPendingIds] = useState<Set<string>>(() => new Set());
   const markPending = (id: string) => setPendingIds((prev) => new Set(prev).add(id));
   const clearPending = (id: string) =>
@@ -3048,7 +3040,8 @@ function ResourceAccessCard({
 
   function resetGrantForm() {
     setPickerResourceId('');
-    setPrincipalValue('');
+    setSelectedMemberIds([]);
+    setSelectedGroupIds([]);
   }
 
   function invalidate() {
@@ -3061,25 +3054,45 @@ function ResourceAccessCard({
     void invalidateProject(queryClient, projectId);
   }
 
-  function splitOnce(v: string): [string, string] {
-    const i = v.indexOf(':');
-    return i < 0 ? [v, ''] : [v.slice(0, i), v.slice(i + 1)];
-  }
+  const selectedPrincipalCount = selectedMemberIds.length + selectedGroupIds.length;
 
   const createMutation = useMutation({
-    mutationFn: () => {
-      const [principalType, principalId] = splitOnce(principalValue);
-      return createProjectResourceGrant(projectId, {
-        resourceType: pickerType as ResourceGrantType,
-        resourceId: pickerResourceId,
-        principalType: principalType as 'member' | 'group',
-        principalId,
-      });
+    mutationFn: async () => {
+      const principals: Array<{ principalType: 'member' | 'group'; principalId: string }> = [
+        ...selectedMemberIds.map((principalId) => ({ principalType: 'member' as const, principalId })),
+        ...selectedGroupIds.map((principalId) => ({ principalType: 'group' as const, principalId })),
+      ];
+      const results = await Promise.allSettled(
+        principals.map((p) =>
+          createProjectResourceGrant(projectId, {
+            resourceType: pickerType as ResourceGrantType,
+            resourceId: pickerResourceId,
+            principalType: p.principalType,
+            principalId: p.principalId,
+          }),
+        ),
+      );
+      const failed = results.filter((r) => r.status === 'rejected') as PromiseRejectedResult[];
+      return { total: principals.length, failed };
     },
-    onSuccess: () => {
-      successToast('Resource scoped');
-      resetGrantForm();
-      setDialogOpen(false);
+    onSuccess: ({ total, failed }) => {
+      const ok = total - failed.length;
+      if (failed.length === 0) {
+        successToast(total === 1 ? 'Resource scoped' : `Resource scoped to ${total}`);
+        resetGrantForm();
+        setDialogOpen(false);
+      } else if (ok > 0) {
+        // Partial failure: leave the dialog open on the still-selected
+        // principals so the failed ones are easy to retry, instead of
+        // silently dropping which ones didn't go through.
+        errorToast(
+          `Granted to ${ok} of ${total} — ${failed.length} failed. Remove the granted ones and retry the rest.`,
+        );
+      } else {
+        errorToast(
+          failed[0]?.reason instanceof Error ? failed[0].reason.message : 'Failed to scope resource',
+        );
+      }
       invalidate();
     },
     onError: (err: Error) => errorToast(err.message || 'Failed to scope resource'),
@@ -3126,7 +3139,7 @@ function ResourceAccessCard({
   );
 
   const canSubmit =
-    !!pickerType && !!pickerResourceId && !!principalValue && !createMutation.isPending;
+    !!pickerType && !!pickerResourceId && selectedPrincipalCount > 0 && !createMutation.isPending;
 
   return (
     <>
@@ -3289,28 +3302,25 @@ function ResourceAccessCard({
               {selectedAgentDeclares && <BlastRadiusPreview declares={selectedAgentDeclares} />}
 
               <div className="space-y-1.5">
-                <span className="text-muted-foreground text-xs font-medium">2. Grant to</span>
-                <Select
-                  value={principalValue}
-                  onValueChange={setPrincipalValue}
-                  disabled={createMutation.isPending}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Member or group" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {members.map((m) => (
-                      <SelectItem key={`member:${m.user_id}`} value={`member:${m.user_id}`}>
-                        {userLabel(m)}
-                      </SelectItem>
-                    ))}
-                    {groups.map((g) => (
-                      <SelectItem key={`group:${g.group_id}`} value={`group:${g.group_id}`}>
-                        {g.name} · group
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <span className="text-muted-foreground text-xs font-medium">
+                  2. Grant to
+                  {selectedPrincipalCount > 0 ? (
+                    <span className="ml-1 tabular-nums">({selectedPrincipalCount})</span>
+                  ) : null}
+                </span>
+                {/* Multi-select, not one-at-a-time: pick as many members and
+                    groups as should get this agent in a single grant action.
+                    Same allow-list component the trigger session-access
+                    picker uses — see SubjectPicker's own doc comment. */}
+                <SubjectPicker
+                  projectId={projectId}
+                  memberIds={selectedMemberIds}
+                  groupIds={selectedGroupIds}
+                  onChange={(memberIds, groupIds) => {
+                    setSelectedMemberIds(memberIds);
+                    setSelectedGroupIds(groupIds);
+                  }}
+                />
               </div>
             </ModalBody>
 
@@ -3325,7 +3335,9 @@ function ResourceAccessCard({
               </Button>
               <Button type="submit" size="sm" disabled={!canSubmit}>
                 {createMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
-                Grant access
+                {selectedPrincipalCount > 1
+                  ? `Grant access to ${selectedPrincipalCount}`
+                  : 'Grant access'}
               </Button>
             </ModalFooter>
           </form>
@@ -3447,7 +3459,9 @@ function ProjectRoleAssignmentsCard({
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [subjectType, setSubjectType] = useState<PrincipalType | ''>(''); // step 1
-  const [subjectId, setSubjectId] = useState(''); // step 2
+  // Step 2, multi-select — bind the same role to several members/groups/agents
+  // of the chosen type in one action, instead of one binding per dialog open.
+  const [subjectIds, setSubjectIds] = useState<string[]>([]);
   const [roleId, setRoleId] = useState('');
   const [policyFilter, setPolicyFilter] = useState<'all' | PrincipalType>('all');
   const [pendingIds, setPendingIds] = useState<Set<string>>(() => new Set());
@@ -3499,27 +3513,48 @@ function ProjectRoleAssignmentsCard({
 
   function resetAssignForm() {
     setSubjectType('');
-    setSubjectId('');
+    setSubjectIds([]);
     setRoleId('');
   }
   function onSubjectTypeChange(t: PrincipalType) {
     setSubjectType(t);
-    setSubjectId(''); // the previous pick belongs to a different subject type
+    setSubjectIds([]); // the previous picks belong to a different subject type
+  }
+  function toggleSubject(id: string) {
+    setSubjectIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
   }
 
   const createMutation = useMutation({
-    mutationFn: () =>
-      createPolicy(accountId, {
-        principalType: subjectType as PrincipalType,
-        principalId: subjectId,
-        scopeType: 'project',
-        scopeId: projectId,
-        roleId,
-      }),
-    onSuccess: () => {
-      successToast('Role assigned');
-      resetAssignForm();
-      setDialogOpen(false);
+    mutationFn: async () => {
+      const results = await Promise.allSettled(
+        subjectIds.map((principalId) =>
+          createPolicy(accountId, {
+            principalType: subjectType as PrincipalType,
+            principalId,
+            scopeType: 'project',
+            scopeId: projectId,
+            roleId,
+          }),
+        ),
+      );
+      const failed = results.filter((r) => r.status === 'rejected') as PromiseRejectedResult[];
+      return { total: subjectIds.length, failed };
+    },
+    onSuccess: ({ total, failed }) => {
+      const ok = total - failed.length;
+      if (failed.length === 0) {
+        successToast(total === 1 ? 'Role assigned' : `Role assigned to ${total}`);
+        resetAssignForm();
+        setDialogOpen(false);
+      } else if (ok > 0) {
+        errorToast(
+          `Assigned to ${ok} of ${total} — ${failed.length} failed. Remove the assigned ones and retry the rest.`,
+        );
+      } else {
+        errorToast(
+          failed[0]?.reason instanceof Error ? failed[0].reason.message : 'Failed to assign role',
+        );
+      }
       invalidate();
     },
     onError: (err: Error) => errorToast(err.message || 'Failed to assign role'),
@@ -3569,7 +3604,8 @@ function ProjectRoleAssignmentsCard({
     [policies, policyFilter],
   );
 
-  const canSubmit = !!subjectType && !!subjectId && !!roleId && !createMutation.isPending;
+  const canSubmit =
+    !!subjectType && subjectIds.length > 0 && !!roleId && !createMutation.isPending;
 
   return (
     <>
@@ -3733,24 +3769,43 @@ function ProjectRoleAssignmentsCard({
               <div className="space-y-1.5">
                 <span className="text-muted-foreground text-xs font-medium">
                   2.{' '}
-                  {subjectType === 'group' ? 'Group' : subjectType === 'token' ? 'Agent' : 'Member'}
+                  {subjectType === 'group'
+                    ? 'Groups'
+                    : subjectType === 'token'
+                      ? 'Agents'
+                      : 'Members'}
+                  {subjectIds.length > 0 ? (
+                    <span className="ml-1 tabular-nums">({subjectIds.length})</span>
+                  ) : null}
                 </span>
-                <Select
-                  value={subjectId}
-                  onValueChange={setSubjectId}
-                  disabled={!subjectType || createMutation.isPending}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder={subjectType ? 'Select one' : 'Pick a type first'} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {activeSubjects.map((s) => (
-                      <SelectItem key={s.id} value={s.id}>
-                        {s.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                {/* Multi-select: bind the same role to several subjects of this
+                    type in one action. `activeSubjects` is already
+                    type-filtered by step 1, so this is a plain checklist —
+                    no search needed for a project's own member/group/agent
+                    count. */}
+                {subjectType ? (
+                  <div className="border-border max-h-56 overflow-y-auto rounded-md border p-1">
+                    {activeSubjects.length === 0 ? (
+                      <p className="text-muted-foreground px-3 py-6 text-center text-xs">
+                        None available.
+                      </p>
+                    ) : (
+                      activeSubjects.map((s) => (
+                        <Checkbox
+                          key={s.id}
+                          label={s.name}
+                          checked={subjectIds.includes(s.id)}
+                          onCheckedChange={() => toggleSubject(s.id)}
+                          disabled={createMutation.isPending}
+                        />
+                      ))
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground border-border rounded-md border border-dashed px-3 py-6 text-center text-xs">
+                    Pick a type first.
+                  </p>
+                )}
               </div>
 
               <div className="space-y-1.5">
@@ -3785,7 +3840,7 @@ function ProjectRoleAssignmentsCard({
               </Button>
               <Button type="submit" size="sm" disabled={!canSubmit}>
                 {createMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
-                Assign role
+                {subjectIds.length > 1 ? `Assign role to ${subjectIds.length}` : 'Assign role'}
               </Button>
             </ModalFooter>
           </form>

--- a/tests/e2e/specs/22-resource-grant-multiselect.spec.ts
+++ b/tests/e2e/specs/22-resource-grant-multiselect.spec.ts
@@ -39,14 +39,18 @@ interface ResourceGrantsResponse {
 }
 
 /**
- * Regression coverage for the "Assign an agent" dialog's multi-select
- * (members-tab.tsx's ResourceAccessCard): reported live as "right away you
- * can only ever edit one user at a time. you should be able to multi-select
- * users in groups which get access to the agent." The picker was replaced
- * with SubjectPicker (a toggle-button allow-list, `aria-pressed` on each
- * row, see sharing-picker.tsx), and submitting fires one
- * createProjectResourceGrant per selected principal via Promise.allSettled —
- * this spec proves both selections actually land as two grants, not one.
+ * Regression coverage for the "Assign an agent" dialog's multi-select on
+ * BOTH steps (members-tab.tsx's ResourceAccessCard): reported live as
+ * "right away you can only ever edit one user at a time. you should be able
+ * to multi-select users in groups which get access to the agent" — and,
+ * once that landed, "sure the agent selection is also a multi-step of
+ * course like granting access." Step 1 (agent) and step 2 (member/group)
+ * are each independent Checkbox lists / SubjectPicker now; submitting fires
+ * one createProjectResourceGrant per (agent, principal) pair via
+ * Promise.allSettled. This spec picks one agent and two members — the
+ * simplest case that still proves the pair-fan-out (2 grants, not 1) — a
+ * fuller multi-agent case is the natural follow-up if that dimension ever
+ * regresses independently.
  *
  * `createLocalGitRepository` seeds `kortix.yaml` with `agents:\n  kortix: {}`
  * (local-git.ts), so every project made through it already has a real
@@ -118,10 +122,10 @@ test.describe('22 — Resource-grant multi-select', () => {
       const dialog = page.getByRole('dialog', { name: 'Assign an agent', exact: true });
       await expect(dialog).toBeVisible();
 
-      await dialog.getByRole('combobox').click();
-      await page.getByRole('option', { name: 'kortix', exact: true }).click();
-
-      // Multi-select: both members, one dialog, one submit.
+      // Multi-select on both sides: one agent, two members, one dialog, one
+      // submit. Both steps are Checkbox lists now (members-tab.tsx), not
+      // single-select dropdowns.
+      await dialog.getByRole('checkbox', { name: 'kortix', exact: true }).click();
       await dialog.getByRole('button', { name: memberAEmail }).click();
       await dialog.getByRole('button', { name: memberBEmail }).click();
 
@@ -134,7 +138,8 @@ test.describe('22 — Resource-grant multi-select', () => {
           grantPostStatuses.push(r.status());
         }
       });
-      await dialog.getByRole('button', { name: 'Grant access to 2', exact: true }).click();
+      // 1 agent x 2 members = 2 total grants.
+      await dialog.getByRole('button', { name: 'Grant access (2)', exact: true }).click();
       await expect(dialog).toHaveCount(0, { timeout: 15_000 });
       await expect
         .poll(() => grantPostStatuses.length, { timeout: 10_000 })

--- a/tests/e2e/specs/22-resource-grant-multiselect.spec.ts
+++ b/tests/e2e/specs/22-resource-grant-multiselect.spec.ts
@@ -144,7 +144,8 @@ test.describe('22 — Resource-grant multi-select', () => {
       await expect
         .poll(() => grantPostStatuses.length, { timeout: 10_000 })
         .toBe(2);
-      expect(grantPostStatuses).toEqual([200, 200]);
+      // POST /resource-grants returns 201 (created), not 200.
+      expect(grantPostStatuses).toEqual([201, 201]);
 
       // The list re-renders with both grants, each labeled by the member it
       // went to — not just a count, the actual two people.

--- a/tests/e2e/specs/22-resource-grant-multiselect.spec.ts
+++ b/tests/e2e/specs/22-resource-grant-multiselect.spec.ts
@@ -1,0 +1,171 @@
+import { expect, test } from '@playwright/test';
+
+import { loadEnv } from '../../src/core/env';
+import { createDatabaseProject, deleteDatabaseProject } from '../../src/fixtures/database-project';
+import { createLocalGitRepository, type LocalGitRepository } from '../../src/fixtures/local-git';
+import { createApiJsonClient } from '../helpers/http';
+import {
+  createAuthUser,
+  deleteAuthUser,
+  installBrowserSessionDirect,
+  signIn,
+} from '../helpers/session-auth';
+import { dismissOnboarding, selectAccountForUi } from '../helpers/ui';
+
+const apiBase = process.env.E2E_API_URL || 'http://localhost:8008/v1';
+const supabaseUrl = process.env.E2E_SUPABASE_URL || 'http://127.0.0.1:54321';
+const databaseUrl = process.env.KE2E_DATABASE_URL || process.env.E2E_DATABASE_URL;
+const password = 'E2eResourceGrantMulti123!';
+const authOptions = { supabaseUrl, password };
+const api = createApiJsonClient(apiBase);
+
+interface AccountSummary {
+  account_id: string;
+  personal_account?: boolean;
+  is_primary_owner?: boolean;
+  account_role: string;
+}
+
+interface ResourceGrantsResponse {
+  resources: { agents: { id: string; name: string }[] };
+  grants: {
+    grant_id: string;
+    resource_type: string;
+    resource_id: string;
+    principal_type: 'member' | 'group';
+    principal_id: string;
+    principal_label: string;
+  }[];
+}
+
+/**
+ * Regression coverage for the "Assign an agent" dialog's multi-select
+ * (members-tab.tsx's ResourceAccessCard): reported live as "right away you
+ * can only ever edit one user at a time. you should be able to multi-select
+ * users in groups which get access to the agent." The picker was replaced
+ * with SubjectPicker (a toggle-button allow-list, `aria-pressed` on each
+ * row, see sharing-picker.tsx), and submitting fires one
+ * createProjectResourceGrant per selected principal via Promise.allSettled —
+ * this spec proves both selections actually land as two grants, not one.
+ *
+ * `createLocalGitRepository` seeds `kortix.yaml` with `agents:\n  kortix: {}`
+ * (local-git.ts), so every project made through it already has a real
+ * "kortix" agent to grant — no extra fixture needed.
+ */
+test.describe('22 — Resource-grant multi-select', () => {
+  test('granting one agent to two members in a single dialog creates two grants', async ({
+    page,
+  }) => {
+    test.skip(!databaseUrl, 'KE2E_DATABASE_URL is required');
+    test.setTimeout(120_000);
+
+    const runId = Date.now().toString(36);
+    const ownerEmail = `e2e-grant-owner-${runId}@example.test`;
+    const memberAEmail = `e2e-grant-a-${runId}@example.test`;
+    const memberBEmail = `e2e-grant-b-${runId}@example.test`;
+
+    const owner = await createAuthUser(ownerEmail, authOptions);
+    const memberA = await createAuthUser(memberAEmail, authOptions);
+    const memberB = await createAuthUser(memberBEmail, authOptions);
+    const session = await signIn(ownerEmail, authOptions);
+    const env = loadEnv();
+
+    let accountId: string | null = null;
+    let projectId: string | null = null;
+    let repository: LocalGitRepository | null = null;
+
+    try {
+      const accounts = await api<AccountSummary[]>(session.access_token, 'GET', '/accounts');
+      const account = accounts.find(
+        (item) => item.personal_account || item.is_primary_owner || item.account_role === 'owner',
+      );
+      if (!account) throw new Error('the seeded user owns no account');
+      accountId = account.account_id;
+
+      await api<{ status: string }>(
+        session.access_token,
+        'POST',
+        `/accounts/${accountId}/members`,
+        { email: memberAEmail, role: 'member' },
+        201,
+      );
+      await api<{ status: string }>(
+        session.access_token,
+        'POST',
+        `/accounts/${accountId}/members`,
+        { email: memberBEmail, role: 'member' },
+        201,
+      );
+
+      repository = await createLocalGitRepository(`Resource grant multiselect ${runId}`);
+      const project = await createDatabaseProject(env, {
+        accountId,
+        userId: owner.id,
+        name: `Resource grant multiselect ${runId}`,
+        repoUrl: repository.repoUrl,
+      });
+      projectId = project.id;
+
+      await installBrowserSessionDirect(page, session, `/projects/${projectId}/members`, authOptions);
+      await selectAccountForUi(page, accountId);
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await dismissOnboarding(page);
+
+      await page.getByRole('tab', { name: 'Access', exact: true }).click();
+      await expect(page.getByText('No agents assigned', { exact: true })).toBeVisible();
+
+      await page.getByRole('button', { name: 'Grant access', exact: true }).click();
+      const dialog = page.getByRole('dialog', { name: 'Assign an agent', exact: true });
+      await expect(dialog).toBeVisible();
+
+      await dialog.getByRole('combobox').click();
+      await page.getByRole('option', { name: 'kortix', exact: true }).click();
+
+      // Multi-select: both members, one dialog, one submit.
+      await dialog.getByRole('button', { name: memberAEmail }).click();
+      await dialog.getByRole('button', { name: memberBEmail }).click();
+
+      const grantPostStatuses: number[] = [];
+      page.on('response', (r) => {
+        if (
+          r.request().method() === 'POST' &&
+          r.url().endsWith(`/v1/projects/${projectId}/resource-grants`)
+        ) {
+          grantPostStatuses.push(r.status());
+        }
+      });
+      await dialog.getByRole('button', { name: 'Grant access to 2', exact: true }).click();
+      await expect(dialog).toHaveCount(0, { timeout: 15_000 });
+      await expect
+        .poll(() => grantPostStatuses.length, { timeout: 10_000 })
+        .toBe(2);
+      expect(grantPostStatuses).toEqual([200, 200]);
+
+      // The list re-renders with both grants, each labeled by the member it
+      // went to — not just a count, the actual two people.
+      await expect(page.getByText('kortix', { exact: true }).first()).toBeVisible();
+      await expect(page.getByText(`Member: ${memberAEmail}`, { exact: true })).toBeVisible();
+      await expect(page.getByText(`Member: ${memberBEmail}`, { exact: true })).toBeVisible();
+
+      // API is the source of truth for persistence, not the optimistic re-render.
+      const after = await api<ResourceGrantsResponse>(
+        session.access_token,
+        'GET',
+        `/projects/${projectId}/resource-grants`,
+      );
+      const kortixGrants = after.grants.filter(
+        (g) => g.resource_type === 'agent' && g.resource_id === 'kortix',
+      );
+      expect(kortixGrants).toHaveLength(2);
+      expect(kortixGrants.map((g) => g.principal_label).sort()).toEqual(
+        [memberAEmail, memberBEmail].sort(),
+      );
+    } finally {
+      if (projectId) await deleteDatabaseProject(env, projectId).catch(() => {});
+      if (repository) await repository.dispose().catch(() => {});
+      await deleteAuthUser(memberB.id, authOptions).catch(() => {});
+      await deleteAuthUser(memberA.id, authOptions).catch(() => {});
+      await deleteAuthUser(owner.id, authOptions).catch(() => {});
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Reported live against the Members > Access tab:
- "when I click the groups link, it doesn't work either" / "Create one in Roles... doesn't work" — both `navigate()` adapters hosting this tab (`buildStandaloneCapabilityNav`, `buildProjectSettingsNav`) never grew a branch for `ACCOUNT_GRADUATED` ids (Groups/Roles moved to `/accounts/[id]?tab=...` before this branch). The click matched nothing and silently no-op'd.
- "right away you can only ever edit one user at a time. you should be able to multi-select users in groups which get access to the agent." Both the "Assign an agent" and "Assign a custom role" dialogs were one-principal-per-submit.

## Changes
- `standalone-settings-nav.ts` / `project-settings-page.tsx`: resolve `ACCOUNT_GRADUATED` ids to `/accounts/<accountId>?tab=<...>` before falling through to the overlay. `members-page.tsx` now actually threads `project.account_id` through (its own doc comment already claimed it did).
- `members-tab.tsx`: "Assign an agent" now uses `SubjectPicker` (the same searchable multi-select member+group allow-list the trigger session-access picker already uses) instead of a single-select `<Select>`. "Assign a custom role" gets a multi-select `Checkbox` list for its type-filtered subject step. Both submit N parallel grant/policy calls via `Promise.allSettled` (no batch endpoint exists) and report partial failures by count.

## Test plan
- `npx tsc --noEmit` clean (only 15 pre-existing known `@types/bun` errors)
- `eslint` clean on touched files (2 pre-existing unrelated warnings)
- New unit tests: `standalone-settings-nav.test.ts` (new file), 2 new cases in `project-settings-page.test.ts` pinning the Groups/Roles regression
- Full `apps/web/src/features/workspace` suite: 1978/1978 pass
- **Not yet verified live in a browser** — local chrome-devtools MCP session was stuck (two competing server instances on one Chrome profile); relying on CI's browser workers for this PR, plus a follow-up dedicated E2E spec for the new multi-select flow before considering this fully done.