### PR TITLE
Revert "enh(web): bake a 110% UI scale into the default (#6524)"

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -788,8 +788,7 @@
 
   html {
     scroll-behavior: smooth;
-    /* Base UI scale: 110% of the 16px default. Tailwind v4 spacing/text/radius tokens are rem-based off this root, so this one value scales nearly the whole app, same mechanism as browser zoom, baked in as the default. */
-    font-size: 110%;
+    font-size: 100%;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/apps/web/src/components/ui/data-grid.tsx
+++ b/apps/web/src/components/ui/data-grid.tsx
@@ -19,14 +19,12 @@ import { cn } from '@/lib/utils';
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 // ── Theme ────────────────────────────────────────────────────────────────
-// AG Grid theme params are fixed px and don't inherit the CSS root font-size
-// scale — bumped by the same 1.1x factor to match.
 const gridTheme = themeQuartz.withParams({
-  spacing: 6.6,
-  headerFontSize: 13,
-  fontSize: 13,
-  rowHeight: 40,
-  headerHeight: 42,
+  spacing: 6,
+  headerFontSize: 12,
+  fontSize: 12,
+  rowHeight: 36,
+  headerHeight: 38,
   wrapperBorderRadius: 0,
   borderRadius: 0,
   cellHorizontalPaddingScale: 1,

--- a/apps/web/src/features/file-renderers/sqlite-renderer.tsx
+++ b/apps/web/src/features/file-renderers/sqlite-renderer.tsx
@@ -70,14 +70,12 @@ import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useStat
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 // AG Grid theme
-// AG Grid theme params are fixed px and don't inherit the CSS root font-size
-// scale — bumped by the same 1.1x factor to match.
 const gridTheme = themeQuartz.withParams({
-  spacing: 6.6,
-  headerFontSize: 13,
-  fontSize: 13,
-  rowHeight: 40,
-  headerHeight: 42,
+  spacing: 6,
+  headerFontSize: 12,
+  fontSize: 12,
+  rowHeight: 36,
+  headerHeight: 38,
   wrapperBorderRadius: 0,
   borderRadius: 0,
   cellHorizontalPaddingScale: 1,

--- a/apps/web/src/features/session/pty-terminal.tsx
+++ b/apps/web/src/features/session/pty-terminal.tsx
@@ -209,9 +209,7 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
     const term = new XTerm({
       cursorBlink: true,
       cursorStyle: 'block',
-      // Canvas-rendered text doesn't inherit the CSS root font-size scale — bump
-      // in step with it (13px base * 1.1).
-      fontSize: 14,
+      fontSize: 13,
       fontFamily: 'JetBrains Mono, Menlo, Monaco, Consolas, monospace',
       theme: terminalTheme,
       allowProposedApi: true,


### PR DESCRIPTION
Reverts b88bfd603d per Marko: the 110% root font-size default and the matching xterm/AG Grid bumps go back to 100%. Clean revert, 4 files.