### PR TITLE
fix(turns): box-initiated turns get authority; busy roots are never read as terminal

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1076,3 +1076,39 @@ strictly (dynamic registration, stateful sessions) as the one you test against.
 *Incident:* found and fixed while building one-click OAuth 2.1 for MCP
 connectors, PR #6579. No production outage — the surface had never been used
 against a real provider, which is precisely why all three shipped unnoticed.
+
+## Transcript shape alone may never end a turn — and every turn needs a record, whoever started it
+
+Session/turn truth rules paid for on Essentia, 2026-08-20 (session `d1b74954`:
+composer flapped "not running" over a visibly streaming session; a user prompt
+delivered mid-turn was silently swallowed; PR #6657):
+
+**1. A verdict that a turn is DEAD must be gated on the runtime's own busy
+signal, not inferred from the transcript.** "A newer user message follows it"
+and "its latest assistant message is completed" both read as terminal and both
+occur mid-turn (prompts forwarded into a live turn; the step boundary while
+tools run). The reaper cleared a streaming turn's authority at 12:48:51Z; its
+step completed at 12:48:54Z. Rule: no terminal verdict while the root reports
+`busy`/`retry`; an unreadable status is `unknown`, never terminal.
+
+**2. Every runtime-initiated turn must be announced to the control plane.**
+OpenCode starts turns nobody delivered (synthetic `<pty_exited>` wake-ups).
+Anything keyed on "a control-plane prompt opened this turn" — `GET .../turn`,
+the deadline grant, Stop — silently misses them. The daemon's `turn_begin`
+relay + `adoptRuntimeSandboxTurn` close this; the general rule: when a new way
+for work to START appears, audit every consumer of "is work running".
+
+**3. A safety floor that DELETES its own retry state is a one-shot race.** The
+orphan-redelivery age floor (30s) was checked once, and losing the check
+cleared the record that was the only possible trigger — the user's prompt died
+at age 27s. A guard that defers must leave the state it will need standing.
+
+**4. An unnamed lifecycle event breaks every consumer keyed on the name.**
+`readRootTurnState` bailed on a trailing user message, so turn-end relays
+carried no `turn_message_id`: dedup vanished (double finalizes) and the strand
+reconciler lost its key. When an identity read has a "give up" branch, list
+what downstream keys on the identity before taking it.
+
+*Automation:* flipped-expectation tests in `orphaned-turn-finalize.test.ts` and
+`sandbox-reaper.test.ts` pin the incident timeline; `turn-begin-relay.test.ts`
+and `integration-sandbox-turn-lifecycle.test.ts` pin the adoption contract.

--- a/apps/api/src/__tests__/integration-sandbox-turn-lifecycle.test.ts
+++ b/apps/api/src/__tests__/integration-sandbox-turn-lifecycle.test.ts
@@ -12,6 +12,7 @@ import { sandboxStopClaimLeaseMs } from '../projects/sandbox-deadline-policy';
 import {
   abandonSandboxTurn,
   acceptSandboxTurn,
+  adoptRuntimeSandboxTurn,
   beginSandboxTurn,
   clearSandboxTurn,
   completeSandboxTurn,
@@ -1036,5 +1037,71 @@ describe('session_turns ledger', () => {
 
     expect(await rejection('bogus', null)).toContain('session_turns_state_check');
     expect(await rejection('ended', 'exploded')).toContain('session_turns_end_reason_check');
+  });
+});
+
+describe('adoptRuntimeSandboxTurn — box-initiated turn authority', () => {
+  // OpenCode starts turns of its own (synthetic `<pty_exited>` wake-ups) that
+  // no control-plane prompt announced. The daemon relays `turn_begin` for
+  // them; this write is what turns that relay into `GET .../turn` truth and a
+  // deadline grant (live incident 2026-08-20, Essentia session d1b74954).
+  const SYNTH = 'msg_synthetic_pty_1';
+
+  async function readOpenBySession(): Promise<Array<Record<string, unknown>>> {
+    const result = await db.execute(sql`
+      SELECT * FROM kortix.session_turns
+       WHERE session_id = ${SESSION_ID} AND state <> 'ended'`);
+    return rows(result) as Array<Record<string, unknown>>;
+  }
+
+  test('adopts a box-initiated turn: active ledger row, activeTurns record, deadline grant', async () => {
+    const before = deadlineMs(await readRow());
+    const outcome = await adoptRuntimeSandboxTurn(SANDBOX_ID, {
+      opencodeSessionId: 'ses_root',
+      messageId: SYNTH,
+    });
+    expect(outcome).toBe('adopted');
+    const open = await readOpenBySession();
+    expect(open).toHaveLength(1);
+    expect(open[0]?.message_id).toBe(SYNTH);
+    expect(open[0]?.state).toBe('active');
+    expect(open[0]?.accepted_at).toBeTruthy();
+    const row = await readRow();
+    const turns = (row.metadata as { activeTurns?: Record<string, { messageId?: string }> })
+      .activeTurns;
+    expect(Object.values(turns ?? {}).some((turn) => turn.messageId === SYNTH)).toBe(true);
+    // acceptSandboxTurn grants the full turn deadline — hours past the
+    // fixture's 10-minute deadline. Without it a long pty-driven work phase
+    // ran on the idle tail and the reaper parked the box mid-work.
+    expect(deadlineMs(row)).toBeGreaterThan(before + 60 * 60 * 1000);
+  });
+
+  test('any open turn means authority is already held — nothing is written', async () => {
+    await beginSandboxTurn(
+      { sandboxId: SANDBOX_ID },
+      { token: t('already-open'), opencodeSessionId: 'ses_root', messageId: 'msg_delivered_1' },
+    );
+    const outcome = await adoptRuntimeSandboxTurn(SANDBOX_ID, {
+      opencodeSessionId: 'ses_root',
+      messageId: SYNTH,
+    });
+    expect(outcome).toBe('open_turn_exists');
+    const open = await readOpenBySession();
+    expect(open).toHaveLength(1);
+    expect(open[0]?.message_id).toBe('msg_delivered_1');
+  });
+
+  test('a message the ledger has EVER seen is refused — a late relay cannot resurrect a closed turn', async () => {
+    await db.execute(sql`
+      INSERT INTO kortix.session_turns
+        (turn_token, session_id, sandbox_id, project_id, account_id, message_id, state, end_reason)
+      VALUES (${t('closed')}, ${SESSION_ID}, ${SANDBOX_ID}::uuid,
+              ${PROJECT_ID}::uuid, ${ACCOUNT_ID}::uuid, ${SYNTH}, 'ended', 'completed')`);
+    const outcome = await adoptRuntimeSandboxTurn(SANDBOX_ID, {
+      opencodeSessionId: 'ses_root',
+      messageId: SYNTH,
+    });
+    expect(outcome).toBe('known_message');
+    expect(await readOpenBySession()).toHaveLength(0);
   });
 });

