### PR TITLE
Bound the per-session audit event rate so one runaway turn cannot take the API down

### DIFF
--- a/apps/api/src/projects/lib/session-audit-rate-flag.test.ts
+++ b/apps/api/src/projects/lib/session-audit-rate-flag.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The durable marker for a sustained-hot session.
+ *
+ * The load-bearing property is that it CANNOT fail loudly: it is invoked
+ * un-awaited from the audit ingest hot path, so a rejected promise here would
+ * surface as an unhandled rejection rather than a handled error.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let updateCalls: Array<{ set: Record<string, unknown> }> = [];
+let updateShouldThrow = false;
+
+mock.module('../../shared/db', () => ({
+  hasDatabase: () => true,
+  db: {
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        if (updateShouldThrow) throw new Error('database is unavailable');
+        updateCalls.push({ set: values });
+        return { where: async () => undefined };
+      },
+    }),
+  },
+}));
+
+const {
+  AUDIT_RATE_LIMIT_METADATA_KEY,
+  flagSessionAuditRateLimited,
+  readAuditRateLimitFlag,
+} = await import('./session-audit-rate-flag');
+
+const INPUT = {
+  accountId: '11111111-1111-4111-8111-111111111111',
+  projectId: '22222222-2222-4222-8222-222222222222',
+  sessionId: '33333333-3333-4333-8333-333333333333',
+  consecutiveHotWindows: 3,
+  now: new Date('2026-08-19T04:00:00.000Z'),
+};
+
+beforeEach(() => {
+  updateCalls = [];
+  updateShouldThrow = false;
+});
+
+afterEach(() => {
+  updateShouldThrow = false;
+});
+
+describe('flagSessionAuditRateLimited', () => {
+  test('writes the marker into session_sandboxes.metadata', async () => {
+    await flagSessionAuditRateLimited(INPUT);
+
+    expect(updateCalls).toHaveLength(1);
+    // The metadata value is a jsonb merge expression, not a literal — the point
+    // is that the write happened and left `updatedAt` alone.
+    expect(Object.keys(updateCalls[0].set)).toEqual(['metadata']);
+  });
+
+  test('never rejects when the database write fails', async () => {
+    updateShouldThrow = true;
+
+    // No try/catch here on purpose: the assertion IS that this resolves.
+    await expect(flagSessionAuditRateLimited(INPUT)).resolves.toBeUndefined();
+    expect(updateCalls).toHaveLength(0);
+  });
+});
+
+describe('readAuditRateLimitFlag', () => {
+  test('reads back a well-formed marker', () => {
+    const flag = readAuditRateLimitFlag({
+      [AUDIT_RATE_LIMIT_METADATA_KEY]: {
+        consecutiveHotWindows: 4,
+        at: '2026-08-19T04:00:00.000Z',
+      },
+      somethingElse: true,
+    });
+
+    expect(flag).toEqual({ consecutiveHotWindows: 4, at: '2026-08-19T04:00:00.000Z' });
+  });
+
+  test('returns null when the marker is absent or malformed', () => {
+    expect(readAuditRateLimitFlag(null)).toBeNull();
+    expect(readAuditRateLimitFlag(undefined)).toBeNull();
+    expect(readAuditRateLimitFlag({})).toBeNull();
+    expect(readAuditRateLimitFlag({ [AUDIT_RATE_LIMIT_METADATA_KEY]: 'hot' })).toBeNull();
+    expect(readAuditRateLimitFlag({ [AUDIT_RATE_LIMIT_METADATA_KEY]: [] })).toBeNull();
+    expect(
+      readAuditRateLimitFlag({ [AUDIT_RATE_LIMIT_METADATA_KEY]: { consecutiveHotWindows: 2 } }),
+    ).toBeNull();
+    expect(
+      readAuditRateLimitFlag({
+        [AUDIT_RATE_LIMIT_METADATA_KEY]: { consecutiveHotWindows: 'many', at: 'now' },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/projects/lib/session-audit-rate-flag.ts
+++ b/apps/api/src/projects/lib/session-audit-rate-flag.ts
@@ -1,0 +1,82 @@
+/**
+ * Durable marker for a session whose audit-event ingest rate stays over the
+ * ceiling for several consecutive windows.
+ *
+ * The rate guard itself (shared/opencode-audit-rate-guard.ts) is per-process and
+ * in-memory, which is right for the hot path but invisible the moment the task
+ * restarts. This writes the condition into `session_sandboxes.metadata` so it
+ * survives a restart, is queryable during an incident, and gives the 5-minute
+ * project-maintenance sweep (projects/maintenance.ts:214 `runProjectMaintenance`)
+ * a signal it can act on later.
+ *
+ * DELIBERATELY A FLAG, NOT AN ACTION. This does not stop, park, or shorten the
+ * deadline of the session. Suppressing the delta class already removes the
+ * database pressure that caused the incident; automatically killing a live user
+ * session on a volume heuristic is a much larger product decision with its own
+ * failure mode (a legitimate long streaming turn being parked mid-flight) and
+ * belongs in its own change. The marker is what a future reaper rule — or a
+ * human — reads.
+ */
+
+import { sessionSandboxes } from '@kortix/db';
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../../shared/db';
+import { mergeMetadata } from '../reaping/sandbox-state-sync';
+
+/** Metadata key the marker is written under. */
+export const AUDIT_RATE_LIMIT_METADATA_KEY = 'auditEventRateLimit';
+
+export interface AuditRateFlagInput {
+  accountId: string;
+  projectId: string;
+  sessionId: string;
+  consecutiveHotWindows: number;
+  now?: Date;
+}
+
+/**
+ * Best-effort. Never throws and never rejects: the caller invokes this without
+ * awaiting, from the audit ingest hot path.
+ */
+export async function flagSessionAuditRateLimited(input: AuditRateFlagInput): Promise<void> {
+  const at = input.now ?? new Date();
+  try {
+    await db
+      .update(sessionSandboxes)
+      // `updatedAt` is deliberately NOT touched. Sandbox lifecycle and idle
+      // detection read that column; a marker write must not look like session
+      // activity.
+      .set({
+        metadata: mergeMetadata({
+          [AUDIT_RATE_LIMIT_METADATA_KEY]: {
+            consecutiveHotWindows: input.consecutiveHotWindows,
+            at: at.toISOString(),
+          },
+        }),
+      })
+      .where(
+        and(
+          eq(sessionSandboxes.accountId, input.accountId),
+          eq(sessionSandboxes.projectId, input.projectId),
+          eq(sessionSandboxes.sessionId, input.sessionId),
+          inArray(sessionSandboxes.status, ['provisioning', 'active']),
+        ),
+      );
+  } catch {
+    // Swallow: a marker that fails to write must not surface as a 500 on an
+    // audit ingest request, and must not turn an unhandled rejection loose.
+  }
+}
+
+/** Reads the marker off a metadata blob. Returns null when absent or malformed. */
+export function readAuditRateLimitFlag(
+  metadata: Record<string, unknown> | null | undefined,
+): { consecutiveHotWindows: number; at: string } | null {
+  const raw = metadata?.[AUDIT_RATE_LIMIT_METADATA_KEY];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  const hot = record.consecutiveHotWindows;
+  const at = record.at;
+  if (typeof hot !== 'number' || !Number.isFinite(hot) || typeof at !== 'string') return null;
+  return { consecutiveHotWindows: hot, at };
+}

--- a/apps/api/src/projects/routes/project-audit-ingestion.test.ts
+++ b/apps/api/src/projects/routes/project-audit-ingestion.test.ts
@@ -5,6 +5,10 @@
  */
 import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { auditEvents, serviceAccounts, sessionSandboxes } from '@kortix/db';
+import {
+  SESSION_EVENT_RATE_LIMITED_ACTION,
+  __resetAuditRateGuardForTest,
+} from '../../shared/opencode-audit-rate-guard';
 
 const ORIGINAL_ENV = {
   ALLOWED_SANDBOX_PROVIDERS: process.env.ALLOWED_SANDBOX_PROVIDERS,
@@ -128,7 +132,12 @@ describe('POST /:projectId/sessions/:sessionId/audit/events', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ accepted: 1, inserted: 1, duplicates: 0 });
+    expect(await response.json()).toEqual({
+      accepted: 1,
+      inserted: 1,
+      duplicates: 0,
+      suppressed: 0,
+    });
     expect(insertedValues).toHaveLength(1);
     expect(insertedValues[0]).toMatchObject({
       accountId: ACCOUNT_ID,
@@ -157,5 +166,98 @@ describe('POST /:projectId/sessions/:sessionId/audit/events', () => {
         },
       },
     });
+  });
+});
+
+/**
+ * The runaway guard, exercised through the real route rather than the pure
+ * function — this is the layer that decides what actually reaches the INSERT.
+ */
+describe('per-session ingest ceiling', () => {
+  const CEILING = 5;
+
+  function deltaEvent(n: number) {
+    return {
+      event_id: n.toString(16).padStart(64, '0'),
+      source_revision: `rev-${n}`,
+      type: 'message.part.delta',
+      occurred_at: '2026-08-08T12:00:00.000Z',
+      outcome: 'success',
+      phase: 'completed',
+      input_sha256: 'b'.repeat(64),
+    };
+  }
+
+  async function post(events: unknown[]) {
+    const response = await projectsApp.request(
+      `/${PROJECT_ID}/sessions/${SESSION_ID}/audit/events`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ events }),
+      },
+    );
+    return { status: response.status, body: (await response.json()) as Record<string, number> };
+  }
+
+  beforeEach(() => {
+    process.env.KORTIX_AUDIT_SESSION_EVENT_CEILING = String(CEILING);
+    __resetAuditRateGuardForTest();
+  });
+
+  afterAll(() => {
+    delete process.env.KORTIX_AUDIT_SESSION_EVENT_CEILING;
+    __resetAuditRateGuardForTest();
+  });
+
+  test('persists every delta while the session stays under the ceiling', async () => {
+    const { status, body } = await post([deltaEvent(1), deltaEvent(2), deltaEvent(3)]);
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ accepted: 3, inserted: 3, duplicates: 0, suppressed: 0 });
+    expect(insertedValues).toHaveLength(3);
+  });
+
+  test('stops persisting deltas over the ceiling and records one notice', async () => {
+    const { status, body } = await post(
+      Array.from({ length: 12 }, (_, i) => deltaEvent(i + 1)),
+    );
+
+    expect(status).toBe(200);
+    expect(body.accepted).toBe(12);
+    expect(body.suppressed).toBe(12 - CEILING);
+
+    // 5 deltas + 1 rate-limited notice reach the INSERT; the other 7 never do.
+    expect(insertedValues).toHaveLength(CEILING + 1);
+    const notices = insertedValues.filter(
+      (value) => value.action === SESSION_EVENT_RATE_LIMITED_ACTION,
+    );
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toMatchObject({
+      accountId: ACCOUNT_ID,
+      projectId: PROJECT_ID,
+      sessionId: SESSION_ID,
+      actorType: 'system',
+      outcome: 'denied',
+    });
+    expect(
+      insertedValues.filter((value) => value.action === 'opencode.message.part.delta'),
+    ).toHaveLength(CEILING);
+  });
+
+  test('a runaway session never blocks the request or loses lifecycle events', async () => {
+    await post(Array.from({ length: 12 }, (_, i) => deltaEvent(i + 1)));
+
+    const lifecycle = {
+      ...deltaEvent(99),
+      event_id: 'f'.repeat(64),
+      type: 'session.idle',
+    };
+    const { status, body } = await post([lifecycle]);
+
+    expect(status).toBe(200);
+    expect(body.suppressed).toBe(0);
+    expect(insertedValues).toHaveLength(1);
+    expect(insertedValues[0]).toMatchObject({ action: 'opencode.session.idle' });
   });
 });

