### PR TITLE
perf(ci): build staging images natively per arch, with a layer cache

### DIFF
--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -9,6 +9,35 @@ name: Build Staging Artifacts
 # source for both full dev-candidate PRs and targeted release-candidate
 # PRs. The deploy workflow may add `[skip ci]` GitOps pin commits after this
 # build; those are deployment metadata, not code promotion.
+#
+# ── Why every image builds as a per-arch matrix + a merge job ────────────────
+# These images are multi-arch because the released tags are what self-hosters
+# pull; ECS runs x86_64 only. Until 2026-08-19 both arches were produced on ONE
+# `ubuntu-latest` x86 runner with `docker/setup-qemu-action`, so the whole arm64
+# leg ran under QEMU emulation. Measured on run 32293230397 (the slowest of 8):
+# arm64 buildx node time 2791.6s vs amd64 596.2s — 80.5% of all build time for
+# the arch nothing in Kortix cloud runs, at 4.4-9.4x per CPU-bound step. The API
+# job alone was 22-26 min and 97-98% of this workflow's wallclock.
+#
+# `ubuntu-24.04-arm` is a standard GitHub-hosted runner, free for public repos
+# (verified on this repo: aarch64, 4 vCPU, 15 GB, buildx `Platforms:
+# linux/arm64` with no QEMU). So each arch now builds NATIVELY on its own
+# runner, in parallel, and a merge job stitches the two digests into the same
+# multi-arch manifest under the same three tags as before. Tag semantics are
+# unchanged: `staging-<full-sha>`, `staging-latest`, `staging-<sha8>`.
+#
+# Building the frontend per-arch also FIXES a real defect. `apps/web/Dockerfile`
+# copies a Next standalone bundle produced by `pnpm install` on the runner. With
+# one x86 runner serving both arches, the published linux/arm64 frontend image
+# carried x64-only native binaries — verified on `staging-latest`:
+#   docker run --platform linux/arm64 kortix/kortix-frontend:staging-latest \
+#     sh -c 'ls /app/node_modules/.pnpm | grep -iE "linux-(x64|arm64)"'
+#   @img+sharp-libvips-linux-x64@1.3.0 / @img+sharp-linux-x64@0.35.3 (no arm64)
+# Each arch now runs its own install+build, so the arm64 image gets arm64 sharp.
+#
+# Registry-backed BuildKit cache (`type=registry,mode=max`, one ref per image
+# per arch) makes an unchanged-dependency build reuse layers instead of
+# rebuilding from scratch — previously `CACHED` was 0 of 222 buildx nodes.
 
 on:
   push:
@@ -65,82 +94,200 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Latest release: ${latest:-none} -> staging ${next}-staging.${sha::8}"
 
+  # ── API image: one native runner per arch, pushed by digest ────────────────
   build-api:
-    name: Build API image (staging)
+    name: Build API image (staging, ${{ matrix.arch }})
     needs: version
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.sha }}
           submodules: false
       - run: git submodule sync --recursive && git submodule update --init --recursive --remote
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push staging API
+      - name: Build and push staging API by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/api/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           build-args: |
             SERVICE=apps/api
             KORTIX_VERSION=${{ needs.version.outputs.version }}
             KORTIX_COMMIT=${{ needs.version.outputs.sha }}
