### PR TITLE
infra(staging): API 3×2vCPU/4GiB — the release gate saturates 2×1vCPU tasks

### DIFF
--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -107,11 +107,16 @@ module "api" {
   # 2 tasks of 1 vCPU / 2 GiB, floor 2, ceiling 4. fargate_base_on_demand = 1
   # pins the first task to on-demand FARGATE: the rest stay Spot for cost, but
   # a Spot reclaim can no longer take the whole environment to zero.
-  task_cpu                   = 1024
-  task_memory                = 2048
-  desired_count              = 2
-  min_capacity               = 2
-  max_capacity               = 4
+  # Gate dry-run 32290094936 (2026-08-19, skew-free): with 2 x 1 vCPU tasks a
+  # plain POST /v1/accounts took 5.8-6.7s when it succeeded and intermittently
+  # 37s -> ALB 5xx -> edge-laundered 503, while the DB sat at 0 slow queries —
+  # API event-loop starvation, not data. 3 x 2 vCPU gives the release gate's
+  # ~18-worker fleet real JS throughput (~+$150/mo at the floor).
+  task_cpu                   = 2048
+  task_memory                = 4096
+  desired_count              = 3
+  min_capacity               = 3
+  max_capacity               = 6
   use_fargate_spot           = true
   fargate_base_on_demand     = 1
   requests_per_target_target = 600


### PR DESCRIPTION
Skew-free dry-run 32290094936: direct probe measured `POST /v1/accounts` at 5.8–6.7 s success / 37 s→laundered 503, with the staging DB at 0 slow queries and /health sub-second — API CPU starvation, not data. `desired/min 2→3, max 4→6, task 1024/2048→2048/4096` (~+$150/mo at the floor). `terraform validate` Success, `fmt` clean; applies via deploy-staging's TF job on the next promotion.