### PR TITLE
fix: every managed model works in every sandbox + session.error renders in place + keyboard scroll intent

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,34 @@ linked, not inlined.
 
 ## Register
 
+### A picker that offers a model the runtime does not know is a silent outage; the runtime must learn the set from the API it talks to (2026-08-19)
+
+**When:** adding or changing a managed model (`LLM_GATEWAY_MANAGED_MODELS`,
+`@kortix/llm-catalog` MANAGED_MODELS), or touching how the sandbox daemon
+builds OpenCode's `kortix` provider (`apps/kortix-sandbox-agent-server/src/opencode.ts`).
+The web picker reads the API (`/model-picker`, `/v1/llm/models`); OpenCode in the
+guest accepts only the ids in the provider map it BOOTED with, built from the
+image-baked `/opt/kortix/llm-catalog.json`. That file is frozen at template-build
+time and nothing rebuilds a template for a catalog change, so every managed
+model added after the bake is offered by the picker and rejected by the guest
+(`ModelNotFound: kortix/<id>`, 2 ms after the user message, before any gateway
+call). Rules: (1) the guest must fetch the managed set from the API on EVERY boot
+(`GET /models?scope=managed`, ~3 KB) and overlay it — never trust a baked list
+for anything deployment-config decides; (2) a boot-path fetch gets its own small
+budget and a bundled fallback, and is started in parallel with the clone, never
+awaited on the critical path beyond a cap; (3) a catalog "refresh" that can
+silently fall back (here 2.5 s/4 s for a 3.3 MB body) is not a refresh — size the
+payload to the budget; (4) a `session.error` with no assistant message must be
+rendered under the turn that failed, or the user sees nothing at all.
+*Incident:* prod 2026-08-19, `grok-4.6` and `deepseek-v4-pro-0813` (added
+2026-08-12/13) returned no reply in every session on templates built before
+then; 0 gateway log rows ever. PR #6576.
+*Enforcer:* `managed-fallback-sync.test.ts` (bundled table vs `MANAGED_MODELS`
+drift), `managed-model-overlay.test.ts` (stale file + live overlay; failed
+fetch → bundled floor; await cap), `managed-scope.test.ts`; web: sync-store
+per-turn `session.error` tests. Not enforced: a live "picker ⊆ guest provider
+map" assertion after deploy — run the dev sweep by hand until it exists.
+
 ### A request/response log must never cap what it captures (2026-08-18)
 
 **When:** persisting or rendering a captured request/response body (gateway

--- a/apps/api/src/llm-gateway/hooks.ts
+++ b/apps/api/src/llm-gateway/hooks.ts
@@ -432,8 +432,12 @@ export function createInProcessGatewayHooks(): GatewayHooks {
     assertBudget: assertGatewayBudget,
     recordUsage: recordGatewayUsage,
     recordTrace: persistGatewayTrace,
-    listModels: async (principal) =>
-      gatewayModelCatalog(principal.projectId, {
+    // `managedOnly` drops the projectId, which is exactly what selects
+    // MANAGED_ONLY in gatewayModelCatalog — BYOK/codex models are gated on a
+    // project. The free-tier rule is untouched: a free account still sees an
+    // empty managed set.
+    listModels: async (principal, opts) =>
+      gatewayModelCatalog(opts?.managedOnly ? undefined : principal.projectId, {
         freeManagedOnly: !!principal.freeModelsOnly,
       }),
   };

--- a/apps/api/src/llm-gateway/internal-routes.ts
+++ b/apps/api/src/llm-gateway/internal-routes.ts
@@ -107,10 +107,14 @@ export function createInternalGatewayRoutes() {
   });
 
   app.post('/models', async (c) => {
-    const { principal } = await c.req.json();
+    const { principal, managedOnly } = await c.req.json();
     const p = principal as AuthedPrincipal;
+    // `managedOnly` backs the standalone gateway's `GET /models?scope=managed`
+    // — the compact managed lineup a sandbox fetches on boot. Dropping the
+    // projectId is what selects MANAGED_ONLY; free-tier accounts still get an
+    // empty managed set.
     return c.json({
-      models: gatewayModelCatalog(p.projectId, {
+      models: gatewayModelCatalog(managedOnly === true ? undefined : p.projectId, {
         freeManagedOnly: !!p.freeModelsOnly,
       }),
     });

--- a/apps/api/src/llm-gateway/managed-scope.test.ts
+++ b/apps/api/src/llm-gateway/managed-scope.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { createGateway, type GatewayHooks, type ModelCatalog } from '@kortix/llm-gateway';
+
+// `GET /models?scope=managed` — the compact managed-lineup listing every
+// sandbox fetches on boot.
+//
+// Why it exists: the managed lineup is deployment config, but each sandbox
+// image bakes the catalog at template-build time. A managed model added after
+// the last build is therefore absent from the box forever, and OpenCode — which
+// reads provider models once, at process start — answers
+// `ModelNotFound: kortix/<id>` for it (prod, 2026-08-19: grok-4.6 and
+// deepseek-v4-pro-0813 returned nothing to the user). The sandbox now learns
+// the managed set from this route on every boot.
+//
+// Two mounts serve it and both are covered here:
+//   1. in-process (`/v1/llm/models`, apps/api wire.ts) → createGateway
+//   2. standalone gateway pod → POST /internal/gateway/models (internal-routes)
+
+mock.module('../lib/logger', () => ({
+  logger: { warn: mock(() => {}), info: mock(() => {}), error: mock(() => {}), debug: mock(() => {}) },
+}));
+const actualBillingGate = await import('../billing/services/billing-gate');
+mock.module('../billing/services/billing-gate', () => ({
+  ...actualBillingGate,
+  assertBillingActive: async () => undefined,
+}));
+mock.module('./budgets', () => ({ checkBudget: async () => ({ exceeded: false }) }));
+const actualHooks = await import('./hooks');
+mock.module('./hooks', () => ({
+  ...actualHooks,
+  authenticatePrincipal: async () => null,
+  authorizeRequest: async () => ({ ok: true }),
+  persistGatewayTrace: async () => {},
+  recordGatewayUsage: async () => {},
+}));
+mock.module('./routing', () => ({
+  resolveGatewayRoute: async () => null,
+}));
+mock.module('./resolution/resolve-candidates', () => ({
+  resolveCandidates: async () => [],
+}));
+
+const { createInternalGatewayRoutes } = await import('./internal-routes');
+const { gatewayModelCatalog } = await import('./models/catalog-models');
+
+const TOKEN = 'test-internal-token-aaaaaaaaaaaaaaaaaaaaaaaa';
+
+function internalApp() {
+  process.env.GATEWAY_INTERNAL_TOKEN = TOKEN;
+  return createInternalGatewayRoutes();
+}
+
+function modelsRequest(body: unknown) {
+  return new Request('http://test/models', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${TOKEN}` },
+    body: JSON.stringify(body),
+  });
+}
+
+async function internalModels(body: unknown): Promise<ModelCatalog> {
+  const res = await internalApp().request(modelsRequest(body));
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { models: ModelCatalog }).models;
+}
+
+describe('POST /internal/gateway/models — managedOnly', () => {
+  test('managedOnly serves EXACTLY the managed lineup, no BYOK/codex models', async () => {
+    const managed = await internalModels({
+      principal: { userId: 'u', accountId: 'a', projectId: 'p', keyId: 'k' },
+      managedOnly: true,
+    });
+
+    expect(Object.keys(managed).sort()).toEqual(Object.keys(gatewayModelCatalog(undefined)).sort());
+    expect(managed['grok-4.6']).toBeDefined();
+    expect(managed['deepseek-v4-pro-0813']).toBeDefined();
+    expect(managed['anthropic/claude-opus-4-8']).toBeUndefined();
+    expect(managed['codex/gpt-5.6-sol']).toBeUndefined();
+    // ~3KB instead of ~3.3MB is the whole point of the scope.
+    expect(JSON.stringify(managed).length).toBeLessThan(20_000);
+  });
+
+  test('the default (no managedOnly) response is unchanged — full project catalog', async () => {
+    const full = await internalModels({
+      principal: { userId: 'u', accountId: 'a', projectId: 'p', keyId: 'k' },
+    });
+
+    expect(Object.keys(full).sort()).toEqual(Object.keys(gatewayModelCatalog('p')).sort());
+    expect(full['anthropic/claude-opus-4-8']).toBeDefined();
+    expect(Object.keys(full).length).toBeGreaterThan(
+      Object.keys(gatewayModelCatalog(undefined)).length,
+    );
+  });
+
+  test('a free-tier account still gets an EMPTY managed set', async () => {
+    const managed = await internalModels({
+      principal: { userId: 'u', accountId: 'a', projectId: 'p', keyId: 'k', freeModelsOnly: true },
+      managedOnly: true,
+    });
+
+    expect(managed).toEqual({});
+  });
+});
+
+describe('gateway.listModels — scope plumbing', () => {
+  const principal = { userId: 'u1', accountId: 'a1', projectId: 'p1', keyId: 'k1' };
+
+  function gatewayWithSpy(): {
+    call: () => { seen: Array<{ managedOnly?: boolean } | undefined> };
+    gateway: ReturnType<typeof createGateway>;
+  } {
+    const seen: Array<{ managedOnly?: boolean } | undefined> = [];
+    const hooks: GatewayHooks = {
+      authenticate: async (token) => (token === 'good' ? principal : null),
+      resolveUpstream: async () => [],
+      assertBillingActive: async () => {},
+      recordUsage: async () => {},
+      listModels: async (_p, opts): Promise<ModelCatalog> => {
+        seen.push(opts);
+        return opts?.managedOnly ? { 'grok-4.6': { name: 'Grok 4.6' } } : { 'a/b': { name: 'B' } };
+      },
+    };
+    return { call: () => ({ seen }), gateway: createGateway(hooks, {}) };
+  }
+
+  test('passes managedOnly straight to the catalog hook', async () => {
+    const { call, gateway } = gatewayWithSpy();
+    const res = await gateway.listModels('Bearer good', { managedOnly: true });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as unknown).toEqual({ models: { 'grok-4.6': { name: 'Grok 4.6' } } });
+    expect(call().seen).toEqual([{ managedOnly: true }]);
+  });
+
+  test('a call with no options keeps the old contract exactly', async () => {
+    const { call, gateway } = gatewayWithSpy();
+    const res = await gateway.listModels('Bearer good');
+    expect(res.status).toBe(200);
+    expect((await res.json()) as unknown).toEqual({ models: { 'a/b': { name: 'B' } } });
+    expect(call().seen).toEqual([undefined]);
+  });
+
+  test('the scope never bypasses auth', async () => {
+    const { gateway } = gatewayWithSpy();
+    expect((await gateway.listModels(undefined, { managedOnly: true })).status).toBe(401);
+    expect((await gateway.listModels('Bearer bad', { managedOnly: true })).status).toBe(401);
+  });
+});

--- a/apps/api/src/llm-gateway/models/managed-fallback-sync.test.ts
+++ b/apps/api/src/llm-gateway/models/managed-fallback-sync.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { MANAGED_MODELS } from '@kortix/llm-catalog';
+
+// The sandbox daemon's LAST-RESORT managed set. It is what OpenCode's `kortix`
+// provider registers when the box has a stale baked catalog AND the live
+// managed fetch (`GET /models?scope=managed`) fails — i.e. the floor under the
+// 2026-08-19 outage, where OpenCode answered `ModelNotFound: kortix/grok-4.6`
+// for a managed model the API had been serving since 2026-08-13.
+//
+// Imported across app boundaries ON PURPOSE: this file is the tripwire that
+// fails the moment the managed lineup and that hand-maintained table drift.
+import { BUNDLED_MANAGED_MODELS } from '../../../../kortix-sandbox-agent-server/src/opencode';
+import { gatewayModelCatalog } from './catalog-models';
+
+const managedIds = MANAGED_MODELS.map((m) => m.id).sort();
+const bundledIds = Object.keys(BUNDLED_MANAGED_MODELS).sort();
+
+describe('daemon bundled managed set vs the managed lineup', () => {
+  test('every @kortix/llm-catalog managed model exists in the daemon fallback', () => {
+    const missing = managedIds.filter((id) => !BUNDLED_MANAGED_MODELS[id]);
+    expect(missing).toEqual([]);
+  });
+
+  // The other direction matters just as much: a bundled entry for a model the
+  // gateway no longer serves resolves as model_not_found and 400s every turn
+  // that selects it (see the commented-out kimi-k3 / claude entries in
+  // opencode.ts, deactivated by the 2026-08-10 slim-down).
+  test('the daemon fallback advertises no model the managed lineup dropped', () => {
+    const extra = bundledIds.filter((id) => !managedIds.includes(id));
+    expect(extra).toEqual([]);
+  });
+
+  test('the fallback matches what the gateway actually serves as managed-only', () => {
+    expect(bundledIds).toEqual(Object.keys(gatewayModelCatalog(undefined)).sort());
+  });
+
+  test('every bundled managed entry is branded as a Kortix-managed bare id', () => {
+    for (const [id, model] of Object.entries(BUNDLED_MANAGED_MODELS)) {
+      expect(id).not.toInclude('/');
+      expect(model.provider).toBe('kortix');
+      expect(model.limit?.context).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -343,6 +343,18 @@ function modelsRoute(path: string) {
     tags: [GATEWAY_INFERENCE_TAG],
     summary: `GET ${fullPath}`,
     description: `Servable model catalog for the caller\'s account/project — a keyed object (NOT the OpenAI \`{object:"list",data:[...]}\` array shape) mapping model id → capabilities.\n\nAuth: ${AUTH_DESCRIPTION}\n\n\`\`\`\ncurl -sS $KORTIX_API_URL${fullPath} -H "Authorization: Bearer $KORTIX_GATEWAY_KEY"\n\`\`\``,
+    request: {
+      query: z.object({
+        scope: z
+          .enum(['managed'])
+          .optional()
+          .openapi({
+            description:
+              'Set to `managed` for the platform-managed lineup only (~3KB instead of ~3.3MB). Sandboxes call this on every boot to learn the current managed set. Omit for the caller\'s full catalog.',
+            example: 'managed',
+          }),
+      }),
+    },
     ...auth,
     responses: { 200: json(ModelsResponseSchema, 'Servable model catalog'), ...errors(401, 502) },
   });
@@ -384,7 +396,16 @@ export function mountLlmGateway(app: OpenAPIHono): void {
         // billing for) upstream tokens no one is listening for anymore.
         signal: c.req.raw.signal,
       });
-    const models = (c: import('hono').Context) => gateway.listModels(c.req.header('authorization'));
+    // `?scope=managed` serves ONLY the platform-managed lineup (~3KB) instead
+    // of the project's full catalog (~3.3MB). Every sandbox calls it on boot to
+    // learn the current managed set — the catalog baked into its image is stale
+    // as soon as the managed lineup changes (prod incident 2026-08-19:
+    // `ModelNotFound: kortix/grok-4.6`). Auth and free-tier semantics are
+    // identical to the default listing; no param = byte-identical response.
+    const models = (c: import('hono').Context) =>
+      gateway.listModels(c.req.header('authorization'), {
+        managedOnly: c.req.query('scope') === 'managed',
+      });
     const messages = async (c: import('hono').Context) =>
       gateway.messages({
         authorization: c.req.header('authorization'),

--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-latency.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-latency.test.ts
@@ -7,6 +7,7 @@ import { spawnSync } from 'node:child_process'
 import { loadConfig } from '../config'
 import { isShallowRepo, scheduleHistoryBackfill } from '../git'
 import {
+  BUNDLED_MANAGED_MODELS,
   MINIMAL_FALLBACK_MODELS,
   buildOpencodeConfigContent,
   catalogIsDegraded,
@@ -188,7 +189,7 @@ describe('building the opencode boot config never touches the network', () => {
     expect(Object.keys(parsed.provider.kortix.models)).toEqual(Object.keys(MINIMAL_FALLBACK_MODELS))
   })
 
-  test('a catalog file on disk is used verbatim, still with no fetch', async () => {
+  test('a catalog file on disk is used verbatim (plus the managed floor), still with no fetch', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'kortix-catalog-'))
     tempDirs.push(dir)
     const file = join(dir, 'catalog.json')
@@ -206,7 +207,14 @@ describe('building the opencode boot config never touches the network', () => {
     } as NodeJS.ProcessEnv)
     const parsed = JSON.parse(raw!) as { provider: { kortix: { models: Record<string, unknown> } } }
 
-    expect(Object.keys(parsed.provider.kortix.models)).toEqual(['test/only-model'])
+    // The file's own models survive untouched...
+    expect(parsed.provider.kortix.models['test/only-model']).toBeDefined()
+    // ...and the BUNDLED managed set fills the ids it lacks, so a baked catalog
+    // that predates a managed-lineup change can never hide a managed model from
+    // OpenCode (prod incident 2026-08-19). Still zero network on the boot path.
+    for (const id of Object.keys(BUNDLED_MANAGED_MODELS)) {
+      expect(parsed.provider.kortix.models[id]).toBeDefined()
+    }
     expect(calls).toEqual([])
   })
 

--- a/apps/kortix-sandbox-agent-server/src/__tests__/managed-model-overlay.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/managed-model-overlay.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  BUNDLED_MANAGED_MODELS,
+  buildOpencodeConfigContent,
+  fetchManagedModels,
+  refreshGatewayCatalogFile,
+  resetManagedModelsStateForTests,
+  startManagedModelsPrefetch,
+  withManagedOverlay,
+} from '../opencode'
+
+// The 2026-08-19 outage in one sentence: the image-baked catalog is frozen at
+// template-build time, the managed lineup is deployment config, so a managed
+// model added after the last build was absent from OpenCode's provider map and
+// every turn on it died with `ModelNotFound: kortix/<id>` 2ms after the prompt.
+// These tests pin the fix — the sandbox learns the managed set from the API it
+// talks to, on every boot, and never falls below the bundled managed floor.
+
+const GATEWAY = {
+  KORTIX_WORKSPACE: '/workspace',
+  KORTIX_LLM_BASE_URL: 'https://gw.kortix.test/v1',
+  KORTIX_LLM_API_KEY: 'gw-key',
+}
+
+// A baked catalog that predates the managed-lineup change: it carries a BYOK
+// model and exactly one managed model, missing the rest.
+const STALE_BAKED = {
+  models: {
+    'openai/gpt-5.5': { name: 'GPT-5.5', provider: 'openai', limit: { context: 400_000 } },
+    'deepseek-v4-flash': { name: 'DeepSeek V4 Flash (stale)', provider: 'kortix' },
+  },
+}
+
+const LIVE_MANAGED = {
+  models: {
+    'deepseek-v4-flash': { name: 'DeepSeek V4 Flash', provider: 'kortix' },
+    'grok-4.6': { name: 'Grok 4.6', provider: 'kortix', limit: { context: 500_000 } },
+    'new-managed-9.9': { name: 'New Managed 9.9', provider: 'kortix' },
+  },
+}
+
+const realFetch = globalThis.fetch
+const tempDirs: string[] = []
+
+async function bakedCatalogFile(body: unknown = STALE_BAKED): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'kortix-managed-'))
+  tempDirs.push(dir)
+  const file = join(dir, 'catalog.json')
+  await writeFile(file, JSON.stringify(body))
+  return file
+}
+
+type ProviderConfig = { provider: { kortix: { models: Record<string, { name?: string }> } } }
+
+function providerModels(raw: string | undefined): Record<string, { name?: string }> {
+  return (JSON.parse(raw!) as ProviderConfig).provider.kortix.models
+}
+
+beforeEach(() => {
+  resetManagedModelsStateForTests()
+})
+
+afterEach(async () => {
+  globalThis.fetch = realFetch
+  resetManagedModelsStateForTests()
+  await Promise.all(tempDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })))
+})
+
+describe('managed listing fetch', () => {
+  test('asks the gateway for the managed scope only', async () => {
+    const urls: string[] = []
+    globalThis.fetch = (async (input: string) => {
+      urls.push(String(input))
+      return new Response(JSON.stringify(LIVE_MANAGED), { status: 200 })
+    }) as unknown as typeof fetch
+
+    const models = await fetchManagedModels('https://gw.kortix.test/v1', 'k')
+
+    expect(urls).toEqual(['https://gw.kortix.test/v1/models?scope=managed'])
+    expect(Object.keys(models ?? {}).sort()).toEqual([
+      'deepseek-v4-flash',
+      'grok-4.6',
+      'new-managed-9.9',
+    ])
+  })
+
+  test('retries a failing gateway inside its budget, then gives up', async () => {
+    let calls = 0
+    globalThis.fetch = (async () => {
+      calls++
+      return new Response('nope', { status: 503 })
+    }) as unknown as typeof fetch
+
+    const started = Date.now()
+    const models = await fetchManagedModels('https://gw.kortix.test/v1', 'k')
+
+    expect(models).toBeNull()
+    expect(calls).toBe(3)
+    expect(Date.now() - started).toBeLessThan(5_500)
+  })
+
+  test('an empty managed set (free tier) is not an overlay', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ models: {} }), { status: 200 })) as unknown as typeof fetch
+
+    expect(await fetchManagedModels('https://gw.kortix.test/v1', 'k')).toBeNull()
+  })
+})
+
+describe('boot config composition', () => {
+  test('a stale baked catalog is overlaid with the LIVE managed set', async () => {
+    globalThis.fetch = (async (input: string) => {
+      expect(String(input)).toContain('scope=managed')
+      return new Response(JSON.stringify(LIVE_MANAGED), { status: 200 })
+    }) as unknown as typeof fetch
+
+    startManagedModelsPrefetch(GATEWAY.KORTIX_LLM_BASE_URL, GATEWAY.KORTIX_LLM_API_KEY)
+    const raw = await buildOpencodeConfigContent({
+      ...GATEWAY,
+      KORTIX_LLM_CATALOG_FILE: await bakedCatalogFile(),
+    } as NodeJS.ProcessEnv)
+    const models = providerModels(raw)
+
+    // The model the baked image never heard of is now registered.
+    expect(models['grok-4.6']).toBeDefined()
+    expect(models['new-managed-9.9']).toBeDefined()
+    // Live data wins over the stale baked record for a managed id.
+    expect(models['deepseek-v4-flash']?.name).toBe('DeepSeek V4 Flash')
+    // BYOK models from the baked catalog are untouched.
+    expect(models['openai/gpt-5.5']).toBeDefined()
+  })
+
+  test('a failed managed fetch still leaves the bundled managed floor', async () => {
+    globalThis.fetch = (async () =>
+      new Response('down', { status: 500 })) as unknown as typeof fetch
+
+    startManagedModelsPrefetch(GATEWAY.KORTIX_LLM_BASE_URL, GATEWAY.KORTIX_LLM_API_KEY)
+    const raw = await buildOpencodeConfigContent({
+      ...GATEWAY,
+      KORTIX_LLM_CATALOG_FILE: await bakedCatalogFile(),
+    } as NodeJS.ProcessEnv)
+    const models = providerModels(raw)
+
+    for (const id of Object.keys(BUNDLED_MANAGED_MODELS)) {
+      expect(models[id]).toBeDefined()
+    }
+    // Fill-only: the hand-maintained table never overwrites the baked record.
+    expect(models['deepseek-v4-flash']?.name).toBe('DeepSeek V4 Flash (stale)')
+    expect(models['openai/gpt-5.5']).toBeDefined()
+  })
+
+  test('a hanging gateway cannot hold the OpenCode spawn past the await cap', async () => {
+    globalThis.fetch = (async () => {
+      await new Promise((r) => setTimeout(r, 60_000))
+      return new Response('{}', { status: 200 })
+    }) as unknown as typeof fetch
+
+    startManagedModelsPrefetch(GATEWAY.KORTIX_LLM_BASE_URL, GATEWAY.KORTIX_LLM_API_KEY)
+    const started = Date.now()
+    const raw = await buildOpencodeConfigContent({
+      ...GATEWAY,
+      KORTIX_LLM_CATALOG_FILE: await bakedCatalogFile(),
+    } as NodeJS.ProcessEnv)
+    const elapsed = Date.now() - started
+    const models = providerModels(raw)
+
+    expect(elapsed).toBeLessThan(4_000)
+    // It waited for the in-flight answer rather than skipping it outright...
+    expect(elapsed).toBeGreaterThan(1_500)
+    // ...and fell back to the bundled floor instead of shipping a short picker.
+    expect(models['grok-4.6']).toBeDefined()
+  }, 15_000)
+
+  test('with no prefetch started the boot path stays network-free', async () => {
+    const calls: string[] = []
+    globalThis.fetch = (async (input: string) => {
+      calls.push(String(input))
+      return new Response(JSON.stringify(LIVE_MANAGED), { status: 200 })
+    }) as unknown as typeof fetch
+
+    const raw = await buildOpencodeConfigContent({
+      ...GATEWAY,
+      KORTIX_LLM_CATALOG_FILE: await bakedCatalogFile(),
+    } as NodeJS.ProcessEnv)
+
+    expect(calls).toEqual([])
+    expect(providerModels(raw)['grok-4.6']).toBeDefined()
+  })
+})
+
+describe('warm-fork adoption refresh', () => {
+  async function refreshWith(
+    current: unknown,
+    full: unknown,
+    managed: unknown,
+  ): Promise<{ changed: boolean; written: Record<string, unknown> }> {
+    const dir = await mkdtemp(join(tmpdir(), 'kortix-adopt-'))
+    tempDirs.push(dir)
+    const currentFile = join(dir, 'baked.json')
+    const targetFile = join(dir, 'session.json')
+    await writeFile(currentFile, JSON.stringify(current))
+    globalThis.fetch = (async (input: string) =>
+      new Response(JSON.stringify(String(input).includes('scope=managed') ? managed : full), {
+        status: 200,
+      })) as unknown as typeof fetch
+
+    const result = await refreshGatewayCatalogFile({
+      currentCatalogFile: currentFile,
+      targetCatalogFile: targetFile,
+      fetchBaseURL: GATEWAY.KORTIX_LLM_BASE_URL,
+      fetchApiKey: GATEWAY.KORTIX_LLM_API_KEY,
+    })
+    const written = JSON.parse(await readFile(targetFile, 'utf8')) as {
+      models: Record<string, unknown>
+    }
+    return { changed: !!result?.changed, written: written.models }
+  }
+
+  test('reports changed when only the MANAGED set differs', async () => {
+    const full = { models: STALE_BAKED.models }
+    const { changed, written } = await refreshWith(STALE_BAKED, full, LIVE_MANAGED)
+
+    // The full catalog is byte-identical to the current file; the managed
+    // overlay is the only difference — and it MUST still trip the controlled
+    // OpenCode restart, because OpenCode reads providers at process start.
+    expect(changed).toBe(true)
+    expect(written['grok-4.6']).toBeDefined()
+  })
+
+  test('an unchanged catalog + unchanged managed set keeps the no-restart path', async () => {
+    const composed = withManagedOverlay(STALE_BAKED.models, LIVE_MANAGED.models)
+    const { changed } = await refreshWith(
+      { models: composed },
+      { models: STALE_BAKED.models },
+      LIVE_MANAGED,
+    )
+
+    expect(changed).toBe(false)
+  })
+
+  test('a dead full-catalog fetch still lands the managed overlay on the session file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kortix-adopt-'))
+    tempDirs.push(dir)
+    const currentFile = join(dir, 'baked.json')
+    const targetFile = join(dir, 'session.json')
+    await writeFile(currentFile, JSON.stringify(STALE_BAKED))
+    globalThis.fetch = (async (input: string) =>
+      String(input).includes('scope=managed')
+        ? new Response(JSON.stringify(LIVE_MANAGED), { status: 200 })
+        : new Response('boom', { status: 500 })) as unknown as typeof fetch
+
+    const result = await refreshGatewayCatalogFile({
+      currentCatalogFile: currentFile,
+      targetCatalogFile: targetFile,
+      fetchBaseURL: GATEWAY.KORTIX_LLM_BASE_URL,
+      fetchApiKey: GATEWAY.KORTIX_LLM_API_KEY,
+    })
+    const written = JSON.parse(await readFile(targetFile, 'utf8')) as {
+      models: Record<string, unknown>
+    }
+
+    expect(result?.changed).toBe(true)
+    expect(written.models['grok-4.6']).toBeDefined()
+    expect(written.models['openai/gpt-5.5']).toBeDefined()
+  }, 20_000)
+})
+
+describe('withManagedOverlay', () => {
+  test('a live managed set is authoritative for its ids and additive elsewhere', () => {
+    const out = withManagedOverlay(
+      { 'a/b': { name: 'B' }, 'grok-4.6': { name: 'old' } },
+      { 'grok-4.6': { name: 'new' }, 'x-1': { name: 'X' } },
+    )
+    expect(out['grok-4.6']?.name).toBe('new')
+    expect(out['a/b']?.name).toBe('B')
+    expect(out['x-1']?.name).toBe('X')
+  })
+
+  test('without a live set the bundled managed models only fill gaps', () => {
+    const out = withManagedOverlay({ 'grok-4.6': { name: 'baked' } }, null)
+    expect(out['grok-4.6']?.name).toBe('baked')
+    expect(out['deepseek-v4-flash']).toBeDefined()
+  })
+
+  test('never removes a model the disk catalog already carried', () => {
+    const out = withManagedOverlay({ 'legacy/model': { name: 'L' } }, { 'grok-4.6': { name: 'G' } })
+    expect(out['legacy/model']).toBeDefined()
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -22,6 +22,7 @@ import {
   OPENCODE_HOME,
   refreshGatewayCatalogFile,
   scheduleCatalogWarm,
+  startManagedModelsPrefetch,
   waitForOpencodeReady,
   type Opencode,
 } from './opencode'
@@ -203,6 +204,16 @@ async function main() {
   const server = startProxy(cfg, opencode, bootTime, bootState, projectEnv, staticWeb.port)
   installShutdownHandlers(opencode, server, staticWeb)
   bootMark('proxy-up')
+
+  // Learn the CURRENT managed lineup from the gateway this session bills
+  // against, concurrently with the repo clone. The managed set is deployment
+  // config and the image's baked catalog goes stale the moment it changes, so
+  // without this a managed model added after the last template build is absent
+  // from OpenCode's provider map and every turn on it dies with
+  // `ModelNotFound: kortix/<id>` (prod incident 2026-08-19). The result is
+  // consumed by buildOpencodeConfigContent at spawn; the clone is the boot
+  // long-pole, so the fetch costs no critical-path time.
+  startManagedModelsPrefetch(process.env.KORTIX_LLM_BASE_URL, process.env.KORTIX_LLM_API_KEY)
 
   const repoMaterializePromise: Promise<void> = cfg.autoClone
     ? materializeRepo(cfg).catch((err) => {

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -942,11 +942,17 @@ export async function refreshGatewayCatalogFile(opts: {
   const base = liveModels ?? currentModels
   // Nothing live and nothing on disk: leave the caller on the boot catalog.
   if (!base) return null
-  const composed = withManagedOverlay(base, liveManaged)
+  // Remote JSON becomes OpenCode's provider config on the next start — rebuild
+  // it to a known shape before it reaches the disk (see sanitizeCatalogForDisk).
+  const composed = sanitizeCatalogForDisk(withManagedOverlay(base, liveManaged))
+  if (!composed) return null
   // `changed` is computed on the COMPOSED result, so a managed model that only
   // the overlay carries still trips the controlled OpenCode restart in the
   // warm-fork adoption path (OpenCode reads provider models at process start).
-  const changed = !isDeepStrictEqual(currentModels, composed)
+  // Both sides go through the same normalizer: a raw baked file vs a sanitized
+  // rewrite must not read as a change, or every adoption would force a restart.
+  const current = currentModels ? sanitizeCatalogForDisk(currentModels) : null
+  const changed = !isDeepStrictEqual(current, composed)
   mkdirSync(dirname(opts.targetCatalogFile), { recursive: true })
   writeFileSync(opts.targetCatalogFile, JSON.stringify({ models: composed }), { mode: 0o600 })
   logger.info('[opencode] refreshed authenticated gateway catalog', {

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -333,12 +333,22 @@ export async function buildOpencodeConfigContent(
       out.provider && typeof out.provider === 'object' && !Array.isArray(out.provider)
         ? (out.provider as Record<string, unknown>)
         : {}
+    // The managed lineup is DEPLOYMENT CONFIG, not image content: a managed
+    // model added to the API after this image was built is absent from the
+    // baked catalog forever (templates are not rebuilt on a catalog change).
+    // On 2026-08-19 that made OpenCode answer `ModelNotFound: kortix/grok-4.6`
+    // for two live managed models. So the sandbox LEARNS the managed set from
+    // the API it talks to on every boot. This await consumes a prefetch started
+    // at boot (startManagedModelsPrefetch, main.ts) — it never starts a fetch
+    // itself, so the "boot path touches no network" rule still holds.
+    const managedOverlay = await awaitManagedModelsOverlay()
     const kortixProvider = buildKortixProvider({
       // In proxy mode opencode talks to the localhost proxy with a placeholder
       // key; the proxy injects the real per-session token upstream. In direct
       // mode (cold/Daytona) it's the real gateway base + key, as before.
       baseURL: proxyMode ? llmProxyUrl! : llmBaseUrl!,
       apiKey: proxyMode ? LLM_PROXY_PLACEHOLDER_KEY : llmApiKey!,
+      managedOverlay,
       // Catalog is org-stable and ships baked into every image at
       // BAKED_LLM_CATALOG_PATH, so this resolves off DISK — no network on the
       // path that gates opencode's port bind. loadGatewayCatalog is local-only
@@ -395,10 +405,13 @@ type KortixProviderOpts = {
   /** Baked catalog file (org-stable models JSON). Local read only — there is
    *  deliberately NO fetch fallback here; see loadGatewayCatalog. */
   catalogFile?: string
+  /** Live managed lineup fetched from `${gateway}/models?scope=managed`, or
+   *  null when it was unavailable (then the BUNDLED managed set fills gaps). */
+  managedOverlay?: Record<string, KortixGatewayModel> | null
 }
 
 function buildKortixProvider(opts: KortixProviderOpts): Record<string, unknown> {
-  const catalog = withModelLimits(loadGatewayCatalog(opts))
+  const catalog = withModelLimits(withManagedOverlay(loadGatewayCatalog(opts), opts.managedOverlay))
   const models = Object.fromEntries(
     Object.entries(catalog).map(([id, model]) => {
       // The gateway catalog's string `provider` is UI metadata describing the
@@ -741,6 +754,162 @@ async function fetchGatewayModels(
   return null
 }
 
+// ── Managed-model overlay ────────────────────────────────────────────────────
+// The managed lineup (bare-id, provider `kortix` models) is deployment config:
+// it changes with LLM_GATEWAY_MANAGED_MODELS / the API's served catalog, NOT
+// with the sandbox image. The baked catalog therefore goes stale the moment a
+// managed model is added, and OpenCode — which reads provider models once, at
+// process start — then answers `ModelNotFound: kortix/<id>` for it (prod
+// incident 2026-08-19: grok-4.6, deepseek-v4-pro-0813).
+//
+// Fix: every boot fetches the compact managed listing (~3KB) from the same
+// gateway the session bills against and overlays it on whatever catalog is on
+// disk. Same principle as the runtime-assets reconcile — the box learns the
+// current truth from the API it talks to.
+const MANAGED_MODELS_TIMEOUT_MS = 2_000
+const MANAGED_MODELS_TOTAL_BUDGET_MS = 5_000
+const MANAGED_MODELS_ATTEMPTS = 3
+// How long buildOpencodeConfigContent may wait on an in-flight prefetch. The
+// prefetch starts at proxy-up and the repo clone runs in front of the config
+// build, so this is normally already resolved and costs 0ms. The cap exists so
+// a degraded gateway can never push the OpenCode spawn out by the full budget:
+// the BUNDLED managed set (below) is the correctness floor, the live fetch is
+// the upgrade.
+const MANAGED_OVERLAY_AWAIT_CAP_MS = 2_500
+// Re-fetch rather than reuse a cache older than this (a warm seed can sit for
+// hours between capture and adoption).
+const MANAGED_CACHE_TTL_MS = 10 * 60_000
+
+let managedPrefetch: Promise<Record<string, KortixGatewayModel> | null> | null = null
+let managedCache: Record<string, KortixGatewayModel> | null = null
+let managedCacheAt = 0
+
+/**
+ * Compose the catalog OpenCode boots with: disk catalog first, managed set on
+ * top.
+ *
+ * - A live managed listing is AUTHORITATIVE for the managed ids it carries
+ *   (it comes from the gateway that will resolve them).
+ * - With no live listing, the bundled managed set only FILLS ids the disk
+ *   catalog lacks — a hand-maintained table never overwrites richer generated
+ *   data for a model that is already there.
+ *
+ * Purely additive in both cases: nothing is removed, so a transient fetch can
+ * never shrink a working picker.
+ */
+export function withManagedOverlay(
+  base: Record<string, KortixGatewayModel>,
+  live: Record<string, KortixGatewayModel> | null | undefined,
+): Record<string, KortixGatewayModel> {
+  if (live && Object.keys(live).length > 0) return { ...base, ...live }
+  const out = { ...base }
+  for (const [id, model] of Object.entries(BUNDLED_MANAGED_MODELS)) {
+    if (!out[id]) out[id] = model
+  }
+  return out
+}
+
+/**
+ * Fetch ONLY the managed lineup: `GET ${base}/models?scope=managed` (~3KB,
+ * versus ~3.3MB for the full project catalog — which is why the full fetch
+ * gets no place on the boot path). Returns null on failure or an empty set
+ * (a free-tier account legitimately has no managed models; callers then keep
+ * whatever the disk catalog holds).
+ */
+export async function fetchManagedModels(
+  baseUrl: string,
+  apiKey: string,
+): Promise<Record<string, KortixGatewayModel> | null> {
+  const url = `${baseUrl.replace(/\/+$/, '')}/models?scope=managed`
+  const deadline = Date.now() + MANAGED_MODELS_TOTAL_BUDGET_MS
+  for (let attempt = 0; attempt < MANAGED_MODELS_ATTEMPTS; attempt++) {
+    if (Date.now() >= deadline) break
+    try {
+      const res = await fetch(url, {
+        headers: { authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(
+          Math.max(250, Math.min(MANAGED_MODELS_TIMEOUT_MS, deadline - Date.now())),
+        ),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const body = (await res.json()) as { models?: Record<string, KortixGatewayModel> }
+      const models = body.models ?? {}
+      if (Object.keys(models).length === 0) {
+        logger.info(`[opencode] managed listing is empty at ${url}; keeping the on-disk catalog`)
+        return null
+      }
+      // Remote JSON becomes OpenCode's provider config — rebuild it to a known
+      // shape before it can get anywhere near the config or the disk.
+      const clean = sanitizeCatalogForDisk(models)
+      if (!clean) return null
+      logger.info(`[opencode] fetched ${Object.keys(clean).length} managed models from ${url}`)
+      return clean
+    } catch (err) {
+      logger.warn(
+        `[opencode] managed models fetch failed (attempt ${attempt + 1}/${MANAGED_MODELS_ATTEMPTS}) ` +
+          `${url}: ${err instanceof Error ? err.message : String(err)}`,
+      )
+      if (Date.now() + 200 >= deadline) break
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+  }
+  logger.warn(`[opencode] managed models unavailable (${url}); using the bundled managed set`)
+  return null
+}
+
+/**
+ * Start the managed-lineup fetch as early as the gateway credentials are known
+ * (see main.ts, right after the proxy binds). It runs CONCURRENTLY with repo
+ * materialization, so by the time the OpenCode config is built the answer is
+ * already in hand and the overlay costs ~0ms of boot.
+ */
+export function startManagedModelsPrefetch(baseUrl?: string, apiKey?: string): void {
+  if (!baseUrl || !apiKey) return
+  if (managedPrefetch) return
+  if (managedCache && Date.now() - managedCacheAt < MANAGED_CACHE_TTL_MS) return
+  managedPrefetch = fetchManagedModels(baseUrl, apiKey)
+    .then((models) => {
+      if (models) rememberManagedModels(models)
+      return models
+    })
+    .catch(() => null)
+    .finally(() => {
+      managedPrefetch = null
+    })
+}
+
+/** Publish a freshly fetched managed set so later config rebuilds (an OpenCode
+ *  restart, a warm-fork adoption) reuse it without another fetch. */
+export function rememberManagedModels(models: Record<string, KortixGatewayModel>): void {
+  managedCache = models
+  managedCacheAt = Date.now()
+}
+
+/** The overlay for the config being built now: the cached live set, else an
+ *  in-flight prefetch (bounded), else null (→ bundled managed set). Never
+ *  starts a fetch — the boot path stays network-free by construction. */
+export async function awaitManagedModelsOverlay(): Promise<Record<string, KortixGatewayModel> | null> {
+  if (managedCache && Date.now() - managedCacheAt < MANAGED_CACHE_TTL_MS) return managedCache
+  const pending = managedPrefetch
+  if (!pending) return managedCache
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const capped = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), MANAGED_OVERLAY_AWAIT_CAP_MS)
+  })
+  try {
+    return (await Promise.race([pending, capped])) ?? managedCache
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+/** Test seam: drop prefetch/cache state between cases. */
+export function resetManagedModelsStateForTests(): void {
+  managedPrefetch = null
+  managedCache = null
+  managedCacheAt = 0
+}
+
 export type GatewayCatalogRefreshResult = {
   changed: boolean
   catalogFile: string
@@ -760,16 +929,31 @@ export async function refreshGatewayCatalogFile(opts: {
   fetchBaseURL: string
   fetchApiKey: string
 }): Promise<GatewayCatalogRefreshResult | null> {
-  const liveModels = await fetchGatewayModels(opts.fetchBaseURL, opts.fetchApiKey)
-  if (!liveModels) return null
+  // Both fetches in parallel: the full catalog can fail (it is ~3.3MB and gets
+  // a 4s budget) while the ~3KB managed listing still lands — and it is the
+  // managed set that decides whether the model a user just picked exists.
+  const [liveModels, liveManaged] = await Promise.all([
+    fetchGatewayModels(opts.fetchBaseURL, opts.fetchApiKey),
+    fetchManagedModels(opts.fetchBaseURL, opts.fetchApiKey),
+  ])
+  if (liveManaged) rememberManagedModels(liveManaged)
 
   const currentModels = readCatalogFile(opts.currentCatalogFile)
-  const changed = !isDeepStrictEqual(currentModels, liveModels)
+  const base = liveModels ?? currentModels
+  // Nothing live and nothing on disk: leave the caller on the boot catalog.
+  if (!base) return null
+  const composed = withManagedOverlay(base, liveManaged)
+  // `changed` is computed on the COMPOSED result, so a managed model that only
+  // the overlay carries still trips the controlled OpenCode restart in the
+  // warm-fork adoption path (OpenCode reads provider models at process start).
+  const changed = !isDeepStrictEqual(currentModels, composed)
   mkdirSync(dirname(opts.targetCatalogFile), { recursive: true })
-  writeFileSync(opts.targetCatalogFile, JSON.stringify({ models: liveModels }), { mode: 0o600 })
+  writeFileSync(opts.targetCatalogFile, JSON.stringify({ models: composed }), { mode: 0o600 })
   logger.info('[opencode] refreshed authenticated gateway catalog', {
     changed,
-    models: Object.keys(liveModels).length,
+    models: Object.keys(composed).length,
+    managed: liveManaged ? Object.keys(liveManaged).length : 0,
+    fullCatalogLive: !!liveModels,
     target: opts.targetCatalogFile,
   })
   return { changed, catalogFile: opts.targetCatalogFile }
@@ -1047,6 +1231,18 @@ export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
     limit: { context: 1_000_000, output: 64_000 },
   },
 }
+
+/** The managed subset of the bundled fallback table: bare ids branded `kortix`.
+ *  Used when the live managed fetch is unavailable, so a managed model is
+ *  present in OpenCode's provider map even with a stale baked catalog AND a
+ *  down gateway. Kept in sync with @kortix/llm-catalog MANAGED_MODELS by
+ *  __tests__/managed-fallback-sync.test.ts — a managed model missing here and
+ *  missing from the baked image is the exact 2026-08-19 ModelNotFound outage. */
+export const BUNDLED_MANAGED_MODELS: Record<string, KortixGatewayModel> = Object.fromEntries(
+  Object.entries(MINIMAL_FALLBACK_MODELS).filter(
+    ([id, model]) => !id.includes('/') && model.provider === 'kortix',
+  ),
+)
 
 // Conservative window for a model we have no declared limit for. Better to
 // compact a little early than to never compact and get stuck at the wall.

--- a/apps/llm-gateway/src/clients/api-client.ts
+++ b/apps/llm-gateway/src/clients/api-client.ts
@@ -4,6 +4,7 @@ import {
   type AuthedPrincipal,
   type AuthorizeResult,
   type GatewayTrace,
+  type ListModelsOptions,
   type ModelCatalog,
   type ModelRouteInput,
   type ModelRoutePlan,
@@ -49,7 +50,7 @@ export interface ApiClient {
   assertBudget: (principal: AuthedPrincipal) => Promise<void>;
   recordUsage: (event: UsageEvent) => Promise<void>;
   recordTrace: (trace: GatewayTrace) => Promise<void>;
-  listModels: (principal: AuthedPrincipal) => Promise<ModelCatalog>;
+  listModels: (principal: AuthedPrincipal, opts?: ListModelsOptions) => Promise<ModelCatalog>;
   ping: () => Promise<ApiPingResult>;
 }
 
@@ -172,9 +173,10 @@ export function createApiClient(opts: ApiClientOptions): ApiClient {
     recordTrace: async (trace) => {
       await post<{ ok: boolean }>('/internal/gateway/trace', { trace });
     },
-    listModels: async (principal) => {
+    listModels: async (principal, opts) => {
       const result = await post<{ models: ModelCatalog }>('/internal/gateway/models', {
         principal,
+        managedOnly: !!opts?.managedOnly,
       });
       return result.models ?? {};
     },

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -240,8 +240,14 @@ export function buildServer(): GatewayServer {
   app.post('/v1/llm/messages', messages);
   app.post('/v1/openai/messages', messages);
 
-  const models = (c: { req: { header: (k: string) => string | undefined } }) =>
-    gateway.listModels(c.req.header('authorization'));
+  // `?scope=managed` → managed lineup only (~3KB). Sandboxes call it on every
+  // boot to learn the live managed set; see wire.ts for the full rationale.
+  const models = (c: {
+    req: { header: (k: string) => string | undefined; query: (k: string) => string | undefined };
+  }) =>
+    gateway.listModels(c.req.header('authorization'), {
+      managedOnly: c.req.query('scope') === 'managed',
+    });
 
   app.get('/models', models);
   app.get('/v1/models', models);

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -73,6 +73,7 @@ import type { AttachedFile, TrackedMention } from '@/features/session/session-ch
 import { SessionContextModal } from '@/features/session/session-context-modal';
 import { SessionRetryDisplay, TurnErrorDisplay } from '@/features/session/session-error-banner';
 import { SessionWelcome } from '@/features/session/session-welcome';
+import { showTurnBusyIndicator } from '@/features/session/turn-busy-visibility';
 import { SessionBusyIndicator } from './session-busy-indicator';
 import { SessionTurnMeta } from './session-turn-meta';
 import {
@@ -1661,7 +1662,7 @@ function SessionTurnImpl({
       )}
 
       {/* ── Working status indicator (always at the end while working) ── */}
-      {working && (
+      {showTurnBusyIndicator({ working, hasError: !!turnError, isRetrying: !!retryInfo }) && (
         <div className="space-y-2">
           {retryInfo && retryMessage && (
             <SessionRetryDisplay

--- a/apps/web/src/features/session/turn-busy-visibility.test.ts
+++ b/apps/web/src/features/session/turn-busy-visibility.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+
+import { showTurnBusyIndicator } from './turn-busy-visibility';
+
+describe('showTurnBusyIndicator', () => {
+  test('shows the indicator for a live turn with no error', () => {
+    expect(showTurnBusyIndicator({ working: true, hasError: false, isRetrying: false })).toBe(true);
+  });
+
+  test('hides it once the turn reports an error', () => {
+    expect(showTurnBusyIndicator({ working: true, hasError: true, isRetrying: false })).toBe(false);
+  });
+
+  test('keeps it while a retry is counting down', () => {
+    expect(showTurnBusyIndicator({ working: true, hasError: true, isRetrying: true })).toBe(true);
+  });
+
+  test('never shows it for a turn that is not working', () => {
+    expect(showTurnBusyIndicator({ working: false, hasError: false, isRetrying: false })).toBe(
+      false,
+    );
+    expect(showTurnBusyIndicator({ working: false, hasError: true, isRetrying: true })).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/turn-busy-visibility.ts
+++ b/apps/web/src/features/session/turn-busy-visibility.ts
@@ -1,0 +1,26 @@
+/**
+ * Does this turn still show the working indicator ("Figuring out what's
+ * next…", the dot matrix, the live duration)?
+ *
+ * A turn that has reported an error is OVER: `session.error` terminates the
+ * turn the runtime was running. Rendering the spinner beside the failure says
+ * two contradictory things at once, and it is what the 2026-08-19 report
+ * showed — a `ModelNotFound` line pinned under a spinner that never stopped,
+ * because the turn's authority (a `GET .../turn` read of a control-plane row
+ * the daemon had not yet closed) still reported the turn open.
+ *
+ * The one exception is a RETRY. The gateway's retry state is an error that has
+ * not finished: the session status is `retry`, the countdown
+ * (`SessionRetryDisplay`) renders inside this same block, and the turn really
+ * is still going. So an error suppresses the indicator only when nothing is
+ * being retried.
+ */
+export function showTurnBusyIndicator(input: {
+  working: boolean;
+  hasError: boolean;
+  isRetrying: boolean;
+}): boolean {
+  if (!input.working) return false;
+  if (input.isRetrying) return true;
+  return !input.hasError;
+}

--- a/apps/web/src/hooks/use-auto-scroll.test.ts
+++ b/apps/web/src/hooks/use-auto-scroll.test.ts
@@ -6,7 +6,10 @@ import {
   CHEVRON_PX,
   TURN_TOP_OFFSET,
   chevronVisible,
+  classifyScrollKey,
   isAtEnd,
+  isEditableTarget,
+  keyScrollIntentFor,
   roomUnderNewestTurn,
 } from './use-auto-scroll';
 
@@ -42,5 +45,126 @@ describe('chevronVisible — measured in CONTENT, the room excluded', () => {
   });
   test('shown once meaningfully away from the end of the content', () => {
     expect(chevronVisible(CHEVRON_PX + 1)).toBe(true);
+  });
+});
+
+// ── Keyboard intent ──────────────────────────────────────────────────
+// The bug these cover: at the end, Cmd+↑ scrolled up for an instant and the
+// next settle() put it straight back, because the keydown listener was bound
+// to the transcript element. The element has no tabindex, so the browser
+// delivers the key to <body> and that listener never fired. Follow was never
+// told the reader had taken over. The listener now sits on `document`, which
+// makes "is this key for the transcript?" the whole question below.
+
+/** Minimal EventTarget stand-in: the guards read only tagName /
+ *  isContentEditable / closest, so no DOM is needed for the full matrix. */
+function target(
+  tagName: string,
+  opts: { isContentEditable?: boolean; matches?: string[] } = {},
+): EventTarget {
+  const matches = opts.matches ?? [];
+  return {
+    tagName,
+    isContentEditable: opts.isContentEditable ?? false,
+    closest: (selector: string) =>
+      matches.some((m) => selector.includes(m)) ? ({} as unknown) : null,
+  } as unknown as EventTarget;
+}
+
+const BODY = target('BODY');
+
+describe('classifyScrollKey', () => {
+  test('every upward key is one intent, modifiers included', () => {
+    expect(classifyScrollKey({ key: 'ArrowUp' })).toBe('up');
+    // macOS "scroll to top" — the exact key in the report.
+    expect(classifyScrollKey({ key: 'ArrowUp', metaKey: true })).toBe('up');
+    expect(classifyScrollKey({ key: 'PageUp' })).toBe('up');
+    expect(classifyScrollKey({ key: 'Home' })).toBe('up');
+    expect(classifyScrollKey({ key: 'Home', ctrlKey: true } as never)).toBe('up');
+    expect(classifyScrollKey({ key: ' ', shiftKey: true })).toBe('up');
+  });
+
+  test('incremental downward keys are ordinary movement', () => {
+    expect(classifyScrollKey({ key: 'ArrowDown' })).toBe('down');
+    expect(classifyScrollKey({ key: 'PageDown' })).toBe('down');
+    expect(classifyScrollKey({ key: ' ' })).toBe('down');
+    expect(classifyScrollKey({ key: 'Spacebar' })).toBe('down');
+  });
+
+  test('"go to the end" keys are their own intent', () => {
+    expect(classifyScrollKey({ key: 'End' })).toBe('end');
+    expect(classifyScrollKey({ key: 'End', ctrlKey: true } as never)).toBe('end');
+    expect(classifyScrollKey({ key: 'ArrowDown', metaKey: true })).toBe('end');
+  });
+
+  test('non-scrolling keys and Alt/Option chords are ignored', () => {
+    expect(classifyScrollKey({ key: 'a' })).toBe(null);
+    expect(classifyScrollKey({ key: 'Enter' })).toBe(null);
+    expect(classifyScrollKey({ key: 'ArrowLeft' })).toBe(null);
+    expect(classifyScrollKey({ key: 'ArrowRight' })).toBe(null);
+    expect(classifyScrollKey({ key: 'Tab' })).toBe(null);
+    // Option+Arrow is a caret move on macOS, never a scroll.
+    expect(classifyScrollKey({ key: 'ArrowUp', altKey: true })).toBe(null);
+    expect(classifyScrollKey({ key: 'ArrowDown', altKey: true })).toBe(null);
+  });
+});
+
+describe('isEditableTarget', () => {
+  test('form fields and contenteditable own their own caret', () => {
+    expect(isEditableTarget(target('TEXTAREA'))).toBe(true);
+    expect(isEditableTarget(target('INPUT'))).toBe(true);
+    expect(isEditableTarget(target('SELECT'))).toBe(true);
+    expect(isEditableTarget(target('DIV', { isContentEditable: true }))).toBe(true);
+    expect(isEditableTarget(target('SPAN', { matches: ['role="textbox"'] }))).toBe(true);
+  });
+
+  test('plain content and a missing target are not editable', () => {
+    expect(isEditableTarget(BODY)).toBe(false);
+    expect(isEditableTarget(target('DIV'))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe('keyScrollIntentFor', () => {
+  test('Cmd+ArrowUp on the transcript leaves the end — the reported bug', () => {
+    expect(keyScrollIntentFor({ key: 'ArrowUp', metaKey: true, target: BODY })).toBe('up');
+    expect(keyScrollIntentFor({ key: 'ArrowUp', target: BODY })).toBe('up');
+    expect(keyScrollIntentFor({ key: 'PageUp', target: BODY })).toBe('up');
+    expect(keyScrollIntentFor({ key: 'Home', target: BODY })).toBe('up');
+  });
+
+  test('End / Cmd+ArrowDown go to the end; PageDown only resumes if it lands there', () => {
+    expect(keyScrollIntentFor({ key: 'End', target: BODY })).toBe('end');
+    expect(keyScrollIntentFor({ key: 'ArrowDown', metaKey: true, target: BODY })).toBe('end');
+    expect(keyScrollIntentFor({ key: 'PageDown', target: BODY })).toBe('down');
+    expect(keyScrollIntentFor({ key: 'ArrowDown', target: BODY })).toBe('down');
+  });
+
+  test('a keypress inside the composer is never transcript intent', () => {
+    const composer = target('TEXTAREA');
+    expect(keyScrollIntentFor({ key: 'ArrowUp', metaKey: true, target: composer })).toBe(null);
+    expect(keyScrollIntentFor({ key: 'ArrowUp', target: composer })).toBe(null);
+    expect(keyScrollIntentFor({ key: 'PageUp', target: composer })).toBe(null);
+    expect(keyScrollIntentFor({ key: 'Home', target: composer })).toBe(null);
+    expect(keyScrollIntentFor({ key: 'End', target: composer })).toBe(null);
+    expect(keyScrollIntentFor({ key: ' ', target: composer })).toBe(null);
+    // Rich-text composers are contenteditable, not <textarea>.
+    expect(
+      keyScrollIntentFor({ key: 'ArrowUp', target: target('DIV', { isContentEditable: true }) }),
+    ).toBe(null);
+  });
+
+  test('Space on a focused button activates it instead of scrolling', () => {
+    const button = target('BUTTON', { matches: ['button'] });
+    expect(keyScrollIntentFor({ key: ' ', target: button })).toBe(null);
+    expect(keyScrollIntentFor({ key: ' ', shiftKey: true, target: button })).toBe(null);
+    // Arrows still scroll while a button holds focus — Chrome does not eat them.
+    expect(keyScrollIntentFor({ key: 'ArrowUp', target: button })).toBe('up');
+    expect(keyScrollIntentFor({ key: 'End', target: button })).toBe('end');
+  });
+
+  test('non-scroll keys stay null wherever focus is', () => {
+    expect(keyScrollIntentFor({ key: 'k', metaKey: true, target: BODY })).toBe(null);
+    expect(keyScrollIntentFor({ key: 'Escape', target: BODY })).toBe(null);
   });
 });

--- a/apps/web/src/hooks/use-auto-scroll.ts
+++ b/apps/web/src/hooks/use-auto-scroll.ts
@@ -29,8 +29,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * stranded mid-screen (the re-expansion is just another layout change).
  * `follow` becomes false only on READER intent — a wheel/touch/keyboard scroll
  * up, or a scrollbar drag that leaves the end — and true again when the reader
- * comes back to the end (drag, wheel, chevron) or sends. Programmatic scrolls
- * never count as intent. Nothing here reads "is the session working": if the
+ * comes back to the end (drag, wheel, chevron, End key) or sends. Intent is
+ * read from the INPUT event, and keys are read on `document`: the transcript
+ * is not focusable, so a key that scrolls it is never delivered to it.
+ * Programmatic scrolls never count as intent. Nothing here reads "is the session working": if the
  * reader is at the end and something appears, they see it.
  *
  * Direct DOM writes only (`spacer.style.height`, `el.scrollTop`) — never React
@@ -60,6 +62,89 @@ export function isAtEnd(distanceFromEnd: number): boolean {
 /** Pure: does the chevron show for a reader who is NOT following? */
 export function chevronVisible(distanceFromContentEnd: number): boolean {
   return distanceFromContentEnd > CHEVRON_PX;
+}
+
+export type ScrollKeyIntent = 'up' | 'down' | 'end' | null;
+
+/**
+ * Pure: which way a key scrolls the transcript, or null when it does not
+ * scroll it.
+ *
+ * Up is one intent — Cmd+ArrowUp, Ctrl+Home and bare Home all mean "the reader
+ * took over" — so modifiers are deliberately not inspected. Down splits in two,
+ * because resuming is the direction that can go wrong:
+ *   'end'  — End / Cmd+ArrowDown. A discrete, unambiguous "go to the end", the
+ *            keyboard form of the chevron, so it goes to the end and follows.
+ *   'down' — PageDown / ArrowDown / Space. Ordinary movement: it resumes only
+ *            if it actually lands at the end (isAtEnd), like a wheel-down.
+ * Alt/Option is excluded: on macOS that is a caret move, not a scroll.
+ */
+export function classifyScrollKey(event: {
+  key: string;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+}): ScrollKeyIntent {
+  if (event.altKey) return null;
+  switch (event.key) {
+    case 'ArrowUp':
+    case 'PageUp':
+    case 'Home':
+      return 'up';
+    case 'End':
+      return 'end';
+    case 'ArrowDown':
+      return event.metaKey ? 'end' : 'down';
+    case 'PageDown':
+      return 'down';
+    case ' ':
+    case 'Spacebar':
+      return event.shiftKey ? 'up' : 'down';
+    default:
+      return null;
+  }
+}
+
+/** Pure: an editable target owns its own caret and its own scrollport, so a
+ *  key typed in the composer is never transcript intent. */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el || typeof el.closest !== 'function') return false;
+  if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') return true;
+  if (el.isContentEditable) return true;
+  return el.closest('[contenteditable="true"], [role="textbox"], [role="combobox"]') !== null;
+}
+
+/** Pure: Space activates the focused control instead of scrolling. Every other
+ *  scroll key still scrolls while a button holds focus, so only Space is
+ *  filtered on this one. */
+export function isSpaceActivatedTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el || typeof el.closest !== 'function') return false;
+  return (
+    el.closest(
+      'button, summary, a[href], [role="button"], [role="menuitem"], [role="option"], [role="tab"], [role="checkbox"], [role="switch"]',
+    ) !== null
+  );
+}
+
+/** Pure: the whole keyboard decision — key plus where focus is. Kept pure so
+ *  the matrix (modifiers, editable focus, Space-on-a-button) is testable
+ *  without a DOM. */
+export function keyScrollIntentFor(event: {
+  key: string;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+  target: EventTarget | null;
+}): ScrollKeyIntent {
+  if (isEditableTarget(event.target)) return null;
+  const intent = classifyScrollKey(event);
+  if (!intent) return null;
+  if ((event.key === ' ' || event.key === 'Spacebar') && isSpaceActivatedTarget(event.target)) {
+    return null;
+  }
+  return intent;
 }
 
 /** Pure: the room under the anchor turn, given the height from that turn's
@@ -272,11 +357,31 @@ export function useAutoScroll({ hasContent = false }: UseAutoScrollOptions = {})
         updateChevron();
       });
     };
-    // Keyboard scrolling inside the transcript.
+    // Keyboard scrolling. Bound to `document` in the CAPTURE phase (below),
+    // NOT to `el`: the transcript carries no tabindex, so the browser delivers
+    // the key to <body> — or to whatever else holds focus — and an element
+    // listener never fires. That is the bug the reader sees: at the end,
+    // Cmd+↑ scrolls up for an instant and the next `settle()` puts it straight
+    // back, because follow was never told the reader had taken over. Capture
+    // also means a handler that stops propagation cannot hide the intent.
     const onKeyDown = (e: KeyboardEvent) => {
-      if (['ArrowUp', 'PageUp', 'Home'].includes(e.key)) leaveEnd('key-up');
+      // A session tab kept mounted but off-screen (`hidden`) must not react to
+      // a key aimed at the visible transcript.
+      if (el.clientHeight === 0) return;
+      const intent = keyScrollIntentFor(e);
+      if (!intent) return;
+      if (intent === 'end') {
+        // "Go to the end" — run the chevron's own jump instead of waiting for
+        // the browser's animation to land. A transcript that is still growing
+        // moves the end away from that animation's target, so the reader would
+        // press End and never get follow back.
+        goToEnd('auto');
+        setFollow(true, 'key-end');
+        return;
+      }
+      if (intent === 'up') leaveEnd('key-up');
       requestAnimationFrame(() => {
-        if (['ArrowDown', 'PageDown', 'End'].includes(e.key)) maybeResume('key-down');
+        if (intent === 'down') maybeResume('key-down');
         updateChevron();
       });
     };
@@ -288,8 +393,22 @@ export function useAutoScroll({ hasContent = false }: UseAutoScrollOptions = {})
     // random (a composer shrink clamped scrollTop by 24px in the same frame a
     // send committed). This listener only re-arms follow when the reader has
     // come back to the end, and keeps the chevron honest.
+    let lastTop = el.scrollTop;
     const onScroll = () => {
-      if (!followRef.current && isAtEnd(distanceFromEnd(el))) setFollow(true, 'scroll-to-end');
+      const top = el.scrollTop;
+      const movedTowardEnd = top >= lastTop;
+      lastTop = top;
+      // Re-arm only when the viewport ARRIVED at the end moving toward it.
+      // Direction matters: the browser animates a keyboard scroll, and its
+      // first frame off the end is 2-3px — inside AT_END_PX. A direction-blind
+      // check therefore re-armed follow on the first frame of Cmd+↑/PageUp,
+      // and the next `settle()` yanked the reader straight back, which is the
+      // very symptom the keydown intent above exists to remove. Content
+      // shrinking and clamping scrollTop moves away from the end too, so this
+      // also keeps the "a clamp is not intent" promise in the header.
+      if (!followRef.current && movedTowardEnd && isAtEnd(distanceFromEnd(el))) {
+        setFollow(true, 'scroll-to-end');
+      }
       updateChevron();
     };
     el.dataset.follow = String(followRef.current);
@@ -297,16 +416,16 @@ export function useAutoScroll({ hasContent = false }: UseAutoScrollOptions = {})
     el.addEventListener('wheel', onWheel, { passive: true });
     el.addEventListener('touchstart', onTouchStart, { passive: true });
     el.addEventListener('touchmove', onTouchMove, { passive: true });
-    el.addEventListener('keydown', onKeyDown);
+    document.addEventListener('keydown', onKeyDown, { capture: true, passive: true });
     el.addEventListener('scroll', onScroll, { passive: true });
     return () => {
       el.removeEventListener('wheel', onWheel);
       el.removeEventListener('touchstart', onTouchStart);
       el.removeEventListener('touchmove', onTouchMove);
-      el.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keydown', onKeyDown, { capture: true });
       el.removeEventListener('scroll', onScroll);
     };
-  }, [hasContent, setFollow]);
+  }, [goToEnd, hasContent, setFollow]);
 
   return {
     scrollRef,

--- a/packages/llm-gateway/src/create-gateway.ts
+++ b/packages/llm-gateway/src/create-gateway.ts
@@ -1,4 +1,4 @@
-import type { GatewayConfig, GatewayHooks } from './domain';
+import type { GatewayConfig, GatewayHooks, ListModelsOptions } from './domain';
 import {
   type AnthropicMessagesRequest,
   anthropicMessagesToChat,
@@ -93,7 +93,10 @@ export function createGateway(
     return match ? match[1].trim() : null;
   };
 
-  const listModels = async (authorization: string | undefined): Promise<Response> => {
+  const listModels = async (
+    authorization: string | undefined,
+    opts?: ListModelsOptions,
+  ): Promise<Response> => {
     const requestId = `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
     const token = bearer(authorization);
     if (!token)
@@ -119,9 +122,10 @@ export function createGateway(
           suggestion: 'Sign in again or provide a valid API token, then retry.',
         });
       if (!hooks.listModels) return jsonResponse({ models: {} });
-      const models = await hooks.listModels(principal);
+      const models = await hooks.listModels(principal, opts);
       logger.info(
-        `[gateway] models ${Object.keys(models).length} for acct=${principal.accountId.slice(0, 8)}`,
+        `[gateway] models ${Object.keys(models).length}${opts?.managedOnly ? ' (managed only)' : ''} ` +
+          `for acct=${principal.accountId.slice(0, 8)}`,
       );
       return jsonResponse({ models });
     } catch (err) {

--- a/packages/llm-gateway/src/domain/hooks.ts
+++ b/packages/llm-gateway/src/domain/hooks.ts
@@ -43,5 +43,16 @@ export interface GatewayHooks {
   assertBudget?: (principal: AuthedPrincipal) => Promise<void>;
   recordUsage: (event: UsageEvent) => Promise<void>;
   recordTrace?: (trace: GatewayTrace) => Promise<void>;
-  listModels?: (principal: AuthedPrincipal) => Promise<ModelCatalog>;
+  listModels?: (principal: AuthedPrincipal, opts?: ListModelsOptions) => Promise<ModelCatalog>;
+}
+
+/** Options for the model-catalog listing.
+ *
+ * `managedOnly` serves ONLY the platform-managed lineup (~3KB) instead of the
+ * project's full catalog (~3.3MB). A sandbox fetches it on every boot to learn
+ * the current managed set, because the catalog baked into its image goes stale
+ * the moment the managed lineup changes. Free-tier semantics are unchanged: an
+ * account with no managed access still gets an empty managed set. */
+export interface ListModelsOptions {
+  managedOnly?: boolean;
 }

--- a/packages/llm-gateway/src/domain/index.ts
+++ b/packages/llm-gateway/src/domain/index.ts
@@ -3,7 +3,7 @@ export type { ProviderKind, UpstreamDescriptor } from './descriptor';
 export type { TokenCounts, UsageEvent } from './usage';
 export type { GatewayTrace } from './trace';
 export type { GatewayAttemptFailure, GatewayAttemptFailureStage } from './failure';
-export type { AuthorizeResult, GatewayHooks } from './hooks';
+export type { AuthorizeResult, GatewayHooks, ListModelsOptions } from './hooks';
 export type {
   ModelInfo,
   ModelCatalog,

--- a/packages/llm-gateway/src/index.ts
+++ b/packages/llm-gateway/src/index.ts
@@ -67,6 +67,7 @@ export type {
   GatewayTrace,
   GatewayAttemptFailure,
   GatewayAttemptFailureStage,
+  ListModelsOptions,
   ModelFallbackCondition,
   ModelFallbackPolicy,
   ModelFallbackPolicyMatch,

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -406,6 +406,54 @@ fail.
 
 ---
 
+### 2026-08-19 — session `session-error-turn` — a `session.error` belongs to the turn that failed — DONE
+
+**Files:** `browser/stores/sync-store.ts` (+`.test.ts`). The `apps/web` half (a
+turn that reports an error stops rendering the working indicator) is outside
+this package.
+
+**What.** A turn that fails BEFORE any assistant message exists (prod
+2026-08-19: `ModelNotFound: kortix/grok-4.6`, `session.error` ~2ms after the
+prompt) put its error in the wrong turn, three different ways. The handler
+patched `.error` onto "the last assistant message ANYWHERE" — an EARLIER turn's
+answer — and the `reconcileTail` hydrate that follows every `session.error`
+then overwrote that message with the server's error-free copy, so the first
+failure rendered NOTHING AT ALL. With no assistant message anywhere it appended
+a stub at the END of the list, which the next prompt's turn then adopted: the
+error moved out from under the prompt it belonged to and rode the bottom of the
+thread.
+
+`session.error` now resolves the failing turn (the last user message) and
+either patches an assistant message that already belongs to THAT turn, or
+inserts a stub directly after that user message, carrying `parentID` so
+`groupMessagesIntoTurns` keeps it there no matter what arrives later. The stub
+id is `${userMessageId}_error`: idempotent for a repeated error, and (all ids
+being equal length) it sorts immediately after its user message, so position
+and `parentID` agree.
+
+`stubAssistantIds` becomes `Map<sessionID, Map<stubId, parentUserId | null>>`
+and `hydrate` reconciles PER TURN instead of per session — an earlier turn's
+reply is not an answer to this one. When the server DOES hold a reply for the
+failing turn the stub's error moves onto it unless the server's copy carries
+one of its own; the stub is dropped only after that. An optimistic parent
+superseded by the server's echo re-keys the stub (both in `hydrate`'s
+correlation and in the `message.updated` echo path, via `rekeyStubParent`), and
+a stub restored from the IndexedDB transcript cache is re-adopted so it stays
+reconcilable across a reload.
+
+**Gates.** `bun test src` 2230 pass / 2 skip / 0 fail (baseline before this
+change: 2220 / 2 / 0); `tsc --noEmit` + examples clean; `smoke:install` passed.
+Public surface unchanged — every symbol touched is module-private.
+
+**Browser proof** (local stack, real Platinum sandbox, `POST .../prompts` with
+`model: kortix/does-not-exist-model`): before the change the second failure took
+the first turn's error with it (turn 1 left with no error at all) and, with an
+earlier turn present, the first failure rendered nothing; after, each error
+renders under its own prompt and survives a page reload. Screenshots in
+`output/session-error/`.
+
+---
+
 ### 2026-08-18 — session `server-truth-m1` — step 10: the proxy names the hop that failed — DONE
 
 **Files:** `core/session/health.ts` (+`core/session/session.test.ts`),

--- a/packages/sdk/src/browser/stores/sync-store.test.ts
+++ b/packages/sdk/src/browser/stores/sync-store.test.ts
@@ -8,6 +8,7 @@ import type {
 	TextPart,
 	UserMessage,
 } from "@opencode-ai/sdk/v2/client";
+import { getTurnError, groupMessagesIntoTurns } from "../../core/turns";
 import { ascendingId, Binary, sameSessionStatus, useSyncStore } from "./sync-store";
 
 // ============================================================================
@@ -370,6 +371,342 @@ describe("useSyncStore — session.error stub reconciliation on hydrate", () => 
 		]);
 
 		expect(useSyncStore.getState().messages.ses_1.map((m) => m.id)).toContain(stubId);
+	});
+});
+
+// ============================================================================
+// A turn that fails BEFORE any assistant message exists (2026-08-19 prod
+// report: `ModelNotFound: kortix/grok-4.6`, `session.error` ~2ms after the
+// user message). The error belongs to THAT turn — the user message it
+// answers — and nowhere else. Three failures were reported, and all three are
+// one question the old handler could not answer: WHICH turn failed?
+//
+//  1. Nothing rendered at all. The session already held an earlier turn, so
+//     the handler patched `.error` onto that turn's assistant message, far up
+//     the transcript — and the `reconcileTail` hydrate that follows every
+//     `session.error` overwrote that message with the server's own copy,
+//     which carries no error. The failure left no trace.
+//  2. The error rendered under the NEXT prompt instead of its own.
+//  3. A later, successful answer kept the stale error pinned below it.
+// ============================================================================
+
+describe("useSyncStore — session.error attaches to the turn that failed", () => {
+	test("does not patch a PREVIOUS turn's assistant message", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_0000000000010000000000"));
+		store.upsertMessage("ses_1", {
+			...assistantMessage("msg_0000000000020000000000"),
+			parentID: "msg_0000000000010000000000",
+		});
+		// The prompt that fails. No assistant message for it exists yet.
+		store.upsertMessage("ses_1", userMessage("msg_0000000000030000000000"));
+
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "UnknownError", data: { message: "ModelNotFound: kortix/grok-4.6" } },
+			},
+		} as never);
+
+		const msgs = useSyncStore.getState().messages.ses_1;
+		const previous = msgs.find(
+			(m) => m.id === "msg_0000000000020000000000",
+		) as AssistantMessage;
+		expect(previous.error).toBeUndefined();
+
+		// The error rides an assistant message parented to the FAILING prompt,
+		// positioned directly after it.
+		const idx = msgs.findIndex((m) => m.id === "msg_0000000000030000000000");
+		const stub = msgs[idx + 1] as AssistantMessage;
+		expect(stub.role).toBe("assistant");
+		expect(stub.parentID).toBe("msg_0000000000030000000000");
+		expect((stub.error as { data: { message: string } }).data.message).toBe(
+			"ModelNotFound: kortix/grok-4.6",
+		);
+		expect(useSyncStore.getState().sessionStatus.ses_1).toEqual({ type: "idle" });
+	});
+
+	test("renders inside the failing turn, and stays there when a later turn arrives", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_0000000000010000000000"));
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "UnknownError", data: { message: "boom" } },
+			},
+		} as never);
+
+		// A later, SUCCESSFUL turn.
+		store.upsertMessage("ses_1", userMessage("msg_0000000000030000000000"));
+		store.upsertMessage("ses_1", {
+			...assistantMessage("msg_0000000000040000000000"),
+			parentID: "msg_0000000000030000000000",
+		});
+
+		const turns = groupMessagesIntoTurns(useSyncStore.getState().getMessages("ses_1"));
+		expect(turns).toHaveLength(2);
+		expect(getTurnError(turns[0])).toBe("boom");
+		// The later turn is clean — nothing is pinned to the bottom of the thread.
+		expect(getTurnError(turns[1])).toBeUndefined();
+	});
+
+	test("still patches an assistant message that already started THIS turn", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_0000000000010000000000"));
+		store.upsertMessage("ses_1", {
+			...assistantMessage("msg_0000000000020000000000"),
+			parentID: "msg_0000000000010000000000",
+		});
+
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "UnknownError", data: { message: "mid-turn failure" } },
+			},
+		} as never);
+
+		const msgs = useSyncStore.getState().messages.ses_1;
+		expect(msgs).toHaveLength(2);
+		expect(
+			(msgs[1] as AssistantMessage).error as { data: { message: string } },
+		).toEqual({ data: { message: "mid-turn failure" }, name: "UnknownError" } as never);
+	});
+
+	test("hydrate KEEPS the error when the server transcript has no reply for that turn", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_0000000000010000000000"));
+		store.upsertMessage("ses_1", {
+			...assistantMessage("msg_0000000000020000000000"),
+			parentID: "msg_0000000000010000000000",
+		});
+		store.upsertMessage("ses_1", userMessage("msg_0000000000030000000000"));
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "UnknownError", data: { message: "boom" } },
+			},
+		} as never);
+
+		// `reconcileTail('session-error')` — the server holds the earlier turn's
+		// assistant message, and NOTHING for the failing turn. The old
+		// session-wide rule read that as "a real assistant message landed" and
+		// dropped the only record of the failure.
+		store.hydrate("ses_1", [
+			{ info: userMessage("msg_0000000000010000000000"), parts: [] },
+			{
+				info: {
+					...assistantMessage("msg_0000000000020000000000"),
+					parentID: "msg_0000000000010000000000",
+				},
+				parts: [],
+			},
+			{ info: userMessage("msg_0000000000030000000000"), parts: [] },
+		]);
+
+		const turns = groupMessagesIntoTurns(useSyncStore.getState().getMessages("ses_1"));
+		expect(turns).toHaveLength(2);
+		expect(getTurnError(turns[1])).toBe("boom");
+	});
+
+	test("hydrate DROPS the error once the server holds a real reply for that turn", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_0000000000010000000000"));
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "UnknownError", data: { message: "boom" } },
+			},
+		} as never);
+
+		store.hydrate("ses_1", [
+			{ info: userMessage("msg_0000000000010000000000"), parts: [] },
+			{
+				info: {
+					...assistantMessage("msg_0000000000020000000000"),
+					parentID: "msg_0000000000010000000000",
+				},
+				parts: [],
+			},
+		]);
+
+		const ids = useSyncStore.getState().messages.ses_1.map((m) => m.id);
+		expect(ids).toEqual(["msg_0000000000010000000000", "msg_0000000000020000000000"]);
+	});
+
+	test("hydrate moves the error onto the server's own reply for that turn", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_0000000000010000000000"));
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "UnknownError", data: { message: "boom" } },
+			},
+		} as never);
+
+		// The server DID persist an assistant message for the failed turn, but
+		// its copy carries no error (opencode records the failure on the
+		// session, not always on the message). Dropping the stub against it
+		// would erase the only evidence the turn failed.
+		store.hydrate("ses_1", [
+			{ info: userMessage("msg_0000000000010000000000"), parts: [] },
+			{
+				info: {
+					...assistantMessage("msg_0000000000020000000000"),
+					parentID: "msg_0000000000010000000000",
+				},
+				parts: [],
+			},
+		]);
+
+		const msgs = useSyncStore.getState().messages.ses_1;
+		expect(msgs.map((m) => m.id)).toEqual([
+			"msg_0000000000010000000000",
+			"msg_0000000000020000000000",
+		]);
+		const turns = groupMessagesIntoTurns(useSyncStore.getState().getMessages("ses_1"));
+		expect(getTurnError(turns[0])).toBe("boom");
+	});
+
+	test("hydrate leaves the server's OWN error on that reply alone", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_0000000000010000000000"));
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "UnknownError", data: { message: "client copy" } },
+			},
+		} as never);
+
+		store.hydrate("ses_1", [
+			{ info: userMessage("msg_0000000000010000000000"), parts: [] },
+			{
+				info: {
+					...assistantMessage("msg_0000000000020000000000"),
+					parentID: "msg_0000000000010000000000",
+					error: { name: "UnknownError", data: { message: "server copy" } },
+				} as never,
+				parts: [],
+			},
+		]);
+
+		const turns = groupMessagesIntoTurns(useSyncStore.getState().getMessages("ses_1"));
+		expect(getTurnError(turns[0])).toBe("server copy");
+	});
+
+	// The stub is part of `messages[sessionID]`, so the transcript cache mirrors
+	// it to IndexedDB and the first paint after a reload brings it back. Its
+	// tracking map does not survive the reload, so `hydrate` re-adopts it —
+	// otherwise a restored stub could never be reconciled again.
+	test("re-adopts a stub restored from the disk transcript cache", () => {
+		const store = useSyncStore.getState();
+		const stub = {
+			...assistantMessage("msg_0000000000010000000000_error"),
+			parentID: "msg_0000000000010000000000",
+			error: { name: "UnknownError", data: { message: "boom" } },
+		} as never as Message;
+
+		// First paint, straight out of the cache.
+		store.hydrate("ses_1", [
+			{ info: userMessage("msg_0000000000010000000000"), parts: [] },
+			{ info: stub, parts: [] },
+		]);
+		expect(
+			getTurnError(groupMessagesIntoTurns(useSyncStore.getState().getMessages("ses_1"))[0]),
+		).toBe("boom");
+
+		// The runtime reconcile behind it: the server now holds a real reply.
+		store.hydrate("ses_1", [
+			{ info: userMessage("msg_0000000000010000000000"), parts: [] },
+			{
+				info: {
+					...assistantMessage("msg_0000000000020000000000"),
+					parentID: "msg_0000000000010000000000",
+				},
+				parts: [],
+			},
+		]);
+
+		expect(useSyncStore.getState().messages.ses_1.map((m) => m.id)).toEqual([
+			"msg_0000000000010000000000",
+			"msg_0000000000020000000000",
+		]);
+	});
+
+	test("follows its user message when a message.updated echo retires the optimistic one", () => {
+		const store = useSyncStore.getState();
+		store.optimisticAdd("ses_1", userMessage("msg_optimistic00000000000"), [
+			textPart("prt_1", "msg_optimistic00000000000", "hi"),
+		]);
+		store.markOptimisticDispatched("ses_1", "msg_optimistic00000000000");
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "UnknownError", data: { message: "boom" } },
+			},
+		} as never);
+
+		// The server's own copy of that prompt, over SSE this time.
+		store.applyEvent({
+			id: "evt_2",
+			type: "message.updated",
+			properties: { info: userMessage("msg_0000000000090000000000") },
+		} as never);
+
+		const msgs = useSyncStore.getState().messages.ses_1;
+		expect(msgs.map((m) => m.id)).not.toContain("msg_optimistic00000000000");
+		const stub = msgs.find((m) => m.role === "assistant") as AssistantMessage;
+		expect(stub.parentID).toBe("msg_0000000000090000000000");
+		const turns = groupMessagesIntoTurns(useSyncStore.getState().getMessages("ses_1"));
+		expect(turns).toHaveLength(1);
+		expect(getTurnError(turns[0])).toBe("boom");
+	});
+
+	test("follows its user message when the server echo supersedes the optimistic one", () => {
+		const store = useSyncStore.getState();
+		store.optimisticAdd("ses_1", userMessage("msg_optimistic00000000000"), [
+			textPart("prt_1", "msg_optimistic00000000000", "hi"),
+		]);
+		store.markOptimisticDispatched("ses_1", "msg_optimistic00000000000");
+		store.applyEvent({
+			id: "evt_1",
+			type: "session.error",
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "UnknownError", data: { message: "boom" } },
+			},
+		} as never);
+
+		// The server's own copy of that prompt, correlated by part id.
+		store.hydrate("ses_1", [
+			{
+				info: userMessage("msg_0000000000090000000000"),
+				parts: [textPart("prt_1", "msg_0000000000090000000000", "hi")],
+			},
+		]);
+
+		const msgs = useSyncStore.getState().messages.ses_1;
+		expect(msgs.map((m) => m.id)).not.toContain("msg_optimistic00000000000");
+		const stub = msgs.find((m) => m.role === "assistant") as AssistantMessage;
+		expect(stub.parentID).toBe("msg_0000000000090000000000");
+		const turns = groupMessagesIntoTurns(useSyncStore.getState().getMessages("ses_1"));
+		expect(turns).toHaveLength(1);
+		expect(getTurnError(turns[0])).toBe("boom");
 	});
 });
 

