### PR TITLE
Release candidate: main → staging (v0.13.0) + group-grants Strix fix (#6560) + shard fleet tuning (#6561)

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -100,15 +100,19 @@ jobs:
       # Pin the run id so the post-run sweep below can reclaim exactly THIS
       # shard's principals (`principals.ts` names them `e2e-<runId>-…`).
       KE2E_RUN_ID: ${{ github.run_id }}-api${{ matrix.shard }}
-      # Fleet arithmetic, not per-job tuning: 4 shards x 3 = 12 concurrent API
-      # workers and 4 x 2 = 8 concurrent sandbox boots against ONE staging
-      # environment, against 3 + 3 before sharding. Staging is a single 0.5 vCPU
-      # Spot task today, and the v0.13.0 gate already collapsed it at 3 + 3 (see
-      # the "tests-release's own load can knock staging over" learning). These
-      # two numbers are the first thing to lower if MAINTENANCE_MODE 503s
-      # reappear.
-      KE2E_API_WORKERS: '3'
-      KE2E_SANDBOX_WORKERS: '2'
+      # Fleet arithmetic, not per-job tuning. Run 32231251280 (the first run
+      # where every shard actually executed) fanned out 4x3 API + 4x2 sandbox +
+      # 3x2 browser = 26 concurrent workers against ONE staging (2 x 1 vCPU
+      # tasks, Medium DB after #6544) and ~50% of flows failed with "exceeded
+      # 120000ms" — staging slowed to the point that the 120s flow budget
+      # tripped, and with #6543 a timeout is no longer retried. The single-job
+      # gate passed 424/441 at 3 + 3. Halve the fleet: 4x2 + 4x1 = 12 against
+      # the API (plus 3x1 browsers), and give a timed-out flow exactly ONE more
+      # attempt here (not the old 3x) — the load is low enough that a retry
+      # cannot cascade. Lower these first if MAINTENANCE_MODE 503s reappear.
+      KE2E_API_WORKERS: '2'
+      KE2E_SANDBOX_WORKERS: '1'
+      KE2E_TIMEOUT_ATTEMPTS: '2'
     steps:
       - uses: actions/checkout@v7
       - name: Require the deployed staging source SHA
@@ -177,7 +181,8 @@ jobs:
         shard: [1, 2, 3]
     env:
       # 3 shards x 2 = 6 concurrent browsers, against 2 before sharding.
-      E2E_BROWSER_WORKERS: '2'
+      # One browser per shard (3 total) — see the fleet arithmetic on the api job.
+      E2E_BROWSER_WORKERS: '1'
     steps:
       - uses: actions/checkout@v7
       - name: Require the deployed staging source SHA

--- a/apps/api/src/__tests__/integration-members-manage-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-members-manage-gates-http.test.ts
@@ -182,6 +182,10 @@ interface EP {
 
 const ENDPOINTS: EP[] = [
   { name: 'GET /audit', method: 'GET', path: () => `/v1/projects/${PROJECT}/audit` },
+  // The GET is manager-only too: it exposes member_count / override_count and
+  // the group→project topology. It was gated on project.session.read until the
+  // v0.13.0 release review caught it (Strix, CWE-863).
+  { name: 'GET /group-grants', method: 'GET', path: () => `/v1/projects/${PROJECT}/group-grants` },
   { name: 'POST /group-grants', method: 'POST', path: () => `/v1/projects/${PROJECT}/group-grants`, body: {} },
   { name: 'PATCH /group-grants/{id}', method: 'PATCH', path: () => `/v1/projects/${PROJECT}/group-grants/${crypto.randomUUID()}`, body: {} },
   { name: 'DELETE /group-grants/{id}', method: 'DELETE', path: () => `/v1/projects/${PROJECT}/group-grants/${crypto.randomUUID()}` },

--- a/apps/api/src/__tests__/unit-iam-object-grants-memo.test.ts
+++ b/apps/api/src/__tests__/unit-iam-object-grants-memo.test.ts
@@ -1,0 +1,27 @@
+// The object-grant memo must not cache an EMPTY map for a closed-by-default
+// object type (agent). Invalidation is per-process; a stale empty map on a
+// sibling replica reads as "still closed" and denies a member who was just
+// granted an agent for one TTL (observed on dev 2026-08-19). Open-by-default
+// types keep caching the empty map — a stale empty map there is "still open",
+// which is what the caller already had. Source pin, because the memo's
+// `enableInTests` is off by design and the rule is one line.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(join(import.meta.dir, '../iam/authorize.ts'), 'utf8');
+const flat = source.replace(/\s+/g, ' ');
+
+describe('loadObjectGrants memo — empty map caching', () => {
+  test('never caches an empty map for a closed-by-default object type', () => {
+    expect(flat).toContain(
+      "shouldCache: (map, _projectId, objectType) => map.size > 0 || !CLOSED_BY_DEFAULT_OBJECT_TYPES.has(objectType)",
+    );
+    expect(flat).toContain("CLOSED_BY_DEFAULT_OBJECT_TYPES: ReadonlySet<string> = new Set(['agent'])");
+  });
+
+  test('the unconditional cache-everything rule is gone', () => {
+    const memo = flat.slice(flat.indexOf('const loadObjectGrants = ttlMemo('), flat.indexOf('registerProjectScopedMemo(loadObjectGrants)'));
+    expect(memo).not.toContain('shouldCache: () => true');
+  });
+});

--- a/apps/api/src/iam/authorize.ts
+++ b/apps/api/src/iam/authorize.ts
@@ -692,6 +692,14 @@ export function customRoleAllows(
 
 // ─── Object grants ──────────────────────────────────────────────────────────
 
+/**
+ * Object types whose unscoped default is CLOSED for member-tier (mirrors the
+ * `object_policies` seed: agent closed; skill/secret/app/trigger open). Kept as
+ * a constant here because the memo's caching rule must not itself depend on a
+ * DB read; `unscopedDefaultFor` stays the source of truth for the VERDICT.
+ */
+const CLOSED_BY_DEFAULT_OBJECT_TYPES: ReadonlySet<string> = new Set(['agent']);
+
 interface ObjectGrantPrincipal {
   principalType: string;
   principalId: string;
@@ -700,11 +708,15 @@ interface ObjectGrantPrincipal {
 /**
  * (project, objectType) -> objectId -> the principals granted it.
  *
- * The EMPTY map is cached, unlike every other authz memo. That is deliberate
- * and pre-existing: "this project scopes nothing" is the common, hot case, and
- * every mutation busts the project entry synchronously on the writing replica.
- * The trade is that a grant CREATE can lag one TTL window on a replica that did
- * not perform the write, where a role grant is instant.
+ * The EMPTY map is cached only for object types whose unscoped default is OPEN
+ * (skill, secret, app, trigger): there a stale empty map means "still open",
+ * which is the state the caller already had. For CLOSED-by-default types (agent)
+ * a stale empty map would mean "still closed" — invalidation is per-process, so
+ * a member granted an agent kept getting 403 for one TTL on every replica that
+ * had not seen the write (measured on dev 2026-08-19: create 403, then 201 ×3
+ * after the TTL). One extra indexed query per uncached check is the price of a
+ * grant taking effect on every replica at once — the same rule the legacy
+ * `loadProjectResourceGrants` memo already applies (#6535).
  */
 const loadObjectGrants = ttlMemo({
   ttlMs: TTL_MS,
@@ -735,7 +747,8 @@ const loadObjectGrants = ttlMemo({
     }
     return map;
   },
-  shouldCache: () => true,
+  shouldCache: (map, _projectId, objectType) =>
+    map.size > 0 || !CLOSED_BY_DEFAULT_OBJECT_TYPES.has(objectType),
 });
 registerProjectScopedMemo(loadObjectGrants);
 

--- a/apps/api/src/projects/routes/group-grants.ts
+++ b/apps/api/src/projects/routes/group-grants.ts
@@ -46,7 +46,13 @@ projectsApp.openapi(
   const projectId = c.req.param('projectId');
   const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
-  await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_READ);
+  // Manager-only, like the POST/PATCH/DELETE siblings in this file and the
+  // contract in accounts/iam/groups.ts ("those routes gate on
+  // project.members.manage"). The listing carries member_count /
+  // override_count that the rest of the IAM surface treats as manager data;
+  // gating it on project.session.read let any baseline project member read
+  // it (Strix, v0.13.0 release review, CWE-863).
+  await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE);
 
   // From `role_assignments`, the store the engine reads. The group NAME is
   // still identity data on `account_groups`, and the inner-join semantics are


### PR DESCRIPTION
Carries #6560 (GET /projects/:id/group-grants → project.members.manage; Strix MEDIUM on #6559) and #6561 (release-gate shard fleet 26→15 workers + one retry on timed-out flows; run 32231251280 had ~50% 120s-timeout failures under 26 workers).