### PR TITLE
gate: survive a transient 503 at world bootstrap; staging API floor 6 tasks

### DIFF
--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -112,11 +112,16 @@ module "api" {
   # 37s -> ALB 5xx -> edge-laundered 503, while the DB sat at 0 slow queries —
   # API event-loop starvation, not data. 3 x 2 vCPU gives the release gate's
   # ~18-worker fleet real JS throughput (~+$150/mo at the floor).
+  # 2026-08-20: floor raised 3 -> 6. Dry-run 32323656671 still collapsed the
+  # write path at 3 tasks (POST /v1/accounts 2.3-15.2s idle over the eu-west-2
+  # DB; 19 workers pushed it past the origin timeout), and a manual
+  # ecs-scale to 6 was silently reverted by the next deploy's TF apply —
+  # the floor must live here or it does not exist.
   task_cpu                   = 2048
   task_memory                = 4096
-  desired_count              = 3
-  min_capacity               = 3
-  max_capacity               = 6
+  desired_count              = 6
+  min_capacity               = 6
+  max_capacity               = 8
   use_fargate_spot           = true
   fargate_base_on_demand     = 1
   requests_per_target_target = 600

--- a/tests/src/fixtures/billing.ts
+++ b/tests/src/fixtures/billing.ts
@@ -12,6 +12,7 @@ import type { Client } from "../core/client";
 import type { Env } from "../core/env";
 import { log } from "../core/log";
 import { sleep } from "../core/poll";
+import { retryBootstrapCreate } from "./transient";
 
 const TEST_PAYMENT_METHOD = "pm_card_visa";
 
@@ -46,12 +47,18 @@ export async function subscribe(
   accountId: string,
   tierKey = "pro",
 ): Promise<void> {
-  const created = await client.post("/v1/billing/create-inline-checkout", {
-    account_id: accountId,
-    tier_key: tierKey,
-    billing_period: "monthly",
+  // Bootstrap-time create: retried through a transient edge-laundered 5xx —
+  // an abandoned predecessor checkout is inert until its PaymentIntent is
+  // confirmed, so re-creating is safe. See fixtures/transient.ts.
+  const created = await retryBootstrapCreate("inline checkout create", async () => {
+    const res = await client.post("/v1/billing/create-inline-checkout", {
+      account_id: accountId,
+      tier_key: tierKey,
+      billing_period: "monthly",
+    });
+    res.status([200, 201]);
+    return res;
   });
-  created.status([200, 201]);
   const body = created.json<any>();
 
   if (body?.no_payment_required) {

--- a/tests/src/fixtures/principals.ts
+++ b/tests/src/fixtures/principals.ts
@@ -15,6 +15,7 @@ import type { Env } from '../core/env';
 import { log } from '../core/log';
 import type { Principal, Principals } from '../core/types';
 import { subscribe } from './billing';
+import { retryBootstrapCreate } from './transient';
 import { adminCreateUser, adminDeleteUser, passwordGrant, type AdminUser } from './supabase';
 
 export interface Provisioned {
@@ -102,8 +103,14 @@ async function provisionOwner(
   // Funding must follow this call, not race it: the account row is created
   // lazily on the first token/project call.
   const ownerClient = new Client(env.apiUrl).as(owner.principal);
-  const tok = await ownerClient.post('/v1/accounts/tokens', {
-    name: `e2e-${runId}-owner-bootstrap`,
+  // Fresh name per attempt: if a laundered 5xx hid a committed create, the
+  // orphan token is inert (revoked by gc) and the retry cannot 409 on it.
+  const tok = await retryBootstrapCreate('owner PAT mint', async (attempt) => {
+    const res = await ownerClient.post('/v1/accounts/tokens', {
+      name: `e2e-${runId}-owner-bootstrap${attempt > 1 ? `-r${attempt}` : ''}`,
+    });
+    res.status([200, 201]);
+    return res;
   });
   const patAcctSecret = tok.json<any>()?.secret_key as string | undefined;
 

--- a/tests/src/fixtures/transient.ts
+++ b/tests/src/fixtures/transient.ts
@@ -1,0 +1,41 @@
+import { log } from "../core/log";
+
+const TRANSIENT_SHAPE =
+  /edge-laundered|MAINTENANCE_MODE|status=50[234]|\b50[234]\b|network error|fetch failed|ECONNRESET|ETIMEDOUT|socket hang up/i;
+
+/**
+ * Bounded retry for WORLD-BOOTSTRAP creates only.
+ *
+ * The ke2e client correctly refuses to replay a non-idempotent POST through an
+ * edge-laundered 5xx mid-flow (the origin may have committed). Bootstrap is
+ * different: it runs once per shard before any flow, all shards start it at
+ * the same instant against a service that may have just rolled, and a single
+ * laundered 503 there kills the whole shard via funding fail-fast (observed:
+ * run 32327849378, every shard dead in 63s on one 503 each).
+ *
+ * The caller must make each attempt SAFE to re-issue — e.g. mint the token
+ * under a fresh per-attempt name, or re-create a checkout whose abandoned
+ * predecessor is inert until confirmed. `attempt` (1-based) is passed in so
+ * the caller can do exactly that.
+ */
+export async function retryBootstrapCreate<T>(
+  what: string,
+  fn: (attempt: number) => Promise<T>,
+  { attempts = 3, baseDelayMs = 5_000 }: { attempts?: number; baseDelayMs?: number } = {},
+): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      lastErr = err;
+      const msg = (err as Error)?.message ?? String(err);
+      if (attempt === attempts || !TRANSIENT_SHAPE.test(msg)) throw err;
+      log.warn(
+        `bootstrap: ${what} attempt ${attempt}/${attempts} hit a transient failure, retrying: ${msg.slice(0, 200)}`,
+      );
+      await new Promise((r) => setTimeout(r, baseDelayMs * attempt));
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
Run 32327849378: all 9 shards died in ~63s — one edge-laundered 503 each on the two world-bootstrap creates (owner PAT mint, inline-checkout create), made fatal by funding fail-fast + the correct no-replay rule. Bootstrap creates now retry up to 3× with per-attempt-safe inputs (fresh token name per attempt; an abandoned checkout is inert until its PaymentIntent is confirmed). The manual ecs-scale to 6 (run 32326411960) was silently reverted by the next deploy's TF apply — the floor now lives in Terraform (desired 6, min 6, max 8). Local: fixture files syntax-checked; create-replay-safety suite runs under vitest in CI (bare bun test lacks vi.stubGlobal — pre-existing).