### PR TITLE
fix(db): unblock dev deploys — reconcile retired role_permissions actions before the cutover's catalog-FK VALIDATE (runtime override)

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,23 @@ linked, not inlined.
 
 ## Register
 
+### A VALIDATE ships only with a reconciliation the TARGET data has passed (2026-08-19)
+
+**When:** writing `VALIDATE CONSTRAINT` for an FK/CHECK added `NOT VALID`.
+Zero violating rows on the local DB is not evidence — local data is young.
+Long-lived envs hold rows written before the catalog/constraint existed (dev:
+`iam_role_actions` rows with retired `project.cr.*`/`trigger.*` actions).
+Either probe every target env for violators first, or — better — precede the
+VALIDATE with idempotent reconciliation DML in the same migration so it cannot
+fail on data the constraint predates. A merged migration that VALIDATE-fails
+blocks EVERY deploy of that env; the only sanctioned fix is a checksum-guarded
+runtime override (`packages/db/scripts/migration-runtime-overrides.ts`).
+*Incident:* RBAC cutover #6594 — `role_permissions_action_permissions_fk`
+VALIDATE 23503'd on dev; Deploy Dev blocked ~1h; fixed by the third runtime
+override (map `cr.*`→`gitops.*` dedup-aware, purge uncataloged, then VALIDATE).
+*Enforcer:* `migration-runtime-overrides.test.ts` pins the override; nothing
+yet lints "VALIDATE without reconciliation" — prose only.
+
 ### `drizzle-kit generate` reports a TTY prompt as "no schema changes" (2026-08-19)
 
 **When:** running `bun packages/db/scripts/generate.ts <slug>` from any

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,25 @@ linked, not inlined.
 
 ## Register
 
+### Rewiring writers and converting their table to a view must be TWO releases (2026-08-19)
+
+**When:** an expand/contract store swap (table -> compatibility view). The
+migration applies BEFORE the new image rolls, so old pods run against the view
+for the whole build+rollout window — and any of their `INSERT ... ON CONFLICT
+(cols)` writers 42P10 for that entire window (INSTEAD OF triggers cannot help;
+conflict inference precedes them). Locally it is worse: the shared Supabase DB
+is cutover'd the moment the migration runs, and EVERY other worktree still on
+pre-cutover code breaks until it merges main.
+The rule: **release N rewires every ON CONFLICT writer off the table; release
+N+1 converts it to a view.** If they must ship together, size the window
+explicitly (dev: minutes; prod: pod drain + build — unacceptable for hot
+writers) and schedule the promote accordingly. After cutting over a shared
+local DB, tell every other active session to merge main IMMEDIATELY.
+*Incident:* RBAC cutover #6594 — dev's grant/invite/SSO-JIT/SCIM upserts
+42P10'd from migration-apply until the API rollout landed; every local
+worktree session on pre-cutover code broke against the shared DB at once.
+*Enforcer:* none — prose only. The promote runbook must carry this check.
+
 ### A VALIDATE ships only with a reconciliation the TARGET data has passed (2026-08-19)
 
 **When:** writing `VALIDATE CONSTRAINT` for an FK/CHECK added `NOT VALID`.

--- a/apps/api/src/__tests__/unit-iam-gate-codemod-pin.test.ts
+++ b/apps/api/src/__tests__/unit-iam-gate-codemod-pin.test.ts
@@ -172,3 +172,22 @@ describe('the gate codemod is complete', () => {
     expect(topLevelAwaits.map((m) => m[0].trim())).toEqual([]);
   });
 });
+
+// The manifest alias table (`MANIFEST_ACTION_ALIASES`) rewrites a hand-written
+// kortix_cli list ON INPUT; every gate then compares canonical-to-canonical.
+// A route asserting the RETIRED spelling breaks that: the grant holds
+// `project.gitops.push`, the assert asks for `project.cr.open`, and an agent
+// with an explicit (non-'all') grant 403s on CR open. Found live by a peer
+// session on a pre-cutover checkout (2026-08-19); the cutover fixed the four
+// call sites — this pin keeps the retired spellings out of production asserts.
+describe('no production gate asserts a retired action spelling', () => {
+  test("assertAgentScope / assertProjectCapability never name project.cr.*", async () => {
+    const { execSync } = await import('node:child_process');
+    const out = execSync(
+      `grep -rn "assertAgentScope(c, 'project.cr\\.\\|assertProjectCapability(.*'project.cr\\." src --include='*.ts' || true`,
+      { cwd: `${import.meta.dir}/../..`, encoding: 'utf8' },
+    );
+    const hits = out.split('\n').filter((l) => l && !l.includes('.test.ts') && !l.includes('__tests__'));
+    expect(hits).toEqual([]);
+  });
+});

