### PR TITLE
infra(ecs-api): force_new_deployment when the capacity-provider strategy changes (fixes staging TF apply)

### DIFF
--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -557,6 +557,15 @@ resource "aws_ecs_service" "this" {
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 
+  # The AWS provider refuses to update `capacity_provider_strategy` unless
+  # `force_new_deployment` is set ("force_new_deployment should be true when
+  # capacity_provider_strategy is being updated"). Only services that carry an
+  # on-demand base (staging) ever change that strategy, so gate it on that: dev
+  # and prod keep today's plan byte-for-byte. `task_definition` stays under
+  # ignore_changes, so a forced deployment re-rolls the service's CURRENT task
+  # definition — the one ecs-deploy.sh registered — never a stale TF revision.
+  force_new_deployment = var.fargate_base_on_demand > 0
+
   # Rolling deploy with circuit breaker → auto-rollback on a bad release.
   deployment_circuit_breaker {
     enable   = true


### PR DESCRIPTION
deploy-staging run 32219303623 → job "Apply staging Terraform" failed:

`Error: force_new_deployment should be true when capacity_provider_strategy is being updated`

Cause: #6544 added an on-demand base (`fargate_base_on_demand = 1`) to staging's ECS capacity-provider strategy; the AWS provider requires `force_new_deployment = true` for that update. Downstream deploy jobs were skipped, so staging is still on the previous SHA.

Fix: `infra/terraform/modules/ecs-api/main.tf` `aws_ecs_service.this` — `force_new_deployment = var.fargate_base_on_demand > 0`. Only staging sets a base, so dev/prod plans are byte-identical. `task_definition` remains under `ignore_changes`, so the forced deployment re-rolls the current ecs-deploy.sh-registered task definition.

Verification: `terraform validate` (staging root, TF 1.15.8) → Success; `terraform fmt -check -recursive infra/terraform` → clean.
