### PR TITLE
fix(sandbox): disable slower fast boot experiment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -449,7 +449,7 @@ jobs:
     env:
       AWS_REGION: us-west-2
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
-      KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}'
+      KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"false"}'
     steps:
       - uses: actions/checkout@v7
       - name: Configure AWS credentials (OIDC)

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -36,10 +36,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { PROVISIONING_SESSION_STATUSES } from '../../projects/lib/session-status';
-import * as realAgents from '../../projects/agents';
-import * as realProviders from '../providers';
 import * as realComputeMetering from '../../billing/services/compute-metering';
+import * as realAgents from '../../projects/agents';
+import { PROVISIONING_SESSION_STATUSES } from '../../projects/lib/session-status';
+import * as realProviders from '../providers';
 
 const dialect = new PgDialect();
 
@@ -70,7 +70,7 @@ let stoppedIds: string[] = [];
 let onRemoved: (() => void) | null = null;
 let computeSessionsOpened: Array<{ sandboxId: string; accountId: string }> = [];
 let onComputeOpened: (() => void) | null = null;
-let recordedEvents: Array<{ outcome: string }> = [];
+let recordedEvents: Array<{ outcome: string; marks?: Array<{ label: string }> }> = [];
 let identityConflict = false;
 let recoveryPlaceholder = false;
 let providerCreateCalls = 0;
@@ -81,6 +81,8 @@ let imageRequests: Array<Record<string, unknown>> = [];
 let fastImageRequests: Array<Record<string, unknown>> = [];
 let accountTokenCreateCalls: Array<Record<string, unknown>> = [];
 let serviceAccountCreateCalls: Array<Record<string, unknown>> = [];
