### PR TITLE
fix(web): stop the animated logo splash on account/group navigation

### DIFF
--- a/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/loading.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/loading.tsx
@@ -1,0 +1,43 @@
+/**
+ * Navigation Suspense boundary for /accounts/[id]/groups/[groupId].
+ *
+ * Same rationale as the sibling boundary at accounts/[id]/loading.tsx: without
+ * this file, the ancestor accounts/loading.tsx animated logo splash covers
+ * this route too, which reads as a jarring full-screen reset for what is
+ * really "open a group from the list". Mirrors GroupDetailPage's own header
+ * shell (back link, avatar, title, tab list) so the handover has no layout
+ * shift.
+ *
+ * Deliberately imports no icon set: @phosphor-icons/react's IconContext
+ * provider needs a Client Component boundary, and this file has to stay a
+ * Server Component (see project-loading equivalent) — a route `loading.tsx`
+ * that needed 'use client' would 500 with "createContext only works in
+ * Client Components" instead of rendering the fallback.
+ */
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function GroupDetailLoading() {
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-5 pb-10">
+      <div className="space-y-5">
+        <div className="flex w-fit items-center gap-1 text-sm">
+          <Skeleton className="size-4 rounded-sm" />
+          <Skeleton className="h-4 w-20 rounded-md" />
+        </div>
+
+        <div className="flex min-w-0 items-center gap-3.5">
+          <Skeleton className="size-10 rounded-md" />
+          <div className="min-w-0 space-y-0.5">
+            <Skeleton className="h-6 w-44" />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex w-full items-center justify-start gap-6 border-b pb-2.5">
+        <Skeleton className="h-4 w-16 rounded-md" />
+        <Skeleton className="h-4 w-16 rounded-md" />
+        <Skeleton className="h-4 w-16 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/accounts/[id]/loading.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/loading.tsx
@@ -1,0 +1,41 @@
+/**
+ * Navigation Suspense boundary for /accounts/[id].
+ *
+ * Without this file, the parent boundary at accounts/loading.tsx (the animated
+ * KortixHyperLogo splash) covers this segment and every descendant that lacks
+ * its own boundary — including groups/[groupId]. That splash is meant for the
+ * first cold load of the whole accounts tree, not for what reads to a user as
+ * an in-app tab switch (e.g. a project's Members page -> this account's
+ * Groups tab). Mirrors the shell accounts/[id]/page.tsx already paints for its
+ * own accountQuery.isLoading state, so the handover to the real page has no
+ * layout shift.
+ */
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function AccountDetailLoading() {
+  return (
+    <div className="mx-auto w-full max-w-6xl pb-10">
+      <div className="lg:grid lg:grid-cols-[208px_minmax(0,1fr)] lg:gap-12">
+        <div className="mb-6 space-y-4 lg:mb-0">
+          <div className="flex items-center gap-2.5">
+            <Skeleton className="size-8 rounded-md" />
+            <Skeleton className="h-5 w-32 rounded-md" />
+          </div>
+          <div className="space-y-1">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-full rounded-md" />
+            ))}
+          </div>
+        </div>
+        <div className="max-w-3xl space-y-4">
+          <Skeleton className="h-7 w-40 rounded-md" />
+          <div className="space-y-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-[58px] w-full rounded-md" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `accounts/loading.tsx` was the only Suspense boundary in the whole `accounts/` route tree, so navigating from a project's Members page into an account's Groups tab or a group's detail page — a different top-level route segment — tripped the full-screen animated `KortixHyperLogo` splash meant for a cold load.
- Adds lightweight per-segment `loading.tsx` skeletons for `accounts/[id]` and `accounts/[id]/groups/[groupId]` that mirror each page's own layout (same pattern `projects/[id]/loading.tsx` already uses), so the transition reads as a tab switch instead of a full-screen reset.

## Test plan
- [x] `npx eslint` on both new files — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] Local browser verification (chrome-devtools MCP) against a seeded test account: navigated from a project's Members settings page into the account's Groups tab and into an individual group's detail page. First pass caught a real bug — the group `loading.tsx` imported `@phosphor-icons/react` icons, which require a Client Component (`createContext` runtime error) while route `loading.tsx` files are Server Components by default. Fixed by dropping the icon imports in favor of plain skeleton blocks, matching `projects/[id]/loading.tsx`'s "import nothing" pattern. Re-verified clean after the fix — both pages render without error and match their real page's layout.