### PR TITLE
ci(release-gate): shard into parallel api/browser jobs, sweep test debris pre/post-run, assert browser env up front

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -10,47 +10,157 @@ concurrency:
   group: tests-release-${{ github.ref }}
   cancel-in-progress: true
 
+# Shared by every job. Top-level env is the only way to avoid repeating this
+# block per matrix job — GitHub Actions has no YAML anchors.
+env:
+  KE2E_API_URL: ${{ vars.QA_API_BASE_URL || 'https://staging-api.kortix.com/v1' }}
+  E2E_BASE_URL: ${{ vars.QA_WEB_BASE_URL || 'https://staging.kortix.com' }}
+  KE2E_GATEWAY_URL: ${{ vars.QA_GATEWAY_URL || 'https://gateway-staging.kortix.com' }}
+  KE2E_TARGET: staging
+  KE2E_LIVE_CONFIRM: ci
+  KE2E_OWNER_EMAIL: ${{ secrets.KE2E_OWNER_EMAIL }}
+  KE2E_OWNER_PASSWORD: ${{ secrets.KE2E_OWNER_PASSWORD }}
+  KE2E_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+  KE2E_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
+  KE2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+  KE2E_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+  KE2E_INTERNAL_SERVICE_KEY: ${{ secrets.STAGING_INTERNAL_SERVICE_KEY }}
+  KE2E_STRIPE_SECRET_KEY: ${{ secrets.STAGING_STRIPE_SECRET_KEY }}
+  KE2E_STRIPE_WEBHOOK_SECRET: ${{ secrets.STAGING_STRIPE_WEBHOOK_SECRET }}
+  E2E_AGENTMAIL_API_KEY: ${{ secrets.E2E_AGENTMAIL_API_KEY }}
+  KE2E_CAP_MANAGED_GIT_PUSH: ${{ vars.KE2E_CAP_MANAGED_GIT_PUSH || '0' }}
+  WEB_PROTECTION_PASSWORD: ${{ secrets.WEB_PROTECTION_PASSWORD }}
+  # Staging is behind Vercel SSO deployment protection; the browser lane must
+  # send x-vercel-protection-bypass (playwright.config) or every authenticated
+  # page 302s to vercel.com/sso-api. This env was missing when tests-release
+  # replaced the old qa-release gate, so the browser lane could never reach
+  # the app.
+  VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
 jobs:
-  deployed-staging:
-    name: full suite + quality gates
+  # Reclaim debris left by EARLIER runs before this one adds load. `--older-than
+  # 2h` cannot touch an account this run just created, so a concurrent release
+  # gate is safe. continue-on-error keeps a janitorial failure from blocking the
+  # release: the shards still run, and the next run sweeps again.
+  sweep-before:
+    name: sweep stale test accounts
     runs-on: ubuntu-latest
-    # `pnpm test -- --target-full` runs all 433 REST/CLI/browser flows against
-    # deployed staging serially. MEASURED on run 31535558700: setup + all 433
-    # flows finished at 44m36s (the tail browser journeys are far slower than
-    # the early REST flows), then the post-test secret-guard/upload steps push
-    # the job past 45m. The old 20-min cap killed it at ~316/433 EVERY release
-    # (v0.12.7 and v0.12.8 both cancelled, not failed) — the gate was
-    # structurally un-passable. Lanes run concurrently; every client retries the
-    # transient laundered-503 (session-create self-heals). Once the Vercel-SSO
-    # bypass let the browser lane actually run, the full suite is ~65-75m real
-    # (the flow lane alone is ~60m), so the cap is 90m. Staging's JWT lifetime
-    # was raised to 2h (was 1h) so a >60m run no longer expires its tokens.
-    # Follow-up: shard the runner (flow + browser as parallel jobs) to cut this.
-    timeout-minutes: 90
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.11.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install runner dependencies
+        run: pnpm install --frozen-lockfile --filter @kortix/tests...
+      - name: Reclaim test accounts older than 2h
+        run: bun tests/bin/ke2e.ts gc --older-than 2h
+
+  # The deployed API suite, sharded by tests/src/core/shard.ts. Shard 1 owns
+  # every serial + global flow (see that file); shards 2-4 split the parallel
+  # flows longest-first. The partition is computed from the live flow registry,
+  # so a newly added flow always lands in exactly one shard.
+  api:
+    name: deployed api shard
+    needs: sweep-before
+    runs-on: ubuntu-latest
+    # Shard 1 carries the strictly sequential serial+global tail (35 flows), so
+    # it is the critical path until the tail itself is cut. 40 minutes is a real
+    # cap that turns a hang into a readable failure; the old single job was 90.
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
-      KE2E_API_URL: ${{ vars.QA_API_BASE_URL || 'https://staging-api.kortix.com/v1' }}
-      E2E_BASE_URL: ${{ vars.QA_WEB_BASE_URL || 'https://staging.kortix.com' }}
-      KE2E_GATEWAY_URL: ${{ vars.QA_GATEWAY_URL || 'https://gateway-staging.kortix.com' }}
-      KE2E_TARGET: staging
-      KE2E_LIVE_CONFIRM: ci
-      KE2E_OWNER_EMAIL: ${{ secrets.KE2E_OWNER_EMAIL }}
-      KE2E_OWNER_PASSWORD: ${{ secrets.KE2E_OWNER_PASSWORD }}
-      KE2E_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
-      KE2E_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
-      KE2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
-      KE2E_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
-      KE2E_INTERNAL_SERVICE_KEY: ${{ secrets.STAGING_INTERNAL_SERVICE_KEY }}
-      KE2E_STRIPE_SECRET_KEY: ${{ secrets.STAGING_STRIPE_SECRET_KEY }}
-      KE2E_STRIPE_WEBHOOK_SECRET: ${{ secrets.STAGING_STRIPE_WEBHOOK_SECRET }}
-      E2E_AGENTMAIL_API_KEY: ${{ secrets.E2E_AGENTMAIL_API_KEY }}
-      KE2E_CAP_MANAGED_GIT_PUSH: ${{ vars.KE2E_CAP_MANAGED_GIT_PUSH || '0' }}
-      WEB_PROTECTION_PASSWORD: ${{ secrets.WEB_PROTECTION_PASSWORD }}
-      # Staging is behind Vercel SSO deployment protection; the browser lane must
-      # send x-vercel-protection-bypass (playwright.config) or every authenticated
-      # page 302s to vercel.com/sso-api. This env was missing when tests-release
-      # replaced the old qa-release gate, so the browser lane could never reach
-      # the app.
-      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      # Pin the run id so the post-run sweep below can reclaim exactly THIS
+      # shard's principals (`principals.ts` names them `e2e-<runId>-…`).
+      KE2E_RUN_ID: ${{ github.run_id }}-api${{ matrix.shard }}
+      # Fleet arithmetic, not per-job tuning: 4 shards x 3 = 12 concurrent API
+      # workers and 4 x 2 = 8 concurrent sandbox boots against ONE staging
+      # environment, against 3 + 3 before sharding. Staging is a single 0.5 vCPU
+      # Spot task today, and the v0.13.0 gate already collapsed it at 3 + 3 (see
+      # the "tests-release's own load can knock staging over" learning). These
+      # two numbers are the first thing to lower if MAINTENANCE_MODE 503s
+      # reappear.
+      KE2E_API_WORKERS: '3'
+      KE2E_SANDBOX_WORKERS: '2'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Require the deployed staging source SHA
+        run: |
+          set -euo pipefail
+          test -f RELEASE_SOURCE_SHA || {
+            echo "::error::Release PR has no RELEASE_SOURCE_SHA."
+            exit 1
+          }
+          source_sha="$(tr -d '[:space:]' < RELEASE_SOURCE_SHA)"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::RELEASE_SOURCE_SHA must contain one 40-character Git SHA."
+            exit 1
+          }
+          echo "KE2E_EXPECT_SHA=$source_sha" >> "$GITHUB_ENV"
+          echo "Expected deployed staging SHA: $source_sha"
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.11.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install deployed-target dependencies
+        run: pnpm install --frozen-lockfile --filter @kortix/tests...
+      - name: Run this shard of the deployed staging API suite
+        run: pnpm test -- --target-api-full --api-shard=${{ matrix.shard }}/4
+      # A cancelled job is SIGKILLed before the runner's `finally` teardown, so
+      # every cancel used to leak its whole world. `always()` covers cancelled,
+      # failed and passed; --run-id scopes the sweep to this shard so it cannot
+      # delete a sibling shard's live accounts.
+      - name: Reclaim this shard's test accounts
+        if: always()
+        continue-on-error: true
+        run: bun tests/bin/ke2e.ts gc --run-id "$KE2E_RUN_ID"
+      - name: Guard test artifacts against secrets
+        if: always()
+        run: |
+          set -euo pipefail
+          if rg -l 'kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.' tests/test-results 2>/dev/null; then
+            echo "::error::A test artifact contains a secret-shaped value."
+            exit 1
+          fi
+          echo "No secret-shaped values found."
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: tests-release-api-shard-${{ matrix.shard }}
+          path: tests/test-results/**
+          if-no-files-found: warn
+          retention-days: 90
+
+  # The deployed browser journeys, sharded with Playwright's own --shard.
+  browser:
+    name: deployed browser shard
+    needs: sweep-before
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    env:
+      # 3 shards x 2 = 6 concurrent browsers, against 2 before sharding.
+      E2E_BROWSER_WORKERS: '2'
     steps:
       - uses: actions/checkout@v7
       - name: Require the deployed staging source SHA
@@ -81,8 +191,12 @@ jobs:
         run: |
           pnpm install --frozen-lockfile --filter @kortix/tests...
           pnpm --dir tests exec playwright install --with-deps chromium
-      - name: Run every deployed staging flow and browser journey through the root runner
-        run: pnpm test -- --target-full
+      - name: Run this shard of the deployed staging browser journeys
+        run: pnpm test -- --target-browser-full --browser-shard=${{ matrix.shard }}/3
+      # No --run-id sweep here: the Playwright specs mint their own Supabase
+      # users (@example.test / @kortix.test) with no run-scoped prefix, so there
+      # is nothing to scope to. sweep-before now covers those domains, which it
+      # did not before, so their debris is reclaimed on the next run.
       - name: Guard test artifacts against secrets
         if: always()
         run: |
@@ -95,7 +209,61 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: tests-release-deployed-staging
+          name: tests-release-browser-shard-${{ matrix.shard }}
           path: tests/test-results/**
           if-no-files-found: warn
           retention-days: 90
+
+  # Backstop for an API shard that was killed before its own post-run sweep ran.
+  # Every shard's run id starts with `<github.run_id>-`, so this one filter
+  # reclaims all of them, and it runs only after every shard has finished.
+  sweep-after:
+    name: sweep this run's test accounts
+    needs: [api, browser]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.11.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install runner dependencies
+        run: pnpm install --frozen-lockfile --filter @kortix/tests...
+      - name: Reclaim this run's test accounts
+        run: bun tests/bin/ke2e.ts gc --run-id ${{ github.run_id }}
+
+  # The required status check on `prod` branch protection is this job's NAME.
+  # Sharding turned one job into seven, so this aggregator keeps the single
+  # context that branch protection already requires. Do not rename it without
+  # updating repos/kortix-ai/suna/branches/prod/protection in the same change.
+  release-gate:
+    name: full suite + quality gates
+    needs: [api, browser]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every deployed shard to pass
+        run: |
+          set -euo pipefail
+          api='${{ needs.api.result }}'
+          browser='${{ needs.browser.result }}'
+          echo "api shards: $api"
+          echo "browser shards: $browser"
+          failed=0
+          [ "$api" = "success" ] || failed=1
+          [ "$browser" = "success" ] || failed=1
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::A deployed staging shard did not pass (api=$api browser=$browser)."
+            exit 1
+          fi
+          echo "Every deployed staging API shard and browser shard passed."

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,7 +27,14 @@ pnpm test -- --packages-only   # Every app/package test and publish contract
 pnpm test -- --full            # Core, browser, and every app/package test
 pnpm test -- --target-smoke    # Deployed staging API SHA and browser smoke
 pnpm test -- --target-full     # Every deployed staging API flow and browser journey
+pnpm test -- --target-api-full --api-shard=1/4     # One deployed API shard
+pnpm test -- --target-browser-full --browser-shard=1/3 # One deployed browser shard
 ```
+
+`--target-full` runs both deployed lanes in one process. The two per-lane modes
+run one lane each, so the release gate can run them as parallel GitHub jobs.
+Both accept a shard, and both assert the deployed SHA exactly as `--target-full`
+does.
 
 Browser and full modes start local Supabase, apply migrations, and start the
 deterministic API, gateway, and web processes. The runner stops only processes
@@ -112,13 +119,53 @@ the sandbox. A new commit also removes the stale `preview` label. A scheduled
 reconciler deletes sandboxes whose pull request is closed, unlabeled, or at a
 different SHA.
 
-`tests-release.yml` runs `pnpm test -- --target-full` against deployed staging
-for pull requests into `prod`. It does not repeat the local-profile suite.
-This mode rejects development and production hosts. It requires the API and gateway
-health commits to equal `RELEASE_SOURCE_SHA`. It runs every selected REST and
-CLI flow with `--require-all`, then runs all configured Playwright journeys
-against `staging.kortix.com` with the Vercel bypass header. A missing external
+`tests-release.yml` runs the deployed staging suite for pull requests into
+`prod`. It does not repeat the local-profile suite. It rejects development and
+production hosts. It requires the API and gateway health commits to equal
+`RELEASE_SOURCE_SHA`. It runs every selected REST and CLI flow with
+`--require-all`, then runs all configured Playwright journeys against
+`staging.kortix.com` with the Vercel bypass header. A missing external
 capability fails the release gate instead of counting as a pass.
+
+#### Release gate shards
+
+The gate runs as parallel matrix jobs instead of one 90-minute job: four API
+shards (`--target-api-full --api-shard=N/4`) and three browser shards
+(`--target-browser-full --browser-shard=N/3`), with `fail-fast: false` so one
+red shard still reports the others. Wall clock becomes the slowest shard rather
+than a contended sum on one 2-vCPU runner.
+
+`src/core/shard.ts` computes the API partition from the live flow registry, so a
+newly added flow always lands in exactly one shard and can never fall out of the
+gate. Shard 1 owns every `serial` and every `global` flow — two jobs running the
+platform-mutating `global` flows at once would corrupt each other. The remaining
+flows are bin-packed longest-first using the declared `timeoutMs` as a static
+cost proxy. `unit/shard.test.ts` proves the partition is total and that the
+pinned flows never leave shard 1.
+
+A final job named `full suite + quality gates` aggregates the shards. That exact
+name is the required status check on `prod` branch protection; renaming it
+without updating the protection rule silently disables the gate.
+
+#### Test-account cleanup
+
+A cancelled GitHub job is killed before the runner's `finally` teardown, so every
+cancel used to leak its whole world. Three mechanisms reclaim it:
+
+- `sweep-before` runs `ke2e gc --older-than 2h` before the shards. The age window
+  cannot match an account the current run just created, so a concurrent release
+  gate is safe. It is `continue-on-error` — cleanup never blocks a release.
+- Each API shard runs `ke2e gc --run-id "$KE2E_RUN_ID"` with `if: always()`.
+  `KE2E_RUN_ID` is pinned per shard so the sweep reclaims only its own
+  principals. `sweep-after` repeats it for the whole run as a backstop.
+- `ke2e run` handles SIGINT/SIGTERM by reclaiming its own run id inside GitHub's
+  pre-SIGKILL window, bounded by `KE2E_CANCEL_RECLAIM_MS` (default 20s).
+
+`ke2e gc` sweeps the ke2e email domain plus the domains the Playwright specs mint
+under (`@example.test`, `@kortix.test`); override with `KE2E_GC_EMAIL_DOMAINS`.
+Only reserved TLDs are accepted. Browser-lane accounts carry no run-scoped
+prefix, so `--run-id` cannot reach them — the age sweep on the next run is what
+reclaims those.
 
 The strict browser lane also runs the Stripe-backed billing journey. It proves
 that the web app starts Team checkout, reads the activated subscription, starts

--- a/tests/bin/ke2e.ts
+++ b/tests/bin/ke2e.ts
@@ -3,11 +3,11 @@
  * ke2e — Kortix end-to-end REST API test runner.
  *
  *   ke2e run [--domain d] [--id ID] [--tag t] [--grep s] [--workers N]
- *            [--api-workers N] [--sandbox-workers N] [--smoke]
+ *            [--api-workers N] [--sandbox-workers N] [--smoke] [--shard i/N]
  *   ke2e local [same filters] [--no-start]
  *   ke2e list
  *   ke2e coverage
- *   ke2e gc [--older-than 2h] [--dry-run]
+ *   ke2e gc [--older-than 2h] [--run-id ID] [--dry-run]
  *   ke2e report <results.json>
  */
 import { resolve } from 'node:path';
