### PR TITLE
feat(worktree): nuke --all with time rules for bulk teardown

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -185,6 +185,34 @@ deleted with `git branch -d` (safe — refuses if unmerged); `--force` uses
 `git worktree remove --force` **and** `git branch -D` (drops unmerged commits).
 Only `nuke` after the work is merged or pushed.
 
+### `nuke --all` — bulk teardown with time rules
+
+```sh
+pnpm worktree nuke --all [--older-than <dur>] [--idle <dur>] [--include-dirty] [--dry-run] [--yes]
+pnpm worktree nuke --all --older-than 2d --yes      # everything created >2 days ago
+pnpm worktree nuke --all --idle 12h --dry-run       # preview: nothing touched in 12h
+```
+
+Scans every registry slot, prints one `keep`/`nuke` line per worktree with the
+reason, then tears down the selected ones with the same per-worktree `nukeOne`
+path as `nuke <n>` (stack stop, isolated-DB Docker cleanup, `git worktree
+remove`, `git branch -d`, slot freed). Selection rules, in order:
+
+- a **running** stack (web or api port answering) is always kept;
+- a slot whose **directory is missing** is always freed;
+- **uncommitted tracked changes** keep the worktree unless `--include-dirty`;
+- `--older-than <dur>` compares the registry `createdAt`;
+- `--idle <dur>` compares last activity = max(HEAD commit time, worktree index
+  mtime); a slot with no readable activity falls back to `createdAt`.
+
+Durations are `<n>m|h|d|w` (`30m`, `12h`, `3d`, `2w`). Both time rules must
+pass when both are given. With no time rule every stopped, clean slot is
+selected. A TTY asks for one confirmation for the whole batch; `--yes` or a
+non-TTY stdin skips it. Local branches survive as with `nuke <n>` (`-d` only,
+`--force` for `-D`), so committed work is never lost — only the checkout and
+its `node_modules` go. `bun` reads stdin: when calling from a shell loop, pass
+`</dev/null`.
+
 ### `pr` — push the branch and open a pull request
 
 ```sh

--- a/scripts/worktree/README.md
+++ b/scripts/worktree/README.md
@@ -27,6 +27,7 @@ pnpm worktree create --name migration-fix --db --yes
 | `pnpm worktree stop <n>` | Stop the dev servers — the whole process tree, verified dead before the registry records it. Isolated mode also stops that worktree's Supabase containers. **Data is preserved.** |
 | `pnpm worktree stop --all` | Stop every worktree in one pass. The end-of-day sweep, and the way back from stacks orphaned by an OOM kill. |
 | `pnpm worktree nuke <n> [--force]` | Tear down the app worktree: stop, `git worktree remove`, delete the slot's store, free the port slot. Isolated mode also drops its Supabase containers **and volumes**. Shared mode leaves primary Supabase untouched. |
+| `pnpm worktree nuke --all [--older-than 2d] [--idle 12h] [--include-dirty] [--dry-run] [--yes]` | Bulk teardown. Always keeps running stacks; frees slots whose directory is gone; keeps dirty checkouts unless `--include-dirty`; time rules filter on `createdAt` / last activity. Prints keep/nuke reasons before acting. |
 | `pnpm worktree list` | Every worktree with its live status and web/api ports, running first then alphabetical. Status comes from a real listening-port scan, not the registry, so it cannot go stale. |
 | `pnpm worktree list <name>` | Filter by substring. A single match expands to full clickable URLs (web, api, studio) plus its path. |
 | `pnpm worktree list [name] --json` | The same data as JSON on stdout for scripting — effective ports, both the probed and recorded status, and URLs. |

--- a/scripts/worktree/__tests__/prune.test.ts
+++ b/scripts/worktree/__tests__/prune.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { parseDuration, selectForPrune, type PruneCandidate } from '../lib';
+
+const DAY = 86_400_000;
+const NOW = Date.parse('2026-08-19T00:00:00Z');
+const c = (o: Partial<PruneCandidate> & { name: string }): PruneCandidate => ({
+  live: false, dirty: false, missing: false,
+  createdAt: new Date(NOW - 10 * DAY).toISOString(), lastActivity: NOW - 5 * DAY, ...o,
+});
+const verdict = (cands: PruneCandidate[], rule = {}, now = NOW) =>
+  Object.fromEntries(selectForPrune(cands, { includeDirty: false, ...rule }, now).map((v) => [v.name, v.nuke]));
+
+describe('parseDuration', () => {
+  test('units', () => {
+    expect(parseDuration('30m')).toBe(30 * 60_000);
+    expect(parseDuration('12h')).toBe(12 * 3_600_000);
+    expect(parseDuration('3d')).toBe(3 * DAY);
+    expect(parseDuration('2w')).toBe(14 * DAY);
+    expect(parseDuration(' 1.5d ')).toBe(1.5 * DAY);
+  });
+  test('rejects garbage', () => {
+    for (const s of ['', '3', 'd3', '3 days', '3s', '-1d']) expect(() => parseDuration(s)).toThrow();
+  });
+});
+
+describe('selectForPrune', () => {
+  test('no rule: every stopped clean slot is selected', () => {
+    expect(verdict([c({ name: 'a' }), c({ name: 'b' })])).toEqual({ a: true, b: true });
+  });
+  test('running stacks are never selected, even when dirty/old/missing flags say otherwise', () => {
+    expect(verdict([c({ name: 'run', live: true, missing: true })], { includeDirty: true })).toEqual({ run: false });
+  });
+  test('missing directory is always freed, even when dirty rule would keep it', () => {
+    expect(verdict([c({ name: 'gone', missing: true, dirty: true })])).toEqual({ gone: true });
+  });
+  test('dirty is kept unless --include-dirty', () => {
+    expect(verdict([c({ name: 'd', dirty: true })])).toEqual({ d: false });
+    expect(verdict([c({ name: 'd', dirty: true })], { includeDirty: true })).toEqual({ d: true });
+  });
+  test('--older-than compares createdAt', () => {
+    const cands = [
+      c({ name: 'old', createdAt: new Date(NOW - 10 * DAY).toISOString() }),
+      c({ name: 'new', createdAt: new Date(NOW - 1 * DAY).toISOString() }),
+      c({ name: 'unknown', createdAt: 'not-a-date' }),
+    ];
+    expect(verdict(cands, { olderThanMs: 3 * DAY })).toEqual({ old: true, new: false, unknown: false });
+  });
+  test('--idle compares lastActivity and falls back to createdAt when unknown', () => {
+    const cands = [
+      c({ name: 'idle', lastActivity: NOW - 5 * DAY }),
+      c({ name: 'busy', lastActivity: NOW - 3_600_000 }),
+      c({ name: 'noact', lastActivity: null, createdAt: new Date(NOW - 9 * DAY).toISOString() }),
+      c({ name: 'noact-new', lastActivity: null, createdAt: new Date(NOW - 1 * DAY).toISOString() }),
+    ];
+    expect(verdict(cands, { idleMs: 2 * DAY })).toEqual({ idle: true, busy: false, noact: true, 'noact-new': false });
+  });
+  test('both rules must pass', () => {
+    const cands = [
+      c({ name: 'old-but-active', createdAt: new Date(NOW - 30 * DAY).toISOString(), lastActivity: NOW - 3_600_000 }),
+      c({ name: 'new-but-idle', createdAt: new Date(NOW - 1 * DAY).toISOString(), lastActivity: NOW - 1 * DAY }),
+      c({ name: 'old-and-idle', createdAt: new Date(NOW - 30 * DAY).toISOString(), lastActivity: NOW - 10 * DAY }),
+    ];
+    expect(verdict(cands, { olderThanMs: 3 * DAY, idleMs: 2 * DAY })).toEqual({ 'old-but-active': false, 'new-but-idle': false, 'old-and-idle': true });
+  });
+  test('every verdict carries a reason', () => {
+    for (const v of selectForPrune([c({ name: 'a' }), c({ name: 'b', live: true }), c({ name: 'c', dirty: true })], { includeDirty: false }, NOW)) {
+      expect(v.why.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/scripts/worktree/cli.ts
+++ b/scripts/worktree/cli.ts
@@ -26,10 +26,12 @@ import {
   ensurePrimarySupabase, primaryCredsFromStatus, SHARED_SUPABASE_PORTS,
   killTree, stackRoots, stackPids, listenersOn, psTable, cwdTable,
   listenPorts, buildRows, sortRows, filterRows, renderRail, renderDetail, toJsonRows,
+  parseDuration, selectForPrune, type PruneCandidate,
   type Registry, type SlotEntry, type Ports, type Tunnel, type StripeListen,
   type DbMode, type KillResult,
 } from './lib';
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, rmSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, join as joinPath } from 'node:path';
 import * as clack from '@clack/prompts';
 import pc from 'picocolors';
 
@@ -164,6 +166,7 @@ ${pc.bgCyan(pc.black(' pnpm worktree '))}  ${pc.dim('isolated multi-instance dev
   ${pc.cyan('pnpm worktree')}                 ${pc.dim('interactive menu')}
   ${pc.cyan('pnpm worktree create')}          ${pc.dim('guided wizard (or --name <n> --from <branch> [--db] [--no-tunnel])')}
   ${pc.cyan('start')} ${pc.dim('<n> [--billing] [--stripe] [--no-tunnel]')}   ${pc.cyan('stop')} ${pc.dim('<n> | --all')}   ${pc.cyan('nuke')} ${pc.dim('<n> [n…] [--force] [--yes]')}
+  ${pc.cyan('nuke --all')} ${pc.dim('[--older-than 3d] [--idle 2d] [--include-dirty] [--dry-run] [--yes]')}   ${pc.dim('bulk: skips running stacks + dirty trees')}
   ${pc.cyan('pr')} ${pc.dim('<n> [--title … --base main --draft --web]')}
   ${pc.cyan('list')} ${pc.dim('[name] [--json]')}   ${pc.cyan('status')} ${pc.dim('[n]')}   ${pc.cyan('doctor')} ${pc.dim('[--yes]')}
 
@@ -654,7 +657,75 @@ async function nukeOne(name: string, e: SlotEntry, flags: Record<string, string 
  * individually in a TTY (answer no to skip one, Ctrl+C/Esc to stop the rest).
  * `--yes` or a non-TTY stdin keeps the old non-interactive behavior for scripts.
  */
+/**
+ * Snapshot one registry slot for the bulk selector. Impure by design: probes
+ * live ports, `git status`, HEAD commit time and the worktree index mtime.
+ */
+function pruneCandidate(name: string, e: SlotEntry, live: Set<number> | null): PruneCandidate {
+  const isLive = live ? live.has(e.ports.web) || live.has(e.ports.api) : e.status === 'running';
+  const missing = !existsSync(e.path);
+  let dirty = false;
+  let lastActivity: number | null = null;
+  if (!missing) {
+    dirty = sh(['git', '-C', e.path, 'status', '--porcelain', '--untracked-files=no']).stdout.trim().length > 0;
+    const head = Number(sh(['git', '-C', e.path, 'log', '-1', '--format=%ct']).stdout.trim());
+    if (Number.isFinite(head) && head > 0) lastActivity = head * 1000;
+    try {
+      // `<path>/.git` is a file: "gitdir: <repo>/.git/worktrees/<id>" — its index mtime is the last checkout/stage.
+      const gitFile = joinPath(e.path, '.git');
+      const gitdir = readFileSync(gitFile, 'utf8').replace(/^gitdir:\s*/, '').trim();
+      const idx = joinPath(isAbsolute(gitdir) ? gitdir : joinPath(e.path, gitdir), 'index');
+      const m = statSync(idx).mtimeMs;
+      lastActivity = lastActivity === null ? m : Math.max(lastActivity, m);
+    } catch {}
+  }
+  return { name, live: isLive, dirty, missing, createdAt: e.createdAt, lastActivity };
+}
+
+/**
+ * `nuke --all [--older-than <dur>] [--idle <dur>] [--include-dirty] [--dry-run]`
+ * — bulk teardown. Running stacks are never touched; checkouts with
+ * uncommitted tracked changes are kept unless --include-dirty; slots whose
+ * directory is already gone are always freed. Local branches survive as usual
+ * (`git branch -d` only, unless --force).
+ */
+async function cmdNukeAll(a: Args) {
+  const reg = loadRegistry();
+  const names = Object.keys(reg.slots);
+  if (!names.length) { ok('no worktrees registered — nothing to nuke'); return; }
+  const rule = {
+    olderThanMs: typeof a.flags['older-than'] === 'string' ? parseDuration(a.flags['older-than']) : undefined,
+    idleMs: typeof a.flags.idle === 'string' ? parseDuration(a.flags.idle) : undefined,
+    includeDirty: !!a.flags['include-dirty'],
+  };
+  step(`Scanning ${plural(names.length, 'worktree', 'worktrees')}`);
+  const live = listenPorts();
+  const candidates = names.map((n) => pruneCandidate(n, reg.slots[n], live));
+  const verdicts = selectForPrune(candidates, rule, Date.now());
+  const keep = verdicts.filter((v) => !v.nuke);
+  const nuke = verdicts.filter((v) => v.nuke);
+  for (const v of keep) sub(`${pc.dim('keep')} ${pc.bold(v.name)} ${pc.dim('— ' + v.why)}`);
+  for (const v of nuke) sub(`${pc.red('nuke')} ${pc.bold(v.name)} ${pc.dim('— ' + v.why)}`);
+  console.log();
+  if (!nuke.length) { ok(`nothing selected (${keep.length} kept)`); return; }
+  if (a.flags['dry-run']) { ok(`dry run: would nuke ${nuke.length}, keep ${keep.length}`); return; }
+  const confirm = !!process.stdin.isTTY && !!process.stdout.isTTY && !a.flags.yes;
+  if (confirm) {
+    const v = await clack.confirm({ message: `Nuke ${pc.bold(String(nuke.length))} worktrees and keep ${keep.length}?`, initialValue: false });
+    if (clack.isCancel(v) || !v) { clack.cancel('Cancelled — nothing was touched.'); return; }
+  }
+  let done = 0;
+  const failed: string[] = [];
+  for (const v of nuke) {
+    try { await nukeOne(v.name, reg.slots[v.name], a.flags); done++; }
+    catch (err: any) { failed.push(v.name); warn(`"${v.name}" failed: ${err?.message ?? err}`); }
+  }
+  ok(`nuked ${done}/${nuke.length} · kept ${keep.length}${failed.length ? ` · failed: ${failed.join(', ')}` : ''}`);
+  if (failed.length) process.exit(1);
+}
+
 async function cmdNuke(a: Args) {
+  if (a.flags.all) return cmdNukeAll(a);
   const names = (a.names.length ? a.names : [need(a.name)]).map(sanitizeName);
   const reg = loadRegistry();
   const targets: { name: string; e: SlotEntry }[] = [];
@@ -837,7 +908,7 @@ try {
     const r = await promptCreate();
     if (!r) process.exit(0);
     a = r;
-  } else if (tty && (a.cmd === 'nuke' || a.cmd === 'rm') && !a.names.length) {
+  } else if (tty && (a.cmd === 'nuke' || a.cmd === 'rm') && !a.names.length && !a.flags.all) {
     clack.intro(pc.bgCyan(pc.black(` pnpm worktree · ${a.cmd} `)));
     const names = await pickWorktrees(a.cmd);
     if (!names || !names.length) process.exit(0);

--- a/scripts/worktree/lib.ts
+++ b/scripts/worktree/lib.ts
@@ -28,5 +28,6 @@ export * from './lib/git';
 export * from './lib/supabase';
 export * from './lib/migrate';
 export * from './lib/launch-env';
+export * from './lib/prune';
 export * from './lib/services';
 export * from './lib/deps';

--- a/scripts/worktree/lib/prune.ts
+++ b/scripts/worktree/lib/prune.ts
@@ -1,0 +1,77 @@
+/**
+ * Bulk-nuke selection: pure rules over a snapshot of every registered worktree.
+ *
+ * `nuke --all` collects one PruneCandidate per registry slot (the impure probes
+ * — live ports, `git status`, index mtime — live in cli.ts) and asks
+ * `selectForPrune` which ones to tear down. Keeping the decision pure makes the
+ * time rules testable without a registry or a git repo.
+ */
+
+export interface PruneCandidate {
+  name: string;
+  /** web or api port answering — a live stack is never nuked in bulk. */
+  live: boolean;
+  /** tracked, uncommitted changes in the checkout. */
+  dirty: boolean;
+  /** registry slot whose directory is gone — always safe to free. */
+  missing: boolean;
+  /** registry createdAt (ISO). */
+  createdAt: string;
+  /** epoch ms of the last activity (max of HEAD commit time and index mtime); null when unknown. */
+  lastActivity: number | null;
+}
+
+export interface PruneRule {
+  /** only slots created more than this many ms ago. */
+  olderThanMs?: number;
+  /** only slots whose last activity is more than this many ms ago. */
+  idleMs?: number;
+  /** nuke checkouts with uncommitted tracked changes too (default: keep them). */
+  includeDirty: boolean;
+}
+
+export type PruneVerdict = { name: string; nuke: true; why: string } | { name: string; nuke: false; why: string };
+
+const UNIT_MS: Record<string, number> = { m: 60_000, h: 3_600_000, d: 86_400_000, w: 7 * 86_400_000 };
+
+/** "30m" | "12h" | "3d" | "2w" → ms. Throws on anything else. */
+export function parseDuration(s: string): number {
+  const m = /^(\d+(?:\.\d+)?)([mhdw])$/.exec(s.trim());
+  if (!m) throw new Error(`invalid duration "${s}" — use <n>m|h|d|w, e.g. 3d or 12h`);
+  return Math.round(Number(m[1]) * UNIT_MS[m[2]]);
+}
+
+export function formatAge(ms: number): string {
+  if (ms < 3_600_000) return `${Math.max(1, Math.round(ms / 60_000))}m`;
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h`;
+  return `${Math.round(ms / 86_400_000)}d`;
+}
+
+/**
+ * Order of precedence: a live stack is always kept; a missing directory is
+ * always freed; then dirty, then the time rules. With no time rule every
+ * non-live, non-dirty slot is selected.
+ */
+export function selectForPrune(candidates: PruneCandidate[], rule: PruneRule, nowMs: number): PruneVerdict[] {
+  return candidates.map((c) => {
+    if (c.live) return { name: c.name, nuke: false, why: 'stack is running' };
+    if (c.missing) return { name: c.name, nuke: true, why: 'directory missing — freeing stale slot' };
+    if (c.dirty && !rule.includeDirty) return { name: c.name, nuke: false, why: 'uncommitted changes (pass --include-dirty)' };
+    const createdMs = Date.parse(c.createdAt);
+    const age = Number.isFinite(createdMs) ? nowMs - createdMs : null;
+    if (rule.olderThanMs !== undefined) {
+      if (age === null) return { name: c.name, nuke: false, why: 'unknown createdAt' };
+      if (age < rule.olderThanMs) return { name: c.name, nuke: false, why: `created ${formatAge(age)} ago (< --older-than)` };
+    }
+    if (rule.idleMs !== undefined) {
+      const idle = c.lastActivity === null ? age : nowMs - c.lastActivity;
+      if (idle === null) return { name: c.name, nuke: false, why: 'unknown activity' };
+      if (idle < rule.idleMs) return { name: c.name, nuke: false, why: `active ${formatAge(idle)} ago (< --idle)` };
+    }
+    const parts: string[] = [];
+    if (age !== null) parts.push(`created ${formatAge(age)} ago`);
+    if (c.lastActivity !== null) parts.push(`last activity ${formatAge(nowMs - c.lastActivity)} ago`);
+    if (c.dirty) parts.push('dirty');
+    return { name: c.name, nuke: true, why: parts.join(', ') || 'no rule excludes it' };
+  });
+}


