### PR TITLE
ci(release-gate): 6 api shards + serial-tail shard, 60-min cap, dry-run dispatch against staging

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -4,7 +4,24 @@ on:
   pull_request:
     branches: [prod]
     types: [opened, synchronize, reopened, ready_for_review]
+  # Dry run. `RELEASE_SOURCE_SHA` only exists on a `release/*` branch, so before
+  # this input the gate could not be exercised without opening a release PR into
+  # `prod` — a gate that has never been green could never be rehearsed either.
+  # `expected_sha` supplies the same value the file would, and nothing else
+  # changes: the same shards, the same staging URLs, the same SHA assertion.
+  #
+  #   gh workflow run tests-release.yml --ref staging -f expected_sha=<sha>
+  #
+  # `--ref` selects which branch's workflow and tests run; the target is always
+  # staging, because the staging URLs come from the env block below and not from
+  # the ref. Dispatch against the branch under test to rehearse a change to the
+  # gate itself.
   workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: 40-character Git SHA that staging must already be serving
+        required: true
+        type: string
 
 concurrency:
   group: tests-release-${{ github.ref }}
@@ -77,9 +94,10 @@ jobs:
         run: bun tests/bin/ke2e.ts gc --older-than 2h
 
   # The deployed API suite, sharded by tests/src/core/shard.ts. Shard 1 owns
-  # every serial + global flow (see that file); shards 2-4 split the parallel
-  # flows longest-first. The partition is computed from the live flow registry,
-  # so a newly added flow always lands in exactly one shard.
+  # every serial + global flow and nothing else (see that file); shards 2-6
+  # split the 409 parallel flows longest-first. The partition is computed from
+  # the live flow registry, so a newly added flow always lands in exactly one
+  # shard.
   api:
     name: deployed api shard
     needs: sweep-before
@@ -88,47 +106,85 @@ jobs:
     # release (see the note on sweep-before).
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    # Shard 1 carries the strictly sequential serial+global tail (35 flows), so
-    # it is the critical path until the tail itself is cut. 40 minutes is a real
-    # cap that turns a hang into a readable failure; the old single job was 90.
-    timeout-minutes: 40
+    # A ceiling that turns a hang into a readable failure — never a throttle.
+    #
+    # Run 32240074477 killed all four API shards on the 40-minute cap at once
+    # (10:35:41 -> 11:20:42) while they were still passing what they ran: shard
+    # 3 had 76/87, shard 4 68/77. The cap destroyed the verdict, not the suite.
+    #
+    # Why 60 alone would not have been enough, and why 6 shards is the fix.
+    # Measured from those two logs, over a 38.4-minute window each:
+    #   shard 3: 87 of 137 flows -> 2.266 flows/min
+    #   shard 4: 77 of 137 flows -> 1.998 flows/min
+    # plus ~1.7 min of checkout/install/provision before the first flow. At 137
+    # flows that projects to 62 and 70 minutes — over a 60-minute cap. At the 82
+    # flows a 6-way split gives each shard it projects to 38 and 43 minutes,
+    # inside 60 with room for the extra load 6 shards offer staging. Both rates
+    # were measured while staging was returning laundered 503s, so treat them as
+    # a floor, not a clean baseline.
+    #
+    # Shard 1 is the exception to watch. Its 35-flow serial+global tail runs
+    # one-at-a-time and its declared timeouts sum to 121 minutes (CR-9 alone is
+    # 20). Its log blob for that run has expired, so there is no observed
+    # duration to check against. 60 minutes bounds it; it does not guarantee it.
+    # If shard 1 caps out, cut the tail's own timeouts — not this number.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     env:
       # Pin the run id so the post-run sweep below can reclaim exactly THIS
       # shard's principals (`principals.ts` names them `e2e-<runId>-…`).
       KE2E_RUN_ID: ${{ github.run_id }}-api${{ matrix.shard }}