+let networkBoundaryBindings: Array<Record<string, unknown>> = [];
+let providerSyncCalls: Array<{ externalId: string; bindings: Array<Record<string, unknown>> }> = [];
 
 function compile(condition: unknown): { sql: string; params: unknown[] } {
   try {
@@ -127,10 +129,12 @@ mock.module('../../shared/db', () => ({
         where: (_cond: unknown) => ({
           limit: async (_n: number) => {
             if (table === projectSessions) {
-              return [{
-                status: scenario.projectSessionStatusAtCheck,
-                metadata: scenario.projectSessionMetadataAtCheck,
-              }];
+              return [
+                {
+                  status: scenario.projectSessionStatusAtCheck,
+                  metadata: scenario.projectSessionMetadataAtCheck,
+                },
+              ];
             }
             return [];
           },
@@ -157,18 +161,20 @@ mock.module('../../shared/db', () => ({
             recoveryPlaceholder = false;
             return updateResult(
               claimed
-                ? [{
-                    sandboxId: SANDBOX_ID,
-                    sessionId: SANDBOX_ID,
-                    accountId: ACCOUNT_ID,
-                    projectId: PROJECT_ID,
-                    provider: 'daytona',
-                    externalId: null,
-                    status: 'provisioning',
-                    baseUrl: null,
-                    config: {},
-                    metadata: { identityRecoveryAuthorizedAt: new Date().toISOString() },
-                  }]
+                ? [
+                    {
+                      sandboxId: SANDBOX_ID,
+                      sessionId: SANDBOX_ID,
+                      accountId: ACCOUNT_ID,
+                      projectId: PROJECT_ID,
+                      provider: 'daytona',
+                      externalId: null,
+                      status: 'provisioning',
+                      baseUrl: null,
+                      config: {},
+                      metadata: { identityRecoveryAuthorizedAt: new Date().toISOString() },
+                    },
+                  ]
                 : [],
             );
           }
@@ -187,29 +193,33 @@ mock.module('../providers', () => ({
   getProvider: (name: string) => {
     providerNamesRequested.push(name);
     return {
-    name,
-    provisioning: { async: true, stages: [{ id: 'boot', progress: 50, message: 'Booting…' }] },
-    create: async (_opts: unknown) => {
-      providerCreateCalls += 1;
-      if (providerCreateErrors[name]) throw new Error(providerCreateErrors[name]);
-      return {
-        externalId: name === 'daytona' ? EXTERNAL_ID : `ext-${name}-1`,
-        baseUrl: 'https://sandbox.test',
-        metadata: {},
-      };
-    },
-    remove: async (externalId: string) => {
-      removedIds.push(externalId);
-      onRemoved?.();
-    },
-    start: async () => {},
-    stop: async (externalId: string) => {
-      stoppedIds.push(externalId);
-    },
-    getStatus: async () => 'running',
-    resolveEndpoint: async () => ({ url: '', headers: {} }),
-    resolveProxyEndpoint: async () => ({ url: '', headers: {} }),
-  }},
+      name,
+      provisioning: { async: true, stages: [{ id: 'boot', progress: 50, message: 'Booting…' }] },
+      create: async (_opts: unknown) => {
+        providerCreateCalls += 1;
+        if (providerCreateErrors[name]) throw new Error(providerCreateErrors[name]);
+        return {
+          externalId: name === 'daytona' ? EXTERNAL_ID : `ext-${name}-1`,
+          baseUrl: 'https://sandbox.test',
+          metadata: {},
+        };
+      },
+      syncNetworkBoundary: async (externalId: string, bindings: Array<Record<string, unknown>>) => {
+        providerSyncCalls.push({ externalId, bindings });
+      },
+      remove: async (externalId: string) => {
+        removedIds.push(externalId);
+        onRemoved?.();
+      },
+      start: async () => {},
+      stop: async (externalId: string) => {
+        stoppedIds.push(externalId);
+      },
+      getStatus: async () => 'running',
+      resolveEndpoint: async () => ({ url: '', headers: {} }),
+      resolveProxyEndpoint: async () => ({ url: '', headers: {} }),
+    };
+  },
   WarmRuntimeUnavailableError: class WarmRuntimeUnavailableError extends Error {},
   SandboxTemplateNotFoundError: class SandboxTemplateNotFoundError extends Error {},
 }));
@@ -272,7 +282,11 @@ mock.module('./provider-events', () => ({
 // whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../billing/services/compute-metering', () => ({
   ...realComputeMetering,
-  startComputeSession: async (input: { sandboxId: string; accountId: string; provider: string }) => {
+  startComputeSession: async (input: {
+    sandboxId: string;
+    accountId: string;
+    provider: string;
+  }) => {
     computeSessionsOpened.push(input);
     onComputeOpened?.();
   },
@@ -302,6 +316,10 @@ mock.module('../../shared/account-limits', () => ({
 
 mock.module('../../projects/triggers', () => ({
   readManifest: async () => null,
+}));
+
+mock.module('../../projects/lib/network-secret-boundary', () => ({
+  resolveSessionNetworkBoundary: async () => networkBoundaryBindings,
 }));
 
 mock.module('../../projects/agents', () => ({
@@ -353,6 +371,8 @@ beforeEach(() => {
   fastImageRequests = [];
   accountTokenCreateCalls = [];
   serviceAccountCreateCalls = [];
+  networkBoundaryBindings = [];
+  providerSyncCalls = [];
 });
 
 afterEach(() => {
@@ -410,6 +430,29 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     expect(imageRequests[0]).not.toHaveProperty('requireCurrentRuntime');
   });
 
+  test('provider telemetry separates provider creation from network-boundary sync', async () => {
+    networkBoundaryBindings = [{ identifier: 'github', host: 'api.github.com' }];
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
+
+    await provisionSessionSandbox(baseOpts());
+    await opened;
+
+    expect(providerSyncCalls).toEqual([
+      {
+        externalId: EXTERNAL_ID,
+        bindings: networkBoundaryBindings,
+      },
+    ]);
+    const labels =
+      recordedEvents.find((event) => event.outcome === 'ok')?.marks?.map((mark) => mark.label) ??
+      [];
+    expect(labels).toContain('provider-create:1x');
+    expect(labels).toContain('network-secrets:1');
+    expect(labels.indexOf('provider-create:1x')).toBeLessThan(labels.indexOf('network-secrets:1'));
+  });
+
   test('the fast flag selects the shared fast image without changing the project template', async () => {
     process.env.KORTIX_FAST_COLD_BOOT_ENABLED = 'true';
     const opened = waitFor((resolve) => {
@@ -422,7 +465,8 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     expect(fastImageRequests).toEqual([{ source: 'session-start', provider: 'daytona' }]);
     expect(imageRequests).toEqual([]);
     const finishCall = updateCalls.find(
-      (call) => call.table === sessionSandboxes && 'externalId' in call.updates && 'config' in call.updates,
+      (call) =>
+        call.table === sessionSandboxes && 'externalId' in call.updates && 'config' in call.updates,
     );
     expect(finishCall?.updates.metadata).toMatchObject({
       runtimeArtifact: {
@@ -441,7 +485,8 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     await opened;
 
     const finishCall = updateCalls.find(
-      (call) => call.table === sessionSandboxes && 'externalId' in call.updates && 'config' in call.updates,
+      (call) =>
+        call.table === sessionSandboxes && 'externalId' in call.updates && 'config' in call.updates,
     );
     expect(finishCall?.updates.metadata).toMatchObject({
       providerExternalId: 'ext-e2b-1',
@@ -530,7 +575,9 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
   test('provider-loss placeholder is reclaimed without inserting a second logical row', async () => {
     identityConflict = true;
     recoveryPlaceholder = true;
-    const opened = waitFor((resolve) => { onComputeOpened = resolve; });
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
 
     await provisionSessionSandbox(baseOpts());
     await opened;
@@ -543,7 +590,9 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
   test('legacy recovery placeholder authorization is single-use under concurrent allocation', async () => {
     identityConflict = true;
     recoveryPlaceholder = true;
-    const opened = waitFor((resolve) => { onComputeOpened = resolve; });
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
 
     const results = await Promise.allSettled([
       provisionSessionSandbox(baseOpts()),
@@ -622,7 +671,9 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
 
   test('manual stop racing provider create stops and preserves the sandbox instead of removing it', async () => {
     scenario.projectSessionStatusAtCheck = 'stopped';
-    const eventRecorded = waitFor((resolve) => { onProviderEvent = resolve; });
+    const eventRecorded = waitFor((resolve) => {
+      onProviderEvent = resolve;
+    });
     await provisionSessionSandbox(baseOpts());
     await eventRecorded;
 

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -750,6 +750,7 @@ export async function provisionSessionSandbox(opts: {
         throw createErr;
       }
       bgExternalId = result.externalId;
+      tl.mark(`provider-create:${attempts}x`);
       // `syncNetworkBoundary` is optional on the provider interface. The
       // non-null assertion was safe only while the pre-check above guaranteed
       // the method existed; now that a shim-backed provider gets past that
@@ -765,7 +766,6 @@ export async function provisionSessionSandbox(opts: {
           throw error;
         }
       }
-      tl.mark(`provider-create:${attempts}x`);
       const timeline = tl.summary();
 
       const [currentSession] = await db

--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -1,6 +1,6 @@
 # Fast cold boot runtime
 
-Status: experimental on dev. Staging and production remain disabled.
+Status: implemented but disabled. Dev, staging, and production use the standard image.
 
 ## Problem
 
@@ -47,8 +47,8 @@ Platinum cannot reuse the standard template ID for a fast-image session.
 
 ## Rollout and rollback
 
-Dev enables the flag in `infra/terraform/environments/dev/variables.tf`.
-Staging, production, and self-hosted installations default to `false`.
+All environments default to `false`.
+Dev sets the flag explicitly in `.github/workflows/deploy-dev.yml`.
 
 Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy to restore the standard image.
 Rollback does not require a database migration or sandbox cleanup.
@@ -65,3 +65,19 @@ The experiment can advance beyond dev only when all gates pass:
 5. The fast image remains smaller than the standard runtime image.
 
 Disable the flag if runtime-ready p90 exceeds 32,607 ms or a lazy tool path fails.
+
+## Dev result
+
+Five clean Platinum boots on 2026-08-19 used `kortix-fast-dev-6ec80828f8659cfa`.
+The one-time 229,015 ms image build was excluded.
+
+| Milestone | Standard p50 | Fast p50 | Standard p90 | Fast p90 |
+|---|---:|---:|---:|---:|
+| Runtime ready | 25,288 ms | 30,773 ms | 32,607 ms | 35,816 ms |
+| Repository materialized | 7,489 ms | 7,050 ms | 8,007 ms | 7,944 ms |
+| Config dependencies | 542 ms | 18 ms | 580 ms | 19 ms |
+| OpenCode answering | 5,308 ms | 7,600 ms | 6,908 ms | 7,798 ms |
+
+The fast image failed the p50 and p90 acceptance gate.
+Dev therefore sets `KORTIX_FAST_COLD_BOOT_ENABLED=false`.
+The implementation remains available for more image and provider work behind the same flag.

--- a/tests/unit/ecs-deploy-environment.test.ts
+++ b/tests/unit/ecs-deploy-environment.test.ts
@@ -55,7 +55,7 @@ describe('ECS task environment overrides', () => {
     ).toThrow();
   });
 
-  it('enables fast cold boot only on the dev API deployment', () => {
+  it('keeps fast cold boot disabled on the dev API deployment', () => {
     const workflow = readFileSync(resolve(root, '.github/workflows/deploy-dev.yml'), 'utf8');
     const deployScript = readFileSync(resolve(root, 'infra/scripts/ecs-deploy.sh'), 'utf8');
     const apiDeploy = workflow.slice(
@@ -68,7 +68,7 @@ describe('ECS task environment overrides', () => {
     );
 
     expect(apiDeploy).toContain(
-      `KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}'`,
+      `KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"false"}'`,
     );
     const apiFilter = workflow.slice(
       workflow.indexOf('            api:'),


### PR DESCRIPTION
## Summary

- set `KORTIX_FAST_COLD_BOOT_ENABLED=false` in the dev ECS override
- keep the implementation available behind the same flag
- separate provider-create and network-boundary telemetry marks
- record the five-boot fast-image result and failed acceptance gate

## Measurements

Original acceptance baseline:

- standard runtime-ready: p50 25,288 ms, p90 32,607 ms
- fast runtime-ready: p50 30,773 ms, p90 35,816 ms
- fast image one-time build: 229,015 ms, excluded

Post-rollback five-boot standard run:

- standard runtime-ready: p50 31,435 ms, p90 33,349 ms
- fast delta: p50 -662 ms, p90 +2,467 ms
- standard provider create: p50 2,830 ms
- standard two-secret edge arming: p50 19,127 ms
- real CLI first prompts: `FAST_BOOT_OK` and `STANDARD_BOOT_OK`

The fast image misses the p90 gate. Dev remains on the standard image.

## Verification

- `bun test apps/api/src/platform/services/session-sandbox.test.ts`: 14 pass, 0 fail
- `pnpm --dir tests test:unit`: 33 files, 263 tests passed
- `pnpm --filter kortix-api typecheck`: pass
- all 15 executed PR checks: pass
- Deploy Dev run 32267700555: success
- deployed commit: `7990a67e2049f3de70af42ae93882e9841c1ab97`
- ECS task definition: `kortix-dev:554`

## Rollback

Set `KORTIX_FAST_COLD_BOOT_ENABLED=true` and redeploy the API to resume the experiment.