### PR TITLE
fix(gateway): disable Bun idleTimeout stream-kill + Bedrock request/response fixes

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1517,19 +1517,17 @@ import {
 export default {
   port: config.PORT,
 
-  // Bun's default HTTP idleTimeout is 10s: a handler that hasn't written any
-  // bytes by then gets its socket closed with an EMPTY reply — no status, no
-  // body — which clients report as a bare network error and Better Stack as a
-  // URL-only timeout. Raise it above the 25s request deadline so a genuinely
-  // stuck request surfaces as the middleware's clean 503 (with Retry-After)
-  // instead of a socket kill. Long-poll/SSE surfaces opt out per-request via
-  // server.timeout(req, 0) below.
-  // Must stay comfortably ABOVE the 25s request deadline. When this equalled
-  // the client's own 30s timeout, whichever fired first was a coin flip, and
-  // the socket-kill path returns an empty reply that the load balancer turns
-  // into a 502 with no CORS headers — surfacing in browsers as a bogus CORS
-  // error rather than a timeout.
-  idleTimeout: 45,
+  // idleTimeout DISABLED (0). Bun's default is 10s and its MAX is 255s, and Bun
+  // does NOT reset idleTimeout on server->client writes — so ANY fixed ceiling
+  // can kill a legitimately long request (e.g. project provisioning runs ~90s
+  // and was being cut at the previous 45s; see provisionProjectWithToken) or a
+  // long-poll/SSE surface, returning an EMPTY reply that the LB turns into a
+  // 502 with no CORS headers (a bogus browser CORS error). The 25s request
+  // deadline middleware remains the PRIMARY guard: a genuinely stuck request
+  // still surfaces as a clean 503 (with Retry-After) well before any socket
+  // concern. So 0 removes only the redundant backstop while letting legitimate
+  // long requests and streams run to completion.
+  idleTimeout: 0,
 
   async fetch(req: Request, server: any): Promise<Response | undefined> {
     // Bun.serve sets `req.url` to a PATH-ONLY string (`"/"`,

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -416,8 +416,11 @@ export function startProxy(
     port: cfg.servicePort,
     hostname: '0.0.0.0',
     // SSE streams from OpenCode can be long-lived with no traffic; default 10s
-    // kills them. 255s matches kortix-master's tuned value.
-    idleTimeout: 255,
+    // kills them. idleTimeout DISABLED (0): Bun's max is 255s AND Bun does not
+    // reset idleTimeout on server->client stream writes, so a 255s ceiling still
+    // killed long-lived low-traffic SSE mid-stream. 0 hands lifetime to the
+    // stream itself / a real client disconnect (still aborts req.signal).
+    idleTimeout: 0,
     async fetch(req, srv) {
       const url = new URL(req.url)
       const isWsUpgrade = req.headers.get('upgrade')?.toLowerCase() === 'websocket'

--- a/apps/kortix-sandbox-agent-server/src/static-web.ts
+++ b/apps/kortix-sandbox-agent-server/src/static-web.ts
@@ -502,7 +502,11 @@ export function startStaticWebServer(port: number = DEFAULT_STATIC_PORT): Static
       hostname: '0.0.0.0',
       // Large media files (video/audio) over slow links can exceed Bun's
       // default 10s idle timeout mid-transfer; give downloads room to finish.
-      idleTimeout: 120,
+      // idleTimeout DISABLED (0): Bun's max is 255s and Bun does not reset the
+      // idle timer on server->client writes, so any fixed ceiling can still cut
+      // a slow large transfer mid-stream. 0 lets the transfer finish; a real
+      // client disconnect still aborts the request.
+      idleTimeout: 0,
       fetch: (req) => handleRequest(req, boundPort),
     })
     boundPort = server.port ?? port

--- a/apps/llm-gateway/src/main.ts
+++ b/apps/llm-gateway/src/main.ts
@@ -6,12 +6,21 @@ const { app, traces } = buildServer();
 
 const server = Bun.serve({
   port: config.port,
-  // Bun's default idleTimeout is 10s: a streaming chat completion that pauses
-  // longer than that between tokens (reasoning models, slow first token) gets
-  // its socket killed mid-stream with an empty reply — which opencode reports as
-  // "Connection reset by server". relayStream emits a keep-alive every 10s so it
-  // never actually idles; this is the backstop ceiling (255 = Bun's max).
-  idleTimeout: 255,
+  // idleTimeout DISABLED (0). Bun's default is 10s and its MAX is 255s — and
+  // crucially Bun does NOT reset idleTimeout on server->client stream writes, so
+  // relayStream's 10s keep-alives do NOT keep the socket alive: the timer fires
+  // 255s after connection start regardless. On a slow-first-token upstream
+  // (a reasoning model prefilling a very large prompt — e.g. Bedrock Claude on a
+  // ~277k-token multimodal turn takes >255s to first byte) Bun aborted the
+  // request signal at 255s with a TimeoutError ("The operation timed out.");
+  // that signal is the SAME one handed to the upstream streamText call, so the
+  // abort propagated to the provider fetch and surfaced as a 0-byte/0-token
+  // empty completion. There is no 255s ceiling that is high enough here, so the
+  // only correct value is 0 (disabled): the gateway governs stream lifetime
+  // itself via relayStream's heartbeats + its own 90-min inactivity budget
+  // (pipeline/streaming.ts INACTIVITY_TIMEOUT_MS), and a real client disconnect
+  // still aborts req.signal (a separate mechanism, unaffected by idleTimeout).
+  idleTimeout: 0,
   fetch: app.fetch,
 });
 

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -59,6 +59,14 @@ const usage = (over: Record<string, unknown> = {}) => ({
 
 const CTX = { model: 'openai/gpt-5.6', provider: 'openai' };
 
+// A Bedrock family covers Claude AND non-Claude (global.openai.*, Nova, Meta)
+// models; only Claude accepts the Converse-only primitives (cachePoint,
+// reasoningConfig:adaptive), gated on the resolved model id (isBedrockClaudeModel).
+// Bedrock tests that assert those primitives pass a Claude resolvedModel.
+const BEDROCK_CLAUDE = 'us.anthropic.claude-fable-5';
+// A non-Claude Bedrock upstream (OpenAI on Bedrock) — must get NEITHER primitive.
+const BEDROCK_OPENAI = 'global.openai.gpt-5.6-sol';
+
 describe('ai-sdk SSE adapter — /v1/llm contract fidelity', () => {
   it('maps cache-write usage when the provider reports no cache reads', () => {
     const mapped = mapUsage(
@@ -504,13 +512,14 @@ describe('ai-sdk per-request capability gating (reuses @kortix/llm-catalog clamp
 
   it('(c) a non-reasoning model suppresses thinking/reasoningEffort entirely (anthropic family)', () => {
     // reasoning:false + no reasoning_options → the effort tier is dropped, so
-    // resolveThinkingRequest never turns extended thinking on and maxOutputTokens
-    // falls back to the plain (non-thinking) 4096 default, not the thinking bump.
+    // resolveThinkingRequest never turns extended thinking on. With no thinking
+    // AND a resolved model, defaultMaxTokens is the model's real ceiling
+    // (limit.output = 8000 here), not the 4096 unresolved-model fallback.
     const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'anthropic', {
       model: effortModel({ reasoning: false, reasoning_options: undefined }),
     });
     expect(args.providerOptions).toBeUndefined();
-    expect(args.maxOutputTokens).toBe(4096);
+    expect(args.maxOutputTokens).toBe(8000);
   });
 
   it('(d) parity: with NO model passed, gating is a no-op — output matches the pre-gating result exactly', () => {
@@ -606,7 +615,9 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
   });
 
   it('bedrock: reasoning_effort maps to adaptive reasoningConfig + effort (never enabled/budgetTokens), never providerOptions.anthropic', () => {
-    const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'medium' }, 'bedrock');
+    const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'medium' }, 'bedrock', {
+      resolvedModel: BEDROCK_CLAUDE,
+    });
     expect(args.providerOptions).toMatchObject({
       bedrock: { reasoningConfig: { type: 'adaptive', maxReasoningEffort: 'medium' } },
     });
@@ -623,6 +634,7 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
     const args = buildAiSdkArgs(
       { messages: [], reasoning_effort: 'max', max_tokens: 2000 },
       'bedrock',
+      { resolvedModel: BEDROCK_CLAUDE },
     );
     expect(args.maxOutputTokens).toBe(2000);
     // Adaptive has no budget to clamp against max_tokens — the whole class of
@@ -643,7 +655,9 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
       ['max', 'max'],
     ];
     for (const [effort, tier] of cases) {
-      const args = buildAiSdkArgs({ messages: [], reasoning_effort: effort }, 'bedrock');
+      const args = buildAiSdkArgs({ messages: [], reasoning_effort: effort }, 'bedrock', {
+        resolvedModel: BEDROCK_CLAUDE,
+      });
       expect((args.providerOptions as any)?.bedrock?.reasoningConfig).toEqual({
         type: 'adaptive',
         maxReasoningEffort: tier,
@@ -655,6 +669,7 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
     const args = buildAiSdkArgs(
       { messages: [], thinking: { type: 'enabled', budget_tokens: 5000 } },
       'bedrock',
+      { resolvedModel: BEDROCK_CLAUDE },
     );
     // The old enabled/budgetTokens shape current-gen Bedrock Claude rejects must
     // never reach the wire — even when the client itself sent it.
@@ -734,7 +749,9 @@ describe('trailing assistant prefill is stripped across the board (one normaliza
   });
 
   it('bedrock: the prompt-cache breakpoint lands on the surviving user turn, not a removed assistant', () => {
-    const args = buildAiSdkArgs({ ...withTrailingAssistant }, 'bedrock');
+    const args = buildAiSdkArgs({ ...withTrailingAssistant }, 'bedrock', {
+      resolvedModel: BEDROCK_CLAUDE,
+    });
     const last = args.messages[args.messages.length - 1] as {
       role: string;
       providerOptions?: { bedrock?: { cachePoint?: unknown } };
@@ -800,6 +817,7 @@ describe('ai-sdk anthropic/bedrock prompt caching (ported from native)', () => {
         tools: [{ function: { name: 'only_tool', parameters: {} } }],
       },
       'bedrock',
+      { resolvedModel: BEDROCK_CLAUDE },
     );
 
     expect(args.system).toBeUndefined();
@@ -816,6 +834,7 @@ describe('ai-sdk anthropic/bedrock prompt caching (ported from native)', () => {
         ],
       },
       'bedrock',
+      { resolvedModel: BEDROCK_CLAUDE },
     );
     expect(withSystem.system).toEqual({
       role: 'system',
@@ -838,6 +857,115 @@ describe('ai-sdk anthropic/bedrock prompt caching (ported from native)', () => {
     expect(openai.system).toBe('ctx');
     expect(openai.messages[openai.messages.length - 1]).not.toHaveProperty('providerOptions');
     expect((openai.tools as any)?.t?.providerOptions).toBeUndefined();
+  });
+});
+
+// FIX B2 — a no-max_tokens request must default to the model's REAL output
+// ceiling (limit.output, e.g. 128000), not the fixed 32000/4096. A fixed cap
+// far below the ceiling truncated Claude mid-answer (finish_reason=length) once
+// adaptive thinking ate the budget. The client's own explicit max_tokens still
+// always wins; the fixed 32000/4096 remain the fallback for an unresolved model.
+describe('ai-sdk default max_tokens follows the model output ceiling (FIX B2)', () => {
+  // A high real output ceiling — far above the old fixed 32000/4096 defaults.
+  const claudeModel = (over: Partial<CatalogModel> = {}): CatalogModel => ({
+    id: 'claude-fable-5',
+    name: 'Claude Fable 5',
+    reasoning: true,
+    reasoning_options: [{ type: 'effort', values: ['low', 'medium', 'high'] }],
+    limit: { context: 1_000_000, output: 128_000 },
+    ...over,
+  });
+
+  it('anthropic (non-thinking, no max_tokens): defaults to limit.output, not 4096', () => {
+    const args = buildAiSdkArgs({ messages: [] }, 'anthropic', { model: claudeModel() });
+    expect(args.maxOutputTokens).toBe(128_000);
+  });
+
+  it('anthropic (thinking active, no max_tokens): defaults to limit.output, not 32000', () => {
+    const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'anthropic', {
+      model: claudeModel(),
+    });
+    // Thinking is on (adaptive), yet the ceiling — not the 32000 thinking
+    // default — sizes the budget, so a long Claude answer is never truncated.
+    expect((args.providerOptions as any)?.anthropic?.thinking?.type).toBe('adaptive');
+    expect(args.maxOutputTokens).toBe(128_000);
+  });
+
+  it('bedrock (Claude, no max_tokens): defaults to limit.output, not 4096/32000', () => {
+    const args = buildAiSdkArgs({ messages: [] }, 'bedrock', {
+      model: claudeModel(),
+      resolvedModel: BEDROCK_CLAUDE,
+    });
+    expect(args.maxOutputTokens).toBe(128_000);
+  });
+
+  it('an explicit client max_tokens still wins over the model ceiling', () => {
+    const args = buildAiSdkArgs({ messages: [], max_tokens: 2000 }, 'anthropic', {
+      model: claudeModel(),
+    });
+    expect(args.maxOutputTokens).toBe(2000);
+  });
+
+  it('an unresolved model (no model) keeps the fixed 4096/32000 fallback', () => {
+    const plain = buildAiSdkArgs({ messages: [] }, 'anthropic');
+    expect(plain.maxOutputTokens).toBe(4096);
+    const thinking = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'anthropic');
+    expect(thinking.maxOutputTokens).toBe(32_000);
+  });
+
+  it('a model with no limit.output falls back to the fixed 4096 default', () => {
+    const args = buildAiSdkArgs({ messages: [] }, 'anthropic', {
+      model: claudeModel({ limit: undefined }),
+    });
+    expect(args.maxOutputTokens).toBe(4096);
+  });
+});
+
+// 403-fix regression (isBedrockClaudeModel gate): a single Bedrock family serves
+// Claude AND non-Claude (global.openai.*, Nova, Meta) models, but only Claude
+// accepts the Converse-only primitives. Non-Claude Bedrock 403s ("You invoked an
+// unsupported model or your request did not allow prompt caching.") on cachePoint
+// / reasoningConfig — so those must be gated on the resolved model id.
+describe('bedrock Converse primitives are gated on the resolved Claude model id (403 fix)', () => {
+  const body = {
+    messages: [
+      { role: 'system', content: 'ctx' },
+      { role: 'user', content: 'hi' },
+    ],
+    reasoning_effort: 'high',
+  };
+
+  it('non-Claude Bedrock (global.openai.*): emits NEITHER cachePoint NOR reasoningConfig', () => {
+    const args = buildAiSdkArgs({ ...body }, 'bedrock', { resolvedModel: BEDROCK_OPENAI });
+    // No reasoningConfig (adaptive thinking) in providerOptions.
+    expect((args.providerOptions as any)?.bedrock?.reasoningConfig).toBeUndefined();
+    // No cachePoint on the system prompt…
+    expect(args.system).toBe('ctx');
+    // …nor on the last message.
+    expect(args.messages[args.messages.length - 1]).not.toHaveProperty('providerOptions');
+  });
+
+  it('Claude Bedrock (us.anthropic.claude-*): still emits BOTH cachePoint and reasoningConfig', () => {
+    const args = buildAiSdkArgs({ ...body }, 'bedrock', { resolvedModel: BEDROCK_CLAUDE });
+    expect((args.providerOptions as any)?.bedrock?.reasoningConfig).toEqual({
+      type: 'adaptive',
+      maxReasoningEffort: 'high',
+    });
+    expect(args.system).toEqual({
+      role: 'system',
+      content: 'ctx',
+      providerOptions: { bedrock: { cachePoint: { type: 'default' } } },
+    });
+    expect(args.messages[args.messages.length - 1]).toMatchObject({
+      providerOptions: { bedrock: { cachePoint: { type: 'default' } } },
+    });
+  });
+
+  it('absent resolvedModel is treated as non-Claude (no Claude primitives)', () => {
+    const args = buildAiSdkArgs({ ...body }, 'bedrock');
+    expect((args.providerOptions as any)?.bedrock?.reasoningConfig).toBeUndefined();
+    expect(args.system).toBe('ctx');
+    expect(args.messages[args.messages.length - 1]).not.toHaveProperty('providerOptions');
   });
 });
 

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -266,6 +266,11 @@ export async function callUpstreamViaAiSdk(
     // it per-candidate from the catalog, so a failover onto a different upstream
     // carries ITS pin, not the previous candidate's.
     bodyExtras: descriptor.bodyExtras,
+    // The UPSTREAM model id — gates the bedrock adapter's Claude-Converse-only
+    // primitives (cachePoint, adaptive reasoningConfig). Same signal
+    // clampMaxOutputTokensForBedrock (below) keys the Nova clamp off of, so a
+    // non-Claude Bedrock model (global.openai.*, Nova) never gets Claude fields.
+    resolvedModel: descriptor.resolvedModel,
   });
   const clientWantsStream = body.stream === true;
   const ctx = {

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -678,6 +678,18 @@ function applyBedrockThinking(
   return { reasoningConfig: { type: 'adaptive', maxReasoningEffort: resolved.effort } };
 }
 
+// A Bedrock-family model resolves to one of two DIFFERENT wire contracts.
+// Anthropic Claude on Bedrock speaks the Converse Anthropic surface: `cachePoint`
+// (prompt caching) and `reasoningConfig:{type:'adaptive'}` (extended thinking)
+// are Claude-Converse-only primitives. OpenAI-on-Bedrock (`global.openai.*`),
+// Amazon Nova, Meta, and DeepSeek do NOT accept them — Bedrock rejects the
+// request with `403 "You invoked an unsupported model or your request did not
+// allow prompt caching."`. Gate both primitives on the model id, mirroring
+// model.ts's `isNovaModel` regex (the existing Bedrock model-id discriminator).
+function isBedrockClaudeModel(resolvedModel: string | undefined): boolean {
+  return /anthropic\.claude/i.test(resolvedModel ?? '');
+}
+
 const ANTHROPIC_CACHE_CONTROL = { type: 'ephemeral' } as const;
 const BEDROCK_CACHE_POINT = { type: 'default' } as const;
 
@@ -790,11 +802,24 @@ interface NormalizedRequest {
   // wins over any family default (see each adapter's `defaultMaxTokens`).
   // Clamped to the model's `limit.output` ceiling when one is known.
   explicitMaxTokens: number | undefined;
+  // The upstream model id (`descriptor.resolvedModel`), e.g.
+  // `global.openai.gpt-5.6-sol` vs `us.anthropic.claude-fable-5`. Gates the
+  // bedrock adapter's Anthropic-Claude-only Converse primitives (cachePoint,
+  // reasoningConfig:adaptive) — a single Bedrock family covers Claude AND
+  // non-Claude (OpenAI/Nova/Meta) models, and only Claude accepts those fields.
+  resolvedModel: string | undefined;
+  // The resolved catalog model, threaded through so an adapter's
+  // `defaultMaxTokens` can default to the model's REAL output ceiling
+  // (`limit.output`, e.g. 128000) instead of a fixed 32000/4096 when the client
+  // sent no max_tokens — a fixed cap far below the ceiling truncates Claude
+  // mid-answer once adaptive thinking eats the budget. Absent → the fixed
+  // fallback (preserves pre-gating behavior for unresolved models).
+  model: CatalogModel | undefined;
 }
 
 function normalizeRequest(
   body: Record<string, unknown>,
-  opts: { defaultReasoningEffort?: string; model?: CatalogModel },
+  opts: { defaultReasoningEffort?: string; model?: CatalogModel; resolvedModel?: string },
 ): NormalizedRequest {
   const { system, messages } = toModelMessages(body.messages);
   const tools = toToolSet(body.tools);
@@ -836,6 +861,8 @@ function normalizeRequest(
     temperature,
     topP,
     explicitMaxTokens,
+    resolvedModel: opts.resolvedModel,
+    model: opts.model,
   };
 }
 
@@ -900,8 +927,11 @@ interface ProviderAdapter {
   // gates whether the orchestrator builds an `AiSdkOutput` at all.
   supportsResponseFormat: boolean;
   // Prompt-cache breakpoint insertion (anthropic/bedrock only). Absent on
-  // families with no caching primitive here (openai/openai-compatible).
+  // families with no caching primitive here (openai/openai-compatible). Takes
+  // `req` so the bedrock adapter can gate the Claude-only `cachePoint` on the
+  // resolved model id (see `isBedrockClaudeModel`).
   applyCaching?(
+    req: NormalizedRequest,
     system: string | AiSdkSystemInstruction | undefined,
     messages: ModelMessage[],
     tools: ToolSet | undefined,
@@ -963,12 +993,19 @@ const anthropicAdapter: ProviderAdapter = {
     if (thinking) Object.assign(options, applyAnthropicThinking(thinking));
     return options;
   },
+  // Prefer the model's REAL output ceiling (`limit.output`, e.g. 128000) when
+  // the client sent no max_tokens — an injected cap below the ceiling truncates
+  // Claude mid-answer once adaptive thinking eats the budget. The 32000/4096
+  // stay as the fallback for an unresolved model (unknown ceiling). The
+  // client's own explicit max_tokens always wins (see buildAiSdkArgs:
+  // `req.explicitMaxTokens ?? adapter.defaultMaxTokens(req)`).
   defaultMaxTokens(req) {
+    const ceiling = req.model?.limit?.output;
     const thinking = resolveThinkingRequest(req.raw, req.reasoningEffort);
-    return thinking ? DEFAULT_MAX_TOKENS_WITH_THINKING : 4096;
+    return thinking ? (ceiling ?? DEFAULT_MAX_TOKENS_WITH_THINKING) : (ceiling ?? 4096);
   },
   supportsResponseFormat: false,
-  applyCaching: (system, messages, tools) =>
+  applyCaching: (_req, system, messages, tools) =>
     applyAnthropicPromptCaching(system, messages, tools, 'anthropic'),
 };
 
@@ -976,6 +1013,10 @@ const bedrockAdapter: ProviderAdapter = {
   optionsKey: () => 'bedrock',
   buildProviderOptions(req) {
     const options: BedrockProviderOptions = {};
+    // `reasoningConfig:{type:'adaptive'}` is a Claude-Converse-only primitive.
+    // Non-Claude Bedrock models (`global.openai.*`, Nova, …) 403 on it — never
+    // attach it for them.
+    if (!isBedrockClaudeModel(req.resolvedModel)) return options;
     const thinking = resolveThinkingRequest(req.raw, req.reasoningEffort);
     // Adaptive thinking carries no token budget to clamp — the model manages
     // its own. `defaultMaxTokens` below still bumps maxOutputTokens so thinking
@@ -983,13 +1024,24 @@ const bedrockAdapter: ProviderAdapter = {
     if (thinking) Object.assign(options, applyBedrockThinking(thinking));
     return options;
   },
+  // Prefer the model's REAL output ceiling (`limit.output`) when the client
+  // sent no max_tokens — an injected cap below the ceiling truncates Claude
+  // mid-answer once adaptive thinking eats the budget. The 32000/4096 stay as
+  // the fallback for an unresolved model. The client's own explicit max_tokens
+  // always wins (see buildAiSdkArgs).
   defaultMaxTokens(req) {
+    const ceiling = req.model?.limit?.output;
     const thinking = resolveThinkingRequest(req.raw, req.reasoningEffort);
-    return thinking ? DEFAULT_MAX_TOKENS_WITH_THINKING : 4096;
+    return thinking ? (ceiling ?? DEFAULT_MAX_TOKENS_WITH_THINKING) : (ceiling ?? 4096);
   },
   supportsResponseFormat: false,
-  applyCaching: (system, messages, tools) =>
-    applyAnthropicPromptCaching(system, messages, tools, 'bedrock'),
+  // `cachePoint` is a Claude-Converse-only primitive. Non-Claude Bedrock models
+  // (`global.openai.*`, Nova, …) 403 on it — pass the system/tools through
+  // unchanged for them.
+  applyCaching: (req, system, messages, tools) =>
+    isBedrockClaudeModel(req.resolvedModel)
+      ? applyAnthropicPromptCaching(system, messages, tools, 'bedrock')
+      : { system, tools },
 };
 
 const ADAPTERS: Record<AiSdkFamily, ProviderAdapter> = {
@@ -1030,6 +1082,12 @@ export function buildAiSdkArgs(
     // schema. Merged LAST so an upstream pin always wins over a same-named
     // client field, exactly as the retired native openai-compat transport did.
     bodyExtras?: Record<string, unknown>;
+    // The upstream model id (`descriptor.resolvedModel`), e.g.
+    // `global.openai.gpt-5.6-sol` vs `us.anthropic.claude-fable-5`. Gates the
+    // bedrock adapter's Claude-Converse-only primitives (cachePoint, adaptive
+    // reasoningConfig) — same signal `clampMaxOutputTokensForBedrock` keys the
+    // Nova clamp off of. Absent → treated as non-Claude (no Claude primitives).
+    resolvedModel?: string;
   } = {},
 ): AiSdkCallArgs {
   const req = normalizeRequest(body, opts);
@@ -1080,7 +1138,7 @@ export function buildAiSdkArgs(
   let system = req.system;
   let tools = req.tools;
   if (adapter.applyCaching) {
-    const cached = adapter.applyCaching(system, req.messages, tools);
+    const cached = adapter.applyCaching(req, system, req.messages, tools);
     system = cached.system;
     tools = cached.tools;
   }

--- a/packages/llm-gateway/src/usage/completion-guard.test.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.test.ts
@@ -50,6 +50,30 @@ describe('jsonHasContent', () => {
     expect(jsonHasContent('nope')).toBe(false);
     expect(jsonHasContent(undefined)).toBe(false);
   });
+
+  // A Claude refusal / content-filter turn is a REAL terminal answer, not the
+  // empty completion this guard exists to catch. Before this, a refusal (empty
+  // content + finish_reason:'content_filter') read as "empty", so the turn was
+  // classified empty_completion and retried 3× to a 502, losing the refusal.
+  test('true when finish_reason is content_filter and content is empty (a refusal is output)', () => {
+    expect(
+      jsonHasContent({
+        choices: [{ message: { content: '' }, finish_reason: 'content_filter' }],
+      }),
+    ).toBe(true);
+  });
+
+  test('true when message.refusal carries the refusal string (no content/tool_calls)', () => {
+    expect(
+      jsonHasContent({
+        choices: [{ message: { content: null, refusal: "I can't help with that." } }],
+      }),
+    ).toBe(true);
+  });
+
+  test('false for an empty refusal string with no other content', () => {
+    expect(jsonHasContent({ choices: [{ message: { content: '', refusal: '' } }] })).toBe(false);
+  });
 });
 
 describe('sseHasContent', () => {
@@ -75,6 +99,20 @@ describe('sseHasContent', () => {
 
   test('ignores malformed JSON lines instead of throwing', () => {
     expect(sseHasContent('data: {not json\n\n')).toBe(false);
+  });
+
+  // The exact terminal frame sse.ts emits for a Claude refusal: an empty delta
+  // plus finish_reason:'content_filter' on the CHOICE (not the delta). Must
+  // count as content so streaming.ts commits the turn instead of retrying it.
+  test('true for a lone content_filter finish frame with an empty delta (a refusal)', () => {
+    const buf =
+      'data: {"choices":[{"delta":{},"finish_reason":"content_filter"}]}\n\ndata: [DONE]\n\n';
+    expect(sseHasContent(buf)).toBe(true);
+  });
+
+  test('true for a refusal delta (delta.refusal populated, no content)', () => {
+    const buf = 'data: {"choices":[{"delta":{"refusal":"I can\'t help with that."}}]}\n\n';
+    expect(sseHasContent(buf)).toBe(true);
   });
 });
 

--- a/packages/llm-gateway/src/usage/completion-guard.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.ts
@@ -10,12 +10,17 @@ interface ChoiceLike {
     tool_calls?: unknown;
     reasoning?: unknown;
     reasoning_content?: unknown;
+    // A Claude refusal / content-filter turn carries the model's decision in
+    // `refusal` (OpenAI's refusal field) with `content` empty — see the
+    // finish-reason note on choiceHasContent below.
+    refusal?: unknown;
   };
   delta?: {
     content?: unknown;
     tool_calls?: unknown;
     reasoning?: unknown;
     reasoning_content?: unknown;
+    refusal?: unknown;
   };
 }
 
@@ -28,12 +33,26 @@ function partHasContent(part: ChoiceLike['message'] | ChoiceLike['delta']): bool
   const reasoningContent = 'reasoning_content' in part ? part.reasoning_content : undefined;
   if (typeof reasoning === 'string' && reasoning.length > 0) return true;
   if (typeof reasoningContent === 'string' && reasoningContent.length > 0) return true;
+  // A refusal IS the model's output — a populated `refusal` string is a real,
+  // committed turn, not the empty completion this guard exists to catch.
+  const refusal = 'refusal' in part ? part.refusal : undefined;
+  if (typeof refusal === 'string' && refusal.length > 0) return true;
   return false;
 }
 
 function choiceHasContent(choice: unknown): boolean {
   if (!choice || typeof choice !== 'object') return false;
   const c = choice as ChoiceLike;
+  // `finish_reason:'content_filter'` is a REAL terminal answer: the model
+  // refused, and that refusal is the turn's output — not an empty completion.
+  // A Claude refusal arrives as a lone `finish` part (finishReason
+  // 'content-filter', no content); sse.ts emits it as a terminal frame with an
+  // empty delta and `finish_reason:'content_filter'`. Without reading the
+  // finish reason here the stream read "empty", so streaming.ts never committed,
+  // handler.ts classified `empty_completion`, and the turn was retried 3× to a
+  // 502 — losing the refusal reason and wasting 3 upstream calls. Count it as
+  // content so the already-emitted content_filter frame flows to the client.
+  if (c.finish_reason === 'content_filter') return true;
   return partHasContent(c.message) || partHasContent(c.delta);
 }
 


### PR DESCRIPTION
## Why

Investigating streaming chat completions that returned **0 tokens** and surfaced `"The operation timed out."` on large-prompt reasoning turns. Two independent root causes, both gateway-side.

## 1. Bun `idleTimeout` was killing long streams (the main fix)

`Bun.serve`'s `idleTimeout` is **capped at 255s** and — critically — **is not reset by server→client stream writes**. So a streaming completion whose upstream is slow to first byte (a reasoning model prefilling a very large prompt) had its socket aborted at ~255s. Bun raises a `TimeoutError` whose message is literally `"The operation timed out."`; the gateway hands that same request signal to the upstream `streamText` call, so the abort propagated to the provider fetch and surfaced as a **0-byte / 0-token empty completion**. Keep-alive heartbeats did not save it (they don't reset the timer).

There is no 255s ceiling high enough here, so the only correct value is **`idleTimeout: 0`** (disabled). Stream lifetime is then governed by the app's own heartbeats + the 90-min inactivity budget (`pipeline/streaming.ts`), and a real client disconnect still aborts `req.signal` (a separate mechanism). Applied to every request-serving `Bun.serve` on the streaming path:

- `apps/llm-gateway/src/main.ts` (255 → 0) — the completion stream itself
- `apps/kortix-sandbox-agent-server/src/proxy.ts` (255 → 0) — long-lived OpenCode SSE
- `apps/kortix-sandbox-agent-server/src/static-web.ts` (120 → 0) — large media over slow links
- `apps/api/src/index.ts` (45 → 0) — also removes the cap that cut ~90s project provisioning; the 25s request-deadline middleware remains the primary stuck-request guard

## 2. Three Bedrock request/response fixes

- **OpenAI-on-Bedrock 403.** The bedrock adapter attached the Claude-Converse-only primitives `cachePoint` + adaptive `reasoningConfig` to **every** Bedrock model, so `global.openai.gpt-5.6-sol` 403'd `"You invoked an unsupported model or your request did not allow prompt caching."` Gate both primitives on the resolved model id (`isBedrockClaudeModel`, mirroring the existing `isNovaModel` discriminator). Non-Claude Bedrock models no longer receive Claude fields.
- **Refusals were swallowed.** A `content_filter` finish / populated `message.refusal` has empty content, so `completion-guard` classified it as `empty_completion` → retried 3× → generic 502, losing the reason. Count both as real completion content so the refusal is surfaced instead.
- **max_tokens truncation.** A no-`max_tokens` Claude request was hard-capped at a fixed 4096 / 32000, well below the model's real `limit.output`; with adaptive thinking eating the budget the answer truncated mid-work. Default to the model's real output ceiling instead (the client's explicit `max_tokens` still always wins).

## Verification

- `packages/llm-gateway` typecheck: clean (exit 0).
- `packages/llm-gateway` tests: **422 pass / 0 fail**. New cases cover: a `content_filter` finish and a `message.refusal` both count as content; a Claude bedrock/anthropic request with no `max_tokens` resolves to the model ceiling; and the 403 gate (OpenAI-on-Bedrock gets no `cachePoint`/`reasoningConfig`, Claude still does).

## Risk

`idleTimeout: 0` removes Bun's inbound idle cleanup on these servers; genuinely dead peers are still bounded (app 90-min inactivity + `req.signal` on real disconnect + upstream Caddy). The three Bedrock fixes are additive and covered by unit tests.
