### PR TITLE
refactor(gateway): make the AI-SDK-native path the default everywhere

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -369,8 +369,9 @@ const envSchema = z.object({
   // (1) the in-process gateway is created with `aiSdkNative` so
   // `gateway.languageModel` serves instead of 404ing, and (2) every session gets
   // `KORTIX_LLM_AI_SDK_NATIVE=true` injected so the daemon's `buildKortixProvider`
-  // selects `@ai-sdk/gateway`. Default OFF — the whole native path stays inert.
-  GATEWAY_AI_SDK_NATIVE: optBoolFalse,
+  // selects `@ai-sdk/gateway`. Default ON — the native path is the default
+  // everywhere; set GATEWAY_AI_SDK_NATIVE=0 to fall back (the kill-switch).
+  GATEWAY_AI_SDK_NATIVE: optBoolTrue,
   // CLOUD-ONLY. Whether KORTIX's own managed model lineup exists on this
   // deployment. The lineup routes through Kortix's shared Bedrock, AsterLab,
   // and OpenRouter credentials. Kortix bills each route as platform credits.

--- a/apps/api/src/llm-gateway/config-ai-sdk-native.test.ts
+++ b/apps/api/src/llm-gateway/config-ai-sdk-native.test.ts
@@ -47,8 +47,8 @@ async function readAiSdkNative(value: string | undefined): Promise<boolean> {
 }
 
 describe('config.aiSdkNative — GATEWAY_AI_SDK_NATIVE parsing', () => {
-  test('default (unset) → false', async () => {
-    expect(await readAiSdkNative(undefined)).toBe(false);
+  test('default (unset) → true (native path is the default everywhere)', async () => {
+    expect(await readAiSdkNative(undefined)).toBe(true);
   });
 
   test('"true" → true', async () => {

--- a/apps/llm-gateway/src/config.ts
+++ b/apps/llm-gateway/src/config.ts
@@ -39,8 +39,10 @@ export const config = {
   },
   captureBodies: flag('GATEWAY_CAPTURE_BODIES', true),
   // AI-SDK-native ingress (`POST /language-model`, Vercel "AI Gateway"
-  // protocol). Default OFF — the route is inert (404) until enabled.
-  aiSdkNative: flag('GATEWAY_AI_SDK_NATIVE', false),
+  // protocol). Default ON — opencode talks to the gateway losslessly (reasoning
+  // signatures, refusals, tools pass through 1:1). Set GATEWAY_AI_SDK_NATIVE=0
+  // to fall back to the OpenAI-compatible path (the kill-switch).
+  aiSdkNative: flag('GATEWAY_AI_SDK_NATIVE', true),
   // Default: 8 MiB. This accepts the measured 2,023,225-byte Aster request and
   // rejects accidental/untrusted oversized payloads before upstream dispatch.
   maxRequestBytes: optionalInt('GATEWAY_MAX_REQUEST_BYTES', DEFAULT_MAX_REQUEST_BYTES),


### PR DESCRIPTION
Flips the AI-SDK-native path from opt-in to the **default everywhere** (dev, prod, self-host). Follows #6609 (native path) + #6615 (API wiring), both merged.

- `apps/llm-gateway/src/config.ts` — `flag('GATEWAY_AI_SDK_NATIVE', true)`
- `apps/api/src/config.ts` — `GATEWAY_AI_SDK_NATIVE: optBoolTrue`

**Unset now means ON.** opencode reaches the gateway via `@ai-sdk/gateway`, so reasoning signatures, refusals, tool calls, and usage pass through 1:1 (proven by the real-`@ai-sdk/gateway`-client e2e in #6609). `GATEWAY_AI_SDK_NATIVE=0` is the kill-switch / instant rollback.

Config default-mapping test updated (unset→true). Wire/session/handler tests use explicit flags, unaffected.

**Rollout:** dev auto-deploys this as the live canary; prod inherits via the gated release (staging full-suite gate runs first); self-host on next update. Verified on the box canary before merge.
