### PR TITLE
fix(web): boot-time composer shows the session's real agent; panels survive boot→ready

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -213,6 +213,19 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
   });
   const sandbox = session.sandbox;
   const startStage = session.stage ?? 'provisioning';
+  // The immutable agent this session was created with — known BEFORE the
+  // sandbox is ready (the sessions-list row is usually already cached from the
+  // sidebar; `/start`'s first response carries it as well). Handed to every
+  // composer on this route so the picker renders the session's real agent from
+  // the first frame instead of guessing `selectable[0]` from the roster while
+  // booting, then "correcting" itself once ready. `'default'` is the server's
+  // spelling of "no agent bound" (see shared.ts serializers), not a roster
+  // agent — it must not shadow the project default.
+  const listAgentName = currentProjectSession?.agent_name?.trim();
+  const boundAgentName =
+    (listAgentName && listAgentName !== 'default' ? listAgentName : null) ??
+    session.agentName ??
+    null;
   const switchingToSessionId = useSessionSwitchStore((state) => state.targetSessionId);
   const completeSessionSwitch = useSessionSwitchStore((state) => state.completeSwitch);
 
@@ -690,6 +703,7 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
                   projectId={projectId}
                   sessionId={sessionId}
                   sessionState={session}
+                  boundAgentName={boundAgentName}
                   onChatReady={() => setChatReady(true)}
                 />
               )}
@@ -712,6 +726,7 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
                 projectId={projectId}
                 sessionId={sessionId}
                 stage={authLoading || !user ? 'provisioning' : startStage}
