### PR TITLE
feat(sandbox): add flagged fast cold boot runtime

### DIFF
--- a/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
+++ b/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
@@ -201,6 +201,14 @@ mock.module('../snapshots/builder', () => ({
     built: false,
     isDefault: true,
   }),
+  ensureFastSandboxImage: async () => ({
+    snapshotName: 'kortix-fast-test',
+    slug: 'default',
+    contentHash: 'f'.repeat(64),
+    built: false,
+    isDefault: true,
+    runtimeProfile: 'fast',
+  }),
   ensureMetaSandboxImage: async () => ({
     snapshotName: 'kortix-meta-test',
     slug: 'meta',

--- a/apps/api/src/__tests__/e2e-project-limit.test.ts
+++ b/apps/api/src/__tests__/e2e-project-limit.test.ts
@@ -149,6 +149,7 @@ mock.module('../projects/git', () => ({
 
 mock.module('../snapshots/builder', () => ({
   ensureSandboxImage: async () => ({ snapshotName: 'kortix-default-test', slug: 'default', contentHash: 'a'.repeat(64), built: false, isDefault: true }),
+  ensureFastSandboxImage: async () => ({ snapshotName: 'kortix-fast-test', slug: 'default', contentHash: 'f'.repeat(64), built: false, isDefault: true, runtimeProfile: 'fast' }),
   ensureMetaSandboxImage: async () => ({ snapshotName: 'kortix-meta-test', slug: 'meta', contentHash: 'b'.repeat(64), built: false, isDefault: false }),
   deleteSandboxImage: async () => ({ deleted: false, snapshotName: 'kortix-default-test', slug: 'default' }),
   listSnapshotBuilds: async () => [],

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -300,6 +300,14 @@ mock.module('../snapshots/builder', () => ({
     built: false,
     isDefault: true,
   }),
+  ensureFastSandboxImage: async () => ({
+    snapshotName: 'kortix-fast-test',
+    slug: 'default',
+    contentHash: 'f'.repeat(64),
+    built: false,
+    isDefault: true,
+    runtimeProfile: 'fast',
+  }),
   ensureMetaSandboxImage: async () => ({
     snapshotName: 'kortix-meta-test',
     slug: 'meta',

--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -205,6 +205,7 @@ mock.module('../projects/git', () => ({
 
 mock.module("../snapshots/builder", () => ({
   ensureSandboxImage: async () => ({ snapshotName: "kortix-default-test", slug: "default", contentHash: "a".repeat(64), built: false, isDefault: true }),
+  ensureFastSandboxImage: async () => ({ snapshotName: "kortix-fast-test", slug: "default", contentHash: "f".repeat(64), built: false, isDefault: true, runtimeProfile: "fast" }),
   ensureMetaSandboxImage: async () => ({ snapshotName: "kortix-meta-test", slug: "meta", contentHash: "b".repeat(64), built: false, isDefault: false }),
   deleteSandboxImage: async () => ({ deleted: false, snapshotName: "kortix-default-test", slug: "default" }),
   listSnapshotBuilds: async () => [],

--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -269,6 +269,7 @@ mock.module('../projects/lib/project-deletion', () => ({
 
 mock.module("../snapshots/builder", () => ({
   ensureSandboxImage: async () => ({ snapshotName: "kortix-default-test", slug: "default", contentHash: "a".repeat(64), built: false, isDefault: true }),
+  ensureFastSandboxImage: async () => ({ snapshotName: "kortix-fast-test", slug: "default", contentHash: "f".repeat(64), built: false, isDefault: true, runtimeProfile: "fast" }),
   ensureMetaSandboxImage: async () => ({ snapshotName: "kortix-meta-test", slug: "meta", contentHash: "b".repeat(64), built: false, isDefault: false }),
   deleteSandboxImage: async () => ({ deleted: false, snapshotName: "kortix-default-test", slug: "default" }),
   listSnapshotBuilds: async () => [],

--- a/apps/api/src/__tests__/e2e-projects-provision.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-provision.test.ts
@@ -177,6 +177,7 @@ mock.module('../projects/git', () => ({
 
 mock.module("../snapshots/builder", () => ({
   ensureSandboxImage: async () => ({ snapshotName: "kortix-default-test", slug: "default", contentHash: "a".repeat(64), built: false, isDefault: true }),
+  ensureFastSandboxImage: async () => ({ snapshotName: "kortix-fast-test", slug: "default", contentHash: "f".repeat(64), built: false, isDefault: true, runtimeProfile: "fast" }),
   ensureMetaSandboxImage: async () => ({ snapshotName: "kortix-meta-test", slug: "meta", contentHash: "b".repeat(64), built: false, isDefault: false }),
   deleteSandboxImage: async () => ({ deleted: false, snapshotName: "kortix-default-test", slug: "default" }),
   listSnapshotBuilds: async () => [],

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -484,6 +484,10 @@ const envSchema = z.object({
   // bakes. Provider transitions still prepare their target image explicitly.
   // Default OFF keeps the session path on one shared image per provider.
   KORTIX_WARM_SNAPSHOT_ENABLED: optBoolFalse,
+  // Experimental shared slim image. It keeps only the session-critical
+  // runtime in the cold image and installs browser/document tool packs on first
+  // use. Default OFF is the rollback path; no database state changes.
+  KORTIX_FAST_COLD_BOOT_ENABLED: optBoolFalse,
   // Per-provider allowlist for per-project warm images of CUSTOM (non-default-
   // slug) templates — see `perProjectWarmEligible` in builder.ts. Defaults to
   // 'platinum' only: Platinum's per-project templates warm-miss 100% of the
@@ -1063,6 +1067,7 @@ export const config = {
   DAYTONA_WEBHOOK_SECRET: env.DAYTONA_WEBHOOK_SECRET,
   KORTIX_SNAPSHOT_REAP_PREDECESSOR: env.KORTIX_SNAPSHOT_REAP_PREDECESSOR,
   KORTIX_WARM_SNAPSHOT_ENABLED: env.KORTIX_WARM_SNAPSHOT_ENABLED,
+  KORTIX_FAST_COLD_BOOT_ENABLED: env.KORTIX_FAST_COLD_BOOT_ENABLED,
 
   // Sandbox lifecycle intervals (minutes) — see schema comment above.
   KORTIX_SANDBOX_AUTOSTOP_MINUTES: env.KORTIX_SANDBOX_AUTOSTOP_MINUTES,

--- a/apps/api/src/platform/services/session-boot-decision.test.ts
+++ b/apps/api/src/platform/services/session-boot-decision.test.ts
@@ -19,7 +19,12 @@ setTestEnv('PLATINUM_API_URL', 'https://platinum.test');
 setTestEnv('PLATINUM_API_KEY', 'pt_live_testkey');
 setTestEnv('DAYTONA_API_KEY', 'dt_test');
 
-const { decideSessionBoot, sessionBootByTemplateIdEnabled } = await import('./session-sandbox');
+const {
+  decideSessionBoot,
+  fastColdBootEnabled,
+  sessionBootByTemplateIdEnabled,
+  useFastColdBootImage,
+} = await import('./session-sandbox');
 
 const pinned = { activeProvider: 'platinum', activeExternalTemplateId: 'tpl_pinned' };
 
@@ -116,5 +121,35 @@ describe('FIX-A kill-switch — KORTIX_SESSION_BOOT_BY_TEMPLATE_ID', () => {
   test.each(['1', 'on', 'true'])('%p keeps id-boot ON', (v) => {
     process.env.KORTIX_SESSION_BOOT_BY_TEMPLATE_ID = v;
     expect(sessionBootByTemplateIdEnabled()).toBe(true);
+  });
+});
+
+describe('fast cold boot kill-switch', () => {
+  const saved = process.env.KORTIX_FAST_COLD_BOOT_ENABLED;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.KORTIX_FAST_COLD_BOOT_ENABLED;
+    else process.env.KORTIX_FAST_COLD_BOOT_ENABLED = saved;
+  });
+
+  test('defaults OFF', () => {
+    delete process.env.KORTIX_FAST_COLD_BOOT_ENABLED;
+    expect(fastColdBootEnabled()).toBe(false);
+  });
+
+  test.each(['1', 'on', 'true', 'yes', 'TRUE'])('%p enables the fast image', (value) => {
+    process.env.KORTIX_FAST_COLD_BOOT_ENABLED = value;
+    expect(fastColdBootEnabled()).toBe(true);
+  });
+
+  test.each(['0', 'off', 'false', 'no', 'unexpected'])('%p keeps the standard image', (value) => {
+    process.env.KORTIX_FAST_COLD_BOOT_ENABLED = value;
+    expect(fastColdBootEnabled()).toBe(false);
+  });
+
+  test('only changes the shared default image', () => {
+    expect(useFastColdBootImage(true, 'default')).toBe(true);
+    expect(useFastColdBootImage(true, 'custom')).toBe(false);
+    expect(useFastColdBootImage(true, 'meta')).toBe(false);
+    expect(useFastColdBootImage(false, 'default')).toBe(false);
   });
 });

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -33,7 +33,7 @@
 // file-scoped — batching many files into one `bun test a b c...` invocation
 // can leak mocks/cached module instances across files. See the same caveat
 // documented in ../../projects/sandbox-reaper.test.ts.
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import { PROVISIONING_SESSION_STATUSES } from '../../projects/lib/session-status';
@@ -78,6 +78,7 @@ let providerFallbackEnabled = false;
 let providerNamesRequested: string[] = [];
 let providerCreateErrors: Record<string, string | undefined> = {};
 let imageRequests: Array<Record<string, unknown>> = [];
+let fastImageRequests: Array<Record<string, unknown>> = [];
 let accountTokenCreateCalls: Array<Record<string, unknown>> = [];
 let serviceAccountCreateCalls: Array<Record<string, unknown>> = [];
 
@@ -243,6 +244,17 @@ mock.module('../../snapshots/builder', () => ({
       built: false,
     };
   },
+  ensureFastSandboxImage: async (opts: Record<string, unknown>) => {
+    fastImageRequests.push(opts);
+    return {
+      snapshotName: 'kortix-fast-dev-test',
+      slug: 'default',
+      contentHash: 'fast-hash-1',
+      isDefault: true,
+      built: false,
+      runtimeProfile: 'fast',
+    };
+  },
   deleteSandboxImage: async () => {},
   resolveTemplate: async (_project: unknown, _slug: unknown) => ({}),
 }));
@@ -338,8 +350,13 @@ beforeEach(() => {
   providerNamesRequested = [];
   providerCreateErrors = {};
   imageRequests = [];
+  fastImageRequests = [];
   accountTokenCreateCalls = [];
   serviceAccountCreateCalls = [];
+});
+
+afterEach(() => {
+  delete process.env.KORTIX_FAST_COLD_BOOT_ENABLED;
 });
 
 function baseOpts() {
@@ -391,6 +408,28 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
 
     expect(imageRequests[0]).toMatchObject({ source: 'session-start' });
     expect(imageRequests[0]).not.toHaveProperty('requireCurrentRuntime');
+  });
+
+  test('the fast flag selects the shared fast image without changing the project template', async () => {
+    process.env.KORTIX_FAST_COLD_BOOT_ENABLED = 'true';
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
+
+    await provisionSessionSandbox(baseOpts());
+    await opened;
+
+    expect(fastImageRequests).toEqual([{ source: 'session-start', provider: 'daytona' }]);
+    expect(imageRequests).toEqual([]);
+    const finishCall = updateCalls.find(
+      (call) => call.table === sessionSandboxes && 'externalId' in call.updates && 'config' in call.updates,
+    );
+    expect(finishCall?.updates.metadata).toMatchObject({
+      runtimeArtifact: {
+        providerArtifactRef: 'kortix-fast-dev-test',
+        runtimeProfile: 'fast',
+      },
+    });
   });
 
   test('E2B success records only provider-neutral lifecycle metadata and E2B billing attribution', async () => {

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -38,6 +38,7 @@ import {
 } from './sandbox-init-state';
 import {
   ensureSandboxImage,
+  ensureFastSandboxImage,
   ensureMetaSandboxImage,
   deleteSandboxImage,
   resolveTemplate,
@@ -205,6 +206,17 @@ export function sessionBootByTemplateIdEnabled(): boolean {
   return !(raw === '0' || raw === 'off' || raw === 'false' || raw === 'no');
 }
 
+/** Default-off kill switch for the shared slim cold-boot image. */
+export function fastColdBootEnabled(): boolean {
+  const raw = (process.env.KORTIX_FAST_COLD_BOOT_ENABLED ?? '').trim().toLowerCase();
+  return raw === '1' || raw === 'on' || raw === 'true' || raw === 'yes';
+}
+
+/** Custom and meta templates keep their declared runtime under the global flag. */
+export function useFastColdBootImage(enabled: boolean, slug: string): boolean {
+  return enabled && slug === DEFAULT_SANDBOX_SLUG;
+}
+
 /**
  * FIX-A: decide whether this boot should use the pinned EXACT template id. Pure
  * (no I/O) so the gate is unit-testable. Returns the id ONLY when every guard
@@ -337,6 +349,8 @@ export async function provisionSessionSandbox(opts: {
   ): Promise<EnsureSandboxImageResult> =>
     slug === META_SANDBOX_SLUG
       ? ensureMetaSandboxImage({ source: 'session-start', provider: targetProvider })
+      : useFastColdBootImage(fastColdBootEnabled(), slug)
+        ? ensureFastSandboxImage({ source: 'session-start', provider: targetProvider })
       : ensureSandboxImage(gitProject, {
           slug,
           accountId,
@@ -554,7 +568,13 @@ export async function provisionSessionSandbox(opts: {
     // Provider failover (one-shot, on init): set true once we've handed off to a
     // second provider, so a session never bounces between providers forever.
     let fallbackAttempted = false;
-    let imageInfo: { snapshotName: string; slug: string; contentHash: string; isDefault: boolean } | null = null;
+    let imageInfo: {
+      snapshotName: string;
+      slug: string;
+      contentHash: string;
+      isDefault: boolean;
+      runtimeProfile?: 'standard' | 'fast' | 'meta';
+    } | null = null;
     // FIX-A: the project's ACTIVATED routing pin (provider + exact template id),
     // read once, best-effort — a DB hiccup yields null → name-boot. Set
     // `idBootDisabled` once a definitive GC'd-pin 404 forces this session down to
@@ -624,6 +644,7 @@ export async function provisionSessionSandbox(opts: {
         slug: image.slug,
         contentHash: image.contentHash,
         isDefault: image.isDefault,
+        runtimeProfile: image.runtimeProfile,
       };
       tl.mark(image.built ? 'image-built' : 'image-cached');
       providerCreateInput.snapshot = image.snapshotName;
@@ -642,7 +663,10 @@ export async function provisionSessionSandbox(opts: {
         routing: activeRouting,
         providerName,
         providerSupportsIdBoot: typeof provider.createFromExternalId === 'function',
-        imageIsDefault: image.isDefault,
+        // A Platinum pin identifies the standard default template. The fast
+        // profile has its own content-addressed name and must never boot that
+        // standard pin by mistake.
+        imageIsDefault: image.isDefault && image.runtimeProfile !== 'fast',
         disabledForSession: idBootDisabled,
       });
       if (bootDecision.bootByTemplateId) {
@@ -879,6 +903,7 @@ export async function provisionSessionSandbox(opts: {
               contentHash: imageInfo!.contentHash,
               sandboxSlug: imageInfo!.slug,
               isPlatformDefault: imageInfo!.isDefault,
+              runtimeProfile: imageInfo!.runtimeProfile ?? 'standard',
               branch,
               provider: providerName,
             },

--- a/apps/api/src/snapshots/build-context.ts
+++ b/apps/api/src/snapshots/build-context.ts
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { createGzip } from 'node:zlib';
 import { AGENT_BROWSER_VERSION, OPENCODE_VERSION } from '@kortix/shared';
-import { buildMetaSandboxDockerfile } from '@kortix/shared/sandbox';
+import { buildFastSandboxDockerfile, buildMetaSandboxDockerfile } from '@kortix/shared/sandbox';
 import { gatewayModelCatalog } from '../llm-gateway/models/catalog-models';
 import { managedSkillOverlayFiles } from '../runtime-assets/managed-skills';
 import { appCaddyBinaryPath, appdBinaryPath } from '../apps/runtime-artifacts';
@@ -70,6 +70,12 @@ const opencodeWarmupSrcPath = () => process.env.KORTIX_SNAPSHOT_OPENCODE_WARMUP_
   || resolve(REPO_ROOT, 'apps/sandbox/opencode-warmup.sh');
 const machineDocSrcPath = () => process.env.KORTIX_SNAPSHOT_MACHINE_DOC_PATH
   || resolve(REPO_ROOT, 'apps/sandbox/MACHINE.md');
+const fastMachineDocSrcPath = () => process.env.KORTIX_SNAPSHOT_FAST_MACHINE_DOC_PATH
+  || resolve(REPO_ROOT, 'apps/sandbox/MACHINE.fast.md');
+const lazyToolsSrcPath = () => process.env.KORTIX_SNAPSHOT_LAZY_TOOLS_PATH
+  || resolve(REPO_ROOT, 'apps/sandbox/lazy-tools');
+const runtimeVersionsSrcPath = () => process.env.KORTIX_SNAPSHOT_RUNTIME_VERSIONS_PATH
+  || resolve(REPO_ROOT, 'packages/shared/src/runtime-versions.json');
 
 function readPositiveIntEnv(name: string, fallback: number): number {
   const raw = Number.parseInt(process.env[name] || '', 10);
@@ -173,6 +179,30 @@ async function stageManagedSkills(outDir: string): Promise<void> {
   }
 }
 
+async function assertRuntimeArtifactsCurrent(
+  agentPath: string,
+  cliPath: string,
+  attestationPath: string,
+): Promise<void> {
+  if (!process.env.KORTIX_SNAPSHOT_AGENT_BIN_PATH) {
+    const binMtime = (await stat(agentPath)).mtimeMs;
+    const srcDir = resolve(REPO_ROOT, 'apps/kortix-sandbox-agent-server/src');
+    const newestSrc = await newestMtimeMs(srcDir);
+    if (newestSrc > binMtime) {
+      throw new Error(
+        `kortix-agent dist binary (${agentPath}) is older than its source ` +
+          `(${srcDir}) — run \`bun run build\` in apps/kortix-sandbox-agent-server ` +
+          `or the image will bake stale code under a fresh content hash`,
+      );
+    }
+  }
+  await assertCliArtifactAttested({
+    cliRoot: resolve(REPO_ROOT, 'apps/cli'),
+    binaryPath: cliPath,
+    attestationPath,
+  });
+}
+
 export async function stageMetaBuildContext(): Promise<StagedContext> {
   const agentPath = agentBinPath();
   const cliPath = cliBinPath();
@@ -204,6 +234,120 @@ export async function stageMetaBuildContext(): Promise<StagedContext> {
     }),
   );
   return { contextDir, composedPath, dockerfileName };
+}
+
+/** Stage the shared slim runtime selected by KORTIX_FAST_COLD_BOOT_ENABLED. */
+export async function stageFastBuildContext(): Promise<StagedContext> {
+  const agentPath = agentBinPath();
+  const cliPath = cliBinPath();
+  const entrypointPath = entrypointSrcPath();
+  const opencodeWarmupPath = opencodeWarmupSrcPath();
+  const slackPath = slackCliSrcPath();
+  const machinePath = fastMachineDocSrcPath();
+  const lazyToolsPath = lazyToolsSrcPath();
+  const runtimeVersionsPath = runtimeVersionsSrcPath();
+  const opencodeConfigPath = opencodeConfigSrcPath();
+
+  await assertExists(agentPath, 'KORTIX_SNAPSHOT_AGENT_BIN_PATH');
+  await assertExists(cliPath, 'KORTIX_SNAPSHOT_CLI_BIN_PATH');
+  await assertExists(entrypointPath, 'KORTIX_SNAPSHOT_ENTRYPOINT_PATH');
+  await assertExists(opencodeWarmupPath, 'KORTIX_SNAPSHOT_OPENCODE_WARMUP_PATH');
+  await assertExists(machinePath, 'KORTIX_SNAPSHOT_FAST_MACHINE_DOC_PATH');
+  await assertExists(runtimeVersionsPath, 'KORTIX_SNAPSHOT_RUNTIME_VERSIONS_PATH');
+  await assertExistsDir(slackPath, 'KORTIX_SNAPSHOT_SLACK_CLI_PATH');
+  await assertExistsDir(lazyToolsPath, 'KORTIX_SNAPSHOT_LAZY_TOOLS_PATH');
+  await assertExistsDir(opencodeConfigPath, 'KORTIX_SNAPSHOT_OPENCODE_CONFIG_PATH');
+  await assertRuntimeArtifactsCurrent(agentPath, cliPath, cliAttestationPath());
+
+  const contextDir = await mkdtemp(join(tmpdir(), 'kortix-fast-snap-'));
+  try {
+    await gzipFile(agentPath, join(contextDir, 'kortix-agent.gz'));
+    await gzipFile(cliPath, join(contextDir, 'kortix.gz'));
+    await copyFile(entrypointPath, join(contextDir, 'kortix-entrypoint'));
+    await copyFile(opencodeWarmupPath, join(contextDir, 'kortix-opencode-warmup'));
+    await copyFile(machinePath, join(contextDir, 'MACHINE.fast.md'));
+    await copyFile(runtimeVersionsPath, join(contextDir, 'runtime-versions.json'));
+    await cp(slackPath, join(contextDir, 'kortix-slack-cli'), { recursive: true });
+    await cp(lazyToolsPath, join(contextDir, 'lazy-tools'), { recursive: true });
+    await cp(opencodeConfigPath, join(contextDir, 'kortix-opencode-config'), { recursive: true });
+    await stageManagedSkills(join(contextDir, 'managed-skills'));
+    await writeFileFs(
+      join(contextDir, 'kortix-llm-catalog.json'),
+      JSON.stringify({ models: gatewayModelCatalog('shared-seed') }),
+    );
+    await stageScaffoldRepo(contextDir);
+
+    const dockerfileName = 'Dockerfile';
+    const composedPath = join(contextDir, dockerfileName);
+    const composed = buildFastSandboxDockerfile({
+      agentBinaryPath: 'kortix-agent.gz',
+      cliBinaryPath: 'kortix.gz',
+      entrypointScriptPath: 'kortix-entrypoint',
+      opencodeWarmupScriptPath: 'kortix-opencode-warmup',
+      machineDocPath: 'MACHINE.fast.md',
+      slackCliPath: 'kortix-slack-cli',
+      lazyToolsPath: 'lazy-tools',
+      catalogPath: 'kortix-llm-catalog.json',
+      managedSkillsPath: 'managed-skills',
+      runtimeVersionsPath: 'runtime-versions.json',
+      opencodeConfigPath: 'kortix-opencode-config',
+      scaffoldPath: 'scaffold.git',
+    });
+    await guardBuildahPortable(composed);
+    await writeComposedDockerfile(composedPath, composed);
+    for (const required of [
+      dockerfileName,
+      'kortix-agent.gz',
+      'kortix.gz',
+      'kortix-entrypoint',
+      'kortix-opencode-warmup',
+      'MACHINE.fast.md',
+      'runtime-versions.json',
+      'kortix-slack-cli',
+      'lazy-tools/install',
+      'kortix-opencode-config',
+      'managed-skills',
+      'kortix-llm-catalog.json',
+      'scaffold.git',
+    ]) {
+      await stat(join(contextDir, required)).catch(() => {
+        throw new Error(`fast build context staging incomplete: ${required} missing in ${contextDir}`);
+      });
+    }
+    return { contextDir, composedPath, dockerfileName };
+  } catch (error) {
+    await rm(contextDir, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+export type RuntimeBuildProfile = 'standard' | 'fast' | 'meta' | 'app';
+
+/** Select one runtime renderer for every provider adapter. */
+export async function stageRuntimeBuildContext(input: {
+  snapshotName: string;
+  userDockerfile: string;
+  runtimeProfile?: RuntimeBuildProfile;
+  appContext?: { sourceDir?: string; runtimeSpec: Record<string, unknown> };
+  warmRepo?: WarmRepoContext;
+  isShared?: boolean;
+}): Promise<StagedContext> {
+  switch (input.runtimeProfile) {
+    case 'app':
+      if (!input.appContext) throw new Error('app runtime profile requires appContext');
+      return stageAppBuildContext(input.snapshotName, input.userDockerfile, input.appContext);
+    case 'meta':
+      return stageMetaBuildContext();
+    case 'fast':
+      return stageFastBuildContext();
+    default:
+      return stageBuildContext(
+        input.snapshotName,
+        input.userDockerfile,
+        input.warmRepo,
+        input.isShared,
+      );
+  }
 }
 
 /**

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -98,6 +98,7 @@ export interface EnsureSandboxImageResult {
   contentHash: string;
   built: boolean;
   isDefault: boolean;
+  runtimeProfile?: 'standard' | 'fast' | 'meta';
 }
 
 /**
@@ -1305,6 +1306,7 @@ function currentMetaRuntimeFingerprint(): Promise<string> {
       { label: 'cli', path: resolve(root, 'apps/cli/src') },
       { label: 'cli-package', path: resolve(root, 'apps/cli/package.json') },
       { label: 'entrypoint', path: resolve(root, 'apps/sandbox/entrypoint.sh') },
+      { label: 'opencode-warmup', path: resolve(root, 'apps/sandbox/opencode-warmup.sh') },
       { label: 'meta-renderer', path: resolve(root, 'packages/shared/src/sandbox/meta-dockerfile.ts') },
       { label: 'sdk', path: resolve(root, 'packages/sdk/src') },
       { label: 'llm-catalog', path: resolve(root, 'packages/llm-catalog/src') },
@@ -1327,7 +1329,7 @@ function currentMetaRuntimeFingerprint(): Promise<string> {
  * image is still the current one for whoever has not restarted yet. Deleting it
  * underneath them would break meta sandbox creation mid-rollout.
  */
-const META_REAP_PROTECT_MS = 60 * 60 * 1000;
+const RUNTIME_REAP_PROTECT_MS = 60 * 60 * 1000;
 
 /** Names are `kortix-meta-<env>-<hash16>`; see `metaSnapshotName`. */
 const META_SNAPSHOT_PREFIX = 'kortix-meta';
@@ -1401,8 +1403,24 @@ export async function reapSupersededMetaSnapshots(
   /** Test seam for the protection lookup; production uses the strict query. */
   recentLookup: (names: string[], withinMs: number) => Promise<Set<string>> = recentlyBuiltStrict,
 ): Promise<void> {
+  return reapSupersededEnvironmentRuntimeSnapshots(
+    provider,
+    META_SNAPSHOT_PREFIX,
+    'meta',
+    keepName,
+    recentLookup,
+  );
+}
+
+async function reapSupersededEnvironmentRuntimeSnapshots(
+  provider: Pick<SandboxProviderAdapter, 'listSnapshots' | 'deleteSnapshot'>,
+  snapshotPrefix: string,
+  logLabel: string,
+  keepName: string,
+  recentLookup: (names: string[], withinMs: number) => Promise<Set<string>>,
+): Promise<void> {
   try {
-    const mine = `${META_SNAPSHOT_PREFIX}-${config.INTERNAL_KORTIX_ENV}-`;
+    const mine = `${snapshotPrefix}-${config.INTERNAL_KORTIX_ENV}-`;
     const candidates = (await provider.listSnapshots())
       .map((snapshot: { name: string }) => snapshot.name)
       .filter((name: string) => name.startsWith(mine) && name !== keepName);
@@ -1414,20 +1432,121 @@ export async function reapSupersededMetaSnapshots(
     // throw here lands in the outer catch and skips the reap entirely, which is
     // the right trade: an extra stale image costs one snapshot slot, deleting a
     // live one breaks meta sandbox creation for the whole environment.
-    const recent = await recentLookup(candidates, META_REAP_PROTECT_MS);
+    const recent = await recentLookup(candidates, RUNTIME_REAP_PROTECT_MS);
     for (const name of candidates) {
       if (recent.has(name)) {
-        console.log(`[snapshots] meta: keeping ${name} (built recently — a replica may still boot it)`);
+        console.log(`[snapshots] ${logLabel}: keeping ${name} (built recently — a replica may still boot it)`);
         continue;
       }
       await provider.deleteSnapshot(name);
-      console.log(`[snapshots] meta: reaped superseded ${name}`);
+      console.log(`[snapshots] ${logLabel}: reaped superseded ${name}`);
     }
   } catch (err) {
     console.warn(
-      `[snapshots] meta: reap skipped: ${err instanceof Error ? err.message : String(err)}`,
+      `[snapshots] ${logLabel}: reap skipped: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+}
+
+const FAST_SNAPSHOT_PREFIX = 'kortix-fast';
+const fastImageBuilds = new Map<string, Promise<EnsureSandboxImageResult>>();
+let fastRuntimeFingerprint: Promise<string> | null = null;
+
+function currentFastRuntimeFingerprint(): Promise<string> {
+  if (fastRuntimeFingerprint) return fastRuntimeFingerprint;
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+  fastRuntimeFingerprint = buildRuntimeArtifactFingerprint({
+    sandboxVersion: `fast-v1:opencode:${OPENCODE_VERSION}`,
+    opencodeVersion: OPENCODE_VERSION,
+    artifacts: [
+      { label: 'agent', path: resolve(root, 'apps/kortix-sandbox-agent-server/src') },
+      { label: 'agent-package', path: resolve(root, 'apps/kortix-sandbox-agent-server/package.json') },
+      { label: 'cli', path: resolve(root, 'apps/cli/src') },
+      { label: 'cli-package', path: resolve(root, 'apps/cli/package.json') },
+      { label: 'entrypoint', path: resolve(root, 'apps/sandbox/entrypoint.sh') },
+      { label: 'machine', path: resolve(root, 'apps/sandbox/MACHINE.fast.md') },
+      { label: 'lazy-tools', path: resolve(root, 'apps/sandbox/lazy-tools') },
+      { label: 'fast-renderer', path: resolve(root, 'packages/shared/src/sandbox/fast-dockerfile.ts') },
+      { label: 'runtime-versions', path: resolve(root, 'packages/shared/src/runtime-versions.json') },
+      { label: 'sdk', path: resolve(root, 'packages/sdk/src') },
+      { label: 'llm-catalog', path: resolve(root, 'packages/llm-catalog/src') },
+      { label: 'manifest-schema', path: resolve(root, 'packages/manifest-schema/src') },
+      { label: 'registry', path: resolve(root, 'packages/registry/src') },
+      { label: 'shared', path: resolve(root, 'packages/shared/src') },
+      { label: 'starter', path: resolve(root, 'packages/starter/src') },
+      { label: 'starter-templates', path: resolve(root, 'packages/starter/templates') },
+    ],
+  });
+  return fastRuntimeFingerprint;
+}
+
+export function fastSnapshotName(contentHash: string): string {
+  return `${FAST_SNAPSHOT_PREFIX}-${config.INTERNAL_KORTIX_ENV}-${contentHash.slice(0, 16)}`;
+}
+
+export async function reapSupersededFastSnapshots(
+  provider: Pick<SandboxProviderAdapter, 'listSnapshots' | 'deleteSnapshot'>,
+  keepName: string,
+  recentLookup: (names: string[], withinMs: number) => Promise<Set<string>> = recentlyBuiltStrict,
+): Promise<void> {
+  return reapSupersededEnvironmentRuntimeSnapshots(
+    provider,
+    FAST_SNAPSHOT_PREFIX,
+    'fast',
+    keepName,
+    recentLookup,
+  );
+}
+
+export async function ensureFastSandboxImage(opts: {
+  source?: SnapshotBuildSource;
+  provider: string;
+}): Promise<EnsureSandboxImageResult> {
+  const provider = getSandboxProvider(opts.provider);
+  if (!provider.isConfigured()) {
+    throw new SnapshotBuildError(`Sandbox provider ${opts.provider} is not configured`);
+  }
+  const fingerprint = await currentFastRuntimeFingerprint();
+  const contentHash = createHash('sha256').update(`fast-runtime-v1\0${fingerprint}`).digest('hex');
+  const snapshotName = fastSnapshotName(contentHash);
+  const buildKey = `${opts.provider}:${snapshotName}`;
+  const existing = fastImageBuilds.get(buildKey);
+  if (existing) return existing;
+
+  const build = (async () => {
+    let state = await provider.getSnapshotState(snapshotName);
+    if (state === 'building') state = await waitForProviderBuild(provider, snapshotName);
+    if (state === 'active') {
+      return {
+        snapshotName,
+        slug: DEFAULT_SANDBOX_SLUG,
+        contentHash,
+        built: false,
+        isDefault: true,
+        runtimeProfile: 'fast' as const,
+      };
+    }
+    if (state === 'build_failed') await provider.deleteSnapshot(snapshotName);
+    await provider.buildSnapshot({
+      snapshotName,
+      userDockerfile: '# platform fast cold-boot runtime',
+      spec: {},
+      slug: DEFAULT_SANDBOX_SLUG,
+      isShared: true,
+      runtimeProfile: 'fast',
+    });
+    await reapSupersededFastSnapshots(provider, snapshotName);
+    return {
+      snapshotName,
+      slug: DEFAULT_SANDBOX_SLUG,
+      contentHash,
+      built: true,
+      isDefault: true,
+      runtimeProfile: 'fast' as const,
+    };
+  })().finally(() => fastImageBuilds.delete(buildKey));
+  fastImageBuilds.set(buildKey, build);
+  return build;
 }
 
 export async function ensureMetaSandboxImage(opts: {
@@ -1449,7 +1568,14 @@ export async function ensureMetaSandboxImage(opts: {
     let state = await provider.getSnapshotState(snapshotName);
     if (state === 'building') state = await waitForProviderBuild(provider, snapshotName);
     if (state === 'active') {
-      return { snapshotName, slug: 'meta', contentHash, built: false, isDefault: false };
+      return {
+        snapshotName,
+        slug: 'meta',
+        contentHash,
+        built: false,
+        isDefault: false,
+        runtimeProfile: 'meta' as const,
+      };
     }
     if (state === 'build_failed') await provider.deleteSnapshot(snapshotName);
     await provider.buildSnapshot({
@@ -1458,12 +1584,19 @@ export async function ensureMetaSandboxImage(opts: {
       spec: { cpu: 1, memoryGb: 2, diskGb: 8 },
       slug: 'meta',
       isShared: true,
-      runtimeProfile: 'meta',
+      runtimeProfile: 'meta' as const,
     });
     // Tidy only after the replacement is actually active, so a failed build
     // can never leave the environment with nothing to boot.
     await reapSupersededMetaSnapshots(provider, snapshotName);
-    return { snapshotName, slug: 'meta', contentHash, built: true, isDefault: false };
+    return {
+      snapshotName,
+      slug: 'meta',
+      contentHash,
+      built: true,
+      isDefault: false,
+      runtimeProfile: 'meta' as const,
+    };
   })().finally(() => metaImageBuilds.delete(buildKey));
   metaImageBuilds.set(buildKey, build);
   return build;
@@ -1483,7 +1616,10 @@ export function kickStartupPreBuild(): void {
   if (startupPreBuildKicked) return;
   startupPreBuildKicked = true;
   for (const providerId of templateBuildProviders()) {
-    void ensurePlatformDefaultImage({ source: 'startup', provider: providerId })
+    const ensureSessionImage = config.KORTIX_FAST_COLD_BOOT_ENABLED
+      ? ensureFastSandboxImage
+      : ensurePlatformDefaultImage;
+    void ensureSessionImage({ source: 'startup', provider: providerId })
       .then((r) =>
         console.log(
           `[snapshots] startup pre-build (${providerId}): default image ${r.snapshotName} ${r.built ? 'built' : 'ready'}`,

--- a/apps/api/src/snapshots/fast-snapshot-reap.test.ts
+++ b/apps/api/src/snapshots/fast-snapshot-reap.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+
+function setTestEnv(name: string, value: string): void {
+  if (!process.env[name] || process.env[name]?.startsWith('encrypted:')) {
+    process.env[name] = value;
+  }
+}
+
+setTestEnv('DATABASE_URL', 'postgres://postgres:postgres@127.0.0.1:54322/postgres');
+setTestEnv('SUPABASE_URL', 'http://127.0.0.1:54321');
+setTestEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role');
+setTestEnv('API_KEY_SECRET', 'test-api-key-secret');
+setTestEnv('TUNNEL_SIGNING_SECRET', 'test-tunnel-signing-secret');
+setTestEnv('KORTIX_URL', 'https://api.example.test');
+setTestEnv('FRONTEND_URL', 'http://localhost:3000');
+setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
+
+const { config } = await import('../config');
+const { fastSnapshotName, reapSupersededFastSnapshots } = await import('./builder');
+
+function fakeProvider(names: string[]) {
+  const deleted: string[] = [];
+  return {
+    deleted,
+    listSnapshots: async () => names.map((name) => ({ name })),
+    deleteSnapshot: async (name: string) => {
+      deleted.push(name);
+    },
+  };
+}
+
+describe('fast snapshot lifecycle', () => {
+  test('names the image per environment and fingerprint', () => {
+    expect(fastSnapshotName('a'.repeat(64))).toBe(
+      `kortix-fast-${config.INTERNAL_KORTIX_ENV}-${'a'.repeat(16)}`,
+    );
+    expect(fastSnapshotName('a'.repeat(64))).not.toBe(fastSnapshotName('b'.repeat(64)));
+  });
+
+  test('reaps only superseded fast images from the same environment', async () => {
+    const keep = fastSnapshotName('b'.repeat(64));
+    const stale = fastSnapshotName('a'.repeat(64));
+    const foreign = `kortix-fast-prod-${'c'.repeat(16)}`;
+    const standard = `kortix-default-${'d'.repeat(12)}`;
+    const provider = fakeProvider([keep, stale, foreign, standard]);
+
+    await reapSupersededFastSnapshots(provider, keep, async () => new Set());
+
+    expect(provider.deleted).toEqual([stale]);
+  });
+
+  test('fails closed when recent-build protection is unavailable', async () => {
+    const keep = fastSnapshotName('b'.repeat(64));
+    const stale = fastSnapshotName('a'.repeat(64));
+    const provider = fakeProvider([keep, stale]);
+
+    await reapSupersededFastSnapshots(provider, keep, async () => {
+      throw new Error('database unavailable');
+    });
+
+    expect(provider.deleted).toEqual([]);
+  });
+});

--- a/apps/api/src/snapshots/providers/daytona.ts
+++ b/apps/api/src/snapshots/providers/daytona.ts
@@ -19,9 +19,7 @@ import {
   DEFAULT_MEMORY_GB,
   KORTIX_ENTRYPOINT,
   type StagedContext,
-  stageBuildContext,
-  stageAppBuildContext,
-  stageMetaBuildContext,
+  stageRuntimeBuildContext,
   stageWarmFromBaseContext,
 } from '../build-context';
 import { type InvalidatableObservation, shortLivedObservation } from '../observation-cache';
@@ -138,16 +136,14 @@ class DaytonaAdapter implements SandboxProviderAdapter {
           input.warmRepo,
         );
       } else {
-        ctx = input.runtimeProfile === 'app'
-          ? await stageAppBuildContext(input.snapshotName, userDockerfile, input.appContext!)
-          : input.runtimeProfile === 'meta'
-          ? await stageMetaBuildContext()
-          : await stageBuildContext(
-              input.snapshotName,
-              userDockerfile,
-              input.warmRepo,
-              input.isShared,
-            );
+        ctx = await stageRuntimeBuildContext({
+          snapshotName: input.snapshotName,
+          userDockerfile,
+          runtimeProfile: input.runtimeProfile,
+          appContext: input.appContext,
+          warmRepo: input.warmRepo,
+          isShared: input.isShared,
+        });
       }
       const buildLogs: string[] = [];
       try {

--- a/apps/api/src/snapshots/providers/e2b.test.ts
+++ b/apps/api/src/snapshots/providers/e2b.test.ts
@@ -46,18 +46,13 @@ mock.module('../build-context', () => ({
   DEFAULT_CPU: 2,
   DEFAULT_MEMORY_GB: 4,
   KORTIX_ENTRYPOINT: '/usr/local/bin/kortix-entrypoint',
-  stageAppBuildContext: async () => ({
-    contextDir: '/tmp/kortix-e2b-app-adapter-test',
-    dockerfileName: 'Dockerfile',
-  }),
-  stageBuildContext: async () => ({
-    contextDir: '/tmp/kortix-e2b-adapter-test',
-    composedPath: '/tmp/kortix-e2b-adapter-test/Dockerfile',
-  }),
-  stageMetaBuildContext: async () => ({
-    contextDir: '/tmp/kortix-e2b-adapter-test',
-    composedPath: '/tmp/kortix-e2b-adapter-test/Dockerfile',
-  }),
+  stageRuntimeBuildContext: async (input: { runtimeProfile?: string }) => {
+    const contextDir =
+      input.runtimeProfile === 'fast'
+        ? '/tmp/kortix-e2b-fast-adapter-test'
+        : '/tmp/kortix-e2b-adapter-test';
+    return { contextDir, composedPath: `${contextDir}/Dockerfile` };
+  },
 }));
 
 const originalFetch = globalThis.fetch;
@@ -74,6 +69,25 @@ afterEach(() => {
 });
 
 describe('E2B template adapter', () => {
+  test('stages the fast runtime profile through its dedicated renderer', async () => {
+    await e2bProvider.buildSnapshot({
+      snapshotName: 'kortix-fast-dev-abc',
+      slug: 'default',
+      userDockerfile: '# platform fast cold-boot runtime',
+      runtimeProfile: 'fast',
+      spec: {},
+    });
+
+    expect(builderCalls[0]).toEqual({
+      method: 'Template',
+      args: [{ fileContextPath: '/tmp/kortix-e2b-fast-adapter-test' }],
+    });
+    expect(builderCalls[1]).toEqual({
+      method: 'fromDockerfile',
+      args: ['/tmp/kortix-e2b-fast-adapter-test/Dockerfile'],
+    });
+  });
+
   test('builds the shared staged Dockerfile without snapshotting a tokenless runtime process', async () => {
     const logs: string[] = [];
 

--- a/apps/api/src/snapshots/providers/e2b.ts
+++ b/apps/api/src/snapshots/providers/e2b.ts
@@ -7,9 +7,7 @@ import { e2bDomain } from '../../platform/providers/e2b-domain';
 import {
   DEFAULT_CPU,
   DEFAULT_MEMORY_GB,
-  stageBuildContext,
-  stageAppBuildContext,
-  stageMetaBuildContext,
+  stageRuntimeBuildContext,
 } from '../build-context';
 import { shortLivedObservation } from '../observation-cache';
 import { isE2BConcurrentBuildConflict, waitForConcurrentE2BBuild } from './e2b-build-conflict';
@@ -85,17 +83,14 @@ class E2BAdapter implements SandboxProviderAdapter {
       throw new Error('E2BAdapter.buildSnapshot: neither image nor userDockerfile set');
     }
     const userDockerfile = input.userDockerfile ?? `FROM ${input.image}\n`;
-    const context =
-      input.runtimeProfile === 'app'
-        ? await stageAppBuildContext(input.snapshotName, userDockerfile, input.appContext!)
-        : input.runtimeProfile === 'meta'
-        ? await stageMetaBuildContext()
-        : await stageBuildContext(
-            input.snapshotName,
-            userDockerfile,
-            input.warmRepo,
-            input.isShared,
-          );
+    const context = await stageRuntimeBuildContext({
+      snapshotName: input.snapshotName,
+      userDockerfile,
+      runtimeProfile: input.runtimeProfile,
+      appContext: input.appContext,
+      warmRepo: input.warmRepo,
+      isShared: input.isShared,
+    });
     observeTemplates.invalidate();
     try {
       // fromDockerfile() converts the Dockerfile ENTRYPOINT into E2B's start

--- a/apps/api/src/snapshots/providers/index.ts
+++ b/apps/api/src/snapshots/providers/index.ts
@@ -56,8 +56,8 @@ export interface BuildableTemplate {
   slug: string;
   /** Shared platform default (vs per-project). Every template is built cold. */
   isShared?: boolean;
-  /** Selects the fixed platform meta-agent runtime instead of the full layer. */
-  runtimeProfile?: 'standard' | 'meta' | 'app';
+  /** Selects a fixed platform runtime instead of the full standard layer. */
+  runtimeProfile?: 'standard' | 'fast' | 'meta' | 'app';
   /** Required when runtimeProfile is app. */
   appContext?: AppBuildContext;
   /**

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -15,14 +15,12 @@ import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { platinumJson, isPlatinumConfigured } from '../../shared/platinum';
 import {
-  stageBuildContext,
-  stageAppBuildContext,
-  stageMetaBuildContext,
   stageAgentBinaryGz,
   DEFAULT_CPU,
   DEFAULT_MEMORY_GB,
   DEFAULT_DISK_GB,
   KORTIX_ENTRYPOINT,
+  stageRuntimeBuildContext,
 } from '../build-context';
 import { SANDBOX_SPEC_LIMITS } from '../dockerfile-layer';
 import { tarBuildContext } from '../staging-tar';
@@ -576,11 +574,14 @@ class PlatinumAdapter implements SandboxProviderAdapter {
    *  staging and the S3 upload self-heals (mirrors the daytona adapter). */
   private async buildOnce(input: BuildableTemplate, userDockerfile: string, tap?: BuildLogTap): Promise<BuildSnapshotResult> {
     // Stage the SAME context Daytona builds (Dockerfile + agent/cli/entrypoint/…).
-    const ctx = input.runtimeProfile === 'app'
-      ? await stageAppBuildContext(input.snapshotName, userDockerfile, input.appContext!)
-      : input.runtimeProfile === 'meta'
-      ? await stageMetaBuildContext()
-      : await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo, input.isShared);
+    const ctx = await stageRuntimeBuildContext({
+      snapshotName: input.snapshotName,
+      userDockerfile,
+      runtimeProfile: input.runtimeProfile,
+      appContext: input.appContext,
+      warmRepo: input.warmRepo,
+      isShared: input.isShared,
+    });
     const tarPath = join(ctx.contextDir, '..', `${input.snapshotName.replace(/[^a-zA-Z0-9_.-]/g, '_')}.tar.gz`);
     try {
       await tarBuildContext(ctx.contextDir, tarPath);

--- a/apps/sandbox/MACHINE.fast.md
+++ b/apps/sandbox/MACHINE.fast.md
@@ -1,0 +1,24 @@
+# Kortix Fast Sandbox
+
+This machine is an isolated Linux sandbox. It uses the experimental fast cold-boot runtime.
+
+## General environment
+
+The runtime user is `kortix`. It has passwordless `sudo` access.
+The project repository and its configuration are in `/workspace`.
+
+Node.js, npm, pnpm, Bun, OpenCode, uv, Git, curl, tmux, and the `kortix` CLI are ready at boot.
+Python installs automatically on its first `python` or `python3` command.
+Use `uv run --with "pkg1,pkg2" script.py` for Python dependencies outside the document tool pack.
+
+## Lazy tool packs
+
+Large tools stay outside the base image. Their first command installs the required tool pack once for this sandbox.
+
+- `agent-browser` or `chromium` installs the browser tool pack.
+- `make`, `gcc`, `g++`, `cc`, `c++`, or `pkg-config` installs the development tool pack.
+- `anydoc`, `libreoffice`, `pandoc`, `pdftotext`, `qpdf`, `tesseract`, `ffmpeg`, or `latexmk` installs the document tool pack.
+- `kortix-toolpack development`, `kortix-toolpack browser`, `kortix-toolpack documents`, or `kortix-toolpack all` installs a pack explicitly.
+
+The first lazy install can take several minutes. Later calls use the installed files.
+Project-specific instructions override this file.

--- a/apps/sandbox/lazy-tools/install
+++ b/apps/sandbox/lazy-tools/install
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_versions=/opt/kortix/runtime-versions.json
+tool_name="$(basename "$0")"
+
+managed_python() {
+  local python_version python_bin
+  python_version="$(node -e "console.log(require('${runtime_versions}').python)")"
+  python_bin="$(uv python find --managed-python "${python_version}" 2>/dev/null || true)"
+  if [ -z "${python_bin}" ]; then
+    uv python install "${python_version}"
+    python_bin="$(uv python find --managed-python "${python_version}")"
+  fi
+  printf '%s' "${python_bin}"
+}
+
+install_apt_packages() {
+  exec 7>/tmp/kortix-toolpack-apt.lock
+  flock 7
+  sudo apt-get update >&2
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$@" >&2
+  sudo rm -rf /var/lib/apt/lists/* >&2
+  flock -u 7
+}
+
+install_development() {
+  local marker=/opt/kortix/toolpacks/development.ready
+  [ -f "${marker}" ] && return
+  exec 6>/tmp/kortix-toolpack-development.lock
+  flock 6
+  [ -f "${marker}" ] && return
+  install_apt_packages build-essential pkg-config
+  mkdir -p "$(dirname "${marker}")"
+  touch "${marker}"
+}
+
+install_documents() {
+  local marker=/opt/kortix/toolpacks/documents.ready
+  [ -f "${marker}" ] && return
+  exec 9>/tmp/kortix-toolpack-documents.lock
+  flock 9
+  [ -f "${marker}" ] && return
+  install_apt_packages \
+    ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk latexmk \
+    libreoffice pandoc poppler-utils qpdf tesseract-ocr texlive-bibtex-extra \
+    texlive-fonts-recommended texlive-latex-base texlive-latex-extra \
+    texlive-latex-recommended
+  local python_bin
+  local anydoc_version
+  python_bin="$(managed_python)"
+  anydoc_version="$(node -e "console.log(require('${runtime_versions}').anydoc)")"
+  mapfile -t python_specs < <(
+    node -e "const p=require('${runtime_versions}').pythonPackages; for (const k of Object.keys(p).sort()) console.log(k+'=='+p[k])"
+  )
+  uv pip install --python "${python_bin}" "${python_specs[@]}"
+  pnpm add -g "@firecrawl/anydoc@${anydoc_version}" >&2
+  mkdir -p "$(dirname "${marker}")"
+  touch "${marker}"
+}
+
+install_browser() {
+  local marker=/opt/kortix/toolpacks/browser.ready
+  [ -f "${marker}" ] && return
+  exec 8>/tmp/kortix-toolpack-browser.lock
+  flock 8
+  [ -f "${marker}" ] && return
+  local agent_browser_version playwright_version chrome
+  agent_browser_version="$(node -e "console.log(require('${runtime_versions}').agentBrowser)")"
+  playwright_version="$(node -e "console.log(require('${runtime_versions}').playwright)")"
+  pnpm add -g --allow-build=agent-browser "agent-browser@${agent_browser_version}" >&2
+  exec 7>/tmp/kortix-toolpack-apt.lock
+  flock 7
+  PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \
+    pnpm dlx "playwright@${playwright_version}" install --with-deps chromium >&2
+  flock -u 7
+  chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)"
+  test -n "${chrome}"
+  ln -sf "${chrome}" /home/kortix/.local/bin/chromium
+  mkdir -p /home/kortix/.agent-browser/browsers
+  ln -sfn "$(dirname "${chrome}")" /home/kortix/.agent-browser/browsers/chrome-linux64
+  mkdir -p "$(dirname "${marker}")"
+  touch "${marker}"
+}
+
+install_pack() {
+  case "${1:-}" in
+    development) install_development ;;
+    browser) install_browser ;;
+    documents) install_documents ;;
+    all) install_development; install_browser; install_documents ;;
+    *) echo 'usage: kortix-toolpack <development|browser|documents|all>' >&2; return 2 ;;
+  esac
+}
+
+case "${tool_name}" in
+  kortix-toolpack)
+    install_pack "${1:-}"
+    ;;
+  python|python3)
+    python_bin="$(managed_python)"
+    exec "${python_bin}" "$@"
+    ;;
+  agent-browser)
+    install_browser
+    exec /home/kortix/.local/share/pnpm/agent-browser "$@"
+    ;;
+  chromium)
+    install_browser
+    exec /home/kortix/.local/bin/chromium "$@"
+    ;;
+  make|gcc|g++|cc|c++|pkg-config)
+    install_development
+    exec "/usr/bin/${tool_name}" "$@"
+    ;;
+  anydoc|libreoffice|pandoc|pdftotext|qpdf|tesseract|ffmpeg|latexmk)
+    install_documents
+    if [ "${tool_name}" = anydoc ]; then
+      exec /home/kortix/.local/share/pnpm/bin/anydoc "$@"
+    fi
+    exec "/usr/bin/${tool_name}" "$@"
+    ;;
+  *)
+    echo "unsupported lazy tool: ${tool_name}" >&2
+    exit 2
+    ;;
+esac

--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -1,0 +1,66 @@
+# Fast cold boot runtime
+
+Status: experimental on dev. Staging and production remain disabled.
+
+## Problem
+
+A clean dev session reaches runtime readiness in 25.3 seconds at p50.
+The current image contains browsers, LibreOffice, TeX, and the complete Python package floor.
+Every sandbox pays the image startup cost even when the first turn does not use those tools.
+
+Measured dev baseline on 2026-08-19, using five new default-template sessions:
+
+| Milestone | p50 | p90 |
+|---|---:|---:|
+| Runtime ready | 25,288 ms | 32,607 ms |
+| Sandbox row active | 19,288 ms | — |
+| Daemon reachable | 21,756 ms | — |
+| Repository materialized | 7,489 ms | 8,007 ms |
+| OpenCode answering | 5,308 ms | 6,908 ms |
+
+## Design
+
+`KORTIX_FAST_COLD_BOOT_ENABLED=true` selects one shared, content-addressed fast image.
+It does not create or retain running sandboxes.
+The standard image remains available through the same flag.
+
+The fast image contains the complete session-critical path:
+
+- Git and the baked scaffold repository
+- Node.js, npm, pnpm, Bun, uv, OpenCode, the Kortix daemon, and the Kortix CLI
+- OpenCode configuration dependencies and its build-time migration warm-up
+- The model catalog, managed skills, and Slack or Teams CLI shims
+
+Large tools install once per sandbox on first use:
+
+- `python` or `python3`: the pinned managed Python runtime
+- `make`, `gcc`, `g++`, `cc`, `c++`, or `pkg-config`: development pack
+- `agent-browser` or `chromium`: browser pack
+- Anydoc, document, PDF, OCR, media, and TeX commands: document pack
+
+`kortix-toolpack development|browser|documents|all` installs a pack explicitly.
+An inter-process lock prevents two first-use commands from running `apt` concurrently.
+
+Custom and meta templates do not change under the flag.
+Platinum cannot reuse the standard template ID for a fast-image session.
+
+## Rollout and rollback
+
+Dev enables the flag in `infra/terraform/environments/dev/variables.tf`.
+Staging, production, and self-hosted installations default to `false`.
+
+Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy to restore the standard image.
+Rollback does not require a database migration or sandbox cleanup.
+Existing sessions continue on the image that created them.
+
+## Acceptance gates
+
+The experiment can advance beyond dev only when all gates pass:
+
+1. Five clean dev boots complete without a provider or runtime failure.
+2. Runtime-ready p50 and p90 improve against the baseline above.
+3. A first prompt completes through OpenCode.
+4. Git, Kortix CLI, Python, development, browser, and document paths pass smoke tests.
+5. The fast image remains smaller than the standard runtime image.
+
+Disable the flag if runtime-ready p90 exceeds 32,607 ms or a lazy tool path fails.

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -82,7 +82,9 @@ variable "container_port" {
 variable "api_environment" {
   description = "Non-secret env vars for the API container (KORTIX_URL, DATABASE host, etc.)."
   type        = map(string)
-  default     = {}
+  default = {
+    KORTIX_FAST_COLD_BOOT_ENABLED = "true"
+  }
 }
 
 variable "api_secrets" {

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildFastSandboxDockerfile } from '../fast-dockerfile';
+
+describe('buildFastSandboxDockerfile', () => {
+  test('keeps the session-critical runtime and defers heavyweight tool packs', () => {
+    const dockerfile = buildFastSandboxDockerfile({
+      agentBinaryPath: 'artifacts/kortix-agent.gz',
+      cliBinaryPath: 'artifacts/kortix.gz',
+      entrypointScriptPath: 'artifacts/kortix-entrypoint',
+      opencodeWarmupScriptPath: 'artifacts/opencode-warmup',
+      machineDocPath: 'artifacts/MACHINE.fast.md',
+      slackCliPath: 'artifacts/slack-cli',
+      lazyToolsPath: 'artifacts/lazy-tools',
+      catalogPath: 'artifacts/llm-catalog.json',
+      managedSkillsPath: 'artifacts/managed-skills',
+      runtimeVersionsPath: 'artifacts/runtime-versions.json',
+      opencodeConfigPath: 'artifacts/opencode',
+      scaffoldPath: 'artifacts/scaffold.git',
+    });
+
+    expect(dockerfile).toContain('FROM debian:bookworm-slim');
+    expect(dockerfile).toContain('opencode-ai@1.17.11');
+    expect(dockerfile).toContain('pnpm-linux-${pnpm_arch}.tar.gz');
+    expect(dockerfile).toContain('bun-v1.3.14');
+    expect(dockerfile).toContain('aarch64|arm64) bun_arch=aarch64');
+    expect(dockerfile).toContain('uv-${uv_arch}-unknown-linux-gnu.tar.gz');
+    expect(dockerfile).toContain('/usr/local/bin/kortix-agent');
+    expect(dockerfile).toContain('/usr/local/bin/kortix');
+    expect(dockerfile).toContain('/opt/kortix/scaffold.git');
+    expect(dockerfile).toContain('/opt/kortix/opencode-config-deps');
+    expect(dockerfile).toContain(
+      'COPY --chown=kortix:kortix artifacts/opencode/package.json artifacts/opencode/bun.lock /opt/kortix/opencode-config-deps/',
+    );
+    expect(dockerfile).toContain('/home/kortix/.bun/bin/bun install --frozen-lockfile');
+    expect(dockerfile).toContain('COPY --chown=kortix:kortix artifacts/opencode-warmup');
+    expect(dockerfile).toContain('bash /tmp/kortix-opencode-warmup migration');
+    expect(dockerfile).toContain('/opt/kortix/runtime-versions.json');
+    expect(dockerfile).toContain('/ephemeral/kortix-master/opencode');
+    expect(dockerfile).toContain('/opt/kortix/lazy-tools/install');
+    expect(dockerfile).toContain('make gcc g++ cc c++ pkg-config');
+    expect(dockerfile).toContain('/opt/pw-browsers');
+    expect(dockerfile).toContain('KORTIX_RUNTIME_PROFILE=fast');
+    expect(dockerfile).toContain('KORTIX_PROJECT_AUTO_CLONE=1');
+    expect(dockerfile).toContain('AGENT_BROWSER_EXECUTABLE_PATH=/home/kortix/.local/bin/chromium');
+
+    expect(dockerfile).not.toContain('apt-get install -y --no-install-recommends libreoffice');
+    expect(dockerfile).not.toContain('texlive-latex-extra');
+    expect(dockerfile).not.toContain('playwright install --with-deps chromium');
+    expect(dockerfile).not.toContain('uv pip install --python');
+  });
+});

--- a/packages/shared/src/sandbox/fast-dockerfile.ts
+++ b/packages/shared/src/sandbox/fast-dockerfile.ts
@@ -1,0 +1,160 @@
+import {
+  BUN_SHA256_AMD64,
+  BUN_SHA256_ARM64,
+  BUN_VERSION,
+  NODE_VERSION,
+  NPM_VERSION,
+  OPENCODE_VERSION,
+  PNPM_SHA256_AMD64,
+  PNPM_SHA256_ARM64,
+  PNPM_VERSION,
+  UV_SHA256_AMD64,
+  UV_SHA256_ARM64,
+  UV_VERSION,
+} from '../runtime-versions';
+
+export interface FastSandboxDockerfileOptions {
+  agentBinaryPath: string;
+  cliBinaryPath: string;
+  entrypointScriptPath: string;
+  opencodeWarmupScriptPath: string;
+  machineDocPath: string;
+  slackCliPath: string;
+  lazyToolsPath: string;
+  catalogPath: string;
+  managedSkillsPath: string;
+  runtimeVersionsPath: string;
+  opencodeConfigPath: string;
+  scaffoldPath: string;
+}
+
+/**
+ * Render the experimental cold-boot runtime.
+ *
+ * The image contains only bytes required before the first agent turn. Large
+ * browser, document, TeX, and Python package floors install on first use through
+ * the staged lazy-tool wrappers. The standard image remains the default.
+ */
+export function buildFastSandboxDockerfile(options: FastSandboxDockerfileOptions): string {
+  return `# syntax=docker/dockerfile:1.7
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      bash ca-certificates curl file git gzip iproute2 iputils-ping jq less \
+      libatomic1 openssh-client procps ripgrep sudo tmux unzip util-linux xz-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash --user-group kortix \
+ && echo 'kortix ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/kortix \
+ && chmod 0440 /etc/sudoers.d/kortix \
+ && mkdir -p /workspace /opt/kortix /opt/pw-browsers /ephemeral/kortix-master/opencode \
+      /home/kortix/.local/bin /home/kortix/.local/share/pnpm/bin /home/kortix/.bun/bin \
+ && chown -R kortix:kortix /workspace /opt/kortix /opt/pw-browsers /ephemeral /home/kortix
+
+ENV PNPM_HOME=/home/kortix/.local/share/pnpm \
+    PATH="/home/kortix/.local/bin:/home/kortix/.local/share/pnpm/bin:/home/kortix/.bun/bin:\${PATH}" \
+    SHELL=/bin/bash
+
+RUN case "$(uname -m)" in \
+      x86_64) pnpm_arch=x64; pnpm_sha=${PNPM_SHA256_AMD64} ;; \
+      aarch64|arm64) pnpm_arch=arm64; pnpm_sha=${PNPM_SHA256_ARM64} ;; \
+      *) echo "unsupported pnpm architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL --retry 3 --retry-delay 2 -o /tmp/pnpm.tar.gz \
+      "https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-linux-\${pnpm_arch}.tar.gz" \
+ && echo "\${pnpm_sha}  /tmp/pnpm.tar.gz" | sha256sum -c - \
+ && tar -xzf /tmp/pnpm.tar.gz -C /home/kortix/.local/bin \
+ && rm /tmp/pnpm.tar.gz \
+ && test "$(pnpm --version)" = "${PNPM_VERSION}" \
+ && HOME=/home/kortix pnpm runtime set node ${NODE_VERSION} --global \
+ && test "$(node --version)" = "v${NODE_VERSION}" \
+ && HOME=/home/kortix pnpm add --global "npm@${NPM_VERSION}" \
+ && test "$(npm --version)" = "${NPM_VERSION}" \
+ && HOME=/home/kortix pnpm add --global --allow-build=opencode-ai "opencode-ai@${OPENCODE_VERSION}" \
+ && test "$(opencode --version)" = "${OPENCODE_VERSION}" \
+ && ln -sf "$(command -v node)" /usr/local/bin/node \
+ && chown -R kortix:kortix /home/kortix
+
+RUN case "$(uname -m)" in \
+      x86_64) bun_arch=x64; bun_sha=${BUN_SHA256_AMD64} ;; \
+      aarch64|arm64) bun_arch=aarch64; bun_sha=${BUN_SHA256_ARM64} ;; \
+      *) echo "unsupported Bun architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL --retry 3 --retry-delay 2 -o /tmp/bun.zip \
+      "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-\${bun_arch}.zip" \
+ && echo "\${bun_sha}  /tmp/bun.zip" | sha256sum -c - \
+ && unzip -q /tmp/bun.zip -d /tmp/bun \
+ && install -m 0755 "/tmp/bun/bun-linux-\${bun_arch}/bun" /home/kortix/.bun/bin/bun \
+ && ln -sf bun /home/kortix/.bun/bin/bunx \
+ && rm -rf /tmp/bun /tmp/bun.zip \
+ && test "$(/home/kortix/.bun/bin/bun --version)" = "${BUN_VERSION}"
+
+RUN case "$(uname -m)" in \
+      x86_64) uv_arch=x86_64; uv_sha=${UV_SHA256_AMD64} ;; \
+      aarch64|arm64) uv_arch=aarch64; uv_sha=${UV_SHA256_ARM64} ;; \
+      *) echo "unsupported uv architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL --retry 3 --retry-delay 2 -o /tmp/uv.tar.gz \
+      "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-\${uv_arch}-unknown-linux-gnu.tar.gz" \
+ && echo "\${uv_sha}  /tmp/uv.tar.gz" | sha256sum -c - \
+ && tar -xzf /tmp/uv.tar.gz --strip-components=1 -C /home/kortix/.local/bin \
+ && rm /tmp/uv.tar.gz \
+ && /home/kortix/.local/bin/uv --version | grep -Eq "^uv ${UV_VERSION}( |$)"
+
+RUN mkdir -p /opt/kortix/opencode-config-deps
+COPY --chown=kortix:kortix ${options.opencodeConfigPath}/package.json ${options.opencodeConfigPath}/bun.lock /opt/kortix/opencode-config-deps/
+RUN cd /opt/kortix/opencode-config-deps \
+ && /home/kortix/.bun/bin/bun install --frozen-lockfile \
+ && /home/kortix/.bun/bin/bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-check \
+ && rm -rf /tmp/opencode-deps-check
+
+COPY --chown=kortix:kortix ${options.opencodeWarmupScriptPath} /tmp/kortix-opencode-warmup
+RUN sudo -u kortix env HOME=/home/kortix PATH="${'$'}{PATH}" \
+      bash /tmp/kortix-opencode-warmup migration \
+ && rm -f /tmp/kortix-opencode-warmup
+
+COPY --chown=kortix:kortix ${options.opencodeConfigPath}/ /ephemeral/kortix-master/opencode/
+COPY --chown=kortix:kortix ${options.catalogPath} /opt/kortix/llm-catalog.json
+COPY --chown=kortix:kortix ${options.managedSkillsPath}/ /opt/kortix/managed-skills/
+COPY --chown=kortix:kortix ${options.runtimeVersionsPath} /opt/kortix/runtime-versions.json
+COPY --chown=kortix:kortix ${options.scaffoldPath}/ /opt/kortix/scaffold.git/
+COPY --chown=kortix:kortix ${options.lazyToolsPath}/ /opt/kortix/lazy-tools/
+COPY ${options.machineDocPath} /MACHINE.md
+COPY ${options.entrypointScriptPath} /usr/local/bin/kortix-entrypoint
+COPY ${options.slackCliPath}/ /opt/kortix/apps/sandbox/slack-cli/
+COPY ${options.agentBinaryPath} /tmp/kortix-agent.gz
+COPY ${options.cliBinaryPath} /tmp/kortix.gz
+
+RUN gzip -dc /tmp/kortix-agent.gz > /usr/local/bin/kortix-agent \
+ && gzip -dc /tmp/kortix.gz > /usr/local/bin/kortix \
+ && rm /tmp/kortix-agent.gz /tmp/kortix.gz \
+ && chmod 0755 /usr/local/bin/kortix-agent /usr/local/bin/kortix /usr/local/bin/kortix-entrypoint \
+      /opt/kortix/lazy-tools/install /opt/kortix/apps/sandbox/slack-cli/install-shims.sh \
+ && ln -sf /opt/kortix/lazy-tools/install /usr/local/bin/kortix-toolpack \
+ && for tool in python python3 make gcc g++ cc c++ pkg-config chromium agent-browser anydoc libreoffice pandoc pdftotext qpdf tesseract ffmpeg latexmk; do \
+      ln -sf /opt/kortix/lazy-tools/install "/usr/local/bin/\${tool}"; \
+    done \
+ && bash /opt/kortix/apps/sandbox/slack-cli/install-shims.sh /opt/kortix/apps/sandbox/slack-cli \
+ && bash -n /usr/local/bin/kortix-entrypoint \
+ && bash -n /opt/kortix/lazy-tools/install
+
+RUN printf '%s\\n' '[ -r /dev/shm/kortix/agent-env.sh ] && . /dev/shm/kortix/agent-env.sh' \
+      > /etc/profile.d/kortix-agent-env.sh \
+ && printf '%s\\n' '[ -r /dev/shm/kortix/agent-env.sh ] && . /dev/shm/kortix/agent-env.sh' \
+      >> /etc/bash.bashrc
+
+ENV KORTIX_WORKSPACE=/workspace \
+    KORTIX_PROJECT_AUTO_CLONE=1 \
+    KORTIX_RUNTIME_PROFILE=fast \
+    KORTIX_LLM_CATALOG_FILE=/opt/kortix/llm-catalog.json \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \
+    AGENT_BROWSER_EXECUTABLE_PATH=/home/kortix/.local/bin/chromium \
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage
+USER kortix
+WORKDIR /workspace
+EXPOSE 8000
+ENTRYPOINT ["/usr/local/bin/kortix-entrypoint"]
+`;
+}

--- a/packages/shared/src/sandbox/index.ts
+++ b/packages/shared/src/sandbox/index.ts
@@ -1,2 +1,3 @@
 export * from './dockerfile-layer';
+export * from './fast-dockerfile';
 export * from './meta-dockerfile';


### PR DESCRIPTION
## Problem

Default sessions pay the startup cost of browsers, LibreOffice, TeX, and the full Python package floor. Five clean dev boots measured 25,288 ms p50 and 32,607 ms p90 to runtime readiness.

## Change

- Add one shared content-addressed fast runtime image.
- Gate selection behind `KORTIX_FAST_COLD_BOOT_ENABLED` with default OFF.
- Enable the experiment only in the dev Terraform environment.
- Keep custom and meta templates on their existing images.
- Bake Git, the scaffold, Node, Bun, uv, OpenCode, config dependencies, migrations, the daemon, and the CLI.
- Install Python, development, browser, and document packs on first use with process locks.
- Prevent Platinum from using a standard pinned template ID for the fast profile.
- Reap superseded fast images with environment and rolling-deploy guards.

## Verification

- `apps/api/scripts/test.sh`: 7,532 passed, 74 skipped, 0 failed.
- API TypeScript: passed.
- Shared sandbox tests: 68 passed, 0 failed.
- Focused API tests: 50 passed, 0 failed.
- Local linux/amd64 image build: passed.
- Image size: 1,410,886,779 bytes.
- Core runtime smoke: passed.
- Baked OpenCode dependency lock comparison: passed.
- OpenCode config dependencies linked in 108 ms without a network install.
- Lazy Python install: 13 seconds.
- Lazy development pack install: 57 seconds.

## Rollback

Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy. No database migration or sandbox cleanup is required.