--- a/apps/api/src/projects/reaping/box-reaper.ts
+++ b/apps/api/src/projects/reaping/box-reaper.ts
@@ -402,6 +402,27 @@ export async function reapAndReconcileSandboxes(
               } else if (observation === 'active') {
                 observedActiveTokens.push(turn.token);
               } else if (observation === 'terminal') {
+                // A YOUNG orphaned prompt DEFERS the clear instead of paying
+                // for it with the prompt's life. Clearing deletes the record,
+                // and the record is the ONLY thing that can ever trigger the
+                // orphan redelivery below — so a terminal observation landing
+                // inside ORPHANED_PROMPT_MIN_AGE_MS was a one-shot race that
+                // silently swallowed the prompt: observed live 2026-08-20
+                // (Essentia session d1b74954, prompt cleared `unknown` at age
+                // 27s, 3s under the floor, never answered). The next pass runs
+                // ~20s later; by then the age check passes and the redelivery
+                // fires, or the prompt got answered and the observation says
+                // so. The deferral is bounded by the floor itself.
+                const orphanAgeMs =
+                  turn.startedAtMs === null ? null : now.getTime() - turn.startedAtMs;
+                if (
+                  orphanedPrompt &&
+                  !huskFinalized &&
+                  orphanAgeMs !== null &&
+                  orphanAgeMs < ORPHANED_PROMPT_MIN_AGE_MS
+                ) {
+                  continue;
+                }
                 // Terminal evidence removes the record, whatever the finalizer
                 // managed to close. Holding the record to retry an unreadable
                 // finalize would keep the box's four-hour turn grant instead of

--- a/apps/api/src/projects/routes/r4-turn-stream-kind.test.ts
+++ b/apps/api/src/projects/routes/r4-turn-stream-kind.test.ts
@@ -7,6 +7,7 @@ describe('turnStreamKindField', () => {
     expect(turnStreamKindField('answer')).toBe('answer');
     expect(turnStreamKindField('end')).toBe('end');
     expect(turnStreamKindField('turn_end')).toBe('turn_end');
+    expect(turnStreamKindField('turn_begin')).toBe('turn_begin');
     expect(turnStreamKindField('turn_accepted')).toBe('turn_accepted');
     expect(turnStreamKindField('turn_abandoned')).toBe('turn_abandoned');
     expect(turnStreamKindField('opencode_session')).toBe('opencode_session');
@@ -30,6 +31,7 @@ describe('turnStreamKindNeedsConnectorWrite', () => {
     // no connector.write) must be allowed to report them.
     expect(turnStreamKindNeedsConnectorWrite('end')).toBe(false);
     expect(turnStreamKindNeedsConnectorWrite('turn_end')).toBe(false);
+    expect(turnStreamKindNeedsConnectorWrite('turn_begin')).toBe(false);
     expect(turnStreamKindNeedsConnectorWrite('turn_accepted')).toBe(false);
     expect(turnStreamKindNeedsConnectorWrite('turn_abandoned')).toBe(false);
     expect(turnStreamKindNeedsConnectorWrite('opencode_session')).toBe(false);

--- a/apps/api/src/projects/routes/r4-turn-stream-kind.ts
+++ b/apps/api/src/projects/routes/r4-turn-stream-kind.ts
@@ -24,6 +24,7 @@ export function turnStreamKindField(kind: unknown): string {
 export const TURN_STREAM_LIFECYCLE_KINDS: ReadonlySet<string> = new Set([
   'end',
   'turn_end',
+  'turn_begin',
   'turn_accepted',
   'turn_abandoned',
   'opencode_session',

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -165,6 +165,7 @@ import { turnStreamKindField, turnStreamKindNeedsConnectorWrite } from './r4-tur
 import {
   abandonSandboxTurn,
   acceptSandboxTurn,
+  adoptRuntimeSandboxTurn,
   completeSandboxTurn,
 } from '../sandbox-turn-lifecycle';
 
@@ -2493,6 +2494,28 @@ projectsApp.openapi(
         messageId,
       });
       return c.json({ ok });
+    }
+
+    // A BOX-INITIATED turn: the daemon observed the root go busy on a user
+    // message the control plane never delivered (OpenCode's synthetic
+    // `<pty_exited>` wake-ups). Adopt it into the ledger so `GET .../turn`
+    // reports the running turn and the deadline grant covers it. Idempotent —
+    // see adoptRuntimeSandboxTurn; requires the sandbox credential like every
+    // upward lifecycle transition.
+    if (body.kind === 'turn_begin') {
+      if (!authenticatedSandboxId) {
+        return c.json({ error: 'turn_begin requires a sandbox token' }, 403);
+      }
+      const opencodeSessionId = body.opencode_session_id?.trim();
+      const messageId = body.turn_message_id?.trim();
+      if (!opencodeSessionId || !messageId) {
+        return c.json({ error: 'opencode_session_id and turn_message_id are required' }, 400);
+      }
+      const outcome = await adoptRuntimeSandboxTurn(authenticatedSandboxId, {
+        opencodeSessionId,
+        messageId,
+      });
+      return c.json({ ok: outcome === 'adopted' || outcome === 'open_turn_exists', outcome });
     }
 
     // `end` / `turn_end` carry no text — the sandbox observed the opencode turn

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -1181,10 +1181,19 @@ describe('reapAndReconcileSandboxes — the one rule: deadline_at <= now', () =>
     ]);
   });
 
-  test('a JUST-ACCEPTED record is not orphaned yet, whatever the daemon says', async () => {
+  test('a JUST-ACCEPTED record is not orphaned yet — and its clear DEFERS, never swallows', async () => {
     // "User message on record, no assistant message, root idle" is also what
     // the moments between OpenCode ACKing a prompt and starting it look like.
     // Redelivering into that window runs the user's prompt twice.
+    //
+    // EXPECTATION CHANGED 2026-08-20 (live incident, Essentia session
+    // d1b74954): this used to CLEAR the record while skipping the redelivery.
+    // Clearing deletes the record — the only thing that can ever trigger the
+    // redelivery — so a terminal observation landing inside the age floor was
+    // a one-shot race that swallowed the prompt for good (cleared `unknown` at
+    // age 27s, 3s under the floor, never answered). Now the young orphan
+    // DEFERS: nothing is cleared, nothing is redelivered, and the next pass
+    // (~20s later) decides with the age check satisfied.
     candidates = [
       candidate({
         deadlineAt: new Date(NOW.getTime() + HOUR),
@@ -1205,7 +1214,7 @@ describe('reapAndReconcileSandboxes — the one rule: deadline_at <= now', () =>
 
     await reapAndReconcileSandboxes(NOW);
 
-    expect(clearedTurnCalls).toEqual([{ sandboxId: 'sb-1', token: 'active-token' }]);
+    expect(clearedTurnCalls).toEqual([]);
     expect(promptRedeliveries).toEqual([]);
   });
 

--- a/apps/api/src/projects/sandbox-turn-lifecycle.ts
+++ b/apps/api/src/projects/sandbox-turn-lifecycle.ts
@@ -573,6 +573,54 @@ export async function beginSandboxTurn(
   return 'granted';
 }
 
+export type RuntimeTurnAdoption = 'adopted' | 'open_turn_exists' | 'known_message' | 'no_box';
+
+/**
+ * Give a BOX-INITIATED turn the same durable authority a delivered prompt gets.
+ *
+ * Not every turn starts with `POST .../prompts`. OpenCode starts turns of its
+ * own — most commonly the synthetic `<pty_exited>` user message it injects when
+ * a background pty finishes — and those turns had NO `session_turns` row, no
+ * `activeTurns` record, and therefore no deadline grant: `GET .../turn`
+ * reported idle for minutes of live streaming, the composer read "not
+ * running" over a working session, and a long pty-driven work phase ran on
+ * the 15-minute idle tail (live incident 2026-08-20, Essentia session
+ * d1b74954). The daemon now relays `turn_begin` when it observes the root go
+ * busy; this is that relay's write.
+ *
+ * Idempotent by construction, so the daemon may relay freely:
+ * - a message id the ledger has EVER seen is refused — a late `turn_begin`
+ *   must not resurrect a turn the reaper or a turn-end already closed;
+ * - any still-open row for this sandbox means authority is already held —
+ *   including the normal case where the control plane wrote the record before
+ *   delivering the prompt — and nothing is written.
+ */
+export async function adoptRuntimeSandboxTurn(
+  sandboxId: string,
+  identity: { opencodeSessionId: string; messageId: string },
+): Promise<RuntimeTurnAdoption> {
+  const guard = await execute(sql`
+    SELECT
+      EXISTS(
+        SELECT 1 FROM kortix.session_turns t
+         WHERE t.sandbox_id = ${sandboxId}::uuid
+           AND t.message_id = ${identity.messageId}) AS known,
+      EXISTS(
+        SELECT 1 FROM kortix.session_turns t
+         WHERE t.sandbox_id = ${sandboxId}::uuid
+           AND t.state <> 'ended') AS open`);
+  const rows = normalizeRows(guard);
+  const known = rows?.[0]?.known === true;
+  const open = rows?.[0]?.open === true;
+  if (known) return 'known_message';
+  if (open) return 'open_turn_exists';
+  const token = randomUUID();
+  const started = await beginSandboxTurn({ sandboxId }, { token, ...identity });
+  if (started !== 'granted') return 'no_box';
+  const accepted = await acceptSandboxTurn({ sandboxId }, token, identity);
+  return accepted ? 'adopted' : 'no_box';
+}
+
 /** Promote only the delivery record created by this request. */
 export async function acceptSandboxTurn(
   target: DeadlineTarget,

--- a/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.test.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.test.ts
@@ -40,7 +40,7 @@ describe('reconcileForwardedTurnsAtEnd', () => {
   test('no-op without an ended message id when the tip has no finished assistant either', async () => {
     const { deps, calls } = fakeDeps({ open: [turn(u1)], tip: [] });
     const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's' }, deps);
-    expect(out).toEqual({ closedOlder: 0, candidates: 0, stranded: 0, requeued: 0, reordered: 0 });
+    expect(out).toEqual({ closedOlder: 0, candidates: 0, stranded: 0, orphaned: 0, requeued: 0, reordered: 0 });
     expect(calls.closeOlder).toHaveLength(0);
   });
 
@@ -54,7 +54,7 @@ describe('reconcileForwardedTurnsAtEnd', () => {
     ];
     const { deps, calls } = fakeDeps({ open: [turn(u1), turn(u4, 'delivering')], tip });
     const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's' }, deps);
-    expect(out).toEqual({ closedOlder: 1, candidates: 1, stranded: 1, requeued: 1, reordered: 0 });
+    expect(out).toEqual({ closedOlder: 1, candidates: 1, stranded: 1, orphaned: 0, requeued: 1, reordered: 0 });
     expect(calls.closeOlder.map((c) => c[2])).toEqual([u1]);
     expect(calls.remove).toEqual([['s', u4]]);
   });
@@ -75,7 +75,7 @@ describe('reconcileForwardedTurnsAtEnd', () => {
     ];
     const { deps, calls } = fakeDeps({ open: [turn(u4, 'delivering')], tip });
     const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M }, deps);
-    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 1, requeued: 1, reordered: 0 });
+    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 1, orphaned: 0, requeued: 1, reordered: 0 });
     expect(calls.remove).toEqual([['s', u4]]);
     expect(calls.requeue).toEqual([['s', u4]]);
     expect(calls.closeStranded).toEqual([['s', u4]]);
@@ -92,16 +92,55 @@ describe('reconcileForwardedTurnsAtEnd', () => {
     ];
     const { deps, calls } = fakeDeps({ open: [turn(u5)], tip });
     const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M }, deps);
-    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 0, requeued: 0, reordered: 0 });
+    expect(out).toEqual({ closedOlder: 0, candidates: 1, stranded: 0, orphaned: 0, requeued: 0, reordered: 0 });
     expect(calls.remove).toHaveLength(0);
     expect(calls.closeStranded).toHaveLength(0);
   });
 
