### PR TITLE
ci(release-gate): the pre-run sweep can never skip the shards

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -66,7 +66,14 @@ jobs:
           cache: pnpm
       - name: Install runner dependencies
         run: pnpm install --frozen-lockfile --filter @kortix/tests...
+      # Bounded at the STEP so a slow sweep ends as a job *failure* (which
+      # continue-on-error absorbs) — never as a job *cancelled*: on run
+      # 32226539107 the 15-minute job cap fired while gc was still deleting a
+      # day's worth of debris, GitHub recorded the job as cancelled, and every
+      # dependent shard was skipped. A janitor must never be able to skip the
+      # gate. Whatever it did not reach, the next run's sweep gets.
       - name: Reclaim test accounts older than 2h
+        timeout-minutes: 12
         run: bun tests/bin/ke2e.ts gc --older-than 2h
 
   # The deployed API suite, sharded by tests/src/core/shard.ts. Shard 1 owns
@@ -76,6 +83,10 @@ jobs:
   api:
     name: deployed api shard
     needs: sweep-before
+    # The pre-run sweep is best-effort. Run the shards whether it passed,
+    # failed, or was cancelled by its own cap — its result must never gate the
+    # release (see the note on sweep-before).
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     # Shard 1 carries the strictly sequential serial+global tail (35 flows), so
     # it is the critical path until the tail itself is cut. 40 minutes is a real
@@ -157,6 +168,7 @@ jobs:
   browser:
     name: deployed browser shard
     needs: sweep-before
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/tests/unit/sandbox-workflow.test.ts
+++ b/tests/unit/sandbox-workflow.test.ts
@@ -85,6 +85,20 @@ describe('sandbox test workflow', () => {
     // teardown, so the sweep must be wired pre-run and `if: always()` post-run.
     expect(release).toContain('bun tests/bin/ke2e.ts gc --older-than 2h');
     expect(release).toContain('bun tests/bin/ke2e.ts gc --run-id');
+    // The pre-run sweep is a janitor, never a gate. On run 32226539107 its
+    // 15-minute JOB cap fired mid-delete, GitHub recorded the job as
+    // `cancelled` (which continue-on-error does not absorb), and every
+    // dependent shard was skipped. Two guards, both required: the gc STEP is
+    // bounded (a step timeout is a job *failure*), and the shard jobs run
+    // unless the whole workflow was cancelled.
+    const sweepBefore = release.slice(release.indexOf('  sweep-before:'), release.indexOf('  api:'));
+    expect(sweepBefore).toContain('continue-on-error: true');
+    expect(sweepBefore).toMatch(/- name: Reclaim test accounts older than 2h\n\s+timeout-minutes: 12/);
+    for (const job of ['  api:', '  browser:']) {
+      const start = release.indexOf(job);
+      const block = release.slice(start, release.indexOf('runs-on:', start));
+      expect(block, `${job.trim()} must not depend on the janitor's result`).toContain('if: ${{ !cancelled() }}');
+    }
     expect(release).toContain('RELEASE_SOURCE_SHA');
     expect(release).toContain('WEB_PROTECTION_PASSWORD');
     // Staging sits behind Vercel SSO deployment protection, which Basic-auth


### PR DESCRIPTION
Run 32226539107 (release/v0.13.0): `sweep stale test accounts` hit its 15-min **job** timeout while deleting a day's accumulated debris (#6552 was the first time gc could connect). GitHub records a job timeout as `cancelled`, which `continue-on-error: true` does not cover → all 7 shards `skipped` → aggregator failed having run nothing.

1. `.github/workflows/tests-release.yml` sweep-before: the gc **step** gets `timeout-minutes: 12` — a step timeout is a job *failure*, which continue-on-error absorbs.
2. `api` and `browser` jobs: `if: ${{ !cancelled() }}` — run regardless of the janitor's result.
3. `tests/unit/sandbox-workflow.test.ts` pins both (positive control: fails against the previous workflow).

Verification: `actionlint` ok; `pnpm --dir tests test:unit` 260/260 (+ the new pins).
