### PR TITLE
fix(slack): users.info was sent as JSON, so Slack never saw the user param

### DIFF
--- a/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
+++ b/apps/api/src/__tests__/unit-slack-bot-mentions.test.ts
@@ -331,3 +331,35 @@ describe('link-bot accepts what an operator will actually type', () => {
     expect(verify).toBeLessThan(write);
   });
 });
+
+// ── users.* must be form-encoded ────────────────────────────────────────────
+//
+// Slack's older read methods do not parse a JSON body: the params are dropped
+// and the call is answered as if they were never sent. users.info replies
+// `user_not_found` for an id Slack itself just returned from users.list and
+// renders fine as <@ID>. Measured on dev 2026-08-19, /ecs/kortix-dev:
+//
+//   [slack-api] users.info failed { error: "user_not_found" }
+//
+// It reads as bad data rather than a bad request, which is why it survived
+// review and a live test.
+
+describe('slack-api sends users.* as form-encoded, not JSON', () => {
+  const api = readFileSync(join(import.meta.dir, '..', 'channels', 'slack-api.ts'), 'utf8');
+
+  test('users.info passes form:true', () => {
+    expect(api, 'users.info with a JSON body silently drops `user` and answers user_not_found')
+      .toContain("slackApiCall(token, 'users.info', { user: userId }, { form: true })");
+  });
+
+  test('users.list passes form:true', () => {
+    expect(api).toContain("slackApiCall(token, 'users.list', { limit: 1000 }, { form: true })");
+  });
+
+  test('the form branch actually changes the Content-Type and the body', () => {
+    // A `form` option that only sets a header would encode nothing.
+    expect(api).toContain('application/x-www-form-urlencoded');
+    expect(api, 'form mode must URL-encode the params, not JSON.stringify them')
+      .toContain('new URLSearchParams(');
+  });
+});

--- a/apps/api/src/channels/slack-api.ts
+++ b/apps/api/src/channels/slack-api.ts
@@ -24,8 +24,20 @@ async function slackApiCall(
   token: string,
   method: string,
   body: Record<string, unknown>,
-  opts: { retries?: number; idempotent?: boolean } = {},
+  opts: { retries?: number; idempotent?: boolean; form?: boolean } = {},
 ): Promise<SlackApiResult> {
+  // `form` sends application/x-www-form-urlencoded instead of JSON.
+  //
+  // NOT a style preference. Slack's older read methods do not parse a JSON body
+  // at all: the params are silently dropped and the call is answered as though
+  // they were never sent. users.info answers `user_not_found` — for a user id
+  // that Slack itself had just returned from users.list, and that Slack renders
+  // correctly as <@ID> in a message. Measured on dev 2026-08-19 from
+  // /ecs/kortix-dev: `[slack-api] users.info failed { error: "user_not_found" }`.
+  //
+  // That failure mode is silent and looks like bad data rather than a bad
+  // request, which is exactly how it cost an evening: the caller concluded the
+  // bot did not exist.
   // `idempotent` (default true) controls whether ambiguous failures are retried.
   // A 429 is ALWAYS safe to retry — Slack guarantees the request wasn't processed
   // — but a 5xx / timeout / network error on a non-idempotent WRITE
@@ -40,10 +52,18 @@ async function slackApiCall(
       const res = await fetch(`${SLACK_API_BASE}/${method}`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
+          'Content-Type': opts.form
+            ? 'application/x-www-form-urlencoded; charset=utf-8'
+            : 'application/json; charset=utf-8',
           authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify(body),
+        body: opts.form
+          ? new URLSearchParams(
+              Object.entries(body)
+                .filter(([, v]) => v !== undefined && v !== null)
+                .map(([k, v]) => [k, typeof v === 'string' ? v : JSON.stringify(v)]),
+            ).toString()
+          : JSON.stringify(body),
         signal: AbortSignal.timeout(10_000),
       });
       if (res.status === 429) {
@@ -466,7 +486,7 @@ export async function findBotUserIdByName(token: string, name: string): Promise<
   const want = name.trim().replace(/^@/, '').toLowerCase();
   if (!want) return null;
   try {
-    const r = await slackApiCall(token, 'users.list', { limit: 1000 });
+    const r = await slackApiCall(token, 'users.list', { limit: 1000 }, { form: true });
     if (!r.ok) {
       console.warn('[slack-api] users.list failed', { error: r.error });
       return null;
@@ -500,7 +520,7 @@ export async function findBotUserIdByName(token: string, name: string): Promise<
 // — and the caller refuses. Guessing "probably a bot" here is the impersonation.
 export async function isBotUser(token: string, userId: string): Promise<boolean | null> {
   try {
-    const r = await slackApiCall(token, 'users.info', { user: userId });
+    const r = await slackApiCall(token, 'users.info', { user: userId }, { form: true });
     if (!r.ok) {
       console.warn('[slack-api] users.info failed', { error: r.error });
       return null;


### PR DESCRIPTION
**Measured on dev**, `/ecs/kortix-dev`:

```
[slack-api] users.info failed { error: "user_not_found" }
```

…for a user id **Slack itself had just returned from `users.list`**, and which Slack renders correctly as `<@ID>` in the very error message the operator saw. The id was never the problem.

## Cause

`slackApiCall` always sends a JSON body. Slack's older read methods don't parse one — the params are dropped and the call is answered as though they were never sent. `users.info` with no `user` is answered `user_not_found`.

`users.list` survived only because **all** of its params are optional: it returned a full workspace list while silently ignoring `limit`.

## Why this one was expensive

It's the worst shape a failure can take: it reads as **bad data** rather than a **bad request**. The caller concluded the bot didn't exist and told the user exactly that — twice — while the bot was sitting in the channel the whole time.

## Fix

`slackApiCall` gains `form: true` → `application/x-www-form-urlencoded` via `URLSearchParams`, applied to `users.info` and `users.list`.

Every other call in this module is `chat.*` / `conversations.*` / `reactions.*`, which do accept JSON — left alone rather than churned.

## Testing

- 24 tests (3 new): both call sites pass `form: true`, and the form branch actually changes **both** the `Content-Type` and the body — a `form` option that only set a header would encode nothing.
- Negative controls: dropping `form: true`, and encoding the form body with `JSON.stringify` — each red on its own.
- **Full Slack surface: 344 pass, 0 fail.**