### PR DESCRIPTION
## What
`pnpm worktree nuke --all [--older-than <dur>] [--idle <dur>] [--include-dirty] [--dry-run] [--yes]` — bulk teardown of registered worktrees with time rules.

Selection (pure, `scripts/worktree/lib/prune.ts`):
- running stack (web/api port live) → always kept
- registry slot whose directory is gone → always freed
- uncommitted tracked changes → kept unless `--include-dirty`
- `--older-than` compares registry `createdAt`; `--idle` compares last activity = max(HEAD commit time, worktree index mtime), falls back to `createdAt`
- durations `<n>m|h|d|w`; both time rules must pass when both given

Prints one `keep`/`nuke` line with a reason per slot, asks once per batch in a TTY (`--yes` / non-TTY skips), then reuses `nukeOne` per target. Local branches survive as before (`git branch -d` only; `--force` for `-D`).

## Verified
- `bun test scripts/worktree/__tests__/` → 109 pass, 0 fail (12 new in `prune.test.ts`)
- `tsc --noEmit -p scripts/worktree/tsconfig.json` → clean
- Real run: `pnpm worktree nuke --all --older-than 2d --yes` → `nuked 109/109 · kept 18`; registry 127 → 18 slots; disk 2.7G → 287G free (after `git prune`/`gc`)
- `--dry-run` output correctly kept a worktree created 1m earlier by another session and the running `access-control-rehaul` stack

## Docs
`.claude/skills/worktree/SKILL.md` (new `nuke --all` section), `scripts/worktree/README.md` (command table row).