--- a/packages/db/migrations-pending/README.md
+++ b/packages/db/migrations-pending/README.md
@@ -115,3 +115,29 @@ DO change behaviour. Expand, then contract.
   query on prod before promoting: `select count(*) from kortix.role_assignments ra
   where ra.scope_type='project' and not exists (select 1 from kortix.projects p
   where p.project_id = ra.scope_id)`.
+
+
+## Pre-promote probe (staging / prod) — run BEFORE promoting the cutover
+
+Long-lived data holds role grants written before the catalog collapse; the
+runtime override in `migration-runtime-overrides.ts` reconciles them, but SIZE
+them first (and confirm the override fires) with:
+
+```sql
+-- role_permissions rows the catalog no longer names (would fail the VALIDATE
+-- without the runtime override):
+SELECT rp.role_id, rp.action
+  FROM kortix.role_permissions rp
+  LEFT JOIN kortix.permissions p ON p.action = rp.action
+ WHERE p.action IS NULL;
+
+-- project-scope assignments pointing at deleted projects (purged by the
+-- cutover backfill; 629 on the local dataset):
+SELECT count(*) FROM kortix.role_assignments ra
+ WHERE ra.scope_type = 'project'
+   AND NOT EXISTS (SELECT 1 FROM kortix.projects pr WHERE pr.project_id = ra.scope_id);
+```
+
+Mixed-version window (learnings register 2026-08-19): old pods 42P10 on the
+five upsert writers from migration-apply until the new image rolls. Promote in
+a low-traffic window and verify the rollout completes promptly.

--- a/packages/db/migrations-pending/README.md
+++ b/packages/db/migrations-pending/README.md
@@ -125,11 +125,21 @@ them first (and confirm the override fires) with:
 
 ```sql
 -- role_permissions rows the catalog no longer names (would fail the VALIDATE
--- without the runtime override):
-SELECT rp.role_id, rp.action
+-- without the runtime override), split by what the override DOES to them:
+--   REMAP  = intent-preserving rename onto the surviving leaf (cr.* -> gitops.*)
+--   PURGE  = dropped. By construction these can only be the dead trigger.*
+--            family (never asserted by any route, so removing them changes no
+--            behaviour) — writes were always validated against VALID_ACTIONS,
+--            so no other uncataloged string can exist. If this query ever
+--            shows a PURGE row outside trigger.*, STOP and investigate before
+--            promoting: that would be a permission the override would drop.
+SELECT rp.role_id, rp.action,
+       CASE WHEN rp.action IN ('project.cr.open','project.cr.merge') THEN 'REMAP'
+            ELSE 'PURGE' END AS override_effect
   FROM kortix.role_permissions rp
   LEFT JOIN kortix.permissions p ON p.action = rp.action
- WHERE p.action IS NULL;
+ WHERE p.action IS NULL
+ ORDER BY override_effect, rp.role_id;
 
 -- project-scope assignments pointing at deleted projects (purged by the
 -- cutover backfill; 629 on the local dataset):

--- a/packages/db/scripts/migration-runtime-overrides.test.ts
+++ b/packages/db/scripts/migration-runtime-overrides.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -28,6 +29,57 @@ function removeLocalDockerFixture(sql: string): string {
   roots.push(root);
   return migrations;
 }
+
+describe('rbac cutover views runtime cleanup', () => {
+  test('prepends the retired-action cleanup before the catalog-FK VALIDATE, only in the runtime copy', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rbac-views-override-'));
+    roots.push(root);
+    const dir = join(root, 'migrations');
+    mkdirSync(dir, { recursive: true });
+    const source = [
+      'set lock_timeout = \'3s\';',
+      'ALTER TABLE kortix.role_permissions',
+      '  VALIDATE CONSTRAINT role_permissions_action_permissions_fk;',
+    ].join('\n');
+    writeFileSync(join(dir, '20260819160100000_rbac_cutover_views.sql'), source);
+    const runtime = materializeMigrationRuntimeDirectory(dir, {
+      rbacCutoverViewsExpectedSha256: createHash('sha256').update(source).digest('hex'),
+    });
+    roots.push(runtime.path);
+    const rewritten = readFileSync(
+      join(runtime.path, '20260819160100000_rbac_cutover_views.sql'),
+      'utf8',
+    );
+    // The cleanup lands BEFORE the VALIDATE, and the VALIDATE survives once.
+    expect(rewritten).toContain("DELETE FROM kortix.role_permissions rp");
+    expect(rewritten).toContain("('project.cr.open',  'project.gitops.push')");
+    expect(rewritten.indexOf('DELETE FROM kortix.role_permissions')).toBeLessThan(
+      rewritten.indexOf('VALIDATE CONSTRAINT role_permissions_action_permissions_fk'),
+    );
+    expect(
+      rewritten.split('VALIDATE CONSTRAINT role_permissions_action_permissions_fk').length - 1,
+    ).toBe(1);
+    // The immutable source is untouched.
+    expect(readFileSync(join(dir, '20260819160100000_rbac_cutover_views.sql'), 'utf8')).toBe(source);
+    expect(runtime.appliedOverrides.some((o) => o.includes('rbac_cutover_views'))).toBe(true);
+  });
+
+  test('fails closed on a checksum mismatch for the views migration', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rbac-views-override-'));
+    roots.push(root);
+    const dir = join(root, 'migrations');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, '20260819160100000_rbac_cutover_views.sql'),
+      'ALTER TABLE kortix.role_permissions\n  VALIDATE CONSTRAINT role_permissions_action_permissions_fk;',
+    );
+    expect(() =>
+      materializeMigrationRuntimeDirectory(dir, {
+        rbacCutoverViewsExpectedSha256: '0'.repeat(64),
+      }),
+    ).toThrow(/checksum mismatch/);
+  });
+});
 
 describe('materializeMigrationRuntimeDirectory', () => {
   test('changes only the known audit-v2 timeout and keeps the immutable source untouched', () => {

--- a/packages/db/scripts/migration-runtime-overrides.ts
+++ b/packages/db/scripts/migration-runtime-overrides.ts
@@ -27,10 +27,42 @@ DROP VIEW IF EXISTS kortix.workspace_sessions;--> statement-breakpoint
 
 `;
 
