### PR TITLE
test(ke2e): send the edge CI-passthrough header so the release gate sees real origin status

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -36,6 +36,11 @@ env:
   # replaced the old qa-release gate, so the browser lane could never reach
   # the app.
   VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+  # Lets the api-router edge Worker return the TRUE origin status/body to the
+  # gate instead of laundering every origin failure into MAINTENANCE_MODE
+  # (worker.mjs CI_PASSTHROUGH_SECRET binding). Diagnosability only; the
+  # Worker's public behavior is unchanged.
+  KE2E_CI_PASSTHROUGH_SECRET: ${{ secrets.CF_WORKER_CI_PASSTHROUGH_SECRET }}
 
 jobs:
   # Reclaim debris left by EARLIER runs before this one adds load. `--older-than

--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -474,6 +474,7 @@ export class Client {
     }
     for (const [k, v] of Object.entries(opts?.headers ?? {})) headers.set(k, v);
     this.applyAuth(headers, url);
+    applyCiPassthrough(headers);
 
     const routeTemplate = `${method} ${template}`;
     const timeoutMs = opts?.timeoutMs ?? this.defaultTimeoutMs;
@@ -577,6 +578,24 @@ export class Client {
 
     throw new Error(`request attempt loop exhausted for ${method} ${url}`);
   }
+}
+
+/**
+ * The api-router edge Worker launders any origin 5xx / fetch failure into a
+ * synthetic MAINTENANCE_MODE 503 (worker.mjs, AUTOMATIC_MAINTENANCE). When the
+ * request carries `X-Kortix-CI-Passthrough` matching the Worker's
+ * CI_PASSTHROUGH_SECRET binding, the Worker returns the TRUE origin response
+ * instead, so a release-gate failure is diagnosable. Opt-in via env so local
+ * and unprivileged runs are unchanged. Exported for tests.
+ */
+export const CI_PASSTHROUGH_HEADER = 'x-kortix-ci-passthrough';
+export function applyCiPassthrough(
+  headers: Headers,
+  secret: string | undefined = process.env.KE2E_CI_PASSTHROUGH_SECRET,
+): void {
+  const value = secret?.trim();
+  if (!value) return;
+  if (!headers.has(CI_PASSTHROUGH_HEADER)) headers.set(CI_PASSTHROUGH_HEADER, value);
 }
 
 function record(c: Captured): void {

--- a/tests/unit/client-ci-passthrough.test.ts
+++ b/tests/unit/client-ci-passthrough.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { CI_PASSTHROUGH_HEADER, applyCiPassthrough } from '../src/core/client';
+
+describe('applyCiPassthrough — edge origin-status passthrough opt-in', () => {
+  it('sends nothing when the secret is unset or blank', () => {
+    for (const secret of [undefined, '', '   ']) {
+      const h = new Headers();
+      applyCiPassthrough(h, secret);
+      expect(h.has(CI_PASSTHROUGH_HEADER)).toBe(false);
+    }
+  });
+
+  it('sends the trimmed secret as X-Kortix-CI-Passthrough when set', () => {
+    const h = new Headers();
+    applyCiPassthrough(h, '  s3cret  ');
+    expect(h.get(CI_PASSTHROUGH_HEADER)).toBe('s3cret');
+  });
+
+  it('never overrides a caller-supplied header value', () => {
+    const h = new Headers();
+    h.set(CI_PASSTHROUGH_HEADER, 'explicit');
+    applyCiPassthrough(h, 'from-env');
+    expect(h.get(CI_PASSTHROUGH_HEADER)).toBe('explicit');
+  });
+});


### PR DESCRIPTION
Client half of the edge origin-status passthrough (#6544 ships the Worker half; plan item P3.3).

1. `tests/src/core/client.ts` — new exported `applyCiPassthrough(headers, secret?)`, called from `request()` after `applyAuth`. Sends `X-Kortix-CI-Passthrough: <KE2E_CI_PASSTHROUGH_SECRET>` when the env is set; omitted otherwise; never overrides a caller-supplied value.
2. `.github/workflows/tests-release.yml` — workflow-level env `KE2E_CI_PASSTHROUGH_SECRET: ${{ secrets.CF_WORKER_CI_PASSTHROUGH_SECRET }}` (secret already created in the repo).
3. `tests/unit/client-ci-passthrough.test.ts` — 3 cases (unset/blank → absent; set → trimmed value; caller value wins).

Verification:
- `pnpm --dir tests test:unit` → 31 files / 259 tests passed
- `pnpm --dir tests typecheck` → exit 0
- `actionlint .github/workflows/tests-release.yml` → ok
