### PR TITLE
feat(email): one EMAIL_URL configures every email Kortix sends

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -49,6 +49,38 @@ fetch → bundled floor; await cap), `managed-scope.test.ts`; web: sync-store
 per-turn `session.error` tests. Not enforced: a live "picker ⊆ guest provider
 map" assertion after deploy — run the dev sweep by hand until it exists.
 
+### `KORTIX_SELF_HOST_CONFIG_DIR` isolates the config, NOT the containers (2026-08-19)
+
+**When:** exercising `kortix self-host` locally on a machine that already runs a
+self-host instance. Pointing `KORTIX_SELF_HOST_CONFIG_DIR` at a temp directory
+looks like a sandbox — `init` writes a fresh `.env` + compose there and touches
+nothing else. But `composeProject(instance)` derives the Docker Compose project
+name from the INSTANCE NAME alone (`kortix-<instance>`), so any command that
+reaches `docker compose` — `env set`, `start`, `update`, `configure` — applies
+the temp config to the containers of the REAL instance of the same name.
+`env set EMAIL_URL=…` against a temp dir recreated the live instance's
+`kortix-api` (×2, from the temp `KORTIX_APP_REPLICAS`) and `supabase-auth` with
+the temp instance's secrets.
+
+The rule: when testing self-host CLI commands against a throwaway config dir,
+**also pass `--instance <unique-name>`** — that is the only input that moves the
+Compose project. Verify with `docker ps --filter name=kortix-<instance>` BEFORE
+running anything that restarts services, and prefer `--no-start` plus reading
+the rendered `.env`/`docker-compose.yml` when you only need to inspect
+derivation.
+
+Recovery: re-apply the real instance's own files —
+`docker compose --project-name kortix-<instance> --env-file <real>/.env -f
+<real>/docker-compose.yml up -d --no-build` — then prove identity by diffing a
+secret from the real `.env` against `docker exec … printenv`, not by health
+alone (a container started from foreign config is perfectly healthy).
+*Incident:* 2026-08-19 near-miss during the EMAIL_URL work — the local
+`kortix-default` instance (16 containers, up 16 h) had 3 containers recreated
+with a temp instance's secrets; restored in ~4 min, all 16 healthy after.
+*Enforcer:* none — the CLI should either namespace the Compose project by the
+config dir or refuse when the resolved project already exists under a different
+instance directory. Until then this rule is the only guard.
+
 ### A request/response log must never cap what it captures (2026-08-18)
 
 **When:** persisting or rendering a captured request/response body (gateway

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,6 +42,7 @@
     "hono": "^4.4.0",
     "jose": "^5.9.6",
     "livekit-server-sdk": "^2.17.0",
+    "nodemailer": "^7.0.0",
     "oauth4webapi": "^3.8.7",
     "postgres": "^3.4.8",
     "re2js": "2.8.6",
@@ -56,6 +57,7 @@
     "@kortix/sdk": "workspace:*",
     "@smithy/signature-v4": "5.6.2",
     "@types/bun": "^1.3.12",
+    "@types/nodemailer": "^8.0.1",
     "bun-types": "^1.3.12",
     "typescript": "^5.4.0"
   }

--- a/apps/api/src/accounts/email.ts
+++ b/apps/api/src/accounts/email.ts
@@ -1,86 +1,26 @@
-// Account-scoped invite email. Rendering lives here; delivery goes through the
-// shared provider-chain transport (lib/email/transport.ts).
+// Account- and project-scoped invite / access-request email. Rendering uses the
+// shared Kortix email shell (lib/email/template.ts); delivery goes through the
+// one platform transport (lib/email/transport.ts).
 import { config } from '../config';
+import { escapeHtml, renderEmail, renderText, actionButton, S } from '../lib/email/template';
 import { isEmailConfigured, sendEmail, type EmailSendResult } from '../lib/email/transport';
 
-const BRAND_WORDMARK = 'Kortix';
-const BRAND_FOOTER = 'Kortix — The Autonomous Company Operating System';
-
 export type EmailDeliveryResult = EmailSendResult;
-
-const COLOR_BG = '#f6f7f9';
-const COLOR_CARD = '#ffffff';
-const COLOR_BORDER = '#e5e7eb';
-const COLOR_TEXT = '#111111';
-const COLOR_MUTED = '#6b7280';
-const COLOR_ACCENT = '#111111';
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
-
-const S = {
-  wrapper: `margin:0;padding:0;background:${COLOR_BG};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;`,
-  outerTable: `width:100%;background:${COLOR_BG};`,
-  container: `max-width:520px;margin:40px auto;background:${COLOR_CARD};border-radius:14px;border:1px solid ${COLOR_BORDER};overflow:hidden;`,
-  header: `padding:28px 32px 0;text-align:center;`,
-  wordmark: `font-size:15px;font-weight:700;letter-spacing:0.5px;color:${COLOR_TEXT};margin:0;`,
-  body: `padding:18px 32px 36px;text-align:center;`,
-  kicker: `font-size:11px;color:${COLOR_MUTED};letter-spacing:0.2em;text-transform:uppercase;margin:24px 0 8px;`,
-  h1: `font-size:22px;line-height:1.25;font-weight:600;color:${COLOR_TEXT};margin:0 0 12px;`,
-  p: `font-size:14px;line-height:1.6;color:${COLOR_MUTED};margin:0 0 24px;`,
-  strong: `color:${COLOR_TEXT};font-weight:600;`,
-  chipWrap: `margin:0 0 28px;`,
-  chip: `display:inline-block;padding:4px 10px;border-radius:999px;border:1px solid ${COLOR_BORDER};font-size:11px;color:${COLOR_MUTED};letter-spacing:0.06em;text-transform:uppercase;`,
-  btn: `display:inline-block;padding:12px 28px;background:${COLOR_ACCENT};color:#ffffff;text-decoration:none;border-radius:10px;font-size:14px;font-weight:500;`,
-  footer: `padding:18px 32px;text-align:center;border-top:1px solid ${COLOR_BORDER};background:${COLOR_CARD};`,
-  footerP: `font-size:12px;color:#9ca3af;margin:0;`,
-  smallNote: `font-size:12px;color:${COLOR_MUTED};margin:24px 0 0;`,
-};
-
-function renderEmail(opts: { kicker?: string; title: string; body: string }): string {
-  return `<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>${escapeHtml(opts.title)}</title>
-  </head>
-  <body style="${S.wrapper}">
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="${S.outerTable}">
-      <tr>
-        <td align="center">
-          <div style="${S.container}">
-            <div style="${S.header}">
-              <p style="${S.wordmark}">${BRAND_WORDMARK}</p>
-            </div>
-            <div style="${S.body}">
-              ${opts.kicker ? `<div style="${S.kicker}">${escapeHtml(opts.kicker)}</div>` : ''}
-              <h1 style="${S.h1}">${escapeHtml(opts.title)}</h1>
-              ${opts.body}
-            </div>
-            <div style="${S.footer}">
-              <p style="${S.footerP}">${BRAND_FOOTER}</p>
-            </div>
-          </div>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>`.trim();
-}
 
 function send(opts: {
   to: string;
   subject: string;
   html: string;
+  text: string;
   category: string;
 }): Promise<EmailDeliveryResult> {
-  return sendEmail({ to: [opts.to], subject: opts.subject, html: opts.html, category: opts.category });
+  return sendEmail({
+    to: [opts.to],
+    subject: opts.subject,
+    html: opts.html,
+    text: opts.text,
+    category: opts.category,
+  });
 }
 
 // Whether invite-email delivery is wired up. Lets callers that fire the email
@@ -142,7 +82,7 @@ export async function sendAccountInviteEmail(opts: {
       ${inviterLine} to join ${target} on Kortix.
     </p>
     ${roleChip}
-    <a href="${escapeHtml(url)}" style="${S.btn}">Review invite</a>
+    ${actionButton(url, 'Review invite')}
     <p style="${S.smallNote}">
       Don't have a Kortix account yet? You'll be prompted to sign up first —
       ${signupTail}
@@ -161,10 +101,26 @@ export async function sendAccountInviteEmail(opts: {
     body,
   });
 
+  const inviterText = opts.inviterEmail ? `${opts.inviterEmail} invited you` : "You've been invited";
+  const targetText = opts.projectName
+    ? `the ${opts.projectName} project`
+    : `the ${opts.accountName} team`;
+
   return send({
     to: opts.email,
     subject: `You're invited to ${subjectTarget} on Kortix`,
     html,
+    text: renderText({
+      title: opts.projectName
+        ? `Join ${opts.projectName} on Kortix`
+        : `Join ${opts.accountName} on Kortix`,
+      paragraphs: [
+        `${inviterText} to join ${targetText} on Kortix.`,
+        ...(opts.role ? [`Role: ${opts.role.toUpperCase()}`] : []),
+      ],
+      cta: { url, label: 'Review invite' },
+      note: `Don't have a Kortix account yet? You'll be prompted to sign up first — ${signupTail}`,
+    }),
     category: 'account-invite',
   });
 }
@@ -188,7 +144,7 @@ export async function sendProjectAccessRequestEmail(opts: {
       requested access to <span style="${S.strong}">${escapeHtml(projectName)}</span>.
     </p>
     ${messageBlock}
-    <a href="${escapeHtml(opts.reviewUrl)}" style="${S.btn}">Review request</a>
+    ${actionButton(opts.reviewUrl, 'Review request')}
     <p style="${S.smallNote}">
       Project managers can approve or decline this from Customize → Members.
     </p>
@@ -204,6 +160,15 @@ export async function sendProjectAccessRequestEmail(opts: {
     to: opts.email,
     subject: `${opts.requesterEmail} requested access to ${projectName}`,
     html,
+    text: renderText({
+      title: 'Review project access',
+      paragraphs: [
+        `${opts.requesterEmail} requested access to ${projectName}.`,
+        ...(message ? [`Message: ${message}`] : []),
+      ],
+      cta: { url: opts.reviewUrl, label: 'Review request' },
+      note: 'Project managers can approve or decline this from Customize → Members.',
+    }),
     category: 'project-access-request',
   });
 }

--- a/apps/api/src/auth/send-email-hook/app.ts
+++ b/apps/api/src/auth/send-email-hook/app.ts
@@ -1,0 +1,3 @@
+import { makeOpenApiApp } from '../../openapi';
+
+export const authEmailHookApp = makeOpenApiApp();

--- a/apps/api/src/auth/send-email-hook/index.ts
+++ b/apps/api/src/auth/send-email-hook/index.ts
@@ -1,0 +1,6 @@
+import './routes';
+
+export { authEmailHookApp } from './app';
+export { authVerifyBaseUrl } from './routes';
+export { parseSendEmailHookPayload, buildVerifyUrl } from './payload';
+export { renderAuthEmail, type AuthEmailActionType } from './templates';

--- a/apps/api/src/auth/send-email-hook/payload.test.ts
+++ b/apps/api/src/auth/send-email-hook/payload.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildVerifyUrl, parseSendEmailHookPayload } from './payload';
+
+const BASE = 'https://supa.example.com';
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    user: { email: 'user@example.test' },
+    email_data: {
+      token: '123456',
+      token_hash: 'hash-abc',
+      redirect_to: 'https://app.example.com/dashboard',
+      email_action_type: 'magiclink',
+      site_url: 'https://app.example.com',
+      ...overrides,
+    },
+  };
+}
+
+describe('parseSendEmailHookPayload', () => {
+  test('builds the GoTrue verify link for a magic link', () => {
+    const result = parseSendEmailHookPayload(payload(), BASE);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.email.recipient).toBe('user@example.test');
+    expect(result.email.actionType).toBe('magiclink');
+    expect(result.email.actionUrl).toBe(
+      'https://supa.example.com/auth/v1/verify?token=hash-abc&type=magiclink&redirect_to=https%3A%2F%2Fapp.example.com%2Fdashboard',
+    );
+  });
+
+  test('every GoTrue action type is handled', () => {
+    for (const type of [
+      'signup',
+      'invite',
+      'magiclink',
+      'recovery',
+      'email_change',
+      'email_change_current',
+    ]) {
+      const result = parseSendEmailHookPayload(payload({ email_action_type: type }), BASE);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  test('email_change_new addresses the NEW mailbox with its own token', () => {
+    const result = parseSendEmailHookPayload(
+      {
+        user: { email: 'old@example.test', new_email: 'new@example.test' },
+        email_data: {
+          email_action_type: 'email_change_new',
+          token_hash: 'old-hash',
+          token_hash_new: 'new-hash',
+          token: '111111',
+          token_new: '222222',
+        },
+      },
+      BASE,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.email.recipient).toBe('new@example.test');
+    expect(result.email.actionUrl).toContain('token=new-hash');
+  });
+
+  test('reauthentication carries a code and no link', () => {
+    const result = parseSendEmailHookPayload(
+      payload({ email_action_type: 'reauthentication', token_hash: '' }),
+      BASE,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.email.token).toBe('123456');
+    expect(result.email.actionUrl).toBe('');
+  });
+
+  test('falls back to site_url when no explicit redirect_to is given', () => {
+    const result = parseSendEmailHookPayload(payload({ redirect_to: '' }), BASE);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.email.actionUrl).toContain('redirect_to=https%3A%2F%2Fapp.example.com');
+  });
+
+  test('reports a precise reason for every malformed payload', () => {
+    expect(parseSendEmailHookPayload({}, BASE)).toEqual({ ok: false, reason: 'missing email_data' });
+    expect(parseSendEmailHookPayload(payload({ email_action_type: 'nope' }), BASE)).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('unsupported email_action_type'),
+    });
+    expect(
+      parseSendEmailHookPayload({ email_data: { email_action_type: 'magiclink' } }, BASE),
+    ).toEqual({ ok: false, reason: 'missing user email' });
+    expect(parseSendEmailHookPayload(payload({ token_hash: '' }), BASE)).toEqual({
+      ok: false,
+      reason: 'missing token_hash',
+    });
+    // Self-host: SUPABASE_URL is an internal Docker hostname, so a link built
+    // from it would be unreachable. Refuse rather than mail a dead link.
+    expect(parseSendEmailHookPayload(payload(), '')).toEqual({
+      ok: false,
+      reason: 'no public Supabase URL configured',
+    });
+  });
+});
+
+describe('buildVerifyUrl', () => {
+  test('normalizes a trailing slash on the base URL', () => {
+    expect(
+      buildVerifyUrl({ verifyBaseUrl: `${BASE}/`, tokenHash: 'h', actionType: 'recovery' }),
+    ).toBe('https://supa.example.com/auth/v1/verify?token=h&type=recovery');
+  });
+});

--- a/apps/api/src/auth/send-email-hook/payload.ts
+++ b/apps/api/src/auth/send-email-hook/payload.ts
@@ -1,0 +1,117 @@
+// Parsing + link building for the Supabase "send email" auth hook payload.
+// Kept separate from the route so every branch is unit-testable without HTTP.
+import type { AuthEmailActionType } from './templates';
+
+export interface SendEmailHookPayload {
+  user?: { email?: string; new_email?: string | null };
+  email_data?: {
+    token?: string;
+    token_hash?: string;
+    token_new?: string;
+    token_hash_new?: string;
+    redirect_to?: string;
+    email_action_type?: string;
+    site_url?: string;
+  };
+}
+
+export interface ParsedAuthEmail {
+  recipient: string;
+  actionType: AuthEmailActionType;
+  actionUrl: string;
+  token: string;
+}
+
+const ACTION_TYPES: readonly AuthEmailActionType[] = [
+  'signup',
+  'invite',
+  'magiclink',
+  'recovery',
+  'email_change',
+  'email_change_current',
+  'email_change_new',
+  'reauthentication',
+];
+
+function asActionType(raw: string | undefined): AuthEmailActionType | null {
+  const value = (raw || '').toLowerCase() as AuthEmailActionType;
+  return ACTION_TYPES.includes(value) ? value : null;
+}
+
+/**
+ * Build the verification link GoTrue would have put in its own template:
+ * `<auth-origin>/auth/v1/verify?token=<hash>&type=<type>&redirect_to=<url>`.
+ *
+ * `verifyBaseUrl` must be the PUBLICLY reachable Supabase origin. On a
+ * self-host box the API talks to Supabase over an internal Docker hostname
+ * (`http://supabase-kong:8000`) that no mail client can resolve, which is
+ * exactly what SUPABASE_PUBLIC_URL exists to correct.
+ */
+export function buildVerifyUrl(input: {
+  verifyBaseUrl: string;
+  tokenHash: string;
+  actionType: AuthEmailActionType;
+  redirectTo?: string;
+}): string {
+  const base = input.verifyBaseUrl.replace(/\/+$/, '');
+  const params = new URLSearchParams({
+    token: input.tokenHash,
+    type: input.actionType,
+  });
+  if (input.redirectTo) params.set('redirect_to', input.redirectTo);
+  return `${base}/auth/v1/verify?${params.toString()}`;
+}
+
+/**
+ * Normalize the hook payload into everything needed to render and address one
+ * email. Returns a reason string instead of throwing so the route can answer
+ * with a precise 400.
+ */
+export function parseSendEmailHookPayload(
+  payload: SendEmailHookPayload,
+  verifyBaseUrl: string,
+): { ok: true; email: ParsedAuthEmail } | { ok: false; reason: string } {
+  const data = payload.email_data;
+  if (!data) return { ok: false, reason: 'missing email_data' };
+
+  const actionType = asActionType(data.email_action_type);
+  if (!actionType) {
+    return { ok: false, reason: `unsupported email_action_type "${data.email_action_type ?? ''}"` };
+  }
+
+  // A change of address confirms from the NEW mailbox with its own token; every
+  // other action (including the confirmation sent to the current address)
+  // confirms from the address already on the account.
+  const usesNewAddress = actionType === 'email_change_new';
+  const recipient = (
+    usesNewAddress ? payload.user?.new_email || payload.user?.email : payload.user?.email
+  )?.trim();
+  if (!recipient) return { ok: false, reason: 'missing user email' };
+
+  const token = (usesNewAddress ? data.token_new || data.token : data.token)?.trim() || '';
+  if (actionType === 'reauthentication') {
+    if (!token) return { ok: false, reason: 'missing token' };
+    return { ok: true, email: { recipient, actionType, actionUrl: '', token } };
+  }
+
+  const tokenHash = (
+    usesNewAddress ? data.token_hash_new || data.token_hash : data.token_hash
+  )?.trim();
+  if (!tokenHash) return { ok: false, reason: 'missing token_hash' };
+  if (!verifyBaseUrl) return { ok: false, reason: 'no public Supabase URL configured' };
+
+  return {
+    ok: true,
+    email: {
+      recipient,
+      actionType,
+      actionUrl: buildVerifyUrl({
+        verifyBaseUrl,
+        tokenHash,
+        actionType,
+        redirectTo: data.redirect_to || data.site_url || undefined,
+      }),
+      token,
+    },
+  };
+}

