### PR TITLE
perf(boot): make Git bundle reuse durable

### DIFF
--- a/apps/api/src/projects/git.ts
+++ b/apps/api/src/projects/git.ts
@@ -69,6 +69,7 @@ export {
 export {
   listBranches,
   remoteBranchExists,
+  resolveRemoteBranchTip,
   createRemoteSessionBranch,
   deleteRemoteSessionBranch,
   commitFileToBranch,

--- a/apps/api/src/projects/git/branches.ts
+++ b/apps/api/src/projects/git/branches.ts
@@ -260,6 +260,13 @@ export async function remoteBranchExists(
   project: GitBackedProject,
   branch: string,
 ): Promise<boolean> {
+  return (await resolveRemoteBranchTip(project, branch)) !== null;
+}
+
+export async function resolveRemoteBranchTip(
+  project: GitBackedProject,
+  branch: string,
+): Promise<string | null> {
   const ref = validateRef(branch);
   const result = await runGit(
     ['ls-remote', '--heads', project.repoUrl, `refs/heads/${ref}`],
@@ -271,7 +278,8 @@ export async function remoteBranchExists(
     undefined,
     project.gitAuthHeaders,
   );
-  return result.stdout.trim().length > 0;
+  const [sha, remoteRef] = result.stdout.trim().split(/\s+/);
+  return /^[0-9a-f]{40}$/.test(sha) && remoteRef === `refs/heads/${ref}` ? sha : null;
 }
 
 export async function createRemoteSessionBranch(

--- a/apps/api/src/projects/git/commits.ts
+++ b/apps/api/src/projects/git/commits.ts
@@ -151,9 +151,10 @@ export async function buildSingleParentDeltaBundle(
 export async function resolveFastBootGitHint(
   project: GitBackedProject,
   ref?: string,
+  forceRefresh = false,
 ): Promise<FastBootGitHint> {
   const treeRef = validateRef(ref || project.defaultBranch);
-  const repoPath = await refreshMirror(project);
+  const repoPath = await refreshMirror(project, forceRefresh);
   const baseSha = (
     await runGit(['rev-parse', '--verify', `${treeRef}^{commit}`], repoPath, false)
   ).stdout.trim();

--- a/apps/api/src/projects/lib/fast-boot-git-hint.test.ts
+++ b/apps/api/src/projects/lib/fast-boot-git-hint.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+import type { FastBootGitHint } from '../git/commits';
+import type { GitBackedProject } from '../git/types';
+import {
+  buildCachedFastBootGitHint,
+  readCachedFastBootGitHint,
+  resolveFastBootGitHintWithCache,
+} from './fast-boot-git-hint';
+
+const project: GitBackedProject = {
+  projectId: 'project-1',
+  repoUrl: 'https://git.example.com/project-1.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+  gitAuthToken: null,
+};
+
+const cachedHint: FastBootGitHint = {
+  baseSha: 'a'.repeat(40),
+  gitDeltaBundleBase64: Buffer.from('bundle').toString('base64'),
+};
+
+function metadataFor(hint: FastBootGitHint = cachedHint, ref = 'main') {
+  return {
+    git: {
+      fast_boot: buildCachedFastBootGitHint(ref, hint, '2026-08-20T00:00:00.000Z'),
+    },
+  };
+}
+
+describe('fast boot Git hint cache', () => {
+  test('reads a bounded cache entry for the requested ref', () => {
+    expect(readCachedFastBootGitHint(metadataFor(), 'main')).toEqual(cachedHint);
+    expect(readCachedFastBootGitHint(metadataFor(cachedHint, 'dev'), 'main')).toBeNull();
+  });
+
+  test('rejects malformed and oversized cache entries', () => {
+    expect(
+      readCachedFastBootGitHint(
+        metadataFor({ baseSha: 'bad', gitDeltaBundleBase64: cachedHint.gitDeltaBundleBase64 }),
+        'main',
+      ),
+    ).toBeNull();
+    expect(
+      buildCachedFastBootGitHint('main', {
+        baseSha: 'a'.repeat(40),
+        gitDeltaBundleBase64: Buffer.alloc(24 * 1024 + 1).toString('base64'),
+      }),
+    ).toBeNull();
+  });
+
+  test('reuses a cache entry only when the remote tip still matches', async () => {
+    let freshCalls = 0;
+    let persistCalls = 0;
+    const result = await resolveFastBootGitHintWithCache(project, 'main', metadataFor(), {
+      resolveRemoteTip: async () => cachedHint.baseSha,
+      resolveFreshHint: async () => {
+        freshCalls += 1;
+        return cachedHint;
+      },
+      persistHint: async () => {
+        persistCalls += 1;
+      },
+    });
+    expect(result).toEqual(cachedHint);
+    expect(freshCalls).toBe(0);
+    expect(persistCalls).toBe(0);
+  });
+
+  test('force-refreshes and replaces a stale cache entry', async () => {
+    const freshHint = {
+      baseSha: 'b'.repeat(40),
+      gitDeltaBundleBase64: Buffer.from('fresh').toString('base64'),
+    };
+    const forceRefreshes: boolean[] = [];
+    const persisted: FastBootGitHint[] = [];
+    const result = await resolveFastBootGitHintWithCache(project, 'main', metadataFor(), {
+      resolveRemoteTip: async () => freshHint.baseSha,
+      resolveFreshHint: async (_project, _ref, forceRefresh) => {
+        forceRefreshes.push(forceRefresh);
+        return freshHint;
+      },
+      persistHint: async (_projectId, _ref, hint) => {
+        persisted.push(hint);
+      },
+    });
+    expect(result).toEqual(freshHint);
+    expect(forceRefreshes).toEqual([true]);
+    expect(persisted).toEqual([freshHint]);
+  });
+
+  test('builds without a forced refresh when no cache entry exists', async () => {
+    const forceRefreshes: boolean[] = [];
+    await resolveFastBootGitHintWithCache(project, 'main', null, {
+      resolveRemoteTip: async () => null,
+      resolveFreshHint: async (_project, _ref, forceRefresh) => {
+        forceRefreshes.push(forceRefresh);
+        return cachedHint;
+      },
+      persistHint: async () => {},
+    });
+    expect(forceRefreshes).toEqual([false]);
+  });
+});

--- a/apps/api/src/projects/lib/fast-boot-git-hint.ts
+++ b/apps/api/src/projects/lib/fast-boot-git-hint.ts
@@ -1,13 +1,10 @@
 import { projects } from '@kortix/db';
 import { eq } from 'drizzle-orm';
-import type { FastBootGitHint } from '../git/commits';
-import {
-  MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES,
-  resolveFastBootGitHint,
-} from '../git/commits';
-import { resolveRemoteBranchTip } from '../git/branches';
-import type { GitBackedProject } from '../git/types';
 import { db } from '../../shared/db';
+import { resolveRemoteBranchTip } from '../git/branches';
+import type { FastBootGitHint } from '../git/commits';
+import { MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES, resolveFastBootGitHint } from '../git/commits';
+import type { GitBackedProject } from '../git/types';
 import { metadataMergeSubtree } from './metadata-merge';
 
 export const FAST_BOOT_GIT_HINT_CACHE_VERSION = 1;
@@ -44,10 +41,7 @@ export function buildCachedFastBootGitHint(
   };
 }
 
-export function readCachedFastBootGitHint(
-  metadata: unknown,
-  ref: string,
-): FastBootGitHint | null {
+export function readCachedFastBootGitHint(metadata: unknown, ref: string): FastBootGitHint | null {
   if (!metadata || typeof metadata !== 'object') return null;
   const git = (metadata as { git?: unknown }).git;
   if (!git || typeof git !== 'object') return null;
@@ -101,11 +95,7 @@ interface FastBootGitHintDependencies {
     ref: string,
     forceRefresh: boolean,
   ) => Promise<FastBootGitHint>;
-  persistHint: (
-    projectId: string,
-    ref: string,
-    hint: FastBootGitHint,
-  ) => Promise<unknown>;
+  persistHint: (projectId: string, ref: string, hint: FastBootGitHint) => Promise<unknown>;
 }
 
 const defaultDependencies: FastBootGitHintDependencies = {

--- a/apps/api/src/projects/lib/fast-boot-git-hint.ts
+++ b/apps/api/src/projects/lib/fast-boot-git-hint.ts
@@ -1,0 +1,146 @@
+import { projects } from '@kortix/db';
+import { eq } from 'drizzle-orm';
+import type { FastBootGitHint } from '../git/commits';
+import {
+  MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES,
+  resolveFastBootGitHint,
+} from '../git/commits';
+import { resolveRemoteBranchTip } from '../git/branches';
+import type { GitBackedProject } from '../git/types';
+import { db } from '../../shared/db';
+import { metadataMergeSubtree } from './metadata-merge';
+
+export const FAST_BOOT_GIT_HINT_CACHE_VERSION = 1;
+
+export interface CachedFastBootGitHint {
+  version: typeof FAST_BOOT_GIT_HINT_CACHE_VERSION;
+  ref: string;
+  base_sha: string;
+  bundle_base64: string;
+  cached_at: string;
+}
+
+export function buildCachedFastBootGitHint(
+  ref: string,
+  hint: FastBootGitHint,
+  cachedAt = new Date().toISOString(),
+): CachedFastBootGitHint | null {
+  if (!/^[0-9a-f]{40}$/.test(hint.baseSha)) return null;
+  const bundle = hint.gitDeltaBundleBase64;
+  if (
+    !bundle ||
+    bundle.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]+={0,2}$/.test(bundle) ||
+    Buffer.byteLength(bundle, 'utf8') > MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES
+  ) {
+    return null;
+  }
+  return {
+    version: FAST_BOOT_GIT_HINT_CACHE_VERSION,
+    ref,
+    base_sha: hint.baseSha,
+    bundle_base64: bundle,
+    cached_at: cachedAt,
+  };
+}
+
+export function readCachedFastBootGitHint(
+  metadata: unknown,
+  ref: string,
+): FastBootGitHint | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const git = (metadata as { git?: unknown }).git;
+  if (!git || typeof git !== 'object') return null;
+  const raw = (git as { fast_boot?: unknown }).fast_boot;
+  if (!raw || typeof raw !== 'object') return null;
+  const entry = raw as Record<string, unknown>;
+  const candidate = buildCachedFastBootGitHint(
+    typeof entry.ref === 'string' ? entry.ref : '',
+    {
+      baseSha: typeof entry.base_sha === 'string' ? entry.base_sha : '',
+      gitDeltaBundleBase64:
+        typeof entry.bundle_base64 === 'string' ? entry.bundle_base64 : undefined,
+    },
+    typeof entry.cached_at === 'string' ? entry.cached_at : '',
+  );
+  if (
+    entry.version !== FAST_BOOT_GIT_HINT_CACHE_VERSION ||
+    !candidate ||
+    candidate.ref !== ref ||
+    candidate.cached_at.length === 0
+  ) {
+    return null;
+  }
+  return {
+    baseSha: candidate.base_sha,
+    gitDeltaBundleBase64: candidate.bundle_base64,
+  };
+}
+
+export async function persistFastBootGitHint(
+  projectId: string,
+  ref: string,
+  hint: FastBootGitHint,
+): Promise<CachedFastBootGitHint | null> {
+  const cached = buildCachedFastBootGitHint(ref, hint);
+  if (!cached) return null;
+  await db
+    .update(projects)
+    .set({
+      metadata: metadataMergeSubtree('git', { fast_boot: cached }),
+      updatedAt: new Date(),
+    })
+    .where(eq(projects.projectId, projectId));
+  return cached;
+}
+
+interface FastBootGitHintDependencies {
+  resolveRemoteTip: (project: GitBackedProject, ref: string) => Promise<string | null>;
+  resolveFreshHint: (
+    project: GitBackedProject,
+    ref: string,
+    forceRefresh: boolean,
+  ) => Promise<FastBootGitHint>;
+  persistHint: (
+    projectId: string,
+    ref: string,
+    hint: FastBootGitHint,
+  ) => Promise<unknown>;
+}
+
+const defaultDependencies: FastBootGitHintDependencies = {
+  resolveRemoteTip: resolveRemoteBranchTip,
+  resolveFreshHint: resolveFastBootGitHint,
+  persistHint: persistFastBootGitHint,
+};
+
+export async function resolveFastBootGitHintWithCache(
+  project: GitBackedProject,
+  ref: string,
+  metadata: unknown,
+  dependencies: FastBootGitHintDependencies = defaultDependencies,
+): Promise<FastBootGitHint> {
+  const cached = readCachedFastBootGitHint(metadata, ref);
+  let forceRefresh = false;
+  if (cached) {
+    try {
+      const remoteTip = await dependencies.resolveRemoteTip(project, ref);
+      if (remoteTip === cached.baseSha) return cached;
+      forceRefresh = true;
+    } catch {
+      forceRefresh = false;
+    }
+  }
+
+  const fresh = await dependencies.resolveFreshHint(project, ref, forceRefresh);
+  if (fresh.gitDeltaBundleBase64) {
+    await dependencies.persistHint(project.projectId, ref, fresh).catch((error) => {
+      console.warn('[git] fast-boot hint cache write failed', {
+        projectId: project.projectId,
+        ref,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+  return fresh;
+}

--- a/apps/api/src/projects/lib/serializers.test.ts
+++ b/apps/api/src/projects/lib/serializers.test.ts
@@ -53,6 +53,28 @@ describe('serializeProject icon', () => {
   test('metadata defaults to {} on the serialized project when the row is null', () => {
     expect(serializeProject(projectRow(null)).metadata).toEqual({});
   });
+
+  test('metadata omits the internal fast boot bundle without mutating stored metadata', () => {
+    const metadata = {
+      icon: '🚀',
+      git: {
+        provider: 'code-storage',
+        fast_boot: {
+          version: 1,
+          ref: 'main',
+          base_sha: 'a'.repeat(40),
+          bundle_base64: 'R0lUIEJVTkRMRQ==',
+          cached_at: '2026-08-20T00:00:00.000Z',
+        },
+      },
+    };
+    const serialized = serializeProject(projectRow(metadata));
+    expect(serialized.metadata).toEqual({
+      icon: '🚀',
+      git: { provider: 'code-storage' },
+    });
+    expect(metadata.git).toHaveProperty('fast_boot');
+  });
 });
 
 describe('serializeProject — icon_glyph', () => {

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -208,7 +208,7 @@ export function serializeProject(
     default_branch: row.defaultBranch,
     manifest_path: row.manifestPath,
     status: row.status,
-    metadata: row.metadata ?? {},
+    metadata: publicProjectMetadata(row.metadata),
     // Per-project emoji, stored in metadata (no migration — same mechanism as
     // default_sandbox_provider below and metadata.onboarding_completed_at).
     // Re-validated on read so a value written before the validator existed, or
@@ -254,6 +254,16 @@ export function serializeProject(
       config.isProviderEnabled(p),
     ),
   };
+}
+
+export function publicProjectMetadata(metadata: unknown): Record<string, unknown> {
+  if (!metadata || typeof metadata !== 'object') return {};
+  const source = metadata as Record<string, unknown>;
+  if (!source.git || typeof source.git !== 'object') return source;
+  const git = source.git as Record<string, unknown>;
+  if (!Object.hasOwn(git, 'fast_boot')) return source;
+  const { fast_boot: _fastBoot, ...publicGit } = git;
+  return { ...source, git: publicGit };
 }
 
 export function serializeProjectGitConnection(row: ProjectGitConnectionRow | null) {

--- a/apps/api/src/projects/lib/sessions.fast-boot-git-hint.test.ts
+++ b/apps/api/src/projects/lib/sessions.fast-boot-git-hint.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+
+async function sessionsSource(): Promise<string> {
+  return Bun.file(new URL('./sessions.ts', import.meta.url)).text();
+}
+
+describe('session fast boot Git hint cache', () => {
+  test('resolves a validated cache entry through the authenticated project', async () => {
+    const source = await sessionsSource();
+    const authPromise = source.indexOf('const projectWithGitAuthPromise');
+    const gate = source.indexOf('config.KORTIX_FAST_COLD_BOOT_ENABLED', authPromise);
+    const resolver = source.indexOf('resolveFastBootGitHintWithCache(', gate);
+    const provision = source.indexOf('provisionSessionSandbox({', resolver);
+    expect(authPromise).toBeGreaterThan(-1);
+    expect(gate).toBeGreaterThan(authPromise);
+    expect(resolver).toBeGreaterThan(gate);
+    expect(provision).toBeGreaterThan(resolver);
+    expect(source.slice(gate, provision)).toContain('projectWithGitAuthPromise');
+    expect(source.slice(resolver, provision)).toContain('project.metadata');
+  });
+
+  test('keeps the cache lookup inside the existing two-second boot deadline', async () => {
+    const source = await sessionsSource();
+    const gate = source.indexOf('config.KORTIX_FAST_COLD_BOOT_ENABLED');
+    const provision = source.indexOf('provisionSessionSandbox({', gate);
+    const fastBootBlock = source.slice(gate, provision);
+    expect(fastBootBlock).toContain('setTimeout(() => resolve(undefined), 2_000)');
+    expect(fastBootBlock).toContain('clearTimeout(fastBootHintTimeout)');
+    expect(fastBootBlock).toContain(': Promise.resolve(undefined)');
+  });
+});

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -49,7 +49,7 @@ import {
   sandboxFromLoadedAgents,
   workspaceFromLoadedAgents,
 } from '../agents';
-import { createRemoteSessionBranch, resolveFastBootGitHint } from '../git';
+import { createRemoteSessionBranch } from '../git';
 import { convertPendingPromptToInboxRow } from '../session-lifecycle/pending-prompt';
 import { resolveSessionSecretGrant } from './secret-grant';
 import {
@@ -67,6 +67,7 @@ import {
 } from './compile-agent-config';
 import type { WorkspaceModeV2 } from '@kortix/manifest-schema';
 import { withProjectGitAuth } from './git';
+import { resolveFastBootGitHintWithCache } from './fast-boot-git-hint';
 import { resolveSessionProvider } from './provider-precedence';
 import { RESERVED_SANDBOX_ENV_NAMES, isReservedSandboxEnvName } from './sandbox-env-names';
 import {
@@ -1492,10 +1493,25 @@ export async function createProjectSession(input: {
       // Best-effort + timeout-guarded (never block create): on failure/timeout
       // the hint is omitted → daemon delta-fetches as before. Runs CONCURRENTLY
       // with gitAuth (folded into the env-build chain, not awaited inline).
-      const fastBootGitHintPromise = Promise.race([
-        resolveFastBootGitHint(project, baseRef).catch(() => undefined),
-        new Promise<undefined>((r) => setTimeout(() => r(undefined), 2000)),
-      ]);
+      let fastBootHintTimeout: ReturnType<typeof setTimeout> | undefined;
+      const fastBootGitHintPromise = config.KORTIX_FAST_COLD_BOOT_ENABLED
+        ? Promise.race([
+            projectWithGitAuthPromise
+              .then((projectWithGitAuth) =>
+                resolveFastBootGitHintWithCache(
+                  projectWithGitAuth,
+                  baseRef,
+                  project.metadata,
+                ),
+              )
+              .catch(() => undefined),
+            new Promise<undefined>((resolve) => {
+              fastBootHintTimeout = setTimeout(() => resolve(undefined), 2_000);
+            }),
+          ]).finally(() => {
+            if (fastBootHintTimeout) clearTimeout(fastBootHintTimeout);
+          })
+        : Promise.resolve(undefined);
       const envPromise = fastBootGitHintPromise
         .then((fastBootGitHint) =>
           buildSessionSandboxEnvVars({

--- a/apps/api/src/projects/provision-core.test.ts
+++ b/apps/api/src/projects/provision-core.test.ts
@@ -111,4 +111,16 @@ describe('provision phases', () => {
     expect(fnBody).toContain('return {');
     expect((fnBody.match(/status:\s*201/g) ?? []).length).toBeGreaterThan(0);
   });
+
+  test('precomputes the Git hint after a verified seed only when fast boot is enabled', async () => {
+    const source = await coreSource();
+    const seedState = source.indexOf('const verifiedSeedState');
+    const gate = source.indexOf('if (config.KORTIX_FAST_COLD_BOOT_ENABLED');
+    const precompute = source.indexOf('resolveFastBootGitHintWithCache(', gate);
+    expect(seedState).toBeGreaterThan(-1);
+    expect(gate).toBeGreaterThan(seedState);
+    expect(precompute).toBeGreaterThan(gate);
+    expect(source.slice(gate, precompute)).toContain('writeUpstream');
+    expect(source).toContain('FAST_BOOT_SEED_HINT_TIMEOUT_MS = 8_000');
+  });
 });

--- a/apps/api/src/projects/provision-core.ts
+++ b/apps/api/src/projects/provision-core.ts
@@ -30,6 +30,7 @@ import {
 } from './seed-files';
 import { getCatalogItemDetail } from '../marketplace/catalog';
 import { remoteBranchExists } from './git';
+import { config } from '../config';
 import { db } from '../shared/db';
 import { projects } from '@kortix/db';
 import { eq } from 'drizzle-orm';
@@ -48,6 +49,10 @@ import {
   upsertProjectGitConnection,
 } from './lib/git';
 import { metadataMerge } from './lib/metadata-merge';
+import {
+  buildCachedFastBootGitHint,
+  resolveFastBootGitHintWithCache,
+} from './lib/fast-boot-git-hint';
 import {
   classifyProvisionReplay,
   findIdempotentProvision,
@@ -72,6 +77,8 @@ export const PROVISION_PHASES = [
 
 export type ProvisionPhase = (typeof PROVISION_PHASES)[number];
 export type ProvisionEmit = (phase: ProvisionPhase) => void;
+
+const FAST_BOOT_SEED_HINT_TIMEOUT_MS = 8_000;
 
 /**
  * The exact status codes `runProvision` can produce, matching both routes'
@@ -615,6 +622,51 @@ export async function runProvision(ctx: ProvisionContext, emit: ProvisionEmit): 
         })
         .where(eq(projects.projectId, row.projectId))
         .catch(() => {}); // best-effort — a mirror-write hiccup must not fail project creation
+
+      if (config.KORTIX_FAST_COLD_BOOT_ENABLED && writeUpstream) {
+        const hintTask = resolveFastBootGitHintWithCache(
+          {
+            projectId: row.projectId,
+            repoUrl: writeUpstream.url,
+            defaultBranch: provisioned.defaultBranch,
+            manifestPath: row.manifestPath,
+            gitAuthToken: null,
+            gitAuthHeaders: writeUpstream.headers,
+          },
+          provisioned.defaultBranch,
+          null,
+        )
+          .then((hint) =>
+            buildCachedFastBootGitHint(provisioned.defaultBranch, hint),
+          )
+          .catch((error) => {
+            console.warn('[projects] fast-boot seed hint unavailable', {
+              projectId: row.projectId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return null;
+          });
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        const cachedHint = await Promise.race([
+          hintTask,
+          new Promise<null>((resolve) => {
+            timeout = setTimeout(() => resolve(null), FAST_BOOT_SEED_HINT_TIMEOUT_MS);
+          }),
+        ]).finally(() => {
+          if (timeout) clearTimeout(timeout);
+        });
+        if (cachedHint) {
+          const currentMetadata = (row.metadata as Record<string, unknown> | null) ?? {};
+          const currentGit =
+            currentMetadata.git && typeof currentMetadata.git === 'object'
+              ? (currentMetadata.git as Record<string, unknown>)
+              : {};
+          row.metadata = {
+            ...currentMetadata,
+            git: { ...currentGit, fast_boot: cachedHint },
+          };
+        }
+      }
     } catch (error) {
       const stage = error instanceof ManagedRepoSeedError ? error.stage : 'push';
       console.error(


### PR DESCRIPTION
## Problem

The API Git mirror is process-local. Two of five deployed cold-session samples missed the two-second mirror deadline and fell back to a 4.9–5.3 second in-sandbox fetch.

## Change

- Persist bounded fast-boot Git hints in project metadata.
- Precompute the hint after a managed project seed.
- Validate the cached SHA with an authenticated remote-tip lookup before reuse.
- Force-refresh and replace stale cache entries.
- Keep all work behind KORTIX_FAST_COLD_BOOT_ENABLED.
- Preserve the two-second session-start deadline and authenticated fallback.

## Verification

- API typecheck: pass.
- Full API unit suite: 7,725 pass, 74 skip, 0 fail, 27,428 assertions.
- Focused API cache/provision/session/bundle suite: 18 pass, 0 fail.
- Sandbox bundle contract: 61 pass, 0 fail.
- git diff --check: pass.

## Rollback

Set KORTIX_FAST_COLD_BOOT_ENABLED=false.