### PR TITLE
fix(slack): link-bot should not require owner/admin — it delegates only your own authority

### DIFF
--- a/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
+++ b/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
@@ -234,8 +234,15 @@ describe('a bot sender is never sent an identity prompt', () => {
     expect(cmds, 'link-bot must write the same chat_user_identities row /login does')
       .toContain('await linkSlackIdentity({ teamId: ctx.teamId, slackUserId: botUserId, userId: me.userId });');
     const h = fnBody(cmds, 'slashLinkBot');
-    expect(h, 'linking a bot must stay owner/admin gated — any app in the channel is a non-member')
-      .toContain('canManageSlackPolicy');
+    // NOT owner/admin. Linking binds the bot to the CALLER's own account, so it
+    // delegates the caller's authority and can never exceed it — the same shape
+    // as issuing yourself an API key. An admin-only gate was actively wrong: an
+    // admin linking a channel-triggerable bot is MORE dangerous than a member
+    // doing it. The gate is the one every Slack message already passes.
+    expect(h, 'the gate must be "could you have done this work yourself", via resolveSlackActor')
+      .toContain('resolveSlackActor(ctx.teamId, ctx.slackUserId, proj.accountId, selection.projectId)');
+    expect(h, 'an owner/admin requirement is the wrong shape for self-delegation')
+      .not.toContain('canManageSlackPolicy');
   });
 });
 