+                boundAgentName={boundAgentName}
                 onSubmit={() => setSubmittedOnShell(true)}
               />
             ) : (
@@ -827,11 +842,15 @@ function ActiveSessionChat({
   projectId,
   sessionId,
   sessionState,
+  boundAgentName,
   onChatReady,
 }: {
   projectId: string;
   sessionId: string;
   sessionState: UseSessionResult;
+  /** The session's immutable creation agent, resolved by the page (sessions
+   *  list row, falling back to /start's `agent_name`). */
+  boundAgentName?: string | null;
   onChatReady?: () => void;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -1000,6 +1019,7 @@ function ActiveSessionChat({
           sessionId={chatSessionId}
           projectSessionId={sessionId}
           projectId={projectId}
+          boundAgentName={boundAgentName}
           sessionState={chatSessionId === sessionState.opencodeSessionId ? sessionState : undefined}
         />
       </ClientErrorBoundary>

--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -134,6 +134,7 @@ export function ComposerChatInput({
    */
   const agentResolution = resolveComposerAgent({
     agents,
+    boundAgent: boundAgentName,
     defaultAgent: projectConfig?.open_code_default_agent,
     selectedAgent: local.agent.current?.name ?? null,
   });

--- a/apps/web/src/features/session/composer/agent-selector.tsx
+++ b/apps/web/src/features/session/composer/agent-selector.tsx
@@ -91,9 +91,16 @@ export function AgentSelector({
   // user's own query with it.
   const showSearch = primaryAgents.length >= SEARCH_MIN_AGENTS;
 
-  const currentAgent = primaryAgents.find((a) => a.name === selectedAgent) || primaryAgents[0];
-  const displayName = currentAgent?.name ? capitalizeWords(currentAgent.name) : 'Agent';
-  const metaSelected = isMetaAgentName(currentAgent?.name);
+  // The trigger names the agent that will RUN, which is `selectedAgent` even
+  // when the roster does not (yet) contain it: a session bound to `kortix`
+  // must read "Kortix" while the roster query is still in flight, not whatever
+  // happens to be first in someone else's list. The `primaryAgents[0]`
+  // fallback stays only for a truly unresolved selection (no name at all),
+  // matching the resolver's own first-accessible pre-selection.
+  const currentAgent = primaryAgents.find((a) => a.name === selectedAgent);
+  const displayedName = currentAgent?.name ?? selectedAgent ?? primaryAgents[0]?.name;
+  const displayName = displayedName ? capitalizeWords(displayedName) : 'Agent';
+  const metaSelected = isMetaAgentName(displayedName);
 
   /**
    * One agent: name, its type, its description, and a check when it is the
@@ -193,7 +200,13 @@ export function AgentSelector({
   return (
     <CommandPopover open={open} onOpenChange={(next) => setOpen(disabled ? false : next)}>
       <CommandPopoverTrigger>
-        <Button type="button" variant="ghost" size="sm" className="text-foreground/70 rounded-lg">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label="Select agent"
+          className="text-foreground/70 rounded-lg"
+        >
           {metaSelected && <MetaFolder className="size-3.5 shrink-0" weight="fill" />}
           <span className={cn('max-w-[100px] truncate', triggerLabelClassName)}>{displayName}</span>
           <CaretDownIcon className={cn('size-3', open && 'rotate-180')} />

--- a/apps/web/src/features/session/composer/composer-agent-access.test.ts
+++ b/apps/web/src/features/session/composer/composer-agent-access.test.ts
@@ -159,3 +159,72 @@ describe('composerSelectableAgents', () => {
     expect(composerSelectableAgents(undefined)).toEqual([]);
   });
 });
+
+describe('resolveComposerAgent — bound session agent', () => {
+  // A project session is created WITH an agent and the server runs that agent
+  // for it regardless of what any roster or default says. The composer must
+  // therefore show it from the first frame — the boot-time picker used to
+  // render `selectable[0]` ("Meta") until the runtime corrected it.
+
+  test('with no pick, the bound agent outranks the project default', () => {
+    const resolved = resolveComposerAgent({
+      agents: [agent('meta'), agent('kortix'), agent('writer')],
+      boundAgent: 'kortix',
+      defaultAgent: 'writer',
+    });
+
+    expect(resolved).toEqual({ selected: 'kortix', disabled: false, reason: 'bound' });
+  });
+
+  test('an explicit accessible pick still outranks the bound agent', () => {
+    const resolved = resolveComposerAgent({
+      agents: [agent('meta'), agent('kortix'), agent('writer')],
+      boundAgent: 'kortix',
+      selectedAgent: 'writer',
+    });
+
+    expect(resolved).toEqual({ selected: 'writer', disabled: false, reason: 'selected' });
+  });
+
+  test('a bound agent missing from the roster is still the one displayed and sent', () => {
+    // The session runs it server-side either way; showing someone else's first
+    // grant would be a lie.
+    const resolved = resolveComposerAgent({
+      agents: [agent('meta')],
+      boundAgent: 'kortix',
+    });
+
+    expect(resolved).toEqual({ selected: 'kortix', disabled: false, reason: 'bound' });
+  });
+
+  test('a bound session is not refused by an empty roster', () => {
+    const resolved = resolveComposerAgent({ agents: [], boundAgent: 'kortix' });
+
+    expect(resolved).toEqual({ selected: 'kortix', disabled: false, reason: 'bound' });
+  });
+
+  test('while the roster loads, the bound agent is the display value', () => {
+    const resolved = resolveComposerAgent({ agents: undefined, boundAgent: 'kortix' });
+
+    expect(resolved).toEqual({ selected: 'kortix', disabled: false, reason: 'loading' });
+  });
+
+  test('while the roster loads, an existing pick still wins over the bound agent', () => {
+    const resolved = resolveComposerAgent({
+      agents: undefined,
+      boundAgent: 'kortix',
+      selectedAgent: 'writer',
+    });
+
+    expect(resolved.selected).toBe('writer');
+  });
+
+  test('without a bound agent, the roster fallback chain is unchanged', () => {
+    const resolved = resolveComposerAgent({
+      agents: [agent('meta'), agent('writer')],
+      defaultAgent: 'kortix',
+    });
+
+    expect(resolved).toEqual({ selected: 'meta', disabled: false, reason: 'first_accessible' });
+  });
+});

--- a/apps/web/src/features/session/composer/composer-agent-access.ts
+++ b/apps/web/src/features/session/composer/composer-agent-access.ts
@@ -41,6 +41,8 @@ export type ComposerAgentReason =
   | 'loading'
   /** The caller's own pick is accessible and stands. */
   | 'selected'
+  /** No pick; the session's immutable creation agent stands. */
+  | 'bound'
   /** No pick (or an inaccessible one); the project default is accessible. */
   | 'default'
   /** Neither the pick nor the default is accessible; first grant wins. */
@@ -73,25 +75,49 @@ export function composerSelectableAgents(agents: Agent[] | undefined): Agent[] {
 export function resolveComposerAgent(input: {
   /** The accessible roster. `undefined` means the query is still in flight. */
   agents: Agent[] | undefined;
+  /**
+   * The session's immutable creation agent, when this composer belongs to an
+   * existing project session. It is what the server RUNS for this session
+   * regardless of roster membership, so with no explicit pick it is the truth
+   * to display — never `selectable[0]`, which is somebody else's first grant
+   * and made a booting Kortix session read "Meta" until the runtime corrected
+   * it.
+   */
+  boundAgent?: string | null;
   /** The project's declared default agent, accessible or not. */
   defaultAgent?: string | null;
   /** The caller's current pick (session slot, last-used, …), if any. */
   selectedAgent?: string | null;
 }): ComposerAgentResolution {
+  const bound = input.boundAgent?.trim() || null;
   // A pending roster is not an empty one. Refusing the send here would disable
-  // the composer on every cold mount for a beat, which reads as broken.
+  // the composer on every cold mount for a beat, which reads as broken. Show
+  // the pick, else the session's bound agent — the one name known to be right
+  // before any query lands.
   if (!Array.isArray(input.agents)) {
-    return { selected: input.selectedAgent?.trim() || null, disabled: false, reason: 'loading' };
+    const picked = input.selectedAgent?.trim();
+    if (picked) return { selected: picked, disabled: false, reason: 'loading' };
+    return { selected: bound, disabled: false, reason: 'loading' };
   }
 
   const selectable = composerSelectableAgents(input.agents);
   if (selectable.length === 0) {
+    // A bound session still runs its own agent server-side; an empty roster
+    // refuses only unbound composers.
+    if (bound) return { selected: bound, disabled: false, reason: 'bound' };
     return { selected: null, disabled: true, reason: 'no_access' };
   }
 
   const picked = input.selectedAgent?.trim();
   if (picked && selectable.some((a) => a.name === picked)) {
     return { selected: picked, disabled: false, reason: 'selected' };
+  }
+
+  // No pick: the session's own agent outranks the project default — an
+  // existing session must never re-prompt under a different agent than the
+  // one it was created with just because a default or grant order says so.
+  if (bound) {
+    return { selected: bound, disabled: false, reason: 'bound' };
   }
 
   const declaredDefault = input.defaultAgent?.trim();

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -2091,7 +2091,8 @@ export function SessionChat({
    */
   const composerAgent = resolveComposerAgent({
     agents,
-    defaultAgent: boundAgentName ?? projectConfig?.open_code_default_agent,
+    boundAgent: boundAgentName,
+    defaultAgent: projectConfig?.open_code_default_agent,
     selectedAgent: local.agent.current?.name ?? null,
   });
   const composerAgentName = composerAgent.selected;

--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -108,10 +108,19 @@ export const SessionLayout = memo(function SessionLayout({
   // (fresh navigation, tab switch, back/forward, transient → real handoff),
   // and `setActiveSession` closes both surfaces, so a session you have just
   // arrived at never inherits the last one's right side.
+  //
+  // `continuity` names the Kortix project session behind this layout id and
+  // whether this mount is the transient boot shell. The store uses it for one
+  // thing: the boot→ready crossfade renames the layout from the Kortix session
+  // id (shell) to the OpenCode id (real chat) for the SAME session — that
+  // handoff must carry an open panel across instead of slamming it shut.
   useEffect(() => {
     if (!isVisibleLayout) return;
-    setActiveSession(sessionId);
-  }, [isVisibleLayout, sessionId, setActiveSession]);
+    setActiveSession(sessionId, {
+      projectSessionId: projectSessionId ?? null,
+      transient,
+    });
+  }, [isVisibleLayout, sessionId, setActiveSession, projectSessionId, transient]);
 
   const storedPanelView = useSessionBrowserStore((s) => s.viewBySession[sessionId]);
   const panelView = normalizeSessionPanelLayoutView(storedPanelView);

--- a/apps/web/src/stores/kortix-computer-store.test.ts
+++ b/apps/web/src/stores/kortix-computer-store.test.ts
@@ -838,3 +838,117 @@ describe('detailOpen never survives its content', () => {
     expect(state().detailOpen).toBe(false);
   });
 });
+
+describe('setActiveSession — boot handoff continuity', () => {
+  beforeEach(() => {
+    useKortixComputerStore.getState().reset();
+  });
+
+  test('transient shell → real chat for the SAME project session keeps the panel open', () => {
+    const s = useKortixComputerStore.getState();
+    // The boot shell activates under the Kortix session id…
+    s.setActiveSession('kortix-sess-1', { projectSessionId: 'kortix-sess-1', transient: true });
+    useKortixComputerStore.getState().setIsSidePanelOpen(true);
+    useKortixComputerStore.getState().setIsActionPanelOpen(true);
+    // …then the real chat mounts under the OpenCode id. Same session, same
+    // screen — the panel the user opened while booting must not slam shut.
+    useKortixComputerStore
+      .getState()
+      .setActiveSession('oc-abc', { projectSessionId: 'kortix-sess-1', transient: false });
+    const after = useKortixComputerStore.getState();
+    expect(after.isSidePanelOpen).toBe(true);
+    expect(after.isActionPanelOpen).toBe(true);
+    expect(after._activeSessionId).toBe('oc-abc');
+  });
+
+  test('transient shell → real chat of a DIFFERENT project session closes', () => {
+    const s = useKortixComputerStore.getState();
+    s.setActiveSession('kortix-sess-1', { projectSessionId: 'kortix-sess-1', transient: true });
+    useKortixComputerStore.getState().setIsSidePanelOpen(true);
+    useKortixComputerStore
+      .getState()
+      .setActiveSession('oc-other', { projectSessionId: 'kortix-sess-2', transient: false });
+    expect(useKortixComputerStore.getState().isSidePanelOpen).toBe(false);
+  });
+
+  test('real → real between sessions still closes, continuity or not', () => {
+    const s = useKortixComputerStore.getState();
+    s.setActiveSession('oc-a', { projectSessionId: 'kortix-sess-1', transient: false });
+    useKortixComputerStore.getState().setIsSidePanelOpen(true);
+    useKortixComputerStore
+      .getState()
+      .setActiveSession('oc-b', { projectSessionId: 'kortix-sess-1', transient: false });
+    expect(useKortixComputerStore.getState().isSidePanelOpen).toBe(false);
+  });
+
+  test('legacy callers without continuity behave exactly as before', () => {
+    const s = useKortixComputerStore.getState();
+    s.setActiveSession('s1');
+    useKortixComputerStore.getState().setIsSidePanelOpen(true);
+    useKortixComputerStore.getState().setActiveSession('s2');
+    expect(useKortixComputerStore.getState().isSidePanelOpen).toBe(false);
+  });
+
+  test('same-id re-activation refreshes the continuity bookkeeping without closing', () => {
+    const s = useKortixComputerStore.getState();
+    // The shell mounts transient, opens a panel, then the SAME layout id is
+    // re-activated as non-transient (never happens today, but the bookkeeping
+    // must not wedge on it).
+    s.setActiveSession('kortix-sess-1', { projectSessionId: 'kortix-sess-1', transient: true });
+    useKortixComputerStore.getState().setIsSidePanelOpen(true);
+    useKortixComputerStore
+      .getState()
+      .setActiveSession('kortix-sess-1', { projectSessionId: 'kortix-sess-1', transient: false });
+    const after = useKortixComputerStore.getState();
+    expect(after.isSidePanelOpen).toBe(true);
+    expect(after._activeIsTransient).toBe(false);
+  });
+});
+
+describe('setActiveSession — boot quick-view replant', () => {
+  beforeEach(() => {
+    useKortixComputerStore.getState().reset();
+  });
+
+  test('a Terminal consumed by the boot shell is replanted for the real layout', () => {
+    const s = useKortixComputerStore.getState();
+    s.setActiveSession('kortix-1', { projectSessionId: 'kortix-1', transient: true });
+    useKortixComputerStore.getState().requestQuickView('terminal');
+    // The shell's provider consumes it (opens the panel on the boot loader)…
+    expect(useKortixComputerStore.getState().consumeQuickView('kortix-1')?.view).toBe('terminal');
+    // …then the real layout mounts. Same project session → the intent is
+    // replanted for the new id, so the surviving panel opens the Terminal
+    // instead of a blank card.
+    useKortixComputerStore
+      .getState()
+      .setActiveSession('oc-1', { projectSessionId: 'kortix-1', transient: false });
+    const after = useKortixComputerStore.getState();
+    expect(after.isSidePanelOpen).toBe(true);
+    expect(after.pendingQuickView?.sessionId).toBe('oc-1');
+    expect(after.consumeQuickView('oc-1')?.view).toBe('terminal');
+    expect(after._bootQuickView).toBeNull();
+  });
+
+  test('the remembered boot view dies with a real session change', () => {
+    const s = useKortixComputerStore.getState();
+    s.setActiveSession('kortix-1', { projectSessionId: 'kortix-1', transient: true });
+    useKortixComputerStore.getState().requestQuickView('terminal');
+    useKortixComputerStore.getState().consumeQuickView('kortix-1');
+    // Navigate to a DIFFERENT session instead of handing off.
+    useKortixComputerStore
+      .getState()
+      .setActiveSession('oc-other', { projectSessionId: 'kortix-2', transient: false });
+    const after = useKortixComputerStore.getState();
+    expect(after.isSidePanelOpen).toBe(false);
+    expect(after.pendingQuickView).toBeNull();
+    expect(after._bootQuickView).toBeNull();
+  });
+
+  test('a quick-view consumed by a real layout is not remembered', () => {
+    const s = useKortixComputerStore.getState();
+    s.setActiveSession('oc-1', { projectSessionId: 'kortix-1', transient: false });
+    useKortixComputerStore.getState().requestQuickView('terminal');
+    useKortixComputerStore.getState().consumeQuickView('oc-1');
+    expect(useKortixComputerStore.getState()._bootQuickView).toBeNull();
+  });
+});

--- a/apps/web/src/stores/kortix-computer-store.ts
+++ b/apps/web/src/stores/kortix-computer-store.ts
@@ -71,6 +71,17 @@ interface KortixComputerState {
    */
   isActionPanelOpen: boolean;
   _activeSessionId: string | null;
+  /** The Kortix project session behind `_activeSessionId`, when the layout
+   *  declared one — see `setActiveSession`'s `continuity` parameter. */
+  _activeProjectSessionId: string | null;
+  /** Whether `_activeSessionId` was activated by the transient boot shell. */
+  _activeIsTransient: boolean;
+  /** See `initialState._bootQuickView`. */
+  _bootQuickView: {
+    projectSessionId: string;
+    view: QuickView;
+    target?: QuickViewTarget;
+  } | null;
   /**
    * Per session: does that session's detail panel still HOLD something to show
    * (a file/app/step/audit detail, or the terminal layer)?
@@ -208,8 +219,18 @@ interface KortixComputerState {
    */
   toggleRightPanel: () => void;
   /** Call when a session becomes visible. Both right surfaces close — panel
-   *  state never travels between sessions. */
-  setActiveSession: (sessionId: string | null) => void;
+   *  state never travels between sessions.
+   *
+   *  `continuity` identifies the KORTIX project session behind the layout id,
+   *  plus whether the caller is the transient boot shell. The one transition it
+   *  changes: transient shell → real chat for the SAME project session (the
+   *  boot→ready crossfade renames the layout from the Kortix session id to the
+   *  OpenCode id). That is not a session change — a panel the user opened while
+   *  the sandbox booted must survive the handoff, not flicker shut. */
+  setActiveSession: (
+    sessionId: string | null,
+    continuity?: { projectSessionId: string | null; transient: boolean },
+  ) => void;
   /** `SessionPanelProvider` publishing whether `sessionId`'s detail panel holds
    *  content. Pass `null` to forget the session (the provider unmounted). */
   setDetailContent: (sessionId: string, has: boolean | null) => void;
@@ -267,6 +288,8 @@ const initialState = {
   isSidePanelOpen: false,
   isActionPanelOpen: false,
   _activeSessionId: null as string | null,
+  _activeProjectSessionId: null as string | null,
+  _activeIsTransient: false,
   _detailContentBySession: {} as Record<string, boolean>,
   isExpanded: false,
   panelSplit: null as number | null,
@@ -284,6 +307,16 @@ const initialState = {
     target?: QuickViewTarget;
   } | null,
   mobileToolView: null as QuickView | null,
+  /** A quick-view consumed by the transient BOOT shell (e.g. Terminal clicked
+   *  while the sandbox boots). The shell's provider dies at the boot→ready
+   *  handoff, taking the view with it — this remembers the intent so
+   *  `setActiveSession`'s handoff branch can replant it for the real layout.
+   *  See the continuity parameter on `setActiveSession`. */
+  _bootQuickView: null as {
+    projectSessionId: string;
+    view: QuickView;
+    target?: QuickViewTarget;
+  } | null,
 };
 
 export const useKortixComputerStore = create<KortixComputerState>()(
@@ -432,7 +465,10 @@ export const useKortixComputerStore = create<KortixComputerState>()(
         else get().setIsActionPanelOpen(true);
       },
 
-      setActiveSession: (sessionId: string | null) => {
+      setActiveSession: (
+        sessionId: string | null,
+        continuity?: { projectSessionId: string | null; transient: boolean },
+      ) => {
         // A quick-view is an intent about the session it was made in — it must
         // not replay when some other session mounts later. Cleared even on the
         // no-op re-activation path below, or a request planted for another
@@ -442,7 +478,55 @@ export const useKortixComputerStore = create<KortixComputerState>()(
           set({ pendingQuickView: null });
         }
         const prev = get()._activeSessionId;
-        if (prev === sessionId) return;
+        const nextProjectSessionId = continuity?.projectSessionId ?? null;
+        const nextIsTransient = continuity?.transient ?? false;
+        if (prev === sessionId) {
+          // Same layout re-activating (e.g. the shell flipping transient→ready
+          // state, or a tab refocus): keep the continuity bookkeeping fresh so
+          // the NEXT activation judges the handoff correctly.
+          if (
+            get()._activeProjectSessionId !== nextProjectSessionId ||
+            get()._activeIsTransient !== nextIsTransient
+          ) {
+            set({
+              _activeProjectSessionId: nextProjectSessionId,
+              _activeIsTransient: nextIsTransient,
+            });
+          }
+          return;
+        }
+        // Boot handoff, NOT a session change: the transient shell (layout id =
+        // Kortix session id) crossfades into the real chat (layout id =
+        // OpenCode id) for the SAME project session. The user is looking at
+        // the same session the whole time — a panel opened during boot must
+        // survive, so only the identity fields move. Everything the user can
+        // see (open flags, split, expansion) stays exactly as it is. One-shot
+        // intents also survive: they were made in this same session.
+        if (
+          prev !== null &&
+          get()._activeIsTransient &&
+          !nextIsTransient &&
+          nextProjectSessionId !== null &&
+          get()._activeProjectSessionId === nextProjectSessionId
+        ) {
+          // A quick-view the shell consumed (Terminal/Browser/Files during
+          // boot) is replanted for the incoming layout — its provider opens
+          // the same view, so the surviving panel shows content, never a
+          // blank card. Fresh timestamp: the boot can outlast the TTL.
+          const boot = get()._bootQuickView;
+          const replant =
+            sessionId && boot && boot.projectSessionId === nextProjectSessionId
+              ? { sessionId, view: boot.view, requestedAt: Date.now(), target: boot.target }
+              : null;
+          set({
+            _activeSessionId: sessionId,
+            _activeProjectSessionId: nextProjectSessionId,
+            _activeIsTransient: false,
+            _bootQuickView: null,
+            ...(replant ? { pendingQuickView: replant } : {}),
+          });
+          return;
+        }
         // EVERY session change lands closed. Both surfaces, no exceptions, no
         // per-session memory.
         //
@@ -460,6 +544,9 @@ export const useKortixComputerStore = create<KortixComputerState>()(
         // pressing ⌘I brings that back rather than the empty card home.
         set({
           _activeSessionId: sessionId,
+          _activeProjectSessionId: nextProjectSessionId,
+          _activeIsTransient: nextIsTransient,
+          _bootQuickView: null,
           isSidePanelOpen: false,
           isActionPanelOpen: false,
           isExpanded: false,
@@ -621,6 +708,19 @@ export const useKortixComputerStore = create<KortixComputerState>()(
         if (!pending || pending.sessionId !== sessionId) return null;
         set({ pendingQuickView: null });
         if (now - pending.requestedAt > QUICK_VIEW_TTL_MS) return null;
+        // Consumed by the transient BOOT shell: its provider (and the view it
+        // opens) will not survive the boot→ready handoff. Remember the intent
+        // keyed by the project session, so the handoff can replant it for the
+        // real layout — a Terminal opened while booting stays a Terminal.
+        if (get()._activeIsTransient && get()._activeProjectSessionId) {
+          set({
+            _bootQuickView: {
+              projectSessionId: get()._activeProjectSessionId!,
+              view: pending.view,
+              target: pending.target,
+            },
+          });
+        }
         return { view: pending.view, target: pending.target };
       },
 

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -1438,6 +1438,17 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
     phase,
     /** Raw /start stage (provisioning|starting|ready|stopped|failed), for boot UI. */
     stage,
+    /**
+     * The immutable agent this project session was created with, from /start
+     * (`agent_name`). Known from the FIRST /start response — long before the
+     * sandbox is ready — so composers can render the session's real agent
+     * while it boots instead of guessing from the roster. The server
+     * serializes `'default'` when no agent was bound; that is not a real
+     * roster agent, so it surfaces as `null` here.
+     */
+    agentName: startData?.agent_name && startData.agent_name !== 'default'
+      ? startData.agent_name
+      : null,
     /** The serialized session_sandboxes row from /start (status, metadata, ids), or null. */
     sandbox,
     /** True once the runtime is switched in and ready (equivalent to phase==='ready'). */


### PR DESCRIPTION
## Problem

Two boot-window bugs on the session route (reported on dev.kortix.com):

1. **Agent picker shows the wrong agent while the sandbox boots.** A session bound to `kortix` rendered "Meta" — whatever was first in the accessible roster — until the runtime came up, then visibly "corrected" itself.
2. **Panels opened during boot slam shut at ready.** The boot→ready crossfade renames the `SessionLayout` id from the Kortix session id (transient shell) to the OpenCode id (real chat). `setActiveSession` treats every id change as a session switch and closes both right-side surfaces.

## Fix

**Agent picker**
- `useSession()` (SDK) now surfaces `agentName` from `/start`'s `agent_name` (known from the FIRST response, long before ready; the server's `'default'` placeholder normalizes to `null`). Additive export — no breaking change.
- `page.tsx` resolves `boundAgentName` (sessions-list row → `/start` fallback) and passes it to both `InstantSessionShell` and `SessionChat`.
- `resolveComposerAgent` gains `boundAgent`: with no explicit pick it outranks the project default and the `selectable[0]` fallback, works while the roster loads, and is not refused by an empty roster (the server runs it for this session regardless).
- `AgentSelector`'s trigger names `selectedAgent` even before the roster contains it (it fell back to `primaryAgents[0]` — the actual "Meta" pixel). Trigger also gains `aria-label="Select agent"`.

**Panel continuity**
- `setActiveSession(sessionId, {projectSessionId, transient})`: the one transition where identity changes but the session doesn't — transient shell → real chat for the SAME project session — now carries the open panel state across. Every real session change still lands closed (the "session B inherits session A's empty panel" bug stays fixed).

## Tests

- `composer-agent-access.test.ts`: +7 (bound outranks default; explicit pick outranks bound; off-roster bound displayed; empty roster not refused for bound; loading states; unbound chain unchanged) — 21 pass.
- `kortix-computer-store.test.ts`: +5 (handoff keeps panels; cross-session closes; real→real closes; legacy signature unchanged; same-id re-activation) — 83 pass.
- Suites: sdk react 720 pass, web session+stores 2519 pass, `tsc --noEmit` clean (both), eslint 0 errors.

Third fix found while verifying: a panel that now SURVIVES the handoff used to land on a blank card — the Terminal a user opened during boot lived in the shell provider's React state and died with it. `consumeQuickView` now remembers a quick-view consumed by the transient shell (`_bootQuickView`, keyed by project session) and the handoff replants it for the incoming layout, so the surviving panel opens the same Terminal/Browser/Files view. +3 store tests (86 pass).

## E2E evidence (local worktree, real Platinum sandbox)

Playwright probe (`queue-lab/probe-boot-ui.ts`), real home→session flow: pick `harness-reflector` (NOT the default — `kortix` is default AND roster[0], so any fallback leak would repaint it), send, optimistic redirect, sandbox boots ~13s.

- 24 painted boot samples (stage=provisioning/starting): agent trigger read **"Harness-Reflector" in every sample** — the default never leaked through.
- Right panel opened at T+7.4 (provisioning, boot checklist) — **71 samples across ready (T+13.4) + 12s: zero closes/drops**, and post-ready it shows the **live Terminal** (`kortix@…:/workspace$`), not a blank card.
- Left sidebar width constant 256px across the entire run.
- Gemini 3.7 Flash frame-by-frame video review: **PASS, 9.5/10, zero P0–P3 findings** ("Zero frame swap or default agent fallback", "Terminal container remained docked … without unmounting or visual flicker", "sidebar … without shifting").

Suites: web `bun test src/features/session src/stores` 2528 pass; sdk `src/react` 720 pass; `tsc --noEmit` clean in both; eslint 0 errors. (The full sdk suite shows 468 pre-existing `makeRequest` mock-server failures on clean `main` `d9de4a223d` with the dev stack running — environmental, unrelated to this diff.)
