### PR TITLE
refactor(gateway): wire API in-process gateway + session env to enable the native path (flag off)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -362,6 +362,15 @@ const envSchema = z.object({
   // Managed LLM gateway (/v1/llm) — the `kortix` OpenCode provider routes every
   // sandbox model call here. Off by default.
   LLM_GATEWAY_ENABLED: optBoolFalse,
+  // AI-SDK-native gateway ingress (`POST /v1/llm/language-model`, Vercel "AI
+  // Gateway" protocol). SAME env name the standalone gateway reads
+  // (apps/llm-gateway config `GATEWAY_AI_SDK_NATIVE`), so one operator switch
+  // turns on BOTH the standalone gateway AND this in-process mount. When ON:
+  // (1) the in-process gateway is created with `aiSdkNative` so
+  // `gateway.languageModel` serves instead of 404ing, and (2) every session gets
+  // `KORTIX_LLM_AI_SDK_NATIVE=true` injected so the daemon's `buildKortixProvider`
+  // selects `@ai-sdk/gateway`. Default OFF — the whole native path stays inert.
+  GATEWAY_AI_SDK_NATIVE: optBoolFalse,
   // CLOUD-ONLY. Whether KORTIX's own managed model lineup exists on this
   // deployment. The lineup routes through Kortix's shared Bedrock, AsterLab,
   // and OpenRouter credentials. Kortix bills each route as platform credits.
@@ -1047,6 +1056,10 @@ export const config = {
   ASTER_API_KEY: env.ASTER_API_KEY,
   CONNECTORS_MCP_ENABLED: env.CONNECTORS_MCP_ENABLED,
   LLM_GATEWAY_ENABLED: env.LLM_GATEWAY_ENABLED,
+  // Single API-side switch for the AI-SDK-native gateway path — read from env
+  // `GATEWAY_AI_SDK_NATIVE`. Consumed by wire.ts (in-process gateway options +
+  // /language-model mount) and session-sandbox.ts (per-session env injection).
+  aiSdkNative: env.GATEWAY_AI_SDK_NATIVE,
   // Unset → follow billing (cloud keeps its revenue lineup even if the env
   // blob misses the var; self-host stays off). Explicit value always wins.
   KORTIX_MANAGED_PROVIDER_ENABLED:

--- a/apps/api/src/llm-gateway/config-ai-sdk-native.test.ts
+++ b/apps/api/src/llm-gateway/config-ai-sdk-native.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+
+// GAP-B (config): `config.aiSdkNative` reads env `GATEWAY_AI_SDK_NATIVE` and
+// maps on/off/default. `config` is a validated singleton evaluated once at
+// import, so each case runs in a FRESH subprocess with a different env value —
+// the only deterministic way to exercise the env→flag mapping.
+//
+// The current process already loaded scripts/test.env (the fake-value hermetic
+// env), so `process.env` here carries every var `config` needs to validate.
+// Each subprocess inherits it and only `GATEWAY_AI_SDK_NATIVE` differs.
+
+const API_ROOT = join(import.meta.dir, '..', '..');
+const CONFIG_PATH = join(API_ROOT, 'src', 'config.ts');
+
+async function readAiSdkNative(value: string | undefined): Promise<boolean> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) if (v !== undefined) env[k] = v;
+  if (value === undefined) delete env.GATEWAY_AI_SDK_NATIVE;
+  else env.GATEWAY_AI_SDK_NATIVE = value;
+
+  const proc = Bun.spawn(
+    [
+      'bun',
+      // Mirrors scripts/test.sh: --env-file loads the hermetic fake-value env
+      // AND stops bun auto-loading the dotenvx-encrypted .env (whose
+      // `encrypted:…` values would fail config validation). GATEWAY_AI_SDK_NATIVE
+      // is absent from test.env, so the value passed via `env` is the only
+      // source for it.
+      '--env-file=scripts/test.env',
+      '-e',
+      // config validation logs to stdout, so wrap the value in sentinels and
+      // extract it rather than parsing the whole stream.
+      `const { config } = await import(${JSON.stringify(CONFIG_PATH)}); process.stdout.write("<<<"+JSON.stringify(config.aiSdkNative)+">>>");`,
+    ],
+    { env, cwd: API_ROOT, stdout: 'pipe', stderr: 'pipe' },
+  );
+  const out = await new Response(proc.stdout).text();
+  const code = await proc.exited;
+  if (code !== 0) {
+    const err = await new Response(proc.stderr).text();
+    throw new Error(`config subprocess exited ${code}: ${err}`);
+  }
+  const match = out.match(/<<<(.+?)>>>/);
+  if (!match) throw new Error(`no result sentinel in config subprocess output: ${out}`);
+  return JSON.parse(match[1]) as boolean;
+}
+
+describe('config.aiSdkNative — GATEWAY_AI_SDK_NATIVE parsing', () => {
+  test('default (unset) → false', async () => {
+    expect(await readAiSdkNative(undefined)).toBe(false);
+  });
+
+  test('"true" → true', async () => {
+    expect(await readAiSdkNative('true')).toBe(true);
+  });
+
+  test('"1" → true', async () => {
+    expect(await readAiSdkNative('1')).toBe(true);
+  });
+
+  test('"false" → false', async () => {
+    expect(await readAiSdkNative('false')).toBe(false);
+  });
+});

--- a/apps/api/src/llm-gateway/wire-language-model.test.ts
+++ b/apps/api/src/llm-gateway/wire-language-model.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// GAP-B: the in-process gateway (apps/api wire.ts) must SERVE
+// `POST /v1/llm/language-model` so opencode's `@ai-sdk/gateway` provider
+// (baseURL `${KORTIX_URL}/v1/llm`) reaches `gateway.languageModel(req)`. wire.ts
+// mounts the route unconditionally and threads `config.aiSdkNative` into
+// `createGateway`; the flag itself is enforced inside `gateway.languageModel`.
+//
+// This drives the REAL mounted route on both sides of the flag:
+//   ON  → the request reaches the gateway auth/decode pipeline (401 without a
+//         token), NOT a route-not-found 404.
+//   OFF → `gateway.languageModel` returns its own flag-gated 404 (JSON body,
+//         code `not_found`) — distinct from a Hono route-404 (plain text). This
+//         proves wire.ts passes `config.aiSdkNative` through rather than
+//         hardcoding it on.
+//
+// The config is mocked by SPREADING the real one (it validates fine under
+// scripts/test.env) and overriding only `LLM_GATEWAY_ENABLED` (so the /v1/llm
+// sub-app mounts) and `aiSdkNative` (a live getter over a per-test toggle).
+// No process.env mutation, so the result is deterministic under the parallel
+// isolated runner.
+const { config: realConfig } = await import('../config');
+
+let aiSdkNativeFlag = false;
+mock.module('../config', () => ({
+  config: {
+    ...realConfig,
+    LLM_GATEWAY_ENABLED: true,
+    get aiSdkNative() {
+      return aiSdkNativeFlag;
+    },
+  },
+}));
+
+// Hermetic gateway hooks — no DB. `authenticate` returns null so `admit`
+// answers 401 for a request with no bearer token. Spread the real module so
+// internal-routes' other `./hooks` imports still resolve.
+const actualHooks = await import('./hooks');
+mock.module('./hooks', () => ({
+  ...actualHooks,
+  createInProcessGatewayHooks: () => ({
+    authenticate: async () => null,
+    resolveUpstream: async () => [],
+    assertBillingActive: async () => {},
+    recordUsage: async () => {},
+    listModels: async () => ({}),
+  }),
+}));
+
+const { mountLlmGateway } = await import('./wire');
+const { makeOpenApiApp } = await import('../openapi');
+
+// A request the gateway's `decodeLanguageModelRequest` accepts: model id in the
+// header, valid `LanguageModelV*CallOptions.prompt` body. Mirrors the fixture in
+// packages/llm-gateway's language-model-handler test.
+function languageModelRequest(path: string, withToken: boolean): Request {
+  return new Request(`http://test${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'ai-language-model-id': 'anthropic/claude-fable-5',
+      ...(withToken ? { authorization: 'Bearer some-token' } : {}),
+    },
+    body: JSON.stringify({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    }),
+  });
+}
+
+function mountedApp() {
+  const app = makeOpenApiApp();
+  mountLlmGateway(app);
+  return app;
+}
+
+describe('wire.ts /v1/llm/language-model — GATEWAY_AI_SDK_NATIVE flag', () => {
+  test('flag ON: the route is mounted and reaches auth — no token returns 401, not a route 404', async () => {
+    aiSdkNativeFlag = true;
+    const res = await mountedApp().request(
+      languageModelRequest('/v1/llm/language-model', false),
+    );
+    // A mounted route with the flag on hits auth/decode. A route-404 would mean
+    // the mount is missing.
+    expect(res.status).not.toBe(404);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code?: string };
+    // The gateway's own JSON error envelope — proves we hit the pipeline, not a
+    // Hono not-found.
+    expect(['missing_token', 'invalid_token']).toContain(body.code ?? '');
+  });
+
+  test('flag OFF: the mounted route returns the gateway flag-gated 404, not a route 404', async () => {
+    aiSdkNativeFlag = false;
+    const res = await mountedApp().request(
+      languageModelRequest('/v1/llm/language-model', true),
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { code?: string; message?: string };
+    // JSON body (NOT a Hono route-not-found) with the flag-off code — proves the
+    // route is mounted and `gateway.languageModel` returned 404 because
+    // `config.aiSdkNative` was threaded through as false.
+    expect(body.code).toBe('not_found');
+    expect(body.message).toContain('not enabled');
+  });
+
+  test('an unmounted /v1/llm path returns a plain 404 — the control for "404 == not found"', async () => {
+    aiSdkNativeFlag = true;
+    const res = await mountedApp().request(
+      new Request('http://test/v1/llm/definitely-not-a-route', { method: 'POST' }),
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -378,6 +378,11 @@ export function mountLlmGateway(app: OpenAPIHono): void {
     const gateway = createGateway(createInProcessGatewayHooks(), {
       captureBodies: true,
       maxRequestBytes: DEFAULT_MAX_REQUEST_BYTES,
+      // AI-SDK-native ingress (`/language-model`). Mirrors the standalone
+      // gateway's `aiSdkNative: config.aiSdkNative` (apps/llm-gateway server.ts).
+      // OFF (default) → `gateway.languageModel` returns 404, so the route
+      // mounted below is inert; ON → it serves the Vercel AI-Gateway protocol.
+      aiSdkNative: config.aiSdkNative,
     });
     // OpenAPIHono (not a plain Hono) so the inference surface below registers
     // in the shared OpenAPI registry — `.route()` merges a child OpenAPIHono's
@@ -411,6 +416,21 @@ export function mountLlmGateway(app: OpenAPIHono): void {
         authorization: c.req.header('authorization'),
         rawBody: await c.req.text(),
       });
+    // AI-SDK-native ingress (Vercel "AI Gateway" protocol): opencode's
+    // `@ai-sdk/gateway` provider POSTs `LanguageModelV{3,4}CallOptions` here. The
+    // model id + spec version + streaming flag are in HEADERS (read via `header`),
+    // NOT the path/body — mirrors the standalone server's `languageModel` handler
+    // (apps/llm-gateway/src/server.ts). Inert (404) until `GATEWAY_AI_SDK_NATIVE`
+    // is on, because `gateway.languageModel` enforces the `aiSdkNative` flag.
+    const languageModel = async (c: import('hono').Context) =>
+      gateway.languageModel({
+        authorization: c.req.header('authorization'),
+        header: (name: string) => c.req.header(name),
+        rawBody: await c.req.text(),
+        // `c.req.raw.signal` fires on client disconnect, so the gateway stops
+        // reading (and billing for) upstream tokens no one is listening for.
+        signal: c.req.raw.signal,
+      });
     // Runtime routes are unchanged plain Hono mounts — same handlers, same
     // signatures, same streaming behavior as before this OpenAPI registration.
     llm.post('/chat/completions', chat);
@@ -430,6 +450,16 @@ export function mountLlmGateway(app: OpenAPIHono): void {
     llm.post('/v1/chat/completions', chat);
     llm.get('/v1/models', models);
     llm.post('/v1/messages', messages);
+    // AI-SDK-native mounts. opencode's `@ai-sdk/gateway` provider is configured
+    // with the `${KORTIX_URL}/v1/llm` baseURL, so it POSTs to
+    // `/v1/llm/language-model` → this sub-app path `/language-model` (the primary
+    // target). `/v1/language-model` is the belt-and-suspenders `/v1/...`-prefixed
+    // variant, exactly like `/v1/chat/completions` above. `@ai-sdk/gateway` may
+    // also derive a `/v{N}/ai/language-model` path from its baseURL, so mount the
+    // prefix-tolerant alias too — mirrors the standalone server.
+    llm.post('/language-model', languageModel);
+    llm.post('/v1/language-model', languageModel);
+    llm.post('/:version/ai/language-model', languageModel);
 
     // OpenAPI documentation ONLY — see the big comment above for why these are
     // `registerPath()` (registry-only) instead of `llm.openapi(route, handler)`.

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -84,6 +84,8 @@ let accountTokenCreateCalls: Array<Record<string, unknown>> = [];
 let serviceAccountCreateCalls: Array<Record<string, unknown>> = [];
 let networkBoundaryBindings: Array<Record<string, unknown>> = [];
 let providerSyncCalls: Array<{ externalId: string; bindings: Array<Record<string, unknown>> }> = [];
+// GATEWAY_AI_SDK_NATIVE — toggled per test via the config mock's getter below.
+let aiSdkNativeFlag = false;
 
 function compile(condition: unknown): { sql: string; params: unknown[] } {
   try {
@@ -111,6 +113,11 @@ mock.module('../../config', () => ({
     LLM_GATEWAY_PROXY_PORT: undefined,
     LLM_GATEWAY_PROXY_TARGET: undefined,
     LLM_GATEWAY_BASE_URL: undefined,
+    // Read live from the toggle so a single test can flip the flag and assert
+    // the session env-injection branch on either side.
+    get aiSdkNative() {
+      return aiSdkNativeFlag;
+    },
   },
 }));
 
@@ -377,6 +384,7 @@ beforeEach(() => {
   serviceAccountCreateCalls = [];
   networkBoundaryBindings = [];
   providerSyncCalls = [];
+  aiSdkNativeFlag = false;
 });
 
 afterEach(() => {
@@ -432,6 +440,36 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
 
     expect(imageRequests[0]).toMatchObject({ source: 'session-start' });
     expect(imageRequests[0]).not.toHaveProperty('requireCurrentRuntime');
+  });
+
+  test('GATEWAY_AI_SDK_NATIVE on injects KORTIX_LLM_AI_SDK_NATIVE=true into the sandbox env', async () => {
+    aiSdkNativeFlag = true;
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
+
+    await provisionSessionSandbox(baseOpts());
+    await opened;
+
+    expect(providerCreateOpts).toHaveLength(1);
+    const envVars = providerCreateOpts[0]?.envVars as Record<string, string>;
+    // The daemon's env route allowlists this name (OPENCODE_RUNTIME_ENV_NAMES);
+    // buildKortixProvider reads it to select @ai-sdk/gateway.
+    expect(envVars.KORTIX_LLM_AI_SDK_NATIVE).toBe('true');
+  });
+
+  test('GATEWAY_AI_SDK_NATIVE off leaves KORTIX_LLM_AI_SDK_NATIVE absent (byte-identical to today)', async () => {
+    // aiSdkNativeFlag stays false (reset in beforeEach).
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
+
+    await provisionSessionSandbox(baseOpts());
+    await opened;
+
+    expect(providerCreateOpts).toHaveLength(1);
+    const envVars = providerCreateOpts[0]?.envVars as Record<string, string>;
+    expect(envVars).not.toHaveProperty('KORTIX_LLM_AI_SDK_NATIVE');
   });
 
   test('the fast flag keeps the standard image so the edge optimization stays isolated', async () => {

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -535,6 +535,16 @@ export async function provisionSessionSandbox(opts: {
             KORTIX_LLM_BASE_URL: llmBaseUrl,
           }
         : {}),
+      // AI-SDK-native transport toggle. When the operator enables the native
+      // gateway path (`GATEWAY_AI_SDK_NATIVE`, one switch for both the gateway
+      // mount and this injection), tell the daemon's `buildKortixProvider` to
+      // select `@ai-sdk/gateway` (native `/language-model`) instead of
+      // `@ai-sdk/openai-compatible`. Allowlisted in the daemon's env route
+      // (OPENCODE_RUNTIME_ENV_NAMES). Inert without the KORTIX_LLM_* pair above:
+      // `buildKortixProvider` runs only when the gateway provider is mounted, so
+      // a session on native BYOK ignores it. When the flag is OFF this key is
+      // absent — byte-identical to the pre-flag env.
+      ...(config.aiSdkNative ? { KORTIX_LLM_AI_SDK_NATIVE: 'true' } : {}),
     },
     // Idle lifecycle: we pass NO explicit autoStopInterval for a normal session,
     // so each provider gets its native idle timer set from


### PR DESCRIPTION
Follow-up to #6609. The native `/language-model` path merged there is **inert on dev/prod/self-host** because those route sandbox LLM traffic to the **API in-process gateway** (`wire.ts`), which never passed `aiSdkNative` and never injected the per-session flag. This closes both, behind one API flag `GATEWAY_AI_SDK_NATIVE` (default **off**).

## Changes (apps/api only)
- `config.ts` — `aiSdkNative` reads `GATEWAY_AI_SDK_NATIVE` (same env as the standalone gateway; default false).
- `wire.ts` — pass `aiSdkNative` into `createGateway`, and mount `POST /v1/llm/language-model` (+ `/v1/language-model`, `/:version/ai/language-model`) mirroring the standalone server. Off → `gateway.languageModel` returns its own 404, so mounting is safe.
- `session-sandbox.ts` — inject `KORTIX_LLM_AI_SDK_NATIVE='true'` into create-time session env when the flag is on (allowlisted for the daemon; opencode then selects `@ai-sdk/gateway`). Absent when off = byte-identical to today.

## Effect
With `GATEWAY_AI_SDK_NATIVE=true` on the API, the whole native path is live end-to-end: opencode POSTs `/v1/llm/language-model`, the in-process gateway serves it, `fullStream` passes through losslessly. Default off = zero behavior change.

## Verification
`apps/api`: **299 pass / 0 fail** (+24 targeted), typecheck clean. Tests: config env mapping; the mounted route hits auth (401) when on and gateway-404 when off (distinct from a route-not-found 404); session env injected only when on.

## Rollout (not here)
Merge dormant → enable on dev → new session → guest-level + real-turn verify → flip default → box.