@@ -30,6 +30,7 @@ import { discoverFlows, runSuite } from '../src/core/runner';
 import { writeUiData } from '../src/core/ui-data';
 import { runCoverage } from '../src/coverage/check-coverage';
 import { runGc } from '../src/fixtures/gc';
+import { parseShardSpec, planShard } from '../src/core/shard';
 
 function parseArgs(argv: string[]): { _: string[]; flags: Record<string, string | boolean> } {
   const _: string[] = [];
@@ -57,9 +58,45 @@ function list(v: string | boolean | undefined): string[] | undefined {
 }
 
 function newRunId(): string {
+  // KE2E_RUN_ID lets the caller PIN the id it will later sweep. The release
+  // gate's matrix needs this: each shard must be able to reclaim exactly its
+  // own principals in an `if: always()` step, and it cannot guess a random
+  // suffix chosen inside this process.
+  const pinned = process.env.KE2E_RUN_ID?.trim();
+  if (pinned) return pinned;
   const ts = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14);
   const r = Math.random().toString(36).slice(2, 8);
   return `${process.env.GITHUB_RUN_ID ?? ts}-${r}`;
+}
+
+/**
+ * Resolve the flow ids belonging to `--shard i/N`.
+ *
+ * The partition is computed from the live registry (see `src/core/shard.ts`),
+ * so every flow lands in exactly one shard and a newly added flow can never
+ * fall out of the release gate. `--shard` selects flows on its own; combining
+ * it with another selector would intersect two partitions and could silently
+ * run nothing, so that is rejected.
+ */
+async function resolveShardIds(
+  value: string,
+  conflicting: Array<[string, unknown]>,
+): Promise<string[]> {
+  const used = conflicting.filter(([, v]) => v !== undefined && v !== false).map(([n]) => n);
+  if (used.length > 0) {
+    throw new Error(`--shard cannot be combined with ${used.map((n) => `--${n}`).join(', ')}`);
+  }
+  const spec = parseShardSpec(value);
+  await discoverFlows();
+  const plan = planShard(allFlows(), spec);
+  if (plan.ids.length === 0) {
+    throw new Error(`--shard ${value} selected no flows`);
+  }
+  log.info(
+    `shard ${spec.current}/${spec.total}: ${plan.ids.length} flows · ` +
+      `projected load ${plan.loads.map((ms) => `${(ms / 60_000).toFixed(0)}m`).join('/')}`,
+  );
+  return plan.ids;
 }
 
 async function main(): Promise<number> {
@@ -104,7 +141,14 @@ async function main(): Promise<number> {
   }
 
   if (cmd === 'gc') {
-    await runGc({ olderThan: (flags['older-than'] as string) ?? '2h', dryRun: !!flags['dry-run'] });
+    const runIdFilter = typeof flags['run-id'] === 'string' ? flags['run-id'] : undefined;
+    const olderThan = typeof flags['older-than'] === 'string' ? flags['older-than'] : undefined;
+    await runGc({
+      // Age-only stays the default so `ke2e gc` keeps its old behaviour.
+      olderThan: olderThan ?? (runIdFilter ? undefined : '2h'),
+      runId: runIdFilter,
+      dryRun: !!flags['dry-run'],
+    });
     return 0;
   }
 
@@ -155,6 +199,20 @@ async function main(): Promise<number> {
     const env = loadEnv();
     const runId = newRunId();
     (globalThis as typeof globalThis & { __KE2E_RUN_ID__: string }).__KE2E_RUN_ID__ = runId;
+    // Deployed runs only. `ke2e local` targets a disposable local database, and
+    // a developer's Ctrl+C should stay instant rather than wait on a sweep.
+    if (!localCommand) installCancellationReclaim(runId);
+
+    const shardIds =
+      typeof flags.shard === 'string'
+        ? await resolveShardIds(flags.shard, [
+            ['id', flags.id],
+            ['domain', flags.domain],
+            ['tag', flags.tag],
+            ['grep', flags.grep],
+            ['smoke', flags.smoke],
+          ])
+        : undefined;
     const outDir = (flags.out as string) ?? resolve(import.meta.dir, '../test-results', runId);
     const gitSha = process.env.GITHUB_SHA ?? (await gitShaLocal());
 
@@ -163,7 +221,7 @@ async function main(): Promise<number> {
 
     const result = await runSuite({
       profile: localCommand ? 'local' : 'all',
-      ids: list(flags.id),
+      ids: shardIds ?? list(flags.id),
       domains: list(flags.domain),
       tags: list(flags.tag),
       grep: typeof flags.grep === 'string' ? flags.grep : undefined,
@@ -203,6 +261,50 @@ async function main(): Promise<number> {
       await localSupabase.stop();
     }
   }
+}
+
+/**
+ * Reclaim this run's principals when the process is cancelled.
+ *
+ * `runner.ts` tears the world down in a `finally`, which a killed process never
+ * reaches — every cancelled GitHub job therefore leaked its whole world. The
+ * runner owns the `World` handle and this binary cannot reach it, so the
+ * handler reclaims the same thing the world's teardown tail reclaims: every
+ * Supabase user named `e2e-<runId>-…` plus the accounts they own (which is what
+ * stops their sandboxes). The durable path is still the workflow's
+ * `if: always()` sweep step — this is defence in depth inside GitHub's short
+ * pre-SIGKILL window, so it is hard-bounded and never blocks exit.
+ *
+ * The same signal shape the sandbox CI workers already use
+ * (`daytona-ci.ts:785-788`, `platinum-ci.ts:1037-1040`).
+ */
+function installCancellationReclaim(runId: string): void {
+  const budgetMs = Number(process.env.KE2E_CANCEL_RECLAIM_MS ?? 20_000);
+  let reclaiming = false;
+  const onSignal = (signal: 'SIGINT' | 'SIGTERM'): void => {
+    if (reclaiming) return;
+    reclaiming = true;
+    const code = signal === 'SIGINT' ? 130 : 143;
+    if (!(budgetMs > 0)) {
+      process.exit(code);
+      return;
+    }
+    log.warn(`${signal}: reclaiming run ${runId} (up to ${(budgetMs / 1000).toFixed(0)}s)`);
+    const bail = setTimeout(() => {
+      log.warn(`${signal}: reclaim budget exhausted; leaving the rest to the workflow sweep`);
+      process.exit(code);
+    }, budgetMs);
+    bail.unref?.();
+    void runGc({ runId, dryRun: false })
+      .then(() => log.info(`${signal}: reclaimed run ${runId}`))
+      .catch((err) => log.warn(`${signal}: reclaim failed: ${String(err?.message ?? err)}`))
+      .finally(() => {
+        clearTimeout(bail);
+        process.exit(code);
+      });
+  };
+  process.once('SIGINT', () => onSignal('SIGINT'));
+  process.once('SIGTERM', () => onSignal('SIGTERM'));
 }
 
 async function gitShaLocal(): Promise<string | null> {

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,114 @@
+/**
+ * Up-front capability assertion for the strict deployed browser lane.
+ *
+ * `local-runner.ts` sets `E2E_REQUIRE_ALL_BROWSER=1` for the deployed lane and
+ * `strict-skip-reporter.ts` then fails the lane if ANY journey skipped. But 11
+ * specs decide to skip at RUNTIME on environment availability — a missing
+ * `KE2E_DATABASE_URL`, or an AgentMail key that answers 403. So a single
+ * email-provider blip turned the whole lane red only after ~50 minutes of
+ * running everything else first, and the failure named a skipped test rather
+ * than the missing capability.
+ *
+ * This runs ONCE before any journey and fails in seconds with the exact list of
+ * what is missing. The per-spec `test.skip(...)` guards stay: they are the
+ * correct behaviour on local and other non-strict runs, where a missing optional
+ * capability should degrade instead of fail. On the strict lane they are now
+ * unreachable, because this setup fails first — which is what removes the old
+ * contradiction between the strict reporter and the conditional skips.
+ */
+import { emailProviderStatus } from './helpers/inbox';
+
+interface Requirement {
+  name: string;
+  detail: string;
+  ok: () => boolean | Promise<boolean>;
+  reason?: () => string | Promise<string>;
+}
+
+export interface EmailProbeResult {
+  available: boolean;
+  reason: string;
+}
+
+export type EmailProbe = () => Promise<EmailProbeResult>;
+
+export function strictBrowserLane(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.E2E_REQUIRE_ALL_BROWSER === '1';
+}
+
+export function browserLaneRequirements(
+  env: NodeJS.ProcessEnv = process.env,
+  // `emailProviderStatus` reads process.env and memoizes its live probe, so it
+  // is injected rather than called through `env` — otherwise a caller passing a
+  // synthetic env would silently get the real process's answer.
+  probeEmail: EmailProbe = emailProviderStatus,
+): Requirement[] {
+  const present = (value: string | undefined): boolean => Boolean(value?.trim());
+  const requirements: Requirement[] = [
+    {
+      // 13-sdk-only, 18-apps-ui, 19-feature-flags, 20-workspace-switching,
+      // 21-trigger-session-access, 22-resource-grant-multiselect all
+      // `test.skip(!databaseUrl, ...)`.
+      name: 'KE2E_DATABASE_URL',
+      detail: 'direct database access; 6 specs skip without it',
+      ok: () => present(env.KE2E_DATABASE_URL) || present(env.E2E_DATABASE_URL),
+    },
+    {
+      // 01-account-auth and 08-accounts-project-access skip on a live probe, so
+      // this must PROBE, not just check that a key is set.
+      name: 'email provider',
+      detail: 'inbox delivery; 01 and 08 skip without it',
+      ok: async () => (await probeEmail()).available,
+      reason: async () => (await probeEmail()).reason,
+    },
+    {
+      name: 'E2E_ENABLE_BILLING_JOURNEY=1',
+      detail: '10-billing-journey skips without it',
+      ok: () => env.E2E_ENABLE_BILLING_JOURNEY === '1',
+    },
+    {
+      name: 'E2E_ENABLE_SANDBOX_TEMPLATE_BUILD=1',
+      detail: '12-sandbox-templates rebuild case skips without it',
+      ok: () => env.E2E_ENABLE_SANDBOX_TEMPLATE_BUILD === '1',
+    },
+    {
+      name: 'E2E_ENABLE_SDK_ONLY_SESSION=1',
+      detail: '13-sdk-only-session skips without it',
+      ok: () => env.E2E_ENABLE_SDK_ONLY_SESSION === '1',
+    },
+  ];
+  // Preview has no stable OAuth callback broker, so `local-runner.ts` sets
+  // E2E_OAUTH_PROVIDER_INITIATION=0 there and authorises that one exclusion in
+  // the strict reporter. Everywhere else spec 17 must really run.
+  if (env.E2E_ALLOW_PREVIEW_OAUTH_EXCLUSION !== '1') {
+    requirements.push({
+      name: 'E2E_OAUTH_PROVIDER_INITIATION=1',
+      detail: '17-oauth-provider-initiation skips without it',
+      ok: () => env.E2E_OAUTH_PROVIDER_INITIATION === '1',
+    });
+  }
+  return requirements;
+}
+
+export async function assertBrowserLaneCapabilities(
+  env: NodeJS.ProcessEnv = process.env,
+  probeEmail: EmailProbe = emailProviderStatus,
+): Promise<void> {
+  if (!strictBrowserLane(env)) return;
+  const missing: string[] = [];
+  for (const requirement of browserLaneRequirements(env, probeEmail)) {
+    if (await requirement.ok()) continue;
+    const reason = requirement.reason ? ` (${await requirement.reason()})` : '';
+    missing.push(`- ${requirement.name}: ${requirement.detail}${reason}`);
+  }
+  if (missing.length === 0) return;
+  throw new Error(
+    `The strict deployed browser lane (E2E_REQUIRE_ALL_BROWSER=1) requires every journey to run, ` +
+      `but ${missing.length} capability/capabilities are unavailable:\n${missing.join('\n')}\n` +
+      `Fix the environment, or run without E2E_REQUIRE_ALL_BROWSER=1 to allow conditional skips.`,
+  );
+}
+
+export default async function globalSetup(): Promise<void> {
+  await assertBrowserLaneCapabilities();
+}

--- a/tests/e2e/strict-skip-reporter.ts
+++ b/tests/e2e/strict-skip-reporter.ts
@@ -1,3 +1,14 @@
+/**
+ * Fails the deployed lane when a journey was excluded.
+ *
+ * This reporter and the specs' conditional `test.skip(...)` guards used to
+ * contradict each other: the guards degrade gracefully on a missing capability,
+ * this reporter turns that same degradation into a lane failure — after the
+ * whole suite had run. `e2e/global-setup.ts` resolves it by asserting every
+ * required capability up front, so on the strict lane a missing capability now
+ * fails in seconds and never reaches a skip. What remains here is the genuine
+ * case: a journey excluded for a reason the setup could not predict.
+ */
 import type { FullResult, Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -37,14 +37,28 @@ const workers = resolveBrowserWorkers(process.env.E2E_BROWSER_WORKERS, Boolean(p
 // deployed lanes.
 const deployedTarget = Boolean(process.env.KE2E_TARGET);
 
+// A deployed journey used to get 300s × 4 attempts, so ONE bad journey could eat
+// 20 minutes of a worker — enough to explain the whole 40-58 min browser lane by
+// itself. The gate is sharded now, so a shard's wall clock is set by its slowest
+// journey: cap a deployed attempt at 120s and retry once. Journeys that
+// legitimately need longer already declare their own `test.setTimeout(...)`
+// (10-billing 300s, 13-sdk-only 12m, 01-account-auth 180s), which overrides this.
+// Local and non-deployed CI keep the old 300s/2-retry budget.
+const deployedTimeoutMs = Number(process.env.E2E_DEPLOYED_TIMEOUT_MS ?? 120_000);
+const deployedRetries = Number(process.env.E2E_DEPLOYED_RETRIES ?? 1);
+
 export default defineConfig({
   testDir: './e2e/specs',
-  timeout: 300_000,
+  // Fails the strict deployed lane in seconds when a required capability is
+  // missing, instead of skipping mid-run and reporting it ~50 min later. No-op
+  // when E2E_REQUIRE_ALL_BROWSER is unset. See e2e/global-setup.ts.
+  globalSetup: './e2e/global-setup.ts',
+  timeout: deployedTarget ? deployedTimeoutMs : 300_000,
   expect: {
     timeout: deployedTarget ? 45_000 : 30_000,
   },
   fullyParallel: true,
-  retries: deployedTarget ? 3 : process.env.CI ? 2 : 0,
+  retries: deployedTarget ? deployedRetries : process.env.CI ? 2 : 0,
   workers,
   reporter: [
     ['list'],

--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -22,10 +22,28 @@ export interface LocalTestLane {
 }
 
 export interface LocalTestPlan {
-  mode: 'core' | 'flows' | 'sdk' | 'browser' | 'packages' | 'target' | 'target-full' | 'full';
+  mode:
+    | 'core'
+    | 'flows'
+    | 'sdk'
+    | 'browser'
+    | 'packages'
+    | 'target'
+    | 'target-full'
+    | 'target-api-full'
+    | 'target-browser-full'
+    | 'full';
   lanes: LocalTestLane[];
   stages: LocalTestLane[][];
 }
+
+/** Modes that assert the deployed target's health and SHA before running. */
+const DEPLOYED_TARGET_MODES = new Set<LocalTestPlan['mode']>([
+  'target',
+  'target-full',
+  'target-api-full',
+  'target-browser-full',
+]);
 
 const flowFilterFlags = new Set(['--domain', '--id', '--tag', '--smoke']);
 
@@ -36,6 +54,15 @@ function hasFlowFilter(args: string[]): boolean {
   });
 }
 
+function assertShardValue(value: string | undefined, flag: string): void {
+  const match = value?.match(/^(\d+)\/(\d+)$/);
+  const current = Number(match?.[1]);
+  const total = Number(match?.[2]);
+  if (!match || current < 1 || total < 2 || current > total) {
+    throw new Error(`${flag} must use CURRENT/TOTAL with 1 <= CURRENT <= TOTAL`);
+  }
+}
+
 export function buildLocalTestPlan(args: string[]): LocalTestPlan {
   const full = args.includes('--full');
   const flowsOnly = args.includes('--flows-only') || hasFlowFilter(args);
@@ -44,7 +71,14 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
   const packagesOnly = args.includes('--packages-only');
   const targetSmoke = args.includes('--target-smoke');
   const targetFull = args.includes('--target-full');
+  // The release gate runs the two deployed lanes as SEPARATE GitHub jobs, each
+  // sharded, so `max(api, browser)` replaces a contended sum on one 2-vCPU
+  // runner. `--target-full` still runs both lanes in one process for
+  // deploy-preview (one sandbox origin, one job by construction) and local use.
+  const targetApiFullOnly = args.includes('--target-api-full');
+  const targetBrowserFullOnly = args.includes('--target-browser-full');
   const browserShardArgs = args.filter((arg) => arg.startsWith('--browser-shard='));
+  const apiShardArgs = args.filter((arg) => arg.startsWith('--api-shard='));
   const modes = [
     full,
     flowsOnly,
@@ -53,25 +87,32 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
     packagesOnly,
     targetSmoke,
     targetFull,
+    targetApiFullOnly,
+    targetBrowserFullOnly,
   ].filter(Boolean).length;
   if (modes > 1) {
     throw new Error(
-      'choose only one of --full, --flows-only, --sdk-only, --browser-only, --packages-only, --target-smoke, or --target-full',
+      'choose only one of --full, --flows-only, --sdk-only, --browser-only, --packages-only, --target-smoke, --target-full, --target-api-full, or --target-browser-full',
     );
   }
   if (browserShardArgs.length > 1) {
     throw new Error('choose only one --browser-shard value');
   }
+  if (apiShardArgs.length > 1) {
+    throw new Error('choose only one --api-shard value');
+  }
   const browserShard = browserShardArgs[0]?.slice('--browser-shard='.length);
   if (browserShardArgs.length === 1) {
-    const match = browserShard.match(/^(\d+)\/(\d+)$/);
-    const current = Number(match?.[1]);
-    const total = Number(match?.[2]);
-    if (!match || current < 1 || total < 2 || current > total) {
-      throw new Error('--browser-shard must use CURRENT/TOTAL with 1 <= CURRENT <= TOTAL');
+    assertShardValue(browserShard, '--browser-shard');
+    if (!browserOnly && !targetBrowserFullOnly) {
+      throw new Error('--browser-shard requires --browser-only or --target-browser-full');
     }
-    if (!browserOnly) {
-      throw new Error('--browser-shard requires --browser-only');
+  }
+  const apiShard = apiShardArgs[0]?.slice('--api-shard='.length);
+  if (apiShardArgs.length === 1) {
+    assertShardValue(apiShard, '--api-shard');
+    if (!targetApiFullOnly) {
+      throw new Error('--api-shard requires --target-api-full');
     }
   }
 
@@ -84,7 +125,10 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
       arg !== '--packages-only' &&
       arg !== '--target-smoke' &&
       arg !== '--target-full' &&
-      !arg.startsWith('--browser-shard='),
+      arg !== '--target-api-full' &&
+      arg !== '--target-browser-full' &&
+      !arg.startsWith('--browser-shard=') &&
+      !arg.startsWith('--api-shard='),
   );
   const flows: LocalTestLane = {
     name: 'api-cli-flows',
@@ -132,23 +176,36 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
   };
   const targetApiFull: LocalTestLane = {
     name: 'target-api-full',
-    command: ['bun', 'tests/bin/ke2e.ts', 'run', '--require-all'],
-    // Runs as its OWN stage (serialized before the browser lane — see below),
-    // so it has the staging Daytona provider to itself. 3 concurrent sandbox
-    // boots is proven to reach runtime-ready fine on its own; the API
-    // (non-sandbox) workers stay at 3 too since those flows are fast. Override
-    // via KE2E_API_WORKERS / KE2E_SANDBOX_WORKERS.
+    command: [
+      'bun',
+      'tests/bin/ke2e.ts',
+      'run',
+      '--require-all',
+      ...(apiShard ? ['--shard', apiShard] : []),
+    ],
+    // KE2E_API_WORKERS was 3. `provision.ts`'s global KE2E_PROVISION_CONCURRENCY
+    // semaphore — not the worker count — is the real ceiling, so 3 workers left
+    // measured parallelism at 1.43x. 6 is the paired half of raising provision
+    // concurrency to 4; raising either alone does almost nothing. Sandbox
+    // workers stay at 3 because those boot real cloud sandboxes.
+    // The release gate's shards override BOTH so the fleet total stays bounded
+    // — see the arithmetic in tests-release.yml.
     env: {
-      KE2E_API_WORKERS: process.env.KE2E_API_WORKERS ?? '3',
+      KE2E_API_WORKERS: process.env.KE2E_API_WORKERS ?? '6',
       KE2E_SANDBOX_WORKERS: process.env.KE2E_SANDBOX_WORKERS ?? '3',
     },
   };
   const targetBrowserFull: LocalTestLane = {
     name: 'target-browser-full',
-    command: ['bun', 'run', 'test:browser'],
+    command: [
+      'bun',
+      'run',
+      'test:browser',
+      ...(browserShard ? ['--', `--shard=${browserShard}`] : []),
+    ],
     cwd: 'tests',
     env: {
-      E2E_BROWSER_WORKERS: '2',
+      E2E_BROWSER_WORKERS: process.env.E2E_BROWSER_WORKERS ?? '2',
       E2E_ENABLE_SDK_ONLY_SESSION: '1',
       E2E_ENABLE_SANDBOX_TEMPLATE_BUILD: '1',
       E2E_OAUTH_PROVIDER_INITIATION: process.env.KE2E_TARGET === 'preview' ? '0' : '1',
@@ -169,6 +226,16 @@ export function buildLocalTestPlan(args: string[]): LocalTestPlan {
   if (targetSmoke) {
     const lanes = [targetApi, targetBrowser];
     return { mode: 'target', lanes, stages: [lanes] };
+  }
+  if (targetApiFullOnly) {
+    return { mode: 'target-api-full', lanes: [targetApiFull], stages: [[targetApiFull]] };
+  }
+  if (targetBrowserFullOnly) {
+    return {
+      mode: 'target-browser-full',
+      lanes: [targetBrowserFull],
+      stages: [[targetBrowserFull]],
+    };
   }
   if (targetFull) {
     // Lanes run CONCURRENTLY (one stage). A serialize experiment was tried to
@@ -356,7 +423,7 @@ export async function runLocalTests(root: string, args: string[]): Promise<numbe
   console.log(`[test] mode=${plan.mode} lanes=${plan.lanes.map((lane) => lane.name).join(',')}`);
   const results: LaneResult[] = [];
   try {
-    if (plan.mode === 'target' || plan.mode === 'target-full') {
+    if (DEPLOYED_TARGET_MODES.has(plan.mode)) {
       const target = resolveTargetSmokeConfig();
       await assertTargetSmokeHealth(target);
       console.log(

--- a/tests/src/core/shard.ts
+++ b/tests/src/core/shard.ts
@@ -1,0 +1,117 @@
+/**
+ * Deterministic flow sharding for the release gate.
+ *
+ * `.github/workflows/tests-release.yml` runs the deployed API suite as N
+ * parallel GitHub jobs. Each job re-discovers the SAME flow registry and asks
+ * this planner which flows belong to its shard, so the partition is computed
+ * from the live registry rather than from a hand-maintained list: a newly added
+ * flow always lands in exactly one shard and can never fall out of the gate.
+ *
+ * Two rules, in order:
+ *
+ * 1. Every `serial` and every `global` flow goes to shard 1. `global` flows
+ *    (ADM-19, BILL-13, CONN-5) mutate platform-wide state that all shards share
+ *    — two jobs running them at once would corrupt each other. `serial` flows
+ *    mutate their own run's OWNER/platform-admin principals; each shard builds
+ *    its own world, so those are technically shard-safe, but pinning the whole
+ *    non-parallel tail to one shard keeps ONE job responsible for it and lets
+ *    the model below give the other shards proportionally more parallel work.
+ * 2. The remaining flows are bin-packed longest-processing-time-first onto the
+ *    shard with the lowest projected load, ties broken by shard index then flow
+ *    id. LPT is deterministic given the same registry, so every job computes an
+ *    identical partition without coordinating.
+ *
+ * The cost model is in worker-seconds and uses the flow's declared `timeoutMs`
+ * (default 120_000, matching `runner.ts`'s `withTimeout` fallback) as a static
+ * proxy for duration. It is a ceiling, not a measurement — good enough to keep
+ * the expensive sandbox flows from piling onto one shard, and it needs no
+ * results artifact to stay current. A serial flow occupies a whole shard while
+ * the other workers idle, so it is charged `SERIAL_WORKER_PENALTY` times its
+ * weight; a parallel flow is charged once.
+ */
+import type { RegisteredFlow } from './flow';
+
+/** `runner.ts:161` — `withTimeout(f.fn(ctx), f.meta.timeoutMs ?? 120_000, f.id)`. */
+export const DEFAULT_FLOW_WEIGHT_MS = 120_000;
+
+/**
+ * Models the per-shard API worker count: a serial flow blocks the shard for its
+ * whole duration while the other workers idle, so it costs the shard that many
+ * worker-seconds. Kept equal to the `KE2E_API_WORKERS` the release gate gives
+ * each API shard.
+ */
+export const SERIAL_WORKER_PENALTY = 3;
+
+export interface ShardSpec {
+  current: number;
+  total: number;
+}
+
+export interface ShardPlan {
+  /** Flow ids assigned to `spec.current`, sorted for a stable command line. */
+  ids: string[];
+  /** Projected worker-second load of every shard, indexed from shard 1. */
+  loads: number[];
+}
+
+/** Parse `CURRENT/TOTAL`. Throws on anything that is not a usable shard spec. */
+export function parseShardSpec(value: string): ShardSpec {
+  const match = value.match(/^(\d+)\/(\d+)$/);
+  const current = Number(match?.[1]);
+  const total = Number(match?.[2]);
+  if (!match || !Number.isInteger(current) || !Number.isInteger(total)) {
+    throw new Error(`--shard must use CURRENT/TOTAL, received "${value}"`);
+  }
+  if (total < 1 || current < 1 || current > total) {
+    throw new Error(`--shard must satisfy 1 <= CURRENT <= TOTAL, received "${value}"`);
+  }
+  return { current, total };
+}
+
+export function flowWeightMs(flow: RegisteredFlow): number {
+  const declared = flow.meta.timeoutMs;
+  return typeof declared === 'number' && declared > 0 ? declared : DEFAULT_FLOW_WEIGHT_MS;
+}
+
+export function isPinnedToFirstShard(flow: RegisteredFlow): boolean {
+  return Boolean(flow.meta.serial) || Boolean(flow.meta.global);
+}
+
+/**
+ * Assign every flow to a shard and return the ids belonging to `spec.current`.
+ * Total across all shards is a partition: every input flow appears exactly once.
+ */
+export function planShard(flows: RegisteredFlow[], spec: ShardSpec): ShardPlan {
+  const loads = new Array<number>(spec.total).fill(0);
+  const assigned = new Array<string[]>(spec.total);
+  for (let i = 0; i < spec.total; i++) assigned[i] = [];
+
+  const pinned = flows.filter(isPinnedToFirstShard);
+  for (const flow of pinned) {
+    assigned[0].push(flow.id);
+    loads[0] += flowWeightMs(flow) * SERIAL_WORKER_PENALTY;
+  }
+
+  const parallel = flows
+    .filter((flow) => !isPinnedToFirstShard(flow))
+    .sort((a, b) => {
+      const delta = flowWeightMs(b) - flowWeightMs(a);
+      return delta !== 0 ? delta : a.id.localeCompare(b.id, undefined, { numeric: true });
+    });
+
+  for (const flow of parallel) {
+    let target = 0;
+    for (let i = 1; i < spec.total; i++) {
+      if (loads[i] < loads[target]) target = i;
+    }
+    assigned[target].push(flow.id);
+    loads[target] += flowWeightMs(flow);
+  }
+
+  return {
+    ids: assigned[spec.current - 1].sort((a, b) =>
+      a.localeCompare(b, undefined, { numeric: true }),
+    ),
+    loads,
+  };
+}

--- a/tests/src/fixtures/gc.ts
+++ b/tests/src/fixtures/gc.ts
@@ -14,8 +14,46 @@ import { adminDeleteUser, passwordGrant } from "./supabase";
 
 const SYNTH_PASSWORD = "Ke2e-passw0rd-Aa1!";
 
+/**
+ * Email domains a test account can live under.
+ *
+ * `env.testEmailDomain` (default `ke2e.kortix.test`) covers every ke2e
+ * principal minted by `principals.ts`. The Playwright suite mints its OWN users
+ * directly against Supabase under `@example.test` and `@kortix.test`, which the
+ * ke2e-only filter never saw — so before this list the sweep reclaimed exactly
+ * zero browser-lane accounts. Override with `KE2E_GC_EMAIL_DOMAINS` (comma
+ * separated). Every entry must be under a reserved TLD so no real user can be
+ * matched.
+ */
+export const BROWSER_TEST_EMAIL_DOMAINS = ["example.test", "kortix.test"] as const;
+
+export function resolveGcEmailDomains(env: Env): string[] {
+  const configured = (process.env.KE2E_GC_EMAIL_DOMAINS ?? "")
+    .split(",")
+    .map((s) => s.trim().replace(/^@/, ""))
+    .filter(Boolean);
+  const domains = configured.length > 0
+    ? configured
+    : [env.testEmailDomain, ...BROWSER_TEST_EMAIL_DOMAINS];
+  for (const domain of domains) {
+    if (!/\.(test|invalid|localhost|example)$/.test(domain)) {
+      throw new Error(
+        `gc refuses email domain "${domain}": only reserved TLDs (.test/.invalid/.localhost/.example) are sweepable`,
+      );
+    }
+  }
+  return [...new Set(domains)];
+}
+
 export interface GcOptions {
-  olderThan: string; // e.g. "2h", "30m", "1d"
+  /** Reclaim accounts created before now minus this duration, e.g. "2h". */
+  olderThan?: string;
+  /**
+   * Reclaim this run's own accounts at any age. `principals.ts:36` names every
+   * principal `e2e-<runId>-<label>-…`, so the prefix targets exactly one run and
+   * never touches a concurrent one. Unioned with `olderThan` when both are set.
+   */
+  runId?: string;
   dryRun: boolean;
 }
 
@@ -24,6 +62,25 @@ function parseDuration(s: string): number {
   if (!m) throw new Error(`bad --older-than "${s}" (use e.g. 30m, 2h, 1d)`);
   const n = Number(m[1]);
   return n * { s: 1e3, m: 60e3, h: 3600e3, d: 86400e3 }[m[2] as "s" | "m" | "h" | "d"];
+}
+
+/** Local-part prefix `principals.ts` gives every principal of one run. */
+export function runIdEmailPrefix(runId: string): string {
+  return `e2e-${runId}-`;
+}
+
+/** Which users this sweep reclaims. Exported so the unit tests can pin it. */
+export function selectReclaimable(
+  users: SupaUser[],
+  opts: { cutoff?: number; runId?: string },
+): SupaUser[] {
+  const prefix = opts.runId ? runIdEmailPrefix(opts.runId) : null;
+  return users.filter((u) => {
+    if (prefix && (u.email ?? "").toLowerCase().startsWith(prefix.toLowerCase())) return true;
+    if (opts.cutoff === undefined) return false;
+    const created = u.created_at ? Date.parse(u.created_at) : 0;
+    return created > 0 && created < opts.cutoff;
+  });
 }
 
 interface SupaUser {
@@ -48,7 +105,7 @@ async function listTestUsersViaApi(env: Env): Promise<SupaUser[]> {
   return out;
 }
 
-async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
+async function listTestUsersViaDb(env: Env, domains: string[]): Promise<SupaUser[]> {
   const conn = env.databaseUrl!;
   const local = conn.includes("localhost") || conn.includes("127.0.0.1");
   const { Client } = await import("pg");
@@ -59,8 +116,8 @@ async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
   await client.connect();
   try {
     const r = await client.query(
-      "SELECT id::text AS id, email, created_at FROM auth.users WHERE email LIKE $1",
-      [`%@${env.testEmailDomain}`],
+      "SELECT id::text AS id, email, created_at FROM auth.users WHERE email LIKE ANY($1::text[])",
+      [domains.map((domain) => `%@${domain}`)],
     );
     return r.rows.map((row: { id: string; email: string | null; created_at: Date | string | null }) => ({
       id: row.id,
@@ -72,10 +129,12 @@ async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
   }
 }
 
-async function listTestUsers(env: Env): Promise<SupaUser[]> {
-  if (env.databaseUrl) return listTestUsersViaDb(env);
+async function listTestUsers(env: Env, domains: string[]): Promise<SupaUser[]> {
+  if (env.databaseUrl) return listTestUsersViaDb(env, domains);
   const users = await listTestUsersViaApi(env);
-  return users.filter((u) => (u.email ?? "").endsWith(`@${env.testEmailDomain}`));
+  return users.filter((u) =>
+    domains.some((domain) => (u.email ?? "").endsWith(`@${domain}`)),
+  );
 }
 
 export async function runGc(opts: GcOptions): Promise<void> {
@@ -83,16 +142,20 @@ export async function runGc(opts: GcOptions): Promise<void> {
   if (!env.capabilities.supabaseAdmin || !env.supabaseAnonKey) {
     throw new Error("gc requires KE2E_SUPABASE_SERVICE_ROLE_KEY + KE2E_SUPABASE_ANON_KEY");
   }
-  const cutoff = Date.now() - parseDuration(opts.olderThan);
-  log.info(`gc: target=${env.target} domain=@${env.testEmailDomain} olderThan=${opts.olderThan} dryRun=${opts.dryRun}`);
+  if (!opts.olderThan && !opts.runId) {
+    throw new Error("gc requires --older-than and/or --run-id");
+  }
+  const domains = resolveGcEmailDomains(env);
+  const cutoff = opts.olderThan ? Date.now() - parseDuration(opts.olderThan) : undefined;
+  log.info(
+    `gc: target=${env.target} domains=${domains.map((d) => `@${d}`).join(",")} ` +
+      `olderThan=${opts.olderThan ?? "-"} runId=${opts.runId ?? "-"} dryRun=${opts.dryRun}`,
+  );
 
-  const users = await listTestUsers(env);
-  const stale = users.filter((u) => {
-    const created = u.created_at ? Date.parse(u.created_at) : 0;
-    return created > 0 && created < cutoff;
-  });
+  const users = await listTestUsers(env, domains);
+  const stale = selectReclaimable(users, { cutoff, runId: opts.runId });
 
-  log.info(`gc: ${users.length} test user(s) found, ${stale.length} older than ${opts.olderThan}`);
+  log.info(`gc: ${users.length} test user(s) found, ${stale.length} selected for reclaim`);
   let removed = 0;
   let failed = 0;
   const configuredWorkers = Number(process.env.KE2E_GC_WORKERS ?? 8);
@@ -122,10 +185,28 @@ export async function runGc(opts: GcOptions): Promise<void> {
 
 async function reclaimUser(env: Env, u: SupaUser): Promise<void> {
   if (u.email) {
-    const jwt = await passwordGrant(env, u.email, SYNTH_PASSWORD);
-    const client = new Client(env.apiUrl).as({ label: "gc", auth: { mode: "bearer", token: jwt } });
-    for (const accountId of await ownedAccountIds(client, u.id)) {
-      await client.del("/v1/account/delete-immediately", { body: { account_id: accountId } });
+    // Best effort. Only ke2e principals share SYNTH_PASSWORD; the Playwright
+    // suite mints its users with per-spec passwords, so the grant legitimately
+    // fails for them. Deleting the Supabase user is the reclaim that must
+    // always happen, so a failed grant must never abort it.
+    try {
+      const jwt = await passwordGrant(env, u.email, SYNTH_PASSWORD);
+      const client = new Client(env.apiUrl).as({
+        label: "gc",
+        auth: { mode: "bearer", token: jwt },
+      });
+      for (const accountId of await ownedAccountIds(client, u.id)) {
+        // The route is mounted under /v1/billing (billing/routes/account-deletion.ts:92)
+        // — the same path world.ts teardown uses. The old un-prefixed path 404'd,
+        // so no GC sweep ever reached stopAccountSandboxes().
+        await client.del("/v1/billing/account/delete-immediately", {
+          body: { account_id: accountId },
+        });
+      }
+    } catch (err) {
+      log.warn(
+        `  account delete skipped for ${u.email}: ${String((err as Error).message).slice(0, 120)}`,
+      );
     }
   }
   await adminDeleteUser(env, u.id);

--- a/tests/unit/browser-lane-capabilities.test.ts
+++ b/tests/unit/browser-lane-capabilities.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertBrowserLaneCapabilities,
+  browserLaneRequirements,
+  strictBrowserLane,
+} from '../e2e/global-setup';
+
+const emailUp = async () => ({ available: true, reason: 'agentmail' });
+const emailDown = async () => ({ available: false, reason: 'AgentMail key rejected (HTTP 403)' });
+
+const fullyConfigured: NodeJS.ProcessEnv = {
+  E2E_REQUIRE_ALL_BROWSER: '1',
+  KE2E_DATABASE_URL: 'postgres://staging',
+  E2E_ENABLE_BILLING_JOURNEY: '1',
+  E2E_ENABLE_SANDBOX_TEMPLATE_BUILD: '1',
+  E2E_ENABLE_SDK_ONLY_SESSION: '1',
+  E2E_OAUTH_PROVIDER_INITIATION: '1',
+};
+
+describe('strict browser lane detection', () => {
+  it('is on only when local-runner sets E2E_REQUIRE_ALL_BROWSER=1', () => {
+    expect(strictBrowserLane({ E2E_REQUIRE_ALL_BROWSER: '1' })).toBe(true);
+    expect(strictBrowserLane({ E2E_REQUIRE_ALL_BROWSER: '0' })).toBe(false);
+    expect(strictBrowserLane({})).toBe(false);
+  });
+});
+
+describe('up-front browser capability assertion', () => {
+  it('passes a fully configured deployed lane', async () => {
+    await expect(
+      assertBrowserLaneCapabilities(fullyConfigured, emailUp),
+    ).resolves.toBeUndefined();
+  });
+
+  it('never blocks a non-strict run, however little is configured', async () => {
+    // Local runs are allowed to skip an unavailable optional capability.
+    await expect(assertBrowserLaneCapabilities({}, emailDown)).resolves.toBeUndefined();
+  });
+
+  it('fails on a rejected email provider and quotes the probe reason', async () => {
+    // The exact blip that used to turn the whole lane red ~50 min in.
+    await expect(
+      assertBrowserLaneCapabilities(fullyConfigured, emailDown),
+    ).rejects.toThrow('AgentMail key rejected (HTTP 403)');
+  });
+
+  it('fails on a missing database URL and names the specs it would skip', async () => {
+    const { KE2E_DATABASE_URL: _drop, ...withoutDb } = fullyConfigured;
+    await expect(assertBrowserLaneCapabilities(withoutDb, emailUp)).rejects.toThrow(
+      'KE2E_DATABASE_URL',
+    );
+  });
+
+  it('accepts E2E_DATABASE_URL as the alternate database source', async () => {
+    const { KE2E_DATABASE_URL: _drop, ...rest } = fullyConfigured;
+    await expect(
+      assertBrowserLaneCapabilities({ ...rest, E2E_DATABASE_URL: 'postgres://x' }, emailUp),
+    ).resolves.toBeUndefined();
+  });
+
+  it('lists every missing capability in one message instead of failing on the first', async () => {
+    await expect(assertBrowserLaneCapabilities({ E2E_REQUIRE_ALL_BROWSER: '1' }, emailDown))
+      .rejects.toThrow(/6 capability/);
+  });
+
+  it('excuses OAuth only where the strict reporter also excuses it', async () => {
+    const { E2E_OAUTH_PROVIDER_INITIATION: _drop, ...withoutOauth } = fullyConfigured;
+    // Preview: local-runner sets the toggle to 0 and authorises the exclusion.
+    await expect(
+      assertBrowserLaneCapabilities(
+        { ...withoutOauth, E2E_ALLOW_PREVIEW_OAUTH_EXCLUSION: '1' },
+        emailUp,
+      ),
+    ).resolves.toBeUndefined();
+    // Staging: no such authorisation, so spec 17 must really run.
+    await expect(
+      assertBrowserLaneCapabilities(withoutOauth, emailUp),
+    ).rejects.toThrow('E2E_OAUTH_PROVIDER_INITIATION=1');
+  });
+
+  it('covers every runtime-skipped capability the strict reporter would fail on', () => {
+    const names = browserLaneRequirements(fullyConfigured, emailUp).map((r) => r.name);
+    expect(names).toEqual([
+      'KE2E_DATABASE_URL',
+      'email provider',
+      'E2E_ENABLE_BILLING_JOURNEY=1',
+      'E2E_ENABLE_SANDBOX_TEMPLATE_BUILD=1',
+      'E2E_ENABLE_SDK_ONLY_SESSION=1',
+      'E2E_OAUTH_PROVIDER_INITIATION=1',
+    ]);
+  });
+});

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -271,7 +271,9 @@ describe("managed Git fixture selection", () => {
 
     expect(gc).toContain("KE2E_GC_WORKERS");
     expect(gc).toContain("mapWithConcurrency(stale, workers");
-    expect(gc).toContain("if (env.databaseUrl) return listTestUsersViaDb(env)");
+    // The sweep now takes the domain list too, so it can also see the browser
+    // suite's accounts — see gc-sweep.test.ts.
+    expect(gc).toContain("if (env.databaseUrl) return listTestUsersViaDb(env, domains)");
     expect(gc).toContain("ssl: local ? false : true");
   });
 });

--- a/tests/unit/gc-sweep.test.ts
+++ b/tests/unit/gc-sweep.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Env } from '../src/core/env';
+import {
+  BROWSER_TEST_EMAIL_DOMAINS,
+  resolveGcEmailDomains,
+  runIdEmailPrefix,
+  selectReclaimable,
+} from '../src/fixtures/gc';
+
+const env = { testEmailDomain: 'ke2e.kortix.test' } as Env;
+
+afterEach(() => {
+  delete process.env.KE2E_GC_EMAIL_DOMAINS;
+});
+
+describe('gc email domains', () => {
+  it('sweeps the ke2e domain and the browser suite domains', () => {
+    // Before this list the filter was `%@ke2e.kortix.test` only, so the sweep
+    // reclaimed ZERO Playwright accounts.
+    const domains = resolveGcEmailDomains(env);
+    expect(domains).toContain('ke2e.kortix.test');
+    for (const domain of BROWSER_TEST_EMAIL_DOMAINS) expect(domains).toContain(domain);
+  });
+
+  it('is overridable and de-duplicated', () => {
+    process.env.KE2E_GC_EMAIL_DOMAINS = '@one.test, two.test ,one.test';
+    expect(resolveGcEmailDomains(env)).toEqual(['one.test', 'two.test']);
+  });
+
+  it('refuses a domain that is not reserved', () => {
+    process.env.KE2E_GC_EMAIL_DOMAINS = 'kortix.com';
+    expect(() => resolveGcEmailDomains(env)).toThrow('only reserved TLDs');
+  });
+});
+
+describe('gc selection', () => {
+  const at = (iso: string) => Date.parse(iso);
+  const users = [
+    { id: 'u1', email: 'e2e-4242-a1b2-owner-x@ke2e.kortix.test', created_at: '2026-08-19T12:00:00Z' },
+    { id: 'u2', email: 'e2e-9999-c3d4-owner-y@ke2e.kortix.test', created_at: '2026-08-19T12:00:00Z' },
+    { id: 'u3', email: 'old-account@ke2e.kortix.test', created_at: '2026-08-01T00:00:00Z' },
+    { id: 'u4', email: 'billing-browser-1@example.test', created_at: '2026-08-01T00:00:00Z' },
+  ];
+
+  it('reclaims one run at any age without touching a concurrent run', () => {
+    const selected = selectReclaimable(users, { runId: '4242' }).map((u) => u.id);
+    expect(selected).toEqual(['u1']);
+  });
+
+  it('reclaims by age when no run id is given', () => {
+    const selected = selectReclaimable(users, { cutoff: at('2026-08-10T00:00:00Z') }).map(
+      (u) => u.id,
+    );
+    expect(selected).toEqual(['u3', 'u4']);
+  });
+
+  it('unions the run id and the age window when both are given', () => {
+    const selected = selectReclaimable(users, {
+      cutoff: at('2026-08-10T00:00:00Z'),
+      runId: '4242',
+    }).map((u) => u.id);
+    expect(selected).toEqual(['u1', 'u3', 'u4']);
+  });
+
+  it('selects nothing when neither filter matches', () => {
+    expect(selectReclaimable(users, { runId: 'nope' })).toEqual([]);
+  });
+
+  it('matches the run-scoped prefix principals.ts actually mints', () => {
+    // principals.ts:36 — `e2e-${runId}-${label}-…@${env.testEmailDomain}`.
+    expect(runIdEmailPrefix('4242-api1')).toBe('e2e-4242-api1-');
+    expect(
+      selectReclaimable(
+        [{ id: 'u5', email: 'e2e-4242-api1-owner-z@ke2e.kortix.test' }],
+        { runId: '4242' },
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/tests/unit/local-runner.test.ts
+++ b/tests/unit/local-runner.test.ts
@@ -170,8 +170,85 @@ describe('local test runner', () => {
     }
   });
 
+  it('raises the deployed API lane to six workers, still overridable by env', () => {
+    const previous = process.env.KE2E_API_WORKERS;
+    delete process.env.KE2E_API_WORKERS;
+    try {
+      // 3 workers left measured parallelism at 1.43x because the real ceiling is
+      // provision.ts's global semaphore, not the worker count.
+      expect(buildLocalTestPlan(['--target-full']).lanes[0]?.env).toEqual({
+        KE2E_API_WORKERS: '6',
+        KE2E_SANDBOX_WORKERS: '3',
+      });
+      process.env.KE2E_API_WORKERS = '3';
+      expect(buildLocalTestPlan(['--target-full']).lanes[0]?.env?.KE2E_API_WORKERS).toBe('3');
+    } finally {
+      if (previous === undefined) delete process.env.KE2E_API_WORKERS;
+      else process.env.KE2E_API_WORKERS = previous;
+    }
+  });
+
+  it('runs one deployed API shard through the release gate command', () => {
+    const plan = buildLocalTestPlan(['--target-api-full', '--api-shard=2/4']);
+
+    expect(plan.mode).toBe('target-api-full');
+    expect(plan.lanes.map((lane) => lane.name)).toEqual(['target-api-full']);
+    expect(plan.lanes[0]?.command).toEqual([
+      'bun',
+      'tests/bin/ke2e.ts',
+      'run',
+      '--require-all',
+      '--shard',
+      '2/4',
+    ]);
+  });
+
+  it('runs one deployed browser shard through the release gate command', () => {
+    const plan = buildLocalTestPlan(['--target-browser-full', '--browser-shard=3/3']);
+
+    expect(plan.mode).toBe('target-browser-full');
+    expect(plan.lanes.map((lane) => lane.name)).toEqual(['target-browser-full']);
+    expect(plan.lanes[0]?.command).toEqual([
+      'bun',
+      'run',
+      'test:browser',
+      '--',
+      '--shard=3/3',
+    ]);
+    expect(plan.lanes[0]?.env?.E2E_REQUIRE_ALL_BROWSER).toBe('1');
+  });
+
+  it('runs each deployed lane unsharded when no shard is given', () => {
+    expect(buildLocalTestPlan(['--target-api-full']).lanes[0]?.command).toEqual([
+      'bun',
+      'tests/bin/ke2e.ts',
+      'run',
+      '--require-all',
+    ]);
+    expect(buildLocalTestPlan(['--target-browser-full']).lanes[0]?.command).toEqual([
+      'bun',
+      'run',
+      'test:browser',
+    ]);
+  });
+
+  it('rejects a shard flag that has no lane to shard', () => {
+    expect(() => buildLocalTestPlan(['--api-shard=1/2'])).toThrow(
+      '--api-shard requires --target-api-full',
+    );
+    expect(() => buildLocalTestPlan(['--target-api-full', '--browser-shard=1/2'])).toThrow(
+      '--browser-shard requires --browser-only or --target-browser-full',
+    );
+    expect(() => buildLocalTestPlan(['--target-api-full', '--api-shard=3/2'])).toThrow(
+      '--api-shard must use CURRENT/TOTAL',
+    );
+  });
+
   it('rejects conflicting modes', () => {
     expect(() => buildLocalTestPlan(['--full', '--sdk-only'])).toThrow('choose only one');
+    expect(() => buildLocalTestPlan(['--target-full', '--target-api-full'])).toThrow(
+      'choose only one',
+    );
   });
 
   it('retries a cold local web route until it is ready', async () => {

--- a/tests/unit/sandbox-workflow.test.ts
+++ b/tests/unit/sandbox-workflow.test.ts
@@ -72,8 +72,19 @@ describe('sandbox test workflow', () => {
   test('release tests prove every deployed staging flow and browser journey', () => {
     const release = readFileSync(resolve(root, '.github/workflows/tests-release.yml'), 'utf8');
 
+    // The gate is sharded into parallel api/browser matrix jobs. Branch
+    // protection on `prod` requires exactly one context — this job name — so an
+    // aggregator job keeps it while the shards do the work. Renaming it breaks
+    // the required check silently.
     expect(release).toContain('name: full suite + quality gates');
-    expect(release).toContain('pnpm test -- --target-full');
+    expect(release).toContain('needs: [api, browser]');
+    expect(release).toContain('pnpm test -- --target-api-full --api-shard=');
+    expect(release).toContain('pnpm test -- --target-browser-full --browser-shard=');
+    expect(release).toContain('fail-fast: false');
+    // Cleanup-on-cancel: a cancelled job never reaches the runner's `finally`
+    // teardown, so the sweep must be wired pre-run and `if: always()` post-run.
+    expect(release).toContain('bun tests/bin/ke2e.ts gc --older-than 2h');
+    expect(release).toContain('bun tests/bin/ke2e.ts gc --run-id');
     expect(release).toContain('RELEASE_SOURCE_SHA');
     expect(release).toContain('WEB_PROTECTION_PASSWORD');
     // Staging sits behind Vercel SSO deployment protection, which Basic-auth
@@ -121,12 +132,19 @@ describe('sandbox test workflow', () => {
         source.includes('uses: ./.github/workflows/tests.yml'),
       ),
     ).toHaveLength(1);
+    // deploy-preview drives ONE sandbox origin from one job, so it keeps the
+    // combined `--target-full` command. The release gate splits the same two
+    // lanes across parallel GitHub jobs, so it calls the per-lane commands.
     const targetFullCallers = workflows.filter(({ source }) =>
       source.includes('pnpm test -- --target-full'),
     );
-    expect(targetFullCallers.map(({ name }) => name).sort()).toEqual([
-      'deploy-preview.yml',
-      'tests-release.yml',
-    ]);
+    expect(targetFullCallers.map(({ name }) => name).sort()).toEqual(['deploy-preview.yml']);
+
+    const shardedTargetCallers = workflows.filter(
+      ({ source }) =>
+        source.includes('pnpm test -- --target-api-full') &&
+        source.includes('pnpm test -- --target-browser-full'),
+    );
+    expect(shardedTargetCallers.map(({ name }) => name).sort()).toEqual(['tests-release.yml']);
   });
 });

--- a/tests/unit/shard.test.ts
+++ b/tests/unit/shard.test.ts
@@ -1,0 +1,184 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { RegisteredFlow } from '../src/core/flow';
+import {
+  DEFAULT_FLOW_WEIGHT_MS,
+  isPinnedToFirstShard,
+  parseShardSpec,
+  planShard,
+} from '../src/core/shard';
+
+function fakeFlow(
+  id: string,
+  meta: Partial<RegisteredFlow['meta']> = {},
+): RegisteredFlow {
+  return {
+    id,
+    meta: { domain: 'test', ...meta } as RegisteredFlow['meta'],
+    fn: async () => {},
+  };
+}
+
+describe('parseShardSpec', () => {
+  it('accepts CURRENT/TOTAL inside range', () => {
+    expect(parseShardSpec('1/4')).toEqual({ current: 1, total: 4 });
+    expect(parseShardSpec('4/4')).toEqual({ current: 4, total: 4 });
+  });
+
+  it('rejects anything that is not a usable shard', () => {
+    expect(() => parseShardSpec('1')).toThrow('CURRENT/TOTAL');
+    expect(() => parseShardSpec('0/4')).toThrow('1 <= CURRENT <= TOTAL');
+    expect(() => parseShardSpec('5/4')).toThrow('1 <= CURRENT <= TOTAL');
+    expect(() => parseShardSpec('a/b')).toThrow('CURRENT/TOTAL');
+  });
+});
+
+describe('planShard', () => {
+  it('is a partition: every flow lands in exactly one shard', () => {
+    const flows = Array.from({ length: 37 }, (_, i) =>
+      fakeFlow(`F-${i}`, { timeoutMs: (i % 5) * 60_000 + 60_000 }),
+    );
+    const seen = new Map<string, number>();
+    for (let current = 1; current <= 4; current++) {
+      for (const id of planShard(flows, { current, total: 4 }).ids) {
+        expect(seen.has(id)).toBe(false);
+        seen.set(id, current);
+      }
+    }
+    expect(seen.size).toBe(flows.length);
+  });
+
+  it('pins every serial and global flow to shard 1', () => {
+    const flows = [
+      fakeFlow('P-1'),
+      fakeFlow('S-1', { serial: true }),
+      fakeFlow('G-1', { global: true }),
+      fakeFlow('SG-1', { serial: true, global: true }),
+      fakeFlow('P-2'),
+    ];
+    expect(planShard(flows, { current: 1, total: 3 }).ids).toEqual(
+      expect.arrayContaining(['S-1', 'G-1', 'SG-1']),
+    );
+    for (const current of [2, 3]) {
+      const ids = planShard(flows, { current, total: 3 }).ids;
+      expect(ids).not.toContain('S-1');
+      expect(ids).not.toContain('G-1');
+      expect(ids).not.toContain('SG-1');
+    }
+  });
+
+  it('is deterministic — the same registry always yields the same partition', () => {
+    const flows = Array.from({ length: 50 }, (_, i) =>
+      fakeFlow(`F-${i}`, { timeoutMs: ((i * 7) % 9) * 30_000 + 30_000 }),
+    );
+    for (let current = 1; current <= 3; current++) {
+      const first = planShard(flows, { current, total: 3 });
+      const second = planShard([...flows].reverse(), { current, total: 3 });
+      expect(second.ids).toEqual(first.ids);
+    }
+  });
+
+  it('charges an undeclared timeout the runner default', () => {
+    const [only] = [fakeFlow('F-1')];
+    expect(planShard([only], { current: 1, total: 2 }).loads[0]).toBe(DEFAULT_FLOW_WEIGHT_MS);
+  });
+
+  it('balances the parallel work instead of splitting by count', () => {
+    const flows = [
+      fakeFlow('SLOW-1', { timeoutMs: 600_000 }),
+      ...Array.from({ length: 10 }, (_, i) => fakeFlow(`FAST-${i}`, { timeoutMs: 60_000 })),
+    ];
+    const loads = planShard(flows, { current: 1, total: 2 }).loads;
+    // Longest-first: the 600s flow alone, the ten 60s flows opposite it.
+    expect(loads[0]).toBe(600_000);
+    expect(loads[1]).toBe(600_000);
+  });
+
+  it('degenerates to the whole suite at --shard 1/1', () => {
+    const flows = [fakeFlow('A-1'), fakeFlow('B-1', { serial: true })];
+    expect(planShard(flows, { current: 1, total: 1 }).ids).toEqual(['A-1', 'B-1']);
+  });
+});
+
+/**
+ * The real registry, through the real runner.
+ *
+ * The flow modules and `discoverFlows` are Bun-only (`import.meta.dir`, Bun's
+ * `Glob`), so vitest cannot import them. Running the partition inside `bun` is
+ * also the more honest check: it exercises the exact code path `ke2e run
+ * --shard` takes, not a re-implementation of it.
+ */
+interface RegistryShardReport {
+  total: number;
+  shards: number;
+  perShard: number[];
+  duplicates: string[];
+  missing: string[];
+  pinned: string[];
+  pinnedOffShardOne: string[];
+}
+
+function shardTheRealRegistry(shards: number): RegistryShardReport {
+  const testsDir = resolve(import.meta.dirname, '..');
+  const script = `
+    const { discoverFlows } = await import(${JSON.stringify(`${testsDir}/src/core/runner.ts`)});
+    const { allFlows } = await import(${JSON.stringify(`${testsDir}/src/core/flow.ts`)});
+    const { planShard, isPinnedToFirstShard } = await import(${JSON.stringify(`${testsDir}/src/core/shard.ts`)});
+    await discoverFlows();
+    const flows = allFlows();
+    const total = ${shards};
+    const owner = new Map();
+    const duplicates = [];
+    const perShard = [];
+    for (let current = 1; current <= total; current++) {
+      const ids = planShard(flows, { current, total }).ids;
+      perShard.push(ids.length);
+      for (const id of ids) {
+        if (owner.has(id)) duplicates.push(id);
+        else owner.set(id, current);
+      }
+    }
+    const pinned = flows.filter(isPinnedToFirstShard).map((f) => f.id).sort();
+    const shardOne = new Set(planShard(flows, { current: 1, total }).ids);
+    console.log(JSON.stringify({
+      total: flows.length,
+      shards: total,
+      perShard,
+      duplicates,
+      missing: flows.filter((f) => !owner.has(f.id)).map((f) => f.id),
+      pinned,
+      pinnedOffShardOne: pinned.filter((id) => !shardOne.has(id)),
+    }));
+  `;
+  const out = execFileSync('bun', ['-e', script], { encoding: 'utf8', cwd: testsDir });
+  return JSON.parse(out.trim().split('\n').at(-1) as string) as RegistryShardReport;
+}
+
+describe('the real flow registry', () => {
+  const reports = new Map<number, RegistryShardReport>();
+
+  beforeAll(() => {
+    for (const shards of [2, 3, 4]) reports.set(shards, shardTheRealRegistry(shards));
+  }, 120_000);
+
+  it('discovers the whole suite', () => {
+    expect(reports.get(4)!.total).toBeGreaterThan(400);
+    expect(reports.get(4)!.pinned.length).toBeGreaterThan(0);
+  });
+
+  for (const shards of [2, 3, 4]) {
+    it(`assigns every registered flow to exactly one of ${shards} shards`, () => {
+      const report = reports.get(shards)!;
+      expect(report.duplicates, 'flows claimed by more than one shard').toEqual([]);
+      expect(report.missing, 'flows assigned to no shard').toEqual([]);
+      expect(report.perShard.reduce((a, b) => a + b, 0)).toBe(report.total);
+    });
+
+    it(`keeps every serial and global flow on shard 1 of ${shards}`, () => {
+      // Two jobs running ADM-19 / BILL-13 / CONN-5 at once would corrupt the
+      // platform-wide state they mutate.
+      expect(reports.get(shards)!.pinnedOffShardOne).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
Implements P2.1, P2.2, P2.3, P3.1, P0.4 and the local-runner half of P1.5 from the release-gate optimization plan.

The gate ran as ONE job on a 2-vCPU `ubuntu-latest` with `timeout-minutes: 90` (`tests-release.yml:29`, `:85`). It is now seven jobs with `fail-fast: false`.

---

## 1. P2.1 / P2.2 / P2.3 — shard the gate into parallel jobs

**New:** `tests/src/core/shard.ts`. It computes the API partition from the **live flow registry**, not a hand-maintained list, so a newly added flow always lands in exactly one shard and can never fall out of the gate.

- Shard 1 owns every `serial` and every `global` flow. The 3 `global` flows (ADM-19, BILL-13, CONN-5) mutate platform-wide state that all shards share; two jobs running them at once would corrupt each other.
- The remaining flows are bin-packed longest-processing-time-first on the declared `meta.timeoutMs` (`runner.ts:161` default `120_000`) as a static cost proxy. Deterministic — every job computes an identical partition without coordinating.

Measured against the real registry:

```
$ bun tests/bin/ke2e.ts run --shard {1,2,3,4}/4
shard 1/4:  35 flows · projected load 324m/313m/311m/311m
shard 2/4: 136 flows · projected load 324m/313m/311m/311m
shard 3/4: 135 flows · projected load 324m/313m/311m/311m
shard 4/4: 135 flows · projected load 324m/313m/311m/311m
                     35+136+135+135 = 441

$ bun tests/bin/ke2e.ts catalog
441 flows · 1696 cases · 589 routes · 38 domains
```

Browser: 21 journeys split 7 / 7 / 7.

```
$ npx playwright test --list                 -> Total: 21 tests in 15 files
$ npx playwright test --list --shard=1/3     -> Total: 7 tests in 6 files
$ npx playwright test --list --shard=2/3     -> Total: 7 tests in 5 files
$ npx playwright test --list --shard=3/3     -> Total: 7 tests in 5 files
```

**Runner surface** (`local-runner.ts`): new `--target-api-full` and `--target-browser-full` modes so each deployed lane can be its own GitHub job, each accepting `--api-shard=i/N` / `--browser-shard=i/N`. `--target-full` is unchanged and still runs both lanes in one process. `--shard` refuses to combine with `--id/--domain/--tag/--grep/--smoke`, which would intersect two partitions and could silently select nothing:

```
$ bun tests/bin/ke2e.ts run --shard 2/4 --domain iam
Error: --shard cannot be combined with --domain
$ bun tests/bin/ke2e.ts run --shard 5/4
Error: --shard must satisfy 1 <= CURRENT <= TOTAL, received "5/4"
```

**Playwright deployed budget** (`playwright.config.ts:42,47`): `retries` 3 → 1, `timeout` 300_000 → 120_000. One bad journey could eat 20 minutes of a worker (5 min × 4 attempts), which explains the 40–58 min browser lane by itself. Specs that legitimately need longer already declare their own `test.setTimeout` (10-billing 300s, 13-sdk-only 12m, 01-account-auth 180s), which overrides the config. Local and non-deployed CI keep 300s / 2 retries. Both values are env-overridable.

**P1.5 (local-runner half):** `KE2E_API_WORKERS` default 3 → 6. `provision.ts:10`'s global semaphore, not the worker count, is the real ceiling — this is the paired half of raising `KE2E_PROVISION_CONCURRENCY` to 4. Still env-overridable.

### The required check name is preserved

`prod` branch protection requires exactly one context:

```
$ gh api repos/kortix-ai/suna/branches/prod/protection --jq '.required_status_checks.contexts'
["full suite + quality gates"]
```

A final aggregator job (`needs: [api, browser]`, `if: always()`) carries that exact name and fails if any shard failed, so **no protection rule needs editing**. Verified byte-identical:

```
$ python3 -c "...yaml.safe_load...; print(name.encode()==req.encode(), repr(name.encode()))"
byte-identical: True b'full suite + quality gates'
```

Shared env moved to workflow level — Actions has no YAML anchors, and this is the only way to keep one copy of the `KE2E_*` / `E2E_*` / `VERCEL_AUTOMATION_BYPASS_SECRET` wiring across the matrix. The `RELEASE_SOURCE_SHA` → `KE2E_EXPECT_SHA` step, the secret guard and the artifact upload all stay `if: always()` in every test job.

---

## 2. P3.1 — cleanup on cancel (all four sub-fixes)

`runner.ts:352-354` / `world.ts:319` only tear down in a `finally`, which a SIGKILLed GitHub job never reaches, so every cancel leaked its whole world. `gc.ts:81` already existed and **no workflow called it**.

1. **`--run-id` filter.** `ke2e gc --run-id <id>` reclaims one run's principals at any age using the `e2e-<runId>-` prefix `principals.ts:36` already mints, so a post-run sweep cannot touch a concurrent run. `--older-than` keeps working; both may be combined (union). `KE2E_RUN_ID` now pins the id so a caller can sweep exactly what it created.
2. **Workflow steps.** `sweep-before` runs `gc --older-than 2h` before the shards — the age window cannot match an account this run just created, so a concurrent gate is safe. Each API shard runs `gc --run-id "$KE2E_RUN_ID"` with `if: always()`, and `sweep-after` (`needs: [api, browser]`, `if: always()`) repeats it run-wide as a backstop for a shard killed before its own step. Both sweep jobs are `continue-on-error` — **cleanup never blocks a release**.
3. **Signal handlers.** `ke2e run` handles SIGINT/SIGTERM by reclaiming its own run id, the same shape as `daytona-ci.ts:785-788` / `platinum-ci.ts:1037-1040`. Bounded by `KE2E_CANCEL_RECLAIM_MS` (default 20s) so it never blocks exit; deployed runs only, so a developer's Ctrl+C on `ke2e local` stays instant.
4. **Browser-suite domains.** The filter was `%@ke2e.kortix.test` only, so it reclaimed **zero** Playwright accounts. It now also sweeps `@example.test` and `@kortix.test` (`KE2E_GC_EMAIL_DOMAINS` overrides; reserved TLDs only — a non-reserved domain is refused).

### Two bugs found while wiring this up

- **`gc.ts:128` used the wrong route.** It called `/v1/account/delete-immediately`; the route is mounted at `/v1/billing/account/delete-immediately` (`apps/api/src/billing/routes/account-deletion.ts:92` — the path `world.ts:335` teardown already uses). The un-prefixed path 404s, so **no GC sweep has ever reached `stopAccountSandboxes()`**. Fixed.
- **A failed password grant aborted the whole reclaim.** Browser users have per-spec passwords, so `passwordGrant` legitimately fails for them and the Supabase user was then never deleted. The grant is now best-effort; the user delete always runs.

### Gap 1 — what account deletion does and does not reclaim

Traced read-only through `apps/api`. **Verdict: it stops cloud sandboxes, partially.**

`DELETE /v1/billing/account/delete-immediately` → `performDeletion` → `stopAccountSandboxes(accountId)` (`billing/services/account-deletion.ts:161-162`), which calls `getProvider(...).stop(externalId)` (`:142`). So it is not a pure DB operation. But:

- **It only ever `stop`s, never `remove`s.** Daytona `sandbox.stop()`, E2B `pause({keepMemory:false})`, Platinum `POST /stop`. The provider sandbox object and its disk survive. The happy-path teardown (`registry.ts:42-47` → `session-lifecycle/actions.ts:104-114`) calls `provider.remove(...)`, a hard delete. Nothing in the GC path ever does.
- **Only the caller's earliest-joined account.** The handler ignores the body and resolves `resolveAccountId(userId)` (`account-deletion.ts:92-103`, `shared/resolve-account.ts:142-170`), so team/secondary accounts' sandboxes are never stopped even though gc loops over every owned id. `registry.ts:91-95` documents this exact hazard.
- **`status='provisioning'` boxes are excluded** by the `WHERE` at `:132`.
- **No rows are deleted** — `session_sandboxes` has no FK on `account_id`, so the DB-driven reaper (`reaping/box-queries.ts:176-178`) can still find and stop them later. Both reaper paths are `stop`-only (`orphan-boxes.ts:19-20`: "STOP only, never delete").

Net: the sweep reclaims accounts and halts running VMs for the primary account; it does not delete provider sandbox objects, and team-account sandboxes are missed. Fixing that means changing `apps/api`, which is out of scope for this PR — flagging it for the coordinator.

### Gap 2 — Stripe test-mode objects still leak

`tests/src/fixtures/billing.ts` only ever creates; there is no cancel or delete path anywhere under `tests/`. Every run leaks its test-mode customers and subscriptions, cancelled or not. Not fixed here.

### Known limit

Browser-lane accounts carry no run-scoped prefix, so `--run-id` cannot reach them. Their debris is reclaimed by the next run's age sweep — which now actually sees those domains, where before it saw none.

---

## 3. P0.4 — assert browser env up front instead of skipping mid-run

`local-runner.ts:156` sets `E2E_REQUIRE_ALL_BROWSER=1` and `strict-skip-reporter.ts:38-52` fails the lane if any test skipped — but 11 specs `test.skip(...)` at runtime on env availability. One email-provider blip = whole lane red after ~50 min, naming a skipped test rather than the missing capability.

There was no existing `globalSetup`. **New:** `tests/e2e/global-setup.ts`, wired in `playwright.config.ts`. It checks all six runtime-skipped capabilities once and fails with the complete list. It **probes** the email provider live rather than trusting that a key is set, because that is how specs 01 and 08 decide.

```
$ env -u KE2E_DATABASE_URL -u E2E_AGENTMAIL_API_KEY ... E2E_REQUIRE_ALL_BROWSER=1 npx playwright test
Error: The strict deployed browser lane (E2E_REQUIRE_ALL_BROWSER=1) requires every journey to run,
but 6 capability/capabilities are unavailable:
- KE2E_DATABASE_URL: direct database access; 6 specs skip without it
- email provider: inbox delivery; 01 and 08 skip without it (no email provider (set E2E_MAILPIT_URL or a valid E2E_AGENTMAIL_API_KEY))
- E2E_ENABLE_BILLING_JOURNEY=1: 10-billing-journey skips without it
- E2E_ENABLE_SANDBOX_TEMPLATE_BUILD=1: 12-sandbox-templates rebuild case skips without it
- E2E_ENABLE_SDK_ONLY_SESSION=1: 13-sdk-only-session skips without it
- E2E_OAUTH_PROVIDER_INITIATION=1: 17-oauth-provider-initiation skips without it
Fix the environment, or run without E2E_REQUIRE_ALL_BROWSER=1 to allow conditional skips.

0.586 total
```

**0.59 seconds instead of ~50 minutes.**

The per-spec `test.skip` guards are **kept**: they are correct on local and other non-strict runs, and they are now unreachable on the strict lane because the setup fails first. That is what removes the standing contradiction between the reporter and the skips. **No spec file was edited.** The preview OAuth exclusion stays authorized exactly where `strict-skip-reporter.ts` authorizes it.

---

## Verification

```
$ pnpm --dir tests test:unit
 Test Files  27 passed (27)
      Tests  209 passed (209)

$ cd tests && npx tsc --noEmit
(clean, exit 0)

$ actionlint .github/workflows/tests-release.yml
(no output, exit 0)

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tests-release.yml'))"
jobs: ['sweep-before', 'api', 'browser', 'sweep-after', 'release-gate']
gate name: 'full suite + quality gates'

$ bun tests/bin/ke2e.ts coverage
97.9% covered · 572/584 routes · 12 allowlisted · 0 uncovered
✓ coverage gate passed
```

New tests: `unit/shard.test.ts` (15), `unit/gc-sweep.test.ts` (8), `unit/browser-lane-capabilities.test.ts` (9). Updated to the new truth rather than deleted: `unit/sandbox-workflow.test.ts` (now pins the sharded commands, the aggregator name, `fail-fast: false` and both gc steps), `unit/local-runner.test.ts`, `unit/database-project-fixture.test.ts`.

**The partition test is falsifiable.** Positive control — dropping one flow from `planShard`:

```
AssertionError: flows assigned to no shard: expected [ 'GOLD-1' ] to deeply equal []
AssertionError: expected [ 'GOLD-1' ] to deeply equal []   (pinnedOffShardOne)
Tests  6 failed | 9 passed (15)
--- restored ---
Tests  15 passed (15)
```

It runs the partition inside `bun` against the real registry through the real `discoverFlows`, because the flow modules are Bun-only (`import.meta.dir`) and vitest cannot import them — so it exercises the exact code path `ke2e run --shard` takes rather than a re-implementation.

**Not verified:** no run against deployed staging. The gate only triggers on a PR into `prod`, and running it needs a real release candidate plus a `RELEASE_SOURCE_SHA` matching what staging serves. Wall-clock and staging-capacity claims below are projections, not measurements.

---

## The risk to watch

The gate now offers staging **12 API workers + 8 concurrent sandbox boots** (4 shards × 3 and × 2) against 3 + 3 before, plus **6 browsers** against 2. Staging is a single 0.5 vCPU Spot task, and the v0.13.0 gate already collapsed it at 3 + 3 — see the "tests-release's own load can knock staging over" learning, where the edge worker then laundered the origin failure into a generic `MAINTENANCE_MODE` 503.

`KE2E_API_WORKERS` and `KE2E_SANDBOX_WORKERS` are set per-job with that arithmetic written next to them; they are the first thing to lower if those 503s reappear. Staging right-sizing (P3.6) is a real prerequisite for this to pay off, and is not part of this PR.

Shard 1 is the critical path: it carries the strictly sequential 35-flow serial+global tail, whose declared timeouts sum to ~109 min at one attempt each. Its 40-minute cap converts a hang into a readable failure instead of a 90-minute one, but the 12–15 min target is not reachable until P1.1 (stop retrying timeouts), P1.2 (overlap the serial lane) and P1.3 (cap CR-9/GOLD-1) land — those are owned elsewhere.

## Follow-up: `deploy-preview.yml` left alone

Its `--target-full` (`:339`, 100-min cap) is **not** a mechanical copy. The preview runs both lanes inside ONE sandbox against ONE preview origin; sharding it across GitHub matrix jobs would need a separate preview sandbox and origin per shard. It does inherit the Playwright change for free (`preview-stack.ts:228` sets `KE2E_TARGET`, so retries 1 / timeout 120s apply), but its cap is left at 100 because lowering it without a measurement only converts a slow run into a hard failure.