-          tags: |
-            kortix/kortix-api:staging-${{ needs.version.outputs.sha }}
-            kortix/kortix-api:staging-latest
-      - name: Retag API staging-<sha8>
+          cache-from: type=registry,ref=kortix/kortix-api:staging-buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=kortix/kortix-api:staging-buildcache-${{ matrix.arch }},mode=max
+          outputs: type=image,name=kortix/kortix-api,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
-          docker buildx imagetools create \
-            --tag "kortix/kortix-api:staging-${{ needs.version.outputs.sha8 }}" \
-            "kortix/kortix-api:staging-${{ needs.version.outputs.sha }}"
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: digests-api-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
-  build-gateway:
-    name: Build gateway image (staging)
-    needs: version
+  merge-api:
+    name: Publish API manifest (staging)
+    needs: [version, build-api]
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digests-api-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Stitch per-arch digests into the staging tags
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          # One digest file per matrix arch. Refuse to publish the multi-arch
+          # tags from anything other than the full set: a partial merge would
+          # silently ship a single-arch manifest under a tag prod retags.
+          refs=()
+          for d in *; do refs+=("kortix/kortix-api@sha256:${d}"); done
+          if [ "${#refs[@]}" -ne 2 ]; then
+            echo "::error::expected 2 per-arch digests, got ${#refs[@]}: ${refs[*]}"
+            exit 1
+          fi
+          docker buildx imagetools create \
+            --tag "kortix/kortix-api:staging-${{ needs.version.outputs.sha }}" \
+            --tag "kortix/kortix-api:staging-latest" \
+            --tag "kortix/kortix-api:staging-${{ needs.version.outputs.sha8 }}" \
+            "${refs[@]}"
+          docker buildx imagetools inspect "kortix/kortix-api:staging-${{ needs.version.outputs.sha8 }}"
+
+  # ── Gateway image ─────────────────────────────────────────────────────────
+  build-gateway:
+    name: Build gateway image (staging, ${{ matrix.arch }})
+    needs: version
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.sha }}
           submodules: false
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push staging gateway
+      - name: Build and push staging gateway by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/llm-gateway/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           build-args: |
             KORTIX_VERSION=${{ needs.version.outputs.version }}
             KORTIX_COMMIT=${{ needs.version.outputs.sha }}
-          tags: |
-            kortix/kortix-gateway:staging-${{ needs.version.outputs.sha }}
-            kortix/kortix-gateway:staging-latest
-      - name: Retag gateway staging-<sha8>
+          cache-from: type=registry,ref=kortix/kortix-gateway:staging-buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=kortix/kortix-gateway:staging-buildcache-${{ matrix.arch }},mode=max
+          outputs: type=image,name=kortix/kortix-gateway,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
-          docker buildx imagetools create \
-            --tag "kortix/kortix-gateway:staging-${{ needs.version.outputs.sha8 }}" \
-            "kortix/kortix-gateway:staging-${{ needs.version.outputs.sha }}"
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: digests-gateway-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
-  build-frontend:
-    name: Build frontend image (staging)
-    needs: version
+  merge-gateway:
+    name: Publish gateway manifest (staging)
+    needs: [version, build-gateway]
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digests-gateway-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Stitch per-arch digests into the staging tags
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          # One digest file per matrix arch. Refuse to publish the multi-arch
+          # tags from anything other than the full set: a partial merge would
+          # silently ship a single-arch manifest under a tag prod retags.
+          refs=()
+          for d in *; do refs+=("kortix/kortix-gateway@sha256:${d}"); done
+          if [ "${#refs[@]}" -ne 2 ]; then
+            echo "::error::expected 2 per-arch digests, got ${#refs[@]}: ${refs[*]}"
+            exit 1
+          fi
+          docker buildx imagetools create \
+            --tag "kortix/kortix-gateway:staging-${{ needs.version.outputs.sha }}" \
+            --tag "kortix/kortix-gateway:staging-latest" \
+            --tag "kortix/kortix-gateway:staging-${{ needs.version.outputs.sha8 }}" \
+            "${refs[@]}"
+          docker buildx imagetools inspect "kortix/kortix-gateway:staging-${{ needs.version.outputs.sha8 }}"
+
+  # ── Frontend image ────────────────────────────────────────────────────────
+  # The Next standalone bundle is built on the RUNNER (apps/web/Dockerfile is
+  # runner-only), so each arch must run its own install+build to get native
+  # binaries into its own image. See the header note on the x64-sharp defect.
+  build-frontend:
+    name: Build frontend image (staging, ${{ matrix.arch }})
+    needs: version
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
         with:
