### PR TITLE
enh(web): bake a 110% UI scale into the default

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -788,7 +788,8 @@
 
   html {
     scroll-behavior: smooth;
-    font-size: 100%;
+    /* Base UI scale: 110% of the 16px default. Tailwind v4 spacing/text/radius tokens are rem-based off this root, so this one value scales nearly the whole app, same mechanism as browser zoom, baked in as the default. */
+    font-size: 110%;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/apps/web/src/components/ui/data-grid.tsx
+++ b/apps/web/src/components/ui/data-grid.tsx
@@ -19,12 +19,14 @@ import { cn } from '@/lib/utils';
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 // ── Theme ────────────────────────────────────────────────────────────────
+// AG Grid theme params are fixed px and don't inherit the CSS root font-size
+// scale — bumped by the same 1.1x factor to match.
 const gridTheme = themeQuartz.withParams({
-  spacing: 6,
-  headerFontSize: 12,
-  fontSize: 12,
-  rowHeight: 36,
-  headerHeight: 38,
+  spacing: 6.6,
+  headerFontSize: 13,
+  fontSize: 13,
+  rowHeight: 40,
+  headerHeight: 42,
   wrapperBorderRadius: 0,
   borderRadius: 0,
   cellHorizontalPaddingScale: 1,

--- a/apps/web/src/features/file-renderers/sqlite-renderer.tsx
+++ b/apps/web/src/features/file-renderers/sqlite-renderer.tsx
@@ -70,12 +70,14 @@ import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useStat
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 // AG Grid theme
+// AG Grid theme params are fixed px and don't inherit the CSS root font-size
+// scale — bumped by the same 1.1x factor to match.
 const gridTheme = themeQuartz.withParams({
-  spacing: 6,
-  headerFontSize: 12,
-  fontSize: 12,
-  rowHeight: 36,
-  headerHeight: 38,
+  spacing: 6.6,
+  headerFontSize: 13,
+  fontSize: 13,
+  rowHeight: 40,
+  headerHeight: 42,
   wrapperBorderRadius: 0,
   borderRadius: 0,
   cellHorizontalPaddingScale: 1,

--- a/apps/web/src/features/session/pty-terminal.tsx
+++ b/apps/web/src/features/session/pty-terminal.tsx
@@ -209,7 +209,9 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
     const term = new XTerm({
       cursorBlink: true,
       cursorStyle: 'block',
-      fontSize: 13,
+      // Canvas-rendered text doesn't inherit the CSS root font-size scale — bump
+      // in step with it (13px base * 1.1).
+      fontSize: 14,
       fontFamily: 'JetBrains Mono, Menlo, Monaco, Consolas, monospace',
       theme: terminalTheme,
       allowProposedApi: true,


### PR DESCRIPTION
## Summary
- `html { font-size: 100% -> 110% }` in `apps/web/src/app/globals.css` — the single real lever: Tailwind v4's `--spacing`/`--text-*`/`--radius-*` tokens are all rem-based off the root, so this scales spacing, type, and radius across nearly the whole app in one place, the same mechanism as browser zoom, now baked in as the default instead of a per-user toggle.
- Bumped the canvas-rendered surfaces that don't inherit CSS font-size, by the same 1.1x factor: xterm terminal `fontSize` (`pty-terminal.tsx`) and the two AG Grid `themeQuartz` params (`data-grid.tsx`, `sqlite-renderer.tsx`).

## Verified
- `getComputedStyle(document.documentElement).fontSize` on the live app -> `17.6px` (16 * 1.1)
- A live rendered button's `text-sm` resolved to `15.4px` (14 * 1.1), confirming the token cascade reaches real components
- `eslint` on all 4 changed files: 0 errors (only pre-existing `react-hooks/refs` warnings unrelated to this change)
- Visually confirmed on the live project home page — headings, chips, sidebar all read larger and proportionate, nothing overlapping or clipped

## Known residual scope (not in this PR)
~55 places across mostly one-off pages (invites, presentations, docs) pass explicit pixel `size={N}` props to icons/logos instead of Tailwind classes, so they won't scale. Not core app chrome; flag if this should be swept too.

## Test plan
- [ ] `pnpm worktree start ui-scale-110`, open the app, sanity-check spacing/type across dashboard, session chat, terminal, and a CSV/SQLite file view



---
Re-opened from #6524 (merged as b88bfd603d, reverted in #6539 / a9a141f889 pending a decision). Same diff, cherry-picked onto current main. Do not merge without a go from Marko.
