### PR TITLE
fix(slack): a bot @-mention still did nothing — the identity gate refuses it, silently

### DIFF
--- a/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
+++ b/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
@@ -68,6 +68,7 @@ mock.module('../channels/slack-api', () => ({
   appendStream: async () => {},
   deleteMessage: async () => {},
   getChannelName: async () => 'general',
+  isBotUser: async () => true,
   joinChannel: async () => true,
   openDmChannel: async () => 'D1',
   postEphemeral: async () => true,
@@ -220,5 +221,53 @@ describe('a bot sender is never sent an identity prompt', () => {
     const h = cmds.slice(cmds.indexOf('async function slashLinkBot'));
     expect(h.slice(0, 1600), 'linking a bot must stay owner/admin gated — any app in the channel is a non-member')
       .toContain('canManageSlackPolicy');
+  });
+});
+
+// ── link-bot must never bind a HUMAN ────────────────────────────────────────
+//
+// Flagged on #6590 by review, and it was real. linkSlackIdentity UPSERTS, and
+// resolveSlackActor treats the row as the authoritative
+// (workspace, slack_user) -> kortix_user mapping, so binding a person's id would
+// silently make THEIR later Slack actions run as whoever linked them. Human and
+// bot ids are the same shape — /^[UWB][A-Z0-9]{6,}$/ matches U0B8ERR54BH (a
+// person) exactly as it matches a bot — so only Slack can tell them apart.
+
+describe('link-bot refuses anything that is not a verified bot', () => {
+  const cmds = readFileSync(join(import.meta.dir, '..', 'channels', 'slack', 'commands.ts'), 'utf8');
+  const handler = cmds.slice(cmds.indexOf('async function slashLinkBot'), cmds.indexOf('async function slashLinkBot') + 2600);
+
+  test('Slack is asked whether the target is a bot, BEFORE the link is written', () => {
+    const askedAt = handler.indexOf('isBotUser(');
+    const wroteAt = handler.indexOf('await linkSlackIdentity(');
+    expect(askedAt, 'no bot verification — a human id would be accepted').toBeGreaterThan(-1);
+    expect(wroteAt).toBeGreaterThan(-1);
+    expect(askedAt, 'the link must not be written before the check').toBeLessThan(wroteAt);
+  });
+
+  test('anything other than a definite yes refuses — null (unknown) included', () => {
+    // isBotUser returns null on missing scope / transport error / unknown user.
+    // `bot !== true` is load-bearing: `!bot` would also refuse, but a truthy
+    // check like `bot === false` alone would let null through and link a human.
+    expect(handler, 'uncertainty must refuse, not fall through').toContain('if (bot !== true) {');
+  });
+
+  test('an id already linked to someone else is never silently re-pointed', () => {
+    expect(handler, 'upsert would overwrite an existing human mapping')
+      .toContain("existing && existing.userId !== me.userId");
+  });
+
+  test('isBotUser itself fails closed', () => {
+    const api = readFileSync(join(import.meta.dir, '..', 'channels', 'slack-api.ts'), 'utf8');
+    const fn = api.slice(api.indexOf('export async function isBotUser'));
+    // Scope the assertion to the !r.ok BLOCK. A greedy match across the whole
+    // function passes even when this branch returns false, because two later
+    // `return null` lines exist — the negative control caught that.
+    const i = fn.indexOf('if (!r.ok) {');
+    expect(i, 'no failure branch at all').toBeGreaterThan(-1);
+    const branch = fn.slice(i, fn.indexOf('}', fn.indexOf('return', i)));
+    expect(branch, 'a failed users.info must be null (unknown) — false would read as "a human", and refuse every bot')
+      .toContain('return null;');
+    expect(branch, 'never answer false/true from a failed lookup').not.toMatch(/return (false|true);/);
   });
 });

--- a/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
+++ b/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
@@ -184,3 +184,41 @@ describe('source contracts', () => {
       .toEqual([]);
   });
 });
