### PR TITLE
perf(boot): remove fresh-session Git network round trips

### DIFF
--- a/apps/api/src/projects/lib/session-runtime-env.test.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.test.ts
@@ -114,3 +114,51 @@ describe('buildSessionRuntimeEnv — workspace mode', () => {
     }
   });
 });
+
+describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
+  test('sends fresh-session and base-tip hints when the experiment is enabled', () => {
+    const baseSha = 'a'.repeat(40);
+    const env = buildSessionRuntimeEnv({
+      ...BASE_INPUT,
+      fastColdBootEnabled: true,
+      freshSession: true,
+      baseSha,
+    });
+
+    expect(env.KORTIX_SESSION_FRESH).toBe('1');
+    expect(env.KORTIX_BASE_SHA).toBe(baseSha);
+  });
+
+  test('omits both hints when the experiment is disabled', () => {
+    const env = buildSessionRuntimeEnv({
+      ...BASE_INPUT,
+      fastColdBootEnabled: false,
+      freshSession: true,
+      baseSha: 'a'.repeat(40),
+    });
+
+    expect(env).not.toHaveProperty('KORTIX_SESSION_FRESH');
+    expect(env).not.toHaveProperty('KORTIX_BASE_SHA');
+  });
+
+  test('omits both hints for resumed and non-repository sessions', () => {
+    for (const env of [
+      buildSessionRuntimeEnv({
+        ...BASE_INPUT,
+        fastColdBootEnabled: true,
+        freshSession: false,
+        baseSha: 'a'.repeat(40),
+      }),
+      buildSessionRuntimeEnv({
+        ...BASE_INPUT,
+        workspaceMode: 'runtime',
+        fastColdBootEnabled: true,
+        freshSession: true,
+        baseSha: 'a'.repeat(40),
+      }),
+    ]) {
+      expect(env).not.toHaveProperty('KORTIX_SESSION_FRESH');
+      expect(env).not.toHaveProperty('KORTIX_BASE_SHA');
+    }
+  });
+});

