### PR TITLE
perf(ci): dev single-arch + layer cache + fix the frontend-skip

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -73,10 +73,44 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Full history so the change-diff can be taken against the SHA that dev
+          # is ACTUALLY running (below), which may be many commits back.
+          fetch-depth: 0
+      - name: Resolve deploy base (what dev is actually running)
+        id: base
+        if: github.event_name == 'push'
+        run: |
+          # THE FLAKY-SKIP FIX. The old filter diffed `github.event.before..sha`
+          # — the commits in THIS push only. But `cancel-in-progress: false`
+          # collapses a burst of pushes into one deploy for the NEWEST sha, whose
+          # own diff misses a surface changed by an earlier, superseded commit —
+          # so that surface's job silently skips and the change strands on dev.
+          # Diff against the sha dev is running instead: every surface stale
+          # relative to the live deployment rebuilds, regardless of push grouping.
+          set +e
+          deployed=$(curl -sf --max-time 8 https://dev-api.kortix.com/v1/health \
+            | python3 -c "import sys,json;print(json.load(sys.stdin).get('commit',''))" 2>/dev/null)
+          set -e
+          if [ -n "$deployed" ] && [ "$deployed" != "unknown" ] && git cat-file -e "${deployed}^{commit}" 2>/dev/null; then
+            echo "base=$deployed" >> "$GITHUB_OUTPUT"
+            echo "force_all=false" >> "$GITHUB_OUTPUT"
+            echo "Comparing changed surfaces against deployed dev SHA ${deployed}"
+          else
+            # Health down, or the deployed sha is not in history (force-push,
+            # shallow, first deploy). Fail SAFE: build every surface rather than
+            # risk skipping a stale one. A redundant build is cheap; a stranded
+            # surface is the bug this fix exists to kill.
+            echo "base=" >> "$GITHUB_OUTPUT"
+            echo "force_all=true" >> "$GITHUB_OUTPUT"
+            echo "Deployed SHA unavailable ('${deployed}') — building ALL surfaces (fail-safe)"
+          fi
       - name: Path filter
         uses: dorny/paths-filter@v4
         id: filter
         with:
+          # For a push, compare against what dev runs (empty = action's default).
+          base: ${{ steps.base.outputs.base }}
           filters: |
             api:
               - 'apps/api/**'
@@ -145,6 +179,11 @@ jobs:
           frontend="${{ steps.filter.outputs.frontend }}"
           cli="${{ steps.filter.outputs.cli }}"
           terraform="${{ steps.filter.outputs.terraform }}"
+          if [ "${{ steps.base.outputs.force_all }}" = "true" ]; then
+            # Fail-safe from the base resolver: dev's running SHA was unknown, so
+            # build everything rather than skip a possibly-stale surface.
+            api=true; apps_router=true; gateway=true; frontend=true; cli=true; terraform=true
+          fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "${{ inputs.surface }}" = "frontend" ]; then
               api=false
@@ -297,7 +336,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push (amd64 + arm64)
+      - name: Build and push (amd64)
+        # DEV IS SINGLE-ARCH (amd64). dev ECS Fargate runs x86_64, so the arm64
+        # half was pure emulation cost — a QEMU-emulated arm64 build took the API
+        # image ~22 min, ~2/3 of the whole run, for an image dev never boots. This
+        # restores the deliberate `1ca937570d` state ("dev single-arch, multi-arch
+        # on prod only") that the `cb9d12a1b3` pipeline rewrite silently undid.
+        # deploy-prod.yml keeps amd64+arm64. Registry layer cache makes warm builds
+        # reuse layers instead of every build being cold.
         # Bake the dev version (e.g. 0.9.7-dev.<sha8>) into the image so
         # /v1/health reports it. The immutable :dev-<sha8> tag (tag-api job below)
         # is the artifact's real identity.
@@ -305,8 +351,10 @@ jobs:
         with:
           context: .
           file: apps/api/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
+          cache-from: type=registry,ref=kortix/kortix-api:dev-buildcache
+          cache-to: type=registry,ref=kortix/kortix-api:dev-buildcache,mode=max
           build-args: |
             SERVICE=apps/api
             KORTIX_VERSION=${{ needs.dev-version.outputs.version }}
