### PR TITLE
perf(sandbox): warm OpenCode instance in fast image

### DIFF
--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -28,7 +28,7 @@ The fast image contains the complete session-critical path:
 
 - Git and the baked scaffold repository
 - Node.js, npm, pnpm, Bun, uv, OpenCode, the Kortix daemon, and the Kortix CLI
-- OpenCode configuration dependencies and its build-time migration warm-up
+- OpenCode configuration dependencies, database migration, and instance warm-up
 - The model catalog, managed skills, and Slack or Teams CLI shims
 
 Large tools install once per sandbox on first use:

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -36,6 +36,11 @@ describe('buildFastSandboxDockerfile', () => {
     expect(dockerfile).toContain('/home/kortix/.bun/bin/bun install --frozen-lockfile');
     expect(dockerfile).toContain('COPY --chown=kortix:kortix artifacts/opencode-warmup');
     expect(dockerfile).toContain('bash /tmp/kortix-opencode-warmup migration');
+    expect(dockerfile).toContain('/opt/kortix/warm-config/.kortix/opencode/');
+    expect(dockerfile).toContain('bash /tmp/kortix-opencode-warmup instance wipe');
+    expect(dockerfile.indexOf('instance wipe')).toBeGreaterThan(
+      dockerfile.indexOf('/opt/kortix/warm-config/.kortix/opencode/'),
+    );
     expect(dockerfile).toContain('/opt/kortix/runtime-versions.json');
     expect(dockerfile).toContain('/ephemeral/kortix-master/opencode');
     expect(dockerfile).toContain('/opt/kortix/lazy-tools/install');

--- a/packages/shared/src/sandbox/fast-dockerfile.ts
+++ b/packages/shared/src/sandbox/fast-dockerfile.ts
@@ -112,10 +112,13 @@ RUN cd /opt/kortix/opencode-config-deps \
 
 COPY --chown=kortix:kortix ${options.opencodeWarmupScriptPath} /tmp/kortix-opencode-warmup
 RUN sudo -u kortix env HOME=/home/kortix PATH="${'$'}{PATH}" \
-      bash /tmp/kortix-opencode-warmup migration \
- && rm -f /tmp/kortix-opencode-warmup
+      bash /tmp/kortix-opencode-warmup migration
 
 COPY --chown=kortix:kortix ${options.opencodeConfigPath}/ /ephemeral/kortix-master/opencode/
+COPY --chown=kortix:kortix ${options.opencodeConfigPath}/ /opt/kortix/warm-config/.kortix/opencode/
+RUN sudo -u kortix env HOME=/home/kortix PATH="${'$'}{PATH}" \
+      bash /tmp/kortix-opencode-warmup instance wipe \
+ && rm -f /tmp/kortix-opencode-warmup
 COPY --chown=kortix:kortix ${options.catalogPath} /opt/kortix/llm-catalog.json
 COPY --chown=kortix:kortix ${options.managedSkillsPath}/ /opt/kortix/managed-skills/
 COPY --chown=kortix:kortix ${options.runtimeVersionsPath} /opt/kortix/runtime-versions.json


### PR DESCRIPTION
## Measured problem

Five live dev boots on `kortix-fast-dev-5093a8be82f45b53` all succeeded, but p50 runtime readiness regressed from 25.288s to 31.340s. The fast image removed config install cost, but OpenCode answering rose from 5.308s to 12.264s.

The standard runtime performs two build-time warm-ups: database migration and one real `/workspace` OpenCode instance. The fast runtime performed only the migration warm-up.

## Change

- Stage the canonical OpenCode config into a temporary warm workspace.
- Start OpenCode during image construction and wait for the real session endpoint.
- Wipe the warm workspace so repository state remains session-specific.
- Preserve OpenCode home caches in the image layer.
- Document both warm-up phases.

## Verification

- `bun test packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts` — 2 passed, 0 failed
- `pnpm exec biome check packages/shared/src/sandbox/fast-dockerfile.ts packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts`
- Generated the full fast build context from production artifacts.
- `docker build -t kortix-fast-warmup:test .` — passed; log: `instance-warm: ready=1`.
- Three fresh local containers reached `/session?directory=/workspace` in 4.202s, 1.998s, and 2.118s.

After merge, I will rebuild the provider image and repeat one excluded warm-up plus five live measured boots.