### PR TITLE
test(ke2e): fix tests typecheck break from #6554 (iam.flow.ts:1739)

### DIFF
--- a/tests/src/flows/iam.flow.ts
+++ b/tests/src/flows/iam.flow.ts
@@ -1736,7 +1736,7 @@ flow(
       const projectAccess = await ctx.client
         .as(ctx.P.OWNER)
         .get('/v1/accounts/:accountId/iam/members/:userId/project-access', {
-          params: { accountId: team.id, userId: member.userId },
+          params: { accountId: team.id, userId: member.userId! },
         });
       projectAccess.status(200);
       const entry = (projectAccess.json<any>().projects as any[]).find(


### PR DESCRIPTION
`tests/src/flows/iam.flow.ts(1739,41): TS2322 string|undefined` — pre-existing since #6554; `member.userId!` exactly as the 12 sibling call sites in the same file. `pnpm --dir tests typecheck` → exit 0.