@@ -541,13 +589,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push (amd64 + arm64)
+      - name: Build and push (amd64)
+        # Single-arch amd64 for dev (see the API build for the full rationale).
         uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/llm-gateway/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
+          cache-from: type=registry,ref=kortix/kortix-gateway:dev-buildcache
+          cache-to: type=registry,ref=kortix/kortix-gateway:dev-buildcache,mode=max
           build-args: |
             KORTIX_VERSION=${{ needs.dev-version.outputs.version }}
             KORTIX_COMMIT=${{ github.sha }}
@@ -699,13 +750,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push (amd64 + arm64)
+      - name: Build and push (amd64)
+        # Single-arch amd64 for dev (see the API build for the full rationale).
         uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/web/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
+          cache-from: type=registry,ref=kortix/kortix-frontend:dev-buildcache
+          cache-to: type=registry,ref=kortix/kortix-frontend:dev-buildcache,mode=max
           tags: |
             kortix/kortix-frontend:dev-latest
       - name: Retag :dev-latest → :dev-<sha8>


### PR DESCRIPTION
## Why dev deploys got slow and flaky

Measured against deploy-dev run `f5135d4767`: **~33 min total, and 22 min of it is a single job** — "Build API image (multi-arch)". Everything else (deploy, scan, migrate, tag) is fast.

Two root causes, both confirmed in git history:

### 1. An emulated arch that dev never runs (the regression)

The dev builds are `platforms: linux/amd64,linux/arm64`. arm64 is **QEMU-emulated** on the amd64 runner (~5–10× slower), so ~half that 22-min build produces an image dev never boots — dev Fargate is `x86_64`.

This was a **deliberate decision that got silently undone**:
- `5dad52cf55` (Apr 6) enabled multi-arch on dev → reverted **one minute later** by `1ca937570d` *"dev builds back to single-arch (amd64), multi-arch on prod only"*.
- `cb9d12a1b3` (May 31, "clean-slate dev→prod pipeline") **re-introduced** `amd64,arm64` on dev — un-reverting that decision. It's been paying the emulation tax ever since, unnoticed because it makes deploys slow, not broken.

**Fix:** dev → `linux/amd64` only. `deploy-prod.yml` keeps `amd64+arm64`. Evidence dev is x86_64: no `runtime_platform.cpu_architecture` in Terraform (→ AWS default x86_64), and dev ran amd64-only for ~2 months (Apr–May) without issue.
**Expected:** API build ~22 min → ~5–7 min.

### 2. No layer cache

The builds had no `cache-from`/`cache-to` — every build was 100% cold. Added durable registry cache (`type=registry,ref=<img>:dev-buildcache,mode=max`) on all three dev builds.

## The flakiness — the frontend-skip you can hit any day

`detect-changes` diffed `github.event.before..sha` — the commits in **this push** only. But `cancel-in-progress: false` (correct — see the 2026-08-10 learning) collapses a burst of pushes into **one** deploy for the **newest** sha, whose own diff misses a surface changed by an **earlier, superseded** commit. That surface's job then **skips**, and the change **strands on dev** — which is exactly what just happened to a frontend change: the API deployed, the frontend silently didn't.

**Fix:** diff against the sha **dev is actually running** (read from `dev-api/health`), not the push delta. Every surface stale relative to the live deployment rebuilds, regardless of how pushes were grouped. When the deployed sha can't be resolved (health down, force-push, first deploy), it **fails safe to building every surface** — a redundant build is cheap; a stranded surface is the bug.

`concurrency: cancel-in-progress: false` is unchanged (flipping it to `true` caused a 3.5h dev outage on 2026-08-10 — kept per that learning).

## Not changed / out of scope
- prod and staging pipelines (they keep multi-arch — that was the original intent).
- The `cancel-in-progress` queueing behavior (deliberately kept).

## Verification
- YAML validated; no `arm64` left in deploy-dev.yml; 6 buildcache refs (from+to × 3).
- Workflow unit tests (`web-ecs-workflow`, `ecs-deploy-environment`, `apps-edge-workflow`, `app-runtime-workflow`) 19/0.
- Real proof after merge: I'll watch the first dev deploy and report the new API-build duration.
