### PR TITLE
refactor(gateway): make the AI-SDK-native path the default everywhere (verified across all providers)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -369,8 +369,9 @@ const envSchema = z.object({
   // (1) the in-process gateway is created with `aiSdkNative` so
   // `gateway.languageModel` serves instead of 404ing, and (2) every session gets
   // `KORTIX_LLM_AI_SDK_NATIVE=true` injected so the daemon's `buildKortixProvider`
-  // selects `@ai-sdk/gateway`. Default OFF — the whole native path stays inert.
-  GATEWAY_AI_SDK_NATIVE: optBoolFalse,
+  // selects `@ai-sdk/gateway`. Default ON — native is the default everywhere;
+  // set GATEWAY_AI_SDK_NATIVE=0 to fall back to the OpenAI-compatible path.
+  GATEWAY_AI_SDK_NATIVE: optBoolTrue,
   // CLOUD-ONLY. Whether KORTIX's own managed model lineup exists on this
   // deployment. The lineup routes through Kortix's shared Bedrock, AsterLab,
   // and OpenRouter credentials. Kortix bills each route as platform credits.

--- a/apps/api/src/llm-gateway/config-ai-sdk-native.test.ts
+++ b/apps/api/src/llm-gateway/config-ai-sdk-native.test.ts
@@ -47,8 +47,8 @@ async function readAiSdkNative(value: string | undefined): Promise<boolean> {
 }
 
 describe('config.aiSdkNative — GATEWAY_AI_SDK_NATIVE parsing', () => {
-  test('default (unset) → false', async () => {
-    expect(await readAiSdkNative(undefined)).toBe(false);
+  test('default (unset) → true (native is the default everywhere)', async () => {
+    expect(await readAiSdkNative(undefined)).toBe(true);
   });
 
   test('"true" → true', async () => {

--- a/apps/llm-gateway/src/config.ts
+++ b/apps/llm-gateway/src/config.ts
@@ -39,8 +39,11 @@ export const config = {
   },
   captureBodies: flag('GATEWAY_CAPTURE_BODIES', true),
   // AI-SDK-native ingress (`POST /language-model`, Vercel "AI Gateway"
-  // protocol). Default OFF — the route is inert (404) until enabled.
-  aiSdkNative: flag('GATEWAY_AI_SDK_NATIVE', false),
+  // protocol). Default ON — opencode talks to the gateway losslessly (reasoning
+  // signatures, refusals, tools 1:1). Verified across every provider on real
+  // self-host traffic (codex, OpenAI-on-Bedrock, Bedrock-Claude, Anthropic).
+  // GATEWAY_AI_SDK_NATIVE=0 is the kill-switch to the OpenAI-compatible path.
+  aiSdkNative: flag('GATEWAY_AI_SDK_NATIVE', true),
   // Default: 8 MiB. This accepts the measured 2,023,225-byte Aster request and
   // rejects accidental/untrusted oversized payloads before upstream dispatch.
   maxRequestBytes: optionalInt('GATEWAY_MAX_REQUEST_BYTES', DEFAULT_MAX_REQUEST_BYTES),


### PR DESCRIPTION
Flips the AI-SDK-native gateway path from opt-in to the **default everywhere** (dev, prod, self-host) — replacing the earlier #6617, which was closed after the native path was found to drop gateway-side provider shaping. Those gaps are now fixed and the path is **verified on real self-host traffic across every provider**.

- `apps/llm-gateway/src/config.ts` — `flag('GATEWAY_AI_SDK_NATIVE', true)`
- `apps/api/src/config.ts` — `GATEWAY_AI_SDK_NATIVE: optBoolTrue`

Unset now means **ON**. opencode reaches the gateway via `@ai-sdk/gateway`, so reasoning signatures, refusals, tool calls, and usage pass through 1:1. `GATEWAY_AI_SDK_NATIVE=0` is the kill-switch.

## Why it's safe now
Verified on essentia (live self-host) with real turns through `/v1/llm/language-model` — every connected provider type returned a clean 200:
- **codex** (ChatGPT backend, the dominant ~6.6k-ok/day path) — no `Store must be set to false` (fixed #6623)
- **OpenAI-on-Bedrock** (`global.openai.gpt-5.6-sol`, `us.openai.gpt-5.6-luna`) — no `Type validation failed` (fixed #6630, `@ai-sdk/amazon-bedrock` 5.0.59 parses `redactedContent`)
- **Bedrock-Claude** (sonnet-5, fable-5, opus-5)
- **Anthropic-direct** (claude-fable-5, claude-opus-4.7)
- Managed/unconnected ids (deepseek, glm, hpc-ai) fail with the **same typed errors as the old path** — not native regressions.

Zero gateway crashes/500s across the drive window.

Depends on merged: #6609 (native path), #6615 (API wiring), #6623 (provider shaping), #6630 (bedrock SDK). Config default-mapping test updated (unset→true); wire/session/handler tests use explicit flags, unaffected.
