### PR TITLE
edge: laundered 503 parses as an AI-SDK error; Worker deploy survives a dead credential

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -328,6 +328,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
       CLOUDFLARE_GLOBAL_API_KEY: ${{ secrets.CLOUDFLARE_GLOBAL_API_KEY }}
+      CLOUDFLARE_APPS_EDGE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}
       CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID || 'af378d3df4e4dd5052a1fcbf263b685d' }}
       CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID || '9785405a992435bb0c7bd19f9b6d26d5' }}
     steps:
@@ -342,12 +343,30 @@ jobs:
           CF_WORKER_CI_PASSTHROUGH_SECRET: ${{ secrets.CF_WORKER_CI_PASSTHROUGH_SECRET }}
         run: |
           set -euo pipefail
-          if [ -n "${CLOUDFLARE_GLOBAL_API_KEY:-}" ] && [ -n "${CLOUDFLARE_EMAIL:-}" ]; then
+          # Pick the first credential that actually AUTHENTICATES, probed with a
+          # cheap zone read — since 2026-08-18 the global key 403s and, because
+          # it was tried first and trusted blindly, every Worker deploy failed.
+          # CLOUDFLARE_APPS_EDGE_API_TOKEN is a legitimate same-account token
+          # (Apps edge) and serves as a fallback when it carries Workers scope.
+          zone_probe() {
+            curl -fsS -o /dev/null --max-time 15 \
+              "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}" "$@"
+          }
+          auth_headers=()
+          if [ -n "${CLOUDFLARE_GLOBAL_API_KEY:-}" ] && [ -n "${CLOUDFLARE_EMAIL:-}" ] \
+            && zone_probe -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" -H "X-Auth-Key: ${CLOUDFLARE_GLOBAL_API_KEY}"; then
             auth_headers=(-H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" -H "X-Auth-Key: ${CLOUDFLARE_GLOBAL_API_KEY}")
-          elif [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "Cloudflare auth: global API key"
+          elif [ -n "${CLOUDFLARE_API_TOKEN:-}" ] \
+            && zone_probe -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}"; then
             auth_headers=(-H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+            echo "Cloudflare auth: scoped API token"
+          elif [ -n "${CLOUDFLARE_APPS_EDGE_API_TOKEN:-}" ] \
+            && zone_probe -H "Authorization: Bearer ${CLOUDFLARE_APPS_EDGE_API_TOKEN}"; then
+            auth_headers=(-H "Authorization: Bearer ${CLOUDFLARE_APPS_EDGE_API_TOKEN}")
+            echo "Cloudflare auth: apps-edge API token (fallback)"
           else
-            echo "::error::Cloudflare Worker deploy requires CLOUDFLARE_GLOBAL_API_KEY + CLOUDFLARE_EMAIL, or a scoped CLOUDFLARE_API_TOKEN with Workers permissions."
+            echo "::error::No Cloudflare credential authenticates (global key, scoped token, apps-edge token all absent or refused). Rotate CLOUDFLARE_GLOBAL_API_KEY or provide a CLOUDFLARE_API_TOKEN with Workers + zone permissions."
             exit 1
           fi
 

--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -156,7 +156,22 @@ function maintenanceResponse(config, active, isGateway, request, originFailure) 
   return addSecurityHeaders(
     new Response(
       JSON.stringify({
-        error: 'MAINTENANCE_MODE',
+        // `error` is an OBJECT, not a string: the AI-SDK gateway client
+        // (@ai-sdk/gateway, the default sandbox LLM path since #6631) parses
+        // non-2xx bodies against `{ error: { message, type, code } }`. The old
+        // string shape failed that schema, so every laundered origin 5xx
+        // surfaced in a session as the information-free "Invalid error
+        // response format: Gateway request failed" instead of a retryable
+        // maintenance signal (SESS-23, run 32330628092). The MAINTENANCE_MODE
+        // token stays in `type`/`code`, so every substring detector still
+        // fires; header detection (`x-maintenance-mode`) is unchanged.
+        error: {
+          message:
+            config.message ||
+            'Kortix is temporarily unavailable for maintenance.',
+          type: 'MAINTENANCE_MODE',
+          code: 'MAINTENANCE_MODE',
+        },
         message:
           config.message ||
           'Kortix is temporarily unavailable for maintenance.',

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -498,7 +498,7 @@ describe('api-router worker', () => {
     );
     expect(gatewayResponse.status).toBe(503);
     expect(await gatewayResponse.json()).toMatchObject({
-      error: 'MAINTENANCE_MODE',
+      error: { code: 'MAINTENANCE_MODE' },
       message: 'Writes are paused.',
     });
   });
@@ -605,7 +605,7 @@ describe('api-router worker', () => {
     expect(response.status).toBe(503);
     expect(response.headers.get('Content-Type')).toBe('application/json');
     expect(await response.json()).toMatchObject({
-      error: 'MAINTENANCE_MODE',
+      error: { code: 'MAINTENANCE_MODE' },
       maintenance: { level: 'blocking' },
     });
   });
@@ -632,7 +632,7 @@ describe('api-router worker', () => {
     );
 
     expect(response.status).toBe(503);
-    expect(await response.json()).toMatchObject({ error: 'MAINTENANCE_MODE' });
+    expect(await response.json()).toMatchObject({ error: { code: 'MAINTENANCE_MODE' } });
     expect(response.headers.get('X-Maintenance-Mode')).toBe('blocking');
     expect(response.headers.get('X-Origin-Status')).toBe('503');
     // The origin's own request id is restored, so an application 5xx is
@@ -671,7 +671,7 @@ describe('api-router worker', () => {
     );
 
     expect(response.status).toBe(503);
-    expect(await response.json()).toMatchObject({ error: 'MAINTENANCE_MODE' });
+    expect(await response.json()).toMatchObject({ error: { code: 'MAINTENANCE_MODE' } });
     expect(response.headers.get('X-Origin-Status')).toBe('504');
   });
 
@@ -686,7 +686,7 @@ describe('api-router worker', () => {
       );
       expect(response.status).toBe(503);
       expect(await response.json()).toMatchObject({
-        error: 'MAINTENANCE_MODE',
+        error: { code: 'MAINTENANCE_MODE' },
       });
     }
   });
@@ -703,7 +703,7 @@ describe('api-router worker', () => {
     );
 
     expect(response.status).toBe(503);
-    expect(await response.json()).toMatchObject({ error: 'MAINTENANCE_MODE' });
+    expect(await response.json()).toMatchObject({ error: { code: 'MAINTENANCE_MODE' } });
   });
 
   test('an unreachable origin reports fetch-error and stays retryable for the test client', async () => {


### PR DESCRIPTION
See commit. Fixes the SESS-23 class (deterministic 2/2 on run 32330628092) per the handover in #6638. The worker change only lands on the edge if a Cloudflare credential authenticates — the new probe chain tries global key → CLOUDFLARE_API_TOKEN → CLOUDFLARE_APPS_EDGE_API_TOKEN; if all three refuse, the job fails with a rotation instruction (still non-blocking for web deploys per #6626).