--- a/apps/api/src/projects/lib/session-runtime-env.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.ts
@@ -16,6 +16,12 @@ export interface SessionRuntimeEnvInput {
   opencodeModel?: string | null;
   /** Project file delivery mode selected by the session's agent. */
   workspaceMode?: WorkspaceModeV2 | null;
+  /** Enables the rollback-safe fresh-session Git fast path. */
+  fastColdBootEnabled?: boolean;
+  /** True only for a newly-created session branch that still equals base. */
+  freshSession?: boolean;
+  /** Server-resolved base tip used to validate the image-baked scaffold. */
+  baseSha?: string;
   /** Server-compiled OpenCode agent config (JSON string) for a `kortix_version:
    *  2` project — see `compile-agent-config.ts`. `null`/omitted for a v1
    *  project: no key is emitted, so v1 sandbox env is byte-for-byte unchanged. */
@@ -24,17 +30,24 @@ export interface SessionRuntimeEnvInput {
 
 export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<string, string> {
   const allowsFullRepository = workspaceModeAllowsFullRepository(input.workspaceMode);
-  const projectGitEnv: Record<string, string> =
-    allowsFullRepository
+  const projectGitEnv: Record<string, string> = allowsFullRepository
+    ? {
+        KORTIX_REPO_URL: input.repoUrl,
+        KORTIX_DEFAULT_BRANCH: input.baseRef,
+        KORTIX_BASE_REF: input.baseRef,
+        KORTIX_BRANCH_NAME: input.sessionId,
+      }
+    : {};
+  const fastGitBootEnv: Record<string, string> =
+    allowsFullRepository && input.fastColdBootEnabled && input.freshSession
       ? {
-          KORTIX_REPO_URL: input.repoUrl,
-          KORTIX_DEFAULT_BRANCH: input.baseRef,
-          KORTIX_BASE_REF: input.baseRef,
-          KORTIX_BRANCH_NAME: input.sessionId,
+          KORTIX_SESSION_FRESH: '1',
+          ...(input.baseSha ? { KORTIX_BASE_SHA: input.baseSha } : {}),
         }
       : {};
   return {
     ...projectGitEnv,
+    ...fastGitBootEnv,
     KORTIX_PROJECT_ID: input.projectId,
     KORTIX_SESSION_ID: input.sessionId,
     KORTIX_SERVICE_PORT: '8000',

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -529,6 +529,9 @@ export async function buildSessionSandboxEnvVars(input: {
       opencodeModel: input.opencodeModel,
       compiledAgentConfig,
       workspaceMode: input.workspaceMode,
+      fastColdBootEnabled: config.KORTIX_FAST_COLD_BOOT_ENABLED,
+      freshSession: input.freshSession,
+      baseSha: input.baseSha,
     }),
     // The platform coordinator uses API-level delegation and never receives a
     // project checkout. Keep this override after buildSessionRuntimeEnv so the

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -369,7 +369,7 @@ describe('daemon proxy auth gate', () => {
         defaultBranch: 'main',
         branchName: 'session-branch',
         sessionFresh: false,
-    baseSha: undefined,
+        baseSha: undefined,
       }))
 
       // Baked checkout means no clone-credential fetch should happen.
@@ -405,6 +405,7 @@ describe('daemon proxy auth gate', () => {
       git(['-c', 'user.email=test@kortix.dev', '-c', 'user.name=Kortix Test', 'commit', '-m', 'seed'], seed)
       git(['remote', 'add', 'origin', remote], seed)
       git(['push', '-u', 'origin', 'main'], seed)
+      git(['symbolic-ref', 'HEAD', 'refs/heads/main'], remote)
       const baseSha = gitOutput(['-C', seed, 'rev-parse', 'HEAD'])
 
       __setScaffoldRepoPathForTests(remote)

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -20,7 +20,14 @@ import type { Opencode } from '../opencode'
 import { buildOpencodeApp } from '../proxy'
 import { createProjectEnvStore, mergeProjectEnv } from '../project-env'
 import { KORTIX_USER_CONTEXT_HEADER } from '../kortix-user-context'
-import { buildGitAuthArgs, configureGlobalGitIdentity, materializeRepo, __clearCloneTokenCacheForTests, __clearRepoIdentityMemoForTests } from '../git'
+import {
+  __clearCloneTokenCacheForTests,
+  __clearRepoIdentityMemoForTests,
+  __setScaffoldRepoPathForTests,
+  buildGitAuthArgs,
+  configureGlobalGitIdentity,
+  materializeRepo,
+} from '../git'
 
 const TEST_TOKEN = 'test-kortix-token-32-chars-1234567890'
 const TEST_AGENT_ENV_FILE = join(tmpdir(), `kortix-proxy-agent-env-${process.pid}.sh`)
@@ -137,6 +144,7 @@ describe('daemon proxy auth gate', () => {
     // own fetch call count + git-config side effects.
     __clearCloneTokenCacheForTests()
     __clearRepoIdentityMemoForTests()
+    __setScaffoldRepoPathForTests()
     rmSync(TEST_AGENT_ENV_FILE, { force: true })
   })
 
@@ -376,6 +384,57 @@ describe('daemon proxy auth gate', () => {
     } finally {
       globalThis.fetch = originalFetch
       process.env.GIT_CONFIG_GLOBAL = originalGitConfigGlobal
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('materializes a matching fresh scaffold without fetching clone credentials', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-matching-scaffold-'))
+    const originalFetch = globalThis.fetch
+    const requests: string[] = []
+    try {
+      const remote = join(root, 'remote.git')
+      const seed = join(root, 'seed')
+      const target = join(root, 'workspace')
+      git(['init', '--bare', remote])
+      mkdirSync(seed)
+      git(['init'], seed)
+      git(['checkout', '-b', 'main'], seed)
+      writeFileSync(join(seed, 'README.md'), 'shared scaffold\n')
+      git(['add', 'README.md'], seed)
+      git(['-c', 'user.email=test@kortix.dev', '-c', 'user.name=Kortix Test', 'commit', '-m', 'seed'], seed)
+      git(['remote', 'add', 'origin', remote], seed)
+      git(['push', '-u', 'origin', 'main'], seed)
+      const baseSha = gitOutput(['-C', seed, 'rev-parse', 'HEAD'])
+
+      __setScaffoldRepoPathForTests(remote)
+      globalThis.fetch = (async (url: string | URL | Request) => {
+        const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url
+        requests.push(href)
+        return new Response(JSON.stringify({ auth: { token: 'clone-token' } }), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }) as unknown as typeof fetch
+
+      await materializeRepo(baseConfig({
+        autoClone: true,
+        projectId: 'project-123',
+        apiUrl: 'http://api.local/v1',
+        projectTarget: target,
+        repoUrl: remote,
+        defaultBranch: 'main',
+        branchName: 'session-fresh',
+        sessionFresh: true,
+        baseSha,
+      }))
+
+      expect(requests.filter((url) => url.includes('/git/clone-credential'))).toHaveLength(0)
+      expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('shared scaffold\n')
+      expect(gitOutput(['-C', target, 'rev-parse', 'HEAD'])).toBe(baseSha)
+      expect(gitOutput(['-C', target, 'rev-parse', '--abbrev-ref', 'HEAD'])).toBe('session-fresh')
+    } finally {
+      globalThis.fetch = originalFetch
+      __setScaffoldRepoPathForTests()
       rmSync(root, { recursive: true, force: true })
     }
   })

--- a/apps/kortix-sandbox-agent-server/src/git.ts
+++ b/apps/kortix-sandbox-agent-server/src/git.ts
@@ -579,12 +579,6 @@ async function checkoutLocalSessionBranch(target: string, branch: string): Promi
   // session made is force-reset away. `git checkout -B` exits 0 and prints only
   // "Switched to and reset branch", so nothing surfaces; the commits survive
   // solely in a reflog the user is never told about.
-  //
-  // The guard that was meant to prevent re-materializing the wrong content
-  // (`mismatched`, keyed on cfg.sessionFresh + cfg.baseSha) cannot help here:
-  // KORTIX_SESSION_FRESH and KORTIX_BASE_SHA have no producer left in apps/api,
-  // so it is always false and this line always runs.
-  //
   // So: only CREATE. If the ref already exists, a plain checkout moves HEAD to
   // it and cannot move the ref.
   const exists = await execGit([
@@ -714,7 +708,6 @@ export async function materializeRepo(cfg: Config): Promise<void> {
     await clearDirContents(target)
   }
   {
-    const cloneCredential = await resolveCloneCredential(cfg)
     // Scaffold fast path: the image bakes the canonical starter repo at
     // /opt/kortix/scaffold.git whose root commit is SHARED with every project
     // seeded from the starter (deterministic root — comp git-backends/seed.ts).
@@ -724,16 +717,24 @@ export async function materializeRepo(cfg: Config): Promise<void> {
     // dev tunnel, 2026-06-13). Imported repos / other starters share no
     // ancestor → the fetch degrades to a full pack (same as a clone); ANY
     // failure falls through to the battle-tested clone path below.
-    if (await tryScaffoldDeltaFetch(cfg, target, base, cloneCredential)) {
+    if (await tryScaffoldDeltaFetch(cfg, target, base)) {
       if (cfg.branchName) {
         // Fresh session → branch == base, create it LOCALLY (zero network).
         // Restart/resume → the remote branch may carry the agent's commits.
         if (cfg.sessionFresh) await checkoutLocalSessionBranch(target, cfg.branchName)
-        else await checkoutSessionBranch(cfg, target, cfg.branchName, cloneCredential)
+        else {
+          await checkoutSessionBranch(
+            cfg,
+            target,
+            cfg.branchName,
+            await resolveCloneCredential(cfg),
+          )
+        }
       }
       await configureRepoGitIdentity(cfg, target)
       return
     }
+    const cloneCredential = await resolveCloneCredential(cfg)
     const tmpTarget = await createStagePath(target, 'clone')
     await rm(tmpTarget, { recursive: true, force: true })
     logger.info('[git] cloning repo', {
@@ -884,7 +885,12 @@ export function scheduleHistoryBackfill(cfg: Config, target: string): void {
   })()
 }
 
-const SCAFFOLD_REPO_PATH = '/opt/kortix/scaffold.git'
+const DEFAULT_SCAFFOLD_REPO_PATH = '/opt/kortix/scaffold.git'
+let scaffoldRepoPath = DEFAULT_SCAFFOLD_REPO_PATH
+
+export function __setScaffoldRepoPathForTests(path?: string): void {
+  scaffoldRepoPath = path ?? DEFAULT_SCAFFOLD_REPO_PATH
+}
 
 /**
  * Seed-only: materialize the image-baked scaffold at `target` with ZERO network,
@@ -898,12 +904,12 @@ const SCAFFOLD_REPO_PATH = '/opt/kortix/scaffold.git'
  * working tree matches what a fresh session expects.
  */
 export async function materializeScaffoldSeed(target: string, base: string): Promise<boolean> {
-  if (!existsSync(SCAFFOLD_REPO_PATH)) return false
+  if (!existsSync(scaffoldRepoPath)) return false
   const tmp = await createStagePath(target, 'seed')
   const t0 = Date.now()
   try {
     await rm(tmp, { recursive: true, force: true })
-    const cloned = await execGit(['clone', '-q', SCAFFOLD_REPO_PATH, tmp])
+    const cloned = await execGit(['clone', '-q', scaffoldRepoPath, tmp])
     if (cloned.code !== 0) throw new Error(`seed scaffold clone: ${cloned.stderr}`)
     const co = await execGit(['-C', tmp, 'checkout', '-q', '-B', base, 'HEAD'])
     if (co.code !== 0) throw new Error(`seed checkout base: ${co.stderr}`)
@@ -959,14 +965,13 @@ async function tryScaffoldDeltaFetch(
   cfg: Config,
   target: string,
   base: string,
-  cloneCredential: CloneCredential | undefined,
 ): Promise<boolean> {
-  if (!existsSync(SCAFFOLD_REPO_PATH) || !cfg.repoUrl) return false
+  if (!existsSync(scaffoldRepoPath) || !cfg.repoUrl) return false
   const tmp = await createStagePath(target, 'scaffold')
   const t0 = Date.now()
   try {
     await rm(tmp, { recursive: true, force: true })
-    const local = await execGit(['clone', '-q', SCAFFOLD_REPO_PATH, tmp])
+    const local = await execGit(['clone', '-q', scaffoldRepoPath, tmp])
     if (local.code !== 0) throw new Error(`local scaffold clone: ${local.stderr}`)
     const su = await execGit(['-C', tmp, 'remote', 'set-url', 'origin', cfg.repoUrl])
     if (su.code !== 0) throw new Error(`set-url: ${su.stderr}`)
@@ -985,6 +990,7 @@ async function tryScaffoldDeltaFetch(
       logger.info('[git] repo materialized via scaffold (zero-network: baked scaffold == base tip)', { ms: Date.now() - t0, base, head: localHead })
       return true
     }
+    const cloneCredential = await resolveCloneCredential(cfg)
     const fetched = await gitWithAuth(cloneCredential, cfg.repoUrl, [
       '-C', tmp,
       '-c', 'http.lowSpeedLimit=1000', '-c', 'http.lowSpeedTime=12',

--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -1,60 +1,54 @@
-# Platinum create-time secret arming
+# Fast cold boot experiment
 
 Status: enabled on dev behind `KORTIX_FAST_COLD_BOOT_ENABLED`.
 
 ## Problem
 
-Platinum used two sequential API operations for every session:
+A five-session dev sample on 2026-08-20 measured repository materialization at
+7,983 ms p50 and 17,251 ms p90. The sandbox image already contains the canonical
+starter repository at `/opt/kortix/scaffold.git`, but the API did not send the
+fresh-session or base-tip hints that activate its local fast path.
 
-1. Create the sandbox.
-2. Attach and arm the network-boundary secrets.
+The daemon therefore performed two avoidable network operations:
 
-The second operation cost 18,261 ms at p50 across five measured boots.
-The sandbox could not become active during this operation.
+1. It fetched clone credentials from the API.
+2. It fetched the fresh session branch after repository materialization.
+
+For a project whose base tip equals the baked scaffold, it also performed an
+unnecessary Git negotiation for zero objects.
 
 ## Design
 
-When `KORTIX_FAST_COLD_BOOT_ENABLED=true`, the API prepares the secret replicas first.
-It includes their IDs in Platinum's sandbox-create request.
-Platinum creates the VM and arms its network boundary in the same operation.
+When `KORTIX_FAST_COLD_BOOT_ENABLED=true`, the API sends these hints for a new
+branch workspace:
 
-The API still waits for the returned secret state to become `armed`.
-It deletes the sandbox when arming fails.
-Raw secret values never enter the sandbox.
+- `KORTIX_SESSION_FRESH=1`
+- `KORTIX_BASE_SHA=<server-resolved base tip>` when SHA resolution completes
+  within its existing two-second deadline
 
-The flag does not change the sandbox image.
-It does not create or retain a sandbox pool.
-It does not change Daytona or E2B behavior.
+The daemon uses the hints as follows:
 
-Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy to restore post-create arming.
-This rollback does not require a database migration or sandbox cleanup.
+- A matching scaffold and base tip materialize from local disk.
+- A new session branch is created locally from base.
+- Clone credentials resolve only if a network fetch is required.
+- A missing SHA, a different base tip, an imported repository, or a local
+  scaffold failure uses the existing shallow-clone fallback.
+- Restarted sessions keep the existing remote-branch fetch behavior.
 
-## Local A/B result
+This design creates no sandbox pool. It adds no database state. It changes no
+Git history or push behavior.
 
-Both groups used the same API, Platinum account, project, standard image code, and Cloudflare tunnel.
-Each group contains five successful boots from 2026-08-19.
+## Rollback
 
-| Milestone | Flag off p50 | Flag on p50 | Change |
-|---|---:|---:|---:|
-| Network secret phase | 18,261 ms | 0 ms | -18,261 ms |
-| Sandbox row active | 36,183 ms | 21,315 ms | -14,868 ms |
-| Provider create | 3,096 ms | 3,735 ms | +639 ms |
+Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy the API. The API then
+omits both hints, and the daemon uses the previous network path.
 
-The row-active result includes normal provider and API variance.
-The measured p50 improvement is 41.1%.
+## Verification
 
-The two groups used different per-project cache states after the first group triggered a warm-image bake.
-Runtime-ready time is therefore not a valid direct A/B metric in this sample.
-The host-side secret phase and row-active milestones remain directly measured.
+The sandbox regression test materialized a matching scaffold in 44-47 ms. It
+observed zero clone-credential requests and verified the resulting branch and
+commit. The previous implementation made one clone-credential request before
+the local SHA comparison.
 
-## Next bottleneck
-
-The flag-on cold-image sample measured these p50 guest stages:
-
-| Stage | p50 |
-|---|---:|
-| Repository materialized | 12,265 ms |
-| OpenCode answering | 5,259 ms |
-| Configuration dependencies | 553 ms |
-
-Git clone is the next isolated optimization target.
+The deployed dev benchmark must compare at least five cold sessions after the
+API and sandbox image contain the same merged commit.


### PR DESCRIPTION
## Problem

Cold repository materialization measured 7,983 ms p50 and 17,251 ms p90 on dev. The API already resolved the fresh-session state and base tip, but did not deliver either value to the sandbox.

## Changes

- Deliver fresh-session and base-tip hints under the existing KORTIX_FAST_COLD_BOOT_ENABLED flag.
- Create a new session branch locally instead of fetching its identical remote branch.
- Use the image-baked scaffold without a Git negotiation when its commit equals the base tip.
- Resolve clone credentials only when a network fetch is required.
- Keep the existing shallow-clone and resumed-session paths unchanged.
- Document rollback and verification.

No sandbox pool is added. No database state changes.

## Verification

- API default suite: 7,713 passed, 74 skipped, 0 failed.
- Sandbox agent server full suite: passed.
- API typecheck: passed.
- Sandbox agent typecheck: passed.
- Sandbox Linux binary build: passed, 95,615,104 bytes.
- Fresh matching scaffold regression: 47 ms local materialization, zero clone-credential requests, expected commit and branch.

## Rollback

Set KORTIX_FAST_COLD_BOOT_ENABLED=false and redeploy the API.
