### PR TITLE
fix(api): ship fast runtime build artifacts

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -217,6 +217,8 @@ COPY --from=app-runtime /out/caddy ./apps/kortix-app-runtime/dist/caddy-linux-am
 COPY apps/sandbox/entrypoint.sh ./apps/sandbox/entrypoint.sh
 COPY apps/sandbox/opencode-warmup.sh ./apps/sandbox/opencode-warmup.sh
 COPY apps/sandbox/MACHINE.md ./apps/sandbox/MACHINE.md
+COPY apps/sandbox/MACHINE.fast.md ./apps/sandbox/MACHINE.fast.md
+COPY apps/sandbox/lazy-tools ./apps/sandbox/lazy-tools
 COPY apps/sandbox/slack-cli ./apps/sandbox/slack-cli
 COPY packages/sdk ./packages/sdk
 

--- a/apps/api/src/__tests__/unit-api-dockerfile-runtime-artifacts.test.ts
+++ b/apps/api/src/__tests__/unit-api-dockerfile-runtime-artifacts.test.ts
@@ -12,6 +12,10 @@ describe('API image sandbox runtime artifacts', () => {
       'COPY apps/sandbox/opencode-warmup.sh ./apps/sandbox/opencode-warmup.sh',
     );
     expect(dockerfile).toContain('COPY apps/sandbox/MACHINE.md ./apps/sandbox/MACHINE.md');
+    expect(dockerfile).toContain(
+      'COPY apps/sandbox/MACHINE.fast.md ./apps/sandbox/MACHINE.fast.md',
+    );
+    expect(dockerfile).toContain('COPY apps/sandbox/lazy-tools ./apps/sandbox/lazy-tools');
   });
 
   test('refreshes the compiled agent time after the final source copy', () => {


### PR DESCRIPTION
## Problem

The first live dev warm-up failed before the provider build:

```
ENOENT: no such file or directory, lstat /app/apps/sandbox/lazy-tools
```

`stageFastBuildContext()` reads `apps/sandbox/lazy-tools` and `apps/sandbox/MACHINE.fast.md` at API runtime. The production API Dockerfile did not copy either path.

## Change

- Copy `MACHINE.fast.md` into the API runtime image.
- Copy `lazy-tools/` into the API runtime image.
- Extend the API Dockerfile artifact regression test.

## Verification

- `bun test apps/api/src/__tests__/unit-api-dockerfile-runtime-artifacts.test.ts` — 3 passed, 0 failed
- `pnpm exec biome check apps/api/src/__tests__/unit-api-dockerfile-runtime-artifacts.test.ts`
- `git diff --check`

After merge, I will deploy the exact merge SHA, warm the fast provider image, then run five measured live boots.