### PR TITLE
perf(api): take audit writes and the owner-email fan-out off the request path

### DIFF
--- a/apps/api/src/__tests__/unit-account-display-names.test.ts
+++ b/apps/api/src/__tests__/unit-account-display-names.test.ts
@@ -17,21 +17,17 @@ function makeChain(): any {
   chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(dbResults.shift() ?? []));
   return chain;
 }
+// Owner emails now come from a single `auth.users` lookup via `db.execute`
+// (they used to be one Supabase admin HTTP call per owner).
+let emailsById: Record<string, string> = {};
 mock.module('../shared/db', () => ({
-  db: { select: () => makeChain(), update: () => makeChain(), insert: () => makeChain(), execute: async () => [] },
+  db: { select: () => makeChain(), update: () => makeChain(), insert: () => makeChain(), execute: async () => Object.entries(emailsById).map(([id, email]) => ({ id, email })) },
   hasDatabase: () => true,
 }));
 
-// Emails looked up via the Supabase admin API (owner ids → emails).
-let emailsById: Record<string, string> = {};
+// Retained because other modules in this import graph still construct a client.
 mock.module('../shared/supabase', () => ({
-  getSupabase: () => ({
-    auth: {
-      admin: {
-        getUserById: async (uid: string) => ({ data: { user: emailsById[uid] ? { email: emailsById[uid] } : null } }),
-      },
-    },
-  }),
+  getSupabase: () => ({ auth: { admin: {} } }),
 }));
 
 mock.module('../shared/resolve-account', () => ({
@@ -40,6 +36,7 @@ mock.module('../shared/resolve-account', () => ({
 
 const {
   accountDisplayName,
+  clearOwnerEmailCache,
   properAccountName,
   resolveAccountDisplayNames,
 } = await import('../accounts/core/app');
@@ -49,6 +46,9 @@ const CALLER = { userId: 'u-caller', email: 'marko@kortix.ai' };
 beforeEach(() => {
   dbResults = [];
   emailsById = {};
+  // The owner-email lookup memoizes for 5 minutes; drop it so each test
+  // observes its own fixture rather than the previous test's.
+  clearOwnerEmailCache();
 });
 
 describe('properAccountName / accountDisplayName', () => {

--- a/apps/api/src/accounts/audit.ts
+++ b/apps/api/src/accounts/audit.ts
@@ -19,7 +19,7 @@ import { ACCOUNT_ACTIONS, assertAuthorized } from '../iam';
 import { actorOf } from '../iam/actor';
 import { assertAllowedSourceAddress } from '../marketplace/catalog';
 import { ErrorSchema, auth, errors, json, makeOpenApiApp } from '../openapi';
-import { recordAuditEvent } from '../shared/audit';
+import { flushAuditEvents, recordAuditEvent } from '../shared/audit';
 import {
   deliverTestEvent,
   generateWebhookSecret,
@@ -145,6 +145,11 @@ auditRouter.openapi(
     await assertAuthorized(await actorOf(c, accountId), ACCOUNT_ACTIONS.AUDIT_READ);
     const denied = await requireEntitlement(c, accountId, 'auditAccess');
     if (denied) return denied;
+    // Audit writes are buffered off the request path (shared/audit-queue.ts).
+    // A reader must observe every event already emitted, so drain the queue
+    // before querying. Readers are rare; this keeps the write path fast without
+    // making the log eventually-consistent for API consumers.
+    await flushAuditEvents();
 
     const actionPrefix = c.req.query('action')?.trim() || null;
     const actor = c.req.query('actor')?.trim() || null;
@@ -329,6 +334,11 @@ auditRouter.openapi(
     await assertAuthorized(await actorOf(c, accountId), ACCOUNT_ACTIONS.AUDIT_READ);
     const denied = await requireEntitlement(c, accountId, 'auditAccess');
     if (denied) return denied;
+    // Audit writes are buffered off the request path (shared/audit-queue.ts).
+    // A reader must observe every event already emitted, so drain the queue
+    // before querying. Readers are rare; this keeps the write path fast without
+    // making the log eventually-consistent for API consumers.
+    await flushAuditEvents();
 
     const format = (c.req.query('format') || 'csv').toLowerCase();
     if (format !== 'csv' && format !== 'jsonl') {
@@ -453,6 +463,11 @@ auditRouter.openapi(
     await assertAuthorized(await actorOf(c, accountId), ACCOUNT_ACTIONS.ACCOUNT_WRITE);
     const denied = await requireEntitlement(c, accountId, 'auditAccess');
     if (denied) return denied;
+    // Audit writes are buffered off the request path (shared/audit-queue.ts).
+    // A reader must observe every event already emitted, so drain the queue
+    // before querying. Readers are rare; this keeps the write path fast without
+    // making the log eventually-consistent for API consumers.
+    await flushAuditEvents();
     let limit: number;
     try {
       limit = parseAuditLimit(c.req.query('limit')?.trim() || null, 1_000, 5_000);
@@ -727,6 +742,11 @@ auditRouter.openapi(
     const accountId = c.req.param('accountId');
     const webhookId = c.req.param('webhookId');
     await assertAuthorized(await actorOf(c, accountId), ACCOUNT_ACTIONS.ACCOUNT_WRITE);
+    // Audit writes are buffered off the request path (shared/audit-queue.ts).
+    // A reader must observe every event already emitted, so drain the queue
+    // before querying. Readers are rare; this keeps the write path fast without
+    // making the log eventually-consistent for API consumers.
+    await flushAuditEvents();
     let limit: number;
     try {
       limit = parseAuditLimit(c.req.query('limit')?.trim() || null, 100, 500);

--- a/apps/api/src/accounts/core/app.ts
+++ b/apps/api/src/accounts/core/app.ts
@@ -10,7 +10,7 @@ import {
 } from '../../shared/impersonation';
 import { accountRoleFor, countAccountOwners } from '../../iam/read-models';
 import { resolveAccountId } from '../../shared/resolve-account';
-import { getSupabase } from '../../shared/supabase';
+import { lookupEmailsByUserIds } from './owner-emails';
 import type { AppEnv } from '../../types';
 
 // ─── Public router (leaf module — no route imports here to avoid cycles) ─────
@@ -217,24 +217,11 @@ export async function countOwners(accountId: string): Promise<number> {
   return countAccountOwners(accountId);
 }
 
-export async function lookupEmailsByUserIds(
-  userIds: string[],
-): Promise<Map<string, string | null>> {
-  const result = new Map<string, string | null>();
-  if (userIds.length === 0) return result;
-  const supabase = getSupabase();
-  await Promise.all(
-    userIds.map(async (uid) => {
-      try {
-        const { data } = await supabase.auth.admin.getUserById(uid);
-        result.set(uid, data?.user?.email ?? null);
-      } catch {
-        result.set(uid, null);
-      }
-    }),
-  );
-  return result;
-}
+// Batched + cached owner-email lookup. Lives in ./owner-emails so it stays a
+// leaf module (db + sql only) and can be unit-tested without the account graph.
+// Re-exported here because it was part of this module's public surface.
+export { clearOwnerEmailCache, ownerEmailCacheSize } from './owner-emails';
+export { lookupEmailsByUserIds };
 
 // Display names for a batch of accounts, deriving the fallback for unnamed
 // (placeholder-named) accounts from the account OWNER's email — not the

--- a/apps/api/src/accounts/core/owner-emails.test.ts
+++ b/apps/api/src/accounts/core/owner-emails.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+interface ExecuteCall {
+  ids: string[];
+}
+
+const state = {
+  calls: [] as ExecuteCall[],
+  rows: [] as Array<{ id: string; email: string | null }>,
+  fail: false,
+};
+
+// Render the SQL through drizzle's own dialect so a test can assert
+// "one statement, N bound parameters" instead of just "one call".
+const dialect = new PgDialect();
+function paramsOf(query: unknown): string[] {
+  const { params } = dialect.sqlToQuery(query as SQL);
+  return params.filter((p): p is string => typeof p === 'string');
+}
+
+mock.module('../../shared/db', () => ({
+  db: {
+    execute: async (query: unknown) => {
+      state.calls.push({ ids: paramsOf(query) });
+      if (state.fail) throw new Error('auth.users unreachable');
+      return state.rows;
+    },
+  },
+  hasDatabase: true,
+}));
+
+const { clearOwnerEmailCache, lookupEmailsByUserIds, OWNER_EMAIL_TTL_MS, ownerEmailCacheSize } =
+  await import('./owner-emails');
+
+const A = '11111111-1111-4111-8111-111111111111';
+const B = '22222222-2222-4222-8222-222222222222';
+const C = '33333333-3333-4333-8333-333333333333';
+
+beforeEach(() => {
+  state.calls = [];
+  state.rows = [];
+  state.fail = false;
+  clearOwnerEmailCache();
+});
+
+describe('lookupEmailsByUserIds', () => {
+  test('issues no query for an empty id list', async () => {
+    const result = await lookupEmailsByUserIds([]);
+    expect(result.size).toBe(0);
+    expect(state.calls).toHaveLength(0);
+  });
+
+  test('resolves N ids with ONE query, not one call per id', async () => {
+    state.rows = [
+      { id: A, email: 'a@example.com' },
+      { id: B, email: 'b@example.com' },
+      { id: C, email: 'c@example.com' },
+    ];
+    const result = await lookupEmailsByUserIds([A, B, C]);
+    expect(state.calls).toHaveLength(1);
+    expect(state.calls[0]?.ids).toEqual([A, B, C]);
+    expect(result.get(A)).toBe('a@example.com');
+    expect(result.get(B)).toBe('b@example.com');
+    expect(result.get(C)).toBe('c@example.com');
+  });
+
+  test('deduplicates repeated ids into a single placeholder each', async () => {
+    state.rows = [{ id: A, email: 'a@example.com' }];
+    const result = await lookupEmailsByUserIds([A, A, A]);
+    expect(state.calls).toHaveLength(1);
+    expect(state.calls[0]?.ids).toEqual([A]);
+    expect(result.get(A)).toBe('a@example.com');
+  });
+
+  test('a warm cache serves repeat lookups with zero queries', async () => {
+    state.rows = [{ id: A, email: 'a@example.com' }];
+    await lookupEmailsByUserIds([A]);
+    expect(state.calls).toHaveLength(1);
+
+    const cached = await lookupEmailsByUserIds([A]);
+    expect(state.calls).toHaveLength(1);
+    expect(cached.get(A)).toBe('a@example.com');
+  });
+
+  test('queries only the ids that are not already cached', async () => {
+    state.rows = [{ id: A, email: 'a@example.com' }];
+    await lookupEmailsByUserIds([A]);
+
+    state.rows = [{ id: B, email: 'b@example.com' }];
+    const result = await lookupEmailsByUserIds([A, B]);
+    expect(state.calls).toHaveLength(2);
+    expect(state.calls[1]?.ids).toEqual([B]);
+    expect(result.get(A)).toBe('a@example.com');
+    expect(result.get(B)).toBe('b@example.com');
+  });
+
+  test('caches unknown ids as null so a deleted user is not re-queried', async () => {
+    state.rows = [];
+    const first = await lookupEmailsByUserIds([A]);
+    expect(first.get(A)).toBeNull();
+    expect(state.calls).toHaveLength(1);
+
+    await lookupEmailsByUserIds([A]);
+    expect(state.calls).toHaveLength(1);
+  });
+
+  test('re-queries once the TTL expires', async () => {
+    const t0 = 1_000_000;
+    state.rows = [{ id: A, email: 'a@example.com' }];
+    await lookupEmailsByUserIds([A], t0);
+    expect(state.calls).toHaveLength(1);
+
+    await lookupEmailsByUserIds([A], t0 + OWNER_EMAIL_TTL_MS - 1);
+    expect(state.calls).toHaveLength(1);
+
+    state.rows = [{ id: A, email: 'renamed@example.com' }];
+    const fresh = await lookupEmailsByUserIds([A], t0 + OWNER_EMAIL_TTL_MS + 1);
+    expect(state.calls).toHaveLength(2);
+    expect(fresh.get(A)).toBe('renamed@example.com');
+  });
+
+  test('a failed lookup degrades to null and does NOT poison the cache', async () => {
+    state.fail = true;
+    const result = await lookupEmailsByUserIds([A]);
+    expect(result.get(A)).toBeNull();
+    expect(ownerEmailCacheSize()).toBe(0);
+
+    // The next call must retry rather than serve a cached null.
+    state.fail = false;
+    state.rows = [{ id: A, email: 'a@example.com' }];
+    const retry = await lookupEmailsByUserIds([A]);
+    expect(state.calls).toHaveLength(2);
+    expect(retry.get(A)).toBe('a@example.com');
+  });
+});

--- a/apps/api/src/accounts/core/owner-emails.ts
+++ b/apps/api/src/accounts/core/owner-emails.ts
@@ -1,0 +1,91 @@
+/**
+ * Batched, cached user-email lookup.
+ *
+ * `resolveAccountDisplayNames` needs the OWNER's email to render a fallback name
+ * for placeholder-named accounts. It used to get them from
+ * `supabase.auth.admin.getUserById()` — one HTTPS call per owner, fanned out
+ * with `Promise.all` and awaited inside `GET /v1/accounts`. That fan-out is free
+ * against a localhost Supabase and costs one Auth-API round trip per owner
+ * against a hosted project, so the route blocked on N remote calls.
+ *
+ * `auth.users` is in the same Postgres the API already pools, and reading it
+ * directly is the established pattern in this codebase (`shared/users.ts`,
+ * `shared/platform-roles.ts`, `admin/index.ts`). One indexed lookup replaces the
+ * fan-out, and a short TTL cache collapses repeat calls.
+ *
+ * Kept as a leaf module (only `db` + `sql`) so it stays unit-testable.
+ */
+import { sql } from 'drizzle-orm';
+import { db } from '../../shared/db';
+
+// Owner emails change rarely and only decorate a display name, so a short TTL
+// is the right trade. Bounded so a large tenant cannot grow the map without end.
+export const OWNER_EMAIL_TTL_MS = 5 * 60 * 1000;
+export const OWNER_EMAIL_CACHE_MAX = 5_000;
+
+interface CacheEntry {
+  email: string | null;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export function clearOwnerEmailCache(): void {
+  cache.clear();
+}
+
+export function ownerEmailCacheSize(): number {
+  return cache.size;
+}
+
+/**
+ * Resolve emails for a batch of user ids using ONE query for everything not
+ * already cached. Unknown ids resolve to `null`. Never throws: a failed lookup
+ * degrades the account name, it does not fail the request.
+ */
+export async function lookupEmailsByUserIds(
+  userIds: string[],
+  now: number = Date.now(),
+): Promise<Map<string, string | null>> {
+  const result = new Map<string, string | null>();
+  if (userIds.length === 0) return result;
+
+  const misses: string[] = [];
+  for (const uid of new Set(userIds)) {
+    const hit = cache.get(uid);
+    if (hit && hit.expiresAt > now) result.set(uid, hit.email);
+    else misses.push(uid);
+  }
+  if (misses.length === 0) return result;
+
+  try {
+    // Explicit placeholder list. Drizzle renders a bare JS array as
+    // `($1, $2, …)`, so both `ANY(${ids}::uuid[])` and `IN (${ids})` produce
+    // invalid SQL — verified against the live postgres-js driver.
+    const placeholders = sql.join(
+      misses.map((uid) => sql`${uid}::uuid`),
+      sql`, `,
+    );
+    const rows = (await db.execute(
+      sql`SELECT id::text AS id, email FROM auth.users WHERE id IN (${placeholders})`,
+    )) as unknown as Array<{ id: string; email: string | null }>;
+    for (const r of rows) result.set(r.id, r.email ?? null);
+  } catch {
+    // auth.users unreachable (restricted role, schema absent). Fall through and
+    // cache nothing, so the next call retries rather than pinning a wrong null.
+    for (const uid of misses) if (!result.has(uid)) result.set(uid, null);
+    return result;
+  }
+
+  for (const uid of misses) {
+    // Cache misses as null too: a deleted user id would otherwise re-query on
+    // every account list.
+    if (!result.has(uid)) result.set(uid, null);
+    if (cache.size >= OWNER_EMAIL_CACHE_MAX) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
+    }
+    cache.set(uid, { email: result.get(uid) ?? null, expiresAt: now + OWNER_EMAIL_TTL_MS });
+  }
+  return result;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -134,7 +134,7 @@ import { accountsRouter } from './accounts';
 import { authRouter } from './auth';
 import { scimRouter } from './scim';
 import { accountInvitesRouter } from './accounts/invites';
-import { auditApiRequest } from './shared/audit';
+import { auditApiRequest, shutdownAuditEvents } from './shared/audit';
 import { startAuditWebhookWorker, stopAuditWebhookWorker } from './shared/audit-webhooks';
 import {
   startAuditReconciliationWorker,
@@ -1466,8 +1466,10 @@ async function shutdown(signal: string) {
   stopTunnelService();
   stopAccessControlCache();
   stopTmpReaper();
-  // Flush observability data before exit
-  await Promise.allSettled([appLogger.flush(), flushSentry()]);
+  // Flush observability data before exit. The audit queue is drained here
+  // because audit rows are buffered off the request path — without this, the
+  // last ~250 ms of events would be lost on every SIGTERM (i.e. every rollout).
+  await Promise.allSettled([shutdownAuditEvents(), appLogger.flush(), flushSentry()]);
   process.exit(0);
 }
 

--- a/apps/api/src/projects/routes/project-audit.ts
+++ b/apps/api/src/projects/routes/project-audit.ts
@@ -24,6 +24,7 @@ import {
   parseAuditSessionCursor,
   serializeAuditEvent,
 } from '../../shared/audit-query';
+import { flushAuditEvents } from '../../shared/audit';
 import { AuditEventSchema, AuditListSchema } from '../../shared/audit-schema';
 import { parseOpenCodeAuditBatch } from '../../shared/opencode-audit-ingestion';
 import { callerKortixSessionId } from '../lib/caller-session';
@@ -115,6 +116,10 @@ projectsApp.openapi(
         buildAuditCursorCondition(cursor, loaded.row.accountId, 'descending'),
       );
     }
+    // Audit writes are buffered off the request path (shared/audit-queue.ts).
+    // A reader must observe every event already emitted, so drain the queue
+    // before querying.
+    await flushAuditEvents();
     const fetched = await db
       .select()
       .from(auditEvents)
@@ -345,6 +350,10 @@ projectsApp.openapi(
       );
       if (cursorCondition) eventConditions.push(cursorCondition);
     }
+    // Audit writes are buffered off the request path (shared/audit-queue.ts).
+    // A reader must observe every event already emitted, so drain the queue
+    // before querying.
+    await flushAuditEvents();
     const fetchedEvents = audited && includeEvents
       ? await db
           .select()

--- a/apps/api/src/shared/audit-queue.test.ts
+++ b/apps/api/src/shared/audit-queue.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  AUDIT_FLUSH_MAX_DEFAULT,
+  AUDIT_FLUSH_MS_DEFAULT,
+  AUDIT_QUEUE_MAX_DEFAULT,
+  type AuditInsertClient,
+  AuditQueue,
+  type AuditRow,
+} from './audit-queue';
+
+function row(action: string): AuditRow {
+  return { action, resourceType: 'account' } as AuditRow;
+}
+
+interface FakeClient {
+  client: AuditInsertClient;
+  /** One entry per INSERT statement, holding that statement's rows. */
+  batches: AuditRow[][];
+  /** Counts `.onConflictDoNothing()` calls — proves dedup is applied. */
+  conflictCalls: number;
+  failNext: (fail: boolean) => void;
+  /** Blocks the write until released, so overlapping flushes can be observed. */
+  gate: (enabled: boolean) => void;
+  release: () => void;
+}
+
+function makeClient(): FakeClient {
+  const batches: AuditRow[][] = [];
+  let shouldFail = false;
+  let gated = false;
+  let releaseFn: (() => void) | null = null;
+  const state = {
+    client: {
+      insert: () => ({
+        values: (rows: AuditRow[]) => ({
+          onConflictDoNothing: async () => {
+            state.conflictCalls += 1;
+            batches.push([...rows]);
+            if (gated) {
+              await new Promise<void>((resolve) => {
+                releaseFn = resolve;
+              });
+            }
+            if (shouldFail) throw new Error('write failed');
+          },
+        }),
+      }),
+    } as unknown as AuditInsertClient,
+    batches,
+    conflictCalls: 0,
+    failNext: (fail: boolean) => {
+      shouldFail = fail;
+    },
+    gate: (enabled: boolean) => {
+      gated = enabled;
+    },
+    release: () => {
+      releaseFn?.();
+      releaseFn = null;
+    },
+  };
+  return state;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('AuditQueue', () => {
+  test('defaults match the documented tuning', () => {
+    expect(AUDIT_FLUSH_MS_DEFAULT).toBe(250);
+    expect(AUDIT_FLUSH_MAX_DEFAULT).toBe(500);
+    expect(AUDIT_QUEUE_MAX_DEFAULT).toBe(5_000);
+  });
+
+  test('enqueue buffers without writing, and never blocks on I/O', () => {
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, { flushMs: 10_000 });
+    q.enqueue(row('a'));
+    q.enqueue(row('b'));
+    // No await happened between enqueue and this assertion.
+    expect(fake.batches).toHaveLength(0);
+    expect(q.stats().queued).toBe(2);
+    expect(q.stats().enqueued).toBe(2);
+  });
+
+  test('flush writes every buffered row in ONE multi-row insert', async () => {
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, { flushMs: 10_000, flushMax: 500 });
+    for (const name of ['a', 'b', 'c']) q.enqueue(row(name));
+    await q.flush();
+    expect(fake.batches).toHaveLength(1);
+    expect(fake.batches[0]).toHaveLength(3);
+    expect(fake.batches[0]?.map((r) => r.action)).toEqual(['a', 'b', 'c']);
+    expect(q.stats().written).toBe(3);
+    expect(q.stats().queued).toBe(0);
+  });
+
+  test('every batch applies onConflictDoNothing, preserving source_record_id dedup', async () => {
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, { flushMs: 10_000, flushMax: 2 });
+    for (const name of ['a', 'b', 'c', 'd']) q.enqueue(row(name));
+    await q.flush();
+    // 4 rows / flushMax 2 => 2 statements, each deduped.
+    expect(fake.batches).toHaveLength(2);
+    expect(fake.conflictCalls).toBe(2);
+  });
+
+  test('chunks a drain into flushMax-sized statements', async () => {
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, { flushMs: 10_000, flushMax: 3, queueMax: 100 });
+    for (let i = 0; i < 7; i += 1) q.enqueue(row(`r${i}`));
+    await q.flush();
+    expect(fake.batches.map((b) => b.length)).toEqual([3, 3, 1]);
+    expect(q.stats().written).toBe(7);
+  });
+
+  test('reaching flushMax triggers an immediate flush without waiting for the timer', async () => {
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, { flushMs: 10_000, flushMax: 3 });
+    q.enqueue(row('a'));
+    q.enqueue(row('b'));
+    expect(fake.batches).toHaveLength(0);
+    q.enqueue(row('c'));
+    await q.flush();
+    expect(fake.batches).toHaveLength(1);
+    expect(fake.batches[0]).toHaveLength(3);
+  });
+
+  test('the timer flushes a partial batch on its own', async () => {
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, { flushMs: 15, flushMax: 500 });
+    q.enqueue(row('a'));
+    expect(fake.batches).toHaveLength(0);
+    await sleep(60);
+    expect(fake.batches).toHaveLength(1);
+    expect(fake.batches[0]?.map((r) => r.action)).toEqual(['a']);
+  });
+
+  test('overflow drops the OLDEST rows and keeps the newest', async () => {
+    const drops: Array<{ total: number; since: number }> = [];
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, {
+      flushMs: 10_000,
+      flushMax: 1_000,
+      queueMax: 3,
+      onDrop: (total, since) => drops.push({ total, since }),
+    });
+    for (const name of ['a', 'b', 'c', 'd', 'e']) q.enqueue(row(name));
+    expect(q.stats().queued).toBe(3);
+    expect(q.stats().dropped).toBe(2);
+    await q.flush();
+    expect(fake.batches[0]?.map((r) => r.action)).toEqual(['c', 'd', 'e']);
+    expect(drops[0]?.total).toBeGreaterThan(0);
+  });
+
+  test('drop warnings are rate-limited to once per interval', () => {
+    const drops: number[] = [];
+    let clock = 1_000;
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, {
+      flushMs: 10_000,
+      flushMax: 1_000,
+      queueMax: 1,
+      dropLogIntervalMs: 60_000,
+      now: () => clock,
+      onDrop: (_total, since) => drops.push(since),
+    });
+    for (let i = 0; i < 10; i += 1) q.enqueue(row(`r${i}`));
+    expect(drops).toHaveLength(1);
+    expect(q.stats().dropped).toBe(9);
+
+    clock += 60_001;
+    for (let i = 0; i < 5; i += 1) q.enqueue(row(`s${i}`));
+    expect(drops).toHaveLength(2);
+    // Rate limiting suppresses the WARNING, never the accounting: the second
+    // warning reports every drop since the first one (8 suppressed + 1 new),
+    // so no dropped event goes unreported.
+    expect(drops[1]).toBe(9);
+    expect(q.stats().dropped).toBe(14);
+  });
+
+  test('a write failure never throws and never wedges the queue', async () => {
+    const errors: number[] = [];
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, {
+      flushMs: 10_000,
+      onError: (_e, count) => errors.push(count),
+    });
+    fake.failNext(true);
+    q.enqueue(row('a'));
+    await q.flush(); // must resolve, not reject
+    expect(errors).toEqual([1]);
+    expect(q.stats().failed).toBe(1);
+    expect(q.stats().written).toBe(0);
+
+    // The queue still accepts and writes afterwards.
+    fake.failNext(false);
+    q.enqueue(row('b'));
+    await q.flush();
+    expect(q.stats().written).toBe(1);
+  });
+
+  test('concurrent flushes share one drain instead of double-writing', async () => {
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, { flushMs: 10_000, flushMax: 100 });
+    fake.gate(true);
+    q.enqueue(row('a'));
+    const first = q.flush();
+    const second = q.flush();
+    expect(second).toBe(first);
+    fake.release();
+    fake.gate(false);
+    await first;
+    expect(fake.batches).toHaveLength(1);
+    expect(q.stats().written).toBe(1);
+  });
+
+  test('shutdown drains the tail so a SIGTERM loses nothing', async () => {
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, { flushMs: 10_000, flushMax: 500 });
+    q.enqueue(row('a'));
+    q.enqueue(row('b'));
+    await q.shutdown();
+    expect(fake.batches).toHaveLength(1);
+    expect(fake.batches[0]).toHaveLength(2);
+    expect(q.stats().queued).toBe(0);
+    expect(q.stats().written).toBe(2);
+  });
+
+  test('rows enqueued during a flush are written by a follow-up drain', async () => {
+    const fake = makeClient();
+    const q = new AuditQueue(fake.client, { flushMs: 10, flushMax: 100 });
+    fake.gate(true);
+    q.enqueue(row('a'));
+    const inFlight = q.flush();
+    q.enqueue(row('b'));
+    fake.release();
+    fake.gate(false);
+    await inFlight;
+    await sleep(40);
+    expect(fake.batches.flat().map((r) => r.action)).toEqual(['a', 'b']);
+  });
+});

--- a/apps/api/src/shared/audit-queue.ts
+++ b/apps/api/src/shared/audit-queue.ts
@@ -1,0 +1,234 @@
+/**
+ * Bounded, batched, asynchronous writer for `kortix.audit_events`.
+ *
+ * Why this exists: `auditApiRequest` (shared/audit.ts) runs on every `/v1/*`
+ * request and used to `await` a single-row INSERT into a 14-index table before
+ * the response was released. On staging that put the audit write on the
+ * critical path of every authenticated request: pg_stat_statements measured the
+ * INSERT at a 8,134 ms mean over 8,885 calls under release-gate load, and the
+ * resulting request times (up to 37 s) turned into ALB 5xx.
+ *
+ * The fix is to decouple emission from the request. Callers enqueue a fully
+ * built row and return immediately; a flusher drains the queue into multi-row
+ * INSERTs. The queue is bounded and drops the OLDEST rows on overflow, so a
+ * database stall degrades audit completeness instead of degrading availability.
+ *
+ * Invariants:
+ *  - `enqueue` never throws and never blocks on I/O.
+ *  - a flush never throws into a caller; failures are logged and the batch is
+ *    dropped (retrying in-process would amplify the stall that caused it).
+ *  - the batch INSERT uses `onConflictDoNothing()`, which preserves the
+ *    `idx_audit_events_source_phase` partial-unique dedup semantics
+ *    (source_ledger, source_record_id, phase, coalesce(source_revision,''))
+ *    used by the OpenCode relay ledger. Without it a single duplicate row would
+ *    fail an entire batch.
+ */
+import { type Database, auditEvents } from '@kortix/db';
+
+export type AuditRow = typeof auditEvents.$inferInsert;
+
+/** The minimum surface the queue needs from Drizzle — keeps tests db-free. */
+export type AuditInsertClient = Pick<Database, 'insert'>;
+
+export interface AuditQueueOptions {
+  /** Flush at most this long after the first row of a batch is enqueued. */
+  flushMs?: number;
+  /** Flush immediately once the queue holds this many rows. */
+  flushMax?: number;
+  /** Hard ceiling on buffered rows. Overflow drops the oldest. */
+  queueMax?: number;
+  /** Minimum gap between "dropped N events" warnings. */
+  dropLogIntervalMs?: number;
+  now?: () => number;
+  onError?: (error: unknown, rowCount: number) => void;
+  onDrop?: (droppedTotal: number, sinceLastLog: number) => void;
+}
+
+export const AUDIT_FLUSH_MS_DEFAULT = 250;
+export const AUDIT_FLUSH_MAX_DEFAULT = 500;
+export const AUDIT_QUEUE_MAX_DEFAULT = 5_000;
+const DROP_LOG_INTERVAL_MS = 60_000;
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export interface AuditQueueStats {
+  queued: number;
+  enqueued: number;
+  written: number;
+  dropped: number;
+  failed: number;
+  flushes: number;
+}
+
+export class AuditQueue {
+  private readonly rows: AuditRow[] = [];
+  private readonly flushMs: number;
+  private readonly flushMax: number;
+  private readonly queueMax: number;
+  private readonly dropLogIntervalMs: number;
+  private readonly now: () => number;
+  private readonly onError: (error: unknown, rowCount: number) => void;
+  private readonly onDrop: (droppedTotal: number, sinceLastLog: number) => void;
+
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private inFlight: Promise<void> | null = null;
+  /** `null` = never warned yet. The FIRST overflow must always warn. */
+  private lastDropLogAt: number | null = null;
+  private droppedSinceLastLog = 0;
+
+  private enqueued = 0;
+  private written = 0;
+  private dropped = 0;
+  private failed = 0;
+  private flushes = 0;
+
+  constructor(
+    private readonly client: AuditInsertClient,
+    options: AuditQueueOptions = {},
+  ) {
+    this.flushMs = options.flushMs ?? AUDIT_FLUSH_MS_DEFAULT;
+    this.flushMax = options.flushMax ?? AUDIT_FLUSH_MAX_DEFAULT;
+    this.queueMax = options.queueMax ?? AUDIT_QUEUE_MAX_DEFAULT;
+    this.dropLogIntervalMs = options.dropLogIntervalMs ?? DROP_LOG_INTERVAL_MS;
+    this.now = options.now ?? Date.now;
+    this.onError =
+      options.onError ??
+      ((error, rowCount) => {
+        console.error(
+          `[audit] Dropped a batch of ${rowCount} events after a write failure:`,
+          error,
+        );
+      });
+    this.onDrop =
+      options.onDrop ??
+      ((droppedTotal, sinceLastLog) => {
+        console.warn(
+          `[audit] Queue full — dropped ${sinceLastLog} oldest events (${droppedTotal} total). Audit writes are falling behind; raise KORTIX_AUDIT_QUEUE_MAX or investigate database latency.`,
+        );
+      });
+  }
+
+  /**
+   * Buffer one row. Returns synchronously — never awaits I/O, never throws.
+   * The row must already be fully built (request context resolved) because it
+   * is written long after the request's AsyncLocalStorage scope has ended.
+   */
+  enqueue(row: AuditRow): void {
+    this.enqueued += 1;
+    this.rows.push(row);
+
+    if (this.rows.length > this.queueMax) {
+      // Drop OLDEST: under sustained overload the newest events describe the
+      // incident in progress and are the ones worth keeping.
+      const overflow = this.rows.length - this.queueMax;
+      this.rows.splice(0, overflow);
+      this.dropped += overflow;
+      this.droppedSinceLastLog += overflow;
+      this.maybeLogDrops();
+    }
+
+    if (this.rows.length >= this.flushMax) {
+      void this.flush();
+      return;
+    }
+    this.scheduleFlush();
+  }
+
+  private maybeLogDrops(): void {
+    const now = this.now();
+    if (this.lastDropLogAt !== null && now - this.lastDropLogAt < this.dropLogIntervalMs) return;
+    this.lastDropLogAt = now;
+    const sinceLastLog = this.droppedSinceLastLog;
+    this.droppedSinceLastLog = 0;
+    this.onDrop(this.dropped, sinceLastLog);
+  }
+
+  private scheduleFlush(): void {
+    if (this.timer !== null || this.rows.length === 0) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.flush();
+    }, this.flushMs);
+    // Never hold the process open for a pending audit flush; `flush()` on the
+    // shutdown path is what guarantees the tail is written.
+    this.timer.unref?.();
+  }
+
+  /**
+   * Drain the queue into batched INSERTs. Safe to call concurrently: overlapping
+   * callers await the in-flight drain instead of racing it. Never rejects.
+   */
+  flush(): Promise<void> {
+    if (this.inFlight) return this.inFlight;
+    const run = this.drain().finally(() => {
+      this.inFlight = null;
+      // A row enqueued while the drain was running still needs a timer.
+      this.scheduleFlush();
+    });
+    this.inFlight = run;
+    return run;
+  }
+
+  private async drain(): Promise<void> {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    while (this.rows.length > 0) {
+      const batch = this.rows.splice(0, this.flushMax);
+      this.flushes += 1;
+      try {
+        await this.client.insert(auditEvents).values(batch).onConflictDoNothing();
+        this.written += batch.length;
+      } catch (error) {
+        // Re-queuing would amplify whatever stalled the database, and the audit
+        // trail is best-effort by construction. Account for it and move on.
+        this.failed += batch.length;
+        this.onError(error, batch.length);
+      }
+    }
+  }
+
+  /** Flush everything and stop the timer. Used by the shutdown path. */
+  async shutdown(): Promise<void> {
+    await this.flush();
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  stats(): AuditQueueStats {
+    return {
+      queued: this.rows.length,
+      enqueued: this.enqueued,
+      written: this.written,
+      dropped: this.dropped,
+      failed: this.failed,
+      flushes: this.flushes,
+    };
+  }
+}
+
+let queue: AuditQueue | null = null;
+
+/** Lazily built so importing this module never touches the database. */
+export function getAuditQueue(client: AuditInsertClient): AuditQueue {
+  if (!queue) {
+    queue = new AuditQueue(client, {
+      flushMs: positiveInt(process.env.KORTIX_AUDIT_FLUSH_MS, AUDIT_FLUSH_MS_DEFAULT),
+      flushMax: positiveInt(process.env.KORTIX_AUDIT_FLUSH_MAX, AUDIT_FLUSH_MAX_DEFAULT),
+      queueMax: positiveInt(process.env.KORTIX_AUDIT_QUEUE_MAX, AUDIT_QUEUE_MAX_DEFAULT),
+    });
+  }
+  return queue;
+}
+
+/** Test seam. */
+export function resetAuditQueueForTests(): void {
+  queue = null;
+}

--- a/apps/api/src/shared/audit.ts
+++ b/apps/api/src/shared/audit.ts
@@ -4,6 +4,7 @@ import type { Context, Next } from 'hono';
 import { getRequestContext } from '../lib/request-context';
 import type { AppEnv } from '../types';
 import { normalizeAuditClientSource } from './audit-client-source';
+import { type AuditRow, getAuditQueue } from './audit-queue';
 import { db } from './db';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -292,7 +293,15 @@ function sanitizeAuditRecord(
 type AuditInsertClient = Pick<Database, 'insert'>;
 type AuditTransaction = Parameters<Parameters<Database['transaction']>[0]>[0];
 
-async function insertAuditEvent(client: AuditInsertClient, input: AuditEventInput): Promise<void> {
+/**
+ * Build the row synchronously, at emit time.
+ *
+ * This MUST stay separate from the write: `recordAuditEvent` enqueues and the
+ * flusher writes hundreds of milliseconds later, by which point the request's
+ * AsyncLocalStorage scope (`getRequestContext()`) has ended and the caller may
+ * have mutated `input`. Everything context- or caller-derived is resolved here.
+ */
+function buildAuditRow(input: AuditEventInput): AuditRow {
   const request = getRequestContext();
   const authoritativeSource = input.authoritativeSource ?? input.source ?? 'api';
   const inputSummary = sanitizeAuditRecord(input.inputSummary);
@@ -300,72 +309,123 @@ async function insertAuditEvent(client: AuditInsertClient, input: AuditEventInpu
   const before = sanitizeAuditRecord(input.before);
   const after = sanitizeAuditRecord(input.after);
   const metadata = sanitizeAuditRecord(input.metadata) ?? {};
+  return {
+    accountId: uuidOrNull(input.accountId || request?.accountId),
+    projectId: uuidOrNull(input.projectId || request?.projectId),
+    sessionId: input.sessionId || request?.sessionId || null,
+    opencodeSessionId: input.opencodeSessionId ?? null,
+    turnId: input.turnId ?? null,
+    messageId: input.messageId ?? null,
+    toolCallId: input.toolCallId ?? null,
+    executionId: input.executionId ?? null,
+    actorUserId: uuidOrNull(input.actorUserId),
+    actorType: input.actorType ?? (input.actorUserId ? 'human' : 'system'),
+    agentId: input.agentId ?? null,
+    agentName: input.agentName ?? null,
+    initiatorActorType: input.initiatorActorType ?? null,
+    initiatorActorId: input.initiatorActorId ?? null,
+    parentEventId: uuidOrNull(input.parentEventId),
+    delegationDepth: input.delegationDepth ?? 0,
+    source: authoritativeSource,
+    authoritativeSource,
+    clientReportedSource: input.clientReportedSource ?? null,
+    outcome: input.outcome ?? 'success',
+    action: input.action,
+    phase: input.phase ?? 'completed',
+    resourceType: input.resourceType,
+    resourceId: input.resourceId || null,
+    httpStatus: input.httpStatus ?? null,
+    durationMs: input.durationMs ?? null,
+    requestId: input.requestId || request?.requestId || null,
+    traceId: input.traceId || request?.traceId || null,
+    correlationId: input.correlationId || null,
+    causationId: input.causationId ?? null,
+    sourceLedger: input.sourceLedger ?? null,
+    sourceRecordId: input.sourceRecordId ?? null,
+    sourceRevision: input.sourceRevision ?? null,
+    inputSummary,
+    outputSummary,
+    inputSha256: input.inputSha256 ?? (input.inputSummary ? sha256(input.inputSummary) : null),
+    outputSha256:
+      input.outputSha256 ??
+      (input.outputSummary
+        ? sha256(input.outputSummary)
+        : input.errorMessage
+          ? sha256(input.errorMessage)
+          : null),
+    errorCode: input.errorCode ?? null,
+    // Provider and runtime errors can echo prompts, credentials, or response
+    // bodies. Preserve `errorCode` and a SHA-256 fingerprint only.
+    errorMessage: null,
+    before,
+    after,
+    ip: input.ip || null,
+    userAgent:
+      typeof input.userAgent === 'string' && SECRET_VALUE_RE.test(input.userAgent)
+        ? '[REDACTED]'
+        : input.userAgent || null,
+    metadata,
+  };
+}
+
+/**
+ * Single-row, synchronous insert. Still used by `runAuditedTransaction` (which
+ * must write inside the caller's transaction) and by the synchronous test mode.
+ * The `.returning()` is what makes the statement awaited by the transaction, so
+ * a failed audit write still rolls the mutation back.
+ */
+async function insertAuditEvent(client: AuditInsertClient, input: AuditEventInput): Promise<void> {
   await client
     .insert(auditEvents)
-    .values({
-      accountId: uuidOrNull(input.accountId || request?.accountId),
-      projectId: uuidOrNull(input.projectId || request?.projectId),
-      sessionId: input.sessionId || request?.sessionId || null,
-      opencodeSessionId: input.opencodeSessionId ?? null,
-      turnId: input.turnId ?? null,
-      messageId: input.messageId ?? null,
-      toolCallId: input.toolCallId ?? null,
-      executionId: input.executionId ?? null,
-      actorUserId: uuidOrNull(input.actorUserId),
-      actorType: input.actorType ?? (input.actorUserId ? 'human' : 'system'),
-      agentId: input.agentId ?? null,
-      agentName: input.agentName ?? null,
-      initiatorActorType: input.initiatorActorType ?? null,
-      initiatorActorId: input.initiatorActorId ?? null,
-      parentEventId: uuidOrNull(input.parentEventId),
-      delegationDepth: input.delegationDepth ?? 0,
-      source: authoritativeSource,
-      authoritativeSource,
-      clientReportedSource: input.clientReportedSource ?? null,
-      outcome: input.outcome ?? 'success',
-      action: input.action,
-      phase: input.phase ?? 'completed',
-      resourceType: input.resourceType,
-      resourceId: input.resourceId || null,
-      httpStatus: input.httpStatus ?? null,
-      durationMs: input.durationMs ?? null,
-      requestId: input.requestId || request?.requestId || null,
-      traceId: input.traceId || request?.traceId || null,
-      correlationId: input.correlationId || null,
-      causationId: input.causationId ?? null,
-      sourceLedger: input.sourceLedger ?? null,
-      sourceRecordId: input.sourceRecordId ?? null,
-      sourceRevision: input.sourceRevision ?? null,
-      inputSummary,
-      outputSummary,
-      inputSha256: input.inputSha256 ?? (input.inputSummary ? sha256(input.inputSummary) : null),
-      outputSha256:
-        input.outputSha256 ??
-        (input.outputSummary
-          ? sha256(input.outputSummary)
-          : input.errorMessage
-            ? sha256(input.errorMessage)
-            : null),
-      errorCode: input.errorCode ?? null,
-      // Provider and runtime errors can echo prompts, credentials, or response
-      // bodies. Preserve `errorCode` and a SHA-256 fingerprint only.
-      errorMessage: null,
-      before,
-      after,
-      ip: input.ip || null,
-      userAgent:
-        typeof input.userAgent === 'string' && SECRET_VALUE_RE.test(input.userAgent)
-          ? '[REDACTED]'
-          : input.userAgent || null,
-      metadata,
-    })
+    .values(buildAuditRow(input))
     .returning({ eventId: auditEvents.eventId });
 }
 
-export async function recordAuditEvent(input: AuditEventInput): Promise<void> {
-  await insertAuditEvent(db, input);
+/**
+ * Synchronous emission is kept for tests, which read the row back immediately
+ * after the action that produced it. `KORTIX_AUDIT_SYNC=1` forces it anywhere;
+ * `KORTIX_AUDIT_SYNC=0` forces the queue on under a test runner.
+ */
+function auditWritesAreSynchronous(): boolean {
+  const flag = process.env.KORTIX_AUDIT_SYNC;
+  if (flag === '1') return true;
+  if (flag === '0') return false;
+  return process.env.NODE_ENV === 'test';
 }
 
+/**
+ * Emit one audit event.
+ *
+ * Returns as soon as the row is buffered — the INSERT happens on the flusher,
+ * off the request path. The signature stays `Promise<void>` so the ~74 existing
+ * call sites are unchanged, and a write failure can no longer surface as a
+ * rejected promise in a request handler.
+ */
+export async function recordAuditEvent(input: AuditEventInput): Promise<void> {
+  if (auditWritesAreSynchronous()) {
+    await insertAuditEvent(db, input);
+    return;
+  }
+  getAuditQueue(db).enqueue(buildAuditRow(input));
+}
+
+/** Drain buffered audit events. Called on shutdown and by tests. */
+export async function flushAuditEvents(): Promise<void> {
+  if (auditWritesAreSynchronous()) return;
+  await getAuditQueue(db).flush();
+}
+
+/** Flush and stop the flush timer. Shutdown path only. */
+export async function shutdownAuditEvents(): Promise<void> {
+  if (auditWritesAreSynchronous()) return;
+  await getAuditQueue(db).shutdown();
+}
+
+/**
+ * Deliberately NOT queued. The whole point of this helper is that the audit row
+ * commits atomically with the operation it describes, so it must stay inside the
+ * transaction. Only 5 call sites use it and none are on a hot path.
+ */
 export async function runAuditedTransaction<T>(
   operation: (tx: AuditTransaction) => Promise<T>,
   event: (result: T) => AuditEventInput,


### PR DESCRIPTION
## Problem

Two synchronous calls sat on the critical path of every authenticated `/v1/*` request.

**1. Audit writes blocked the response.** `auditApiRequest` is mounted globally (`index.ts:377`) and awaited a single-row INSERT into `kortix.audit_events` — a 14-index table — inside its `finally` block (`shared/audit.ts:405`). The response was not released until that row committed. `/v1/health` is in `SKIPPED_PATHS`, which is exactly why health stayed fast on staging while authenticated routes did not.

Under release-gate load on staging, `pg_stat_statements` measured that INSERT at a **8,134 ms mean over 8,885 calls**. Requests reached 37 s, the ALB turned them into 5xx, and the edge laundered those into MAINTENANCE_MODE 503s.

`POST /v1/accounts` paid it **twice** — once for the middleware and once for `assignRole` (`iam/assignments.ts:923`).

**2. Owner-email resolution was an N+1 over HTTPS.** `lookupEmailsByUserIds` issued one `supabase.auth.admin.getUserById()` call per account owner, fanned out with `Promise.all` and awaited inside `GET /v1/accounts` (via `resolveAccountDisplayNames`). Free against a localhost Supabase; one Supabase Auth API round trip per owner against a hosted project.

## Fix

### Audit queue (`shared/audit-queue.ts`, new)

`recordAuditEvent` now builds the row synchronously and enqueues it. Row construction **must** stay on the request path — `getRequestContext()` reads AsyncLocalStorage that is gone by flush time, and callers may mutate their input afterwards.

- flushes every **250 ms** or **500 rows**, whichever comes first
- bounded at **5,000 rows**; overflow drops the **oldest** (the newest events describe the incident in progress), with a warning at most once per minute
- all three tunable: `KORTIX_AUDIT_FLUSH_MS`, `KORTIX_AUDIT_FLUSH_MAX`, `KORTIX_AUDIT_QUEUE_MAX`
- `enqueue` never blocks and never throws; a failed batch is counted and dropped rather than retried, which would amplify whatever stalled the database
- concurrent `flush()` calls coalesce onto one in-flight drain
- the batch INSERT uses `onConflictDoNothing()`, preserving the `idx_audit_events_source_phase` partial-unique dedup on `(source_ledger, source_record_id, phase, coalesce(source_revision,''))`. **Without it a single duplicate row would fail an entire 500-row batch** — the single-row insert it replaces had no conflict clause because one row could simply throw.
- `shutdown()` drains the queue in the SIGTERM path (`index.ts:1472`)

**Deliberately left synchronous:**

| Site | Why |
|---|---|
| `runAuditedTransaction` | Its contract is that the audit row commits atomically with the mutation. Must stay in the transaction. 5 call sites, none hot. |
| `POST /v1/projects/:id/audit` ingestion | Response body reports `inserted`/`duplicates`, so it genuinely depends on the written rows. Untouched — the #6583 runaway guard still counts and suppresses before the insert, same semantics. |
| Test runs (`NODE_ENV=test`) | Tests read audit rows back immediately after the action. `KORTIX_AUDIT_SYNC=1\|0` forces either mode explicitly. |

### Read-after-write consistency

Buffering created a real hazard: a client that reads the audit log immediately after the action that produced an event would see an empty log. The `AUD-FILTER` and `AUD-6` e2e flows do exactly that, with no polling, and they caught it.

The fix is to make **readers** pay, not writers. Every endpoint that serves audit data drains the queue before it queries:

| Route | File |
|---|---|
| `GET /v1/accounts/{id}/audit` | `accounts/audit.ts` |
| `GET /v1/accounts/{id}/audit/export` | `accounts/audit.ts` |
| `GET /v1/accounts/{id}/audit/webhooks/{id}/deliveries` | `accounts/audit.ts` |
| `POST /v1/accounts/{id}/audit/reconcile` | `accounts/audit.ts` |
| `GET /v1/projects/{id}/audit` | `projects/routes/project-audit.ts` |
| `GET /v1/projects/{id}/sessions/{id}/audit` | `projects/routes/project-audit.ts` |

The deliveries route needs it too: `audit_events_enqueue_webhooks` is an `AFTER INSERT ... FOR EACH ROW` trigger, so the delivery row only exists once the buffered audit row lands. Batching preserves the trigger — it fires per row in a multi-row insert.

Reads are rare and not latency-critical, so this keeps the entire write-path win. The flush sits after authorization, so it is not an unauthenticated lever.

Proven causally: both flows pass with the flush; disabling **only** the flush reproduces the exact CI errors (`expected one correlated event, got 0`).

### Batched owner emails (`accounts/core/owner-emails.ts`, new)

One indexed `auth.users` lookup for the whole batch through the pool the API already holds, plus a 5-minute / 5,000-entry in-process cache. Reading `auth.users` directly is the established pattern here (`shared/users.ts`, `shared/platform-roles.ts`, `admin/index.ts`). Extracted to a leaf module so it is unit-testable without the account import graph.

A failed lookup degrades to `null` and does **not** cache, so the next call retries instead of pinning a wrong value.

> Note on the SQL: drizzle renders a bare JS array as `($1, $2, …)`, so both `ANY(${ids}::uuid[])` and `IN (${ids})` produce invalid SQL. Verified against the live driver; the code uses an explicit `sql.join` placeholder list.

## Measured result

Interleaved on one machine — main and this branch alternated, same session, so drift is controlled. Local Postgres is on localhost, so this **understates** the staging effect.

**concurrency 100, 1000 requests, 3 runs each**

| | main | this PR | |
|---|---|---|---|
| `GET /v1/accounts` mean | 171 ms | **148 ms** | −14% |
| `GET /v1/accounts` p95 | 203 ms | **179 ms** | −12% |
| `POST /v1/accounts` mean | 271 ms | **221 ms** | −19% |
| `POST /v1/accounts` p95 | 321 ms | **263 ms** | −18% |
| throughput | 442 req/s | **524 req/s** | +19% |

**idle, 10 samples each**

| | main | this PR | |
|---|---|---|---|
| `GET /v1/accounts` mean | 8.7 ms | **6.4 ms** | −27% |
| `POST /v1/accounts` mean | 11.2 ms | **8.8 ms** | −21% |

Baseline and fix ranges do not overlap on any metric (e.g. baseline throughput max 469.7 req/s < fix min 506.0 req/s).

An earlier A/B that disabled audit writes entirely gave GET 128 ms / POST 191 ms / 605 req/s — the ceiling. The queue lands close to it **while still writing every row**.

**No audit rows are lost.** 1000 requests produced 2,626 audit rows.

**Shutdown drain, with a negative control:** 12 requests then an immediate SIGTERM inside the flush window → **12 of 12 rows land**. With the shutdown hook removed → only **4 of 12** land. The hook is load-bearing and the assertion is not vacuous.

## On the ~3–5 s staging overhead at idle

**It does not reproduce locally** — `GET /v1/accounts` is 8.7 ms and `POST` 11.2 ms here on main. Local Supabase is on localhost, so every per-request call to it is ~1 ms. The overhead is environment-specific, and the call-site evidence points at the awaited per-request calls that are ~0 ms locally and real time against hosted services:

1. **`shared/resolve-account.ts:45`** — `withTimeout(syncLegacyStripeSubscription(…), 1_500)`, reached on every `GET`/`POST /v1/accounts` via `accounts/index.ts:26`. Blocks up to **1.5 s**, once per account per hour (`ttlMemo`). The release gate creates accounts constantly, so a large share of its requests are that first one. **Not changed here** — it is already bounded and memoized by a prior fix, and its in-code comment records the 8–12 s it used to cost. Flagging it as the next candidate rather than widening this PR's blast radius.
2. **`accounts/core/app.ts:229`** — the admin-API N+1. **Fixed in this PR.**
3. **`shared/audit.ts:405`** — the synchronous audit insert. **Fixed in this PR.**

Attribution of the residual seconds needs a measurement from inside a staging task; I did not have one and am not claiming a number I cannot show.

## Tests

21 new cases.

- `shared/audit-queue.test.ts` — enqueue buffers without I/O; one multi-row insert per drain; `flushMax` chunking; timer flush; immediate flush at threshold; overflow drops oldest and keeps newest; drop warnings rate-limited (and the accounting still reports every drop); write failure neither throws nor wedges; concurrent flushes coalesce; shutdown drains the tail; rows enqueued mid-flush are picked up.
- `accounts/core/owner-emails.test.ts` — one query for N ids (asserted on the rendered parameter list, not just call count); dedup; warm-cache zero queries; only-uncached ids queried; negative caching; TTL expiry; failure does not poison the cache.

`unit-account-display-names.test.ts` updated: its db mock now serves emails through `db.execute` instead of the admin API, and it clears the new cache between tests.

## Verification

```
apps/api $ npx tsc --noEmit                 # TYPECHECK_EXIT=0
apps/api $ bash scripts/test.sh             # SUITE_EXIT=0
                                            # 7553 pass, 74 skip, 0 fail, 657 files
$ pnpm test -- --domain audit               # EXIT=0  7/7 passed
$ pnpm test -- --id AUD-FILTER              # EXIT=0  1/1 passed
$ pnpm test -- --id AUD-6                   # EXIT=0  1/1 passed
```

A full local `pnpm test` also reports 15 unrelated IAM/INV/PACC/TRG/MEM/APP/CHN failures. Those reproduce identically on `main` in this checkout (verified: `IAM-10` fails with the same 500 on stashed-to-main code) — they are local shared-Supabase pollution from my own load testing, not this change. CI's core lane failed on `AUD-FILTER` and `AUD-6` only, both fixed here.

Biome clean on every file this PR adds or rewrites. `index.ts` reports 21 lint errors both with and without this change — pre-existing, unchanged.

No schema change. No migration. `tests/**`, `.github/workflows/**`, `infra/**`, and `packages/db/migrations/**` untouched.
