### PR TITLE
fix(api): a spawned sub-session inherits its parent's sharing, not private

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1129,6 +1129,47 @@ describe('project session API contract', () => {
     expect((await response.json()).agent_name).toBe('meta');
   });
 
+  test('a session-bound spawn inherits the SPAWNING session sharing, not the private default', async () => {
+    // The caller's own session (sessionRow / SESSION_ID) is shared project-wide.
+    // A worker it spawns must be reachable by the same grantees, not fall back
+    // to the private default — otherwise sharing the coordinator would not
+    // actually share anything it spawns. See resolveInheritedSessionSharing.
+    sessionRow = { ...sessionRow!, visibility: 'project' };
+    const app = createApp();
+    const response = await app.request(`/v1/projects/${PROJECT_ID}/sessions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${SESSION_BOUND_PAT}`,
+      },
+      body: JSON.stringify({ provider: 'daytona', base_ref: 'main' }),
+    });
+
+    expect(response.status).toBe(201);
+    const created = await response.json();
+    expect(created.metadata?.spawned_by_session).toBe(SESSION_ID);
+    expect(created.visibility).toBe('project');
+  });
+
+  test('a plain browser create is NOT session-bound, so it keeps the private default', async () => {
+    // Same shared-project-wide parent state as above, but with the Supabase
+    // browser auth path (no Authorization header) instead of a session-bound
+    // PAT — proves inheritance is gated on an actual spawning session, not
+    // just on the existence of an unrelated session row in the fixture.
+    sessionRow = { ...sessionRow!, visibility: 'project' };
+    const app = createApp();
+    const response = await app.request(`/v1/projects/${PROJECT_ID}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: 'daytona', base_ref: 'main' }),
+    });
+
+    expect(response.status).toBe(201);
+    const created = await response.json();
+    expect(created.metadata?.spawned_by_session).toBeUndefined();
+    expect(created.visibility).toBe('private');
+  });
+
   test('GET project session inventory rejects callers without project.session.read', async () => {
     deniedIamAction = 'project.session.read';
     const app = createApp();

--- a/apps/api/src/__tests__/unit-connector-share.test.ts
+++ b/apps/api/src/__tests__/unit-connector-share.test.ts
@@ -9,6 +9,7 @@ import {
   isSessionTargetVisibleToCaller,
   isSessionVisibleTo,
   parseSharingIntent,
+  resolveInheritedSessionSharing,
   scopeToIntent,
   sessionIntentToVisibility,
   visibilityToIntent,
@@ -215,6 +216,49 @@ describe('session sharing — default private; team-wide or select-members', () 
     expect(visibilityToIntent('project', [])).toEqual({ mode: 'project' });
     expect(visibilityToIntent('private', [])).toEqual({ mode: 'private', ownerId: '' });
     expect(visibilityToIntent('restricted', members.grants)).toEqual({ mode: 'members', memberIds: [BOB], groupIds: [SALES] });
+  });
+});
+
+describe('resolveInheritedSessionSharing — a spawned worker inherits its parent', () => {
+  test('no parent (no spawning session) → default private, no grants', () => {
+    expect(resolveInheritedSessionSharing(undefined, null)).toEqual({
+      visibility: 'private',
+      grants: [],
+    });
+  });
+
+  test('parent shared project-wide → worker is project-wide too', () => {
+    expect(resolveInheritedSessionSharing(undefined, { visibility: 'project', grants: [] })).toEqual({
+      visibility: 'project',
+      grants: [],
+    });
+  });
+
+  test('parent shared with select members → worker copies the same grants', () => {
+    const grants: SecretGrant[] = [{ principalType: 'member', principalId: BOB }];
+    expect(resolveInheritedSessionSharing(undefined, { visibility: 'restricted', grants })).toEqual({
+      visibility: 'restricted',
+      grants,
+    });
+  });
+
+  test('parent private → worker stays private (unchanged default)', () => {
+    expect(resolveInheritedSessionSharing(undefined, { visibility: 'private', grants: [] })).toEqual({
+      visibility: 'private',
+      grants: [],
+    });
+  });
+
+  test('an explicit requested visibility always wins, even with a parent present', () => {
+    // Automation callers (triggers, channels) pin their own visibility and
+    // must never inherit — this is what stops that regressing.
+    expect(
+      resolveInheritedSessionSharing('project', { visibility: 'restricted', grants: [{ principalType: 'member', principalId: BOB }] }),
+    ).toEqual({ visibility: 'project', grants: [] });
+    expect(resolveInheritedSessionSharing('private', { visibility: 'project', grants: [] })).toEqual({
+      visibility: 'private',
+      grants: [],
+    });
   });
 });
 

--- a/apps/api/src/connectors/share.ts
+++ b/apps/api/src/connectors/share.ts
@@ -251,6 +251,29 @@ export function visibilityToIntent(visibility: SessionVisibility, grants: Secret
   return { mode: 'members', memberIds, groupIds };
 }
 
+/**
+ * A session created while another running session's own token is the caller
+ * (a sub-agent/coordinator spawning a worker) inherits THAT session's sharing
+ * instead of defaulting to private. Without this, a worker a coordinator
+ * spawns is invisible to anyone the coordinator was shared with — only the
+ * human who happens to match `created_by` could ever open it, which defeats
+ * the point of sharing the parent in the first place.
+ *
+ * `requestedVisibility` explicit (automation callers — triggers, channels —
+ * always pass one) wins outright and carries no inherited grants: those
+ * callers manage their own sharing story and were never eligible to inherit.
+ * `parent` is null when there is no spawning session, or it could not be
+ * resolved (defense in depth) — falls back to the private default.
+ */
+export function resolveInheritedSessionSharing(
+  requestedVisibility: SessionVisibility | undefined,
+  parent: { visibility: SessionVisibility; grants: SecretGrant[] } | null,
+): { visibility: SessionVisibility; grants: SecretGrant[] } {
+  if (requestedVisibility !== undefined) return { visibility: requestedVisibility, grants: [] };
+  if (parent) return { visibility: parent.visibility, grants: parent.grants };
+  return { visibility: 'private', grants: [] };
+}
+
 /** Bulk-load session grants → map sessionId → grants. */
 export async function loadSessionGrants(sessionIds: string[]): Promise<Map<string, SecretGrant[]>> {
   const out = new Map<string, SecretGrant[]>();

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import {
   projectSessionConnectorBindings,
+  projectSessionGrants,
   projectSessionRuntimeContexts,
   projectSessions,
 } from '@kortix/db';
@@ -11,6 +12,12 @@ import { checkBillingActive } from '../../billing/services/billing-gate';
 import { accountMayUseManagedModels } from '../../billing/services/entitlements';
 import { type SandboxProviderName, config } from '../../config';
 import { agentMayUseConnector } from '../../iam/agent-scope';
+import {
+  loadSessionGrants,
+  resolveInheritedSessionSharing,
+  type SecretGrant,
+  type SessionVisibility,
+} from '../../connectors/share';
 import { setContextField } from '../../lib/request-context';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import {
@@ -640,6 +647,29 @@ export async function sandboxCallbackDeadTunnelReason(
   return reason;
 }
 
+/**
+ * Read the SPAWNING session's own sharing (visibility + grants), scoped to
+ * the same account and project as the session being created — a stale or
+ * cross-project caller id (should not happen; defense in depth) falls back
+ * to the caller's normal default rather than inheriting nothing.
+ */
+async function loadParentSessionSharing(
+  callerSessionId: string,
+  accountId: string,
+  projectId: string,
+): Promise<{ visibility: SessionVisibility; grants: SecretGrant[] } | null> {
+  const [parent] = await db
+    .select({ visibility: projectSessions.visibility, projectId: projectSessions.projectId })
+    .from(projectSessions)
+    .where(and(eq(projectSessions.sessionId, callerSessionId), eq(projectSessions.accountId, accountId)))
+    .limit(1);
+  if (!parent || parent.projectId !== projectId) return null;
+  const visibility = parent.visibility as SessionVisibility;
+  if (visibility !== 'restricted') return { visibility, grants: [] };
+  const grants = (await loadSessionGrants([callerSessionId])).get(callerSessionId) ?? [];
+  return { visibility, grants };
+}
+
 export async function createProjectSession(input: {
   project: ProjectRow;
   userId: string;
@@ -687,9 +717,21 @@ export async function createProjectSession(input: {
   headers?: Record<string, string>;
 }> {
   const { project, userId, body } = input;
-  const visibility = input.visibility ?? 'private';
   const projectId = project.projectId;
   const accountId = project.accountId;
+  // A session spawned by ANOTHER running session (a sub-agent/coordinator
+  // worker, via that session's own bound token) inherits the SPAWNING
+  // session's sharing instead of defaulting to private — see
+  // resolveInheritedSessionSharing. Automation callers (triggers, channels)
+  // always pass `visibility` explicitly, so the lookup is skipped for them.
+  const parentSharing =
+    input.visibility === undefined && input.callerSessionId
+      ? await loadParentSessionSharing(input.callerSessionId, accountId, projectId)
+      : null;
+  const { visibility, grants: inheritedGrants } = resolveInheritedSessionSharing(
+    input.visibility,
+    parentSharing,
+  );
   const parsedRuntimeContext = parseSessionRuntimeContext(body.runtime_context);
   if (!parsedRuntimeContext.ok) {
     return {
@@ -1346,6 +1388,15 @@ export async function createProjectSession(input: {
             })),
           )
           .returning({ sessionId: projectSessionConnectorBindings.sessionId });
+      }
+      if (inheritedGrants.length > 0) {
+        await tx.insert(projectSessionGrants).values(
+          inheritedGrants.map((g) => ({
+            sessionId,
+            principalType: g.principalType,
+            principalId: g.principalId,
+          })),
+        );
       }
       return row;
     });


### PR DESCRIPTION
## Problem

Reported via a shared session link on Essentia (`/projects/.../sessions/...`)
that landed on the project's own access gate — while investigating, found the
adjacent gap this PR fixes: sharing a coordinator/parent session did not make
the sessions it spawns reachable.

`createProjectSession` always defaulted a new session's `visibility` to
`'private'` (owner-only). A sub-agent/coordinator worker spawned from a
running session (via that session's own bound token — `callerSessionId`) got
this same private default, independent of how the *spawning* session was
shared. So: share a coordinator session project-wide or with specific
members, and everyone granted access could open the coordinator — but not a
single worker it spawned. Only the original creator (who also happens to be
`created_by`) could ever open those. Sharing the parent effectively shared
nothing.

## Fix

`createProjectSession` (`apps/api/src/projects/lib/sessions.ts`) now inherits
the spawning session's `visibility` + grants when:
- the caller is session-bound (`callerSessionId` set — a real in-sandbox
  spawn, never a human browser session), **and**
- the caller did not explicitly pass a `visibility` (automation callers —
  triggers, Slack/Telegram channels — always pass one explicitly and are
  unaffected).

The decision itself is a small pure function,
`resolveInheritedSessionSharing` (`apps/api/src/connectors/share.ts`),
alongside this file's other pure sharing helpers.

## Verification

- `pnpm --filter kortix-api typecheck` (via `apps/api`: `tsc --noEmit`) — clean.
- New unit tests for `resolveInheritedSessionSharing`
  (`apps/api/src/__tests__/unit-connector-share.test.ts`) — all 5 decision
  branches (no parent, project-wide parent, restricted parent w/ grants,
  private parent, explicit visibility always wins).
- New black-box HTTP tests in the existing session-create contract suite
  (`apps/api/src/__tests__/e2e-project-session-contract.test.ts`): a
  session-bound (PAT) spawn of a `visibility='project'` parent creates a
  `visibility='project'` child; a plain browser create (not session-bound)
  against the same parent state stays `private` — proves inheritance is
  gated on an actual spawn, not just on a session row existing.
- Full local suite: `bash apps/api/scripts/test.sh` — **7037 pass, 74 skip, 5
  fail**. The 5 failures (`e2e-project-limit.test.ts`) are pre-existing on
  `main` in this environment — verified byte-identical with `git stash` on
  the same worktree before applying this change.

## Not yet verified

- Not exercised against a live sandbox/dev deploy (no real session-bound PAT
  minted end-to-end) — the fix is verified at the DB-write/HTTP-contract
  level (unit + black-box HTTP), consistent with how this file's existing
  sharing logic is tested.