### PR TITLE
fix(connectors): authenticate MCP catalog discovery

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,21 @@ linked, not inlined.
 
 ## Register
 
+### Catalog discovery must use execution credentials and fail on upstream errors (2026-08-18)
+
+**When:** materializing a remote connector catalog, especially MCP
+`tools/list`. Resolve the same effective connection credential and static
+headers used by tool execution, including OAuth refresh. Reject non-2xx,
+protocol-error, and malformed responses; persist a safe error instead of an
+apparently healthy empty catalog. Re-run discovery after credentials change,
+and never include raw or encoded credential material in diagnostics.
+*Incident:* Essentia Dev Sage Intacct authenticated successfully and exposed
+four MCP tools, while Kortix sent no credential, parsed an empty HTTP 401 body,
+and materialized zero actions without an error.
+*Enforcer:* `sync-mcp.test.ts`, `unit-connector-call.test.ts`, and
+`oauth2.test.ts` cover authenticated discovery, refresh/rematerialization,
+HTTP/JSON-RPC failures, and credential redaction.
+
 ### A reused speculative resource needs a consumption signal every holder can see (2026-08-17)
 
 **When:** caching a server-side find-or-create resource client-side (the warm

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### A shared connector catalog needs one canonical credential scope (2026-08-18)
+
+**When:** rematerializing a credential-dependent connector catalog. Only the
+project-default credential may write project-wide `connectorActions`. Never use
+a member-owned or non-default connection credential. Store catalogs per
+connection before supporting credential-specific action sets.
+*Incident:* Strix found that PR #6507 let a member MCP credential overwrite the
+shared project catalog and expose tenant-specific tool metadata before merge.
+*Enforcer:* `sync-mcp.test.ts` rejects member and non-default rematerialization.
+
 ### Catalog discovery must use execution credentials and fail on upstream errors (2026-08-18)
 
 **When:** materializing a remote connector catalog, especially MCP

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,6 +42,7 @@
     "hono": "^4.4.0",
     "jose": "^5.9.6",
     "livekit-server-sdk": "^2.17.0",
+    "oauth4webapi": "^3.8.7",
     "postgres": "^3.4.8",
     "re2js": "2.8.6",
     "smol-toml": "^1.6.1",

--- a/apps/api/src/__tests__/unit-connector-call.test.ts
+++ b/apps/api/src/__tests__/unit-connector-call.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   executeCall,
+  listMcpTools,
   oauth1Header,
   oauth1Signature,
   paramHintsFromSchema,
@@ -300,6 +301,132 @@ describe('MCP execution request shape', () => {
       method: 'tools/call',
       params: { name: 'search', arguments: { q: 'a' } },
     });
+  });
+
+  test('lists tools with the connector credential and static headers', async () => {
+    const { fetchImpl, calls } = recordingFetch(
+      200,
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          tools: [{ name: 'queryRecords', inputSchema: { type: 'object' } }],
+        },
+      }),
+    );
+    const tools = await listMcpTools({
+      url: 'https://mcp.example.com/mcp',
+      auth: BEARER,
+      secret: 'access-token',
+      headers: { 'X-Tenant': 'sandbox' },
+      fetchImpl,
+    });
+
+    expect(calls[0]!.headers.Authorization).toBe('Bearer access-token');
+    expect(calls[0]!.headers['X-Tenant']).toBe('sandbox');
+    expect(JSON.parse(calls[0]!.body!)).toMatchObject({
+      method: 'tools/list',
+      params: {},
+    });
+    expect(tools.map((tool) => tool.name)).toEqual(['queryRecords']);
+  });
+
+  test('rejects an MCP catalog HTTP error instead of materializing zero tools', async () => {
+    const { fetchImpl } = recordingFetch(401, '');
+    await expect(
+      listMcpTools({
+        url: 'https://mcp.example.com/mcp',
+        auth: BEARER,
+        secret: 'expired-token',
+        fetchImpl,
+      }),
+    ).rejects.toThrow('MCP tools/list failed: HTTP 401');
+  });
+
+  test('rejects a JSON-RPC error instead of materializing zero tools', async () => {
+    const { fetchImpl } = recordingFetch(
+      200,
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32001, message: 'Unauthorized' },
+      }),
+    );
+    await expect(listMcpTools({ url: 'https://mcp.example.com/mcp', fetchImpl })).rejects.toThrow(
+      'MCP tools/list failed: JSON-RPC -32001 Unauthorized',
+    );
+  });
+
+  test('redacts the connector credential if an MCP JSON-RPC error echoes it', async () => {
+    const { fetchImpl } = recordingFetch(
+      200,
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        error: {
+          code: -32001,
+          message: 'credential access-token-123 is invalid',
+        },
+      }),
+    );
+    let message = '';
+    try {
+      await listMcpTools({
+        url: 'https://mcp.example.com/mcp',
+        auth: BEARER,
+        secret: 'access-token-123',
+        fetchImpl,
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('credential [REDACTED] is invalid');
+    expect(message).not.toContain('access-token-123');
+  });
+
+  test('does not expose a query credential from an MCP transport error', async () => {
+    const secret = 'query-secret-123';
+    let message = '';
+    try {
+      await listMcpTools({
+        url: 'https://mcp.example.com/mcp',
+        auth: { type: 'custom', in: 'query', name: 'api_key', prefix: null },
+        secret,
+        fetchImpl: async (url) => {
+          throw new Error(`connect failed for ${url}`);
+        },
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toBe('MCP tools/list failed: transport error');
+    expect(message).not.toContain(secret);
+  });
+
+  test('redacts a form-encoded query credential from an MCP JSON-RPC error', async () => {
+    const secret = 'query secret+123';
+    const encoded = new URLSearchParams({ api_key: secret }).toString();
+    const { fetchImpl } = recordingFetch(
+      200,
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32001, message: `request failed: ?${encoded}` },
+      }),
+    );
+    let message = '';
+    try {
+      await listMcpTools({
+        url: 'https://mcp.example.com/mcp',
+        auth: { type: 'custom', in: 'query', name: 'api_key', prefix: null },
+        secret,
+        fetchImpl,
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('api_key=[REDACTED]');
+    expect(message).not.toContain('query+secret%2B123');
   });
 });
 

--- a/apps/api/src/connectors/call.ts
+++ b/apps/api/src/connectors/call.ts
@@ -583,15 +583,15 @@ function buildGraphqlRequest(opts: {
   return { url, method: 'POST', headers, body: JSON.stringify({ query }) };
 }
 
-/** Build a JSON-RPC `tools/call` request for an MCP (http transport) connector. */
-function buildMcpRequest(opts: {
+/** Build one JSON-RPC request for an MCP streamable-HTTP connector. */
+function buildMcpJsonRpcRequest(opts: {
   url: string;
   auth?: ConnectorAuth;
   /** Connector-level static headers (kortix.yaml `headers:`). */
   headers?: Record<string, string> | null;
   secret?: string | null;
-  toolName: string;
-  args?: Record<string, unknown>;
+  method: string;
+  params: Record<string, unknown>;
 }): BuiltRequest {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -607,10 +607,29 @@ function buildMcpRequest(opts: {
   const body = JSON.stringify({
     jsonrpc: '2.0',
     id: 1,
+    method: opts.method,
+    params: opts.params,
+  });
+  return { url, method: 'POST', headers, body };
+}
+
+/** Build a JSON-RPC `tools/call` request for an MCP (http transport) connector. */
+function buildMcpRequest(opts: {
+  url: string;
+  auth?: ConnectorAuth;
+  headers?: Record<string, string> | null;
+  secret?: string | null;
+  toolName: string;
+  args?: Record<string, unknown>;
+}): BuiltRequest {
+  return buildMcpJsonRpcRequest({
+    url: opts.url,
+    auth: opts.auth,
+    headers: opts.headers,
+    secret: opts.secret,
     method: 'tools/call',
     params: { name: opts.toolName, arguments: opts.args ?? {} },
   });
-  return { url, method: 'POST', headers, body };
 }
 
 export type FetchImpl = (
@@ -668,6 +687,89 @@ async function performRequest(
   });
   const text = await res.text();
   return { status: res.status, ok: res.ok, data: parseResponseBody(text) };
+}
+
+function redactExactValue(value: string, secret: string | null | undefined): string {
+  if (!secret) return value;
+  const formEncoded = new URLSearchParams({ value: secret }).toString().slice('value='.length);
+  const representations = new Set([
+    secret,
+    encodeURIComponent(secret),
+    formEncoded,
+    Buffer.from(secret).toString('base64'),
+  ]);
+  let redacted = value;
+  for (const representation of representations) {
+    if (representation) redacted = redacted.split(representation).join('[REDACTED]');
+  }
+  return redacted;
+}
+
+function mcpJsonRpcError(data: unknown, secret?: string | null): string | null {
+  if (!data || typeof data !== 'object' || !('error' in data)) return null;
+  const error = (data as { error?: unknown }).error;
+  if (!error || typeof error !== 'object') return 'unknown error';
+  const record = error as { code?: unknown; message?: unknown };
+  const code =
+    typeof record.code === 'number' || typeof record.code === 'string'
+      ? String(record.code)
+      : 'unknown';
+  const message =
+    typeof record.message === 'string'
+      ? redactExactValue(
+          record.message
+            .replace(/[\r\n\t\0-\x1f\x7f]/g, ' ')
+            .trim()
+            .slice(0, 512),
+          secret,
+        )
+      : 'unknown error';
+  return `${code} ${message}`;
+}
+
+/** List an MCP connector's tools through the same auth path used for tool calls. */
+export async function listMcpTools(opts: {
+  url: string;
+  auth?: ConnectorAuth;
+  headers?: Record<string, string> | null;
+  secret?: string | null;
+  now?: () => Date;
+  fetchImpl: FetchImpl;
+}): Promise<any[]> {
+  const auth = opts.auth ?? NO_AUTH;
+  let result: ExecResult;
+  try {
+    result = await performRequest(
+      buildMcpJsonRpcRequest({
+        url: opts.url,
+        auth,
+        headers: opts.headers,
+        secret: opts.secret,
+        method: 'tools/list',
+        params: {},
+      }),
+      opts.fetchImpl,
+      auth,
+      opts.secret ?? null,
+      opts.now ?? (() => new Date()),
+    );
+  } catch {
+    // Fetch implementations commonly include the full URL in thrown errors.
+    // Query-auth credentials are part of that URL, so never persist or return
+    // the raw transport exception from catalog discovery.
+    throw new Error('MCP tools/list failed: transport error');
+  }
+  if (!result.ok) throw new Error(`MCP tools/list failed: HTTP ${result.status}`);
+  const rpcError = mcpJsonRpcError(result.data, opts.secret);
+  if (rpcError) throw new Error(`MCP tools/list failed: JSON-RPC ${rpcError}`);
+  const tools =
+    result.data && typeof result.data === 'object'
+      ? (result.data as { result?: { tools?: unknown } }).result?.tools
+      : null;
+  if (!Array.isArray(tools)) {
+    throw new Error('MCP tools/list failed: response has no result.tools array');
+  }
+  return tools;
 }
 
 /**

--- a/apps/api/src/connectors/manifest-crud.ts
+++ b/apps/api/src/connectors/manifest-crud.ts
@@ -365,6 +365,8 @@ export async function setConnectorCredentialShared(
     projectId,
     accountId: connector.accountId,
     provider: connector.providerType,
+    ownerType: 'project',
+    isDefault: true,
   });
   return { ok: true, ...(sync ? { sync } : {}) };
 }

--- a/apps/api/src/connectors/manifest-crud.ts
+++ b/apps/api/src/connectors/manifest-crud.ts
@@ -34,7 +34,11 @@ import {
 import { db } from '../shared/db';
 import { upsertCredential, upsertOAuth2Credential } from './credentials';
 import { areValidConditions, isValidMatcher } from './policy';
-import { type SyncResult, syncProjectConnectors } from './sync';
+import {
+  rematerializeCatalogAfterCredentialUpdate,
+  type SyncResult,
+  syncProjectConnectors,
+} from './sync';
 import {
   type ManifestMutationResult,
   mutateManifestWithRetry,
@@ -318,6 +322,8 @@ export async function setConnectorCredentialShared(
   const [connector] = await db
     .select({
       connectorId: connectors.connectorId,
+      accountId: connectors.accountId,
+      providerType: connectors.providerType,
       authorizationStrategy: connectors.authorizationStrategy,
       authSecret: connectors.authSecret,
     })
@@ -355,7 +361,12 @@ export async function setConnectorCredentialShared(
       kind: input.kind,
     });
   }
-  return { ok: true };
+  const sync = await rematerializeCatalogAfterCredentialUpdate({
+    projectId,
+    accountId: connector.accountId,
+    provider: connector.providerType,
+  });
+  return { ok: true, ...(sync ? { sync } : {}) };
 }
 
 /**

--- a/apps/api/src/connectors/oauth2.test.ts
+++ b/apps/api/src/connectors/oauth2.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'bun:test';
 import { constants, generateKeyPairSync, verify } from 'node:crypto';
 import {
   acquireOAuth2ClientCredentialsToken,
-  buildPrivateKeyClientAssertion,
   createStoredOAuth2Credential,
   oauth2TokenIsFresh,
   resolveStoredOAuth2Credential,
@@ -10,18 +9,21 @@ import {
 
 const SECRET_CONFIG = {
   type: 'oauth2_client_credentials' as const,
-  token_url: 'https://login.example.com/oauth2/v2.0/token',
+  token_url: 'https://identity.example.com/oauth2/token',
   client_id: 'client-123',
   token_endpoint_auth_method: 'client_secret_post' as const,
   client_secret: 'secret-123',
-  scopes: ['https://graph.example.com/.default'],
-  resource: 'https://sharepoint.example.com',
+  scopes: ['records.read'],
+  resource: 'https://resource.example.com',
   audience: 'https://api.example.com',
+  token_params: { tenant_hint: 'tenant-123' },
 };
 
 describe('OAuth2 client credentials', () => {
   test('posts a client secret and normalizes the token expiry', async () => {
-    const request: { current: { url: string; init: RequestInit } | null } = { current: null };
+    const request: { current: { url: string; init: RequestInit } | null } = {
+      current: null,
+    };
     const token = await acquireOAuth2ClientCredentialsToken(SECRET_CONFIG, {
       now: () => 1_000_000,
       fetchImpl: async (url, init) => {
@@ -45,9 +47,10 @@ describe('OAuth2 client credentials', () => {
         grant_type: 'client_credentials',
         client_id: 'client-123',
         client_secret: 'secret-123',
-        scope: 'https://graph.example.com/.default',
-        resource: 'https://sharepoint.example.com',
+        scope: 'records.read',
+        resource: 'https://resource.example.com',
         audience: 'https://api.example.com',
+        tenant_hint: 'tenant-123',
       }),
     );
     expect(token).toEqual({
@@ -58,26 +61,38 @@ describe('OAuth2 client credentials', () => {
     });
   });
 
-  test('uses HTTP Basic without placing the secret in the form', async () => {
+  test('uses client_secret_basic with form-encoded credentials and no body credential', async () => {
     const request: { current: RequestInit | null } = { current: null };
     await acquireOAuth2ClientCredentialsToken(
-      { ...SECRET_CONFIG, token_endpoint_auth_method: 'client_secret_basic' },
+      {
+        ...SECRET_CONFIG,
+        client_id: 'client id:one',
+        client_secret: 'secret+value two',
+        token_endpoint_auth_method: 'client_secret_basic',
+      },
       {
         fetchImpl: async (_url, init) => {
           request.current = init ?? {};
-          return Response.json({ access_token: 'access-123', expires_in: 3600 });
+          return Response.json({
+            access_token: 'access-123',
+            expires_in: 3600,
+          });
         },
       },
     );
 
     expect(new Headers(request.current?.headers).get('authorization')).toBe(
-      `Basic ${Buffer.from('client-123:secret-123').toString('base64')}`,
+      `Basic ${Buffer.from('client+id%3Aone:secret%2Bvalue+two').toString('base64')}`,
     );
-    expect(new URLSearchParams(String(request.current?.body)).has('client_secret')).toBe(false);
+    const body = new URLSearchParams(String(request.current?.body));
+    expect(body.has('client_id')).toBe(false);
+    expect(body.has('client_secret')).toBe(false);
+    expect(body.get('tenant_hint')).toBe('tenant-123');
   });
 
-  test('supports public clients and client_secret_jwt', async () => {
+  test('uses none for a public client without any client authentication', async () => {
     let publicBody = new URLSearchParams();
+    let publicHeaders = new Headers();
     await acquireOAuth2ClientCredentialsToken(
       {
         ...SECRET_CONFIG,
@@ -87,19 +102,23 @@ describe('OAuth2 client credentials', () => {
       {
         fetchImpl: async (_url, init) => {
           publicBody = new URLSearchParams(String(init?.body));
+          publicHeaders = new Headers(init?.headers);
           return Response.json({ access_token: 'public-access' });
         },
       },
     );
     expect(publicBody.get('client_id')).toBe('client-123');
     expect(publicBody.has('client_secret')).toBe(false);
+    expect(publicBody.has('client_assertion')).toBe(false);
+    expect(publicBody.get('tenant_hint')).toBe('tenant-123');
+    expect(publicHeaders.get('authorization')).toBeNull();
+  });
 
+  test('uses client_secret_jwt with an HS256 assertion and no raw secret', async () => {
     let jwtBody = new URLSearchParams();
     await acquireOAuth2ClientCredentialsToken(
       { ...SECRET_CONFIG, token_endpoint_auth_method: 'client_secret_jwt' },
       {
-        now: () => 1_000_000,
-        randomId: () => 'jwt-id',
         fetchImpl: async (_url, init) => {
           jwtBody = new URLSearchParams(String(init?.body));
           return Response.json({ access_token: 'jwt-access' });
@@ -107,13 +126,35 @@ describe('OAuth2 client credentials', () => {
       },
     );
     expect(jwtBody.has('client_secret')).toBe(false);
+    expect(jwtBody.get('client_id')).toBe('client-123');
+    expect(jwtBody.get('tenant_hint')).toBe('tenant-123');
     expect(jwtBody.get('client_assertion_type')).toContain('jwt-bearer');
-    expect(jwtBody.get('client_assertion')?.split('.')).toHaveLength(3);
+    const assertion = jwtBody.get('client_assertion');
+    if (!assertion) throw new Error('expected client_secret_jwt assertion');
+    const [encodedHeader, encodedPayload] = assertion.split('.');
+    expect(JSON.parse(Buffer.from(encodedHeader, 'base64url').toString())).toEqual({
+      alg: 'HS256',
+      typ: 'JWT',
+    });
+    const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString());
+    expect(payload).toMatchObject({
+      aud: SECRET_CONFIG.token_url,
+      iss: 'client-123',
+      sub: 'client-123',
+    });
+    expect(typeof payload.jti).toBe('string');
+    expect(payload.nbf).toBe(payload.iat);
+    expect(payload.exp - payload.iat).toBe(60);
+    expect(assertion.split('.')).toHaveLength(3);
   });
 
-  test('creates a PS256 private-key client assertion with the certificate thumbprint', async () => {
-    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
-    const assertion = await buildPrivateKeyClientAssertion(
+  test('uses private_key_jwt in an actual token request with no shared secret', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+    });
+    let requestBody = new URLSearchParams();
+    let requestHeaders = new Headers();
+    await acquireOAuth2ClientCredentialsToken(
       {
         ...SECRET_CONFIG,
         token_endpoint_auth_method: 'private_key_jwt',
@@ -121,20 +162,78 @@ describe('OAuth2 client credentials', () => {
         private_key: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
         certificate_thumbprint: 'thumbprint-123',
       },
-      { now: () => 1_000_000, randomId: () => 'assertion-id' },
+      {
+        fetchImpl: async (_url, init) => {
+          requestBody = new URLSearchParams(String(init?.body));
+          requestHeaders = new Headers(init?.headers);
+          return Response.json({ access_token: 'private-key-access' });
+        },
+      },
     );
-    const [encodedHeader, encodedPayload, signature] = assertion.split('.');
-    const header = JSON.parse(Buffer.from(encodedHeader, 'base64url').toString());
-    const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString());
 
-    expect(header).toEqual({ alg: 'PS256', typ: 'JWT', 'x5t#S256': 'thumbprint-123' });
-    expect(payload).toEqual({
+    expect(requestHeaders.get('authorization')).toBeNull();
+    expect(requestBody.get('client_id')).toBe('client-123');
+    expect(requestBody.has('client_secret')).toBe(false);
+    expect(requestBody.get('tenant_hint')).toBe('tenant-123');
+    expect(requestBody.get('client_assertion_type')).toContain('jwt-bearer');
+    const assertion = requestBody.get('client_assertion');
+    if (!assertion) throw new Error('expected private_key_jwt assertion');
+    const [encodedHeader, encodedPayload, signature] = assertion.split('.');
+    expect(JSON.parse(Buffer.from(encodedHeader, 'base64url').toString())).toEqual({
+      alg: 'PS256',
+      typ: 'JWT',
+      'x5t#S256': 'thumbprint-123',
+    });
+    const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString());
+    expect(payload).toMatchObject({
       aud: SECRET_CONFIG.token_url,
       iss: 'client-123',
       sub: 'client-123',
-      jti: 'assertion-id',
-      nbf: 940,
-      exp: 1600,
+    });
+    expect(typeof payload.jti).toBe('string');
+    expect(payload.nbf).toBe(payload.iat);
+    expect(payload.exp - payload.iat).toBe(60);
+    expect(
+      verify(
+        'sha256',
+        Buffer.from(`${encodedHeader}.${encodedPayload}`),
+        {
+          key: publicKey,
+          padding: constants.RSA_PKCS1_PSS_PADDING,
+          saltLength: constants.RSA_PSS_SALTLEN_DIGEST,
+        },
+        Buffer.from(signature, 'base64url'),
+      ),
+    ).toBe(true);
+  });
+
+  test('uses private_key_jwt without an optional certificate thumbprint', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+    });
+    let requestBody = new URLSearchParams();
+    await acquireOAuth2ClientCredentialsToken(
+      {
+        ...SECRET_CONFIG,
+        token_endpoint_auth_method: 'private_key_jwt',
+        client_secret: undefined,
+        private_key: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+        certificate_thumbprint: undefined,
+      },
+      {
+        fetchImpl: async (_url, init) => {
+          requestBody = new URLSearchParams(String(init?.body));
+          return Response.json({ access_token: 'private-key-access' });
+        },
+      },
+    );
+
+    const assertion = requestBody.get('client_assertion');
+    if (!assertion) throw new Error('expected private_key_jwt assertion');
+    const [encodedHeader, encodedPayload, signature] = assertion.split('.');
+    expect(JSON.parse(Buffer.from(encodedHeader, 'base64url').toString())).toEqual({
+      alg: 'PS256',
+      typ: 'JWT',
     });
     expect(
       verify(
@@ -148,6 +247,42 @@ describe('OAuth2 client credentials', () => {
         Buffer.from(signature, 'base64url'),
       ),
     ).toBe(true);
+  });
+
+  test('defensively ignores protocol-owned token_params from legacy stored input', async () => {
+    let body = new URLSearchParams();
+    await acquireOAuth2ClientCredentialsToken(
+      {
+        ...SECRET_CONFIG,
+        token_params: {
+          tenant_hint: 'tenant-123',
+          grant_type: 'password',
+          client_id: 'attacker-client',
+          client_secret: 'attacker-secret',
+          scope: 'attacker-scope',
+          resource: 'https://attacker.example.com',
+          audience: 'https://attacker.example.com',
+          client_assertion: 'attacker-assertion',
+          client_assertion_type: 'attacker-type',
+        },
+      },
+      {
+        fetchImpl: async (_url, init) => {
+          body = new URLSearchParams(String(init?.body));
+          return Response.json({ access_token: 'access-123' });
+        },
+      },
+    );
+
+    expect(Object.fromEntries(body)).toEqual({
+      tenant_hint: 'tenant-123',
+      grant_type: 'client_credentials',
+      scope: 'records.read',
+      resource: 'https://resource.example.com',
+      audience: 'https://api.example.com',
+      client_id: 'client-123',
+      client_secret: 'secret-123',
+    });
   });
 
   test('refreshes tokens inside the 60 second expiry window', () => {
@@ -195,8 +330,12 @@ describe('OAuth2 client credentials', () => {
 
     expect(resolved.accessToken).toBe('fresh-access');
     expect(resolved.updatedValue).toContain('"kind":"oauth2_client_credentials"');
+    if (!resolved.updatedValue) throw new Error('expected refreshed stored credential');
+    expect(JSON.parse(resolved.updatedValue).config.token_params).toEqual({
+      tenant_hint: 'tenant-123',
+    });
     expect(
-      await resolveStoredOAuth2Credential(resolved.updatedValue!, {
+      await resolveStoredOAuth2Credential(resolved.updatedValue, {
         now: () => 1_000_000,
         acquire: async () => {
           throw new Error('not expected');
@@ -210,7 +349,10 @@ describe('OAuth2 client credentials', () => {
       acquireOAuth2ClientCredentialsToken(SECRET_CONFIG, {
         fetchImpl: async () =>
           Response.json(
-            { error: 'invalid_client', error_description: 'secret-123 is invalid' },
+            {
+              error: 'invalid_client',
+              error_description: 'secret-123 is invalid',
+            },
             { status: 401 },
           ),
       }),

--- a/apps/api/src/connectors/oauth2.ts
+++ b/apps/api/src/connectors/oauth2.ts
@@ -1,6 +1,21 @@
-import { createPrivateKey, createSecretKey, randomUUID } from 'node:crypto';
-import { OAuth2ClientCredentialsSchema, type OAuth2ClientCredentials } from '@kortix/api-contract';
-import { CompactSign } from 'jose';
+import {
+  OAUTH2_RESERVED_TOKEN_PARAMETER_NAMES,
+  type OAuth2ClientCredentials,
+  OAuth2ClientCredentialsSchema,
+} from '@kortix/api-contract';
+import {
+  type AuthorizationServer,
+  type Client,
+  type ClientAuth,
+  ClientSecretBasic,
+  ClientSecretJwt,
+  ClientSecretPost,
+  None,
+  PrivateKeyJwt,
+  clientCredentialsGrantRequest,
+  customFetch,
+  modifyAssertion,
+} from 'oauth4webapi';
 import { safeEgressFetch } from '../shared/ssrf-guard';
 
 export interface OAuth2AccessToken {
@@ -20,92 +35,51 @@ interface StoredOAuth2Credential {
 interface OAuth2Runtime {
   fetchImpl?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
   now?: () => number;
-  randomId?: () => string;
 }
 
-export async function buildPrivateKeyClientAssertion(
-  config: OAuth2ClientCredentials,
-  runtime: Pick<OAuth2Runtime, 'now' | 'randomId'> = {},
-): Promise<string> {
-  if (
-    config.token_endpoint_auth_method !== 'private_key_jwt' ||
-    !config.private_key ||
-    !config.certificate_thumbprint
-  ) {
-    throw new Error('OAuth2 private_key_jwt requires a private key and certificate thumbprint');
+const OAUTH2_RESERVED_TOKEN_PARAMETERS = new Set<string>(OAUTH2_RESERVED_TOKEN_PARAMETER_NAMES);
+
+async function importPs256PrivateKey(pem: string): Promise<CryptoKey> {
+  const match = pem
+    .trim()
+    .match(/^-----BEGIN PRIVATE KEY-----\s*([A-Za-z0-9+/=\s]+?)\s*-----END PRIVATE KEY-----$/);
+  const encoded = match?.[1];
+  if (!encoded) throw new Error('OAuth2 private_key_jwt requires a PKCS#8 PEM private key');
+  const bytes = new Uint8Array(Buffer.from(encoded.replace(/\s+/g, ''), 'base64'));
+  return crypto.subtle.importKey('pkcs8', bytes, { name: 'RSA-PSS', hash: 'SHA-256' }, false, [
+    'sign',
+  ]);
+}
+
+async function clientAuthentication(config: OAuth2ClientCredentials): Promise<ClientAuth> {
+  switch (config.token_endpoint_auth_method) {
+    case 'none':
+      return None();
+    case 'client_secret_basic':
+      return ClientSecretBasic(config.client_secret ?? '');
+    case 'client_secret_post':
+      return ClientSecretPost(config.client_secret ?? '');
+    case 'client_secret_jwt':
+      return ClientSecretJwt(config.client_secret ?? '', {
+        [modifyAssertion](header, payload) {
+          header.typ = 'JWT';
+          payload.aud = config.token_url;
+        },
+      });
+    case 'private_key_jwt': {
+      if (!config.private_key) throw new Error('OAuth2 private_key_jwt requires a private key');
+      const key = await importPs256PrivateKey(config.private_key);
+      return PrivateKeyJwt(key, {
+        [modifyAssertion](header, payload) {
+          header.typ = 'JWT';
+          if (config.certificate_thumbprint) {
+            header['x5t#S256'] = config.certificate_thumbprint;
+          }
+          payload.aud = config.token_url;
+        },
+      });
+    }
   }
-  const nowSeconds = Math.floor((runtime.now?.() ?? Date.now()) / 1000);
-  const payload = Buffer.from(
-    JSON.stringify({
-      aud: config.token_url,
-      iss: config.client_id,
-      sub: config.client_id,
-      jti: runtime.randomId?.() ?? randomUUID(),
-      nbf: nowSeconds - 60,
-      exp: nowSeconds + 600,
-    }),
-  );
-  return new CompactSign(payload)
-    .setProtectedHeader({
-      alg: 'PS256',
-      typ: 'JWT',
-      'x5t#S256': config.certificate_thumbprint,
-    })
-    .sign(createPrivateKey(config.private_key));
-}
-
-async function buildClientSecretAssertion(
-  config: OAuth2ClientCredentials,
-  runtime: OAuth2Runtime,
-): Promise<string> {
-  const nowSeconds = Math.floor((runtime.now?.() ?? Date.now()) / 1000);
-  const payload = Buffer.from(
-    JSON.stringify({
-      aud: config.token_url,
-      iss: config.client_id,
-      sub: config.client_id,
-      jti: runtime.randomId?.() ?? randomUUID(),
-      iat: nowSeconds,
-      exp: nowSeconds + 300,
-    }),
-  );
-  return new CompactSign(payload)
-    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
-    .sign(createSecretKey(Buffer.from(config.client_secret ?? '')));
-}
-
-async function tokenRequest(
-  config: OAuth2ClientCredentials,
-  runtime: OAuth2Runtime,
-): Promise<RequestInit> {
-  const body = new URLSearchParams({
-    grant_type: 'client_credentials',
-    client_id: config.client_id,
-  });
-  const headers = new Headers({ 'content-type': 'application/x-www-form-urlencoded' });
-
-  if (config.scopes?.length) body.set('scope', config.scopes.join(' '));
-  if (config.resource) body.set('resource', config.resource);
-  if (config.audience) body.set('audience', config.audience);
-
-  if (config.token_endpoint_auth_method === 'none') {
-    // Public client. client_id remains in the request body.
-  } else if (config.token_endpoint_auth_method === 'client_secret_basic') {
-    headers.set(
-      'authorization',
-      `Basic ${Buffer.from(`${config.client_id}:${config.client_secret}`).toString('base64')}`,
-    );
-  } else if (config.token_endpoint_auth_method === 'client_secret_post') {
-    body.set('client_secret', config.client_secret ?? '');
-  } else if (config.token_endpoint_auth_method === 'client_secret_jwt') {
-    body.set('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
-    body.set('client_assertion', await buildClientSecretAssertion(config, runtime));
-  } else {
-    body.set('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
-    body.set('client_assertion', await buildPrivateKeyClientAssertion(config, runtime));
-  }
-
-  return { method: 'POST', headers, body };
 }
 
 export async function acquireOAuth2ClientCredentialsToken(
@@ -113,10 +87,32 @@ export async function acquireOAuth2ClientCredentialsToken(
   runtime: OAuth2Runtime = {},
 ): Promise<OAuth2AccessToken> {
   const now = runtime.now?.() ?? Date.now();
-  const request = await tokenRequest(config, runtime);
-  const response = runtime.fetchImpl
-    ? await runtime.fetchImpl(config.token_url, request)
-    : await safeEgressFetch(config.token_url, request);
+  const parameters = new URLSearchParams();
+  for (const [key, value] of Object.entries(config.token_params ?? {})) {
+    // The API schema rejects these names. Keep this defensive filter because
+    // stored credentials can predate schema changes or originate outside the
+    // current HTTP boundary.
+    if (!OAUTH2_RESERVED_TOKEN_PARAMETERS.has(key)) parameters.set(key, value);
+  }
+  if (config.scopes?.length) parameters.set('scope', config.scopes.join(' '));
+  if (config.resource) parameters.set('resource', config.resource);
+  if (config.audience) parameters.set('audience', config.audience);
+
+  const authorizationServer: AuthorizationServer = {
+    issuer: config.token_url,
+    token_endpoint: config.token_url,
+  };
+  const client: Client = { client_id: config.client_id };
+  const fetchImpl = runtime.fetchImpl ?? safeEgressFetch;
+  const response = await clientCredentialsGrantRequest(
+    authorizationServer,
+    client,
+    await clientAuthentication(config),
+    parameters,
+    {
+      [customFetch]: (input, init) => fetchImpl(input, init as RequestInit),
+    },
+  );
   let payload: Record<string, unknown> = {};
   try {
     payload = (await response.json()) as Record<string, unknown>;

--- a/apps/api/src/connectors/sync-mcp.test.ts
+++ b/apps/api/src/connectors/sync-mcp.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from 'bun:test';
+import type { ConnectorSpec } from '../projects/connectors';
+import type { GitBackedProject } from '../projects/git';
+import {
+  catalogPersistenceState,
+  mcpCatalogCredentialError,
+  rematerializeCatalogAfterCredentialUpdate,
+  resolveCatalog,
+  resolveMcpCatalogCredential,
+  shouldReuseConnectorCatalog,
+} from './sync';
+
+const MCP_SPEC = {
+  slug: 'records',
+  path: 'kortix.yaml#connectors.records',
+  name: 'Records',
+  enabled: true,
+  provider: 'mcp',
+  credentialMode: 'shared',
+  authorizationStrategy: 'project',
+  sensitive: false,
+  app: null,
+  account: null,
+  url: 'https://mcp.example.com/mcp',
+  transport: 'http',
+  endpoint: null,
+  baseUrl: null,
+  platform: null,
+  spec: null,
+  auth: {
+    type: 'bearer',
+    in: 'header',
+    name: null,
+    prefix: null,
+    secret: null,
+  },
+  headers: { 'X-Tenant': 'tenant-123' },
+  policies: [],
+} satisfies ConnectorSpec;
+
+const UNUSED_PROJECT = {} as GitBackedProject;
+
+describe('MCP catalog materialization', () => {
+  test('uses the execution credential path and normalizes authenticated tools', async () => {
+    const requests: Array<{ headers: Record<string, string>; body?: string }> = [];
+    const result = await resolveCatalog(UNUSED_PROJECT, MCP_SPEC, {
+      credential: 'catalog-access-token',
+      mcpFetchImpl: async (_url, init) => {
+        requests.push({ headers: init.headers, body: init.body });
+        return {
+          status: 200,
+          ok: true,
+          text: async () =>
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: 1,
+              result: {
+                tools: [
+                  {
+                    name: 'queryRecords',
+                    description: 'Query records',
+                    inputSchema: { type: 'object' },
+                    annotations: { readOnlyHint: true },
+                  },
+                ],
+              },
+            }),
+        };
+      },
+    });
+
+    expect(requests).toHaveLength(1);
+    const request = requests[0];
+    if (!request) throw new Error('expected one MCP catalog request');
+    expect(request.headers.Authorization).toBe('Bearer catalog-access-token');
+    expect(request.headers['X-Tenant']).toBe('tenant-123');
+    expect(JSON.parse(request.body ?? '')).toMatchObject({
+      method: 'tools/list',
+    });
+    expect(result).toMatchObject({
+      server: 'https://mcp.example.com/mcp',
+      actions: [{ path: 'queryrecords', risk: 'read' }],
+    });
+  });
+
+  test('turns an upstream 401 into a useful catalog error without leaking the credential', async () => {
+    const result = await resolveCatalog(UNUSED_PROJECT, MCP_SPEC, {
+      credential: 'catalog-access-token',
+      mcpFetchImpl: async () => ({
+        status: 401,
+        ok: false,
+        text: async () => 'catalog-access-token is invalid',
+      }),
+    });
+
+    expect(result.actions).toEqual([]);
+    expect(result.error).toBe('MCP tools/list failed: HTTP 401');
+    expect(catalogPersistenceState(true, result)).toEqual({
+      status: 'error',
+      lastError: 'MCP tools/list failed: HTTP 401',
+    });
+    expect(JSON.stringify(result)).not.toContain('catalog-access-token');
+  });
+
+  test('retries an existing active MCP connector whose catalog has zero actions', () => {
+    expect(
+      shouldReuseConnectorCatalog({
+        force: false,
+        hasExisting: true,
+        existingStatus: 'active',
+        provider: 'mcp',
+        mcpHasActions: false,
+        manifestMatches: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReuseConnectorCatalog({
+        force: false,
+        hasExisting: true,
+        existingStatus: 'active',
+        provider: 'mcp',
+        mcpHasActions: true,
+        manifestMatches: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('never reuses error rows or any catalog when force is requested', () => {
+    const base = {
+      hasExisting: true,
+      provider: 'mcp' as const,
+      mcpHasActions: true,
+      manifestMatches: true,
+    };
+    expect(
+      shouldReuseConnectorCatalog({
+        ...base,
+        force: false,
+        existingStatus: 'error',
+      }),
+    ).toBe(false);
+    expect(
+      shouldReuseConnectorCatalog({
+        ...base,
+        force: true,
+        existingStatus: 'active',
+      }),
+    ).toBe(false);
+  });
+
+  test('credential updates force MCP rematerialization and skip unrelated providers', async () => {
+    const calls: Array<{
+      projectId: string;
+      accountId: string;
+      force?: boolean;
+      credential?: string;
+    }> = [];
+    const sync = async (
+      projectId: string,
+      accountId: string,
+      options: {
+        force?: boolean;
+        mcpCredentialOverrides?: ReadonlyMap<string, string>;
+      } = {},
+    ) => {
+      calls.push({
+        projectId,
+        accountId,
+        force: options.force,
+        credential: options.mcpCredentialOverrides?.get('connector-1'),
+      });
+      return { synced: 1, errors: [] };
+    };
+    expect(
+      await rematerializeCatalogAfterCredentialUpdate(
+        {
+          projectId: 'project-1',
+          accountId: 'account-1',
+          provider: 'mcp',
+          connectorId: 'connector-1',
+          credential: 'connection-access-token',
+        },
+        sync,
+      ),
+    ).toEqual({ synced: 1, errors: [] });
+    expect(
+      await rematerializeCatalogAfterCredentialUpdate(
+        { projectId: 'project-1', accountId: 'account-1', provider: 'openapi' },
+        sync,
+      ),
+    ).toBeUndefined();
+    expect(calls).toEqual([
+      {
+        projectId: 'project-1',
+        accountId: 'account-1',
+        force: true,
+        credential: 'connection-access-token',
+      },
+    ]);
+  });
+
+  test('a connection-specific refresh credential wins over the project default', async () => {
+    let fallbackCalls = 0;
+    const resolveDefault = async () => {
+      fallbackCalls += 1;
+      return 'project-default-token';
+    };
+    expect(
+      await resolveMcpCatalogCredential(
+        'connector-1',
+        new Map([['connector-1', 'connection-access-token']]),
+        resolveDefault,
+      ),
+    ).toBe('connection-access-token');
+    expect(fallbackCalls).toBe(0);
+    expect(await resolveMcpCatalogCredential('connector-1', undefined, resolveDefault)).toBe(
+      'project-default-token',
+    );
+    expect(fallbackCalls).toBe(1);
+  });
+
+  test('credential-resolution errors retain safe OAuth codes and redact unknown messages', () => {
+    expect(
+      mcpCatalogCredentialError(new Error('OAuth2 token request failed (401): invalid_client')),
+    ).toBe(
+      'MCP catalog credential resolution failed: OAuth2 token request failed (401): invalid_client',
+    );
+    expect(
+      mcpCatalogCredentialError(new Error('secret catalog-access-token failed to decrypt')),
+    ).toBe('MCP catalog credential resolution failed');
+  });
+});

--- a/apps/api/src/connectors/sync-mcp.test.ts
+++ b/apps/api/src/connectors/sync-mcp.test.ts
@@ -148,7 +148,7 @@ describe('MCP catalog materialization', () => {
     ).toBe(false);
   });
 
-  test('credential updates force MCP rematerialization and skip unrelated providers', async () => {
+  test('only project-default credential updates can rematerialize the shared MCP catalog', async () => {
     const calls: Array<{
       projectId: string;
       accountId: string;
@@ -177,6 +177,8 @@ describe('MCP catalog materialization', () => {
           projectId: 'project-1',
           accountId: 'account-1',
           provider: 'mcp',
+          ownerType: 'project',
+          isDefault: true,
           connectorId: 'connector-1',
           credential: 'connection-access-token',
         },
@@ -185,7 +187,41 @@ describe('MCP catalog materialization', () => {
     ).toEqual({ synced: 1, errors: [] });
     expect(
       await rematerializeCatalogAfterCredentialUpdate(
-        { projectId: 'project-1', accountId: 'account-1', provider: 'openapi' },
+        {
+          projectId: 'project-1',
+          accountId: 'account-1',
+          provider: 'openapi',
+          ownerType: 'project',
+          isDefault: true,
+        },
+        sync,
+      ),
+    ).toBeUndefined();
+    expect(
+      await rematerializeCatalogAfterCredentialUpdate(
+        {
+          projectId: 'project-1',
+          accountId: 'account-1',
+          provider: 'mcp',
+          ownerType: 'member',
+          isDefault: true,
+          connectorId: 'connector-1',
+          credential: 'member-access-token',
+        },
+        sync,
+      ),
+    ).toBeUndefined();
+    expect(
+      await rematerializeCatalogAfterCredentialUpdate(
+        {
+          projectId: 'project-1',
+          accountId: 'account-1',
+          provider: 'mcp',
+          ownerType: 'project',
+          isDefault: false,
+          connectorId: 'connector-1',
+          credential: 'non-default-access-token',
+        },
         sync,
       ),
     ).toBeUndefined();

--- a/apps/api/src/connectors/sync.ts
+++ b/apps/api/src/connectors/sync.ts
@@ -17,7 +17,7 @@ import {
  * a connector that can't be reached is stored with status='error' + 0 actions,
  * never failing the whole sweep. See docs/specs/connector.md §3, §7.
  */
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import { parse as parseToml } from 'smol-toml';
 import { listAgentMailInstalls, loadSlackInstall } from '../channels/install-store';
 import { resolveFeatureFlag } from '../feature-flags/registry';
@@ -33,6 +33,7 @@ import {
 import { type GitBackedProject, isRepoFileNotFoundError, readRepoFile } from '../projects/git';
 import { withProjectGitAuth } from '../projects/index';
 import { extractProjectPolicies } from '../projects/policies';
+import { getProjectSecretValueForConsumer } from '../projects/secrets';
 import { extractTriggers, readManifest } from '../projects/triggers';
 import { reconcileProjectTriggerRuntime } from '../projects/trigger-runtime-catalog';
 import { db } from '../shared/db';
@@ -42,8 +43,8 @@ import { synthesizeChannelConnectors } from './channel-materialize';
 import { channelApiBase, channelCatalog, channelDefaultSlug } from './channels';
 import { synthesizeComputerConnectors } from './computer-materialize';
 import { COMPUTER_SLUG, computerCatalog } from './computers';
-import { ensureDefaultConnection } from './credentials';
-import { parseResponseBody } from './call';
+import { ensureDefaultConnection, resolveCredentialValue } from './credentials';
+import { listMcpTools, type FetchImpl } from './call';
 import type { ProjectPolicySpec } from '../projects/policies';
 import { connectorConfig, toPolicyRows, toProjectPolicyRows } from './materialize';
 import {
@@ -70,6 +71,76 @@ import type { HttpRouteSpec, NormalizedAction } from './types';
 export interface SyncResult {
   synced: number;
   errors: Array<{ slug: string; error: string }>;
+}
+
+export function shouldReuseConnectorCatalog(input: {
+  force: boolean;
+  hasExisting: boolean;
+  existingStatus: string | null;
+  provider: ConnectorSpec['provider'];
+  mcpHasActions: boolean;
+  manifestMatches: boolean;
+}): boolean {
+  return (
+    !input.force &&
+    input.hasExisting &&
+    input.existingStatus !== 'error' &&
+    input.provider !== 'channel' &&
+    input.provider !== 'computer' &&
+    (input.provider !== 'mcp' || input.mcpHasActions) &&
+    input.manifestMatches
+  );
+}
+
+export async function rematerializeCatalogAfterCredentialUpdate(
+  input: {
+    projectId: string;
+    accountId: string;
+    provider: string;
+    connectorId?: string;
+    credential?: string | null;
+  },
+  sync: typeof syncProjectConnectors = syncProjectConnectors,
+): Promise<SyncResult | undefined> {
+  if (input.provider !== 'mcp') return undefined;
+  const mcpCredentialOverrides =
+    input.connectorId && input.credential
+      ? new Map([[input.connectorId, input.credential]])
+      : undefined;
+  return sync(input.projectId, input.accountId, {
+    force: true,
+    ...(mcpCredentialOverrides ? { mcpCredentialOverrides } : {}),
+  });
+}
+
+export function catalogPersistenceState(
+  enabled: boolean,
+  catalog: { error?: string } | null,
+): { status: 'active' | 'disabled' | 'error'; lastError: string | null } {
+  return {
+    status: catalog?.error ? 'error' : enabled ? 'active' : 'disabled',
+    lastError: catalog?.error ?? null,
+  };
+}
+
+export function mcpCatalogCredentialError(error: unknown): string {
+  const message = error instanceof Error ? error.message : '';
+  if (
+    /^OAuth2 token request failed \([1-5][0-9]{2}\): [A-Za-z0-9_.-]{1,128}$/.test(message) ||
+    message === 'OAuth2 token response has no access_token' ||
+    message === 'Invalid stored OAuth2 credential'
+  ) {
+    return `MCP catalog credential resolution failed: ${message}`;
+  }
+  return 'MCP catalog credential resolution failed';
+}
+
+export async function resolveMcpCatalogCredential(
+  connectorId: string,
+  overrides: ReadonlyMap<string, string> | undefined,
+  resolve: typeof resolveCredentialValue = resolveCredentialValue,
+): Promise<string | null> {
+  return overrides?.get(connectorId) ?? resolve(connectorId, null);
 }
 
 /**
@@ -299,6 +370,8 @@ export interface SyncOptions {
    * an unchanged connector skips its (network) catalog fetch.
    */
   force?: boolean;
+  /** Exact connection credentials used only for this in-memory MCP refresh. */
+  mcpCredentialOverrides?: ReadonlyMap<string, string>;
 }
 
 interface ResolvedCatalog {
@@ -409,6 +482,17 @@ export async function syncProjectConnectors(
     .from(connectors)
     .where(eq(connectors.projectId, projectId));
   const existingBySlug = new Map(existing.map((e) => [e.slug, e]));
+  const existingIds = existing.map((connector) => connector.connectorId);
+  const connectorsWithActions = new Set(
+    existingIds.length === 0
+      ? []
+      : (
+          await db
+            .selectDistinct({ connectorId: connectorActions.connectorId })
+            .from(connectorActions)
+            .where(inArray(connectorActions.connectorId, existingIds))
+        ).map((row) => row.connectorId),
+  );
   const desiredSlugs = new Set(specs.map((s) => s.slug));
 
   let synced = 0;
@@ -458,14 +542,40 @@ export async function syncProjectConnectors(
       // projects, and the same was true of any Slack/Teams/email action ever
       // added. Re-resolving locally on every sync is free and keeps deployed
       // projects honest.
-      const catalogUnchanged =
-        !opts.force &&
-        !!ex &&
-        ex.status !== 'error' &&
-        spec.provider !== 'channel' &&
-        spec.provider !== 'computer' &&
-        ex.manifestHash === manifestHashForConnector(spec);
-      const catalog = catalogUnchanged ? null : await resolveCatalog(gitProject, spec);
+      const catalogUnchanged = shouldReuseConnectorCatalog({
+        force: opts.force === true,
+        hasExisting: !!ex,
+        existingStatus: ex?.status ?? null,
+        provider: spec.provider,
+        mcpHasActions: ex ? connectorsWithActions.has(ex.connectorId) : false,
+        manifestMatches: ex?.manifestHash === manifestHashForConnector(spec),
+      });
+      let catalogCredential: string | null = null;
+      let catalogCredentialError: string | null = null;
+      if (!catalogUnchanged && spec.provider === 'mcp') {
+        try {
+          catalogCredential = ex
+            ? await resolveMcpCatalogCredential(ex.connectorId, opts.mcpCredentialOverrides)
+            : null;
+          if (catalogCredential === null && spec.auth.secret) {
+            catalogCredential = await getProjectSecretValueForConsumer({
+              projectId,
+              accountId,
+              name: spec.auth.secret,
+              consumer: 'connector',
+            });
+          }
+        } catch (error) {
+          catalogCredentialError = mcpCatalogCredentialError(error);
+        }
+      }
+      const catalog = catalogUnchanged
+        ? null
+        : catalogCredentialError
+          ? { actions: [], server: null, error: catalogCredentialError }
+          : await resolveCatalog(gitProject, spec, {
+              credential: catalogCredential,
+            });
       await upsertConnector(projectId, accountId, spec, catalog, ex?.connectorId ?? null);
       if (catalog?.error) errors.push({ slug: spec.slug, error: catalog.error });
       synced++;
@@ -611,7 +721,7 @@ async function upsertConnector(
 ): Promise<void> {
   const isNew = !existingId;
   const manifestHash = manifestHashForConnector(spec);
-  const status = catalog?.error ? 'error' : spec.enabled ? 'active' : 'disabled';
+  const { status, lastError } = catalogPersistenceState(spec.enabled, catalog);
   // New connector definitions never carry a secret reference. An existing
   // authSecret is an explicit control-plane binding and must survive sync.
   const authSecret = spec.auth.secret ?? null;
@@ -627,7 +737,7 @@ async function upsertConnector(
     authorizationStrategy: spec.authorizationStrategy,
     manifestHash,
     status,
-    lastError: catalog?.error ?? null,
+    lastError,
     lastSyncedAt: new Date(),
     updatedAt: new Date(),
   } as const;
@@ -752,6 +862,7 @@ export async function materializeComputerConnectorProfile(input: {
 export async function resolveCatalog(
   project: GitBackedProject,
   spec: ConnectorSpec,
+  options: { credential?: string | null; mcpFetchImpl?: FetchImpl } = {},
 ): Promise<ResolvedCatalog> {
   try {
     switch (spec.provider) {
@@ -799,7 +910,21 @@ export async function resolveCatalog(
         };
       }
       case 'mcp': {
-        const tools = await listMcpTools(spec.url!);
+        assertAllowedSourceAddress(spec.url!);
+        const tools = await listMcpTools({
+          url: spec.url!,
+          auth: spec.auth,
+          headers: spec.headers,
+          secret: options.credential ?? null,
+          fetchImpl:
+            options.mcpFetchImpl ??
+            (async (url, init) =>
+              safeEgressFetch(url, {
+                method: init.method,
+                headers: init.headers,
+                body: init.body,
+              })),
+        });
         return { actions: normalizeMcp(tools), server: spec.url };
       }
       case 'pipedream': {
@@ -1063,24 +1188,4 @@ async function reconcileProjectPolicies(
     if (!isUniqueViolation(error)) throw error;
     if ((await updateExisting()).length === 0) throw error;
   }
-}
-
-async function listMcpTools(url: string): Promise<any[]> {
-  assertAllowedSourceAddress(url);
-  const res = await safeEgressFetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json, text/event-stream',
-    },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'tools/list',
-      params: {},
-    }),
-  });
-  // Streamable-HTTP MCP responds with SSE-framed JSON, not plain JSON.
-  const json: any = parseResponseBody(await res.text());
-  return json?.result?.tools ?? [];
 }

--- a/apps/api/src/connectors/sync.ts
+++ b/apps/api/src/connectors/sync.ts
@@ -97,12 +97,19 @@ export async function rematerializeCatalogAfterCredentialUpdate(
     projectId: string;
     accountId: string;
     provider: string;
+    ownerType: string;
+    isDefault: boolean;
     connectorId?: string;
     credential?: string | null;
   },
   sync: typeof syncProjectConnectors = syncProjectConnectors,
 ): Promise<SyncResult | undefined> {
-  if (input.provider !== 'mcp') return undefined;
+  // connectorActions is one project-wide catalog. Only its canonical shared
+  // credential may write it. A member-owned or non-default connection can have
+  // tenant-specific tools and must never publish those tools to other users.
+  if (input.provider !== 'mcp' || input.ownerType !== 'project' || !input.isDefault) {
+    return undefined;
+  }
   const mcpCredentialOverrides =
     input.connectorId && input.credential
       ? new Map([[input.connectorId, input.credential]])

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -785,6 +785,7 @@ for (const operation of ['credential', 'revoke', 'activate', 'default'] as const
           connectorId: connectorConnections.connectorId,
           ownerType: connectorConnections.ownerType,
           ownerId: connectorConnections.ownerId,
+          isDefault: connectorConnections.isDefault,
           metadata: connectorConnections.metadata,
           authorizationStrategy: connectors.authorizationStrategy,
           providerType: connectors.providerType,
@@ -858,9 +859,13 @@ for (const operation of ['credential', 'revoke', 'activate', 'default'] as const
           projectId,
           accountId: loaded.row.accountId,
           provider: connection.providerType,
+          ownerType: connection.ownerType,
+          isDefault: connection.isDefault,
           connectorId: connection.connectorId,
           credential:
-            connection.providerType === 'mcp'
+            connection.providerType === 'mcp' &&
+            connection.ownerType === 'project' &&
+            connection.isDefault
               ? await resolveConnectionCredentialValue({
                   connectorId: connection.connectorId,
                   connectionId,
@@ -888,6 +893,21 @@ for (const operation of ['credential', 'revoke', 'activate', 'default'] as const
             .update(connectorConnections)
             .set({ isDefault: true, updatedAt: new Date() })
             .where(eq(connectorConnections.connectionId, connectionId));
+        });
+        await rematerializeCatalogAfterCredentialUpdate({
+          projectId,
+          accountId: loaded.row.accountId,
+          provider: connection.providerType,
+          ownerType: connection.ownerType,
+          isDefault: true,
+          connectorId: connection.connectorId,
+          credential:
+            connection.providerType === 'mcp' && connection.ownerType === 'project'
+              ? await resolveConnectionCredentialValue({
+                  connectorId: connection.connectorId,
+                  connectionId,
+                })
+              : null,
         });
       } else {
         if (operation === 'revoke') await revokeConnectionOAuth2(connectionId);

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -61,6 +61,7 @@ import {
 import { setProjectBotName } from '../../channels/voice-identity';
 import { config } from '../../config';
 import {
+  resolveConnectionCredentialValue,
   upsertConnectionCredential,
   upsertConnectionOAuth2Credential,
 } from '../../connectors/credentials';
@@ -71,7 +72,10 @@ import {
   pipedreamConfigured,
   pipedreamConnectUrl,
 } from '../../connectors/pipedream';
-import { reconcileChannelConnectors } from '../../connectors/sync';
+import {
+  reconcileChannelConnectors,
+  rematerializeCatalogAfterCredentialUpdate,
+} from '../../connectors/sync';
 import { resolveFeatureFlag } from '../../feature-flags/registry';
 import { featureDisabledBody } from '../../feature-flags/gate';
 import { PROJECT_ACTIONS } from '../../iam';
@@ -850,6 +854,19 @@ for (const operation of ['credential', 'revoke', 'activate', 'default'] as const
         } catch (error) {
           return c.json({ error: (error as Error).message || 'credential validation failed' }, 400);
         }
+        await rematerializeCatalogAfterCredentialUpdate({
+          projectId,
+          accountId: loaded.row.accountId,
+          provider: connection.providerType,
+          connectorId: connection.connectorId,
+          credential:
+            connection.providerType === 'mcp'
+              ? await resolveConnectionCredentialValue({
+                  connectorId: connection.connectorId,
+                  connectionId,
+                })
+              : null,
+        });
       } else if (operation === 'default') {
         // Make THIS the default connection for its owner scope. Defaults are
         // per-owner (one team default; one per member), and the partial unique

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -10,6 +10,7 @@ import {
   OkResponseSchema,
   OAuth2ApplicationInputSchema,
   OAuth2AuthorizationStartInputSchema,
+  OAuth2ClientCredentialsSchema,
   OAuth2DeviceAuthorizationStartInputSchema,
   ProjectSchema,
   ProjectSessionSandboxSchema,
@@ -886,6 +887,8 @@ describe('session connection contracts', () => {
           token_endpoint_auth_method: 'client_secret_post',
           client_secret: 'client-secret',
           scopes: ['https://graph.microsoft.com/.default'],
+          resource: 'https://resource.example.com',
+          token_params: { tenant_hint: 'tenant-123' },
         },
       }).success,
     ).toBe(true);
@@ -897,6 +900,52 @@ describe('session connection contracts', () => {
           client_id: 'client-id',
           token_endpoint_auth_method: 'client_secret_post',
           client_secret: 'client-secret',
+        },
+      }).success,
+    ).toBe(false);
+    for (const reserved of [
+      'grant_type',
+      'client_id',
+      'client_secret',
+      'client_assertion',
+      'client_assertion_type',
+      'scope',
+      'resource',
+      'audience',
+    ]) {
+      expect(
+        UpdateConnectionCredentialInputSchema.safeParse({
+          oauth2: {
+            type: 'oauth2_client_credentials',
+            token_url: 'https://identity.example.com/token',
+            client_id: 'client-id',
+            token_endpoint_auth_method: 'none',
+            token_params: { [reserved]: 'override' },
+          },
+        }).success,
+      ).toBe(false);
+    }
+    expect(
+      UpdateConnectionCredentialInputSchema.safeParse({
+        oauth2: {
+          type: 'oauth2_client_credentials',
+          token_url: 'https://identity.example.com/token',
+          client_id: 'client-id',
+          token_endpoint_auth_method: 'none',
+          token_params: Object.fromEntries(
+            Array.from({ length: 33 }, (_, index) => [`hint_${index}`, 'value']),
+          ),
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      UpdateConnectionCredentialInputSchema.safeParse({
+        oauth2: {
+          type: 'oauth2_client_credentials',
+          token_url: 'https://identity.example.com/token',
+          client_id: 'client-id',
+          token_endpoint_auth_method: 'none',
+          token_params: { 'invalid parameter': 'value' },
         },
       }).success,
     ).toBe(false);
@@ -1050,6 +1099,75 @@ describe('required connection contracts', () => {
 });
 
 describe('native OAuth2 lifecycle schemas', () => {
+  test('accepts every client-credentials endpoint authentication method', () => {
+    const base = {
+      type: 'oauth2_client_credentials' as const,
+      token_url: 'https://identity.example.com/token',
+      client_id: 'client-123',
+      token_params: { tenant_hint: 'tenant-123' },
+    };
+    expect(
+      OAuth2ClientCredentialsSchema.safeParse({
+        ...base,
+        token_endpoint_auth_method: 'none',
+      }).success,
+    ).toBe(true);
+    for (const token_endpoint_auth_method of [
+      'client_secret_post',
+      'client_secret_basic',
+      'client_secret_jwt',
+    ] as const) {
+      expect(
+        OAuth2ClientCredentialsSchema.safeParse({
+          ...base,
+          token_endpoint_auth_method,
+          client_secret: 'secret-123',
+        }).success,
+      ).toBe(true);
+    }
+    expect(
+      OAuth2ClientCredentialsSchema.safeParse({
+        ...base,
+        token_endpoint_auth_method: 'private_key_jwt',
+        private_key: 'pem-private-key',
+        certificate_thumbprint: 'certificate-thumbprint',
+      }).success,
+    ).toBe(true);
+  });
+
+  test('requires all key material selected by the endpoint authentication method', () => {
+    const base = {
+      type: 'oauth2_client_credentials' as const,
+      token_url: 'https://identity.example.com/token',
+      client_id: 'client-123',
+    };
+    for (const token_endpoint_auth_method of [
+      'client_secret_post',
+      'client_secret_basic',
+      'client_secret_jwt',
+    ] as const) {
+      expect(
+        OAuth2ClientCredentialsSchema.safeParse({
+          ...base,
+          token_endpoint_auth_method,
+        }).success,
+      ).toBe(false);
+    }
+    expect(
+      OAuth2ClientCredentialsSchema.safeParse({
+        ...base,
+        token_endpoint_auth_method: 'private_key_jwt',
+        private_key: 'pem-private-key',
+      }).success,
+    ).toBe(true);
+    expect(
+      OAuth2ClientCredentialsSchema.safeParse({
+        ...base,
+        token_endpoint_auth_method: 'private_key_jwt',
+      }).success,
+    ).toBe(false);
+  });
+
   test('accepts a provider-independent Authorization Code application with PKCE', () => {
     expect(
       OAuth2ApplicationInputSchema.parse({

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -488,6 +488,49 @@ export const ReconcileConnectionInputSchema = z
   .strict();
 export type ReconcileConnectionInput = z.infer<typeof ReconcileConnectionInputSchema>;
 
+const OAuth2TokenParameterNameSchema = z
+  .string()
+  .regex(
+    /^[A-Za-z][A-Za-z0-9_.~-]{0,127}$/,
+    'token parameter names must be 1-128 URL-form-safe characters and start with a letter',
+  );
+
+export const OAUTH2_RESERVED_TOKEN_PARAMETER_NAMES = [
+  'grant_type',
+  'client_id',
+  'client_secret',
+  'client_assertion',
+  'client_assertion_type',
+  'scope',
+  'resource',
+  'audience',
+] as const;
+const OAUTH2_RESERVED_TOKEN_PARAMETERS = new Set<string>(OAUTH2_RESERVED_TOKEN_PARAMETER_NAMES);
+
+const OAuth2AdditionalTokenParametersSchema = z
+  .record(OAuth2TokenParameterNameSchema, z.string().max(4096))
+  .superRefine((value, ctx) => {
+    const entries = Object.entries(value);
+    if (entries.length > 32) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.too_big,
+        type: 'array',
+        maximum: 32,
+        inclusive: true,
+        message: 'at most 32 additional token parameters are allowed',
+      });
+    }
+    for (const [key] of entries) {
+      if (OAUTH2_RESERVED_TOKEN_PARAMETERS.has(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `${key} is owned by the OAuth2 client-credentials protocol`,
+        });
+      }
+    }
+  });
+
 export const OAuth2ClientCredentialsSchema = z
   .object({
     type: z.literal('oauth2_client_credentials'),
@@ -509,6 +552,7 @@ export const OAuth2ClientCredentialsSchema = z
     scopes: z.array(z.string().trim().min(1).max(2048)).max(64).optional(),
     resource: z.string().trim().min(1).max(4096).optional(),
     audience: z.string().trim().min(1).max(4096).optional(),
+    token_params: OAuth2AdditionalTokenParametersSchema.optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -10428,3 +10428,13 @@ holes + 2 hygiene issues. All fixed, TDD RED first (3 new tests):
 **Evidence** — SDK: 2122 pass, 0 fail, 148 files; typecheck clean;
 smoke:install passed. Web tsc clean apart from the known baseline; eslint
 clean on the drain hook.
+
+### 2026-08-18 — session `fix-mcp-catalog-auth` claim
+
+Claimed the additive `token_params` field on `OAuth2ClientCredentials`. This
+field lets connector authors send provider-required client-credentials form
+parameters such as Sage Intacct `username`. Existing OAuth2 fields and static
+credentials remain compatible.
+
+**Status:** IN PROGRESS. RED test, implementation, full SDK gates, repository
+delivery, Essentia deploy proof, and live Intacct verification remain required.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -10431,10 +10431,25 @@ clean on the drain hook.
 
 ### 2026-08-18 — session `fix-mcp-catalog-auth` claim
 
-Claimed the additive `token_params` field on `OAuth2ClientCredentials`. This
-field lets connector authors send provider-required client-credentials form
-parameters such as Sage Intacct `username`. Existing OAuth2 fields and static
-credentials remain compatible.
+Completed the additive, provider-neutral `token_params` field on
+`OAuth2ClientCredentials` and fixed authenticated MCP catalog discovery.
+Connector authors can supply bounded provider-required token form parameters;
+OAuth-owned fields cannot be overridden. The API now uses `oauth4webapi` for
+all five supported endpoint authentication methods (`none`,
+`client_secret_post`, `client_secret_basic`, `client_secret_jwt`, and
+`private_key_jwt`). MCP `tools/list` uses the same credential/static-header
+path as execution, rejects HTTP and JSON-RPC failures, redacts raw and encoded
+credential representations, retries broken zero-action catalogs, and refreshes
+after both shared and connection-specific credential updates.
 
-**Status:** IN PROGRESS. RED test, implementation, full SDK gates, repository
-delivery, Essentia deploy proof, and live Intacct verification remain required.
+**Evidence:** focused OAuth/MCP/contract/SDK matrix **166 pass / 0 fail**;
+API unit suite **7051 pass / 74 skip / 0 fail** across 630 files; SDK suite
+**2125 pass / 0 fail** across 148 files; API-contract suite **73 pass / 0
+fail**; API, SDK, and API-contract typechecks clean; SDK packed-install smoke
+passed; `git diff --check` clean. The OAuth tests make real token requests for
+all five methods and verify PS256 assertions both with and without an optional
+certificate thumbprint.
+
+**Status:** COMPLETE. **Shippable to production: YES** for the implementation.
+Repository merge, Deploy Dev, and live Intacct verification are release proof,
+tracked separately from the SDK/API code verdict.

--- a/packages/sdk/src/core/rest/projects-client/connectors.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/connectors.test.ts
@@ -681,13 +681,15 @@ test('setConnectorCredential PUTs { value }', async () => {
 
 test('setConnectorCredential PUTs a native OAuth2 client-credentials configuration', async () => {
   nextResponse = { status: 200, body: { ok: true } };
-  const oauth2 = {
+  const oauth2: import('./connectors').OAuth2ClientCredentials = {
     type: 'oauth2_client_credentials' as const,
     token_url: 'https://login.microsoftonline.com/tenant/oauth2/v2.0/token',
     client_id: 'client-id',
     token_endpoint_auth_method: 'client_secret_post' as const,
     client_secret: 'client-secret',
     scopes: ['https://graph.microsoft.com/.default'],
+    resource: 'https://resource.example.com',
+    token_params: { tenant_hint: 'tenant-123' },
   };
   await setConnectorCredential('P1', 'sharepoint', { oauth2 });
   expect(last().url).toContain('/connectors/projects/P1/connectors/sharepoint/credential');

--- a/packages/sdk/src/core/rest/projects-client/connectors.ts
+++ b/packages/sdk/src/core/rest/projects-client/connectors.ts
@@ -380,6 +380,8 @@ export interface OAuth2ClientCredentials {
   scopes?: string[];
   resource?: string;
   audience?: string;
+  /** Additional provider-required token form fields not owned by OAuth2 itself. */
+  token_params?: Record<string, string>;
 }
 
 export type OAuth2TokenEndpointAuthMethod =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       livekit-server-sdk:
         specifier: ^2.17.0
         version: 2.17.0
+      oauth4webapi:
+        specifier: ^3.8.7
+        version: 3.8.7
       postgres:
         specifier: ^3.4.8
         version: 3.4.9
@@ -23700,6 +23703,10 @@ packages:
 
   /nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  /oauth4webapi@3.8.7:
+    resolution: {integrity: sha512-4RxcKxXjuItDFZ20RRPf4YTw3kpeXJyCgJFxVzJ068A7PNJ18st2Dg90tlC1LkSDS0GecroagCLHYEIVUhCAkw==}
+    dev: false
 
   /ob1@0.83.3:
     resolution: {integrity: sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA==}


### PR DESCRIPTION
## Summary
- discover MCP tools through the same resolved credential and static-header path used for execution
- reject HTTP, JSON-RPC, malformed, and transport failures instead of silently materializing zero actions
- add bounded provider-neutral OAuth token parameters and use oauth4webapi for all five supported client authentication methods
- refresh broken zero-action catalogs and rematerialize after shared or connection-specific credential updates
- redact raw, form-encoded, URL-encoded, and Basic-encoded credential representations from catalog diagnostics

## Root cause
Kortix catalog sync called MCP tools/list without the stored connection credential, did not reject the upstream HTTP 401, parsed the empty response, and persisted an apparently healthy empty action list. Existing OAuth token caching and refresh were already present; the missing pieces were authenticated discovery and generic extra token form fields.

## Reference implementation
Uses panva/oauth4webapi for standards-sensitive client authentication and token request construction. The dependency is MIT, dependency-free, Bun-tested, and its upstream suite covers none, client_secret_post, client_secret_basic, client_secret_jwt, and private_key_jwt. The official MCP TypeScript SDK remains a behavioral reference; it is not added as a runtime dependency.

## Verification
- focused OAuth/MCP/contract/SDK matrix: 166 pass, 0 fail
- API unit suite: 7051 pass, 74 skip, 0 fail across 630 files
- SDK suite: 2125 pass, 0 fail across 148 files
- API contract: 73 pass, 0 fail
- API, API-contract, and SDK typechecks: pass
- SDK packed-install smoke: pass
- git diff --check: pass

Shippable to production: YES for the implementation. Dev deployment and live Intacct verification follow after merge.