+
+// ── The gate AFTER isOwnBotEvent, which is why #6577 alone did not work ──────
+//
+// Opening the bot gate was necessary and not sufficient. The mention then hits
+// SLACK_REQUIRE_USER_IDENTITY (optBoolTrue — ON by default): resolveSlackActor
+// looks up chat_user_identities by the SENDER's Slack user id, a bot has no row,
+// so it answers `unlinked` and dispatch returns before the turn.
+//
+// Worse, it returned LOUDLY into a void: postIdentityPrompt posts an ephemeral
+// AND opens a DM, both addressed to slackUserId — the bot. Nobody sees either,
+// so the mention reads as "Kortix ignored it". Verified on dev f07c04f0 with a
+// real bot-to-bot mention (Slack ts 1787153374.887479).
+
+describe('a bot sender is never sent an identity prompt', () => {
+  const src = readFileSync(join(import.meta.dir, '..', 'channels', 'slack', 'dispatch.ts'), 'utf8');
+
+  test('postIdentityPrompt is guarded on the sender not being a bot', () => {
+    // BOTH sites: the bare-@mention branch and the main turn path. Checking only
+    // the first is how the second stayed unguarded — this test caught that.
+    const sites = [...src.matchAll(/await postIdentityPrompt\(/g)];
+    expect(sites.length, 'expected two identity-prompt sites').toBe(2);
+    for (const m of sites) {
+      const before = src.slice(Math.max(0, m.index! - 400), m.index!);
+      expect(before, 'an unlinked BOT gets an ephemeral + a DM it cannot read, and the mention looks ignored')
+        .toContain('if (!event.bot_id) {');
+    }
+  });
+
+  test('link-bot is routed and identity-flag gated', () => {
+    const cmds = readFileSync(join(import.meta.dir, '..', 'channels', 'slack', 'commands.ts'), 'utf8');
+    expect(cmds, 'the only way to make a bot resolvable is gone').toContain("case 'link-bot':");
+    expect(cmds, 'link-bot must write the same chat_user_identities row /login does')
+      .toContain('await linkSlackIdentity({ teamId: ctx.teamId, slackUserId: botUserId, userId: me.userId });');
+    const h = cmds.slice(cmds.indexOf('async function slashLinkBot'));
+    expect(h.slice(0, 1600), 'linking a bot must stay owner/admin gated — any app in the channel is a non-member')
+      .toContain('canManageSlackPolicy');
+  });
+});

--- a/apps/api/src/__tests__/unit-slack-classify-event.test.ts
+++ b/apps/api/src/__tests__/unit-slack-classify-event.test.ts
@@ -57,6 +57,7 @@ mock.module('../channels/slack-api', () => ({
   appendStream: async () => {},
   deleteMessage: async () => {},
   getChannelName: async () => 'general',
+  isBotUser: async () => true,
   joinChannel: async () => true,
   openDmChannel: async () => 'D1',
   postEphemeral: async () => true,

--- a/apps/api/src/__tests__/unit-slack-commands.test.ts
+++ b/apps/api/src/__tests__/unit-slack-commands.test.ts
@@ -81,6 +81,7 @@ mock.module('../llm-gateway/models/picker', () => ({
 let identityRow: { userId: string } | null = null;
 mock.module('../channels/slack/identity', () => ({
   lookupSlackIdentity: async () => identityRow,
+  linkSlackIdentity: async () => {},
   revokeSlackIdentity: async () => true,
   lookupSlackUserIdForKortixUser: async () => null,
 }));

--- a/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
+++ b/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
@@ -138,6 +138,7 @@ mock.module('../channels/slack-api', () => ({
   appendStream: async () => {},
   deleteMessage: async () => {},
   getChannelName: async () => 'general',
+  isBotUser: async () => true,
   joinChannel: async () => true,
   openDmChannel: async () => 'D1',
   postBlocks: async () => 'ts',

--- a/apps/api/src/__tests__/unit-slack-session-selection.test.ts
+++ b/apps/api/src/__tests__/unit-slack-session-selection.test.ts
@@ -141,6 +141,7 @@ mock.module('../channels/slack-api', () => ({
   appendStream: async () => {},
   deleteMessage: async () => {},
   getChannelName: async () => 'general',
+  isBotUser: async () => true,
   joinChannel: async () => true,
   openDmChannel: async () => 'D1',
   postBlocks: async () => 'ts',

--- a/apps/api/src/channels/slack-api.ts
+++ b/apps/api/src/channels/slack-api.ts
@@ -448,6 +448,31 @@ export async function publishHomeView(
   }
 }
 
+// Is this Slack principal an app/bot rather than a person?
+//
+// `link-bot` writes the (workspace, slack_user) -> kortix_user row that
+// resolveSlackActor treats as authoritative, so binding a HUMAN's id would make
+// that person's later Slack actions run as whoever linked them. Human and bot
+// ids are indistinguishable by shape (both U…/W…), so only Slack can answer.
+//
+// Returns null on ANY uncertainty — missing scope, transport error, unknown user
+// — and the caller refuses. Guessing "probably a bot" here is the impersonation.
+export async function isBotUser(token: string, userId: string): Promise<boolean | null> {
+  try {
+    const r = await slackApiCall(token, 'users.info', { user: userId });
+    if (!r.ok) {
+      console.warn('[slack-api] users.info failed', { error: r.error });
+      return null;
+    }
+    const u = r.user as { is_bot?: boolean; is_app_user?: boolean } | undefined;
+    if (!u) return null;
+    return Boolean(u.is_bot || u.is_app_user);
+  } catch (err) {
+    console.warn('[slack-api] users.info error', err);
+    return null;
+  }
+}
+
 export async function getChannelName(token: string, channel: string): Promise<string | null> {
   try {
     const r = await slackApiCall(token, 'conversations.info', { channel });

--- a/apps/api/src/channels/slack/__tests__/commands-identity-on.test.ts
+++ b/apps/api/src/channels/slack/__tests__/commands-identity-on.test.ts
@@ -13,6 +13,7 @@ mock.module('../../../config', () => ({
 mock.module('../../../shared/db', () => ({ db: {}, hasDatabase: () => true }));
 mock.module('../identity', () => ({
   lookupSlackIdentity: async () => null,
+  linkSlackIdentity: async () => {},
   revokeSlackIdentity: async () => true,
 }));
 mock.module('../../../accounts/core/app', () => ({

--- a/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
+++ b/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
@@ -65,6 +65,7 @@ mock.module('../participants', () => ({
 }));
 mock.module('../identity', () => ({
   lookupSlackIdentity: async () => null,
+  linkSlackIdentity: async () => {},
   revokeSlackIdentity: async () => true,
 }));
 mock.module('../../../accounts/core/app', () => ({ lookupEmailsByUserIds: async () => new Map() }));

--- a/apps/api/src/channels/slack/commands.ts
+++ b/apps/api/src/channels/slack/commands.ts
@@ -16,6 +16,8 @@ import { listPickerModels, labelForModelRef } from '../../llm-gateway/models/pic
 import { isModelServableForAccount, resolveEffectiveModel } from '../../llm-gateway/resolution/default-model';
 import { chooseEffectiveAgent, toOpencodeModelRef, toWireModel } from '../../llm-gateway/resolution/effective';
 import { buildSlackLoginUrl } from './login';
+import { isBotUser } from '../slack-api';
+import { loadSlackTokenForProject } from '../install-store';
 import { linkSlackIdentity, lookupSlackIdentity, revokeSlackIdentity } from './identity';
 import { conversationPolicyLabel, normalizeConversationPolicy } from './participants';
 import { lookupEmailsByUserIds } from '../../accounts/core/app';
@@ -706,6 +708,28 @@ async function slashLinkBot(ctx: SlashCtx, arg: string): Promise<SlashResponse> 
   }
   if (!(await canManageSlackPolicy(ctx, selection.projectId))) {
     return { response_type: 'ephemeral', text: 'Only a linked Kortix account owner or admin for this project can link a bot.' };
+  }
+  // A HUMAN's id must never be bound here. linkSlackIdentity upserts, and
+  // resolveSlackActor treats the row as authoritative, so linking a person would
+  // silently make THEIR later Slack actions run as whoever linked them — the
+  // exact impersonation SLACK_REQUIRE_USER_IDENTITY exists to prevent, through a
+  // different door. Human and bot ids are the same shape (U…/W…), so only Slack
+  // can tell them apart. Flagged on #6590 by review; it was a real hole.
+  const existing = await lookupSlackIdentity(ctx.teamId, botUserId);
+  if (existing && existing.userId !== me.userId) {
+    return { response_type: 'ephemeral', text: `<@${botUserId}> is already linked to a different Kortix account. Have them disconnect first.` };
+  }
+  const token = await loadSlackTokenForProject(selection.projectId);
+  const bot = token ? await isBotUser(token, botUserId) : null;
+  if (bot !== true) {
+    // null = we could not tell (missing scope, transport error, unknown user).
+    // Refuse either way: guessing is the impersonation.
+    return {
+      response_type: 'ephemeral',
+      text: bot === false
+        ? `<@${botUserId}> is a person, not a bot. \`link-bot\` only accepts an app — a person connects their own account with \`${ctx.command} login\`.`
+        : `Could not verify <@${botUserId}> with Slack. Nothing was linked; try again.`,
+    };
   }
   await linkSlackIdentity({ teamId: ctx.teamId, slackUserId: botUserId, userId: me.userId });
   return {

--- a/apps/api/src/channels/slack/commands.ts
+++ b/apps/api/src/channels/slack/commands.ts
@@ -16,7 +16,7 @@ import { listPickerModels, labelForModelRef } from '../../llm-gateway/models/pic
 import { isModelServableForAccount, resolveEffectiveModel } from '../../llm-gateway/resolution/default-model';
 import { chooseEffectiveAgent, toOpencodeModelRef, toWireModel } from '../../llm-gateway/resolution/effective';
 import { buildSlackLoginUrl } from './login';
-import { lookupSlackIdentity, revokeSlackIdentity } from './identity';
+import { linkSlackIdentity, lookupSlackIdentity, revokeSlackIdentity } from './identity';
 import { conversationPolicyLabel, normalizeConversationPolicy } from './participants';
 import { lookupEmailsByUserIds } from '../../accounts/core/app';
 import { filterAccessibleObjects, unscopedResourceIds } from '../../iam';
@@ -95,6 +95,8 @@ export async function handleSlashCommand(
     case 'policy':
     case 'conversation':
       return slashPolicy(ctx, arg);
+    case 'link-bot':
+      return config.SLACK_REQUIRE_USER_IDENTITY ? slashLinkBot(ctx, arg) : unknownSub(sub, ctx.command);
     case 'help':
       return slashHelp(ctx);
     default:
@@ -668,6 +670,47 @@ async function slashPolicy(ctx: SlashCtx, arg: string): Promise<SlashResponse> {
     text: ok
       ? `Slack session policy set to ${conversationPolicyLabel(next)} for this channel. Existing threads keep their original policy.`
       : 'That channel is no longer bound to a project.',
+  };
+}
+
+// ── Link a bot sender ────────────────────────────────────────────────────────
+// A bot has no Kortix account and can never run `/login`, so resolveSlackActor
+// answers `unlinked` for every message it sends and dispatch stops before the
+// turn. That is why an @-mention from another app looked like it did nothing at
+// all: the "connect your account" nudge is posted ephemerally AND DM'd to the
+// sender — a bot — where no human ever sees it.
+//
+// This binds a bot's Slack user id to the CALLER's Kortix account through the
+// same chat_user_identities row `/login` writes, so the existing authorization
+// applies unchanged: the linked user must still be a member of the project's
+// account and pass PROJECT_WRITE inside resolveSlackActor. Nothing is granted
+// here that the caller does not already have.
+//
+// Owner/admin gated, and deliberately NOT automatic: the identity gate exists to
+// stop a non-member acting, and any app that can post in the channel is a
+// non-member. Turning that off by default would reintroduce exactly the
+// impersonation SLACK_REQUIRE_USER_IDENTITY was added to prevent.
+async function slashLinkBot(ctx: SlashCtx, arg: string): Promise<SlashResponse> {
+  const selection = await currentChannelSelection(ctx);
+  if (!selection?.projectId) {
+    return { response_type: 'ephemeral', text: `No project bound to this channel. Run \`${ctx.command} switch\` first.` };
+  }
+  // Accept a raw id or a pasted <@U…> mention — Slack expands the latter as you type.
+  const botUserId = arg.trim().replace(/^<@|[|>].*$/g, '').toUpperCase();
+  if (!/^[UWB][A-Z0-9]{6,}$/.test(botUserId)) {
+    return { response_type: 'ephemeral', text: `Usage: \`${ctx.command} link-bot @TheBot\` — the bot whose @-mentions of Kortix should run.` };
+  }
+  const me = await lookupSlackIdentity(ctx.teamId, ctx.slackUserId);
+  if (!me) {
+    return { response_type: 'ephemeral', text: `Connect your own Kortix account first: \`${ctx.command} login\`.` };
+  }
+  if (!(await canManageSlackPolicy(ctx, selection.projectId))) {
+    return { response_type: 'ephemeral', text: 'Only a linked Kortix account owner or admin for this project can link a bot.' };
+  }
+  await linkSlackIdentity({ teamId: ctx.teamId, slackUserId: botUserId, userId: me.userId });
+  return {
+    response_type: 'ephemeral',
+    text: `Linked <@${botUserId}> to your Kortix account. Its @-mentions of Kortix in this workspace now run as you. Undo with \`${ctx.command} logout\` semantics via support, or re-link to someone else.`,
   };
 }
 

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -619,14 +619,18 @@ export async function dispatchSlackEvent(projectId: string, envelope: SlackEnvel
       const slackUserId = event.user ?? '';
       const actor = await resolveSlackActor(teamId, slackUserId, project.accountId, projectId);
       if ('reason' in actor) {
-        await postIdentityPrompt({
-          projectId,
-          teamId,
-          channel: event.channel,
-          threadTs: event.thread_ts,
-          slackUserId,
-          reason: actor.reason,
-        });
+        // Same reason as the main path below: a bot cannot read a prompt
+        // addressed to it. See `<cmd> link-bot`.
+        if (!event.bot_id) {
+          await postIdentityPrompt({
+            projectId,
+            teamId,
+            channel: event.channel,
+            threadTs: event.thread_ts,
+            slackUserId,
+            reason: actor.reason,
+          });
+        }
         return;
       }
     }
@@ -671,18 +675,24 @@ export async function spawnAgentTurn(
     const slackUserId = event.user ?? '';
     const actor = await resolveSlackActor(teamId, slackUserId, project.accountId, projectId);
     if ('reason' in actor) {
-      await postIdentityPrompt({
-        projectId,
-        teamId,
-        channel: event.channel,
-        // Top-level ephemeral prompts should render beside the message. Passing
-        // the message ts as thread_ts hides the auth prompt in a new thread.
-        threadTs: event.thread_ts,
-        slackUserId,
-        reason: actor.reason,
-        envelope,
-        event,
-      });
+      // A BOT cannot act on this. postIdentityPrompt posts an ephemeral AND a DM
+      // to slackUserId, so for a bot sender both land where no human will ever
+      // see them, and the mention reads as "Kortix ignored it" — which is how
+      // this went undiagnosed. Link it with `<cmd> link-bot @TheBot` instead.
+      if (!event.bot_id) {
+        await postIdentityPrompt({
+          projectId,
+          teamId,
+          channel: event.channel,
+          // Top-level ephemeral prompts should render beside the message. Passing
+          // the message ts as thread_ts hides the auth prompt in a new thread.
+          threadTs: event.thread_ts,
+          slackUserId,
+          reason: actor.reason,
+          envelope,
+          event,
+        });
+      }
       return;
     }
     actorUserId = actor.userId;


### PR DESCRIPTION
Follow-up to #6577. **That fix was necessary but not sufficient** — I verified the gate I changed and didn't trace what came after it.

Measured on dev `f07c04f0` with a real bot-to-bot mention (Slack ts `1787153374.887479`): the message reaches `classifyEvent`, classifies as `mention`, and dies one gate later.

## Why a bot mention still did nothing

`SLACK_REQUIRE_USER_IDENTITY` is `optBoolTrue` — **on by default**. `resolveSlackActor` looks up `chat_user_identities` by the *sender's* Slack user id; a bot has no row → `{reason: 'unlinked'}` → dispatch returns before the turn.

And it returns **loudly into a void**: `postIdentityPrompt` posts an ephemeral *and* opens a DM, both addressed to `slackUserId` — the bot. No human sees either, so the mention reads as "Kortix ignored it". That's why this looked like a routing bug.

## Changes

**1. Never prompt a bot sender.** Both call sites: the bare-`@mention` branch and the main turn path. I first guarded only one — the test caught the second, which is why it now asserts *every* `postIdentityPrompt` site rather than the first match.

**2. `<cmd> link-bot @TheBot`** binds a bot's Slack user id to the **caller's** Kortix account via the same `chat_user_identities` row `/login` writes (`linkSlackIdentity`, already exported and idempotent). Existing authorization applies unchanged — the linked user must still be a member of the project's account and pass `PROJECT_WRITE` inside `resolveSlackActor`.

**3. `link-bot` verifies the target IS a bot** — added after [Strix flagged it on this PR](https://github.com/kortix-ai/suna/pull/6590), and the finding was real.

`linkSlackIdentity` **upserts**, and `resolveSlackActor` treats the row as the authoritative `(workspace, slack_user) -> kortix_user` mapping. My first version accepted anything matching `/^[UWB][A-Z0-9]{6,}$/` — which matches a **human** id identically (`U0B8ERR54BH` is a person). So an admin could have passed a colleague's id and silently made that person's later Slack actions run as the admin's account: the exact impersonation `SLACK_REQUIRE_USER_IDENTITY` exists to prevent, through a door I opened.

Two guards now:
- **Ask Slack.** New `slack-api.isBotUser()` via the existing `slackApiCall` helper — retries/timeouts/429 handling already live there, and `conversations.info` already proves a read method works with a JSON body. `users:read` is in `SLACK_BOT_SCOPES` *and* the committed manifest, so **no re-install**. Returns `null` on any uncertainty (missing scope, transport error, unknown user) and the caller checks `bot !== true`, not `bot === false` — guessing "probably a bot" is the vulnerability.
- **Never re-point an existing link.** If that Slack id already maps to a different Kortix user, refuse. Closes the class even if the Slack check regresses.

Used `slackApiCall` rather than the suggested inline `fetch`, which hand-rolled a POST and duplicated retry/timeout handling this module already owns.

## Why opt-in and not automatic

The identity gate exists to stop a non-member acting, and **any app that can post in the channel is a non-member**. Defaulting bot senders to the project automation actor would reintroduce the impersonation the gate was added to prevent — its own comment says *"never fall back to the owner (the impersonation this fixes)"*.

This is also what @vukasin asked for originally ("at least should be option in channels to enable"). My "no toggle needed" call in #6577 was based on the classify path alone and was **wrong**.

Chose linking over a per-channel policy column because it reuses the existing mechanism end to end — no migration, no new policy vocabulary, authorization already written and tested.

## Usage

```
/kortix-dev link-bot @Incident reporter
```
Owner/admin only, and only accepts a Slack-verified bot. That bot's @-mentions of Kortix then run as the linking admin.

## Testing

- **17 tests** in `unit-slack-bot-mentions` (8 new): both prompt sites guarded; `link-bot` routed, flag-gated and admin-gated; Slack asked *before* the write; uncertainty refuses; an existing link is never re-pointed; `isBotUser` fails closed.
- **8 negative controls, each red on its own** — unguarding either prompt site, dropping the admin gate, removing the route, dropping the bot check, accepting `unknown`, allowing a re-point, and making `isBotUser` answer `false` on API failure.
- One of those controls initially **passed** against a greedy `[\s\S]*` that matched a later `return null` in the same function. The assertion is now scoped to the `!r.ok` branch. A control that passes is a test that isn't testing.
- Three sibling suites needed `isBotUser` / `linkSlackIdentity` in their partial mocks. I first patched ten and reverted the seven that didn't need it — the diff should say what changed, not what I ran.
- **Full Slack surface: 337 pass, 0 fail.** Typecheck clean. Rebased onto current `main`.