### PR TITLE
fix(api,ke2e): account deletion stops+removes every sandbox, revoked tokens stop authenticating, gc reclaims sessions+tokens

### DIFF
--- a/apps/api/src/__tests__/integration-revoked-token-auth.test.ts
+++ b/apps/api/src/__tests__/integration-revoked-token-auth.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Integration (real local DB + the real Hono app): a token whose `revoked_at`
+ * is stamped must stop authenticating immediately, at the repository AND over
+ * HTTP.
+ *
+ * `validateAccountToken` used to gate on `status = 'active'` alone. Nothing in
+ * the database ties `status` and `revoked_at` together — `account_tokens` has no
+ * CHECK, no trigger and no partial index — so a row could be `status='active'`
+ * with `revoked_at` set and it authenticated cleanly on every surface, emitting
+ * a normal `auth.login.success` audit event that hid the bypass.
+ *
+ * The release-gate sweep revokes its test PATs with exactly that write
+ * (`UPDATE account_tokens SET revoked_at = now()`). 186 "Connector Session"
+ * tokens survived it and their sandbox agents kept hitting the staging gateway
+ * with dead credentials until it reported `degraded`.
+ *
+ * The `revoked_at`-only UPDATE below is the whole point of this test: revoking
+ * through `revokeAccountToken` (which sets both columns) would pass even with
+ * the bug present.
+ */
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { sql } from 'drizzle-orm';
+import { db } from '../shared/db';
+import { app } from '../index';
+import { createAccountToken, validateAccountToken } from '../repositories/account-tokens';
+
+const ACCOUNT = crypto.randomUUID();
+const USER = crypto.randomUUID();
+const minted: string[] = [];
+
+beforeAll(async () => {
+  await db.execute(
+    sql`insert into kortix.accounts (account_id, name) values (${ACCOUNT}, 'revoked-token-auth-test')`,
+  );
+  // No ON CONFLICT: the pair is freshly generated, so it cannot collide, and a
+  // local DB behind on migration 105 has no matching constraint to infer (42P10).
+  await db.execute(
+    sql`insert into kortix.account_members (user_id, account_id, account_role)
+        values (${USER}, ${ACCOUNT}, 'owner')`,
+  );
+});
+
+afterAll(async () => {
+  for (const tokenId of minted) {
+    await db.execute(sql`delete from kortix.account_tokens where token_id = ${tokenId}`);
+  }
+  // Cascades account_members and any remaining tokens.
+  await db.execute(sql`delete from kortix.accounts where account_id = ${ACCOUNT}`);
+});
+
+async function mintToken(name: string): Promise<{ secretKey: string; tokenId: string }> {
+  const token = await createAccountToken({ accountId: ACCOUNT, userId: USER, name });
+  minted.push(token.tokenId);
+  return { secretKey: token.secretKey, tokenId: token.tokenId };
+}
+
+/** Stamp ONLY `revoked_at`, leaving `status = 'active'` — the real-world write. */
+async function stampRevokedAtOnly(tokenId: string): Promise<void> {
+  await db.execute(
+    sql`update kortix.account_tokens set revoked_at = now() where token_id = ${tokenId}`,
+  );
+}
+
+const authedRequest = (secretKey: string) =>
+  app.request('/v1/accounts', { headers: { Authorization: `Bearer ${secretKey}` } });
+
+describe('a revoked_at-stamped token stops authenticating', () => {
+  test('repository: valid before the stamp, refused after it', async () => {
+    const { secretKey, tokenId } = await mintToken('revoked-at-only-repo');
+
+    const before = await validateAccountToken(secretKey);
+    expect(before.isValid).toBe(true);
+    expect(before.accountId).toBe(ACCOUNT);
+
+    await stampRevokedAtOnly(tokenId);
+
+    const after = await validateAccountToken(secretKey);
+    expect(after.isValid).toBe(false);
+    expect(after.error).toBe('PAT not found or revoked');
+  });
+
+  test('the row really is still status=active — status alone would have let it through', async () => {
+    const { secretKey, tokenId } = await mintToken('revoked-at-only-status');
+    await stampRevokedAtOnly(tokenId);
+
+    const rows = (await db.execute(
+      sql`select status, revoked_at from kortix.account_tokens where token_id = ${tokenId}`,
+    )) as unknown as Array<{ status: string; revoked_at: string | null }>;
+
+    expect(rows[0]?.status).toBe('active');
+    expect(rows[0]?.revoked_at).toBeTruthy();
+    expect((await validateAccountToken(secretKey)).isValid).toBe(false);
+  });
+
+  test('HTTP: the same bearer returns 401 after the stamp', async () => {
+    const { secretKey, tokenId } = await mintToken('revoked-at-only-http');
+
+    const before = await authedRequest(secretKey);
+    expect(before.status).not.toBe(401);
+
+    await stampRevokedAtOnly(tokenId);
+
+    const after = await authedRequest(secretKey);
+    expect(after.status).toBe(401);
+  });
+
+  test('a token revoked the ordinary way (both columns) is still refused', async () => {
+    const { secretKey, tokenId } = await mintToken('revoked-both-columns');
+    await db.execute(
+      sql`update kortix.account_tokens set status = 'revoked', revoked_at = now() where token_id = ${tokenId}`,
+    );
+
+    expect((await validateAccountToken(secretKey)).isValid).toBe(false);
+    expect((await authedRequest(secretKey)).status).toBe(401);
+  });
+
+  test('an untouched token still authenticates — the gate is not refusing everything', async () => {
+    const { secretKey } = await mintToken('never-revoked');
+
+    expect((await validateAccountToken(secretKey)).isValid).toBe(true);
+    expect((await authedRequest(secretKey)).status).not.toBe(401);
+  });
+});

--- a/apps/api/src/billing/routes/account-deletion.ts
+++ b/apps/api/src/billing/routes/account-deletion.ts
@@ -99,8 +99,11 @@ accountDeletionRouter.openapi(
     },
   }),
   async (c: any) => {
-    const { accountId } = await resolveDeletionContext(c);
-    const result = await deleteAccountImmediately(accountId);
+    const { accountId, userId } = await resolveDeletionContext(c);
+    // Pass `userId`: `resolveAccountId` above returns only the earliest-joined
+    // account, so without it every sandbox in a team account this user owns
+    // survives the deletion, still running and still billing.
+    const result = await deleteAccountImmediately(accountId, userId);
     return c.json(result);
   },
 );

--- a/apps/api/src/billing/services/account-deletion.test.ts
+++ b/apps/api/src/billing/services/account-deletion.test.ts
@@ -1,22 +1,59 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { accountMembers, projectSessions, sessionSandboxes } from '@kortix/db';
 import * as realProviders from '../../platform/providers';
 import * as realSandboxReaper from '../../projects/sandbox-reaper';
 
-let sandboxRows: Array<{ sandboxId: string; provider: string; externalId: string | null }> = [];
+type SandboxRow = { sandboxId: string; provider: string; externalId: string | null };
+
+let sandboxRows: SandboxRow[] = [];
 let sandboxQueryError: Error | null = null;
+let ownedAccountRows: Array<{ accountId: string }> = [];
+let ownedAccountsQueryError: Error | null = null;
+let sandboxWhereArg: unknown = null;
+let sessionUpdateWhereArg: unknown = null;
+let sessionsSettled: Array<{ sessionId: string }> = [];
+let sessionUpdateError: Error | null = null;
+
 let stops: string[] = [];
+let removes: string[] = [];
 let stopErrorByExternal: Record<string, Error> = {};
-let reconciled: string[] = [];
+let removeErrorByExternal: Record<string, Error> = {};
+let providerAvailable = true;
+let reconciledRemoved: string[] = [];
+let reconciledStopped: string[] = [];
+let removedReconcileErrorByExternal: Record<string, Error> = {};
 let creditAccount: Record<string, unknown> | null = null;
 
