### PR TITLE
perf(ke2e): overlap the serial lane, stop retrying timeouts, fail fast on funding, backoff+breaker in the client

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -226,6 +226,77 @@ Each flow run writes `results.json` and `report.html` under
 `tests/test-results/<runId>/`. Use `results.json` to prove fixture and request
 counts. Do not infer those counts from source files.
 
+## Runner scheduling, retries, and load knobs
+
+The runner splits selected flows into three lanes.
+
+- **Parallel lanes** — `meta.serial` and `meta.global` unset. Split again into an
+  API lane and a live-sandbox lane by `requires: ['daytona']`.
+- **Serial lane** — `meta.serial`. Never runs beside another serial flow. It
+  runs at concurrency 1 *inside the same `Promise.all` as the parallel lanes*,
+  so it overlaps them instead of appending a sequential tail.
+- **Global lane** — `meta.global`. Runs last, one at a time, with nothing else
+  in flight. The three global flows each mutate state no flow owns: `BILL-13`
+  and `ADM-19` write every account on the deployment, `CONN-5` mutates
+  `kortix.yaml` on the shared managed repository.
+
+Mark a flow `serial` when it must not run beside its peers. Mark it `global`
+only when it must be the only thing running on the deployment.
+
+### Retry budgets
+
+Retries are budgeted per error class. Assertion failures never retry.
+
+| Class | Default attempts | Env knob |
+| --- | --- | --- |
+| Flow-level timeout (`flow X exceeded Nms`) | 1 | `KE2E_TIMEOUT_ATTEMPTS` |
+| Session-runtime readiness timeout | 2 | `KE2E_SESSION_RUNTIME_ATTEMPTS` |
+| Marked infra error (network, laundered 503) | 3 | `KE2E_FLOW_ATTEMPTS` |
+| Assertion failure or unmarked error | 1 | — |
+
+A flow-level timeout is a hang, not a blip: retrying it spends the full declared
+timeout again on the most expensive flows in the suite. `meta.retry.attempts`
+still overrides every class for one flow. `KE2E_DEFAULT_FLOW_ATTEMPTS` is the
+legacy name and stays a ceiling over every class — the local profile and the
+preview stack pin it to `1`.
+
+### Load knobs
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `KE2E_API_WORKERS` | 4 | API-lane concurrency. |
+| `KE2E_SANDBOX_WORKERS` | 4 | Live-sandbox-lane concurrency. |
+| `KE2E_PROVISION_CONCURRENCY` | 4 | Global cap on concurrent project provisions. Each provision creates a real managed GitHub repository, so this — not the worker counts — is the binding constraint on suite parallelism. |
+| `KE2E_PROVISION_RATE_LIMIT_BASE_DELAY_MS` | 15000 | First delay after a GitHub rate-limit response. Doubles per attempt with equal jitter. |
+| `KE2E_PROVISION_RATE_LIMIT_DELAY_MS` | 120000 | Ceiling for that backoff. |
+| `KE2E_TEARDOWN_WORKERS` | 8 | Concurrency for deleting synthesized users at teardown. |
+| `KE2E_GATEWAY_RETRIES` | 3 | In-request retries of a gateway-generated transient 502/503/504. |
+| `KE2E_RETRY_BASE_DELAY_MS` | 500 | Base for that retry's exponential backoff with full jitter. |
+| `KE2E_RETRY_MAX_DELAY_MS` | 8000 | Cap for that backoff. |
+| `KE2E_BREAKER_THRESHOLD` | 20 | Transient edge failures in the window that open the client circuit breaker. `0` disables it. |
+| `KE2E_BREAKER_WINDOW_MS` | 60000 | Rolling window for the breaker. |
+| `KE2E_FUNDING_OPTIONAL` | unset | `1` downgrades a fatal OWNER funding failure to a warning. |
+
+### Circuit breaker
+
+The HTTP client shares one process-wide breaker over laundered-503 and network
+failures. Once the deployment is observably overloaded, more retries are the
+problem: when the breaker is open the client stops retrying and stops marking
+the failure retryable, so the flow-level budget cannot re-amplify it either. The
+window is rolling, so the breaker closes on its own.
+
+Every transient response is logged with `describeEdgeResponse` — the
+`x-maintenance-mode` and `x-request-id` header pair that separates a Cloudflare
+worker laundering an origin failure (`edge-laundered`) from a genuine
+application 5xx (`origin`). Do not guess at which one a 503 was.
+
+### Failing fast on OWNER funding
+
+52 flows declare `requires: ['funded']`. When the target declares the `stripe`
+capability, a failed OWNER Stripe subscribe now throws during provisioning
+instead of degrading 52 flows to `skip` and reporting the red at the end of the
+run. Set `KE2E_FUNDING_OPTIONAL=1` to restore the warning-only behavior.
+
 ## Browser journeys
 
 Playwright exists only for behavior that requires a browser. Browser tests live

--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -8,6 +8,7 @@
  */
 import { currentRecorder } from './context';
 import { assert, BodyAssert } from './expect';
+import { log } from './log';
 import type { Captured } from './result';
 
 export type Auth =
@@ -146,10 +147,14 @@ export class Res {
   status(code: number | number[]): this {
     const codes = Array.isArray(code) ? code : [code];
     if (!codes.includes(this.statusCode) && isKe2eTransientGatewayResponse(this)) {
+      const breakerOpen = transientBreaker.isOpen();
       const error = new Error(
-        `transient gateway status ${this.statusCode}; expected [${codes.join(', ')}]`,
+        `transient gateway status ${this.statusCode}; expected [${codes.join(', ')}] ` +
+          `${describeEdgeResponse(this.statusCode, this.captured.res.headers)}` +
+          (breakerOpen ? ` — ${transientBreaker.describe()}` : ''),
       );
-      (error as any).ke2eRetryable = true;
+      // With the breaker open the flow-level budget must not re-amplify this.
+      (error as any).ke2eRetryable = !breakerOpen;
       (error as any).ke2eRetryAfterMs = retryAfterMs(this.header('retry-after'));
       throw error;
     }
@@ -220,7 +225,149 @@ function retryAfterMs(value: string | undefined): number | undefined {
   return Math.max(0, at - Date.now());
 }
 
-const TRANSIENT_GATEWAY_RETRY_DELAY_MS = 2_000;
+/**
+ * Describe WHERE a response came from, terse enough for an error message.
+ *
+ * The Cloudflare worker replaces any origin throw or 502/503/504 with a
+ * synthetic maintenance 503 that carries `X-Maintenance-Mode` and drops the
+ * origin's `x-request-id`. Printing both facts lets a log reader tell an edge
+ * laundering apart from a genuine application 5xx without guessing.
+ */
+export function describeEdgeResponse(
+  status: number,
+  headers: Record<string, string>,
+): string {
+  const maintenance = headers['x-maintenance-mode'];
+  const requestId = headers['x-request-id'];
+  const origin = requestId ? 'origin' : maintenance ? 'edge-laundered' : 'edge';
+  return (
+    `[${origin} status=${status} ` +
+    `x-maintenance-mode=${maintenance ?? 'absent'} ` +
+    `x-request-id=${requestId ? 'present' : 'absent'}]`
+  );
+}
+
+const RETRY_BASE_DELAY_MS = Number(process.env.KE2E_RETRY_BASE_DELAY_MS ?? 500);
+const RETRY_MAX_DELAY_MS = Number(process.env.KE2E_RETRY_MAX_DELAY_MS ?? 8_000);
+
+/**
+ * Exponential backoff with FULL jitter for the in-request transient retry.
+ *
+ * The old policy was a fixed 2s × 4 attempts. Layered under 3 flow attempts one
+ * request could hit the origin 12 times, and every client backed off in
+ * lockstep — a textbook metastable failure that turns a staging blip into a
+ * run-ending cascade. Full jitter spreads the retries; the cap bounds the
+ * worst case. A `Retry-After` from the edge raises the floor but never parks
+ * longer than the cap.
+ */
+export function transientRetryDelayMs(
+  attempt: number,
+  opts: {
+    baseMs?: number;
+    capMs?: number;
+    retryAfterMs?: number;
+    random?: () => number;
+  } = {},
+): number {
+  const base = opts.baseMs ?? RETRY_BASE_DELAY_MS;
+  const cap = opts.capMs ?? RETRY_MAX_DELAY_MS;
+  const random = opts.random ?? Math.random;
+  const ceiling = Math.min(cap, base * 2 ** Math.max(0, attempt - 1));
+  const jittered = Math.round(random() * ceiling);
+  const floor =
+    typeof opts.retryAfterMs === 'number' && Number.isFinite(opts.retryAfterMs)
+      ? Math.max(0, opts.retryAfterMs)
+      : 0;
+  return Math.min(cap, Math.max(jittered, floor));
+}
+
+export interface BreakerOptions {
+  /** Transient edge failures within the window that trip the breaker. 0 disables. */
+  threshold: number;
+  windowMs: number;
+  now?: () => number;
+}
+
+/**
+ * Process-wide circuit breaker over laundered-503 / network-failure events.
+ *
+ * Once the deployment is observably overloaded, more retries are the problem,
+ * not the remedy. When the breaker is open the client stops retrying and stops
+ * marking the failure retryable, so the flow-level budget cannot re-amplify it
+ * either. The window is rolling: the breaker closes on its own once the
+ * failures age out.
+ */
+export class TransientCircuitBreaker {
+  private events: number[] = [];
+  private openSince: number | null = null;
+  private readonly now: () => number;
+
+  constructor(private readonly opts: BreakerOptions) {
+    this.now = opts.now ?? Date.now;
+  }
+
+  private prune(at: number): void {
+    const cutoff = at - this.opts.windowMs;
+    while (this.events.length > 0 && this.events[0] <= cutoff) this.events.shift();
+  }
+
+  record(): void {
+    const at = this.now();
+    this.prune(at);
+    this.events.push(at);
+  }
+
+  failuresInWindow(): number {
+    this.prune(this.now());
+    return this.events.length;
+  }
+
+  isOpen(): boolean {
+    if (this.opts.threshold <= 0) return false;
+    const open = this.failuresInWindow() >= this.opts.threshold;
+    if (!open) this.openSince = null;
+    return open;
+  }
+
+  /** True exactly once per open transition, so callers log one line, not thousands. */
+  shouldAnnounce(): boolean {
+    if (!this.isOpen()) return false;
+    if (this.openSince !== null) return false;
+    this.openSince = this.now();
+    return true;
+  }
+
+  describe(): string {
+    return (
+      `circuit open: ${this.failuresInWindow()} transient edge failures in ` +
+      `${this.opts.windowMs}ms (threshold ${this.opts.threshold}) — the deployment is ` +
+      'overloaded; not retrying'
+    );
+  }
+
+  reset(): void {
+    this.events = [];
+    this.openSince = null;
+  }
+}
+
+export function readBreakerOptions(
+  vars: Record<string, string | undefined> = process.env,
+): BreakerOptions {
+  const threshold = Number(vars.KE2E_BREAKER_THRESHOLD ?? 20);
+  const windowMs = Number(vars.KE2E_BREAKER_WINDOW_MS ?? 60_000);
+  return {
+    threshold: Number.isFinite(threshold) ? Math.trunc(threshold) : 20,
+    windowMs: Number.isFinite(windowMs) && windowMs > 0 ? Math.trunc(windowMs) : 60_000,
+  };
+}
+
+/** The one breaker every Client in the process shares. */
+export const transientBreaker = new TransientCircuitBreaker(readBreakerOptions());
+
+function announceBreaker(): void {
+  if (transientBreaker.shouldAnnounce()) log.warn(`ke2e ${transientBreaker.describe()}`);
+}
 
 export class Client {
   private readonly origin: string;
@@ -353,12 +500,21 @@ export class Client {
           ms,
         };
         record(captured);
-        if (attempt < maxAttempts) {
-          await new Promise((resolve) => setTimeout(resolve, TRANSIENT_GATEWAY_RETRY_DELAY_MS));
+        transientBreaker.record();
+        const breakerOpen = transientBreaker.isOpen();
+        if (breakerOpen) announceBreaker();
+        if (attempt < maxAttempts && !breakerOpen) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, transientRetryDelayMs(attempt)),
+          );
           continue;
         }
-        const e = new Error(`network error ${method} ${url}: ${err?.message ?? err}`);
-        (e as any).ke2eRetryable = true;
+        const e = new Error(
+          `network error ${method} ${url} after ${attempt}/${maxAttempts} attempt(s): ` +
+            `${err?.message ?? err}` +
+            (breakerOpen ? ` — ${transientBreaker.describe()}` : ''),
+        );
+        (e as any).ke2eRetryable = !breakerOpen;
         throw e;
       }
 
