### PR TITLE
fix(gateway): re-apply gateway-side provider shaping (codex store:false + 3 more) on the native path

### DIFF
--- a/packages/llm-gateway/src/pipeline/language-model-handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/language-model-handler.test.ts
@@ -451,6 +451,148 @@ describe('handleLanguageModel — admission billing-hold reconciliation (FIX 1)'
   });
 });
 
+// Prove the GATEWAY-SIDE request shaping reaches the UPSTREAM WIRE through the
+// real @ai-sdk provider serialization (not just the pure helper). A capturing
+// fetch double records the outgoing request body; the stream then errors out
+// (the body is already captured), so each test asserts on the wire body
+// regardless of the final response status.
+function captureBodyGateway(descriptor: UpstreamDescriptor) {
+  const captured: { url: string; body: Record<string, unknown> | null } = { url: '', body: null };
+  const gateway = createGateway(
+    baseHooks({ resolveUpstream: async () => [descriptor] }),
+    { aiSdkNative: true },
+    {
+      fetchImpl: async (url: string, init?: { body?: unknown }) => {
+        captured.url = url;
+        try {
+          captured.body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+        } catch {
+          captured.body = null;
+        }
+        // End the attempt immediately — the body is already captured. A terminal
+        // 400 stops failover; the handler returns an error, which these tests
+        // ignore in favor of the captured wire body.
+        return new Response(JSON.stringify({ error: { message: 'captured' } }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    },
+  );
+  return { gateway, captured };
+}
+
+describe('handleLanguageModel — gateway-side wire shaping (codex store:false)', () => {
+  const CODEX: UpstreamDescriptor = {
+    provider: 'openai-codex',
+    kind: 'openai-responses',
+    baseUrl: 'https://chatgpt.com/backend-api/codex',
+    apiKey: 'sk-codex',
+    resolvedModel: 'gpt-5.6-sol',
+    billingMode: 'credits',
+    markup: 1,
+  };
+
+  it('sends store:false and NO max_output_tokens for a codex model', async () => {
+    const { gateway, captured } = captureBodyGateway(CODEX);
+    await gateway.languageModel(
+      req(HEADERS({ 'ai-language-model-id': 'openai/gpt-5.6-sol' }), {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        maxOutputTokens: 4096,
+      }),
+    );
+    expect(captured.body).not.toBeNull();
+    // The confirmed prod bug: without the fix, `store` is dropped and codex 400s
+    // "Store must be set to false".
+    expect(captured.body?.store).toBe(false);
+    // Codex 400s on max_output_tokens — it must be absent.
+    expect('max_output_tokens' in (captured.body ?? {})).toBe(false);
+  });
+});
+
+describe('handleLanguageModel — gateway-side wire shaping (plain openai)', () => {
+  const OPENAI: UpstreamDescriptor = {
+    provider: 'openai',
+    kind: 'openai-compat',
+    npm: '@ai-sdk/openai',
+    baseUrl: 'https://api.openai.com',
+    apiKey: 'sk-openai',
+    resolvedModel: 'gpt-4o',
+    billingMode: 'credits',
+    markup: 1,
+  };
+
+  it('does NOT set store for a non-codex openai model', async () => {
+    const { gateway, captured } = captureBodyGateway(OPENAI);
+    await gateway.languageModel(
+      req(HEADERS({ 'ai-language-model-id': 'openai/gpt-4o' }), {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        maxOutputTokens: 512,
+      }),
+    );
+    expect(captured.body).not.toBeNull();
+    // store:false is codex-only; a plain openai chat request must never carry it.
+    expect(captured.body?.store).toBeUndefined();
+  });
+});
+
+describe('handleLanguageModel — gateway-side wire shaping (openrouter bodyExtras)', () => {
+  const OPENROUTER: UpstreamDescriptor = {
+    provider: 'openrouter',
+    kind: 'openai-compat',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    apiKey: 'sk-or',
+    resolvedModel: 'anthropic/claude-x',
+    billingMode: 'credits',
+    markup: 1,
+    bodyExtras: { provider: { order: ['Anthropic'], allow_fallbacks: false } },
+  };
+
+  it('forwards descriptor.bodyExtras (provider routing pins) onto the wire', async () => {
+    const { gateway, captured } = captureBodyGateway(OPENROUTER);
+    await gateway.languageModel(
+      req(HEADERS({ 'ai-language-model-id': 'openrouter/anthropic/claude-x' }), {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      }),
+    );
+    expect(captured.body).not.toBeNull();
+    // The OpenRouter `provider` routing pin the client cannot send must reach the
+    // upstream verbatim (openai-compatible spreads unknown providerOptions keys).
+    expect(captured.body?.provider).toEqual({ order: ['Anthropic'], allow_fallbacks: false });
+  });
+});
+
+describe('handleLanguageModel — gateway-side wire shaping (anthropic regression)', () => {
+  const ANTHROPIC: UpstreamDescriptor = {
+    provider: 'anthropic',
+    kind: 'anthropic',
+    npm: '@ai-sdk/anthropic',
+    baseUrl: 'https://api.anthropic.com',
+    apiKey: 'sk-anthropic',
+    resolvedModel: 'claude-fable-5',
+    billingMode: 'credits',
+    markup: 1,
+  };
+
+  it('forwards client providerOptions (thinking) + maxOutputTokens, adds no store', async () => {
+    const { gateway, captured } = captureBodyGateway(ANTHROPIC);
+    await gateway.languageModel(
+      req(HEADERS(), {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        maxOutputTokens: 1024,
+        providerOptions: { anthropic: { thinking: { type: 'adaptive' }, effort: 'high' } },
+      }),
+    );
+    expect(captured.body).not.toBeNull();
+    // The Anthropic wire carries max_tokens (client cap forwarded unchanged) and
+    // the adaptive-thinking block from the client's own providerOptions.
+    expect(captured.body?.max_tokens).toBe(1024);
+    expect(captured.body?.thinking).toEqual({ type: 'adaptive' });
+    // No codex/openai shaping leaked into a non-openai family.
+    expect(captured.body?.store).toBeUndefined();
+  });
+});
+
 describe('handleLanguageModel — request-size ceiling (FIX 2)', () => {
   it('returns 413 request_too_large when the body exceeds maxRequestBytes, before auth/billing', async () => {
     let authenticated = false;

--- a/packages/llm-gateway/src/pipeline/language-model-handler.ts
+++ b/packages/llm-gateway/src/pipeline/language-model-handler.ts
@@ -4,6 +4,7 @@ import { parseUpstreamErrorBody } from '../http/parse-upstream-error';
 import {
   type FullStreamPart,
   aiGatewaySseFromFullStream,
+  applyNativeGatewayShaping,
   guardAgainstUnhandledResultRejections,
   resolveAiModel,
   toTransportError,
@@ -46,12 +47,19 @@ import { type NativeFailure, runNativeFailover } from './native-failover';
 //     handler.ts's empty-completion retry loop, but over typed `fullStream`
 //     parts instead of OpenAI SSE bytes. ONLY the committed candidate is billed.
 //
+// GATEWAY-SIDE request shaping (`applyNativeGatewayShaping`, request.ts):
+//   - opencode's `@ai-sdk/gateway` sends provider-native `providerOptions` for
+//     all CLIENT-SIDE shaping (thinking/reasoning, prompt-cache breakpoints,
+//     sampling), which the decoded call forwards to `streamText` verbatim.
+//   - It CANNOT send the Kortix-proxy-only tweaks `buildAiSdkArgs` +
+//     callUpstreamViaAiSdk apply on the OpenAI-compat path (codex store:false +
+//     max_output_tokens drop, OpenRouter bodyExtras, Nova maxOutputTokens
+//     clamp). Those are re-applied per-candidate in `startStream` below. Without
+//     them, codex models 400 `{"detail":"Store must be set to false"}`.
+//
 // DEFERRED to Phase 3 (documented, NOT silently missing):
 //   - Non-streaming (`ai-language-model-streaming: false`) collects the stream
 //     into a single JSON result — exact `doGenerate` wire parity is Phase 2.
-//   - `buildAiSdkArgs`'s thinking/caching re-shaping. opencode's
-//     `@ai-sdk/gateway` already sends provider-native `providerOptions`, so the
-//     decoded call args are forwarded to `streamText` verbatim here.
 // ---------------------------------------------------------------------------
 
 // Imported lazily via a typed shim so this module does not hard-depend on the
@@ -281,6 +289,16 @@ export async function handleLanguageModel(
         ...(fetchImpl ? { fetch: (input, init) => fetchImpl(String(input), init ?? {}) } : {}),
       },
     );
+    // Re-apply the GATEWAY-SIDE, provider-specific request shaping opencode's
+    // `@ai-sdk/gateway` client cannot send (codex store:false + max_output_tokens
+    // drop, OpenRouter bodyExtras, Nova maxOutputTokens clamp) — keyed off THIS
+    // candidate's resolved descriptor so a failover onto a different provider
+    // carries its own shaping. Client-side shaping (thinking/caching/sampling)
+    // stays forwarded verbatim below. Single source of truth: request.ts.
+    const shaped = applyNativeGatewayShaping(candidate.descriptor, {
+      providerOptions: decoded.call.providerOptions,
+      maxOutputTokens: decoded.call.maxOutputTokens,
+    });
     // biome-ignore lint/suspicious/noExplicitAny: decoded.call is the AI-SDK
     // CallSettings-shaped args (messages/tools/providerOptions/...), forwarded
     // to streamText verbatim; the exact union is validated by the SDK at runtime.
@@ -296,9 +314,9 @@ export async function handleLanguageModel(
       frequencyPenalty: decoded.call.frequencyPenalty,
       presencePenalty: decoded.call.presencePenalty,
       stopSequences: decoded.call.stopSequences,
-      maxOutputTokens: decoded.call.maxOutputTokens,
+      maxOutputTokens: shaped.maxOutputTokens,
       seed: decoded.call.seed,
-      providerOptions: decoded.call.providerOptions,
+      providerOptions: shaped.providerOptions,
       maxRetries: 0,
       abortSignal: req.signal,
       onError: () => {

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -12,6 +12,9 @@ import {
 import { buildAiSdkArgs } from './request';
 import { openAiJsonFromResult, openAiSseFromFullStream } from './sse';
 
+export { applyNativeGatewayShaping } from './request';
+export type { NativeShapableCall } from './request';
+
 export type { AiSdkFetch } from './model';
 export {
   aiSdkFamilyFor,

--- a/packages/llm-gateway/src/transports/ai-sdk/request-native-shaping.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request-native-shaping.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'bun:test';
+import type { UpstreamDescriptor } from '../../domain';
+import { applyNativeGatewayShaping } from './request';
+
+// Pure-function proof of the GATEWAY-SIDE, provider-specific request shaping the
+// native `/language-model` path re-applies (see request.ts's
+// applyNativeGatewayShaping doc). Each case mirrors exactly one tweak the
+// OpenAI-compat path (buildAiSdkArgs + callUpstreamViaAiSdk) applies and the
+// native passthrough would otherwise drop.
+
+const CODEX: UpstreamDescriptor = {
+  provider: 'openai-codex',
+  kind: 'openai-responses',
+  baseUrl: 'https://chatgpt.com/backend-api/codex',
+  apiKey: 'sk-codex',
+  resolvedModel: 'gpt-5.6-sol',
+  billingMode: 'credits',
+  markup: 1,
+};
+
+const OPENAI: UpstreamDescriptor = {
+  provider: 'openai',
+  kind: 'openai-compat',
+  npm: '@ai-sdk/openai',
+  baseUrl: 'https://api.openai.com',
+  apiKey: 'sk-openai',
+  resolvedModel: 'gpt-4o',
+  billingMode: 'credits',
+  markup: 1,
+};
+
+const OPENROUTER: UpstreamDescriptor = {
+  provider: 'openrouter',
+  kind: 'openai-compat',
+  baseUrl: 'https://openrouter.ai/api/v1',
+  apiKey: 'sk-or',
+  resolvedModel: 'anthropic/claude-x',
+  billingMode: 'credits',
+  markup: 1,
+  bodyExtras: { provider: { order: ['Anthropic'], allow_fallbacks: false } },
+};
+
+const NOVA: UpstreamDescriptor = {
+  provider: 'bedrock',
+  kind: 'bedrock',
+  npm: '@ai-sdk/amazon-bedrock',
+  baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+  apiKey: 'sk-bedrock',
+  resolvedModel: 'amazon.nova-pro-v1:0',
+  region: 'us-east-1',
+  billingMode: 'credits',
+  markup: 1,
+};
+
+const ANTHROPIC: UpstreamDescriptor = {
+  provider: 'anthropic',
+  kind: 'anthropic',
+  npm: '@ai-sdk/anthropic',
+  baseUrl: 'https://api.anthropic.com',
+  apiKey: 'sk-anthropic',
+  resolvedModel: 'claude-fable-5',
+  billingMode: 'credits',
+  markup: 1,
+};
+
+describe('applyNativeGatewayShaping — codex', () => {
+  it('sets providerOptions.openai.store = false and DROPS maxOutputTokens', () => {
+    const out = applyNativeGatewayShaping(CODEX, { maxOutputTokens: 4096 });
+    expect(out.providerOptions?.openai?.store).toBe(false);
+    expect(out.maxOutputTokens).toBeUndefined();
+  });
+
+  it('preserves other client providerOptions while adding store', () => {
+    const out = applyNativeGatewayShaping(CODEX, {
+      providerOptions: { openai: { reasoningEffort: 'low' } },
+      maxOutputTokens: 1000,
+    });
+    expect(out.providerOptions?.openai).toEqual({ reasoningEffort: 'low', store: false });
+    expect(out.maxOutputTokens).toBeUndefined();
+  });
+});
+
+describe('applyNativeGatewayShaping — plain openai (NOT codex)', () => {
+  it('does NOT set store and forwards maxOutputTokens unchanged', () => {
+    const out = applyNativeGatewayShaping(OPENAI, {
+      providerOptions: { openai: { reasoningEffort: 'high' } },
+      maxOutputTokens: 8192,
+    });
+    expect(out.providerOptions?.openai).toEqual({ reasoningEffort: 'high' });
+    expect(out.providerOptions?.openai?.store).toBeUndefined();
+    expect(out.maxOutputTokens).toBe(8192);
+  });
+});
+
+describe('applyNativeGatewayShaping — openrouter bodyExtras', () => {
+  it('merges descriptor.bodyExtras under the provider-name key', () => {
+    const out = applyNativeGatewayShaping(OPENROUTER, { maxOutputTokens: 2048 });
+    expect(out.providerOptions?.openrouter).toEqual({
+      provider: { order: ['Anthropic'], allow_fallbacks: false },
+    });
+    // Non-codex → client cap forwarded.
+    expect(out.maxOutputTokens).toBe(2048);
+  });
+
+  it('an upstream pin wins over a same-named client field (merged LAST)', () => {
+    const out = applyNativeGatewayShaping(OPENROUTER, {
+      providerOptions: { openrouter: { provider: { order: ['Client'] }, keep: true } },
+    });
+    expect(out.providerOptions?.openrouter).toEqual({
+      keep: true,
+      provider: { order: ['Anthropic'], allow_fallbacks: false },
+    });
+  });
+});
+
+describe('applyNativeGatewayShaping — bedrock Nova clamp', () => {
+  it('clamps an over-large maxOutputTokens to the Nova ceiling (10000)', () => {
+    const out = applyNativeGatewayShaping(NOVA, { maxOutputTokens: 128000 });
+    expect(out.maxOutputTokens).toBe(10000);
+  });
+
+  it('leaves a smaller cap untouched', () => {
+    const out = applyNativeGatewayShaping(NOVA, { maxOutputTokens: 4096 });
+    expect(out.maxOutputTokens).toBe(4096);
+  });
+});
+
+describe('applyNativeGatewayShaping — anthropic/bedrock-claude regression (no-op)', () => {
+  it('forwards client providerOptions + maxOutputTokens verbatim, no store', () => {
+    const out = applyNativeGatewayShaping(ANTHROPIC, {
+      providerOptions: {
+        anthropic: { thinking: { type: 'adaptive' }, effort: 'high' },
+      },
+      maxOutputTokens: 32000,
+    });
+    expect(out.providerOptions).toEqual({
+      anthropic: { thinking: { type: 'adaptive' }, effort: 'high' },
+    });
+    expect(out.providerOptions?.openai).toBeUndefined();
+    expect(out.maxOutputTokens).toBe(32000);
+  });
+
+  it('leaves providerOptions undefined when the client sent none', () => {
+    const out = applyNativeGatewayShaping(ANTHROPIC, { maxOutputTokens: 4096 });
+    expect(out.providerOptions).toBeUndefined();
+    expect(out.maxOutputTokens).toBe(4096);
+  });
+});

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -10,8 +10,14 @@ import {
   jsonSchema,
   tool,
 } from 'ai';
+import type { UpstreamDescriptor } from '../../domain';
 import { reasoningEffort as reasoningEffortFromBody } from '../route-kind';
-import type { AiSdkFamily } from './model';
+import {
+  type AiSdkFamily,
+  aiSdkFamilyFor,
+  clampMaxOutputTokensForBedrock,
+  isCodexDescriptor,
+} from './model';
 
 // `system` normally collapses to a plain string, but the anthropic/bedrock
 // prompt-caching port below (applyAnthropicPromptCaching) needs to attach a
@@ -1169,5 +1175,86 @@ export function buildAiSdkArgs(
     providerOptions: (Object.keys(providerOptions).length ? providerOptions : undefined) as
       | Record<string, Record<string, JSONValue>>
       | undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AI-SDK-NATIVE (`POST /language-model`) gateway-side request shaping.
+//
+// The native path (language-model-handler.ts) decodes opencode's
+// `@ai-sdk/gateway` CallOptions and forwards them to `streamText` verbatim.
+// That is correct for CLIENT-SIDE shaping — thinking/reasoning, prompt-cache
+// breakpoints, temperature/top_p — which opencode already sends as
+// provider-native `providerOptions`/CallSettings.
+//
+// It is WRONG for the handful of GATEWAY-SIDE tweaks that are Kortix-proxy
+// requirements the client cannot know. Those live only on the OpenAI-compat
+// path (buildAiSdkArgs above + callUpstreamViaAiSdk in index.ts) and were
+// silently dropped natively. `applyNativeGatewayShaping` re-applies exactly
+// that set, keyed off the RESOLVED descriptor, so the two engines stay in
+// parity. It is the single source of truth for the native path; keep it in
+// lockstep with the OpenAI-compat sites named per tweak below.
+//
+// The set (mirrors the OpenAI-compat path field-for-field):
+//   1. openai-codex → providerOptions.openai.store = false. The ChatGPT
+//      subscription Responses backend 400s a body that omits `store`
+//      (`{"detail":"Store must be set to false"}`). Mirrors openAiAdapter's
+//      `if (providerName === 'openai-codex') options.store = false`. A codex
+//      descriptor resolves to @ai-sdk/openai's `.responses()` model (see
+//      aiSdkFamilyFor / needsResponsesApi), which reads providerOptions.openai.
+//   2. openai-codex → drop maxOutputTokens. The same backend 400s
+//      `max_output_tokens` outright (`{"detail":"Unsupported parameter:
+//      max_output_tokens"}`). Mirrors callUpstreamViaAiSdk's
+//      `opts.providerName === 'openai-codex' ? undefined : ...`.
+//   3. openai-compatible (OpenRouter) → merge descriptor.bodyExtras (the
+//      upstream `provider` routing pins) under the provider-name key, LAST so
+//      an upstream pin wins over a same-named client field. Mirrors
+//      buildAiSdkArgs's bodyExtras merge.
+//   4. bedrock/Nova → clamp maxOutputTokens to the Converse ceiling Nova hard-
+//      rejects above. Reuses the exact clampMaxOutputTokensForBedrock helper
+//      callUpstreamViaAiSdk uses. A no-op for every other family/model.
+//
+// `isCodexDescriptor` is the canonical codex discriminator (a codex descriptor
+// always carries BOTH provider 'openai-codex' AND kind 'openai-responses' — see
+// model.ts) and is exactly the set aiSdkFamilyFor routes to the Responses API,
+// where store/max_output_tokens matter.
+export interface NativeShapableCall {
+  providerOptions?: Record<string, Record<string, JSONValue>>;
+  maxOutputTokens?: number;
+}
+
+export function applyNativeGatewayShaping(
+  descriptor: UpstreamDescriptor,
+  call: NativeShapableCall,
+): NativeShapableCall {
+  const codex = isCodexDescriptor(descriptor);
+  const family = aiSdkFamilyFor(descriptor);
+  const providerOptions: Record<string, Record<string, JSONValue>> = { ...call.providerOptions };
+
+  // (1) Codex store:false.
+  if (codex) {
+    providerOptions.openai = { ...providerOptions.openai, store: false };
+  }
+
+  // (3) OpenRouter bodyExtras — merged last so an upstream pin wins.
+  if (family === 'openai-compatible' && descriptor.bodyExtras) {
+    const key = descriptor.provider || 'openai-compatible';
+    const extras = Object.fromEntries(
+      Object.entries(descriptor.bodyExtras).filter(([, value]) => value !== undefined),
+    ) as Record<string, JSONValue>;
+    if (Object.keys(extras).length) {
+      providerOptions[key] = { ...providerOptions[key], ...extras };
+    }
+  }
+
+  // (2) Codex drops maxOutputTokens outright; (4) Nova clamps it. The client's
+  // own cap is otherwise forwarded unchanged.
+  const maxOutputTokens = codex
+    ? undefined
+    : clampMaxOutputTokensForBedrock(call.maxOutputTokens, family, descriptor.resolvedModel);
+
+  return {
+    providerOptions: Object.keys(providerOptions).length ? providerOptions : undefined,
+    maxOutputTokens,
   };
 }


### PR DESCRIPTION
Fixes a confirmed prod break on the AI-SDK-native `/language-model` path: `openai-codex` models 400'd `{"detail":"Store must be set to false"}` because the native path (a payload passthrough) dropped **gateway-side** provider shaping that the OpenAI-compatible path applied. These tweaks are Kortix-proxy requirements the client (opencode's `@ai-sdk/gateway`) can't send — so the gateway must re-apply them.

## The whole class (audited, all four closed)
| Tweak | Provider | Why |
|---|---|---|
| `store: false` | openai-codex | ChatGPT Codex backend rejects otherwise (the break) |
| drop `max_output_tokens` | openai-codex | Codex backend 400s on it |
| forward `bodyExtras` | openai-compatible (OpenRouter) | provider-routing pins |
| `clampMaxOutputTokensForBedrock` | bedrock/Nova | Converse rejects an oversized ceiling |

Everything else is either **client-side** (opencode sends provider-native `providerOptions` — thinking, `cacheControl`/`cachePoint`, temperature — forwarded verbatim) or already inside the **shared** `resolveAiModel`.

## Change
- `applyNativeGatewayShaping(descriptor, {...})` — a single source of truth (`transports/ai-sdk/request.ts`), reusing `clampMaxOutputTokensForBedrock` / `isCodexDescriptor` / `aiSdkFamilyFor`.
- Wired per-candidate in `language-model-handler.ts` (so a failover onto a different provider carries its own shaping).

## Verification
`packages/llm-gateway`: **479 pass / 4 skip / 0 fail**, typecheck clean. Includes black-box **wire-capture** tests through real `@ai-sdk` serialization: codex emits `store:false` + no `max_output_tokens`; plain openai emits neither; OpenRouter forwards its `provider` pins; anthropic regression forwards client thinking + `max_tokens`, adds no `store`.

**Not proven live yet** against a real Codex backend — dev verification (codex + OpenAI + Claude + Bedrock + OpenRouter turns) is the gate before re-enabling the native path anywhere. Flag stays **off** by default.
