### PR TITLE
feat(iam): remove duplicate Access cards, fix Customize discoverability

### DIFF
--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -301,13 +301,24 @@ export default function AccountSettingsPage() {
   const accountStateQuery = useAccountState({ accountId, enabled: !!user && !!accountId });
   const entitlements = accountStateQuery.data?.tier?.entitlements;
   const enterpriseIdentityEnabled = !!(entitlements?.sso || entitlements?.scim);
-  // The IAM surfaces (Groups, Roles, Audit, SSO/SCIM) are enterprise-gated.
-  // Tabs/sections stay VISIBLE for discoverability, but a non-entitled
-  // account sees the EnterpriseUpsell card in place of the feature — mirrors
-  // the server's 402 (requireEntitlement) so an admin never touches a control
-  // the backend will reject. While the account state is still loading we
-  // render nothing gated (skeleton) to avoid flashing the upsell at
-  // enterprise accounts.
+  // Audit and SSO/SCIM have no free-tier content — the server has nothing to
+  // list until the account is entitled, so the EnterpriseUpsell card stands
+  // in for the whole feature. Groups and Roles are different: `GET
+  // .../groups` and `GET .../roles` carry NO entitlement check
+  // (`apps/api/src/accounts/iam/groups.ts` / `custom-roles.ts` — only the
+  // mutating routes call `requireEntitlement(..., 'rbac')`), because the six
+  // built-in roles and an account's real (if empty) group list are product,
+  // not upsell. `GroupsTab`/`RolesTab` already render that list unconditionally
+  // and gate only "Create a group" / "New role" behind `rbacEnabled` — a
+  // disabled control with an inline "Enterprise feature" tooltip/banner,
+  // mirroring the server's 403 so an admin never submits a mutation the
+  // backend will reject. Blocking the whole tab behind `rbacEnabled` here (as
+  // this used to) hid that free content behind an upsell card for no reason;
+  // see `enterprise-upsell.tsx`'s own header comment, which already said the
+  // intent was to "keep the tab/section visible for discoverability" — the
+  // page-level gate below just never let that happen. Audit/Identity keep the
+  // outer gate; Groups/Roles no longer do. While the account state is still
+  // loading we render nothing gated (skeleton) to avoid flashing.
   const rbacEnabled = !!entitlements?.rbac;
   const auditEnabled = !!entitlements?.auditAccess;
   const entitlementsLoading = !entitlements && accountStateQuery.isLoading;
@@ -536,28 +547,24 @@ export default function AccountSettingsPage() {
             {activeSection === 'groups' ? (
               entitlementsLoading ? (
                 <Skeleton className="h-64 w-full rounded-md" />
-              ) : rbacEnabled ? (
+              ) : (
                 <GroupsTab
                   accountId={account.account_id}
                   canCreate={canCreateGroup}
                   rbacEnabled={rbacEnabled}
                 />
-              ) : (
-                <EnterpriseUpsell feature="groups" />
               )
             ) : null}
 
             {activeSection === 'roles' && canManageRoles ? (
               entitlementsLoading ? (
                 <Skeleton className="h-64 w-full rounded-md" />
-              ) : rbacEnabled ? (
+              ) : (
                 <RolesTab
                   accountId={account.account_id}
                   canManage={canManageRoles}
                   rbacEnabled={rbacEnabled}
                 />
-              ) : (
-                <EnterpriseUpsell feature="roles" />
               )
             ) : null}
 

--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -1957,9 +1957,10 @@ function InviteMemberModal({
     >
       <ModalContent className="lg:max-w-lg">
         <ModalHeader>
-          <ModalTitle>Invite members</ModalTitle>
+          <ModalTitle>Invite to account</ModalTitle>
           <ModalDescription>
-            Invite by email. If they don&apos;t have an account yet, the invite waits for them.
+            They&apos;ll get account access at the role you pick, across every workspace. If they
+            don&apos;t have an account yet, the invite waits for them.
           </ModalDescription>
         </ModalHeader>
         <form onSubmit={handleSubmit}>
@@ -2020,13 +2021,23 @@ function InviteMemberModal({
                 <SelectTrigger id="invite-role">
                   <SelectValue />
                 </SelectTrigger>
+                {/* `description`, not a concatenated "label — blurb" string.
+                    Each option used to read its full sentence inline
+                    ("Admin — Everything except deleting the account or
+                    transferring ownership."), which wrapped to two lines per
+                    row inside this modal and pushed the open popover past
+                    the bottom of the screen. `SelectItem`'s own
+                    `description` prop already renders label and blurb as two
+                    properly-laid-out lines — the same fix already applied to
+                    `InviteToAccountDialog`
+                    (`features/workspace/settings/tabs/members-tab.tsx`),
+                    never ported back to this older duplicate until now. */}
                 <SelectContent>
-                  <SelectItem value="member">
-                    {ACCOUNT_ROLE_DESCRIPTORS.member.label} —{' '}
-                    {ACCOUNT_ROLE_DESCRIPTORS.member.blurb}
+                  <SelectItem value="member" description={ACCOUNT_ROLE_DESCRIPTORS.member.blurb}>
+                    {ACCOUNT_ROLE_DESCRIPTORS.member.label}
                   </SelectItem>
-                  <SelectItem value="admin">
-                    {ACCOUNT_ROLE_DESCRIPTORS.admin.label} — {ACCOUNT_ROLE_DESCRIPTORS.admin.blurb}
+                  <SelectItem value="admin" description={ACCOUNT_ROLE_DESCRIPTORS.admin.blurb}>
+                    {ACCOUNT_ROLE_DESCRIPTORS.admin.label}
                   </SelectItem>
                 </SelectContent>
               </Select>

--- a/apps/web/src/components/iam/enterprise-upsell.test.ts
+++ b/apps/web/src/components/iam/enterprise-upsell.test.ts
@@ -27,14 +27,23 @@ describe('EnterpriseUpsell component', () => {
 });
 
 describe('account page gates each IAM surface behind the entitlement', () => {
-  test('groups tab: rbac entitlement or upsell', () => {
-    expect(pageSource).toMatch(/rbacEnabled \? \(\s*<GroupsTab/);
-    expect(pageSource).toContain('<EnterpriseUpsell feature="groups" />');
+  // Groups and Roles are NOT gated the way Audit/Identity are: `GET
+  // .../groups` and `GET .../roles` carry no entitlement check server-side
+  // (only the mutating routes do), so the built-in roles and an account's
+  // real group list are free content, not upsell. `GroupsTab`/`RolesTab`
+  // always render and gate only their own "Create"/"New role" controls on
+  // `rbacEnabled` internally — see this file's other describe block, and
+  // `page.tsx`'s comment above these two sections.
+  test('groups tab: always mounted, passed rbacEnabled to gate its own controls', () => {
+    expect(pageSource).toMatch(/activeSection === 'groups' \?[\s\S]*?<GroupsTab/);
+    expect(pageSource).toMatch(/<GroupsTab[\s\S]*?rbacEnabled=\{rbacEnabled\}/);
+    expect(pageSource).not.toContain('<EnterpriseUpsell feature="groups" />');
   });
 
-  test('roles tab: rbac entitlement or upsell', () => {
-    expect(pageSource).toMatch(/rbacEnabled \? \(\s*<RolesTab/);
-    expect(pageSource).toContain('<EnterpriseUpsell feature="roles" />');
+  test('roles tab: always mounted, passed rbacEnabled to gate its own controls', () => {
+    expect(pageSource).toMatch(/activeSection === 'roles' && canManageRoles \?[\s\S]*?<RolesTab/);
+    expect(pageSource).toMatch(/<RolesTab[\s\S]*?rbacEnabled=\{rbacEnabled\}/);
+    expect(pageSource).not.toContain('<EnterpriseUpsell feature="roles" />');
   });
 
   test('audit tab: auditAccess entitlement or upsell', () => {

--- a/apps/web/src/components/iam/permissions-help-popover.tsx
+++ b/apps/web/src/components/iam/permissions-help-popover.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import type { AccountRole } from '@kortix/sdk';
 import { QuestionIcon as HelpCircle } from '@phosphor-icons/react';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import {
   ACCOUNT_ROLE_DESCRIPTORS,
@@ -16,11 +17,24 @@ const ACCOUNT_ROLES_DESCENDING: AccountRole[] = ['owner', 'admin', 'member'];
 interface Props {
   triggerLabel?: string;
   align?: 'start' | 'center' | 'end';
+  /**
+   * Shows the "Custom roles" section with a real link to
+   * `/accounts/<accountId>?tab=roles`, ONLY when passed. The account page's
+   * own mount (`accounts/[id]/page.tsx`) omits this — a "manage roles" link
+   * to the page the popover is already open on is a link to nowhere new.
+   * Project-scoped mounts (`members-tab.tsx`) pass it: this is the one place
+   * a person reading "how do project roles work" would otherwise never learn
+   * custom roles exist at all, now that the project-level Access tab shows
+   * only agent assignment — group-role and custom-role binding moved to
+   * their account-level homes (see `members-tab.tsx`'s header comment).
+   */
+  accountId?: string;
 }
 
 export function PermissionsHelpPopover({
   triggerLabel = 'How permissions work',
   align = 'start',
+  accountId,
 }: Props = {}) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   return (
@@ -77,6 +91,24 @@ export function PermissionsHelpPopover({
             })}
           </ul>
         </section>
+
+        {accountId ? (
+          <section className="space-y-1">
+            <h3 className="text-foreground font-semibold">Custom roles</h3>
+            <p className="text-muted-foreground text-xs">
+              For a permission set beyond these three tiers. Defined once on
+              the account, then bound to a member, group, or agent — either
+              account-wide, or to just this project.{' '}
+              <Link
+                href={`/accounts/${accountId}?tab=roles`}
+                className="text-foreground underline underline-offset-2"
+              >
+                Manage roles
+              </Link>
+              .
+            </p>
+          </section>
+        ) : null}
 
         <section className="space-y-1">
           <h3 className="text-foreground font-semibold">Groups</h3>

--- a/apps/web/src/components/iam/roles-tab.tsx
+++ b/apps/web/src/components/iam/roles-tab.tsx
@@ -12,6 +12,7 @@
 
 import {
   CopyIcon as Copy,
+  EyeIcon as Eye,
   LockIcon as Lock,
   PencilSimpleIcon,
   PlusIcon as Plus,
@@ -134,6 +135,7 @@ function RolesSection({ accountId, canManage, rbacEnabled }: RolesTabProps) {
   const [createOpen, setCreateOpen] = useState(false);
   const [createPrefill, setCreatePrefill] = useState<RolePrefill | null>(null);
   const [editTarget, setEditTarget] = useState<IamRole | null>(null);
+  const [viewTarget, setViewTarget] = useState<IamRole | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<IamRole | null>(null);
 
   const rolesQuery = useQuery({
@@ -216,6 +218,7 @@ function RolesSection({ accountId, canManage, rbacEnabled }: RolesTabProps) {
               <TableHead>Name</TableHead>
               <TableHead>Type</TableHead>
               <TableHead>Origin</TableHead>
+              <TableHead>Capabilities</TableHead>
               <TableHead>Used by</TableHead>
               <TableHead className="w-28">
                 <span className="sr-only">Actions</span>
@@ -231,6 +234,7 @@ function RolesSection({ accountId, canManage, rbacEnabled }: RolesTabProps) {
                 canManage={canManage}
                 rbacEnabled={rbacEnabled}
                 onEdit={() => setEditTarget(role)}
+                onView={() => setViewTarget(role)}
                 onDelete={() => setDeleteTarget(role)}
                 onDuplicate={(prefill) => openCreate(prefill)}
               />
@@ -264,6 +268,18 @@ function RolesSection({ accountId, canManage, rbacEnabled }: RolesTabProps) {
         />
       )}
 
+      {viewTarget && (
+        <RoleDialog
+          accountId={accountId}
+          mode="view"
+          role={viewTarget}
+          open={!!viewTarget}
+          onOpenChange={(o) => {
+            if (!o) setViewTarget(null);
+          }}
+        />
+      )}
+
       {deleteTarget && (
         <DeleteRoleConfirm
           accountId={accountId}
@@ -281,6 +297,7 @@ function RoleRow({
   canManage,
   rbacEnabled,
   onEdit,
+  onView,
   onDelete,
   onDuplicate,
 }: {
@@ -289,6 +306,7 @@ function RoleRow({
   canManage: boolean;
   rbacEnabled: boolean;
   onEdit: () => void;
+  onView: () => void;
   onDelete: () => void;
   onDuplicate: (prefill: RolePrefill) => void;
 }) {
@@ -301,6 +319,17 @@ function RoleRow({
     queryFn: () => getRoleUsage(accountId, role.role_id),
     staleTime: 30_000,
     enabled: isCustom,
+  });
+
+  // "You will see what they can do and what they can't" — at a glance, not
+  // just after opening Edit. Fetched for every role, built-in included (the
+  // same call `handleDuplicate` below already proves works for both); shares
+  // its cache key with the edit/view dialog's own `permsQuery`, so opening
+  // either after this resolves is instant, not a second round-trip.
+  const permsQuery = useQuery({
+    queryKey: ['iam-role-permissions', accountId, role.role_id],
+    queryFn: () => getRolePermissions(accountId, role.role_id),
+    staleTime: 30_000,
   });
 
   async function handleDuplicate() {
@@ -354,6 +383,28 @@ function RoleRow({
           <Badge variant="outline" size="sm" className="font-normal">
             Custom
           </Badge>
+        )}
+      </TableCell>
+      <TableCell>
+        {/* The count itself is the affordance — clickable for everyone, not
+            just managers. "What can this role do?" should never require
+            permission to change it; a raw number with no way to see WHICH
+            capabilities it covers is not actually an answer. */}
+        {permsQuery.isError ? (
+          <span className="text-muted-foreground text-xs">—</span>
+        ) : permsQuery.isLoading ? (
+          <Skeleton className="h-4 w-20" />
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-foreground -mx-2 h-auto gap-1 px-2 py-1 text-xs font-normal"
+            onClick={onView}
+          >
+            <Eye className="size-3.5 shrink-0" />
+            {permsQuery.data?.actions.length ?? 0} capabilities
+          </Button>
         )}
       </TableCell>
       <TableCell className="text-muted-foreground text-xs">
@@ -459,14 +510,21 @@ function RoleDialog({
   onOpenChange,
 }: {
   accountId: string;
-  mode: 'create' | 'edit';
+  /** 'view' is read-only — everyone gets it (including non-managers and on
+   *  built-in roles), not just people who can edit. "What can this role
+   *  actually do?" should never require permission to change it. */
+  mode: 'create' | 'edit' | 'view';
   role?: IamRole;
   prefill?: RolePrefill | null;
   open: boolean;
   onOpenChange: (o: boolean) => void;
 }) {
   const queryClient = useQueryClient();
+  const isView = mode === 'view';
   const isEdit = mode === 'edit' && !!role;
+  // Both edit and view load the role's existing grant set into the matrix —
+  // view just never lets it change.
+  const hasExistingRole = (mode === 'edit' || mode === 'view') && !!role;
 
   const [name, setName] = useState(role?.name ?? prefill?.name ?? '');
   const [keyValue, setKeyValue] = useState(role?.key ?? (prefill ? slugifyKey(prefill.name) : ''));
@@ -484,21 +542,22 @@ function RoleDialog({
     staleTime: 30_000,
   });
 
-  // Pre-fill the matrix selection for an edit.
+  // Pre-fill the matrix selection for an edit OR a view — both read the
+  // role's existing grant set, view just never writes it back.
   const permsQuery = useQuery({
     queryKey: ['iam-role-permissions', accountId, role?.role_id],
     queryFn: () => getRolePermissions(accountId, role!.role_id),
     staleTime: 30_000,
-    enabled: isEdit,
+    enabled: hasExistingRole,
   });
 
-  // Seed selected from loaded permissions (edit mode) once the query resolves.
-  // Keyed on the resolved data so we never toggle against a not-yet-seeded set.
+  // Seed selected from loaded permissions once the query resolves. Keyed on
+  // the resolved data so we never toggle against a not-yet-seeded set.
   useEffect(() => {
-    if (isEdit && permsQuery.data) {
+    if (hasExistingRole && permsQuery.data) {
       setSelected(new Set(permsQuery.data.actions));
     }
-  }, [isEdit, permsQuery.data]);
+  }, [hasExistingRole, permsQuery.data]);
 
   const matrixActions = useMemo(
     () => (actionsQuery.data ?? []).filter((a) => a.resource_type === resourceType),
@@ -592,11 +651,12 @@ function RoleDialog({
 
   const mutation = isEdit ? updateMutation : createMutation;
   const isPending = mutation.isPending;
-  const matrixLoading = actionsQuery.isLoading || (isEdit && permsQuery.isLoading);
-  const matrixError = actionsQuery.isError || (isEdit && permsQuery.isError);
+  const matrixLoading = actionsQuery.isLoading || (hasExistingRole && permsQuery.isLoading);
+  const matrixError = actionsQuery.isError || (hasExistingRole && permsQuery.isError);
   // Guard the matrix until the edit-mode permissions seed has resolved, so an
-  // admin never toggles against an empty (not-yet-seeded) set.
-  const matrixDisabled = isPending || matrixLoading || matrixError;
+  // admin never toggles against an empty (not-yet-seeded) set. View mode is
+  // always disabled — there is nothing to guard against, it just never opens.
+  const matrixDisabled = isView || isPending || matrixLoading || matrixError;
 
   const submitDisabled =
     isPending || !nameValid || (!isEdit && !keyValid) || matrixLoading || matrixError;
@@ -605,10 +665,11 @@ function RoleDialog({
     <Modal open={open} onOpenChange={(o) => !isPending && onOpenChange(o)}>
       <ModalContent className="max-h-[90vh] lg:max-h-[85vh] lg:max-w-2xl">
         <ModalHeader>
-          <ModalTitle>{isEdit ? 'Edit role' : 'New role'}</ModalTitle>
+          <ModalTitle>{isView ? 'View role' : isEdit ? 'Edit role' : 'New role'}</ModalTitle>
           <ModalDescription>
-            Pick the capabilities this role grants. Anything left unchecked is deactivated for
-            principals assigned this role.
+            {isView
+              ? `What ${role?.name ?? 'this role'} can do — checked capabilities are granted, everything else is deactivated for anyone assigned it.`
+              : 'Pick the capabilities this role grants. Anything left unchecked is deactivated for principals assigned this role.'}
           </ModalDescription>
         </ModalHeader>
 
@@ -621,8 +682,8 @@ function RoleDialog({
                 value={name}
                 onChange={(e) => handleNameChange(e.target.value)}
                 placeholder="Deploy operator"
-                disabled={isPending}
-                autoFocus
+                disabled={isPending || isView}
+                autoFocus={!isView}
               />
             </div>
             <div className="space-y-1.5">
@@ -635,7 +696,7 @@ function RoleDialog({
                   setKeyValue(e.target.value);
                 }}
                 placeholder="deploy_operator"
-                disabled={isPending || isEdit}
+                disabled={isPending || isEdit || isView}
                 className="font-mono"
               />
               {!isEdit && keyValue.length > 0 && !keyValid && (
@@ -653,7 +714,7 @@ function RoleDialog({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What this role is for"
-              disabled={isPending}
+              disabled={isPending || isView}
             />
           </div>
 
@@ -665,7 +726,7 @@ function RoleDialog({
                 setResourceType(v as ResourceType);
                 if (!isEdit) setSelected(new Set());
               }}
-              disabled={isPending || isEdit}
+              disabled={isPending || isEdit || isView}
             >
               <SelectTrigger id="role-resource-type" className="w-48">
                 <SelectValue />
@@ -766,19 +827,25 @@ function RoleDialog({
           </div>
         </ModalBody>
 
-        <ModalFooter className="sm:justify-between">
+        <ModalFooter className={isView ? undefined : 'sm:justify-between'}>
           <Button
             type="button"
             variant="outline-ghost"
             onClick={() => onOpenChange(false)}
             disabled={isPending}
           >
-            Cancel
+            {isView ? 'Close' : 'Cancel'}
           </Button>
-          <Button onClick={() => mutation.mutate()} disabled={submitDisabled} className="gap-1.5">
-            {isPending && <Loading className="size-4 shrink-0" />}
-            {isEdit ? 'Save changes' : 'Create role'}
-          </Button>
+          {!isView && (
+            <Button
+              onClick={() => mutation.mutate()}
+              disabled={submitDisabled}
+              className="gap-1.5"
+            >
+              {isPending && <Loading className="size-4 shrink-0" />}
+              {isEdit ? 'Save changes' : 'Create role'}
+            </Button>
+          )}
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/apps/web/src/features/session/composer/editor/composer-editor.tsx
+++ b/apps/web/src/features/session/composer/editor/composer-editor.tsx
@@ -505,14 +505,18 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
           'aria-multiline': 'true',
           'aria-label': 'Message input',
           /**
-           * `min-h-[2.25em]` — slightly taller than one line by design (Jay's
-           * call, 2026-08-17: "increase the base height... just slightly").
-           * This used to be `1.5em`, exactly one line, on the reasoning that a
-           * taller floor made an empty composer look padded beyond its
-           * content — that reasoning still holds in spirit, `2.25em` is a
-           * deliberately modest bump (~1.5 lines), not a return to the old
-           * `3rem` floor it was written to avoid. It still grows with the
-           * text past this floor.
+           * `min-h-[3.5em]` — taller than one line by design. History: was
+           * `1.5em` (exactly one line) on the reasoning that a taller floor
+           * made an empty composer look padded beyond its content; bumped to
+           * `2.25em` on 2026-08-17 (Jay's call, "just slightly"); bumped
+           * again here on 2026-08-18 (explicit follow-up ask — the first
+           * bump still read as short) to `3.5em` (~2.3 lines). Still short
+           * of the old `3rem` floor this was originally written to avoid in
+           * spirit, but the "avoid padding an empty composer" reasoning has
+           * now been outweighed twice by "it still looks too short" — if
+           * asked again, stop nudging by increments and ask what target
+           * looks right instead. It still grows with the text past this
+           * floor.
            *
            * The `vh` caps are the reference's, verbatim, including the fact
            * that the middle band is the SHORTEST. Tailwind emits base → sm →
@@ -522,7 +526,7 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
            * change the `sm:` step if the tablet cap turns out to be wrong.
            */
           class:
-            'outline-none min-h-[2.25em] max-h-[45vh] sm:max-h-[25vh] lg:max-h-[40vh] overflow-y-auto',
+            'outline-none min-h-[3.5em] max-h-[45vh] sm:max-h-[25vh] lg:max-h-[40vh] overflow-y-auto',
         },
         handleKeyDown,
       },

--- a/apps/web/src/features/workspace/project-sidebar/project-settings-nav-contract.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-settings-nav-contract.test.ts
@@ -105,17 +105,22 @@ describe('project Customize sidebar entry (the routed one)', () => {
     expect(SOURCE).toContain('p.allowed || p.isLoading');
   });
 
-  test('is gated on project.customize.write, on top of the per-tab read leaves', () => {
-    // A plain Member has every per-tab READ leaf (they're in
-    // PROJECT_MEMBER_BASELINE) but not PROJECT_CUSTOMIZE_WRITE (EDITOR_EXTRAS
-    // only) — so without this second gate a Member would see the row even
-    // though every tab behind it is read-only for them. Optimistic like every
-    // other probe here: hide only on an explicit `false`, never while loading.
+  test('is gated on project.customize.read, on top of the per-tab read leaves', () => {
+    // Was project.customize.write — an audited live bug, not a design call
+    // that held up. PROJECT_CUSTOMIZE_READ sits in PROJECT_MEMBER_BASELINE,
+    // so every project role (plain Member included) can reach this row. A
+    // Member is not "look but never touch" behind it: the Member baseline
+    // already includes browsing Connectors, seeing the Agent roster, and
+    // firing Triggers on demand (PROJECT_MEMBER_EXTRAS) — real capabilities
+    // Member gets today, and a .write-gated row hid discovery of a surface
+    // they could already use once they got there (direct URL navigation to
+    // /projects/<id>/customize always worked; the sidebar row was the only
+    // thing that didn't). .write still gates every individual mutation on
+    // every page beneath this row. Optimistic like every other probe here:
+    // hide only on an explicit `false`, never while loading.
     const navItem = fnSource('ProjectCustomizeNavItem');
 
-    expect(navItem).toContain(
-      'useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE)',
-    );
+    expect(navItem).toContain('useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ)');
     expect(navItem).toContain('if (canCustomize.allowed === false) return null;');
   });
 

--- a/apps/web/src/features/workspace/project-sidebar/project-settings-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-settings-nav.tsx
@@ -149,13 +149,24 @@ export function useSettingsKeyboardShortcut() {
  *
  * Gated TWICE, on two different questions:
  *
- *  1. Can this caller configure the project at all? `project.customize.write`
- *     is exactly this leaf — it sits in `EDITOR_EXTRAS`
- *     (`apps/api/src/iam/role-perms.ts`), not the member baseline, so a plain
- *     Member never sees this row. Members can still USE what the row would
- *     lead to (run triggers, read connectors) — they just can't configure it,
- *     and a row that only opens a place to look, never to change anything, is
- *     not worth the sidebar space Customize's own name promises.
+ *  1. Can this caller reach the Customize surface at all? `project.customize.read`
+ *     — it sits in `PROJECT_MEMBER_BASELINE` (`apps/api/src/iam/role-perms.ts`),
+ *     so every project role, plain Member included, sees this row. This was
+ *     `.write` until an audit surfaced it as a live bug, not a design call
+ *     that still held up: Member is NOT "look but never touch" here — the
+ *     Member baseline already includes browsing the Connectors catalogue,
+ *     seeing the Agent roster, and firing Triggers on demand
+ *     (`PROJECT_MEMBER_EXTRAS`). A `.write`-gated row hid a surface the
+ *     caller could already use once they got there, with no discovery path
+ *     to it apart from a bookmarked URL — direct navigation to
+ *     `/projects/<id>/customize` already worked and always had, the row was
+ *     the only thing that didn't. `.write` still gates every individual
+ *     mutation on every page beneath this row (each tab, and the
+ *     Settings/config tab's own sections, already probe their own write
+ *     leaf) — this fixes visibility of the entry point, not what a Member
+ *     can change once inside it. Same pattern the Settings tab's own
+ *     sub-nav already uses for the identical reason, see
+ *     `CUSTOMIZE_SECTION_ACCESS` in `lib/project-actions.ts`.
  *  2. Does at least one tab exist for them to land on once there?
  *     `useCapabilityTab()` still probes each tab's own read leaf — a caller
  *     denied every single one gets no row at all, rather than a link to an
@@ -175,7 +186,7 @@ export function ProjectCustomizeNavItem() {
   const projectId = params?.id;
   const isMobile = useIsMobile();
   const { setOpenMobile } = useSidebar();
-  const canCustomize = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE);
+  const canCustomize = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ);
   const tab = useCapabilityTab(projectId);
   // Active on the index itself (`/customize`, no deeper segment) AND on any
   // capability tab it links out to — the row should stay lit while browsing

--- a/apps/web/src/features/workspace/settings/tabs/member-access-label.test.ts
+++ b/apps/web/src/features/workspace/settings/tabs/member-access-label.test.ts
@@ -82,7 +82,13 @@ describe('memberAccessLabel', () => {
     expect(memberAccessLabel(member({}))).toEqual({ role: '—', via: 'no access' });
   });
 
-  test('the first group source wins when several contribute', () => {
+  test('the first group source wins the role when several contribute, and the rest are counted, not dropped', () => {
+    // The role shown ("Editor") is genuinely explained by Engineering alone
+    // — Viewers contributes nothing to it. But Viewers is still real access
+    // this member has on this project via a second group, and used to be
+    // fully invisible without leaving to the account page. "+1 more" keeps
+    // that discoverable in one line instead of silently naming only the
+    // winner.
     expect(
       memberAccessLabel(
         member({
@@ -94,6 +100,22 @@ describe('memberAccessLabel', () => {
           ],
         }),
       ).via,
-    ).toBe('via Engineering');
+    ).toBe('via Engineering +1 more');
+  });
+
+  test('three or more group sources count all the extras, not just one', () => {
+    expect(
+      memberAccessLabel(
+        member({
+          effective_project_role: 'editor',
+          effective_source: 'group',
+          group_sources: [
+            { group_id: 'g1', group_name: 'Engineering', role: 'editor' },
+            { group_id: 'g2', group_name: 'Viewers', role: 'viewer' as ProjectRole },
+            { group_id: 'g3', group_name: 'Contractors', role: 'viewer' as ProjectRole },
+          ],
+        }),
+      ).via,
+    ).toBe('via Engineering +2 more');
   });
 });

--- a/apps/web/src/features/workspace/settings/tabs/member-access-label.ts
+++ b/apps/web/src/features/workspace/settings/tabs/member-access-label.ts
@@ -40,8 +40,17 @@ export function memberAccessLabel(member: ProjectAccessMember): MemberAccessLabe
   if (member.effective_source === 'group') {
     // Server sorts `group_sources` by role desc (access.ts:24) — the first
     // entry is the group that actually produced `effective_project_role`.
+    // Additional entries are lower-role groups this member also belongs to
+    // on this project — real access, just not the one that won. Naming only
+    // the winner used to make every other membership invisible without
+    // leaving the project (an audited gap); "+N more" keeps the row one
+    // line while saying that access exists instead of silently dropping it.
     const groupName = member.group_sources?.[0]?.group_name;
-    return { role, via: groupName ? `via ${groupName}` : null };
+    const extra = (member.group_sources?.length ?? 0) - 1;
+    return {
+      role,
+      via: groupName ? `via ${groupName}${extra > 0 ? ` +${extra} more` : ''}` : null,
+    };
   }
 
   // 'direct', or an unrecognized/undefined source with a resolved role —

--- a/apps/web/src/features/workspace/settings/tabs/members-tab-nonarray-guard.test.ts
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab-nonarray-guard.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { toArray } from '@/features/workspace/customize/shared/utils';
-
 // Regression test for the Better Stack error pattern
 //   `f9603a4344ea892980086cc75a9f15d6457da1e8bfa88ffbcfa7b08f1c2dcb0b` —
 //   `TypeError: (intermediate value)(intermediate value)(intermediate value).filter is not a function`
@@ -24,63 +22,26 @@ import { toArray } from '@/features/workspace/customize/shared/utils';
 // `ResourceAccessCard` and `ProjectRoleAssignmentsCard`, which share the same
 // `toArray(policiesQuery.data)` / `toArray(groupsQuery.data)` derivation
 // shape — was rehomed (cut, not copied) from `members-view.tsx` into
-// `members-tab.tsx`; see that file's header comment. This guard follows the
-// code it protects: the invariant is about the derivation, not about which
-// file happens to hold it, so it now reads `members-tab.tsx`'s source
-// instead. `members-view.tsx` no longer contains this card at all.
+// `members-tab.tsx`; see that file's header comment.
 //
-// These tests (a) reproduce the exact prod throw on the unguarded path and
-// (b) keep a future refactor from silently restoring the `(x ?? []).filter`
-// shape via source-level assertions (same convention as chunk22256-guard.test.ts
-// and policies-panel.test.ts).
+// **`ProjectGroupGrantsCard` and its `groupsWithCustomRole` derivation are
+// gone.** Both it and `ProjectRoleAssignmentsCard` were removed outright,
+// not just fixed — they duplicated proper account-level homes (a group's own
+// "Projects" tab, the account Roles page's `PolicyAssignments`) and were
+// never a resource concern the project's Access tab should own. The exact
+// `policiesQuery.data` derivation this file used to reproduce no longer
+// exists anywhere in `members-tab.tsx`, so the reproduction tests below it
+// were removed with it — they tested a synthetic copy of logic that has no
+// real counterpart left to protect. What remains is the general hygiene
+// guard: this file's own history proves the `(query.data ?? []).filter`
+// shape is a recurring mistake, worth catching for ANY query in this file,
+// present or future, not just the one that actually threw.
+//
+// These tests keep a future refactor from silently reintroducing the
+// `(x ?? []).filter` shape via source-level assertions (same convention as
+// chunk22256-guard.test.ts and policies-panel.test.ts).
 
 const membersTabSource = readFileSync(join(import.meta.dir, 'members-tab.tsx'), 'utf8');
-
-/**
- * The exact derivation that threw in prod, lifted out of the useMemo so it can
- * be exercised without a react-query harness. Mirrors the
- * `ProjectGroupGrantsCard` `groupsWithCustomRole` derivation: filter the
- * project-scoped group policies and collect their principal ids.
- */
-function groupsWithCustomRoleFrom(policiesData: unknown, projectId: string): Set<string> {
-  return new Set(
-    toArray(policiesData)
-      .filter(
-        (p: any) =>
-          p.principal_type === 'group' && p.scope_type === 'project' && p.scope_id === projectId,
-      )
-      .map((p: any) => p.principal_id),
-  );
-}
-
-describe('members-tab non-array guard — ProjectGroupGrantsCard derivation', () => {
-  test('does NOT throw on the exact prod failure shape: a defined non-array policies value', () => {
-    // The shape that fired in prod: `policiesQuery.data` is a defined non-array
-    // (e.g. an empty object or an error envelope). The old `(data ?? []).filter`
-    // path threw `(intermediate value)...filter is not a function` here.
-    expect(() => groupsWithCustomRoleFrom({}, 'p1')).not.toThrow();
-    expect(() => groupsWithCustomRoleFrom({ error: 'x' }, 'p1')).not.toThrow();
-    expect(() => groupsWithCustomRoleFrom('not-an-array', 'p1')).not.toThrow();
-    expect(() => groupsWithCustomRoleFrom(42, 'p1')).not.toThrow();
-    expect(groupsWithCustomRoleFrom({}, 'p1')).toEqual(new Set());
-  });
-
-  test('absorbs null/undefined (the ?? [] cases) without throwing', () => {
-    expect(() => groupsWithCustomRoleFrom(null, 'p1')).not.toThrow();
-    expect(() => groupsWithCustomRoleFrom(undefined, 'p1')).not.toThrow();
-    expect(groupsWithCustomRoleFrom(null, 'p1')).toEqual(new Set());
-    expect(groupsWithCustomRoleFrom(undefined, 'p1')).toEqual(new Set());
-  });
-
-  test('happy path: filters project-scoped group policies and collects principal ids', () => {
-    const policies = [
-      { principal_type: 'group', scope_type: 'project', scope_id: 'p1', principal_id: 'g1' },
-      { principal_type: 'group', scope_type: 'project', scope_id: 'p2', principal_id: 'g2' },
-      { principal_type: 'member', scope_type: 'project', scope_id: 'p1', principal_id: 'u1' },
-    ];
-    expect(groupsWithCustomRoleFrom(policies, 'p1')).toEqual(new Set(['g1']));
-  });
-});
 
 describe('members-tab source guard — no unguarded (query.data ?? []).filter/.map', () => {
   // The prod throw was a `(policiesQuery.data ?? []).filter(...)` inside a
@@ -89,12 +50,6 @@ describe('members-tab source guard — no unguarded (query.data ?? []).filter/.m
   test('imports toArray from the shared customize utils', () => {
     expect(membersTabSource).toContain("from '@/features/workspace/customize/shared/utils'");
     expect(membersTabSource).toContain('toArray(');
-  });
-
-  test('ProjectGroupGrantsCard groupsWithCustomRole routes through toArray, not (data ?? []).filter', () => {
-    // The exact line that threw in prod.
-    expect(membersTabSource).not.toContain('(policiesQuery.data ?? []).filter(');
-    expect(membersTabSource).toContain('toArray(policiesQuery.data)');
   });
 
   test('no remaining unguarded (query.data ?? []).filter or .map in the file', () => {

--- a/apps/web/src/features/workspace/settings/tabs/members-tab.test.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab.test.tsx
@@ -108,7 +108,14 @@ describe('MembersTabView', () => {
     expect(out).toContain('help-marker');
   });
 
-  test('renders one row per member, with an Account role and a Workspace access column', () => {
+  test('renders one row per member, with an Account column and a This-project column, scope-labelled', () => {
+    // Was "Account role" / "Project role" — two labels for "the same kind of
+    // thing" that read as equally scoped on a page that lives entirely
+    // inside ONE project. Scope leads now ("Account" / "This project"), with
+    // a muted second line spelling out what changing it actually reaches —
+    // the confusion a live screenshot called out directly: "nobody will know
+    // what is an account role, what is a project role... this is in the
+    // project settings."
     const out = renderToStaticMarkup(
       <MembersTabView
         members={[
@@ -117,8 +124,10 @@ describe('MembersTabView', () => {
         ]}
       />,
     );
-    expect(out).toContain('Account role');
-    expect(out).toContain('Workspace access');
+    expect(out).toContain('Account');
+    expect(out).toContain('every workspace');
+    expect(out).toContain('This project');
+    expect(out).toContain('only here');
     expect(out).toContain('owner@kortix.com');
     expect(out).toContain('viewer@kortix.com');
     expect(out.match(/<tr/g)?.length).toBe(3); // 1 header row + 2 member rows
@@ -225,7 +234,7 @@ describe('MembersTabView', () => {
   test('People is the default tab — the table is what you land on', () => {
     const out = renderToStaticMarkup(<MembersTabView members={[member({})]} />);
     expect(out).toContain('<table');
-    expect(out).toContain('Workspace access');
+    expect(out).toContain('This project');
   });
 
   test('the pane heading stays above the tab bar, outside every panel', () => {
@@ -295,7 +304,7 @@ describe('MembersTabView', () => {
         canManageMembers
       />,
     );
-    // Four columns: Member, Account role, Workspace access, Joined. The
+    // Four columns: Member, Account, This project, Joined. The
     // character class keeps `<thead` out of the count.
     expect(out.match(/<th[ >]/g)?.length).toBe(4);
     expect(out).toContain('role="combobox"');

--- a/apps/web/src/features/workspace/settings/tabs/members-tab.test.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab.test.tsx
@@ -409,41 +409,31 @@ describe('MembersTabView', () => {
     expect(out).toContain('invite-dialog-marker');
   });
 
-  test('the Access tab holds the three rehomed slots, in that order', () => {
+  test('the Access tab holds the resource-access slot', () => {
+    // Only one slot now — group role assignment and custom-role binding were
+    // removed outright (not rehomed, not hidden): both duplicated a proper
+    // account-level home that already existed (a group's own "Projects" tab,
+    // the account Roles page's PolicyAssignments). See members-tab.tsx's
+    // header comment.
     const out = renderToStaticMarkup(
       <MembersTabView
         section="access"
         members={[member({})]}
-        groupGrantsSlot={<div>group-grants-marker</div>}
         resourceAccessSlot={<div>resource-access-marker</div>}
-        roleAssignmentsSlot={<div>role-assignments-marker</div>}
       />,
     );
-    expect(out).toContain('group-grants-marker');
     expect(out).toContain('resource-access-marker');
-    expect(out).toContain('role-assignments-marker');
-    // Rehomed in their existing order (members-view.tsx's own composition
-    // order: ProjectGroupGrantsCard, ResourceAccessCard,
-    // ProjectRoleAssignmentsCard) — see members-tab.tsx's header comment.
-    expect(out.indexOf('group-grants-marker')).toBeLessThan(out.indexOf('resource-access-marker'));
-    expect(out.indexOf('resource-access-marker')).toBeLessThan(
-      out.indexOf('role-assignments-marker'),
-    );
   });
 
-  test('the access slots are NOT on the People tab — the table stands alone there', () => {
+  test('the access slot is NOT on the People tab — the table stands alone there', () => {
     const out = renderToStaticMarkup(
       <MembersTabView
         members={[member({})]}
-        groupGrantsSlot={<div>group-grants-marker</div>}
         resourceAccessSlot={<div>resource-access-marker</div>}
-        roleAssignmentsSlot={<div>role-assignments-marker</div>}
       />,
     );
     expect(out).toContain('<table');
-    expect(out).not.toContain('group-grants-marker');
     expect(out).not.toContain('resource-access-marker');
-    expect(out).not.toContain('role-assignments-marker');
   });
 
   test('an Access tab with no slots shows an empty state, not a blank panel', () => {

--- a/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
@@ -2624,6 +2624,18 @@ function ProjectGroupGrantsCard({
     onError: (err: Error) => errorToast(err.message || 'Failed to detach group'),
   });
 
+  // Progressive disclosure: this card is a role-assignment shortcut for a
+  // GROUP (the same operation the People tab does per-member — see
+  // attachMutation's `role: ProjectRole` above), not a resource concern. For
+  // the overwhelming majority of accounts that have never created a group,
+  // it is a permanently-empty "go create one elsewhere" teaching card that
+  // only adds noise to a page about THIS project's access. Hide it entirely
+  // once loaded with nothing to show; a project with an existing grant (even
+  // an orphaned one, pointing at a since-deleted group) keeps the card, since
+  // that grant still needs to be manageable/removable.
+  const groupsLoaded = !grantsQuery.isLoading && !groupsQuery.isLoading;
+  if (groupsLoaded && groups.length === 0 && grants.length === 0) return null;
+
   return (
     <>
       <section className="space-y-3">
@@ -3625,6 +3637,15 @@ function ProjectRoleAssignmentsCard({
 
   const canSubmit =
     !!subjectType && subjectIds.length > 0 && !!roleId && !createMutation.isPending;
+
+  // Progressive disclosure — see ProjectGroupGrantsCard's identical comment.
+  // Custom roles are defined on the account Roles page; an account that has
+  // never made one gets a permanently-empty "go create one elsewhere" card
+  // here. Hide it once loaded with nothing to show; keep it if there is an
+  // existing project-scoped binding to manage/remove, even one whose role
+  // was since deleted.
+  const rolesLoaded = !policiesQuery.isLoading && !rolesQuery.isLoading;
+  if (rolesLoaded && customRoles.length === 0 && policies.length === 0) return null;
 
   return (
     <>

--- a/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
@@ -1106,7 +1106,18 @@ export function MembersTabView({
                             ) : canManageMembers && isInheritedFromGroupOnly(member) ? (
                               <Hint
                                 side="top"
-                                label={`Inherited from the ${member.group_sources?.[0]?.group_name ?? 'group'} group. Change the group's project access to update this.`}
+                                label={(() => {
+                                  const groupName = member.group_sources?.[0]?.group_name ?? 'group';
+                                  const extra = (member.group_sources?.length ?? 0) - 1;
+                                  // Only naming the winning group used to make
+                                  // "change the group's project access" a lie
+                                  // when a second group also granted access —
+                                  // editing just Engineering wouldn't actually
+                                  // unlock the row if Viewers still applied.
+                                  return extra > 0
+                                    ? `Inherited from the ${groupName} group and ${extra} other group${extra === 1 ? '' : 's'}. Change all of their project access to update this.`
+                                    : `Inherited from the ${groupName} group. Change the group's project access to update this.`;
+                                })()}
                               >
                                 <Lock className="text-muted-foreground size-3.5 shrink-0" />
                               </Hint>

--- a/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
@@ -63,7 +63,11 @@
  * dropped — `ProjectGroupGrantsCard` (bulk group-access grants),
  * `ResourceAccessCard` (per-agent/skill scoping) and
  * `ProjectRoleAssignmentsCard` (custom-role bindings) were moved into this
- * file (cut, not copied — see their slots below), and
+ * file (cut, not copied — see their slots below). Of those three,
+ * `ProjectGroupGrantsCard` and `ProjectRoleAssignmentsCard` were later
+ * removed outright (not just this move) — see the header comment further
+ * down, right above where they used to live, for why; `ResourceAccessCard`
+ * is the only one left. And
  * `consumeMembersTabIntent` moved to `members-tab-intent.ts` beside its only
  * caller. `PermissionsHelpPopover` keeps a live mount here as this tab's own
  * header action, independent of `accounts/[id]/page.tsx`'s.
@@ -356,9 +360,20 @@
  * - **Invites** — everyone waiting to get in: the project invites, the account
  *   invites, and the access requests, each retitled to say who is waiting and
  *   for what. See "Plain titles" below.
- * - **Access** — `groupGrantsSlot` / `resourceAccessSlot` /
- *   `roleAssignmentsSlot`, in the same order, behind the same gates the
- *   container already passed them under. Out of the way until wanted.
+ * - **Access** — `resourceAccessSlot` only: which members/groups can USE
+ *   which agent, the one project-scoped concern this page owns. Assigning a
+ *   project ROLE to a whole group at once, and binding a custom role, both
+ *   moved out — they were never a resource concern (Groups attached a plain
+ *   ProjectRole, the same op the People tab does per-member; Custom roles
+ *   bound an account-defined role) and both already have a proper home:
+ *   a group's own detail page's "Projects" tab
+ *   (`accounts/[id]/groups/[groupId]`'s `GroupProjectGrantsCard`) and the
+ *   account Roles page's `PolicyAssignments`, which can target ANY project,
+ *   not just the one you happen to be viewing. Keeping a second, narrower
+ *   copy of each on every individual project's Access tab was pure
+ *   duplication — and, for the vast majority of accounts with zero groups
+ *   and zero custom roles, a permanently-empty "go create one elsewhere"
+ *   card that only added noise.
  *
  * **Plain titles.** The three waiting lists were renamed for a non-technical
  * reader; each is a display string with no other consumer (verified with
@@ -455,28 +470,15 @@ import { UserAvatar } from '@/components/ui/user-avatar';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { useCopy } from '@/hooks/use-copy';
-import {
-  createPolicy,
-  deletePolicy,
-  listAgentIdentities,
-  listGroups,
-  listPolicies,
-  listRoles,
-  type AccountGroup,
-  type IamPolicy,
-  type PrincipalType,
-} from '@/lib/iam-client';
 import { PROJECT_LANDING_PATH } from '@/lib/onboarding/landing-destination';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { usePermission } from '@/lib/use-permission';
 import { useProjectCan } from '@/lib/use-project-can';
 import {
   approveProjectAccessRequest,
-  attachGroupToProject,
   cancelAccountInvite,
   createProjectResourceGrant,
   deleteProjectResourceGrant,
-  detachGroupFromProject,
   getAccount,
   getProject,
   inviteAccountMember,
@@ -487,7 +489,6 @@ import {
   listPendingProjectInvites,
   listProjectAccess,
   listProjectAccessRequests,
-  listProjectGroupGrants,
   listProjectResourceGrants,
   rejectProjectAccessRequest,
   removeAccountMember,
@@ -497,20 +498,17 @@ import {
   revokeProjectAccess,
   updateAccountMemberRole,
   updateProjectAccess,
-  updateProjectGroupGrant,
   type AccountInvitation,
   type AccountRole,
   type PendingProjectInvite,
   type ProjectAccessMember,
   type ProjectAccessRequest,
-  type ProjectGroupGrant,
   type ProjectResourceGrant,
   type ProjectRole,
   type ResourceGrantType,
 } from '@kortix/sdk';
 import { contract, invalidateProject, qk } from '@kortix/sdk/react';
 import {
-  RobotIcon as Bot,
   CheckIcon as Check,
   ClockIcon as Clock,
   ArrowElbowDownRightIcon as CornerDownRight,
@@ -520,7 +518,6 @@ import {
   PlugIcon as Plug,
   PlusIcon as Plus,
   ArrowClockwiseIcon as RefreshCw,
-  UserIcon as User,
   UsersIcon as Users,
   XIcon as X,
 } from '@phosphor-icons/react';
@@ -600,21 +597,13 @@ export interface MembersTabViewProps {
   /** `InviteMemberDialog` — see this file's header comment for why it's a
    *  slot. */
   inviteDialogSlot?: ReactNode;
-  /** `ProjectGroupGrantsCard`, moved (cut, not copied) from
-   *  `members-view.tsx` — see this file's header comment, "Rehomed from
-   *  MembersView". Owns its own `useQuery`/`useMutation` (and
-   *  `useTranslations`), so it's a slot. The container renders it only when
-   *  `project?.account_id` is known — same gate `members-view.tsx` used at
-   *  its own mount site, preserved exactly, not re-derived. */
-  groupGrantsSlot?: ReactNode;
   /** `ResourceAccessCard`, moved from `members-view.tsx`. The container
    *  renders it only when `project?.account_id && canManage` — same gate
    *  `members-view.tsx` used, preserved exactly (manager-only DATA: the
-   *  grants list route denies non-managers). */
+   *  grants list route denies non-managers). The only slot the Access tab
+   *  renders now — group-role and custom-role assignment moved out to their
+   *  proper account-level homes, see this file's header comment. */
   resourceAccessSlot?: ReactNode;
-  /** `ProjectRoleAssignmentsCard`, moved from `members-view.tsx`. Same gate
-   *  as `resourceAccessSlot` (manager-only DATA). */
-  roleAssignmentsSlot?: ReactNode;
   /** `<PermissionsHelpPopover />` — see this file's header comment for why
    *  it's a slot (it calls `useTranslations`, which throws with no
    *  `NextIntlClientProvider`). Carries `ACCOUNT_ROLE_DESCRIPTORS`'
@@ -761,9 +750,7 @@ export function MembersTabView({
   onOpenInvite = () => {},
   inviteDialogSlot,
   permissionsHelpSlot,
-  groupGrantsSlot,
   resourceAccessSlot,
-  roleAssignmentsSlot,
   pendingInvites = [],
   isPendingInvitesLoading = false,
   pendingInviteBusyIds = new Set(),
@@ -838,7 +825,7 @@ export function MembersTabView({
   // The Access tab is exactly the three rehomed slots. The container decides
   // whether each one exists at all (its gate, unchanged); this only decides
   // whether the tab shows them or one muted row instead of a blank panel.
-  const showAccessCards = !!(groupGrantsSlot || resourceAccessSlot || roleAssignmentsSlot);
+  const showAccessCards = !!resourceAccessSlot;
   // Everyone waiting to get in, counted once for the Invites tab's own count.
   const waitingCount =
     pendingInvites.length + accessRequests.length + (accountId ? accountInvites.length : 0);
@@ -1431,26 +1418,24 @@ export function MembersTabView({
         </TabsContent>
 
         {/* ── Access ────────────────────────────────────────────────────── */}
-        {/* The three rehomed cards, in their existing order and behind the
-            gates the container already passed them under — see this file's
-            header comment, "Rehomed from MembersView". Nothing is re-derived
-            here; this tab only decides where they sit. */}
+        {/* Who can USE which agent — the one project-scoped resource concern
+            this tab owns. Nothing is re-derived here; this tab only decides
+            where the card sits, behind the same gate the container already
+            passed it under. See this file's header comment for why group
+            role assignment and custom-role binding live on their account-
+            level pages instead of a second copy here. */}
         <TabsContent value="access" className="space-y-8">
           {showAccessCards ? (
-            <>
-              {groupGrantsSlot}
-              {resourceAccessSlot}
-              {roleAssignmentsSlot}
-            </>
+            resourceAccessSlot
           ) : (
-            /* The same muted row the three cards use when their own list is
-               empty — not a second, illustrated way of saying "nothing here".
-               A viewer who can see no access card at all reads one row, in the
+            /* The same muted row the card uses when its own list is empty —
+               not a second, illustrated way of saying "nothing here". A
+               viewer who can see no access card at all reads one row, in the
                same bordered group, at the same height. */
             <SettingsRowGroup>
               <SettingsEmptyRow
                 label="No extra access rules"
-                description="Group access, agent assignments, and custom roles for this workspace appear here."
+                description="Agent assignments for this workspace appear here."
               />
             </SettingsRowGroup>
           )}
@@ -2051,32 +2036,14 @@ function MembersTabInner({
           onInvited={invalidateAccess}
         />
       }
-      // Rehomed from `members-view.tsx` — gates preserved EXACTLY as that
-      // file passed them at its own mount site (see this file's header
-      // comment). `ProjectGroupGrantsCard` gates on `project?.account_id`
-      // alone; the other two additionally require `canManage`.
-      groupGrantsSlot={
-        project?.account_id ? (
-          <ProjectGroupGrantsCard
-            projectId={projectId}
-            accountId={project.account_id}
-            canManage={!!canManage}
-          />
-        ) : undefined
-      }
+      // Gate preserved EXACTLY as `members-view.tsx` passed it at its own
+      // mount site (see this file's header comment): manager-only DATA, the
+      // grants list route denies non-managers. Group-role assignment and
+      // custom-role binding used to render here too — removed, not hidden;
+      // see this file's header comment for where they live now.
       resourceAccessSlot={
         project?.account_id && canManage ? (
           <ResourceAccessCard projectId={projectId} canManage={!!canManage} />
-        ) : undefined
-      }
-      roleAssignmentsSlot={
-        project?.account_id && canManage ? (
-          <ProjectRoleAssignmentsCard
-            projectId={projectId}
-            accountId={project.account_id}
-            canManage={!!canManage}
-            members={accessQuery.data?.members ?? []}
-          />
         ) : undefined
       }
       accountId={accountId}
@@ -2417,26 +2384,24 @@ function InviteToAccountDialog({
 }
 
 // ─────────────────────────────────────────────────────────────────────────
-// Rehomed from `members-view.tsx` (moved, not copied — a copy leaves two
-// implementations to drift). `ProjectGroupGrantsCard`, `FilterChips`,
-// `ScopeLine`, `BlastRadiusPreview`, `ResourceAccessCard`, and
-// `ProjectRoleAssignmentsCard` are UNMODIFIED below apart from using this
-// file's own `MEMBER_ROW`/`formatDate`/`userLabel` (byte-identical
-// definitions already declared above) instead of re-declaring them. Each
-// card is mounted as a slot from `MembersTabInner` with its gate preserved
-// EXACTLY as `members-view.tsx` passed it at its own mount site — see
-// `MembersTabViewProps.groupGrantsSlot`/`resourceAccessSlot`/
-// `roleAssignmentsSlot`'s doc comments and `MembersTabInner`'s own comment
-// next to `canManage`.
-//
-// Their PRESENTATION is now the panel's own: each card is a
-// `SettingsSubsectionHeader` over one `SettingsRowGroup`, one `SettingsRow`
-// per item. Before this pass the three of them had three different bespoke
-// list shapes and — with the tab's own fallback — four different ways to say
-// "there is nothing here" (an illustrated `EmptyState` with a `Users` icon,
-// two bare `<p>`s, and a second illustrated `EmptyState`), while
-// `SettingsRowGroup` appeared in this file zero times. Behaviour, gates,
-// queries and mutations are untouched; only the markup around them changed.
+// Originally rehomed from `members-view.tsx` (moved, not copied) as three
+// cards: `ProjectGroupGrantsCard`, `ResourceAccessCard`, and
+// `ProjectRoleAssignmentsCard`. The group and custom-role cards are gone —
+// removed, not hidden — once it became clear they were never a resource
+// concern (Groups attached a plain ProjectRole, the exact op the People tab
+// already does per-member; Custom roles bound an account-defined role) and
+// both duplicated a proper account-level home that already existed: a
+// group's own detail page's "Projects" tab
+// (`accounts/[id]/groups/[groupId]`'s `GroupProjectGrantsCard`) and the
+// account Roles page's `PolicyAssignments`, which can target ANY project,
+// not just the one you happen to be on. `FilterChips`, `ScopeLine`,
+// `BlastRadiusPreview`, and `ResourceAccessCard` below are what's left —
+// mounted as a slot from `MembersTabInner` with its gate preserved EXACTLY
+// as `members-view.tsx` passed it at its own mount site, using this file's
+// own `MEMBER_ROW`/`formatDate`/`userLabel` (byte-identical definitions
+// already declared above) instead of re-declaring them. Its PRESENTATION is
+// the panel's own: a `SettingsSubsectionHeader` over one `SettingsRowGroup`,
+// one `SettingsRow` per item.
 // ─────────────────────────────────────────────────────────────────────────
 
 /**
@@ -2498,368 +2463,6 @@ function SettingsEmptyRow({ label, description }: { label: string; description?:
       label={<span className="text-muted-foreground font-normal">{label}</span>}
       description={description}
     />
-  );
-}
-
-function ProjectGroupGrantsCard({
-  projectId,
-  accountId,
-  canManage,
-}: {
-  projectId: string;
-  accountId: string;
-  canManage: boolean;
-}) {
-  // Switches the panel's tab rather than navigating away — Groups is a tab
-  // in this same panel now, not a separate account page.
-  const { navigate } = useSettingsNav();
-  const tHardcodedUi = useTranslations('hardcodedUi');
-  const queryClient = useQueryClient();
-  const grantsKey = qk.project.groupGrants(projectId);
-
-  const grantsQuery = useQuery({
-    queryKey: grantsKey,
-    queryFn: () => listProjectGroupGrants(projectId),
-    ...contract('inventory'),
-  });
-  const groupsQuery = useQuery({
-    queryKey: ['account-groups', accountId],
-    queryFn: () => listGroups(accountId),
-    enabled: canManage,
-    staleTime: 60_000,
-  });
-  // Custom-role policies bound to a GROUP on this project. A group that has BOTH
-  // a built-in grant (this list) AND a custom-role policy hits the union trap:
-  // allow-only/highest-wins means the built-in role WINS and silently overrides
-  // the custom role's restrictions. We flag those rows so it isn't a silent gotcha.
-  // qk.project.policies — the IAM role-policy family, NOT
-  // qk.project.executorPolicies (the unrelated sandbox tool-rule family
-  // PoliciesPanel reads). Both used to share the literal ['project-policies',
-  // id] pre-migration, which meant whichever fetch resolved last clobbered
-  // the other's cache entry with an incompatible shape.
-  const policiesQuery = useQuery({
-    queryKey: qk.project.policies(projectId),
-    queryFn: () => listPolicies(accountId, { scopeId: projectId }),
-    enabled: canManage,
-    ...contract('config'),
-  });
-  const groupsWithCustomRole = useMemo(() => {
-    const ids = new Set<string>();
-    for (const p of toArray(policiesQuery.data)) {
-      if (p.principal_type === 'group' && p.scope_type === 'project' && p.scope_id === projectId) {
-        ids.add(p.principal_id);
-      }
-    }
-    return ids;
-  }, [policiesQuery.data, projectId]);
-
-  const grants = useMemo(() => {
-    const raw = toArray(grantsQuery.data?.grants);
-    return [...raw].sort((a, b) => {
-      const t = a.created_at.localeCompare(b.created_at);
-      return t !== 0 ? t : a.group_id.localeCompare(b.group_id);
-    });
-  }, [grantsQuery.data]);
-  const groups: AccountGroup[] = useMemo(() => toArray(groupsQuery.data), [groupsQuery.data]);
-  const attachedIds = useMemo(() => new Set(grants.map((g) => g.group_id)), [grants]);
-  const available = useMemo(
-    () => groups.filter((g) => !attachedIds.has(g.group_id)),
-    [groups, attachedIds],
-  );
-
-  const [pickerGroupId, setPickerGroupId] = useState<string>('');
-  const [pickerRole, setPickerRole] = useState<ProjectRole>('member');
-  const [pendingGroupIds, setPendingGroupIds] = useState<Set<string>>(() => new Set());
-  const markPending = (id: string) => setPendingGroupIds((prev) => new Set(prev).add(id));
-  const clearPending = (id: string) =>
-    setPendingGroupIds((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
-  const [detachTarget, setDetachTarget] = useState<ProjectGroupGrant | null>(null);
-
-  function invalidate() {
-    queryClient.invalidateQueries({ queryKey: grantsKey });
-    queryClient.invalidateQueries({ queryKey: qk.project.access(projectId) });
-    queryClient.invalidateQueries({ queryKey: qk.project.summary(projectId) });
-  }
-
-  const attachMutation = useMutation({
-    mutationFn: () => attachGroupToProject(projectId, pickerGroupId, pickerRole),
-    onMutate: () => {
-      markPending(pickerGroupId);
-      return { groupId: pickerGroupId };
-    },
-    onSettled: (_data, _error, _vars, ctx) => clearPending(ctx!.groupId),
-    onSuccess: () => {
-      successToast('Group attached');
-      setPickerGroupId('');
-      setPickerRole('editor');
-      invalidate();
-    },
-    onError: (err: Error) => errorToast(err.message || 'Failed to attach group'),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: (input: { groupId: string; role: ProjectRole }) =>
-      updateProjectGroupGrant(projectId, input.groupId, input.role),
-    onMutate: (input) => markPending(input.groupId),
-    onSettled: (_data, _error, input) => clearPending(input.groupId),
-    onSuccess: () => {
-      successToast('Role updated');
-      invalidate();
-    },
-    onError: (err: Error) => errorToast(err.message || 'Failed to update role'),
-  });
-
-  const detachMutation = useMutation({
-    mutationFn: (groupId: string) => detachGroupFromProject(projectId, groupId),
-    onMutate: (groupId) => markPending(groupId),
-    onSettled: (_data, _error, groupId) => clearPending(groupId),
-    onSuccess: () => {
-      successToast('Group detached');
-      invalidate();
-    },
-    onError: (err: Error) => errorToast(err.message || 'Failed to detach group'),
-  });
-
-  // Progressive disclosure: this card is a role-assignment shortcut for a
-  // GROUP (the same operation the People tab does per-member — see
-  // attachMutation's `role: ProjectRole` above), not a resource concern. For
-  // the overwhelming majority of accounts that have never created a group,
-  // it is a permanently-empty "go create one elsewhere" teaching card that
-  // only adds noise to a page about THIS project's access. Hide it entirely
-  // once loaded with nothing to show; a project with an existing grant (even
-  // an orphaned one, pointing at a since-deleted group) keeps the card, since
-  // that grant still needs to be manageable/removable.
-  const groupsLoaded = !grantsQuery.isLoading && !groupsQuery.isLoading;
-  if (groupsLoaded && groups.length === 0 && grants.length === 0) return null;
-
-  return (
-    <>
-      <section className="space-y-3">
-        {/* Was "Group access" / "Attach an account group to this project…"
-            routed through auto-generated i18n keys. Plain words, written
-            here: nobody thinks of it as "attaching" anything. */}
-        <SettingsSubsectionHeader
-          title={
-            <>
-              Groups
-              {grants.length > 0 ? (
-                <span className="text-muted-foreground ml-1.5 font-normal tabular-nums">
-                  {grants.length}
-                </span>
-              ) : null}
-            </>
-          }
-          description="Give a whole group access here at once. Everyone in the group gets the role you pick."
-          action={
-            canManage && available.length > 0 ? (
-              <form
-                className="flex shrink-0 items-center gap-1.5"
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  if (!pickerGroupId || attachMutation.isPending) return;
-                  attachMutation.mutate();
-                }}
-              >
-                <Select
-                  value={pickerGroupId}
-                  onValueChange={setPickerGroupId}
-                  disabled={attachMutation.isPending}
-                >
-                  <SelectTrigger className="h-8 w-44 text-xs">
-                    <SelectValue
-                      placeholder={tHardcodedUi.raw(
-                        'autoComponentsProjectsCustomizeSectionsMembersViewJsxAttrPlaceholderPickf0432525',
-                      )}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {available.map((g) => (
-                      <SelectItem key={g.group_id} value={g.group_id}>
-                        {g.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Select
-                  value={pickerRole}
-                  onValueChange={(v) => setPickerRole(v as ProjectRole)}
-                  disabled={attachMutation.isPending}
-                >
-                  <SelectTrigger className="h-8 w-28 text-xs">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <ProjectRoleSelectItem role="member" />
-                    <ProjectRoleSelectItem role="editor" />
-                    <ProjectRoleSelectItem role="manager" />
-                  </SelectContent>
-                </Select>
-                <Button
-                  type="submit"
-                  size="sm"
-                  variant="outline"
-                  disabled={!pickerGroupId || attachMutation.isPending}
-                >
-                  Attach
-                </Button>
-              </form>
-            ) : null
-          }
-        />
-
-        <SettingsRowGroup>
-          {grantsQuery.isLoading ? (
-            <>
-              <SettingsRowSkeleton />
-              <SettingsRowSkeleton />
-            </>
-          ) : grants.length === 0 ? (
-            <SettingsEmptyRow
-              label="No groups yet"
-              description={
-                canManage && groups.length === 0 ? (
-                  <>
-                    {/* Was an <a> to `/accounts/{id}` — the page the settings
-                        panel replaced. Groups now live in this same panel, so
-                        this switches tabs instead of navigating away: no
-                        reload, and the panel stays open where the user already
-                        is. `/settings/groups` remains a real URL for anyone
-                        linking in from outside. */}
-                    Create one in{' '}
-                    <button
-                      type="button"
-                      onClick={() => navigate('groups')}
-                      className="hover:text-foreground cursor-pointer underline underline-offset-2"
-                    >
-                      Groups
-                    </button>
-                    .
-                  </>
-                ) : canManage && available.length === 0 && groups.length > 0 ? (
-                  'Every group already has access to this project.'
-                ) : (
-                  'Nobody reaches this project through a group.'
-                )
-              }
-            />
-          ) : (
-            grants.map((g: ProjectGroupGrant) => {
-              const busy = pendingGroupIds.has(g.group_id);
-              return (
-                <SettingsRow
-                  key={g.group_id}
-                  label={g.group_name}
-                  description={
-                    <RowMeta>
-                      <span>Attached {formatDate(g.created_at)}</span>
-                      {typeof g.member_count === 'number' && (
-                        <span>
-                          {g.member_count} {g.member_count === 1 ? 'member' : 'members'}
-                        </span>
-                      )}
-                      {typeof g.override_count === 'number' && g.override_count > 0 && (
-                        <span
-                          className="text-kortix-orange"
-                          title={tHardcodedUi.raw(
-                            'autoComponentsProjectsCustomizeSectionsMembersViewJsxAttrTitleAccount2914778b',
-                          )}
-                        >
-                          {g.override_count} of {g.member_count}{' '}
-                          {tHardcodedUi.raw(
-                            'autoComponentsProjectsCustomizeSectionsMembersViewJsxTextGetManagera88e6fc4',
-                          )}
-                        </span>
-                      )}
-                      {groupsWithCustomRole.has(g.group_id) && (
-                        <span
-                          className="text-kortix-orange font-medium"
-                          title="This group also has a custom role assigned on this project. Built-in role grants WIN over custom roles (allow-only / highest-wins), so this grant overrides the custom role's limits. Detach it to let the custom role apply."
-                        >
-                          ⚠ overrides an assigned custom role
-                        </span>
-                      )}
-                    </RowMeta>
-                  }
-                >
-                  {busy ? (
-                    <Loading className="text-muted-foreground shrink-0" />
-                  ) : canManage ? (
-                    <>
-                      <Select
-                        value={g.role}
-                        onValueChange={(v) =>
-                          updateMutation.mutate({ groupId: g.group_id, role: v as ProjectRole })
-                        }
-                      >
-                        <SelectTrigger className="h-8 w-28 text-xs">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <ProjectRoleSelectItem role="member" />
-                          <ProjectRoleSelectItem role="editor" />
-                          <ProjectRoleSelectItem role="manager" />
-                        </SelectContent>
-                      </Select>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => setDetachTarget(g)}
-                      >
-                        Detach
-                      </Button>
-                    </>
-                  ) : (
-                    <Badge variant="outline" size="sm" className="capitalize">
-                      {g.role}
-                    </Badge>
-                  )}
-                </SettingsRow>
-              );
-            })
-          )}
-        </SettingsRowGroup>
-      </section>
-
-      <ConfirmDialog
-        open={detachTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) setDetachTarget(null);
-        }}
-        title={tHardcodedUi.raw(
-          'autoComponentsProjectsCustomizeSectionsMembersViewJsxAttrTitleDetach8e4cbc87',
-        )}
-        description={
-          detachTarget ? (
-            <span>
-              <strong>{detachTarget.group_name}</strong>{' '}
-              {tHardcodedUi.raw(
-                'autoComponentsProjectsCustomizeSectionsMembersViewJsxTextWillNob7c4fd05',
-              )}
-              <strong>{detachTarget.role}</strong>{' '}
-              {tHardcodedUi.raw(
-                'autoComponentsProjectsCustomizeSectionsMembersViewJsxTextAccessUnless520e90ca',
-              )}
-            </span>
-          ) : null
-        }
-        confirmLabel={tHardcodedUi.raw(
-          'autoComponentsProjectsCustomizeSectionsMembersViewJsxAttrConfirmLabelDetache64492d2',
-        )}
-        confirmVariant="destructive"
-        isPending={detachMutation.isPending}
-        onConfirm={() => {
-          if (!detachTarget) return;
-          const target = detachTarget;
-          setDetachTarget(null);
-          detachMutation.mutate(target.group_id);
-        }}
-      />
-    </>
   );
 }
 
@@ -3378,514 +2981,3 @@ function ResourceAccessCard({
   );
 }
 
-/**
- * Custom-role assignments for THIS project — the project-level view of the
- * account Roles page's bindings. Custom roles are DEFINED on the account Roles
- * page; here a manager grants one (to a member / group / agent) scoped to
- * this project, so a project's full access picture lives in one place.
- */
-function ProjectRoleAssignmentsCard({
-  projectId,
-  accountId,
-  canManage,
-  members,
-}: {
-  projectId: string;
-  accountId: string;
-  canManage: boolean;
-  members: ProjectAccessMember[];
-}) {
-  // Same reason as ProjectGroupGrantsCard: Roles is a tab in this panel.
-  const { navigate } = useSettingsNav();
-  const queryClient = useQueryClient();
-  // qk.project.policies — the IAM role-policy family. See
-  // ProjectGroupGrantsCard's policiesQuery above for why this is NOT
-  // qk.project.executorPolicies (a different endpoint/shape both used to
-  // share the literal ['project-policies', id] with, pre-migration).
-  const policiesKey = qk.project.policies(projectId);
-
-  const policiesQuery = useQuery({
-    queryKey: policiesKey,
-    // Gated like every sibling below: the account-IAM policies route asserts
-    // policy.read, which a non-manager doesn't hold — firing it anyway just
-    // 403s for data this card can never show them.
-    enabled: canManage,
-    queryFn: () => listPolicies(accountId, { scopeId: projectId }),
-    ...contract('config'),
-  });
-  const rolesQuery = useQuery({
-    queryKey: ['iam-roles', accountId],
-    queryFn: () => listRoles(accountId),
-    enabled: canManage,
-    staleTime: 60_000,
-  });
-  const groupsQuery = useQuery({
-    queryKey: ['account-groups', accountId],
-    queryFn: () => listGroups(accountId),
-    enabled: canManage,
-    staleTime: 60_000,
-  });
-  const agentsQuery = useQuery({
-    queryKey: ['iam-agent-identities', accountId],
-    queryFn: () => listAgentIdentities(accountId),
-    enabled: canManage,
-    staleTime: 60_000,
-  });
-
-  // Only project-scoped bindings for THIS project (account-wide custom roles
-  // apply too, but they're managed on the account page, not per-project).
-  const policies = useMemo(
-    () =>
-      toArray(policiesQuery.data).filter(
-        (p) => p.scope_type === 'project' && p.scope_id === projectId,
-      ),
-    [policiesQuery.data, projectId],
-  );
-  const customRoles = useMemo(
-    () => toArray(rolesQuery.data).filter((r) => !r.is_system),
-    [rolesQuery.data],
-  );
-  const groups = useMemo(() => toArray(groupsQuery.data), [groupsQuery.data]);
-  const projectAgents = useMemo(
-    () => toArray(agentsQuery.data).filter((a) => a.project_id === projectId),
-    [agentsQuery.data, projectId],
-  );
-
-  const roleNameById = useMemo(
-    () => new Map(toArray(rolesQuery.data).map((r) => [r.role_id, r.name])),
-    [rolesQuery.data],
-  );
-  const memberLabelById = useMemo(
-    () => new Map(members.map((m) => [m.user_id, userLabel(m)])),
-    [members],
-  );
-  const groupNameById = useMemo(() => new Map(groups.map((g) => [g.group_id, g.name])), [groups]);
-  const agentLabelById = useMemo(
-    () =>
-      new Map(toArray(agentsQuery.data).map((a) => [a.service_account_id, a.agent_name ?? a.name])),
-    [agentsQuery.data],
-  );
-
-  function principalLabel(p: IamPolicy): { kind: string; label: string; missing: boolean } {
-    if (p.principal_type === 'group') {
-      return {
-        kind: 'Group',
-        label: groupNameById.get(p.principal_id) ?? p.principal_id,
-        missing: false,
-      };
-    }
-    if (p.principal_type === 'token') {
-      // Agent SAs resolve from the account-wide identity list; a miss means the
-      // agent was deleted/renamed, so the binding is stale. Show a short id and
-      // flag it rather than a bare 36-char UUID.
-      const name = agentLabelById.get(p.principal_id);
-      return { kind: 'Agent', label: name ?? `${p.principal_id.slice(0, 8)}…`, missing: !name };
-    }
-    return {
-      kind: 'Member',
-      label: memberLabelById.get(p.principal_id) ?? p.principal_id,
-      missing: false,
-    };
-  }
-
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [subjectType, setSubjectType] = useState<PrincipalType | ''>(''); // step 1
-  // Step 2, multi-select — bind the same role to several members/groups/agents
-  // of the chosen type in one action, instead of one binding per dialog open.
-  const [subjectIds, setSubjectIds] = useState<string[]>([]);
-  const [roleId, setRoleId] = useState('');
-  const [policyFilter, setPolicyFilter] = useState<'all' | PrincipalType>('all');
-  const [pendingIds, setPendingIds] = useState<Set<string>>(() => new Set());
-  const markPending = (id: string) => setPendingIds((prev) => new Set(prev).add(id));
-  const clearPending = (id: string) =>
-    setPendingIds((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
-
-  function invalidate() {
-    queryClient.invalidateQueries({ queryKey: policiesKey });
-  }
-
-  // Step 1 of the assign flow: pick the SUBJECT type. Only offer types that
-  // have someone to assign (no empty "Agent" list when the project has none).
-  const subjectOptions = useMemo(
-    () =>
-      (
-        [
-          {
-            type: 'member',
-            label: 'Member',
-            Icon: User,
-            items: members.map((m) => ({ id: m.user_id, name: userLabel(m) })),
-          },
-          {
-            type: 'group',
-            label: 'Group',
-            Icon: Users,
-            items: groups.map((g) => ({ id: g.group_id, name: g.name })),
-          },
-          {
-            type: 'token',
-            label: 'Agent',
-            Icon: Bot,
-            items: projectAgents.map((a) => ({
-              id: a.service_account_id,
-              name: a.agent_name ?? a.name,
-            })),
-          },
-        ] as const
-      ).filter((o) => o.items.length > 0),
-    [members, groups, projectAgents],
-  );
-  // Step 2 options: only the subjects of the chosen type.
-  const activeSubjects = subjectOptions.find((o) => o.type === subjectType)?.items ?? [];
-
-  function resetAssignForm() {
-    setSubjectType('');
-    setSubjectIds([]);
-    setRoleId('');
-  }
-  function onSubjectTypeChange(t: PrincipalType) {
-    setSubjectType(t);
-    setSubjectIds([]); // the previous picks belong to a different subject type
-  }
-  function toggleSubject(id: string) {
-    setSubjectIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
-  }
-
-  const createMutation = useMutation({
-    mutationFn: async () => {
-      const results = await Promise.allSettled(
-        subjectIds.map((principalId) =>
-          createPolicy(accountId, {
-            principalType: subjectType as PrincipalType,
-            principalId,
-            scopeType: 'project',
-            scopeId: projectId,
-            roleId,
-          }),
-        ),
-      );
-      const failed = results.filter((r) => r.status === 'rejected') as PromiseRejectedResult[];
-      return { total: subjectIds.length, failed };
-    },
-    onSuccess: ({ total, failed }) => {
-      const ok = total - failed.length;
-      if (failed.length === 0) {
-        successToast(total === 1 ? 'Role assigned' : `Role assigned to ${total}`);
-        resetAssignForm();
-        setDialogOpen(false);
-      } else if (ok > 0) {
-        errorToast(
-          `Assigned to ${ok} of ${total} — ${failed.length} failed. Remove the assigned ones and retry the rest.`,
-        );
-      } else {
-        errorToast(
-          failed[0]?.reason instanceof Error ? failed[0].reason.message : 'Failed to assign role',
-        );
-      }
-      invalidate();
-    },
-    onError: (err: Error) => errorToast(err.message || 'Failed to assign role'),
-  });
-
-  function onDialogOpenChange(next: boolean) {
-    if (createMutation.isPending) return;
-    if (next) {
-      resetAssignForm();
-      setSubjectType(subjectOptions[0]?.type ?? '');
-    }
-    setDialogOpen(next);
-  }
-
-  const removeMutation = useMutation({
-    mutationFn: (policyId: string) => deletePolicy(accountId, policyId),
-    onMutate: (policyId) => markPending(policyId),
-    onSettled: (_d, _e, policyId) => clearPending(policyId),
-    onSuccess: () => {
-      successToast('Assignment removed');
-      invalidate();
-    },
-    onError: (err: Error) => errorToast(err.message || 'Failed to remove assignment'),
-  });
-
-  // List filter (below): segment a long mixed binding list by subject type.
-  const policyCounts = useMemo(() => {
-    const c: Record<string, number> = { member: 0, group: 0, token: 0 };
-    for (const p of policies) c[p.principal_type] = (c[p.principal_type] ?? 0) + 1;
-    return c;
-  }, [policies]);
-  const policyFilterOptions = useMemo(() => {
-    const opts: { value: 'all' | PrincipalType; label: string; count: number }[] = [
-      { value: 'all', label: 'All', count: policies.length },
-    ];
-    if (policyCounts.member)
-      opts.push({ value: 'member', label: 'Members', count: policyCounts.member });
-    if (policyCounts.group)
-      opts.push({ value: 'group', label: 'Groups', count: policyCounts.group });
-    if (policyCounts.token)
-      opts.push({ value: 'token', label: 'Agents', count: policyCounts.token });
-    return opts;
-  }, [policies.length, policyCounts]);
-  const visiblePolicies = useMemo(
-    () =>
-      policyFilter === 'all' ? policies : policies.filter((p) => p.principal_type === policyFilter),
-    [policies, policyFilter],
-  );
-
-  const canSubmit =
-    !!subjectType && subjectIds.length > 0 && !!roleId && !createMutation.isPending;
-
-  // Progressive disclosure — see ProjectGroupGrantsCard's identical comment.
-  // Custom roles are defined on the account Roles page; an account that has
-  // never made one gets a permanently-empty "go create one elsewhere" card
-  // here. Hide it once loaded with nothing to show; keep it if there is an
-  // existing project-scoped binding to manage/remove, even one whose role
-  // was since deleted.
-  const rolesLoaded = !policiesQuery.isLoading && !rolesQuery.isLoading;
-  if (rolesLoaded && customRoles.length === 0 && policies.length === 0) return null;
-
-  return (
-    <>
-      <section className="space-y-3">
-        <SettingsSubsectionHeader
-          title={
-            <>
-              Custom roles
-              {policies.length > 0 ? (
-                <span className="text-muted-foreground ml-1.5 font-normal tabular-nums">
-                  {policies.length}
-                </span>
-              ) : null}
-            </>
-          }
-          description="Grant a custom role to a member, group, or agent on this project. Custom roles are defined on the account Roles page; here you bind them for this project only."
-          action={
-            canManage && customRoles.length > 0 ? (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="shrink-0 gap-1.5"
-                onClick={() => onDialogOpenChange(true)}
-              >
-                <Plus className="size-3.5 shrink-0" />
-                Assign role
-              </Button>
-            ) : null
-          }
-        />
-
-        {!policiesQuery.isLoading && policies.length > 0 && policyFilterOptions.length > 2 && (
-          <FilterChips
-            value={policyFilter}
-            onChange={setPolicyFilter}
-            options={policyFilterOptions}
-          />
-        )}
-
-        <SettingsRowGroup>
-          {policiesQuery.isLoading ? (
-            <SettingsRowSkeleton />
-          ) : policies.length === 0 ? (
-            <SettingsEmptyRow
-              label="No custom roles here"
-              description={
-                customRoles.length === 0 ? (
-                  <>
-                    {/* Same replacement as the Groups link above: `/accounts/{id}
-                        ?tab=roles` is the page this panel replaced, and Roles is
-                        a tab in this very panel. */}
-                    Create one in{' '}
-                    <button
-                      type="button"
-                      onClick={() => navigate('roles')}
-                      className="hover:text-foreground cursor-pointer underline underline-offset-2"
-                    >
-                      Roles
-                    </button>
-                    , then apply it here.
-                  </>
-                ) : (
-                  'Assign one to give a member, group, or agent a custom role on this project.'
-                )
-              }
-            />
-          ) : (
-            visiblePolicies.map((p) => {
-              const busy = pendingIds.has(p.policy_id);
-              const { kind, label, missing } = principalLabel(p);
-              return (
-                <SettingsRow
-                  key={p.policy_id}
-                  label={
-                    <>
-                      <span className="min-w-0">{roleNameById.get(p.role_id) ?? p.role_id}</span>
-                      <Badge variant="outline" size="sm">
-                        Custom
-                      </Badge>
-                    </>
-                  }
-                  description={
-                    <RowMeta>
-                      <span className="flex items-center gap-1.5">
-                        {kind}: {label}
-                        {missing && (
-                          <Badge
-                            variant="outline"
-                            size="sm"
-                            className="border-kortix-orange/30 text-kortix-orange"
-                            title="This agent no longer exists (deleted or renamed). The binding is stale — remove it or re-assign the current agent."
-                          >
-                            removed
-                          </Badge>
-                        )}
-                      </span>
-                      {p.expires_at ? <span>Expires {formatDate(p.expires_at)}</span> : null}
-                    </RowMeta>
-                  }
-                >
-                  {busy ? (
-                    <Loading className="text-muted-foreground shrink-0" />
-                  ) : canManage ? (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => removeMutation.mutate(p.policy_id)}
-                    >
-                      Remove
-                    </Button>
-                  ) : (
-                    <Badge variant="outline" size="sm" className="capitalize">
-                      {kind}
-                    </Badge>
-                  )}
-                </SettingsRow>
-              );
-            })
-          )}
-        </SettingsRowGroup>
-      </section>
-
-      <Modal open={dialogOpen} onOpenChange={onDialogOpenChange}>
-        <ModalContent className="sm:max-w-md">
-          <ModalHeader>
-            <ModalTitle>Assign a custom role</ModalTitle>
-            <ModalDescription>
-              Bind a custom role to a member, group, or agent on this project only.
-            </ModalDescription>
-          </ModalHeader>
-
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              if (!canSubmit) return;
-              createMutation.mutate();
-            }}
-          >
-            <ModalBody className="space-y-4">
-              <div className="space-y-1.5">
-                <span className="text-muted-foreground text-xs font-medium">1. Assign to</span>
-                <div className="flex gap-1.5">
-                  {subjectOptions.map(({ type, label, Icon }) => (
-                    <Button
-                      key={type}
-                      type="button"
-                      size="sm"
-                      variant={subjectType === type ? 'default' : 'outline'}
-                      className="flex-1 gap-1.5"
-                      onClick={() => onSubjectTypeChange(type)}
-                    >
-                      <Icon className="size-3.5 shrink-0" />
-                      {label}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-
-              <div className="space-y-1.5">
-                <span className="text-muted-foreground text-xs font-medium">
-                  2.{' '}
-                  {subjectType === 'group'
-                    ? 'Groups'
-                    : subjectType === 'token'
-                      ? 'Agents'
-                      : 'Members'}
-                  {subjectIds.length > 0 ? (
-                    <span className="ml-1 tabular-nums">({subjectIds.length})</span>
-                  ) : null}
-                </span>
-                {/* Multi-select: bind the same role to several subjects of this
-                    type in one action. `activeSubjects` is already
-                    type-filtered by step 1, so this is a plain checklist —
-                    no search needed for a project's own member/group/agent
-                    count. */}
-                {subjectType ? (
-                  <div className="border-border max-h-56 overflow-y-auto rounded-md border p-1">
-                    {activeSubjects.length === 0 ? (
-                      <p className="text-muted-foreground px-3 py-6 text-center text-xs">
-                        None available.
-                      </p>
-                    ) : (
-                      activeSubjects.map((s) => (
-                        <Checkbox
-                          key={s.id}
-                          label={s.name}
-                          checked={subjectIds.includes(s.id)}
-                          onCheckedChange={() => toggleSubject(s.id)}
-                          disabled={createMutation.isPending}
-                        />
-                      ))
-                    )}
-                  </div>
-                ) : (
-                  <p className="text-muted-foreground border-border rounded-md border border-dashed px-3 py-6 text-center text-xs">
-                    Pick a type first.
-                  </p>
-                )}
-              </div>
-
-              <div className="space-y-1.5">
-                <span className="text-muted-foreground text-xs font-medium">3. Custom role</span>
-                <Select
-                  value={roleId}
-                  onValueChange={setRoleId}
-                  disabled={createMutation.isPending}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select a role" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {customRoles.map((r) => (
-                      <SelectItem key={r.role_id} value={r.role_id}>
-                        {r.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </ModalBody>
-
-            <ModalFooter className="sm:justify-between">
-              <Button
-                type="button"
-                variant="outline-ghost"
-                size="sm"
-                onClick={() => onDialogOpenChange(false)}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" size="sm" disabled={!canSubmit}>
-                {createMutation.isPending ? <Loading className="size-4 shrink-0" /> : null}
-                {subjectIds.length > 1 ? `Assign role to ${subjectIds.length}` : 'Assign role'}
-              </Button>
-            </ModalFooter>
-          </form>
-        </ModalContent>
-      </Modal>
-    </>
-  );
-}

--- a/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
@@ -2008,7 +2008,7 @@ function MembersTabInner({
       }}
       isRemovePending={removeMutation.isPending}
       onOpenInvite={() => setInviteOpen(true)}
-      permissionsHelpSlot={<PermissionsHelpPopover align="end" />}
+      permissionsHelpSlot={<PermissionsHelpPopover align="end" accountId={accountId} />}
       pendingInvites={pendingInvitesQuery.data?.pending ?? []}
       isPendingInvitesLoading={canManageMembers && pendingInvitesQuery.isLoading}
       pendingInviteBusyIds={pendingInviteBusyIds}

--- a/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/members-tab.tsx
@@ -14,8 +14,11 @@
  * and `effective_source`. This tab renders that one response as one table:
  * an "Account role" column (`member.account_role`, read-only — account
  * roles are an account-settings concern, not a project one) and a
- * "Workspace access" column (`memberAccessLabel(member)`, see
- * `member-access-label.ts`). Unlike the old `ProjectAccessCard`
+ * "Project role" column (`memberAccessLabel(member)`, see
+ * `member-access-label.ts` — was "Workspace access", which named a
+ * different concept, "access", than the value it showed, a role name or
+ * "No access"; both columns now read as the same kind of thing at two
+ * scopes). Unlike the old `ProjectAccessCard`
  * (`members-view.tsx`), which filtered to
  * `has_implicit_access || effective_project_role != null` and hid every
  * account member with zero project access, this table renders every row
@@ -28,7 +31,7 @@
  * `member.invite`/`member.update`/`member.remove` and workspace writes on
  * `project.member.write`". Checked directly against
  * `apps/api/src/projects/routes/r6.ts`: EVERY mutation this table's
- * **workspace-access column** (or the project-scoped sections below it) can
+ * **project-role column** (or the project-scoped sections below it) can
  * trigger — invite (`:673`), list/revoke/resend a pending invite (`:851`,
  * `:941`, `:1012`), list/approve/reject an access request (`:491`, `:533`),
  * and update/revoke a member's own access (`:1096`, `:1169`) — asserts the
@@ -201,7 +204,7 @@
  * task adds the first other caller.
  *
  * These three are a THIRD axis, distinct from both `project.members.manage`
- * (workspace-access column above) and `member.invite`-for-invites
+ * (project-role column above) and `member.invite`-for-invites
  * (`canManageAccountInvites`, JAY-548): they mutate the ACCOUNT roster
  * itself — who is a member of this account at all, and at what account
  * role. Gates are copied byte-for-byte from `page.tsx`'s
@@ -324,7 +327,7 @@
  *    absent `joined_at` reads as an em dash rather than `formatDate`'s
  *    "Never", which is nonsense for a join date.
  * 3. The trailing actions column is gone: the workspace-access `Select` now
- *    sits in the workspace-access column it edits. Nothing is lost —
+ *    sits in the project-role column it edits. Nothing is lost —
  *    `memberAccessLabel` only returns a `via` annotation for implicit or
  *    group-sourced access, and `editable` excludes both.
  * 4. The read-only account role is tonal text, not a filled `Badge` — an
@@ -698,7 +701,7 @@ export interface MembersTabViewProps {
   canRemoveFromAccount?: boolean;
   /** user_id set — rows currently mid account-role-change or
    *  account-removal. Separate from `pendingUserIds` above (that Set is for
-   *  the workspace-access column's own mutations) so an account-scope
+   *  the project-role column's own mutations) so an account-scope
    *  mutation never shows a misleading "workspace access is changing"
    *  spinner. */
   accountPendingUserIds?: Set<string>;
@@ -941,8 +944,28 @@ export function MembersTabView({
               <TableHeader>
                 <TableRow className="hover:bg-transparent">
                   <TableHead>Member</TableHead>
-                  <TableHead>Account role</TableHead>
-                  <TableHead>Workspace access</TableHead>
+                  {/* SCOPE is the word that answers the actual question here
+                      — "does changing this reach every workspace, or just
+                      the one I'm looking at?" — so scope leads, "role" is
+                      the secondary line. "Account role" / "Project role"
+                      read as two labels for the same kind of thing; on a
+                      PROJECT-scoped page (this whole pane lives under one
+                      project's Customize bar) that reads as two flavors of
+                      "this project's roles" when one of them is actually
+                      account-wide and edits the person everywhere, not just
+                      here. See this file's header comment. */}
+                  <TableHead>
+                    <span className="text-foreground block">Account</span>
+                    <span className="text-muted-foreground/70 block text-[11px] font-normal">
+                      every workspace
+                    </span>
+                  </TableHead>
+                  <TableHead>
+                    <span className="text-foreground block">This project</span>
+                    <span className="text-muted-foreground/70 block text-[11px] font-normal">
+                      only here
+                    </span>
+                  </TableHead>
                   <TableHead className="text-right">Joined</TableHead>
                 </TableRow>
               </TableHeader>
@@ -1038,7 +1061,7 @@ export function MembersTabView({
                         </div>
                       </TableCell>
                       {/* One column, one fact: the workspace-access control
-                            lives in the workspace-access column it edits. No
+                            lives in the project-role column it edits. No
                             annotation is lost — `memberAccessLabel` only
                             returns a `via` for implicit or group-sourced
                             access, and `editable` excludes both. */}
@@ -1055,7 +1078,7 @@ export function MembersTabView({
                             >
                               <SelectTrigger
                                 className="h-7 w-32 text-xs"
-                                aria-label={`Workspace access for ${userLabel(member)}`}
+                                aria-label={`Project role for ${userLabel(member)}`}
                               >
                                 <SelectValue />
                               </SelectTrigger>
@@ -1949,7 +1972,7 @@ function MembersTabInner({
   const { allowed: canRemoveFromAccount } = usePermission(accountId, 'member.remove');
 
   // Separate busy-set from `pendingUserIds` above — that one belongs to the
-  // workspace-access column's own mutations. Sharing it would show a
+  // project-role column's own mutations. Sharing it would show a
   // misleading "workspace access is changing" spinner during an
   // account-scope mutation.
   const [accountPendingUserIds, setAccountPendingUserIds] = useState<Set<string>>(() => new Set());

--- a/tests/e2e/specs/08-accounts-project-access.spec.ts
+++ b/tests/e2e/specs/08-accounts-project-access.spec.ts
@@ -544,12 +544,16 @@ test.describe("08 — Accounts, invites, and project access", () => {
         response.request().method() === "POST",
     );
     await page.getByRole("button", { name: "Invite", exact: true }).click();
+    // Title renamed "Invite members" -> "Invite to account" (page.tsx's
+    // InviteMemberModal) — the account page's own invite composer, kept
+    // distinct from InviteMemberDialog's "Invite a member" above, which is
+    // the project-scoped one.
     await expect(
-      page.getByRole("dialog", { name: "Invite members" }),
+      page.getByRole("dialog", { name: "Invite to account" }),
     ).toBeVisible();
     await page.getByLabel("Emails").fill(uiInvitedEmail);
     await page
-      .getByRole("dialog", { name: "Invite members" })
+      .getByRole("dialog", { name: "Invite to account" })
       .getByRole("button", { name: "Invite", exact: true })
       .click();
     expect((await uiInviteResponse).status()).toBe(201);

--- a/tests/e2e/specs/08-accounts-project-access.spec.ts
+++ b/tests/e2e/specs/08-accounts-project-access.spec.ts
@@ -635,7 +635,7 @@ test.describe("08 — Accounts, invites, and project access", () => {
       .filter({ hasText: memberEmail })
       .first();
     await expect(memberAccessRow).toBeVisible({ timeout: 15_000 });
-    // Third column = "Workspace access" (`members-tab.tsx:930-934`). Pinned by
+    // Third column = "Project role" (`members-tab.tsx:930-934`). Pinned by
     // column because that select carries no accessible name of its own, and
     // the row's other combobox is the account-role one beside it.
     await expect(


### PR DESCRIPTION
## Summary
Three rounds on the project Access tab / IAM system, driven by a live user thread plus a 4-agent parallel audit of the whole RBAC surface (account members/roles, project members/roles, resource access, and customize read/write gating).

1. **Removed** (not hidden) `ProjectGroupGrantsCard` and `ProjectRoleAssignmentsCard` from the project Access tab. Both duplicated a proper account-level home: a group's own detail page's "Projects" tab, and the account Roles page's `PolicyAssignments` (which can target any project, not just one). The Access tab now shows exactly one thing: agent assignment — the only real project-scoped resource concern.
2. **Custom roles made legible, not just editable**: the permissions-help popover now explains Custom roles and links to the account Roles page; every role row (built-in included) gets a "Capabilities" column with a real count and a read-only "View" mode — no one needs edit permission just to see what a role grants.
3. **The highest-impact fix**: the sidebar Customize row was gated on `project.customize.write`. `project.customize.read` already exists, is already baseline-granted to every plain Member, and a read-only Customize experience already worked end to end (direct URL navigation, no 403). The row was the only thing that didn't respect it — every plain Member on every project had no way to discover a feature they already had. Fixed to gate on `.read`; `.write` still gates every individual mutation everywhere it always did.
4. Smaller: multi-group access (`via <group>`) now counts additional groups instead of silently dropping them; the inherited-role lock tooltip no longer lies about which group to edit when more than one applies.

## Test plan
- `npx tsc --noEmit` clean (15 pre-existing known errors only) at every step
- `eslint` clean on every touched file (2 pre-existing unrelated warnings, unchanged)
- Full `apps/web/src/features/workspace` (+`src/components/iam`) suite: 1975/1975 pass
- Live-verified in Chromium: created a fresh account + project + a user granted only an explicit project "member" role (`effective_project_role: "member"`, `has_implicit_access: false` — confirmed via the API), signed in as them, and confirmed via direct DOM query that the Customize sidebar link now renders (`href=/projects/<id>/customize`) — before the fix this role made `ProjectCustomizeNavItem` return `null` entirely. Also live-verified the permissions popover's new Custom-roles link navigates correctly, and that a non-RBAC-entitled account correctly sees the Enterprise upsell on the Roles page (not a bug — rbac is entitlement-gated).