### PR TITLE
Give CONCURRENTLY migrations a lock_timeout that can actually land on live prod

### DIFF
--- a/packages/db/MIGRATIONS.md
+++ b/packages/db/MIGRATIONS.md
@@ -128,6 +128,7 @@ Target a specific DB (secrets never go through the shell): the adapter reads `DA
 - One logical change per migration.
 - Generated/hand-written SQL is reviewed by a human before it touches a database.
 - Every migration needs `lock_timeout`/`statement_timeout` set (squawk: `require-timeout-settings`) — **both** `migrate:create` and `migrate:generate` pre-fill this. (`migrate:generate` did not until 2026-08-05; it renamed drizzle-kit's output through unchanged, so generated migrations were born failing the rule.)
+- A `.concurrent.ts` migration takes the **opposite** `lock_timeout` to a `.sql` one: `'180s'`, never 2–5 s. `CREATE INDEX CONCURRENTLY` waits on every older transaction and `lock_timeout` governs that wait, so a short budget fails on live prod regardless of table size. Enforced — below 120 s fails lint. See [Roll-forward safety](#lock_timeout-in-a-concurrentts-file-is-the-opposite-of-the-house-value).
 - Any migration that **drops or alters** a constraint, unique index, column, or enum value needs a `-- mixed-version-safe: <justification>` (or `-- enum-value-checked: <justification>` for `ADD VALUE`) comment, or CI fails it — see [Zero-downtime rules](#zero-downtime-rules-checklist). Same rule for `.concurrent.ts` (e.g. a `DROP INDEX CONCURRENTLY`) — use a `//` comment there instead of `--`.
 
 ---
@@ -198,6 +199,19 @@ merge-conflict markers, duplicate timestamps — which they already pass).
 **Any filename not in that list — i.e. every migration written from now
 on — gets full enforcement.** The list only ever stays fixed; nothing is
 ever added to it.
