### PR TITLE
fix(web): keep capability-tab-routes server-safe — unblocks Deploy Dev frontend build

### DIFF
--- a/apps/web/src/features/workspace/capabilities/shared/capability-tab-routes.ts
+++ b/apps/web/src/features/workspace/capabilities/shared/capability-tab-routes.ts
@@ -22,24 +22,14 @@
  * something outside it", and splitting that question across two top-level tabs
  * made the answer depend on knowing which direction the bytes travel.
  *
- * `icon`: a Phosphor icon component for the surfaces that have room for one —
- * the sidebar Customize row and the Customize index cards. The tab bar itself
- * is text-only (Marko, 2026-08-19: eight mixed 16px glyphs in one row read as
- * clutter; the Vercel/Linear text-tab pattern is the elegant one). The Members
- * launcher, which leaves the page for the account hub, carries a small
- * trailing ↗ instead of an icon.
+ * No `icon` field, on purpose. This module is pure data and is imported by
+ * SERVER components (`/projects/[id]/channels/page.tsx` needs `channelsHref`);
+ * a `@phosphor-icons/react` import here calls `createContext` at module load
+ * and fails `next build` ("Failed to collect page data" — Deploy Dev
+ * 2026-08-19). The tab bar is text-only anyway (Marko, 2026-08-19: eight mixed
+ * 16px glyphs in one row read as clutter); the sidebar Customize row and the
+ * index cards keep their own icons in their own client files.
  */
