### PR TITLE
test(ke2e): declare daytona on 3 flows that boot a real sandbox (P1.6)

### DIFF
--- a/tests/src/flows/channels.flow.ts
+++ b/tests/src/flows/channels.flow.ts
@@ -957,6 +957,7 @@ flow(
   "CHN-23",
   {
     domain: "channels",
+    requires: ["daytona"],
     routes: ["POST /v1/projects/:projectId/channels/slack/bind-thread"],
   },
   async (ctx) => {

--- a/tests/src/flows/cli-ship.flow.ts
+++ b/tests/src/flows/cli-ship.flow.ts
@@ -608,7 +608,7 @@ flow(
   'CR-9',
   {
     domain: 'cli',
-    requires: ['funded'],
+    requires: ['funded', 'daytona'],
     serial: true,
     timeoutMs: 1_200_000,
     routes: [

--- a/tests/src/flows/new-routes-coverage.flow.ts
+++ b/tests/src/flows/new-routes-coverage.flow.ts
@@ -186,6 +186,7 @@ flow(
   'SESS-20',
   {
     domain: 'sessions',
+    requires: ['daytona'],
     routes: [
       'GET /v1/projects/:projectId/sessions/:sessionId/transcript',
       'GET /v1/projects/:projectId/sessions/:sessionId/turn',


### PR DESCRIPTION
Follow-up to #6542/#6543 (test-flow optimization plan item P1.6).

1. `tests/src/flows/new-routes-coverage.flow.ts` SESS-20, `tests/src/flows/channels.flow.ts` CHN-23, `tests/src/flows/cli-ship.flow.ts` CR-9 — add `'daytona'` to `requires`. Each calls `ctx.fixtures.session()` (real sandbox create) but declared no capability, so `tests/src/core/lanes.ts` routed them into the unthrottled API lane and never skipped them when Daytona is down.
2. Deliberately NOT capping GOLD-1 (600s / 480s snapshot wait) or CR-9 (1200s / 660s readiness wait): those reflect real cloud latency; #6543 made timeouts non-retryable so worst case is now 1×. Real fix = pre-warm the base snapshot at run start (follow-up).

Verification:
- `bun tests/bin/ke2e.ts catalog` → 439 flows · 1719 cases · 592 routes · 38 domains
- `pnpm --dir tests test:unit` → 27 files / 219 tests passed
- `pnpm --dir tests typecheck` → exit 0
