### PR TITLE
Release candidate: main → staging (v0.13.0) + Terraform apply fix (#6549)

### DIFF
--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -557,6 +557,15 @@ resource "aws_ecs_service" "this" {
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 
+  # The AWS provider refuses to update `capacity_provider_strategy` unless
+  # `force_new_deployment` is set ("force_new_deployment should be true when
+  # capacity_provider_strategy is being updated"). Only services that carry an
+  # on-demand base (staging) ever change that strategy, so gate it on that: dev
+  # and prod keep today's plan byte-for-byte. `task_definition` stays under
+  # ignore_changes, so a forced deployment re-rolls the service's CURRENT task
+  # definition — the one ecs-deploy.sh registered — never a stale TF revision.
+  force_new_deployment = var.fargate_base_on_demand > 0
+
   # Rolling deploy with circuit breaker → auto-rollback on a bad release.
   deployment_circuit_breaker {
     enable   = true


### PR DESCRIPTION
Carries #6549 (force_new_deployment when the ECS capacity-provider strategy changes) so deploy-staging's Terraform apply succeeds and the downstream API/gateway/web deploy jobs run. Everything else is already in staging via #6548.