### PR TITLE
fix(iam): don't cache empty agent object-grant maps (canonical engine) — grants take effect on all replicas immediately

### DIFF
--- a/apps/api/src/__tests__/unit-iam-object-grants-memo.test.ts
+++ b/apps/api/src/__tests__/unit-iam-object-grants-memo.test.ts
@@ -1,0 +1,27 @@
+// The object-grant memo must not cache an EMPTY map for a closed-by-default
+// object type (agent). Invalidation is per-process; a stale empty map on a
+// sibling replica reads as "still closed" and denies a member who was just
+// granted an agent for one TTL (observed on dev 2026-08-19). Open-by-default
+// types keep caching the empty map — a stale empty map there is "still open",
+// which is what the caller already had. Source pin, because the memo's
+// `enableInTests` is off by design and the rule is one line.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(join(import.meta.dir, '../iam/authorize.ts'), 'utf8');
+const flat = source.replace(/\s+/g, ' ');
+
+describe('loadObjectGrants memo — empty map caching', () => {
+  test('never caches an empty map for a closed-by-default object type', () => {
+    expect(flat).toContain(
+      "shouldCache: (map, _projectId, objectType) => map.size > 0 || !CLOSED_BY_DEFAULT_OBJECT_TYPES.has(objectType)",
+    );
+    expect(flat).toContain("CLOSED_BY_DEFAULT_OBJECT_TYPES: ReadonlySet<string> = new Set(['agent'])");
+  });
+
+  test('the unconditional cache-everything rule is gone', () => {
+    const memo = flat.slice(flat.indexOf('const loadObjectGrants = ttlMemo('), flat.indexOf('registerProjectScopedMemo(loadObjectGrants)'));
+    expect(memo).not.toContain('shouldCache: () => true');
+  });
+});

--- a/apps/api/src/iam/authorize.ts
+++ b/apps/api/src/iam/authorize.ts
@@ -692,6 +692,14 @@ export function customRoleAllows(
 
 // ─── Object grants ──────────────────────────────────────────────────────────
 
+/**
+ * Object types whose unscoped default is CLOSED for member-tier (mirrors the
+ * `object_policies` seed: agent closed; skill/secret/app/trigger open). Kept as
+ * a constant here because the memo's caching rule must not itself depend on a
+ * DB read; `unscopedDefaultFor` stays the source of truth for the VERDICT.
+ */
+const CLOSED_BY_DEFAULT_OBJECT_TYPES: ReadonlySet<string> = new Set(['agent']);
+
 interface ObjectGrantPrincipal {
   principalType: string;
   principalId: string;
@@ -700,11 +708,15 @@ interface ObjectGrantPrincipal {
 /**
  * (project, objectType) -> objectId -> the principals granted it.
  *
- * The EMPTY map is cached, unlike every other authz memo. That is deliberate
- * and pre-existing: "this project scopes nothing" is the common, hot case, and
- * every mutation busts the project entry synchronously on the writing replica.
- * The trade is that a grant CREATE can lag one TTL window on a replica that did
- * not perform the write, where a role grant is instant.
+ * The EMPTY map is cached only for object types whose unscoped default is OPEN
+ * (skill, secret, app, trigger): there a stale empty map means "still open",
+ * which is the state the caller already had. For CLOSED-by-default types (agent)
+ * a stale empty map would mean "still closed" — invalidation is per-process, so
+ * a member granted an agent kept getting 403 for one TTL on every replica that
+ * had not seen the write (measured on dev 2026-08-19: create 403, then 201 ×3
+ * after the TTL). One extra indexed query per uncached check is the price of a
+ * grant taking effect on every replica at once — the same rule the legacy
+ * `loadProjectResourceGrants` memo already applies (#6535).
  */
 const loadObjectGrants = ttlMemo({
   ttlMs: TTL_MS,
@@ -735,7 +747,8 @@ const loadObjectGrants = ttlMemo({
     }
     return map;
   },
-  shouldCache: () => true,
+  shouldCache: (map, _projectId, objectType) =>
+    map.size > 0 || !CLOSED_BY_DEFAULT_OBJECT_TYPES.has(objectType),
 });
 registerProjectScopedMemo(loadObjectGrants);
 


### PR DESCRIPTION
Observed on dev-api `3d876d755d` right after deploy: `POST /iam/assignments` (agent-user on agent X for a member) → 201, then that member's `POST /projects/:id/sessions {agent_name:X}` → **403** for ~15 s, then 201 ×3.

Cause: the canonical engine's `loadObjectGrants` memo (per-process, 15 s TTL) cached the EMPTY map for every object type; invalidation only reaches the replica that handled the write. Agents are closed-by-default for member-tier, so a stale empty map = "still closed" on the other replicas — the exact class fixed for the legacy memo in #6535, re-introduced by the new engine.

Fix: cache an empty map only for open-by-default object types (skill/secret/app/trigger); for closed-by-default types (`agent`) re-read (one indexed query). Verdict source of truth (`unscopedDefaultFor` / `object_policies`) unchanged.

Tests: new `unit-iam-object-grants-memo.test.ts` (source pin); `rbac-parity.ts` still 19,760 / 0; `apps/api tsc` 0.
