### PR TITLE
Hide IAM/Customize entry points the API would refuse, instead of 403-ing on click

### DIFF
--- a/apps/web/src/app/(app)/accounts/[id]/access-nav-gating.test.ts
+++ b/apps/web/src/app/(app)/accounts/[id]/access-nav-gating.test.ts
@@ -1,0 +1,63 @@
+// The account settings left rail must not offer a section the API will refuse.
+//
+// ENTITLEMENT gating (does this plan include the feature?) is covered by
+// `components/iam/enterprise-upsell.test.ts`. This file covers the other axis:
+// PERMISSION gating (may THIS caller read it at all?). The two are independent,
+// and conflating them is what produced the bug this file guards:
+//
+//   `GET /accounts/:id/iam/roles` asserts `role.read`
+//   (apps/api/src/accounts/iam/custom-roles.ts). `role.read` is in
+//   ADMIN_EXTRAS, NOT in the account `member` floor — unlike `member.read` and
+//   `group.read`, which are both in MEMBER_BASELINE
+//   (apps/api/src/iam/role-perms.ts). The rail hardcoded `roles: true` for
+//   "discoverability", so a plain member saw Roles, clicked it, and landed on
+//   "Failed to load roles — You don't have permission to perform this action
+//   (role.read)".
+//
+// Source assertions rather than a render test: the rail is a map of booleans
+// inside a large client page, and pinning the map is what stops the regression.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const pageSource = readFileSync(join(import.meta.dir, 'page.tsx'), 'utf8');
+
+const sectionVisible = pageSource.slice(
+  pageSource.indexOf('const sectionVisible'),
+  pageSource.indexOf('const activeSection'),
+);
+
+describe('Access rail gates each section on the permission its data fetch asserts', () => {
+  test('probes role.read, not just role.create', () => {
+    // role.create answers "can this caller MAKE a role", which is a different
+    // question from "may they LIST them" — probing only the former is exactly
+    // how the rail item stayed visible for a caller the list route refuses.
+    expect(pageSource).toContain("{ action: 'role.read' }");
+    expect(pageSource).toContain("{ action: 'role.create' }");
+    expect(pageSource).toContain('{ allowed: canReadRoles }');
+  });
+
+  test('Roles is hidden unless role.read came back allowed', () => {
+    expect(sectionVisible).toContain('roles: canReadRoles === true');
+    expect(sectionVisible).not.toMatch(/roles:\s*true/);
+  });
+
+  test('Members and Groups stay unconditional — both leaves are in the member floor', () => {
+    // Deliberate asymmetry, not an oversight: MEMBER_BASELINE carries
+    // member.read and group.read, so gating these would hide rows every member
+    // can actually open. Members is also the fallback section, so it must never
+    // resolve false.
+    expect(sectionVisible).toContain('members: true');
+    expect(sectionVisible).toContain('groups: true');
+  });
+
+  test('a denied deep link falls back to Members instead of an error pane', () => {
+    expect(pageSource).toContain(
+      'const activeSection: AccountSection = sectionVisible[requestedTab] ? requestedTab : \'members\'',
+    );
+  });
+
+  test('a group whose every item is hidden drops its heading too', () => {
+    expect(pageSource).toContain('group.items.filter((item) => sectionVisible[item.id])');
+  });
+});

