### PR TITLE
fix(daemon): managed-model overlay never blocks the spawn; reconcile once before readiness

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/managed-model-overlay.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/managed-model-overlay.test.ts
@@ -6,19 +6,27 @@ import { join } from 'node:path'
 import {
   BUNDLED_MANAGED_MODELS,
   buildOpencodeConfigContent,
+  configuredProviderModelIds,
   fetchManagedModels,
+  missingManagedModelIds,
   refreshGatewayCatalogFile,
   resetManagedModelsStateForTests,
+  settleManagedModelsPrefetch,
   startManagedModelsPrefetch,
   withManagedOverlay,
+  type Opencode,
 } from '../opencode'
+import { loadConfig } from '../config'
+import { reconcileManagedModels, resetManagedReconcileForTests } from '../main'
 
 // The 2026-08-19 outage in one sentence: the image-baked catalog is frozen at
 // template-build time, the managed lineup is deployment config, so a managed
 // model added after the last build was absent from OpenCode's provider map and
 // every turn on it died with `ModelNotFound: kortix/<id>` 2ms after the prompt.
-// These tests pin the fix — the sandbox learns the managed set from the API it
-// talks to, on every boot, and never falls below the bundled managed floor.
+// These tests pin the fix AND its cost model: the boot config never waits on
+// the network (waiting cost 1.6s of a 6.5s dev boot), and the live answer is
+// applied after the spawn — one controlled restart, only when a managed model
+// is genuinely missing.
 
 const GATEWAY = {
   KORTIX_WORKSPACE: '/workspace',
@@ -62,11 +70,13 @@ function providerModels(raw: string | undefined): Record<string, { name?: string
 
 beforeEach(() => {
   resetManagedModelsStateForTests()
+  resetManagedReconcileForTests()
 })
 
 afterEach(async () => {
   globalThis.fetch = realFetch
   resetManagedModelsStateForTests()
+  resetManagedReconcileForTests()
   await Promise.all(tempDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })))
 })
 
