### PR TITLE
fix(worktree): create --branch checks out a remote-only branch instead of forking HEAD

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -98,7 +98,7 @@ pnpm worktree create <n>        [flags]   # positional name also works
 | Flag | Default | Effect |
 | --- | --- | --- |
 | `--name <n>` / positional `<n>` | — (required) | Worktree name → branch name + slot identity. |
-| `--branch <b>` | `<n>` | Branch to use. If it already exists it's checked out; otherwise created from `--from`. |
+| `--branch <b>` | `<n>` | Branch to use. A local branch is checked out; a branch that exists only as `origin/<b>` (run `git fetch` first) is checked out tracking it; otherwise it is created from `--from`. |
 | `--from <ref>` | `HEAD` | Base ref for a newly created branch. Must carry current `packages/db/migrations` (see above). |
 | `--db` / `--with-db` / `--isolated-db` | off | Opt into the old full isolated Supabase project (`kortix-wt-<n>`) with its own containers/volumes/migrations. |
 | `--no-db` / `--shared-db` | on | Explicitly use the default shared primary Supabase DB. |

--- a/scripts/worktree/__tests__/git.test.ts
+++ b/scripts/worktree/__tests__/git.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { branchExists, remoteBranchExists, worktreeAddArgs } from '../lib';
+
+const git = (cwd: string, ...args: string[]) => {
+  const r = Bun.spawnSync(['git', '-C', cwd, ...args], { stdout: 'pipe', stderr: 'pipe' });
+  if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')}: ${r.stderr.toString()}`);
+  return r.stdout.toString().trim();
+};
+
+/** A clone with one local branch (`main`) and one remote-only branch (`origin/feature`). */
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'wt-git-'));
+  const origin = join(dir, 'origin.git');
+  const seed = join(dir, 'seed');
+  git(dir, 'init', '-q', '--bare', origin);
+  git(dir, 'init', '-q', '-b', 'main', seed);
+  git(seed, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '--allow-empty', '-m', 'root');
+  git(seed, 'branch', 'feature');
+  git(seed, 'remote', 'add', 'origin', origin);
+  git(seed, 'push', '-q', 'origin', 'main', 'feature');
+  const clone = join(dir, 'clone');
+  git(dir, 'clone', '-q', origin, clone);
+  git(clone, 'checkout', '-q', 'main');
+  return clone;
+}
+
+describe('worktreeAddArgs', () => {
+  test('a branch that exists only on origin is checked out tracking origin/<branch>, not created from HEAD', () => {
+    const root = fixture();
+    expect(branchExists(root, 'feature')).toBe(false);
+    expect(remoteBranchExists(root, 'feature')).toBe(true);
+    const { args, mode } = worktreeAddArgs(root, '/tmp/wt', 'feature', 'HEAD');
+    expect(mode).toBe('remote');
+    expect(args.slice(3)).toEqual(['worktree', 'add', '--track', '-b', 'feature', '/tmp/wt', 'origin/feature']);
+  });
+  test('a local branch is checked out as-is', () => {
+    const root = fixture();
+    const { args, mode } = worktreeAddArgs(root, '/tmp/wt', 'main', 'HEAD');
+    expect(mode).toBe('local');
+    expect(args.slice(3)).toEqual(['worktree', 'add', '/tmp/wt', 'main']);
+  });
+  test('an unknown branch is created from --from', () => {
+    const root = fixture();
+    const { args, mode } = worktreeAddArgs(root, '/tmp/wt', 'brand-new', 'main');
+    expect(mode).toBe('new');
+    expect(args.slice(3)).toEqual(['worktree', 'add', '-b', 'brand-new', '/tmp/wt', 'main']);
+  });
+  test('the remote argv really checks out the remote tip', () => {
+    const root = fixture();
+    const wt = join(root, '..', 'wt-feature');
+    const { args } = worktreeAddArgs(root, wt, 'feature', 'HEAD');
+    const r = Bun.spawnSync(args, { stdout: 'pipe', stderr: 'pipe' });
+    expect(r.exitCode).toBe(0);
+    expect(git(wt, 'rev-parse', 'HEAD')).toBe(git(root, 'rev-parse', 'origin/feature'));
+    expect(git(wt, 'rev-parse', '--abbrev-ref', '@{upstream}')).toBe('origin/feature');
+  });
+});