@@ -265,6 +272,13 @@ describe('link-bot refuses anything that is not a verified bot', () => {
     // `bot !== true` is load-bearing: `!bot` would also refuse, but a truthy
     // check like `bot === false` alone would let null through and link a human.
     expect(handler, 'uncertainty must refuse, not fall through').toContain('if (bot !== true) {');
+  });
+
+  test('the link is always to the CALLER — never to a third party', () => {
+    // This is what makes the relaxed gate safe: you can only ever delegate your
+    // own authority, so there is no privilege to escalate.
+    const h = fnBody(readFileSync(join(import.meta.dir, '..', 'channels', 'slack', 'commands.ts'), 'utf8'), 'slashLinkBot');
+    expect(h).toContain('userId: me.userId');
   });
 
   test('an id already linked to someone else is never silently re-pointed', () => {

--- a/apps/api/src/__tests__/unit-slack-commands.test.ts
+++ b/apps/api/src/__tests__/unit-slack-commands.test.ts
@@ -82,6 +82,7 @@ let identityRow: { userId: string } | null = null;
 mock.module('../channels/slack/identity', () => ({
   lookupSlackIdentity: async () => identityRow,
   linkSlackIdentity: async () => {},
+  resolveSlackActor: async () => ({ userId: 'user-1' }),
   revokeSlackIdentity: async () => true,
   lookupSlackUserIdForKortixUser: async () => null,
 }));

--- a/apps/api/src/channels/slack/__tests__/commands-identity-on.test.ts
+++ b/apps/api/src/channels/slack/__tests__/commands-identity-on.test.ts
@@ -14,6 +14,7 @@ mock.module('../../../shared/db', () => ({ db: {}, hasDatabase: () => true }));
 mock.module('../identity', () => ({
   lookupSlackIdentity: async () => null,
   linkSlackIdentity: async () => {},
+  resolveSlackActor: async () => ({ userId: 'user-1' }),
   revokeSlackIdentity: async () => true,
 }));
 mock.module('../../../accounts/core/app', () => ({

--- a/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
+++ b/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
@@ -66,6 +66,7 @@ mock.module('../participants', () => ({
 mock.module('../identity', () => ({
   lookupSlackIdentity: async () => null,
   linkSlackIdentity: async () => {},
+  resolveSlackActor: async () => ({ userId: 'user-1' }),
   revokeSlackIdentity: async () => true,
 }));
 mock.module('../../../accounts/core/app', () => ({ lookupEmailsByUserIds: async () => new Map() }));

--- a/apps/api/src/channels/slack/commands.ts
+++ b/apps/api/src/channels/slack/commands.ts
@@ -18,7 +18,7 @@ import { chooseEffectiveAgent, toOpencodeModelRef, toWireModel } from '../../llm
 import { buildSlackLoginUrl } from './login';
 import { findBotUserIdByName, isBotUser } from '../slack-api';
 import { loadSlackTokenForProject } from '../install-store';
-import { linkSlackIdentity, lookupSlackIdentity, revokeSlackIdentity } from './identity';
+import { linkSlackIdentity, lookupSlackIdentity, resolveSlackActor, revokeSlackIdentity } from './identity';
 import { conversationPolicyLabel, normalizeConversationPolicy } from './participants';
 import { lookupEmailsByUserIds } from '../../accounts/core/app';
 import { filterAccessibleObjects, unscopedResourceIds } from '../../iam';
@@ -726,8 +726,36 @@ async function slashLinkBot(ctx: SlashCtx, arg: string): Promise<SlashResponse> 
     }
     botUserId = byName;
   }
-  if (!(await canManageSlackPolicy(ctx, selection.projectId))) {
-    return { response_type: 'ephemeral', text: 'Only a linked Kortix account owner or admin for this project can link a bot.' };
+  // GATE: "could you have done this work yourself?" — NOT "are you an admin?".
+  //
+  // Linking binds the bot to the CALLER's own account (userId: me.userId below,
+  // and a bot already linked to someone else is refused), so it delegates the
+  // caller's authority and can never exceed it. That makes it the same shape as
+  // issuing yourself an API key, and an owner/admin requirement actively wrong:
+  // an admin linking a bot that anyone in the channel can trigger is strictly
+  // MORE dangerous than a regular member doing the same.
+  //
+  // So the check is the one resolveSlackActor already performs for every Slack
+  // message — linked identity, member of this project's account, PROJECT_WRITE.
+  // Anyone who can @-mention the agent and have it act can delegate exactly that
+  // and nothing more. Reusing it also means the two can never disagree: if this
+  // passes, the bot's mentions will resolve; if it fails, they would not have.
+  const [proj] = await db
+    .select({ accountId: projects.accountId })
+    .from(projects)
+    .where(eq(projects.projectId, selection.projectId))
+    .limit(1);
+  if (!proj) {
+    return { response_type: 'ephemeral', text: 'That channel is no longer bound to a project.' };
+  }
+  const actor = await resolveSlackActor(ctx.teamId, ctx.slackUserId, proj.accountId, selection.projectId);
+  if ('reason' in actor) {
+    return {
+      response_type: 'ephemeral',
+      text: actor.reason === 'not_member'
+        ? "You're connected, but don't have access to this project yet."
+        : `Connect your Kortix account first: \`${ctx.command} login\`.`,
+    };
   }
   // A HUMAN's id must never be bound here. linkSlackIdentity upserts, and
   // resolveSlackActor treats the row as authoritative, so linking a person would


### PR DESCRIPTION
**This commit was orphaned by a merge race and never shipped.** It was pushed to the #6606 branch at 18:34:26Z, two and a half minutes *after* #6606 merged at 18:32:04Z — so the squash (`fb809043`) captured only the first commit. Verified against the merged artifact: `findBotUserIdByName=1`, `resolveSlackActor=0`. My sequencing error; re-opening it on its own.

## The change

`link-bot` was gated on `canManageSlackPolicy` (account **owner or admin**). That's the wrong shape, and backwards in the dangerous direction.

Linking binds the bot to the **caller's own** account (`userId: me.userId`, and a bot already linked to someone else is refused), so it can only ever delegate the caller's authority and never exceed it — the same shape as issuing yourself an API key.

An owner/admin requirement makes that *worse*: an admin linking a bot that anyone in the channel can trigger hands out **admin** authority, while the same act by a regular member hands out only that member's. Requiring the more privileged actor to be the one who does it is precisely inverted.

The gate is now the check every Slack message already passes — `resolveSlackActor`: linked identity, member of this project's account, `PROJECT_WRITE`. **Any member who can @-mention the agent and have it act may delegate exactly that, and nothing more.**

Reusing `resolveSlackActor` rather than writing a second predicate also means the two can't disagree: if `link-bot` passes, the bot's mentions will resolve; if it fails, they wouldn't have.

Reported from the channel — `Only a linked Kortix account owner or admin for this project can link a bot` — on an account whose own operator could tag the agent and have it work.

## Testing

- 21 tests (1 new: the link target is always the caller, which is what makes the relaxed gate safe).
- Negative controls: removing the actor gate, and writing a `userId` other than the caller's — each red on its own.
- That second control initially **passed**: my `sed` replaced the first occurrence of `userId: me.userId`, which sits in a *comment* three lines above the real call. It was mutating prose. Re-run against the actual `linkSlackIdentity` call, it reds.
- Three sibling suites needed `resolveSlackActor` in their partial `../identity` mock.
- **Full Slack surface: 341 pass, 0 fail.**