-import {
-  ClockCounterClockwiseIcon as TriggersIcon,
-  CubeIcon as ModelsIcon,
-  GearSixIcon as SettingsIcon,
-  LightningIcon as SkillsIcon,
-  LockKeyIcon as SecretsIcon,
-  PlugsIcon as ConnectorsIcon,
-  RobotIcon as AgentsIcon,
-  type Icon,
-} from '@phosphor-icons/react';
-
 export interface CapabilityTab {
   key:
     | 'agent'
@@ -50,7 +40,6 @@ export interface CapabilityTab {
     | 'secrets'
     | 'config';
   label: string;
-  icon: Icon;
 }
 
 /**
@@ -70,13 +59,13 @@ export interface CapabilityTab {
  * redirects here through `settings-tabs.ts`'s `GRADUATED` map.
  */
 export const CAPABILITY_TABS: readonly CapabilityTab[] = [
-  { key: 'models', label: 'Models', icon: ModelsIcon },
-  { key: 'connectors', label: 'Connectors', icon: ConnectorsIcon },
-  { key: 'agent', label: 'Agents', icon: AgentsIcon },
-  { key: 'skills', label: 'Skills', icon: SkillsIcon },
-  { key: 'triggers', label: 'Triggers', icon: TriggersIcon },
-  { key: 'secrets', label: 'Secrets', icon: SecretsIcon },
-  { key: 'config', label: 'Settings', icon: SettingsIcon },
+  { key: 'models', label: 'Models' },
+  { key: 'connectors', label: 'Connectors' },
+  { key: 'agent', label: 'Agents' },
+  { key: 'skills', label: 'Skills' },
+  { key: 'triggers', label: 'Triggers' },
+  { key: 'secrets', label: 'Secrets' },
+  { key: 'config', label: 'Settings' },
 ];
 
 export function capabilityTabHref(projectId: string, key: CapabilityTab['key']): string {

--- a/tests/e2e/specs/08-accounts-project-access.spec.ts
+++ b/tests/e2e/specs/08-accounts-project-access.spec.ts
@@ -170,13 +170,21 @@ async function openRepositoriesSection(page: Page, projectId: string) {
  * required.
  */
 async function openMembersSection(page: Page, projectId: string) {
+  // The per-project Members page is gone (2026-08-18/19): `/projects/:id/members`
+  // redirects into the account hub's Projects panel for that project
+  // (`?tab=access-projects&project=…`), which lists who has access as one
+  // shared `AccessList` and opens the shared "Grant access" dialog.
   await page.goto(`/projects/${projectId}/members`, {
     waitUntil: "domcontentloaded",
   });
   await dismissOnboarding(page);
-  await expect(
-    page.getByRole("heading", { name: "Members", exact: true }),
-  ).toBeVisible({ timeout: 30_000 });
+  await expect(page).toHaveURL(
+    new RegExp(`/accounts/[0-9a-f-]+\\?tab=access-projects&project=${projectId}`),
+    { timeout: 30_000 },
+  );
+  await expect(page.getByText(/^Access · \d+$/).first()).toBeVisible({
+    timeout: 30_000,
+  });
   return page;
 }
 
@@ -396,18 +404,28 @@ test.describe("08 — Accounts, invites, and project access", () => {
       `/projects/${project.project_id}`,
     );
     expect(readableProject.effective_project_role).toBe("member");
-    // A plain member is the floor *usable* role: it can start sessions and use the
-    // agent chat (this previously 403'd, which made the floor project role useless).
-    // It reaches provider validation just like an owner — an invalid provider is a
-    // 400, NOT the old role 403 (and avoids actually provisioning a sandbox here).
-    expect(
-      await apiStatus(
-        memberSession.access_token,
-        "POST",
-        `/projects/${project.project_id}/sessions`,
-        { provider: "justavps" },
-      ),
-    ).toBe(400);
+    // A plain member holds `project.session.start`, but agents are
+    // deny-by-default for member-tier (2026-08-19): with no agent grant —
+    // and this repo-URL project has no manifest, so there is no agent to
+    // grant — session create is refused with a NAMED reason, not the old
+    // "your role is too low" 403. Owners and managers are untouched (the
+    // owner already created sessions above). The granted-member happy path
+    // is pinned by `integration-member-session-prompt-gates-http.test.ts`.
+    {
+      const refused = await fetch(
+        `${apiBase}/projects/${project.project_id}/sessions`,
+        {
+          method: "POST",
+          headers: authHeaders(memberSession.access_token),
+          // A well-formed body: the agent gate answers before provider
+          // validation would, and an invalid provider would 400 first.
+          body: JSON.stringify({ name: "member-blocked" }),
+        },
+      );
+      expect(refused.status).toBe(403);
+      const refusedBody = (await refused.json()) as { code?: string };
+      expect(refusedBody.code).toBe("no_agent_access");
+    }
     // ...but it still cannot customize the project.
     expect(
       await apiStatus(
@@ -544,17 +562,21 @@ test.describe("08 — Accounts, invites, and project access", () => {
         response.request().method() === "POST",
     );
     await page.getByRole("button", { name: "Invite", exact: true }).click();
-    // Title renamed "Invite members" -> "Invite to account" (page.tsx's
-    // InviteMemberModal) — the account page's own invite composer, kept
-    // distinct from InviteMemberDialog's "Invite a member" above, which is
-    // the project-scoped one.
-    await expect(
-      page.getByRole("dialog", { name: "Invite to account" }),
-    ).toBeVisible();
-    await page.getByLabel("Emails").fill(uiInvitedEmail);
-    await page
-      .getByRole("dialog", { name: "Invite to account" })
-      .getByRole("button", { name: "Invite", exact: true })
+    // One shared "Grant access" dialog for every access surface (2026-08-19,
+    // `features/workspace/shared/access/access-dialog.tsx`): the account
+    // Invite button opens it in grant mode. A new person is invited by
+    // typing their email into the principal picker and choosing the
+    // "Invite <email>" row it surfaces — no separate email composer.
+    const grantDialog = page.getByRole("dialog", { name: "Grant access" });
+    await expect(grantDialog).toBeVisible();
+    await grantDialog
+      .getByPlaceholder("Search or type an email")
+      .fill(uiInvitedEmail);
+    await grantDialog
+      .getByRole("button", { name: `Invite ${uiInvitedEmail}` })
+      .click();
+    await grantDialog
+      .getByRole("button", { name: /^Grant access/ })
       .click();
     expect((await uiInviteResponse).status()).toBe(201);
     await expect(page.getByText(uiInvitedEmail, { exact: true })).toBeVisible();
@@ -607,46 +629,40 @@ test.describe("08 — Accounts, invites, and project access", () => {
     const membersPanel = await openMembersSection(page, project.project_id);
     // Wait for the initial access inventory before submitting a mutation.
     // Otherwise a slow pre-mutation response can overwrite the invalidated query.
-    // The member list is a `Table` now (`members-tab.tsx:926-1080`), so a
-    // member is a `row`, not a list item.
+    // Rows are the shared `AccessRow` (a list item), not a table row.
     await expect(
-      membersPanel.getByRole("row").filter({ hasText: ownerEmail }).first(),
+      membersPanel.getByRole("listitem").filter({ hasText: ownerEmail }).first(),
     ).toBeVisible();
-    // Inviting is a dialog off the People tab's own Invite button
-    // (`members-tab.tsx:888`, `InviteMemberDialog`), not the "Invite" tab the
-    // old members section carried. The dialog is portalled, so it is a sibling
-    // of the settings panel rather than a descendant.
-    await membersPanel.getByRole("button", { name: "Invite", exact: true }).click();
-    const inviteDialog = page.getByRole("dialog", { name: "Invite a member" });
-    await expect(inviteDialog).toBeVisible();
-    await inviteDialog.getByLabel("Email", { exact: true }).fill(memberEmail);
-    await inviteDialog.locator("#invite-member-role").click();
-    // Each option renders its role name plus a capability blurb, so the
-    // accessible name is "Member <blurb>" — matched on the role word only.
-    await page.getByRole("option", { name: /^Member\b/ }).click();
-    const accessInvite = page.waitForResponse(
+    // ONE "Grant access" dialog for every access surface: pick the account
+    // member in the principal picker, keep the default Member role, submit.
+    // An existing account member is granted through PUT /access/:userId (the
+    // invite route is only for people who are not on the account yet).
+    await membersPanel
+      .getByRole("button", { name: "Grant access", exact: true })
+      .click();
+    const grantAccessDialog = page.getByRole("dialog", { name: "Grant access" });
+    await expect(grantAccessDialog).toBeVisible();
+    await grantAccessDialog.getByRole("button", { name: memberEmail }).click();
+    const accessGrant = page.waitForResponse(
       (response) =>
         response
           .url()
-          .includes(`/v1/projects/${project.project_id}/access/invite`) &&
-        response.request().method() === "POST",
+          .includes(`/v1/projects/${project.project_id}/access/${member.id}`) &&
+        response.request().method() === "PUT",
     );
-    await inviteDialog.getByRole("button", { name: "Invite", exact: true }).click();
-    expect((await accessInvite).status()).toBe(200);
-    await expect(inviteDialog).toHaveCount(0);
+    await grantAccessDialog
+      .getByRole("button", { name: /^Grant access/ })
+      .click();
+    expect((await accessGrant).status()).toBe(200);
+    await expect(grantAccessDialog).toHaveCount(0);
     const memberAccessRow = membersPanel
-      .getByRole("row")
+      .getByRole("listitem")
       .filter({ hasText: memberEmail })
       .first();
     await expect(memberAccessRow).toBeVisible({ timeout: 15_000 });
-    // Third column = "Project role" (`members-tab.tsx:930-934`). Pinned by
-    // column because that select carries no accessible name of its own. The
-    // Account column (index 1) is a plain read-only link now, not a
-    // combobox — account-role editing moved to /accounts/:id entirely
-    // (2026-08-18) — so this row carries exactly one combobox.
-    await expect(
-      memberAccessRow.getByRole("cell").nth(2).getByRole("combobox"),
-    ).toContainText("Member");
+    // The row's trailing slot carries the role label — "Member" — and its
+    // meta says the member has no agent yet (deny-by-default).
+    await expect(memberAccessRow.getByText("Member", { exact: true })).toBeVisible();
 
     // Initialize member auth before persisting the organization. Otherwise the
     // auth reset clears the selection and the personal account wins /projects.

--- a/tests/e2e/specs/22-resource-grant-multiselect.spec.ts
+++ b/tests/e2e/specs/22-resource-grant-multiselect.spec.ts
@@ -115,19 +115,26 @@ test.describe('22 — Resource-grant multi-select', () => {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await dismissOnboarding(page);
 
-      await page.getByRole('tab', { name: 'Access', exact: true }).click();
-      await expect(page.getByText('No agents assigned', { exact: true })).toBeVisible();
-
+      // The per-project Members page is gone (2026-08-18/19): `/projects/:id/
+      // members` redirects into the account hub's Projects panel for this
+      // project, and agent access is a field of the ONE "Grant access" dialog
+      // (`features/workspace/shared/access/access-dialog.tsx`), not a separate
+      // "Assign an agent" flow. Members are deny-by-default for agents, so
+      // granting the two members with Agents = "Only these… → kortix" is what
+      // creates the two resource grants.
+      await expect(page).toHaveURL(
+        new RegExp(`/accounts/${accountId}\\?tab=access-projects&project=${projectId}`),
+      );
       await page.getByRole('button', { name: 'Grant access', exact: true }).click();
-      const dialog = page.getByRole('dialog', { name: 'Assign an agent', exact: true });
+      const dialog = page.getByRole('dialog', { name: 'Grant access', exact: true });
       await expect(dialog).toBeVisible();
 
-      // Multi-select on both sides: one agent, two members, one dialog, one
-      // submit. Both steps are Checkbox lists now (members-tab.tsx), not
-      // single-select dropdowns.
-      await dialog.getByRole('checkbox', { name: 'kortix', exact: true }).click();
+      // Multi-select principals in the shared picker (each row is a toggle
+      // button named by the member's email), then narrow Agents to kortix.
       await dialog.getByRole('button', { name: memberAEmail }).click();
       await dialog.getByRole('button', { name: memberBEmail }).click();
+      await dialog.getByRole('tab', { name: 'Only these…', exact: true }).click();
+      await dialog.getByRole('checkbox', { name: 'kortix', exact: true }).click();
 
       const grantPostStatuses: number[] = [];
       page.on('response', (r) => {
@@ -138,7 +145,8 @@ test.describe('22 — Resource-grant multi-select', () => {
           grantPostStatuses.push(r.status());
         }
       });
-      // 1 agent x 2 members = 2 total grants.
+      // 2 principals × 1 agent = 2 resource grants (plus one project-role
+      // write per principal, which is not what this contract counts).
       await dialog.getByRole('button', { name: 'Grant access (2)', exact: true }).click();
       await expect(dialog).toHaveCount(0, { timeout: 15_000 });
       await expect
@@ -147,11 +155,14 @@ test.describe('22 — Resource-grant multi-select', () => {
       // POST /resource-grants returns 201 (created), not 200.
       expect(grantPostStatuses).toEqual([201, 201]);
 
-      // The list re-renders with both grants, each labeled by the member it
-      // went to — not just a count, the actual two people.
-      await expect(page.getByText('kortix', { exact: true }).first()).toBeVisible();
-      await expect(page.getByText(`Member: ${memberAEmail}`, { exact: true })).toBeVisible();
-      await expect(page.getByText(`Member: ${memberBEmail}`, { exact: true })).toBeVisible();
+      // The access list re-renders with both people, each row carrying the
+      // narrowed agent count — the actual two rows, not just a total.
+      const rowA = page.getByRole('listitem').filter({ hasText: memberAEmail });
+      const rowB = page.getByRole('listitem').filter({ hasText: memberBEmail });
+      await expect(rowA).toBeVisible();
+      await expect(rowB).toBeVisible();
+      await expect(rowA.getByText(/Agents: 1\b/)).toBeVisible();
+      await expect(rowB.getByText(/Agents: 1\b/)).toBeVisible();
 
       // API is the source of truth for persistence, not the optimistic re-render.
       const after = await api<ResourceGrantsResponse>(


### PR DESCRIPTION
Deploy Dev run 32202272593 for #6531 failed at **Build frontend image**: `Failed to collect page data for /projects/[id]/channels — TypeError: createContext is not a function`.

Cause: #6531 added `@phosphor-icons/react` icon imports to `capability-tab-routes.ts` (a plain data module) for the tab bar; the `/projects/[id]/channels` **server** page imports `channelsHref` from that module, and Phosphor calls `createContext` at module load, which fails in the RSC graph during `next build` (`next dev` never evaluates that path). The tab bar had since gone text-only, so nothing reads `tab.icon` anymore.

Fix: drop the `icon` field and the Phosphor import — the module is pure data again, with a comment explaining why it must stay that way.

Verified: `npx next build` locally → ✓ Compiled, 202/202 static pages, exit 0 (was failing at page-data collection). `tsc` 0 new errors; `bun test src/features/workspace/capabilities src/features/workspace/project-sidebar` 625/0.
