### PR TITLE
fix(queue): forwarded prompts cannot strand, Stop cannot leak, bubbles keep one identity

### DIFF
--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -106,6 +106,7 @@ import { db } from '../../shared/db';
 import { isUniqueViolation } from '../../shared/postgres-errors';
 import { continueSession, drainSessionLifecycleQueue } from '../session-lifecycle';
 import { promoteNextInboxRow } from '../session-lifecycle/store';
+import { reconcileForwardedTurnsAtEnd } from '../session-lifecycle/forwarded-strand-reconcile';
 import {
   getOpenQuestion,
   recordPendingQuestion,
@@ -2541,6 +2542,24 @@ projectsApp.openapi(
         errorInfo,
         childSession ? childIdleGraceMs() : undefined,
       );
+      // Prompts forwarded INTO the turn that just ended: close the ones the
+      // step answered (older than the ended message), and re-queue any that
+      // the loop stranded below a newer assistant — see
+      // forwarded-strand-reconcile.ts. Fire-and-forget: it reads the box once
+      // and must not hold the daemon's relay.
+      if (!childSession) {
+        void reconcileForwardedTurnsAtEnd({
+          sessionId,
+          opencodeSessionId:
+            typeof body.opencode_session_id === 'string' ? body.opencode_session_id : null,
+          endedMessageId: typeof body.turn_message_id === 'string' ? body.turn_message_id : null,
+        }).catch((err) =>
+          console.warn(
+            `[forwarded-turns] reconcile failed for session ${sessionId}:`,
+            err instanceof Error ? err.message : err,
+          ),
+        );
+      }
       // THE TURN ENDED — the session's next queued prompt is admissible NOW.
       // Fire-and-forget: the drain re-runs admission itself, and a lost kick
       // falls back to the scheduler tick (bounded by the admission backoff).

--- a/apps/api/src/projects/routes/r8-session-prompts.test.ts
+++ b/apps/api/src/projects/routes/r8-session-prompts.test.ts
@@ -478,6 +478,7 @@ describe('GET .../prompts', () => {
         message_id: WIRE_ID,
         // The id the client painted under — the same while nothing re-minted.
         wire_message_id: WIRE_ID,
+        client_sent_at_ms: null,
         state: 'queued',
         reason: null,
         text: 'say hi',

--- a/apps/api/src/projects/routes/r8-session-prompts.test.ts
+++ b/apps/api/src/projects/routes/r8-session-prompts.test.ts
@@ -476,6 +476,8 @@ describe('GET .../prompts', () => {
         prompt_id: PROMPT_ID,
         client_message_id: 'q_1',
         message_id: WIRE_ID,
+        // The id the client painted under — the same while nothing re-minted.
+        wire_message_id: WIRE_ID,
         state: 'queued',
         reason: null,
         text: 'say hi',

--- a/apps/api/src/projects/routes/r8-session-prompts.test.ts
+++ b/apps/api/src/projects/routes/r8-session-prompts.test.ts
@@ -598,6 +598,7 @@ describe('DELETE .../prompts/:promptId', () => {
     expect(await response.json()).toEqual({
       removed: {
         prompt_id: PROMPT_ID,
+        removed_message_ids: [WIRE_ID],
         client_message_id: 'q_1',
         message_id: WIRE_ID,
         parts: [

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -54,6 +54,7 @@ import {
   stopSession,
 } from '../session-lifecycle';
 import { settleInboxHoldAfterStopInBackground } from '../session-lifecycle/inbox-hold-settle';
+import { cancelForwardedPrompt, findInboxRowIdByMessageId } from '../session-lifecycle/cancel-forwarded';
 import {
   PROMPT_TEXT_PREVIEW_CHARS,
   flattenPromptText,
@@ -533,6 +534,7 @@ const SessionPromptSchema = z.object({
 const RemovedSessionPromptSchema = z.object({
   prompt_id: z.string(),
   client_message_id: z.string(),
+  removed_message_ids: z.array(z.string()).optional(),
   message_id: z.string(),
   parts: z.array(z.any()),
   overrides: z.any().nullable(),
@@ -629,6 +631,14 @@ function serializeRemovedPrompt(row: PromptRow) {
     // The ORIGINAL wire id, never the re-minted one: an undo re-creates the
     // submission, and `POST .../prompts` places it again from there.
     message_id: typeof payload.wireMessageId === 'string' ? payload.wireMessageId : '',
+    // EVERY id this prompt ever travelled under, so the client can clear the
+    // transcript husk a cancel leaves behind (the copy at the runtime is
+    // emptied, not necessarily deleted, while a step runs).
+    removed_message_ids: [
+      payload.wireMessageId,
+      payload.redeliveredMessageId,
+      (row.result as Record<string, unknown> | null)?.forwarded_message_id,
+    ].filter((id, i, all): id is string => typeof id === 'string' && !!id && all.indexOf(id) === i),
     // The full body, untruncated, with every file/agent part — see the DELETE
     // handler for why the display shape cannot stand in for this.
     parts: parts.length > 0 ? parts : [{ type: 'text', text: payload.text ?? '' }],
@@ -876,7 +886,11 @@ projectsApp.openapi(
     const sessionId = c.req.param('sessionId');
     const promptId = c.req.param('promptId');
     if (!UUID_V4_REGEX.test(sessionId)) return c.json({ error: 'Invalid session id' }, 400);
-    if (!UUID_V4_REGEX.test(promptId)) return c.json({ error: 'Invalid prompt id' }, 400);
+    // A prompt is named by its row id (uuid) OR by its wire message id — the
+    // handle the bubble still has after the row leaves the list.
+    if (!UUID_V4_REGEX.test(promptId) && !/^msg_[A-Za-z0-9]{6,40}$/.test(promptId)) {
+      return c.json({ error: 'Invalid prompt id' }, 400);
+    }
 
     // Floor 'session' — see the POST /prompts gate comment. Un-queuing your own
     // pending message is running the session, not editing the project.
@@ -896,7 +910,18 @@ projectsApp.openapi(
     // The session AND inbox scopes are in the DELETE's own predicate, so
     // neither a prompt id from another session nor an automation's
     // `continue_session` row can be removed by naming it here.
-    const outcome = await deleteInboxPrompt(sessionId, promptId);
+    //
+    // A `msg_…` id names the prompt by its MESSAGE instead: the row leaves
+    // `GET .../prompts` the moment the daemon confirms persistence (~1 s),
+    // but the bubble on screen still knows its wire id — and the prompt is
+    // still cancellable until a model step reads it.
+    let effectivePromptId = promptId;
+    if (promptId.startsWith('msg_')) {
+      const found = await findInboxRowIdByMessageId(sessionId, promptId);
+      if (!found) return c.json({ error: 'Not found' }, 404);
+      effectivePromptId = found;
+    }
+    const outcome = await deleteInboxPrompt(sessionId, effectivePromptId);
     // The response CARRIES THE PROMPT IT REMOVED. A removal is offered with an
     // undo, and the row is hard-deleted, so this response is the only place the
     // full body still exists. Undoing from `GET /prompts`'s view instead
@@ -906,7 +931,30 @@ projectsApp.openapi(
       return c.json({ removed: serializeRemovedPrompt(outcome.row) }, 200);
     }
     if (outcome.outcome === 'delivering') {
-      return c.json({ error: 'Prompt is already being delivered' }, 409);
+      // On the wire is no longer the point of no return: a forwarded prompt
+      // the loop has not READ is taken back out of the runtime — whole
+      // message when idle, part by part when busy (an empty user message is
+      // invisible to the model). Only "a step is answering it" still refuses.
+      const cancelled = await cancelForwardedPrompt(sessionId, effectivePromptId);
+      if (cancelled.outcome === 'cancelled') {
+        return c.json({ removed: serializeRemovedPrompt(cancelled.row) }, 200);
+      }
+      if (cancelled.outcome === 'not_forwarded') {
+        // The row fell back into the queue while the cancel watched it.
+        const retried = await deleteInboxPrompt(sessionId, effectivePromptId);
+        if (retried.outcome === 'deleted') {
+          return c.json({ removed: serializeRemovedPrompt(retried.row) }, 200);
+        }
+      }
+      return c.json(
+        {
+          error:
+            cancelled.outcome === 'answered'
+              ? 'Prompt is already being answered'
+              : 'Prompt is being delivered and the runtime could not be reached to cancel it',
+        },
+        409,
+      );
     }
     return c.json({ error: 'Not found' }, 404);
   },

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -53,6 +53,7 @@ import {
   startSession,
   stopSession,
 } from '../session-lifecycle';
+import { settleInboxHoldAfterStopInBackground } from '../session-lifecycle/inbox-hold-settle';
 import {
   PROMPT_TEXT_PREVIEW_CHARS,
   flattenPromptText,
@@ -514,6 +515,7 @@ const SessionPromptSchema = z.object({
   prompt_id: z.string(),
   client_message_id: z.string(),
   message_id: z.string(),
+  wire_message_id: z.string(),
   state: z.enum(['queued', 'delivering', 'waiting', 'failed']),
   reason: z.string().nullable(),
   text: z.string(),
@@ -596,6 +598,12 @@ function serializePrompt(row: PromptRow) {
           : typeof payload.wireMessageId === 'string'
             ? payload.wireMessageId
             : '',
+    // The id the CLIENT painted its bubble under. `message_id` above moves to
+    // the re-minted id the moment the drain places the prompt — before the
+    // runtime echoes it — and a client that only knew `message_id` drew the
+    // row beside its own bubble for that window (a second dimmed copy for
+    // ~0.4 s on every mid-turn send). Both ids name one prompt.
+    wire_message_id: typeof payload.wireMessageId === 'string' ? payload.wireMessageId : '',
     state,
     reason,
     text: (typeof payload.text === 'string' ? payload.text : '').slice(
@@ -1000,7 +1008,14 @@ projectsApp.openapi(
 
     await holdInboxPrompts(sessionId, body.held);
     const rows = await listInboxPrompts(sessionId, PROMPT_LIST_LIMIT);
-    if (!body.held) void drainSessionLifecycleQueue({ limit: 1 }).catch(() => undefined);
+    if (body.held) {
+      // The instant marking above is what the client waits for; what a Stop
+      // means for prompts already on the wire needs the box and happens behind
+      // this response — see inbox-hold-settle.ts.
+      settleInboxHoldAfterStopInBackground(sessionId);
+    } else {
+      void drainSessionLifecycleQueue({ limit: 1 }).catch(() => undefined);
+    }
     return c.json({ prompts: rows.map(serializePrompt) });
   },
 );

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -516,6 +516,7 @@ const SessionPromptSchema = z.object({
   client_message_id: z.string(),
   message_id: z.string(),
   wire_message_id: z.string(),
+  client_sent_at_ms: z.number().nullable(),
   state: z.enum(['queued', 'delivering', 'waiting', 'failed']),
   reason: z.string().nullable(),
   text: z.string(),
@@ -604,6 +605,8 @@ function serializePrompt(row: PromptRow) {
     // row beside its own bubble for that window (a second dimmed copy for
     // ~0.4 s on every mid-turn send). Both ids name one prompt.
     wire_message_id: typeof payload.wireMessageId === 'string' ? payload.wireMessageId : '',
+    client_sent_at_ms:
+      typeof payload.clientSentAtMs === 'number' ? payload.clientSentAtMs : null,
     state,
     reason,
     text: (typeof payload.text === 'string' ? payload.text : '').slice(
@@ -769,6 +772,13 @@ projectsApp.openapi(
       // The drain re-mints against the live root before delivering, which is
       // the only place that can place the id correctly.
       ...(body.remint_on_delivery === true ? { remintOnDelivery: true } : {}),
+      // SEND order across surfaces whose POSTs race — see the batch sort in
+      // the drain. Bounded to the near past/future so a wrong client clock
+      // cannot pin its prompts to the head or tail of every future batch.
+      ...(typeof body.client_sent_at_ms === 'number' &&
+      Math.abs(Date.now() - body.client_sent_at_ms) < 10 * 60_000
+        ? { clientSentAtMs: Math.trunc(body.client_sent_at_ms) }
+        : {}),
       parts,
       overrides,
     });

--- a/apps/api/src/projects/sandbox-turn-lifecycle.ts
+++ b/apps/api/src/projects/sandbox-turn-lifecycle.ts
@@ -992,6 +992,151 @@ export async function completeSandboxTurn(
 }
 
 /**
+ * Close ONE open turn by the user message it was opened for — exact match only,
+ * no fallback to an unkeyed record — and write its ledger end with `reason`.
+ *
+ * For prompts forwarded INTO a live turn: their records are opened per
+ * message and the daemon's `end` relay names only the message the FINAL
+ * assistant answered, so every other forwarded record of that turn would stay
+ * open until a reaper sweep gave up on it (~20 s of "working" after the last
+ * answer). `session-lifecycle/forwarded-strand-reconcile.ts` closes the ones
+ * the step answered with `completed`, and the ones it stranded with
+ * `abandoned` once they are re-queued; `inbox-hold-settle.ts` closes the ones
+ * a Stop took back out of the transcript with `abandoned` too.
+ *
+ * Does NOT confirm inbox consumption: the callers decide what the row becomes.
+ * Returns true when a record was closed.
+ */
+export async function closeSandboxTurnByMessageId(
+  sessionId: string,
+  messageId: string,
+  reason: SessionTurnEndReason,
+  graceMs = idleGraceMs(),
+): Promise<boolean> {
+  const metadata = jsonbObject(sql`s.metadata`);
+  const result = await execute(sql`
+    WITH target AS (
+      SELECT s.sandbox_id,
+             ${metadata} AS metadata
+        FROM kortix.session_sandboxes s
+       WHERE s.session_id = ${sessionId}
+         AND s.status IN ('active', 'provisioning')
+       FOR UPDATE OF s
+    ), selected AS (
+      SELECT target.sandbox_id,
+             'activeTurns'::text AS source,
+             entry.key,
+             entry.value->>'token' AS token,
+             entry.value
+        FROM target
+        CROSS JOIN LATERAL jsonb_each(CASE
+          WHEN jsonb_typeof(target.metadata->'activeTurns') = 'object'
+            THEN target.metadata->'activeTurns'
+          ELSE '{}'::jsonb
+        END) entry
+       WHERE entry.value->>'state' IN ('delivering', 'active')
+         AND entry.value->>'messageId' = ${messageId}
+      UNION ALL
+      SELECT target.sandbox_id,
+             'activeTurn'::text AS source,
+             'activeTurn'::text AS key,
+             target.metadata->'activeTurn'->>'token' AS token,
+             target.metadata->'activeTurn' AS value
+        FROM target
+       WHERE target.metadata->'activeTurn'->>'state' IN ('delivering', 'active')
+         AND target.metadata->'activeTurn'->>'messageId' = ${messageId}
+    ), next_state AS (
+      SELECT target.sandbox_id,
+             jsonb_set(
+               CASE
+                 WHEN EXISTS (
+                   SELECT 1 FROM selected
+                    WHERE selected.sandbox_id = target.sandbox_id
+                      AND selected.source = 'activeTurn')
+                 THEN target.metadata - 'activeTurn'
+                 ELSE target.metadata
+               END,
+               '{activeTurns}',
+               coalesce((
+                 SELECT jsonb_object_agg(entry.key, entry.value)
+                   FROM jsonb_each(CASE
+                     WHEN jsonb_typeof(target.metadata->'activeTurns') = 'object'
+                       THEN target.metadata->'activeTurns'
+                     ELSE '{}'::jsonb
+                   END) entry
+                  WHERE NOT EXISTS (
+                    SELECT 1 FROM selected
+                     WHERE selected.sandbox_id = target.sandbox_id
+                       AND selected.source = 'activeTurns'
+                       AND selected.key = entry.key)),
+                 '{}'::jsonb),
+               true) AS metadata,
+             (SELECT coalesce(
+                       jsonb_agg(jsonb_build_object(
+                         'token', selected.token,
+                         'opencodeSessionId', selected.value->>'opencodeSessionId',
+                         'messageId', selected.value->>'messageId',
+                         'startedAtMs', selected.value->>'startedAtMs'))
+                         FILTER (WHERE selected.token IS NOT NULL),
+                       '[]'::jsonb)
+                FROM selected
+               WHERE selected.sandbox_id = target.sandbox_id) AS ended_turns
+        FROM target
+       WHERE EXISTS (SELECT 1 FROM selected WHERE selected.sandbox_id = target.sandbox_id)
+    )
+    UPDATE kortix.session_sandboxes s
+       SET metadata = next_state.metadata,
+           deadline_at = CASE
+             WHEN next_state.metadata->'activeTurn'->>'state' IN ('delivering', 'active')
+               OR EXISTS (
+                 SELECT 1
+                   FROM jsonb_each(CASE
+                     WHEN jsonb_typeof(next_state.metadata->'activeTurns') = 'object'
+                       THEN next_state.metadata->'activeTurns'
+                     ELSE '{}'::jsonb
+                   END) remaining
+                  WHERE remaining.value->>'state' IN ('delivering', 'active'))
+             THEN s.deadline_at
+             ELSE LEAST(
+               s.deadline_at,
+               now() + make_interval(secs => ${secs(graceMs)}))
+           END,
+           updated_at = now()
+      FROM next_state
+     WHERE s.sandbox_id = next_state.sandbox_id
+    RETURNING next_state.ended_turns, s.session_id, s.sandbox_id, s.project_id, s.account_id`);
+  const rows = normalizeRows(result);
+  const owner = rows?.[0] ? ledgerIdentity(rows[0]) : null;
+  const turns = endedLedgerTurns(rows?.[0]?.ended_turns);
+  if (owner && turns.length > 0) {
+    await recordTurnLedger(
+      endedTurnLedger(owner, turns, reason),
+      `close-by-message ${turns.map((turn) => turn.token).join(',')} (${reason})`,
+    );
+  }
+  // The ledger row may still be open with its metadata entry already gone
+  // (settled by a renewal/acceptance pass that never named this message):
+  // close it directly, by the message it was opened for. Observation, never
+  // authority — a failed write is logged and the reaper's backstop closes it.
+  let closedLedger = false;
+  try {
+    const direct = await execute(sql`UPDATE kortix.session_turns
+         SET state = 'ended', end_reason = ${reason}, ended_at = now(), updated_at = now()
+       WHERE session_id = ${sessionId}
+         AND message_id = ${messageId}
+         AND state <> 'ended'
+       RETURNING turn_token`);
+    closedLedger = (normalizeRows(direct)?.length ?? 0) > 0;
+  } catch (error) {
+    console.warn(
+      `[turn-ledger] close-by-message ledger write failed for ${messageId}:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+  return turns.length > 0 || closedLedger;
+}
+
+/**
  * Renew one accepted turn after the reaper observes that exact OpenCode turn in
  * flight. The token CAS prevents stale evidence from renewing a newer turn.
  */

--- a/apps/api/src/projects/session-lifecycle/cancel-forwarded.ts
+++ b/apps/api/src/projects/session-lifecycle/cancel-forwarded.ts
@@ -1,0 +1,231 @@
+/**
+ * Cancelling a prompt that is already AT OpenCode but not yet reached.
+ *
+ * "Forwarded" used to be the point of no return: `DELETE .../prompts/:id`
+ * answered 409 the moment the drain handed the message over, which — with the
+ * drain forwarding within ~1 s of Enter — meant the queue's Remove button
+ * existed for about a second per prompt. But a forwarded prompt the loop has
+ * not READ is still only text in the runtime's transcript, and it can be
+ * taken back out:
+ *
+ *  - box idle → `DELETE /session/:id/message/:mid` removes it whole;
+ *  - box mid-turn → that route is refused (`assertNotBusy`), but
+ *    `DELETE …/part/:pid` is not, and a user message with ZERO parts is
+ *    skipped by `toModelMessages` (`if (msg.parts.length === 0) continue`) —
+ *    the model never sees it, the loop's id-order bookkeeping is untouched.
+ *
+ * A prompt the loop HAS reached (an assistant answers it, or a step parented
+ * on it/newer read it) stays: that is "already being answered", and the 409
+ * remains truthful for it.
+ */
+
+import { sessionLifecycleCommands } from '@kortix/db';
+import { and, desc, eq, or, sql } from 'drizzle-orm';
+import { logger } from '../../lib/logger';
+import { db } from '../../shared/db';
+import { sandboxRuntimeRequestHeaders } from '../sandbox-fetch';
+import { closeSandboxTurnByMessageId } from '../sandbox-turn-lifecycle';
+import { resolveSessionOpencodeEndpoint } from './engine';
+import { reachedPlacement, strandedPlacement } from './forwarded-placement';
+import { inboxScope } from './inbox-rows';
+
+function isOnWire(result: unknown): boolean {
+  const status = (result as { status?: unknown } | null)?.status;
+  return status === 'forwarded' || status === 'delivered';
+}
+import type { SessionLifecycleCommandRow } from './store';
+
+const WORKSPACE = '/workspace';
+const TIP_LIMIT = 30;
+
+export type CancelForwardedOutcome =
+  | { outcome: 'cancelled'; row: SessionLifecycleCommandRow }
+  | { outcome: 'answered' }
+  | { outcome: 'unreachable' }
+  | { outcome: 'not_forwarded' };
+
+interface TipEntry {
+  id: string;
+  role: string;
+  parentID: string | null;
+  completed: number | null;
+  partIds: string[];
+}
+
+/** Find the newest inbox row that ever carried this wire/message id — the
+ *  client's handle once the row left the prompt list (confirmed `delivered`
+ *  on persistence, long before the model reads it). */
+export async function findInboxRowIdByMessageId(
+  sessionId: string,
+  messageId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ commandId: sessionLifecycleCommands.commandId })
+    .from(sessionLifecycleCommands)
+    .where(
+      and(
+        inboxScope(sessionId),
+        or(
+          sql`${sessionLifecycleCommands.payload}->>'wireMessageId' = ${messageId}`,
+          sql`${sessionLifecycleCommands.payload}->>'redeliveredMessageId' = ${messageId}`,
+          sql`${sessionLifecycleCommands.result}->>'forwarded_message_id' = ${messageId}`,
+        ),
+      ),
+    )
+    .orderBy(desc(sessionLifecycleCommands.createdAt))
+    .limit(1);
+  return row?.commandId ?? null;
+}
+
+export async function cancelForwardedPrompt(
+  sessionId: string,
+  promptId: string,
+): Promise<CancelForwardedOutcome> {
+  // A row the drain has CLAIMED settles into `forwarded` within ~1.5 s (one
+  // proxied POST). The click that races that window waits it out rather than
+  // refusing — from the user's side the prompt is equally "queued" either way.
+  let row: SessionLifecycleCommandRow | undefined;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const [found] = await db
+      .select()
+      .from(sessionLifecycleCommands)
+      .where(and(eq(sessionLifecycleCommands.commandId, promptId), inboxScope(sessionId)))
+      .limit(1);
+    if (!found) return { outcome: 'not_forwarded' };
+    // ON THE WIRE: forwarded, or already confirmed `delivered` — the daemon's
+    // acceptance relay confirms on PERSISTENCE (~1 s after delivery), long
+    // before any model step reads the message. The tip read below is what
+    // decides "actually being answered".
+    if (found.status === 'succeeded' && isOnWire(found.result)) {
+      row = found as SessionLifecycleCommandRow;
+      break;
+    }
+    if (found.status === 'queued' || found.status === 'failed') {
+      // Fell back into the queue while we watched — the plain delete path
+      // owns it again.
+      return { outcome: 'not_forwarded' };
+    }
+    if (found.status !== 'running') return { outcome: 'not_forwarded' };
+    await new Promise((resolve) => setTimeout(resolve, 400));
+  }
+  if (!row) {
+    logger.warn('[cancel-forwarded] row never settled out of running', { session_id: sessionId, prompt_id: promptId });
+    return { outcome: 'unreachable' };
+  }
+  const payload = (row.payload ?? {}) as Record<string, unknown>;
+  const result = (row.result ?? {}) as Record<string, unknown>;
+  const targetIds = [result.forwarded_message_id, payload.redeliveredMessageId, payload.wireMessageId]
+    .filter((id, i, all): id is string => typeof id === 'string' && !!id && all.indexOf(id) === i);
+  if (targetIds.length === 0) return { outcome: 'not_forwarded' };
+
+  const resolved = await resolveSessionOpencodeEndpoint(sessionId, row.actorUserId);
+  if (!resolved) {
+    logger.warn('[cancel-forwarded] endpoint unresolved', { session_id: sessionId, prompt_id: promptId });
+    return { outcome: 'unreachable' };
+  }
+  const headers = sandboxRuntimeRequestHeaders(resolved.endpoint.headers);
+  const base = `${resolved.endpoint.url}/session/${encodeURIComponent(resolved.opencodeSessionId)}`;
+
+  let tip: TipEntry[];
+  try {
+    const res = await fetch(
+      `${base}/message?directory=${encodeURIComponent(WORKSPACE)}&limit=${TIP_LIMIT}`,
+      { method: 'GET', headers, signal: AbortSignal.timeout(5_000) },
+    );
+    if (!res.ok) {
+      logger.warn('[cancel-forwarded] tip read refused', { session_id: sessionId, status: res.status });
+      return { outcome: 'unreachable' };
+    }
+    const body = (await res.json().catch(() => null)) as Array<{
+      info?: { id?: unknown; role?: unknown; parentID?: unknown; time?: { completed?: unknown } };
+      parts?: Array<{ id?: unknown }>;
+    }> | null;
+    if (!Array.isArray(body)) return { outcome: 'unreachable' };
+    tip = body.flatMap((entry) => {
+      const info = entry?.info;
+      if (!info || typeof info.id !== 'string' || typeof info.role !== 'string') return [];
+      return [
+        {
+          id: info.id,
+          role: info.role,
+          parentID: typeof info.parentID === 'string' ? info.parentID : null,
+          completed: typeof info.time?.completed === 'number' ? info.time.completed : null,
+          partIds: (entry.parts ?? []).flatMap((part) =>
+            typeof part?.id === 'string' ? [part.id] : [],
+          ),
+        },
+      ];
+    });
+  } catch (err) {
+    logger.warn('[cancel-forwarded] tip read threw', { session_id: sessionId, error: err instanceof Error ? err.message : String(err) });
+    return { outcome: 'unreachable' };
+  }
+
+  const present = tip.filter((m) => targetIds.includes(m.id));
+  for (const id of targetIds) {
+    const verdict = strandedPlacement(tip, id);
+    // Answered, or a step has read it (it is being answered right now).
+    if (verdict.answered) return { outcome: 'answered' };
+    if (!verdict.stranded && reachedPlacement(tip, id)) return { outcome: 'answered' };
+  }
+
+  // Take the copies out. Whole-message first (works while idle); when the
+  // loop is busy that route is refused — empty the message part by part
+  // instead, which the model then never sees.
+  for (const message of present) {
+    let removed = false;
+    try {
+      const res = await fetch(
+        `${base}/message/${encodeURIComponent(message.id)}?directory=${encodeURIComponent(WORKSPACE)}`,
+        { method: 'DELETE', headers, signal: AbortSignal.timeout(5_000) },
+      );
+      removed = res.ok || res.status === 404;
+    } catch {
+      removed = false;
+    }
+    if (removed) continue;
+    for (const partId of message.partIds) {
+      try {
+        const res = await fetch(
+          `${base}/message/${encodeURIComponent(message.id)}/part/${encodeURIComponent(partId)}?directory=${encodeURIComponent(WORKSPACE)}`,
+          { method: 'DELETE', headers, signal: AbortSignal.timeout(5_000) },
+        );
+        if (!res.ok && res.status !== 404) {
+          logger.warn('[cancel-forwarded] part delete refused', {
+            session_id: sessionId,
+            message_id: message.id,
+            part_id: partId,
+            status: res.status,
+          });
+          return { outcome: 'unreachable' };
+        }
+      } catch {
+        return { outcome: 'unreachable' };
+      }
+    }
+  }
+
+  // The runtime no longer holds it: the row goes, and its turn authority with
+  // it. Guarded on status so a concurrent consumption cannot be deleted from
+  // under its own confirmation.
+  const deleted = await db
+    .delete(sessionLifecycleCommands)
+    .where(
+      and(
+        eq(sessionLifecycleCommands.commandId, promptId),
+        inboxScope(sessionId),
+        eq(sessionLifecycleCommands.status, 'succeeded'),
+      ),
+    )
+    .returning();
+  if (!deleted[0]) return { outcome: 'answered' };
+  for (const id of targetIds) {
+    await closeSandboxTurnByMessageId(sessionId, id, 'abandoned').catch(() => undefined);
+  }
+  logger.info('[cancel-forwarded] forwarded prompt cancelled', {
+    session_id: sessionId,
+    prompt_id: promptId,
+    message_ids: targetIds,
+  });
+  return { outcome: 'cancelled', row: deleted[0] as SessionLifecycleCommandRow };
+}

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -587,6 +587,15 @@ export async function drainSessionLifecycleQueue(
   } = {},
 ): Promise<{ claimed: number; succeeded: number; failed: number; queued: number }> {
   const workerId = input.workerId ?? `session-lifecycle:${process.pid}:${Date.now()}`;
+  // COALESCE a burst before claiming. A targeted kick fires per POST, and the
+  // composer sends a burst's POSTs concurrently — their arrival order is the
+  // network's. Claiming instantly let the first arrival's batch close before
+  // the rest of the burst was even durable (measured: one of four boot sends
+  // delivered a step behind, out of order). A quarter second collects the
+  // stragglers and is invisible next to the ~1.3 s delivery itself.
+  if (input.idempotencyKey) {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
   const rows = await claimDueLifecycleCommands({
     workerId,
     limit: input.limit ?? 10,
@@ -720,13 +729,21 @@ export async function drainSessionLifecycleQueue(
         };
         const batch = lane.slice(i, j).sort((a, b) => sendOrder(a) - sendOrder(b));
         i = j;
-        await runRow(batch[0]);
-        if (batch.length === 1) continue;
+        const headDone = runRow(batch[0]);
+        if (batch.length === 1) {
+          await headDone;
+          continue;
+        }
         const rest = batch.slice(1);
-        // One gate per member: each waits for the previous member's id to be
-        // final before minting its own, then all POST concurrently.
+        // One gate per member: the FIRST waits for the HEAD (its id is not
+        // final until its delivery placed it — minting before that inverted
+        // head and member on the wire), each next waits for the previous
+        // member's mint; the POSTs then run concurrently.
         const gates: BatchPlacementGate[] = [];
-        let previous: Promise<void> = Promise.resolve();
+        let previous: Promise<void> = headDone.then(
+          () => undefined,
+          () => undefined,
+        );
         for (let k = 0; k < rest.length; k += 1) {
           let release!: () => void;
           const mine = new Promise<void>((resolve) => {
@@ -735,11 +752,12 @@ export async function drainSessionLifecycleQueue(
           gates.push({ waitTurn: previous, release });
           previous = mine;
         }
-        await Promise.all(
-          rest.map((member, k) =>
+        await Promise.all([
+          headDone,
+          ...rest.map((member, k) =>
             runRow(member, { batch: gates[k] }).finally(() => gates[k].release()),
           ),
-        );
+        ]);
       }
     }),
   );

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -740,14 +740,14 @@ export async function drainSessionLifecycleQueue(
         // head and member on the wire), each next waits for the previous
         // member's mint; the POSTs then run concurrently.
         const gates: BatchPlacementGate[] = [];
-        let previous: Promise<void> = headDone.then(
-          () => undefined,
-          () => undefined,
+        let previous: Promise<bigint | null> = headDone.then(
+          () => null,
+          () => null,
         );
         for (let k = 0; k < rest.length; k += 1) {
-          let release!: () => void;
-          const mine = new Promise<void>((resolve) => {
-            release = resolve;
+          let release!: (mintedTime?: bigint | null) => void;
+          const mine = new Promise<bigint | null>((resolve) => {
+            release = (mintedTime) => resolve(mintedTime ?? null);
           });
           gates.push({ waitTurn: previous, release });
           previous = mine;
@@ -1091,6 +1091,10 @@ async function remintWireMessageId(
   row: SessionLifecycleCommandRow,
   payload: QueuedContinueSessionPayload,
   transcript: InboxTranscriptState,
+  /** A batch member's hard floor: the PREVIOUS member's minted clock, so the
+   *  batch's ids are strictly ascending in send order — a skew sample landing
+   *  mid-batch made two members mint on different rules and swap. */
+  batchFloor: bigint | null = null,
 ): Promise<string> {
   const submitted = wireIdTime(payload.wireMessageId ?? '');
   const floor = transcript.read
@@ -1107,7 +1111,8 @@ async function remintWireMessageId(
   // and OpenCode reads it as already answered and never runs it. The inbox
   // already knows every id it put on the wire; that is the missing floor.
   const delivered = await readDeliveredWireIdFloor(row);
-  const known = delivered !== null && (floor === null || delivered > floor) ? delivered : floor;
+  let known = delivered !== null && (floor === null || delivered > floor) ? delivered : floor;
+  if (batchFloor !== null && (known === null || batchFloor > known)) known = batchFloor;
   const newest = known !== null && (submitted === null || known > submitted) ? known : submitted;
 
   // Placed at the BOX's clock "now" when it is known (see forwarded-placement
@@ -1324,8 +1329,11 @@ function externalIdFromSandboxUrlField(url: string | null): string | null {
  * then POSTs concurrently with everyone else.
  */
 export interface BatchPlacementGate {
-  waitTurn: Promise<void>;
-  release: () => void;
+  /** Resolves with the previous member's minted id clock (null for the first
+   *  member after the head) — this member's mint floor, so batch ids are
+   *  strictly ascending in send order whatever the skew cache says. */
+  waitTurn: Promise<bigint | null>;
+  release: (mintedTime?: bigint | null) => void;
 }
 
 export interface ExecuteQueuedContinueOptions {
@@ -1535,8 +1543,9 @@ export async function executeQueuedContinue(
   let turnLive = false;
   // The head of the batch landed and opened a turn (or joined the live one);
   // every row after it is placed as into a live turn, by definition.
+  let batchFloor: bigint | null = null;
   if (opts.batch) {
-    await opts.batch.waitTurn;
+    batchFloor = await opts.batch.waitTurn;
     tl.mark('batch-turn');
     turnLive = true;
   }
@@ -1605,6 +1614,7 @@ export async function executeQueuedContinue(
     // first. Only a first delivery may do this: a re-POST's original id may
     // already be persisted.
     if (
+      !opts.batch &&
       deliveryAttempt === 0 &&
       redeliveries === 0 &&
       payload.wireMessageId &&
@@ -1616,12 +1626,12 @@ export async function executeQueuedContinue(
       underPlaced = true;
       tl.mark('under-placed');
     } else {
-      wireMessageId = await remintWireMessageId(row, payload, transcript);
+      wireMessageId = await remintWireMessageId(row, payload, transcript, batchFloor);
       tl.mark('remint');
     }
   }
   // The id is final: the next batch member may mint above it.
-  opts.batch?.release();
+  opts.batch?.release(wireMessageId ? wireIdTime(wireMessageId) : null);
 
   {
     const stagedRevertLate = await stagedRevertPromise;

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -48,6 +48,7 @@ import {
   markCommandSucceeded,
   requeueForAdmission,
   resultFromExistingCommand,
+  withNextDeliveryAttempt,
 } from './store';
 import type {
   PromptOverridesWire,
@@ -55,6 +56,14 @@ import type {
   QueuedContinueSessionPayload,
 } from './store';
 import { admitInboxPrompt, sessionHoldsLiveTurn } from './inbox-admission';
+import {
+  type PlacementTipMessage,
+  boxClockSkewMs,
+  mintLivePlacement,
+  noteBoxClockSample,
+  parsePlacementTip,
+  strandedPlacement,
+} from './forwarded-placement';
 import {
   MAX_WIRE_ID_CLOCK_CORRECTION,
   WIRE_ID_TIME_MASK,
@@ -767,16 +776,33 @@ async function queuedContinueOpencodeEndpoint(row: SessionLifecycleCommandRow): 
   endpoint: { url: string; headers: Record<string, string> };
   opencodeSessionId: string;
 } | null> {
-  if (!row.sessionId) return null;
+  return resolveSessionOpencodeEndpoint(row.sessionId, row.actorUserId);
+}
+
+/**
+ * The signed proxy endpoint + OpenCode root id for one session — the same
+ * resolution every drain-side transcript read uses. Exported for the turn-end
+ * reconciliation (`forwarded-strand-reconcile.ts`), which has a session, not a
+ * row.
+ */
+export async function resolveSessionOpencodeEndpoint(
+  sessionId: string | null | undefined,
+  actorUserId?: string | null,
+): Promise<{
+  endpoint: { url: string; headers: Record<string, string> };
+  opencodeSessionId: string;
+} | null> {
+  if (!sessionId) return null;
   const [session] = await db
     .select({
       opencodeSessionId: projectSessions.opencodeSessionId,
       sandboxUrl: projectSessions.sandboxUrl,
       accountId: projectSessions.accountId,
       projectId: projectSessions.projectId,
+      createdBy: projectSessions.createdBy,
     })
     .from(projectSessions)
-    .where(eq(projectSessions.sessionId, row.sessionId))
+    .where(eq(projectSessions.sessionId, sessionId))
     .limit(1);
   if (!session?.opencodeSessionId) return null;
 
@@ -787,7 +813,7 @@ async function queuedContinueOpencodeEndpoint(row: SessionLifecycleCommandRow): 
       .from(sessionSandboxes)
       .where(
         and(
-          eq(sessionSandboxes.sessionId, row.sessionId),
+          eq(sessionSandboxes.sessionId, sessionId),
           eq(sessionSandboxes.projectId, session.projectId),
           eq(sessionSandboxes.accountId, session.accountId),
         ),
@@ -798,7 +824,14 @@ async function queuedContinueOpencodeEndpoint(row: SessionLifecycleCommandRow): 
   }
   if (!externalId) return null;
 
-  const endpoint = await sandboxOpencodeEndpoint(externalId, row.actorUserId ?? undefined);
+  // The signed user context is what the daemon admits a runtime read on
+  // (`verifyKortixUserContext`); with no actor the call is refused as
+  // `malformed`. A caller with no row of its own (turn-end reconciliation,
+  // the stop settle) reads as the session's creator.
+  const endpoint = await sandboxOpencodeEndpoint(
+    externalId,
+    actorUserId ?? session.createdBy ?? undefined,
+  );
   if (!endpoint) return null;
   return { endpoint, opencodeSessionId: session.opencodeSessionId };
 }
@@ -812,6 +845,8 @@ interface InboxTranscriptState {
   answered: boolean;
   /** The transcript was actually read. A failed read answers nothing. */
   read: boolean;
+  /** The messages the read returned (newest tail), for placement proofs. */
+  tip: PlacementTipMessage[] | null;
 }
 
 /**
@@ -830,7 +865,7 @@ async function readInboxTranscriptState(
   deliveredIds: string[],
   opts: { full?: boolean } = {},
 ): Promise<InboxTranscriptState> {
-  const empty: InboxTranscriptState = { newest: null, answered: false, read: false };
+  const empty: InboxTranscriptState = { newest: null, answered: false, read: false, tip: null };
   try {
     const resolved = await queuedContinueOpencodeEndpoint(row);
     if (!resolved) return empty;
@@ -847,23 +882,19 @@ async function readInboxTranscriptState(
       signal: AbortSignal.timeout(5_000),
     });
     if (!res.ok) return empty;
-    const messages = (await res.json().catch(() => null)) as Array<{
-      info?: { id?: unknown; role?: unknown; parentID?: unknown };
-    }> | null;
-    if (!Array.isArray(messages)) return empty;
+    const tip = parsePlacementTip(await res.json().catch(() => null));
+    if (!tip) return empty;
 
-    const newest = newestWireIdTime(
-      messages.map((message) => (typeof message?.info?.id === 'string' ? message.info.id : null)),
-    );
+    const newest = newestWireIdTime(tip.map((message) => message.id));
     // Same rule the daemon's `observeOpencodeDelivery` uses: an assistant
     // message parented on the prompt is the turn having run.
-    const answered = messages.some(
+    const answered = tip.some(
       (message) =>
-        message?.info?.role === 'assistant' &&
-        typeof message.info.parentID === 'string' &&
-        deliveredIds.includes(message.info.parentID),
+        message.role === 'assistant' &&
+        typeof message.parentID === 'string' &&
+        deliveredIds.includes(message.parentID),
     );
-    return { newest, answered, read: true };
+    return { newest, answered, read: true, tip };
   } catch (err) {
     console.warn('[session-lifecycle] inbox transcript read failed — proceeding without it', {
       sessionId: row.sessionId,
@@ -991,7 +1022,14 @@ async function remintWireMessageId(
   const known = delivered !== null && (floor === null || delivered > floor) ? delivered : floor;
   const newest = known !== null && (submitted === null || known > submitted) ? known : submitted;
 
-  const minted = mintWireMessageId({ nowMs: Date.now(), newestKnownTime: newest });
+  // Placed at the BOX's clock "now" when it is known (see forwarded-placement
+  // .ts): newest+1 is only safe while nothing else is minting, and a live turn
+  // mints an assistant id at every step boundary.
+  const minted = mintLivePlacement({
+    nowMs: Date.now(),
+    newestKnownTime: newest,
+    boxSkewMs: row.sessionId ? boxClockSkewMs(row.sessionId) : null,
+  });
   if (newest !== null && minted.time <= newest) {
     // The lift refused: `MAX_WIRE_ID_CLOCK_CORRECTION` (1h) caps how far a
     // transcript may drag an id, and past that cap the id we are about to send
@@ -1019,6 +1057,110 @@ async function remintWireMessageId(
     // Throwing here would abandon a CLAIMED row in `running`, where nothing
     // reclaims it until its lock expires.
     console.warn('[session-lifecycle] could not persist the re-minted wire id', {
+      sessionId: row.sessionId,
+      commandId: row.commandId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return minted.id;
+}
+
+/** How many times one delivery re-places itself before leaving the rest to
+ *  turn-end reconciliation. Each round is one tip read + one DELETE + one POST
+ *  — a second strand in a row means step boundaries are landing inside every
+ *  window, and the turn-end net is the cheaper place to catch it. */
+const MAX_LIVE_PLACEMENT_REPAIRS = 2;
+
+/**
+ * Read the tip once after a live-turn delivery and say whether the prompt
+ * landed where the loop will run it — see `strandedPlacement`. Also takes the
+ * box-clock sample the next placement for this session mints from.
+ *
+ * Fails OPEN as "not stranded": an unreadable tip proves nothing, and the
+ * turn-end reconciliation re-asks the question with the same predicate.
+ */
+async function verifyLivePlacement(
+  row: SessionLifecycleCommandRow,
+  wireMessageId: string,
+  postedAtMs: number,
+): Promise<{ stranded: boolean; strandedBy: string | null; newest: bigint | null }> {
+  const ackAtMs = Date.now();
+  const transcript = await readInboxTranscriptState(row, [wireMessageId]);
+  if (!transcript.read || !transcript.tip) return { stranded: false, strandedBy: null, newest: null };
+  const verdict = strandedPlacement(transcript.tip, wireMessageId);
+  if (row.sessionId && verdict.createdMs !== null && verdict.createdMs >= postedAtMs - 60_000) {
+    // The box stamped `created` somewhere between our POST and its ack; the
+    // ack is the conservative pairing (see `noteBoxClockSample`).
+    noteBoxClockSample(row.sessionId, verdict.createdMs, ackAtMs);
+  }
+  return { stranded: verdict.stranded, strandedBy: verdict.strandedBy, newest: verdict.newest };
+}
+
+/**
+ * Delete a stranded user message from the root transcript, so the re-placed
+ * copy is the only one OpenCode — and the model — holds. `true` only on a
+ * confirmed 2xx (or a 404: already gone).
+ */
+async function removeStrandedOpencodeMessage(
+  row: SessionLifecycleCommandRow,
+  wireMessageId: string,
+): Promise<boolean> {
+  try {
+    const resolved = await queuedContinueOpencodeEndpoint(row);
+    if (!resolved) return false;
+    const url = `${resolved.endpoint.url}/session/${encodeURIComponent(resolved.opencodeSessionId)}/message/${encodeURIComponent(wireMessageId)}?directory=${encodeURIComponent(WORKSPACE)}`;
+    const res = await fetch(url, {
+      method: 'DELETE',
+      headers: sandboxRuntimeRequestHeaders(resolved.endpoint.headers),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (res.ok || res.status === 404) return true;
+    // 409 = the loop is running (`assertNotBusy`); expected mid-turn.
+    if (res.status !== 409) {
+      console.warn('[session-lifecycle] stranded message delete refused', {
+        sessionId: row.sessionId,
+        commandId: row.commandId,
+        status: res.status,
+        body: (await res.text().catch(() => '')).slice(0, 200),
+      });
+    }
+    return false;
+  } catch (err) {
+    console.warn('[session-lifecycle] stranded message delete threw', {
+      sessionId: row.sessionId,
+      commandId: row.commandId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+/**
+ * Mint the id a REPAIR goes out under — above the assistant that proved the
+ * strand — and persist it with the next delivery attempt BEFORE the POST, for
+ * the same crash-safety reason `remintWireMessageId` persists first.
+ */
+async function remintForRepair(
+  row: SessionLifecycleCommandRow,
+  newestKnownTime: bigint | null,
+): Promise<string> {
+  const minted = mintLivePlacement({
+    nowMs: Date.now(),
+    newestKnownTime,
+    boxSkewMs: row.sessionId ? boxClockSkewMs(row.sessionId) : null,
+  });
+  try {
+    await db
+      .update(sessionLifecycleCommands)
+      .set({
+        payload: withNextDeliveryAttempt(
+          sql`${sessionLifecycleCommands.payload} || ${JSON.stringify({ redeliveredMessageId: minted.id })}::jsonb`,
+        ),
+        updatedAt: new Date(),
+      })
+      .where(eq(sessionLifecycleCommands.commandId, row.commandId));
+  } catch (err) {
+    console.warn('[session-lifecycle] could not persist the re-placed wire id', {
       sessionId: row.sessionId,
       commandId: row.commandId,
       error: err instanceof Error ? err.message : String(err),
@@ -1315,37 +1457,44 @@ export async function executeQueuedContinue(
     }
   }
 
+  // Did this delivery go into a turn that was LIVE when it left? Then the
+  // placement has to be PROVEN, not assumed — see forwarded-placement.ts.
+  const placedIntoLiveTurn = !!wireMessageId && (turnLive || remintKnown);
   try {
-    const delivery = await continueSession(
-      {
-        source: row.source as SessionInvocationSource,
-        sessionId: row.sessionId,
-        text,
-        userId: row.actorUserId,
-        ...(payload.parts?.length ? { parts: payload.parts } : {}),
-        ...(payload.overrides ? { overrides: payload.overrides } : {}),
-        ...(wireMessageId ? { wireMessageId } : {}),
-      },
-      // F2: stable across every drain-and-retry of THIS row — see
-      // `postPrompt`'s F2 note. Two DIFFERENT queued commands (distinct
-      // `commandId`s) with identical text now deliver independently instead
-      // of the second silently deduping against the first.
-      //
-      // A ROW THAT ALREADY WENT OUT suffixes it: the previous attempt's
-      // 10-minute dedupe claim is still live in the proxy, and reusing the key
-      // would let that claim swallow the delivery meant to replace it — a
-      // `200 {"deduplicated": true}` that `postPrompt` reads as delivered.
-      // Still stable across `deliverWithRetry`'s inner retries, which is what
-      // the claim is for.
-      //
-      // `deliveryAttempt`, not `redeliveries`: a released Stop and a "send now"
-      // on a stop-paused row are re-POSTs too, and neither is a reaper
-      // redelivery. See `withNextDeliveryAttempt`.
-      deliveryAttempt > 0 ? `${row.commandId}:r${deliveryAttempt}` : row.commandId,
-      tl,
-    );
-    tl.mark('delivered');
-    if (delivery === 'delivered') {
+    let attempt = deliveryAttempt;
+    let delivery: SessionDeliveryOutcome = 'pending';
+    for (let round = 0; ; round += 1) {
+      const postedAt = Date.now();
+      delivery = await continueSession(
+        {
+          source: row.source as SessionInvocationSource,
+          sessionId: row.sessionId,
+          text,
+          userId: row.actorUserId,
+          ...(payload.parts?.length ? { parts: payload.parts } : {}),
+          ...(payload.overrides ? { overrides: payload.overrides } : {}),
+          ...(wireMessageId ? { wireMessageId } : {}),
+        },
+        // F2: stable across every drain-and-retry of THIS row — see
+        // `postPrompt`'s F2 note. Two DIFFERENT queued commands (distinct
+        // `commandId`s) with identical text now deliver independently instead
+        // of the second silently deduping against the first.
+        //
+        // A ROW THAT ALREADY WENT OUT suffixes it: the previous attempt's
+        // 10-minute dedupe claim is still live in the proxy, and reusing the key
+        // would let that claim swallow the delivery meant to replace it — a
+        // `200 {"deduplicated": true}` that `postPrompt` reads as delivered.
+        // Still stable across `deliverWithRetry`'s inner retries, which is what
+        // the claim is for.
+        //
+        // `deliveryAttempt`, not `redeliveries`: a released Stop and a "send now"
+        // on a stop-paused row are re-POSTs too, and neither is a reaper
+        // redelivery. See `withNextDeliveryAttempt`.
+        attempt > 0 ? `${row.commandId}:r${attempt}` : row.commandId,
+        tl,
+      );
+      tl.mark('delivered');
+      if (delivery !== 'delivered') break;
       // DELIVERED IS NOT CONSUMED. OpenCode persists the prompt and queues it
       // behind the turn in flight, so the row stays OPEN — see
       // `markCommandForwarded` — until `session_turns` names this wire id.
@@ -1361,6 +1510,65 @@ export async function executeQueuedContinue(
         await markCommandSucceeded(row.commandId, { status: 'delivered' }, row.sessionId);
       }
       tl.mark('marked');
+      if (!placedIntoLiveTurn || !wireMessageId) break;
+      // PROOF. One tip read after the insert answers exactly whether the box
+      // created a newer assistant BEFORE this prompt landed (the strand
+      // signature). It also hands back the box's own `time.created` for the
+      // message, which calibrates the next placement for this session.
+      const proof = await verifyLivePlacement(row, wireMessageId, postedAt);
+      tl.mark('placement-proof');
+      if (!proof.stranded) break;
+      if (round >= MAX_LIVE_PLACEMENT_REPAIRS) {
+        logger.error(
+          '[session-lifecycle] forwarded prompt still stranded after repairs — leaving it to turn-end reconciliation',
+          {
+            session_id: row.sessionId,
+            command_id: row.commandId,
+            wire_message_id: wireMessageId,
+            stranded_by: proof.strandedBy,
+          },
+        );
+        break;
+      }
+      // REPAIR: take the stranded copy out of the transcript, place again
+      // above the assistant that proves the strand, and go round once more.
+      // The stale message must go first: OpenCode would otherwise hold the
+      // prompt twice, and the model would read it twice.
+      //
+      // OpenCode refuses a message delete WHILE THE LOOP RUNS
+      // (`deleteMessage` → `assertNotBusy`), and a strand is, almost by
+      // definition, detected while it runs. So this repair fires only when
+      // the step already ended between the insert and the proof; the
+      // ordinary case is handed to turn-end reconciliation
+      // (forwarded-strand-reconcile.ts), which runs the same repair the
+      // moment the daemon relays the turn's end — before the box is idle
+      // long enough for anyone to notice.
+      const removed = await removeStrandedOpencodeMessage(row, wireMessageId);
+      if (!removed) {
+        logger.info(
+          '[session-lifecycle] stranded prompt detected mid-turn — turn-end reconciliation will re-place it',
+          {
+            session_id: row.sessionId,
+            command_id: row.commandId,
+            wire_message_id: wireMessageId,
+            stranded_by: proof.strandedBy,
+          },
+        );
+        break;
+      }
+      const replaced = await remintForRepair(row, proof.newest);
+      attempt += 1;
+      logger.warn('[session-lifecycle] forwarded prompt landed below a newer assistant — re-placed', {
+        session_id: row.sessionId,
+        command_id: row.commandId,
+        stranded_wire_id: wireMessageId,
+        stranded_by: proof.strandedBy,
+        replaced_wire_id: replaced,
+        round: round + 1,
+      });
+      wireMessageId = replaced;
+    }
+    if (delivery === 'delivered') {
       // CHAIN. This row is on the wire, so the session's next queued row is
       // admissible NOW — do not leave it to the scheduler tick or to whatever
       // `requeueForAdmission` backoff it accrued while waiting on this one.

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -6,7 +6,7 @@ import {
   sessionLifecycleCommands,
   sessionSandboxes,
 } from '@kortix/db';
-import { type SQL, and, desc, eq, gte, sql } from 'drizzle-orm';
+import { type SQL, and, desc, eq, gte, inArray, or, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { ProvisionTimeline } from '../../platform/services/provision-timeline';
 import { WIRE_ID_PLACED_HEADER } from '../../sandbox-proxy/prompt-wire-id-repair';
@@ -56,11 +56,13 @@ import type {
   QueuedContinueSessionPayload,
 } from './store';
 import { admitInboxPrompt, sessionHoldsLiveTurn } from './inbox-admission';
+import { claimDueSessionInboxSiblings } from './inbox-rows';
 import {
   type PlacementTipMessage,
   boxClockSkewMs,
   mintLivePlacement,
   noteBoxClockSample,
+  openUserAbove,
   parsePlacementTip,
   strandedPlacement,
 } from './forwarded-placement';
@@ -591,6 +593,18 @@ export async function drainSessionLifecycleQueue(
     idempotencyKey: input.idempotencyKey,
     availableBefore: input.availableBefore,
   });
+  // A targeted claim (one POST's kick) takes exactly its own row — but the
+  // rows already queued for the SAME session are this delivery's batch, and
+  // leaving them to their own kicks is what delivered a burst of sends one
+  // ~1.5 s round-trip at a time (and let a step boundary split the answers).
+  // Sweep them in so the lane batches them below.
+  if (input.idempotencyKey && rows.length > 0) {
+    const sessions = [...new Set(rows.map((r) => r.sessionId).filter((v): v is string => !!v))];
+    for (const sessionId of sessions) {
+      const siblings = await claimDueSessionInboxSiblings({ workerId, sessionId });
+      rows.push(...siblings.filter((sib) => !rows.some((r) => r.commandId === sib.commandId)));
+    }
+  }
   const out = { claimed: rows.length, succeeded: 0, failed: 0, queued: 0 };
 
   // ONE LANE PER SESSION, and the lanes run concurrently.
@@ -610,13 +624,16 @@ export async function drainSessionLifecycleQueue(
     else lanes.set(lane, [row]);
   }
 
-  const runRow = async (row: SessionLifecycleCommandRow): Promise<void> => {
+  const runRow = async (
+    row: SessionLifecycleCommandRow,
+    opts: ExecuteQueuedContinueOptions = {},
+  ): Promise<void> => {
     if (row.commandType === 'continue_session') {
       // Contained per row. Every row in this batch is CLAIMED (`running`), and
       // one throw escaping the loop would leave the rest of them there — a
       // state nothing reclaims until the lock expires, and one that blocks
       // every later prompt of the same session behind it.
-      const outcome = await executeQueuedContinue(row).catch(async (err) => {
+      const outcome = await executeQueuedContinue(row, opts).catch(async (err) => {
         await markCommandFailed(
           row.commandId,
           `drain failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -678,10 +695,63 @@ export async function drainSessionLifecycleQueue(
 
   await Promise.all(
     [...lanes.values()].map(async (lane) => {
-      for (const row of lane) await runRow(row);
+      // Same-session INBOX rows go as ONE batch: the head lands first (it may
+      // open the turn), then the rest mint in queue order and POST together
+      // — so everything queued reaches OpenCode within one proxy round-trip
+      // of the head instead of ~1.5 s apiece, and the step after the current
+      // one answers all of them at once. Measured before: 4 prompts queued
+      // during boot ran as 3 + 1 across two steps.
+      let i = 0;
+      while (i < lane.length) {
+        const row = lane[i];
+        if (!isInboxRow(row)) {
+          await runRow(row);
+          i += 1;
+          continue;
+        }
+        let j = i + 1;
+        while (j < lane.length && isInboxRow(lane[j])) j += 1;
+        const sendOrder = (row: SessionLifecycleCommandRow): number => {
+          const at = (row.payload as { clientSentAtMs?: unknown } | null)?.clientSentAtMs;
+          // The sender tab's Enter instant when it was supplied: the POSTs of
+          // two surfaces race across the boot-shell crossfade, and row
+          // creation order is the race's outcome, not the user's.
+          return typeof at === 'number' ? at : row.createdAt.getTime();
+        };
+        const batch = lane.slice(i, j).sort((a, b) => sendOrder(a) - sendOrder(b));
+        i = j;
+        await runRow(batch[0]);
+        if (batch.length === 1) continue;
+        const rest = batch.slice(1);
+        // One gate per member: each waits for the previous member's id to be
+        // final before minting its own, then all POST concurrently.
+        const gates: BatchPlacementGate[] = [];
+        let previous: Promise<void> = Promise.resolve();
+        for (let k = 0; k < rest.length; k += 1) {
+          let release!: () => void;
+          const mine = new Promise<void>((resolve) => {
+            release = resolve;
+          });
+          gates.push({ waitTurn: previous, release });
+          previous = mine;
+        }
+        await Promise.all(
+          rest.map((member, k) =>
+            runRow(member, { batch: gates[k] }).finally(() => gates[k].release()),
+          ),
+        );
+      }
     }),
   );
   return out;
+}
+
+/** An inbox prompt row: a `continue_session` with the client's own
+ *  submission id — what the queue strip lists and what batches. */
+function isInboxRow(row: SessionLifecycleCommandRow): boolean {
+  if (row.commandType !== 'continue_session') return false;
+  const payload = row.payload as { clientMessageId?: unknown } | null;
+  return typeof payload?.clientMessageId === 'string' && payload.clientMessageId.length > 0;
 }
 
 /**
@@ -1096,6 +1166,33 @@ async function verifyLivePlacement(
   return { stranded: verdict.stranded, strandedBy: verdict.strandedBy, newest: verdict.newest };
 }
 
+/** Is a forwarded/queued inbox row of this session NEWER than `row` already
+ *  on the wire (or in line)? Then `row`'s send order is pinned by it. */
+async function hasLaterForwardedSibling(row: SessionLifecycleCommandRow): Promise<boolean> {
+  if (!row.sessionId) return false;
+  try {
+    const [later] = await db
+      .select({ commandId: sessionLifecycleCommands.commandId })
+      .from(sessionLifecycleCommands)
+      .where(
+        and(
+          eq(sessionLifecycleCommands.sessionId, row.sessionId),
+          eq(sessionLifecycleCommands.commandType, 'continue_session'),
+          sql`${sessionLifecycleCommands.payload}->>'clientMessageId' IS NOT NULL`,
+          sql`${sessionLifecycleCommands.createdAt} > ${row.createdAt.toISOString()}::timestamptz`,
+          or(
+            inArray(sessionLifecycleCommands.status, ['queued', 'running']),
+            sql`${sessionLifecycleCommands.result}->>'status' = 'forwarded'`,
+          ),
+        ),
+      )
+      .limit(1);
+    return !!later;
+  } catch {
+    return false; // fail open: a solo repair is better than none
+  }
+}
+
 /**
  * Delete a stranded user message from the root transcript, so the re-placed
  * copy is the only one OpenCode — and the model — holds. `true` only on a
@@ -1202,8 +1299,27 @@ function externalIdFromSandboxUrlField(url: string | null): string | null {
   return match?.[1] ?? null;
 }
 
+/**
+ * How one row of a same-session BATCH (see the drain's lane runner)
+ * coordinates with the rows before it: it waits its turn to MINT (so ids come
+ * out in queue order), releases the next row the moment its id is final, and
+ * then POSTs concurrently with everyone else.
+ */
+export interface BatchPlacementGate {
+  waitTurn: Promise<void>;
+  release: () => void;
+}
+
+export interface ExecuteQueuedContinueOptions {
+  /** A member of a same-session batch after the head: admission is the
+   *  batch's own ordering, and the id is placed as into a LIVE turn (the head
+   *  opened one) and proven afterwards. */
+  batch?: BatchPlacementGate;
+}
+
 export async function executeQueuedContinue(
   row: SessionLifecycleCommandRow,
+  opts: ExecuteQueuedContinueOptions = {},
 ): Promise<'succeeded' | 'queued' | 'failed'> {
   const payload = row.payload as unknown as QueuedContinueSessionPayload;
   const text = typeof payload.text === 'string' ? payload.text : '';
@@ -1236,7 +1352,11 @@ export async function executeQueuedContinue(
   const tl = new ProvisionTimeline(row.commandId, 'deliver');
   let admission: Awaited<ReturnType<typeof admitInboxPrompt>>;
   try {
-    admission = await admitInboxPrompt(row);
+    // A batch member's ordering IS the batch: the lane minted the rows before
+    // it first (see the gate below), so the admission read — "is an older
+    // prompt of this session in flight?" — would only ever refuse it for the
+    // siblings it is being delivered with.
+    admission = opts.batch ? { admit: true } : await admitInboxPrompt(row);
     tl.mark('admission');
   } catch (err) {
     await markCommandFailed(
@@ -1395,7 +1515,14 @@ export async function executeQueuedContinue(
   // none, and every id-less producer would pay for this read for nothing.
   const remintKnown = deliveryAttempt > 0 || redeliveries > 0 || waited;
   let turnLive = false;
-  if (payload.wireMessageId && !remintKnown) {
+  // The head of the batch landed and opened a turn (or joined the live one);
+  // every row after it is placed as into a live turn, by definition.
+  if (opts.batch) {
+    await opts.batch.waitTurn;
+    tl.mark('batch-turn');
+    turnLive = true;
+  }
+  if (payload.wireMessageId && !remintKnown && !opts.batch) {
     try {
       turnLive = await sessionHoldsLiveTurn(row.sessionId);
     } catch (err) {
@@ -1408,6 +1535,9 @@ export async function executeQueuedContinue(
     }
   }
   let wireMessageId = payload.wireMessageId;
+  /** Deliberately placed BELOW an open sibling — the sibling's step answers
+   *  it, and the post-insert strand proof must not "repair" it to the top. */
+  let underPlaced = false;
   if (payload.wireMessageId && (remintKnown || turnLive)) {
     const deliveredIds = [payload.wireMessageId, payload.redeliveredMessageId].filter(
       (id): id is string => typeof id === 'string' && id.length > 0,
@@ -1419,7 +1549,10 @@ export async function executeQueuedContinue(
     const stagedRevertEarly = await stagedRevertPromise;
     if (stagedRevertEarly) {
       const settled = await settleStagedRevert();
-      if (settled) return settled;
+      if (settled) {
+        opts.batch?.release();
+        return settled;
+      }
     }
     const transcript = await transcriptPromise;
     tl.mark('transcript-read');
@@ -1442,11 +1575,35 @@ export async function executeQueuedContinue(
         { status: 'skipped', reason: 'already_answered' },
         row.sessionId,
       );
+      opts.batch?.release();
       return 'succeeded';
     }
-    wireMessageId = await remintWireMessageId(row, payload, transcript);
-    tl.mark('remint');
+    // A LATE delivery does not always go to the top. When the transcript
+    // still holds an OPEN sibling above this prompt's original id — placed,
+    // unanswered — the original id slots the prompt into its SEND position,
+    // and that sibling's step answers both (OpenCode hands the model the
+    // whole transcript). Re-minting was what put a delayed message below its
+    // answer— and a re-mint here put it visually LAST when it was sent
+    // first. Only a first delivery may do this: a re-POST's original id may
+    // already be persisted.
+    if (
+      deliveryAttempt === 0 &&
+      redeliveries === 0 &&
+      payload.wireMessageId &&
+      transcript.read &&
+      transcript.tip &&
+      openUserAbove(transcript.tip, payload.wireMessageId)
+    ) {
+      wireMessageId = payload.wireMessageId;
+      underPlaced = true;
+      tl.mark('under-placed');
+    } else {
+      wireMessageId = await remintWireMessageId(row, payload, transcript);
+      tl.mark('remint');
+    }
   }
+  // The id is final: the next batch member may mint above it.
+  opts.batch?.release();
 
   {
     const stagedRevertLate = await stagedRevertPromise;
@@ -1517,7 +1674,19 @@ export async function executeQueuedContinue(
       // message, which calibrates the next placement for this session.
       const proof = await verifyLivePlacement(row, wireMessageId, postedAt);
       tl.mark('placement-proof');
+      if (underPlaced) break; // below an open sibling by design — its step answers this
       if (!proof.stranded) break;
+      // A later sibling already on the wire pins this row's ORDER: repairing
+      // solo would re-mint it above the sibling and OpenCode would answer them
+      // inverted. The turn-end reconciliation re-places the whole tail in
+      // send order instead.
+      if (await hasLaterForwardedSibling(row)) {
+        logger.info(
+          '[session-lifecycle] stranded prompt has later siblings — turn-end reconciliation will re-place the tail in order',
+          { session_id: row.sessionId, command_id: row.commandId, wire_message_id: wireMessageId },
+        );
+        break;
+      }
       if (round >= MAX_LIVE_PLACEMENT_REPAIRS) {
         logger.error(
           '[session-lifecycle] forwarded prompt still stranded after repairs — leaving it to turn-end reconciliation',

--- a/apps/api/src/projects/session-lifecycle/forwarded-placement.test.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-placement.test.ts
@@ -112,6 +112,26 @@ describe('reachedPlacement + tipIsBusy', () => {
   test('a stranded message is NOT reached (higher assistant, older parent)', () => {
     expect(reachedPlacement([{ id: u1, role: 'user' }, { id: u2, role: 'user' }, { id: id(T + 25, 1, 'ASSTXASSTXASST'), role: 'assistant', parentID: u1 }], u2)).toBe(false);
   });
+  test('an assistant whose step STARTED before the message was persisted has not read it', () => {
+    // Under-placement gives the message a LOW id on purpose; the running
+    // step's assistant has a higher id and a parent >= it — but the box's
+    // arrival stamps prove the step began first. Not reached → cancellable.
+    const asst = id(T + 41, 1, 'ASSTRASSTRASST');
+    const tip = [
+      { id: u3, role: 'user', created: 500 },
+      { id: u2, role: 'user', created: 900 }, // under-placed, arrived later
+      { id: asst, role: 'assistant', parentID: u3, created: 600 },
+    ];
+    expect(reachedPlacement(tip, u2)).toBe(false);
+    // Same shape, but the step began AFTER the message landed: reached.
+    const tip2 = [
+      { id: u3, role: 'user', created: 500 },
+      { id: u2, role: 'user', created: 550 },
+      { id: asst, role: 'assistant', parentID: u3, created: 600 },
+    ];
+    expect(reachedPlacement(tip2, u2)).toBe(true);
+  });
+
   test('tipIsBusy reads the newest assistant', () => {
     expect(tipIsBusy([{ id: a1, role: 'assistant', parentID: u1, completed: null }])).toBe(true);
     expect(tipIsBusy([{ id: a1, role: 'assistant', parentID: u1, completed: 5 }])).toBe(false);
@@ -129,8 +149,8 @@ describe('parsePlacementTip', () => {
         null,
       ]),
     ).toEqual([
-      { id: 'msg_a', role: 'user', parentID: null, created: 5, completed: null },
-      { id: 'msg_b', role: 'assistant', parentID: 'msg_a', created: null, completed: null },
+      { id: 'msg_a', role: 'user', parentID: null, created: 5, completed: null, partIds: [] },
+      { id: 'msg_b', role: 'assistant', parentID: 'msg_a', created: null, completed: null, partIds: [] },
     ]);
     expect(parsePlacementTip({})).toBeNull();
   });

--- a/apps/api/src/projects/session-lifecycle/forwarded-placement.test.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-placement.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  boxClockSkewMs,
+  reachedPlacement,
+  tipIsBusy,
+  mintLivePlacement,
+  noteBoxClockSample,
+  parsePlacementTip,
+  resetBoxClockSkewForTests,
+  strandedPlacement,
+} from './forwarded-placement';
+import { WIRE_ID_TIME_SCALE, wireIdTime } from '../wire-message-id';
+
+/** An id whose clock is `ms` (box clock) and counter `n`. */
+const id = (ms: number, n = 1, tail = 'AAAAAAAAAAAAAA') =>
+  `msg_${((BigInt(ms) * WIRE_ID_TIME_SCALE + BigInt(n)) & BigInt(0xffffffffffff)).toString(16).padStart(12, '0')}${tail}`;
+
+const T = 1_800_000_000_000;
+
+describe('strandedPlacement', () => {
+  const user1 = id(T, 1, 'USER1USER1USER');
+  const asst1 = id(T + 10, 1, 'ASST1ASST1ASST');
+  const user2 = id(T + 20, 1, 'USER2USER2USER');
+
+  test('answered when an assistant is parented on the wire id', () => {
+    const v = strandedPlacement(
+      [
+        { id: user1, role: 'user' },
+        { id: asst1, role: 'assistant', parentID: user1 },
+        { id: user2, role: 'user', created: T + 20 },
+        { id: id(T + 30, 1, 'ASST2ASST2ASST'), role: 'assistant', parentID: user2 },
+      ],
+      user2,
+    );
+    expect(v.answered).toBe(true);
+    expect(v.stranded).toBe(false);
+    expect(v.createdMs).toBe(T + 20);
+  });
+
+  test('stranded: a higher assistant whose parent is an OLDER user message', () => {
+    // user2 was inserted at T+20 with an id below asst2 (created T+25 by a
+    // step that read the transcript before user2 existed).
+    const asst2 = id(T + 25, 1, 'ASST2ASST2ASST');
+    const v = strandedPlacement(
+      [
+        { id: user1, role: 'user' },
+        { id: asst1, role: 'assistant', parentID: user1 },
+        { id: id(T + 22, 1, 'LATEUSERLATEUS'), role: 'user' },
+        { id: asst2, role: 'assistant', parentID: user1 },
+      ],
+      id(T + 22, 1, 'LATEUSERLATEUS'),
+    );
+    expect(v.stranded).toBe(true);
+    expect(v.strandedBy).toBe(asst2);
+    expect(v.newest).toBe(wireIdTime(asst2));
+  });
+
+  test('not stranded: the higher assistant is parented on a NEWER user message (answered in that step)', () => {
+    // OpenCode parents the step on the newest user message and answers every
+    // queued one before it in the same step.
+    const user3 = id(T + 40, 1, 'USER3USER3USER');
+    const asst3 = id(T + 41, 1, 'ASST3ASST3ASST');
+    const v = strandedPlacement(
+      [
+        { id: user2, role: 'user' },
+        { id: user3, role: 'user' },
+        { id: asst3, role: 'assistant', parentID: user3 },
+      ],
+      user2,
+    );
+    expect(v.stranded).toBe(false);
+    expect(v.answered).toBe(false);
+  });
+
+  test('not reached yet: no assistant above it', () => {
+    const v = strandedPlacement(
+      [
+        { id: user1, role: 'user' },
+        { id: asst1, role: 'assistant', parentID: user1 },
+        { id: user2, role: 'user' },
+      ],
+      user2,
+    );
+    expect(v.stranded).toBe(false);
+    expect(v.answered).toBe(false);
+  });
+
+  test('an assistant with no parent proves nothing', () => {
+    const v = strandedPlacement(
+      [
+        { id: user2, role: 'user' },
+        { id: id(T + 30, 1, 'ORPHANORPHANOR'), role: 'assistant' },
+      ],
+      user2,
+    );
+    expect(v.stranded).toBe(false);
+  });
+});
+
+describe('reachedPlacement + tipIsBusy', () => {
+  const u1 = id(T, 1, 'USER1USER1USER');
+  const a1 = id(T + 10, 1, 'ASST1ASST1ASST');
+  const u2 = id(T + 20, 1, 'USER2USER2USER');
+  const u3 = id(T + 30, 1, 'USER3USER3USER');
+  const a3 = id(T + 31, 1, 'ASST3ASST3ASST');
+  test('unreached: nothing above it read it', () => {
+    expect(reachedPlacement([{ id: u1, role: 'user' }, { id: a1, role: 'assistant', parentID: u1 }, { id: u2, role: 'user' }], u2)).toBe(false);
+  });
+  test('reached via a step parented on a newer user message', () => {
+    expect(reachedPlacement([{ id: u2, role: 'user' }, { id: u3, role: 'user' }, { id: a3, role: 'assistant', parentID: u3 }], u2)).toBe(true);
+  });
+  test('a stranded message is NOT reached (higher assistant, older parent)', () => {
+    expect(reachedPlacement([{ id: u1, role: 'user' }, { id: u2, role: 'user' }, { id: id(T + 25, 1, 'ASSTXASSTXASST'), role: 'assistant', parentID: u1 }], u2)).toBe(false);
+  });
+  test('tipIsBusy reads the newest assistant', () => {
+    expect(tipIsBusy([{ id: a1, role: 'assistant', parentID: u1, completed: null }])).toBe(true);
+    expect(tipIsBusy([{ id: a1, role: 'assistant', parentID: u1, completed: 5 }])).toBe(false);
+    expect(tipIsBusy([{ id: u1, role: 'user' }])).toBe(false);
+  });
+});
+
+describe('parsePlacementTip', () => {
+  test('reads id, role, parentID and time.created', () => {
+    expect(
+      parsePlacementTip([
+        { info: { id: 'msg_a', role: 'user', time: { created: 5 } } },
+        { info: { id: 'msg_b', role: 'assistant', parentID: 'msg_a' } },
+        { info: { role: 'assistant' } },
+        null,
+      ]),
+    ).toEqual([
+      { id: 'msg_a', role: 'user', parentID: null, created: 5, completed: null },
+      { id: 'msg_b', role: 'assistant', parentID: 'msg_a', created: null, completed: null },
+    ]);
+    expect(parsePlacementTip({})).toBeNull();
+  });
+});
+
+describe('box clock + live placement', () => {
+  afterEach(() => resetBoxClockSkewForTests());
+
+  test('skew is a lower bound (created − ack) and expires', () => {
+    expect(noteBoxClockSample('s1', 1_000, 1_250, 10_000)).toBe(-250);
+    expect(boxClockSkewMs('s1', 10_000)).toBe(-250);
+    expect(boxClockSkewMs('s1', 10_000 + 3 * 60_000)).toBeNull();
+  });
+
+  test('no skew → the classic floor (newest+1, backdated clock)', () => {
+    const newest = wireIdTime(id(T + 500));
+    const m = mintLivePlacement({ nowMs: T + 600, newestKnownTime: newest, boxSkewMs: null, random: () => 0 });
+    expect(m.lifted).toBe(false);
+    expect(m.time).toBe(newest! + BigInt(1));
+  });
+
+  test('known skew lifts the id to the box clock now, above the floor', () => {
+    const newest = wireIdTime(id(T + 500));
+    const m = mintLivePlacement({ nowMs: T + 2_000, newestKnownTime: newest, boxSkewMs: -300, random: () => 0 });
+    expect(m.lifted).toBe(true);
+    expect(m.time).toBe((BigInt(T + 1_700) * WIRE_ID_TIME_SCALE) & BigInt(0xffffffffffff));
+    expect(m.id).toMatch(/^msg_[0-9a-f]{12}[A-Za-z0-9]{14}$/);
+  });
+
+  test('the lift never goes below the floor', () => {
+    // The box wrote an id newer than our estimate of its clock.
+    const newest = wireIdTime(id(T + 5_000));
+    const m = mintLivePlacement({ nowMs: T + 2_000, newestKnownTime: newest, boxSkewMs: 0, random: () => 0 });
+    expect(m.lifted).toBe(false);
+    expect(m.time).toBe(newest! + BigInt(1));
+  });
+
+  test('an absurd skew is not trusted', () => {
+    const newest = wireIdTime(id(T + 500));
+    const m = mintLivePlacement({ nowMs: T + 2_000, newestKnownTime: newest, boxSkewMs: 5 * 60 * 60_000, random: () => 0 });
+    expect(m.lifted).toBe(false);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/forwarded-placement.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-placement.ts
@@ -57,6 +57,9 @@ export interface PlacementTipMessage {
   created?: number | null;
   /** `time.completed` — null/absent while an assistant message is still open. */
   completed?: number | null;
+  /** Ids of the message's parts. A USER message with zero parts is a husk a
+   *  cancel left behind (the model never sees it) — see the reconcile sweep. */
+  partIds?: string[];
 }
 
 export interface PlacementVerdict {
@@ -134,12 +137,28 @@ export function reachedPlacement(
 ): boolean {
   const mine = wireIdTime(wireMessageId);
   if (mine === null) return false;
+  const own = tip.find((m) => m.id === wireMessageId);
   for (const m of tip) {
     if (m.role !== 'assistant') continue;
     if (m.parentID === wireMessageId) return true;
     const at = wireIdTime(m.id);
     const parentAt = typeof m.parentID === 'string' ? wireIdTime(m.parentID) : null;
-    if (at !== null && parentAt !== null && at > mine && parentAt >= mine) return true;
+    if (at === null || parentAt === null || at <= mine || parentAt < mine) continue;
+    // ID order says this step covers the message — but ids are minted from
+    // the SENDER's clock, not from causality: a message deliberately placed
+    // BELOW the running step's parent (under-placement) has a lower id than
+    // an assistant whose step began before it even arrived. `time.created`
+    // is stamped at PERSISTENCE by the box, on one clock — when both stamps
+    // exist, a step only read this message if it STARTED after the message
+    // was persisted.
+    if (
+      typeof own?.created === 'number' &&
+      typeof m.created === 'number' &&
+      m.created <= own.created
+    ) {
+      continue;
+    }
+    return true;
   }
   return false;
 }
@@ -193,6 +212,9 @@ export function parsePlacementTip(body: unknown): PlacementTipMessage[] | null {
       parentID: typeof info.parentID === 'string' ? info.parentID : null,
       created: typeof time?.created === 'number' ? time.created : null,
       completed: typeof time?.completed === 'number' ? time.completed : null,
+      partIds: (
+        (entry as { parts?: Array<{ id?: unknown }> }).parts ?? []
+      ).flatMap((part) => (typeof part?.id === 'string' ? [part.id] : [])),
     });
   }
   return out;

--- a/apps/api/src/projects/session-lifecycle/forwarded-placement.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-placement.ts
@@ -1,0 +1,285 @@
+/**
+ * Placing a forwarded prompt INTO a live OpenCode turn, and proving it landed.
+ *
+ * OpenCode's loop decides "is the latest user message answered?" by ID ORDER:
+ * at the top of every step it exits when `lastUser.id < lastAssistant.id` and
+ * that assistant finished without tool calls. A user message whose id sorts
+ * below an assistant message that was created BEFORE it was inserted is
+ * therefore read as history the moment the running step ends — the model
+ * never sees it and nothing ever answers it. The prompt is STRANDED: persisted,
+ * visible in the transcript, silently dropped.
+ *
+ * The drain re-mints a mid-turn prompt above the transcript's newest id, but
+ * "newest" is read BEFORE the POST. The box keeps minting ids on its own clock
+ * in between (every step opens a new assistant message), so a read→insert
+ * window of a few hundred milliseconds loses a prompt whenever a step boundary
+ * falls inside it. Measured locally: 1 of 3 queued prompts (`queue-lab`,
+ * 2026-08-19).
+ *
+ * Two layers close that window, both server-side:
+ *
+ *  1. PLACEMENT — `mintLivePlacement`: place the prompt at the BOX's clock
+ *     "now", not at newest+1. The box clock is learned from the box itself:
+ *     every message we insert comes back with `time.created` stamped by the
+ *     box, and we know when our POST was acknowledged, so
+ *     `created − ackAt` is a lower bound on (box − api) skew (the box stamped
+ *     it before we saw the ack). Lower bound on purpose: an id that lands a
+ *     little LOW can only be stranded, which layer 2 repairs; an id that lands
+ *     HIGH (above the assistant that will answer it) makes OpenCode run the
+ *     step twice — a duplicate answer nothing can take back.
+ *
+ *  2. PROOF — `strandedPlacement`: after the insert, one tip read answers
+ *     "did this land above every assistant that predates it?" exactly. An
+ *     assistant with a higher id whose parent is an OLDER user message was
+ *     created by a step that never read this prompt. When it is there, the
+ *     drain deletes the stranded message and delivers again, above it. The
+ *     same predicate runs at turn end for every still-open forwarded prompt
+ *     (`routes/r4.ts` `turn-stream` `end`) — the safety net for a verify read
+ *     that failed.
+ *
+ * Pure over its inputs so the golden cases are assertable without a box.
+ */
+
+import {
+  MAX_WIRE_ID_CLOCK_CORRECTION,
+  WIRE_ID_TIME_MASK,
+  WIRE_ID_TIME_SCALE,
+  mintWireMessageId,
+  newestWireIdTime,
+  wireIdTime,
+} from '../wire-message-id';
+
+/** The shape of one transcript message the placement logic reads. */
+export interface PlacementTipMessage {
+  id: string;
+  role: string;
+  parentID?: string | null;
+  created?: number | null;
+  /** `time.completed` — null/absent while an assistant message is still open. */
+  completed?: number | null;
+}
+
+export interface PlacementVerdict {
+  /** An assistant message is parented on this wire id — the turn ran. */
+  answered: boolean;
+  /** The strand signature: an assistant with a HIGHER id whose parent is an
+   *  OLDER user message — a step that never read this prompt finished after
+   *  it landed. Never true when `answered`. */
+  stranded: boolean;
+  /** The id of the newest assistant that proves the strand, for the log. */
+  strandedBy: string | null;
+  /** Highest id clock on the tip, for placing the next mint above it. */
+  newest: bigint | null;
+  /** The box's `time.created` for this wire id, when the tip holds it. */
+  createdMs: number | null;
+}
+
+/**
+ * Is this forwarded prompt answered, stranded, or still in line?
+ *
+ *  - answered: some assistant's `parentID` is this id.
+ *  - stranded: no assistant answers it, and some assistant has a higher id
+ *    AND a parent that sorts BELOW this id. That assistant's step read the
+ *    transcript before this prompt existed; the loop's exit check sorts this
+ *    prompt under it and never runs it. An assistant with a higher id whose
+ *    parent is this id or a NEWER user message read the prompt (OpenCode
+ *    parents each step on the newest user message and answers everything
+ *    before it in that step) — that is "in line", not stranded.
+ *  - otherwise: not reached yet.
+ *
+ * An assistant with no readable parent proves nothing either way.
+ */
+export function strandedPlacement(
+  tip: ReadonlyArray<PlacementTipMessage>,
+  wireMessageId: string,
+): PlacementVerdict {
+  const mine = wireIdTime(wireMessageId);
+  const newest = newestWireIdTime(tip.map((m) => m.id));
+  const own = tip.find((m) => m.id === wireMessageId);
+  const createdMs = typeof own?.created === 'number' && Number.isFinite(own.created) ? own.created : null;
+  let answered = false;
+  let strandedBy: string | null = null;
+  if (mine !== null) {
+    for (const m of tip) {
+      if (m.role !== 'assistant') continue;
+      if (m.parentID === wireMessageId) {
+        answered = true;
+        break;
+      }
+      const at = wireIdTime(m.id);
+      const parentAt = typeof m.parentID === 'string' ? wireIdTime(m.parentID) : null;
+      if (at === null || parentAt === null) continue;
+      if (at > mine && parentAt < mine) strandedBy = m.id;
+    }
+  }
+  return {
+    answered,
+    stranded: !answered && strandedBy !== null,
+    strandedBy: answered ? null : strandedBy,
+    newest,
+    createdMs,
+  };
+}
+
+/**
+ * Has the loop REACHED this user message — read it into a step? True when an
+ * assistant answers it, or when an assistant with a higher id is parented on
+ * it or on a NEWER user message (that step's read included it). A message the
+ * loop has not reached is still just text in the transcript: it can be taken
+ * back out without the model ever having seen it.
+ */
+export function reachedPlacement(
+  tip: ReadonlyArray<PlacementTipMessage>,
+  wireMessageId: string,
+): boolean {
+  const mine = wireIdTime(wireMessageId);
+  if (mine === null) return false;
+  for (const m of tip) {
+    if (m.role !== 'assistant') continue;
+    if (m.parentID === wireMessageId) return true;
+    const at = wireIdTime(m.id);
+    const parentAt = typeof m.parentID === 'string' ? wireIdTime(m.parentID) : null;
+    if (at !== null && parentAt !== null && at > mine && parentAt >= mine) return true;
+  }
+  return false;
+}
+
+/** Is the box mid-step — its newest assistant message still open? */
+export function tipIsBusy(tip: ReadonlyArray<PlacementTipMessage>): boolean {
+  let newest: PlacementTipMessage | null = null;
+  for (const m of tip) {
+    if (m.role !== 'assistant') continue;
+    if (!newest || m.id > newest.id) newest = m;
+  }
+  return !!newest && (newest.completed === null || newest.completed === undefined);
+}
+
+/** Parse OpenCode's `GET /session/:id/message` body into tip messages. */
+export function parsePlacementTip(body: unknown): PlacementTipMessage[] | null {
+  if (!Array.isArray(body)) return null;
+  const out: PlacementTipMessage[] = [];
+  for (const entry of body) {
+    const info = (entry as { info?: Record<string, unknown> } | null)?.info;
+    if (!info || typeof info.id !== 'string' || typeof info.role !== 'string') continue;
+    const time = info.time as { created?: unknown; completed?: unknown } | undefined;
+    out.push({
+      id: info.id,
+      role: info.role,
+      parentID: typeof info.parentID === 'string' ? info.parentID : null,
+      created: typeof time?.created === 'number' ? time.created : null,
+      completed: typeof time?.completed === 'number' ? time.completed : null,
+    });
+  }
+  return out;
+}
+
+// ─── Box clock ───────────────────────────────────────────────────────────────
+
+/**
+ * A learned (box − api) clock skew, per session. In-process and bounded: a
+ * replica that has not learned a session's skew falls back to newest+1 and the
+ * proof layer — correctness never depends on this cache being populated.
+ *
+ * SHORT-lived on purpose. A sample is only ever taken from a live delivery,
+ * and a box that parks and resumes (a snapshot restore) comes back with its
+ * guest clock BEHIND by the parked time until NTP steps it — a sample from
+ * before the park would then place ids HIGH, the one direction nothing can
+ * repair. A box parks only after minutes of idle, so a 2-minute TTL cannot
+ * straddle a park; every live delivery re-samples anyway.
+ */
+const SKEW_TTL_MS = 2 * 60_000;
+const SKEW_CACHE_MAX = 5_000;
+const skewBySession = new Map<string, { skewMs: number; at: number }>();
+
+/**
+ * Record one sample: the box stamped `createdMs` on a message whose POST we
+ * saw acknowledged at `ackAtMs` (api clock). The box wrote the stamp before
+ * we saw the ack, so `created − ack` never overstates the skew.
+ */
+export function noteBoxClockSample(
+  sessionId: string,
+  createdMs: number,
+  ackAtMs: number,
+  nowMs = Date.now(),
+): number {
+  const skewMs = createdMs - ackAtMs;
+  if (skewBySession.size >= SKEW_CACHE_MAX) {
+    const oldest = skewBySession.keys().next().value;
+    if (oldest !== undefined) skewBySession.delete(oldest);
+  }
+  skewBySession.delete(sessionId);
+  skewBySession.set(sessionId, { skewMs, at: nowMs });
+  return skewMs;
+}
+
+/**
+ * Chaos knob: `KORTIX_PLACEMENT_LIFT_DISABLED=1` places every live-turn
+ * delivery at newest+1 again (the pre-fix behaviour), so the strand path and
+ * its turn-end repair can be exercised on demand. Never set in a deployment.
+ */
+function liftDisabled(): boolean {
+  return (process.env.KORTIX_PLACEMENT_LIFT_DISABLED ?? '').trim() === '1';
+}
+
+export function boxClockSkewMs(sessionId: string, nowMs = Date.now()): number | null {
+  if (liftDisabled()) return null;
+  const entry = skewBySession.get(sessionId);
+  if (!entry) return null;
+  if (nowMs - entry.at > SKEW_TTL_MS) {
+    skewBySession.delete(sessionId);
+    return null;
+  }
+  return entry.skewMs;
+}
+
+/** Test seam. */
+export function resetBoxClockSkewForTests(): void {
+  skewBySession.clear();
+}
+
+/**
+ * A learned skew larger than this is not trusted for placement: it would put
+ * the id far from anything the box is writing, which on the high side means a
+ * duplicate step. Bounded by the same ceiling the transcript lift accepts.
+ */
+const MAX_TRUSTED_SKEW_MS = Number(MAX_WIRE_ID_CLOCK_CORRECTION / WIRE_ID_TIME_SCALE);
+
+/**
+ * Mint the id a LIVE-turn delivery goes out under.
+ *
+ * Floor: strictly above `newestKnownTime` (what `remintWireMessageId` always
+ * did). Lift: when the box clock is known, up to the box's estimated "now" —
+ * where OpenCode itself would have minted the message, which is the one place
+ * that is both above every assistant already created and below the one that
+ * will answer it. The lift is never applied beyond the trusted-skew ceiling,
+ * and never moves the id BELOW the floor.
+ */
+export function mintLivePlacement(input: {
+  nowMs: number;
+  newestKnownTime: bigint | null;
+  boxSkewMs: number | null;
+  random?: () => number;
+}): { id: string; time: bigint; lifted: boolean } {
+  const base = mintWireMessageId({
+    nowMs: input.nowMs,
+    newestKnownTime: input.newestKnownTime,
+    random: input.random,
+  });
+  const skew = input.boxSkewMs;
+  if (skew === null || !Number.isFinite(skew) || Math.abs(skew) > MAX_TRUSTED_SKEW_MS) {
+    return { ...base, lifted: false };
+  }
+  const boxNow =
+    (BigInt(Math.trunc(input.nowMs + skew)) * WIRE_ID_TIME_SCALE) & WIRE_ID_TIME_MASK;
+  if (boxNow <= base.time) return { ...base, lifted: false };
+  // Never lift past what the floor itself would accept as a correction.
+  if (input.newestKnownTime !== null && boxNow - input.newestKnownTime > MAX_WIRE_ID_CLOCK_CORRECTION) {
+    return { ...base, lifted: false };
+  }
+  const tail = base.id.slice('msg_'.length + 12);
+  return {
+    id: `msg_${boxNow.toString(16).padStart(12, '0')}${tail}`,
+    time: boxNow,
+    lifted: true,
+  };
+}

--- a/apps/api/src/projects/session-lifecycle/forwarded-placement.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-placement.ts
@@ -144,6 +144,31 @@ export function reachedPlacement(
   return false;
 }
 
+/**
+ * Is there an OPEN user message ABOVE this id — placed (not stranded),
+ * unanswered? Then a message that sits BELOW it is not lost: OpenCode's next
+ * step parents on the newest user message and hands the model the whole
+ * transcript, so everything under it is answered in that step. This is what
+ * lets a late delivery keep its ORIGINAL (send-ordered) id instead of
+ * re-minting to the top, and what lets the reconciler leave a stranded row
+ * alone.
+ */
+export function openUserAbove(
+  tip: ReadonlyArray<PlacementTipMessage>,
+  wireMessageId: string,
+): boolean {
+  const mine = wireIdTime(wireMessageId);
+  if (mine === null) return false;
+  for (const m of tip) {
+    if (m.role !== 'user' || m.id === wireMessageId) continue;
+    const at = wireIdTime(m.id);
+    if (at === null || at <= mine) continue;
+    const v = strandedPlacement(tip, m.id);
+    if (!v.answered && !v.stranded) return true;
+  }
+  return false;
+}
+
 /** Is the box mid-step — its newest assistant message still open? */
 export function tipIsBusy(tip: ReadonlyArray<PlacementTipMessage>): boolean {
   let newest: PlacementTipMessage | null = null;

--- a/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.test.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.test.ts
@@ -40,7 +40,7 @@ describe('reconcileForwardedTurnsAtEnd', () => {
   test('no-op without an ended message id when the tip has no finished assistant either', async () => {
     const { deps, calls } = fakeDeps({ open: [turn(u1)], tip: [] });
     const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's' }, deps);
-    expect(out).toEqual({ closedOlder: 0, candidates: 0, stranded: 0, requeued: 0 });
+    expect(out).toEqual({ closedOlder: 0, candidates: 0, stranded: 0, requeued: 0, reordered: 0 });
     expect(calls.closeOlder).toHaveLength(0);
   });
 
@@ -54,7 +54,7 @@ describe('reconcileForwardedTurnsAtEnd', () => {
     ];
     const { deps, calls } = fakeDeps({ open: [turn(u1), turn(u4, 'delivering')], tip });
     const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's' }, deps);
-    expect(out).toEqual({ closedOlder: 1, candidates: 1, stranded: 1, requeued: 1 });
+    expect(out).toEqual({ closedOlder: 1, candidates: 1, stranded: 1, requeued: 1, reordered: 0 });
     expect(calls.closeOlder.map((c) => c[2])).toEqual([u1]);
     expect(calls.remove).toEqual([['s', u4]]);
   });
@@ -75,7 +75,7 @@ describe('reconcileForwardedTurnsAtEnd', () => {
     ];
     const { deps, calls } = fakeDeps({ open: [turn(u4, 'delivering')], tip });
     const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M }, deps);
-    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 1, requeued: 1 });
+    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 1, requeued: 1, reordered: 0 });
     expect(calls.remove).toEqual([['s', u4]]);
     expect(calls.requeue).toEqual([['s', u4]]);
     expect(calls.closeStranded).toEqual([['s', u4]]);
@@ -92,7 +92,7 @@ describe('reconcileForwardedTurnsAtEnd', () => {
     ];
     const { deps, calls } = fakeDeps({ open: [turn(u5)], tip });
     const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M }, deps);
-    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 0, requeued: 0 });
+    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 0, requeued: 0, reordered: 0 });
     expect(calls.remove).toHaveLength(0);
     expect(calls.closeStranded).toHaveLength(0);
   });
@@ -121,6 +121,69 @@ describe('reconcileForwardedTurnsAtEnd', () => {
     expect(out.requeued).toBe(0);
     expect(calls.requeue).toHaveLength(0);
     expect(calls.closeStranded).toHaveLength(0);
+  });
+
+  test('a stranded row with a later OPEN sibling above it is left in place — that sibling\'s step answers both', async () => {
+    // u4 stranded below aM; u5 landed fine above it and is still unanswered.
+    // OpenCode's next step parents on u5 and hands the model the whole
+    // transcript — u4 included — so pulling u4 back out would only reorder
+    // the user's messages. Nothing is removed or re-queued.
+    const tip = [
+      { id: M, role: 'user' },
+      { id: u4, role: 'user' },
+      { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 },
+      { id: u5, role: 'user' },
+    ];
+    const { deps, calls } = fakeDeps({ open: [turn(u4, 'delivering'), turn(u5, 'delivering')], tip });
+    const out = await reconcileForwardedTurnsAtEnd(
+      { sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M },
+      deps,
+    );
+    expect(out).toEqual({ closedOlder: 0, candidates: 2, stranded: 1, requeued: 0, reordered: 0 });
+    expect(calls.remove).toHaveLength(0);
+    expect(calls.requeue).toHaveLength(0);
+  });
+
+  test('a fully stranded TAIL re-queues as a whole, so the batch re-mints it in order', async () => {
+    // Both u4 and u5 are stranded below aM — the loop exited without either.
+    // Both come back; the drain's batch re-mints them by send order.
+    const u5b = id(T + 2_600, 'USER5BUSER5BUS');
+    const tip = [
+      { id: M, role: 'user' },
+      { id: u4, role: 'user' },
+      { id: u5b, role: 'user' },
+      { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 },
+    ];
+    const { deps, calls } = fakeDeps({ open: [turn(u4, 'delivering'), turn(u5b, 'delivering')], tip });
+    const out = await reconcileForwardedTurnsAtEnd(
+      { sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M },
+      deps,
+    );
+    expect(out.stranded).toBe(2);
+    expect(out.requeued).toBe(2);
+    expect(calls.remove).toEqual([
+      ['s', u4],
+      ['s', u5b],
+    ]);
+  });
+
+  test('a later sibling a step already REACHED stays put (cannot be pulled back)', async () => {
+    const a5 = id(T + 4_100, 'ASST5ASST5ASST');
+    const tip = [
+      { id: M, role: 'user' },
+      { id: u4, role: 'user' },
+      { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 },
+      { id: u5, role: 'user' },
+      { id: a5, role: 'assistant', parentID: u5 },
+    ];
+    const { deps, calls } = fakeDeps({ open: [turn(u4, 'delivering'), turn(u5, 'delivering')], tip });
+    const out = await reconcileForwardedTurnsAtEnd(
+      { sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M },
+      deps,
+    );
+    expect(out.requeued).toBe(1);
+    expect(out.reordered).toBe(0);
+    expect(calls.remove).toEqual([['s', u4]]);
   });
 
   test('turns of another opencode root are ignored', async () => {

--- a/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.test.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test';
+import type { StoredSandboxTurn } from '../sandbox-turn-lifecycle';
+import { WIRE_ID_TIME_SCALE } from '../wire-message-id';
+import { type StrandReconcileDeps, reconcileForwardedTurnsAtEnd } from './forwarded-strand-reconcile';
+
+const id = (ms: number, tail: string) =>
+  `msg_${((BigInt(ms) * WIRE_ID_TIME_SCALE + BigInt(1)) & BigInt(0xffffffffffff)).toString(16).padStart(12, '0')}${tail}`;
+const T = 1_800_000_000_000;
+const turn = (messageId: string, state: 'delivering' | 'active' = 'active'): StoredSandboxTurn => ({
+  token: `tok-${messageId}`,
+  state,
+  messageId,
+  opencodeSessionId: 'ses_root',
+  startedAtMs: T,
+});
+
+function fakeDeps(over: Partial<StrandReconcileDeps> & { open: StoredSandboxTurn[]; tip: any[] | null }) {
+  const calls: Record<string, unknown[][]> = { closeOlder: [], closeStranded: [], remove: [], requeue: [], kick: [] };
+  const deps: StrandReconcileDeps = {
+    readOpenTurns: async () => over.open,
+    closeOlderTurn: async (...a) => { calls.closeOlder.push(a); },
+    closeStrandedTurn: async (...a) => { calls.closeStranded.push(a); },
+    readTip: async () => over.tip,
+    removeMessage: async (...a) => { calls.remove.push(a); return true; },
+    requeueStranded: async (...a) => { calls.requeue.push(a); return 'requeued'; },
+    kickDrain: (...a) => { calls.kick.push(a); },
+    ...over,
+  };
+  return { deps, calls };
+}
+
+describe('reconcileForwardedTurnsAtEnd', () => {
+  const u1 = id(T, 'USER1USER1USER');
+  const u2 = id(T + 1_000, 'USER2USER2USER');
+  const M = id(T + 2_000, 'USERMUSERMUSER');
+  const aM = id(T + 3_000, 'ASSTMASSTMASST');
+  const u4 = id(T + 2_500, 'USER4USER4USER'); // landed below aM, never read
+  const u5 = id(T + 4_000, 'USER5USER5USER'); // a fresh send after the end
+
+  test('no-op without an ended message id when the tip has no finished assistant either', async () => {
+    const { deps, calls } = fakeDeps({ open: [turn(u1)], tip: [] });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's' }, deps);
+    expect(out).toEqual({ closedOlder: 0, candidates: 0, stranded: 0, requeued: 0 });
+    expect(calls.closeOlder).toHaveLength(0);
+  });
+
+  test('a relay that names no message falls back to the newest finished assistant\'s parent', async () => {
+    // The daemon could not attribute the end; the tip can: the step that
+    // ended answered M, and u4 sits above M below its assistant — stranded.
+    const tip = [
+      { id: M, role: 'user' },
+      { id: u4, role: 'user' },
+      { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 },
+    ];
+    const { deps, calls } = fakeDeps({ open: [turn(u1), turn(u4, 'delivering')], tip });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's' }, deps);
+    expect(out).toEqual({ closedOlder: 1, candidates: 1, stranded: 1, requeued: 1 });
+    expect(calls.closeOlder.map((c) => c[2])).toEqual([u1]);
+    expect(calls.remove).toEqual([['s', u4]]);
+  });
+
+  test('older forwarded turns close as completed; the ended one is left to the relay', async () => {
+    const { deps, calls } = fakeDeps({ open: [turn(u1), turn(u2), turn(M)], tip: [] });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M }, deps);
+    expect(out.closedOlder).toBe(2);
+    expect(calls.closeOlder.map((c) => c[2])).toEqual([u1, u2]);
+    expect(out.candidates).toBe(0);
+  });
+
+  test('a stranded newer prompt is removed, re-queued, its turn closed, and the drain kicked', async () => {
+    const tip = [
+      { id: M, role: 'user' },
+      { id: u4, role: 'user' },
+      { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 },
+    ];
+    const { deps, calls } = fakeDeps({ open: [turn(u4, 'delivering')], tip });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M }, deps);
+    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 1, requeued: 1 });
+    expect(calls.remove).toEqual([['s', u4]]);
+    expect(calls.requeue).toEqual([['s', u4]]);
+    expect(calls.closeStranded).toEqual([['s', u4]]);
+    expect(calls.kick).toHaveLength(1);
+  });
+
+  test('a newer prompt that opened its own turn is left alone', async () => {
+    const a5 = id(T + 4_100, 'ASST5ASST5ASST');
+    const tip = [
+      { id: M, role: 'user' },
+      { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 },
+      { id: u5, role: 'user' },
+      { id: a5, role: 'assistant', parentID: u5 },
+    ];
+    const { deps, calls } = fakeDeps({ open: [turn(u5)], tip });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M }, deps);
+    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 0, requeued: 0 });
+    expect(calls.remove).toHaveLength(0);
+    expect(calls.closeStranded).toHaveLength(0);
+  });
+
+  test('a newer prompt not yet reached (no assistant above it) is left alone', async () => {
+    const tip = [{ id: M, role: 'user' }, { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 }, { id: u5, role: 'user' }];
+    const { deps, calls } = fakeDeps({ open: [turn(u5)], tip });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', endedMessageId: M }, deps);
+    expect(out.stranded).toBe(0);
+    expect(calls.remove).toHaveLength(0);
+  });
+
+  test('an unreadable tip skips the strand check but still closes older turns', async () => {
+    const { deps, calls } = fakeDeps({ open: [turn(u1), turn(u4)], tip: null });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', endedMessageId: M }, deps);
+    expect(out.closedOlder).toBe(1);
+    expect(out.stranded).toBe(0);
+    expect(calls.remove).toHaveLength(0);
+  });
+
+  test('a failed removal never re-queues (no duplicate), the turn stays', async () => {
+    const tip = [{ id: M, role: 'user' }, { id: u4, role: 'user' }, { id: aM, role: 'assistant', parentID: M }];
+    const { deps, calls } = fakeDeps({ open: [turn(u4)], tip, removeMessage: async () => false });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', endedMessageId: M }, deps);
+    expect(out.stranded).toBe(1);
+    expect(out.requeued).toBe(0);
+    expect(calls.requeue).toHaveLength(0);
+    expect(calls.closeStranded).toHaveLength(0);
+  });
+
+  test('turns of another opencode root are ignored', async () => {
+    const foreign = { ...turn(u1), opencodeSessionId: 'ses_child' };
+    const { deps, calls } = fakeDeps({ open: [foreign], tip: [] });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M }, deps);
+    expect(out.closedOlder).toBe(0);
+    expect(calls.closeOlder).toHaveLength(0);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.ts
@@ -1,0 +1,318 @@
+/**
+ * Turn-end reconciliation for prompts forwarded INTO a live turn.
+ *
+ * When the daemon relays that a turn ENDED (`turn-stream` kind `end`, with the
+ * user message the final assistant answered — `M`), every forwarded prompt
+ * still open in the turn ledger is one of two things:
+ *
+ *  - OLDER than `M` (lower wire id): the loop had it when it opened the step
+ *    that ended — OpenCode parents each step on the newest user message and
+ *    answers everything queued before it in that same step. It is DONE, and
+ *    its ledger record must close now. Left open it only closed when a reaper
+ *    sweep gave up on it (~20 s later, `unknown`), and for those 20 s the
+ *    session read as WORKING to every client (`sessionHoldsTurnAuthority`),
+ *    shimmer and all, after the final answer was on screen.
+ *
+ *  - NEWER than `M` (higher wire id): either a prompt that opened a turn of
+ *    its own after this one (the `end` relay is ~1 s behind the box, so a
+ *    fresh send can already be running), or a STRANDED prompt — persisted
+ *    below an assistant that predates it, which the loop's exit check read as
+ *    answered. The transcript tells them apart exactly (`strandedPlacement`):
+ *    a stranded one has a higher assistant parented on an OLDER user message
+ *    and nothing parented on itself. Those are taken out of the transcript and
+ *    re-queued, so the drain delivers them again — placed above everything —
+ *    instead of leaving the user's message on screen with nothing ever under
+ *    it.
+ *
+ * This is the safety net behind the drain's own post-insert proof
+ * (`executeQueuedContinue` → `verifyLivePlacement`): a verify read that failed
+ * or a repair that could not run ends up here, a turn later.
+ */
+
+import { sessionLifecycleCommands, sessionTurns } from '@kortix/db';
+import { and, desc, eq, ne, or, sql } from 'drizzle-orm';
+import { logger } from '../../lib/logger';
+import { db } from '../../shared/db';
+import {
+  type StoredSandboxTurn,
+  closeSandboxTurnByMessageId,
+} from '../sandbox-turn-lifecycle';
+import { sandboxRuntimeRequestHeaders } from '../sandbox-fetch';
+import { wireIdTime } from '../wire-message-id';
+import { drainSessionLifecycleQueue, resolveSessionOpencodeEndpoint } from './engine';
+import { type PlacementTipMessage, parsePlacementTip, strandedPlacement } from './forwarded-placement';
+import { promoteNextInboxRow, withNextDeliveryAttempt } from './store';
+
+const WORKSPACE = '/workspace';
+/** The stranded prompt and the assistant that proves it both sit at the tip. */
+const TIP_LIMIT = 12;
+const MAX_STRAND_REDELIVERIES = 3;
+
+export interface ForwardedTurnReconciliation {
+  closedOlder: number;
+  candidates: number;
+  stranded: number;
+  requeued: number;
+}
+
+export interface StrandReconcileDeps {
+  readOpenTurns: (sessionId: string) => Promise<StoredSandboxTurn[]>;
+  closeOlderTurn: (sessionId: string, opencodeSessionId: string | null, messageId: string) => Promise<void>;
+  closeStrandedTurn: (sessionId: string, messageId: string) => Promise<void>;
+  readTip: (sessionId: string) => Promise<PlacementTipMessage[] | null>;
+  removeMessage: (sessionId: string, messageId: string) => Promise<boolean>;
+  requeueStranded: (sessionId: string, messageId: string) => Promise<'requeued' | 'no_row' | 'exhausted' | 'not_open'>;
+  kickDrain: (sessionId: string) => void;
+}
+
+const liveDeps: StrandReconcileDeps = {
+  async readOpenTurns(sessionId) {
+    // The LEDGER, not the sandbox row's `activeTurns`: the metadata entry of a
+    // forwarded prompt is frequently gone by the time the `end` relay lands
+    // (the proxy's own acceptance/renewal passes settle it), while its ledger
+    // row — the durable record `GET .../turn` and the reaper read — stays open
+    // until something names it. That open row is what keeps the session
+    // reading as working, and what this reconciliation closes.
+    const rows = await db
+      .select({
+        token: sessionTurns.turnToken,
+        messageId: sessionTurns.messageId,
+        opencodeSessionId: sessionTurns.opencodeSessionId,
+        state: sessionTurns.state,
+        startedAt: sessionTurns.startedAt,
+      })
+      .from(sessionTurns)
+      .where(and(eq(sessionTurns.sessionId, sessionId), ne(sessionTurns.state, 'ended')));
+    return rows.map((row) => ({
+      token: row.token,
+      messageId: row.messageId,
+      opencodeSessionId: row.opencodeSessionId,
+      state: (row.state === 'active' ? 'active' : 'delivering') as 'active' | 'delivering',
+      startedAtMs: row.startedAt ? new Date(row.startedAt).getTime() : null,
+    }));
+  },
+  async closeOlderTurn(sessionId, _opencodeSessionId, messageId) {
+    // The step that just ended answered it (OpenCode answers every queued
+    // message below the one it parents the step on, in that step).
+    await closeSandboxTurnByMessageId(sessionId, messageId, 'completed');
+  },
+  async closeStrandedTurn(sessionId, messageId) {
+    await closeSandboxTurnByMessageId(sessionId, messageId, 'abandoned');
+  },
+  async readTip(sessionId) {
+    const resolved = await resolveSessionOpencodeEndpoint(sessionId);
+    if (!resolved) return null;
+    const url = `${resolved.endpoint.url}/session/${encodeURIComponent(resolved.opencodeSessionId)}/message?directory=${encodeURIComponent(WORKSPACE)}&limit=${TIP_LIMIT}`;
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: sandboxRuntimeRequestHeaders(resolved.endpoint.headers),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) return null;
+    return parsePlacementTip(await res.json().catch(() => null));
+  },
+  async removeMessage(sessionId, messageId) {
+    const resolved = await resolveSessionOpencodeEndpoint(sessionId);
+    if (!resolved) return false;
+    const url = `${resolved.endpoint.url}/session/${encodeURIComponent(resolved.opencodeSessionId)}/message/${encodeURIComponent(messageId)}?directory=${encodeURIComponent(WORKSPACE)}`;
+    const res = await fetch(url, {
+      method: 'DELETE',
+      headers: sandboxRuntimeRequestHeaders(resolved.endpoint.headers),
+      signal: AbortSignal.timeout(5_000),
+    });
+    return res.ok || res.status === 404;
+  },
+  async requeueStranded(sessionId, messageId) {
+    const [row] = await db
+      .select({
+        commandId: sessionLifecycleCommands.commandId,
+        status: sessionLifecycleCommands.status,
+        payload: sessionLifecycleCommands.payload,
+      })
+      .from(sessionLifecycleCommands)
+      .where(
+        and(
+          eq(sessionLifecycleCommands.sessionId, sessionId),
+          eq(sessionLifecycleCommands.commandType, 'continue_session'),
+          or(
+            sql`${sessionLifecycleCommands.payload}->>'wireMessageId' = ${messageId}`,
+            sql`${sessionLifecycleCommands.payload}->>'redeliveredMessageId' = ${messageId}`,
+          ),
+        ),
+      )
+      .orderBy(desc(sessionLifecycleCommands.createdAt))
+      .limit(1);
+    if (!row) return 'no_row';
+    if (row.status !== 'succeeded') return 'not_open';
+    const payload = (row.payload ?? {}) as { redeliveries?: unknown };
+    const redeliveries = Number(payload.redeliveries ?? 0) + 1;
+    if (redeliveries > MAX_STRAND_REDELIVERIES) return 'exhausted';
+    await db
+      .update(sessionLifecycleCommands)
+      .set({
+        status: 'queued',
+        availableAt: new Date(),
+        attempts: 0,
+        lockedBy: null,
+        lockedUntil: null,
+        lastError: 'redelivered after stranded placement',
+        payload: withNextDeliveryAttempt(
+          sql`${sessionLifecycleCommands.payload} || ${JSON.stringify({ redeliveries, remintOnDelivery: true })}::jsonb`,
+        ),
+        // Every delivery marker goes: the row is back in line as if never sent.
+        result: { redelivered_from: 'stranded_placement' },
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(sessionLifecycleCommands.commandId, row.commandId),
+          eq(sessionLifecycleCommands.status, 'succeeded'),
+        ),
+      );
+    return 'requeued';
+  },
+  kickDrain(sessionId) {
+    void promoteNextInboxRow(sessionId)
+      .then((key) => (key ? drainSessionLifecycleQueue({ idempotencyKey: key }) : null))
+      .catch(() => undefined);
+  },
+};
+
+/**
+ * Run at `turn-stream` `end` for `sessionId`, where `endedMessageId` is the
+ * user message the final assistant answered (`M`). No-op when the relay did
+ * not name one, or when no forwarded turn is open.
+ */
+export async function reconcileForwardedTurnsAtEnd(
+  input: { sessionId: string; opencodeSessionId?: string | null; endedMessageId?: string | null },
+  deps: StrandReconcileDeps = liveDeps,
+): Promise<ForwardedTurnReconciliation> {
+  const out: ForwardedTurnReconciliation = { closedOlder: 0, candidates: 0, stranded: 0, requeued: 0 };
+  let open: StoredSandboxTurn[];
+  try {
+    open = await deps.readOpenTurns(input.sessionId);
+  } catch (err) {
+    logger.warn('[forwarded-turns] open-turn read failed', {
+      session_id: input.sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return out;
+  }
+  const sameRoot = (turn: StoredSandboxTurn) =>
+    !input.opencodeSessionId || !turn.opencodeSessionId || turn.opencodeSessionId === input.opencodeSessionId;
+  const forwarded = open.filter((turn) => !!turn.messageId && sameRoot(turn));
+  if (forwarded.length === 0) return out;
+  // ONE tip read for everything below. It also stands in for the relay when
+  // the daemon named no message (an older agent build, or an end it could not
+  // attribute): the newest FINISHED assistant's parent is the message the
+  // ended turn answered.
+  let tip: PlacementTipMessage[] | null = null;
+  try {
+    tip = await deps.readTip(input.sessionId);
+  } catch (err) {
+    logger.warn('[forwarded-turns] tip read failed — reconciliation skipped', {
+      session_id: input.sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  let endedMessageId = input.endedMessageId ?? null;
+  if (!endedMessageId && tip) {
+    let newest: PlacementTipMessage | null = null;
+    for (const m of tip) {
+      if (m.role !== 'assistant' || m.completed === null || m.completed === undefined) continue;
+      if (typeof m.parentID !== 'string') continue;
+      if (!newest || m.id > newest.id) newest = m;
+    }
+    endedMessageId = newest?.parentID ?? null;
+  }
+  const endedAt = endedMessageId ? wireIdTime(endedMessageId) : null;
+  if (endedAt === null) {
+    logger.info('[forwarded-turns] turn end named no message and the tip has no finished assistant — nothing to reconcile against', {
+      session_id: input.sessionId,
+      open: forwarded.length,
+    });
+    return out;
+  }
+  const older: StoredSandboxTurn[] = [];
+  const newer: StoredSandboxTurn[] = [];
+  for (const turn of forwarded) {
+    const at = wireIdTime(turn.messageId!);
+    if (at === null || turn.messageId === endedMessageId) continue;
+    if (at < endedAt) older.push(turn);
+    else newer.push(turn);
+  }
+  for (const turn of older) {
+    try {
+      await deps.closeOlderTurn(input.sessionId, turn.opencodeSessionId, turn.messageId!);
+      out.closedOlder += 1;
+    } catch (err) {
+      logger.warn('[forwarded-turns] could not close an older forwarded turn', {
+        session_id: input.sessionId,
+        message_id: turn.messageId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  out.candidates = newer.length;
+  logger.info('[forwarded-turns] turn end reconciled', {
+    session_id: input.sessionId,
+    ended_message_id: endedMessageId,
+    relay_named: !!input.endedMessageId,
+    open: open.length,
+    closed_older: out.closedOlder,
+    candidates: newer.map((t) => t.messageId),
+  });
+  if (newer.length === 0) return out;
+  if (!tip) return out;
+  let kicked = false;
+  for (const turn of newer) {
+    const verdict = strandedPlacement(tip, turn.messageId!);
+    if (!verdict.stranded) continue;
+    out.stranded += 1;
+    let removed = false;
+    try {
+      removed = await deps.removeMessage(input.sessionId, turn.messageId!);
+    } catch (err) {
+      logger.warn('[forwarded-turns] stranded message delete threw', {
+        session_id: input.sessionId,
+        message_id: turn.messageId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    if (!removed) {
+      // Usually the box is busy again already (a fresh send opened a loop; its
+      // step reads this message and answers it). The record stays open and the
+      // next turn end re-asks.
+      logger.warn('[forwarded-turns] stranded prompt could not be removed — not re-queued', {
+        session_id: input.sessionId,
+        message_id: turn.messageId,
+        stranded_by: verdict.strandedBy,
+      });
+      continue;
+    }
+    const requeue = await deps.requeueStranded(input.sessionId, turn.messageId!);
+    logger.warn('[forwarded-turns] stranded forwarded prompt re-queued', {
+      session_id: input.sessionId,
+      message_id: turn.messageId,
+      stranded_by: verdict.strandedBy,
+      outcome: requeue,
+    });
+    if (requeue === 'requeued') {
+      out.requeued += 1;
+      kicked = true;
+    }
+    // Whatever the row became, nothing is running THIS copy of the prompt:
+    // close its turn authority so the session does not read as working on it.
+    try {
+      await deps.closeStrandedTurn(input.sessionId, turn.messageId!);
+    } catch (err) {
+      logger.warn('[forwarded-turns] could not close a stranded turn record', {
+        session_id: input.sessionId,
+        message_id: turn.messageId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  if (kicked) deps.kickDrain(input.sessionId);
+  return out;
+}

--- a/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.ts
@@ -338,5 +338,25 @@ export async function reconcileForwardedTurnsAtEnd(
     }
   }
   if (kicked) deps.kickDrain(input.sessionId);
+  // Husk sweep: a cancelled prompt whose whole-message delete was refused
+  // mid-turn left a PART-LESS user message at the runtime — invisible to the
+  // model, but every client render shows it as an empty bubble. The turn just
+  // ended, so the whole-message delete goes through now.
+  for (const message of tip) {
+    if (message.role !== 'user') continue;
+    if (!message.partIds || message.partIds.length > 0) continue;
+    if (tip.some((m) => m.role === 'assistant' && m.parentID === message.id)) continue;
+    try {
+      const removed = await deps.removeMessage(input.sessionId, message.id);
+      if (removed) {
+        logger.info('[forwarded-turns] part-less husk removed', {
+          session_id: input.sessionId,
+          message_id: message.id,
+        });
+      }
+    } catch {
+      /* next turn end retries */
+    }
+  }
   return out;
 }

--- a/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.ts
@@ -40,7 +40,7 @@ import {
 import { sandboxRuntimeRequestHeaders } from '../sandbox-fetch';
 import { wireIdTime } from '../wire-message-id';
 import { drainSessionLifecycleQueue, resolveSessionOpencodeEndpoint } from './engine';
-import { type PlacementTipMessage, parsePlacementTip, strandedPlacement } from './forwarded-placement';
+import { type PlacementTipMessage, openUserAbove, parsePlacementTip, strandedPlacement } from './forwarded-placement';
 import { promoteNextInboxRow, withNextDeliveryAttempt } from './store';
 
 const WORKSPACE = '/workspace';
@@ -53,6 +53,9 @@ export interface ForwardedTurnReconciliation {
   candidates: number;
   stranded: number;
   requeued: number;
+  /** Later, un-stranded siblings pulled back with a stranded row so the
+   *  redelivery batch restores send order. */
+  reordered: number;
 }
 
 export interface StrandReconcileDeps {
@@ -83,13 +86,15 @@ const liveDeps: StrandReconcileDeps = {
       })
       .from(sessionTurns)
       .where(and(eq(sessionTurns.sessionId, sessionId), ne(sessionTurns.state, 'ended')));
-    return rows.map((row) => ({
-      token: row.token,
-      messageId: row.messageId,
-      opencodeSessionId: row.opencodeSessionId,
-      state: (row.state === 'active' ? 'active' : 'delivering') as 'active' | 'delivering',
-      startedAtMs: row.startedAt ? new Date(row.startedAt).getTime() : null,
-    }));
+    return rows.map(
+      (row): StoredSandboxTurn => ({
+        token: row.token,
+        messageId: row.messageId ?? null,
+        opencodeSessionId: row.opencodeSessionId ?? '',
+        state: row.state === 'active' ? 'active' : 'delivering',
+        startedAtMs: row.startedAt ? new Date(row.startedAt).getTime() : null,
+      }),
+    );
   },
   async closeOlderTurn(sessionId, _opencodeSessionId, messageId) {
     // The step that just ended answered it (OpenCode answers every queued
@@ -187,7 +192,7 @@ export async function reconcileForwardedTurnsAtEnd(
   input: { sessionId: string; opencodeSessionId?: string | null; endedMessageId?: string | null },
   deps: StrandReconcileDeps = liveDeps,
 ): Promise<ForwardedTurnReconciliation> {
-  const out: ForwardedTurnReconciliation = { closedOlder: 0, candidates: 0, stranded: 0, requeued: 0 };
+  const out: ForwardedTurnReconciliation = { closedOlder: 0, candidates: 0, stranded: 0, requeued: 0, reordered: 0 };
   let open: StoredSandboxTurn[];
   try {
     open = await deps.readOpenTurns(input.sessionId);
@@ -265,10 +270,29 @@ export async function reconcileForwardedTurnsAtEnd(
   if (newer.length === 0) return out;
   if (!tip) return out;
   let kicked = false;
-  for (const turn of newer) {
-    const verdict = strandedPlacement(tip, turn.messageId!);
+  // Classify the newer candidates by the tip. A STRANDED row (persisted below
+  // an assistant that predates it) is not lost while a LATER, correctly
+  // placed, still-unanswered sibling exists above it: that sibling's step
+  // hands the model the whole transcript, the stranded text included, and the
+  // model answers both — leave it. Only the stranded TAIL — stranded rows
+  // with nothing open above them — is truly dropped (the loop has exited),
+  // and it re-queues AS A WHOLE so the redelivery batch re-mints it in send
+  // order. Re-queueing one row of a burst individually is what scrambled the
+  // order (measured: FIRST, B3, B1, B4, B2).
+  const verdicts = newer.map((turn) => ({ turn, verdict: strandedPlacement(tip!, turn.messageId!) }));
+  for (const { turn, verdict } of verdicts) {
     if (!verdict.stranded) continue;
     out.stranded += 1;
+    // The tip, not just the ledger candidates: ANY placed, unanswered user
+    // message above covers this one — a direct send included.
+    if (openUserAbove(tip, turn.messageId!)) {
+      logger.info('[forwarded-turns] stranded prompt is covered by a later open sibling — left in place', {
+        session_id: input.sessionId,
+        message_id: turn.messageId,
+        stranded_by: verdict.strandedBy,
+      });
+      continue;
+    }
     let removed = false;
     try {
       removed = await deps.removeMessage(input.sessionId, turn.messageId!);

--- a/apps/api/src/projects/session-lifecycle/inbox-hold-settle.test.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-hold-settle.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test';
+import { WIRE_ID_TIME_SCALE } from '../wire-message-id';
+import { type HoldSettleDeps, settleInboxHoldAfterStop } from './inbox-hold-settle';
+
+const id = (ms: number, tail: string) =>
+  `msg_${((BigInt(ms) * WIRE_ID_TIME_SCALE + BigInt(1)) & BigInt(0xffffffffffff)).toString(16).padStart(12, '0')}${tail}`;
+const T = 1_800_000_000_000;
+
+function fakeDeps(over: Partial<HoldSettleDeps> & { claimed?: number[]; tips?: any[] }) {
+  let now = 0;
+  const claimedSeq = [...(over.claimed ?? [0])];
+  const tips = [...(over.tips ?? [[]])];
+  const calls: Record<string, unknown[][]> = { abort: [], remove: [], hold: [], close: [], closeTurn: [] };
+  const deps: HoldSettleDeps = {
+    countClaimed: async () => (claimedSeq.length > 1 ? claimedSeq.shift()! : claimedSeq[0]),
+    listStopPaused: async () => [],
+    readTip: async () => (tips.length > 1 ? tips.shift()! : tips[0]),
+    abort: async (...a) => { calls.abort.push(a); return true; },
+    removeMessage: async (...a) => { calls.remove.push(a); return true; },
+    holdAsQueued: async (...a) => { calls.hold.push(a); },
+    closeDelivered: async (...a) => { calls.close.push(a); },
+    closeTurn: async (...a) => { calls.closeTurn.push(a); },
+    sleep: async (ms) => { now += ms; },
+    now: () => now,
+    ...over,
+  };
+  return { deps, calls };
+}
+
+describe('settleInboxHoldAfterStop', () => {
+  const u1 = id(T, 'USER1USER1USER');
+  const a1 = id(T + 100, 'ASST1ASST1ASST');
+  const u2 = id(T + 200, 'USER2USER2USER'); // forwarded, never read
+  const u3 = id(T + 300, 'USER3USER3USER'); // forwarded, read by the aborted step
+  const a3 = id(T + 400, 'ASST3ASST3ASST');
+
+  test('nothing claimed, nothing stop-paused → no box access', async () => {
+    const { deps, calls } = fakeDeps({});
+    const out = await settleInboxHoldAfterStop('s', deps);
+    expect(out.heldBack).toBe(0);
+    expect(calls.abort).toHaveLength(0);
+  });
+
+  test('waits for claimed deliveries to land, bounded', async () => {
+    const { deps } = fakeDeps({ claimed: [1, 1, 1, 0] });
+    const out = await settleInboxHoldAfterStop('s', deps);
+    expect(out.waitedMs).toBe(300);
+    expect(out.claimedLeft).toBe(0);
+  });
+
+  test('gives up on a delivery that never lands', async () => {
+    const { deps } = fakeDeps({ claimed: [1] });
+    const out = await settleInboxHoldAfterStop('s', deps);
+    expect(out.waitedMs).toBeGreaterThanOrEqual(3_000);
+    expect(out.claimedLeft).toBe(1);
+  });
+
+  test('an unreached forwarded prompt is removed from the box, held as queued, its turn closed', async () => {
+    const tip = [
+      { id: u1, role: 'user' },
+      { id: a1, role: 'assistant', parentID: u1, completed: T + 150 },
+      { id: u2, role: 'user' },
+    ];
+    const { deps, calls } = fakeDeps({
+      tips: [tip],
+      listStopPaused: async () => [{ commandId: 'c2', wireIds: [u2] }],
+    });
+    const out = await settleInboxHoldAfterStop('s', deps);
+    expect(out.heldBack).toBe(1);
+    expect(calls.remove).toEqual([['s', u2]]);
+    expect(calls.hold).toEqual([['c2']]);
+    expect(calls.closeTurn).toEqual([['s', u2]]);
+    expect(calls.abort).toHaveLength(0);
+  });
+
+  test('a forwarded prompt the aborted step READ closes as delivered (runs with the next send)', async () => {
+    const tip = [
+      { id: u1, role: 'user' },
+      { id: u3, role: 'user' },
+      { id: a3, role: 'assistant', parentID: u3, completed: T + 450 },
+    ];
+    const { deps, calls } = fakeDeps({
+      tips: [tip],
+      listStopPaused: async () => [{ commandId: 'c3', wireIds: [u3] }],
+    });
+    const out = await settleInboxHoldAfterStop('s', deps);
+    expect(out.closedAsInterrupted).toBe(1);
+    expect(calls.close).toEqual([['c3']]);
+    expect(calls.remove).toHaveLength(0);
+  });
+
+  test('a box still mid-step after the hold (an escaped delivery restarted it) is aborted again', async () => {
+    const busyTip = [{ id: u3, role: 'user' }, { id: a3, role: 'assistant', parentID: u3, completed: null }];
+    const idleTip = [{ id: u3, role: 'user' }, { id: a3, role: 'assistant', parentID: u3, completed: T + 500 }];
+    const { deps, calls } = fakeDeps({
+      claimed: [1, 0],
+      tips: [busyTip, idleTip],
+      listStopPaused: async () => [{ commandId: 'c3', wireIds: [u3] }],
+    });
+    const out = await settleInboxHoldAfterStop('s', deps);
+    expect(out.reAborted).toBe(true);
+    expect(calls.abort).toHaveLength(1);
+    expect(out.closedAsInterrupted).toBe(1);
+  });
+
+  test('a removal that fails leaves the row stop-paused (no duplicate, no loss)', async () => {
+    const tip = [{ id: u2, role: 'user' }];
+    const { deps, calls } = fakeDeps({
+      tips: [tip],
+      listStopPaused: async () => [{ commandId: 'c2', wireIds: [u2] }],
+      removeMessage: async () => false,
+    });
+    const out = await settleInboxHoldAfterStop('s', deps);
+    expect(out.heldBack).toBe(0);
+    expect(calls.hold).toHaveLength(0);
+  });
+
+  test('an unreadable box leaves everything as the instant hold marked it', async () => {
+    const { deps, calls } = fakeDeps({
+      tips: [null],
+      listStopPaused: async () => [{ commandId: 'c2', wireIds: [u2] }],
+    });
+    const out = await settleInboxHoldAfterStop('s', deps);
+    expect(out.unreadable).toBe(true);
+    expect(calls.hold).toHaveLength(0);
+    expect(calls.close).toHaveLength(0);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/inbox-hold-settle.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-hold-settle.ts
@@ -1,0 +1,300 @@
+/**
+ * What a Stop means for prompts that were already ON THE WIRE.
+ *
+ * `holdInboxPrompts(sessionId, true)` is instant and purely a marking: queued
+ * rows become held, forwarded rows become stop-paused, a row the drain has
+ * CLAIMED gets a payload flag its delivery consumes. The client aborts the box
+ * right after. Two things that marking cannot do are done here, after the hold
+ * route has answered, because each needs the box:
+ *
+ *  1. A CLAIMED row's POST can land AFTER the abort. OpenCode's runner is idle
+ *     by then, so that prompt starts a fresh loop — the agent visibly restarts
+ *     on a message the user queued BEFORE pressing Stop (measured, `queue-lab`
+ *     `stop_hold`: abort at 48.367, next prompt persisted 48.397, new loop at
+ *     48.425, full answer streamed). This waits for claimed rows to settle and,
+ *     if the box is mid-step afterwards, aborts it once more.
+ *
+ *  2. A forwarded prompt the loop never READ is still only text in the
+ *     transcript. It is taken back out of OpenCode and becomes an ordinary HELD
+ *     row — "Held — stopped", with Send now / Remove — instead of the
+ *     previous "stop-paused" limbo whose release re-delivered the prompt while
+ *     OpenCode still held the original, unanswered (the documented duplicate in
+ *     inbox-rows.ts). A forwarded prompt the loop DID read belongs to the turn
+ *     the abort ended: it stays in the transcript as part of that interrupted
+ *     turn (the runtime answers it with the next send) and its row closes as
+ *     delivered, so a release cannot send it a second time.
+ *
+ * Best-effort end to end: a box that cannot be read leaves the rows exactly
+ * as the instant hold marked them, which is the pre-existing behaviour.
+ */
+
+import { sessionLifecycleCommands } from '@kortix/db';
+import { and, eq, sql } from 'drizzle-orm';
+import { logger } from '../../lib/logger';
+import { db } from '../../shared/db';
+import { sandboxRuntimeRequestHeaders } from '../sandbox-fetch';
+import { closeSandboxTurnByMessageId } from '../sandbox-turn-lifecycle';
+import { resolveSessionOpencodeEndpoint } from './engine';
+import {
+  type PlacementTipMessage,
+  parsePlacementTip,
+  reachedPlacement,
+  tipIsBusy,
+} from './forwarded-placement';
+import { INBOX_HOLD_MS, inboxScope } from './inbox-rows';
+import { withNextDeliveryAttempt } from './store';
+
+const WORKSPACE = '/workspace';
+const TIP_LIMIT = 16;
+/** How long a claimed delivery is given to land after the hold. A delivery is
+ *  one proxied POST (~0.3–1.5 s); the drain's own retry budget is far longer,
+ *  but a prompt that is still in flight after this is not going to land into
+ *  the turn the user stopped. */
+const CLAIMED_SETTLE_MS = 3_000;
+const CLAIMED_POLL_MS = 100;
+
+export interface StopPausedRow {
+  commandId: string;
+  /** Every id this row was ever posted under, newest last. */
+  wireIds: string[];
+}
+
+export interface HoldSettleDeps {
+  countClaimed: (sessionId: string) => Promise<number>;
+  listStopPaused: (sessionId: string) => Promise<StopPausedRow[]>;
+  readTip: (sessionId: string) => Promise<PlacementTipMessage[] | null>;
+  abort: (sessionId: string) => Promise<boolean>;
+  removeMessage: (sessionId: string, messageId: string) => Promise<boolean>;
+  /** Forwarded + stop-paused → plain queued + held (deliverable on release). */
+  holdAsQueued: (commandId: string) => Promise<void>;
+  /** Forwarded + stop-paused → delivered (the interrupted turn owns it). */
+  closeDelivered: (commandId: string) => Promise<void>;
+  /** The turn-ledger record opened for a wire id that was taken back out. */
+  closeTurn: (sessionId: string, messageId: string) => Promise<void>;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+const liveDeps: HoldSettleDeps = {
+  async countClaimed(sessionId) {
+    const [row] = await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(sessionLifecycleCommands)
+      .where(and(inboxScope(sessionId), eq(sessionLifecycleCommands.status, 'running')));
+    return Number(row?.n ?? 0);
+  },
+  async listStopPaused(sessionId) {
+    const rows = await db
+      .select({
+        commandId: sessionLifecycleCommands.commandId,
+        wire: sql<string | null>`${sessionLifecycleCommands.payload}->>'wireMessageId'`,
+        redelivered: sql<string | null>`${sessionLifecycleCommands.payload}->>'redeliveredMessageId'`,
+        forwarded: sql<string | null>`${sessionLifecycleCommands.result}->>'forwarded_message_id'`,
+      })
+      .from(sessionLifecycleCommands)
+      .where(
+        and(
+          inboxScope(sessionId),
+          eq(sessionLifecycleCommands.status, 'succeeded'),
+          // ON THE WIRE: forwarded, or already confirmed `delivered` by the
+          // daemon's acceptance relay — that relay fires when OpenCode
+          // PERSISTS the message, long before any step reads it, so a
+          // `delivered` row is just as likely to be unreached by a Stop. Only
+          // the recent ones: an old delivered row is history.
+          sql`${sessionLifecycleCommands.result}->>'status' IN ('forwarded', 'delivered')`,
+          sql`COALESCE(${sessionLifecycleCommands.result}->>'held', '') <> 'true'`,
+          sql`(${sessionLifecycleCommands.result}->>'forwarded_at')::timestamptz > now() - interval '10 minutes'`,
+        ),
+      );
+    return rows.map((row) => ({
+      commandId: row.commandId,
+      wireIds: [row.wire, row.redelivered, row.forwarded].filter(
+        (id, i, all): id is string => typeof id === 'string' && id.length > 0 && all.indexOf(id) === i,
+      ),
+    }));
+  },
+  async readTip(sessionId) {
+    const resolved = await resolveSessionOpencodeEndpoint(sessionId);
+    if (!resolved) return null;
+    const url = `${resolved.endpoint.url}/session/${encodeURIComponent(resolved.opencodeSessionId)}/message?directory=${encodeURIComponent(WORKSPACE)}&limit=${TIP_LIMIT}`;
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: sandboxRuntimeRequestHeaders(resolved.endpoint.headers),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) return null;
+    return parsePlacementTip(await res.json().catch(() => null));
+  },
+  async abort(sessionId) {
+    const resolved = await resolveSessionOpencodeEndpoint(sessionId);
+    if (!resolved) return false;
+    const url = `${resolved.endpoint.url}/session/${encodeURIComponent(resolved.opencodeSessionId)}/abort?directory=${encodeURIComponent(WORKSPACE)}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: sandboxRuntimeRequestHeaders(resolved.endpoint.headers),
+      signal: AbortSignal.timeout(5_000),
+    });
+    return res.ok;
+  },
+  async removeMessage(sessionId, messageId) {
+    const resolved = await resolveSessionOpencodeEndpoint(sessionId);
+    if (!resolved) return false;
+    const url = `${resolved.endpoint.url}/session/${encodeURIComponent(resolved.opencodeSessionId)}/message/${encodeURIComponent(messageId)}?directory=${encodeURIComponent(WORKSPACE)}`;
+    const res = await fetch(url, {
+      method: 'DELETE',
+      headers: sandboxRuntimeRequestHeaders(resolved.endpoint.headers),
+      signal: AbortSignal.timeout(5_000),
+    });
+    return res.ok || res.status === 404;
+  },
+  async holdAsQueued(commandId) {
+    await db
+      .update(sessionLifecycleCommands)
+      .set({
+        status: 'queued',
+        availableAt: new Date(Date.now() + INBOX_HOLD_MS),
+        attempts: 0,
+        lockedBy: null,
+        lockedUntil: null,
+        // The delivery markers go; `held` stays. `remintOnDelivery` was
+        // stamped by the hold, so the release re-places it above the
+        // transcript it lands in.
+        result: { held: true },
+        payload: withNextDeliveryAttempt(
+          sql`${sessionLifecycleCommands.payload} || '{"remintOnDelivery": true}'::jsonb`,
+        ),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(sessionLifecycleCommands.commandId, commandId),
+          eq(sessionLifecycleCommands.status, 'succeeded'),
+          sql`${sessionLifecycleCommands.result}->>'status' IN ('forwarded', 'delivered')`,
+        ),
+      );
+  },
+  async closeDelivered(commandId) {
+    await db
+      .update(sessionLifecycleCommands)
+      .set({
+        result: sql`(COALESCE(${sessionLifecycleCommands.result}, '{}'::jsonb) || '{"status": "delivered"}'::jsonb) - 'stop_paused' - 'held'`,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(sessionLifecycleCommands.commandId, commandId),
+          eq(sessionLifecycleCommands.status, 'succeeded'),
+          sql`${sessionLifecycleCommands.result}->>'status' IN ('forwarded', 'delivered')`,
+        ),
+      );
+  },
+  async closeTurn(sessionId, messageId) {
+    await closeSandboxTurnByMessageId(sessionId, messageId, 'abandoned');
+  },
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  now: () => Date.now(),
+};
+
+export interface HoldSettlement {
+  waitedMs: number;
+  claimedLeft: number;
+  reAborted: boolean;
+  heldBack: number;
+  closedAsInterrupted: number;
+  unreadable: boolean;
+}
+
+export async function settleInboxHoldAfterStop(
+  sessionId: string,
+  deps: HoldSettleDeps = liveDeps,
+): Promise<HoldSettlement> {
+  const out: HoldSettlement = {
+    waitedMs: 0,
+    claimedLeft: 0,
+    reAborted: false,
+    heldBack: 0,
+    closedAsInterrupted: 0,
+    unreadable: false,
+  };
+  // 1. Let claimed deliveries land (or give up on them).
+  const started = deps.now();
+  let claimed = await deps.countClaimed(sessionId);
+  while (claimed > 0 && deps.now() - started < CLAIMED_SETTLE_MS) {
+    await deps.sleep(CLAIMED_POLL_MS);
+    claimed = await deps.countClaimed(sessionId);
+  }
+  out.waitedMs = deps.now() - started;
+  out.claimedLeft = claimed;
+
+  const stopPaused = await deps.listStopPaused(sessionId);
+  if (stopPaused.length === 0 && claimed === 0) return out;
+
+  // 2. One look at the box.
+  let tip = await deps.readTip(sessionId);
+  if (!tip) {
+    out.unreadable = true;
+    return out;
+  }
+  // A prompt that landed after the abort restarted the loop: stop it again.
+  if (tipIsBusy(tip)) {
+    out.reAborted = await deps.abort(sessionId);
+    if (out.reAborted) {
+      await deps.sleep(250);
+      tip = (await deps.readTip(sessionId)) ?? tip;
+    }
+  }
+
+  // 3. Settle every stop-paused row by what the loop did with it.
+  for (const row of stopPaused) {
+    const ids = row.wireIds;
+    if (ids.length === 0) continue;
+    const reached = ids.some((id) => reachedPlacement(tip!, id));
+    if (reached) {
+      await deps.closeDelivered(row.commandId);
+      out.closedAsInterrupted += 1;
+      continue;
+    }
+    // Unreached: take the copies out of the transcript, then hold the row.
+    // If a copy cannot be removed the row stays stop-paused — the old,
+    // duplicating-but-never-losing path.
+    let removedAll = true;
+    for (const id of ids) {
+      const present = tip.some((m) => m.id === id);
+      if (!present) continue;
+      if (!(await deps.removeMessage(sessionId, id))) removedAll = false;
+    }
+    if (!removedAll) continue;
+    await deps.holdAsQueued(row.commandId);
+    // The turn authority opened for this delivery must not keep the session
+    // reading as working: nothing is running this prompt any more.
+    for (const id of ids) {
+      try {
+        await deps.closeTurn(sessionId, id);
+      } catch (err) {
+        logger.warn('[inbox-hold] could not close the ledger turn of a held-back prompt', {
+          session_id: sessionId,
+          message_id: id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    out.heldBack += 1;
+  }
+  return out;
+}
+
+/** Fire-and-forget entry for the hold route. */
+export function settleInboxHoldAfterStopInBackground(sessionId: string): void {
+  void settleInboxHoldAfterStop(sessionId)
+    .then((result) => {
+      if (result.reAborted || result.heldBack || result.closedAsInterrupted || result.claimedLeft) {
+        logger.info('[inbox-hold] settled after stop', { session_id: sessionId, ...result });
+      }
+    })
+    .catch((err) =>
+      logger.warn('[inbox-hold] settle after stop failed', {
+        session_id: sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+}

--- a/apps/api/src/projects/session-lifecycle/inbox-rows.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-rows.ts
@@ -1,5 +1,5 @@
 import { sessionLifecycleCommands } from '@kortix/db';
-import { and, asc, eq, inArray, isNotNull, ne, or, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNotNull, isNull, lte, ne, or, sql } from 'drizzle-orm';
 import { db } from '../../shared/db';
 import { type SessionLifecycleCommandRow, withNextDeliveryAttempt } from './store';
 
@@ -435,3 +435,65 @@ export function isHeldInboxRow(result: unknown): boolean {
 export function isStopPausedInboxRow(result: unknown): boolean {
   return (result as { stop_paused?: unknown } | null)?.stop_paused === true;
 }
+
+/**
+ * Claim every DUE queued inbox prompt of one session — the siblings a targeted
+ * drain sweeps into its delivery batch (see `drainSessionLifecycleQueue`).
+ * Only rows with a `clientMessageId` (the composer's own submissions); an
+ * admission-backoff row is due later and is left to its backoff.
+ */
+export async function claimDueSessionInboxSiblings(input: {
+  workerId: string;
+  sessionId: string;
+  now?: Date;
+  limit?: number;
+}): Promise<SessionLifecycleCommandRow[]> {
+  const now = input.now ?? new Date();
+  const rows = await db
+    .select()
+    .from(sessionLifecycleCommands)
+    .where(
+      and(
+        eq(sessionLifecycleCommands.sessionId, input.sessionId),
+        eq(sessionLifecycleCommands.commandType, 'continue_session'),
+        eq(sessionLifecycleCommands.status, 'queued'),
+        sql`${sessionLifecycleCommands.payload}->>'clientMessageId' IS NOT NULL`,
+        sql`COALESCE(${sessionLifecycleCommands.result}->>'held', '') <> 'true'`,
+        or(
+          isNull(sessionLifecycleCommands.lockedUntil),
+          lte(sessionLifecycleCommands.lockedUntil, now),
+        ),
+        // NOT gated on availableAt: this sweep only runs while a delivery for
+        // this session is in hand, and a backoff written when the box was
+        // still booting (every attempt during a cold boot fails 'pending')
+        // is stale the moment one delivery gets through. Leaving those rows
+        // to their own timers is what split a boot burst into stragglers
+        // (measured: B1 redelivered minutes after B2–B4). Admission-refused
+        // rows are ordered by the batch itself; held rows stay excluded.
+      ),
+    )
+    .orderBy(asc(sessionLifecycleCommands.createdAt))
+    .limit(input.limit ?? 20);
+  const claimed: SessionLifecycleCommandRow[] = [];
+  for (const row of rows) {
+    const [locked] = await db
+      .update(sessionLifecycleCommands)
+      .set({
+        status: 'running',
+        attempts: row.attempts + 1,
+        lockedBy: input.workerId,
+        lockedUntil: new Date(now.getTime() + 5 * 60_000),
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(sessionLifecycleCommands.commandId, row.commandId),
+          eq(sessionLifecycleCommands.status, 'queued'),
+        ),
+      )
+      .returning();
+    if (locked) claimed.push(locked as SessionLifecycleCommandRow);
+  }
+  return claimed;
+}
+

--- a/apps/api/src/projects/session-lifecycle/inbox-rows.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-rows.ts
@@ -131,7 +131,14 @@ export async function deleteInboxPrompt(
     .limit(1);
   if (!existing) return { outcome: 'missing' };
   if (existing.status === 'running') return { outcome: 'delivering' };
-  return isForwardedInboxRow(existing.result) ? { outcome: 'delivering' } : { outcome: 'missing' };
+  // Forwarded, or confirmed `delivered` on persistence (the daemon's
+  // acceptance relay — which fires long before a model step reads the
+  // message): both are "on the wire", and the DELETE route's cancel arm
+  // decides from the transcript whether the prompt can still come back.
+  const status = (existing.result as { status?: unknown } | null)?.status;
+  return isForwardedInboxRow(existing.result) || status === 'delivered'
+    ? { outcome: 'delivering' }
+    : { outcome: 'missing' };
 }
 
 /**

--- a/apps/api/src/projects/session-lifecycle/inbox-rows.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-rows.ts
@@ -17,7 +17,7 @@ import { type SessionLifecycleCommandRow, withNextDeliveryAttempt } from './stor
  */
 
 /** A `continue_session` row the USER created through the composer. */
-function inboxScope(sessionId: string) {
+export function inboxScope(sessionId: string) {
   return and(
     eq(sessionLifecycleCommands.sessionId, sessionId),
     eq(sessionLifecycleCommands.commandType, 'continue_session'),

--- a/apps/api/src/projects/session-lifecycle/store.ts
+++ b/apps/api/src/projects/session-lifecycle/store.ts
@@ -136,6 +136,9 @@ export interface QueuedContinueSessionPayload {
    * mints at page load for a message typed before the last reload.
    */
   remintOnDelivery?: boolean;
+  /** The sender tab's clock at Enter — the SEND order across surfaces whose
+   *  POSTs race (boot shell vs chat during the crossfade). */
+  clientSentAtMs?: number;
   parts?: PromptPartWire[];
   overrides?: PromptOverridesWire;
 }
@@ -164,6 +167,9 @@ export interface EnqueueContinueSessionCommandInput {
   /** The producer already knows its wire id is stale — see
    *  `QueuedContinueSessionPayload.remintOnDelivery`. */
   remintOnDelivery?: boolean;
+  /** The sender tab's clock at Enter — the SEND order across surfaces whose
+   *  POSTs race (boot shell vs chat during the crossfade). */
+  clientSentAtMs?: number;
   parts?: PromptPartWire[];
   overrides?: PromptOverridesWire;
 }
@@ -181,6 +187,7 @@ export function buildContinueSessionCommandValues(input: EnqueueContinueSessionC
     ...(input.clientMessageId ? { clientMessageId: input.clientMessageId } : {}),
     ...(input.wireMessageId ? { wireMessageId: input.wireMessageId } : {}),
     ...(input.remintOnDelivery ? { remintOnDelivery: true } : {}),
+    ...(typeof input.clientSentAtMs === 'number' ? { clientSentAtMs: input.clientSentAtMs } : {}),
     ...(input.parts ? { parts: input.parts } : {}),
     ...(input.overrides ? { overrides: input.overrides } : {}),
   };

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/loading.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/loading.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import ProjectHomeLoading from '../../loading';
+import { InstantSessionShell } from '@/features/session/instant-session-shell';
+import { useFirstPromptPreviewStore } from '@/stores/session-composer-handoff-store';
+
+/**
+ * Navigation Suspense boundary for /projects/[id]/sessions/[sessionId].
+ *
+ * The session layout is dynamic (it resolves the tab title on the server), so
+ * every navigation into a session paints a loading boundary for the length of
+ * that round-trip (~60–100 ms). Without a boundary of its own this segment
+ * inherited ../../loading.tsx — ProjectHome's skeleton — which, on the one
+ * navigation people make most (home composer → brand-new session), put a
+ * centered skeleton BETWEEN the home page and the instant session shell: two
+ * frames of grey bars flashing where the user's own message was about to be.
+ *
+ * So on that navigation this boundary renders the instant session shell
+ * itself — the very component the page mounts first — with the first prompt
+ * from the producer's preview store. The hand-over to the page is then
+ * pixel-identical: same bubble, same waiting row, same composer. Every other
+ * navigation into a session (sidebar, back/forward) has no preview and keeps
+ * the project skeleton it always had.
+ */
+export default function SessionLoading() {
+  const params = useParams<{ id: string; sessionId: string }>();
+  const projectId = params?.id;
+  const sessionId = params?.sessionId;
+  const preview = useFirstPromptPreviewStore((s) =>
+    sessionId ? (s.previewBySession[sessionId] ?? null) : null,
+  );
+  if (!projectId || !sessionId || !preview) return <ProjectHomeLoading />;
+  return <InstantSessionShell projectId={projectId} sessionId={sessionId} stage="provisioning" />;
+}

--- a/apps/web/src/features/session/composer/composer-submit-latch.test.ts
+++ b/apps/web/src/features/session/composer/composer-submit-latch.test.ts
@@ -49,7 +49,7 @@ describe('the composer submits through the latch', () => {
     // the instance survive every render; the handler itself is stable (`[]`)
     // because its only inputs are refs.
     const wiring = between('const submitLatchRef = useRef', 'const editorPlaceholder');
-    expect(wiring).toContain('submitLatchRef.current ??= createSubmitLatch(');
+    expect(wiring).toContain('submitLatchRef.current ??= createSubmitLatch<StashedDraft>(');
     expect(wiring).toContain('return submitLatchRef.current();');
     expect(wiring).toContain('}, []);');
   });
@@ -60,16 +60,19 @@ describe('the composer submits through the latch', () => {
     // creation would submit against stale attachedFiles/queue props.
     const wiring = between('const dispatchSubmissionRef = useRef', 'const editorPlaceholder');
     expect(wiring).toContain('dispatchSubmissionRef.current = dispatchSubmission;');
-    expect(wiring).toContain('() => dispatchSubmissionRef.current()');
+    expect(wiring).toContain('(stash) => dispatchSubmissionRef.current(stash)');
   });
 
-  test('the deferral discriminator is typed text in the live editor', () => {
+  test('the stash discriminator is typed text in the live editor, and the stash clears the editor', () => {
     // A double-fire arrives with the editor already cleared (dispatch clears it
     // synchronously); a distinct second message arrives with text. Files alone
-    // must NOT arm the deferral — un-flushed `attachedFiles` state is exactly
-    // the hazard the latch exists to swallow.
-    const wiring = between('submitLatchRef.current ??= createSubmitLatch(', 'const editorPlaceholder');
-    expect(wiring).toContain('editorRef.current?.getContent().text.trim()');
+    // must NOT arm the stash — un-flushed `attachedFiles` state is exactly
+    // the hazard the latch exists to swallow. A stashed draft leaves the
+    // editor at once, so the next Enter cannot merge into it.
+    const wiring = between('submitLatchRef.current ??= createSubmitLatch<StashedDraft>(', 'const editorPlaceholder');
+    expect(wiring).toContain("if (!editor || !content || !content.text.trim()) return null;");
+    expect(wiring).toContain('editor.clear();');
+    expect(wiring).toContain('attachedFilesRef.current = [];');
   });
 
   test('every submit entry point goes through the latched handler', () => {

--- a/apps/web/src/features/session/composer/composer.tsx
+++ b/apps/web/src/features/session/composer/composer.tsx
@@ -68,6 +68,13 @@ import { useComposerFocus } from './hooks/use-composer-focus';
 import { useMenuRevalidation } from './hooks/use-file-search';
 import { controlToOpenFor, SLASH_ACTIONS, type SlashAction } from './menus/slash-actions';
 import { createSubmitLatch } from './submit-latch';
+
+/** A draft captured out of the editor at Enter time — see `createSubmitLatch`. */
+interface StashedDraft {
+  content: ReturnType<ComposerEditorHandle['getContent']>;
+  doc: JSONContent | null;
+  files: AttachedFile[];
+}
 import type { AttachedFile, TrackedMention } from './types';
 
 export interface SessionChatInputProps {
@@ -394,6 +401,12 @@ function ComposerImpl({
   const dockId = `composer-slash-dock-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
 
   const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([]);
+  // Synchronous mirror of `attachedFiles`, for the one reader that cannot
+  // wait for a React flush: the submit latch's stash (see `handleSubmit`).
+  const attachedFilesRef = useRef<AttachedFile[]>([]);
+  useEffect(() => {
+    attachedFilesRef.current = attachedFiles;
+  }, [attachedFiles]);
   const [isDragOver, setIsDragOver] = useState(false);
   const [isEmpty, setIsEmpty] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -882,7 +895,7 @@ function ComposerImpl({
     [cycleAgent],
   );
 
-  const dispatchSubmission = useCallback(async () => {
+  const dispatchSubmission = useCallback(async (stash?: StashedDraft) => {
     // Ahead of the model check: with no agent to run it, the model this prompt
     // would have used is not the user's problem.
     if (agentUnavailable) {
@@ -913,7 +926,12 @@ function ComposerImpl({
       return;
     }
 
-    const draft = editorRef.current?.getContent();
+    // A stashed draft was captured out of the editor (and the editor cleared)
+    // when its Enter arrived mid-send — see `createSubmitLatch`. It is
+    // submitted as captured; the live editor belongs to whatever the user
+    // typed since.
+    const draft = stash ? stash.content : editorRef.current?.getContent();
+    const filesNow = stash ? stash.files : attachedFiles;
     const plan = planDraftSubmission({
       commandName: draft?.commandName,
       text: draft?.text ?? '',
@@ -929,7 +947,7 @@ function ComposerImpl({
       // covers the keyboard path, which no disabled button can gate.
       const guard = planCommandAttachments({
         isCommand: true,
-        attachmentCount: attachedFiles.length,
+        attachmentCount: filesNow.length,
       });
       if (guard.kind === 'refuse') {
         toast.error(guard.message, { description: guard.description });
@@ -969,7 +987,7 @@ function ComposerImpl({
         return;
       }
       onCommand?.(plan.command, plan.args, draft?.commandSplit);
-      if (clearOnSend) {
+      if (clearOnSend && !stash) {
         editorRef.current?.clear();
         setAttachedFiles((prev) => {
           for (const file of prev) {
@@ -982,10 +1000,10 @@ function ComposerImpl({
     }
 
     if (lockForQuestion) {
-      const trimmed = (editorRef.current?.getContent().text ?? '').trim();
+      const trimmed = (draft?.text ?? '').trim();
       if (trimmed && onCustomAnswer) {
         onCustomAnswer(trimmed);
-        editorRef.current?.clear();
+        if (!stash) editorRef.current?.clear();
         return;
       }
       if (onQuestionAction) {
@@ -997,16 +1015,17 @@ function ComposerImpl({
 
     const content = draft ?? { text: '', mentions: [] };
     const trimmed = plan.text;
-    if ((!trimmed && attachedFiles.length === 0) || submitDisabled) return;
+    if ((!trimmed && filesNow.length === 0) || submitDisabled) return;
 
-    const filesToSend = attachedFiles.length > 0 ? [...attachedFiles] : undefined;
+    const filesToSend = filesNow.length > 0 ? [...filesNow] : undefined;
     const mentionsToSend = content.mentions.length > 0 ? [...content.mentions] : undefined;
-    const submittedDoc = editorRef.current?.getDocument() ?? null;
-    const submittedIsEmpty = editorRef.current?.isEmpty() ?? true;
+    const submittedDoc = stash ? stash.doc : (editorRef.current?.getDocument() ?? null);
+    const submittedIsEmpty = stash ? false : (editorRef.current?.isEmpty() ?? true);
 
-    const reset = resolveComposerResetOnSend(clearOnSend, attachedFiles);
-    if (reset.clear) {
+    const reset = resolveComposerResetOnSend(clearOnSend, filesNow);
+    if (reset.clear && !stash) {
       editorRef.current?.clear();
+      attachedFilesRef.current = [];
       setAttachedFiles([]);
     }
 
@@ -1084,12 +1103,26 @@ function ComposerImpl({
   const handleSubmit = useCallback(() => {
     // Lazy-created at the first submit (never during render, which the
     // compiler's ref rules forbid) and reused forever after.
-    submitLatchRef.current ??= createSubmitLatch(
-      () => dispatchSubmissionRef.current(),
+    submitLatchRef.current ??= createSubmitLatch<StashedDraft>(
+      (stash) => dispatchSubmissionRef.current(stash),
       // Typed text is what marks a re-entrant submit as a distinct message
-      // worth deferring; a double-fire arrives with the editor already
-      // cleared.
-      () => Boolean(editorRef.current?.getContent().text.trim()),
+      // worth stashing; a double-fire arrives with the editor already
+      // cleared. The stash takes the draft OUT of the editor right now — the
+      // user sees the message leave on Enter, exactly as a direct send — and
+      // submits it unchanged once the in-flight send settles. Files ride
+      // along from the synchronous mirror, not from React state that may not
+      // have flushed.
+      () => {
+        const editor = editorRef.current;
+        const content = editor?.getContent();
+        if (!editor || !content || !content.text.trim()) return null;
+        const doc = editor.getDocument() ?? null;
+        const files = attachedFilesRef.current;
+        editor.clear();
+        attachedFilesRef.current = [];
+        setAttachedFiles([]);
+        return { content, doc, files };
+      },
     );
     return submitLatchRef.current();
   }, []);

--- a/apps/web/src/features/session/composer/send-stop-control.tsx
+++ b/apps/web/src/features/session/composer/send-stop-control.tsx
@@ -87,6 +87,7 @@ export function SendStopControl({
         >
           <Button
             size="icon-base"
+            aria-label="Stop"
             onClick={onStop}
             disabled={stopDisabled || !onStop}
             className={ICON_BUTTON}

--- a/apps/web/src/features/session/composer/submit-latch.test.ts
+++ b/apps/web/src/features/session/composer/submit-latch.test.ts
@@ -26,8 +26,10 @@ function controlledDispatch() {
   const resolvers: Array<() => void> = [];
   const rejecters: Array<(err: Error) => void> = [];
   let calls = 0;
-  const dispatch = () => {
+  const args: unknown[] = [];
+  const dispatch = (draft?: unknown) => {
     calls++;
+    args.push(draft);
     return new Promise<void>((resolve, reject) => {
       resolvers.push(resolve);
       rejecters.push(reject);
@@ -36,6 +38,7 @@ function controlledDispatch() {
   return {
     dispatch,
     calls: () => calls,
+    args: () => args,
     settle: (i: number) => resolvers[i](),
     fail: (i: number) => rejecters[i](new Error('send failed')),
   };
@@ -68,7 +71,7 @@ describe('createSubmitLatch', () => {
 
   test('a re-entrant submit with an EMPTY draft is dropped (double-fire guard)', async () => {
     const d = controlledDispatch();
-    const submit = createSubmitLatch(d.dispatch, () => false);
+    const submit = createSubmitLatch(d.dispatch, () => null);
     const first = submit();
     void submit(); // same-tick double-fire: editor already cleared
     d.settle(0);
@@ -77,17 +80,45 @@ describe('createSubmitLatch', () => {
     expect(d.calls()).toBe(1); // dropped, exactly like the old latch
   });
 
-  test('many re-entrant submits collapse into one deferred re-run', async () => {
+  test('each distinct re-entrant submit is its OWN submission, dispatched in order', async () => {
+    // Three messages typed during one slow ACK used to collapse into ONE
+    // deferred re-run that re-read the live editor — i.e. one message with the
+    // three texts run together. Every Enter is one message, in Enter order.
     const d = controlledDispatch();
-    const submit = createSubmitLatch(d.dispatch, () => true);
+    let n = 0;
+    const submit = createSubmitLatch(d.dispatch, () => `draft-${++n}`);
     const first = submit();
     void submit();
     void submit();
-    void submit(); // mashing Enter while blocked
+    void submit();
+    expect(d.calls()).toBe(1);
     d.settle(0);
     await first;
     await tick();
-    expect(d.calls()).toBe(2); // one re-run reads the whole current draft
+    expect(d.calls()).toBe(2);
+    expect(d.args()).toEqual([undefined, 'draft-1']);
+    d.settle(1);
+    await tick();
+    d.settle(2);
+    await tick();
+    expect(d.calls()).toBe(4);
+    expect(d.args()).toEqual([undefined, 'draft-1', 'draft-2', 'draft-3']);
+    d.settle(3);
+  });
+
+  test('the stash is captured at submit time, not re-read later', async () => {
+    // The whole point: what the user had typed at Enter #2 is what #2 sends,
+    // whatever they type afterwards.
+    const d = controlledDispatch();
+    let draft = 'second';
+    const submit = createSubmitLatch(d.dispatch, () => draft);
+    const first = submit();
+    void submit();
+    draft = 'typed later';
+    d.settle(0);
+    await first;
+    await tick();
+    expect(d.args()[1]).toBe('second');
     d.settle(1);
   });
 
@@ -106,7 +137,7 @@ describe('createSubmitLatch', () => {
 
   test('a throw releases the latch — the composer cannot wedge', async () => {
     const d = controlledDispatch();
-    const submit = createSubmitLatch(d.dispatch, () => false);
+    const submit = createSubmitLatch(d.dispatch, () => null);
     const first = submit();
     d.fail(0);
     await first.catch(() => {});

--- a/apps/web/src/features/session/composer/submit-latch.test.ts
+++ b/apps/web/src/features/session/composer/submit-latch.test.ts
@@ -80,10 +80,13 @@ describe('createSubmitLatch', () => {
     expect(d.calls()).toBe(1); // dropped, exactly like the old latch
   });
 
-  test('each distinct re-entrant submit is its OWN submission, dispatched in order', async () => {
+  test('each distinct re-entrant submit is its OWN submission, fired as one burst in order', async () => {
     // Three messages typed during one slow ACK used to collapse into ONE
-    // deferred re-run that re-read the live editor — i.e. one message with the
-    // three texts run together. Every Enter is one message, in Enter order.
+    // deferred re-run that re-read the live editor — i.e. one message with
+    // the three texts run together. Every Enter is one message; when the
+    // in-flight dispatch settles the whole stash goes out TOGETHER (invoked
+    // in Enter order — the sync prefix mints ids in order — awaited
+    // concurrently, so one slow ack cannot hold the burst back).
     const d = controlledDispatch();
     let n = 0;
     const submit = createSubmitLatch(d.dispatch, () => `draft-${++n}`);
@@ -95,14 +98,10 @@ describe('createSubmitLatch', () => {
     d.settle(0);
     await first;
     await tick();
-    expect(d.calls()).toBe(2);
-    expect(d.args()).toEqual([undefined, 'draft-1']);
-    d.settle(1);
-    await tick();
-    d.settle(2);
-    await tick();
     expect(d.calls()).toBe(4);
     expect(d.args()).toEqual([undefined, 'draft-1', 'draft-2', 'draft-3']);
+    d.settle(1);
+    d.settle(2);
     d.settle(3);
   });
 
@@ -146,16 +145,17 @@ describe('createSubmitLatch', () => {
     d.settle(1);
   });
 
-  test('the deferred re-run is itself latched (a submit during it defers again)', async () => {
+  test('a submit during the burst stashes and fires when the burst settles', async () => {
     const d = controlledDispatch();
-    const submit = createSubmitLatch(d.dispatch, () => true);
+    let n = 0;
+    const submit = createSubmitLatch(d.dispatch, () => `draft-${++n}`);
     const first = submit();
     void submit();
     d.settle(0);
     await first;
     await tick();
-    expect(d.calls()).toBe(2); // deferred run in flight
-    void submit(); // typed during the deferred run
+    expect(d.calls()).toBe(2); // burst in flight
+    void submit(); // typed during the burst
     expect(d.calls()).toBe(2); // not re-entrant
     d.settle(1);
     await tick();

--- a/apps/web/src/features/session/composer/submit-latch.ts
+++ b/apps/web/src/features/session/composer/submit-latch.ts
@@ -1,5 +1,6 @@
 /**
- * One user action = one submission — without eating the NEXT user action.
+ * One user action = one submission — without eating the NEXT user action, and
+ * without MERGING the next actions into one.
  *
  * Why a latch exists at all: the sandbox proxy used to absorb an accidental
  * double-fire for free by deduping deliveries on a body hash; per-submission
@@ -14,8 +15,9 @@
  * Why it is THIS latch and not `if (inFlight) return;`: the dispatch it guards
  * awaits the previous send's ACK, and that ACK is not instant — file uploads,
  * plus `promptOpenCodeMessage`'s transient-failure retries with a ~30s
- * boot/wake window for a sleeping sandbox. A blanket return held the gate for
- * that entire window and silently dropped every submission inside it, so the
+ * boot/wake window for a sleeping sandbox, and an API under load (measured
+ * 9 s for one `POST .../prompts`). A blanket return held the gate for that
+ * entire window and silently dropped every submission inside it, so the
  * second message a user typed right after the first NEVER reached the
  * busy→queue decision the composer owns. The queue existed precisely for that
  * message, and the latch stood in front of it.
@@ -25,52 +27,56 @@
  *
  *  - **Double-fire** (the hazard the latch is for): the editor is already
  *    empty — dispatch cleared it synchronously. Dropped, as before.
- *  - **Distinct second message**: the user typed new text. Deferred — it
- *    re-runs once the in-flight dispatch settles. By then the session's
- *    optimistic busy status is set (synchronously, at send start), so the
- *    re-run routes into the message queue rather than double-sending.
+ *  - **Distinct message**: the user typed new text. STASHED — captured out of
+ *    the editor (which is cleared, exactly as a dispatch would clear it) into a
+ *    FIFO, and dispatched in order once the in-flight dispatch settles. By
+ *    then the session's optimistic busy status is set, so each stashed draft
+ *    routes into the message queue rather than double-sending.
  *
- * Repeated submissions while blocked collapse into ONE deferred re-run: the
- * re-run reads the live editor draft, which already contains everything the
- * user typed. A files-only second message (no text) inside the in-flight
- * window is indistinguishable from the hazard and stays dropped — that trade
- * is deliberate; the hazard's cost is a duplicate send on the wire.
+ * Stashing, not collapsing. The previous version deferred ONE re-run that
+ * re-read the live editor, "which already contains everything the user
+ * typed" — so three Enters during one slow ACK became ONE message with the
+ * three texts run together ("say ALPHA only.Queued #2: then say BETA only."),
+ * measured live (queue-lab `queue3` on a cold box, 2026-08-19). Every Enter is
+ * one message; the order is the order the user pressed Enter.
  *
- * Framework-free on purpose so the deferral ordering is unit-testable with
- * real promises instead of source-text assertions.
+ * Framework-free on purpose so the ordering is unit-testable with real
+ * promises instead of source-text assertions.
  */
-export function createSubmitLatch(
-  dispatch: () => Promise<void>,
+export function createSubmitLatch<Draft>(
   /**
-   * Whether the CURRENT draft carries typed text worth deferring for. Read at
-   * re-entrant-submit time, so a cleared editor (double-fire) reads false and
-   * a typed second message reads true.
+   * Run one submission. With no argument: read the live editor, as a direct
+   * submit always has. With a stashed draft: submit THAT, the editor having
+   * been cleared at stash time.
    */
-  hasDeferrableDraft: () => boolean,
+  dispatch: (stashed?: Draft) => Promise<void>,
+  /**
+   * Capture the CURRENT draft as its own submission — and clear it from the
+   * editor — or return null when there is nothing distinct to submit (a
+   * cleared editor: the double-fire). Read at re-entrant-submit time.
+   */
+  stashDeferrableDraft: () => Draft | null,
 ): () => Promise<void> {
   let inFlight = false;
-  let deferred = false;
+  const stashed: Draft[] = [];
 
-  const submit = async (): Promise<void> => {
-    if (inFlight) {
-      if (hasDeferrableDraft()) deferred = true;
-      return;
-    }
+  const run = async (draft?: Draft): Promise<void> => {
     inFlight = true;
     try {
-      await dispatch();
+      await dispatch(draft);
     } finally {
-      // `finally`, so a throw from any dispatch path cannot wedge the composer
-      // into permanently refusing to send. `dispatchSubmission` handles its own
-      // send failure and restores the draft; this only releases the gate — and
-      // runs the submission that arrived while it was closed.
       inFlight = false;
-      if (deferred) {
-        deferred = false;
-        void submit();
-      }
+      const next = stashed.shift();
+      if (next !== undefined) void run(next);
     }
   };
 
-  return submit;
+  return (): Promise<void> => {
+    if (inFlight) {
+      const draft = stashDeferrableDraft();
+      if (draft !== null) stashed.push(draft);
+      return Promise.resolve();
+    }
+    return run();
+  };
 }

--- a/apps/web/src/features/session/composer/submit-latch.ts
+++ b/apps/web/src/features/session/composer/submit-latch.ts
@@ -65,9 +65,23 @@ export function createSubmitLatch<Draft>(
     try {
       await dispatch(draft);
     } finally {
+      // Everything stashed while this dispatch was in flight goes out NOW,
+      // TOGETHER. The dispatches are invoked in stash order — their
+      // synchronous prefixes (wire-id mint, optimistic paint) run in that
+      // order, which is what display and the server's `client_sent_at_ms`
+      // key on — but their awaits (uploads, the POST) run concurrently: one
+      // slow ack must not hold the rest of a burst back one round-trip each,
+      // or the server's batch closes before the burst is even durable.
+      const burst = stashed.splice(0);
+      if (burst.length > 0) {
+        void Promise.allSettled(burst.map((next) => dispatch(next))).finally(() => {
+          inFlight = false;
+          const late = stashed.splice(0);
+          if (late.length > 0) void Promise.allSettled(late.map((next) => dispatch(next)));
+        });
+        return;
+      }
       inFlight = false;
-      const next = stashed.shift();
-      if (next !== undefined) void run(next);
     }
   };
 

--- a/apps/web/src/features/session/instant-session-shell.tsx
+++ b/apps/web/src/features/session/instant-session-shell.tsx
@@ -7,6 +7,7 @@ import { createPortal } from 'react-dom';
 import { ComposerChatInput, type ComposerOptions } from '@/features/session/composer-chat-input';
 import { SessionSiteHeader } from '@/features/session/header/session-site-header';
 import { OptimisticTurn } from '@/features/session/optimistic-turn';
+import { QueuedPromptBubbles } from '@/features/session/turn/queued-prompt-bubbles';
 import type { AttachedFile } from '@/features/session/session-chat-input';
 import { SessionLayout } from '@/features/session/session-layout';
 import { useSessionWallpaperLayer } from '@/features/session/session-wallpaper-layer';
@@ -106,6 +107,12 @@ export function InstantSessionShell({
     text: string;
     files: AttachedFile[];
   } | null>(null);
+  // Every send AFTER the first, painted the moment Enter lands — the durable
+  // row takes over on the next poll. Without this the shell drew only the
+  // first prompt, and anything typed while the box booted stayed invisible
+  // until the real chat mounted (measured: four prompts popping in at once,
+  // ~15 s later).
+  const [extraSends, setExtraSends] = useState<Array<{ id: string; text: string }>>([]);
   const stashedSubmission = useMemo(() => {
     if (!hydrated) return null;
     // `readStartStash` covers the canonical SDK stash (written under the route
@@ -132,6 +139,18 @@ export function InstantSessionShell({
     if (!row) return null;
     return { text: row.text, files: [] as AttachedFile[] };
   }, [promptInbox.prompts]);
+  // The queue behind the first prompt: every durable row after the first,
+  // plus the sends this shell has made that no row lists yet (matched by
+  // text, which is all the list view carries).
+  const queuedBehindFirst = useMemo(() => {
+    const rows = promptInbox.prompts.filter((p) => p.text.trim().length > 0);
+    const behind = rows.slice(1).map((p) => ({ id: p.prompt_id, text: p.text }));
+    const listed = new Set(rows.map((p) => p.text.trim()));
+    for (const extra of extraSends) {
+      if (!listed.has(extra.text.trim())) behind.push(extra);
+    }
+    return behind;
+  }, [promptInbox.prompts, extraSends]);
   // The producer's own copy of the first prompt, drawn from the first frame —
   // the row read above can miss it entirely when a warm box delivers between
   // navigation and the fetch. See `useFirstPromptPreviewStore`.
@@ -190,6 +209,8 @@ export function InstantSessionShell({
       if (!submitted) {
         setSubmission({ text, files: files ?? [] });
         onSubmit?.();
+      } else {
+        setExtraSends((prev) => [...prev, { id: `shell-extra-${Date.now()}`, text }]);
       }
     },
     [projectId, sessionId, submitted, onSubmit],
@@ -295,6 +316,10 @@ export function InstantSessionShell({
                   deferPreview
                   sessionId={sessionId}
                 />
+                {/* What was typed while the box boots, as the dimmed queued
+                    bubbles they already are on the server — same component
+                    SessionChat draws, so the crossfade changes nothing. */}
+                <QueuedPromptBubbles className="mt-3" queued={queuedBehindFirst} />
               </div>
             )}
           </div>

--- a/apps/web/src/features/session/queue-projection.test.ts
+++ b/apps/web/src/features/session/queue-projection.test.ts
@@ -64,6 +64,28 @@ describe('projectQueueRows', () => {
     expect(projection.inFlightIds).toEqual(['unpainted']);
   });
 
+  test('a row whose WIRE id is in the transcript leaves the strip, even after the server re-minted it', () => {
+    // The drain re-mints a mid-turn prompt above the live turn's ids and the
+    // row's `message_id` moves to the new id BEFORE the runtime echoes it —
+    // the echo is what lets the store alias the new id back to the bubble.
+    // For that window (~0.4 s, every mid-turn send) the bubble this tab
+    // painted is on screen under the ORIGINAL wire id and the row, matched
+    // on `message_id` only, was drawn beside it: a second dimmed copy that
+    // then vanished.
+    const projection = projectQueueRows({
+      prompts: [
+        prompt({
+          prompt_id: 'reminted',
+          message_id: 'msg_reminted',
+          wire_message_id: 'msg_original',
+          state: 'delivering',
+        }),
+      ],
+      transcriptMessageIds: new Set(['msg_original']),
+    });
+    expect(projection.queued).toEqual([]);
+  });
+
   test('a HELD row in the transcript is NOT a queue row — the bubble carries its controls, but the hold is still reported', () => {
     // A stop-paused prompt IS in the transcript, unanswered and parked. Its
     // remove and "send now" live in the bubble's own meta row now

--- a/apps/web/src/features/session/queue-projection.ts
+++ b/apps/web/src/features/session/queue-projection.ts
@@ -70,7 +70,15 @@ export function projectQueueRows(input: {
     // runtime echoes it. The transcript wins; this list is for what is NOT in
     // it yet. A HELD row in the transcript is no exception any more: its
     // controls live in the bubble's own meta row (`QueuedPromptControls`).
-    if (prompt.message_id && input.transcriptMessageIds?.has(prompt.message_id)) {
+    // EITHER of the prompt's ids counts: `message_id` moves to the server's
+    // re-minted id the moment the drain places the prompt — before the
+    // runtime echoes it and before the store can alias the echo back — while
+    // the bubble this tab painted still carries `wire_message_id`. Matching
+    // only `message_id` drew the row beside its own bubble for that window.
+    if (
+      (prompt.message_id && input.transcriptMessageIds?.has(prompt.message_id)) ||
+      (prompt.wire_message_id && input.transcriptMessageIds?.has(prompt.wire_message_id))
+    ) {
       continue;
     }
     // A DELIVERING row is a queue row too. The server forwards a prompt typed

--- a/apps/web/src/features/session/session-chat-inbox-queue.test.ts
+++ b/apps/web/src/features/session/session-chat-inbox-queue.test.ts
@@ -158,7 +158,7 @@ describe('ONE prompt = ONE id = ONE bubble, from Enter', () => {
     // copy transiently share an origin (duplicate keys corrupt the list).
     expect(chat).toContain('key={turnRenderKeys.get(turn.userMessage.info.id)}');
     expect(chat).toContain('const origin = optimisticOriginOf(sessionId, id);');
-    expect(chat).toContain("const key = used.has(preferred) ? id : preferred;");
+    expect(chat).toContain('while (used.has(key)) key = `${key}~`;');
   });
 });
 

--- a/apps/web/src/features/session/session-chat-inbox-queue.test.ts
+++ b/apps/web/src/features/session/session-chat-inbox-queue.test.ts
@@ -152,8 +152,13 @@ describe('ONE prompt = ONE id = ONE bubble, from Enter', () => {
     expect(chat).toContain('transcriptMessageIds: transcriptUserMessageIds');
   });
 
-  test('the turn is keyed by the id the bubble was FIRST painted under', () => {
-    expect(chat).toContain('optimisticOriginOf(sessionId, turn.userMessage.info.id) ??');
+  test('the turn is keyed by the id the bubble was FIRST painted under — uniquely', () => {
+    // The origin key keeps one element across the re-mint swap; the
+    // uniqueness pass keeps React sane when an old echo and its re-placed
+    // copy transiently share an origin (duplicate keys corrupt the list).
+    expect(chat).toContain('key={turnRenderKeys.get(turn.userMessage.info.id)}');
+    expect(chat).toContain('const origin = optimisticOriginOf(sessionId, id);');
+    expect(chat).toContain("const key = used.has(preferred) ? id : preferred;");
   });
 });
 

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -45,6 +45,7 @@ import { stabilizeTurns } from './turn/stable-turns';
 import { ThrottledMarkdown } from './turn/throttled-markdown';
 import { TurnViewport } from './turn/turn-viewport';
 import { UserMessage } from './turn/user-message';
+import { isOptimisticSessionPrompt } from '@kortix/sdk/react';
 import {
   QueuedPromptActions,
   QueuedPromptBubbles,
@@ -2841,7 +2842,70 @@ export function SessionChat({
       }
     };
   }, []);
-  const rawTurns = useMemo(() => (messages ? groupMessagesIntoTurns(messages) : []), [messages]);
+  /**
+   * Queue rows the transcript does not hold yet, as SYNTHETIC user messages —
+   * fed into the SAME turn list as everything else, sorted by their creation
+   * time, so a queued prompt never renders in a second container below newer
+   * turns. The strip used to draw them after the turns; a send painted as an
+   * optimistic TURN while an older row was still a strip ROW then displayed
+   * newest-first (measured on the shell→chat handoff: Boot 4 above Boot 1–3).
+   * The echo arrives under the same `message_id`, so the synthetic turn
+   * becomes the real one in place — same element, same key.
+   */
+  const queuedSyntheticMessages = useMemo(() => {
+    const out: NonNullable<typeof messages> = [];
+    // A queued row is by definition newer than everything the transcript
+    // already holds — but its clock is the SENDER TAB's, and the box stamps
+    // real messages from its own. A box running ~1 s ahead sorted a fresh
+    // queued row ABOVE the previous turn (measured). Floor every synthetic
+    // time just past the newest real stamp, keeping the rows' own relative
+    // order.
+    let floor = 0;
+    for (const message of messages ?? []) {
+      const created = (message.info as { time?: { created?: number } }).time?.created;
+      if (typeof created === 'number' && created > floor) floor = created;
+    }
+    let previous = floor;
+    for (const prompt of promptInbox.prompts) {
+      if (prompt.state === 'failed') continue;
+      if (!prompt.text.trim()) continue;
+      if (prompt.message_id && transcriptUserMessageIds.has(prompt.message_id)) continue;
+      if (prompt.wire_message_id && transcriptUserMessageIds.has(prompt.wire_message_id)) continue;
+      if (isOptimisticSessionPrompt(prompt)) continue; // painted by this tab already
+      const id = prompt.message_id || `queued-${prompt.prompt_id}`;
+      const sentAt =
+        typeof prompt.client_sent_at_ms === 'number'
+          ? prompt.client_sent_at_ms
+          : Date.parse(prompt.created_at);
+      const createdMs = Math.max(sentAt, previous + 1);
+      previous = createdMs;
+      out.push({
+        info: {
+          id,
+          sessionID: sessionId,
+          role: 'user',
+          time: Number.isFinite(createdMs) ? { created: createdMs } : {},
+        },
+        parts: [
+          {
+            id: `syn-${prompt.prompt_id}`,
+            messageID: id,
+            sessionID: sessionId,
+            type: 'text',
+            text: prompt.text,
+          },
+        ],
+      } as unknown as NonNullable<typeof messages>[number]);
+    }
+    return out;
+  }, [promptInbox.prompts, transcriptUserMessageIds, sessionId]);
+  const rawTurns = useMemo(
+    () =>
+      messages || queuedSyntheticMessages.length > 0
+        ? groupMessagesIntoTurns([...(messages ?? []), ...queuedSyntheticMessages])
+        : [],
+    [messages, queuedSyntheticMessages],
+  );
   /**
    * `groupMessagesIntoTurns` allocates a fresh object per turn on every call, and
    * `messages` is rebuilt on every SSE frame — so a fifty-turn session handed
@@ -2908,6 +2972,28 @@ export function SessionChat({
     [turns, working.turnId],
   );
   const pendingTurnIds = useMemo(() => new Set(workingTurn.pendingTurnIds), [workingTurn]);
+  /**
+   * ONE render key per turn. A turn keeps the id its bubble was FIRST painted
+   * under (the optimistic origin), so a re-minted echo re-renders the same
+   * element instead of mounting a new one. But an origin can transiently be
+   * claimed by TWO turns — an old echo still on screen while its re-placed
+   * copy arrives — and duplicate React keys corrupt the whole list (measured:
+   * 1.5k "two children with the same key" errors in one churn). The origin
+   * key goes to the FIRST claimant; any other turn falls back to its own id.
+   */
+  const turnRenderKeys = useMemo(() => {
+    const keys = new Map<string, string>();
+    const used = new Set<string>();
+    for (const turn of turns) {
+      const id = turn.userMessage.info.id;
+      const origin = optimisticOriginOf(sessionId, id);
+      const preferred = origin && !used.has(origin) ? origin : id;
+      const key = used.has(preferred) ? id : preferred;
+      keys.set(id, key);
+      used.add(key);
+    }
+    return keys;
+  }, [turns, sessionId, optimisticOriginOf]);
   // User messages a Stop stranded: the session is idle, the newest turn with
   // content ended by abort, and these came after it with nothing under them.
   // The runtime holds them; nothing runs them until the next send.
@@ -3241,6 +3327,7 @@ export function SessionChat({
       // hand-off between them was a frame where the message doubled, blinked
       // or jumped.
       const clientMessageId = overrides?.clientMessageId ?? ascendingId('msg');
+      const sentAtMs = Date.now();
       const messageID = mintSessionWireMessageId(sessionId, clientMessageId);
 
       // Generate part IDs upfront so the optimistic message and the server
@@ -3500,6 +3587,9 @@ export function SessionChat({
             clientMessageId,
             messageId: messageID,
             parts: mappedParts,
+            // Enter time, not POST time: uploads and a busy API sit between
+            // the two, and the server orders racing sends by THIS.
+            clientSentAtMs: sentAtMs,
             overrides: {
               // Pass the session's directory so opencode resolves project-scoped
               // agents (.opencode/agent/*.md under the project) and applies them
@@ -4397,10 +4487,7 @@ export function SessionChat({
                             // re-minted echo id re-renders this node instead
                             // of mounting a new one (opacity keeps animating,
                             // hover state survives, nothing jumps).
-                            key={
-                              optimisticOriginOf(sessionId, turn.userMessage.info.id) ??
-                              turn.userMessage.info.id
-                            }
+                            key={turnRenderKeys.get(turn.userMessage.info.id)}
                             turnId={turn.userMessage.info.id}
                             // Queued bubbles STACK: a pending turn right after
                             // another pending turn sits close to it, like a
@@ -4521,6 +4608,10 @@ export function SessionChat({
                         stands in until either the row or the transcript has it,
                         so the bubble the boot shell drew never blinks out in the
                         crossfade. */}
+                    {/* Unpainted queue rows render as synthetic turns in the
+                        list above (`queuedSyntheticMessages`); only FAILED
+                        rows remain here — a failure is not a turn-to-be and
+                        must not dim like one. */}
                     <QueuedPromptBubbles
                       className={
                         turns.length === 0
@@ -4530,7 +4621,7 @@ export function SessionChat({
                             ? 'mt-3'
                             : 'mt-12'
                       }
-                      queued={queuedMessages}
+                      queued={[]}
                       inFlightIds={queueInFlightIds}
                       failed={failedQueuedMessages}
                       held={queueRows.held}

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -46,8 +46,9 @@ import { ThrottledMarkdown } from './turn/throttled-markdown';
 import { TurnViewport } from './turn/turn-viewport';
 import { UserMessage } from './turn/user-message';
 import {
+  QueuedPromptActions,
   QueuedPromptBubbles,
-  QueuedPromptControls,
+  QueuedPromptStatus,
   QUEUED_BUBBLE_OPACITY_CLASS,
   type QueuedPromptState,
 } from './turn/queued-prompt-bubbles';
@@ -827,6 +828,10 @@ function SessionTurnImpl({
       : interruptedBeforeRun
         ? 'interrupted'
         : null;
+  // The word under the bubble. A PENDING bubble says "Queued" even when its
+  // inbox row is already closed (the runtime holds the message, the agent has
+  // not reached it): the dim alone reads as "something is wrong".
+  const statusState: QueuedPromptState | null = queueState ?? (pending ? 'queued' : null);
 
   const activeAssistantMessage = useMemo(() => {
     if (turn.assistantMessages.length === 0) return undefined;
@@ -1479,14 +1484,19 @@ function SessionTurnImpl({
             ownsPlan={ownsPlan}
             onRewind={onRewind}
             rewindDisabled={rewindDisabled}
+            leadingStatus={
+              statusState ? (
+                <QueuedPromptStatus
+                  state={statusState}
+                  lastError={queueRow?.last_error ?? undefined}
+                />
+              ) : undefined
+            }
             leadingActions={
-              queueState === 'interrupted' ? (
-                <QueuedPromptControls id={turn.userMessage.info.id} state="interrupted" />
-              ) : queueRow && queueState ? (
-                <QueuedPromptControls
+              queueRow && queueState && queueState !== 'interrupted' ? (
+                <QueuedPromptActions
                   id={queueRow.prompt_id}
                   state={queueState}
-                  lastError={queueRow.last_error ?? undefined}
                   onRemove={onQueueRemove}
                   onSendNow={onQueueSendNow}
                   onRetry={onQueueRetry}
@@ -2560,6 +2570,12 @@ export function SessionChat({
       byId.set(prompt.message_id, prompt);
       const echo = store.optimisticEchoOf(sessionId, prompt.message_id);
       if (echo) byId.set(echo, prompt);
+      // The id this tab painted under, when the drain already re-minted.
+      if (prompt.wire_message_id && prompt.wire_message_id !== prompt.message_id) {
+        byId.set(prompt.wire_message_id, prompt);
+        const wireEcho = store.optimisticEchoOf(sessionId, prompt.wire_message_id);
+        if (wireEcho) byId.set(wireEcho, prompt);
+      }
     }
     return byId;
   }, [promptInbox.prompts, sessionId]);
@@ -3302,11 +3318,14 @@ export function SessionChat({
 
       // A send follows from here: the new bubble lands at the top of the
       // screen the frame it commits (use-auto-scroll.ts, FACT 2 + THE RULE).
-      // Not while a turn runs: a reader who scrolled up to read the streaming
-      // answer must not be pulled to the queued bubble; one who is at the end
-      // sees it appear anyway (the room is measured from the working turn, so
-      // the queued bubble does not shift the answer out of view either).
+      // While a turn runs the queued bubble is not anchored at the top (that
+      // would shift the streaming answer out of view); one who is at the end
+      // sees it appear anyway. One who had scrolled UP is brought to it,
+      // smoothly: pressing Enter is intent to see the message land, and a
+      // queued bubble that appears off-screen with no feedback reads as
+      // "nothing happened" (queue-lab `scroll_up_queue`, 2026-08-19).
       if (!sendingIntoRunningTurn) anchorTurn(messageID);
+      else if (scrollRef.current?.dataset.follow === 'false') smoothScrollToAbsoluteBottom();
 
       const options: Record<string, unknown> = {};
       const overrideAgent = overrides?.agent;
@@ -3544,6 +3563,8 @@ export function SessionChat({
       local.model.sendKey,
       local.model.variant.current,
       anchorTurn,
+      smoothScrollToAbsoluteBottom,
+      scrollRef,
       replyTo,
       messages,
       sessionState,
@@ -4381,7 +4402,19 @@ export function SessionChat({
                               turn.userMessage.info.id
                             }
                             turnId={turn.userMessage.info.id}
-                            className={turnIndex === 0 ? '' : 'mt-12'}
+                            // Queued bubbles STACK: a pending turn right after
+                            // another pending turn sits close to it, like a
+                            // list of what is waiting — not a turn's width
+                            // apart as if each had been answered in between.
+                            className={
+                              turnIndex === 0
+                                ? ''
+                                : lastTurnWorking &&
+                                    pendingTurnIds.has(turn.userMessage.info.id) &&
+                                    pendingTurnIds.has(turns[turnIndex - 1].userMessage.info.id)
+                                  ? 'mt-3'
+                                  : 'mt-12'
+                            }
                           >
                             {/* Compaction divider — shown before the first turn after compaction */}
                             {hasCompaction && (
@@ -4489,7 +4522,14 @@ export function SessionChat({
                         so the bubble the boot shell drew never blinks out in the
                         crossfade. */}
                     <QueuedPromptBubbles
-                      className={turns.length > 0 ? 'mt-12' : undefined}
+                      className={
+                        turns.length === 0
+                          ? undefined
+                          : lastTurnWorking &&
+                              pendingTurnIds.has(turns[turns.length - 1].userMessage.info.id)
+                            ? 'mt-3'
+                            : 'mt-12'
+                      }
                       queued={queuedMessages}
                       inFlightIds={queueInFlightIds}
                       failed={failedQueuedMessages}

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -50,6 +50,7 @@ import {
   QueuedPromptActions,
   QueuedPromptBubbles,
   QueuedPromptStatus,
+  RemoveFromQueueButton,
   QUEUED_BUBBLE_OPACITY_CLASS,
   type QueuedPromptState,
 } from './turn/queued-prompt-bubbles';
@@ -833,6 +834,13 @@ function SessionTurnImpl({
   // inbox row is already closed (the runtime holds the message, the agent has
   // not reached it): the dim alone reads as "something is wrong".
   const statusState: QueuedPromptState | null = queueState ?? (pending ? 'queued' : null);
+  // What the X removes: the row while it is listed, the message's own wire id
+  // after the row left the list (the DELETE route resolves `msg_…` handles) —
+  // for any bubble the agent has not reached.
+  const queueRemovalId =
+    onQueueRemove && statusState && statusState !== 'interrupted' && statusState !== 'failed'
+      ? (queueRow?.prompt_id ?? turn.userMessage.info.id)
+      : null;
 
   const activeAssistantMessage = useMemo(() => {
     if (turn.assistantMessages.length === 0) return undefined;
@@ -1474,8 +1482,18 @@ function SessionTurnImpl({
           className={cn(
             'transition-opacity duration-500',
             (pending || interruptedBeforeRun) && QUEUED_BUBBLE_OPACITY_CLASS,
+            // A removable queued bubble reserves a slim column at its right
+            // for the X, so the control has ONE fixed home — the meta row
+            // reflows as timestamps and copy appear, and an X living there
+            // jumped out from under the pointer.
+            queueRemovalId && 'relative pr-7',
           )}
         >
+          {queueRemovalId && (
+            <div className="absolute top-2 right-0 opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100 focus-within:opacity-100">
+              <RemoveFromQueueButton id={queueRemovalId} onRemove={onQueueRemove!} />
+            </div>
+          )}
           <UserMessage
             message={turn.userMessage}
             agentNames={agentNames}
@@ -1495,10 +1513,11 @@ function SessionTurnImpl({
             }
             leadingActions={
               queueRow && queueState && queueState !== 'interrupted' ? (
+                // Send-now / Retry stay in the meta row; the X lives beside
+                // the bubble (see `queueRemovalId`).
                 <QueuedPromptActions
                   id={queueRow.prompt_id}
                   state={queueState}
-                  onRemove={onQueueRemove}
                   onSendNow={onQueueSendNow}
                   onRetry={onQueueRetry}
                 />
@@ -2568,6 +2587,12 @@ export function SessionChat({
     const byId = new Map<string, SessionPrompt>();
     for (const prompt of promptInbox.prompts) {
       if (!prompt.message_id) continue;
+      // The row names the re-minted id BEFORE the runtime echoes it: register
+      // the alias so the echo supersedes ITS OWN optimistic bubble instead of
+      // the ordinal fallback consuming the oldest one in flight.
+      if (prompt.wire_message_id && prompt.wire_message_id !== prompt.message_id) {
+        store.registerOptimisticEcho(sessionId, prompt.wire_message_id, prompt.message_id);
+      }
       byId.set(prompt.message_id, prompt);
       const echo = store.optimisticEchoOf(sessionId, prompt.message_id);
       if (echo) byId.set(echo, prompt);
@@ -2615,16 +2640,21 @@ export function SessionChat({
         // answers 409 rather than lying about it.
         errorToast(
           error instanceof Error && /409/.test(error.message)
-            ? 'That prompt is already being delivered'
+            ? 'The agent is already answering that prompt'
             : 'Could not remove that prompt',
         );
         return;
       }
       if (!removed) return;
-      // The bubble IS the queue entry: the row is gone, so its optimistic
-      // bubble goes with it. A no-op for a message the runtime already
-      // confirmed — that one is the transcript's now, not the queue's.
-      useSessionStateStore.getState().optimisticRemove(sessionId, removed.message_id);
+      // The bubble IS the queue entry: the row is gone, so every copy of the
+      // message goes with it — the optimistic bubble, a confirmed echo, and
+      // the ownership marks that would otherwise resurrect it when the
+      // runtime relays the deletion.
+      const store = useSessionStateStore.getState();
+      store.optimisticRemove(sessionId, removed.message_id);
+      for (const id of removed.removed_message_ids ?? [removed.message_id]) {
+        store.forgetControlPlaneMessage(sessionId, id);
+      }
 
       // Undo rather than a confirm dialog. A queue is something you curate —
       // gating every removal behind a modal would make it unusable, and the
@@ -2987,8 +3017,10 @@ export function SessionChat({
     for (const turn of turns) {
       const id = turn.userMessage.info.id;
       const origin = optimisticOriginOf(sessionId, id);
-      const preferred = origin && !used.has(origin) ? origin : id;
-      const key = used.has(preferred) ? id : preferred;
+      let key = origin && !used.has(origin) ? origin : id;
+      // Belt and braces: whatever aliasing produced a collision, NEVER hand
+      // React two children with one key — that corrupts the whole list.
+      while (used.has(key)) key = `${key}~`;
       keys.set(id, key);
       used.add(key);
     }
@@ -4545,7 +4577,15 @@ export function SessionChat({
                               onPermissionReply={handlePermissionReply}
                               onRewind={handleRewind}
                               rewindDisabled={
-                                !!readOnly || !sessionState || isBusy || sessionState.rewindPending
+                                !!readOnly ||
+                                !sessionState ||
+                                isBusy ||
+                                sessionState.rewindPending ||
+                                // The runtime is not idle while queued prompts
+                                // are still on their way to it — a rewind mid-
+                                // delivery fails downstream with "Session is
+                                // busy" (measured); refuse it up front instead.
+                                promptInbox.prompts.length > 0
                               }
                             />
                           </TurnViewport>

--- a/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
+++ b/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
@@ -26,8 +26,8 @@ import { cn } from '@/lib/utils';
 import {
   ArrowClockwiseIcon,
   PaperPlaneRightIcon,
-  TrashIcon,
   WarningIcon,
+  XIcon,
 } from '@phosphor-icons/react';
 import { BUBBLE_SURFACE, BUBBLE_TEXT } from './user-message';
 
@@ -159,8 +159,8 @@ export function QueuedPromptActions({
         </Action>
       )}
       {onRemove && (
-        <Action label="Remove" onClick={() => onRemove(id)} destructive>
-          <TrashIcon className="size-4" />
+        <Action label="Remove from queue" onClick={() => onRemove(id)} destructive>
+          <XIcon className="size-4" />
         </Action>
       )}
     </div>
@@ -240,29 +240,26 @@ function QueuedBubble({
     <div
       data-queued-prompt-id={row.id}
       data-queued-state={state}
-      className="group/queued ml-auto flex w-full max-w-[80%] flex-col items-end gap-2 self-end"
+      className="group/queued ml-auto flex w-full max-w-[80%] flex-col items-end gap-1 self-end"
     >
-      <div
-        className={cn(
-          BUBBLE_SURFACE,
-          'w-fit transition-opacity duration-500',
-          failed ? 'opacity-90' : live ? 'opacity-100' : QUEUED_BUBBLE_OPACITY_CLASS,
-        )}
-      >
-        <div className={cn('max-w-full min-w-0 max-h-[200px] overflow-hidden', BUBBLE_TEXT)}>
-          {row.text}
-        </div>
-      </div>
-      {/* Same anatomy as the sent bubble's meta row: the status is always
-          readable (it is what explains the dim), the controls reveal on hover;
-          height held so nothing reflows. A failed row keeps everything
-          visible — a failure the user has to hunt for is a message silently
-          lost. */}
-      <div className="flex w-full items-center justify-end gap-2">
-        <QueuedPromptStatus state={state} lastError={row.lastError} />
+      {/* Bubble + its controls in ONE row: the actions sit beside the bubble,
+          to its right, revealed on hover — never floating in space. The
+          column is width-reserved (`w-6`) so nothing shifts on hover. */}
+      <div className="flex w-full items-center justify-end gap-1">
         <div
           className={cn(
-            'flex items-center transition-opacity duration-150',
+            BUBBLE_SURFACE,
+            'w-fit transition-opacity duration-500',
+            failed ? 'opacity-90' : live ? 'opacity-100' : QUEUED_BUBBLE_OPACITY_CLASS,
+          )}
+        >
+          <div className={cn('max-w-full min-w-0 max-h-[200px] overflow-hidden', BUBBLE_TEXT)}>
+            {row.text}
+          </div>
+        </div>
+        <div
+          className={cn(
+            'flex w-6 shrink-0 flex-col items-center justify-center transition-opacity duration-150',
             failed
               ? 'opacity-100'
               : 'opacity-0 group-hover/queued:opacity-100 focus-within:opacity-100',
@@ -276,6 +273,13 @@ function QueuedBubble({
             onRetry={onRetry}
           />
         </div>
+      </div>
+      {/* The status word sits SNUG under the bubble, aligned to its edge —
+          it is what explains the dim, so it is always readable, and it must
+          read as the bubble's caption, not a free-floating label. `pr-7`
+          keeps it flush with the bubble (the reserved actions column). */}
+      <div className="flex w-full items-center justify-end pr-7">
+        <QueuedPromptStatus state={state} lastError={row.lastError} />
       </div>
     </div>
   );

--- a/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
+++ b/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
@@ -106,6 +106,11 @@ export function QueuedPromptStatus({
   lastError?: string;
 }) {
   const failed = state === 'failed';
+  // A plain queued/in-flight bubble says nothing: the dim IS the state, and a
+  // caption under every queued message read as clutter (review feedback).
+  // Held, failed and interrupted still speak — those need words to be
+  // actionable.
+  if (state === 'queued' || state === 'in-flight') return null;
   return (
     <InlineMeta>
       <span
@@ -139,10 +144,12 @@ export function QueuedPromptActions({
   onRetry?: (id: string) => void;
 }) {
   const failed = state === 'failed';
-  const inFlight = state === 'in-flight';
   const interrupted = state === 'interrupted';
+  // In-flight is NOT beyond removal any more: the server cancels a forwarded
+  // prompt the agent has not read (and answers 409 with the reason when a
+  // step already owns it). Only an interrupted message keeps zero controls —
+  // the runtime holds it and the next send runs it.
   const showActions =
-    !inFlight &&
     !interrupted &&
     (Boolean(onRemove) || (failed && !!onRetry) || (state === 'held' && !!onSendNow));
   if (!showActions) return null;
@@ -158,12 +165,27 @@ export function QueuedPromptActions({
           <PaperPlaneRightIcon className="size-4" />
         </Action>
       )}
-      {onRemove && (
-        <Action label="Remove from queue" onClick={() => onRemove(id)} destructive>
-          <XIcon className="size-4" />
-        </Action>
-      )}
+      {onRemove && <RemoveFromQueueButton id={id} onRemove={onRemove} />}
     </div>
+  );
+}
+
+/**
+ * The one way OUT of the queue, in a FIXED spot: beside the bubble, never in
+ * the meta row — the timestamp and copy control appear and resize there, and
+ * an X that jumps around is an X nobody can aim at (review feedback).
+ */
+export function RemoveFromQueueButton({
+  id,
+  onRemove,
+}: {
+  id: string;
+  onRemove: (id: string) => void;
+}) {
+  return (
+    <Action label="Remove from queue" onClick={() => onRemove(id)} destructive>
+      <XIcon className="size-4" />
+    </Action>
   );
 }
 

--- a/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
+++ b/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
@@ -92,9 +92,85 @@ function Action({
 }
 
 /**
- * Status text + the controls a queued prompt has, laid out for a bubble's
- * meta row. A row on the wire has no controls — the server refuses every
- * action for it — and says so.
+ * The one-word status of a queued prompt — "Queued", "Held — stopped", "Not
+ * sent — …". ALWAYS visible: a bubble at 50% opacity with nothing said about
+ * it reads as "something is wrong", and the word is what makes the dim legible
+ * (Claude.ai/ChatGPT both caption a queued message). The controls beside it
+ * stay hover-revealed — see `QueuedPromptActions`.
+ */
+export function QueuedPromptStatus({
+  state,
+  lastError,
+}: {
+  state: QueuedPromptState;
+  lastError?: string;
+}) {
+  const failed = state === 'failed';
+  return (
+    <InlineMeta>
+      <span
+        data-queued-status={state}
+        className={cn('flex items-center gap-1', failed && 'text-destructive')}
+      >
+        {failed && <WarningIcon className="size-3.5" />}
+        {queuedPromptStatusLabel(state, lastError)}
+      </span>
+    </InlineMeta>
+  );
+}
+
+/**
+ * The controls a queued prompt has: remove; send now while the queue is HELD
+ * by a stop; retry on a failed row. Null when the row has none — on the wire
+ * (the server refuses every action for it) or interrupted (the runtime holds
+ * it; a button here only invited a duplicate).
+ */
+export function QueuedPromptActions({
+  id,
+  state,
+  onRemove,
+  onSendNow,
+  onRetry,
+}: {
+  id: string;
+  state: QueuedPromptState;
+  onRemove?: (id: string) => void;
+  onSendNow?: (id: string) => void;
+  onRetry?: (id: string) => void;
+}) {
+  const failed = state === 'failed';
+  const inFlight = state === 'in-flight';
+  const interrupted = state === 'interrupted';
+  const showActions =
+    !inFlight &&
+    !interrupted &&
+    (Boolean(onRemove) || (failed && !!onRetry) || (state === 'held' && !!onSendNow));
+  if (!showActions) return null;
+  return (
+    <div className="flex shrink-0 items-center gap-0.5">
+      {failed && onRetry && (
+        <Action label="Retry" onClick={() => onRetry(id)}>
+          <ArrowClockwiseIcon className="size-4" />
+        </Action>
+      )}
+      {state === 'held' && onSendNow && (
+        <Action label="Send now" onClick={() => onSendNow(id)}>
+          <PaperPlaneRightIcon className="size-4" />
+        </Action>
+      )}
+      {onRemove && (
+        <Action label="Remove" onClick={() => onRemove(id)} destructive>
+          <TrashIcon className="size-4" />
+        </Action>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Status + controls together, for a caller that lays out one row. A row on
+ * the wire has no controls — the server refuses every action for it — and
+ * says so.
  */
 export function QueuedPromptControls({
   id,
@@ -111,45 +187,16 @@ export function QueuedPromptControls({
   onSendNow?: (id: string) => void;
   onRetry?: (id: string) => void;
 }) {
-  const failed = state === 'failed';
-  const inFlight = state === 'in-flight';
-  const interrupted = state === 'interrupted';
-  // An interrupted message has no controls: the runtime already holds it and
-  // the next send runs it — a button here only invited a duplicate.
-  const showActions =
-    !inFlight &&
-    !interrupted &&
-    (Boolean(onRemove) || (failed && !!onRetry) || (state === 'held' && !!onSendNow));
   return (
     <>
-      <InlineMeta>
-        <span
-          data-queued-status={state}
-          className={cn('flex items-center gap-1', failed && 'text-destructive')}
-        >
-          {failed && <WarningIcon className="size-3.5" />}
-          {queuedPromptStatusLabel(state, lastError)}
-        </span>
-      </InlineMeta>
-      {showActions && (
-        <div className="flex shrink-0 items-center gap-0.5">
-          {failed && onRetry && (
-            <Action label="Retry" onClick={() => onRetry(id)}>
-              <ArrowClockwiseIcon className="size-4" />
-            </Action>
-          )}
-          {state === 'held' && onSendNow && (
-            <Action label="Send now" onClick={() => onSendNow(id)}>
-              <PaperPlaneRightIcon className="size-4" />
-            </Action>
-          )}
-          {onRemove && (
-            <Action label="Remove" onClick={() => onRemove(id)} destructive>
-              <TrashIcon className="size-4" />
-            </Action>
-          )}
-        </div>
-      )}
+      <QueuedPromptStatus state={state} lastError={lastError} />
+      <QueuedPromptActions
+        id={id}
+        state={state}
+        onRemove={onRemove}
+        onSendNow={onSendNow}
+        onRetry={onRetry}
+      />
     </>
   );
 }
@@ -206,26 +253,29 @@ function QueuedBubble({
           {row.text}
         </div>
       </div>
-      {/* Same anatomy as the sent bubble's meta row: status + controls,
-          revealed on hover, height held so nothing reflows. A failed row keeps
-          its row visible — a failure the user has to hunt for is a message
-          silently lost. */}
-      <div
-        className={cn(
-          'flex w-full items-center justify-end gap-2 transition-opacity duration-150',
-          failed
-            ? 'opacity-100'
-            : 'opacity-0 group-hover/queued:opacity-100 focus-within:opacity-100',
-        )}
-      >
-        <QueuedPromptControls
-          id={row.id}
-          state={state}
-          lastError={row.lastError}
-          onRemove={onRemove}
-          onSendNow={onSendNow}
-          onRetry={onRetry}
-        />
+      {/* Same anatomy as the sent bubble's meta row: the status is always
+          readable (it is what explains the dim), the controls reveal on hover;
+          height held so nothing reflows. A failed row keeps everything
+          visible — a failure the user has to hunt for is a message silently
+          lost. */}
+      <div className="flex w-full items-center justify-end gap-2">
+        <QueuedPromptStatus state={state} lastError={row.lastError} />
+        <div
+          className={cn(
+            'flex items-center transition-opacity duration-150',
+            failed
+              ? 'opacity-100'
+              : 'opacity-0 group-hover/queued:opacity-100 focus-within:opacity-100',
+          )}
+        >
+          <QueuedPromptActions
+            id={row.id}
+            state={state}
+            onRemove={onRemove}
+            onSendNow={onSendNow}
+            onRetry={onRetry}
+          />
+        </div>
       </div>
     </div>
   );
@@ -248,7 +298,7 @@ export function QueuedPromptBubbles({
     <div
       role="list"
       aria-label={held ? 'Queued prompts, held' : 'Queued prompts'}
-      className={cn('flex flex-col gap-4', className)}
+      className={cn('flex flex-col gap-3', className)}
     >
       {queued.map((row) => (
         <QueuedBubble

--- a/apps/web/src/features/session/turn/user-message.tsx
+++ b/apps/web/src/features/session/turn/user-message.tsx
@@ -828,6 +828,7 @@ export function UserMessageActions({
   onRewind,
   rewindDisabled,
   leading,
+  leadingStatus,
   alwaysVisible = false,
 }: {
   /** Epoch milliseconds, or `null` when the backend never stamped one. */
@@ -846,6 +847,12 @@ export function UserMessageActions({
    * grow a second strip under it.
    */
   leading?: React.ReactNode;
+  /**
+   * Rendered before `leading` and ALWAYS visible — a queued prompt's status
+   * word (`QueuedPromptStatus`). The dim is what marks a bubble as queued;
+   * the word is what makes the dim legible, so it does not wait for a hover.
+   */
+  leadingStatus?: React.ReactNode;
   /** Keep the row visible without hover — a failed send must not be a thing
    *  the user has to hunt for. */
   alwaysVisible?: boolean;
@@ -856,21 +863,25 @@ export function UserMessageActions({
   const hasMeta = timestamp !== null || Boolean(edited);
 
   // Nothing to say and nothing to do — don't leave an empty row behind.
-  if (!hasMeta && !copyText && !leading) return null;
+  if (!hasMeta && !copyText && !leading && !leadingStatus) return null;
 
   return (
     // The fade sits on the ROW, so the timestamp and the buttons reveal
     // together as one object rather than a label with controls growing out of
     // it. `opacity`, never mounting: the row holds its height whether or not
     // the pointer is over the turn, so nothing in the transcript reflows.
-    <div
-      className={cn(
-        'flex w-full items-center justify-end gap-2 transition-opacity duration-150',
-        alwaysVisible
-          ? 'opacity-100'
-          : 'opacity-0 group-hover/turn:opacity-100 focus-within:opacity-100',
-      )}
-    >
+    // The status word (when there is one) sits OUTSIDE the fade: it is the
+    // one thing on this row a user must not have to hover to learn.
+    <div className="flex w-full items-center justify-end gap-2">
+      {leadingStatus}
+      <div
+        className={cn(
+          'flex items-center gap-2 transition-opacity duration-150',
+          alwaysVisible
+            ? 'opacity-100'
+            : 'opacity-0 group-hover/turn:opacity-100 focus-within:opacity-100',
+        )}
+      >
       {leading}
       {/* `InlineMeta` owns the `·` separator and drops absent children, so a
           message with no stamp never renders a leading bullet. Skipped
@@ -901,6 +912,7 @@ export function UserMessageActions({
           <CopyButton code={copyText} size="sm" hintSide="top" />
         </div>
       )}
+      </div>
     </div>
   );
 }
@@ -919,6 +931,7 @@ export function UserMessage({
   onRewind,
   rewindDisabled = false,
   leadingActions,
+  leadingStatus,
   actionsAlwaysVisible = false,
 }: {
   message: MessageWithParts;
@@ -940,6 +953,8 @@ export function UserMessage({
   rewindDisabled?: boolean;
   /** See `UserMessageActions.leading` — a queued prompt's status + controls. */
   leadingActions?: React.ReactNode;
+  /** See `UserMessageActions.leadingStatus`. */
+  leadingStatus?: React.ReactNode;
   /** See `UserMessageActions.alwaysVisible`. */
   actionsAlwaysVisible?: boolean;
 }) {
@@ -1119,6 +1134,7 @@ export function UserMessage({
       onRewind={onRewind}
       rewindDisabled={rewindDisabled}
       leading={leadingActions}
+      leadingStatus={leadingStatus}
       alwaysVisible={actionsAlwaysVisible}
     />
   );

--- a/apps/web/src/hooks/use-auto-scroll.ts
+++ b/apps/web/src/hooks/use-auto-scroll.ts
@@ -108,6 +108,13 @@ export function useAutoScroll({ hasContent = false }: UseAutoScrollOptions = {})
 
   /** THE RULE's one bit. Starts true: a session opens at its end. */
   const followRef = useRef(true);
+  /** The anchor turn `sizeRoom` last measured against, so a CHANGE of anchor
+   *  (the agent reached a queued prompt; a send opened a turn) is known. */
+  const lastAnchorIdRef = useRef<string | null>(null);
+  /** While a smooth glide to the end is in flight, instant settles stand
+   *  down so they do not cut it short; the glide is followed by one instant
+   *  settle for whatever streamed in the meantime. */
+  const smoothUntilRef = useRef(0);
   /** The one bit, with its reason, mirrored onto the scroll element as
    *  `data-follow` / `data-follow-why` — readable by e2e assertions and by a
    *  human in devtools, so "why did it stop following?" is never a guess. */
@@ -129,11 +136,11 @@ export function useAutoScroll({ hasContent = false }: UseAutoScrollOptions = {})
    * take some of that room; the moment the agent reaches one (its pending
    * mark drops) it becomes the anchor and the viewport shifts to it.
    */
-  const sizeRoom = useCallback((): number => {
+  const sizeRoom = useCallback((): { room: number; anchorChanged: boolean } => {
     const el = scrollRef.current;
     const content = contentRef.current;
     const spacer = spacerElRef.current;
-    if (!el || !content || !spacer) return 0;
+    if (!el || !content || !spacer) return { room: 0, anchorChanged: false };
     const turns = content.querySelectorAll<HTMLElement>('[data-turn-id]');
     let anchor: HTMLElement | null = null;
     for (let i = turns.length - 1; i >= 0; i--) {
@@ -152,18 +159,41 @@ export function useAutoScroll({ hasContent = false }: UseAutoScrollOptions = {})
       : null;
     const h = roomUnderNewestTurn(el.clientHeight, span);
     if (spacer.style.height !== `${h}px`) spacer.style.height = `${h}px`;
-    return h;
+    const anchorId = anchor?.getAttribute('data-turn-id') ?? null;
+    const anchorChanged = lastAnchorIdRef.current !== null && anchorId !== lastAnchorIdRef.current;
+    lastAnchorIdRef.current = anchorId;
+    return { room: h, anchorChanged };
   }, []);
 
   /** FACT 2 + THE RULE: after any layout change, a following viewport is at the end. */
+  const SMOOTH_GLIDE_MS = 420;
   const settle = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
-    sizeRoom();
+    const { anchorChanged } = sizeRoom();
     if (!followRef.current) return;
     const end = el.scrollHeight - el.clientHeight;
-    if (Math.abs(el.scrollTop - end) > 0.5) el.scrollTop = end;
+    const now = performance.now();
+    if (now < smoothUntilRef.current) return; // a glide is in flight — let it land
+    const distance = Math.abs(el.scrollTop - end);
+    // A NEW ANCHOR is a jump of a whole turn: the viewport moves from the
+    // answer that just ended to the prompt the agent reached. Glide it, once;
+    // a cut is what read as "the transcript got wiped" in review. Every other
+    // settle (text streaming in under the anchor) stays instant — that is the
+    // follow, and a glide there would lag the text.
+    if (anchorChanged && distance > 80) {
+      smoothUntilRef.current = now + SMOOTH_GLIDE_MS;
+      el.scrollTo({ top: end, behavior: 'smooth' });
+      window.setTimeout(() => {
+        smoothUntilRef.current = 0;
+        settleRef.current?.();
+      }, SMOOTH_GLIDE_MS + 40);
+      return;
+    }
+    if (distance > 0.5) el.scrollTop = end;
   }, [sizeRoom]);
+  const settleRef = useRef<(() => void) | null>(null);
+  settleRef.current = settle;
 
   const goToEnd = useCallback(
     (behavior: ScrollBehavior) => {
@@ -173,8 +203,14 @@ export function useAutoScroll({ hasContent = false }: UseAutoScrollOptions = {})
       setShowScrollButton(false);
       sizeRoom();
       const end = el.scrollHeight - el.clientHeight;
-      if (behavior === 'smooth') el.scrollTo({ top: end, behavior: 'smooth' });
-      else el.scrollTop = end;
+      if (behavior === 'smooth') {
+        smoothUntilRef.current = performance.now() + SMOOTH_GLIDE_MS;
+        el.scrollTo({ top: end, behavior: 'smooth' });
+        window.setTimeout(() => {
+          smoothUntilRef.current = 0;
+          settleRef.current?.();
+        }, SMOOTH_GLIDE_MS + 40);
+      } else el.scrollTop = end;
     },
     [sizeRoom, setFollow],
   );

--- a/packages/sdk/src/browser/session-sync/session-transcript-cache.test.ts
+++ b/packages/sdk/src/browser/session-sync/session-transcript-cache.test.ts
@@ -36,6 +36,24 @@ describe('selectSessionTranscript', () => {
     expect(selectSessionTranscript(state, 's1')?.parts.m1).toEqual([]);
   });
 
+  test('leaves out messages the caller marks as not worth persisting (optimistic stubs)', () => {
+    // A stub persisted to disk came back after a reload as a PLAIN message
+    // the runtime had never heard of — a phantom bubble beside the real one,
+    // for ever (queue-lab `reload_midturn`, 2026-08-19).
+    const state = {
+      messages: { s1: [msg('m1'), msg('opt-1'), msg('m2', 'assistant')] },
+      parts: { m1: [part('p1', 'm1')], 'opt-1': [part('p9', 'opt-1')], m2: [] },
+    };
+    const transcript = selectSessionTranscript(state, 's1', (id) => id === 'opt-1');
+    expect(transcript?.messages.map((m) => m.id)).toEqual(['m1', 'm2']);
+    expect(Object.keys(transcript?.parts ?? {})).toEqual(['m1', 'm2']);
+  });
+
+  test('a session whose only messages are excluded is not worth caching', () => {
+    const state = { messages: { s1: [msg('opt-1')] }, parts: {} };
+    expect(selectSessionTranscript(state, 's1', () => true)).toBeNull();
+  });
+
   test('returns null when the session was never in the store', () => {
     expect(selectSessionTranscript({ messages: {}, parts: {} }, 's1')).toBeNull();
   });

--- a/packages/sdk/src/browser/session-sync/session-transcript-cache.ts
+++ b/packages/sdk/src/browser/session-sync/session-transcript-cache.ts
@@ -36,9 +36,18 @@ interface TranscriptStoreSlice {
 export function selectSessionTranscript(
   state: TranscriptStoreSlice,
   sessionId: string,
+  /**
+   * Messages to leave OUT of the entry — this tab's optimistic stubs. The
+   * cache mirrors the runtime's transcript, and a stub is not in it: persisted,
+   * it came back after a reload as a plain message the runtime had never
+   * heard of, beside the real one, for ever.
+   */
+  exclude?: (messageId: string) => boolean,
 ): CachedTranscript | null {
-  const messages = state.messages[sessionId];
-  if (!messages || messages.length === 0) return null;
+  const all = state.messages[sessionId];
+  if (!all || all.length === 0) return null;
+  const messages = exclude ? all.filter((message) => !message?.id || !exclude(message.id)) : all;
+  if (messages.length === 0) return null;
   const parts: Record<string, Part[]> = {};
   for (const message of messages) {
     if (!message?.id) continue;
@@ -46,7 +55,6 @@ export function selectSessionTranscript(
   }
   return { messages, parts };
 }
-
 /** Reshape a cached transcript into the `{ info, parts }` rows `hydrate` takes. */
 export function toHydrateEntries(
   transcript: CachedTranscript,
@@ -107,8 +115,9 @@ export function writeCachedTranscript(
   state: TranscriptStoreSlice,
   sessionId: string,
   kortixSessionScope?: string,
+  exclude?: (messageId: string) => boolean,
 ): Promise<void> {
-  const transcript = selectSessionTranscript(state, sessionId);
+  const transcript = selectSessionTranscript(state, sessionId, exclude);
   if (!transcript) return Promise.resolve();
   return saveSessionToIDB(sessionId, transcript.messages, transcript.parts, kortixSessionScope);
 }

--- a/packages/sdk/src/browser/stores/sync-store.test.ts
+++ b/packages/sdk/src/browser/stores/sync-store.test.ts
@@ -2696,3 +2696,105 @@ describe("useSyncStore — an INBOX-BACKED optimistic message survives the idle 
 		expect(useSyncStore.getState().messages["ses_1"]?.map((m) => m.id)).toEqual(["msg_reminted"]);
 	});
 });
+
+describe("useSyncStore — cache-sourced messages are provisional until the runtime confirms them", () => {
+	test("a cache-sourced user message the runtime's own tail does not contain is dropped (a phantom)", () => {
+		const store = useSyncStore.getState();
+		// Disk repaint: two real messages and a phantom (an optimistic stub that
+		// was mirrored to disk before its echo) — all plain messages by now.
+		store.hydrate(
+			"ses_1",
+			[
+				{ info: userMessage("msg_a"), parts: [] },
+				{ info: userMessage("msg_phantom"), parts: [] },
+				{ info: userMessage("msg_c"), parts: [] },
+			],
+			{ source: "cache" },
+		);
+		expect(useSyncStore.getState().messages.ses_1.map((m) => m.id)).toEqual([
+			"msg_a",
+			"msg_c",
+			"msg_phantom",
+		]);
+		// The runtime's tail covers that range and knows nothing of the phantom.
+		store.hydrate("ses_1", [
+			{ info: userMessage("msg_a"), parts: [] },
+			{ info: userMessage("msg_c"), parts: [] },
+		]);
+		expect(useSyncStore.getState().messages.ses_1.map((m) => m.id)).toEqual(["msg_a", "msg_c"]);
+	});
+
+	test("a cache-sourced message OLDER than the runtime's tail is kept (history the tail did not reach)", () => {
+		const store = useSyncStore.getState();
+		store.hydrate(
+			"ses_1",
+			[
+				{ info: userMessage("msg_a"), parts: [] },
+				{ info: userMessage("msg_b"), parts: [] },
+			],
+			{ source: "cache" },
+		);
+		// A bounded tail that starts at msg_b: msg_a is simply older than it.
+		store.hydrate("ses_1", [
+			{ info: userMessage("msg_b"), parts: [] },
+			{ info: userMessage("msg_c"), parts: [] },
+		]);
+		expect(useSyncStore.getState().messages.ses_1.map((m) => m.id)).toEqual([
+			"msg_a",
+			"msg_b",
+			"msg_c",
+		]);
+	});
+
+	test("an optimistic message is reported as such, and a plain one is not", () => {
+		const store = useSyncStore.getState();
+		store.optimisticAdd("ses_1", userMessage("msg_opt"), []);
+		store.upsertMessage("ses_1", userMessage("msg_real"));
+		expect(store.isOptimisticMessage("ses_1", "msg_opt")).toBe(true);
+		expect(store.isOptimisticMessage("ses_1", "msg_real")).toBe(false);
+	});
+});
+
+describe("useSyncStore — a removed user message the control plane still owns keeps its bubble", () => {
+	test("message.removed for an inbox-backed message re-marks it optimistic instead of dropping it", () => {
+		// The drain deletes a stranded copy of a forwarded prompt and re-places
+		// it under a new id; the box emits message.removed for the old copy.
+		// The user's bubble must not blink out between the two.
+		const store = useSyncStore.getState();
+		store.optimisticAdd("ses_1", userMessage("msg_c"), [textPart("prt_1", "msg_c", "hi")]);
+		store.markOptimisticDispatched("ses_1", "msg_c");
+		store.markOptimisticInboxBacked("ses_1", "msg_c");
+		// The echo confirms it in place (same id).
+		store.hydrate("ses_1", [{ info: userMessage("msg_c"), parts: [textPart("prt_1", "msg_c", "hi")] }]);
+		expect(store.isOptimisticMessage("ses_1", "msg_c")).toBe(false);
+
+		store.applyEvent({
+			type: "message.removed",
+			properties: { sessionID: "ses_1", messageID: "msg_c" },
+		} as never);
+		const msgs = useSyncStore.getState().messages.ses_1;
+		expect(msgs.map((m) => m.id)).toEqual(["msg_c"]);
+		expect(useSyncStore.getState().parts.msg_c?.[0]?.id).toBe("prt_1");
+		expect(useSyncStore.getState().isOptimisticMessage("ses_1", "msg_c")).toBe(true);
+
+		// The re-placed copy arrives under a new id: it supersedes the bubble,
+		// and the alias chain keeps pointing at the id the host keyed on.
+		store.applyEvent({
+			type: "message.updated",
+			properties: { info: userMessage("msg_c2") },
+		} as never);
+		expect(useSyncStore.getState().messages.ses_1.map((m) => m.id)).toEqual(["msg_c2"]);
+		expect(useSyncStore.getState().optimisticOriginOf("ses_1", "msg_c2")).toBe("msg_c");
+		expect(useSyncStore.getState().parts.msg_c2?.[0]?.id).toBe("prt_1");
+	});
+
+	test("message.removed for a message nobody owns still removes it", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_x"));
+		store.applyEvent({
+			type: "message.removed",
+			properties: { sessionID: "ses_1", messageID: "msg_x" },
+		} as never);
+		expect(useSyncStore.getState().messages.ses_1).toEqual([]);
+	});
+});

--- a/packages/sdk/src/browser/stores/sync-store.ts
+++ b/packages/sdk/src/browser/stores/sync-store.ts
@@ -272,6 +272,18 @@ interface SyncState {
 	 *  message — lets the SSE reconciler avoid idling+clearing a brand-new session
 	 *  whose first prompt the server hasn't registered yet. */
 	hasOptimisticMessages: (sessionID: string) => boolean;
+	/** Is this message still this tab's optimistic stub (not yet confirmed
+	 *  by the runtime)? Hosts use it to keep stubs out of anything that must
+	 *  only hold what the runtime holds — the disk transcript cache. */
+	isOptimisticMessage: (sessionID: string, messageID: string) => boolean;
+	/**
+	 * A `message.removed` for a user message the control plane still owns
+	 * (an inbox-backed send the runtime confirmed) is a RE-PLACEMENT in
+	 * progress — the server took the copy out to insert it again under a new
+	 * id. Keeps the bubble as an optimistic stub for the next echo to
+	 * supersede. Returns true when the removal was absorbed this way.
+	 */
+	reclaimRemovedMessage: (sessionID: string, messageID: string) => boolean;
 	clearSession: (sessionID: string) => void;
 	/**
 	 * Take a hold on `sessionID`'s transcript for one mounted consumer, and get
@@ -333,6 +345,13 @@ interface SyncState {
 	hydrate: (
 		sessionID: string,
 		msgs: Array<{ info: Message; parts: Part[] }>,
+		/**
+		 * Where this snapshot came from. `cache` (the disk transcript cache)
+		 * paints messages PROVISIONALLY: the next runtime hydrate whose tail
+		 * covers their position drops any it does not contain. Default:
+		 * the runtime.
+		 */
+		opts?: { source?: "cache" | "runtime" },
 	) => void;
 	reset: () => void;
 
@@ -371,15 +390,36 @@ const inboxBackedOptimisticIds = new Map<string, Set<string>>();
 // per session; released with the session.
 const optimisticEchoes = new Map<string, Map<string, string>>();
 const optimisticOrigins = new Map<string, Map<string, string>>();
+// Message ids the CONTROL PLANE still owns after the runtime confirmed them:
+// the echo (same id or re-minted) of an inbox-backed optimistic send. The
+// server can take such a message back out of the runtime and place it again
+// under a new id — a stranded mid-turn prompt being re-placed, a Stop taking
+// an unread prompt back into the queue. A `message.removed` for one of these
+// is not "the message is gone", it is "the message is between two ids": the
+// bubble is re-marked optimistic (dispatched, inbox-backed) and the next echo
+// supersedes it, instead of the bubble blinking out and a new one appearing.
+// Released with the session.
+const controlPlaneOwnedIds = new Map<string, Set<string>>();
+// Message ids that came from the DISK CACHE and have not yet been seen in a
+// runtime read. The cache is a first-paint accelerator; a message it holds
+// that the runtime's own tail — covering that message's position — does not,
+// never existed there (an optimistic stub mirrored to disk before its echo)
+// and must not outlive the first authoritative read.
+const cacheSourcedIds = new Map<string, Set<string>>();
 
 function recordOptimisticEcho(sessionID: string, optimisticID: string, echoID: string): void {
 	if (optimisticID === echoID) return;
+	// Chain through an earlier swap: a message that itself superseded an
+	// optimistic id keeps pointing the host at that ORIGINAL id, so a second
+	// re-placement does not change the identity the host keyed its bubble on.
+	const origin = optimisticOrigins.get(sessionID)?.get(optimisticID) ?? optimisticID;
 	let fwd = optimisticEchoes.get(sessionID);
 	if (!fwd) optimisticEchoes.set(sessionID, (fwd = new Map()));
-	fwd.set(optimisticID, echoID);
+	fwd.set(origin, echoID);
+	if (origin !== optimisticID) fwd.set(optimisticID, echoID);
 	let rev = optimisticOrigins.get(sessionID);
 	if (!rev) optimisticOrigins.set(sessionID, (rev = new Map()));
-	rev.set(echoID, optimisticID);
+	rev.set(echoID, origin);
 }
 
 /** Forget every optimistic mark for one id — confirmed, superseded, or removed. */
@@ -387,6 +427,15 @@ function releaseOptimisticId(sessionID: string, id: string): void {
 	untrackId(optimisticIds, sessionID, id);
 	untrackId(dispatchedOptimisticIds, sessionID, id);
 	untrackId(inboxBackedOptimisticIds, sessionID, id);
+}
+
+/** The runtime confirmed an inbox-backed optimistic send under `echoID`
+ *  (same id, or re-minted): the control plane still owns that message. */
+function releaseConfirmedOptimisticId(sessionID: string, optimisticID: string, echoID: string): void {
+	if (hasTrackedId(inboxBackedOptimisticIds, sessionID, optimisticID)) {
+		trackId(controlPlaneOwnedIds, sessionID, echoID);
+	}
+	releaseOptimisticId(sessionID, optimisticID);
 }
 
 function trackId(store: Map<string, Set<string>>, sessionID: string, id: string): void {
@@ -418,6 +467,8 @@ function forgetSessionIds(sessionID: string): void {
 	inboxBackedOptimisticIds.delete(sessionID);
 	optimisticEchoes.delete(sessionID);
 	optimisticOrigins.delete(sessionID);
+	controlPlaneOwnedIds.delete(sessionID);
+	cacheSourcedIds.delete(sessionID);
 	// The joined rows hold the very message and part arrays this session's
 	// data is being dropped from. Left behind, they keep the transcript
 	// reachable and the drop achieves nothing.
@@ -1120,6 +1171,25 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 
 	optimisticOriginOf: (sessionID, echoID) => optimisticOrigins.get(sessionID)?.get(echoID),
 
+	isOptimisticMessage: (sessionID, messageID) => isOptimistic(sessionID, messageID),
+
+	reclaimRemovedMessage: (sessionID, messageID) => {
+		// See `controlPlaneOwnedIds`: a removal of a message the control plane
+		// still owns is a re-placement in progress, not a deletion. Keep the
+		// message and its parts; put the optimistic marks back (dispatched, so
+		// the ordinal echo match may claim it; inbox-backed, so the idle sweep
+		// leaves it) and let the next echo supersede it.
+		if (!hasTrackedId(controlPlaneOwnedIds, sessionID, messageID)) return false;
+		const list = get().messages[sessionID];
+		const message = list?.find((m) => m.id === messageID);
+		if (!message || message.role !== "user") return false;
+		untrackId(controlPlaneOwnedIds, sessionID, messageID);
+		trackId(optimisticIds, sessionID, messageID);
+		trackId(dispatchedOptimisticIds, sessionID, messageID);
+		trackId(inboxBackedOptimisticIds, sessionID, messageID);
+		return true;
+	},
+
 	optimisticRemove: (sessionID, messageID) => {
 		// Only an OPTIMISTIC message can be removed this way. One the runtime has
 		// confirmed (same-id echo, or the store never tracked it) is the
@@ -1270,7 +1340,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 		return result;
 	},
 
-	hydrate: (sessionID, msgs) =>
+	hydrate: (sessionID, msgs, opts) =>
 		set((s) => {
 			// An authoritative load — the disk repaint itself, or a reconcile —
 			// re-establishes the session, so its entry is no longer a fragment.
@@ -1281,6 +1351,31 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 				.filter((m) => !!m?.info?.id)
 				.map((m) => m.info)
 				.sort((a, b) => cmp(a.id, b.id));
+			const fromCache = opts?.source === "cache";
+			if (fromCache) {
+				for (const m of incoming) trackId(cacheSourcedIds, sessionID, m.id);
+			}
+			// A RUNTIME read settles the cache's provisional messages: the ones
+			// it contains are real; the ones it lacks but whose position it
+			// COVERS (at or above the oldest message it returned) never existed
+			// there and are dropped. Older ones are history the bounded tail did
+			// not reach — kept, still provisional.
+			let droppedPhantoms: Set<string> | null = null;
+			const provisional = fromCache ? undefined : cacheSourcedIds.get(sessionID);
+			if (provisional && provisional.size > 0 && incoming.length > 0) {
+				const oldestIncoming = incoming[0].id;
+				const incomingIds = new Set(incoming.map((m) => m.id));
+				for (const id of [...provisional]) {
+					if (incomingIds.has(id)) {
+						untrackId(cacheSourcedIds, sessionID, id);
+						continue;
+					}
+					if (cmp(id, oldestIncoming) >= 0 && !isOptimistic(sessionID, id)) {
+						untrackId(cacheSourcedIds, sessionID, id);
+						(droppedPhantoms ??= new Set()).add(id);
+					}
+				}
+			}
 
 			// T16 — reconcile a `session.error` stub assistant message
 			// (see `stubAssistantIds` and the `session.error` handler above). The
@@ -1302,7 +1397,10 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			// Merge incoming messages with existing ones — never delete messages
 			// that exist in the sync store but are missing from the fetch (they may
 			// be from a newer turn that the server hasn't persisted yet).
-			const existing = s.messages[sessionID] ?? [];
+			const existingAll = s.messages[sessionID] ?? [];
+			const existing = droppedPhantoms
+				? existingAll.filter((m) => !droppedPhantoms!.has(m.id))
+				: existingAll;
 			const merged: typeof existing = [];
 			const seen = new Set<string>();
 
@@ -1328,7 +1426,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			// bridge its optimistic parts until real ones land.
 			for (const m of incoming) {
 				if (m.role !== "user" || !isOptimistic(sessionID, m.id)) continue;
-				releaseOptimisticId(sessionID, m.id);
+				releaseConfirmedOptimisticId(sessionID, m.id, m.id);
 				const optimisticParts = s.parts[m.id];
 				const entry = msgs.find((x) => x.info.id === m.id);
 				if ((entry?.parts?.length ?? 0) === 0 && optimisticParts?.length) {
@@ -1429,9 +1527,13 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			// Clean up superseded optimistic IDs, remembering which runtime id
 			// each one became.
 			for (const id of supersededOptimistic) {
-				releaseOptimisticId(sessionID, id);
 				const echoId = supersededBy.get(id);
-				if (echoId) recordOptimisticEcho(sessionID, id, echoId);
+				if (echoId) {
+					releaseConfirmedOptimisticId(sessionID, id, echoId);
+					recordOptimisticEcho(sessionID, id, echoId);
+				} else {
+					releaseOptimisticId(sessionID, id);
+				}
 			}
 			// Append surviving optimistic messages at the end
 			for (const m of deferredOptimistic) {
@@ -1444,6 +1546,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			// Otherwise, incoming parts win (server is authoritative), but keep
 			// any extra parts from SSE that aren't in the fetch response.
 			const newParts = { ...s.parts };
+			if (droppedPhantoms) for (const id of droppedPhantoms) delete newParts[id];
 			// When superseding an optimistic user message, bridge its parts to
 			// the real user message ID if the server hasn't sent parts yet.
 			// Mirrors the message.updated SSE handler (see above) — without
@@ -1681,7 +1784,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 							// Clean up optimistic tracking, remembering the runtime id
 							// each superseded message became.
 							for (const id of optIds) {
-								releaseOptimisticId(info.sessionID, id);
+								releaseConfirmedOptimisticId(info.sessionID, id, info.id);
 								recordOptimisticEcho(info.sessionID, id, info.id);
 							}
 							// Atomic: remove optimistic + insert real in one set()
@@ -1730,6 +1833,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 					messageID: string;
 				};
 				if (!props.sessionID || !props.messageID) return;
+				if (store.reclaimRemovedMessage(props.sessionID, props.messageID)) return;
 				store.removeMessage(props.sessionID, props.messageID);
 				return;
 			}

--- a/packages/sdk/src/browser/stores/sync-store.ts
+++ b/packages/sdk/src/browser/stores/sync-store.ts
@@ -268,6 +268,23 @@ interface SyncState {
 	optimisticEchoOf: (sessionID: string, optimisticID: string) => string | undefined;
 	/** The inverse of {@link SyncState.optimisticEchoOf}. */
 	optimisticOriginOf: (sessionID: string, echoID: string) => string | undefined;
+	/**
+	 * Announce, AHEAD of the echo, which runtime id an optimistic message will
+	 * come back under. The control plane re-mints a queued prompt's wire id at
+	 * delivery and lists BOTH ids on the row — so the pairing is known before
+	 * any `message.updated` arrives. With it recorded, the echo supersedes ITS
+	 * OWN bubble; without it, an echo whose parts had not landed yet fell back
+	 * to superseding the OLDEST in-flight optimistic message (measured: a
+	 * burst's first bubble vanished, replaced by the second's echo).
+	 */
+	registerOptimisticEcho: (sessionID: string, optimisticID: string, echoID: string) => void;
+	/**
+	 * The user CANCELLED this message (`DELETE .../prompts`): drop its bubble
+	 * and every claim on it — the reclaim that normally protects a
+	 * control-plane-owned message from `message.removed` must not resurrect
+	 * something the user explicitly removed.
+	 */
+	forgetControlPlaneMessage: (sessionID: string, messageID: string) => void;
 	/** True when the session's message list still holds an unconfirmed optimistic
 	 *  message — lets the SSE reconciler avoid idling+clearing a brand-new session
 	 *  whose first prompt the server hasn't registered yet. */
@@ -400,6 +417,12 @@ const optimisticOrigins = new Map<string, Map<string, string>>();
 // supersedes it, instead of the bubble blinking out and a new one appearing.
 // Released with the session.
 const controlPlaneOwnedIds = new Map<string, Set<string>>();
+// Message ids the user explicitly CANCELLED (`DELETE .../prompts`). The
+// runtime may keep a part-less husk of the message (a busy loop refuses the
+// whole-message delete; the parts are emptied instead), and every later
+// transcript read would resurrect it as an empty bubble. A tombstoned id is
+// dropped from incoming reads and events. Released with the session.
+const cancelledMessageIds = new Map<string, Set<string>>();
 // Message ids that came from the DISK CACHE and have not yet been seen in a
 // runtime read. The cache is a first-paint accelerator; a message it holds
 // that the runtime's own tail — covering that message's position — does not,
@@ -469,6 +492,7 @@ function forgetSessionIds(sessionID: string): void {
 	optimisticOrigins.delete(sessionID);
 	controlPlaneOwnedIds.delete(sessionID);
 	cacheSourcedIds.delete(sessionID);
+	cancelledMessageIds.delete(sessionID);
 	// The joined rows hold the very message and part arrays this session's
 	// data is being dropped from. Left behind, they keep the transcript
 	// reachable and the drop achieves nothing.
@@ -1173,6 +1197,19 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 
 	isOptimisticMessage: (sessionID, messageID) => isOptimistic(sessionID, messageID),
 
+	forgetControlPlaneMessage: (sessionID, messageID) => {
+		untrackId(controlPlaneOwnedIds, sessionID, messageID);
+		releaseOptimisticId(sessionID, messageID);
+		trackId(cancelledMessageIds, sessionID, messageID);
+		get().removeMessage(sessionID, messageID);
+	},
+
+	registerOptimisticEcho: (sessionID, optimisticID, echoID) => {
+		if (!isOptimistic(sessionID, optimisticID)) return;
+		if (optimisticID === echoID) return;
+		recordOptimisticEcho(sessionID, optimisticID, echoID);
+	},
+
 	reclaimRemovedMessage: (sessionID, messageID) => {
 		// See `controlPlaneOwnedIds`: a removal of a message the control plane
 		// still owns is a re-placement in progress, not a deletion. Keep the
@@ -1347,8 +1384,9 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			evictedSessions.delete(sessionID);
 			const cmp = (a: string, b: string) =>
 				a < b ? -1 : a > b ? 1 : 0;
+			const tombstones = cancelledMessageIds.get(sessionID);
 			const incoming = msgs
-				.filter((m) => !!m?.info?.id)
+				.filter((m) => !!m?.info?.id && !tombstones?.has(m.info.id))
 				.map((m) => m.info)
 				.sort((a, b) => cmp(a.id, b.id));
 			const fromCache = opts?.source === "cache";
@@ -1509,12 +1547,28 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			// duplicate of anything the server holds, so it is never eligible.
 			// That restriction is what keeps a message sent from another tab from
 			// consuming this tab's in-flight bubble.
-			const claimable = candidateEchoes.filter((m) => unclaimedEchoes.has(m.id));
+			const claimed = new Set<string>();
+			for (const m of unmatchedOptimisticUsers) {
+				// Alias first: the inbox row announced this message's echo id.
+				const alias = optimisticEchoes.get(sessionID)?.get(m.id);
+				if (alias && unclaimedEchoes.has(alias) && !claimed.has(alias)) {
+					claimed.add(alias);
+					supersededOptimistic.push(m.id);
+					supersededBy.set(m.id, alias);
+				}
+			}
+			const claimable = candidateEchoes.filter(
+				(m) => unclaimedEchoes.has(m.id) && !claimed.has(m.id),
+			);
 			let next = 0;
 			for (const m of unmatchedOptimisticUsers) {
-				const echo = isDispatched(sessionID, m.id)
-					? claimable[next]
-					: undefined;
+				if (supersededBy.has(m.id)) continue;
+				const echo =
+					isDispatched(sessionID, m.id) &&
+					// Known-different echo → never consume someone else's.
+					!optimisticEchoes.get(sessionID)?.get(m.id)
+						? claimable[next]
+						: undefined;
 				if (echo) {
 					next += 1;
 					supersededOptimistic.push(m.id);
@@ -1709,6 +1763,8 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			case "message.updated": {
 				const info = (event.properties as { info: Message }).info;
 				if (!info?.sessionID) return;
+				// The user cancelled this message; the runtime's husk stays dead.
+				if (cancelledMessageIds.get(info.sessionID)?.has(info.id)) return;
 					// When a real user message arrives from the server, swap out the
 				// optimistic message(s) in a SINGLE atomic set() call.
 				// This prevents the intermediate render where the user bubble
@@ -1777,8 +1833,28 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 						// matching: at `message.updated` time the confirmed message
 						// usually has no parts in the store yet (they arrive separately
 						// via `message.part.updated`).
+						// A pre-registered alias (`registerOptimisticEcho`) is an identity
+						// match: the row named this echo id before it arrived.
+						const byAlias = optimisticUsers.find(
+							(m) => optimisticEchoes.get(info.sessionID)?.get(m.id) === info.id,
+						);
+						// The ordinal guess is only safe when there is exactly ONE
+						// in-flight send it could be. With a burst in flight, a
+						// part-less echo that matches neither a part id nor a
+						// registered alias WAITS: the hydrate that follows carries
+						// the parts (identity match), and consuming the oldest
+						// bubble here handed one message's echo another message's
+						// text (measured: the first bubble of a burst vanished).
+						const eligible = optimisticUsers.filter(
+							(m) =>
+								isDispatched(info.sessionID, m.id) &&
+								// An optimistic message whose OWN echo is known to be a
+								// DIFFERENT id must not be consumed by someone else's.
+								!optimisticEchoes.get(info.sessionID)?.get(m.id),
+						);
 						const matched =
-							byPartId ?? optimisticUsers.find((m) => isDispatched(info.sessionID, m.id));
+							byPartId ?? byAlias ?? (eligible.length === 1 ? eligible[0] : undefined);
+						if (!matched && eligible.length > 1) return;
 						const optIds = matched ? [matched.id] : [];
 						if (optIds.length > 0) {
 							// Clean up optimistic tracking, remembering the runtime id

--- a/packages/sdk/src/core/rest/projects-client/sessions.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.ts
@@ -637,6 +637,8 @@ export interface SessionPrompt {
   reason: string | null;
   /** Flattened text preview, capped server-side. */
   text: string;
+  /** The sender tab's clock at Enter, when the producer supplied it. */
+  client_sent_at_ms?: number | null;
   attempts: number;
   last_error: string | null;
   created_at: string;
@@ -672,6 +674,13 @@ export interface CreateSessionPromptInput {
    * the delivery path of every message.
    */
   remintOnDelivery?: boolean;
+  /**
+   * The tab's own clock at the moment the user pressed Enter. The server
+   * preserves SEND order with it when several prompts race in over different
+   * surfaces (the boot shell and the chat both send during the crossfade, and
+   * their POSTs finish in either order). Milliseconds since epoch.
+   */
+  clientSentAtMs?: number;
 }
 
 /** Put one prompt in the session's server-side inbox (`POST .../prompts`).
@@ -690,6 +699,9 @@ export async function createSessionPrompt(
         parts: input.parts,
         ...(input.overrides ? { overrides: input.overrides } : {}),
         ...(input.remintOnDelivery ? { remint_on_delivery: true } : {}),
+        ...(typeof input.clientSentAtMs === 'number'
+          ? { client_sent_at_ms: Math.trunc(input.clientSentAtMs) }
+          : {}),
       },
     ),
   );

--- a/packages/sdk/src/core/rest/projects-client/sessions.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.ts
@@ -732,13 +732,18 @@ export interface RemovedSessionPrompt {
   prompt_id: string;
   client_message_id: string;
   message_id: string;
+  /** Every wire id this prompt ever travelled under — for clearing the
+   *  transcript husk a cancel leaves at the runtime. */
+  removed_message_ids?: string[];
   parts: SessionPromptPart[];
   overrides: SessionPromptOverrides | null;
 }
 
 /**
- * Drop a prompt that has not gone out yet. A prompt already on the wire cannot
- * be cancelled and the server answers 409.
+ * Drop a prompt — queued, or already on the wire but not yet read by a model
+ * step (the server takes the runtime's copy back out; only "already being
+ * answered" refuses with 409). `promptId` may be the row id or, once the row
+ * has left the list, the message's own `msg_…` wire id.
  *
  * Returns the removed prompt, because the row is HARD-deleted: re-POSTing this
  * result with its original `client_message_id` is the only lossless undo.

--- a/packages/sdk/src/core/rest/projects-client/sessions.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.ts
@@ -619,8 +619,15 @@ export interface SessionPrompt {
   /** The host's own stable submission name — the same value re-POSTing is a
    *  no-op on, and the key an optimistic row is matched by. */
   client_message_id: string;
-  /** The OpenCode wire id this prompt will be delivered under. */
+  /** The OpenCode wire id this prompt will be delivered under. Moves to the
+   *  server's re-minted id the moment the drain places the prompt — BEFORE
+   *  the runtime echoes it. */
   message_id: string;
+  /** The wire id the HOST painted its bubble under (the one it minted and
+   *  POSTed). Together with `message_id` these are every id this prompt has
+   *  ever had; a host hides the row when the transcript shows EITHER. Absent
+   *  from servers older than this field. */
+  wire_message_id?: string;
   state: SessionPromptState;
   /** Why the prompt is `waiting`: `older_prompt_pending` (its own queue is
    *  ahead of it) or `held` (the user pressed Stop — only an explicit send or

--- a/packages/sdk/src/core/turns/grouping.ts
+++ b/packages/sdk/src/core/turns/grouping.ts
@@ -26,23 +26,38 @@ interface TextPartLike extends PartLike {
 // ============================================================================
 
 /**
- * Display order: `time.created` first, wire id as the tiebreak.
+ * Display order: WIRE ID first for two well-formed wire ids, `time.created`
+ * otherwise, untimed messages (optimistic stubs) last.
  *
- * The sync store keeps messages sorted by ID (its binary-search invariant),
- * and the id is CLIENT-minted for user messages — a wrong one used to teleport
- * a bubble to the top of the thread. OpenCode stamps `time.created` at
- * persistence, from the box's clock, so a message ordered by it lands where it
- * happened whatever id it travelled under; a foreign or backdated id degrades
- * to slightly-odd placement at worst. A message with no timestamp (an
- * optimistic stub) sorts as newest — it is the latest thing the user did — and
- * two untimed messages keep their INPUT order, so a host that feeds unstamped
- * messages sees exactly the sequential behaviour it always had. Equal stamps
- * keep id order. A weak order (stable sort), never a partial one.
+ * The wire id is the message's POSITION: OpenCode's own loop resolves "is
+ * this answered?" by id order, and every id that reaches the transcript is
+ * placed by the control plane (the proxy's wire-id repair lifts a stale
+ * client id; the drain re-mints a queued prompt above the live turn). So for
+ * wire ids, id order IS conversation order.
+ *
+ * `time.created` is NOT: OpenCode stamps it at PERSISTENCE, from arrival
+ * wall-clock. A batch of queued prompts is posted concurrently on purpose
+ * (so one step answers them all), and their arrival order is the network's —
+ * sorting by it displayed "B4, FIRST, B2, B3" for a burst the model itself
+ * read, and answered, in id order. It remains the fallback for anything
+ * without two well-formed wire ids, where it is the only clock there is.
+ *
+ * A message with no timestamp AND no orderable id (a host's plain stub)
+ * sorts as newest — it is the latest thing the user did — and two such keep
+ * their INPUT order. Equal keys keep id order. A weak order (stable sort),
+ * never a partial one.
  */
+const WIRE_DISPLAY_ID = /^msg_[0-9a-f]{12}/;
+
 export function compareMessagesForDisplay(
   a: { info: { id: string; time?: { created?: number } } },
   b: { info: { id: string; time?: { created?: number } } },
 ): number {
+  const aWire = WIRE_DISPLAY_ID.test(a.info.id);
+  const bWire = WIRE_DISPLAY_ID.test(b.info.id);
+  if (aWire && bWire) {
+    return a.info.id < b.info.id ? -1 : a.info.id > b.info.id ? 1 : 0;
+  }
   const at = typeof a.info.time?.created === 'number' ? a.info.time.created : null;
   const bt = typeof b.info.time?.created === 'number' ? b.info.time.created : null;
   if (at === null && bt === null) return 0;

--- a/packages/sdk/src/core/turns/turns.test.ts
+++ b/packages/sdk/src/core/turns/turns.test.ts
@@ -74,22 +74,23 @@ describe('groupMessagesIntoTurns — display order is by time.created, id is the
   const at = (id: string, role: 'user' | 'assistant', created: number, parentID?: string) =>
     ({ info: { id, role, parentID, time: { created } }, parts: [] }) as MessageWithPartsLike;
 
-  test('a backdated wire id does NOT teleport a later prompt to the top', () => {
+  test('wire ids define display order — arrival timestamps do not reorder a batch', () => {
+    // OpenCode stamps `time.created` at PERSISTENCE (arrival wall-clock), and
+    // a batch of queued prompts is posted concurrently — their arrival order
+    // is the network's, not the user's. The wire id is the message's PLACED
+    // position (the control plane lifts a stale client id before it reaches
+    // the transcript), so for two wire ids the id decides. Here the batch
+    // arrived scrambled (created 5000 before 1000): display follows the ids.
     const turns = groupMessagesIntoTurns([
-      // Stored id-sorted, as the sync store keeps them: the steer's id sorts first.
-      at('msg_000000000001steer', 'user', 5_000),
-      at('msg_000000000100first', 'user', 1_000),
-      at('msg_000000000200reply', 'assistant', 2_000, 'msg_000000000100first'),
-      at('msg_000000000300reply2', 'assistant', 3_000, 'msg_000000000100first'),
+      at('msg_000000000001first', 'user', 5_000),
+      at('msg_000000000100second', 'user', 1_000),
+      at('msg_000000000200reply', 'assistant', 2_000, 'msg_000000000001first'),
     ]);
     expect(turns.map((t) => t.userMessage.info.id)).toEqual([
-      'msg_000000000100first',
-      'msg_000000000001steer',
+      'msg_000000000001first',
+      'msg_000000000100second',
     ]);
-    expect(turns[0].assistantMessages.map((m) => m.info.id)).toEqual([
-      'msg_000000000200reply',
-      'msg_000000000300reply2',
-    ]);
+    expect(turns[0].assistantMessages.map((m) => m.info.id)).toEqual(['msg_000000000200reply']);
   });
 
   test('equal timestamps fall back to id order, so the sort is total and stable', () => {

--- a/packages/sdk/src/react/use-session-prompts.ts
+++ b/packages/sdk/src/react/use-session-prompts.ts
@@ -249,16 +249,23 @@ export function useSessionPrompts(
     },
     onSettled: invalidate,
   });
+  // No-op hook-level `onError`s: every caller shows its own specific toast,
+  // and without one TanStack falls back to the app-global default `onError`
+  // IN ADDITION — a second, generic "Failed to perform action: …" for every
+  // expected refusal (e.g. removing a prompt a step just started answering).
   const removeMutation = useMutation({
     mutationFn: (promptId: string) => deleteSessionPrompt(projectId!, sessionId!, promptId),
+    onError: () => {},
     onSettled: invalidate,
   });
   const retryMutation = useMutation({
     mutationFn: (promptId: string) => retrySessionPrompt(projectId!, sessionId!, promptId),
+    onError: () => {},
     onSettled: invalidate,
   });
   const holdMutation = useMutation({
     mutationFn: (held: boolean) => holdSessionPrompts(projectId!, sessionId!, held),
+    onError: () => {},
     onSettled: invalidate,
   });
 

--- a/packages/sdk/src/react/use-session-prompts.ts
+++ b/packages/sdk/src/react/use-session-prompts.ts
@@ -327,6 +327,7 @@ export async function startSessionWithPrompt(
       clientMessageId,
       messageId: mintSessionWireMessageId(sessionId, clientMessageId),
       parts: input.parts,
+      clientSentAtMs: now(),
       ...(input.overrides ? { overrides: input.overrides } : {}),
       remintOnDelivery: true,
     });

--- a/packages/sdk/src/react/use-session-send.test.ts
+++ b/packages/sdk/src/react/use-session-send.test.ts
@@ -99,6 +99,19 @@ describe('beginOptimisticSend', () => {
     expect('sess-1' in useSyncStore.getState().sessionStatus).toBe(false);
   });
 
+  test('the stub carries NO time.created — display order puts it newest, whatever the box clock says', () => {
+    // `compareMessagesForDisplay` orders by `time.created`, which the BOX
+    // stamps on real messages. A stub stamped from the browser clock sorted
+    // ABOVE real messages whenever the box ran behind the browser (measured:
+    // ~1 s locally) — "Held B" drawn above "Held A", rapid sends 2..5 drawn
+    // above 1. An untimed stub is "the newest thing the user did" by the
+    // comparator's own rule, which is the only order that is right on every
+    // clock.
+    beginOptimisticSend('sess-1', 'msg-1', 'hello there', ['prt-1']);
+    const info = useSyncStore.getState().messages['sess-1']?.[0] as { time?: { created?: number } };
+    expect(info.time?.created).toBeUndefined();
+  });
+
   test('adds no parts for empty/whitespace-only text', () => {
     beginOptimisticSend('sess-1', 'msg-1', '   ');
     expect(useSyncStore.getState().parts['msg-1'] ?? []).toHaveLength(0);

--- a/packages/sdk/src/react/use-session-send.ts
+++ b/packages/sdk/src/react/use-session-send.ts
@@ -95,8 +95,12 @@ export function beginOptimisticSend(
     id: messageId,
     sessionID: sessionId,
     role: 'user',
-    time: { created: Date.now() },
-  } as Message;
+    // No `time.created`: display order is by the BOX's `time.created`
+    // (`compareMessagesForDisplay`), and a stub stamped from the browser's
+    // clock sorted ABOVE real messages whenever the box ran behind it. An
+    // untimed stub is "the newest thing the user did", on every clock.
+    time: {},
+  } as unknown as Message;
   useSyncStore.getState().optimisticAdd(sessionId, info, parts);
 }
 

--- a/packages/sdk/src/react/use-session-sync.ts
+++ b/packages/sdk/src/react/use-session-sync.ts
@@ -159,7 +159,8 @@ export function useSessionSync(sessionId: string, options: UseSessionSyncOptions
       ) {
         return;
       }
-      store.hydrate(sessionId, toHydrateEntries(cached));
+      // Provisional: the first runtime read settles what the disk copy holds.
+      store.hydrate(sessionId, toHydrateEntries(cached), { source: 'cache' });
     })();
     return () => {
       cancelled = true;
@@ -190,14 +191,20 @@ export function useSessionSync(sessionId: string, options: UseSessionSyncOptions
     if (!canQueryOpenCodeSession(sessionId)) return;
     let lastMessages: unknown;
     let lastParts: unknown;
-    const persist = (state: { messages: any; parts: any }) => {
+    const persist = (state: {
+      messages: any;
+      parts: any;
+      isOptimisticMessage: (sessionID: string, messageID: string) => boolean;
+    }) => {
       // The store is shared by every session and also carries status/todos, so
       // most notifications are irrelevant here. Compare the two slices this
       // cache actually mirrors before rebuilding anything.
       if (state.messages[sessionId] === lastMessages && state.parts === lastParts) return;
       lastMessages = state.messages[sessionId];
       lastParts = state.parts;
-      void writeCachedTranscript(state, sessionId, kortixSessionScope);
+      void writeCachedTranscript(state, sessionId, kortixSessionScope, (id) =>
+        state.isOptimisticMessage(sessionId, id),
+      );
     };
     persist(useSyncStore.getState());
     return useSyncStore.subscribe(persist);

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -498,8 +498,12 @@ export function beginOptimisticPlainTextSend(
     id: messageId,
     sessionID: sessionId,
     role: 'user',
-    time: { created: Date.now() },
-  } as Message;
+    // No `time.created`: display order is by the BOX's `time.created`
+    // (`compareMessagesForDisplay`), and a stub stamped from the browser's
+    // clock sorted ABOVE real messages whenever the box ran behind it. An
+    // untimed stub is "the newest thing the user did", on every clock.
+    time: {},
+  } as unknown as Message;
   useSyncStore.getState().optimisticAdd(sessionId, info, optimisticParts);
   // No status write. `sessionStatus` is where the runtime's own SSE frames
   // land, and a fabricated `busy` there outranked a real `GET .../turn` read


### PR DESCRIPTION
## Problem

The session chat queue was unstable. Measured with a recorded Playwright lab (12 scenarios, fresh sandbox sessions, each video reviewed frame-by-frame by Gemini 3.7 Flash, plus OpenCode transcript + inbox/ledger dumps):

| # | Defect (before) | Evidence |
|---|---|---|
| P0 | A prompt queued mid-turn was **silently never answered** (1 of 3). The drain placed it at `newest+1`; OpenCode created the next assistant id between our read and our insert, so its loop's `lastUser.id < lastAssistant.id` exit read it as answered. | `queue3`: `msg_…f006` user row, no assistant, inbox empty |
| P0 | **Stop did not stop**: a claimed delivery landed after the abort, OpenCode's runner was idle, a new loop started and streamed a full answer. | opencode.log `cancel 48.367 → loop step=0 48.425` |
| P0 | **Phantom bubble after reload**: optimistic stubs were mirrored to IndexedDB and came back as plain messages the runtime never had. | `reload_midturn`: 3 turns for 2 sends, persisted |
| P0 | **Queue order inverted** (B above A; rapid 2..5 above 1): display sorts by the box's `time.created`; stubs were stamped from the browser clock (~1 s ahead locally). | DOM traces |
| P1 | Three Enters during one slow ACK **merged into one prompt** (submit latch re-read the live editor). | `"say ALPHA only.Queued #2: …"` as one row |
| P1 | Duplicate dimmed bubble for ~0.4 s after every mid-turn send (row `message_id` moved to the re-minted id before the echo). | frame T+8.15 |
| P1 | Session read as **working ~20 s after the last answer** (forwarded prompts' ledger rows only closed by a sweep). | `rapid5` shimmer 20 s |
| P1 | Queued bubbles 80 px apart, no status word; Stop button had no accessible name; send while scrolled up gave no feedback. | Gemini reports |

## Fix (server-first; SDK only for rendering/optimistic identity)

**API** — `forwarded-placement.ts` (box-clock placement + exact strand predicate), `engine.ts` (post-insert proof + immediate re-place, chaos knob `KORTIX_PLACEMENT_LIFT_DISABLED`), `forwarded-strand-reconcile.ts` (turn-end: close answered ledger rows, re-queue stranded prompts), `inbox-hold-settle.ts` (after Stop: wait claimed, re-abort an escaped loop, take unreached prompts back into HELD rows — kills the documented release duplicate), `closeSandboxTurnByMessageId`, `wire_message_id` on prompt rows.

**SDK** — untimed optimistic stubs (sort newest on every clock), cache excludes stubs + provisional cache-sourced messages, `message.removed` of a control-plane-owned message keeps the bubble for the re-placed echo, alias chain.

**Web** — FIFO stash submit latch (each Enter = one message), projection matches either id, always-visible status + hover actions, tight stacking, smooth glide on anchor change / send-while-scrolled, Stop `aria-label`.

## Verified

- Unit: `apps/api` lifecycle+r8+turn suites 268 pass; `packages/sdk` 2315 pass / 0 fail; `apps/web` session+hooks 2525 pass. `tsc`: api clean, sdk clean, web only the known `test.each` errors.
- Live (worktree stack, real Platinum sandboxes, DeepSeek): 10+ runs of `queue3`/`rapid5`/`strand1`/`stop_hold`/`reload_midturn`/`two_tabs`/`scroll_up_queue`/`long_text` on fresh sessions — every queued prompt answered, no phantom after reload, no order inversion, Stop settle logged `reAborted:true` on an escaped delivery, turn-end reconcile `closed_older` immediately. Gemini polish scores moved 2–3/10 → 5–6/10; remaining flags are design-level (see below).
- Placement proof observed live: `stranded prompt … re-placed` (immediate repair) and `detected mid-turn → turn-end reconciliation` (then rescued by the next prompt's step). The pure turn-end **re-queue** path is unit-tested, not yet observed live.

## Open / product decisions

1. **Forward-immediately vs hold-until-turn-end.** Because a queued prompt is forwarded into the live turn within ~1 s, OpenCode answers several queued prompts in ONE step ("ALPHA BETA GAMMA" under the last bubble) and Remove/Send-now are effectively unavailable (row is on the wire). Claude.ai holds queued messages until the turn ends: one answer per message, editable until sent. Worth deciding.
2. Remove of a forwarded-but-unreached prompt mid-turn needs `deletePart` (OpenCode refuses `deleteMessage` while busy) — not built.
3. Rotating composer placeholder while idle is flagged as distracting in every review.
