### PR TITLE
perf(sandbox): align fast runtime base with Ubuntu

### DIFF
--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -26,6 +26,7 @@ The standard image remains available through the same flag.
 
 The fast image contains the complete session-critical path:
 
+- Ubuntu 24.04, matching the standard runtime's faster OpenCode startup path
 - Git and the baked scaffold repository
 - Node.js, npm, pnpm, Bun, uv, OpenCode, the Kortix daemon, and the Kortix CLI
 - OpenCode configuration dependencies, tool bundle cache, database migration, and instance warm-up

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -20,7 +20,7 @@ describe('buildFastSandboxDockerfile', () => {
       scaffoldPath: 'artifacts/scaffold.git',
     });
 
-    expect(dockerfile).toContain('FROM debian:bookworm-slim');
+    expect(dockerfile).toContain('FROM ubuntu:24.04');
     expect(dockerfile).toContain('opencode-ai@1.17.11');
     expect(dockerfile).toContain('pnpm-linux-${pnpm_arch}.tar.gz');
     expect(dockerfile).toContain('bun-v1.3.14');

--- a/packages/shared/src/sandbox/fast-dockerfile.ts
+++ b/packages/shared/src/sandbox/fast-dockerfile.ts
@@ -37,7 +37,7 @@ export interface FastSandboxDockerfileOptions {
  */
 export function buildFastSandboxDockerfile(options: FastSandboxDockerfileOptions): string {
   return `# syntax=docker/dockerfile:1.7
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \


### PR DESCRIPTION
## Problem

The flagged fast image still started OpenCode slower than the standard image on dev. Both images use the same OpenCode version and warm-up, but the fast image ran Debian while the standard image ran Ubuntu 24.04.

## Change

- Run the flagged fast image on Ubuntu 24.04.
- Keep the package set and lazy-tool model unchanged.
- Assert the runtime base in the renderer test.
- Document the base alignment.

## Evidence

- `bun test packages/shared/src/sandbox`: 69 pass, 0 fail.
- Biome: pass.
- Full Ubuntu linux/arm64 image build: pass.
- Debian image size: 1,601,512,465 bytes.
- Ubuntu image size: 1,577,282,432 bytes (-24,230,033 bytes).
- Five fresh Debian containers: 7642ms, 5705ms, 5474ms, 5822ms, 5494ms; median 5705ms.
- Five fresh Ubuntu containers: 2146ms, 4065ms, 2077ms, 2012ms, 2083ms; median 2083ms.
- Median local OpenCode startup: 5705ms -> 2083ms (-63.5%).
- `git diff --check`: pass.