### PR TITLE
test(ke2e): GW-1 tolerates a traffic-degraded gateway (aligns with #6582 preflight)

### DIFF
--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -356,7 +356,9 @@ async function runLane(root: string, lane: LocalTestLane): Promise<LaneResult> {
   try {
     // Every lane can sign a Supabase auth-hook request: the local stack starts
     // the API with this same fixed secret (see local-stack.ts).
-    let env = {
+    // Widened explicitly: lanes append their own E2E_*/KE2E_* keys below, and
+    // the inferred literal type would reject any key not present here (TS2353).
+    let env: Record<string, string | undefined> = {
       ...process.env,
       KE2E_AUTH_EMAIL_HOOK_SECRET: LOCAL_AUTH_EMAIL_HOOK_SECRET,
       ...(lane.env ?? {}),

--- a/tests/src/flows/llm-gateway.flow.ts
+++ b/tests/src/flows/llm-gateway.flow.ts
@@ -5,7 +5,21 @@ flow('GW-1', { domain: 'llm-gateway', tags: ['smoke'], routes: ['GET /health'] }
   const gw = new Client(ctx.env.gatewayUrl);
   await ctx.step('gateway /health is public', async () => {
     const r = await gw.get('/health');
-    r.status(200).body().has('$.status', 'healthy').has('$.service', 'kortix-llm-gateway');
+    // `degraded` is a traffic metric (error-rate over the last 300s window),
+    // and the gate's own suite drives error traffic through this gateway. What
+    // this flow asserts is the health CONTRACT: the endpoint is public, the
+    // service names itself, and its API dependency is up. Same reasoning as
+    // the preflight in core/target-smoke.ts (#6582): serving-but-degraded is
+    // not an outage; `down`/`unhealthy` still fails.
+    r.status(200).body().has('$.service', 'kortix-llm-gateway');
+    const body = r.json<{ status?: string; checks?: { api?: { status?: string } } }>();
+    const status = body?.status;
+    const apiUp = body?.checks?.api?.status === 'up';
+    if (status !== 'healthy' && !(status === 'degraded' && apiUp)) {
+      throw new Error(
+        `gateway health contract failed: status=${status} api=${body?.checks?.api?.status}`,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
Gate dry-run 32277830095: GW-1 red on `expected healthy, got degraded` while `checks.api.status=='up'` — the suite's own LLM error traffic trips the gateway's 300s error-rate metric. Same acceptance as the #6582 preflight: healthy OR degraded-with-api-up; down/unhealthy still fails. NOTE: the rest of that run's failures were mixed-version skew (staging DB had the RBAC-cutover views from 1addb77a0c's migrations while staging code at 871c08c857 predated the rewired writers → writer paths 500 → edge-laundered MAINTENANCE_MODE). Re-promoting current main fixes that; this PR is the only test change needed. typecheck exit 0; catalog 444 flows.