--- a/packages/sdk/src/browser/stores/sync-store.ts
+++ b/packages/sdk/src/browser/stores/sync-store.ts
@@ -516,15 +516,103 @@ const deltaActiveParts = new Map<string, Set<string>>();
 const deltaEventTails = new Map<string, Map<string, Set<string>>>();
 
 /** Session-scoped tracking for `session.error`'s stub assistant message (see
- *  the handler below) — same shape/reason as the maps above. A stub only
- *  ever stands in for a real assistant message that has not arrived yet;
- *  `hydrate` reconciles (drops) it the moment the server's own transcript
- *  contains a real one for this session, which is the promise the stub's own
- *  creation comment made but that nothing previously fulfilled. Released
- *  wholesale by `forgetSessionIds`/`reset()`; NOT cleared on idle/error — the
- *  stub message it names still lives in `messages[sessionID]` until hydrate
- *  reconciles it or the session itself ends. */
-const stubAssistantIds = new Map<string, Set<string>>();
+ *  the handler below) — same shape/reason as the maps above, except the value
+ *  is a MAP: stub message id → the id of the user message whose turn failed
+ *  (`null` only when the session held no user message at all).
+ *
+ *  The parent is tracked, not merely implied, because every question asked
+ *  about a stub afterwards is a question about its TURN. A stub stands in for
+ *  the assistant message that turn never produced, so `hydrate` may drop it
+ *  only once the server's transcript answers THAT turn — a session-wide "any
+ *  assistant message exists" test deleted the only record of a failure the
+ *  moment an EARLIER turn's reply arrived (the 2026-08-19 report: the first
+ *  `ModelNotFound` rendered nothing at all).
+ *
+ *  Released wholesale by `forgetSessionIds`/`reset()`; NOT cleared on
+ *  idle/error — the stub message it names still lives in `messages[sessionID]`
+ *  until hydrate reconciles it or the session itself ends. */
+const stubAssistantIds = new Map<string, Map<string, string | null>>();
+
+/** Remember `stubId` as this session's stand-in for the turn `parentId` opened. */
+function trackStub(sessionID: string, stubId: string, parentId: string | null): void {
+	const bucket = stubAssistantIds.get(sessionID);
+	if (bucket) bucket.set(stubId, parentId);
+	else stubAssistantIds.set(sessionID, new Map([[stubId, parentId]]));
+}
+
+function untrackStub(sessionID: string, stubId: string): void {
+	const bucket = stubAssistantIds.get(sessionID);
+	if (!bucket) return;
+	bucket.delete(stubId);
+	if (bucket.size === 0) stubAssistantIds.delete(sessionID);
+}
+
+/** The stub id for the turn `userId` opened.
+ *
+ *  Derived from the user message's own id, for two reasons. It is IDEMPOTENT —
+ *  a second `session.error` for the same turn finds the stub it already made
+ *  instead of appending another. And it SORTS immediately after that user
+ *  message: every id the store handles has the same length, so an id that
+ *  extends `userId` byte for byte precedes every id greater than `userId` and
+ *  follows `userId` itself. Position and `parentID` therefore agree, whichever
+ *  of the two a reader uses. */
+const stubIdFor = (userId: string) => `${userId}_error`;
+
+/** A stub id as seen from a list that has no tracking map to hand (`hydrate`'s
+ *  incoming server snapshot, which can never legitimately contain one). */
+const isStubShaped = (id: string) => id.endsWith("_error");
+
+/** Does `messages` hold an assistant message answering the turn `parentId`
+ *  opened? `parentID` is the linkage `groupMessagesIntoTurns` reads; the id
+ *  comparison covers a wire assistant message that carries none (ids ascend,
+ *  so a greater id is a later message). With no parent turn to speak of, any
+ *  assistant message answers. */
+function hasAssistantForTurn(
+	messages: readonly Message[],
+	parentId: string | null,
+): boolean {
+	return messages.some(
+		(m) =>
+			m.role === "assistant" &&
+			!isStubShaped(m.id) &&
+			(!parentId || m.parentID === parentId || (!m.parentID && m.id > parentId)),
+	);
+}
+
+/** Move this session's `session.error` stubs from the optimistic user message
+ *  `fromId` onto the server's own copy of that prompt, `toId`.
+ *
+ *  Both paths that retire an optimistic user message call this — `hydrate`'s
+ *  correlation and the `message.updated` echo — because a stub whose parent id
+ *  no longer names a message in the list has lost the only link that says which
+ *  turn failed, and `groupMessagesIntoTurns` would fall back to "the last turn
+ *  seen", i.e. the bottom of the thread. Returns the list unchanged when this
+ *  session has no stub on `fromId`. */
+function rekeyStubParent(
+	sessionID: string,
+	list: readonly Message[],
+	fromId: string,
+	toId: string,
+): Message[] {
+	const bucket = stubAssistantIds.get(sessionID);
+	if (!bucket) return list as Message[];
+	const moved = [...bucket.entries()].filter(([, parentId]) => parentId === fromId);
+	if (moved.length === 0) return list as Message[];
+	let next = [...list];
+	for (const [stubId] of moved) {
+		untrackStub(sessionID, stubId);
+		const idx = next.findIndex((m) => m.id === stubId);
+		if (idx === -1) continue;
+		const nextId = stubIdFor(toId);
+		trackStub(sessionID, nextId, toId);
+		const rekeyed = { ...next[idx], id: nextId, parentID: toId } as Message;
+		next.splice(idx, 1);
+		const parentIdx = next.findIndex((m) => m.id === toId);
+		if (parentIdx === -1) next = [...next, rekeyed];
+		else next.splice(parentIdx + 1, 0, rekeyed);
+	}
+	return next;
+}
 
 // ---------------------------------------------------------------------------
 // Session retention — how a transcript ever LEAVES memory again.
