### PR TITLE
fix(dev): apply fast cold boot flag to ECS tasks

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -86,6 +86,7 @@ jobs:
               - 'apps/cli/**'          # baked into the API image (sandbox kortix CLI)
               - 'packages/**'
               - 'scripts/ci/cosign-sign-attest.sh'
+              - 'infra/scripts/ecs-deploy.sh'
               - '.github/workflows/deploy-dev.yml'
               - 'supabase/migrations/**' # run by ensureSchema at boot — must redeploy to apply
               - 'pnpm-lock.yaml'
@@ -448,6 +449,7 @@ jobs:
     env:
       AWS_REGION: us-west-2
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
+      KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}'
     steps:
       - uses: actions/checkout@v7
       - name: Configure AWS credentials (OIDC)

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -32,6 +32,11 @@
 #
 # Requires: awscli v2, jq. Assumes the ECS cluster/service/ALB/target-group and
 # the exec/task IAM roles already exist (Terraform owns those).
+#
+# Optional non-secret task environment overrides are read from
+# KORTIX_ECS_ENV_OVERRIDES as a JSON object of string values. The renderer
+# replaces matching values from the running task and preserves every other
+# value. Secrets remain in the aggregate Secrets Manager blob.
 
 set -euo pipefail
 
@@ -70,6 +75,23 @@ configure_service_coordinates() {
       return 2
       ;;
   esac
+}
+
+merge_environment_overrides() {
+  local current="${1:-[]}" overrides="${2:-}"
+  [ -n "$overrides" ] || overrides='{}'
+  jq -cn --argjson current "$current" --argjson overrides "$overrides" '
+    if ($current | type) != "array" or any($current[]; (.name | type) != "string" or (.value | type) != "string") then
+      error("current ECS environment must be an array of string name/value objects")
+    elif ($overrides | type) != "object" or any($overrides[]; type != "string") then
+      error("KORTIX_ECS_ENV_OVERRIDES must be a JSON object of strings")
+    elif (($overrides | keys) | all(.[]; test("^[A-Za-z_][A-Za-z0-9_]*$"))) | not then
+      error("KORTIX_ECS_ENV_OVERRIDES contains an invalid environment name")
+    else
+      [$current[] | select(.name as $name | ($overrides | has($name) | not))]
+      + [$overrides | to_entries | sort_by(.key)[] | {name: .key, value: .value}]
+    end
+  '
 }
 
 # Allow sourcing for tests: `KORTIX_ECS_DEPLOY_LIB=1 source ecs-deploy.sh`.
@@ -176,6 +198,16 @@ CURRENT_TD="$(aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" 
 CURRENT_TD_JSON="$(aws ecs describe-task-definition --region "$REGION" \
   --task-definition "$CURRENT_TD" --query 'taskDefinition' --output json)"
 
+ENVIRONMENT_OVERRIDES_JSON="${KORTIX_ECS_ENV_OVERRIDES:-}"
+[ -n "$ENVIRONMENT_OVERRIDES_JSON" ] || ENVIRONMENT_OVERRIDES_JSON='{}'
+CURRENT_ENVIRONMENT_JSON="$(printf '%s' "$CURRENT_TD_JSON" | jq -c --arg c "$CONTAINER" \
+  '[.containerDefinitions[] | select(.name == $c) | (.environment // [])][0] // []')"
+MERGED_ENVIRONMENT_JSON="$(merge_environment_overrides "$CURRENT_ENVIRONMENT_JSON" "$ENVIRONMENT_OVERRIDES_JSON")"
+ENVIRONMENT_OVERRIDE_COUNT="$(printf '%s' "$ENVIRONMENT_OVERRIDES_JSON" | jq 'length')"
+if [ "$ENVIRONMENT_OVERRIDE_COUNT" -gt 0 ]; then
+  echo "▶ applied $ENVIRONMENT_OVERRIDE_COUNT explicit non-secret environment override(s)"
+fi
+
 # ── task size (cpu/memory) is owned by Terraform, not by the running task ────
 # Terraform owns task_cpu/task_memory (infra/terraform/modules/ecs-api), but the
 # service carries `ignore_changes = [task_definition]`, so a TF apply that
@@ -225,7 +257,8 @@ NEW_TD_JSON="$(printf '%s' "$CURRENT_TD_JSON" \
   | jq --arg img "$IMAGE" --arg c "$CONTAINER" --arg ver "$VERSION_OVERRIDE" \
        --arg version_env "$VERSION_ENV_NAME" \
        --arg cpu "$DESIRED_CPU" --arg memory "$DESIRED_MEMORY" \
-       --argjson secrets "$SECRETS_JSON" '
+       --argjson secrets "$SECRETS_JSON" \
+       --argjson environment "$MERGED_ENVIRONMENT_JSON" '
       # drop read-only fields register-task-definition rejects
       del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
           .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)
