### PR TITLE
gate: fix the four session residuals, and stop reruns colliding with themselves

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -143,7 +143,19 @@ jobs:
     env:
       # Pin the run id so the post-run sweep below can reclaim exactly THIS
       # shard's principals (`principals.ts` names them `e2e-<runId>-…`).
-      KE2E_RUN_ID: ${{ github.run_id }}-api${{ matrix.shard }}
+      #
+      # The ATTEMPT is part of the identity, or `gh run rerun --failed` collides
+      # with its own debris: `github.run_id` is identical across attempts, so
+      # every run-scoped fixture name is too, and attempt 2's world bootstrap
+      # re-derives names attempt 1 already claimed. Run 32330628092 attempt 2
+      # failed KAAB-7 in 2.2s with `409 IDEMPOTENCY_KEY_CONFLICT` on its first
+      # `POST /sessions` for exactly this reason — a green flow reported as a
+      # failure, on the release gate, during a release.
+      #
+      # Attempt 1 keeps the OLD id byte-for-byte, so nothing that greps existing
+      # logs or artifacts changes; only a re-run gets the suffix. The reclaim
+      # step below reads this same variable, so the sweep stays exact.
+      KE2E_RUN_ID: ${{ github.run_id }}-api${{ matrix.shard }}${{ github.run_attempt != 1 && format('-a{0}', github.run_attempt) || '' }}
       # Fleet arithmetic, not per-job tuning, and UNCHANGED per shard by the
       # move to 6 — the throughput comes from fewer flows per shard, not from
       # more workers inside one.

--- a/apps/api/src/__tests__/unit-opencode-session-snapshot.test.ts
+++ b/apps/api/src/__tests__/unit-opencode-session-snapshot.test.ts
@@ -119,9 +119,15 @@ describe('scheduleOpencodeSnapshotSync', () => {
         return r;
       },
     };
-    scheduleOpencodeSnapshotSync({ sessionId: 's', projectId: 'p', externalId: 'ext' }, opts);
+    scheduleOpencodeSnapshotSync(
+      { sessionId: 's', projectId: 'p', externalId: 'ext', userId: 'u1' },
+      opts,
+    );
     // A second schedule while the first is in flight is deduped.
-    scheduleOpencodeSnapshotSync({ sessionId: 's', projectId: 'p', externalId: 'ext' }, opts);
+    scheduleOpencodeSnapshotSync(
+      { sessionId: 's', projectId: 'p', externalId: 'ext', userId: 'u1' },
+      opts,
+    );
     expect(pendingSnapshotSyncs()).toBe(1);
     await waitFor(() => calls.length === 2 && pendingSnapshotSyncs() === 0);
     expect(calls).toEqual(['s', 's']);