+const RBAC_CUTOVER_VIEWS_MIGRATION = '20260819160100000_rbac_cutover_views.sql';
+const RBAC_CUTOVER_VIEWS_SHA256 = '81fd7a986fe0039c12656c4f3b70a356651d6492da457c6ca07f17b64f0c3f87';
+const RBAC_CUTOVER_VIEWS_INSERTION_POINT = `ALTER TABLE kortix.role_permissions
+  VALIDATE CONSTRAINT role_permissions_action_permissions_fk;`;
+const RBAC_CUTOVER_VIEWS_RUNTIME_CLEANUP = `-- Runtime correction: long-lived databases (dev was the first) hold
+-- role_permissions rows whose action string was RETIRED from the catalog —
+-- the pre-#6554 spellings project.cr.open / project.cr.merge (folded into the
+-- gitops leaves) and the dead trigger.* family. The local DB this migration
+-- was proved on had zero such rows, so the VALIDATE below 23503'd on dev and
+-- blocked every deploy. Map the renamed pair onto the surviving leaves
+-- (dedup-aware), then drop anything else the catalog no longer names. Bounded
+-- DML: role_permissions is a per-custom-role action list (hundreds of rows),
+-- not a data table.
+UPDATE kortix.role_permissions rp
+   SET action = m.new_action
+  FROM (VALUES ('project.cr.open',  'project.gitops.push'),
+               ('project.cr.merge', 'project.gitops.merge')) AS m(old_action, new_action)
+ WHERE rp.action = m.old_action
+   AND NOT EXISTS (
+     SELECT 1 FROM kortix.role_permissions d
+      WHERE d.role_id = rp.role_id AND d.action = m.new_action
+   );
+
+DELETE FROM kortix.role_permissions rp
+ WHERE NOT EXISTS (
+   SELECT 1 FROM kortix.permissions p WHERE p.action = rp.action
+ );
+
+ALTER TABLE kortix.role_permissions
+  VALIDATE CONSTRAINT role_permissions_action_permissions_fk;`;
+
 interface RuntimeOverrideOptions {
   /** Test seam. Production always uses the committed migration checksum above. */
   expectedSha256?: string;
   removeLocalDockerExpectedSha256?: string;
+  rbacCutoverViewsExpectedSha256?: string;
 }
 
 export interface MigrationRuntimeDirectory {
@@ -55,15 +87,20 @@ export function materializeMigrationRuntimeDirectory(
 ): MigrationRuntimeDirectory {
   const auditPath = join(sourceDirectory, AUDIT_V2_MIGRATION);
   const removeLocalDockerPath = join(sourceDirectory, REMOVE_LOCAL_DOCKER_MIGRATION);
+  const rbacCutoverViewsPath = join(sourceDirectory, RBAC_CUTOVER_VIEWS_MIGRATION);
   const hasAuditOverride = existsSync(auditPath);
   const hasRemoveLocalDockerOverride = existsSync(removeLocalDockerPath);
-  if (!hasAuditOverride && !hasRemoveLocalDockerOverride) {
+  const hasRbacCutoverViewsOverride = existsSync(rbacCutoverViewsPath);
+  if (!hasAuditOverride && !hasRemoveLocalDockerOverride && !hasRbacCutoverViewsOverride) {
     return { path: sourceDirectory, appliedOverrides: [], cleanup: () => {} };
   }
 
   const auditSource = hasAuditOverride ? readFileSync(auditPath, 'utf8') : null;
   const removeLocalDockerSource = hasRemoveLocalDockerOverride
     ? readFileSync(removeLocalDockerPath, 'utf8')
+    : null;
+  const rbacCutoverViewsSource = hasRbacCutoverViewsOverride
+    ? readFileSync(rbacCutoverViewsPath, 'utf8')
     : null;
   if (auditSource) {
     const expectedSha256 = options.expectedSha256 ?? AUDIT_V2_SHA256;
@@ -96,6 +133,22 @@ export function materializeMigrationRuntimeDirectory(
     }
   }
 
+  if (rbacCutoverViewsSource) {
+    const expectedSha256 = options.rbacCutoverViewsExpectedSha256 ?? RBAC_CUTOVER_VIEWS_SHA256;
+    const actualSha256 = sha256(rbacCutoverViewsSource);
+    if (actualSha256 !== expectedSha256) {
+      throw new Error(
+        `${RBAC_CUTOVER_VIEWS_MIGRATION} checksum mismatch: expected ${expectedSha256}, received ${actualSha256}`,
+      );
+    }
+    const occurrenceCount =
+      rbacCutoverViewsSource.split(RBAC_CUTOVER_VIEWS_INSERTION_POINT).length - 1;
+    if (occurrenceCount !== 1) {
+      throw new Error(
+        `${RBAC_CUTOVER_VIEWS_MIGRATION} expected exactly one role_permissions VALIDATE statement; found ${occurrenceCount}`,
+      );
+    }
+  }
   const runtimeRoot = mkdtempSync(join(tmpdir(), 'kortix-migrations-'));
   const runtimeDirectory = join(runtimeRoot, 'migrations');
   const appliedOverrides: string[] = [];
@@ -120,6 +173,18 @@ export function materializeMigrationRuntimeDirectory(
       );
       appliedOverrides.push(
         `${REMOVE_LOCAL_DOCKER_MIGRATION}: drop historical workspace_sessions view (${REMOVE_LOCAL_DOCKER_SHA256})`,
+      );
+    }
+    if (rbacCutoverViewsSource) {
+      writeFileSync(
+        join(runtimeDirectory, RBAC_CUTOVER_VIEWS_MIGRATION),
+        rbacCutoverViewsSource.replace(
+          RBAC_CUTOVER_VIEWS_INSERTION_POINT,
+          RBAC_CUTOVER_VIEWS_RUNTIME_CLEANUP,
+        ),
+      );
+      appliedOverrides.push(
+        `${RBAC_CUTOVER_VIEWS_MIGRATION}: retire project.cr.*/trigger.* role_permissions rows before the catalog-FK VALIDATE (${RBAC_CUTOVER_VIEWS_SHA256})`,
       );
     }
   } catch (error) {


### PR DESCRIPTION
**Dev deploys are blocked**: `Apply DB migrations to dev` fails in every Deploy Dev run since #6594 with `insert or update on table "role_permissions" violates foreign key constraint "role_permissions_action_permissions_fk"` — the `VALIDATE` at the end of the (merged, immutable) `20260819160100000_rbac_cutover_views.sql`.

Cause: dev's `iam_role_actions` holds rows written before #6554's catalog existed, carrying the retired spellings `project.cr.open`/`project.cr.merge` and dead `trigger.*` actions. The local DB the cutover was proved on had zero such rows (the NOT VALID FK has blocked new ones since #6554), so the VALIDATE scan passed locally and 23503s on dev.

Fix: the third **checksum-guarded runtime override** (`migration-runtime-overrides.ts`, same mechanism as audit-v2 and remove-local-docker): before the VALIDATE, map `cr.open→gitops.push` / `cr.merge→gitops.merge` (dedup-aware) and delete any `role_permissions` row whose action is no longer in `kortix.permissions`. Bounded DML (a per-role action list, hundreds of rows).

Proof:
- Unit: `migration-runtime-overrides.test.ts` 6/6 (rewrite lands before the VALIDATE, once; source untouched; checksum fails closed).
- Live repro on a scratch DB migrated to dev's exact state (5 planted rows incl. all three retired kinds, FK re-added NOT VALID): full `migrate up` **exit 0**, survivors `gitops.merge, gitops.push, secret.read` (cr.open deduped, cr.merge mapped, trigger.fire purged), FK `convalidated = t`.
- `packages/db` script tests 153/0, migrate:lint 185 files, tsc 0.

Learning appended to the register: a VALIDATE ships only with a reconciliation the target data has passed — local zero-rows is not evidence.