-  test('a newer prompt not yet reached (no assistant above it) is left alone', async () => {
+  // EXPECTATION FLIPPED 2026-08-20 (live incident, Essentia session
+  // d1b74954): an unreached prompt at the TIP with the loop exited (the tip's
+  // newest assistant is COMPLETED) is not "in line" — nothing will ever read
+  // it. Left alone, the reaper cleared its turn `unknown` and the prompt was
+  // swallowed. It now requeues exactly like a stranded row.
+  test('an ACCEPTED tip prompt the exited loop never read is removed and re-queued', async () => {
     const tip = [{ id: M, role: 'user' }, { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 }, { id: u5, role: 'user' }];
     const { deps, calls } = fakeDeps({ open: [turn(u5)], tip });
     const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', endedMessageId: M }, deps);
     expect(out.stranded).toBe(0);
+    expect(out.orphaned).toBe(1);
+    expect(out.requeued).toBe(1);
+    expect(calls.remove).toEqual([['s', u5]]);
+    expect(calls.requeue).toEqual([['s', u5]]);
+    expect(calls.closeStranded).toEqual([['s', u5]]);
+  });
+
+  test('a tip prompt is left alone while the tip is MID-STEP — the open step will read it', async () => {
+    const aOpen = id(T + 4_100, 'ASSTOASSTOASST');
+    const tip = [
+      { id: M, role: 'user' },
+      { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 },
+      { id: u5, role: 'user' },
+      { id: aOpen, role: 'assistant', parentID: u5 },
+    ];
+    const { deps, calls } = fakeDeps({ open: [turn(u5)], tip });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', endedMessageId: M }, deps);
+    expect(out.orphaned).toBe(0);
+    expect(calls.remove).toHaveLength(0);
+  });
+
+  test('a DELIVERING tip prompt is left alone — the send is still on the wire', async () => {
+    const tip = [{ id: M, role: 'user' }, { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 }, { id: u5, role: 'user' }];
+    const { deps, calls } = fakeDeps({ open: [turn(u5, 'delivering')], tip });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', endedMessageId: M }, deps);
+    expect(out.orphaned).toBe(0);
+    expect(calls.remove).toHaveLength(0);
+  });
+
+  test('a candidate absent from the tip window is left to the reaper', async () => {
+    const tip = [{ id: M, role: 'user' }, { id: aM, role: 'assistant', parentID: M, completed: T + 3_500 }];
+    const { deps, calls } = fakeDeps({ open: [turn(u5)], tip });
+    const out = await reconcileForwardedTurnsAtEnd({ sessionId: 's', endedMessageId: M }, deps);
+    expect(out.orphaned).toBe(0);
     expect(calls.remove).toHaveLength(0);
   });
 
@@ -139,7 +178,7 @@ describe('reconcileForwardedTurnsAtEnd', () => {
       { sessionId: 's', opencodeSessionId: 'ses_root', endedMessageId: M },
       deps,
     );
-    expect(out).toEqual({ closedOlder: 0, candidates: 2, stranded: 1, requeued: 0, reordered: 0 });
+    expect(out).toEqual({ closedOlder: 0, candidates: 2, stranded: 1, orphaned: 0, requeued: 0, reordered: 0 });
     expect(calls.remove).toHaveLength(0);
     expect(calls.requeue).toHaveLength(0);
   });

--- a/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.ts
+++ b/apps/api/src/projects/session-lifecycle/forwarded-strand-reconcile.ts
@@ -40,7 +40,7 @@ import {
 import { sandboxRuntimeRequestHeaders } from '../sandbox-fetch';
 import { wireIdTime } from '../wire-message-id';
 import { drainSessionLifecycleQueue, resolveSessionOpencodeEndpoint } from './engine';
-import { type PlacementTipMessage, openUserAbove, parsePlacementTip, strandedPlacement } from './forwarded-placement';
+import { type PlacementTipMessage, openUserAbove, parsePlacementTip, strandedPlacement, tipIsBusy } from './forwarded-placement';
 import { promoteNextInboxRow, withNextDeliveryAttempt } from './store';
 
 const WORKSPACE = '/workspace';
@@ -52,6 +52,12 @@ export interface ForwardedTurnReconciliation {
   closedOlder: number;
   candidates: number;
   stranded: number;
+  /** Newer candidates the loop exited PAST: placed at the tip, never read,
+   *  nothing running. Live incident 2026-08-20 (Essentia session d1b74954):
+   *  a prompt forwarded at 12:59:05Z sat at the tip; the loop completed at
+   *  12:59:17Z without reading it and its queued continuation was rejected —
+   *  "not stranded" left it in place forever. */
+  orphaned: number;
   requeued: number;
   /** Later, un-stranded siblings pulled back with a stranded row so the
    *  redelivery batch restores send order. */
@@ -192,7 +198,7 @@ export async function reconcileForwardedTurnsAtEnd(
   input: { sessionId: string; opencodeSessionId?: string | null; endedMessageId?: string | null },
   deps: StrandReconcileDeps = liveDeps,
 ): Promise<ForwardedTurnReconciliation> {
-  const out: ForwardedTurnReconciliation = { closedOlder: 0, candidates: 0, stranded: 0, requeued: 0, reordered: 0 };
+  const out: ForwardedTurnReconciliation = { closedOlder: 0, candidates: 0, stranded: 0, orphaned: 0, requeued: 0, reordered: 0 };
   let open: StoredSandboxTurn[];
   try {
     open = await deps.readOpenTurns(input.sessionId);
@@ -280,9 +286,28 @@ export async function reconcileForwardedTurnsAtEnd(
   // order. Re-queueing one row of a burst individually is what scrambled the
   // order (measured: FIRST, B3, B1, B4, B2).
   const verdicts = newer.map((turn) => ({ turn, verdict: strandedPlacement(tip!, turn.messageId!) }));
+  // The strand verdict has a blind spot the loop's exit exposes: a candidate
+  // placed correctly AT THE TIP (no assistant above it, so not "stranded")
+  // that the ended loop simply never read. With the tip's newest assistant
+  // CLOSED, nothing will ever answer it — OpenCode's queued continuation for
+  // it can be rejected at turn end (observed live 2026-08-20, Essentia
+  // session d1b74954: "Bro no fucking idea whats happening here lol",
+  // delivered 12:59:05Z, loop completed 12:59:17Z past it, queue request
+  // rejected, prompt swallowed). Requeue it exactly like a stranded row.
+  // Guards, in order: the row must be ACCEPTED (`active` — a `delivering`
+  // row is a send still on the wire), the message must actually be on the
+  // tip, and the tip must not be mid-step (an open newest assistant is a
+  // fresh turn that will read it).
   for (const { turn, verdict } of verdicts) {
-    if (!verdict.stranded) continue;
-    out.stranded += 1;
+    const orphanedAtTip =
+      !verdict.stranded &&
+      !verdict.answered &&
+      turn.state === 'active' &&
+      tip.some((m) => m.role === 'user' && m.id === turn.messageId) &&
+      !tipIsBusy(tip);
+    if (!verdict.stranded && !orphanedAtTip) continue;
+    if (verdict.stranded) out.stranded += 1;
+    else out.orphaned += 1;
     // The tip, not just the ledger candidates: ANY placed, unanswered user
     // message above covers this one — a direct send included.
     if (openUserAbove(tip, turn.messageId!)) {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/orphaned-turn-finalize.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/orphaned-turn-finalize.test.ts
@@ -250,7 +250,15 @@ describe('opencodeDeliveryInFlight — lifecycle acceptance recovery', () => {
     expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBeNull();
   });
 
-  test('a later user message makes the exact older turn terminal even while the session is busy', async () => {
+  // EXPECTATION FLIPPED 2026-08-20 (live incident, Essentia session d1b74954):
+  // prompts forwarded INTO a live turn — and OpenCode's own synthetic
+  // `<pty_exited>` wake-ups — put a NEWER user message on the root while the
+  // SAME loop is still streaming the older turn's steps. The old rule ("a
+  // newer user message owns the root, never ask the status") made the reaper
+  // read that turn as terminal and destroy live turn authority mid-stream
+  // (cleared 12:48:51Z; the step completed 12:48:54Z). Transcript shape alone
+  // may never end a turn while the root itself reports busy.
+  test('a later user message does NOT end an unanswered older turn while the session is busy', async () => {
     stubFetch(
       [
         { info: { id: 'msg_turn_1', role: 'user' } },
@@ -258,8 +266,91 @@ describe('opencodeDeliveryInFlight — lifecycle acceptance recovery', () => {
       ],
       { sessionStatus: { [SESSION]: { type: 'busy' } } },
     );
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(true);
+    expect(calls.some((url) => url.includes('/session/status'))).toBe(true);
+  });
+
+  test('a later user message ends an unanswered older turn once the session is idle', async () => {
+    stubFetch(
+      [
+        { info: { id: 'msg_turn_1', role: 'user' } },
+        { info: { id: 'msg_turn_2', role: 'user' } },
+      ],
+      { sessionStatus: { [SESSION]: { type: 'idle' } } },
+    );
     expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(false);
+  });
+
+  test('a later user message with an unreadable status is unknown, never terminal', async () => {
+    stubFetch(
+      [
+        { info: { id: 'msg_turn_1', role: 'user' } },
+        { info: { id: 'msg_turn_2', role: 'user' } },
+      ],
+      { sessionStatusOk: false },
+    );
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBeNull();
+  });
+
+  test('a later user message after a COMPLETED answer is terminal without asking the status', async () => {
+    stubFetch(
+      [
+        { info: { id: 'msg_turn_1', role: 'user' } },
+        { info: { role: 'assistant', parentID: 'msg_turn_1', time: { completed: 1234 } } },
+        { info: { id: 'msg_turn_2', role: 'user' } },
+      ],
+      { sessionStatus: { [SESSION]: { type: 'busy' } } },
+    );
+    const observed = await observeOpencodeDelivery(BASE, WORKSPACE, SESSION, 'msg_turn_1');
+    expect(observed).toEqual({ inFlight: false, end: 'completed' });
     expect(calls.some((url) => url.includes('/session/status'))).toBe(false);
+  });
+
+  // The step-boundary window: each step of ONE turn is its own assistant
+  // message, completed at the step's end, and the next step's message does not
+  // exist yet while tools run. A completed latest step + a busy root is the
+  // SAME turn between steps, not a finished turn.
+  test('a completed latest step with a busy root stays active (step boundary)', async () => {
+    stubFetch(
+      [
+        { info: { id: 'msg_turn_1', role: 'user' } },
+        { info: { role: 'assistant', parentID: 'msg_turn_1', time: { completed: 1234 } } },
+      ],
+      { sessionStatus: { [SESSION]: { type: 'busy' } } },
+    );
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(true);
+  });
+
+  test('a completed latest step with an unreadable status is unknown', async () => {
+    stubFetch(
+      [
+        { info: { id: 'msg_turn_1', role: 'user' } },
+        { info: { role: 'assistant', parentID: 'msg_turn_1', time: { completed: 1234 } } },
+      ],
+      { sessionStatusOk: false },
+    );
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBeNull();
+  });
+
+  test('a non-retryable error is terminal even while the root reports busy', async () => {
+    // A terminally-errored answer cannot un-fail; a busy root there is a NEWER
+    // turn already running. Holding this record open would pin authority on a
+    // turn that is provably over.
+    stubFetch(
+      [
+        { info: { id: 'msg_turn_1', role: 'user' } },
+        {
+          info: {
+            role: 'assistant',
+            parentID: 'msg_turn_1',
+            time: {},
+            error: { name: 'APIError', data: { isRetryable: false } },
+          },
+        },
+      ],
+      { sessionStatus: { [SESSION]: { type: 'busy' } } },
+    );
+    expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toBe(false);
   });
 
   test('an incomplete assistant for the exact user message remains active', async () => {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/turn-begin-relay.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/turn-begin-relay.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { relayTurnBeginToApi, __resetRelayedTurnBegins } from '../main'
+import type { Config } from '../config'
+
+// A BOX-INITIATED turn (OpenCode's synthetic `<pty_exited>` wake-up) must be
+// announced to apps/api so it gets turn authority — live incident 2026-08-20
+// (Essentia session d1b74954): pty-driven turns streamed for 10+ minutes while
+// `GET .../turn` reported idle, because nothing ever told the control plane a
+// turn had started.
+
+const ROOT = 'ses_root'
+const CHILD = 'ses_child'
+const WORKSPACE = '/workspace'
+
+function startMocks(getMessages: () => unknown[]) {
+  let turnStreamCalls = 0
+  const turnStreamBodies: Array<Record<string, unknown>> = []
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url)
+      if (url.pathname.endsWith('/turn-stream')) {
+        turnStreamCalls++
+        turnStreamBodies.push((await req.json()) as Record<string, unknown>)
+        return Response.json({ ok: true, outcome: 'adopted' })
+      }
+      if (url.pathname === `/session/${ROOT}/message`) {
+        return Response.json(getMessages())
+      }
+      if (url.pathname === `/session/${ROOT}`) {
+        return Response.json({ parentID: null })
+      }
+      if (url.pathname === `/session/${CHILD}`) {
+        return Response.json({ parentID: ROOT })
+      }
+      return new Response('not found', { status: 404 })
+    },
+  })
+  return {
+    baseUrl: `http://127.0.0.1:${server.port}`,
+    calls: () => turnStreamCalls,
+    bodies: () => turnStreamBodies,
+    stop: () => server.stop(true),
+  }
+}
+
+let saved: Record<string, string | undefined> = {}
+beforeEach(() => {
+  __resetRelayedTurnBegins()
+  saved = {
+    KORTIX_PROJECT_ID: process.env.KORTIX_PROJECT_ID,
+    KORTIX_SESSION_ID: process.env.KORTIX_SESSION_ID,
+    KORTIX_SANDBOX_TOKEN: process.env.KORTIX_SANDBOX_TOKEN,
+    KORTIX_API_URL: process.env.KORTIX_API_URL,
+  }
+})
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+})
+
+function sessionEnv(apiUrl: string) {
+  process.env.KORTIX_PROJECT_ID = 'proj_1'
+  process.env.KORTIX_SESSION_ID = 'sess_1'
+  process.env.KORTIX_SANDBOX_TOKEN = 'tok'
+  process.env.KORTIX_API_URL = apiUrl
+}
+
+const syntheticTurn = () => [
+  { info: { id: 'msg_user_1', role: 'user' } },
+  { info: { id: 'msg_asst_1', role: 'assistant', parentID: 'msg_user_1', time: { completed: 1 } } },
+  { info: { id: 'msg_pty_2', role: 'user' } },
+]
+
+describe('relayTurnBeginToApi — box-initiated turn adoption', () => {
+  test('relays turn_begin naming the NEWEST user message', async () => {
+    const m = startMocks(syntheticTurn)
+    sessionEnv(m.baseUrl)
+    const opencode = { getInternalUrl: () => m.baseUrl }
+    const cfg = { workspace: WORKSPACE } as unknown as Config
+    try {
+      await relayTurnBeginToApi(ROOT, opencode, cfg)
+      expect(m.calls()).toBe(1)
+      expect(m.bodies()[0]).toMatchObject({
+        kind: 'turn_begin',
+        opencode_session_id: ROOT,
+        turn_message_id: 'msg_pty_2',
+      })
+    } finally {
+      m.stop()
+    }
+  })
+
+  test('one turn relays once no matter how many status frames fire', async () => {
+    const m = startMocks(syntheticTurn)
+    sessionEnv(m.baseUrl)
+    const opencode = { getInternalUrl: () => m.baseUrl }
+    const cfg = { workspace: WORKSPACE } as unknown as Config
+    try {
+      await relayTurnBeginToApi(ROOT, opencode, cfg)
+      await relayTurnBeginToApi(ROOT, opencode, cfg)
+      await relayTurnBeginToApi(ROOT, opencode, cfg)
+      expect(m.calls()).toBe(1)
+    } finally {
+      m.stop()
+    }
+  })
+
+  test('a NEW user message relays again', async () => {
+    let messages = syntheticTurn()
+    const m = startMocks(() => messages)
+    sessionEnv(m.baseUrl)
+    const opencode = { getInternalUrl: () => m.baseUrl }
+    const cfg = { workspace: WORKSPACE } as unknown as Config
+    try {
+      await relayTurnBeginToApi(ROOT, opencode, cfg)
+      messages = [...syntheticTurn(), { info: { id: 'msg_pty_3', role: 'user' } }]
+      await relayTurnBeginToApi(ROOT, opencode, cfg)
+      expect(m.calls()).toBe(2)
+      expect(m.bodies()[1]?.turn_message_id).toBe('msg_pty_3')
+    } finally {
+      m.stop()
+    }
+  })
+
+  test('a CHILD session never relays — only root turns carry authority', async () => {
+    const m = startMocks(syntheticTurn)
+    sessionEnv(m.baseUrl)
+    const opencode = { getInternalUrl: () => m.baseUrl }
+    const cfg = { workspace: WORKSPACE } as unknown as Config
+    try {
+      await relayTurnBeginToApi(CHILD, opencode, cfg)
+      expect(m.calls()).toBe(0)
+    } finally {
+      m.stop()
+    }
+  })
+
+  test('no user message on the root relays nothing', async () => {
+    const m = startMocks(() => [])
+    sessionEnv(m.baseUrl)
+    const opencode = { getInternalUrl: () => m.baseUrl }
+    const cfg = { workspace: WORKSPACE } as unknown as Config
+    try {
+      await relayTurnBeginToApi(ROOT, opencode, cfg)
+      expect(m.calls()).toBe(0)
+    } finally {
+      m.stop()
+    }
+  })
+
+  test('does not relay without sandbox callback identity', async () => {
+    const m = startMocks(syntheticTurn)
+    const opencode = { getInternalUrl: () => m.baseUrl }
+    const cfg = { workspace: WORKSPACE } as unknown as Config
+    try {
+      await relayTurnBeginToApi(ROOT, opencode, cfg)
+      expect(m.calls()).toBe(0)
+    } finally {
+      m.stop()
+    }
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/turn-end-dedup.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/turn-end-dedup.test.ts
@@ -15,7 +15,11 @@ const WORKSPACE = '/workspace'
 // Minimal opencode + apps/api mock. opencode: GET /session/:id (root, no
 // parentID) and GET /session/:id/message (last assistant message with a
 // completed timestamp we control). apps/api: POST .../turn-stream counts calls.
-function startMocks(getCompletedAt: () => number, turnStreamOk: () => boolean = () => true) {
+function startMocks(
+  getCompletedAt: () => number,
+  turnStreamOk: () => boolean = () => true,
+  getMessages?: () => unknown[],
+) {
   let turnStreamCalls = 0
   const turnStreamBodies: Array<Record<string, unknown>> = []
   const server = Bun.serve({
@@ -33,16 +37,18 @@ function startMocks(getCompletedAt: () => number, turnStreamOk: () => boolean = 
       }
       // opencode: message list for the root turn — one completed assistant reply.
       if (url.pathname === `/session/${ROOT}/message`) {
-        return Response.json([
-          { info: { id: 'msg_turn_1', role: 'user' } },
-          {
-            info: {
-              role: 'assistant',
-              parentID: 'msg_turn_1',
-              time: { completed: getCompletedAt() },
+        return Response.json(
+          getMessages?.() ?? [
+            { info: { id: 'msg_turn_1', role: 'user' } },
+            {
+              info: {
+                role: 'assistant',
+                parentID: 'msg_turn_1',
+                time: { completed: getCompletedAt() },
+              },
             },
-          },
-        ])
+          ],
+        )
       }
       // opencode: session lookup — root has no parentID.
       if (url.pathname === `/session/${ROOT}`) {
@@ -129,6 +135,60 @@ describe('relayTurnEndToApi — exactly-once per completed turn', () => {
     try {
       await relayTurnEndToApi(ROOT, 'idle', opencode, cfg)
       expect(m.calls()).toBe(1)
+    } finally {
+      m.stop()
+    }
+  })
+
+  // A prompt forwarded into a live turn (or a synthetic `<pty_exited>`
+  // wake-up) leaves a USER message as the newest row when the turn ends. The
+  // relay must still NAME the turn the newest assistant answered — an unnamed
+  // relay loses the dedup signature (double finalizes, observed live
+  // 2026-08-20: reconciles at 12:59:17 AND 12:59:19 for one end) and starves
+  // the forwarded-turn reconciler of its primary key.
+  test('a trailing user message does not unname the relay', async () => {
+    const m = startMocks(
+      () => 1000,
+      () => true,
+      () => [
+        { info: { id: 'msg_turn_1', role: 'user' } },
+        { info: { role: 'assistant', parentID: 'msg_turn_1', time: { completed: 1000 } } },
+        { info: { id: 'msg_turn_2', role: 'user' } },
+      ],
+    )
+    sessionEnv(m.baseUrl)
+    const opencode = { getInternalUrl: () => m.baseUrl }
+    const cfg = { workspace: WORKSPACE } as unknown as Config
+    try {
+      await relayTurnEndToApi(ROOT, 'idle', opencode, cfg)
+      await relayTurnEndToApi(ROOT, 'idle', opencode, cfg)
+      expect(m.bodies()[0]?.turn_message_id).toBe('msg_turn_1')
+      expect(m.calls()).toBe(1)
+    } finally {
+      m.stop()
+    }
+  })
+
+  test('an OPEN newest assistant (a racing new turn) keeps the relay unnamed', async () => {
+    // Naming the racing turn would let completeSandboxTurn close the row of a
+    // turn that is still running. Unnamed is the honest answer; the tip
+    // fallback in the forwarded-turn reconciler resolves it server-side.
+    const m = startMocks(
+      () => 1000,
+      () => true,
+      () => [
+        { info: { id: 'msg_turn_1', role: 'user' } },
+        { info: { role: 'assistant', parentID: 'msg_turn_1', time: { completed: 1000 } } },
+        { info: { id: 'msg_turn_2', role: 'user' } },
+        { info: { role: 'assistant', parentID: 'msg_turn_2', time: {} } },
+      ],
+    )
+    sessionEnv(m.baseUrl)
+    const opencode = { getInternalUrl: () => m.baseUrl }
+    const cfg = { workspace: WORKSPACE } as unknown as Config
+    try {
+      await relayTurnEndToApi(ROOT, 'idle', opencode, cfg)
+      expect(m.bodies()[0]?.turn_message_id).toBeUndefined()
     } finally {
       m.stop()
     }

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -593,6 +593,12 @@ async function startSessionRuntime(
       logger.warn('[opencode-events] turn-end relay failed', { err: (err as Error).message }),
     )
   }
+  const onSessionStatus = (opencodeSessionId: string, statusType: string) => {
+    if (statusType !== 'busy' && statusType !== 'retry') return
+    void relayTurnBeginToApi(opencodeSessionId, opencode, cfg).catch((err) =>
+      logger.warn('[opencode-events] turn-begin relay failed', { err: (err as Error).message }),
+    )
+  }
   let initialTurnAcceptanceSettled = false
   let initialTurnAcceptanceInFlight = false
   const reconcileInitialTurnAcceptance = async () => {
@@ -640,6 +646,7 @@ async function startSessionRuntime(
     onQuestionAsked,
     onSessionIdle,
     onSessionError,
+    onSessionStatus,
     onConnected,
     onReconcile: onConnected,
   }
@@ -2242,6 +2249,111 @@ export function __resetRelayedTurnSignatures(): void {
   relayedTurnSignatures.clear()
 }
 
+// Turn-begin relay dedup: root id -> the newest user message id already
+// relayed (or refused as already-known by apps/api). A turn's identity is its
+// user message, so one turn relays once no matter how many `busy`/`retry`
+// status frames it emits. Per-process, like `relayedTurnSignatures`.
+const relayedTurnBegins = new Map<string, string>()
+const turnBeginRelaysInFlight = new Set<string>()
+
+/** Test-only: clear the per-turn begin dedup between cases. */
+export function __resetRelayedTurnBegins(): void {
+  relayedTurnBegins.clear()
+  turnBeginRelaysInFlight.clear()
+}
+
+/**
+ * Announce a BOX-INITIATED turn to apps/api (`turn-stream` kind `turn_begin`).
+ *
+ * Every control-plane prompt gets its `session_turns` row BEFORE delivery, but
+ * OpenCode also starts turns nobody delivered — the synthetic `<pty_exited>`
+ * user message it injects when a background pty finishes. Those turns had no
+ * authority at all: `GET .../turn` read idle over minutes of live streaming
+ * and the box ran on its 15-minute idle tail (live incident 2026-08-20,
+ * Essentia session d1b74954). This relay fires on the root's `busy`/`retry`
+ * status frames and names the newest user message; apps/api adopts it only
+ * when no open turn exists and the message was never seen — so relaying for
+ * an ordinary delivered prompt is a cheap no-op.
+ */
+export async function relayTurnBeginToApi(
+  opencodeSessionId: string,
+  opencode: Pick<Opencode, 'getInternalUrl'>,
+  cfg: Config,
+): Promise<void> {
+  const ctx = sandboxRelayContext()
+  if (!ctx) return
+  if (turnBeginRelaysInFlight.has(opencodeSessionId)) return
+  turnBeginRelaysInFlight.add(opencodeSessionId)
+  try {
+    if (!(await isRootOpencodeSession(opencodeSessionId, opencode, cfg))) return
+    // The newest USER message names the turn that is running.
+    let newestUserId: string | null = null
+    try {
+      const res = await fetch(
+        `${opencode.getInternalUrl()}/session/${encodeURIComponent(opencodeSessionId)}/message?directory=${encodeURIComponent(cfg.workspace)}`,
+        { signal: AbortSignal.timeout(5_000) },
+      )
+      if (!res.ok) return
+      const rows = (await res.json()) as Array<{ info?: { id?: string; role?: string } }>
+      if (!Array.isArray(rows)) return
+      for (let i = rows.length - 1; i >= 0; i--) {
+        const info = rows[i]?.info
+        if (info?.role === 'user' && typeof info.id === 'string') {
+          newestUserId = info.id
+          break
+        }
+      }
+    } catch {
+      return
+    }
+    if (!newestUserId) return
+    if (relayedTurnBegins.get(opencodeSessionId) === newestUserId) return
+
+    const { projectId, sessionId, token, apiRoot } = ctx
+    const url = `${apiRoot}/projects/${encodeURIComponent(projectId)}/turn-stream`
+    const payload = JSON.stringify({
+      session_id: sessionId,
+      kind: 'turn_begin',
+      opencode_session_id: opencodeSessionId,
+      turn_message_id: newestUserId,
+    })
+    // Two attempts only: `busy`/`retry` frames recur for a live turn, so a
+    // transient failure retries itself on the next frame.
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: payload,
+          signal: AbortSignal.timeout(15_000),
+        })
+        if (res.ok) {
+          // ANY definitive answer dedups: adopted, already-open, or
+          // already-known all mean this exact message needs no further relay.
+          relayedTurnBegins.set(opencodeSessionId, newestUserId)
+          const data = (await res.json().catch(() => null)) as { outcome?: string } | null
+          if (data?.outcome === 'adopted') {
+            logger.info('[opencode-events] box-initiated turn adopted', {
+              opencodeSessionId,
+              messageId: newestUserId,
+            })
+          }
+          return
+        }
+        logger.warn('[opencode-events] turn-begin relay non-ok', { status: res.status, attempt })
+      } catch (err) {
+        logger.warn('[opencode-events] turn-begin relay fetch failed', {
+          err: (err as Error).message,
+          attempt,
+        })
+      }
+      if (attempt < 2) await new Promise((r) => setTimeout(r, 1_000))
+    }
+  } finally {
+    turnBeginRelaysInFlight.delete(opencodeSessionId)
+  }
+}
+
 export async function relayTurnEndToApi(
   opencodeSessionId: string,
   status: 'idle' | 'error',
@@ -2416,15 +2528,26 @@ async function readRootTurnState(
       }
     }>
     if (!Array.isArray(rows)) return { completedAt: null, parentMessageId: null }
-    // The most recent assistant message decides the turn's outcome. Crucially,
-    // stop at the turn boundary: if a USER message is the newest row (a pending or
-    // follow-up turn that hasn't produced an assistant reply yet), treat the run
-    // as clean/incomplete — never walk back into a PRIOR turn's already-superseded
-    // error and relay it as this turn's failure.
+    // The most recent assistant message decides the turn's outcome. Trailing
+    // USER rows are SKIPPED, not a boundary: a prompt forwarded into a live
+    // turn — and OpenCode's own synthetic `<pty_exited>` wake-ups — leave a
+    // user message as the newest row at almost every turn end, and bailing
+    // there unnamed EVERY relay for such sessions (live 2026-08-20, Essentia
+    // session d1b74954: `relay_named:false` on each end, double finalizes
+    // because the unnamed relay has no dedup signature, and the forwarded-turn
+    // reconciler lost its primary key). Attribution is message-scoped — the
+    // assistant's own `parentID` names the turn it answered — so a pending
+    // follow-up prompt can never be blamed for a prior turn's error.
+    //
+    // One case stays unnamed on purpose: a newest assistant that is still OPEN
+    // (no completion, no terminal error) is a RACING NEW turn — naming it would
+    // let completeSandboxTurn close the row of a turn that is still running.
     for (let i = rows.length - 1; i >= 0; i--) {
       const info = rows[i]?.info
-      if (info?.role === 'user') return { completedAt: null, parentMessageId: null }
       if (info?.role !== 'assistant') continue
+      const open =
+        info.time?.completed == null && (!info.error || info.error.data?.isRetryable === true)
+      if (open) return { completedAt: null, parentMessageId: null }
       return {
         error: info.error ? flattenOpencodeError(info.error) : undefined,
         completedAt: info.time?.completed ?? null,

--- a/apps/kortix-sandbox-agent-server/src/opencode-events.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-events.ts
@@ -44,6 +44,11 @@ type OpencodeEventHandlers = {
   // filtering down to the root turn.
   onSessionIdle?: (sessionID: string) => void
   onSessionError?: (sessionID: string, error?: OpencodeTurnError) => void
+  // Fired on every `session.status` frame. `busy`/`retry` for the root is the
+  // one signal that exists for BOX-INITIATED turns (OpenCode's synthetic
+  // `<pty_exited>` wake-ups start a turn no control-plane prompt announced) —
+  // the turn-begin relay hangs off it.
+  onSessionStatus?: (sessionID: string, statusType: string) => void
   // Fired every time the /event SSE (re)subscribes successfully. Used to
   // reconcile a turn that finished BEFORE the subscription was live: a fast
   // boot could reach session.idle inside the gap between prompt_async and the
@@ -225,6 +230,15 @@ export function dispatch(
     const req = event.properties as QuestionRequest
     if (req?.id && req?.sessionID && Array.isArray(req.questions)) {
       handlers.onQuestionAsked(req)
+    }
+    return
+  }
+  if (event.type === 'session.status' && handlers.onSessionStatus) {
+    const props = event.properties as
+      | { sessionID?: string; status?: { type?: string } }
+      | undefined
+    if (props?.sessionID && typeof props.status?.type === 'string') {
+      handlers.onSessionStatus(props.sessionID, props.status.type)
     }
     return
   }

--- a/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
@@ -259,14 +259,29 @@ export async function observeOpencodeDelivery(
         ? 'completed'
         : null
 
-    // A newer user message owns the root now, so this turn is over whatever the
-    // root reports. Its status would describe the NEWER turn, so never ask.
-    if (after.some((message) => message.info?.role === 'user')) return { inFlight: false, end }
-    if (end !== null) return { inFlight: false, end }
+    // A hard failure cannot un-fail, and a completed answer stays answered: a
+    // busy root next to either is a NEWER turn already running, never this one.
+    if (errored) return { inFlight: false, end }
+    const newerUser = after.some((message) => message.info?.role === 'user')
+    if (newerUser && end === 'completed') return { inFlight: false, end }
 
+    // Every remaining verdict is a claim that the turn DIED, made from
+    // transcript shape alone — and transcript shape cannot see a running loop.
+    // A prompt forwarded INTO a live turn (and OpenCode's own synthetic
+    // `<pty_exited>` wake-ups) put a newer user message on the root while the
+    // SAME loop still streams the older turn's steps; and between two steps of
+    // one turn the latest assistant message reads completed while tools run
+    // and the next step's message does not exist yet. Both shapes read
+    // "terminal" here and were: live incident 2026-08-20 (Essentia session
+    // d1b74954) — the reaper destroyed a streaming turn's authority at
+    // 12:48:51Z on the newer-user rule; its step completed at 12:48:54Z. So no
+    // terminal verdict leaves this function while the root itself reports
+    // busy, and an unreadable status is unknown, never terminal.
     const busy = await opencodeSessionInFlight(baseUrl, workspace, rootSessionId)
     if (busy === null) return unreadable
     if (busy) return { inFlight: true, end: null }
+    if (newerUser) return { inFlight: false, end }
+    if (end !== null) return { inFlight: false, end }
     // The root is idle with this turn's assistant message still open: the husk a
     // killed model call leaves behind. With no assistant message at all, the
     // prompt landed and produced nothing, and nothing here says why — but that


### PR DESCRIPTION
## Problem

Live on Essentia (session `d1b74954`, 2026-08-20): the composer flapped between working and not-running over a session that was visibly streaming steps, and a prompt sent mid-turn ("Bro no fucking idea whats happening here lol", 12:59:05Z) was silently swallowed — delivered to OpenCode, never answered, never redelivered.

Ground truth was pulled from the box itself (E2B `isx4cmzurxlye2zueryrj`) and the `session_turns` ledger. Five defects compose:

| # | Defect | Live evidence |
|---|---|---|
| 1 | Box-initiated turns (OpenCode's synthetic `<pty_exited>` wake-ups) have **no turn record at all** — `GET .../turn` reads idle across whole working phases | 3 pty-driven turns 12:48→12:59Z streamed with an empty ledger; composer idle, box on the 15-min idle tail |
| 2 | `observeOpencodeDelivery` answers `inFlight:false` on the newer-user rule **without asking the session status** — the reaper then destroys live turn authority | turn `msg_01f3518bd002` cleared `unknown` at 12:48:51Z while its step was mid-stream (completed 12:48:54Z) |
| 3 | Reaper orphan redelivery is a **one-shot race**: a terminal observation inside the 30s age floor clears the record, and the record is the only trigger redelivery has | the swallowed prompt's turn cleared `unknown` at age **27s** — 3s under the floor |
| 4 | The strand reconciler has **no verdict for a tip orphan** (placed at the tip, loop exited past it, queued continuation `rejected`) — "not stranded" left it forever | `[forwarded-turns] ... candidates:[msg_01f3f1865000]` logged, nothing acted |
| 5 | A trailing user message **unnames every turn-end relay** (`relay_named:false`) — no dedup signature, no reconciler key | double finalizes at 12:59:17Z + 12:59:19Z for one end |

## Fix

- **Daemon**: new `turn_begin` relay on the root's `busy`/`retry` status frames (per-turn dedup by newest user message id); no terminal verdict from transcript shape while the root reports busy (unreadable status = unknown); `readRootTurnState` names the newest completed/errored assistant past trailing user rows, and deliberately stays unnamed when the newest assistant is an open racing turn.
- **API**: `adoptRuntimeSandboxTurn` (turn-stream kind `turn_begin`, sandbox-token-gated, idempotent: refuses any ever-seen message id, no-ops when an open turn exists) — box-initiated turns now appear in `GET .../turn` and carry the full turn deadline grant; the reaper defers a young orphan instead of clearing it; the strand reconciler removes+requeues an accepted tip orphan when the tip is not mid-step and no open sibling covers it.

Two test expectations were deliberately flipped, each annotated with the incident: "newer user message = terminal even while busy" (orphaned-turn-finalize) and "just-accepted orphan clears without redelivery" (sandbox-reaper).

## Verification

- `apps/kortix-sandbox-agent-server`: `bun test src` — **710 pass, 0 fail**; `tsc --noEmit` clean.
- `apps/api`: `bash scripts/test.sh` — **7729 pass, 0 fail** (676 files); `tsc --noEmit` clean.
- `bash scripts/test.sh integration` scope: `integration-sandbox-turn-lifecycle` — **37 pass** against local Postgres, including 3 new `adoptRuntimeSandboxTurn` cases (adoption + deadline grant, open-turn no-op, never-resurrect).

## Rollout notes

- API side ships with dev-latest; self-host boxes (Essentia) pick it up on their updater cycle.
- Daemon side (`kortix-sandbox-agent-server`) reaches sandboxes via template rebuild — existing boxes keep the old daemon until then. The API-side fixes (#3, #4) are effective for old daemons too.
- Unattributed residual: the `cancel` (abort) at 12:59:19.546Z in the opencode log — not the runaway guard (null parents never count). Tracked in the session notes; the F5 naming fix removes the null-parent condition either way.
