### PR TITLE
Release candidate: main → staging (v0.13.0) + sharded-gate runtime fixes (#6552)

### DIFF
--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -55,13 +55,28 @@ export interface RunOptions {
 
 const FLOWS_DIR = resolve(import.meta.dir, "../flows");
 
+// Idempotent on purpose. `flow(...)` registers at module-evaluation time and
+// ES module imports are cached per process, so a SECOND discoverFlows() that
+// clears the registry and re-imports gets nothing back — the flow files never
+// re-execute — and the registry ends up empty. That is exactly what happened
+// on the first sharded release-gate run: `--shard` resolves its ids via
+// discoverFlows(), then runSuite() discovered again → "no flows matched the
+// selected filters" on every API shard (run 32222342409). Discover once.
+let discovered = false;
 export async function discoverFlows(): Promise<void> {
+  if (discovered) return;
   clearRegistry();
   const glob = new Glob("*.flow.ts");
   const files: string[] = [];
   for await (const f of glob.scan({ cwd: FLOWS_DIR, absolute: true })) files.push(f);
   files.sort();
   for (const f of files) await import(f);
+  discovered = true;
+}
+
+/** Test-only: allow a fresh discovery in a process that already discovered. */
+export function __resetDiscoveryForTest(): void {
+  discovered = false;
 }
 
 function selected(f: RegisteredFlow, o: RunOptions): boolean {

--- a/tests/src/fixtures/gc.ts
+++ b/tests/src/fixtures/gc.ts
@@ -111,7 +111,11 @@ async function listTestUsersViaDb(env: Env, domains: string[]): Promise<SupaUser
   const { Client } = await import("pg");
   const client = new Client({
     connectionString: conn,
-    ssl: local ? false : true,
+    // Same policy as database-project.ts / platform-admin.ts: Supabase's direct
+    // Postgres endpoint presents a chain Node's default trust store rejects
+    // ("self signed certificate in certificate chain"), which is what killed
+    // both gc sweeps on the first sharded release-gate run (32222342409).
+    ssl: local ? false : { rejectUnauthorized: false },
   });
   await client.connect();
   try {

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -274,6 +274,6 @@ describe("managed Git fixture selection", () => {
     // The sweep now takes the domain list too, so it can also see the browser
     // suite's accounts — see gc-sweep.test.ts.
     expect(gc).toContain("if (env.databaseUrl) return listTestUsersViaDb(env, domains)");
-    expect(gc).toContain("ssl: local ? false : true");
+    expect(gc).toContain("ssl: local ? false : { rejectUnauthorized: false }");
   });
 });

--- a/tests/unit/discover-flows-idempotent.test.ts
+++ b/tests/unit/discover-flows-idempotent.test.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression for the first sharded release-gate run (32222342409): `--shard`
+ * calls discoverFlows() to plan its ids, then runSuite() calls it again. The
+ * second call used to clearRegistry() and re-import the (cached) flow modules,
+ * which never re-execute — so the registry came back EMPTY and every API shard
+ * died with "no flows matched the selected filters". Run in a subprocess so
+ * this test owns a pristine module graph.
+ */
+function countAfterDoubleDiscover(): { first: number; second: number } {
+  const testsDir = resolve(import.meta.dirname, '..');
+  const script = `
+    const { discoverFlows } = await import(${JSON.stringify(`${testsDir}/src/core/runner.ts`)});
+    const { allFlows } = await import(${JSON.stringify(`${testsDir}/src/core/flow.ts`)});
+    await discoverFlows();
+    const first = allFlows().length;
+    await discoverFlows();
+    const second = allFlows().length;
+    console.log(JSON.stringify({ first, second }));
+  `;
+  const out = execFileSync('bun', ['-e', script], { cwd: testsDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  const lines = out.trim().split('\n');
+  return JSON.parse(lines[lines.length - 1]!);
+}
+
+describe('discoverFlows is idempotent within one process', () => {
+  it('a second discoverFlows() keeps every registered flow', () => {
+    const { first, second } = countAfterDoubleDiscover();
+    expect(first).toBeGreaterThan(400);
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
Carries #6552: discoverFlows() idempotent (API shards ran 0 flows) + gc sweep SSL policy (both sweeps died on Supabase cert chain). First sharded gate run 32222342409 was 12m47s wall clock — the sharding itself works.