### PR TITLE
docs: the egress pin survives a stop/resume — measured on both shim providers

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -517,3 +517,34 @@ the resolver returns one constant, so no size can reproduce 90,000 again.
 metric that counted it. `kortix.probe_timeout` was left pinned to false on
 every span — a dashboard built on it looks healthy by construction.
 *Incident:* PR #6473, merged `7e8a56badaef80374a189e0e427a08eb06b44697`.
+
+### A user-visible string is a shared resource; file ownership cuts through it (2026-08-18)
+
+**When:** any change that renames a label, error message, remedy or flag name —
+especially work split across parallel agents by file ownership.
+
+Renaming the network-boundary flag from "Network boundary without Platinum" to
+"Network boundary in-guest shim" touched EIGHT files: the feature-flag registry
+(which is what the Feature-flags screen actually renders), two route error
+bodies, a provisioning-error remedy, its test, two docs pages and the web
+constant. An agent that owned only the web file renamed it there and nowhere
+else. Nothing failed — no typecheck, no test, no lint — and the result would
+have shipped a UI telling users to turn on a flag by a name the screen never
+displays. The one guard that existed was a source-text assertion in a file the
+agent did not own, which is what eventually caught a sibling change.
+
+The rule: before renaming any user-visible string, grep the OLD string across
+the whole repo (`--include='*.ts' --include='*.tsx' --include='*.md'
+--include='*.mdx' --include='*.json'`) and change every hit in ONE commit. Then
+grep it again and expect zero. A partial rename is worse than no rename: the old
+name at least matched the UI.
+
+Corollary for parallel agents: **file ownership is the wrong boundary for a
+shared string.** Assign the whole rename to one agent, or do it yourself after
+the fan-out lands. Two other same-shaped catches in the same batch — a test
+pinning the exact `networkBoundaryEchoNotice(...)` call site, and one pinning
+the exact `sudo -u kortix --` invocation — both lived in files the changing
+agent did not own, and both only surfaced in CI. Reproducing CI's own command
+locally (`pnpm --filter ./packages/** --filter ./apps/** … test`) found them in
+one pass instead of one CI round-trip each.
+*Incident:* PR #6511, caught in review before merge; two CI round-trips spent.

--- a/docs/NETWORK_BOUNDARY_WITHOUT_PLATINUM.md
+++ b/docs/NETWORK_BOUNDARY_WITHOUT_PLATINUM.md
@@ -734,10 +734,44 @@ addresses, so a CIDR pin means trusting 1,524,736 addresses and an agent would
 exfiltrate through a Cloudflare Worker — while breaking git, npm and pip. It
 becomes worth building only behind a dedicated non-Cloudflare ingress.
 
+#### Does the pin survive a stop/resume? Measured — yes, on both shim providers
+
+The pin is first-write-wins and is never refreshed, and the measurement behind it
+was taken on two RUNNING boxes. Nobody had measured a stop/resume, which is the
+case that matters: if the address moves there is no reset path, so every broker
+call 403s for the rest of the session and the feature dies silently on any box
+that ever idles out.
+
+Measured black-box — record the guest's real egress address (an unruled host, so
+it tunnels blind rather than reporting the broker's), stop the session, start it,
+and re-run the identical boundary request:
+
+| provider | egress IP before → after | boundary before → after |
+| --- | --- | --- |
+| daytona (2 runs) | `185.26.9.249` → same, `67.213.119.5` → same | WORKS → WORKS |
+| e2b (2 runs) | `35.247.62.198` → same, `136.66.235.121` → same | WORKS → WORKS |
+
+Same sandbox id each time, so this measures a resume and not a fresh box. E2B is
+the interesting half: it pauses by construction (`onTimeout: pause`,
+`keepMemory: false`, `autoResume: false`) and cold-resumes, and it is also where
+the sealed runtime env has to be re-opened — so these runs double as proof that
+sealing did not break resume.
+
+**The trap this nearly fell into.** A resumed box answers the API as `running`
+before its guest network is up, and a probe then returns EMPTY — which reads
+exactly like a refused pin. One run reported BROKEN for that reason alone. The
+harness now gates on a CONTROL fetch of an unruled host and reports
+INCONCLUSIVE rather than BROKEN when the guest itself cannot reach anything: an
+absent reading is a failed read, never evidence of a move. Without that gate the
+measurement produces a confident false positive and sends someone to fix a
+non-bug.
+
 #### Still open
 
-- **The e2b live run.** Same code, same flag, never executed against an e2b sandbox. Until it
-  is, §7.7 proves the property on one provider rather than on the class.
+- **E2B in a deployed environment.** The e2b live run is DONE (17/0, identical to daytona), but
+  it needed a locally-run API holding `E2B_API_KEY`, because e2b appears in no `infra/terraform`
+  environment — neither dev nor prod can reach an e2b sandbox. The property is proven on the
+  class; what is missing is somewhere deployed to exercise it.
 - **Allow-list survival across resume / CoW-restore** — the funnel must not open on restore.
   Not required for the security property (an agent that bypasses the shim gets an
   UNAUTHENTICATED request, never a credential), so this is egress restriction, a separate


### PR DESCRIPTION
Closes the one gap I named when [#6511](https://github.com/kortix-ai/suna/pull/6511) merged: the egress pin is first-write-wins, never refreshed, has no reset path, and its justifying measurement was taken on two **running** boxes. Nobody had measured a stop/resume — the case that matters, because if the address moves every broker call `403`s for the rest of the session and the feature dies silently on any box that idles out.

## Measured — it survives

Black-box, so it measures the consequence and not just the number: record the guest's real egress address (via an unruled host, so it tunnels blind and reports the box rather than the broker), stop the session, start it, re-run the identical boundary request.

| provider | egress IP before → after | boundary before → after |
| --- | --- | --- |
| daytona (2 runs) | `185.26.9.249` → same, `67.213.119.5` → same | WORKS → WORKS |
| e2b (2 runs) | `35.247.62.198` → same, `136.66.235.121` → same | WORKS → WORKS |

Same sandbox id every run, so this is a resume and not a fresh box. **E2B is the interesting half** — it pauses by construction (`onTimeout: pause`, `keepMemory: false`, `autoResume: false`) and cold-resumes, and it is also where #6511's sealed runtime env has to be re-opened. So those runs double as live proof that sealing did not break resume, which was the riskiest thing in that PR.

No code change needed. The re-pin path I sketched as a contingency is not required for this path.

## The trap, recorded because it produced a confident wrong answer

A resumed box answers the API as `running` before its guest network is up, and a probe then returns **empty** — which reads exactly like a refused pin. One run reported BROKEN on that basis alone, and I nearly wrote up "the pin breaks the feature across a resume."

The harness now gates on a CONTROL fetch of an unruled host and reports INCONCLUSIVE rather than BROKEN when the guest cannot reach anything at all. An absent reading is a failed read, never evidence of a move. Same correction applied to the IP comparison, which had called an empty second reading "MOVED".

## Also: a learnings entry

A user-visible string is a shared resource, and file ownership cuts straight through it. During #6511 an agent owning one file renamed a flag label that lives in eight — no typecheck, test or lint covers a partial rename, and it would have shipped a UI telling users to enable a flag by a name the screen never renders. Two sibling catches had the same shape (tests pinning an exact call site and an exact `sudo` invocation, both in files the changing agent did not own). Reproducing CI's own command locally found them in one pass instead of one round-trip each.

Docs only.