### PR TITLE
test(e2e): harden the recurring deployed-target browser specs; quarantine the non-deterministic ones into a nightly lane

### DIFF
--- a/.github/workflows/tests-browser-nightly.yml
+++ b/.github/workflows/tests-browser-nightly.yml
@@ -1,0 +1,101 @@
+name: Tests - browser quarantine (nightly)
+
+# The non-blocking home for browser journeys that cannot be made deterministic
+# against a deployed target.
+#
+# `tests-release.yml` excludes the `@quarantine` tag so a third-party outage
+# cannot hold a production release. This workflow runs EXACTLY that tag, on a
+# schedule, against the same staging origin and with the same secrets — so a
+# quarantined journey keeps being exercised and keeps an owner, instead of
+# rotting into a spec nobody runs.
+#
+# It is required by no branch and gates nothing. A red run here is a ticket, not
+# a block. If a journey goes green here for a sustained period AND its
+# non-determinism has been removed at the source, drop its tag and it returns to
+# the blocking gate automatically — no workflow edit needed.
+
+on:
+  schedule:
+    # 04:20 UTC daily — after the nightly deploys have settled and well clear of
+    # the release-gate window, so the two lanes never contend for staging.
+    - cron: '20 4 * * *'
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Tag filter to run (default @quarantine)'
+        required: false
+        default: '@quarantine'
+
+concurrency:
+  group: tests-browser-nightly
+  cancel-in-progress: false
+
+# Mirrors the top-level env of tests-release.yml. Both target the same deployed
+# staging origin with the same credentials; keep them in step when either
+# changes.
+env:
+  KE2E_API_URL: ${{ vars.QA_API_BASE_URL || 'https://staging-api.kortix.com/v1' }}
+  E2E_BASE_URL: ${{ vars.QA_WEB_BASE_URL || 'https://staging.kortix.com' }}
+  KE2E_GATEWAY_URL: ${{ vars.QA_GATEWAY_URL || 'https://gateway-staging.kortix.com' }}
+  KE2E_TARGET: staging
+  KE2E_LIVE_CONFIRM: ci
+  KE2E_OWNER_EMAIL: ${{ secrets.KE2E_OWNER_EMAIL }}
+  KE2E_OWNER_PASSWORD: ${{ secrets.KE2E_OWNER_PASSWORD }}
+  KE2E_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+  KE2E_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
+  KE2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+  KE2E_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+  KE2E_INTERNAL_SERVICE_KEY: ${{ secrets.STAGING_INTERNAL_SERVICE_KEY }}
+  KE2E_STRIPE_SECRET_KEY: ${{ secrets.STAGING_STRIPE_SECRET_KEY }}
+  KE2E_STRIPE_WEBHOOK_SECRET: ${{ secrets.STAGING_STRIPE_WEBHOOK_SECRET }}
+  E2E_AGENTMAIL_API_KEY: ${{ secrets.E2E_AGENTMAIL_API_KEY }}
+  KE2E_CAP_MANAGED_GIT_PUSH: ${{ vars.KE2E_CAP_MANAGED_GIT_PUSH || '0' }}
+  WEB_PROTECTION_PASSWORD: ${{ secrets.WEB_PROTECTION_PASSWORD }}
+  # Staging sits behind Vercel SSO deployment protection; without this header
+  # every authenticated page 302s to vercel.com/sso-api. See playwright.config.
+  VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+  KE2E_CI_PASSTHROUGH_SECRET: ${{ secrets.CF_WORKER_CI_PASSTHROUGH_SECRET }}
+
+jobs:
+  quarantine:
+    name: quarantined browser journeys
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      # `playwright.config.ts` turns this into `grep`, so the run loads ONLY the
+      # tagged journeys. Everything else is never collected.
+      E2E_INCLUDE_TAGS: ${{ github.event.inputs.tags || '@quarantine' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 8.11.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install deployed-target dependencies
+        run: |
+          pnpm install --frozen-lockfile --filter @kortix/tests...
+          pnpm --dir tests exec playwright install --with-deps chromium
+      - name: Run the quarantined browser journeys against staging
+        run: pnpm test -- --target-browser-full
+      - name: Guard test artifacts against secrets
+        if: always()
+        run: |
+          set -euo pipefail
+          if rg -l 'kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.' tests/test-results 2>/dev/null; then
+            echo "::error::A test artifact contains a secret-shaped value."
+            exit 1
+          fi
+          echo "No secret-shaped values found."
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: tests-browser-nightly-quarantine
+          path: tests/test-results/**
+          if-no-files-found: warn
+          retention-days: 30

--- a/tests/README.md
+++ b/tests/README.md
@@ -403,6 +403,67 @@ The regular browser lane excludes provider-mutating journeys. Set
 journey. That journey creates and deletes its own product snapshot. The
 Platinum CI worker remains a separate infrastructure sandbox.
 
+### Tag filters
+
+`playwright.config.ts` reads four environment variables and turns them into
+Playwright's `grep` and `grepInvert`:
+
+| Variable | Direction | Value |
+| --- | --- | --- |
+| `E2E_EXCLUDE_TAGS` | exclude | comma-separated tags, each escaped |
+| `E2E_INCLUDE_TAGS` | include | comma-separated tags, each escaped |
+| `E2E_GREP_INVERT` | exclude | raw regex |
+| `E2E_GREP` | include | raw regex |
+
+Entries in the same direction are unioned. Playwright applies both at
+collection, before `--shard`, so an excluded journey is never loaded, never
+counted, and never lands in a shard.
+
+### Quarantined journeys
+
+A browser journey that cannot be made deterministic against a deployed target
+carries the `@quarantine` tag on its `test.describe`. Today that is
+`17-oauth-provider-initiation` alone: it clicks through to `accounts.google.com`
+and `github.com` and asserts what those pages do, so a third-party interstitial
+turns the production release gate red with no Kortix defect behind it.
+
+- The blocking release gate excludes the tag.
+- `.github/workflows/tests-browser-nightly.yml` runs exactly the tag, nightly
+  and on dispatch, against the same staging origin with the same secrets. It
+  gates nothing. A red run there is a ticket, not a block.
+
+An excluded journey does not count as a skip. `strict-skip-reporter.ts` fails
+the strict lane on a `skipped` RESULT, and a grep-excluded journey produces no
+result at all. Prove the set with `playwright test --list`.
+
+To return a journey to the blocking gate, remove its tag — no workflow edit is
+needed. Remove it only once the non-determinism is gone at the source, not
+because the nightly happened to be green.
+
+### Deployed-target resilience
+
+A deployed target shares one origin with the concurrent REST lane and with real
+traffic, so the browser helpers separate an environment fault from a product
+defect:
+
+- `helpers/http.ts` retries `429/502/503/504` for up to 60s on a deployed target
+  (`E2E_TRANSIENT_RETRY_MS`, 0 locally). It retries any request the maintenance
+  gate rejected, and otherwise only idempotent methods — a non-idempotent
+  request that reached the origin is never repeated.
+- `isProductServerError` treats `500` as a defect and `502/503/504` as
+  environment. Journeys asserting "this page issued no failing request" use it
+  instead of a blanket `status >= 500`.
+- `pollApiStatus` polls an assertion that follows a REVOKE for up to 20s.
+  `apps/api/src/iam/cache-invalidation.ts` busts its authz memo
+  process-locally, so on multi-replica staging a revoke can take up to one ~15s
+  TTL window to become visible on a sibling replica.
+- `helpers/database.ts:pollDatabaseRows` polls a read-back that follows a UI
+  action, instead of assuming the write landed before the response rendered.
+
+Prefer waiting on the visible outcome over `page.waitForResponse(url === …)`.
+The latter pins a client cache and hydration detail, not a product contract, and
+its default budget is 30s.
+
 ## SDK tests
 
 SDK tests stay in `packages/sdk`. They protect the published package contract

--- a/tests/e2e/helpers/accounts.ts
+++ b/tests/e2e/helpers/accounts.ts
@@ -1,0 +1,55 @@
+import { expect } from "@playwright/test";
+
+export interface AccountSummary {
+  account_id: string;
+  personal_account?: boolean;
+  is_primary_owner?: boolean;
+  account_role?: string;
+}
+
+type ResultClient = <T>(
+  token: string,
+  method: string,
+  path: string,
+  body?: unknown,
+) => Promise<{ status: number; json: T | null }>;
+
+/**
+ * The account a freshly seeded user owns.
+ *
+ * Every browser journey starts here, and until now each one wrote
+ * `accounts.json?.find(...)` inline. When staging answered
+ * `503 MAINTENANCE_MODE` the body was an object, `.find` was undefined, and the
+ * release gate reported `TypeError: _accounts$json.find is not a function`
+ * (run 32231251280, `12-sandbox-templates.spec.ts:94`) — a stack trace that
+ * names neither the 503 nor the endpoint. Asserting the status and the shape
+ * first turns that into "GET /accounts answered 503, body …".
+ *
+ * `createApiResultClient` already retries a transient 5xx, so reaching this
+ * assertion means the outage outlasted the whole retry budget.
+ */
+export async function resolvePersonalAccountId(
+  api: ResultClient,
+  token: string,
+): Promise<string> {
+  const accounts = await api<AccountSummary[]>(token, "GET", "/accounts");
+  expect(
+    accounts.status,
+    `GET /accounts answered ${accounts.status}: ${JSON.stringify(accounts.json)}`,
+  ).toBe(200);
+  expect(
+    Array.isArray(accounts.json),
+    `GET /accounts must return an array, got ${JSON.stringify(accounts.json)}`,
+  ).toBe(true);
+  const personalAccount = (accounts.json ?? []).find(
+    (account) =>
+      account.personal_account ||
+      account.is_primary_owner ||
+      account.account_role === "owner",
+  );
+  expect(
+    personalAccount?.account_id,
+    "the seeded user must own a personal account",
+  ).toBeTruthy();
+  return personalAccount?.account_id as string;
+}

--- a/tests/e2e/helpers/database.ts
+++ b/tests/e2e/helpers/database.ts
@@ -40,6 +40,32 @@ export async function queryDatabaseRows<
   }
 }
 
