### PR TITLE
infra(selfhost): bake a daily docker-prune timer into the box

### DIFF
--- a/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
+++ b/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
@@ -185,6 +185,48 @@ systemctl enable --now containerd.service
 systemctl enable --now docker.service
 docker compose version >/dev/null 2>&1 || { echo "FATAL: docker compose plugin unavailable after install" >&2; exit 1; }
 
+# ── 2b. Daily Docker prune. The box pulls the rolling dev-latest/stable image
+#    tags on every self-update; each `docker compose pull` leaves the PREVIOUS
+#    image digest dangling. Unpruned they fill the data volume and crash-loop
+#    Postgres with "No space left on device" (root-caused live 2026-08-19 on
+#    essentia: 24GB dangling images + 40GB build cache). Prune only removes what
+#    NO container references, so it is safe unattended even mid-rollout. A
+#    systemd timer (not a cron) so `Persistent=true` catches a missed run and
+#    it survives reboots.
+cat > /usr/local/bin/kortix-docker-prune.sh <<'PRUNE'
+#!/usr/bin/env bash
+set -uo pipefail
+docker image prune -af    >/dev/null 2>&1 || true
+docker builder prune -af  >/dev/null 2>&1 || true
+docker container prune -f >/dev/null 2>&1 || true
+logger -t kortix-docker-prune "reclaim pass complete ($(df -h "$(docker info -f '{{.DockerRootDir}}' 2>/dev/null || echo /)" 2>/dev/null | awk 'NR==2{print $4" free on "$6}'))"
+PRUNE
+chmod +x /usr/local/bin/kortix-docker-prune.sh
+cat > /etc/systemd/system/kortix-docker-prune.service <<'UNIT'
+[Unit]
+Description=Kortix self-host: prune unused Docker images + build cache
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/kortix-docker-prune.sh
+UNIT
+cat > /etc/systemd/system/kortix-docker-prune.timer <<'UNIT'
+[Unit]
+Description=Daily Kortix Docker prune
+
+[Timer]
+OnCalendar=*-*-* 04:30:00
+Persistent=true
+RandomizedDelaySec=900
+
+[Install]
+WantedBy=timers.target
+UNIT
+systemctl daemon-reload
+systemctl enable --now kortix-docker-prune.timer
+
 # ── 3. Pin KORTIX_SELF_HOST_CONFIG_DIR — every kortix invocation (this
 #    script's systemd unit, and any later `kortix self-host ...` an operator
 #    runs over SSM) must agree on where the instance lives, or the CLI creates


### PR DESCRIPTION
## Problem

On 2026-08-19 the essentia self-host box crash-looped Postgres with `could not write lock file "postmaster.pid": No space left on device`. The data volume (`/mnt/kortix-data`) had filled with **24 GB dangling images + 40 GB build cache**. Root cause: the box `docker compose pull`s the rolling `dev-latest`/`stable` tags on every self-update, and each pull leaves the previous image digest dangling — nothing ever prunes them. (Downstream symptoms were nasty and misleading: Docker couldn't write network state so `supabase-db` showed an "invalid IP" and DNS `getaddrinfo ENOTFOUND` before the disk cause was clear.)

## Fix

Bake a daily `systemd` timer (`kortix-docker-prune`, 04:30 + jitter, `Persistent=true`) into the box user_data — `docker image prune -af` + `docker builder prune -af` + `docker container prune -f`. Safe unattended: prune only removes what **no** container references, so running containers keep theirs even mid-rollout. Mirrors the `growfs` timer already in this template. Every self-host box now gets this by default.

## Verification
- Installed live on essentia (via `kortix-infra` while this lands) — reclaimed **64 GB**, data volume back to 36% used / 60 G free; timer armed (`systemctl list-timers`), test run logged.
- No Terraform interpolation in the added block (verified no stray `${`), so `templatefile()` renders it verbatim.

## Related (not in this PR)
- Essentia's CloudWatch agent was never actually installed, so the module's existing `disk_usage_data`/`disk_usage_root` alarms sat in INSUFFICIENT_DATA since box creation and never fired — the module's `%{ if enable_alarms }` install block postdates that box's user_data run. Installed the agent on the box by hand so the alarms now get data; no module change needed (the install block is already correct for new boxes).
