### PR TITLE
fix(sandbox): harden lazy tool dispatch

### DIFF
--- a/apps/sandbox/lazy-tools/install
+++ b/apps/sandbox/lazy-tools/install
@@ -4,7 +4,7 @@ set -euo pipefail
 runtime_versions=/opt/kortix/runtime-versions.json
 tool_name="$(basename "$0")"
 
-managed_python() {
+managed_python_base() {
   local python_version python_bin
   python_version="$(node -e "console.log(require('${runtime_versions}').python)")"
   python_bin="$(uv python find --managed-python "${python_version}" 2>/dev/null || true)"
@@ -13,6 +13,15 @@ managed_python() {
     python_bin="$(uv python find --managed-python "${python_version}")"
   fi
   printf '%s' "${python_bin}"
+}
+
+managed_python() {
+  local document_python=/home/kortix/.local/share/kortix/python/bin/python
+  if [ -x "${document_python}" ]; then
+    printf '%s' "${document_python}"
+    return
+  fi
+  managed_python_base
 }
 
 install_apt_packages() {
@@ -46,14 +55,18 @@ install_documents() {
     libreoffice pandoc poppler-utils qpdf tesseract-ocr texlive-bibtex-extra \
     texlive-fonts-recommended texlive-latex-base texlive-latex-extra \
     texlive-latex-recommended
-  local python_bin
+  local python_bin python_env
   local anydoc_version
-  python_bin="$(managed_python)"
+  python_bin="$(managed_python_base)"
+  python_env=/home/kortix/.local/share/kortix/python
   anydoc_version="$(node -e "console.log(require('${runtime_versions}').anydoc)")"
   mapfile -t python_specs < <(
     node -e "const p=require('${runtime_versions}').pythonPackages; for (const k of Object.keys(p).sort()) console.log(k+'=='+p[k])"
   )
-  uv pip install --python "${python_bin}" "${python_specs[@]}"
+  if [ ! -x "${python_env}/bin/python" ]; then
+    uv venv --python "${python_bin}" "${python_env}"
+  fi
+  uv pip install --python "${python_env}/bin/python" "${python_specs[@]}"
   pnpm add -g "@firecrawl/anydoc@${anydoc_version}" >&2
   mkdir -p "$(dirname "${marker}")"
   touch "${marker}"
@@ -103,7 +116,7 @@ case "${tool_name}" in
     ;;
   agent-browser)
     install_browser
-    exec /home/kortix/.local/share/pnpm/agent-browser "$@"
+    exec /home/kortix/.local/share/pnpm/bin/agent-browser "$@"
     ;;
   chromium)
     install_browser

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 
 import { buildFastSandboxDockerfile } from '../fast-dockerfile';
 
@@ -48,5 +49,18 @@ describe('buildFastSandboxDockerfile', () => {
     expect(dockerfile).not.toContain('texlive-latex-extra');
     expect(dockerfile).not.toContain('playwright install --with-deps chromium');
     expect(dockerfile).not.toContain('uv pip install --python');
+  });
+
+  test('uses valid lazy-tool runtime paths', () => {
+    const installer = readFileSync(
+      new URL('../../../../../apps/sandbox/lazy-tools/install', import.meta.url),
+      'utf8',
+    );
+
+    expect(installer).toContain('exec /home/kortix/.local/share/pnpm/bin/agent-browser "$@"');
+    expect(installer).toContain('uv venv --python "${python_bin}" "${python_env}"');
+    expect(installer).toContain(
+      'uv pip install --python "${python_env}/bin/python" "${python_specs[@]}"',
+    );
   });
 });


### PR DESCRIPTION
## What changed

- execute `agent-browser` from pnpm's configured global bin directory
- install the document Python floor into a dedicated uv virtual environment
- route later `python` and `python3` calls through that environment
- add regression assertions for both runtime paths

## Why

Full cold-install image tests after #6562 found two first-use failures:

- `agent-browser` used `/home/kortix/.local/share/pnpm/agent-browser`; pnpm installs it at `/home/kortix/.local/share/pnpm/bin/agent-browser`
- `uv pip` rejected direct writes to the uv-managed interpreter as externally managed

## Verification

- `bash -n apps/sandbox/lazy-tools/install`
- `bun test packages/shared/src/sandbox/__tests__` — 65 pass, 0 fail
- `pnpm exec biome check packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts` — clean
- `git diff --check` — clean
- fresh browser lazy pack — `agent-browser 0.27.0`, Chromium 148, 180 seconds
- fresh document lazy pack — 48 pinned Python packages, `anydoc 0.1.6`, LibreOffice 7.4, 419 seconds
- focused virtual-environment smoke — `pypdf 6.14.2` imports through the lazy `python3` wrapper
