### PR TITLE
fix(daemon): do not arm the in-guest shim where a provider edge owns the destination

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/egress-shim/rules.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/rules.ts
@@ -78,6 +78,19 @@ export function parseShimRules(raw: string | undefined): ShimBrokerRule[] {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
     const item = entry as Record<string, unknown>
     if (item.delivery !== 'network') continue
+    // `on_echo` is the API's statement of WHICH mechanism owns this
+    // destination, and it is the only one the guest gets: 'redact' means the
+    // shim relays and the broker injects, 'block' means the provider's own
+    // credential edge does it outside the sandbox.
+    //
+    // Skipping 'block' is not an optimisation. Measured on a Platinum session
+    // with the project flag OFF: the shim armed anyway (the flag gates the API
+    // half, never the daemon), so the guest ran a TLS-terminating proxy on a
+    // provider whose whole property is that nothing runs in the guest — and
+    // the agent, told `on_echo: 'block'`, got a 200 with [REDACTED] instead of
+    // the cut connection it was promised. Same credential either way; the
+    // wrong mechanism, and guidance that describes the other one.
+    if (item.on_echo === 'block') continue
     if (typeof item.identifier !== 'string' || !IDENTIFIER_RE.test(item.identifier)) continue
     if (!Array.isArray(item.hosts)) continue
 

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/shim.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/shim.test.ts
@@ -333,6 +333,24 @@ describe('rules are derived from what the guest already has', () => {
     ])
   })
 
+  test("a destination the provider's own edge owns is left alone", () => {
+    // on_echo is the only signal the guest gets for WHICH mechanism injects.
+    // 'block' means an edge outside the sandbox does it, so arming here would
+    // put a TLS-terminating proxy in a guest that is not supposed to have one
+    // and hand the agent the other mechanism's symptom. Measured on Platinum
+    // with the project flag off, where the shim armed and returned [REDACTED]
+    // to an agent that had been told to expect a cut connection.
+    expect(parseShimRules(caps({ on_echo: 'block' }))).toEqual([])
+  })
+
+  test('a destination the shim owns still arms', () => {
+    // The positive half — without it the assertion above passes for a parser
+    // that returns nothing at all.
+    expect(parseShimRules(caps({ on_echo: 'redact' }))).toEqual([
+      { hosts: ['api.example.com'], identifier: 'DEMO_TOKEN' },
+    ])
+  })
+
   test('non-network deliveries are ignored', () => {
     const raw = JSON.stringify({
       version: 1,


### PR DESCRIPTION
Found by running the full secret-type sweep on **Platinum** on dev, which is the first time that combination was exercised end to end.

## What happens today

A Platinum session with `network_boundary_shim` **OFF** — i.e. a project that never opted into the shim:

```
KORTIX_SECRET_CAPABILITIES -> {"identifier":"BOUNDARY_SECRET","delivery":"network",...,"on_echo":"block"}
CA=yes
PROXY=http://127.0.0.1:4321
curl https://postman-echo.com/get -> {"headers":{"x-all":"Bearer [REDACTED]", ...}}
```

Two things are wrong:

1. **A TLS-terminating proxy is running in the guest**, with its own CA, on the one provider whose entire property is that nothing runs in the guest. The project never asked for it — the flag gates the *API* half, and the daemon only ever filtered on `delivery === 'network'`.
2. **The agent is told the opposite of what happens.** It receives `on_echo: 'block'` (expect a cut connection) and gets a `200` containing `[REDACTED]`. This is the same inverted-symptom failure as the web copy fixed in #6511, in the other direction.

The credential is still never in the guest either way, so this is correctness and least-privilege, not a leak. But which mechanism serves a request should not depend on a flag the daemon cannot see.

## The fix

`on_echo` already carries the answer — it is the API's statement of which mechanism owns the destination (`apps/api/src/projects/secret-capabilities.ts`). `parseShimRules` now skips entries marked `'block'`.

No new plumbing, and backward compatible: an absent `on_echo` (older API) still arms, so this narrows only the case the API explicitly marks edge-owned.

## Not a regression from #6511

Pre-existing since the original shim commit `1d82cd2735`. #6511 added mid-session arming; the boot-time arm that produces this was always unconditional.

## Verification

- Daemon suite: **646 pass / 0 fail**, typecheck clean.
- Two new tests, and deliberately a matched pair — `on_echo: 'block'` yields no rules, `'redact'` still yields the rule. Without the positive half the first assertion would pass for a parser that returns nothing at all.
- Daytona is unaffected: its capabilities carry `on_echo: 'redact'`, which is exactly the live behaviour measured in the 24/24 sweep.

**Live verification needs a new sandbox image.** The daemon is baked in, so this cannot be proven on dev in the same cycle — the API half of a split control goes live immediately and the daemon half arrives with the next image (see the learnings entry on split API/daemon controls). The Platinum sweep should go from 22/1 to 23/0 once an image carrying this exists.