### PR TITLE
fix(web): boot composer reads the stashed agent pick before /start answers

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/loading.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/loading.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import ProjectHomeLoading from '../../loading';
 import { InstantSessionShell } from '@/features/session/instant-session-shell';
 import { useFirstPromptPreviewStore } from '@/stores/session-composer-handoff-store';
+import { readStartStash } from '@kortix/sdk/react';
 
 /**
  * Navigation Suspense boundary for /projects/[id]/sessions/[sessionId].
@@ -32,5 +33,18 @@ export default function SessionLoading() {
     sessionId ? (s.previewBySession[sessionId] ?? null) : null,
   );
   if (!projectId || !sessionId || !preview) return <ProjectHomeLoading />;
-  return <InstantSessionShell projectId={projectId} sessionId={sessionId} stage="provisioning" />;
+  // The producer stashed the picked agent alongside the prompt (see
+  // `writeStartStash` on the home composer) — hand it to the shell so the
+  // agent picker names the session's real agent on THIS boundary's first
+  // frame, not the project default. Safe to read here: the `preview` gate
+  // above means this branch only renders on a soft navigation, where the
+  // in-memory store (and therefore sessionStorage) is already client-side.
+  return (
+    <InstantSessionShell
+      projectId={projectId}
+      sessionId={sessionId}
+      stage="provisioning"
+      boundAgentName={readStartStash(sessionId)?.agent ?? null}
+    />
+  );
 }

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -221,11 +221,18 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
   // booting, then "correcting" itself once ready. `'default'` is the server's
   // spelling of "no agent bound" (see shared.ts serializers), not a roster
   // agent — it must not shadow the project default.
+  // The start-stash covers the window BEFORE either server source answers: on
+  // the optimistic home→session redirect the producer stashed the picked agent
+  // under this route id (`writeStartStash`), and the picker must not fall back
+  // to the project default for the second it takes /start to respond. Lazy
+  // state, read once per mount: the stash is consumed later in this session's
+  // life, and re-reading it on every render would flip this back to null.
+  const [stashAgentName] = useState(() => readStartStash(sessionId)?.agent?.trim() || null);
   const listAgentName = currentProjectSession?.agent_name?.trim();
   const boundAgentName =
     (listAgentName && listAgentName !== 'default' ? listAgentName : null) ??
     session.agentName ??
-    null;
+    stashAgentName;
   const switchingToSessionId = useSessionSwitchStore((state) => state.targetSessionId);
   const completeSessionSwitch = useSessionSwitchStore((state) => state.completeSwitch);
 


### PR DESCRIPTION
Follow-up to #6625, found while re-verifying the merged fix on dev.kortix.com with the boot-UI probe: on the optimistic home→session redirect there is a ~1.3s window (the `loading.tsx` boundary + the page's first frames, before the sessions-list row or `/start` has answered) where the agent picker fell back to the project default — 6 of 59 boot samples read **Kortix** for a **harness-reflector** session.

The producer already writes the picked agent into the start-stash (`writeStartStash`) before navigating. Now:
- `loading.tsx` hands `readStartStash(sessionId)?.agent` to the instant shell (safe: the preview-store gate means that branch only renders on soft navigation).
- `page.tsx` uses the stash as the last `boundAgentName` fallback: sessions-list row → `/start agent_name` → stash. Lazy `useState` — read once per mount, so later stash consumption cannot flip it back to null.

Gates: web `tsc --noEmit` clean, eslint 0 errors, `bun test src/features/session src/stores src/app` 2783 pass. Dev re-probe after deploy will assert zero wrong-agent frames across the full boot.