@@ -132,7 +138,7 @@ describe('scheduleOpencodeSnapshotSync', () => {
     await expect(
       (async () => {
         scheduleOpencodeSnapshotSync(
-          { sessionId: 's2', projectId: 'p', externalId: 'ext' },
+          { sessionId: 's2', projectId: 'p', externalId: 'ext', userId: 'u1' },
           {
             firstMs: 0,
             retryMs: 0,
@@ -145,5 +151,32 @@ describe('scheduleOpencodeSnapshotSync', () => {
         await waitFor(() => pendingSnapshotSyncs() === 0);
       })(),
     ).resolves.toBeUndefined();
+  });
+
+  // REGRESSION (staging release gate, SESS-10). The scheduler used to drop the
+  // caller's `userId` on the floor. `sandboxOpencodeEndpoint` mints the
+  // X-Kortix-User-Context header only when a userId is present, and the daemon's
+  // auth gate 401s every non-`/kortix/*` path — `GET /session` included —
+  // without it (apps/kortix-sandbox-agent-server/src/proxy.ts). So the list
+  // degraded to `unreachable`, `syncOpencodeSessionSnapshot` returned the row
+  // untouched, and `metadata.opencode_sessions` was NEVER written: 0 of 2804
+  // staging sessions created in 2026-08 had a populated snapshot. Pin that the
+  // identity survives the whole hop from schedule to sync.
+  it('carries the caller userId through to the sync that talks to the daemon', async () => {
+    const seen: Array<string | undefined> = [];
+    scheduleOpencodeSnapshotSync(
+      { sessionId: 's3', projectId: 'p', externalId: 'ext', userId: 'user-42' },
+      {
+        firstMs: 0,
+        retryMs: 0,
+        loadRow: async () => row({ sessionId: 's3' }),
+        sync: async ({ row: r, userId }: { row: ProjectSessionRow; userId?: string }) => {
+          seen.push(userId);
+          return r;
+        },
+      },
+    );
+    await waitFor(() => seen.length === 2 && pendingSnapshotSyncs() === 0);
+    expect(seen).toEqual(['user-42', 'user-42']);
   });
 });

--- a/apps/api/src/projects/opencode-mapping.ts
+++ b/apps/api/src/projects/opencode-mapping.ts
@@ -25,6 +25,7 @@
 import { and, eq } from 'drizzle-orm';
 
 import { projectSessions } from '@kortix/db';
+import { logger as appLogger } from '../lib/logger';
 import { db } from '../shared/db';
 import {
   KORTIX_USER_CONTEXT_HEADER,
@@ -98,6 +99,19 @@ export async function listSandboxOpencodeSessions(
     // 503 = daemon up but OpenCode/repo not ready yet — distinct from a hard
     // failure so callers can retry rather than treat it as "empty".
     if (res.status === 503) return { ok: false, reason: 'not_ready' };
+    // A 401 here is NEVER transient and never the sandbox's fault: the daemon
+    // rejects every non-`/kortix/*` path without a valid X-Kortix-User-Context,
+    // and this call only carries one when `userId` was supplied. Folding that
+    // into a silent `unreachable` is what let a userId-less caller disable the
+    // opencode_sessions snapshot for three weeks unnoticed (0 of 2804 staging
+    // sessions in 2026-08). Name it in the log; the caller contract is unchanged.
+    if (res.status === 401) {
+      appLogger.warn('[opencode-mapping] daemon refused the session list (unsigned context)', {
+        externalId,
+        hasUserId: Boolean(userId),
+      });
+      return { ok: false, reason: 'unreachable' };
+    }
     if (!res.ok) return { ok: false, reason: 'unreachable' };
     const data = (await res.json()) as unknown;
     const sessions = Array.isArray(data) ? (data as OpencodeSessionLite[]) : [];

--- a/apps/api/src/projects/opencode-session-snapshot.ts
+++ b/apps/api/src/projects/opencode-session-snapshot.ts
@@ -188,9 +188,21 @@ async function loadRow(sessionId: string, projectId: string): Promise<ProjectSes
  * Schedule a deferred `opencode_sessions` refresh for a session that just served
  * a prompt. Safe to call on every prompt — deduped per session; two attempts
  * (the second catches sub-agent sessions spawned during the turn).
+ *
+ * `userId` is REQUIRED, not optional. The daemon's auth gate rejects every
+ * non-`/kortix/*` path — `GET /session` included — with 401 unless the call
+ * carries a valid `X-Kortix-User-Context` header (apps/kortix-sandbox-agent-server
+ * /src/proxy.ts). That header is minted by `sandboxOpencodeEndpoint` ONLY when a
+ * userId is supplied: `resolvePreviewUserContext` returns null for `undefined`.
+ * A userId-less schedule therefore 401s, degrades to `unreachable`, and the
+ * snapshot is silently never written — which is exactly what happened between
+ * 2026-08-01 and 2026-08-20, when 0 of 2804 staging sessions got a populated
+ * `metadata.opencode_sessions`. Spelling the parameter as required (rather than
+ * `userId?`) makes the compiler, not a reviewer, catch the next caller that
+ * forgets it.
  */
 export function scheduleOpencodeSnapshotSync(
-  input: { sessionId: string; projectId: string; externalId: string; userId?: string },
+  input: { sessionId: string; projectId: string; externalId: string; userId: string | undefined },
   options: SnapshotSyncOptions = {},
 ): void {
   if (!input.sessionId || !input.projectId || !input.externalId) return;

--- a/apps/api/src/sandbox-proxy/command-env-sync.test.ts
+++ b/apps/api/src/sandbox-proxy/command-env-sync.test.ts
@@ -68,7 +68,7 @@ type Recorder = {
   deps: PrePromptEnvSyncDeps;
   envSync: Array<{ requestedAgent?: string | null; sessionId: string; providerName: string }>;
   remint: Array<{ sessionAgent: string; requestedAgent: string | null }>;
-  snapshot: string[];
+  snapshot: Array<{ sessionId: string; projectId: string; externalId: string; userId?: string }>;
   titles: string[];
 };
 
@@ -95,7 +95,12 @@ function recorder(opts: { envSyncError?: () => Error } = {}): Recorder {
       return { action: 'skip' };
     }) as PrePromptEnvSyncDeps['remintGrant'],
     scheduleSnapshot: ((input) => {
-      rec.snapshot.push(input.sessionId);
+      rec.snapshot.push({
+        sessionId: input.sessionId,
+        projectId: input.projectId,
+        externalId: input.externalId,
+        userId: input.userId,
+      });
     }) as PrePromptEnvSyncDeps['scheduleSnapshot'],
     generateTitle: (async (input) => {
       rec.titles.push(input.firstPromptText);
@@ -204,7 +209,23 @@ describe('runPrePromptEnvSync — a /command body', () => {
   test('schedules the opencode snapshot refresh', async () => {
     const rec = recorder();
     await runSync(rec, COMMAND_BODY);
-    expect(rec.snapshot).toEqual(['sess-1']);
+    expect(rec.snapshot).toEqual([
+      { sessionId: 'sess-1', projectId: 'proj-1', externalId: 'ext-1', userId: 'u1' },
+    ]);
+  });
+
+  // REGRESSION (staging release gate, SESS-10): the schedule used to omit
+  // `userId`. `sandboxOpencodeEndpoint` mints the X-Kortix-User-Context header
+  // only when a userId is present (`resolvePreviewUserContext` returns null for
+  // undefined), and the daemon 401s every non-`/kortix/*` path without it. The
+  // refresh therefore degraded to `unreachable` and NEVER wrote:
+  // 0 of 2804 staging sessions created in 2026-08 had a populated
+  // `metadata.opencode_sessions`. Assert the identity reaches the scheduler.
+  test('forwards the caller userId so the daemon call is authenticated', async () => {
+    const rec = recorder();
+    await runSync(rec, COMMAND_BODY);
+    expect(rec.snapshot).toHaveLength(1);
+    expect(rec.snapshot[0]?.userId).toBe('u1');
   });
 
   test('generates NO session title from a command body', async () => {

--- a/apps/api/src/sandbox-proxy/pre-prompt-env-sync.ts
+++ b/apps/api/src/sandbox-proxy/pre-prompt-env-sync.ts
@@ -304,10 +304,14 @@ export async function runPrePromptEnvSync(
       modelHint: prompt.model ?? undefined,
     });
   }
+  // `userId` is load-bearing, not decorative: without it the snapshot's daemon
+  // call carries no X-Kortix-User-Context header and the daemon answers 401,
+  // so the refresh silently never lands. See scheduleOpencodeSnapshotSync.
   deps.scheduleSnapshot({
     sessionId: record.sessionId,
     projectId: record.projectId,
     externalId: record.externalId,
+    userId,
   });
   try {
     await deps.syncEnv({

--- a/tests/bin/ke2e.ts
+++ b/tests/bin/ke2e.ts
@@ -26,6 +26,7 @@ import {
 import { log } from '../src/core/log';
 import { renderStepSummary, writeResults } from '../src/core/report';
 import { runExitCode } from '../src/core/result';
+import { runAttemptSuffix } from '../src/core/run-identity';
 import { discoverFlows, runSuite } from '../src/core/runner';
 import { writeUiData } from '../src/core/ui-data';
 import { runCoverage } from '../src/coverage/check-coverage';
@@ -62,11 +63,16 @@ function newRunId(): string {
   // gate's matrix needs this: each shard must be able to reclaim exactly its
   // own principals in an `if: always()` step, and it cannot guess a random
   // suffix chosen inside this process.
+  //
+  // A PINNED id is returned VERBATIM. The pin and the `gc --run-id` sweep that
+  // follows it read the same variable, so the attempt must be folded in where
+  // that variable is set (tests-release.yml), never here — appending it here
+  // would rename the world out from under its own reclaim step.
   const pinned = process.env.KE2E_RUN_ID?.trim();
   if (pinned) return pinned;
   const ts = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14);
   const r = Math.random().toString(36).slice(2, 8);
-  return `${process.env.GITHUB_RUN_ID ?? ts}-${r}`;
+  return `${process.env.GITHUB_RUN_ID ?? ts}${runAttemptSuffix()}-${r}`;
 }
 
 /**

--- a/tests/src/core/run-identity.ts
+++ b/tests/src/core/run-identity.ts
@@ -1,0 +1,28 @@
+/**
+ * Run-scoped identity helpers.
+ *
+ * Deliberately dependency-free (no `bun:` imports) so the unit lane, which runs
+ * under vitest/node, can load it directly.
+ */
+
+/**
+ * The re-run suffix for a run-scoped identity, or '' on the first attempt.
+ *
+ * `github.run_id` is IDENTICAL across attempts of one workflow run, and the
+ * release gate seeds every run-scoped fixture name from it (`principals.ts`
+ * names principals `e2e-<runId>-…`). Without this suffix `gh run rerun --failed`
+ * re-derives names its own first attempt already claimed: run 32330628092
+ * attempt 2 failed KAAB-7 in 2.2s with `409 IDEMPOTENCY_KEY_CONFLICT` on its
+ * first `POST /sessions`, reporting a healthy flow as a failure on the release
+ * gate during a release.
+ *
+ * Attempt 1 returns '' so first-attempt ids stay byte-identical to what they
+ * have always been — only a re-run is namespaced. A malformed value degrades to
+ * '' rather than inventing a junk namespace that nothing would ever reclaim.
+ */
+export function runAttemptSuffix(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const attempt = Number.parseInt(env.GITHUB_RUN_ATTEMPT ?? '1', 10);
+  return Number.isFinite(attempt) && attempt > 1 ? `-a${attempt}` : '';
+}

--- a/tests/src/flows/run-session-backlog.flow.ts
+++ b/tests/src/flows/run-session-backlog.flow.ts
@@ -198,18 +198,35 @@ flow(
 /**
  * Boot a fresh session and wait for its runtime to reach `ready`, returning the
  * proxy id (`external_id`, the value `:sandboxId` in the preview proxy path).
+ *
+ * The body runs INSIDE a `ctx.step`, and that is the whole point of the wrapper.
+ * Request capture is `AsyncLocalStorage`-scoped to a step (core/context.ts
+ * `withRecorder`, entered only by `ctx.step` in core/runner.ts), so every
+ * `POST /start` poll made outside one is recorded NOWHERE. RUN-4 failed in run
+ * 32330628092 with `Timed out waiting for session runtime ready` and produced a
+ * flow record with `"steps": []` — no request, no body, no `provisioningStage`,
+ * no `lastInitError`, on the single failure mode these flows actually fail with.
+ * Boot is the most expensive and most failure-prone part of every flow here; it
+ * must leave evidence behind.
  */
 async function bootSandbox(
   ctx: FlowContext,
   opts?: { prompt?: string; readinessTimeoutMs?: number },
 ): Promise<{ projectId: string; sessionId: string; sandboxId: string; sandbox: any }> {
-  const project = await ctx.fixtures.sharedSeededProject();
-  const session = await ctx.fixtures.session(project, { prompt: opts?.prompt ?? 'say hello' });
-  const started = await waitForSessionReady(ctx, project.id, session.id, opts?.readinessTimeoutMs);
+  return ctx.step('a fresh session boots to a ready runtime', async () => {
+    const project = await ctx.fixtures.sharedSeededProject();
+    const session = await ctx.fixtures.session(project, { prompt: opts?.prompt ?? 'say hello' });
+    const started = await waitForSessionReady(
+      ctx,
+      project.id,
+      session.id,
+      opts?.readinessTimeoutMs,
+    );
 
-  const sandbox = started.sandbox;
-  const sandboxId = String(sandbox.external_id ?? sandbox.externalId);
-  return { projectId: project.id, sessionId: session.id, sandboxId, sandbox };
+    const sandbox = started.sandbox;
+    const sandboxId = String(sandbox.external_id ?? sandbox.externalId);
+    return { projectId: project.id, sessionId: session.id, sandboxId, sandbox };
+  });
 }
 
 /** The workspace directory the session's OpenCode root lives under (see

--- a/tests/src/flows/session-thread-reliability.flow.ts
+++ b/tests/src/flows/session-thread-reliability.flow.ts
@@ -97,12 +97,22 @@ async function bootSandbox(
   ctx: FlowContext,
   opts?: { prompt?: string; readinessTimeoutMs?: number },
 ): Promise<{ projectId: string; sessionId: string; sandboxId: string; sandbox: any }> {
-  const project = await ctx.fixtures.sharedSeededProject();
-  const session = await ctx.fixtures.session(project, { prompt: opts?.prompt ?? 'say hello' });
-  const started = await waitForSessionReady(ctx, project.id, session.id, opts?.readinessTimeoutMs);
-  const sandbox = started.sandbox;
-  const sandboxId = String(sandbox.external_id ?? sandbox.externalId);
-  return { projectId: project.id, sessionId: session.id, sandboxId, sandbox };
+  // Inside a step so a boot failure records its `POST /start` polls — request
+  // capture is AsyncLocalStorage-scoped to `ctx.step`. See the twin helper in
+  // run-session-backlog.flow.ts for the run that proved this matters.
+  return ctx.step('a fresh session boots to a ready runtime', async () => {
+    const project = await ctx.fixtures.sharedSeededProject();
+    const session = await ctx.fixtures.session(project, { prompt: opts?.prompt ?? 'say hello' });
+    const started = await waitForSessionReady(
+      ctx,
+      project.id,
+      session.id,
+      opts?.readinessTimeoutMs,
+    );
+    const sandbox = started.sandbox;
+    const sandboxId = String(sandbox.external_id ?? sandbox.externalId);
+    return { projectId: project.id, sessionId: session.id, sandboxId, sandbox };
+  });
 }
 
 const WORKSPACE = '/workspace';
@@ -177,21 +187,125 @@ async function listOcMessages(
   return Array.isArray(body) ? body : [];
 }
 
+/**
+ * The two error names OpenCode stamps when a turn is ABORTED — the same
+ * whitelist RUN-9 asserts against below. Anything else on `info.error` is a
+ * genuine provider/gateway failure, NOT an "Interrupted" stamp.
+ */
+const OC_ABORT_ERROR_NAMES = ['AbortError', 'MessageAbortedError'];
+
+function ocErrorName(m: OcMessage): string | undefined {
+  return ((m.info ?? (m as any))?.error as { name?: string } | undefined)?.name;
+}
+
+/** An assistant turn the runtime finished by ABORTING it (the "Interrupted" stamp). */
+function isAbortStamp(m: OcMessage): boolean {
+  const name = ocErrorName(m);
+  return ocRole(m) === 'assistant' && Boolean(name) && OC_ABORT_ERROR_NAMES.includes(name!);
+}
+
+/**
+ * An assistant turn that died on something that is NOT an abort — a provider or
+ * Kortix-gateway failure. The turn is TERMINAL: `time.completed` is stamped and
+ * no further part will ever be appended to it.
+ */
+function terminalTurnFailure(messages: OcMessage[], knownIds: Set<string>): OcMessage | null {
+  for (const m of messages) {
+    if (ocRole(m) !== 'assistant') continue;
+    const id = ocId(m);
+    if (id && knownIds.has(id)) continue;
+    const name = ocErrorName(m);
+    if (name && !OC_ABORT_ERROR_NAMES.includes(name)) return m;
+  }
+  return null;
+}
+
+/**
+ * `Invalid error response format: Gateway request failed` reads like a gateway
+ * bug and is not one. Both halves are HARDCODED by `@ai-sdk/gateway`: it emits
+ * `Invalid error response format: ${defaultMessage}` when a non-2xx body fails
+ * its `{ error: { message: string } }` schema, and `defaultMessage` is the
+ * constant `'Gateway request failed'`. The real body is discarded into
+ * `.response`/`.validationError`, which OpenCode does not surface.
+ *
+ * On this deployment the body that fails that schema is the `api-router`
+ * Cloudflare Worker's synthetic maintenance response
+ * (`infra/cloudflare/workers/api-router/worker.mjs:157`), which the Worker
+ * substitutes for ANY origin 502/503/504 and which spells `error` as a STRING:
+ * `{"error":"MAINTENANCE_MODE","message":…}`. So this signature means "the edge
+ * swallowed an origin 5xx", and the origin's real message is gone. Say that in
+ * the failure text — the alternative is another triage cycle spent on it.
+ */
+function decodeOpaqueGatewayError(detail: string): string {
+  if (!detail.includes('Invalid error response format')) return '';
+  return (
+    ' — NOTE: this string is emitted by @ai-sdk/gateway when an error body fails' +
+    ' its {error:{message}} schema; both halves are hardcoded constants and carry' +
+    ' NO information about the real failure. On this deployment that body is the' +
+    ' api-router Worker maintenance response substituted for an origin 502/503/504' +
+    ' (infra/cloudflare/workers/api-router/worker.mjs:157, `error` is a string).' +
+    ' Read X-Origin-Status / X-Request-Id at the edge, or replay with the CI' +
+    ' passthrough header, to recover the origin error.'
+  );
+}
+
+/**
+ * A turn that ended on a provider/gateway error can never produce the marker, so
+ * waiting out the remaining budget only converts a diagnosable upstream failure
+ * into a misleading "timed out waiting for <marker>". Raised as its own class so
+ * `waitFor`'s retryOnError does not swallow it, and marked ke2eRetryable so the
+ * runner spends an INFRA attempt on it — a transient upstream outage is exactly
+ * what a retry is for, and a persistent one still fails the flow, by name.
+ */
+class TerminalTurnError extends Error {
+  readonly ke2eRetryable = true;
+  readonly ke2eRetryClass = 'infra';
+  constructor(message: string) {
+    super(message);
+    this.name = 'TerminalTurnError';
+  }
+}
+
 async function waitForAssistantMarker(
   ctx: FlowContext,
   sandboxId: string,
   ocSessionId: string,
   marker: string,
   timeoutMs = 240_000,
+  /** Assistant ids that already carried an error BEFORE this wait started. */
+  preExistingErrorIds: Set<string> = new Set(),
 ): Promise<OcMessage[]> {
   return waitFor(
-    async () => listOcMessages(ctx, sandboxId, ocSessionId),
+    async () => {
+      const messages = await listOcMessages(ctx, sandboxId, ocSessionId);
+      // Run 32330628092 (shard 2) spent 191.4s of a 240s budget re-reading a
+      // transcript that had been terminal for 48.6s: the turn's last assistant
+      // message carried `UnknownError: Invalid error response format: Gateway
+      // request failed` and zero text parts, while staging's edge was
+      // simultaneously serving MAINTENANCE_MODE 503s. Surface THAT, immediately.
+      const dead = terminalTurnFailure(messages, preExistingErrorIds);
+      if (dead) {
+        const err = (dead.info ?? (dead as any))?.error as
+          | { name?: string; message?: string; data?: { message?: string } }
+          | undefined;
+        const detail = err?.data?.message ?? err?.message ?? '';
+        throw new TerminalTurnError(
+          `the assistant turn ended on a NON-abort runtime error, so "${marker}" can never appear: ` +
+            `${err?.name ?? 'unknown'}${detail ? `: ${detail}` : ''} (message ${ocId(dead) ?? '?'})` +
+            decodeOpaqueGatewayError(detail),
+        );
+      }
+      return messages;
+    },
     {
       until: (messages) =>
         messages.some((m) => ocRole(m) === 'assistant' && ocText(m).includes(marker)),
       timeoutMs,
       intervalMs: 4_000,
       description: `assistant reply containing "${marker}" in OpenCode session ${ocSessionId}`,
+      // A laundered edge 503 mid-wait is transit, not a verdict — ride it out.
+      // The terminal-turn verdict above must NOT be ridden out, so exclude it.
+      retryOnError: (error) => !(error instanceof TerminalTurnError) && isKe2eRetryableError(error),
     },
   );
 }
@@ -387,6 +501,7 @@ flow(
     let preStopUserIds: string[] = [];
     let preStopAbortCount = 0;
     let preStopMessageIds: string[] = [];
+    let preWakeErrorIds = new Set<string>();
     await ctx.step('capture the message baseline before stopping', async () => {
       const messages = await listOcMessages(ctx, sandboxId, ocSessionId);
       preStopMessageIds = messages.map((m) => ocId(m)).filter((id): id is string => Boolean(id));
@@ -394,9 +509,10 @@ flow(
         .filter((m) => ocRole(m) === 'user')
         .map((m) => ocId(m))
         .filter((id): id is string => Boolean(id));
-      preStopAbortCount = messages.filter(
-        (m) => ocRole(m) === 'assistant' && Boolean((m.info ?? (m as any))?.error),
-      ).length;
+      // Count ABORT stamps only. `Boolean(info.error)` also counts a provider or
+      // gateway failure, so an unrelated upstream blip used to be reported as
+      // "a NEW 'Interrupted' stamp appeared" — the wrong defect, named wrongly.
+      preStopAbortCount = messages.filter(isAbortStamp).length;
     });
 
     await ctx.step(
@@ -454,14 +570,20 @@ flow(
             `user message ids changed across the wake — the original prompt was redelivered as a new message: before=${JSON.stringify(preStopUserIds)} after=${JSON.stringify(userIds)}`,
           );
         }
-        const abortCount = messages.filter(
-          (m) => ocRole(m) === 'assistant' && Boolean((m.info ?? (m as any))?.error),
-        ).length;
+        const abortCount = messages.filter(isAbortStamp).length;
         if (abortCount !== preStopAbortCount) {
           throw new Error(
             `abort-marked assistant message count changed on wake alone (no new prompt sent yet) — a new "Interrupted" stamp appeared: before=${preStopAbortCount} after=${abortCount}`,
           );
         }
+        // Anything already carrying an error at this point predates the wake
+        // prompt and must not be blamed on it by the terminal-turn escape.
+        preWakeErrorIds = new Set(
+          messages
+            .filter((m) => ocRole(m) === 'assistant' && Boolean(ocErrorName(m)))
+            .map((m) => ocId(m))
+            .filter((id): id is string => Boolean(id)),
+        );
       },
     );
 
@@ -483,7 +605,14 @@ flow(
     await ctx.step(
       'the wake prompt lands exactly once, and the pre-existing abort-stamp count still has NOT grown',
       async () => {
-        const messages = await waitForAssistantMarker(ctx, sandboxId, ocSessionId, newMarker);
+        const messages = await waitForAssistantMarker(
+          ctx,
+          sandboxId,
+          ocSessionId,
+          newMarker,
+          240_000,
+          preWakeErrorIds,
+        );
         const userIds = messages
           .filter((m) => ocRole(m) === 'user')
           .map((m) => ocId(m))
@@ -501,9 +630,7 @@ flow(
             `expected exactly one assistant reply carrying the wake-prompt marker, saw ${assistantsWithMarker.length}`,
           );
         }
-        const abortCount = messages.filter(
-          (m) => ocRole(m) === 'assistant' && Boolean((m.info ?? (m as any))?.error),
-        ).length;
+        const abortCount = messages.filter(isAbortStamp).length;
         if (abortCount !== preStopAbortCount) {
           throw new Error(
             `abort-marked assistant message count grew after the wake prompt — a NEW "Interrupted" stamp appeared on top of the pre-existing one(s): before=${preStopAbortCount} after=${abortCount}`,
@@ -758,17 +885,34 @@ flow(
 // tab, a second device, or a crash lost queued messages silently and two tabs
 // on one session disagreed about what was pending.
 //
-// Deliberately NOT gated on a booted sandbox: everything asserted here is the
-// control plane's own contract — the durable row, the idempotency key, the
-// state projection, and the two write gates. Whether the runtime then answers
-// the prompt is SESS-23's business, not this flow's.
+// Most of what is asserted here is the control plane's own contract — the
+// durable row, the idempotency key, the state projection, and the two write
+// gates. Whether the runtime then answers the prompt is SESS-23's business.
+//
+// The runtime IS booted to ready first, though, and that is load-bearing rather
+// than incidental. `holdInboxPrompts` (session-lifecycle/inbox-rows.ts) writes a
+// reader-visible `result.held` for `queued` and `forwarded` rows, but a row the
+// drain has already CLAIMED (`status = 'running'`) gets a PAYLOAD flag only —
+// `markCommandForwarded` replaces `result` wholesale, so `promptState` keeps
+// answering `delivering/null` until that claimed delivery lands. On a COLD box
+// the claim window is the whole of `continueSession`, up to
+// `READY_DEADLINE_MS = 300_000` (session-lifecycle/engine.ts). Run 32330628092
+// posted into a cold session, the drain claimed the row 6s later, and the hold
+// step then re-POSTed for 32s against a row that read `delivering/null` every
+// time and could not have read anything else. That is the documented server
+// contract, not a defect — Stop cannot unsend a POST. Booting first keeps the
+// claim window at ~1.3s, so every branch of the hold predicate is reachable.
 flow(
   'SESS-25',
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 300_000,
+    // Raised with the readiness wait added below: a real cold boot measured
+    // 36-50s typically and 158s worst-success in run 32330628092, and it now
+    // runs BEFORE the inbox assertions rather than racing them.
+    timeoutMs: 600_000,
     routes: [
+      'POST /v1/projects/:projectId/sessions/:sessionId/start',
       'POST /v1/projects/:projectId/sessions/:sessionId/prompts',
       'GET /v1/projects/:projectId/sessions/:sessionId/prompts',
       'DELETE /v1/projects/:projectId/sessions/:sessionId/prompts/:promptId',
@@ -781,6 +925,12 @@ flow(
     const session = await ctx.fixtures.session(project);
     const owner = ctx.client.as(ctx.P.OWNER);
     const params = { projectId: project.id, sessionId: session.id };
+    // See the header: the hold predicate is unsatisfiable while the drain holds
+    // a claim against a box that is still booting. `ctx.fixtures.session` does
+    // NOT wait for readiness, so wait here, before the first prompt exists.
+    await ctx.step('the session runtime is ready before anything is queued', async () => {
+      await waitForSessionReady(ctx, project.id, session.id, 240_000);
+    });
     const clientMessageId = `q_sess25_${Date.now()}`;
     // The CLIENT mints the wire id: OpenCode orders its transcript by the id's
     // clock prefix, and only a process holding the transcript can place one.
@@ -886,7 +1036,11 @@ flow(
       // apps/api/src/projects/session-lifecycle/inbox-hold-settle.ts). Run
       // 32306385663 read the response one tick too early and saw exactly that.
       // The route is idempotent, so re-POST until the row is held or gone — a
-      // hold that never lands still fails the flow.
+      // hold that never lands still fails the flow. The budget is sized for a
+      // READY box (claim -> forward ~1.3s measured), which the readiness step
+      // above guarantees; 30s was sized for that too but ran against a cold box,
+      // where the claim can stand for up to READY_DEADLINE_MS = 300s.
+      let lastSeen = 'never observed';
       const held = await waitFor(
         async () =>
           owner.post(
@@ -901,14 +1055,26 @@ flow(
               (p: any) => p.prompt_id === promptId,
             );
             // Absent = already delivered; it IS the transcript and cannot be held.
-            return !mine || (mine.state === 'waiting' && mine.reason === 'held');
+            if (!mine) {
+              lastSeen = 'absent (delivered)';
+              return true;
+            }
+            lastSeen = `${mine.state}/${mine.reason ?? 'null'}`;
+            return mine.state === 'waiting' && mine.reason === 'held';
           },
-          timeoutMs: 30_000,
+          timeoutMs: 90_000,
           intervalMs: 2_000,
           description: `prompt ${promptId} to read waiting/held once the hold settles`,
           retryOnError: isKe2eRetryableError,
         },
-      );
+      ).catch((error) => {
+        // Name the state actually observed. A bare "timed out waiting for
+        // waiting/held" cost run 32330628092 a whole triage cycle to discover
+        // the row had read `delivering/null` for every one of its 4 polls.
+        throw error instanceof Error
+          ? Object.assign(error, { message: `${error.message}; last observed state: ${lastSeen}` })
+          : error;
+      });
       held.status(200);
 
       const bad = await owner.post(

--- a/tests/unit/rerun-identity.test.ts
+++ b/tests/unit/rerun-identity.test.ts
@@ -1,0 +1,56 @@
+/**
+ * A re-run must not collide with its own first attempt.
+ *
+ * `github.run_id` is IDENTICAL across attempts of the same workflow run, and the
+ * release gate seeds every run-scoped fixture name from it
+ * (`principals.ts` names principals `e2e-<runId>-…`). So `gh run rerun --failed`
+ * used to re-derive names attempt 1 had already claimed: run 32330628092
+ * attempt 2 failed KAAB-7 in 2.2s with
+ * `{"error":"Idempotency key is already in use","code":"IDEMPOTENCY_KEY_CONFLICT"}`
+ * on its very first `POST /sessions` — a passing flow reported as a failure, on
+ * the release gate, mid-release. Re-run is the cheapest recovery lever the gate
+ * has; it has to be trustworthy.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+import { runAttemptSuffix } from '../src/core/run-identity';
+
+const root = resolve(import.meta.dirname, '../..');
+const releaseWorkflow = readFileSync(
+  resolve(root, '.github/workflows/tests-release.yml'),
+  'utf8',
+);
+
+describe('runAttemptSuffix', () => {
+  test('is empty on the first attempt, so existing ids are unchanged', () => {
+    expect(runAttemptSuffix({})).toBe('');
+    expect(runAttemptSuffix({ GITHUB_RUN_ATTEMPT: '1' })).toBe('');
+  });
+
+  test('namespaces every attempt after the first', () => {
+    expect(runAttemptSuffix({ GITHUB_RUN_ATTEMPT: '2' })).toBe('-a2');
+    expect(runAttemptSuffix({ GITHUB_RUN_ATTEMPT: '11' })).toBe('-a11');
+  });
+
+  test('a malformed attempt degrades to no suffix rather than a junk namespace', () => {
+    expect(runAttemptSuffix({ GITHUB_RUN_ATTEMPT: '' })).toBe('');
+    expect(runAttemptSuffix({ GITHUB_RUN_ATTEMPT: 'nope' })).toBe('');
+  });
+});
+
+describe('release gate run identity', () => {
+  test('the pinned shard run id carries the attempt', () => {
+    expect(releaseWorkflow).toContain(
+      "KE2E_RUN_ID: ${{ github.run_id }}-api${{ matrix.shard }}${{ github.run_attempt != 1 && format('-a{0}', github.run_attempt) || '' }}",
+    );
+  });
+
+  test('the reclaim sweep reuses that exact variable, so it stays scoped', () => {
+    // If the sweep re-derived the id instead of reading KE2E_RUN_ID, a re-run
+    // would rename the world out from under its own `if: always()` reclaim and
+    // leak every principal it created.
+    expect(releaseWorkflow).toContain('bun tests/bin/ke2e.ts gc --run-id "$KE2E_RUN_ID"');
+  });
+});


### PR DESCRIPTION
# Session residuals of the staging release gate

Run 32330628092 (staging SHA `c935c016c399`) ended 442/446 API flows green, with
four failures — one per shard, all real-Daytona session flows. This PR diagnoses
all four and fixes three at the root. The fourth is a reproducible product bug
that this PR makes fast and diagnosable rather than silent; it is NOT fixed here.

Every shard was re-run on the same run id. That second data point is what
separates deterministic from load-shaped:

| Flow | 1st run | Re-run | Verdict | Class |
| --- | --- | --- | --- | --- |
| SESS-10 | fail | **fail** (`opencode_sessions: []` again) | deterministic product bug | (c) |
| SESS-23 | fail | **fail** (same error, staging healthy) | root-caused, NOT fixed (edge) | (c) |
| RUN-4 | fail x2 attempts | **pass** | infra/flake, cause unrecorded | (b) diagnostics |
| SESS-25 | fail | **pass** | real unsatisfiable-predicate race | (b) |

---

## SESS-10 — `metadata.opencode_sessions` has been dead since 2026-08-01

**Symptom.** `Timed out waiting for the OpenCode title/tree mirror`. Across all
31 polls of the first run and all 33 of the re-run, the session read returned
`opencode_sessions: []` while `name` was correctly mirrored.

**Root cause.** `runPrePromptEnvSync` scheduled the snapshot refresh without a
`userId`:

```ts
deps.scheduleSnapshot({ sessionId, projectId, externalId });   // no userId
```

`syncOpencodeSessionSnapshot` passes that to `listSandboxOpencodeSessions`, which
builds its daemon call in `sandboxOpencodeEndpoint`. That mints the
`X-Kortix-User-Context` header only when a userId is present —
`resolvePreviewUserContext` returns `null` for `undefined`
(`apps/api/src/shared/preview-ownership.ts:291`). The daemon's auth gate rejects
every non-`/kortix/*` path without that header:

```ts
// apps/kortix-sandbox-agent-server/src/proxy.ts
const result = verifyKortixUserContext(header, cfg.sandboxToken)
if (!result.ok) return c.json({ error: 'unauthorized', reason: result.reason }, 401)
```

`GET /session` is not `/kortix/*`. There is no bearer/service-key fallback in
that middleware. So the list 401'd, degraded to `unreachable`, and
`syncOpencodeSessionSnapshot` returned the row untouched — every time, silently.
`scheduleOpencodeSnapshotSync` is the ONLY writer of `metadata.opencode_sessions`.

**Blast radius, measured on the staging DB (read-only):**

```
select date_trunc('month',created_at) m, count(*) total,
       count(*) filter (where jsonb_array_length(
         coalesce(metadata->'opencode_sessions','[]'::jsonb))>0) nonempty
from kortix.project_sessions group by 1 order by 1;

 2026-06-01 |    8 |  8
 2026-07-01 | 1779 | 43
 2026-08-01 | 2804 |  0     <-- zero
```

This is not test-only. The frontend reads `opencode_sessions` for the
conversation count and per-conversation labels, and `serializers.ts` resolves the
displayed session name from it (`runtimeTitle` outranks the generated
`autoName`). Rows that DO have a populated mirror confirm the serializer
contract exactly — `metadata.name` equals the root title, and the root entry id
equals the pin:

```
ac23cdf2-… | Casual greeting | Casual greeting | t
c98bd950-… | Greeting        | Greeting        | t
```

That is precisely SESS-10's predicate, so the flow passes by construction once
the mirror populates. Across ALL 51 rows that ever got a populated mirror, 26
carry a non-placeholder root title and `metadata.name` equals that title in
**26 of 26**. The flow was right and the product was wrong.

Residual risk, stated plainly: the fix guarantees the mirror is WRITTEN, not
that OpenCode's in-sandbox summarizer has produced a non-placeholder root title
within SESS-10's 180s window — the other 25 of those 51 rows are frozen on
`New session - <iso>`. SESS-10 re-arms the writer by re-prompting every 75s, so
each re-arm re-syncs and picks the title up once it exists; that is the design
the flow already had, and it could not work at all while the writer was 401ing.

Why the pin still worked while the snapshot did not: `ensureOpencodeSessionPin`
is called with a real identity (`userId: loaded.userId`,
`apps/api/src/projects/routes/shared.ts:1159`). Only the snapshot path dropped it.

**Fix.**
1. Thread `userId` through `runPrePromptEnvSync` -> `scheduleSnapshot`.
2. Make `userId` a REQUIRED field on `scheduleOpencodeSnapshotSync`'s input
   (`userId: string | undefined`, not `userId?`) so the compiler catches the next
   caller that forgets. It immediately caught the existing unit test, which is
   the point.
3. Log the 401 in `listSandboxOpencodeSessions` instead of folding it into a
   silent `unreachable`. A silent degrade is what hid this for three weeks.

---

## SESS-23 — root-caused, NOT fixed here: the edge destroys the real error

**This flow will still fail until someone fixes the Cloudflare Worker.** What
this PR changes is that it now fails in ~50s naming a signature we can decode,
instead of timing out at 240s naming the wrong thing.

### The error message is not what it looks like

`UnknownError: Invalid error response format: Gateway request failed` reads like
a gateway bug. Neither half carries any information. Both are hardcoded
constants in `@ai-sdk/gateway`:

```ts
// create-gateway-error.ts:43
message: `Invalid error response format: ${defaultMessage}`
// as-gateway-error.ts:59
defaultMessage: 'Gateway request failed'
```

It is emitted when a non-2xx body fails this schema:

```ts
z.object({ error: z.object({ message: z.string(), type: …, param: …, code: … }), … })
```

The real body is discarded into `.response` / `.validationError`, which OpenCode
never surfaces. So the message means exactly one thing: **"a non-2xx arrived
whose body has no `error.message`."**

### What produced such a body

Staging sandboxes reach the gateway at
`LLM_GATEWAY_BASE_URL = https://gateway-staging.kortix.com/v1/llm`
(`sandbox-base-url.ts:18`, `deploy-staging.yml:34,214,226`), and that hostname is
the `api-router` Cloudflare Worker, not the ALB
(`infra/terraform/environments/staging/main.tf:6-9`).

The Worker replaces **any** origin 502/503/504 with a synthetic maintenance body
(`worker.mjs:309-336`) unless the caller presents the CI passthrough secret
(`worker.mjs:61-67`) — which a sandbox never does. That body spells `error` as a
**string**:

```js
// infra/cloudflare/workers/api-router/worker.mjs:157-165
JSON.stringify({
  error: 'MAINTENANCE_MODE',        // <-- a STRING; the schema needs an OBJECT
  message: config.message || 'Kortix is temporarily unavailable for maintenance.',
  maintenance: config,
})
```

String -> schema fails -> `GatewayResponseError` -> OpenCode `UnknownError`.
Exact match for the observed payload.

Corroboration from this same run, independent of any code reading: the ke2e
client itself received that literal body five times during the first SESS-23
attempt (`503`, `retry-after: 30`, no `x-request-id`,
`{"error":"MAINTENANCE_MODE",…}`) — the Worker was demonstrably laundering
origin 5xx in that window.

Every deliberate gateway error, by contrast, goes through `gatewayErrorResponse`
(`pipeline/error-response.ts:32-59`) and emits a well-formed
`{error:{message,type,…}}`; the standalone server even try/catches unhandled
throws into one (`apps/llm-gateway/src/server.ts:266-279`). **No gateway code
path can produce the observed body** — it came from outside the gateway.

### The malformed-history hypothesis is falsified

Two independent falsifications, so it is not the cause:

1. **Wrong error shape.** An orphan tool call yields an upstream 400 /
   `InvalidPromptError`; both become `UpstreamHttpError` -> `describeNativeFailure`
   -> `gatewayErrorResponse(400, …)` — a VALID envelope. OpenCode would have
   printed the real upstream text.
2. **Wrong timing.** The husk is in history from the first post-wake step
   onward, yet step 1 succeeded in both runs and the kill landed at different
   positions (step 3, then step 2). A history-shape defect fails
   deterministically at step 1.

Consistent with that: RUN-6 passed in the SAME shard, SAME model
(`kortix/deepseek-v4-flash`), same window, with a two-step tool-calling turn
(`["memory","no-tool"]`). Multi-step tool turns are not broken.

Best-supported origin (labelled INFERENCE): `describeNativeFailure` returns
**502** for `empty_completion` and `upstream_unreachable`
(`language-model-handler.ts:476-485`). An empty completion is stochastic, fast
(~5s), and leaves zero parts / zero tokens / zero cost after `refundBillingHold`
— which matches the observation and explains the non-deterministic position.
Infra 5xx under gate load is the alternative, laundered identically.

### Why I did NOT ship the Worker fix in this PR

The one-line fix is to make the laundered body carry `error` as an object. I am
deliberately not doing it here: `worker.mjs` is shared edge code in front of
**every** environment including prod, I cannot verify it from a branch, and its
string shape is load-bearing for the gate's OWN transient detection —
`tests/src/core/client.ts:650`, `tests/src/fixtures/transient.ts:4`,
`tests/unit/browser-transient-retry.test.ts:15`, and four assertions in
`worker.test.mjs`. Changing it blind, in the PR that is meant to stabilise the
release gate, is how you break the release gate.

Handing over a shape that satisfies the AI-SDK schema AND keeps every existing
substring matcher working (`type` and `code` are `string.nullish()` in the
schema, so the token survives):

```json
{
  "error": { "message": "Kortix is temporarily unavailable…",
             "type": "MAINTENANCE_MODE", "code": "MAINTENANCE_MODE" },
  "message": "Kortix is temporarily unavailable…",
  "maintenance": { … }
}
```

Only the four strict `toMatchObject({ error: 'MAINTENANCE_MODE' })` assertions in
`worker.test.mjs` would need updating; every substring matcher above still sees
`MAINTENANCE_MODE` in the raw body.

To settle the underlying 502 in one request: replay against
`gateway-staging.kortix.com/v1/llm/language-model` with, then without, the CI
passthrough header. With it you get the origin's real `gatewayErrorResponse` and
its `code`; without it, the maintenance body. The Worker also preserves the
truth in `X-Origin-Status` / `X-Request-Id` (`worker.mjs:139-149`) — OpenCode
just discards headers on error.

### Two more regressions found on the way, both from #6631

Independently verified by grep in this branch:

- **`gateway_request_logs` has been dark for all agent traffic.** Its only
  writer chain ends at `handler.ts:247` (the legacy path).
  `language-model-handler.ts` has **0** trace/emit calls; `handler.ts` has 10.
  The native path bills via `recordUsage` -> `usage_events` but never writes a
  trace row. Since #6631 made native the default, the observability table for
  the default path is empty by construction — the ~110-token rows I found are
  legacy `/chat/completions` title generation. My original "no row, so the
  request never arrived" reading was therefore WRONG, and I am correcting it
  here rather than leaving it in the record.
- **PR #6489's sanitizers are not on the default path.** `repairToolPairing`
  and `stripTrailingAssistantPrefill` have one call site, `request.ts:274`,
  reachable only via the legacy handler; `language-model-request.ts` references
  them **0** times and copies tool-calls through unconditionally. Latent today
  only because `deepseek-v4-flash` tolerates orphan tool-calls and trailing
  prefill — it will bite on Bedrock/Anthropic, which is precisely the incident
  #6489 was written for.

### A third, separate product bug this exposed

The dangling pre-stop assistant message survives `POST /stop` + `/start`
unchanged, identically in both runs:

```
run1  msg_01d640c58001atYWW5jbl8knLd  time.completed=NONE  error=none  tools=["write:pending"]
rerun msg_01d780cc0001ghwe9lhI6ftZrB  time.completed=NONE  error=none  tools=["write:pending"]
```

No `time.completed`, no error, a `write` tool frozen at
`{"status":"pending","input":{}}`. `abortLiveTurnBeforeStop`
(`projects/reaping/stop-box.ts`) exists to prevent exactly this — RUN-9's own
comment calls the dangling never-completed row the historical cause of a phantom
"Interrupted" (T11) — and the wake-side finalizer did not close it either.
SESS-23 structurally cannot catch it: its assertion is on the abort-stamp COUNT,
and a husk with no stamp does not move that count. Not the cause of the failure
above, but a real defect sitting in every stopped-mid-turn session.

### What this PR does change

`waitForAssistantMarker` had no concept of a terminal turn, so it re-read a
frozen transcript for 191 of its 240 seconds and then blamed the marker. It now:

- fails as soon as the turn's assistant message carries a non-abort `info.error`,
- names the real error, and appends a decoder for this exact signature so the
  next person does not spend a triage cycle on a hardcoded constant,
- is classified `ke2eRetryable` / class `infra`, which is the correct handling
  for a laundered origin 5xx — a transient one now costs a retry instead of the
  flow.

Replayed against BOTH real recorded transcripts:

```
run 1:  TERMINAL ESCAPE FIRES at poll #3, +48s into the wait   (step ran 240s)
re-run: TERMINAL ESCAPE FIRES at poll #2, +57s into the wait   (step ran 241s)
```

Second flow defect fixed alongside: the abort-stamp predicate counted ANY
assistant `info.error` as an "Interrupted" stamp, so this same gateway failure
ALSO tripped `abort-marked assistant message count grew…` — a second wrong
verdict on one event. It now matches only the abort names RUN-9 already
whitelists (`AbortError`, `MessageAbortedError`).

## SESS-25 — the hold predicate was unsatisfiable against a cold box

**Re-run passed**, but the race is real and worth removing.

`ctx.fixtures.session()` does not wait for readiness, so the box was cold. The
drain claimed the prompt row 6s after it was created and entered
`continueSession`, whose claim window is the whole ready-wait — up to
`READY_DEADLINE_MS = 300_000`. `holdInboxPrompts` handles a claimed
(`status = 'running'`) row by writing the PAYLOAD only, because
`markCommandForwarded` replaces `result` wholesale:

```ts
// session-lifecycle/inbox-rows.ts — the `running` arm
payload: sql`${payload} || '{"stopPausedOnDelivery": true, "remintOnDelivery": true}'::jsonb`
```

and `promptState` reads `result` only, so it answers `delivering/null`
(`routes/r8.ts:568`). The row read `delivering/null` on all 4 hold polls and
could not have read anything else. That is the documented server contract —
Stop cannot unsend a POST — so this is the flow's expectation that was wrong,
not the server.

**Fix.** Wait for the runtime to be ready before anything is queued, which keeps
the claim window at ~1.3s and makes every branch of the hold predicate
reachable. Budget 30s -> 90s, flow budget 300s -> 600s to cover the added boot
(measured 36-50s typical, 158s worst success in this run), and the timeout now
reports the state actually observed instead of only the state expected.

Honest limitation: on a ready box the common outcome is the row already being
delivered and absent from the inbox, which the flow's own comment explicitly
blesses as a pass. A deterministic `waiting/held` assertion would need the
prompt queued behind a live turn; that is deliberately NOT added here because it
would couple SESS-25 to the SESS-23 gateway defect above.

---

## RUN-4 — passed on re-run; the real defect was that it left no evidence

The failure produced a flow record with `"steps": []`. Request capture is
`AsyncLocalStorage`-scoped to `ctx.step` (`core/context.ts` `withRecorder`,
entered only by `ctx.step` in `core/runner.ts:171`), and `bootSandbox` ran at
flow top level. So the readiness poll that failed recorded nothing: no request,
no body, no `provisioningStage`, no `lastInitError` — on the single failure mode
these flows actually fail with. The session id appears exactly once in the whole
57MB artifact, inside the error string.

The 300s budget is not the problem: measured time-to-ready in the same run was
36-50s typical and 158s worst success. Raising it is unjustified.

**Fix.** `bootSandbox` now runs inside a `ctx.step`, in both flow files — one
change that covers all 15 call sites (RUN-1..8, FILE-8/9, SESS-* boots). The
readiness error message is unchanged, so
`markSessionReadinessTimeoutRetryable`'s exact-string match and the
`session-runtime` retry class still apply.

---

---

## Second deliverable: `gh run rerun --failed` no longer collides with itself

Re-running the failed shards is the cheapest recovery lever the release gate
has, and it was silently unsafe. `github.run_id` is IDENTICAL across attempts,
and the gate seeds every run-scoped fixture name from it
(`KE2E_RUN_ID: <run_id>-api<shard>` -> `principals.ts` names principals
`e2e-<runId>-…`). So attempt 2 re-derives names attempt 1 already claimed.

That is not hypothetical — it is what shard 4's re-run actually did:

```
FLOW KAAB-7 fail 2192ms attempts=1
REASON: status in [201, 202] — expected [201,202], got 409
 [fail] first runtime context claims the idempotency key
      x1  POST /v1/projects/:projectId/sessions -> 409
      LAST BODY: {"error":"Idempotency key is already in use","code":"IDEMPOTENCY_KEY_CONFLICT"}
```

A healthy flow, reported as a gate failure, in 2.2s, during a release.

**Fix.** Fold `github.run_attempt` into the run-scoped identity:

- `.github/workflows/tests-release.yml` — `KE2E_RUN_ID` gains
  `${{ github.run_attempt != 1 && format('-a{0}', github.run_attempt) || '' }}`.
  The reclaim step reads that SAME variable (`gc --run-id "$KE2E_RUN_ID"`), so
  the sweep stays exactly scoped and a re-run cannot leak its principals.
- `tests/src/core/run-identity.ts` — new dependency-free `runAttemptSuffix()`
  (no `bun:` imports, so the vitest unit lane can load it), used by `newRunId()`
  for the UNPINNED path.

Two deliberate choices:

1. **Attempt 1 is byte-identical to today** (`''`, not `-a1`), so nothing that
   greps existing logs, artifacts, or `ke2e run 32330628092-api1` output changes.
   Only a re-run is namespaced.
2. **A pinned `KE2E_RUN_ID` is returned VERBATIM by `newRunId()`.** The attempt
   is folded in where the variable is SET, never inside the process — appending
   it in `newRunId()` would rename the world out from under its own
   `if: always()` reclaim step, which reads the raw env var, and leak every
   principal the re-run created.

`gc`'s `e2e-%` age-based sweep is untouched: `runIdEmailPrefix` is still
`e2e-<runId>-`, so the general reclaim keeps matching.

New `tests/unit/rerun-identity.test.ts` pins both halves (5 tests): the suffix
function including its malformed-input degrade, and the workflow plumbing
including that the sweep reuses the same variable.

## Verification

- `apps/api` full unit suite: **7712 pass, 74 skip, 0 fail**, 673 files, exit 0
  (`bash scripts/test.sh`).
- `apps/api` `tsc --noEmit`: clean.
- `tests` `tsc --noEmit`: clean.
- `ke2e list`: 446 flows still register.
- `actionlint .github/workflows/tests-release.yml`: clean.
- `tests` unit lane: 351 pass (was 346 — the 5 new rerun-identity tests), with
  the 5 pre-existing failures noted below unchanged.
- SESS-23 predicates replayed against both real recorded transcripts (above).
- SESS-10 root cause and the serializer contract verified against the staging
  DB read-only, with the census and sample rows quoted above.

Not verified, and it cannot be from a branch: the SESS-10 fix against deployed
staging. These flows drive the DEPLOYED API, so the fix only becomes observable
once it is on staging. The offline evidence is the census (0/2804), the daemon's
own auth gate, and the serializer derivation.

## Pre-existing, untouched

- `tests` unit gate is RED on `main` independently of this branch: 5 failures in
  `sandbox-workflow.test.ts` (asserts `KE2E_API_WORKERS: '2'`; the workflow on
  main says `'1'`) and `provisioning-perf.test.ts`. Neither file is in this diff.
- Shard 4's re-run failed a DIFFERENT flow, KAAB-7, with
  `409 IDEMPOTENCY_KEY_CONFLICT`. That was the re-run self-collision, and it is
  fixed by the second deliverable above.
