### PR TITLE
deploy-staging: Cloudflare auth failure must not freeze the staging frontend

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -316,6 +316,14 @@ jobs:
   wire-cloudflare:
     name: Wire Cloudflare staging DNS and Worker
     runs-on: ubuntu-latest
+    # Non-blocking: deploy-web-vercel, verify, and promote-staging-channel
+    # `needs:` this job, and a Cloudflare auth failure (403 since 2026-08-18)
+    # silently skipped every staging web deploy for a week — the suite then
+    # drove a frozen Aug-12 frontend against the current API. The Worker/DNS
+    # config this job manages already exists and rarely changes; when it
+    # fails, the failed step stays visible here but must not freeze the
+    # frontend. verify still curls the live staging hosts independently.
+    continue-on-error: true
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}


### PR DESCRIPTION
## Problem

`wire-cloudflare` fails with a 403 on every deploy-staging run since 2026-08-18 (the `CLOUDFLARE_GLOBAL_API_KEY` secret no longer authenticates). Three jobs `needs:` it:

- `deploy-web-vercel` — **skipped on every run**, so `staging.kortix.com` has served the **2026-08-12** frontend for a week while the API moved on. The release-gate browser shards fail across 12 journeys on that skew (dry-run 32306385663).
- `verify` — skipped, so the skew was never reported.
- `promote-staging-channel` — skipped, so `:staging-<sha8>` retags never happened.

## Fix

`continue-on-error: true` on `wire-cloudflare`. The failed step stays visible in the run; the frontend deploys regardless; `verify` still curls the live staging hosts independently. The Worker/DNS config the job manages already exists and rarely changes.

## Evidence

- 10 consecutive deploy-staging runs show `Vercel: skipped,skipped | Cloudflare: failure`; last success 2026-08-12 20:04 UTC.
- Job log: first `curl` returns 403 with `X-Auth-Email`/`X-Auth-Key` auth.
- `actionlint` + YAML parse clean; `bun test tests/unit/web-ecs-workflow.test.ts tests/unit/staging-secret-workflow.test.ts` pass.

## Follow-up (not this PR)

Rotate/replace the Cloudflare credentials (`CLOUDFLARE_GLOBAL_API_KEY`/`CLOUDFLARE_EMAIL` or a scoped `CLOUDFLARE_API_TOKEN` with Workers+DNS perms) so the Worker CI-passthrough change can actually land on the edge.
