### PR TITLE
enh(web): rework the public share page chrome

### DIFF
--- a/apps/web/src/app/(public)/share/session/[token]/page.tsx
+++ b/apps/web/src/app/(public)/share/session/[token]/page.tsx
@@ -1,26 +1,27 @@
 'use client';
 
 import {
+  ArrowsInSimpleIcon as ArrowsInSimple,
+  ArrowsOutSimpleIcon as ArrowsOutSimple,
+  DownloadIcon as Download,
   ArrowSquareOutIcon as ExternalLink,
-  FileTextIcon as FileText,
-  GlobeIcon as Globe,
-  SignInIcon as LogIn,
   PlayIcon as Play,
   ShieldWarningIcon as ShieldAlert,
 } from '@phosphor-icons/react';
 import { useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
 import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
 import Loading from '@/components/ui/loading';
 import { getAuthToken } from '@/lib/auth-token';
 import { getEnv } from '@/lib/env-config';
-import { cn } from '@/lib/utils';
-import { PublicFileShareView } from './public-file-share-view';
-import { SHARE_PAGE_ROOT_CLASS, SHARE_PREVIEW_IFRAME_CLASS } from './share-layout';
 import { getPublicShareByToken, startSessionWithToken } from '@kortix/sdk';
+import { PublicFileShareView } from './public-file-share-view';
+import { downloadFileFromUrl, fileNameFromPath } from './share-file';
+import { SHARE_PAGE_ROOT_CLASS, SHARE_PREVIEW_IFRAME_CLASS } from './share-layout';
 
 interface PublicShareMeta {
   share: {
@@ -61,6 +62,11 @@ export default function PublicSessionSharePage() {
   const [loading, setLoading] = useState(true);
   const [hasAuth, setHasAuth] = useState(false);
   const [starting, setStarting] = useState(false);
+  // Full screen here means "no share chrome" — the header unmounts and the
+  // shared content owns the whole viewport. Deliberately not the native
+  // Fullscreen API: the content is an iframe, and animating/entering native
+  // fullscreen forces it to re-layout twice on a surface we do not control.
+  const [fullscreen, setFullscreen] = useState(false);
 
   const base = apiBase();
   const origin = apiOrigin();
@@ -106,6 +112,17 @@ export default function PublicSessionSharePage() {
     };
   }, [base, token]);
 
+  // Escape leaves full screen. Focus inside the iframe never reaches this
+  // listener, which is why the floating exit control below stays visible.
+  useEffect(() => {
+    if (!fullscreen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setFullscreen(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [fullscreen]);
+
   async function startSession() {
     if (!meta) return;
     const authToken = await getAuthToken();
@@ -128,6 +145,13 @@ export default function PublicSessionSharePage() {
   function signInForAccess() {
     window.location.href = `/auth?next=${encodeURIComponent(window.location.pathname)}`;
   }
+
+  const filePath = meta?.share.file_path || meta?.share.label || '';
+  const fileName = fileNameFromPath(filePath, meta?.share.label ?? 'Shared file');
+  const handleDownload = useCallback(() => {
+    if (!fileSrc) return;
+    void downloadFileFromUrl(fileSrc, fileName);
+  }, [fileName, fileSrc]);
 
   if (loading) {
     return (
@@ -155,11 +179,10 @@ export default function PublicSessionSharePage() {
 
   const offline = meta.share.sandbox_status !== 'active';
   const isFileShare = meta.share.resource_type === 'file';
-  const Icon = isFileShare ? FileText : Globe;
-  const shareType = isFileShare ? 'File share' : 'Preview share';
-  const sharePermission = isFileShare
-    ? 'View only · no workspace browsing'
-    : 'No terminal, files, or session controls';
+  // A file share is titled by its file name only — the workspace path is
+  // internal detail the recipient has no context for.
+  const title = isFileShare ? fileName : meta.share.label;
+  const authHref = `/auth?next=${encodeURIComponent(`/share/session/${token}`)}`;
   const sessionHref = `/projects/${meta.share.project_id}/sessions/${meta.share.session_id}`;
   const offlineTitle = isFileShare
     ? 'This shared file is offline'
@@ -168,89 +191,105 @@ export default function PublicSessionSharePage() {
     ? 'The session runtime that serves this file is not active. Sign in with access to this project to start it.'
     : 'The session runtime is not active. Sign in with access to this project to start it.';
 
+  const openAppLabel = tI18nHardcoded.raw(
+    'autoAppPublicShareSessionTokenPageJsxTextOpenAppa9aa1bb9',
+  );
+
   return (
     <main className={SHARE_PAGE_ROOT_CLASS}>
-      <header className="border-border/70 bg-background/95 flex min-h-[64px] flex-col gap-3 border-b px-4 py-3 backdrop-blur sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-          <div className="flex shrink-0 items-center gap-2.5">
-            <KortixLogo variant="logomark" size={18} className="text-foreground" />
-            <span className="bg-border hidden h-4 w-px sm:block" />
-            <span className="text-muted-foreground text-xs font-medium">
-              {tI18nHardcoded.raw('autoAppPublicShareSessionTokenPageJsxTextPublicSharedbc2d952')}
-            </span>
+      {/* Bar shape copied from the file viewer toolbar (file-preview-modal.tsx):
+          h-12, gap-2, px-3, name left, actions right. No border-b — the pane
+          below draws the seam with its own top border. */}
+      {!fullscreen && (
+        <header className="flex py-2 shrink-0 items-center gap-2 px-3.5 pr-3">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <KortixLogo variant="symbol" size={16} className="shrink-0" />
+            <h1 className="truncate text-sm font-medium">{title}</h1>
           </div>
-          <div className="flex min-w-0 items-center gap-2.5">
-            <div
-              className={cn(
-                'border-border/70 bg-muted/40 flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border',
-                isFileShare ? 'text-muted-foreground' : 'text-primary',
-              )}
-            >
-              <Icon className="h-4 w-4" />
-            </div>
-            <div className="min-w-0">
-              <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                <h1 className="max-w-full truncate text-sm font-medium">{meta.share.label}</h1>
-                <span className="text-muted-foreground text-xs">{shareType}</span>
-              </div>
-              <p className="text-muted-foreground mt-0.5 truncate text-xs">{sharePermission}</p>
-            </div>
-          </div>
-        </div>
-        <div className="flex shrink-0 flex-wrap items-center gap-2">
-          {offline && hasAuth && (
-            <Button size="sm" className="h-8 gap-1.5" onClick={startSession} disabled={starting}>
-              {starting ? (
-                <Loading className="h-3.5 w-3.5" />
-              ) : (
-                <Play className="h-3.5 w-3.5" />
-              )}
-              Start
-            </Button>
-          )}
-          {!hasAuth ? (
-            <Button size="sm" variant="outline" className="h-8 gap-1.5" onClick={signInForAccess}>
-              <LogIn className="h-3.5 w-3.5" />
-              {tI18nHardcoded.raw('autoAppPublicShareSessionTokenPageJsxTextSignInc63c237b')}
-            </Button>
-          ) : (
+          <div className="flex shrink-0 items-center gap-1">
+            {offline && hasAuth && (
+              <Button size="sm" onClick={startSession} disabled={starting}>
+                {starting ? <Loading /> : <Play />}
+                Start
+              </Button>
+            )}
+            {isFileShare && !offline && fileSrc && (
+              <Hint label="Download" side="bottom">
+                <Button
+                  variant="ghost"
+                  size="icon-base"
+                  aria-label="Download"
+                  onClick={handleDownload}
+                >
+                  <Download />
+                </Button>
+              </Hint>
+            )}
+            {iframeSrc && !offline && !isFileShare && (
+              <Hint label={openAppLabel} side="bottom">
+                <Button
+                  variant="ghost"
+                  size="icon-base"
+                  aria-label={openAppLabel}
+                  onClick={() => window.open(iframeSrc, '_blank', 'noopener,noreferrer')}
+                >
+                  <ExternalLink />
+                </Button>
+              </Hint>
+            )}
+            {/* One CTA in both auth states. A signed-out visitor still wants
+                "Open in Kortix"; sign-in is a step on the way there, not a
+                different destination. */}
             <Button
               size="sm"
-              variant={offline ? 'outline' : 'ghost'}
-              className="h-8 gap-1.5"
               onClick={() => {
-                window.location.href = sessionHref;
+                window.location.href = hasAuth ? sessionHref : authHref;
               }}
             >
               {tI18nHardcoded.raw('autoAppPublicShareSessionTokenPageJsxTextOpenIn2fdbf464')}
             </Button>
-          )}
-          {iframeSrc && !offline && !isFileShare && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-8 gap-1.5"
-              onClick={() => window.open(iframeSrc, '_blank', 'noopener,noreferrer')}
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              {tI18nHardcoded.raw('autoAppPublicShareSessionTokenPageJsxTextOpenAppa9aa1bb9')}
-            </Button>
-          )}
-        </div>
-      </header>
-      <section className="relative min-h-0 flex-1">
+            <Hint label="Full screen" side="bottom">
+              <Button
+                variant="ghost"
+                size="icon-base"
+                aria-label="Full screen"
+                onClick={() => setFullscreen(true)}
+              >
+                <ArrowsOutSimple />
+              </Button>
+            </Hint>
+          </div>
+        </header>
+      )}
+      {/* Escape also exits, but focus inside the iframe never reaches the
+          parent document — so the way out has to be visible. `secondary` is
+          opaque: this floats over content whose colours we do not control. */}
+      {fullscreen && (
+        <Hint label="Exit full screen (Esc)" side="left">
+          <Button
+            variant="secondary"
+            size="icon-base"
+            aria-label="Exit full screen"
+            className="fixed top-2 right-3 z-50 shadow-md"
+            onClick={() => setFullscreen(false)}
+          >
+            <ArrowsInSimple />
+          </Button>
+        </Hint>
+      )}
+      {/* `overflow-clip` is what makes `rounded-t-md` visible: without it the
+          iframe paints its square background over the corners. `clip` rather
+          than `hidden` so this never becomes a scrollable box — the scrolling
+          belongs to the child. */}
+      <section className="bg-background border-border relative min-h-0 h-dvh flex-1 overflow-clip rounded-t-md border-x border-t">
         {offline ? (
-          <div className="flex h-full min-h-[60vh] items-center justify-center px-6 text-center">
+          <div className="flex h-full items-center justify-center px-6 text-center">
             <div className="max-w-sm">
               <h2 className="text-base font-semibold">{offlineTitle}</h2>
               <p className="text-muted-foreground mt-2 text-sm">{offlineDescription}</p>
               {hasAuth ? (
-                <Button className="mt-5 gap-1.5" onClick={startSession} disabled={starting}>
-                  {starting ? (
-                    <Loading className="h-4 w-4" />
-                  ) : (
-                    <Play className="h-4 w-4" />
-                  )}
+                <Button className="mt-5" onClick={startSession} disabled={starting}>
+                  {starting ? <Loading /> : <Play />}
                   {tI18nHardcoded.raw(
                     'autoAppPublicShareSessionTokenPageJsxTextStartSessiond4216ec8',
                   )}
@@ -266,7 +305,7 @@ export default function PublicSessionSharePage() {
           <PublicFileShareView token={token} share={meta.share} fileUrl={fileSrc} />
         ) : (
           <iframe
-            title={meta.share.label}
+            title={title}
             src={iframeSrc}
             className={SHARE_PREVIEW_IFRAME_CLASS}
             sandbox={tI18nHardcoded.raw(

--- a/apps/web/src/app/(public)/share/session/[token]/public-file-share-view.tsx
+++ b/apps/web/src/app/(public)/share/session/[token]/public-file-share-view.tsx
@@ -1,15 +1,9 @@
 'use client';
 
-import {
-  DownloadIcon as Download,
-  ArrowSquareOutIcon as ExternalLink,
-  FileTextIcon as FileText,
-} from '@phosphor-icons/react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useState } from 'react';
 
-import { Button } from '@/components/ui/button';
 import {
   FileContentRenderer,
   FileSourceProvider,
@@ -19,17 +13,12 @@ import {
   type FileContentResult,
   type FileSource,
 } from '@/features/file-viewer';
-import { cn } from '@/lib/utils';
+import { downloadFileFromUrl, fileNameFromPath } from './share-file';
 import { SHARE_FILE_IFRAME_CLASS } from './share-layout';
 
 export interface PublicFileShare {
   label: string;
   file_path: string | null;
-}
-
-function fileNameFromPath(path: string | null | undefined, fallback = 'Shared file') {
-  if (!path) return fallback;
-  return path.split('/').filter(Boolean).at(-1) || fallback;
 }
 
 function isTextResponse(filePath: string, contentType: string) {
@@ -136,31 +125,6 @@ function usePublicBinaryBlob(
   };
 }
 
-function PublicFileBreadcrumbs({ filePath }: { filePath: string }) {
-  const parts = filePath
-    .replace(/^\/workspace\/?/, '')
-    .split('/')
-    .filter(Boolean);
-  return (
-    <div className="flex min-w-0 items-center gap-1 text-xs">
-      <span className="text-muted-foreground shrink-0">workspace</span>
-      {parts.map((part, index) => (
-        <span key={`${part}-${index}`} className="flex min-w-0 items-center gap-1">
-          <span className="text-muted-foreground/40">/</span>
-          <span
-            className={cn(
-              'truncate',
-              index === parts.length - 1 ? 'text-foreground font-medium' : 'text-muted-foreground',
-            )}
-          >
-            {part}
-          </span>
-        </span>
-      ))}
-    </div>
-  );
-}
-
 export function PublicFileShareView({
   token,
   share,
@@ -179,68 +143,41 @@ export function PublicFileShareView({
     () => ({
       useFileContent: (path) => usePublicFileContent(token, path, fileUrl),
       useBinaryBlob: (path) => usePublicBinaryBlob(token, path, fileUrl),
-      download: async (_filePath, name) => {
-        const res = await fetch(fileUrl, { cache: 'no-store' });
-        if (!res.ok) throw new Error(res.statusText || `HTTP ${res.status}`);
-        const blob = await res.blob();
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = name || fileName;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(url);
-      },
+      download: (_filePath, name) => downloadFileFromUrl(fileUrl, name || fileName),
       upload: async () => {
         throw new Error('Public file shares are read-only');
       },
-      Breadcrumbs: PublicFileBreadcrumbs,
+      // No `Breadcrumbs`: a recipient of a share link has no workspace to
+      // navigate, and the sender's directory layout is not theirs to see. The
+      // file name in the page header is the whole identity of this page.
     }),
     [fileName, fileUrl, token],
   );
 
+  // HTML renders from the proxy URL directly so its relative assets resolve.
   if (isHtmlFile) {
     return (
-      <div className="bg-background flex h-full min-h-0 flex-col">
-        <div className="border-border/60 flex h-11 shrink-0 items-center gap-2 border-b px-3">
-          <FileText className="text-muted-foreground h-4 w-4 shrink-0" />
-          <PublicFileBreadcrumbs filePath={filePath} />
-          <div className="ml-auto flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              onClick={() => window.open(fileUrl, '_blank', 'noopener,noreferrer')}
-            >
-              <ExternalLink className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-8 gap-1.5 px-3 text-xs font-medium"
-              onClick={() => source.download(filePath, fileName)}
-            >
-              <Download className="h-3.5 w-3.5" />
-              Download
-            </Button>
-          </div>
-        </div>
-        <iframe
-          title={fileName}
-          src={fileUrl}
-          className={SHARE_FILE_IFRAME_CLASS}
-          sandbox={tI18nHardcoded.raw(
-            'autoAppPublicShareSessionTokenPublicFileShareViewJsxeeb5b063',
-          )}
-        />
-      </div>
+      <iframe
+        title={fileName}
+        src={fileUrl}
+        className={SHARE_FILE_IFRAME_CLASS}
+        sandbox={tI18nHardcoded.raw('autoAppPublicShareSessionTokenPublicFileShareViewJsxeeb5b063')}
+      />
     );
   }
 
+  // `showHeader={false}`: the share page header owns the file name and the
+  // Download action, so the renderer's own bar (path breadcrumbs, VIEW ONLY
+  // badge, second Download) would only repeat it.
   return (
     <FileSourceProvider value={source}>
-      <FileContentRenderer filePath={filePath} readOnly className="bg-background h-full" />
+      <FileContentRenderer
+        codeEditorEditorClassName="bg-card dark:bg-card h-full"
+        filePath={filePath}
+        readOnly
+        showHeader={false}
+        className="bg-card h-dvh"
+      />
     </FileSourceProvider>
   );
 }

--- a/apps/web/src/app/(public)/share/session/[token]/share-file.ts
+++ b/apps/web/src/app/(public)/share/session/[token]/share-file.ts
@@ -1,0 +1,38 @@
+/**
+ * File helpers for the public session share surface.
+ *
+ * The page header owns the Download action, but the file renderer still needs
+ * the same behaviour internally — binary/unsupported categories render their
+ * own inline "Download" button through the `FileSource`. Keeping one
+ * implementation here stops the two paths from drifting into different file
+ * names or fetch options.
+ */
+
+/** Last segment of a workspace path — `/workspace/docs/report.md` → `report.md`. */
+export function fileNameFromPath(
+  path: string | null | undefined,
+  fallback = 'Shared file',
+): string {
+  if (!path) return fallback;
+  return path.split('/').filter(Boolean).at(-1) || fallback;
+}
+
+/**
+ * Fetch the shared file and hand it to the browser as a download.
+ *
+ * `cache: 'no-store'` matches the viewer's fetches: a share can be revoked or
+ * the file rewritten at any time, and a cached 200 would hide that.
+ */
+export async function downloadFileFromUrl(fileUrl: string, fileName: string): Promise<void> {
+  const res = await fetch(fileUrl, { cache: 'no-store' });
+  if (!res.ok) throw new Error(res.statusText || `HTTP ${res.status}`);
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/web/src/app/(public)/share/session/[token]/share-header.test.ts
+++ b/apps/web/src/app/(public)/share/session/[token]/share-header.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const page = readFileSync(resolve(import.meta.dir, 'page.tsx'), 'utf8');
+const view = readFileSync(resolve(import.meta.dir, 'public-file-share-view.tsx'), 'utf8');
+const root = readFileSync(resolve(import.meta.dir, 'share-layout.ts'), 'utf8');
+
+// Anti-vacuity guard: every `not.toContain` below would pass on an empty
+// string, so prove first that both files were actually read.
+describe('public share sources are loaded', () => {
+  test('page and file view sources are non-empty and are the expected modules', () => {
+    expect(page).toContain('export default function PublicSessionSharePage');
+    expect(view).toContain('export function PublicFileShareView');
+  });
+});
+
+describe('public share header chrome', () => {
+  test('identity is the Kortix logo plus the file name only', () => {
+    expect(page).toContain('KortixLogo');
+    // The title comes from the file name, never the workspace path.
+    expect(page).toContain('fileNameFromPath');
+    expect(page).toContain('const title = isFileShare ? fileName : meta.share.label');
+  });
+
+  test('header controls carry no ad-hoc sizing or press effects', () => {
+    const header = page.slice(page.indexOf('<header'), page.indexOf('</header>'));
+    // Button owns its own height, gap and icon size through `size`/`variant`.
+    // Re-specifying them here is how a toolbar drifts out of the system.
+    expect(header).not.toContain('active:scale');
+    expect(header).not.toContain('h-8');
+    expect(header).not.toContain('size-3.5');
+  });
+
+  test('the removed share-meta labels stay removed', () => {
+    // 'Public share' eyebrow, share-type caption, and permission line.
+    expect(page).not.toContain('autoAppPublicShareSessionTokenPageJsxTextPublicSharedbc2d952');
+    expect(page).not.toContain('File share');
+    expect(page).not.toContain('Preview share');
+    expect(page).not.toContain('No terminal, files, or session controls');
+    expect(page).not.toContain('View only');
+  });
+
+  test('Download and Full screen sit in the header next to Open in Kortix', () => {
+    const header = page.slice(page.indexOf('<header'), page.indexOf('</header>'));
+    expect(header).toContain('Download');
+    expect(header).toContain('Full screen');
+    // 'Open in Kortix'
+    expect(header).toContain('autoAppPublicShareSessionTokenPageJsxTextOpenIn2fdbf464');
+  });
+
+  test('full screen hides the header and offers a way back out', () => {
+    expect(page).toContain('{!fullscreen && (');
+    expect(page).toContain('Exit full screen');
+    // Escape is a convenience only; focus inside the iframe never reaches it,
+    // so the visible exit control must not be conditioned on hover/focus.
+    expect(page).toContain("event.key === 'Escape'");
+  });
+});
+
+describe('public share content pane', () => {
+  test('the pane clips its own radius, and canvas and sheet are different tones', () => {
+    const start = page.indexOf('<section');
+    const section = page.slice(start, page.indexOf('>', start));
+    // Anti-vacuity guard: prove the slice is the content region.
+    expect(section).toContain('flex-1');
+    expect(section).toContain('rounded-t-md');
+    // Without a clip the iframe paints its square background straight over the
+    // corners and the radius is invisible.
+    expect(section).toContain('overflow-clip');
+    // And the corner notch needs a different tone behind it to be seen at all.
+    expect(section).toContain('bg-background');
+    expect(root).toContain('bg-card');
+  });
+});
+
+describe('public file share view', () => {
+  test('renders no second header: no breadcrumbs, no VIEW ONLY badge, no duplicate download', () => {
+    expect(view).toContain('showHeader={false}');
+    expect(view).not.toContain('Breadcrumbs:');
+    expect(view).not.toContain('PublicFileBreadcrumbs');
+  });
+
+  test('stays read-only', () => {
+    expect(view).toContain('readOnly');
+    expect(view).toContain('Public file shares are read-only');
+  });
+});

--- a/apps/web/src/app/(public)/share/session/[token]/share-layout.test.ts
+++ b/apps/web/src/app/(public)/share/session/[token]/share-layout.test.ts
@@ -21,11 +21,11 @@ describe('public session share layout sizing', () => {
     expect(SHARE_PREVIEW_IFRAME_CLASS).toContain('w-full');
   });
 
-  test('html file iframe takes the remaining height and full width', () => {
-    // Sits below a fixed toolbar inside a flex column, so it grows via flex-1
-    // (with min-h-0 so it can shrink) and spans the full width.
-    expect(SHARE_FILE_IFRAME_CLASS).toContain('flex-1');
-    expect(SHARE_FILE_IFRAME_CLASS).toContain('min-h-0');
+  test('html file iframe fills the region full width and full height', () => {
+    // The share view no longer stacks a toolbar above the document, so this
+    // iframe is the only child of the content region and claims the whole box
+    // exactly like the preview iframe.
+    expect(SHARE_FILE_IFRAME_CLASS).toContain('h-full');
     expect(SHARE_FILE_IFRAME_CLASS).toContain('w-full');
   });
 

--- a/apps/web/src/app/(public)/share/session/[token]/share-layout.ts
+++ b/apps/web/src/app/(public)/share/session/[token]/share-layout.ts
@@ -15,11 +15,18 @@
  */
 
 // Page root: definite viewport height so the flex chain resolves to real pixels.
-export const SHARE_PAGE_ROOT_CLASS = 'bg-background text-foreground flex h-dvh flex-col';
+//
+// `bg-card` (surface-1), not `bg-background`: the root is the canvas the header
+// sits on, and the content pane below is a `bg-background` sheet with a rounded
+// top. A radius is only visible if something different shows through the corner
+// notch, so canvas and sheet must be different tones — same value on both and
+// the rounding silently does nothing.
+export const SHARE_PAGE_ROOT_CLASS = 'bg-card text-foreground flex h-dvh flex-col';
 
 // Live preview iframe: fills its flex-1 region edge to edge.
 export const SHARE_PREVIEW_IFRAME_CLASS = 'h-full w-full border-0';
 
-// HTML file iframe: sits below a fixed toolbar inside a flex-col, so it takes
-// the remaining height (flex-1) and spans the full width.
-export const SHARE_FILE_IFRAME_CLASS = 'min-h-0 w-full flex-1 border-0 bg-white';
+// HTML file iframe: the only child of the content region, so it claims the
+// full box exactly like the preview iframe. `bg-white` keeps a transparent
+// document from showing the app's dark surface through the page.
+export const SHARE_FILE_IFRAME_CLASS = 'h-full w-full border-0 bg-white';

--- a/apps/web/src/components/file-editors/code-editor.tsx
+++ b/apps/web/src/components/file-editors/code-editor.tsx
@@ -339,6 +339,7 @@ interface CodeEditorProps {
   diagnostics?: LspDiagnostic[];
   /** 1-indexed line number to scroll to after mount (used for click-to-navigate from diagnostics panel) */
   targetLine?: number | null;
+  editorClassName?: string;
 }
 
 export function CodeEditor({
@@ -358,6 +359,7 @@ export function CodeEditor({
   fontSize,
   diagnostics,
   targetLine,
+  editorClassName,
 }: CodeEditorProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const { resolvedTheme } = useTheme();
@@ -754,6 +756,7 @@ export function CodeEditor({
         ref={editorContainerRef}
         className={cn(
           'w-full max-w-full bg-white dark:bg-zinc-900',
+          editorClassName,
           readOnly
             ? 'min-h-full flex-1 overflow-visible' // Stretch to fill parent so short files still fill the viewport
             : 'max-h-full min-h-0 flex-1 overflow-hidden',

--- a/apps/web/src/features/file-viewer/file-content-renderer.tsx
+++ b/apps/web/src/features/file-viewer/file-content-renderer.tsx
@@ -8,8 +8,8 @@ import { MarkdownWithFrontmatter } from '@/components/markdown/markdown-frontmat
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { InfoBanner } from '@/components/ui/info-banner';
-import { errorToast, successToast } from '@/components/ui/toast';
 import Loading from '@/components/ui/loading';
+import { errorToast, successToast } from '@/components/ui/toast';
 import {
   appendPreviewToken,
   isSubdomainPreviewUrl,
@@ -17,12 +17,12 @@ import {
 } from '@/hooks/use-authenticated-preview-url';
 import { useHeicBlob } from '@/hooks/use-heic-url';
 import { getAuthToken } from '@/lib/auth-token';
-import { getActiveStaticFileHealthUrl, getActiveStaticFilePreviewUrl } from '@kortix/sdk/react';
 import { getIframeSandbox } from '@/lib/security/iframe-sandbox';
 import { cn } from '@/lib/utils';
 import { isHeicFile } from '@/lib/utils/heic-convert';
 import { findDiagnosticsForFile, useDiagnosticsStore } from '@/stores/diagnostics-store';
 import { toSandboxAbsolutePath } from '@kortix/sdk';
+import { getActiveStaticFileHealthUrl, getActiveStaticFilePreviewUrl } from '@kortix/sdk/react';
 import {
   WarningIcon as AlertTriangle,
   BracketsCurlyIcon as Braces,
@@ -303,6 +303,8 @@ export interface FileContentRendererProps {
   /** PDF only: start the zoom plugin at fit-to-page instead of the numeric
    *  default. No effect on any other file category. */
   fitOnOpen?: boolean;
+  /** Additional class name for the code editor */
+  codeEditorEditorClassName?: string;
 }
 
 export function FileContentRenderer({
@@ -319,6 +321,7 @@ export function FileContentRenderer({
   onMarkdownPreviewChange,
   onStatusChange,
   fitOnOpen = false,
+  codeEditorEditorClassName,
 }: FileContentRendererProps) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -1065,6 +1068,7 @@ export function FileContentRenderer({
           {/* HTML source — shown when preview toggle is off */}
           {isHtmlFile && !isHtmlPreview && !isLoading && !error && fileContent?.type === 'text' && (
             <CodeEditor
+              editorClassName={codeEditorEditorClassName}
               key={`html-source-${filePath}-${discardKey}`}
               {...codeEditorProps}
               className={readOnly ? 'min-h-full' : 'h-full'}
@@ -1123,10 +1127,23 @@ export function FileContentRenderer({
                     />
                   </div>
                 ) : isMarkdownPreview && isMarkdownFile ? (
+                  // Markdown is prose, so it gets a measure. The markdown root
+                  // renders at text-[15px]; full-bleed on a wide viewport that
+                  // is ~190 characters per line, well past the comfortable
+                  // 65-90. `max-w-2xl` is the same reading column the customize
+                  // sections use, and it is a no-op in panels already narrower
+                  // than 672px. Deliberately not applied to the code editor:
+                  // code line length is the author's decision, and a narrow
+                  // column would only add horizontal scrolling.
+                  //
+                  // The cap sits on an inner element so the scroll container
+                  // stays full width and its scrollbar rides the panel edge.
                   <div key={filePath} className="h-full w-full overflow-auto p-6">
-                    <MarkdownWithFrontmatter
-                      content={hasUnsavedChanges ? latestContentRef.current : displayContent}
-                    />
+                    <div className="mx-auto w-full max-w-2xl">
+                      <MarkdownWithFrontmatter
+                        content={hasUnsavedChanges ? latestContentRef.current : displayContent}
+                      />
+                    </div>
                   </div>
                 ) : (
                   <CodeEditor

--- a/apps/web/src/features/file-viewer/markdown-measure.test.ts
+++ b/apps/web/src/features/file-viewer/markdown-measure.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { getLanguageFromExt } from './file-content-renderer';
+
+const src = readFileSync(resolve(import.meta.dir, 'file-content-renderer.tsx'), 'utf8');
+
+/**
+ * Markdown is prose and gets a reading measure; code does not. These pin the
+ * split, because "why is this column narrow?" is exactly the kind of class a
+ * later refactor drops or copies onto the wrong branch.
+ */
+describe('markdown preview measure', () => {
+  test('both .md and .mdx take the markdown branch', () => {
+    // The preview branch keys off `language === 'markdown'`, so this is what
+    // decides whether a file is capped at all.
+    expect(getLanguageFromExt('README.md')).toBe('markdown');
+    expect(getLanguageFromExt('page.mdx')).toBe('markdown');
+  });
+
+  test('code files do not take the markdown branch', () => {
+    for (const [file, language] of [
+      ['app.tsx', 'tsx'],
+      ['util.ts', 'typescript'],
+      ['main.py', 'python'],
+    ]) {
+      expect(getLanguageFromExt(file)).toBe(language);
+      expect(getLanguageFromExt(file)).not.toBe('markdown');
+    }
+  });
+
+  test('the markdown preview caps its column and centers it', () => {
+    const start = src.indexOf('isMarkdownPreview && isMarkdownFile ?');
+    // `<CodeEditor` also appears earlier (the HTML "view source" branch), so
+    // anchor the end to the next one after the markdown branch, not the first.
+    const branch = src.slice(start, src.indexOf('<CodeEditor', start));
+    // Anti-vacuity guard: prove the slice is the branch we mean.
+    expect(branch).toContain('MarkdownWithFrontmatter');
+    expect(branch).toContain('max-w-2xl');
+    expect(branch).toContain('mx-auto');
+  });
+
+  test('the code editor stays full width', () => {
+    // The main editor is the last <CodeEditor> in the file.
+    const start = src.lastIndexOf('<CodeEditor');
+    const editor = src.slice(start, src.indexOf('/>', start));
+    expect(editor).toContain('codeEditorProps');
+    // A measure on code would re-break lines the author already formatted.
+    expect(editor).not.toContain('max-w-');
+  });
+});


### PR DESCRIPTION
## Issue

Opening a share link showed the recipient more chrome than content. The page header carried a "Public share" eyebrow, a file-type icon tile, a "File share" caption, and a "View only · no workspace browsing" permission line. Underneath it, file shares rendered a *second* toolbar with the full `/workspace/...` path as breadcrumbs, a `VIEW ONLY` badge, and a second Download button — three stacked headers for one shared file. The path and the permission copy are meaningless to a recipient who has no workspace to navigate.

Markdown had no reading measure either. The markdown root renders at `text-[15px]`; full-bleed on a wide viewport that is roughly 190 characters per line, well past the comfortable 65–90.

## Solution

One header: Kortix logomark plus the file name — never the path. Download sits beside Open in Kortix, and a new full screen control hides the header so the shared content owns the viewport.

The second and third headers are removed by *opting out*, not by editing shared code: `FileContentRenderer` already accepts `showHeader={false}` and treats `Breadcrumbs` on the `FileSource` as optional, so the share view declines both and every other surface that renders files is untouched.

Full screen is a chrome toggle, not the native Fullscreen API — the content is a cross-origin iframe, and `requestFullscreen()` would force it to re-layout twice for no gain. Escape exits, but focus inside the iframe never reaches the parent document, so the floating exit control stays visible rather than hover-revealed.

Markdown preview is capped at `max-w-2xl`, the same reading column `section-wrapper.tsx` already establishes, applied on an inner element so the scroll container stays full width and its scrollbar rides the panel edge. Code editors are deliberately left uncapped: line length in code is the author's decision, and a narrow column only adds horizontal scrolling to lines that would otherwise fit.

## Changes

- `page.tsx` — single header, full screen state, Download promoted from the file view.
- `public-file-share-view.tsx` — toolbar and breadcrumbs deleted, `showHeader={false}` (−107 lines).
- `share-file.ts` (new) — `fileNameFromPath` / `downloadFileFromUrl`, shared by the header button and the `FileSource`, so the two cannot drift.
- `share-layout.ts` — content pane is a rounded sheet. Two things are required for the radius to be visible at all: `overflow-clip` (an unclipped iframe paints its square background over the corners) and different tones for canvas and sheet (a corner notch showing the same colour shows nothing). Both are pinned by a test.
- `file-content-renderer.tsx` — markdown measure, plus a `codeEditorEditorClassName` passthrough.

## Testing

```
bun test ./src/app/(public)/share/session/[token]/ ./src/features/file-viewer/   36 pass, 0 fail
npx tsc --noEmit                                                                 clean
npx eslint "src/app/(public)/share/"                                             0 errors
```

`tsc` reports only the 15 known `@types/bun` `test.each` errors documented in `apps/web` CLAUDE.md. ESLint warnings in the touched files are pre-existing (`window.location` navigation, one `setState` in an effect).

New tests pin the contracts that fail silently when broken: the removed labels stay removed, header controls carry no ad-hoc sizing, the content pane keeps its clip, and `.md`/`.mdx` take the measure branch while `.tsx`/`.ts`/`.py` do not. Each source-assertion block opens with a guard proving the file was read, since `not.toContain` passes on an empty string.

## Notes

- Not verified in a browser. The layout is reasoned from tokens and pinned by tests, but nobody has looked at the rendered page.
- `codeEditorEditorClassName` is threaded through to the HTML source editor but no caller passes it yet.
- The markdown measure lands in the shared renderer, so it applies to every surface that previews markdown — the share page, workspace file viewer, project files, preview modal, easy panel. It is a no-op in any panel already narrower than 672px.
- Sign in is no longer its own button; a signed-out visitor gets the same "Open in Kortix" CTA and routes through `/auth?next=` back to the share.
