### PR TITLE
fix(iam): GET /projects/:id/group-grants requires project.members.manage (Strix MEDIUM)

### DIFF
--- a/apps/api/src/__tests__/integration-members-manage-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-members-manage-gates-http.test.ts
@@ -182,6 +182,10 @@ interface EP {
 
 const ENDPOINTS: EP[] = [
   { name: 'GET /audit', method: 'GET', path: () => `/v1/projects/${PROJECT}/audit` },
+  // The GET is manager-only too: it exposes member_count / override_count and
+  // the group→project topology. It was gated on project.session.read until the
+  // v0.13.0 release review caught it (Strix, CWE-863).
+  { name: 'GET /group-grants', method: 'GET', path: () => `/v1/projects/${PROJECT}/group-grants` },
   { name: 'POST /group-grants', method: 'POST', path: () => `/v1/projects/${PROJECT}/group-grants`, body: {} },
   { name: 'PATCH /group-grants/{id}', method: 'PATCH', path: () => `/v1/projects/${PROJECT}/group-grants/${crypto.randomUUID()}`, body: {} },
   { name: 'DELETE /group-grants/{id}', method: 'DELETE', path: () => `/v1/projects/${PROJECT}/group-grants/${crypto.randomUUID()}` },

--- a/apps/api/src/projects/routes/group-grants.ts
+++ b/apps/api/src/projects/routes/group-grants.ts
@@ -46,7 +46,13 @@ projectsApp.openapi(
   const projectId = c.req.param('projectId');
   const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
-  await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_READ);
+  // Manager-only, like the POST/PATCH/DELETE siblings in this file and the
+  // contract in accounts/iam/groups.ts ("those routes gate on
+  // project.members.manage"). The listing carries member_count /
+  // override_count that the rest of the IAM surface treats as manager data;
+  // gating it on project.session.read let any baseline project member read
+  // it (Strix, v0.13.0 release review, CWE-863).
+  await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
 
   // From `role_assignments`, the store the engine reads. The group NAME is
   // still identity data on `account_groups`, and the inner-join semantics are


### PR DESCRIPTION
Strix finding on release PR #6559 (MEDIUM, CWE-863): `GET /v1/projects/:projectId/group-grants` authorized with `PROJECT_SESSION_READ`; baseline project members hold that, so they could list group→project grants + `member_count`/`override_count`. Now `PROJECT_MEMBERS_MANAGE`, matching POST/PATCH/DELETE in the same file and the contract in `accounts/iam/groups.ts:474`. No web caller today (SDK-only). Regression test: GET added to the ENDPOINTS matrix in `integration-members-manage-gates-http.test.ts` (WRITER → 403). Strix's exact suggested diff.