@@ -112,13 +122,16 @@ describe('managed listing fetch', () => {
 })
 
 describe('boot config composition', () => {
-  test('a stale baked catalog is overlaid with the LIVE managed set', async () => {
+  test('a stale baked catalog is overlaid with the LIVE managed set once it is known', async () => {
     globalThis.fetch = (async (input: string) => {
       expect(String(input)).toContain('scope=managed')
       return new Response(JSON.stringify(LIVE_MANAGED), { status: 200 })
     }) as unknown as typeof fetch
 
     startManagedModelsPrefetch(GATEWAY.KORTIX_LLM_BASE_URL, GATEWAY.KORTIX_LLM_API_KEY)
+    // Cached by the post-spawn reconcile; every later config build (the
+    // reconcile's own restart, any restart after it) reads it synchronously.
+    await settleManagedModelsPrefetch()
     const raw = await buildOpencodeConfigContent({
       ...GATEWAY,
       KORTIX_LLM_CATALOG_FILE: await bakedCatalogFile(),
@@ -153,26 +166,29 @@ describe('boot config composition', () => {
     expect(models['openai/gpt-5.5']).toBeDefined()
   })
 
-  test('a hanging gateway cannot hold the OpenCode spawn past the await cap', async () => {
+  // THE latency regression this design exists to prevent. `opencode serve`
+  // cannot bind its port until this config is written, so the build must never
+  // wait on a fetch — a hanging gateway has to cost ~0ms, not the fetch budget.
+  test('a hanging gateway costs the config build no time at all', async () => {
     globalThis.fetch = (async () => {
       await new Promise((r) => setTimeout(r, 60_000))
       return new Response('{}', { status: 200 })
     }) as unknown as typeof fetch
 
+    const file = await bakedCatalogFile()
     startManagedModelsPrefetch(GATEWAY.KORTIX_LLM_BASE_URL, GATEWAY.KORTIX_LLM_API_KEY)
     const started = Date.now()
     const raw = await buildOpencodeConfigContent({
       ...GATEWAY,
-      KORTIX_LLM_CATALOG_FILE: await bakedCatalogFile(),
+      KORTIX_LLM_CATALOG_FILE: file,
     } as NodeJS.ProcessEnv)
     const elapsed = Date.now() - started
     const models = providerModels(raw)
 
-    expect(elapsed).toBeLessThan(4_000)
-    // It waited for the in-flight answer rather than skipping it outright...
-    expect(elapsed).toBeGreaterThan(1_500)
-    // ...and fell back to the bundled floor instead of shipping a short picker.
+    expect(elapsed).toBeLessThan(50)
+    // The bundled floor still ships, so the picker is never short.
     expect(models['grok-4.6']).toBeDefined()
+    expect(models['openai/gpt-5.5']).toBeDefined()
   }, 15_000)
 
   test('with no prefetch started the boot path stays network-free', async () => {
@@ -290,4 +306,134 @@ describe('withManagedOverlay', () => {
     const out = withManagedOverlay({ 'legacy/model': { name: 'L' } }, { 'grok-4.6': { name: 'G' } })
     expect(out['legacy/model']).toBeDefined()
   })
+})
+
+describe('post-spawn managed reconcile', () => {
+  const REAL_CATALOG_ENV = process.env.KORTIX_LLM_CATALOG_FILE
+
+  afterEach(() => {
+    if (REAL_CATALOG_ENV === undefined) delete process.env.KORTIX_LLM_CATALOG_FILE
+    else process.env.KORTIX_LLM_CATALOG_FILE = REAL_CATALOG_ENV
+  })
+
+  function fakeOpencode(restarts: { n: number }): Opencode {
+    return {
+      getInternalUrl: () => 'http://127.0.0.1:65535',
+      // waitForOpencodeReady short-circuits on 'ok', so the fake never polls.
+      getState: () => 'ok',
+      markReady: () => {},
+      restart: async () => {
+        restarts.n++
+      },
+    } as unknown as Opencode
+  }
+
+  const cfg = loadConfig({ KORTIX_WORKSPACE: '/workspace' } as NodeJS.ProcessEnv)
+
+  async function targetPath(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'kortix-reconcile-'))
+    tempDirs.push(dir)
+    return join(dir, 'kortix-llm-catalog.session.json')
+  }
+
+  /** Boot exactly as production does: prefetch in flight, config built WITHOUT
+   *  waiting for it — so the running OpenCode has only the bundled managed set. */
+  async function bootWithLiveGateway(): Promise<void> {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(LIVE_MANAGED), { status: 200 })) as unknown as typeof fetch
+    process.env.KORTIX_LLM_CATALOG_FILE = await bakedCatalogFile()
+    startManagedModelsPrefetch(GATEWAY.KORTIX_LLM_BASE_URL, GATEWAY.KORTIX_LLM_API_KEY)
+    await buildOpencodeConfigContent({
+      ...GATEWAY,
+      KORTIX_LLM_CATALOG_FILE: process.env.KORTIX_LLM_CATALOG_FILE,
+    } as NodeJS.ProcessEnv)
+  }
+
+  test('restarts opencode EXACTLY ONCE when the live set has a model the boot config lacks', async () => {
+    await bootWithLiveGateway()
+    // The provider map OpenCode booted with does not know the new model.
+    expect(configuredProviderModelIds()?.has('new-managed-9.9')).toBe(false)
+
+    const restarts = { n: 0 }
+    const marks: string[] = []
+    const target = await targetPath()
+    const opts = { catalogTargetFile: target, turnProbe: async () => false }
+
+    await reconcileManagedModels(fakeOpencode(restarts), cfg, (m) => marks.push(m), opts)
+    // Single-flight: a second call must never buy a second restart.
+    await reconcileManagedModels(fakeOpencode(restarts), cfg, (m) => marks.push(m), opts)
+
+    expect(restarts.n).toBe(1)
+    expect(marks).toEqual(['managed-reconcile'])
+    // The overlay is on disk, and the next spawn reads it.
+    const written = JSON.parse(await readFile(target, 'utf8')) as {
+      models: Record<string, unknown>
+    }
+    expect(written.models['new-managed-9.9']).toBeDefined()
+    expect(written.models['openai/gpt-5.5']).toBeDefined()
+    expect(process.env.KORTIX_LLM_CATALOG_FILE).toBe(target)
+  })
+
+  test('does nothing when the boot config already has every managed model', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(LIVE_MANAGED), { status: 200 })) as unknown as typeof fetch
+    process.env.KORTIX_LLM_CATALOG_FILE = await bakedCatalogFile()
+    startManagedModelsPrefetch(GATEWAY.KORTIX_LLM_BASE_URL, GATEWAY.KORTIX_LLM_API_KEY)
+    await settleManagedModelsPrefetch()
+    await buildOpencodeConfigContent({
+      ...GATEWAY,
+      KORTIX_LLM_CATALOG_FILE: process.env.KORTIX_LLM_CATALOG_FILE,
+    } as NodeJS.ProcessEnv)
+
+    const restarts = { n: 0 }
+    const marks: string[] = []
+    const target = await targetPath()
+    await reconcileManagedModels(fakeOpencode(restarts), cfg, (m) => marks.push(m), {
+      catalogTargetFile: target,
+      turnProbe: async () => false,
+    })
+
+    expect(missingManagedModelIds(LIVE_MANAGED.models)).toEqual([])
+    expect(restarts.n).toBe(0)
+    expect(marks).toEqual(['managed-reconcile'])
+    expect(await readFile(target, 'utf8').catch(() => null)).toBeNull()
+  })
+
+  test('never restarts across a live turn — or one it cannot read', async () => {
+    for (const turnInFlight of [true, null] as const) {
+      resetManagedModelsStateForTests()
+      resetManagedReconcileForTests()
+      await bootWithLiveGateway()
+
+      const restarts = { n: 0 }
+      const target = await targetPath()
+      await reconcileManagedModels(fakeOpencode(restarts), cfg, () => {}, {
+        catalogTargetFile: target,
+        turnProbe: async () => turnInFlight,
+      })
+
+      expect(restarts.n).toBe(0)
+      expect(await readFile(target, 'utf8').catch(() => null)).toBeNull()
+    }
+  })
+
+  test('is a no-op when the gateway never answers (bundled managed set stands)', async () => {
+    globalThis.fetch = (async () =>
+      new Response('down', { status: 500 })) as unknown as typeof fetch
+    process.env.KORTIX_LLM_CATALOG_FILE = await bakedCatalogFile()
+    startManagedModelsPrefetch(GATEWAY.KORTIX_LLM_BASE_URL, GATEWAY.KORTIX_LLM_API_KEY)
+    await buildOpencodeConfigContent({
+      ...GATEWAY,
+      KORTIX_LLM_CATALOG_FILE: process.env.KORTIX_LLM_CATALOG_FILE,
+    } as NodeJS.ProcessEnv)
+
+    const restarts = { n: 0 }
+    const target = await targetPath()
+    await reconcileManagedModels(fakeOpencode(restarts), cfg, () => {}, {
+      catalogTargetFile: target,
+      turnProbe: async () => false,
+    })
+
+    expect(restarts.n).toBe(0)
+  }, 15_000)
 })

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -20,9 +20,12 @@ import {
   createOpencodeSupervisor,
   hasKortixLlmGateway,
   OPENCODE_HOME,
+  missingManagedModelIds,
   refreshGatewayCatalogFile,
   scheduleCatalogWarm,
+  settleManagedModelsPrefetch,
   startManagedModelsPrefetch,
+  writeManagedOverlayCatalogFile,
   waitForOpencodeReady,
   type Opencode,
 } from './opencode'
@@ -63,7 +66,7 @@ import {
 import type { SandboxBootState } from './routes/health'
 import { installShutdownHandlers } from './shutdown'
 import { startStaticWebServer } from './static-web'
-import { opencodeDeliveryInFlight } from './opencode-turn-state'
+import { opencodeDeliveryInFlight, opencodeTurnInFlight } from './opencode-turn-state'
 
 const LEGACY_OPENCODE_ZEN_FREE_MODELS = new Set([
   'deepseek-v4-flash-free',
@@ -419,12 +422,122 @@ function armSeedAdoption(
 // prompt/bootstrap was requested) and start the question-relay event loop.
 // Shared post-boot session runtime: create the initial opencode session when
 // requested and wire the question/turn event relay.
+// Once per daemon process. A second call is a no-op even if a second runtime
+// start happens (seed boot then fork adoption), so a box can never restart
+// OpenCode twice for the same reason.
+let managedReconcileRan = false
+
+/**
+ * Post-spawn managed-model reconcile — the OFF-CRITICAL-PATH half of "the
+ * sandbox learns the managed set from the API it talks to".
+ *
+ * The config build (buildOpencodeConfigContent) is synchronous by rule: it uses
+ * only what is already known, because `opencode serve` cannot bind its port
+ * until that file is written — awaiting the fetch there cost 1.6s of a 6.5s dev
+ * boot. So the live answer is applied HERE instead, after the spawn and before
+ * the initial prompt is delivered:
+ *
+ *   - settle the prefetch started at proxy-up (its own ≤5s budget, started at
+ *     ~80ms — by the time OpenCode is spawning this is already resolved, so it
+ *     costs ~0ms and runs concurrently with OpenCode's own cold start);
+ *   - diff the live managed set against the provider map OpenCode actually
+ *     booted with;
+ *   - only a genuinely MISSING managed id — the model that would answer
+ *     `ModelNotFound` — buys one controlled restart. The bundled managed table
+ *     ships with every release, so the common case is a no-op.
+ *
+ * Never restarts across a live turn: `opencodeTurnInFlight` treats "cannot
+ * tell" as busy, and a cold box with no pin answers a definite `false` without
+ * a request.
+ */
+/** Test seam: re-arm the once-per-process guard. */
+export function resetManagedReconcileForTests(): void {
+  managedReconcileRan = false
+}
+
+export async function reconcileManagedModels(
+  opencode: ReturnType<typeof createOpencodeSupervisor>,
+  cfg: Config,
+  bootMark: (label: string) => void,
+  // Test seams only — production always uses these defaults. The session
+  // catalog file lives under the daemon's own home (never `env.HOME`, see
+  // KORTIX_OPENCODE_CONFIG_PATH), and the live-turn probe is the real one.
+  opts: {
+    catalogTargetFile?: string
+    turnProbe?: (baseUrl: string, workspace: string) => Promise<boolean | null>
+  } = {},
+): Promise<void> {
+  if (managedReconcileRan) return
+  managedReconcileRan = true
+  const startedAt = Date.now()
+  try {
+    // Free in wall-clock terms: OpenCode is cold-starting in its OWN process
+    // (4.7-12s spawn→answering) while this waits, and the very next boot step
+    // blocks on that anyway. The prefetch's own ≤5s budget started at proxy-up,
+    // so it is normally already settled when this runs.
+    const live = await settleManagedModelsPrefetch()
+    if (!live) {
+      logger.info('[boot] managed reconcile: no live managed set; bundled managed models stand', {
+        ms: Date.now() - startedAt,
+      })
+      return
+    }
+    const missing = missingManagedModelIds(live)
+    if (missing.length === 0) {
+      logger.info('[boot] managed reconcile: opencode already has every managed model', {
+        managed: Object.keys(live).length,
+        ms: Date.now() - startedAt,
+      })
+      return
+    }
+    const probe = opts.turnProbe ?? opencodeTurnInFlight
+    const turnInFlight = await probe(opencode.getInternalUrl(), cfg.workspace)
+    if (turnInFlight !== false) {
+      logger.warn('[boot] managed reconcile: skipping restart — a turn is live or unreadable', {
+        missing,
+        turnInFlight,
+        ms: Date.now() - startedAt,
+      })
+      return
+    }
+    const written = writeManagedOverlayCatalogFile({
+      currentCatalogFile: process.env.KORTIX_LLM_CATALOG_FILE ?? '/opt/kortix/llm-catalog.json',
+      targetCatalogFile:
+        opts.catalogTargetFile ?? `${OPENCODE_HOME}/.config/kortix-llm-catalog.session.json`,
+      managed: live,
+    })
+    if (written) process.env.KORTIX_LLM_CATALOG_FILE = written
+    // OpenCode materializes provider models at process start, so the file alone
+    // changes nothing for the process that is already running.
+    await opencode.restart()
+    const ready = await waitForOpencodeReady(opencode, cfg.projectTarget)
+    logger.info('[boot] managed reconcile: restarted opencode with the missing managed models', {
+      missing,
+      managed: Object.keys(live).length,
+      catalogFile: written,
+      ready,
+      ms: Date.now() - startedAt,
+    })
+  } catch (err) {
+    logger.warn('[boot] managed reconcile failed; boot continues on the configured catalog', {
+      err: err instanceof Error ? err.message : String(err),
+      ms: Date.now() - startedAt,
+    })
+  } finally {
+    bootMark('managed-reconcile')
+  }
+}
+
 async function startSessionRuntime(
   opencode: ReturnType<typeof createOpencodeSupervisor>,
   cfg: Config,
   bootState: SandboxBootState,
   bootMark: (label: string) => void,
 ): Promise<void> {
+  // BEFORE the event loop, the root resolution and any prompt delivery: a
+  // restart here strands nothing, and the first turn must run on a provider map
+  // that has every managed model the picker offers.
+  await reconcileManagedModels(opencode, cfg, bootMark)
   const auditRelay = createAuditRelay(
     async (events) => {
       const ctx = sandboxRelayContext(auditRelayToken(process.env))

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -338,10 +338,18 @@ export async function buildOpencodeConfigContent(
     // baked catalog forever (templates are not rebuilt on a catalog change).
     // On 2026-08-19 that made OpenCode answer `ModelNotFound: kortix/grok-4.6`
     // for two live managed models. So the sandbox LEARNS the managed set from
-    // the API it talks to on every boot. This await consumes a prefetch started
-    // at boot (startManagedModelsPrefetch, main.ts) — it never starts a fetch
-    // itself, so the "boot path touches no network" rule still holds.
-    const managedOverlay = await awaitManagedModelsOverlay()
+    // the API it talks to — but NEVER on this path.
+    //
+    // This read is SYNCHRONOUS and non-blocking by hard rule. Waiting on the
+    // in-flight fetch here cost 1.6s of a 6.5s dev boot (config-deps 114ms →
+    // runtime-config-ready 1727ms, measured on a Platinum guest 2026-08-19):
+    // `opencode serve` cannot bind its port until this config is written, so
+    // anything awaited here is dead time on EVERY session boot. Cold boot uses
+    // whatever is already known (bundled managed table, or a cache filled by an
+    // earlier fetch on this box); a managed model that only the live set knows
+    // is picked up by the post-spawn reconcile in main.ts, off the critical
+    // path.
+    const managedOverlay = cachedManagedModels()
     const kortixProvider = buildKortixProvider({
       // In proxy mode opencode talks to the localhost proxy with a placeholder
       // key; the proxy injects the real per-session token upstream. In direct
@@ -412,6 +420,12 @@ type KortixProviderOpts = {
 
 function buildKortixProvider(opts: KortixProviderOpts): Record<string, unknown> {
   const catalog = withModelLimits(withManagedOverlay(loadGatewayCatalog(opts), opts.managedOverlay))
+  // Remember the exact id set this config registers. Every spawn writes its
+  // config immediately before exec (see spawnOpencode → writeKortixOpencodeConfig),
+  // so this is the provider map the RUNNING OpenCode holds — the post-spawn
+  // reconcile diffs the live managed set against it to decide whether one
+  // controlled restart is warranted.
+  lastConfiguredProviderModelIds = new Set(Object.keys(catalog))
   const models = Object.fromEntries(
     Object.entries(catalog).map(([id, model]) => {
       // The gateway catalog's string `provider` is UI metadata describing the
@@ -762,20 +776,20 @@ async function fetchGatewayModels(
 // process start — then answers `ModelNotFound: kortix/<id>` for it (prod
 // incident 2026-08-19: grok-4.6, deepseek-v4-pro-0813).
 //
-// Fix: every boot fetches the compact managed listing (~3KB) from the same
-// gateway the session bills against and overlays it on whatever catalog is on
-// disk. Same principle as the runtime-assets reconcile — the box learns the
-// current truth from the API it talks to.
+// Fix, in two halves that never block each other:
+//   1. BOOT reads only what it already knows (cachedManagedModels) — the
+//      bundled managed table on a cold box. Zero network, zero wait, because
+//      `opencode serve` cannot bind its port until that config is written.
+//   2. AFTER the spawn, the prefetch started at proxy-up is settled and diffed
+//      against the provider map OpenCode actually booted with. Only a genuinely
+//      missing managed id costs one controlled restart (main.ts,
+//      reconcileManagedModels). The bundled table ships with every release, so
+//      the miss is rare by construction.
+// Same principle as the runtime-assets reconcile — the box learns the current
+// truth from the API it talks to, without paying for it on the hot path.
 const MANAGED_MODELS_TIMEOUT_MS = 2_000
 const MANAGED_MODELS_TOTAL_BUDGET_MS = 5_000
 const MANAGED_MODELS_ATTEMPTS = 3
-// How long buildOpencodeConfigContent may wait on an in-flight prefetch. The
-// prefetch starts at proxy-up and the repo clone runs in front of the config
-// build, so this is normally already resolved and costs 0ms. The cap exists so
-// a degraded gateway can never push the OpenCode spawn out by the full budget:
-// the BUNDLED managed set (below) is the correctness floor, the live fetch is
-// the upgrade.
-const MANAGED_OVERLAY_AWAIT_CAP_MS = 2_500
 // Re-fetch rather than reuse a cache older than this (a warm seed can sit for
 // hours between capture and adoption).
 const MANAGED_CACHE_TTL_MS = 10 * 60_000
@@ -783,6 +797,9 @@ const MANAGED_CACHE_TTL_MS = 10 * 60_000
 let managedPrefetch: Promise<Record<string, KortixGatewayModel> | null> | null = null
 let managedCache: Record<string, KortixGatewayModel> | null = null
 let managedCacheAt = 0
+/** The kortix-provider model ids the most recently WRITTEN config registers.
+ *  Written on every spawn, so it is what the running OpenCode holds. */
+let lastConfiguredProviderModelIds: Set<string> | null = null
 
 /**
  * Compose the catalog OpenCode boots with: disk catalog first, managed set on
@@ -885,29 +902,82 @@ export function rememberManagedModels(models: Record<string, KortixGatewayModel>
   managedCacheAt = Date.now()
 }
 
-/** The overlay for the config being built now: the cached live set, else an
- *  in-flight prefetch (bounded), else null (→ bundled managed set). Never
- *  starts a fetch — the boot path stays network-free by construction. */
-export async function awaitManagedModelsOverlay(): Promise<Record<string, KortixGatewayModel> | null> {
+/**
+ * The live managed set IF it is already known — synchronous, never a wait.
+ *
+ * Returns the cache when it is fresh (an earlier fetch on this box: a prior
+ * OpenCode restart, a warm-fork adoption, or the post-spawn reconcile), else
+ * null so the caller falls back to the bundled managed table. It deliberately
+ * does NOT consult the in-flight prefetch: the config build is what gates
+ * OpenCode's port bind, and awaiting the fetch there measured 1.6s of dead
+ * boot time on a real dev guest.
+ */
+export function cachedManagedModels(): Record<string, KortixGatewayModel> | null {
   if (managedCache && Date.now() - managedCacheAt < MANAGED_CACHE_TTL_MS) return managedCache
-  const pending = managedPrefetch
-  if (!pending) return managedCache
-  let timer: ReturnType<typeof setTimeout> | undefined
-  const capped = new Promise<null>((resolve) => {
-    timer = setTimeout(() => resolve(null), MANAGED_OVERLAY_AWAIT_CAP_MS)
-  })
-  try {
-    return (await Promise.race([pending, capped])) ?? managedCache
-  } finally {
-    if (timer) clearTimeout(timer)
-  }
+  return null
 }
 
-/** Test seam: drop prefetch/cache state between cases. */
+/**
+ * Settle the boot prefetch, for the POST-SPAWN reconcile only.
+ *
+ * Bounded by the prefetch's own ≤5s budget, which started at proxy-up — by the
+ * time OpenCode is spawned it is normally already resolved, so this returns
+ * immediately. Never call it from a path that gates the spawn.
+ */
+export async function settleManagedModelsPrefetch(): Promise<Record<
+  string,
+  KortixGatewayModel
+> | null> {
+  const pending = managedPrefetch
+  if (pending) await pending.catch(() => null)
+  return cachedManagedModels()
+}
+
+/** The kortix model ids the running OpenCode's provider map holds (i.e. the ids
+ *  in the config written by the last spawn), or null before any config build. */
+export function configuredProviderModelIds(): Set<string> | null {
+  return lastConfiguredProviderModelIds
+}
+
+/**
+ * Managed ids the live gateway serves that the running OpenCode does NOT have.
+ *
+ * Each one is a model the picker offers and the runtime answers `ModelNotFound`
+ * for — the 2026-08-19 outage, exactly. An empty result means the boot config
+ * was already complete and nothing has to be restarted.
+ */
+export function missingManagedModelIds(live: Record<string, KortixGatewayModel> | null): string[] {
+  if (!live) return []
+  const configured = lastConfiguredProviderModelIds
+  if (!configured) return []
+  return Object.keys(live).filter((id) => !configured.has(id))
+}
+
+/**
+ * Persist the managed overlay so the NEXT OpenCode start (the reconcile's
+ * restart, and any later restart on this box) registers it from disk, not just
+ * from this process's cache. Returns the file OpenCode should read, or null
+ * when nothing usable could be composed.
+ */
+export function writeManagedOverlayCatalogFile(opts: {
+  currentCatalogFile: string
+  targetCatalogFile: string
+  managed: Record<string, KortixGatewayModel>
+}): string | null {
+  const base = readCatalogFile(opts.currentCatalogFile) ?? readCatalogFile(BAKED_LLM_CATALOG_PATH)
+  const composed = sanitizeCatalogForDisk(withManagedOverlay(base ?? MINIMAL_FALLBACK_MODELS, opts.managed))
+  if (!composed) return null
+  mkdirSync(dirname(opts.targetCatalogFile), { recursive: true })
+  writeFileSync(opts.targetCatalogFile, JSON.stringify({ models: composed }), { mode: 0o600 })
+  return opts.targetCatalogFile
+}
+
+/** Test seam: drop prefetch/cache/config state between cases. */
 export function resetManagedModelsStateForTests(): void {
   managedPrefetch = null
   managedCache = null
   managedCacheAt = 0
+  lastConfiguredProviderModelIds = null
 }
 
 export type GatewayCatalogRefreshResult = {


### PR DESCRIPTION
Follow-up to #6576 (merged, dev-verified: all 7 managed models answer in a real dev session).

## Problem found in dev verification
The real guest's boot timeline showed the OpenCode config build waiting on the `?scope=managed` fetch: `config-deps` 114 ms → `runtime-config-ready` 1727 ms (old daemon: 59 ms). The authenticated endpoint has 0.6–2.0 s TTFB on dev (auth path; `/health` is 0.35 s), so every boot paid ~1–1.6 s of ~6.5 s.

## Change (daemon only)
- `buildOpencodeConfigContent` reads `cachedManagedModels()` synchronously — cache from an earlier fetch on this box, else the bundled managed table. The prefetch still starts at proxy-up.
- `reconcileManagedModels()` runs as the first step of `startSessionRuntime` (after `opencode.start()` returned, before root resolution / prompt delivery): settle the prefetch (overlaps OpenCode's own cold start), diff the live set against the provider ids the written config registered; only when an id is missing: write the overlay catalog file, repoint `KORTIX_LLM_CATALOG_FILE`, ONE `opencode.restart()`, re-wait readiness. Skips with a warn if a turn is live. Single-flight; `bootMark('managed-reconcile')` + one log line always.

## Evidence
- Local gateway with the dev-measured 1.5 s auth TTFB: config build **2–8 ms** in both branches; restarts **1** only when the live set adds an id the daemon release never had, **0** otherwise; one managed request per boot.
- `managed-model-overlay.test.ts` 17 pass (hanging gateway ⇒ config build < 50 ms; exactly-once restart; none when nothing missing / turn live / gateway silent). `boot-latency` 20 pass. Daemon suite 665 pass + 1 known flaky `monitor-runner` timeout (20/20 in isolation). `tsc` clean, `bun run build` OK.

## After merge
Deploy Dev → template rebuild → new session: expect `config-deps → runtime-config-ready` back to ~60 ms and a `managed-reconcile` boot mark; re-run the 7-model sweep.