--- a/scripts/worktree/cli.ts
+++ b/scripts/worktree/cli.ts
@@ -19,7 +19,7 @@
  */
 import {
   STRIDE, BASE, computePorts, loadRegistry, saveRegistry, withLock, sanitizeName,
-  lowestFreeSlot, sh, run, which, portInUse, repoRoot, defaultWorktreePath, branchExists,
+  lowestFreeSlot, sh, run, which, portInUse, repoRoot, defaultWorktreePath, branchExists, worktreeAddArgs,
   renderSupabaseProject, runMigrate, supa, supaStatusEnv, slotCredsFromStatus, apiLaunchEnv, webLaunchEnv, gatewayLaunchEnv,
   writeMarker, ensureDeps, checkDeps, supaWorkdir, slotDir, startTunnel, startStripeListen, WT_HOME, REGISTRY_PATH,
   startSupabaseDb, startSupabaseFullStack, hasKortixSchema, ensureRuntimeArtifacts, dbModeOf,
@@ -393,14 +393,13 @@ async function cmdCreate(a: Args) {
   const existing = sh(['git', '-C', root, 'worktree', 'list', '--porcelain']).stdout;
   if (existing.includes(`worktree ${wtPath}`)) {
     sub('already exists — reusing');
-  } else if (branchExists(root, branch)) {
-    const r = sh(['git', '-C', root, 'worktree', 'add', wtPath, branch]);
-    if (!r.ok) await failCreate(`git worktree add failed: ${r.stderr}`);
-    sub(`checked out existing branch "${branch}"`);
   } else {
-    const r = sh(['git', '-C', root, 'worktree', 'add', '-b', branch, wtPath, from]);
-    if (!r.ok) await failCreate(`git worktree add -b failed: ${r.stderr}`);
-    sub(`created branch "${branch}" from ${from}`);
+    const { args, mode } = worktreeAddArgs(root, wtPath, branch, from);
+    const r = sh(args);
+    if (!r.ok) await failCreate(`${args.slice(0, 5).join(' ')} failed: ${r.stderr}`);
+    if (mode === 'local') sub(`checked out existing branch "${branch}"`);
+    else if (mode === 'remote') sub(`checked out "${branch}" tracking origin/${branch}`);
+    else sub(`created branch "${branch}" from ${from}`);
   }
 
   // Use the shared global pnpm store (default). Each worktree still has its own

--- a/scripts/worktree/lib/git.ts
+++ b/scripts/worktree/lib/git.ts
@@ -12,3 +12,18 @@ export function defaultWorktreePath(root: string, name: string): string {
 export function branchExists(root: string, branch: string): boolean {
   return sh(['git', '-C', root, 'rev-parse', '--verify', '--quiet', `refs/heads/${branch}`]).ok;
 }
+/** True when `origin/<branch>` exists locally (after a fetch) but no local branch does. */
+export function remoteBranchExists(root: string, branch: string): boolean {
+  return sh(['git', '-C', root, 'rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`]).ok;
+}
+/**
+ * The `git worktree add` argv for `branch`: check out the local branch when it
+ * exists; otherwise create it tracking `origin/<branch>` when that ref exists;
+ * otherwise create it from `from`. Pure — callers run it.
+ */
+export function worktreeAddArgs(root: string, wtPath: string, branch: string, from: string): { args: string[]; mode: 'local' | 'remote' | 'new' } {
+  if (branchExists(root, branch)) return { args: ['git', '-C', root, 'worktree', 'add', wtPath, branch], mode: 'local' };
+  if (remoteBranchExists(root, branch))
+    return { args: ['git', '-C', root, 'worktree', 'add', '--track', '-b', branch, wtPath, `origin/${branch}`], mode: 'remote' };
+  return { args: ['git', '-C', root, 'worktree', 'add', '-b', branch, wtPath, from], mode: 'new' };
+}


### PR DESCRIPTION
## Problem
`pnpm worktree create --name x --branch <b>` only checked `refs/heads/<b>`. When `<b>` existed only as `origin/<b>` — the normal case when checking out someone else's PR branch — it silently ran `git worktree add -b <b> <path> HEAD`, so the worktree held **main's tree under the PR's branch name**. Two agents in tonight's open-PR sweep reviewed `main` instead of the PR until they compared `HEAD` with `origin/<b>`.

## Fix
`worktreeAddArgs(root, wtPath, branch, from)` in `scripts/worktree/lib/git.ts` resolves in order: local branch → `--track -b <b> origin/<b>` → `-b <b> <from>`. `cli.ts` `create` uses it and reports which mode it took. Docs row for `--branch` updated in `.claude/skills/worktree/SKILL.md`.

## Verified
- `bun test scripts/worktree/__tests__/` → 113 pass, 0 fail (4 new in `git.test.ts`; one test runs the real argv against a temp clone with a remote-only branch and asserts worktree `HEAD == origin/feature` and `@{upstream} == origin/feature`).
- `tsc --noEmit -p scripts/worktree/tsconfig.json` → clean.