+
+Each later guard gets its **own** baseline with its own cutoff, rather than
+reopening the 2026-07-16 list:
+
+| Baseline | Guard | Cutoff |
+| --- | --- | --- |
+| `grandfathered-migrations.json` | mixed-version + enum-value annotations, squawk | 2026-07-16 |
+| `backfill-grandfathered-migrations.json` | top-level DML in a single-transaction `.sql` migration | 2026-08-10 (`centralized_audit_v2` outage) |
+| `concurrent-lock-timeout-grandfathered-migrations.json` | the 120 s `lock_timeout` floor for CONCURRENTLY migrations | 2026-08-19 (deploy-prod run `32248002434`) |
+
+The cutoffs are independent: a file exempt from one guard is still held to the
+others. Same contract for all three — the lists are fixed, and nothing is ever
+added to them.
 
 See `packages/db/SQUAWK_BASELINE.md` for the one-time squawk retro-lint
 report over the pre-existing corpus (178 findings, none fixed, none blocking
@@ -276,6 +290,62 @@ immediately after it in the same `pnpm migrate` invocation applies correctly
 in the reopened transaction. `scripts/lint-migrations.ts` flags any
 `.concurrent.ts` file with a multi-statement `pgm.sql()` call.
 
+### `lock_timeout` in a `.concurrent.ts` file is the OPPOSITE of the house value
+
+**Use `set lock_timeout = '180s'` in a CONCURRENTLY migration — never the 2–5 s
+a plain `.sql` migration uses.** This is lint-enforced: a new `.concurrent.ts`
+file that runs a CONCURRENTLY operation and sets `lock_timeout` below **120 s**
+fails `pnpm --filter @kortix/db lint`.
+
+The reason the house value is short does not apply here, and following it breaks
+the migration outright. `CREATE INDEX CONCURRENTLY` does not merely take a brief
+lock at the end: to make its scans safe it must wait for **every transaction in
+the database that began before it**, taking a `ShareLock` on each one's virtual
+transaction id — once before it starts, and again before it finishes. And
+`lock_timeout` governs that wait.
+
+So on a live system the table's own size is irrelevant. Prod takes an
+`audit_events` write on nearly every request and runs multi-second session-turn
+transactions, so *some* transaction outlives a 5-second budget almost every
+time. The build is then cancelled with `55P03` and — because CIC is
+non-transactional — leaves an **INVALID index** behind, which makes a plain
+re-run fail with "already exists".
+
+Meanwhile the only lock a CIC actually *holds* is `ShareUpdateExclusive` on the
+target table, which excludes other DDL and `VACUUM` but never queries or writes.
+A long wait here blocks no user. That is the whole asymmetry: the short value
+protects against DDL that blocks traffic; a CIC is not that.
+
+`'0'` (wait indefinitely) is also accepted by the lint, as is omitting
+`lock_timeout` entirely — Postgres defaults it to `0`. Keep `statement_timeout`
+generous too (`'30min'` in the scaffold): an index build on a large table
+legitimately runs for minutes, and the `.sql` header's 30 s budget would kill it.
+
+**When it has already failed** (`55P03` during `Apply DB migrations to prod`):
+
+1. Find the leftover — `select indexrelname from pg_stat_user_indexes s join
+   pg_index i on i.indexrelid = s.indexrelid where not i.indisvalid;`
+2. `drop index concurrently if exists <it>;`
+3. Re-run the migration's exact statements in `psql` with
+   `set lock_timeout='180s'; set statement_timeout='30min';` and confirm
+   `indisvalid`.
+4. Record it: `insert into kortix_migrations.pgmigrations (name, run_on) values
+   ('<file basename without extension>', now());` — the ledger must match what is
+   live.
+5. `gh run rerun <deploy-prod run> --failed`; the migrate step now sees nothing
+   pending.
+
+Migration files are immutable once merged, so **do not edit the failing file** —
+fix the template and the house rule for the next one, which is what the 120 s
+floor is.
+
+*Incident: v0.13.0 deploy-prod run `32248002434` failed its migration job twice
+this way, first on `kortix.iam_roles` (6 rows, 80 kB), then on
+`kortix.account_tokens` (30 k rows). The 6-row table is what proved size was not
+the variable. Pre-floor `.concurrent.ts` files are exempt via
+`concurrent-lock-timeout-grandfathered-migrations.json` — they are immutable and
+already applied.*
+
 ---
 
 ## How migrations are applied, per environment
@@ -317,7 +387,7 @@ mode we've actually hit:
 
 | Job | Enforces | Failure mode it prevents |
 |---|---|---|
-| `lint` | Filename shape, no merge markers, no empty files/placeholders, no duplicate timestamps, **mixed-version guard, enum-value annotation** (new migrations only) | Malformed migrations; the `20260713220001000` class; the `sandbox_provider` enum-drift class |
+| `lint` | Filename shape, no merge markers, no empty files/placeholders, no duplicate timestamps, **mixed-version guard, enum-value annotation, backfill-DML guard, CONCURRENTLY `lock_timeout` floor** (new migrations only) | Malformed migrations; the `20260713220001000` class; the `sandbox_provider` enum-drift class; the `centralized_audit_v2` backfill outage; the `32248002434` `55P03` CIC class |
 | `squawk` | Deterministic Postgres locking/downtime rules (new migrations only) — see `.squawk.toml` | Non-concurrent index ops, unvalidated constraints, missing timeout headers, ACCESS EXCLUSIVE type changes, ... |
 | `immutability` | Already-merged migration files are never modified | Silent schema drift between environments that ran the file at different times |
 | `sequence` | New migrations sort after every already-merged migration | The historical `_journal`/`pgmigrations` ordering-dedupe incident |

--- a/packages/db/concurrent-lock-timeout-grandfathered-migrations.json
+++ b/packages/db/concurrent-lock-timeout-grandfathered-migrations.json
@@ -1,0 +1,42 @@
+{
+  "_comment": [
+    "Snapshot of migrations/*.concurrent.ts that set lock_timeout BELOW the 120s CONCURRENTLY floor introduced on 2026-08-19, after v0.13.0 deploy-prod run 32248002434 failed its migration job twice with 55P03 (canceling statement due to lock timeout).",
+    "Same contract as grandfathered-migrations.json: these files are immutable and already applied in every environment, so the floor cannot be retrofitted onto them. Only the CONCURRENTLY lock_timeout check exempts them.",
+    "CREATE INDEX CONCURRENTLY waits for every transaction that began before it, and lock_timeout governs that wait — so a 2-5s budget fails on a live system regardless of table size. New .concurrent.ts migrations must use 180s (what `pnpm migrate:create <slug> --concurrent` scaffolds).",
+    "Do not add to this list."
+  ],
+  "generatedAt": "2026-08-19T00:00:00Z",
+  "files": [
+    "20260718115307722_account_model_preferences_scope_global_index.concurrent.ts",
+    "20260718115309065_account_model_preferences_scope_project_index.concurrent.ts",
+    "20260718115310430_drop_account_model_preferences_scope_index.concurrent.ts",
+    "20260721202705000_add_audit_events_occurred_at_index.concurrent.ts",
+    "20260726000708000_project_sessions_one_available_warm.concurrent.ts",
+    "20260727010700000_exact_trigger_scheduler_due_index.concurrent.ts",
+    "20260727092101567_multi_connections_per_connector.concurrent.ts",
+    "20260727112630384_usage_events_account_origin_time_index.concurrent.ts",
+    "20260727113441902_project_sessions_origin_active_index.concurrent.ts",
+    "20260727113441903_project_sessions_account_active_index.concurrent.ts",
+    "20260728082438985_project_sessions_project_origin_index.concurrent.ts",
+    "20260728132613912_secret_delivery_indexes.concurrent.ts",
+    "20260730000452600_sandbox_deadline_index.concurrent.ts",
+    "20260731083554880_audit_account_project_time_index.concurrent.ts",
+    "20260731083554881_audit_account_session_time_index.concurrent.ts",
+    "20260731083554882_audit_request_index.concurrent.ts",
+    "20260731083554883_audit_correlation_index.concurrent.ts",
+    "20260805205751000_projects_account_idempotency_key_index.concurrent.ts",
+    "20260806140259565_connector_binding_connection_index.concurrent.ts",
+    "20260807202731277_admin_analytics_time_indexes.concurrent.ts",
+    "20260807202731278_admin_analytics_ledger_time_index.concurrent.ts",
+    "20260807221201000_audit_account_project_sequence_index.concurrent.ts",
+    "20260807221202000_audit_account_session_sequence_index.concurrent.ts",
+    "20260807221203000_audit_source_phase_index.concurrent.ts",
+    "20260807221204000_audit_action_pattern_index.concurrent.ts",
+    "20260807221205000_audit_account_source_phase_time_index.concurrent.ts",
+    "20260807221206000_audit_account_client_source_time_index.concurrent.ts",
+    "20260813203000000_drop_one_available_warm_index.concurrent.ts",
+    "20260818120000000_project_role_editor_to_manager.concurrent.ts",
+    "20260819015724600_rbac_canonical_indexes.concurrent.ts",
+    "20260819015726000_account_tokens_session_id_index.concurrent.ts"
+  ]
+}

--- a/packages/db/scripts/create-migration.ts
+++ b/packages/db/scripts/create-migration.ts
@@ -68,9 +68,23 @@ if (concurrent) {
 //   - Always use IF NOT EXISTS / IF EXISTS -- a CONCURRENTLY build can fail
 //     partway through and leave an INVALID index; the migration must be safe
 //     to re-run (check pg_index.indisvalid before retrying by hand if it does).
-//   - lock_timeout still matters for the brief catalog-level lock the build
-//     takes at the very end; statement_timeout should be generous (index
-//     builds on large tables can legitimately run long) or left unset.
+//   - lock_timeout MUST be generous here -- 180s below, never the 2-5s used by
+//     a plain .sql migration. CREATE INDEX CONCURRENTLY does not just take a
+//     brief lock at the end: before it can start, and again before it can
+//     finish, it waits for EVERY transaction in the database that began before
+//     it (it takes a ShareLock on each one's virtual transaction id), and
+//     \`lock_timeout\` governs that wait. On a live system -- audit_events
+//     writers on every request, multi-second session-turn transactions -- some
+//     transaction outlives a 5-second budget almost every time, so the build is
+//     cancelled with 55P03 and leaves an INVALID index behind, which then makes
+//     a plain re-run fail with "already exists". The 2-5s house value exists to
+//     stop DDL blocking prod; the one lock a CONCURRENTLY build holds
+//     (ShareUpdateExclusive on the table) only excludes other DDL and VACUUM,
+//     so a long wait here blocks no user and that rationale does not apply.
+//     This is lint-enforced: a new .concurrent.ts file that sets lock_timeout
+//     below 120s fails \`pnpm --filter @kortix/db lint\`.
+//   - statement_timeout should be generous (index builds on large tables can
+//     legitimately run long) -- 30min below.
 //   - This is lint-enforced: packages/db/scripts/lint-migrations.ts requires
 //     pgm.noTransaction() AND a CONCURRENTLY operation in every .concurrent.ts
 //     file, or CI fails.
@@ -90,7 +104,8 @@ export const up = (pgm) => {
   // silently defeats pgm.noTransaction() (CONCURRENTLY still fails with
   // "cannot run inside a transaction block") even though noTransaction() IS
   // working correctly at the node-pg-migrate level. One statement per call.
-  pgm.sql(\`set lock_timeout = '2s'\`);
+  pgm.sql(\`set lock_timeout = '180s'\`);
+  pgm.sql(\`set statement_timeout = '30min'\`);
   pgm.sql(\`
     create index concurrently if not exists idx_TODO_ON_TODO_TABLE
       on kortix.TODO_TABLE (TODO_COLUMN)

--- a/packages/db/scripts/generate-safety-header.test.ts
+++ b/packages/db/scripts/generate-safety-header.test.ts
@@ -17,6 +17,7 @@
  * that must not drift: the timeout statements themselves.
  */
 import { describe, expect, test } from 'bun:test';
+import { lintMigration, parseLockTimeoutMs } from './lint-migrations';
 
 const GENERATE = await Bun.file(new URL('./generate.ts', import.meta.url).pathname).text();
 const CREATE = await Bun.file(new URL('./create-migration.ts', import.meta.url).pathname).text();
@@ -30,6 +31,16 @@ function timeouts(src: string): Record<string, string> {
   return out;
 }
 
+// create-migration.ts holds TWO templates with different timeout budgets: the
+// .concurrent.ts escape hatch (a long lock_timeout, because CREATE INDEX
+// CONCURRENTLY waits on every older transaction) and the plain .sql header (the
+// short house value, because its DDL blocks queries). `-- SAFETY HEADER` marks
+// the start of the .sql one. Scanning the whole file would silently compare
+// whichever template happens to appear last.
+const SQL_MARKER = '-- SAFETY HEADER';
+const CREATE_SQL_TEMPLATE = CREATE.slice(CREATE.indexOf(SQL_MARKER));
+const CREATE_CONCURRENT_TEMPLATE = CREATE.slice(0, CREATE.indexOf(SQL_MARKER));
+
 describe('generate.ts safety header', () => {
   test('emits both timeout statements', () => {
     const t = timeouts(GENERATE);
@@ -40,7 +51,7 @@ describe('generate.ts safety header', () => {
   test('uses the SAME values as the hand-written template', () => {
     // Two headers that disagree would make "which command did you use?" a
     // silent input to how safe the migration is.
-    expect(timeouts(GENERATE)).toEqual(timeouts(CREATE));
+    expect(timeouts(GENERATE)).toEqual(timeouts(CREATE_SQL_TEMPLATE));
   });
 
   test('prepends the header to the generated file, not just prints it', () => {
@@ -60,5 +71,38 @@ describe('generate.ts safety header', () => {
   test('tells the author to review the generated SQL', () => {
     // drizzle knows the target shape, not how to reach it without downtime.
     expect(GENERATE).toContain('REVIEW THE GENERATED SQL');
+  });
+});
+
+describe('the .concurrent.ts template', () => {
+  test('scaffolds a lock_timeout at or above the lint floor', () => {
+    // The template and lint-migrations.ts must not drift apart: a scaffold that
+    // emits a value its own linter rejects would fail every new migration on
+    // the first `pnpm --filter @kortix/db lint`.
+    const value = timeouts(CREATE_CONCURRENT_TEMPLATE).lock_timeout;
+    expect(value).toBeDefined();
+    expect(parseLockTimeoutMs(value)).toBeGreaterThanOrEqual(120_000);
+  });
+
+  test('the scaffolded file passes its own lint', () => {
+    // The end-to-end contract: what `migrate:create --concurrent` writes must
+    // be lint-clean once the TODOs are filled in.
+    const scaffold = [
+      'export const up = (pgm) => {',
+      '  pgm.noTransaction();',
+      `  pgm.sql(\`set lock_timeout = '${timeouts(CREATE_CONCURRENT_TEMPLATE).lock_timeout}'\`);`,
+      '  pgm.sql(`create index concurrently if not exists idx_widgets_name on kortix.widgets (name)`);',
+      '};',
+    ].join('\n');
+    const { errors } = lintMigration('20260101000000000_add_widget_index.concurrent.ts', scaffold);
+    expect(errors).toEqual([]);
+  });
+
+  test('keeps a generous statement_timeout for long index builds', () => {
+    // A CIC on a large table legitimately runs for minutes; the .sql header's
+    // 30s budget would kill it.
+    const value = timeouts(CREATE_CONCURRENT_TEMPLATE).statement_timeout;
+    expect(value).toBeDefined();
+    expect(parseLockTimeoutMs(value)).toBeGreaterThanOrEqual(600_000);
   });
 });

