### PR TITLE
feat(web): unify secret Delivery + "Used by" into one Access picker

### DIFF
--- a/apps/web/content/docs/project/secrets.mdx
+++ b/apps/web/content/docs/project/secrets.mdx
@@ -46,17 +46,28 @@ the default when you omit it. See [Agents](/docs/project/agents).
 Delivery decides where the value is allowed to go. Every secret has one
 delivery mode. The default is **Sandbox**.
 
-| Delivery | The sandbox receives | Use it for |
-|---|---|---|
-| **Sandbox** | The plaintext value, as an environment variable | A local process or script that must read the value |
-| **Kortix service** | Nothing | The LLM gateway, a connector, Git, or one policy-bound HTTPS request Kortix makes for you |
-| **Network boundary** | Nothing | An ordinary HTTP client in the sandbox that calls one known host over HTTPS |
-| **Disabled** | Nothing | Keeping a value on file without letting anything use it |
+The Secrets page calls this control **Access** and offers six values, grouped
+by who uses them:
 
-**Sandbox** is the only mode that puts plaintext in the sandbox. Agent code
-can read, print, and forward it. Every other mode keeps the value outside.
+| Group | Access | The sandbox receives | Use it for |
+|---|---|---|---|
+| For your agent's own code | **Sandbox** | The plaintext value, as an environment variable | A local process or script that must read the value |
+| For your agent's own code | **Network boundary** | Nothing | An ordinary HTTP client in the sandbox that calls one known host over HTTPS |
+| For your agent's own code | **HTTPS broker** | Nothing | One policy-bound HTTPS request Kortix makes for you |
+| For a Kortix service | **LLM gateway** | Nothing | The Kortix model gateway |
+| For a Kortix service | **Connector** | Nothing | A connected app, such as Slack or a Git host |
+| — | **Disabled** | Nothing | Keeping a value on file without letting anything use it |
 