--- a/apps/api/src/auth/send-email-hook/routes.ts
+++ b/apps/api/src/auth/send-email-hook/routes.ts
@@ -1,0 +1,103 @@
+// POST /v1/webhooks/auth/send-email — Supabase Auth "send email" hook.
+//
+// GoTrue calls this instead of sending auth mail itself, so magic links,
+// signup confirmations, password resets and email changes go out through the
+// same provider chain, sender identity and templates as every other Kortix
+// email. Configure once (EMAIL_URL) and both halves of the system work.
+//
+// The route is unauthenticated by design and gated on a Standard Webhooks HMAC
+// signature (AUTH_EMAIL_HOOK_SECRET). It deliberately lives under /v1/webhooks
+// rather than /v1/auth, which requires a Supabase session.
+//
+// It answers only after the send resolves. Supabase bounds hook execution, so a
+// relay that is slow enough to blow that budget surfaces to the user as a
+// failed sign-in — which is the honest signal. SMTP connections are pooled, so
+// only the first send after a cold start pays the TLS handshake.
+import { createRoute, z } from '@hono/zod-openapi';
+
+import { config } from '../../config';
+import { sendEmail } from '../../lib/email/transport';
+import {
+  readStandardWebhookHeaders,
+  verifyStandardWebhook,
+} from '../../lib/webhooks/standard-webhooks';
+import { errors, json } from '../../openapi';
+import { authEmailHookApp } from './app';
+import { parseSendEmailHookPayload, type SendEmailHookPayload } from './payload';
+import { renderAuthEmail } from './templates';
+
+/** Public Supabase origin for the verification link — see buildVerifyUrl(). */
+export function authVerifyBaseUrl(): string {
+  return (config.SUPABASE_PUBLIC_URL || config.SUPABASE_URL || '').trim();
+}
+
+authEmailHookApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/send-email',
+    tags: ['auth'],
+    summary: 'Supabase Auth send-email hook (Standard Webhooks signature verified)',
+    request: {
+      body: { content: { 'application/json': { schema: z.any() } } },
+    },
+    responses: {
+      200: json(z.object({}), 'Email sent'),
+      ...errors(400, 401, 500, 503),
+    },
+  }),
+  async (c: any) => {
+    const secret = (config.AUTH_EMAIL_HOOK_SECRET || '').trim();
+    if (!secret) {
+      return c.json({ error: 'Auth email hook is not configured' }, 503);
+    }
+
+    const rawBody = await c.req.text();
+    const verified = verifyStandardWebhook({
+      rawBody,
+      secret,
+      headers: readStandardWebhookHeaders((name) => c.req.header(name)),
+    });
+    if (!verified) {
+      return c.json({ error: 'Invalid signature' }, 401);
+    }
+
+    let payload: SendEmailHookPayload;
+    try {
+      payload = JSON.parse(rawBody) as SendEmailHookPayload;
+    } catch {
+      return c.json({ error: 'Invalid JSON' }, 400);
+    }
+
+    const parsed = parseSendEmailHookPayload(payload, authVerifyBaseUrl());
+    if (!parsed.ok) {
+      return c.json({ error: parsed.reason }, 400);
+    }
+
+    const content = renderAuthEmail({
+      actionType: parsed.email.actionType,
+      actionUrl: parsed.email.actionUrl,
+      token: parsed.email.token,
+    });
+
+    const result = await sendEmail({
+      to: [parsed.email.recipient],
+      subject: content.subject,
+      html: content.html,
+      text: content.text,
+      category: content.category,
+    });
+
+    if (result.ok) return c.json({}, 200);
+
+    // Surface the failure to GoTrue so the user is told the mail did not go out,
+    // rather than being left waiting for a link that will never arrive.
+    if ('skipped' in result && result.skipped) {
+      console.error('[auth-email-hook] no email provider configured — set EMAIL_URL');
+      return c.json({ error: 'Email delivery is not configured' }, 503);
+    }
+    console.error(
+      `[auth-email-hook] ${parsed.email.actionType} send failed via ${result.provider}: ${result.error}`,
+    );
+    return c.json({ error: 'Email delivery failed' }, 500);
+  },
+);

--- a/apps/api/src/auth/send-email-hook/templates.ts
+++ b/apps/api/src/auth/send-email-hook/templates.ts
@@ -1,0 +1,144 @@
+// Auth email bodies — magic link, signup confirmation, password recovery,
+// email change, reauthentication code.
+//
+// GoTrue can only render its own plain templates and can only send over SMTP.
+// Routing it through the send-email hook means these use the same Kortix shell,
+// the same sender identity and the same provider chain as invites, so an
+// operator who configures Resend or SES (no SMTP anywhere) still gets working
+// magic links.
+import { actionButton, escapeHtml, renderEmail, renderText, S } from '../../lib/email/template';
+
+export type AuthEmailActionType =
+  | 'signup'
+  | 'invite'
+  | 'magiclink'
+  | 'recovery'
+  | 'email_change'
+  | 'email_change_current'
+  | 'email_change_new'
+  | 'reauthentication';
+
+export interface AuthEmailContent {
+  subject: string;
+  html: string;
+  text: string;
+  category: string;
+}
+
+interface Copy {
+  subject: string;
+  kicker: string;
+  title: string;
+  lead: string;
+  cta: string;
+  note: string;
+}
+
+const COPY: Record<Exclude<AuthEmailActionType, 'reauthentication'>, Copy> = {
+  signup: {
+    subject: 'Confirm your email',
+    kicker: 'Confirm your email',
+    title: 'Confirm your email address',
+    lead: 'Confirm this address to finish creating your Kortix account.',
+    cta: 'Confirm email',
+    note: 'If you did not create a Kortix account, you can ignore this email.',
+  },
+  invite: {
+    subject: 'You have been invited to Kortix',
+    kicker: "You're invited",
+    title: 'You have been invited',
+    lead: 'Accept the invitation to create your Kortix account.',
+    cta: 'Accept invite',
+    note: 'If you were not expecting this invitation, you can ignore this email.',
+  },
+  magiclink: {
+    subject: 'Your Kortix sign-in link',
+    kicker: 'Sign in',
+    title: 'Sign in to Kortix',
+    lead: 'Use the link below to sign in. It expires shortly and can be used once.',
+    cta: 'Sign in',
+    note: 'If you did not request this link, you can ignore this email.',
+  },
+  recovery: {
+    subject: 'Reset your Kortix password',
+    kicker: 'Password reset',
+    title: 'Reset your password',
+    lead: 'Use the link below to choose a new password.',
+    cta: 'Reset password',
+    note: 'If you did not request a password reset, you can ignore this email.',
+  },
+  email_change: {
+    subject: 'Confirm your new email address',
+    kicker: 'Email change',
+    title: 'Confirm your new email address',
+    lead: 'Confirm this change to move your Kortix account to the new address.',
+    cta: 'Confirm change',
+    note: 'If you did not request this change, reset your password immediately.',
+  },
+  email_change_current: {
+    subject: 'Confirm your email change',
+    kicker: 'Email change',
+    title: 'Confirm your email change',
+    lead: 'Confirm from your current address to move your Kortix account.',
+    cta: 'Confirm change',
+    note: 'If you did not request this change, reset your password immediately.',
+  },
+  email_change_new: {
+    subject: 'Confirm your new email address',
+    kicker: 'Email change',
+    title: 'Confirm your new email address',
+    lead: 'Confirm this address to finish moving your Kortix account to it.',
+    cta: 'Confirm change',
+    note: 'If you did not request this change, you can ignore this email.',
+  },
+};
+
+/** Six-digit code flow — no link is issued for reauthentication. */
+function renderCode(token: string): AuthEmailContent {
+  const body = `
+    <p style="${S.p}">Enter this code to confirm it is you.</p>
+    <div style="${S.chipWrap}"><span style="${S.code}">${escapeHtml(token)}</span></div>
+    <p style="${S.smallNote}">
+      The code expires shortly. If you did not request it, you can ignore this email.
+    </p>
+  `;
+  const title = 'Confirm it is you';
+  const note = 'The code expires shortly. If you did not request it, you can ignore this email.';
+  return {
+    subject: 'Your Kortix confirmation code',
+    html: renderEmail({ kicker: 'Confirmation code', title, body }),
+    text: renderText({
+      title,
+      paragraphs: ['Enter this code to confirm it is you.'],
+      code: token,
+      note,
+    }),
+    category: 'auth-reauthentication',
+  };
+}
+
+export function renderAuthEmail(input: {
+  actionType: AuthEmailActionType;
+  actionUrl: string;
+  token: string;
+}): AuthEmailContent {
+  if (input.actionType === 'reauthentication') return renderCode(input.token);
+
+  const copy = COPY[input.actionType];
+  const body = `
+    <p style="${S.p}">${escapeHtml(copy.lead)}</p>
+    ${actionButton(input.actionUrl, copy.cta)}
+    <p style="${S.smallNote}">${escapeHtml(copy.note)}</p>
+  `;
+  return {
+    subject: copy.subject,
+    html: renderEmail({ kicker: copy.kicker, title: copy.title, body }),
+    text: renderText({
+      title: copy.title,
+      paragraphs: [copy.lead],
+      cta: { url: input.actionUrl, label: copy.cta },
+      note: copy.note,
+    }),
+    category: `auth-${input.actionType.replace(/_/g, '-')}`,
+  };
+}

--- a/apps/api/src/channels/email/verify.ts
+++ b/apps/api/src/channels/email/verify.ts
@@ -1,7 +1,10 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { verifyStandardWebhook } from '../../lib/webhooks/standard-webhooks';
 