--- a/apps/api/src/projects/routes/project-audit.ts
+++ b/apps/api/src/projects/routes/project-audit.ts
@@ -26,6 +26,8 @@ import {
 } from '../../shared/audit-query';
 import { AuditEventSchema, AuditListSchema } from '../../shared/audit-schema';
 import { parseOpenCodeAuditBatch } from '../../shared/opencode-audit-ingestion';
+import { applyOpenCodeAuditRateLimit } from '../../shared/opencode-audit-rate-guard';
+import { flagSessionAuditRateLimited } from '../lib/session-audit-rate-flag';
 import { callerKortixSessionId } from '../lib/caller-session';
 import { sandboxTokenMayActOnSession } from '../lib/sandbox-token-session';
 
@@ -239,15 +241,57 @@ projectsApp.openapi(
     } catch (error) {
       return c.json({ error: (error as Error).message }, 400);
     }
+    // Per-session ingest ceiling. A single runaway turn emitting ~1725
+    // `opencode.message.part.delta` rows/min took staging down through
+    // audit_events index contention (release-gate run 32151213430); this bounds
+    // the write rate before it reaches a 14-index table. It drops ONLY the
+    // per-token delta class and never blocks the request.
+    //
+    // Wrapped because a guard defect must never cost an audit write: any throw
+    // here falls back to persisting the batch exactly as parsed.
+    let toInsert = parsed.values;
+    let suppressed = 0;
+    try {
+      const decision = applyOpenCodeAuditRateLimit({
+        accountId,
+        projectId,
+        sessionId,
+        values: parsed.values,
+      });
+      toInsert = decision.values;
+      suppressed = decision.suppressed;
+      if (decision.flagForReaper) {
+        // Durable, best-effort marker for the maintenance sweep and for
+        // operators querying during an incident. Deliberately not awaited: the
+        // hot path must not gain a write it has to wait on.
+        void flagSessionAuditRateLimited({
+          accountId,
+          projectId,
+          sessionId,
+          consecutiveHotWindows: decision.consecutiveHotWindows,
+        });
+      }
+    } catch {
+      toInsert = parsed.values;
+      suppressed = 0;
+    }
+
+    if (toInsert.length === 0) {
+      return c.json({ accepted: parsed.accepted, inserted: 0, duplicates: 0, suppressed });
+    }
+
     const inserted = await db
       .insert(auditEvents)