@@ -166,32 +313,73 @@ jobs:
           NEXT_PUBLIC_KORTIX_VERSION: ${{ needs.version.outputs.version }}
           NEXT_PUBLIC_KORTIX_COMMIT: ${{ needs.version.outputs.sha }}
           NEXT_OUTPUT: standalone
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push staging frontend
+      - name: Build and push staging frontend by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/web/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            kortix/kortix-frontend:staging-${{ needs.version.outputs.sha }}
-            kortix/kortix-frontend:staging-latest
-      - name: Retag frontend staging-<sha8>
+          platforms: ${{ matrix.platform }}
+          cache-from: type=registry,ref=kortix/kortix-frontend:staging-buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=kortix/kortix-frontend:staging-buildcache-${{ matrix.arch }},mode=max
+          outputs: type=image,name=kortix/kortix-frontend,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: digests-frontend-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-frontend:
+    name: Publish frontend manifest (staging)
+    needs: [version, build-frontend]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digests-frontend-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Stitch per-arch digests into the staging tags
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          # One digest file per matrix arch. Refuse to publish the multi-arch
+          # tags from anything other than the full set: a partial merge would
+          # silently ship a single-arch manifest under a tag prod retags.
+          refs=()
+          for d in *; do refs+=("kortix/kortix-frontend@sha256:${d}"); done
+          if [ "${#refs[@]}" -ne 2 ]; then
+            echo "::error::expected 2 per-arch digests, got ${#refs[@]}: ${refs[*]}"
+            exit 1
+          fi
           docker buildx imagetools create \
+            --tag "kortix/kortix-frontend:staging-${{ needs.version.outputs.sha }}" \
+            --tag "kortix/kortix-frontend:staging-latest" \
             --tag "kortix/kortix-frontend:staging-${{ needs.version.outputs.sha8 }}" \
-            "kortix/kortix-frontend:staging-${{ needs.version.outputs.sha }}"
+            "${refs[@]}"
+          docker buildx imagetools inspect "kortix/kortix-frontend:staging-${{ needs.version.outputs.sha8 }}"
 
   dispatch-deploy:
     name: Dispatch staging deploy
-    needs: [version, build-api, build-gateway, build-frontend]
+    needs: [version, merge-api, merge-gateway, merge-frontend]
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -320,7 +320,7 @@ jobs:
 
   # ── Build + push the multi-arch API image ───────────────────────────────────
   build-api:
-    name: Build API image (multi-arch)
+    name: Build API image (amd64)
     needs: [detect-changes, dev-version]
     if: needs.detect-changes.outputs.api == 'true'
     runs-on: ubuntu-latest
@@ -328,8 +328,6 @@ jobs:
       - uses: actions/checkout@v7
         with: { submodules: false }
       - run: git submodule sync --recursive && git submodule update --init --recursive --remote
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
@@ -574,15 +572,13 @@ jobs:
   # ── Build + push the multi-arch gateway image ───────────────────────────────
   # Standalone LLM gateway (apps/llm-gateway). Same dev-<sha8> versioning as the API.
   build-gateway:
-    name: Build gateway image (multi-arch)
+    name: Build gateway image (amd64)
     needs: [detect-changes, dev-version]
     if: needs.detect-changes.outputs.gateway == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with: { submodules: false }
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
@@ -713,7 +709,7 @@ jobs:
   # ── Build + push the multi-arch frontend image ──────────────────────────────
   # The same immutable image serves Dev ECS and the self-host distribution.
   build-frontend:
-    name: Build frontend image (multi-arch)
+    name: Build frontend image (amd64)
     needs: [detect-changes, dev-version]
     if: needs.detect-changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
@@ -742,8 +738,6 @@ jobs:
           NEXT_PUBLIC_KORTIX_VERSION: ${{ needs.dev-version.outputs.version }}
           NEXT_PUBLIC_KORTIX_COMMIT: ${{ github.sha }}
           NEXT_OUTPUT: standalone
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,7 +16,7 @@ FROM oven/bun:${BUN_VERSION}-slim AS base
 # App snapshots are built at API runtime. The deployed API image therefore
 # carries the exact supervisor and ingress binaries that every provider adds to
 # a user image.
-FROM golang:1.26-bookworm AS app-runtime
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS app-runtime
 
 WORKDIR /runtime
 COPY apps/kortix-app-runtime/go.mod apps/kortix-app-runtime/main.go ./
