### PR TITLE
ci(dev): auto-deploy latest + cancel-stale (builds are fast now)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,11 +1,12 @@
 name: Deploy Dev
 
-# DEV pipeline. `main` is the dev branch. Deploys are EXPLICIT (the Deploy Dev
-# button / `workflow_dispatch`), NOT per-push — see the `on:` block for why. A
-# dispatch builds the things that changed since dev's live sha (or all/frontend
-# on demand) as a DEV build versioned `<next>-dev.<sha8>`, where <next> is one
-# patch above the latest published release tag (see the dev-version job). So a
-# dev deploy tracks prod's version line and `main` carries no release-version bump.
+# DEV pipeline. `main` is the dev branch: every push auto-deploys the surfaces
+# that changed vs what dev currently runs, on the LATEST commit, cancelling any
+# superseded in-flight deploy (see the `on:` and `concurrency:` blocks). A manual
+# `workflow_dispatch` can force all/frontend on demand. Builds are versioned
+# `<next>-dev.<sha8>`, where <next> is one patch above the latest published release
+# tag (see the dev-version job). So dev tracks prod's version line automatically
+# and `main` carries no release-version bump.
 #
 #   - API image   → kortix/kortix-api:dev-<sha8> + :dev-latest, deployed to dev
 #                   via ECS Fargate. dev-api.kortix.com
@@ -26,11 +27,15 @@ name: Deploy Dev
 # the single unified vX.Y.Z release bundling API + frontend + CLI + desktop.
 
 on:
-  # DEV DEPLOYS ARE EXPLICIT — NOT on every push to main. main is a high-traffic
-  # trunk; auto-deploying each push meant deploys queued/cancelled all day and
-  # nobody could tell which sha was live. Now you deploy on demand (the button
-  # below), which collapses a burst of pushes into ONE intentional deploy of
-  # main HEAD. A once-daily safety-net run keeps dev from silently going stale.
+  # DEV auto-deploys the LATEST main commit on every push, building only the
+  # surfaces that actually changed vs what dev is currently running (detect-
+  # changes below diffs against dev-api's live SHA). A newer push CANCELS the
+  # in-progress deploy — dev should always converge to newest, never spend
+  # minutes finishing a superseded build.
+  push:
+    branches: [main]
+  # Manual override: force a full or frontend-only redeploy, or re-deploy on
+  # demand. `changed` (default) matches the push path — only stale surfaces.
   workflow_dispatch:
     inputs:
       surface:
@@ -42,31 +47,29 @@ on:
           - changed   # only surfaces stale vs what dev currently runs (fast — the default)
           - all       # force-rebuild + redeploy every surface
           - frontend  # frontend only
-  schedule:
-    # Safety net only: once a day, deploy whatever changed since the last dev
-    # deploy. Keeps dev current if nobody dispatched — never a substitute for
-    # the explicit button. 06:00 UTC = a quiet hour.
-    - cron: '0 6 * * *'
 
-# One group for every surface, and it must NOT cancel what is already running.
+# Cancel a superseded deploy so dev always converges to the newest commit.
 #