--- a/packages/db/scripts/lint-migrations.test.ts
+++ b/packages/db/scripts/lint-migrations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { lintMigration, lintMigrationSet } from './lint-migrations';
+import { lintMigration, lintMigrationSet, parseLockTimeoutMs } from './lint-migrations';
 
 const GOOD_NAME = '20260101000000000_add_widget.sql';
 
@@ -279,7 +279,7 @@ describe('.concurrent.ts escape hatch', () => {
       [
         'export const up = (pgm) => {',
         '  pgm.noTransaction();',
-        "  pgm.sql(`set lock_timeout = '2s'; create index concurrently idx_x on kortix.widgets (name);`);",
+        "  pgm.sql(`set lock_timeout = '180s'; create index concurrently idx_x on kortix.widgets (name);`);",
         '};',
       ].join('\n'),
     );
@@ -292,7 +292,7 @@ describe('.concurrent.ts escape hatch', () => {
       [
         'export const up = (pgm) => {',
         '  pgm.noTransaction();',
-        "  pgm.sql(`set lock_timeout = '2s'`);",
+        "  pgm.sql(`set lock_timeout = '180s'`);",
         "  pgm.sql(`create index concurrently if not exists idx_widgets_name on kortix.widgets (name)`);",
         '};',
       ].join('\n'),
@@ -326,6 +326,20 @@ describe('.concurrent.ts escape hatch', () => {
     expect(errors.some((e) => e.includes('mixed-version'))).toBe(true);
   });
 
+  test('accepts a well-formed CONCURRENTLY migration at the scaffolded lock_timeout', () => {
+    const { errors } = lintMigration(
+      CONCURRENT_NAME,
+      [
+        'export const up = (pgm) => {',
+        '  pgm.noTransaction();',
+        "  pgm.sql(`set lock_timeout = '180s'`);",
+        "  pgm.sql(`create index concurrently if not exists idx_widgets_name on kortix.widgets (name)`);",
+        '};',
+      ].join('\n'),
+    );
+    expect(errors).toEqual([]);
+  });
+
   test('accepts a .concurrent.ts DROP INDEX CONCURRENTLY with a // mixed-version-safe annotation', () => {
     const { errors } = lintMigration(
       CONCURRENT_NAME,
@@ -338,5 +352,161 @@ describe('.concurrent.ts escape hatch', () => {
       ].join('\n'),
     );
     expect(errors.some((e) => e.includes('mixed-version'))).toBe(false);
+  });
+});
+
+/**
+ * The CONCURRENTLY lock_timeout floor.
+ *
+ * v0.13.0 deploy-prod run 32248002434 failed its migration job twice with 55P03
+ * on `.concurrent` migrations that set `lock_timeout = '5s'` — once on a 6-row,
+ * 80 kB table, which is what proved table size was not the variable. CIC waits
+ * on every transaction that began before it, and lock_timeout governs that wait.
+ */
+describe('CONCURRENTLY lock_timeout floor', () => {
+  const CONCURRENT_NAME = '20260101000000000_add_widget_index.concurrent.ts';
+
+  function concurrentFile(lockTimeout: string | null): string {
+    return [
+      'export const up = (pgm) => {',
+      '  pgm.noTransaction();',
+      ...(lockTimeout === null ? [] : [`  pgm.sql(\`set lock_timeout = '${lockTimeout}'\`);`]),
+      '  pgm.sql(`create index concurrently if not exists idx_widgets_name on kortix.widgets (name)`);',
+      '};',
+    ].join('\n');
+  }
+
+  function lockTimeoutErrors(source: string, options = {}) {
+    return lintMigration(CONCURRENT_NAME, source, options).errors.filter((e) =>
+      e.includes('lock_timeout'),
+    );
+  }
+
+  test("rejects the 5s value that failed prod", () => {
+    const errors = lockTimeoutErrors(concurrentFile('5s'));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("lock_timeout = '5s'");
+    expect(errors[0]).toContain('120s floor');
+    expect(errors[0]).toContain('55P03');
+  });
+
+  test('rejects the 2s house value the old template scaffolded', () => {
+    expect(lockTimeoutErrors(concurrentFile('2s'))).toHaveLength(1);
+  });
+
+  test('accepts the 180s value the template now scaffolds', () => {
+    expect(lockTimeoutErrors(concurrentFile('180s'))).toEqual([]);
+  });
+
+  test('accepts equivalent durations at or above the floor', () => {
+    for (const value of ['120s', '3min', '2min', '180000', '300000ms', '1h']) {
+      expect(lockTimeoutErrors(concurrentFile(value))).toEqual([]);
+    }
+  });
+
+  test('rejects sub-floor durations however they are spelled', () => {
+    for (const value of ['119s', '1min', '5000', '90000ms', '1000000us']) {
+      expect(lockTimeoutErrors(concurrentFile(value))).toHaveLength(1);
+    }
+  });
+
+  test("accepts '0', which disables the timeout and waits indefinitely", () => {
+    expect(lockTimeoutErrors(concurrentFile('0'))).toEqual([]);
+  });
+
+  test('accepts a file that sets no lock_timeout at all', () => {
+    // Postgres defaults lock_timeout to 0 (disabled), which is safe for a CIC.
+    // The rule is "if you set it, set it high enough", not "you must set it".
+    expect(lockTimeoutErrors(concurrentFile(null))).toEqual([]);
+  });
+
+  test('flags an unparseable value rather than passing it', () => {
+    const errors = lockTimeoutErrors(concurrentFile('soon'));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('unrecognized');
+  });
+
+  test('checks every lock_timeout in the file, not just the first', () => {
+    const source = [
+      'export const up = (pgm) => {',
+      '  pgm.noTransaction();',
+      "  pgm.sql(`set lock_timeout = '180s'`);",
+      '  pgm.sql(`create index concurrently if not exists idx_a on kortix.widgets (a)`);',
+      "  pgm.sql(`set lock_timeout = '5s'`);",
+      '  pgm.sql(`create index concurrently if not exists idx_b on kortix.widgets (b)`);',
+      '};',
+    ].join('\n');
+    expect(lockTimeoutErrors(source)).toHaveLength(1);
+  });
+
+  test('ignores a lock_timeout that appears only in a comment', () => {
+    const source = [
+      "// Do not copy `set lock_timeout = '2s'` from a .sql migration into this file.",
+      'export const up = (pgm) => {',
+      '  pgm.noTransaction();',
+      "  pgm.sql(`set lock_timeout = '180s'`);",
+      '  pgm.sql(`create index concurrently if not exists idx_widgets_name on kortix.widgets (name)`);',
+      '};',
+    ].join('\n');
+    expect(lockTimeoutErrors(source)).toEqual([]);
+  });
+
+  test('does NOT apply to a batched-DML pass, which needs the short value', () => {
+    // A batched data migration holds ROW locks, so a long lock_timeout there
+    // really would queue writers behind it. The floor is CONCURRENTLY-only.
+    const source = [
+      '// batched-dml: role_assignments, 1000 rows per batch, bounded by account count',
+      'export const up = (pgm) => {',
+      '  pgm.noTransaction();',
+      "  pgm.sql(`set lock_timeout = '5s'`);",
+      "  pgm.sql(`update kortix.widgets set kind = 'x' where kind is null`);",
+      '};',
+    ].join('\n');
+    expect(lockTimeoutErrors(source)).toEqual([]);
+  });
+
+  test('exempts a grandfathered pre-floor migration', () => {
+    expect(
+      lockTimeoutErrors(concurrentFile('2s'), { concurrentLockTimeoutGrandfathered: true }),
+    ).toEqual([]);
+  });
+
+  test('the floor is independent of the other grandfather baselines', () => {
+    // A file exempted from the mixed-version/backfill baselines is still held
+    // to the lock_timeout floor — the cutoffs are separate on purpose.
+    expect(
+      lockTimeoutErrors(concurrentFile('5s'), { grandfathered: true, backfillGrandfathered: true }),
+    ).toHaveLength(1);
+  });
+});
+
+describe('parseLockTimeoutMs', () => {
+  test('reads every Postgres duration unit', () => {
+    expect(parseLockTimeoutMs('180s')).toBe(180_000);
+    expect(parseLockTimeoutMs('3min')).toBe(180_000);
+    expect(parseLockTimeoutMs('2h')).toBe(7_200_000);
+    expect(parseLockTimeoutMs('1d')).toBe(86_400_000);
+    expect(parseLockTimeoutMs('500ms')).toBe(500);
+    expect(parseLockTimeoutMs('2000us')).toBe(2);
+  });
+
+  test('treats a bare number as milliseconds, like Postgres', () => {
+    expect(parseLockTimeoutMs('180000')).toBe(180_000);
+  });
+
+  test("treats '0' as no timeout at all", () => {
+    expect(parseLockTimeoutMs('0')).toBe(Number.POSITIVE_INFINITY);
+    expect(parseLockTimeoutMs('0s')).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  test('tolerates whitespace and case', () => {
+    expect(parseLockTimeoutMs('  180S  ')).toBe(180_000);
+  });
+
+  test('returns null for anything it cannot read', () => {
+    expect(parseLockTimeoutMs('soon')).toBeNull();
+    expect(parseLockTimeoutMs('')).toBeNull();
+    expect(parseLockTimeoutMs('3 weeks')).toBeNull();
+    expect(parseLockTimeoutMs('-5s')).toBeNull();
   });
 });

--- a/packages/db/scripts/lint-migrations.ts
+++ b/packages/db/scripts/lint-migrations.ts
@@ -5,6 +5,11 @@ import { join } from 'node:path';
 const DIR = join(import.meta.dir, '..', 'migrations');
 const GRANDFATHER_FILE = join(import.meta.dir, '..', 'grandfathered-migrations.json');
 const BACKFILL_GRANDFATHER_FILE = join(import.meta.dir, '..', 'backfill-grandfathered-migrations.json');
+const CONCURRENT_LOCK_TIMEOUT_GRANDFATHER_FILE = join(
+  import.meta.dir,
+  '..',
+  'concurrent-lock-timeout-grandfathered-migrations.json',
+);
 // Two valid migration file shapes:
 //  - <ts>_<slug>.sql            hand-written or drizzle-generated, runs inside
 //                                the batch transaction (see MIGRATIONS.md).
@@ -55,6 +60,57 @@ const ENUM_ANNOTATION_RE = /(?:--|\/\/)\s*enum-value-checked\s*:\s*\S/i;
 // no CONCURRENTLY statement, so it declares itself with
 // `// batched-dml: <what is batched, batch size, bound on row count>` instead.
 const BATCHED_DML_ANNOTATION_RE = /(?:--|\/\/)\s*batched-dml\s*:\s*\S/i;
+
+// CREATE INDEX CONCURRENTLY cannot land on a live database under the 2-5s
+// `lock_timeout` a plain .sql migration uses. CIC has to wait for EVERY
+// transaction that began before it (a ShareLock on each one's virtual
+// transaction id), both before it starts and before it finishes, and
+// `lock_timeout` governs that wait — table size is irrelevant. On prod, where
+// audit_events takes a write on nearly every request and session turns run for
+// seconds, some transaction outlives a 5s budget almost every time: the build
+// is cancelled with 55P03 and leaves an INVALID index that makes a plain re-run
+// fail with "already exists".
+//
+// The house 2-5s value exists to stop DDL blocking prod. It does not apply
+// here: the only lock a CIC holds (ShareUpdateExclusive on the table) excludes
+// other DDL and VACUUM, never queries or writes, so a long wait blocks no user.
+//
+// Incident: v0.13.0 deploy-prod run 32248002434 failed its migration job TWICE
+// on `.concurrent` migrations that set `lock_timeout = '5s'` — once on a
+// 6-row/80 kB table, which is what proved size was not the variable.
+const MIN_CONCURRENT_LOCK_TIMEOUT_MS = 120_000;
+const LOCK_TIMEOUT_RE = /\bset\s+lock_timeout\s*(?:=|\s+to\s+)\s*(?:'([^']*)'|([A-Za-z0-9]+))/gi;
+
+/**
+ * Postgres duration -> milliseconds. A bare number is milliseconds; `0` (in any
+ * unit) disables the timeout entirely, which is the SAFEST setting for a CIC.
+ * Returns null for anything unrecognized, which the caller reports rather than
+ * silently passing.
+ */
+export function parseLockTimeoutMs(raw: string): number | null {
+  const match = /^(\d+)\s*(us|ms|s|min|h|d)?$/.exec(raw.trim().toLowerCase());
+  if (!match) return null;
+  const value = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(value)) return null;
+  if (value === 0) return Number.POSITIVE_INFINITY;
+  switch (match[2]) {
+    case 'us':
+      return value / 1000;
+    case undefined:
+    case 'ms':
+      return value;
+    case 's':
+      return value * 1000;
+    case 'min':
+      return value * 60_000;
+    case 'h':
+      return value * 3_600_000;
+    case 'd':
+      return value * 86_400_000;
+    default:
+      return null;
+  }
+}
 
 export interface LintResult {
   errors: string[];
@@ -129,10 +185,50 @@ function checkMixedVersionAndEnum(
   return errors;
 }
 
+/**
+ * The CIC lock_timeout floor.
+ *
+ * Applies ONLY to files that actually run a CONCURRENTLY operation. A
+ * .concurrent.ts that exists for a batched DML pass (`// batched-dml:`) holds
+ * ROW locks, so a long lock_timeout there really would queue writers behind it
+ * — the short house value is correct for that file, and the CIC rationale is
+ * exactly inverted.
+ */
+function checkConcurrentLockTimeout(
+  filename: string,
+  scanText: string,
+  grandfathered: boolean,
+): string[] {
+  if (grandfathered) return [];
+  if (!/\bconcurrently\b/i.test(scanText)) return [];
+
+  const errors: string[] = [];
+  for (const match of scanText.matchAll(LOCK_TIMEOUT_RE)) {
+    const literal = (match[1] ?? match[2] ?? '').trim();
+    const ms = parseLockTimeoutMs(literal);
+
+    if (ms === null) {
+      errors.push(
+        `${filename}: sets lock_timeout to an unrecognized value ('${literal}'). Use a plain Postgres duration (e.g. '180s' or '3min') so the CONCURRENTLY floor can be checked.`,
+      );
+      continue;
+    }
+    if (ms < MIN_CONCURRENT_LOCK_TIMEOUT_MS) {
+      errors.push(
+        `${filename}: sets lock_timeout = '${literal}' in a CONCURRENTLY migration, below the ${MIN_CONCURRENT_LOCK_TIMEOUT_MS / 1000}s floor. ` +
+          'CREATE/DROP INDEX CONCURRENTLY must wait for every transaction that began before it, and lock_timeout governs that wait — on live prod some transaction outlives a short budget almost every time, whatever the table size, so the build is cancelled with 55P03 and leaves an INVALID index behind (v0.13.0 deploy-prod run 32248002434, which failed this way on a 6-row table). ' +
+          "The short house value guards DDL that blocks queries; a CONCURRENTLY build holds only ShareUpdateExclusive and blocks no user. Use `set lock_timeout = '180s'` (what `pnpm migrate:create <slug> --concurrent` now scaffolds), or '0' to wait indefinitely.",
+      );
+    }
+  }
+  return errors;
+}
+
 function lintConcurrentMigration(
   filename: string,
   raw: string,
   grandfathered: boolean,
+  lockTimeoutGrandfathered: boolean,
 ): LintResult {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -185,6 +281,9 @@ function lintConcurrentMigration(
   }
 
   errors.push(...checkMixedVersionAndEnum(filename, stripComments(raw), raw, grandfathered));
+  errors.push(
+    ...checkConcurrentLockTimeout(filename, stripComments(raw), lockTimeoutGrandfathered),
+  );
 
   return { errors, warnings };
 }
@@ -203,11 +302,24 @@ export interface LintOptions {
    * see backfill-grandfathered-migrations.json.
    */
   backfillGrandfathered?: boolean;
+  /**
+   * Same contract, separate cutoff: .concurrent.ts migrations that existed
+   * before the CONCURRENTLY lock_timeout floor landed (2026-08-19, v0.13.0
+   * deploy-prod run 32248002434) — see
+   * concurrent-lock-timeout-grandfathered-migrations.json. They are immutable
+   * and already applied; the floor governs every new one.
+   */
+  concurrentLockTimeoutGrandfathered?: boolean;
 }
 
 export function lintMigration(filename: string, raw: string, options: LintOptions = {}): LintResult {
   if (CONCURRENT_NAME_RE.test(filename)) {
-    return lintConcurrentMigration(filename, raw, options.grandfathered ?? false);
+    return lintConcurrentMigration(
+      filename,
+      raw,
+      options.grandfathered ?? false,
+      options.concurrentLockTimeoutGrandfathered ?? false,
+    );
   }
 
   const errors: string[] = [];
@@ -322,11 +434,23 @@ function loadBackfillGrandfatherSet(): Set<string> {
   }
 }
 
+function loadConcurrentLockTimeoutGrandfatherSet(): Set<string> {
+  try {
+    const data = JSON.parse(readFileSync(CONCURRENT_LOCK_TIMEOUT_GRANDFATHER_FILE, 'utf8')) as {
+      files: string[];
+    };
+    return new Set(data.files);
+  } catch {
+    return new Set();
+  }
+}
+
 function main(): void {
   const errors: string[] = [];
   const warnings: string[] = [];
   const grandfathered = loadGrandfatherSet();
   const backfillGrandfathered = loadBackfillGrandfatherSet();
+  const lockTimeoutGrandfathered = loadConcurrentLockTimeoutGrandfatherSet();
   const files = readdirSync(DIR)
     .filter((f) => f.endsWith('.sql') || f.endsWith('.concurrent.ts'))
     .sort();
@@ -336,6 +460,7 @@ function main(): void {
     const { errors: e, warnings: w } = lintMigration(f, readFileSync(join(DIR, f), 'utf8'), {
       grandfathered: grandfathered.has(f),
       backfillGrandfathered: backfillGrandfathered.has(f),
+      concurrentLockTimeoutGrandfathered: lockTimeoutGrandfathered.has(f),
     });
     errors.push(...e);
     warnings.push(...w);


### PR DESCRIPTION
## Problem

v0.13.0's deploy-prod (run [`32248002434`](https://github.com/kortix-ai/suna/actions/runs/32248002434)) failed its migration job **twice**, both times with `55P03 canceling statement due to lock timeout`, on `.concurrent` migrations that did `set lock_timeout = '5s'` then `create index concurrently …`:

- `20260819015724600_rbac_canonical_indexes.concurrent` — `kortix.iam_roles`, **6 rows, 80 kB**
- `20260819015726000_account_tokens_session_id_index.concurrent` — `kortix.account_tokens`, 30 k rows

The 6-row table is the interesting one: **table size is not the variable.**

`CREATE INDEX CONCURRENTLY` must wait for *every transaction in the database that began before it* — it takes a `ShareLock` on each one's virtual transaction id, once before it starts and again before it finishes — and **`lock_timeout` governs that wait**. On live prod, where `audit_events` takes a write on nearly every request and session turns run for seconds, some transaction outlives a 5 s budget almost every time. The build is then cancelled and, because CIC is non-transactional, leaves an **INVALID index** behind, which makes a plain re-run fail with "already exists".

The 2–5 s house value exists to stop DDL blocking traffic. It does not apply here: the only lock a CIC *holds* is `ShareUpdateExclusive` on the table, which excludes other DDL and `VACUUM` but never queries or writes. **A long wait here blocks no user.**

The old template actively taught the wrong thing, which is why the wrong value looked deliberate in review:

```
//   - lock_timeout still matters for the brief catalog-level lock the build
//     takes at the very end; …
```

## Changes

### 1. The template — `packages/db/scripts/create-migration.ts`

`pnpm migrate:create <slug> --concurrent` now scaffolds `set lock_timeout = '180s'` and `set statement_timeout = '30min'` (was `'2s'`, no statement_timeout). `30min` is included because a CIC on a large table legitimately runs for minutes and is the adjacent failure mode. The misleading comment is replaced with the actual mechanism and the reason the house value is inverted here.

### 2. The lint rule — `packages/db/scripts/lint-migrations.ts`

Fails any **new** `.concurrent.ts` migration that runs a CONCURRENTLY operation and sets `lock_timeout` below **120 s**.

- Parses every Postgres duration unit (`us`/`ms`/`s`/`min`/`h`/`d`) and a bare number as ms, via an exported `parseLockTimeoutMs`.
- Accepts `'0'` (waits indefinitely — the safest CIC setting) and accepts a file that sets no `lock_timeout` at all, since Postgres defaults it to `0`. The rule is "if you set it, set it high enough", not "you must set it".
- Reports an unparseable value rather than silently passing it.
- Checks **every** `lock_timeout` in the file, and ignores one that appears only in a comment.
- **Scoped to CONCURRENTLY files on purpose.** A `.concurrent.ts` that exists for a `// batched-dml:` pass holds ROW locks, so a long `lock_timeout` there really would queue writers behind it — the short house value is correct for that file and the rationale is exactly inverted. Of the 32 existing `.concurrent.ts` files, the one the rule does *not* flag is exactly the batched-DML pass, which is a good check on the scoping.

The 31 pre-floor files are exempt via a dedicated baseline, `concurrent-lock-timeout-grandfathered-migrations.json`, following the existing per-guard-cutoff pattern (`grandfathered-migrations.json`, `backfill-grandfathered-migrations.json`). The cutoffs are independent — a file exempt from one guard is still held to the others, and there's a test for that.

**No existing migration file is modified.** `git status packages/db/migrations/` is empty.

### 3. Docs — `packages/db/MIGRATIONS.md`

New subsection under Roll-forward safety explaining the mechanism and the asymmetry with `.sql` migrations, plus the **recovery drill** for a CIC that has already failed (find the INVALID index in `pg_stat_user_indexes`, `drop index concurrently`, re-run the statements by hand with a 180 s budget, insert the `kortix_migrations.pgmigrations` ledger row, `gh run rerun --failed`). Also updates the house-rules bullet list, the enforcement-scope section with a table of the three baselines, and the CI-gates table.

## Workflow diff needed: **none**

The rule lives inside `scripts/lint-migrations.ts`, which the existing required check already invokes:

```yaml
# .github/workflows/db-migrations.yml:49-50
- name: Lint migration files
  run: cd packages/db && bun scripts/lint-migrations.ts
```

So it gates PRs through the existing **"Migration files are well-formed"** job. No `.github/workflows/**` file is touched.

## Verification

**End-to-end, against the real scripts** — scaffolded a migration, filled the TODOs, linted, then broke it:

```
$ bun scripts/create-migration.ts proof_of_floor --concurrent
Created: packages/db/migrations/20260819151811109_proof_of_floor.concurrent.ts
  56:  pgm.sql(`set lock_timeout = '180s'`);
  57:  pgm.sql(`set statement_timeout = '30min'`);

$ bun scripts/lint-migrations.ts            # as scaffolded
✓ 183 migration file(s) pass lint (12 warning(s)).

# edit lock_timeout to the '5s' that failed prod:
$ bun scripts/lint-migrations.ts
::error::20260819151811109_proof_of_floor.concurrent.ts: sets lock_timeout = '5s'
in a CONCURRENTLY migration, below the 120s floor. … cancelled with 55P03 and
leaves an INVALID index behind (v0.13.0 deploy-prod run 32248002434, which failed
this way on a 6-row table). …
✗ 1 migration lint error(s) — fix before merging.
lint exit code: 1
```

The temporary file was then deleted; `packages/db/migrations/` is unmodified.

**Suites:**

- `bun test scripts/lint-migrations.test.ts` — **59 pass / 0 fail**. New block covers: 5 s rejected, 2 s rejected, 180 s accepted, equivalent durations at/above the floor (`120s`, `3min`, `180000`, `300000ms`, `1h`), sub-floor spellings rejected (`119s`, `1min`, `5000`, `90000ms`, `1000000us`), `'0'` accepted, absent setting accepted, unparseable flagged, multiple settings all checked, comment-only mention ignored, batched-DML exempt, grandfathered exempt, and baseline independence. Plus 9 `parseLockTimeoutMs` unit cases.
- `bun test scripts/generate-safety-header.test.ts` — **8 pass / 0 fail**. The existing "same values as the hand-written template" assertion scanned the whole of `create-migration.ts` and only passed by accident once a second template gained timeouts (last match wins); it is now scoped to the `.sql` template explicitly. Three new tests pin the concurrent template at or above the lint floor, assert the scaffolded file passes its own lint, and require a generous `statement_timeout`.
- `pnpm --filter @kortix/db lint` — **182 migration files pass**, squawk **0 issues in 95 files**.
- `bun test` (packages/db) — **248 pass / 18 skip / 0 fail**.
- `bun run typecheck` — clean. Note `tsconfig.json` includes only `src/**/*`, so `scripts/` is *not* covered by that command; every changed script was typechecked explicitly under `--strict` (exit 0).
