### PR TITLE
perf(sandbox): precompile fast OpenCode tools

### DIFF
--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -28,7 +28,7 @@ The fast image contains the complete session-critical path:
 
 - Git and the baked scaffold repository
 - Node.js, npm, pnpm, Bun, uv, OpenCode, the Kortix daemon, and the Kortix CLI
-- OpenCode configuration dependencies, database migration, and instance warm-up
+- OpenCode configuration dependencies, tool bundle cache, database migration, and instance warm-up
 - The model catalog, managed skills, and Slack or Teams CLI shims
 
 Large tools install once per sandbox on first use:

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -37,7 +37,16 @@ describe('buildFastSandboxDockerfile', () => {
     expect(dockerfile).toContain('COPY --chown=kortix:kortix artifacts/opencode-warmup');
     expect(dockerfile).toContain('bash /tmp/kortix-opencode-warmup migration');
     expect(dockerfile).toContain('/opt/kortix/warm-config/.kortix/opencode/');
+    expect(dockerfile).toContain(
+      '/home/kortix/.bun/bin/bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check',
+    );
     expect(dockerfile).toContain('bash /tmp/kortix-opencode-warmup instance wipe');
+    expect(dockerfile.indexOf('bun build tools/*.ts')).toBeGreaterThan(
+      dockerfile.indexOf('/opt/kortix/warm-config/.kortix/opencode/'),
+    );
+    expect(dockerfile.indexOf('instance wipe')).toBeGreaterThan(
+      dockerfile.indexOf('bun build tools/*.ts'),
+    );
     expect(dockerfile.indexOf('instance wipe')).toBeGreaterThan(
       dockerfile.indexOf('/opt/kortix/warm-config/.kortix/opencode/'),
     );

--- a/packages/shared/src/sandbox/fast-dockerfile.ts
+++ b/packages/shared/src/sandbox/fast-dockerfile.ts
@@ -116,6 +116,11 @@ RUN sudo -u kortix env HOME=/home/kortix PATH="${'$'}{PATH}" \
 
 COPY --chown=kortix:kortix ${options.opencodeConfigPath}/ /ephemeral/kortix-master/opencode/
 COPY --chown=kortix:kortix ${options.opencodeConfigPath}/ /opt/kortix/warm-config/.kortix/opencode/
+RUN cd /opt/kortix/warm-config/.kortix/opencode \
+ && rm -rf node_modules \
+ && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \
+ && /home/kortix/.bun/bin/bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check \
+ && rm -rf /tmp/opencode-tools-bundle-check
 RUN sudo -u kortix env HOME=/home/kortix PATH="${'$'}{PATH}" \
       bash /tmp/kortix-opencode-warmup instance wipe \
  && rm -f /tmp/kortix-opencode-warmup


### PR DESCRIPTION
## Problem

The first dev benchmark exposed a remaining OpenCode regression. The standard image precompiles the complete starter tool graph, but the fast image only precompiled two dependency files.

## Change

- Precompile every starter OpenCode tool before the fast image instance warm-up.
- Keep the generated bundles out of the final image.
- Assert the cache build occurs before the instance warm-up.
- Document the tool bundle cache.

## Evidence

- `bun test packages/shared/src/sandbox`: 69 pass, 0 fail.
- Focused renderer test: 2 pass, 0 fail, 35 assertions.
- Full linux/arm64 Docker image build: pass; 280 modules bundled.
- Three fresh local containers, old image: 6842ms, 5290ms, 5357ms.
- Three fresh local containers, new image: 2027ms, 2101ms, 2055ms.
- Median OpenCode startup: 5357ms -> 2055ms (-61.6%).
- Biome: pass.
- `git diff --check`: pass.

`@kortix/shared` typecheck still reports the existing `src/project-glyphs.test.ts:32` error. This PR does not change that file.