-const FIVE_MINUTES_S = 5 * 60;
-
+/**
+ * AgentMail signs with Standard Webhooks (Svix). The comparison itself lives in
+ * lib/webhooks/standard-webhooks.ts, shared with the Supabase auth send-email
+ * hook; this wrapper only keeps AgentMail's parameter names.
+ */
 export function verifyAgentMailSignature(input: {
   rawBody: string;
   secret: string;
@@ -9,29 +12,13 @@ export function verifyAgentMailSignature(input: {
   svixTimestamp: string;
   svixSignature: string;
 }): boolean {
-  const ts = Number(input.svixTimestamp);
-  if (!Number.isFinite(ts)) return false;
-  if (Math.abs(Math.floor(Date.now() / 1000) - ts) > FIVE_MINUTES_S) return false;
-
-  const key = decodeSvixSecret(input.secret);
-  if (!key) return false;
-  const signed = `${input.svixId}.${input.svixTimestamp}.${input.rawBody}`;
-  const expected = createHmac('sha256', key).update(signed).digest('base64');
-  for (const part of input.svixSignature.split(/\s+/)) {
-    const [version, sig] = part.split(',');
-    if (version !== 'v1' || !sig) continue;
-    const a = Buffer.from(sig);
-    const b = Buffer.from(expected);
-    if (a.length === b.length && timingSafeEqual(a, b)) return true;
-  }
-  return false;
-}
-
-function decodeSvixSecret(secret: string): Buffer | null {
-  const raw = secret.startsWith('whsec_') ? secret.slice('whsec_'.length) : secret;
-  try {
-    return Buffer.from(raw, 'base64');
-  } catch {
-    return null;
-  }
+  return verifyStandardWebhook({
+    rawBody: input.rawBody,
+    secret: input.secret,
+    headers: {
+      id: input.svixId,
+      timestamp: input.svixTimestamp,
+      signature: input.svixSignature,
+    },
+  });
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -616,10 +616,38 @@ const envSchema = z.object({
   SANDBOX_VERSION: optStr, // dev override: skip npm registry lookup for latest version
   GITHUB_TOKEN: optStr, // optional: authenticated GitHub API calls for changelog
 
-  // ── Transactional email (provider chain: SES → Resend → Mailtrap) ─────────
-  // Every provider is optional; the transport tries each configured one in
-  // EMAIL_PROVIDER_ORDER and falls through on failure. See lib/email/transport.ts.
-  EMAIL_PROVIDER_ORDER: optStrDefault('ses,resend,mailtrap'),
+  // ── Transactional email ───────────────────────────────────────────────────
+  // ONE connection string configures delivery for every email the platform
+  // sends, product and auth alike. The scheme picks the transport:
+  //   smtp://user:pass@host:587 · smtps://user:pass@host:465
+  //   resend://<api-key> · ses://<key>:<secret>@<region> · ses://<region>
+  //   mailtrap://<token> · mailpit://host:8025
+  // Comma-separate for a fallback chain. See lib/email/dsn.ts.
+  EMAIL_URL: optStr,
+  // Sender identity: `Name <address>` or a bare address.
+  EMAIL_FROM: optStr,
+  // Shared secret for the Supabase send-email hook (`v1,whsec_<base64>`), which
+  // routes GoTrue's magic-link / confirmation / recovery mail through this API
+  // so auth email uses the same provider and templates as product email.
+  // See auth/send-email-hook/.
+  AUTH_EMAIL_HOOK_SECRET: optStr,
+
+  // ── Transactional email: pre-EMAIL_URL variables (still supported) ────────
+  // Deployed Kortix runs on these today. They are used whenever EMAIL_URL is
+  // unset; setting EMAIL_URL overrides all of them.
+  // `smtp` is last but present by default: an existing self-host that
+  // configured SMTP_* for GoTrue before EMAIL_URL shipped starts sending
+  // product email (invites, access requests) through that same relay on
+  // upgrade, with no new setting. Cloud sets no SMTP_*, so nothing changes
+  // there.
+  EMAIL_PROVIDER_ORDER: optStrDefault('ses,resend,mailtrap,smtp'),
+  // Discrete SMTP settings, as GoTrue consumes them. Shared with the API so a
+  // self-host that configures a relay for auth email also sends product email
+  // through it with no second setting.
+  SMTP_HOST: optStr,
+  SMTP_PORT: optStr,
+  SMTP_USER: optStr,
+  SMTP_PASS: optStr,
   // AWS SES (SigV4-signed SESv2 HTTP API). ECS uses its task role. Static
   // credentials remain optional for local and self-hosted deployments.
   AWS_SES_REGION: optStrDefault('us-east-2'),
@@ -1177,7 +1205,14 @@ export const config = {
   GITHUB_TOKEN: env.GITHUB_TOKEN,
 
   // ─── Transactional email (provider chain) ──────────────────────────────────
+  EMAIL_URL: env.EMAIL_URL,
+  EMAIL_FROM: env.EMAIL_FROM,
+  AUTH_EMAIL_HOOK_SECRET: env.AUTH_EMAIL_HOOK_SECRET,
   EMAIL_PROVIDER_ORDER: env.EMAIL_PROVIDER_ORDER,
+  SMTP_HOST: env.SMTP_HOST,
+  SMTP_PORT: env.SMTP_PORT,
+  SMTP_USER: env.SMTP_USER,
+  SMTP_PASS: env.SMTP_PASS,
   AWS_SES_REGION: env.AWS_SES_REGION,
   AWS_SES_ACCESS_KEY_ID: env.AWS_SES_ACCESS_KEY_ID,
   AWS_SES_SECRET_ACCESS_KEY: env.AWS_SES_SECRET_ACCESS_KEY,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -132,6 +132,8 @@ import {
 } from './projects/provider-transition/provider-transition-worker';
 import { accountsRouter } from './accounts';
 import { authRouter } from './auth';
+import { authEmailHookApp } from './auth/send-email-hook';
+import { describeEmailChain } from './lib/email/transport';
 import { scimRouter } from './scim';
 import { accountInvitesRouter } from './accounts/invites';
 import { auditApiRequest } from './shared/audit';
@@ -906,6 +908,7 @@ app.route('/v1/channels/slack/identity', slackIdentityApp); // /v1/channels/slac
 app.route('/v1/channels/teams/identity', teamsIdentityApp); // /v1/channels/teams/identity/bind — authed login bind
 app.route('/v1/webhooks/telegram', telegramWebhookApp); // /v1/webhooks/telegram/:projectId — Telegram updates
 app.route('/v1/webhooks/email', emailWebhookApp); // /v1/webhooks/email/agentmail — AgentMail inbound email (Svix-signed)
+app.route('/v1/webhooks/auth', authEmailHookApp); // /v1/webhooks/auth/send-email — Supabase Auth send-email hook (Standard Webhooks-signed)
 
 app.route('/v1/webhooks/sandbox', sandboxWebhooksApp); // /v1/webhooks/sandbox/{daytona,platinum} — provider lifecycle → close billing
 
@@ -1477,6 +1480,11 @@ async function shutdown(signal: string) {
 // route table without starting the DB schema check, background workers, or
 // signal handlers. Does NOT change production boot — there, import.meta.main is true.
 if (import.meta.main) {
+  // One line an operator can grep for when email "does not work": which
+  // providers EMAIL_URL resolved to, and the address mail is sent from. Never
+  // prints credentials.
+  console.log(`[email] ${describeEmailChain()}`);
+
   ensureSchema()
     .then(async () => {
       schemaReady = true;

--- a/apps/api/src/lib/demo-request-email.ts
+++ b/apps/api/src/lib/demo-request-email.ts
@@ -85,6 +85,26 @@ function renderHtml(lead: DemoRequestLead): string {
 </html>`.trim();
 }
 
+/** Plain-text alternative, built from the same fields as the HTML table. */
+function renderPlainText(lead: DemoRequestLead): string {
+  const fields: Array<[string, unknown]> = [
+    ['Name', lead.name],
+    ['Email', lead.email],
+    ['Company', lead.company_name],
+    ['Company size', lead.company_size],
+    ['Goal', lead.goal],
+    ['Qualified', lead.qualified],
+    ['Source', lead.source],
+  ];
+  const lines = ['New demo request', ''];
+  for (const [label, value] of fields) {
+    const text = typeof value === 'boolean' ? (value ? 'yes' : 'no') : String(value ?? '').trim();
+    if (text) lines.push(`${label}: ${text}`);
+  }
+  lines.push('', 'Kortix — automated lead notification');
+  return lines.join('\n');
+}
+
 /**
  * Send the internal "new demo request" notification. Never throws — returns a
  * result the caller can log. Recipients come from config.DEMO_LEAD_NOTIFY_EMAIL,
@@ -108,6 +128,7 @@ export async function sendDemoRequestNotification(
     to: recipients,
     subject: `New demo request — ${who}`,
     html: renderHtml(lead),
+    text: renderPlainText(lead),
     category: 'demo-request',
     from: {
       email: config.DEMO_LEAD_FROM_EMAIL || config.MAILTRAP_FROM_EMAIL,

--- a/apps/api/src/lib/email/address.ts
+++ b/apps/api/src/lib/email/address.ts
@@ -1,0 +1,31 @@
+import type { EmailAddress } from './types';
+
+/**
+ * Parse EMAIL_FROM. Accepts the forms operators actually write:
+ *   Kortix <noreply@example.com>
+ *   "Kortix Support" <noreply@example.com>
+ *   noreply@example.com
+ * Returns null when the value has no usable address, so the caller can fall
+ * back rather than send from an empty envelope.
+ */
+export function parseEmailAddress(raw: string | undefined | null): EmailAddress | null {
+  const value = (raw || '').trim();
+  if (!value) return null;
+
+  const angle = value.match(/^(.*)<\s*([^<>\s]+@[^<>\s]+)\s*>$/);
+  if (angle) {
+    const name = angle[1].trim().replace(/^"(.*)"$/, '$1').trim();
+    return { email: angle[2].trim(), name };
+  }
+  if (!value.includes('@') || /\s/.test(value)) return null;
+  return { email: value, name: '' };
+}
+
+/** Render an address as a header value: `Name <addr>` or bare `addr`. */
+export function formatEmailAddress(address: EmailAddress): string {
+  if (!address.name) return address.email;
+  // Quote names containing specials, per RFC 5322 atom rules.
+  const needsQuoting = /[",;:<>@()\[\]\\.]/.test(address.name);
+  const name = needsQuoting ? `"${address.name.replace(/(["\\])/g, '\\$1')}"` : address.name;
+  return `${name} <${address.email}>`;
+}

--- a/apps/api/src/lib/email/providers/http.ts
+++ b/apps/api/src/lib/email/providers/http.ts
@@ -1,0 +1,85 @@
+// The three HTTP-API providers. Each speaks plain `fetch`, so the whole set
+// stays mockable through globalThis.fetch in tests.
+import { formatEmailAddress } from '../address';
+import type { EmailTarget } from '@kortix/shared/email-url';
+import { EMAIL_SEND_TIMEOUT_MS, type EmailSendResult, type ResolvedEmailMessage } from '../types';
+
+export async function sendViaResend(
+  msg: ResolvedEmailMessage,
+  target: Extract<EmailTarget, { kind: 'resend' }>,
+): Promise<EmailSendResult> {
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${target.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: formatEmailAddress(msg.from),
+      to: msg.to,
+      subject: msg.subject,
+      html: msg.html,
+      ...(msg.text ? { text: msg.text } : {}),
+      ...(msg.replyTo ? { reply_to: msg.replyTo } : {}),
+      tags: [{ name: 'category', value: msg.category }],
+    }),
+    signal: AbortSignal.timeout(EMAIL_SEND_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    return { ok: false, provider: 'resend', status: res.status, error: text || res.statusText };
+  }
+  return { ok: true, provider: 'resend', status: res.status };
+}
+
+export async function sendViaMailtrap(
+  msg: ResolvedEmailMessage,
+  target: Extract<EmailTarget, { kind: 'mailtrap' }>,
+): Promise<EmailSendResult> {
+  const res = await fetch('https://send.api.mailtrap.io/api/send', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${target.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: { email: msg.from.email, name: msg.from.name },
+      to: msg.to.map((email) => ({ email })),
+      subject: msg.subject,
+      html: msg.html,
+      ...(msg.text ? { text: msg.text } : {}),
+      category: msg.category,
+    }),
+    signal: AbortSignal.timeout(EMAIL_SEND_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    return { ok: false, provider: 'mailtrap', status: res.status, error: text || res.statusText };
+  }
+  return { ok: true, provider: 'mailtrap', status: res.status };
+}
+
+/** Local capture only — Mailpit's HTTP send API, used by the test profile. */
+export async function sendViaMailpit(
+  msg: ResolvedEmailMessage,
+  target: Extract<EmailTarget, { kind: 'mailpit' }>,
+): Promise<EmailSendResult> {
+  const res = await fetch(`${target.baseUrl.replace(/\/+$/, '')}/api/v1/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      From: { Email: msg.from.email, Name: msg.from.name },
+      To: msg.to.map((email) => ({ Email: email })),
+      Subject: msg.subject,
+      HTML: msg.html,
+      Text: msg.text,
+      Tags: [msg.category],
+    }),
+    signal: AbortSignal.timeout(EMAIL_SEND_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    return { ok: false, provider: 'mailpit', status: res.status, error: text || res.statusText };
+  }
+  return { ok: true, provider: 'mailpit', status: res.status };
+}

--- a/apps/api/src/lib/email/providers/ses.ts
+++ b/apps/api/src/lib/email/providers/ses.ts
@@ -1,0 +1,83 @@
+// AWS SES v2 SendEmail over a SigV4-signed fetch. Hand-signed with node:crypto
+// so the API keeps no AWS SDK client dependency; only the credential provider
+// is borrowed, and only when the DSN carries no static key pair (ECS task role,
+// EKS web identity).
+import { createHash, createHmac } from 'node:crypto';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+
+import { formatEmailAddress } from '../address';
+import type { EmailTarget } from '@kortix/shared/email-url';
+import { EMAIL_SEND_TIMEOUT_MS, type EmailSendResult, type ResolvedEmailMessage } from '../types';
+
+function hmac(key: Buffer | string, data: string): Buffer {
+  return createHmac('sha256', key).update(data, 'utf8').digest();
+}
+
+function sha256Hex(data: string): string {
+  return createHash('sha256').update(data, 'utf8').digest('hex');
+}
+
+export async function sendViaSes(
+  msg: ResolvedEmailMessage,
+  target: Extract<EmailTarget, { kind: 'ses' }>,
+): Promise<EmailSendResult> {
+  const region = target.region;
+  const host = `email.${region}.amazonaws.com`;
+  const path = '/v2/email/outbound-emails';
+  const credentials =
+    target.accessKeyId && target.secretAccessKey
+      ? { accessKeyId: target.accessKeyId, secretAccessKey: target.secretAccessKey }
+      : await defaultProvider()();
+
+  const body = JSON.stringify({
+    FromEmailAddress: formatEmailAddress(msg.from),
+    Destination: { ToAddresses: msg.to },
+    ...(msg.replyTo ? { ReplyToAddresses: [msg.replyTo] } : {}),
+    Content: {
+      Simple: {
+        Subject: { Data: msg.subject, Charset: 'UTF-8' },
+        Body: {
+          Html: { Data: msg.html, Charset: 'UTF-8' },
+          ...(msg.text ? { Text: { Data: msg.text, Charset: 'UTF-8' } } : {}),
+        },
+      },
+    },
+    EmailTags: [{ Name: 'category', Value: msg.category }],
+  });
+
+  const amzDate = new Date().toISOString().replace(/[:-]|\.\d{3}/g, ''); // YYYYMMDDTHHMMSSZ
+  const dateStamp = amzDate.slice(0, 8);
+  const payloadHash = sha256Hex(body);
+  const sessionToken = (credentials as { sessionToken?: string }).sessionToken;
+  const securityTokenHeader = sessionToken ? `x-amz-security-token:${sessionToken}\n` : '';
+  const canonicalHeaders = `content-type:application/json\nhost:${host}\nx-amz-content-sha256:${payloadHash}\nx-amz-date:${amzDate}\n${securityTokenHeader}`;
+  const signedHeaders = sessionToken
+    ? 'content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token'
+    : 'content-type;host;x-amz-content-sha256;x-amz-date';
+  const canonicalRequest = `POST\n${path}\n\n${canonicalHeaders}\n${signedHeaders}\n${payloadHash}`;
+  const scope = `${dateStamp}/${region}/ses/aws4_request`;
+  const stringToSign = `AWS4-HMAC-SHA256\n${amzDate}\n${scope}\n${sha256Hex(canonicalRequest)}`;
+  const signingKey = hmac(
+    hmac(hmac(hmac(`AWS4${credentials.secretAccessKey}`, dateStamp), region), 'ses'),
+    'aws4_request',
+  );
+  const signature = createHmac('sha256', signingKey).update(stringToSign, 'utf8').digest('hex');
+
+  const res = await fetch(`https://${host}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Amz-Content-Sha256': payloadHash,
+      'X-Amz-Date': amzDate,
+      ...(sessionToken ? { 'X-Amz-Security-Token': sessionToken } : {}),
+      Authorization: `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    },
+    body,
+    signal: AbortSignal.timeout(EMAIL_SEND_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    return { ok: false, provider: 'ses', status: res.status, error: text || res.statusText };
+  }
+  return { ok: true, provider: 'ses', status: res.status };
+}

--- a/apps/api/src/lib/email/providers/smtp.test.ts
+++ b/apps/api/src/lib/email/providers/smtp.test.ts
@@ -1,0 +1,145 @@
+// Real SMTP conversation against an in-process server: no mock of the client,
+// no container. Proves the wire path (EHLO → AUTH → MAIL FROM → RCPT TO → DATA)
+// and that the message body actually carries what the transport was given.
+import { createServer, type Server, type Socket } from 'node:net';
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import type { EmailTarget } from '@kortix/shared/email-url';
+import { closeSmtpTransports, sendViaSmtp } from './smtp';
+import type { ResolvedEmailMessage } from '../types';
+
+interface Captured {
+  commands: string[];
+  data: string;
+}
+
+function startSmtpServer(opts: { advertiseAuth: boolean }): Promise<{
+  server: Server;
+  port: number;
+  captured: Captured;
+}> {
+  const captured: Captured = { commands: [], data: '' };
+  const server = createServer((socket: Socket) => {
+    let inData = false;
+    let buffer = '';
+    socket.write('220 test ESMTP\r\n');
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      let index: number;
+      while ((index = buffer.indexOf('\r\n')) !== -1) {
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 2);
+
+        if (inData) {
+          if (line === '.') {
+            inData = false;
+            socket.write('250 2.0.0 Ok: queued as TEST\r\n');
+          } else {
+            captured.data += `${line}\n`;
+          }
+          continue;
+        }
+
+        captured.commands.push(line);
+        const verb = line.split(' ')[0]!.toUpperCase();
+        if (verb === 'EHLO') {
+          socket.write('250-test\r\n');
+          socket.write(opts.advertiseAuth ? '250 AUTH PLAIN LOGIN\r\n' : '250 8BITMIME\r\n');
+        } else if (verb === 'AUTH') {
+          socket.write('235 2.7.0 Authentication successful\r\n');
+        } else if (verb === 'DATA') {
+          inData = true;
+          socket.write('354 End data with <CR><LF>.<CR><LF>\r\n');
+        } else if (verb === 'QUIT') {
+          socket.write('221 Bye\r\n');
+          socket.end();
+        } else {
+          socket.write('250 OK\r\n');
+        }
+      }
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({ server, port, captured });
+    });
+  });
+}
+
+const MESSAGE: ResolvedEmailMessage = {
+  to: ['user@example.test'],
+  subject: 'Sign in to Kortix',
+  html: '<p>hello <b>world</b></p>',
+  text: 'hello world',
+  category: 'auth-magiclink',
+  from: { email: 'noreply@example.test', name: 'Kortix' },
+};
+
+afterEach(() => {
+  closeSmtpTransports();
+});
+
+describe('sendViaSmtp', () => {
+  test('delivers over a plain anonymous relay and carries both body parts', async () => {
+    const { server, port, captured } = await startSmtpServer({ advertiseAuth: false });
+    const target: EmailTarget = {
+      kind: 'smtp',
+      host: '127.0.0.1',
+      port,
+      secure: false,
+      requireTls: false,
+      rejectUnauthorized: false,
+    };
+
+    const result = await sendViaSmtp(MESSAGE, target);
+    expect(result).toEqual({ ok: true, provider: 'smtp', status: 250 });
+
+    expect(captured.commands.some((line) => line.startsWith('MAIL FROM:<noreply@example.test>'))).toBe(true);
+    expect(captured.commands.some((line) => line.startsWith('RCPT TO:<user@example.test>'))).toBe(true);
+    // RFC 2047-encoded or literal, the subject must survive; nodemailer emits
+    // the header verbatim when it is pure ASCII.
+    expect(captured.data).toContain('Subject: Sign in to Kortix');
+    expect(captured.data).toContain('From: Kortix <noreply@example.test>');
+    expect(captured.data).toContain('X-Kortix-Category: auth-magiclink');
+    expect(captured.data).toContain('multipart/alternative');
+    server.close();
+  });
+
+  test('authenticates when the relay advertises AUTH', async () => {
+    const { server, port, captured } = await startSmtpServer({ advertiseAuth: true });
+    const result = await sendViaSmtp(MESSAGE, {
+      kind: 'smtp',
+      host: '127.0.0.1',
+      port,
+      secure: false,
+      // ?tls=off — this relay offers no STARTTLS, which is the only reason
+      // credentials are allowed over a plain socket here.
+      requireTls: false,
+      rejectUnauthorized: false,
+      user: 'alice',
+      pass: 's3cret',
+    });
+    expect(result.ok).toBe(true);
+    expect(captured.commands.some((line) => line.startsWith('AUTH'))).toBe(true);
+    server.close();
+  });
+
+  test('reports a refused connection as a failed result rather than throwing', async () => {
+    const result = await sendViaSmtp(MESSAGE, {
+      kind: 'smtp',
+      host: '127.0.0.1',
+      // Port 1 is reserved and never listening.
+      port: 1,
+      secure: false,
+      requireTls: false,
+      rejectUnauthorized: false,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok || ('skipped' in result && result.skipped)) return;
+    expect(result.provider).toBe('smtp');
+    expect(result.error).toBeTruthy();
+  });
+});

--- a/apps/api/src/lib/email/providers/smtp.ts
+++ b/apps/api/src/lib/email/providers/smtp.ts
@@ -1,0 +1,79 @@
+// Plain SMTP — the provider every mail system on earth already speaks, and the
+// one a self-hoster with a corporate relay can actually use.
+//
+// Transports are pooled and cached per DSN: opening a TCP+TLS connection per
+// invite is wasteful, and nodemailer's pool reuses the socket across sends.
+import nodemailer, { type Transporter } from 'nodemailer';
+
+import { formatEmailAddress } from '../address';
+import type { EmailTarget } from '@kortix/shared/email-url';
+import { EMAIL_SEND_TIMEOUT_MS, type EmailSendResult, type ResolvedEmailMessage } from '../types';
+
+type SmtpTarget = Extract<EmailTarget, { kind: 'smtp' }>;
+
+const transporters = new Map<string, Transporter>();
+
+function cacheKey(target: SmtpTarget): string {
+  return [
+    target.host,
+    target.port,
+    target.secure ? 'tls' : 'plain',
+    target.requireTls ? 'starttls' : 'opportunistic',
+    target.rejectUnauthorized ? 'verify' : 'insecure',
+    target.user ?? '',
+  ].join('|');
+}
+
+function transporterFor(target: SmtpTarget): Transporter {
+  const key = cacheKey(target);
+  const existing = transporters.get(key);
+  if (existing) return existing;
+
+  const created = nodemailer.createTransport({
+    host: target.host,
+    port: target.port,
+    secure: target.secure,
+    requireTLS: target.requireTls,
+    ...(target.user ? { auth: { user: target.user, pass: target.pass ?? '' } } : {}),
+    tls: { rejectUnauthorized: target.rejectUnauthorized },
+    pool: true,
+    maxConnections: 3,
+    connectionTimeout: EMAIL_SEND_TIMEOUT_MS,
+    greetingTimeout: EMAIL_SEND_TIMEOUT_MS,
+    socketTimeout: EMAIL_SEND_TIMEOUT_MS,
+  });
+  transporters.set(key, created);
+  return created;
+}
+
+export async function sendViaSmtp(
+  msg: ResolvedEmailMessage,
+  target: SmtpTarget,
+): Promise<EmailSendResult> {
+  try {
+    await transporterFor(target).sendMail({
+      from: formatEmailAddress(msg.from),
+      to: msg.to,
+      subject: msg.subject,
+      html: msg.html,
+      ...(msg.text ? { text: msg.text } : {}),
+      ...(msg.replyTo ? { replyTo: msg.replyTo } : {}),
+      headers: { 'X-Kortix-Category': msg.category },
+    });
+    return { ok: true, provider: 'smtp', status: 250 };
+  } catch (err) {
+    const error = err as Error & { responseCode?: number };
+    return {
+      ok: false,
+      provider: 'smtp',
+      ...(error.responseCode ? { status: error.responseCode } : {}),
+      error: error.message || 'SMTP send failed',
+    };
+  }
+}
+
+/** Close pooled sockets. Used by tests and graceful shutdown. */
+export function closeSmtpTransports(): void {
+  for (const transporter of transporters.values()) transporter.close();
+  transporters.clear();
+}

--- a/apps/api/src/lib/email/template.ts
+++ b/apps/api/src/lib/email/template.ts
@@ -1,0 +1,110 @@
+// The Kortix email shell. Every email the platform sends — invites, access
+// requests, magic links, signup confirmations, password recovery — is rendered
+// through renderEmail() so they are visibly one product rather than a branded
+// invite next to a default GoTrue plain-text link.
+const BRAND_WORDMARK = 'Kortix';
+const BRAND_FOOTER = 'Kortix — The Autonomous Company Operating System';
+
+const COLOR_BG = '#f6f7f9';
+const COLOR_CARD = '#ffffff';
+const COLOR_BORDER = '#e5e7eb';
+const COLOR_TEXT = '#111111';
+const COLOR_MUTED = '#6b7280';
+const COLOR_ACCENT = '#111111';
+
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Inline styles — email clients strip <style> blocks, so every rule is local. */
+export const S = {
+  wrapper: `margin:0;padding:0;background:${COLOR_BG};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;`,
+  outerTable: `width:100%;background:${COLOR_BG};`,
+  container: `max-width:520px;margin:40px auto;background:${COLOR_CARD};border-radius:14px;border:1px solid ${COLOR_BORDER};overflow:hidden;`,
+  header: `padding:28px 32px 0;text-align:center;`,
+  wordmark: `font-size:15px;font-weight:700;letter-spacing:0.5px;color:${COLOR_TEXT};margin:0;`,
+  body: `padding:18px 32px 36px;text-align:center;`,
+  kicker: `font-size:11px;color:${COLOR_MUTED};letter-spacing:0.2em;text-transform:uppercase;margin:24px 0 8px;`,
+  h1: `font-size:22px;line-height:1.25;font-weight:600;color:${COLOR_TEXT};margin:0 0 12px;`,
+  p: `font-size:14px;line-height:1.6;color:${COLOR_MUTED};margin:0 0 24px;`,
+  strong: `color:${COLOR_TEXT};font-weight:600;`,
+  chipWrap: `margin:0 0 28px;`,
+  chip: `display:inline-block;padding:4px 10px;border-radius:999px;border:1px solid ${COLOR_BORDER};font-size:11px;color:${COLOR_MUTED};letter-spacing:0.06em;text-transform:uppercase;`,
+  btn: `display:inline-block;padding:12px 28px;background:${COLOR_ACCENT};color:#ffffff;text-decoration:none;border-radius:10px;font-size:14px;font-weight:500;`,
+  code: `display:inline-block;padding:12px 24px;border:1px solid ${COLOR_BORDER};border-radius:10px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:24px;letter-spacing:0.35em;color:${COLOR_TEXT};`,
+  footer: `padding:18px 32px;text-align:center;border-top:1px solid ${COLOR_BORDER};background:${COLOR_CARD};`,
+  footerP: `font-size:12px;color:#9ca3af;margin:0;`,
+  smallNote: `font-size:12px;color:${COLOR_MUTED};margin:24px 0 0;`,
+  linkFallback: `font-size:12px;color:${COLOR_MUTED};margin:16px 0 0;word-break:break-all;`,
+};
+
+export function renderEmail(opts: { kicker?: string; title: string; body: string }): string {
+  return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>${escapeHtml(opts.title)}</title>
+  </head>
+  <body style="${S.wrapper}">
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="${S.outerTable}">
+      <tr>
+        <td align="center">
+          <div style="${S.container}">
+            <div style="${S.header}">
+              <p style="${S.wordmark}">${BRAND_WORDMARK}</p>
+            </div>
+            <div style="${S.body}">
+              ${opts.kicker ? `<div style="${S.kicker}">${escapeHtml(opts.kicker)}</div>` : ''}
+              <h1 style="${S.h1}">${escapeHtml(opts.title)}</h1>
+              ${opts.body}
+            </div>
+            <div style="${S.footer}">
+              <p style="${S.footerP}">${BRAND_FOOTER}</p>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`.trim();
+}
+
+/**
+ * Plain-text alternative, built from the SAME structured content as the HTML.
+ *
+ * Deliberately not derived by stripping tags out of the rendered HTML: a
+ * regex tag-stripper is both fragile (CodeQL js/bad-tag-filter,
+ * js/incomplete-multi-character-sanitization, js/double-escaping all landed on
+ * exactly that) and pointless here, because every caller already holds the
+ * structured content the HTML was built from.
+ */
+export function renderText(opts: {
+  title: string;
+  paragraphs: string[];
+  cta?: { url: string; label: string };
+  code?: string;
+  note?: string;
+}): string {
+  const lines = [opts.title, ''];
+  for (const paragraph of opts.paragraphs) lines.push(paragraph, '');
+  if (opts.code) lines.push(opts.code, '');
+  if (opts.cta) lines.push(`${opts.cta.label}: ${opts.cta.url}`, '');
+  if (opts.note) lines.push(opts.note, '');
+  lines.push(BRAND_FOOTER);
+  return lines.join('\n').trim();
+}
+
+/** Primary call-to-action button plus the copy/paste fallback link beneath it. */
+export function actionButton(url: string, label: string): string {
+  return `
+    <a href="${escapeHtml(url)}" style="${S.btn}">${escapeHtml(label)}</a>
+    <p style="${S.linkFallback}">
+      Or paste this link into your browser:<br />${escapeHtml(url)}
+    </p>
+  `;
+}

--- a/apps/api/src/lib/email/transport-email-url.test.ts
+++ b/apps/api/src/lib/email/transport-email-url.test.ts
@@ -1,0 +1,142 @@
+// EMAIL_URL is the single configuration surface: it selects the provider(s),
+// the order they are tried in, and (with EMAIL_FROM) the sender identity —
+// overriding every pre-EMAIL_URL variable.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const mockConfig = {
+  EMAIL_URL: '',
+  EMAIL_FROM: '',
+  EMAIL_PROVIDER_ORDER: 'ses,resend,mailtrap',
+  AWS_SES_REGION: 'us-east-2',
+  AWS_SES_ACCESS_KEY_ID: '',
+  AWS_SES_SECRET_ACCESS_KEY: '',
+  RESEND_API_KEY: '',
+  RESEND_FROM_EMAIL: '',
+  MAILPIT_API_URL: '',
+  MAILTRAP_API_TOKEN: '',
+  MAILTRAP_FROM_EMAIL: 'noreply@kortix.com',
+  MAILTRAP_FROM_NAME: 'Kortix',
+  SMTP_HOST: '',
+  SMTP_PORT: '',
+  SMTP_USER: '',
+  SMTP_PASS: '',
+};
+
+mock.module('../../config', () => ({ config: mockConfig }));
+
+const { configuredEmailProviders, emailSender, isEmailConfigured, sendEmail } =
+  await import('./transport');
+
+let calls: Array<{ url: string; init: RequestInit }> = [];
+let responder: (url: string) => Response;
+
+beforeEach(() => {
+  calls = [];
+  responder = () => new Response('{}', { status: 200 });
+  Object.assign(mockConfig, {
+    EMAIL_URL: '',
+    EMAIL_FROM: '',
+    EMAIL_PROVIDER_ORDER: 'ses,resend,mailtrap',
+    RESEND_API_KEY: '',
+    RESEND_FROM_EMAIL: '',
+    MAILTRAP_API_TOKEN: '',
+    MAILPIT_API_URL: '',
+    SMTP_HOST: '',
+    SMTP_USER: '',
+    SMTP_PASS: '',
+  });
+  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return responder(String(url));
+  }) as unknown as typeof fetch;
+});
+
+const MSG = {
+  to: ['user@example.test'],
+  subject: 'Test',
+  html: '<p>hello</p>',
+  category: 'unit-test',
+};
+
+describe('EMAIL_URL configuration', () => {
+  test('one URL configures the provider with no other variable set', () => {
+    mockConfig.EMAIL_URL = 'resend://re_live_key';
+    expect(isEmailConfigured()).toBe(true);
+    expect(configuredEmailProviders()).toEqual(['resend']);
+  });
+
+  test('a comma-separated list becomes the fallback chain, in order', () => {
+    mockConfig.EMAIL_URL = 'ses://us-east-2,resend://re_key,mailtrap://tok';
+    expect(configuredEmailProviders()).toEqual(['ses', 'resend', 'mailtrap']);
+  });
+
+  test('EMAIL_URL overrides the pre-EMAIL_URL variables entirely', () => {
+    mockConfig.RESEND_API_KEY = 're_legacy';
+    mockConfig.MAILTRAP_API_TOKEN = 'tok_legacy';
+    mockConfig.EMAIL_URL = 'mailpit://127.0.0.1:8025';
+    expect(configuredEmailProviders()).toEqual(['mailpit']);
+  });
+
+  test('an unparsable EMAIL_URL disables delivery rather than sending anywhere else', () => {
+    mockConfig.RESEND_API_KEY = 're_legacy';
+    mockConfig.EMAIL_URL = 'not-a-url';
+    expect(isEmailConfigured()).toBe(false);
+  });
+
+  test('EMAIL_FROM sets the sender; without it the legacy pair still applies', () => {
+    mockConfig.EMAIL_FROM = 'Acme Support <no-reply@acme.test>';
+    expect(emailSender()).toEqual({ email: 'no-reply@acme.test', name: 'Acme Support' });
+    mockConfig.EMAIL_FROM = '';
+    expect(emailSender()).toEqual({ email: 'noreply@kortix.com', name: 'Kortix' });
+  });
+
+  test('the sender reaches the provider payload', async () => {
+    mockConfig.EMAIL_URL = 'resend://re_key';
+    mockConfig.EMAIL_FROM = 'Acme <no-reply@acme.test>';
+    const result = await sendEmail(MSG);
+    expect(result).toEqual({ ok: true, provider: 'resend', status: 200 });
+    expect(JSON.parse(String(calls[0]!.init.body)).from).toBe('Acme <no-reply@acme.test>');
+  });
+
+  test('a failing provider falls through to the next in the chain', async () => {
+    mockConfig.EMAIL_URL = 'resend://re_key,mailtrap://tok';
+    responder = (url) =>
+      url.includes('resend') ? new Response('nope', { status: 403 }) : new Response('{}', { status: 200 });
+    const result = await sendEmail(MSG);
+    expect(result).toEqual({ ok: true, provider: 'mailtrap', status: 200 });
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe('pre-EMAIL_URL SMTP variables', () => {
+  test('SMTP_* is used when listed in EMAIL_PROVIDER_ORDER', () => {
+    mockConfig.SMTP_HOST = 'smtp.example.com';
+    mockConfig.SMTP_PORT = '587';
+    mockConfig.SMTP_USER = 'alice';
+    mockConfig.SMTP_PASS = 'secret';
+    mockConfig.EMAIL_PROVIDER_ORDER = 'smtp';
+    expect(configuredEmailProviders()).toEqual(['smtp']);
+  });
+
+  // The upgrade path for a self-host that configured SMTP for GoTrue before
+  // EMAIL_URL existed: product email starts working with no new setting.
+  test('a GoTrue-only SMTP relay is picked up by the DEFAULT provider order', () => {
+    mockConfig.SMTP_HOST = 'smtp.example.com';
+    mockConfig.SMTP_PORT = '587';
+    mockConfig.SMTP_USER = 'alice';
+    mockConfig.SMTP_PASS = 'secret';
+    mockConfig.EMAIL_PROVIDER_ORDER = '';
+    expect(configuredEmailProviders()).toEqual(['smtp']);
+  });
+
+  // A self-host created before EMAIL_URL shipped carries this inert quartet so
+  // GoTrue can boot. Treating it as configured would turn a clean
+  // `email_not_configured` skip into connection-refused on every invite.
+  test('the self-host placeholder quartet is NOT a configured provider', () => {
+    mockConfig.SMTP_HOST = 'localhost';
+    mockConfig.SMTP_USER = 'unused';
+    mockConfig.SMTP_PASS = 'unused';
+    mockConfig.EMAIL_PROVIDER_ORDER = 'smtp';
+    expect(isEmailConfigured()).toBe(false);
+  });
+});

--- a/apps/api/src/lib/email/transport.test.ts
+++ b/apps/api/src/lib/email/transport.test.ts
@@ -121,6 +121,8 @@ describe('configuredEmailProviders', () => {
       To: [{ Email: 'user@example.test' }],
       Subject: 'Test',
       HTML: '<p>hello</p>',
+      // Empty: this caller passes no `text`. Kortix templates all supply one
+      // (see template.ts renderText); nothing is derived from the HTML.
       Text: '',
       Tags: ['unit-test'],
     });

--- a/apps/api/src/lib/email/transport.ts
+++ b/apps/api/src/lib/email/transport.ts
@@ -1,52 +1,160 @@
-// Shared transactional-email transport with a provider fallback chain.
+// One transactional-email transport for the whole platform.
 //
-// Born out of the 2026-08-05 Mailtrap suspension: a single email vendor is a
-// single point of failure for invites, access requests, and lead
-// notifications, so every send now walks EMAIL_PROVIDER_ORDER (default
-// "ses,resend,mailtrap") and falls through to the next configured provider on
-// any failure. A provider is "configured" iff its credentials are present, so
-// each environment enables only what it has keys for.
+// Every email Kortix sends — account invites, project invites, access
+// requests, demo leads, and (via the Supabase send-email hook) magic links,
+// signup confirmations and password recovery — goes through sendEmail() here.
+// One sender identity, one provider chain, one place to add a provider.
 //
-// All three providers speak plain `fetch` — SES via a SigV4-signed SESv2
-// SendEmail call (node:crypto, no AWS SDK dependency) — which keeps this
-// module mockable with the same global-fetch pattern the existing email tests
-// use.
-import { createHash, createHmac } from 'node:crypto';
-import { defaultProvider } from '@aws-sdk/credential-provider-node';
-
+// Configuration is a single connection string, EMAIL_URL (see dsn.ts), plus
+// EMAIL_FROM for the sender identity. The per-provider env vars that predate
+// it (RESEND_API_KEY, AWS_SES_*, MAILTRAP_API_TOKEN, MAILPIT_API_URL,
+// EMAIL_PROVIDER_ORDER) still work unchanged and are used whenever EMAIL_URL
+// is unset, so deployed environments keep sending with no env change.
+//
+// The chain exists because a single vendor is a single point of failure: the
+// 2026-08-05 Mailtrap suspension took invites down. Any failure falls through
+// to the next configured provider.
 import { config } from '../../config';
+import { formatEmailAddress, parseEmailAddress } from './address';
+import { parseEmailTargets, type EmailTarget } from '@kortix/shared/email-url';
+import { sendViaMailpit, sendViaMailtrap, sendViaResend } from './providers/http';
+import { sendViaSes } from './providers/ses';
+import { sendViaSmtp } from './providers/smtp';
+import type {
+  EmailAddress,
+  EmailMessage,
+  EmailProvider,
+  EmailSendResult,
+  ResolvedEmailMessage,
+} from './types';
 
-export type EmailProvider = 'ses' | 'resend' | 'mailtrap' | 'mailpit';
+export type { EmailAddress, EmailMessage, EmailProvider, EmailSendResult } from './types';
+export { closeSmtpTransports } from './providers/smtp';
 
-export interface EmailMessage {
-  to: string[];
-  subject: string;
-  html: string;
-  // Provider-side label for the send (SES tag / Resend tag / Mailtrap
-  // category). Letters, numbers, dashes, underscores only.
-  category: string;
-  // Defaults to MAILTRAP_FROM_EMAIL / MAILTRAP_FROM_NAME.
-  from?: { email: string; name: string };
+const FALLBACK_FROM: EmailAddress = { email: 'noreply@kortix.com', name: 'Kortix' };
+
+let loggedUrlErrors = '';
+
+/**
+ * The ordered provider chain plus the sender identity, resolved fresh on every
+ * call: config is read lazily so tests (and a future hot-reload) see current
+ * values rather than a snapshot taken at import time.
+ */
+export function resolveEmailChain(): { targets: EmailTarget[]; from: EmailAddress } {
+  const from = resolveSender();
+
+  const raw = (config.EMAIL_URL || '').trim();
+  if (raw) {
+    const { targets, errors } = parseEmailTargets(raw);
+    if (errors.length) {
+      // Log each distinct fault once — a bad EMAIL_URL is a startup-class
+      // mistake and must not spam a line per send.
+      const fingerprint = errors.join('|');
+      if (fingerprint !== loggedUrlErrors) {
+        loggedUrlErrors = fingerprint;
+        for (const error of errors) console.error(`[email] ignoring EMAIL_URL entry: ${error}`);
+      }
+    }
+    return { targets, from };
+  }
+
+  return { targets: legacyTargets(), from };
 }
 
-export type EmailSendResult =
-  | { ok: true; provider: EmailProvider; status: number }
-  | { ok: false; skipped: true; reason: 'email_not_configured' }
-  | { ok: false; skipped?: false; provider: EmailProvider; status?: number; error: string };
+/**
+ * EMAIL_FROM wins. Without it the pre-EMAIL_FROM pair is used: the MAILTRAP_
+ * prefix is historical — those two have always set the global sender identity,
+ * whichever provider actually did the sending.
+ */
+function resolveSender(): EmailAddress {
+  const explicit = parseEmailAddress(config.EMAIL_FROM);
+  if (explicit) return explicit;
+  const legacy = (config.MAILTRAP_FROM_EMAIL || '').trim();
+  if (legacy) return { email: legacy, name: config.MAILTRAP_FROM_NAME || '' };
+  return FALLBACK_FROM;
+}
 
-const SEND_TIMEOUT_MS = 10_000;
+/**
+ * Build the chain from the pre-EMAIL_URL environment variables. Deployed Kortix
+ * (dev/staging/prod) still runs on these, so this path is load-bearing, not a
+ * deprecation shim.
+ */
+function legacyTargets(): EmailTarget[] {
+  const order = (config.EMAIL_PROVIDER_ORDER || 'ses,resend,mailtrap,smtp')
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
 
-function isConfigured(provider: EmailProvider): boolean {
-  switch (provider) {
-    case 'ses':
-      return !!(config.AWS_SES_ACCESS_KEY_ID && config.AWS_SES_SECRET_ACCESS_KEY) || hasAwsWorkloadIdentity();
-    case 'resend':
-      return !!config.RESEND_API_KEY;
-    case 'mailtrap':
-      return !!config.MAILTRAP_API_TOKEN;
-    case 'mailpit':
-      return !!config.MAILPIT_API_URL;
+  const targets: EmailTarget[] = [];
+  for (const provider of order) {
+    switch (provider) {
+      case 'ses': {
+        const hasStatic = !!(config.AWS_SES_ACCESS_KEY_ID && config.AWS_SES_SECRET_ACCESS_KEY);
+        if (!hasStatic && !hasAwsWorkloadIdentity()) break;
+        targets.push({
+          kind: 'ses',
+          region: config.AWS_SES_REGION || 'us-east-2',
+          ...(hasStatic
+            ? {
+                accessKeyId: config.AWS_SES_ACCESS_KEY_ID,
+                secretAccessKey: config.AWS_SES_SECRET_ACCESS_KEY,
+              }
+            : {}),
+        });
+        break;
+      }
+      case 'resend':
+        if (config.RESEND_API_KEY) targets.push({ kind: 'resend', apiKey: config.RESEND_API_KEY });
+        break;
+      case 'mailtrap':
+        if (config.MAILTRAP_API_TOKEN) {
+          targets.push({ kind: 'mailtrap', token: config.MAILTRAP_API_TOKEN });
+        }
+        break;
+      case 'mailpit':
+        if (config.MAILPIT_API_URL) {
+          targets.push({ kind: 'mailpit', baseUrl: config.MAILPIT_API_URL });
+        }
+        break;
+      case 'smtp': {
+        const target = legacySmtpTarget();
+        if (target) targets.push(target);
+        break;
+      }
+      default:
+        break;
+    }
   }
+  return targets;
+}
+
+/**
+ * Discrete SMTP_* variables, as GoTrue consumes them. Self-host installs
+ * created before EMAIL_URL shipped carry a PLACEHOLDER quartet
+ * (`localhost` / `unused` / `unused`) written by `kortix self-host init` so
+ * GoTrue would boot with no relay. Treating that as a configured provider
+ * would turn a clean `email_not_configured` skip into a connection-refused
+ * failure on every invite, so it is explicitly not configured.
+ */
+function legacySmtpTarget(): EmailTarget | null {
+  const host = (config.SMTP_HOST || '').trim();
+  if (!host) return null;
+  const user = (config.SMTP_USER || '').trim();
+  const pass = (config.SMTP_PASS || '').trim();
+  if (host === 'localhost' && user === 'unused' && pass === 'unused') return null;
+
+  const port = Number(config.SMTP_PORT) || 587;
+  const secure = port === 465;
+  return {
+    kind: 'smtp',
+    host,
+    port,
+    secure,
+    requireTls: !secure && Boolean(user || pass),
+    rejectUnauthorized: true,
+    ...(user ? { user } : {}),
+    ...(pass ? { pass } : {}),
+  };
 }
 
 function hasAwsWorkloadIdentity(): boolean {
@@ -59,185 +167,50 @@ function hasAwsWorkloadIdentity(): boolean {
 
 /** Providers that will be attempted, in order. Empty = no email delivery. */
 export function configuredEmailProviders(): EmailProvider[] {
-  return (config.EMAIL_PROVIDER_ORDER || 'ses,resend,mailtrap')
-    .split(',')
-    .map((p) => p.trim().toLowerCase())
-    .filter(
-      (p): p is EmailProvider =>
-        p === 'ses' || p === 'resend' || p === 'mailtrap' || p === 'mailpit',
-    )
-    .filter(isConfigured);
+  return resolveEmailChain().targets.map((target) => target.kind);
 }
 
 export function isEmailConfigured(): boolean {
-  return configuredEmailProviders().length > 0;
+  return resolveEmailChain().targets.length > 0;
 }
 
-function resolveFrom(msg: EmailMessage): { email: string; name: string } {
-  return msg.from ?? { email: config.MAILTRAP_FROM_EMAIL, name: config.MAILTRAP_FROM_NAME };
+/** The address every email is sent from, after EMAIL_FROM / legacy fallback. */
+export function emailSender(): EmailAddress {
+  return resolveEmailChain().from;
 }
 
-// ── AWS SES (SESv2 SendEmail, SigV4) ─────────────────────────────────────────
-
-function hmac(key: Buffer | string, data: string): Buffer {
-  return createHmac('sha256', key).update(data, 'utf8').digest();
+/** Operator-facing description of the chain, safe to log (no credentials). */
+export function describeEmailChain(): string {
+  const { targets, from } = resolveEmailChain();
+  if (!targets.length) return 'email: not configured';
+  return `email: ${targets.map((t) => t.kind).join(' → ')} as ${formatEmailAddress(from)}`;
 }
 
-function sha256Hex(data: string): string {
-  return createHash('sha256').update(data, 'utf8').digest('hex');
+function resolve(msg: EmailMessage, from: EmailAddress): ResolvedEmailMessage {
+  return {
+    ...msg,
+    from: msg.from ?? from,
+    // Every Kortix template supplies its own plain-text alternative, rendered
+    // from the same structured content as the HTML (see template.ts). There is
+    // deliberately no HTML-to-text fallback.
+    text: msg.text ?? '',
+  };
 }
 
-async function sendViaSes(msg: EmailMessage): Promise<EmailSendResult> {
-  const region = config.AWS_SES_REGION || 'us-east-2';
-  const host = `email.${region}.amazonaws.com`;
-  const path = '/v2/email/outbound-emails';
-  const from = resolveFrom(msg);
-  const credentials =
-    config.AWS_SES_ACCESS_KEY_ID && config.AWS_SES_SECRET_ACCESS_KEY
-      ? {
-          accessKeyId: config.AWS_SES_ACCESS_KEY_ID,
-          secretAccessKey: config.AWS_SES_SECRET_ACCESS_KEY,
-        }
-      : await defaultProvider()();
-
-  const body = JSON.stringify({
-    FromEmailAddress: `${from.name} <${from.email}>`,
-    Destination: { ToAddresses: msg.to },
-    Content: {
-      Simple: {
-        Subject: { Data: msg.subject, Charset: 'UTF-8' },
-        Body: { Html: { Data: msg.html, Charset: 'UTF-8' } },
-      },
-    },
-    EmailTags: [{ Name: 'category', Value: msg.category }],
-  });
-
-  const amzDate = new Date().toISOString().replace(/[:-]|\.\d{3}/g, ''); // YYYYMMDDTHHMMSSZ
-  const dateStamp = amzDate.slice(0, 8);
-  const payloadHash = sha256Hex(body);
-  const securityTokenHeader = credentials.sessionToken
-    ? `x-amz-security-token:${credentials.sessionToken}\n`
-    : '';
-  const canonicalHeaders = `content-type:application/json\nhost:${host}\nx-amz-content-sha256:${payloadHash}\nx-amz-date:${amzDate}\n${securityTokenHeader}`;
-  const signedHeaders = credentials.sessionToken
-    ? 'content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token'
-    : 'content-type;host;x-amz-content-sha256;x-amz-date';
-  const canonicalRequest = `POST\n${path}\n\n${canonicalHeaders}\n${signedHeaders}\n${payloadHash}`;
-  const scope = `${dateStamp}/${region}/ses/aws4_request`;
-  const stringToSign = `AWS4-HMAC-SHA256\n${amzDate}\n${scope}\n${sha256Hex(canonicalRequest)}`;
-  const signingKey = hmac(
-    hmac(hmac(hmac(`AWS4${credentials.secretAccessKey}`, dateStamp), region), 'ses'),
-    'aws4_request',
-  );
-  const signature = createHmac('sha256', signingKey).update(stringToSign, 'utf8').digest('hex');
-
-  const res = await fetch(`https://${host}${path}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Amz-Content-Sha256': payloadHash,
-      'X-Amz-Date': amzDate,
-      ...(credentials.sessionToken ? { 'X-Amz-Security-Token': credentials.sessionToken } : {}),
-      Authorization: `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
-    },
-    body,
-    signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    return { ok: false, provider: 'ses', status: res.status, error: text || res.statusText };
+function dispatch(msg: ResolvedEmailMessage, target: EmailTarget): Promise<EmailSendResult> {
+  switch (target.kind) {
+    case 'smtp':
+      return sendViaSmtp(msg, target);
+    case 'resend':
+      return sendViaResend(msg, target);
+    case 'ses':
+      return sendViaSes(msg, target);
+    case 'mailtrap':
+      return sendViaMailtrap(msg, target);
+    case 'mailpit':
+      return sendViaMailpit(msg, target);
   }
-  return { ok: true, provider: 'ses', status: res.status };
 }
-
-// ── Resend ───────────────────────────────────────────────────────────────────
-
-async function sendViaResend(msg: EmailMessage): Promise<EmailSendResult> {
-  const from = resolveFrom(msg);
-  // While the primary from-domain is not verified in the Resend team,
-  // RESEND_FROM_EMAIL substitutes a verified sender and keeps the intended
-  // address as Reply-To.
-  const fromEmail = config.RESEND_FROM_EMAIL || from.email;
-  const res = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${config.RESEND_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      from: `${from.name} <${fromEmail}>`,
-      to: msg.to,
-      subject: msg.subject,
-      html: msg.html,
-      ...(fromEmail !== from.email ? { reply_to: from.email } : {}),
-      tags: [{ name: 'category', value: msg.category }],
-    }),
-    signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    return { ok: false, provider: 'resend', status: res.status, error: text || res.statusText };
-  }
-  return { ok: true, provider: 'resend', status: res.status };
-}
-
-// ── Mailtrap ─────────────────────────────────────────────────────────────────
-
-async function sendViaMailtrap(msg: EmailMessage): Promise<EmailSendResult> {
-  const from = resolveFrom(msg);
-  const res = await fetch('https://send.api.mailtrap.io/api/send', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${config.MAILTRAP_API_TOKEN}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      from: { email: from.email, name: from.name },
-      to: msg.to.map((email) => ({ email })),
-      subject: msg.subject,
-      html: msg.html,
-      category: msg.category,
-    }),
-    signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    return { ok: false, provider: 'mailtrap', status: res.status, error: text || res.statusText };
-  }
-  return { ok: true, provider: 'mailtrap', status: res.status };
-}
-
-// ── Mailpit local capture ────────────────────────────────────────────────────
-
-async function sendViaMailpit(msg: EmailMessage): Promise<EmailSendResult> {
-  const from = resolveFrom(msg);
-  const baseUrl = config.MAILPIT_API_URL.replace(/\/+$/, '');
-  const res = await fetch(`${baseUrl}/api/v1/send`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      From: { Email: from.email, Name: from.name },
-      To: msg.to.map((email) => ({ Email: email })),
-      Subject: msg.subject,
-      HTML: msg.html,
-      Text: '',
-      Tags: [msg.category],
-    }),
-    signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    return { ok: false, provider: 'mailpit', status: res.status, error: text || res.statusText };
-  }
-  return { ok: true, provider: 'mailpit', status: res.status };
-}
-
-const SENDERS: Record<EmailProvider, (msg: EmailMessage) => Promise<EmailSendResult>> = {
-  ses: sendViaSes,
-  resend: sendViaResend,
-  mailtrap: sendViaMailtrap,
-  mailpit: sendViaMailpit,
-};
 
 /**
  * Send one transactional email through the first provider in the configured
@@ -246,24 +219,52 @@ const SENDERS: Record<EmailProvider, (msg: EmailMessage) => Promise<EmailSendRes
  * whole chain is exhausted.
  */
 export async function sendEmail(msg: EmailMessage): Promise<EmailSendResult> {
-  const providers = configuredEmailProviders();
-  if (providers.length === 0) {
+  const { targets, from } = resolveEmailChain();
+  if (targets.length === 0) {
     return { ok: false, skipped: true, reason: 'email_not_configured' };
   }
 
+  const variants = applyLegacyResendSenderOverride(resolve(msg, from), targets);
+
   let lastFailure: EmailSendResult | null = null;
-  for (const provider of providers) {
+  for (const target of targets) {
+    const resolved = target.kind === 'resend' ? variants.resend : variants.default;
     let result: EmailSendResult;
     try {
-      result = await SENDERS[provider](msg);
+      result = await dispatch(resolved, target);
     } catch (err) {
-      result = { ok: false, provider, error: (err as Error).message };
+      result = { ok: false, provider: target.kind, error: (err as Error).message };
     }
     if (result.ok) return result;
     console.warn(
-      `[email] ${provider} send failed (${'status' in result && result.status ? result.status : 'network'}): ${'error' in result ? result.error : 'unknown'}`,
+      `[email] ${target.kind} send failed (${'status' in result && result.status ? result.status : 'network'}): ${'error' in result ? result.error : 'unknown'}`,
     );
     lastFailure = result;
   }
   return lastFailure as EmailSendResult;
+}
+
+/**
+ * RESEND_FROM_EMAIL substitutes a verified sender on the Resend leg only, while
+ * the intended address is preserved as Reply-To. It exists because the primary
+ * from-domain is not verified in the Resend team; it applies to no other
+ * provider, so the Resend variant of the message is built separately.
+ */
+function applyLegacyResendSenderOverride(
+  msg: ResolvedEmailMessage,
+  targets: EmailTarget[],
+): { default: ResolvedEmailMessage; resend: ResolvedEmailMessage } {
+  const override = (config.RESEND_FROM_EMAIL || '').trim();
+  const usesResend = targets.some((target) => target.kind === 'resend');
+  if (!override || !usesResend || override === msg.from.email) {
+    return { default: msg, resend: msg };
+  }
+  return {
+    default: msg,
+    resend: {
+      ...msg,
+      from: { email: override, name: msg.from.name },
+      replyTo: msg.replyTo ?? msg.from.email,
+    },
+  };
 }

--- a/apps/api/src/lib/email/types.ts
+++ b/apps/api/src/lib/email/types.ts
@@ -1,0 +1,41 @@
+import type { EmailTargetKind } from '@kortix/shared/email-url';
+
+/** Provider that actually accepted (or rejected) a send. */
+export type EmailProvider = EmailTargetKind;
+
+export interface EmailAddress {
+  email: string;
+  name: string;
+}
+
+export interface EmailMessage {
+  to: string[];
+  subject: string;
+  html: string;
+  /** Plain-text alternative. Derived from `html` when omitted. */
+  text?: string;
+  /** Provider-side label for the send (SES tag / Resend tag / Mailtrap category). */
+  category: string;
+  /** Defaults to the transport's configured sender (EMAIL_FROM). */
+  from?: EmailAddress;
+  replyTo?: string;
+}
+
+export type EmailSendResult =
+  | { ok: true; provider: EmailProvider; status: number }
+  | { ok: false; skipped: true; reason: 'email_not_configured' }
+  | {
+      ok: false;
+      skipped?: false;
+      provider: EmailProvider;
+      status?: number;
+      error: string;
+    };
+
+/** A message with every default already applied, as handed to a provider. */
+export interface ResolvedEmailMessage extends EmailMessage {
+  from: EmailAddress;
+  text: string;
+}
+
+export const EMAIL_SEND_TIMEOUT_MS = 10_000;

--- a/apps/api/src/lib/webhooks/standard-webhooks.test.ts
+++ b/apps/api/src/lib/webhooks/standard-webhooks.test.ts
@@ -1,0 +1,96 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, test } from 'bun:test';
+
+import {
+  decodeSecrets,
+  readStandardWebhookHeaders,
+  verifyStandardWebhook,
+} from './standard-webhooks';
+
+const SECRET_BYTES = Buffer.from('a'.repeat(32));
+const BASE64 = SECRET_BYTES.toString('base64');
+const NOW = 1_700_000_000_000;
+
+function sign(rawBody: string, id: string, timestamp: string, key = SECRET_BYTES): string {
+  return `v1,${createHmac('sha256', key).update(`${id}.${timestamp}.${rawBody}`).digest('base64')}`;
+}
+
+describe('verifyStandardWebhook', () => {
+  const rawBody = '{"user":{"email":"a@b.test"}}';
+  const id = 'msg_1';
+  const timestamp = String(Math.floor(NOW / 1000));
+
+  test('accepts a valid signature under every secret encoding', () => {
+    // Supabase writes `v1,whsec_<base64>`; Svix senders use `whsec_<base64>`.
+    for (const secret of [BASE64, `whsec_${BASE64}`, `v1,whsec_${BASE64}`]) {
+      expect(
+        verifyStandardWebhook({
+          rawBody,
+          secret,
+          headers: { id, timestamp, signature: sign(rawBody, id, timestamp) },
+          now: NOW,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test('rejects a tampered body, a wrong key, and a missing signature', () => {
+    const headers = { id, timestamp, signature: sign(rawBody, id, timestamp) };
+    expect(verifyStandardWebhook({ rawBody: `${rawBody} `, secret: BASE64, headers, now: NOW })).toBe(false);
+    expect(
+      verifyStandardWebhook({
+        rawBody,
+        secret: Buffer.from('b'.repeat(32)).toString('base64'),
+        headers,
+        now: NOW,
+      }),
+    ).toBe(false);
+    expect(
+      verifyStandardWebhook({ rawBody, secret: BASE64, headers: { id, timestamp, signature: '' }, now: NOW }),
+    ).toBe(false);
+  });
+
+  test('rejects a replay outside the timestamp tolerance', () => {
+    const old = String(Math.floor(NOW / 1000) - 600);
+    expect(
+      verifyStandardWebhook({
+        rawBody,
+        secret: BASE64,
+        headers: { id, timestamp: old, signature: sign(rawBody, id, old) },
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  test('accepts either secret while one is being rotated', () => {
+    const next = Buffer.from('c'.repeat(32));
+    expect(
+      verifyStandardWebhook({
+        rawBody,
+        secret: `v1,whsec_${BASE64} v1,whsec_${next.toString('base64')}`,
+        headers: { id, timestamp, signature: sign(rawBody, id, timestamp, next) },
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('decodeSecrets', () => {
+  test('ignores empty and undecodable entries', () => {
+    expect(decodeSecrets('')).toEqual([]);
+    expect(decodeSecrets(`v1,whsec_${BASE64}`)).toHaveLength(1);
+  });
+});
+
+describe('readStandardWebhookHeaders', () => {
+  test('prefers standard names and falls back to the legacy svix-* ones', () => {
+    expect(
+      readStandardWebhookHeaders((name) => (name === 'svix-id' ? 'legacy' : undefined)),
+    ).toEqual({ id: 'legacy', timestamp: '', signature: '' });
+    expect(
+      readStandardWebhookHeaders((name) =>
+        name === 'webhook-id' ? 'standard' : name === 'svix-id' ? 'legacy' : undefined,
+      ).id,
+    ).toBe('standard');
+  });
+});

--- a/apps/api/src/lib/webhooks/standard-webhooks.ts
+++ b/apps/api/src/lib/webhooks/standard-webhooks.ts
@@ -1,0 +1,89 @@
+// Standard Webhooks (standardwebhooks.com) signature verification.
+//
+// Two senders reach this API with that scheme — AgentMail (inbound email) and
+// Supabase Auth (the send-email hook) — so the HMAC comparison lives in one
+// place instead of once per integration. Both accept the legacy `svix-*`
+// header names as well as the standardized `webhook-*` ones.
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const DEFAULT_TOLERANCE_S = 5 * 60;
+
+export interface StandardWebhookHeaders {
+  id: string;
+  timestamp: string;
+  signature: string;
+}
+
+/**
+ * Verify a Standard Webhooks signature over the RAW request body.
+ *
+ * `secret` accepts `whsec_<base64>`, a bare base64 secret, or the
+ * `v1,whsec_<base64>` form Supabase writes for auth hooks. Several
+ * space-separated secrets are accepted so a secret can be rotated without
+ * downtime; the signature only has to match one.
+ */
+export function verifyStandardWebhook(input: {
+  rawBody: string;
+  secret: string;
+  headers: StandardWebhookHeaders;
+  toleranceSeconds?: number;
+  now?: number;
+}): boolean {
+  const tolerance = input.toleranceSeconds ?? DEFAULT_TOLERANCE_S;
+  const ts = Number(input.headers.timestamp);
+  if (!Number.isFinite(ts)) return false;
+  const nowSeconds = Math.floor((input.now ?? Date.now()) / 1000);
+  if (Math.abs(nowSeconds - ts) > tolerance) return false;
+
+  const keys = decodeSecrets(input.secret);
+  if (!keys.length) return false;
+
+  const signed = `${input.headers.id}.${input.headers.timestamp}.${input.rawBody}`;
+  const expected = keys.map((key) => createHmac('sha256', key).update(signed).digest('base64'));
+
+  for (const part of input.headers.signature.split(/\s+/)) {
+    const [version, sig] = part.split(',');
+    if (version !== 'v1' || !sig) continue;
+    for (const candidate of expected) {
+      const a = Buffer.from(sig);
+      const b = Buffer.from(candidate);
+      if (a.length === b.length && timingSafeEqual(a, b)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Decode one or more signing secrets. Supabase stores auth-hook secrets as
+ * `v1,whsec_<base64>`; Svix-style senders use a bare `whsec_<base64>`.
+ */
+export function decodeSecrets(secret: string): Buffer[] {
+  const keys: Buffer[] = [];
+  for (const entry of (secret || '').split(/\s+/)) {
+    const value = entry.trim();
+    if (!value) continue;
+    // Strip an optional `v<n>,` version prefix, then an optional `whsec_`.
+    const withoutVersion = value.replace(/^v\d+,/, '');
+    const raw = withoutVersion.startsWith('whsec_')
+      ? withoutVersion.slice('whsec_'.length)
+      : withoutVersion;
+    try {
+      const decoded = Buffer.from(raw, 'base64');
+      if (decoded.length) keys.push(decoded);
+    } catch {
+      // Skip an undecodable secret rather than failing the whole set.
+    }
+  }
+  return keys;
+}
+
+/** Read the signature headers under either the standard or legacy names. */
+export function readStandardWebhookHeaders(
+  get: (name: string) => string | undefined,
+): StandardWebhookHeaders {
+  return {
+    id: get('webhook-id') ?? get('svix-id') ?? '',
+    timestamp: get('webhook-timestamp') ?? get('svix-timestamp') ?? '',
+    signature: get('webhook-signature') ?? get('svix-signature') ?? '',
+  };
+}

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -23,6 +23,8 @@ import {
   writeSupabaseVendorAssets,
 } from '../self-host/compose-assets.ts';
 import { SHARED_SELF_HOST_DEFAULTS } from '../self-host/shared-runtime-defaults.ts';
+import { applyEmailWiring } from '../self-host/email-wiring.ts';
+import { parseEmailTargets, redactUrl } from '@kortix/shared/email-url';
 import {
   CATEGORY_LABELS,
   groupSecretsByCategory,
@@ -630,6 +632,25 @@ function selfHostDoctor(flags: GlobalFlags): number {
         ? actual
         : `stale KORTIX_INSTANCE_DIR="${recorded}" (actual: ${actual}) — run \`kortix self-host configure\` (or any of init/start/update/env set) to reconcile`,
     });
+  }
+  if (existsSync(envPath(flags.instance))) {
+    // A malformed EMAIL_URL is silent otherwise: the API logs one line at the
+    // first send and then skips delivery, so the operator learns about it from
+    // a missing invite. Parse it here, with the same parser the API uses.
+    const env = loadEnv(flags.instance);
+    const raw = (env?.EMAIL_URL ?? '').trim();
+    if (raw) {
+      const { targets, errors } = parseEmailTargets(raw);
+      checks.push({
+        name: 'email-url',
+        ok: errors.length === 0 && targets.length > 0,
+        detail: errors.length
+          ? errors.join('; ')
+          : targets.length
+            ? `${targets.map((target) => target.kind).join(' → ')} (${redactUrl(raw.split(',')[0]!.trim())})`
+            : 'no usable provider',
+      });
+    }
   }
   const ok = checks.every((check) => check.ok);
   if (flags.json) {
@@ -1383,6 +1404,7 @@ async function selfHostEnvSet(args: string[], flags: GlobalFlags): Promise<numbe
   }
 
   const changedKeys: string[] = [];
+  const previousEmailUrl = env.EMAIL_URL ?? '';
 
   // `env set KEY` (no '=') — prompt interactively for exactly one key.
   if (args.length === 1 && !args[0]!.includes('=')) {
@@ -1415,9 +1437,18 @@ async function selfHostEnvSet(args: string[], flags: GlobalFlags): Promise<numbe
     }
   }
 
+  // EMAIL_URL is the one email setting; everything else it implies (the GoTrue
+  // send-email hook, its shared secret, the sender identity, and the auth
+  // behavior flags) is derived here rather than typed by the operator.
+  const wiring = applyEmailWiring(env, previousEmailUrl);
+  changedKeys.push(...wiring.changed);
+
   writeEnv(flags.instance, env);
   writeCompose(flags.instance, env);
   process.stdout.write(`${status.ok(`Updated ${changedKeys.join(', ')}`)}\n`);
+  for (const note of wiring.notes) {
+    process.stdout.write(`  ${C.dim}${note}${C.reset}\n`);
+  }
   return restartServicesForKeys(flags.instance, env, changedKeys);
 }
 
@@ -2030,7 +2061,7 @@ function shouldPrompt(flags: GlobalFlags): boolean {
 function renderConnectionSummary(env: SelfHostEnv): void {
   // The ONLY row gated as configured/missing here is the sandbox runtime — the
   // one connection the CLI still requires (see missingRequiredSecrets()).
-  // Everything else (managed git, LLM key, connectors, SMTP) is dashboard
+  // Everything else (managed git, LLM key, connectors, EMAIL_URL) is dashboard
   // territory — see renderAfterStartNote() below, not a CLI configured/missing
   // gate that would incorrectly suggest a CLI fix is needed.
   const provider = sandboxProviders(env)[0];
@@ -2064,7 +2095,7 @@ function renderConnectionSummary(env: SelfHostEnv): void {
  */
 function renderAfterStartNote(): void {
   process.stdout.write(
-    `  ${C.dim}After start ${C.reset}Sign in → Settings → Git to connect GitHub (projects) · connect your model key in the app (BYOK) · optional: connectors, SMTP — all in the dashboard.${C.reset}\n\n`,
+    `  ${C.dim}After start ${C.reset}Sign in → Settings → Git to connect GitHub (projects) · connect your model key in the app (BYOK) · optional: connectors · email with ${C.reset}env set EMAIL_URL=smtp://user:pass@host:587${C.dim}.${C.reset}\n\n`,
   );
 }
 
@@ -2240,6 +2271,20 @@ function defaultEnv(flags: GlobalFlags): SelfHostEnv {
     // Auth + agent sandbox defaults shared with every self-host flavor — see
     // shared-runtime-defaults.ts for why these must not be duplicated here.
     ...SHARED_SELF_HOST_DEFAULTS,
+    // ONE setting turns on email, for auth AND product mail alike:
+    //   kortix self-host env set EMAIL_URL=smtp://user:pass@smtp.example.com:587
+    // applyEmailWiring() derives the GoTrue send-email hook, the shared HMAC
+    // secret, the sender identity and the auth behavior flags from it.
+    EMAIL_URL: '',
+    EMAIL_FROM: '',
+    AUTH_EMAIL_HOOK_SECRET: '',
+    GOTRUE_HOOK_SEND_EMAIL_ENABLED: 'false',
+    GOTRUE_HOOK_SEND_EMAIL_URI: '',
+    // GoTrue refuses to boot without an SMTP host, so a fresh instance carries
+    // this inert placeholder quartet until real email is configured. The API
+    // recognizes exactly this combination as "not configured" rather than
+    // trying to deliver invites through it — see legacySmtpTarget() in
+    // apps/api/src/lib/email/transport.ts.
     SMTP_ADMIN_EMAIL: 'admin@localhost',
     SMTP_HOST: 'localhost',
     SMTP_PORT: '587',
@@ -2447,6 +2492,12 @@ function normalizeFullSupabaseEnv(instance: string, env: SelfHostEnv): void {
 
   env.API_EXTERNAL_URL = `${env.SUPABASE_PUBLIC_URL.replace(/\/$/, '')}/auth/v1`;
   env.SITE_URL = env.PUBLIC_URL;
+
+  // Reconcile the email-derived keys on every write. Passing the CURRENT
+  // EMAIL_URL as the previous value makes this a no-transition reconcile: the
+  // hook URI/secret self-heal, while the auth behavior flags are left exactly
+  // as the operator last set them.
+  applyEmailWiring(env, env.EMAIL_URL);
 
   // Always recomputed (never `||=`) — see the KORTIX_INSTANCE_DIR field's doc
   // comment on SelfHostEnv. Unconditional on purpose: if the instance

--- a/apps/cli/src/self-host/__tests__/email-wiring.test.ts
+++ b/apps/cli/src/self-host/__tests__/email-wiring.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test';
+
+import { AUTH_EMAIL_HOOK_URI, applyEmailWiring } from '../email-wiring';
+
+function freshInstance(overrides: Record<string, string> = {}): Record<string, string> {
+  return {
+    EMAIL_URL: '',
+    EMAIL_FROM: '',
+    AUTH_EMAIL_HOOK_SECRET: '',
+    GOTRUE_HOOK_SEND_EMAIL_ENABLED: 'false',
+    GOTRUE_HOOK_SEND_EMAIL_URI: '',
+    ENABLE_EMAIL_AUTOCONFIRM: 'true',
+    KORTIX_PUBLIC_AUTH_METHODS: 'password',
+    KORTIX_DOMAIN: 'kortix.example.com',
+    ...overrides,
+  };
+}
+
+describe('applyEmailWiring', () => {
+  test('setting EMAIL_URL is the ONLY step an operator takes', () => {
+    const env = freshInstance();
+    env.EMAIL_URL = 'smtp://user:pass@smtp.example.com:587';
+
+    applyEmailWiring(env, '');
+
+    // GoTrue now delegates to the API, so auth mail uses the same provider.
+    expect(env.GOTRUE_HOOK_SEND_EMAIL_ENABLED).toBe('true');
+    expect(env.GOTRUE_HOOK_SEND_EMAIL_URI).toBe(AUTH_EMAIL_HOOK_URI);
+    expect(env.AUTH_EMAIL_HOOK_SECRET).toMatch(/^v1,whsec_.+/);
+    // Email works, so confirmation is required and magic-link is offered.
+    expect(env.ENABLE_EMAIL_AUTOCONFIRM).toBe('false');
+    expect(env.KORTIX_PUBLIC_AUTH_METHODS).toBe('password,magic');
+    // Sending as noreply@kortix.com from someone else's box fails SPF/DKIM.
+    expect(env.EMAIL_FROM).toBe('Kortix <noreply@kortix.example.com>');
+  });
+
+  test('an API-key provider works the same way — no SMTP anywhere', () => {
+    const env = freshInstance();
+    env.EMAIL_URL = 'resend://re_key';
+    applyEmailWiring(env, '');
+    expect(env.GOTRUE_HOOK_SEND_EMAIL_ENABLED).toBe('true');
+    expect(env.KORTIX_PUBLIC_AUTH_METHODS).toBe('password,magic');
+  });
+
+  test('the hook secret is generated once and then preserved', () => {
+    const env = freshInstance({ EMAIL_URL: 'resend://re_key' });
+    applyEmailWiring(env, '');
+    const first = env.AUTH_EMAIL_HOOK_SECRET;
+    applyEmailWiring(env, env.EMAIL_URL);
+    expect(env.AUTH_EMAIL_HOOK_SECRET).toBe(first);
+  });
+
+  test('an operator override survives every later reconcile', () => {
+    const env = freshInstance({ EMAIL_URL: 'resend://re_key' });
+    applyEmailWiring(env, '');
+
+    // Operator deliberately turns auto-confirm back on.
+    env.ENABLE_EMAIL_AUTOCONFIRM = 'true';
+    // Every subsequent write reconciles with no transition and must not fight.
+    applyEmailWiring(env, env.EMAIL_URL);
+    applyEmailWiring(env, env.EMAIL_URL);
+    expect(env.ENABLE_EMAIL_AUTOCONFIRM).toBe('true');
+  });
+
+  test('removing EMAIL_URL restores a usable instance instead of locking signups out', () => {
+    const env = freshInstance({ EMAIL_URL: 'resend://re_key' });
+    applyEmailWiring(env, '');
+    expect(env.ENABLE_EMAIL_AUTOCONFIRM).toBe('false');
+
+    const previous = env.EMAIL_URL;
+    env.EMAIL_URL = '';
+    applyEmailWiring(env, previous);
+
+    expect(env.GOTRUE_HOOK_SEND_EMAIL_ENABLED).toBe('false');
+    // Confirmation mail can no longer be sent, so requiring it would strand
+    // every new signup on an instance that cannot confirm them.
+    expect(env.ENABLE_EMAIL_AUTOCONFIRM).toBe('true');
+    expect(env.KORTIX_PUBLIC_AUTH_METHODS).toBe('password');
+  });
+
+  test('an explicit EMAIL_FROM is never overwritten', () => {
+    const env = freshInstance({ EMAIL_FROM: 'Support <help@acme.test>' });
+    env.EMAIL_URL = 'smtp://relay.acme.test:25';
+    applyEmailWiring(env, '');
+    expect(env.EMAIL_FROM).toBe('Support <help@acme.test>');
+  });
+
+  test('reports what it changed so `env set` can restart the right services', () => {
+    const env = freshInstance({ EMAIL_URL: 'resend://re_key' });
+    const outcome = applyEmailWiring(env, '');
+    expect(outcome.changed).toContain('GOTRUE_HOOK_SEND_EMAIL_ENABLED');
+    expect(outcome.changed).toContain('AUTH_EMAIL_HOOK_SECRET');
+    expect(outcome.notes.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -323,6 +323,15 @@ export function renderFullDockerCompose(composeProject: string, options: RenderC
     authEnv.GOTRUE_RATE_LIMIT_TOKEN_REFRESH ||= '150';
     authEnv.GOTRUE_RATE_LIMIT_OTP ||= '30';
     authEnv.GOTRUE_RATE_LIMIT_ANONYMOUS_USERS ||= '30';
+    // Send-email hook. When EMAIL_URL is configured, GoTrue stops sending auth
+    // mail itself and posts each one to kortix-api instead, so magic links and
+    // confirmations use the same provider, sender and templates as invites —
+    // and work over Resend/SES, which GoTrue cannot speak at all. Values are
+    // substituted from .env at `docker compose` time; applyEmailWiring() in
+    // self-host/email-wiring.ts derives all three from EMAIL_URL.
+    authEnv.GOTRUE_HOOK_SEND_EMAIL_ENABLED = '${GOTRUE_HOOK_SEND_EMAIL_ENABLED}';
+    authEnv.GOTRUE_HOOK_SEND_EMAIL_URI = '${GOTRUE_HOOK_SEND_EMAIL_URI}';
+    authEnv.GOTRUE_HOOK_SEND_EMAIL_SECRETS = '${AUTH_EMAIL_HOOK_SECRET}';
     auth.environment = authEnv;
   }
   for (const serviceName of ['supabase-analytics', 'supabase-storage']) {

--- a/apps/cli/src/self-host/email-wiring.ts
+++ b/apps/cli/src/self-host/email-wiring.ts
@@ -1,0 +1,99 @@
+// Self-host email: set EMAIL_URL, get working email. Everything else derives.
+//
+// Before this, turning on email meant setting six SMTP_* variables AND
+// remembering two more behavior flags (ENABLE_EMAIL_AUTOCONFIRM,
+// KORTIX_PUBLIC_AUTH_METHODS) — and product email (invites) still did not work,
+// because GoTrue's SMTP settings were never read by kortix-api. Now one
+// connection string configures both halves:
+//
+//   kortix self-host env set EMAIL_URL=smtp://user:pass@smtp.example.com:587
+//
+// From that single value this module derives the GoTrue send-email hook (so
+// auth mail is rendered and sent by kortix-api through the same provider),
+// generates the shared HMAC secret, and — only on the transition into or out
+// of "email configured" — flips the auth behavior flags so magic-link sign-in
+// turns on with email and turns back off without it. Deriving only on the
+// transition is what makes a later operator override stick: a steady-state
+// rule would re-apply itself on every write and fight the operator forever.
+import { randomBytes } from 'node:crypto';
+
+/** Where GoTrue posts the send-email hook: the API, over the compose network. */
+export const AUTH_EMAIL_HOOK_URI = 'http://kortix-api:8008/v1/webhooks/auth/send-email';
+
+export interface EmailWiringOutcome {
+  /** Keys this module changed, for restart-service accumulation. */
+  changed: string[];
+  /** Operator-facing lines describing what was derived. */
+  notes: string[];
+}
+
+/** `v1,whsec_<base64>` — the secret format Supabase Auth hooks expect. */
+export function generateAuthEmailHookSecret(): string {
+  return `v1,whsec_${randomBytes(32).toString('base64')}`;
+}
+
+function isConfigured(value: string | undefined): boolean {
+  return Boolean((value || '').trim());
+}
+
+/**
+ * Reconcile every email-derived key against the current EMAIL_URL.
+ *
+ * `previousEmailUrl` is the value before this write. Pass the same value as
+ * `env.EMAIL_URL` for an idempotent reconcile (no transition, no behavior
+ * flags touched).
+ */
+export function applyEmailWiring(
+  env: Record<string, string>,
+  previousEmailUrl: string | undefined,
+): EmailWiringOutcome {
+  const changed: string[] = [];
+  const notes: string[] = [];
+  const set = (key: string, value: string) => {
+    if (env[key] === value) return;
+    env[key] = value;
+    changed.push(key);
+  };
+
+  const nowConfigured = isConfigured(env.EMAIL_URL);
+  const wasConfigured = isConfigured(previousEmailUrl);
+
+  if (nowConfigured) {
+    // The hook secret is generated once and then persists like every other
+    // per-instance secret, so a restart does not invalidate GoTrue's copy.
+    if (!isConfigured(env.AUTH_EMAIL_HOOK_SECRET)) {
+      set('AUTH_EMAIL_HOOK_SECRET', generateAuthEmailHookSecret());
+    }
+    set('GOTRUE_HOOK_SEND_EMAIL_ENABLED', 'true');
+    set('GOTRUE_HOOK_SEND_EMAIL_URI', AUTH_EMAIL_HOOK_URI);
+
+    // A self-host that sends from noreply@kortix.com would fail SPF/DKIM at
+    // every receiving server. Default the sender to the instance's own domain.
+    if (!isConfigured(env.EMAIL_FROM)) {
+      const domain = (env.KORTIX_DOMAIN || '').trim();
+      if (domain) {
+        set('EMAIL_FROM', `Kortix <noreply@${domain}>`);
+        notes.push(`EMAIL_FROM defaulted to "Kortix <noreply@${domain}>"`);
+      }
+    }
+  } else {
+    set('GOTRUE_HOOK_SEND_EMAIL_ENABLED', 'false');
+  }
+
+  if (nowConfigured && !wasConfigured) {
+    // Email now works, so stop auto-confirming signups and offer magic-link
+    // sign-in. Both are the reason an operator configures email at all.
+    set('ENABLE_EMAIL_AUTOCONFIRM', 'false');
+    set('KORTIX_PUBLIC_AUTH_METHODS', 'password,magic');
+    notes.push('email confirmation is now required (ENABLE_EMAIL_AUTOCONFIRM=false)');
+    notes.push('magic-link sign-in enabled (KORTIX_PUBLIC_AUTH_METHODS=password,magic)');
+  } else if (!nowConfigured && wasConfigured) {
+    // Email is gone. Leaving confirmation required would lock every new signup
+    // out of an instance that can no longer send the confirmation mail.
+    set('ENABLE_EMAIL_AUTOCONFIRM', 'true');
+    set('KORTIX_PUBLIC_AUTH_METHODS', 'password');
+    notes.push('email removed — signups auto-confirm again and magic-link is off');
+  }
+
+  return { changed, notes };
+}

--- a/apps/cli/src/self-host/secrets-registry.ts
+++ b/apps/cli/src/self-host/secrets-registry.ts
@@ -89,6 +89,13 @@ export const SECRET_DEFS: SecretDef[] = [
   { key: 'LOGFLARE_PRIVATE_ACCESS_TOKEN', category: 'database', kind: 'generated', required: true, rotatable: false },
 
   // Auth / Email / SMTP
+  // EMAIL_URL is THE email setting: one connection string that configures both
+  // product email (kortix-api) and auth email (GoTrue, via the send-email
+  // hook). The SMTP_* quartet below is the pre-EMAIL_URL surface, still read by
+  // GoTrue directly when no EMAIL_URL is set.
+  { key: 'EMAIL_URL', category: 'auth_email', kind: 'operator', required: false },
+  { key: 'EMAIL_FROM', category: 'auth_email', kind: 'operator', required: false },
+  { key: 'AUTH_EMAIL_HOOK_SECRET', category: 'auth_email', kind: 'generated', required: false, rotatable: true },
   { key: 'SMTP_HOST', category: 'auth_email', kind: 'operator', required: false },
   { key: 'SMTP_PORT', category: 'auth_email', kind: 'operator', required: false },
   { key: 'SMTP_USER', category: 'auth_email', kind: 'operator', required: false },
@@ -241,7 +248,13 @@ export const KEY_SERVICE_MAP: Record<string, readonly string[]> = {
   LOGFLARE_PUBLIC_ACCESS_TOKEN: ['supabase-analytics', 'supabase-vector'],
   LOGFLARE_PRIVATE_ACCESS_TOKEN: ['supabase-studio', 'supabase-analytics'],
 
-  // Auth / Email / SMTP — all consumed by GoTrue only.
+  // Auth / Email / SMTP.
+  // EMAIL_URL / EMAIL_FROM reach BOTH halves: kortix-api sends with them, and
+  // GoTrue's send-email hook wiring is derived from them.
+  EMAIL_URL: ['kortix-api', 'supabase-auth'],
+  EMAIL_FROM: ['kortix-api'],
+  AUTH_EMAIL_HOOK_SECRET: ['kortix-api', 'supabase-auth'],
+  // The rest are consumed by GoTrue only.
   SMTP_HOST: ['supabase-auth'],
   SMTP_PORT: ['supabase-auth'],
   SMTP_USER: ['supabase-auth'],

--- a/apps/web/src/components/iam/audit-http-routes.generated.ts
+++ b/apps/web/src/components/iam/audit-http-routes.generated.ts
@@ -580,6 +580,7 @@ const AUDIT_HTTP_ROUTE_KEYS = [
   "GET|v1|usage|session-costs",
   "GET|v1|usage|session-costs|:sessionId",
   "GET|v1|user-roles",
+  "POST|v1|webhooks|auth|send-email",
   "POST|v1|webhooks|email|agentmail",
   "POST|v1|webhooks|projects|:projectId|:slug",
   "POST|v1|webhooks|sandbox|daytona",

--- a/docs/runbooks/self-hosting.md
+++ b/docs/runbooks/self-hosting.md
@@ -54,9 +54,10 @@ box.
   (the default) or [Platinum](https://www.platinum.dev/), Kortix's own microVM
   sandbox provider. [E2B](https://e2b.dev/) is also supported. Any of these
   need an API key, settable after first boot with `kortix self-host configure`.
-- **Not required to get started:** SMTP. A fresh install auto-confirms email
+- **Not required to get started:** email. A fresh install auto-confirms email
   signups and leads with password auth, so the first account works with zero
-  email configuration. Configure SMTP later to enable magic-link sign-in.
+  email configuration. Set `EMAIL_URL` later to turn on invite email and
+  magic-link sign-in — one variable, see below.
 
 ## Reachability (required for agent sessions) — VPS-first
 
@@ -376,7 +377,7 @@ whether a newer release is available.
 > To get a release that hasn't been promoted to `:stable` yet, use
 > `--channel latest` or pin `--tag <version>`.
 
-## Configuring SMTP, Daytona, and other integrations later
+## Configuring email, Daytona, and other integrations later
 
 Everything is `kortix self-host env set KEY=VALUE …` followed by
 `kortix self-host start` (or the interactive `kortix self-host configure`),
@@ -389,11 +390,9 @@ kortix self-host env set DAYTONA_API_KEY=... DAYTONA_SERVER_URL=https://app.dayt
 # Managed git (required to create projects) — PAT or GitHub App
 kortix self-host env set MANAGED_GIT_PROVIDER=github MANAGED_GIT_GITHUB_TOKEN=... MANAGED_GIT_GITHUB_OWNER=your-org
 
-# SMTP (optional — enables magic-link / email verification instead of the
-# password-only, auto-confirmed default)
-kortix self-host env set SMTP_HOST=smtp.example.com SMTP_PORT=587 SMTP_USER=... SMTP_PASS=... \
-  SMTP_ADMIN_EMAIL=admin@example.com SMTP_SENDER_NAME=Kortix
-kortix self-host env set ENABLE_EMAIL_AUTOCONFIRM=false KORTIX_PUBLIC_AUTH_METHODS=password,magic
+# Email (optional) — ONE connection string turns on BOTH invite/access-request
+# email and auth email (magic link, signup confirmation, password reset).
+kortix self-host env set EMAIL_URL=smtp://user:pass@smtp.example.com:587
 
 # Pipedream connectors (optional)
 kortix self-host env set CONNECTOR_AUTH_PROVIDER=pipedream PIPEDREAM_CLIENT_ID=... \
@@ -402,6 +401,55 @@ kortix self-host env set CONNECTOR_AUTH_PROVIDER=pipedream PIPEDREAM_CLIENT_ID=.
 
 `kortix self-host env ls` lists every key (secrets masked); `kortix self-host
 doctor` validates the rendered Compose config without applying anything.
+
+### Email: one variable
+
+`EMAIL_URL` is the only email setting. The scheme picks the transport:
+
+| `EMAIL_URL` | Transport |
+| --- | --- |
+| `smtp://user:pass@mail.example.com:587` | SMTP, STARTTLS |
+| `smtps://user:pass@mail.example.com:465` | SMTP, implicit TLS |
+| `resend://re_xxxxxxxx` | Resend HTTP API |
+| `ses://AKIA...:secret@us-east-2` | AWS SES (static credentials) |
+| `ses://us-east-2` | AWS SES (instance role) |
+| `mailtrap://<api-token>` | Mailtrap HTTP API |
+
+Comma-separate several for a fallback chain, tried left to right:
+
+```sh
+kortix self-host env set EMAIL_URL=ses://us-east-2,smtp://user:pass@backup.example.com:587
+```
+
+Setting it derives everything else, so there is nothing else to configure:
+
+- **Product email** (invites, project access requests) sends through it.
+- **Auth email** (magic link, signup confirmation, password reset, email
+  change) sends through it too: GoTrue stops sending mail itself and posts each
+  one to `kortix-api`'s send-email hook, which renders the Kortix template and
+  sends it through the same provider. That is why `resend://` and `ses://` work
+  for auth email even though GoTrue itself speaks only SMTP.
+- `AUTH_EMAIL_HOOK_SECRET` is generated once and shared with GoTrue.
+- `ENABLE_EMAIL_AUTOCONFIRM` flips to `false` and `KORTIX_PUBLIC_AUTH_METHODS`
+  becomes `password,magic` — but only on the transition into "email
+  configured". A later manual override of either is never overwritten.
+- `EMAIL_FROM` defaults to `Kortix <noreply@<your-domain>>`. Override it with
+  an address on a domain whose SPF/DKIM authorizes your relay:
+
+```sh
+kortix self-host env set EMAIL_FROM="Acme <no-reply@acme.com>"
+```
+
+Clearing `EMAIL_URL` reverses all of it, including restoring auto-confirmed
+signups — an instance that cannot send mail must not require email
+confirmation, or every new signup is stranded.
+
+Two extra flags for awkward relays: `?tls=off` (relay offers no STARTTLS) and
+`?insecure=1` (self-signed certificate). Credentials are never sent over an
+unencrypted connection unless `?tls=off` is set explicitly.
+
+`kortix self-host doctor` parses `EMAIL_URL` and reports the resolved provider
+chain, so a typo surfaces there instead of as a missing invite.
 
 ## SAML SSO + SCIM (Enterprise)
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,7 @@
     "./utils": "./src/utils/index.ts",
     "./constants": "./src/constants/upload-limits.ts",
     "./runtime-versions": "./src/runtime-versions.ts",
+    "./email-url": "./src/email-url.ts",
     "./sandbox": "./src/sandbox/index.ts",
     "./sandbox-runtime-artifact": "./src/sandbox-runtime-artifact.ts"
   },

--- a/packages/shared/src/email-url.test.ts
+++ b/packages/shared/src/email-url.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+
+import { EmailUrlError, parseEmailTarget, parseEmailTargets, redactUrl } from './email-url';
+
+describe('parseEmailTarget', () => {
+  test('parses an SMTP URL with credentials and an explicit port', () => {
+    expect(parseEmailTarget('smtp://alice:s3cret@mail.example.com:2525')).toEqual({
+      kind: 'smtp',
+      host: 'mail.example.com',
+      port: 2525,
+      secure: false,
+      requireTls: true,
+      rejectUnauthorized: true,
+      user: 'alice',
+      pass: 's3cret',
+    });
+  });
+
+  test('defaults to 587 with STARTTLS, and to 465 with implicit TLS for smtps', () => {
+    expect(parseEmailTarget('smtp://user:pw@mail.example.com')).toMatchObject({
+      port: 587,
+      secure: false,
+      requireTls: true,
+    });
+    expect(parseEmailTarget('smtps://user:pw@mail.example.com')).toMatchObject({
+      port: 465,
+      secure: true,
+      requireTls: false,
+    });
+  });
+
+  test('treats port 465 as implicit TLS even under the smtp scheme', () => {
+    expect(parseEmailTarget('smtp://user:pw@mail.example.com:465')).toMatchObject({
+      secure: true,
+      requireTls: false,
+    });
+  });
+
+  test('an anonymous relay stays opportunistic; credentials force STARTTLS', () => {
+    const anonymous = parseEmailTarget('smtp://127.0.0.1:1025');
+    expect(anonymous).toMatchObject({ requireTls: false });
+    expect(anonymous).not.toHaveProperty('user');
+    expect(parseEmailTarget('smtp://u:p@127.0.0.1:1025')).toMatchObject({ requireTls: true });
+  });
+
+  test('?tls=off drops the STARTTLS requirement, ?insecure=1 accepts self-signed certs', () => {
+    expect(parseEmailTarget('smtp://u:p@relay.internal:587?tls=off')).toMatchObject({
+      requireTls: false,
+    });
+    expect(parseEmailTarget('smtp://u:p@relay.internal:587?insecure=1')).toMatchObject({
+      rejectUnauthorized: false,
+    });
+  });
+
+  test('percent-decodes credentials and splits on the LAST @', () => {
+    expect(parseEmailTarget('smtp://user%40corp.com:p%40ss@mail.example.com:587')).toMatchObject({
+      user: 'user@corp.com',
+      pass: 'p@ss',
+      host: 'mail.example.com',
+    });
+  });
+
+  test('keeps IPv6 hosts intact', () => {
+    expect(parseEmailTarget('smtp://[::1]:1025')).toMatchObject({ host: '::1', port: 1025 });
+  });
+
+  // The reason this parser is hand-rolled: `new URL()` lowercases the host, so
+  // an API key or AWS access key in that position would be silently corrupted.
+  test('preserves case in API keys and AWS access keys', () => {
+    expect(parseEmailTarget('resend://re_AbC123XyZ')).toEqual({ // gitleaks:allow
+      kind: 'resend',
+      apiKey: 're_AbC123XyZ', // gitleaks:allow
+    });
+    expect(parseEmailTarget('ses://AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI@us-east-2')).toEqual({
+      kind: 'ses',
+      region: 'us-east-2',
+      accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      secretAccessKey: 'wJalrXUtnFEMI',
+    });
+  });
+
+  test('ses://<region> alone means instance/task-role credentials', () => {
+    expect(parseEmailTarget('ses://eu-west-1')).toEqual({ kind: 'ses', region: 'eu-west-1' });
+  });
+
+  test('parses mailtrap and mailpit', () => {
+    expect(parseEmailTarget('mailtrap://tok_123')).toEqual({ kind: 'mailtrap', token: 'tok_123' });
+    expect(parseEmailTarget('mailpit://127.0.0.1:8025')).toEqual({
+      kind: 'mailpit',
+      baseUrl: 'http://127.0.0.1:8025',
+    });
+  });
+
+  test('rejects a non-URL, an unknown scheme, and an invalid port', () => {
+    expect(() => parseEmailTarget('smtp.example.com')).toThrow(EmailUrlError);
+    expect(() => parseEmailTarget('carrier-pigeon://nest')).toThrow(/unsupported email scheme/);
+    expect(() => parseEmailTarget('smtp://host:99999')).toThrow(/invalid port/);
+    expect(() => parseEmailTarget('resend://')).toThrow(/missing Resend API key/);
+  });
+});
+
+describe('parseEmailTargets', () => {
+  test('builds an ordered chain from a comma-separated list', () => {
+    const { targets, errors } = parseEmailTargets('ses://us-east-2, resend://re_key');
+    expect(errors).toEqual([]);
+    expect(targets.map((target) => target.kind)).toEqual(['ses', 'resend']);
+  });
+
+  test('one bad entry is reported but does not discard the good ones', () => {
+    const { targets, errors } = parseEmailTargets('nope://x,smtp://127.0.0.1:1025');
+    expect(targets.map((target) => target.kind)).toEqual(['smtp']);
+    expect(errors).toHaveLength(1);
+  });
+
+  test('empty input yields no providers', () => {
+    expect(parseEmailTargets('').targets).toEqual([]);
+    expect(parseEmailTargets(undefined).targets).toEqual([]);
+  });
+});
+
+describe('redactUrl', () => {
+  test('never leaks credentials into a log line', () => {
+    expect(redactUrl('smtp://alice:s3cret@mail.example.com:587')).toBe(
+      'smtp://***@mail.example.com:587',
+    );
+    expect(redactUrl('resend://re_secret')).toBe('resend://***');
+    expect(redactUrl('ses://AKIA:secret@us-east-2')).toBe('ses://***@us-east-2');
+  });
+});

--- a/packages/shared/src/email-url.ts
+++ b/packages/shared/src/email-url.ts
@@ -1,0 +1,252 @@
+// One connection string per email provider: EMAIL_URL.
+//
+// Before this module every provider had its own bespoke pair of env vars
+// (RESEND_API_KEY, AWS_SES_ACCESS_KEY_ID + AWS_SES_SECRET_ACCESS_KEY +
+// AWS_SES_REGION, MAILTRAP_API_TOKEN, MAILPIT_API_URL) and plain SMTP was not
+// supported at all — which meant a self-hoster with an ordinary mail relay had
+// no way to send product email, and every new provider added three more keys.
+// EMAIL_URL collapses all of that into one string whose scheme selects the
+// transport:
+//
+//   smtp://user:pass@mail.example.com:587    STARTTLS (opportunistic; forced
+//                                            whenever credentials are present)
+//   smtps://user:pass@mail.example.com:465   implicit TLS
+//   resend://re_xxxxxxxx
+//   ses://AKIA...:secret@us-east-2           static credentials
+//   ses://us-east-2                          instance/task role credentials
+//   mailtrap://<api-token>
+//   mailpit://127.0.0.1:8025                 local capture (HTTP API)
+//
+// Comma-separate several to get a fallback chain, tried left to right:
+//   EMAIL_URL=ses://us-east-2,resend://re_xxxxxxxx
+//
+// Parsing is deliberately hand-rolled rather than `new URL()`: WHATWG URL
+// lowercases the host, and provider credentials are case-sensitive. An API key
+// placed in the host position (`resend://re_AbC`) would be silently corrupted
+// to `re_abc` and every send would 401 with no hint why.
+
+export type EmailTargetKind = 'smtp' | 'resend' | 'ses' | 'mailtrap' | 'mailpit';
+
+export type EmailTarget =
+  | {
+      kind: 'smtp';
+      host: string;
+      port: number;
+      /** Implicit TLS from the first byte (port 465 / `smtps:`). */
+      secure: boolean;
+      /** Refuse to continue unless STARTTLS upgrades the connection. */
+      requireTls: boolean;
+      /** `false` only via `?insecure=1` — self-signed relay certificates. */
+      rejectUnauthorized: boolean;
+      user?: string;
+      pass?: string;
+    }
+  | { kind: 'resend'; apiKey: string }
+  | { kind: 'ses'; region: string; accessKeyId?: string; secretAccessKey?: string }
+  | { kind: 'mailtrap'; token: string }
+  | { kind: 'mailpit'; baseUrl: string };
+
+export class EmailUrlError extends Error {}
+
+const DEFAULT_SMTP_PORT = 587;
+const IMPLICIT_TLS_PORT = 465;
+
+/**
+ * Trim trailing slashes without a regex. `/\/+$/` against a long run of
+ * slashes backtracks polynomially, and EMAIL_URL — while operator-set — is
+ * parsed by an exported library function, so it gets library-grade handling.
+ */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
+}
+
+/** Split on the LAST `@` so an un-encoded `@` inside a password still parses. */
+function splitUserInfo(rest: string): { userInfo: string | null; remainder: string } {
+  const at = rest.lastIndexOf('@');
+  if (at === -1) return { userInfo: null, remainder: rest };
+  return { userInfo: rest.slice(0, at), remainder: rest.slice(at + 1) };
+}
+
+function splitQuery(rest: string): { body: string; query: URLSearchParams } {
+  const mark = rest.indexOf('?');
+  if (mark === -1) return { body: rest, query: new URLSearchParams() };
+  return { body: rest.slice(0, mark), query: new URLSearchParams(rest.slice(mark + 1)) };
+}
+
+function decode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/** `host:port`, `host`, `[::1]:port` — port optional. */
+function splitHostPort(input: string): { host: string; port: number | null } {
+  const trimmed = stripTrailingSlashes(input);
+  if (trimmed.startsWith('[')) {
+    const close = trimmed.indexOf(']');
+    if (close === -1) throw new EmailUrlError(`unterminated IPv6 host in "${input}"`);
+    const host = trimmed.slice(1, close);
+    const tail = trimmed.slice(close + 1);
+    if (!tail) return { host, port: null };
+    if (!tail.startsWith(':')) throw new EmailUrlError(`unexpected "${tail}" after IPv6 host`);
+    return { host, port: parsePort(tail.slice(1)) };
+  }
+  const colon = trimmed.lastIndexOf(':');
+  if (colon === -1) return { host: trimmed, port: null };
+  return { host: trimmed.slice(0, colon), port: parsePort(trimmed.slice(colon + 1)) };
+}
+
+function parsePort(raw: string): number {
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new EmailUrlError(`invalid port "${raw}"`);
+  }
+  return port;
+}
+
+function isTrue(value: string | null): boolean {
+  return value === '1' || value?.toLowerCase() === 'true';
+}
+
+function parseSmtp(scheme: string, rest: string): EmailTarget {
+  const { body, query } = splitQuery(rest);
+  const { userInfo, remainder } = splitUserInfo(body);
+  if (!remainder) throw new EmailUrlError('missing SMTP host');
+
+  const { host, port: explicitPort } = splitHostPort(remainder);
+  if (!host) throw new EmailUrlError('missing SMTP host');
+
+  let user: string | undefined;
+  let pass: string | undefined;
+  if (userInfo) {
+    const colon = userInfo.indexOf(':');
+    user = decode(colon === -1 ? userInfo : userInfo.slice(0, colon));
+    pass = colon === -1 ? undefined : decode(userInfo.slice(colon + 1));
+  }
+
+  const tls = (query.get('tls') || '').toLowerCase();
+  const port = explicitPort ?? (scheme === 'smtps' ? IMPLICIT_TLS_PORT : DEFAULT_SMTP_PORT);
+  const secure = scheme === 'smtps' || port === IMPLICIT_TLS_PORT || tls === 'implicit';
+
+  // Credentials never travel in the clear: whenever a password would be sent,
+  // STARTTLS is mandatory unless the operator explicitly opts out with
+  // `?tls=off`. An anonymous relay (a local Mailpit, an internal MTA on :25)
+  // stays opportunistic so it keeps working with no flags.
+  const hasCredentials = Boolean(user || pass);
+  const requireTls = !secure && tls !== 'off' && (hasCredentials || tls === 'required');
+
+  return {
+    kind: 'smtp',
+    host,
+    port,
+    secure,
+    requireTls,
+    rejectUnauthorized: !isTrue(query.get('insecure')),
+    ...(user ? { user } : {}),
+    ...(pass ? { pass } : {}),
+  };
+}
+
+function parseSes(rest: string): EmailTarget {
+  const { body } = splitQuery(rest);
+  const { userInfo, remainder } = splitUserInfo(body);
+  const region = stripTrailingSlashes(remainder).toLowerCase();
+  if (!region) throw new EmailUrlError('missing SES region (ses://<region>)');
+  if (!userInfo) return { kind: 'ses', region };
+
+  const colon = userInfo.indexOf(':');
+  if (colon === -1) {
+    throw new EmailUrlError('SES credentials must be ses://<key-id>:<secret>@<region>');
+  }
+  return {
+    kind: 'ses',
+    region,
+    accessKeyId: decode(userInfo.slice(0, colon)),
+    secretAccessKey: decode(userInfo.slice(colon + 1)),
+  };
+}
+
+function parseMailpit(rest: string): EmailTarget {
+  const { body } = splitQuery(rest);
+  const target = stripTrailingSlashes(body);
+  if (!target) throw new EmailUrlError('missing Mailpit host');
+  const baseUrl = /^https?:\/\//i.test(target) ? target : `http://${target}`;
+  return { kind: 'mailpit', baseUrl };
+}
+
+/** Parse one EMAIL_URL entry. Throws EmailUrlError with an operator-readable reason. */
+export function parseEmailTarget(raw: string): EmailTarget {
+  const value = raw.trim();
+  const sep = value.indexOf('://');
+  if (sep === -1) {
+    throw new EmailUrlError(
+      `"${redactUrl(value)}" is not a URL — expected e.g. smtp://user:pass@host:587`,
+    );
+  }
+  const scheme = value.slice(0, sep).toLowerCase();
+  const rest = value.slice(sep + 3);
+
+  switch (scheme) {
+    case 'smtp':
+    case 'smtps':
+      return parseSmtp(scheme, rest);
+    case 'resend': {
+      const apiKey = stripTrailingSlashes(splitQuery(rest).body);
+      if (!apiKey) throw new EmailUrlError('missing Resend API key (resend://<api-key>)');
+      return { kind: 'resend', apiKey };
+    }
+    case 'ses':
+      return parseSes(rest);
+    case 'mailtrap': {
+      const token = stripTrailingSlashes(splitQuery(rest).body);
+      if (!token) throw new EmailUrlError('missing Mailtrap token (mailtrap://<api-token>)');
+      return { kind: 'mailtrap', token };
+    }
+    case 'mailpit':
+      return parseMailpit(rest);
+    default:
+      throw new EmailUrlError(
+        `unsupported email scheme "${scheme}" — use smtp, smtps, resend, ses, mailtrap or mailpit`,
+      );
+  }
+}
+
+/**
+ * Parse a comma-separated EMAIL_URL into an ordered fallback chain. Invalid
+ * entries are reported rather than thrown so one typo cannot take down every
+ * remaining provider — the caller logs `errors` and sends through `targets`.
+ */
+export function parseEmailTargets(raw: string | undefined | null): {
+  targets: EmailTarget[];
+  errors: string[];
+} {
+  const targets: EmailTarget[] = [];
+  const errors: string[] = [];
+  for (const entry of (raw || '').split(',')) {
+    const value = entry.trim();
+    if (!value) continue;
+    try {
+      targets.push(parseEmailTarget(value));
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+  return { targets, errors };
+}
+
+/** Strip credentials from a URL so it is safe to put in a log line. */
+export function redactUrl(raw: string): string {
+  const sep = raw.indexOf('://');
+  if (sep === -1) return raw;
+  const scheme = raw.slice(0, sep);
+  const rest = raw.slice(sep + 3);
+  if (scheme === 'smtp' || scheme === 'smtps' || scheme === 'ses') {
+    const at = rest.lastIndexOf('@');
+    return at === -1 ? `${scheme}://${rest}` : `${scheme}://***@${rest.slice(at + 1)}`;
+  }
+  return `${scheme}://***`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       livekit-server-sdk:
         specifier: ^2.17.0
         version: 2.17.0
+      nodemailer:
+        specifier: ^7.0.0
+        version: 7.0.13
       oauth4webapi:
         specifier: ^3.8.7
         version: 3.8.7
@@ -255,6 +258,9 @@ importers:
       '@types/bun':
         specifier: ^1.3.12
         version: 1.3.14
+      '@types/nodemailer':
+        specifier: ^8.0.1
+        version: 8.0.1
       bun-types:
         specifier: ^1.3.12
         version: 1.3.14
@@ -13914,6 +13920,12 @@ packages:
       undici-types: 6.21.0
     dev: true
 
+  /@types/nodemailer@8.0.1:
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
+    dependencies:
+      '@types/node': 20.19.43
+    dev: true
+
   /@types/pako@2.0.4:
     resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
     dev: false
@@ -23641,6 +23653,11 @@ packages:
   /node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
+
+  /nodemailer@7.0.13:
+    resolution: {integrity: sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==}
+    engines: {node: '>=6.0.0'}
+    dev: false
 
   /nopt@6.0.0:
     resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -88,7 +88,7 @@ cd your-project && kortix ship
 
 See
 [`docs/runbooks/self-hosting.md`](../docs/runbooks/self-hosting.md) for the
-no-public-domain Cloudflare-tunnel evaluation path, SMTP, using the CLI
+no-public-domain Cloudflare-tunnel evaluation path, email, using the CLI
 from a different machine than the one you self-hosted on, uninstalling, and
 the full `kortix self-host` command reference.
 
@@ -184,7 +184,7 @@ exact command, no SSH key or open port required):
 ```sh
 kortix self-host update            # pull the newest image on your channel now, migrate, roll forward
 kortix self-host env ls            # list every value, grouped by service (secrets masked)
-kortix self-host env set KEY=VALUE ...   # set a value (sandbox key, GitHub token, SMTP, ...); restarts affected services only
+kortix self-host env set KEY=VALUE ...   # set a value (sandbox key, GitHub token, EMAIL_URL, ...); restarts affected services only
 kortix self-host env rotate KEY    # regenerate a rotatable generated secret (or --all-generated)
 kortix self-host logs [service]    # tail Compose logs
 kortix self-host status            # container status

--- a/tests/spec/end-to-end.md
+++ b/tests/spec/end-to-end.md
@@ -773,6 +773,7 @@ supplied scope field without restarting the session.
 `PACC-6` `GET/POST /projects/:id/group-grants` · `PATCH/DELETE /:groupId` → manage; missing group_id → 400; unknown → 404.
 `BILL-10` per-seat: `POST /billing/sync-seat-quantity` · `claim-per-seat` → no-op/skipped on non-legacy.
 `AUTH-1` `POST /v1/auth/logout` → OWNER 200/204; ANON 200/401.
+`AUTH-2` `POST /v1/webhooks/auth/send-email` — Supabase Auth send-email hook, public + Standard Webhooks HMAC (`AUTH_EMAIL_HOOK_SECRET`, `v1,whsec_…`) over the RAW body. Unsigned → 401 (503 when no secret is configured); valid signature over a tampered body → 401; signed `magiclink` payload → 200 and the mail goes out through the one platform transport (`EMAIL_URL`); unknown `email_action_type` → 400.
 `BILL-11` `GET /billing/checkout-session/:sessionId` · `POST /billing/confirm-checkout-session` → unknown/missing → 4xx.
 `BILL-3b` `POST /billing/create-checkout-session` · `create-per-seat-checkout` · `create-portal-session` → Stripe URL or 400/500.
 `BILL-4b` `POST /billing/cancel-subscription` · `sync-seat-quantity` → NONMEMBER → 403.

--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 594,
+  "count": 595,
   "routes": [
     {
       "method": "GET",
@@ -2313,6 +2313,10 @@
     {
       "method": "GET",
       "path": "/v1/user-roles"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/webhooks/auth/send-email"
     },
     {
       "method": "POST",

--- a/tests/src/core/local-profile.ts
+++ b/tests/src/core/local-profile.ts
@@ -111,3 +111,11 @@ export function localRunExitCode(summary: { failed: number; skipped: number; tod
 export function localWorkerCount(cpuCount = availableParallelism()): number {
   return Math.max(4, Math.min(16, Math.trunc(cpuCount)));
 }
+
+/**
+ * Signing secret for the Supabase send-email hook in the local profile. Fixed
+ * (not random) so a flow can sign a request the running API will accept, in the
+ * `v1,whsec_<base64>` form Supabase itself writes.
+ */
+export const LOCAL_AUTH_EMAIL_HOOK_SECRET =
+  'v1,whsec_bG9jYWwtZmxvdy1ydW5uZXItYXV0aC1lbWFpbC1ob29rLXNlY3JldA==';

--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { localWebUrl } from './local-profile';
+import { LOCAL_AUTH_EMAIL_HOOK_SECRET, localWebUrl } from './local-profile';
 import {
   type LocalStackHandle,
   type LocalSupabaseHandle,
@@ -354,7 +354,13 @@ async function runLane(root: string, lane: LocalTestLane): Promise<LaneResult> {
   const startedAt = performance.now();
   console.log(`\n[test] START ${lane.name}: ${lane.command.join(' ')}`);
   try {
-    let env = { ...process.env, ...(lane.env ?? {}) };
+    // Every lane can sign a Supabase auth-hook request: the local stack starts
+    // the API with this same fixed secret (see local-stack.ts).
+    let env = {
+      ...process.env,
+      KE2E_AUTH_EMAIL_HOOK_SECRET: LOCAL_AUTH_EMAIL_HOOK_SECRET,
+      ...(lane.env ?? {}),
+    };
     if (lane.name === 'browser') {
       const topology = resolveLocalTopology(root);
       const supabase = await readLocalSupabaseEnvironment(topology);

--- a/tests/src/core/local-stack.ts
+++ b/tests/src/core/local-stack.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
+  LOCAL_AUTH_EMAIL_HOOK_SECRET,
   LOCAL_FLOW_INTERNAL_SERVICE_KEY,
   localWebUrl,
   type LocalSupabaseEnvironment,
@@ -477,10 +478,15 @@ export async function ensureLocalStack(
           GATEWAY_INTERNAL_TOKEN: gatewayToken,
           TUNNEL_ENABLED: "false",
           TUNNEL_SIGNING_SECRET: "local-flow-runner-tunnel-signing-secret",
-          EMAIL_PROVIDER_ORDER: "mailpit",
+          // One connection string configures delivery, exactly as an operator
+          // sets it — so the local suite exercises the EMAIL_URL path itself.
           ...(options.supabase.MAILPIT_URL
-            ? { MAILPIT_API_URL: options.supabase.MAILPIT_URL }
+            ? {
+                EMAIL_URL: `mailpit://${options.supabase.MAILPIT_URL.replace(/^https?:\/\//, "")}`,
+              }
             : {}),
+          EMAIL_FROM: "Kortix Local <noreply@kortix.local>",
+          AUTH_EMAIL_HOOK_SECRET: LOCAL_AUTH_EMAIL_HOOK_SECRET,
           KORTIX_MARKETPLACE_EXTERNAL_ENABLED: "0",
           KORTIX_MODEL_CATALOG_LIVE_ENABLED: "0",
           KORTIX_MODEL_PRICING_LIVE_ENABLED: "0",

--- a/tests/src/flows/auth-email-hook.flow.ts
+++ b/tests/src/flows/auth-email-hook.flow.ts
@@ -1,0 +1,112 @@
+/**
+ * Supabase Auth send-email hook — `POST /v1/webhooks/auth/send-email`.
+ *
+ * GoTrue posts every auth email (magic link, signup confirmation, password
+ * recovery, email change) to this route instead of sending it itself, so auth
+ * mail uses the same provider chain, sender identity and templates as invites.
+ * The route is public and gated purely on a Standard Webhooks HMAC signature.
+ *
+ * Signature is over the RAW body, so the request is sent as a pre-serialized
+ * string: re-serializing would change the bytes and invalidate the HMAC.
+ */
+import { createHmac } from "node:crypto";
+
+import { flow } from "../core/flow";
+
+const ROUTE = "/v1/webhooks/auth/send-email";
+
+function hookSecret(): string {
+  return process.env.KE2E_AUTH_EMAIL_HOOK_SECRET?.trim() ?? "";
+}
+
+/** Standard Webhooks signature: base64(HMAC-SHA256(`{id}.{ts}.{body}`)). */
+function signBody(rawBody: string, id: string, timestamp: string, secret: string): string {
+  const key = Buffer.from(secret.replace(/^v\d+,/, "").replace(/^whsec_/, ""), "base64");
+  const mac = createHmac("sha256", key).update(`${id}.${timestamp}.${rawBody}`).digest("base64");
+  return `v1,${mac}`;
+}
+
+function magicLinkPayload(recipient: string): string {
+  return JSON.stringify({
+    user: { email: recipient },
+    email_data: {
+      token: "123456",
+      token_hash: "ke2e-token-hash",
+      redirect_to: "http://127.0.0.1:3000/dashboard",
+      email_action_type: "magiclink",
+      site_url: "http://127.0.0.1:3000",
+    },
+  });
+}
+
+flow(
+  "AUTH-2",
+  { domain: "auth", routes: [`POST ${ROUTE}`] },
+  async (ctx) => {
+    const secret = hookSecret();
+
+    await ctx.step("unsigned request → 401 (never 200)", async () => {
+      const r = await ctx.client.as(ctx.P.ANON).post(ROUTE, magicLinkPayload("nobody@example.test"), {
+        headers: { "content-type": "application/json" },
+      });
+      // 503 when the deployment has no hook secret configured at all; the
+      // contract that matters is that an unsigned body is never accepted.
+      r.status([401, 503]);
+    });
+
+    await ctx.step("valid signature over a tampered body → 401", async () => {
+      if (!secret) return;
+      const signed = magicLinkPayload("victim@example.test");
+      const id = "ke2e-tamper";
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const r = await ctx.client.as(ctx.P.ANON).post(ROUTE, `${signed} `, {
+        headers: {
+          "content-type": "application/json",
+          "webhook-id": id,
+          "webhook-timestamp": timestamp,
+          "webhook-signature": signBody(signed, id, timestamp, secret),
+        },
+      });
+      r.status(401);
+    });
+
+    // 200 is only returned AFTER the send resolves — the route answers 500 on a
+    // provider failure and 503 when nothing is configured — so a 200 here means
+    // the mail actually went out through the configured provider.
+    await ctx.step("signed magic-link payload → 200 and the email is sent", async () => {
+      if (!secret) return;
+      const recipient = `ke2e-auth-hook-${Date.now()}@example.test`;
+      const rawBody = magicLinkPayload(recipient);
+      const id = `ke2e-${Date.now()}`;
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const r = await ctx.client.as(ctx.P.ANON).post(ROUTE, rawBody, {
+        headers: {
+          "content-type": "application/json",
+          "webhook-id": id,
+          "webhook-timestamp": timestamp,
+          "webhook-signature": signBody(rawBody, id, timestamp, secret),
+        },
+      });
+      r.status(200);
+    });
+
+    await ctx.step("unsupported email_action_type → 400", async () => {
+      if (!secret) return;
+      const rawBody = JSON.stringify({
+        user: { email: "user@example.test" },
+        email_data: { email_action_type: "telepathy", token_hash: "x" },
+      });
+      const id = `ke2e-bad-${Date.now()}`;
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const r = await ctx.client.as(ctx.P.ANON).post(ROUTE, rawBody, {
+        headers: {
+          "content-type": "application/json",
+          "webhook-id": id,
+          "webhook-timestamp": timestamp,
+          "webhook-signature": signBody(rawBody, id, timestamp, secret),
+        },
+      });
+      r.status(400);
+    });
+  },
+);


### PR DESCRIPTION
## The problem

Email was **two disconnected systems** that shared no configuration:

| | Auth email (magic link, confirmation, recovery) | Product email (invites, access requests) |
| --- | --- | --- |
| Sent by | Supabase GoTrue | `kortix-api` |
| Reads | `SMTP_*` | `RESEND_API_KEY`, `AWS_SES_*`, `MAILTRAP_API_TOKEN`, … |
| Speaks | SMTP only | vendor HTTP APIs only |

Consequences, both real:

- A self-hoster with an ordinary SMTP relay configured auth email correctly and every invite was still silently skipped — `kortix-api` never read `SMTP_*`, and plain SMTP was not a supported provider at all.
- A Resend/SES operator got the mirror image: invites worked, magic links could not, because GoTrue cannot speak an HTTP API.

Turning email on also meant six `SMTP_*` variables plus two behavior flags nobody remembers (`ENABLE_EMAIL_AUTOCONFIRM`, `KORTIX_PUBLIC_AUTH_METHODS`).

## The change

**One connection string configures every email the platform sends.**

```sh
EMAIL_URL=smtp://user:pass@smtp.example.com:587
EMAIL_URL=resend://re_xxxxxxxx
EMAIL_URL=ses://AKIA...:secret@us-east-2      # or ses://us-east-2 for the task role
EMAIL_URL=ses://us-east-2,resend://re_key     # fallback chain, tried in order
EMAIL_FROM="Acme <no-reply@acme.com>"
```

- **SMTP is a first-class provider** (nodemailer, pooled connections). Credentials never cross an unencrypted socket: STARTTLS is forced whenever a password is present; `?tls=off` is the explicit opt-out, `?insecure=1` allows a self-signed relay cert.
- **GoTrue delegates to the API.** It stops sending mail itself and posts each auth email to `POST /v1/webhooks/auth/send-email` (Standard Webhooks HMAC). Auth mail then uses the same provider, sender and templates as product mail — which is *why* `resend://` and `ses://` now work for magic links.
- **One DSN parser in `@kortix/shared`**, used by both the API and the self-host CLI's `doctor`. It is hand-rolled on purpose: `new URL()` lowercases the host, which silently corrupts an API key or AWS access key placed there and yields 401s with no hint why.
- **The Standard Webhooks verifier is now shared** with the AgentMail webhook instead of existing twice.
- Every email now carries a plain-text alternative (HTML-only mail scores worse with spam filters).

### Self-host: setting `EMAIL_URL` is the only step

```
$ kortix self-host env set EMAIL_URL=smtp://postmaster:hunter2@smtp.example.com:587
  ✓  Updated EMAIL_URL, AUTH_EMAIL_HOOK_SECRET, GOTRUE_HOOK_SEND_EMAIL_ENABLED,
     GOTRUE_HOOK_SEND_EMAIL_URI, EMAIL_FROM, ENABLE_EMAIL_AUTOCONFIRM,
     KORTIX_PUBLIC_AUTH_METHODS
  EMAIL_FROM defaulted to "Kortix <noreply@kortix.example.com>"
  email confirmation is now required (ENABLE_EMAIL_AUTOCONFIRM=false)
  magic-link sign-in enabled (KORTIX_PUBLIC_AUTH_METHODS=password,magic)
```

Two design points worth review:

- The behavior flags are derived **only on the transition** into/out of "email configured", never on every write. A steady-state rule would re-apply itself on every reconcile and fight an operator override forever.
- Clearing `EMAIL_URL` reverses all of it, **including restoring auto-confirmed signups** — an instance that can no longer send mail must not require email confirmation, or every new signup is stranded.

`EMAIL_FROM` defaults to the instance's own domain, not `noreply@kortix.com`, which would fail SPF/DKIM at every receiving server.

## Backward compatibility

Nothing changes for deployed Kortix. Every pre-`EMAIL_URL` variable still works and is used whenever `EMAIL_URL` is unset; dev/staging/prod keep sending through SES + Resend with no env change. Two deliberate details:

- `smtp` joins the **default** provider order, so an existing self-host that configured SMTP for GoTrue starts sending invites on upgrade with no new setting.
- The inert placeholder quartet `kortix self-host init` writes so GoTrue can boot (`localhost` / `unused` / `unused`) is explicitly recognized as *not configured*. Treating it as a provider would turn a clean `email_not_configured` skip into connection-refused on every invite.

## Does this work for prod?

Yes. Dev/staging/prod run **hosted** Supabase, where the Send Email hook is available on Free and Pro plans and accepts any HTTPS endpoint. Prod needs one deliberate console toggle plus the shared secret in prod env — until then the hook is inert and existing SES/Resend sending is untouched.

## Verification

Real HTTP against a running API with `EMAIL_URL=smtp://…`, into a real Mailpit mailbox:

```
1. unsigned                 → 401 {"error":"Invalid signature"}
2. signature vs tampered    → 401 {"error":"Invalid signature"}
3. signed magiclink         → 200 {}
4. unknown action type      → 400 {"error":"unsupported email_action_type \"telepathy\""}
5. signed recovery          → 200 {}

Mailpit: 2 message(s)
  From:    Kortix Verify <noreply@kortix.local>
  Subject: Your Kortix sign-in link
  Link:    http://127.0.0.1:54321/auth/v1/verify?token=pkce_verify_hash_abc&type=magiclink&redirect_to=...
```

Product email through the same setting: `POST /v1/system/demo-request` → `{"ok":true,"emailed":true}`, message present in Mailpit.

- New/updated unit tests, incl. a **real in-process SMTP conversation** (EHLO → AUTH → MAIL FROM → RCPT TO → DATA) rather than a mocked client, DSN parsing (case preservation, TLS defaults, IPv6, redaction), HMAC verify (tamper, replay, rotation), hook payload parsing, and the self-host transition/override logic.
- New flow **AUTH-2** (`tests/spec/end-to-end.md`), route manifest regenerated, coverage gate passes (`581/593, 0 uncovered`).
- API suite: **7556 pass**, 1 unrelated Daytona-snapshot timeout that passes in isolation.
- Full local suite: 366/381. The **15 failures reproduce identically on the base commit** (`01636a582d`) — IAM/PACC/INV/TRG/APP-4/CHN-20/MEM-7, pre-existing on `main`, none email-related.

## Note

`.claude/skills/learnings/SKILL.md` gains one entry from a near-miss during this work: `KORTIX_SELF_HOST_CONFIG_DIR` isolates the config directory but **not** the Docker Compose project name, so a "sandboxed" self-host CLI run mutates the real instance of the same name. Details and recovery in the register.
