### PR TITLE
fix(email): nodemailer 7.0.13 -> 9.0.5 (open advisories, incl. one high)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,7 +42,7 @@
     "hono": "^4.4.0",
     "jose": "^5.9.6",
     "livekit-server-sdk": "^2.17.0",
-    "nodemailer": "^7.0.0",
+    "nodemailer": "^9.0.5",
     "oauth4webapi": "^3.8.7",
     "postgres": "^3.4.8",
     "re2js": "2.8.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,8 +219,8 @@ importers:
         specifier: ^2.17.0
         version: 2.17.0
       nodemailer:
-        specifier: ^7.0.0
-        version: 7.0.13
+        specifier: ^9.0.5
+        version: 9.0.5
       oauth4webapi:
         specifier: ^3.8.7
         version: 3.8.7
@@ -23654,8 +23654,8 @@ packages:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
-  /nodemailer@7.0.13:
-    resolution: {integrity: sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==}
+  /nodemailer@9.0.5:
+    resolution: {integrity: sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==}
     engines: {node: '>=6.0.0'}
     dev: false
 


### PR DESCRIPTION
Follow-up to #6585, which introduced the SMTP provider on `nodemailer@^7.0.0` → 7.0.13. That version carries open Dependabot advisories:

| Severity | Advisory | Vulnerable | Patched |
| --- | --- | --- | --- |
| **high** | message-level `raw` bypasses `disableFileAccess`/`disableUrlAccess` — arbitrary file read + full-response SSRF | `<= 9.0.0` | 9.0.1 |
| medium | CRLF injection in `List-*` header comments | `<= 8.0.8` | 8.0.9 |
| medium | `jsonTransport` bypasses `disableFileAccess`/`disableUrlAccess` | `<= 8.0.8` | 8.0.9 |
| medium | improper TLS certificate validation in OAuth2 token fetch | `<= 8.0.7` | 8.0.8 |
| medium | SMTP command injection via CRLF in the transport `name` option | `<= 8.0.4` | 8.0.5 |

Kortix passes neither `raw` nor a transport `name`, and every header value is server-constructed, so actual exposure is low. That is a reason not to panic, not a reason to keep a HIGH advisory in the tree when a patched release exists.

**Verified on 9.0.5**
- `apps/api/src/lib/email` — 25/25 pass, including the real in-process SMTP conversation test (EHLO → AUTH → MAIL FROM → RCPT TO → DATA) and the AUTH-advertised variant.
- Live send to Mailpit: `250 2.0.0 Ok: queued`, UTF-8 subject (`Bun SMTP smoke — ünïcode ✓`) and `From: Kortix Test <noreply@kortix.test>` intact.

No source changes — the 7 → 9 major does not touch the API surface this code uses (`createTransport` + `sendMail`).