@@ -246,7 +279,7 @@ NEW_TD_JSON="$(printf '%s' "$CURRENT_TD_JSON" \
             .image = $img
             | .secrets = $secrets
             | .environment = (
-                ((.environment // []) | map(
+                ($environment | map(
                   select(
                     .name != "KORTIX_VERSION" and
                     .name != "KORTIX_PUBLIC_VERSION" and

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -82,9 +82,7 @@ variable "container_port" {
 variable "api_environment" {
   description = "Non-secret env vars for the API container (KORTIX_URL, DATABASE host, etc.)."
   type        = map(string)
-  default = {
-    KORTIX_FAST_COLD_BOOT_ENABLED = "true"
-  }
+  default     = {}
 }
 
 variable "api_secrets" {

--- a/tests/unit/ecs-deploy-environment.test.ts
+++ b/tests/unit/ecs-deploy-environment.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '../..');
+
+function mergeEnvironment(
+  current: Array<{ name: string; value: string }>,
+  overrides: Record<string, string>,
+): Array<{ name: string; value: string }> {
+  const output = execFileSync(
+    'bash',
+    [
+      '-c',
+      'source infra/scripts/ecs-deploy.sh; merge_environment_overrides "$CURRENT" "$OVERRIDES"',
+    ],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        KORTIX_ECS_DEPLOY_LIB: '1',
+        CURRENT: JSON.stringify(current),
+        OVERRIDES: JSON.stringify(overrides),
+      },
+    },
+  );
+  return JSON.parse(output);
+}
+
+describe('ECS task environment overrides', () => {
+  it('replaces named values and preserves unrelated task environment', () => {
+    expect(
+      mergeEnvironment(
+        [
+          { name: 'KEEP', value: 'unchanged' },
+          { name: 'KORTIX_FAST_COLD_BOOT_ENABLED', value: 'false' },
+        ],
+        {
+          KORTIX_FAST_COLD_BOOT_ENABLED: 'true',
+          SECOND_FLAG: 'enabled',
+        },
+      ),
+    ).toEqual([
+      { name: 'KEEP', value: 'unchanged' },
+      { name: 'KORTIX_FAST_COLD_BOOT_ENABLED', value: 'true' },
+      { name: 'SECOND_FLAG', value: 'enabled' },
+    ]);
+  });
+
+  it('rejects non-string override values', () => {
+    expect(() =>
+      mergeEnvironment([], { INVALID: 1 } as unknown as Record<string, string>),
+    ).toThrow();
+  });
+
+  it('enables fast cold boot only on the dev API deployment', () => {
+    const workflow = readFileSync(resolve(root, '.github/workflows/deploy-dev.yml'), 'utf8');
+    const deployScript = readFileSync(resolve(root, 'infra/scripts/ecs-deploy.sh'), 'utf8');
+    const apiDeploy = workflow.slice(
+      workflow.indexOf('  deploy-api-ecs:'),
+      workflow.indexOf('  deploy-apps-router:'),
+    );
+    const terraform = readFileSync(
+      resolve(root, 'infra/terraform/environments/dev/variables.tf'),
+      'utf8',
+    );
+
+    expect(apiDeploy).toContain(
+      `KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}'`,
+    );
+    const apiFilter = workflow.slice(
+      workflow.indexOf('            api:'),
+      workflow.indexOf('            gateway:'),
+    );
+    expect(apiFilter).toContain("- 'infra/scripts/ecs-deploy.sh'");
+    expect(deployScript).toContain('--argjson environment "$MERGED_ENVIRONMENT_JSON"');
+    expect(terraform).not.toContain('KORTIX_FAST_COLD_BOOT_ENABLED');
+  });
+});


### PR DESCRIPTION
## Problem

The fast cold boot implementation was merged and deployed, but live sessions still used `kortix-default-*`. Terraform intentionally ignores ECS task definition changes after bootstrap, and `infra/scripts/ecs-deploy.sh` copied the running task environment into every new revision. The dev-only flag in Terraform therefore never reached the API process.

## Change

- Add validated non-secret ECS environment overlays to `ecs-deploy.sh`.
- Set `KORTIX_FAST_COLD_BOOT_ENABLED=true` only in the dev API deployment job.
- Remove the ineffective Terraform declaration.
- Make changes to `ecs-deploy.sh` trigger the dev API pipeline.
- Add regression tests for replacement, preservation, invalid values, and workflow scope.

## Verification

- `bash -n infra/scripts/ecs-deploy.sh`
- `pnpm --dir tests exec vitest run --config unit/vitest.config.ts unit/ecs-deploy-environment.test.ts unit/web-ecs-workflow.test.ts` — 13 passed
- `pnpm exec biome check tests/unit/ecs-deploy-environment.test.ts`
- `git diff --check`

After merge, I will deploy the exact merge SHA and run one warm-up plus five measured live dev session boots.