@@ -394,9 +550,27 @@ export class Client {
       };
       record(captured);
       const response = new Res(captured);
-      if (attempt < maxAttempts && isKe2eTransientGatewayResponse(response)) {
-        await new Promise((resolve) => setTimeout(resolve, TRANSIENT_GATEWAY_RETRY_DELAY_MS));
-        continue;
+      if (isKe2eTransientGatewayResponse(response)) {
+        transientBreaker.record();
+        const breakerOpen = transientBreaker.isOpen();
+        if (breakerOpen) announceBreaker();
+        if (attempt < maxAttempts && !breakerOpen) {
+          log.warn(
+            `ke2e retry ${attempt}/${maxAttempts} ${routeTemplate} ` +
+              `${describeEdgeResponse(res.status, resHeaders)}`,
+          );
+          await new Promise((resolve) =>
+            setTimeout(resolve, transientRetryDelayMs(attempt, {
+              retryAfterMs: retryAfterMs(resHeaders['retry-after']),
+            })),
+          );
+          continue;
+        }
+        log.warn(
+          `ke2e giving up ${routeTemplate} after ${attempt}/${maxAttempts} attempt(s) ` +
+            `${describeEdgeResponse(res.status, resHeaders)}` +
+            (breakerOpen ? ` — ${transientBreaker.describe()}` : ''),
+        );
       }
       return response;
     }

--- a/tests/src/core/flow.ts
+++ b/tests/src/core/flow.ts
@@ -11,6 +11,111 @@ export interface RegisteredFlow {
 }
 
 export const DEFAULT_FLOW_ATTEMPTS = 3;
+/**
+ * A flow-level timeout is a hang, not an infrastructure blip. Retrying it burns
+ * the full declared timeout again for a flow that was already the most
+ * expensive in the run, so the default budget is a single attempt.
+ */
+export const DEFAULT_TIMEOUT_ATTEMPTS = 1;
+/**
+ * "Timed out waiting for session runtime ready" IS worth one retry (a cold
+ * sandbox pool recovers), but two attempts of a 5–7 minute wait is the ceiling.
+ */
+export const DEFAULT_SESSION_RUNTIME_ATTEMPTS = 2;
+
+/** Marker set by withTimeout on the flow-level timeout error. */
+export const KE2E_FLOW_TIMEOUT = 'ke2eFlowTimeout';
+/** Marker set by markSessionReadinessTimeoutRetryable. */
+export const KE2E_RETRY_CLASS = 'ke2eRetryClass';
+
+export type FlowRetryClass = 'assertion' | 'timeout' | 'session-runtime' | 'infra' | 'fatal';
+
+export interface AttemptPolicy {
+  /** Budget for ordinary marked-retryable infra errors (network, laundered 503). */
+  infra: number;
+  /** Budget for a flow-level timeout. */
+  timeout: number;
+  /** Budget for a session-runtime-readiness timeout. */
+  sessionRuntime: number;
+}
+
+function positiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.trunc(parsed));
+}
+
+/**
+ * Read the per-class attempt budget from the environment.
+ *
+ * `KE2E_FLOW_ATTEMPTS` sets the infra class only. Timeouts and session-runtime
+ * readiness have their own knobs, so raising the infra budget can never
+ * re-inflate the serial tail.
+ *
+ * `KE2E_DEFAULT_FLOW_ATTEMPTS` is the LEGACY name and keeps its old meaning: a
+ * ceiling over every class. The local profile and the preview stack both pin it
+ * to 1 to make their runs deterministic (local-profile.ts, preview-stack.ts),
+ * and that must keep capping timeouts and readiness waits, not just infra.
+ */
+export function readAttemptPolicy(
+  vars: Record<string, string | undefined> = process.env,
+): AttemptPolicy {
+  const policy: AttemptPolicy = {
+    infra: positiveInt(
+      vars.KE2E_FLOW_ATTEMPTS ?? vars.KE2E_DEFAULT_FLOW_ATTEMPTS,
+      DEFAULT_FLOW_ATTEMPTS,
+    ),
+    timeout: positiveInt(vars.KE2E_TIMEOUT_ATTEMPTS, DEFAULT_TIMEOUT_ATTEMPTS),
+    sessionRuntime: positiveInt(
+      vars.KE2E_SESSION_RUNTIME_ATTEMPTS,
+      DEFAULT_SESSION_RUNTIME_ATTEMPTS,
+    ),
+  };
+  if (vars.KE2E_DEFAULT_FLOW_ATTEMPTS !== undefined && vars.KE2E_DEFAULT_FLOW_ATTEMPTS !== '') {
+    const ceiling = positiveInt(vars.KE2E_DEFAULT_FLOW_ATTEMPTS, DEFAULT_FLOW_ATTEMPTS);
+    policy.infra = Math.min(policy.infra, ceiling);
+    policy.timeout = Math.min(policy.timeout, ceiling);
+    policy.sessionRuntime = Math.min(policy.sessionRuntime, ceiling);
+  }
+  return policy;
+}
+
+/**
+ * Classify a flow error into its retry class.
+ *
+ * `isAssertion` is passed in so this module stays free of the assertion layer.
+ */
+export function classifyFlowError(error: unknown, isAssertion: boolean): FlowRetryClass {
+  if (isAssertion) return 'assertion';
+  const marked = error as Record<string, unknown> | null | undefined;
+  if (marked?.[KE2E_FLOW_TIMEOUT] === true) return 'timeout';
+  if (marked?.ke2eRetryable !== true) return 'fatal';
+  if (marked[KE2E_RETRY_CLASS] === 'session-runtime') return 'session-runtime';
+  return 'infra';
+}
+
+/** Total attempts allowed for one error class. 1 means "never retry". */
+export function attemptsFor(retryClass: FlowRetryClass, policy: AttemptPolicy): number {
+  switch (retryClass) {
+    case 'timeout':
+      return policy.timeout;
+    case 'session-runtime':
+      return policy.sessionRuntime;
+    case 'infra':
+      return policy.infra;
+    default:
+      return 1;
+  }
+}
+
+/**
+ * Upper bound on the attempt loop across every class, so the loop can be
+ * written once and the per-error cap applied when the error is known.
+ */
+export function maxAttemptBound(policy: AttemptPolicy): number {
+  return Math.max(policy.infra, policy.timeout, policy.sessionRuntime, 1);
+}
 
 const registry = new Map<string, RegisteredFlow>();
 

--- a/tests/src/core/lanes.ts
+++ b/tests/src/core/lanes.ts
@@ -1,3 +1,4 @@
+import { mapWithConcurrency } from './concurrency';
 import type { RegisteredFlow } from './flow';
 
 export function partitionParallelFlows(flows: RegisteredFlow[]): {
@@ -11,4 +12,50 @@ export function partitionParallelFlows(flows: RegisteredFlow[]): {
     else apiLane.push(flow);
   }
   return { apiLane, sandboxLane };
+}
+
+export interface ConcurrentLane {
+  flows: RegisteredFlow[];
+  workers: number;
+}
+
+export interface LaneSchedule {
+  /** Lanes that run at the same time as each other, each with its own worker count. */
+  concurrent: ConcurrentLane[];
+  /** `meta.serial` flows: never beside each other, but free to overlap `concurrent`. */
+  serial: RegisteredFlow[];
+  /** `meta.global` flows: nothing else may run. Drained last, one at a time. */
+  global: RegisteredFlow[];
+}
+
+/**
+ * Execute a lane schedule.
+ *
+ * The serial lane joins the same `Promise.all` as the parallel lanes at
+ * concurrency 1. `meta.serial` means "does not share state with its peers",
+ * not "must be the only thing running", so overlapping it with the parallel
+ * lanes removes the ~30-45 min sequential tail without changing what any flow
+ * observes: a serial flow still never runs beside another serial flow.
+ *
+ * The global lane stays strictly last and strictly sequential. All three
+ * global flows genuinely require an otherwise-idle deployment:
+ *   BILL-13  POST /v1/billing/cron/free-tier-rotation — writes every account
+ *   ADM-19   POST /v1/billing/cron/trial-expiry       — writes every account
+ *   CONN-5   mutates kortix.yaml on the SHARED managed repo other flows read
+ * Overlapping any of them would race flows they do not own.
+ *
+ * Result order within the returned array is not significant — the caller sorts
+ * by flow id and `summarize` counts are order-independent.
+ */
+export async function runScheduled<R>(
+  schedule: LaneSchedule,
+  run: (flow: RegisteredFlow) => Promise<R>,
+): Promise<R[]> {
+  const overlapped = await Promise.all([
+    ...schedule.concurrent.map((lane) => mapWithConcurrency(lane.flows, lane.workers, run)),
+    mapWithConcurrency(schedule.serial, 1, run),
+  ]);
+  const out: R[] = overlapped.flat();
+  for (const flow of schedule.global) out.push(await run(flow));
+  return out;
 }

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -10,15 +10,18 @@ import { withRecorder, type StepRecorder } from "./context";
 import { AssertionError } from "./expect";
 import {
   allFlows,
+  attemptsFor,
+  classifyFlowError,
   clearRegistry,
-  DEFAULT_FLOW_ATTEMPTS,
+  KE2E_FLOW_TIMEOUT,
+  maxAttemptBound,
+  readAttemptPolicy,
   type RegisteredFlow,
 } from "./flow";
 import { loadEnv, type Env } from "./env";
 import { log } from "./log";
 import { formatFlowProgress, redactSensitiveLogText } from "./progress";
