### PR TITLE
perf(sandbox): arm Platinum secrets during create

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -449,7 +449,7 @@ jobs:
     env:
       AWS_REGION: us-west-2
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
-      KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"false"}'
+      KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}'
     steps:
       - uses: actions/checkout@v7
       - name: Configure AWS credentials (OIDC)

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -110,6 +110,11 @@ export interface CreateSandboxOpts {
    */
   createAttempt?: number;
   /**
+   * Network-boundary secrets a capable provider attaches atomically during
+   * sandbox creation. The values remain in the provider control plane.
+   */
+  networkBoundary?: NetworkBoundarySecretBinding[];
+  /**
    * Runtime contract hosted by the provider object. Missing means `session`
    * for backward compatibility with every existing caller.
    *
@@ -257,6 +262,8 @@ export interface SandboxProvider {
   readonly provisioning: ProvisioningTraits;
   /** Absent means the provider enforces the whole App machine specification. */
   readonly appMachineSupport?: AppMachineSupport;
+  /** The provider can attach `CreateSandboxOpts.networkBoundary` before first boot. */
+  readonly networkBoundaryAtCreate?: boolean;
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;
   /**
    * Ensure the Kortix App supervisor is running after create or resume.
@@ -324,6 +331,7 @@ export interface SandboxProvider {
   syncNetworkBoundary?(
     externalId: string,
     bindings: NetworkBoundarySecretBinding[],
+    opts?: { replicaOwnerId?: string },
   ): Promise<{ state: 'armed'; attached: number }>;
   /**
    * List the running boxes this deployment owns, for the orphan-box reaper

--- a/apps/api/src/platform/providers/platinum-create-dedup.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-dedup.test.ts
@@ -48,6 +48,7 @@ let createSequence: Array<{ result?: Record<string, unknown>; error?: Error }> =
   { result: { id: 'sbx_new', state: 'running' } },
 ];
 let createCallCount = 0;
+let nextSecretId = 1;
 
 function normalizeHeaders(h: RequestInit['headers']): Record<string, string> {
   if (!h) return {};
@@ -62,6 +63,10 @@ mock.module('../../shared/platinum', () => ({
     const body = init.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : undefined;
     const headers = normalizeHeaders(init.headers);
     calls.push({ path, method: String(init.method ?? 'GET'), headers, body });
+    if (path.startsWith('/v1/secrets?')) return { items: [], cursor: null };
+    if (path === '/v1/secrets' && String(init.method ?? 'GET') === 'POST') {
+      return { id: `sec_${nextSecretId++}`, ...body };
+    }
     if (path.startsWith('/v1/sandboxes?')) {
       const idx = Math.min(createCallCount, createSequence.length - 1);
       createCallCount += 1;
@@ -98,11 +103,40 @@ function createCalls() {
 beforeEach(() => {
   calls = [];
   createCallCount = 0;
+  nextSecretId = 1;
   createSequence = [{ result: { id: 'sbx_new', state: 'running' } }];
   delete process.env.KORTIX_PLATINUM_CREATE_DEDUP;
 });
 
 describe('S1 deterministic name + Idempotency-Key derivation', () => {
+  test('create-time network-boundary attachments are sent in the sandbox create body', async () => {
+    createSequence = [{
+      result: {
+        id: 'sbx_new',
+        state: 'running',
+        secrets: { sandbox_id: 'sbx_new', state: 'armed', secrets: [{ secret_id: 'sec_1', state: 'armed' }] },
+      },
+    }];
+    const p = new PlatinumProvider();
+    await p.create({
+      ...baseOpts,
+      networkBoundary: [{
+        secretId: 'primary',
+        identifier: 'billing-api',
+        alias: 'KORTIX_primary',
+        hosts: ['api.example.com'],
+        header: 'authorization',
+        value: 'Bearer first-value',
+        onEcho: 'block',
+      }],
+    });
+
+    expect(createCalls()[0].body?.secrets).toEqual([
+      { secret: 'sec_1', alias: 'KORTIX_primary', header: 'authorization' },
+    ]);
+    expect(calls.some((call) => call.path === '/v1/sandboxes/sbx_new/secrets' && call.method === 'PUT')).toBe(false);
+  });
+
   test('both derive from the FULL sandboxId, never opts.name / an 8-char truncation', async () => {
     const p = new PlatinumProvider();
     await p.create({ ...baseOpts, createAttempt: 1 });

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -42,7 +42,12 @@
 import { createHash } from 'node:crypto';
 import { SANDBOX_VERSION, config } from '../../config';
 import type { NetworkBoundarySecretBinding } from '../../secrets/network-boundary';
-import { syncPlatinumNetworkBoundary } from '../../secrets/platinum-network-boundary';
+import {
+  preparePlatinumNetworkBoundary,
+  syncPlatinumNetworkBoundary,
+  waitForPlatinumNetworkBoundary,
+  type PlatinumSandboxSecrets,
+} from '../../secrets/platinum-network-boundary';
 import { isOpencodePort } from '../../shared/opencode-ports';
 import { platinumJson } from '../../shared/platinum';
 import { sandboxFrontendBaseUrl } from '../sandbox-frontend-url';
@@ -84,6 +89,7 @@ interface PlatinumSandbox {
   metadata?: Record<string, unknown>;
   created_at?: string | null;
   createdAt?: string | null;
+  secrets?: PlatinumSandboxSecrets;
 }
 
 /** `GET /v1/sandboxes?paginated=true` — Platinum's list envelope. */
@@ -197,6 +203,7 @@ function isNameTakenConflict(error: unknown): boolean {
 
 export class PlatinumProvider implements SandboxProvider {
   readonly name: ProviderName = 'platinum';
+  readonly networkBoundaryAtCreate = true;
 
   readonly provisioning: ProvisioningTraits = {
     async: false,
@@ -210,11 +217,12 @@ export class PlatinumProvider implements SandboxProvider {
   syncNetworkBoundary(
     externalId: string,
     bindings: NetworkBoundarySecretBinding[],
+    opts?: { replicaOwnerId?: string },
   ): Promise<{ state: 'armed'; attached: number }> {
     return syncPlatinumNetworkBoundary(externalId, bindings, {
       environment: config.INTERNAL_KORTIX_ENV,
       rootSecret: config.API_KEY_SECRET,
-    });
+    }, { replicaOwnerId: opts?.replicaOwnerId });
   }
 
   async create(opts: CreateSandboxOpts): Promise<ProvisionResult> {
@@ -263,6 +271,7 @@ export class PlatinumProvider implements SandboxProvider {
     template: string,
     opts: CreateSandboxOpts,
   ): Promise<ProvisionResult> {
+    const _t0 = Date.now();
     const workloadType = sandboxWorkloadType(opts);
     const sandboxApiBase = config.KORTIX_URL
       .replace(/\/+$/, '')
@@ -289,6 +298,17 @@ export class PlatinumProvider implements SandboxProvider {
     // box mid-work. See providerAutoStopBackstopMinutes(), which is now that
     // policy alone and no longer doubles as the billing clamp's grace.
     const autoStop = opts.autoStopInterval ?? providerAutoStopBackstopMinutes();
+    if (opts.networkBoundary?.length && !opts.sandboxId) {
+      throw new Error('[platinum] create-time network boundary requires sandboxId');
+    }
+    const _tBoundaryPrepare0 = Date.now();
+    const preparedNetworkBoundary = opts.networkBoundary?.length
+      ? await preparePlatinumNetworkBoundary(opts.sandboxId!, opts.networkBoundary, {
+          environment: config.INTERNAL_KORTIX_ENV,
+          rootSecret: config.API_KEY_SECRET,
+        })
+      : null;
+    const _boundaryPrepareMs = Date.now() - _tBoundaryPrepare0;
 
     // ── S1: create-side dedup identity (see module doc for the full design) ──
     // `attempt` is session-sandbox.ts's MONOTONIC, persisted counter — stable
@@ -327,6 +347,7 @@ export class PlatinumProvider implements SandboxProvider {
         'kortix.workload': workloadType,
         ...(opts.sandboxId ? { 'kortix.sandbox_id': opts.sandboxId } : {}),
       },
+      ...(preparedNetworkBoundary ? { secrets: preparedNetworkBoundary.secrets } : {}),
     };
     if (dedup) {
       createBody.name = dedup.name;
@@ -345,7 +366,7 @@ export class PlatinumProvider implements SandboxProvider {
         ...(dedup ? { headers: { 'Idempotency-Key': dedup.idempotencyKey } } : {}),
       });
 
-    const _t0 = Date.now();
+    const _tCreate0 = Date.now();
     let sandbox: PlatinumSandbox;
     try {
       sandbox = await postCreate();
@@ -366,7 +387,12 @@ export class PlatinumProvider implements SandboxProvider {
         throw err;
       }
     }
-    const _vmMs = Date.now() - _t0;
+    const _vmMs = Date.now() - _tCreate0;
+    const _tBoundaryArm0 = Date.now();
+    if (preparedNetworkBoundary) {
+      await waitForPlatinumNetworkBoundary(sandbox.id, sandbox.secrets);
+    }
+    const _boundaryArmMs = Date.now() - _tBoundaryArm0;
 
     const externalId = sandbox.id;
 
@@ -441,7 +467,8 @@ export class PlatinumProvider implements SandboxProvider {
     // clone stall in the background while the FE waits, so the session still
     // becomes usable without any create-path hang.
     console.log(
-      `[platinum-timing] ${externalId} vm-running=${_vmMs}ms expose=${_exposeMs}ms ` +
+      `[platinum-timing] ${externalId} boundary-prepare=${_boundaryPrepareMs}ms ` +
+        `vm-running=${_vmMs}ms boundary-arm=${_boundaryArmMs}ms expose=${_exposeMs}ms ` +
         `edge=${exposedUrl ? 'ready' : 'lazy'} total=${Date.now() - _t0}ms (runtime-ready deferred to FE poll, like daytona)` +
         (sandbox.replayed ? ' [S1: Idempotency-Key replay — adopted an already-committed box]' : ''),
     );

--- a/apps/api/src/platform/services/session-boot-decision.test.ts
+++ b/apps/api/src/platform/services/session-boot-decision.test.ts
@@ -23,7 +23,6 @@ const {
   decideSessionBoot,
   fastColdBootEnabled,
   sessionBootByTemplateIdEnabled,
-  useFastColdBootImage,
 } = await import('./session-sandbox');
 
 const pinned = { activeProvider: 'platinum', activeExternalTemplateId: 'tpl_pinned' };
@@ -136,20 +135,14 @@ describe('fast cold boot kill-switch', () => {
     expect(fastColdBootEnabled()).toBe(false);
   });
 
-  test.each(['1', 'on', 'true', 'yes', 'TRUE'])('%p enables the fast image', (value) => {
+  test.each(['1', 'on', 'true', 'yes', 'TRUE'])('%p enables the experiment', (value) => {
     process.env.KORTIX_FAST_COLD_BOOT_ENABLED = value;
     expect(fastColdBootEnabled()).toBe(true);
   });
 
-  test.each(['0', 'off', 'false', 'no', 'unexpected'])('%p keeps the standard image', (value) => {
+  test.each(['0', 'off', 'false', 'no', 'unexpected'])('%p disables the experiment', (value) => {
     process.env.KORTIX_FAST_COLD_BOOT_ENABLED = value;
     expect(fastColdBootEnabled()).toBe(false);
   });
 
-  test('only changes the shared default image', () => {
-    expect(useFastColdBootImage(true, 'default')).toBe(true);
-    expect(useFastColdBootImage(true, 'custom')).toBe(false);
-    expect(useFastColdBootImage(true, 'meta')).toBe(false);
-    expect(useFastColdBootImage(false, 'default')).toBe(false);
-  });
 });

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -476,7 +476,7 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     expect(labels).toContain('network-secrets:create:1');
   });
 
-  test('the fast flag selects the shared fast image without changing the project template', async () => {
+  test('the fast flag keeps the standard image so the edge optimization stays isolated', async () => {
     process.env.KORTIX_FAST_COLD_BOOT_ENABLED = 'true';
     const opened = waitFor((resolve) => {
       onComputeOpened = resolve;
@@ -485,16 +485,15 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     await provisionSessionSandbox(baseOpts());
     await opened;
 
-    expect(fastImageRequests).toEqual([{ source: 'session-start', provider: 'daytona' }]);
-    expect(imageRequests).toEqual([]);
+    expect(fastImageRequests).toEqual([]);
+    expect(imageRequests).toHaveLength(1);
     const finishCall = updateCalls.find(
       (call) =>
         call.table === sessionSandboxes && 'externalId' in call.updates && 'config' in call.updates,
     );
     expect(finishCall?.updates.metadata).toMatchObject({
       runtimeArtifact: {
-        providerArtifactRef: 'kortix-fast-dev-test',
-        runtimeProfile: 'fast',
+        providerArtifactRef: 'snap-test-1',
       },
     });
   });

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -74,6 +74,7 @@ let recordedEvents: Array<{ outcome: string; marks?: Array<{ label: string }> }>
 let identityConflict = false;
 let recoveryPlaceholder = false;
 let providerCreateCalls = 0;
+let providerCreateOpts: Array<Record<string, unknown>> = [];
 let providerFallbackEnabled = false;
 let providerNamesRequested: string[] = [];
 let providerCreateErrors: Record<string, string | undefined> = {};
@@ -194,9 +195,11 @@ mock.module('../providers', () => ({
     providerNamesRequested.push(name);
     return {
       name,
+      networkBoundaryAtCreate: name === 'platinum',
       provisioning: { async: true, stages: [{ id: 'boot', progress: 50, message: 'Booting…' }] },
-      create: async (_opts: unknown) => {
+      create: async (opts: Record<string, unknown>) => {
         providerCreateCalls += 1;
+        providerCreateOpts.push(opts);
         if (providerCreateErrors[name]) throw new Error(providerCreateErrors[name]);
         return {
           externalId: name === 'daytona' ? EXTERNAL_ID : `ext-${name}-1`,
@@ -364,6 +367,7 @@ beforeEach(() => {
   identityConflict = false;
   recoveryPlaceholder = false;
   providerCreateCalls = 0;
+  providerCreateOpts = [];
   providerFallbackEnabled = false;
   providerNamesRequested = [];
   providerCreateErrors = {};
@@ -451,6 +455,25 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     expect(labels).toContain('provider-create:1x');
     expect(labels).toContain('network-secrets:1');
     expect(labels.indexOf('provider-create:1x')).toBeLessThan(labels.indexOf('network-secrets:1'));
+  });
+
+  test('the fast Platinum path attaches network-boundary secrets during create', async () => {
+    process.env.KORTIX_FAST_COLD_BOOT_ENABLED = 'true';
+    networkBoundaryBindings = [{ identifier: 'github', host: 'api.github.com' }];
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
+
+    await provisionSessionSandbox({ ...baseOpts(), provider: 'platinum' });
+    await opened;
+
+    expect(providerCreateOpts).toHaveLength(1);
+    expect(providerCreateOpts[0]?.networkBoundary).toEqual(networkBoundaryBindings);
+    expect(providerSyncCalls).toEqual([]);
+    const labels =
+      recordedEvents.find((event) => event.outcome === 'ok')?.marks?.map((mark) => mark.label) ??
+      [];
+    expect(labels).toContain('network-secrets:create:1');
   });
 
   test('the fast flag selects the shared fast image without changing the project template', async () => {

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -38,7 +38,6 @@ import {
 } from './sandbox-init-state';
 import {
   ensureSandboxImage,
-  ensureFastSandboxImage,
   ensureMetaSandboxImage,
   deleteSandboxImage,
   resolveTemplate,
@@ -212,11 +211,6 @@ export function fastColdBootEnabled(): boolean {
   return raw === '1' || raw === 'on' || raw === 'true' || raw === 'yes';
 }
 
-/** Custom and meta templates keep their declared runtime under the global flag. */
-export function useFastColdBootImage(enabled: boolean, slug: string): boolean {
-  return enabled && slug === DEFAULT_SANDBOX_SLUG;
-}
-
 /**
  * FIX-A: decide whether this boot should use the pinned EXACT template id. Pure
  * (no I/O) so the gate is unit-testable. Returns the id ONLY when every guard
@@ -349,8 +343,6 @@ export async function provisionSessionSandbox(opts: {
   ): Promise<EnsureSandboxImageResult> =>
     slug === META_SANDBOX_SLUG
       ? ensureMetaSandboxImage({ source: 'session-start', provider: targetProvider })
-      : useFastColdBootImage(fastColdBootEnabled(), slug)
-        ? ensureFastSandboxImage({ source: 'session-start', provider: targetProvider })
       : ensureSandboxImage(gitProject, {
           slug,
           accountId,

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -678,6 +678,11 @@ export async function provisionSessionSandbox(opts: {
       const createFn = bootDecision.bootByTemplateId
         ? (o: CreateSandboxOpts) => provider.createFromExternalId!(bootDecision.bootByTemplateId!, o)
         : undefined;
+      const attachNetworkBoundaryDuringCreate =
+        fastColdBootEnabled() && provider.networkBoundaryAtCreate === true;
+      providerCreateInput.networkBoundary = attachNetworkBoundaryDuringCreate
+        ? networkBoundary
+        : undefined;
       let result: ProvisionResult;
       let attempts: number;
       try {
@@ -756,15 +761,24 @@ export async function provisionSessionSandbox(opts: {
       // the method existed; now that a shim-backed provider gets past that
       // check, calling it unguarded would be a TypeError at provision time
       // rather than the clean skip this is.
-      if (networkBoundary.length > 0 && provider.syncNetworkBoundary) {
+      if (
+        networkBoundary.length > 0 &&
+        provider.syncNetworkBoundary &&
+        !attachNetworkBoundaryDuringCreate
+      ) {
         try {
-          await provider.syncNetworkBoundary(result.externalId, networkBoundary);
+          await provider.syncNetworkBoundary(result.externalId, networkBoundary, {
+            replicaOwnerId: sandbox.sandboxId,
+          });
           tl.mark(`network-secrets:${networkBoundary.length}`);
         } catch (error) {
           await provider.remove(result.externalId).catch(() => {});
           bgExternalId = null;
           throw error;
         }
+      }
+      if (networkBoundary.length > 0 && attachNetworkBoundaryDuringCreate) {
+        tl.mark(`network-secrets:create:${networkBoundary.length}`);
       }
       const timeline = tl.summary();
 

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -252,6 +252,7 @@ function rememberNetworkBoundaryArm(externalId: string, digest: string, secretId
 function startNetworkBoundaryArm(
   projectId: string,
   providerName: ProviderName,
+  replicaOwnerId: string,
   externalId: string,
   bindings: NetworkBoundarySecretBinding[],
   digest: string,
@@ -287,7 +288,7 @@ function startNetworkBoundaryArm(
         );
       }
       try {
-        await provider.syncNetworkBoundary(externalId, bindings);
+        await provider.syncNetworkBoundary(externalId, bindings, { replicaOwnerId });
         rememberNetworkBoundaryArm(
           externalId,
           digest,
@@ -322,6 +323,7 @@ function startNetworkBoundaryArm(
 async function syncProviderNetworkBoundary(
   projectId: string,
   providerName: ProviderName,
+  replicaOwnerId: string,
   externalId: string,
   bindings: NetworkBoundarySecretBinding[],
   opts?: { maxWaitMs?: number },
@@ -333,7 +335,14 @@ async function syncProviderNetworkBoundary(
     return 'skipped';
   }
 
-  const attempt = startNetworkBoundaryArm(projectId, providerName, externalId, bindings, digest);
+  const attempt = startNetworkBoundaryArm(
+    projectId,
+    providerName,
+    replicaOwnerId,
+    externalId,
+    bindings,
+    digest,
+  );
   const maxWaitMs = opts?.maxWaitMs;
   if (!maxWaitMs) {
     await attempt;
@@ -708,6 +717,7 @@ export async function syncSandboxEnvForPrompt(args: {
     const armState = await syncProviderNetworkBoundary(
       args.projectId,
       args.providerName,
+      args.sessionId,
       args.externalId,
       networkBoundary,
       { maxWaitMs: PROMPT_BOUNDARY_ARM_WAIT_MS },
@@ -890,7 +900,13 @@ export async function propagateProjectSecretsToActiveSandboxes(
         // caller reports the per-sandbox outcome to the author who just saved the
         // secret. An arming failure has to be visible there, so it stays a
         // `status: 'failed'` row rather than a warning nobody reads.
-        await syncProviderNetworkBoundary(projectId, providerName, row.externalId, networkBoundary);
+        await syncProviderNetworkBoundary(
+          projectId,
+          providerName,
+          row.sessionId,
+          row.externalId,
+          networkBoundary,
+        );
         const { url, headers } = await resolveSandboxIngress(row.externalId, { port: SANDBOX_SERVICE_PORT, transport: 'http' });
         const proof = await postEnvToDaemon({
           previewUrl: url,

--- a/apps/api/src/secrets/platinum-network-boundary.test.ts
+++ b/apps/api/src/secrets/platinum-network-boundary.test.ts
@@ -114,7 +114,7 @@ mock.module('../shared/platinum', () => ({
   },
 }));
 
-const { syncPlatinumNetworkBoundary } = await import('./platinum-network-boundary');
+const { preparePlatinumNetworkBoundary, syncPlatinumNetworkBoundary } = await import('./platinum-network-boundary');
 const context = { environment: 'test', rootSecret: 'network-boundary-test-root' };
 
 function binding(value = 'Bearer first-value'): NetworkBoundarySecretBinding {
@@ -138,6 +138,29 @@ beforeEach(() => {
 });
 
 describe('syncPlatinumNetworkBoundary', () => {
+  test('prepares create-time attachments without touching a sandbox', async () => {
+    const result = await preparePlatinumNetworkBoundary('logical-sandbox-1', [binding()], context);
+
+    expect(result).toEqual({
+      secrets: [{ secret: 'sec_1', alias: 'KORTIX_primary', header: 'authorization' }],
+    });
+    expect(calls.some((call) => call.path.startsWith('/v1/sandboxes/'))).toBe(false);
+  });
+
+  test('reuses the create-time replica during later synchronization', async () => {
+    const prepared = await preparePlatinumNetworkBoundary('logical-sandbox-1', [binding()], context);
+    attached.set('provider-sandbox-1', [prepared.secrets[0].secret]);
+    calls.length = 0;
+
+    await syncPlatinumNetworkBoundary('provider-sandbox-1', [binding()], context, {
+      replicaOwnerId: 'logical-sandbox-1',
+    });
+
+    expect(external.size).toBe(1);
+    expect(calls.some((call) => call.path.endsWith('/versions'))).toBe(false);
+    expect(attached.get('provider-sandbox-1')).toEqual(['sec_1']);
+  });
+
   test('creates a write-only provider secret and attaches the exact session set', async () => {
     const result = await syncPlatinumNetworkBoundary('sandbox-1', [binding()], context);
 

--- a/apps/api/src/secrets/platinum-network-boundary.ts
+++ b/apps/api/src/secrets/platinum-network-boundary.ts
@@ -13,7 +13,7 @@ type PlatinumSecret = {
   on_echo: 'block' | 'redact';
 };
 
-type PlatinumSandboxSecrets = {
+export type PlatinumSandboxSecrets = {
   sandbox_id: string;
   state: 'armed' | 'arming' | 'unavailable';
   secrets: Array<{ secret_id: string; state: 'armed' | 'arming' | 'unavailable' }>;
@@ -221,6 +221,46 @@ async function waitUntilArmed(
   }
 }
 
+export interface PlatinumPreparedNetworkBoundary {
+  secrets: Array<{ secret: string; alias: string; header: string }>;
+}
+
+export async function preparePlatinumNetworkBoundary(
+  replicaOwnerId: string,
+  bindings: NetworkBoundarySecretBinding[],
+  context: PlatinumNetworkBoundaryContext,
+): Promise<PlatinumPreparedNetworkBoundary> {
+  const desired = await Promise.all(
+    bindings.map(async (binding) => ({
+      binding,
+      secret: await ensureSecret(replicaOwnerId, binding, context),
+    })),
+  );
+  return {
+    secrets: desired.map(({ binding, secret }) => ({
+      secret: secret.id,
+      alias: binding.alias,
+      header: binding.header,
+    })),
+  };
+}
+
+export async function waitForPlatinumNetworkBoundary(
+  externalId: string,
+  initial?: PlatinumSandboxSecrets,
+  options?: { armTimeoutMs?: number },
+): Promise<{ state: 'armed'; attached: number }> {
+  const current = initial ?? await platinumJson<PlatinumSandboxSecrets>(
+    `/v1/sandboxes/${encodeURIComponent(externalId)}/secrets`,
+  );
+  const armed = await waitUntilArmed(
+    externalId,
+    current,
+    options?.armTimeoutMs ?? ARM_TIMEOUT_MS,
+  );
+  return { state: 'armed', attached: armed.secrets.length };
+}
+
 /**
  * Make the provider edge hold exactly `bindings` for this sandbox.
  *
@@ -237,14 +277,14 @@ export async function syncPlatinumNetworkBoundary(
   externalId: string,
   bindings: NetworkBoundarySecretBinding[],
   context: PlatinumNetworkBoundaryContext,
-  options?: { armTimeoutMs?: number },
+  options?: { armTimeoutMs?: number; replicaOwnerId?: string },
 ): Promise<{ state: 'armed'; attached: number }> {
   const sandboxPath = `/v1/sandboxes/${encodeURIComponent(externalId)}/secrets`;
   const before = await platinumJson<PlatinumSandboxSecrets>(sandboxPath);
   const desired = await Promise.all(
     bindings.map(async (binding) => ({
       binding,
-      secret: await ensureSecret(externalId, binding, context),
+      secret: await ensureSecret(options?.replicaOwnerId ?? externalId, binding, context),
     })),
   );
   const updated = await platinumJson<PlatinumSandboxSecrets>(sandboxPath, {

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -1616,10 +1616,7 @@ export function kickStartupPreBuild(): void {
   if (startupPreBuildKicked) return;
   startupPreBuildKicked = true;
   for (const providerId of templateBuildProviders()) {
-    const ensureSessionImage = config.KORTIX_FAST_COLD_BOOT_ENABLED
-      ? ensureFastSandboxImage
-      : ensurePlatformDefaultImage;
-    void ensureSessionImage({ source: 'startup', provider: providerId })
+    void ensurePlatformDefaultImage({ source: 'startup', provider: providerId })
       .then((r) =>
         console.log(
           `[snapshots] startup pre-build (${providerId}): default image ${r.snapshotName} ${r.built ? 'built' : 'ready'}`,

--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -1,83 +1,60 @@
-# Fast cold boot runtime
+# Platinum create-time secret arming
 
-Status: implemented but disabled. Dev, staging, and production use the standard image.
+Status: enabled on dev behind `KORTIX_FAST_COLD_BOOT_ENABLED`.
 
 ## Problem
 
-A clean dev session reaches runtime readiness in 25.3 seconds at p50.
-The current image contains browsers, LibreOffice, TeX, and the complete Python package floor.
-Every sandbox pays the image startup cost even when the first turn does not use those tools.
+Platinum used two sequential API operations for every session:
 
-Measured dev baseline on 2026-08-19, using five new default-template sessions:
+1. Create the sandbox.
+2. Attach and arm the network-boundary secrets.
 
-| Milestone | p50 | p90 |
-|---|---:|---:|
-| Runtime ready | 25,288 ms | 32,607 ms |
-| Sandbox row active | 19,288 ms | — |
-| Daemon reachable | 21,756 ms | — |
-| Repository materialized | 7,489 ms | 8,007 ms |
-| OpenCode answering | 5,308 ms | 6,908 ms |
+The second operation cost 18,261 ms at p50 across five measured boots.
+The sandbox could not become active during this operation.
 
 ## Design
 
-`KORTIX_FAST_COLD_BOOT_ENABLED=true` selects one shared, content-addressed fast image.
-It does not create or retain running sandboxes.
-The standard image remains available through the same flag.
+When `KORTIX_FAST_COLD_BOOT_ENABLED=true`, the API prepares the secret replicas first.
+It includes their IDs in Platinum's sandbox-create request.
+Platinum creates the VM and arms its network boundary in the same operation.
 
-The fast image contains the complete session-critical path:
+The API still waits for the returned secret state to become `armed`.
+It deletes the sandbox when arming fails.
+Raw secret values never enter the sandbox.
 
-- Ubuntu 24.04, matching the standard runtime's faster OpenCode startup path
-- Git and the baked scaffold repository
-- Node.js, npm, pnpm, Bun, uv, OpenCode, the Kortix daemon, and the Kortix CLI
-- OpenCode configuration dependencies, tool bundle cache, database migration, and instance warm-up
-- The model catalog, managed skills, and Slack or Teams CLI shims
+The flag does not change the sandbox image.
+It does not create or retain a sandbox pool.
+It does not change Daytona or E2B behavior.
 
-Large tools install once per sandbox on first use:
+Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy to restore post-create arming.
+This rollback does not require a database migration or sandbox cleanup.
 
-- `python` or `python3`: the pinned managed Python runtime
-- `make`, `gcc`, `g++`, `cc`, `c++`, or `pkg-config`: development pack
-- `agent-browser` or `chromium`: browser pack
-- Anydoc, document, PDF, OCR, media, and TeX commands: document pack
+## Local A/B result
 
-`kortix-toolpack development|browser|documents|all` installs a pack explicitly.
-An inter-process lock prevents two first-use commands from running `apt` concurrently.
+Both groups used the same API, Platinum account, project, standard image code, and Cloudflare tunnel.
+Each group contains five successful boots from 2026-08-19.
 
-Custom and meta templates do not change under the flag.
-Platinum cannot reuse the standard template ID for a fast-image session.
+| Milestone | Flag off p50 | Flag on p50 | Change |
+|---|---:|---:|---:|
+| Network secret phase | 18,261 ms | 0 ms | -18,261 ms |
+| Sandbox row active | 36,183 ms | 21,315 ms | -14,868 ms |
+| Provider create | 3,096 ms | 3,735 ms | +639 ms |
 
-## Rollout and rollback
+The row-active result includes normal provider and API variance.
+The measured p50 improvement is 41.1%.
 
-All environments default to `false`.
-Dev sets the flag explicitly in `.github/workflows/deploy-dev.yml`.
+The two groups used different per-project cache states after the first group triggered a warm-image bake.
+Runtime-ready time is therefore not a valid direct A/B metric in this sample.
+The host-side secret phase and row-active milestones remain directly measured.
 
-Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy to restore the standard image.
-Rollback does not require a database migration or sandbox cleanup.
-Existing sessions continue on the image that created them.
+## Next bottleneck
 
-## Acceptance gates
+The flag-on cold-image sample measured these p50 guest stages:
 
-The experiment can advance beyond dev only when all gates pass:
+| Stage | p50 |
+|---|---:|
+| Repository materialized | 12,265 ms |
+| OpenCode answering | 5,259 ms |
+| Configuration dependencies | 553 ms |
 
-1. Five clean dev boots complete without a provider or runtime failure.
-2. Runtime-ready p50 and p90 improve against the baseline above.
-3. A first prompt completes through OpenCode.
-4. Git, Kortix CLI, Python, development, browser, and document paths pass smoke tests.
-5. The fast image remains smaller than the standard runtime image.
-
-Disable the flag if runtime-ready p90 exceeds 32,607 ms or a lazy tool path fails.
-
-## Dev result
-
-Five clean Platinum boots on 2026-08-19 used `kortix-fast-dev-6ec80828f8659cfa`.
-The one-time 229,015 ms image build was excluded.
-
-| Milestone | Standard p50 | Fast p50 | Standard p90 | Fast p90 |
-|---|---:|---:|---:|---:|
-| Runtime ready | 25,288 ms | 30,773 ms | 32,607 ms | 35,816 ms |
-| Repository materialized | 7,489 ms | 7,050 ms | 8,007 ms | 7,944 ms |
-| Config dependencies | 542 ms | 18 ms | 580 ms | 19 ms |
-| OpenCode answering | 5,308 ms | 7,600 ms | 6,908 ms | 7,798 ms |
-
-The fast image failed the p50 and p90 acceptance gate.
-Dev therefore sets `KORTIX_FAST_COLD_BOOT_ENABLED=false`.
-The implementation remains available for more image and provider work behind the same flag.
+Git clone is the next isolated optimization target.

--- a/tests/unit/ecs-deploy-environment.test.ts
+++ b/tests/unit/ecs-deploy-environment.test.ts
@@ -55,9 +55,13 @@ describe('ECS task environment overrides', () => {
     ).toThrow();
   });
 
-  it('keeps fast cold boot disabled on the dev API deployment', () => {
+  it('enables create-time secret arming on the dev API deployment', () => {
     const workflow = readFileSync(resolve(root, '.github/workflows/deploy-dev.yml'), 'utf8');
     const deployScript = readFileSync(resolve(root, 'infra/scripts/ecs-deploy.sh'), 'utf8');
+    const snapshotBuilder = readFileSync(
+      resolve(root, 'apps/api/src/snapshots/builder.ts'),
+      'utf8',
+    );
     const apiDeploy = workflow.slice(
       workflow.indexOf('  deploy-api-ecs:'),
       workflow.indexOf('  deploy-apps-router:'),
@@ -68,7 +72,7 @@ describe('ECS task environment overrides', () => {
     );
 
     expect(apiDeploy).toContain(
-      `KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"false"}'`,
+      `KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}'`,
     );
     const apiFilter = workflow.slice(
       workflow.indexOf('            api:'),
@@ -77,5 +81,11 @@ describe('ECS task environment overrides', () => {
     expect(apiFilter).toContain("- 'infra/scripts/ecs-deploy.sh'");
     expect(deployScript).toContain('--argjson environment "$MERGED_ENVIRONMENT_JSON"');
     expect(terraform).not.toContain('KORTIX_FAST_COLD_BOOT_ENABLED');
+    const startupPrebuild = snapshotBuilder.slice(
+      snapshotBuilder.indexOf('export function kickStartupPreBuild'),
+      snapshotBuilder.indexOf('// ─── Custom (toml / UI) templates'),
+    );
+    expect(startupPrebuild).toContain('ensurePlatformDefaultImage');
+    expect(startupPrebuild).not.toContain('ensureFastSandboxImage');
   });
 });


### PR DESCRIPTION
## Problem

Platinum session provisioning attaches network-boundary secrets after VM creation. Five control boots measured this sequential phase at 18,261 ms p50.

## Change

- prepare write-only Platinum secret replicas before VM creation
- send secret references in `POST /v1/sandboxes`
- wait fail-closed for the create response to report an armed boundary
- keep the standard sandbox image
- guard the path with `KORTIX_FAST_COLD_BOOT_ENABLED`
- enable the experiment on dev only
- preserve post-create synchronization when the flag is off or the provider lacks create-time support

This change does not create a sandbox pool. Raw secret values do not enter the guest.

## Measurement

Five real Platinum boots per group, same local API and tunnel:

| Milestone | Flag off p50 | Flag on p50 | Change |
|---|---:|---:|---:|
| Network secret phase | 18,261 ms | 0 ms | -18,261 ms |
| Sandbox row active | 36,183 ms | 21,315 ms | -14,868 ms |
| Provider create | 3,096 ms | 3,735 ms | +639 ms |

The row-active p50 improves 41.1%.

## Verification

- `pnpm --filter ./apps/api test`: 7,602 passed, 74 skipped, 0 failed
- focused provisioning and boundary suite: 67 passed, 0 failed
- `pnpm --filter ./apps/api typecheck`: passed
- `bun test tests/unit/ecs-deploy-environment.test.ts`: 3 passed, 0 failed
- real Platinum A/B: 10/10 sessions booted and were deleted after measurement

## Rollback

Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` in the dev deploy workflow and redeploy. No migration or sandbox cleanup is required.