@@ -1282,22 +1370,32 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 				.map((m) => m.info)
 				.sort((a, b) => cmp(a.id, b.id));
 
-			// T16 — reconcile a `session.error` stub assistant message
-			// (see `stubAssistantIds` and the `session.error` handler above). The
-			// stub only ever stood in for a real assistant message that had not
-			// arrived yet, sorted BELOW every server id (`ascendingId('msg')`) —
-			// wrong once real data exists. The moment the server's OWN transcript
-			// contains a real assistant message for this session, every
-			// currently-tracked stub for it is stale and is dropped below rather
-			// than kept alongside the real one at the wrong position. If the
-			// incoming snapshot has no assistant message at all yet, nothing has
-			// arrived to reconcile against, so the stub is left untouched.
+			// T16 — a `session.error` stub assistant message is reconciled
+			// PER TURN, after the optimistic correlation below has run (see
+			// `pendingStubs`). It only ever stood in for the assistant message
+			// its own turn never produced, so the question is not "does this
+			// session have an assistant message" — an earlier turn's answer is
+			// no answer at all — but "does the server now answer THAT turn".
+
+			// Re-adopt a stub that arrives IN the snapshot. The transcript cache
+			// mirrors `messages[sessionID]` to IndexedDB, stubs included, so the
+			// first paint after a reload brings one back — while
+			// `stubAssistantIds` (module state) did not survive the reload. An
+			// unadopted stub is unreconcilable: it would sit beside the server's
+			// own reply forever. Only the runtime ever produces these ids, so
+			// nothing else can be mistaken for one.
+			for (const info of incoming) {
+				if (info.role !== "assistant" || !isStubShaped(info.id)) continue;
+				if (!(info as { error?: unknown }).error) continue;
+				if (stubAssistantIds.get(sessionID)?.has(info.id)) continue;
+				trackStub(sessionID, info.id, info.parentID ?? null);
+			}
+
 			const trackedStubIds = stubAssistantIds.get(sessionID);
