### PR TITLE
perf(boot): deliver exact Git delta during sandbox creation

### DIFF
--- a/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
+++ b/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
@@ -186,6 +186,9 @@ mock.module('../projects/git', () => ({
   getFileHistory: async () => ({ entries: [], nextCursor: null }),
   // Used by snapshots/builder + the snapshots HTTP surface in projects/index.
   resolveCommitSha: async () => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  resolveFastBootGitHint: async () => ({
+    baseSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  }),
   resolveTreeOid: async () => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
   materializeRepoContext: async () => '/tmp/fake-snapshot-context',
   resolveBranchTip: async () => 'a'.repeat(40),

--- a/apps/api/src/__tests__/e2e-project-limit.test.ts
+++ b/apps/api/src/__tests__/e2e-project-limit.test.ts
@@ -135,6 +135,7 @@ mock.module('../projects/git', () => ({
   getCommitDiff: async () => null,
   getFileHistory: async () => ({ entries: [], nextCursor: null }),
   resolveCommitSha: async () => 'a'.repeat(40),
+  resolveFastBootGitHint: async () => ({ baseSha: 'a'.repeat(40) }),
   resolveTreeOid: async () => 'b'.repeat(40),
   materializeRepoContext: async () => '/tmp/fake-snapshot-context',
   resolveBranchTip: async () => 'a'.repeat(40),

--- a/apps/api/src/__tests__/e2e-project-maintenance.test.ts
+++ b/apps/api/src/__tests__/e2e-project-maintenance.test.ts
@@ -94,6 +94,7 @@ mock.module('../projects/git', () => ({
   getFileHistory: async () => ({ entries: [], nextCursor: null }),
   getFileAtRef: async () => null,
   resolveCommitSha: async () => 'a'.repeat(40),
+  resolveFastBootGitHint: async () => ({ baseSha: 'a'.repeat(40) }),
   resolveTreeOid: async () => 'b'.repeat(40),
   materializeRepoContext: async () => '/tmp/fake-snapshot-context',
   resolveBranchTip: async () => 'a'.repeat(40),

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -283,6 +283,10 @@ mock.module('../projects/git', () => ({
   getFileHistory: async () => ({ entries: [], nextCursor: null }),
   getFileAtRef: async () => null,
   resolveCommitSha: async () => 'a'.repeat(40),
+  resolveFastBootGitHint: async () => ({
+    baseSha: 'a'.repeat(40),
+    gitDeltaBundleBase64: 'R0lUIEJVTkRMRQ==',
+  }),
   resolveBranchTip: async () => 'a'.repeat(40),
   resolveBranchAheadState: async () => ({ ahead: 0, behind: 0 }),
   getBranchDiff: async () => ({ files: [], diff: '' }),

--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -177,6 +177,7 @@ mock.module('../projects/git', () => ({
     mirrorInvalidationCalls += 1;
   },
   resolveCommitSha: async () => 'a'.repeat(40),
+  resolveFastBootGitHint: async () => ({ baseSha: 'a'.repeat(40) }),
   resolveBranchTip: async () => 'a'.repeat(40),
   getBranchDiff: async () => ({ files: [], diff: '' }),
   getDiffBetweenShas: async () => ({ files: [], diff: '' }),

--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -267,6 +267,7 @@ mock.module('../projects/git', () => ({
   getFileHistory: async () => ({ entries: [], nextCursor: null }),
   invalidateProjectMirror: () => {},
   resolveCommitSha: async () => 'a'.repeat(40),
+  resolveFastBootGitHint: async () => ({ baseSha: 'a'.repeat(40) }),
   resolveBranchTip: async () => 'a'.repeat(40),
   getBranchDiff: async () => ({ files: [], diff: '' }),
   getDiffBetweenShas: async () => ({ files: [], diff: '' }),

--- a/apps/api/src/__tests__/e2e-projects-provision.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-provision.test.ts
@@ -173,6 +173,7 @@ mock.module('../projects/git', () => ({
   getCommitDiff: async () => null,
   getFileHistory: async () => ({ entries: [], nextCursor: null }),
   resolveCommitSha: async () => 'a'.repeat(40),
+  resolveFastBootGitHint: async () => ({ baseSha: 'a'.repeat(40) }),
   resolveTreeOid: async () => 'b'.repeat(40),
   materializeRepoContext: async () => '/tmp/fake-snapshot-context',
   resolveBranchTip: async () => 'a'.repeat(40),

--- a/apps/api/src/projects/git.ts
+++ b/apps/api/src/projects/git.ts
@@ -58,6 +58,8 @@ export {
 
 export {
   resolveCommitSha,
+  resolveFastBootGitHint,
+  buildSingleParentDeltaBundle,
   listCommits,
   getCommit,
   getCommitDiff,

--- a/apps/api/src/projects/git/commits.ts
+++ b/apps/api/src/projects/git/commits.ts
@@ -2,6 +2,9 @@
 // LOG_FORMAT, parseLogStdout, decodeStatusChar) used by branches.ts and
 // merge.ts as well.
 
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { validateRef, validateSha } from '../git-ref';
 import { normalizeTreePath, refreshMirror, runGit } from './mirror';
 import type {
@@ -16,6 +19,7 @@ import type {
 
 export const FIELD_SEP = '';
 export const RECORD_SEP = '';
+export const MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES = 24 * 1024;
 export const LOG_FORMAT = [
   '%H',
   '%h',
@@ -100,6 +104,75 @@ export async function resolveCommitSha(project: GitBackedProject, ref?: string):
     throw new Error(`Unexpected git rev-parse output for ${treeRef}: ${sha}`);
   }
   return sha;
+}
+
+export interface FastBootGitHint {
+  baseSha: string;
+  gitDeltaBundleBase64?: string;
+}
+
+/**
+ * Build a bundle containing only a branch tip's single commit above its first
+ * parent. The sandbox image already owns the parent scaffold, so this payload
+ * supplies the exact remote commit without an in-sandbox fetch.
+ */
+export async function buildSingleParentDeltaBundle(
+  repoPath: string,
+  ref: string,
+): Promise<{ baseSha: string; parentSha: string; bundleBase64: string } | null> {
+  const treeRef = validateRef(ref);
+  const revision = await runGit(
+    ['rev-list', '--parents', '-n', '1', treeRef],
+    repoPath,
+    false,
+  );
+  const [baseSha, ...parents] = revision.stdout.trim().split(/\s+/);
+  if (!baseSha || !/^[0-9a-f]{40}$/.test(baseSha) || parents.length !== 1) return null;
+  const parentSha = parents[0]!;
+  const temp = await mkdtemp(join(tmpdir(), 'kortix-fast-boot-bundle-'));
+  const bundlePath = join(temp, 'delta.bundle');
+  try {
+    await runGit(
+      ['bundle', 'create', bundlePath, `refs/heads/${treeRef}`, `^${parentSha}`],
+      repoPath,
+      false,
+    );
+    const bundleBase64 = (await readFile(bundlePath)).toString('base64');
+    if (Buffer.byteLength(bundleBase64, 'utf8') > MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES) {
+      return null;
+    }
+    return { baseSha, parentSha, bundleBase64 };
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+}
+
+/** Resolve the base tip and attach a bounded local-mirror delta when possible. */
+export async function resolveFastBootGitHint(
+  project: GitBackedProject,
+  ref?: string,
+): Promise<FastBootGitHint> {
+  const treeRef = validateRef(ref || project.defaultBranch);
+  const repoPath = await refreshMirror(project);
+  const baseSha = (
+    await runGit(['rev-parse', '--verify', `${treeRef}^{commit}`], repoPath, false)
+  ).stdout.trim();
+  if (!/^[0-9a-f]{40}$/.test(baseSha)) {
+    throw new Error(`Unexpected git rev-parse output for ${treeRef}: ${baseSha}`);
+  }
+  try {
+    const delta = await buildSingleParentDeltaBundle(repoPath, treeRef);
+    return delta?.baseSha === baseSha
+      ? { baseSha, gitDeltaBundleBase64: delta.bundleBase64 }
+      : { baseSha };
+  } catch (error) {
+    console.warn('[git] fast-boot delta bundle unavailable', {
+      projectId: project.projectId,
+      ref: treeRef,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { baseSha };
+  }
 }
 
 export async function listCommits(

--- a/apps/api/src/projects/git/fast-boot-bundle.test.ts
+++ b/apps/api/src/projects/git/fast-boot-bundle.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+import { buildProjectSeedFiles } from '../seed-files';
+import { buildSingleParentDeltaBundle } from './commits';
+
+function git(args: string[], cwd: string, env?: Record<string, string>): string {
+  return execFileSync('git', args, {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  }).trim();
+}
+
+describe('buildSingleParentDeltaBundle', () => {
+  test('packages one exact commit on top of an image-baked parent', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-fast-boot-bundle-'));
+    try {
+      const source = join(root, 'source');
+      const scaffoldRepo = join(root, 'scaffold.git');
+      const scaffold = join(root, 'scaffold');
+      mkdirSync(source);
+      git(['init', '-b', 'main'], source);
+      writeFileSync(join(source, 'README.md'), 'generic scaffold\n');
+      git(['add', 'README.md'], source);
+      git(['commit', '-m', 'chore: scaffold Kortix project'], source, {
+        GIT_AUTHOR_NAME: 'Kortix',
+        GIT_AUTHOR_EMAIL: 'noreply@kortix.ai',
+        GIT_COMMITTER_NAME: 'Kortix',
+        GIT_COMMITTER_EMAIL: 'noreply@kortix.ai',
+      });
+      const scaffoldSha = git(['rev-parse', 'HEAD'], source);
+      git(['clone', '--bare', source, scaffoldRepo], root);
+
+      writeFileSync(join(source, 'README.md'), 'customer project\n');
+      git(['add', 'README.md'], source);
+      git(['commit', '-m', 'chore: project setup'], source, {
+        GIT_AUTHOR_NAME: 'Kortix',
+        GIT_AUTHOR_EMAIL: 'noreply@kortix.ai',
+        GIT_COMMITTER_NAME: 'Kortix',
+        GIT_COMMITTER_EMAIL: 'noreply@kortix.ai',
+      });
+      const baseSha = git(['rev-parse', 'HEAD'], source);
+
+      const bundle = await buildSingleParentDeltaBundle(source, 'main');
+      expect(bundle?.baseSha).toBe(baseSha);
+      expect(bundle?.parentSha).toBe(scaffoldSha);
+      expect(bundle?.bundleBase64.length).toBeGreaterThan(0);
+
+      git(['clone', '-q', scaffoldRepo, scaffold], root);
+      const bundlePath = join(root, 'delta.bundle');
+      writeFileSync(bundlePath, Buffer.from(bundle!.bundleBase64, 'base64'));
+      git(['bundle', 'unbundle', bundlePath], scaffold);
+      git(['checkout', '-q', '-B', 'main', baseSha], scaffold);
+
+      expect(git(['rev-parse', 'HEAD'], scaffold)).toBe(baseSha);
+      expect(readFileSync(join(scaffold, 'README.md'), 'utf8')).toBe('customer project\n');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('keeps the current managed starter delta below the sandbox env limit', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-starter-fast-boot-bundle-'));
+    try {
+      const source = join(root, 'source');
+      mkdirSync(source);
+      git(['init', '-b', 'main'], source);
+      const seed = await buildProjectSeedFiles({
+        projectName: 'Boot Benchmark',
+        repoFullName: 'boot-benchmark-project-id',
+        template: 'general-knowledge-worker',
+        marketplaceItems: [],
+        now: '2026-08-20T00:00:00.000Z',
+      });
+      for (const file of seed.baseFiles) {
+        const path = join(source, file.path);
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, file.content);
+      }
+      git(['add', '-A'], source);
+      git(['commit', '-m', 'chore: scaffold Kortix project'], source, {
+        GIT_AUTHOR_NAME: 'Kortix',
+        GIT_AUTHOR_EMAIL: 'noreply@kortix.ai',
+        GIT_COMMITTER_NAME: 'Kortix',
+        GIT_COMMITTER_EMAIL: 'noreply@kortix.ai',
+      });
+      for (const file of seed.files) {
+        const path = join(source, file.path);
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, file.content);
+      }
+      git(['add', '-A'], source);
+      git(['commit', '-m', 'chore: project setup'], source, {
+        GIT_AUTHOR_NAME: 'Kortix',
+        GIT_AUTHOR_EMAIL: 'noreply@kortix.ai',
+        GIT_COMMITTER_NAME: 'Kortix',
+        GIT_COMMITTER_EMAIL: 'noreply@kortix.ai',
+      });
+
+      const bundle = await buildSingleParentDeltaBundle(source, 'main');
+      expect(bundle).not.toBeNull();
+      expect(bundle!.bundleBase64.length).toBeLessThanOrEqual(24 * 1024);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/api/src/projects/lib/session-runtime-env.test.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.test.ts
@@ -118,15 +118,18 @@ describe('buildSessionRuntimeEnv — workspace mode', () => {
 describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
   test('sends fresh-session and base-tip hints when the experiment is enabled', () => {
     const baseSha = 'a'.repeat(40);
+    const gitDeltaBundleBase64 = 'R0lUIEJVTkRMRQ==';
     const env = buildSessionRuntimeEnv({
       ...BASE_INPUT,
       fastColdBootEnabled: true,
       freshSession: true,
       baseSha,
+      gitDeltaBundleBase64,
     });
 
     expect(env.KORTIX_SESSION_FRESH).toBe('1');
     expect(env.KORTIX_BASE_SHA).toBe(baseSha);
+    expect(env.KORTIX_GIT_DELTA_BUNDLE_BASE64).toBe(gitDeltaBundleBase64);
   });
 
   test('omits both hints when the experiment is disabled', () => {
@@ -135,10 +138,12 @@ describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
       fastColdBootEnabled: false,
       freshSession: true,
       baseSha: 'a'.repeat(40),
+      gitDeltaBundleBase64: 'R0lUIEJVTkRMRQ==',
     });
 
     expect(env).not.toHaveProperty('KORTIX_SESSION_FRESH');
     expect(env).not.toHaveProperty('KORTIX_BASE_SHA');
+    expect(env).not.toHaveProperty('KORTIX_GIT_DELTA_BUNDLE_BASE64');
   });
 
   test('omits both hints for resumed and non-repository sessions', () => {
@@ -148,6 +153,7 @@ describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
         fastColdBootEnabled: true,
         freshSession: false,
         baseSha: 'a'.repeat(40),
+        gitDeltaBundleBase64: 'R0lUIEJVTkRMRQ==',
       }),
       buildSessionRuntimeEnv({
         ...BASE_INPUT,
@@ -155,10 +161,12 @@ describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
         fastColdBootEnabled: true,
         freshSession: true,
         baseSha: 'a'.repeat(40),
+        gitDeltaBundleBase64: 'R0lUIEJVTkRMRQ==',
       }),
     ]) {
       expect(env).not.toHaveProperty('KORTIX_SESSION_FRESH');
       expect(env).not.toHaveProperty('KORTIX_BASE_SHA');
+      expect(env).not.toHaveProperty('KORTIX_GIT_DELTA_BUNDLE_BASE64');
     }
   });
 });

--- a/apps/api/src/projects/lib/session-runtime-env.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.ts
@@ -22,6 +22,8 @@ export interface SessionRuntimeEnvInput {
   freshSession?: boolean;
   /** Server-resolved base tip used to validate the image-baked scaffold. */
   baseSha?: string;
+  /** Bounded Git bundle containing the exact base-tip commit above the baked scaffold. */
+  gitDeltaBundleBase64?: string;
   /** Server-compiled OpenCode agent config (JSON string) for a `kortix_version:
    *  2` project — see `compile-agent-config.ts`. `null`/omitted for a v1
    *  project: no key is emitted, so v1 sandbox env is byte-for-byte unchanged. */
@@ -43,6 +45,9 @@ export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<st
       ? {
           KORTIX_SESSION_FRESH: '1',
           ...(input.baseSha ? { KORTIX_BASE_SHA: input.baseSha } : {}),
+          ...(input.gitDeltaBundleBase64
+            ? { KORTIX_GIT_DELTA_BUNDLE_BASE64: input.gitDeltaBundleBase64 }
+            : {}),
         }
       : {};
   return {

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -49,7 +49,7 @@ import {
   sandboxFromLoadedAgents,
   workspaceFromLoadedAgents,
 } from '../agents';
-import { createRemoteSessionBranch, resolveCommitSha } from '../git';
+import { createRemoteSessionBranch, resolveFastBootGitHint } from '../git';
 import { convertPendingPromptToInboxRow } from '../session-lifecycle/pending-prompt';
 import { resolveSessionSecretGrant } from './secret-grant';
 import {
@@ -302,14 +302,11 @@ export async function buildSessionSandboxEnvVars(input: {
    *  through the dev tunnel (2026-06-13). Restart/resume omit it (their branch
    *  may carry the agent's pushed commits → real fetch needed). */
   freshSession?: boolean;
-  /** The project's base-branch tip SHA, resolved server-side (no tunnel). When
-   *  it equals the image-baked scaffold's root SHA — true for a fresh project
-   *  seeded from the starter with no per-project commit — the daemon skips the
-   *  in-guest `git fetch` ENTIRELY (the baked scaffold already IS base), turning
-   *  repo materialization into a pure-local op. That fetch is a zero-object
-   *  negotiation round-trip that still hung for 34s through the flaky dev tunnel
-   *  (2026-06-13). Omitted → daemon delta-fetches as before. */
+  /** The project's base-branch tip SHA, resolved from the API's Git mirror. */
   baseSha?: string;
+  /** Bounded exact commit delta from the API mirror. The daemon imports it on
+   *  top of the baked scaffold and verifies `baseSha` before use. */
+  gitDeltaBundleBase64?: string;
   /** Project git context, so the running agent's `secrets` grant in `agents:`
    *  can be resolved and applied by IDENTIFIER — secrets the agent isn't
    *  granted are dropped from the injected env (a prompt-injected agent then
@@ -532,6 +529,7 @@ export async function buildSessionSandboxEnvVars(input: {
       fastColdBootEnabled: config.KORTIX_FAST_COLD_BOOT_ENABLED,
       freshSession: input.freshSession,
       baseSha: input.baseSha,
+      gitDeltaBundleBase64: input.gitDeltaBundleBase64,
     }),
     // The platform coordinator uses API-level delegation and never receives a
     // project checkout. Keep this override after buildSessionRuntimeEnv so the
@@ -1488,17 +1486,18 @@ export async function createProjectSession(input: {
         tl.mark('git-auth');
         return gitProject;
       });
-      // Resolve the base-branch tip SHA server-side (no tunnel) so the daemon
-      // can skip the in-guest fetch when the baked scaffold already IS base.
+      // Resolve the base tip from the API's existing mirror and package its
+      // one-commit scaffold delta. This moves the small object transfer into
+      // sandbox creation and removes the slow in-guest Git negotiation.
       // Best-effort + timeout-guarded (never block create): on failure/timeout
       // the hint is omitted → daemon delta-fetches as before. Runs CONCURRENTLY
       // with gitAuth (folded into the env-build chain, not awaited inline).
-      const baseShaPromise = Promise.race([
-        resolveCommitSha(project, baseRef).catch(() => undefined),
+      const fastBootGitHintPromise = Promise.race([
+        resolveFastBootGitHint(project, baseRef).catch(() => undefined),
         new Promise<undefined>((r) => setTimeout(() => r(undefined), 2000)),
       ]);
-      const envPromise = baseShaPromise
-        .then((baseSha) =>
+      const envPromise = fastBootGitHintPromise
+        .then((fastBootGitHint) =>
           buildSessionSandboxEnvVars({
             accountId,
             projectId,
@@ -1513,7 +1512,8 @@ export async function createProjectSession(input: {
             llmGatewayEnabled,
             platformMetaAgent,
             freshSession: true,
-            baseSha,
+            baseSha: fastBootGitHint?.baseSha,
+            gitDeltaBundleBase64: fastBootGitHint?.gitDeltaBundleBase64,
             defaultBranch: project.defaultBranch,
             manifestPath: project.manifestPath,
             workspaceMode,

--- a/apps/api/src/projects/provision-core.ts
+++ b/apps/api/src/projects/provision-core.ts
@@ -546,14 +546,10 @@ export async function runProvision(ctx: ProvisionContext, emit: ProvisionEmit): 
             marketplaceItems,
             now: now.toISOString(),
           });
-      // Seed the project tip == the deterministic scaffold root (the constant
-      // 'kortix-project' render), byte-identical to the image-baked scaffold
-      // (snapshots/build-context.ts). This lets a fresh session's fork REUSE
-      // the warm-seed's already-opencode-initialized /workspace with ZERO
-      // network (git.ts baked-checkout reuse fires when baseSha == scaffold
-      // root) — the single biggest spawn-latency win. The per-project name
-      // customization is applied in-sandbox at fork (not committed to the
-      // shared remote root) so the warm reuse is never broken by a divergent tip.
+      // Seed a deterministic scaffold root followed by the project's small
+      // customization commit. Fresh-session boot can import that exact second
+      // commit from the API mirror as a bounded Git bundle, on top of the
+      // image-baked root, without an in-sandbox network fetch.
       await pushVerifiedSeed({
         projectId: row.projectId,
         branch: provisioned.defaultBranch,

--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-latency.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-latency.test.ts
@@ -42,6 +42,14 @@ afterEach(async () => {
 })
 
 describe('clone depth configuration', () => {
+  test('loads the API-provided fast-boot Git delta bundle', () => {
+    const cfg = loadConfig({
+      ...BASE_ENV,
+      KORTIX_GIT_DELTA_BUNDLE_BASE64: 'R0lUIEJVTkRMRQ==',
+    } as NodeJS.ProcessEnv)
+    expect(cfg.gitDeltaBundleBase64).toBe('R0lUIEJVTkRMRQ==')
+  })
+
   test('defaults to a shallow depth-1 clone', () => {
     expect(loadConfig(BASE_ENV as NodeJS.ProcessEnv).cloneDepth).toBe(1)
   })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -51,6 +51,7 @@ function baseConfig(over: Partial<Config> = {}): Config {
     branchName: undefined,
     sessionFresh: false,
     baseSha: undefined,
+    gitDeltaBundleBase64: undefined,
     sandboxToken: TEST_TOKEN,
     gitUserName: 'Kortix Agent',
     gitUserEmail: 'agent@kortix.ai',
@@ -433,6 +434,113 @@ describe('daemon proxy auth gate', () => {
       expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('shared scaffold\n')
       expect(gitOutput(['-C', target, 'rev-parse', 'HEAD'])).toBe(baseSha)
       expect(gitOutput(['-C', target, 'rev-parse', '--abbrev-ref', 'HEAD'])).toBe('session-fresh')
+    } finally {
+      globalThis.fetch = originalFetch
+      __setScaffoldRepoPathForTests()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('materializes an exact fresh-project delta bundle without fetching clone credentials', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-delta-bundle-scaffold-'))
+    const originalFetch = globalThis.fetch
+    const requests: string[] = []
+    try {
+      const source = join(root, 'source')
+      const scaffold = join(root, 'scaffold.git')
+      const target = join(root, 'workspace')
+      const bundlePath = join(root, 'delta.bundle')
+      mkdirSync(source)
+      git(['init', '-b', 'main'], source)
+      writeFileSync(join(source, 'README.md'), 'generic scaffold\n')
+      git(['add', 'README.md'], source)
+      git(['-c', 'user.email=noreply@kortix.ai', '-c', 'user.name=Kortix', 'commit', '-m', 'scaffold'], source)
+      const scaffoldSha = gitOutput(['-C', source, 'rev-parse', 'HEAD'])
+      git(['clone', '--bare', source, scaffold])
+
+      writeFileSync(join(source, 'README.md'), 'customer project\n')
+      git(['add', 'README.md'], source)
+      git(['-c', 'user.email=noreply@kortix.ai', '-c', 'user.name=Kortix', 'commit', '-m', 'project setup'], source)
+      const baseSha = gitOutput(['-C', source, 'rev-parse', 'HEAD'])
+      git(['bundle', 'create', bundlePath, 'refs/heads/main', `^${scaffoldSha}`], source)
+
+      __setScaffoldRepoPathForTests(scaffold)
+      globalThis.fetch = (async (url: string | URL | Request) => {
+        const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url
+        requests.push(href)
+        return new Response(JSON.stringify({ auth: { token: 'clone-token' } }), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }) as unknown as typeof fetch
+
+      await materializeRepo(baseConfig({
+        autoClone: true,
+        projectId: 'project-123',
+        apiUrl: 'http://api.local/v1',
+        projectTarget: target,
+        repoUrl: source,
+        defaultBranch: 'main',
+        branchName: 'session-fresh',
+        sessionFresh: true,
+        baseSha,
+        gitDeltaBundleBase64: readFileSync(bundlePath).toString('base64'),
+      }))
+
+      expect(requests.filter((url) => url.includes('/git/clone-credential'))).toHaveLength(0)
+      expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('customer project\n')
+      expect(gitOutput(['-C', target, 'rev-parse', 'HEAD'])).toBe(baseSha)
+      expect(gitOutput(['-C', target, 'rev-parse', '--abbrev-ref', 'HEAD'])).toBe('session-fresh')
+    } finally {
+      globalThis.fetch = originalFetch
+      __setScaffoldRepoPathForTests()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to the authenticated fetch when a delta bundle is invalid', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-invalid-delta-bundle-'))
+    const originalFetch = globalThis.fetch
+    const requests: string[] = []
+    try {
+      const source = join(root, 'source')
+      const scaffold = join(root, 'scaffold.git')
+      const target = join(root, 'workspace')
+      mkdirSync(source)
+      git(['init', '-b', 'main'], source)
+      writeFileSync(join(source, 'README.md'), 'generic scaffold\n')
+      git(['add', 'README.md'], source)
+      git(['-c', 'user.email=noreply@kortix.ai', '-c', 'user.name=Kortix', 'commit', '-m', 'scaffold'], source)
+      git(['clone', '--bare', source, scaffold])
+      writeFileSync(join(source, 'README.md'), 'remote truth\n')
+      git(['add', 'README.md'], source)
+      git(['-c', 'user.email=noreply@kortix.ai', '-c', 'user.name=Kortix', 'commit', '-m', 'project setup'], source)
+      const baseSha = gitOutput(['-C', source, 'rev-parse', 'HEAD'])
+
+      __setScaffoldRepoPathForTests(scaffold)
+      globalThis.fetch = (async (url: string | URL | Request) => {
+        const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url
+        requests.push(href)
+        return new Response(JSON.stringify({ auth: { token: 'clone-token' } }), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }) as unknown as typeof fetch
+
+      await materializeRepo(baseConfig({
+        autoClone: true,
+        projectId: 'project-123',
+        apiUrl: 'http://api.local/v1',
+        projectTarget: target,
+        repoUrl: source,
+        defaultBranch: 'main',
+        branchName: 'session-fresh',
+        sessionFresh: true,
+        baseSha,
+        gitDeltaBundleBase64: Buffer.from('not a git bundle').toString('base64'),
+      }))
+
+      expect(requests.filter((url) => url.includes('/git/clone-credential'))).toHaveLength(1)
+      expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('remote truth\n')
+      expect(gitOutput(['-C', target, 'rev-parse', 'HEAD'])).toBe(baseSha)
     } finally {
       globalThis.fetch = originalFetch
       __setScaffoldRepoPathForTests()

--- a/apps/kortix-sandbox-agent-server/src/config.ts
+++ b/apps/kortix-sandbox-agent-server/src/config.ts
@@ -56,6 +56,7 @@ const Schema = z.object({
   KORTIX_BRANCH_NAME: z.string().optional(),
   KORTIX_SESSION_FRESH: z.string().optional(),
   KORTIX_BASE_SHA: z.string().optional(),
+  KORTIX_GIT_DELTA_BUNDLE_BASE64: z.string().optional(),
   // The sandbox credential. KORTIX_SANDBOX_TOKEN is canonical; KORTIX_TOKEN is
   // the legacy alias (resolved with a fallback below).
   KORTIX_SANDBOX_TOKEN: z.string().optional(),
@@ -120,6 +121,7 @@ export type Config = {
   branchName: string | undefined
   sessionFresh: boolean
   baseSha: string | undefined
+  gitDeltaBundleBase64?: string
   /** The sandbox credential (HMAC key + sandbox-identity route bearer). NOT the
    *  session/user token — see the module doc. */
   sandboxToken: string | undefined
@@ -154,6 +156,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     KORTIX_BRANCH_NAME: env.KORTIX_BRANCH_NAME,
     KORTIX_SESSION_FRESH: env.KORTIX_SESSION_FRESH,
     KORTIX_BASE_SHA: env.KORTIX_BASE_SHA,
+    KORTIX_GIT_DELTA_BUNDLE_BASE64: env.KORTIX_GIT_DELTA_BUNDLE_BASE64,
     KORTIX_SANDBOX_TOKEN: env.KORTIX_SANDBOX_TOKEN,
     KORTIX_TOKEN: env.KORTIX_TOKEN,
     KORTIX_GIT_USER_NAME: env.KORTIX_GIT_USER_NAME,
@@ -183,6 +186,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     branchName: parsed.KORTIX_BRANCH_NAME,
     sessionFresh: parsed.KORTIX_SESSION_FRESH === '1',
     baseSha: parsed.KORTIX_BASE_SHA,
+    gitDeltaBundleBase64: parsed.KORTIX_GIT_DELTA_BUNDLE_BASE64,
     // Canonical name wins; fall back to the legacy alias so daemons running in
     // older-API sandboxes (which only inject KORTIX_TOKEN) still resolve it.
     sandboxToken: parsed.KORTIX_SANDBOX_TOKEN ?? parsed.KORTIX_TOKEN,

--- a/apps/kortix-sandbox-agent-server/src/git.ts
+++ b/apps/kortix-sandbox-agent-server/src/git.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { mkdir, readdir, rename, rm, stat } from 'node:fs/promises'
+import { mkdir, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 
 import type { Config } from './config'
@@ -990,6 +990,20 @@ async function tryScaffoldDeltaFetch(
       logger.info('[git] repo materialized via scaffold (zero-network: baked scaffold == base tip)', { ms: Date.now() - t0, base, head: localHead })
       return true
     }
+    if (
+      cfg.sessionFresh &&
+      cfg.baseSha &&
+      cfg.gitDeltaBundleBase64 &&
+      await applyFastBootDeltaBundle(tmp, base, cfg.baseSha, cfg.gitDeltaBundleBase64)
+    ) {
+      await swapStageIntoTarget(tmp, target)
+      logger.info('[git] repo materialized via scaffold (zero-network: API delta bundle)', {
+        ms: Date.now() - t0,
+        base,
+        head: cfg.baseSha,
+      })
+      return true
+    }
     const cloneCredential = await resolveCloneCredential(cfg)
     const fetched = await gitWithAuth(cloneCredential, cfg.repoUrl, [
       '-C', tmp,
@@ -1008,6 +1022,47 @@ async function tryScaffoldDeltaFetch(
     })
     await rm(tmp, { recursive: true, force: true }).catch(() => {})
     return false
+  }
+}
+
+const MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES = 24 * 1024
+
+/** Import a bounded API-generated Git bundle only when it resolves to baseSha. */
+async function applyFastBootDeltaBundle(
+  repoPath: string,
+  base: string,
+  baseSha: string,
+  bundleBase64: string,
+): Promise<boolean> {
+  if (!/^[0-9a-f]{40}$/i.test(baseSha)) return false
+  if (
+    bundleBase64.length === 0 ||
+    bundleBase64.length > MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES ||
+    bundleBase64.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]+={0,2}$/.test(bundleBase64)
+  ) return false
+
+  const bytes = Buffer.from(bundleBase64, 'base64')
+  if (bytes.toString('base64') !== bundleBase64) return false
+  const bundlePath = join(repoPath, '.kortix-fast-boot.bundle')
+  try {
+    await writeFile(bundlePath, bytes, { mode: 0o600 })
+    const verified = await execGit(['-C', repoPath, 'bundle', 'verify', bundlePath])
+    if (verified.code !== 0) throw new Error(`bundle verify: ${verified.stderr}`)
+    const imported = await execGit(['-C', repoPath, 'bundle', 'unbundle', bundlePath])
+    if (imported.code !== 0) throw new Error(`bundle unbundle: ${imported.stderr}`)
+    const exists = await execGit(['-C', repoPath, 'cat-file', '-e', `${baseSha}^{commit}`])
+    if (exists.code !== 0) throw new Error('bundle does not contain the expected base commit')
+    const checkout = await execGit(['-C', repoPath, 'checkout', '-q', '-B', base, baseSha])
+    if (checkout.code !== 0) throw new Error(`checkout bundled base: ${checkout.stderr}`)
+    return true
+  } catch (error) {
+    logger.info('[git] API delta bundle unavailable; using authenticated fetch', {
+      error: error instanceof Error ? error.message.slice(0, 200) : String(error),
+    })
+    return false
+  } finally {
+    await rm(bundlePath, { force: true }).catch(() => {})
   }
 }
 

--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -17,6 +17,9 @@ The daemon therefore performed two avoidable network operations:
 For a project whose base tip equals the baked scaffold, it also performed an
 unnecessary Git negotiation for zero objects.
 
+Managed projects normally have one customization commit above the deterministic
+scaffold. The base-tip equality check cannot remove that project's fetch.
+
 ## Design
 
 When `KORTIX_FAST_COLD_BOOT_ENABLED=true`, the API sends these hints for a new
@@ -25,15 +28,23 @@ branch workspace:
 - `KORTIX_SESSION_FRESH=1`
 - `KORTIX_BASE_SHA=<server-resolved base tip>` when SHA resolution completes
   within its existing two-second deadline
+- `KORTIX_GIT_DELTA_BUNDLE_BASE64=<bounded exact commit bundle>` when the base
+  tip is one commit above its parent and the encoded bundle is at most 24 KiB
 
 The daemon uses the hints as follows:
 
 - A matching scaffold and base tip materialize from local disk.
+- A one-commit managed-project tip imports from the API mirror bundle and must
+  resolve to `KORTIX_BASE_SHA` before checkout.
 - A new session branch is created locally from base.
 - Clone credentials resolve only if a network fetch is required.
 - A missing SHA, a different base tip, an imported repository, or a local
   scaffold failure uses the existing shallow-clone fallback.
 - Restarted sessions keep the existing remote-branch fetch behavior.
+
+The bundle is transported with the sandbox creation environment. The daemon
+validates its encoding, size, prerequisite commit, and resulting SHA. Any
+validation failure uses the authenticated fetch path.
 
 This design creates no sandbox pool. It adds no database state. It changes no
 Git history or push behavior.
@@ -41,14 +52,14 @@ Git history or push behavior.
 ## Rollback
 
 Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy the API. The API then
-omits both hints, and the daemon uses the previous network path.
+omits all three hints, and the daemon uses the previous network path.
 
 ## Verification
 
-The sandbox regression test materialized a matching scaffold in 44-47 ms. It
-observed zero clone-credential requests and verified the resulting branch and
-commit. The previous implementation made one clone-credential request before
-the local SHA comparison.
+The sandbox regression test materialized an exact scaffold-plus-bundle checkout
+in 79 ms. It observed zero clone-credential requests and verified the resulting
+branch, content, and commit. The current managed starter's bundle stays below
+the 24 KiB delivery cap.
 
 The deployed dev benchmark must compare at least five cold sessions after the
 API and sandbox image contain the same merged commit.


### PR DESCRIPTION
## Problem

Fresh managed projects have one customization commit above the image-baked scaffold. The sandbox still performs an authenticated Git fetch for that commit, so repository materialization remains about 5.4 seconds p50 on dev.

## Change

- Build a bounded one-commit Git bundle from the API's existing project mirror.
- Deliver it only for fresh repository sessions behind `KORTIX_FAST_COLD_BOOT_ENABLED`.
- Import it on top of `/opt/kortix/scaffold.git` inside the sandbox.
- Verify the bundle prerequisite and exact `KORTIX_BASE_SHA` before checkout.
- Fall back to the existing authenticated fetch for missing, invalid, oversized, or incompatible bundles.
- Keep resumed sessions and non-repository workspaces unchanged.

This adds no running sandbox pool and no database state.

## Local verification

- API typecheck: pass.
- Sandbox daemon typecheck: pass.
- Sandbox Linux compile: pass, 95,619,200-byte binary.
- Focused API, bundle, daemon, fallback, and contract tests: pass.
- Exact local materialization: 79 ms with zero clone-credential requests.
- Invalid bundle: authenticated-fetch fallback returns the exact remote tip.
- Current managed starter delta: within the 24 KiB encoded payload cap.

## Rollback

Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy the API. The API omits all fresh-boot Git hints.
