### PR TITLE
iam: strip Agents/Connectors/Skills/Customize from the member floor role

### DIFF
--- a/apps/api/src/__tests__/integration-project-read-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-read-leaf-gates-http.test.ts
@@ -110,7 +110,6 @@ const CASES: Case[] = [
   { name: 'project session audit', leaf: PROJECT_ACTIONS.PROJECT_SESSION_READ, path: () => `/v1/projects/${PROJECT}/sessions/${crypto.randomUUID()}/audit` },
   { name: 'project session scope', leaf: PROJECT_ACTIONS.PROJECT_SESSION_READ, path: () => `/v1/projects/${PROJECT}/sessions/${crypto.randomUUID()}/scope` },
   { name: 'project access list', leaf: PROJECT_ACTIONS.PROJECT_MEMBERS_READ, path: () => `/v1/projects/${PROJECT}/access` },
-  { name: 'oauth credentials list', leaf: PROJECT_ACTIONS.PROJECT_CONNECTOR_READ, path: () => `/v1/projects/${PROJECT}/oauth` },
   { name: 'review items inbox', leaf: PROJECT_ACTIONS.PROJECT_REVIEW_READ, path: () => `/v1/projects/${PROJECT}/review/items` },
   { name: 'branches', leaf: PROJECT_ACTIONS.PROJECT_GITOPS_READ, path: () => `/v1/projects/${PROJECT}/branches` },
   { name: 'commits', leaf: PROJECT_ACTIONS.PROJECT_GITOPS_READ, path: () => `/v1/projects/${PROJECT}/commits` },
@@ -120,10 +119,12 @@ const CASES: Case[] = [
   { name: 'triggers list', leaf: PROJECT_ACTIONS.PROJECT_TRIGGER_READ, path: () => `/v1/projects/${PROJECT}/triggers` },
 ];
 
-// EDITOR-TIER reads: project.file.read + project.secret.read were moved OUT of
-// the floor `member` role into editor, so a bare member is 403 here (they can
-// run the agent/chat but not browse the file tree or view secret values); an
-// editor passes. Same agent-grant fold as the member-tier CASES above.
+// EDITOR-TIER reads: project.file.read, project.secret.read, and the entire
+// Agents/Connectors/Skills/Customize surface were moved OUT of the floor
+// `member` role into editor, so a bare member is 403 here (they can start/stop
+// sessions but can't browse the file tree, view secret values, or reach
+// Customize); an editor passes. Same agent-grant fold as the member-tier CASES
+// above.
 const EDITOR_TIER_READ_CASES: Case[] = [
   { name: 'files list', leaf: PROJECT_ACTIONS.PROJECT_FILE_READ, path: () => `/v1/projects/${PROJECT}/files` },
   { name: 'files archive', leaf: PROJECT_ACTIONS.PROJECT_FILE_READ, path: () => `/v1/projects/${PROJECT}/files/archive` },
@@ -131,6 +132,7 @@ const EDITOR_TIER_READ_CASES: Case[] = [
   { name: 'files content', leaf: PROJECT_ACTIONS.PROJECT_FILE_READ, path: () => `/v1/projects/${PROJECT}/files/content?path=README.md` },
   { name: 'files history', leaf: PROJECT_ACTIONS.PROJECT_FILE_READ, path: () => `/v1/projects/${PROJECT}/files/history?path=README.md` },
   { name: 'secrets list', leaf: PROJECT_ACTIONS.PROJECT_SECRET_READ, path: () => `/v1/projects/${PROJECT}/secrets` },
+  { name: 'oauth credentials list', leaf: PROJECT_ACTIONS.PROJECT_CONNECTOR_READ, path: () => `/v1/projects/${PROJECT}/oauth` },
 ];
 
 describe('HTTP enforcement — project read-leaf gates (agent-grant fold now reachable)', () => {
@@ -172,7 +174,7 @@ describe('HTTP enforcement — gateway playground spend gate', () => {
   });
 });
 
-describe('HTTP enforcement — editor-tier read gates (file.read / secret.read moved off member)', () => {
+describe('HTTP enforcement — editor-tier read gates (file/secret/connector reads moved off member)', () => {
   for (const c of EDITOR_TIER_READ_CASES) {
     describe(c.name, () => {
       test('floor MEMBER (no file/secret read) → 403', async () => {

--- a/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
@@ -229,7 +229,7 @@ const CASES: WCase[] = [
     name: 'channel bindings list (connector.read)',
     leaf: A.PROJECT_CONNECTOR_READ, method: 'GET',
     path: () => `/v1/projects/${PROJECT}/channels/bindings`,
-    tier: 'member', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_READ],
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_READ],
   },
   // ── Customize (write) ────────────────────────────────────────────────────
   {

--- a/apps/api/src/__tests__/unit-iam-role-presets.test.ts
+++ b/apps/api/src/__tests__/unit-iam-role-presets.test.ts
@@ -41,9 +41,13 @@ describe('built-in role presets', () => {
     expect(set.has(PROJECT_ACTIONS.PROJECT_SESSION_START)).toBe(true);
     expect(set.has(PROJECT_ACTIONS.PROJECT_SESSION_STOP)).toBe(true);
     expect(set.has(PROJECT_ACTIONS.PROJECT_TRIGGER_FIRE)).toBe(true);
-    // read leaves yes…
-    expect(set.has(PROJECT_ACTIONS.PROJECT_AGENT_READ)).toBe(true);
-    // …but NO write/config/gitops/members/deploy
+    // Agents/Connectors/Skills/Customize reads are editor-tier, NOT in the
+    // Member floor — a member gets zero default access to that surface.
+    expect(set.has(PROJECT_ACTIONS.PROJECT_AGENT_READ)).toBe(false);
+    expect(set.has(PROJECT_ACTIONS.PROJECT_CONNECTOR_READ)).toBe(false);
+    expect(set.has(PROJECT_ACTIONS.PROJECT_SKILL_READ)).toBe(false);
+    expect(set.has(PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ)).toBe(false);
+    // …and NO write/config/gitops/members/deploy
     expect(set.has(PROJECT_ACTIONS.PROJECT_WRITE)).toBe(false);
     expect(set.has(PROJECT_ACTIONS.PROJECT_AGENT_WRITE)).toBe(false);
     expect(set.has(PROJECT_ACTIONS.PROJECT_GITOPS_MERGE)).toBe(false);

--- a/apps/api/src/__tests__/unit-iam-v2-role-perms.test.ts
+++ b/apps/api/src/__tests__/unit-iam-v2-role-perms.test.ts
@@ -135,9 +135,11 @@ describe('IAM V2 — role helpers', () => {
 describe('IAM V2 — no unknown actions', () => {
   // IAM v1 per-capability leaves: backward-compat invariant. Editor must hold
   // every write leaf (it had all of these via project.write before). The floor
-  // Member role keeps MOST read leaves — EXCEPT file.read + secret.read, which
-  // moved to editor-tier (a member can run the agent/chat but can't browse the
-  // file tree or view secret values). Member must NOT gain any write leaf.
+  // Member role keeps only the non-Customize read leaves — file.read,
+  // secret.read, agent.read, connector.read, skill.read, and customize.read are
+  // ALL editor-tier: a plain member gets zero default access to Agents,
+  // Connectors, Skills, or the Customize surface. Member must NOT gain any
+  // write leaf.
   test('per-capability leaves preserve the editor/member capability surface', () => {
     const writeLeaves = [
       PROJECT_ACTIONS.PROJECT_AGENT_WRITE,
@@ -152,17 +154,18 @@ describe('IAM V2 — no unknown actions', () => {
     ];
     // Reads the floor member role keeps.
     const memberReadLeaves = [
-      PROJECT_ACTIONS.PROJECT_AGENT_READ,
-      PROJECT_ACTIONS.PROJECT_SKILL_READ,
       PROJECT_ACTIONS.PROJECT_COMMAND_READ,
-      PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ,
       PROJECT_ACTIONS.PROJECT_GITOPS_READ,
-      PROJECT_ACTIONS.PROJECT_CONNECTOR_READ,
     ];
-    // Sensitive reads that are now editor-tier (member is denied).
+    // Sensitive/Customize reads that are now editor-tier (member is denied):
+    // files, secrets, and the entire Agents/Connectors/Skills/Customize surface.
     const editorReadLeaves = [
       PROJECT_ACTIONS.PROJECT_FILE_READ,
       PROJECT_ACTIONS.PROJECT_SECRET_READ,
+      PROJECT_ACTIONS.PROJECT_AGENT_READ,
+      PROJECT_ACTIONS.PROJECT_CONNECTOR_READ,
+      PROJECT_ACTIONS.PROJECT_SKILL_READ,
+      PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ,
     ];
     for (const a of writeLeaves) {
       expect(projectRoleAllows('editor', a)).toBe(true);

--- a/apps/api/src/iam/role-perms.ts
+++ b/apps/api/src/iam/role-perms.ts
@@ -120,26 +120,35 @@ const EDITOR_EXTRAS: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_APP_DEPLOY,
 
   // Sensitive READS — moved out of the floor `member` role. A plain member can
-  // use the project (run the agent/chat) but can't browse the file tree via the
-  // files page or view secret values; editor+ retains both. Makes "project
-  // access without files/secrets" expressible as the built-in `member` role.
+  // read the project shell and its own sessions, but not browse the file tree,
+  // view secret values, or reach ANY of the "Customize" surface (Agents,
+  // Connectors, Skills, the customize hub itself). Editor+ retains all of it.
+  // Running an already-started/default session is unaffected — this only gates
+  // BROWSING/LAUNCHING agents by name and the Customize UI (see
+  // PROJECT_MEMBER_BASELINE below for the full rationale).
   PROJECT_ACTIONS.PROJECT_FILE_READ,
   PROJECT_ACTIONS.PROJECT_SECRET_READ,
+  PROJECT_ACTIONS.PROJECT_AGENT_READ,
+  PROJECT_ACTIONS.PROJECT_CONNECTOR_READ,
+  PROJECT_ACTIONS.PROJECT_SKILL_READ,
+  PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ,
 
   // Acting on a review item (approve / reject / answer) is a decision on agent
   // work — editor-tier, alongside gitops.
   PROJECT_ACTIONS.PROJECT_REVIEW_ACT,
 ];
 
-/** Baseline for the floor project role. `member` is the base *usable* role:
- *  it can read the project and start / run / stop sessions — i.e. actually use
- *  the agent and the chat — but NOT view secret values or browse the file tree
- *  (those moved to editor-tier). A role that can't open a session is useless,
- *  and this is the role new members get by default, so it has to be able to
- *  drive Kortix. What it CANNOT do is customize the project (edit settings,
- *  deploy, manage members, create/delete triggers) OR read files/secrets —
- *  those live in EDITOR_EXTRAS / MANAGER_ONLY above. Named PROJECT_MEMBER_* to
- *  avoid colliding with the account-role MEMBER_BASELINE above. */
+/** Baseline for the floor project role. `member` is a READ-ONLY, no-Customize
+ *  role: it can see the project shell, its sessions, and its member/trigger
+ *  list, and it can start/stop/fire what it's already scoped to — but it
+ *  CANNOT browse, launch-by-name, or manage Agents, Connectors, or Skills, and
+ *  it cannot open the Customize surface at all (project.customize.read lives in
+ *  EDITOR_EXTRAS now). Agents/Connectors/Skills/Customize are ALL editor-tier
+ *  by default: a plain member gets none of them unless an explicit per-resource
+ *  IAM v1 grant names them, or their role is bumped to editor/manager. This is
+ *  deliberate — access is opt-in via role/scope, never blanket-on-for-everyone.
+ *  Named PROJECT_MEMBER_* to avoid colliding with the account-role
+ *  MEMBER_BASELINE above. */
 const PROJECT_MEMBER_BASELINE: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_READ,
   PROJECT_ACTIONS.PROJECT_SESSION_READ,
@@ -152,17 +161,14 @@ const PROJECT_MEMBER_BASELINE: readonly string[] = [
   PROJECT_ACTIONS.PROJECT_GATEWAY_LOGS_READ,
   PROJECT_ACTIONS.PROJECT_GATEWAY_SPEND_READ,
 
-  // Per-capability read leaves (IAM v1). NOTE: project.file.read and
-  // project.secret.read are DELIBERATELY NOT here — they moved to EDITOR_EXTRAS
-  // so a floor `member` can run the agent/chat but can't browse the file tree or
-  // view secret values (the sensitive reads are an editor concern). This is the
-  // one place `member ⊂ editor` is a real capability difference on reads.
-  PROJECT_ACTIONS.PROJECT_AGENT_READ,
-  PROJECT_ACTIONS.PROJECT_SKILL_READ,
+  // Per-capability read leaves (IAM v1). NOTE: project.file.read,
+  // project.secret.read, project.agent.read, project.connector.read,
+  // project.skill.read, and project.customize.read are DELIBERATELY NOT here —
+  // they all moved to EDITOR_EXTRAS. A floor `member` gets NO default access to
+  // Agents/Connectors/Skills/Customize; that whole surface is editor-tier
+  // (or an explicit per-resource grant) by design.
   PROJECT_ACTIONS.PROJECT_COMMAND_READ,
-  PROJECT_ACTIONS.PROJECT_CUSTOMIZE_READ,
   PROJECT_ACTIONS.PROJECT_GITOPS_READ,
-  PROJECT_ACTIONS.PROJECT_CONNECTOR_READ,
   // Kortix Apps: a member sees the Apps the App access policy shares with
   // them. The policy, not this leaf, decides which Apps that is.
   PROJECT_ACTIONS.PROJECT_APP_READ,


### PR DESCRIPTION
## Summary

- MEMBER project role no longer gets default access to Agents, Connectors, Skills, or the Customize surface (frontend nav row + permission scopes). Previously PROJECT_MEMBER_BASELINE granted project.agent.read, project.connector.read, project.skill.read, and project.customize.read to every project member, so any member could browse/launch every agent and reach the Customize sidebar row with no explicit grant.
- Moves those 4 read leaves from PROJECT_MEMBER_BASELINE to EDITOR_EXTRAS in apps/api/src/iam/role-perms.ts (single source of truth). Only editor/manager roles (or an explicit per-resource IAM v1 grant via upsertResourceGrant) get default access now.
- No frontend code changes needed: the sidebar's ProjectCustomizeNavItem (useCapabilityTab) and the Settings overlay's per-tab gating (CUSTOMIZE_SECTION_ACCESS / isCustomizeSectionVisible) already read off these same IAM leaves, so the "Customize" row and the Channels/Secrets settings tabs disappear for members automatically.
- Updated 4 test files whose fixtures encoded the old member-baseline assumption (unit-iam-v2-role-perms.test.ts, unit-iam-role-presets.test.ts, and the two integration-project-*-leaf-gates-http.test.ts HTTP suites) to assert the new tier.

## Why

Member role should not have any default access to project customization or to launching/browsing agents. That access should only come from role (editor+) or an explicit granted scope, never on for everyone by default.

## Test plan

- [x] apps/api unit suite (env-file scripts/test.env): 7035 pass / 0 fail.
- [x] apps/api integration-project-read-leaf-gates-http.test.ts + integration-project-write-leaf-gates-http.test.ts against a real local DB: 184 pass / 0 fail.
- [x] Live HTTP: minted a real member token and an editor token on a seeded project. GET /oauth (connector.read) is 403 for member, 200 for editor. GET /projects/:id (project.read baseline) stays 200 for member.
- [x] Live browser: logged in as a real Supabase-authenticated member-role user via chrome-devtools MCP. Confirmed via a11y snapshot and network trace that the sidebar Customize row is gone, the Settings overlay's Channels/Secrets tabs are gone, and the IAM effective-permission probes for connector/agent/skill read all return allowed false, reason project_role_insufficient.
- [x] Confirmed the 6 unrelated failures seen in a full integration-suite run (computer-connector, approvals, agent-scope-http CR-merge, preview-agent-authz x3) reproduce identically on unmodified main. Pre-existing local-env flakiness, not a regression from this change.
