### PR TITLE
fix(web): distinct Auto reasoning-effort icon + capitalize agent names

### DIFF
--- a/apps/web/src/components/home/interactive-demo-section.tsx
+++ b/apps/web/src/components/home/interactive-demo-section.tsx
@@ -311,7 +311,7 @@ type AgentDef = {
 
 const AGENTS: AgentDef[] = [
   {
-    name: 'kortix',
+    name: 'Kortix',
     desc: 'General knowledge worker — full tool access; codes, researches, writes and runs ops end-to-end in an isolated sandbox.',
     icon: Bot,
     trigger: 'primary',
@@ -322,7 +322,7 @@ const AGENTS: AgentDef[] = [
     on: true,
   },
   {
-    name: 'pr-bot',
+    name: 'PR Bot',
     desc: 'Runs a thermo-nuclear review and stands up a one-click preview on every pull request to kortix-ai/kortix.',
     icon: GitPullRequest,
     trigger: 'webhook',
@@ -333,7 +333,7 @@ const AGENTS: AgentDef[] = [
     on: true,
   },
   {
-    name: 'memory-reflector',
+    name: 'Memory Reflector',
     desc: 'Reflects on recent activity and curates .kortix/memory, opening a memory CR each run.',
     icon: Brain,
     trigger: 'cron',
@@ -344,7 +344,7 @@ const AGENTS: AgentDef[] = [
     on: false,
   },
   {
-    name: 'researcher',
+    name: 'Researcher',
     desc: 'Deep multi-source research with structured synthesis, inline citations and charts.',
     icon: Search,
     trigger: 'manual',
@@ -355,7 +355,7 @@ const AGENTS: AgentDef[] = [
     on: true,
   },
   {
-    name: 'analyst',
+    name: 'Analyst',
     desc: 'Profiles the warehouse, writes performant SQL and ships a dashboard from a plain question.',
     icon: Database,
     trigger: 'manual',
@@ -366,7 +366,7 @@ const AGENTS: AgentDef[] = [
     on: true,
   },
   {
-    name: 'support-triage',
+    name: 'Support Triage',
     desc: 'Categorizes, prioritizes and routes inbound tickets, drafting an empathetic first reply.',
     icon: MessageSquare,
     trigger: 'webhook',
@@ -377,7 +377,7 @@ const AGENTS: AgentDef[] = [
     on: true,
   },
   {
-    name: 'deck-builder',
+    name: 'Deck Builder',
     desc: 'Turns a prompt and your latest data into board decks and polished presentations.',
     icon: FileText,
     trigger: 'manual',
@@ -388,7 +388,7 @@ const AGENTS: AgentDef[] = [
     on: false,
   },
   {
-    name: 'sdr',
+    name: 'SDR',
     desc: 'Enriches leads from the CRM, researches each account and drafts tailored outreach.',
     icon: FaUsers,
     trigger: 'manual',
@@ -778,7 +778,7 @@ function ModelsPage({
 type ScheduleJob = { name: string; cron: string; when: string; next: string; on: boolean };
 
 const INITIAL_JOBS: ScheduleJob[] = [
-  { name: 'memory-reflector', cron: '0 */6 * * *', when: 'every 6 hours', next: 'in 2h', on: true },
+  { name: 'Memory reflector', cron: '0 */6 * * *', when: 'every 6 hours', next: 'in 2h', on: true },
   { name: 'Daily briefing', cron: '0 8 * * *', when: 'every day · 08:00', next: 'in 6h', on: true },
   {
     name: 'Weekly PR digest',

--- a/apps/web/src/features/session/composer/agent-selector.tsx
+++ b/apps/web/src/features/session/composer/agent-selector.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/command';
 import { cn } from '@/lib/utils';
 import type { Agent } from '@kortix/sdk/react';
-import { isMetaAgentName } from '@kortix/shared';
+import { capitalizeWords, isMetaAgentName } from '@kortix/shared';
 import { CaretDownIcon, CheckIcon, FolderSimpleIcon as MetaFolder } from '@phosphor-icons/react';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useState } from 'react';
@@ -84,7 +84,7 @@ export function AgentSelector({
   const showSearch = primaryAgents.length >= SEARCH_MIN_AGENTS;
 
   const currentAgent = primaryAgents.find((a) => a.name === selectedAgent) || primaryAgents[0];
-  const displayName = currentAgent?.name || 'Agent';
+  const displayName = currentAgent?.name ? capitalizeWords(currentAgent.name) : 'Agent';
   const metaSelected = isMetaAgentName(currentAgent?.name);
 
   /**
@@ -123,8 +123,8 @@ export function AgentSelector({
       >
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-1.5">
-            <span className="text-foreground truncate text-sm font-medium capitalize">
-              {agent.name}
+            <span className="text-foreground truncate text-sm font-medium">
+              {capitalizeWords(agent.name)}
             </span>
             {meta && (
               <Badge variant="outline" size="xs" className="shrink-0 font-normal">

--- a/apps/web/src/features/session/reasoning-effort-selector.tsx
+++ b/apps/web/src/features/session/reasoning-effort-selector.tsx
@@ -61,8 +61,8 @@ import {
   CellSignalLowIcon,
   CellSignalMediumIcon,
   CellSignalNoneIcon,
+  GaugeIcon,
 } from '@phosphor-icons/react';
-import { Kortix } from '../icon/icons/kortix';
 
 export interface ReasoningEffortModelKey {
   providerID: string;
@@ -182,12 +182,16 @@ function label(value: string): string {
  * (no `style={{ backgroundImage }}`).
  */
 /**
- * Cell-signal bars for effort — empty → full maps none/auto → max. Extra
- * ladder steps (`xhigh`, `max`) share Full; unknown ids fall back to Medium
- * so a future catalog value never renders without an icon.
+ * Cell-signal bars for effort — none → full ladder. Extra ladder steps
+ * (`xhigh`, `max`) share Full; unknown ids fall back to Medium so a future
+ * catalog value never renders without an icon.
  *
- * `max` / `full` paint the Kortix rainbow through the icon via
- * `mix-blend-destination-in` — `bg-clip-text` does not clip to SVG paths.
+ * `null`/`'auto'` (model decides, no project override) gets a Gauge icon
+ * instead of a cell-signal step — it isn't a fixed point on the none→full
+ * ladder, it's the dial that finds its own reading per turn. Reusing the
+ * Kortix brand mark here read as an unrelated "Kortix" button rather than a
+ * value on this control, and a generic sparkle is the same AI-chrome glyph
+ * used everywhere else in the product for unrelated things.
  *
  * A switch that returns JSX (not a component reference) — assigning
  * `const Icon = map[value]` and then `<Icon />` trips the React Compiler's
@@ -195,9 +199,9 @@ function label(value: string): string {
  */
 function EffortIcon({ value, className }: { value: string | null; className?: string }) {
   switch (value) {
-    case 'auto':
-      return <Kortix className={cn(className, 'size-4')} />;
     case null:
+    case 'auto':
+      return <GaugeIcon className={className} weight="bold" />;
     case 'none':
       return <CellSignalNoneIcon className={className} weight="fill" />;
     case 'low':
@@ -306,7 +310,7 @@ export function ReasoningEffortSelector({
               control would be a one-way door. */}
           <DropdownMenuRadioItem value={AUTO} disabled={pending}>
             <span className="flex items-center gap-2">
-              <Kortix className="size-4 shrink-0" />
+              <EffortIcon value={null} className="size-4 shrink-0" />
               Auto
             </span>
           </DropdownMenuRadioItem>

--- a/apps/web/src/features/session/tool/tools/session-spawn-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/session-spawn-tool.tsx
@@ -13,6 +13,7 @@ import {
   type MessageWithParts,
 } from '@/ui';
 import { useRuntimeMessages } from '@kortix/sdk/react';
+import { capitalizeWords } from '@kortix/shared';
 import { CpuIcon as Cpu, ArrowSquareOutIcon as ExternalLink } from '@phosphor-icons/react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
@@ -24,7 +25,7 @@ export function SessionSpawnTool({ part, forceOpen }: ToolProps) {
   const pathname = usePathname();
   const router = useRouter();
 
-  const agentName = (input.agent as string) || 'kortix';
+  const agentName = capitalizeWords((input.agent as string) || 'kortix');
   const description = (input.description as string) || '';
   const projectName = (input.project as string) || '';
   const fullPrompt = (input.prompt as string) || '';

--- a/apps/web/src/features/workspace/capabilities/agents/agents-page.tsx
+++ b/apps/web/src/features/workspace/capabilities/agents/agents-page.tsx
@@ -36,6 +36,7 @@ import {
   updateProjectDefaultAgent,
 } from '@kortix/sdk';
 import { contract, qk, useProjectAccountId } from '@kortix/sdk/react';
+import { capitalizeWords } from '@kortix/shared';
 import {
   MagnifyingGlassIcon,
   PlusIcon,
@@ -247,7 +248,7 @@ export function AgentsPage({ projectId }: { projectId: string }) {
         {filtered.map((agent) => (
           <CatalogCard
             key={agent.path}
-            title={agent.name}
+            title={capitalizeWords(agent.name)}
             description={agent.description}
             badges={<AgentCardBadges agent={agent} isDefault={defaultAgent === agent.name} />}
             onClick={() => setSelectedPath(agent.path)}
@@ -386,7 +387,7 @@ function DefaultAgentSelector({
   const mutation = useMutation({
     mutationFn: (agentName: string) => updateProjectDefaultAgent(projectId, agentName),
     onSuccess: async (result) => {
-      successToast(`${result.default_agent} is now the project default`);
+      successToast(`${capitalizeWords(result.default_agent)} is now the project default`);
       // One invalidation, not two: the project CONFIG is a `select` projection
       // over this same `qk.project.detail(id)` entry (`useProjectConfig`), not
       // its own fetch. The retired standalone `['project-config', id]` slot no
@@ -413,7 +414,7 @@ function DefaultAgentSelector({
         <SelectContent align="end">
           {availableAgents.map((agent) => (
             <SelectItem key={agent.name} value={agent.name}>
-              {agent.name}
+              {capitalizeWords(agent.name)}
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -130,7 +130,7 @@ import {
   useModelStore,
   useRuntimeMessages,
 } from '@kortix/sdk/react';
-import { chalkColors, formatRelativeTime } from '@kortix/shared';
+import { capitalizeWords, chalkColors, formatRelativeTime } from '@kortix/shared';
 import { UsersIcon as UsersSolid } from '@phosphor-icons/react';
 import { useTheme } from 'next-themes';
 
@@ -2057,7 +2057,9 @@ export function CommandPalette() {
                             <Bot className="size-5 shrink-0" />
                           </div>
                           <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-                            <span className="truncate text-sm font-medium">{agent.name}</span>
+                            <span className="truncate text-sm font-medium">
+                              {capitalizeWords(agent.name)}
+                            </span>
                             {agent.description && (
                               <span className="text-muted-foreground/50 truncate text-xs">
                                 {agent.description}
@@ -2100,7 +2102,7 @@ export function CommandPalette() {
                             )}
                           </div>
                           <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-                            <span className="truncate text-sm capitalize">{agent.name}</span>
+                            <span className="truncate text-sm">{capitalizeWords(agent.name)}</span>
                             {agent.description && (
                               <span className="text-muted-foreground/50 truncate text-xs">
                                 {agent.description}

--- a/packages/shared/src/utils/string.test.ts
+++ b/packages/shared/src/utils/string.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { truncateString } from './string';
+import { capitalizeWords, truncateString } from './string';
 
 describe('truncateString', () => {
   test('returns empty string for undefined input', () => {
@@ -46,5 +46,32 @@ describe('truncateString', () => {
 
   test('preserves the leading slice content when truncating', () => {
     expect(truncateString('abcdefghij', 3)).toBe('abc...');
+  });
+});
+
+describe('capitalizeWords', () => {
+  test('returns empty string unchanged', () => {
+    expect(capitalizeWords('')).toBe('');
+  });
+
+  test('capitalizes a single lowercase word', () => {
+    expect(capitalizeWords('kortix')).toBe('Kortix');
+  });
+
+  test('capitalizes each hyphen-separated segment', () => {
+    expect(capitalizeWords('harness-reflector')).toBe('Harness-Reflector');
+    expect(capitalizeWords('session-reviewer')).toBe('Session-Reviewer');
+  });
+
+  test('capitalizes each space-separated word', () => {
+    expect(capitalizeWords('customer support agent')).toBe('Customer Support Agent');
+  });
+
+  test('leaves an already-capitalized name unchanged', () => {
+    expect(capitalizeWords('Kortix')).toBe('Kortix');
+  });
+
+  test('leaves digits and internal casing alone, only touches word starts', () => {
+    expect(capitalizeWords('gpt5-agent')).toBe('Gpt5-Agent');
   });
 });

--- a/packages/shared/src/utils/string.ts
+++ b/packages/shared/src/utils/string.ts
@@ -13,3 +13,15 @@ export function truncateString(str?: string, maxLength = 50): string {
   if (str.length <= maxLength) return str;
   return str.slice(0, maxLength) + '...';
 }
+
+/**
+ * Capitalize the first letter of each whitespace- or hyphen-separated word.
+ * Mirrors CSS `text-transform: capitalize` as a real string transform, for
+ * contexts that can't apply CSS to get there (native `<select>` triggers,
+ * exported/copied text, accessible names) — e.g. turning a lowercase agent
+ * slug (`harness-reflector`) into a display name (`Harness-Reflector`).
+ */
+export function capitalizeWords(str: string): string {
+  if (!str) return str;
+  return str.replace(/(^|[\s-])([a-z])/g, (_match, sep: string, ch: string) => sep + ch.toUpperCase());
+}


### PR DESCRIPTION
## Summary
- Reasoning-effort "Auto" no longer reuses the Kortix brand mark, and the composer trigger no longer falls through to the "None" cell-signal icon (`current` is `null` for Auto, not the string `'auto'`) — both trigger and dropdown now render the same Gauge icon via `EffortIcon()`.
- Agent names are raw lowercase config identifiers (`kortix`, `harness-reflector`, `session-reviewer`, ...). Added `capitalizeWords()` to `@kortix/shared` (mirrors CSS `text-transform: capitalize` as a real string transform) and applied it everywhere an agent name renders as a label: the composer's agent-selector trigger + list, Customize > Agents cards + Default-agent picker (card grid, Select trigger/items, success toast), the global Cmd-K agent list (both primary and sub-agent groups), the sub-agent "spawn" tool chip, and the marketing homepage's interactive-demo mock data.

## Test plan
- [x] `bun test packages/shared/src/utils/string.test.ts` — 16/16 pass, incl. new `capitalizeWords` cases
- [x] `bun test apps/web/src/features/session/reasoning-effort-selector.test.ts` — 11/11 pass
- [x] `bun test` on command-palette + reasoning-effort-selector suites — 111/111 pass
- [x] `packages/shared`: `bun test` — 294/294 pass
- [x] `npx tsc --noEmit` on `apps/web` and `packages/shared` — no new errors in touched files
- [x] `npx eslint` on every touched file — 0 errors (only pre-existing unrelated warnings)
- [x] Verified live in a local worktree stack via chrome-devtools MCP: Auto shows a gauge icon consistently in both the reasoning-effort dropdown and its trigger; composer agent trigger shows "Kortix" / "Harness-Reflector" properly capitalized (confirmed in the accessibility tree, not just visually); Customize > Agents page shows "Harness-Reflector" / "Kortix" / "Session-Reviewer" cards and a "Kortix" Default-agent picker
