### PR TITLE
fix(slack): let another bot @-mention Kortix — the gate blocked every bot, not just us

### DIFF
--- a/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
+++ b/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
@@ -1,0 +1,186 @@
+import { afterAll, describe, expect, mock, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// @Kortix from another bot did nothing, and the code that was supposed to allow
+// it had never been reachable.
+//
+// dispatchSlackEvent gated on:
+//
+//     if ((botUserId && event.user === botUserId) || event.bot_id) return;
+//
+// `|| event.bot_id` returns on ANY bot, so no message from another app ever
+// reached classifyEvent. classifyEvent, meanwhile, has a `bot_message` branch
+// written specifically to let other bots through, justified in its own comment
+// by "our own bot is blocked by the separate gate in dispatchSlackEvent" — an
+// assumption that gate contradicted.
+//
+// The three tests in unit-slack-classify-event.test.ts that assert this
+// behaviour (bot_message → dm / mention / ignored-without-mention) PASS TODAY
+// while the feature cannot work, because they call classifyEvent directly and
+// never cross the gate. That is the blind spot this file closes: the gate is
+// now a named function with its own cases, plus a source contract on the call
+// site so the fix cannot be silently unwired.
+//
+// Loop safety is unchanged. Only OUR messages can loop, and event.user
+// identifies them — every post this codebase makes uses a plain bot token, with
+// no username/icon override anywhere under channels/slack, so Slack stamps our
+// bot user id on the resulting event. The last test pins that absence.
+
+// ─── Mocks so importing dispatch.ts (and its module graph) loads cleanly ──────
+function makeChain(): any {
+  const chain: any = {};
+  for (const m of ['from', 'where', 'limit']) chain[m] = () => chain;
+  chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve([]));
+  return chain;
+}
+mock.module('../shared/db', () => ({
+  db: { select: () => makeChain() },
+  hasDatabase: () => true,
+}));
+mock.module('../channels/slack/turn', () => ({
+  claimFinalize: async () => true,
+  openPlanMessage: async () => true,
+  repaintLivePlan: async () => {},
+  loadTurn: async () => null,
+  startTurn: async () => ({ sessionId: '', channel: 'C1', token: 'xoxb', ts: '', steps: [] }),
+  saveTurn: async () => {},
+  deleteTurn: async () => {},
+  finalizeTurn: async () => {},
+  buildSlackTurnEnv: () => ({}),
+  relayTurnAnswer: async () => {},
+  relayTurnEnd: async () => {},
+  relayTurnStep: async () => {},
+  rowToHandle: () => ({ sessionId: '', channel: 'C1', token: 'xoxb', ts: '', steps: [] }),
+}));
+const realInstallStore = await import('../channels/install-store');
+mock.module('../channels/install-store', () => ({
+  ...realInstallStore,
+  loadSlackBotUserIdForProject: async () => 'B1',
+  loadSlackTokenForProject: async () => 'xoxb-test',
+  loadSlackSigningSecretForProject: async () => null,
+  loadSlackTeamNameForProject: async () => null,
+  listProjectsForWorkspace: async () => ['proj-1'],
+  loadSlackInstall: async () => null,
+}));
+mock.module('../channels/slack-api', () => ({
+  addReaction: async () => {},
+  appendStream: async () => {},
+  deleteMessage: async () => {},
+  getChannelName: async () => 'general',
+  joinChannel: async () => true,
+  openDmChannel: async () => 'D1',
+  postEphemeral: async () => true,
+  postBlocks: async () => 'ts',
+  postMessage: async () => 'ts',
+  publishHomeView: async () => {},
+  removeReaction: async () => {},
+  startStream: async () => 'ts',
+  stopStream: async () => {},
+  updateBlocks: async () => {},
+  updateMessage: async () => {},
+}));
+
+const { classifyEvent, isOwnBotEvent } = await import('../channels/slack/dispatch');
+
+const BOT = 'B1';
+const ev = (e: Record<string, unknown>) => ({ type: 'message', ...e }) as any;
+
+afterAll(() => mock.restore());
+
+describe('isOwnBotEvent — blocks ourselves, not every bot', () => {
+  test('our own message (user === botUserId) is ours', () => {
+    expect(isOwnBotEvent(ev({ user: BOT, bot_id: 'BSELF', text: 'hi' }), BOT)).toBe(true);
+  });
+
+  test('THE FIX: another bot with its own bot_id is NOT ours', () => {
+    expect(isOwnBotEvent(ev({ user: 'U_OTHERBOT', bot_id: 'B999', text: '<@B1> go' }), BOT)).toBe(false);
+  });
+
+  test('THE FIX: a webhook / Workflow Builder post (bot_id, NO user) is NOT ours', () => {
+    // Incoming webhooks and Workflow Builder post with bot_id and no user at
+    // all. These were blocked outright, so an automation could never tag Kortix.
+    expect(isOwnBotEvent(ev({ bot_id: 'B999', subtype: 'bot_message', text: '<@B1> deploy done' }), BOT)).toBe(false);
+  });
+
+  test('a human is never ours', () => {
+    expect(isOwnBotEvent(ev({ user: 'U_HUMAN', text: '<@B1> hello' }), BOT)).toBe(false);
+  });
+
+  test('identity unknown + a bot message → treated as ours (stay conservative)', () => {
+    // botUserId comes from a secret read on every event. If that read fails we
+    // cannot tell our own message from another app's, and guessing wrong is an
+    // infinite self-loop — so bot traffic stops until we know who we are.
+    expect(isOwnBotEvent(ev({ bot_id: 'B999', text: 'anything' }), null)).toBe(true);
+  });
+
+  test('identity unknown + a HUMAN message still passes — humans are not collateral', () => {
+    // A blanket fail-closed would silence the bot for people too. Only the
+    // ambiguous (bot) traffic is dropped.
+    expect(isOwnBotEvent(ev({ user: 'U_HUMAN', text: '<@B1> hello' }), null)).toBe(false);
+  });
+});
+
+describe('the event another bot sends now classifies as real work', () => {
+  // These mirror unit-slack-classify-event.test.ts, but paired with the gate —
+  // there they proved a branch nothing could reach.
+  test('another bot @-mentioning us in a channel → mention', async () => {
+    const e = ev({ subtype: 'bot_message', channel_type: 'channel', text: '<@B1> analyze this', bot_id: 'B999' });
+    expect(isOwnBotEvent(e, BOT)).toBe(false);
+    expect(await classifyEvent('T1', e, BOT)).toBe('mention');
+  });
+
+  test('another bot DMing us → dm', async () => {
+    const e = ev({ subtype: 'bot_message', channel_type: 'im', text: 'hello from another bot', bot_id: 'B999' });
+    expect(isOwnBotEvent(e, BOT)).toBe(false);
+    expect(await classifyEvent('T1', e, BOT)).toBe('dm');
+  });
+
+  test('bot chatter with no mention is STILL ignored — this is why no channel toggle is needed', async () => {
+    // The mention requirement is the opt-in. Opening the gate does not make the
+    // bot answer ambient traffic.
+    const e = ev({ subtype: 'bot_message', channel_type: 'channel', text: 'other bot chatter', bot_id: 'B999' });
+    expect(isOwnBotEvent(e, BOT)).toBe(false);
+    expect(await classifyEvent('T1', e, BOT)).toBe('ignore');
+  });
+});
+
+describe('source contracts', () => {
+  const dispatchSrc = readFileSync(
+    join(import.meta.dir, '..', 'channels', 'slack', 'dispatch.ts'),
+    'utf8',
+  );
+
+  test('dispatchSlackEvent uses isOwnBotEvent, not a blanket bot_id gate', () => {
+    // Every behavioural test above passes even if the call site still returns on
+    // any bot, because they exercise the function directly. Pin the call site.
+    const body = dispatchSrc.slice(dispatchSrc.indexOf('export async function dispatchSlackEvent'));
+    expect(body, 'the self-identity gate is gone — the bot would answer its own messages in a loop')
+      .toContain('if (isOwnBotEvent(event, botUserId)) return;');
+    expect(
+      body.split('\n').filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*')).join('\n'),
+      'the blanket `|| event.bot_id` gate is back — every other bot is silently dropped again',
+    ).not.toMatch(/\|\|\s*event\.bot_id\s*\)\s*return/);
+  });
+
+  test('no username/icon override in the Slack send path — that is what keeps event.user ours', () => {
+    // isOwnBotEvent identifies our messages by event.user. Slack only sets that
+    // when a post goes out as the bot itself; posting with username/icon_emoji/
+    // icon_url instead yields bot_message with NO user, and the self-loop guard
+    // would stop matching. If this test ever reds, the fix is to key the guard on
+    // a stored bot_id (auth.test returns one) — not to delete this test.
+    const dir = join(import.meta.dir, '..', 'channels', 'slack');
+    const glob = new Bun.Glob('**/*.ts');
+    const offenders: string[] = [];
+    for (const rel of glob.scanSync({ cwd: dir })) {
+      if (rel.includes('__tests__') || rel.endsWith('.test.ts')) continue;
+      const src = readFileSync(join(dir, rel), 'utf8')
+        .split('\n')
+        .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*'))
+        .join('\n');
+      if (/\b(username|icon_emoji|icon_url)\s*:/.test(src)) offenders.push(rel);
+    }
+    expect(offenders, 'a post with a username/icon override arrives with NO event.user, weakening isOwnBotEvent')
+      .toEqual([]);
+  });
+});

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -434,8 +434,8 @@ export async function classifyEvent(
     // Allow these user-generated subtypes through:
     //   file_share   — audio messages, images, documents, etc. (agent sees file info)
     //   me_message   — /me actions (e.g. "/me waves hello")
-    //   bot_message  — messages from OTHER bots (our own bot is blocked by the
-    //                  separate bot_id/user===botUserId gate in dispatchSlackEvent)
+    //   bot_message  — messages from OTHER bots (our own bot is blocked by
+    //                  isOwnBotEvent in dispatchSlackEvent)
     // All other subtypes (message_changed, message_deleted, thread_broadcast,
     // channel_join, etc.) remain ignored to avoid loops, redundancy, or system noise.
     if (event.subtype === 'file_share' && event.files?.length) {
@@ -443,7 +443,7 @@ export async function classifyEvent(
     } else if (event.subtype === 'me_message') {
       // pass through — user-generated /me action
     } else if (event.subtype === 'bot_message') {
-      // pass through — other bots' messages (our bot_id gate prevents self-loops)
+      // pass through — other bots' messages (isOwnBotEvent prevents self-loops)
     } else {
       return 'ignore';
     }
@@ -532,6 +532,42 @@ export async function maybePostChannelIntro(teamId: string, event: SlackEvent): 
   await postChannelIntro(install.projectId, event.channel);
 }
 
+/**
+ * Is this event OUR OWN bot talking? The self-loop guard, and nothing wider.
+ *
+ * The gate here used to be `(botUserId && event.user === botUserId) || event.bot_id`,
+ * which returns on ANY bot — so a message from another app could never reach
+ * classifyEvent. That made classifyEvent's `bot_message` branch dead code: it is
+ * written to pass other bots through, and says so ("our own bot is blocked by the
+ * separate gate in dispatchSlackEvent"), but nothing ever arrived. Three tests in
+ * unit-slack-classify-event.test.ts assert that branch works and pass today,
+ * because they call classifyEvent directly and never cross this gate.
+ *
+ * Only OUR messages can loop, and `event.user` identifies them: every Slack post
+ * this codebase makes goes out with a plain bot token — there is no `username`,
+ * `icon_emoji` or `icon_url` override anywhere under channels/slack — so Slack
+ * always stamps our bot user id on the resulting event. (That absence is pinned
+ * by a test; adding such an override strips `user` and would weaken this.)
+ *
+ * The second clause covers the one hole. `botUserId` comes from a secret read on
+ * every event, and if that read fails we cannot tell our own message from another
+ * app's — so we stay conservative with BOT traffic specifically. Humans are
+ * unaffected in that window, which a blanket fail-closed would not manage.
+ *
+ * Deliberately NOT keyed on a stored bot_id: `oauth.v2.access` does not return
+ * one, so that would mean an extra auth.test at install, a new secret, and a
+ * backfill for every existing install — to defend against a code change a test
+ * already catches. This works for every install that exists today with no
+ * migration, because botUserId is a REQUIRED field on both install paths
+ * (install-store.ts saveSlackInstall + saveSlackOauthInstall) and is written
+ * unconditionally by both.
+ */
+export function isOwnBotEvent(event: SlackEvent, botUserId: string | null): boolean {
+  if (botUserId && event.user === botUserId) return true;
+  if (event.bot_id && !botUserId) return true;
+  return false;
+}
+
 export async function dispatchSlackEvent(projectId: string, envelope: SlackEnvelope): Promise<void> {
   const event = envelope.event;
   if (!event) return;
@@ -552,7 +588,7 @@ export async function dispatchSlackEvent(projectId: string, envelope: SlackEnvel
     return;
   }
 
-  if ((botUserId && event.user === botUserId) || event.bot_id) return;
+  if (isOwnBotEvent(event, botUserId)) return;
 
   const eventClass = await classifyEvent(teamId, event, botUserId);
   if (eventClass === 'ignore') return;


### PR DESCRIPTION
`dispatchSlackEvent` gated on:

```ts
if ((botUserId && event.user === botUserId) || event.bot_id) return;
```

`|| event.bot_id` returns on **any** bot, so no message from another app ever reached `classifyEvent`.

`classifyEvent` has a `bot_message` branch written specifically to pass other bots through, justified in its own comment by *"our own bot is blocked by the separate gate in dispatchSlackEvent"* — an assumption that gate contradicted. **The branch was unreachable.**

The three tests asserting that behaviour (`unit-slack-classify-event.test.ts:139/144/149` — `bot_message` → dm / mention / ignored-without-mention) **pass today while the feature cannot work**, because they call `classifyEvent` directly and never cross the gate. That blind spot is why this shipped unnoticed.

## The fix

```ts
export function isOwnBotEvent(event: SlackEvent, botUserId: string | null): boolean {
  if (botUserId && event.user === botUserId) return true;
  if (event.bot_id && !botUserId) return true;
  return false;
}
```

**Loop safety is unchanged** — it's the whole reason the old clause existed. Only *our* messages can loop, and `event.user` identifies them: every Slack post in this codebase goes out with a plain bot token (no `username` / `icon_emoji` / `icon_url` override anywhere under `channels/slack`), so Slack always stamps our bot user id on the resulting event. A source-contract test pins that absence — adding such an override strips `user` and would silently weaken the guard.

The second clause covers the one hole a naive removal leaves: `botUserId` comes from a secret read on every event, and if that read fails we can't tell our own message from another app's. There we stay conservative with **bot** traffic only — humans keep working, which a blanket fail-closed wouldn't manage.

## Works for every existing install, no migration

This *removes* a condition rather than adding a data dependency. `botUserId` is already a **required** field on both install paths (`install-store.ts` `saveSlackInstall` + `saveSlackOauthInstall`) and is written unconditionally by both — the OAuth one fanning it out to every project sharing the workspace.

Deliberately **not** keyed on a stored `bot_id`: `oauth.v2.access` doesn't return one, so that would mean an `auth.test` call at install, a new secret key, and a backfill — to defend against a code change the source-contract test already catches.

## Behaviour

| Event | Before | After |
|---|---|---|
| Kortix's own message | ignored | **ignored** — loop safe |
| Another bot @-mentions Kortix | ignored | **triggers** |
| Another bot DMs Kortix | ignored | **triggers** |
| Another bot replies in a Kortix-owned thread | ignored | **triggers** |
| Another bot posts, no mention | ignored | **ignored** — unchanged |
| Human @mention | triggers | triggers |

Incoming webhooks and **Workflow Builder** posts carry `bot_id` with no `user` — blocked outright before, they now classify normally, so an automation can tag Kortix and get a real turn.

**No per-channel toggle needed:** another bot only wakes Kortix if it explicitly @-mentions it, DMs it, or replies in a thread Kortix owns. Ambient chatter stays ignored — the mention requirement *is* the opt-in.

One line covers **both** webhook routes: the OAuth multi-tenant path (`routes.ts:147`) and the BYO self-hosted path (`:271`) both converge on `dispatchSlackEvent`.

## Testing

- **11 new tests**, including a source contract on the call site so the fix can't be silently unwired, and the `username`/`icon` guard-rail.
- **Negative controls** — restoring the blanket gate, dropping the identity-unknown clause, and adding a `username` override — each go red.
- **29 Slack/channel test files: 331 pass, 0 fail.** Typecheck clean.