### PR TITLE
ci(dev): explicit Deploy Dev action instead of per-push storm

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,10 +1,11 @@
 name: Deploy Dev
 
-# DEV pipeline. `main` is the dev branch: every push auto-deploys the things that
-# change on most commits — API, frontend, CLI — as a DEV build versioned
-# `<next>-dev.<sha8>`, where <next> is one patch above the latest published
-# release tag (see the dev-version job). So dev tracks prod automatically and
-# `main` carries no release-version bump.
+# DEV pipeline. `main` is the dev branch. Deploys are EXPLICIT (the Deploy Dev
+# button / `workflow_dispatch`), NOT per-push — see the `on:` block for why. A
+# dispatch builds the things that changed since dev's live sha (or all/frontend
+# on demand) as a DEV build versioned `<next>-dev.<sha8>`, where <next> is one
+# patch above the latest published release tag (see the dev-version job). So a
+# dev deploy tracks prod's version line and `main` carries no release-version bump.
 #
 #   - API image   → kortix/kortix-api:dev-<sha8> + :dev-latest, deployed to dev
 #                   via ECS Fargate. dev-api.kortix.com
@@ -25,18 +26,27 @@ name: Deploy Dev
 # the single unified vX.Y.Z release bundling API + frontend + CLI + desktop.
 
 on:
-  push:
-    branches: [main]
+  # DEV DEPLOYS ARE EXPLICIT — NOT on every push to main. main is a high-traffic
+  # trunk; auto-deploying each push meant deploys queued/cancelled all day and
+  # nobody could tell which sha was live. Now you deploy on demand (the button
+  # below), which collapses a burst of pushes into ONE intentional deploy of
+  # main HEAD. A once-daily safety-net run keeps dev from silently going stale.
   workflow_dispatch:
     inputs:
       surface:
-        description: Surface to deploy from a manual branch run
+        description: What to deploy (main HEAD)
         type: choice
         required: true
-        default: all
+        default: changed
         options:
-          - all
-          - frontend
+          - changed   # only surfaces stale vs what dev currently runs (fast — the default)
+          - all       # force-rebuild + redeploy every surface
+          - frontend  # frontend only
+  schedule:
+    # Safety net only: once a day, deploy whatever changed since the last dev
+    # deploy. Keeps dev current if nobody dispatched — never a substitute for
+    # the explicit button. 06:00 UTC = a quiet hour.
+    - cron: '0 6 * * *'
 
 # One group for every surface, and it must NOT cancel what is already running.
 #
@@ -79,7 +89,10 @@ jobs:
           fetch-depth: 0
       - name: Resolve deploy base (what dev is actually running)
         id: base
-        if: github.event_name == 'push'
+        # Runs for the change-diffing paths: the daily safety-net schedule, and an
+        # explicit dispatch with surface=changed. surface=all / surface=frontend
+        # force their own set below and skip this.
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.surface == 'changed')
         run: |
           # THE FLAKY-SKIP FIX. The old filter diffed `github.event.before..sha`
           # — the commits in THIS push only. But `cancel-in-progress: false`
@@ -185,20 +198,19 @@ jobs:
             api=true; apps_router=true; gateway=true; frontend=true; cli=true; terraform=true
           fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ inputs.surface }}" = "frontend" ]; then
