### PR TITLE
fix(web): unify "No second factor enrolled" alert tone + icon

### DIFF
--- a/apps/web/src/features/auth/mfa-step-up.tsx
+++ b/apps/web/src/features/auth/mfa-step-up.tsx
@@ -10,7 +10,10 @@
 // Members with NO enrolled factor get pointed at Settings → Security instead
 // of a dead-end code prompt.
 
-import { ShieldCheckIcon as ShieldCheck } from '@phosphor-icons/react';
+import {
+  ShieldCheckIcon as ShieldCheck,
+  ShieldWarningIcon as ShieldWarning,
+} from '@phosphor-icons/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 
@@ -123,7 +126,7 @@ export function MfaStepUpProvider({ children }: { children?: React.ReactNode }) 
               />
             </div>
           ) : (
-            <InfoBanner tone="warning" title="No second factor enrolled">
+            <InfoBanner tone="warning" icon={ShieldWarning} title="No second factor enrolled">
               Enroll an authenticator app under Settings → Security, then retry — this account
               blocks gated actions until your session is MFA-verified.
             </InfoBanner>

--- a/apps/web/src/features/workspace/settings/tabs/profile-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/profile-tab.tsx
@@ -21,7 +21,7 @@
  *   text on the right instead of swapping the row out for a paragraph.
  *
  * The factor list answers in four states and each one is visible: loading
- * (skeleton row), failed (red `InfoBanner` + Retry), empty (yellow "No second
+ * (skeleton row), failed (red `InfoBanner` + Retry), empty (orange "No second
  * factor enrolled" nudge), and populated (`FactorRow`s). A failed fetch never
  * borrows the empty-state copy — that copy asserts the account has no second
  * factor, which a failed fetch cannot know.
@@ -462,7 +462,9 @@ export function ProfileTabView({
             - it failed  → say so, in red, with a Retry. Never the empty-state
               copy: "No second factor enrolled" is a claim about the account,
               and a fetch that failed knows nothing about the account.
-            - it is empty → the enrollment nudge, in yellow.
+            - it is empty → the enrollment nudge, in orange ("needs attention"
+              per the design system's status-token table — matches the same
+              copy's tone in mfa-step-up.tsx's step-up dialog).
             - it has factors → nothing here; the rows above ARE the answer.
             Loading outranks both: an in-flight list has no answer yet. */}
         {!factorsLoading && factorsError ? (
@@ -479,7 +481,7 @@ export function ProfileTabView({
             Your two-factor settings are unchanged — this is only the list failing to load.
           </InfoBanner>
         ) : !factorsLoading && factors.length === 0 && !enrolling ? (
-          <InfoBanner tone="info" icon={ShieldWarning} title="No second factor enrolled">
+          <InfoBanner tone="warning" icon={ShieldWarning} title="No second factor enrolled">
             If your organization requires MFA, you’ll be blocked from gated actions until you enroll
             an authenticator here.
           </InfoBanner>


### PR DESCRIPTION
## Summary
- The MFA "No second factor enrolled" empty-state banner rendered `tone="info"` (kortix-yellow) on Settings → Profile → Security, but `tone="warning"` (kortix-orange) for the identical message in the MFA step-up dialog — same copy, two different colors depending on where a user saw it.
- The design system's own status-token table (`.claude/skills/kortix-design-system/SKILL.md`) classifies "needs attention" as `kortix-orange` and "pending/informational" as `kortix-yellow`. A blocking MFA nudge is the former, not the latter.
- The yellow tint also read washed-out/muddy in light mode (a pale khaki fill with low visual weight), compared to a crisper amber in dark mode — same token, different perceived contrast per theme.
- Unified both banners on `tone="warning"` and gave the step-up dialog's banner the same `ShieldWarning` icon the profile-tab banner already had (it previously had none), so the identical message now looks identical everywhere it appears.

## Screenshots
Before (light) — washed-out khaki, no icon parity between the two surfaces.
After (light/dark, both surfaces) — consistent amber warning with icon.

## Test plan
- [x] `npx eslint` on both changed files — 0 errors (1 pre-existing unrelated warning)
- [x] `npx tsc --noEmit` — clean on both changed files
- [x] `bun test profile-tab.test.tsx` — 16/16 pass
- [x] Verified live in a worktree dev stack (chrome-devtools MCP), both light and dark, on both surfaces:
  - Settings → Profile → Security → "No second factor enrolled" banner
  - MFA step-up dialog ("Verify it's you") triggered via the `kortix:mfa-required` event with a factorless test user