-      # Fleet arithmetic, not per-job tuning. Run 32231251280 (the first run
-      # where every shard actually executed) fanned out 4x3 API + 4x2 sandbox +
-      # 3x2 browser = 26 concurrent workers against ONE staging (2 x 1 vCPU
-      # tasks, Medium DB after #6544) and ~50% of flows failed with "exceeded
-      # 120000ms" — staging slowed to the point that the 120s flow budget
-      # tripped, and with #6543 a timeout is no longer retried. The single-job
-      # gate passed 424/441 at 3 + 3. Halve the fleet: 4x2 + 4x1 = 12 against
-      # the API (plus 3x1 browsers), and give a timed-out flow exactly ONE more
-      # attempt here (not the old 3x) — the load is low enough that a retry
-      # cannot cascade. Lower these first if MAINTENANCE_MODE 503s reappear.
+      # Fleet arithmetic, not per-job tuning, and UNCHANGED per shard by the
+      # move to 6 — the throughput comes from fewer flows per shard, not from
+      # more workers inside one.
+      #
+      # Run 32231251280 fanned out 4x3 API + 4x2 sandbox + 3x2 browser = 26
+      # concurrent workers against ONE staging (2 x 1 vCPU tasks, Medium DB
+      # after #6544) and ~50% of flows failed with "exceeded 120000ms": staging
+      # slowed until the 120s flow budget tripped, and with #6543 a timeout is
+      # no longer retried. Run 32240074477 halved that to these values — 15
+      # workers — and staging held: 87-88% of what ran, passed. That is the
+      # proven-safe point, and these numbers are it.
+      #
+      # 6 shards raise the peak from 15 to 19 (shard 1 contributes 1, not 3:
+      # its flows are serial by definition). 19 sits nearer the 15 that held
+      # than the 26 that collapsed. Lower these first if MAINTENANCE_MODE 503s
+      # reappear; dropping KE2E_API_WORKERS to 1 returns the fleet to 13.
       KE2E_API_WORKERS: '2'
       KE2E_SANDBOX_WORKERS: '1'
       KE2E_TIMEOUT_ATTEMPTS: '2'
     steps:
       - uses: actions/checkout@v7
+      # One SHA, two sources. A release PR carries RELEASE_SOURCE_SHA in the
+      # tree; a dry run supplies the same value as `expected_sha`. The input
+      # arrives through env, never interpolated into this script, so a dispatch
+      # cannot inject shell — and it is accepted only after the same
+      # 40-hex-character check the file gets.
       - name: Require the deployed staging source SHA
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
         run: |
           set -euo pipefail
-          test -f RELEASE_SOURCE_SHA || {
-            echo "::error::Release PR has no RELEASE_SOURCE_SHA."
-            exit 1
-          }
-          source_sha="$(tr -d '[:space:]' < RELEASE_SOURCE_SHA)"
+          if [ -n "${EXPECTED_SHA:-}" ]; then
+            source_sha="$(printf '%s' "$EXPECTED_SHA" | tr -d '[:space:]')"
+            origin="workflow_dispatch input expected_sha"
+          else
+            test -f RELEASE_SOURCE_SHA || {
+              echo "::error::No RELEASE_SOURCE_SHA in the tree and no expected_sha input."
+              exit 1
+            }
+            source_sha="$(tr -d '[:space:]' < RELEASE_SOURCE_SHA)"
+            origin="RELEASE_SOURCE_SHA"
+          fi
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "::error::RELEASE_SOURCE_SHA must contain one 40-character Git SHA."
+            echo "::error::$origin must give one 40-character Git SHA."
             exit 1
           }
           echo "KE2E_EXPECT_SHA=$source_sha" >> "$GITHUB_ENV"
-          echo "Expected deployed staging SHA: $source_sha"
+          echo "Expected deployed staging SHA: $source_sha (from $origin)"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
@@ -142,7 +198,7 @@ jobs:
       - name: Install deployed-target dependencies
         run: pnpm install --frozen-lockfile --filter @kortix/tests...
       - name: Run this shard of the deployed staging API suite
-        run: pnpm test -- --target-api-full --api-shard=${{ matrix.shard }}/4
+        run: pnpm test -- --target-api-full --api-shard=${{ matrix.shard }}/6
       # A cancelled job is SIGKILLed before the runner's `finally` teardown, so
       # every cancel used to leak its whole world. `always()` covers cancelled,
       # failed and passed; --run-id scopes the sweep to this shard so it cannot
@@ -185,20 +241,33 @@ jobs:
       E2E_BROWSER_WORKERS: '1'
     steps:
       - uses: actions/checkout@v7
+      # One SHA, two sources. A release PR carries RELEASE_SOURCE_SHA in the
+      # tree; a dry run supplies the same value as `expected_sha`. The input
+      # arrives through env, never interpolated into this script, so a dispatch
+      # cannot inject shell — and it is accepted only after the same
+      # 40-hex-character check the file gets.
       - name: Require the deployed staging source SHA
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
         run: |
           set -euo pipefail