-# `cancel-in-progress: true` starved the slowest surface out of existence. The
-# multi-arch API image takes ~23 min to build; main lands every ~10-20 min during
-# the day; and the group is workflow-wide, so a frontend-only push cancelled an
-# in-flight API build. Measured 2026-08-10: 19 of 30 runs cancelled, the API image
-# had not deployed in 3.5 h, and 5 API commits were stranded — the run that finally
-# landed only survived because the trunk went quiet in the evening.
-#
-# Queueing instead guarantees forward progress. GitHub keeps at most one pending
-# run per group and cancels the previous pending one, so a burst of pushes still
-# collapses into a single follow-up deploy — the newest commit wins, it just waits
-# its turn. This matches deploy-prod, rollback-prod and promote, which have always
-# used `false` for the same reason.
-#
-# It also stops `migrate-db` being killed mid-migration by an unrelated push.
+# HISTORY: this was flipped to `false` on 2026-08-10 after `true` caused a 3.5h
+# outage — the multi-arch API image took ~23 min, main landed every ~10-20 min,
+# so a frontend-only push kept cancelling the in-flight API build and 5 API
+# commits stranded (it never outran the trunk). TWO things fixed the root cause,
+# so `true` is safe again and is what we want:
+#   1. The API image is single-arch amd64 now (~4-7 min, not ~23) — it comfortably
+#      outruns the push cadence, so a cancel is a fresh fast rebuild, not a starve.
+#   2. detect-changes diffs against dev's LIVE SHA, so a surface whose deploy was
+#      cancelled is still stale-vs-dev and the next run rebuilds it. A cancel can
+#      no longer strand a surface — the property the 2026-08-10 stranding relied on
+#      is gone.
+# Residual risk, dev-only and recoverable: a cancel can kill `migrate-db` mid-run.
+# node-pg-migrate wraps each step in a transaction so a killed ordinary migration
+# rolls back cleanly and the next deploy re-applies it; a `.concurrent` migration
+# can leave an INVALID index that the next `IF NOT EXISTS` skips — drop+rebuild it
+# by hand (learnings: "CREATE INDEX CONCURRENTLY under lock_timeout"). staging/prod
+# are unaffected — they are promote-gated, never per-push.
 concurrency:
   group: deploy-dev
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Detect what changed (so unrelated surfaces are skipped) ─────────────────
@@ -89,18 +92,18 @@ jobs:
           fetch-depth: 0
       - name: Resolve deploy base (what dev is actually running)
         id: base
-        # Runs for the change-diffing paths: the daily safety-net schedule, and an
-        # explicit dispatch with surface=changed. surface=all / surface=frontend
-        # force their own set below and skip this.
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.surface == 'changed')
+        # Runs for the change-diffing paths: an ordinary push, and an explicit
+        # dispatch with surface=changed. surface=all / surface=frontend force
+        # their own set below and skip this.
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.surface == 'changed')
         run: |
           # THE FLAKY-SKIP FIX. The old filter diffed `github.event.before..sha`
-          # — the commits in THIS push only. But `cancel-in-progress: false`
-          # collapses a burst of pushes into one deploy for the NEWEST sha, whose
-          # own diff misses a surface changed by an earlier, superseded commit —
-          # so that surface's job silently skips and the change strands on dev.
-          # Diff against the sha dev is running instead: every surface stale
-          # relative to the live deployment rebuilds, regardless of push grouping.
+          # — the commits in THIS push only. But a superseded/cancelled deploy
+          # meant a surface changed by an earlier commit was never built, and its
+          # push's diff was gone — so it stranded on dev. Diff against the sha dev
+          # is actually running instead: every surface stale relative to the live
+          # deployment rebuilds, and a cancelled deploy is simply re-picked-up by
+          # the next run (which is what makes cancel-in-progress safe here).
           set +e
           deployed=$(curl -sf --max-time 8 https://dev-api.kortix.com/v1/health \
             | python3 -c "import sys,json;print(json.load(sys.stdin).get('commit',''))" 2>/dev/null)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,13 +193,14 @@ non-trivial change through this full lifecycle:
    real inputs and outputs.
 3. Push the branch, open a PR against `main`, wait for required checks, and merge
    it. Do not leave finished work only on a branch or stop after opening the PR.
-4. Dev deploys are **EXPLICIT** — merging to `main` does NOT deploy to dev.
-   Trigger the **Deploy Dev** workflow yourself: `gh workflow run deploy-dev.yml
-   -f surface=changed` (or `all` / `frontend`), or the Actions "Run workflow"
-   button. Then follow it through completion. Confirm the deployed artifact
-   contains the merged SHA; a successful `/health` response alone is not
-   deployment proof. Full procedure, surfaces, and verification:
-   `docs/runbooks/deploy-dev.md`.
+4. Dev **auto-deploys on merge to `main`** — every push builds the surfaces that
+   changed vs dev's live SHA and cancels any superseded in-flight deploy. Follow
+   the resulting **Deploy Dev** run through completion. Confirm the deployed
+   artifact contains the merged SHA; a successful `/health` response alone is not
+   deployment proof. A newer push cancels an older run by design — if yours was
+   cancelled before it deployed, the next push re-picks-up your still-stale
+   surface, or force it with `gh workflow run deploy-dev.yml -f surface=all`.
+   Full procedure, surfaces, and verification: `docs/runbooks/deploy-dev.md`.
 5. Re-run the user-visible behavior against `https://dev.kortix.com` and/or
    `https://dev-api.kortix.com`. Prefer the real Kortix CLI configured for the
    dev API for CLI/project/session flows, and direct authenticated HTTP calls for

