### PR TITLE
fix(slack): link-bot documented the one input form Slack cannot send

### DIFF
--- a/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
+++ b/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
@@ -69,6 +69,7 @@ mock.module('../channels/slack-api', () => ({
   deleteMessage: async () => {},
   getChannelName: async () => 'general',
   isBotUser: async () => true,
+  findBotUserIdByName: async () => null,
   joinChannel: async () => true,
   openDmChannel: async () => 'D1',
   postEphemeral: async () => true,
@@ -83,6 +84,20 @@ mock.module('../channels/slack-api', () => ({
 }));
 
 const { classifyEvent, isOwnBotEvent } = await import('../channels/slack/dispatch');
+
+// Extract a whole top-level function body. Fixed-length slices (…, i + 2600)
+// silently stop reaching their assertions the moment the function grows, which
+// is exactly what happened when link-bot learned to resolve names: three tests
+// went red without the behaviour changing at all.
+function fnBody(src: string, name: string): string {
+  const i = src.indexOf(`async function ${name}`);
+  if (i < 0) return '';
+  const nextFn = src.indexOf('\nasync function ', i + 1);
+  const nextTop = src.indexOf('\nfunction ', i + 1);
+  const ends = [nextFn, nextTop, src.length].filter((n) => n > 0);
+  return src.slice(i, Math.min(...ends));
+}
+
 
 const BOT = 'B1';
 const ev = (e: Record<string, unknown>) => ({ type: 'message', ...e }) as any;
@@ -218,8 +233,8 @@ describe('a bot sender is never sent an identity prompt', () => {
     expect(cmds, 'the only way to make a bot resolvable is gone').toContain("case 'link-bot':");
     expect(cmds, 'link-bot must write the same chat_user_identities row /login does')
       .toContain('await linkSlackIdentity({ teamId: ctx.teamId, slackUserId: botUserId, userId: me.userId });');
-    const h = cmds.slice(cmds.indexOf('async function slashLinkBot'));
-    expect(h.slice(0, 1600), 'linking a bot must stay owner/admin gated — any app in the channel is a non-member')
+    const h = fnBody(cmds, 'slashLinkBot');
+    expect(h, 'linking a bot must stay owner/admin gated — any app in the channel is a non-member')
       .toContain('canManageSlackPolicy');
   });
 });
@@ -235,7 +250,7 @@ describe('a bot sender is never sent an identity prompt', () => {
 
 describe('link-bot refuses anything that is not a verified bot', () => {
   const cmds = readFileSync(join(import.meta.dir, '..', 'channels', 'slack', 'commands.ts'), 'utf8');
-  const handler = cmds.slice(cmds.indexOf('async function slashLinkBot'), cmds.indexOf('async function slashLinkBot') + 2600);
+  const handler = fnBody(cmds, 'slashLinkBot');
 
   test('Slack is asked whether the target is a bot, BEFORE the link is written', () => {
     const askedAt = handler.indexOf('isBotUser(');
@@ -269,5 +284,36 @@ describe('link-bot refuses anything that is not a verified bot', () => {
     expect(branch, 'a failed users.info must be null (unknown) — false would read as "a human", and refuse every bot')
       .toContain('return null;');
     expect(branch, 'never answer false/true from a failed lookup').not.toMatch(/return (false|true);/);
+  });
+});
+
+// ── the usage that could not work ───────────────────────────────────────────
+//
+// The slash command is registered should_escape:false, so Slack sends
+// "@Incident reporter" LITERALLY — never <@U…>. v1 accepted only an id and its
+// usage text said `link-bot @TheBot`: it documented the single form that cannot
+// work, and that is exactly what came back in the channel.
+
+describe('link-bot accepts what an operator will actually type', () => {
+  const cmds = readFileSync(join(import.meta.dir, '..', 'channels', 'slack', 'commands.ts'), 'utf8');
+  const h = fnBody(cmds, 'slashLinkBot');
+
+  test('a plain name is resolved, not rejected', () => {
+    expect(h, 'a bare name must be looked up — Slack never expands it to <@U…>')
+      .toContain('findBotUserIdByName(token, raw)');
+  });
+
+  test('the failure message tells you where to get a member ID', () => {
+    expect(h, 'usage must not point at a form that cannot work').not.toContain('link-bot @TheBot');
+    expect(h, 'give the operator the copy-member-ID path').toContain('Copy member ID');
+  });
+
+  test('name resolution still goes through the is-a-bot check', () => {
+    // Resolving by name must not become a second, unguarded way in.
+    const byName = h.indexOf('findBotUserIdByName');
+    const verify = h.indexOf('isBotUser(');
+    const write  = h.indexOf('await linkSlackIdentity(');
+    expect(byName).toBeLessThan(verify);
+    expect(verify).toBeLessThan(write);
   });
 });

--- a/apps/api/src/__tests__/unit-slack-classify-event.test.ts
+++ b/apps/api/src/__tests__/unit-slack-classify-event.test.ts
@@ -58,6 +58,7 @@ mock.module('../channels/slack-api', () => ({
   deleteMessage: async () => {},
   getChannelName: async () => 'general',
   isBotUser: async () => true,
+  findBotUserIdByName: async () => null,
   joinChannel: async () => true,
   openDmChannel: async () => 'D1',
   postEphemeral: async () => true,

--- a/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
+++ b/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
@@ -139,6 +139,7 @@ mock.module('../channels/slack-api', () => ({
   deleteMessage: async () => {},
   getChannelName: async () => 'general',
   isBotUser: async () => true,
+  findBotUserIdByName: async () => null,
   joinChannel: async () => true,
   openDmChannel: async () => 'D1',
   postBlocks: async () => 'ts',

--- a/apps/api/src/__tests__/unit-slack-session-selection.test.ts
+++ b/apps/api/src/__tests__/unit-slack-session-selection.test.ts
@@ -142,6 +142,7 @@ mock.module('../channels/slack-api', () => ({
   deleteMessage: async () => {},
   getChannelName: async () => 'general',
   isBotUser: async () => true,
+  findBotUserIdByName: async () => null,
   joinChannel: async () => true,
   openDmChannel: async () => 'D1',
   postBlocks: async () => 'ts',

--- a/apps/api/src/channels/slack-api.ts
+++ b/apps/api/src/channels/slack-api.ts
@@ -448,6 +448,47 @@ export async function publishHomeView(
   }
 }
 
+// Resolve a bot by the name a human would type, e.g. "Incident reporter".
+//
+// The slash command is registered with should_escape:false, so Slack sends the
+// LITERAL text "@Incident reporter" — never <@U…>. Telling an operator to type
+// the thing Slack will not encode is how `link-bot @TheBot` shipped as usage
+// that could not work.
+//
+// Bots only: this feeds link-bot, and returning a human here would hand that
+// person's identity to whoever ran the command. An ambiguous match returns null
+// rather than guessing — two apps with the same display name is a bad reason to
+// bind the wrong one.
+//
+// One page of 1000 covers any workspace this is plausible in; beyond that the
+// operator can paste the member ID, which always works.
+export async function findBotUserIdByName(token: string, name: string): Promise<string | null> {
+  const want = name.trim().replace(/^@/, '').toLowerCase();
+  if (!want) return null;
+  try {
+    const r = await slackApiCall(token, 'users.list', { limit: 1000 });
+    if (!r.ok) {
+      console.warn('[slack-api] users.list failed', { error: r.error });
+      return null;
+    }
+    const members = (r.members ?? []) as Array<{
+      id?: string; name?: string; deleted?: boolean;
+      is_bot?: boolean; is_app_user?: boolean;
+      profile?: { display_name?: string; real_name?: string };
+    }>;
+    const hits = members.filter((m) => {
+      if (m.deleted || !m.id) return false;
+      if (!m.is_bot && !m.is_app_user) return false;
+      return [m.name, m.profile?.display_name, m.profile?.real_name]
+        .some((n) => (n ?? '').trim().toLowerCase() === want);
+    });
+    return hits.length === 1 ? hits[0]!.id! : null;
+  } catch (err) {
+    console.warn('[slack-api] users.list error', err);
+    return null;
+  }
+}
+
 // Is this Slack principal an app/bot rather than a person?
 //
 // `link-bot` writes the (workspace, slack_user) -> kortix_user row that

--- a/apps/api/src/channels/slack/commands.ts
+++ b/apps/api/src/channels/slack/commands.ts
@@ -16,7 +16,7 @@ import { listPickerModels, labelForModelRef } from '../../llm-gateway/models/pic
 import { isModelServableForAccount, resolveEffectiveModel } from '../../llm-gateway/resolution/default-model';
 import { chooseEffectiveAgent, toOpencodeModelRef, toWireModel } from '../../llm-gateway/resolution/effective';
 import { buildSlackLoginUrl } from './login';
-import { isBotUser } from '../slack-api';
+import { findBotUserIdByName, isBotUser } from '../slack-api';
 import { loadSlackTokenForProject } from '../install-store';
 import { linkSlackIdentity, lookupSlackIdentity, revokeSlackIdentity } from './identity';
 import { conversationPolicyLabel, normalizeConversationPolicy } from './participants';
@@ -697,14 +697,34 @@ async function slashLinkBot(ctx: SlashCtx, arg: string): Promise<SlashResponse> 
   if (!selection?.projectId) {
     return { response_type: 'ephemeral', text: `No project bound to this channel. Run \`${ctx.command} switch\` first.` };
   }
-  // Accept a raw id or a pasted <@U…> mention — Slack expands the latter as you type.
-  const botUserId = arg.trim().replace(/^<@|[|>].*$/g, '').toUpperCase();
-  if (!/^[UWB][A-Z0-9]{6,}$/.test(botUserId)) {
-    return { response_type: 'ephemeral', text: `Usage: \`${ctx.command} link-bot @TheBot\` — the bot whose @-mentions of Kortix should run.` };
-  }
   const me = await lookupSlackIdentity(ctx.teamId, ctx.slackUserId);
   if (!me) {
     return { response_type: 'ephemeral', text: `Connect your own Kortix account first: \`${ctx.command} login\`.` };
+  }
+  const token = await loadSlackTokenForProject(selection.projectId);
+  if (!token) {
+    return { response_type: 'ephemeral', text: 'Slack is not fully connected for this project yet.' };
+  }
+  // THREE INPUT FORMS, because only one of them is what an operator will type.
+  // The slash command is registered should_escape:false, so Slack sends
+  // "@Incident reporter" LITERALLY — it is never expanded to <@U…>. The first
+  // version of this accepted only an id and its usage text said `link-bot
+  // @TheBot`, i.e. it documented the one form that cannot work. Reported from
+  // the channel: "Usage: ..." came back for exactly that.
+  const raw = arg.trim();
+  let botUserId = raw.replace(/^<@|[|>].*$/g, '').toUpperCase();
+  if (!/^[UWB][A-Z0-9]{6,}$/.test(botUserId)) {
+    const byName = await findBotUserIdByName(token, raw);
+    if (!byName) {
+      return {
+        response_type: 'ephemeral',
+        text: `Couldn't find a bot called \`${raw || '…'}\`.\n`
+          + `Try the member ID instead: open the bot's profile → **⋮** → *Copy member ID*, then `
+          + `\`${ctx.command} link-bot U01234ABCDE\`.\n`
+          + `_(Typing @Name works only if the name matches exactly — Slack sends it to this command as plain text, not a mention.)_`,
+      };
+    }
+    botUserId = byName;
   }
   if (!(await canManageSlackPolicy(ctx, selection.projectId))) {
     return { response_type: 'ephemeral', text: 'Only a linked Kortix account owner or admin for this project can link a bot.' };
@@ -719,8 +739,7 @@ async function slashLinkBot(ctx: SlashCtx, arg: string): Promise<SlashResponse> 
   if (existing && existing.userId !== me.userId) {
     return { response_type: 'ephemeral', text: `<@${botUserId}> is already linked to a different Kortix account. Have them disconnect first.` };
   }
-  const token = await loadSlackTokenForProject(selection.projectId);
-  const bot = token ? await isBotUser(token, botUserId) : null;
+  const bot = await isBotUser(token, botUserId);
   if (bot !== true) {
     // null = we could not tell (missing scope, transport error, unknown user).
     // Refuse either way: guessing is the impersonation.


### PR DESCRIPTION
Reported from the channel:

```
/kortix-dev link-bot @incident
Usage: `/kortix-dev link-bot @TheBot` — the bot whose @-mentions of Kortix should run.
```

The slash command is registered with **`should_escape: false`** (`slack-manifest.ts`), so Slack sends `@incident` as **literal text** — it is never expanded to `<@U…>`. v1 accepted only `/^[UWB][A-Z0-9]{6,}$/` and its usage string told the operator to type an `@name`: **it documented the single form that cannot work**, with no way to discover the working one.

## Now accepts all three forms

| input | result |
|---|---|
| `U01234ABCDE` | member ID |
| `<@U01234ABCDE>` | pasted mention |
| `@Incident reporter` | **resolved via `users.list`** |

New `slack-api.findBotUserIdByName()` filters to `is_bot`/`is_app_user`, matches `name` / `display_name` / `real_name` case-insensitively, and returns `null` on an **ambiguous** match rather than guessing — two apps sharing a display name is a bad reason to bind the wrong identity.

**Name resolution is not a second way in.** The resolved id still goes through `isBotUser()` and the already-linked check before anything is written — asserted by ordering (`byName < verify < write`), not by inspection.

The failure message now points at the reliable path (profile → **⋮** → *Copy member ID*) instead of repeating a form that cannot work.

## A real defect in my own tests

Three existing assertions sliced the handler by **fixed byte length** (`indexOf(...) + 2600`). Growing `slashLinkBot` pushed `canManageSlackPolicy` and `isBotUser` past the window, and three tests went red **with no behaviour change**. A fourth sliced to end-of-file, so it could have passed on a match in an unrelated later function.

Both replaced with `fnBody()`, which extracts to the next top-level function. A test whose scope depends on the length of the code it inspects is not testing what it claims.

## Testing

- 20 tests (3 new).
- Negative controls: dropping name resolution, and dropping the is-bot check — each red on its own.
- Three sibling suites needed `findBotUserIdByName` in their partial `slack-api` mock.
- **Full Slack surface: 340 pass, 0 fail.**