### PR TITLE
feat(web): assign a custom role from inside a group, clarify Agent copy

### DIFF
--- a/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
@@ -113,6 +113,9 @@ export default function GroupDetailPage() {
   const accountId = params?.id;
   const groupId = params?.groupId;
   const { user, isLoading: authLoading } = useAuth();
+  // Controlled so the "give a custom role" empty state can jump straight to
+  // the Projects tab (where built-in roles are actually assigned to a group).
+  const [activeGroupTab, setActiveGroupTab] = useState('members');
 
   const accountQuery = useQuery({
     queryKey: ['account', accountId],
@@ -213,7 +216,7 @@ export default function GroupDetailPage() {
       ) : null}
 
       {group && account ? (
-        <Tabs defaultValue="members" className="space-y-6">
+        <Tabs value={activeGroupTab} onValueChange={setActiveGroupTab} className="space-y-6">
           <TabsList type="underline" className="flex w-full items-center justify-start">
             <TabsTrigger value="members" className="w-fit flex-none">
               Members
@@ -235,6 +238,7 @@ export default function GroupDetailPage() {
               canAssignRoles={canAssignRoles}
               rbacEnabled={rbacEnabled}
               idpManaged={group.source === 'scim'}
+              onOpenBuiltinRolePath={() => setActiveGroupTab('projects')}
             />
           </TabsContent>
 
@@ -274,6 +278,7 @@ function GroupMembersCard({
   canAssignRoles,
   rbacEnabled,
   idpManaged,
+  onOpenBuiltinRolePath,
 }: {
   accountId: string;
   groupId: string;
@@ -287,6 +292,10 @@ function GroupMembersCard({
   /** SCIM-sourced group: membership is owned by the IdP — the API 409s local
    *  edits (they'd be clobbered by the next push), so hide the affordances. */
   idpManaged: boolean;
+  /** Jump to the Projects tab, where a built-in role (Manager/Editor/Member)
+   *  is actually attached to this group — surfaced from the assignment
+   *  dialog's empty state when there are no custom roles to pick from. */
+  onOpenBuiltinRolePath: () => void;
 }) {
   // Local membership edits only make sense for locally-owned groups.
   const canMutate = canManage && !idpManaged;
@@ -521,6 +530,7 @@ function GroupMembersCard({
         projects={projectsQuery.data ?? []}
         projectsLoading={projectsQuery.isLoading}
         presetPrincipal={{ type: 'group', id: groupId, label: groupName }}
+        onOpenBuiltinRolePath={onOpenBuiltinRolePath}
         onCreated={() => {
           queryClient.invalidateQueries({ queryKey: ['iam-policies', accountId] });
           setAssignRoleOpen(false);

--- a/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
@@ -4,6 +4,7 @@ import {
   CaretLeftIcon as ChevronLeft,
   FolderOpenIcon as FolderOpen,
   PlusIcon as Plus,
+  ShieldIcon as Shield,
   TrashIcon as Trash2,
   UsersIcon as Users,
 } from '@phosphor-icons/react';
@@ -21,10 +22,12 @@ import {
   sortGroupMembersByOverride,
   type AccountMeta,
 } from '@/components/iam/iam-display-helpers';
+import { CreateAssignmentDialog } from '@/components/iam/policy-assignments';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { EntityAvatar } from '@/components/ui/entity-avatar';
+import Hint from '@/components/ui/hint';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { Input } from '@/components/ui/input';
@@ -53,12 +56,14 @@ import { UserAvatar } from '@/components/ui/user-avatar';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { useAuth } from '@/features/providers/auth-provider';
+import { useAccountState } from '@/hooks/billing';
 import {
   addGroupMembers,
   deleteGroup,
   getGroup,
   listGroupMembers,
   listGroupProjectGrants,
+  listRoles,
   removeGroupMember,
   updateGroup,
   type GroupProjectGrant,
@@ -74,6 +79,12 @@ import {
   type ProjectRole,
 } from '@kortix/sdk';
 import { contract, qk } from '@kortix/sdk/react';
+
+// Same wording the backend's requireEntitlement('rbac') 402 uses — keep it in
+// sync with apps/api/src/accounts/iam/helpers.ts ENTITLEMENT_LABEL.rbac and
+// the duplicate in roles-tab.tsx / policy-assignments.tsx.
+const RBAC_UPSELL_MESSAGE =
+  'Custom roles, policies, and groups are available on the Enterprise plan. Contact sales to enable it.';
 
 // Entity row dialect shared with the customize section views.
 const MEMBER_ROW = 'bg-popover flex items-center gap-3 rounded-md border px-4 py-2.5';
@@ -132,6 +143,12 @@ export default function GroupDetailPage() {
     resourceType: 'group',
     resourceId: groupId,
   }).allowed;
+  // Same gate the account Roles tab uses (role.create) — assigning a role to
+  // this group is the same capability, just reached from the group page.
+  const canAssignRoles = usePermission(accountId, 'role.create').allowed;
+
+  const accountStateQuery = useAccountState({ accountId, enabled: !!user && !!accountId });
+  const rbacEnabled = !!accountStateQuery.data?.tier?.entitlements?.rbac;
 
   if (authLoading || !user) {
     return <ConnectingScreen forceConnecting overrideStage="auth" hideWorkspacePicker />;
@@ -213,7 +230,10 @@ export default function GroupDetailPage() {
             <GroupMembersCard
               accountId={account.account_id}
               groupId={group.group_id}
+              groupName={group.name}
               canManage={canManageMembers}
+              canAssignRoles={canAssignRoles}
+              rbacEnabled={rbacEnabled}
               idpManaged={group.source === 'scim'}
             />
           </TabsContent>
@@ -249,12 +269,21 @@ export default function GroupDetailPage() {
 function GroupMembersCard({
   accountId,
   groupId,
+  groupName,
   canManage,
+  canAssignRoles,
+  rbacEnabled,
   idpManaged,
 }: {
   accountId: string;
   groupId: string;
+  groupName: string;
   canManage: boolean;
+  /** Gates the "Give a custom role" action — the role.create capability,
+   *  same as the account Roles tab. Independent of canManage (membership). */
+  canAssignRoles: boolean;
+  /** Whether the account's tier carries the `rbac` entitlement. */
+  rbacEnabled: boolean;
   /** SCIM-sourced group: membership is owned by the IdP — the API 409s local
    *  edits (they'd be clobbered by the next push), so hide the affordances. */
   idpManaged: boolean;
@@ -263,7 +292,21 @@ function GroupMembersCard({
   const canMutate = canManage && !idpManaged;
   const queryClient = useQueryClient();
   const [addOpen, setAddOpen] = useState(false);
+  const [assignRoleOpen, setAssignRoleOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<string | null>(null);
+
+  // Same query keys PolicyAssignments/RolesTab use — shares the cache instead
+  // of double-fetching when an admin has visited the account Roles tab too.
+  const rolesQuery = useQuery({
+    queryKey: ['iam-roles', accountId],
+    queryFn: () => listRoles(accountId),
+    staleTime: 30_000,
+  });
+  const projectsQuery = useQuery({
+    queryKey: ['account-projects', accountId],
+    queryFn: () => listProjectsForAccount(accountId),
+    staleTime: 30_000,
+  });
 
   const membersQuery = useQuery({
     queryKey: ['group-members', accountId, groupId],
@@ -334,17 +377,44 @@ function GroupMembersCard({
               : 'Members of this group inherit every policy attached to it.'}
           </p>
         </div>
-        {canMutate ? (
-          <Button
-            size="sm"
-            variant="secondary"
-            className="gap-1.5"
-            onClick={() => setAddOpen(true)}
-          >
-            <Plus className="size-4" />
-            Add members
-          </Button>
-        ) : null}
+        <div className="flex items-center gap-2">
+          {canAssignRoles ? (
+            rbacEnabled ? (
+              <Button
+                size="sm"
+                variant="outline"
+                className="gap-1.5"
+                onClick={() => setAssignRoleOpen(true)}
+              >
+                <Shield className="size-4" />
+                Give a custom role
+              </Button>
+            ) : (
+              <Hint label={RBAC_UPSELL_MESSAGE} side="top" className="max-w-xs">
+                <span className="inline-flex items-center gap-1.5">
+                  <Button size="sm" variant="outline" className="gap-1.5" disabled>
+                    <Shield className="size-4" />
+                    Give a custom role
+                  </Button>
+                  <Badge variant="outline" size="sm">
+                    Enterprise
+                  </Badge>
+                </span>
+              </Hint>
+            )
+          ) : null}
+          {canMutate ? (
+            <Button
+              size="sm"
+              variant="secondary"
+              className="gap-1.5"
+              onClick={() => setAddOpen(true)}
+            >
+              <Plus className="size-4" />
+              Add members
+            </Button>
+          ) : null}
+        </div>
       </div>
 
       {membersQuery.isLoading ? (
@@ -436,6 +506,25 @@ function GroupMembersCard({
         groupId={groupId}
         existingUserIds={new Set(members.map((m) => m.user_id))}
         candidates={accountMembersQuery.data ?? []}
+      />
+
+      <CreateAssignmentDialog
+        accountId={accountId}
+        open={assignRoleOpen}
+        onOpenChange={setAssignRoleOpen}
+        roles={rolesQuery.data ?? []}
+        rolesLoading={rolesQuery.isLoading}
+        members={[]}
+        groups={[{ group_id: groupId, name: groupName }]}
+        agents={[]}
+        serviceAccounts={[]}
+        projects={projectsQuery.data ?? []}
+        projectsLoading={projectsQuery.isLoading}
+        presetPrincipal={{ type: 'group', id: groupId, label: groupName }}
+        onCreated={() => {
+          queryClient.invalidateQueries({ queryKey: ['iam-policies', accountId] });
+          setAssignRoleOpen(false);
+        }}
       />
 
       <ConfirmDialog

--- a/apps/web/src/components/iam/policy-assignments.tsx
+++ b/apps/web/src/components/iam/policy-assignments.tsx
@@ -398,7 +398,16 @@ export function PolicyAssignments({ accountId, canManage, rbacEnabled }: PolicyA
 type PrincipalType = 'member' | 'group' | 'token';
 type ScopeType = 'account' | 'project';
 
-function CreateAssignmentDialog({
+/** A principal already known by the caller — e.g. a group page assigning a
+ * role to the group it's showing. Skips the principal-type + entity pickers
+ * and binds straight to this identity. */
+export interface AssignmentPrincipalPreset {
+  type: 'group';
+  id: string;
+  label: string;
+}
+
+export function CreateAssignmentDialog({
   accountId,
   open,
   onOpenChange,
@@ -411,6 +420,7 @@ function CreateAssignmentDialog({
   projects,
   projectsLoading,
   onCreated,
+  presetPrincipal,
 }: {
   accountId: string;
   open: boolean;
@@ -424,11 +434,16 @@ function CreateAssignmentDialog({
   projects: KortixProject[];
   projectsLoading: boolean;
   onCreated: () => void;
+  /** Pre-bind the principal (e.g. a group already open on screen) and hide
+   * the principal-type/entity pickers so the dialog is just role + scope. */
+  presetPrincipal?: AssignmentPrincipalPreset;
 }) {
   // `service_account` is a UI-only principal type — a standalone (non-agent)
   // service account. It maps to the backend `token` principal on submit.
-  const [principalType, setPrincipalType] = useState<PrincipalType | 'service_account'>('member');
-  const [principalId, setPrincipalId] = useState('');
+  const [principalType, setPrincipalType] = useState<PrincipalType | 'service_account'>(
+    presetPrincipal?.type ?? 'member',
+  );
+  const [principalId, setPrincipalId] = useState(presetPrincipal?.id ?? '');
   const [roleId, setRoleId] = useState('');
   const [scopeType, setScopeType] = useState<ScopeType>('account');
   const [projectId, setProjectId] = useState('');
@@ -438,8 +453,8 @@ function CreateAssignmentDialog({
   const customRoles = useMemo(() => roles.filter((r) => !r.is_system), [roles]);
 
   function reset() {
-    setPrincipalType('member');
-    setPrincipalId('');
+    setPrincipalType(presetPrincipal?.type ?? 'member');
+    setPrincipalId(presetPrincipal?.id ?? '');
     setRoleId('');
     setScopeType('account');
     setProjectId('');
@@ -487,49 +502,61 @@ function CreateAssignmentDialog({
     >
       <ModalContent className="max-h-[90vh] lg:max-h-[85vh] lg:max-w-md">
         <ModalHeader>
-          <ModalTitle>Give a custom role</ModalTitle>
+          <ModalTitle>
+            {presetPrincipal ? `Give ${presetPrincipal.label} a custom role` : 'Give a custom role'}
+          </ModalTitle>
           <ModalDescription>
-            Give one of your custom roles to a person, group, or agent — for the whole account, or
-            just one project.
+            {presetPrincipal
+              ? `Bind ${presetPrincipal.label} to a custom role at a scope.`
+              : 'Give one of your custom roles to a person, group, or agent — for the whole account, or just one project.'}
           </ModalDescription>
         </ModalHeader>
 
         <ModalBody className="max-h-[60vh] space-y-4 overflow-y-auto">
-          <div className="space-y-1.5">
-            <Label htmlFor="assignment-principal-type">Who is this for?</Label>
-            <Select
-              value={principalType}
-              onValueChange={(v) => {
-                const next = v as PrincipalType;
-                setPrincipalType(next);
-                setPrincipalId('');
-                // Agents are project-scoped — switch to project scope and make
-                // the admin pick the project FIRST, then its agents. Member /
-                // group default back to account scope.
-                if (next === 'token') {
-                  setScopeType('project');
-                } else {
-                  setScopeType('account');
-                }
-                setProjectId('');
-              }}
-              disabled={mutation.isPending}
-            >
-              <SelectTrigger id="assignment-principal-type">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="member">Member</SelectItem>
-                <SelectItem value="group">Group</SelectItem>
-                {/* token = a service-account / agent standing identity. Assigning
-                    a role here promotes the agent to a standing teammate. */}
-                <SelectItem value="token">Agent</SelectItem>
-                {/* Standalone service account — a CI/CD / integration machine
-                    identity (no agent). Backend principal is also `token`. */}
-                <SelectItem value="service_account">Service account</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          {presetPrincipal ? null : (
+            <div className="space-y-1.5">
+              <Label htmlFor="assignment-principal-type">Who is this for?</Label>
+              <Select
+                value={principalType}
+                onValueChange={(v) => {
+                  const next = v as PrincipalType;
+                  setPrincipalType(next);
+                  setPrincipalId('');
+                  // Agents are project-scoped — switch to project scope and make
+                  // the admin pick the project FIRST, then its agents. Member /
+                  // group default back to account scope.
+                  if (next === 'token') {
+                    setScopeType('project');
+                  } else {
+                    setScopeType('account');
+                  }
+                  setProjectId('');
+                }}
+                disabled={mutation.isPending}
+              >
+                <SelectTrigger id="assignment-principal-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="member">Member</SelectItem>
+                  <SelectItem value="group">Group</SelectItem>
+                  {/* token = a standing service identity: an Agent (lives inside a
+                      project) or a standalone Service account (CI/CD, no agent).
+                      Assigning a role here makes it act with that access on its
+                      own, the same as any human teammate. */}
+                  <SelectItem value="token">Agent</SelectItem>
+                  <SelectItem value="service_account">Service account</SelectItem>
+                </SelectContent>
+              </Select>
+              {principalType === 'token' || principalType === 'service_account' ? (
+                <p className="text-muted-foreground text-xs">
+                  {principalType === 'token'
+                    ? "A role here binds to the agent's own standing identity — it acts with that access on its own, the same as a human teammate."
+                    : 'A standalone machine identity (CI/CD, integrations) with no human or agent behind it.'}
+                </p>
+              ) : null}
+            </div>
+          )}
 
           {/* Agents live IN a project — pick the project first, then its agents. */}
           {principalType === 'token' && (
@@ -567,6 +594,14 @@ function CreateAssignmentDialog({
             </div>
           )}
 
+          {presetPrincipal ? (
+            <div className="space-y-1.5">
+              <Label>Group</Label>
+              <div className="border-input bg-muted/40 flex h-9 items-center rounded-md border px-3 text-sm">
+                {presetPrincipal.label}
+              </div>
+            </div>
+          ) : (
           <div className="space-y-1.5">
             <Label htmlFor="assignment-principal">
               {principalType === 'member'
@@ -661,6 +696,7 @@ function CreateAssignmentDialog({
               </SelectContent>
             </Select>
           </div>
+          )}
 
           <div className="space-y-1.5">
             <Label htmlFor="assignment-role">Role</Label>

--- a/apps/web/src/components/iam/policy-assignments.tsx
+++ b/apps/web/src/components/iam/policy-assignments.tsx
@@ -8,6 +8,7 @@
 import { errorToast, successToast } from '@/components/ui/toast';
 import { PlusIcon as Plus, ShieldIcon as Shield, TrashIcon as Trash2 } from '@phosphor-icons/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
@@ -421,6 +422,7 @@ export function CreateAssignmentDialog({
   projectsLoading,
   onCreated,
   presetPrincipal,
+  onOpenBuiltinRolePath,
 }: {
   accountId: string;
   open: boolean;
@@ -437,6 +439,10 @@ export function CreateAssignmentDialog({
   /** Pre-bind the principal (e.g. a group already open on screen) and hide
    * the principal-type/entity pickers so the dialog is just role + scope. */
   presetPrincipal?: AssignmentPrincipalPreset;
+  /** Only used with presetPrincipal: jump to wherever this principal's
+   * built-in role actually gets assigned (e.g. a group's Projects tab),
+   * surfaced from the empty-state when the account has no custom roles yet. */
+  onOpenBuiltinRolePath?: () => void;
 }) {
   // `service_account` is a UI-only principal type — a standalone (non-agent)
   // service account. It maps to the backend `token` principal on submit.
@@ -703,7 +709,42 @@ export function CreateAssignmentDialog({
             {rolesLoading ? (
               <p className="text-muted-foreground text-xs">Loading roles…</p>
             ) : customRoles.length === 0 ? (
-              <p className="text-muted-foreground text-xs">Create a custom role first.</p>
+              <div className="border-border bg-muted/30 space-y-2 rounded-md border border-dashed p-3">
+                <p className="text-muted-foreground text-xs">
+                  This account has no custom roles yet. Custom roles are an additive layer on top
+                  of built-in roles (Owner, Admin, Manager, Editor, Member) — for a built-in role,
+                  assign it directly instead of through this dialog.
+                </p>
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  {presetPrincipal && onOpenBuiltinRolePath ? (
+                    <button
+                      type="button"
+                      className="text-foreground text-xs font-medium underline underline-offset-2"
+                      onClick={() => {
+                        onOpenBuiltinRolePath();
+                        onOpenChange(false);
+                      }}
+                    >
+                      Open Projects tab
+                    </button>
+                  ) : !presetPrincipal ? (
+                    <Link
+                      href={`/accounts/${accountId}?tab=members`}
+                      className="text-foreground text-xs font-medium underline underline-offset-2"
+                      onClick={() => onOpenChange(false)}
+                    >
+                      Open Members tab
+                    </Link>
+                  ) : null}
+                  <Link
+                    href={`/accounts/${accountId}?tab=roles`}
+                    className="text-foreground text-xs font-medium underline underline-offset-2"
+                    onClick={() => onOpenChange(false)}
+                  >
+                    Create a custom role
+                  </Link>
+                </div>
+              </div>
             ) : (
               <Select value={roleId} onValueChange={setRoleId} disabled={mutation.isPending}>
                 <SelectTrigger id="assignment-role">


### PR DESCRIPTION
## Summary
- **Group detail page** (`accounts/[id]/groups/[groupId]`): adds a "Give a custom role" action to the Members tab toolbar. Opens the existing account-level assignment dialog pre-bound to that group (principal locked, no need to re-pick it), so assigning a role to a group no longer requires leaving the group page for the account's separate Roles tab. Gated on the same `role.create` permission + `rbac` entitlement the Roles tab already uses.
- **`CreateAssignmentDialog`** (`policy-assignments.tsx`) gains an optional `presetPrincipal` prop. When set: the principal-type/entity pickers are replaced with a static "Group: `<name>`" line, and copy switches to "Give `<name>` a custom role". The unlocked path (existing dialog from the Roles tab) is unchanged.
- **Agent clarity**: the assign-role dialog now shows a visible helper line when Agent/Service account is selected ("A role here binds to the agent's own standing identity — it acts with that access on its own, the same as a human teammate."), so the option reads as intentional rather than a stray addition mixed in with human members.
- **Built-in vs. custom role dead-end fixed**: when an account has zero custom roles, the Role picker used to show a dead "Create a custom role first." with no path forward — confusing, because built-in roles (Owner/Admin/Manager/Editor/Member) are NOT assignable through this dialog by design (the backend rejects built-in role ids: `custom-roles.ts:825-827`, "built-in roles are assigned via project members/groups, not policies"). Replaced with an explanation plus two working exits: jump straight to wherever the principal's built-in role actually gets assigned (the group's Projects tab when opened from a group — its Tabs is now controlled so this can switch tabs programmatically — or the account's Members tab otherwise), or go create a custom role.

## Context
Follow-up to a live walkthrough of `dev.kortix.com`'s account/groups pages. Confirmed via code read that Agent-as-role-principal is a deliberate, fully modeled feature (not a bug), and that the custom-vs-built-in role split is intentional and backend-enforced — this PR only adds the missing explanation and working exits in the UI, no behavior change to what's assignable where.

Rebased onto latest `main` after a concurrent, unrelated refactor landed there: the project-scoped "Assign a custom role" dialog in `members-tab.tsx` was removed and consolidated into this same account-level `CreateAssignmentDialog` (which already supports project scope), and the modal's copy was independently updated ("New assignment" → "Give a custom role", "Principal type" → "Who is this for?"). Both are reflected here; no separate members-tab.tsx changes remain since that dialog no longer exists.

## Test plan
- [x] `npx eslint` on all changed files — 0 errors (pre-existing unrelated warnings only).
- [x] `npx tsc --noEmit` — clean.
- [x] Local browser verification (chrome-devtools MCP) end-to-end against seeded test accounts with RBAC enabled, across 3 rounds (including a full re-verify after the rebase):
  - Group Members tab → "Give a custom role" opens pre-locked to that group; submit succeeds and the resulting policy shows up correctly on both the account Roles tab and (pre-consolidation) the project's Access tab.
  - Original unlocked dialog (Member/Group/Agent/Service account picker) unaffected.
  - Agent helper copy renders correctly when Agent is selected, no layout issues.
  - Empty-state (zero custom roles): verified both variants — "Open Projects tab" (group-preset, actually switches the group page's tab and closes the dialog) and "Open Members tab" (account-level, real link to `?tab=members`) plus "Create a custom role" (`?tab=roles`) in both contexts.