### PR TITLE
ci(release-gate): E2E_EXCLUDE_TAGS='@quarantine' on the browser shards (companion to #6584)

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -239,6 +239,12 @@ jobs:
       # 3 shards x 2 = 6 concurrent browsers, against 2 before sharding.
       # One browser per shard (3 total) — see the fleet arithmetic on the api job.
       E2E_BROWSER_WORKERS: '1'
+      # Specs tagged @quarantine (today: 17-oauth-provider-initiation, which
+      # asserts on accounts.google.com / github.com) run in the non-blocking
+      # nightly lane (tests-browser-nightly.yml), never in the release gate.
+      # Playwright applies this at collection, so an excluded spec is absent,
+      # not "skipped" — the strict-skip reporter stays strict. See #6584.
+      E2E_EXCLUDE_TAGS: '@quarantine'
     steps:
       - uses: actions/checkout@v7
       # One SHA, two sources. A release PR carries RELEASE_SOURCE_SHA in the


### PR DESCRIPTION
One env line on the `browser` job: `E2E_EXCLUDE_TAGS: '@quarantine'`. Depends on #6584 (which adds the tag filter to playwright.config and the nightly lane); harmless if merged first (env is ignored until the config reads it). actionlint ok.