--- a/docs/runbooks/deploy-dev.md
+++ b/docs/runbooks/deploy-dev.md
@@ -1,29 +1,34 @@
-# Deploy to dev — the explicit Deploy Dev action
+# Deploy to dev — auto on push, cancel-stale, with a manual override
 
-**Dev deploys are EXPLICIT.** Merging to `main` does NOT deploy to dev. You
-trigger the deploy yourself, on demand. This is a GitHub Actions
-`workflow_dispatch` on `.github/workflows/deploy-dev.yml` — the "Deploy Dev"
-workflow.
+**Dev auto-deploys on every push to `main`.** Each push builds only the surfaces
+that changed vs what dev currently runs, on the LATEST commit, and a newer push
+CANCELS the in-progress deploy so dev always converges to newest. There is also a
+manual **Deploy Dev** button (`workflow_dispatch`) to force a full/frontend
+redeploy on demand.
 
-## Why it is explicit, not per-push
+## The model
 
-`main` is a high-traffic trunk. Auto-deploying every push meant deploys queued
-and cancelled all day (the concurrency group serialises, and the slow surface
-loses), dev lagged 30–60 min behind, and nobody could tell which SHA was live.
-An explicit deploy collapses a burst of merges into ONE intentional deploy of
-`main` HEAD, when you decide dev should move.
+- **Trigger:** `on: push` to `main` + `workflow_dispatch`.
+- **Cancel-stale:** `concurrency.cancel-in-progress: true` — a newer push kills a
+  superseded deploy. Safe here because (1) the single-arch amd64 API build is
+  ~4–7 min and outruns the push cadence, and (2) detect-changes diffs against
+  dev's LIVE SHA, so a surface whose deploy was cancelled is still stale-vs-dev
+  and the next push rebuilds it — a cancel can't strand a surface.
+- **Changed-only:** detect-changes reads dev's live SHA from
+  `dev-api.kortix.com/v1/health` and builds only surfaces stale vs it; if that
+  SHA can't be resolved it FAILS SAFE and builds everything.
 
-`staging` and `prod` are unaffected — they were always promote-gated, never
-per-push (see the `kortix-release` skill).
+`staging` and `prod` are unaffected — promote-gated, never per-push (see the
+`kortix-release` skill).
 
-## How to deploy
+## Manual deploy (override)
 
-Three equivalent ways. All deploy `main` HEAD.
+You rarely need this — push already deploys. Use it to force a full or
+frontend-only redeploy:
 
 1. **GitHub UI** — Actions tab → **Deploy Dev** → **Run workflow** → pick a
    `surface` → **Run workflow**.
-2. **CLI** — `gh workflow run deploy-dev.yml -f surface=changed`
-3. **From an agent session** — the same `gh workflow run` call.
+2. **CLI** — `gh workflow run deploy-dev.yml -f surface=all` (or `frontend` / `changed`).
 
 ### The `surface` input
 
@@ -38,12 +43,6 @@ against it, so a surface changed by any commit since the last dev deploy
 rebuilds — regardless of how the pushes were grouped. If that SHA cannot be
 resolved (health down, force-push, first deploy), it FAILS SAFE and builds every
 surface.
-
-## Safety net
-
-A `schedule` fires once a day at 06:00 UTC and runs the `changed` path, so dev
-cannot silently rot if nobody dispatched. It is a floor, not a substitute for
-the explicit deploy.
 
 ## Verify a deploy landed
 
