### PR TITLE
perf(sessions): stop paying two provider round trips to resume a stopped box

### DIFF
--- a/apps/api/scripts/bench-meta-boot.ts
+++ b/apps/api/scripts/bench-meta-boot.ts
@@ -1,0 +1,266 @@
+#!/usr/bin/env bun
+/**
+ * Meta-agent session boot benchmark.
+ *
+ * `bench-boot-attribution.ts` measures ordinary sessions and needs a direct
+ * Postgres connection for the host-side transitions. This one measures the
+ * PLATFORM META sandbox (`sandbox_slug: 'meta'`, the `meta` runtime profile)
+ * from a laptop against a deployed API, with no database access:
+ *
+ *   t0 ─ POST /projects/:p/sessions returns        → api_create_ms
+ *      ─ GET  /sessions/:s exposes `sandbox_url`   → vm_created_ms
+ *      ─ first 2xx from /kortix/health             → daemon_reachable_ms
+ *      ─ health.runtimeReady === true              → runtime_ready_ms   (usable)
+ *
+ * plus the daemon's own `boot_timeline` (in-guest, daemon-start-relative), so a
+ * boot decomposes into "waiting for the provider" vs "the guest booting itself".
+ *
+ * `sandbox_url` lands the moment the provider returns the VM, which is the
+ * closest public proxy for the `external_id` write the DB harness watches.
+ *
+ * Usage:
+ *   cd apps/api
+ *   BENCH_API=https://dev-api.kortix.com \
+ *   BENCH_TOKEN=kortix_pat_... \
+ *   BENCH_PROJECT=<project with meta_agent enabled> \
+ *   BENCH_ROUNDS=3 bun run scripts/bench-meta-boot.ts
+ *
+ * Env:
+ *   BENCH_PROJECT   project id. Required. meta_agent must be enabled on it
+ *                   unless BENCH_AGENT/BENCH_SLUG say otherwise.
+ *   BENCH_TOKEN     kortix_pat_… Required. Environment only, never a config file.
+ *   BENCH_API       API origin (default https://dev-api.kortix.com).
+ *   BENCH_ROUNDS    boots per label (default 3).
+ *   BENCH_LABEL     row label (default "meta").
+ *   BENCH_AGENT     explicit agent for the create body (default: omitted, so
+ *                   the project's meta default applies).
+ *   BENCH_SLUG      explicit sandbox_slug (default: omitted).
+ *   BENCH_TIMEOUT_S per-boot ceiling (default 240).
+ *   BENCH_KEEP      "1" to leave the sessions behind (default: delete them).
+ *   BENCH_OUT       write raw JSON here.
+ */
+import { writeFileSync } from 'node:fs';
+import { SQL } from 'bun';
+
+const API = (process.env.BENCH_API ?? 'https://dev-api.kortix.com').replace(/\/+$/, '');
+const TOKEN = (process.env.BENCH_TOKEN ?? '').trim();
+const PROJECT = (process.env.BENCH_PROJECT ?? '').trim();
+const ROUNDS = Number(process.env.BENCH_ROUNDS ?? 3);
+const LABEL = process.env.BENCH_LABEL ?? 'meta';
+const AGENT = process.env.BENCH_AGENT ?? '';
+const SLUG = process.env.BENCH_SLUG ?? '';
+const TIMEOUT_MS = Number(process.env.BENCH_TIMEOUT_S ?? 240) * 1000;
+const KEEP = process.env.BENCH_KEEP === '1';
+// Optional. With it, the host-side marks the API already records
+// (`session_sandboxes.metadata.provisionTimeline`) are merged into the client
+// timeline, which is the only way to see WHERE the pre-VM seconds go: the
+// public API exposes the outcome, never the stages that produced it.
+const DB_URL = (process.env.BENCH_DB_URL ?? '').trim();
+const sqlDb = DB_URL ? new SQL(DB_URL) : null;
+
+if (!TOKEN || !PROJECT) {
+  console.error('Need BENCH_TOKEN and BENCH_PROJECT.');
+  process.exit(1);
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface BootMark { label: string; atMs: number }
+interface Boot {
+  label: string;
+  round: number;
+  sessionId: string | null;
+  provider: string | null;
+  agent: string | null;
+  slug: string | null;
+  externalId: string | null;
+  apiCreateMs: number | null;
+  vmCreatedMs: number | null;
+  daemonReachableMs: number | null;
+  runtimeReadyMs: number | null;
+  bootTimeline: BootMark[] | null;
+  /** Wall-clock epoch of t0, so server timestamps join onto the client clock. */
+  t0Epoch: number;
+  sessionRowMs: number | null;
+  sandboxRowMs: number | null;
+  provisionMarks: { label: string; atMs: number; deltaMs: number }[] | null;
+  provisionStartMs: number | null;
+  error?: string;
+}
+
+function api(path: string, init?: RequestInit) {
+  return fetch(`${API}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${TOKEN}`,
+      ...init?.headers,
+    },
+    signal: AbortSignal.timeout(120_000),
+  });
+}
+
+/** One boot, fully attributed. Never throws — a failed boot is recorded as one. */
+async function measureBoot(round: number): Promise<Boot> {
+  const boot: Boot = {
+    label: LABEL, round, sessionId: null, provider: null, agent: null, slug: null,
+    externalId: null, apiCreateMs: null, vmCreatedMs: null,
+    daemonReachableMs: null, runtimeReadyMs: null, bootTimeline: null,
+    t0Epoch: Date.now(), sessionRowMs: null, sandboxRowMs: null,
+    provisionMarks: null, provisionStartMs: null,
+  };
+  const t0 = performance.now();
+  const at = () => Math.round(performance.now() - t0);
+
+  try {
+    const body: Record<string, unknown> = {};
+    if (AGENT) body.agent = AGENT;
+    if (SLUG) body.sandbox_slug = SLUG;
+    const res = await api(`/v1/projects/${PROJECT}/sessions`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    boot.apiCreateMs = at();
+    const created: any = await res.json().catch(() => null);
+    if (!res.ok) throw new Error(`create ${res.status}: ${JSON.stringify(created).slice(0, 300)}`);
+    boot.sessionId = created?.session_id ?? created?.id ?? null;
+    if (!boot.sessionId) throw new Error(`create returned no session id: ${JSON.stringify(created).slice(0, 300)}`);
+    boot.provider = created?.sandbox_provider ?? null;
+    boot.agent = created?.agent_name ?? null;
+    boot.slug = created?.metadata?.sandbox_slug ?? null;
+
+    // The health poll runs concurrently with the session poll: the guest is
+    // already booting while the host is still finishing its bookkeeping, so
+    // serializing the two would fold host writes into the in-guest numbers.
+    let healthPolling: Promise<void> | null = null;
+    const pollHealth = async (eid: string) => {
+      while (performance.now() - t0 < TIMEOUT_MS) {
+        try {
+          const h = await fetch(`${API}/v1/p/${eid}/8000/kortix/health`, {
+            headers: { Authorization: `Bearer ${TOKEN}` },
+            signal: AbortSignal.timeout(10_000),
+          });
+          if (h.ok) {
+            if (boot.daemonReachableMs === null) boot.daemonReachableMs = at();
+            const hb: any = await h.json().catch(() => null);
+            if (hb?.boot_timeline) boot.bootTimeline = hb.boot_timeline;
+            if (hb?.runtimeReady) { boot.runtimeReadyMs = at(); return; }
+          }
+        } catch { /* daemon not up yet */ }
+        await sleep(200);
+      }
+    };
+
+    while (performance.now() - t0 < TIMEOUT_MS) {
+      const r = await api(`/v1/projects/${PROJECT}/sessions/${boot.sessionId}`);
+      const s: any = await r.json().catch(() => null);
+      if (s?.status === 'error') throw new Error(`session error: ${s?.error ?? 'unknown'}`);
+      const url: string | null = s?.sandbox_url ?? null;
+      if (url && boot.vmCreatedMs === null) {
+        boot.vmCreatedMs = at();
+        // sandbox_url = `${API}/v1/p/<external_id>/8000`
+        boot.externalId = url.split('/v1/p/')[1]?.split('/')[0] ?? null;
+        if (boot.externalId) healthPolling = pollHealth(boot.externalId);
+      }
+      if (boot.runtimeReadyMs !== null) break;
+      if (healthPolling) { await healthPolling; break; }
+      await sleep(250);
+    }
+    if (healthPolling) await healthPolling;
+    if (boot.runtimeReadyMs === null) boot.error ??= 'timeout before runtimeReady';
+  } catch (err) {
+    boot.error = err instanceof Error ? err.message : String(err);
+  } finally {
+    if (sqlDb && boot.sessionId) {
+      try {
+        const [row] = await sqlDb`
+          select s.created_at as sess_created,
+                 b.created_at as sbx_created,
+                 b.metadata->'provisionTimeline' as tl
+          from kortix.project_sessions s
+          left join kortix.session_sandboxes b on b.sandbox_id::text = s.session_id::text
+          where s.session_id::text = ${boot.sessionId} limit 1`;
+        if (row) {
+          const rel = (d: Date | string | null) => (d ? new Date(d).getTime() - boot.t0Epoch : null);
+          boot.sessionRowMs = rel(row.sess_created);
+          boot.sandboxRowMs = rel(row.sbx_created);
+          boot.provisionMarks = row.tl?.marks ?? null;
+          // The provision timeline is relative to its own start, which the row
+          // does not store. The sandbox row is inserted inside the provision
+          // call, so its created_at is the tightest anchor available.
+          boot.provisionStartMs = boot.sandboxRowMs;
+        }
+      } catch (err) {
+        console.error(`  (db harvest failed: ${err instanceof Error ? err.message : err})`);
+      }
+    }
+    if (boot.sessionId && !KEEP) {
+      await api(`/v1/projects/${PROJECT}/sessions/${boot.sessionId}`, { method: 'DELETE' }).catch(() => {});
+    }
+  }
+  return boot;
+}
+
+function stat(values: number[]): string {
+  const ok = values.filter((v) => Number.isFinite(v));
+  if (!ok.length) return '—';
+  const s = [...ok].sort((a, b) => a - b);
+  const p = (q: number) => s[Math.min(s.length - 1, Math.floor(q * s.length))];
+  return `min ${(s[0] / 1000).toFixed(1)}s  p50 ${(p(0.5) / 1000).toFixed(1)}s  max ${(s[s.length - 1] / 1000).toFixed(1)}s`;
+}
+
+const boots: Boot[] = [];
+for (let round = 1; round <= ROUNDS; round++) {
+  const b = await measureBoot(round);
+  boots.push(b);
+  const ready = b.runtimeReadyMs === null ? 'FAILED' : `${(b.runtimeReadyMs / 1000).toFixed(1)}s`;
+  console.error(
+    `[${LABEL}] round ${round}/${ROUNDS}  ready ${ready}  provider ${b.provider}  agent ${b.agent}  slug ${b.slug}` +
+      (b.error ? `  error: ${b.error}` : ''),
+  );
+}
+
+console.error(`\n── ${LABEL} · ${boots.length} boots · ${API} ─────────────`);
+const col = (pick: (b: Boot) => number | null) => stat(boots.map((b) => pick(b) ?? NaN));
+console.error(`  api_create        ${col((b) => b.apiCreateMs)}`);
+console.error(`  vm_created        ${col((b) => b.vmCreatedMs)}`);
+console.error(`  daemon_reachable  ${col((b) => b.daemonReachableMs)}`);
+console.error(`  runtime_ready     ${col((b) => b.runtimeReadyMs)}`);
+
+// In-guest stage marks, daemon-start-relative. Union of labels across boots so a
+// boot that skipped a stage does not silently drop it from the table.
+const labels: string[] = [];
+for (const b of boots) for (const m of b.bootTimeline ?? []) if (!labels.includes(m.label)) labels.push(m.label);
+if (labels.length) {
+  console.error(`\n  in-guest (daemon start = 0):`);
+  for (const l of labels) {
+    const vals = boots.map((b) => b.bootTimeline?.find((m) => m.label === l)?.atMs ?? NaN);
+    console.error(`    ${l.padEnd(30)} ${stat(vals)}`);
+  }
+}
+
+// One merged, t0-anchored timeline: host marks land where they actually
+// happened on the client clock, so "3s of api_create" stops being opaque.
+if (sqlDb) {
+  const hostLabels: string[] = [];
+  for (const b of boots) for (const m of b.provisionMarks ?? []) if (!hostLabels.includes(m.label)) hostLabels.push(m.label);
+  if (hostLabels.length) {
+    console.error(`\n  host provision (t0-anchored):`);
+    console.error(`    ${'session-row-inserted'.padEnd(30)} ${stat(boots.map((b) => b.sessionRowMs ?? NaN))}`);
+    console.error(`    ${'sandbox-row-inserted'.padEnd(30)} ${stat(boots.map((b) => b.sandboxRowMs ?? NaN))}`);
+    for (const l of hostLabels) {
+      const vals = boots.map((b) => {
+        const m = b.provisionMarks?.find((x) => x.label === l);
+        return m && b.provisionStartMs !== null ? b.provisionStartMs + m.atMs : NaN;
+      });
+      console.error(`    ${`provision:${l}`.padEnd(30)} ${stat(vals)}`);
+    }
+  }
+}
+
+const out = process.env.BENCH_OUT;
+if (out) {
+  writeFileSync(out, JSON.stringify({ api: API, project: PROJECT, label: LABEL, boots }, null, 2));
+  console.error(`\nwrote ${out}`);
+}
+console.log(JSON.stringify({ api: API, project: PROJECT, label: LABEL, boots }));

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -61,6 +61,7 @@ import {
 import { isWarmProjectSession } from '../lib/warm-sessions';
 import { dropWarmSessionMarkerOnAdopt } from './warm-sessions';
 import { refreshCrTips } from './shared';
+import { ProvisionTimeline } from '../../platform/services/provision-timeline';
 
 // POST /v1/projects/:projectId/sessions/:sessionId/start
 // THE unified session-open endpoint. One idempotent call that provisions a
@@ -91,12 +92,18 @@ projectsApp.openapi(
     // Floor 'session' (= project.session.start) so the human gate matches
     // restart/stop and a custom role that withholds session.start is denied here
     // (was 'read', which let any project-reader start sessions).
+    // Every millisecond here is in front of the provider call, so a resume can
+    // never be faster than this prologue. Instrumented for the same reason
+    // provisioning is: without per-step marks, "start is slow" is unactionable.
+    const stl = new ProvisionTimeline(sessionId, 'session-start');
     const loaded = await loadProjectForUser(c, projectId, 'session');
+    stl.mark('project-loaded');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     // Per-agent gate: resuming a session provisions compute. A scoped agent
     // token must hold project.session.start (no-op for human/PAT tokens).
     assertAgentScope(c, PROJECT_ACTIONS.PROJECT_SESSION_START);
     const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null, callerKortixSessionId(c));
+    stl.mark('session-loaded');
     if (!visible) return c.json({ error: 'Not found' }, 404);
     // The agent this session will actually run has to still be one the caller
     // may run — grants change after a session is created, and `/start` is what
@@ -104,6 +111,7 @@ projectsApp.openapi(
     // may also be the `default` sentinel, which resolves here to the manifest
     // default rather than being waved through unchecked.
     await resolveAndAuthorizeAgent(c, loaded, projectId, null, visible.row.agentName);
+    stl.mark('agent-authorized');
 
     // Adoption (JAY-599/T21): a still-warm row (pre-created, never prompted)
     // stops being speculative the instant a user's tab calls /start on it —
@@ -113,10 +121,12 @@ projectsApp.openapi(
     // resume that follows.
     if (isWarmProjectSession(visible.row.metadata)) {
       await dropWarmSessionMarkerOnAdopt(sessionId);
+      stl.mark('warm-adopted');
     }
 
     // Same gate as wake/create: resuming or provisioning spends compute.
     const billing = await checkBillingActive(loaded.row.accountId);
+    stl.mark('billing-checked');
     if (!billing.ok) {
       return c.json(
         {
@@ -148,6 +158,8 @@ projectsApp.openapi(
       sessionId,
       waitMs,
     });
+    stl.mark(`open-session:${result.start.stage}`);
+    stl.log({ waitMs });
     return c.json(
       {
         ...result.start,

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -828,8 +828,15 @@ export async function openSession(args: {
           externalId: row.externalId,
           metadata: row.metadata as Record<string, unknown> | null,
         },
-        // Already read one line above — do not buy it twice.
-        stoppedProviderStatus,
+        // Already read one line above — do not buy it twice. Withheld for
+        // 'removed': that status makes the wake fail INSTEAD of starting, and
+        // the fence is detached (`void`), so without its own `getStatus` await
+        // to defer it the failure write races — and beats — the row re-read
+        // three lines below. The caller would then serve the terminal cooldown
+        // payload for a box whose wake had only just been claimed, instead of
+        // `runtime_waking`. A removed box is a rare terminal path where one
+        // extra provider round trip buys nothing worth that.
+        stoppedProviderStatus === 'removed' ? null : stoppedProviderStatus,
       );
       const [resumed] = await db
         .select()

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -66,14 +66,22 @@ import {
  * open compute billing. A hard failure records a terminal cooldown payload, so
  * browser `/start` polling cannot create a provider retry storm.
  */
-export async function resumeStoppedSandbox(row: {
-  sandboxId: string;
-  sessionId: string;
-  accountId: string;
-  provider: string;
-  externalId: string | null;
-  metadata?: Record<string, unknown> | null;
-}): Promise<boolean> {
+export async function resumeStoppedSandbox(
+  row: {
+    sandboxId: string;
+    sessionId: string;
+    accountId: string;
+    provider: string;
+    externalId: string | null;
+    metadata?: Record<string, unknown> | null;
+  },
+  /**
+   * A provider status the caller already read, forwarded to the wake so it does
+   * not pay a second provider round trip for the same answer. See
+   * `executeClaimedRuntimeWake`'s `knownStatus`.
+   */
+  knownProviderStatus?: string | null,
+): Promise<boolean> {
   if (!row.externalId) return false;
   if (!(config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(row.provider)) return false;
 
@@ -138,6 +146,7 @@ export async function resumeStoppedSandbox(row: {
 
   const provider = getProvider(row.provider as SandboxProviderName);
   void executeClaimedRuntimeWake({
+    knownStatus: knownProviderStatus ?? null,
     getStatus: () => provider.getStatus(externalId),
     start: () => provider.start(externalId),
     stop: () => provider.stop(externalId),
@@ -810,14 +819,18 @@ export async function openSession(args: {
       .getStatus(row.externalId)
       .catch(() => 'unknown' as const);
     if (stoppedProviderStatus !== 'removed' || !provider.recoverInPlace) {
-      await resumeStoppedSandbox({
-        sandboxId: row.sandboxId,
-        sessionId: row.sessionId,
-        accountId: row.accountId,
-        provider: row.provider,
-        externalId: row.externalId,
-        metadata: row.metadata as Record<string, unknown> | null,
-      });
+      await resumeStoppedSandbox(
+        {
+          sandboxId: row.sandboxId,
+          sessionId: row.sessionId,
+          accountId: row.accountId,
+          provider: row.provider,
+          externalId: row.externalId,
+          metadata: row.metadata as Record<string, unknown> | null,
+        },
+        // Already read one line above — do not buy it twice.
+        stoppedProviderStatus,
+      );
       const [resumed] = await db
         .select()
         .from(sessionSandboxes)

--- a/apps/api/src/projects/session-lifecycle/runtime-wake-fence.test.ts
+++ b/apps/api/src/projects/session-lifecycle/runtime-wake-fence.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   executeClaimedRuntimeWake,
   runtimeWakeInProgress,
+  runtimeWakePollDelayMs,
   waitForRuntimeWakeRunning,
 } from './runtime-wake-fence';
 
@@ -174,4 +175,120 @@ test('runtimeWakeInProgress uses the durable lease expiry', () => {
       now,
     ),
   ).toBe(true);
+});
+
+// ── Latency: the resume path must not buy the same answer twice, and must not
+// sit on an already-running VM waiting out a flat poll tick. ───────────────
+describe('wake latency', () => {
+  test('knownStatus skips the pre-start provider round trip entirely', async () => {
+    let statusCalls = 0;
+    let started = 0;
+    const result = await executeClaimedRuntimeWake({
+      knownStatus: 'stopped',
+      getStatus: async () => {
+        statusCalls += 1;
+        return 'running';
+      },
+      start: async () => {
+        started += 1;
+      },
+      stop: async () => {},
+      finalize: async () => true,
+      fail: async () => true,
+      claimState: async () => 'owned',
+      waitOptions: { graceMs: 3_000, pollMs: 1, sleep: async () => {} },
+    });
+
+    expect(result).toBe('running');
+    expect(started).toBe(1);
+    // Exactly one — the confirmation poll. The pre-check is gone, not merely
+    // faster: a second call here is the regression this test exists to catch.
+    expect(statusCalls).toBe(1);
+  });
+
+  test('a knownStatus of running finalizes without starting or polling at all', async () => {
+    let statusCalls = 0;
+    let started = 0;
+    const result = await executeClaimedRuntimeWake({
+      knownStatus: 'running',
+      getStatus: async () => {
+        statusCalls += 1;
+        return 'running';
+      },
+      start: async () => {
+        started += 1;
+      },
+      stop: async () => {},
+      finalize: async () => true,
+      fail: async () => true,
+      claimState: async () => 'owned',
+    });
+
+    expect(result).toBe('running');
+    expect(started).toBe(0);
+    expect(statusCalls).toBe(0);
+  });
+
+  test('omitting knownStatus preserves the original pre-check', async () => {
+    let statusCalls = 0;
+    const result = await executeClaimedRuntimeWake({
+      getStatus: async () => {
+        statusCalls += 1;
+        return 'running';
+      },
+      start: async () => {},
+      stop: async () => {},
+      finalize: async () => true,
+      fail: async () => true,
+      claimState: async () => 'owned',
+    });
+
+    expect(result).toBe('running');
+    expect(statusCalls).toBe(1);
+  });
+
+  test('the poll ramp checks early, then decays to the flat steady cadence', () => {
+    expect(runtimeWakePollDelayMs(0)).toBe(150);
+    expect(runtimeWakePollDelayMs(1)).toBe(250);
+    expect(runtimeWakePollDelayMs(2)).toBe(400);
+    expect(runtimeWakePollDelayMs(3)).toBe(600);
+    expect(runtimeWakePollDelayMs(4)).toBe(1_000);
+    expect(runtimeWakePollDelayMs(50)).toBe(1_000);
+    // The ramp must never spend more than the flat poll it replaced, or a slow
+    // wake pays more provider calls than before.
+    for (let i = 0; i < 4; i += 1) expect(runtimeWakePollDelayMs(i)).toBeLessThan(1_000);
+  });
+
+  test('a VM that comes up mid-ramp is caught by the first short delay', async () => {
+    const statuses = ['stopped', 'running'];
+    let calls = 0;
+    const slept: number[] = [];
+    const running = await waitForRuntimeWakeRunning(
+      async () => statuses[calls++] ?? 'running',
+      { graceMs: 90_000, sleep: async (ms) => { slept.push(ms); } },
+    );
+    expect(running).toBe(true);
+    expect(slept).toEqual([150]);
+  });
+
+  test('the ramp still honours the grace budget as a deadline', async () => {
+    let clock = 0;
+    let calls = 0;
+    const running = await waitForRuntimeWakeRunning(
+      async () => {
+        calls += 1;
+        return 'stopped';
+      },
+      {
+        graceMs: 500,
+        sleep: async (ms) => {
+          clock += ms;
+        },
+      },
+    );
+    expect(running).toBe(false);
+    // 150 + 250 fits inside 500ms; the 400 that would overrun is not slept.
+    expect(clock).toBe(400);
+    expect(calls).toBe(3);
+  });
 });

--- a/apps/api/src/projects/session-lifecycle/runtime-wake-fence.ts
+++ b/apps/api/src/projects/session-lifecycle/runtime-wake-fence.ts
@@ -12,7 +12,18 @@ export const RUNTIME_WAKE_LEASE_MS = 240_000;
 export const RUNTIME_WAKE_CLEANUP_LEASE_MS = 180_000;
 export const RUNTIME_WAKE_RETRY_COOLDOWN_MS = 120_000;
 export const RUNTIME_WAKE_LATE_START_GUARD_MS = 15 * 60_000;
+// Wake-poll cadence. A Platinum CoW resume reaches `running` in ~1.9s
+// (measured 3/3: 1918/1906/2391ms), so a flat 1000ms poll spent up to a full
+// second sitting on an already-running VM. The ramp checks early where the
+// answer actually changes, then decays to the old flat second so a slow or
+// stuck wake costs no more provider calls than before across the 90s grace.
+const RUNTIME_WAKE_POLL_RAMP_MS = [150, 250, 400, 600] as const;
 const RUNTIME_WAKE_POLL_MS = 1_000;
+
+/** Delay before the (attempt+1)-th status re-check. */
+export function runtimeWakePollDelayMs(attempt: number, steadyMs: number = RUNTIME_WAKE_POLL_MS): number {
+  return RUNTIME_WAKE_POLL_RAMP_MS[attempt] ?? steadyMs;
+}
 
 export async function waitForRuntimeWakeRunning(
   getStatus: () => Promise<string>,
@@ -23,17 +34,28 @@ export async function waitForRuntimeWakeRunning(
   } = {},
 ): Promise<boolean> {
   const graceMs = Math.max(0, opts.graceMs ?? RUNTIME_WAKE_GRACE_MS);
-  const pollMs = Math.max(1, opts.pollMs ?? RUNTIME_WAKE_POLL_MS);
-  const attempts = Math.max(1, Math.ceil(graceMs / pollMs));
+  // An explicit pollMs pins the cadence flat (tests, and any caller that wants
+  // the old behaviour); otherwise the ramp above runs.
+  const steadyMs = Math.max(1, opts.pollMs ?? RUNTIME_WAKE_POLL_MS);
+  const ramped = opts.pollMs === undefined;
   const sleep = opts.sleep ?? Bun.sleep;
 
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
+  // The budget counts the delays this loop ITSELF schedules, not wall-clock.
+  // With a variable delay an attempt count is no longer a stand-in for the
+  // grace, but reading a clock instead would make the loop spin under an
+  // injected no-op sleep. Accumulating the scheduled delay is deterministic
+  // under a fake sleep and reduces to the old `ceil(grace / poll)` attempt
+  // count exactly when the cadence is flat.
+  let scheduledMs = 0;
+  for (let attempt = 0; ; attempt += 1) {
     const status = await getStatus().catch(() => 'unknown');
     if (status === 'running') return true;
     if (status === 'removed') return false;
-    if (attempt + 1 < attempts) await sleep(pollMs);
+    const delay = ramped ? runtimeWakePollDelayMs(attempt, steadyMs) : steadyMs;
+    if (scheduledMs + delay >= graceMs) return false;
+    scheduledMs += delay;
+    await sleep(delay);
   }
-  return false;
 }
 
 export function runtimeWakeInProgress(
@@ -92,8 +114,23 @@ export async function executeClaimedRuntimeWake(input: {
   claimState: () => Promise<'owned' | 'delegated' | 'cancelled'>;
   isMissingError?: (error: unknown) => boolean;
   waitOptions?: Parameters<typeof waitForRuntimeWakeRunning>[1];
+  /**
+   * A provider status the caller ALREADY paid a round trip for, reused here
+   * instead of asking again.
+   *
+   * `openSession` reads `provider.getStatus()` immediately before claiming the
+   * wake (it has to: a `removed` box needs backup restoration, not a start).
+   * Re-reading it here cost a second full provider round trip on the critical
+   * path of every resume — measured ~0.5s against Platinum from the dev API,
+   * for an answer taken microseconds earlier. The status can only have gone
+   * stale in the caller's favour: a box that became `running` in that window is
+   * started again (idempotent, and the adapter already handles the 409), and a
+   * box that stopped harder is still started. Omit it and the pre-check runs as
+   * before.
+   */
+  knownStatus?: string | null;
 }): Promise<RuntimeWakeExecutionResult> {
-  let status = await input.getStatus().catch(() => 'unknown');
+  let status = input.knownStatus ?? (await input.getStatus().catch(() => 'unknown'));
   let startError: unknown = null;
 
   if (status !== 'running' && status !== 'removed') {


### PR DESCRIPTION
## Why

A meta-agent session resume on dev reaches `runtimeReady` in **5.9s** while the
VM itself is serving at **1.9s**. The gap is our control plane, not Platinum.

Measured trace (dev, platinum, t0 = just before `POST /start`):

| step | at |
|---|---|
| `/start` returned | 2.01s |
| platinum `state=running` | 4.01s |
| `providerRunningConfirmedAt` | 4.21s |
| row `status=active` | 4.83s |
| proxy health 200 | 5.90s |

Only **0.82s** of that is post-VM bookkeeping. Raw Platinum stop -> resume is
1.9s, consistent 3/3 (1918 / 1906 / 2391 ms). Resumed directly via the Platinum
API, the VM serves at 1.9s while our proxy 503s indefinitely (127 consecutive)
because the row still reads `stopped` — the proxy gates on the row, so every
millisecond before the row flips is user-visible latency.

Stop/resume is a true VM freeze, not a reboot: `opencode_pid` 147 survived three
cycles, `opencode_session_id` stayed identical, `uptime_s` kept counting, and
the guest `boot_timeline` still carried its original cold-boot marks. A resumed
meta agent answers a prompt normally.

## What changed

**1. One provider round trip removed from every resume.** `openSession` reads
`provider.getStatus()` before claiming the wake — it must, since a `removed` box
needs backup restoration rather than a start. `executeClaimedRuntimeWake` then
read it AGAIN as its first action. The dev API runs in us-west-2 and the VMs
report `region: eu-west`, so that was a second full Atlantic crossing for an
answer taken microseconds earlier. It is now forwarded as `knownStatus`. The
status can only be stale in our favour: a box that came up in that window is
started again, which is idempotent and already 409-handled by the adapter.

**2. The wake confirmation no longer sits on a flat tick.**
`waitForRuntimeWakeRunning` polled every 1000ms at a VM that reaches `running`
in ~1.9s, so confirmation could waste up to a full second. It now ramps
150/250/400/600ms before decaying to the old flat second, so a slow or stuck
wake costs no more provider calls than before across the 90s grace.

The grace budget now counts the delays the loop itself schedules instead of a
precomputed attempt count, which a variable cadence invalidates. Budgeting on
wall-clock instead would spin under an injected no-op sleep — the existing
"never reaches running" test catches exactly that, and did.

**3. `/start` is instrumented** with the same `ProvisionTimeline` the provision
path already uses. Every millisecond of that prologue sits in front of the
provider call, so a resume can never beat it, and "start is slow" is
unactionable without per-step marks.

**4. `scripts/bench-meta-boot.ts`** — boots real sessions against a deployed API
and attributes each one (api_create / vm_created / daemon_reachable /
runtime_ready) plus the in-guest `boot_timeline`, merging host provision marks
when `BENCH_DB_URL` is set. The client-side half needs no database access.

## Not done here, deliberately

Issuing `provider.start()` concurrently with the auth and billing checks would
cut ~1.9s and is wrong: it spends compute before establishing that the caller
may spend it. `openSession`'s "Gate browser polling before any provider call"
is load-bearing.

## Verification

- `runtime-wake-fence.test.ts` 15/15 (4 new: knownStatus skips the pre-check,
  a known `running` finalizes without starting, omitting it preserves the old
  behaviour, ramp shape + grace budget).
- `src/projects/session-lifecycle` 166/166.
- `tsc --noEmit` clean on the touched files.
- The 5 failures under `src/projects/routes` are pre-existing and reproduce
  identically with these changes stashed (Hono matcher collision when route
  files share one process).

Dev verification of the latency delta follows this merge, using the harness
added here.