-              api=false
-              apps_router=false
-              gateway=false
-              frontend=true
-              cli=false
-              terraform=false
-            else
-              api=true
-              apps_router=true
-              gateway=true
-              frontend=true
-              terraform=true
-            fi
+            case "${{ inputs.surface }}" in
+              frontend)
+                api=false; apps_router=false; gateway=false
+                frontend=true; cli=false; terraform=false ;;
+              all)
+                api=true; apps_router=true; gateway=true
+                frontend=true; cli=true; terraform=true ;;
+              changed)
+                # Keep the path-filter outputs — they were diffed against the sha
+                # dev actually runs (the base step above), so only stale surfaces
+                # build. force_all already covered the "deployed sha unknown" case.
+                : ;;
+            esac
           fi
           {
             echo "api=$api"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,11 +193,13 @@ non-trivial change through this full lifecycle:
    real inputs and outputs.
 3. Push the branch, open a PR against `main`, wait for required checks, and merge
    it. Do not leave finished work only on a branch or stop after opening the PR.
-4. Follow the resulting **Deploy Dev** workflow through completion. Confirm the
-   deployed artifact contains the merged SHA; a successful `/health` response
-   alone is not deployment proof. If a newer push cancels or supersedes the run,
-   verify its path filters still rebuild every affected artifact. Manually
-   dispatch the workflow when necessary to avoid a skipped component.
+4. Dev deploys are **EXPLICIT** — merging to `main` does NOT deploy to dev.
+   Trigger the **Deploy Dev** workflow yourself: `gh workflow run deploy-dev.yml
+   -f surface=changed` (or `all` / `frontend`), or the Actions "Run workflow"
+   button. Then follow it through completion. Confirm the deployed artifact
+   contains the merged SHA; a successful `/health` response alone is not
+   deployment proof. Full procedure, surfaces, and verification:
+   `docs/runbooks/deploy-dev.md`.
 5. Re-run the user-visible behavior against `https://dev.kortix.com` and/or
    `https://dev-api.kortix.com`. Prefer the real Kortix CLI configured for the
    dev API for CLI/project/session flows, and direct authenticated HTTP calls for

--- a/docs/runbooks/deploy-dev.md
+++ b/docs/runbooks/deploy-dev.md
@@ -1,0 +1,81 @@
+# Deploy to dev — the explicit Deploy Dev action
+
+**Dev deploys are EXPLICIT.** Merging to `main` does NOT deploy to dev. You
+trigger the deploy yourself, on demand. This is a GitHub Actions
+`workflow_dispatch` on `.github/workflows/deploy-dev.yml` — the "Deploy Dev"
+workflow.
+
+## Why it is explicit, not per-push
+
+`main` is a high-traffic trunk. Auto-deploying every push meant deploys queued
+and cancelled all day (the concurrency group serialises, and the slow surface
+loses), dev lagged 30–60 min behind, and nobody could tell which SHA was live.
+An explicit deploy collapses a burst of merges into ONE intentional deploy of
+`main` HEAD, when you decide dev should move.
+
+`staging` and `prod` are unaffected — they were always promote-gated, never
+per-push (see the `kortix-release` skill).
+
+## How to deploy
+
+Three equivalent ways. All deploy `main` HEAD.
+
+1. **GitHub UI** — Actions tab → **Deploy Dev** → **Run workflow** → pick a
+   `surface` → **Run workflow**.
+2. **CLI** — `gh workflow run deploy-dev.yml -f surface=changed`
+3. **From an agent session** — the same `gh workflow run` call.
+
+### The `surface` input
+
+| value | what it builds + deploys | when |
+| --- | --- | --- |
+| `changed` (default) | only the surfaces STALE vs the SHA dev is currently running | the normal case — fast, skips unchanged surfaces |
+| `all` | force-rebuild + redeploy every surface (API, gateway, frontend, CLI, terraform) | recovery, or when you want a guaranteed full refresh |
+| `frontend` | the frontend only | a frontend-only change, or to re-ship a stale frontend |
+
+`changed` reads dev's live SHA from `dev-api.kortix.com/v1/health` and diffs
+against it, so a surface changed by any commit since the last dev deploy
+rebuilds — regardless of how the pushes were grouped. If that SHA cannot be
+resolved (health down, force-push, first deploy), it FAILS SAFE and builds every
+surface.
+
+## Safety net
+
+A `schedule` fires once a day at 06:00 UTC and runs the `changed` path, so dev
+cannot silently rot if nobody dispatched. It is a floor, not a substitute for
+the explicit deploy.
+
+## Verify a deploy landed
+
+A green run is not proof by itself. Confirm the deployed artifact carries the
+SHA you deployed:
+
+- **API:** `curl -s https://dev-api.kortix.com/v1/health` → `.commit` is your
+  merge SHA (or has it as an ancestor).
+- **Frontend:** `curl -s https://dev.kortix.com/api/health` → `.commit` likewise.
+- Then exercise the actual user-visible behavior against the deployed surface
+  (see CLAUDE.md "Default delivery" step 5).
+
+## Common traps
+
+- **Stale browser tab mimics a stale deploy.** `dev.kortix.com` is a single-page
+  app; an open tab keeps running the JS bundle it loaded before the deploy. If
+  the UI looks old but `/api/health` reports the new commit, hard-reload
+  (Cmd/Ctrl+Shift+R). The deploy is fine.
+- **Concurrency queues, never cancels.** `cancel-in-progress: false` is
+  deliberate (flipping it to `true` caused a 3.5h dev outage on 2026-08-10 — see
+  the `learnings` skill). A dispatch while another deploy runs QUEUES behind it;
+  the newest pending wins. Do not spam dispatches — one is enough.
+
+## Build speed
+
+Dev builds are single-arch amd64 (dev Fargate is x86_64), with registry layer
+cache. The API image builds in ~4–7 min (was ~22 min when it emulated arm64 that
+dev never runs). `deploy-prod.yml` keeps multi-arch — that is prod's concern, not
+dev's.
+
+## Related
+
+- `.github/workflows/deploy-dev.yml` — the workflow itself.
+- `kortix-release` skill — how prod releases work (promote, not dispatch).
+- `learnings` skill — the concurrency and frontend-skip incidents behind this design.

--- a/tests/unit/app-runtime-workflow.test.ts
+++ b/tests/unit/app-runtime-workflow.test.ts
@@ -24,10 +24,18 @@ describe('app runtime workflow coverage', () => {
       workflow.indexOf('      - name: Normalize outputs'),
       workflow.indexOf('      - name: Summary'),
     );
-    const allSurface = normalize.slice(normalize.indexOf('            else'));
+    // The manual `surface: all` dispatch forces every deployable service. It is
+    // the `all)` case of the dispatch switch (was an if/else `else` before the
+    // schedule+dispatch refactor added a `changed` default).
+    const allSurface = normalize.slice(
+      normalize.indexOf('              all)'),
+      normalize.indexOf('              changed)'),
+    );
 
     expect(allSurface).toContain('api=true');
     expect(allSurface).toContain('gateway=true');
     expect(allSurface).toContain('frontend=true');
+    expect(allSurface).toContain('cli=true');
+    expect(allSurface).toContain('terraform=true');
   });
 });