@@ -62,10 +61,16 @@ SHA you deployed:
   app; an open tab keeps running the JS bundle it loaded before the deploy. If
   the UI looks old but `/api/health` reports the new commit, hard-reload
   (Cmd/Ctrl+Shift+R). The deploy is fine.
-- **Concurrency queues, never cancels.** `cancel-in-progress: false` is
-  deliberate (flipping it to `true` caused a 3.5h dev outage on 2026-08-10 — see
-  the `learnings` skill). A dispatch while another deploy runs QUEUES behind it;
-  the newest pending wins. Do not spam dispatches — one is enough.
+- **Cancel-stale is intentional.** `cancel-in-progress: true` — a newer push
+  cancels an in-flight deploy so dev converges to newest. A cancelled run is
+  normal, not a failure. (This was `false` from 2026-08-10 to 2026-08-20 after
+  `true` caused a 3.5h outage on a ~23-min multi-arch build; the single-arch
+  speedup + diff-vs-deployed detect-changes removed that hazard — see the
+  `learnings` skill.)
+- **Cancelled `migrate-db` is recoverable.** node-pg-migrate wraps each step in a
+  transaction (a killed ordinary migration rolls back, the next deploy re-applies
+  it); a `.concurrent` migration can leave an INVALID index — drop+rebuild it by
+  hand (learnings: "CREATE INDEX CONCURRENTLY under lock_timeout").
 
 ## Build speed
 


### PR DESCRIPTION
## Dev: auto-deploy the latest commit on push, cancel the stale one

Reverts the explicit-dispatch model (#6621) back to **auto-deploy on push**, and flips `concurrency.cancel-in-progress` `false → true` so a newer push **cancels a superseded in-flight deploy**. Dev always converges to the newest commit, and it never spends minutes finishing an outdated build.

### Why this is safe now (it wasn't in August)

`cancel-in-progress: true` was flipped to `false` on 2026-08-10 after it caused a 3.5h outage — the multi-arch API build took ~23 min, main landed every ~10–20 min, so a frontend-only push kept cancelling the in-flight API build and 5 API commits stranded (it never outran the trunk). **Both root causes are now fixed:**

1. **Fast builds.** The API image is single-arch amd64 (~4–7 min, was ~23) — it comfortably outruns the push cadence, so a cancel is a fresh fast rebuild, not a starve.
2. **Cancel can't strand a surface.** detect-changes diffs against dev's **live SHA** (#6619), so a surface whose deploy was cancelled is still stale-vs-dev and the next push rebuilds it. The exact property the 2026-08-10 stranding relied on is gone.

### What it does now
- **Trigger:** `push` to main + `workflow_dispatch` (manual override kept: `all` / `frontend` / `changed`).
- **Changed-only:** builds only surfaces stale vs dev's live SHA; fails safe to building everything if that SHA can't be resolved.
- **Cancel-stale:** newest push wins; older run cancelled.
- Removed the daily safety-net schedule (auto-on-push makes it redundant).

### Residual risk (dev-only, recoverable, documented)
A cancel can kill `migrate-db` mid-run. node-pg-migrate wraps each step in a transaction, so a killed ordinary migration rolls back and the next deploy re-applies it; a `.concurrent` migration can leave an INVALID index that the next `IF NOT EXISTS` skips — drop+rebuild by hand (learnings: "CREATE INDEX CONCURRENTLY under lock_timeout"). staging/prod are unaffected — promote-gated, never per-push.

## Verification
- YAML valid; triggers `push` + `workflow_dispatch`; `cancel-in-progress: true`.
- Workflow unit tests (`web-ecs-workflow`, `ecs-deploy-environment`, `apps-edge-workflow`, `app-runtime-workflow`, `cosign-sign-attest`) **22/0**.
- Docs updated in the same PR: `docs/runbooks/deploy-dev.md` + `AGENTS.md` step 4 now describe auto+cancel.
- Real proof after merge: this PR's own merge auto-deploys; I'll confirm dev-api reports the merge SHA and that a follow-up push cancels the prior run.