-import { partitionParallelFlows } from "./lanes";
-import { mapWithConcurrency } from "./concurrency";
+import { partitionParallelFlows, runScheduled, type ConcurrentLane } from "./lanes";
 import { planLocalFlows } from "./local-profile";
 import { ke2eRetryDelayMs } from "./client";
 import {
@@ -99,15 +102,15 @@ async function runOneFlow(
 ): Promise<FlowResult> {
   const steps: StepResult[] = [];
   const flowStart = performance.now();
-  // Every flow gets one clean retry for errors explicitly marked as
-  // infrastructure failures. Assertion failures never retry.
-  const configuredAttempts = Number(
-    process.env.KE2E_DEFAULT_FLOW_ATTEMPTS ?? DEFAULT_FLOW_ATTEMPTS,
-  );
-  const defaultAttempts = Number.isFinite(configuredAttempts)
-    ? Math.max(1, Math.trunc(configuredAttempts))
-    : DEFAULT_FLOW_ATTEMPTS;
-  const maxAttempts = f.meta.retry?.attempts ?? defaultAttempts;
+  // Retries are budgeted PER ERROR CLASS (see flow.ts):
+  //   assertion / unmarked   → 1 attempt, never retried
+  //   flow-level timeout     → KE2E_TIMEOUT_ATTEMPTS, default 1
+  //   session-runtime ready  → KE2E_SESSION_RUNTIME_ATTEMPTS, default 2
+  //   marked infra (network, laundered 503) → KE2E_FLOW_ATTEMPTS, default 3
+  // A per-flow `meta.retry.attempts` overrides every class explicitly.
+  const policy = readAttemptPolicy();
+  const declaredAttempts = f.meta.retry?.attempts;
+  const maxAttempts = declaredAttempts ?? maxAttemptBound(policy);
 
   // Capability gating → skip with reason.
   const missing = (f.meta.requires ?? []).filter((cap) => !env.capabilities[cap]);
@@ -167,11 +170,13 @@ async function runOneFlow(
         return mkResult(f, "skip", err.reason, steps, performance.now() - flowStart, attempt);
       }
       lastError = err;
-      // Never retry assertion failures — only infra signals.
-      const retryable = !(err instanceof AssertionError) && (err as any)?.ke2eRetryable === true;
-      if (!retryable || attempt >= maxAttempts) break;
+      // Never retry assertion failures — only infra signals, and each class
+      // gets its own budget so a timeout can never triple the serial tail.
+      const retryClass = classifyFlowError(err, err instanceof AssertionError);
+      const allowed = declaredAttempts ?? attemptsFor(retryClass, policy);
+      if (attempt >= allowed || attempt >= maxAttempts) break;
       log.warn(
-        `retry ${f.id} after attempt ${attempt}/${maxAttempts}: ` +
+        `retry ${f.id} (${retryClass}) after attempt ${attempt}/${allowed}: ` +
           `${redactSensitiveLogText((err as Error)?.message ?? String(err))}`,
       );
       await new Promise((resolve) => setTimeout(resolve, ke2eRetryDelayMs(err)));
@@ -221,8 +226,12 @@ function mkResult(
 function withTimeout<T>(p: Promise<T>, ms: number, id: string): Promise<T> {
   return new Promise<T>((res, rej) => {
     const t = setTimeout(() => {
+      // NOT ke2eRetryable. A flow that burned its whole declared timeout is
+      // hung, not blipping; retrying it spends the same timeout again on the
+      // most expensive flows in the suite. Tagged as its own class so
+      // KE2E_TIMEOUT_ATTEMPTS can re-enable retries deliberately.
       const e = new Error(`flow ${id} exceeded ${ms}ms`);
-      (e as any).ke2eRetryable = true;
+      (e as any)[KE2E_FLOW_TIMEOUT] = true;
       rej(e);
     }, ms);
     p.then(
@@ -299,14 +308,14 @@ export async function runSuite(opts: RunOptions): Promise<RunResult> {
         throw error;
       }
     };
+    let concurrent: ConcurrentLane[];
     if (opts.workers !== undefined) {
       const workers = positiveWorkerCount(opts.workers, 4);
-      log.info(`lanes: ${parallelLane.length} parallel flows · ${workers} explicit workers`);
-      out.push(
-        ...(await mapWithConcurrency(parallelLane, workers, (f) =>
-          runTrackedFlow(f),
-        )),
+      log.info(
+        `lanes: ${parallelLane.length} parallel flows × ${workers} explicit workers · ` +
+          `${serialLane.length} serial flows × 1 worker (overlapped)`,
       );
+      concurrent = [{ flows: parallelLane, workers }];
     } else {
       const { apiLane, sandboxLane } = partitionParallelFlows(parallelLane);
       const apiWorkers = positiveWorkerCount(
@@ -319,18 +328,21 @@ export async function runSuite(opts: RunOptions): Promise<RunResult> {
       );
       log.info(
         `lanes: ${apiLane.length} API flows × ${apiWorkers} workers · ` +
-          `${sandboxLane.length} sandbox flows × ${sandboxWorkers} workers`,
+          `${sandboxLane.length} sandbox flows × ${sandboxWorkers} workers · ` +
+          `${serialLane.length} serial flows × 1 worker (overlapped) · ` +
+          `${globalLane.length} global flows last`,
       );
-      const [apiResults, sandboxResults] = await Promise.all([
-        mapWithConcurrency(apiLane, apiWorkers, runTrackedFlow),
-        mapWithConcurrency(sandboxLane, sandboxWorkers, (f) =>
-          runTrackedFlow(f),
-        ),
-      ]);
-      out.push(...apiResults, ...sandboxResults);
+      concurrent = [
+        { flows: apiLane, workers: apiWorkers },
+        { flows: sandboxLane, workers: sandboxWorkers },
+      ];
     }
-    for (const f of serialLane) out.push(await runTrackedFlow(f));
-    for (const f of globalLane) out.push(await runTrackedFlow(f));
+    out.push(
+      ...(await runScheduled(
+        { concurrent, serial: serialLane, global: globalLane },
+        runTrackedFlow,
+      )),
+    );
 
     out.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
     const durationMs = performance.now() - start;

--- a/tests/src/core/session-runtime-retry.ts
+++ b/tests/src/core/session-runtime-retry.ts
@@ -1,9 +1,19 @@
+import { KE2E_RETRY_CLASS } from './flow';
+
+/**
+ * Mark the named session-runtime readiness timeout as retryable AND tag its
+ * retry class, so the runner can give it its own (smaller) attempt budget
+ * instead of the general infra budget. A 5–7 minute readiness wait retried
+ * three times is one of the two biggest wall-clock multipliers in the suite.
+ */
 export function markSessionReadinessTimeoutRetryable(error: unknown, sessionId: string): unknown {
   if (
     error instanceof Error &&
     error.message === `Timed out waiting for session runtime ready for ${sessionId}`
   ) {
-    (error as Error & { ke2eRetryable?: boolean }).ke2eRetryable = true;
+    const marked = error as Error & { ke2eRetryable?: boolean; ke2eRetryClass?: string };
+    marked.ke2eRetryable = true;
+    marked[KE2E_RETRY_CLASS as 'ke2eRetryClass'] = 'session-runtime';
   }
   return error;
 }

--- a/tests/src/fixtures/principals.ts
+++ b/tests/src/fixtures/principals.ts
@@ -15,7 +15,7 @@ import type { Env } from '../core/env';
 import { log } from '../core/log';
 import type { Principal, Principals } from '../core/types';
 import { subscribe } from './billing';
-import { adminCreateUser, passwordGrant, type AdminUser } from './supabase';
+import { adminCreateUser, adminDeleteUser, passwordGrant, type AdminUser } from './supabase';
 
 export interface Provisioned {
   principals: Partial<Principals>;
@@ -64,12 +64,43 @@ export async function synthUserWithEmail(
   return { user, jwt, principal };
 }
 
-export async function provisionMatrix(env: Env, runId: string): Promise<Provisioned> {
-  const supabaseUserIds: string[] = [];
+/**
+ * Decide whether a Stripe funding failure sinks the run.
+ *
+ * When `stripe` is a declared capability the run EXPECTS funding to work, and
+ * every flow requiring `funded` (the largest capability group in the suite)
+ * silently degrades to `skip` if it does not. Under `--require-all` that is a
+ * red reported ~75 minutes later by a run that was doomed in its first minute.
+ * So: fatal by default on a Stripe-capable target, soft on a local profile
+ * without Stripe, and `KE2E_FUNDING_OPTIONAL=1` restores the old soft-fail.
+ */
+export function fundingFailureIsFatal(
+  env: Pick<Env, 'capabilities'>,
+  vars: Record<string, string | undefined> = process.env,
+): boolean {
+  if (!env.capabilities.stripe) return false;
+  const optional = vars.KE2E_FUNDING_OPTIONAL;
+  return !(optional === '1' || optional === 'true');
+}
 
+/** The exact message a fatal funding failure raises. */
+export function fundingFailureMessage(cause: unknown): string {
+  return (
+    'OWNER funding failed — every flow requiring the `funded` capability cannot run. ' +
+    'Failing fast now instead of reporting the skips at the end of the run. ' +
+    'Set KE2E_FUNDING_OPTIONAL=1 to downgrade this to a warning. ' +
+    `Cause: ${(cause as Error)?.message ?? cause}`
+  );
+}
+
+async function provisionOwner(
+  env: Env,
+  runId: string,
+): Promise<{ owner: SynthUser; patAcctSecret: string | undefined }> {
   const owner = await synthUser(env, 'OWNER', runId);
-  supabaseUserIds.push(owner.user.id);
   // Force the personal account into existence + capture its id (== userId).
+  // Funding must follow this call, not race it: the account row is created
+  // lazily on the first token/project call.
   const ownerClient = new Client(env.apiUrl).as(owner.principal);
   const tok = await ownerClient.post('/v1/accounts/tokens', {
     name: `e2e-${runId}-owner-bootstrap`,
@@ -78,22 +109,47 @@ export async function provisionMatrix(env: Env, runId: string): Promise<Provisio
 
   // Fund the OWNER's personal account so flows aren't blocked by the free-tier
   // 1-project / 402 limits — real Stripe test-mode subscribe → paid tier + credits.
-  // Non-fatal: a funding failure degrades to the unfunded behaviour with a clear
-  // warning rather than sinking the whole run.
   if (env.capabilities.stripe) {
     try {
       await subscribe(env, ownerClient, owner.principal.accountId!);
       env.capabilities.funded = true;
       log.step(`provision: OWNER ${owner.principal.accountId} funded (pro tier + credits)`);
     } catch (err) {
+      if (fundingFailureIsFatal(env)) throw new Error(fundingFailureMessage(err));
       log.warn(
         `provision: OWNER funding failed — paid-tier flows will hit project_limit/402: ${(err as Error)?.message ?? err}`,
       );
     }
   }
+  return { owner, patAcctSecret };
+}
 
-  const nonmember = await synthUser(env, 'NONMEMBER', runId);
-  supabaseUserIds.push(nonmember.user.id);
+export async function provisionMatrix(env: Env, runId: string): Promise<Provisioned> {
+  const supabaseUserIds: string[] = [];
+
+  // NONMEMBER depends on nothing in the OWNER chain (create → bootstrap PAT →
+  // Stripe subscribe), so it runs beside it instead of after it. allSettled,
+  // not Promise.all: a rejected OWNER chain must not strand a created
+  // NONMEMBER as an unreclaimed Supabase user.
+  const [ownerSettled, nonmemberSettled] = await Promise.allSettled([
+    provisionOwner(env, runId),
+    synthUser(env, 'NONMEMBER', runId),
+  ]);
+
+  if (ownerSettled.status === 'rejected') {
+    if (nonmemberSettled.status === 'fulfilled') {
+      await adminDeleteUser(env, nonmemberSettled.value.user.id).catch(() => undefined);
+    }
+    throw ownerSettled.reason;
+  }
+  if (nonmemberSettled.status === 'rejected') {
+    await adminDeleteUser(env, ownerSettled.value.owner.user.id).catch(() => undefined);
+    throw nonmemberSettled.reason;
+  }
+
+  const { owner, patAcctSecret } = ownerSettled.value;
+  const nonmember = nonmemberSettled.value;
+  supabaseUserIds.push(owner.user.id, nonmember.user.id);
 
   const principals: Partial<Principals> = {
     OWNER: owner.principal,

--- a/tests/src/fixtures/provision.ts
+++ b/tests/src/fixtures/provision.ts
@@ -7,9 +7,24 @@
 import { type Client, isKe2eRetryableError } from '../core/client';
 import { sleep } from '../core/poll';
 
-const MAX = Number(process.env.KE2E_PROVISION_CONCURRENCY ?? 2);
+/**
+ * Global cap on concurrent project provisions (KE2E_PROVISION_CONCURRENCY).
+ *
+ * This — not KE2E_API_WORKERS — was the binding constraint on suite
+ * parallelism: most flows start by provisioning, so 2 concurrent provisions
+ * held measured speedup at 1.43x with 6 flow workers. 4 doubles the ceiling.
+ * The next constraint is GitHub's SECONDARY rate limit on repo creation, which
+ * is why raising this is paired with a jittered backoff below: 4 provisions
+ * that hit a 403 together must not retry in lockstep.
+ */
+const MAX = Number(process.env.KE2E_PROVISION_CONCURRENCY ?? 4);
 const MIN_REQUEST_INTERVAL_MS = Number(process.env.KE2E_PROVISION_MIN_INTERVAL_MS ?? 0);
+/** Ceiling for a rate-limited retry (KE2E_PROVISION_RATE_LIMIT_DELAY_MS). */
 const RATE_LIMIT_DELAY_MS = Number(process.env.KE2E_PROVISION_RATE_LIMIT_DELAY_MS ?? 120_000);
+/** First rate-limited retry delay; doubles per attempt up to the ceiling. */
+const RATE_LIMIT_BASE_DELAY_MS = Number(
+  process.env.KE2E_PROVISION_RATE_LIMIT_BASE_DELAY_MS ?? 15_000,
+);
 let active = 0;
 const waiters: Array<() => void> = [];
 let nextRequestAt = 0;
@@ -36,9 +51,27 @@ function isRetryableProvisionStatus(status: number): boolean {
   return status >= 500 && status <= 599;
 }
 
-function retryDelayMs(attempt: number, rateLimited: boolean): number {
-  if (rateLimited) return RATE_LIMIT_DELAY_MS;
-  return Math.min(5_000 * 2 ** attempt, 30_000);
+/**
+ * Exponential backoff with equal jitter for a failed provision.
+ *
+ * Rate-limited retries were a FIXED 120s, so 5 attempts spent up to 8 minutes
+ * holding a semaphore slot even when GitHub's block cleared in seconds. They
+ * now start at 15s and double to the 120s ceiling. Both paths carry equal
+ * jitter (half fixed, half random) so concurrent provisions that trip the same
+ * secondary rate limit do not retry in lockstep and re-trip it. Equal jitter,
+ * not full jitter: a near-zero retry against a secondary rate limit extends
+ * the block instead of clearing it.
+ */
+export function retryDelayMs(
+  attempt: number,
+  rateLimited: boolean,
+  random: () => number = Math.random,
+): number {
+  const ceiling = rateLimited
+    ? Math.min(RATE_LIMIT_BASE_DELAY_MS * 2 ** attempt, RATE_LIMIT_DELAY_MS)
+    : Math.min(5_000 * 2 ** attempt, 30_000);
+  const half = ceiling / 2;
+  return Math.round(half + random() * half);
 }
 
 export async function paceProvisionRequest(

--- a/tests/src/fixtures/world.ts
+++ b/tests/src/fixtures/world.ts
@@ -61,6 +61,39 @@ function principalsProxy(provided: Partial<Principals>): Principals {
   }) as Principals;
 }
 
+interface EphemeralPlatformAdmin {
+  userId: string;
+  jwt: string;
+  /** Remove the granted role at teardown. */
+  revoke: () => Promise<void>;
+  /** Undo everything this fixture created, for an aborted buildWorld. */
+  release: () => Promise<void>;
+}
+
+/** Synthesize a user and grant it the run-scoped platform super-admin role. */
+async function provisionPlatformAdmin(
+  env: Env,
+  runId: string,
+): Promise<EphemeralPlatformAdmin> {
+  const platformAdmin = await synthUser(env, 'PLATFORM-ADMIN', runId);
+  let revoke: () => Promise<void>;
+  try {
+    revoke = await grantEphemeralPlatformAdmin(env, platformAdmin.user.id);
+  } catch (err) {
+    await adminDeleteUser(env, platformAdmin.user.id);
+    throw err;
+  }
+  return {
+    userId: platformAdmin.user.id,
+    jwt: platformAdmin.jwt,
+    revoke,
+    release: async () => {
+      await revoke().catch(() => undefined);
+      await adminDeleteUser(env, platformAdmin.user.id).catch(() => undefined);
+    },
+  };
+}
+
 export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<World> {
   const needsAuth = flows.some((f) => !PUBLIC_DOMAINS.has(f.meta.domain));
 
@@ -85,27 +118,42 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
   }
 
   const runId = (globalThis as any).__KE2E_RUN_ID__ ?? 'run';
-  const provisioned: Provisioned = await provisionMatrix(env, runId);
-  const owner = provisioned.principals.OWNER!;
-  let revokePlatformAdmin: (() => Promise<void>) | null = null;
 
   // Release QA needs a real, short-lived Supabase identity for the platform
   // admin success paths. A server API key is not a human identity and cannot
   // satisfy requireAdmin. Keep OWNER non-admin so every negative boundary
   // assertion remains honest; synthesize a dedicated principal instead.
-  if (env.capabilities.database && env.target !== 'prod') {
-    const platformAdmin = await synthUser(env, 'PLATFORM-ADMIN', runId);
-    provisioned.supabaseUserIds.push(platformAdmin.user.id);
-    try {
-      revokePlatformAdmin = await grantEphemeralPlatformAdmin(env, platformAdmin.user.id);
-    } catch (err) {
-      await adminDeleteUser(env, platformAdmin.user.id);
-      throw err;
+  //
+  // It depends on nothing in provisionMatrix, so both run at once. Nothing in
+  // the suite starts until this whole block finishes, so every second saved
+  // here is a second off the wall clock. allSettled keeps a rejection on one
+  // side from stranding the resources the other side already created.
+  const wantsPlatformAdmin = env.capabilities.database && env.target !== 'prod';
+  const [matrixSettled, adminSettled] = await Promise.allSettled([
+    provisionMatrix(env, runId),
+    wantsPlatformAdmin ? provisionPlatformAdmin(env, runId) : Promise.resolve(null),
+  ]);
+
+  if (matrixSettled.status === 'rejected') {
+    if (adminSettled.status === 'fulfilled' && adminSettled.value) {
+      await adminSettled.value.release().catch(() => undefined);
     }
+    throw matrixSettled.reason;
+  }
+  const provisioned: Provisioned = matrixSettled.value;
+  if (adminSettled.status === 'rejected') throw adminSettled.reason;
+
+  let revokePlatformAdmin: (() => Promise<void>) | null = null;
+  if (adminSettled.value) {
+    const platformAdmin = adminSettled.value;
+    provisioned.supabaseUserIds.push(platformAdmin.userId);
+    revokePlatformAdmin = platformAdmin.revoke;
     env.adminToken = platformAdmin.jwt;
     env.capabilities.admin = true;
-    log.step(`provision: run-scoped platform admin ${platformAdmin.user.id} active`);
+    log.step(`provision: run-scoped platform admin ${platformAdmin.userId} active`);
   }
+
+  const owner = provisioned.principals.OWNER!;
   const adminClient = new Client(env.apiUrl).as(owner as Identity);
   const canCreateDatabaseProject = env.capabilities.database && env.target !== 'prod';
   const deleteDatabaseProjectFixture = canCreateDatabaseProject
@@ -340,7 +388,11 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
         }
       }
       const userIds = [...provisioned.supabaseUserIds, ...extraUserIds];
-      const cleanupWorkers = Number(process.env.KE2E_TEARDOWN_WORKERS ?? 2);
+      // A full run synthesizes hundreds of users. Deleting them 2 at a time
+      // added 2-5 min to the tail; 8 matches gc.ts's existing sweep default and
+      // is a Supabase admin call, not a provisioning call, so it does not touch
+      // the GitHub repo-creation budget. Override with KE2E_TEARDOWN_WORKERS.
+      const cleanupWorkers = Number(process.env.KE2E_TEARDOWN_WORKERS ?? 8);
       await mapWithConcurrency(userIds, cleanupWorkers, async (uid) => {
         try {
           await adminDeleteUser(env, uid);

--- a/tests/unit/client-resilience.test.ts
+++ b/tests/unit/client-resilience.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Client,
+  Res,
+  TransientCircuitBreaker,
+  describeEdgeResponse,
+  isKe2eRetryableError,
+  readBreakerOptions,
+  transientBreaker,
+  transientRetryDelayMs,
+} from '../src/core/client';
+import type { Captured } from '../src/core/result';
+
+function capturedResponse(status: number, headers: Record<string, string>): Res {
+  const captured: Captured = {
+    routeTemplate: 'GET /v1/test',
+    req: { method: 'GET', url: 'https://example.test/v1/test', headers: {} },
+    res: { status, headers, bodyText: '' },
+    ms: 1,
+  };
+  return new Res(captured);
+}
+
+function launderedMaintenance503(): Response {
+  return new Response('<html>maintenance</html>', {
+    status: 503,
+    headers: {
+      'content-type': 'text/html; charset=UTF-8',
+      'retry-after': '1',
+      'x-maintenance-mode': 'blocking',
+    },
+  });
+}
+
+beforeEach(() => {
+  transientBreaker.reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  transientBreaker.reset();
+});
+
+// ---------------------------------------------------------------------------
+// P3.2 (a) — exponential backoff with full jitter replaces the fixed 2s delay.
+// ---------------------------------------------------------------------------
+
+describe('transient retry backoff (P3.2)', () => {
+  it('grows exponentially from a ~500ms base and caps at ~8s', () => {
+    const ceilings = [1, 2, 3, 4, 5, 6].map((attempt) =>
+      transientRetryDelayMs(attempt, { random: () => 1 }),
+    );
+
+    expect(ceilings).toEqual([500, 1_000, 2_000, 4_000, 8_000, 8_000]);
+  });
+
+  it('applies FULL jitter — the whole window below the ceiling is reachable', () => {
+    expect(transientRetryDelayMs(4, { random: () => 0 })).toBe(0);
+    expect(transientRetryDelayMs(4, { random: () => 0.5 })).toBe(2_000);
+    expect(transientRetryDelayMs(4, { random: () => 1 })).toBe(4_000);
+  });
+
+  it('is never the old fixed 2s for every attempt', () => {
+    const fixed = [1, 2, 3].every(
+      (attempt) => transientRetryDelayMs(attempt, { random: () => 0.5 }) === 2_000,
+    );
+
+    expect(fixed).toBe(false);
+  });
+
+  it('raises the floor to the edge Retry-After but never past the cap', () => {
+    expect(transientRetryDelayMs(1, { retryAfterMs: 3_000, random: () => 0 })).toBe(3_000);
+    expect(transientRetryDelayMs(1, { retryAfterMs: 180_000, random: () => 0 })).toBe(8_000);
+  });
+
+  it('honours the env-tunable base and cap', () => {
+    expect(
+      transientRetryDelayMs(3, { baseMs: 100, capMs: 1_000, random: () => 1 }),
+    ).toBe(400);
+    expect(
+      transientRetryDelayMs(9, { baseMs: 100, capMs: 1_000, random: () => 1 }),
+    ).toBe(1_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P3.2 (b) — the process-wide circuit breaker.
+// ---------------------------------------------------------------------------
+
+describe('transient circuit breaker (P3.2)', () => {
+  it('opens only at the threshold within the rolling window', () => {
+    let now = 1_000;
+    const breaker = new TransientCircuitBreaker({
+      threshold: 3,
+      windowMs: 60_000,
+      now: () => now,
+    });
+
+    breaker.record();
+    breaker.record();
+    expect(breaker.isOpen()).toBe(false);
+    breaker.record();
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.failuresInWindow()).toBe(3);
+  });
+
+  it('closes on its own once the failures age out of the window', () => {
+    let now = 1_000;
+    const breaker = new TransientCircuitBreaker({
+      threshold: 2,
+      windowMs: 60_000,
+      now: () => now,
+    });
+
+    breaker.record();
+    breaker.record();
+    expect(breaker.isOpen()).toBe(true);
+
+    now += 60_001;
+    expect(breaker.isOpen()).toBe(false);
+    expect(breaker.failuresInWindow()).toBe(0);
+  });
+
+  it('announces exactly once per open transition', () => {
+    let now = 1_000;
+    const breaker = new TransientCircuitBreaker({
+      threshold: 1,
+      windowMs: 60_000,
+      now: () => now,
+    });
+
+    breaker.record();
+    expect(breaker.shouldAnnounce()).toBe(true);
+    expect(breaker.shouldAnnounce()).toBe(false);
+
+    now += 60_001;
+    expect(breaker.isOpen()).toBe(false);
+    breaker.record();
+    expect(breaker.shouldAnnounce()).toBe(true);
+  });
+
+  it('is disabled by a non-positive threshold', () => {
+    const breaker = new TransientCircuitBreaker({ threshold: 0, windowMs: 60_000 });
+    for (let i = 0; i < 100; i++) breaker.record();
+
+    expect(breaker.isOpen()).toBe(false);
+  });
+
+  it('reads env-tunable thresholds with 20-in-60s defaults', () => {
+    expect(readBreakerOptions({})).toEqual({ threshold: 20, windowMs: 60_000 });
+    expect(
+      readBreakerOptions({ KE2E_BREAKER_THRESHOLD: '5', KE2E_BREAKER_WINDOW_MS: '10000' }),
+    ).toEqual({ threshold: 5, windowMs: 10_000 });
+  });
+
+  it('stops retrying and stops marking retryable once open', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('KE2E_BREAKER_THRESHOLD', '2');
+    vi.resetModules();
+    const mod = await import('../src/core/client');
+    mod.transientBreaker.reset();
+
+    const fetchMock = vi.fn().mockImplementation(async () => launderedMaintenance503());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new mod.Client('https://example.test/v1').withTransientGatewayRetries(3);
+    const promise = client.get('/v1/test');
+    await vi.runAllTimersAsync();
+    const response = await promise;
+
+    // Threshold 2 within the window: attempt 1 records, attempt 2 records and
+    // trips the breaker, so the 4-attempt budget is cut short.
+    expect(fetchMock.mock.calls.length).toBeLessThan(4);
+    expect(mod.transientBreaker.isOpen()).toBe(true);
+
+    let error: unknown;
+    try {
+      response.status(200);
+    } catch (caught) {
+      error = caught;
+    }
+    expect((error as Error).message).toContain('circuit open');
+    // With the breaker open the flow-level budget must not re-amplify this.
+    expect(isKe2eRetryableError(error)).toBe(false);
+
+    mod.transientBreaker.reset();
+  });
+
+  it('still marks a laundered 503 retryable while the breaker is closed', () => {
+    const response = capturedResponse(503, {
+      'content-type': 'text/html',
+      'retry-after': '30',
+      'x-maintenance-mode': 'blocking',
+    });
+
+    let error: unknown;
+    try {
+      response.status(200);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(isKe2eRetryableError(error)).toBe(true);
+    expect((error as Error).message).not.toContain('circuit open');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P3.3 — name the edge response instead of guessing at it.
+// ---------------------------------------------------------------------------
+
+describe('edge response diagnostics (P3.3)', () => {
+  it('names a laundered edge maintenance 503 by its header pair', () => {
+    expect(
+      describeEdgeResponse(503, {
+        'x-maintenance-mode': 'blocking',
+        'retry-after': '60',
+      }),
+    ).toBe(
+      '[edge-laundered status=503 x-maintenance-mode=blocking x-request-id=absent]',
+    );
+  });
+
+  it('names a genuine application 5xx by its x-request-id', () => {
+    expect(
+      describeEdgeResponse(503, {
+        'x-request-id': 'req-1',
+        'content-type': 'application/json',
+      }),
+    ).toBe('[origin status=503 x-maintenance-mode=absent x-request-id=present]');
+  });
+
+  it('does not claim maintenance for an unlabelled edge failure', () => {
+    expect(describeEdgeResponse(502, {})).toBe(
+      '[edge status=502 x-maintenance-mode=absent x-request-id=absent]',
+    );
+  });
+
+  it('puts the diagnostics in the thrown retry-classification message', () => {
+    const response = capturedResponse(503, {
+      'content-type': 'text/html',
+      'retry-after': '30',
+      'x-maintenance-mode': 'blocking',
+    });
+
+    let error: unknown;
+    try {
+      response.status(200);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect((error as Error).message).toContain('x-maintenance-mode=blocking');
+    expect((error as Error).message).toContain('x-request-id=absent');
+    expect((error as Error).message).toContain('edge-laundered');
+  });
+
+  it('reports the attempt count in an exhausted network-error throw', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = new Client('https://example.test/v1')
+      .withTransientGatewayRetries(2)
+      .get('/v1/test');
+    const settled = promise.catch((err) => err as Error);
+    await vi.runAllTimersAsync();
+    const error = await settled;
+
+    expect(error.message).toContain('after 3/3 attempt(s)');
+    expect(error.message).toContain('ECONNRESET');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/unit/provisioning-perf.test.ts
+++ b/tests/unit/provisioning-perf.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { retryDelayMs } from '../src/fixtures/provision';
+import { fundingFailureIsFatal, fundingFailureMessage } from '../src/fixtures/principals';
+import type { Env } from '../src/core/env';
+
+function envWith(capabilities: Partial<Env['capabilities']>): Pick<Env, 'capabilities'> {
+  return { capabilities: capabilities as Env['capabilities'] };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// P1.5 — provisioning concurrency and its jittered backoff.
+// ---------------------------------------------------------------------------
+
+describe('provision retry backoff (P1.5)', () => {
+  it('replaces the fixed 120s rate-limit wait with exponential backoff', () => {
+    const ceilings = [0, 1, 2, 3, 4].map((attempt) => retryDelayMs(attempt, true, () => 1));
+
+    expect(ceilings).toEqual([15_000, 30_000, 60_000, 120_000, 120_000]);
+    // The old policy waited a flat 120s on the FIRST rate-limited retry.
+    expect(ceilings[0]).toBeLessThan(120_000);
+  });
+
+  it('applies equal jitter so concurrent provisions never retry in lockstep', () => {
+    expect(retryDelayMs(0, true, () => 0)).toBe(7_500);
+    expect(retryDelayMs(0, true, () => 0.5)).toBe(11_250);
+    expect(retryDelayMs(0, true, () => 1)).toBe(15_000);
+  });
+
+  it('keeps a non-zero floor — a near-instant retry re-trips a secondary rate limit', () => {
+    for (const attempt of [0, 1, 2, 3]) {
+      expect(retryDelayMs(attempt, true, () => 0)).toBeGreaterThan(0);
+      expect(retryDelayMs(attempt, false, () => 0)).toBeGreaterThan(0);
+    }
+  });
+
+  it('jitters the non-rate-limited 5s→30s backoff too', () => {
+    expect(retryDelayMs(0, false, () => 1)).toBe(5_000);
+    expect(retryDelayMs(0, false, () => 0)).toBe(2_500);
+    expect(retryDelayMs(9, false, () => 1)).toBe(30_000);
+  });
+});
+
+describe('provision concurrency default (P1.5)', () => {
+  it('allows 4 concurrent provisions by default, not 2', async () => {
+    vi.stubEnv('KE2E_PROVISION_CONCURRENCY', '');
+    vi.unstubAllEnvs();
+    delete process.env.KE2E_PROVISION_CONCURRENCY;
+    vi.resetModules();
+    const { provisionProject } = await import('../src/fixtures/provision');
+
+    let active = 0;
+    let maxActive = 0;
+    const release: Array<() => void> = [];
+    const post = vi.fn().mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise<void>((resolve) => release.push(resolve));
+      active--;
+      return {
+        statusCode: 200,
+        text: () => '{"project_id":"p"}',
+        json: <T>() => ({ project_id: 'p' }) as T,
+      };
+    });
+    const client = { post } as never;
+
+    const inflight = Array.from({ length: 8 }, () => provisionProject(client, { name: 'x' }));
+    // Let the semaphore hand out every slot it is willing to.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const grantedFirstWave = maxActive;
+    for (const resolve of [...release]) resolve();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    for (const resolve of [...release]) resolve();
+    await Promise.all(inflight);
+
+    expect(grantedFirstWave).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P0.3 — OWNER funding is fatal on a Stripe-capable target.
+// ---------------------------------------------------------------------------
+
+describe('OWNER funding failure policy (P0.3)', () => {
+  it('is FATAL when the target declares the stripe capability', () => {
+    expect(fundingFailureIsFatal(envWith({ stripe: true }), {})).toBe(true);
+  });
+
+  it('stays soft on a local profile without stripe', () => {
+    expect(fundingFailureIsFatal(envWith({ stripe: false }), {})).toBe(false);
+  });
+
+  it('restores soft-fail with KE2E_FUNDING_OPTIONAL', () => {
+    expect(
+      fundingFailureIsFatal(envWith({ stripe: true }), { KE2E_FUNDING_OPTIONAL: '1' }),
+    ).toBe(false);
+    expect(
+      fundingFailureIsFatal(envWith({ stripe: true }), { KE2E_FUNDING_OPTIONAL: 'true' }),
+    ).toBe(false);
+    expect(
+      fundingFailureIsFatal(envWith({ stripe: true }), { KE2E_FUNDING_OPTIONAL: '0' }),
+    ).toBe(true);
+  });
+
+  it('names the consequence, the escape hatch, and the cause', () => {
+    const message = fundingFailureMessage(new Error('Stripe PI confirm failed: 402'));
+
+    expect(message).toContain('`funded`');
+    expect(message).toContain('Failing fast');
+    expect(message).toContain('KE2E_FUNDING_OPTIONAL=1');
+    expect(message).toContain('Stripe PI confirm failed: 402');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P1.7 — provisionMatrix runs the OWNER chain and NONMEMBER at the same time.
+// ---------------------------------------------------------------------------
+
+interface Window {
+  label: string;
+  startedAt: number;
+  endedAt: number;
+}
+
+async function loadProvisionMatrix(opts: {
+  windows: Window[];
+  subscribe: () => Promise<void>;
+  createDelayMs?: number;
+}) {
+  const delay = opts.createDelayMs ?? 25;
+  vi.doMock('../src/fixtures/supabase', () => ({
+    adminCreateUser: async (_env: unknown, email: string) => {
+      const label = email.includes('nonmember') ? 'NONMEMBER' : 'OWNER';
+      const startedAt = performance.now();
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      opts.windows.push({ label, startedAt, endedAt: performance.now() });
+      return { id: `${label}-user-id` };
+    },
+    passwordGrant: async () => 'jwt-token',
+    adminDeleteUser: async () => undefined,
+  }));
+  vi.doMock('../src/fixtures/billing', () => ({ subscribe: opts.subscribe }));
+  vi.doMock('../src/core/client', () => ({
+    Client: class {
+      as() {
+        return this;
+      }
+      async post() {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return { json: () => ({ secret_key: 'pat-secret' }), text: () => '' };
+      }
+    },
+  }));
+  vi.resetModules();
+  return (await import('../src/fixtures/principals')).provisionMatrix;
+}
+
+describe('provisionMatrix parallelism (P1.7)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../src/fixtures/supabase');
+    vi.doUnmock('../src/fixtures/billing');
+    vi.doUnmock('../src/core/client');
+    vi.resetModules();
+  });
+
+  it('creates NONMEMBER at the same time as the OWNER chain', async () => {
+    const windows: Window[] = [];
+    const provisionMatrix = await loadProvisionMatrix({
+      windows,
+      subscribe: async () => undefined,
+    });
+
+    const env = {
+      apiUrl: 'https://example.test/v1',
+      testEmailDomain: 'ke2e.kortix.test',
+      capabilities: { stripe: false },
+    } as unknown as Env;
+    const result = await provisionMatrix(env, 'run-1');
+
+    const owner = windows.find((w) => w.label === 'OWNER')!;
+    const nonmember = windows.find((w) => w.label === 'NONMEMBER')!;
+    expect(owner.startedAt < nonmember.endedAt && nonmember.startedAt < owner.endedAt).toBe(
+      true,
+    );
+    expect(result.supabaseUserIds).toEqual(['OWNER-user-id', 'NONMEMBER-user-id']);
+    expect(result.principals.PAT_ACCT?.auth).toEqual({
+      mode: 'bearer',
+      token: 'pat-secret',
+    });
+  });
+
+  it('throws immediately when funding fails on a stripe-capable target', async () => {
+    const windows: Window[] = [];
+    const provisionMatrix = await loadProvisionMatrix({
+      windows,
+      subscribe: async () => {
+        throw new Error('Stripe PI confirm failed: 402');
+      },
+    });
+
+    const env = {
+      apiUrl: 'https://example.test/v1',
+      testEmailDomain: 'ke2e.kortix.test',
+      capabilities: { stripe: true, funded: false },
+    } as unknown as Env;
+
+    await expect(provisionMatrix(env, 'run-2')).rejects.toThrow(/OWNER funding failed/);
+  });
+
+  it('cleans up NONMEMBER instead of stranding it when the OWNER chain fails', async () => {
+    const deleted: string[] = [];
+    vi.doMock('../src/fixtures/supabase', () => ({
+      adminCreateUser: async (_env: unknown, email: string) => ({
+        id: email.includes('nonmember') ? 'NONMEMBER-user-id' : 'OWNER-user-id',
+      }),
+      passwordGrant: async () => 'jwt-token',
+      adminDeleteUser: async (_env: unknown, id: string) => {
+        deleted.push(id);
+      },
+    }));
+    vi.doMock('../src/fixtures/billing', () => ({
+      subscribe: async () => {
+        throw new Error('Stripe down');
+      },
+    }));
+    vi.doMock('../src/core/client', () => ({
+      Client: class {
+        as() {
+          return this;
+        }
+        async post() {
+          return { json: () => ({ secret_key: 's' }), text: () => '' };
+        }
+      },
+    }));
+    vi.resetModules();
+    const { provisionMatrix } = await import('../src/fixtures/principals');
+
+    const env = {
+      apiUrl: 'https://example.test/v1',
+      testEmailDomain: 'ke2e.kortix.test',
+      capabilities: { stripe: true },
+    } as unknown as Env;
+
+    await expect(provisionMatrix(env, 'run-4')).rejects.toThrow(/OWNER funding failed/);
+    expect(deleted).toEqual(['NONMEMBER-user-id']);
+  });
+
+  it('warns instead of throwing when KE2E_FUNDING_OPTIONAL is set', async () => {
+    vi.stubEnv('KE2E_FUNDING_OPTIONAL', '1');
+    const windows: Window[] = [];
+    const provisionMatrix = await loadProvisionMatrix({
+      windows,
+      subscribe: async () => {
+        throw new Error('Stripe PI confirm failed: 402');
+      },
+    });
+
+    const env = {
+      apiUrl: 'https://example.test/v1',
+      testEmailDomain: 'ke2e.kortix.test',
+      capabilities: { stripe: true, funded: false },
+    } as unknown as Env;
+
+    const result = await provisionMatrix(env, 'run-3');
+    expect(result.principals.OWNER).toBeDefined();
+    expect(env.capabilities.funded).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P1.7 — buildWorld provisions the platform admin BESIDE provisionMatrix.
+// ---------------------------------------------------------------------------
+
+describe('buildWorld provisioning parallelism (P1.7)', () => {
+  afterEach(() => {
+    vi.doUnmock('../src/fixtures/principals');
+    vi.doUnmock('../src/fixtures/platform-admin');
+    vi.doUnmock('../src/fixtures/supabase');
+    vi.doUnmock('../src/core/client');
+    vi.resetModules();
+  });
+
+  it('overlaps provisionMatrix with the platform-admin grant', async () => {
+    const windows: Window[] = [];
+    const record = async (label: string, ms: number) => {
+      const startedAt = performance.now();
+      await new Promise((resolve) => setTimeout(resolve, ms));
+      windows.push({ label, startedAt, endedAt: performance.now() });
+    };
+
+    vi.doMock('../src/fixtures/principals', () => ({
+      provisionMatrix: async () => {
+        await record('matrix', 30);
+        return {
+          principals: {
+            OWNER: { label: 'OWNER', auth: { mode: 'bearer', token: 't' }, accountId: 'a', userId: 'u' },
+            ANON: { label: 'ANON', auth: { mode: 'none' } },
+            accountId: 'a',
+          },
+          runAccountIds: [],
+          supabaseUserIds: ['OWNER-user-id'],
+        };
+      },
+      synthUser: async () => {
+        await record('platform-admin-user', 30);
+        return { user: { id: 'ADMIN-user-id' }, jwt: 'admin-jwt', principal: {} };
+      },
+      synthUserWithEmail: async () => ({ user: { id: 'x' }, jwt: 'j', principal: {} }),
+    }));
+    vi.doMock('../src/fixtures/platform-admin', () => ({
+      grantEphemeralPlatformAdmin: async () => async () => undefined,
+    }));
+    vi.doMock('../src/fixtures/supabase', () => ({ adminDeleteUser: async () => undefined }));
+    vi.doMock('../src/core/client', () => ({
+      Client: class {
+        as() {
+          return this;
+        }
+      },
+    }));
+    vi.resetModules();
+    const { buildWorld } = await import('../src/fixtures/world');
+
+    const env = {
+      apiUrl: 'https://example.test/v1',
+      target: 'staging',
+      supabaseAnonKey: 'anon',
+      testEmailDomain: 'ke2e.kortix.test',
+      capabilities: { supabaseAdmin: true, database: true },
+    } as unknown as Env;
+
+    const world = await buildWorld(env, [
+      { id: 'ACC-1', meta: { domain: 'accounts' }, fn: async () => {} } as never,
+    ]);
+
+    const matrix = windows.find((w) => w.label === 'matrix')!;
+    const admin = windows.find((w) => w.label === 'platform-admin-user')!;
+    expect(matrix.startedAt < admin.endedAt && admin.startedAt < matrix.endedAt).toBe(true);
+
+    // The admin identity is still wired into env exactly as before.
+    expect(env.adminToken).toBe('admin-jwt');
+    expect(env.capabilities.admin).toBe(true);
+    expect(world.principals.accountId).toBe('a');
+  });
+});

--- a/tests/unit/release-gate-resilience.test.ts
+++ b/tests/unit/release-gate-resilience.test.ts
@@ -5,6 +5,7 @@ import {
   isKe2eRetryableError,
   isKe2eTransientGatewayResponse,
   ke2eRetryDelayMs,
+  transientBreaker,
 } from '../src/core/client';
 import { DEFAULT_FLOW_ATTEMPTS } from '../src/core/flow';
 import { waitFor } from '../src/core/poll';
@@ -49,6 +50,8 @@ describe('release gate transient failure resilience', () => {
     vi.stubEnv('KE2E_PROVISION_CONCURRENCY', '2');
     vi.stubEnv('KE2E_PROVISION_MIN_INTERVAL_MS', '0');
     vi.stubEnv('KE2E_PROVISION_RATE_LIMIT_DELAY_MS', '120000');
+    // The transient breaker is process-wide: keep it out of these assertions.
+    transientBreaker.reset();
     vi.resetModules();
     ({ paceProvisionRequest, provisionProject } = await import('../src/fixtures/provision'));
   });
@@ -120,7 +123,12 @@ describe('release gate transient failure resilience', () => {
     await expect(settleTimers(result)).resolves.toBe('project-3');
     expect(post).toHaveBeenCalledTimes(2);
     expect(attempts).toHaveLength(2);
-    expect((attempts.at(1) ?? 0) - (attempts.at(0) ?? 0)).toBeGreaterThanOrEqual(120_000);
+    // P1.5: the first rate-limited retry is exponential-with-equal-jitter from
+    // a 15s base, not a flat 120s. 120s is now only the CEILING (attempt 4+).
+    // The exact schedule is asserted in provisioning-perf.test.ts.
+    const delay = (attempts.at(1) ?? 0) - (attempts.at(0) ?? 0);
+    expect(delay).toBeGreaterThanOrEqual(7_500);
+    expect(delay).toBeLessThanOrEqual(15_000);
   });
 
   it('paces concurrent managed repository creation attempts', async () => {

--- a/tests/unit/runner-perf.test.ts
+++ b/tests/unit/runner-perf.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import {
+  attemptsFor,
+  classifyFlowError,
+  DEFAULT_FLOW_ATTEMPTS,
+  DEFAULT_SESSION_RUNTIME_ATTEMPTS,
+  DEFAULT_TIMEOUT_ATTEMPTS,
+  KE2E_FLOW_TIMEOUT,
+  maxAttemptBound,
+  readAttemptPolicy,
+  type RegisteredFlow,
+} from '../src/core/flow';
+import { runScheduled, type LaneSchedule } from '../src/core/lanes';
+import { markSessionReadinessTimeoutRetryable } from '../src/core/session-runtime-retry';
+
+function flowTimeoutError(id = 'CR-9', ms = 1_200_000): Error {
+  const error = new Error(`flow ${id} exceeded ${ms}ms`);
+  (error as Record<string, unknown>)[KE2E_FLOW_TIMEOUT] = true;
+  return error;
+}
+
+describe('flow attempt policy (P1.1)', () => {
+  it('defaults to 3 infra attempts, 1 timeout attempt, 2 session-runtime attempts', () => {
+    const policy = readAttemptPolicy({});
+
+    expect(policy).toEqual({ infra: 3, timeout: 1, sessionRuntime: 2 });
+    expect(DEFAULT_FLOW_ATTEMPTS).toBe(3);
+    expect(DEFAULT_TIMEOUT_ATTEMPTS).toBe(1);
+    expect(DEFAULT_SESSION_RUNTIME_ATTEMPTS).toBe(2);
+  });
+
+  it('reads every budget from its own env knob', () => {
+    expect(
+      readAttemptPolicy({
+        KE2E_FLOW_ATTEMPTS: '5',
+        KE2E_TIMEOUT_ATTEMPTS: '2',
+        KE2E_SESSION_RUNTIME_ATTEMPTS: '4',
+      }),
+    ).toEqual({ infra: 5, timeout: 2, sessionRuntime: 4 });
+  });
+
+  it('rejects junk and clamps to at least one attempt', () => {
+    expect(readAttemptPolicy({ KE2E_FLOW_ATTEMPTS: 'nonsense' }).infra).toBe(3);
+    expect(readAttemptPolicy({ KE2E_FLOW_ATTEMPTS: '0' }).infra).toBe(1);
+  });
+
+  it('keeps the legacy KE2E_DEFAULT_FLOW_ATTEMPTS as a ceiling over EVERY class', () => {
+    // local-profile.ts and preview-stack.ts both pin this to 1 for determinism.
+    // If it only fed the infra budget, those runs would silently regain a
+    // session-runtime retry they deliberately gave up.
+    expect(readAttemptPolicy({ KE2E_DEFAULT_FLOW_ATTEMPTS: '1' })).toEqual({
+      infra: 1,
+      timeout: 1,
+      sessionRuntime: 1,
+    });
+    expect(readAttemptPolicy({ KE2E_DEFAULT_FLOW_ATTEMPTS: '6' })).toEqual({
+      infra: 6,
+      timeout: 1,
+      sessionRuntime: 2,
+    });
+  });
+
+  it('lets the explicit knobs win under the legacy ceiling', () => {
+    expect(
+      readAttemptPolicy({ KE2E_FLOW_ATTEMPTS: '4', KE2E_DEFAULT_FLOW_ATTEMPTS: '2' }).infra,
+    ).toBe(2);
+  });
+
+  it('does NOT retry a flow-level timeout — it is a hang, not a blip', () => {
+    const policy = readAttemptPolicy({});
+    const error = flowTimeoutError();
+
+    // The timeout path must never carry the generic infra marker again.
+    expect((error as Record<string, unknown>).ke2eRetryable).toBeUndefined();
+    expect(classifyFlowError(error, false)).toBe('timeout');
+    expect(attemptsFor('timeout', policy)).toBe(1);
+  });
+
+  it('re-enables timeout retries only when KE2E_TIMEOUT_ATTEMPTS asks for it', () => {
+    const policy = readAttemptPolicy({ KE2E_TIMEOUT_ATTEMPTS: '3' });
+
+    expect(attemptsFor(classifyFlowError(flowTimeoutError(), false), policy)).toBe(3);
+  });
+
+  it('caps a session-runtime readiness timeout at 2 attempts, not 3', () => {
+    const sessionId = 'session-1';
+    const error = markSessionReadinessTimeoutRetryable(
+      new Error(`Timed out waiting for session runtime ready for ${sessionId}`),
+      sessionId,
+    );
+    const policy = readAttemptPolicy({});
+
+    expect(classifyFlowError(error, false)).toBe('session-runtime');
+    expect(attemptsFor('session-runtime', policy)).toBe(2);
+    expect(attemptsFor('infra', policy)).toBe(3);
+  });
+
+  it('keeps 3 attempts for a genuine network error or laundered 503', () => {
+    const network = Object.assign(new Error('network error GET /v1/projects'), {
+      ke2eRetryable: true,
+    });
+
+    expect(classifyFlowError(network, false)).toBe('infra');
+    expect(attemptsFor('infra', readAttemptPolicy({}))).toBe(3);
+  });
+
+  it('never retries an assertion failure or an unmarked error', () => {
+    const policy = readAttemptPolicy({});
+
+    expect(classifyFlowError(new Error('status expected 200, received 400'), true)).toBe(
+      'assertion',
+    );
+    expect(classifyFlowError(new Error('undefined is not a function'), false)).toBe('fatal');
+    expect(attemptsFor('assertion', policy)).toBe(1);
+    expect(attemptsFor('fatal', policy)).toBe(1);
+  });
+
+  it('bounds the attempt loop by the largest configured class budget', () => {
+    expect(maxAttemptBound({ infra: 3, timeout: 1, sessionRuntime: 2 })).toBe(3);
+    expect(maxAttemptBound({ infra: 1, timeout: 1, sessionRuntime: 5 })).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P1.2 — the serial lane overlaps the parallel lanes; the global lane does not.
+// ---------------------------------------------------------------------------
+
+interface Trace {
+  id: string;
+  startedAt: number;
+  endedAt: number;
+}
+
+function fakeFlow(id: string): RegisteredFlow {
+  return { id, meta: { domain: 'test' }, fn: async () => {} };
+}
+
+function overlaps(a: Trace, b: Trace): boolean {
+  return a.startedAt < b.endedAt && b.startedAt < a.endedAt;
+}
+
+/** Run a schedule of fake flows, recording exact start/end windows. */
+async function traceSchedule(schedule: LaneSchedule, durationMs = 20): Promise<Trace[]> {
+  const traces: Trace[] = [];
+  await runScheduled(schedule, async (flow) => {
+    const startedAt = performance.now();
+    await new Promise((resolve) => setTimeout(resolve, durationMs));
+    const trace = { id: flow.id, startedAt, endedAt: performance.now() };
+    traces.push(trace);
+    return trace;
+  });
+  return traces;
+}
+
+describe('lane scheduling (P1.2)', () => {
+  it('runs serial flows one at a time — never beside each other', async () => {
+    const schedule: LaneSchedule = {
+      concurrent: [{ flows: [fakeFlow('API-1'), fakeFlow('API-2')], workers: 2 }],
+      serial: [fakeFlow('SER-1'), fakeFlow('SER-2'), fakeFlow('SER-3')],
+      global: [],
+    };
+
+    const traces = await traceSchedule(schedule);
+    const serial = traces.filter((t) => t.id.startsWith('SER-'));
+
+    expect(serial).toHaveLength(3);
+    for (const a of serial) {
+      for (const b of serial) {
+        if (a.id !== b.id) expect(overlaps(a, b)).toBe(false);
+      }
+    }
+  });
+
+  it('overlaps the serial lane WITH the parallel lanes instead of appending it', async () => {
+    const schedule: LaneSchedule = {
+      concurrent: [
+        { flows: [fakeFlow('API-1'), fakeFlow('API-2'), fakeFlow('API-3')], workers: 3 },
+        { flows: [fakeFlow('SBX-1')], workers: 1 },
+      ],
+      serial: [fakeFlow('SER-1'), fakeFlow('SER-2')],
+      global: [],
+    };
+
+    const traces = await traceSchedule(schedule);
+    const byId = new Map(traces.map((t) => [t.id, t]));
+    const firstSerial = byId.get('SER-1')!;
+
+    // The first serial flow must run at the same time as the parallel lanes,
+    // not after them. Before P1.2 it started only once both lanes had drained.
+    const parallelIds = ['API-1', 'API-2', 'API-3', 'SBX-1'];
+    const overlapping = parallelIds.filter((id) => overlaps(firstSerial, byId.get(id)!));
+    expect(overlapping.length).toBeGreaterThan(0);
+  });
+
+  it('drains every global flow after everything else, one at a time', async () => {
+    const schedule: LaneSchedule = {
+      concurrent: [{ flows: [fakeFlow('API-1'), fakeFlow('API-2')], workers: 2 }],
+      serial: [fakeFlow('SER-1')],
+      global: [fakeFlow('BILL-13'), fakeFlow('ADM-19')],
+    };
+
+    const traces = await traceSchedule(schedule);
+    const byId = new Map(traces.map((t) => [t.id, t]));
+    const globals = ['BILL-13', 'ADM-19'].map((id) => byId.get(id)!);
+    const others = ['API-1', 'API-2', 'SER-1'].map((id) => byId.get(id)!);
+
+    // A global flow mutates every account on the deployment (BILL-13/ADM-19) or
+    // the shared managed repo (CONN-5): nothing may be in flight beside it.
+    for (const g of globals) {
+      for (const other of [...others, ...globals]) {
+        if (other.id !== g.id) expect(overlaps(g, other)).toBe(false);
+      }
+      expect(g.startedAt).toBeGreaterThanOrEqual(Math.max(...others.map((o) => o.endedAt)));
+    }
+  });
+
+  it('returns one result per scheduled flow across every lane', async () => {
+    const schedule: LaneSchedule = {
+      concurrent: [{ flows: [fakeFlow('API-1')], workers: 2 }, { flows: [fakeFlow('SBX-1')], workers: 1 }],
+      serial: [fakeFlow('SER-1')],
+      global: [fakeFlow('GLB-1')],
+    };
+
+    const results = await runScheduled(schedule, async (flow) => flow.id);
+
+    expect(results.sort()).toEqual(['API-1', 'GLB-1', 'SBX-1', 'SER-1']);
+  });
+
+  it('tolerates empty lanes', async () => {
+    const results = await runScheduled(
+      { concurrent: [{ flows: [], workers: 4 }], serial: [], global: [] },
+      async (flow) => flow.id,
+    );
+
+    expect(results).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements the runner-performance half of the release-gate optimization plan: P1.1, P1.2 (option 1), P1.4, P1.5 (provision half), P1.7, P0.3, P3.2, and the client half of P3.3.

Scope is `tests/` only. No flow assertion changed. No change to which flows run.

---

### 1. P1.1 — A flow-level timeout is no longer retried

**What/why.** `runner.ts:225` set `ke2eRetryable = true` on every flow timeout and `flow.ts:13` allowed 3 attempts, so a timed-out flow burned its full declared timeout three times, sequentially, in the tail. On the last two runs SESS-10 + CLI-SESS + CLI-TRG (360+300+180s) spent ~42 min on three flows that were always going to fail. A timeout is a hang, not an infrastructure blip.

Retries are now budgeted per error class:

| Class | Attempts | Knob |
| --- | --- | --- |
| Flow-level timeout | 1 | `KE2E_TIMEOUT_ATTEMPTS` |
| Session-runtime readiness timeout | 2 | `KE2E_SESSION_RUNTIME_ATTEMPTS` |
| Marked infra (network, laundered 503) | 3 | `KE2E_FLOW_ATTEMPTS` |
| Assertion / unmarked | 1 | — |

Session-runtime readiness (`session-runtime-retry.ts`) is the other big multiplier — a 5-7 min wait — and is capped at 2, not 3. `meta.retry.attempts` still overrides every class for one flow.

`KE2E_DEFAULT_FLOW_ATTEMPTS` keeps its legacy meaning as a **ceiling over every class**. This matters: `local-profile.ts:71` and `preview-stack.ts:254` both pin it to `1`. Mapping it to the infra budget alone would have silently handed those runs back a session-runtime retry they deliberately gave up.

**Tests.** `unit/runner-perf.test.ts`, 10 cases: per-class defaults, each env knob, the legacy ceiling over all three classes, timeout classified as `timeout` and never carrying `ke2eRetryable`, session-runtime capped at 2, infra still 3, assertion and unmarked never retried.

**Expected impact.** −25 to −40 min on a run with timeouts.

### 2. P1.2 — The serial lane overlaps the parallel lanes

**What/why.** `runner.ts:324` drained both parallel lanes via `Promise.all`, then `:332` ran the 32 serial flows one at a time as an appended tail. `meta.serial` means "does not share state with its peers", not "must be the only thing running". The serial lane now joins the same `Promise.all` at concurrency 1.

A serial flow still never runs beside another serial flow. Peak concurrency on the target rises by 1.

**The global lane stays strictly last and strictly alone.** I read all three: `BILL-13` and `ADM-19` are internal-cron routes that write across every account on the deployment; `CONN-5`'s own comment says it mutates `kortix.yaml` on the shared managed repository and must not race read-only flows. None can overlap anything.

Scheduling moved into `lanes.ts` `runScheduled` so it is unit-testable — `runner.ts` imports `bun` and cannot be imported under vitest.

**Tests.** `unit/runner-perf.test.ts`, 5 cases with real timing windows on fake flows: serial flows never overlap each other; the first serial flow **does** overlap the parallel lanes; every global flow starts after the last non-global end and overlaps nothing; result count preserved across lanes; empty lanes tolerated.

**Positive control.** I re-ran the exact overlap assertion against the pre-change algorithm (verbatim `runner.ts:324-332`) and it fails as required:

```
× the OLD scheduler fails the overlap assertion
  → expected 0 to be greater than 0
```

The new scheduler yields >0 overlapping flows. The test is a real control, not a tautology.

**Expected impact.** −15 to −25 min.

### 3. P1.4 — Teardown concurrency 2 → 8

**What/why.** `world.ts:343` deleted the hundreds of users a full run synthesizes two at a time, at the very end. 8 matches `gc.ts`'s existing default. It is a Supabase admin call, not a provisioning call, so it does not consume the GitHub repo-creation budget. `KE2E_TEARDOWN_WORKERS` still overrides, and `local-profile.ts:74` already sets it explicitly, so local runs are unaffected.

**Expected impact.** −2 to −4 min.

### 4. P1.5 — Provision concurrency 2 → 4, with a jittered backoff

**What/why.** `provision.ts:10` capped concurrent project provisions globally at 2. Most flows begin by provisioning, which is why measured parallelism was 1.43x with 6 workers — this, not `KE2E_API_WORKERS`, was the binding constraint.

Raising it makes GitHub's secondary rate limit on repo creation the next constraint, so I changed the backoff with it. It was a **fixed 120s** per rate-limited retry (`provision.ts:40`): 5 attempts could spend 8 minutes holding a semaphore slot even when the block cleared in seconds, and 4 concurrent provisions that trip the same limit would retry in lockstep and re-trip it.

It is now exponential from a 15s base to the same 120s ceiling (`KE2E_PROVISION_RATE_LIMIT_BASE_DELAY_MS`, `KE2E_PROVISION_RATE_LIMIT_DELAY_MS`), with **equal** jitter on both the rate-limited and the ordinary path. Equal jitter rather than full jitter deliberately: a near-instant retry against a secondary rate limit extends the block instead of clearing it, so the delay keeps a non-zero floor.

Worst-case rate-limited retry budget drops from ~480s to ~225s.

**Tests.** `unit/provisioning-perf.test.ts`, 5 cases: the exponential ceiling schedule `[15s, 30s, 60s, 120s, 120s]`, equal-jitter bounds at each end, a non-zero floor on every attempt, jitter on the non-rate-limited path, and a behavioral test that 8 queued provisions are granted exactly 4 slots. `unit/release-gate-resilience.test.ts:123` asserted the old flat 120s and is updated to the new `[7.5s, 15s]` first-retry window.

**Not touched:** the `local-runner.ts` worker-count bump (owned by another agent).

### 5. P1.7 — `provisionMatrix` and the platform admin run in parallel

**What/why.** `principals.ts:67` ran OWNER → bootstrap PAT → Stripe subscribe → NONMEMBER strictly in order, then `world.ts:97` added the platform admin. Nothing in the suite starts until all of it finishes.

NONMEMBER and the platform admin depend on nothing in the OWNER chain, so both now run beside it. The bootstrap PAT still precedes the subscribe — the personal account row is created lazily on the first token call, so that ordering is a real dependency, not incidental.

Both use `allSettled`, not `Promise.all`: a rejection on one side must not strand the Supabase user or the granted platform role the other side just created. The failure paths delete what they created.

**Tests.** `unit/provisioning-perf.test.ts`, 3 cases with timing windows over mocked Supabase/Stripe/HTTP: OWNER and NONMEMBER creation windows overlap; `buildWorld`'s matrix and platform-admin windows overlap while `env.adminToken` / `capabilities.admin` are still wired identically; a failed OWNER chain deletes the NONMEMBER user instead of stranding it.

**Expected impact.** −1 to −3 min, plus a much faster failure.

### 6. P0.3 — OWNER funding failure is fatal, asserted up front

**What/why.** `principals.ts:88` swallowed a Stripe subscribe failure with a warning. `env.ts:160` defaults `funded` to false and **52 flows** declare `requires: ['funded']` (verified: `grep -c` over `tests/src/flows/*.flow.ts`) — the largest capability group in the suite. One Stripe hiccup in the first 60 seconds silently turned 52 flows into skips, and `--require-all` reported the red ~75 minutes later.

Funding failure now throws during provisioning whenever the target declares the `stripe` capability. The message names the consequence, the escape hatch, and the cause. Targets without Stripe (the local profile) keep the warning. `KE2E_FUNDING_OPTIONAL=1` restores the soft failure.

**Tests.** `unit/provisioning-perf.test.ts`, 6 cases: fatal with `stripe`, soft without it, `KE2E_FUNDING_OPTIONAL` in `1`/`true`/`0` forms, the message contents, a real `provisionMatrix` rejection on a stripe-capable env, and a real non-throwing run under `KE2E_FUNDING_OPTIONAL=1`.

**Expected impact.** Failure in <2 min instead of ~75.

### 7. P3.2 — Backoff with jitter and a circuit breaker in the client

**What/why.** `client.ts:223` retried a laundered 503 up to 4 times at a **fixed 2s** delay (`:397-400`). Layered under 3 flow attempts, one request could hit the origin 12 times, and every client backed off in lockstep. That is a metastable failure: the target slows, offered load quadruples, the target slows further, and a brief blip ends the run.

**(a)** The transient retry now uses exponential backoff with **full** jitter, 500ms base to 8s cap (`KE2E_RETRY_BASE_DELAY_MS`, `KE2E_RETRY_MAX_DELAY_MS`). A `Retry-After` from the edge raises the floor but never parks past the cap.

**(b)** A process-wide `TransientCircuitBreaker` counts laundered-503 and network failures in a rolling window. At 20 in 60s (`KE2E_BREAKER_THRESHOLD`, `KE2E_BREAKER_WINDOW_MS`) the client stops retrying **and stops marking the failure retryable**, so the flow-level budget cannot re-amplify what the client just refused to. The window is rolling, so the breaker closes on its own; threshold `0` disables it. It announces once per open transition, not once per request.

**Tests.** `unit/client-resilience.test.ts`, 12 cases: the exact ceiling schedule `[500, 1000, 2000, 4000, 8000, 8000]`, full-jitter reachability across the window, an explicit assertion that it is no longer a fixed 2s, `Retry-After` floor and cap, env-tunable base/cap; breaker opens only at threshold, closes as failures age out, announces once, disables at 0, reads its env defaults; and an end-to-end case proving an open breaker cuts the 4-attempt budget short, produces a `circuit open` message, and returns a **non-retryable** error.

### 8. P3.3 (client half) — Stop guessing at the edge's response

**What/why.** The Cloudflare worker replaces any origin throw or 502/503/504 with a synthetic maintenance 503 that sets `X-Maintenance-Mode` and drops the origin's `x-request-id` (`worker.mjs:96-110`, `:251-272`). Every genuine origin failure reached the suite as an indistinguishable 503.

`describeEdgeResponse` prints that header pair and labels the response, and is now in the retry-classification message, the per-retry log line, and the give-up line:

```
[edge-laundered status=503 x-maintenance-mode=blocking x-request-id=absent]
[origin status=503 x-maintenance-mode=absent x-request-id=present]
```

The exhausted-retry throw also carries the attempt count (`after 3/3 attempt(s)`), and the give-up line carries the last status and header state. Observed live in the test run:

```
! ke2e retry 1/4 GET /v1/test [edge-laundered status=503 x-maintenance-mode=blocking x-request-id=absent]
! ke2e circuit open: 2 transient edge failures in 60000ms (threshold 2) — the deployment is overloaded; not retrying
! ke2e giving up GET /v1/test after 2/4 attempt(s) [edge-laundered ...] — circuit open: ...
```

**No worker change.** The header this reads is already set today. `infra/cloudflare/workers/api-router/worker.mjs` is untouched.

**Tests.** `unit/client-resilience.test.ts`, 5 cases covering all three labels and the attempt count in an exhausted network-error throw.

---

## Verification

```
$ pnpm --dir tests typecheck          # tsc --noEmit
exit 0, no output

$ pnpm --dir tests test:unit
 Test Files  27 passed (27)
      Tests  219 passed (219)
   Duration  1.22s
```

219 passing, up from 172 — 47 new cases. Zero pre-existing tests removed; one (`release-gate-resilience.test.ts:123`) updated because it pinned the old fixed 120s delay this PR deliberately replaces.

Real-surface smoke, not just unit tests:

```
$ bun bin/ke2e.ts list
441 flows            # exit 0 — the rewritten runner/flow/lanes import cleanly

$ KE2E_API_URL=http://127.0.0.1:18080/v1 bun bin/ke2e.ts run --domain system,access
world: public-only run — no principals provisioned
lanes: 13 API flows × 4 workers · 0 sandbox flows × 4 workers · 0 serial flows × 1 worker (overlapped) · 0 global flows last
results: 0/13 passed · 13 failed · 0 skipped · 0 todo · 0.0s
```

Real `runSuite` through the new lane path against a stub origin: 13 flows in, 13 results out, aggregation intact. The failures are the stub answering `{"ok":true}` for every route. The 0.0s duration also confirms assertion failures are still never retried.

## Not verified

- **No deployed staging run.** The wall-clock figures above are the plan's estimates, not measured. The real proof is the next `tests-release.yml` run; that also needs the P0.1/P0.2 fixes (todo stubs, `KE2E_CAP_MANAGED_GIT_PUSH`) which are outside this PR — the gate stays un-passable without them.
- **No full local `pnpm test`.** `local-runner.ts` is owned by a parallel agent in this workstream, so I avoided the shared local stack. The narrowest real proof available (441-flow discovery + a real `runSuite` lane execution) is above.
- **Raising provision concurrency to 4 is the untested-at-scale change.** The jittered backoff is the mitigation. If GitHub's secondary rate limit bites, `KE2E_PROVISION_CONCURRENCY=2` reverts it without a deploy.

## What to test next

1. Run the gate and read the new `lanes:` line — it reports serial and global counts, so the overlap is visible in the log.
2. Grep the run log for `edge-laundered` vs `origin` on any 503, and for `circuit open`.
3. If a flow times out, confirm `attempts=1` in its `results.json` entry rather than 3.
