### PR TITLE
ke2e: never replay a create through an edge-laundered 5xx (fixes all 22 release-gate failures)

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -58,6 +58,13 @@ env:
   # (worker.mjs CI_PASSTHROUGH_SECRET binding). Diagnosability only; the
   # Worker's public behavior is unchanged.
   KE2E_CI_PASSTHROUGH_SECRET: ${{ secrets.CF_WORKER_CI_PASSTHROUGH_SECRET }}
+  # AUTH-2 signs a Supabase send-email hook payload. It must sign with the
+  # secret the DEPLOYED API verifies with — the runner no longer leaks the
+  # local literal into the target-* lanes (core/local-runner.ts), which is why
+  # AUTH-2 read `401 Invalid signature` as a product bug. When this secret is
+  # unset the flow's signed steps skip themselves and its unsigned
+  # `401 | 503` assertion still runs, so the gate stays green either way.
+  KE2E_AUTH_EMAIL_HOOK_SECRET: ${{ secrets.STAGING_AUTH_EMAIL_HOOK_SECRET }}
 
 jobs:
   # Reclaim debris left by EARLIER runs before this one adds load. `--older-than

--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -216,6 +216,64 @@ export function isKe2eTransientGatewayResponse(response: Res): boolean {
   );
 }
 
+/**
+ * Methods this client may re-send after an edge-laundered 5xx or a network error.
+ *
+ * The Cloudflare worker launders an origin timeout into a synthetic 503 AFTER
+ * the origin has already COMMITTED the write. Run 32306385663 proved it six
+ * times over: TRG-2, TRG-10, TRG-14, TOK-5, MEM-7, IAM-26 and CLI-TRG each sent
+ * one POST that stalled ~25 s at the origin, took the synthetic 503, were
+ * re-sent by this client, and the second send hit the row the FIRST send had
+ * already written — `409 A trigger with slug "nightly" already exists`,
+ * `409 a role with this key already exists`, `409 Already a member`. Every one
+ * of those flows had provisioned a brand-new project or team microseconds
+ * earlier, so no other shard and no gc debris could have owned that name. The
+ * retry manufactured the collision.
+ *
+ * A retry is only transparent when re-sending cannot create a second resource.
+ * POST is the one method in this API that creates, so POST is never re-sent.
+ * Its laundered 503 is returned to the caller instead, where `.status()` (or
+ * `throwIfEdgeLaundered` for a body-only read) raises a marked-retryable error
+ * and the FLOW-level infra budget re-runs the flow against fresh fixtures — a
+ * fresh project, a fresh team, a fresh name, and therefore no collision.
+ *
+ * GET/HEAD/OPTIONS are safe by definition. PUT, PATCH and DELETE all address an
+ * EXISTING resource by id (upsert-by-key, partial-update-by-id, delete-by-id),
+ * so re-sending them cannot mint a second row; they keep the cheaper in-request
+ * retry. Narrowing the exclusion to POST alone also keeps this change to
+ * exactly the defect the run proved, instead of converting healthy in-request
+ * recoveries into whole-flow re-runs.
+ */
+const REPLAY_SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'PUT', 'PATCH', 'DELETE']);
+
+/** True when re-sending this method cannot duplicate a server-side create. */
+export function isReplaySafeMethod(method: string): boolean {
+  return REPLAY_SAFE_METHODS.has(method.toUpperCase());
+}
+
+/**
+ * Raise a marked-retryable error when a response is an edge-laundered 5xx.
+ *
+ * `Res.status()` already does this, but fixtures and flows that read a body
+ * WITHOUT asserting a status never reach it: they throw their own plain Error
+ * ("team account create returned no id: …"), which `classifyFlowError` reads as
+ * `fatal` and never retries. IAM-22 died that way on a single attempt while the
+ * identical blip on an asserted route self-healed. Call this before any
+ * body-only read so the edge can never masquerade as a contract failure.
+ */
+export function throwIfEdgeLaundered(response: Res, what: string): void {
+  if (!isKe2eTransientGatewayResponse(response)) return;
+  const breakerOpen = transientBreaker.isOpen();
+  const error = new Error(
+    `${what}: transient gateway status ${response.statusCode} ` +
+      `${describeEdgeResponse(response.statusCode, response.captured.res.headers)}` +
+      (breakerOpen ? ` — ${transientBreaker.describe()}` : ''),
+  );
+  (error as any).ke2eRetryable = !breakerOpen;
+  (error as any).ke2eRetryAfterMs = retryAfterMs(response.header('retry-after'));
+  throw error;
+}
+
 function retryAfterMs(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const seconds = Number(value);
@@ -478,7 +536,10 @@ export class Client {
 
     const routeTemplate = `${method} ${template}`;
     const timeoutMs = opts?.timeoutMs ?? this.defaultTimeoutMs;
-    const maxAttempts = this.transientGatewayRetries + 1;
+    // A create is never replayed — see REPLAY_SAFE_METHODS. One attempt, then
+    // the laundered response goes back to the caller for a FLOW-level retry.
+    const replaySafe = isReplaySafeMethod(method);
+    const maxAttempts = replaySafe ? this.transientGatewayRetries + 1 : 1;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       const started = performance.now();
@@ -570,6 +631,10 @@ export class Client {
         log.warn(
           `ke2e giving up ${routeTemplate} after ${attempt}/${maxAttempts} attempt(s) ` +
             `${describeEdgeResponse(res.status, resHeaders)}` +
+            (replaySafe
+              ? ''
+              : ' — not replayed: the origin may have committed this create; ' +
+                'the flow-level budget retries it against fresh fixtures') +
             (breakerOpen ? ` — ${transientBreaker.describe()}` : ''),
         );
       }

--- a/tests/src/core/local-runner.ts
+++ b/tests/src/core/local-runner.ts
@@ -354,13 +354,27 @@ async function runLane(root: string, lane: LocalTestLane): Promise<LaneResult> {
   const startedAt = performance.now();
   console.log(`\n[test] START ${lane.name}: ${lane.command.join(' ')}`);
   try {
-    // Every lane can sign a Supabase auth-hook request: the local stack starts
-    // the API with this same fixed secret (see local-stack.ts).
+    // A LOCAL lane can sign a Supabase auth-hook request, because the local
+    // stack starts the API with this same fixed secret (see local-stack.ts).
+    //
+    // A `target-*` lane must NOT: it runs against DEPLOYED staging, which has
+    // its own AUTH_EMAIL_HOOK_SECRET. Injecting the local literal there made
+    // AUTH-2 sign staging with the wrong key and read the resulting
+    // `401 Invalid signature` as a product regression — it has never passed on
+    // a deployed target that has the secret set. On the deployed lane the
+    // secret comes from the environment (the release gate can supply
+    // `KE2E_AUTH_EMAIL_HOOK_SECRET` from the staging secret blob); when it is
+    // absent, AUTH-2's signed steps skip themselves and its unsigned
+    // `401 | 503` assertion still runs.
+    //
     // Widened explicitly: lanes append their own E2E_*/KE2E_* keys below, and
     // the inferred literal type would reject any key not present here (TS2353).
+    const deployedLane = lane.name.startsWith('target-');
     let env: Record<string, string | undefined> = {
       ...process.env,
-      KE2E_AUTH_EMAIL_HOOK_SECRET: LOCAL_AUTH_EMAIL_HOOK_SECRET,
+      ...(deployedLane
+        ? {}
+        : { KE2E_AUTH_EMAIL_HOOK_SECRET: LOCAL_AUTH_EMAIL_HOOK_SECRET }),
       ...(lane.env ?? {}),
     };
     if (lane.name === 'browser') {

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -161,7 +161,9 @@ async function runOneFlow(
       skip: (reason) => {
         throw new SkipSignal(reason);
       },
-      fixtures: world.makeFixtures(stack),
+      // Attempt-scoped: a retry must not re-derive the SAME names its failed
+      // predecessor already committed (see world.ts attemptSuffix).
+      fixtures: world.makeFixtures(stack, attempt),
       step: async (name, fn) => {
         const collector = new StepCollector(routesHit);
         const start = performance.now();

--- a/tests/src/core/types.ts
+++ b/tests/src/core/types.ts
@@ -111,7 +111,16 @@ export interface Fixtures {
    * accept/decline handlers reject callers whose email doesn't match the invite.
    */
   userWithEmail(email: string, opts?: { label?: string }): Promise<Principal>;
-  /** A unique run-scoped name with the e2e-<runId>- prefix. */
+  /**
+   * A unique run-scoped name with the `e2e-<runId>-` prefix.
+   *
+   * Stable within one flow ATTEMPT (two calls with the same slug return the
+   * same string, so a create and its later read agree) and distinct across
+   * attempts (attempt 2 appends `-r2`). Attempt-scoping is required, not
+   * cosmetic: a retried flow re-creates its fixtures but a name derived only
+   * from the run id would still collide with whatever the previous attempt
+   * committed before it failed.
+   */
   name(slug: string): string;
 }
 

--- a/tests/src/fixtures/cli.ts
+++ b/tests/src/fixtures/cli.ts
@@ -27,11 +27,22 @@
  */
 import { mkdtempSync, rmSync, mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { resolve, join } from 'node:path';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { loadEnv } from '../core/env';
 
+/**
+ * This file's directory, resolved portably.
+ *
+ * `import.meta.dir` is Bun-only and is `undefined` under vitest, which threw at
+ * MODULE LOAD ("paths[0] must be of type string") and made this fixture
+ * impossible to unit-test at all. The classifiers below (`throwIfCliInfraFailure`
+ * and friends) are pure and must be testable, so derive the path from
+ * `import.meta.url`, which both runtimes provide.
+ */
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 /** Repo root resolved from this file (tests/src/fixtures → ../../..). */
-const REPO_ROOT = resolve(import.meta.dir, '../../..');
+const REPO_ROOT = resolve(MODULE_DIR, '../../..');
 /** CLI source entry — invoked via `bun run` so a stale binary can't mislead. */
 const CLI_ENTRY = resolve(REPO_ROOT, 'apps/cli/src/index.ts');
 
@@ -40,8 +51,66 @@ const CLI_ENTRY = resolve(REPO_ROOT, 'apps/cli/src/index.ts');
  * ONE constant, because every path here starts the same binary against the same
  * target: a budget that fits a local API but not deployed staging turns a slow
  * network into a fake product failure (exit 143, not the CLI's own exit code).
+ *
+ * 60 s was that fake failure. Deployed staging runs its API in us-west-2 against
+ * a eu-west-2 database, so every query carries ~140 ms of round trip, and run
+ * 32306385663 recorded single origin requests stalling ~25 s under six parallel
+ * shards. A CLI command makes several sequential calls, so `kortix secrets ls`
+ * hit this killer and reported exit 143 (SIGTERM) — CLI-SEC's whole failure was
+ * this constant, not the product. 120 s covers the measured worst case with
+ * headroom; `KE2E_CLI_PROCESS_BUDGET_MS` overrides it per profile.
  */
-const CLI_PROCESS_BUDGET_MS = 60_000;
+const CLI_PROCESS_BUDGET_MS = Number(process.env.KE2E_CLI_PROCESS_BUDGET_MS ?? 120_000);
+
+/** Exit codes that mean OUR killer, not the CLI, ended the process. */
+const SIGTERM_EXIT = 143;
+const SIGKILL_EXIT = 137;
+
+/**
+ * How the CLI renders the edge's synthetic maintenance 503.
+ *
+ * The Cloudflare worker launders any origin 5xx into
+ * `{"error":"MAINTENANCE_MODE",…}`, which the CLI prints as
+ * `✗  HTTP 503: Kortix is temporarily unavailable.` That is an infrastructure
+ * blip, not a CLI contract failure — CLI-SESS and CR-9 both died on it in run
+ * 32306385663, on their FIRST attempt, because the plain Error their assertion
+ * helpers threw classified as `fatal` and was never retried.
+ */
+const CLI_EDGE_MAINTENANCE_RE =
+  /HTTP 50[234]\b|MAINTENANCE_MODE|temporarily unavailable\. Service will resume/i;
+
+export function isCliEdgeMaintenanceFailure(result: CliResult): boolean {
+  return result.exitCode !== 0 && CLI_EDGE_MAINTENANCE_RE.test(result.all);
+}
+
+export function isCliProcessKilled(result: CliResult): boolean {
+  return result.exitCode === SIGTERM_EXIT || result.exitCode === SIGKILL_EXIT;
+}
+
+/**
+ * Raise a marked-retryable error when a CLI invocation failed on infrastructure.
+ *
+ * Deliberately NOT an in-place re-run of the command: `kortix sessions new` and
+ * `kortix cr open` CREATE, and replaying a create through a laundered 503 is the
+ * exact bug that cost run 32306385663 seven flows (see REPLAY_SAFE_METHODS in
+ * core/client.ts). Marking the error retryable hands it to the FLOW-level infra
+ * budget, which re-runs the flow against fresh fixtures instead.
+ *
+ * Every CLI assertion helper must call this BEFORE asserting the exit code.
+ */
+export function throwIfCliInfraFailure(result: CliResult, action: string): void {
+  const killed = isCliProcessKilled(result);
+  if (!killed && !isCliEdgeMaintenanceFailure(result)) return;
+  const why = killed
+    ? `the ke2e process budget (${CLI_PROCESS_BUDGET_MS}ms) killed it — exit ${result.exitCode}`
+    : 'the edge returned a synthetic maintenance 5xx';
+  const error = new Error(
+    `${action} failed on infrastructure, not on contract: ${why}. ` +
+      `Output: ${result.all.slice(0, 1_000)}`,
+  );
+  (error as any).ke2eRetryable = true;
+  throw error;
+}
 
 /** ke2e target origin without a trailing `/v1` (the CLI re-adds it). */
 function targetApiBase(): string {

--- a/tests/src/fixtures/world.ts
+++ b/tests/src/fixtures/world.ts
@@ -9,7 +9,7 @@
  * route contracts are pinned by the audit. OWNER/ANON/PAT_ACCT/APIKEY + the run
  * account are wired here.
  */
-import { Client, type Identity } from '../core/client';
+import { Client, throwIfEdgeLaundered, type Identity } from '../core/client';
 import type { Env } from '../core/env';
 import { log } from '../core/log';
 import type {
@@ -41,9 +41,26 @@ const PUBLIC_DOMAINS = new Set(['system', 'access']);
 export interface World {
   principals: Principals;
   newStack(): ResourceStack;
-  makeFixtures(stack: ResourceStack): Fixtures;
+  /**
+   * Fixtures for ONE flow attempt. `attempt` (1-based) namespaces every
+   * user-chosen name the attempt derives, so a retry cannot collide with the
+   * rows its own previous attempt committed before failing.
+   */
+  makeFixtures(stack: ResourceStack, attempt?: number): Fixtures;
   fixtureStats(): FixtureStats;
   teardownAll(): Promise<void>;
+}
+
+/**
+ * The per-attempt suffix for every derived name.
+ *
+ * Attempt 1 gets NO suffix, so the 100+ existing `fixtures.name()` call sites,
+ * the `e2e-%` gc patterns, and every recorded fixture name keep the exact bytes
+ * they have today. Only a RETRY is renamed, which is the only case that can
+ * collide with itself.
+ */
+export function attemptSuffix(attempt: number): string {
+  return attempt > 1 ? `-r${attempt}` : '';
 }
 
 const ANON_PRINCIPAL: Principal = { label: 'ANON', auth: { mode: 'none' } };
@@ -216,8 +233,10 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
     return { id, name } as CreatedProject;
   }
 
-  const fixturesFor = (stack: ResourceStack): Fixtures => ({
-    name: (slug) => `e2e-${runId}-${slug}`,
+  const fixturesFor = (stack: ResourceStack, attempt = 1): Fixtures => {
+    const suffix = attemptSuffix(attempt);
+    return {
+    name: (slug) => `e2e-${runId}-${slug}${suffix}`,
     sharedProject() {
       if (!sharedProjectPromise) {
         sharedProjectPromise = createProject(sharedStack, {
@@ -243,6 +262,10 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
       const res = await adminClient.post('/v1/accounts', {
         name: opts?.name ?? `e2e-${runId}-team-${rand()}`,
       });
+      // IAM-22 (run 32306385663) died here on ONE attempt: the edge laundered
+      // an origin blip into a MAINTENANCE_MODE 503, this read found no
+      // account_id, and the plain Error below classified as `fatal`.
+      throwIfEdgeLaundered(res, 'team account create');
       const accountId = res.json<any>()?.account_id;
       if (!accountId) throw new Error(`team account create returned no id: ${res.text()}`);
       stack.push('account', accountId);
@@ -269,19 +292,39 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
         async addMember(role) {
           const u = await synthUser(env, `MEM-${role}`, runId);
           extraUserIds.push(u.user.id);
-          await adminClient.post(
+          // This response used to be DISCARDED. A failed add then surfaced two
+          // steps later as someone else's bug: MEM-4 read `DELETE member → 404`
+          // and IAM-36 read `expected exactly one account-scope system
+          // assignment, got 0` — both of which mean only "the member was never
+          // added". Because addMember runs OUTSIDE ctx.step(), the request was
+          // not even in the step log. Fail here, where the cause is.
+          const added = await adminClient.post(
             '/v1/accounts/:accountId/members',
             { email: u.user.email, role },
             { params: { accountId } },
           );
+          throwIfEdgeLaundered(added, `team addMember(${role})`);
+          if (added.statusCode !== 201) {
+            throw new Error(
+              `team addMember(${role}) failed: ${added.statusCode} ${added.text()}`,
+            );
+          }
           return u.principal;
         },
         async grantProjectRole(projectId, userId, role) {
-          await adminClient.put(
+          const granted = await adminClient.put(
             '/v1/projects/:projectId/access/:userId',
             { role },
             { params: { projectId, userId } },
           );
+          // Same class as addMember above: a swallowed grant becomes a 403 in
+          // whichever later step relies on the role.
+          throwIfEdgeLaundered(granted, `team grantProjectRole(${role})`);
+          if (granted.statusCode !== 200 && granted.statusCode !== 201) {
+            throw new Error(
+              `team grantProjectRole(${role}) failed: ${granted.statusCode} ${granted.text()}`,
+            );
+          }
         },
         async project(o) {
           return createProject(stack, {
@@ -300,7 +343,8 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
       // team, which is exactly what account-deletion flows require.
       const bootstrap = await new Client(env.apiUrl)
         .as(u.principal)
-        .post('/v1/accounts/tokens', { name: `e2e-${runId}-user-bootstrap` });
+        .post('/v1/accounts/tokens', { name: `e2e-${runId}-user-bootstrap${suffix}` });
+      throwIfEdgeLaundered(bootstrap, 'standalone user bootstrap');
       if (bootstrap.statusCode !== 201) {
         throw new Error(`standalone user bootstrap failed: ${bootstrap.text()}`);
       }
@@ -314,7 +358,8 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
       // account-scoped reads (e.g. /v1/accounts/me) work for this identity.
       const bootstrap = await new Client(env.apiUrl)
         .as(u.principal)
-        .post('/v1/accounts/tokens', { name: `e2e-${runId}-user-email-bootstrap` });
+        .post('/v1/accounts/tokens', { name: `e2e-${runId}-user-email-bootstrap${suffix}` });
+      throwIfEdgeLaundered(bootstrap, 'standalone user-with-email bootstrap');
       if (bootstrap.statusCode !== 201) {
         throw new Error(`standalone user-with-email bootstrap failed: ${bootstrap.text()}`);
       }
@@ -340,6 +385,7 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
           params: { projectId: project.id },
         },
       );
+      throwIfEdgeLaundered(res, 'session create');
       const body = res.json<any>();
       const id = body?.session_id ?? body?.sessionId ?? body?.id;
       if (!id) throw new Error(`session create returned no id: ${res.text()}`);
@@ -350,6 +396,7 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
       const res = await adminClient.post('/v1/accounts/tokens', {
         name: opts?.name ?? `e2e-${runId}-pat-${rand()}`,
       });
+      throwIfEdgeLaundered(res, 'token mint');
       const body = res.json<any>();
       const secret = body?.secret_key ?? body?.token;
       const tokenId = body?.id ?? body?.token_id;
@@ -357,7 +404,8 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
       if (tokenId) stack.push('token', tokenId);
       return secret as string;
     },
-  });
+    };
+  };
 
   return {
     principals: principalsProxy(provisioned.principals),

--- a/tests/src/flows/audit.flow.ts
+++ b/tests/src/flows/audit.flow.ts
@@ -4,6 +4,8 @@
  * Uses ctx.fixtures.team() — OWNER is authorized, NONMEMBER → 403. Maps to AUD-*.
  */
 import { flow } from '../core/flow';
+import { isKe2eRetryableError } from '../core/client';
+import { waitFor } from '../core/poll';
 
 interface AuditPageBody {
   events: Array<{ event_id: string }>;
@@ -517,16 +519,35 @@ flow(
       });
       action.status(200);
 
-      const r = await ctx.client.as(ctx.P.OWNER).get('/v1/accounts/:accountId/audit', {
-        ...base,
-        query: {
-          project_id: project.id,
-          actor_type: 'human',
-          source: 'cli',
-          outcome: 'success',
-          correlation_id: correlationId,
+      // Audit writes are an in-process async queue since #6618
+      // (apps/api/src/shared/audit-queue.ts, 250 ms batch timer). The list
+      // route flushes — but flushes ITS OWN process's queue, and deployed
+      // staging runs 3 API tasks, so the read usually lands on a task that did
+      // not emit the event. Run 32306385663 read 0 events for that reason. Poll
+      // until the emitter's own timer has flushed; the strict envelope
+      // assertions below are unchanged. Never make audit writes synchronous.
+      const r = await waitFor(
+        async () =>
+          ctx.client.as(ctx.P.OWNER).get('/v1/accounts/:accountId/audit', {
+            ...base,
+            query: {
+              project_id: project.id,
+              actor_type: 'human',
+              source: 'cli',
+              outcome: 'success',
+              correlation_id: correlationId,
+            },
+          }),
+        {
+          until: (res) =>
+            res.statusCode === 200 &&
+            (res.json<{ events?: unknown[] }>().events?.length ?? 0) > 0,
+          timeoutMs: 15_000,
+          intervalMs: 500,
+          description: `the correlated audit event for ${correlationId} to be flushed`,
+          retryOnError: isKe2eRetryableError,
         },
-      });
+      );
       r.status(200).body().exists('$.events');
       const events = r.json<{ events: Array<Record<string, unknown>> }>().events;
       if (events.length !== 1) {

--- a/tests/src/flows/cli-resources.flow.ts
+++ b/tests/src/flows/cli-resources.flow.ts
@@ -6,9 +6,13 @@
  */
 import { flow } from '../core/flow';
 import { waitFor } from '../core/poll';
-import { CliSandbox, type CliResult } from '../fixtures/cli';
+import { CliSandbox, throwIfCliInfraFailure, type CliResult } from '../fixtures/cli';
 
 function requireExit(result: CliResult, expected: number, action: string): void {
+  // An edge-laundered 5xx or a killed process is infrastructure, not contract.
+  // It must reach the flow-level infra budget as a RETRYABLE error — CLI-SEC
+  // (exit 143) and CLI-SESS (HTTP 503) both failed on their first attempt here.
+  if (expected === 0) throwIfCliInfraFailure(result, action);
   if (result.exitCode !== expected) {
     throw new Error(`${action} exited ${result.exitCode}, expected ${expected}: ${result.all}`);
   }
@@ -104,6 +108,13 @@ flow(
   'CLI-SEC',
   {
     domain: 'cli',
+    // CLI-SEC starts EIGHT sequential CLI subprocesses (login, set, ls, env
+    // pull, env push, ls, unset, ls). It was the only CLI flow left on the
+    // deployed 180_000ms floor while CLI-SESS declares 300_000 and CLI-SHIP
+    // 420_000. Eight deployed round trips do not fit in 180s, which is how run
+    // 32306385663 got `kortix secrets ls … exited 143` — the harness killer,
+    // not the CLI. Match CLI-SESS.
+    timeoutMs: 300_000,
     routes: [
       'GET /v1/accounts/me',
       'GET /v1/projects/:projectId/secrets',

--- a/tests/src/flows/cli-ship.flow.ts
+++ b/tests/src/flows/cli-ship.flow.ts
@@ -39,7 +39,7 @@ import { flow } from '../core/flow';
 import { isKe2eRetryableError } from '../core/client';
 import { assert } from '../core/expect';
 import { waitFor } from '../core/poll';
-import { CliSandbox } from '../fixtures/cli';
+import { CliSandbox, throwIfCliInfraFailure, type CliResult } from '../fixtures/cli';
 
 function check(description: string, pass: boolean, expected: unknown, actual: unknown): void {
   assert({ kind: 'cli', description, expected, actual, pass });
@@ -47,9 +47,12 @@ function check(description: string, pass: boolean, expected: unknown, actual: un
 
 function checkExit(
   description: string,
-  result: { exitCode: number; all: string },
+  result: CliResult,
   expected: number,
 ): void {
+  // CR-9 failed here in run 32306385663 with `HTTP 503: Kortix is temporarily
+  // unavailable` — an edge blip recorded as a CLI contract failure, unretried.
+  if (expected === 0) throwIfCliInfraFailure(result, description);
   check(description, result.exitCode === expected, expected, {
     exitCode: result.exitCode,
     output: result.all.slice(0, 3_000),

--- a/tests/src/flows/run-session-backlog.flow.ts
+++ b/tests/src/flows/run-session-backlog.flow.ts
@@ -113,27 +113,43 @@ flow(
     // Waiting for the mirror straight after an initial_prompt boot is therefore
     // unsatisfiable by construction. Drive ONE real turn through the proxy, the
     // way every client does, and then assert the mirror the flow is about.
-    let ocSessionId = '';
-    await ctx.step('a real prompt through the preview proxy produces assistant output', async () => {
-      ocSessionId = await canonicalOcConversation(ctx, sandboxId);
+    const MIRROR_PROMPT =
+      'Summarize why deterministic end-to-end tests reduce release risk in one sentence.';
+    /** Prompt the pinned root through the proxy — this is what arms the snapshot. */
+    const promptPinnedRoot = async (ocId: string) => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
-        .post(ocPath(sandboxId, `/session/${ocSessionId}/prompt_async`), {
-          parts: [
-            {
-              type: 'text',
-              text: 'Summarize why deterministic end-to-end tests reduce release risk in one sentence.',
-            },
-          ],
+        .post(ocPath(sandboxId, `/session/${ocId}/prompt_async`), {
+          parts: [{ type: 'text', text: MIRROR_PROMPT }],
         });
       r.status([200, 202, 204]);
+    };
+
+    let ocSessionId = '';
+    await ctx.step('a real prompt through the preview proxy produces assistant output', async () => {
+      ocSessionId = await pinnedOcRoot(ctx, project.id, session.id, sandboxId);
+      await promptPinnedRoot(ocSessionId);
       await waitForAssistantOutput(ctx, sandboxId, ocSessionId);
     });
 
     let mirrored: any = null;
     await ctx.step('the session read exposes a non-placeholder root OpenCode title and tree', async () => {
+      // `metadata.opencode_sessions` has exactly ONE writer:
+      // `scheduleOpencodeSnapshotSync`, armed by the proxy's pre-prompt hook.
+      // It fires at prompt+20s and prompt+60s and then STOPS
+      // (apps/api/src/projects/opencode-session-snapshot.ts). The session read
+      // itself is a pure DB read — a source-level guard test enforces that. So
+      // a poll that merely waits is reading a value whose writer has already
+      // retired: run 32306385663 spent 120 of its 180 s that way. Re-arm the
+      // writer by re-prompting the pinned root, instead of waiting on a dead one.
+      const REARM_AFTER_MS = 75_000;
+      let lastPromptAt = Date.now();
       mirrored = await waitFor(
         async () => {
+          if (Date.now() - lastPromptAt > REARM_AFTER_MS) {
+            lastPromptAt = Date.now();
+            await promptPinnedRoot(ocSessionId);
+          }
           const response = await ctx.client
             .as(ctx.P.OWNER)
             .get('/v1/projects/:projectId/sessions/:sessionId', {
@@ -272,6 +288,34 @@ async function canonicalOcConversation(ctx: FlowContext, sandboxId: string): Pro
   const id = roots[0]?.id;
   if (!id) throw new Error(`no canonical OpenCode root on sandbox ${sandboxId}`);
   return String(id);
+}
+
+/**
+ * The root the SERVER has pinned for this session, preferred over re-deriving it.
+ *
+ * `resolveRootSessionId` (apps/api/src/projects/opencode-session-resolver.ts)
+ * returns an EXISTING pin unconditionally — "most recently active parentless
+ * root" is the server's rule only for the FIRST resolution. Once a pin exists
+ * the two rules can disagree (a daemon restart or a warm-fork seed rotation
+ * leaves a second root), and then the flow prompts root B while the snapshot
+ * mirrors pinned root A. Root A is never prompted, so its title never changes,
+ * and the mirror wait can never be satisfied at any budget — SESS-10's 410 s
+ * failure in run 32306385663. Ask the server which root it pinned.
+ */
+async function pinnedOcRoot(
+  ctx: FlowContext,
+  projectId: string,
+  sessionId: string,
+  sandboxId: string,
+): Promise<string> {
+  const r = await ctx.client
+    .as(ctx.P.OWNER)
+    .get('/v1/projects/:projectId/sessions/:sessionId', { params: { projectId, sessionId } });
+  const pinned = r.statusCode === 200 ? r.json<any>()?.opencode_session_id : null;
+  if (typeof pinned === 'string' && pinned.length > 0) return pinned;
+  // Nothing pinned yet — the server's first resolution will adopt whatever
+  // root is most recently active, which is exactly what this derives.
+  return canonicalOcConversation(ctx, sandboxId);
 }
 
 function hasAssistantOutput(messages: unknown): boolean {

--- a/tests/src/flows/secrets.flow.ts
+++ b/tests/src/flows/secrets.flow.ts
@@ -119,6 +119,15 @@ flow(
   "SEC-8",
   {
     domain: "secrets",
+    // SEC-8 provisions a REAL managed GitHub repository, and one provision
+    // request is allowed 180_000ms on its own (fixtures/provision.ts
+    // PROVISION_REQUEST_TIMEOUT_MS). On the deployed lane this flow inherited
+    // the same 180_000ms floor (core/local-runner.ts DEPLOYED_FLOW_TIMEOUT_MS),
+    // so a provision that took its full budget and SUCCEEDED still failed the
+    // flow before its first step ran — which is how run 32306385663 recorded
+    // `flow SEC-8 exceeded 180000ms` twice. The budget must exceed the bounds
+    // the flow itself contains.
+    timeoutMs: 300_000,
     routes: [
       "POST /v1/projects/:projectId/secrets",
       "GET /v1/projects/:projectId/secrets",

--- a/tests/src/flows/session-thread-reliability.flow.ts
+++ b/tests/src/flows/session-thread-reliability.flow.ts
@@ -316,9 +316,22 @@ flow(
             `the first turn's assistant message has no time.completed set — it is a dangling, never-finalized row (the phantom "Interrupted" class of bug): ${JSON.stringify(turn1Last)}`,
           );
         }
-        if (!info?.error) {
+        // OpenCode 1.17.11 (pinned in packages/shared/src/runtime-versions.json)
+        // does NOT guarantee `info.error` on an abort. `SessionProcessor.cleanup`
+        // stamps `time.completed` with no error at the end of EVERY processor
+        // iteration, and the prompt-level abort finalizer early-returns when
+        // `time.completed` is already set — so an abort that lands between
+        // iterations finalizes the row with no error at all. Run 32306385663
+        // caught exactly that: `time.completed` set, `parts: []`, no error.
+        //
+        // `time.completed` above is the load-bearing half — it is what
+        // `isAbortableHusk` reads, and a missing one is the real "dangling row"
+        // bug. What must still never happen is the turn ending on a genuine
+        // provider failure dressed up as an abort, so assert that instead.
+        const abortErrorName = (info?.error as { name?: string } | undefined)?.name;
+        if (abortErrorName && !['AbortError', 'MessageAbortedError'].includes(abortErrorName)) {
           throw new Error(
-            `the first turn's assistant message carries no abort error even though it was aborted: ${JSON.stringify(turn1Last)}`,
+            `the first turn ended on a NON-abort error even though it was aborted: ${JSON.stringify(turn1Last)}`,
           );
         }
       },
@@ -338,7 +351,13 @@ flow(
   {
     domain: 'sessions',
     requires: ['funded', 'daytona'],
-    timeoutMs: 420_000,
+    // 420_000 was smaller than the sum of the bounds this flow itself contains:
+    // boot readiness 300_000 + OpenCode readiness 120_000 + stop-settle 60_000
+    // + wake readiness (below) + assistant marker 240_000. The two readiness
+    // waits ALONE were 600_000 — 1.43x the whole budget — so run 32306385663
+    // hit `flow SESS-23 exceeded 420000ms` on both attempts. Matches the
+    // 900_000 that SESS-10 already declares for the same boot+turn shape.
+    timeoutMs: 900_000,
     routes: [
       'POST /v1/projects/:projectId/sessions',
       'POST /v1/projects/:projectId/sessions/:sessionId/start',
@@ -411,7 +430,10 @@ flow(
     );
 
     await ctx.step('wake the box back up via /start', async () => {
-      await waitForSessionReady(ctx, projectId, sessionId);
+      // A WAKE is not a cold boot — the VM is resumed, not created (~19-25s
+      // measured). The 300_000 default is cold-boot money, and spending it here
+      // lets one slow wake swallow the whole flow budget.
+      await waitForSessionReady(ctx, projectId, sessionId, 180_000);
     });
 
     await ctx.step(
@@ -856,18 +878,38 @@ flow(
       // What the Stop button writes. A client-side pause would leave the
       // admission gate free to deliver the very message the user pressed Stop
       // to get ahead of, one scheduler tick after the abort.
-      const held = await owner.post(
-        '/v1/projects/:projectId/sessions/:sessionId/prompts/hold',
-        { held: true },
-        { params },
+      // A row the drain has ALREADY CLAIMED (status 'running') gets only a
+      // PAYLOAD flag from the instant hold — `stopPausedOnDelivery` — because
+      // `markCommandForwarded` replaces `result` wholesale, so `promptState`
+      // answers `delivering/null` for it. The `held` marker lands only once the
+      // claimed delivery settles, in the background (CLAIMED_SETTLE_MS = 3_000,
+      // apps/api/src/projects/session-lifecycle/inbox-hold-settle.ts). Run
+      // 32306385663 read the response one tick too early and saw exactly that.
+      // The route is idempotent, so re-POST until the row is held or gone — a
+      // hold that never lands still fails the flow.
+      const held = await waitFor(
+        async () =>
+          owner.post(
+            '/v1/projects/:projectId/sessions/:sessionId/prompts/hold',
+            { held: true },
+            { params },
+          ),
+        {
+          until: (r) => {
+            if (r.statusCode !== 200) return false;
+            const mine = (r.json<any>().prompts ?? []).find(
+              (p: any) => p.prompt_id === promptId,
+            );
+            // Absent = already delivered; it IS the transcript and cannot be held.
+            return !mine || (mine.state === 'waiting' && mine.reason === 'held');
+          },
+          timeoutMs: 30_000,
+          intervalMs: 2_000,
+          description: `prompt ${promptId} to read waiting/held once the hold settles`,
+          retryOnError: isKe2eRetryableError,
+        },
       );
       held.status(200);
-      for (const prompt of held.json<any>().prompts ?? []) {
-        if (prompt.prompt_id !== promptId) continue;
-        if (prompt.state !== 'waiting' || prompt.reason !== 'held') {
-          throw new Error(`a held prompt must read waiting/held, got ${prompt.state}/${prompt.reason}`);
-        }
-      }
 
       const bad = await owner.post(
         '/v1/projects/:projectId/sessions/:sessionId/prompts/hold',

--- a/tests/src/flows/sessions.flow.ts
+++ b/tests/src/flows/sessions.flow.ts
@@ -971,7 +971,13 @@ flow(
     ],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.sharedSeededProject();
+    // A DEDICATED project, not the shard-wide shared one. The warm pool is
+    // scoped by (accountId, projectId, createdBy) — warm-sessions.ts:66-89 — so
+    // every `reused: false` assertion below is only deterministic when nothing
+    // else can leave a warm row in this project. On a shared project a warm row
+    // whose create response was lost to an edge-laundered 503 is never learned,
+    // never tracked, never torn down, and the next `reused: false` reads `true`.
+    const p = await ctx.fixtures.project({ seed: true });
     const owner = ctx.client.as(ctx.P.OWNER);
     let warmSessionId = '';
     let replacementId = '';

--- a/tests/unit/create-replay-safety.test.ts
+++ b/tests/unit/create-replay-safety.test.ts
@@ -1,0 +1,301 @@
+/**
+ * A create is never replayed after an edge-laundered 5xx.
+ *
+ * Release-gate run 32306385663 lost SEVEN flows to one bug: the Cloudflare
+ * worker launders an origin TIMEOUT into a synthetic MAINTENANCE_MODE 503, but
+ * the origin has already COMMITTED the write. The ke2e client re-sent the POST,
+ * and the second send collided with the row the first send had created —
+ * `409 A trigger with slug "nightly" already exists` (TRG-2, TOK-5, TRG-14,
+ * CLI-TRG), `409 a role with this key already exists` (TRG-10, IAM-26),
+ * `409 Already a member` (MEM-7). Every one of those flows had provisioned a
+ * brand-new project or team milliseconds earlier, so nothing but the client's
+ * own retry could have owned that name.
+ *
+ * These tests pin the three parts of the fix:
+ *   1. POST is sent exactly once; GET/PUT/DELETE keep the in-request retry.
+ *   2. A body-only read of a laundered response raises a RETRYABLE error, so
+ *      the flow-level budget re-runs it (IAM-22 died as `fatal` on 1 attempt).
+ *   3. A flow retry derives DIFFERENT names than the attempt that failed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Client,
+  Res,
+  isKe2eRetryableError,
+  isReplaySafeMethod,
+  throwIfEdgeLaundered,
+  transientBreaker,
+} from '../src/core/client';
+import { attemptSuffix } from '../src/fixtures/world';
+import {
+  isCliEdgeMaintenanceFailure,
+  isCliProcessKilled,
+  throwIfCliInfraFailure,
+  type CliResult,
+} from '../src/fixtures/cli';
+import type { Captured } from '../src/core/result';
+
+/** The exact response shape captured from staging in run 32306385663. */
+function launderedMaintenance503(): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'MAINTENANCE_MODE',
+      message: 'Kortix is temporarily unavailable. Service will resume automatically.',
+    }),
+    {
+      status: 503,
+      headers: {
+        'content-type': 'application/json',
+        'retry-after': '30',
+        'x-maintenance-mode': 'blocking',
+        // NO x-request-id — that absence is what marks it edge-laundered.
+      },
+    },
+  );
+}
+
+function capturedLaundered(): Res {
+  const captured: Captured = {
+    routeTemplate: 'POST /v1/accounts',
+    req: { method: 'POST', url: 'https://example.test/v1/accounts', headers: {} },
+    res: {
+      status: 503,
+      headers: {
+        'content-type': 'application/json',
+        'retry-after': '30',
+        'x-maintenance-mode': 'blocking',
+      },
+      bodyText: '{"error":"MAINTENANCE_MODE"}',
+    },
+    ms: 1,
+  };
+  return new Res(captured);
+}
+
+beforeEach(() => {
+  transientBreaker.reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  transientBreaker.reset();
+});
+
+describe('replay safety: a create is never re-sent (run 32306385663 Class A)', () => {
+  it('classifies only the methods that cannot duplicate a create as replay-safe', () => {
+    expect(isReplaySafeMethod('GET')).toBe(true);
+    expect(isReplaySafeMethod('head')).toBe(true);
+    expect(isReplaySafeMethod('PUT')).toBe(true);
+    expect(isReplaySafeMethod('DELETE')).toBe(true);
+    // PATCH addresses an existing resource by id — it cannot mint a second row.
+    expect(isReplaySafeMethod('PATCH')).toBe(true);
+    // POST is the ONLY create verb, and therefore the only exclusion.
+    expect(isReplaySafeMethod('POST')).toBe(false);
+    expect(isReplaySafeMethod('post')).toBe(false);
+  });
+
+  it('sends a POST exactly ONCE through a laundered 503 — no second create', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockImplementation(async () => launderedMaintenance503());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = new Client('https://example.test/v1')
+      .withTransientGatewayRetries(3)
+      .post('/v1/projects/:projectId/triggers', { name: 'Nightly' });
+    await vi.runAllTimersAsync();
+    const response = await promise;
+
+    // THE regression guard. Before the fix this was 4 — and sends 2..4 are what
+    // produced `409 already exists` against send 1's committed row.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('still retries a GET through the same laundered 503', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockImplementation(async () => launderedMaintenance503());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = new Client('https://example.test/v1')
+      .withTransientGatewayRetries(3)
+      .get('/v1/projects/:projectId/triggers');
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('still retries an idempotent PUT and DELETE', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockImplementation(async () => launderedMaintenance503());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new Client('https://example.test/v1').withTransientGatewayRetries(1);
+    const put = client.put('/v1/projects/:projectId/access/:userId', { role: 'manager' });
+    await vi.runAllTimersAsync();
+    await put;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    fetchMock.mockClear();
+    const del = client.del('/v1/projects/:projectId');
+    await vi.runAllTimersAsync();
+    await del;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-send a POST after a NETWORK error either', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const settled = new Client('https://example.test/v1')
+      .withTransientGatewayRetries(3)
+      .post('/v1/accounts', { name: 'team' })
+      .catch((err) => err as Error);
+    await vi.runAllTimersAsync();
+    const error = await settled;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // One send, but still retryable — the FLOW re-runs it with fresh fixtures.
+    expect(isKe2eRetryableError(error)).toBe(true);
+  });
+
+  it('hands the un-replayed POST back as a RETRYABLE error, not a hard failure', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async () => launderedMaintenance503()));
+
+    const promise = new Client('https://example.test/v1').post('/v1/accounts', { name: 'team' });
+    await vi.runAllTimersAsync();
+    const response = await promise;
+
+    let error: unknown;
+    try {
+      response.status(201);
+    } catch (caught) {
+      error = caught;
+    }
+    // This is what routes the failure to the flow-level infra budget instead of
+    // failing the flow on its first attempt.
+    expect(isKe2eRetryableError(error)).toBe(true);
+    expect((error as Error).message).toContain('edge-laundered');
+  });
+});
+
+describe('body-only reads of a laundered response (run 32306385663 Class B / IAM-22)', () => {
+  it('raises a retryable error before the caller can misread the body', () => {
+    let error: unknown;
+    try {
+      throwIfEdgeLaundered(capturedLaundered(), 'team account create');
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(isKe2eRetryableError(error)).toBe(true);
+    expect((error as Error).message).toContain('team account create');
+    expect((error as Error).message).toContain('edge-laundered');
+    expect((error as Error).message).toContain('x-request-id=absent');
+  });
+
+  it('is a no-op for a genuine application 5xx (it carries x-request-id)', () => {
+    const captured: Captured = {
+      routeTemplate: 'POST /v1/accounts',
+      req: { method: 'POST', url: 'https://example.test/v1/accounts', headers: {} },
+      res: {
+        status: 503,
+        headers: { 'content-type': 'application/json', 'x-request-id': 'req-1' },
+        bodyText: '{"error":"boom"}',
+      },
+      ms: 1,
+    };
+    // A real API 5xx must still fail the flow — never retried, never excused.
+    expect(() => throwIfEdgeLaundered(new Res(captured), 'team account create')).not.toThrow();
+  });
+
+  it('is a no-op for a success', () => {
+    const captured: Captured = {
+      routeTemplate: 'POST /v1/accounts',
+      req: { method: 'POST', url: 'https://example.test/v1/accounts', headers: {} },
+      res: { status: 201, headers: {}, bodyText: '{"account_id":"a"}' },
+      ms: 1,
+    };
+    expect(() => throwIfEdgeLaundered(new Res(captured), 'team account create')).not.toThrow();
+  });
+});
+
+describe('CLI infrastructure failures (run 32306385663 Class B / CLI-SESS, CR-9, CLI-SEC)', () => {
+  const result = (exitCode: number, all: string): CliResult => ({
+    exitCode,
+    stdout: '',
+    stderr: all,
+    all,
+  });
+
+  it('marks the CLI rendering of the edge maintenance 503 retryable', () => {
+    // Verbatim from CLI-SESS's recorded output.
+    const cli = result(
+      1,
+      '\nhost cloud (https://staging-api.kortix.com, e2e-…@ke2e.kortix.test (user))\n' +
+        '  ✗  HTTP 503: Kortix is temporarily unavailable. Service will resume automatically.\n',
+    );
+    expect(isCliEdgeMaintenanceFailure(cli)).toBe(true);
+
+    let error: unknown;
+    try {
+      throwIfCliInfraFailure(cli, 'kortix sessions new');
+    } catch (caught) {
+      error = caught;
+    }
+    expect(isKe2eRetryableError(error)).toBe(true);
+    expect((error as Error).message).toContain('kortix sessions new');
+    expect((error as Error).message).toContain('infrastructure, not on contract');
+  });
+
+  it('marks a killed process (exit 143) retryable and names the budget', () => {
+    // CLI-SEC: `kortix secrets ls after env push exited 143`.
+    const cli = result(143, 'host cloud (https://staging-api.kortix.com, …)\n');
+    expect(isCliProcessKilled(cli)).toBe(true);
+
+    let error: unknown;
+    try {
+      throwIfCliInfraFailure(cli, 'kortix secrets ls after env push');
+    } catch (caught) {
+      error = caught;
+    }
+    expect(isKe2eRetryableError(error)).toBe(true);
+    expect((error as Error).message).toContain('process budget');
+  });
+
+  it('leaves a genuine CLI contract failure alone', () => {
+    const cli = result(1, "error: unknown flag '--nope'");
+    expect(isCliEdgeMaintenanceFailure(cli)).toBe(false);
+    expect(isCliProcessKilled(cli)).toBe(false);
+    expect(() => throwIfCliInfraFailure(cli, 'kortix sessions new')).not.toThrow();
+  });
+
+  it('leaves a successful invocation alone even if its output mentions a 503', () => {
+    const cli = result(0, 'last incident: HTTP 503 (resolved)');
+    expect(() => throwIfCliInfraFailure(cli, 'kortix sessions ls')).not.toThrow();
+  });
+});
+
+describe('per-attempt name scoping (run 32306385663 Class A, self-collision)', () => {
+  it('leaves attempt 1 byte-identical and renames only a retry', () => {
+    expect(attemptSuffix(1)).toBe('');
+    expect(attemptSuffix(2)).toBe('-r2');
+    expect(attemptSuffix(3)).toBe('-r3');
+  });
+
+  it('keeps every derived name inside the e2e- prefix the gc sweep matches', () => {
+    const name = (slug: string, attempt: number) => `e2e-run1-${slug}${attemptSuffix(attempt)}`;
+    expect(name('mem7-existing', 1)).toBe('e2e-run1-mem7-existing');
+    expect(name('mem7-existing', 2)).toBe('e2e-run1-mem7-existing-r2');
+    expect(name('mem7-existing', 2).startsWith('e2e-')).toBe(true);
+    // Stable WITHIN an attempt: a create and its later read must agree.
+    expect(name('hook', 2)).toBe(name('hook', 2));
+    // Distinct ACROSS attempts: a retry cannot collide with its predecessor.
+    expect(name('hook', 1)).not.toBe(name('hook', 2));
+  });
+});


### PR DESCRIPTION
Release-gate run [32306385663](https://github.com/kortix-ai/suna/actions/runs/32306385663) against live staging (`6b503ef47e8a6cdaba32fe207f0b7124e9ecd324`) passed 423/446 API flows. This fixes all 22 failures.

**One defect caused 10 of them, and it was not what the failure messages said.** Seven flows reported `409 already exists`. None of them collided with gc debris or with another shard. They collided with *themselves*.

## The core defect: the ke2e client replayed non-idempotent creates

Every Class A failure has an identical trace, recovered from the shard artifacts:

```
TRG-2  POST /v1/projects/:projectId/triggers -> 503 ms=25060   (edge-laundered)
TRG-2  POST /v1/projects/:projectId/triggers -> 409 ms=3042    "slug \"nightly\" already exists"
TRG-10 POST /v1/accounts/:accountId/iam/roles -> 503 ms=26058
TRG-10 POST /v1/accounts/:accountId/iam/roles -> 409 ms=3069   "a role with this key already exists"
MEM-7  POST /v1/accounts/:accountId/members   -> 503 ms=25047
MEM-7  POST /v1/accounts/:accountId/members   -> 409 ms=20698  "Already a member"
```

The sequence is: a POST stalls ~25 s at the origin; the Cloudflare worker launders the stall into a synthetic `MAINTENANCE_MODE` 503 (`retry-after: 30`, `x-maintenance-mode: blocking`, **no** `x-request-id`); `tests/src/core/client.ts` classifies that as transient and **re-sends the POST**; the origin had already committed the first write, so the second send hits its own row.

Every one of those flows had provisioned a brand-new project or team milliseconds earlier, so no other shard and no debris could have owned that name. The retry manufactured the collision. `SESS-18` is the same bug wearing a 200: its replayed warm-session create found the row attempt 1 had written and answered `reused: true`.

**Fix** (`tests/src/core/client.ts`): a retry is only transparent when re-sending cannot create a second resource. GET/HEAD/OPTIONS/PUT/PATCH/DELETE all address an existing resource and keep the in-request retry. POST — the only create verb — is sent exactly once; its laundered 503 goes back to the caller, where `.status()` raises a *marked-retryable* error and the flow-level infra budget re-runs the flow against fresh fixtures.

Because a retry now re-derives names, `fixtures.name()` is attempt-scoped: attempt 1 is byte-identical to today, attempt 2 appends `-r2`. That is what stops a retry colliding with what its own failed predecessor committed (`INV-7`).

**I did not tighten the gc sweep.** The brief floated a `gc --run-id` pass or a lower `--older-than`. The evidence says debris was never involved, and lowering the window risks deleting a concurrent shard's live fixtures. Fixing the sweep would have fixed nothing.

## Per-failure verdicts

| Flow | Class | Root cause | Fix |
|---|---|---|---|
| TRG-2, TRG-10, TRG-14, TOK-5, MEM-7, IAM-26, CLI-TRG | A | Client replayed a POST after an edge-laundered 503; second send hit its own committed row | `client.ts` never replays POST |
| SESS-18 | A/D | Same replay, 200-shaped: warm create replayed → `reused: true`. Also ran on the shard-wide shared project, where an unlearned warm row is never torn down | `client.ts` + SESS-18 gets its own project (warm pool is scoped by `project_id`) |
| INV-7 | A/D | Not an API change. The flow's own attempt 1 created `inv7a@…`; attempt 2 re-derived the same address, so the invite legitimately read `added` | Attempt-scoped `fixtures.name()` |
| IAM-22 | B | `team()` read `account_id` off a laundered 503 body and threw a plain Error → classified `fatal` → 1 attempt, while the same blip self-healed on asserted routes | `throwIfEdgeLaundered()` before every body-only fixture read |
| CLI-SESS, CR-9 | B | CLI printed `HTTP 503: Kortix is temporarily unavailable`; the assertion helpers threw a plain Error → never retried | `throwIfCliInfraFailure()` in `requireExit`/`checkExit` marks it retryable |
| CLI-SEC | B/C | `exit 143` was **our** killer, not the CLI: 8 sequential subprocesses against a 60 s per-command budget and the 180 s deployed flow floor | Budget 60 s → 120 s (env-overridable), flow `timeoutMs: 300_000`, and a harness kill is now reported as infra |
| SEC-8 | C | No declared `timeoutMs` → 180 s deployed floor, which is **≤ its own single provision request timeout** (180 s). A provision that took its budget and *succeeded* still failed the flow | `timeoutMs: 300_000` |
| SESS-23 | C | Declared 420 s while the bounds it contains sum to ~1 023 s; the two readiness waits alone are 600 s | `timeoutMs: 900_000`; wake bounded at 180 s (a resume is not a cold boot) |
| SESS-10 | C | **Impossible wait.** `metadata.opencode_sessions` has one writer, armed by the proxy pre-prompt hook, which fires at prompt+20 s and prompt+60 s and then retires. The 180 s poll spent its last 120 s reading a value with no writer. The flow also prompted a re-derived root that can diverge from the root the server pinned — and the mirror only tracks the pin | Prompt the **pinned** root (`opencode_session_id`); re-arm the writer inside the poll. Budget unchanged — it was never reached |
| MEM-4, IAM-36 | D | Neither stale nor a regression. `team.addMember()` **discarded its response**, so a failed add resurfaced two steps later as `DELETE → 404` and `got 0 assignments`. It runs outside `ctx.step()`, so the request was not even in the log | Assert the fixture's own calls (`addMember`, `grantProjectRole`) |
| AUTH-2 | D | Harness bug. `local-runner.ts` injected the hardcoded **local** hook secret into every lane including `target-*`, so AUTH-2 signed deployed staging with the wrong key and read `401 Invalid signature` as a regression. It has never passed against a deployed target that has the secret | Scope the local literal to local lanes; the gate can supply `KE2E_AUTH_EMAIL_HOOK_SECRET` |
| RUN-9 | D | Flow over-strict. OpenCode 1.17.11 does not guarantee `info.error` on abort: cleanup stamps `time.completed` with no error every iteration, and the abort finalizer early-returns when it is already set. Observed exactly that — `time.completed` set, `parts: []` | Keep the `time.completed` assertion (the real anti-regression); reject only a **non-abort** error |
| SESS-25 | D | Flow stale. A row the drain already claimed gets a payload-only hold, so `promptState` correctly answers `delivering/null` until the claimed delivery settles (`CLAIMED_SETTLE_MS = 3_000`) | Bounded re-POST of the idempotent hold (30 s) until held-or-gone |
| AUD-FILTER | D | Flow stale. Audit writes are an async batched queue since #6618. The list route flushes **its own process's** queue, and staging runs 3 API tasks, so the read usually lands on a task that did not emit | Bounded poll (15 s). No synchronous audit writes reintroduced |

Two verdicts are worth stating plainly: **no API regression was found.** Every failure is in the test harness or the flows, except SESS-10, where the flow waits on a server value whose writer has retired — fixed flow-side by re-arming the writer rather than by changing the product.

## Verification

Local, against the real stack (no mocks at the product boundary):

```
pnpm test                              → 381/381 flows, all 5 lanes PASS, exit 0
pnpm test -- --id TRG-10,TRG-14,TOK-5,MEM-7,IAM-26,IAM-22   → 6/6 passed
bun tests/bin/ke2e.ts run --id MEM-4,IAM-36,INV-7,MEM-3,MEM-7,IAM-26,TOK-5,TRG-10 → 8/8 passed
pnpm test -- --id AUD-FILTER,SEC-8,CLI-SEC                  → 3/3 passed
tests typecheck (tsc --noEmit)         → clean
tests unit suite                       → 350/350 passed
```

The replay defect cannot be reproduced against a local API — nothing launders a 503 there — so it is pinned by unit tests that inject the exact staging response (`tests/unit/create-replay-safety.test.ts`, 15 tests). The runner's own log is the proof:

```
ke2e giving up POST /v1/accounts after 1/1 attempt(s) [edge-laundered status=503
  x-maintenance-mode=blocking x-request-id=absent] — not replayed: the origin may
  have committed this create; the flow-level budget retries it against fresh fixtures
ke2e giving up GET /v1/projects/:projectId/triggers after 4/4 attempt(s) [...]
```

POST once, GET four times, from one shared retry budget.

Against **real cloud sandboxes** on a local API with the callback tunnel up:

```
bun tests/bin/ke2e.ts run --id SESS-25                        → PASS (3.5s)
bun tests/bin/ke2e.ts run --id SESS-18,RUN-9,SESS-10,SESS-23  → SESS-18 PASS
                                                                 3 FAIL, see below
```

`SESS-18` — the warm-pool flow, and the one real-sandbox flow among these whose
fix I could isolate — **passes**.

`RUN-9`, `SESS-10` and `SESS-23` all failed at `Timed out waiting for session
runtime ready`, during sandbox boot. That is **pre-existing and environmental,
not this branch**. Two independent proofs:

1. The diff touches no boot path — `git diff origin/main` contains no change to
   `waitForSessionReady` or `bootSandbox`; every edit is downstream of readiness.
2. A control run of the same two flows from a **pristine `origin/main`** worktree,
   against the same API and the same sandbox provider, fails identically:

```
ke2e run (origin/main, f59549a3db)
✗ SESS-10 305.2s — Timed out waiting for session runtime ready for 06ca48aa…
✗ RUN-9   306.9s — Timed out waiting for session runtime ready for 57e58658…
```

The API log shows why: `open-session:failed` with zero `/v1/p/<ext>/8000/…`
daemon requests — the guest never became reachable on this machine. So the
assertion changes in those three flows are **unexercised locally** and dry-run #4
is their first real test.

## Not verifiable locally

- `CLI-SESS`, `CLI-TRG`, `CR-9` are excluded from the local profile (`daytona`/`funded`/managed-git). Their fix is the shared `requireExit`/`checkExit` guard, which `CLI-SEC` exercises end to end locally and the unit tests pin directly.
- `RUN-9`, `SESS-10`, `SESS-23` — their assertion/poll changes are unexercised: this machine cannot boot a session to OpenCode readiness, on this branch *or* on `origin/main` (control above). The budget changes (SEC-8, SESS-23, CLI-SEC) are arithmetic against bounds the flows declare, and I have shown that arithmetic rather than tuned by feel; **SESS-10's re-arm loop and RUN-9's relaxed assertion are the two changes carrying the most residual risk into dry-run #4.**
- `AUTH-2`'s deployed 200 path stays unexercised until `STAGING_AUTH_EMAIL_HOOK_SECRET` is provisioned. Until then the flow skips its signed steps and still asserts the unsigned `401 | 503`. **This secret needs provisioning to regain that coverage.**
- `SEC-8` also recorded a `500` on `POST /v1/projects/:projectId/secrets`. I traced the handler and found no path that returns 500 on that rotation; the likeliest source is the un-cancelled attempt-1 body still running against a project that teardown had already purged (`withTimeout` rejects the promise but never cancels the flow). Raising the budget removes that mechanism. **If a 500 reappears on attempt 1 in dry-run #4, check the captured response for `x-request-id`: present = genuine origin 500 worth chasing; absent = edge laundering.**

## Follow-ups (not in this PR)

- `markCommandFailed` requeues a failed claimed delivery to `queued` without converting `stopPausedOnDelivery` into `result.held`, so a held prompt can be delivered once before being marked held. Small window, real hole.
- `security-backlog.flow.ts` and `secrets.flow.ts` read audit rows back with no poll and will flake the same way AUD-FILTER did.
- `fixtures/provision.ts` still retries a provision POST on 5xx at its own layer. That is now the only remaining path that can double-create, and it is strictly better than before (5 sends max, was up to 20).
