### PR TITLE
staging: raise the request deadline to 55s (cross-region DB)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -238,7 +238,7 @@ jobs:
               # true origin failure: "Request exceeded the 25s server
               # processing deadline". 55s stays under the 60s ALB idle
               # timeout; browsers still abort at 30s so UX is unchanged; the
-              # release gate's API client budgets are far larger. Prod keeps
+              # release-gate API client budgets are far larger. Prod keeps
               # the 25s default (co-regional DB).
               REQUEST_DEADLINE_MS: "55000"
             }')"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -230,7 +230,17 @@ jobs:
               # run 3 API tasks. Four app connections plus one leader connection
               # per process
               # leaves 12 slots for Supabase services, migrations, and QA.
-              DB_POOL_MAX: "4"
+              DB_POOL_MAX: "4",
+              # Staging-only: the staging DB is in eu-west-2 while ECS is in
+              # us-west-2 (~140ms per round trip), so heavy IAM/team writes
+              # legitimately exceed the 25s default under gate load — with the
+              # edge CI passthrough live, dry-run 32335937697 surfaced the
+              # true origin failure: "Request exceeded the 25s server
+              # processing deadline". 55s stays under the 60s ALB idle
+              # timeout; browsers still abort at 30s so UX is unchanged; the
+              # release gate's API client budgets are far larger. Prod keeps
+              # the 25s default (co-regional DB).
+              REQUEST_DEADLINE_MS: "55000"
             }')"
 
           if [ "$staging_secret_exists" = true ]; then


### PR DESCRIPTION
See commit. Staging-only via the kortix-staging-env bundle overlay; prod default unchanged. Evidence: dry-run 32335937697 shard logs show the deadline 503s verbatim now that the edge passthrough returns true origin bodies.