+/**
+ * The same query, retried until it returns at least one row.
+ *
+ * A browser journey that acts through the UI and then reads the database is
+ * racing two independent systems: the API commits the row after the response
+ * the browser already rendered. Polling is the only sound wait — a fixed sleep
+ * is either flaky or slow, and the browser exposes no event for "the server
+ * finished writing".
+ *
+ * Returns the last (possibly empty) result when the budget runs out, so the
+ * caller's own `expect` still reports what it actually wanted.
+ */
+export async function pollDatabaseRows<T extends QueryResultRow = QueryResultRow>(
+  sql: string,
+  values: unknown[] = [],
+  { timeoutMs = 20_000, intervalMs = 500 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<T[]> {
+  const deadline = Date.now() + timeoutMs;
+  let rows: T[] = [];
+  for (;;) {
+    rows = await queryDatabaseRows<T>(sql, values).catch(() => [] as T[]);
+    if (rows.length > 0 || Date.now() >= deadline) return rows;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
 export async function seedDatabaseProject({
   accountId,
   userId,

--- a/tests/e2e/helpers/http.ts
+++ b/tests/e2e/helpers/http.ts
@@ -1,3 +1,95 @@
+/**
+ * Transient-status retry for the deployed browser lane.
+ *
+ * Release gate 32240074477 failed with staging-api answering `503
+ * MAINTENANCE_MODE` and the gateway reporting `"status":"degraded"` with an
+ * "error rate 51% over 300s" incident. None of the browser helpers retried a
+ * 5xx — only a transport throw — so a blip that cleared in seconds surfaced as
+ * either an opaque `TypeError: accounts.json.find is not a function`
+ * (a 503 body is an object, not the expected array) or an
+ * `expect(503).toBe(403)`. Both name the wrong thing.
+ *
+ * What is retried, and why it is safe:
+ *  - Any request whose body says `MAINTENANCE_MODE`. The edge rejects that
+ *    request before the origin handler runs, so repeating it cannot duplicate
+ *    a write.
+ *  - `GET`/`HEAD` on 429/502/503/504. Idempotent by definition.
+ * A non-idempotent request that reached the origin (a plain 502/504 on POST)
+ * is NOT retried — a duplicate write is worse than a red gate.
+ *
+ * A status the caller explicitly expects is never retried: `apiJson(…, 403)`
+ * asserting a refusal must not sit in a backoff loop.
+ */
+const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export function transientRetryBudgetMs(env: NodeJS.ProcessEnv = process.env): number {
+  const configured = Number.parseInt(env.E2E_TRANSIENT_RETRY_MS ?? '', 10);
+  if (Number.isFinite(configured) && configured >= 0) return configured;
+  // Only a deployed target shares its origin with the concurrent REST lane and
+  // with real traffic. Locally a 5xx is a genuine defect and must fail fast.
+  return env.KE2E_TARGET ? 60_000 : 0;
+}
+
+export function isTransientStatus(
+  method: string,
+  status: number,
+  body: string,
+  expectedStatus: number[] = [],
+): boolean {
+  if (expectedStatus.includes(status)) return false;
+  if (!RETRYABLE_STATUSES.has(status)) return false;
+  if (body.includes('MAINTENANCE_MODE')) return true;
+  return IDEMPOTENT_METHODS.has(method.toUpperCase());
+}
+
+export function transientRetryDelayMs(attempt: number): number {
+  return Math.min(1_000 * 2 ** attempt, 8_000);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface RawResponse {
+  status: number;
+  url: string;
+  body: string;
+}
+
+/**
+ * One request, retried past a transient deployed-target status.
+ *
+ * Returns the LAST response when the budget runs out, so the caller still
+ * reports the real status and body — never a synthetic error.
+ */
+export async function requestWithTransientRetry(
+  url: string,
+  init: RequestInit,
+  expectedStatus: number[] = [],
+  budgetMs: number = transientRetryBudgetMs(),
+): Promise<RawResponse> {
+  const method = (init.method ?? 'GET').toUpperCase();
+  const deadline = Date.now() + budgetMs;
+  // A transport throw keeps the 3-attempt tolerance `apiResult` always had, so
+  // a local run (budget 0) does not lose its connection-reset resilience.
+  const minTransportAttempts = 3;
+  let attempt = 0;
+  for (;;) {
+    try {
+      const response = await fetch(url, init);
+      const body = await response.text();
+      const result = { status: response.status, url: response.url || url, body };
+      if (!isTransientStatus(method, response.status, body, expectedStatus)) return result;
+      if (Date.now() >= deadline) return result;
+    } catch (error) {
+      if (attempt + 1 >= minTransportAttempts && Date.now() >= deadline) throw error;
+    }
+    await sleep(transientRetryDelayMs(attempt));
+    attempt += 1;
+  }
+}
+
 export function authHeaders(token: string): Record<string, string> {
   return {
     Authorization: `Bearer ${token}`,
@@ -26,13 +118,12 @@ export async function apiStatus(
   path: string,
   body?: Record<string, unknown>,
 ): Promise<number> {
-  const response = await fetch(`${apiBase}${path}`, {
+  const { status } = await requestWithTransientRetry(`${apiBase}${path}`, {
     method,
     headers: authHeaders(token),
     body: body === undefined ? undefined : JSON.stringify(body),
   });
-  await response.text();
-  return response.status;
+  return status;
 }
 
 export function createApiStatusClient(apiBase: string) {
@@ -52,14 +143,22 @@ export async function apiJson<T>(
   body?: Record<string, unknown>,
   expectedStatus: number | number[] = 200,
 ): Promise<T> {
-  return json<T>(
-    await fetch(`${apiBase}${path}`, {
+  const expected = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
+  const response = await requestWithTransientRetry(
+    `${apiBase}${path}`,
+    {
       method,
       headers: authHeaders(token),
       body: body === undefined ? undefined : JSON.stringify(body),
-    }),
-    expectedStatus,
+    },
+    expected,
   );
+  if (!expected.includes(response.status)) {
+    throw new Error(
+      `Expected ${expected.join('/')} from ${response.url}, got ${response.status}: ${response.body}`,
+    );
+  }
+  return response.body ? (JSON.parse(response.body) as T) : ({} as T);
 }
 
 export function createApiJsonClient(apiBase: string) {
@@ -72,6 +171,53 @@ export function createApiJsonClient(apiBase: string) {
   ): Promise<T> => apiJson<T>(apiBase, token, method, path, body, expectedStatus);
 }
 
+/**
+ * Statuses a shared deployed origin emits for reasons outside the product.
+ *
+ * `502/503/504` come from the edge, the load balancer, or the maintenance gate
+ * — never from an application code path a browser journey is asserting. Release
+ * gate 32240074477 ran while staging-api was answering `503 MAINTENANCE_MODE`
+ * and the gateway reported `"status":"degraded"`, so every journey with a
+ * blanket "no 5xx" assertion failed on the environment rather than on the
+ * product.
+ *
+ * `500` stays a hard failure: that is an unhandled exception in a route, which
+ * is exactly the class of defect these journeys exist to catch.
+ */
+export const INFRASTRUCTURE_STATUSES = new Set([502, 503, 504]);
+
+export function isProductServerError(status: number): boolean {
+  return status >= 500 && !INFRASTRUCTURE_STATUSES.has(status);
+}
+
+/**
+ * Poll one request until it answers the status the caller demands.
+ *
+ * For assertions that follow a REVOKE. `apps/api/src/iam/cache-invalidation.ts`
+ * memoizes authz lookups for ~15s and busts them **process-locally** — its own
+ * header says "each API replica busts its own cache". Staging runs several
+ * replicas behind one load balancer, so the replica that served the revoke is
+ * often not the replica that serves the next read, and the stale POSITIVE entry
+ * can answer 200 for up to one TTL window. That is correct product behavior;
+ * asserting the refusal in the very next request is what is unsound.
+ *
+ * The budget is 20s — one TTL window plus margin. Returns the last status seen,
+ * so a genuine authz regression still fails with the real status, only later.
+ */
+export async function pollApiStatus(
+  request: () => Promise<number>,
+  expected: number,
+  { timeoutMs = 20_000, intervalMs = 1_000 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  let status = await request();
+  while (status !== expected && Date.now() < deadline) {
+    await sleep(intervalMs);
+    status = await request();
+  }
+  return status;
+}
+
 export async function apiResult<T>(
   apiBase: string,
   token: string,
@@ -79,30 +225,17 @@ export async function apiResult<T>(
   path: string,
   body?: unknown,
 ): Promise<{ status: number; json: T | null }> {
-  let response: Response | null = null;
-  let lastError: unknown = null;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      response = await fetch(`${apiBase}${path}`, {
-        method,
-        headers: {
-          Authorization: `Bearer ${token}`,
-          ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
-        },
-        body: body !== undefined ? JSON.stringify(body) : undefined,
-      });
-      break;
-    } catch (error) {
-      lastError = error;
-      await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
-    }
-  }
-  if (!response) throw lastError;
-
-  const text = await response.text();
+  const response = await requestWithTransientRetry(`${apiBase}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
   let parsed: T | null = null;
   try {
-    parsed = text ? (JSON.parse(text) as T) : null;
+    parsed = response.body ? (JSON.parse(response.body) as T) : null;
   } catch {
     parsed = null;
   }

--- a/tests/e2e/specs/01-account-auth.spec.ts
+++ b/tests/e2e/specs/01-account-auth.spec.ts
@@ -1,6 +1,10 @@
 import { type Page, expect, test } from "@playwright/test";
 
-import { queryDatabaseRows, runDatabaseSql } from "../helpers/database";
+import {
+  pollDatabaseRows,
+  queryDatabaseRows,
+  runDatabaseSql,
+} from "../helpers/database";
 import {
   type AuthEmailAction,
   createDisposableInbox,
@@ -91,23 +95,34 @@ test.describe("01 - Account authentication", () => {
       await test.step("A new email receives a real signup message", async () => {
         const sentAt = await requestEmailAuthentication(page, email);
         const action = await inbox.waitForAuthAction(sentAt);
-        const accountsResponse = page.waitForResponse((response) => {
-          const url = new URL(response.url());
-          return url.pathname === "/v1/accounts" && response.status() === 200;
-        });
         await completeEmailAuthentication(page, action);
-        const accounts = (await accountsResponse).json() as Promise<
-          Array<{ account_id?: string }>
-        >;
-        for (const account of await accounts) {
-          if (account.account_id) accountIds.push(account.account_id);
-        }
-        const rows = await queryDatabaseRows<UserRow>(
+        // The account ids this test must clean up come from the database, not
+        // from a `page.waitForResponse('/v1/accounts')`.
+        //
+        // That wait was the single most frequent failure of the deployed gate:
+        // `TimeoutError: page.waitForResponse: Timeout 30000ms exceeded` on
+        // runs 32240074477 and 32231251280. It is not a product assertion —
+        // nothing was asserted about the response beyond harvesting ids the
+        // `finally` block already re-reads from `kortix.account_members`. And
+        // it is unsound as a wait: whether the freshly authenticated app
+        // issues exactly one `GET /v1/accounts` that resolves 200 inside 30s
+        // is a client cache and hydration detail, and on a staging replica
+        // answering 503 it never resolves at all.
+        //
+        // What the step actually proves is unchanged and stronger:
+        // `completeEmailAuthentication` already asserts the browser left
+        // `/auth`, and the row below proves the user exists.
+        const rows = await pollDatabaseRows<UserRow>(
           "select id::text from auth.users where lower(email) = lower($1) limit 1",
           [email],
         );
         userId = rows[0]?.id ?? null;
-        expect(userId).toBeTruthy();
+        expect(userId, `no auth.users row for ${email}`).toBeTruthy();
+        const accountRows = await queryDatabaseRows<AccountRow>(
+          "select distinct account_id::text from kortix.account_members where user_id = $1::uuid",
+          [userId],
+        ).catch(() => []);
+        for (const row of accountRows) accountIds.push(row.account_id);
       });
 
       await test.step("The test clears the browser session", async () => {

--- a/tests/e2e/specs/08-accounts-project-access.spec.ts
+++ b/tests/e2e/specs/08-accounts-project-access.spec.ts
@@ -5,6 +5,8 @@ import {
   authHeaders,
   createApiJsonClient,
   createApiStatusClient,
+  isProductServerError,
+  pollApiStatus,
 } from "../helpers/http";
 import {
   type DisposableInbox,
@@ -235,8 +237,11 @@ test.describe("08 — Accounts, invites, and project access", () => {
     page.on("response", (response) => {
       const status = response.status();
       const url = response.url();
+      // 500 only — a 502/503/504 on this shared staging origin is the edge or
+      // the maintenance gate, not a defect in the page. See
+      // `isProductServerError`.
       if (
-        status >= 500 &&
+        isProductServerError(status) &&
         (url.includes("/v1/accounts") || url.includes("/v1/projects"))
       ) {
         serverErrors.push(`${status} ${url}`);
@@ -443,11 +448,17 @@ test.describe("08 — Accounts, invites, and project access", () => {
       "DELETE",
       `/projects/${project.project_id}/access/${member.id}`,
     );
+    // Poll, do not assert instantly: the revoke is only guaranteed to be
+    // visible on the replica that served it. See `pollApiStatus`.
     expect(
-      await apiStatus(
-        memberSession.access_token,
-        "GET",
-        `/projects/${project.project_id}`,
+      await pollApiStatus(
+        () =>
+          apiStatus(
+            memberSession.access_token,
+            "GET",
+            `/projects/${project.project_id}`,
+          ),
+        403,
       ),
     ).toBe(403);
 
@@ -474,11 +485,16 @@ test.describe("08 — Accounts, invites, and project access", () => {
       `/accounts/${account.account_id}/members/${member.id}`,
       { role: "member" },
     );
+    // A demotion is a revoke: same process-local IAM cache window as above.
     expect(
-      await apiStatus(
-        memberSession.access_token,
-        "GET",
-        `/projects/${project.project_id}`,
+      await pollApiStatus(
+        () =>
+          apiStatus(
+            memberSession.access_token,
+            "GET",
+            `/projects/${project.project_id}`,
+          ),
+        403,
       ),
     ).toBe(403);
 

--- a/tests/e2e/specs/09-admin-console.spec.ts
+++ b/tests/e2e/specs/09-admin-console.spec.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { type Page, expect, test } from "@playwright/test";
 import { runDatabaseSql } from "../helpers/database";
-import { json } from "../helpers/http";
+import { INFRASTRUCTURE_STATUSES, json } from "../helpers/http";
 import {
   createAuthUser,
   deleteAuthUser,
@@ -14,6 +14,48 @@ const supabaseUrl = process.env.E2E_SUPABASE_URL || "http://127.0.0.1:54321";
 const password = process.env.E2E_ADMIN_PASSWORD || "E2eAccountAccess123!";
 const authOptions = { supabaseUrl, password, envFiles: ["apps/api/.env"] };
 
+/**
+ * Load `/admin` until the platform-admin guard actually lets the page through.
+ *
+ * `admin-shell.tsx:34` gates the whole route on `useAdminRole()`. It renders
+ * three different things and only one of them contains a single word this spec
+ * asserts:
+ *   - resolving        → a bare `<Skeleton>`, no text at all (`:40-46`)
+ *   - not an admin     → `<h1>Admin access required</h1>` (`:56-58`)
+ *   - admin            → the overview
+ * `useAdminRole` is a plain query with no `throwOnError`, so a 503 from the
+ * role probe — which is exactly what staging-api was returning during release
+ * runs 32240074477 and 32231251280 — resolves to "not an admin" and renders
+ * the refusal screen. The old code then failed on
+ * `expect(getByText('Admin overview')).toBeVisible()`, which names neither the
+ * guard nor the 503.
+ *
+ * The grant itself can also lag: the spec inserts `platform_user_roles`
+ * directly, and the replica serving the probe need not see it on the first
+ * read. Both causes clear on a retry, so retry — and when it never clears,
+ * fail naming which of the three states was actually on screen.
+ */
+async function openAdminOverview(page: Page, path: string): Promise<void> {
+  const attempts = 3;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    await page.goto(path, { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL((url) => url.pathname === path);
+    const overview = page.getByText("Admin overview").first();
+    const refused = page.getByRole("heading", {
+      name: "Admin access required",
+    });
+    // Resolve the guard's skeleton into one of its two terminal states first,
+    // so a slow probe is a wait and not a failure.
+    await expect(overview.or(refused).first()).toBeVisible({ timeout: 60_000 });
+    if (await overview.isVisible().catch(() => false)) return;
+    if (attempt < attempts) await page.waitForTimeout(5_000);
+  }
+  throw new Error(
+    `/admin still renders "Admin access required" after ${attempts} attempts: the ` +
+      `platform-admin probe never saw this user's super_admin grant.`,
+  );
+}
+
 async function assertAdminRouteClean(
   page: Page,
   path: string,
@@ -23,18 +65,23 @@ async function assertAdminRouteClean(
   const consoleErrors: string[] = [];
 
   page.on("response", (response) => {
-    if (response.status() >= 400) {
-      const url = response.url();
-      if (
-        url.includes("/_vercel/insights/") ||
-        url.includes("/_vercel/speed-insights/")
-      ) {
-        return;
-      }
-      badResponses.push(
-        `${response.status()} ${response.request().method()} ${response.url()}`,
-      );
+    const status = response.status();
+    if (status < 400) return;
+    const url = response.url();
+    if (
+      url.includes("/_vercel/insights/") ||
+      url.includes("/_vercel/speed-insights/")
+    ) {
+      return;
     }
+    // 502/503/504 on this shared staging origin is the edge or the maintenance
+    // gate, not a defect in the admin console. `openAdminOverview` already
+    // retries past it; asserting on it here would just re-fail the lane for the
+    // environment. A 500 — an unhandled exception in a route — still counts.
+    if (INFRASTRUCTURE_STATUSES.has(status)) return;
+    badResponses.push(
+      `${status} ${response.request().method()} ${response.url()}`,
+    );
   });
   page.on("console", (message) => {
     if (message.type() === "error") {
@@ -50,8 +97,14 @@ async function assertAdminRouteClean(
     }
   });
 
-  await page.goto(path, { waitUntil: "domcontentloaded" });
-  await expect(page).toHaveURL((url) => url.pathname === path);
+  // First pass: get the guard to let us in. Any attempt here may have raced a
+  // degraded replica, so nothing it recorded is evidence about the product.
+  await openAdminOverview(page, path);
+  badResponses.length = 0;
+  consoleErrors.length = 0;
+
+  // Second pass: this is the load the assertions below judge.
+  await openAdminOverview(page, path);
 
   for (const text of expectedTexts) {
     await expect(page.getByText(text).first()).toBeVisible();

--- a/tests/e2e/specs/10-billing-journey.spec.ts
+++ b/tests/e2e/specs/10-billing-journey.spec.ts
@@ -72,7 +72,13 @@ test.describe
     }) => {
       const billingUrl = `/accounts/${accountId}?tab=billing`;
       await installBrowserSessionDirect(page, session, billingUrl, authOptions);
-      await expect(page.getByRole('heading', { name: 'Billing' })).toBeVisible();
+      // The pane heading is "Plan", not "Billing". `?tab=billing` is still the
+      // route, and "Billing" is still the nav GROUP label, but the pane itself
+      // renders `PANE_META.billing.title` = 'Plan' as an `<h2>`
+      // (`app/(app)/accounts/[id]/page.tsx:224` and `:577`). "Billing" survives
+      // only as a group label, which is not a heading — so the old locator
+      // could never resolve and failed at 0 ms on every release run.
+      await expect(page.getByRole('heading', { name: 'Plan', exact: true })).toBeVisible();
 
       await test.step('The owner starts Team checkout from the Billing page', async () => {
         await page.getByRole('button', { name: 'Subscribe to Team' }).click();
@@ -114,16 +120,22 @@ test.describe
       });
 
       await test.step('The owner starts a one-time credit purchase', async () => {
-        // The topup button's accessible name is "$10 1,000 credits" (two spans:
-        // amount + credits), so an exact "$10" never matches. Anchor on the
-        // leading amount instead of pinning the whole composite label.
-        await page.getByRole('button', { name: /^\$10\b/ }).click();
+        // `credit-topup-section.tsx` replaced the old amount+credits buttons
+        // with a radiogroup of preset amounts. `AmountCell` is a `<button>`
+        // carrying an explicit `role="radio"` (`:260-263`), and an explicit
+        // role wins, so `getByRole('button', …)` can no longer see it. The
+        // cell's whole accessible name is now just the amount (`:175`).
+        const topup = page.getByRole('radiogroup', { name: 'Top-up amount' });
+        await topup.getByRole('radio', { name: '$10', exact: true }).click();
         const purchaseResponsePromise = page.waitForResponse(
           (response) =>
             response.request().method() === 'POST' &&
             new URL(response.url()).pathname === '/v1/billing/purchase-credits',
         );
-        await page.getByRole('button', { name: 'Buy $10 in credits' }).click();
+        // The CTA is `actionLabel` (`credit-topup-section.tsx:82-84`): "Add $10"
+        // once an amount is chosen, "Add credits" before that. "Buy $10 in
+        // credits" is gone.
+        await page.getByRole('button', { name: 'Add $10', exact: true }).click();
         const purchaseResponse = await purchaseResponsePromise;
         expect(purchaseResponse.status()).toBe(200);
         expect(purchaseResponse.request().postDataJSON()).toMatchObject({

--- a/tests/e2e/specs/12-sandbox-templates.spec.ts
+++ b/tests/e2e/specs/12-sandbox-templates.spec.ts
@@ -20,6 +20,7 @@
 
 import { randomUUID } from "node:crypto";
 import { type Page, expect, test } from "@playwright/test";
+import { resolvePersonalAccountId } from "../helpers/accounts";
 import { seedDatabaseProject } from "../helpers/database";
 import { createApiResultClient } from "../helpers/http";
 import {
@@ -43,12 +44,6 @@ const password = "E2eSandboxTpl123!";
 const api = createApiResultClient(apiBase);
 const authOptions = { supabaseUrl, password };
 
-interface AccountSummary {
-  account_id: string;
-  personal_account?: boolean;
-  is_primary_owner?: boolean;
-  account_role?: "owner" | "admin" | "member";
-}
 interface TemplateCreateResult {
   template_id: string;
   slug: string;
@@ -86,20 +81,7 @@ test.describe("12 — Sandbox templates UI", () => {
     user = await createAuthUser(email, authOptions);
     session = await signIn(email, authOptions);
     const projectName = `e2e-ui-tpl-${runId}`;
-    const accounts = await api<AccountSummary[]>(
-      session.access_token,
-      "GET",
-      "/accounts",
-    );
-    const personalAccount = accounts.json?.find(
-      (account) =>
-        account.personal_account ||
-        account.is_primary_owner ||
-        account.account_role === "owner",
-    );
-    expect(personalAccount?.account_id).toBeTruthy();
-    if (!personalAccount) throw new Error("test user has no personal account");
-    accountId = personalAccount.account_id;
+    accountId = await resolvePersonalAccountId(api, session.access_token);
     projectId = await seedDatabaseProject({
       accountId,
       userId: user.id,
@@ -176,13 +158,16 @@ test.describe("12 — Sandbox templates UI", () => {
 
     // Every available provider reports its real launch state. A local stack can
     // legitimately report Not ready when no provider snapshot exists.
+    //
+    // The pinned provider renders `Daytona•Selected•Ready`, not `Daytona•Ready`
+    // (`sandbox-provider-coverage.tsx:119-126`), so the optional `Selected`
+    // segment is part of the contract — without it this assertion silently
+    // depends on the project never pinning a provider.
     const launchState = "Ready|Building|Failed|Not ready|Unavailable|Unknown";
-    await expect(platformRow).toContainText(
-      new RegExp(`Daytona[^A-Za-z]*(?:${launchState})`),
-    );
-    await expect(platformRow).toContainText(
-      new RegExp(`Platinum[^A-Za-z]*(?:${launchState})`),
-    );
+    const providerState = (provider: string) =>
+      new RegExp(`${provider}(?:[^A-Za-z]*Selected)?[^A-Za-z]*(?:${launchState})`);
+    await expect(platformRow).toContainText(providerState("Daytona"));
+    await expect(platformRow).toContainText(providerState("Platinum"));
 
     expect(pageErrors, `client errors: ${pageErrors.join(" | ")}`).toEqual([]);
   });

--- a/tests/e2e/specs/13-connector-oauth2.spec.ts
+++ b/tests/e2e/specs/13-connector-oauth2.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { resolvePersonalAccountId } from "../helpers/accounts";
 import { seedDatabaseProject } from "../helpers/database";
 import { createApiResultClient } from "../helpers/http";
 import {
@@ -17,13 +18,6 @@ const password = "E2eConnectorOauth123!";
 const api = createApiResultClient(apiBase);
 const authOptions = { supabaseUrl, password };
 
-interface AccountSummary {
-  account_id: string;
-  personal_account?: boolean;
-  is_primary_owner?: boolean;
-  account_role?: "owner" | "admin" | "member";
-}
-
 test.describe("13 — Custom connector OAuth2", () => {
   test.setTimeout(180_000);
 
@@ -36,20 +30,7 @@ test.describe("13 — Custom connector OAuth2", () => {
     const email = `e2e-connector-oauth-${Date.now()}@kortix.test`;
     user = await createAuthUser(email, authOptions);
     session = await signIn(email, authOptions);
-    const accounts = await api<AccountSummary[]>(
-      session.access_token,
-      "GET",
-      "/accounts",
-    );
-    const personalAccount = accounts.json?.find(
-      (account) =>
-        account.personal_account ||
-        account.is_primary_owner ||
-        account.account_role === "owner",
-    );
-    expect(personalAccount?.account_id).toBeTruthy();
-    if (!personalAccount) throw new Error("test user has no personal account");
-    accountId = personalAccount.account_id;
+    accountId = await resolvePersonalAccountId(api, session.access_token);
     projectId = await seedDatabaseProject({
       accountId,
       userId: user.id,

--- a/tests/e2e/specs/17-oauth-provider-initiation.spec.ts
+++ b/tests/e2e/specs/17-oauth-provider-initiation.spec.ts
@@ -4,7 +4,32 @@ const frontendUrl = process.env.E2E_BASE_URL || 'http://localhost:3000';
 const supabaseUrl = process.env.E2E_SUPABASE_URL || 'http://127.0.0.1:54321';
 const verifyOAuthProviders = process.env.E2E_OAUTH_PROVIDER_INITIATION === '1';
 
-test.describe('17 — OAuth provider initiation', () => {
+/**
+ * QUARANTINED — runs in `tests-browser-nightly.yml`, not in the release gate.
+ *
+ * This is the only browser journey whose assertions depend on servers Kortix
+ * does not operate: it clicks through to `accounts.google.com` and
+ * `github.com` and asserts what those pages do. Three consequences make it
+ * unfit for a blocking gate, and none of them are fixable from this repo:
+ *
+ *  1. It failed in every observed release run — 32240074477 and 32231251280 —
+ *     at 2.2 min and 32 s, on `page.waitForURL`/`waitForRequest` against a
+ *     third-party redirect chain. Google and GitHub are free to add an interstitial,
+ *     a consent screen, or a bot check at any time, and each of those turns the
+ *     production release gate red with no Kortix defect behind it.
+ *  2. It is the slowest pair in the lane. Two tests spend up to 30 s each in
+ *     `waitForURL` plus a full third-party page load.
+ *  3. `playwright.config.ts` puts `x-vercel-protection-bypass` in
+ *     `extraHTTPHeaders`, which applies to EVERY origin the page touches — so
+ *     this spec is also the one journey that sends the staging bypass secret to
+ *     Google and GitHub.
+ *
+ * What it protects is still worth running: that Supabase's authorize endpoint
+ * hands the provider the callback URI the provider has registered — the
+ * `redirect_uri_mismatch` class of outage. That check just belongs on a
+ * schedule with an owner, not between a release and production.
+ */
+test.describe('17 — OAuth provider initiation', { tag: '@quarantine' }, () => {
   test.skip(
     !verifyOAuthProviders,
     'Set E2E_OAUTH_PROVIDER_INITIATION=1 for the deployed OAuth gate.',

--- a/tests/e2e/strict-skip-reporter.ts
+++ b/tests/e2e/strict-skip-reporter.ts
@@ -8,6 +8,16 @@
  * required capability up front, so on the strict lane a missing capability now
  * fails in seconds and never reaches a skip. What remains here is the genuine
  * case: a journey excluded for a reason the setup could not predict.
+ *
+ * A `@quarantine` journey is NOT such a case, and does not need an allowance
+ * here. `playwright.config.ts` turns `E2E_EXCLUDE_TAGS` into `grepInvert`, and
+ * Playwright applies grep at COLLECTION — before sharding, before any hook, and
+ * before this reporter exists. An excluded journey therefore produces no
+ * `TestCase` and no `onTestEnd` call at all: it is absent from the run, not
+ * skipped in it, so `this.skipped` never sees it and the lane stays green
+ * without weakening the strict rule for anything else. Verified by
+ * `playwright test --list`: 21 tests bare, 19 with `E2E_EXCLUDE_TAGS`, and
+ * exactly the 2 quarantined tests with `E2E_INCLUDE_TAGS`.
  */
 import type { FullResult, Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 import { mkdir, writeFile } from 'node:fs/promises';

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -29,6 +29,68 @@ export function resolveBrowserWorkers(value: string | undefined, ci: boolean): n
 
 const workers = resolveBrowserWorkers(process.env.E2E_BROWSER_WORKERS, Boolean(process.env.CI));
 
+export interface GrepFilters {
+  grep?: RegExp;
+  grepInvert?: RegExp;
+}
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function splitList(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function union(sources: string[]): RegExp | undefined {
+  if (sources.length === 0) return undefined;
+  return new RegExp(sources.join('|'));
+}
+
+/**
+ * Tag and title filters for the browser lane, read from the environment.
+ *
+ * A journey that cannot be made deterministic against a deployed target is
+ * tagged `@quarantine` at its `test.describe`. The blocking release gate
+ * excludes that tag; `tests-browser-nightly.yml` runs exactly that tag and
+ * nothing else. Both directions come from here so neither lane needs a custom
+ * command line.
+ *
+ * - `E2E_EXCLUDE_TAGS` / `E2E_INCLUDE_TAGS` — comma-separated tag or title
+ *   fragments. Each entry is escaped, so `@quarantine` matches literally and
+ *   cannot be read as a regex by accident.
+ * - `E2E_GREP_INVERT` / `E2E_GREP` — raw regex escape hatches, unioned with the
+ *   tag lists in the same direction.
+ *
+ * Playwright appends a test's tags to the title it matches `grep`/`grepInvert`
+ * against, and it applies both BEFORE `--shard`, so an excluded journey is
+ * never loaded, never counted, and never lands in a shard. That is what keeps
+ * `strict-skip-reporter.ts` coherent: the reporter fails the lane on a
+ * `status === 'skipped'` result, and a grep-excluded test produces no result at
+ * all — it is absent, not skipped.
+ */
+export function resolveGrepFilters(env: NodeJS.ProcessEnv = process.env): GrepFilters {
+  const includes = [
+    ...splitList(env.E2E_INCLUDE_TAGS).map(escapeForRegExp),
+    ...splitList(env.E2E_GREP),
+  ];
+  const excludes = [
+    ...splitList(env.E2E_EXCLUDE_TAGS).map(escapeForRegExp),
+    ...splitList(env.E2E_GREP_INVERT),
+  ];
+  const filters: GrepFilters = {};
+  const grep = union(includes);
+  const grepInvert = union(excludes);
+  if (grep) filters.grep = grep;
+  if (grepInvert) filters.grepInvert = grepInvert;
+  return filters;
+}
+
+const grepFilters = resolveGrepFilters(process.env);
+
 // A deployed target (staging/preview) shares one origin with the concurrent
 // REST lane, so transient overload (5xx laundered into MAINTENANCE_MODE by the
 // edge) shows up as slow/empty page loads. Give deployed runs more retries and
@@ -49,6 +111,7 @@ const deployedRetries = Number(process.env.E2E_DEPLOYED_RETRIES ?? 1);
 
 export default defineConfig({
   testDir: './e2e/specs',
+  ...grepFilters,
   // Fails the strict deployed lane in seconds when a required capability is
   // missing, instead of skipping mid-run and reporting it ~50 min later. No-op
   // when E2E_REQUIRE_ALL_BROWSER is unset. See e2e/global-setup.ts.

--- a/tests/unit/browser-grep-filters.test.ts
+++ b/tests/unit/browser-grep-filters.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveGrepFilters } from '../playwright.config';
+
+describe('browser lane grep filters', () => {
+  it('applies no filter when the environment names none', () => {
+    expect(resolveGrepFilters({})).toEqual({});
+  });
+
+  it('excludes a quarantined tag for the blocking gate', () => {
+    const { grep, grepInvert } = resolveGrepFilters({ E2E_EXCLUDE_TAGS: '@quarantine' });
+    expect(grep).toBeUndefined();
+    expect(grepInvert?.source).toBe('@quarantine');
+    expect(grepInvert?.test('17 — OAuth provider initiation @quarantine')).toBe(true);
+    expect(grepInvert?.test('09 - Admin console › admin opens the current overview')).toBe(false);
+  });
+
+  it('selects only the quarantined tag for the nightly lane', () => {
+    const { grep, grepInvert } = resolveGrepFilters({ E2E_INCLUDE_TAGS: '@quarantine' });
+    expect(grepInvert).toBeUndefined();
+    expect(grep?.test('17 — OAuth provider initiation @quarantine')).toBe(true);
+    expect(grep?.test('19 — Feature flags UI › lists every available flag')).toBe(false);
+  });
+
+  it('escapes each tag so a list entry is never read as a regex', () => {
+    const { grepInvert } = resolveGrepFilters({ E2E_EXCLUDE_TAGS: '@quarantine, @slow(deployed)' });
+    expect(grepInvert?.source).toBe('@quarantine|@slow\\(deployed\\)');
+    expect(grepInvert?.test('journey @slow(deployed)')).toBe(true);
+    expect(grepInvert?.test('journey @slowXdeployedX')).toBe(false);
+  });
+
+  it('unions the raw regex escape hatch with the tag list', () => {
+    const { grepInvert } = resolveGrepFilters({
+      E2E_EXCLUDE_TAGS: '@quarantine',
+      E2E_GREP_INVERT: '^17 —',
+    });
+    expect(grepInvert?.source).toBe('@quarantine|^17 —');
+    expect(grepInvert?.test('17 — OAuth provider initiation')).toBe(true);
+  });
+
+  it('ignores empty and whitespace-only entries', () => {
+    expect(resolveGrepFilters({ E2E_EXCLUDE_TAGS: '  ,, ', E2E_GREP: '' })).toEqual({});
+  });
+});

--- a/tests/unit/browser-transient-retry.test.ts
+++ b/tests/unit/browser-transient-retry.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isProductServerError,
+  isTransientStatus,
+  pollApiStatus,
+  transientRetryBudgetMs,
+  transientRetryDelayMs,
+} from '../e2e/helpers/http';
+
+describe('deployed-target transient statuses', () => {
+  it('retries any request the maintenance gate rejected', () => {
+    // The edge refuses before the origin handler runs, so repeating a POST
+    // cannot duplicate a write.
+    expect(isTransientStatus('POST', 503, '{"error":"MAINTENANCE_MODE"}')).toBe(true);
+    expect(isTransientStatus('DELETE', 503, '{"error":"MAINTENANCE_MODE"}')).toBe(true);
+  });
+
+  it('retries an idempotent request on a plain edge failure', () => {
+    expect(isTransientStatus('GET', 502, 'bad gateway')).toBe(true);
+    expect(isTransientStatus('GET', 504, '')).toBe(true);
+    expect(isTransientStatus('GET', 429, '')).toBe(true);
+  });
+
+  it('never repeats a non-idempotent request that reached the origin', () => {
+    // A duplicated write is worse than a red gate.
+    expect(isTransientStatus('POST', 502, 'bad gateway')).toBe(false);
+    expect(isTransientStatus('PATCH', 504, '')).toBe(false);
+  });
+
+  it('leaves a real product status alone', () => {
+    expect(isTransientStatus('GET', 403, '')).toBe(false);
+    expect(isTransientStatus('GET', 500, 'boom')).toBe(false);
+    expect(isTransientStatus('GET', 200, '[]')).toBe(false);
+  });
+
+  it('never retries a status the caller explicitly expects', () => {
+    // `apiJson(…, 503)` asserting a maintenance response must not sit in a
+    // backoff loop.
+    expect(isTransientStatus('GET', 503, 'MAINTENANCE_MODE', [503])).toBe(false);
+  });
+
+  it('spends a retry budget only against a deployed target', () => {
+    expect(transientRetryBudgetMs({ KE2E_TARGET: 'staging' })).toBe(60_000);
+    // Locally a 5xx is a genuine defect and must fail fast.
+    expect(transientRetryBudgetMs({})).toBe(0);
+    expect(transientRetryBudgetMs({ KE2E_TARGET: 'staging', E2E_TRANSIENT_RETRY_MS: '5000' })).toBe(
+      5_000,
+    );
+    expect(transientRetryBudgetMs({ KE2E_TARGET: 'staging', E2E_TRANSIENT_RETRY_MS: '0' })).toBe(0);
+  });
+
+  it('backs off exponentially and caps the delay', () => {
+    expect(transientRetryDelayMs(0)).toBe(1_000);
+    expect(transientRetryDelayMs(1)).toBe(2_000);
+    expect(transientRetryDelayMs(3)).toBe(8_000);
+    expect(transientRetryDelayMs(9)).toBe(8_000);
+  });
+});
+
+describe('product versus infrastructure server errors', () => {
+  it('treats 500 as a defect the journey must catch', () => {
+    expect(isProductServerError(500)).toBe(true);
+  });
+
+  it('treats an edge failure as environment, not product', () => {
+    expect(isProductServerError(502)).toBe(false);
+    expect(isProductServerError(503)).toBe(false);
+    expect(isProductServerError(504)).toBe(false);
+  });
+
+  it('ignores anything below 500', () => {
+    expect(isProductServerError(403)).toBe(false);
+    expect(isProductServerError(200)).toBe(false);
+  });
+});
+
+describe('polling a revoke past the IAM cache window', () => {
+  it('returns as soon as the expected status appears', async () => {
+    const statuses = [200, 200, 403];
+    let calls = 0;
+    const result = await pollApiStatus(
+      async () => statuses[calls++] ?? 403,
+      403,
+      { timeoutMs: 5_000, intervalMs: 1 },
+    );
+    expect(result).toBe(403);
+    expect(calls).toBe(3);
+  });
+
+  it('reports the real status when the budget runs out', async () => {
+    // A genuine authz regression must still fail — only later.
+    const result = await pollApiStatus(async () => 200, 403, { timeoutMs: 10, intervalMs: 1 });
+    expect(result).toBe(200);
+  });
+});


### PR DESCRIPTION
## Problem

The sharded release gate's browser lane failed in every run tonight while the API lane reached 87-88%. Runs read: 32240074477, 32231251280, 32151213430.

Reading the shard logs, **the dominant cause is not the product.** During those windows staging-api answered `503 MAINTENANCE_MODE` and the gateway health reported `"status":"degraded"` with an `error rate 51% over 300s` incident. The browser lane had no way to tell an environment fault from a defect, and several specs converted a transient 503 into an error that named something else entirely — `TypeError: accounts.json.find is not a function`, `expect(503).toBe(403)`, `element not found`.

Two genuine test defects sat underneath: one stale selector set from the billing pane rebuild, and one assertion that races a documented product behaviour.

## Per-spec

| Spec | Root cause | Action | Evidence |
| --- | --- | --- | --- |
| `01-account-auth` | `page.waitForResponse('/v1/accounts' && 200)` timed out at 30 s. It was never an assertion — it harvested account ids the `finally` block already re-reads from `kortix.account_members`. Whether the freshly authenticated app issues exactly one such request that resolves 200 inside 30 s is a client cache/hydration detail, and against a replica answering 503 it never resolves. | **Hardened** — wait deleted; ids read from the database via the new `pollDatabaseRows`. What the step proves is unchanged: `completeEmailAuthentication` already asserts the browser left `/auth`. | `TimeoutError: page.waitForResponse: Timeout 30000ms exceeded` in runs 32240074477 and 32231251280 |
| `08-accounts-project-access` | Two `expect(...).toBe(403)` fire in the request immediately after a revoke/demotion. `apps/api/src/iam/cache-invalidation.ts` memoizes authz for ~15 s and busts it **process-locally** — its own header says "each API replica busts its own cache". On multi-replica staging the replica serving the revoke is often not the one serving the next read. Separately, a blanket `status >= 500` recorder failed on edge 503s. | **Hardened** — both assertions poll via `pollApiStatus` (20 s > one TTL window); the recorder narrowed to `isProductServerError`. | `cache-invalidation.ts:1-19`; `Expected: 403 / Received: 200` |
| `09-admin-console` | `admin-shell.tsx:34` gates `/admin` on `useAdminRole()`, which has **no `throwOnError`**. A 503 from the role probe resolves to "not an admin" and renders `<h1>Admin access required</h1>`; a slow probe renders a textless `<Skeleton>`. The spec asserted `getByText('Admin overview')` and named neither. | **Hardened** — new `openAdminOverview` resolves the guard to a terminal state (`overview.or(refused)`), retries 3×, and fails naming which state was on screen. Recorders reset after the guard clears, and ignore `502/503/504`. | `admin-shell.tsx:40-46, :56-58`; `app/admin/page.tsx:38` |
| `10-billing-journey` | **Genuinely stale selectors** from the billing pane rebuild. (a) Pane heading is `Plan`, not `Billing` — "Billing" survives only as a nav *group* label, which is not a heading. (b) The `$10` preset is now `role="radio"` inside a `Top-up amount` radiogroup; an explicit role wins, so `getByRole('button')` cannot see it. (c) The CTA is `Add $10`; `Buy $10 in credits` no longer exists. | **Hardened** — all three selectors updated. | `accounts/[id]/page.tsx:224,:577`; `credit-topup-section.tsx:161-162,:175,:260-263,:82-84` |
| `12-sandbox-templates` | Setup crashed with `TypeError: accounts.json.find is not a function` — a 503 body is an object, not the expected array. Latent second bug: a pinned provider renders `Daytona•Selected•Ready`, which `Daytona[^A-Za-z]*(Ready\|…)` cannot match. | **Hardened** — new `resolvePersonalAccountId` asserts status + shape first; provider regex accepts the optional `Selected` segment. | `12-sandbox-templates.spec.ts:94` in 32231251280; `sandbox-provider-coverage.tsx:119-126` |
| `13-connector-oauth2` | **Every selector audited and still current** — the Customize sidebar link, the index card, the dialog, both comboboxes, all five strategies and all labelled fields. The failure was the outage; `ERR_CONNECTION_REFUSED` in PR-CI is a different, local-stack symptom. | **Unchanged** (setup now benefits from the shared retry) | `project-settings-nav.tsx:214,:233`; `connectors-page.tsx:596-604,:775`; `connector-oauth2-fields.tsx:33,:46,:56,:61,:65-69,:76,:86,:106` |
| `17-oauth-provider-initiation` | Clicks through to `accounts.google.com` and `github.com` and asserts what those pages do. Not fixable from this repo: Google/GitHub may add an interstitial at any time; it is the slowest pair in the lane (2.2 m / 32 s); and it is the one journey that sends the staging `x-vercel-protection-bypass` header to Google and GitHub, because `extraHTTPHeaders` applies to every origin. | **Quarantined** → `@quarantine`, runs nightly | failed in both observed release runs |
| `18-apps-ui` | **Every selector audited and still current** (14 of 14: heading, gate copy, the Feature-flags link, card, modal, versions, copy button, close). | **Unchanged** | `apps-view.tsx:392,464,510-513,276,549,619,659,688,711,696-702,775`; `feature-gate-screen.tsx:48-50,:56`; `copy-button.tsx:42` |
| `19-feature-flags-ui` | **Every selector audited and still current**, including the `div.divide-y > div` row shape `featureFlagRow` depends on. The `MAINTENANCE_MODE` 503 seen once is the outage. | **Unchanged** | `project-settings-page.tsx:445`; `experimental-tab.tsx:171,:174-176,:177-179,:180,:186-191,:314`; `project-settings-sections.ts:110` |

`20-workspace-switching` was also audited while in the area — `Switch workspace` still resolves inside `data-slot="sidebar"` (`workspace-switcher.tsx:135-137`, `sidebar.tsx:225`). Unchanged.

## Mechanism

`playwright.config.ts` gains `resolveGrepFilters`, turning four env vars into `grep`/`grepInvert`:

| Variable | Direction | Value |
| --- | --- | --- |
| `E2E_EXCLUDE_TAGS` | exclude | comma-separated tags, each regex-escaped |
| `E2E_INCLUDE_TAGS` | include | comma-separated tags, each regex-escaped |
| `E2E_GREP_INVERT` | exclude | raw regex |
| `E2E_GREP` | include | raw regex |

**Reporter coherence.** Playwright applies grep at *collection* — before sharding, before any hook, before the reporter exists. An excluded journey produces no `TestCase` and no `onTestEnd`, so it is **absent, not skipped**. `strict-skip-reporter.ts` fails on a `skipped` *result*, so it stays strict for everything else with no logic change (documentation only).

`.github/workflows/tests-browser-nightly.yml` runs exactly `@quarantine` against the same staging origin, copying tests-release's top-level env block. Cron 04:20 UTC + `workflow_dispatch`. Required by no branch; uploads its report. Removing a tag returns a journey to the gate with no workflow edit.

## Deployed-target resilience (shared helpers)

- `helpers/http.ts` retries `429/502/503/504` for up to 60 s on a deployed target (0 locally, `E2E_TRANSIENT_RETRY_MS`). It retries **any** request the maintenance gate rejected — the edge refuses before the origin handler runs, so a repeat cannot duplicate a write — and otherwise **only idempotent methods**. A non-idempotent request that reached the origin is never repeated. A status the caller expects is never retried.
- `isProductServerError` splits `500` (a defect) from `502/503/504` (the edge).
- `pollApiStatus` / `pollDatabaseRows` for read-after-write and read-after-revoke.

## Required change to `tests-release.yml` (owned by W1a — I did not touch it)

Add **one line** to the `browser` job's existing `env:` block (alongside `E2E_BROWSER_WORKERS: '1'`):

```yaml
      E2E_EXCLUDE_TAGS: '@quarantine'
```

Without it the gate still runs spec 17 and nothing else regresses — the mechanism is opt-in.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --dir tests test:unit` | **281/281 pass**, 35 files (18 new tests in 2 new files) |
| `playwright test --list` | 21 tests / 15 files |
| `E2E_EXCLUDE_TAGS='@quarantine' … --list` | **19 tests / 14 files** |
| `E2E_INCLUDE_TAGS='@quarantine' … --list` | **exactly the 2 spec-17 tests** |
| `E2E_EXCLUDE_TAGS='@quarantine' … --list --shard=1/3` | 7 tests / 6 files — sharding balances after exclusion |
| `actionlint tests-browser-nightly.yml` | clean, exit 0 |
| `pnpm --dir tests typecheck` | only `src/flows/iam.flow.ts(1739,41)`, **pre-existing on main** (confirmed by stashing this diff); zero new errors |

## Not verified, and why

- **No run against live staging.** `staging.kortix.com` is behind Vercel SSO (`/auth` 302s to `vercel.com/sso-api`) and `VERCEL_AUTOMATION_BYPASS_SECRET` is a CI secret I cannot read. The next release-gate run is the first real execution.
- **No local browser run.** The machine was at 12.6 GiB of 14 GiB swap with several worktree stacks live; starting another deterministic stack risked OOMing concurrent work. Selector claims above are therefore **static** — read from the current `apps/web/src` with file:line — not executed.
- Spec 09 **cannot detect an ops-overview outage**: `app/admin/page.tsx:38` destructures only `data`, so the page renders placeholders (`API "..."`, `Accounts 0`) and passes either way. Pre-existing coverage gap, deliberately not widened here — tightening it would make the gate *more* fragile, which is the opposite of this PR's goal.