-			const reconcileStubs =
-				!!trackedStubIds &&
-				trackedStubIds.size > 0 &&
-				incoming.some((m) => m.role === "assistant");
-			if (reconcileStubs) stubAssistantIds.delete(sessionID);
+			/** Stubs held back from the merge below until their parent turn is
+			 *  known (an optimistic parent may be superseded by the server's own
+			 *  copy in this very snapshot). */
+			const pendingStubs: Message[] = [];
 
 			// Merge incoming messages with existing ones — never delete messages
 			// that exist in the sync store but are missing from the fetch (they may
@@ -1375,10 +1473,11 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			const unmatchedOptimisticUsers: typeof existing = [];
 			for (const m of existing) {
 				if (!seen.has(m.id)) {
-					if (reconcileStubs && trackedStubIds!.has(m.id)) {
-						// Superseded by a real assistant message this same hydrate
-						// snapshot introduced — drop it, don't reinsert it below the
-						// real data at its stale `ascendingId` position.
+					if (trackedStubIds?.has(m.id)) {
+						// Placed (or dropped) after the correlation passes below,
+						// because where it belongs depends on what happened to the
+						// user message it is parented to.
+						pendingStubs.push(m);
 						continue;
 					}
 					if (isOptimistic(sessionID, m.id)) {
@@ -1436,6 +1535,60 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			// Append surviving optimistic messages at the end
 			for (const m of deferredOptimistic) {
 				merged.push(m);
+			}
+
+			// Now place (or retire) each `session.error` stub, with its turn
+			// finally settled. Three outcomes, in order:
+			//
+			//  - its user message was superseded by the server's own copy in this
+			//    snapshot → the stub follows it, re-keyed onto the real id;
+			//  - the server now holds a real assistant message for that turn →
+			//    the stub was a stand-in for exactly that message, so it goes;
+			//  - otherwise → it stays, directly after its user message. This is
+			//    the case the reported bug turned on: the `reconcileTail` that
+			//    every `session.error` triggers returns a transcript with NO
+			//    reply for the failed turn, and dropping the stub there left the
+			//    user staring at their own prompt and nothing else.
+			for (const stub of pendingStubs) {
+				const trackedParent = trackedStubIds?.get(stub.id) ?? null;
+				const parentId = (trackedParent && supersededBy.get(trackedParent)) || trackedParent;
+				untrackStub(sessionID, stub.id);
+				// The server DOES hold a reply for this turn — the stub stood in
+				// for exactly that message, so it goes. Its error moves onto the
+				// real message first, unless the server's copy carries one of its
+				// own: `session.error` is the runtime's report of THIS turn
+				// failing, and the transcript read that follows it does not always
+				// carry the failure back (the same race
+				// `use-opencode-events`'s cache patch exists for). Dropping the
+				// stub against an error-free server copy would erase the only
+				// evidence the turn failed.
+				if (hasAssistantForTurn(incoming, parentId)) {
+					const replyIdx = merged.findIndex(
+						(m) =>
+							m.role === "assistant" &&
+							!isStubShaped(m.id) &&
+							(!parentId || m.parentID === parentId || (!m.parentID && m.id > parentId)),
+					);
+					const reply = replyIdx === -1 ? undefined : merged[replyIdx];
+					const stubError = (stub as { error?: unknown }).error;
+					if (reply && !(reply as { error?: unknown }).error && stubError) {
+						merged[replyIdx] = { ...reply, error: stubError } as Message;
+					}
+					continue;
+				}
+				const stubId = parentId ? stubIdFor(parentId) : stub.id;
+				const placed =
+					stubId === stub.id && (stub as { parentID?: string }).parentID === (parentId ?? undefined)
+						? stub
+						: ({ ...stub, id: stubId, ...(parentId ? { parentID: parentId } : {}) } as Message);
+				trackStub(sessionID, stubId, parentId);
+				const parentIdx = parentId ? merged.findIndex((m) => m.id === parentId) : -1;
+				if (parentIdx !== -1) {
+					merged.splice(parentIdx + 1, 0, placed);
+					continue;
+				}
+				const r = Binary.search(merged, placed.id, (x) => x.id);
+				if (!r.found) merged.splice(r.index, 0, placed);
 			}
 
 			// Merge parts: for each message, reconcile by part ID.
@@ -1691,11 +1844,18 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 								const without = list.filter((m) => !optIds.includes(m.id));
 								// Insert the real message at sorted position
 								const r = Binary.search(without, info.id, (m) => m.id);
-								const next = [...without];
+								let next = [...without];
 								if (r.found) {
 									next[r.index] = info;
 								} else {
 									next.splice(r.index, 0, info);
+								}
+								// A turn that failed before this confirmation arrived
+								// has a `session.error` stub keyed to the optimistic id
+								// being retired here. Re-key it, or its error detaches
+								// from the turn and drifts to the bottom of the thread.
+								for (const id of optIds) {
+									next = rekeyStubParent(info.sessionID, next, id, info.id);
 								}
 								// Bridge optimistic parts to the real message ID so
 								// the user bubble never flickers empty while waiting
@@ -1911,47 +2071,76 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			deltaActiveParts.delete(sid);
 			deltaEventTails.delete(sid);
 
-			// Patch the error onto the last assistant message in the sync store.
-			// If no assistant message exists yet, create a temporary one so the
-			// error is visible immediately. The event handler in
-			// use-opencode-events.ts will also fetch real messages from the
-			// server which will bring in the authoritative data via hydrate().
+			// Attach the error to the TURN THAT FAILED, which is the turn the
+			// last user message opened: `session.error` terminates the turn the
+			// runtime was running, and the runtime runs one at a time.
+			//
+			// When that turn already produced an assistant message the error is
+			// patched onto it, as before. When it produced none — the whole
+			// class of failures that die before generation starts, e.g.
+			// `ModelNotFound`, which arrives ~2ms after the prompt — a stub
+			// assistant message stands in for it, parented to that user message
+			// and positioned directly after it.
+			//
+			// It used to be "the last assistant message ANYWHERE, else append a
+			// stub at the end", and both halves put the error in the wrong turn:
+			// the patch landed on the previous turn's answer (where the
+			// `reconcileTail` hydrate that follows every `session.error` then
+			// overwrote it with the server's error-free copy, so the failure
+			// rendered NOTHING), and the appended stub rode the bottom of the
+			// thread, reappearing under whichever prompt came next.
+			//
+			// The event handler in use-opencode-events.ts also fetches real
+			// messages from the server, which brings in the authoritative data
+			// via hydrate().
 			set((s) => {
 				const msgs = s.messages[sid] ?? [];
-				// Find last assistant message and patch .error onto it
+				// The prompt this error answers.
+				let userIdx = -1;
 				for (let i = msgs.length - 1; i >= 0; i--) {
-					const msg = msgs[i];
-					if (msg.role === "assistant") {
-						if (msg.error) return s; // already has error
-						const next = [...msgs];
-						// `error` may be the client-synthesized `SyntheticAbortError`
-						// (see `MessageError`), which the SDK's own `AssistantMessage.error`
-						// union doesn't declare — the assertion is the documented, narrow
-						// exception for that one extra shape.
-						next[i] = { ...msg, error } as typeof msg;
-						return { messages: { ...s.messages, [sid]: next } };
+					if (msgs[i].role === "user") {
+						userIdx = i;
+						break;
 					}
 				}
+				const userId = userIdx === -1 ? null : msgs[userIdx].id;
 
-				// No assistant message yet — create a stub so the error shows.
-				// Tracked in `stubAssistantIds` (T16) so `hydrate` can
-				// reconcile it away once a real assistant message for this
-				// session lands — see that map's doc comment and the
-				// reconciliation in `hydrate` below. `ascendingId('msg')` sorts
-				// BELOW every server id, which is fine as a placeholder position
-				// but wrong once real data exists; that is exactly what the
-				// reconciliation fixes.
-				const stubId = ascendingId("msg");
-				trackId(stubAssistantIds, sid, stubId);
+				// An assistant message that already belongs to THAT turn takes
+				// the error. Scanning back only as far as the user message is
+				// what keeps an earlier turn's answer out of it.
+				for (let i = msgs.length - 1; i > userIdx; i--) {
+					const msg = msgs[i];
+					if (msg.role !== "assistant") continue;
+					if (userId && msg.parentID && msg.parentID !== userId) continue;
+					if (msg.error) return s; // already has error
+					const next = [...msgs];
+					// `error` may be the client-synthesized `SyntheticAbortError`
+					// (see `MessageError`), which the SDK's own `AssistantMessage.error`
+					// union doesn't declare — the assertion is the documented, narrow
+					// exception for that one extra shape.
+					next[i] = { ...msg, error } as typeof msg;
+					return { messages: { ...s.messages, [sid]: next } };
+				}
+
+				// No assistant message for this turn yet — stand one in so the
+				// error renders under the prompt it answers. Tracked in
+				// `stubAssistantIds` (T16) with its parent so `hydrate` can
+				// reconcile it away once the server's own transcript answers
+				// THAT turn — see that map's doc comment and the reconciliation
+				// in `hydrate` below.
+				const stubId = userId ? stubIdFor(userId) : ascendingId("msg");
+				if (msgs.some((m) => m.id === stubId)) return s;
+				trackStub(sid, stubId, userId);
 				const stubMsg: Message = {
 					id: stubId,
 					sessionID: sid,
 					role: "assistant",
+					...(userId ? { parentID: userId } : {}),
 					error,
 				} as Message;
-				return {
-					messages: { ...s.messages, [sid]: [...msgs, stubMsg] },
-				};
+				const next = [...msgs];
+				next.splice(userIdx === -1 ? next.length : userIdx + 1, 0, stubMsg);
+				return { messages: { ...s.messages, [sid]: next } };
 			});
 			return;
 		}


### PR DESCRIPTION
## Incident (prod, 2026-08-19)

Picking managed models `grok-4.6` or `deepseek-v4-pro-0813` in the web picker produced **no reply at all**. Two sessions on kortix.com (project `fda4e35e`), verified live:

- OpenCode in the sandbox threw `ModelNotFound: kortix/grok-4.6` 2 ms after the user message (audit `opencode.session.error`), before any gateway call — `gateway_request_logs` has **0 rows ever** for `deepseek-v4-pro-0813` as a managed id.
- OpenCode's `kortix` provider map = the image-baked `/opt/kortix/llm-catalog.json` (5,624 models, managed ids frozen at the 2026-08-10 lineup). The prod API `/v1/llm/models` returned the 7 current managed ids.
- Cold boots never refresh that file; warm-fork adoption fetches the ~3.3 MB project catalog inside a 2.5 s/4 s budget and silently falls back (no `kortix-llm-catalog.session.json` on either box). Templates do not rebuild on catalog changes.
- Web: the error rendered nowhere on the first failure, then as a stale line pinned at the bottom under a stuck "Figuring out what's next…" spinner.

## Fix (3 commits)

1. **runtime** — `GET /models?scope=managed` (~3 KB; in-process mount, standalone gateway pod, internal route). Daemon prefetches it right after proxy-up (concurrent with the clone) and overlays it onto the disk catalog before `buildKortixProvider` (≤2.5 s cap; boot path still network-free). Bundled managed table fills missing ids when the fetch fails. Warm-fork adoption composes full+managed and computes `changed` on the composed result. 23 new tests incl. a drift test between `@kortix/llm-catalog` `MANAGED_MODELS` and the daemon's bundled table.
2. **web** — keyboard scrolling is scroll intent. The hook bound `keydown` to the scroll element, which has no tabindex, so Cmd+↑ / PageUp / Home landed on `<body>`; follow stayed true and the next `settle()` wrote `scrollTop = end` (control trace snaps back at ~200 ms; fixed holds while the transcript grows). Document-capture keydown with editable/Space-on-button guards; End / Cmd+↓ re-arms; `onScroll` re-arm now requires arriving at the end moving toward it (the first animated frame off the end was inside `AT_END_PX`). 193 hook tests; Playwright 12/12 vs control 5/12.
3. **sdk/web** — a `session.error` belongs to the turn that failed: stub spliced directly after its user message with `parentID`, per-turn hydrate reconcile, no spinner on an errored turn. Reproduced before/after on a live sandbox (screenshots in the agent run). 11 SDK TDD tests (2232 pass), web 2321 pass.

## Verification so far

- Branch rebuilt on top of main `049b34bcd1` (today's scroll-physics rewrite + sync-store changes). SDK full suite on origin/main already has 464 cross-file failures (fetch-stub leak, pre-existing, not from this PR); our files add +10 pass / 0 new fail; `src/core/http` and `sync-store` pass in isolation.

- daemon: `bun test` 660 pass; `bun run build` OK. api: `bun run test` 7333 pass; llm-gateway pkg 408 pass; `tsc --noEmit` clean everywhere; `apps/web` tsc = known 15 baseline errors; eslint 0 errors.
- Real HTTP: `POST /internal/gateway/models {managedOnly:true}` → 7 managed ids, 3270 B; default → 4943 models.
- Real network daemon proof: stale 5-id baked file + live `?scope=managed` → `grok-4.6` and `deepseek-v4-pro-0813` registered; gateway refused → still registered from the bundled floor.
- Browser: Playwright runs for both web fixes against the worktree stack.

## After merge

Follow Deploy Dev; then on dev: new session → assert OpenCode provider map contains every `?scope=managed` id and a prompt on each managed model answers. Rollout note: deploy API/gateway before sandbox templates rebuild (an old gateway ignores `scope=` and returns the full catalog, which the daemon tolerates — it times out and falls back to the bundled floor).