--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -146,6 +146,15 @@ const ACCOUNT_PERMISSION_PROBES = [
   { action: 'group.create' },
   { action: 'audit.read' },
   { action: 'role.create' },
+  // Roles is the only Access section whose LIST call is not in the account
+  // `member` floor: `role.read` lives in ADMIN_EXTRAS while `member.read` and
+  // `group.read` are in MEMBER_BASELINE (`apps/api/src/iam/role-perms.ts`), and
+  // `GET /accounts/:id/iam/roles` asserts it (`accounts/iam/custom-roles.ts`).
+  // Probing `role.create` alone only answered "can this caller MAKE a role",
+  // which is why the rail item stayed visible for a plain member and the pane
+  // then failed with "You don't have permission to perform this action
+  // (role.read)".
+  { action: 'role.read' },
 ];
 
 const ROLE_LABEL: Record<AccountRole, string> = {
@@ -360,6 +369,7 @@ export default function AccountSettingsPage() {
     { allowed: canCreateGroup },
     { allowed: canReadAudit },
     { allowed: canManageRoles },
+    { allowed: canReadRoles },
   ] = usePermissions(accountId, ACCOUNT_PERMISSION_PROBES);
 
   const prefersReducedMotion = useReducedMotion();
@@ -386,13 +396,20 @@ export default function AccountSettingsPage() {
   const sectionVisible: Record<AccountSection, boolean> = {
     members: true,
     groups: true,
-    // Discoverable for everyone, same as Groups — the six built-in roles are
-    // free content (GET .../roles carries no entitlement check), and RolesTab
-    // itself already gates "New role" on rbacEnabled + canManage internally.
-    // This used to hide the rail item for non-admins, contradicting the
-    // comment above NAV_GROUPS (and this same file's own doc comment further
-    // up) that both should stay visible for discoverability.
-    roles: true,
+    // Discoverable for everyone the API will actually serve. The six built-in
+    // roles carry no ENTITLEMENT check (that was the gate this line was right
+    // to drop — RolesTab gates "New role" on rbacEnabled + canManage
+    // internally), but `GET /accounts/:id/iam/roles` still asserts the
+    // PERMISSION `role.read`, which is admin/owner-tier (ADMIN_EXTRAS in
+    // `apps/api/src/iam/role-perms.ts`) and NOT in the account `member` floor
+    // — unlike `member.read`/`group.read` above, which is why those two stay
+    // unconditional and this one cannot. Hardcoding `true` here showed a plain
+    // member a rail item that opened straight into "Failed to load roles — You
+    // don't have permission to perform this action (role.read)". Strict
+    // `=== true` (hidden until the probe answers yes) matches every other
+    // gated row in this map — audit, identity, billing, git, tokens, settings
+    // — rather than introducing a second, optimistic dialect on one line.
+    roles: canReadRoles === true,
     identity: canWriteAccount === true,
     billing: canWriteAccount === true && billingActive,
     transactions: canWriteAccount === true,

--- a/apps/web/src/features/workspace/capabilities/shared/capability-tabs.test.ts
+++ b/apps/web/src/features/workspace/capabilities/shared/capability-tabs.test.ts
@@ -98,9 +98,39 @@ describe('CapabilityTabs right-aligns Members and Settings', () => {
 
   test('ml-auto lands on the first trailing tab, inside the one shared TabsList', () => {
     const body = code(source);
-    expect(body).toContain("tab.key === TRAILING_TABS[0] && 'ml-auto'");
+    // Anchored on the first trailing tab STILL RENDERED, not hardcoded to
+    // TRAILING_TABS[0]: tabs are permission-filtered now, and pinning the
+    // spacer to 'members' loses it whenever members is the denied one, leaving
+    // Settings flush against the build-the-agent tabs.
+    expect(body).toContain(
+      'const trailingAnchor = TRAILING_TABS.find((key) => tabs.some((t) => t.key === key))',
+    );
+    expect(body).toContain("tab.key === trailingAnchor && 'ml-auto'");
     // One list, not two — this is a visual push, not a second `role="tablist"`.
     expect((body.match(/<TabsList\b/g) ?? []).length).toBe(1);
+  });
+});
+
+/**
+ * The bar links into pages that assert per-capability read leaves. Four of the
+ * eight — Connectors, Agents, Skills, Secrets — sit outside
+ * PROJECT_MEMBER_BASELINE, and their pages gate only WRITE controls, so an
+ * unfiltered bar handed a plain member four tabs that 403 on arrival.
+ */
+describe('CapabilityTabs hides tabs the caller is denied', () => {
+  test('probes the shared TAB_PREFERENCE table in one batch', () => {
+    const body = code(source);
+    expect(body).toContain('TAB_PREFERENCE');
+    expect(body).toContain('useProjectCans(projectId, TAB_ACTIONS)');
+  });
+
+  test('filters on an explicit deny only, never on !allowed', () => {
+    const body = code(source);
+    expect(body).toContain("caps[pref.action]?.allowed !== false");
+    expect(body).not.toContain("caps[pref.action]?.allowed === true");
+    // The rendered list is the filtered one.
+    expect(body).toContain('{tabs.map((tab) => (');
+    expect(body).not.toContain('{CAPABILITY_TABS.map((tab) => (');
   });
 });
 

--- a/apps/web/src/features/workspace/capabilities/shared/capability-tabs.tsx
+++ b/apps/web/src/features/workspace/capabilities/shared/capability-tabs.tsx
@@ -12,6 +12,8 @@ import {
   sidebarOpenerLabel,
   useShowPageSidebarOpener,
 } from '@/features/workspace/project-layout/sidebar-opener';
+import { TAB_PREFERENCE } from '@/features/workspace/project-sidebar/project-settings-nav';
+import { useProjectCans } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 
 import {
@@ -86,9 +88,34 @@ function CapabilitySidebarToggle() {
  */
 const TRAILING_TABS: readonly CapabilityTab['key'][] = ['members', 'config'];
 
+/** Stable across renders — `useProjectCans` keys its query on this list. */
+const TAB_ACTIONS: readonly string[] = TAB_PREFERENCE.map((t) => t.action);
+
 export function CapabilityTabs({ projectId }: { projectId: string }) {
   const pathname = usePathname();
   const activeKey = activeCapabilityTab(pathname);
+  // A tab whose destination the caller is denied is not rendered. Four of the
+  // eight — Connectors, Agents, Skills, Secrets — assert leaves that are NOT in
+  // PROJECT_MEMBER_BASELINE (apps/api/src/iam/role-perms.ts), and their pages
+  // gate only their WRITE controls, so the list GET still fired and 403'd into
+  // an error state. This bar was the last of four surfaces built on the same
+  // TAB_PREFERENCE table still rendering it unfiltered — the Customize rail
+  // (`project-settings-nav`), the Customize index (`customize-index-page`) and
+  // the project-home setup pills all already drop denied entries.
+  //
+  // Explicit deny only (`allowed === false`), never `!allowed`: an in-flight
+  // probe reports allowed:false, and a bar that empties on every cold load and
+  // refills is worse than one that briefly offers a tab.
+  const caps = useProjectCans(projectId, TAB_ACTIONS);
+  const tabs = CAPABILITY_TABS.filter((tab) => {
+    const pref = TAB_PREFERENCE.find((t) => t.key === tab.key);
+    return pref ? caps[pref.action]?.allowed !== false : true;
+  });
+  // `ml-auto` pushes the trailing pair to the right. Anchor it on the first
+  // trailing tab STILL PRESENT: hardcoding 'members' loses the spacer whenever
+  // members is the denied one, and Settings would then sit flush against the
+  // build-the-agent tabs instead of across the gap.
+  const trailingAnchor = TRAILING_TABS.find((key) => tabs.some((t) => t.key === key));
   // This bar is the first in-flow child of the capabilities layout, which the
   // layout's own doc confirms adds no vertical offset — so on the desktop
   // shell it starts at y=0 and shares the band with the OS window controls.
@@ -108,15 +135,12 @@ export function CapabilityTabs({ projectId }: { projectId: string }) {
           size="lg"
           className="h-auto w-full justify-start gap-5 border-b-0 px-2"
         >
-          {CAPABILITY_TABS.map((tab) => (
+          {tabs.map((tab) => (
             <TabsTrigger
               key={tab.key}
               value={tab.key}
               asChild
-              className={cn(
-                'w-fit flex-none px-1 py-3',
-                tab.key === TRAILING_TABS[0] && 'ml-auto',
-              )}
+              className={cn('w-fit flex-none px-1 py-3', tab.key === trailingAnchor && 'ml-auto')}
             >
               <Link href={capabilityTabHref(projectId, tab.key)} prefetch={true}>
                 {tab.label}

--- a/apps/web/src/features/workspace/project-layout/project-home.test.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-home.test.tsx
@@ -30,3 +30,52 @@ describe('ProjectHome sidebar toggle', () => {
     expect(source).not.toContain('sandbox_slug: activeSlug');
   });
 });
+
+/**
+ * The setup pill row links straight into Customize surfaces. A plain project
+ * `member` holds none of project.connector.read / skill.read / agent.read
+ * (they sit in EDITOR_EXTRAS, apps/api/src/iam/role-perms.ts), so an ungated
+ * row handed that user six buttons and a "forbidden" toast on click. Each pill
+ * now probes the SAME leaf its destination asserts, and disappears on an
+ * explicit deny.
+ */
+describe('ProjectHome setup tiles are gated by the permission their destination needs', () => {
+  const tileBlock = source.slice(
+    source.indexOf('const PROJECT_SETUP_TILES'),
+    source.indexOf('const SETUP_TILE_ACTIONS'),
+  );
+
+  test('every tile declares the action its destination asserts', () => {
+    // One `action:` per tile. A new pill without one is a pill that cannot be
+    // gated — the exact regression this row shipped with.
+    const tiles = tileBlock.match(/title: '/g) ?? [];
+    const actions = tileBlock.match(/action: PROJECT_ACTIONS\./g) ?? [];
+    expect(tiles.length).toBeGreaterThan(0);
+    expect(actions.length).toBe(tiles.length);
+  });
+
+  test('the leaves match TAB_PREFERENCE, the table the Customize rail already uses', () => {
+    for (const action of [
+      'PROJECT_CONNECTOR_READ',
+      'PROJECT_TRIGGER_READ',
+      'PROJECT_SKILL_READ',
+      'PROJECT_MEMBERS_READ',
+      'PROJECT_AGENT_READ',
+    ]) {
+      expect(tileBlock).toContain(`action: PROJECT_ACTIONS.${action}`);
+    }
+  });
+
+  test('probes in one batch and hides only on an explicit deny', () => {
+    // `allowed !== false`, never `allowed === true`: an in-flight probe reports
+    // allowed:false, so a truthiness gate would blank the row on every cold
+    // load and pop it back in.
+    expect(source).toContain('useProjectCans(projectId, SETUP_TILE_ACTIONS)');
+    expect(source).toContain('caps[tile.action]?.allowed !== false');
+    expect(source).not.toContain('caps[tile.action]?.allowed === true');
+  });
+
+  test('renders nothing rather than an empty strip when every tile is denied', () => {
+    expect(source).toContain('if (tiles.length === 0) return null;');
+  });
+});

--- a/apps/web/src/features/workspace/project-layout/project-home.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-home.tsx
@@ -47,7 +47,9 @@ import {
   projectSettingsSectionHref,
   type ProjectSettingsSectionKey,
 } from '@/features/workspace/capabilities/project-settings/project-settings-sections';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { STARTER_PROMPTS } from '@/lib/starter-prompts';
+import { useProjectCans } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import { useComposerPrefillStore } from '@/stores/composer-prefill-store';
 import {
@@ -494,6 +496,22 @@ type SetupTile = {
    * half of it.
    */
   href?: (projectId: string) => string;
+  /**
+   * The IAM leaf the tile's DESTINATION asserts. A tile whose probe comes back
+   * an explicit deny is not rendered: without this the row offered every user
+   * six buttons and a plain project `member` — who holds none of
+   * project.connector.read / skill.read / agent.read (they live in
+   * EDITOR_EXTRAS, `apps/api/src/iam/role-perms.ts`) — got a "forbidden" toast
+   * on click instead of a page.
+   *
+   * Each action is copied from `TAB_PREFERENCE`
+   * (`project-sidebar/project-settings-nav.tsx`), the single table that already
+   * maps a capability tab to the leaf its route asserts, so the pill row, the
+   * Customize rail and the Customize index all hide the same rows for the same
+   * caller. Do not invent a narrower leaf here — a pill that survives its own
+   * gate but 403s on arrival is the bug this field exists to prevent.
+   */
+  action: string;
 };
 
 const isCapabilityTabKey = (section: SetupTile['section']): section is CapabilityTab['key'] =>
@@ -506,18 +524,21 @@ const PROJECT_SETUP_TILES: SetupTile[] = [
     title: 'Connectors',
     desc: 'Connect tools your agent can act in.',
     section: 'connectors',
+    action: PROJECT_ACTIONS.PROJECT_CONNECTOR_READ,
   },
   {
     icon: CalendarClock,
     title: 'Triggers',
     desc: 'Run work on a repeating schedule, or when another app sends a signal.',
     section: 'triggers',
+    action: PROJECT_ACTIONS.PROJECT_TRIGGER_READ,
   },
   {
     icon: SparklesSolid,
     title: 'Skills',
     desc: 'Repeatable workflows your agent reuses.',
     section: 'skills',
+    action: PROJECT_ACTIONS.PROJECT_SKILL_READ,
   },
   {
     icon: Slack,
@@ -525,12 +546,17 @@ const PROJECT_SETUP_TILES: SetupTile[] = [
     desc: 'Run this project right from chat.',
     section: 'connectors',
     href: channelsHref,
+    // Channels is a SCOPE of the Connectors page, so it gates on the same leaf
+    // the Connectors tile does — exactly as TAB_PREFERENCE folded the old
+    // `channels` row into `project.connector.read`.
+    action: PROJECT_ACTIONS.PROJECT_CONNECTOR_READ,
   },
   {
     icon: UsersGroupSolid,
     title: 'Your team',
     desc: 'Invite people to run and review work.',
     section: 'members',
+    action: PROJECT_ACTIONS.PROJECT_MEMBERS_READ,
   },
   {
     icon: Kortix,
@@ -541,12 +567,27 @@ const PROJECT_SETUP_TILES: SetupTile[] = [
     // silently fall through to the Settings tab and land on its default
     // section instead of Agents.
     section: 'agent',
+    action: PROJECT_ACTIONS.PROJECT_AGENT_READ,
   },
 ];
 
+/** Stable across renders — `useProjectCans` keys its query on this list. */
+const SETUP_TILE_ACTIONS: readonly string[] = Array.from(
+  new Set(PROJECT_SETUP_TILES.map((t) => t.action)),
+);
+
 function ProjectHomeSections({ projectId }: { projectId: string }) {
   const router = useRouter();
-  const tiles = PROJECT_SETUP_TILES;
+  const caps = useProjectCans(projectId, SETUP_TILE_ACTIONS);
+  // Hide on an explicit deny only, never on `!allowed`: a probe still in
+  // flight reports `allowed:false`, so gating on truthiness would blank the
+  // whole row on every cold load and pop it back in. Same rule as
+  // `CustomizeIndexPage` and `ProjectCustomizeNavItem`.
+  const tiles = PROJECT_SETUP_TILES.filter((tile) => caps[tile.action]?.allowed !== false);
+
+  // A caller denied every destination gets no row at all, not an empty strip
+  // holding its gap/margin open under the composer.
+  if (tiles.length === 0) return null;
 
   return (
     <div className="flex w-full max-w-3xl flex-wrap items-center justify-center gap-2">


### PR DESCRIPTION
Two IAM surfaces rendered a control that the API then refused. The user's only feedback was an error *after* the click. Both are gated now on the exact permission their destination asserts, reusing the existing probe hooks — no new gating mechanism.

## 1. Project home setup pills

`apps/web/src/features/workspace/project-layout/project-home.tsx`

The row (Connectors / Triggers / Skills / Slack / Your team / Agent) rendered unconditionally. A plain project `member` holds none of `project.connector.read`, `project.skill.read`, `project.agent.read` — those sit in `EDITOR_EXTRAS` (`apps/api/src/iam/role-perms.ts`) — so **four of the six pills led to a "forbidden" toast**.

Each tile now declares the leaf its destination asserts, copied from `TAB_PREFERENCE` (`project-sidebar/project-settings-nav.tsx`) — the table the Customize rail and the Customize index already share:

| Pill | Destination | Permission |
|---|---|---|
| Connectors | `/projects/:id/connectors` | `project.connector.read` |
| Triggers | `/projects/:id/triggers` | `project.trigger.read` |
| Skills | `/projects/:id/skills` | `project.skill.read` |
| Slack | `/projects/:id/connectors?scope=channels` | `project.connector.read` |
| Your team | `/projects/:id/members` | `project.members.read` |
| Agent | `/projects/:id/agent` | `project.agent.read` |

One batched `useProjectCans` probe, not six. Hidden on an **explicit deny only** (`allowed !== false`), never on `!allowed` — an in-flight probe reports `allowed:false`, so a truthiness gate would blank the row on every cold load and pop it back in. Same rule as `CustomizeIndexPage` and `ProjectCustomizeNavItem`. A caller denied every destination gets no row at all rather than an empty strip holding its margin open.

## 2. Account Access rail — Roles

`apps/web/src/app/(app)/accounts/[id]/page.tsx`

`sectionVisible.roles` was hardcoded `true`. That was right about **entitlement** (`GET .../iam/roles` carries no `rbac` check, so the six built-in roles are free content) but wrong about **permission**: the route asserts `role.read`, which is admin/owner-tier (`ADMIN_EXTRAS`), while `member.read` and `group.read` are in the account `MEMBER_BASELINE`. A plain member saw Roles and landed on *"Failed to load roles — You don't have permission to perform this action (role.read)."*

The rail now probes `role.read` alongside the existing `role.create` probe and gates on it — `role.create` only ever answered "can this caller **make** a role", a different question from "may they **list** them".

Members and Groups stay unconditional on purpose: both leaves are in the member floor, and Members is also the fallback section. A `?tab=roles` deep link falls back to Members instead of an error pane. Entitlement behavior is untouched — `RolesTab` still mounts with `rbacEnabled` and gates "New role" itself.

## Verification (local stack, web `28000` / api `28008`, real API)

Seeded one owner and one **plain member** (account role `member`, project role `member`) on one account + one provisioned project.

**Gate inputs — `POST /accounts/:id/iam/members/:userId/effective:batch`:**

```
=== OWNER (HTTP 200) ===
  role.read                allowed=true  reason=super_admin
  member.read              allowed=true  reason=super_admin
  group.read               allowed=true  reason=super_admin
  project.connector.read   allowed=true  reason=super_admin
  project.skill.read       allowed=true  reason=super_admin
  project.agent.read       allowed=true  reason=super_admin
  project.trigger.read     allowed=true  reason=super_admin
  project.members.read     allowed=true  reason=super_admin

=== MEMBER (HTTP 200) ===
  role.read                allowed=false reason=account_role_insufficient
  member.read              allowed=true  reason=account_role
  group.read               allowed=true  reason=account_role
  project.connector.read   allowed=false reason=project_role_insufficient
  project.skill.read       allowed=false reason=project_role_insufficient
  project.agent.read       allowed=false reason=project_role_insufficient
  project.trigger.read     allowed=true  reason=project_role
  project.members.read     allowed=true  reason=project_role
```

**The bug, reproduced at the route:**

```
GET /accounts/:id/iam/roles as OWNER:  200 {"roles":[{"role_id":"builtin:manager",...
GET /accounts/:id/iam/roles as MEMBER: 403 {"error":true,"message":"You don't have permission to perform this action (role.read).","status":403}
```

**Rendered UI (Chromium, both callers), asserted on the DOM:**

| | MEMBER | OWNER |
|---|---|---|
| Access rail | `Members / Groups / How permissions work` — **no Roles** | `Settings / Git / Tokens · ACCESS Members / Groups / Roles · BILLING · ENTERPRISE` |
| `?tab=roles` deep link | falls back to Members; no "Failed to load roles", no `role.read` string | Roles pane loads, `Roles · 6` |
| Setup pills | `Triggers`, `Your team` only | all six present |

The member's rendered pill set matches the probe table exactly: the four denied leaves are the four hidden pills. Owner is unchanged on both surfaces — nothing over-gated.

## Checks

- `npx eslint` on both changed files: **0 errors** (3 pre-existing `react-hooks/set-state-in-effect` warnings, untouched).
- `npx tsc --noEmit` (apps/web): clean apart from the 15 known `@types/bun` `test.each` errors in the 3 files CLAUDE.md whitelists.
- `bun test` on the 3 affected test files: **26 pass / 0 fail**.

## Tests added

- `apps/web/src/app/(app)/accounts/[id]/access-nav-gating.test.ts` (new) — pins that the rail probes `role.read`, gates Roles on it, keeps Members/Groups unconditional (with the member-floor rationale), falls back to Members, and drops an empty group's heading.
- `project-home.test.tsx` — pins that every tile declares an action, that the leaves match `TAB_PREFERENCE`, that the probe is batched and hides only on an explicit deny, and that an all-denied row renders `null`. A new pill added without an `action` fails the count assertion.

## 3. Capability tab bar (found by the sweep, same bug class)

`apps/web/src/features/workspace/capabilities/shared/capability-tabs.tsx`

`CapabilityTabs` rendered all 8 entries of `CAPABILITY_TABS` unconditionally. Four — **Connectors, Agents, Skills, Secrets** — assert leaves outside `PROJECT_MEMBER_BASELINE`, and their pages gate only their *write* controls, so the list `GET` still fired and 403'd into an error state. Settings asserts `project.customize.write`.

This bar was the **last of four surfaces** built on the `TAB_PREFERENCE` table still rendering it unfiltered — `project-settings-nav` (Customize rail), `customize-index-page` (Customize index) and the project-home pills above all already drop denied entries. It now takes the same batched `useProjectCans` probe and hides on an explicit deny only.

The `ml-auto` spacer is re-anchored on the first trailing tab **still present**: hardcoding `TRAILING_TABS[0]` lost the gap whenever Members was the denied one, leaving Settings flush against the build-the-agent tabs.

Verified in the browser on the same seeded pair, asserted on `[role="tablist"]`:

| | Tabs rendered |
|---|---|
| OWNER | `Models, Connectors, Agents, Skills, Triggers, Secrets, Members, Settings` |
| MEMBER | `Models, Triggers, Members` — no permission error on the page |

Which matches the member's probe table exactly: Models → `project.read` ✅, Triggers → `project.trigger.read` ✅, Members → `project.members.read` ✅; Connectors/Agents/Skills denied, Secrets (`project.secret.read`) and Settings (`project.customize.write`) denied.

`capability-tabs.test.ts` gains two tests (batched `TAB_PREFERENCE` probe; explicit-deny-only filter on the rendered list) and its existing `ml-auto` test now pins the new anchor.

## Sweep — noted, not fixed

A time-boxed sweep of the same two areas turned up no other high-confidence 403 gap. Three ambiguous items, deliberately left alone:

- `accounts/[id]/page.tsx` — `tokens` / `billing` / `transactions` gate on `account.write`, but `token.read` and `billing.read` are in the member floor. That is the **inverse** (over-gating: a member who could read them never sees the rail item), not a 403 gap. Out of scope for this PR.
- `project-sandbox-alert.tsx:161` — ungated push to `config?section=sandbox`. Likely fine: that section's read leaf is `project.read` and `project-settings-page` filters sections itself. Inconsistent with the Settings *tab* gate, not a 403.
- `accounts/[id]/groups/[groupId]/page.tsx:222-230` — per-tab triggers unprobed; reaching the page already requires `group.read`, so Members is certainly fine and the other two are unverified.

## Final check state

- `bun test` across all 5 affected test files: **54 pass / 0 fail**.
- `npx eslint` on all changed files: **0 errors**.