@@ -34,7 +34,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 # The API builds Daytona layered snapshots at runtime. Those snapshots bake the
 # sandbox-side daemon from this repo, so the deployable API image must carry the
 # latest compiled Linux binary even though we no longer publish a sandbox image.
-FROM oven/bun:${SANDBOX_AGENT_BUN_VERSION}-slim AS sandbox-agent
+FROM --platform=$BUILDPLATFORM oven/bun:${SANDBOX_AGENT_BUN_VERSION}-slim AS sandbox-agent
 
 WORKDIR /agent
 
@@ -52,7 +52,7 @@ RUN BUN_COMPILE_TARGET=${KORTIX_AGENT_BUN_TARGET} bash scripts/build.sh
 # it to a self-contained Linux binary here, the same way as the daemon above,
 # and the runner copies it to the path the snapshot builder reads
 # (apps/cli/dist/kortix → KORTIX_SNAPSHOT_CLI_BIN_PATH).
-FROM oven/bun:${BUN_VERSION}-slim AS sandbox-cli
+FROM --platform=$BUILDPLATFORM oven/bun:${BUN_VERSION}-slim AS sandbox-cli
 
 WORKDIR /cli
 
@@ -98,7 +98,40 @@ ARG SERVICE
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY patches ./patches
 
-# Copy the target app and workspace packages it depends on
+# MANIFESTS ONLY, ahead of the install. This layer is keyed on dependency
+# DECLARATIONS, so an ordinary source edit no longer invalidates `pnpm install`
+# — the single most expensive step in this file (82.5s native / 396.0s emulated
+# on GitHub runners, measured on build-staging run 32293230397). The full
+# sources are copied AFTER the install, below.
+#
+# Every package listed here must also be COPYed in full further down, and the
+# two lists must stay in sync: a package whose manifest is present but whose
+# source is missing installs fine and then fails at runtime.
+COPY ${SERVICE}/package.json ./${SERVICE}/
+COPY packages/api-contract/package.json ./packages/api-contract/
+COPY packages/shared/package.json ./packages/shared/
+COPY packages/llm-catalog/package.json ./packages/llm-catalog/
+COPY packages/db/package.json ./packages/db/
+COPY packages/agent-tunnel/package.json ./packages/agent-tunnel/
+COPY packages/starter/package.json ./packages/starter/
+COPY packages/manifest-schema/package.json ./packages/manifest-schema/
+COPY packages/registry/package.json ./packages/registry/
+COPY packages/llm-gateway/package.json ./packages/llm-gateway/
+COPY packages/sdk/package.json ./packages/sdk/
+
+# Install pnpm and deps for this app + workspace packages it depends on.
+# --shamefully-hoist flattens node_modules (no symlinks) so COPY works on all Docker versions.
+# Include devDeps because the API runs TypeScript source directly under Bun.
+# Also install the root project's deps (--filter kortix) so the migration runner
+# (node-pg-migrate, pg) is bundled in the image — self-hosters apply migrations
+# with `bun packages/db/scripts/migrate.ts up`. node-pg-migrate lives at the root
+# (not @kortix/db) to keep the db package's drizzle-orm resolution single.
+RUN corepack enable pnpm && \
+    pnpm install --filter ./${SERVICE}... --filter kortix --shamefully-hoist --prod=false --ignore-scripts
+
+# Sources, after the install layer. `.dockerignore` excludes `**/node_modules`,
+# so these COPYs merge over the installed tree without clobbering what pnpm
+# just wrote. Keep this list identical to the manifest list above.
 COPY ${SERVICE} ./${SERVICE}
 COPY packages/api-contract ./packages/api-contract
 COPY packages/shared ./packages/shared
@@ -110,16 +143,6 @@ COPY packages/manifest-schema ./packages/manifest-schema
 COPY packages/registry ./packages/registry
 COPY packages/llm-gateway ./packages/llm-gateway
 COPY packages/sdk ./packages/sdk