-Change the mode in the project's Secrets page, or from the CLI:
+A secret Kortix assigned for its own Git access shows as **Git service**
+instead, read-only — it is not one of the six values you can pick.
+
+**Sandbox** is the only value that puts plaintext in the sandbox. Agent code
+can read, print, and forward it. Every other value keeps it outside.
+
+Underneath, Access still stores one of four delivery modes plus, for
+**HTTPS broker**, **LLM gateway**, and **Connector**, which consumer reads it —
+the same pair the CLI and REST API use. Change it in the project's Secrets
+page, or from the CLI:
 
 ```bash
 kortix secrets delivery STRIPE_API_KEY denied
@@ -357,9 +368,9 @@ policy with `400` when you save it — it never stores a rule it cannot apply.
 The rule is the same on both mechanisms, so a policy written for one is a
 policy the other can run.
 
-Use Kortix service delivery with the HTTPS broker consumer when you need
-wildcards, paths, or method filters. Kortix makes that request itself, so it can
-enforce controls the boundary cannot.
+Use **HTTPS broker** Access when you need wildcards, paths, or method filters.
+Kortix makes that request itself, so it can enforce controls the boundary
+cannot.
 
 ### One header per host
 

--- a/apps/web/src/features/workspace/customize/sections/view/secret-delivery.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-delivery.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
-  brokerConsumerForSecret,
   buildBrokerPolicy,
   buildNetworkBoundaryPolicy,
   canSaveSecretDelivery,
   connectorBindingChanges,
   connectorBindingOptions,
+  defaultSecretAccess,
   missingAgentGrantNotice,
   networkBoundaryAvailability,
   networkBoundaryBlockedReason,
@@ -14,23 +14,90 @@ import {
   networkBoundaryMode,
   parseBoundaryHosts,
   readSecretDeliverySync,
+  secretAccessChoice,
+  secretAccessIsSystemManaged,
+  secretAccessTarget,
   secretDeliveryBlockedReason,
+  secretDeliveryLegend,
+  secretDeliveryOptionGroups,
   secretDeliveryOptions,
   secretDeliveryPresentation,
   secretDeliverySyncWarning,
   shouldWarnMissingAgentGrant,
 } from './secret-delivery';
 
-describe('brokerConsumerForSecret', () => {
-  test('keeps canonical consumers unchanged', () => {
-    expect(brokerConsumerForSecret('llm_gateway')).toBe('llm_gateway');
-    expect(brokerConsumerForSecret('connector')).toBe('connector');
-    expect(brokerConsumerForSecret('http_broker')).toBe('http_broker');
+describe('secretAccessChoice / secretAccessTarget', () => {
+  test('round-trips every choice through its stored strategy+consumer pair', () => {
+    const choices = [
+      'sandbox',
+      'network_boundary',
+      'http_broker',
+      'llm_gateway',
+      'connector',
+      'disabled',
+    ] as const;
+    for (const choice of choices) {
+      const target = secretAccessTarget(choice);
+      expect(secretAccessChoice(target.strategy, target.consumer)).toBe(choice);
+    }
   });
 
-  test('defaults unsupported consumers to the HTTPS broker', () => {
-    expect(brokerConsumerForSecret(null)).toBe('http_broker');
-    expect(brokerConsumerForSecret('sandbox')).toBe('http_broker');
+  test('a git_proxy row resolves to http_broker as a fallback, never to a real choice', () => {
+    expect(secretAccessChoice('broker', 'git_proxy')).toBe('http_broker');
+  });
+});
+
+describe('secretAccessIsSystemManaged', () => {
+  test('is true only for a git-connection-assigned row', () => {
+    expect(secretAccessIsSystemManaged('git_proxy')).toBe(true);
+    expect(secretAccessIsSystemManaged('sandbox')).toBe(false);
+    expect(secretAccessIsSystemManaged(null)).toBe(false);
+    expect(secretAccessIsSystemManaged(undefined)).toBe(false);
+  });
+});
+
+describe('defaultSecretAccess', () => {
+  test('an existing row opens on the value it has, including one the picker does not offer', () => {
+    expect(defaultSecretAccess({ strategy: 'broker', consumer: 'git_proxy' }, 'available')).toBe(
+      'http_broker',
+    );
+    expect(defaultSecretAccess({ strategy: 'runtime', consumer: 'sandbox' }, 'unsupported')).toBe(
+      'sandbox',
+    );
+  });
+
+  test('a new secret defaults to Network boundary where the project can deliver it', () => {
+    expect(defaultSecretAccess(null, 'available')).toBe('network_boundary');
+  });
+
+  test('a new secret defaults to Sandbox everywhere else', () => {
+    expect(defaultSecretAccess(null, 'unsupported')).toBe('sandbox');
+    expect(defaultSecretAccess(null, 'project_not_pinned')).toBe('sandbox');
+    expect(defaultSecretAccess(undefined, 'unsupported')).toBe('sandbox');
+  });
+});
+
+describe('secretDeliveryLegend', () => {
+  test('lists exactly the five pickable values, in picker order', () => {
+    expect(secretDeliveryLegend().map((entry) => entry.choice)).toEqual([
+      'sandbox',
+      'network_boundary',
+      'http_broker',
+      'llm_gateway',
+      'connector',
+      'disabled',
+    ]);
+  });
+
+  test('the wording matches secretDeliveryPresentation exactly — one source of truth', () => {
+    for (const entry of secretDeliveryLegend()) {
+      const target = secretAccessTarget(entry.choice);
+      expect(secretDeliveryPresentation(target.strategy, target.consumer)).toEqual({
+        label: entry.label,
+        description: entry.description,
+        tone: entry.tone,
+      });
+    }
   });
 });
 
@@ -52,8 +119,10 @@ describe('secretDeliveryPresentation', () => {
   });
 
   test('describes broker and egress without claiming sandbox access', () => {
+    // A 'broker' strategy with no recognized consumer falls back to the
+    // HTTPS broker presentation — see secretAccessChoice's default case.
     expect(secretDeliveryPresentation('broker').description).toBe(
-      'Used by an approved Kortix service without entering the sandbox.',
+      'Added only to an approved HTTPS request outside the sandbox.',
     );
     expect(secretDeliveryPresentation('egress').description).toBe(
       'Added to approved outbound requests at the network boundary.',
@@ -263,37 +332,65 @@ describe('networkBoundaryBlockedReason', () => {
 });
 
 describe('secretDeliveryOptions', () => {
-  test('offers the HTTPS broker and enables network delivery when the project runs on Platinum', () => {
-    const options = secretDeliveryOptions('runtime', 'available', 'available');
-    expect(options.map(({ strategy, disabled }) => ({ strategy, disabled }))).toEqual([
-      { strategy: 'runtime', disabled: false },
-      { strategy: 'broker', disabled: false },
-      { strategy: 'egress', disabled: false },
-      { strategy: 'denied', disabled: false },
+  test('offers all five values, network boundary enabled when the project runs on Platinum', () => {
+    const options = secretDeliveryOptions('sandbox', 'available', 'available');
+    expect(options.map(({ choice, disabled }) => ({ choice, disabled }))).toEqual([
+      { choice: 'sandbox', disabled: false },
+      { choice: 'network_boundary', disabled: false },
+      { choice: 'http_broker', disabled: false },
+      { choice: 'llm_gateway', disabled: false },
+      { choice: 'connector', disabled: false },
+      { choice: 'disabled', disabled: false },
     ]);
-    expect(options[2]?.disabledReason).toBeNull();
+    expect(options[1]?.disabledReason).toBeNull();
   });
 
-  test('keeps network delivery disabled when Platinum is unavailable', () => {
-    expect(secretDeliveryOptions('broker', 'available', 'unsupported')[1]?.disabled).toBe(false);
-    expect(secretDeliveryOptions('egress', 'available', 'unsupported')[2]).toMatchObject({
+  test('keeps network boundary disabled when Platinum is unavailable', () => {
+    expect(secretDeliveryOptions('http_broker', 'available', 'unsupported')[2]?.disabled).toBe(
+      false,
+    );
+    expect(secretDeliveryOptions('sandbox', 'available', 'unsupported')[1]).toMatchObject({
       disabled: true,
       disabledReason: SHIM_FIX,
     });
   });
 
-  test('disables network delivery on an unpinned project and states the fix', () => {
-    expect(secretDeliveryOptions('runtime', 'available', 'project_not_pinned')[2]).toMatchObject({
+  test('disables network boundary on an unpinned project and states the fix', () => {
+    expect(secretDeliveryOptions('sandbox', 'available', 'project_not_pinned')[1]).toMatchObject({
       disabled: true,
       disabledReason: PIN_FIX,
     });
   });
 
-  test('disables a selected non-runtime policy when the server marks it unavailable', () => {
-    expect(secretDeliveryOptions('broker', 'unavailable', 'available')[1]).toMatchObject({
+  test('disables a selected broker value when the server marks it unavailable', () => {
+    expect(secretDeliveryOptions('http_broker', 'unavailable', 'available')[2]).toMatchObject({
       disabled: true,
       disabledReason: 'Not available in this deployment.',
     });
+  });
+
+  test('leaves an unselected broker value enabled even when the server marks it unavailable', () => {
+    // `status` describes the SELECTED strategy's own deployment; it must not
+    // leak into a sibling broker value the dialog is not currently showing.
+    expect(secretDeliveryOptions('llm_gateway', 'unavailable', 'available')[2]).toMatchObject({
+      disabled: false,
+      disabledReason: null,
+    });
+  });
+});
+
+describe('secretDeliveryOptionGroups', () => {
+  test('buckets the flat list into "for your agent" then "for a Kortix service", in order', () => {
+    const groups = secretDeliveryOptionGroups(secretDeliveryOptions('sandbox', 'available', 'available'));
+    expect(groups.map((g) => ({ group: g.group, label: g.label, choices: g.options.map((o) => o.choice) }))).toEqual([
+      {
+        group: 'agent',
+        label: "For your agent's own code",
+        choices: ['sandbox', 'network_boundary', 'http_broker'],
+      },
+      { group: 'service', label: 'For a Kortix service', choices: ['llm_gateway', 'connector'] },
+      { group: 'none', label: null, choices: ['disabled'] },
+    ]);
   });
 });
 

--- a/apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secret-delivery.ts
@@ -14,12 +14,105 @@ export type ConnectorBindingOption = {
   description: string;
 };
 
-export type BrokerConsumer = 'llm_gateway' | 'connector' | 'http_broker';
+/**
+ * One Access value, as the picker offers it.
+ *
+ * The stored shape is two columns — `strategy` and `consumer` — and the
+ * picker used to make the user fill them in two steps: pick "Delivery", then
+ * for "Kortix service" pick "Used by". "Kortix service" was a UX grouping
+ * over three unrelated mechanisms (LLM gateway, HTTPS broker, Connector), not
+ * a delivery mechanism itself, and it forced a second screen to express a
+ * single choice. There are five mechanisms and the user picks exactly one, so
+ * there is exactly one control.
+ *
+ * `git_proxy` is deliberately NOT here. It is assigned by the git-connection
+ * flow (apps/api/src/projects/lib/git.ts) and nothing else ever writes it, so
+ * offering it as a sixth option would be offering a choice that does not
+ * exist. It still has a label and description for the rows that carry it —
+ * see `secretAccessIsSystemManaged` and `secretDeliveryPresentation`.
+ */
+export type SecretAccessChoice =
+  | 'sandbox'
+  | 'network_boundary'
+  | 'http_broker'
+  | 'llm_gateway'
+  | 'connector'
+  | 'disabled';
 
-export function brokerConsumerForSecret(consumer?: SecretConsumer | null): BrokerConsumer {
+/**
+ * The two things an Access value can be for.
+ *
+ * `agent` — the value serves code the project runs. Either it is IN the
+ * process (Sandbox) or it is attached to that code's outbound request and
+ * never in the process at all (Network boundary, HTTPS broker).
+ *
+ * `service` — the value serves a first-party Kortix service. The project's
+ * own code never touches it.
+ *
+ * This is ORDER and copy, not a second decision: grouping the list is what
+ * makes five flat options readable, and it costs the user no extra click.
+ */
+export type SecretAccessGroup = 'agent' | 'service' | 'none';
+
+export const SECRET_ACCESS_GROUP_LABEL: Record<SecretAccessGroup, string | null> = {
+  agent: "For your agent's own code",
+  service: 'For a Kortix service',
+  none: null,
+};
+
+/** The stored `strategy` + `consumer` pair one choice writes. */
+export function secretAccessTarget(choice: SecretAccessChoice): {
+  strategy: SecretDeliveryStrategy;
+  consumer: SecretConsumer | null;
+} {
+  switch (choice) {
+    case 'sandbox':
+      return { strategy: 'runtime', consumer: 'sandbox' };
+    case 'network_boundary':
+      return { strategy: 'egress', consumer: 'network' };
+    case 'http_broker':
+      return { strategy: 'broker', consumer: 'http_broker' };
+    case 'llm_gateway':
+      return { strategy: 'broker', consumer: 'llm_gateway' };
+    case 'connector':
+      return { strategy: 'broker', consumer: 'connector' };
+    case 'disabled':
+      return { strategy: 'denied', consumer: null };
+  }
+}
+
+/**
+ * Read a stored row back into the one value the picker shows.
+ *
+ * A `git_proxy` row resolves to `http_broker` here ON PURPOSE ONLY as a
+ * last-resort fallback: callers must check `secretAccessIsSystemManaged`
+ * first and never open the picker on such a row, because silently
+ * re-labelling a git-assigned secret as an HTTPS-broker secret would rewrite
+ * its consumer on the next save.
+ */
+export function secretAccessChoice(
+  strategy: SecretDeliveryStrategy,
+  consumer?: SecretConsumer | null,
+): SecretAccessChoice {
+  if (strategy === 'runtime') return 'sandbox';
+  if (strategy === 'egress') return 'network_boundary';
+  if (strategy === 'denied') return 'disabled';
   if (consumer === 'llm_gateway') return 'llm_gateway';
   if (consumer === 'connector') return 'connector';
   return 'http_broker';
+}
+
+/**
+ * True when Kortix assigned this row's Access and a human may not reassign
+ * it.
+ *
+ * Only the git-connection flow produces one. The picker has no `git_proxy`
+ * option, so an edit dialog opened on such a row would offer five values none
+ * of which is the one it has — and saving would move the secret off the
+ * consumer the git connection depends on.
+ */
+export function secretAccessIsSystemManaged(consumer?: SecretConsumer | null): boolean {
+  return consumer === 'git_proxy';
 }
 
 export function connectorBindingOptions(
@@ -69,66 +162,103 @@ export type SecretDeliveryPresentation = {
   tone: 'warning' | 'secondary' | 'outline';
 };
 
-const PRESENTATIONS: Record<SecretDeliveryStrategy, SecretDeliveryPresentation> = {
-  runtime: {
+/**
+ * The five pickable mechanisms, in the order the picker lists them.
+ *
+ * Order is the argument. Sandbox and Network boundary sit adjacent because
+ * they are the real either/or for one question — does the value go INTO the
+ * process, or does it only ever attach to that process's outbound request.
+ * The HTTPS broker closes that group as the policy-shaped version of the same
+ * idea. LLM gateway and Connector follow as a separate group: Kortix plumbing
+ * the project's code never interacts with, not a variant of the boundary.
+ *
+ * Wording is unchanged from the strategy-keyed table this replaces — only the
+ * key and the grouping are new — so every existing badge and sentence still
+ * reads exactly the same.
+ */
+const ACCESS_PRESENTATIONS: Record<
+  SecretAccessChoice,
+  SecretDeliveryPresentation & { group: SecretAccessGroup }
+> = {
+  sandbox: {
     // The only mode where agent code can read the value, so the badge is a
     // warning and not a neutral label. `secrets-view.tsx` says the same thing
-    // in longhand right below it (`InfoBanner tone="warning"`, "Readable inside
-    // the sandbox"); the two must agree.
+    // in longhand right below it (`InfoBanner tone="warning"`, "Readable
+    // inside the sandbox"); the two must agree.
     label: 'Sandbox',
     description: 'Available to agent code and commands as an environment variable.',
     tone: 'warning',
+    group: 'agent',
   },
-  broker: {
-    label: 'Kortix service',
-    description: 'Used by an approved Kortix service without entering the sandbox.',
-    tone: 'secondary',
-  },
-  egress: {
+  network_boundary: {
     label: 'Network boundary',
     description: 'Added to approved outbound requests at the network boundary.',
     tone: 'secondary',
+    group: 'agent',
   },
-  denied: {
+  http_broker: {
+    label: 'HTTPS broker',
+    description: 'Added only to an approved HTTPS request outside the sandbox.',
+    tone: 'secondary',
+    group: 'agent',
+  },
+  llm_gateway: {
+    label: 'LLM gateway',
+    description: 'Used for model requests without entering the sandbox.',
+    tone: 'secondary',
+    group: 'service',
+  },
+  connector: {
+    label: 'Connector',
+    description: 'Used by an authorized connector without entering the sandbox.',
+    tone: 'secondary',
+    group: 'service',
+  },
+  disabled: {
     label: 'Disabled',
     description: 'Stored securely, but unavailable to sessions and Kortix services.',
     tone: 'outline',
+    group: 'none',
   },
 };
+
+/**
+ * The one Access value no user can pick, so it lives outside the picker's
+ * table. Wording unchanged from the `git_proxy` branch this replaces.
+ */
+const GIT_SERVICE_PRESENTATION: SecretDeliveryPresentation = {
+  label: 'Git service',
+  description: 'Used for repository access without entering the sandbox.',
+  tone: 'secondary',
+};
+
+export type SecretDeliveryLegendEntry = SecretDeliveryPresentation & {
+  choice: SecretAccessChoice;
+  group: SecretAccessGroup;
+};
+
+/**
+ * Every Access value the page can show, in picker order.
+ *
+ * The Secrets page renders this as its "What each Access value means" legend.
+ * It reads the same table the picker and each row's badge read, which is the
+ * only reason the three can be trusted to agree.
+ */
+export function secretDeliveryLegend(): SecretDeliveryLegendEntry[] {
+  return (Object.keys(ACCESS_PRESENTATIONS) as SecretAccessChoice[]).map((choice) => ({
+    choice,
+    ...ACCESS_PRESENTATIONS[choice],
+  }));
+}
 
 export function secretDeliveryPresentation(
   strategy: SecretDeliveryStrategy,
   consumer?: SecretConsumer | null,
 ): SecretDeliveryPresentation {
-  if (strategy === 'broker' && consumer === 'llm_gateway') {
-    return {
-      label: 'LLM gateway',
-      description: 'Used for model requests without entering the sandbox.',
-      tone: 'secondary',
-    };
-  }
-  if (strategy === 'broker' && consumer === 'http_broker') {
-    return {
-      label: 'HTTPS broker',
-      description: 'Added only to an approved HTTPS request outside the sandbox.',
-      tone: 'secondary',
-    };
-  }
-  if (strategy === 'broker' && consumer === 'connector') {
-    return {
-      label: 'Connector',
-      description: 'Used by an authorized connector without entering the sandbox.',
-      tone: 'secondary',
-    };
-  }
-  if (strategy === 'broker' && consumer === 'git_proxy') {
-    return {
-      label: 'Git service',
-      description: 'Used for repository access without entering the sandbox.',
-      tone: 'secondary',
-    };
-  }
-  return PRESENTATIONS[strategy];
+  if (secretAccessIsSystemManaged(consumer)) return GIT_SERVICE_PRESENTATION;
+  const { group: _group, ...presentation } =
+    ACCESS_PRESENTATIONS[secretAccessChoice(strategy, consumer)];
+  return presentation;
 }
 
 export type NetworkBoundaryAvailability = 'available' | 'project_not_pinned' | 'unsupported';
@@ -216,32 +346,100 @@ export function networkBoundaryBlockedReason(
   return `Turn on "${SHIM_FLAG}" in Feature flags → Experimental, or pin this project to Platinum in Feature flags → Runtime → Sandbox provider.`;
 }
 
+/**
+ * The Access value the dialog opens with.
+ *
+ * An existing secret opens on the value it has — always, including a value
+ * the picker does not offer, so the caller can lock the control instead of
+ * showing the wrong one (see `secretAccessIsSystemManaged`).
+ *
+ * A NEW secret defaults to Network boundary wherever the project can deliver
+ * it, and to Sandbox everywhere else. Sandbox is the only value whose
+ * plaintext lands in a process the agent can read, so it is the one that
+ * should be chosen on purpose rather than by default.
+ */
+export function defaultSecretAccess(
+  row: { strategy: SecretDeliveryStrategy; consumer: SecretConsumer | null } | null | undefined,
+  networkBoundary: NetworkBoundaryAvailability,
+): SecretAccessChoice {
+  if (row) return secretAccessChoice(row.strategy, row.consumer);
+  return networkBoundary === 'available' ? 'network_boundary' : 'sandbox';
+}
+
 export type SecretDeliveryOption = SecretDeliveryPresentation & {
-  strategy: SecretDeliveryStrategy;
+  choice: SecretAccessChoice;
+  group: SecretAccessGroup;
   disabled: boolean;
   /** Why the option cannot be selected. Null when it can. */
   disabledReason: string | null;
 };
 
+/**
+ * Every Access value the user may pick, flat and in one list.
+ *
+ * `selected` is the value the dialog currently holds. It matters for exactly
+ * one case: a broker row whose backing service reports itself unavailable
+ * stays visible and disabled rather than vanishing, so the user can see what
+ * the secret is set to.
+ */
 export function secretDeliveryOptions(
-  selected: SecretDeliveryStrategy,
+  selected: SecretAccessChoice,
   status: SecretDeliveryStatus,
   networkBoundary: NetworkBoundaryAvailability,
 ): SecretDeliveryOption[] {
-  return (Object.keys(PRESENTATIONS) as SecretDeliveryStrategy[]).map((strategy) => {
+  const choices = Object.keys(ACCESS_PRESENTATIONS) as SecretAccessChoice[];
+  return choices.map((choice) => {
+    const presentation = ACCESS_PRESENTATIONS[choice];
+    const isBroker = secretAccessTarget(choice).strategy === 'broker';
     const disabledReason =
-      strategy === 'egress'
+      choice === 'network_boundary'
         ? networkBoundaryBlockedReason(networkBoundary)
-        : strategy === 'broker' && strategy === selected && status !== 'available'
+        : isBroker && choice === selected && status !== 'available'
           ? 'Not available in this deployment.'
           : null;
     return {
-      strategy,
-      ...PRESENTATIONS[strategy],
+      choice,
+      ...presentation,
       disabled: disabledReason !== null,
       disabledReason,
     };
   });
+}
+
+export type SecretDeliveryOptionGroup = {
+  group: SecretAccessGroup;
+  /** Null for the group that gets no heading. */
+  label: string | null;
+  options: SecretDeliveryOption[];
+};
+
+/**
+ * The same flat list, bucketed for rendering.
+ *
+ * Radix requires a `SelectLabel` to sit inside a `SelectGroup`, so the picker
+ * cannot emit a heading as a loose sibling between items — it throws
+ * "`SelectLabel` must be used within `SelectGroup`" and takes the page down
+ * with it. Grouping is therefore computed here rather than reconstructed in
+ * JSX, and the order within each group is the order `secretDeliveryOptions`
+ * produced.
+ */
+export function secretDeliveryOptionGroups(
+  options: readonly SecretDeliveryOption[],
+): SecretDeliveryOptionGroup[] {
+  const groups: SecretDeliveryOptionGroup[] = [];
+  for (const option of options) {
+    const current = groups[groups.length - 1];
+    if (current && current.group === option.group) {
+      current.options.push(option);
+      continue;
+    }
+    groups.push({
+      group: option.group,
+      label: SECRET_ACCESS_GROUP_LABEL[option.group],
+      options: [option],
+    });
+  }
+  return groups;
 }
 
 export type SecretDeliveryBlockedReason = 'no_agent_grant';

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.chrome.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.chrome.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Page chrome for Secrets. It is a sibling tab of Connectors / Agents /
+ * Skills / Triggers on the Customize bar and has to read as one: same
+ * `CapabilityPageShell`, same `max-w-5xl` column, same heading, same header
+ * group. It brought its own `max-w-2xl` column and its own
+ * `SettingsSectionHeader` before, which is what made it look like a different
+ * product beside the other four.
+ *
+ * Source-level assertions, following `schedule-view.test.tsx` and
+ * `connectors-page.global-rules.test.ts`: apps/web has no DOM testing library,
+ * and what is pinned here is WHERE a control is mounted, not what it renders.
+ */
+const source = readFileSync(join(import.meta.dir, 'secrets-view.tsx'), 'utf8');
+
+/** Comments name the old layout on purpose; assert on code only. */
+const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+const CHILDREN_START = '<div className="space-y-4">';
+const shellStart = code.indexOf('<CapabilityPageShell');
+const childrenStart = code.indexOf(CHILDREN_START);
+/** The shell's props — `title`, `description`, `search`, `action`, `filters`. */
+const shellHeader = code.slice(shellStart, childrenStart);
+/** Everything the shell renders as its content column. */
+const shellChildren = code.slice(childrenStart);
+
+describe('SecretsView page chrome', () => {
+  test('the page is the shared capability shell, not its own column', () => {
+    expect(shellStart).toBeGreaterThan(-1);
+    expect(childrenStart).toBeGreaterThan(shellStart);
+    expect(shellHeader).toContain('title="Secrets"');
+    // The two pieces of the old narrow layout, gone for good. The heading is
+    // written here rather than looked up: `secrets` is in neither registry
+    // `SettingsTabHeader` reads, and a missed lookup renders nothing at all.
+    expect(code).not.toContain('max-w-2xl');
+    expect(code).not.toContain('SettingsSectionHeader');
+    expect(code).not.toContain('SettingsTabHeader');
+    expect(code).not.toContain('CustomizeSectionWrapper');
+  });
+
+  /**
+   * The heading has to actually say something. A `title` with no `description`
+   * is the state the page was in — a word at the top of a bare table — so both
+   * are pinned, and the description has to name the mechanism rather than
+   * restate the title.
+   */
+  test('the heading explains what a secret is and how it reaches a session', () => {
+    const description = shellHeader.match(/description="([^"]+)"/)?.[1] ?? '';
+    expect(description.length).toBeGreaterThan(80);
+    expect(description).toContain('environment variable');
+  });
+
+  test('search and the Add action are the shell’s slots, not inline', () => {
+    expect(shellHeader).toContain('InputGroupSearchInput');
+    expect(shellHeader).toContain('onClick={openCreate}');
+    expect(shellChildren).not.toContain('InputGroupSearchInput');
+  });
+
+  /**
+   * Docs first, Add last — the pairing `SettingsTabHeader` renders for every
+   * pane that declares a `docsHref`. Secrets has no registry entry to declare
+   * one from, so losing the button is a silent regression unless it is pinned.
+   */
+  test('Docs sits beside Add in the one header cluster, secondary first', () => {
+    const action = shellHeader.slice(shellHeader.indexOf('action={'));
+    expect(action.indexOf('/docs/project/secrets')).toBeGreaterThan(-1);
+    expect(action.indexOf('/docs/project/secrets')).toBeLessThan(
+      action.indexOf('onClick={openCreate}'),
+    );
+  });
+
+  /**
+   * The Access legend is the shell's secondary row — where Skills and
+   * Connectors put their scope tabs — not a block in the content column above
+   * the table it explains. It must stay the collapsible built from the shared
+   * presentation table: a legend restated in JSX drifts from the badge.
+   */
+  test('the Access legend is the filters row, and reads the shared table', () => {
+    expect(shellHeader).toContain('filters={<SecretsAccessExplainer />}');
+    expect(shellChildren).not.toContain('<SecretsAccessExplainer />');
+    expect(code).toContain('secretDeliveryLegend()');
+    expect(code).toContain('What each Access value means');
+    expect(code).toContain('<Collapsible open={open} onOpenChange={setOpen}');
+    expect(code).toContain('<CollapsibleTrigger');
+    expect(code).toContain('<CollapsibleContent>');
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.delivery.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.delivery.test.ts
@@ -49,7 +49,7 @@ describe('SecretsView gates network-boundary delivery on the ACTIVE provider', (
   test('the dialog receives the availability and forwards it to the option builder', () => {
     expect(code).toContain('networkBoundary={networkBoundary}');
     expect(code).toContain('networkBoundary: NetworkBoundaryAvailability;');
-    expect(sliceBetween('secretDeliveryOptions(', ');')).toContain('networkBoundary,');
+    expect(sliceBetween('secretDeliveryOptions(', ');')).toContain('networkBoundary)');
   });
 
   test('the disabled option states its own reason instead of one fixed sentence', () => {
@@ -195,7 +195,10 @@ describe('SecretsView states the cost of an empty header template', () => {
  * the hosts the user typed and stops naming a host they can actually probe.
  */
 describe('SecretsView states the echo caveat in the boundary panel', () => {
-  const panel = sliceBetween("{strategy === 'egress' && (", "{strategy === 'broker' && (");
+  const panel = sliceBetween(
+    "{strategy === 'egress' && (",
+    "{strategy === 'broker' && access !== 'llm_gateway' && (",
+  );
 
   test('the scan found the network-boundary panel', () => {
     expect(panel.length).toBeGreaterThan(0);

--- a/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/secrets-view.tsx
@@ -4,6 +4,8 @@ import { useTranslations } from 'next-intl';
 
 import {
   AsteriskIcon as Asterisk,
+  BookOpenIcon,
+  CaretDownIcon,
   KeyIcon as KeyRound,
   LockSimpleIcon as Lock,
   DotsThreeIcon as MoreHorizontal,
@@ -16,6 +18,7 @@ import { type FormEvent, useCallback, useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   DropdownMenu,
@@ -46,7 +49,9 @@ import {
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
@@ -64,8 +69,8 @@ import { errorToast, infoToast, successToast, warningToast } from '@/components/
 import { Plus as PlusIcon } from '@/features/icon/icons/plus';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
+import { CapabilityPageShell } from '@/features/workspace/capabilities/shared/capability-page-shell';
 import { ProjectProviderModal } from '@/features/workspace/customize/sections/llm-provider/llm-provider-modal';
-import { SettingsTabHeader } from '@/features/workspace/settings/settings-tab-header';
 import { useSettingsNav } from '@/features/workspace/shared/settings-nav-context';
 import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
 import { cn } from '@/lib/utils';
@@ -95,6 +100,7 @@ import {
 import {
   type NetworkBoundaryAvailability,
   type NetworkBoundaryMode,
+  type SecretAccessChoice,
   type SecretDeliveryBlockedReason,
   agentGrantActionLabel,
   agentGrantCandidateHint,
@@ -103,18 +109,22 @@ import {
   agentGrantOutcome,
   agentGrantPlan,
   agentGrantSnippet,
-  brokerConsumerForSecret,
   buildBrokerPolicy,
   buildNetworkBoundaryPolicy,
   canSaveSecretDelivery,
   connectorBindingChanges,
   connectorBindingOptions,
+  defaultSecretAccess,
   missingAgentGrantNotice,
   networkBoundaryAvailability,
   networkBoundaryBlockedReason,
   networkBoundaryEchoNotice,
   networkBoundaryMode,
+  secretAccessIsSystemManaged,
+  secretAccessTarget,
   secretDeliveryBlockedReason,
+  secretDeliveryLegend,
+  secretDeliveryOptionGroups,
   secretDeliveryOptions,
   secretDeliveryPresentation,
   secretDeliverySyncWarning,
@@ -243,21 +253,24 @@ export function SecretsView({ projectId }: { projectId: string }) {
     }
   };
 
+  /** The list resolved. Neither header control means anything before it does. */
+  const showContent = !secretsQuery.isLoading && !secretsQuery.isError;
+
   return (
-    <>
-      <div className="mx-auto w-full max-w-2xl space-y-8">
-        <SettingsTabHeader
-          tab="secrets"
-          action={
-            !secretsQuery.isLoading && !secretsQuery.isError && canManage ? (
-              <Button size="sm" variant="secondary" onClick={openCreate}>
-                <PlusIcon className="size-4 shrink-0" />
-                Add
-              </Button>
-            ) : null
-          }
-        />
-        <div className="space-y-4">
+    <CapabilityPageShell
+      title="Secrets"
+      /* "the VALUE out of that machine" is exact, not hedged: an HTTPS
+         broker secret does put an env var in the sandbox — an opaque
+         handle under the same key (`apps/api/src/projects/secrets.ts`
+         `env[row.key] = await input.mintHandleFor(row)`), never the
+         credential. "Sandbox is the only mode that puts a value in the
+         sandbox" is the claim the API actually guarantees
+         (`deliversPlaintextToSandbox`, `apps/api/src/secrets/strategy.ts`). */
+      description="Encrypted credentials this project keeps out of its repository. Access decides where each value goes — Sandbox sets it as an environment variable inside the machine a session runs on, and every other mode keeps the value out of that machine."
+      search={
+        /* Hidden until there is a list to search, the same rule Triggers
+           uses: a filter over nothing is a control that cannot do anything. */
+        showContent && allRows.length > 0 ? (
           <InputGroupSearch>
             <InputGroupSearchIcon>
               <Search />
@@ -267,109 +280,134 @@ export function SecretsView({ projectId }: { projectId: string }) {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               variant="popover"
+              size="sm"
             />
             <InputGroupSearchClear onClick={() => setQuery('')} />
           </InputGroupSearch>
-
-          {secretsQuery.isLoading ? (
-            <div className="space-y-1">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <Skeleton key={i} className="h-10 rounded-md" />
-              ))}
-            </div>
-          ) : secretsQuery.isError ? (
-            <ErrorState
-              size="sm"
-              title={tHardcodedUi.raw(
-                'appProjectsIdCustomizeSecretsPage.line773JsxAttrTitleFailedToLoadSecrets',
-              )}
-              description={(secretsQuery.error as Error)?.message ?? 'Failed to load secrets'}
-              action={
-                <Button variant="outline" size="sm" onClick={() => secretsQuery.refetch()}>
-                  Retry
-                </Button>
-              }
-            />
-          ) : (
-            <>
-              {missingRequired.length > 0 && (
-                <InfoBanner
-                  tone="warning"
-                  icon={<DangerTriangleSolid weight="fill" />}
-                  title={`${missingRequired.length} required ${missingRequired.length === 1 ? 'secret' : 'secrets'} not set`}
-                >
-                  Sessions can still start, but the agent will be missing these values.
-                </InfoBanner>
-              )}
-
-              {filtered.length === 0 ? (
-                query.trim() ? (
-                  <p className="text-muted-foreground px-3 py-6 text-center text-xs">
-                    No matches for <span className="text-foreground font-mono">{query}</span>.
-                  </p>
-                ) : (
-                  <EmptyState
-                    icon={KeyRound}
-                    size="sm"
-                    title="No secrets yet"
-                    description="Add one to inject it into every new session."
-                    action={
-                      canManage ? (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="gap-1.5"
-                          onClick={openCreate}
-                        >
-                          <Plus className="size-3.5 shrink-0" />
-                          Add secret
-                        </Button>
-                      ) : undefined
-                    }
-                  />
-                )
-              ) : (
-                <Table className="overflow-hidden rounded-md">
-                  <TableHeader>
-                    <TableRow className="hover:bg-transparent">
-                      <TableHead>Identifier</TableHead>
-                      <TableHead>Value</TableHead>
-                      <TableHead>Access</TableHead>
-                      <TableHead className="w-[52px]">
-                        <span className="sr-only">Actions</span>
-                      </TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {filtered.map((row) => (
-                      <SecretTableRow
-                        key={row.identifier}
-                        row={row}
-                        canManage={canManage}
-                        busy={removeShared.isPending && removeShared.variables === row.identifier}
-                        onEdit={() => openEdit(row)}
-                        onDelete={() => setDeleteRow(row)}
-                      />
-                    ))}
-                  </TableBody>
-                </Table>
-              )}
-
-              <SecretDialog
-                key={dialogRow?.identifier ?? 'new'}
-                open={dialogOpen}
-                onOpenChange={setDialogOpen}
-                projectId={projectId}
-                row={dialogRow}
-                connectors={connectorsQuery.data?.connectors ?? []}
-                connectorsLoading={connectorsQuery.isLoading}
-                networkBoundary={networkBoundary}
-                boundaryMode={boundaryMode}
-                onSaved={refreshSecretsAndProviders}
-              />
-            </>
-          )}
+        ) : undefined
+      }
+      action={
+        /* One right-hand cluster, secondary control first, primary last —
+           the pairing `SettingsTabHeader` renders for every pane with a
+           `docsHref`. This page has no registry entry to declare one from,
+           so the same button is written here rather than dropped. */
+        <div className="flex min-w-0 items-center gap-2">
+          {/* New tab: this page is often open over live work. */}
+          <Button asChild variant="secondary" size="sm" className="gap-1.5">
+            <Link href="/docs/project/secrets" target="_blank" rel="noreferrer">
+              <BookOpenIcon className="size-3.5 shrink-0" />
+              Docs
+            </Link>
+          </Button>
+          {showContent && canManage ? (
+            <Button size="sm" variant="secondary" onClick={openCreate}>
+              <PlusIcon className="size-4 shrink-0" />
+              Add
+            </Button>
+          ) : null}
         </div>
+      }
+      /* The shell's secondary row — where Skills and Connectors put their
+         scope tabs. The legend is the same kind of thing: one small control
+         under the header that reframes the list below it. Collapsed it is a
+         single line, so it costs the table nothing; in the content column it
+         would sit between the header and the first row it explains. */
+      filters={<SecretsAccessExplainer />}
+    >
+      <div className="space-y-4">
+        {secretsQuery.isLoading ? (
+          <div className="space-y-1">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 rounded-md" />
+            ))}
+          </div>
+        ) : secretsQuery.isError ? (
+          <ErrorState
+            size="sm"
+            title={tHardcodedUi.raw(
+              'appProjectsIdCustomizeSecretsPage.line773JsxAttrTitleFailedToLoadSecrets',
+            )}
+            description={(secretsQuery.error as Error)?.message ?? 'Failed to load secrets'}
+            action={
+              <Button variant="outline" size="sm" onClick={() => secretsQuery.refetch()}>
+                Retry
+              </Button>
+            }
+          />
+        ) : (
+          <>
+            {missingRequired.length > 0 && (
+              <InfoBanner
+                tone="warning"
+                icon={<DangerTriangleSolid weight="fill" />}
+                title={`${missingRequired.length} required ${missingRequired.length === 1 ? 'secret' : 'secrets'} not set`}
+              >
+                Sessions can still start, but the agent will be missing these values.
+              </InfoBanner>
+            )}
+
+            {filtered.length === 0 ? (
+              query.trim() ? (
+                <p className="text-muted-foreground px-3 py-6 text-center text-xs">
+                  No matches for <span className="text-foreground font-mono">{query}</span>.
+                </p>
+              ) : (
+                <EmptyState
+                  icon={KeyRound}
+                  size="sm"
+                  title="No secrets yet"
+                  description="Add one to inject it into every new session."
+                  action={
+                    canManage ? (
+                      <Button variant="outline" size="sm" className="gap-1.5" onClick={openCreate}>
+                        <Plus className="size-3.5 shrink-0" />
+                        Add secret
+                      </Button>
+                    ) : undefined
+                  }
+                />
+              )
+            ) : (
+              <Table className="overflow-hidden rounded-md">
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead>Identifier</TableHead>
+                    <TableHead>Value</TableHead>
+                    <TableHead>Access</TableHead>
+                    <TableHead className="w-[52px]">
+                      <span className="sr-only">Actions</span>
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map((row) => (
+                    <SecretTableRow
+                      key={row.identifier}
+                      row={row}
+                      canManage={canManage}
+                      busy={removeShared.isPending && removeShared.variables === row.identifier}
+                      onEdit={() => openEdit(row)}
+                      onDelete={() => setDeleteRow(row)}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+
+            <SecretDialog
+              key={dialogRow?.identifier ?? 'new'}
+              open={dialogOpen}
+              onOpenChange={setDialogOpen}
+              projectId={projectId}
+              row={dialogRow}
+              connectors={connectorsQuery.data?.connectors ?? []}
+              connectorsLoading={connectorsQuery.isLoading}
+              networkBoundary={networkBoundary}
+              boundaryMode={boundaryMode}
+              onSaved={refreshSecretsAndProviders}
+            />
+          </>
+        )}
       </div>
       <ProjectProviderModal
         projectId={projectId}
@@ -400,7 +438,82 @@ export function SecretsView({ projectId }: { projectId: string }) {
         }}
         isPending={removeShared.isPending}
       />
-    </>
+    </CapabilityPageShell>
+  );
+}
+
+/**
+ * What the Access column actually means, folded away until asked for.
+ *
+ * The page shipped with a bare Identifier / Value / Access table and no words
+ * at all, so `Sandbox` beside `STRIPE_API_KEY` was a label with nothing behind
+ * it. The four values are four genuinely different places a value is allowed
+ * to reach — that distinction is the whole feature, and it was invisible.
+ *
+ * Collapsed by default, and one click from the badges it defines: four
+ * definitions permanently expanded above a five-row table would be a wall of
+ * text in front of the thing the page is for.
+ *
+ * The labels and sentences come from `secretDeliveryLegend()`, the same
+ * `ACCESS_PRESENTATIONS` table that renders each row's badge and each option
+ * in the dialog's Access picker. Restating them here in JSX is how the legend
+ * and the badge start disagreeing.
+ */
+function SecretsAccessExplainer() {
+  const [open, setOpen] = useState(false);
+  return (
+    /* `w-full` because the shell's filters row is a flex line: without it the
+       expanded legend shrink-wraps to its longest sentence instead of the
+       column. */
+    <Collapsible open={open} onOpenChange={setOpen} className="w-full">
+      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-xs font-medium transition-colors">
+        <CaretDownIcon
+          className={cn('size-3.5 shrink-0 transition-transform', open ? '' : '-rotate-90')}
+        />
+        What each Access value means
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <dl className="border-border bg-sidebar mt-2 flex flex-col gap-2.5 rounded-md border p-3">
+          {secretDeliveryLegend().map((mode) => (
+            <div key={mode.choice} className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+              <dt className="shrink-0 sm:w-36">
+                <Badge variant={mode.tone} size="sm">
+                  {mode.label}
+                </Badge>
+              </dt>
+              <dd className="text-muted-foreground min-w-0 text-xs text-pretty">
+                {mode.description}
+              </dd>
+            </div>
+          ))}
+          {/* Two things the list above cannot say on its own.
+
+              First, the grant. This used to name "Network boundary and the
+              HTTPS broker", which was wrong: `resolveSecretDelivery`
+              (apps/api/src/secrets/strategy.ts) returns `agent_grant_unscoped`
+              for EVERY strategy other than `runtime`, so LLM gateway and
+              Connector are gated by the identical rule. Sandbox is the one
+              exception, and it has to stay one — a project with no `agents:`
+              block hands every Sandbox secret to every agent, so a blanket
+              "a grant is always required" would be false for the default value
+              on most projects. See `shouldWarnMissingAgentGrant`.
+
+              Second, Git service: a value the picker does not offer, because
+              only the git-connection flow assigns it. A row can therefore show
+              a badge with no matching option, which reads as a bug unless the
+              page says who set it. */}
+          <p className="text-muted-foreground border-border mt-0.5 border-t pt-2.5 text-xs text-pretty">
+            Every value except <span className="text-foreground">Sandbox</span> reaches a session
+            only when its agent lists the identifier under{' '}
+            <code className="font-mono">secrets</code> in{' '}
+            <code className="font-mono">kortix.yaml</code>;{' '}
+            <code className="font-mono">secrets: all</code> does not count. A secret can also read{' '}
+            <span className="text-foreground">Git service</span>: Kortix assigns that one when you
+            connect a repository, and it cannot be chosen or changed here.
+          </p>
+        </dl>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -662,10 +775,24 @@ function SecretDialog({
   const [identifier, setIdentifier] = useState(row?.identifier ?? '');
   const [key, setKey] = useState(row?.key ?? '');
   const [value, setValue] = useState('');
-  const [strategy, setStrategy] = useState<SecretDeliveryStrategy>(row?.strategy ?? 'runtime');
-  const [brokerConsumer, setBrokerConsumer] = useState(() =>
-    brokerConsumerForSecret(row?.consumer),
+  /**
+   * ONE control, one piece of state. The dialog used to hold `strategy` and
+   * `brokerConsumer` separately and render a picker for each, which made
+   * "LLM gateway" a two-step answer to a one-step question. `strategy` and
+   * `consumer` are still what gets STORED — they are derived here, not typed
+   * by the user.
+   */
+  const [access, setAccess] = useState<SecretAccessChoice>(() =>
+    defaultSecretAccess(row, networkBoundary),
   );
+  const { strategy, consumer: accessConsumer } = secretAccessTarget(access);
+  /**
+   * The git connection owns this row's Access, so the picker must not be
+   * shown at all. It offers five values, none of them `git_proxy`; rendering
+   * it would silently move the secret off the consumer the git connection
+   * reads.
+   */
+  const accessLocked = secretAccessIsSystemManaged(row?.consumer);
   const [selectedConnectorSlugs, setSelectedConnectorSlugs] = useState<string[] | null>(null);
   const effectiveSelectedConnectorSlugs =
     selectedConnectorSlugs ??
@@ -698,8 +825,7 @@ function SecretDialog({
     setIdentifier(row?.identifier ?? '');
     setKey(row?.key ?? '');
     setValue('');
-    setStrategy(row?.strategy ?? 'runtime');
-    setBrokerConsumer(brokerConsumerForSecret(row?.consumer));
+    setAccess(defaultSecretAccess(row, networkBoundary));
     setSelectedConnectorSlugs(null);
     setBrokerHosts(currentPolicy?.rules.map((rule) => rule.host).join('\n') ?? '');
     setBrokerMethods(currentPolicy?.rules[0]?.methods?.join(', ') ?? 'POST');
@@ -733,10 +859,7 @@ function SecretDialog({
   const prepareSavePlan = (): SecretSavePlan => {
     const finalKey = (row?.key ?? key).trim().toUpperCase();
     const finalIdentifier = (row?.identifier ?? identifier).trim() || finalKey;
-    const nextConnectorSlugs =
-      strategy === 'broker' && brokerConsumer === 'connector'
-        ? effectiveSelectedConnectorSlugs
-        : [];
+    const nextConnectorSlugs = access === 'connector' ? effectiveSelectedConnectorSlugs : [];
     const bindingChanges = connectorBindingChanges(connectors, finalIdentifier, nextConnectorSlugs);
     if (!SECRET_NAME_REGEX.test(finalKey)) {
       throw new Error('Key: use A-Z, 0-9, _ only. Must start with a letter or _. Max 64 chars.');
@@ -753,33 +876,22 @@ function SecretDialog({
     if (strategy === 'runtime' && row?.requiresRotation && !value.trim()) {
       throw new Error('Enter a new value before making this secret readable in the sandbox.');
     }
-    if (strategy === 'broker' && brokerConsumer === 'http_broker' && !brokerPolicy) {
+    if (access === 'http_broker' && !brokerPolicy) {
       throw new Error('Complete the broker destination and credential placement.');
     }
     if (strategy === 'egress' && !networkBoundaryPolicy) {
       throw new Error('Add an exact HTTPS host and a valid header placement.');
     }
-    if (
-      strategy === 'broker' &&
-      brokerConsumer === 'connector' &&
-      nextConnectorSlugs.length === 0
-    ) {
+    if (access === 'connector' && nextConnectorSlugs.length === 0) {
       throw new Error('Select at least one connector.');
     }
 
-    const nextConsumer: SecretConsumer | null =
-      strategy === 'runtime'
-        ? 'sandbox'
-        : strategy === 'denied'
-          ? null
-          : strategy === 'egress'
-            ? 'network'
-            : brokerConsumer;
+    const nextConsumer: SecretConsumer | null = accessConsumer;
     const hasValueChange = Boolean(value.trim()) || !row?.configured;
     const egressPolicy =
       strategy === 'egress'
         ? (networkBoundaryPolicy ?? undefined)
-        : strategy === 'broker' && brokerConsumer === 'http_broker' && brokerPolicy
+        : access === 'http_broker' && brokerPolicy
           ? brokerPolicy
           : undefined;
     const shouldSetStrategy =
@@ -958,16 +1070,11 @@ function SecretDialog({
     : row.configured
       ? `Edit ${row.identifier}`
       : `Set ${row.identifier}`;
-  const selectedDelivery = secretDeliveryPresentation(
-    strategy,
-    strategy === 'broker' ? brokerConsumer : undefined,
-  );
+  const selectedDelivery = secretDeliveryPresentation(strategy, accessConsumer);
   const bindingIdentifier = (row?.identifier ?? identifier).trim() || key.trim().toUpperCase();
   const connectorOptions = connectorBindingOptions(connectors, bindingIdentifier);
-  const deliveryOptions = secretDeliveryOptions(
-    strategy,
-    row?.deliveryStatus ?? 'available',
-    networkBoundary,
+  const deliveryGroups = secretDeliveryOptionGroups(
+    secretDeliveryOptions(access, row?.deliveryStatus ?? 'available', networkBoundary),
   );
   const networkBoundaryNotice = networkBoundaryBlockedReason(networkBoundary);
   // A blocked project runs neither mechanism yet, and the fix above leads with
@@ -997,14 +1104,7 @@ function SecretDialog({
     requiresRotation: Boolean(row?.requiresRotation),
     currentStrategy: row?.strategy ?? 'runtime',
     nextStrategy: strategy,
-    nextConsumer:
-      strategy === 'runtime'
-        ? 'sandbox'
-        : strategy === 'denied'
-          ? null
-          : strategy === 'egress'
-            ? 'network'
-            : brokerConsumer,
+    nextConsumer: accessConsumer,
     brokerPolicyValid: brokerPolicy !== null,
     networkBoundaryPolicyValid: networkBoundaryPolicy !== null,
     selectedConnectorCount: effectiveSelectedConnectorSlugs.length,
@@ -1097,33 +1197,57 @@ function SecretDialog({
               )}
 
               <Field>
-                <FieldLabel htmlFor="secret-dialog-delivery">Delivery</FieldLabel>
-                <Select
-                  value={strategy}
-                  onValueChange={(next) => setStrategy(next as SecretDeliveryStrategy)}
-                  disabled={save.isPending}
-                >
-                  <SelectTrigger id="secret-dialog-delivery" className="min-h-10 w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {deliveryOptions.map((option) => (
-                      <SelectItem
-                        key={option.strategy}
-                        value={option.strategy}
-                        disabled={option.disabled}
-                        description={
-                          option.disabledReason
-                            ? `${option.description} ${option.disabledReason}`
-                            : option.description
-                        }
-                      >
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <FieldDescription>{selectedDelivery.description}</FieldDescription>
+                <FieldLabel htmlFor="secret-dialog-delivery">Access</FieldLabel>
+                {accessLocked ? (
+                  <div
+                    id="secret-dialog-delivery"
+                    className="border-border bg-sidebar rounded-md border p-3"
+                  >
+                    <Badge variant={selectedDelivery.tone} size="sm">
+                      {selectedDelivery.label}
+                    </Badge>
+                    <p className="text-muted-foreground mt-2 text-xs text-pretty">
+                      {selectedDelivery.description}
+                    </p>
+                  </div>
+                ) : (
+                  <Select
+                    value={access}
+                    onValueChange={(next) => setAccess(next as SecretAccessChoice)}
+                    disabled={save.isPending}
+                  >
+                    <SelectTrigger id="secret-dialog-delivery" className="min-h-10 w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    {/* One list, five values, no second screen. The group label
+                        is a heading, not an option: it says who the value
+                        serves — the project's own code, or a Kortix service
+                        the code never touches — without asking the user to
+                        choose that first. */}
+                    <SelectContent>
+                      {deliveryGroups.map((group) => (
+                        <SelectGroup key={group.group}>
+                          {group.label && <SelectLabel>{group.label}</SelectLabel>}
+                          {group.options.map((option) => (
+                            <SelectItem
+                              key={option.choice}
+                              value={option.choice}
+                              disabled={option.disabled}
+                              description={
+                                option.disabledReason
+                                  ? `${option.description} ${option.disabledReason}`
+                                  : option.description
+                              }
+                            >
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                {!accessLocked && <FieldDescription>{selectedDelivery.description}</FieldDescription>}
               </Field>
 
               {strategy === 'runtime' && (
@@ -1292,51 +1416,13 @@ function SecretDialog({
                 </div>
               )}
 
-              {strategy === 'broker' && (
+              {/* Only two of the three broker values configure anything: a
+                  Connector picks connectors, the HTTPS broker states a
+                  policy. LLM gateway needs nothing, so it renders no panel at
+                  all — which is exactly why "Used by" was never a step. */}
+              {strategy === 'broker' && access !== 'llm_gateway' && (
                 <div className="border-border bg-sidebar space-y-4 rounded-md border p-3">
-                  <div className="space-y-1">
-                    <p className="text-sm font-medium">Kortix service</p>
-                    <p className="text-muted-foreground text-xs">
-                      The selected service uses the value outside the sandbox.
-                    </p>
-                  </div>
-
-                  <Field>
-                    <FieldLabel htmlFor="secret-dialog-broker-consumer">Used by</FieldLabel>
-                    <Select
-                      value={brokerConsumer}
-                      onValueChange={(next) =>
-                        setBrokerConsumer(next as 'llm_gateway' | 'connector' | 'http_broker')
-                      }
-                      disabled={save.isPending}
-                    >
-                      <SelectTrigger id="secret-dialog-broker-consumer" className="w-full">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem
-                          value="llm_gateway"
-                          description="Kortix sends model requests. The sandbox receives no key."
-                        >
-                          LLM gateway
-                        </SelectItem>
-                        <SelectItem
-                          value="http_broker"
-                          description="Kortix adds the value to one approved HTTPS destination."
-                        >
-                          HTTPS broker
-                        </SelectItem>
-                        <SelectItem
-                          value="connector"
-                          description="An authorized connector uses the value. The sandbox receives no key."
-                        >
-                          Connector
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </Field>
-
-                  {brokerConsumer === 'connector' && (
+                  {access === 'connector' && (
                     <Field>
                       <FieldLabel>Connectors</FieldLabel>
                       {connectorsLoading ? (
@@ -1398,7 +1484,7 @@ function SecretDialog({
                     </Field>
                   )}
 
-                  {brokerConsumer === 'http_broker' && (
+                  {access === 'http_broker' && (
                     <>
                       <InfoBanner tone="neutral" title="Opaque sandbox handle">
                         The sandbox receives a session handle. Kortix adds the real value only to a


### PR DESCRIPTION
## Summary
- Collapses the Secrets edit dialog's two-step picker (Delivery, then "Used by" for Kortix service) into one `SecretAccessChoice` control: Sandbox, Network boundary, HTTPS broker, LLM gateway, Connector, Disabled — grouped as "for your agent's own code" vs "for a Kortix service".
- Git-assigned secrets (`git_proxy`) show as a locked, read-only "Git service" badge instead of a picker choice that doesn't exist.
- Adds a collapsed-by-default "What each Access value means" legend on the list page, reading the same presentation table as the row badges and the picker.
- Migrates the page shell from `SettingsTabHeader` to `CapabilityPageShell` (matches Connectors/Agents/Skills/Triggers) and adds a Docs link.
- Updates `apps/web/content/docs/project/secrets.mdx`'s Delivery section to describe the new six-value, two-group Access picker.
- Rebased on top of the `network_boundary_shim` / `networkBoundaryMode()` work already on `main`: the two-state `NetworkBoundaryAvailability`, the provider-edge-vs-in-guest-shim distinction, and the "Network boundary in-guest shim" flag name are untouched by this PR — only the dashboard's target-picking UI changes, not how network-boundary delivery is detected or gated.

## Test plan
- [x] `bun test secret-delivery.test.ts secrets-view.delivery.test.ts secrets-view.chrome.test.ts secret-optimistic-cache.test.ts` — 129/129 pass
- [x] `tsc --noEmit` clean on every touched file
- [x] `eslint` clean on every touched file
- [ ] Click through the reconciled Access picker on deployed dev after merge
