### PR TITLE
Never render sandbox readiness 503s as errors — waking state + retry across all surfaces

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -766,6 +766,10 @@ describe('Preview proxy: ownership', () => {
         status: 503,
         hop: 'control_plane',
         upstream_status: null,
+        // Stable machine code + retry flag: a readiness 503 is a pending
+        // state a client re-polls, never a terminal error.
+        code: 'sandbox_not_ready',
+        retry: true,
       });
     },
   );

--- a/apps/api/src/sandbox-proxy/routes/preview.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.test.ts
@@ -303,6 +303,23 @@ describe('portUnreachableResponse carries hop attribution', () => {
     });
   });
 
+  test('a readiness 503 carries the stable machine code and retry flag', async () => {
+    // Clients branch on `code`, not on the human-readable `reason` — and
+    // `retry: true` says the same request succeeds once the box is up.
+    const res = portUnreachableResponse({
+      port: 8000,
+      status: 503,
+      origin: 'https://app.kortix.test',
+      incomingHeaders: jsonHeaders,
+      reason: 'sandbox not ready (status: stopped)',
+      hop: 'control_plane',
+      code: 'sandbox_not_ready',
+      retry: true,
+    });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ code: 'sandbox_not_ready', retry: true });
+  });
+
   test('a dead daemon reports the upstream status it actually saw', async () => {
     const res = portUnreachableResponse({
       port: 8000,

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -313,8 +313,14 @@ export function portUnreachableResponse(opts: {
   reason: string;
   hop: ProxyHop;
   upstreamStatus?: number | null;
+  // Stable machine code for the failure class (e.g. 'sandbox_not_ready'), so
+  // clients branch on a code instead of matching the human-readable `reason`.
+  code?: string;
+  // True when the failure is transient by design (a parked/booting box) and a
+  // retry of the same request is expected to succeed once the box is up.
+  retry?: boolean;
 }): Response {
-  const { port, status, origin, incomingHeaders, reason, hop } = opts;
+  const { port, status, origin, incomingHeaders, reason, hop, code, retry } = opts;
   const upstreamStatus = opts.upstreamStatus ?? null;
   const headers = new Headers({ 'Cache-Control': 'no-store' });
   // Set on EVERY variant, HTML included: a `fetch` probe that lands on the
@@ -340,7 +346,15 @@ export function portUnreachableResponse(opts: {
   }
   headers.set('Content-Type', 'application/json');
   return new Response(
-    JSON.stringify({ error: reason, port, status, hop, upstream_status: upstreamStatus }),
+    JSON.stringify({
+      error: reason,
+      port,
+      status,
+      hop,
+      upstream_status: upstreamStatus,
+      ...(code ? { code } : {}),
+      ...(retry !== undefined ? { retry } : {}),
+    }),
     {
       status,
       headers,
@@ -941,6 +955,8 @@ export async function forwardToSandbox(
         // nothing about whether the runtime is reachable — a probe that counts
         // it as evidence of a dead box is counting our own answer.
         hop: 'control_plane',
+        code: 'sandbox_not_ready',
+        retry: true,
       });
     }
   }

--- a/apps/web/src/app/(public)/share/session/[token]/public-file-share-view.tsx
+++ b/apps/web/src/app/(public)/share/session/[token]/public-file-share-view.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { isSandboxNotReadyError } from '@kortix/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useState } from 'react';
@@ -56,6 +57,9 @@ function usePublicFileContent(
     staleTime: 30_000,
     refetchOnWindowFocus: false,
     retry: false,
+    // A readiness 503 (parked/booting sandbox) is a pending state, not a
+    // failure: keep polling so the shared file loads once the box is up.
+    refetchInterval: (query) => (isSandboxNotReadyError(query.state.error) ? 3_000 : false),
     queryFn: async () => {
       const res = await fetch(fileUrl, { cache: 'no-store' });
       if (!res.ok) {
@@ -94,6 +98,8 @@ function usePublicBinaryBlob(
     staleTime: 30_000,
     refetchOnWindowFocus: false,
     retry: false,
+    // Same readiness poll as usePublicFileContent above.
+    refetchInterval: (query) => (isSandboxNotReadyError(query.state.error) ? 3_000 : false),
     queryFn: async () => {
       const res = await fetch(fileUrl, { cache: 'no-store' });
       if (!res.ok) {

--- a/apps/web/src/features/file-viewer/file-content-renderer.tsx
+++ b/apps/web/src/features/file-viewer/file-content-renderer.tsx
@@ -21,7 +21,7 @@ import { getIframeSandbox } from '@/lib/security/iframe-sandbox';
 import { cn } from '@/lib/utils';
 import { isHeicFile } from '@/lib/utils/heic-convert';
 import { findDiagnosticsForFile, useDiagnosticsStore } from '@/stores/diagnostics-store';
-import { toSandboxAbsolutePath } from '@kortix/sdk';
+import { isSandboxNotReadyError, toSandboxAbsolutePath } from '@kortix/sdk';
 import { getActiveStaticFileHealthUrl, getActiveStaticFilePreviewUrl } from '@kortix/sdk/react';
 import {
   WarningIcon as AlertTriangle,
@@ -630,6 +630,12 @@ export function FileContentRenderer({
         : null;
   const showLoadingState = needsBlob ? blobLoading : isLoading;
 
+  // A readiness 503 means the sandbox is parked or still booting — a pending
+  // state, never a failure. The file hooks keep polling while this is true
+  // (SANDBOX_WAKING_REFETCH_INTERVAL_MS), so the content appears on its own
+  // once the box is up.
+  const isSandboxWaking = !!contentError && isSandboxNotReadyError(contentError);
+
   // Detect "file not found" — either via explicit error or empty resolution
   const isNotFound = useMemo(() => {
     if (contentError) return isNotFoundError(contentError);
@@ -655,9 +661,9 @@ export function FileContentRenderer({
   useEffect(() => {
     if (!onStatusChange) return;
     if (isNotFound) onStatusChange('error');
-    else if (showLoadingState) onStatusChange('loading');
+    else if (showLoadingState || isSandboxWaking) onStatusChange('loading');
     else onStatusChange('ready');
-  }, [onStatusChange, isNotFound, showLoadingState]);
+  }, [onStatusChange, isNotFound, showLoadingState, isSandboxWaking]);
 
   // An `image` that settled without an image to show: bytes whose mime is not
   // `image/*` (so `imageDataUrl` stayed null and the binary/text fallback ran
@@ -892,9 +898,29 @@ export function FileContentRenderer({
             </div>
           )}
 
+          {/* Sandbox waking — the workspace is parked or booting; the file
+              hooks keep polling and the content replaces this on its own.
+              Takes precedence over errorFallback: a waking box is not an
+              error, so no surface gets to render it as one. */}
+          {contentError && !showLoadingState && isSandboxWaking && (
+            <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
+              <Loading className="text-muted-foreground/40 h-4 w-4" />
+              <p className="text-muted-foreground text-sm font-medium">
+                Waking up the workspace…
+              </p>
+              <p className="text-muted-foreground/50 max-w-sm font-mono text-xs break-all">
+                {filePath}
+              </p>
+              <p className="text-muted-foreground/40 max-w-xs text-xs">
+                The sandbox is starting. This file will load automatically.
+              </p>
+            </div>
+          )}
+
           {/* Error */}
           {contentError &&
             !showLoadingState &&
+            !isSandboxWaking &&
             (errorFallback ? (
               errorFallback(contentError, filePath)
             ) : isNotFound ? (

--- a/apps/web/src/features/files/hooks/file-read-retry.test.ts
+++ b/apps/web/src/features/files/hooks/file-read-retry.test.ts
@@ -75,6 +75,19 @@ describe('file read retry policy', () => {
     expect(shouldRetryFileRead('/workspace/src/x.ts', 0, rateLimited)).toBe(true);
   });
 
+  test('fails fast on a sandbox readiness 503 — the waking state owns the retry', () => {
+    // The viewer renders "waking up" and the query-level poll re-reads; the
+    // inline loop must not sit on the error burning its retry budget first.
+    const parked = Object.assign(new Error('sandbox not ready (status: stopped)'), {
+      status: 503,
+    });
+    expect(shouldRetryFileRead('/workspace/src/x.ts', 0, parked)).toBe(false);
+    expect(shouldRetryFileRead('/workspace/uploads/report.pdf', 0, parked)).toBe(false);
+    expect(shouldRetryFileRead('/workspace/src/x.ts', 0, new Error('Sandbox is not ready'))).toBe(
+      false,
+    );
+  });
+
   test('uses a fixed uploaded-file retry delay without changing normal backoff', () => {
     expect(fileReadRetryDelayMs(4, '/workspace/uploads/report.pdf')).toBe(
       UPLOADED_FILE_READ_RETRY_DELAY_MS,

--- a/apps/web/src/features/files/hooks/file-read-retry.ts
+++ b/apps/web/src/features/files/hooks/file-read-retry.ts
@@ -1,3 +1,5 @@
+import { isSandboxNotReadyError } from '@kortix/sdk';
+
 export const UPLOADED_FILE_READ_RETRY_DELAY_MS = 2_000;
 export const UPLOADED_FILE_READ_RETRY_WINDOW_MS = 60_000;
 export const UPLOADED_FILE_READ_MAX_RETRIES = Math.ceil(
@@ -74,11 +76,23 @@ function isMissingFileReadFailure(error: unknown): boolean {
   );
 }
 
+// How often a file query re-polls while the sandbox reports a readiness 503
+// ("sandbox not ready (status: …)"). The control plane answers these without
+// dialling the box, so the poll is cheap; the query keeps polling until the
+// box is active and the file loads on its own.
+export const SANDBOX_WAKING_REFETCH_INTERVAL_MS = 3_000;
+
 export function shouldRetryFileRead(
   filePath: string | null | undefined,
   failureCount: number,
   error: unknown,
 ): boolean {
+  // A parked/booting sandbox is not a failed read. Fail fast out of the inline
+  // retry loop so the viewer can render its "waking up" state immediately; the
+  // query-level poll (SANDBOX_WAKING_REFETCH_INTERVAL_MS) re-reads until the
+  // sandbox is back.
+  if (isSandboxNotReadyError(error)) return false;
+
   if (isUploadedWorkspacePath(filePath)) {
     if (isPermanentFileReadFailure(error) && !isMissingFileReadFailure(error)) return false;
     return failureCount < UPLOADED_FILE_READ_MAX_RETRIES;

--- a/apps/web/src/features/files/hooks/use-binary-blob.ts
+++ b/apps/web/src/features/files/hooks/use-binary-blob.ts
@@ -1,10 +1,12 @@
 'use client';
 
+import { isSandboxNotReadyError } from '@kortix/sdk';
 import { useRuntimeStore } from '@kortix/sdk/react';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import { readRuntimeFileWithRetry } from '../api/runtime-file-read';
 import { readFileAsBlob } from '../api/runtime-files';
+import { SANDBOX_WAKING_REFETCH_INTERVAL_MS } from './file-read-retry';
 
 // ── Query keys ─────────────────────────────────────────────────────────────
 
@@ -64,6 +66,11 @@ export function useBinaryBlob(filePath: string | null): {
     gcTime: 5 * 60_000,
     refetchOnWindowFocus: false,
     retry: false,
+    // A readiness 503 (parked/booting sandbox) is a pending state, not a
+    // failure: keep polling until the box is active so the blob loads on its
+    // own once the sandbox wakes.
+    refetchInterval: (query) =>
+      isSandboxNotReadyError(query.state.error) ? SANDBOX_WAKING_REFETCH_INTERVAL_MS : false,
   });
 
   const cachedBlob = query.data ?? null;

--- a/apps/web/src/features/files/hooks/use-file-content.ts
+++ b/apps/web/src/features/files/hooks/use-file-content.ts
@@ -1,10 +1,12 @@
 'use client';
 
 import type { FileContent } from '@/features/file-browser/types';
+import { isSandboxNotReadyError } from '@kortix/sdk';
 import { useRuntimeStore } from '@kortix/sdk/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { readRuntimeFileWithRetry } from '../api/runtime-file-read';
 import { readFile } from '../api/runtime-files';
+import { SANDBOX_WAKING_REFETCH_INTERVAL_MS } from './file-read-retry';
 import { isSystemDirectoryPath } from './system-dir';
 
 export const fileContentKeys = {
@@ -34,6 +36,11 @@ export function useFileContent(
     gcTime: 5 * 60_000,
     refetchOnWindowFocus: false,
     retry: false,
+    // A readiness 503 (parked/booting sandbox) is a pending state, not a
+    // failure: keep polling until the box is active so the file loads on its
+    // own once the sandbox wakes.
+    refetchInterval: (query) =>
+      isSandboxNotReadyError(query.state.error) ? SANDBOX_WAKING_REFETCH_INTERVAL_MS : false,
   });
 }
 

--- a/apps/web/src/features/project-files/components/drive-explorer.tsx
+++ b/apps/web/src/features/project-files/components/drive-explorer.tsx
@@ -27,6 +27,7 @@ import {
   FolderPlusIcon as FolderPlus,
   UploadIcon as Upload,
 } from '@phosphor-icons/react';
+import { isSandboxNotReadyError } from '@kortix/sdk';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useFileExplorerSource } from '../explorer-source';
@@ -118,6 +119,16 @@ export function DriveExplorer({
     error,
     refetch: refetchFiles,
   } = source.useFileList(currentPath);
+
+  // A readiness 503 means the sandbox is parked or booting — a pending state,
+  // never a failure. Keep polling until the box is up so the listing appears
+  // on its own.
+  const sandboxWaking = !!error && isSandboxNotReadyError(error);
+  useEffect(() => {
+    if (!sandboxWaking) return;
+    const interval = window.setInterval(() => void refetchFiles(), 3_000);
+    return () => window.clearInterval(interval);
+  }, [sandboxWaking, refetchFiles]);
 
   const { data: gitStatuses } = source.useGitStatus();
   const gitStatusMap = useMemo(() => buildGitStatusMap(gitStatuses), [gitStatuses]);
@@ -777,19 +788,31 @@ export function DriveExplorer({
             </div>
           )}
 
-          {!!error && !isLoading && (
-            <ErrorState
-              title={tHardcodedUi.raw(
-                'featuresProjectFilesComponentsFileExplorerPage.line658JsxTextFailedToLoadFiles',
-              )}
-              description={error instanceof Error ? error.message : 'Unknown error'}
-              action={
-                <Button variant="outline" size="sm" onClick={() => refetchFiles()}>
-                  Retry
-                </Button>
-              }
-            />
-          )}
+          {!!error &&
+            !isLoading &&
+            (sandboxWaking ? (
+              <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+                <Loading className="text-muted-foreground/40 h-4 w-4" />
+                <p className="text-muted-foreground text-sm font-medium">
+                  Waking up the workspace…
+                </p>
+                <p className="text-muted-foreground/40 max-w-xs text-xs">
+                  The sandbox is starting. Files will appear automatically.
+                </p>
+              </div>
+            ) : (
+              <ErrorState
+                title={tHardcodedUi.raw(
+                  'featuresProjectFilesComponentsFileExplorerPage.line658JsxTextFailedToLoadFiles',
+                )}
+                description={error instanceof Error ? error.message : 'Unknown error'}
+                action={
+                  <Button variant="outline" size="sm" onClick={() => refetchFiles()}>
+                    Retry
+                  </Button>
+                }
+              />
+            ))}
 
           {isEmpty && (
             <EmptyState

--- a/apps/web/src/features/session/action-panel/easy/file-preview.tsx
+++ b/apps/web/src/features/session/action-panel/easy/file-preview.tsx
@@ -35,6 +35,7 @@ import {
   useKortixComputerStore,
   useToggleExpanded,
 } from '@/stores/kortix-computer-store';
+import { isSandboxNotReadyError } from '@kortix/sdk';
 import { useRuntimeConnectionStore } from '@kortix/sdk/react';
 import {
   CheckIcon as Check,
@@ -395,7 +396,12 @@ export function FilePreview({
 
   // The rich renderers fetch their own bytes (and stream the big ones), so
   // pulling the whole file into a string here first would be wasted work.
-  const { data, isLoading, isError } = useFileContent(path, { enabled: !rich });
+  const { data, isLoading, isError, error } = useFileContent(path, { enabled: !rich });
+
+  // A readiness 503 means the sandbox is parked or booting — a pending state,
+  // never a failure. `useFileContent` keeps polling while this is true, so the
+  // content replaces the waking notice on its own.
+  const sandboxWaking = isError && isSandboxNotReadyError(error);
 
   // A file that cannot be opened has no shape, and `openDetail` no longer
   // clears the ratio on the way in for anything that CAN measure (see
@@ -487,12 +493,21 @@ export function FilePreview({
         onPresent={onPresent}
       >
         <Centered>
-          <FileWarning className="size-5" />
-          <span>
-            {!sandboxAlive
-              ? "This session's workspace has ended, so its files can't be opened anymore."
-              : "This file couldn't be opened."}
-          </span>
+          {sandboxWaking ? (
+            <>
+              <Loading className="size-5" />
+              <span>Waking up the workspace… this file will load automatically.</span>
+            </>
+          ) : (
+            <>
+              <FileWarning className="size-5" />
+              <span>
+                {!sandboxAlive
+                  ? "This session's workspace has ended, so its files can't be opened anymore."
+                  : "This file couldn't be opened."}
+              </span>
+            </>
+          )}
         </Centered>
       </PreviewShell>
     );

--- a/apps/web/src/features/session/pty-connection.test.ts
+++ b/apps/web/src/features/session/pty-connection.test.ts
@@ -61,6 +61,17 @@ describe('deriveTerminalPanelState', () => {
     expect(deriveTerminalPanelState({ ...readyInput, isCreateError: true })).toBe('error');
   });
 
+  test('holds the connecting state while the failure is a sandbox readiness 503', () => {
+    // A parked/booting box answers list/create with "sandbox not ready" — a
+    // pending state, never a terminal error card.
+    expect(
+      deriveTerminalPanelState({ ...readyInput, isListError: true, isSandboxWaking: true }),
+    ).toBe('connecting');
+    expect(
+      deriveTerminalPanelState({ ...readyInput, isCreateError: true, isSandboxWaking: true }),
+    ).toBe('connecting');
+  });
+
   test('keeps an existing terminal visible during background query failures', () => {
     expect(deriveTerminalPanelState({ ...readyInput, hasPty: true, isListError: true })).toBe(
       'terminal',

--- a/apps/web/src/features/session/pty-connection.ts
+++ b/apps/web/src/features/session/pty-connection.ts
@@ -11,10 +11,16 @@ export function deriveTerminalPanelState(input: {
   isCreatePending: boolean;
   isCreateError: boolean;
   isEnsuring: boolean;
+  /** The list/create failure is a sandbox readiness 503 (parked or booting
+   *  box) — a pending state the panel must keep waiting through, never render
+   *  as a terminal error. */
+  isSandboxWaking?: boolean;
 }): TerminalPanelState {
   if (input.hasPty) return 'terminal';
   if (!input.hasServerUrl) return input.serverWaitExpired ? 'error' : 'connecting';
-  if (input.isListError || input.isCreateError) return 'error';
+  if (input.isListError || input.isCreateError) {
+    return input.isSandboxWaking ? 'connecting' : 'error';
+  }
   if (input.isListLoading || input.isCreatePending || input.isEnsuring) return 'connecting';
   return 'empty';
 }

--- a/apps/web/src/features/session/sandbox-image.tsx
+++ b/apps/web/src/features/session/sandbox-image.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 
 import { useFileContent } from '@/features/files/hooks/use-file-content';
+import { isSandboxNotReadyError } from '@kortix/sdk';
 import { ImagePreview } from '@/features/session/image-preview';
 import { cn } from '@/lib/utils';
 import { useEffect, useMemo, useState } from 'react';
@@ -39,7 +40,11 @@ export function useSandboxImageSrc(src: string): {
     return src.replace(/^\/workspace\//, '');
   }, [isLocalPath, src]);
 
-  const { data: fileContentData, isLoading } = useFileContent(fileContentPath, {
+  const {
+    data: fileContentData,
+    isLoading,
+    error,
+  } = useFileContent(fileContentPath, {
     enabled: !!fileContentPath,
   });
 
@@ -64,7 +69,12 @@ export function useSandboxImageSrc(src: string): {
 
   return {
     resolvedSrc: isLocalPath ? blobUrl : src,
-    isLoading: isLocalPath && (isLoading || (hasBase64 && !blobUrl)),
+    // A readiness 503 (parked/booting sandbox) counts as loading, not failure:
+    // useFileContent keeps polling while it lasts, so the image resolves on
+    // its own once the box is up — meanwhile show the skeleton, never the
+    // "Image unavailable" box.
+    isLoading:
+      isLocalPath && (isLoading || (hasBase64 && !blobUrl) || isSandboxNotReadyError(error)),
   };
 }
 

--- a/apps/web/src/features/session/session-terminal-panel.tsx
+++ b/apps/web/src/features/session/session-terminal-panel.tsx
@@ -8,6 +8,7 @@ import {
   deriveTerminalPanelState,
   shouldAutoReplaceTerminal,
 } from '@/features/session/pty-connection';
+import { isSandboxNotReadyError } from '@kortix/sdk';
 import { useCreatePty, useRuntimePtyList, type Pty } from '@kortix/sdk/react';
 import { useRuntimeStore } from '@kortix/sdk/react';
 import { useSessionBrowserStore } from '@/stores/session-browser-store';
@@ -25,6 +26,10 @@ const PtyTerminal = dynamic(
 
 const PTY_ENV = { TERM: 'xterm-256color', COLORTERM: 'truecolor' } as const;
 const SERVER_URL_WAIT_MS = 15_000;
+// How often to retry PTY list/create while the sandbox reports a readiness
+// 503 (parked or booting box). The control plane answers without dialling
+// the box, so the poll is cheap.
+const SANDBOX_WAKING_RETRY_INTERVAL_MS = 3_000;
 
 /**
  * Live terminal for the session side panel — a {@link PtyTerminal} bound to
@@ -53,6 +58,7 @@ export function SessionTerminalPanel({
     data: ptys,
     isLoading,
     isError: isListError,
+    error: listError,
     refetch: refetchPtys,
   } = useRuntimePtyList({ serverUrl, enabled: !!serverUrl });
   // Failures surface in the pane (retry button / reconnect flow) — keep them
@@ -149,6 +155,26 @@ export function SessionTerminalPanel({
     ensurePty();
   }, [createPty, ensurePty, isListError, refetchPtys, serverUrl]);
 
+  // A parked/booting sandbox answers PTY list/create with a readiness 503 —
+  // a pending state, never a terminal error. Keep the connecting spinner and
+  // retry on an interval until the box is up.
+  const sandboxWaking =
+    (isListError && isSandboxNotReadyError(listError)) ||
+    (createPty.isError && isSandboxNotReadyError(createPty.error));
+
+  const retryTerminalRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    retryTerminalRef.current = retryTerminal;
+  }, [retryTerminal]);
+  useEffect(() => {
+    if (!sandboxWaking) return;
+    const interval = window.setInterval(
+      () => retryTerminalRef.current(),
+      SANDBOX_WAKING_RETRY_INTERVAL_MS,
+    );
+    return () => window.clearInterval(interval);
+  }, [sandboxWaking]);
+
   const panelState = deriveTerminalPanelState({
     hasServerUrl: !!serverUrl,
     serverWaitExpired,
@@ -158,6 +184,7 @@ export function SessionTerminalPanel({
     isCreatePending: createPty.isPending,
     isCreateError: createPty.isError,
     isEnsuring: ensuringRef.current,
+    isSandboxWaking: sandboxWaking,
   });
 
   let content: React.ReactNode;
@@ -166,7 +193,11 @@ export function SessionTerminalPanel({
       <div className="flex h-full w-full flex-col items-center justify-center">
         <Loading className="text-muted-foreground size-4" />
         <span className="text-muted-foreground mt-2 text-xs">
-          {tI18nHardcoded.raw('autoFeaturesSessionSessionTerminalPanelJsxTextConnecting80303e70')}
+          {sandboxWaking
+            ? 'Waking up the workspace…'
+            : tI18nHardcoded.raw(
+                'autoFeaturesSessionSessionTerminalPanelJsxTextConnecting80303e70',
+              )}
         </span>
       </div>
     );

--- a/apps/web/src/features/session/tool/tools/image-gen-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/image-gen-tool.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { TextShimmer } from '@/components/ui/text-shimmer';
 import { useFileContent } from '@/features/files/hooks/use-file-content';
+import { isSandboxNotReadyError } from '@kortix/sdk';
 import { parseImageOutput } from '@/features/session/image-output-path';
 import {
   BasicTool,
@@ -37,9 +38,16 @@ export function ImageGenTool({ part, defaultOpen, forceOpen, locked }: ToolProps
     if (!isLocalPath || !imagePath || directUrl) return null;
     return imagePath.replace(/^\/workspace\//, '');
   }, [isLocalPath, imagePath, directUrl]);
-  const { data: fileContentData, isLoading: isImageLoading } = useFileContent(fileContentPath, {
+  const {
+    data: fileContentData,
+    isLoading: isQueryLoading,
+    error: fileContentError,
+  } = useFileContent(fileContentPath, {
     enabled: !!fileContentPath,
   });
+  // A readiness 503 (parked/booting sandbox) counts as loading: useFileContent
+  // keeps polling while it lasts, so the image resolves once the box is up.
+  const isImageLoading = isQueryLoading || isSandboxNotReadyError(fileContentError);
 
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   useEffect(() => {

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,9 +12,11 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
-### 2026-08-19 — session `sandbox-waking` — additive: `isSandboxNotReadyError` classifier + `formatOpenCodeRuntimeError` covers every readiness phrase — IN PROGRESS
+### 2026-08-19 — session `sandbox-waking` — additive: `isSandboxNotReadyError` classifier + `formatOpenCodeRuntimeError` covers every readiness phrase — DONE
 
-**Files:** `core/http/opencode-errors.ts` + `opencode-errors.test.ts`, surface snapshots.
+**Files:** `core/http/opencode-errors.ts` + `opencode-errors.test.ts`, surface snapshots
+(additive: `isSandboxNotReadyError` on the root barrel via the existing
+`export * from './core/http/opencode-errors'`).
 
 **Why.** The web file viewer (and terminal panel, drive explorer, public share)
 render the proxy's `sandbox not ready (status: stopped)` 503 as a terminal red
@@ -24,6 +26,23 @@ error. The proxy emits several readiness phrases (`sandbox not ready`,
 classified today, and only by `formatOpenCodeRuntimeError`. Hosts need one
 boolean classifier so every surface can show "waking up" + retry instead of an
 error card.
+
+**What.** `isSandboxNotReadyError(error)` — accepts an `Error`, a raw message
+string, or a JSON body containing one; matches every readiness phrase listed
+above. `sandbox port unreachable` is deliberately excluded (emitted only after
+the box reported active — a genuine failure). `formatOpenCodeRuntimeError` now
+routes its waking branch through the classifier instead of the exact
+`(status: stopped)` regex. TDD: 4 new tests seen RED
+(`Export named 'isSandboxNotReadyError' not found`) before implementation.
+
+**Gates.**
+
+```
+pnpm --filter @kortix/sdk typecheck       → clean
+pnpm --filter @kortix/sdk test            → 2324 pass, 2 skip, 0 fail, 158 files
+                                            (baseline before this change: 2320 / 2 / 0, 158 files)
+pnpm --filter @kortix/sdk smoke:install   → ✔ install smoke test passed
+```
 
 ---
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,21 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-19 — session `sandbox-waking` — additive: `isSandboxNotReadyError` classifier + `formatOpenCodeRuntimeError` covers every readiness phrase — IN PROGRESS
+
+**Files:** `core/http/opencode-errors.ts` + `opencode-errors.test.ts`, surface snapshots.
+
+**Why.** The web file viewer (and terminal panel, drive explorer, public share)
+render the proxy's `sandbox not ready (status: stopped)` 503 as a terminal red
+error. The proxy emits several readiness phrases (`sandbox not ready`,
+`Sandbox is not ready`, `Sandbox is not running`, `opencode not ready`,
+`sandbox_lifecycle_unavailable`); only the exact `(status: stopped)` string is
+classified today, and only by `formatOpenCodeRuntimeError`. Hosts need one
+boolean classifier so every surface can show "waking up" + retry instead of an
+error card.
+
+---
+
 ### 2026-08-19 — session `rbac-cutover-client-leftovers` — BREAKING (field): `AccountDetail.iam_v2_enabled` removed — DONE
 
 **Files:** `core/rest/projects-client/accounts.ts` (−1 field, −3 comment lines),

--- a/packages/sdk/src/core/http/opencode-errors.test.ts
+++ b/packages/sdk/src/core/http/opencode-errors.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'bun:test';
-import { formatOpenCodeRuntimeError } from './opencode-errors';
+import { formatOpenCodeRuntimeError, isSandboxNotReadyError } from './opencode-errors';
 
 // Both inputs below are constructed as real `Error` instances — that is the
 // ONLY shape `formatOpenCodeRuntimeError` is ever actually called with.
@@ -20,6 +20,88 @@ test('a stopped-sandbox 503 is dormancy, not an OpenCode failure', () => {
   const formatted = formatOpenCodeRuntimeError(new Error('sandbox not ready (status: stopped)'));
   expect(formatted.title).toBe('Session is waking up');
   expect(formatted.title).not.toBe('OpenCode failed to load');
+});
+
+// ── isSandboxNotReadyError ──────────────────────────────────────────────────
+// One phrase per production site in apps/api. Each is a readiness state the
+// control plane reports on purpose — never a crash — so a UI must show
+// "waking up" and keep polling, not a terminal error card.
+
+test('classifies every proxy readiness phrase as sandbox-not-ready', () => {
+  const readiness = [
+    // sandbox-proxy/routes/preview.ts — `sandbox not ready (status: ${record.status})`
+    'sandbox not ready (status: stopped)',
+    'sandbox not ready (status: starting)',
+    'sandbox not ready (status: archived)',
+    // preview.ts WebSocket resolver — bare phrase, no status suffix
+    'sandbox not ready',
+    // sandbox-proxy/routes/public-share.ts
+    'Sandbox is not running',
+    // public-session-shares + shared/session-public-shares
+    'Sandbox is not ready',
+    // daemon 503 passed through while OpenCode itself is still booting
+    'opencode not ready',
+    // projects/lib/session-transcript.ts + shared/public-session-share-view.ts
+    'OpenCode session not ready in the sandbox',
+    'OpenCode not ready in the sandbox',
+    'OpenCode is not ready in the sandbox yet',
+    // stable machine codes on 503 bodies (preview.ts)
+    'sandbox_not_ready',
+    'sandbox_lifecycle_unavailable',
+  ];
+  for (const phrase of readiness) {
+    expect({ phrase, notReady: isSandboxNotReadyError(new Error(phrase)) }).toEqual({
+      phrase,
+      notReady: true,
+    });
+  }
+});
+
+test('accepts the raw string and JSON-wrapped bodies, not just Error instances', () => {
+  // Public share view throws `new Error(text)` where text is the whole 503
+  // JSON body — the phrase survives inside it.
+  expect(isSandboxNotReadyError('sandbox not ready (status: stopped)')).toBe(true);
+  expect(
+    isSandboxNotReadyError(
+      new Error('{"error":"Sandbox is not ready","status":503}'),
+    ),
+  ).toBe(true);
+});
+
+test('does not classify genuine failures as sandbox-not-ready', () => {
+  const genuine = [
+    'file not found',
+    'Path is a directory',
+    // Box is active but the port never answered — a real failure, not parking.
+    'sandbox port unreachable',
+    'OpenCode failed to load',
+    'Internal Server Error',
+    '',
+    // Mentions "stopped" without being the readiness phrase.
+    'process stopped unexpectedly',
+  ];
+  for (const phrase of genuine) {
+    expect({ phrase, notReady: isSandboxNotReadyError(new Error(phrase)) }).toEqual({
+      phrase,
+      notReady: false,
+    });
+  }
+  expect(isSandboxNotReadyError(null)).toBe(false);
+  expect(isSandboxNotReadyError(undefined)).toBe(false);
+});
+
+test('formatOpenCodeRuntimeError treats every readiness phrase as waking, not just status: stopped', () => {
+  for (const phrase of [
+    'sandbox not ready (status: starting)',
+    'sandbox not ready',
+    'Sandbox is not ready',
+  ]) {
+    const formatted = formatOpenCodeRuntimeError(new Error(phrase));
+    expect({ phrase, title: formatted.title }).toEqual({
+      phrase,
+      title: 'Session is waking up',
+    });
+  }
 });
 
 test('a genuine config error keeps its own title', () => {

--- a/packages/sdk/src/core/http/opencode-errors.ts
+++ b/packages/sdk/src/core/http/opencode-errors.ts
@@ -59,6 +59,40 @@ export function isOpenCodeConfigInvalidError(error: unknown): boolean {
   return getOpenCodeConfigInvalidError(error) !== null;
 }
 
+// Every readiness phrase the API can answer with while a sandbox (or the
+// OpenCode server inside it) is provisioning, resuming, or parked. Each line
+// maps to a production site in apps/api:
+//   - `sandbox not ready (status: X)` / bare `sandbox not ready`
+//     → sandbox-proxy/routes/preview.ts (HTTP proxy + WebSocket resolver)
+//   - `Sandbox is not running` → sandbox-proxy/routes/public-share.ts
+//   - `Sandbox is not ready` → public-session-shares, shared/session-public-shares
+//   - `opencode … not ready` → daemon 503 pass-through, session-transcript,
+//     public-session-share-view
+//   - `sandbox_not_ready`, `sandbox_lifecycle_unavailable` → machine codes on
+//     503 bodies from the sandbox proxy
+// Deliberately NOT here: `sandbox port unreachable` — that is emitted only
+// after the box reported active and the port still failed to answer, which is
+// a genuine failure, not parking.
+const SANDBOX_NOT_READY_PATTERNS: readonly RegExp[] = [
+  /sandbox not ready/i,
+  /sandbox is not (?:ready|running)/i,
+  /opencode (?:session )?(?:is )?not ready/i,
+  /\bsandbox_not_ready\b/,
+  /\bsandbox_lifecycle_unavailable\b/,
+];
+
+/**
+ * True when an error means "the sandbox is still starting / parked", i.e. a
+ * readiness state the control plane reports on purpose. A UI must render this
+ * as a pending "waking up" state and keep polling — never as a terminal error.
+ * Accepts an `Error`, the raw message string, or a JSON body containing one.
+ */
+export function isSandboxNotReadyError(error: unknown): boolean {
+  const raw = rawErrorMessage(error);
+  if (!raw) return false;
+  return SANDBOX_NOT_READY_PATTERNS.some((pattern) => pattern.test(raw));
+}
+
 export function formatOpenCodeRuntimeError(error: unknown): {
   title: string;
   message: string;
@@ -83,20 +117,19 @@ export function formatOpenCodeRuntimeError(error: unknown): {
 
   const raw = rawErrorMessage(error);
 
-  // A parked box is not a crash. The proxy answers `sandbox not ready
-  // (status: stopped)` for a sandbox the control plane stopped ON PURPOSE to
-  // save compute, and the conversation is intact behind it. Reserve "OpenCode
-  // failed to load" for a runtime that genuinely broke.
+  // A parked or still-provisioning box is not a crash. The proxy answers with
+  // a readiness phrase for a sandbox the control plane stopped ON PURPOSE to
+  // save compute (or has not finished booting), and the conversation is intact
+  // behind it. Reserve "OpenCode failed to load" for a runtime that genuinely
+  // broke.
   //
-  // Matched against `raw`, not a `parseOpenCodeErrorPayload` field: `unwrap()`
-  // (react/use-opencode-sessions/shared.ts) is what actually produces the
-  // error this function receives for the session-list poll that drives the
-  // page's runtime-error card, and it throws `new Error(body.error)` — just
-  // the bare phrase, with the JSON wrapper already stripped off. There is no
-  // payload left to parse by the time it gets here. The regex is exact enough
-  // (`(status: stopped)` and all) that matching it against the raw string
-  // cannot false-positive on an unrelated error that merely mentions "stopped".
-  if (/sandbox not ready \(status: stopped\)/.test(raw)) {
+  // Matched against the raw string, not a `parseOpenCodeErrorPayload` field:
+  // `unwrap()` (react/use-opencode-sessions/shared.ts) is what actually
+  // produces the error this function receives for the session-list poll that
+  // drives the page's runtime-error card, and it throws `new Error(body.error)`
+  // — just the bare phrase, with the JSON wrapper already stripped off. There
+  // is no payload left to parse by the time it gets here.
+  if (isSandboxNotReadyError(raw)) {
     return {
       title: 'Session is waking up',
       message:

--- a/packages/sdk/src/public-surface.snapshot.json
+++ b/packages/sdk/src/public-surface.snapshot.json
@@ -441,6 +441,7 @@
     "isReasoningPart",
     "isRetryableTurnError",
     "isRuntimeReady",
+    "isSandboxNotReadyError",
     "isServerReachable",
     "isSessionFresh",
     "isSessionStartError",
@@ -1886,6 +1887,7 @@
     "formatOpenCodeRuntimeError",
     "getOpenCodeConfigInvalidError",
     "isOpenCodeConfigInvalidError",
+    "isSandboxNotReadyError",
     "parseOpenCodeErrorPayload"
   ],
   "./platform-client": [

--- a/packages/sdk/src/public-type-surface.snapshot.json
+++ b/packages/sdk/src/public-type-surface.snapshot.json
@@ -2507,6 +2507,7 @@
     "isReasoningPart",
     "isRetryableTurnError",
     "isRuntimeReady",
+    "isSandboxNotReadyError",
     "isServerReachable",
     "isSessionFresh",
     "isSessionStartError",
@@ -6105,6 +6106,7 @@
     "formatOpenCodeRuntimeError",
     "getOpenCodeConfigInvalidError",
     "isOpenCodeConfigInvalidError",
+    "isSandboxNotReadyError",
     "parseOpenCodeErrorPayload"
   ],
   "./platform-client": [


### PR DESCRIPTION
## Problem

A parked or still-booting sandbox answers file/PTY reads with a 503 `sandbox not ready (status: stopped)`. Every file surface rendered that as a terminal red error: "Failed to load file" + the raw proxy string (screenshot in session). A GET on port 8000 is deliberately non-wake-capable, so a parked box always ended in the red card. Rule from this change on: a readiness 503 is a pending state, never an error, on every surface.

## What changed

- **SDK** (`packages/sdk`, additive): new `isSandboxNotReadyError(error)` classifier in `core/http/opencode-errors.ts` covering every readiness phrase the API emits (`sandbox not ready (status: *)`, bare `sandbox not ready`, `Sandbox is not ready`, `Sandbox is not running`, `opencode … not ready`, codes `sandbox_not_ready` / `sandbox_lifecycle_unavailable`). `sandbox port unreachable` is deliberately excluded (box reported active, port dead = real failure). `formatOpenCodeRuntimeError` routes its "Session is waking up" branch through the classifier instead of the exact `(status: stopped)` regex. TDD, surface snapshots re-recorded (additive only).
- **apps/web**:
  - `FileContentRenderer` (preview modal, session panel rich preview, thumbnails, public share): a classified error renders a calm "Waking up the workspace…" state (spinner + path + "This file will load automatically"), takes precedence over `errorFallback`/not-found, and `onStatusChange` reports `loading`.
  - `useFileContent` / `useBinaryBlob` + both public-share hooks: `refetchInterval` polls every 3s while the error classifies as not-ready; the inline retry loop (`file-read-retry.ts`) fails fast on readiness errors instead of burning its 3-attempt budget.
  - Session terminal panel: readiness failures on PTY list/create hold the `connecting` state ("Waking up the workspace…") and retry every 3s — never "Terminal connection failed".
  - Drive explorer (workspace view): waking state + 3s list re-poll instead of `ErrorState`.
  - Transcript sandbox images + image-gen tool: waking counts as loading (skeleton/shimmer), never "Image unavailable".
  - Session side-panel non-rich preview: waking notice instead of "This file couldn't be opened."
- **apps/api**: the readiness 503 body from the sandbox proxy now carries `code: "sandbox_not_ready"` and `retry: true` (same shape as `sandbox_lifecycle_unavailable`), so clients branch on a stable code instead of the human string.

## Verification

- `pnpm --filter @kortix/sdk typecheck` clean; `test` 2324 pass / 0 fail (baseline 2320); `smoke:install` passed.
- `apps/api` `tsc --noEmit` clean; `preview.test.ts` 35 pass / 0 fail (new test for `code`/`retry`).
- `apps/web` `tsc --noEmit` clean (only the 3 known `@types/bun test.each` files); eslint on all changed files: 0 errors.
- New unit tests: readiness classification (SDK), fail-fast retry policy (web), terminal panel waking state (web), proxy body fields (api). All seen red first where new.
- **Live e2e on a real Platinum sandbox** (worktree stack, web 15300 / api 15308):
  - `GET /v1/p/sbx_01M0DNMGW85XGSC5ZPY3RT6K9P/8000/file/content?path=waking-proof.md` with the row `stopped` → `503 {"error":"sandbox not ready (status: stopped)",…,"code":"sandbox_not_ready","retry":true}`, `X-Kortix-Proxy-Hop: control_plane`.
  - Browser: opening the file with the row stopped shows the waking card (no red error); flipping the row back to `active` auto-loads the file within one 3s poll, zero user action. Terminal panel shows "Connecting…" while stopped and lands in a live shell after recovery, no manual retry. Session-page `/start` resume of a genuinely stopped Platinum box verified (file list appears after resume).

Screenshots: output/sandbox-waking/01-waking-state.png, 02-auto-loaded.png, 03-terminal-waking.png, 04-terminal-recovered.png (local).