-          test -f RELEASE_SOURCE_SHA || {
-            echo "::error::Release PR has no RELEASE_SOURCE_SHA."
-            exit 1
-          }
-          source_sha="$(tr -d '[:space:]' < RELEASE_SOURCE_SHA)"
+          if [ -n "${EXPECTED_SHA:-}" ]; then
+            source_sha="$(printf '%s' "$EXPECTED_SHA" | tr -d '[:space:]')"
+            origin="workflow_dispatch input expected_sha"
+          else
+            test -f RELEASE_SOURCE_SHA || {
+              echo "::error::No RELEASE_SOURCE_SHA in the tree and no expected_sha input."
+              exit 1
+            }
+            source_sha="$(tr -d '[:space:]' < RELEASE_SOURCE_SHA)"
+            origin="RELEASE_SOURCE_SHA"
+          fi
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "::error::RELEASE_SOURCE_SHA must contain one 40-character Git SHA."
+            echo "::error::$origin must give one 40-character Git SHA."
             exit 1
           }
           echo "KE2E_EXPECT_SHA=$source_sha" >> "$GITHUB_ENV"
-          echo "Expected deployed staging SHA: $source_sha"
+          echo "Expected deployed staging SHA: $source_sha (from $origin)"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,7 +27,7 @@ pnpm test -- --packages-only   # Every app/package test and publish contract
 pnpm test -- --full            # Core, browser, and every app/package test
 pnpm test -- --target-smoke    # Deployed staging API SHA and browser smoke
 pnpm test -- --target-full     # Every deployed staging API flow and browser journey
-pnpm test -- --target-api-full --api-shard=1/4     # One deployed API shard
+pnpm test -- --target-api-full --api-shard=1/6     # One deployed API shard
 pnpm test -- --target-browser-full --browser-shard=1/3 # One deployed browser shard
 ```
 
@@ -129,23 +129,52 @@ capability fails the release gate instead of counting as a pass.
 
 #### Release gate shards
 
-The gate runs as parallel matrix jobs instead of one 90-minute job: four API
-shards (`--target-api-full --api-shard=N/4`) and three browser shards
+The gate runs as parallel matrix jobs instead of one 90-minute job: six API
+shards (`--target-api-full --api-shard=N/6`) and three browser shards
 (`--target-browser-full --browser-shard=N/3`), with `fail-fast: false` so one
 red shard still reports the others. Wall clock becomes the slowest shard rather
 than a contended sum on one 2-vCPU runner.
 
 `src/core/shard.ts` computes the API partition from the live flow registry, so a
 newly added flow always lands in exactly one shard and can never fall out of the
-gate. Shard 1 owns every `serial` and every `global` flow — two jobs running the
-platform-mutating `global` flows at once would corrupt each other. The remaining
-flows are bin-packed longest-first using the declared `timeoutMs` as a static
-cost proxy. `unit/shard.test.ts` proves the partition is total and that the
-pinned flows never leave shard 1.
+gate. Shard 1 owns every `serial` and every `global` flow, and nothing else. Two
+jobs running the platform-mutating `global` flows at once would corrupt each
+other, and both kinds run strictly one-at-a-time, so a parallel flow sharing
+that runner waits behind a queue it cannot help drain. The remaining flows are
+bin-packed longest-first using the declared `timeoutMs` as a static cost proxy.
+Read a printed projected load as a wall-clock ceiling of
+`load / KE2E_API_WORKERS`. `unit/shard.test.ts` proves the partition is total,
+that the pinned flows never leave shard 1, and that shard 1 takes no packed
+work.
+
+Why six. On run 32240074477 four shards of 137 flows were all killed by the
+40-minute job cap while still passing what they ran (76/87 and 68/77). Measured
+from those logs, a shard completes 2.0–2.3 flows/min, so 137 flows needs 62–70
+minutes — more than a 60-minute cap allows. Six shards put 82 flows on each,
+which the same rates finish in 38–43 minutes. Each shard keeps
+`KE2E_API_WORKERS=2` and `KE2E_SANDBOX_WORKERS=1`: the throughput comes from
+fewer flows per shard, not from more workers inside one.
 
 A final job named `full suite + quality gates` aggregates the shards. That exact
 name is the required status check on `prod` branch protection; renaming it
 without updating the protection rule silently disables the gate.
+
+#### Rehearsing the gate against staging
+
+`RELEASE_SOURCE_SHA` exists only on a `release/*` branch, so the gate used to be
+unrunnable without opening a release PR into `prod`. `workflow_dispatch` now
+takes an `expected_sha` input that supplies the same value:
+
+```bash
+gh workflow run tests-release.yml --ref staging -f expected_sha=<40-char-sha>
+```
+
+Nothing else changes — the same shards, the same staging URLs, the same SHA
+assertion, which still fails when the deployed API or gateway reports a
+different commit. `--ref` picks which branch's workflow and tests run; the
+target is always staging, because the staging URLs come from the workflow's env
+block and not from the ref. Dispatch against the branch under test to rehearse a
+change to the gate itself.
 
 #### Test-account cleanup
 

--- a/tests/src/core/shard.ts
+++ b/tests/src/core/shard.ts
@@ -9,17 +9,19 @@
  *
  * Two rules, in order:
  *
- * 1. Every `serial` and every `global` flow goes to shard 1. `global` flows
- *    (ADM-19, BILL-13, CONN-5) mutate platform-wide state that all shards share
- *    — two jobs running them at once would corrupt each other. `serial` flows
- *    mutate their own run's OWNER/platform-admin principals; each shard builds
- *    its own world, so those are technically shard-safe, but pinning the whole
- *    non-parallel tail to one shard keeps ONE job responsible for it and lets
- *    the model below give the other shards proportionally more parallel work.
+ * 1. Every `serial` and every `global` flow goes to shard 1, and — whenever such
+ *    a flow exists and there is more than one shard — shard 1 gets NOTHING else.
+ *    `global` flows (ADM-19, BILL-13, CONN-5) mutate platform-wide state that
+ *    all shards share, so two jobs running them at once would corrupt each
+ *    other. `serial` flows mutate their own run's OWNER/platform-admin
+ *    principals. Both kinds run strictly one-at-a-time (`runner.ts` drains them
+ *    after the parallel lanes), so any parallel flow sharing their shard waits
+ *    behind a queue it cannot help drain. Giving the tail its own runner is what
+ *    lets the remaining shards be sized purely by parallel work.
  * 2. The remaining flows are bin-packed longest-processing-time-first onto the
- *    shard with the lowest projected load, ties broken by shard index then flow
- *    id. LPT is deterministic given the same registry, so every job computes an
- *    identical partition without coordinating.
+ *    eligible shard with the lowest projected load, ties broken by shard index
+ *    then flow id. LPT is deterministic given the same registry, so every job
+ *    computes an identical partition without coordinating.
  *
  * The cost model is in worker-seconds and uses the flow's declared `timeoutMs`
  * (default 120_000, matching `runner.ts`'s `withTimeout` fallback) as a static
@@ -27,7 +29,8 @@
  * the expensive sandbox flows from piling onto one shard, and it needs no
  * results artifact to stay current. A serial flow occupies a whole shard while
  * the other workers idle, so it is charged `SERIAL_WORKER_PENALTY` times its
- * weight; a parallel flow is charged once.
+ * weight; a parallel flow is charged once. Read a projected load as a wall-clock
+ * ceiling of `load / KE2E_API_WORKERS`, uniformly across every shard.
  */
 import type { RegisteredFlow } from './flow';
 
