### PR TITLE
docs(learnings): reconcile a retired constraint value by remapping, never deleting

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -48,7 +48,12 @@ Long-lived envs hold rows written before the catalog/constraint existed (dev:
 `iam_role_actions` rows with retired `project.cr.*`/`trigger.*` actions).
 Either probe every target env for violators first, or — better — precede the
 VALIDATE with idempotent reconciliation DML in the same migration so it cannot
-fail on data the constraint predates. A merged migration that VALIDATE-fails
+fail on data the constraint predates. Reconcile by REMAPPING a retired value to
+its replacement, never by deleting the row: where the retired action was a
+rename/collapse (`project.cr.open` -> `project.gitops.push`), the row is the
+whole reason the old name still exists, and deleting it silently strips a
+capability from whoever held it — a permission change disguised as a migration
+fix. Delete only a value with no replacement (the dead `trigger.*` family). A merged migration that VALIDATE-fails
 blocks EVERY deploy of that env; the only sanctioned fix is a checksum-guarded
 runtime override (`packages/db/scripts/migration-runtime-overrides.ts`).
 *Incident:* RBAC cutover #6594 — `role_permissions_action_permissions_fk`


### PR DESCRIPTION
One-sentence addition to the existing "A VALIDATE ships only with a reconciliation the TARGET data has passed" entry (#6602's incident), stating the rule that entry implies but does not say.

When the retired value was a rename/collapse — `project.cr.open` -> `project.gitops.push` — the violating row is the whole reason the old name still exists. Deleting it clears the VALIDATE and silently strips a capability from whoever held it: a permission change disguised as a migration fix. Deletion is correct only for a value with no replacement (the dead `trigger.*` family), which is exactly the split the #6602 override already implements.

Learned while unblocking dev: the two `iam_role_actions` rows there were remapped rather than dropped, preserving the custom role's capability.

Docs only — no code paths touched.