-
-# Install pnpm and deps for this app + workspace packages it depends on.
-# --shamefully-hoist flattens node_modules (no symlinks) so COPY works on all Docker versions.
-# Include devDeps because the API runs TypeScript source directly under Bun.
-# Also install the root project's deps (--filter kortix) so the migration runner
-# (node-pg-migrate, pg) is bundled in the image — self-hosters apply migrations
-# with `bun packages/db/scripts/migrate.ts up`. node-pg-migrate lives at the root
-# (not @kortix/db) to keep the db package's drizzle-orm resolution single.
-RUN corepack enable pnpm && \
-    pnpm install --filter ./${SERVICE}... --filter kortix --shamefully-hoist --prod=false --ignore-scripts
 
 # ---- Runner Stage ----
 FROM base AS runner

--- a/tests/unit/image-build-speed-workflow.test.ts
+++ b/tests/unit/image-build-speed-workflow.test.ts
@@ -1,0 +1,151 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Guards the container-image build topology. Before 2026-08-19 every image in
+// build-staging.yml built both arches on ONE x86 runner under QEMU, with no
+// BuildKit cache: measured on run 32293230397 the arm64 leg was 2791.6s of
+// 3469.0s total buildx node time (80.5%) and the API job alone ran 22-26 min,
+// 97-98% of the workflow's wallclock. These assertions exist so that cost
+// cannot come back by accident.
+
+const read = (name: string) =>
+  readFileSync(resolve(import.meta.dirname, `../../.github/workflows/${name}`), 'utf8');
+
+const IMAGES = ['api', 'gateway', 'frontend'] as const;
+
+// The block of a workflow belonging to one top-level job id.
+const jobBlock = (workflow: string, jobId: string): string => {
+  const start = workflow.indexOf(`\n  ${jobId}:\n`);
+  expect(start, `job ${jobId} is missing`).toBeGreaterThan(-1);
+  const rest = workflow.slice(start + 1);
+  const next = rest.search(/\n {2}[a-z][a-z0-9-]*:\n/);
+  return next === -1 ? rest : rest.slice(0, next);
+};
+
+describe('staging image builds are native per-arch, cached, and merged', () => {
+  const source = read('build-staging.yml');
+
+  it('never reintroduces QEMU emulation', () => {
+    // A single runner emulating the other arch is the 4.4-9.4x-per-step cost
+    // this topology exists to remove.
+    // Match the step, not the prose: the header comment names it as history.
+    expect(source).not.toContain('uses: docker/setup-qemu-action');
+  });
+
+  it.each(IMAGES)('builds %s natively on one runner per arch', (image) => {
+    const job = jobBlock(source, `build-${image}`);
+
+    expect(job).toContain('runs-on: ${{ matrix.runner }}');
+    // Each leg's runner architecture must match the platform it produces.
+    // ubuntu-24.04-arm is verified available to this repo (aarch64, 4 vCPU).
+    expect(job).toContain('platform: linux/amd64\n            runner: ubuntu-latest');
+    expect(job).toContain('platform: linux/arm64\n            runner: ubuntu-24.04-arm');
+    // Emulating both arches in one job is exactly what this replaced.
+    expect(job).not.toContain('platforms: linux/amd64,linux/arm64');
+  });
+
+  it.each(IMAGES)('gives %s a registry layer cache scoped per arch', (image) => {
+    const job = jobBlock(source, `build-${image}`);
+
+    expect(job).toContain(
+      `cache-from: type=registry,ref=kortix/kortix-${image}:staging-buildcache-\${{ matrix.arch }}`,
+    );
+    // mode=max caches intermediate stages too, not just the final layers.
+    expect(job).toContain(
+      `cache-to: type=registry,ref=kortix/kortix-${image}:staging-buildcache-\${{ matrix.arch }},mode=max`,
+    );
+  });
+
+  it.each(IMAGES)('publishes %s by digest, never by tag, from the arch legs', (image) => {
+    const job = jobBlock(source, `build-${image}`);
+
+    // Tagging from a single-arch leg would clobber the multi-arch manifest.
+    expect(job).toContain('push-by-digest=true');
+    expect(job).not.toContain('tags:');
+  });
+
+  it.each(IMAGES)('keeps the exact three %s staging tags on the merge job', (image) => {
+    const merge = jobBlock(source, `merge-${image}`);
+
+    // Tag semantics are load-bearing: deploy-prod retags staging-<sha8>.
+    expect(merge).toContain(
+      `--tag "kortix/kortix-${image}:staging-\${{ needs.version.outputs.sha }}"`,
+    );
+    expect(merge).toContain(`--tag "kortix/kortix-${image}:staging-latest"`);
+    expect(merge).toContain(
+      `--tag "kortix/kortix-${image}:staging-\${{ needs.version.outputs.sha8 }}"`,
+    );
+    // A partial merge must fail rather than ship a single-arch manifest.
+    expect(merge).toContain('-ne 2');
+  });
+
+  it('gates the staging deploy dispatch on the merged manifests', () => {
+    const dispatch = jobBlock(source, 'dispatch-deploy');
+
+    // Dispatching on the per-arch legs would race the manifest publish.
+    expect(dispatch).toContain(
+      'needs: [version, merge-api, merge-gateway, merge-frontend]',
+    );
+  });
+});
+
+describe('dev image builds stay single-arch and cached', () => {
+  const source = read('deploy-dev.yml');
+
+  it('carries no QEMU setup, since every dev build is linux/amd64', () => {
+    // Dev images are consumed only by ECS Fargate, which runs x86_64.
+    expect(source).not.toContain('uses: docker/setup-qemu-action');
+    expect(source).not.toContain('platforms: linux/amd64,linux/arm64');
+  });
+
+  it.each(IMAGES)('keeps the %s dev build cache wired', (image) => {
+    expect(source).toContain(`cache-from: type=registry,ref=kortix/kortix-${image}:dev-buildcache`);
+    expect(source).toContain(
+      `cache-to: type=registry,ref=kortix/kortix-${image}:dev-buildcache,mode=max`,
+    );
+  });
+});
+
+describe('the API Dockerfile keeps its install layer off the source path', () => {
+  const dockerfile = readFileSync(resolve(import.meta.dirname, '../../apps/api/Dockerfile'), 'utf8');
+
+  it('copies manifests before pnpm install and sources after it', () => {
+    const manifest = dockerfile.indexOf('COPY ${SERVICE}/package.json');
+    const install = dockerfile.indexOf('pnpm install --filter ./${SERVICE}...');
+    const sources = dockerfile.indexOf('COPY ${SERVICE} ./${SERVICE}');
+
+    expect(manifest).toBeGreaterThan(-1);
+    expect(sources).toBeGreaterThan(-1);
+    // Source before install is what made every code edit reinstall every dep.
+    expect(manifest).toBeLessThan(install);
+    expect(install).toBeLessThan(sources);
+  });
+
+  it('keeps the manifest and source copy lists identical', () => {
+    // A package whose manifest is copied but whose source is not installs
+    // fine and then fails at runtime.
+    // Scope to the deps stage: the sandbox-cli stage copies packages too.
+    const deps = dockerfile.slice(
+      dockerfile.indexOf('FROM node:22-slim AS deps'),
+      dockerfile.indexOf('# ---- Runner Stage ----'),
+    );
+    const pkgs = (re: RegExp) => [...deps.matchAll(re)].map((m) => m[1]).sort();
+    const manifests = pkgs(/^COPY (packages\/[a-z-]+)\/package\.json /gm);
+    const sources = pkgs(/^COPY (packages\/[a-z-]+) \.\/packages\//gm);
+
+    expect(manifests.length).toBeGreaterThan(0);
+    expect(manifests).toEqual(sources);
+  });
+
+  it('builds the cross-compiled stages on the build platform, never emulated', () => {
+    // These stages hardcode amd64 output (GOARCH=amd64 / bun-linux-x64), so
+    // emulating them under a foreign target platform is pure waste.
+    for (const stage of ['app-runtime', 'sandbox-agent', 'sandbox-cli']) {
+      const line = dockerfile
+        .split('\n')
+        .find((l) => l.startsWith('FROM') && l.endsWith(`AS ${stage}`));
+      expect(line, `stage ${stage}`).toContain('--platform=$BUILDPLATFORM');
+    }
+  });
+});


### PR DESCRIPTION
## The problem

`build-staging.yml` took **22–27 min** on every staging push, and the API image
was **97–98%** of that. It has been the wall-clock tax on every release
iteration.

Last 8 runs: 22m58s, 26m08s, 23m53s, 26m50s, 16m49s, 26m02s, 23m19s, 25m47s.
Per job, on three of them:

| job | 32302640218 | 32293230397 | 32286309233 |
|---|---|---|---|
| **Build API image (staging)** | **22m20s** | **25m37s** | **23m22s** |
| Build frontend image | 3m38s | 3m34s | 3m39s |
| Build gateway image | 0m59s | 0m41s | 0m52s |
| Compute staging version | 0m29s | 0m22s | 0m22s |

## Where the time actually went (profiled, not guessed)

Parsed all 222 buildx nodes from the slowest API job (run 32293230397, job
96198724480), 3469.0s of node time:

| platform | node time | share |
|---|---|---|
| **linux/arm64** | **2791.6s** | **80.5%** |
| linux/amd64 | 596.2s | 17.2% |
| internal | 81.2s | 2.3% |

Both arches were built on **one `ubuntu-latest` x86 runner** via
`docker/setup-qemu-action`, so the entire arm64 leg ran under QEMU. On paired
identical instructions arm64 cost **2198.3s more** than amd64:

| instruction | amd64 | arm64 | ratio |
|---|---|---|---|
| `sandbox-cli` bun install + compile | 9.4s | 88.5s | **9.41x** |
| `apt-get install` (runner stage) | 69.5s | 494.6s | **7.12x** |
| `bun build --compile` (sandbox-agent) | 49.5s | 350.5s | **7.08x** |
| `go build -o /out/kortix-appd` | 81.4s | 487.1s | **5.98x** |
| `pnpm install` | 82.5s | 396.0s | **4.80x** |
| `go build -o /out/caddy` | 192.1s | 839.2s | **4.37x** |
| `go mod download` (network-bound) | 27.6s | 50.0s | 1.81x |
| `FROM` pulls (network-bound) | — | — | 0.99–1.22x |

Every CPU-bound step 4.4–9.4x, network-bound steps ~1x. That ratio pattern is
the emulation signature, and `tonistiigi/binfmt` appears in the log directly.

**Nothing was cached.** `CACHED` was **0 of 222** nodes; neither `cache-from`
nor `cache-to` appeared anywhere in the workflow. The full cost was paid on
every single push.

## What changed

**1. Each arch builds on a runner that natively matches it.** `ubuntu-latest`
for amd64, `ubuntu-24.04-arm` for arm64, in parallel, pushed by digest; a merge
job stitches both digests into one manifest. Wallclock becomes
`max(amd64, arm64)` instead of `amd64 + emulated-arm64`. All `setup-qemu-action`
steps are gone.

**2. Registry-backed BuildKit cache**, `mode=max`, one ref per image per arch.

**3. `apps/api/Dockerfile`: manifests before `pnpm install`, sources after.**
Previously `COPY ${SERVICE}` preceded the install, so *any* API source edit
reinstalled every dependency — the single most expensive step in the file
(82.5s native / 396.0s emulated). Now the install layer is keyed on dependency
declarations only.

**4. Three cross-compile stages pinned to `$BUILDPLATFORM`.** `app-runtime`,
`sandbox-agent` and `sandbox-cli` all hardcode amd64 output (`GOARCH=amd64`,
`bun-linux-x64`). Emulating them under a foreign target platform spent **~2027s**
of the arm64 leg producing byte-identical artifacts.

**5. `deploy-dev.yml` cleanup**: three `setup-qemu` steps left dead by #6619, and
three job names still claiming `(multi-arch)` while building `linux/amd64`.

**6. New guard**: `tests/unit/image-build-speed-workflow.test.ts`, 21 assertions
pinning the topology, the cache refs, the tag set, and the Dockerfile ordering.

## Expected saving, anchored to a real measurement

#6619 made exactly this class of change (single-arch + registry cache) on
`deploy-dev`, and it is already measured:

| deploy-dev run | API image build |
|---|---|
| 32300401577 (before) | 19m10s |
| 32302570982 (before) | 18m55s |
| **32303563520 (after)** | **4m18s** |

**4.4x, on a still-cold cache** — that run had nothing to import yet
(`importing cache manifest` ×2, `CACHED` 0). Staging should land in the same
band per leg, with the two legs running concurrently, so **≤5 min warm and
≤10 min cold** for the API image is the target this is sized against.

## Bonus: this fixes a real defect

`apps/web/Dockerfile` copies a Next standalone bundle produced by `pnpm install`
**on the runner**. With one x86 runner serving both arches, the published
`linux/arm64` frontend image carried x64-only native binaries. Verified against
the live tag:

```
$ docker run --platform linux/arm64 kortix/kortix-frontend:staging-latest \
    sh -c 'ls /app/node_modules/.pnpm | grep -iE "linux-(x64|arm64)"'
@img+sharp-libvips-linux-x64@1.3.0
@img+sharp-libvips-linux-x64@1.3.2
@img+sharp-linux-x64@0.35.0
@img+sharp-linux-x64@0.35.3
```

Zero arm64 entries — that image cannot work on real ARM hardware. Each arch now
runs its own install and build, so the arm64 image gets arm64 `sharp`.

## Proven vs. inferred

**Proven:**
- `ubuntu-24.04-arm` is available to this repo. Throwaway probe run
  [32305426488](https://github.com/kortix-ai/suna/actions/runs/32305426488), both
  jobs green in 9s: `arch=aarch64`, `nproc=4`, 15 GB, buildx reports
  `Platforms: linux/arm64, linux/arm/v7, linux/arm/v6` — native, no QEMU. No
  runner provisioning needed (repo is public). *The probe branch is not part of
  this PR and has been deleted.*
- **Image contents are unchanged.** Local build of the old and new Dockerfile:
  **54,352 identical paths**, identical file sizes, identical `docker inspect`
  config, same 1.62 GB. The only differing file is `/app/apps/api/Dockerfile`
  itself, which the image copies in.
- The timing breakdown above (parsed from raw job logs).
- The x64-sharp defect (pulled and inspected the live arm64 image).
- The new test is falsifiable: reverting the arm runner, a cache ref and one
  `$BUILDPLATFORM` turned it red on 5 assertions; restoring made it green.
- ECS runs x86_64 — no `runtime_platform` / `cpu_architecture` anywhere in
  `infra/terraform`, so Fargate defaults to X86_64.

**Inferred (not yet measured):** the exact staging wallclock after this lands.
The 4m18s figure is deploy-dev's, on the same Dockerfile and the same class of
change; staging's arm64 leg has no equivalent prior measurement because it has
never been built natively. First staging push after merge will confirm.

## Deliberately not changed

- **`deploy-prod.yml`** only retags (`imagetools create`) — it never builds.
  Untouched, and it still gets a genuine multi-arch manifest.
- **`deploy-preview.yml`** builds `push: false` with no registry login, on the
  fork-PR path. Adding a shared cache there is cache-poisoning surface on a
  security-gated workflow, and it is not in the hot loop. Left alone on purpose.
- **`deploy-dev` job ordering.** `deploy-web-ecs` → `terraform-dev` →
  `terraform-dev-api` → `tag-api` → `build-api`, so on a push that also changes
  terraform, the frontend deploy waits for the API image. The dependency is real
  (`terraform-dev-api` consumes `needs.tag-api.outputs.image`), and decoupling it
  risks deploying a frontend against un-converged infra. With the API build down
  to ~4 min this costs ~4 min instead of ~19, so the right move is to re-measure
  after this lands rather than reorder infra convergence now.

## Verification run

```
actionlint .github/workflows/build-staging.yml .github/workflows/deploy-dev.yml   # clean
python3 -c "import yaml; ..."                                                     # both parse
pnpm --dir tests test:unit                                                        # 335 passed (37 files)
docker build -f apps/api/Dockerfile ...  (old + new, file-set + size + config diff)
```

Local `pnpm --dir tests test:unit` went from 314 to 335 tests; the 21 new ones
are this PR's guard.