-      .values(parsed.values)
+      .values(toInsert)
       .onConflictDoNothing()
       .returning({ eventId: auditEvents.eventId });
     return c.json({
       accepted: parsed.accepted,
       inserted: inserted.length,
-      duplicates: parsed.accepted - inserted.length,
+      // Rows the unique index rejected. Identical to the previous
+      // `accepted - inserted` whenever nothing was suppressed.
+      duplicates: Math.max(0, toInsert.length - inserted.length),
+      suppressed,
     });
   },
 );

--- a/apps/api/src/shared/opencode-audit-rate-guard.test.ts
+++ b/apps/api/src/shared/opencode-audit-rate-guard.test.ts
@@ -1,0 +1,305 @@
+/**
+ * The per-session audit ingest ceiling.
+ *
+ * The invariant these pin: a runaway session loses its per-token stream deltas
+ * and NOTHING else, and the drop is announced exactly once per window. The
+ * incident this guards against (release-gate run 32151213430) was one session
+ * writing ~1725 `opencode.message.part.delta` rows/min into a 14-index table.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import {
+  applyOpenCodeAuditRateLimit,
+  isSuppressibleStreamDelta,
+  RATE_GUARD_SOURCE_LEDGER,
+  SESSION_EVENT_RATE_LIMITED_ACTION,
+  SUPPRESSED_ACTION_CLASS,
+  __resetAuditRateGuardForTest,
+  __trackedSessionCountForTest,
+} from './opencode-audit-rate-guard';
+
+const SCOPE = {
+  accountId: '11111111-1111-4111-8111-111111111111',
+  projectId: '22222222-2222-4222-8222-222222222222',
+  sessionId: '33333333-3333-4333-8333-333333333333',
+};
+
+const WINDOW_MS = 60_000;
+const T0 = 1_760_000_000_000;
+
+/** A minimal parsed row — only the fields the guard reads. */
+function evt(action: string) {
+  return { action, resourceType: 'opencode_event' } as Parameters<
+    typeof applyOpenCodeAuditRateLimit
+  >[0]['values'][number];
+}
+
+function delta(n: number) {
+  return Array.from({ length: n }, () => evt(SUPPRESSED_ACTION_CLASS));
+}
+
+function run(values: ReturnType<typeof evt>[], now: number, sessionId = SCOPE.sessionId) {
+  return applyOpenCodeAuditRateLimit({ ...SCOPE, sessionId, values, now });
+}
+
+const ENV_KEYS = [
+  'KORTIX_AUDIT_SESSION_EVENT_CEILING',
+  'KORTIX_AUDIT_SESSION_WINDOW_MS',
+  'KORTIX_AUDIT_SESSION_HOT_WINDOWS',
+  'KORTIX_AUDIT_RATE_GUARD_MAX_SESSIONS',
+] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) saved[key] = process.env[key];
+  process.env.KORTIX_AUDIT_SESSION_EVENT_CEILING = '5';
+  process.env.KORTIX_AUDIT_SESSION_WINDOW_MS = String(WINDOW_MS);
+  __resetAuditRateGuardForTest();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key] as string;
+  }
+  __resetAuditRateGuardForTest();
+});
+
+describe('below the ceiling', () => {
+  test('persists every event and announces nothing', () => {
+    const result = run(delta(5), T0);
+
+    expect(result.values).toHaveLength(5);
+    expect(result.suppressed).toBe(0);
+    expect(result.limited).toBe(false);
+    expect(result.flagForReaper).toBe(false);
+    expect(result.values.some((v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION)).toBe(false);
+  });
+
+  test('accumulates across batches inside one window', () => {
+    run(delta(3), T0);
+    const second = run(delta(2), T0 + 1_000);
+
+    expect(second.suppressed).toBe(0);
+    expect(second.limited).toBe(false);
+  });
+});
+
+describe('above the ceiling', () => {
+  test('drops the excess deltas and emits exactly one notice', () => {
+    const result = run(delta(10), T0);
+
+    // 5 under the ceiling survive, 5 are dropped, 1 notice is appended.
+    expect(result.suppressed).toBe(5);
+    expect(result.limited).toBe(true);
+    expect(result.values).toHaveLength(6);
+
+    const notices = result.values.filter((v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION);
+    expect(notices).toHaveLength(1);
+    expect(result.values.filter((v) => v.action === SUPPRESSED_ACTION_CLASS)).toHaveLength(5);
+  });
+
+  test('the notice carries the counts that justify it', () => {
+    const notice = run(delta(10), T0).values.find(
+      (v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION,
+    );
+
+    expect(notice).toBeDefined();
+    const metadata = notice?.metadata as Record<string, unknown>;
+    expect(metadata.ceiling).toBe(5);
+    expect(metadata.window_ms).toBe(WINDOW_MS);
+    expect(metadata.observed_events).toBe(10);
+    expect(metadata.consecutive_hot_windows).toBe(1);
+    expect(metadata.suppressed_action_class).toBe(SUPPRESSED_ACTION_CLASS);
+    expect(notice?.sessionId).toBe(SCOPE.sessionId);
+    expect(notice?.accountId).toBe(SCOPE.accountId);
+    expect(notice?.outcome).toBe('denied');
+    expect(notice?.actorType).toBe('system');
+  });
+
+  test('the notice dedupes per window, so a relay retry cannot multiply it', () => {
+    const notice = run(delta(10), T0).values.find(
+      (v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION,
+    );
+    const expected = createHash('sha256').update(`${SCOPE.sessionId}:${T0}`).digest('hex');
+
+    expect(notice?.sourceLedger).toBe(RATE_GUARD_SOURCE_LEDGER);
+    expect(notice?.sourceRecordId).toBe(expected);
+  });
+
+  test('announces once per window, not once per batch', () => {
+    const first = run(delta(10), T0);
+    const second = run(delta(10), T0 + 1_000);
+    const third = run(delta(10), T0 + 2_000);
+
+    expect(first.values.filter((v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION)).toHaveLength(1);
+    expect(second.values.filter((v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION)).toHaveLength(0);
+    expect(third.values.filter((v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION)).toHaveLength(0);
+    // Suppression keeps working after the announcement.
+    expect(second.suppressed).toBe(10);
+    expect(third.suppressed).toBe(10);
+  });
+
+  test('counts dropped events toward the observed rate', () => {
+    run(delta(10), T0);
+    const notice = run(delta(10), T0 + 1_000).values.find(
+      (v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION,
+    );
+    // No second notice this window; the running count is still advancing.
+    expect(notice).toBeUndefined();
+
+    const later = run(delta(1), T0 + 2_000);
+    expect(later.limited).toBe(true);
+  });
+
+  test('each session gets its own budget', () => {
+    const other = '44444444-4444-4444-8444-444444444444';
+    run(delta(10), T0);
+    const clean = run(delta(3), T0, other);
+
+    expect(clean.suppressed).toBe(0);
+    expect(clean.limited).toBe(false);
+  });
+});
+
+describe('what may never be dropped', () => {
+  test('lifecycle, tool and permission events survive far over the ceiling', () => {
+    const keepers = [
+      'opencode.session.idle',
+      'opencode.tool.updated',
+      'opencode.permission.updated',
+      'opencode.message.part.text.updated',
+      'opencode.session.error',
+      'session.usage.recorded',
+    ];
+    const result = run([...delta(20), ...keepers.map(evt)], T0);
+
+    for (const action of keepers) {
+      expect(result.values.filter((v) => v.action === action)).toHaveLength(1);
+    }
+    // Only the delta class was ever dropped.
+    expect(result.suppressed).toBe(15);
+  });
+
+  test('a session made entirely of non-delta events is never suppressed', () => {
+    const result = run(
+      Array.from({ length: 50 }, (_, i) => evt(`opencode.tool.updated.${i % 3}`)),
+      T0,
+    );
+
+    expect(result.suppressed).toBe(0);
+    expect(result.values.filter((v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION)).toHaveLength(1);
+    // The window is still marked hot — the rate is real even when nothing is droppable.
+    expect(result.limited).toBe(true);
+  });
+
+  test('the suppressible class is pinned to per-token deltas', () => {
+    expect(isSuppressibleStreamDelta('opencode.message.part.delta')).toBe(true);
+    expect(isSuppressibleStreamDelta('opencode.message.part.delta.text')).toBe(true);
+    expect(isSuppressibleStreamDelta('opencode.message.part.text.updated')).toBe(false);
+    expect(isSuppressibleStreamDelta('opencode.tool.updated')).toBe(false);
+    expect(isSuppressibleStreamDelta('opencode.session.idle')).toBe(false);
+    expect(isSuppressibleStreamDelta('account.member.removed')).toBe(false);
+    expect(isSuppressibleStreamDelta(null)).toBe(false);
+    expect(isSuppressibleStreamDelta(undefined)).toBe(false);
+  });
+});
+
+describe('window rollover', () => {
+  test('resets the counter so a new window starts clean', () => {
+    const hot = run(delta(10), T0);
+    expect(hot.limited).toBe(true);
+
+    const next = run(delta(5), T0 + WINDOW_MS);
+    expect(next.suppressed).toBe(0);
+    expect(next.limited).toBe(false);
+    expect(next.values).toHaveLength(5);
+  });
+
+  test('re-announces in a new window that goes hot again', () => {
+    run(delta(10), T0);
+    const next = run(delta(10), T0 + WINDOW_MS);
+
+    expect(next.values.filter((v) => v.action === SESSION_EVENT_RATE_LIMITED_ACTION)).toHaveLength(1);
+    expect((next.values.at(-1)?.metadata as Record<string, unknown>).consecutive_hot_windows).toBe(2);
+  });
+
+  test('a window that stays under the ceiling breaks the hot streak', () => {
+    run(delta(10), T0);
+    run(delta(1), T0 + WINDOW_MS);
+    const third = run(delta(10), T0 + WINDOW_MS * 2);
+
+    expect(third.consecutiveHotWindows).toBe(1);
+  });
+
+  test('an idle gap of more than one window breaks the streak', () => {
+    run(delta(10), T0);
+    const later = run(delta(10), T0 + WINDOW_MS * 3);
+
+    expect(later.consecutiveHotWindows).toBe(1);
+  });
+});
+
+describe('sustained-hot flagging', () => {
+  test('raises the reaper flag only after the configured consecutive windows', () => {
+    process.env.KORTIX_AUDIT_SESSION_HOT_WINDOWS = '3';
+
+    const first = run(delta(10), T0);
+    expect(first.consecutiveHotWindows).toBe(1);
+    expect(first.flagForReaper).toBe(false);
+
+    const second = run(delta(10), T0 + WINDOW_MS);
+    expect(second.consecutiveHotWindows).toBe(2);
+    expect(second.flagForReaper).toBe(false);
+
+    const third = run(delta(10), T0 + WINDOW_MS * 2);
+    expect(third.consecutiveHotWindows).toBe(3);
+    expect(third.flagForReaper).toBe(true);
+  });
+
+  test('a session that never trips is never flagged', () => {
+    process.env.KORTIX_AUDIT_SESSION_HOT_WINDOWS = '1';
+    const result = run(delta(2), T0);
+
+    expect(result.flagForReaper).toBe(false);
+  });
+});
+
+describe('bounded state', () => {
+  test('tracked sessions cannot grow without limit', () => {
+    process.env.KORTIX_AUDIT_RATE_GUARD_MAX_SESSIONS = '10';
+
+    for (let i = 0; i < 200; i += 1) {
+      run(delta(1), T0 + i, `session-${i}`);
+    }
+
+    expect(__trackedSessionCountForTest()).toBeLessThanOrEqual(10);
+  });
+});
+
+describe('configuration', () => {
+  test('the shipped default ceiling sits between healthy and runaway traffic', () => {
+    delete process.env.KORTIX_AUDIT_SESSION_EVENT_CEILING;
+    __resetAuditRateGuardForTest();
+
+    // 257/min was the busiest healthy streaming session measured during the
+    // incident; 1725/min was the runaway. The default must clear the first and
+    // catch the second.
+    const healthy = run(delta(257), T0);
+    expect(healthy.suppressed).toBe(0);
+    expect(healthy.limited).toBe(false);
+
+    __resetAuditRateGuardForTest();
+    const runaway = run(delta(1725), T0);
+    expect(runaway.limited).toBe(true);
+    expect(runaway.suppressed).toBe(1725 - 900);
+  });
+
+  test('an invalid env override falls back to the safe default', () => {
+    process.env.KORTIX_AUDIT_SESSION_EVENT_CEILING = 'not-a-number';
+    __resetAuditRateGuardForTest();
+
+    const result = run(delta(257), T0);
+    expect(result.limited).toBe(false);
+  });
+});

--- a/apps/api/src/shared/opencode-audit-rate-guard.ts
+++ b/apps/api/src/shared/opencode-audit-rate-guard.ts
@@ -1,0 +1,320 @@
+/**
+ * Per-session ingest-rate ceiling for sandbox-reported OpenCode audit events.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `kortix.audit_events` carries 14 indexes (packages/db/src/schema/kortix.ts:2688-2741)
+ * and is written on essentially every request. The sandbox relay forwards EVERY
+ * OpenCode SSE event 1:1 with no type filter
+ * (apps/kortix-sandbox-agent-server/src/opencode-events.ts:223 ->
+ * opencode-audit-relay.ts), and it stamps a fresh `randomUUID()` per emission,
+ * so the `idx_audit_events_source_phase` unique index only ever catches a
+ * transport retry — never a genuine repeat delta. Nothing bounded the write
+ * rate.
+ *
+ * During release-gate run 32151213430 (attempt 8) ONE session emitted ~1725
+ * `opencode.message.part.delta` rows per minute. The resulting index-maintenance
+ * lock contention took the staging API down, and the edge worker laundered the
+ * 5xx into a generic `MAINTENANCE_MODE` 503 — so the log said "maintenance"
+ * while the real cause was a single runaway turn (see the 2026-08-18/19
+ * learnings entries).
+ *
+ * WHAT THIS DOES
+ * --------------
+ * Counts every event ingested for a session inside a fixed window. Once the
+ * window is over the ceiling it stops PERSISTING the one high-volume class —
+ * per-token stream deltas — for the rest of that window, and emits exactly one
+ * `session.event_rate_limited` row naming the counts. Lifecycle, tool,
+ * permission, question, error, auth and billing events are NEVER dropped: they
+ * are low-volume and each one is forensically load-bearing. A dropped delta
+ * costs nothing that the surrounding `.updated` and lifecycle events do not
+ * already imply.
+ *
+ * DESIGN NOTES
+ * ------------
+ * - The counter is a FIXED (tumbling) window, not a true sliding one. A sliding
+ *   window has to retain a timestamp per event, which means the guard's own
+ *   memory grows with exactly the load it exists to contain. A tumbling window
+ *   is O(1) state per session. The cost is that a burst straddling a boundary
+ *   can pass up to 2x the ceiling in 60s; that is still far under the runaway
+ *   rate, and the next window re-engages immediately.
+ * - In-memory and per process. No new table, no extra DB round-trip on the hot
+ *   path — a guard that writes to the database to decide whether to write to the
+ *   database would deepen the exact contention it is here to relieve. With N API
+ *   tasks the effective ceiling is N x the configured value; the default is set
+ *   low enough that this still bounds the runaway well below the observed rate.
+ * - This module never throws and never awaits. The caller treats a failure as
+ *   "persist everything", because a guard bug must not cost an audit write.
+ */
+
+import type { auditEvents } from '@kortix/db';
+import { createHash } from 'node:crypto';
+
+type AuditInsert = typeof auditEvents.$inferInsert;
+
+/** Action written when a session trips the ceiling. One row per hot window. */
+export const SESSION_EVENT_RATE_LIMITED_ACTION = 'session.event_rate_limited';
+
+/** Own ledger so the notice can never collide with a relayed OpenCode event. */
+export const RATE_GUARD_SOURCE_LEDGER = 'kortix_audit_rate_guard';
+
+/** The single event class this guard is allowed to drop. */
+export const SUPPRESSED_ACTION_CLASS = 'opencode.message.part.delta';
+
+function positiveEnvInt(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** Width of one counting window. */
+export function auditRateWindowMs(): number {
+  return positiveEnvInt('KORTIX_AUDIT_SESSION_WINDOW_MS', 60_000);
+}
+
+/**
+ * Events per session per window before delta suppression engages.
+ *
+ * Chosen from the real distribution measured the night of the incident: healthy
+ * streaming turns produced 119-257 delta events/min, while the runaway session
+ * sustained 1725/min. 900 sits ~3.5x above the busiest healthy session observed
+ * and just over half the runaway rate — high enough that no normal turn can
+ * reach it even allowing for several concurrent streams on one session, low
+ * enough that a runaway is cut off inside its first window.
+ */
+export function auditRateCeiling(): number {
+  return positiveEnvInt('KORTIX_AUDIT_SESSION_EVENT_CEILING', 900);
+}
+
+/**
+ * Consecutive hot windows before the session is flagged in
+ * `session_sandboxes.metadata` for operator/reaper attention. Three windows is
+ * three full minutes of sustained over-ceiling traffic — well past any burst a
+ * legitimate turn produces.
+ */
+export function auditRateHotWindowsBeforeFlag(): number {
+  return positiveEnvInt('KORTIX_AUDIT_SESSION_HOT_WINDOWS', 3);
+}
+
+/** Hard bound on tracked sessions, so the guard's own state cannot grow without limit. */
+export function auditRateMaxTrackedSessions(): number {
+  return positiveEnvInt('KORTIX_AUDIT_RATE_GUARD_MAX_SESSIONS', 20_000);
+}
+
+/**
+ * True only for per-token stream deltas.
+ *
+ * Deliberately an exact match rather than a prefix over
+ * `opencode.message.part.*`: `canonicalOpenCodeAction`
+ * (shared/opencode-audit-ingestion.ts:215-229) also produces
+ * `opencode.message.part.<type>.updated` and `opencode.tool.updated` from
+ * `message.part.updated`, and those carry state transitions worth keeping.
+ * Widening this predicate widens what an incident can erase, so it stays
+ * pinned to the class that was actually measured runaway.
+ */
+export function isSuppressibleStreamDelta(action: string | null | undefined): boolean {
+  if (!action) return false;
+  return action === SUPPRESSED_ACTION_CLASS || action.startsWith(`${SUPPRESSED_ACTION_CLASS}.`);
+}
+
+interface SessionWindow {
+  windowStartMs: number;
+  /** Events observed this window, including ones this guard dropped. */
+  observed: number;
+  suppressed: number;
+  /** Whether this window has already crossed the ceiling. */
+  hot: boolean;
+  consecutiveHotWindows: number;
+  lastSeenMs: number;
+}
+
+const windows = new Map<string, SessionWindow>();
+
+function evictIfNeeded(now: number, windowMs: number): void {
+  const max = auditRateMaxTrackedSessions();
+  if (windows.size < max) return;
+
+  const staleBefore = now - windowMs * 5;
+  for (const [key, state] of windows) {
+    if (state.lastSeenMs < staleBefore) windows.delete(key);
+  }
+  if (windows.size < max) return;
+
+  // Still full: drop the least recently seen half. Losing a counter fails OPEN
+  // (that session simply starts a fresh window), which is the safe direction.
+  const byAge = [...windows.entries()].sort((a, b) => a[1].lastSeenMs - b[1].lastSeenMs);
+  const drop = windows.size - Math.floor(max / 2);
+  for (let i = 0; i < drop && i < byAge.length; i += 1) windows.delete(byAge[i][0]);
+}
+
+function windowFor(sessionId: string, now: number, windowMs: number): SessionWindow {
+  const existing = windows.get(sessionId);
+  if (!existing) {
+    evictIfNeeded(now, windowMs);
+    const fresh: SessionWindow = {
+      windowStartMs: now,
+      observed: 0,
+      suppressed: 0,
+      hot: false,
+      consecutiveHotWindows: 0,
+      lastSeenMs: now,
+    };
+    windows.set(sessionId, fresh);
+    return fresh;
+  }
+
+  const elapsed = now - existing.windowStartMs;
+  if (elapsed >= windowMs) {
+    // The streak counts CONSECUTIVE hot windows. It breaks when the window that
+    // just closed never tripped, and also when more than one window has elapsed
+    // — the windows in between saw no traffic at all, so they were not hot.
+    if (!existing.hot || elapsed >= windowMs * 2) existing.consecutiveHotWindows = 0;
+    existing.windowStartMs = now;
+    existing.observed = 0;
+    existing.suppressed = 0;
+    existing.hot = false;
+  }
+  existing.lastSeenMs = now;
+  return existing;
+}
+
+function rateLimitedNotice(args: {
+  accountId: string;
+  projectId: string;
+  sessionId: string;
+  now: number;
+  windowStartMs: number;
+  windowMs: number;
+  ceiling: number;
+  observed: number;
+  consecutiveHotWindows: number;
+}): AuditInsert {
+  // Deterministic per (session, window): if the batch that tripped the ceiling
+  // is retried by the relay, the unique index collapses it to the one row.
+  const sourceRecordId = createHash('sha256')
+    .update(`${args.sessionId}:${args.windowStartMs}`)
+    .digest('hex');
+
+  return {
+    accountId: args.accountId,
+    projectId: args.projectId,
+    sessionId: args.sessionId,
+    actorType: 'system',
+    source: 'kortix',
+    authoritativeSource: 'system',
+    outcome: 'denied',
+    action: SESSION_EVENT_RATE_LIMITED_ACTION,
+    phase: 'completed',
+    resourceType: 'session',
+    resourceId: args.sessionId,
+    correlationId: args.sessionId,
+    sourceLedger: RATE_GUARD_SOURCE_LEDGER,
+    sourceRecordId,
+    sourceRevision: 'window',
+    delegationDepth: 0,
+    metadata: {
+      event_type: SESSION_EVENT_RATE_LIMITED_ACTION,
+      window_ms: args.windowMs,
+      window_started_at: new Date(args.windowStartMs).toISOString(),
+      ceiling: args.ceiling,
+      observed_events: args.observed,
+      consecutive_hot_windows: args.consecutiveHotWindows,
+      suppressed_action_class: SUPPRESSED_ACTION_CLASS,
+    },
+    occurredAt: new Date(args.now),
+  };
+}
+
+export interface RateGuardInput {
+  accountId: string;
+  projectId: string;
+  sessionId: string;
+  /** Parsed rows for this batch, in order. */
+  values: AuditInsert[];
+  /** Injectable clock. Tests pass this; the route does not. */
+  now?: number;
+}
+
+export interface RateGuardDecision {
+  /** Rows to persist. Includes the notice row when this batch tripped the ceiling. */
+  values: AuditInsert[];
+  /** Delta rows dropped from THIS batch. */
+  suppressed: number;
+  /** Whether the session's current window is over the ceiling. */
+  limited: boolean;
+  /** Consecutive over-ceiling windows for this session right now. */
+  consecutiveHotWindows: number;
+  /** The session has been hot long enough to deserve a durable marker. */
+  flagForReaper: boolean;
+}
+
+/**
+ * Apply the per-session ceiling to one parsed batch.
+ *
+ * Pure apart from the module-level counter map: no I/O, no awaits, no throws.
+ */
+export function applyOpenCodeAuditRateLimit(input: RateGuardInput): RateGuardDecision {
+  const now = input.now ?? Date.now();
+  const windowMs = auditRateWindowMs();
+  const ceiling = auditRateCeiling();
+  const state = windowFor(input.sessionId, now, windowMs);
+
+  const kept: AuditInsert[] = [];
+  let suppressed = 0;
+  let trippedInThisBatch = false;
+
+  for (const value of input.values) {
+    // Count every event, including dropped ones: the measured quantity is the
+    // session's ingest RATE. Counting only what we persist would pin the
+    // counter at the ceiling and hide how far over the session really is.
+    state.observed += 1;
+    const overCeiling = state.observed > ceiling;
+
+    if (overCeiling && !state.hot) {
+      state.hot = true;
+      state.consecutiveHotWindows += 1;
+      trippedInThisBatch = true;
+    }
+
+    if (overCeiling && isSuppressibleStreamDelta(value.action)) {
+      state.suppressed += 1;
+      suppressed += 1;
+      continue;
+    }
+
+    kept.push(value);
+  }
+
+  if (trippedInThisBatch) {
+    kept.push(
+      rateLimitedNotice({
+        accountId: input.accountId,
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        now,
+        windowStartMs: state.windowStartMs,
+        windowMs,
+        ceiling,
+        observed: state.observed,
+        consecutiveHotWindows: state.consecutiveHotWindows,
+      }),
+    );
+  }
+
+  return {
+    values: kept,
+    suppressed,
+    limited: state.hot,
+    consecutiveHotWindows: state.consecutiveHotWindows,
+    flagForReaper: state.hot && state.consecutiveHotWindows >= auditRateHotWindowsBeforeFlag(),
+  };
+}
+
+/** Test-only: drop all counters so cases cannot leak state into each other. */
+export function __resetAuditRateGuardForTest(): void {
+  windows.clear();
+}
+
+/** Test-only: how many sessions the guard currently tracks. */
+export function __trackedSessionCountForTest(): number {
+  return windows.size;
+}


### PR DESCRIPTION
## Problem

During release-gate run `32151213430` (attempt 8) one test session emitted **~1725 `opencode.message.part.delta` audit events per minute** (3,271 events in 2 minutes for the account) into `kortix.audit_events`.

That table carries **14 indexes** (`packages/db/src/schema/kortix.ts:2688-2741`) and is written on nearly every request. The resulting index-maintenance lock contention took the staging API down. The edge Worker then rewrote the origin 5xx into a generic `MAINTENANCE_MODE` 503 (`infra/cloudflare/workers/api-router/worker.mjs:251-273`), so the log said "maintenance" while the real cause was a single runaway turn.

**There was no server-side guard.** Two facts made that worse than it looks:

- The sandbox relay forwards **every** OpenCode SSE event 1:1 with no type filter (`apps/kortix-sandbox-agent-server/src/opencode-events.ts:223` → `opencode-audit-relay.ts`).
- The relay stamps a fresh `randomUUID()` per emission (`opencode-audit-relay.ts:365`), so the `idx_audit_events_source_phase` unique index only ever caught a transport retry — never a genuine repeat delta.

## What this adds

A per-session sliding ceiling on the ingest path that persists these events, applied in `POST /v1/projects/:projectId/sessions/:sessionId/audit/events` between parse and INSERT.

| File | Role |
| --- | --- |
| `apps/api/src/shared/opencode-audit-rate-guard.ts` | The guard. Pure apart from one counter map; no I/O, no awaits, no throws. |
| `apps/api/src/projects/routes/project-audit.ts:242-289` | Wires it in ahead of the INSERT. |
| `apps/api/src/projects/lib/session-audit-rate-flag.ts` | Durable `session_sandboxes.metadata` marker for a sustained-hot session. |

Behaviour:

1. **Counts every event** ingested for a session inside a fixed 60 s window — including events it drops, so the counter measures the real ingest rate rather than pinning at the ceiling.
2. **Over the ceiling, stops persisting only the per-token delta class** for the rest of that window (`opencode-audit-rate-guard.ts:104-112`). Lifecycle, tool, permission, question, error, auth and billing events are never dropped.
3. **Emits exactly one `session.event_rate_limited` row per hot window**, carrying the ceiling, window width, observed count and the consecutive-hot-window streak. Its `source_record_id` is `sha256(sessionId:windowStart)`, so a relay retry of the tripping batch collapses to the one row via the existing unique index.
4. **Flags a session hot for 3 consecutive windows** in `session_sandboxes.metadata`, un-awaited and best-effort.

## The threshold, and why

**900 events per session per minute** (`KORTIX_AUDIT_SESSION_EVENT_CEILING`).

Taken from the real distribution that night: healthy streaming turns produced **119–257 deltas/min**; the runaway sustained **1725/min**. 900 clears the busiest healthy session observed by ~3.5x — enough headroom for several concurrent streams on one session — and still cuts the runaway inside its first window. `opencode-audit-rate-guard.test.ts:283-300` pins both ends of that gap against the shipped default, so the number cannot drift silently.

All knobs are env-tunable with safe defaults, and an unparseable value falls back to the default:

| Variable | Default |
| --- | --- |
| `KORTIX_AUDIT_SESSION_EVENT_CEILING` | 900 |
| `KORTIX_AUDIT_SESSION_WINDOW_MS` | 60000 |
| `KORTIX_AUDIT_SESSION_HOT_WINDOWS` | 3 |
| `KORTIX_AUDIT_RATE_GUARD_MAX_SESSIONS` | 20000 |

## Deliberate design choices

- **Tumbling window, not a true sliding one.** A sliding window retains a timestamp per event, so the guard's own memory would grow with exactly the load it exists to contain. This is O(1) state per session. The cost is that a burst straddling a boundary can pass up to 2x the ceiling in 60 s — still far below the runaway rate, and the next window re-engages.
- **In-memory, per process.** A guard that writes to the database to decide whether to write to the database would deepen the contention it relieves. With N API tasks the effective ceiling is N x the value; the default is low enough that this still bounds the runaway well under the observed rate.
- **Fails open.** Any throw in the guard falls back to persisting the batch exactly as parsed (`project-audit.ts:283-286`). A guard defect must never cost an audit write.
- **The suppressible class is pinned, not a prefix.** `canonicalOpenCodeAction` also produces `opencode.message.part.<type>.updated` and `opencode.tool.updated` from `message.part.updated`, and those carry state transitions worth keeping. Widening the predicate widens what an incident can erase.
- **A flag, not a park.** The marker does not stop, park, or shorten the deadline of a session. Suppressing the delta class already removes the database pressure that caused the incident; automatically killing a live user session on a volume heuristic has its own failure mode (a legitimate long streaming turn parked mid-flight) and belongs in its own change.

`duplicates` in the response keeps its meaning — it is now `toInsert.length - inserted.length`, identical to the previous `accepted - inserted` whenever nothing was suppressed. A new `suppressed` field is additive; the route's response schema is `AnyObject`, so no contract change.

## Verification

- `bun test src/shared/opencode-audit-rate-guard.test.ts` — **20 pass**, 72 expect() calls. Below the ceiling everything persists; above it only deltas drop and exactly one notice appears; window rollover resets; a quiet window and an idle gap both break the hot streak; lifecycle/tool/permission/`.updated` events survive 20 deltas over the ceiling; tracked-session state stays bounded at the configured cap.
- `bun test src/projects/routes/project-audit-ingestion.test.ts` — **4 pass**. Three new cases drive the real handler: under the ceiling all deltas reach the INSERT; over it exactly `ceiling` deltas plus one notice reach the INSERT; a lifecycle event posted by an already-limited session is still persisted and the request still returns 200.
- `bun test src/projects/lib/session-audit-rate-flag.test.ts` — **4 pass**, including the load-bearing one: the marker write **never rejects** when the database throws.
- `bash scripts/test.sh` — **7569 pass / 74 skip / 1 fail** across 658 files. The single failure is `builder-provider-dedupe.test.ts`, which passes in isolation; a clean `origin/main` tree fails **3 different** tests in the same snapshots suite (15 s timeouts). Pre-existing parallel-load flakiness in that suite, not this change.
- `pnpm --filter kortix-api typecheck` — clean.