+/**
+ * The fake keys off the drizzle table object handed to `.from()` / `.update()`,
+ * so the two different SELECTs (owned accounts vs sandboxes) and the session
+ * settle UPDATE are told apart by identity rather than by call order.
+ */
 mock.module('../../shared/db', () => ({
   db: {
     select: () => ({
-      from: () => ({
-        where: async () => {
+      from: (table: unknown) => ({
+        where: async (cond: unknown) => {
+          if (table === accountMembers) {
+            if (ownedAccountsQueryError) throw ownedAccountsQueryError;
+            return ownedAccountRows;
+          }
+          sandboxWhereArg = cond;
           if (sandboxQueryError) throw sandboxQueryError;
           return sandboxRows;
         },
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: () => ({
+        where: (cond: unknown) => ({
+          returning: async () => {
+            if (table !== projectSessions) return [];
+            sessionUpdateWhereArg = cond;
+            if (sessionUpdateError) throw sessionUpdateError;
+            return sessionsSettled;
+          },
+        }),
       }),
     }),
   },
@@ -27,13 +64,21 @@ mock.module('../../shared/db', () => ({
 // whatever unrelated file imports the missing name next, attributed to no test.
 mock.module('../../platform/providers', () => ({
   ...realProviders,
-  getProvider: (_name: string) => ({
-    stop: async (externalId: string) => {
-      stops.push(externalId);
-      const err = stopErrorByExternal[externalId];
-      if (err) throw err;
-    },
-  }),
+  tryGetProvider: (_name: string) =>
+    providerAvailable
+      ? {
+          stop: async (externalId: string) => {
+            stops.push(externalId);
+            const err = stopErrorByExternal[externalId];
+            if (err) throw err;
+          },
+          remove: async (externalId: string) => {
+            removes.push(externalId);
+            const err = removeErrorByExternal[externalId];
+            if (err) throw err;
+          },
+        }
+      : null,
 }));
 
 // Spread the real module: `mock.module` replaces it WHOLESALE, so a stub that
@@ -43,8 +88,14 @@ mock.module('../../projects/sandbox-reaper', () => ({
   ...realSandboxReaper,
   isAlreadyNotRunning: (err: unknown) =>
     err instanceof Error && err.message.toLowerCase().includes('already stopped'),
+  reconcileSandboxRemovedByExternalId: async (externalId: string) => {
+    const err = removedReconcileErrorByExternal[externalId];
+    if (err) throw err;
+    reconciledRemoved.push(externalId);
+    return true;
+  },
   reconcileSandboxStoppedByExternalId: async (externalId: string) => {
-    reconciled.push(externalId);
+    reconciledStopped.push(externalId);
     return true;
   },
 }));
@@ -72,28 +123,131 @@ mock.module('../repositories/account-deletion', () => ({
   getScheduledDeletions: async () => [],
 }));
 
-const { deleteAccountImmediately } = await import('./account-deletion');
+const {
+  deleteAccountImmediately,
+  reclaimableAccountIds,
+  RECLAIMABLE_SANDBOX_STATUSES,
+  LIVE_SESSION_STATUSES,
+} = await import('./account-deletion');
+
+/**
+ * Collect every primitive a drizzle condition tree carries, so a test can prove
+ * which account ids and statuses actually reached the WHERE clause without
+ * depending on drizzle's internal chunk shape.
+ */
+function conditionValues(node: unknown, seen = new Set<unknown>()): string[] {
+  if (node == null) return [];
+  if (typeof node === 'string') return [node];
+  if (typeof node !== 'object') return [];
+  if (seen.has(node)) return [];
+  seen.add(node);
+  const out: string[] = [];
+  for (const value of Object.values(node as Record<string, unknown>)) {
+    out.push(...conditionValues(value, seen));
+  }
+  return out;
+}
 
 beforeEach(() => {
   sandboxRows = [];
   sandboxQueryError = null;
+  ownedAccountRows = [];
+  ownedAccountsQueryError = null;
+  sandboxWhereArg = null;
+  sessionUpdateWhereArg = null;
+  sessionsSettled = [];
+  sessionUpdateError = null;
   stops = [];
+  removes = [];
   stopErrorByExternal = {};
-  reconciled = [];
+  removeErrorByExternal = {};
+  providerAvailable = true;
+  reconciledRemoved = [];
+  reconciledStopped = [];
+  removedReconcileErrorByExternal = {};
   creditAccount = null;
 });
 
-describe('deleteAccountImmediately — sandbox teardown', () => {
-  test('stops every active sandbox owned by the account and reconciles each', async () => {
+describe('reclaim status filters', () => {
+  test('a box mid-provision or in error is reclaimable, a terminal one is not', () => {
+    // `active` alone was the old filter. A box that died during provisioning or
+    // whose last control-plane call errored still exists at the provider and
+    // still bills — 47 of them survived the release-gate sweep that way.
+    expect([...RECLAIMABLE_SANDBOX_STATUSES]).toEqual(['provisioning', 'active', 'error']);
+    expect(RECLAIMABLE_SANDBOX_STATUSES).not.toContain('stopped');
+    expect(RECLAIMABLE_SANDBOX_STATUSES).not.toContain('archived');
+  });
+
+  test('every non-terminal session status is settled', () => {
+    expect([...LIVE_SESSION_STATUSES]).toEqual([
+      'queued',
+      'branching',
+      'provisioning',
+      'running',
+    ]);
+    for (const terminal of ['stopped', 'failed', 'completed']) {
+      expect(LIVE_SESSION_STATUSES).not.toContain(terminal);
+    }
+  });
+});
+
+describe('reclaimableAccountIds', () => {
+  test('without a user id it is just the resolved account', async () => {
+    ownedAccountRows = [{ accountId: 'acct-2' }];
+    expect(await reclaimableAccountIds('acct-1')).toEqual(['acct-1']);
+  });
+
+  test('with a user id it covers every account that user owns', async () => {
+    ownedAccountRows = [{ accountId: 'acct-2' }, { accountId: 'acct-3' }];
+    const ids = await reclaimableAccountIds('acct-1', 'user-1');
+    expect(ids.sort()).toEqual(['acct-1', 'acct-2', 'acct-3']);
+  });
+
+  test('the resolved account is never duplicated', async () => {
+    ownedAccountRows = [{ accountId: 'acct-1' }, { accountId: 'acct-2' }];
+    expect((await reclaimableAccountIds('acct-1', 'user-1')).sort()).toEqual([
+      'acct-1',
+      'acct-2',
+    ]);
+  });
+
+  test('a failed membership lookup degrades to the single account, never to none', async () => {
+    ownedAccountsQueryError = new Error('connection terminated');
+    expect(await reclaimableAccountIds('acct-1', 'user-1')).toEqual(['acct-1']);
+  });
+});
+
+describe('deleteAccountImmediately — sandbox reclaim', () => {
+  test('stops AND removes every reclaimable box across every account the user owns', async () => {
+    // 2 accounts × 2 boxes. Before this change the sweep saw only acct-1's
+    // boxes, because the route resolves the earliest-joined account and nothing
+    // widened it.
+    ownedAccountRows = [{ accountId: 'acct-2' }];
     sandboxRows = [
       { sandboxId: 'sb-1', provider: 'daytona', externalId: 'ext-1' },
-      { sandboxId: 'sb-2', provider: 'e2b', externalId: 'ext-2' },
+      { sandboxId: 'sb-2', provider: 'daytona', externalId: 'ext-2' },
+      { sandboxId: 'sb-3', provider: 'e2b', externalId: 'ext-3' },
+      { sandboxId: 'sb-4', provider: 'platinum', externalId: 'ext-4' },
     ];
 
-    await deleteAccountImmediately('acct-1');
+    await deleteAccountImmediately('acct-1', 'user-1');
 
-    expect(stops.sort()).toEqual(['ext-1', 'ext-2']);
-    expect(reconciled.sort()).toEqual(['ext-1', 'ext-2']);
+    expect(stops.sort()).toEqual(['ext-1', 'ext-2', 'ext-3', 'ext-4']);
+    expect(removes.sort()).toEqual(['ext-1', 'ext-2', 'ext-3', 'ext-4']);
+    // The removed reconcile is the one that revokes the session connector
+    // token, which is what actually kills a surviving agent process.
+    expect(reconciledRemoved.sort()).toEqual(['ext-1', 'ext-2', 'ext-3', 'ext-4']);
+  });
+
+  test('both owned accounts and every reclaimable status reach the sandbox query', async () => {
+    ownedAccountRows = [{ accountId: 'acct-2' }];
+
+    await deleteAccountImmediately('acct-1', 'user-1');
+
+    const values = conditionValues(sandboxWhereArg);
+    expect(values).toContain('acct-1');
+    expect(values).toContain('acct-2');
+    for (const status of RECLAIMABLE_SANDBOX_STATUSES) expect(values).toContain(status);
   });
 
   test('a box with no external id is skipped entirely', async () => {
@@ -102,10 +256,11 @@ describe('deleteAccountImmediately — sandbox teardown', () => {
     await deleteAccountImmediately('acct-1');
 
     expect(stops).toEqual([]);
-    expect(reconciled).toEqual([]);
+    expect(removes).toEqual([]);
+    expect(reconciledRemoved).toEqual([]);
   });
 
-  test('a provider stop failure on one box does not block the rest or the deletion', async () => {
+  test('a stop failure on one box still removes it and never blocks the others', async () => {
     sandboxRows = [
       { sandboxId: 'sb-1', provider: 'daytona', externalId: 'ext-1' },
       { sandboxId: 'sb-2', provider: 'daytona', externalId: 'ext-2' },
@@ -116,16 +271,58 @@ describe('deleteAccountImmediately — sandbox teardown', () => {
 
     expect(result.success).toBe(true);
     expect(stops.sort()).toEqual(['ext-1', 'ext-2']);
-    expect(reconciled).toEqual(['ext-2']);
+    // A box we could not park is exactly the box that must not survive.
+    expect(removes.sort()).toEqual(['ext-1', 'ext-2']);
+    expect(reconciledRemoved.sort()).toEqual(['ext-1', 'ext-2']);
   });
 
-  test('an already-stopped box still reconciles cleanly', async () => {
+  test('a remove failure on one box does not block the rest or the deletion', async () => {
+    sandboxRows = [
+      { sandboxId: 'sb-1', provider: 'daytona', externalId: 'ext-1' },
+      { sandboxId: 'sb-2', provider: 'daytona', externalId: 'ext-2' },
+    ];
+    removeErrorByExternal['ext-1'] = new Error('provider 500');
+
+    const result = await deleteAccountImmediately('acct-1');
+
+    expect(result.success).toBe(true);
+    expect(removes.sort()).toEqual(['ext-1', 'ext-2']);
+    // The row is still settled, so nothing keeps billing against it.
+    expect(reconciledRemoved.sort()).toEqual(['ext-1', 'ext-2']);
+  });
+
+  test('an already-gone box still stops, removes and reconciles cleanly', async () => {
     sandboxRows = [{ sandboxId: 'sb-1', provider: 'daytona', externalId: 'ext-1' }];
     stopErrorByExternal['ext-1'] = new Error('Sandbox already stopped');
+    removeErrorByExternal['ext-1'] = new Error('Sandbox already stopped');
 
     await deleteAccountImmediately('acct-1');
 
-    expect(reconciled).toEqual(['ext-1']);
+    expect(reconciledRemoved).toEqual(['ext-1']);
+  });
+
+  test('a failed removed-reconcile falls back to the stopped reconcile', async () => {
+    // The row must end terminal either way — an eternally `active` row keeps
+    // billing and keeps the box eligible for a wake.
+    sandboxRows = [{ sandboxId: 'sb-1', provider: 'daytona', externalId: 'ext-1' }];
+    removedReconcileErrorByExternal['ext-1'] = new Error('deadlock detected');
+
+    const result = await deleteAccountImmediately('acct-1');
+
+    expect(result.success).toBe(true);
+    expect(reconciledRemoved).toEqual([]);
+    expect(reconciledStopped).toEqual(['ext-1']);
+  });
+
+  test('a provider with no configured client still settles the row', async () => {
+    providerAvailable = false;
+    sandboxRows = [{ sandboxId: 'sb-1', provider: 'daytona', externalId: 'ext-1' }];
+
+    const result = await deleteAccountImmediately('acct-1');
+
+    expect(result.success).toBe(true);
+    expect(stops).toEqual([]);
+    expect(reconciledRemoved).toEqual(['ext-1']);
   });
 
   test('a failure looking up the sandboxes does not block the deletion', async () => {
@@ -137,12 +334,48 @@ describe('deleteAccountImmediately — sandbox teardown', () => {
     expect(stops).toEqual([]);
   });
 
-  test('no active sandboxes → no stop calls, deletion still succeeds', async () => {
+  test('no reclaimable sandboxes → no provider calls, deletion still succeeds', async () => {
     sandboxRows = [];
 
     const result = await deleteAccountImmediately('acct-1');
 
     expect(result.success).toBe(true);
     expect(stops).toEqual([]);
+    expect(removes).toEqual([]);
+  });
+});
+
+describe('deleteAccountImmediately — session settle', () => {
+  test('every non-terminal session in every owned account is marked stopped', async () => {
+    // These are the rows the manual playbook had to fix by hand: a session with
+    // no sandbox row, or one whose row had no external id, stayed `running`
+    // forever and the next preflight read it as live.
+    ownedAccountRows = [{ accountId: 'acct-2' }];
+    sessionsSettled = [{ sessionId: 's-1' }, { sessionId: 's-2' }];
+
+    await deleteAccountImmediately('acct-1', 'user-1');
+
+    const values = conditionValues(sessionUpdateWhereArg);
+    expect(values).toContain('acct-1');
+    expect(values).toContain('acct-2');
+    for (const status of LIVE_SESSION_STATUSES) expect(values).toContain(status);
+  });
+
+  test('the sessions are settled even when the sandbox lookup failed', async () => {
+    sandboxQueryError = new Error('connection terminated');
+    sessionsSettled = [{ sessionId: 's-1' }];
+
+    const result = await deleteAccountImmediately('acct-1');
+
+    expect(result.success).toBe(true);
+    expect(sessionUpdateWhereArg).not.toBeNull();
+  });
+
+  test('a failed session settle does not block the deletion', async () => {
+    sessionUpdateError = new Error('deadlock detected');
+
+    const result = await deleteAccountImmediately('acct-1');
+
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/api/src/billing/services/account-deletion.ts
+++ b/apps/api/src/billing/services/account-deletion.ts
@@ -1,10 +1,14 @@
-import { and, eq } from 'drizzle-orm';
-import { sessionSandboxes } from '@kortix/db';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
+import { accountMembers, projectSessions, sessionSandboxes } from '@kortix/db';
 import { getStripe } from '../../shared/stripe';
 import { db } from '../../shared/db';
 import { BillingError } from '../../errors';
-import { getProvider, type ProviderName } from '../../platform/providers';
-import { isAlreadyNotRunning, reconcileSandboxStoppedByExternalId } from '../../projects/sandbox-reaper';
+import { tryGetProvider } from '../../platform/providers';
+import {
+  isAlreadyNotRunning,
+  reconcileSandboxRemovedByExternalId,
+  reconcileSandboxStoppedByExternalId,
+} from '../../projects/sandbox-reaper';
 import { getCreditAccount, updateCreditAccount } from '../repositories/credit-accounts';
 import { insertLedgerEntry } from '../repositories/transactions';
 import {
@@ -71,9 +75,15 @@ export async function cancelAccountDeletion(accountId: string) {
   return { success: true, message: 'Account deletion cancelled' };
 }
 
-export async function deleteAccountImmediately(accountId: string) {
+/**
+ * `userId` widens the sandbox sweep to every account this user OWNS, not just
+ * the one the route resolved. Optional so existing callers keep compiling, but
+ * the route should always pass it — without it a user's team-account sandboxes
+ * survive the deletion. See `reclaimableAccountIds`.
+ */
+export async function deleteAccountImmediately(accountId: string, userId?: string) {
   const request = await getActiveDeletionRequest(accountId);
-  await performDeletion(accountId);
+  await performDeletion(accountId, userId ?? request?.userId);
   if (request) {
     await markDeletionCompleted(request.id);
   }
@@ -91,7 +101,9 @@ export async function processScheduledDeletions(): Promise<{
 
   for (const request of requests) {
     try {
-      await performDeletion(request.accountId);
+      // The request row carries the requester, so the scheduled path gets the
+      // same owner-wide sweep as the immediate one.
+      await performDeletion(request.accountId, request.userId);
       await markDeletionCompleted(request.id);
       processed++;
     } catch (err) {
@@ -105,18 +117,99 @@ export async function processScheduledDeletions(): Promise<{
   return { processed, errors };
 }
 
-/**
- * Stop every still-active sandbox owned by the account being deleted, right
- * now, while we still know who it belongs to. This closes the gap BEFORE the
- * row goes orphaned, rather than relying on the reaper's orphan-account
- * sweep (sandbox-reaper.ts) to notice later — same reasoning as that sweep's
- * bypass: the account is gone, so there is no customer whose in-flight turn
- * a stop could interrupt. Best-effort per box; one failure must not block
- * deletion or leave the rest of the account's boxes running.
- */
-const STOP_CONCURRENCY = 6;
+const STOP_CONCURRENCY = 8;
 
-async function stopAccountSandboxes(accountId: string): Promise<void> {
+/**
+ * Sandbox rows that may still map to a box the provider is charging for.
+ *
+ * `active` alone is NOT the right filter, which is how this leaked. A box that
+ * died mid-provision (`provisioning`) or whose last control-plane call errored
+ * (`error`) still exists at the provider and still bills; only `stopped` and
+ * `archived` are terminal. The release-gate incident that motivated this found
+ * 47 sessions in exactly these non-`active` states with live Daytona boxes.
+ */
+export const RECLAIMABLE_SANDBOX_STATUSES = ['provisioning', 'active', 'error'] as const;
+
+/** `project_sessions` states that still claim the session is doing something. */
+export const LIVE_SESSION_STATUSES = [
+  'queued',
+  'branching',
+  'provisioning',
+  'running',
+] as const;
+
+export interface SandboxReclaimSummary {
+  accounts: number;
+  boxes: number;
+  stopped: number;
+  removed: number;
+  sessionsSettled: number;
+  errors: number;
+}
+
+/**
+ * Every account this user OWNS, including the account passed in.
+ *
+ * Deletion used to sweep exactly one account: the route resolves the caller
+ * through `resolveAccountId` (shared/resolve-account.ts), which returns the
+ * user's EARLIEST-JOINED membership and nothing else. A user who owned a team
+ * account created after their personal one therefore had every team sandbox
+ * survive the deletion, still running and still billing, with no account left
+ * to attribute them to. That is the second half of the release-gate leak.
+ *
+ * Scoped to `account_role = 'owner'` on purpose, NOT to bare membership:
+ * deleting your own account must never tear down sandboxes in someone else's
+ * team that you merely belong to. Owner is the same authority the route already
+ * requires (ACCOUNT_ACTIONS.ACCOUNT_DELETE), so this widens the sweep to
+ * exactly the accounts the caller could have deleted one at a time anyway.
+ */
+export async function reclaimableAccountIds(
+  accountId: string,
+  userId?: string,
+): Promise<string[]> {
+  const ids = new Set<string>([accountId]);
+  if (!userId) return [...ids];
+  try {
+    const owned = await db
+      .select({ accountId: accountMembers.accountId })
+      .from(accountMembers)
+      .where(and(eq(accountMembers.userId, userId), eq(accountMembers.accountRole, 'owner')));
+    for (const row of owned) if (row.accountId) ids.add(row.accountId);
+  } catch (err) {
+    // Degrade to the single account rather than skipping teardown entirely.
+    console.error(
+      `[AccountDeletion] owned-account lookup failed for user ${userId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+  return [...ids];
+}
+
+/**
+ * Stop AND remove every sandbox owned by the accounts being deleted, right now,
+ * while we still know who they belong to.
+ *
+ * `stop()` alone was not enough. A stopped box still exists at the provider,
+ * still holds the disk, still counts against the org quota, and — the part that
+ * actually broke the release gate — can be woken again by anything holding its
+ * connector token. So each box is stopped, then REMOVED, then reconciled
+ * through `reconcileSandboxRemovedByExternalId`, which settles billing, flips
+ * `session_sandboxes` AND `project_sessions` to `stopped` in one transaction,
+ * and revokes the session's connector token so no surviving agent process can
+ * authenticate with it.
+ *
+ * Best-effort per box: one provider failure must never block deletion, abort
+ * the remaining boxes, or leave the row claiming to be alive.
+ */
+async function reclaimAccountSandboxes(accountIds: string[]): Promise<SandboxReclaimSummary> {
+  const summary: SandboxReclaimSummary = {
+    accounts: accountIds.length,
+    boxes: 0,
+    stopped: 0,
+    removed: 0,
+    sessionsSettled: 0,
+    errors: 0,
+  };
   // Deletion must never fail because teardown did. Every failure mode here —
   // the lookup itself, a provider stop, a reconcile — degrades to "leave the
   // box for the reaper's orphan sweep", which is exactly what this path
@@ -129,37 +222,131 @@ async function stopAccountSandboxes(accountId: string): Promise<void> {
         externalId: sessionSandboxes.externalId,
       })
       .from(sessionSandboxes)
-      .where(and(eq(sessionSandboxes.accountId, accountId), eq(sessionSandboxes.status, 'active')));
+      .where(
+        and(
+          inArray(sessionSandboxes.accountId, accountIds),
+          inArray(sessionSandboxes.status, [...RECLAIMABLE_SANDBOX_STATUSES]),
+          isNotNull(sessionSandboxes.externalId),
+        ),
+      );
 
     const targets = rows.filter((row) => !!row.externalId);
+    summary.boxes = targets.length;
+
     // Bounded fan-out: this runs inline on DELETE /v1/account/delete-immediately,
     // whose caller aborts at 30s. A serial loop over a large account would
     // serialise that many provider round-trips into one request.
     for (let i = 0; i < targets.length; i += STOP_CONCURRENCY) {
       await Promise.all(
         targets.slice(i, i + STOP_CONCURRENCY).map(async (row) => {
-          try {
-            await getProvider(row.provider as ProviderName).stop(row.externalId as string);
-          } catch (err) {
-            if (!isAlreadyNotRunning(err)) {
-              console.error(`[AccountDeletion] Failed to stop sandbox ${row.sandboxId} for ${accountId}:`, err instanceof Error ? err.message : err);
-              return;
+          const externalId = row.externalId as string;
+          // `tryGetProvider`, not `getProvider`: a provider whose API key is
+          // unset on this deployment must not throw and skip the box — the row
+          // still has to be settled so nothing keeps billing against it.
+          const provider = tryGetProvider(row.provider as string);
+
+          if (provider) {
+            try {
+              await provider.stop(externalId);
+              summary.stopped++;
+            } catch (err) {
+              if (!isAlreadyNotRunning(err)) {
+                summary.errors++;
+                console.error(
+                  `[AccountDeletion] Failed to stop sandbox ${row.sandboxId}:`,
+                  err instanceof Error ? err.message : err,
+                );
+              } else {
+                summary.stopped++;
+              }
             }
-            // Already stopped/gone on the provider side — proceed to reconcile.
+
+            // Remove even when the stop failed: a box we could not park is
+            // exactly the box that must not survive this deletion.
+            try {
+              await provider.remove(externalId);
+              summary.removed++;
+            } catch (err) {
+              if (!isAlreadyNotRunning(err)) {
+                summary.errors++;
+                console.error(
+                  `[AccountDeletion] Failed to remove sandbox ${row.sandboxId}:`,
+                  err instanceof Error ? err.message : err,
+                );
+              } else {
+                summary.removed++;
+              }
+            }
+          } else {
+            summary.errors++;
+            console.error(
+              `[AccountDeletion] No provider client for ${row.provider}; settling sandbox ${row.sandboxId} without a provider call`,
+            );
           }
-          await reconcileSandboxStoppedByExternalId(row.externalId as string).catch((err) =>
-            console.warn(`[AccountDeletion] reconcile failed for sandbox ${row.sandboxId}:`, err instanceof Error ? err.message : err),
-          );
+
+          // Reconcile regardless of what the provider did. `removed` is the
+          // stronger settle — it revokes the session's connector token, which
+          // is the credential a surviving agent process would otherwise keep
+          // using. Fall back to the stopped reconcile so a failure here still
+          // leaves the row terminal rather than eternally `active`.
+          try {
+            await reconcileSandboxRemovedByExternalId(externalId);
+          } catch (err) {
+            console.warn(
+              `[AccountDeletion] removed-reconcile failed for sandbox ${row.sandboxId}:`,
+              err instanceof Error ? err.message : err,
+            );
+            await reconcileSandboxStoppedByExternalId(externalId).catch((fallbackErr) => {
+              summary.errors++;
+              console.warn(
+                `[AccountDeletion] stopped-reconcile also failed for sandbox ${row.sandboxId}:`,
+                fallbackErr instanceof Error ? fallbackErr.message : fallbackErr,
+              );
+            });
+          }
         }),
       );
     }
   } catch (err) {
-    console.error(`[AccountDeletion] sandbox teardown failed for ${accountId}:`, err instanceof Error ? err.message : err);
+    summary.errors++;
+    console.error(
+      `[AccountDeletion] sandbox teardown failed for ${accountIds.join(', ')}:`,
+      err instanceof Error ? err.message : err,
+    );
   }
+
+  // Settle sessions the sandbox sweep could not reach: a session that never got
+  // a `session_sandboxes` row, or whose row had no `external_id`, still shows as
+  // `running` forever. Those are the rows the manual playbook had to fix by
+  // hand. Terminal statuses are left alone.
+  try {
+    const settled = await db
+      .update(projectSessions)
+      .set({ status: 'stopped', updatedAt: new Date() })
+      .where(
+        and(
+          inArray(projectSessions.accountId, accountIds),
+          inArray(projectSessions.status, [...LIVE_SESSION_STATUSES]),
+        ),
+      )
+      .returning({ sessionId: projectSessions.sessionId });
+    summary.sessionsSettled = settled.length;
+  } catch (err) {
+    summary.errors++;
+    console.error(
+      `[AccountDeletion] session settle failed for ${accountIds.join(', ')}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  console.log(
+    `[AccountDeletion] reclaim: accounts=${summary.accounts} boxes=${summary.boxes} stopped=${summary.stopped} removed=${summary.removed} sessions=${summary.sessionsSettled} errors=${summary.errors}`,
+  );
+  return summary;
 }
 
-async function performDeletion(accountId: string) {
-  await stopAccountSandboxes(accountId);
+async function performDeletion(accountId: string, userId?: string) {
+  await reclaimAccountSandboxes(await reclaimableAccountIds(accountId, userId));
 
   const account = await getCreditAccount(accountId);
 

--- a/apps/api/src/repositories/account-tokens-revoked.test.ts
+++ b/apps/api/src/repositories/account-tokens-revoked.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression: a token with `revoked_at` stamped must NOT authenticate.
+ *
+ * `validateAccountToken` used to gate on `status = 'active'` alone. Nothing in
+ * the database ties `status` and `revoked_at` together — there is no CHECK, no
+ * trigger and no partial index on `account_tokens` — so any writer that stamps
+ * `revoked_at` without also flipping `status` left a fully live credential.
+ *
+ * That is not hypothetical. The release-gate sweep revokes its test PATs with a
+ * direct `UPDATE account_tokens SET revoked_at = now()`; 186 "Connector Session"
+ * tokens kept authenticating afterwards and their sandbox agents kept hammering
+ * the staging gateway with dead credentials until it reported `degraded`.
+ *
+ * These tests run in the hermetic unit lane (`scripts/test.sh default`), so the
+ * database is a fake. They assert the SHAPE of the query — which columns the
+ * WHERE clause constrains — with a positive control proving the assertion can
+ * fail. The end-to-end behaviour against real Postgres plus a real HTTP request
+ * is covered by `src/__tests__/integration-revoked-token-auth.test.ts`.
+ */
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { accountTokens } from '@kortix/db';
+
+let capturedWhere: unknown = null;
+let rows: Array<Record<string, unknown>> = [];
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: (cond: unknown) => {
+            capturedWhere = cond;
+            return { limit: async () => rows };
+          },
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({ where: async () => undefined, catch: () => undefined }),
+    }),
+  },
+}));
+
+const { validateAccountToken } = await import('./account-tokens');
+const { generateAccountTokenPair } = await import('../shared/crypto');
+
+/**
+ * Every column the condition tree constrains.
+ *
+ * Recursion stops at a column node on purpose: a drizzle column holds a
+ * back-reference to its whole table, so descending into one yields every column
+ * of `account_tokens` and the assertion would pass no matter what was filtered.
+ */
+function filteredColumns(node: unknown, seen = new Set<unknown>(), out: string[] = []): string[] {
+  if (!node || typeof node !== 'object' || seen.has(node)) return out;
+  seen.add(node);
+  const candidate = node as { name?: unknown; columnType?: unknown };
+  if (typeof candidate.name === 'string' && typeof candidate.columnType === 'string') {
+    out.push(candidate.name);
+    return out;
+  }
+  for (const value of Object.values(node as Record<string, unknown>)) {
+    filteredColumns(value, seen, out);
+  }
+  return out;
+}
+
+beforeEach(() => {
+  capturedWhere = null;
+  rows = [];
+});
+
+describe('validateAccountToken revocation gate', () => {
+  test('the lookup constrains revoked_at, not only status', async () => {
+    const { secretKey } = generateAccountTokenPair();
+
+    await validateAccountToken(secretKey);
+
+    const columns = filteredColumns(capturedWhere);
+    expect(columns).toContain('secret_key_hash');
+    expect(columns).toContain('status');
+    // The fix. Without it a `revoked_at`-stamped row authenticates cleanly and
+    // even emits a normal `auth.login.success` audit event, hiding the bypass.
+    expect(columns).toContain('revoked_at');
+  });
+
+  test('positive control: the assertion above fails on the pre-fix condition', () => {
+    // Proves `filteredColumns` actually discriminates rather than always
+    // reporting every column of the table.
+    const preFix = and(
+      inArray(accountTokens.secretKeyHash, ['h']),
+      eq(accountTokens.status, 'active'),
+    );
+    const fixed = and(
+      inArray(accountTokens.secretKeyHash, ['h']),
+      eq(accountTokens.status, 'active'),
+      isNull(accountTokens.revokedAt),
+    );
+    expect(filteredColumns(preFix)).toEqual(['secret_key_hash', 'status']);
+    expect(filteredColumns(fixed)).toEqual(['secret_key_hash', 'status', 'revoked_at']);
+  });
+
+  test('a filtered-out row is reported as revoked, never as valid', async () => {
+    const { secretKey } = generateAccountTokenPair();
+    rows = [];
+
+    const result = await validateAccountToken(secretKey);
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe('PAT not found or revoked');
+  });
+
+  test('a live row still authenticates — the gate is not just refusing everything', async () => {
+    const { secretKey } = generateAccountTokenPair();
+    rows = [
+      {
+        tokenId: 'tok-1',
+        accountId: 'acct-1',
+        userId: 'user-1',
+        projectId: null,
+        sessionId: null,
+        status: 'active',
+        expiresAt: null,
+        lastUsedAt: new Date(),
+        createdAt: new Date(),
+        agentGrant: null,
+        patIdleRevokeDays: null,
+      },
+    ];
+
+    const result = await validateAccountToken(secretKey);
+
+    expect(result.isValid).toBe(true);
+    expect(result.accountId).toBe('acct-1');
+    expect(result.userId).toBe('user-1');
+  });
+
+  test('a malformed token is refused before any lookup runs', async () => {
+    const result = await validateAccountToken('not-a-kortix-pat');
+
+    expect(result.isValid).toBe(false);
+    expect(capturedWhere).toBeNull();
+  });
+});

--- a/apps/api/src/repositories/account-tokens.ts
+++ b/apps/api/src/repositories/account-tokens.ts
@@ -391,6 +391,24 @@ export async function validateAccountToken(
         and(
           inArray(accountTokens.secretKeyHash, secretKeyHashes),
           eq(accountTokens.status, 'active'),
+          // `revoked_at` is the SECOND half of the revocation invariant and it
+          // must be checked here, not only `status`. Nothing in the database
+          // ties the two columns together — there is no CHECK, no trigger and
+          // no partial index (schema: packages/db/src/schema/kortix.ts
+          // `accountTokens`) — so a row can be `status='active'` with
+          // `revoked_at` stamped. Until this predicate existed, every such row
+          // authenticated cleanly on every surface (REST, LLM gateway, git
+          // proxy, preview proxy, connectors) and emitted a normal
+          // `auth.login.success` audit event, which hid the bypass.
+          //
+          // This is not hypothetical: the release-gate sweep revokes test PATs
+          // with a direct `UPDATE account_tokens SET revoked_at = now()`, and
+          // 186 "Connector Session" tokens kept authenticating afterwards,
+          // keeping zombie sandbox agents alive against staging. Every other
+          // reader of this table already checks both columns — see
+          // projects/lib/session-token-grant.ts, whose comment states the
+          // intent outright: "a revoked token must stay dead".
+          isNull(accountTokens.revokedAt),
         ),
       )
       .limit(1);
@@ -459,7 +477,17 @@ async function updateLastUsedThrottled(tokenId: string): Promise<void> {
     await db
       .update(accountTokens)
       .set({ lastUsedAt: new Date() })
-      .where(eq(accountTokens.tokenId, tokenId));
+      // Same liveness predicate as the validation query. A revoked token must
+      // not keep refreshing its own idle clock: without this, a token revoked
+      // between the read and this write looks freshly used, which defeats the
+      // idle-revoke sweep above and makes the token appear live in the UI.
+      .where(
+        and(
+          eq(accountTokens.tokenId, tokenId),
+          eq(accountTokens.status, 'active'),
+          isNull(accountTokens.revokedAt),
+        ),
+      );
   } catch (err) {
     console.warn('Failed to update account_tokens.last_used_at:', err);
   }

--- a/tests/src/fixtures/gc.ts
+++ b/tests/src/fixtures/gc.ts
@@ -105,21 +105,37 @@ async function listTestUsersViaApi(env: Env): Promise<SupaUser[]> {
   return out;
 }
 
-async function listTestUsersViaDb(env: Env, domains: string[]): Promise<SupaUser[]> {
-  const conn = env.databaseUrl!;
+/**
+ * SSL policy for a direct Postgres connection.
+ *
+ * Same policy as database-project.ts / platform-admin.ts: Supabase's direct
+ * Postgres endpoint presents a chain Node's default trust store rejects
+ * ("self signed certificate in certificate chain"), which is what killed both
+ * gc sweeps on the first sharded release-gate run (32222342409). A local
+ * connection uses no TLS at all.
+ */
+export function gcDbSsl(conn: string): false | { rejectUnauthorized: false } {
   const local = conn.includes("localhost") || conn.includes("127.0.0.1");
-  const { Client } = await import("pg");
-  const client = new Client({
-    connectionString: conn,
-    // Same policy as database-project.ts / platform-admin.ts: Supabase's direct
-    // Postgres endpoint presents a chain Node's default trust store rejects
-    // ("self signed certificate in certificate chain"), which is what killed
-    // both gc sweeps on the first sharded release-gate run (32222342409).
-    ssl: local ? false : { rejectUnauthorized: false },
-  });
-  await client.connect();
+  return local ? false : { rejectUnauthorized: false };
+}
+
+/** Minimal shape of the `pg` pool this module uses, so tests can fake it. */
+export interface GcDb {
+  query(text: string, values?: unknown[]): Promise<{ rows: any[]; rowCount?: number | null }>;
+  end(): Promise<void>;
+}
+
+async function openGcDb(conn: string): Promise<GcDb> {
+  const { Pool } = await import("pg");
+  // A pool, not a single Client: `reclaimUser` runs under `mapWithConcurrency`,
+  // so several workers query at once. One Client would serialise all of them.
+  return new Pool({ connectionString: conn, ssl: gcDbSsl(conn), max: 8 }) as unknown as GcDb;
+}
+
+async function listTestUsersViaDb(env: Env, domains: string[]): Promise<SupaUser[]> {
+  const db = await openGcDb(env.databaseUrl!);
   try {
-    const r = await client.query(
+    const r = await db.query(
       "SELECT id::text AS id, email, created_at FROM auth.users WHERE email LIKE ANY($1::text[])",
       [domains.map((domain) => `%@${domain}`)],
     );
@@ -129,8 +145,93 @@ async function listTestUsersViaDb(env: Env, domains: string[]): Promise<SupaUser
       created_at: row.created_at instanceof Date ? row.created_at.toISOString() : (row.created_at ?? undefined),
     }));
   } finally {
-    await client.end();
+    await db.end();
   }
+}
+
+/**
+ * Every account this user OWNS, straight from the database.
+ *
+ * The API-driven `ownedAccountIds` below needs a working password grant, which
+ * the Playwright lane's users legitimately do not have. This one always works
+ * wherever `KE2E_DATABASE_URL` is set, which is the release gate.
+ */
+export async function ownedAccountIdsViaDb(db: GcDb, userId: string): Promise<string[]> {
+  const r = await db.query(
+    `SELECT account_id::text AS account_id
+       FROM kortix.account_members
+      WHERE user_id = $1::uuid AND account_role = 'owner'`,
+    [userId],
+  );
+  return r.rows.map((row: { account_id: string }) => row.account_id);
+}
+
+/**
+ * Revoke EVERY token in these accounts, setting both columns.
+ *
+ * Both columns, because they are two halves of one invariant and nothing in the
+ * database ties them together — no CHECK, no trigger, no partial index. The
+ * sweep used to stamp `revoked_at` alone, and `validateAccountToken` gated on
+ * `status` alone, so 186 "Connector Session" tokens kept authenticating after a
+ * "successful" revoke and their agents kept hitting the staging gateway until it
+ * reported `degraded`. The API side is fixed
+ * (apps/api/src/repositories/account-tokens.ts), and this write no longer
+ * depends on that fix being present.
+ *
+ * The `OR status = 'active'` arm also heals any row already left in the
+ * inconsistent state by an earlier sweep.
+ */
+export async function revokeAccountTokens(db: GcDb, accountIds: string[]): Promise<number> {
+  if (accountIds.length === 0) return 0;
+  const r = await db.query(
+    `UPDATE kortix.account_tokens
+        SET status = 'revoked', revoked_at = now()
+      WHERE account_id = ANY($1::uuid[])
+        AND (revoked_at IS NULL OR status = 'active')
+      RETURNING token_id`,
+    [accountIds],
+  );
+  return r.rows.length;
+}
+
+/**
+ * Sessions in these accounts that still claim to be alive, or whose sandbox row
+ * still points at a box the provider has not been told to release.
+ *
+ * The sandbox arm matters as much as the session arm: run 32231251280 left 47
+ * sessions whose `project_sessions.status` was already settled but whose
+ * `session_sandboxes` row still carried a live `external_id`.
+ */
+export async function listLiveSessions(
+  db: GcDb,
+  accountIds: string[],
+): Promise<Array<{ sessionId: string; projectId: string }>> {
+  if (accountIds.length === 0) return [];
+  const r = await db.query(
+    `SELECT DISTINCT s.session_id, s.project_id::text AS project_id
+       FROM kortix.project_sessions s
+       LEFT JOIN kortix.session_sandboxes sb ON sb.session_id = s.session_id
+      WHERE s.account_id = ANY($1::uuid[])
+        AND (
+          s.status IN ('queued', 'branching', 'provisioning', 'running')
+          OR (sb.external_id IS NOT NULL AND sb.status IN ('provisioning', 'active', 'error'))
+        )`,
+    [accountIds],
+  );
+  return r.rows.map((row: { session_id: string; project_id: string }) => ({
+    sessionId: row.session_id,
+    projectId: row.project_id,
+  }));
+}
+
+/**
+ * Which stop responses mean "this box is no longer our problem".
+ *
+ * 409 is "not running" and 404 is "already gone" — both are the desired end
+ * state, so counting them as failures would make a clean sweep look broken.
+ */
+export function isSessionReclaimed(statusCode: number): boolean {
+  return statusCode < 300 || statusCode === 404 || statusCode === 409;
 }
 
 async function listTestUsers(env: Env, domains: string[]): Promise<SupaUser[]> {
@@ -162,32 +263,97 @@ export async function runGc(opts: GcOptions): Promise<void> {
   log.info(`gc: ${users.length} test user(s) found, ${stale.length} selected for reclaim`);
   let removed = 0;
   let failed = 0;
+  const summary: GcSummary = { sessionsStopped: 0, tokensRevoked: 0, errors: 0 };
   const configuredWorkers = Number(process.env.KE2E_GC_WORKERS ?? 8);
   const workers =
     Number.isFinite(configuredWorkers) && configuredWorkers > 0
       ? Math.min(32, Math.trunc(configuredWorkers))
       : 8;
   log.info(`gc: reclaiming with ${workers} workers`);
-  await mapWithConcurrency(stale, workers, async (u) => {
-    if (opts.dryRun) {
-      log.info(`  would delete ${u.email} (${u.id})`);
-      return;
-    }
-    try {
-      await reclaimUser(env, u);
-      removed++;
-    } catch (err) {
-      failed++;
-      log.warn(`  could not reclaim ${u.email}: ${String((err as Error).message).slice(0, 120)}`);
-    }
-  });
+
+  // One pool for the whole sweep. Without a database URL the sweep still runs,
+  // just without the belt-and-braces session/token reclaim.
+  const db = !opts.dryRun && env.databaseUrl ? await openGcDb(env.databaseUrl) : null;
+  if (!db && !opts.dryRun) {
+    log.warn("gc: no KE2E_DATABASE_URL — session + token reclaim is disabled for this sweep");
+  }
+
+  try {
+    await mapWithConcurrency(stale, workers, async (u) => {
+      if (opts.dryRun) {
+        log.info(`  would delete ${u.email} (${u.id})`);
+        return;
+      }
+      try {
+        await reclaimUser(env, u, db, summary);
+        removed++;
+      } catch (err) {
+        failed++;
+        log.warn(`  could not reclaim ${u.email}: ${String((err as Error).message).slice(0, 120)}`);
+      }
+    });
+  } finally {
+    await db?.end().catch(() => {});
+  }
+
   if (!opts.dryRun) {
-    log.pass(`gc: reclaimed ${removed} stale test user(s)`);
+    log.pass(
+      `gc: reclaimed ${removed} stale test user(s); ` +
+        `sessions stopped=${summary.sessionsStopped} tokens revoked=${summary.tokensRevoked} ` +
+        `reclaim errors=${summary.errors}`,
+    );
     if (failed) log.fail(`gc: ${failed} could not be reclaimed (see warnings)`);
   }
 }
 
-async function reclaimUser(env: Env, u: SupaUser): Promise<void> {
+export interface GcSummary {
+  sessionsStopped: number;
+  tokensRevoked: number;
+  errors: number;
+}
+
+/**
+ * Reclaim one test user.
+ *
+ * Order is deliberate and is the whole point of this function:
+ *
+ *   1. Revoke every token in every account the user owns. This is FIRST because
+ *      it is the only step that needs neither a password grant nor a healthy
+ *      API, and it is what actually stops a surviving sandbox agent from
+ *      authenticating. When the API shards were killed at their 40-minute cap,
+ *      the agents that kept the staging gateway `degraded` were all running on
+ *      credentials a "successful" sweep had left live.
+ *   2. Stop each still-live session through the API, so the provider is told to
+ *      release the box rather than waiting for account deletion to get there.
+ *   3. Delete the account, which stops AND removes anything step 2 missed.
+ *   4. Delete the Supabase user — the reclaim that must always happen.
+ *
+ * Every step is best-effort and independent: a failure in one must never skip
+ * the rest, because each one alone still shrinks the leak.
+ */
+async function reclaimUser(
+  env: Env,
+  u: SupaUser,
+  db: GcDb | null,
+  summary: GcSummary,
+): Promise<void> {
+  const accountIds = new Set<string>([u.id]);
+
+  if (db) {
+    try {
+      for (const id of await ownedAccountIdsViaDb(db, u.id)) accountIds.add(id);
+    } catch (err) {
+      summary.errors++;
+      log.warn(`  owned-account lookup failed for ${u.email}: ${errText(err)}`);
+    }
+    try {
+      summary.tokensRevoked += await revokeAccountTokens(db, [...accountIds]);
+    } catch (err) {
+      summary.errors++;
+      log.warn(`  token revoke failed for ${u.email}: ${errText(err)}`);
+    }
+  }
+
   if (u.email) {
     // Best effort. Only ke2e principals share SYNTH_PASSWORD; the Playwright
     // suite mints its users with per-spec passwords, so the grant legitimately
@@ -199,21 +365,67 @@ async function reclaimUser(env: Env, u: SupaUser): Promise<void> {
         label: "gc",
         auth: { mode: "bearer", token: jwt },
       });
-      for (const accountId of await ownedAccountIds(client, u.id)) {
-        // The route is mounted under /v1/billing (billing/routes/account-deletion.ts:92)
-        // — the same path world.ts teardown uses. The old un-prefixed path 404'd,
-        // so no GC sweep ever reached stopAccountSandboxes().
-        await client.del("/v1/billing/account/delete-immediately", {
-          body: { account_id: accountId },
-        });
+      for (const id of await ownedAccountIds(client, u.id)) accountIds.add(id);
+
+      if (db) {
+        summary.sessionsStopped += await stopLiveSessions(client, db, [...accountIds], summary);
       }
+
+      // ONE call. The route resolves the caller's earliest-joined account
+      // (shared/resolve-account.ts) and ignores a body `account_id`, but
+      // `deleteAccountImmediately` now sweeps the sandboxes of EVERY account
+      // the caller owns, so a per-account loop would just repeat the same work.
+      await client.del("/v1/billing/account/delete-immediately");
     } catch (err) {
-      log.warn(
-        `  account delete skipped for ${u.email}: ${String((err as Error).message).slice(0, 120)}`,
-      );
+      summary.errors++;
+      log.warn(`  account delete skipped for ${u.email}: ${errText(err)}`);
     }
   }
+
   await adminDeleteUser(env, u.id);
+}
+
+function errText(err: unknown): string {
+  return String((err as Error)?.message ?? err).slice(0, 120);
+}
+
+/** Stop every live session in these accounts through the real stop route. */
+async function stopLiveSessions(
+  client: Client,
+  db: GcDb,
+  accountIds: string[],
+  summary: GcSummary,
+): Promise<number> {
+  let stopped = 0;
+  let sessions: Array<{ sessionId: string; projectId: string }>;
+  try {
+    sessions = await listLiveSessions(db, accountIds);
+  } catch (err) {
+    summary.errors++;
+    log.warn(`  live-session lookup failed: ${errText(err)}`);
+    return 0;
+  }
+
+  await mapWithConcurrency(sessions, 4, async (s) => {
+    try {
+      const res = await client.post(
+        "/v1/projects/:projectId/sessions/:sessionId/stop",
+        {},
+        { params: { projectId: s.projectId, sessionId: s.sessionId } },
+      );
+      if (isSessionReclaimed(res.statusCode)) {
+        stopped++;
+      } else {
+        summary.errors++;
+        log.warn(`  stop ${s.sessionId} returned ${res.statusCode}`);
+      }
+    } catch (err) {
+      summary.errors++;
+      log.warn(`  stop ${s.sessionId} failed: ${errText(err)}`);
+    }
+  });
+
+  return stopped;
 }
 
 async function ownedAccountIds(client: Client, userId: string): Promise<string[]> {

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -274,6 +274,9 @@ describe("managed Git fixture selection", () => {
     // The sweep now takes the domain list too, so it can also see the browser
     // suite's accounts — see gc-sweep.test.ts.
     expect(gc).toContain("if (env.databaseUrl) return listTestUsersViaDb(env, domains)");
-    expect(gc).toContain("ssl: local ? false : { rejectUnauthorized: false }");
+    // The permissive-chain policy moved into `gcDbSsl`, which gc-sweep.test.ts
+    // now pins by behaviour instead of by source text. Assert the connection
+    // helper still routes through it.
+    expect(gc).toContain("ssl: gcDbSsl(conn)");
   });
 });

--- a/tests/unit/gc-sweep.test.ts
+++ b/tests/unit/gc-sweep.test.ts
@@ -2,10 +2,29 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { Env } from '../src/core/env';
 import {
   BROWSER_TEST_EMAIL_DOMAINS,
+  type GcDb,
+  gcDbSsl,
+  isSessionReclaimed,
+  listLiveSessions,
+  ownedAccountIdsViaDb,
   resolveGcEmailDomains,
+  revokeAccountTokens,
   runIdEmailPrefix,
   selectReclaimable,
 } from '../src/fixtures/gc';
+
+/** Records every statement so a test can assert what the sweep actually ran. */
+function fakeDb(rows: any[] = []): GcDb & { calls: Array<{ text: string; values?: unknown[] }> } {
+  const calls: Array<{ text: string; values?: unknown[] }> = [];
+  return {
+    calls,
+    async query(text: string, values?: unknown[]) {
+      calls.push({ text, values });
+      return { rows };
+    },
+    async end() {},
+  };
+}
 
 const env = { testEmailDomain: 'ke2e.kortix.test' } as Env;
 
@@ -75,5 +94,98 @@ describe('gc selection', () => {
         { runId: '4242' },
       ),
     ).toHaveLength(1);
+  });
+});
+
+describe('gc database connection', () => {
+  it('uses no TLS locally and a permissive chain against Supabase', () => {
+    // Supabase's direct Postgres endpoint presents a chain Node's default trust
+    // store rejects; that rejection killed both sweeps on run 32222342409.
+    expect(gcDbSsl('postgres://u:p@127.0.0.1:54322/postgres')).toBe(false);
+    expect(gcDbSsl('postgres://u:p@localhost:54322/postgres')).toBe(false);
+    expect(gcDbSsl('postgres://u:p@db.abc.supabase.co:5432/postgres')).toEqual({
+      rejectUnauthorized: false,
+    });
+  });
+});
+
+describe('gc token revocation', () => {
+  it('sets BOTH status and revoked_at', async () => {
+    // The sweep used to stamp revoked_at alone while validateAccountToken gated
+    // on status alone, so 186 "Connector Session" tokens kept authenticating
+    // after a "successful" revoke.
+    const db = fakeDb([{ token_id: 't1' }, { token_id: 't2' }]);
+
+    const revoked = await revokeAccountTokens(db, ['acct-1', 'acct-2']);
+
+    expect(revoked).toBe(2);
+    const sql = db.calls[0]!.text;
+    expect(sql).toContain("status = 'revoked'");
+    expect(sql).toContain('revoked_at = now()');
+    expect(db.calls[0]!.values).toEqual([['acct-1', 'acct-2']]);
+  });
+
+  it('also heals a row already left status=active with revoked_at set', async () => {
+    const db = fakeDb([]);
+    await revokeAccountTokens(db, ['acct-1']);
+    expect(db.calls[0]!.text).toContain("revoked_at IS NULL OR status = 'active'");
+  });
+
+  it('runs no statement when the user owns nothing', async () => {
+    const db = fakeDb([]);
+    expect(await revokeAccountTokens(db, [])).toBe(0);
+    expect(db.calls).toHaveLength(0);
+  });
+});
+
+describe('gc live-session lookup', () => {
+  it('selects a live session AND a settled session whose box is still alive', async () => {
+    // Run 32231251280 left 47 sessions whose project_sessions row was already
+    // settled but whose session_sandboxes row still carried an external_id.
+    const db = fakeDb([{ session_id: 's1', project_id: 'p1' }]);
+
+    const sessions = await listLiveSessions(db, ['acct-1']);
+
+    expect(sessions).toEqual([{ sessionId: 's1', projectId: 'p1' }]);
+    const sql = db.calls[0]!.text;
+    expect(sql).toContain("s.status IN ('queued', 'branching', 'provisioning', 'running')");
+    expect(sql).toContain("sb.external_id IS NOT NULL");
+    expect(sql).toContain("sb.status IN ('provisioning', 'active', 'error')");
+  });
+
+  it('runs no statement when the user owns nothing', async () => {
+    const db = fakeDb([]);
+    expect(await listLiveSessions(db, [])).toEqual([]);
+    expect(db.calls).toHaveLength(0);
+  });
+});
+
+describe('gc owned accounts', () => {
+  it('reads owner memberships straight from the database', async () => {
+    // The API path needs a password grant the Playwright lane's users do not
+    // have; this one works wherever KE2E_DATABASE_URL is set.
+    const db = fakeDb([{ account_id: 'acct-1' }, { account_id: 'acct-2' }]);
+
+    expect(await ownedAccountIdsViaDb(db, 'user-1')).toEqual(['acct-1', 'acct-2']);
+    expect(db.calls[0]!.text).toContain("account_role = 'owner'");
+    expect(db.calls[0]!.values).toEqual(['user-1']);
+  });
+});
+
+describe('gc stop-response classification', () => {
+  it('counts already-stopped and already-gone as reclaimed', () => {
+    expect(isSessionReclaimed(200)).toBe(true);
+    expect(isSessionReclaimed(204)).toBe(true);
+    // 409 "not running" and 404 "gone" ARE the desired end state — counting them
+    // as failures would make a clean sweep look broken.
+    expect(isSessionReclaimed(409)).toBe(true);
+    expect(isSessionReclaimed(404)).toBe(true);
+  });
+
+  it('counts a refusal or a server error as not reclaimed', () => {
+    expect(isSessionReclaimed(401)).toBe(false);
+    expect(isSessionReclaimed(403)).toBe(false);
+    expect(isSessionReclaimed(500)).toBe(false);
+    expect(isSessionReclaimed(502)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Test debris survives a release-gate run and poisons the next one.

After run 32231251280's API shards were killed at their 40-minute cap, 47 `e2e-%` sessions stayed `running` with live Daytona sandboxes whose agents kept hitting the staging gateway with dead credentials, so the gateway reported `degraded` and the next run's preflight refused. Earlier, 73 zombie sessions and 186 un-revoked "Connector Session" PATs from one test account DoS'd staging for hours. The post-run sweep ran successfully and left all of it.

Three independent defects. Each one alone is sufficient to leak a live sandbox.

## 1. A revoked token kept authenticating (security)

`apps/api/src/repositories/account-tokens.ts:390-395` gated on `status = 'active'` and never read `revoked_at`:

```ts
.where(
  and(
    inArray(accountTokens.secretKeyHash, secretKeyHashes),
    eq(accountTokens.status, 'active'),
  ),
)
```

Nothing in the database ties the two columns together — `account_tokens` has no CHECK, no trigger and no partial index. A row with `revoked_at` stamped and `status` still `active` authenticated cleanly on every surface: REST, LLM gateway, git proxy, preview proxy, connectors. It also emitted a normal `auth.login.success` audit event, so forensics showed a healthy login rather than a revoked-credential use.

This is the defect that made the other two unrecoverable. The gate sweep revokes its test PATs with `UPDATE account_tokens SET revoked_at = now()` — exactly the write the gate did not honour — so 186 tokens stayed live and their agents stayed alive.

Every other reader of this table already checked both columns. `apps/api/src/projects/lib/session-token-grant.ts:45` states the intent outright: *"a revoked token must stay dead"*.

**Fix:** `isNull(accountTokens.revokedAt)` added to the lookup. The same predicate is added to the `last_used_at` write, so a token revoked between the read and that write cannot refresh its own idle clock and defeat the idle-revoke sweep.

## 2. Account deletion stopped some sandboxes and removed none

`stopAccountSandboxes` read only `status = 'active'` rows for a single account and called `stop()`.

- **One account.** The route resolves the caller through `resolveAccountId` (`apps/api/src/shared/resolve-account.ts:157-165`), which returns the earliest-joined membership. Sandboxes in a team account the user owned survived the deletion, still running and still billing, with no account left to attribute them to.
- **`active` only.** A box that died mid-provision (`provisioning`) or whose last control-plane call errored (`error`) still exists at the provider and still bills. 47 of them survived that way.
- **`stop()` only.** A stopped box still exists, still holds its disk, still counts against the org quota, and can be woken again by anything holding its connector token.

**Fix:**

- Sweep every account the user **owns** — `account_role = 'owner'`, deliberately not bare membership, so deleting your own account never tears down a team you merely belong to. Owner is the same authority the route already requires for `ACCOUNT_DELETE`.
- Sweep every non-terminal sandbox status: `provisioning`, `active`, `error`.
- `stop()` **then** `remove()`, then `reconcileSandboxRemovedByExternalId` — which settles billing, flips `session_sandboxes` and `project_sessions` to `stopped` in one transaction, and revokes the session's connector token so no surviving agent process can authenticate.
- Settle any remaining non-terminal `project_sessions` rows: sessions with no sandbox row, or whose row had no `external_id`, used to stay `running` forever. Those are the rows the manual playbook fixed by hand.
- Bounded at 8. `tryGetProvider`, so a provider whose key is unset on this deployment settles the row instead of throwing and skipping the box. `remove()` runs even when `stop()` failed — a box we could not park is exactly the box that must not survive. Every failure is isolated per box; one never aborts the rest or blocks the deletion.

## 3. gc reclaimed nothing but Supabase users

`tests/src/fixtures/gc.ts` deleted the Supabase user and called the account-deletion route, and that was all.

**Fix** — a belt-and-braces path that does not depend on the API being healthy:

1. **Revoke every token in every owned account** by direct `UPDATE`, setting **both** `status` and `revoked_at`. This runs **first**: it is the only step needing neither a password grant nor a healthy API, and it is what actually stops a surviving agent authenticating. It also heals any row an earlier sweep left inconsistent.
2. **Stop each live session** through the real `POST /v1/projects/:projectId/sessions/:sessionId/stop` route, so the provider is told to release the box rather than waiting for account deletion to reach it. The lookup catches both a live `project_sessions` row and a settled one whose `session_sandboxes` row still carries an `external_id`.
3. **One account delete.** The route ignores a body `account_id`, but `deleteAccountImmediately` now sweeps every account the caller owns, so the old per-account loop repeated the same work.
4. **Delete the Supabase user** — the reclaim that must always happen.

Owner accounts and live sessions are read from the database, so the Playwright lane — whose users have per-spec passwords and legitimately cannot password-grant — is covered too. `--older-than` and `--run-id` are unchanged. The sweep logs `sessions stopped`, `tokens revoked`, `reclaim errors`.

`installCancellationReclaim` in `tests/bin/ke2e.ts` calls `runGc`, so SIGTERM reclaim inherits all of this unchanged. Its 20 s budget is why token revocation is ordered first: the highest-value action completes earliest.

## Verification

| Gate | Result |
| --- | --- |
| `apps/api` — `bash scripts/test.sh` | **7550 pass, 0 fail, 74 skip** (656 files, 28.3 s) |
| `pnpm --filter kortix-api typecheck` | **exit 0** |
| `pnpm --dir tests test:unit` | **272 pass** (33 files) |
| `pnpm --dir tests typecheck` | fails only on pre-existing `src/flows/iam.flow.ts:1739` TS2322 (present at branch point, another owner) |

**The revoked-token fix is proven end-to-end against real Postgres and the real Hono app.** `src/__tests__/integration-revoked-token-auth.test.ts` mints a token, stamps **only** `revoked_at`, and asserts the row is still `status = 'active'` — then:

```
--> GET /v1/accounts 200 41ms      # live token
--> GET /v1/accounts 401 22ms      # after revoked_at alone is stamped
    [ERROR] 401 "PAT not found or revoked"
5 pass, 0 fail
```

**Positive control:** deleting the one-line fix turns 3 of those 5 tests red, including the HTTP one — so the test genuinely catches the bug rather than passing by construction.

Revoking through `revokeAccountToken` (which sets both columns) would pass even with the bug present, which is why the test writes `revoked_at` alone.

The unit-lane test `src/repositories/account-tokens-revoked.test.ts` pins the query shape and carries its own positive control proving its column walk discriminates.

`account-deletion.test.ts` goes from 6 to 19 tests: two accounts × four boxes all stopped, removed and reconciled; a stop failure still removes; a remove failure still settles; a failed reconcile falls back; a missing provider client still settles the row; sessions settled across both accounts. The account ids and statuses are asserted to actually reach the WHERE clause, not just to have been passed in.

## Not fixed here, flagged deliberately

1. **No database constraint ties `status` to `revoked_at`.** The fix closes the read side; nothing stops a future writer recreating the inconsistent state. Every other `revokedAt`-bearing table in this repo is revoked by stamping the timestamp alone, so copying that idiom onto `account_tokens` is a live footgun. A CHECK or partial index is the durable fix and wants its own migration.
2. **`sandbox-proxy/subdomain.ts:59` caches "already authenticated" per subdomain for 4 hours** with no revoke hook. Even a correctly revoked PAT keeps driving preview-subdomain traffic from the same IP and user-agent until that entry expires. Outside the files I own.
3. **`iam/actor.ts:163` memoizes the token binding for 15 s** with no liveness predicate, delegating revocation upstream. Correct now that upstream works, but there is no second line of defence.
4. **`deleteSession` fires `provider.remove()` as `void`** (`session-lifecycle/actions.ts:109`), so a session delete returns before the provider confirms removal. If the process is killed immediately after — the 40-minute-cap scenario — the remove may never land. The gc sweep and account deletion now both cover this, but the fire-and-forget is the original leak vector.

## Workflow diff needed

**None.** `.github/workflows/tests-release.yml` already runs `bun tests/bin/ke2e.ts gc --run-id <id>` under `if: always()`, and no flags changed. The existing step picks all of this up unmodified.