### PR DESCRIPTION
## Dev deploys are now an explicit action, not a per-push storm

main is a high-traffic trunk. Auto-deploying on every push meant deploys queued and cancelled all day, dev lagged 30–60 min behind, and it was impossible to tell which SHA was actually live (the confusion behind the "why is the old flag still showing" reports).

### New model
- **Trigger:** `workflow_dispatch` — the **Deploy Dev** button — plus a **once-daily safety-net** schedule (06:00 UTC) so dev can't silently rot if nobody deploys. **No `push` trigger.**
- **`surface` input:**
  - `changed` (default) — only rebuilds surfaces stale vs **dev's live SHA** (uses the deployed-SHA diff from #6619). Fast.
  - `all` — force-rebuild + redeploy every surface.
  - `frontend` — frontend only.
- A burst of N pushes now collapses into **one intentional deploy** of main HEAD, on your command.

### Unchanged
- `concurrency: cancel-in-progress: false` (kept per the 2026-08-10 learning — flipping it caused a 3.5h dev outage).
- staging / prod pipelines (already promote-gated, never per-push).

### Why not fully-manual-only
The daily safety net means a forgotten deploy can't leave dev days-stale before a demo. Explicit is the primary path; the schedule is a floor, not a substitute.

### Pairs with #6619 (already merged)
Single-arch dev builds + layer cache + the frontend-skip fix. Measured proof: the API build now runs **~4.3 min** (was ~22 min) — run 32303563520, cold cache.

## Verification
- YAML validated; triggers are `workflow_dispatch` + `schedule` (no push).
- Workflow unit tests (`web-ecs-workflow`, `ecs-deploy-environment`, `apps-edge-workflow`, `app-runtime-workflow`, `cosign-sign-attest`) **22/0** — updated the all-surface test to the new `case` structure (behavior preserved: `surface: all` still forces every service).
- Real proof after merge: I'll dispatch a `changed` deploy and confirm it builds only what's stale, fast.