@@ -37,10 +40,16 @@ export const DEFAULT_FLOW_WEIGHT_MS = 120_000;
 /**
  * Models the per-shard API worker count: a serial flow blocks the shard for its
  * whole duration while the other workers idle, so it costs the shard that many
- * worker-seconds. Kept equal to the `KE2E_API_WORKERS` the release gate gives
- * each API shard.
+ * worker-seconds. Must equal the `KE2E_API_WORKERS` the release gate gives each
+ * API shard (`tests-release.yml`), or a projected load no longer converts to a
+ * wall-clock ceiling by the same divisor on every shard. It was 3 while the gate
+ * ran 3 API workers; the gate now runs 2.
+ *
+ * This value cannot change the partition. Rule 1 gives the serial tail its own
+ * shard, so the only load it inflates is a shard that receives no bin-packed
+ * work — it is a reporting constant, not a packing input.
  */
-export const SERIAL_WORKER_PENALTY = 3;
+export const SERIAL_WORKER_PENALTY = 2;
 
 export interface ShardSpec {
   current: number;
@@ -92,6 +101,13 @@ export function planShard(flows: RegisteredFlow[], spec: ShardSpec): ShardPlan {
     loads[0] += flowWeightMs(flow) * SERIAL_WORKER_PENALTY;
   }
 
+  // Rule 1: the serial tail owns shard 1 alone. Two escapes, both required to
+  // keep the planner total — a shard that can receive nothing must not exist:
+  // at `--shard 1/1` shard 1 is the only shard there is, and a registry with no
+  // serial or global flow has no tail to isolate.
+  const firstShardIsReserved = pinned.length > 0 && spec.total > 1;
+  const packStart = firstShardIsReserved ? 1 : 0;
+
   const parallel = flows
     .filter((flow) => !isPinnedToFirstShard(flow))
     .sort((a, b) => {
@@ -100,8 +116,8 @@ export function planShard(flows: RegisteredFlow[], spec: ShardSpec): ShardPlan {
     });
 
   for (const flow of parallel) {
-    let target = 0;
-    for (let i = 1; i < spec.total; i++) {
+    let target = packStart;
+    for (let i = packStart + 1; i < spec.total; i++) {
       if (loads[i] < loads[target]) target = i;
     }
     assigned[target].push(flow.id);

--- a/tests/unit/sandbox-workflow.test.ts
+++ b/tests/unit/sandbox-workflow.test.ts
@@ -78,9 +78,35 @@ describe('sandbox test workflow', () => {
     // the required check silently.
     expect(release).toContain('name: full suite + quality gates');
     expect(release).toContain('needs: [api, browser]');
-    expect(release).toContain('pnpm test -- --target-api-full --api-shard=');
-    expect(release).toContain('pnpm test -- --target-browser-full --browser-shard=');
+    // Six API shards, and the workflow must ask for the same denominator that
+    // `unit/shard.test.ts` proves the partition against. On run 32240074477
+    // four shards of 137 flows were all killed by their cap ~60% through.
+    expect(release).toContain('shard: [1, 2, 3, 4, 5, 6]');
+    expect(release).toContain('pnpm test -- --target-api-full --api-shard=${{ matrix.shard }}/6');
+    expect(release).toContain('pnpm test -- --target-browser-full --browser-shard=${{ matrix.shard }}/3');
     expect(release).toContain('fail-fast: false');
+    // A cap is a hang detector, not a throttle. 40 minutes throttled: it killed
+    // shards that were passing 76/87 and 68/77 of what they had run.
+    expect(release).toMatch(/^ {4}timeout-minutes: 60$/m);
+    // The load each shard offers staging is unchanged by the extra shards.
+    expect(release).toContain("KE2E_API_WORKERS: '2'");
+    expect(release).toContain("KE2E_SANDBOX_WORKERS: '1'");
+    expect(release).toContain("KE2E_TIMEOUT_ATTEMPTS: '2'");
+    // Dry run against staging without a release PR. `RELEASE_SOURCE_SHA` only
+    // exists on a `release/*` branch, so without this input the gate could
+    // never be rehearsed — which is how it stayed un-green. The input is read
+    // through env, never interpolated into the shell, and both jobs still
+    // enforce the same 40-hex-character check.
+    expect(release).toContain('expected_sha:');
+    expect(release).toContain('EXPECTED_SHA: ${{ inputs.expected_sha }}');
+    // Every reference to the input is an `env:` binding. A dispatch input
+    // interpolated straight into a `run:` script is arbitrary code execution,
+    // so the counts must match exactly — once per SHA-checking job.
+    const bindings = release.match(/^\s+EXPECTED_SHA: \$\{\{ inputs\.expected_sha \}\}$/gm) ?? [];
+    const references = release.match(/inputs\.expected_sha/g) ?? [];
+    expect(bindings).toHaveLength(2);
+    expect(references).toHaveLength(bindings.length);
+    expect(release.match(/\[\[ "\$source_sha" =~ \^\[0-9a-f\]\{40\}\$ \]\]/g)).toHaveLength(2);
     // Cleanup-on-cancel: a cancelled job never reaches the runner's `finally`
     // teardown, so the sweep must be wired pre-run and `if: always()` post-run.
     expect(release).toContain('bun tests/bin/ke2e.ts gc --older-than 2h');

--- a/tests/unit/shard.test.ts
+++ b/tests/unit/shard.test.ts
@@ -68,6 +68,25 @@ describe('planShard', () => {
     }
   });
 
+  it('gives the serial tail shard 1 to itself', () => {
+    // A parallel flow sharing the tail's shard waits behind a queue it cannot
+    // help drain, so shard 1 takes no bin-packed work at all.
+    const flows = [
+      fakeFlow('S-1', { serial: true, timeoutMs: 60_000 }),
+      ...Array.from({ length: 12 }, (_, i) => fakeFlow(`P-${i}`, { timeoutMs: 600_000 })),
+    ];
+    expect(planShard(flows, { current: 1, total: 3 }).ids).toEqual(['S-1']);
+    const rest = [2, 3].flatMap((current) => planShard(flows, { current, total: 3 }).ids);
+    expect(rest.sort()).toEqual(flows.slice(1).map((f) => f.id).sort());
+  });
+
+  it('leaves every shard eligible when the registry has no serial tail', () => {
+    // Reserving shard 1 for a tail that does not exist would idle a whole job.
+    const flows = Array.from({ length: 8 }, (_, i) => fakeFlow(`P-${i}`, { timeoutMs: 60_000 }));
+    const loads = planShard(flows, { current: 1, total: 4 }).loads;
+    expect(loads).toEqual([120_000, 120_000, 120_000, 120_000]);
+  });
+
   it('is deterministic — the same registry always yields the same partition', () => {
     const flows = Array.from({ length: 50 }, (_, i) =>
       fakeFlow(`F-${i}`, { timeoutMs: ((i * 7) % 9) * 30_000 + 30_000 }),
@@ -113,10 +132,13 @@ interface RegistryShardReport {
   total: number;
   shards: number;
   perShard: number[];
+  loadsMs: number[];
   duplicates: string[];
   missing: string[];
   pinned: string[];
   pinnedOffShardOne: string[];
+  /** Flows on shard 1 that are neither serial nor global — must always be empty. */
+  unpinnedOnShardOne: string[];
 }
 
 function shardTheRealRegistry(shards: number): RegistryShardReport {
@@ -140,34 +162,44 @@ function shardTheRealRegistry(shards: number): RegistryShardReport {
       }
     }
     const pinned = flows.filter(isPinnedToFirstShard).map((f) => f.id).sort();
-    const shardOne = new Set(planShard(flows, { current: 1, total }).ids);
+    const pinnedSet = new Set(pinned);
+    const plans = [];
+    for (let current = 1; current <= total; current++) plans.push(planShard(flows, { current, total }));
+    const shardOne = new Set(plans[0].ids);
     console.log(JSON.stringify({
       total: flows.length,
       shards: total,
       perShard,
+      loadsMs: plans[0].loads,
       duplicates,
       missing: flows.filter((f) => !owner.has(f.id)).map((f) => f.id),
       pinned,
       pinnedOffShardOne: pinned.filter((id) => !shardOne.has(id)),
+      unpinnedOnShardOne: [...shardOne].filter((id) => !pinnedSet.has(id)),
     }));
   `;
   const out = execFileSync('bun', ['-e', script], { encoding: 'utf8', cwd: testsDir });
   return JSON.parse(out.trim().split('\n').at(-1) as string) as RegistryShardReport;
 }
 
+/** The shard count `tests-release.yml` actually runs. Keep the two in step. */
+const RELEASE_GATE_API_SHARDS = 6;
+
 describe('the real flow registry', () => {
+  const shardCounts = [2, 4, RELEASE_GATE_API_SHARDS];
   const reports = new Map<number, RegistryShardReport>();
 
   beforeAll(() => {
-    for (const shards of [2, 3, 4]) reports.set(shards, shardTheRealRegistry(shards));
-  }, 120_000);
+    for (const shards of shardCounts) reports.set(shards, shardTheRealRegistry(shards));
+  }, 180_000);
 
   it('discovers the whole suite', () => {
-    expect(reports.get(4)!.total).toBeGreaterThan(400);
-    expect(reports.get(4)!.pinned.length).toBeGreaterThan(0);
+    const report = reports.get(RELEASE_GATE_API_SHARDS)!;
+    expect(report.total).toBeGreaterThan(400);
+    expect(report.pinned.length).toBeGreaterThan(0);
   });
 
-  for (const shards of [2, 3, 4]) {
+  for (const shards of shardCounts) {
     it(`assigns every registered flow to exactly one of ${shards} shards`, () => {
       const report = reports.get(shards)!;
       expect(report.duplicates, 'flows claimed by more than one shard').toEqual([]);
@@ -180,5 +212,33 @@ describe('the real flow registry', () => {
       // platform-wide state they mutate.
       expect(reports.get(shards)!.pinnedOffShardOne).toEqual([]);
     });
+
+    it(`gives shard 1 of ${shards} nothing but that tail`, () => {
+      // The tail drains one flow at a time. Anything else on its runner waits
+      // for the whole queue, which is what made shard 1 the critical path.
+      const report = reports.get(shards)!;
+      expect(report.unpinnedOnShardOne, 'parallel flows stuck behind the serial tail').toEqual([]);
+      expect(report.perShard[0]).toBe(report.pinned.length);
+    });
   }
+
+  it(`splits the parallel flows evenly across shards 2-${RELEASE_GATE_API_SHARDS}`, () => {
+    // The reason to shard at all. On run 32240074477 every 137-flow shard was
+    // killed by its cap ~60% through; the packer must not leave one shard
+    // carrying materially more than its peers.
+    const report = reports.get(RELEASE_GATE_API_SHARDS)!;
+    const packed = report.perShard.slice(1);
+    expect(packed).toHaveLength(RELEASE_GATE_API_SHARDS - 1);
+    expect(Math.max(...packed) - Math.min(...packed)).toBeLessThanOrEqual(10);
+
+    const packedLoads = report.loadsMs.slice(1);
+    const spread = Math.max(...packedLoads) - Math.min(...packedLoads);
+    expect(spread / Math.max(...packedLoads)).toBeLessThan(0.05);
+  });
+
+  it('cuts the per-shard parallel load by going from 4 shards to 6', () => {
+    const four = Math.max(...reports.get(4)!.loadsMs.slice(1));
+    const six = Math.max(...reports.get(RELEASE_GATE_API_SHARDS)!.loadsMs.slice(1));
+    expect(six).toBeLessThan(four * 0.7);
+  });
 });


### PR DESCRIPTION
The sharded release gate has never been green. Tonight's evidence says the
blocker is throughput, not pass rate: on run 32240074477 all four API shards
were killed by the 40-minute job cap at the same second (10:35:41 -> 11:20:42)
while they were still passing what they had run — shard 3 at 76/87, shard 4 at
68/77.

## 1. What the logs measure

From the shard 3 and shard 4 job logs of run 32240074477, over a 38.4-minute
window each:

| shard | completed / assigned | rate | projected time for 137 flows |
|---|---|---|---|
| 3 | 87 / 137 | 2.266 flows/min | 62 min |
| 4 | 77 / 137 | 1.998 flows/min | 70 min |

Plus ~1.7 min of checkout, install and provisioning before the first flow.

Two conclusions. Raising the cap alone does not fix this — at 137 flows a shard
needs 62-70 min, past a 60-minute cap. And the shards must get smaller. At the
82 flows a 6-way split gives each one, the same rates finish in 38-43 min.

Both rates were measured while staging was returning laundered 503s
(`x-maintenance-mode=blocking` appears throughout both logs), so they are a
floor, not a clean baseline.

The shard 1 and shard 2 log blobs have expired (`BlobNotFound`) and no
api-shard artifact was uploaded, because a cancelled job stops before the
upload step. Their per-flow numbers are unavailable and nothing here claims
them.

## 2. Projected per-shard loads, before and after

Computed against the live registry (444 flows, 35 of them serial or global) by
`tests/src/core/shard.ts`. Loads are worker-minutes of declared-timeout
ceiling; wall-clock ceiling is `load / KE2E_API_WORKERS`.

Before — `N=4`:

```
s1:  35f/363m | s2: 135f/322m | s3: 137f/323m | s4: 137f/323m
```

After — `N=6`:

```
s1:  35f/242m | s2:  81f/193m | s3:  82f/194m | s4:  82f/193m
             | s5:  82f/194m | s6:  82f/194m
```

Parallel flows per shard drop from 135-137 to 81-82, a 40% cut. Shard 1's
count is unchanged; its load falls only because `SERIAL_WORKER_PENALTY` is
corrected below. Both partitions were verified total: 444/444 flows, no
duplicate, no orphan.

## 3. Changes

1. `.github/workflows/tests-release.yml:124` — API matrix `[1, 2, 3, 4]` ->
   `[1, 2, 3, 4, 5, 6]`, and `:198` `--api-shard=${{ matrix.shard }}/6`.

2. `.github/workflows/tests-release.yml:145-147` — per-shard worker env is
   deliberately **unchanged**: `KE2E_API_WORKERS=2`, `KE2E_SANDBOX_WORKERS=1`,
   `KE2E_TIMEOUT_ATTEMPTS=2`. The throughput comes from fewer flows per shard,
   not from more workers inside one.

   Staging load arithmetic. Run 32231251280 offered 26 concurrent workers and
   ~50% of flows failed with `exceeded 120000ms`. Run 32240074477 offered 15
   and staging held, passing 87-88% of what ran. Six shards offer 19: shard 1
   contributes 1, not 3, because its flows are serial by definition, so
   `5x3 + 1 + 3 browser = 19`. That is nearer the 15 that held than the 26 that
   collapsed. If MAINTENANCE_MODE 503s reappear, `KE2E_API_WORKERS=1` returns
   the fleet to 13.

3. `.github/workflows/tests-release.yml:120` — API job cap 40 -> 60 min, with
   the arithmetic above recorded in the comment. Browser stays at 30, the
   aggregator at 5.

4. `tests/src/core/shard.ts:102-113` — the serial+global tail now owns shard 1
   **exclusively**. Both kinds of flow run strictly one-at-a-time, so a
   parallel flow sharing that runner waits behind a queue it cannot help
   drain. This was already true in practice, because the tail's load made
   shard 1 unattractive to the packer; it is now an invariant, asserted by a
   test, rather than an accident of the cost model. Two guarded escapes keep
   the planner total: `--shard 1/1`, and a registry with no serial or global
   flow at all.

5. `tests/src/core/shard.ts:43-54` — `SERIAL_WORKER_PENALTY` 3 -> 2, matching
   the `KE2E_API_WORKERS` the gate actually gives each shard. Its own comment
   already required these to be equal; the value was stale. This cannot change
   the partition — the only load it inflates now belongs to a shard that
   receives no packed work — so it is a reporting fix, and it makes a printed
   projected load convert to a wall-clock ceiling by the same divisor on every
   shard.

6. `.github/workflows/tests-release.yml:19-24` — `workflow_dispatch` input
   `expected_sha`. `RELEASE_SOURCE_SHA` exists only on a `release/*` branch, so
   the gate could not be exercised without opening a release PR into `prod` — a
   gate that has never been green could never be rehearsed either. The step
   `Require the deployed staging source SHA` now uses the input when dispatched
   and the file otherwise, in both the api and browser jobs, which remain
   byte-identical to each other. Everything else is unchanged: same shards,
   same staging URLs, same SHA assertion.

   The input arrives through an `env:` binding and is never interpolated into
   the `run:` script, so a dispatch cannot inject shell, and it is accepted
   only after the same 40-hex-character check the file gets.

7. `tests/README.md` — release-gate section updated to six shards with the
   measured reasoning, plus a new "Rehearsing the gate against staging"
   section documenting the dispatch.

## 4. Preserved deliberately

Verified present and unchanged: the aggregator job name `full suite + quality
gates` (byte-compared against
`repos/kortix-ai/suna/branches/prod/protection`, which requires exactly
`["full suite + quality gates"]`), `fail-fast: false`, the step-bounded
`continue-on-error` `sweep-before`, `sweep-after`, `if: ${{ !cancelled() }}` on
both shard jobs, per-shard `KE2E_RUN_ID`, and every `KE2E_*` / `E2E_*` /
`VERCEL_AUTOMATION_BYPASS_SECRET` / `KE2E_CI_PASSTHROUGH_SECRET` env entry.

## 5. Verification

`actionlint .github/workflows/tests-release.yml` — exit 0, no output.

`python3 -c "import yaml; yaml.safe_load(...)"` — parses; asserts
`api.strategy.matrix.shard == [1,2,3,4,5,6]`, `api.timeout-minutes == 60`,
`browser.timeout-minutes == 30`, `fail-fast == False`,
`release-gate.name == 'full suite + quality gates'`.

`pnpm --dir tests test:unit` — **33 files, 270 tests, 270 passed**, 2.09s.
`unit/shard.test.ts` is 22 of them, including the real-registry partition run
through `bun` at N = 2, 4 and 6: total partition, no duplicates, no orphans,
every pinned flow on shard 1, and shard 1 holding nothing else.

The new SHA-resolution script was extracted from the YAML and black-box run in
all seven cases:

| case | result |
|---|---|
| valid `expected_sha` | exit 0, `(from workflow_dispatch input expected_sha)` |
| input with stray whitespace/newline | exit 0, trimmed |
| no input, `RELEASE_SOURCE_SHA` present | exit 0, `(from RELEASE_SOURCE_SHA)` |
| no input, no file | exit 1, `::error::No RELEASE_SOURCE_SHA in the tree and no expected_sha input.` |
| input `$(touch /tmp/PWNED)` | exit 1, and `/tmp/PWNED` does not exist |
| short SHA `abc123` | exit 1 |
| api vs browser script | byte-identical |

## 6. Unverified and risky, stated plainly

- **Shard 1 is not proven to fit 60 minutes.** Its 35-flow tail runs
  one-at-a-time and its declared timeouts sum to 121 min (`CR-9` alone is 20).
  Its log for run 32240074477 has expired, so there is no observed duration to
  check against. 60 min bounds it; it does not guarantee it. If shard 1 caps
  out, the fix is cutting the tail's own timeouts, not a larger cap.
- **19 concurrent workers against staging is an increase, not a proven point.**
  15 held; 26 collapsed. The mitigation lever is in the comment at
  `tests-release.yml:145`.
- **Nothing here changes the pass rate.** The ~13% of flows failing on their
  merits are untouched by this PR and owned elsewhere.
- **`pnpm --dir tests typecheck` does not exit 0**, and did not before this
  branch. One pre-existing error, in a file this PR does not touch:
  `tests/src/flows/iam.flow.ts(1739,41): error TS2322` — `member.userId` is
  `string | undefined` where `string | number` is required. Introduced by
  3d876d755d (#6554, merged today). Reproduced identically on an unmodified
  primary checkout at `bd5aae39c4`. Flagging, not fixing — that file is outside
  this PR's ownership.

## 7. How to rehearse the gate

```bash
gh workflow run tests-release.yml --ref staging -f expected_sha=<40-char-sha>
```

`--ref` picks which branch's workflow and tests run; the target is always
staging, because the staging URLs come from the workflow's env block, not from
the ref. To rehearse **this** change before it reaches staging, dispatch
against this branch: `--ref gate-throughput`.
