### PR TITLE
infra(staging): right-size for the release gate (2 tasks, on-demand base, bigger box), record DB tier, let CI see real origin status at the edge

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -612,6 +612,43 @@ maintenance-mode 503s were real but were not the dominant cause of the later
 attempts (4 occurrences in attempt 10 vs 36 in attempt 1) — see the next entry.
 Capacity fix not yet made — staging still runs this gate at capacity risk.
 
+**Addendum (2026-08-19) — what the capacity audit found, and the durable fix.**
+Three facts, none of them visible from the symptom:
+
+- **Staging was smaller than dev.** `environments/staging/main.tf:98-103` ran
+  the API at `512/1024`, `desired/min/max = 1/1/3`; dev runs `2/2/6` and carries
+  no load. The environment that absorbs the heaviest load in the company had the
+  smallest box, and its autoscaling ceiling was 3 × 0.5 vCPU = 1.5 vCPU total.
+- **The single task was Spot with `base = 0`** (`modules/ecs-api/main.tf:506`)
+  behind `deployment_minimum_healthy_percent = 100` (`:521`). One Spot reclaim
+  empties the service and ECS cannot place the replacement until Spot capacity
+  returns. Some of the "cascading failures" chased that night may have been
+  reclaims, not load — and the edge laundered both into the same 503. **Any Spot
+  service whose total unavailability is a real cost needs an on-demand base.**
+- **The database tier lives outside Terraform.** The staging DB is hosted
+  Supabase (`ujzsbwvurfyeuerxxeaz`), injected as `STAGING_DATABASE_URL`; a
+  repo-wide grep for RDS/ElastiCache returns zero hits. The `ci_micro` →
+  `ci_medium` resize therefore survives every apply AND is recorded by nothing.
+  **A resource no plan can show is a resource only a runbook can hold** —
+  `docs/runbooks/staging-sizing.md` now does.
+
+**The Terraform trap this exposed, which generalises past staging:** the ecs-api
+service carries `ignore_changes = [task_definition, desired_count]` and the
+task-def carries `ignore_changes = [container_definitions]`, by design so CI
+image rolls do not fight Terraform. `infra/scripts/ecs-deploy.sh` then renders
+each new revision from the service's CURRENT one. So **changing `task_cpu` /
+`task_memory` in Terraform registers a revision the service never adopts — the
+apply is green and the live task never resizes.** Writing a size into Terraform
+is not the same as a task running at that size; verify with
+`describe-task-definition` on the service's live revision, never from the plan.
+Fixed durably by having `ecs-deploy.sh` take ONLY `cpu`/`memory` from the
+family's latest ACTIVE revision (Terraform's, right after an apply; its own
+previous one otherwise) and everything else from the service's current revision
+— so a resize propagates on the next deploy and is a no-op on every other one.
+*Enforcer:* `worker.test.mjs` pins staging >= dev on cpu/memory/min_capacity,
+pins `fargate_base_on_demand = 1` on both staging services, and pins the new
+module variable's default at `0` so dev/prod strategies cannot move.
+
 ### A frontend deploy job that `needs:` an unrelated edge job ships a half-deployed staging, and the release gate then blames the code (2026-08-19)
 
 **When:** `deploy-staging.yml` for `044d99480d` (v0.13.0 candidate),

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -331,6 +331,7 @@ jobs:
         env:
           WORKER_NAME: staging-api-kortix-router
           WORKER_ROUTE: staging-api.kortix.com/*
+          CF_WORKER_CI_PASSTHROUGH_SECRET: ${{ secrets.CF_WORKER_CI_PASSTHROUGH_SECRET }}
         run: |
           set -euo pipefail
           if [ -n "${CLOUDFLARE_GLOBAL_API_KEY:-}" ] && [ -n "${CLOUDFLARE_EMAIL:-}" ]; then
@@ -344,15 +345,28 @@ jobs:
 
           # This REST deploy replaces all staging Worker bindings. The API
           # and gateway both use ECS Fargate. EKS was decommissioned 2026-08-02.
-          metadata="$(jq -cn '{
+          #
+          # CI_PASSTHROUGH_SECRET lets a trusted release-gate run see the TRUE
+          # origin status instead of the synthetic MAINTENANCE_MODE 503 (see
+          # worker.mjs isTrustedCiPassthrough). It is bound only when the
+          # repository secret exists; without it the Worker's passthrough branch
+          # is unreachable and staging behaves exactly as before.
+          ci_binding='[]'
+          if [ -n "${CF_WORKER_CI_PASSTHROUGH_SECRET:-}" ]; then
+            ci_binding="$(jq -cn --arg secret "${CF_WORKER_CI_PASSTHROUGH_SECRET}" \
+              '[{type:"secret_text", name:"CI_PASSTHROUGH_SECRET", text:$secret}]')"
+          else
+            echo "::notice::CF_WORKER_CI_PASSTHROUGH_SECRET unset — deploying staging Worker without the CI passthrough binding."
+          fi
+          metadata="$(jq -cn --argjson ci "$ci_binding" '{
             main_module: "worker.mjs",
             compatibility_date: "2026-06-01",
-            bindings: [
+            bindings: ([
               {type:"plain_text", name:"ACTIVE_BACKEND", text:"ecs-fargate"},
               {type:"plain_text", name:"BACKEND_ECS_FARGATE", text:"https://staging-api-ecs-fargate.kortix.com"},
               {type:"plain_text", name:"GATEWAY_ACTIVE_BACKEND", text:"ecs-fargate"},
               {type:"plain_text", name:"GATEWAY_BACKEND_ECS_FARGATE", text:"https://gateway-staging-ecs-fargate.kortix.com"}
-            ]
+            ] + $ci)
           }')"
           curl -fsS -X PUT \
             "${auth_headers[@]}" \

--- a/docs/runbooks/staging-sizing.md
+++ b/docs/runbooks/staging-sizing.md
@@ -1,0 +1,267 @@
+# Runbook — staging capacity and sizing
+
+Staging is the only environment that ever sees the release gate's full load.
+`pnpm test -- --target-full` drives 441 REST flows and 21 Playwright journeys
+against `staging-api.kortix.com` / `staging.kortix.com`. Nothing else in the
+company generates that traffic, so staging must be sized for it — not for the
+handful of manual checks a release candidate otherwise gets.
+
+This runbook records what staging runs, why, and how to change each piece.
+
+---
+
+## 1. What staging runs today
+
+| Component | Value | Owned by |
+|---|---|---|
+| API task size | 1024 CPU / 2048 MiB | Terraform — `infra/terraform/environments/staging/main.tf` |
+| API count | desired 2, min 2, max 4 | Terraform (min/max), autoscaling (live count) |
+| API capacity | FARGATE_SPOT, **on-demand base 1** | Terraform — `fargate_base_on_demand` |
+| Gateway task size | 512 CPU / 1024 MiB | Terraform |
+| Gateway count | desired 2, min 2, max 3 | Terraform |
+| Gateway capacity | FARGATE_SPOT, **on-demand base 1** | Terraform |
+| Scaling policies | CPU 60%, memory 70%, 600 req/target | `infra/terraform/modules/ecs-api/main.tf` |
+| Database | Supabase project `ujzsbwvurfyeuerxxeaz`, region eu-west-2, compute **Medium** | **Nothing in this repo — see §4** |
+| Region | us-west-2 (ECS), eu-west-2 (Supabase) | — |
+
+### Why these numbers
+
+Before 2026-08-19 staging ran **1 task of 512 CPU / 1024 MiB on Spot with
+`base = 0`**. Three properties made that indefensible:
+
+1. **Staging was smaller than dev.** Dev runs desired/min 2 and carries no load;
+   staging ran 1 and carries all of it.
+2. **The autoscaling ceiling was 3 × 0.5 vCPU = 1.5 vCPU** for the entire API.
+3. **One Spot reclaim was a total outage.** `base = 0` means no task is pinned to
+   on-demand, and `deployment_minimum_healthy_percent = 100`
+   (`modules/ecs-api/main.tf`) blocks the replacement until Spot capacity
+   returns.
+
+During the v0.13.0 release gate the suite's own traffic drove the single task
+unhealthy, ECS replaced it mid-run, and the edge Worker reported the resulting
+5xx as `MAINTENANCE_MODE`. Two `tests-release` attempts were lost. See the
+`learnings` skill entry "`tests-release`'s own load can knock staging over".
+
+### Cost
+
+us-west-2, 730 h/mo, on-demand $0.04048/vCPU-hr + $0.004445/GiB-hr; Spot is
+roughly 70% of on-demand.
+
+| | API | Gateway | Total |
+|---|---|---|---|
+| Before (1 × 0.5 vCPU/1 GiB Spot; 1 × 0.25 vCPU/0.5 GiB Spot) | ~$14/mo | ~$7/mo | **~$21/mo** |
+| After (2 × 1 vCPU/2 GiB, 1 on-demand; 2 × 0.5 vCPU/1 GiB, 1 on-demand) | ~$96/mo | ~$48/mo | **~$144/mo** |
+
+Delta at the `min_capacity` floor: **~+$123/mo**. At full scale-out (API 4,
+gateway 3) it is ~$255/mo. Against a release process that was costing 10+
+engineer-hours per attempt, this is not a decision worth deliberating.
+
+---
+
+## 2. Changing ECS sizing — and the Terraform trap
+
+**The trap:** `modules/ecs-api/main.tf` deliberately carries
+
+```hcl
+# on aws_ecs_task_definition
+lifecycle { ignore_changes = [container_definitions] }
+# on aws_ecs_service
+lifecycle { ignore_changes = [task_definition, desired_count] }
+```
+
+so that CI image rolls do not fight Terraform. The consequence is that
+**changing `task_cpu` / `task_memory` in Terraform is not, by itself, enough.**
+Terraform registers a new task-definition revision with the new size, but the
+service keeps rolling from the lineage `infra/scripts/ecs-deploy.sh` renders,
+and that renderer rebuilds each revision from the service's **current** one.
+
+**The fix (live since 2026-08-19):** `ecs-deploy.sh` takes **only `cpu` and
+`memory`** from the family's latest ACTIVE revision, and everything else from
+the service's current revision.
+
+Terraform and `ecs-deploy.sh` register into the *same* family, and every
+`register-task-definition` appends. So the family's latest revision is either
+Terraform's (right after an apply that changed the size) or `ecs-deploy.sh`'s own
+previous one (which already carries Terraform's size). The override therefore
+propagates a resize on the very next deploy and is a no-op otherwise. It
+soft-fails: if the family cannot be read, the running size is preserved and the
+deploy proceeds as before.
+
+This works because `deploy-staging.yml`'s `deploy-ecs` job `needs:` the
+`terraform-staging` job — Terraform always applies before the ECS roll.
+
+### To change task size or counts
+
+1. Edit `infra/terraform/environments/staging/main.tf` (`module "api"` /
+   `module "gateway"`).
+2. Open a PR to `main`. `terraform-ci.yml` runs `fmt`, `validate`, `tflint` and
+   `checkov`.
+3. Merge to `main`, then promote `main` → `staging`. **The staging Terraform
+   apply only runs on a push to `staging`** (`deploy-staging.yml` triggers on the
+   `Build Staging Artifacts` workflow for branch `staging`). A merge to `main`
+   changes nothing on staging.
+4. Watch the `Apply staging Terraform` job, then `Deploy API + gateway to
+   staging (ECS Fargate)`.
+5. Verify the live task size — do **not** trust the apply alone:
+
+```sh
+aws ecs describe-services --region us-west-2 \
+  --cluster kortix-staging --services kortix-staging \
+  --query 'services[0].taskDefinition' --output text
+# then
+aws ecs describe-task-definition --region us-west-2 \
+  --task-definition <that arn> --query 'taskDefinition.{cpu:cpu,memory:memory}'
+```
+
+`min_capacity` / `max_capacity` are different: they live on
+`aws_appautoscaling_target`, which has no `ignore_changes`, so a Terraform apply
+changes them directly. Raising `min_capacity` raises the running count on its
+own.
+
+### Fargate Spot and the on-demand base
+
+`use_fargate_spot = true` alone means `base = 0` — every task is interruptible
+and the service can reach zero. `fargate_base_on_demand = N` pins N tasks to
+on-demand `FARGATE` while the rest stay Spot. The module defaults it to `0`, so
+dev and prod behavior is unchanged; only environments that opt in move.
+
+`fargate_base_on_demand` must be `<= min_capacity`. That is enforced as a
+precondition on `aws_appautoscaling_target`, so a bad value fails the plan.
+
+---
+
+## 3. Emergency lever — `ecs-scale.yml`
+
+`.github/workflows/ecs-scale.yml` (`workflow_dispatch`) sets `desired_count` on a
+live service without Terraform. This is the intended ops mechanism, precisely
+because the service ignores `desired_count`.
+
+```
+cluster:       kortix-staging          (or kortix-staging-gateway)
+service:       kortix-staging          (or kortix-staging-gateway)
+desired_count: <n>
+region:        us-west-2
+```
+
+**Use it when:** staging is degrading during a run you cannot afford to lose, or
+you need temporary headroom for a one-off load test.
+
+**Do not use it as a fix.** It is not durable in either direction:
+
+- Autoscaling will pull the count back inside `[min_capacity, max_capacity]`.
+  Scaling *below* `min_capacity` is undone within minutes.
+- Nothing records why the count changed. On 2026-08-18 staging was hand-scaled
+  to API 3 / gateway 2 during the v0.13.0 incident; that change existed nowhere
+  in code, which is what this runbook and the Terraform change now correct.
+
+If you find yourself reaching for it twice for the same reason, raise
+`min_capacity` in Terraform instead.
+
+---
+
+## 4. The database is NOT in Terraform
+
+The staging database is a **hosted Supabase project**, injected into CI as
+`STAGING_DATABASE_URL` (`.github/workflows/tests-release.yml`). A repo-wide grep
+for `aws_db_instance` / `aws_rds_cluster` / `aws_elasticache_*` returns **zero
+hits**. There is no Terraform knob, no state entry, and no plan that will ever
+show it.
+
+| | |
+|---|---|
+| Project ref | `ujzsbwvurfyeuerxxeaz` |
+| Region | eu-west-2 |
+| Compute add-on | **`ci_medium`** — resized from `ci_micro` on 2026-08-18 |
+| Decision | **Keep at Medium permanently.** |
+
+**Why Medium.** `kortix.audit_events` carries 14 indexes and takes a write on
+every API request. Under the release gate's concurrency the `ci_micro` instance
+was the binding constraint. Roughly $10/mo → $60/mo (Supabase list pricing,
+external to this repo, verify before budgeting) against a gate that was costing
+10+ engineer-hours per attempt.
+
+**This also means the tier survives every `terraform apply`** — and that nothing
+will restore it if someone changes it in the Supabase dashboard. This runbook is
+the only record. Update it if the tier changes.
+
+### Reading and changing the tier (Supabase Management API)
+
+Requires a Supabase personal access token with access to the Kortix org.
+
+```sh
+# read the current compute add-on
+curl -sS -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  https://api.supabase.com/v1/projects/ujzsbwvurfyeuerxxeaz/billing/addons | jq .
+
+# change it (variants: ci_micro, ci_small, ci_medium, ci_large, ci_xlarge, …)
+curl -sS -X POST \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  https://api.supabase.com/v1/projects/ujzsbwvurfyeuerxxeaz/billing/addons \
+  -d '{"addon_type":"compute_instance","addon_variant":"ci_medium"}'
+```
+
+A compute change restarts the database. Do not run it during a release gate.
+Confirm the applied variant with the `GET` above before declaring it done —
+verify the endpoint shape against current Supabase Management API docs if the
+call 404s, since that API is outside this repo's control.
+
+---
+
+## 5. Do not cancel a running release gate without sweeping its debris
+
+`tests-release.yml` tears down its world in a `finally` block
+(`tests/src/core/runner.ts`, `tests/src/fixtures/world.ts`). A cancelled GitHub
+job is SIGKILLed and never reaches it. Every cancel therefore leaks that run's
+entire world: accounts, PATs, projects, and live sandboxes. Nine cancels
+compounded into 73 running sessions and 186 live PATs, whose background traffic
+then loaded the same staging origin the next attempt had to run against.
+
+**The rule: a cancel is not free.** If you cancel a `tests-release` run, sweep
+its debris in the same sitting:
+
+```sh
+bun tests/bin/ke2e.ts gc --older-than 2h
+```
+
+`tests-release.yml` now sweeps automatically (added in #6545): a pre-run
+`ke2e gc --older-than 2h` (`:65`) clears prior debris before load starts, and
+each shard runs `ke2e gc --run-id "$KE2E_RUN_ID"` under `if: always()` (`:131-133`)
+so a failed or passed shard reclaims exactly its own accounts. The manual
+command above is the fallback for a job killed outside those hooks — a SIGKILLed
+runner never reaches `always()` either.
+
+Two known gaps in the sweep, both still open at the time of writing:
+
+- GC filters on `%@ke2e.kortix.test`; the Playwright specs mint accounts under
+  `@example.test` and are not reclaimed.
+- Stripe test-mode customers and subscriptions leak on every run.
+
+---
+
+## 6. `MAINTENANCE_MODE` from staging is usually not maintenance
+
+`infra/cloudflare/workers/api-router/worker.mjs` replaces any origin fetch
+failure, or any origin 502/503/504, with a synthetic `MAINTENANCE_MODE` 503. A
+real capacity problem reads as a scheduled maintenance window.
+
+Since 2026-08-19 the Worker attaches `X-Origin-Status` to that synthetic
+response (the true origin status, or `fetch-error` when the fetch threw) and
+restores the origin's `x-request-id` when it sent one. **Read `X-Origin-Status`
+first** — it separates "the origin returned 503" from "the origin was
+unreachable".
+
+A trusted CI run can also opt out of the laundering entirely by sending
+`X-Kortix-CI-Passthrough: <secret>`, matched against the Worker's
+`CI_PASSTHROUGH_SECRET` binding (deployed from the `CF_WORKER_CI_PASSTHROUGH_SECRET`
+repository secret). With a valid marker the true origin status and body pass
+through unmodified. Public behavior is unchanged.
+
+---
+
+## Related
+
+- `.claude/skills/learnings/SKILL.md` — "`tests-release`'s own load can knock
+  staging over, then the edge worker hides it as 'maintenance'".
+- `docs/runbooks/enable-sandbox-provider.md`, `docs/runbooks/self-hosting.md`.
+- `infra/terraform/modules/ecs-api/` — the shared module for every ECS service.

--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -38,6 +38,34 @@ const AUTOMATIC_MAINTENANCE = {
     'Kortix is temporarily unavailable. Service will resume automatically.',
 };
 
+// Header a trusted CI run presents to opt OUT of maintenance laundering and see
+// the real origin response instead. Compared against the CI_PASSTHROUGH_SECRET
+// binding; absent or wrong, the request is treated as ordinary public traffic.
+const CI_PASSTHROUGH_HEADER = 'X-Kortix-CI-Passthrough';
+
+// Constant-time over the compared bytes. The length is not secret (a mismatched
+// length returns false immediately), the contents are.
+function timingSafeEqualStrings(a, b) {
+  const encoder = new TextEncoder();
+  const left = encoder.encode(a);
+  const right = encoder.encode(b);
+  if (left.length !== right.length) return false;
+  let diff = 0;
+  for (let i = 0; i < left.length; i += 1) diff |= left[i] ^ right[i];
+  return diff === 0;
+}
+
+// True only when the request carries the exact shared secret. An unset or empty
+// binding disables passthrough entirely, so an environment that never sets the
+// secret cannot be tricked into revealing origin failures.
+function isTrustedCiPassthrough(request, env) {
+  const secret = env?.CI_PASSTHROUGH_SECRET;
+  if (typeof secret !== 'string' || secret.length === 0) return false;
+  const presented = request.headers.get(CI_PASSTHROUGH_HEADER);
+  if (typeof presented !== 'string' || presented.length === 0) return false;
+  return timingSafeEqualStrings(presented, secret);
+}
+
 function addSecurityHeaders(response) {
   response.headers.set('Strict-Transport-Security', STRICT_TRANSPORT_SECURITY);
   response.headers.set('X-Content-Type-Options', 'nosniff');
@@ -93,7 +121,13 @@ async function readMaintenanceConfig(env) {
   }
 }
 
-function maintenanceResponse(config, active, isGateway, request) {
+// `originFailure` is set only on the AUTOMATIC path, where a real origin failure
+// is being replaced by a synthetic 503. It carries what the origin actually did:
+//   status    — the origin HTTP status, or 'fetch-error' when the fetch threw.
+//   requestId — the origin's x-request-id, when it sent one.
+// Both are surfaced on the response so a failure is diagnosable without
+// changing the body every public client already handles.
+function maintenanceResponse(config, active, isGateway, request, originFailure) {
   const origin = request.headers.get('Origin');
   const headers = new Headers({
     'Cache-Control': 'no-store',
@@ -103,6 +137,16 @@ function maintenanceResponse(config, active, isGateway, request) {
     'X-Backend-Service': isGateway ? 'gateway' : 'api',
     'X-Maintenance-Mode': 'blocking',
   });
+  if (originFailure) {
+    headers.set('X-Origin-Status', String(originFailure.status));
+    // Restoring the origin's x-request-id is what makes an app-generated 5xx
+    // distinguishable from an edge/infrastructure one. Laundering used to erase
+    // it, so a genuine application 503 was indistinguishable from an
+    // unreachable origin.
+    if (originFailure.requestId) {
+      headers.set('X-Request-Id', originFailure.requestId);
+    }
+  }
   if (origin) {
     headers.set('Access-Control-Allow-Credentials', 'true');
     headers.set('Access-Control-Allow-Origin', origin);
@@ -252,11 +296,14 @@ export default {
     try {
       response = await fetch(modifiedRequest);
     } catch {
+      // No origin response exists, so there is nothing to pass through even for
+      // CI. Say so explicitly instead of leaving the cause unnamed.
       return maintenanceResponse(
         { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() },
         active,
         isGateway,
         request,
+        { status: 'fetch-error' },
       );
     }
     if (
@@ -264,11 +311,29 @@ export default {
       response.status === 503 ||
       response.status === 504
     ) {
+      // A trusted CI run needs the real failure, not a maintenance page: the
+      // v0.13.0 release gate spent hours reading laundered 503s as a scheduled
+      // maintenance window while staging was simply out of capacity. Public
+      // traffic still gets the identical synthetic 503 it always got.
+      if (isTrustedCiPassthrough(request, env)) {
+        const passthrough = new Response(response.body, response);
+        passthrough.headers.set('X-Backend', active);
+        passthrough.headers.set(
+          'X-Backend-Service',
+          isGateway ? 'gateway' : 'api',
+        );
+        passthrough.headers.set('X-Origin-Status', String(response.status));
+        return addSecurityHeaders(passthrough);
+      }
       return maintenanceResponse(
         { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() },
         active,
         isGateway,
         request,
+        {
+          status: response.status,
+          requestId: response.headers.get('x-request-id'),
+        },
       );
     }
     // Cloudflare attaches the accepted socket to response.webSocket. Creating

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -80,9 +80,11 @@ describe('api-router worker', () => {
       'utf8',
     );
 
-    expect(ecsDeploy).toContain(
-      'select(.name != "KORTIX_VERSION" and .name != "KORTIX_COMMIT")',
-    );
+    // The select grew two more names (KORTIX_PUBLIC_VERSION,
+    // NEXT_PUBLIC_KORTIX_VERSION) and now spans several lines, so pinning its
+    // exact formatting went stale. Assert the two invariants instead.
+    expect(ecsDeploy).toContain('.name != "KORTIX_VERSION"');
+    expect(ecsDeploy).toContain('.name != "KORTIX_COMMIT"');
     expect(shadowWorkflow).toContain(
       'api_commit="$(jq -r \'.commit // empty\'',
     );
@@ -133,7 +135,9 @@ describe('api-router worker', () => {
     );
 
     expect(ecsDeploy).toContain('refusing live $ENV rollout without --database-migrated');
-    expect(prodWorkflow.match(/--database-migrated/g)?.length).toBe(2);
+    // Three live prod rolls now carry the gate: api, gateway, and the web
+    // service added at deploy-prod.yml:1238.
+    expect(prodWorkflow.match(/--database-migrated/g)?.length).toBe(3);
     expect(shadowWorkflow.match(/--database-migrated/g)?.length).toBe(2);
   });
 
@@ -152,6 +156,70 @@ describe('api-router worker', () => {
     expect(prodTerraform).toMatch(/module "api"[\s\S]*?min_capacity\s*=\s*3/);
     expect(shadowTerraform).toMatch(/module "api"[\s\S]*?task_memory\s*=\s*4096/);
     expect(shadowTerraform).toMatch(/module "api"[\s\S]*?secrets_blob_arn\s*=\s*var\.secret_arn/);
+  });
+
+  test('keeps staging sized for the release gate, with an on-demand floor', () => {
+    const stagingTerraform = readFileSync(
+      new URL('../../../terraform/environments/staging/main.tf', import.meta.url),
+      'utf8',
+    );
+    const devTerraform = readFileSync(
+      new URL('../../../terraform/environments/dev/main.tf', import.meta.url),
+      'utf8',
+    );
+
+    const stagingApi = stagingTerraform.match(
+      /module "api"[\s\S]*?\n}\n/,
+    )?.[0];
+    const devApi = devTerraform.match(/module "api"[\s\S]*?\n}\n/)?.[0];
+    expect(stagingApi).toBeDefined();
+    expect(devApi).toBeDefined();
+
+    // Staging absorbs the full release gate; dev absorbs nothing. Staging being
+    // SMALLER than dev is what let the v0.13.0 gate knock it over.
+    const num = (source, key) =>
+      Number(source.match(new RegExp(`${key}\\s*=\\s*(\\d+)`))?.[1]);
+    expect(num(stagingApi, 'task_cpu')).toBeGreaterThanOrEqual(
+      num(devApi, 'task_cpu'),
+    );
+    expect(num(stagingApi, 'task_memory')).toBeGreaterThanOrEqual(
+      num(devApi, 'task_memory'),
+    );
+    expect(num(stagingApi, 'min_capacity')).toBeGreaterThanOrEqual(
+      num(devApi, 'min_capacity'),
+    );
+
+    // A Spot-only service with no on-demand base goes to zero tasks on one
+    // reclaim, and the edge then reports that as MAINTENANCE_MODE.
+    expect(stagingApi).toMatch(/fargate_base_on_demand\s*=\s*1/);
+    expect(stagingTerraform).toMatch(
+      /module "gateway"[\s\S]*?fargate_base_on_demand\s*=\s*1/,
+    );
+    // Without this the module never creates the request-count scaling policy.
+    expect(stagingTerraform).toMatch(
+      /module "gateway"[\s\S]*?requests_per_target_target\s*=\s*600/,
+    );
+  });
+
+  test('the on-demand base is opt-in, so dev and prod strategies do not move', () => {
+    const module = readFileSync(
+      new URL('../../../terraform/modules/ecs-api/variables.tf', import.meta.url),
+      'utf8',
+    );
+    const devTerraform = readFileSync(
+      new URL('../../../terraform/environments/dev/main.tf', import.meta.url),
+      'utf8',
+    );
+    const prodTerraform = readFileSync(
+      new URL('../../../terraform/environments/prod/main.tf', import.meta.url),
+      'utf8',
+    );
+
+    expect(module).toMatch(
+      /variable "fargate_base_on_demand"[\s\S]*?default\s*=\s*0/,
+    );
+    expect(devTerraform).not.toContain('fargate_base_on_demand');
+    expect(prodTerraform).not.toContain('fargate_base_on_demand');
   });
 
   test('runs privileged US workflows only from the protected prod branch', () => {
@@ -540,6 +608,154 @@ describe('api-router worker', () => {
       error: 'MAINTENANCE_MODE',
       maintenance: { level: 'blocking' },
     });
+  });
+
+  // ── CI origin-status passthrough ───────────────────────────────────────────
+  // The laundering above is correct for public traffic and actively harmful for
+  // the release gate: it turns "staging ran out of capacity" into "scheduled
+  // maintenance". These pin the additive escape hatch — the public shape must
+  // not move, and the passthrough must be reachable ONLY with the exact secret.
+  const CI_SECRET = 'ci-passthrough-secret-value';
+  const ciEnv = { ...env, CI_PASSTHROUGH_SECRET: CI_SECRET };
+
+  function originFails(status, headers = {}) {
+    globalThis.fetch = async () =>
+      new Response('origin body', { status, headers });
+  }
+
+  test('without the CI header, an origin 503 is still laundered but names the origin status', async () => {
+    originFails(503, { 'x-request-id': 'req-abc123' });
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/accounts'),
+      ciEnv,
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ error: 'MAINTENANCE_MODE' });
+    expect(response.headers.get('X-Maintenance-Mode')).toBe('blocking');
+    expect(response.headers.get('X-Origin-Status')).toBe('503');
+    // The origin's own request id is restored, so an application 5xx is
+    // distinguishable from an unreachable origin.
+    expect(response.headers.get('X-Request-Id')).toBe('req-abc123');
+  });
+
+  test('with the correct CI header, the true origin status and body pass through', async () => {
+    originFails(502, { 'x-request-id': 'req-xyz789' });
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/accounts', {
+        headers: { 'X-Kortix-CI-Passthrough': CI_SECRET },
+      }),
+      ciEnv,
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe('origin body');
+    expect(response.headers.get('X-Origin-Status')).toBe('502');
+    expect(response.headers.get('x-request-id')).toBe('req-xyz789');
+    // No maintenance fiction is layered on top of a real failure.
+    expect(response.headers.get('X-Maintenance-Mode')).toBeNull();
+    expect(response.headers.get('X-Backend')).toBe('ecs-fargate');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  test('a wrong CI header gets the ordinary synthetic maintenance 503', async () => {
+    originFails(504);
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/accounts', {
+        headers: { 'X-Kortix-CI-Passthrough': 'not-the-secret-value-at-all' },
+      }),
+      ciEnv,
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ error: 'MAINTENANCE_MODE' });
+    expect(response.headers.get('X-Origin-Status')).toBe('504');
+  });
+
+  test('a prefix of the secret does not pass, and neither does an empty header', async () => {
+    for (const presented of [CI_SECRET.slice(0, -1), `${CI_SECRET}x`, '']) {
+      originFails(503);
+      const response = await worker.fetch(
+        new Request('https://api.kortix.com/v1/accounts', {
+          headers: { 'X-Kortix-CI-Passthrough': presented },
+        }),
+        ciEnv,
+      );
+      expect(response.status).toBe(503);
+      expect(await response.json()).toMatchObject({
+        error: 'MAINTENANCE_MODE',
+      });
+    }
+  });
+
+  test('an environment with no CI_PASSTHROUGH_SECRET binding cannot be opted out of laundering', async () => {
+    originFails(503);
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/accounts', {
+        headers: { 'X-Kortix-CI-Passthrough': CI_SECRET },
+      }),
+      // `env` deliberately has no CI_PASSTHROUGH_SECRET.
+      env,
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ error: 'MAINTENANCE_MODE' });
+  });
+
+  test('an unreachable origin reports fetch-error and stays retryable for the test client', async () => {
+    globalThis.fetch = async () => {
+      throw new Error('connection refused');
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/accounts', {
+        headers: { 'X-Kortix-CI-Passthrough': CI_SECRET },
+      }),
+      ciEnv,
+    );
+
+    // There is no origin response to pass through, so CI gets the synthetic
+    // 503 too — but it now says why.
+    expect(response.status).toBe(503);
+    expect(response.headers.get('X-Origin-Status')).toBe('fetch-error');
+    // tests/src/core/client.ts isKe2eTransientGatewayResponse classifies a
+    // 502/503/504 as transient only when x-request-id is ABSENT and retry-after
+    // is present. An unreachable origin must keep matching that.
+    expect(response.headers.get('x-request-id')).toBeNull();
+    expect(response.headers.get('Retry-After')).toBe('30');
+  });
+
+  test('a healthy origin response carries no origin-status header', async () => {
+    globalThis.fetch = async () => Response.json({ ok: true }, { status: 200 });
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/accounts'),
+      ciEnv,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Origin-Status')).toBeNull();
+  });
+
+  test('the staging Worker deploy binds CI_PASSTHROUGH_SECRET from the repository secret', () => {
+    const deployWorkflow = readFileSync(
+      new URL(
+        '../../../../.github/workflows/deploy-staging.yml',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+
+    expect(deployWorkflow).toContain(
+      'CF_WORKER_CI_PASSTHROUGH_SECRET: ${{ secrets.CF_WORKER_CI_PASSTHROUGH_SECRET }}',
+    );
+    expect(deployWorkflow).toContain(
+      '[{type:"secret_text", name:"CI_PASSTHROUGH_SECRET", text:$secret}]',
+    );
   });
 
   test('gateway HTTPS redirect keeps the gateway hostname', async () => {

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -173,14 +173,67 @@ CURRENT_TD="$(aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" 
   --services "$SERVICE" --query 'services[0].taskDefinition' --output text)"
 [ -n "$CURRENT_TD" ] && [ "$CURRENT_TD" != "None" ] || { echo "service $SERVICE has no task-def" >&2; exit 1; }
 
-NEW_TD_JSON="$(aws ecs describe-task-definition --region "$REGION" \
-  --task-definition "$CURRENT_TD" --query 'taskDefinition' --output json \
+CURRENT_TD_JSON="$(aws ecs describe-task-definition --region "$REGION" \
+  --task-definition "$CURRENT_TD" --query 'taskDefinition' --output json)"
+
+# ── task size (cpu/memory) is owned by Terraform, not by the running task ────
+# Terraform owns task_cpu/task_memory (infra/terraform/modules/ecs-api), but the
+# service carries `ignore_changes = [task_definition]`, so a TF apply that
+# resizes the task registers a revision the service never adopts. This renderer
+# rebuilds from the service's CURRENT revision — which is how image, env and any
+# out-of-band container change survive a deploy — so without the override below
+# a Terraform resize could never reach a running task.
+#
+# Terraform and this script register into the SAME family, and every
+# register-task-definition call appends. The family's LATEST ACTIVE revision is
+# therefore either (a) Terraform's, immediately after an apply that changed the
+# size, or (b) this script's own previous revision, which already carries
+# Terraform's size. Taking ONLY cpu/memory from family-latest, and everything
+# else from the service's current revision, propagates a Terraform resize on the
+# very next deploy and is a no-op on every other deploy. The ordering holds
+# because deploy-{dev,staging,prod}.yml run their terraform-* job before the ECS
+# roll.
+#
+# Soft-fail by design: if the family cannot be read, the current size is kept and
+# the deploy proceeds exactly as it did before this override existed.
+FAMILY="$(printf '%s' "$CURRENT_TD_JSON" | jq -r '.family // empty')"
+CURRENT_CPU="$(printf '%s' "$CURRENT_TD_JSON" | jq -r '.cpu // empty')"
+CURRENT_MEMORY="$(printf '%s' "$CURRENT_TD_JSON" | jq -r '.memory // empty')"
+DESIRED_CPU="$CURRENT_CPU"
+DESIRED_MEMORY="$CURRENT_MEMORY"
+
+if [ -n "$FAMILY" ]; then
+  LATEST_TD_JSON="$(aws ecs describe-task-definition --region "$REGION" \
+    --task-definition "$FAMILY" --query 'taskDefinition' --output json 2>/dev/null || true)"
+  if [ -n "$LATEST_TD_JSON" ]; then
+    LATEST_CPU="$(printf '%s' "$LATEST_TD_JSON" | jq -r '.cpu // empty')"
+    LATEST_MEMORY="$(printf '%s' "$LATEST_TD_JSON" | jq -r '.memory // empty')"
+    if [ -n "$LATEST_CPU" ]; then DESIRED_CPU="$LATEST_CPU"; fi
+    if [ -n "$LATEST_MEMORY" ]; then DESIRED_MEMORY="$LATEST_MEMORY"; fi
+  else
+    echo "⚠ could not read family $FAMILY — keeping the running task size ${CURRENT_CPU}/${CURRENT_MEMORY}"
+  fi
+fi
+
+if [ "$DESIRED_CPU" != "$CURRENT_CPU" ] || [ "$DESIRED_MEMORY" != "$CURRENT_MEMORY" ]; then
+  echo "▶ task size ${CURRENT_CPU} cpu / ${CURRENT_MEMORY} MiB → ${DESIRED_CPU} cpu / ${DESIRED_MEMORY} MiB (from the latest $FAMILY revision — Terraform)"
+else
+  echo "▶ task size ${DESIRED_CPU} cpu / ${DESIRED_MEMORY} MiB (unchanged)"
+fi
+
+NEW_TD_JSON="$(printf '%s' "$CURRENT_TD_JSON" \
   | jq --arg img "$IMAGE" --arg c "$CONTAINER" --arg ver "$VERSION_OVERRIDE" \
        --arg version_env "$VERSION_ENV_NAME" \
+       --arg cpu "$DESIRED_CPU" --arg memory "$DESIRED_MEMORY" \
        --argjson secrets "$SECRETS_JSON" '
       # drop read-only fields register-task-definition rejects
       del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
           .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)
+      # Adopt the Terraform task size resolved above. Empty means not readable
+      # — keep whatever the running revision declares. NOTE: this jq program is
+      # a single-quoted shell string; an apostrophe here terminates it.
+      | (if $cpu == "" then . else .cpu = $cpu end)
+      | (if $memory == "" then . else .memory = $memory end)
       # Override image + full secrets on the target container. Stamp
       # KORTIX_VERSION as explicit container env so ECS reports the same clean
       # version EKS reports. Always remove KORTIX_COMMIT from the task
@@ -206,6 +259,7 @@ NEW_TD_JSON="$(aws ecs describe-task-definition --region "$REGION" \
 
 if [ "$DRY_RUN" = "1" ]; then
   echo "── dry-run: rendered task-def override for container '$CONTAINER' ──"
+  echo "$NEW_TD_JSON" | jq '{family, cpu, memory}'
   echo "$NEW_TD_JSON" | jq --arg c "$CONTAINER" \
     '.containerDefinitions[] | select(.name == $c) | {image, environment, secretKeys: (.secrets | length)}'
   echo "✅ dry-run only — nothing registered, nothing rolled."

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -94,13 +94,26 @@ module "api" {
 
   alb_ingress_cidrs = local.cloudflare_ip_ranges
 
-  # staging sizing: small + spot, floor of 1 (release-candidate lane)
-  task_cpu                   = 512
-  task_memory                = 1024
-  desired_count              = 1
-  min_capacity               = 1
-  max_capacity               = 3
+  # staging sizing — see docs/runbooks/staging-sizing.md.
+  #
+  # Staging must absorb the release gate's FULL concurrent load: `pnpm test --
+  # --target-full` drives 441 REST flows plus 21 Playwright journeys against
+  # this origin, and it is the only environment that ever sees that traffic.
+  # Until 2026-08-19 it ran 1 task of 0.5 vCPU / 1 GiB — SMALLER than dev
+  # (2 tasks), which carries no load at all. The v0.13.0 release gate's own
+  # traffic drove the single task unhealthy, ECS replaced it mid-run, and the
+  # api-router Worker laundered every resulting 5xx into MAINTENANCE_MODE.
+  #
+  # 2 tasks of 1 vCPU / 2 GiB, floor 2, ceiling 4. fargate_base_on_demand = 1
+  # pins the first task to on-demand FARGATE: the rest stay Spot for cost, but
+  # a Spot reclaim can no longer take the whole environment to zero.
+  task_cpu                   = 1024
+  task_memory                = 2048
+  desired_count              = 2
+  min_capacity               = 2
+  max_capacity               = 4
   use_fargate_spot           = true
+  fargate_base_on_demand     = 1
   requests_per_target_target = 600
   tags                       = local.tags
 }
@@ -126,13 +139,20 @@ module "gateway" {
 
   alb_ingress_cidrs = local.cloudflare_ip_ranges
 
-  task_cpu         = 256
-  task_memory      = 512
-  desired_count    = 1
-  min_capacity     = 1
-  max_capacity     = 3
-  use_fargate_spot = true
-  tags             = local.tags
+  # The gateway proxies every LLM call the release gate's sessions make, so it
+  # sees the same burst as the API. requests_per_target_target creates the
+  # ALBRequestCountPerTarget policy, which the module skips while the value is
+  # 0 (its default) — the gateway had CPU/memory tracking only, and an
+  # I/O-bound gateway blocked on upstream models never moves either metric.
+  task_cpu                   = 512
+  task_memory                = 1024
+  desired_count              = 2
+  min_capacity               = 2
+  max_capacity               = 3
+  use_fargate_spot           = true
+  fargate_base_on_demand     = 1
+  requests_per_target_target = 600
+  tags                       = local.tags
 }
 
 # ── DNS (optional; default off — records created out-of-band) ─────────────────

--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -21,6 +21,39 @@ locals {
   name = var.name
   # PORT is always injected so the app binds the port the target group checks.
   environment = merge(var.environment, { PORT = tostring(var.container_port) })
+
+  # Capacity-provider strategy for the service.
+  #
+  #   use_fargate_spot = false          -> one FARGATE block (weight 1, base 1).
+  #   use_fargate_spot = true, base = 0 -> one FARGATE_SPOT block (weight 1,
+  #                                        base 0). Identical to the pre-2026-08-19
+  #                                        single-block form, so dev/prod do not
+  #                                        move.
+  #   use_fargate_spot = true, base > 0 -> `base` tasks pinned to on-demand
+  #                                        FARGATE, every task above that on
+  #                                        FARGATE_SPOT.
+  #
+  # ECS satisfies `base` first, then splits the remainder by `weight`. The
+  # on-demand block therefore carries weight 0: it must hold exactly the base,
+  # never absorb scale-out. A Spot-only service with base 0 has no floor — one
+  # Spot reclaim empties it, and with deployment_minimum_healthy_percent = 100
+  # ECS cannot place a replacement until Spot capacity returns.
+  capacity_provider_strategy = var.use_fargate_spot ? concat(
+    var.fargate_base_on_demand > 0 ? [{
+      capacity_provider = "FARGATE"
+      weight            = 0
+      base              = var.fargate_base_on_demand
+    }] : [],
+    [{
+      capacity_provider = "FARGATE_SPOT"
+      weight            = 1
+      base              = 0
+    }]
+    ) : [{
+      capacity_provider = "FARGATE"
+      weight            = 1
+      base              = 1
+  }]
 }
 
 data "aws_caller_identity" "current" {}
@@ -500,10 +533,13 @@ resource "aws_ecs_service" "this" {
   desired_count   = var.desired_count
   launch_type     = null # capacity-provider strategy drives placement
 
-  capacity_provider_strategy {
-    capacity_provider = var.use_fargate_spot ? "FARGATE_SPOT" : "FARGATE"
-    weight            = 1
-    base              = var.use_fargate_spot ? 0 : 1
+  dynamic "capacity_provider_strategy" {
+    for_each = local.capacity_provider_strategy
+    content {
+      capacity_provider = capacity_provider_strategy.value.capacity_provider
+      weight            = capacity_provider_strategy.value.weight
+      base              = capacity_provider_strategy.value.base
+    }
   }
 
   network_configuration {
@@ -551,6 +587,13 @@ resource "aws_appautoscaling_target" "this" {
   resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.this.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
+
+  lifecycle {
+    precondition {
+      condition     = var.fargate_base_on_demand <= var.min_capacity
+      error_message = "fargate_base_on_demand (${var.fargate_base_on_demand}) exceeds min_capacity (${var.min_capacity}); the autoscaling floor cannot be smaller than the on-demand base."
+    }
+  }
 }
 
 resource "aws_appautoscaling_policy" "cpu" {

--- a/infra/terraform/modules/ecs-api/variables.tf
+++ b/infra/terraform/modules/ecs-api/variables.tf
@@ -139,6 +139,29 @@ variable "use_fargate_spot" {
   default     = false
 }
 
+variable "fargate_base_on_demand" {
+  description = <<-EOT
+    Number of tasks pinned to on-demand FARGATE when use_fargate_spot = true.
+    Ignored when use_fargate_spot = false (that service is already all
+    on-demand). 0 keeps the historic Spot-only strategy, so setting nothing
+    changes nothing. Use >= 1 on any Spot environment whose total unavailability
+    is a real cost: with base 0 a single Spot reclaim drops the service to zero
+    tasks, and deployment_minimum_healthy_percent = 100 blocks the replacement
+    until Spot capacity returns.
+  EOT
+  type        = number
+  default     = 0
+
+  # Must also be <= min_capacity. That is a cross-variable rule, which
+  # `validation` only supports from Terraform 1.9 while this module declares
+  # >= 1.5 — it is enforced as a precondition on aws_appautoscaling_target
+  # instead.
+  validation {
+    condition     = var.fargate_base_on_demand >= 0 && floor(var.fargate_base_on_demand) == var.fargate_base_on_demand
+    error_message = "fargate_base_on_demand must be a non-negative whole number."
+  }
+}
+
 variable "container_insights" {
   description = "Enable CloudWatch Container Insights."
   type        = bool


### PR DESCRIPTION
Implements P2.1, P2.2, P2.3, P3.1, P0.4 and the local-runner half of P1.5 from the release-gate optimization plan.

The gate ran as ONE job on a 2-vCPU `ubuntu-latest` with `timeout-minutes: 90` (`tests-release.yml:29`, `:85`). It is now seven jobs with `fail-fast: false`.

---

## 1. P2.1 / P2.2 / P2.3 — shard the gate into parallel jobs

**New:** `tests/src/core/shard.ts`. It computes the API partition from the **live flow registry**, not a hand-maintained list, so a newly added flow always lands in exactly one shard and can never fall out of the gate.

- Shard 1 owns every `serial` and every `global` flow. The 3 `global` flows (ADM-19, BILL-13, CONN-5) mutate platform-wide state that all shards share; two jobs running them at once would corrupt each other.
- The remaining flows are bin-packed longest-processing-time-first on the declared `meta.timeoutMs` (`runner.ts:161` default `120_000`) as a static cost proxy. Deterministic — every job computes an identical partition without coordinating.

Measured against the real registry:

```
$ bun tests/bin/ke2e.ts run --shard {1,2,3,4}/4
shard 1/4:  35 flows · projected load 324m/313m/311m/311m
shard 2/4: 136 flows · projected load 324m/313m/311m/311m
shard 3/4: 135 flows · projected load 324m/313m/311m/311m
shard 4/4: 135 flows · projected load 324m/313m/311m/311m
                     35+136+135+135 = 441

$ bun tests/bin/ke2e.ts catalog
441 flows · 1696 cases · 589 routes · 38 domains
```

Browser: 21 journeys split 7 / 7 / 7.

```
$ npx playwright test --list                 -> Total: 21 tests in 15 files
$ npx playwright test --list --shard=1/3     -> Total: 7 tests in 6 files
$ npx playwright test --list --shard=2/3     -> Total: 7 tests in 5 files
$ npx playwright test --list --shard=3/3     -> Total: 7 tests in 5 files
```

**Runner surface** (`local-runner.ts`): new `--target-api-full` and `--target-browser-full` modes so each deployed lane can be its own GitHub job, each accepting `--api-shard=i/N` / `--browser-shard=i/N`. `--target-full` is unchanged and still runs both lanes in one process. `--shard` refuses to combine with `--id/--domain/--tag/--grep/--smoke`, which would intersect two partitions and could silently select nothing:

```
$ bun tests/bin/ke2e.ts run --shard 2/4 --domain iam
Error: --shard cannot be combined with --domain
$ bun tests/bin/ke2e.ts run --shard 5/4
Error: --shard must satisfy 1 <= CURRENT <= TOTAL, received "5/4"
```

**Playwright deployed budget** (`playwright.config.ts:42,47`): `retries` 3 → 1, `timeout` 300_000 → 120_000. One bad journey could eat 20 minutes of a worker (5 min × 4 attempts), which explains the 40–58 min browser lane by itself. Specs that legitimately need longer already declare their own `test.setTimeout` (10-billing 300s, 13-sdk-only 12m, 01-account-auth 180s), which overrides the config. Local and non-deployed CI keep 300s / 2 retries. Both values are env-overridable.

**P1.5 (local-runner half):** `KE2E_API_WORKERS` default 3 → 6. `provision.ts:10`'s global semaphore, not the worker count, is the real ceiling — this is the paired half of raising `KE2E_PROVISION_CONCURRENCY` to 4. Still env-overridable.

### The required check name is preserved

`prod` branch protection requires exactly one context:

```
$ gh api repos/kortix-ai/suna/branches/prod/protection --jq '.required_status_checks.contexts'
["full suite + quality gates"]
```

A final aggregator job (`needs: [api, browser]`, `if: always()`) carries that exact name and fails if any shard failed, so **no protection rule needs editing**. Verified byte-identical:

```
$ python3 -c "...yaml.safe_load...; print(name.encode()==req.encode(), repr(name.encode()))"
byte-identical: True b'full suite + quality gates'
```

Shared env moved to workflow level — Actions has no YAML anchors, and this is the only way to keep one copy of the `KE2E_*` / `E2E_*` / `VERCEL_AUTOMATION_BYPASS_SECRET` wiring across the matrix. The `RELEASE_SOURCE_SHA` → `KE2E_EXPECT_SHA` step, the secret guard and the artifact upload all stay `if: always()` in every test job.

---

## 2. P3.1 — cleanup on cancel (all four sub-fixes)

`runner.ts:352-354` / `world.ts:319` only tear down in a `finally`, which a SIGKILLed GitHub job never reaches, so every cancel leaked its whole world. `gc.ts:81` already existed and **no workflow called it**.

1. **`--run-id` filter.** `ke2e gc --run-id <id>` reclaims one run's principals at any age using the `e2e-<runId>-` prefix `principals.ts:36` already mints, so a post-run sweep cannot touch a concurrent run. `--older-than` keeps working; both may be combined (union). `KE2E_RUN_ID` now pins the id so a caller can sweep exactly what it created.
2. **Workflow steps.** `sweep-before` runs `gc --older-than 2h` before the shards — the age window cannot match an account this run just created, so a concurrent gate is safe. Each API shard runs `gc --run-id "$KE2E_RUN_ID"` with `if: always()`, and `sweep-after` (`needs: [api, browser]`, `if: always()`) repeats it run-wide as a backstop for a shard killed before its own step. Both sweep jobs are `continue-on-error` — **cleanup never blocks a release**.
3. **Signal handlers.** `ke2e run` handles SIGINT/SIGTERM by reclaiming its own run id, the same shape as `daytona-ci.ts:785-788` / `platinum-ci.ts:1037-1040`. Bounded by `KE2E_CANCEL_RECLAIM_MS` (default 20s) so it never blocks exit; deployed runs only, so a developer's Ctrl+C on `ke2e local` stays instant.
4. **Browser-suite domains.** The filter was `%@ke2e.kortix.test` only, so it reclaimed **zero** Playwright accounts. It now also sweeps `@example.test` and `@kortix.test` (`KE2E_GC_EMAIL_DOMAINS` overrides; reserved TLDs only — a non-reserved domain is refused).

### Two bugs found while wiring this up

- **`gc.ts:128` used the wrong route.** It called `/v1/account/delete-immediately`; the route is mounted at `/v1/billing/account/delete-immediately` (`apps/api/src/billing/routes/account-deletion.ts:92` — the path `world.ts:335` teardown already uses). The un-prefixed path 404s, so **no GC sweep has ever reached `stopAccountSandboxes()`**. Fixed.
- **A failed password grant aborted the whole reclaim.** Browser users have per-spec passwords, so `passwordGrant` legitimately fails for them and the Supabase user was then never deleted. The grant is now best-effort; the user delete always runs.

### Gap 1 — what account deletion does and does not reclaim

Traced read-only through `apps/api`. **Verdict: it stops cloud sandboxes, partially.**

`DELETE /v1/billing/account/delete-immediately` → `performDeletion` → `stopAccountSandboxes(accountId)` (`billing/services/account-deletion.ts:161-162`), which calls `getProvider(...).stop(externalId)` (`:142`). So it is not a pure DB operation. But:

- **It only ever `stop`s, never `remove`s.** Daytona `sandbox.stop()`, E2B `pause({keepMemory:false})`, Platinum `POST /stop`. The provider sandbox object and its disk survive. The happy-path teardown (`registry.ts:42-47` → `session-lifecycle/actions.ts:104-114`) calls `provider.remove(...)`, a hard delete. Nothing in the GC path ever does.
- **Only the caller's earliest-joined account.** The handler ignores the body and resolves `resolveAccountId(userId)` (`account-deletion.ts:92-103`, `shared/resolve-account.ts:142-170`), so team/secondary accounts' sandboxes are never stopped even though gc loops over every owned id. `registry.ts:91-95` documents this exact hazard.
- **`status='provisioning'` boxes are excluded** by the `WHERE` at `:132`.
- **No rows are deleted** — `session_sandboxes` has no FK on `account_id`, so the DB-driven reaper (`reaping/box-queries.ts:176-178`) can still find and stop them later. Both reaper paths are `stop`-only (`orphan-boxes.ts:19-20`: "STOP only, never delete").

Net: the sweep reclaims accounts and halts running VMs for the primary account; it does not delete provider sandbox objects, and team-account sandboxes are missed. Fixing that means changing `apps/api`, which is out of scope for this PR — flagging it for the coordinator.

### Gap 2 — Stripe test-mode objects still leak

`tests/src/fixtures/billing.ts` only ever creates; there is no cancel or delete path anywhere under `tests/`. Every run leaks its test-mode customers and subscriptions, cancelled or not. Not fixed here.

### Known limit

Browser-lane accounts carry no run-scoped prefix, so `--run-id` cannot reach them. Their debris is reclaimed by the next run's age sweep — which now actually sees those domains, where before it saw none.

---

## 3. P0.4 — assert browser env up front instead of skipping mid-run

`local-runner.ts:156` sets `E2E_REQUIRE_ALL_BROWSER=1` and `strict-skip-reporter.ts:38-52` fails the lane if any test skipped — but 11 specs `test.skip(...)` at runtime on env availability. One email-provider blip = whole lane red after ~50 min, naming a skipped test rather than the missing capability.

There was no existing `globalSetup`. **New:** `tests/e2e/global-setup.ts`, wired in `playwright.config.ts`. It checks all six runtime-skipped capabilities once and fails with the complete list. It **probes** the email provider live rather than trusting that a key is set, because that is how specs 01 and 08 decide.

```
$ env -u KE2E_DATABASE_URL -u E2E_AGENTMAIL_API_KEY ... E2E_REQUIRE_ALL_BROWSER=1 npx playwright test
Error: The strict deployed browser lane (E2E_REQUIRE_ALL_BROWSER=1) requires every journey to run,
but 6 capability/capabilities are unavailable:
- KE2E_DATABASE_URL: direct database access; 6 specs skip without it
- email provider: inbox delivery; 01 and 08 skip without it (no email provider (set E2E_MAILPIT_URL or a valid E2E_AGENTMAIL_API_KEY))
- E2E_ENABLE_BILLING_JOURNEY=1: 10-billing-journey skips without it
- E2E_ENABLE_SANDBOX_TEMPLATE_BUILD=1: 12-sandbox-templates rebuild case skips without it
- E2E_ENABLE_SDK_ONLY_SESSION=1: 13-sdk-only-session skips without it
- E2E_OAUTH_PROVIDER_INITIATION=1: 17-oauth-provider-initiation skips without it
Fix the environment, or run without E2E_REQUIRE_ALL_BROWSER=1 to allow conditional skips.

0.586 total
```

**0.59 seconds instead of ~50 minutes.**

The per-spec `test.skip` guards are **kept**: they are correct on local and other non-strict runs, and they are now unreachable on the strict lane because the setup fails first. That is what removes the standing contradiction between the reporter and the skips. **No spec file was edited.** The preview OAuth exclusion stays authorized exactly where `strict-skip-reporter.ts` authorizes it.

---

## Verification

```
$ pnpm --dir tests test:unit
 Test Files  27 passed (27)
      Tests  209 passed (209)

$ cd tests && npx tsc --noEmit
(clean, exit 0)

$ actionlint .github/workflows/tests-release.yml
(no output, exit 0)

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tests-release.yml'))"
jobs: ['sweep-before', 'api', 'browser', 'sweep-after', 'release-gate']
gate name: 'full suite + quality gates'

$ bun tests/bin/ke2e.ts coverage
97.9% covered · 572/584 routes · 12 allowlisted · 0 uncovered
✓ coverage gate passed
```

New tests: `unit/shard.test.ts` (15), `unit/gc-sweep.test.ts` (8), `unit/browser-lane-capabilities.test.ts` (9). Updated to the new truth rather than deleted: `unit/sandbox-workflow.test.ts` (now pins the sharded commands, the aggregator name, `fail-fast: false` and both gc steps), `unit/local-runner.test.ts`, `unit/database-project-fixture.test.ts`.

**The partition test is falsifiable.** Positive control — dropping one flow from `planShard`:

```
AssertionError: flows assigned to no shard: expected [ 'GOLD-1' ] to deeply equal []
AssertionError: expected [ 'GOLD-1' ] to deeply equal []   (pinnedOffShardOne)
Tests  6 failed | 9 passed (15)
--- restored ---
Tests  15 passed (15)
```

It runs the partition inside `bun` against the real registry through the real `discoverFlows`, because the flow modules are Bun-only (`import.meta.dir`) and vitest cannot import them — so it exercises the exact code path `ke2e run --shard` takes rather than a re-implementation.

**Not verified:** no run against deployed staging. The gate only triggers on a PR into `prod`, and running it needs a real release candidate plus a `RELEASE_SOURCE_SHA` matching what staging serves. Wall-clock and staging-capacity claims below are projections, not measurements.

---

## The risk to watch

The gate now offers staging **12 API workers + 8 concurrent sandbox boots** (4 shards × 3 and × 2) against 3 + 3 before, plus **6 browsers** against 2. Staging is a single 0.5 vCPU Spot task, and the v0.13.0 gate already collapsed it at 3 + 3 — see the "tests-release's own load can knock staging over" learning, where the edge worker then laundered the origin failure into a generic `MAINTENANCE_MODE` 503.

`KE2E_API_WORKERS` and `KE2E_SANDBOX_WORKERS` are set per-job with that arithmetic written next to them; they are the first thing to lower if those 503s reappear. Staging right-sizing (P3.6) is a real prerequisite for this to pay off, and is not part of this PR.

Shard 1 is the critical path: it carries the strictly sequential 35-flow serial+global tail, whose declared timeouts sum to ~109 min at one attempt each. Its 40-minute cap converts a hang into a readable failure instead of a 90-minute one, but the 12–15 min target is not reachable until P1.1 (stop retrying timeouts), P1.2 (overlap the serial lane) and P1.3 (cap CR-9/GOLD-1) land — those are owned elsewhere.

## Follow-up: `deploy-preview.yml` left alone

Its `--target-full` (`:339`, 100-min cap) is **not** a mechanical copy. The preview runs both lanes inside ONE sandbox against ONE preview origin; sharding it across GitHub matrix jobs would need a separate preview sandbox and origin per shard. It does inherit the Playwright change for free (`preview-stack.ts:228` sets `KE2E_TARGET`, so retries 1 / timeout 120s apply), but its cap is left at 100 because lowering it without a measurement only converts a slow run into a hard failure.


---

## Rebase note (2026-08-19)

Rebased onto `2a3654ed4f` (after #6542, #6543, #6545). One conflict, in
`.claude/skills/learnings/SKILL.md`: `main` had corrected the 2026-08-18 entry's
`*Incident:*` paragraph and appended two new entries, while this branch had
appended a dated addendum to the same entry. Resolved keeping **both** — `main`'s
corrected paragraph verbatim, then this branch's addendum inside that entry, then
`main`'s two new entries. Heading sets before and after are identical (37 = 37),
so no entry was lost, and `main`'s correction was not rewritten (the register is
append-only; the dated addendum supersedes it in place).

All verification re-run after the rebase: worker tests 32/32, tests/unit 256/256,
`terraform fmt -check` clean, `validate` clean on all 5 roots, `bash -n` and
`shellcheck -S warning` clean.
